### PR TITLE
fix: improve OpenAI stream handling for anomalous tool-call chunks

### DIFF
--- a/src/crates/ai-adapters/src/client/response_aggregator.rs
+++ b/src/crates/ai-adapters/src/client/response_aggregator.rs
@@ -47,6 +47,7 @@ pub(crate) async fn aggregate_stream_response(
                         id,
                         name,
                         arguments,
+                        arguments_is_snapshot,
                     } = tool_call;
 
                     if let Some(tool_call_id) = id {
@@ -85,7 +86,11 @@ pub(crate) async fn aggregate_stream_response(
 
                     if let Some(tool_call_arguments) = arguments {
                         if pending_tool_call.has_pending() {
-                            pending_tool_call.append_arguments(&tool_call_arguments);
+                            if arguments_is_snapshot {
+                                pending_tool_call.replace_arguments(&tool_call_arguments);
+                            } else {
+                                pending_tool_call.append_arguments(&tool_call_arguments);
+                            }
                         }
                     }
                 }

--- a/src/crates/ai-adapters/src/stream/stream_handler/gemini.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/gemini.rs
@@ -200,6 +200,7 @@ mod tests {
             id: None,
             name: Some("get_weather".to_string()),
             arguments: Some("{\"city\":".to_string()),
+            arguments_is_snapshot: false,
         };
         state.assign_id(&mut first);
 
@@ -207,6 +208,7 @@ mod tests {
             id: None,
             name: Some("get_weather".to_string()),
             arguments: Some("\"Paris\"}".to_string()),
+            arguments_is_snapshot: false,
         };
         state.assign_id(&mut second);
 
@@ -225,6 +227,7 @@ mod tests {
             id: None,
             name: Some("get_weather".to_string()),
             arguments: Some("{}".to_string()),
+            arguments_is_snapshot: false,
         };
         state.assign_id(&mut first);
         state.on_non_tool_response();
@@ -233,6 +236,7 @@ mod tests {
             id: None,
             name: Some("get_weather".to_string()),
             arguments: Some("{}".to_string()),
+            arguments_is_snapshot: false,
         };
         state.assign_id(&mut second);
 
@@ -252,11 +256,13 @@ mod tests {
             id: None,
             name: Some("grep".to_string()),
             arguments: Some("{}".to_string()),
+            arguments_is_snapshot: false,
         };
         let mut second = UnifiedToolCall {
             id: None,
             name: Some("read".to_string()),
             arguments: Some("{}".to_string()),
+            arguments_is_snapshot: false,
         };
 
         first_state.assign_id(&mut first);

--- a/src/crates/ai-adapters/src/stream/stream_handler/openai.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/openai.rs
@@ -1,5 +1,5 @@
 use super::stream_stats::StreamStats;
-use crate::stream::types::openai::OpenAISSEData;
+use crate::stream::types::openai::{OpenAISSEData, OpenAIToolCallArgumentsNormalizer};
 use crate::stream::types::unified::{UnifiedResponse, UnifiedTokenUsage};
 use anyhow::{anyhow, Result};
 use eventsource_stream::Eventsource;
@@ -20,10 +20,13 @@ const INLINE_THINK_CLOSE_TAG: &str = "</think>";
 #[derive(Debug, Default)]
 struct OpenAIToolCallFilter {
     seen_tool_call_ids: HashSet<String>,
+    pending_tool_call_id: Option<String>,
 }
 
 impl OpenAIToolCallFilter {
     fn normalize_response(&mut self, mut response: UnifiedResponse) -> Option<UnifiedResponse> {
+        self.resolve_pending_tool_call_id(&mut response);
+
         let Some(tool_call) = response.tool_call.as_ref() else {
             return Some(response);
         };
@@ -44,12 +47,20 @@ impl OpenAIToolCallFilter {
 
         if let Some(tool_id) = tool_id {
             let seen_before = self.seen_tool_call_ids.contains(&tool_id);
-            self.seen_tool_call_ids.insert(tool_id);
+            self.seen_tool_call_ids.insert(tool_id.clone());
 
-            // OpenAI-compatible providers may emit a trailing chunk that only repeats an
-            // already-seen tool id after the arguments have completed. It carries no new
-            // information and should not reopen a fresh tool-call buffer downstream.
-            if seen_before && !has_name && !has_arguments {
+            // Some OpenAI-compatible providers emit "id only" tool-call chunks.
+            // They can be either:
+            // 1. a harmless trailing/orphan chunk that should be dropped, or
+            // 2. a prelude chunk where later deltas carry the actual name/arguments.
+            //
+            // For (2), keep the id around and reattach it to the next meaningful tool-call
+            // delta when that delta omits the id. For (1), stripping this chunk is safe
+            // because it carries no semantic payload on its own.
+            if !has_name && !has_arguments {
+                if !seen_before {
+                    self.pending_tool_call_id = Some(tool_id);
+                }
                 response.tool_call = None;
                 return Self::keep_if_non_empty(response);
             }
@@ -59,6 +70,41 @@ impl OpenAIToolCallFilter {
         }
 
         Some(response)
+    }
+
+    fn resolve_pending_tool_call_id(&mut self, response: &mut UnifiedResponse) {
+        let Some(pending_tool_call_id) = self.pending_tool_call_id.clone() else {
+            return;
+        };
+
+        let Some(tool_call) = response.tool_call.as_mut() else {
+            self.pending_tool_call_id = None;
+            return;
+        };
+
+        let has_name = tool_call
+            .name
+            .as_ref()
+            .is_some_and(|value| !value.is_empty());
+        let has_arguments = tool_call
+            .arguments
+            .as_ref()
+            .is_some_and(|value| !value.is_empty());
+        let has_payload = has_name || has_arguments;
+
+        match tool_call.id.as_ref() {
+            Some(id) if !id.is_empty() && id == &pending_tool_call_id => {
+                self.pending_tool_call_id = None;
+            }
+            Some(id) if !id.is_empty() => {
+                self.pending_tool_call_id = None;
+            }
+            _ if has_payload => {
+                tool_call.id = Some(pending_tool_call_id);
+                self.pending_tool_call_id = None;
+            }
+            _ => {}
+        }
     }
 
     fn keep_if_non_empty(response: UnifiedResponse) -> Option<UnifiedResponse> {
@@ -323,6 +369,7 @@ impl OpenAIInlineThinkParser {
 
 #[derive(Debug)]
 struct OpenAIResponseNormalizer {
+    tool_arguments_normalizer: OpenAIToolCallArgumentsNormalizer,
     tool_call_filter: OpenAIToolCallFilter,
     inline_think_parser: OpenAIInlineThinkParser,
 }
@@ -330,9 +377,14 @@ struct OpenAIResponseNormalizer {
 impl OpenAIResponseNormalizer {
     fn new(inline_think_in_text: bool) -> Self {
         Self {
+            tool_arguments_normalizer: OpenAIToolCallArgumentsNormalizer::default(),
             tool_call_filter: OpenAIToolCallFilter::default(),
             inline_think_parser: OpenAIInlineThinkParser::new(inline_think_in_text),
         }
+    }
+
+    fn normalize_sse_data(&mut self, sse_data: &mut OpenAISSEData) {
+        sse_data.normalize_tool_call_arguments(&mut self.tool_arguments_normalizer);
     }
 
     fn normalize_response(&mut self, response: UnifiedResponse) -> Vec<UnifiedResponse> {
@@ -481,7 +533,7 @@ pub async fn handle_openai_stream(
         }
 
         stats.increment("chunk:chat_completion");
-        let sse_data: OpenAISSEData = match serde_json::from_value(event_json) {
+        let mut sse_data: OpenAISSEData = match serde_json::from_value(event_json) {
             Ok(event) => event,
             Err(e) => {
                 let error_msg = format!("SSE data schema error: {}, data: {}", e, &raw);
@@ -501,6 +553,8 @@ pub async fn handle_openai_stream(
                 tool_call_count
             );
         }
+
+        normalizer.normalize_sse_data(&mut sse_data);
 
         let has_empty_choices = sse_data.is_choices_empty();
         let unified_responses = sse_data.into_unified_responses();
@@ -549,7 +603,20 @@ mod tests {
         longest_suffix_prefix_len, InlineThinkActivation, InlineThinkMode, OpenAIInlineThinkParser,
         OpenAIToolCallFilter,
     };
+    use crate::stream::types::openai::OpenAISSEData;
     use crate::stream::types::unified::{UnifiedResponse, UnifiedToolCall};
+
+    fn normalize_raw_with_filter(
+        filter: &mut OpenAIToolCallFilter,
+        raw: &str,
+    ) -> Vec<UnifiedResponse> {
+        let sse_data: OpenAISSEData = serde_json::from_str(raw).expect("valid openai sse data");
+        sse_data
+            .into_unified_responses()
+            .into_iter()
+            .filter_map(|response| filter.normalize_response(response))
+            .collect()
+    }
 
     #[test]
     fn weak_filter_accepts_chat_completion_chunk() {
@@ -616,6 +683,7 @@ mod tests {
                 id: Some("call_1".to_string()),
                 name: Some("read_file".to_string()),
                 arguments: Some("{\"path\":\"a.txt\"}".to_string()),
+                arguments_is_snapshot: false,
             }),
             ..Default::default()
         };
@@ -624,6 +692,7 @@ mod tests {
                 id: Some("call_1".to_string()),
                 name: None,
                 arguments: Some(String::new()),
+                arguments_is_snapshot: false,
             }),
             ..Default::default()
         };
@@ -641,6 +710,7 @@ mod tests {
                 id: Some("call_1".to_string()),
                 name: Some("read_file".to_string()),
                 arguments: Some("{\"path\":\"a.txt\"}".to_string()),
+                arguments_is_snapshot: false,
             }),
             ..Default::default()
         };
@@ -649,6 +719,7 @@ mod tests {
                 id: Some("call_1".to_string()),
                 name: None,
                 arguments: None,
+                arguments_is_snapshot: false,
             }),
             finish_reason: Some("tool_calls".to_string()),
             ..Default::default()
@@ -660,6 +731,157 @@ mod tests {
             .expect("finish_reason should be preserved");
         assert!(normalized.tool_call.is_none());
         assert_eq!(normalized.finish_reason.as_deref(), Some("tool_calls"));
+    }
+
+    #[test]
+    fn strips_unseen_id_only_tool_call_but_keeps_finish_reason() {
+        let mut filter = OpenAIToolCallFilter::default();
+
+        let orphan = UnifiedResponse {
+            tool_call: Some(UnifiedToolCall {
+                id: Some("call_orphan".to_string()),
+                name: None,
+                arguments: None,
+                arguments_is_snapshot: false,
+            }),
+            finish_reason: Some("tool_calls".to_string()),
+            ..Default::default()
+        };
+
+        let normalized = filter
+            .normalize_response(orphan)
+            .expect("finish_reason should be preserved");
+        assert!(normalized.tool_call.is_none());
+        assert_eq!(normalized.finish_reason.as_deref(), Some("tool_calls"));
+    }
+
+    #[test]
+    fn reattaches_pending_id_to_following_payload_chunk() {
+        let mut filter = OpenAIToolCallFilter::default();
+
+        let prelude = UnifiedResponse {
+            tool_call: Some(UnifiedToolCall {
+                id: Some("call_1".to_string()),
+                name: None,
+                arguments: None,
+                arguments_is_snapshot: false,
+            }),
+            ..Default::default()
+        };
+        let payload = UnifiedResponse {
+            tool_call: Some(UnifiedToolCall {
+                id: None,
+                name: Some("read_file".to_string()),
+                arguments: Some("{\"path\":\"a.txt\"}".to_string()),
+                arguments_is_snapshot: false,
+            }),
+            ..Default::default()
+        };
+
+        assert!(filter.normalize_response(prelude).is_none());
+        let normalized = filter
+            .normalize_response(payload)
+            .expect("payload chunk should be kept");
+        let tool_call = normalized.tool_call.expect("tool call should exist");
+        assert_eq!(tool_call.id.as_deref(), Some("call_1"));
+        assert_eq!(tool_call.name.as_deref(), Some("read_file"));
+        assert_eq!(tool_call.arguments.as_deref(), Some("{\"path\":\"a.txt\"}"));
+    }
+
+    #[test]
+    fn drops_orphan_id_only_tool_call_when_it_shares_sse_with_normal_final_tool_chunk() {
+        let mut filter = OpenAIToolCallFilter::default();
+
+        let responses = normalize_raw_with_filter(
+            &mut filter,
+            r#"{
+                "id": "chatcmpl_test",
+                "created": 123,
+                "model": "gpt-test",
+                "choices": [{
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "read_file",
+                                    "arguments": "{\"path\":\"a.txt\"}"
+                                }
+                            },
+                            {
+                                "index": 1,
+                                "id": "call_orphan",
+                                "type": "function",
+                                "function": {}
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls"
+                }]
+            }"#,
+        );
+
+        assert_eq!(responses.len(), 1);
+        let tool_call = responses[0].tool_call.as_ref().expect("tool call should exist");
+        assert_eq!(tool_call.id.as_deref(), Some("call_1"));
+        assert_eq!(tool_call.name.as_deref(), Some("read_file"));
+        assert_eq!(tool_call.arguments.as_deref(), Some("{\"path\":\"a.txt\"}"));
+        assert_eq!(responses[0].finish_reason.as_deref(), Some("tool_calls"));
+    }
+
+    #[test]
+    fn drops_orphan_id_only_tool_call_when_it_shares_sse_with_redundant_empty_tail() {
+        let mut filter = OpenAIToolCallFilter::default();
+
+        assert!(
+            filter
+                .normalize_response(UnifiedResponse {
+                    tool_call: Some(UnifiedToolCall {
+                        id: Some("call_1".to_string()),
+                        name: Some("read_file".to_string()),
+                        arguments: Some("{\"path\":\"a.txt\"}".to_string()),
+                        arguments_is_snapshot: false,
+                    }),
+                    ..Default::default()
+                })
+                .is_some()
+        );
+
+        let responses = normalize_raw_with_filter(
+            &mut filter,
+            r#"{
+                "id": "chatcmpl_test",
+                "created": 123,
+                "model": "gpt-test",
+                "choices": [{
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {}
+                            },
+                            {
+                                "index": 1,
+                                "id": "call_orphan",
+                                "type": "function",
+                                "function": {}
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls"
+                }]
+            }"#,
+        );
+
+        assert_eq!(responses.len(), 1);
+        assert!(responses[0].tool_call.is_none());
+        assert_eq!(responses[0].finish_reason.as_deref(), Some("tool_calls"));
     }
 
     #[test]

--- a/src/crates/ai-adapters/src/stream/stream_handler/responses.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/responses.rs
@@ -126,6 +126,7 @@ fn handle_function_call_output_item_done(
                     id,
                     name,
                     arguments: Some(delta),
+                    arguments_is_snapshot: false,
                 }),
                 ..Default::default()
             };
@@ -318,6 +319,7 @@ pub async fn handle_responses_stream(
                         id,
                         name,
                         arguments: Some(delta),
+                        arguments_is_snapshot: false,
                     }),
                     ..Default::default()
                 };
