### PR TITLE
feat(ci): build and publish Windows installer executable in release workflows

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -86,7 +86,7 @@ jobs:
           - os: windows-latest
             name: windows-x64
             target: x86_64-pc-windows-msvc
-            build_command: npm run desktop:build:nsis
+            build_command: npm run installer:build
 
     steps:
       - name: Checkout
@@ -113,6 +113,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install installer dependencies
+        if: matrix.platform.name == 'windows-x64'
+        run: npm --prefix BitFun-Installer ci
+
       - name: Build desktop app
         run: ${{ matrix.platform.build_command }}
 
@@ -125,6 +129,7 @@ jobs:
             target/*/release/bundle
             target/release/bundle
             src/apps/desktop/target/release/bundle
+            BitFun-Installer/src-tauri/target/release/bitfun-installer.exe
 
   # ── Upload assets to GitHub Release ────────────────────────────────
   upload-release-assets:
@@ -152,5 +157,5 @@ jobs:
           tag_name: ${{ needs.prepare.outputs.release_tag }}
           files: |
             release-assets/**/*.dmg
-            release-assets/**/*setup.exe
+            release-assets/**/*bitfun-installer.exe
           fail_on_unmatched_files: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,7 +83,7 @@ jobs:
           - os: windows-latest
             name: windows-x64
             target: x86_64-pc-windows-msvc
-            build_command: npm run desktop:build:nsis
+            build_command: npm run installer:build
 
     steps:
       - uses: actions/checkout@v4
@@ -106,6 +106,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Install installer dependencies
+        if: matrix.platform.name == 'windows-x64'
+        run: npm --prefix BitFun-Installer ci
 
       - name: Patch nightly version
         shell: bash
@@ -146,6 +150,7 @@ jobs:
             target/*/release/bundle
             target/release/bundle
             src/apps/desktop/target/release/bundle
+            BitFun-Installer/src-tauri/target/release/bitfun-installer.exe
 
   # ── Publish nightly pre-release ────────────────────────────────────
   publish-nightly:
@@ -191,4 +196,4 @@ jobs:
           prerelease: true
           files: |
             release-assets/**/*.dmg
-            release-assets/**/*setup.exe
+            release-assets/**/*bitfun-installer.exe


### PR DESCRIPTION
 ## Summary
  Update CI workflows to build and publish the new Windows installer executable (`bitfun-installer.exe`) instead of the
  old `setup.exe` output.

  ## Changes
  - In `.github/workflows/desktop-package.yml` and `.github/workflows/nightly.yml`:
    - Switch Windows build command:
      - `npm run desktop:build:nsis` -> `npm run installer:build`
    - Add Windows-only installer dependency install step:
      - `npm --prefix BitFun-Installer ci`
    - Add installer output to artifact collection:
      - `BitFun-Installer/src-tauri/target/release/bitfun-installer.exe`
    - Update release asset glob:
      - `**/*setup.exe` -> `**/*bitfun-installer.exe`

  ## Impact
  - Windows release/nightly pipelines now publish the new installer binary.
  - macOS packaging logic remains unchanged.