### PR TITLE
fix(core): propagate tool is_error and harden stream recovery

### DIFF
--- a/src/crates/core/src/agentic/core/message.rs
+++ b/src/crates/core/src/agentic/core/message.rs
@@ -196,6 +196,7 @@ impl From<Message> for AIMessage {
                     tool_calls: None,
                     tool_call_id: None,
                     name: None,
+                    is_error: None,
                     tool_image_attachments: None,
                 }
             }
@@ -229,6 +230,7 @@ impl From<Message> for AIMessage {
                     tool_calls: None,
                     tool_call_id: None,
                     name: None,
+                    is_error: None,
                     tool_image_attachments: None,
                 }
             }
@@ -285,6 +287,7 @@ impl From<Message> for AIMessage {
                     tool_calls: converted_tool_calls,
                     tool_call_id: None,
                     name: None,
+                    is_error: None,
                     tool_image_attachments: None,
                 }
             }
@@ -293,8 +296,8 @@ impl From<Message> for AIMessage {
                 tool_name,
                 result,
                 result_for_assistant,
+                is_error,
                 image_attachments,
-                ..
             } => {
                 // Tool messages must include tool_call_id
                 // Prefer result_for_assistant (text specifically for AI), if None or empty then use result (data field)
@@ -321,6 +324,7 @@ impl From<Message> for AIMessage {
                     tool_calls: None,
                     tool_call_id: Some(tool_id),
                     name: Some(tool_name),
+                    is_error: Some(is_error),
                     tool_image_attachments: image_attachments.clone(),
                 }
             }

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -216,6 +216,17 @@ impl RoundExecutor {
         };
 
         // Model returned successfully (output to AI log file)
+        if let Some(ref reason) = stream_result.partial_recovery_reason {
+            warn!(
+                "Stream recovered with partial output: session_id={}, round_id={}, reason={}, text_len={}, tool_calls={}",
+                context.session_id,
+                round_id,
+                reason,
+                stream_result.full_text.len(),
+                stream_result.tool_calls.len()
+            );
+        }
+
         let tool_names: Vec<&str> = stream_result
             .tool_calls
             .iter()

--- a/src/crates/core/src/agentic/execution/stream_processor.rs
+++ b/src/crates/core/src/agentic/execution/stream_processor.rs
@@ -103,6 +103,9 @@ impl SseLogCollector {
     }
 }
 
+/// Placeholder name for tool calls whose name was not received before the stream terminated.
+const UNKNOWN_TOOL_PLACEHOLDER: &str = "unknown_tool";
+
 /// Stream processing result
 #[derive(Debug, Clone)]
 pub struct StreamResult {
@@ -117,6 +120,9 @@ pub struct StreamResult {
     pub provider_metadata: Option<Value>,
     /// Whether this stream produced any user-visible output (text/thinking/tool events)
     pub has_effective_output: bool,
+    /// When set, the stream terminated abnormally but was recovered with partial output.
+    /// Contains a human-readable reason (e.g. "Stream processing error: ..." or "Stream data timeout ...").
+    pub partial_recovery_reason: Option<String>,
 }
 
 /// Stream processing error with output diagnostics.
@@ -160,6 +166,7 @@ struct StreamContext {
     thinking_chunks_count: usize,
     thinking_completed_sent: bool,
     has_effective_output: bool,
+    partial_recovery_reason: Option<String>,
 }
 
 impl StreamContext {
@@ -187,6 +194,7 @@ impl StreamContext {
             thinking_chunks_count: 0,
             thinking_completed_sent: false,
             has_effective_output: false,
+            partial_recovery_reason: None,
         }
     }
 
@@ -199,14 +207,12 @@ impl StreamContext {
             usage: self.usage,
             provider_metadata: self.provider_metadata,
             has_effective_output: self.has_effective_output,
+            partial_recovery_reason: self.partial_recovery_reason,
         }
     }
 
