### PR TITLE
fix: clear processing state after rollback

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
@@ -10,6 +10,8 @@ import type { DialogTurn } from '../../types/flow-chat';
 import { useFlowChatContext } from './FlowChatContext';
 import { useActiveSession } from '../../store/modernFlowChatStore';
 import { flowChatStore } from '../../store/FlowChatStore';
+import { useActiveSessionState } from '../../hooks/useActiveSessionState';
+import { SessionExecutionEvent, stateMachineManager } from '../../state-machine';
 import { snapshotAPI } from '@/infrastructure/api';
 import { notificationService } from '@/shared/notification-system';
 import { globalEventBus } from '@/infrastructure/event-bus';
@@ -29,6 +31,7 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
     const { t } = useTranslation('flow-chat');
     const { config, sessionId } = useFlowChatContext();
     const activeSession = useActiveSession();
+    const { isProcessing } = useActiveSessionState();
     const [copied, setCopied] = useState(false);
     const [expanded, setExpanded] = useState(false);
     const [hasOverflow, setHasOverflow] = useState(false);
@@ -41,6 +44,7 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
     const dialogTurn = turnIndex >= 0 ? activeSession?.dialogTurns[turnIndex] : null;
     const isFailed = dialogTurn?.status === 'error';
     const canRollback = !!sessionId && turnIndex >= 0 && !isRollingBack;
+    const rollbackNeedsCancel = isProcessing && turnIndex === (activeSession?.dialogTurns.length ?? 0) - 1;
 
     
     // Avoid zero-size errors by rendering a placeholder instead of null.
