### PR TITLE
feat: miniapp bridge extensions

### DIFF
--- a/MiniApp/Demo/icon-design-system/meta.json
+++ b/MiniApp/Demo/icon-design-system/meta.json
@@ -1,0 +1,31 @@
+{
+  "id": "icon-design-system",
+  "name": "Icon Design System",
+  "description": "AI 辅助的图标设计系统工具。通过对话定义设计风格，批量生成图标 SVG，管理变体，支持手动编辑与导出。",
+  "icon": "pen-tool",
+  "category": "design",
+  "tags": ["design", "icon", "ai", "svg"],
+  "version": 1,
+  "created_at": 0,
+  "updated_at": 0,
+  "permissions": {
+    "fs": {
+      "read": ["{appdata}", "{user-selected}"],
+      "write": ["{appdata}", "{user-selected}"]
+    },
+    "net": {
+      "allow": ["esm.sh"]
+    },
+    "ai": {
+      "enabled": true,
+      "allowed_models": ["primary", "fast"],
+      "max_tokens_per_request": 8192,
+      "rate_limit_per_minute": 30
+    },
+    "node": {
+      "enabled": true,
+      "timeout_ms": 60000
+    }
+  },
+  "ai_context": null
+}

--- a/MiniApp/Demo/icon-design-system/source/esm_dependencies.json
+++ b/MiniApp/Demo/icon-design-system/source/esm_dependencies.json
@@ -1,0 +1,4 @@
+[
+  { "name": "preact", "url": "https://esm.sh/preact@10.22.0" },
+  { "name": "preact/hooks", "url": "https://esm.sh/preact@10.22.0/hooks" }
+]