@@ -388,6 +390,7 @@ pub async fn handle_responses_stream(
                                                 id,
                                                 name,
                                                 arguments: Some(delta),
+                                                arguments_is_snapshot: false,
                                             },
                                         ),
                                         ..Default::default()

--- a/src/crates/ai-adapters/src/stream/types/anthropic.rs
+++ b/src/crates/ai-adapters/src/stream/types/anthropic.rs
@@ -117,6 +117,7 @@ impl From<ContentBlockStart> for UnifiedResponse {
                 id: Some(id),
                 name: Some(name),
                 arguments: None,
+                arguments_is_snapshot: false,
             };
             result.tool_call = Some(tool_call);
         }
@@ -160,6 +161,7 @@ impl TryFrom<ContentBlockDelta> for UnifiedResponse {
                     id: None,
                     name: None,
                     arguments: Some(partial_json),
+                    arguments_is_snapshot: false,
                 };
                 result.tool_call = Some(tool_call);
             }

--- a/src/crates/ai-adapters/src/stream/types/gemini.rs
+++ b/src/crates/ai-adapters/src/stream/types/gemini.rs
@@ -363,6 +363,7 @@ impl GeminiSSEData {
                             id: None,
                             name: function_call.name,
                             arguments: serde_json::to_string(&arguments).ok(),
+                            arguments_is_snapshot: false,
                         }),
                         usage: usage.take(),
                         finish_reason: finish_reason.take(),

