### PR TITLE
feat(web-ui): keyboard shortcuts hub, ShortcutManager, settings reference

### DIFF
--- a/src/crates/core/src/service/config/types.rs
+++ b/src/crates/core/src/service/config/types.rs
@@ -74,6 +74,11 @@ pub struct AppConfig {
     #[serde(default)]
     pub session_config: AppSessionConfig,
     pub ai_experience: AIExperienceConfig,
+    /// User-defined keyboard shortcut overrides.
+    /// Stored as opaque JSON so the backend remains schema-agnostic;
+    /// the frontend owns the versioned format (StoredKeybindingsV1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keybindings: Option<serde_json::Value>,
 }
 
 /// App logging configuration.
@@ -990,6 +995,7 @@ impl Default for AppConfig {
             },
             session_config: AppSessionConfig::default(),
             ai_experience: AIExperienceConfig::default(),
+            keybindings: None,
         }
     }
 }

--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useCallback, useState, useRef } from 'react';
+import { useShortcut } from '@/infrastructure/hooks/useShortcut';
 import { ChatProvider, useAIInitialization } from '../infrastructure';
 import { ViewModeProvider } from '../infrastructure/contexts/ViewModeProvider';
 import { SSHRemoteProvider } from '../features/ssh-remote';
@@ -10,6 +11,7 @@ import { ConfirmDialogRenderer } from '../component-library';
 import { createLogger } from '@/shared/utils/logger';
 import { useWorkspaceContext } from '../infrastructure/contexts/WorkspaceContext';
 import SplashScreen from './components/SplashScreen/SplashScreen';
+import { useGlobalSceneShortcuts } from './hooks/useGlobalSceneShortcuts';
 
 // Toolbar Mode
 import { ToolbarModeProvider } from '../flow_chat';
@@ -159,21 +161,16 @@ function App() {
     }
   }, [aiInitialized, aiInitializing, aiError, currentConfig]);
 
-  // Keyboard shortcuts
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Escape closes modal
-      if (e.key === 'Escape') {
-        window.dispatchEvent(new CustomEvent('closePreview'));
-      }
-    };
+  // Escape closes preview overlay (registered via ShortcutManager)
+  useShortcut(
+    'app.closePreview',
+    { key: 'Escape', scope: 'app', allowInInput: true },
+    () => window.dispatchEvent(new CustomEvent('closePreview')),
+    { priority: 1, description: 'keyboard.shortcuts.app.closePreview' }
+  );
 
