### PR TITLE
fix: align nav resize divider to visual gap between nav and scene areas

### DIFF
--- a/src/web-ui/src/app/layout/WorkspaceBody.scss
+++ b/src/web-ui/src/app/layout/WorkspaceBody.scss
@@ -71,11 +71,11 @@ $_nav-collapsed-width: 80px;
 .bitfun-workspace-body__nav-divider {
   position: absolute;
   top: 0;
-  right: -4px;
+  left: calc(#{$size-gap-2} + var(--nav-width, #{$_nav-width}));
   width: 8px;
   height: 100%;
   cursor: ew-resize;
-  z-index: 2;
+  z-index: 10;
 
   &::after {
     content: '';

--- a/src/web-ui/src/app/layout/WorkspaceBody.tsx
+++ b/src/web-ui/src/app/layout/WorkspaceBody.tsx
@@ -105,15 +105,18 @@ const WorkspaceBody: React.FC<WorkspaceBodyProps> = ({
       >
         <NavBar onExpandNav={toggleLeftPanel} onMaximize={onMaximize} />
         <NavPanel className="bitfun-workspace-body__nav-panel" />
-        {!isNavCollapsed && (
-          <div
-            className="bitfun-workspace-body__nav-divider"
-            onMouseDown={handleNavCollapseDragStart}
-            role="separator"
-            aria-hidden="true"
-          />
-        )}
       </div>
+
+      {/* Resize divider — placed at workspace-body level to avoid overflow:hidden clipping */}
+      {!isNavCollapsed && (
+        <div
+          className="bitfun-workspace-body__nav-divider"
+          style={{ '--nav-width': `${navWidth}px` } as React.CSSProperties}
+          onMouseDown={handleNavCollapseDragStart}
+          role="separator"
+          aria-hidden="true"
+        />
+      )}
 
       {/* Right: scene tab bar + scene content */}
       <div className="bitfun-workspace-body__scene-area">


### PR DESCRIPTION
## 问题
左侧导航拖拽调节尺寸的可点击区域与视觉上看到的分隔线位置不一致，偏左。
- 根本原因\n\n.bitfun-workspace-body__nav-divider 原本放在 .bitfun-workspace-body__nav-area 内部，使用 position: absolute; right: -4px 定位。但 nav-area 设置了 overflow: hidden（用于折叠动画），导致超出边界的 4px 被裁切，实际可交互区域只剩内部的 4px，视觉上偏左。
- 修复\n\n- 将 divider 从 nav-area 内部移到 workspace-body 根层级，避免被 overflow: hidden 裁切\n- 改用 left: calc(\-gap-2 + var(--nav-width)) 精确对齐到 nav 和 scene 之间的 gap 中心