@@ -111,12 +115,23 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
 
       setIsRollingBack(true);
       try {
+        if (rollbackNeedsCancel && dialogTurn?.id) {
+          const cancelled = await stateMachineManager.transition(sessionId, SessionExecutionEvent.USER_CANCEL);
+          if (!cancelled) {
+            flowChatStore.cancelSessionTask(sessionId);
+            stateMachineManager.reset(sessionId);
+          }
+        }
+
         const restoredFiles = await snapshotAPI.rollbackToTurn(sessionId, turnIndex, true);
 
         // 1) Truncate local dialog turns from this index.
         flowChatStore.truncateDialogTurnsFrom(sessionId, turnIndex);
 
-        // 2) Refresh file tree and open editors.
+        // 2) Ensure the session state machine leaves processing state after rollback.
+        stateMachineManager.reset(sessionId);
+
+        // 3) Refresh file tree and open editors.
         const { globalEventBus } = await import('@/infrastructure/event-bus');
         globalEventBus.emit('file-tree:refresh');
         restoredFiles.forEach(filePath => {
@@ -130,7 +145,7 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
       } finally {
         setIsRollingBack(false);
       }
-    }, [canRollback, sessionId, t, turnIndex]);
+    }, [canRollback, dialogTurn?.id, rollbackNeedsCancel, sessionId, t, turnIndex]);
     
     // Toggle expanded state.
     const handleToggleExpand = useCallback(() => {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -27,6 +27,7 @@
     "test:l1:settings": "wdio run ./config/wdio.conf.ts --spec \"./specs/l1-settings.spec.ts\"",
     "test:l1:session": "wdio run ./config/wdio.conf.ts --spec \"./specs/l1-session.spec.ts\"",
     "test:l1:dialog": "wdio run ./config/wdio.conf.ts --spec \"./specs/l1-dialog.spec.ts\"",
+    "test:l1:rollback": "wdio run ./config/wdio.conf.ts --spec \"./specs/l1-rollback.spec.ts\"",
     "test:l1:chat-flow": "wdio run ./config/wdio.conf.ts --spec \"./specs/l1-chat.spec.ts\"",
     "test:smoke": "wdio run ./config/wdio.conf.ts --spec \"./specs/startup/*.spec.ts\"",
     "test:chat": "wdio run ./config/wdio.conf.ts --spec \"./specs/chat/*.spec.ts\"",

--- a/tests/e2e/page-objects/ChatPage.ts
+++ b/tests/e2e/page-objects/ChatPage.ts
@@ -12,14 +12,18 @@ export class ChatPage extends BasePage {
     inputContainer: '[data-testid="chat-input-container"], .chat-input-container',
     textarea: '[data-testid="chat-input-textarea"], .chat-input textarea, textarea[class*="chat-input"]',
     sendBtn: '[data-testid="chat-input-send-btn"], .chat-input__send-btn, button[class*="send"]',
+    cancelBtn: '[data-testid="chat-input-cancel-btn"], .chat-input__cancel-btn, button[class*="cancel"]',
     messageList: '[data-testid="message-list"], .message-list, .chat-messages',
-    userMessage: '[data-testid^="user-message-"], .user-message, [class*="user-message"]',
+    userMessage: '[data-testid^="user-message-"], .user-message-item, .user-message, [class*="user-message"]',
+    latestUserMessageItem: '.user-message-item:last-of-type',
+    rollbackButton: '.user-message-item__rollback-btn',
     modelResponse: '[data-testid^="model-response-"], .model-response, [class*="model-response"], [class*="assistant-message"]',
     modelSelector: '[data-testid="model-selector"], .model-selector, [class*="model-select"]',
     modelDropdown: '[data-testid="model-selector-dropdown"], .model-dropdown',
     toolCard: '[data-testid^="tool-card-"], .tool-card, [class*="tool-card"]',
     loadingIndicator: '[data-testid="loading-indicator"], .loading-indicator, [class*="loading"]',
     streamingIndicator: '[data-testid="streaming-indicator"], .streaming-indicator, [class*="streaming"]',
+    processingIndicator: '.processing-indicator',
   };
 
   async waitForLoad(): Promise<void> {
@@ -115,20 +119,122 @@ export class ChatPage extends BasePage {
     return texts;
   }
 
-  async getModelResponses(): Promise<string[]> {
-    const responses = await $$(this.selectors.modelResponse);
-    const texts: string[] = [];
+  async getVisibleUserMessageCount(): Promise<number> {
+    const candidates = await $$(this.selectors.userMessage);
+    let visibleCount = 0;
 
-    for (const resp of responses) {
+    for (const candidate of candidates) {
       try {
-        const text = await resp.getText();
-        texts.push(text);
-      } catch (e) {
-        // Skip
+        if (await candidate.isDisplayed()) {
+          visibleCount += 1;
+        }
+      } catch {
+        // Ignore stale or hidden elements.
       }
     }
 
-    return texts;
+    return visibleCount;
+  }
+
+  async hoverLatestUserMessage(): Promise<void> {
+    const candidates = await $$(this.selectors.userMessage);
+
+    for (let i = candidates.length - 1; i >= 0; i -= 1) {
+      try {
+        if (await candidates[i].isDisplayed()) {
+          await candidates[i].moveTo();
+          return;
+        }
+      } catch {
+        // Try previous candidate.
+      }
+    }
+
+    throw new Error('No visible user message found to hover');
+  }
+
+  async waitForRollbackButton(timeout: number = 5000): Promise<WebdriverIO.Element> {
+    await browser.waitUntil(
+      async () => {
+        const buttons = await $$(this.selectors.rollbackButton);
+        for (const button of buttons) {
+          try {
+            if (await button.isDisplayed()) {
+              return true;
+            }
+          } catch {
+            // Continue checking.
+          }
+        }
+        return false;
+      },
+      {
+        timeout,
+        timeoutMsg: `Rollback button not visible within ${timeout}ms`,
+      }
+    );
+
+    const buttons = await $$(this.selectors.rollbackButton);
+    for (const button of buttons) {
+      try {
+        if (await button.isDisplayed()) {
+          return button;
+        }
+      } catch {
+        // Continue checking.
+      }
+    }
+
+    throw new Error('Rollback button not found after wait');
+  }
+
+  async clickLatestRollbackButton(): Promise<void> {
+    await this.hoverLatestUserMessage();
+    const button = await this.waitForRollbackButton();
+    await button.click();
+  }
+
+  async waitForProcessingIndicatorVisible(timeout: number = 10000): Promise<void> {
+    await browser.waitUntil(
+      async () => {
+        const indicator = await $(this.selectors.processingIndicator);
+        return indicator.isExisting();
+      },
+      {
+        timeout,
+        timeoutMsg: `Processing indicator not found within ${timeout}ms`,
+      }
+    );
+  }
+
+  async waitForProcessingIndicatorHidden(timeout: number = 10000): Promise<void> {
+    await browser.waitUntil(
+      async () => {
+        const indicator = await $(this.selectors.processingIndicator);
+        const exists = await indicator.isExisting();
+        if (!exists) {
+          return true;
+        }
+
+        const ariaHidden = await indicator.getAttribute('aria-hidden');
+        return ariaHidden === 'true';
+      },
+      {
+        timeout,
+        timeoutMsg: `Processing indicator still visible after ${timeout}ms`,
+      }
+    );
+  }
+
+  async hasVisibleProcessingIndicator(): Promise<boolean> {
+    const indicator = await $(this.selectors.processingIndicator);
+    const exists = await indicator.isExisting();
+    if (!exists) {
+      return false;
+    }
+
+    const ariaHidden = await indicator.getAttribute('aria-hidden');
+    return ariaHidden !== 'true';
   }
 
   async getLastModelResponse(): Promise<string> {

--- a/tests/e2e/specs/l1-rollback.spec.ts
+++ b/tests/e2e/specs/l1-rollback.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * L1 rollback spec: validates rollback clears processing indicator.
+ */
+
+import { browser, expect } from '@wdio/globals';
+import { ChatPage } from '../page-objects/ChatPage';
+import { ChatInput } from '../page-objects/components/ChatInput';
+import { Header } from '../page-objects/components/Header';
+import { StartupPage } from '../page-objects/StartupPage';
+import { saveScreenshot, saveFailureScreenshot } from '../helpers/screenshot-utils';
+import { ensureWorkspaceOpen } from '../helpers/workspace-utils';
+
+describe('L1 Rollback', () => {
+  let chatPage: ChatPage;
+  let chatInput: ChatInput;
+  let header: Header;
+  let startupPage: StartupPage;
+
+  let hasWorkspace = false;
+
+  before(async () => {
+    console.log('[L1] Starting rollback tests');
+
+    chatPage = new ChatPage();
+    chatInput = new ChatInput();
+    header = new Header();
+    startupPage = new StartupPage();
+
+    await browser.pause(3000);
+    await header.waitForLoad();
+
+    hasWorkspace = await ensureWorkspaceOpen(startupPage);
+
+    if (!hasWorkspace) {
+      console.log('[L1] No workspace available - tests will be skipped');
+      return;
+    }
+
+    await chatPage.waitForLoad();
+    await chatInput.waitForLoad();
+  });
+
+  it('rollback should clear processing indicator for the reverted turn', async function () {
+    if (!hasWorkspace) {
+      this.skip();
+      return;
+    }
+
+    await chatInput.clear();
+
+    const userCountBefore = await chatPage.getVisibleUserMessageCount();
+    const prompt = `rollback-e2e-${Date.now()}`;
+
+    await chatInput.typeMessage(prompt);
+    await chatInput.clickSend();
+
+    await browser.waitUntil(
+      async () => (await chatPage.getVisibleUserMessageCount()) >= userCountBefore + 1,
+      {
+        timeout: 15000,
+        timeoutMsg: 'User message did not appear after sending',
+      }
+    );
+
+    await chatPage.waitForProcessingIndicatorVisible(15000);
+
+    await browser.execute(() => {
+      const originalConfirm = window.confirm;
+      window.confirm = () => {
+        window.confirm = originalConfirm;
+        return true;
+      };
+    });
+
+    await chatPage.clickLatestRollbackButton();
+
+    await browser.waitUntil(
+      async () => (await chatPage.getVisibleUserMessageCount()) === userCountBefore,
+      {
+        timeout: 15000,
+        timeoutMsg: 'Rolled back user message still exists',
+      }
+    );
+
+    await chatPage.waitForProcessingIndicatorHidden(15000);
+
+    expect(await chatPage.hasVisibleProcessingIndicator()).toBe(false);
+  });
+
+  afterEach(async function () {
+    if (this.currentTest?.state === 'failed') {
+      await saveFailureScreenshot(`l1-rollback-${this.currentTest.title}`);
+    }
+  });
+
+  after(async () => {
+    await saveScreenshot('l1-rollback-complete');
+    console.log('[L1] Rollback tests complete');
+  });
+});


### PR DESCRIPTION
## Summary
- fix the modern chat rollback flow so reverting the currently processing turn also clears the session processing state
- reset the flow chat state machine after rollback completes to remove the lingering loading indicator
- add an L1 E2E regression test covering rollback while the processing indicator is visible

## Testing
- npm --prefix "C:/Users/wgq/workspace/BitFun/tests/e2e" run test:l1:rollback -- --mochaOpts.timeout 180000

fix https://github.com/GCWing/BitFun/issues/109