### PR TITLE
fix(chat-input): use flex centering for actions container instead of transform

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInput.scss
@@ -208,9 +208,11 @@
 
       .bitfun-chat-input__actions {
         position: absolute;
-        top: 50%;
+        top: 0;
         right: 14px;
-        transform: translateY(-50%);
+        bottom: 0;
+        display: flex;
+        align-items: center;
         z-index: 2;
       }
 


### PR DESCRIPTION
## Summary
- Replace `top: 50%; transform: translateY(-50%)` with `top: 0; bottom: 0; display: flex; align-items: center` for the `.bitfun-chat-input__actions` container
- Flex-based centering is more robust and avoids sub-pixel rendering issues that can occur with transform-based centering

## Test plan
- [ ] Verify the action buttons in ChatInput remain vertically centered
- [ ] Check alignment at different viewport sizes and input heights


Made with [Cursor](https://cursor.com)