### PR TITLE
fix: restore evicted session in update_session_model_id to prevent 'Session not found' error after idle

### DIFF
--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -71,6 +71,12 @@ pub struct SessionManager {
     /// Active sessions in memory
     sessions: Arc<DashMap<String, Session>>,
 
+    /// Persistent index of session_id -> effective workspace path.
+    /// Populated on session create/restore; NOT cleared on memory eviction.
+    /// Allows commands that only receive a session_id (e.g. update_session_model_id)
+    /// to restore an evicted session without requiring the caller to supply a path.
+    session_workspace_index: Arc<DashMap<String, PathBuf>>,
+
     /// Sub-components
     context_store: Arc<SessionContextStore>,
     persistence_manager: Arc<PersistenceManager>,
@@ -367,6 +373,7 @@ impl SessionManager {
 
         let manager = Self {
             sessions: Arc::new(DashMap::new()),
+            session_workspace_index: Arc::new(DashMap::new()),
             context_store,
             persistence_manager,
             config,
@@ -479,6 +486,8 @@ impl SessionManager {
 
         // 1. Add to memory
         self.sessions.insert(session_id.clone(), session.clone());
+        self.session_workspace_index
+            .insert(session_id.clone(), session_storage_path.clone());
 
         // 2. Initialize the in-memory context cache.
         self.context_store.create_session(&session_id);
@@ -651,6 +660,18 @@ impl SessionManager {
         session_id: &str,
         model_id: &str,
     ) -> BitFunResult<()> {
+        // If the session was evicted from memory (idle > 1h), try to restore it
+        // using the workspace path recorded when it was first created/restored.
+        if !self.sessions.contains_key(session_id) && self.config.enable_persistence {
+            if let Some(workspace_path) = self.session_workspace_index.get(session_id) {
+                debug!(
+                    "Session evicted from memory, restoring for model update: session_id={}",
+                    session_id
+                );
+                let _ = self.restore_session(&workspace_path.clone(), session_id).await;
+            }
+        }
+
         if let Some(mut session) = self.sessions.get_mut(session_id) {
             session.config.model_id = Some(model_id.to_string());
             session.updated_at = SystemTime::now();
@@ -919,6 +940,8 @@ impl SessionManager {
         // 4. Add to memory (will overwrite if already exists)
         self.sessions
             .insert(session_id.to_string(), session.clone());
+        self.session_workspace_index
+            .insert(session_id.to_string(), session_storage_path.clone());
 
         Ok(session)
     }


### PR DESCRIPTION
## 问题

关联 Issue：#375

Session 空闲超过 1 小时后被从内存驱逐（`session_idle_timeout = 3600s`）。此后若前端继续向该 Session 发送消息，会报错：

```
Thinking process error
Failed to update session model: Not found: Session not found: <session-id>
```

根本原因：`update_session_model_id` 只检查内存中的 `sessions` DashMap，不会触发从持久化存储恢复 Session 的逻辑。而 `coordinator` 的对话路径有完整的 restore 机制，`update_session_model_id` 绕过了它。

## 修复方案

在 `SessionManager` 中新增 `session_workspace_index: Arc<DashMap<String, PathBuf>>`：

- Session 创建或恢复时，将 `session_id → workspace_path` 写入此索引
- Session 被内存驱逐时**不清除**此索引（轻量级，仅存路径字符串）
- `update_session_model_id` 发现 Session 不在内存时，先用索引找到 workspace，调用 `restore_session` 恢复，再执行更新

## 变更文件

`src/crates/core/src/agentic/session/session_manager.rs`

- 新增 `session_workspace_index` 字段（+6 行）
- `create_session_with_id_and_details`：session 入内存后写入索引（+2 行）
- `restore_session`：session 恢复后写入索引（+2 行）
- `update_session_model_id`：session 不在内存时自动 restore（+13 行）

## 测试建议

1. 打开一个 Code 会话正常使用
2. 等待超过 1 小时（或临时将 `session_idle_timeout` 改为 10s 加速复现）
3. 在同一会话中发送消息
4. 预期：消息正常发送，不再出现 `Session not found` 错误