### PR TITLE
feat(web-ui): move side questions into an auxiliary panel

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/MainNav.tsx
+++ b/src/web-ui/src/app/components/NavPanel/MainNav.tsx
@@ -606,7 +606,7 @@ const MainNav: React.FC<MainNavProps> = ({
                         aria-expanded={workspaceMenuOpen}
                         onClick={toggleWorkspaceMenu}
                       >
-                        <FolderOpen size={13} />
+                        <Plus size={13} />
                       </button>
                     </div>
                   ) : undefined}

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
@@ -92,25 +92,45 @@
     }
 
     &.is-child {
-      height: 24px;
+      min-height: 24px;
       font-size: 12px;
-      padding-left: calc(#{$size-gap-1} + 14px);
+      padding-left: calc(#{$size-gap-1} + 18px);
       position: relative;
 
       &::before {
         content: '';
         position: absolute;
         left: 10px;
+        top: 0;
+        width: 1px;
+        height: 50%;
+        background: color-mix(in srgb, var(--border-subtle) 88%, transparent);
+        opacity: 0.95;
+      }
+
+      &::after {
+        content: '';
+        position: absolute;
+        left: 10px;
         top: 50%;
-        width: 10px;
+        width: 12px;
         height: 1px;
-        background: var(--border-subtle);
-        opacity: 0.9;
+        background: color-mix(in srgb, var(--border-subtle) 92%, transparent);
+        opacity: 0.95;
         transform: translateY(-50%);
       }
 
       .bitfun-nav-panel__inline-item-icon {
-        opacity: 0.55;
+        opacity: 0.72;
+      }
+    }
+
+    &.is-btw-child {
+      background: color-mix(in srgb, var(--element-bg-soft) 38%, transparent);
+
+      &:hover,
+      &.is-active {
+        background: color-mix(in srgb, var(--element-bg-soft) 74%, transparent);
       }
     }
   }
@@ -136,11 +156,58 @@
     }
   }
 