-    fn can_recover_as_partial_text_result(&self) -> bool {
+    fn can_recover_as_partial_result(&self) -> bool {
         self.has_effective_output
-            && !self.full_text.is_empty()
-            && self.tool_calls.is_empty()
-            && !self.pending_tool_call.has_pending()
     }
 
     fn finalize_pending_tool_call(
@@ -214,9 +220,19 @@ impl StreamContext {
         boundary: ToolCallBoundary,
     ) -> Option<FinalizedToolCall> {
         let finalized = self.pending_tool_call.finalize(boundary)?;
+        let tool_name = if finalized.tool_name.is_empty() {
+            UNKNOWN_TOOL_PLACEHOLDER.to_string()
+        } else {
+            finalized.tool_name.clone()
+        };
+        let tool_id = if finalized.tool_id.is_empty() {
+            uuid::Uuid::new_v4().to_string()
+        } else {
+            finalized.tool_id.clone()
+        };
         self.tool_calls.push(ToolCall {
-            tool_id: finalized.tool_id.clone(),
-            tool_name: finalized.tool_name.clone(),
+            tool_id,
+            tool_name,
             arguments: finalized.arguments.clone(),
             is_error: finalized.is_error,
         });
@@ -679,9 +695,11 @@ impl StreamProcessor {
                         Ok(Some(Err(e))) => {
                             let error_msg = format!("Stream processing error: {}", e);
                             error!("{}", error_msg);
-                            if ctx.can_recover_as_partial_text_result() {
+                            if ctx.can_recover_as_partial_result() {
                                 flush_sse_on_error(&sse_collector, &error_msg).await;
                                 self.send_thinking_end_if_needed(&mut ctx).await;
+                                ctx.force_finish_pending_tool_call();
+                                ctx.partial_recovery_reason = Some(error_msg.clone());
                                 self.log_stream_result(&ctx);
                                 break;
                             }
@@ -698,6 +716,13 @@ impl StreamProcessor {
                             error!("Stream data timeout ({} seconds), forcing termination", chunk_timeout.as_secs());
                             // log SSE for timeout errors
                             flush_sse_on_error(&sse_collector, &error_msg).await;
+                            if ctx.can_recover_as_partial_result() {
+                                self.send_thinking_end_if_needed(&mut ctx).await;
+                                ctx.force_finish_pending_tool_call();
+                                ctx.partial_recovery_reason = Some(error_msg.clone());
+                                self.log_stream_result(&ctx);
+                                break;
+                            }
                             self.graceful_shutdown_from_ctx(&mut ctx, error_msg.clone()).await;
                             return Err(StreamProcessError::new(
                                 BitFunError::AIClient(error_msg),

--- a/src/crates/core/src/agentic/image_analysis/image_processing.rs
+++ b/src/crates/core/src/agentic/image_analysis/image_processing.rs
@@ -272,6 +272,7 @@ pub fn build_multimodal_message(
             tool_calls: None,
             tool_call_id: None,
             name: None,
+            is_error: None,
             tool_image_attachments: None,
         }
     } else if provider_lower.contains("gemini") || provider_lower.contains("google") {
@@ -293,6 +294,7 @@ pub fn build_multimodal_message(
             tool_calls: None,
             tool_call_id: None,
             name: None,
+            is_error: None,
             tool_image_attachments: None,
         }
     } else {
@@ -316,6 +318,7 @@ pub fn build_multimodal_message(
             tool_calls: None,
             tool_call_id: None,
             name: None,
+            is_error: None,
             tool_image_attachments: None,
         }
     };
@@ -432,6 +435,7 @@ pub fn build_multimodal_message_with_images(
         tool_calls: None,
         tool_call_id: None,
         name: None,
+        is_error: None,
         tool_image_attachments: None,
     }])
 }

--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -1696,6 +1696,7 @@ impl SessionManager {
                 tool_calls: None,
                 tool_call_id: None,
                 name: None,
+                is_error: None,
                 tool_image_attachments: None,
             },
             Message {
@@ -1706,6 +1707,7 @@ impl SessionManager {
                 tool_calls: None,
                 tool_call_id: None,
                 name: None,
+                is_error: None,
                 tool_image_attachments: None,
             },
         ];

--- a/src/crates/core/src/infrastructure/ai/client.rs
+++ b/src/crates/core/src/infrastructure/ai/client.rs
@@ -2059,6 +2059,7 @@ impl AIClient {
             tool_calls: None,
             tool_call_id: None,
             name: None,
+            is_error: None,
             tool_image_attachments: None,
         }];
 

--- a/src/crates/core/src/infrastructure/ai/providers/anthropic/message_converter.rs
+++ b/src/crates/core/src/infrastructure/ai/providers/anthropic/message_converter.rs
@@ -177,6 +177,7 @@ impl AnthropicMessageConverter {
         let tool_call_id = msg.tool_call_id.unwrap_or_default();
         let text = msg.content.unwrap_or_default();
 
+        let is_error = msg.is_error.unwrap_or(false);
         let tool_content: Value =
             if let Some(attachments) = msg.tool_image_attachments.filter(|a| !a.is_empty()) {
                 let mut blocks: Vec<Value> = attachments
@@ -198,13 +199,18 @@ impl AnthropicMessageConverter {
                 json!(text)
             };
 
+        let mut tool_result = json!({
+            "type": "tool_result",
+            "tool_use_id": tool_call_id,
+            "content": tool_content,
+        });
+        if is_error {
+            tool_result["is_error"] = json!(true);
+        }
+
         json!({
             "role": "user",
-            "content": [{
-                "type": "tool_result",
-                "tool_use_id": tool_call_id,
-                "content": tool_content
-            }]
+            "content": [tool_result]
         })
     }
 

--- a/src/crates/core/src/infrastructure/ai/providers/gemini/message_converter.rs
+++ b/src/crates/core/src/infrastructure/ai/providers/gemini/message_converter.rs
@@ -102,7 +102,17 @@ impl GeminiMessageConverter {
                         continue;
                     }
 
-                    let response = Self::parse_tool_response(msg.content.as_deref());
+                    let is_error = msg.is_error.unwrap_or(false);
+                    let response = if is_error {
+                        let error_text = msg
+                            .content
+                            .as_deref()
+                            .filter(|s| !s.trim().is_empty())
+                            .unwrap_or("Tool execution failed");
+                        json!({ "error": error_text })
+                    } else {
+                        Self::parse_tool_response(msg.content.as_deref())
+                    };
                     let parts = vec![json!({
                         "functionResponse": {
                             "name": tool_name,
@@ -664,6 +674,7 @@ mod tests {
                 }]),
                 tool_call_id: None,
                 name: None,
+                is_error: None,
                 tool_image_attachments: None,
             },
             Message {
@@ -674,6 +685,7 @@ mod tests {
                 tool_calls: None,
                 tool_call_id: Some("call_1".to_string()),
                 name: Some("get_weather".to_string()),
+                is_error: None,
                 tool_image_attachments: None,
             },
         ];
@@ -717,6 +729,7 @@ mod tests {
             }]),
             tool_call_id: None,
             name: None,
+            is_error: None,
             tool_image_attachments: None,
         }];
 
@@ -754,6 +767,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: None,
             name: None,
+            is_error: None,
             tool_image_attachments: None,
         }];
 

