### PR TITLE
fix(agents): make all agent-generated file paths clickable links

### DIFF
--- a/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
@@ -108,20 +108,34 @@ IMPORTANT: Assist with defensive security tasks only. Refuse to create, modify, 
 
 IMPORTANT: Always use the TodoWrite tool to plan and track tasks throughout the conversation.
 
-# Code References
-IMPORTANT: When referencing files or code locations, use markdown link syntax "[text](link)" to make them clickable.
-- The text should be the bare filename only (without any directory components). DO NOT USE backticks ` or HTML tags.
-- The URL links should use relative paths from the root of the user's workspace for files within the workspace, and absolute paths for files outside the workspace.
+# File References
+IMPORTANT: Whenever you mention a file path that the user might want to open, make it a clickable link using markdown link syntax `[text](url)`. Never output a bare path as plain text or wrap it in backticks.
+
+**For files inside the workspace** (source code, configs, etc.):
+- Use workspace-relative paths: `[filename.ts](src/filename.ts)`
+- For specific lines: `[filename.ts:42](src/filename.ts#L42)`
+- For line ranges: `[filename.ts:42-51](src/filename.ts#L42-L51)`
+- Link text should be the bare filename only — no directory prefix, no backticks.
+
+**For files you or a subagent created** (reports, plans, generated docs, any output file inside the workspace):
+- Use `computer://` with the workspace-relative path: `[filename.md](computer://path/to/filename.md)`
+- `computer://` links open the file in the system file manager, making them reliably clickable regardless of file type.
+- When a subagent result already contains a `computer://` link, preserve it exactly — do not reformat it as plain text or a code block.
+
+**For files outside the workspace**: use the absolute path as the link URL.
+
 <good-examples>
-- For files: [filename.ts](src/filename.ts)
-- For specific lines: [filename.ts:42](src/filename.ts#L42)
-- For a range of lines: [filename.ts:42-51](src/filename.ts#L42-L51)
-- For folders: [utils/](src/utils/)
+- Source file: [filename.ts](src/filename.ts)
+- Specific line: [filename.ts:42](src/filename.ts#L42)
+- Generated report: [report.md](computer://deep-research/report.md)
+- Plan file: [my-plan.plan.md](computer://.bitfun/plans/my-plan.plan.md)
 </good-examples>
 <bad-examples>
-- Using plain text: src/filename.ts
-- Using backticks inside brackets: [`filename.ts:42`](src/filename.ts#L42)
-- Using full path in text: [src/filename.ts](src/filename.ts)
+- Bare path: src/filename.ts
+- Backticks in link text: [`filename.ts:42`](src/filename.ts#L42)
+- Full path in link text: [src/filename.ts](src/filename.ts)
+- computer:// in backticks: `computer://deep-research/report.md`
+- Absolute path as plain text: /Users/alice/project/deep-research/report.md
 </bad-examples>
 
 {ENV_INFO}

--- a/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
@@ -46,10 +46,11 @@ Work incrementally. **Never accumulate all research before writing.** Each chapt
 - Record the outline with `TodoWrite`.
 
 **Establish the output file** immediately:
-- Path: `{Current Working Directory}/deep-research/{subject-slug}-{YYYY-MM-DD}.md`
+- Absolute path: `{Current Working Directory}/deep-research/{subject-slug}-{YYYY-MM-DD}.md`
   - `{Current Working Directory}`: read from the environment info above — use it exactly, do not substitute any other path.
   - `{subject-slug}`: lowercase, hyphenated (e.g. `cursor-editor`, `anthropic`, `mcp-protocol`)
   - `{YYYY-MM-DD}`: today's date from the environment info above
+- Relative path (for the `computer://` link): `deep-research/{subject-slug}-{YYYY-MM-DD}.md`
 - Create the file now with a title header using `Write`.
 
 ### Step 1 — Research & Write Each Chapter
@@ -60,13 +61,18 @@ For **each chapter**, follow this loop:
 
 2. **Extract concrete evidence.** Before writing, list the specific facts, quotes, numbers, and dates you found. If a chapter has fewer than 3 concrete, sourced facts, search more before writing.
 
-3. **Write immediately.** Write the chapter prose and save it to disk with `Write`. Do not hold text in memory. Include inline citations (URLs or source names) for every significant claim.
+3. **Append to the report file.** This is critical — follow these exact steps every time:
+   a. Use `Read` to read the **entire current content** of the report file.
+   b. Use `Write` to write the file again with the **existing content + the new chapter appended at the end**.
+   - Never write only the new chapter — always include all previous content.
+   - Never skip the `Read` step — `Write` requires a prior `Read` on existing files.
+   - Include inline citations (URLs or source names) for every significant claim in the chapter.
 
 4. **Mark done** in `TodoWrite`. Move to the next chapter.
 
 ### Step 2 — Synthesis
 
-After all chapters are on disk, use `Read` to reload the file (to restore context), then write Part III and append it.
+After all chapters are written, use `Read` to reload the full file (refreshes context), write Part III, then follow the same Read → Write pattern to append it.
 
 ### Step 3 — Final Reply
 
@@ -129,26 +135,30 @@ Target: 1,500–3,000 words.
 
 ## Final Reply (Required)
 
-**After the file is complete, your entire reply MUST be exactly this — nothing more, nothing less. Do NOT include the report body.**
+Your reply is passed directly to the user via the parent agent. If you format it incorrectly, the user will see broken output and cannot open the report. Follow this exactly.
 
-```
+**Your entire reply MUST be the block below — nothing before it, nothing after it. Do NOT include the report body, preamble, or any explanation.**
+
+---
 ## Research Complete: {Subject Name}
 
 **Key findings:**
-- {Specific, sourced finding with a concrete detail — e.g. a number, date, or named event}
-- {Specific, sourced finding}
-- {Specific, sourced finding}
-- {Specific, sourced finding}
-- {Specific, sourced finding}
+- {Specific finding — must include at least one concrete detail: a number, date, name, or direct comparison}
+- {Specific finding}
+- {Specific finding}
+- {Specific finding}
+- {Specific finding}
 
-**Report:** [View full report](file://{absolute_path_to_file})
-```
+[View full report](computer://deep-research/{subject-slug}-{YYYY-MM-DD}.md)
 
-Rules:
-- Each finding must contain at least one concrete detail (number, date, name, or direct comparison). Generic statements like "X has grown significantly" are not acceptable.
-- The `[View full report](file:///...)` link MUST use the exact absolute path of the saved file.
-- **NEVER wrap the file path in backticks, code blocks, or any other formatting.** It must be a plain markdown hyperlink so the reader can click it in the chat interface.
-- No other text before or after this block.
+---
+
+Formatting rules — violations will break the user experience:
+1. The report link MUST use `computer://` with the **relative path** from the workspace root (e.g. `[View full report](computer://deep-research/cursor-editor-2026-04-13.md)`). Do NOT use `file://` or absolute paths.
+2. **Do NOT wrap the link in backticks, code fences, or any other markup.** Write it as a plain markdown link.
+3. **Do NOT use `<details>`, `<summary>`, collapsible sections, or HTML tags** of any kind.
+4. **Do NOT include the report content** in this reply — it is already in the file.
+5. Each finding must be a single sentence with at least one concrete detail. "X has grown significantly" is not acceptable.
 
 ---
 

--- a/src/crates/core/src/agentic/agents/prompts/plan_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/plan_mode.md
@@ -44,7 +44,7 @@ At any point in time through this workflow you should feel free to ask the user 
 
 1. When you're done researching, present your plan by calling the CreatePlan tool, which creates a plan file for user approval. Do NOT make any file changes or run any tools that modify the system state in any way.
 
-2. After the CreatePlan tool succeeds, briefly tell the user the plan is ready and wait for user approval. Your final reply in that turn MUST include the exact returned plan file path. Do not continue with more research or additional planning work in the same turn.
+2. After the CreatePlan tool succeeds, briefly tell the user the plan is ready and wait for user approval. Your final reply in that turn MUST include the clickable `computer://` link returned by the tool (e.g. `[plan-name.plan.md](computer://.bitfun/plans/plan-name.plan.md)`). Do NOT output the path as plain text or wrap it in backticks. Do not continue with more research or additional planning work in the same turn.
 
 3. To update the plan, edit the plan file returned by the CreatePlan tool directly.
 

--- a/src/crates/core/src/agentic/tools/implementations/create_plan_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/create_plan_tool.rs
@@ -246,9 +246,26 @@ Additional guidelines:
             vec![]
         };
 
+        // Build a workspace-relative path for the computer:// link so the user can
+        // click it directly in the chat interface. Falls back to the absolute path
+        // for remote workspaces where a relative path cannot be derived.
+        let computer_link = context
+            .workspace_root()
+            .and_then(|root| {
+                std::path::Path::new(&plan_file_path_str)
+                    .strip_prefix(root)
+                    .ok()
+                    .map(|rel| format!("computer://{}", rel.to_string_lossy().replace('\\', "/")))
+            })
+            .unwrap_or_else(|| plan_file_path_str.clone());
+
         let result_for_assistant = format!(
-            "Plan file created at: {}\nYour next reply MUST include this exact plan file path and then end the conversation turn. Do not continue with more planning details or additional questions.",
-            plan_file_path_str
+            "Plan file created. Absolute path: {}\nLink for user: [{}]({})\nYour next reply MUST show the clickable link [{}]({}) and then end the conversation turn. Do not continue with more planning details or additional questions.",
+            plan_file_path_str,
+            plan_file_name,
+            computer_link,
+            plan_file_name,
+            computer_link,
         );
 
         let result = json!({


### PR DESCRIPTION
## Problem

Agents would output file paths as plain text or wrapped in backticks, making them unclickable in the chat interface. This affected:
- Plan files created by the Plan mode (`CreatePlan` tool)
- Research reports generated by the DeepResearch subagent
- Any file an agent creates and then mentions in its reply

## Root Cause

The existing `# Code References` section in `agentic_mode.md` only covered referencing *existing* source files. It had no guidance for files the agent itself creates, so agents defaulted to outputting bare absolute paths or code-block-wrapped paths.

The `CreatePlan` tool's `result_for_assistant` gave the agent a bare absolute path string and said "include this exact path" — guaranteeing the agent would output it as-is.

## Changes

### `agentic_mode.md`
Renamed `# Code References` → `# File References` and added explicit rules for three cases:
- **Workspace source files**: workspace-relative markdown link (existing behavior)
- **Agent/subagent output files**: `computer://` workspace-relative link — e.g. `[report.md](computer://deep-research/report.md)`
- **Files outside workspace**: absolute path as link URL

`computer://` is the BitFun-native file sharing protocol: the frontend remark plugin auto-converts bare `computer://` text to clickable links, so links survive even if a parent agent paraphrases a subagent reply.

### `plan_mode.md`
Require the `computer://` link returned by `CreatePlan` to be used in the reply instead of the raw absolute path.

### `create_plan_tool.rs`
Compute a `computer://` workspace-relative link in `result_for_assistant` and give the agent a ready-to-use markdown link, removing the opportunity for misformatting.

### `deep_research_agent.md`
Switch the report link from `file://` absolute path to `computer://` workspace-relative path, consistent with `cowork_mode.md` convention.

## Test Plan

- [ ] `cargo build -p bitfun-core` passes
- [ ] Plan mode: after `CreatePlan`, the reply contains a clickable `[name.plan.md](computer://.bitfun/plans/...)` link
- [ ] DeepResearch: final reply contains a clickable `[View full report](computer://deep-research/...)` link
- [ ] Agentic mode: when agent creates any file, it links it with `computer://` rather than a bare path