### PR TITLE
feat(chat): add input history navigation with up/down arrows

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -34,6 +34,7 @@ import { MERMAID_INTERACTIVE_EXAMPLE } from '../constants/mermaidExamples';
 import { useMessageSender } from '../hooks/useMessageSender';
 import { useTemplateEditor } from '../hooks/useTemplateEditor';
 import { useChatInputState } from '../store/chatInputStateStore';
+import { useInputHistoryStore } from '../store/inputHistoryStore';
 import { createLogger } from '@/shared/utils/logger';
 import { Tooltip, IconButton } from '@/component-library';
 import './ChatInput.scss';
@@ -60,6 +61,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const modeDropdownRef = useRef<HTMLDivElement>(null);
   const isImeComposingRef = useRef(false);
   const lastImeCompositionEndAtRef = useRef(0);
+  
+  // History navigation state
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const [savedDraft, setSavedDraft] = useState('');
+  const { messages: inputHistory, addMessage: addToHistory } = useInputHistoryStore();
   
   const contexts = useContextStore(state => state.contexts);
   const addContext = useContextStore(state => state.addContext);
@@ -598,6 +604,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     
     const message = inputState.value.trim();
     
+    // Add to history before clearing
+    addToHistory(message);
+    setHistoryIndex(-1);
+    setSavedDraft('');
+    
     dispatchInput({ type: 'CLEAR_VALUE' });
     
     try {
@@ -607,7 +618,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       log.error('Failed to send message', { error });
       dispatchInput({ type: 'SET_VALUE', payload: message });
     }
-  }, [inputState.value, derivedState, transition, sendMessage]);
+  }, [inputState.value, derivedState, transition, sendMessage, addToHistory]);
   
   const getFilteredModes = useCallback(() => {
     if (!canSwitchModes) {
@@ -739,6 +750,84 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       }
     }
     
+    // History navigation with up/down arrows
+    // Only handle when not in slash command mode and not composing
+    if (!slashCommandState.isActive && inputHistory.length > 0) {
+      const selection = window.getSelection();
+      const editor = richTextInputRef.current;
+      
+      if (selection && selection.rangeCount > 0 && editor) {
+        const range = selection.getRangeAt(0);
+        
+        // Check cursor position
+        const isAtStart = range.collapsed && range.startOffset === 0 && 
+                          (range.startContainer === editor || 
+                           (range.startContainer.nodeType === Node.TEXT_NODE && 
+                            range.startContainer.previousSibling === null &&
+                            range.startContainer.parentNode === editor));
+        
+        // For end position, we need to check if cursor is at the end of content
+        const isAtEnd = (() => {
+          if (!range.collapsed) return false;
+          const editorContent = editor.textContent || '';
+          let cursorPos = 0;
+          const traverse = (node: Node): boolean => {
+            if (node === range.startContainer) {
+              if (node.nodeType === Node.TEXT_NODE) {
+                cursorPos += range.startOffset;
+              }
+              return true;
+            }
+            if (node.nodeType === Node.TEXT_NODE) {
+              cursorPos += (node.textContent || '').length;
+            } else if (node.nodeType === Node.ELEMENT_NODE) {
+              for (const child of Array.from(node.childNodes)) {
+                if (traverse(child)) return true;
+              }
+            }
+            return false;
+          };
+          traverse(editor);
+          return cursorPos === editorContent.length;
+        })();
+        
+        // Arrow Up at start of line -> go back in history
+        if (e.key === 'ArrowUp' && isAtStart) {
+          e.preventDefault();
+          
+          // Save draft if starting navigation
+          if (historyIndex === -1 && inputState.value.trim()) {
+            setSavedDraft(inputState.value);
+          }
+          
+          // Navigate back (older messages)
+          if (historyIndex < inputHistory.length - 1) {
+            const newIndex = historyIndex + 1;
+            setHistoryIndex(newIndex);
+            dispatchInput({ type: 'SET_VALUE', payload: inputHistory[newIndex] });
+          }
+          return;
+        }
+        
+        // Arrow Down at end of line -> go forward in history
+        if (e.key === 'ArrowDown' && isAtEnd) {
+          e.preventDefault();
+          
+          if (historyIndex > 0) {
+            // Navigate forward (newer messages)
+            const newIndex = historyIndex - 1;
+            setHistoryIndex(newIndex);
+            dispatchInput({ type: 'SET_VALUE', payload: inputHistory[newIndex] });
+          } else if (historyIndex === 0) {
+            // Return to draft/empty
+            setHistoryIndex(-1);
+            dispatchInput({ type: 'SET_VALUE', payload: savedDraft });
+          }
+          return;
+        }
+      }
+    }
+    
     const isComposing = (e.nativeEvent as KeyboardEvent).isComposing || isImeComposingRef.current;
     const justFinishedComposition = Date.now() - lastImeCompositionEndAtRef.current < IME_ENTER_GUARD_MS;
     
@@ -761,7 +850,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       e.preventDefault();
       transition(SessionExecutionEvent.USER_CANCEL);
     }
