### PR TITLE
fix(web-ui): remove redundant platform note row in Computer Use settings

### DIFF
--- a/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
@@ -520,11 +520,6 @@ const SessionConfig: React.FC = () => {
                   />
                 </div>
               </ConfigPageRow>
-              {computerUseNote ? (
-                <ConfigPageRow label={t('computerUse.platformNote')} align="start">
-                  <span className="bitfun-func-agent-config__hint">{computerUseNote}</span>
-                </ConfigPageRow>
-              ) : null}
               <ConfigPageRow
                 label={t('computerUse.accessibility')}
                 description={t('computerUse.accessibilityDesc')}

--- a/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
@@ -62,7 +62,6 @@ const SessionConfig: React.FC = () => {
   const [computerUseEnabled, setComputerUseEnabled] = useState(false);
   const [computerUseAccess, setComputerUseAccess] = useState(false);
   const [computerUseScreen, setComputerUseScreen] = useState(false);
-  const [computerUseNote, setComputerUseNote] = useState<string | null>(null);
   const [computerUseBusy, setComputerUseBusy] = useState(false);
 
   // ── Debug mode config state ──────────────────────────────────────────────
@@ -80,7 +79,6 @@ const SessionConfig: React.FC = () => {
       setComputerUseEnabled(s.computerUseEnabled);
       setComputerUseAccess(s.accessibilityGranted);
       setComputerUseScreen(s.screenCaptureGranted);
-      setComputerUseNote(s.platformNote ?? null);
       return true;
     } catch (error) {
       log.error('computer_use_get_status failed', error);


### PR DESCRIPTION
## Summary

- Remove the `platformNote` row in the Computer Use settings section that displayed a "说明" label with development build instructions
- This row was unnecessary UI noise and has been removed entirely

## Test plan

- [x] Open Settings → Session Config → Computer Use section
- [x] Verify the "说明" / platform note row no longer appears
