### PR TITLE
feat: move /btw persistence to backend, add workspace cleanup, simplify WelcomeScene

### DIFF
--- a/src/apps/desktop/src/api/btw_api.rs
+++ b/src/apps/desktop/src/api/btw_api.rs
@@ -1,7 +1,7 @@
 //! BTW (side question) API
 //!
 //! Desktop adapter for the core side-question service:
-//! - Reads current session context (no new dialog turn, no persistence writes)
+//! - Reads current session context without mutating the parent session
 //! - Streams answer via `btw://...` events
 //! - Supports cancellation by request id
 
@@ -14,8 +14,10 @@ use crate::api::app_state::AppState;
 
 use bitfun_core::agentic::coordination::ConversationCoordinator;
 use bitfun_core::agentic::side_question::{
-    SideQuestionService, SideQuestionStreamEvent, SideQuestionStreamRequest,
+    SideQuestionPersistTarget, SideQuestionService, SideQuestionStreamEvent,
+    SideQuestionStreamRequest,
 };
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -44,6 +46,10 @@ pub struct BtwAskStreamRequest {
     pub model_id: Option<String>,
     /// Limit how many context messages are included (from the end).
     pub max_context_messages: Option<usize>,
+    pub child_session_id: Option<String>,
+    pub workspace_path: Option<String>,
+    pub parent_dialog_turn_id: Option<String>,
+    pub parent_turn_index: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -135,6 +141,20 @@ pub async fn btw_ask_stream(
             question: request.question.clone(),
             model_id: request.model_id.clone(),
             max_context_messages: request.max_context_messages,
+            persist_target: match (&request.child_session_id, &request.workspace_path) {
+                (Some(child_session_id), Some(workspace_path))
+                    if !child_session_id.trim().is_empty() && !workspace_path.trim().is_empty() =>
+                {
+                    Some(SideQuestionPersistTarget {
+                        child_session_id: child_session_id.clone(),
+                        workspace_path: PathBuf::from(workspace_path),
+                        parent_session_id: request.session_id.clone(),
+                        parent_dialog_turn_id: request.parent_dialog_turn_id.clone(),
+                        parent_turn_index: request.parent_turn_index,
+                    })
+                }
+                _ => None,
+            },
         })
         .await
         .map_err(|e| e.to_string())?;

--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -1009,6 +1009,40 @@ pub async fn get_recent_workspaces(
 }
 
 #[tauri::command]
