### PR TITLE
feat(desktop): DMG helper docs; simplify Computer Use session UI

### DIFF
--- a/scripts/desktop-tauri-build.mjs
+++ b/scripts/desktop-tauri-build.mjs
@@ -6,6 +6,7 @@
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { readdirSync } from 'fs';
 import { ensureOpenSslWindows } from './ensure-openssl-windows.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -43,7 +44,54 @@ async function main() {
     console.error(r.error);
     process.exit(1);
   }
+
+  if (r.status === 0 && process.platform === 'darwin') {
+    patchDmgExtras(ROOT);
+  }
+
   process.exit(r.status ?? 1);
+}
+
+// Find all .dmg files under target/ and inject the helper TXT files
+// (quarantine removal instructions) into each one.
+function patchDmgExtras(root) {
+  const patchScript = join(root, 'scripts', 'patch-dmg-extras.sh');
+  const targetDir = join(root, 'target');
+
+  const dmgFiles = findDmgFiles(targetDir);
+  if (dmgFiles.length === 0) {
+    console.log('[patch-dmg] No .dmg files found — skipping.');
+    return;
+  }
+
+  for (const dmg of dmgFiles) {
+    console.log(`[patch-dmg] Patching ${dmg}`);
+    const p = spawnSync('bash', [patchScript, dmg], {
+      stdio: 'inherit',
+      shell: false,
+    });
+    if (p.status !== 0) {
+      console.error(`[patch-dmg] Failed to patch ${dmg}`);
+      process.exit(1);
+    }
+  }
+}
+
+function findDmgFiles(dir) {
+  const results = [];
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        results.push(...findDmgFiles(full));
+      } else if (entry.name.endsWith('.dmg')) {
+        results.push(full);
+      }
+    }
+  } catch {
+    // directory may not exist for some targets
+  }
+  return results;
 }
 
 main().catch((e) => {

--- a/scripts/patch-dmg-extras.sh
+++ b/scripts/patch-dmg-extras.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Inject extra TXT files into a Tauri-generated DMG.
+# Usage: ./scripts/patch-dmg-extras.sh <path-to.dmg>
+#
+# The script converts the read-only DMG to read-write, mounts it,
+# copies the helper TXT files, unmounts, and converts back to
+# a compressed read-only DMG (overwriting the original).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+EXTRAS_DIR="$ROOT_DIR/src/apps/desktop/dmg-extras"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <path-to.dmg>"
+  exit 1
+fi
+
+DMG_PATH="$1"
+
+if [[ ! -f "$DMG_PATH" ]]; then
+  echo "Error: DMG not found at $DMG_PATH"
+  exit 1
+fi
+
+if [[ ! -d "$EXTRAS_DIR" ]]; then
+  echo "Error: dmg-extras directory not found at $EXTRAS_DIR"
+  exit 1
+fi
+
+echo "==> Patching DMG: $DMG_PATH"
+
+WORK_DIR="$(mktemp -d)"
+RW_DMG="$WORK_DIR/rw.dmg"
+MOUNT_POINT="$WORK_DIR/mnt"
+
+cleanup() {
+  if mount | grep -q "$MOUNT_POINT"; then
+    hdiutil detach "$MOUNT_POINT" -quiet -force 2>/dev/null || true
+  fi
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+echo "    Converting to read-write..."
+hdiutil convert "$DMG_PATH" -format UDRW -o "$RW_DMG" -quiet
+
+echo "    Mounting read-write DMG..."
+mkdir -p "$MOUNT_POINT"
+hdiutil attach "$RW_DMG" -mountpoint "$MOUNT_POINT" -nobrowse -quiet
+
+echo "    Copying extra files..."
+for f in "$EXTRAS_DIR"/*.txt; do
+  if [[ -f "$f" ]]; then
+    cp "$f" "$MOUNT_POINT/"
+    echo "      + $(basename "$f")"
+  fi
+done
+
+echo "    Unmounting..."
+hdiutil detach "$MOUNT_POINT" -quiet
+
+echo "    Converting back to compressed read-only..."
+rm -f "$DMG_PATH"
+hdiutil convert "$RW_DMG" -format UDZO -o "$DMG_PATH" -quiet
+
+echo "==> Done: $DMG_PATH"

--- a/src/apps/desktop/dmg-extras/If app is damaged read this.txt
+++ b/src/apps/desktop/dmg-extras/If app is damaged read this.txt
@@ -1,0 +1,17 @@
+If macOS says "BitFun is damaged and can't be opened", follow these steps:
+
+1. Drag BitFun.app into the Applications folder
+2. Open Terminal (found in Applications > Utilities)
+3. Paste the following command and press Enter:
+
+   xattr -d com.apple.quarantine /Applications/BitFun.app
+
+4. Open BitFun again — it should launch normally
+
+---
+
+Why this happens:
+macOS Gatekeeper adds a quarantine flag to apps downloaded from the internet.
+Because BitFun is not yet notarized by Apple, the system incorrectly reports
+it as "damaged". The command above removes the quarantine flag and does not
+affect your system security.

--- a/src/apps/desktop/dmg-extras/如果提示已损坏请看这里.txt
+++ b/src/apps/desktop/dmg-extras/如果提示已损坏请看这里.txt
@@ -1,0 +1,16 @@
+如果 macOS 提示 "BitFun 已损坏，无法打开"，请按以下步骤操作：
+
+1. 将 BitFun.app 拖入 Applications（应用程序）文件夹
+2. 打开「终端」应用（在 应用程序 > 实用工具 中）
+3. 粘贴以下命令并按回车执行：
+
+   xattr -d com.apple.quarantine /Applications/BitFun.app
+
+4. 再次打开 BitFun 即可正常使用
+
+---
+
+原因说明：
+macOS 的 Gatekeeper 安全机制会对从网络下载的应用添加隔离标记。
+由于 BitFun 尚未进行 Apple 公证（Notarization），系统会误报"已损坏"。
+上述命令用于移除隔离标记，不会影响系统安全。

--- a/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
@@ -230,21 +230,6 @@ const SessionConfig: React.FC = () => {
     }
   };
 
-  const handleComputerUseRequestPermissions = async () => {
-    setComputerUseBusy(true);
-    try {
-      const { invoke } = await import('@tauri-apps/api/core');
-      await invoke('computer_use_request_permissions');
-      await refreshComputerUseStatus();
-      notificationService.success(t('messages.saveSuccess'), { duration: 2000 });
-    } catch (error) {
-      log.error('computer_use_request_permissions failed', error);
-      notificationService.error(t('messages.saveFailed'));
-    } finally {
-      setComputerUseBusy(false);
-    }
-  };
-
   const handleComputerUseOpenSettings = async (pane: 'accessibility' | 'screen_capture') => {
     try {
       const { invoke } = await import('@tauri-apps/api/core');
@@ -573,17 +558,6 @@ const SessionConfig: React.FC = () => {
                       <RefreshCw size={14} />
                     </IconButton>
                   </span>
-                  {!computerUseAccess ? (
-                    <Button
-                      className="bitfun-func-agent-config__row-action-btn"
-                      size="small"
-                      variant="secondary"
-                      disabled={computerUseBusy}
-                      onClick={() => void handleComputerUseRequestPermissions()}
-                    >
-                      {t('computerUse.request')}
-                    </Button>
-                  ) : null}
                   <Button
                     className="bitfun-func-agent-config__row-action-btn"
                     size="small"

--- a/src/web-ui/src/locales/en-US/settings/session-config.json
+++ b/src/web-ui/src/locales/en-US/settings/session-config.json
@@ -28,7 +28,6 @@
     "screenCaptureDesc": "",
     "granted": "Granted",
     "notGranted": "Not granted",
-    "request": "Request",
     "openSettings": "Setting",
     "refreshStatus": "Refresh status",
     "desktopOnly": "Computer use settings are only available in the BitFun desktop app.",

--- a/src/web-ui/src/locales/zh-CN/settings/session-config.json
+++ b/src/web-ui/src/locales/zh-CN/settings/session-config.json
@@ -28,7 +28,6 @@
     "screenCaptureDesc": "",
     "granted": "已授权",
     "notGranted": "未授权",
-    "request": "请求授权",
     "openSettings": "系统设置",
     "refreshStatus": "刷新状态",
     "desktopOnly": "Computer use 仅在 BitFun 桌面应用中可用。",


### PR DESCRIPTION
## Summary

- **macOS DMG**: After a successful `tauri build` on darwin, run `scripts/patch-dmg-extras.sh` to inject bilingual TXT files from `src/apps/desktop/dmg-extras/` into each generated `.dmg` (gatekeeper / "app is damaged" guidance).
- **Web UI**: Remove the session settings **Request** button that called `computer_use_request_permissions`; keep **Open settings** and **Refresh**. Drop unused `computerUse.request` i18n keys.

## Verification

- `pnpm run lint:web`
- `pnpm run type-check:web`
- `cargo check` (desktop crate)