--- a/src/crates/ai-adapters/src/stream/types/openai.rs
+++ b/src/crates/ai-adapters/src/stream/types/openai.rs
@@ -1,5 +1,5 @@
 use super::unified::{UnifiedResponse, UnifiedTokenUsage, UnifiedToolCall};
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 #[derive(Debug, Deserialize)]
 struct PromptTokensDetails {
@@ -37,6 +37,8 @@ struct Choice {
     index: usize,
     delta: Delta,
     finish_reason: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
+    stop_reason: Option<String>,
 }
 
 /// MiniMax `reasoning_details` array element.
@@ -69,6 +71,8 @@ struct OpenAIToolCall {
     #[allow(dead_code)]
     #[serde(rename = "type")]
     tool_type: Option<String>,
+    #[serde(default)]
+    arguments_is_snapshot: bool,
     function: Option<FunctionCall>,
 }
 
@@ -81,6 +85,7 @@ impl From<OpenAIToolCall> for UnifiedToolCall {
                 .function
                 .as_ref()
                 .and_then(|f| f.arguments.clone()),
+            arguments_is_snapshot: tool_call.arguments_is_snapshot,
         }
     }
 }
@@ -103,7 +108,70 @@ pub struct OpenAISSEData {
     usage: Option<OpenAIUsage>,
 }
 