+pub async fn cleanup_invalid_workspaces(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<usize, String> {
+    match state.workspace_service.cleanup_invalid_workspaces().await {
+        Ok(removed_count) => {
+            if let Some(workspace_info) = state.workspace_service.get_current_workspace().await {
+                apply_active_workspace_context(&state, &app, &workspace_info).await;
+            } else {
+                clear_active_workspace_context(&state, &app).await;
+            }
+
+            if let Err(e) = state
+                .workspace_identity_watch_service
+                .sync_watched_workspaces()
+                .await
+            {
+                warn!(
+                    "Failed to sync workspace identity watchers after workspace cleanup: {}",
+                    e
+                );
+            }
+
+            info!("Invalid workspaces cleaned up: removed_count={}", removed_count);
+            Ok(removed_count)
+        }
+        Err(e) => {
+            error!("Failed to cleanup invalid workspaces: {}", e);
+            Err(format!("Failed to cleanup invalid workspaces: {}", e))
+        }
+    }
+}
+
+#[tauri::command]
 pub async fn get_opened_workspaces(
     state: State<'_, AppState>,
 ) -> Result<Vec<WorkspaceInfoDto>, String> {

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -550,6 +550,7 @@ pub async fn run() {
             subscribe_config_updates,
             get_model_configs,
             get_recent_workspaces,
+            cleanup_invalid_workspaces,
             get_opened_workspaces,
             open_workspace,
             create_assistant_workspace,

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -1814,6 +1814,32 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         &self.session_manager
     }
 
+    /// Persist a completed `/btw` side-question turn into an existing child session.
+    pub async fn persist_btw_turn(
+        &self,
+        workspace_path: &Path,
+        child_session_id: &str,
+        request_id: &str,
+        question: &str,
+        full_text: &str,
+        parent_session_id: &str,
+        parent_dialog_turn_id: Option<&str>,
+        parent_turn_index: Option<usize>,
+    ) -> BitFunResult<()> {
+        self.session_manager
+            .persist_btw_turn(
+                workspace_path,
+                child_session_id,
+                request_id,
+                question,
+                full_text,
+                parent_session_id,
+                parent_dialog_turn_id,
+                parent_turn_index,
+            )
+            .await
+    }
+
     /// Set global coordinator (called during initialization)
     ///
     /// Skips if global coordinator already exists

--- a/src/crates/core/src/agentic/persistence/manager.rs
+++ b/src/crates/core/src/agentic/persistence/manager.rs
@@ -25,6 +25,7 @@ const JSON_WRITE_MAX_RETRIES: usize = 5;
 const JSON_WRITE_RETRY_BASE_DELAY_MS: u64 = 30;
 
 static JSON_FILE_WRITE_LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
+static SESSION_INDEX_LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct StoredSessionMetadataFile {
@@ -285,6 +286,16 @@ impl PersistenceManager {
             .clone()
     }
 
+    async fn get_session_index_lock(&self, workspace_path: &Path) -> Arc<Mutex<()>> {
+        let index_path = self.index_path(workspace_path);
+        let registry = SESSION_INDEX_LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+        let mut registry_guard = registry.lock().await;
+        registry_guard
+            .entry(index_path)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
     fn build_temp_json_path(path: &Path, attempt: usize) -> BitFunResult<PathBuf> {
         let parent = path.parent().ok_or_else(|| {
             BitFunError::io(format!(
@@ -468,7 +479,7 @@ impl PersistenceManager {
         }
     }
 
-    async fn rebuild_index(&self, workspace_path: &Path) -> BitFunResult<Vec<SessionMetadata>> {
+    async fn rebuild_index_locked(&self, workspace_path: &Path) -> BitFunResult<Vec<SessionMetadata>> {
         let sessions_root = self.ensure_project_sessions_dir(workspace_path).await?;
         let mut metadata_list = Vec::new();
         let mut entries = fs::read_dir(&sessions_root)
@@ -515,7 +526,7 @@ impl PersistenceManager {
         Ok(metadata_list)
     }
 
-    async fn upsert_index_entry(
+    async fn upsert_index_entry_locked(
         &self,
         workspace_path: &Path,
         metadata: &SessionMetadata,
@@ -548,7 +559,7 @@ impl PersistenceManager {
         self.write_json_atomic(&index_path, &index).await
     }
 
-    async fn remove_index_entry(
+    async fn remove_index_entry_locked(
         &self,
         workspace_path: &Path,
         session_id: &str,
@@ -568,6 +579,32 @@ impl PersistenceManager {
         self.write_json_atomic(&index_path, &index).await
     }
 
+    async fn rebuild_index(&self, workspace_path: &Path) -> BitFunResult<Vec<SessionMetadata>> {
+        let lock = self.get_session_index_lock(workspace_path).await;
+        let _guard = lock.lock().await;
+        self.rebuild_index_locked(workspace_path).await
+    }
+
+    async fn upsert_index_entry(
+        &self,
+        workspace_path: &Path,
+        metadata: &SessionMetadata,
+    ) -> BitFunResult<()> {
+        let lock = self.get_session_index_lock(workspace_path).await;
+        let _guard = lock.lock().await;
+        self.upsert_index_entry_locked(workspace_path, metadata).await
+    }
+
+    async fn remove_index_entry(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+    ) -> BitFunResult<()> {
+        let lock = self.get_session_index_lock(workspace_path).await;
+        let _guard = lock.lock().await;
+        self.remove_index_entry_locked(workspace_path, session_id).await
+    }
+
     pub async fn list_session_metadata(
         &self,
         workspace_path: &Path,
@@ -576,15 +613,28 @@ impl PersistenceManager {
             return Ok(Vec::new());
         }
 
+        let lock = self.get_session_index_lock(workspace_path).await;
+        let _guard = lock.lock().await;
         let index_path = self.index_path(workspace_path);
         if let Some(index) = self
             .read_json_optional::<StoredSessionIndex>(&index_path)
             .await?
         {
+            let has_stale_entry = index
+                .sessions
+                .iter()
+                .any(|metadata| !self.metadata_path(workspace_path, &metadata.session_id).exists());
+            if has_stale_entry {
+                warn!(
+                    "Session index contains stale entries, rebuilding: {}",
+                    index_path.display()
+                );
+                return self.rebuild_index_locked(workspace_path).await;
+            }
             return Ok(index.sessions);
         }
 
-        self.rebuild_index(workspace_path).await
+        self.rebuild_index_locked(workspace_path).await
     }
 
     pub async fn save_session_metadata(
@@ -944,6 +994,16 @@ impl PersistenceManager {
         workspace_path: &Path,
         turn: &DialogTurnData,
     ) -> BitFunResult<()> {
+        let mut metadata = self
+            .load_session_metadata(workspace_path, &turn.session_id)
+            .await?
+            .ok_or_else(|| {
+                BitFunError::NotFound(format!(
+                    "Session metadata not found: {}",
+                    turn.session_id
+                ))
+            })?;
+
         self.ensure_turns_dir(workspace_path, &turn.session_id)
             .await?;
 
@@ -956,18 +1016,6 @@ impl PersistenceManager {
             &file,
         )
         .await?;
-
-        let mut metadata = self
-            .load_session_metadata(workspace_path, &turn.session_id)
-            .await?
-            .unwrap_or_else(|| {
-                SessionMetadata::new(
-                    turn.session_id.clone(),
-                    "New Session".to_string(),
-                    "agentic".to_string(),
-                    "default".to_string(),
-                )
-            });
 
         let turns = self
             .load_session_turns(workspace_path, &turn.session_id)

--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -17,6 +17,7 @@ use crate::service::snapshot::ensure_snapshot_manager_for_workspace;
 use crate::util::errors::{BitFunError, BitFunResult};
 use dashmap::DashMap;
 use log::{debug, error, info, warn};
+use serde_json::json;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -910,6 +911,95 @@ impl SessionManager {
             "Dialog turn marked as failed: turn_id={}, turn_index={}, error={}",
             turn_id, turn.turn_index, error
         );
+
+        Ok(())
+    }
+
+    /// Persist a completed `/btw` side-question turn into an existing child session.
+    pub async fn persist_btw_turn(
+        &self,
+        workspace_path: &Path,
+        child_session_id: &str,
+        request_id: &str,
+        question: &str,
+        full_text: &str,
+        parent_session_id: &str,
+        parent_dialog_turn_id: Option<&str>,
+        parent_turn_index: Option<usize>,
+    ) -> BitFunResult<()> {
+        let session = self
+            .sessions
+            .get(child_session_id)
+            .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {}", child_session_id)))?;
+
+        let turn_id = format!("btw-turn-{}", request_id);
+        let user_message_id = format!("btw-user-{}", request_id);
+        let round_id = format!("btw-round-{}", request_id);
+        let text_id = format!("btw-text-{}", request_id);
+        let now = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        let mut turn = DialogTurnData::new(
+            turn_id.clone(),
+            0,
+            child_session_id.to_string(),
+            UserMessageData {
+                id: user_message_id,
+                content: question.to_string(),
+                timestamp: now,
+                metadata: Some(json!({
+                    "kind": "btw",
+                    "parentSessionId": parent_session_id,
+                    "parentRequestId": request_id,
+                    "parentDialogTurnId": parent_dialog_turn_id,
+                    "parentTurnIndex": parent_turn_index,
+                })),
+            },
+        );
+        turn.timestamp = now;
+        turn.start_time = now;
+        turn.end_time = Some(now);
+        turn.duration_ms = Some(0);
+        turn.status = TurnStatus::Completed;
+        turn.model_rounds = vec![ModelRoundData {
+            id: round_id,
+            turn_id: turn_id.clone(),
+            round_index: 0,
+            timestamp: now,
+            text_items: vec![TextItemData {
+                id: text_id,
+                content: full_text.to_string(),
+                is_streaming: false,
+                timestamp: now,
+                is_markdown: true,
+                order_index: None,
+                is_subagent_item: None,
+                parent_task_tool_id: None,
+                subagent_session_id: None,
+                status: Some("completed".to_string()),
+            }],
+            tool_items: vec![],
+            thinking_items: vec![],
+            start_time: now,
+            end_time: Some(now),
+            status: "completed".to_string(),
+        }];
+
+        drop(session);
+
+        self.persistence_manager
+            .save_dialog_turn(workspace_path, &turn)
+            .await?;
+
+        if let Some(mut session) = self.sessions.get_mut(child_session_id) {
+            if !session.dialog_turn_ids.iter().any(|existing| existing == &turn_id) {
+                session.dialog_turn_ids.push(turn_id);
+            }
+            session.updated_at = SystemTime::now();
+            session.last_activity_at = SystemTime::now();
+        }
 
         Ok(())
     }

--- a/src/crates/core/src/agentic/side_question.rs
+++ b/src/crates/core/src/agentic/side_question.rs
@@ -14,6 +14,7 @@ use crate::util::types::message::Message as AIMessage;
 use futures::StreamExt;
 use log::{debug, warn};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
@@ -280,6 +281,9 @@ Rules:\n\
         let (tx, rx) = mpsc::unbounded_channel();
         let request_id = request.request_id.clone();
         let session_id = request.session_id.clone();
+        let question = request.question.clone();
+        let persist_target = request.persist_target.clone();
+        let coordinator = self.coordinator.clone();
         let runtime = self.runtime.clone();
 
         tokio::spawn(async move {
@@ -346,6 +350,27 @@ Rules:\n\
                 );
             }
 
+            if let Some(target) = persist_target {
+                if let Err(error) = coordinator
+                    .persist_btw_turn(
+                        &target.workspace_path,
+                        &target.child_session_id,
+                        &request_id,
+                        &question,
+                        full_text.trim(),
+                        &target.parent_session_id,
+                        target.parent_dialog_turn_id.as_deref(),
+                        target.parent_turn_index,
+                    )
+                    .await
+                {
+                    warn!(
+                        "Failed to persist side-question turn: child_session_id={}, request_id={}, error={}",
+                        target.child_session_id, request_id, error
+                    );
+                }
+            }
+
             let _ = tx.send(SideQuestionStreamEvent::Completed {
                 request_id,
                 session_id,
@@ -365,6 +390,16 @@ pub struct SideQuestionStreamRequest {
     pub question: String,
     pub model_id: Option<String>,
     pub max_context_messages: Option<usize>,
+    pub persist_target: Option<SideQuestionPersistTarget>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SideQuestionPersistTarget {
+    pub child_session_id: String,
+    pub workspace_path: PathBuf,
+    pub parent_session_id: String,
+    pub parent_dialog_turn_id: Option<String>,
+    pub parent_turn_index: Option<usize>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/crates/core/src/service/workspace/service.rs
+++ b/src/crates/core/src/service/workspace/service.rs
@@ -726,7 +726,11 @@ impl WorkspaceService {
             manager.cleanup_invalid_workspaces().await
         };
 
-        if result.is_ok() {}
+        if result.is_ok() {
+            if let Err(e) = self.save_workspace_data().await {
+                warn!("Failed to save workspace data after cleanup: {}", e);
+            }
+        }
 
         result
     }

--- a/src/web-ui/src/app/components/NavPanel/MainNav.tsx
+++ b/src/web-ui/src/app/components/NavPanel/MainNav.tsx
@@ -175,7 +175,13 @@ const MainNav: React.FC<MainNavProps> = ({
     }, 150);
   }, []);
 
-  const openWorkspaceMenu = useCallback(() => {
+  const openWorkspaceMenu = useCallback(async () => {
+    try {
+      await workspaceManager.cleanupInvalidWorkspaces();
+    } catch (error) {
+      log.warn('Failed to cleanup invalid workspaces before opening workspace menu', { error });
+    }
+
     const rect = workspaceMenuButtonRef.current?.getBoundingClientRect();
     if (!rect) return;
     setWorkspaceMenuPos({
@@ -191,7 +197,7 @@ const MainNav: React.FC<MainNavProps> = ({
       closeWorkspaceMenu();
       return;
     }
-    openWorkspaceMenu();
+    void openWorkspaceMenu();
   }, [closeWorkspaceMenu, openWorkspaceMenu, workspaceMenuOpen]);
 
   const setSessionMode = useSessionModeStore(s => s.setMode);

--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -646,9 +646,16 @@ $_section-header-height: 24px;
     transition: color $motion-fast $easing-standard,
                 background $motion-fast $easing-standard;
 
-    &:hover {
+    &:hover:not(:disabled):not(.is-disabled) {
       color: var(--color-text-primary);
       background: var(--element-bg-soft);
+    }
+
+    &.is-disabled,
+    &:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+      color: var(--color-text-muted);
     }
 
     svg {

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -369,10 +369,12 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
                 <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.deleteAssistant')}</span>
               </button>
             )}
-            <button type="button" className="bitfun-nav-panel__workspace-item-menu-item is-danger" onClick={() => { void handleCloseWorkspace(); }}>
-              <FolderOpen size={13} />
-              <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.close')}</span>
-            </button>
+            {workspace.workspaceKind !== WorkspaceKind.Assistant && (
+              <button type="button" className="bitfun-nav-panel__workspace-item-menu-item is-danger" onClick={() => { void handleCloseWorkspace(); }}>
+                <FolderOpen size={13} />
+                <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.close')}</span>
+              </button>
+            )}
           </div>,
           document.body
         )}
@@ -403,7 +405,6 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
         confirmText={t('nav.workspaces.actions.deleteAssistant')}
         cancelText={t('actions.cancel')}
         confirmDanger
-        preview={`${t('nav.workspaces.deleteAssistantDialog.pathLabel')}\n${workspace.rootPath}`}
       />
       <ConfirmDialog
         isOpen={resetDialogOpen}

--- a/src/web-ui/src/app/components/SplashScreen/SplashScreen.scss
+++ b/src/web-ui/src/app/components/SplashScreen/SplashScreen.scss
@@ -65,13 +65,13 @@
 .splash-screen__dots {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
 }
 
 .splash-screen__dot {
   display: block;
-  width: 3px;
-  height: 3px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: var(--color-text-muted);
 
@@ -94,10 +94,10 @@
   100% { opacity: 0; }
 }
 
-// Dot loading bounce
+// Dot loading pulse without vertical movement
 @keyframes splash-dot {
-  0%, 100% { opacity: 0.25; transform: translateY(0);    }
-  50%       { opacity: 0.85; transform: translateY(-4px); }
+  0%, 100% { opacity: 0.3; transform: scale(0.92); }
+  50%      { opacity: 0.9; transform: scale(1.16); }
 }
 
 // ── Reduced motion ────────────────────────────────────────────────────────────

--- a/src/web-ui/src/app/scenes/profile/views/PersonaView.scss
+++ b/src/web-ui/src/app/scenes/profile/views/PersonaView.scss
@@ -143,20 +143,52 @@ $gutter: clamp(40px, 6vw, 80px);
       flex: 1;
       min-width: 0;
       max-width: 520px;
-      min-height: 180px;
+      min-height: 400px;
       display: flex;
       flex-direction: column;
       justify-content: flex-start;
       gap: 0;
-      padding: 18px 20px;
+      padding: 0;
       border-radius: 12px;
       border: 1px dashed var(--border-subtle);
       background: transparent;
-      cursor: default;
+      cursor: text;
+      overflow: hidden;
       transition: border-color $motion-fast $easing-standard;
 
-      &:hover {
+      &:hover,
+      &:focus-within {
         border-color: var(--border-medium);
+      }
+
+      // 嵌入 IR Markdown 编辑器的样式覆盖
+      .m-editor {
+        background: transparent;
+        border-radius: 0;
+      }
+
+      .m-editor-ir {
+        padding: 16px 20px;
+        background: transparent;
+
+        &-placeholder {
+          padding: 2px 0;
+          font-size: $font-size-sm;
+          color: var(--color-text-disabled);
+          line-height: 1.8;
+        }
+      }
+
+      .m-editor-ir-block-preview {
+        font-size: $font-size-sm;
+        line-height: 1.8;
+        color: var(--color-text-secondary);
+      }
+
+      .m-editor-ir-block-textarea {
+        font-size: $font-size-sm;
+        line-height: 1.8;
+        font-family: $font-family-mono;
       }
     }
 

--- a/src/web-ui/src/app/scenes/profile/views/PersonaView.tsx
+++ b/src/web-ui/src/app/scenes/profile/views/PersonaView.tsx
@@ -14,7 +14,6 @@ import {
   Search,
   Select,
   Switch,
-  Textarea,
   Tooltip,
   type SelectOption,
 } from '@/component-library';
@@ -37,6 +36,7 @@ import { useAgentIdentityDocument } from '@/app/scenes/my-agent/useAgentIdentity
 import { PersonaRadar } from './PersonaRadar';
 import { notificationService } from '@/shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
+import { MEditor } from '@/tools/editor/meditor';
 import './PersonaView.scss';
 
 const log = createLogger('PersonaView');
@@ -309,12 +309,11 @@ const PersonaView: React.FC<{ workspacePath: string }> = ({ workspacePath }) => 
     resetPersonaFiles,
   } = useAgentIdentityDocument(workspacePath);
   const [editingField, setEditingField] = useState<
-    'name' | 'body' | 'emoji' | 'creature' | 'vibe' | null
+    'name' | 'emoji' | 'creature' | 'vibe' | null
   >(null);
   const [editValue, setEditValue] = useState('');
   const nameInputRef = useRef<HTMLInputElement>(null);
   const metaInputRef = useRef<HTMLInputElement>(null);
-  const bodyTextareaRef = useRef<HTMLTextAreaElement>(null);
 
   const [models, setModels] = useState<AIModelConfig[]>([]);
   const [funcAgentModels, setFuncAgentModels] = useState<Record<string, string>>({});
@@ -452,24 +451,17 @@ const PersonaView: React.FC<{ workspacePath: string }> = ({ workspacePath }) => 
     [identityDocument.creature, identityDocument.emoji, identityDocument.vibe, t]
   );
 
-  const startEdit = (field: 'name' | 'body' | 'emoji' | 'creature' | 'vibe') => {
+  const startEdit = (field: 'name' | 'emoji' | 'creature' | 'vibe') => {
     setEditingField(field);
     const nextValue =
       field === 'name'
         ? identityDocument.name
-        : field === 'body'
-          ? identityDocument.body
-          : identityDocument[field];
+        : identityDocument[field];
 
     setEditValue(nextValue);
     setTimeout(() => {
       if (field === 'name') {
         nameInputRef.current?.focus();
-        return;
-      }
-
-      if (field === 'body') {
-        bodyTextareaRef.current?.focus();
         return;
       }
 
@@ -480,17 +472,23 @@ const PersonaView: React.FC<{ workspacePath: string }> = ({ workspacePath }) => 
     if (!editingField) return;
     if (editingField === 'name') {
       updateIdentityField('name', editValue.trim());
-    } else if (editingField === 'body') {
-      updateIdentityField('body', editValue.replace(/\r\n/g, '\n'));
     } else {
       updateIdentityField(editingField, editValue.trim());
     }
     setEditingField(null);
   }, [editValue, editingField, updateIdentityField]);
   const onEditKey = (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    if (editingField !== 'body' && e.key === 'Enter') commitEdit();
+    if (e.key === 'Enter') commitEdit();
     if (e.key === 'Escape') setEditingField(null);
   };
+
+  const bodyUpdateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleBodyChange = useCallback((newBody: string) => {
+    if (bodyUpdateTimerRef.current) clearTimeout(bodyUpdateTimerRef.current);
+    bodyUpdateTimerRef.current = setTimeout(() => {
+      updateIdentityField('body', newBody);
+    }, 600);
+  }, [updateIdentityField]);
 
   const handleConfirmResetIdentity = useCallback(async () => {
     setEditingField(null);
@@ -1056,43 +1054,19 @@ const PersonaView: React.FC<{ workspacePath: string }> = ({ workspacePath }) => 
             })}
           </div>
 
-          {/* Description + Radar side by side */}
+          {/* Description — IR Markdown editor */}
           <div className={`${C}-home__body-row`}>
-            <div className={`${C}-home__desc-block`} onClick={() => !editingField && startEdit('body')}>
-              {editingField === 'body' ? (
-                <Textarea
-                  ref={bodyTextareaRef}
-                  className={`${C}-home__desc-input`}
-                  value={editValue}
-                  onChange={e => setEditValue(e.target.value)}
-                  onBlur={commitEdit}
-                  onKeyDown={onEditKey}
-                  placeholder={identityBodyFallback}
-                  autoResize
-                  rows={7}
-                />
-              ) : (
-                identityDocument.body ? (
-                  <div
-                    className={`${C}-home__desc-markdown`}
-                    title={t('hero.editDescTitle')}
-                  >
-                    {identityDocument.body}
-                  </div>
-                ) : (
-                  <p
-                    className={`${C}-home__desc`}
-                    title={t('hero.editDescTitle')}
-                  >
-                    {identityBodyFallback}
-                  </p>
-                )
-              )}
-              {!editingField && (
-                <p className={`${C}-home__desc-block-hint`}>
-                  {t('home.descHint')}
-                </p>
-              )}
+            <div className={`${C}-home__desc-block`}>
+              <MEditor
+                value={identityDocument.body ?? ''}
+                onChange={handleBodyChange}
+                mode="ir"
+                theme="dark"
+                toolbar={false}
+                height="400px"
+                width="100%"
+                placeholder={identityBodyFallback}
+              />
             </div>
           </div>
 

--- a/src/web-ui/src/app/scenes/welcome/WelcomeScene.scss
+++ b/src/web-ui/src/app/scenes/welcome/WelcomeScene.scss
@@ -21,73 +21,33 @@
     display: flex;
     flex-direction: column;
     gap: $size-gap-8;
-    max-width: 480px;
+    max-width: 560px;
     width: 100%;
   }
-
-  // ── Greeting ────────────────────────────────────────
 
   &__greeting {
     display: flex;
     flex-direction: column;
-    gap: $size-gap-1;
+    align-items: center;
+    text-align: center;
+    gap: $size-gap-3;
   }
 
-  &__greeting-inner {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-end;
-    gap: $size-gap-4;
-  }
-
-  &__greeting-text {
-    display: flex;
-    flex-direction: column;
-    gap: $size-gap-1;
-    min-width: 0;
-  }
-
-  &__title-row {
-    display: flex;
-    align-items: baseline;
-    gap: $size-gap-2;
-    flex-wrap: nowrap;
-    min-width: 0;
+  &__title {
+    margin: 0;
+    font-size: $font-size-2xl;
+    line-height: $line-height-tight;
+    letter-spacing: -0.02em;
+    color: var(--color-text-primary);
+    font-weight: $font-weight-semibold;
   }
 
   &__greeting-label {
-    font-size: $font-size-base;
-    color: var(--color-text-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-
-  &__workspace-title {
-    font-size: 28px;
-    font-weight: $font-weight-semibold;
+    font-size: $font-size-lg;
+    line-height: 1.5;
     color: var(--color-text-primary);
     margin: 0;
-    line-height: $line-height-tight;
-    letter-spacing: -0.02em;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  &__meta-tag {
-    display: inline-flex;
-    align-items: center;
-    align-self: center;
-    gap: 3px;
-    padding: 2px $size-gap-2;
-    border-radius: $size-radius-sm;
-    background: var(--color-accent-100);
-    color: var(--color-accent-500);
-    font-size: $font-size-xs;
-    font-weight: $font-weight-medium;
-
-    span { line-height: 1.4; }
-    svg  { flex-shrink: 0; }
+    max-width: 420px;
   }
 
   // ── Divider ──────────────────────────────────────────
@@ -97,91 +57,12 @@
     background: var(--border-subtle);
   }
 
-  // ── Session buttons (match btn-action default) ───────
-
-  &__sessions {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: $size-gap-2;
-
-    &--single {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  &__session-btn {
-    display: flex;
-    align-items: flex-start;
-    gap: $size-gap-3;
-    padding: $size-gap-3 $size-gap-3;
-    border: 1px dashed var(--border-subtle);
-    border-radius: $size-radius-sm;
-    background: transparent;
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    text-align: left;
-    transition: background $motion-fast $easing-standard,
-                color $motion-fast $easing-standard,
-                border-color $motion-fast $easing-standard;
-
-    &:hover {
-      background: var(--element-bg-medium);
-      color: var(--color-text-primary);
-      border-color: var(--color-accent-400);
-
-      > svg:first-child { color: var(--color-accent-500); }
-    }
-
-    &:active { background: var(--element-bg-soft); }
-
-    > svg:first-child {
-      flex-shrink: 0;
-      margin-top: 2px;
-      color: var(--color-text-muted);
-      transition: color $motion-fast $easing-standard;
-    }
-  }
-
-  &__session-btn-text {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    min-width: 0;
-  }
-
-  &__session-btn-label {
-    display: flex;
-    align-items: center;
-    gap: $size-gap-2;
-    font-size: $font-size-base;
-    font-weight: $font-weight-medium;
-    color: var(--color-text-primary);
-    line-height: 1.3;
-  }
-
-  &__session-btn-desc {
-    font-size: $font-size-sm;
-    color: var(--color-text-muted);
-    line-height: $line-height-base;
-  }
-
-  &__soon-badge {
-    flex-shrink: 0;
-    font-size: 10px;
-    font-weight: $font-weight-medium;
-    padding: 1px 5px;
-    border-radius: $size-radius-sm;
-    background: var(--element-bg-base);
-    color: var(--color-text-muted);
-    line-height: 1.5;
-  }
-
   // ── Switch workspace section ─────────────────────────
 
   &__switch {
     display: flex;
     flex-direction: column;
-    gap: $size-gap-2;
+    gap: $size-gap-3;
   }
 
   &__switch-header {
@@ -293,149 +174,9 @@
     padding: $size-gap-1 $size-gap-2;
   }
 
-  // ── First-time actions ───────────────────────────────
-
-  &__first-time-actions {
-    display: flex;
-    flex-direction: column;
-    gap: $size-gap-3;
-  }
-
-  &__primary-action {
-    display: flex;
-    align-items: center;
-    gap: $size-gap-4;
-    padding: $size-gap-3 + 2px $size-gap-4;
-    border: none;
-    border-radius: $size-radius-sm;
-    background: var(--element-bg-base);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    text-align: left;
-    transition: background $motion-fast $easing-standard,
-                color $motion-fast $easing-standard;
-
-    &:hover:not(:disabled) {
-      background: var(--element-bg-medium);
-      color: var(--color-text-primary);
-
-      > svg:first-child { color: var(--color-accent-500); }
-
-      .welcome-scene__primary-action-arrow {
-        transform: translateX(3px);
-        color: var(--color-text-secondary);
-      }
-    }
-
-    &:disabled {
-      opacity: $opacity-disabled;
-      cursor: default;
-    }
-
-    > svg:first-child {
-      flex-shrink: 0;
-      color: var(--color-text-muted);
-      transition: color $motion-fast $easing-standard;
-    }
-  }
-
-  &__primary-action-text {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    min-width: 0;
-  }
-
-  &__primary-action-title {
-    font-size: $font-size-sm;
-    font-weight: $font-weight-medium;
-    color: var(--color-text-primary);
-  }
-
-  &__primary-action-desc {
-    font-size: $font-size-xs;
-    color: var(--color-text-muted);
-  }
-
-  &__primary-action-arrow {
-    flex-shrink: 0;
-    color: var(--color-text-muted);
-    transition: transform $motion-fast $easing-standard,
-                color $motion-fast $easing-standard;
-  }
-
-  // ── Logo ─────────────────────────────────────────────
-
-  &__logo {
-    margin-bottom: $size-gap-2;
-  }
-
-  &__logo-img {
-    width: 48px;
-    height: 48px;
-    border-radius: $size-radius-lg;
-  }
-
-  // ── Panda mascot ─────────────────────────────────────
-
-  &__panda {
-    position: relative;
-    flex-shrink: 0;
-    width: 100px;
-    pointer-events: none;
-    user-select: none;
-    image-rendering: pixelated;
-  }
-
-  &__panda-frame {
-    display: block;
-    width: 100%;
-    height: auto;
-    image-rendering: pixelated;
-  }
-
-  &__panda-frame--2 {
-    position: absolute;
-    top: 0;
-    left: 0;
-    animation: panda-blink 1.2s steps(1, end) infinite;
-  }
-
-  &__panda-frame--1 {
-    animation: panda-blink-inv 1.2s steps(1, end) infinite;
-  }
-
-  // ── First-time modifier ──────────────────────────────
-
-  &--first-time {
-    .welcome-scene__greeting {
-      align-items: center;
-      text-align: center;
-    }
-
-    .welcome-scene__workspace-title {
-      font-size: $font-size-2xl;
-    }
-
-    .welcome-scene__greeting-label {
-      max-width: 340px;
-      text-align: center;
-    }
-  }
 }
 
 // ── Animations ────────────────────────────────────────
-
-@keyframes panda-blink {
-  0%, 49%  { opacity: 0; }
-  50%, 100% { opacity: 1; }
-}
-
-@keyframes panda-blink-inv {
-  0%, 49%  { opacity: 1; }
-  50%, 100% { opacity: 0; }
-}
 
 @keyframes welcome-fade-in {
   from {
@@ -453,8 +194,6 @@
 @media (max-width: 480px) {
   .welcome-scene {
     padding: $size-gap-5 $size-gap-4;
-
-    &__workspace-title { font-size: $font-size-3xl; }
   }
 }
 
@@ -462,11 +201,6 @@
   .welcome-scene {
     animation: none;
 
-    &__panda-frame--1 { animation: none; opacity: 1; }
-    &__panda-frame--2 { animation: none; opacity: 0; }
-
-    &__session-btn,
-    &__primary-action,
     &__recent-item,
     &__link-btn {
       transition: none;

--- a/src/web-ui/src/app/scenes/welcome/WelcomeScene.tsx
+++ b/src/web-ui/src/app/scenes/welcome/WelcomeScene.tsx
@@ -8,18 +8,15 @@
 
 import React, { useState, useCallback, useMemo } from 'react';
 import {
-  Bot, MessageSquare, Users, GitBranch,
   FolderOpen, Clock, FolderPlus,
 } from 'lucide-react';
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
 import { useSceneStore } from '@/app/stores/sceneStore';
 import { useI18n } from '@/infrastructure/i18n';
-import { useGitBasicInfo } from '@/tools/git/hooks/useGitState';
-import { FlowChatManager } from '@/flow_chat/services/FlowChatManager';
 import { Tooltip } from '@/component-library';
 import { createLogger } from '@/shared/utils/logger';
 import type { SceneTabId } from '@/app/components/SceneBar/types';
-import { WorkspaceKind, type WorkspaceInfo } from '@/shared/types';
+import type { WorkspaceInfo } from '@/shared/types';
 import './WelcomeScene.scss';
 
 const log = createLogger('WelcomeScene');
@@ -28,25 +25,33 @@ const WelcomeScene: React.FC = () => {
   const { t } = useI18n('common');
   const {
     hasWorkspace, currentWorkspace, recentWorkspaces,
-    workspacePath, openWorkspace, switchWorkspace,
+    openWorkspace, switchWorkspace,
   } = useWorkspaceContext();
   const openScene = useSceneStore(s => s.openScene);
-  const { isRepository, currentBranch } = useGitBasicInfo(workspacePath || '');
   const [isSelecting, setIsSelecting] = useState(false);
-  const isAssistantWorkspace = currentWorkspace?.workspaceKind === WorkspaceKind.Assistant;
-  const workspaceDisplayName =
-    isAssistantWorkspace
-      ? currentWorkspace?.identity?.name?.trim() || currentWorkspace?.name
-      : currentWorkspace?.name;
+  const [welcomeMessageIndex] = useState(
+    () => Math.floor(Math.random() * 4),
+  );
+  const welcomeMessages = useMemo(
+    () => [
+      t('welcomeScene.messages.message1'),
+      t('welcomeScene.messages.message2'),
+      t('welcomeScene.messages.message3'),
+      t('welcomeScene.messages.message4'),
+    ],
+    [t],
+  );
+  const welcomeMessage = welcomeMessages[welcomeMessageIndex % welcomeMessages.length];
 
-  const otherWorkspaces = useMemo(
-    () => recentWorkspaces
-      .filter(ws => ws.id !== currentWorkspace?.id)
-      .slice(0, 5),
-    [recentWorkspaces, currentWorkspace?.id],
+  const displayRecentWorkspaces = useMemo(
+    () => (hasWorkspace
+      ? recentWorkspaces.filter(ws => ws.id !== currentWorkspace?.id)
+      : recentWorkspaces
+    ).slice(0, 5),
+    [hasWorkspace, recentWorkspaces, currentWorkspace?.id],
   );
 
-  const handleOpenFolder = useCallback(async (preferredMode?: string) => {
+  const handleOpenFolder = useCallback(async () => {
     try {
       setIsSelecting(true);
       const { open } = await import('@tauri-apps/plugin-dialog');
@@ -56,9 +61,6 @@ const WelcomeScene: React.FC = () => {
         title: t('startup.selectWorkspaceDirectory'),
       });
       if (selected && typeof selected === 'string') {
-        if (preferredMode) {
-          sessionStorage.setItem('bitfun:flowchat:preferredMode', preferredMode);
-        }
         await openWorkspace(selected);
         openScene('session' as SceneTabId);
       }
@@ -68,47 +70,6 @@ const WelcomeScene: React.FC = () => {
       setIsSelecting(false);
     }
   }, [openWorkspace, openScene, t]);
-
-  const handleNewCodeSession = useCallback(async () => {
-    try {
-      if (hasWorkspace) {
-        const flowChatManager = FlowChatManager.getInstance();
-        await flowChatManager.createChatSession({});
-        openScene('session' as SceneTabId);
-        return;
-      }
-      await handleOpenFolder();
-    } catch (e) {
-      log.error('Failed to create code session', e);
-    }
-  }, [hasWorkspace, openScene, handleOpenFolder]);
-
-  const handleNewCoworkSession = useCallback(async () => {
-    try {
-      if (hasWorkspace) {
-        const flowChatManager = FlowChatManager.getInstance();
-        await flowChatManager.createChatSession({}, 'Cowork');
-        openScene('session' as SceneTabId);
-        return;
-      }
-      await handleOpenFolder('Cowork');
-    } catch (e) {
-      log.error('Failed to create cowork session', e);
-    }
-  }, [hasWorkspace, openScene, handleOpenFolder]);
-
-  const handleNewClawSession = useCallback(async () => {
-    try {
-      if (!hasWorkspace) {
-        return;
-      }
-      const flowChatManager = FlowChatManager.getInstance();
-      await flowChatManager.createChatSession({}, 'Claw');
-      openScene('session' as SceneTabId);
-    } catch (e) {
-      log.error('Failed to create claw session', e);
-    }
-  }, [hasWorkspace, openScene]);
 
   const handleNewProject = useCallback(() => {
     window.dispatchEvent(new Event('nav:new-project'));
@@ -138,160 +99,21 @@ const WelcomeScene: React.FC = () => {
     }
   }, [t]);
 
-  if (hasWorkspace) {
-    return (
-      <div className="welcome-scene">
-        <div className="welcome-scene__content">
-
-          {/* Greeting */}
-          <div className="welcome-scene__greeting">
-            <div className="welcome-scene__greeting-inner">
-              <div className="welcome-scene__panda" aria-hidden="true">
-                <img src="/panda_full_1.png" className="welcome-scene__panda-frame welcome-scene__panda-frame--1" alt="" />
-                <img src="/panda_full_2.png" className="welcome-scene__panda-frame welcome-scene__panda-frame--2" alt="" />
-              </div>
-              <div className="welcome-scene__greeting-text">
-                <p className="welcome-scene__greeting-label">{t('welcomeScene.welcomeBack')}</p>
-                <div className="welcome-scene__title-row">
-                  <h1 className="welcome-scene__workspace-title">{workspaceDisplayName}</h1>
-                  {isRepository && currentBranch && (
-                    <span className="welcome-scene__meta-tag">
-                      <GitBranch size={11} />
-                      <span>{currentBranch}</span>
-                    </span>
-                  )}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="welcome-scene__divider" />
-
-          {/* Session actions */}
-          <div className="welcome-scene__sessions">
-            {isAssistantWorkspace ? (
-              <button className="welcome-scene__session-btn" onClick={handleNewClawSession}>
-                <Bot size={16} />
-                <div className="welcome-scene__session-btn-text">
-                  <span className="welcome-scene__session-btn-label">{t('welcomeScene.newClawSession')}</span>
-                  <span className="welcome-scene__session-btn-desc">{t('welcomeScene.newClawSessionDesc')}</span>
-                </div>
-              </button>
-            ) : (
-              <>
-                <button className="welcome-scene__session-btn" onClick={handleNewCodeSession}>
-                  <MessageSquare size={16} />
-                  <div className="welcome-scene__session-btn-text">
-                    <span className="welcome-scene__session-btn-label">{t('welcomeScene.newCodeSession')}</span>
-                    <span className="welcome-scene__session-btn-desc">{t('welcomeScene.newCodeSessionDesc')}</span>
-                  </div>
-                </button>
-
-                <button className="welcome-scene__session-btn" onClick={handleNewCoworkSession}>
-                  <Users size={16} />
-                  <div className="welcome-scene__session-btn-text">
-                    <span className="welcome-scene__session-btn-label">
-                      {t('welcomeScene.newCoworkSession')}
-                    </span>
-                    <span className="welcome-scene__session-btn-desc">{t('welcomeScene.newCoworkSessionDesc')}</span>
-                  </div>
-                </button>
-              </>
-            )}
-          </div>
-
-          {/* Switch workspace section */}
-          <div className="welcome-scene__switch">
-            <div className="welcome-scene__switch-header">
-              <span className="welcome-scene__section-label">
-                <Clock size={12} />
-                {t('welcomeScene.recentWorkspaces')}
-              </span>
-              <div className="welcome-scene__switch-actions">
-                <button
-                  className="welcome-scene__link-btn"
-                  onClick={() => void handleOpenFolder()}
-                  disabled={isSelecting}
-                >
-                  <FolderOpen size={12} />
-                  {t('welcomeScene.openOtherProject')}
-                </button>
-                <button className="welcome-scene__link-btn" onClick={handleNewProject}>
-                  <FolderPlus size={12} />
-                  {t('welcomeScene.newProject')}
-                </button>
-              </div>
-            </div>
-
-            {otherWorkspaces.length > 0 ? (
-              <div className="welcome-scene__recent-list">
-                {otherWorkspaces.map(ws => (
-                  <Tooltip key={ws.id} content={ws.rootPath} placement="right" followCursor>
-                    <button
-                      className="welcome-scene__recent-item"
-                      onClick={() => { void handleSwitchWorkspace(ws); }}
-                    >
-                      <FolderOpen size={13} />
-                      <span className="welcome-scene__recent-name">{ws.name}</span>
-                      <span className="welcome-scene__recent-time">{formatDate(ws.lastAccessed)}</span>
-                    </button>
-                  </Tooltip>
-                ))}
-              </div>
-            ) : (
-              <p className="welcome-scene__no-recent">{t('welcomeScene.noOtherWorkspaces')}</p>
-            )}
-          </div>
-
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="welcome-scene welcome-scene--first-time">
+    <div className="welcome-scene">
       <div className="welcome-scene__content">
-
-        {/* Logo + greeting */}
         <div className="welcome-scene__greeting">
-          <div className="welcome-scene__logo">
-            <img src="/Logo-ICON.png" alt="BitFun" className="welcome-scene__logo-img" />
-          </div>
-          <h1 className="welcome-scene__workspace-title">{t('welcomeScene.firstTime.title')}</h1>
-          <p className="welcome-scene__greeting-label">{t('welcomeScene.firstTime.subtitle')}</p>
+          <h1 className="welcome-scene__title">{t('welcomeScene.firstTime.title')}</h1>
+          <p className="welcome-scene__greeting-label">{welcomeMessage}</p>
         </div>
 
         <div className="welcome-scene__divider" />
 
-        {/* Session actions */}
-        <div className="welcome-scene__sessions">
-          <button className="welcome-scene__session-btn" onClick={handleNewCodeSession}>
-            <MessageSquare size={16} />
-            <div className="welcome-scene__session-btn-text">
-              <span className="welcome-scene__session-btn-label">{t('welcomeScene.newCodeSession')}</span>
-              <span className="welcome-scene__session-btn-desc">{t('welcomeScene.newCodeSessionDesc')}</span>
-            </div>
-          </button>
-
-          <button className="welcome-scene__session-btn" onClick={handleNewCoworkSession}>
-            <Users size={16} />
-            <div className="welcome-scene__session-btn-text">
-              <span className="welcome-scene__session-btn-label">
-                {t('welcomeScene.newCoworkSession')}
-              </span>
-              <span className="welcome-scene__session-btn-desc">
-                {t('welcomeScene.newCoworkSessionDesc')}
-              </span>
-            </div>
-          </button>
-        </div>
-
-        {/* Workspace section: hint + open/new actions */}
-        <div className="welcome-scene__switch">
+        <section className="welcome-scene__switch">
           <div className="welcome-scene__switch-header">
             <span className="welcome-scene__section-label">
-              <FolderOpen size={12} />
-              {t('welcomeScene.firstTime.noWorkspaceHint')}
+              <Clock size={12} />
+              {t('welcomeScene.recentWorkspaces')}
             </span>
             <div className="welcome-scene__switch-actions">
               <button
@@ -300,18 +122,18 @@ const WelcomeScene: React.FC = () => {
                 disabled={isSelecting}
               >
                 <FolderOpen size={12} />
-                {t('welcomeScene.firstTime.openProject')}
+                {t('welcomeScene.openOtherProject')}
               </button>
               <button className="welcome-scene__link-btn" onClick={handleNewProject}>
                 <FolderPlus size={12} />
-                {t('welcomeScene.firstTime.newProject')}
+                {t('welcomeScene.newProject')}
               </button>
             </div>
           </div>
 
-          {recentWorkspaces.length > 0 && (
+          {displayRecentWorkspaces.length > 0 ? (
             <div className="welcome-scene__recent-list">
-              {recentWorkspaces.slice(0, 5).map(ws => (
+              {displayRecentWorkspaces.map(ws => (
                 <Tooltip key={ws.id} content={ws.rootPath} placement="right" followCursor>
                   <button
                     className="welcome-scene__recent-item"
@@ -324,8 +146,10 @@ const WelcomeScene: React.FC = () => {
                 </Tooltip>
               ))}
             </div>
+          ) : (
+            <p className="welcome-scene__no-recent">{t('welcomeScene.noRecentWorkspaces')}</p>
           )}
-        </div>
+        </section>
 
       </div>
     </div>

--- a/src/web-ui/src/flow_chat/components/ChatInput.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInput.scss
@@ -62,7 +62,7 @@
   
   &--collapsed {
     cursor: pointer;
-    max-width: 480px;
+    max-width: 300px;
     margin: 0 auto;
     
     .bitfun-chat-input__box {
@@ -119,7 +119,7 @@
       .rich-text-input {
         min-height: 24px !important;
         max-height: 24px !important;
-        max-width: min(100%, calc(100% - 132px));
+        max-width: 100%;
         font-size: 14px;
         line-height: 24px;
         overflow: hidden;
@@ -138,6 +138,24 @@
           width: 100%;
         }
       }
+
+      .bitfun-chat-input__space-hint {
+        display: inline-flex;
+        position: absolute;
+        inset: 0;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        width: 100%;
+        font-size: 13px;
+        line-height: 24px;
+        color: var(--color-text-muted);
+        opacity: 0.62;
+        white-space: nowrap;
+        pointer-events: none;
+        letter-spacing: 0.01em;
+        animation: bitfun-space-hint-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) 0.32s both;
+      }
     }
     
     .bitfun-chat-input__actions {
@@ -147,27 +165,8 @@
       margin: 0;
     }
 
-    .bitfun-chat-input__space-hint {
-      display: flex;
-      position: absolute;
-      top: 50%;
-      right: 16px;
-      align-items: center;
-      gap: 6px;
-      flex-shrink: 0;
-      font-size: 11px;
-      color: var(--color-text-muted);
-      opacity: 0.5;
-      white-space: nowrap;
-      pointer-events: none;
-      letter-spacing: 0.01em;
-      transform: translateY(-50%);
-      transform-origin: center center;
-      animation: bitfun-space-hint-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) 0.32s both;
-    }
-
     &:hover .bitfun-chat-input__space-hint {
-      opacity: 0.75;
+      opacity: 0.9;
     }
   }
 
@@ -176,26 +175,15 @@
   }
 
   &__space-key {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 32px;
-    height: 18px;
-    padding: 0 7px;
-    border-radius: 999px;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    background: rgba(255, 255, 255, 0.04);
+    display: inline-block;
+    padding: 0 4px;
     color: var(--color-text-secondary);
-    font-size: 9px;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  }
-
-  &__space-hint-text {
-    display: inline-flex;
-    align-items: center;
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    background: transparent;
+    border: none;
+    box-shadow: none;
   }
   
   &--active {
@@ -1338,10 +1326,10 @@
 @keyframes bitfun-space-hint-pop {
   0% {
     opacity: 0;
-    transform: scale(0.6);
+    transform: scale(0.92);
   }
   100% {
-    opacity: 0.5;
+    opacity: 0.62;
     transform: scale(1);
   }
 }

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useRef, useCallback, useEffect, useReducer, useState, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { ArrowUp, Image, Network, ChevronsUp, ChevronsDown, RotateCcw, FileText } from 'lucide-react';
 import { ContextDropZone, useContextStore } from '../../shared/context-system';
 import { useActiveSessionState } from '../hooks/useActiveSessionState';
@@ -1436,13 +1436,25 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 onKeyDown={handleKeyDown}
                 onCompositionStart={handleImeCompositionStart}
                 onCompositionEnd={handleImeCompositionEnd}
-                placeholder={t('input.placeholder')}
+                placeholder={inputState.isActive ? t('input.placeholder') : ''}
                 disabled={false}
                 contexts={contexts}
                 onRemoveContext={removeContext}
                 onMentionStateChange={setMentionState}
                 data-testid="chat-input-textarea"
               />
+
+              {!inputState.isActive && (
+                <span className="bitfun-chat-input__space-hint">
+                  <Trans
+                    i18nKey="input.spaceToActivate"
+                    t={t}
+                    components={{
+                      space: <span className="bitfun-chat-input__space-key" />,
+                    }}
+                  />
+                </span>
+              )}
               
               <FileMentionPicker
                 isOpen={mentionState.isActive}
@@ -1591,15 +1603,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             )}
             </div>
             
-            {!inputState.isActive && (
-              <span className="bitfun-chat-input__space-hint">
-                <span className="bitfun-chat-input__space-key" aria-hidden="true">Space</span>
-                <span className="bitfun-chat-input__space-hint-text">
-                  {t('input.spaceToActivate')}
-                </span>
-              </span>
-            )}
-
             <IconButton
               className="bitfun-chat-input__expand-button"
               variant="ghost"

--- a/src/web-ui/src/flow_chat/services/BtwThreadService.ts
+++ b/src/web-ui/src/flow_chat/services/BtwThreadService.ts
@@ -273,76 +273,6 @@ export async function startBtwThread(params: {
 
       cleanup();
 
-      // Persist the /btw dialog into the child session as turn-0000.
-      const now = Date.now();
-      const turnData: import('@/shared/types/session-history').DialogTurnData = {
-        turnId: `btw-turn-${requestId}`,
-        turnIndex: 0,
-        sessionId: childSessionId,
-        timestamp: now,
-        userMessage: {
-          id: `btw-user-${requestId}`,
-          content: question,
-          timestamp: now,
-          metadata: {
-            kind: 'btw',
-            parentSessionId,
-            parentRequestId: requestId,
-            parentDialogTurnId: parentDialogTurnId ?? null,
-            parentTurnIndex: parentTurnIndex ?? null,
-          },
-        },
-        modelRounds: [
-          {
-            id: `btw-round-${requestId}`,
-            turnId: `btw-turn-${requestId}`,
-            roundIndex: 0,
-            timestamp: now,
-            startTime: now,
-            endTime: now,
-            status: 'completed',
-            textItems: [
-              {
-                id: `btw-text-${requestId}`,
-                content: fullText,
-                isStreaming: false,
-                timestamp: now,
-              } as any,
-            ],
-            toolItems: [],
-            thinkingItems: [],
-          } as any,
-        ],
-        startTime: now,
-        endTime: now,
-        durationMs: 0,
-        status: 'completed',
-      };
-
-      try {
-        await sessionAPI.saveSessionTurn(turnData, workspacePath);
-
-        const childSession = flowChatStore.getState().sessions.get(childSessionId);
-        if (childSession) {
-          const meta = await loadSessionMetadataWithRetry(childSessionId, workspacePath, {
-            retries: 3,
-            delayMs: 80,
-          });
-          await sessionAPI.saveSessionMetadata(
-            buildSessionMetadata(childSession, meta ?? undefined),
-            workspacePath
-          );
-        }
-      } catch (e) {
-        log.error('Failed to persist btw child turn', { childSessionId, e });
-      }
-
-      // Sync backend session state with persisted turns to avoid turn-index collisions on follow-ups.
-      try {
-        await agentAPI.restoreSession(childSessionId, workspacePath);
-      } catch (e) {
-        log.warn('Failed to restore btw child session after persistence', { childSessionId, e });
-      }
     }
   );
 
@@ -377,9 +307,13 @@ export async function startBtwThread(params: {
     await btwAPI.askStream({
       requestId,
       sessionId: parentSessionId,
+      childSessionId,
+      workspacePath,
       question,
       modelId: params.modelId ?? 'fast',
       maxContextMessages: params.maxContextMessages ?? 60,
+      parentDialogTurnId,
+      parentTurnIndex,
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/src/web-ui/src/infrastructure/api/service-api/BtwAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/BtwAPI.ts
@@ -16,6 +16,10 @@ export interface BtwAskResponse {
 
 export interface BtwAskStreamRequest extends BtwAskRequest {
   requestId: string;
+  childSessionId?: string;
+  workspacePath?: string;
+  parentDialogTurnId?: string;
+  parentTurnIndex?: number;
 }
 
 export interface BtwAskStreamResponse {

--- a/src/web-ui/src/infrastructure/api/service-api/GlobalAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/GlobalAPI.ts
@@ -210,6 +210,14 @@ export class GlobalAPI {
     }
   }
 
+  async cleanupInvalidWorkspaces(): Promise<number> {
+    try {
+      return await api.invoke('cleanup_invalid_workspaces');
+    } catch (error) {
+      throw createTauriCommandError('cleanup_invalid_workspaces', error);
+    }
+  }
+
   async getOpenedWorkspaces(): Promise<WorkspaceInfo[]> {
     try {
       return await api.invoke('get_opened_workspaces', {

--- a/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
+++ b/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
@@ -337,6 +337,7 @@ class WorkspaceManager {
 
       const initResult = await globalStateAPI.initializeGlobalState();
       log.debug('Backend initialization completed', { result: initResult });
+      await globalStateAPI.cleanupInvalidWorkspaces();
 
       const [recentWorkspaces, openedWorkspaces, currentWorkspace] = await Promise.all([
         globalStateAPI.getRecentWorkspaces(),
@@ -714,6 +715,37 @@ class WorkspaceManager {
       log.debug('Recent workspaces refreshed', { count: recentWorkspaces.length });
     } catch (error) {
       log.error('Failed to refresh recent workspaces', { error });
+    }
+  }
+
+  public async cleanupInvalidWorkspaces(): Promise<number> {
+    try {
+      const removedCount = await globalStateAPI.cleanupInvalidWorkspaces();
+
+      if (removedCount === 0) {
+        return 0;
+      }
+
+      const [currentWorkspace, recentWorkspaces, openedWorkspaces] = await Promise.all([
+        globalStateAPI.getCurrentWorkspace(),
+        globalStateAPI.getRecentWorkspaces(),
+        globalStateAPI.getOpenedWorkspaces(),
+      ]);
+
+      this.updateWorkspaceState(
+        currentWorkspace,
+        recentWorkspaces,
+        openedWorkspaces,
+        false,
+        null
+      );
+      this.emit({ type: 'workspace:active-changed', workspace: currentWorkspace });
+
+      log.info('Invalid workspaces cleaned up', { removedCount });
+      return removedCount;
+    } catch (error) {
+      log.error('Failed to cleanup invalid workspaces', { error });
+      throw error;
     }
   }
 

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -658,12 +658,43 @@
     "welcomeBack": "Welcome back to",
     "welcomeTabTitle": "Welcome",
     "quickStart": "Start",
+    "heroBadge": "BitFun Workspace",
+    "heroTitle": "A real workspace, not just a chat box",
+    "heroDescription": "An AI assistant with personality, memory, and real execution power. Sessions, agent teams, and mini apps all work around the same workflow, so AI is doing work, not just replying.",
     "newCodeSession": "New Code Session",
-    "newCodeSessionDesc": "For everyday coding, Q&A and debugging",
+    "newCodeSessionDesc": "Start coding, debug issues, or open a project and jump straight into building",
     "newCoworkSession": "New Cowork Session",
-    "newCoworkSessionDesc": "Suitable for assisting with everyday work",
+    "newCoworkSessionDesc": "Great for clarifying requests, moving tasks forward, drafting content, and everyday collaboration",
     "newClawSession": "New Claw Session",
-    "newClawSessionDesc": "Personal assistant session with a dedicated assistant workspace",
+    "newClawSessionDesc": "Enter your personal assistant workspace and keep context and preferences over time",
+    "assistantEntryLabel": "Personal Assistant",
+    "assistantEntryTitle": "BitFun can be your assistant too, not only your project workspace",
+    "assistantEntryDescription": "You do not need to pick a project first. Enter the assistant workspace to chat, organize thoughts, draft writing, or let the assistant keep moving your tasks forward.",
+    "assistantEntryAction": "Enter Assistant Mode",
+    "assistantHint": "Besides Code and Cowork, you can also jump straight into assistant mode for thinking, drafting, and everyday collaboration outside project work.",
+    "workspaceSectionTitle": "Projects and Workspaces",
+    "workspaceSectionHint": "Open a project to start Code or Cowork, or switch to one of your recent workspaces.",
+    "noRecentWorkspaces": "No recent workspaces yet",
+    "messages": {
+      "message1": "Welcome back. Let's turn another idea into something real.",
+      "message2": "Hi. Feels like a good day to build something fun.",
+      "message3": "Your creative partner is online and ready to work.",
+      "message4": "Welcome to BitFun. Let's make something interesting."
+    },
+    "features": {
+      "workspace": {
+        "title": "AI in action",
+        "description": "Thinking chains, terminal commands, code diffs, and planning all show up live so the process stays transparent."
+      },
+      "team": {
+        "title": "Your AI team",
+        "description": "Set up Code, Cowork, and other agents for different jobs, then let them collaborate on more complex tasks."
+      },
+      "assistant": {
+        "title": "An assistant that keeps growing",
+        "description": "The assistant workspace keeps context and personal preferences, making it fit for thinking, writing, and everyday collaboration."
+      }
+    },
     "comingSoon": "Coming Soon",
     "recentWorkspaces": "Switch Workspace",
     "openOtherProject": "Open",

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -122,7 +122,7 @@
     "willSendAfterStop": "Will send after stop",
     "openWorkspaceFolder": "Open workspace folder",
     "openWorkspaceFolderFailed": "Failed to open workspace folder: {{error}}",
-    "spaceToActivate": "Space to type"
+    "spaceToActivate": "Press <space>Space</space> to tell me what you'd like to do"
   },
   "context": {
     "title": "Context",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -658,12 +658,43 @@
     "welcomeBack": "欢迎回到",
     "welcomeTabTitle": "欢迎使用",
     "quickStart": "开始",
+    "heroBadge": "BitFun Workspace",
+    "heroTitle": "真实工作台，而不只是一个聊天框",
+    "heroDescription": "有个性，有记忆，帮你做事的 AI 助理。会话流、Agent 团队与小应用围绕同一个工作流协同展开，AI 在做事，不只是回答。",
     "newCodeSession": "新建 Code 会话",
-    "newCodeSessionDesc": "适合日常编码、问答与调试",
+    "newCodeSessionDesc": "开始代码任务、调试问题，或打开一个项目进入开发状态",
     "newCoworkSession": "新建 Cowork 会话",
-    "newCoworkSessionDesc": "适合协助日常工作",
+    "newCoworkSessionDesc": "适合整理需求、推进任务、起草内容和日常协作",
     "newClawSession": "新建 Claw 会话",
-    "newClawSessionDesc": "个人助理专属会话，使用独立助理工作区",
+    "newClawSessionDesc": "进入个人助理工作区，延续上下文与偏好持续协作",
+    "assistantEntryLabel": "个人助理",
+    "assistantEntryTitle": "除了项目工作流，你也可以直接使用 BitFun 助理",
+    "assistantEntryDescription": "不用先选项目。进入助理工作区后，可以直接聊天、整理思路、起草文字，或让助理持续跟进你的任务。",
+    "assistantEntryAction": "进入助理模式",
+    "assistantHint": "除了 Code 和 Cowork，你也可以直接进入助理模式，处理项目之外的整理、起草和日常协作。",
+    "workspaceSectionTitle": "项目与工作区",
+    "workspaceSectionHint": "打开项目开始 Code 或 Cowork，也可以切换到最近使用的工作区。",
+    "noRecentWorkspaces": "暂无最近工作区",
+    "messages": {
+      "message1": "欢迎回来，继续把想法变成现实。",
+      "message2": "嗨，今天也来整点好玩的。",
+      "message3": "你的创作搭子已上线，随时开工。",
+      "message4": "欢迎使用 BitFun，开始做点有意思的事。"
+    },
+    "features": {
+      "workspace": {
+        "title": "AI 在做事",
+        "description": "思考链、终端命令、代码差异与任务规划都会实时出现，过程透明，不只是回答。"
+      },
+      "team": {
+        "title": "你的 AI 团队",
+        "description": "为不同场景配置 Code、Cowork 和更多 Agent，让它们分工协作，完成复杂任务。"
+      },
+      "assistant": {
+        "title": "助理会持续成长",
+        "description": "助理工作区会保留上下文和个人偏好，适合整理思路、起草内容和日常协作。"
+      }
+    },
     "comingSoon": "即将推出",
     "recentWorkspaces": "切换工作区",
     "openOtherProject": "打开",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -122,7 +122,7 @@
     "willSendAfterStop": "将在停止后发送",
     "openWorkspaceFolder": "打开工作区文件夹",
     "openWorkspaceFolderFailed": "打开工作区文件夹失败：{{error}}",
-    "spaceToActivate": "空格激活"
+    "spaceToActivate": "按<space>空格键</space>说说你想做什么"
   },
   "context": {
     "title": "上下文",

--- a/src/web-ui/src/shared/types/global-state.ts
+++ b/src/web-ui/src/shared/types/global-state.ts
@@ -148,6 +148,7 @@ export interface GlobalStateAPI {
   getCurrentWorkspace(): Promise<WorkspaceInfo | null>;
   getOpenedWorkspaces(): Promise<WorkspaceInfo[]>;
   getRecentWorkspaces(): Promise<WorkspaceInfo[]>;
+  cleanupInvalidWorkspaces(): Promise<number>;
   scanWorkspaceInfo(workspacePath: string): Promise<WorkspaceInfo | null>;
   
   
@@ -330,6 +331,10 @@ export function createGlobalStateAPI(): GlobalStateAPI {
       const workspaces = (await globalAPI.getRecentWorkspaces()).map(mapWorkspaceInfo);
       logger.debug('getRecentWorkspaces returned', workspaces);
       return workspaces;
+    },
+
+    async cleanupInvalidWorkspaces(): Promise<number> {
+      return await globalAPI.cleanupInvalidWorkspaces();
     },
 
     async scanWorkspaceInfo(workspacePath: string): Promise<WorkspaceInfo | null> {


### PR DESCRIPTION

- Move /btw side-question turn persistence from frontend to Rust backend: add persist_btw_turn to SessionManager and Coordinator, expose via BtwAskStreamRequest and remove inline saveSessionTurn logic from BtwThreadService
- Add per-workspace mutex (SESSION_INDEX_LOCKS) in PersistenceManager to prevent session-index races; detect and rebuild stale index entries; fix metadata-before-write ordering in save_dialog_turn
- Add cleanup_invalid_workspaces Tauri command and save workspace data after cleanup in workspace service; call it on app startup in workspaceManager
- Refactor WelcomeScene into a single unified view, removing has-workspace / first-time split, panda mascot, session-type buttons, and git branch tag; update locales (en-US / zh-CN) accordingly
- Minor UI polish: NavPanel, SplashScreen, PersonaView, ChatInput styles