--- a/src/crates/core/src/infrastructure/ai/providers/openai/message_converter.rs
+++ b/src/crates/core/src/infrastructure/ai/providers/openai/message_converter.rs
@@ -83,7 +83,13 @@ impl OpenAIMessageConverter {
 
     fn convert_tool_message_to_responses_item(msg: Message) -> Option<Value> {
         let call_id = msg.tool_call_id?;
+        let is_error = msg.is_error.unwrap_or(false);
         let text = msg.content.unwrap_or_default();
+        let text = if is_error && !text.starts_with("[TOOL ERROR]") {
+            format!("[TOOL ERROR] {}", text)
+        } else {
+            text
+        };
 
         // Responses API: `output` may be a string or a list of input_text / input_image / input_file
         // (see OpenAI FunctionCallOutput schema).
@@ -199,7 +205,16 @@ impl OpenAIMessageConverter {
         }
     }
 
-    fn convert_single_message(msg: Message) -> Value {
+    fn convert_single_message(mut msg: Message) -> Value {
+        // Prefix tool error content so the model can distinguish failures from normal results.
+        if msg.role == "tool" && msg.is_error.unwrap_or(false) {
+            if let Some(ref content) = msg.content {
+                if !content.starts_with("[TOOL ERROR]") {
+                    msg.content = Some(format!("[TOOL ERROR] {}", content));
+                }
+            }
+        }
+
         // Chat Completions: multimodal tool message (e.g. GPT-4o vision + tools) — image parts + text.
         if msg.role == "tool" {
             if let Some(ref attachments) = msg.tool_image_attachments {
@@ -374,6 +389,7 @@ mod tests {
                 tool_calls: None,
                 tool_call_id: Some("call_1".to_string()),
                 name: Some("get_weather".to_string()),
+                is_error: None,
                 tool_image_attachments: None,
             },
         ];
@@ -412,6 +428,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: None,
             name: None,
+            is_error: None,
             tool_image_attachments: None,
         }];
 
@@ -432,6 +449,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: Some("call_cu_1".to_string()),
             name: Some("computer_use".to_string()),
+            is_error: None,
             tool_image_attachments: Some(vec![ToolImageAttachment {
                 mime_type: "image/jpeg".to_string(),
                 data_base64: "AAA".to_string(),
@@ -462,6 +480,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: Some("call_1".to_string()),
             name: Some("computer_use".to_string()),
+            is_error: None,
             tool_image_attachments: Some(vec![ToolImageAttachment {
                 mime_type: "image/jpeg".to_string(),
                 data_base64: "YmFi".to_string(),

--- a/src/crates/core/src/util/types/message.rs
+++ b/src/crates/core/src/util/types/message.rs
@@ -19,6 +19,9 @@ pub struct Message {
     pub tool_call_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Indicates if the tool result is an error
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
     /// Images attached to a tool result (Anthropic multimodal tool_result).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_image_attachments: Option<Vec<ToolImageAttachment>>,
@@ -34,6 +37,7 @@ impl Message {
             tool_calls: None,
             tool_call_id: None,
             name: None,
+            is_error: None,
             tool_image_attachments: None,
         }
     }
@@ -47,6 +51,7 @@ impl Message {
             tool_calls: None,
             tool_call_id: None,
             name: None,
+            is_error: None,
             tool_image_attachments: None,
         }
     }
@@ -60,6 +65,7 @@ impl Message {
             tool_calls: Some(tool_calls),
             tool_call_id: None,
             name: None,
+            is_error: None,
             tool_image_attachments: None,
         }
     }
@@ -73,6 +79,7 @@ impl Message {
             tool_calls: None,
             tool_call_id: None,
             name: None,
+            is_error: None,
             tool_image_attachments: None,
         }
     }


### PR DESCRIPTION
## Summary

This PR improves agent stability when tool results fail and when model streams end abnormally.

## Changes

- **`Message.is_error`**: Internal `util::types::Message` carries tool error flag; `ToolResult` is mapped through `AIMessage` conversion (previously dropped).
- **Providers**:
  - **Anthropic**: `tool_result.is_error` is sent only when `true` (API-optional field).
  - **OpenAI**: Tool errors get a `[TOOL ERROR]` prefix on Responses and Chat Completions paths.
  - **Gemini**: Tool errors use `functionResponse.response: { "error": "..." }`.
- **Stream processor**: Broader partial recovery on stream error/timeout when there is effective output; force-finish pending tool calls; placeholder tool name (`UNKNOWN_TOOL_PLACEHOLDER`) and generated id when missing; `StreamResult.partial_recovery_reason` records why recovery happened.
- **Round executor**: `warn!` when a stream returns partial output after recovery.

## Testing

- `cargo check` / `cargo test` on `bitfun-core`: all tests pass.

## Notes

- OpenAI Responses API does not expose an Anthropic-style boolean on outputs; the prefix convention signals errors to the model.