+#[derive(Debug, Default)]
+pub struct OpenAIToolCallArgumentsNormalizer;
+
+fn deserialize_optional_stringish<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(match value {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(value)) => Some(value),
+        Some(serde_json::Value::Number(value)) => Some(value.to_string()),
+        Some(serde_json::Value::Bool(value)) => Some(value.to_string()),
+        Some(other) => Some(other.to_string()),
+    })
+}
+
+impl OpenAIToolCallArgumentsNormalizer {
+    fn normalize_choice(&mut self, choice: &mut Choice) {
+        let has_stop_reason = choice.stop_reason.is_some();
+        let Some(tool_calls) = choice.delta.tool_calls.as_mut() else {
+            return;
+        };
+
+        for tool_call in tool_calls.iter_mut() {
+            self.normalize_tool_call(tool_call, has_stop_reason);
+        }
+    }
+
+    fn normalize_tool_call(&mut self, tool_call: &mut OpenAIToolCall, has_stop_reason: bool) {
+        let has_id = tool_call.id.as_ref().is_some_and(|value| !value.is_empty());
+        let has_name = tool_call
+            .function
+            .as_ref()
+            .and_then(|function| function.name.as_ref())
+            .is_some_and(|value| !value.is_empty());
+
+        let Some(function) = tool_call.function.as_mut() else {
+            return;
+        };
+        let Some(arguments) = function.arguments.as_ref() else {
+            return;
+        };
+
+        if arguments.is_empty() {
+            return;
+        }
+
+        if has_stop_reason && !has_id && !has_name {
+            tool_call.arguments_is_snapshot = true;
+        }
+    }
+}
+
 impl OpenAISSEData {
+    pub fn normalize_tool_call_arguments(
+        &mut self,
+        normalizer: &mut OpenAIToolCallArgumentsNormalizer,
+    ) {
+        if let Some(first_choice) = self.choices.first_mut() {
+            normalizer.normalize_choice(first_choice);
+        }
+    }
+
     pub fn is_choices_empty(&self) -> bool {
         self.choices.is_empty()
     }
@@ -227,7 +295,7 @@ impl From<OpenAISSEData> for UnifiedResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::OpenAISSEData;
+    use super::{OpenAISSEData, OpenAIToolCallArgumentsNormalizer};
 
     #[test]
     fn splits_multiple_tool_calls_in_first_choice() {
@@ -384,5 +452,192 @@ mod tests {
         );
         assert!(responses[1].usage.is_none());
         assert!(responses[1].finish_reason.is_none());
+    }
+
+    #[test]
+    fn marks_stop_reason_tool_chunk_as_snapshot() {
+        let mut normalizer = OpenAIToolCallArgumentsNormalizer::default();
+
+        let mut first_chunk: OpenAISSEData = serde_json::from_str(
+            r#"{
+                "id": "chatcmpl_test",
+                "created": 123,
+                "model": "gpt-test",
+                "choices": [{
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [{
+                            "index": 0,
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "tool_a",
+                                "arguments": "{\"city\":\"Bei"
+                            }
+                        }]
+                    },
+                    "finish_reason": null
+                }]
+            }"#,
+        )
+        .expect("valid first chunk");
+        first_chunk.normalize_tool_call_arguments(&mut normalizer);
+        let first_responses = first_chunk.into_unified_responses();
+        assert_eq!(
+            first_responses[0]
+                .tool_call
+                .as_ref()
+                .and_then(|tool| tool.arguments.as_deref()),
+            Some("{\"city\":\"Bei")
+        );
+        assert!(
+            !first_responses[0]
+                .tool_call
+                .as_ref()
+                .expect("tool call")
+                .arguments_is_snapshot
+        );
+
+        let mut snapshot_chunk: OpenAISSEData = serde_json::from_str(
+            r#"{
+                "id": "chatcmpl_test",
+                "created": 123,
+                "model": "gpt-test",
+                "choices": [{
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [{
+                            "index": 0,
+                            "type": "function",
+                            "function": {
+                                "arguments": "{\"city\":\"Beijing\"}"
+                            }
+                        }]
+                    },
+                    "stop_reason": "stop"
+                }]
+            }"#,
+        )
+        .expect("valid snapshot chunk");
+        snapshot_chunk.normalize_tool_call_arguments(&mut normalizer);
+        let snapshot_responses = snapshot_chunk.into_unified_responses();
+        assert_eq!(
+            snapshot_responses[0]
+                .tool_call
+                .as_ref()
+                .and_then(|tool| tool.arguments.as_deref()),
+            Some("{\"city\":\"Beijing\"}")
+        );
+        assert!(
+            snapshot_responses[0]
+                .tool_call
+                .as_ref()
+                .expect("tool call")
+                .arguments_is_snapshot
+        );
+        assert!(snapshot_responses[0].finish_reason.is_none());
+    }
+
+    #[test]
+    fn leaves_normal_tool_delta_chunks_as_non_snapshot() {
+        let mut normalizer = OpenAIToolCallArgumentsNormalizer::default();
+
+        let mut chunk: OpenAISSEData = serde_json::from_str(
+            r#"{
+                "id": "chatcmpl_test",
+                "created": 123,
+                "model": "gpt-test",
+                "choices": [{
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [{
+                            "index": 0,
+                            "type": "function",
+                            "function": {
+                                "arguments": "jing"
+                            }
+                        }]
+                    },
+                    "finish_reason": "tool_calls"
+                }]
+            }"#,
+        )
+        .expect("valid chunk");
+        chunk.normalize_tool_call_arguments(&mut normalizer);
+        let responses = chunk.into_unified_responses();
+        assert_eq!(responses.len(), 1);
+        assert!(
+            !responses[0]
+                .tool_call
+                .as_ref()
+                .expect("tool call")
+                .arguments_is_snapshot
+        );
+    }
+
+    #[test]
+    fn parses_numeric_stop_reason_as_string() {
+        let data: OpenAISSEData = serde_json::from_str(
+            r#"{
+                "id": "chatcmpl_test",
+                "created": 123,
+                "model": "gpt-test",
+                "choices": [{
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [{
+                            "index": 0,
+                            "type": "function",
+                            "function": {
+                                "arguments": "{\"a\":1}"
+                            }
+                        }]
+                    },
+                    "stop_reason": 154829
+                }]
+            }"#,
+        )
+        .expect("valid numeric stop_reason payload");
+
+        let mut normalizer = OpenAIToolCallArgumentsNormalizer::default();
+        let mut data = data;
+        data.normalize_tool_call_arguments(&mut normalizer);
+        let responses = data.into_unified_responses();
+
+        assert_eq!(responses.len(), 1);
+        assert!(responses[0].tool_call.is_some());
+    }
+
+    #[test]
+    fn parses_string_stop_reason_unchanged() {
+        let data: OpenAISSEData = serde_json::from_str(
+            r#"{
+                "id": "chatcmpl_test",
+                "created": 123,
+                "model": "gpt-test",
+                "choices": [{
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [{
+                            "index": 0,
+                            "type": "function",
+                            "function": {
+                                "arguments": "{\"a\":1}"
+                            }
+                        }]
+                    },
+                    "stop_reason": "154829"
+                }]
+            }"#,
+        )
+        .expect("valid string stop_reason payload");
+
+        let mut normalizer = OpenAIToolCallArgumentsNormalizer::default();
+        let mut data = data;
+        data.normalize_tool_call_arguments(&mut normalizer);
+        let responses = data.into_unified_responses();
+
+        assert_eq!(responses.len(), 1);
+        assert!(responses[0].tool_call.is_some());
     }
 }

