### PR TITLE
feat: add Code/Cowork session options and fix copy button position

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -345,7 +345,6 @@ $_section-header-height: 24px;
     &--split-right {
       border-top-right-radius: $size-radius-base;
       border-bottom-right-radius: $size-radius-base;
-      color: color-mix(in srgb, var(--color-accent-500) 84%, var(--color-text-secondary));
 
       &:hover {
         color: var(--color-text-primary);

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -198,14 +198,14 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
     }
   }, [t, workspace.rootPath]);
 
-  const handleCreateSession = useCallback(async () => {
+  const handleCreateSession = useCallback(async (mode?: 'agentic' | 'Cowork' | 'Claw') => {
     setMenuOpen(false);
     try {
       await flowChatManager.createChatSession(
         {
           workspacePath: workspace.rootPath,
         },
-        workspace.workspaceKind === WorkspaceKind.Assistant ? 'Claw' : undefined
+        mode ?? (workspace.workspaceKind === WorkspaceKind.Assistant ? 'Claw' : undefined)
       );
       await setActiveWorkspace(workspace.id);
     } catch (error) {
@@ -215,6 +215,14 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
       );
     }
   }, [setActiveWorkspace, t, workspace.id, workspace.rootPath, workspace.workspaceKind]);
+
+  const handleCreateCodeSession = useCallback(() => {
+    void handleCreateSession('agentic');
+  }, [handleCreateSession]);
+
+  const handleCreateCoworkSession = useCallback(() => {
+    void handleCreateSession('Cowork');
+  }, [handleCreateSession]);
 
   const handleCreateWorktree = useCallback(async (result: BranchSelectResult) => {
     try {
@@ -327,10 +335,23 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
             role="menu"
             style={{ top: `${menuPosition.top}px`, left: `${menuPosition.left}px` }}
           >
-            <button type="button" className="bitfun-nav-panel__workspace-item-menu-item" onClick={() => { void handleCreateSession(); }}>
-              <Plus size={13} />
-              <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.newSession')}</span>
-            </button>
+            {workspace.workspaceKind === WorkspaceKind.Assistant ? (
+              <button type="button" className="bitfun-nav-panel__workspace-item-menu-item" onClick={() => { void handleCreateSession(); }}>
+                <Plus size={13} />
+                <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.newSession')}</span>
+              </button>
+            ) : (
+              <>
+                <button type="button" className="bitfun-nav-panel__workspace-item-menu-item" onClick={handleCreateCodeSession}>
+                  <Plus size={13} />
+                  <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.newCodeSession')}</span>
+                </button>
+                <button type="button" className="bitfun-nav-panel__workspace-item-menu-item" onClick={handleCreateCoworkSession}>
+                  <Plus size={13} />
+                  <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.newCoworkSession')}</span>
+                </button>
+              </>
+            )}
             {workspace.workspaceKind !== WorkspaceKind.Assistant && (
               <button
                 type="button"

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.scss
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.scss
@@ -259,8 +259,8 @@
 
 .markdown-renderer .copy-button {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 0.35rem;
+  transform: none;
   right: 0.75rem;
   padding: 0.5rem;
   background: transparent;
@@ -290,12 +290,25 @@
 .markdown-renderer .copy-button:hover {
   background: transparent;
   color: #3b82f6;
-  transform: translateY(-50%) scale(1.1);
+  transform: scale(1.1);
 }
 
 .markdown-renderer .copy-button:active {
-  transform: translateY(-50%) scale(1);
+  transform: scale(1);
   color: #2563eb;
+}
+
+.markdown-renderer .code-block-wrapper--single-line .copy-button {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.markdown-renderer .code-block-wrapper--single-line .copy-button:hover {
+  transform: translateY(-50%) scale(1.1);
+}
+
+.markdown-renderer .code-block-wrapper--single-line .copy-button:active {
+  transform: translateY(-50%) scale(1);
 }
 
 

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
@@ -387,7 +387,7 @@ export const Markdown = React.memo<MarkdownProps>(({
       const normalizedLang = getPrismLanguageFromAlias(language);
       
       return (
-        <div className="code-block-wrapper">
+        <div className={`code-block-wrapper${hasMultipleLines ? '' : ' code-block-wrapper--single-line'}`}>
           <CopyButton code={code} />
           <SyntaxHighlighter
             language={normalizedLang}

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -190,6 +190,8 @@
       "actions": {
         "more": "More actions",
         "newSession": "New session",
+        "newCodeSession": "New Code session",
+        "newCoworkSession": "New Cowork session",
         "newAssistant": "New personal assistant",
         "deleteAssistant": "Delete personal assistant",
         "resetWorkspace": "Reset workspace",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -190,6 +190,8 @@
       "actions": {
         "more": "更多操作",
         "newSession": "新建会话",
+        "newCodeSession": "新建 Code 会话",
+        "newCoworkSession": "新建 Cowork 会话",
         "newAssistant": "新建个人助理",
         "deleteAssistant": "删除个人助理",
         "resetWorkspace": "重置工作区",


### PR DESCRIPTION
## Changes
- Add New Code session and New Cowork session menu items in WorkspaceItem for non-Assistant workspaces
- Support explicit mode param in handleCreateSession for agentic / Cowork / Claw
- Remove forced color on split-right button in NavPanel
- Fix copy button position for multi-line code blocks\n- Keep vertically centered copy button for single-line code blocks via code-block-wrapper--single-line CSS class
- Add i18n keys newCodeSession / newCoworkSession (en-US, zh-CN)