### PR TITLE
fix: sync btw messages to in-memory caches to preserve conversation context

### DIFF
--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -988,8 +988,32 @@ impl SessionManager {
 
         drop(session);
 
+        // Persist the turn to disk
         self.persistence_manager
             .save_dialog_turn(workspace_path, &turn)
+            .await?;
+
+        // Sync messages to in-memory caches so subsequent对话 can access context
+        let user_message = Message::user(question.to_string())
+            .with_turn_id(turn_id.clone())
+            .with_semantic_kind(MessageSemanticKind::ActualUserInput);
+        let assistant_message = Message::assistant(full_text.to_string())
+            .with_turn_id(turn_id.clone());
+
+        // Add to MessageHistoryManager
+        self.history_manager
+            .add_message(child_session_id, user_message.clone())
+            .await?;
+        self.history_manager
+            .add_message(child_session_id, assistant_message.clone())
+            .await?;
+
+        // Add to CompressionManager
+        self.compression_manager
+            .add_message(child_session_id, user_message)
+            .await?;
+        self.compression_manager
+            .add_message(child_session_id, assistant_message)
             .await?;
 
         if let Some(mut session) = self.sessions.get_mut(child_session_id) {


### PR DESCRIPTION
## Fix: BTW continue flow loses previous conversation context

### Problem
When using the `/btw` conversation flow and then asking a follow-up question, the assistant behaves as if the previous conversation does not exist. The follow-up appears to start from a fresh context instead of continuing the existing conversation.

### Root Cause
In `persist_btw_turn` method (session_manager.rs), when a `/btw` conversation completes, although the `DialogTurnData` was saved to persistence layer, the user message and assistant response were **not** synced to the in-memory caches (`MessageHistoryManager` and `CompressionManager`).

When users send follow-up messages in the btw session, `get_context_messages` couldn't retrieve previous conversation context, making the conversation appear as a new empty session.

### Fix
After persisting the turn to disk, sync the user message and assistant response to both memory caches.

### Testing
- `cargo check -p bitfun-core` passes

Fixes #182