### PR TITLE
Fix stale image contexts after chat input removal

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -551,10 +551,17 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     }
   }, [currentSessionId, workspacePath, derivedState?.isProcessing]);
   
-  const handleInputChange = useCallback((text: string) => {
+  const handleInputChange = useCallback((text: string, activeContexts: import('../../shared/types/context').ContextItem[]) => {
     if (!inputState.isActive && text.length > 0) {
       dispatchInput({ type: 'ACTIVATE' });
     }
+
+    const activeContextIds = new Set(activeContexts.map(context => context.id));
+    contexts.forEach(context => {
+      if (!activeContextIds.has(context.id)) {
+        removeContext(context.id);
+      }
+    });
     
     dispatchInput({ type: 'SET_VALUE', payload: text });
     
@@ -578,7 +585,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         });
       }
     }
-  }, [derivedState, setQueuedInput, inputState.isActive, slashCommandState.isActive]);
+  }, [contexts, derivedState, inputState.isActive, removeContext, setQueuedInput, slashCommandState.isActive]);
   
   const handleSendOrCancel = useCallback(async () => {
     if (!derivedState) return;

--- a/src/web-ui/src/flow_chat/components/RichTextInput.tsx
+++ b/src/web-ui/src/flow_chat/components/RichTextInput.tsx
@@ -302,13 +302,20 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
     if (isComposingRef.current) return;
     
     const textContent = extractTextContent();
-    onChange(textContent, contexts);
+    const visibleContextIds = new Set(
+      Array.from(internalRef.current?.querySelectorAll<HTMLElement>('[data-context-id]') ?? [])
+        .map(element => element.dataset.contextId)
+        .filter((id): id is string => !!id)
+    );
+    const visibleContexts = contexts.filter(context => visibleContextIds.has(context.id));
+
+    onChange(textContent, visibleContexts);
     
     // Ensure detection runs after DOM updates
     requestAnimationFrame(() => {
       detectMention();
     });
-  }, [contexts, onChange, detectMention]);
+  }, [contexts, onChange, detectMention, internalRef]);
 
   const handlePaste = useCallback((e: React.ClipboardEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary

  Fix a chat input state sync bug where removing an image from the input UI did
  not always remove the underlying image context from the store.

  In the broken flow:

  1. A user attached an image without configuring an image understanding model
  2. Sending failed once as expected
  3. The user removed the image and tried sending text only
  4. The old image context was still included in the next request, so the same
     error kept happening until app restart

  ## Root Cause

  RichTextInput and the global contextStore could get out of sync.

  The image tag could be removed from the editor DOM, but the corresponding
  context item could remain in store state. Later sends looked like text-only
  messages in the UI, while the backend still received stale image contexts.

  ## Changes

  - Update RichTextInput to derive active contexts from the currently visible
    DOM tags before propagating input changes
  - Update ChatInput to remove context-store entries that are no longer present
    in the editor
  - Keep image/context state aligned after inline tag removal, including the
    failed-send recovery path

  ## Result

  After an image-triggered send error, removing the image from the chat input
  now fully clears its context. Users can continue with text-only messages
  immediately, without restarting the app.