--- a/src/crates/ai-adapters/src/stream/types/responses.rs
+++ b/src/crates/ai-adapters/src/stream/types/responses.rs
@@ -87,6 +87,7 @@ pub fn parse_responses_output_item(item_value: Value) -> Option<UnifiedResponse>
                     .get("arguments")
                     .and_then(Value::as_str)
                     .map(ToString::to_string),
+                arguments_is_snapshot: false,
             }),
             usage: None,
             finish_reason: None,

--- a/src/crates/ai-adapters/src/stream/types/unified.rs
+++ b/src/crates/ai-adapters/src/stream/types/unified.rs
@@ -6,6 +6,8 @@ pub struct UnifiedToolCall {
     pub id: Option<String>,
     pub name: Option<String>,
     pub arguments: Option<String>,
+    #[serde(default)]
+    pub arguments_is_snapshot: bool,
 }
 
 /// Unified AI response format

--- a/src/crates/ai-adapters/src/tool_call_accumulator.rs
+++ b/src/crates/ai-adapters/src/tool_call_accumulator.rs
@@ -116,6 +116,11 @@ impl PendingToolCall {
         self.raw_arguments.push_str(arguments_chunk);
     }
 
+    pub fn replace_arguments(&mut self, arguments_snapshot: &str) {
+        self.raw_arguments.clear();
+        self.raw_arguments.push_str(arguments_snapshot);
+    }
+
     pub fn finalize(&mut self, boundary: ToolCallBoundary) -> Option<FinalizedToolCall> {
         if !self.has_pending() {
             return None;
@@ -212,5 +217,20 @@ mod tests {
 
         assert_eq!(map.get("a"), Some(&json!(1)));
         assert_eq!(map.get("b"), Some(&json!("x")));
+    }
+
+    #[test]
+    fn replace_arguments_overwrites_partial_buffer() {
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("tool_a".to_string()));
+        pending.append_arguments("{\"city\":\"Bei");
+        pending.replace_arguments("{\"city\":\"Beijing\"}");
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason)
+            .expect("finalized tool");
+
+        assert_eq!(finalized.arguments, json!({"city": "Beijing"}));
+        assert!(!finalized.is_error);
     }
 }

