### PR TITLE
feat(ui): market hero search + on-demand pagination; real agent data …

### DIFF
--- a/src/apps/desktop/src/api/skill_api.rs
+++ b/src/apps/desktop/src/api/skill_api.rs
@@ -23,8 +23,8 @@ use bitfun_core::util::process_manager;
 
 const SKILLS_SEARCH_API_BASE: &str = "https://skills.sh";
 const DEFAULT_MARKET_QUERY: &str = "skill";
-const DEFAULT_MARKET_LIMIT: u8 = 12;
-const MAX_MARKET_LIMIT: u8 = 50;
+const DEFAULT_MARKET_LIMIT: u32 = 12;
+const MAX_MARKET_LIMIT: u32 = 500;
 const MAX_OUTPUT_PREVIEW_CHARS: usize = 2000;
 const MARKET_DESC_FETCH_TIMEOUT_SECS: u64 = 4;
 const MARKET_DESC_FETCH_CONCURRENCY: usize = 6;
@@ -44,14 +44,14 @@ pub struct SkillValidationResult {
 #[serde(rename_all = "camelCase")]
 pub struct SkillMarketListRequest {
     pub query: Option<String>,
-    pub limit: Option<u8>,
+    pub limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SkillMarketSearchRequest {
     pub query: String,
-    pub limit: Option<u8>,
+    pub limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -463,13 +463,13 @@ pub async fn download_skill_market(
     })
 }
 
-fn normalize_market_limit(value: Option<u8>) -> u8 {
+fn normalize_market_limit(value: Option<u32>) -> u32 {
     value
         .unwrap_or(DEFAULT_MARKET_LIMIT)
         .clamp(1, MAX_MARKET_LIMIT)
 }
 
-async fn fetch_skill_market(query: &str, limit: u8) -> Result<Vec<SkillMarketItem>, String> {
+async fn fetch_skill_market(query: &str, limit: u32) -> Result<Vec<SkillMarketItem>, String> {
     let api_base =
         std::env::var("SKILLS_API_URL").unwrap_or_else(|_| SKILLS_SEARCH_API_BASE.into());
     let base_url = api_base.trim_end_matches('/');

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState } from 'react';
 import { useI18n } from '@/infrastructure/i18n';
-import { Modal } from '@/component-library';
+import { Modal, Badge } from '@/component-library';
 import './RemoteConnectDialog.scss';
 
 type ConnectionType = 'nat' | 'relay';
@@ -83,6 +83,7 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
       isOpen={isOpen}
       onClose={onClose}
       title={t('remoteConnect.title')}
+      titleExtra={<Badge variant="warning">WIP</Badge>}
       showCloseButton={true}
       size="small"
     >

--- a/src/web-ui/src/app/scenes/skills/SkillsScene.scss
+++ b/src/web-ui/src/app/scenes/skills/SkillsScene.scss
@@ -25,6 +25,12 @@
     width: 100%;
     height: 100%;
     overflow: hidden;
+
+    // Hero mode: center everything
+    &--hero {
+      align-items: center;
+      justify-content: center;
+    }
   }
 
   &__view-header {
@@ -170,6 +176,63 @@
 // ── Market list ───────────────────────────────────────────────
 
 .bitfun-market {
+
+  // ── Hero (pre-search) ─────────────────────────────────────
+
+  &__hero {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: $size-gap-4;
+    padding: $size-gap-8 $size-gap-6;
+    width: min(100%, 480px);
+    animation: bitfun-market-item-in 0.3s $easing-decelerate both;
+  }
+
+  &__hero-title {
+    font-size: $font-size-3xl;
+    font-weight: $font-weight-semibold;
+    color: var(--color-text-primary);
+    margin: 0;
+    line-height: $line-height-tight;
+  }
+
+  &__hero-search {
+    width: 100%;
+    margin-top: $size-gap-2;
+
+    .search__wrapper {
+      background: linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.06) 0%,
+        rgba(255, 255, 255, 0.03) 100%
+      );
+      border: 1px solid var(--border-subtle);
+      border-radius: $size-radius-lg;
+    }
+  }
+
+  // ── Source attribution ─────────────────────────────────────
+
+  &__source-note {
+    font-size: $font-size-xs;
+    color: var(--color-text-muted);
+    opacity: 0.6;
+    margin: $size-gap-2 0 0;
+    text-align: center;
+  }
+
+  &__source-link {
+    color: inherit;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+
+    &:hover {
+      opacity: 0.9;
+      color: var(--color-primary);
+    }
+  }
 
   // ── List container ────────────────────────────────────────
 
@@ -521,6 +584,15 @@
       padding: $size-gap-4;
     }
   }