+  &__inline-item-main {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
   &__inline-item-label {
     flex: 1;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  &__inline-item-btw-badge {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    height: 12px;
+    padding: 0 4px;
+    border: 1px solid color-mix(in srgb, var(--border-subtle) 85%, transparent);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--element-bg-soft) 42%, transparent);
+    color: var(--color-text-muted);
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    opacity: 0.78;
+  }
+
+  &__inline-item-tooltip {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    max-width: 260px;
+  }
+
+  &__inline-item-tooltip-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    line-height: 1.4;
+    word-break: break-word;
+  }
+
+  &__inline-item-tooltip-meta {
+    font-size: 11px;
+    color: var(--color-text-secondary);
+    line-height: 1.4;
+    word-break: break-word;
   }
 
   &__inline-item-actions {
@@ -170,12 +237,60 @@
     transition: color $motion-fast $easing-standard,
                 background $motion-fast $easing-standard;
 
-    &:hover {
+    &:hover,
+    &.is-open {
       color: var(--color-text-primary);
       background: color-mix(in srgb, var(--color-text-primary) 10%, transparent);
     }
+  }
 
-    &.delete:hover {
+  &__inline-item-menu-popover {
+    position: fixed;
+    width: max-content;
+    min-width: 140px;
+    max-width: min(220px, calc(100vw - 24px));
+    padding: $size-gap-1 0;
+    border-radius: $size-radius-base;
+    background: var(--color-bg-elevated, #1e1e22);
+    border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    z-index: 10000;
+    transform-origin: top left;
+    animation: bitfun-footer-menu-in $motion-fast $easing-decelerate forwards;
+  }
+
+  &__inline-item-menu-item {
+    display: flex;
+    align-items: center;
+    gap: $size-gap-2;
+    width: 100%;
+    min-height: 28px;
+    padding: 0 $size-gap-2;
+    border: none;
+    background: transparent;
+    color: var(--color-text-secondary);
+    font-size: $font-size-sm;
+    font-weight: 400;
+    cursor: pointer;
+    text-align: left;
+    white-space: nowrap;
+    transition: color $motion-fast $easing-standard,
+                background $motion-fast $easing-standard;
+
+    svg {
+      flex-shrink: 0;
+      opacity: 0.7;
+      transition: opacity $motion-fast $easing-standard;
+    }
+
+    &:hover:not(:disabled) {
+      color: var(--color-text-primary);
+      background: var(--element-bg-soft);
+
+      svg { opacity: 1; }
+    }
+
+    &.is-danger:hover:not(:disabled) {
       color: var(--color-error, #ef4444);
       background: color-mix(in srgb, var(--color-error, #ef4444) 10%, transparent);
     }

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -6,17 +6,23 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Pencil, Trash2, Check, X, Bot, Code2, Users } from 'lucide-react';
+import { createPortal } from 'react-dom';
+import { Pencil, Trash2, Check, X, Bot, Code2, Users, MoreHorizontal } from 'lucide-react';
 import { IconButton, Input, Tooltip } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n';
 import { flowChatStore } from '../../../../../flow_chat/store/FlowChatStore';
 import { flowChatManager } from '../../../../../flow_chat/services/FlowChatManager';
 import type { FlowChatState, Session } from '../../../../../flow_chat/types/flow-chat';
 import { useSceneStore } from '../../../../stores/sceneStore';
-import { useApp } from '../../../../hooks/useApp';
 import type { SceneTabId } from '../../../SceneBar/types';
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
 import { createLogger } from '@/shared/utils/logger';
+import { useAgentCanvasStore } from '@/app/components/panels/content-canvas/stores';
+import {
+  openBtwSessionInAuxPane,
+  openMainSession,
+  selectActiveBtwSessionTab,
+} from '@/flow_chat/services/openBtwSession';
 import './SessionsSection.scss';
 
 const MAX_VISIBLE_SESSIONS = 8;
@@ -50,17 +56,22 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   isActiveWorkspace = true,
 }) => {
   const { t } = useI18n('common');
-  const { switchLeftPanelTab } = useApp();
   const { setActiveWorkspace } = useWorkspaceContext();
-  const openScene = useSceneStore(s => s.openScene);
   const activeTabId = useSceneStore(s => s.activeTabId);
+  const activeBtwSessionTab = useAgentCanvasStore(state => selectActiveBtwSessionTab(state as any));
+  const activeBtwSessionData = activeBtwSessionTab?.content.data as
+    | { childSessionId: string; parentSessionId: string; workspacePath?: string }
+    | undefined;
   const [flowChatState, setFlowChatState] = useState<FlowChatState>(() =>
     flowChatStore.getState()
   );
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
   const [showAll, setShowAll] = useState(false);
+  const [openMenuSessionId, setOpenMenuSessionId] = useState<string | null>(null);
+  const [sessionMenuPosition, setSessionMenuPosition] = useState<{ top: number; left: number } | null>(null);
   const editInputRef = useRef<HTMLInputElement>(null);
+  const sessionMenuPopoverRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const unsub = flowChatStore.subscribe(s => setFlowChatState(s));
@@ -77,6 +88,18 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   useEffect(() => {
     setShowAll(false);
   }, [workspaceId, workspacePath, isActiveWorkspace]);
+
+  useEffect(() => {
+    if (!openMenuSessionId) return;
+    const handleOutside = (event: MouseEvent) => {
+      if (!sessionMenuPopoverRef.current?.contains(event.target as Node)) {
+        setOpenMenuSessionId(null);
+        setSessionMenuPosition(null);
+      }
+    };
+    document.addEventListener('mousedown', handleOutside);
+    return () => document.removeEventListener('mousedown', handleOutside);
+  }, [openMenuSessionId]);
 
   const sessions = useMemo(
     () =>
@@ -154,14 +177,40 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   const handleSwitch = useCallback(
     async (sessionId: string) => {
       if (editingSessionId) return;
-      openScene('session');
-      switchLeftPanelTab('sessions');
-      if (sessionId === activeSessionId) return;
       try {
-        if (workspaceId && !isActiveWorkspace) {
-          await setActiveWorkspace(workspaceId);
+        const session = flowChatStore.getState().sessions.get(sessionId);
+        const parentSessionId = session?.btwOrigin?.parentSessionId || session?.parentSessionId;
+        const activateWorkspace = workspaceId && !isActiveWorkspace
+          ? async (targetWorkspaceId: string) => {
+            await setActiveWorkspace(targetWorkspaceId);
+          }
+          : undefined;
+
+        if (session?.sessionKind === 'btw' && parentSessionId) {
+          await openMainSession(parentSessionId, {
+            workspaceId,
+            activateWorkspace,
+          });
+          openBtwSessionInAuxPane({
+            childSessionId: sessionId,
+            parentSessionId,
+            workspacePath: session.workspacePath,
+          });
+          return;
         }
-        await flowChatManager.switchChatSession(sessionId);
+
+        if (sessionId === activeSessionId) {
+          await openMainSession(sessionId, {
+            workspaceId,
+            activateWorkspace,
+          });
+          return;
+        }
+
+        await openMainSession(sessionId, {
+          workspaceId,
+          activateWorkspace,
+        });
         window.dispatchEvent(
           new CustomEvent('flowchat:switch-session', { detail: { sessionId } })
         );
@@ -169,7 +218,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
         log.error('Failed to switch session', err);
       }
     },
-    [activeSessionId, editingSessionId, isActiveWorkspace, openScene, setActiveWorkspace, switchLeftPanelTab, workspaceId]
+    [activeSessionId, editingSessionId, isActiveWorkspace, setActiveWorkspace, workspaceId]
   );
 
   const resolveSessionTitle = useCallback(
@@ -188,6 +237,28 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
       return `${label} ${matched[1]}`;
     },
     [t]
+  );
+
+  const handleMenuOpen = useCallback(
+    (e: React.MouseEvent, sessionId: string) => {
+      e.stopPropagation();
+      if (openMenuSessionId === sessionId) {
+        setOpenMenuSessionId(null);
+        setSessionMenuPosition(null);
+        return;
+      }
+      const btn = e.currentTarget as HTMLElement;
+      const rect = btn.getBoundingClientRect();
+      const viewportPadding = 8;
+      const estimatedWidth = 160;
+      const maxLeft = window.innerWidth - estimatedWidth - viewportPadding;
+      setSessionMenuPosition({
+        top: Math.max(viewportPadding, rect.bottom + 4),
+        left: Math.max(viewportPadding, Math.min(rect.left, maxLeft)),
+      });
+      setOpenMenuSessionId(sessionId);
+    },
+    [openMenuSessionId]
   );
 
   const handleDelete = useCallback(
@@ -250,20 +321,37 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
       ) : (
         visibleItems.map(({ session, level }) => {
           const isEditing = editingSessionId === session.sessionId;
+          const isBtwChild = level === 1 && session.sessionKind === 'btw';
           const sessionModeKey = resolveSessionModeType(session);
           const sessionTitle = resolveSessionTitle(session);
+          const parentSessionId = session.btwOrigin?.parentSessionId || session.parentSessionId;
+          const parentSession = parentSessionId ? flowChatState.sessions.get(parentSessionId) : undefined;
+          const parentTitle = parentSession ? resolveSessionTitle(parentSession) : '';
+          const parentTurnIndex = session.btwOrigin?.parentTurnIndex;
+          const tooltipContent = isBtwChild ? (
+            <div className="bitfun-nav-panel__inline-item-tooltip">
+              <div className="bitfun-nav-panel__inline-item-tooltip-title">{sessionTitle}</div>
+              <div className="bitfun-nav-panel__inline-item-tooltip-meta">
+                {`来自 ${parentTitle || '父会话'}${parentTurnIndex ? ` · 第 ${parentTurnIndex} 轮` : ''}`}
+              </div>
+            </div>
+          ) : sessionTitle;
           const SessionIcon =
             sessionModeKey === 'cowork'
               ? Users
               : sessionModeKey === 'claw'
                 ? Bot
                 : Code2;
+          const isRowActive = activeBtwSessionData?.childSessionId
+            ? session.sessionId === activeBtwSessionData.childSessionId
+            : activeTabId === AGENT_SCENE && session.sessionId === activeSessionId;
           const row = (
             <div
               className={[
                 'bitfun-nav-panel__inline-item',
                 level === 1 && 'is-child',
-                activeTabId === AGENT_SCENE && session.sessionId === activeSessionId && 'is-active',
+                isBtwChild && 'is-btw-child',
+                isRowActive && 'is-active',
                 isEditing && 'is-editing',
               ]
                 .filter(Boolean)
@@ -317,35 +405,53 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
                 </div>
               ) : (
                 <>
-                  <span className="bitfun-nav-panel__inline-item-label">{sessionTitle}</span>
+                  <span className="bitfun-nav-panel__inline-item-main">
+                    <span className="bitfun-nav-panel__inline-item-label">{sessionTitle}</span>
+                    {isBtwChild ? (
+                      <span className="bitfun-nav-panel__inline-item-btw-badge">btw</span>
+                    ) : null}
+                  </span>
                   <div className="bitfun-nav-panel__inline-item-actions">
-                    <IconButton
-                      variant="default"
-                      size="xs"
-                      className="bitfun-nav-panel__inline-item-action-btn"
-                      onClick={e => handleStartEdit(e, session)}
-                      tooltip={t('nav.sessions.rename')}
-                      tooltipPlacement="top"
+                    <button
+                      type="button"
+                      className={`bitfun-nav-panel__inline-item-action-btn${openMenuSessionId === session.sessionId ? ' is-open' : ''}`}
+                      onClick={e => handleMenuOpen(e, session.sessionId)}
                     >
-                      <Pencil size={11} />
-                    </IconButton>
-                    <IconButton
-                      variant="danger"
-                      size="xs"
-                      className="bitfun-nav-panel__inline-item-action-btn delete"
-                      onClick={e => handleDelete(e, session.sessionId)}
-                      tooltip={t('nav.sessions.delete')}
-                      tooltipPlacement="top"
-                    >
-                      <Trash2 size={11} />
-                    </IconButton>
+                      <MoreHorizontal size={12} />
+                    </button>
                   </div>
+                  {openMenuSessionId === session.sessionId && sessionMenuPosition && createPortal(
+                    <div
+                      ref={sessionMenuPopoverRef}
+                      className="bitfun-nav-panel__inline-item-menu-popover"
+                      role="menu"
+                      style={{ top: `${sessionMenuPosition.top}px`, left: `${sessionMenuPosition.left}px` }}
+                    >
+                      <button
+                        type="button"
+                        className="bitfun-nav-panel__inline-item-menu-item"
+                        onClick={e => { setOpenMenuSessionId(null); handleStartEdit(e, session); }}
+                      >
+                        <Pencil size={13} />
+                        <span>{t('nav.sessions.rename')}</span>
+                      </button>
+                      <button
+                        type="button"
+                        className="bitfun-nav-panel__inline-item-menu-item is-danger"
+                        onClick={e => { setOpenMenuSessionId(null); void handleDelete(e, session.sessionId); }}
+                      >
+                        <Trash2 size={13} />
+                        <span>{t('nav.sessions.delete')}</span>
+                      </button>
+                    </div>,
+                    document.body
+                  )}
                 </>
               )}
             </div>
           );
-          return isEditing ? row : (
-            <Tooltip key={session.sessionId} content={sessionTitle} placement="right" followCursor>
+          return isEditing || openMenuSessionId !== null ? row : (
+            <Tooltip key={session.sessionId} content={tooltipContent} placement="right" followCursor>
               {row}
             </Tooltip>
           );

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -310,18 +310,20 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({ workspace, isActive, isSi
               <Plus size={13} />
               <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.newSession')}</span>
             </button>
-            <button
-              type="button"
-              className="bitfun-nav-panel__workspace-item-menu-item"
-              onClick={() => {
-                setMenuOpen(false);
-                setWorktreeModalOpen(true);
-              }}
-              disabled={!isRepository}
-            >
-              <GitBranch size={13} />
-              <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.newWorktree')}</span>
-            </button>
+            {workspace.workspaceKind !== WorkspaceKind.Assistant && (
+              <button
+                type="button"
+                className="bitfun-nav-panel__workspace-item-menu-item"
+                onClick={() => {
+                  setMenuOpen(false);
+                  setWorktreeModalOpen(true);
+                }}
+                disabled={!isRepository}
+              >
+                <GitBranch size={13} />
+                <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.newWorktree')}</span>
+              </button>
+            )}
             <button type="button" className="bitfun-nav-panel__workspace-item-menu-item" onClick={() => { void handleReveal(); }}>
               <FolderSearch size={13} />
               <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.reveal')}</span>

--- a/src/web-ui/src/app/components/panels/base/FlexiblePanel.tsx
+++ b/src/web-ui/src/app/components/panels/base/FlexiblePanel.tsx
@@ -63,6 +63,12 @@ const TaskDetailPanel = React.lazy(() =>
   }))
 );
 
+const BtwSessionPanel = React.lazy(() =>
+  import('@/flow_chat/components/btw/BtwSessionPanel').then(module => ({
+    default: module.BtwSessionPanel
+  }))
+);
+
 // CodePreview, ChartRenderer and CodeNode removed - visualization features disabled
 import { 
   FlexiblePanelProps
@@ -710,6 +716,17 @@ const FlexiblePanel: React.FC<ExtendedFlexiblePanelProps> = memo(({
                 autoFocus={true}
               />
             </div>
+          </React.Suspense>
+        );
+
+      case 'btw-session':
+        return (
+          <React.Suspense fallback={<div className="bitfun-flexible-panel__loading">{t('flexiblePanel.loading.taskDetail')}</div>}>
+            <BtwSessionPanel
+              childSessionId={content.data?.childSessionId}
+              parentSessionId={content.data?.parentSessionId}
+              workspacePath={content.data?.workspacePath || workspacePath}
+            />
           </React.Suspense>
         );
 

--- a/src/web-ui/src/app/components/panels/base/types.ts
+++ b/src/web-ui/src/app/components/panels/base/types.ts
@@ -26,6 +26,7 @@ export type PanelContentType =
   | 'design-tokens'
   | 'task-detail'
   | 'plan-viewer'
+  | 'btw-session'
   | 'terminal';
 
 export interface PanelContent {

--- a/src/web-ui/src/app/components/panels/base/utils.ts
+++ b/src/web-ui/src/app/components/panels/base/utils.ts
@@ -14,7 +14,8 @@ import {
   Settings,
   ClipboardList,
   Image,
-  Network
+  Network,
+  MessageSquareQuote
 } from 'lucide-react';
 import { PanelContentType, PanelContentConfig } from './types';
 
@@ -192,6 +193,14 @@ export const PANEL_CONTENT_CONFIGS: Record<PanelContentType, PanelContentConfig>
     type: 'plan-viewer',
     displayName: 'Plan Viewer',
     icon: ClipboardList,
+    supportsCopy: false,
+    supportsDownload: false,
+    showHeader: false
+  },
+  'btw-session': {
+    type: 'btw-session',
+    displayName: 'Side Session',
+    icon: MessageSquareQuote,
     supportsCopy: false,
     supportsDownload: false,
     showHeader: false

--- a/src/web-ui/src/app/components/panels/content-canvas/ContentCanvas.tsx
+++ b/src/web-ui/src/app/components/panels/content-canvas/ContentCanvas.tsx
@@ -3,7 +3,7 @@
  * Core component for the right panel, aggregating submodules.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { EditorArea } from './editor-area';
 import { AnchorZone } from './anchor-zone';
 import { MissionControl } from './mission-control';
@@ -11,6 +11,7 @@ import { EmptyState } from './empty-state';
 import { useCanvasStore } from './stores';
 import { useTabLifecycle, useKeyboardShortcuts, usePanelTabCoordinator } from './hooks';
 import type { AnchorPosition } from './types';
+import { openMainSession, selectActiveBtwSessionTab } from '@/flow_chat/services/openBtwSession';
 import './ContentCanvas.scss';
 export interface ContentCanvasProps {
   /** Workspace path */
@@ -38,6 +39,11 @@ export const ContentCanvas: React.FC<ContentCanvasProps> = ({
     closeMissionControl,
     openMissionControl,
   } = useCanvasStore();
+  const activeBtwSessionTab = useCanvasStore(state => selectActiveBtwSessionTab(state as any));
+  const activeBtwSessionData = activeBtwSessionTab?.content.data as
+    | { childSessionId: string; parentSessionId: string; workspacePath?: string }
+    | undefined;
+  const lastSyncedBtwTabIdRef = useRef<string | null>(null);
   // Initialize hooks
   const { handleCloseWithDirtyCheck, handleCloseAllWithDirtyCheck } = useTabLifecycle({ mode });
   useKeyboardShortcuts({ enabled: true, handleCloseWithDirtyCheck });
@@ -46,6 +52,20 @@ export const ContentCanvas: React.FC<ContentCanvasProps> = ({
     autoCollapseOnEmpty: true,
     autoExpandOnTabOpen: true,
   });
+
+  useEffect(() => {
+    if (mode !== 'agent' || !activeBtwSessionTab?.id || !activeBtwSessionData?.parentSessionId) {
+      lastSyncedBtwTabIdRef.current = null;
+      return;
+    }
+
+    if (lastSyncedBtwTabIdRef.current === activeBtwSessionTab.id) {
+      return;
+    }
+
+    lastSyncedBtwTabIdRef.current = activeBtwSessionTab.id;
+    void openMainSession(activeBtwSessionData.parentSessionId);
+  }, [activeBtwSessionData?.parentSessionId, activeBtwSessionTab?.id, mode]);
 
   // Check if primary group has visible tabs
   const hasPrimaryVisibleTabs = useMemo(() => {

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.scss
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.scss
@@ -505,6 +505,10 @@
   background: rgba(255, 255, 255, 0.04);
 }
 
+.table-wrapper td {
+  background: transparent;
+}
+
 
 .markdown-renderer a {
   color: var(--primary-color);
@@ -691,6 +695,43 @@
 
   .code-block-wrapper code[style] {
     background: #f6f8fa !important;
+  }
+
+  .table-wrapper {
+    background: #ffffff;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    box-shadow: 0 4px 14px rgba(15, 23, 42, 0.06);
+  }
+
+  .table-wrapper th,
+  .table-wrapper td {
+    border-bottom-color: rgba(15, 23, 42, 0.1);
+  }
+
+  .table-wrapper th + th,
+  .table-wrapper td + td {
+    border-left: 1px solid rgba(15, 23, 42, 0.08);
+  }
+
+  .table-wrapper th {
+    background: #f3f6fb;
+    color: #0f172a;
+  }
+
+  .table-wrapper td {
+    color: var(--color-text-primary, #1f2937);
+  }
+
+  .table-wrapper tbody tr {
+    background: #ffffff;
+  }
+
+  .table-wrapper tbody tr:nth-child(2n) {
+    background: #f8fafc;
+  }
+
+  .table-wrapper tbody tr:hover {
+    background: #eef4ff;
   }
 }
 

--- a/src/web-ui/src/component-library/components/Tooltip/Tooltip.tsx
+++ b/src/web-ui/src/component-library/components/Tooltip/Tooltip.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import './Tooltip.scss';
 
 export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+const DEFAULT_TOOLTIP_DELAY = 450;
 
 export interface TooltipProps {
   content: React.ReactNode;
@@ -135,7 +136,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   placement = 'top',
   followCursor = false,
   trigger = 'hover',
-  delay = 200,
+  delay = DEFAULT_TOOLTIP_DELAY,
   disabled = false,
   className = '',
 }) => {
@@ -147,6 +148,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   const triggerRef = useRef<HTMLElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestMousePositionRef = useRef<{ x: number; y: number } | null>(null);
 
   const gap = 8;
   const viewportPadding = 8;
@@ -189,10 +191,17 @@ export const Tooltip: React.FC<TooltipProps> = ({
 
   const showTooltip = (e?: React.MouseEvent) => {
     if (disabled) return;
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
     if (followCursor && e) {
-      setMousePosition({ x: e.clientX, y: e.clientY });
+      latestMousePositionRef.current = { x: e.clientX, y: e.clientY };
     }
     timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
+      if (followCursor) {
+        setMousePosition(latestMousePositionRef.current);
+      }
       setPositionReady(false);
       setVisible(true);
     }, delay);
@@ -201,16 +210,20 @@ export const Tooltip: React.FC<TooltipProps> = ({
   const hideTooltip = () => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
     }
     setVisible(false);
     setPositionReady(false);
-    if (followCursor) setMousePosition(null);
+    if (followCursor) {
+      latestMousePositionRef.current = null;
+      setMousePosition(null);
+    }
   };
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => {
-      if (followCursor && visible) {
-        setMousePosition({ x: e.clientX, y: e.clientY });
+      if (followCursor && !visible) {
+        latestMousePositionRef.current = { x: e.clientX, y: e.clientY };
       }
       const childProps = children.props as Record<string, unknown>;
       if (typeof childProps.onMouseMove === 'function') {
@@ -243,13 +256,12 @@ export const Tooltip: React.FC<TooltipProps> = ({
   }, [visible, followCursor, calculatePosition]);
 
   useEffect(() => {
-    if (!followCursor || !visible) return;
-    const onMouseMove = (e: MouseEvent) => {
-      setMousePosition({ x: e.clientX, y: e.clientY });
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
     };
-    window.addEventListener('mousemove', onMouseMove);
-    return () => window.removeEventListener('mousemove', onMouseMove);
-  }, [followCursor, visible]);
+  }, []);
 
   const childProps = children.props as Record<string, unknown>;
 

--- a/src/web-ui/src/flow_chat/components/ChatInput.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInput.scss
@@ -95,6 +95,7 @@
     .bitfun-chat-input__template-hint,
     .bitfun-chat-input__cowork-examples,
     .bitfun-chat-input__recommendations,
+    .bitfun-chat-input__target-switcher,
     .bitfun-chat-input__actions-left,
     .bitfun-chat-input__mode-selector,
     .bitfun-chat-input__queued-indicator {
@@ -360,6 +361,70 @@
     
     & > * {
       pointer-events: auto;
+    }
+  }
+
+  &__target-switcher {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    padding-bottom: 7px;
+    margin-bottom: 1px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    animation: bitfun-chat-input-fade-in 0.18s ease-out;
+  }
+
+  &__target-switcher-label {
+    font-size: 10px;
+    color: var(--color-text-muted);
+    font-weight: 400;
+    padding: 2px 8px 2px 0;
+    margin-right: 4px;
+    flex-shrink: 0;
+    letter-spacing: 0.02em;
+    opacity: 0.72;
+  }
+
+  &__target-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 11px;
+    font-weight: 400;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: color 0.15s ease, background 0.15s ease;
+    white-space: nowrap;
+    outline: none;
+
+    &:hover:not(#{&}--active) {
+      color: var(--color-text-secondary);
+      background: rgba(255, 255, 255, 0.04);
+    }
+
+    &--active {
+      color: rgba(155, 190, 255, 0.95);
+      font-weight: 500;
+      background: rgba(80, 130, 255, 0.09);
+    }
+  }
+
+  &__target-tab-name {
+    max-width: 110px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 10px;
+    font-weight: 400;
+    opacity: 0.65;
+
+    &::before {
+      content: '·';
+      margin-right: 2px;
     }
   }
   
@@ -1233,48 +1298,3 @@
   }
 }
 
-.bitfun-chat-input__btw-origin {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 8px 10px;
-  margin: 0 0 8px 0;
-  border: 1px solid var(--border-subtle);
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--color-bg-elevated) 72%, transparent);
-  color: var(--color-text-secondary);
-}
-
-.bitfun-chat-input__btw-origin-text {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 8px;
-  min-width: 0;
-}
-
-.bitfun-chat-input__btw-origin-label {
-  font-size: 12px;
-  color: var(--color-text-muted);
-  white-space: nowrap;
-}
-
-.bitfun-chat-input__btw-origin-parent {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 360px;
-}
-
-.bitfun-chat-input__btw-origin-turn {
-  font-size: 12px;
-  color: var(--color-text-muted);
-  white-space: nowrap;
-}
-
-.bitfun-chat-input__btw-origin-back {
-  flex: 0 0 auto;
-}

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -16,7 +16,7 @@ import { SessionExecutionEvent } from '../state-machine/types';
 import TokenUsageIndicator from './TokenUsageIndicator';
 import { ModelSelector } from './ModelSelector';
 import { FlowChatStore } from '../store/FlowChatStore';
-import type { FlowChatState, Session } from '../types/flow-chat';
+import type { FlowChatState } from '../types/flow-chat';
 import type { FileContext, DirectoryContext } from '../../shared/types/context';
 import type { PromptTemplate } from '../../shared/types/prompt-template';
 import { SmartRecommendations } from './smart-recommendations';
@@ -39,6 +39,8 @@ import { useInputHistoryStore } from '../store/inputHistoryStore';
 import { startBtwThread } from '../services/BtwThreadService';
 import { createLogger } from '@/shared/utils/logger';
 import { Tooltip, IconButton } from '@/component-library';
+import { useAgentCanvasStore } from '@/app/components/panels/content-canvas/stores';
+import { openBtwSessionInAuxPane, selectActiveBtwSessionTab } from '../services/openBtwSession';
 import './ChatInput.scss';
 
 const log = createLogger('ChatInput');
@@ -48,6 +50,22 @@ export interface ChatInputProps {
   className?: string;
   onSendMessage?: (message: string) => void;
 }
+
+type SlashActionItem = {
+  kind: 'action';
+  id: string;
+  command: string;
+  label: string;
+};
+
+type SlashModeItem = {
+  kind: 'mode';
+  id: string;
+  name: string;
+};
+
+type SlashPickerItem = SlashActionItem | SlashModeItem;
+type ChatInputTarget = 'main' | 'btw';
 
 export const ChatInput: React.FC<ChatInputProps> = ({
   className = '',
@@ -67,6 +85,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   // History navigation state
   const [historyIndex, setHistoryIndex] = useState(-1);
   const [savedDraft, setSavedDraft] = useState('');
+  const [inputTarget, setInputTarget] = useState<ChatInputTarget>('main');
   const { addMessage: addToHistory, getSessionHistory } = useInputHistoryStore();
   
   const contexts = useContextStore(state => state.contexts);
@@ -80,13 +99,31 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   );
   
   const activeSessionState = useActiveSessionState();
+  const activeBtwSessionTab = useAgentCanvasStore(state => selectActiveBtwSessionTab(state as any));
+  const [flowChatState, setFlowChatState] = useState<FlowChatState>(() => FlowChatStore.getInstance().getState());
   const currentSessionId = activeSessionState.sessionId;
+  const currentSession = currentSessionId ? flowChatState.sessions.get(currentSessionId) : undefined;
+  const activeBtwSessionData = activeBtwSessionTab?.content.data as
+    | { childSessionId: string; parentSessionId: string; workspacePath?: string }
+    | undefined;
+  const activeBtwSessionId = activeBtwSessionData?.childSessionId;
+  const effectiveTargetSessionId =
+    inputTarget === 'btw' && activeBtwSessionId ? activeBtwSessionId : currentSessionId;
+  const effectiveTargetSession = effectiveTargetSessionId
+    ? flowChatState.sessions.get(effectiveTargetSessionId)
+    : undefined;
+  const isBtwSession = effectiveTargetSession?.sessionKind === 'btw';
+  const showTargetSwitcher = !!activeBtwSessionId;
+  const currentSessionTitle = currentSession?.title?.trim() || t('session.untitled');
+  const activeBtwSessionTitle = activeBtwSessionId
+    ? flowChatState.sessions.get(activeBtwSessionId)?.title?.trim() || t('btw.threadLabel')
+    : '';
   
   // Get input history for current session (after currentSessionId is defined)
-  const inputHistory = currentSessionId ? getSessionHistory(currentSessionId) : [];
-  const derivedState = useSessionDerivedState(currentSessionId);
-  const { transition, setQueuedInput } = useSessionStateMachineActions(currentSessionId);
-  const stateMachine = useSessionStateMachine(currentSessionId);
+  const inputHistory = effectiveTargetSessionId ? getSessionHistory(effectiveTargetSessionId) : [];
+  const derivedState = useSessionDerivedState(effectiveTargetSessionId);
+  const { transition, setQueuedInput } = useSessionStateMachineActions(effectiveTargetSessionId);
+  const stateMachine = useSessionStateMachine(effectiveTargetSessionId);
 
   const { workspace, workspacePath } = useCurrentWorkspace();
   
@@ -108,10 +145,17 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const setChatInputActive = useChatInputState(state => state.setActive);
   const setChatInputExpanded = useChatInputState(state => state.setExpanded);
 
-  // /btw now creates a child session ("side thread") and adds a lightweight marker on the parent session.
-  const [btwOrigin, setBtwOrigin] = React.useState<Session['btwOrigin'] | null>(null);
-  const [btwParentTitle, setBtwParentTitle] = React.useState<string>('');
-  
+  useEffect(() => {
+    const unsubscribe = FlowChatStore.getInstance().subscribe(setFlowChatState);
+    return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    if (!showTargetSwitcher || !activeBtwSessionId) {
+      setInputTarget('main');
+    }
+  }, [activeBtwSessionId, showTargetSwitcher]);
+
   useEffect(() => {
     setChatInputActive(inputState.isActive);
   }, [inputState.isActive, setChatInputActive]);
@@ -123,10 +167,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   // Reset history index when switching sessions
   useEffect(() => {
     setHistoryIndex(-1);
-  }, [currentSessionId]);
+  }, [effectiveTargetSessionId]);
   
   const { sendMessage } = useMessageSender({
-    currentSessionId: currentSessionId || undefined,
+    currentSessionId: effectiveTargetSessionId || undefined,
     contexts,
     onClearContexts: clearContexts,
     onSuccess: onSendMessage,
@@ -140,7 +184,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         }
       }
     },
-    currentAgentType: modeState.current,
+    currentAgentType: effectiveTargetSession?.mode || modeState.current,
   });
   
   const {
@@ -179,7 +223,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   
   const [slashCommandState, setSlashCommandState] = useState<{
     isActive: boolean;
-    kind: 'modes' | 'actions';
+    kind: 'modes' | 'actions' | 'all';
     query: string;
     selectedIndex: number;
   }>({
@@ -193,45 +237,30 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     const store = FlowChatStore.getInstance();
     
     const unsubscribe = store.subscribe((state: FlowChatState) => {
-      if (currentSessionId) {
-        const session = state.sessions.get(currentSessionId);
+      if (effectiveTargetSessionId) {
+        const session = state.sessions.get(effectiveTargetSessionId);
         if (session) {
           setTokenUsage({
             current: session.currentTokenUsage?.totalTokens || 0,
             max: session.maxContextTokens || 128128
           });
-          const nextOrigin = (session.btwOrigin ||
-            (session.sessionKind === 'btw' && session.parentSessionId ? { parentSessionId: session.parentSessionId } : null)) as any;
-          setBtwOrigin(nextOrigin);
-          const parentId = nextOrigin?.parentSessionId || session.parentSessionId;
-          const parent = parentId ? state.sessions.get(parentId) : undefined;
-          setBtwParentTitle(parent?.title || '');
         }
       }
     });
 
-    if (currentSessionId) {
+    if (effectiveTargetSessionId) {
       const state = store.getState();
-      const session = state.sessions.get(currentSessionId);
+      const session = state.sessions.get(effectiveTargetSessionId);
       if (session) {
         setTokenUsage({
           current: session.currentTokenUsage?.totalTokens || 0,
           max: session.maxContextTokens || 128128
         });
-        const nextOrigin = (session.btwOrigin ||
-          (session.sessionKind === 'btw' && session.parentSessionId ? { parentSessionId: session.parentSessionId } : null)) as any;
-        setBtwOrigin(nextOrigin);
-        const parentId = nextOrigin?.parentSessionId || session.parentSessionId;
-        const parent = parentId ? state.sessions.get(parentId) : undefined;
-        setBtwParentTitle(parent?.title || '');
-      } else {
-        setBtwOrigin(null);
-        setBtwParentTitle('');
       }
     }
 
     return () => unsubscribe();
-  }, [currentSessionId]);
+  }, [effectiveTargetSessionId]);
 
   React.useEffect(() => {
     const initializeTemplateService = async () => {
@@ -452,14 +481,14 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   }, []);
 
   React.useEffect(() => {
-    if (!currentSessionId) return;
+    if (!effectiveTargetSessionId) return;
     
     const store = FlowChatStore.getInstance();
     const state = store.getState();
-    const session = state.sessions.get(currentSessionId);
+    const session = state.sessions.get(effectiveTargetSessionId);
     
     if (session?.mode) {
-      log.debug('Session ID changed, syncing mode', { sessionId: currentSessionId, mode: session.mode });
+      log.debug('Session ID changed, syncing mode', { sessionId: effectiveTargetSessionId, mode: session.mode });
       dispatchMode({ type: 'SET_CURRENT_MODE', payload: session.mode });
       try {
         sessionStorage.setItem('bitfun:flowchat:lastMode', session.mode);
@@ -467,7 +496,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         // ignore
       }
     }
-  }, [currentSessionId]);
+  }, [effectiveTargetSessionId]);
 
   React.useEffect(() => {
     if (!isAssistantWorkspace || modeState.current === 'Claw') {
@@ -479,7 +508,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
   React.useEffect(() => {
     const queuedInput = stateMachine?.context?.queuedInput;
-    if (queuedInput && currentSessionId) {
+    if (queuedInput && effectiveTargetSessionId) {
       log.debug('Detected queuedInput, restoring message to input', { queuedInput });
       dispatchInput({ type: 'ACTIVATE' });
       dispatchInput({ type: 'SET_VALUE', payload: queuedInput });
@@ -490,7 +519,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         richTextInputRef.current.focus();
       }
     }
-  }, [stateMachine?.context?.queuedInput, currentSessionId, setQueuedInput, stateMachine?.context]);
+  }, [stateMachine?.context?.queuedInput, effectiveTargetSessionId, setQueuedInput, stateMachine?.context]);
 
   React.useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -555,13 +584,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   }, [addContext, currentImageCount]);
 
   React.useEffect(() => {
-    if (!currentSessionId || !workspacePath) {
+    if (!effectiveTargetSessionId || !workspacePath) {
       return;
     }
 
     const store = FlowChatStore.getInstance();
     const state = store.getState();
-    const session = state.sessions.get(currentSessionId);
+    const session = state.sessions.get(effectiveTargetSessionId);
 
     if (!session || session.dialogTurns.length === 0) {
       return;
@@ -594,13 +623,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         log.debug('File modifications detected, updating recommendation context', { modifiedFiles });
         setRecommendationContext({
           workspacePath,
-          sessionId: currentSessionId,
+          sessionId: effectiveTargetSessionId,
           turnIndex: session.dialogTurns.length - 1,
           modifiedFiles: [...new Set(modifiedFiles)]
         });
       }
     }
-  }, [currentSessionId, workspacePath, derivedState?.isProcessing]);
+  }, [effectiveTargetSessionId, workspacePath, derivedState?.isProcessing]);
   
   const handleInputChange = useCallback((text: string, activeContexts: import('../../shared/types/context').ContextItem[]) => {
     if (!inputState.isActive && text.length > 0) {
@@ -652,7 +681,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       if (!isBtwCommand) {
         setSlashCommandState({
           isActive: true,
-          kind: 'modes',
+          kind: 'all',
           query,
           selectedIndex: 0,
         });
@@ -676,6 +705,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       notificationService.error(t('btw.noSession', { defaultValue: 'No active session for /btw' }));
       return;
     }
+    if (isBtwSession) {
+      notificationService.warning(t('btw.nestedDisabled', { defaultValue: 'Side questions cannot create another side question' }));
+      return;
+    }
 
     const message = inputState.value.trim();
     const question = message.replace(/^\/btw\b/i, '').trim();
@@ -691,17 +724,24 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     }
 
     try {
-      await startBtwThread({
+      const { childSessionId } = await startBtwThread({
         parentSessionId: currentSessionId,
         workspacePath,
         question,
         modelId: 'fast',
         maxContextMessages: 60,
       });
+      openBtwSessionInAuxPane({
+        childSessionId,
+        parentSessionId: currentSessionId,
+        workspacePath,
+        expand: true,
+      });
+      setInputTarget('btw');
     } catch (e) {
       log.error('Failed to start /btw thread', { e });
     }
-  }, [currentSessionId, derivedState, inputState.value, setQueuedInput, t, workspacePath]);
+  }, [currentSessionId, derivedState, inputState.value, isBtwSession, setQueuedInput, t, workspacePath]);
   
   const handleSendOrCancel = useCallback(async () => {
     if (!derivedState) return;
@@ -728,8 +768,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     }
     
     // Add to history before clearing (session-scoped)
-    if (currentSessionId) {
-      addToHistory(currentSessionId, message);
+    if (effectiveTargetSessionId) {
+      addToHistory(effectiveTargetSessionId, message);
     }
     setHistoryIndex(-1);
     setSavedDraft('');
@@ -743,7 +783,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       log.error('Failed to send message', { error });
       dispatchInput({ type: 'SET_VALUE', payload: message });
     }
-  }, [inputState.value, derivedState, transition, sendMessage, addToHistory, setQueuedInput, submitBtwFromInput]);
+  }, [inputState.value, derivedState, transition, sendMessage, addToHistory, effectiveTargetSessionId, setQueuedInput, submitBtwFromInput]);
   
   const getFilteredModes = useCallback(() => {
     if (!canSwitchModes) {
@@ -770,10 +810,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       // ignore
     }
 
-    if (currentSessionId) {
-      FlowChatStore.getInstance().updateSessionMode(currentSessionId, modeId);
+    if (effectiveTargetSessionId) {
+      FlowChatStore.getInstance().updateSessionMode(effectiveTargetSessionId, modeId);
     }
-  }, [currentSessionId]);
+  }, [effectiveTargetSessionId]);
 
   const requestModeChange = useCallback((modeId: string) => {
     if (!canSwitchModes) {
@@ -808,9 +848,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   }, [requestModeChange]);
 
   const getFilteredActions = useCallback(() => {
+    if (isBtwSession) {
+      return [];
+    }
     // For now we only support one action: /btw.
-    const items = [
+    const items: SlashActionItem[] = [
       {
+        kind: 'action',
         id: 'btw',
         command: '/btw',
         label: t('btw.title', { defaultValue: 'Side question' }),
@@ -824,9 +868,20 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       const cmd = i.command.slice(1).toLowerCase();
       return cmd.includes(q) || i.label.toLowerCase().includes(q);
     });
-  }, [slashCommandState.query, t]);
+  }, [isBtwSession, slashCommandState.query, t]);
+
+  const getSlashPickerItems = useCallback((): SlashPickerItem[] => {
+    const actions = getFilteredActions();
+    const modes: SlashModeItem[] = getFilteredModes().map(mode => ({
+      kind: 'mode',
+      id: mode.id,
+      name: mode.name,
+    }));
+    return [...actions, ...modes];
+  }, [getFilteredActions, getFilteredModes]);
 
   const selectSlashCommandAction = useCallback((actionId: string) => {
+    if (isBtwSession) return;
     if (actionId !== 'btw') return;
 
     const raw = inputState.value || '';
@@ -850,7 +905,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     dispatchInput({ type: 'SET_VALUE', payload: next });
     setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
     window.setTimeout(() => richTextInputRef.current?.focus(), 0);
-  }, [inputState.value]);
+  }, [inputState.value, isBtwSession]);
   
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     // Local /btw shortcut (Ctrl/Cmd+Alt+B) should work even when ChatInput is focused.
@@ -860,6 +915,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
       if (!currentSessionId) {
         notificationService.error(t('btw.noSession', { defaultValue: 'No active session for /btw' }));
+        return;
+      }
+      if (isBtwSession) {
+        notificationService.warning(t('btw.nestedDisabled', { defaultValue: 'Side questions cannot create another side question' }));
         return;
       }
 