-  }, [handleSendOrCancel, derivedState, transition, templateState.fillState, moveToNextPlaceholder, moveToPrevPlaceholder, exitTemplateMode, slashCommandState, getFilteredModes, selectSlashCommandMode, canSwitchModes]);
+  }, [handleSendOrCancel, derivedState, transition, templateState.fillState, moveToNextPlaceholder, moveToPrevPlaceholder, exitTemplateMode, slashCommandState, getFilteredModes, selectSlashCommandMode, canSwitchModes, historyIndex, inputHistory, savedDraft, inputState.value]);
 
   const handleImeCompositionStart = useCallback(() => {
     isImeComposingRef.current = true;

--- a/src/web-ui/src/flow_chat/store/inputHistoryStore.ts
+++ b/src/web-ui/src/flow_chat/store/inputHistoryStore.ts
@@ -1,0 +1,66 @@
+/**
+ * Input history store for navigating previously sent messages.
+ * Provides terminal-like up/down arrow navigation through message history.
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface InputHistoryState {
+  /** List of previously sent messages (most recent first) */
+  messages: string[];
+  /** Maximum number of messages to keep */
+  maxHistorySize: number;
+  
+  /** Add a message to history */
+  addMessage: (message: string) => void;
+  /** Clear all history */
+  clearHistory: () => void;
+  /** Get message at index (0 = most recent) */
+  getMessage: (index: number) => string | null;
+  /** Get total count */
+  getCount: () => number;
+}
+
+export const useInputHistoryStore = create<InputHistoryState>()(
+  persist(
+    (set, get) => ({
+      messages: [],
+      maxHistorySize: 100,
+      
+      addMessage: (message: string) => {
+        const trimmed = message.trim();
+        if (!trimmed) return;
+        
+        set((state) => {
+          // Don't add duplicates in a row
+          if (state.messages[0] === trimmed) {
+            return state;
+          }
+          
+          // Remove the message if it exists elsewhere in history
+          const filtered = state.messages.filter(m => m !== trimmed);
+          
+          // Add to front, limit size
+          const newMessages = [trimmed, ...filtered].slice(0, state.maxHistorySize);
+          
+          return { messages: newMessages };
+        });
+      },
+      
+      clearHistory: () => set({ messages: [] }),
+      
+      getMessage: (index: number) => {
+        const { messages } = get();
+        if (index < 0 || index >= messages.length) return null;
+        return messages[index];
+      },
+      
+      getCount: () => get().messages.length,
+    }),
+    {
+      name: 'bitfun-input-history',
+      version: 1,
+    }
+  )
+);


### PR DESCRIPTION
- Create inputHistoryStore for persisting message history
- Add up/down arrow navigation when cursor is at start/end of input
- Save draft when navigating away from current input
- History persists across sessions (max 100 messages)

<img width="591" height="391" alt="image" src="https://github.com/user-attachments/assets/dbe28488-2929-46b8-ae71-f0cdb56fe544" />
