### PR TITLE
feat(config): enable tool auto-execution by default

### DIFF
--- a/src/crates/core/src/agentic/tools/implementations/delete_file_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/delete_file_tool.rs
@@ -100,7 +100,7 @@ Important notes:
     }
     
     fn needs_permissions(&self, _input: Option<&Value>) -> bool {
-        true
+        false
     }
     
     async fn validate_input(&self, input: &Value, _context: Option<&ToolUseContext>) -> ValidationResult {

--- a/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -61,7 +61,7 @@ Usage:
     }
 
     fn needs_permissions(&self, _input: Option<&Value>) -> bool {
-        true
+        false
     }
 
     async fn validate_input(

--- a/src/crates/core/src/service/config/types.rs
+++ b/src/crates/core/src/service/config/types.rs
@@ -404,7 +404,7 @@ pub struct AIConfig {
     pub tool_confirmation_timeout_secs: Option<u64>,
 
     /// Skip tool execution confirmation (global, applies to all modes).
-    #[serde(default)]
+    #[serde(default = "default_skip_tool_confirmation")]
     pub skip_tool_confirmation: bool,
 
     /// Debug-mode configuration (log path, language templates, etc.).
@@ -451,6 +451,10 @@ fn default_tool_execution_timeout() -> Option<u64> {
 /// Default is no timeout (wait forever).
 fn default_tool_confirmation_timeout() -> Option<u64> {
     None
+}
+
+fn default_skip_tool_confirmation() -> bool {
+    true
 }
 
 impl Default for ModeConfig {
@@ -1114,7 +1118,7 @@ impl Default for AIConfig {
             proxy: ProxyConfig::default(),
             tool_execution_timeout_secs: default_tool_execution_timeout(),
             tool_confirmation_timeout_secs: default_tool_confirmation_timeout(),
-            skip_tool_confirmation: false,
+            skip_tool_confirmation: true,
             debug_mode_config: DebugModeConfig::default(),
             known_tools: Vec::new(),
         }


### PR DESCRIPTION
## Summary

- Set `skip_tool_confirmation` default to `true` in `AIConfig` so new users get auto-execute enabled out of the box
- Add dedicated serde default function `default_skip_tool_confirmation()` so the value is also `true` when the field is absent from an existing config file
- Mark `DeleteFileTool` and `FileWriteTool` `needs_permissions` as `false`, aligning them with the auto-execute default

## Test plan

- [x] Fresh installation: verify the tool auto-execute toggle in Settings > Tools is ON by default
- [ ] Existing config without `skip_tool_confirmation` field: verify it defaults to enabled after upgrade
- [ ] File write and delete operations execute without a confirmation prompt when auto-execute is enabled
- [ ] Toggling the switch in Settings still persists the user preference correctly