@@ -873,7 +932,12 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
     if (slashCommandState.isActive) {
       if (!(slashCommandState.kind === 'modes' && !canSwitchModes)) {
-        const items = slashCommandState.kind === 'modes' ? getFilteredModes() : getFilteredActions();
+        const items =
+          slashCommandState.kind === 'modes'
+            ? getFilteredModes()
+            : slashCommandState.kind === 'actions'
+              ? getFilteredActions()
+              : getSlashPickerItems();
         const maxIndex = Math.max(0, items.length - 1);
         
         if (e.key === 'ArrowDown') {
@@ -900,9 +964,16 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             if (slashCommandState.kind === 'modes') {
               const mode = items[slashCommandState.selectedIndex] as any;
               selectSlashCommandMode(mode.id);
-            } else {
+            } else if (slashCommandState.kind === 'actions') {
               const action = items[slashCommandState.selectedIndex] as any;
               selectSlashCommandAction(action.id);
+            } else {
+              const item = items[slashCommandState.selectedIndex] as SlashPickerItem;
+              if (item.kind === 'mode') {
+                selectSlashCommandMode(item.id);
+              } else {
+                selectSlashCommandAction(item.id);
+              }
             }
           }
           return;
@@ -914,7 +985,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
           setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
 
           // For mode switching picker, "/" is just a trigger and should be cleared on cancel.
-          if (kind === 'modes') {
+          if (kind !== 'actions') {
             dispatchInput({ type: 'CLEAR_VALUE' });
           }
           return;
@@ -926,9 +997,16 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             if (slashCommandState.kind === 'modes') {
               const mode = items[slashCommandState.selectedIndex] as any;
               selectSlashCommandMode(mode.id);
-            } else {
+            } else if (slashCommandState.kind === 'actions') {
               const action = items[slashCommandState.selectedIndex] as any;
               selectSlashCommandAction(action.id);
+            } else {
+              const item = items[slashCommandState.selectedIndex] as SlashPickerItem;
+              if (item.kind === 'mode') {
+                selectSlashCommandMode(item.id);
+              } else {
+                selectSlashCommandAction(item.id);
+              }
             }
           }
           return;
@@ -955,6 +1033,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       }
     }
     