--- a/MiniApp/Demo/icon-design-system/source/index.html
+++ b/MiniApp/Demo/icon-design-system/source/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en" data-theme-type="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Icon Design System</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/MiniApp/Demo/icon-design-system/source/style.css
+++ b/MiniApp/Demo/icon-design-system/source/style.css
@@ -1,0 +1,503 @@
+/* ── Theme token aliases ────────────────────────────────────────────────────── */
+/* Map --bitfun-* host variables to local names so every rule auto-adapts.    */
+:root {
+  --bg:           var(--bitfun-bg, #121214);
+  --bg2:          var(--bitfun-bg-secondary, #18181a);
+  --bg3:          var(--bitfun-bg-tertiary, #0e0e10);
+  --bg-el:        var(--bitfun-element-bg, #27272a);
+  --bg-hover:     var(--bitfun-element-hover, #3f3f46);
+  --text:         var(--bitfun-text, #e8e8e8);
+  --text2:        var(--bitfun-text-secondary, #b0b0b0);
+  --text3:        var(--bitfun-text-muted, #858585);
+  --accent:       var(--bitfun-accent, #60a5fa);
+  --accent2:      var(--bitfun-accent-hover, #3b82f6);
+  --success:      var(--bitfun-success, #34d399);
+  --warning:      var(--bitfun-warning, #f59e0b);
+  --danger:       var(--bitfun-error, #ef4444);
+  --info:         var(--bitfun-info, #60a5fa);
+  --border:       var(--bitfun-border, #2e2e32);
+  --border2:      var(--bitfun-border-subtle, #27272a);
+  --radius:       var(--bitfun-radius, 6px);
+  --radius-lg:    var(--bitfun-radius-lg, 10px);
+  --font:         var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  --font-mono:    var(--bitfun-font-mono, ui-monospace, monospace);
+  --scrollbar:    var(--bitfun-scrollbar-thumb, rgba(128,128,128,0.25));
+
+  /* Derived semantic tokens */
+  --on-accent:    #fff;          /* text on accent-coloured surface */
+  --on-danger:    #fff;          /* text on danger-coloured surface */
+  --on-success:   #fff;          /* text on success-coloured surface */
+}
+
+/* In light theme the on-accent/danger text must be white only if the accent is
+   dark enough; hosts should override via --bitfun-on-accent if needed. */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.5;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* ── Layout ─────────────────────────────────────────────────────────────────── */
+#app { display: flex; height: 100vh; }
+
+.sidebar {
+  width: 200px;
+  min-width: 200px;
+  background: var(--bg2);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  padding: 12px 0;
+}
+
+.main { flex: 1; display: flex; flex-direction: column; overflow: hidden; background: var(--bg); }
+
+/* ── Sidebar nav ──────────────────────────────────────────────────────────── */
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+  color: var(--text2);
+  transition: background 0.12s, color 0.12s;
+  font-size: 13px;
+}
+.nav-item:hover { background: var(--bg-hover); color: var(--text); }
+.nav-item.active { background: var(--bg-el); color: var(--accent); }
+.nav-item .icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.nav-item .icon svg { width: 18px; height: 18px; }
+
+.nav-section {
+  padding: 16px 16px 6px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text3);
+}
+
+/* ── Panel ───────────────────────────────────────────────────────────────── */
+.panel { flex: 1; overflow-y: auto; padding: 20px; background: var(--bg); }
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+.panel-title { font-size: 16px; font-weight: 600; color: var(--text); }
+
+/* ── Buttons ─────────────────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: var(--radius);
+  border: none;
+  font-family: var(--font);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.12s, opacity 0.12s;
+  white-space: nowrap;
+}
+.btn-primary {
+  background: var(--accent);
+  color: var(--on-accent);
+}
+.btn-primary:hover { background: var(--accent2); }
+
+.btn-secondary {
+  background: var(--bg-el);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+.btn-secondary:hover { background: var(--bg-hover); }
+
+.btn-danger {
+  background: transparent;
+  color: var(--danger);
+  border: 1px solid var(--danger);
+}
+.btn-danger:hover { background: color-mix(in srgb, var(--danger) 12%, transparent); }
+
+.btn:disabled { opacity: 0.45; cursor: not-allowed; pointer-events: none; }
+.btn-sm { padding: 4px 8px; font-size: 12px; }
+.btn-icon { padding: 6px; }
+
+/* ── Form controls ───────────────────────────────────────────────────────── */
+/* Include `input:not([type])` because the CSS attribute selector does NOT   */
+/* match inputs whose type is the implicit default ("text").                 */
+input[type="text"],
+input[type="number"],
+input:not([type]),
+textarea,
+.input {
+  background: var(--bg-el);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 13px;
+  padding: 6px 10px;
+  outline: none;
+  transition: border-color 0.12s;
+  width: 100%;
+}
+input[type="text"]:focus,
+input[type="number"]:focus,
+input:not([type]):focus,
+textarea:focus { border-color: var(--accent); }
+input::placeholder,
+textarea::placeholder { color: var(--text3); }
+input[type="range"] { accent-color: var(--accent); width: 100%; }
+
+/* ── Icon grid ───────────────────────────────────────────────────────────── */
+.icon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));
+  gap: 12px;
+}
+
+.icon-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 8px;
+  border-radius: var(--radius-lg);
+  background: var(--bg2);
+  border: 1px solid var(--border2);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  position: relative;
+  user-select: none;
+}
+.icon-card:hover { border-color: var(--border); background: var(--bg-el); }
+.icon-card.selected { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 10%, transparent); }
+
+.icon-card .preview {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text);
+}
+.icon-card .preview svg { width: 24px; height: 24px; }
+
+.icon-card .name {
+  font-size: 11px;
+  color: var(--text2);
+  text-align: center;
+  word-break: break-word;
+  line-height: 1.3;
+  max-width: 100%;
+}
+
+.icon-card .delete-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  opacity: 0;
+  background: var(--danger);
+  color: var(--on-danger);
+  border: none;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  font-size: 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.15s;
+}
+.icon-card:hover .delete-btn { opacity: 1; }
+
+/* ── Empty state ─────────────────────────────────────────────────────────── */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 48px 0;
+  color: var(--text3);
+  text-align: center;
+}
+.empty-state .big-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text2);
+}
+.empty-state .big-icon svg { width: 48px; height: 48px; }
+
+@keyframes icon-spin {
+  to { transform: rotate(360deg); }
+}
+svg.icon-spin {
+  animation: icon-spin 0.9s linear infinite;
+  transform-origin: center;
+}
+
+/* ── Chat ────────────────────────────────────────────────────────────────── */
+.chat-layout { display: flex; flex-direction: column; height: 100%; }
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: var(--bg);
+}
+
+.message { display: flex; gap: 10px; max-width: 100%; }
+.message.user { flex-direction: row-reverse; }
+
+.message-bubble {
+  max-width: 75%;
+  padding: 10px 14px;
+  border-radius: var(--radius-lg);
+  font-size: 13px;
+  line-height: 1.6;
+}
+.message.assistant .message-bubble {
+  background: var(--bg-el);
+  color: var(--text);
+  border: 1px solid var(--border2);
+}
+.message.user .message-bubble {
+  background: var(--accent);
+  color: var(--on-accent);
+}
+
+.message-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--bg-el);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text2);
+  flex-shrink: 0;
+}
+.message-avatar svg { width: 16px; height: 16px; }
+
+.chat-input-area {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  background: var(--bg2);
+}
+
+.chat-input {
+  flex: 1;
+  background: var(--bg-el);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 13px;
+  padding: 8px 12px;
+  resize: none;
+  min-height: 38px;
+  max-height: 120px;
+  line-height: 1.5;
+  outline: none;
+  transition: border-color 0.12s;
+}
+.chat-input:focus { border-color: var(--accent); }
+.chat-input::placeholder { color: var(--text3); }
+
+/* ── Token editor ────────────────────────────────────────────────────────── */
+.token-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.token-field label {
+  display: block;
+  font-size: 12px;
+  color: var(--text2);
+  margin-bottom: 6px;
+}
+
+.token-field input[type="number"],
+.token-field input[type="text"] { width: 100%; }
+.token-field input[type="range"] { width: 100%; }
+.token-value { font-size: 12px; color: var(--text3); margin-top: 2px; }
+
+/* ── SVG preview ─────────────────────────────────────────────────────────── */
+.svg-preview-box {
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  color: var(--text);   /* so currentColor in SVG picks up the right colour */
+}
+.svg-preview-box svg { max-width: 64px; max-height: 64px; }
+
+/* ── SVG code block ──────────────────────────────────────────────────────── */
+pre.svg-code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: var(--bg3);
+  border: 1px solid var(--border2);
+  border-radius: var(--radius);
+  padding: 10px;
+  overflow: auto;
+  max-height: 200px;
+  white-space: pre;
+  color: var(--text2);
+  word-break: break-all;
+}
+
+/* ── Detail panel ────────────────────────────────────────────────────────── */
+.detail-panel {
+  width: 280px;
+  background: var(--bg2);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.detail-panel-content { flex: 1; overflow-y: auto; padding: 16px; }
+
+.detail-section { margin-bottom: 20px; }
+.detail-section-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text3);
+  margin-bottom: 10px;
+}
+
+/* ── Search ──────────────────────────────────────────────────────────────── */
+.search-row { display: flex; gap: 8px; margin-bottom: 16px; }
+.search-input { flex: 1; }
+
+/* ── Tags ────────────────────────────────────────────────────────────────── */
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 100px;
+  background: var(--bg-el);
+  color: var(--text2);
+  border: 1px solid var(--border2);
+  font-size: 11px;
+}
+.tags { display: flex; flex-wrap: wrap; gap: 4px; }
+
+/* ── Typing indicator ────────────────────────────────────────────────────── */
+.typing-indicator { display: flex; gap: 4px; align-items: center; padding: 4px 0; }
+.dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--text3);
+  animation: bounce 1.2s infinite ease-in-out;
+}
+.dot:nth-child(2) { animation-delay: 0.2s; }
+.dot:nth-child(3) { animation-delay: 0.4s; }
+@keyframes bounce {
+  0%, 80%, 100% { transform: scale(0.7); opacity: 0.5; }
+  40%            { transform: scale(1);   opacity: 1; }
+}
+
+/* ── Scrollbar ───────────────────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--scrollbar); border-radius: 3px; }
+
+/* ── Toast ───────────────────────────────────────────────────────────────── */
+.toast-container {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 1000;
+}
+.toast {
+  padding: 10px 16px;
+  border-radius: var(--radius);
+  font-size: 13px;
+  animation: slide-in 0.2s ease;
+  max-width: 320px;
+  word-break: break-word;
+}
+.toast.success { background: var(--success); color: var(--on-success); }
+.toast.error   { background: var(--danger);  color: var(--on-danger);  }
+.toast.info    { background: var(--bg-el); color: var(--text); border: 1px solid var(--border); }
+@keyframes slide-in { from { transform: translateX(40px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+
+/* ── Divider ─────────────────────────────────────────────────────────────── */
+.divider { border: none; border-top: 1px solid var(--border); margin: 16px 0; }
+
+/* ── Generate panel ──────────────────────────────────────────────────────── */
+.generate-form { display: flex; flex-direction: column; gap: 16px; }
+
+/* ── Library layout ──────────────────────────────────────────────────────── */
+.library-layout { display: flex; height: 100%; overflow: hidden; background: var(--bg); }
+.library-main { flex: 1; overflow-y: auto; background: var(--bg); }
+.library-wrapper { display: flex; height: 100%; overflow: hidden; background: var(--bg); }
+
+/* ── Chat panel visibility ───────────────────────────────────────────────── */
+.chat-panel-wrap {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  height: 100%;
+  background: var(--bg);
+}
+.panel--hidden { display: none !important; }
+.panel--visible { display: flex !important; }
+
+/* ── SVG icon wrapper ────────────────────────────────────────────────────── */
+.svg-icon-wrap { display: flex; align-items: center; justify-content: center; width: 64px; height: 64px; }
+.svg-icon-wrap svg { max-width: 100%; max-height: 100%; }
+
+/* msg SVG preview — smaller */
+.msg-svg-preview { min-height: 80px; margin-top: 8px; }
+.msg-svg-preview .svg-icon-wrap { width: 40px; height: 40px; }
+
+/* svg action bar below a chat SVG */
+.svg-actions { margin-top: 8px; display: flex; gap: 6px; }
+
+/* ── Utility classes ─────────────────────────────────────────────────────── */
+.btn-row { display: flex; gap: 8px; flex-wrap: wrap; }
+.btn-full { width: 100%; justify-content: center; margin-top: 8px; }
+.mt6 { margin-top: 6px; }
+.hint-text { font-size: 12px; color: var(--text3); margin-top: 4px; }
+.icon-name-text { font-weight: 600; color: var(--text); }
+
+/* ── Token section ───────────────────────────────────────────────────────── */
+.token-section { margin-top: 20px; }
+.token-section .detail-section-title { margin-bottom: 8px; }
+
+/* ── Sidebar bottom section ──────────────────────────────────────────────── */
+.nav-section--bottom { margin-top: auto; }

--- a/MiniApp/Demo/icon-design-system/source/ui.js
+++ b/MiniApp/Demo/icon-design-system/source/ui.js
@@ -1,0 +1,595 @@
+/** @jsx h */
+import { h, render, Fragment } from 'preact';
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+
+const app = window.app;
+
+// ── Inline SVG icons (no emoji) ─────────────────────────────────────────────
+
+function path(d) {
+  return h('path', { d });
+}
+
+function ic(size, children, extra = {}) {
+  return h('svg', {
+    xmlns: 'http://www.w3.org/2000/svg',
+    width: size,
+    height: size,
+    viewBox: '0 0 24 24',
+    fill: 'none',
+    stroke: 'currentColor',
+    'stroke-width': 1.5,
+    'stroke-linecap': 'round',
+    'stroke-linejoin': 'round',
+    'aria-hidden': 'true',
+    ...extra,
+  }, children);
+}
+
+const Ico = {
+  chat: (s = 18) => ic(s, path('M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z')),
+  bolt: (s = 18) => ic(s, path('M13 10V3L4 14h7v7l9-11h-7z')),
+  library: (s = 18) => ic(s, path('M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z')),
+  tokens: (s = 18) => ic(s, [
+    path('M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z'),
+  ]),
+  user: (s = 16) => ic(s, path('M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z')),
+  assistant: (s = 16) => ic(s, path('M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z')),
+  copy: (s = 14) => ic(s, path('M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2M8 16a2 2 0 002 2h8a2 2 0 002-2v-8a2 2 0 00-2-2h-2M8 16V8a2 2 0 012-2h8')),
+  check: (s = 14) => ic(s, path('M4.5 12.75l6 6 9-13.5')),
+  refresh: (s = 16) => ic(s, path('M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15')),
+  download: (s = 16) => ic(s, path('M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4')),
+  loader: (s = 48) => ic(s, [
+    path('M12 2v4'),
+    path('M12 18v4'),
+    path('M4.93 4.93l2.83 2.83'),
+    path('M16.24 16.24l2.83 2.83'),
+    path('M2 12h4'),
+    path('M18 12h4'),
+    path('M4.93 19.07l2.83-2.83'),
+    path('M16.24 7.76l2.83-2.83'),
+  ], { class: 'icon-spin' }),
+  empty: (s = 48) => ic(s, path('M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4')),
+  close: (s = 10) => ic(s, path('M6 18L18 6M6 6l12 12')),
+};
+
+// ── Toast ─────────────────────────────────────────────────────────────────────
+
+function useToasts() {
+  const [toasts, setToasts] = useState([]);
+  const show = useCallback((msg, type = 'info') => {
+    const id = Date.now();
+    setToasts(prev => [...prev, { id, msg, type }]);
+    setTimeout(() => setToasts(prev => prev.filter(t => t.id !== id)), 3000);
+  }, []);
+  return { toasts, show };
+}
+
+function ToastContainer({ toasts }) {
+  return h('div', { class: 'toast-container' },
+    toasts.map(t => h('div', { key: t.id, class: `toast ${t.type}` }, t.msg))
+  );
+}
+
+// ── System Prompt ─────────────────────────────────────────────────────────────
+
+const ICON_DESIGN_SYSTEM_PROMPT = `You are an expert icon designer specializing in SVG icon systems.
+
+When asked to generate icons, output ONLY the SVG code, no explanations.
+
+SVG requirements:
+- viewBox="0 0 24 24"
+- width="24" height="24"
+- Use currentColor for strokes/fills (do NOT hardcode colors)
+- stroke-width="1.5" unless specified otherwise
+- stroke-linecap="round" stroke-linejoin="round" for line icons
+- No <title>, no <desc>, no XML declaration
+- Clean, minimal paths
+
+When discussing design style or tokens, respond naturally in the conversation language.
+When generating icons, output ONLY the SVG element, starting with <svg`.trim();
+
+// ── Design Tokens Panel ───────────────────────────────────────────────────────
+
+function TokenField(label, value, onChange, min, max, step) {
+  return h('div', { class: 'token-field' },
+    h('label', null, label),
+    h('input', { type: 'range', min, max, step, value, onInput: e => onChange(e.target.value) }),
+    h('div', { class: 'token-value' }, value)
+  );
+}
+
+function TokensPanel({ tokens, onSave, showToast }) {
+  const [local, setLocal] = useState(tokens);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => setLocal(tokens), [tokens]);
+
+  const set = (key, val) => setLocal(prev => ({ ...prev, [key]: val }));
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await app.call('saveTokens', { tokens: local });
+      onSave(local);
+      showToast('Design tokens saved', 'success');
+    } catch (e) {
+      showToast('Failed to save: ' + e.message, 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return h(Fragment, null,
+    h('div', { class: 'panel-header' },
+      h('div', { class: 'panel-title' }, 'Design Tokens'),
+      h('button', { class: 'btn btn-primary btn-sm', onClick: handleSave, disabled: saving },
+        saving ? 'Saving…' : 'Save'
+      )
+    ),
+    h('div', { class: 'token-grid' },
+      TokenField('Stroke Width', local.strokeWidth, v => set('strokeWidth', Number(v)), 0.5, 4, 0.25),
+      TokenField('Corner Radius', local.cornerRadius, v => set('cornerRadius', Number(v)), 0, 12, 0.5),
+      TokenField('Grid Size', local.gridSize, v => set('gridSize', Number(v)), 16, 48, 8),
+      TokenField('Optical Padding', local.opticalPadding, v => set('opticalPadding', Number(v)), 0, 4, 0.5),
+    ),
+    h('div', { class: 'token-section' },
+      h('div', { class: 'detail-section-title' }, 'Size Variants (px)'),
+      h('div', { class: 'tags' },
+        (local.sizeVariants || [16, 20, 24, 32, 48]).map(s =>
+          h('span', { key: s, class: 'tag' }, `${s}px`)
+        )
+      )
+    ),
+    h('div', { class: 'token-section' },
+      h('div', { class: 'detail-section-title' }, 'Style Variants'),
+      h('div', { class: 'tags' },
+        (local.styleVariants || ['outlined', 'filled']).map(s =>
+          h('span', { key: s, class: 'tag' }, s)
+        )
+      )
+    )
+  );
+}
+
+// ── AI Style Chat Panel ───────────────────────────────────────────────────────
+
+function ChatPanel({ tokens, showToast }) {
+  const [messages, setMessages] = useState([
+    { role: 'assistant', content: 'Hi! I can help you define the icon design style and generate icons. Describe the style you want — e.g., "sharp geometric, 2px stroke, minimal" or ask me to generate a specific icon.' }
+  ]);
+  const [input, setInput] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [streamText, setStreamText] = useState('');
+  const cancelRef = useRef(null);
+  const bottomRef = useRef(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, streamText]);
+
+  const sendMessage = async () => {
+    const text = input.trim();
+    if (!text || busy) return;
+    setInput('');
+
+    const userMsg = { role: 'user', content: text };
+    const history = [...messages, userMsg];
+    setMessages(history);
+    setBusy(true);
+    setStreamText('');
+
+    const contextHint = `\n\n[Current design tokens: strokeWidth=${tokens.strokeWidth}, cornerRadius=${tokens.cornerRadius}, gridSize=${tokens.gridSize}]`;
+
+    try {
+      let accumulated = '';
+      const handle = await app.ai.chat(
+        history.map(m => ({ role: m.role, content: m.content })),
+        {
+          systemPrompt: ICON_DESIGN_SYSTEM_PROMPT + contextHint,
+          model: 'primary',
+          onChunk: ({ text: t }) => {
+            if (t) { accumulated += t; setStreamText(accumulated); }
+          },
+          onDone: ({ fullText }) => {
+            const final = fullText || accumulated;
+            setMessages(prev => [...prev, { role: 'assistant', content: final }]);
+            setStreamText('');
+            setBusy(false);
+            cancelRef.current = null;
+            if (/<svg/i.test(final)) showToast('SVG detected — save it from the Generate tab!', 'info');
+          },
+          onError: ({ message }) => {
+            showToast('AI error: ' + message, 'error');
+            setStreamText('');
+            setBusy(false);
+            cancelRef.current = null;
+          },
+        }
+      );
+      cancelRef.current = handle.cancel;
+    } catch (e) {
+      showToast('Failed to send: ' + e.message, 'error');
+      setBusy(false);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
+  };
+
+  const cancel = () => {
+    if (cancelRef.current) { cancelRef.current(); cancelRef.current = null; }
+    setStreamText('');
+    setBusy(false);
+  };
+
+  return h('div', { class: 'chat-layout' },
+    h('div', { class: 'messages' },
+      messages.map((m, i) => h(ChatMessage, { key: i, message: m, showToast })),
+      streamText && h('div', { class: 'message assistant' },
+        h('div', { class: 'message-avatar' }, Ico.assistant()),
+        h('div', { class: 'message-bubble' },
+          streamText,
+          h('div', { class: 'typing-indicator' },
+            h('div', { class: 'dot' }), h('div', { class: 'dot' }), h('div', { class: 'dot' })
+          )
+        )
+      ),
+      h('div', { ref: bottomRef })
+    ),
+    h('div', { class: 'chat-input-area' },
+      h('textarea', {
+        class: 'chat-input',
+        placeholder: 'Describe a style or ask to generate an icon…',
+        value: input,
+        onInput: e => setInput(e.target.value),
+        onKeyDown: handleKeyDown,
+        disabled: busy,
+        rows: 1,
+      }),
+      busy
+        ? h('button', { class: 'btn btn-secondary btn-sm', onClick: cancel }, 'Stop')
+        : h('button', { class: 'btn btn-primary btn-sm', onClick: sendMessage, disabled: !input.trim() }, 'Send')
+    )
+  );
+}
+
+function ChatMessage({ message, showToast }) {
+  const isUser = message.role === 'user';
+  const svgMatch = !isUser && message.content.match(/<svg[\s\S]*?<\/svg>/i);
+  const [copied, setCopied] = useState(false);
+
+  const copySvg = async () => {
+    if (!svgMatch) return;
+    try {
+      await app.clipboard.writeText(svgMatch[0]);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // fallback: show in a prompt so the user can copy manually
+      window.prompt('Copy the SVG code below:', svgMatch[0]);
+    }
+  };
+
+  return h('div', { class: `message ${message.role}` },
+    h('div', { class: 'message-avatar' }, isUser ? Ico.user() : Ico.assistant()),
+    h('div', { class: 'message-bubble' },
+      svgMatch
+        ? h(Fragment, null,
+            h('span', null, message.content.replace(svgMatch[0], '')),
+            h('div', { class: 'svg-preview-box msg-svg-preview' },
+              h('div', { dangerouslySetInnerHTML: { __html: svgMatch[0] } })
+            ),
+            h('div', { class: 'svg-actions' },
+              h('button', { class: 'btn btn-secondary btn-sm', onClick: copySvg },
+                copied
+                  ? h(Fragment, null, Ico.check(14), ' Copied!')
+                  : h(Fragment, null, Ico.copy(14), ' Copy SVG')
+              )
+            )
+          )
+        : message.content
+    )
+  );
+}
+
+// ── Generate Panel ────────────────────────────────────────────────────────────
+
+function GeneratePanel({ tokens, onIconAdded, showToast }) {
+  const [prompt, setPrompt] = useState('');
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [generated, setGenerated] = useState('');
+
+  const generate = async () => {
+    if (!prompt.trim() || busy) return;
+    setBusy(true);
+    setGenerated('');
+
+    try {
+      const tokenCtx = `Stroke width: ${tokens.strokeWidth}px, corner radius: ${tokens.cornerRadius}, grid: ${tokens.gridSize}x${tokens.gridSize}`;
+      const result = await app.ai.complete(
+        `Generate a ${tokens.gridSize}x${tokens.gridSize} SVG icon for: ${prompt}\n\nDesign constraints: ${tokenCtx}`,
+        { systemPrompt: ICON_DESIGN_SYSTEM_PROMPT, model: 'fast', maxTokens: 2048 }
+      );
+      const svgMatch = result.text.match(/<svg[\s\S]*?<\/svg>/i);
+      if (!svgMatch) showToast('No SVG found in AI response. Try rephrasing.', 'error');
+      else setGenerated(svgMatch[0]);
+    } catch (e) {
+      showToast('Generation failed: ' + e.message, 'error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveToLibrary = async () => {
+    if (!generated) return;
+    try {
+      await app.call('saveIcon', {
+        name: name.trim() || prompt.trim().slice(0, 32),
+        tags: [],
+        category: 'general',
+        svgSource: generated,
+      });
+      onIconAdded();
+      showToast('Icon saved to library!', 'success');
+      setGenerated(''); setName(''); setPrompt('');
+    } catch (e) {
+      showToast('Save failed: ' + e.message, 'error');
+    }
+  };
+
+  return h(Fragment, null,
+    h('div', { class: 'panel-header' },
+      h('div', { class: 'panel-title' }, 'Generate Icon')
+    ),
+    h('div', { class: 'generate-form' },
+      h('div', { class: 'token-field' },
+        h('label', null, 'Icon description'),
+        h('input', {
+          type: 'text',
+          placeholder: 'e.g. "settings gear with minimalist style"',
+          value: prompt,
+          onInput: e => setPrompt(e.target.value),
+          onKeyDown: e => e.key === 'Enter' && generate(),
+          disabled: busy,
+        })
+      ),
+      h('div', { class: 'token-field' },
+        h('label', null, 'Name (optional)'),
+        h('input', {
+          type: 'text',
+          placeholder: 'e.g. "Settings"',
+          value: name,
+          onInput: e => setName(e.target.value),
+          disabled: busy,
+        })
+      ),
+      h('button', { class: 'btn btn-primary', onClick: generate, disabled: busy || !prompt.trim() },
+        busy ? 'Generating…' : 'Generate'
+      ),
+
+      generated && h(Fragment, null,
+        h('div', { class: 'detail-section-title' }, 'Preview'),
+        h('div', { class: 'svg-preview-box' },
+          h('div', { dangerouslySetInnerHTML: { __html: generated }, class: 'svg-icon-wrap' })
+        ),
+        h('div', { class: 'btn-row' },
+          h('button', { class: 'btn btn-primary', onClick: saveToLibrary }, 'Save to Library'),
+          h('button', { class: 'btn btn-secondary', onClick: () => setGenerated('') }, 'Discard'),
+        ),
+        h('div', { class: 'detail-section-title' }, 'SVG Source'),
+        h('pre', { class: 'svg-code' }, generated)
+      )
+    )
+  );
+}
+
+// ── Library Panel ─────────────────────────────────────────────────────────────
+
+function LibraryPanel({ refreshKey, showToast }) {
+  const [icons, setIcons] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [iconData, setIconData] = useState({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const list = await app.call('listIcons', {});
+      setIcons(list || []);
+    } catch (e) {
+      showToast('Failed to load library: ' + e.message, 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [refreshKey]);
+
+  const selectIcon = async (id) => {
+    setSelected(id);
+    if (!iconData[id]) {
+      try {
+        const data = await app.call('getIcon', { id });
+        setIconData(prev => ({ ...prev, [id]: data }));
+      } catch { /* ignore */ }
+    }
+  };
+
+  const deleteIcon = async (e, id) => {
+    e.stopPropagation();
+    try {
+      await app.call('deleteIcon', { id });
+      if (selected === id) setSelected(null);
+      load();
+      showToast('Icon deleted', 'info');
+    } catch (err) {
+      showToast('Delete failed: ' + err.message, 'error');
+    }
+  };
+
+  const copyToClipboard = async (text) => {
+    try {
+      await app.clipboard.writeText(text);
+      showToast('Copied!', 'success');
+    } catch {
+      showToast('Copy failed', 'error');
+    }
+  };
+
+  const exportAll = async () => {
+    try {
+      const dir = await app.dialog.open({ directory: true, title: 'Export icons to folder' });
+      if (!dir) return;
+      const result = await app.call('exportIcons', { targetDir: dir, format: 'svg' });
+      showToast(`Exported ${result.exported} icons`, 'success');
+    } catch (e) {
+      showToast('Export failed: ' + e.message, 'error');
+    }
+  };
+
+  const filtered = icons.filter(i =>
+    !search || i.name.toLowerCase().includes(search.toLowerCase())
+  );
+  const selectedData = selected ? iconData[selected] : null;
+
+  return h('div', { class: 'library-layout' },
+    h('div', { class: 'panel library-main' },
+      h('div', { class: 'panel-header' },
+        h('div', { class: 'panel-title' }, `Library (${icons.length})`),
+        h('div', { class: 'btn-row' },
+          h('button', { class: 'btn btn-secondary btn-sm btn-icon', onClick: load, 'aria-label': 'Refresh library' }, Ico.refresh(16)),
+          h('button', { class: 'btn btn-secondary btn-sm', onClick: exportAll },
+            Ico.download(16), ' Export')
+        )
+      ),
+      h('div', { class: 'search-row' },
+        h('input', {
+          type: 'text',
+          class: 'search-input',
+          placeholder: 'Search icons…',
+          value: search,
+          onInput: e => setSearch(e.target.value),
+        })
+      ),
+      loading
+        ? h('div', { class: 'empty-state' }, h('div', { class: 'big-icon' }, Ico.loader(48)), 'Loading…')
+        : filtered.length === 0
+          ? h('div', { class: 'empty-state' },
+              h('div', { class: 'big-icon' }, Ico.empty(48)),
+              h('p', null, search ? 'No icons match your search' : 'No icons yet'),
+              !search && h('p', { class: 'hint-text' }, 'Use the Generate tab to create your first icon')
+            )
+          : h('div', { class: 'icon-grid' },
+              filtered.map(icon => h('div', {
+                key: icon.id,
+                class: `icon-card ${selected === icon.id ? 'selected' : ''}`,
+                onClick: () => selectIcon(icon.id),
+              },
+                h('button', { class: 'delete-btn', onClick: e => deleteIcon(e, icon.id), 'aria-label': 'Delete icon' }, Ico.close(10)),
+                h('div', {
+                  class: 'preview',
+                  dangerouslySetInnerHTML: {
+                    __html: iconData[icon.id]?.svgSource ||
+                      '<svg viewBox="0 0 24 24" width="24" height="24"><rect width="24" height="24" fill="none"/></svg>'
+                  }
+                }),
+                h('div', { class: 'name' }, icon.name)
+              ))
+            )
+    ),
+    selectedData && h('div', { class: 'detail-panel' },
+      h('div', { class: 'detail-panel-content' },
+        h('div', { class: 'detail-section' },
+          h('div', { class: 'detail-section-title' }, 'Preview'),
+          h('div', { class: 'svg-preview-box' },
+            h('div', { dangerouslySetInnerHTML: { __html: selectedData.svgSource }, class: 'svg-icon-wrap' })
+          )
+        ),
+        h('div', { class: 'detail-section' },
+          h('div', { class: 'detail-section-title' }, 'Info'),
+          h('div', { class: 'icon-name-text' }, selectedData.name),
+          selectedData.category && h('div', { class: 'tags mt6' },
+            h('span', { class: 'tag' }, selectedData.category)
+          )
+        ),
+        h('div', { class: 'detail-section' },
+          h('div', { class: 'detail-section-title' }, 'SVG Source'),
+          h('pre', { class: 'svg-code' }, selectedData.svgSource),
+          h('button', {
+            class: 'btn btn-secondary btn-sm btn-full',
+            onClick: () => copyToClipboard(selectedData.svgSource)
+          }, Ico.copy(14), ' Copy SVG')
+        )
+      )
+    )
+  );
+}
+
+// ── App Root ──────────────────────────────────────────────────────────────────
+
+function App() {
+  const [tab, setTab] = useState('chat');
+  const [tokens, setTokens] = useState({
+    strokeWidth: 1.5,
+    cornerRadius: 2,
+    gridSize: 24,
+    opticalPadding: 1,
+    sizeVariants: [16, 20, 24, 32, 48],
+    styleVariants: ['outlined', 'filled'],
+  });
+  const [libraryKey, setLibraryKey] = useState(0);
+  const { toasts, show: showToast } = useToasts();
+
+  useEffect(() => {
+    app.call('getTokens', {}).then(t => {
+      if (t && t.strokeWidth) setTokens(t);
+    }).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    app.on('worker:progress', (data) => {
+      if (data && data.total > 0) {
+        showToast(`Exporting ${data.name}… (${data.done}/${data.total})`, 'info');
+      }
+    });
+  }, []);
+
+  const nav = (id, iconEl, label) => h('div', {
+    class: `nav-item ${tab === id ? 'active' : ''}`,
+    onClick: () => setTab(id),
+  }, h('span', { class: 'icon' }, iconEl), label);
+
+  return h(Fragment, null,
+    h('div', { id: 'app' },
+      h('div', { class: 'sidebar' },
+        h('div', { class: 'nav-section' }, 'Icon Design'),
+        nav('chat', Ico.chat(), 'Style Chat'),
+        nav('generate', Ico.bolt(), 'Generate'),
+        nav('library', Ico.library(), 'Library'),
+        h('div', { class: 'nav-section nav-section--bottom' }, 'Settings'),
+        nav('tokens', Ico.tokens(), 'Tokens'),
+      ),
+      h('div', { class: 'main' },
+        h('div', { class: `panel chat-panel-wrap ${tab === 'chat' ? 'panel--visible' : 'panel--hidden'}` },
+          h(ChatPanel, { tokens, showToast })
+        ),
+        tab === 'generate' && h('div', { class: 'panel' },
+          h(GeneratePanel, { tokens, onIconAdded: () => setLibraryKey(k => k + 1), showToast })
+        ),
+        tab === 'library' && h('div', { class: 'library-wrapper' },
+          h(LibraryPanel, { refreshKey: libraryKey, showToast })
+        ),
+        tab === 'tokens' && h('div', { class: 'panel' },
+          h(TokensPanel, { tokens, onSave: setTokens, showToast })
+        ),
+      )
+    ),
+    h(ToastContainer, { toasts })
+  );
+}
+
+render(h(App, null), document.getElementById('root'));

--- a/MiniApp/Demo/icon-design-system/source/worker.js
+++ b/MiniApp/Demo/icon-design-system/source/worker.js
@@ -1,0 +1,231 @@
+/**
+ * Icon Design System — Worker
+ * Handles file I/O, icon library management, SVG optimization, and export.
+ */
+
+const fs = require('fs/promises');
+const path = require('path');
+
+const APP_DATA_DIR = process.env.BITFUN_APP_DATA || process.cwd();
+
+const ICONS_DIR = path.join(APP_DATA_DIR, 'icons');
+const LIBRARY_FILE = path.join(APP_DATA_DIR, 'library.json');
+const TOKENS_FILE = path.join(APP_DATA_DIR, 'design-tokens.json');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function ensureDir(dir) {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function readJsonFile(filePath, defaultValue) {
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch {
+    return defaultValue;
+  }
+}
+
+async function writeJsonFile(filePath, data) {
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf8');
+}
+
+function generateId() {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+}
+
+// ── Icon Library ──────────────────────────────────────────────────────────────
+
+async function loadLibrary() {
+  return readJsonFile(LIBRARY_FILE, { icons: [], updatedAt: 0 });
+}
+
+async function saveLibrary(library) {
+  library.updatedAt = Date.now();
+  await ensureDir(APP_DATA_DIR);
+  await writeJsonFile(LIBRARY_FILE, library);
+}
+
+// ── Exports ───────────────────────────────────────────────────────────────────
+
+/**
+ * Get design tokens (style definition).
+ */
+exports.getTokens = async () => {
+  return readJsonFile(TOKENS_FILE, getDefaultTokens());
+};
+
+/**
+ * Save design tokens.
+ */
+exports.saveTokens = async ({ tokens }) => {
+  await ensureDir(APP_DATA_DIR);
+  await writeJsonFile(TOKENS_FILE, { ...tokens, updatedAt: Date.now() });
+  return { ok: true };
+};
+
+/**
+ * List all icons in the library.
+ */
+exports.listIcons = async () => {
+  const library = await loadLibrary();
+  return library.icons || [];
+};
+
+/**
+ * Get a single icon by id (includes SVG source).
+ */
+exports.getIcon = async ({ id }) => {
+  const library = await loadLibrary();
+  const meta = (library.icons || []).find(icon => icon.id === id);
+  if (!meta) throw new Error(`Icon not found: ${id}`);
+
+  const svgPath = path.join(ICONS_DIR, id, 'base.svg');
+  let svg = '';
+  try {
+    svg = await fs.readFile(svgPath, 'utf8');
+  } catch {
+    svg = meta.svgSource || '';
+  }
+  return { ...meta, svgSource: svg };
+};
+
+/**
+ * Save a new or updated icon.
+ */
+exports.saveIcon = async ({ id, name, tags, category, svgSource }) => {
+  const iconId = id || generateId();
+  await ensureDir(path.join(ICONS_DIR, iconId));
+
+  // Save SVG file
+  const svgPath = path.join(ICONS_DIR, iconId, 'base.svg');
+  await fs.writeFile(svgPath, svgSource || '', 'utf8');
+
+  // Update library index
+  const library = await loadLibrary();
+  const icons = library.icons || [];
+  const existing = icons.findIndex(i => i.id === iconId);
+  const meta = {
+    id: iconId,
+    name: name || 'Untitled',
+    tags: tags || [],
+    category: category || 'general',
+    createdAt: existing >= 0 ? icons[existing].createdAt : Date.now(),
+    updatedAt: Date.now(),
+  };
+  if (existing >= 0) {
+    icons[existing] = meta;
+  } else {
+    icons.push(meta);
+  }
+  library.icons = icons;
+  await saveLibrary(library);
+
+  return meta;
+};
+
+/**
+ * Delete an icon.
+ */
+exports.deleteIcon = async ({ id }) => {
+  const library = await loadLibrary();
+  library.icons = (library.icons || []).filter(i => i.id !== id);
+  await saveLibrary(library);
+
+  // Remove icon directory
+  const iconDir = path.join(ICONS_DIR, id);
+  try {
+    await fs.rm(iconDir, { recursive: true, force: true });
+  } catch { /* ignore */ }
+
+  return { ok: true };
+};
+
+/**
+ * Export all icons as a ZIP-style directory structure.
+ * Emits progress events via rpcEmit.
+ */
+exports.exportIcons = async ({ targetDir, format }) => {
+  const library = await loadLibrary();
+  const icons = library.icons || [];
+
+  await ensureDir(targetDir);
+
+  let done = 0;
+  for (const meta of icons) {
+    const svgPath = path.join(ICONS_DIR, meta.id, 'base.svg');
+    let svg = '';
+    try {
+      svg = await fs.readFile(svgPath, 'utf8');
+    } catch { /* skip */ }
+
+    if (format === 'react') {
+      const componentName = toPascalCase(meta.name) + 'Icon';
+      const tsx = svgToReactComponent(componentName, svg);
+      await fs.writeFile(path.join(targetDir, `${componentName}.tsx`), tsx, 'utf8');
+    } else {
+      // Default: plain SVG files
+      const safeName = meta.name.replace(/[^a-z0-9-_]/gi, '-').toLowerCase();
+      await fs.writeFile(path.join(targetDir, `${safeName}.svg`), svg, 'utf8');
+    }
+
+    done++;
+    if (global.rpcEmit) {
+      global.rpcEmit('progress', { done, total: icons.length, name: meta.name });
+    }
+  }
+
+  return { exported: done, targetDir };
+};
+
+/**
+ * Export design tokens as a JSON file.
+ */
+exports.exportTokens = async ({ targetPath }) => {
+  const tokens = await readJsonFile(TOKENS_FILE, getDefaultTokens());
+  await fs.writeFile(targetPath, JSON.stringify(tokens, null, 2), 'utf8');
+  return { ok: true };
+};
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+function toPascalCase(str) {
+  return str
+    .replace(/[^a-z0-9]/gi, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join('');
+}
+
+function svgToReactComponent(componentName, svgSource) {
+  const svgBody = (svgSource || '')
+    .replace(/<\?xml[^>]*\?>/g, '')
+    .replace(/<!--.*?-->/gs, '')
+    .trim();
+  return `import React from 'react';
+
+interface ${componentName}Props extends React.SVGProps<SVGSVGElement> {}
+
+export const ${componentName}: React.FC<${componentName}Props> = (props) => (
+  ${svgBody.replace(/<svg/, '<svg {...props}')}
+);
+
+export default ${componentName};
+`;
+}
+
+function getDefaultTokens() {
+  return {
+    version: 1,
+    strokeWidth: 1.5,
+    cornerRadius: 2,
+    gridSize: 24,
+    opticalPadding: 1,
+    colorMode: 'currentColor',
+    sizeVariants: [16, 20, 24, 32, 48],
+    styleVariants: ['outlined', 'filled'],
+    updatedAt: 0,
+  };
+}

--- a/MiniApp/Skills/miniapp-dev/api-reference.md
+++ b/MiniApp/Skills/miniapp-dev/api-reference.md
@@ -2,6 +2,8 @@
 
 此文档定义 AI 生成的 MiniApp 代码中可用的全部 API，供 Agent 工具 system prompt 或调试时参考。
 
+> **实际全局对象为 `window.app`**（非 `window.__BITFUN__`），以下各节均基于 `window.app`。
+
 ## 标准 Node.js API（通过 require() shim）
 
 ### fs/promises
@@ -69,58 +71,220 @@ const crypto = require('crypto');
 ## 标准浏览器 API
 
 MiniApp 运行在 iframe 中，完整支持:
-- DOM、CSS（含 CSS 变量 `--bg`, `--fg`, `--accent`）
+- DOM、CSS（含 CSS 变量 `--bitfun-bg`, `--bitfun-text`, `--bitfun-accent` 等）
 - Canvas 2D / WebGL
 - Web Audio
-- `navigator.clipboard`
 - LocalStorage / SessionStorage（iframe 级隔离）
+- `navigator.clipboard`（通过 `app.clipboard.*` 代理，绕过 sandbox 限制）
 
-## fetch()（代理增强）
+## `window.app` — 全局 Runtime Adapter
+
+MiniApp 中所有与宿主通信的 API 均通过 `window.app` 暴露。
+
+### 基本属性
 
 ```javascript
-// 外部请求 — 通过 Rust reqwest 代理，无 CORS 限制
-const res = await fetch('https://api.example.com/data');
+app.appId        // string — 当前 MiniApp 的 ID
+app.appDataDir   // string — 应用数据目录绝对路径
+app.workspaceDir // string — 当前工作区路径
+app.theme        // 'dark' | 'light' — 当前主题
+app.platform     // 'win32' | 'darwin' | 'linux'
+app.mode         // 'hosted'
+```
 
-// 内部 API — 访问 BitFun 能力
-const res = await fetch('/api/ai/complete', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ prompt: '...' })
+### `app.fs.*` — 文件系统
+
+需在 `permissions.fs` 中声明读写范围。
+
+| 方法 | 签名 | 说明 |
+|------|------|------|
+| `readFile` | `(path, opts?) → Promise<string>` | opts: `{ encoding: 'utf-8' \| 'base64' }` |
+| `writeFile` | `(path, data, opts?) → Promise<void>` | opts: `{ encoding: 'utf-8' \| 'base64' }` |
+| `appendFile` | `(path, data) → Promise<void>` | |
+| `readdir` | `(path, opts?) → Promise<string[]>` | opts: `{ withFileTypes: boolean }` |
+| `mkdir` | `(path, opts?) → Promise<void>` | opts: `{ recursive: boolean }` |
+| `rm` | `(path, opts?) → Promise<void>` | opts: `{ recursive: boolean, force: boolean }` |
+| `stat` | `(path) → Promise<Stats>` | `{ size, isFile, isDirectory, mtime, ctime }` |
+| `copyFile` | `(src, dst) → Promise<void>` | |
+| `rename` | `(oldPath, newPath) → Promise<void>` | |
+
+### `app.storage.*` — KV 持久化存储
+
+无权限要求，数据存储在 `{appdata}/storage.json`。
+
+```javascript
+await app.storage.set('myKey', { foo: 'bar' });
+const value = await app.storage.get('myKey'); // { foo: 'bar' }
+```
+
+### `app.dialog.*` — 系统对话框
+
+```javascript
+const path = await app.dialog.open({
+  title: '选择文件',
+  multiple: false,
+  filters: [{ name: 'SVG', extensions: ['svg'] }]
+});
+const savePath = await app.dialog.save({ title: '保存', defaultPath: 'output.svg' });
+await app.dialog.message({ title: '提示', message: '操作成功' });
+```
+
+### `app.shell.*` — Shell 命令执行
+
+需在 `permissions.shell.allow` 中声明命令白名单。
+
+```javascript
+const result = await app.shell.exec('git log --oneline -10', { cwd: app.workspaceDir });
+```
+
+### `app.net.*` — 网络请求（Worker 侧）
+
+需在 `permissions.net.allow` 中声明域名白名单。
+
+```javascript
+const data = await app.net.fetch('https://api.example.com/data', { method: 'GET' });
+```
+
+### `app.os.*` — 系统信息
+
+```javascript
+const info = await app.os.info(); // { platform, homedir, tmpdir, ... }
+```
+
+### `app.call(method, params)` — 调用 Worker 方法
+
+调用 `source/worker.js` 中导出的函数。
+
+```javascript
+const result = await app.call('myWorkerMethod', { key: 'value' });
+```
+
+---
+
+## `app.ai.*` — AI 接口（v2）
+
+直接复用宿主应用的 AI Client，无需配置 API Key。需在 `permissions.ai` 中声明。
+
+### `app.ai.complete(prompt, opts?)` — 单次补全
+
+返回完整文本，适合一次性生成场景。
+
+```javascript
+const result = await app.ai.complete('生成一个设置图标的 SVG，viewBox 24x24，线性风格', {
+  systemPrompt: '你是一个图标设计专家，只输出 SVG 代码，不含任何说明文字。',
+  model: 'fast',        // 'primary' | 'fast' | 具体 model_id，默认 'primary'
+  maxTokens: 4096,
+  temperature: 0.7,
+});
+console.log(result.text);   // SVG 字符串
+console.log(result.usage);  // { promptTokens, completionTokens, totalTokens }
+```
+
+### `app.ai.chat(messages, opts?)` — 流式对话
+
+支持多轮对话和流式输出，适合交互式生成场景。
+
+```javascript
+const handle = await app.ai.chat(
+  [
+    { role: 'user', content: '设计一个首页图标，圆角风格，24px 网格' }
+  ],
+  {
+    systemPrompt: '你是图标设计专家，生成符合设计规范的 SVG 代码。',
+    model: 'primary',
+    onChunk: ({ text, reasoningContent }) => {
+      // 实时更新预览
+      if (text) appendToPreview(text);
+    },
+    onDone: ({ fullText, usage }) => {
+      // 完成后处理完整结果
+      const svg = extractSvg(fullText);
+      renderIcon(svg);
+    },
+    onError: ({ message }) => {
+      console.error('AI error:', message);
+    },
+  }
+);
+
+// 取消流式请求
+cancelButton.onclick = () => handle.cancel();
+
+// handle.streamId — 当前流的唯一 ID
+```
+
+### `app.ai.getModels()` — 查询可用模型
+
+返回当前 MiniApp 权限范围内可用的模型列表（不含 API Key 等敏感信息）。
+
+```javascript
+const models = await app.ai.getModels();
+// [{ id: 'gpt4o', name: 'GPT-4o', provider: 'openai', isDefault: true }, ...]
+```
+
+### `app.ai.cancel(streamId)` — 取消流式请求
+
+```javascript
+await app.ai.cancel(handle.streamId);
+```
+
+### AI 权限声明
+
+```json
+{
+  "permissions": {
+    "ai": {
+      "enabled": true,
+      "allowed_models": ["primary", "fast"],
+      "max_tokens_per_request": 8192,
+      "rate_limit_per_minute": 30
+    }
+  }
+}
+```
+
+- `allowed_models`：可用模型引用列表，支持 `"primary"`、`"fast"` 及具体 model_id；为空则允许所有模型
+- `max_tokens_per_request`：单次请求最大输出 token 数
+- `rate_limit_per_minute`：每分钟最大请求次数（按 app 计数）
+
+---
+
+## `app.clipboard.*` — 剪贴板
+
+通过宿主代理，绕过 iframe sandbox 的 clipboard 限制。
+
+```javascript
+await app.clipboard.writeText('Hello World');
+const text = await app.clipboard.readText();
+```
+
+---
+
+## 生命周期钩子
+
+```javascript
+app.onActivate(() => { /* Tab 变为活跃状态 */ });
+app.onDeactivate(() => { /* Tab 切走 */ });
+app.onThemeChange((payload) => {
+  // payload: { type: 'dark'|'light', vars: { '--bitfun-bg': '...', ... } }
 });
 ```
 
-### 内部 API 路由
-
-| 路由 | 方法 | 功能 |
-|------|------|------|
-| `/api/ai/complete` | POST | AI 文本补全 |
-| `/api/ai/chat` | POST | 向对话发消息 |
-| `/api/storage` | GET/PUT/DELETE | KV 存储 |
-| `/api/apps` | GET | 列出其他 MiniApp |
-| `/api/apps/:id/send` | POST | 跨 App 通信 |
-
-## __BITFUN__ 全局对象
-
-唯一非标准 API，仅含对话框和环境信息:
+## 自定义事件
 
 ```javascript
-window.__BITFUN__ = {
-  appId: 'uuid',
-  appDataDir: '/path/to/app/data',
-  workspaceDir: '/path/to/workspace',
-  theme: 'dark' | 'light',
-  _platform: 'win32' | 'darwin' | 'linux',
-
-  showOpenDialog(opts): Promise<string | string[] | null>,
-  showSaveDialog(opts): Promise<string | null>,
-  showMessageBox(opts): Promise<string>,
-};
+app.on('myEvent', (payload) => { /* 处理事件 */ });
+app.off('myEvent', handler);
 ```
 
-### showOpenDialog
+---
+
+## `app.dialog.*` — 系统对话框（详细）
+
+### `app.dialog.open`
 
 ```javascript
-const filePath = await __BITFUN__.showOpenDialog({
+const filePath = await app.dialog.open({
   title: '选择文件',
   directory: false,           // true 选目录
   multiple: false,            // true 多选
@@ -130,10 +294,10 @@ const filePath = await __BITFUN__.showOpenDialog({
 });
 ```
 
-### showSaveDialog
+### `app.dialog.save`
 
 ```javascript
-const savePath = await __BITFUN__.showSaveDialog({
+const savePath = await app.dialog.save({
   title: '保存文件',
   defaultPath: 'output.png',
   filters: [
@@ -157,8 +321,16 @@ const savePath = await __BITFUN__.showSaveDialog({
     "net": {
       "allow": ["api.example.com", "cdn.jsdelivr.net"]
     },
-    "env": false,
-    "compute": true
+    "ai": {
+      "enabled": true,
+      "allowed_models": ["primary", "fast"],
+      "max_tokens_per_request": 8192,
+      "rate_limit_per_minute": 30
+    },
+    "node": {
+      "enabled": true,
+      "timeout_ms": 30000
+    }
   }
 }
 ```
@@ -166,7 +338,7 @@ const savePath = await __BITFUN__.showSaveDialog({
 路径变量:
 - `{appdata}` — `{user_data_dir}/miniapps/{app_id}/data/`，始终可读写
 - `{workspace}` — 当前打开的工作区路径
-- `{user-selected}` — 用户通过 showOpenDialog/showSaveDialog 选择的路径
+- `{user-selected}` — 用户通过 app.dialog.open/save 选择的路径
 - `{home}` — 用户主目录（高风险）
 
 ## CDN 依赖

--- a/src/apps/desktop/resources/worker_host.js
+++ b/src/apps/desktop/resources/worker_host.js
@@ -23,6 +23,20 @@ function rpcSend(obj) {
   process.stderr.write(JSON.stringify(obj) + '\n');
 }
 
+/**
+ * Emit a push event to the MiniApp iframe (no request id, no reply expected).
+ * The host process will forward this to the iframe via "miniapp://worker-event:{appId}".
+ *
+ * @param {string} event - Event name (e.g. 'progress', 'status')
+ * @param {any} data - Event payload
+ */
+function rpcEmit(event, data) {
+  process.stderr.write(JSON.stringify({ event, data }) + '\n');
+}
+
+// Make rpcEmit available globally so source/worker.js can use it.
+global.rpcEmit = rpcEmit;
+
 function isPathAllowed(targetPath, mode) {
   if (!policy.fs) return false;
   const resolved = path.resolve(targetPath);

--- a/src/apps/desktop/src/api/miniapp_api.rs
+++ b/src/apps/desktop/src/api/miniapp_api.rs
@@ -6,10 +6,17 @@ use bitfun_core::miniapp::{
     InstallResult as CoreInstallResult, MiniApp, MiniAppAiContext, MiniAppMeta, MiniAppPermissions,
     MiniAppSource,
 };
+use bitfun_core::service::config::types::GlobalConfig;
+use bitfun_core::util::types::Message;
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::path::PathBuf;
-use tauri::State;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tauri::{AppHandle, Emitter, State};
 
 // ============== Request/Response DTOs ==============
 
@@ -634,4 +641,496 @@ pub async fn miniapp_sync_from_fs(
     maybe_stop_worker(&state, &app).await;
     emit_miniapp_event("miniapp-updated", miniapp_payload(&app, "sync-from-fs")).await;
     Ok(app)
+}
+
+// ============== AI commands ==============
+
+/// Active AI stream cancellation flags: stream_id → cancel flag.
+static AI_STREAM_REGISTRY: OnceLock<Mutex<HashMap<String, Arc<AtomicBool>>>> = OnceLock::new();
+
+/// Per-app rate limiter state: app_id → (request_count, window_start_ms).
+static AI_RATE_LIMITER: OnceLock<Mutex<HashMap<String, (u32, u64)>>> = OnceLock::new();
+
+fn ai_stream_registry() -> &'static Mutex<HashMap<String, Arc<AtomicBool>>> {
+    AI_STREAM_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn ai_rate_limiter() -> &'static Mutex<HashMap<String, (u32, u64)>> {
+    AI_RATE_LIMITER.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+/// Check and increment the rate limiter for a given app. Returns Err if rate limit exceeded.
+fn check_rate_limit(app_id: &str, rate_limit_per_minute: u32) -> Result<(), String> {
+    if rate_limit_per_minute == 0 {
+        return Ok(());
+    }
+    let now = now_ms();
+    let window_ms: u64 = 60_000;
+    let mut map = ai_rate_limiter().lock().unwrap_or_else(|p| p.into_inner());
+    let entry = map.entry(app_id.to_string()).or_insert((0, now));
+    if now - entry.1 >= window_ms {
+        *entry = (1, now);
+    } else {
+        entry.0 += 1;
+        if entry.0 > rate_limit_per_minute {
+            return Err(format!(
+                "AI rate limit exceeded: max {} requests/minute",
+                rate_limit_per_minute
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate the requested model against the app's allowed_models list.
+/// Returns the resolved model id (may be "primary" / "fast") to pass to AIClientFactory.
+fn validate_model(model: Option<&str>, ai_perms: &bitfun_core::miniapp::AiPermissions) -> Result<String, String> {
+    let requested = model.unwrap_or("primary");
+    if let Some(ref allowed) = ai_perms.allowed_models {
+        if !allowed.is_empty() && !allowed.iter().any(|m| m == requested) {
+            return Err(format!(
+                "Model '{}' is not allowed by this MiniApp's AI permissions",
+                requested
+            ));
+        }
+    }
+    Ok(requested.to_string())
+}
+
+// ---- Request/Response DTOs for AI commands ----
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MiniAppAiChatMessage {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MiniAppAiCompleteRequest {
+    pub app_id: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub system_prompt: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+    #[serde(default)]
+    pub temperature: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MiniAppAiCompleteResponse {
+    pub text: String,
+    pub usage: Option<MiniAppAiUsage>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MiniAppAiUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MiniAppAiChatRequest {
+    pub app_id: String,
+    pub messages: Vec<MiniAppAiChatMessage>,
+    pub stream_id: String,
+    #[serde(default)]
+    pub system_prompt: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+    #[serde(default)]
+    pub temperature: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MiniAppAiChatStartedResponse {
+    pub stream_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MiniAppAiCancelRequest {
+    pub app_id: String,
+    pub stream_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MiniAppAiListModelsRequest {
+    pub app_id: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MiniAppAiModelInfo {
+    pub id: String,
+    pub name: String,
+    pub provider: String,
+    pub is_default: bool,
+}
+
+// ---- Payload structs for Tauri events ----
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct AiStreamChunkPayload {
+    pub app_id: String,
+    pub stream_id: String,
+    #[serde(rename = "type")]
+    pub payload_type: String,
+    pub data: serde_json::Value,
+}
+
+// ---- Helper: build Message list from request ----
+
+fn build_messages_for_ai(
+    system_prompt: Option<&str>,
+    chat_messages: &[MiniAppAiChatMessage],
+) -> Vec<Message> {
+    let mut msgs = Vec::new();
+    if let Some(sp) = system_prompt {
+        if !sp.is_empty() {
+            msgs.push(Message::system(sp.to_string()));
+        }
+    }
+    for m in chat_messages {
+        let role = m.role.to_lowercase();
+        if role == "assistant" {
+            msgs.push(Message::assistant(m.content.clone()));
+        } else {
+            // Treat any unrecognized role as "user" for safety
+            msgs.push(Message::user(m.content.clone()));
+        }
+    }
+    msgs
+}
+
+// ---- Commands ----
+
+/// Non-streaming AI completion — waits for the full response before returning.
+#[tauri::command]
+pub async fn miniapp_ai_complete(
+    state: State<'_, AppState>,
+    request: MiniAppAiCompleteRequest,
+) -> Result<MiniAppAiCompleteResponse, String> {
+    let app = state
+        .miniapp_manager
+        .get(&request.app_id)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let ai_perms = app
+        .permissions
+        .ai
+        .as_ref()
+        .ok_or("AI access is not enabled for this MiniApp")?;
+
+    if !ai_perms.enabled {
+        return Err("AI access is not enabled for this MiniApp".to_string());
+    }
+
+    let rate_limit = ai_perms.rate_limit_per_minute.unwrap_or(0);
+    check_rate_limit(&request.app_id, rate_limit)?;
+
+    let model_ref = validate_model(request.model.as_deref(), ai_perms)?;
+
+    let ai_client = state
+        .ai_client_factory
+        .get_client_resolved(&model_ref)
+        .await
+        .map_err(|e| format!("Failed to get AI client: {}", e))?;
+
+    let messages = build_messages_for_ai(
+        request.system_prompt.as_deref(),
+        &[MiniAppAiChatMessage {
+            role: "user".to_string(),
+            content: request.prompt.clone(),
+        }],
+    );
+
+    let stream_response = ai_client
+        .send_message_stream(messages, None)
+        .await
+        .map_err(|e| format!("AI request failed: {}", e))?;
+
+    let mut stream = stream_response.stream;
+    let mut full_text = String::new();
+    let mut usage: Option<MiniAppAiUsage> = None;
+
+    while let Some(chunk_result) = stream.next().await {
+        match chunk_result {
+            Ok(chunk) => {
+                if let Some(text) = chunk.text {
+                    full_text.push_str(&text);
+                }
+                if let Some(u) = chunk.usage {
+                    usage = Some(MiniAppAiUsage {
+                        prompt_tokens: u.prompt_token_count,
+                        completion_tokens: u.candidates_token_count,
+                        total_tokens: u.total_token_count,
+                    });
+                }
+            }
+            Err(e) => {
+                return Err(format!("AI stream error: {}", e));
+            }
+        }
+    }
+
+    Ok(MiniAppAiCompleteResponse {
+        text: full_text,
+        usage,
+    })
+}
+
+/// Streaming AI chat — returns immediately, emits chunks via "miniapp://ai-stream" events.
+#[tauri::command]
+pub async fn miniapp_ai_chat(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    request: MiniAppAiChatRequest,
+) -> Result<MiniAppAiChatStartedResponse, String> {
+    if request.stream_id.trim().is_empty() {
+        return Err("streamId is required".to_string());
+    }
+    if request.messages.is_empty() {
+        return Err("messages must not be empty".to_string());
+    }
+
+    let miniapp = state
+        .miniapp_manager
+        .get(&request.app_id)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let ai_perms = miniapp
+        .permissions
+        .ai
+        .as_ref()
+        .ok_or("AI access is not enabled for this MiniApp")?;
+
+    if !ai_perms.enabled {
+        return Err("AI access is not enabled for this MiniApp".to_string());
+    }
+
+    let rate_limit = ai_perms.rate_limit_per_minute.unwrap_or(0);
+    check_rate_limit(&request.app_id, rate_limit)?;
+
+    let model_ref = validate_model(request.model.as_deref(), ai_perms)?;
+
+    let ai_client = state
+        .ai_client_factory
+        .get_client_resolved(&model_ref)
+        .await
+        .map_err(|e| format!("Failed to get AI client: {}", e))?;
+
+    let messages = build_messages_for_ai(request.system_prompt.as_deref(), &request.messages);
+
+    let stream_response = ai_client
+        .send_message_stream(messages, None)
+        .await
+        .map_err(|e| format!("AI request failed: {}", e))?;
+
+    // Register a cancellation flag for this stream
+    let cancel_flag = Arc::new(AtomicBool::new(false));
+    {
+        let mut registry = ai_stream_registry().lock().unwrap_or_else(|p| p.into_inner());
+        registry.insert(request.stream_id.clone(), cancel_flag.clone());
+    }
+
+    let stream_id = request.stream_id.clone();
+    let app_id = request.app_id.clone();
+    let app_handle = app.clone();
+
+    tokio::spawn(async move {
+        let mut stream = stream_response.stream;
+        let mut full_text = String::new();
+        let mut last_usage: Option<MiniAppAiUsage> = None;
+
+        while let Some(chunk_result) = stream.next().await {
+            // Check cancellation
+            if cancel_flag.load(Ordering::SeqCst) {
+                break;
+            }
+
+            match chunk_result {
+                Ok(chunk) => {
+                    let has_text = chunk.text.as_ref().map(|t| !t.is_empty()).unwrap_or(false);
+                    let has_reasoning = chunk.reasoning_content.as_ref().map(|t| !t.is_empty()).unwrap_or(false);
+
+                    if has_text || has_reasoning {
+                        if let Some(ref t) = chunk.text {
+                            full_text.push_str(t);
+                        }
+                        let payload = AiStreamChunkPayload {
+                            app_id: app_id.clone(),
+                            stream_id: stream_id.clone(),
+                            payload_type: "chunk".to_string(),
+                            data: json!({
+                                "text": chunk.text,
+                                "reasoningContent": chunk.reasoning_content,
+                            }),
+                        };
+                        if let Err(e) = app_handle.emit("miniapp://ai-stream", &payload) {
+                            log::warn!("Failed to emit AI stream chunk: {}", e);
+                        }
+                    }
+
+                    if let Some(u) = chunk.usage {
+                        last_usage = Some(MiniAppAiUsage {
+                            prompt_tokens: u.prompt_token_count,
+                            completion_tokens: u.candidates_token_count,
+                            total_tokens: u.total_token_count,
+                        });
+                    }
+
+                    if let Some(ref reason) = chunk.finish_reason {
+                        if !reason.is_empty() && reason != "null" {
+                            break;
+                        }
+                    }
+                }
+                Err(e) => {
+                    let payload = AiStreamChunkPayload {
+                        app_id: app_id.clone(),
+                        stream_id: stream_id.clone(),
+                        payload_type: "error".to_string(),
+                        data: json!({ "message": e.to_string() }),
+                    };
+                    let _ = app_handle.emit("miniapp://ai-stream", &payload);
+                    // Clean up registry
+                    let mut registry = ai_stream_registry().lock().unwrap_or_else(|p| p.into_inner());
+                    registry.remove(&stream_id);
+                    return;
+                }
+            }
+        }
+
+        // Emit done
+        let usage_val = last_usage.map(|u| json!({
+            "promptTokens": u.prompt_tokens,
+            "completionTokens": u.completion_tokens,
+            "totalTokens": u.total_tokens,
+        }));
+        let done_payload = AiStreamChunkPayload {
+            app_id: app_id.clone(),
+            stream_id: stream_id.clone(),
+            payload_type: "done".to_string(),
+            data: json!({
+                "fullText": full_text,
+                "usage": usage_val,
+            }),
+        };
+        let _ = app_handle.emit("miniapp://ai-stream", &done_payload);
+
+        // Clean up registry
+        let mut registry = ai_stream_registry().lock().unwrap_or_else(|p| p.into_inner());
+        registry.remove(&stream_id);
+    });
+
+    Ok(MiniAppAiChatStartedResponse {
+        stream_id: request.stream_id,
+    })
+}
+
+/// Cancel an ongoing AI stream.
+#[tauri::command]
+pub async fn miniapp_ai_cancel(
+    _state: State<'_, AppState>,
+    request: MiniAppAiCancelRequest,
+) -> Result<(), String> {
+    let mut registry = ai_stream_registry().lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(flag) = registry.get(&request.stream_id) {
+        flag.store(true, Ordering::SeqCst);
+    }
+    // Remove from registry so it gets GC'd
+    registry.remove(&request.stream_id);
+    Ok(())
+}
+
+/// List AI models available to a MiniApp (no sensitive fields).
+#[tauri::command]
+pub async fn miniapp_ai_list_models(
+    state: State<'_, AppState>,
+    request: MiniAppAiListModelsRequest,
+) -> Result<Vec<MiniAppAiModelInfo>, String> {
+    let miniapp = state
+        .miniapp_manager
+        .get(&request.app_id)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let ai_perms = miniapp
+        .permissions
+        .ai
+        .as_ref()
+        .ok_or("AI access is not enabled for this MiniApp")?;
+
+    if !ai_perms.enabled {
+        return Err("AI access is not enabled for this MiniApp".to_string());
+    }
+
+    let global_config = state
+        .config_service
+        .get_config::<GlobalConfig>(None)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let primary_id = global_config
+        .ai
+        .resolve_model_selection("primary")
+        .unwrap_or_default();
+    let fast_id = global_config
+        .ai
+        .resolve_model_selection("fast")
+        .unwrap_or_default();
+
+    let allowed = ai_perms.allowed_models.as_deref().unwrap_or(&[]);
+
+    let models: Vec<MiniAppAiModelInfo> = global_config
+        .ai
+        .models
+        .iter()
+        .filter(|m| m.enabled)
+        .filter(|m| {
+            if allowed.is_empty() {
+                // No restriction — allow all
+                true
+            } else {
+                // Allow if model id/name matches any entry in allowed list,
+                // or if "primary"/"fast" is in allowed and this model is the resolved target.
+                allowed.iter().any(|a| match a.as_str() {
+                    "primary" => m.id == primary_id,
+                    "fast" => m.id == fast_id,
+                    other => m.id == other || m.name == other,
+                })
+            }
+        })
+        .map(|m| MiniAppAiModelInfo {
+            id: m.id.clone(),
+            name: m.name.clone(),
+            provider: m.provider.clone(),
+            is_default: m.id == primary_id,
+        })
+        .collect();
+
+    Ok(models)
 }

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -680,6 +680,10 @@ pub async fn run() {
             api::miniapp_api::miniapp_dialog_message,
             api::miniapp_api::miniapp_import_from_path,
             api::miniapp_api::miniapp_sync_from_fs,
+            api::miniapp_api::miniapp_ai_complete,
+            api::miniapp_api::miniapp_ai_chat,
+            api::miniapp_api::miniapp_ai_cancel,
+            api::miniapp_api::miniapp_ai_list_models,
             // Browser API
             api::browser_api::browser_webview_eval,
             api::browser_api::browser_get_url,

--- a/src/crates/core/src/agentic/tools/implementations/miniapp_init_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/miniapp_init_tool.rs
@@ -157,6 +157,7 @@ Returns app_id and the app root directory. Use the root directory and file names
                 allow: Some(vec!["*".to_string()]),
             }),
             node: None,
+            ai: None,
         };
 
         let app = manager

--- a/src/crates/core/src/miniapp/bridge_builder.rs
+++ b/src/crates/core/src/miniapp/bridge_builder.rs
@@ -4,7 +4,8 @@ use crate::miniapp::types::{EsmDep, MiniAppPermissions};
 use serde_json;
 
 /// Build the Runtime Adapter script (JS) to inject into the iframe.
-/// Exposes window.app with call(), fs.*, shell.*, net.*, os.*, storage.*, dialog.*, lifecycle, events.
+/// Exposes window.app with call(), fs.*, shell.*, net.*, os.*, storage.*, dialog.*,
+/// ai.*, clipboard.*, lifecycle, events.
 pub fn build_bridge_script(
     app_id: &str,
     app_data_dir: &str,
@@ -80,6 +81,40 @@ pub fn build_bridge_script(
       message: (opts) => _rpc('dialog.message', opts || {{}}),
     }},
 
+    // AI namespace — proxies to host application AI client (no API key exposure).
+    _aiStreams: {{}},
+    ai: {{
+      complete: (prompt, opts) => _rpc('ai.complete', {{ prompt, ...(opts || {{}}) }}),
+      chat: (messages, opts) => {{
+        const streamId = 'ai-stream-' + Math.random().toString(36).slice(2) + '-' + Date.now();
+        const handlers = {{
+          onChunk: opts && opts.onChunk,
+          onDone:  opts && opts.onDone,
+          onError: opts && opts.onError,
+        }};
+        app._aiStreams[streamId] = handlers;
+        const rpcOpts = {{}};
+        if (opts) {{
+          if (opts.systemPrompt !== undefined) rpcOpts.systemPrompt = opts.systemPrompt;
+          if (opts.model !== undefined) rpcOpts.model = opts.model;
+          if (opts.maxTokens !== undefined) rpcOpts.maxTokens = opts.maxTokens;
+          if (opts.temperature !== undefined) rpcOpts.temperature = opts.temperature;
+        }}
+        return _rpc('ai.chat', {{ messages, streamId, ...rpcOpts }}).then((result) => ({{
+          streamId: result && result.streamId ? result.streamId : streamId,
+          cancel: () => _rpc('ai.cancel', {{ streamId }}),
+        }}));
+      }},
+      cancel:    (streamId) => _rpc('ai.cancel', {{ streamId }}),
+      getModels: () => _rpc('ai.getModels', {{}}),
+    }},
+
+    // Clipboard namespace — proxies to host navigator.clipboard (bypasses sandbox restriction).
+    clipboard: {{
+      writeText: (text) => _rpc('clipboard.writeText', {{ text }}),
+      readText:  () => _rpc('clipboard.readText', {{}}),
+    }},
+
     _lifecycleHandlers: {{ activate: [], deactivate: [], themeChange: [] }},
     onActivate:   (fn) => app._lifecycleHandlers.activate.push(fn),
     onDeactivate: (fn) => app._lifecycleHandlers.deactivate.push(fn),
@@ -105,6 +140,29 @@ pub fn build_bridge_script(
         }}
         app._lifecycleHandlers.themeChange.forEach(f => f(payload));
         (app._eventHandlers[event] || []).forEach(f => f(payload));
+      }} else if (event === 'ai:stream') {{
+        // Route AI stream chunks to the registered callbacks
+        if (payload && payload.streamId) {{
+          const h = app._aiStreams[payload.streamId];
+          if (h) {{
+            if (payload.type === 'chunk' && h.onChunk) h.onChunk(payload.data || {{}});
+            if (payload.type === 'done') {{
+              if (h.onDone) h.onDone(payload.data || {{}});
+              delete app._aiStreams[payload.streamId];
+            }}
+            if (payload.type === 'error') {{
+              if (h.onError) h.onError(payload.data || {{}});
+              delete app._aiStreams[payload.streamId];
+            }}
+          }}
+        }}
+      }} else if (event === 'worker:event') {{
+        // Forward Worker push events to registered app.on('worker:*', ...) handlers
+        if (payload && payload.event) {{
+          const evtKey = 'worker:' + payload.event;
+          (app._eventHandlers[evtKey] || []).forEach(f => f(payload.data));
+          (app._eventHandlers['worker:*'] || []).forEach(f => f(payload.event, payload.data));
+        }}
       }} else {{
         (app._eventHandlers[event] || []).forEach(f => f(payload));
       }}

--- a/src/crates/core/src/miniapp/js_worker.rs
+++ b/src/crates/core/src/miniapp/js_worker.rs
@@ -1,5 +1,6 @@
 //! JS Worker — single child process (Bun/Node) with stdin/stderr JSON-RPC.
 
+use crate::infrastructure::events::{emit_global_event, BackendEvent};
 use crate::miniapp::runtime_detect::DetectedRuntime;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -25,11 +26,13 @@ pub struct JsWorker {
 
 impl JsWorker {
     /// Spawn Worker process: `runtime_path worker_host_path '<policy_json>'` with cwd = app_dir.
+    /// The `app_id` is used as the source identifier when emitting worker events.
     pub async fn spawn(
         runtime: &DetectedRuntime,
         worker_host_path: &Path,
         app_dir: &Path,
         policy_json: &str,
+        app_id: String,
     ) -> Result<Self, String> {
         let exe = runtime.path.to_string_lossy();
         let host = worker_host_path.to_string_lossy();
@@ -78,6 +81,8 @@ impl JsWorker {
                     Ok(v) => v,
                     Err(_) => continue,
                 };
+
+                // Lines with an `id` are RPC responses — route to the pending map.
                 let id = msg.get("id").and_then(Value::as_str).map(String::from);
                 if let Some(id) = id {
                     let result = if let Some(err) = msg.get("error") {
@@ -95,6 +100,24 @@ impl JsWorker {
                     if let Some(tx) = guard.remove(&id) {
                         let _ = tx.send(result);
                     }
+                    continue;
+                }
+
+                // Lines with an `event` field (no `id`) are push events from the Worker.
+                // Forward them as Tauri-level events so the Bridge can relay to the iframe.
+                if let Some(event_name) = msg.get("event").and_then(Value::as_str) {
+                    let data = msg.get("data").cloned().unwrap_or(Value::Null);
+                    let payload = serde_json::json!({
+                        "appId": app_id,
+                        "event": event_name,
+                        "data": data,
+                    });
+                    let event_full_name = format!("miniapp://worker-event:{}", app_id);
+                    let _ = emit_global_event(BackendEvent::Custom {
+                        event_name: event_full_name,
+                        payload,
+                    })
+                    .await;
                 }
             }
         });

--- a/src/crates/core/src/miniapp/js_worker_pool.rs
+++ b/src/crates/core/src/miniapp/js_worker_pool.rs
@@ -122,9 +122,15 @@ impl JsWorkerPool {
             )));
         }
 
-        let worker = JsWorker::spawn(&self.runtime, &self.worker_host_path, &app_dir, policy_json)
-            .await
-            .map_err(BitFunError::validation)?;
+        let worker = JsWorker::spawn(
+            &self.runtime,
+            &self.worker_host_path,
+            &app_dir,
+            policy_json,
+            app_id.to_string(),
+        )
+        .await
+        .map_err(BitFunError::validation)?;
 
         let _timeout_ms = node_perms.and_then(|n| n.timeout_ms).unwrap_or(30_000);
         let worker = Arc::new(Mutex::new(worker));

--- a/src/crates/core/src/miniapp/mod.rs
+++ b/src/crates/core/src/miniapp/mod.rs
@@ -20,6 +20,7 @@ pub use permission_policy::resolve_policy;
 pub use runtime_detect::{DetectedRuntime, RuntimeKind};
 pub use storage::MiniAppStorage;
 pub use types::{
-    EsmDep, FsPermissions, MiniApp, MiniAppAiContext, MiniAppMeta, MiniAppPermissions,
-    MiniAppSource, NetPermissions, NodePermissions, NpmDep, PathScope, ShellPermissions,
+    AiPermissions, EsmDep, FsPermissions, MiniApp, MiniAppAiContext, MiniAppMeta,
+    MiniAppPermissions, MiniAppSource, NetPermissions, NodePermissions, NpmDep, PathScope,
+    ShellPermissions,
 };

--- a/src/crates/core/src/miniapp/types.rs
+++ b/src/crates/core/src/miniapp/types.rs
@@ -47,6 +47,8 @@ pub struct MiniAppPermissions {
     pub net: Option<NetPermissions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node: Option<NodePermissions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ai: Option<AiPermissions>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -85,6 +87,24 @@ pub struct NodePermissions {
 
 fn default_node_enabled() -> bool {
     true
+}
+
+/// AI permissions — controls access to the host application's AI client.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AiPermissions {
+    /// Whether AI access is enabled for this MiniApp.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Allowed model references (e.g. ["primary", "fast"] or specific model ids).
+    /// Empty or absent means only "primary" is allowed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_models: Option<Vec<String>>,
+    /// Maximum output tokens per single request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens_per_request: Option<u32>,
+    /// Maximum number of AI requests per minute (per app).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit_per_minute: Option<u32>,
 }
 
 /// AI context for iteration (stored in meta, not in compiled HTML).

--- a/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppBridge.ts
+++ b/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppBridge.ts
@@ -1,6 +1,7 @@
 /**
  * useMiniAppBridge — handles postMessage JSON-RPC from the MiniApp iframe:
- * worker.call → JS Worker, dialog.open/save/message → Tauri dialog.
+ * worker.call → JS Worker, dialog.open/save/message → Tauri dialog,
+ * ai.* → Host AI client, clipboard.* → Host navigator.clipboard.
  * Also handles bitfun/request-theme and pushes theme changes to the iframe.
  */
 import { useLayoutEffect, useRef, useEffect, RefObject } from 'react';
@@ -10,12 +11,20 @@ import type { MiniApp } from '@/infrastructure/api/service-api/MiniAppAPI';
 import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
 import { useTheme } from '@/infrastructure/theme/hooks/useTheme';
 import { buildMiniAppThemeVars } from '../utils/buildMiniAppThemeVars';
+import { api } from '@/infrastructure/api/service-api/ApiClient';
 
 interface JSONRPC {
   jsonrpc?: string;
   id: number | string;
   method: string;
   params?: Record<string, unknown>;
+}
+
+interface AiStreamPayload {
+  appId: string;
+  streamId: string;
+  type: 'chunk' | 'done' | 'error';
+  data: Record<string, unknown>;
 }
 
 export function useMiniAppBridge(
@@ -84,6 +93,56 @@ export function useMiniAppBridge(
           reply(await dialogMessage(params as unknown as Parameters<typeof dialogMessage>[0]));
           return;
         }
+
+        // ── AI commands ──────────────────────────────────────────────────────
+        if (method === 'ai.complete') {
+          const result = await miniAppAPI.aiComplete(appId, (params.prompt as string) ?? '', {
+            systemPrompt: params.systemPrompt as string | undefined,
+            model: params.model as string | undefined,
+            maxTokens: params.maxTokens as number | undefined,
+            temperature: params.temperature as number | undefined,
+          });
+          reply(result);
+          return;
+        }
+        if (method === 'ai.chat') {
+          const result = await miniAppAPI.aiChat(
+            appId,
+            (params.messages as { role: 'user' | 'assistant'; content: string }[]) ?? [],
+            (params.streamId as string) ?? '',
+            {
+              systemPrompt: params.systemPrompt as string | undefined,
+              model: params.model as string | undefined,
+              maxTokens: params.maxTokens as number | undefined,
+              temperature: params.temperature as number | undefined,
+            },
+          );
+          reply(result);
+          return;
+        }
+        if (method === 'ai.cancel') {
+          await miniAppAPI.aiCancel(appId, (params.streamId as string) ?? '');
+          reply(null);
+          return;
+        }
+        if (method === 'ai.getModels') {
+          const models = await miniAppAPI.aiListModels(appId);
+          reply(models);
+          return;
+        }
+
+        // ── Clipboard commands ───────────────────────────────────────────────
+        if (method === 'clipboard.writeText') {
+          await navigator.clipboard.writeText((params.text as string) ?? '');
+          reply(null);
+          return;
+        }
+        if (method === 'clipboard.readText') {
+          const text = await navigator.clipboard.readText();
+          reply(text);
+          return;
+        }
+
         replyError(`Unknown method: ${method}`);
       } catch (error) {
         replyError(typeof error === 'string' ? error : String(error));
@@ -103,4 +162,56 @@ export function useMiniAppBridge(
       '*',
     );
   }, [currentTheme, iframeRef]);
+
+  // Listen for AI stream events from Tauri and forward them to the iframe.
+  useEffect(() => {
+    const currentAppId = app.id;
+    const unlisten = api.listen<AiStreamPayload>('miniapp://ai-stream', (payload) => {
+      if (!iframeRef.current?.contentWindow) return;
+      if (payload.appId !== currentAppId) return;
+      iframeRef.current.contentWindow.postMessage(
+        {
+          type: 'bitfun:event',
+          event: 'ai:stream',
+          payload: {
+            streamId: payload.streamId,
+            type: payload.type,
+            data: payload.data,
+          },
+        },
+        '*',
+      );
+    });
+
+    return () => {
+      unlisten();
+    };
+  }, [app.id, iframeRef]);
+
+  // Listen for Worker push events and forward them to the iframe.
+  useEffect(() => {
+    const currentAppId = app.id;
+    const eventName = `miniapp://worker-event:${currentAppId}`;
+    const unlisten = api.listen<{ appId: string; event: string; data: unknown }>(
+      eventName,
+      (payload) => {
+        if (!iframeRef.current?.contentWindow) return;
+        iframeRef.current.contentWindow.postMessage(
+          {
+            type: 'bitfun:event',
+            event: 'worker:event',
+            payload: {
+              event: payload.event,
+              data: payload.data,
+            },
+          },
+          '*',
+        );
+      },
+    );
+
+    return () => {
+      unlisten();
+    };
+  }, [app.id, iframeRef]);
 }

--- a/src/web-ui/src/infrastructure/api/service-api/MiniAppAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/MiniAppAPI.ts
@@ -28,6 +28,53 @@ export interface MiniAppPermissions {
   shell?: { allow?: string[] };
   net?: { allow?: string[] };
   node?: { enabled?: boolean; max_memory_mb?: number; timeout_ms?: number };
+  ai?: {
+    enabled?: boolean;
+    allowed_models?: string[];
+    max_tokens_per_request?: number;
+    rate_limit_per_minute?: number;
+  };
+}
+
+// ─── AI Types ─────────────────────────────────────────────────────────────────
+
+export interface AiCompleteOptions {
+  systemPrompt?: string;
+  model?: string;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export interface AiCompleteResult {
+  text: string;
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+}
+
+export interface AiChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface AiChatOptions {
+  systemPrompt?: string;
+  model?: string;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export interface AiChatStartedResult {
+  streamId: string;
+}
+
+export interface AiModelInfo {
+  id: string;
+  name: string;
+  provider: string;
+  isDefault: boolean;
 }
 
 export interface MiniAppRuntimeState {
@@ -236,6 +283,64 @@ export class MiniAppAPI {
       });
     } catch (error) {
       throw createTauriCommandError('miniapp_sync_from_fs', error, { appId, workspacePath });
+    }
+  }
+
+  // ─── AI commands ────────────────────────────────────────────────────────────
+
+  async aiComplete(appId: string, prompt: string, options?: AiCompleteOptions): Promise<AiCompleteResult> {
+    try {
+      return await api.invoke('miniapp_ai_complete', {
+        request: {
+          appId,
+          prompt,
+          systemPrompt: options?.systemPrompt,
+          model: options?.model,
+          maxTokens: options?.maxTokens,
+          temperature: options?.temperature,
+        }
+      });
+    } catch (error) {
+      throw createTauriCommandError('miniapp_ai_complete', error, { appId });
+    }
+  }
+
+  async aiChat(
+    appId: string,
+    messages: AiChatMessage[],
+    streamId: string,
+    options?: AiChatOptions,
+  ): Promise<AiChatStartedResult> {
+    try {
+      return await api.invoke('miniapp_ai_chat', {
+        request: {
+          appId,
+          messages,
+          streamId,
+          systemPrompt: options?.systemPrompt,
+          model: options?.model,
+          maxTokens: options?.maxTokens,
+          temperature: options?.temperature,
+        }
+      });
+    } catch (error) {
+      throw createTauriCommandError('miniapp_ai_chat', error, { appId, streamId });
+    }
+  }
+
+  async aiCancel(appId: string, streamId: string): Promise<void> {
+    try {
+      await api.invoke('miniapp_ai_cancel', { request: { appId, streamId } });
+    } catch (error) {
+      throw createTauriCommandError('miniapp_ai_cancel', error, { appId, streamId });
+    }
+  }
+
+  async aiListModels(appId: string): Promise<AiModelInfo[]> {
+    try {
+      return await api.invoke('miniapp_ai_list_models', { request: { appId } });
+    } catch (error) {
+      throw createTauriCommandError('miniapp_ai_list_models', error, { appId });
     }
   }
 }


### PR DESCRIPTION
## Summary
### MiniApp
- Extend desktop and web bridge APIs, worker pool, and bridge builder behavior.
- Add MiniApp/Demo/icon-design-system sample and expand miniapp-dev API reference.

### Verification
- cargo check (desktop) passed locally for the Rust changes.

---
Opened via gh pr create targeting main.