### PR TITLE
feat(web-ui): model selector token usage and chat input shortcuts

### DIFF
--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -162,6 +162,22 @@ function App() {
     }
   }, [aiInitialized, aiInitializing, aiError, currentConfig]);
 
+  // Block browser-native Ctrl+F (find bar) and Ctrl+R (hard reload).
+  // On macOS the equivalent modifiers are Cmd+F / Cmd+R.
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const primary = e.ctrlKey || e.metaKey;
+      if (!primary) return;
+      const key = e.key.toLowerCase();
+      if (key === 'f' || key === 'r') {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true });
+  }, []);
+
   // Escape closes preview overlay (registered via ShortcutManager)
   useShortcut(
     'app.closePreview',

--- a/src/web-ui/src/app/scenes/session/ChatPane.tsx
+++ b/src/web-ui/src/app/scenes/session/ChatPane.tsx
@@ -69,6 +69,7 @@ const ChatPaneInner: React.FC<ChatPaneProps> = ({
   return (
     <div
       className="bitfun-chat-pane__content"
+      data-shortcut-scope="chat"
       data-fullscreen={isFullscreen}
     >
       <FlowChatContainer

--- a/src/web-ui/src/app/scenes/settings/SettingsNav.scss
+++ b/src/web-ui/src/app/scenes/settings/SettingsNav.scss
@@ -137,7 +137,7 @@
 
   &__search-result-desc {
     width: 100%;
-    font-size: 11px;
+    font-size: var(--font-size-2xs);
     line-height: 1.35;
     color: var(--color-text-muted);
     font-weight: 400;
@@ -190,7 +190,7 @@
   }
 
   &__category-label {
-    font-size: 10px;
+    font-size: var(--font-size-2xs);
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -219,7 +219,7 @@
   &__item-beta {
     flex-shrink: 0;
     margin-left: $size-gap-2;
-    font-size: 10px;
+    font-size: var(--font-size-xxs);
     font-weight: 600;
     line-height: 1;
     letter-spacing: 0.02em;

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -17,7 +17,6 @@ import {
   useSessionStateMachineActions,
 } from '../hooks/useSessionStateMachine';
 import { SessionExecutionEvent } from '../state-machine/types';
-import TokenUsageIndicator from './TokenUsageIndicator';
 import { ModelSelector } from './ModelSelector';
 import { FlowChatStore } from '../store/FlowChatStore';
 import type { FlowChatState } from '../types/flow-chat';
@@ -2031,8 +2030,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       focusRichTextInputSoon();
     };
 
-    document.addEventListener('keydown', handleGlobalKeyDown);
-    return () => document.removeEventListener('keydown', handleGlobalKeyDown);
+    // Capture phase so activation runs before nested handlers; Space must dispatch ACTIVATE, not only focus().
+    document.addEventListener('keydown', handleGlobalKeyDown, true);
+    return () => document.removeEventListener('keydown', handleGlobalKeyDown, true);
   }, [derivedState?.canCancel, focusRichTextInputSoon, inputState.isActive, transition]);
   
   const containerRef = useRef<HTMLDivElement>(null);
@@ -2651,14 +2651,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 <ModelSelector
                   currentMode={modeState.current}
                   sessionId={effectiveTargetSessionId || undefined}
+                  currentTokens={tokenUsage.current}
+                  maxTokens={tokenUsage.max}
                 />
-                
-                {tokenUsage.current > 0 && (
-                  <TokenUsageIndicator
-                    currentTokens={tokenUsage.current}
-                    maxTokens={tokenUsage.max}
-                  />
-                )}
               </div>
               <div className="bitfun-chat-input__actions-right">
                 {isCollapsedProcessing && !petReplacesStopChrome && (

--- a/src/web-ui/src/flow_chat/components/ModelSelector.scss
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.scss
@@ -106,6 +106,27 @@
     text-transform: uppercase;
   }
   
+  &__ctx-usage {
+    font-size: 9px;
+    font-weight: 400;
+    color: var(--color-text-muted);
+    opacity: 0.55;
+    letter-spacing: 0.2px;
+    transition: color 0.3s ease, opacity 0.3s ease;
+    flex-shrink: 0;
+
+    &--warning {
+      color: rgba(251, 146, 60, 0.9);
+      opacity: 0.9;
+    }
+
+    &--critical {
+      color: rgba(248, 113, 113, 0.95);
+      opacity: 1;
+      animation: bitfun-ctx-critical-pulse 2s ease-in-out infinite;
+    }
+  }
+
   &__chevron {
     color: var(--color-text-tertiary);
     flex-shrink: 0;
@@ -322,4 +343,9 @@
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+@keyframes bitfun-ctx-critical-pulse {
+  0%, 100% { opacity: 0.8; }
+  50%       { opacity: 1; }
 }

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -318,10 +318,12 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
 
   const currentModelId = getCurrentModelId();
 
-  const providerText = currentModel?.providerName ?? t('modelSelector.autoModelDesc');
-  const tooltipContent = currentTokens > 0 && maxTokens > 0
-    ? `${providerText} · ${formatTokenCount(currentTokens)}/${formatTokenCount(maxTokens)} (${tokenPercentage}%)`
-    : providerText;
+  const fallbackTooltip = t('modelSelector.autoModelDesc');
+  const baseTooltip = getModelTooltipText(currentModel, fallbackTooltip);
+  const tooltipContent =
+    currentTokens > 0 && maxTokens > 0
+      ? `${baseTooltip} · ${formatTokenCount(currentTokens)}/${formatTokenCount(maxTokens)} (${tokenPercentage}%)`
+      : baseTooltip;
 
   return (
     <div

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -29,6 +29,10 @@ interface ModelSelectorProps {
   className?: string;
   /** Current session ID (used to update session mode config). */
   sessionId?: string;
+  /** Current token count. */
+  currentTokens?: number;
+  /** Max token capacity. */
+  maxTokens?: number;
 }
 
 interface ModelInfo {
@@ -114,6 +118,8 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   currentMode,
   className = '',
   sessionId,
+  currentTokens = 0,
+  maxTokens = 0,
 }) => {
   const { t } = useTranslation('flow-chat');
   const [allModels, setAllModels] = useState<AIModelConfig[]>([]);
@@ -292,18 +298,37 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     }
   }, [currentMode, loading, sessionId]);
   
+  const tokenPercentage = useMemo(() => {
+    if (!maxTokens || maxTokens <= 0 || !currentTokens) return 0;
+    return Math.min(Math.round((currentTokens / maxTokens) * 100), 100);
+  }, [currentTokens, maxTokens]);
+
+  const tokenStatusClass = useMemo(() => {
+    if (tokenPercentage >= 90) return 'critical';
+    if (tokenPercentage >= 70) return 'warning';
+    return '';
+  }, [tokenPercentage]);
+
+  const formatTokenCount = (n: number) =>
+    n >= 1000 ? `${Math.round(n / 1000)}K` : `${n}`;
+
   if (availableModels.length === 0) {
     return null;
   }
 
   const currentModelId = getCurrentModelId();
 
+  const providerText = currentModel?.providerName ?? t('modelSelector.autoModelDesc');
+  const tooltipContent = currentTokens > 0 && maxTokens > 0
+    ? `${providerText} · ${formatTokenCount(currentTokens)}/${formatTokenCount(maxTokens)} (${tokenPercentage}%)`
+    : providerText;
+
   return (
     <div
       ref={dropdownRef}
       className={`bitfun-model-selector ${className}`}
     >
-      <Tooltip content={getModelTooltipText(currentModel, t('modelSelector.autoModelDesc'))}>
+      <Tooltip content={tooltipContent}>
         <button
           className={`bitfun-model-selector__trigger ${dropdownOpen ? 'bitfun-model-selector__trigger--open' : ''}`}
           onClick={() => setDropdownOpen(!dropdownOpen)}
@@ -319,6 +344,11 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           {currentModel?.reasoningEffort && (
             <span className="bitfun-model-selector__effort-badge">
               {currentModel.reasoningEffort}
+            </span>
+          )}
+          {tokenPercentage > 0 && (
+            <span className={`bitfun-model-selector__ctx-usage${tokenStatusClass ? ` bitfun-model-selector__ctx-usage--${tokenStatusClass}` : ''}`}>
+              · {tokenPercentage}%
             </span>
           )}
           <ChevronDown size={10} className="bitfun-model-selector__chevron" />

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -227,19 +227,6 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   );
 
   useShortcut(
-    'chat.activateInput',
-    { key: ' ', scope: 'chat' },
-    () => {
-      const root = chatScopeRef.current;
-      const el = root?.querySelector(
-        '.bitfun-chat-input textarea, .bitfun-chat-input [contenteditable="true"]'
-      ) as HTMLElement | null;
-      el?.focus();
-    },
-    { priority: 10, description: 'keyboard.shortcuts.chat.activateInput' }
-  );
-
-  useShortcut(
     'chat.newSession',
     { key: 'N', ctrl: true, scope: 'chat' },
     () => {

--- a/src/web-ui/src/shared/constants/shortcuts.ts
+++ b/src/web-ui/src/shared/constants/shortcuts.ts
@@ -18,7 +18,6 @@ export interface ShortcutDef {
  */
 export const NON_USER_CUSTOMIZABLE_SHORTCUT_IDS = new Set<string>([
   'scene.openSession',
-  'chat.activateInput',
 ]);
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
@@ -31,11 +30,6 @@ function mod(
   extras: Omit<ShortcutConfig, 'key' | 'ctrl' | 'meta'> = {}
 ): ShortcutConfig {
   return isMac ? { key, meta: true, ...extras } : { key, ctrl: true, ...extras };
-}
-
-/** Shortcut with no primary modifier (plain key, scope-aware). */
-function plain(key: string, scope: ShortcutScope, allowInInput = false): ShortcutConfig {
-  return { key, scope, allowInInput };
 }
 
 // ─── Global shortcuts (scope: 'app') ──────────────────────────────────────
@@ -211,11 +205,6 @@ export const CHAT_SHORTCUTS: ShortcutDef[] = [
     id: 'chat.stopGeneration',
     config: { key: 'Escape', scope: 'chat', allowInInput: true },
     descriptionKey: 'keyboard.shortcuts.chat.stopGeneration',
-  },
-  {
-    id: 'chat.activateInput',
-    config: plain(' ', 'chat', false),
-    descriptionKey: 'keyboard.shortcuts.chat.activateInput',
   },
   {
     id: 'chat.newSession',


### PR DESCRIPTION
## Summary

- Model selector: context token usage % on trigger; tooltip merges provider and token counts; warning/critical styles.
- Chat input: global keydown uses capture phase; token row passes counts into ModelSelector (removes separate TokenUsageIndicator).
- Shortcuts: remove duplicate Space activateInput from container and registry; ChatPane sets data-shortcut-scope for chat.
- App: block browser Ctrl/Cmd+F and Ctrl/Cmd+R in the web shell.
- Settings: font sizes use theme tokens in SettingsNav.

## Testing

- Manual smoke recommended for model selector, chat focus, and shortcuts.