+    // Tab key: toggle send target when the btw session switcher is visible
+    if (showTargetSwitcher && e.key === 'Tab' && !e.shiftKey && !slashCommandState.isActive && !templateState.fillState?.isActive) {
+      e.preventDefault();
+      setInputTarget(prev => prev === 'main' ? 'btw' : 'main');
+      return;
+    }
+
     // History navigation with up/down arrows
     // Only handle when not in slash command mode and not composing
     if (!slashCommandState.isActive && inputHistory.length > 0) {
@@ -1064,7 +1149,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       e.preventDefault();
       transition(SessionExecutionEvent.USER_CANCEL);
     }
-  }, [handleSendOrCancel, submitBtwFromInput, derivedState, transition, templateState.fillState, moveToNextPlaceholder, moveToPrevPlaceholder, exitTemplateMode, slashCommandState, getFilteredModes, getFilteredActions, selectSlashCommandMode, selectSlashCommandAction, canSwitchModes, historyIndex, inputHistory, savedDraft, inputState.value, currentSessionId, t]);
+  }, [handleSendOrCancel, submitBtwFromInput, derivedState, transition, templateState.fillState, moveToNextPlaceholder, moveToPrevPlaceholder, exitTemplateMode, slashCommandState, getFilteredModes, getFilteredActions, getSlashPickerItems, selectSlashCommandMode, selectSlashCommandAction, canSwitchModes, historyIndex, inputHistory, savedDraft, inputState.value, currentSessionId, isBtwSession, showTargetSwitcher, setInputTarget, t]);
 
   const handleImeCompositionStart = useCallback(() => {
     isImeComposingRef.current = true;
@@ -1274,44 +1359,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         )}
 
         <div className="bitfun-chat-input__container">