--- a/src/crates/core/src/agentic/execution/stream_processor.rs
+++ b/src/crates/core/src/agentic/execution/stream_processor.rs
@@ -451,6 +451,7 @@ impl StreamProcessor {
             id,
             name,
             arguments,
+            arguments_is_snapshot,
         } = tool_call;
 
         // Handle tool ID and name
@@ -495,7 +496,11 @@ impl StreamProcessor {
             // have a pending tool call; otherwise treat this as an orphaned delta and ignore it.
             if ctx.pending_tool_call.has_pending() {
                 ctx.has_effective_output = true;
-                ctx.pending_tool_call.append_arguments(&tool_call_arguments);
+                if arguments_is_snapshot {
+                    ctx.pending_tool_call.replace_arguments(&tool_call_arguments);
+                } else {
+                    ctx.pending_tool_call.append_arguments(&tool_call_arguments);
+                }
 
                 // Send partial parameters event
                 let _ = self
@@ -848,6 +853,7 @@ mod tests {
                     id: Some("call_1".to_string()),
                     name: Some("tool_a".to_string()),
                     arguments: Some("{\"a\":".to_string()),
+                    arguments_is_snapshot: false,
                 }),
                 usage: Some(sample_usage(5)),
                 ..Default::default()
@@ -857,6 +863,7 @@ mod tests {
                     id: None,
                     name: None,
                     arguments: Some("1}".to_string()),
+                    arguments_is_snapshot: false,
                 }),
                 usage: Some(sample_usage(7)),
                 ..Default::default()
