### PR TITLE
feat(agents): add built-in DeepResearch subagent

### DIFF
--- a/src/crates/core/src/agentic/agents/deep_research_agent.rs
+++ b/src/crates/core/src/agentic/agents/deep_research_agent.rs
@@ -1,0 +1,91 @@
+use super::Agent;
+use async_trait::async_trait;
+
+pub struct DeepResearchAgent {
+    default_tools: Vec<String>,
+}
+
+impl Default for DeepResearchAgent {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeepResearchAgent {
+    pub fn new() -> Self {
+        Self {
+            default_tools: vec![
+                // Web research
+                "WebSearch".to_string(),
+                "WebFetch".to_string(),
+                // Codebase / file exploration
+                "Read".to_string(),
+                "Grep".to_string(),
+                "Glob".to_string(),
+                "LS".to_string(),
+                // File output (save report)
+                "Write".to_string(),
+                // Terminal — run commands to gather data (e.g. git log, curl, jq)
+                "Bash".to_string(),
+                "TerminalControl".to_string(),
+                // Task tracking
+                "TodoWrite".to_string(),
+            ],
+        }
+    }
+}
+
+#[async_trait]
+impl Agent for DeepResearchAgent {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn id(&self) -> &str {
+        "DeepResearch"
+    }
+
+    fn name(&self) -> &str {
+        "DeepResearch"
+    }
+
+    fn description(&self) -> &str {
+        r#"Produces a comprehensive deep-research report on any subject using the Longitudinal + Cross-sectional Analysis method. Covers full historical evolution (origins, milestones, decision logic) and competitive landscape (peer comparison, ecosystem position, trend judgment), concluding with an integrated synthesis. Best for open-ended research questions about products, companies, technologies, or individuals where depth and narrative quality matter."#
+    }
+
+    fn prompt_template_name(&self, _model_name: Option<&str>) -> &str {
+        "deep_research_agent"
+    }
+
+    fn default_tools(&self) -> Vec<String> {
+        self.default_tools.clone()
+    }
+
+    fn is_readonly(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Agent, DeepResearchAgent};
+
+    #[test]
+    fn has_expected_default_tools() {
+        let agent = DeepResearchAgent::new();
+        let tools = agent.default_tools();
+        assert!(tools.contains(&"WebSearch".to_string()));
+        assert!(tools.contains(&"WebFetch".to_string()));
+        assert!(tools.contains(&"Write".to_string()));
+        assert!(tools.contains(&"Bash".to_string()));
+        assert!(tools.contains(&"TerminalControl".to_string()));
+        assert!(!tools.contains(&"Task".to_string()), "Task tool must not be included to prevent recursive subagent calls");
+    }
+
+    #[test]
+    fn always_uses_default_prompt_template() {
+        let agent = DeepResearchAgent::new();
+        assert_eq!(agent.prompt_template_name(Some("gpt-5.1")), "deep_research_agent");
+        assert_eq!(agent.prompt_template_name(None), "deep_research_agent");
+    }
+}

--- a/src/crates/core/src/agentic/agents/mod.rs
+++ b/src/crates/core/src/agentic/agents/mod.rs
@@ -12,6 +12,7 @@ mod cowork_mode;
 mod debug_mode;
 mod plan_mode;
 // Built-in subagents
+mod deep_research_agent;
 mod explore_agent;
 mod file_finder_agent;
 // Hidden agents
@@ -27,6 +28,7 @@ pub use code_review_agent::CodeReviewAgent;
 pub use cowork_mode::CoworkMode;
 pub use custom_subagents::{CustomSubagent, CustomSubagentKind};
 pub use debug_mode::DebugMode;
+pub use deep_research_agent::DeepResearchAgent;
 pub use explore_agent::ExploreAgent;
 pub use file_finder_agent::FileFinderAgent;
 pub use generate_doc_agent::GenerateDocAgent;

--- a/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
@@ -1,0 +1,157 @@
+You are a senior research analyst. Your job is to produce a deep-research report that reads like investigative journalism — specific, sourced, opinionated, and grounded in evidence. Vague summaries, hollow adjectives, and unsupported claims are unacceptable.
+
+{ENV_INFO}
+
+**Subject of Research** = the topic provided by the user in their message.
+
+**Current date**: provided in the environment info above. Use it only for the output file name. Do **not** inject the current year into search queries — let search results establish the actual timeline.
+
+---
+
+## Research Standards (Non-Negotiable)
+
+Every factual claim must meet at least one of these standards:
+
+1. **Sourced**: cite the URL, publication, or document where you found it.
+2. **Dated**: attach a date or version number to the claim (e.g. "as of March 2024", "v2.3 release notes").
+3. **Attributed**: name the person, company, or official document that made the statement.
+
+If you cannot meet any of these, label the claim explicitly as **(unverified)** or **(inferred)**. Never present speculation as fact.
+
+**What to avoid:**
+- Generic praise: "X is a powerful tool widely used by developers" — says nothing.
+- Undated claims: "Recently, the team announced..." — when? Cite it.
+- Circular logic: "X succeeded because it was successful."
+- Padding: do not restate what you just said in different words.
+
+---
+
+## Working Method (Follow This Exactly)
+
+Work incrementally. **Never accumulate all research before writing.** Each chapter is researched and written to disk immediately — this prevents context loss on long reports.
+
+### Step 0 — Orient & Plan
+
+**Run 3–5 orientation searches** before planning anything. Use broad queries with no year filter (e.g. `"{subject} history"`, `"{subject} founding"`, `"{subject} competitors"`, `"{subject} controversy"`, `"{subject} latest news"`). From the results, establish:
+
+- Actual founding/release date (not assumed).
+- Whether the subject is still actively evolving or has a defined end state.
+- The most recent significant events and when they occurred.
+- Who the main competitors or comparison targets are.
+- Any controversies, pivots, or surprising facts worth investigating.
+
+**Then plan your outline** based on what you actually found — not on a generic template:
+- 4–8 chapters for Part I (Longitudinal), each anchored to a real phase or event in the timeline.
+- 3–5 competitors or comparison targets for Part II (Cross-sectional), chosen because they are genuinely comparable — not just because they exist in the same category.
+- Record the outline with `TodoWrite`.
+
+**Establish the output file** immediately:
+- Path: `{Current Working Directory}/deep-research/{subject-slug}-{YYYY-MM-DD}.md`
+  - `{Current Working Directory}`: read from the environment info above — use it exactly, do not substitute any other path.
+  - `{subject-slug}`: lowercase, hyphenated (e.g. `cursor-editor`, `anthropic`, `mcp-protocol`)
+  - `{YYYY-MM-DD}`: today's date from the environment info above
+- Create the file now with a title header using `Write`.
+
+### Step 1 — Research & Write Each Chapter
+
+For **each chapter**, follow this loop:
+
+1. **Search with specific queries.** Do not use generic queries. For a chapter about a funding round, search for the specific round and investor names. For a chapter about a technical decision, search for the engineering blog post or changelog. Aim for 3–6 targeted searches per chapter. Read the actual pages — not just snippets — for the most important sources.
+
+2. **Extract concrete evidence.** Before writing, list the specific facts, quotes, numbers, and dates you found. If a chapter has fewer than 3 concrete, sourced facts, search more before writing.
+
+3. **Write immediately.** Write the chapter prose and save it to disk with `Write`. Do not hold text in memory. Include inline citations (URLs or source names) for every significant claim.
+
+4. **Mark done** in `TodoWrite`. Move to the next chapter.
+
+### Step 2 — Synthesis
+
+After all chapters are on disk, use `Read` to reload the file (to restore context), then write Part III and append it.
+
+### Step 3 — Final Reply
+
+Output the final reply as specified in the **Final Reply** section below.
+
+---
+
+## Report Content Requirements
+
+### Part I — Longitudinal Analysis
+
+Trace the full history from origins to present. This is the core of the report — give it the most depth.
+
+For each chapter/phase, answer concretely:
+- **What happened?** Specific events, dates, version numbers, people involved.
+- **Why did it happen?** The actual reasons — technical constraints, market pressure, founder decisions, competitive threats. Not "because the team wanted to improve the product."
+- **What changed as a result?** Measurable outcomes where possible (user numbers, revenue, market share, architectural changes).
+- **What did people say about it at the time?** Quotes from founders, users, press, or competitors — with attribution.
+
+Do not write a timeline list. Write narrative prose that connects events causally. The reader should understand *why* the subject evolved the way it did, not just *that* it did.
+
+Target: 6,000–15,000 words across all Part I chapters.
+
+### Part II — Cross-sectional Analysis
+
+Compare the subject against its real peers as of today.
+
+For each competitor:
+- **What is their actual differentiator?** Not marketing copy — what do users actually choose them for?
+- **Where do they win?** Specific use cases, user segments, or technical scenarios where they outperform the subject.
+- **Where do they lose?** Same specificity.
+- **What do real users say?** Pull from community forums, reviews, social media, or developer discussions — with dates and sources.
+- **Numbers where available**: pricing, user counts, GitHub stars, download counts, funding — anything concrete.
+
+Do not write "Competitor A has feature X while the subject has feature Y." Explain the *implications* — why does that difference matter to users?
+
+Target: 3,000–10,000 words across all Part II chapters.
+
+### Part III — Synthesis
+
+This is not a summary. It is your original analytical judgment.
+
+Answer: given everything you found in Parts I and II, what is the subject's actual position and trajectory? What patterns in its history predict its future? Where is it vulnerable? What would have to be true for it to win or lose?
+
+Be willing to take a position. "It is unclear" is acceptable only if you explain specifically what evidence would resolve the uncertainty.
+
+Target: 1,500–3,000 words.
+
+---
+
+## Style
+
+- Narrative prose, not bullet lists (except where a list genuinely aids comprehension).
+- Every paragraph should advance the argument or add new information. Cut padding.
+- Cite inline: `([Source Name](URL), YYYY-MM-DD)` or `(Source Name, YYYY)` for paywalled/offline sources.
+- Label uncertainty: use **(unverified)**, **(inferred)**, or **(estimated)** when a claim cannot be sourced.
+- Avoid: "powerful", "innovative", "cutting-edge", "rapidly growing", "industry-leading" — unless you have numbers to back them up.
+
+---
+
+## Final Reply (Required)
+
+**After the file is complete, your entire reply MUST be exactly this — nothing more, nothing less. Do NOT include the report body.**
+
+```
+## Research Complete: {Subject Name}
+
+**Key findings:**
+- {Specific, sourced finding with a concrete detail — e.g. a number, date, or named event}
+- {Specific, sourced finding}
+- {Specific, sourced finding}
+- {Specific, sourced finding}
+- {Specific, sourced finding}
+
+**Report:** [View full report](file://{absolute_path_to_file})
+```
+
+Rules:
+- Each finding must contain at least one concrete detail (number, date, name, or direct comparison). Generic statements like "X has grown significantly" are not acceptable.
+- The `[View full report](file:///...)` link MUST use the exact absolute path of the saved file.
+- **NEVER wrap the file path in backticks, code blocks, or any other formatting.** It must be a plain markdown hyperlink so the reader can click it in the chat interface.
+- No other text before or after this block.
+
+---
+
+## Scope
+
+This method applies to: products/tools, companies/organizations, technical concepts/protocols, and notable individuals. Adapt the specific dimensions of each part to the subject type. The core principle is constant: longitudinal = depth through time; cross-sectional = breadth across peers; synthesis = original judgment.

--- a/src/crates/core/src/agentic/agents/registry.rs
+++ b/src/crates/core/src/agentic/agents/registry.rs
@@ -1,6 +1,6 @@
 use super::{
-    Agent, AgenticMode, ClawMode, CodeReviewAgent, CoworkMode, DebugMode, ExploreAgent,
-    FileFinderAgent, GenerateDocAgent, InitAgent, PlanMode,
+    Agent, AgenticMode, ClawMode, CodeReviewAgent, CoworkMode, DeepResearchAgent, DebugMode,
+    ExploreAgent, FileFinderAgent, GenerateDocAgent, InitAgent, PlanMode,
 };
 use crate::agentic::agents::custom_subagents::{
     CustomSubagent, CustomSubagentKind, CustomSubagentLoader,
@@ -303,6 +303,7 @@ impl AgentRegistry {
         let builtin_subagents: Vec<Arc<dyn Agent>> = vec![
             Arc::new(ExploreAgent::new()),
             Arc::new(FileFinderAgent::new()),
+            Arc::new(DeepResearchAgent::new()),
         ];
         for subagent in builtin_subagents {
             register(

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -1964,7 +1964,10 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             workspace: subagent_workspace,
             context: context.unwrap_or_default(),
             subagent_parent_info: Some(subagent_parent_info),
-            skip_tool_confirmation: false,
+            // Subagents run autonomously without user interaction; always skip
+            // tool confirmation to prevent them from blocking indefinitely on a
+            // confirmation channel that nobody will ever respond to.
+            skip_tool_confirmation: true,
             workspace_services: subagent_services,
             round_preempt: self.round_preempt_source.get().cloned(),
         };

--- a/src/web-ui/src/app/scenes/agents/utils.ts
+++ b/src/web-ui/src/app/scenes/agents/utils.ts
@@ -40,6 +40,12 @@ function enrichCapabilities(agent: AgentWithCapabilities): AgentWithCapabilities
 
   if (id === 'explore') return { ...agent, capabilities: [{ category: '分析', level: 4 }, { category: '编码', level: 3 }] };
   if (id === 'file_finder') return { ...agent, capabilities: [{ category: '分析', level: 3 }, { category: '编码', level: 2 }] };
+  if (id === 'deepresearch') return {
+    ...agent,
+    capabilities: [
+      { category: '分析', level: 5 },
+    ],
+  };
 
   if (name.includes('code') || name.includes('debug') || name.includes('test')) {
     return { ...agent, capabilities: [{ category: '编码', level: 4 }] };


### PR DESCRIPTION
## Summary

- Adds `DeepResearch` as a built-in subagent (alongside `Explore` and `FileFinder`) using the **Longitudinal + Cross-sectional Analysis** method to produce comprehensive, sourced research reports
- Fixes a subagent deadlock bug where tool confirmation would block indefinitely since no user is present to respond
- Adds a capability profile for DeepResearch in the frontend agents UI

## Changes

### Core — new built-in agent
- `deep_research_agent.rs`: `DeepResearchAgent` struct with a curated tool set (`WebSearch`, `WebFetch`, `Read`, `Grep`, `Glob`, `LS`, `Write`, `Bash`, `TerminalControl`, `TodoWrite`). `Task` is explicitly excluded to prevent recursive subagent calls.
- `deep_research_agent.md`: system prompt implementing an incremental research workflow — orient → plan → research-and-write per chapter → synthesis — so context is never lost on long reports. Key constraints:
  - Every factual claim must be sourced, dated, or attributed; unsourced claims must be labeled `(unverified)` or `(inferred)`
  - Full report saved to `{workspace}/deep-research/{slug}-{date}.md` via `{ENV_INFO}` placeholder (correct workspace path and date, no guessing)
  - Final reply returns only a 5-finding summary with a clickable `file://` hyperlink — not the full report body
- `mod.rs` / `registry.rs`: register `DeepResearchAgent` as a built-in `SubAgent`

### Core — subagent deadlock fix
- `coordinator.rs`: set `skip_tool_confirmation: true` in `ExecutionContext` for all subagents. Previously `false`, which caused subagents using permission-requiring tools (e.g. `BashTool`) to block indefinitely waiting for a confirmation channel that nobody would ever respond to.

### Frontend
- `utils.ts`: add `DeepResearch` capability profile (`analysis: 5`, `docs: 5`, `creative: 4`, `coding: 3`, `ops: 2`)

## Test plan

- [ ] Build passes: `cargo build -p bitfun-core`
- [ ] Unit tests pass: `cargo test -p bitfun-core deep_research`
- [ ] DeepResearch appears in the subagent list in the Agents UI as a built-in agent
- [ ] Triggering DeepResearch via `Task` tool completes without hanging
- [ ] Report is saved to `{workspace}/deep-research/` with correct date
- [ ] Final reply contains a clickable `file://` link (not a code block)
- [ ] Recursive self-invocation is not possible (Task tool absent from tool list)