-          {!!btwOrigin?.parentSessionId && (
-            <div className="bitfun-chat-input__btw-origin" data-testid="btw-origin-banner">
-              <div className="bitfun-chat-input__btw-origin-text">
-                <span className="bitfun-chat-input__btw-origin-label">
-                  {t('btw.origin', { defaultValue: 'Asked from' })}
-                </span>
-                <span className="bitfun-chat-input__btw-origin-parent">
-                  {btwParentTitle || t('btw.parent', { defaultValue: 'parent session' })}
-                </span>
-                {btwOrigin?.parentTurnIndex ? (
-                  <span className="bitfun-chat-input__btw-origin-turn">
-                    {t('btw.turnLabel', { index: btwOrigin.parentTurnIndex, defaultValue: `turn ${btwOrigin.parentTurnIndex}` })}
-                  </span>
-                ) : null}
-              </div>
-              <IconButton
-                className="bitfun-chat-input__btw-origin-back"
-                variant="ghost"
-                size="xs"
-                onClick={() => {
-                  const parentId = btwOrigin?.parentSessionId;
-                  if (!parentId) return;
-                  const requestId = btwOrigin?.requestId;
-                  const itemId = requestId ? `btw_marker_${requestId}` : undefined;
-                  globalEventBus.emit('flowchat:focus-item', {
-                    sessionId: parentId,
-                    turnIndex: btwOrigin?.parentTurnIndex,
-                    itemId,
-                  }, 'ChatInput');
-                }}
-                tooltip={t('btw.backToParent', { defaultValue: 'Back to parent session' })}
-                disabled={!btwOrigin?.parentSessionId}
-              >
-                {t('btw.back', { defaultValue: 'Back' })}
-              </IconButton>
-            </div>
-          )}
-
           {templateState.fillState?.isActive && (
 <div className="bitfun-chat-input__template-hint">
                 <span className="bitfun-chat-input__template-hint-text" dangerouslySetInnerHTML={{ __html: t('chatInput.templateHint') }} />
@@ -1322,6 +1369,33 @@ export const ChatInput: React.FC<ChatInputProps> = ({
           )}
           
           <div className={`bitfun-chat-input__box ${inputState.isExpanded ? 'bitfun-chat-input__box--expanded' : ''}`}>
+            {showTargetSwitcher && (
+              <div className="bitfun-chat-input__target-switcher" data-testid="chat-input-target-switcher">
+                <span className="bitfun-chat-input__target-switcher-label">{t('chatInput.conversationTarget')}</span>
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  className={`bitfun-chat-input__target-tab ${inputTarget === 'main' ? 'bitfun-chat-input__target-tab--active' : ''}`}
+                  onClick={() => setInputTarget('main')}
+                >
+                  {t('chatInput.targetMain')}
+                  {inputTarget === 'main' && currentSessionTitle && (
+                    <span className="bitfun-chat-input__target-tab-name">{currentSessionTitle}</span>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  className={`bitfun-chat-input__target-tab ${inputTarget === 'btw' ? 'bitfun-chat-input__target-tab--active' : ''}`}
+                  onClick={() => setInputTarget('btw')}
+                >
+                  {t('chatInput.targetBtw')}
+                  {inputTarget === 'btw' && activeBtwSessionTitle && (
+                    <span className="bitfun-chat-input__target-tab-name">{activeBtwSessionTitle}</span>
+                  )}
+                </button>
+              </div>
+            )}
             <div className="bitfun-chat-input__input-area">
               <RichTextInput
                 ref={richTextInputRef}
@@ -1377,6 +1451,42 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                             >
                               <span className="bitfun-chat-input__slash-command-name">{action.command}</span>
                               <span className="bitfun-chat-input__slash-command-label">{action.label}</span>
+                            </div>
+                          ))
+                        ) : (
+                          <div className="bitfun-chat-input__slash-command-empty">
+                            {t('chatInput.noMatchingCommand', { defaultValue: 'No matching command' })}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                }
+
+                if (slashCommandState.kind === 'all') {
+                  const items = getSlashPickerItems();
+                  return (
+                    <div className="bitfun-chat-input__slash-command-picker">
+                      <div className="bitfun-chat-input__slash-command-header">
+                        <span>{t('chatInput.quickAction', { defaultValue: 'Commands' })}</span>
+                        <span className="bitfun-chat-input__slash-command-hint">{t('chatInput.selectHint')}</span>
+                      </div>
+                      <div className="bitfun-chat-input__slash-command-list">
+                        {items.length > 0 ? (
+                          items.map((item, index) => (
+                            <div
+                              key={`${item.kind}-${item.id}`}
+                              className={`bitfun-chat-input__slash-command-item ${index === slashCommandState.selectedIndex ? 'bitfun-chat-input__slash-command-item--selected' : ''} ${item.kind === 'mode' && item.id === modeState.current ? 'bitfun-chat-input__slash-command-item--active' : ''}`}
+                              onClick={() => item.kind === 'mode' ? selectSlashCommandMode(item.id) : selectSlashCommandAction(item.id)}
+                              onMouseEnter={() => setSlashCommandState(prev => ({ ...prev, selectedIndex: index }))}
+                            >
+                              <span className="bitfun-chat-input__slash-command-name">
+                                {item.kind === 'mode' ? `/${item.id}` : item.command}
+                              </span>
+                              <span className="bitfun-chat-input__slash-command-label">
+                                {item.kind === 'mode' ? item.name : item.label}
+                              </span>
+                              {item.kind === 'mode' && item.id === modeState.current && <span className="bitfun-chat-input__slash-command-current">{t('chatInput.current')}</span>}
                             </div>
                           ))
                         ) : (
@@ -1462,7 +1572,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
               <div className="bitfun-chat-input__actions-left">
                 <ModelSelector
                   currentMode={modeState.current}
-                  sessionId={currentSessionId || undefined}
+                  sessionId={effectiveTargetSessionId || undefined}
                 />
                 
                 {tokenUsage.current > 0 && (

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -31,6 +31,9 @@ interface ModelSelectorProps {
 
 interface ModelInfo {
   id: string;
+  /** User-defined configuration name (AIModelConfig.name). */
+  configName: string;
+  /** Actual model identifier (AIModelConfig.model_name). */
   modelName: string;
   providerName: string;
   provider: string;
@@ -147,6 +150,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     if (modelId === 'auto') {
       return {
         id: 'auto',
+        configName: t('modelSelector.autoModel'),
         modelName: t('modelSelector.autoModel'),
         providerName: t('modelSelector.autoModelDesc'),
         provider: 'auto',
@@ -161,7 +165,8 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       if (!model) return null;
 
       return {
-        id: modelId, // Keep 'primary' or 'fast'
+        id: modelId,
+        configName: modelId === 'primary' ? t('modelSelector.primaryModel') : t('modelSelector.fastModel'),
         modelName: model.model_name,
         providerName: getProviderDisplayName(model),
         provider: model.provider,
@@ -176,6 +181,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
 
     return {
       id: model.id || '',
+      configName: model.name,
       modelName: model.model_name,
       providerName: getProviderDisplayName(model),
       provider: model.provider,
@@ -195,6 +201,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       })
       .map(m => ({
         id: m.id || '',
+        configName: m.name,
         modelName: m.model_name,
         providerName: getProviderDisplayName(m),
         provider: m.provider,
@@ -241,7 +248,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       ref={dropdownRef}
       className={`bitfun-model-selector ${className}`}
     >
-      <Tooltip content={currentModel ? `${t('modelSelector.model')}: ${currentModel.modelName}` : t('modelSelector.modelNotConfigured')}>
+      <Tooltip content={currentModel ? `${currentModel.modelName} · ${buildModelMetaText(currentModel)}` : t('modelSelector.modelNotConfigured')}>
         <button
           className={`bitfun-model-selector__trigger ${dropdownOpen ? 'bitfun-model-selector__trigger--open' : ''}`}
           onClick={() => setDropdownOpen(!dropdownOpen)}
@@ -249,7 +256,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
         >
           <Cpu size={10} className="bitfun-model-selector__icon" />
           <span className="bitfun-model-selector__name">
-            {currentModel ? currentModel.modelName : t('modelSelector.modelNotConfigured')}
+            {currentModel ? currentModel.configName : t('modelSelector.modelNotConfigured')}
           </span>
           {currentModel?.enableThinking && (
             <Sparkles size={9} className="bitfun-model-selector__thinking-icon" />
@@ -272,94 +279,63 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             </span>
           </div>
 
-          <div
-            className={`bitfun-model-selector__option bitfun-model-selector__option--special ${currentModelId === 'auto' ? 'bitfun-model-selector__option--selected' : ''}`}
-            onClick={() => handleSelectModel('auto')}
-          >
-            <div className="bitfun-model-selector__option-main">
-              <div className="bitfun-model-selector__option-content">
-                <span className="bitfun-model-selector__option-name">{t('modelSelector.autoModelDesc')}</span>
-                <span className="bitfun-model-selector__option-desc">{t('modelSelector.autoModel')}</span>
+          <Tooltip content={t('modelSelector.autoModelDesc')} placement="right">
+            <div
+              className={`bitfun-model-selector__option bitfun-model-selector__option--special ${currentModelId === 'auto' ? 'bitfun-model-selector__option--selected' : ''}`}
+              onClick={() => handleSelectModel('auto')}
+            >
+              <div className="bitfun-model-selector__option-main">
+                <span className="bitfun-model-selector__option-name">{t('modelSelector.autoModel')}</span>
               </div>
+              {currentModelId === 'auto' && (
+                <Check size={14} className="bitfun-model-selector__option-check" />
+              )}
             </div>
-            {currentModelId === 'auto' && (
-              <Check size={14} className="bitfun-model-selector__option-check" />
-            )}
-          </div>
+          </Tooltip>
 
-          <div
-            className={`bitfun-model-selector__option bitfun-model-selector__option--special ${currentModelId === 'primary' ? 'bitfun-model-selector__option--selected' : ''}`}
-            onClick={() => handleSelectModel('primary')}
-          >
-            <div className="bitfun-model-selector__option-main">
-              <div className="bitfun-model-selector__option-content">
-                <span className="bitfun-model-selector__option-name">{t('modelSelector.primaryModel')}</span>
-                {(() => {
-                  const model = allModels.find(m => m.id === defaultModels.primary);
-                  if (!model) {
-                    return (
-                      <span className="bitfun-model-selector__option-desc">
-                        {t('modelSelector.modelNotConfigured')}
-                      </span>
-                    );
-                  }
+          {(() => {
+            const primaryModel = allModels.find(m => m.id === defaultModels.primary);
+            const primaryTooltip = primaryModel
+              ? `${primaryModel.name}（${primaryModel.model_name}）· ${buildModelMetaText({ providerName: getProviderDisplayName(primaryModel), contextWindow: primaryModel.context_window, reasoningEffort: primaryModel.reasoning_effort })}`
+              : t('modelSelector.modelNotConfigured');
+            return (
+              <Tooltip content={primaryTooltip} placement="right">
+                <div
+                  className={`bitfun-model-selector__option bitfun-model-selector__option--special ${currentModelId === 'primary' ? 'bitfun-model-selector__option--selected' : ''}`}
+                  onClick={() => handleSelectModel('primary')}
+                >
+                  <div className="bitfun-model-selector__option-main">
+                    <span className="bitfun-model-selector__option-name">{t('modelSelector.primaryModel')}</span>
+                  </div>
+                  {currentModelId === 'primary' && (
+                    <Check size={14} className="bitfun-model-selector__option-check" />
+                  )}
+                </div>
+              </Tooltip>
+            );
+          })()}
 
-                  return (
-                    <div className="bitfun-model-selector__option-meta">
-                      <span className="bitfun-model-selector__option-desc">{model.model_name}</span>
-                      <span className="bitfun-model-selector__option-subdesc">
-                        {buildModelMetaText({
-                          providerName: getProviderDisplayName(model),
-                          contextWindow: model.context_window,
-                          reasoningEffort: model.reasoning_effort,
-                        })}
-                      </span>
-                    </div>
-                  );
-                })()}
-              </div>
-            </div>
-            {currentModelId === 'primary' && (
-              <Check size={14} className="bitfun-model-selector__option-check" />
-            )}
-          </div>
-
-          <div
-            className={`bitfun-model-selector__option bitfun-model-selector__option--special ${currentModelId === 'fast' ? 'bitfun-model-selector__option--selected' : ''}`}
-            onClick={() => handleSelectModel('fast')}
-          >
-            <div className="bitfun-model-selector__option-main">
-              <div className="bitfun-model-selector__option-content">
-                <span className="bitfun-model-selector__option-name">{t('modelSelector.fastModel')}</span>
-                {(() => {
-                  const model = allModels.find(m => m.id === defaultModels.fast);
-                  if (!model) {
-                    return (
-                      <span className="bitfun-model-selector__option-desc">
-                        {t('modelSelector.modelNotConfigured')}
-                      </span>
-                    );
-                  }
-
-                  return (
-                    <div className="bitfun-model-selector__option-meta">
-                      <span className="bitfun-model-selector__option-desc">{model.model_name}</span>
-                      <span className="bitfun-model-selector__option-subdesc">
-                        {buildModelMetaText({
-                          providerName: getProviderDisplayName(model),
-                          contextWindow: model.context_window,
-                          reasoningEffort: model.reasoning_effort,
-                        })}
-                      </span>
-                    </div>
-                  );
-                })()}
-              </div>
-            </div>
-            {currentModelId === 'fast' && (
-              <Check size={14} className="bitfun-model-selector__option-check" />
-            )}
-          </div>
+          {(() => {
+            const fastModel = allModels.find(m => m.id === defaultModels.fast);
+            const fastTooltip = fastModel
+              ? `${fastModel.name}（${fastModel.model_name}）· ${buildModelMetaText({ providerName: getProviderDisplayName(fastModel), contextWindow: fastModel.context_window, reasoningEffort: fastModel.reasoning_effort })}`
+              : t('modelSelector.modelNotConfigured');
+            return (
+              <Tooltip content={fastTooltip} placement="right">
+                <div
+                  className={`bitfun-model-selector__option bitfun-model-selector__option--special ${currentModelId === 'fast' ? 'bitfun-model-selector__option--selected' : ''}`}
+                  onClick={() => handleSelectModel('fast')}
+                >
+                  <div className="bitfun-model-selector__option-main">
+                    <span className="bitfun-model-selector__option-name">{t('modelSelector.fastModel')}</span>
+                  </div>
+                  {currentModelId === 'fast' && (
+                    <Check size={14} className="bitfun-model-selector__option-check" />
+                  )}
+                </div>
+              </Tooltip>
+            );
+          })()}
 
           <div className="bitfun-model-selector__divider" />
 
@@ -368,26 +344,24 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
               const isSelected = currentModelId === model.id;
 
               return (
-                <div
-                  key={model.id}
-                  className={`bitfun-model-selector__option ${isSelected ? 'bitfun-model-selector__option--selected' : ''}`}
-                  onClick={() => handleSelectModel(model.id)}
-                >
-                  <div className="bitfun-model-selector__option-main">
-                    <span className="bitfun-model-selector__option-name">
-                      {model.modelName}
-                      {model.enableThinking && (
-                        <Sparkles size={10} className="bitfun-model-selector__option-thinking" />
-                      )}
-                    </span>
-                    <span className="bitfun-model-selector__option-desc">
-                      {buildModelMetaText(model)}
-                    </span>
+                <Tooltip key={model.id} content={`${model.modelName} · ${buildModelMetaText(model)}`} placement="right">
+                  <div
+                    className={`bitfun-model-selector__option ${isSelected ? 'bitfun-model-selector__option--selected' : ''}`}
+                    onClick={() => handleSelectModel(model.id)}
+                  >
+                    <div className="bitfun-model-selector__option-main">
+                      <span className="bitfun-model-selector__option-name">
+                        {model.configName}
+                        {model.enableThinking && (
+                          <Sparkles size={10} className="bitfun-model-selector__option-thinking" />
+                        )}
+                      </span>
+                    </div>
+                    {isSelected && (
+                      <Check size={14} className="bitfun-model-selector__option-check" />
+                    )}
                   </div>
-                  {isSelected && (
-                    <Check size={14} className="bitfun-model-selector__option-check" />
-                  )}
-                </div>
+                </Tooltip>
               );
             })}
           </div>

--- a/src/web-ui/src/flow_chat/components/RichTextInput.scss
+++ b/src/web-ui/src/flow_chat/components/RichTextInput.scss
@@ -43,6 +43,15 @@
   
 }
 
+// Improve placeholder contrast in light theme.
+:root[data-theme="light"] .rich-text-input,
+:root[data-theme-type="light"] .rich-text-input,
+.light .rich-text-input {
+  &:empty::before {
+    color: var(--color-text-secondary, #6b7280);
+  }
+}
+
 // Placeholder styles
 
 .rich-text-placeholder {

--- a/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.scss
+++ b/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.scss
@@ -1,0 +1,149 @@
+/**
+ * BTW session panel styles.
+ * Align the shell with TaskDetailPanel while reusing FlowChat message renderers.
+ */
+
+.btw-session-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--color-bg-flowchat);
+  color: var(--color-text-primary);
+
+  &--empty {
+    .btw-session-panel__empty-state {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      color: var(--color-text-muted);
+      font-size: 13px;
+    }
+  }
+
+  &__header {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 10px 16px;
+    background: var(--color-bg-secondary);
+    border-bottom: 1px dashed var(--border-base);
+    flex-shrink: 0;
+    min-height: 36px;
+  }
+
+  &__header-left {
+    position: absolute;
+    left: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+  }
+
+  &__header-title-wrap {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+    max-width: 60%;
+  }
+
+  &__header-right {
+    position: absolute;
+    right: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  &__badge {
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    background: rgba(255, 255, 255, 0.08);
+    flex-shrink: 0;
+  }
+
+  &__title {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--color-text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+    text-align: center;
+  }
+
+  &__meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: var(--color-text-muted);
+    white-space: nowrap;
+    max-width: 240px;
+  }
+
+  &__meta-label {
+    color: var(--color-text-muted);
+  }
+
+  &__meta-title {
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__origin-button {
+    flex-shrink: 0;
+    color: var(--color-text-secondary);
+
+    &:not(:disabled):hover {
+      background: color-mix(in srgb, var(--element-bg-soft) 82%, transparent);
+      color: var(--color-text-primary);
+    }
+  }
+
+  &__body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 12px 16px;
+    display: block;
+
+    &::after {
+      content: '';
+      display: block;
+      height: 140px;
+      min-height: 140px;
+      width: 100%;
+      pointer-events: none;
+    }
+
+    .virtual-item-wrapper {
+      width: 100%;
+      display: block;
+    }
+  }
+
+  &__empty-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 120px;
+    color: var(--color-text-muted);
+    font-size: 13px;
+    text-align: center;
+  }
+}

--- a/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx
@@ -1,0 +1,290 @@
+import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import path from 'path-browserify';
+import { MessageSquareQuote, Link2, CornerUpLeft } from 'lucide-react';
+import { FlowChatContext } from '../modern/FlowChatContext';
+import { VirtualItemRenderer } from '../modern/VirtualItemRenderer';
+import { ProcessingIndicator } from '../modern/ProcessingIndicator';
+import { flowChatStore } from '../../store/FlowChatStore';
+import type { FlowChatConfig, FlowChatState, Session } from '../../types/flow-chat';
+import { sessionToVirtualItems } from '../../store/modernFlowChatStore';
+import { fileTabManager } from '@/shared/services/FileTabManager';
+import { createTab } from '@/shared/utils/tabUtils';
+import { IconButton, type LineRange } from '@/component-library';
+import { globalEventBus } from '@/infrastructure/event-bus';
+import './BtwSessionPanel.scss';
+
+export interface BtwSessionPanelProps {
+  childSessionId?: string;
+  parentSessionId?: string;
+  workspacePath?: string;
+}
+
+const PANEL_CONFIG: FlowChatConfig = {
+  enableMarkdown: true,
+  autoScroll: true,
+  showTimestamps: false,
+  maxHistoryRounds: 50,
+  enableVirtualScroll: false,
+  theme: 'dark',
+};
+
+const resolveSessionTitle = (session?: Session | null, fallback = 'Side thread') =>
+  session?.title?.trim() || fallback;
+
+export const BtwSessionPanel: React.FC<BtwSessionPanelProps> = ({
+  childSessionId,
+  parentSessionId,
+  workspacePath,
+}) => {
+  const { t } = useTranslation('flow-chat');
+  const [flowChatState, setFlowChatState] = useState<FlowChatState>(() => flowChatStore.getState());
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const shouldAutoScrollRef = useRef(true);
+
+  useEffect(() => {
+    const unsubscribe = flowChatStore.subscribe(setFlowChatState);
+    return unsubscribe;
+  }, []);
+
+  const childSession = childSessionId ? flowChatState.sessions.get(childSessionId) : undefined;
+  const parentSession = parentSessionId ? flowChatState.sessions.get(parentSessionId) : undefined;
+  const virtualItems = useMemo(() => sessionToVirtualItems(childSession ?? null), [childSession]);
+
+  // Load history for historical sessions that have not yet had their turns loaded.
+  const isLoadingRef = useRef(false);
+  useEffect(() => {
+    if (!childSessionId || !childSession) return;
+    if (!childSession.isHistorical) return;
+    if (isLoadingRef.current) return;
+
+    const path = workspacePath ?? childSession.workspacePath;
+    if (!path) return;
+
+    isLoadingRef.current = true;
+    flowChatStore.loadSessionHistory(childSessionId, path).finally(() => {
+      isLoadingRef.current = false;
+    });
+  }, [childSessionId, childSession, workspacePath]);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      if (e.deltaY < 0) {
+        shouldAutoScrollRef.current = false;
+      } else if (e.deltaY > 0) {
+        const { scrollTop, scrollHeight, clientHeight } = container;
+        const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
+        if (distanceFromBottom < 100) {
+          shouldAutoScrollRef.current = true;
+        }
+      }
+    };
+
+    container.addEventListener('wheel', handleWheel, { passive: true });
+    return () => container.removeEventListener('wheel', handleWheel);
+  }, []);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !shouldAutoScrollRef.current) return;
+    requestAnimationFrame(() => {
+      container.scrollTop = container.scrollHeight;
+    });
+  }, [virtualItems]);
+
+  const handleFileViewRequest = useCallback((
+    filePath: string,
+    fileName: string,
+    lineRange?: LineRange
+  ) => {
+    let absoluteFilePath = filePath;
+    const isWindowsAbsolutePath = /^[A-Za-z]:[\\/]/.test(filePath);
+
+    if (!isWindowsAbsolutePath && !path.isAbsolute(filePath) && workspacePath) {
+      absoluteFilePath = path.join(workspacePath, filePath);
+    }
+
+    fileTabManager.openFile({
+      filePath: absoluteFilePath,
+      fileName,
+      workspacePath,
+      jumpToRange: lineRange,
+      mode: 'agent',
+    });
+  }, [workspacePath]);
+
+  const handleTabOpen = useCallback((tabInfo: any) => {
+    if (!tabInfo?.type) return;
+    createTab({
+      type: tabInfo.type,
+      title: tabInfo.title || 'New Tab',
+      data: tabInfo.data,
+      metadata: tabInfo.metadata,
+      checkDuplicate: !!tabInfo.metadata?.duplicateCheckKey,
+      duplicateCheckKey: tabInfo.metadata?.duplicateCheckKey,
+      replaceExisting: false,
+      mode: 'agent',
+    });
+  }, []);
+
+  const contextValue = useMemo(() => ({
+    onFileViewRequest: handleFileViewRequest,
+    onTabOpen: handleTabOpen,
+    sessionId: childSessionId,
+    activeSessionOverride: childSession ?? null,
+    config: PANEL_CONFIG,
+  }), [childSession, childSessionId, handleFileViewRequest, handleTabOpen]);
+
+  const lastDialogTurn = childSession?.dialogTurns[childSession.dialogTurns.length - 1];
+  const lastModelRound = lastDialogTurn?.modelRounds[lastDialogTurn.modelRounds.length - 1];
+  const lastItem = lastModelRound?.items[lastModelRound.items.length - 1];
+  const lastItemContent = lastItem && 'content' in lastItem ? String((lastItem as any).content || '') : '';
+  const isTurnProcessing = lastDialogTurn?.status === 'processing' || lastDialogTurn?.status === 'image_analyzing';
+  const [isContentGrowing, setIsContentGrowing] = useState(true);
+  const lastContentRef = useRef(lastItemContent);
+  const contentTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (lastItemContent !== lastContentRef.current) {
+      lastContentRef.current = lastItemContent;
+      setIsContentGrowing(true);
+      if (contentTimeoutRef.current) clearTimeout(contentTimeoutRef.current);
+      contentTimeoutRef.current = setTimeout(() => {
+        setIsContentGrowing(false);
+      }, 500);
+    }
+
+    return () => {
+      if (contentTimeoutRef.current) {
+        clearTimeout(contentTimeoutRef.current);
+      }
+    };
+  }, [lastItemContent]);
+
+  useEffect(() => {
+    if (!isTurnProcessing) {
+      setIsContentGrowing(false);
+    }
+  }, [isTurnProcessing]);
+
+  const showProcessingIndicator = useMemo(() => {
+    if (!isTurnProcessing) return false;
+    if (!lastItem) return true;
+
+    if (lastItem.type === 'text' || lastItem.type === 'thinking') {
+      const hasContent = 'content' in lastItem && Boolean((lastItem as any).content);
+      if (hasContent && isContentGrowing) {
+        return false;
+      }
+    }
+
+    if (lastItem.type === 'tool') {
+      const toolStatus = (lastItem as any).status;
+      if (toolStatus === 'running' || toolStatus === 'streaming' || toolStatus === 'preparing') {
+        return false;
+      }
+    }
+
+    return true;
+  }, [isTurnProcessing, lastItem, isContentGrowing]);
+
+  const btwOrigin = childSession?.btwOrigin;
+  const parentLabel = resolveSessionTitle(parentSession, t('btw.parent'));
+  const backTooltip = btwOrigin?.parentTurnIndex
+    ? t('flowChatHeader.btwBackTooltipWithTurn', {
+        title: parentLabel,
+        turn: btwOrigin.parentTurnIndex,
+        defaultValue: `Go back to the source session: ${parentLabel} (Turn ${btwOrigin.parentTurnIndex})`,
+      })
+    : t('flowChatHeader.btwBackTooltipWithoutTurn', {
+        title: parentLabel,
+        defaultValue: `Go back to the source session: ${parentLabel}`,
+      });
+
+  const handleFocusOriginTurn = useCallback(() => {
+    const resolvedParentSessionId = btwOrigin?.parentSessionId || parentSessionId;
+    if (!resolvedParentSessionId) return;
+
+    const requestId = btwOrigin?.requestId;
+    const itemId = requestId ? `btw_marker_${requestId}` : undefined;
+
+    globalEventBus.emit(
+      'flowchat:focus-item',
+      {
+        sessionId: resolvedParentSessionId,
+        turnIndex: btwOrigin?.parentTurnIndex,
+        itemId,
+      },
+      'BtwSessionPanel'
+    );
+  }, [btwOrigin, parentSessionId]);
+
+  if (!childSessionId || !childSession) {
+    return (
+      <div className="btw-session-panel btw-session-panel--empty">
+        <MessageSquareQuote size={18} />
+        <span>{t('btw.threadLabel')}</span>
+      </div>
+    );
+  }
+
+  return (
+    <FlowChatContext.Provider value={contextValue}>
+      <div className="btw-session-panel">
+        <div className="btw-session-panel__header">
+          <div className="btw-session-panel__header-left">
+            <span className="btw-session-panel__badge">{t('btw.shortLabel')}</span>
+          </div>
+          <div className="btw-session-panel__header-title-wrap">
+            <span className="btw-session-panel__title">{resolveSessionTitle(childSession, t('btw.threadLabel'))}</span>
+          </div>
+          <div className="btw-session-panel__header-right">
+            <div className="btw-session-panel__meta">
+              <span className="btw-session-panel__meta-label">{t('btw.origin')}</span>
+              <Link2 size={11} />
+              <span className="btw-session-panel__meta-title">{resolveSessionTitle(parentSession, t('btw.parent'))}</span>
+            </div>
+            {!!(btwOrigin?.parentSessionId || parentSessionId) && (
+              <IconButton
+                className="btw-session-panel__origin-button"
+                variant="ghost"
+                size="xs"
+                onClick={handleFocusOriginTurn}
+                tooltip={backTooltip}
+                aria-label={t('btw.backToParent')}
+                data-testid="btw-session-panel-origin-button"
+              >
+                <CornerUpLeft size={12} />
+              </IconButton>
+            )}
+          </div>
+        </div>
+
+        <div ref={scrollContainerRef} className="btw-session-panel__body">
+          {virtualItems.length === 0 ? (
+            <div className="btw-session-panel__empty-state">{t('session.empty')}</div>
+          ) : (
+            <>
+              {virtualItems.map((item, index) => (
+                <VirtualItemRenderer
+                  key={`${item.turnId}-${item.type}-${index}`}
+                  item={item}
+                  index={index}
+                />
+              ))}
+              <ProcessingIndicator
+                visible={showProcessingIndicator}
+                reserveSpace={isTurnProcessing}
+              />
+            </>
+          )}
+        </div>
+      </div>
+    </FlowChatContext.Provider>
+  );
+};
+
+BtwSessionPanel.displayName = 'BtwSessionPanel';

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatContext.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatContext.tsx
@@ -4,7 +4,7 @@
  */
 
 import { createContext, useContext } from 'react';
-import type { FlowChatConfig } from '../../types/flow-chat';
+import type { FlowChatConfig, Session } from '../../types/flow-chat';
 import type { LineRange } from '@/component-library';
 
 export interface FlowChatContextValue {
@@ -20,6 +20,7 @@ export interface FlowChatContextValue {
 
   // Session info
   sessionId?: string;
+  activeSessionOverride?: Session | null;
 
   // Config
   config?: FlowChatConfig;

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.scss
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.scss
@@ -47,16 +47,49 @@
     -webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%);
   }
 
-  &__turn-info {
-    font-size: $font-size-sm;
-    font-weight: $font-weight-medium;
-    color: var(--color-text-secondary);
-    white-space: nowrap;
+  &__btw-back {
+    flex: 0 0 auto;
+
+    &:not(:disabled):hover {
+      background: color-mix(in srgb, var(--element-bg-soft) 82%, transparent);
+    }
+  }
+
+  &__btw-create {
+    flex: 0 0 auto;
+
+    &:not(:disabled):hover {
+      background: color-mix(in srgb, var(--element-bg-soft) 82%, transparent);
+    }
   }
 
   // ==================== Center message ====================
   &__message {
     flex: 1;
+    min-width: 0;
+    padding: 0 $size-gap-3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: $size-gap-2;
+    overflow: hidden;
+  }
+
+  &__turn-badge {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    max-width: 100%;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--element-bg-soft) 82%, transparent);
+    color: var(--color-text-secondary);
+    font-size: $font-size-xs;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  &__message-text {
     min-width: 0;
     font-size: $font-size-sm;
     color: var(--color-text-primary);
@@ -64,7 +97,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     text-align: center;
-    padding: 0 $size-gap-3;
   }
 
   // ==================== Actions ====================

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
@@ -5,13 +5,17 @@
  */
 
 import React from 'react';
-import { Tooltip } from '@/component-library';
+import { CornerUpLeft, MessageSquarePlus } from 'lucide-react';
+import { Tooltip, IconButton } from '@/component-library';
+import { useTranslation } from 'react-i18next';
+import { globalEventBus } from '@/infrastructure/event-bus';
 import { SessionFilesBadge } from './SessionFilesBadge';
+import type { Session } from '../../types/flow-chat';
 import './FlowChatHeader.scss';
 
 export interface FlowChatHeaderProps {
-  /** Current visible turn index (1-based). */
-  currentTurnIndex: number;
+  /** Current turn index. */
+  currentTurn: number;
   /** Total turns. */
   totalTurns: number;
   /** Current user message. */
@@ -20,14 +24,25 @@ export interface FlowChatHeaderProps {
   visible: boolean;
   /** Session ID. */
   sessionId?: string;
+  /** BTW child-session origin metadata. */
+  btwOrigin?: Session['btwOrigin'] | null;
+  /** BTW parent session title. */
+  btwParentTitle?: string;
+  /** Creates a new BTW thread from the current session. */
+  onCreateBtwSession?: () => void;
 }
 export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
-  currentTurnIndex,
+  currentTurn,
   totalTurns,
   currentUserMessage,
   visible,
   sessionId,
+  btwOrigin,
+  btwParentTitle = '',
+  onCreateBtwSession,
 }) => {
+  const { t } = useTranslation('flow-chat');
+
   if (!visible || totalTurns === 0) {
     return null;
   }
@@ -36,6 +51,36 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
   const truncatedMessage = currentUserMessage.length > 50
     ? currentUserMessage.slice(0, 50) + '...'
     : currentUserMessage;
+  const parentLabel = btwParentTitle || t('btw.parent', { defaultValue: 'parent session' });
+  const backTooltip = btwOrigin?.parentTurnIndex
+    ? t('flowChatHeader.btwBackTooltipWithTurn', {
+      title: parentLabel,
+      turn: btwOrigin.parentTurnIndex,
+      defaultValue: `Go back to the source session: ${parentLabel} (Turn ${btwOrigin.parentTurnIndex})`,
+    })
+    : t('flowChatHeader.btwBackTooltipWithoutTurn', {
+      title: parentLabel,
+      defaultValue: `Go back to the source session: ${parentLabel}`,
+    });
+  const createBtwTooltip = t('flowChatHeader.btwCreateTooltip', {
+    defaultValue: 'Start a quick side question',
+  });
+  const turnBadgeLabel = t('flowChatHeader.turnBadge', {
+    current: currentTurn,
+    defaultValue: `Turn ${currentTurn}`,
+  });
+
+  const handleBackToParent = () => {
+    const parentId = btwOrigin?.parentSessionId;
+    if (!parentId) return;
+    const requestId = btwOrigin?.requestId;
+    const itemId = requestId ? `btw_marker_${requestId}` : undefined;
+    globalEventBus.emit('flowchat:focus-item', {
+      sessionId: parentId,
+      turnIndex: btwOrigin?.parentTurnIndex,
+      itemId,
+    }, 'FlowChatHeader');
+  };
 
   return (
     <div className="flowchat-header">
@@ -45,14 +90,43 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
 
       <Tooltip content={currentUserMessage} placement="bottom">
         <div className="flowchat-header__message">
-          {truncatedMessage}
+          <span className="flowchat-header__turn-badge" aria-label={turnBadgeLabel}>
+            <span>{turnBadgeLabel}</span>
+          </span>
+          <span className="flowchat-header__message-text">
+            {truncatedMessage}
+          </span>
         </div>
       </Tooltip>
 
       <div className="flowchat-header__actions">
-        <span className="flowchat-header__turn-info">
-          {currentTurnIndex} / {totalTurns}
-        </span>
+        {!!btwOrigin?.parentSessionId && (
+          <IconButton
+            className="flowchat-header__btw-back"
+            variant="ghost"
+            size="xs"
+            onClick={handleBackToParent}
+            tooltip={backTooltip}
+            disabled={!btwOrigin.parentSessionId}
+            aria-label={t('btw.back', { defaultValue: 'Back' })}
+            data-testid="flowchat-header-btw-back"
+          >
+            <CornerUpLeft size={12} />
+          </IconButton>
+        )}
+        {onCreateBtwSession && (
+          <IconButton
+            className="flowchat-header__btw-create"
+            variant="ghost"
+            size="xs"
+            onClick={onCreateBtwSession}
+            tooltip={createBtwTooltip}
+            aria-label={createBtwTooltip}
+            data-testid="flowchat-header-btw-create"
+          >
+            <MessageSquarePlus size={14} />
+          </IconButton>
+        )}
       </div>
     </div>
   );

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -15,7 +15,7 @@ import { startAutoSync } from '../../services/storeSync';
 import { useModernFlowChatStore } from '../../store/modernFlowChatStore';
 import { globalEventBus } from '../../../infrastructure/event-bus';
 import { getElementText, copyTextToClipboard } from '../../../shared/utils/textSelection';
-import type { FlowChatConfig, FlowToolItem, DialogTurn, ModelRound, FlowItem } from '../../types/flow-chat';
+import type { FlowChatConfig, FlowToolItem, DialogTurn, ModelRound, FlowItem, Session } from '../../types/flow-chat';
 import { notificationService } from '../../../shared/notification-system';
 import { agentAPI } from '@/infrastructure/api';
 import { fileTabManager } from '@/shared/services/FileTabManager';
@@ -54,6 +54,9 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const visibleTurnInfo = useVisibleTurnInfo();
   const virtualListRef = useRef<VirtualMessageListRef>(null);
   const { workspacePath } = useWorkspaceContext();
+  const isBtwSession = activeSession?.sessionKind === 'btw';
+  const [btwOrigin, setBtwOrigin] = useState<Session['btwOrigin'] | null>(null);
+  const [btwParentTitle, setBtwParentTitle] = useState('');
   
   // Explore group collapse state (key: groupId, true = user-expanded).
   const [exploreGroupStates, setExploreGroupStates] = useState<Map<string, boolean>>(new Map());
@@ -95,6 +98,36 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       unsubscribe();
     };
   }, []);