+}
+
+@keyframes bitfun-market-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+.bitfun-market__spin {
+  animation: bitfun-market-spin 0.8s linear infinite;
 }
 
 @keyframes bitfun-market-row-shimmer {

--- a/src/web-ui/src/app/scenes/team/components/ExpertTeamsPage.tsx
+++ b/src/web-ui/src/app/scenes/team/components/ExpertTeamsPage.tsx
@@ -5,17 +5,20 @@ import { Search, IconButton, Badge } from '@/component-library';
 import {
   useTeamStore,
   MOCK_AGENTS,
+  MOCK_TEAMS,
   CAPABILITY_CATEGORIES,
   computeTeamCapabilities,
   type AgentWithCapabilities,
   type Team,
 } from '../teamStore';
+
+const EXAMPLE_TEAM_IDS = new Set(MOCK_TEAMS.map((t) => t.id));
 import { AGENT_ICON_MAP } from '../teamIcons';
 import './TeamHomePage.scss';
 
 // ─── Team list item ───────────────────────────────────────────────────────────
 
-const TeamListItem: React.FC<{ team: Team; index: number }> = ({ team, index }) => {
+const TeamListItem: React.FC<{ team: Team; index: number; isExample: boolean }> = ({ team, index, isExample }) => {
   const { t } = useTranslation('scenes/team');
   const { openTeamEditor } = useTeamStore();
   const [expanded, setExpanded] = useState(false);
@@ -52,6 +55,7 @@ const TeamListItem: React.FC<{ team: Team; index: number }> = ({ team, index }) 
         <div className="th-list__item-info">
           <div className="th-list__item-name-row">
             <span className="th-list__item-name">{team.name}</span>
+            {isExample && <Badge variant="neutral">示例</Badge>}
             <Badge variant="neutral">{strategyLabel}</Badge>
           </div>
           <p className="th-list__item-desc">{team.description || '—'}</p>
@@ -164,7 +168,10 @@ const ExpertTeamsPage: React.FC = () => {
         <div className="th__header-inner">
           <div className="th__title-row">
             <div>
-              <h2 className="th__title">{t('expertTeams.title')}</h2>
+              <div className="th__title-with-badge">
+                <h2 className="th__title">{t('expertTeams.title')}</h2>
+                <Badge variant="warning">WIP</Badge>
+              </div>
               <p className="th__title-sub">{t('expertTeams.subtitle')}</p>
             </div>
             <button type="button" className="th__create-btn" onClick={handleCreateTeam}>
@@ -198,7 +205,12 @@ const ExpertTeamsPage: React.FC = () => {
           ) : (
             <div className="th-list">
               {filteredTeams.map((team, i) => (
-                <TeamListItem key={team.id} team={team} index={i} />
+                <TeamListItem
+                  key={team.id}
+                  team={team}
+                  index={i}
+                  isExample={EXAMPLE_TEAM_IDS.has(team.id)}
+                />
               ))}
             </div>
           )}

--- a/src/web-ui/src/app/scenes/team/components/TeamHomePage.scss
+++ b/src/web-ui/src/app/scenes/team/components/TeamHomePage.scss
@@ -48,11 +48,18 @@
   margin-bottom: $size-gap-3;
 }
 
+.th__title-with-badge {
+  display: flex;
+  align-items: center;
+  gap: $size-gap-2;
+  margin-bottom: 4px;
+}
+
 .th__title {
   font-size: $font-size-xl;
   font-weight: $font-weight-semibold;
   color: var(--th-text-main);
-  margin: 0 0 4px;
+  margin: 0;
   line-height: $line-height-tight;
 }
 

--- a/src/web-ui/src/app/scenes/team/teamStore.ts
+++ b/src/web-ui/src/app/scenes/team/teamStore.ts
@@ -13,6 +13,9 @@ export type TeamViewMode = 'formation' | 'list';
 export const CAPABILITY_CATEGORIES = ['编码', '文档', '分析', '测试', '创意', '运维'] as const;
 export type CapabilityCategory = (typeof CAPABILITY_CATEGORIES)[number];
 
+/** 'mode' = 主 Agent 模式（如 Agentic/Plan/Debug），'subagent' = 子 Agent */
+export type AgentKind = 'mode' | 'subagent';
+
 export interface AgentCapability {
   category: CapabilityCategory;
   level: number; // 1-5
@@ -21,6 +24,8 @@ export interface AgentCapability {
 export interface AgentWithCapabilities extends SubagentInfo {
   capabilities: AgentCapability[];
   iconKey?: string;
+  /** 区分 Agent 模式与 Sub-Agent */
+  agentKind?: AgentKind;
 }
 
 export interface TeamMember {
@@ -369,7 +374,7 @@ export const useTeamStore = create<TeamStoreState>((set) => ({
   openAgentsOverview: () => set({ page: 'agentsOverview' }),
   openExpertTeamsOverview: () => set({ page: 'expertTeamsOverview' }),
   openTeamEditor: (teamId) => set({ page: 'editor', activeTeamId: teamId }),
-  agentSoloEnabled: Object.fromEntries(MOCK_AGENTS.map((agent) => [agent.id, agent.enabled])),
+  agentSoloEnabled: {},
   setAgentSoloEnabled: (agentId, enabled) =>
     set((s) => ({
       agentSoloEnabled: {

--- a/src/web-ui/src/component-library/components/Modal/Modal.scss
+++ b/src/web-ui/src/component-library/components/Modal/Modal.scss
@@ -118,11 +118,24 @@
     }
   }
 
+  &__title-group {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+
   &__title {
     margin: 0;
     font-size: 12px;
     font-weight: 500;
     color: var(--color-text-secondary);
+  }
+
+  &__title-extra {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
   }
 
 

--- a/src/web-ui/src/component-library/components/Modal/Modal.tsx
+++ b/src/web-ui/src/component-library/components/Modal/Modal.tsx
@@ -10,6 +10,7 @@ export interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   title?: string;
+  titleExtra?: React.ReactNode;
   children: React.ReactNode;
   size?: 'small' | 'medium' | 'large';
   contentInset?: boolean;
@@ -23,6 +24,7 @@ export const Modal: React.FC<ModalProps> = ({
   isOpen,
   onClose,
   title,
+  titleExtra,
   children,
   size = 'medium',
   contentInset = false,
@@ -253,7 +255,12 @@ export const Modal: React.FC<ModalProps> = ({
             ref={headerRef}
             className={`modal__header ${draggable ? 'modal__header--draggable' : ''}`}
           >
-            {title && <h2 className="modal__title">{title}</h2>}
+            {title && (
+              <div className="modal__title-group">
+                <h2 className="modal__title">{title}</h2>
+                {titleExtra && <span className="modal__title-extra">{titleExtra}</span>}
+              </div>
+            )}
             {showCloseButton && (
               <button
                 className="modal__close"

--- a/src/web-ui/src/locales/en-US/scenes/skills.json
+++ b/src/web-ui/src/locales/en-US/scenes/skills.json
@@ -61,7 +61,13 @@
     "pagination": {
       "prev": "Previous page",
       "next": "Next page",
-      "info": "{{current}} / {{total}}"
+      "info": "{{current}} / {{total}}",
+      "infoMore": "Page {{current}}",
+      "loading": "Loading..."
+    },
+    "sourceNote": {
+      "prefix": "Source:",
+      "suffix": " · Up to {{max}} results"
     }
   },
   "form": {

--- a/src/web-ui/src/locales/zh-CN/scenes/skills.json
+++ b/src/web-ui/src/locales/zh-CN/scenes/skills.json
@@ -61,7 +61,13 @@
     "pagination": {
       "prev": "上一页",
       "next": "下一页",
-      "info": "第 {{current}} / {{total}} 页"
+      "info": "第 {{current}} / {{total}} 页",
+      "infoMore": "第 {{current}} 页",
+      "loading": "加载中..."
+    },
+    "sourceNote": {
+      "prefix": "数据来源",
+      "suffix": " · 最多显示前 {{max}} 条结果"
     }
   },
   "form": {

--- a/src/web-ui/src/shared/notification-system/components/NotificationCenter.scss
+++ b/src/web-ui/src/shared/notification-system/components/NotificationCenter.scss
@@ -82,6 +82,10 @@
   }
 
   &__filter {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     padding: 6px $size-gap-2;
     background: transparent;
     border: none;


### PR DESCRIPTION
…in team pages

- Skills market: hero pre-search view, on-demand page loading (up to 500), source attribution
- skill_api: limit type u8 → u32, MAX_MARKET_LIMIT 50 → 500
- Team: load real modes + sub-agents, replace MOCK_AGENTS, add AgentKind badges
- Modal: add titleExtra prop; ExpertTeams/RemoteConnect: add WIP badges