@@ -893,6 +900,7 @@ mod tests {
                 id: Some("call_1".to_string()),
                 name: Some("tool_a".to_string()),
                 arguments: Some("{\"a\":1}".to_string()),
+                arguments_is_snapshot: false,
             }),
             usage: Some(sample_usage(9)),
             finish_reason: Some("tool_calls".to_string()),
@@ -926,6 +934,7 @@ mod tests {
                 id: Some("call_1".to_string()),
                 name: Some("tool_a".to_string()),
                 arguments: Some("{\"a\":1}}".to_string()),
+                arguments_is_snapshot: false,
             }),
             finish_reason: Some("tool_calls".to_string()),
             ..Default::default()
@@ -949,6 +958,52 @@ mod tests {
         assert_eq!(result.tool_calls[0].tool_id, "call_1");
         assert_eq!(result.tool_calls[0].tool_name, "tool_a");
         assert_eq!(result.tool_calls[0].arguments, json!({"a": 1}));
+        assert!(!result.tool_calls[0].is_error);
+    }
+
+    #[tokio::test]
+    async fn replaces_tool_args_when_snapshot_chunk_arrives() {
+        let processor = build_processor();
+        let stream = iter(vec![
+            Ok(UnifiedResponse {
+                tool_call: Some(UnifiedToolCall {
+                    id: Some("call_1".to_string()),
+                    name: Some("tool_a".to_string()),
+                    arguments: Some("{\"city\":\"Bei".to_string()),
+                    arguments_is_snapshot: false,
+                }),
+                ..Default::default()
+            }),
+            Ok(UnifiedResponse {
+                tool_call: Some(UnifiedToolCall {
+                    id: None,
+                    name: None,
+                    arguments: Some("{\"city\":\"Beijing\"}".to_string()),
+                    arguments_is_snapshot: true,
+                }),
+                finish_reason: Some("tool_calls".to_string()),
+                ..Default::default()
+            }),
+        ])
+        .boxed();
+
+        let result = processor
+            .process_stream(
+                stream,
+                None,
+                "session_1".to_string(),
+                "turn_1".to_string(),
+                "round_1".to_string(),
+                None,
+                &CancellationToken::new(),
+            )
+            .await
+            .expect("stream result");
+
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].tool_id, "call_1");
+        assert_eq!(result.tool_calls[0].tool_name, "tool_a");
+        assert_eq!(result.tool_calls[0].arguments, json!({"city": "Beijing"}));
         assert!(!result.tool_calls[0].is_error);
     }
 }

--- a/src/crates/core/tests/fixtures/stream/openai/tool_args_snapshot_stop_reason.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/tool_args_snapshot_stop_reason.sse
@@ -1,0 +1,7 @@
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":500,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"tool_a","arguments":"{\"city\":\"Bei"}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":501,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":null,"type":"function","function":{"arguments":"{\"city\":\"Beijing\"}"}}]},"stop_reason":"stop"}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":502,"model":"gpt-test","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":6,"total_tokens":9}}
+
+data: [DONE]

--- a/src/crates/core/tests/fixtures/stream/openai/tool_id_only_orphan_filtered.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/tool_id_only_orphan_filtered.sse
@@ -1,0 +1,3 @@
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":600,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_orphan","type":"function","function":{}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":4,"completion_tokens":5,"total_tokens":9}}
+
+data: [DONE]

--- a/src/crates/core/tests/fixtures/stream/openai/tool_id_prelude_then_payload_without_id.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/tool_id_prelude_then_payload_without_id.sse
@@ -1,0 +1,5 @@
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":400,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":401,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":null,"type":"function","function":{"name":"tool_a","arguments":"{\"city\":\"Beijing\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":3,"completion_tokens":6,"total_tokens":9}}
+
+data: [DONE]

--- a/src/crates/core/tests/fixtures/stream/openai/two_tools_first_final_chunk_contains_orphan_id_only.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/two_tools_first_final_chunk_contains_orphan_id_only.sse
@@ -1,0 +1,7 @@
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":700,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"tool_one","arguments":"{\"x\":"}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":701,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"arguments":"1}"}},{"index":1,"id":"call_orphan","type":"function","function":{}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":702,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_2","type":"function","function":{"name":"tool_two","arguments":"{\"y\":2}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":6,"total_tokens":11}}
+
+data: [DONE]

