### PR TITLE
feat(ui): add Beta badge to Assistant mode and MiniApp entry

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/MainNav.tsx
+++ b/src/web-ui/src/app/components/NavPanel/MainNav.tsx
@@ -14,7 +14,7 @@
 import React, { useCallback, useState, useMemo, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Plus, FolderOpen, FolderPlus, History, Check, Bot } from 'lucide-react';
-import { Tooltip } from '@/component-library';
+import { Badge, Tooltip } from '@/component-library';
 import { useApp } from '../../hooks/useApp';
 import { useSceneManager } from '../../hooks/useSceneManager';
 import { useNavSceneStore } from '../../stores/navSceneStore';
@@ -616,7 +616,6 @@ const MainNav: React.FC<MainNavProps> = ({
   return (
     <>
       <div className="bitfun-nav-panel__workspace-toolbar">
-        <Tooltip content={navModeHint} placement="right" followCursor>
           <button
             type="button"
             className={[
@@ -653,7 +652,10 @@ const MainNav: React.FC<MainNavProps> = ({
               )}
             </span>
             <span className="bitfun-nav-panel__mode-switch-copy">
-              <span className="bitfun-nav-panel__mode-switch-label">{navModeLabel}</span>
+              <span className="bitfun-nav-panel__mode-switch-label">
+                {navModeLabel}
+                {isAssistantNavMode && <Badge variant="neutral">Beta</Badge>}
+              </span>
               <span className="bitfun-nav-panel__mode-switch-sub">
                 <span className="bitfun-nav-panel__mode-switch-desc">
                   <span className="bitfun-nav-panel__mode-switch-desc-main">{navModeDesc}</span>
@@ -662,7 +664,6 @@ const MainNav: React.FC<MainNavProps> = ({
               </span>
             </span>
           </button>
-        </Tooltip>
         <div className="bitfun-nav-panel__workspace-create-group">
           {isAssistantNavMode ? (
             <Tooltip content={createSessionTooltip} placement="right" followCursor>

--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -231,6 +231,9 @@ $_section-header-height: 24px;
   }
 
   &__mode-switch-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     font-size: 13px;
     font-weight: 600;
     line-height: 1.15;

--- a/src/web-ui/src/app/components/NavPanel/components/MiniAppEntry.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/MiniAppEntry.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { Boxes } from 'lucide-react';
-import { Tooltip } from '@/component-library';
+import { Badge, Tooltip } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
 import { useMiniAppStore } from '@/app/scenes/miniapps/miniAppStore';
 import { renderMiniAppIcon, getMiniAppIconGradient } from '@/app/scenes/miniapps/utils/miniAppIcons';
@@ -70,6 +70,7 @@ const MiniAppEntry: React.FC<MiniAppEntryProps> = ({
           </span>
           <span className="bitfun-nav-panel__miniapp-entry-copy">
             <span className="bitfun-nav-panel__miniapp-entry-title">{t('scenes.miniApps')}</span>
+            <Badge variant="neutral">Beta</Badge>
           </span>
         </span>
 

--- a/src/web-ui/src/flow_chat/components/ChatInput.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInput.scss
@@ -61,7 +61,7 @@
   transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
   
   &--collapsed {
-    cursor: pointer;
+    cursor: text;
     max-width: 300px;
     margin: 0 auto;
     
@@ -70,6 +70,7 @@
       max-height: 42px;
       padding: 0 18px;
       border-radius: 999px;
+      cursor: text;
       background: rgba(18, 18, 28, 0.22);
       border: 1px solid rgba(255, 255, 255, 0.1);
       backdrop-filter: blur(8px);


### PR DESCRIPTION
- Add Beta badge next to Assistant nav mode label in MainNav
- Add Beta badge next to MiniApps entry title in MiniAppEntry
- Remove Tooltip wrapper from mode switch button
- Fix ChatInput collapsed state cursor to use text instead of pointer

Generated with BitFun

Co-Authored-By: BitFun