+
+  useEffect(() => {
+    const syncBtwState = (state = flowChatStore.getState()) => {
+      const currentSessionId = activeSession?.sessionId;
+      if (!currentSessionId) {
+        setBtwOrigin(null);
+        setBtwParentTitle('');
+        return;
+      }
+
+      const session = state.sessions.get(currentSessionId);
+      if (!session) {
+        setBtwOrigin(null);
+        setBtwParentTitle('');
+        return;
+      }
+
+      const nextOrigin = (session.btwOrigin ||
+        (session.sessionKind === 'btw' && session.parentSessionId ? { parentSessionId: session.parentSessionId } : null)) as Session['btwOrigin'] | null;
+      const parentId = nextOrigin?.parentSessionId || session.parentSessionId;
+      const parent = parentId ? state.sessions.get(parentId) : undefined;
+
+      setBtwOrigin(nextOrigin);
+      setBtwParentTitle(parent?.title || '');
+    };
+
+    syncBtwState();
+    const unsubscribe = flowChatStore.subscribe(syncBtwState);
+    return unsubscribe;
+  }, [activeSession?.sessionId]);
   
   useEffect(() => {
     const unlisten = agentAPI.onSessionTitleGenerated((event) => {
@@ -420,6 +453,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     onToolConfirm: handleToolConfirm,
     onToolReject: handleToolReject,
     sessionId: activeSession?.sessionId,
+    activeSessionOverride: activeSession,
     config: {
       enableMarkdown: true,
       autoScroll: true,
@@ -447,16 +481,26 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     handleExpandAllInTurn,
     handleCollapseGroup,
   ]);
+
+  const handleCreateBtwSession = useCallback(() => {
+    if (!activeSession?.sessionId) return;
+    window.dispatchEvent(new CustomEvent('fill-chat-input', {
+      detail: { message: '/btw ' }
+    }));
+  }, [activeSession?.sessionId]);
   
   return (
     <FlowChatContext.Provider value={contextValue}>
       <div className={`modern-flowchat-container ${className}`}>
         <FlowChatHeader
-          currentTurnIndex={visibleTurnInfo?.turnIndex ?? 0}
+          currentTurn={visibleTurnInfo?.turnIndex ?? 0}
           totalTurns={visibleTurnInfo?.totalTurns ?? 0}
           currentUserMessage={visibleTurnInfo?.userMessage ?? ''}
           visible={virtualItems.length > 0}
           sessionId={activeSession?.sessionId}
+          btwOrigin={btwOrigin}
+          btwParentTitle={btwParentTitle}
+          onCreateBtwSession={activeSession?.sessionId && !isBtwSession ? handleCreateBtwSession : undefined}
         />
 
         <div className="modern-flowchat-container__messages">

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
@@ -27,8 +27,9 @@ interface UserMessageItemProps {
 export const UserMessageItem = React.memo<UserMessageItemProps>(
   ({ message, turnId }) => {
     const { t } = useTranslation('flow-chat');
-    const { config, sessionId } = useFlowChatContext();
-    const activeSession = useActiveSession();
+    const { config, sessionId, activeSessionOverride } = useFlowChatContext();
+    const activeSessionFromStore = useActiveSession();
+    const activeSession = activeSessionOverride ?? activeSessionFromStore;
     const [copied, setCopied] = useState(false);
     const [expanded, setExpanded] = useState(false);
     const [hasOverflow, setHasOverflow] = useState(false);

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -298,6 +298,7 @@ export class FlowChatManager {
         id: markerId,
         input: {
           requestId,
+          parentSessionId,
           childSessionId,
           title,
         },

--- a/src/web-ui/src/flow_chat/services/openBtwSession.ts
+++ b/src/web-ui/src/flow_chat/services/openBtwSession.ts
@@ -1,0 +1,135 @@
+import { i18nService } from '@/infrastructure/i18n';
+import { appManager } from '@/app/services/AppManager';
+import { useSceneStore } from '@/app/stores/sceneStore';
+import { createTab } from '@/shared/utils/tabUtils';
+import type { PanelContent } from '@/app/components/panels/base/types';
+import { useAgentCanvasStore } from '@/app/components/panels/content-canvas/stores';
+import type { CanvasTab } from '@/app/components/panels/content-canvas/types';
+import { flowChatStore } from '../store/FlowChatStore';
+import { flowChatManager } from './FlowChatManager';
+
+export const BTW_SESSION_PANEL_TYPE = 'btw-session' as const;
+
+export interface BtwSessionPanelData {
+  childSessionId: string;
+  parentSessionId: string;
+  workspacePath?: string;
+}
+
+export interface BtwSessionPanelMetadata {
+  duplicateCheckKey: string;
+  childSessionId: string;
+  parentSessionId: string;
+  contentRole: 'btw-session';
+}
+
+type AgentCanvasState = ReturnType<typeof useAgentCanvasStore.getState>;
+
+const getBtwSessionDuplicateKey = (childSessionId: string) => `btw-session-${childSessionId}`;
+
+const resolveBtwSessionTitle = (childSessionId: string): string => {
+  const session = flowChatStore.getState().sessions.get(childSessionId);
+  const title = session?.title?.trim();
+  if (title) return title;
+  return i18nService.t('flow-chat:btw.threadLabel', { defaultValue: 'Side thread' });
+};
+
+export const isBtwSessionPanelContent = (content: PanelContent | null | undefined): boolean =>
+  content?.type === BTW_SESSION_PANEL_TYPE;
+
+export const buildBtwSessionPanelContent = (
+  childSessionId: string,
+  parentSessionId: string,
+  workspacePath?: string
+): PanelContent => ({
+  type: BTW_SESSION_PANEL_TYPE,
+  title: resolveBtwSessionTitle(childSessionId),
+  data: {
+    childSessionId,
+    parentSessionId,
+    workspacePath,
+  } satisfies BtwSessionPanelData,
+  metadata: {
+    duplicateCheckKey: getBtwSessionDuplicateKey(childSessionId),
+    childSessionId,
+    parentSessionId,
+    contentRole: 'btw-session',
+  } satisfies BtwSessionPanelMetadata,
+});
+
+export const selectActiveAgentTab = (state: AgentCanvasState) => {
+  const activeGroup = state.activeGroupId === 'primary'
+    ? state.primaryGroup
+    : state.activeGroupId === 'secondary'
+      ? state.secondaryGroup
+      : state.tertiaryGroup;
+  const activeTabId = activeGroup.activeTabId;
+  if (!activeTabId) return null;
+  return activeGroup.tabs.find(tab => tab.id === activeTabId && !tab.isHidden) ?? null;
+};
+
+export const selectActiveBtwSessionTab = (state: AgentCanvasState): CanvasTab | null => {
+  const activeTab = selectActiveAgentTab(state);
+  if (!activeTab || !isBtwSessionPanelContent(activeTab.content)) {
+    return null;
+  }
+
+  const data = activeTab.content.data as BtwSessionPanelData | undefined;
+  if (!data?.childSessionId || !data.parentSessionId) {
+    return null;
+  }
+
+  return activeTab;
+};
+
+export async function openMainSession(
+  sessionId: string,
+  options?: {
+    workspaceId?: string;
+    activateWorkspace?: (workspaceId: string) => Promise<void> | void;
+  }
+): Promise<void> {
+  useSceneStore.getState().openScene('session');
+  appManager.updateLayout({
+    leftPanelActiveTab: 'sessions',
+    leftPanelCollapsed: false,
+  });
+
+  if (options?.workspaceId && options.activateWorkspace) {
+    await options.activateWorkspace(options.workspaceId);
+  }
+
+  if (flowChatStore.getState().activeSessionId === sessionId) {
+    return;
+  }
+
+  await flowChatManager.switchChatSession(sessionId);
+}
+
+export function openBtwSessionInAuxPane(params: {
+  childSessionId: string;
+  parentSessionId: string;
+  workspacePath?: string;
+  expand?: boolean;
+}): void {
+  const content = buildBtwSessionPanelContent(
+    params.childSessionId,
+    params.parentSessionId,
+    params.workspacePath
+  );
+
+  if (params.expand !== false) {
+    window.dispatchEvent(new CustomEvent('expand-right-panel'));
+  }
+
+  createTab({
+    type: content.type,
+    title: content.title,
+    data: content.data,
+    metadata: content.metadata,
+    checkDuplicate: true,
+    duplicateCheckKey: content.metadata?.duplicateCheckKey,
+    replaceExisting: false,
+    mode: 'agent',
+  });
+}

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
@@ -119,7 +119,7 @@ let cachedVirtualItems: VirtualItem[] = [];
  * 
  * Explore group merging: consecutive explore-only rounds merged into single explore-group VirtualItem
  */
-function sessionToVirtualItems(session: Session | null): VirtualItem[] {
+export function sessionToVirtualItems(session: Session | null): VirtualItem[] {
   if (!session) {
     if (cachedSession !== null) {
       cachedSession = null;

--- a/src/web-ui/src/flow_chat/tool-cards/BtwMarkerCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/BtwMarkerCard.tsx
@@ -9,9 +9,9 @@ import { CornerDownRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { ToolCardProps } from '../types/flow-chat';
 import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
-import { flowChatManager } from '../services/FlowChatManager';
+import { openBtwSessionInAuxPane, openMainSession } from '../services/openBtwSession';
 
-export const BtwMarkerCard: React.FC<ToolCardProps> = React.memo(({ toolItem }) => {
+export const BtwMarkerCard: React.FC<ToolCardProps> = React.memo(({ toolItem, sessionId }) => {
   const { t } = useTranslation('flow-chat');
 
   const input = (toolItem.toolCall?.input || {}) as any;
@@ -28,9 +28,18 @@ export const BtwMarkerCard: React.FC<ToolCardProps> = React.memo(({ toolItem }) 
       status="completed"
       isExpanded={false}
       clickable={clickable}
-      onClick={() => {
+      onClick={async () => {
         if (!childSessionId) return;
-        void flowChatManager.switchChatSession(childSessionId);
+        const parentSessionId = typeof input?.parentSessionId === 'string' && input.parentSessionId
+          ? input.parentSessionId
+          : sessionId;
+        if (!parentSessionId) return;
+
+        await openMainSession(parentSessionId);
+        openBtwSessionInAuxPane({
+          childSessionId,
+          parentSessionId,
+        });
       }}
       header={
         <CompactToolCardHeader

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.scss
@@ -86,24 +86,6 @@
   }
 }
 
-.file-diff-stats {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 10px;
-  font-weight: 600;
-  font-family: var(--tool-card-font-mono);
-  flex-shrink: 0;
-  
-  .additions {
-    color: var(--color-success);
-  }
-  
-  .deletions {
-    color: var(--color-error);
-  }
-}
-
 .delete-label {
   font-size: 10px;
   font-weight: 500;
@@ -111,24 +93,46 @@
   flex-shrink: 0;
 }
 
-.preview-toggle-btn {
+.diff-preview-group {
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  padding: 0;
+  gap: 3px;
+  padding: 2px 6px;
   border: none;
-  border-radius: 4px;
+  border-radius: 20px;
   background: transparent;
-  color: var(--color-text-muted);
   cursor: pointer;
-  transition: all 0.2s ease;
   flex-shrink: 0;
-  
+  transition: background 0.15s ease, color 0.15s ease;
+  font-family: var(--tool-card-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  line-height: 1;
+
+  .additions {
+    color: var(--color-success);
+  }
+
+  .deletions {
+    color: var(--color-error);
+  }
+
+  svg {
+    flex-shrink: 0;
+    opacity: 0.6;
+  }
+
   &:hover {
-    background: var(--color-bg-hover, rgba(255, 255, 255, 0.08));
-    color: var(--color-text-primary);
+    background: color-mix(in srgb, var(--color-text-primary) 10%, transparent);
+
+    svg {
+      opacity: 1;
+    }
+  }
+
+  &:active {
+    background: color-mix(in srgb, var(--color-text-primary) 16%, transparent);
   }
 }
 

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useCallback, useMemo, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { XCircle, GitBranch, FileText, ChevronDown, ChevronUp, FileEdit, FilePlus, Trash2 } from 'lucide-react';
+import { XCircle, GitBranch, FileText, ChevronDown, ChevronUp, FileEdit, FilePlus, Trash2, Loader2, Clock, Check } from 'lucide-react';
 import { CubeLoading } from '../../component-library';
 import type { ToolCardProps } from '../types/flow-chat';
 import { BaseToolCard, ToolCardHeader } from './BaseToolCard';
@@ -16,7 +16,9 @@ import { createCodeEditorTab, createDiffEditorTab } from '../../shared/utils/tab
 import { CodePreview } from '../components/CodePreview';
 import { InlineDiffPreview } from '../components/InlineDiffPreview';
 import { Tooltip } from '@/component-library';
+import { diffLines } from 'diff';
 import { createLogger } from '@/shared/utils/logger';
+import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
 import './FileOperationToolCard.scss';
 
 const log = createLogger('FileOperationToolCard');
@@ -35,10 +37,11 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   const { toolCall, toolResult, status, isParamsStreaming, partialParams } = toolItem;
   
   const [isErrorExpanded, setIsErrorExpanded] = useState(false);
-  const [isPreviewExpanded, setIsPreviewExpanded] = useState(false);
+  const [isPreviewExpanded, setIsPreviewExpanded] = useState(isParamsStreaming);
   const [operationDiffStats, setOperationDiffStats] = useState<{ additions: number; deletions: number } | null>(null);
   
   const prevIsParamsStreamingRef = useRef(isParamsStreaming);
+  const userCollapsedRef = useRef(false);
   
   useEffect(() => {
     const prevIsParamsStreaming = prevIsParamsStreamingRef.current;
@@ -47,6 +50,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
       prevIsParamsStreamingRef.current = isParamsStreaming;
       
       if (isParamsStreaming) {
+        userCollapsedRef.current = false;
         setIsPreviewExpanded(true);
       } else {
         setIsPreviewExpanded(false);
@@ -131,9 +135,30 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
     }
   }, [error, clearError, currentFilePath]);
 
+  const localDiffStats = useMemo(() => {
+    if (status !== 'completed' || isFailed) return null;
+    if (toolItem.toolName === 'Write' && contentPreview) {
+      const lines = contentPreview.split('\n');
+      const count = lines[lines.length - 1] === '' ? lines.length - 1 : lines.length;
+      return { additions: count, deletions: 0 };
+    }
+    if (toolItem.toolName === 'Edit' && (oldStringContent || newStringContent)) {
+      const changes = diffLines(oldStringContent, newStringContent);
+      let additions = 0;
+      let deletions = 0;
+      for (const change of changes) {
+        const lineCount = change.count ?? 0;
+        if (change.added) additions += lineCount;
+        else if (change.removed) deletions += lineCount;
+      }
+      return { additions, deletions };
+    }
+    return null;
+  }, [toolItem.toolName, contentPreview, oldStringContent, newStringContent, status, isFailed]);
+
   const currentFileDiffStats = useMemo(() => {
-    return operationDiffStats ?? { additions: 0, deletions: 0 };
-  }, [operationDiffStats]);
+    return operationDiffStats ?? localDiffStats ?? { additions: 0, deletions: 0 };
+  }, [operationDiffStats, localDiffStats]);
 
   useEffect(() => {
     if (!sessionId || !toolCall?.id || status !== 'completed' || isFailed) return;
@@ -341,28 +366,27 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
             <span className="delete-label">{t('toolCards.file.deletedLabel')}</span>
           )}
           
-          {!isDeleteTool && !isParamsStreaming && !isFailed && !isLoading && (currentFileDiffStats.additions > 0 || currentFileDiffStats.deletions > 0) && (
-            <span className="file-diff-stats">
-              {currentFileDiffStats.additions > 0 && (
-                <span className="additions">+{currentFileDiffStats.additions}</span>
-              )}
-              {currentFileDiffStats.deletions > 0 && (
-                <span className="deletions">-{currentFileDiffStats.deletions}</span>
-              )}
-            </span>
-          )}
-          
-          {!isFailed && (oldStringContent || newStringContent || contentPreview) && (
+          {!isDeleteTool && !isParamsStreaming && !isFailed && !isLoading && (
+            (currentFileDiffStats.additions > 0 || currentFileDiffStats.deletions > 0 || oldStringContent || newStringContent || contentPreview)
+          ) && (
             <Tooltip content={isPreviewExpanded ? t('toolCards.file.collapsePreview') : t('toolCards.file.expandPreview')} placement="top">
               <button
-                className="preview-toggle-btn"
+                className="diff-preview-group"
                 onClick={(e) => {
                   e.stopPropagation();
                   window.dispatchEvent(new CustomEvent('tool-card-toggle'));
-                  setIsPreviewExpanded(!isPreviewExpanded);
+                  const next = !isPreviewExpanded;
+                  userCollapsedRef.current = !next;
+                  setIsPreviewExpanded(next);
                 }}
               >
-                {isPreviewExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                {currentFileDiffStats.additions > 0 && (
+                  <span className="additions">+{currentFileDiffStats.additions}</span>
+                )}
+                {currentFileDiffStats.deletions > 0 && (
+                  <span className="deletions">-{currentFileDiffStats.deletions}</span>
+                )}
+                {isPreviewExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
               </button>
             </Tooltip>
           )}
@@ -502,6 +526,55 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   );
 
   const isDeleteTool = toolItem.toolName === 'Delete';
+
+  const getDeleteStatusIcon = () => {
+    switch (status) {
+      case 'running':
+      case 'streaming':
+      case 'preparing':
+        return <Loader2 className="animate-spin" size={12} />;
+      case 'completed':
+        return <Check size={12} className="icon-check-done" />;
+      case 'pending':
+      case 'confirmed':
+      case 'pending_confirmation':
+      case 'analyzing':
+      default:
+        return <Clock size={12} />;
+    }
+  };
+
+  const renderDeleteContent = () => {
+    const baseLabel = `${t('toolCards.file.delete')}: ${fileName}`;
+
+    if (status === 'completed') {
+      return baseLabel;
+    }
+
+    if (status === 'error') {
+      return `${t('toolCards.file.delete')}${t('toolCards.file.failed')}: ${fileName}`;
+    }
+
+    return baseLabel;
+  };
+
+  if (isDeleteTool) {
+    return (
+      <CompactToolCard
+        status={status}
+        isExpanded={false}
+        className="read-file-card delete-file-card"
+        clickable={false}
+        header={
+          <CompactToolCardHeader
+            statusIcon={getDeleteStatusIcon()}
+            content={renderDeleteContent()}
+            extra={status === 'completed' ? t('toolCards.file.deletedLabel') : undefined}
+          />
+        }
+      />
+    );
+  }
 
   return (
     <BaseToolCard

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -193,6 +193,12 @@
     "templateHint": "Press <kbd>Tab</kbd> for next placeholder, <kbd>Shift+Tab</kbd> for previous, <kbd>Esc</kbd> to exit",
     "templateProgress": "{{current}} / {{total}}",
     "wip": "WIP",
+    "sendTarget": "Send to",
+    "conversationTarget": "Conversation target",
+    "targetMain": "Main",
+    "targetBtw": "Side",
+    "sendingToMain": "Main session: {{title}}",
+    "sendingToBtw": "Side session: {{title}}",
     "modeDescriptions": {
       "agentic": "Full-featured AI assistant with access to all tools for comprehensive software development tasks",
       "Claw": "Personal assistant mode for dedicated assistant workspaces and everyday task support",
@@ -257,6 +263,7 @@
   },
   "btw": {
     "title": "Side question",
+    "shortLabel": "Side",
     "hint": "Not saved · Uses current chat context · No tools",
     "placeholder": "Ask a quick question…",
     "ask": "Ask",
@@ -270,13 +277,18 @@
     "back": "Back",
     "backToParent": "Back to parent session",
     "empty": "Please provide a question after /btw",
+    "nestedDisabled": "A side question cannot start another side question",
     "error": "Failed",
     "close": "Close",
     "noSession": "No active session for /btw"
   },
   "flowChatHeader": {
     "previousTurn": "Previous turn",
-    "nextTurn": "Next turn"
+    "nextTurn": "Next turn",
+    "turnBadge": "Turn {{current}}",
+    "btwBackTooltipWithTurn": "Go back to the source session: {{title}} (Turn {{turn}})",
+    "btwBackTooltipWithoutTurn": "Go back to the source session: {{title}}",
+    "btwCreateTooltip": "Start a quick side question"
   },
   "sessionFilesBadge": {
     "files": "files",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -193,6 +193,12 @@
     "templateHint": "按 <kbd>Tab</kbd> 切换到下一个占位符，<kbd>Shift+Tab</kbd> 返回上一个，<kbd>Esc</kbd> 退出编辑",
     "templateProgress": "{{current}} / {{total}}",
     "wip": "开发中",
+    "sendTarget": "发送到",
+    "conversationTarget": "对话目标",
+    "targetMain": "主会话",
+    "targetBtw": "当前侧问",
+    "sendingToMain": "主会话：{{title}}",
+    "sendingToBtw": "侧问会话：{{title}}",
     "modeDescriptions": {
       "agentic": "AI 主导执行，自动规划和完成编码任务，拥有完整的工具访问能力",
       "Claw": "个人助理模式：面向个人工作区和日常事务，使用独立的助理上下文",
@@ -256,7 +262,8 @@
     "close": "关闭"
   },
   "btw": {
-    "title": "BTW",
+    "title": "侧问",
+    "shortLabel": "侧问",
     "hint": "不保存 · 使用当前对话上下文 · 无工具",
     "placeholder": "问个小问题…",
     "ask": "提问",
@@ -270,13 +277,18 @@
     "back": "返回",
     "backToParent": "返回父会话",
     "empty": "请在 /btw 后面写上问题",
+    "nestedDisabled": "侧问会话中不能继续新建侧问",
     "error": "失败",
     "close": "关闭",
     "noSession": "当前没有可用于 /btw 的会话"
   },
   "flowChatHeader": {
     "previousTurn": "上一轮对话",
-    "nextTurn": "下一轮对话"
+    "nextTurn": "下一轮对话",
+    "turnBadge": "第 {{current}} 轮",
+    "btwBackTooltipWithTurn": "返回到来源会话：{{title}}（第 {{turn}} 轮）",
+    "btwBackTooltipWithoutTurn": "返回到来源会话：{{title}}",
+    "btwCreateTooltip": "快速发起一个侧问"
   },
   "sessionFilesBadge": {
     "files": "文件",


### PR DESCRIPTION
## Summary
- move BTW side questions into a dedicated auxiliary panel so the main thread and side thread can stay visible together
- add session navigation and source-linking improvements across the nav panel, chat header, and right-side canvas for BTW flows
- refine chat input, model selection, tooltip timing, markdown tables, and file operation cards to better support the updated side-session experience

## Test plan
- [ ] Verify creating a `/btw` side question opens the side session in the auxiliary panel and keeps the parent session in sync
- [ ] Verify switching between main and side targets in the chat input sends messages to the intended session
- [ ] Verify session list actions, source back-navigation, and BTW markers focus the correct parent turn
- [ ] Verify file operation cards, tooltip behavior, and markdown table rendering still behave correctly in the updated UI