--- a/src/crates/core/tests/stream_processor_openai.rs
+++ b/src/crates/core/tests/stream_processor_openai.rs
@@ -179,3 +179,195 @@ async fn openai_fixture_parses_inline_think_tags_into_reasoning_content() {
         .collect();
     assert_eq!(text_chunks, vec!["Final answer."]);
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn openai_fixture_reattaches_id_only_prelude_to_following_payload_chunk() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::OpenAi,
+        "stream/openai/tool_id_prelude_then_payload_without_id.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].tool_id, "call_1");
+    assert_eq!(result.tool_calls[0].tool_name, "tool_a");
+    assert_eq!(result.tool_calls[0].arguments, json!({ "city": "Beijing" }));
+    assert!(!result.tool_calls[0].is_error);
+    assert_eq!(
+        result.usage.as_ref().map(|usage| usage.total_token_count),
+        Some(9)
+    );
+
+    let early_detected = output.events.iter().any(|event| {
+        matches!(
+            event,
+            AgenticEvent::ToolEvent {
+                tool_event: ToolEventData::EarlyDetected { tool_id, tool_name },
+                ..
+            } if tool_id == "call_1" && tool_name == "tool_a"
+        )
+    });
+    assert!(early_detected, "expected reattached tool id to trigger early detection");
+
+    let partial_params: Vec<&str> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ToolEvent {
+                tool_event: ToolEventData::ParamsPartial { params, .. },
+                ..
+            } => Some(params.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(partial_params, vec!["{\"city\":\"Beijing\"}"]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn openai_fixture_replaces_snapshot_tool_args_after_stop_reason_chunk() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::OpenAi,
+        "stream/openai/tool_args_snapshot_stop_reason.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].tool_id, "call_1");
+    assert_eq!(result.tool_calls[0].tool_name, "tool_a");
+    assert_eq!(result.tool_calls[0].arguments, json!({ "city": "Beijing" }));
+    assert!(!result.tool_calls[0].is_error);
+    assert_eq!(
+        result.usage.as_ref().map(|usage| usage.total_token_count),
+        Some(9)
+    );
+
+    let partial_params: Vec<&str> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ToolEvent {
+                tool_event: ToolEventData::ParamsPartial { params, .. },
+                ..
+            } => Some(params.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(partial_params, vec!["{\"city\":\"Bei", "{\"city\":\"Beijing\"}"]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn openai_fixture_filters_unseen_id_only_orphan_tool_chunk() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::OpenAi,
+        "stream/openai/tool_id_only_orphan_filtered.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+
+    assert!(result.full_thinking.is_empty());
+    assert!(result.full_text.is_empty());
+    assert!(result.tool_calls.is_empty());
+    assert_eq!(
+        result.usage.as_ref().map(|usage| usage.total_token_count),
+        Some(9)
+    );
+
+    let tool_events = output.events.iter().any(|event| {
+        matches!(
+            event,
+            AgenticEvent::ToolEvent {
+                tool_event:
+                    ToolEventData::EarlyDetected { .. } | ToolEventData::ParamsPartial { .. },
+                ..
+            }
+        )
+    });
+    assert!(
+        !tool_events,
+        "id-only orphan chunk should not emit any tool lifecycle events"
+    );
+
+    let failed_or_cancelled = output.events.iter().any(|event| {
+        matches!(
+            event,
+            AgenticEvent::DialogTurnFailed { .. } | AgenticEvent::DialogTurnCancelled { .. }
+        )
+    });
+    assert!(
+        !failed_or_cancelled,
+        "filtered orphan chunk should still complete the stream normally"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn openai_fixture_filters_orphan_id_only_block_when_it_shares_chunk_with_first_tool_tail() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::OpenAi,
+        "stream/openai/two_tools_first_final_chunk_contains_orphan_id_only.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+
+    assert_eq!(result.tool_calls.len(), 2);
+
+    assert_eq!(result.tool_calls[0].tool_id, "call_1");
+    assert_eq!(result.tool_calls[0].tool_name, "tool_one");
+    assert_eq!(result.tool_calls[0].arguments, json!({ "x": 1 }));
+    assert!(!result.tool_calls[0].is_error);
+
+    assert_eq!(result.tool_calls[1].tool_id, "call_2");
+    assert_eq!(result.tool_calls[1].tool_name, "tool_two");
+    assert_eq!(result.tool_calls[1].arguments, json!({ "y": 2 }));
+    assert!(!result.tool_calls[1].is_error);
+
+    assert_eq!(
+        result.usage.as_ref().map(|usage| usage.total_token_count),
+        Some(11)
+    );
+
+    let early_detected_ids: Vec<&str> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ToolEvent {
+                tool_event: ToolEventData::EarlyDetected { tool_id, .. },
+                ..
+            } => Some(tool_id.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(early_detected_ids, vec!["call_1", "call_2"]);
+
+    let partial_params: Vec<(&str, &str)> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ToolEvent {
+                tool_event:
+                    ToolEventData::ParamsPartial {
+                        tool_id, params, ..
+                    },
+                ..
+            } => Some((tool_id.as_str(), params.as_str())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        partial_params,
+        vec![
+            ("call_1", "{\"x\":"),
+            ("call_1", "1}"),
+            ("call_2", "{\"y\":2}"),
+        ]
+    );
+}


### PR DESCRIPTION
- filter id-only orphan tool-call chunks without dropping finish metadata
- reattach pending tool-call ids to subsequent payload chunks that omit ids
- detect snapshot-style tool argument chunks and replace buffered arguments
- add unit tests for OpenAI normalization and tool-call argument replacement
- add OpenAI stream integration fixtures for orphan, mixed-chunk, and snapshot cases