-    window.addEventListener('keydown', handleKeyDown);
-    
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, []);
+  // Top SceneBar: Mod+Alt+1..9 / Mod+Alt+PageUp/PageDown
+  useGlobalSceneShortcuts();
 
   // Unified layout via a single AppLayout
   return (

--- a/src/web-ui/src/app/components/SceneBar/types.ts
+++ b/src/web-ui/src/app/components/SceneBar/types.ts
@@ -4,7 +4,7 @@
 
 import type { LucideIcon } from 'lucide-react';
 
-/** Scene tab identifier — max 3 open at a time */
+/** Scene tab identifier — concurrent open count is capped by MAX_OPEN_SCENES (see scene registry) */
 export type SceneTabId =
   | 'welcome'
   | 'session'

--- a/src/web-ui/src/app/components/panels/content-canvas/ContentCanvas.tsx
+++ b/src/web-ui/src/app/components/panels/content-canvas/ContentCanvas.tsx
@@ -145,7 +145,10 @@ export const ContentCanvas: React.FC<ContentCanvasProps> = ({
   };
 
   return (
-    <div className={`canvas-content-canvas ${layout.isMaximized ? 'is-maximized' : ''}`}>
+    <div
+      className={`canvas-content-canvas ${layout.isMaximized ? 'is-maximized' : ''}`}
+      data-shortcut-scope="canvas"
+    >
       {/* Main content */}
       {renderContent()}
 

--- a/src/web-ui/src/app/components/panels/content-canvas/hooks/useKeyboardShortcuts.ts
+++ b/src/web-ui/src/app/components/panels/content-canvas/hooks/useKeyboardShortcuts.ts
@@ -1,69 +1,21 @@
 /**
  * useKeyboardShortcuts Hook
- * Keyboard shortcut system.
+ *
+ * Registers canvas-level keyboard shortcuts via ShortcutManager.
+ * All shortcuts use scope 'canvas' so they only fire when focus is inside
+ * the editor canvas area (data-shortcut-scope="canvas").
  */
 
-import { useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
+import { useShortcut } from '@/infrastructure/hooks/useShortcut';
 import { useCanvasStore } from '../stores';
 import type { EditorGroupId } from '../types';
 
-/**
- * Shortcut definitions.
- */
-const SHORTCUTS = {
-  // Mission control
-  'mod+tab': 'toggleMissionControl',
-  
-  // Split layout
-  'mod+\\': 'toggleHorizontalSplit',
-  'mod+shift+\\': 'toggleVerticalSplit',
-  
-  // Anchor zone
-  'mod+`': 'toggleAnchorZone',
-  
-  // Maximize
-  'mod+shift+m': 'maximizeEditor',
-  
-  // Tab actions
-  'mod+w': 'closeCurrentTab',
-  'mod+shift+t': 'reopenClosedTab',
-  'mod+1': 'switchToTab1',
-  'mod+2': 'switchToTab2',
-  'mod+3': 'switchToTab3',
-  'mod+4': 'switchToTab4',
-  'mod+5': 'switchToTab5',
-  'mod+6': 'switchToTab6',
-  'mod+7': 'switchToTab7',
-  'mod+8': 'switchToTab8',
-  'mod+9': 'switchToLastTab',
-} as const;
-
-type ShortcutAction = typeof SHORTCUTS[keyof typeof SHORTCUTS];
-
 interface UseKeyboardShortcutsOptions {
-  /** Whether enabled */
   enabled?: boolean;
-  /** Dirty-check callback before closing tab */
   handleCloseWithDirtyCheck?: (tabId: string, groupId: EditorGroupId) => Promise<boolean>;
 }
 
-/**
- * Check if modifier keys are pressed.
- */
-const checkModifiers = (e: KeyboardEvent, mod: boolean, shift: boolean): boolean => {
-  const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-  const modPressed = isMac ? e.metaKey : e.ctrlKey;
-  
-  if (mod && !modPressed) return false;
-  if (shift && !e.shiftKey) return false;
-  if (!shift && e.shiftKey && mod) return false; // Shift pressed when not required
-  
-  return true;
-};
-
-/**
- * Keyboard shortcuts hook.
- */
 export const useKeyboardShortcuts = (options: UseKeyboardShortcutsOptions = {}) => {
   const { enabled = true, handleCloseWithDirtyCheck } = options;
 
@@ -80,142 +32,107 @@ export const useKeyboardShortcuts = (options: UseKeyboardShortcutsOptions = {}) 
     toggleMaximize,
     toggleMissionControl,
   } = useCanvasStore();
-  // Execute shortcut action
-  const executeAction = useCallback((action: ShortcutAction) => {
-    const activeGroup = activeGroupId === 'primary' ? primaryGroup : secondaryGroup;
-    const visibleTabs = activeGroup.tabs.filter(t => !t.isHidden);
 
-    switch (action) {
-      case 'toggleMissionControl':
-        toggleMissionControl();
-        break;
-        
-      case 'toggleHorizontalSplit':
-        setSplitMode(layout.splitMode === 'horizontal' ? 'none' : 'horizontal');
-        break;
-        
-      case 'toggleVerticalSplit':
-        setSplitMode(layout.splitMode === 'vertical' ? 'none' : 'vertical');
-        break;
-        
-      case 'toggleAnchorZone':
-        setAnchorPosition(layout.anchorPosition === 'hidden' ? 'bottom' : 'hidden');
-        break;
-        
-      case 'maximizeEditor':
-        toggleMaximize();
-        break;
-        
-      case 'closeCurrentTab':
-        if (activeGroup.activeTabId) {
-          if (handleCloseWithDirtyCheck) {
-            handleCloseWithDirtyCheck(activeGroup.activeTabId, activeGroupId);
-          } else {
-            closeTab(activeGroup.activeTabId, activeGroupId);
-          }
-        }
-        break;
-        
-      case 'reopenClosedTab':
-        reopenClosedTab();
-        break;
-        
-      case 'switchToTab1':
-      case 'switchToTab2':
-      case 'switchToTab3':
-      case 'switchToTab4':
-      case 'switchToTab5':
-      case 'switchToTab6':
-      case 'switchToTab7':
-      case 'switchToTab8': {
-        const tabIndex = parseInt(action.replace('switchToTab', '')) - 1;
-        if (visibleTabs[tabIndex]) {
-          switchToTab(visibleTabs[tabIndex].id, activeGroupId);
-        }
-        break;
+  const getActiveGroup = useCallback(() => {
+    return activeGroupId === 'primary' ? primaryGroup : secondaryGroup;
+  }, [activeGroupId, primaryGroup, secondaryGroup]);
+
+  const getVisibleTabs = useCallback(() => {
+    return getActiveGroup().tabs.filter((t) => !t.isHidden);
+  }, [getActiveGroup]);
+
+  // Mission control
+  useShortcut(
+    'canvas.missionControl',
+    { key: 'Tab', ctrl: true, scope: 'canvas', allowInInput: true },
+    () => toggleMissionControl(),
+    { enabled, priority: 10, description: 'keyboard.shortcuts.canvas.missionControl' }
+  );
+
+  // Horizontal split: mod+\
+  useShortcut(
+    'canvas.splitHorizontal',
+    { key: '\\', ctrl: true, scope: 'canvas' },
+    () => setSplitMode(layout.splitMode === 'horizontal' ? 'none' : 'horizontal'),
+    { enabled, description: 'keyboard.shortcuts.canvas.splitHorizontal' }
+  );
+
+  // Vertical split: mod+Shift+\
+  useShortcut(
+    'canvas.splitVertical',
+    { key: '\\', ctrl: true, shift: true, scope: 'canvas' },
+    () => setSplitMode(layout.splitMode === 'vertical' ? 'none' : 'vertical'),
+    { enabled, description: 'keyboard.shortcuts.canvas.splitVertical' }
+  );
+
+  // Anchor zone: mod+`
+  useShortcut(
+    'canvas.anchorZone',
+    { key: '`', ctrl: true, scope: 'canvas' },
+    () => setAnchorPosition(layout.anchorPosition === 'hidden' ? 'bottom' : 'hidden'),
+    { enabled, description: 'keyboard.shortcuts.canvas.anchorZone' }
+  );
+
+  // Maximize: mod+Shift+M
+  useShortcut(
+    'canvas.maximize',
+    { key: 'M', ctrl: true, shift: true, scope: 'canvas' },
+    () => toggleMaximize(),
+    { enabled, description: 'keyboard.shortcuts.canvas.maximize' }
+  );
+
+  // Close canvas preview/modal overlay: Escape
+  useShortcut(
+    'canvas.closePreview',
+    { key: 'Escape', scope: 'canvas', allowInInput: true },
+    () => window.dispatchEvent(new CustomEvent('closePreview')),
+    { enabled, priority: 5, description: 'keyboard.shortcuts.canvas.closePreview' }
+  );
+
+  // Close current tab: mod+W
+  useShortcut(
+    'tab.close',
+    { key: 'W', ctrl: true, scope: 'canvas', allowInInput: true },
+    () => {
+      const activeGroup = getActiveGroup();
+      if (!activeGroup.activeTabId) return;
+      if (handleCloseWithDirtyCheck) {
+        handleCloseWithDirtyCheck(activeGroup.activeTabId, activeGroupId);
+      } else {
+        closeTab(activeGroup.activeTabId, activeGroupId);
       }
-        
-      case 'switchToLastTab':
-        if (visibleTabs.length > 0) {
-          switchToTab(visibleTabs[visibleTabs.length - 1].id, activeGroupId);
-        }
-        break;
-    }
-  }, [
-    activeGroupId,
-    handleCloseWithDirtyCheck,
-    primaryGroup,
-    secondaryGroup,
-    layout,
-    toggleMissionControl,
-    setSplitMode,
-    setAnchorPosition,
-    toggleMaximize,
-    closeTab,
-    reopenClosedTab,
-    switchToTab,
-  ]);
+    },
+    { enabled, priority: 10, description: 'keyboard.shortcuts.tab.close' }
+  );
 
-  // Keyboard event handling
-  useEffect(() => {
-    if (!enabled) return;
+  // Reopen closed tab: mod+Shift+T
+  useShortcut(
+    'tab.reopenClosed',
+    { key: 'T', ctrl: true, shift: true, scope: 'canvas', allowInInput: true },
+    () => reopenClosedTab(),
+    { enabled, priority: 10, description: 'keyboard.shortcuts.tab.reopenClosed' }
+  );
 
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Skip most shortcuts when an input is focused
-      const activeElement = document.activeElement;
-      const isInputFocused = activeElement instanceof HTMLInputElement ||
-        activeElement instanceof HTMLTextAreaElement ||
-        (activeElement as HTMLElement)?.isContentEditable;
+  // Switch to tab by number: mod+1~9
+  const switchToTabByIndex = useCallback(
+    (index: number) => {
+      const tabs = getVisibleTabs();
+      const target = index === -1 ? tabs[tabs.length - 1] : tabs[index];
+      if (target) switchToTab(target.id, activeGroupId);
+    },
+    [getVisibleTabs, switchToTab, activeGroupId]
+  );
 
-      // Some shortcuts should still work while typing
-      const alwaysHandle = ['mod+tab', 'mod+w', 'mod+shift+t'];
-
-      // Check each shortcut
-      for (const [shortcut, action] of Object.entries(SHORTCUTS)) {
-        const parts = shortcut.split('+');
-        const key = parts[parts.length - 1];
-        const needsMod = parts.includes('mod');
-        const needsShift = parts.includes('shift');
-
-        // Check key
-        if (e.key.toLowerCase() !== key.toLowerCase() && 
-            e.key !== key && 
-            e.code !== `Key${key.toUpperCase()}` &&
-            e.code !== `Digit${key}` &&
-            e.key !== '`' && key !== '`') {
-          continue;
-        }
-
-        // Special handling for Tab
-        if (key === 'tab' && e.key !== 'Tab') continue;
-        
-        // Special handling for backtick
-        if (key === '`' && e.key !== '`') continue;
-
-        // Check modifiers
-        if (!checkModifiers(e, needsMod, needsShift)) {
-          continue;
-        }
-
-        // Only handle certain shortcuts when input is focused
-        if (isInputFocused && !alwaysHandle.includes(shortcut)) {
-          continue;
-        }
-
-        // Prevent default and execute action
-        e.preventDefault();
-        executeAction(action);
-        return;
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [enabled, executeAction]);
-
-  return {
-    executeAction,
-  };
+  // allowInInput so Ctrl+1..9 still work while focus is in a Monaco editor
+  useShortcut('tab.switch1',    { key: '1', ctrl: true, scope: 'canvas', allowInInput: true }, () => switchToTabByIndex(0),  { enabled, description: 'keyboard.shortcuts.tab.switchMerged' });
+  useShortcut('tab.switch2',    { key: '2', ctrl: true, scope: 'canvas', allowInInput: true }, () => switchToTabByIndex(1),  { enabled, description: 'keyboard.shortcuts.tab.switchMerged' });
+  useShortcut('tab.switch3',    { key: '3', ctrl: true, scope: 'canvas', allowInInput: true }, () => switchToTabByIndex(2),  { enabled, description: 'keyboard.shortcuts.tab.switchMerged' });
+  useShortcut('tab.switch4',    { key: '4', ctrl: true, scope: 'canvas', allowInInput: true }, () => switchToTabByIndex(3),  { enabled, description: 'keyboard.shortcuts.tab.switchMerged' });
+  useShortcut('tab.switch5',    { key: '5', ctrl: true, scope: 'canvas', allowInInput: true }, () => switchToTabByIndex(4),  { enabled, description: 'keyboard.shortcuts.tab.switchMerged' });
+  useShortcut('tab.switch6',    { key: '6', ctrl: true, scope: 'canvas', allowInInput: true }, () => switchToTabByIndex(5),  { enabled, description: 'keyboard.shortcuts.tab.switchMerged' });
+  useShortcut('tab.switch7',    { key: '7', ctrl: true, scope: 'canvas', allowInInput: true }, () => switchToTabByIndex(6),  { enabled, description: 'keyboard.shortcuts.tab.switchMerged' });
+  useShortcut('tab.switch8',    { key: '8', ctrl: true, scope: 'canvas', allowInInput: true }, () => switchToTabByIndex(7),  { enabled, description: 'keyboard.shortcuts.tab.switchMerged' });
+  useShortcut('tab.switchLast', { key: '9', ctrl: true, scope: 'canvas', allowInInput: true }, () => switchToTabByIndex(-1), { enabled, description: 'keyboard.shortcuts.tab.switchMerged' });
 };
 
 export default useKeyboardShortcuts;

--- a/src/web-ui/src/app/hooks/index.ts
+++ b/src/web-ui/src/app/hooks/index.ts
@@ -8,3 +8,4 @@ export * from './useSceneManager';
 export * from './useNavHistory';
 export * from './useCurrentSessionTitle';
 export * from './useCurrentSettingsTabTitle';
+export * from './useGlobalSceneShortcuts';

--- a/src/web-ui/src/app/hooks/useGlobalSceneShortcuts.ts
+++ b/src/web-ui/src/app/hooks/useGlobalSceneShortcuts.ts
@@ -1,0 +1,74 @@
+/**
+ * Global shortcuts for the top SceneBar and scene quick-open actions.
+ *
+ * Scene navigation (allowInInput: true — fires from anywhere):
+ *   Alt+1 / Alt+2 / Alt+3  — activate the 1st–3rd open scene left-to-right.
+ *
+ * Scene quick-open (allowInInput: true — fires from anywhere):
+ *   Mod+Shift+A — open Agent/Session scene
+ *   Mod+Shift+G — open Git scene
+ *   Mod+,       — open Settings scene
+ *   Mod+Shift+` — open Terminal scene
+ */
+
+import { useCallback } from 'react';
+import { useShortcut } from '@/infrastructure/hooks/useShortcut';
+import { useSceneStore } from '@/app/stores/sceneStore';
+import type { SceneTabId } from '@/app/components/SceneBar/types';
+
+function activateSceneByStripIndex(index: number): void {
+  const { openTabs, activateScene } = useSceneStore.getState();
+  if (index < 0 || index >= openTabs.length) return;
+  activateScene(openTabs[index].id);
+}
+
+function openSceneById(id: SceneTabId): void {
+  useSceneStore.getState().openScene(id);
+}
+
+export function useGlobalSceneShortcuts(): void {
+  const byIndex = useCallback((i: number) => () => activateSceneByStripIndex(i), []);
+
+  // ── Scene-bar position shortcuts (Alt+1–3) ────────────────────────────
+  useShortcut('scene.focus1', { key: '1', alt: true, scope: 'app', allowInInput: true }, byIndex(0), {
+    priority: 12,
+    description: 'keyboard.shortcuts.scene.focusMerged',
+  });
+  useShortcut('scene.focus2', { key: '2', alt: true, scope: 'app', allowInInput: true }, byIndex(1), {
+    priority: 12,
+    description: 'keyboard.shortcuts.scene.focusMerged',
+  });
+  useShortcut('scene.focus3', { key: '3', alt: true, scope: 'app', allowInInput: true }, byIndex(2), {
+    priority: 12,
+    description: 'keyboard.shortcuts.scene.focusMerged',
+  });
+
+  // ── Scene quick-open ──────────────────────────────────────────────────
+  useShortcut(
+    'scene.openSession',
+    { key: 'A', ctrl: true, shift: true, scope: 'app', allowInInput: true },
+    () => openSceneById('session'),
+    { priority: 10, description: 'keyboard.shortcuts.scene.openSession' }
+  );
+
+  useShortcut(
+    'scene.openGit',
+    { key: 'G', ctrl: true, shift: true, scope: 'app', allowInInput: true },
+    () => openSceneById('git'),
+    { priority: 10, description: 'keyboard.shortcuts.scene.openGit' }
+  );
+
+  useShortcut(
+    'scene.openSettings',
+    { key: ',', ctrl: true, scope: 'app', allowInInput: true },
+    () => openSceneById('settings'),
+    { priority: 10, description: 'keyboard.shortcuts.scene.openSettings' }
+  );
+
+  useShortcut(
+    'scene.openTerminal',
+    { key: '`', ctrl: true, shift: true, scope: 'app', allowInInput: true },
+    () => openSceneById('terminal'),
+    { priority: 10, description: 'keyboard.shortcuts.scene.openTerminal' }
+  );
+}

--- a/src/web-ui/src/app/layout/AppLayout.tsx
+++ b/src/web-ui/src/app/layout/AppLayout.tsx
@@ -15,6 +15,8 @@ import { useWindowControls } from '../hooks/useWindowControls';
 import { useAssistantBootstrap } from '../hooks/useAssistantBootstrap';
 import { useApp } from '../hooks/useApp';
 import { useSceneStore } from '../stores/sceneStore';
+import { useShortcut } from '@/infrastructure/hooks/useShortcut';
+import { configManager } from '@/infrastructure/config';
 
 type TransitionDirection = 'entering' | 'returning' | null;
 import { FlowChatManager } from '../../flow_chat/services/FlowChatManager';
@@ -30,7 +32,7 @@ import { createLogger } from '@/shared/utils/logger';
 import { useI18n } from '@/infrastructure/i18n';
 import { WorkspaceKind } from '@/shared/types';
 import { SSHContext } from '@/features/ssh-remote/SSHRemoteContext';
-import { shortcutManager } from '@/infrastructure/services/ShortcutManager';
+import { shortcutManager, parseStoredKeybindings } from '@/infrastructure/services/ShortcutManager';
 import { useSessionModeStore } from '../stores/sessionModeStore';
 import './AppLayout.scss';
 
@@ -64,6 +66,32 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
     useWindowControls({ isToolbarMode });
 
   const { state, switchLeftPanelTab, toggleLeftPanel, toggleRightPanel } = useApp();
+
+  // ── Load user keybinding overrides from config on startup ────────────────
+  useEffect(() => {
+    let unsubscribe: (() => void) | undefined;
+
+    const load = async () => {
+      try {
+        const raw = await configManager.getConfig('app.keybindings');
+        const overrides = parseStoredKeybindings(raw);
+        if (Object.keys(overrides).length > 0) {
+          shortcutManager.loadUserOverrides(overrides);
+        }
+      } catch {
+        // No overrides stored yet — that's fine
+      }
+    };
+
+    void load();
+
+    unsubscribe = configManager.onConfigChange((path) => {
+      if (path === 'app.keybindings') void load();
+    });
+
+    return () => unsubscribe?.();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const activeSceneId = useSceneStore(s => s.activeTabId);
   const isAgentScene = activeSceneId === 'session';
   const isWelcomeScene = activeSceneId === 'welcome';
@@ -326,26 +354,30 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
     return () => window.removeEventListener('toolbar-send-message', handleToolbarSendMessage);
   }, []);
 
-  // Global /btw shortcut (Ctrl/Cmd+Alt+B): fill ChatInput with "/btw ".
-  React.useEffect(() => {
-    const unregister = shortcutManager.register(
-      'btw-fill',
-      { key: 'B', ctrl: true, alt: true },
-      () => {
-        const selected = (window.getSelection?.()?.toString() ?? '').trim();
-        const message = selected ? `/btw Explain this:\n\n${selected}` : '/btw ';
-        window.dispatchEvent(new CustomEvent('fill-chat-input', { detail: { message } }));
-      },
-      {
-        description: 'Fill /btw into chat input',
-        priority: 20
-      }
-    );
+  // Toggle left panel: mod+B (VS Code convention)
+  useShortcut(
+    'panel.toggleLeft',
+    { key: 'B', ctrl: true, scope: 'app' },
+    () => toggleLeftPanel(),
+    { priority: 5, description: 'keyboard.shortcuts.panel.toggleLeft' }
+  );
 
-    return () => {
-      unregister();
-    };
-  }, []);
+  // Collapse/expand both panels: mod+Shift+B
+  useShortcut(
+    'panel.toggleBoth',
+    { key: 'B', ctrl: true, shift: true, scope: 'app' },
+    () => {
+      const bothCollapsed = state.layout.leftPanelCollapsed && state.layout.rightPanelCollapsed;
+      if (bothCollapsed) {
+        toggleLeftPanel();
+        setTimeout(() => toggleRightPanel(), 50);
+      } else {
+        if (!state.layout.leftPanelCollapsed) toggleLeftPanel();
+        if (!state.layout.rightPanelCollapsed) toggleRightPanel();
+      }
+    },
+    { priority: 5, description: 'keyboard.shortcuts.panel.toggleBoth' }
+  );
 
   // Toolbar cancel task
   React.useEffect(() => {

--- a/src/web-ui/src/app/layout/AppLayout.tsx
+++ b/src/web-ui/src/app/layout/AppLayout.tsx
@@ -69,8 +69,6 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
 
   // ── Load user keybinding overrides from config on startup ────────────────
   useEffect(() => {
-    let unsubscribe: (() => void) | undefined;
-
     const load = async () => {
       try {
         const raw = await configManager.getConfig('app.keybindings');
@@ -85,12 +83,11 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
 
     void load();
 
-    unsubscribe = configManager.onConfigChange((path) => {
+    const unsubscribe = configManager.onConfigChange((path) => {
       if (path === 'app.keybindings') void load();
     });
 
-    return () => unsubscribe?.();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => unsubscribe();
   }, []);
   const activeSceneId = useSceneStore(s => s.activeTabId);
   const isAgentScene = activeSceneId === 'session';

--- a/src/web-ui/src/app/scenes/git/GitScene.tsx
+++ b/src/web-ui/src/app/scenes/git/GitScene.tsx
@@ -143,7 +143,7 @@ const GitScene: React.FC<GitSceneProps> = ({
     );
   }
 
-  return <div className="bitfun-git-scene">{renderView()}</div>;
+  return <div className="bitfun-git-scene" data-shortcut-scope="git">{renderView()}</div>;
 };
 
 export default GitScene;

--- a/src/web-ui/src/app/scenes/git/views/WorkingCopyView.tsx
+++ b/src/web-ui/src/app/scenes/git/views/WorkingCopyView.tsx
@@ -3,6 +3,7 @@
  */
 
 import React, { useCallback, useState, useMemo, useEffect, useRef } from 'react';
+import { useShortcut } from '@/infrastructure/hooks/useShortcut';
 import { useTranslation } from 'react-i18next';
 import {
   GitBranch,
@@ -93,7 +94,7 @@ const WorkingCopyView: React.FC<WorkingCopyViewProps> = ({
     [currentBranch, staged, unstaged, untracked, ahead, behind]
   );
 
-  const { isOperating, addFiles, commit, push, pull } = useGitOperations({
+  const { isOperating, addFiles, commit, push, pull, resetFiles } = useGitOperations({
     repositoryPath: workspacePath ?? '',
     autoRefresh: false,
   });
@@ -310,6 +311,76 @@ const WorkingCopyView: React.FC<WorkingCopyViewProps> = ({
     document.addEventListener('mousemove', onMouseMove);
     document.addEventListener('mouseup', onMouseUp);
   }, [fileListWidth]);
+
+  const handleGitStageAll = useCallback(async () => {
+    const files = getAllUnstagedFiles();
+    if (files.length === 0) return;
+    const result = await addFiles({ files, all: false });
+    if (result.success) {
+      setSelectedFiles(new Set());
+      await handleRefresh();
+      notification.success(t('notifications.stageSuccess', { count: files.length }));
+    } else if (result.error) notification.error(t('notifications.stageFailed', { error: result.error }));
+  }, [getAllUnstagedFiles, addFiles, handleRefresh, notification, t]);
+
+  const handleGitUnstageAll = useCallback(async () => {
+    if (!status?.staged?.length) return;
+    const paths = status.staged.map((f: { path: string }) => f.path);
+    const result = await resetFiles(paths, true);
+    if (result.success) await handleRefresh();
+    else if (result.error) notification.error(result.error);
+  }, [status, resetFiles, handleRefresh, notification]);
+
+  const gitShortcutsEnabled = Boolean(workspacePath) && isActive;
+
+  useShortcut(
+    'git.refresh',
+    { key: 'F5', scope: 'git' },
+    () => {
+      void handleRefresh();
+    },
+    { enabled: gitShortcutsEnabled, description: 'keyboard.shortcuts.git.refresh' }
+  );
+  useShortcut(
+    'git.commit',
+    { key: 'Enter', ctrl: true, scope: 'git', allowInInput: true },
+    () => {
+      void handleQuickCommit();
+    },
+    { enabled: gitShortcutsEnabled, description: 'keyboard.shortcuts.git.commit' }
+  );
+  useShortcut(
+    'git.push',
+    { key: 'P', ctrl: true, shift: true, scope: 'git' },
+    () => {
+      void handlePush();
+    },
+    { enabled: gitShortcutsEnabled, description: 'keyboard.shortcuts.git.push' }
+  );
+  useShortcut(
+    'git.pull',
+    { key: 'L', ctrl: true, shift: true, scope: 'git' },
+    () => {
+      void handlePull();
+    },
+    { enabled: gitShortcutsEnabled, description: 'keyboard.shortcuts.git.pull' }
+  );
+  useShortcut(
+    'git.stageAll',
+    { key: 'A', ctrl: true, shift: true, scope: 'git' },
+    () => {
+      void handleGitStageAll();
+    },
+    { enabled: gitShortcutsEnabled, description: 'keyboard.shortcuts.git.stageAll' }
+  );
+  useShortcut(
+    'git.unstageAll',
+    { key: 'U', ctrl: true, shift: true, scope: 'git' },
+    () => {
+      void handleGitUnstageAll();
+    },
+    { enabled: gitShortcutsEnabled, description: 'keyboard.shortcuts.git.unstageAll' }
+  );
 
   if (!workspacePath) {
     return (

--- a/src/web-ui/src/app/scenes/registry.ts
+++ b/src/web-ui/src/app/scenes/registry.ts
@@ -2,7 +2,7 @@
  * SCENE_TAB_REGISTRY — static definitions for all scene tab types.
  *
  * Rules:
- *  - Max 3 open tabs total.
+ *  - Max MAX_OPEN_SCENES open tabs total.
  *  - pinned = true: protected from auto-eviction and manual close.
  *  - pinned = false: can be auto-evicted and manually closed.
  */
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react';
 import type { SceneTabDef, SceneTabId } from '../components/SceneBar/types';
 
+/** Upper bound for concurrent open scene tabs (top bar); oldest closable tab is evicted when exceeded. */
 export const MAX_OPEN_SCENES = 3;
 
 export const SCENE_TAB_REGISTRY: SceneTabDef[] = [

--- a/src/web-ui/src/app/scenes/session/SessionScene.tsx
+++ b/src/web-ui/src/app/scenes/session/SessionScene.tsx
@@ -12,14 +12,12 @@
 import React, { useRef, useState, useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApp } from '../../hooks/useApp';
-
 import ChatPane from './ChatPane';
 import AuxPane, { type AuxPaneRef } from './AuxPane';
 
 import {
   RIGHT_PANEL_CONFIG,
   PANEL_COMMON_CONFIG,
-  PANEL_SHORTCUTS,
   STORAGE_KEYS,
   PanelDisplayMode,
   getPanelDisplayMode,
@@ -96,13 +94,6 @@ const SessionScene: React.FC<SessionSceneProps> = ({
     saveAndUpdateRightWidth(calculateValidRightWidth(targetWidth));
   }, [rightPanelMode, calculateValidRightWidth, saveAndUpdateRightWidth]);
 
-  const handleToggleAuxPane = useCallback(() => {
-    if (state.layout.rightPanelCollapsed) {
-      updateRightPanelWidth(calculateValidRightWidth(lastRightWidth));
-    }
-    toggleRightPanel();
-  }, [state.layout.rightPanelCollapsed, lastRightWidth, calculateValidRightWidth, updateRightPanelWidth, toggleRightPanel]);
-
   const handleMouseDownResizer = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     if (!containerRef.current) return;
@@ -150,20 +141,6 @@ const SessionScene: React.FC<SessionSceneProps> = ({
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
   }, [currentRightWidth, calculateValidRightWidth, updateRightPanelWidth, saveAndUpdateRightWidth, state.layout.chatCollapsed]);
-
-  // Keyboard shortcut: Ctrl+] toggle aux pane
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      const isMac = navigator.platform.toUpperCase().includes('MAC');
-      const ctrlOrMeta = isMac ? e.metaKey : e.ctrlKey;
-      if (ctrlOrMeta && e.key === PANEL_SHORTCUTS.TOGGLE_RIGHT.key && !e.shiftKey) {
-        e.preventDefault();
-        handleToggleAuxPane();
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleToggleAuxPane]);
 
   // No-animation expansion
   const [isAuxPaneExpandingImmediate, setIsAuxPaneExpandingImmediate] = useState(false);

--- a/src/web-ui/src/app/scenes/session/SessionScene.tsx
+++ b/src/web-ui/src/app/scenes/session/SessionScene.tsx
@@ -49,7 +49,7 @@ const SessionScene: React.FC<SessionSceneProps> = ({
   const [isDragging, setIsDragging] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
 
-  const [lastRightWidth, setLastRightWidth] = useState<number>(() =>
+  const [, setLastRightWidth] = useState<number>(() =>
     loadPanelWidth(STORAGE_KEYS.RIGHT_PANEL_LAST_WIDTH, RIGHT_PANEL_CONFIG.COMFORTABLE_DEFAULT)
   );
 

--- a/src/web-ui/src/app/scenes/settings/SettingsNav.scss
+++ b/src/web-ui/src/app/scenes/settings/SettingsNav.scss
@@ -207,9 +207,30 @@
     gap: 2px;
   }
 
+  &__item-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
+  }
+
+  &__item-beta {
+    flex-shrink: 0;
+    margin-left: $size-gap-2;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+  }
+
   &__item {
     display: flex;
     align-items: center;
+    justify-content: space-between;
+    gap: $size-gap-2;
     height: 32px;
     padding: 0 $size-gap-2 0 $size-gap-3;
     border: none;

--- a/src/web-ui/src/app/scenes/settings/SettingsNav.tsx
+++ b/src/web-ui/src/app/scenes/settings/SettingsNav.tsx
@@ -20,7 +20,7 @@ import React, {
 } from 'react';
 import type { i18n as I18nApi } from 'i18next';
 import { useTranslation } from 'react-i18next';
-import { Search } from '@/component-library';
+import { Search, Badge } from '@/component-library';
 import { useSettingsStore } from './settingsStore';
 import { SETTINGS_CATEGORIES } from './settingsConfig';
 import type { ConfigTab } from './settingsConfig';
@@ -376,7 +376,14 @@ const SettingsNav: React.FC = () => {
                       .join(' ')}
                     onClick={() => handleTabClick(tabDef.id)}
                   >
-                    {t(tabDef.labelKey, { defaultValue: tabDef.id })}
+                    <span className="bitfun-settings-nav__item-label">
+                      {t(tabDef.labelKey, { defaultValue: tabDef.id })}
+                    </span>
+                    {tabDef.beta ? (
+                      <Badge variant="warning" className="bitfun-settings-nav__item-beta">
+                        {t('configCenter.beta')}
+                      </Badge>
+                    ) : null}
                   </button>
                 ))}
               </div>

--- a/src/web-ui/src/app/scenes/settings/SettingsScene.tsx
+++ b/src/web-ui/src/app/scenes/settings/SettingsScene.tsx
@@ -6,7 +6,7 @@
  * driven by settingsStore.activeTab.
  */
 
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { useSettingsStore } from './settingsStore';
 import './SettingsScene.scss';
 import AIModelConfig from '../../../infrastructure/config/components/AIModelConfig';
@@ -16,8 +16,22 @@ import McpToolsConfig from '../../../infrastructure/config/components/McpToolsCo
 import EditorConfig from '../../../infrastructure/config/components/EditorConfig';
 import BasicsConfig from '../../../infrastructure/config/components/BasicsConfig';
 
+const KeyboardShortcutsTab = lazy(() => import('./components/KeyboardShortcutsTab'));
+
 const SettingsScene: React.FC = () => {
   const activeTab = useSettingsStore(s => s.activeTab);
+
+  if (activeTab === 'keyboard') {
+    return (
+      <div className="bitfun-settings-scene">
+        <div key="keyboard" className="bitfun-settings-scene__content-wrapper">
+          <Suspense fallback={null}>
+            <KeyboardShortcutsTab />
+          </Suspense>
+        </div>
+      </div>
+    );
+  }
 
   let Content: React.ComponentType | null = null;
 

--- a/src/web-ui/src/app/scenes/settings/components/KeyboardShortcutsTab.scss
+++ b/src/web-ui/src/app/scenes/settings/components/KeyboardShortcutsTab.scss
@@ -1,0 +1,218 @@
+.kb-shortcuts {
+  &__toolbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 20px;
+  }
+
+  /** Component-library `Search` — align with settings nav capsule */
+  &__search.search {
+    flex: 1;
+    min-width: 0;
+
+    .search__wrapper {
+      height: 32px;
+      min-height: 32px;
+      padding: 0 10px;
+      gap: 8px;
+      border-radius: 6px;
+      /* Match Search defaults; --color-border alone can be undefined and drop the border */
+      border: 1px solid var(--border-base);
+      background: var(--color-bg-input, var(--color-surface));
+      transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    &.search--hovered:not(.search--disabled) .search__wrapper {
+      border-color: var(--border-medium);
+    }
+
+    &.search--focused .search__wrapper,
+    .search__wrapper:focus-within {
+      border-color: var(--color-accent-500, var(--color-accent));
+      box-shadow: 0 0 0 2px var(--color-accent-alpha, rgba(99, 102, 241, 0.2));
+    }
+
+    .search__input {
+      font-size: 13px;
+
+      &::placeholder {
+        color: var(--color-text-tertiary);
+      }
+    }
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  &__error {
+    padding: 8px 12px;
+    margin-bottom: 16px;
+    border-radius: 6px;
+    background: var(--color-error-surface, rgba(239, 68, 68, 0.1));
+    color: var(--color-error, #ef4444);
+    font-size: 13px;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    border-radius: 6px;
+    transition: background 0.1s;
+
+    &:hover {
+      background: var(--color-bg-hover, rgba(0, 0, 0, 0.04));
+    }
+
+    &--recording {
+      background: var(--color-accent-alpha, rgba(99, 102, 241, 0.08));
+    }
+
+    &--conflict {
+      background: var(--color-warning-surface, rgba(245, 158, 11, 0.08));
+    }
+
+    &--modified .kb-shortcuts__item-name {
+      font-style: italic;
+    }
+  }
+
+  &__item-label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__item-name {
+    font-size: 13px;
+    color: var(--color-text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__item-hint {
+    font-size: 10px;
+    line-height: 1.35;
+    color: var(--color-text-tertiary);
+    font-weight: 400;
+    white-space: normal;
+    opacity: 0.62;
+  }
+
+  &__item-conflict-hint {
+    font-size: 11px;
+    color: var(--color-warning, #f59e0b);
+  }
+
+  &__item-key {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+    margin-left: 16px;
+  }
+
+  &__item--merged {
+    opacity: 0.95;
+  }
+
+  &__keybadge--readonly {
+    cursor: default;
+    user-select: none;
+
+    &:hover {
+      border-color: var(--color-border);
+      color: var(--color-text-secondary);
+    }
+  }
+
+  &__keybadge {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    font-family: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+    font-size: 12px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: border-color 0.1s, background 0.1s;
+    min-width: 60px;
+    justify-content: center;
+
+    &:hover {
+      border-color: var(--color-accent);
+      color: var(--color-text-primary);
+    }
+
+    &--recording {
+      border-color: var(--color-accent);
+      background: var(--color-accent-alpha, rgba(99, 102, 241, 0.1));
+      color: var(--color-accent);
+      animation: kb-pulse 1s ease-in-out infinite;
+    }
+
+    &--conflict {
+      border-color: var(--color-warning, #f59e0b);
+      color: var(--color-warning, #f59e0b);
+    }
+  }
+
+  &__revert-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    border: 1px solid var(--color-border);
+    background: transparent;
+    color: var(--color-text-tertiary);
+    font-size: 13px;
+    cursor: pointer;
+    padding: 0;
+
+    &:hover {
+      color: var(--color-text-primary);
+      border-color: var(--color-text-secondary);
+    }
+  }
+
+  &__empty {
+    padding: 32px;
+    text-align: center;
+    color: var(--color-text-tertiary);
+    font-size: 14px;
+  }
+}
+
+@keyframes kb-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+/* Page subtitle: keep primary title dominant */
+.kb-shortcuts-page-header.bitfun-config-page-header {
+  .bitfun-config-page-header__subtitle {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-tertiary);
+    opacity: 0.88;
+  }
+}

--- a/src/web-ui/src/app/scenes/settings/components/KeyboardShortcutsTab.tsx
+++ b/src/web-ui/src/app/scenes/settings/components/KeyboardShortcutsTab.tsx
@@ -1,0 +1,819 @@
+/**
+ * KeyboardShortcutsTab — settings page for viewing and remapping keyboard shortcuts.
+ *
+ * Features:
+ * - Grouped by scope with i18n labels
+ * - Search filter by action name or key combination
+ * - Click-to-record new key binding (capture mode)
+ * - Real-time conflict detection (highlighted in red)
+ * - Apply saves to configManager at path 'app.keybindings'
+ * - Reset button restores all defaults
+ */
+
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { Button, Search, Tooltip } from '@/component-library';
+import { useI18n } from '@/infrastructure/i18n';
+import { ConfigPageLayout, ConfigPageHeader, ConfigPageContent, ConfigPageSection } from '@/infrastructure/config/components/common';
+import {
+  shortcutManager,
+  parseStoredKeybindings,
+  buildStoredKeybindings,
+  type ShortcutRegistration,
+  type KeybindingOverrides,
+} from '@/infrastructure/services/ShortcutManager';
+import { configManager } from '@/infrastructure/config';
+import type { ShortcutConfig, ShortcutScope } from '@/shared/types/shortcut';
+import {
+  ALL_SHORTCUTS,
+  SCOPE_ORDER,
+  SCOPE_LABEL_KEYS,
+  getShortcutDescriptionI18nKey,
+  NON_USER_CUSTOMIZABLE_SHORTCUT_IDS,
+} from '@/shared/constants/shortcuts';
+import { createLogger } from '@/shared/utils/logger';
+import './KeyboardShortcutsTab.scss';
+
+const log = createLogger('KeyboardShortcutsTab');
+
+const SCOPE_DISPLAY_ORDER: ShortcutScope[] = SCOPE_ORDER;
+
+/** SceneBar Alt+1–3: merged into one row in settings; not listed individually */
+const MERGED_SCENE_FOCUS_IDS = new Set(['scene.focus1', 'scene.focus2', 'scene.focus3']);
+
+/** Canvas tabs Mod+1–9: merged into one row in settings; not listed individually */
+const MERGED_TAB_SWITCH_IDS = new Set([
+  'tab.switch1',
+  'tab.switch2',
+  'tab.switch3',
+  'tab.switch4',
+  'tab.switch5',
+  'tab.switch6',
+  'tab.switch7',
+  'tab.switch8',
+  'tab.switchLast',
+]);
+
+const MERGED_SCENE_RECORD_ID = '__merged_scene__';
+const MERGED_TAB_RECORD_ID = '__merged_tab__';
+
+const SCENE_FOCUS_ORDER = ['scene.focus1', 'scene.focus2', 'scene.focus3'] as const;
+const TAB_SWITCH_ORDER = [
+  'tab.switch1',
+  'tab.switch2',
+  'tab.switch3',
+  'tab.switch4',
+  'tab.switch5',
+  'tab.switch6',
+  'tab.switch7',
+  'tab.switch8',
+  'tab.switchLast',
+] as const;
+
+/**
+ * Merge live ShortcutManager registrations with the static catalog so the settings UI
+ * lists every known shortcut even when no runtime useShortcut has registered yet.
+ */
+/** Key cap label: bare space is invisible in UI; other single chars stay upper-case. */
+function formatShortcutKeyCap(key: string, t: (key: string) => string): string {
+  if (key === ' ') return t('keyboard.keyLabels.space');
+  if (key.length === 1) return key.toUpperCase();
+  return key;
+}
+
+function mergeCatalogWithLive(live: ShortcutRegistration[]): ShortcutRegistration[] {
+  const liveById = new Map(live.map((r) => [r.id, r]));
+  const out: ShortcutRegistration[] = [];
+  for (const def of ALL_SHORTCUTS) {
+    const hit = liveById.get(def.id);
+    if (hit) {
+      out.push(hit);
+      liveById.delete(def.id);
+    } else {
+      out.push({
+        id: def.id,
+        config: shortcutManager.getEffectiveConfig(def.id, def.config),
+        callback: () => {},
+        priority: 0,
+        description: def.descriptionKey,
+      });
+    }
+  }
+  for (const r of liveById.values()) {
+    out.push(r);
+  }
+  out.sort((a, b) => {
+    const scopeOrder: Record<ShortcutScope, number> = { app: 0, chat: 1, canvas: 2, filetree: 3, git: 4 };
+    const sa = scopeOrder[a.config.scope ?? 'app'];
+    const sb = scopeOrder[b.config.scope ?? 'app'];
+    if (sa !== sb) return sa - sb;
+    return b.priority - a.priority;
+  });
+  return out;
+}
+
+function captureDigit(e: KeyboardEvent): string | null {
+  const code = e.code ?? '';
+  const d = /^Digit([1-9])$/i.exec(code);
+  if (d) return d[1];
+  const n = /^Numpad([1-9])$/i.exec(code);
+  if (n) return n[1];
+  return null;
+}
+
+function modSignature(cfg: ShortcutConfig): string {
+  const isMac = typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC');
+  const primary = isMac ? Boolean(cfg.meta || cfg.ctrl) : Boolean(cfg.ctrl);
+  return [primary ? '1' : '0', cfg.shift ? '1' : '0', cfg.alt ? '1' : '0'].join('');
+}
+
+function getEffectiveConfig(reg: ShortcutRegistration, pending?: PendingChange): ShortcutConfig {
+  if (!pending) return reg.config;
+  return {
+    ...reg.config,
+    key: pending.key,
+    ctrl: pending.ctrl,
+    shift: pending.shift,
+    alt: pending.alt,
+  };
+}
+
+function sceneGroupUniform(
+  registrations: ShortcutRegistration[],
+  pending: Record<string, PendingChange>
+): boolean {
+  const cfgs = SCENE_FOCUS_ORDER.map((id) => {
+    const reg = registrations.find((r) => r.id === id);
+    if (!reg) return null;
+    return getEffectiveConfig(reg, pending[id]);
+  });
+  if (cfgs.some((c) => !c)) return false;
+  const m0 = modSignature(cfgs[0]!);
+  return (
+    m0 === modSignature(cfgs[1]!) &&
+    m0 === modSignature(cfgs[2]!) &&
+    cfgs[0]!.key === '1' &&
+    cfgs[1]!.key === '2' &&
+    cfgs[2]!.key === '3'
+  );
+}
+
+function tabGroupUniform(
+  registrations: ShortcutRegistration[],
+  pending: Record<string, PendingChange>
+): boolean {
+  const cfgs = TAB_SWITCH_ORDER.map((id) => {
+    const reg = registrations.find((r) => r.id === id);
+    if (!reg) return null;
+    return getEffectiveConfig(reg, pending[id]);
+  });
+  if (cfgs.some((c) => !c)) return false;
+  const m0 = modSignature(cfgs[0]!);
+  for (let i = 0; i < 9; i++) {
+    if (modSignature(cfgs[i]!) !== m0) return false;
+    if (cfgs[i]!.key !== String(i + 1)) return false;
+  }
+  return true;
+}
+
+function formatModifierPrefix(cfg: ShortcutConfig): string {
+  const isMac = typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC');
+  const primary = isMac ? Boolean(cfg.meta || cfg.ctrl) : Boolean(cfg.ctrl);
+  const parts: string[] = [];
+  if (primary) parts.push(isMac ? '⌘' : 'Ctrl');
+  if (cfg.shift) parts.push(isMac ? '⇧' : 'Shift');
+  if (cfg.alt) parts.push(isMac ? '⌥' : 'Alt');
+  return parts.join(isMac ? '' : '+');
+}
+
+function formatMergedRangeLabel(cfg: ShortcutConfig, range: '1–3' | '1–9'): string {
+  const prefix = formatModifierPrefix(cfg);
+  const isMac = typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC');
+  if (!prefix) return range;
+  return isMac ? `${prefix}${range}` : `${prefix}+${range}`;
+}
+
+function firstConflictInGroup(
+  ids: readonly string[],
+  registrations: ShortcutRegistration[],
+  pendingChanges: Record<string, PendingChange>
+): ShortcutRegistration | null {
+  for (const id of ids) {
+    const reg = registrations.find((r) => r.id === id);
+    if (!reg) continue;
+    const eff = getEffectiveConfig(reg, pendingChanges[id]);
+    const conflicts = shortcutManager.checkConflicts(
+      {
+        key: eff.key,
+        ctrl: !!eff.ctrl,
+        shift: !!eff.shift,
+        alt: !!eff.alt,
+        meta: eff.meta,
+        scope: eff.scope ?? 'app',
+      },
+      id,
+      [...ids].filter((x) => x !== id)
+    );
+    if (conflicts[0]) return conflicts[0];
+  }
+  return null;
+}
+
+interface PendingChange {
+  id: string;
+  key: string;
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+}
+
+/** Human-readable label for settings list (always via settings namespace + catalog). */
+function shortcutDisplayName(
+  reg: ShortcutRegistration,
+  t: (key: string) => string
+): string {
+  const i18nKey =
+    getShortcutDescriptionI18nKey(reg.id) ??
+    (reg.description?.startsWith('keyboard.') ? reg.description : undefined);
+  if (i18nKey) {
+    const text = t(i18nKey);
+    if (text && text !== i18nKey) return text;
+  }
+  if (reg.description && !reg.description.startsWith('keyboard.')) {
+    return reg.description;
+  }
+  return reg.id.replace(/[._]/g, ' ');
+}
+
+const KeyboardShortcutsTab: React.FC = () => {
+  const { t } = useI18n('settings');
+
+  const [registrations, setRegistrations] = useState<ShortcutRegistration[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [recordingId, setRecordingId] = useState<string | null>(null);
+  const [pendingChanges, setPendingChanges] = useState<Record<string, PendingChange>>({});
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const recordingRef = useRef<string | null>(null);
+  recordingRef.current = recordingId;
+
+  // Live registrations from ShortcutManager (effects may register after first paint).
+  const refreshRegistrations = useCallback(() => {
+    setRegistrations(shortcutManager.getAllRegistrations());
+  }, []);
+
+  useEffect(() => {
+    refreshRegistrations();
+    return shortcutManager.subscribeRegistrationChanges(refreshRegistrations);
+  }, [refreshRegistrations]);
+
+  /** Full list for the UI: catalog + live, so every scope shows even before hooks register. */
+  const displayRegistrations = useMemo(() => mergeCatalogWithLive(registrations), [registrations]);
+
+  // Key capture during recording mode
+  useEffect(() => {
+    if (!recordingId) return;
+
+    const handleCapture = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.key === 'Escape') {
+        setRecordingId(null);
+        return;
+      }
+
+      const isMac = navigator.platform.toUpperCase().includes('MAC');
+      const ctrl = isMac ? e.metaKey : e.ctrlKey;
+
+      if (recordingId === MERGED_SCENE_RECORD_ID) {
+        if (!captureDigit(e)) return;
+        const next: Record<string, PendingChange> = {};
+        for (let i = 0; i < SCENE_FOCUS_ORDER.length; i++) {
+          const id = SCENE_FOCUS_ORDER[i];
+          next[id] = {
+            id,
+            key: String(i + 1),
+            ctrl,
+            shift: e.shiftKey,
+            alt: e.altKey,
+          };
+        }
+        setPendingChanges((prev) => ({ ...prev, ...next }));
+        setRecordingId(null);
+        return;
+      }
+
+      if (recordingId === MERGED_TAB_RECORD_ID) {
+        if (!captureDigit(e)) return;
+        const next: Record<string, PendingChange> = {};
+        for (let i = 0; i < TAB_SWITCH_ORDER.length; i++) {
+          const id = TAB_SWITCH_ORDER[i];
+          next[id] = {
+            id,
+            key: String(i + 1),
+            ctrl,
+            shift: e.shiftKey,
+            alt: e.altKey,
+          };
+        }
+        setPendingChanges((prev) => ({ ...prev, ...next }));
+        setRecordingId(null);
+        return;
+      }
+
+      // Skip modifier-only presses
+      if (['Control', 'Shift', 'Alt', 'Meta', 'OS'].includes(e.key)) return;
+
+      setPendingChanges((prev) => ({
+        ...prev,
+        [recordingId]: {
+          id: recordingId,
+          key: e.key,
+          ctrl,
+          shift: e.shiftKey,
+          alt: e.altKey,
+        },
+      }));
+      setRecordingId(null);
+    };
+
+    window.addEventListener('keydown', handleCapture, true);
+    return () => window.removeEventListener('keydown', handleCapture, true);
+  }, [recordingId]);
+
+  // Detect conflicts for a given pending change
+  const detectConflict = useCallback(
+    (
+      change: PendingChange,
+      originalScope: ShortcutScope,
+      excludeIds?: string[]
+    ): ShortcutRegistration | null => {
+      const conflicts = shortcutManager.checkConflicts(
+        { key: change.key, ctrl: change.ctrl, shift: change.shift, alt: change.alt, scope: originalScope },
+        change.id,
+        excludeIds
+      );
+      return conflicts[0] ?? null;
+    },
+    []
+  );
+
+  // Apply all pending changes
+  const handleApply = useCallback(async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      // 1. Read existing stored overrides so previous sessions' changes are not lost
+      let existingOverrides: KeybindingOverrides = {};
+      try {
+        const raw = await configManager.getConfig('app.keybindings');
+        existingOverrides = parseStoredKeybindings(raw);
+      } catch {
+        // First use — no stored overrides yet
+      }
+
+      // 2. Build overrides map from this session's pending changes
+      const pendingOverrides: KeybindingOverrides = {};
+      for (const [id, change] of Object.entries(pendingChanges)) {
+        pendingOverrides[id] = {
+          key: change.key,
+          ...(change.ctrl  ? { ctrl:  true } : {}),
+          ...(change.shift ? { shift: true } : {}),
+          ...(change.alt   ? { alt:   true } : {}),
+        };
+      }
+
+      // 3. Merge: pending changes override existing ones
+      const merged: KeybindingOverrides = { ...existingOverrides, ...pendingOverrides };
+
+      // 4. Prune overrides whose shortcut ID no longer exists in the catalog,
+      //    preventing unbounded storage growth as shortcuts are added/removed.
+      const knownIds = new Set(ALL_SHORTCUTS.map((d) => d.id));
+      for (const id of Object.keys(merged)) {
+        if (!knownIds.has(id) || NON_USER_CUSTOMIZABLE_SHORTCUT_IDS.has(id)) delete merged[id];
+      }
+
+      // 5. Persist with versioned format + sync in-memory state
+      await configManager.setConfig('app.keybindings', buildStoredKeybindings(merged));
+      shortcutManager.loadUserOverrides(merged);
+      setPendingChanges({});
+      refreshRegistrations();
+    } catch (err) {
+      log.error('Failed to save keybindings', err);
+      setSaveError(t('keyboard.saveError'));
+    } finally {
+      setSaving(false);
+    }
+  }, [pendingChanges, refreshRegistrations, t]);
+
+  // Reset all to defaults
+  const handleReset = useCallback(async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await configManager.setConfig('app.keybindings', buildStoredKeybindings({}));
+      shortcutManager.loadUserOverrides({});
+      setPendingChanges({});
+      refreshRegistrations();
+    } catch (err) {
+      log.error('Failed to reset keybindings', err);
+      setSaveError(t('keyboard.resetError'));
+    } finally {
+      setSaving(false);
+    }
+  }, [refreshRegistrations, t]);
+
+  // Format a key combination from a registration or pending change
+  const formatKey = (reg: ShortcutRegistration, pending?: PendingChange): string => {
+    const isMac = navigator.platform.toUpperCase().includes('MAC');
+    const cfg = pending
+      ? { key: pending.key, ctrl: pending.ctrl, shift: pending.shift, alt: pending.alt }
+      : reg.config;
+    const parts: string[] = [];
+    if (cfg.ctrl) parts.push(isMac ? '⌘' : 'Ctrl');
+    if (cfg.shift) parts.push(isMac ? '⇧' : 'Shift');
+    if (cfg.alt) parts.push(isMac ? '⌥' : 'Alt');
+    parts.push(formatShortcutKeyCap(cfg.key, t));
+    return parts.join(isMac ? '' : '+');
+  };
+
+  // Filter by search query (match translated action name or key combo)
+  const filteredByScope = (scope: ShortcutScope): ShortcutRegistration[] => {
+    const q = searchQuery.toLowerCase();
+    return displayRegistrations.filter((r) => {
+      if ((r.config.scope ?? 'app') !== scope) return false;
+      if (!q) return true;
+      const name = shortcutDisplayName(r, t).toLowerCase();
+      const descMatch = name.includes(q) || r.id.toLowerCase().includes(q);
+      const keyMatch = formatKey(r).toLowerCase().includes(q);
+      return descMatch || keyMatch;
+    });
+  };
+
+  /** Whether the merged SceneBar row matches the current search query */
+  const mergedSceneRowVisible = useMemo(() => {
+    const hasRegs = displayRegistrations.some((r) => MERGED_SCENE_FOCUS_IDS.has(r.id));
+    if (!hasRegs) return false;
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return true;
+    const hay = [
+      t('keyboard.shortcuts.scene.focusMerged'),
+      t('keyboard.shortcuts.scene.focusMergedHint'),
+      t('keyboard.mergedNonUniform'),
+    ]
+      .join(' ')
+      .toLowerCase();
+    return hay.includes(q);
+  }, [displayRegistrations, searchQuery, t]);
+
+  /** Whether the merged canvas-tab row matches the current search query */
+  const mergedTabSwitchRowVisible = useMemo(() => {
+    const hasRegs = displayRegistrations.some((r) => MERGED_TAB_SWITCH_IDS.has(r.id));
+    if (!hasRegs) return false;
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return true;
+    const hay = [
+      t('keyboard.shortcuts.tab.switchMerged'),
+      t('keyboard.shortcuts.tab.switchMergedHint'),
+      t('keyboard.mergedNonUniform'),
+    ]
+      .join(' ')
+      .toLowerCase();
+    return hay.includes(q);
+  }, [displayRegistrations, searchQuery, t]);
+
+  const mergedSceneKeyLabel = useMemo(() => {
+    const firstId = SCENE_FOCUS_ORDER[0];
+    const reg = displayRegistrations.find((r) => r.id === firstId);
+    if (!reg) return t('keyboard.mergedNonUniform');
+    if (!sceneGroupUniform(displayRegistrations, pendingChanges)) {
+      return t('keyboard.mergedNonUniform');
+    }
+    const cfg = getEffectiveConfig(reg, pendingChanges[firstId]);
+    return formatMergedRangeLabel(cfg, '1–3');
+  }, [displayRegistrations, pendingChanges, t]);
+
+  const mergedTabKeyLabel = useMemo(() => {
+    const firstId = TAB_SWITCH_ORDER[0];
+    const reg = displayRegistrations.find((r) => r.id === firstId);
+    if (!reg) return t('keyboard.mergedNonUniform');
+    if (!tabGroupUniform(displayRegistrations, pendingChanges)) {
+      return t('keyboard.mergedNonUniform');
+    }
+    const cfg = getEffectiveConfig(reg, pendingChanges[firstId]);
+    return formatMergedRangeLabel(cfg, '1–9');
+  }, [displayRegistrations, pendingChanges, t]);
+
+  const mergedSceneConflict = useMemo(
+    () => firstConflictInGroup(SCENE_FOCUS_ORDER, displayRegistrations, pendingChanges),
+    [displayRegistrations, pendingChanges]
+  );
+
+  const mergedTabConflict = useMemo(
+    () => firstConflictInGroup(TAB_SWITCH_ORDER, displayRegistrations, pendingChanges),
+    [displayRegistrations, pendingChanges]
+  );
+
+  const mergedScenePending = useMemo(
+    () => SCENE_FOCUS_ORDER.some((id) => pendingChanges[id] !== undefined),
+    [pendingChanges]
+  );
+
+  const mergedTabPending = useMemo(
+    () => TAB_SWITCH_ORDER.some((id) => pendingChanges[id] !== undefined),
+    [pendingChanges]
+  );
+
+  const appShortcutsWithoutMerged = filteredByScope('app').filter(
+    (r) => !MERGED_SCENE_FOCUS_IDS.has(r.id)
+  );
+  const canvasShortcutsWithoutMerged = filteredByScope('canvas').filter(
+    (r) => !MERGED_TAB_SWITCH_IDS.has(r.id)
+  );
+  const hasAnyVisibleShortcut =
+    mergedTabSwitchRowVisible ||
+    mergedSceneRowVisible ||
+    appShortcutsWithoutMerged.length > 0 ||
+    canvasShortcutsWithoutMerged.length > 0 ||
+    filteredByScope('chat').length > 0 ||
+    filteredByScope('filetree').length > 0 ||
+    filteredByScope('git').length > 0;
+
+  const hasPendingChanges = Object.keys(pendingChanges).length > 0;
+
+  return (
+    <ConfigPageLayout>
+      <ConfigPageHeader
+        className="kb-shortcuts-page-header"
+        title={t('keyboard.title')}
+        subtitle={t('keyboard.description')}
+      />
+      <ConfigPageContent>
+        {/* Search + actions bar */}
+        <div className="kb-shortcuts__toolbar">
+          <Search
+            className="kb-shortcuts__search"
+            size="small"
+            value={searchQuery}
+            onChange={setSearchQuery}
+            placeholder={t('keyboard.search')}
+            inputAriaLabel={t('keyboard.search')}
+            enterToSearch={false}
+            clearable
+          />
+          <div className="kb-shortcuts__actions">
+            {hasPendingChanges && (
+              <Button
+                variant="primary"
+              size="small"
+              onClick={handleApply}
+              disabled={saving}
+            >
+              {saving ? t('keyboard.saving') : t('keyboard.apply')}
+            </Button>
+          )}
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={handleReset}
+              disabled={saving}
+            >
+              {t('keyboard.reset')}
+            </Button>
+          </div>
+        </div>
+
+        {saveError && (
+          <div className="kb-shortcuts__error">{saveError}</div>
+        )}
+
+        {/* Shortcuts grouped by scope */}
+        {SCOPE_DISPLAY_ORDER.map((scope) => {
+          const rawItems = filteredByScope(scope);
+          const showMergedTab = scope === 'canvas' && mergedTabSwitchRowVisible;
+          const showMergedScene = scope === 'app' && mergedSceneRowVisible;
+          const items =
+            scope === 'app'
+              ? rawItems.filter((r) => !MERGED_SCENE_FOCUS_IDS.has(r.id))
+              : scope === 'canvas'
+              ? rawItems.filter((r) => !MERGED_TAB_SWITCH_IDS.has(r.id))
+              : rawItems;
+          if (items.length === 0 && !showMergedScene && !showMergedTab) return null;
+
+          return (
+            <ConfigPageSection
+              key={scope}
+              title={t(SCOPE_LABEL_KEYS[scope])}
+            >
+              <div className="kb-shortcuts__list">
+                {showMergedTab && (
+                  <div
+                    className={[
+                      'kb-shortcuts__item kb-shortcuts__item--merged',
+                      recordingId === MERGED_TAB_RECORD_ID ? 'kb-shortcuts__item--recording' : '',
+                      mergedTabConflict ? 'kb-shortcuts__item--conflict' : '',
+                      mergedTabPending ? 'kb-shortcuts__item--modified' : '',
+                    ]
+                      .filter(Boolean)
+                      .join(' ')}
+                    key="tab-switch-merged"
+                  >
+                    <div className="kb-shortcuts__item-label">
+                      <span className="kb-shortcuts__item-name">{t('keyboard.shortcuts.tab.switchMerged')}</span>
+                      <span className="kb-shortcuts__item-hint">{t('keyboard.shortcuts.tab.switchMergedHint')}</span>
+                      {mergedTabConflict && (
+                        <span className="kb-shortcuts__item-conflict-hint">
+                          {t('keyboard.conflict')}: {shortcutDisplayName(mergedTabConflict, t)}
+                        </span>
+                      )}
+                    </div>
+                    <div className="kb-shortcuts__item-key">
+                      <Tooltip content={t('keyboard.clickToRecord')} placement="top">
+                        <button
+                          type="button"
+                          className={[
+                            'kb-shortcuts__keybadge',
+                            recordingId === MERGED_TAB_RECORD_ID ? 'kb-shortcuts__keybadge--recording' : '',
+                            mergedTabConflict ? 'kb-shortcuts__keybadge--conflict' : '',
+                          ]
+                            .filter(Boolean)
+                            .join(' ')}
+                          onClick={() =>
+                            setRecordingId(recordingId === MERGED_TAB_RECORD_ID ? null : MERGED_TAB_RECORD_ID)
+                          }
+                        >
+                          {recordingId === MERGED_TAB_RECORD_ID ? t('keyboard.recording') : mergedTabKeyLabel}
+                        </button>
+                      </Tooltip>
+                      {mergedTabPending && recordingId !== MERGED_TAB_RECORD_ID && (
+                        <Tooltip content={t('keyboard.revertChange')} placement="top">
+                          <button
+                            type="button"
+                            className="kb-shortcuts__revert-btn"
+                            onClick={() => {
+                              setPendingChanges((prev) => {
+                                const next = { ...prev };
+                                for (const id of TAB_SWITCH_ORDER) delete next[id];
+                                return next;
+                              });
+                            }}
+                          >
+                            ↩
+                          </button>
+                        </Tooltip>
+                      )}
+                    </div>
+                  </div>
+                )}
+                {showMergedScene && (
+                  <div
+                    className={[
+                      'kb-shortcuts__item kb-shortcuts__item--merged',
+                      recordingId === MERGED_SCENE_RECORD_ID ? 'kb-shortcuts__item--recording' : '',
+                      mergedSceneConflict ? 'kb-shortcuts__item--conflict' : '',
+                      mergedScenePending ? 'kb-shortcuts__item--modified' : '',
+                    ]
+                      .filter(Boolean)
+                      .join(' ')}
+                    key="scene-focus-merged"
+                  >
+                    <div className="kb-shortcuts__item-label">
+                      <span className="kb-shortcuts__item-name">{t('keyboard.shortcuts.scene.focusMerged')}</span>
+                      <span className="kb-shortcuts__item-hint">{t('keyboard.shortcuts.scene.focusMergedHint')}</span>
+                      {mergedSceneConflict && (
+                        <span className="kb-shortcuts__item-conflict-hint">
+                          {t('keyboard.conflict')}: {shortcutDisplayName(mergedSceneConflict, t)}
+                        </span>
+                      )}
+                    </div>
+                    <div className="kb-shortcuts__item-key">
+                      <Tooltip content={t('keyboard.clickToRecord')} placement="top">
+                        <button
+                          type="button"
+                          className={[
+                            'kb-shortcuts__keybadge',
+                            recordingId === MERGED_SCENE_RECORD_ID ? 'kb-shortcuts__keybadge--recording' : '',
+                            mergedSceneConflict ? 'kb-shortcuts__keybadge--conflict' : '',
+                          ]
+                            .filter(Boolean)
+                            .join(' ')}
+                          onClick={() =>
+                            setRecordingId(recordingId === MERGED_SCENE_RECORD_ID ? null : MERGED_SCENE_RECORD_ID)
+                          }
+                        >
+                          {recordingId === MERGED_SCENE_RECORD_ID ? t('keyboard.recording') : mergedSceneKeyLabel}
+                        </button>
+                      </Tooltip>
+                      {mergedScenePending && recordingId !== MERGED_SCENE_RECORD_ID && (
+                        <Tooltip content={t('keyboard.revertChange')} placement="top">
+                          <button
+                            type="button"
+                            className="kb-shortcuts__revert-btn"
+                            onClick={() => {
+                              setPendingChanges((prev) => {
+                                const next = { ...prev };
+                                for (const id of SCENE_FOCUS_ORDER) delete next[id];
+                                return next;
+                              });
+                            }}
+                          >
+                            ↩
+                          </button>
+                        </Tooltip>
+                      )}
+                    </div>
+                  </div>
+                )}
+                {items.map((reg) => {
+                  const pending = pendingChanges[reg.id];
+                  const isRecording = recordingId === reg.id;
+                  const fixed = NON_USER_CUSTOMIZABLE_SHORTCUT_IDS.has(reg.id);
+                  const conflict =
+                    !fixed && pending ? detectConflict(pending, reg.config.scope ?? 'app') : null;
+
+                  return (
+                    <div
+                      key={reg.id}
+                      className={[
+                        'kb-shortcuts__item',
+                        !fixed && isRecording ? 'kb-shortcuts__item--recording' : '',
+                        conflict ? 'kb-shortcuts__item--conflict' : '',
+                        pending && !fixed ? 'kb-shortcuts__item--modified' : '',
+                      ].filter(Boolean).join(' ')}
+                    >
+                      <div className="kb-shortcuts__item-label">
+                        <span className="kb-shortcuts__item-name">
+                          {shortcutDisplayName(reg, t)}
+                        </span>
+                        {conflict && (
+                          <span className="kb-shortcuts__item-conflict-hint">
+                            {t('keyboard.conflict')}: {shortcutDisplayName(conflict, t)}
+                          </span>
+                        )}
+                      </div>
+                      <div className="kb-shortcuts__item-key">
+                        {fixed ? (
+                          <Tooltip content={t('keyboard.fixedBinding')} placement="top">
+                            <span
+                              className={['kb-shortcuts__keybadge', 'kb-shortcuts__keybadge--readonly'].join(' ')}
+                            >
+                              {formatKey(reg)}
+                            </span>
+                          </Tooltip>
+                        ) : (
+                          <>
+                            <Tooltip content={t('keyboard.clickToRecord')} placement="top">
+                              <button
+                                type="button"
+                                className={[
+                                  'kb-shortcuts__keybadge',
+                                  isRecording ? 'kb-shortcuts__keybadge--recording' : '',
+                                  conflict ? 'kb-shortcuts__keybadge--conflict' : '',
+                                ].filter(Boolean).join(' ')}
+                                onClick={() => setRecordingId(isRecording ? null : reg.id)}
+                              >
+                                {isRecording
+                                  ? t('keyboard.recording')
+                                  : formatKey(reg, pending)}
+                              </button>
+                            </Tooltip>
+                            {pending && !isRecording && (
+                              <Tooltip content={t('keyboard.revertChange')} placement="top">
+                                <button
+                                  type="button"
+                                  className="kb-shortcuts__revert-btn"
+                                  onClick={() => {
+                                    setPendingChanges((prev) => {
+                                      const next = { ...prev };
+                                      delete next[reg.id];
+                                      return next;
+                                    });
+                                  }}
+                                >
+                                  ↩
+                                </button>
+                              </Tooltip>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </ConfigPageSection>
+          );
+        })}
+
+        {displayRegistrations.length > 0 && !hasAnyVisibleShortcut && (
+          <div className="kb-shortcuts__empty">
+            {t('keyboard.noResults')}
+          </div>
+        )}
+      </ConfigPageContent>
+    </ConfigPageLayout>
+  );
+};
+
+export default KeyboardShortcutsTab;

--- a/src/web-ui/src/app/scenes/settings/settingsConfig.ts
+++ b/src/web-ui/src/app/scenes/settings/settingsConfig.ts
@@ -12,7 +12,8 @@ export type ConfigTab =
   | 'ai-context'
   | 'mcp-tools'
   // | 'lsp' // temporarily hidden from config center
-  | 'editor';
+  | 'editor'
+  | 'keyboard';
 
 export interface ConfigTabDef {
   id: ConfigTab;
@@ -21,6 +22,8 @@ export interface ConfigTabDef {
   descriptionKey?: string;
   /** Language-neutral extra tokens matched by search (ASCII recommended). */
   keywords?: string[];
+  /** Show a Beta pill next to the tab label in the settings nav. */
+  beta?: boolean;
 }
 
 export interface ConfigCategoryDef {
@@ -72,6 +75,22 @@ export const SETTINGS_CATEGORIES: ConfigCategoryDef[] = [
           'model',
           'temperature',
           'token',
+        ],
+      },
+      {
+        id: 'keyboard',
+        labelKey: 'configCenter.tabs.keyboard',
+        descriptionKey: 'configCenter.tabDescriptions.keyboard',
+        beta: true,
+        keywords: [
+          'keyboard',
+          'shortcut',
+          'keybinding',
+          'hotkey',
+          'shortcut key',
+          '快捷键',
+          '键位',
+          'beta',
         ],
       },
     ],
@@ -150,6 +169,7 @@ const KNOWN_TABS: ConfigTab[] = SETTINGS_CATEGORIES.flatMap((c) => c.tabs.map((t
 export function normalizeSettingsTab(section: string): ConfigTab {
   if (section === 'theme' || section === 'logging' || section === 'terminal') return 'basics';
   if (section === 'lsp') return DEFAULT_SETTINGS_TAB;
+  if (section === 'shortcuts' || section === 'keybindings' || section === 'hotkeys') return 'keyboard';
   if ((KNOWN_TABS as readonly string[]).includes(section)) return section as ConfigTab;
   return DEFAULT_SETTINGS_TAB;
 }

--- a/src/web-ui/src/app/scenes/settings/settingsTabSearchContent.ts
+++ b/src/web-ui/src/app/scenes/settings/settingsTabSearchContent.ts
@@ -97,5 +97,20 @@ export const SETTINGS_TAB_SEARCH_CONTENT: Record<ConfigTab, readonly SettingsTab
     { ns: 'settings/editor', key: 'actions.saveDesc' },
   ],
 
+  keyboard: [
+    { ns: 'settings', key: 'keyboard.title' },
+    { ns: 'settings', key: 'keyboard.description' },
+    { ns: 'settings', key: 'keyboard.scopes.app' },
+    { ns: 'settings', key: 'keyboard.scopes.chat' },
+    { ns: 'settings', key: 'keyboard.scopes.filetree' },
+    { ns: 'settings', key: 'keyboard.scopes.git' },
+    { ns: 'settings', key: 'keyboard.shortcuts.panel.toggleLeft' },
+    { ns: 'settings', key: 'keyboard.shortcuts.tab.close' },
+    { ns: 'settings', key: 'keyboard.shortcuts.scene.focusMerged' },
+    { ns: 'settings', key: 'keyboard.shortcuts.scene.focusMergedHint' },
+    { ns: 'settings', key: 'keyboard.shortcuts.tab.switchMerged' },
+    { ns: 'settings', key: 'keyboard.shortcuts.tab.switchMergedHint' },
+  ],
+
   // lsp: [ ... ], // nav entry temporarily hidden; omit from search index
 };

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -4,6 +4,9 @@
  */
 
 import React, { useMemo, useCallback, useRef, useEffect, useState } from 'react';
+import { useShortcut } from '@/infrastructure/hooks/useShortcut';
+import { FlowChatManager } from '@/flow_chat/services/FlowChatManager';
+import { useSessionModeStore } from '@/app/stores/sessionModeStore';
 import { VirtualMessageList, VirtualMessageListRef } from './VirtualMessageList';
 import { FlowChatHeader, type FlowChatHeaderTurnSummary } from './FlowChatHeader';
 import { WelcomePanel } from '../WelcomePanel';
@@ -46,6 +49,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const [pendingHeaderTurnId, setPendingHeaderTurnId] = useState<string | null>(null);
   const autoPinnedSessionIdRef = useRef<string | null>(null);
   const virtualListRef = useRef<VirtualMessageListRef>(null);
+  const chatScopeRef = useRef<HTMLDivElement>(null);
   const { workspacePath } = useWorkspaceContext();
   const { btwOrigin, btwParentTitle } = useFlowChatSessionRelationship(activeSession);
   const {
@@ -212,10 +216,63 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     if (!nextTurn) return;
     handleJumpToTurn(nextTurn.turnId);
   }, [effectiveVisibleTurnInfo, handleJumpToTurn, turnSummaries]);
-  
+
+  useShortcut(
+    'chat.stopGeneration',
+    { key: 'Escape', scope: 'chat', allowInInput: true },
+    () => {
+      void FlowChatManager.getInstance().cancelCurrentTask();
+    },
+    { priority: 20, description: 'keyboard.shortcuts.chat.stopGeneration' }
+  );
+
+  useShortcut(
+    'chat.activateInput',
+    { key: ' ', scope: 'chat' },
+    () => {
+      const root = chatScopeRef.current;
+      const el = root?.querySelector(
+        '.bitfun-chat-input textarea, .bitfun-chat-input [contenteditable="true"]'
+      ) as HTMLElement | null;
+      el?.focus();
+    },
+    { priority: 10, description: 'keyboard.shortcuts.chat.activateInput' }
+  );
+
+  useShortcut(
+    'chat.newSession',
+    { key: 'N', ctrl: true, scope: 'chat' },
+    () => {
+      void (async () => {
+        try {
+          useSessionModeStore.getState().setMode('code');
+          await FlowChatManager.getInstance().createChatSession({}, 'agentic');
+        } catch {
+          /* ignore */
+        }
+      })();
+    },
+    { priority: 10, description: 'keyboard.shortcuts.chat.newSession' }
+  );
+
+  useShortcut(
+    'btw-fill',
+    { key: 'B', ctrl: true, alt: true, scope: 'chat', allowInInput: true },
+    () => {
+      const selected = (window.getSelection?.()?.toString() ?? '').trim();
+      const message = selected ? `/btw Explain this:\n\n${selected}` : '/btw ';
+      window.dispatchEvent(new CustomEvent('fill-chat-input', { detail: { message } }));
+    },
+    { priority: 20, description: 'keyboard.shortcuts.chat.btwFill' }
+  );
+
   return (
     <FlowChatContext.Provider value={contextValue}>
-      <div className={`modern-flowchat-container flow-chat-typography ${className}`}>
+      <div
+        ref={chatScopeRef}
+        className={`modern-flowchat-container flow-chat-typography ${className}`}
+        data-shortcut-scope="chat"
+      >
         <FlowChatHeader
           currentTurn={effectiveVisibleTurnInfo?.turnIndex ?? 0}
           totalTurns={effectiveVisibleTurnInfo?.totalTurns ?? 0}

--- a/src/web-ui/src/flow_chat/components/modern/ProcessingIndicator.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ProcessingIndicator.tsx
@@ -52,7 +52,7 @@ export const ProcessingIndicator: React.FC<ProcessingIndicatorProps> = ({ visibl
       if (delayTimerRef.current) clearTimeout(delayTimerRef.current);
       if (rotateTimerRef.current) clearInterval(rotateTimerRef.current);
     };
-  }, [visible]);
+  }, [visible, hints.length]);
 
   const shouldRender = visible || reserveSpace;
   if (!shouldRender) return null;

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigPageHeader.scss
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigPageHeader.scss
@@ -42,11 +42,12 @@
 
 .bitfun-config-page-header__subtitle {
   margin: 0;
+  margin-top: 2px;
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   line-height: var(--line-height-relaxed);
   font-family: var(--font-family-sans);
-  display: none;
+  max-width: 100%;
 }
 
 .bitfun-config-page-header__extra {

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigPageHeader.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigPageHeader.tsx
@@ -11,7 +11,7 @@ export interface ConfigPageHeaderProps {
 
 export const ConfigPageHeader: React.FC<ConfigPageHeaderProps> = ({
   title,
-  subtitle: _subtitle,
+  subtitle,
   icon: _icon,
   extra,
   className = '',
@@ -22,6 +22,9 @@ export const ConfigPageHeader: React.FC<ConfigPageHeaderProps> = ({
         <div className="bitfun-config-page-header__left">
           <div className="bitfun-config-page-header__info">
             <h2 className="bitfun-config-page-header__title">{title}</h2>
+            {subtitle ? (
+              <p className="bitfun-config-page-header__subtitle">{subtitle}</p>
+            ) : null}
           </div>
         </div>
         {extra && (

--- a/src/web-ui/src/infrastructure/hooks/index.ts
+++ b/src/web-ui/src/infrastructure/hooks/index.ts
@@ -6,3 +6,6 @@
 export * from './useAIInitialization';
 export * from './useAIRules';
 export * from './useWorkspaceManagerSync';
+
+// Shortcut hook
+export * from './useShortcut';

--- a/src/web-ui/src/infrastructure/hooks/useShortcut.ts
+++ b/src/web-ui/src/infrastructure/hooks/useShortcut.ts
@@ -1,0 +1,62 @@
+
+import { useEffect, useRef } from 'react';
+import { shortcutManager, type ShortcutCallback } from '@/infrastructure/services/ShortcutManager';
+import type { ShortcutConfig } from '@/shared/types/shortcut';
+
+export interface UseShortcutOptions {
+  description?: string;
+  priority?: number;
+  /** Set to false to temporarily disable this shortcut without unregistering. */
+  enabled?: boolean;
+}
+
+/**
+ * Register a keyboard shortcut via ShortcutManager with automatic cleanup.
+ *
+ * Uses a stable ref pattern so that changes to `callback` never cause the
+ * shortcut to be unregistered and re-registered — only changes to `id` or
+ * `config` trigger a re-registration.
+ *
+ * @param id       Unique shortcut identifier (e.g. 'panel.toggleLeft')
+ * @param config   Key + modifiers + scope config
+ * @param callback Handler to invoke when the shortcut fires
+ * @param options  Optional description, priority, enabled flag
+ */
+export function useShortcut(
+  id: string,
+  config: ShortcutConfig,
+  callback: ShortcutCallback,
+  options: UseShortcutOptions = {}
+): void {
+  const { description, priority, enabled = true } = options;
+
+  // Keep the latest callback in a ref so changes don't trigger re-registration.
+  const callbackRef = useRef<ShortcutCallback>(callback);
+  callbackRef.current = callback;
+
+  // Stable wrapper that delegates to the current callback ref.
+  const stableCallback = useRef<ShortcutCallback>((e) => callbackRef.current(e));
+
+  // Serialize config to a stable string for the dependency array.
+  const configKey = JSON.stringify({
+    key: config.key,
+    ctrl: config.ctrl,
+    shift: config.shift,
+    alt: config.alt,
+    meta: config.meta,
+    scope: config.scope,
+    allowInInput: config.allowInInput,
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const unregister = shortcutManager.register(id, config, stableCallback.current, {
+      description,
+      priority,
+    });
+
+    return unregister;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, configKey, enabled, description, priority]);
+}

--- a/src/web-ui/src/infrastructure/services/ShortcutManager.ts
+++ b/src/web-ui/src/infrastructure/services/ShortcutManager.ts
@@ -1,32 +1,150 @@
- 
 
-import type { ShortcutConfig } from '@/shared/types/shortcut';
+import type { ShortcutConfig, ShortcutScope } from '@/shared/types/shortcut';
+import { NON_USER_CUSTOMIZABLE_SHORTCUT_IDS } from '@/shared/constants/shortcuts';
 import { createLogger } from '@/shared/utils/logger';
 
 const log = createLogger('ShortcutManager');
 
 export type ShortcutCallback = (event: KeyboardEvent) => void;
 
-interface ShortcutRegistration {
+export interface ShortcutRegistration {
   id: string;
   config: ShortcutConfig;
   callback: ShortcutCallback;
   description?: string;
-  priority: number; 
+  priority: number;
 }
 
- 
+/**
+ * User-defined keybinding overrides stored in config (app.keybindings).
+ * Maps shortcut id → partial ShortcutConfig (only key/modifier fields).
+ */
+export type KeybindingOverrides = Record<string, Pick<ShortcutConfig, 'key' | 'ctrl' | 'shift' | 'alt' | 'meta'>>;
+
+// ─── Persistent storage utilities ─────────────────────────────────────────
+
+export const KEYBINDINGS_STORAGE_VERSION = 1;
+
+/** Versioned shape written to / read from config key `app.keybindings`. */
+export interface StoredKeybindingsV1 {
+  __version__: 1;
+  overrides: KeybindingOverrides;
+}
+
+/**
+ * Parse the raw value returned by configManager for `app.keybindings`.
+ * Handles two formats:
+ *   - V1 (current): { __version__: 1, overrides: { ... } }
+ *   - Legacy (no version field): flat object treated as overrides directly
+ * Unknown or malformed entries are silently skipped.
+ */
+export function parseStoredKeybindings(raw: unknown): KeybindingOverrides {
+  if (!raw || typeof raw !== 'object') return {};
+  const obj = raw as Record<string, unknown>;
+  if (obj.__version__ === 1 && obj.overrides && typeof obj.overrides === 'object') {
+    return sanitizeOverrides(obj.overrides as Record<string, unknown>);
+  }
+  // Legacy format: no __version__ key → treat entire object as overrides map
+  if (!('__version__' in obj)) {
+    return sanitizeOverrides(obj);
+  }
+  return {};
+}
+
+/** Build the versioned object to write back to config storage. */
+export function buildStoredKeybindings(overrides: KeybindingOverrides): StoredKeybindingsV1 {
+  return { __version__: 1, overrides };
+}
+
+function sanitizeOverrides(raw: Record<string, unknown>): KeybindingOverrides {
+  const result: KeybindingOverrides = {};
+  for (const [id, val] of Object.entries(raw)) {
+    if (NON_USER_CUSTOMIZABLE_SHORTCUT_IDS.has(id)) continue;
+    if (id.startsWith('__') || !val || typeof val !== 'object') continue;
+    const v = val as Record<string, unknown>;
+    if (typeof v.key !== 'string' || !v.key) continue;
+    result[id] = {
+      key: v.key,
+      ...(v.ctrl  ? { ctrl:  true } : {}),
+      ...(v.shift ? { shift: true } : {}),
+      ...(v.alt   ? { alt:   true } : {}),
+      ...(v.meta  ? { meta:  true } : {}),
+    };
+  }
+  return result;
+}
+
+/**
+ * Compute the O(1) map key for a shortcut config.
+ * Format: "{scope}:{key_lower}:{ctrl}{shift}{alt}{meta}"
+ * Example: "app:]:1000"
+ */
+function makeMapKey(scope: ShortcutScope, config: ShortcutConfig): string {
+  const c = config.ctrl ? '1' : '0';
+  const s = config.shift ? '1' : '0';
+  const a = config.alt ? '1' : '0';
+  const m = config.meta ? '1' : '0';
+  return `${scope}:${config.key.toLowerCase()}:${c}${s}${a}${m}`;
+}
+
+/**
+ * Normalize which logical key was pressed for lookup.
+ * Digit row: prefer `event.code` (Digit1–Digit9) so Ctrl+digit shortcuts work when `event.key`
+ * differs by layout/browser; also support Numpad1–Numpad9.
+ */
+function eventKeyForLookup(event: KeyboardEvent): string {
+  const code = event.code ?? '';
+  const digit = /^Digit([1-9])$/.exec(code);
+  if (digit) return digit[1];
+  const numpad = /^Numpad([1-9])$/.exec(code);
+  if (numpad) return numpad[1];
+  // Keep in sync with makeMapKey: always lower-case logical key (Tab, escape, w, etc.)
+  return event.key.toLowerCase();
+}
+
+/**
+ * Compute the map key directly from a KeyboardEvent for lookup.
+ */
+function makeEventKey(scope: ShortcutScope, event: KeyboardEvent): string {
+  const isMac = navigator.platform.toUpperCase().includes('MAC');
+  const ctrl = isMac ? event.metaKey : event.ctrlKey;
+  const c = ctrl ? '1' : '0';
+  const s = event.shiftKey ? '1' : '0';
+  const a = event.altKey ? '1' : '0';
+  // meta is not used as standalone modifier in our system (folded into ctrl on Mac)
+  return `${scope}:${eventKeyForLookup(event)}:${c}${s}${a}0`;
+}
+
 export class ShortcutManager {
   private static instance: ShortcutManager;
+
+  /**
+   * All registrations, keyed by shortcut id.
+   */
   private registrations: Map<string, ShortcutRegistration> = new Map();
+
+  /**
+   * O(1) lookup index: mapKey → sorted registrations (descending priority).
+   * Built incrementally on register/unregister.
+   */
+  private lookupMap: Map<string, ShortcutRegistration[]> = new Map();
+
   private keyDownHandler: ((e: KeyboardEvent) => void) | null = null;
   private isEnabled: boolean = true;
+
+  /**
+   * User overrides from configManager (id → key+modifiers).
+   * Applied when a shortcut is registered or overrides are (re)loaded.
+   */
+  private userOverrides: KeybindingOverrides = {};
+
+  /** Listeners notified whenever the registration set changes (for settings UI sync). */
+  private registrationListeners: Set<() => void> = new Set();
 
   private constructor() {
     this.start();
   }
 
-   
   public static getInstance(): ShortcutManager {
     if (!ShortcutManager.instance) {
       ShortcutManager.instance = new ShortcutManager();
@@ -34,17 +152,12 @@ export class ShortcutManager {
     return ShortcutManager.instance;
   }
 
-   
   private start(): void {
-    if (this.keyDownHandler) {
-      return;
-    }
-
+    if (this.keyDownHandler) return;
     this.keyDownHandler = this.handleKeyDown.bind(this);
     window.addEventListener('keydown', this.keyDownHandler, true);
   }
 
-   
   public stop(): void {
     if (this.keyDownHandler) {
       window.removeEventListener('keydown', this.keyDownHandler, true);
@@ -52,245 +165,312 @@ export class ShortcutManager {
     }
   }
 
-   
+  // ─── Registration ──────────────────────────────────────────────────────────
+
   public register(
     id: string,
     config: ShortcutConfig,
     callback: ShortcutCallback,
-    options?: {
-      description?: string;
-      priority?: number;
-    }
+    options?: { description?: string; priority?: number }
   ): () => void {
-    
-    const conflicts = this.checkConflicts(config);
-    if (conflicts.length > 0) {
-      log.warn('Shortcut conflict detected', { 
-        shortcut: this.formatShortcut(config), 
-        conflicts: conflicts.map(c => c.id) 
-      });
+    // Apply user override if present
+    const effectiveConfig = this.applyOverride(id, config);
+
+    const existing = this.registrations.get(id);
+    if (existing) {
+      this.removeFromLookupMap(existing);
     }
 
     const registration: ShortcutRegistration = {
       id,
-      config,
+      config: effectiveConfig,
       callback,
       description: options?.description,
-      priority: options?.priority ?? 0
+      priority: options?.priority ?? 0,
     };
 
     this.registrations.set(id, registration);
+    this.addToLookupMap(registration);
+    this.notifyRegistrationListeners();
 
-    
     return () => this.unregister(id);
   }
 
-   
   public unregister(id: string): boolean {
-    return this.registrations.delete(id);
-  }
-
-   
-  private handleKeyDown(event: KeyboardEvent): void {
-    if (!this.isEnabled) {
-      return;
-    }
-
-    
-    if (this.shouldIgnoreEvent(event)) {
-      return;
-    }
-
-    
-    const matched = this.findMatchingShortcuts(event);
-
-    if (matched.length === 0) {
-      return;
-    }
-
-    
-    matched.sort((a, b) => b.priority - a.priority);
-
-    
-    const registration = matched[0];
-    
-    try {
-      event.preventDefault();
-      event.stopPropagation();
-      registration.callback(event);
-    } catch (error) {
-      log.error('Shortcut callback execution failed', { id: registration.id, error });
-    }
-  }
-
-   
-  private findMatchingShortcuts(event: KeyboardEvent): ShortcutRegistration[] {
-    const matched: ShortcutRegistration[] = [];
-
-    for (const registration of this.registrations.values()) {
-      if (this.isShortcutMatch(event, registration.config)) {
-        matched.push(registration);
-      }
-    }
-
-    return matched;
-  }
-
-   
-  private isShortcutMatch(event: KeyboardEvent, config: ShortcutConfig): boolean {
-    
-    const key = event.key.toUpperCase();
-    const configKey = config.key.toUpperCase();
-    
-    if (key !== configKey) {
-      return false;
-    }
-
-    
-    if (!!config.ctrl !== (event.ctrlKey || event.metaKey)) {
-      return false;
-    }
-
-    if (!!config.shift !== event.shiftKey) {
-      return false;
-    }
-
-    if (!!config.alt !== event.altKey) {
-      return false;
-    }
-
-    if (!!config.meta !== event.metaKey) {
-      return false;
-    }
-
+    const registration = this.registrations.get(id);
+    if (!registration) return false;
+    this.removeFromLookupMap(registration);
+    this.registrations.delete(id);
+    this.notifyRegistrationListeners();
     return true;
   }
 
-   
-  private shouldIgnoreEvent(event: KeyboardEvent): boolean {
-    const target = event.target as HTMLElement;
-    if (!target) {
-      return false;
+  // ─── Lookup map maintenance ────────────────────────────────────────────────
+
+  private addToLookupMap(reg: ShortcutRegistration): void {
+    const scope = reg.config.scope ?? 'app';
+    const key = makeMapKey(scope, reg.config);
+    const list = this.lookupMap.get(key) ?? [];
+    list.push(reg);
+    list.sort((a, b) => b.priority - a.priority);
+    this.lookupMap.set(key, list);
+  }
+
+  private removeFromLookupMap(reg: ShortcutRegistration): void {
+    const scope = reg.config.scope ?? 'app';
+    const key = makeMapKey(scope, reg.config);
+    const list = this.lookupMap.get(key);
+    if (!list) return;
+    const idx = list.indexOf(reg);
+    if (idx !== -1) list.splice(idx, 1);
+    if (list.length === 0) {
+      this.lookupMap.delete(key);
+    }
+  }
+
+  // ─── Event handling ────────────────────────────────────────────────────────
+
+  private handleKeyDown(event: KeyboardEvent): void {
+    if (!this.isEnabled) return;
+
+    const inInput = this.isInputContext(event);
+    const activeScope = this.detectScope(event.target);
+
+    // Collect candidates: always check 'app' scope, plus active panel scope if different
+    const candidates = this.findCandidates(event, activeScope, inInput);
+
+    if (candidates.length === 0) return;
+
+    // Candidates are already sorted: panel-scope first, then app-scope, then by priority
+    const winner = candidates[0];
+    try {
+      event.preventDefault();
+      event.stopPropagation();
+      winner.callback(event);
+    } catch (error) {
+      log.error('Shortcut callback execution failed', { id: winner.id, error });
+    }
+  }
+
+  private findCandidates(
+    event: KeyboardEvent,
+    activeScope: ShortcutScope,
+    inInput: boolean
+  ): ShortcutRegistration[] {
+    const results: ShortcutRegistration[] = [];
+
+    // Check app-scope registrations
+    const appKey = makeEventKey('app', event);
+    const appList = this.lookupMap.get(appKey) ?? [];
+    for (const reg of appList) {
+      if (inInput && !reg.config.allowInInput) continue;
+      results.push(reg);
     }
 
-    
-    const isCodeEditor = target.classList.contains('monaco-editor') ||
-                        target.classList.contains('code-editor') ||
-                        target.closest('.monaco-editor') !== null ||
-                        target.closest('.code-editor') !== null;
-    
-    if (isCodeEditor) {
-      return false;
-    }
-
-    const tagName = target.tagName.toLowerCase();
-
-    
-    if (['input', 'textarea', 'select'].includes(tagName)) {
-      const style = window.getComputedStyle(target);
-      if (style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0') {
-        return true;
+    // Check panel-scope registrations (if inside a scoped panel)
+    if (activeScope !== 'app') {
+      const panelKey = makeEventKey(activeScope, event);
+      const panelList = this.lookupMap.get(panelKey) ?? [];
+      for (const reg of panelList) {
+        if (inInput && !reg.config.allowInInput) continue;
+        // Panel-scope shortcuts get higher effective priority
+        results.unshift(...panelList.filter((r) => !inInput || r.config.allowInInput));
+        break;
       }
     }
 
-    
-    if (target.classList.contains('bitfun-chat-input') ||
-        target.classList.contains('rich-text-input') ||
-        target.closest('.bitfun-chat-input') !== null ||
-        target.closest('.rich-text-input') !== null) {
+    // Deduplicate (panel-scope items inserted at front may repeat)
+    const seen = new Set<string>();
+    return results.filter((r) => {
+      if (seen.has(r.id)) return false;
+      seen.add(r.id);
+      return true;
+    });
+  }
+
+  /**
+   * Detect the active shortcut scope by walking up the DOM from the event target.
+   * Returns the innermost known data-shortcut-scope value, or 'app' as fallback.
+   */
+  private detectScope(target: EventTarget | null): ShortcutScope {
+    if (!target || !(target instanceof Element)) return 'app';
+    const el = target.closest('[data-shortcut-scope]');
+    const scope = el?.getAttribute('data-shortcut-scope') as ShortcutScope | null;
+    // Only accept known panel scopes; canvas is included so canvas-scoped shortcuts
+    // fire only when focus is inside the editor canvas area.
+    if (scope === 'canvas' || scope === 'chat' || scope === 'filetree' || scope === 'git') return scope;
+    return 'app';
+  }
+
+  /**
+   * Determine whether the current event originates from an input context.
+   * Monaco editor is explicitly excluded (it manages its own keybindings).
+   */
+  private isInputContext(event: KeyboardEvent): boolean {
+    const target = event.target as HTMLElement | null;
+    if (!target) return false;
+
+    // Monaco editor — not treated as a generic input context
+    if (
+      target.classList.contains('monaco-editor') ||
+      target.classList.contains('inputarea') ||
+      target.closest('.monaco-editor') !== null
+    ) {
+      return false;
+    }
+
+    const tag = target.tagName.toLowerCase();
+    if (['input', 'textarea', 'select'].includes(tag)) {
+      const style = window.getComputedStyle(target);
+      if (style.display !== 'none' && style.visibility !== 'hidden') return true;
+    }
+
+    if (
+      target.classList.contains('bitfun-chat-input') ||
+      target.classList.contains('rich-text-input') ||
+      target.closest('.bitfun-chat-input') !== null ||
+      target.closest('.rich-text-input') !== null
+    ) {
       return true;
     }
 
-    
-    if (target.isContentEditable) {
-      return true;
-    }
+    if (target.isContentEditable) return true;
 
     return false;
   }
 
-   
-  public checkConflicts(config: ShortcutConfig): ShortcutRegistration[] {
-    const conflicts: ShortcutRegistration[] = [];
+  // ─── User overrides ────────────────────────────────────────────────────────
 
-    for (const registration of this.registrations.values()) {
-      if (this.isShortcutEqual(config, registration.config)) {
-        conflicts.push(registration);
-      }
+  /**
+   * Load user keybinding overrides from config storage.
+   * Existing registrations are re-indexed with the new effective configs.
+   * Call this once on app startup and again whenever configManager fires a change.
+   */
+  public loadUserOverrides(overrides: KeybindingOverrides): void {
+    this.userOverrides = overrides ?? {};
+
+    // Re-apply overrides to all existing registrations
+    for (const [id, registration] of this.registrations.entries()) {
+      const newConfig = this.applyOverride(id, registration.config);
+      this.removeFromLookupMap(registration);
+      registration.config = newConfig;
+      this.addToLookupMap(registration);
     }
 
-    return conflicts;
+    log.debug('User keybinding overrides loaded', { count: Object.keys(this.userOverrides).length });
+    this.notifyRegistrationListeners();
   }
 
-   
-  private isShortcutEqual(a: ShortcutConfig, b: ShortcutConfig): boolean {
-    return (
-      a.key.toUpperCase() === b.key.toUpperCase() &&
-      !!a.ctrl === !!b.ctrl &&
-      !!a.shift === !!b.shift &&
-      !!a.alt === !!b.alt &&
-      !!a.meta === !!b.meta
-    );
+  /**
+   * Effective config for a shortcut id (catalog default merged with user overrides).
+   * Used by the keyboard settings UI for shortcuts not yet registered at runtime.
+   */
+  public getEffectiveConfig(id: string, catalogDefault: ShortcutConfig): ShortcutConfig {
+    return this.applyOverride(id, catalogDefault);
   }
 
-   
-  public formatShortcut(config: ShortcutConfig): string {
-    const parts: string[] = [];
-
-    if (config.ctrl) parts.push('Ctrl');
-    if (config.shift) parts.push('Shift');
-    if (config.alt) parts.push('Alt');
-    if (config.meta) parts.push('Meta');
-    parts.push(config.key.toUpperCase());
-
-    return parts.join('+');
-  }
-
-   
-  public parseShortcut(shortcut: string): ShortcutConfig | null {
-    const parts = shortcut.split('+').map(s => s.trim().toLowerCase());
-    
-    if (parts.length === 0) {
-      return null;
-    }
-
-    const key = parts[parts.length - 1];
-    
+  private applyOverride(id: string, config: ShortcutConfig): ShortcutConfig {
+    if (NON_USER_CUSTOMIZABLE_SHORTCUT_IDS.has(id)) return config;
+    const override = this.userOverrides[id];
+    if (!override) return config;
+    // Stored overrides only persist truthy modifiers. Shallow merge would keep
+    // catalog ctrl/meta when the user clears them (e.g. Alt+Q must not stay Ctrl+Alt+Q).
     return {
-      key: key.toUpperCase(),
-      ctrl: parts.includes('ctrl'),
-      shift: parts.includes('shift'),
-      alt: parts.includes('alt'),
-      meta: parts.includes('meta')
+      ...config,
+      key: override.key,
+      ctrl: !!override.ctrl,
+      shift: !!override.shift,
+      alt: !!override.alt,
+      meta: !!override.meta,
     };
   }
 
-   
-  public validateShortcut(shortcut: string): boolean {
-    return this.parseShortcut(shortcut) !== null;
+  /** Subscribe to registration / override changes. Used to refresh the shortcuts settings list. */
+  public subscribeRegistrationChanges(listener: () => void): () => void {
+    this.registrationListeners.add(listener);
+    return () => {
+      this.registrationListeners.delete(listener);
+    };
   }
 
-   
+  private notifyRegistrationListeners(): void {
+    for (const fn of this.registrationListeners) {
+      try {
+        fn();
+      } catch (e) {
+        log.error('registration listener failed', { error: e });
+      }
+    }
+  }
+
+  // ─── Introspection ─────────────────────────────────────────────────────────
+
+  /**
+   * Returns all current registrations for display in the settings UI.
+   * Returned array is sorted by scope then priority (descending).
+   */
   public getAllRegistrations(): ShortcutRegistration[] {
-    return Array.from(this.registrations.values());
+    return Array.from(this.registrations.values()).sort((a, b) => {
+      const scopeOrder: Record<ShortcutScope, number> = { app: 0, chat: 1, canvas: 2, filetree: 3, git: 4 };
+      const sa = scopeOrder[a.config.scope ?? 'app'];
+      const sb = scopeOrder[b.config.scope ?? 'app'];
+      if (sa !== sb) return sa - sb;
+      return b.priority - a.priority;
+    });
   }
 
-   
+  /**
+   * Check whether a given config conflicts with any registered shortcut in the same scope.
+   * Used by the settings UI for real-time conflict detection.
+   */
+  public checkConflicts(config: ShortcutConfig, excludeId?: string, excludeIds?: string[]): ShortcutRegistration[] {
+    const scope = config.scope ?? 'app';
+    const key = makeMapKey(scope, config);
+    const list = this.lookupMap.get(key) ?? [];
+    const exclude = new Set<string>([...(excludeIds ?? [])]);
+    if (excludeId) exclude.add(excludeId);
+    return exclude.size ? list.filter((r) => !exclude.has(r.id)) : [...list];
+  }
+
+  // ─── Utilities ─────────────────────────────────────────────────────────────
+
+  public formatShortcut(config: ShortcutConfig): string {
+    const isMac = navigator.platform.toUpperCase().includes('MAC');
+    const parts: string[] = [];
+    if (config.ctrl) parts.push(isMac ? '⌘' : 'Ctrl');
+    if (config.shift) parts.push(isMac ? '⇧' : 'Shift');
+    if (config.alt) parts.push(isMac ? '⌥' : 'Alt');
+    const key = config.key === ' ' ? 'Space' : config.key.length === 1 ? config.key.toUpperCase() : config.key;
+    parts.push(key);
+    return parts.join(isMac ? '' : '+');
+  }
+
+  public parseShortcut(shortcut: string): Omit<ShortcutConfig, 'scope' | 'allowInInput'> | null {
+    const parts = shortcut.split('+').map((s) => s.trim().toLowerCase());
+    if (parts.length === 0) return null;
+    const key = parts[parts.length - 1];
+    return {
+      key,
+      ctrl: parts.includes('ctrl') || parts.includes('cmd') || parts.includes('mod'),
+      shift: parts.includes('shift'),
+      alt: parts.includes('alt'),
+      meta: parts.includes('meta'),
+    };
+  }
+
   public setEnabled(enabled: boolean): void {
     this.isEnabled = enabled;
   }
 
-   
   public isShortcutEnabled(): boolean {
     return this.isEnabled;
   }
 
-   
   public clear(): void {
     this.registrations.clear();
+    this.lookupMap.clear();
+    this.notifyRegistrationListeners();
   }
 }
 
-
 export const shortcutManager = ShortcutManager.getInstance();
-

--- a/src/web-ui/src/locales/en-US/settings.json
+++ b/src/web-ui/src/locales/en-US/settings.json
@@ -6,6 +6,7 @@
     "searchPlaceholder": "Search settings…",
     "searchNoResults": "No matching settings",
     "searchClear": "Clear search",
+    "beta": "Beta",
     "tabDescriptions": {
       "basics": "Language, theme, logging, terminal shell, and launch at login.",
       "models": "AI models, API keys, providers, and proxy.",
@@ -13,7 +14,8 @@
       "aiContext": "Rules and memory for AI context.",
       "mcpTools": "MCP servers and tool integrations.",
       "editor": "Editor font, display, and formatting.",
-      "lsp": "Language servers and code intelligence."
+      "lsp": "Language servers and code intelligence.",
+      "keyboard": "Shortcuts and key bindings."
     },
     "categories": {
       "general": "General",
@@ -31,7 +33,8 @@
       "mcpTools": "MCP",
       "agents": "Agents",
       "editor": "Editor",
-      "lsp": "LSP"
+      "lsp": "LSP",
+      "keyboard": "Keyboard"
     }
   },
   "general": {
@@ -140,11 +143,84 @@
     }
   },
   "keyboard": {
-    "title": "Keyboard",
-    "shortcuts": "Keyboard Shortcuts",
-    "search": "Search Shortcuts",
-    "reset": "Reset to Default",
-    "conflict": "Shortcut Conflict"
+    "title": "Keyboard Shortcuts",
+    "description": "View and edit bindings below.",
+    "search": "Search shortcuts or key bindings…",
+    "apply": "Apply",
+    "saving": "Saving…",
+    "reset": "Reset to Defaults",
+    "clickToRecord": "Click to record a new key binding",
+    "recording": "Press new key combination…",
+    "revertChange": "Revert this change",
+    "fixedBinding": "This shortcut is fixed and cannot be changed",
+    "noResults": "No matching shortcuts found",
+    "conflict": "Conflict",
+    "saveError": "Failed to save, please try again",
+    "resetError": "Failed to reset, please try again",
+    "mergedNonUniform": "Mixed bindings — record to reset as a set",
+    "keyLabels": {
+      "space": "Space"
+    },
+    "scopes": {
+      "app": "Global",
+      "canvas": "Editor Canvas",
+      "chat": "Agent Session",
+      "filetree": "File Tree",
+      "git": "Git"
+    },
+    "shortcuts": {
+      "panel": {
+        "toggleLeft": "Expand or collapse left navigation",
+        "toggleBoth": "Collapse All Panels"
+      },
+      "scene": {
+        "focusMerged": "Switch scene",
+        "focusMergedHint": "Record Alt (or your chosen modifiers) + any digit 1–3 once; keys 1–3 map to scenes left to right.",
+        "openSession": "Open Agent Session",
+        "openGit": "Open Git",
+        "openSettings": "Open Settings",
+        "openTerminal": "Open Terminal"
+      },
+      "app": {
+        "closePreview": "Close Preview / Dismiss Dialog"
+      },
+      "canvas": {
+        "missionControl": "Mission Control",
+        "splitHorizontal": "Horizontal Split",
+        "splitVertical": "Vertical Split",
+        "anchorZone": "Toggle Anchor Zone",
+        "maximize": "Maximize Editor",
+        "closePreview": "Close Preview"
+      },
+      "tab": {
+        "close": "Close Current Tab",
+        "reopenClosed": "Reopen Closed Tab",
+        "switchMerged": "Switch editor tab",
+        "switchMergedHint": "Record modifier + any digit 1–9 once; the same modifiers apply to all tab slots."
+      },
+      "chat": {
+        "btwFill": "Start side-thread session",
+        "stopGeneration": "Stop Generation",
+        "activateInput": "Activate Input",
+        "newSession": "New Session"
+      },
+      "filetree": {
+        "rename": "Rename",
+        "delete": "Delete",
+        "refresh": "Refresh",
+        "newFile": "New File",
+        "newFolder": "New Folder",
+        "collapseAll": "Collapse All"
+      },
+      "git": {
+        "commit": "Commit",
+        "refresh": "Refresh Status",
+        "stageAll": "Stage All Changes",
+        "unstageAll": "Unstage All Changes",
+        "push": "Push",
+        "pull": "Pull"
+      }
+    }
   },
   "advanced": {
     "title": "Advanced",

--- a/src/web-ui/src/locales/zh-CN/settings.json
+++ b/src/web-ui/src/locales/zh-CN/settings.json
@@ -6,6 +6,7 @@
     "searchPlaceholder": "搜索配置…",
     "searchNoResults": "没有匹配的配置",
     "searchClear": "清除搜索",
+    "beta": "Beta",
     "tabDescriptions": {
       "basics": "语言、主题、日志、终端 Shell 与开机启动。",
       "models": "AI 模型、API 密钥、供应商与代理。",
@@ -13,7 +14,8 @@
       "aiContext": "规则与记忆等 AI 上下文。",
       "mcpTools": "MCP 服务器与工具集成。",
       "editor": "编辑器字体、显示与格式化。",
-      "lsp": "语言服务与代码智能。"
+      "lsp": "语言服务与代码智能。",
+      "keyboard": "快捷键与键位。"
     },
     "categories": {
       "general": "通用",
@@ -31,7 +33,8 @@
       "mcpTools": "MCP",
       "agents": "智能体",
       "editor": "编辑器",
-      "lsp": "语言服务"
+      "lsp": "语言服务",
+      "keyboard": "快捷键"
     }
   },
   "general": {
@@ -141,10 +144,83 @@
   },
   "keyboard": {
     "title": "快捷键",
-    "shortcuts": "快捷键设置",
-    "search": "搜索快捷键",
+    "description": "在此查看并修改快捷键。",
+    "search": "搜索快捷键或键位…",
+    "apply": "应用",
+    "saving": "保存中…",
     "reset": "重置为默认",
-    "conflict": "快捷键冲突"
+    "clickToRecord": "点击录制新的快捷键",
+    "recording": "按下新键位…",
+    "revertChange": "撤销此更改",
+    "fixedBinding": "系统固定快捷键，无法自定义",
+    "noResults": "未找到匹配的快捷键",
+    "conflict": "冲突",
+    "saveError": "保存失败，请重试",
+    "resetError": "重置失败，请重试",
+    "mergedNonUniform": "键位不一致，可重新录制为一组",
+    "keyLabels": {
+      "space": "空格"
+    },
+    "scopes": {
+      "app": "全局",
+      "canvas": "编辑器画布",
+      "chat": "Agent 会话",
+      "filetree": "文件树",
+      "git": "Git"
+    },
+    "shortcuts": {
+      "panel": {
+        "toggleLeft": "展开/收起左侧导航区域",
+        "toggleBoth": "折叠所有面板"
+      },
+      "scene": {
+        "focusMerged": "切换场景",
+        "focusMergedHint": "录制一次修饰键 + 任意数字 1–3；数字 1–3 对应从左到右的场景。",
+        "openSession": "打开 Agent 会话",
+        "openGit": "打开 Git",
+        "openSettings": "打开设置",
+        "openTerminal": "打开终端"
+      },
+      "app": {
+        "closePreview": "关闭预览 / 关闭弹窗"
+      },
+      "canvas": {
+        "missionControl": "Mission Control",
+        "splitHorizontal": "水平分屏",
+        "splitVertical": "垂直分屏",
+        "anchorZone": "切换锚点区",
+        "maximize": "最大化编辑器",
+        "closePreview": "关闭预览"
+      },
+      "tab": {
+        "close": "关闭当前标签页",
+        "reopenClosed": "重新打开已关闭标签页",
+        "switchMerged": "切换编辑器标签",
+        "switchMergedHint": "录制一次修饰键 + 任意数字 1–9；同一组修饰键会应用到各标签位。"
+      },
+      "chat": {
+        "btwFill": "开启侧问会话",
+        "stopGeneration": "停止生成",
+        "activateInput": "激活输入框",
+        "newSession": "新建会话"
+      },
+      "filetree": {
+        "rename": "重命名",
+        "delete": "删除",
+        "refresh": "刷新",
+        "newFile": "新建文件",
+        "newFolder": "新建文件夹",
+        "collapseAll": "折叠所有目录"
+      },
+      "git": {
+        "commit": "提交",
+        "refresh": "刷新状态",
+        "stageAll": "暂存所有更改",
+        "unstageAll": "取消暂存所有更改",
+        "push": "推送",
+        "pull": "拉取"
+      }
+    }
   },
   "advanced": {
     "title": "高级",

--- a/src/web-ui/src/shared/constants/index.ts
+++ b/src/web-ui/src/shared/constants/index.ts
@@ -1,3 +1,4 @@
 
 export * from './app';
+export * from './shortcuts';
 

--- a/src/web-ui/src/shared/constants/shortcuts.ts
+++ b/src/web-ui/src/shared/constants/shortcuts.ts
@@ -1,0 +1,324 @@
+
+import type { ShortcutConfig, ShortcutScope } from '@/shared/types/shortcut';
+
+/**
+ * A complete shortcut definition: default key binding + metadata.
+ * The `descriptionKey` is an i18n key under the 'settings' namespace.
+ */
+export interface ShortcutDef {
+  id: string;
+  config: ShortcutConfig;
+  /** i18n key for the human-readable shortcut description */
+  descriptionKey: string;
+}
+
+/**
+ * These bindings always use catalog defaults; user overrides in config are ignored
+ * and the keyboard settings UI does not allow remapping them.
+ */
+export const NON_USER_CUSTOMIZABLE_SHORTCUT_IDS = new Set<string>([
+  'scene.openSession',
+  'chat.activateInput',
+]);
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+const isMac = typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC');
+
+/** Build a ShortcutConfig using Ctrl (Win/Linux) or Meta (Mac) as the primary modifier. */
+function mod(
+  key: string,
+  extras: Omit<ShortcutConfig, 'key' | 'ctrl' | 'meta'> = {}
+): ShortcutConfig {
+  return isMac ? { key, meta: true, ...extras } : { key, ctrl: true, ...extras };
+}
+
+/** Shortcut with no primary modifier (plain key, scope-aware). */
+function plain(key: string, scope: ShortcutScope, allowInInput = false): ShortcutConfig {
+  return { key, scope, allowInInput };
+}
+
+// ─── Global shortcuts (scope: 'app') ──────────────────────────────────────
+// These fire regardless of where focus is, including inside input elements
+// (where allowInInput: true) or from any scene. Use sparingly — only for
+// navigation and layout operations that must always be reachable.
+
+export const APP_SHORTCUTS: ShortcutDef[] = [
+  // Panel layout
+  {
+    id: 'panel.toggleLeft',
+    config: mod('B', { scope: 'app' }),
+    descriptionKey: 'keyboard.shortcuts.panel.toggleLeft',
+  },
+  {
+    id: 'panel.toggleBoth',
+    config: mod('B', { shift: true, scope: 'app' }),
+    descriptionKey: 'keyboard.shortcuts.panel.toggleBoth',
+  },
+
+  // Scene quick-open — jump to a named scene from anywhere
+  {
+    id: 'scene.openSession',
+    config: mod('A', { shift: true, scope: 'app', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.scene.openSession',
+  },
+  {
+    id: 'scene.openGit',
+    config: mod('G', { shift: true, scope: 'app', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.scene.openGit',
+  },
+  {
+    id: 'scene.openSettings',
+    config: mod(',', { scope: 'app', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.scene.openSettings',
+  },
+  {
+    id: 'scene.openTerminal',
+    config: mod('`', { shift: true, scope: 'app', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.scene.openTerminal',
+  },
+
+  // App-level UI
+  {
+    id: 'app.closePreview',
+    config: { key: 'Escape', scope: 'app', allowInInput: true },
+    descriptionKey: 'keyboard.shortcuts.app.closePreview',
+  },
+];
+
+// ─── Scene-bar navigation (scope: 'app', allowInInput: true) ──────────────
+// Alt+1–3: switch between the top-level scene tabs; merged into one row in
+// settings. Kept separate from APP_SHORTCUTS so the UI can merge them.
+
+export const SCENE_SHORTCUTS: ShortcutDef[] = [
+  { id: 'scene.focus1', config: { key: '1', alt: true, scope: 'app', allowInInput: true }, descriptionKey: 'keyboard.shortcuts.scene.focusMerged' },
+  { id: 'scene.focus2', config: { key: '2', alt: true, scope: 'app', allowInInput: true }, descriptionKey: 'keyboard.shortcuts.scene.focusMerged' },
+  { id: 'scene.focus3', config: { key: '3', alt: true, scope: 'app', allowInInput: true }, descriptionKey: 'keyboard.shortcuts.scene.focusMerged' },
+];
+
+// ─── Editor canvas shortcuts (scope: 'canvas') ────────────────────────────
+// Active only when focus is inside the editor canvas area
+// (data-shortcut-scope="canvas"). Tab-switch shortcuts retain allowInInput
+// so they continue to work while a Monaco editor is focused.
+
+export const CANVAS_SHORTCUTS: ShortcutDef[] = [
+  // View
+  {
+    id: 'canvas.missionControl',
+    config: mod('Tab', { scope: 'canvas', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.canvas.missionControl',
+  },
+  {
+    id: 'canvas.splitHorizontal',
+    config: mod('\\', { scope: 'canvas' }),
+    descriptionKey: 'keyboard.shortcuts.canvas.splitHorizontal',
+  },
+  {
+    id: 'canvas.splitVertical',
+    config: mod('\\', { shift: true, scope: 'canvas' }),
+    descriptionKey: 'keyboard.shortcuts.canvas.splitVertical',
+  },
+  {
+    id: 'canvas.anchorZone',
+    config: mod('`', { scope: 'canvas' }),
+    descriptionKey: 'keyboard.shortcuts.canvas.anchorZone',
+  },
+  {
+    id: 'canvas.maximize',
+    config: mod('M', { shift: true, scope: 'canvas' }),
+    descriptionKey: 'keyboard.shortcuts.canvas.maximize',
+  },
+  {
+    id: 'canvas.closePreview',
+    config: { key: 'Escape', scope: 'canvas', allowInInput: true },
+    descriptionKey: 'keyboard.shortcuts.canvas.closePreview',
+  },
+
+  // Tab management
+  {
+    id: 'tab.close',
+    config: mod('W', { scope: 'canvas', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.tab.close',
+  },
+  {
+    id: 'tab.reopenClosed',
+    config: mod('T', { shift: true, scope: 'canvas', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.tab.reopenClosed',
+  },
+  {
+    id: 'tab.switch1',
+    config: mod('1', { scope: 'canvas', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.tab.switchMerged',
+  },
+  {
+    id: 'tab.switch2',
+    config: mod('2', { scope: 'canvas', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.tab.switchMerged',
+  },
+  {
+    id: 'tab.switch3',
+    config: mod('3', { scope: 'canvas', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.tab.switchMerged',
+  },
+  {
+    id: 'tab.switch4',
+    config: mod('4', { scope: 'canvas', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.tab.switchMerged',
+  },
+  {
+    id: 'tab.switch5',
+    config: mod('5', { scope: 'canvas', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.tab.switchMerged',
+  },
+  {
+    id: 'tab.switch6',
+    config: mod('6', { scope: 'canvas', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.tab.switchMerged',
+  },
+  {
+    id: 'tab.switch7',
+    config: mod('7', { scope: 'canvas', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.tab.switchMerged',
+  },
+  {
+    id: 'tab.switch8',
+    config: mod('8', { scope: 'canvas', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.tab.switchMerged',
+  },
+  {
+    id: 'tab.switchLast',
+    config: mod('9', { scope: 'canvas', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.tab.switchMerged',
+  },
+];
+
+// ─── Chat shortcuts (scope: 'chat') ───────────────────────────────────────
+
+export const CHAT_SHORTCUTS: ShortcutDef[] = [
+  {
+    id: 'btw-fill',
+    config: { key: 'B', ctrl: true, alt: true, scope: 'chat', allowInInput: true },
+    descriptionKey: 'keyboard.shortcuts.chat.btwFill',
+  },
+  {
+    id: 'chat.stopGeneration',
+    config: { key: 'Escape', scope: 'chat', allowInInput: true },
+    descriptionKey: 'keyboard.shortcuts.chat.stopGeneration',
+  },
+  {
+    id: 'chat.activateInput',
+    config: plain(' ', 'chat', false),
+    descriptionKey: 'keyboard.shortcuts.chat.activateInput',
+  },
+  {
+    id: 'chat.newSession',
+    config: mod('N', { scope: 'chat' }),
+    descriptionKey: 'keyboard.shortcuts.chat.newSession',
+  },
+];
+
+// ─── File tree shortcuts (scope: 'filetree') ──────────────────────────────
+
+export const FILETREE_SHORTCUTS: ShortcutDef[] = [
+  {
+    id: 'filetree.rename',
+    config: { key: 'F2', scope: 'filetree' },
+    descriptionKey: 'keyboard.shortcuts.filetree.rename',
+  },
+  {
+    id: 'filetree.delete',
+    config: { key: 'Delete', scope: 'filetree' },
+    descriptionKey: 'keyboard.shortcuts.filetree.delete',
+  },
+  {
+    id: 'filetree.refresh',
+    config: { key: 'F5', scope: 'filetree' },
+    descriptionKey: 'keyboard.shortcuts.filetree.refresh',
+  },
+  {
+    id: 'filetree.newFile',
+    config: mod('N', { scope: 'filetree' }),
+    descriptionKey: 'keyboard.shortcuts.filetree.newFile',
+  },
+  {
+    id: 'filetree.newFolder',
+    config: mod('N', { shift: true, scope: 'filetree' }),
+    descriptionKey: 'keyboard.shortcuts.filetree.newFolder',
+  },
+  {
+    id: 'filetree.collapseAll',
+    config: mod('[', { shift: true, scope: 'filetree' }),
+    descriptionKey: 'keyboard.shortcuts.filetree.collapseAll',
+  },
+];
+
+// ─── Git shortcuts (scope: 'git') ─────────────────────────────────────────
+
+export const GIT_SHORTCUTS: ShortcutDef[] = [
+  {
+    id: 'git.commit',
+    config: mod('Enter', { scope: 'git', allowInInput: true }),
+    descriptionKey: 'keyboard.shortcuts.git.commit',
+  },
+  {
+    id: 'git.refresh',
+    config: { key: 'F5', scope: 'git' },
+    descriptionKey: 'keyboard.shortcuts.git.refresh',
+  },
+  {
+    id: 'git.stageAll',
+    config: mod('A', { shift: true, scope: 'git' }),
+    descriptionKey: 'keyboard.shortcuts.git.stageAll',
+  },
+  {
+    id: 'git.unstageAll',
+    config: mod('U', { shift: true, scope: 'git' }),
+    descriptionKey: 'keyboard.shortcuts.git.unstageAll',
+  },
+  {
+    id: 'git.push',
+    config: mod('P', { shift: true, scope: 'git' }),
+    descriptionKey: 'keyboard.shortcuts.git.push',
+  },
+  {
+    id: 'git.pull',
+    config: mod('L', { shift: true, scope: 'git' }),
+    descriptionKey: 'keyboard.shortcuts.git.pull',
+  },
+];
+
+// ─── All shortcuts combined ────────────────────────────────────────────────
+
+export const ALL_SHORTCUTS: ShortcutDef[] = [
+  ...APP_SHORTCUTS,
+  ...SCENE_SHORTCUTS,
+  ...CANVAS_SHORTCUTS,
+  ...CHAT_SHORTCUTS,
+  ...FILETREE_SHORTCUTS,
+  ...GIT_SHORTCUTS,
+];
+
+/** Shortcuts registered in code but not listed in ALL_SHORTCUTS (e.g. legacy ids). */
+const EXTRA_SHORTCUT_DESCRIPTION_KEYS: Record<string, string> = {};
+
+/**
+ * Resolve the i18n key (settings namespace) for a shortcut id.
+ * Used by the keyboard settings UI so labels always match known definitions.
+ */
+export function getShortcutDescriptionI18nKey(id: string): string | undefined {
+  const fromCatalog = ALL_SHORTCUTS.find((d) => d.id === id)?.descriptionKey;
+  if (fromCatalog) return fromCatalog;
+  return EXTRA_SHORTCUT_DESCRIPTION_KEYS[id];
+}
+
+/** Scope display order for the settings UI. */
+export const SCOPE_ORDER: ShortcutScope[] = ['app', 'chat', 'canvas', 'filetree', 'git'];
+
+/** i18n keys for scope group labels in the settings UI. */
+export const SCOPE_LABEL_KEYS: Record<ShortcutScope, string> = {
+  app:      'keyboard.scopes.app',
+  chat:     'keyboard.scopes.chat',
+  canvas:   'keyboard.scopes.canvas',
+  filetree: 'keyboard.scopes.filetree',
+  git:      'keyboard.scopes.git',
+};

--- a/src/web-ui/src/shared/types/shortcut.ts
+++ b/src/web-ui/src/shared/types/shortcut.ts
@@ -1,5 +1,17 @@
+
 /**
- * Keyboard shortcut configuration (modifier + key).
+ * Keyboard shortcut scope — determines when a shortcut is active.
+ *
+ * - 'app'      : always active within the application window (not input-focused by default)
+ * - 'canvas'   : active when focus is inside the editor canvas (data-shortcut-scope="canvas")
+ * - 'chat'     : active when focus is inside the chat panel (data-shortcut-scope="chat")
+ * - 'filetree' : active when focus is inside the file tree panel
+ * - 'git'      : active when focus is inside the git panel
+ */
+export type ShortcutScope = 'app' | 'canvas' | 'chat' | 'filetree' | 'git';
+
+/**
+ * Keyboard shortcut configuration (modifier + key + scope).
  * Used by ShortcutManager for global shortcut registration.
  */
 export interface ShortcutConfig {
@@ -8,4 +20,14 @@ export interface ShortcutConfig {
   shift?: boolean;
   alt?: boolean;
   meta?: boolean;
+  /**
+   * Scope in which this shortcut is active.
+   * Defaults to 'app' if not specified.
+   */
+  scope?: ShortcutScope;
+  /**
+   * When true, the shortcut fires even when an input/textarea/contenteditable
+   * element is focused. Defaults to false.
+   */
+  allowInInput?: boolean;
 }

--- a/src/web-ui/src/tools/file-system/components/FileExplorer.tsx
+++ b/src/web-ui/src/tools/file-system/components/FileExplorer.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { useShortcut } from '@/infrastructure/hooks/useShortcut';
 import { Folder, ChevronRight, FilePlus, FolderPlus, RefreshCw } from 'lucide-react';
 import { FileTree } from './FileTree';
 import { VirtualFileTree } from './VirtualFileTree';
@@ -300,12 +301,32 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({
     }
   }, [externalOnNodeExpand]);
 
+  useShortcut(
+    'filetree.refresh',
+    { key: 'F5', scope: 'filetree' },
+    handleRefresh,
+    { enabled: Boolean(onRefresh), description: 'keyboard.shortcuts.filetree.refresh' }
+  );
+  useShortcut(
+    'filetree.newFile',
+    { key: 'N', ctrl: true, scope: 'filetree' },
+    handleNewFile,
+    { enabled: Boolean(onNewFile), description: 'keyboard.shortcuts.filetree.newFile' }
+  );
+  useShortcut(
+    'filetree.newFolder',
+    { key: 'N', ctrl: true, shift: true, scope: 'filetree' },
+    handleNewFolder,
+    { enabled: Boolean(onNewFolder), description: 'keyboard.shortcuts.filetree.newFolder' }
+  );
+
   if (filteredFileTree.length === 0) {
     return (
       <div 
         className={`bitfun-file-explorer bitfun-file-explorer--empty ${className}`}
         data-area="file-explorer"
         data-workspace-root={workspacePath}
+        data-shortcut-scope="filetree"
         tabIndex={0}
       >
         <div className="bitfun-file-explorer__empty">
@@ -322,6 +343,7 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({
       className={`bitfun-file-explorer ${className}`}
       data-area="file-explorer"
       data-workspace-root={workspacePath}
+      data-shortcut-scope="filetree"
       tabIndex={0}
       onMouseEnter={() => setIsToolbarVisible(true)}
       onMouseLeave={() => {


### PR DESCRIPTION
## Summary

This PR centralizes keyboard shortcut handling and adds a **Settings → Keyboard shortcuts** reference tab (en/zh).

## Changes

- **ShortcutManager**: refactored registration and dispatch; aligns with shared shortcut IDs and types.
- **Hooks**: useShortcut, useGlobalSceneShortcuts for consistent binding across the app.
- **Settings**: new KeyboardShortcutsTab with searchable shortcut list styling.
- **Integration**: content canvas, Git working copy, flow chat, file explorer, and layout wiring.
- **Core**: small extension to config types for shortcut-related preferences.

## Testing

- Manual: verify shortcuts in main scenes and that the settings tab lists expected bindings.
