### PR TITLE
feat(web-ui): refine flow chat tool cards and chat input behavior

### DIFF
--- a/src/web-ui/src/component-library/components/Markdown/Markdown.scss
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.scss
@@ -210,7 +210,7 @@
 
 
 .markdown-renderer .inline-code {
-  padding: 0.2em 0.4em;
+  padding: 0.1em 0.4em;
   margin: 0 0.05em;
   font-size: 0.9em;
   background: rgba(255, 255, 255, 0.05);
@@ -224,6 +224,8 @@
   color: #a8b4c8;
   font-weight: 500;
   transition: all 0.15s ease;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 
 

--- a/src/web-ui/src/flow_chat/components/ChatInput.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInput.scss
@@ -580,8 +580,8 @@
     background: color-mix(in srgb, var(--color-text-muted) 14%, transparent);
 
     &--Plan {
-      background: rgba(6, 182, 212, 0.2);
-      color: rgba(14, 116, 144, 0.98);
+      background: rgba(245, 158, 11, 0.15);
+      color: rgba(180, 110, 0, 0.98);
     }
 
     &--debug {

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -184,6 +184,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   
   const setChatInputActive = useChatInputState(state => state.setActive);
   const setChatInputExpanded = useChatInputState(state => state.setExpanded);
+  const setChatInputHeight = useChatInputState(state => state.setInputHeight);
 
   useEffect(() => {
     const unsubscribe = FlowChatStore.getInstance().subscribe(setFlowChatState);
@@ -1328,10 +1329,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      // Do not collapse when clicking the scroll-to-latest bar.
+      if ((target as Element)?.closest?.('.scroll-to-latest-bar')) return;
       if (
         inputState.isActive &&
         containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
+        !containerRef.current.contains(target)
       ) {
         if (inputState.value.trim() === '') {
           dispatchInput({ type: 'DEACTIVATE' });
@@ -1344,6 +1348,19 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [inputState.isActive, inputState.value]);
+
+  useEffect(() => {
+    const dropZone = containerRef.current?.closest('.bitfun-chat-input-drop-zone') as HTMLElement | null;
+    const el = dropZone ?? containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      setChatInputHeight(el.offsetHeight);
+    });
+    observer.observe(el);
+    setChatInputHeight(el.offsetHeight);
+    return () => observer.disconnect();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   
   const renderActionButton = () => {
     if (!derivedState) return <IconButton className="bitfun-chat-input__send-button" disabled size="small"><ArrowUp size={11} /></IconButton>;

--- a/src/web-ui/src/flow_chat/components/PlannerButton.scss
+++ b/src/web-ui/src/flow_chat/components/PlannerButton.scss
@@ -23,8 +23,8 @@
   border-radius: 11px;
   
   // Default state without glass effect
-  background: rgba(59, 130, 246, 0.08);
-  border: 1px solid rgba(59, 130, 246, 0.2);
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.2);
   color: rgba(255, 255, 255, 0.7);
   box-shadow: none;
   backdrop-filter: none;
@@ -57,18 +57,18 @@
   // Hover: enable glass effect
   &:hover {
     background: linear-gradient(135deg,
-      rgba(59, 130, 246, 0.20) 0%,
-      rgba(96, 165, 250, 0.17) 30%,
-      rgba(59, 130, 246, 0.13) 60%,
-      rgba(59, 130, 246, 0.23) 100%
+      rgba(245, 158, 11, 0.20) 0%,
+      rgba(251, 191, 36, 0.17) 30%,
+      rgba(245, 158, 11, 0.13) 60%,
+      rgba(245, 158, 11, 0.23) 100%
     );
-    border-color: rgba(59, 130, 246, 0.5);
+    border-color: rgba(245, 158, 11, 0.5);
     color: var(--color-text-primary);
     box-shadow: 
-      0 10px 20px rgba(59, 130, 246, 0.25),
-      0 6px 12px rgba(96, 165, 250, 0.2),
+      0 10px 20px rgba(245, 158, 11, 0.2),
+      0 6px 12px rgba(251, 191, 36, 0.15),
       inset 0 1px 0 rgba(255, 255, 255, 0.25),
-      inset 0 -1px 0 rgba(59, 130, 246, 0.15);
+      inset 0 -1px 0 rgba(245, 158, 11, 0.15);
     backdrop-filter: blur(12px) saturate(1.2) brightness(1.05);
     -webkit-backdrop-filter: blur(12px) saturate(1.2) brightness(1.05);
     transform: translateY(-1px);
@@ -87,8 +87,8 @@
     width: 5px;
     height: 5px;
     border-radius: 50%;
-    background: rgba(59, 130, 246, 0.9);
-    box-shadow: 0 0 6px rgba(59, 130, 246, 0.6);
+    background: rgba(245, 158, 11, 0.9);
+    box-shadow: 0 0 6px rgba(245, 158, 11, 0.6);
     animation: bitfun-planner-button-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
     flex-shrink: 0;
     position: relative;

--- a/src/web-ui/src/flow_chat/components/ScrollToLatestBar.scss
+++ b/src/web-ui/src/flow_chat/components/ScrollToLatestBar.scss
@@ -12,8 +12,8 @@
   cursor: pointer;
   pointer-events: none;
   
-  // Default height: ChatInput active (box ~80px + bottom gap 16px = 96px, add 24px margin)
-  height: 120px;
+  // Default height: ChatInput active (box ~80px + bottom gap 16px = 96px, add 49px margin for content visibility)
+  height: 145px;
   
   transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1);
   
@@ -138,7 +138,7 @@
 // ========== Responsive tweaks ==========
 @media (max-width: 768px) {
   .scroll-to-latest-bar {
-    height: 110px;
+    height: 135px;
     
     &--input-collapsed {
       height: 70px;

--- a/src/web-ui/src/flow_chat/components/ScrollToLatestBar.tsx
+++ b/src/web-ui/src/flow_chat/components/ScrollToLatestBar.tsx
@@ -14,6 +14,8 @@ interface ScrollToLatestBarProps {
   isInputExpanded?: boolean;
   /** Whether ChatInput is active. */
   isInputActive?: boolean;
+  /** Measured height of the ChatInput container in pixels (0 if unknown). */
+  inputHeight?: number;
   className?: string;
 }
 
@@ -22,6 +24,7 @@ export const ScrollToLatestBar: React.FC<ScrollToLatestBarProps> = ({
   onClick,
   isInputExpanded = false,
   isInputActive = true,
+  inputHeight = 0,
   className = ''
 }) => {
   const { t } = useTranslation('flow-chat');
@@ -35,9 +38,17 @@ export const ScrollToLatestBar: React.FC<ScrollToLatestBarProps> = ({
       ? 'scroll-to-latest-bar--input-expanded' 
       : '';
 
+  // Dynamically offset the bar height based on measured ChatInput height.
+  // bottom: 16px (drop-zone offset) + inputHeight + 28px (content margin above input)
+  const dynamicStyle: React.CSSProperties =
+    isInputActive && !isInputExpanded && inputHeight > 0
+      ? { height: `${inputHeight + 16 + 28}px` }
+      : {};
+
   return (
     <div 
       className={`scroll-to-latest-bar ${inputStateClass} ${className}`}
+      style={dynamicStyle}
       onClick={onClick}
       role="button"
       tabIndex={0}

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
@@ -285,7 +285,13 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
                 />
               ));
             
-            case 'critical':
+            case 'critical': {
+              // If next group is the matching subagent, skip here — rendered by subagent case.
+              const nextGroup = groupedItems[groupIndex + 1];
+              const isTaskForSubagent = group.item.type === 'tool' &&
+                nextGroup?.type === 'subagent' &&
+                nextGroup.parentTaskToolId === group.item.id;
+              if (isTaskForSubagent) return null;
               return (
                 <FlowItemRenderer 
                   key={group.item.id}
@@ -295,9 +301,16 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
                   isLastItem={isLast}
                 />
               );
+            }
             
-            case 'subagent':
-              return (
+            case 'subagent': {
+              // If previous group is the matching task tool, wrap both in a unified card.
+              const prevGroup = groupedItems[groupIndex - 1];
+              const hasPairedTask = prevGroup?.type === 'critical' &&
+                prevGroup.item.type === 'tool' &&
+                group.parentTaskToolId === prevGroup.item.id;
+              
+              const subagentContainer = (
                 <SubagentItemsContainer 
                   key={`subagent-group-${group.parentTaskToolId}-${groupIndex}`}
                   parentTaskToolId={group.parentTaskToolId}
@@ -306,6 +319,22 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
                   roundId={round.id}
                 />
               );
+              
+              if (hasPairedTask) {
+                return (
+                  <div key={`task-with-subagent-${prevGroup.item.id}`} className="task-with-subagent-wrapper">
+                    <FlowItemRenderer
+                      item={prevGroup.item}
+                      turnId={turnId}
+                      roundId={round.id}
+                      isLastItem={false}
+                    />
+                    {subagentContainer}
+                  </div>
+                );
+              }
+              return subagentContainer;
+            }
             
             default:
               return null;

--- a/src/web-ui/src/flow_chat/components/modern/SubagentItems.scss
+++ b/src/web-ui/src/flow_chat/components/modern/SubagentItems.scss
@@ -1,52 +1,11 @@
 /**
  * Subagent items styles.
- * Controls visibility for subagent text and tool cards.
- * Blends with the TaskTool card design.
+ * When expanded, the subagent container merges with the task tool card header
+ * to form a single unified card with squared top corners.
  */
 
-// Subagent outer wrapper with relative positioning context.
 .subagent-items-wrapper {
   position: relative;
-  margin-top: -6px; // Counter the base-tool-card margin.
-  
-  // Top fade mask.
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 1px;
-    right: 1px;
-    height: 24px;
-    pointer-events: none;
-    z-index: 3;
-    background: linear-gradient(
-      to bottom,
-      var(--color-bg-flowchat, #121214) 0%,
-      color-mix(in srgb, var(--color-bg-flowchat, #121214) 80%, transparent) 40%,
-      color-mix(in srgb, var(--color-bg-flowchat, #121214) 40%, transparent) 70%,
-      transparent 100%
-    );
-  }
-  
-  // Bottom fade mask (inside the border).
-  &::after {
-    content: '';
-    position: absolute;
-    bottom: 1px;  // Avoid the bottom border.
-    left: 1px;
-    right: 1px;
-    height: 24px;
-    pointer-events: none;
-    z-index: 3;
-    border-radius: 0 0 7px 7px;
-    background: linear-gradient(
-      to top,
-      var(--color-bg-flowchat, #121214) 0%,
-      color-mix(in srgb, var(--color-bg-flowchat, #121214) 80%, transparent) 40%,
-      color-mix(in srgb, var(--color-bg-flowchat, #121214) 40%, transparent) 70%,
-      transparent 100%
-    );
-  }
 }
 
 .subagent-items-wrapper--collapsed {
@@ -59,23 +18,17 @@
 
 // Subagent container for items under the same parent task.
 .subagent-items-container {
-  // Blend with the TaskTool card.
-  margin-left: 0;
-  margin-right: 0;
   padding: 12px 14px;
-  
-  // Match BaseToolCard expanded area styling.
+
+  // Continue the task card border on left/right/bottom; top border is hidden.
   background: var(--color-bg-flowchat);
   border: 1px solid var(--border-base);
+  border-top: none;
+  // Top corners are square to merge with the header card above.
   border-radius: 0 0 8px 8px;
   backdrop-filter: blur(8px);
-  
-  // Top divider.
-  border-top: none;
-  box-shadow: inset 0 1px 0 0 var(--border-base, rgba(107, 114, 128, 0.25));
-  
-  // Fixed height to avoid growth during streaming output.
-  // Keep height even when content is short; overflow scrolls.
+
+  // Fixed height; overflow scrolls.
   height: 400px;
   overflow-y: auto;
 }
@@ -84,18 +37,15 @@
   overflow: hidden;
 }
 
-// TaskTool card bottom radius is controlled by TaskToolDisplay.scss.
-
 // Keep the legacy subagent-item class for compatibility.
 .subagent-item {
   display: block;
-  
+
   &.subagent-item--collapsed {
     display: none;
   }
-  
+
   &.subagent-item--expanded {
     display: block;
   }
 }
-

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
@@ -14,10 +14,6 @@
   position: relative;
   
   &:hover {
-    background: var(--element-bg-strong);
-    border-color: var(--border-prominent);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-    
     .user-message-item__copy-btn {
       opacity: 1;
     }
@@ -72,9 +68,6 @@
   user-select: text;
   transition: all 0.2s ease;
   
-  &:hover {
-    opacity: 0.8;
-  }
 }
 
 // Expanded state.

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -264,6 +264,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
 
   const isInputActive = useChatInputState(state => state.isActive);
   const isInputExpanded = useChatInputState(state => state.isExpanded);
+  const inputHeight = useChatInputState(state => state.inputHeight);
 
   const activeSessionState = useActiveSessionState();
   const isProcessing = activeSessionState.isProcessing;
@@ -1918,6 +1919,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
         onClick={scrollToLatestEndPosition}
         isInputActive={isInputActive}
         isInputExpanded={isInputExpanded}
+        inputHeight={inputHeight}
       />
     </div>
   );

--- a/src/web-ui/src/flow_chat/store/chatInputStateStore.ts
+++ b/src/web-ui/src/flow_chat/store/chatInputStateStore.ts
@@ -9,16 +9,21 @@ interface ChatInputStateStore {
   isActive: boolean;
   /** Whether ChatInput is expanded (full height mode) */
   isExpanded: boolean;
+  /** Measured height of the ChatInput container in pixels (0 if unknown) */
+  inputHeight: number;
   
   setActive: (isActive: boolean) => void;
   setExpanded: (isExpanded: boolean) => void;
+  setInputHeight: (height: number) => void;
 }
 
 export const useChatInputState = create<ChatInputStateStore>((set) => ({
   isActive: true,
   isExpanded: false,
+  inputHeight: 0,
   
   setActive: (isActive) => set({ isActive }),
   setExpanded: (isExpanded) => set({ isExpanded }),
+  setInputHeight: (inputHeight) => set({ inputHeight }),
 }));
 

--- a/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.scss
@@ -17,6 +17,11 @@
 
   &:hover {
     border-color: var(--border-medium);
+    box-shadow:
+      0 4px 16px rgba(0, 0, 0, 0.2),
+      0 2px 8px rgba(0, 0, 0, 0.12),
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    transform: translateY(-1px);
   }
 
   &--loading {
@@ -35,7 +40,12 @@
     align-items: center;
     justify-content: space-between;
     padding: 10px 14px;
-    background: rgba(255, 255, 255, 0.02);
+    background: linear-gradient(
+      90deg,
+      rgba(245, 158, 11, 0.07) 0%,
+      rgba(245, 158, 11, 0.04) 50%,
+      rgba(255, 255, 255, 0.02) 100%
+    );
     border-bottom: 1px solid var(--border-base);
     
     &--clickable {
@@ -43,7 +53,12 @@
       transition: background 0.15s ease;
       
       &:hover {
-        background: rgba(255, 255, 255, 0.06);
+        background: linear-gradient(
+          90deg,
+          rgba(245, 158, 11, 0.13) 0%,
+          rgba(245, 158, 11, 0.08) 50%,
+          rgba(255, 255, 255, 0.05) 100%
+        );
         
         .file-name {
           color: var(--tool-card-text-primary);
@@ -61,15 +76,15 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 24px;
-      height: 24px;
-      background: rgba(255, 255, 255, 0.06);
+      width: 28px;
+      height: 28px;
+      background: transparent;
       border-radius: 4px;
-      color: var(--tool-card-text-muted);
+      color: #f59e0b;
 
       svg {
-        width: 14px;
-        height: 14px;
+        width: 18px;
+        height: 18px;
       }
     }
 
@@ -85,7 +100,15 @@
   }
 
   .create-plan-content {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
     padding: 14px 16px;
+
+    .plan-content-left {
+      flex: 1;
+      min-width: 0;
+    }
 
     .plan-title {
       margin: 0 0 6px 0;
@@ -101,55 +124,39 @@
       color: var(--tool-card-text-secondary);
       line-height: 1.5;
     }
+
+    .todos-toggle-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      align-self: center;
+      width: 32px;
+      height: 32px;
+      padding: 0;
+      border: 1px solid transparent;
+      border-radius: 6px;
+      background: transparent;
+      color: var(--tool-card-text-muted);
+      cursor: pointer;
+      transition: all 0.15s ease;
+
+      svg {
+        width: 22px;
+        height: 22px;
+      }
+
+      &:hover {
+        border-color: rgba(245, 158, 11, 0.35);
+        background: rgba(245, 158, 11, 0.07);
+        color: #f59e0b;
+      }
+    }
   }
 
   .create-plan-todos {
     border-top: 1px solid var(--border-base);
     padding: 10px 16px;
-
-    .todos-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      cursor: pointer;
-      padding: 4px 0;
-      margin: -4px 0;
-      border-radius: 4px;
-      transition: background 0.15s ease;
-      
-      &:hover {
-        background: rgba(255, 255, 255, 0.04);
-      }
-
-      .todos-count {
-        font-size: 12px;
-        color: var(--tool-card-text-muted);
-      }
-      
-      .todos-toggle-btn {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 20px;
-        height: 20px;
-        padding: 0;
-        border: none;
-        background: transparent;
-        color: var(--tool-card-text-muted);
-        cursor: pointer;
-        border-radius: 4px;
-        transition: all 0.15s ease;
-        
-        &:hover {
-          color: var(--tool-card-text-primary);
-          background: rgba(255, 255, 255, 0.08);
-        }
-      }
-    }
-    
-    &--expanded .todos-header {
-      margin-bottom: 8px;
-    }
 
     .todos-list {
       display: flex;

--- a/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FileText, Circle, Loader2, CheckCircle, CheckCircle2, PlayCircle, XCircle, ChevronDown, ChevronUp } from 'lucide-react';
+import { ClipboardList, Circle, Loader2, CheckCircle, CheckCircle2, PlayCircle, XCircle, ChevronsUpDown, ChevronsDownUp } from 'lucide-react';
 import type { ToolCardProps } from '../types/flow-chat';
 import { ideControl } from '@/shared/services/ide-control/api';
 import { flowChatManager } from '@/flow_chat/services/FlowChatManager';
@@ -207,11 +207,6 @@ export const PlanDisplay: React.FC<PlanDisplayProps> = ({
     };
   }, [effectiveCacheKey, planFilePath, initialName, initialOverview, initialTodos]);
 
-  const remainingTodos = useMemo(() => {
-    if (!planData?.todos) return 0;
-    return planData.todos.filter(t => t.status !== 'completed').length;
-  }, [planData]);
-
   // Build button status transitions: build -> building -> built.
   const buildStatus = useMemo((): 'build' | 'building' | 'built' => {
     if (planData?.todos?.length) {
@@ -331,7 +326,7 @@ ${JSON.stringify(simpleTodos, null, 2)}
         >
           <div className="header-left">
             <div className="file-icon-wrapper">
-              <FileText size={14} />
+              <ClipboardList size={14} />
             </div>
             <span className="file-name">{planFileName}</span>
           </div>
@@ -342,45 +337,45 @@ ${JSON.stringify(simpleTodos, null, 2)}
       </Tooltip>
 
       <div className="create-plan-content">
-        <h3 className="plan-title">{planData.name}</h3>
-        <p className="plan-overview">{planData.overview}</p>
-      </div>
-
-      {planData.todos && planData.todos.length > 0 && (
-        <div className={`create-plan-todos ${isTodosExpanded ? 'create-plan-todos--expanded' : ''}`}>
-          <div 
-            className="todos-header"
+        <div className="plan-content-left">
+          <h3 className="plan-title">{planData.name}</h3>
+          <p className="plan-overview">{planData.overview}</p>
+        </div>
+        {planData.todos && planData.todos.length > 0 && (
+          <button
+            className="todos-toggle-btn"
+            type="button"
             onClick={handleToggleTodos}
           >
-            <span className="todos-count">{t('toolCards.plan.remainingTodos', { count: remainingTodos })}</span>
-            <button className="todos-toggle-btn" type="button">
-              {isTodosExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-            </button>
+            {isTodosExpanded ? <ChevronsDownUp size={22} /> : <ChevronsUpDown size={22} />}
+          </button>
+        )}
+      </div>
+
+      {planData.todos && planData.todos.length > 0 && isTodosExpanded && (
+        <div className="create-plan-todos create-plan-todos--expanded">
+          <div className="todos-list">
+            {planData.todos.map((todo, index) => (
+              <div
+                key={todo.id || index}
+                className={`todo-item status-${todo.status || 'pending'}`}
+              >
+                {todo.status === 'completed' && (
+                  <CheckCircle2 size={12} className="todo-icon todo-icon--completed" />
+                )}
+                {todo.status === 'in_progress' && (
+                  <PlayCircle size={12} className="todo-icon todo-icon--in-progress" />
+                )}
+                {(!todo.status || todo.status === 'pending') && (
+                  <Circle size={12} className="todo-icon todo-icon--pending" />
+                )}
+                {todo.status === 'cancelled' && (
+                  <XCircle size={12} className="todo-icon todo-icon--cancelled" />
+                )}
+                <span className="todo-content">{todo.content}</span>
+              </div>
+            ))}
           </div>
-          {isTodosExpanded && (
-            <div className="todos-list">
-              {planData.todos.map((todo, index) => (
-                <div 
-                  key={todo.id || index} 
-                  className={`todo-item status-${todo.status || 'pending'}`}
-                >
-                  {todo.status === 'completed' && (
-                    <CheckCircle2 size={12} className="todo-icon todo-icon--completed" />
-                  )}
-                  {todo.status === 'in_progress' && (
-                    <PlayCircle size={12} className="todo-icon todo-icon--in-progress" />
-                  )}
-                  {(!todo.status || todo.status === 'pending') && (
-                    <Circle size={12} className="todo-icon todo-icon--pending" />
-                  )}
-                  {todo.status === 'cancelled' && (
-                    <XCircle size={12} className="todo-icon todo-icon--cancelled" />
-                  )}
-                  <span className="todo-content">{todo.content}</span>
-                </div>
-              ))}
-            </div>
-          )}
         </div>
       )}
 

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.scss
@@ -26,8 +26,9 @@
         font-weight: 500;
       }
 
-      .delete-label {
-        color: var(--color-text-primary);
+      .delete-file-name {
+        text-decoration: line-through;
+        color: var(--color-text-muted);
       }
     }
 
@@ -89,24 +90,16 @@
   }
 }
 
-.delete-label {
-  font-size: 10px;
-  font-weight: 500;
+.delete-file-name {
+  text-decoration: line-through;
   color: var(--color-text-muted);
-  flex-shrink: 0;
 }
 
 .diff-preview-group {
   display: flex;
   align-items: center;
   gap: 3px;
-  padding: 2px 6px;
-  border: none;
-  border-radius: 20px;
-  background: transparent;
-  cursor: pointer;
   flex-shrink: 0;
-  transition: background 0.15s ease, color 0.15s ease;
   font-family: var(--tool-card-font-mono);
   font-size: 10px;
   font-weight: 600;
@@ -119,23 +112,6 @@
 
   .deletions {
     color: var(--color-error);
-  }
-
-  svg {
-    flex-shrink: 0;
-    opacity: 0.6;
-  }
-
-  &:hover {
-    background: color-mix(in srgb, var(--color-text-primary) 10%, transparent);
-
-    svg {
-      opacity: 1;
-    }
-  }
-
-  &:active {
-    background: color-mix(in srgb, var(--color-text-primary) 16%, transparent);
   }
 }
 

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useCallback, useMemo, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { XCircle, GitBranch, FileText, ChevronDown, ChevronUp, FileEdit, FilePlus, Trash2, Loader2, Clock, Check } from 'lucide-react';
+import { XCircle, GitBranch, FileText, ChevronDown, ChevronUp, FileEdit, FilePlus, FileX2, Loader2, Clock, Check } from 'lucide-react';
 import { CubeLoading } from '../../component-library';
 import type { ToolCardProps } from '../types/flow-chat';
 import { BaseToolCard, ToolCardHeader } from './BaseToolCard';
@@ -44,12 +44,11 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   const toolId = toolItem.id ?? toolCall?.id;
   
   const [isErrorExpanded, setIsErrorExpanded] = useState(false);
-  const [isPreviewExpanded, setIsPreviewExpanded] = useState(true);
   const [operationDiffStats, setOperationDiffStats] = useState<{ additions: number; deletions: number } | null>(null);
   
   const hasInitializedCompletionEffectRef = useRef(false);
   const previousCompletionEndTimeRef = useRef<number | null>(toolItem.endTime ?? null);
-  const { cardRootRef, applyExpandedState } = useToolCardHeightContract({
+  const { cardRootRef } = useToolCardHeightContract({
     toolId,
     toolName: toolItem.toolName,
   });
@@ -73,12 +72,6 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
 
   const currentFilePath = getFilePath();
 
-  useEffect(() => {
-    if (isParamsStreaming) {
-      setIsPreviewExpanded(true);
-    }
-  }, [isParamsStreaming]);
-  
   const getOldString = useCallback((): string => {
     const params = partialParams || toolCall?.input;
     if (!params) return '';
@@ -326,7 +319,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
     if (currentFilePath && onOpenInEditor) {
       onOpenInEditor(currentFilePath);
     }
-  }, [currentFilePath, onOpenInEditor, isFailed, isErrorExpanded, sessionId, status, handleOpenInCodeEditor, toolItem.toolName]);
+  }, [currentFilePath, onOpenInEditor, isFailed, sessionId, status, handleOpenInCodeEditor, toolItem.toolName]);
 
   const handleOpenBaselineDiff = useCallback(async () => {
     if (!currentFile || !currentWorkspace) {
@@ -366,7 +359,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
     const iconMap: Record<string, { icon: React.ReactNode; className: string }> = {
       'Write': { icon: <FilePlus size={16} />, className: 'write-icon' },
       'Edit': { icon: <FileEdit size={16} />, className: 'edit-icon' },
-      'Delete': { icon: <Trash2 size={16} />, className: 'delete-icon' }
+      'Delete': { icon: <FileX2 size={16} />, className: 'delete-icon' }
     };
     
     return iconMap[toolItem.toolName] || { icon: <FileText size={16} />, className: 'file-icon' };
@@ -390,17 +383,6 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
     return null;
   };
 
-  const handlePreviewToggle = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    const nextExpanded = !isPreviewExpanded;
-
-    applyExpandedState(isPreviewExpanded, nextExpanded, setIsPreviewExpanded, {
-      detail: {
-        filePath: currentFilePath,
-      },
-    });
-  }, [applyExpandedState, currentFilePath, isPreviewExpanded]);
-
   const renderHeader = () => {
     const { className: iconClassName } = getToolIconInfo();
     const isDeleteTool = toolItem.toolName === 'Delete';
@@ -415,11 +397,25 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
         iconClassName={iconClassName}
         action={actionText}
       content={
-        <Tooltip content={currentFilePath || fileName} placement="top">
-          <span className={`file-name ${isDeleteTool ? 'file-name--muted' : ''}`}>
-            {fileName}
-          </span>
-        </Tooltip>
+        <>
+          <Tooltip content={currentFilePath || fileName} placement="top">
+            <span className={`file-name ${isDeleteTool ? 'file-name--muted' : ''}`}>
+              {fileName}
+            </span>
+          </Tooltip>
+          {!isDeleteTool && !isParamsStreaming && !isFailed && !isLoading && (
+            (currentFileDiffStats.additions > 0 || currentFileDiffStats.deletions > 0)
+          ) && (
+            <span className="diff-preview-group">
+              {currentFileDiffStats.additions > 0 && (
+                <span className="additions">+{currentFileDiffStats.additions}</span>
+              )}
+              {currentFileDiffStats.deletions > 0 && (
+                <span className="deletions">-{currentFileDiffStats.deletions}</span>
+              )}
+            </span>
+          )}
+        </>
       }
       extra={
         <>
@@ -429,28 +425,6 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
             </span>
           )}
           
-          {isDeleteTool && !isParamsStreaming && !isFailed && !isLoading && status === 'completed' && (
-            <span className="delete-label">{t('toolCards.file.deletedLabel')}</span>
-          )}
-          
-          {!isDeleteTool && !isParamsStreaming && !isFailed && !isLoading && (
-            (currentFileDiffStats.additions > 0 || currentFileDiffStats.deletions > 0 || oldStringContent || newStringContent || contentPreview)
-          ) && (
-            <Tooltip content={isPreviewExpanded ? t('toolCards.file.collapsePreview') : t('toolCards.file.expandPreview')} placement="top">
-              <button
-                className="diff-preview-group"
-                onClick={handlePreviewToggle}
-              >
-                {currentFileDiffStats.additions > 0 && (
-                  <span className="additions">+{currentFileDiffStats.additions}</span>
-                )}
-                {currentFileDiffStats.deletions > 0 && (
-                  <span className="deletions">-{currentFileDiffStats.deletions}</span>
-                )}
-                {isPreviewExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
-              </button>
-            </Tooltip>
-          )}
           
           {!isDeleteTool && !isFailed && !isLoading && status === 'completed' && (
             <div className="compact-actions" onClick={(e) => e.stopPropagation()}>
@@ -606,17 +580,10 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   };
 
   const renderDeleteContent = () => {
-    const baseLabel = `${t('toolCards.file.delete')}: ${fileName}`;
-
-    if (status === 'completed') {
-      return baseLabel;
-    }
-
     if (status === 'error') {
       return `${t('toolCards.file.delete')}${t('toolCards.file.failed')}: ${fileName}`;
     }
-
-    return baseLabel;
+    return <>{t('toolCards.file.delete')}: <span className="delete-file-name">{fileName}</span></>;
   };
 
   if (isDeleteTool) {
@@ -630,7 +597,6 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
           <CompactToolCardHeader
             statusIcon={getDeleteStatusIcon()}
             content={renderDeleteContent()}
-            extra={status === 'completed' ? t('toolCards.file.deletedLabel') : undefined}
           />
         }
       />
@@ -641,7 +607,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
     <div ref={cardRootRef} data-tool-card-id={toolId ?? ''}>
       <BaseToolCard
         status={status}
-        isExpanded={isPreviewExpanded}
+        isExpanded={true}
         onClick={handleCardClick}
         className={`file-operation-card ${isDeleteTool ? 'non-clickable' : ''}`}
         header={renderHeader()}

--- a/src/web-ui/src/flow_chat/tool-cards/MermaidInteractiveDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/MermaidInteractiveDisplay.scss
@@ -9,13 +9,6 @@
   
   &.clickable {
     cursor: pointer;
-    
-    &:hover {
-      .mermaid-view-icon {
-        color: var(--color-accent-500);
-        transform: scale(1.1);
-      }
-    }
   }
 }
 
@@ -33,20 +26,6 @@
   .icon-completed {
     color: var(--color-success);
     filter: drop-shadow(0 0 4px var(--color-success-border));
-  }
-}
-
-.mermaid-view-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  color: var(--color-text-muted);
-  transition: all 0.2s ease;
-  
-  svg {
-    width: 14px;
-    height: 14px;
   }
 }
 

--- a/src/web-ui/src/flow_chat/tool-cards/MermaidInteractiveDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/MermaidInteractiveDisplay.tsx
@@ -3,7 +3,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { Eye, Network } from 'lucide-react';
+import { Network } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { CubeLoading } from '../../component-library';
 import type { ToolCardProps, FlowToolItem } from '../types/flow-chat';
@@ -172,19 +172,12 @@ export const MermaidInteractiveDisplay: React.FC<ToolCardProps> = ({
         <span className="mermaid-title-content">{title}</span>
       }
       extra={
-        <>
-          {status === 'completed' && (
-            <div className="mermaid-view-icon">
-              <Eye size={14} />
-            </div>
-          )}
-          {isLoading && (
-            <span className="mermaid-status-text">
-              {(status === 'running' || status === 'streaming') && t('toolCards.diagram.creating')}
-              {status === 'pending' && t('toolCards.diagram.preparing')}
-            </span>
-          )}
-        </>
+        isLoading ? (
+          <span className="mermaid-status-text">
+            {(status === 'running' || status === 'streaming') && t('toolCards.diagram.creating')}
+            {status === 'pending' && t('toolCards.diagram.preparing')}
+          </span>
+        ) : null
       }
       statusIcon={renderStatusIcon()}
     />

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.scss
@@ -115,7 +115,7 @@
   .task-header-extra {
     display: flex;
     align-items: center;
-    gap: 2px;
+    gap: 6px;
     margin-left: auto;
     flex-shrink: 0;
   }
@@ -150,7 +150,7 @@
     color: var(--color-text-secondary, #9ca3af);
     line-height: 1.4;
     border-radius: 4px;
-    cursor: default;
+    cursor: pointer;
     transition: background 0.15s ease;
     
     .task-prompt-content {
@@ -158,6 +158,8 @@
       min-width: 0;
       word-break: break-word;
       white-space: pre-wrap;
+      max-height: calc(1.4em * 3);
+      overflow-y: auto;
     }
     
     &.task-prompt-row--clickable {
@@ -340,11 +342,54 @@
 }
 
 
-/* Square bottom corners when followed by subagent items. */
-/* FlowToolCard wraps in .flow-tool-card-wrapper, so select from parent. */
-.flow-tool-card-wrapper:has(+ .subagent-items-wrapper) {
-  .base-tool-card-wrapper.task-tool-display {
-    border-radius: 8px 8px 0 0 !important;
+/**
+ * Make the entire header area show pointer cursor.
+ * BaseToolCard already sets cursor:pointer on .base-tool-card,
+ * but the header content area clips it — force it here.
+ */
+.task-tool-display {
+  .base-tool-card {
+    cursor: pointer;
+  }
+}
+
+/**
+ * Unified task + subagent card wrapper.
+ * Wraps the task tool header card and the subagent items container so they
+ * behave as a single card with a shared hover/shadow effect.
+ */
+.task-with-subagent-wrapper {
+  position: relative;
+  border-radius: 8px;
+  margin-bottom: 10px;
+  transition: box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+
+  // Expanded state: subtle default elevation.
+  &:has(.subagent-items-wrapper--expanded) {
+    box-shadow:
+      0 2px 6px rgba(0, 0, 0, 0.15),
+      0 1px 3px rgba(0, 0, 0, 0.1);
+  }
+
+  // Hover over expanded card: stronger elevation.
+  &:has(.subagent-items-wrapper--expanded):hover {
+    box-shadow:
+      0 4px 16px rgba(0, 0, 0, 0.25),
+      0 2px 8px rgba(0, 0, 0, 0.15),
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+
+  // Square the bottom corners of the task header card when expanded.
+  &:has(.subagent-items-wrapper--expanded) {
+    .flow-tool-card-wrapper .base-tool-card-wrapper.task-tool-display {
+      border-radius: 8px 8px 0 0;
+      // Remove bottom margin so the subagent container connects flush.
+      margin-bottom: 0;
+      // Suppress the base card's own hover shadow; the wrapper handles it.
+      &:hover {
+        box-shadow: none;
+      }
+    }
   }
 }
 

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
@@ -4,12 +4,11 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
-  ChevronDown,
-  ChevronUp,
   Split,
   Timer,
   PanelRightOpen
 } from 'lucide-react';
+
 import { useTranslation } from 'react-i18next';
 import { CubeLoading, Button, IconButton } from '../../component-library';
 import type { ToolCardProps } from '../types/flow-chat';
@@ -40,9 +39,6 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
   
   const isRunning = status === 'preparing' || status === 'streaming' || status === 'running';
   
-  const [isPromptExpanded, setIsPromptExpanded] = useState(false);
-  const promptRef = useRef<HTMLDivElement>(null);
-  const [isPromptOverflow, setIsPromptOverflow] = useState(false);
   const { cardRootRef, applyExpandedState } = useToolCardHeightContract({
     toolId,
     toolName: toolItem.toolName,
@@ -57,10 +53,6 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
     applyExpandedState(isExpanded, nextExpanded, setIsExpanded, { reason });
   }, [applyExpandedState, isExpanded, isRunning, status, toolId]);
 
-  const updatePromptExpandedState = useCallback((nextExpanded: boolean) => {
-    applyExpandedState(isPromptExpanded, nextExpanded, setIsPromptExpanded);
-  }, [applyExpandedState, isPromptExpanded]);
-  
   useEffect(() => {
     const prevStatus = prevStatusRef.current;
     
@@ -74,17 +66,6 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
       }
     }
   }, [isRunning, status, updateCardExpandedState]);
-  
-  useEffect(() => {
-    const prompt = toolCall?.input?.prompt;
-    if (prompt) {
-      let visualWidth = 0;
-      for (const char of prompt) {
-        visualWidth += isFullWidth(char) ? 2 : 1;
-      }
-      setIsPromptOverflow(visualWidth > 100 || prompt.includes('\n'));
-    }
-  }, [toolCall?.input?.prompt]);
   
   useEffect(() => {
     taskCollapseStateManager.setCollapsed(toolItem.id, !isExpanded);
@@ -180,11 +161,10 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
 
   const renderHeader = () => {
     const hasPromptContent = taskInput && taskInput.prompt && taskInput.prompt !== 'Not provided';
-    const isPromptVisible = hasPromptContent && (!isPromptOverflow || isPromptExpanded);
     
     return (
     <div className="task-header-wrapper">
-      <div className={`task-icon-container ${isRunning ? 'is-running' : ''} ${isPromptVisible ? 'prompt-visible' : ''}`}>
+      <div className={`task-icon-container ${isRunning ? 'is-running' : ''} ${hasPromptContent ? 'prompt-visible' : ''}`}>
         {renderToolIcon()}
       </div>
       
@@ -208,23 +188,9 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
             )}
             
             <IconButton
-              className="preview-toggle-btn"
-              variant="ghost"
-              size="xs"
-              onClick={(e) => {
-                e.stopPropagation();
-                updateCardExpandedState(!isExpanded);
-              }}
-              tooltip={isExpanded ? t('toolCards.common.collapse') : t('toolCards.common.expand')}
-              tooltipPlacement="top"
-            >
-              {isExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
-            </IconButton>
-            
-            <IconButton
               className="open-panel-btn"
               variant="ghost"
-              size="xs"
+              size="small"
               onClick={(e) => {
                 e.stopPropagation();
                 const panelData = { toolItem, taskInput, sessionId };
@@ -243,7 +209,7 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
               tooltip={t('toolCards.taskTool.openInPanel')}
               tooltipPlacement="top"
             >
-              <PanelRightOpen size={12} />
+              <PanelRightOpen size={14} />
             </IconButton>
             
             <div className="task-status-icon">
@@ -256,13 +222,6 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
     </div>
   )};
 
-  const handlePromptRowClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (isPromptOverflow) {
-      updatePromptExpandedState(!isPromptExpanded);
-    }
-  }, [isPromptExpanded, isPromptOverflow, updatePromptExpandedState]);
-
   const renderPromptRow = () => {
     const hasPrompt = taskInput && taskInput.prompt && taskInput.prompt !== 'Not provided';
     
@@ -270,30 +229,11 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
       return null;
     }
     
-    const isPromptCollapsed = !isPromptExpanded && isPromptOverflow;
-    
     return (
-      <div 
-        className={`task-prompt-row ${isPromptCollapsed ? 'task-prompt-row--collapsed' : ''} ${isPromptOverflow ? 'task-prompt-row--clickable' : ''}`}
-        onClick={handlePromptRowClick}
-      >
-        <div 
-          ref={promptRef}
-          className="task-prompt-content"
-        >
+      <div className="task-prompt-row">
+        <div className="task-prompt-content">
           {taskInput!.prompt}
         </div>
-        {isPromptExpanded && isPromptOverflow && (
-          <IconButton 
-            className="task-prompt-toggle-btn task-prompt-toggle-btn--collapse" 
-            variant="ghost"
-            size="xs"
-            onClick={handlePromptRowClick} 
-            tooltip={t('toolCards.common.collapse')}
-          >
-            <ChevronUp size={14} />
-          </IconButton>
-        )}
       </div>
     );
   };
@@ -333,22 +273,13 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
     );
   };
 
-  // Error details are shown in the side panel only.
-  const hasPrompt = taskInput && taskInput.prompt && taskInput.prompt !== 'Not provided';
-  const isPromptRowExpanded = hasPrompt && isPromptExpanded;
-  
-  const cardClassName = [
-    'task-tool-display',
-    isPromptRowExpanded ? 'prompt-expanded' : ''
-  ].filter(Boolean).join(' ');
-
   return (
     <div ref={cardRootRef} data-tool-card-id={toolId ?? ''}>
       <BaseToolCard
         status={status}
         isExpanded={isExpanded}
         onClick={handleCardClick}
-        className={cardClassName}
+        className="task-tool-display"
         header={renderHeader()}
         expandedContent={renderExpandedContent()}
         isFailed={isFailed}

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
@@ -16,6 +16,20 @@
   }
 }
 
+/* Entire header row shows pointer (card toggles expand); children must not force default cursor. */
+.base-tool-card-wrapper.terminal-tool-card .base-tool-card-header {
+  cursor: pointer;
+}
+
+/* Footer bar: full width + background to bottom inner edge of card (matches .base-tool-card-expanded padding). */
+.base-tool-card-wrapper.terminal-tool-card .terminal-result-footer {
+  margin-left: -10px;
+  margin-right: -10px;
+  margin-bottom: -10px;
+  padding: 6px 10px;
+  border-radius: 0 0 7px 7px;
+}
+
 /* ========== Fix scrollbar visibility on card hover ========== */
 .base-tool-card-wrapper.terminal-tool-card:hover {
   .terminal-execution-output,
@@ -45,7 +59,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  cursor: default;
+  cursor: inherit;
   transition: none;
   display: inline-block;
   background: none !important;
@@ -84,6 +98,7 @@
 .terminal-command-input {
   flex: 1;
   min-width: 0;
+  cursor: text;
   background: transparent;
   padding: 0;
   font-family: var(--tool-card-font-mono);
@@ -120,11 +135,6 @@
   font-weight: 600;
   flex-shrink: 0;
   margin-right: 4px;
-
-  &.status-completed {
-    background: var(--color-success-bg);
-    color: var(--color-success);
-  }
 
   &.status-cancelled {
     background: var(--color-warning-bg);
@@ -242,21 +252,12 @@
 }
 
 .external-btn {
-  color: rgba(59, 130, 246, 0.9);
-
-  &:hover {
-    background: rgba(59, 130, 246, 0.15);
-    color: rgba(59, 130, 246, 1);
-    box-shadow: 0 2px 8px rgba(59, 130, 246, 0.2);
-  }
-}
-
-.toggle-btn {
   color: var(--color-text-muted);
 
-  &:hover {
-    background: var(--color-bg-hover, rgba(255, 255, 255, 0.08));
-    color: var(--color-text-primary);
+  &:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--color-text-secondary);
+    box-shadow: none;
   }
 }
 
@@ -299,42 +300,52 @@
 /* ========== Static result container (after command completion) ========== */
 .terminal-result-container {
   padding: 0;
+  display: flex;
+  flex-direction: column;
   
   &.cancelled {
     .terminal-cancelled-text {
       color: var(--color-warning);
-      font-size: 12px;
+      font-size: 11px;
       font-weight: 500;
+      line-height: 1.2;
     }
   }
 }
 
-.terminal-result-header {
+.terminal-result-footer {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 8px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--border-subtle);
+  align-content: center;
+  gap: 6px;
   flex-wrap: wrap;
+  line-height: 1.2;
+  background: var(--element-bg-subtle, rgba(255, 255, 255, 0.05));
+  box-sizing: border-box;
+}
+
+.terminal-result-output + .terminal-result-footer {
+  margin-top: 6px;
+  border-top: 1px solid var(--border-subtle);
 }
 
 .terminal-result-label {
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 600;
   color: var(--color-text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.04em;
 }
 
 .terminal-result-value {
   font-family: var(--tool-card-font-mono);
-  font-size: 12px;
+  font-size: 11px;
   color: var(--color-text-primary);
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  line-height: 1.2;
 }
 
 .terminal-result-output {
@@ -349,28 +360,28 @@
 .terminal-exit-code {
   display: inline-flex;
   align-items: center;
-  padding: 2px 6px;
-  border-radius: 3px;
-  font-size: 10px;
+  padding: 0;
+  font-size: 9px;
   font-weight: 600;
   font-family: var(--tool-card-font-mono);
+  line-height: 1.2;
   margin-left: auto;
+  background: transparent;
 
   &.success {
-    background: var(--color-success-bg);
-    color: var(--color-success);
+    color: var(--color-text-muted);
   }
 
   &.error {
-    background: var(--color-error-bg);
     color: var(--color-error);
   }
 }
 
 .terminal-execution-time {
-  font-size: 10px;
+  font-size: 9px;
   color: var(--color-text-muted);
   font-family: var(--tool-card-font-mono);
+  line-height: 1.2;
 }
 
 /* ========== xterm output renderer styles ========== */

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
@@ -15,7 +15,7 @@
 import React, { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolCardProps } from '../types/flow-chat';
-import { Terminal, Play, X, ExternalLink, Square, ChevronDown, ChevronUp } from 'lucide-react';
+import { Terminal, Play, X, ExternalLink, Square } from 'lucide-react';
 import { createTerminalTab } from '@/shared/utils/tabUtils';
 import { BaseToolCard, ToolCardHeader } from './BaseToolCard';
 import { CubeLoading, IconButton } from '../../component-library';
@@ -279,11 +279,6 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
     applyExpandedState(newExpanded, true, 'manual');
   }, [applyExpandedState, isExpanded]);
   
-  const handleToggleExpand = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    toggleExpand();
-  }, [toggleExpand]);
-
   const handleOpenInPanel = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     if (!terminalSessionId) {
@@ -356,7 +351,7 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
     
     switch (status) {
       case 'completed':
-        return <span className="terminal-status-text status-completed">{t('toolCards.terminal.completed')}</span>;
+        return null;
       case 'cancelled':
         return <span className="terminal-status-text status-cancelled">{t('toolCards.terminal.cancelled')}</span>;
       case 'error':
@@ -432,16 +427,6 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
                 <ExternalLink size={12} />
               </IconButton>
             )}
-
-            <IconButton 
-              className="terminal-action-btn toggle-btn"
-              variant="ghost"
-              size="xs"
-              onClick={handleToggleExpand}
-              tooltip={isExpanded ? t('toolCards.terminal.collapseOutput') : t('toolCards.terminal.expandOutput')}
-            >
-              {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-            </IconButton>
           </>
         }
         statusIcon={renderStatusIcon()}
@@ -470,7 +455,16 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
 
         {status === 'completed' && (
           <div className="terminal-result-container">
-            <div className="terminal-result-header">
+            {output && (
+              <div className="terminal-result-output">
+                <TerminalOutputRenderer 
+                  content={output}
+                  className="terminal-xterm-output"
+                  maxHeight={TERMINAL_OUTPUT_PREVIEW_MAX_HEIGHT}
+                />
+              </div>
+            )}
+            <div className="terminal-result-footer">
               {workingDir && (
                 <>
                   <span className="terminal-result-label">{t('toolCards.terminal.workingDirectory')}</span>
@@ -486,30 +480,20 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
                 </span>
               )}
             </div>
-            
-            {output && (
-              <div className="terminal-result-output">
-                <TerminalOutputRenderer 
-                  content={output}
-                  className="terminal-xterm-output"
-                  maxHeight={TERMINAL_OUTPUT_PREVIEW_MAX_HEIGHT}
-                />
-              </div>
-            )}
           </div>
         )}
         
         {status === 'cancelled' && accumulatedOutput && (
           <div className="terminal-result-container cancelled">
-            <div className="terminal-result-header">
-              <span className="terminal-cancelled-text">{t('toolCards.terminal.commandInterrupted')}</span>
-            </div>
             <div className="terminal-result-output">
               <TerminalOutputRenderer 
                 content={accumulatedOutput}
                 className="terminal-xterm-output"
                 maxHeight={TERMINAL_OUTPUT_PREVIEW_MAX_HEIGHT}
               />
+            </div>
+            <div className="terminal-result-footer">
+              <span className="terminal-cancelled-text">{t('toolCards.terminal.commandInterrupted')}</span>
             </div>
           </div>
         )}

--- a/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.scss
@@ -187,19 +187,12 @@
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    cursor: pointer;
-    transition: transform 0.15s ease, opacity 0.15s ease;
+    flex-shrink: 0;
 
     &--completed  { background: var(--color-success); }
     &--in_progress { background: var(--color-info); }
     &--pending    { background: var(--tool-card-text-muted); opacity: 0.35; }
     &--cancelled  { background: var(--color-error); opacity: 0.5; }
-
-    &:hover,
-    &--hovered {
-      transform: scale(1.6);
-      opacity: 1;
-    }
   }
 
   .track-stats {

--- a/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.tsx
@@ -16,7 +16,6 @@ export const TodoWriteDisplay: React.FC<ToolCardProps> = ({
   const { t } = useTranslation('flow-chat');
   const { status, toolResult, partialParams, isParamsStreaming } = toolItem;
   
-  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [expandedState, setExpandedState] = useState<boolean | null>(null);
   const toolId = toolItem.id;
   const { cardRootRef, applyExpandedState } = useToolCardHeightContract({
@@ -45,13 +44,6 @@ export const TodoWriteDisplay: React.FC<ToolCardProps> = ({
   const inProgressTasks = useMemo(() => {
     return todosToDisplay.filter((t: any) => t.status === 'in_progress');
   }, [todosToDisplay]);
-
-  const hoveredTask = useMemo(() => {
-    if (hoveredIndex !== null && todosToDisplay[hoveredIndex]) {
-      return todosToDisplay[hoveredIndex];
-    }
-    return null;
-  }, [hoveredIndex, todosToDisplay]);
 
   const isAllCompleted = useMemo(() => {
     return todosToDisplay.length > 0 && taskStats.completed === taskStats.total;
@@ -88,13 +80,10 @@ export const TodoWriteDisplay: React.FC<ToolCardProps> = ({
 
   const renderTrackDot = (todo: any, index: number) => {
     const statusClass = `track-dot--${todo.status}`;
-    const isHovered = hoveredIndex === index;
     return (
-      <div 
-        key={todo.id || index} 
-        className={`track-dot ${statusClass} ${isHovered ? 'track-dot--hovered' : ''}`}
-        onMouseEnter={() => setHoveredIndex(index)}
-        onMouseLeave={() => setHoveredIndex(null)}
+      <div
+        key={todo.id || index}
+        className={`track-dot ${statusClass}`}
       />
     );
   };
@@ -120,14 +109,11 @@ export const TodoWriteDisplay: React.FC<ToolCardProps> = ({
   );
 
   const currentDisplayTask = useMemo(() => {
-    if (hoveredTask) {
-      return hoveredTask;
-    }
     if (inProgressTasks.length > 0) {
       return inProgressTasks[0];
     }
     return null;
-  }, [hoveredTask, inProgressTasks]);
+  }, [inProgressTasks]);
 
   const handleToggleExpanded = useCallback(() => {
     if (todosToDisplay.length === 0) {
@@ -166,7 +152,7 @@ export const TodoWriteDisplay: React.FC<ToolCardProps> = ({
               {!isExpanded && todosToDisplay.length > 0 && currentDisplayTask && (
                 <div className={`current-task-inline current-task-inline--${currentDisplayTask.status}`}>
                   <span className="inline-task-text">{currentDisplayTask.content}</span>
-                  {inProgressTasks.length > 1 && !hoveredTask && (
+                  {inProgressTasks.length > 1 && (
                     <span className="inline-task-more">+{inProgressTasks.length - 1}</span>
                   )}
                 </div>

--- a/src/web-ui/src/tools/editor/services/ThemeManager.ts
+++ b/src/web-ui/src/tools/editor/services/ThemeManager.ts
@@ -143,7 +143,8 @@ class ThemeManager {
           : (currentTheme.type === 'dark' ? this.getDefaultThemeId() : 'vs');
         
         this.currentThemeId = themeId;
-        monaco.editor.setTheme(themeId);
+        const { monacoThemeSync } = await import('@/infrastructure/theme/integrations/MonacoThemeSync');
+        monacoThemeSync.syncTheme(currentTheme);
       }
       
       themeService.on('theme:after-change', (event) => {


### PR DESCRIPTION
## Summary

- Track chat input height with ResizeObserver and shared chat input state; prevent collapsing the input when clicking the scroll-to-latest bar.
- Simplify and restyle multiple flow chat tool cards (task, terminal, file operations, mermaid, todo, create plan) and related styles.
- Minor tweaks to Markdown, planner button, message list items, ScrollToLatestBar, and ThemeManager for visual consistency.

## Test plan

- [ ] Open flow chat and verify tool cards render and expand/collapse as expected.
- [ ] Resize chat input / use scroll-to-latest; confirm input state and layout behave correctly.