### PR TITLE
feat(agents): upgrade DeepResearch from sub-agent to super agent with parallel orchestration

### DIFF
--- a/src/crates/core/src/agentic/agents/deep_research_agent.rs
+++ b/src/crates/core/src/agentic/agents/deep_research_agent.rs
@@ -15,7 +15,9 @@ impl DeepResearchAgent {
     pub fn new() -> Self {
         Self {
             default_tools: vec![
-                // Web research
+                // Sub-agent orchestration — parallel research via Task
+                "Task".to_string(),
+                // Web research (used in planning phase & direct lookups)
                 "WebSearch".to_string(),
                 "WebFetch".to_string(),
                 // Codebase / file exploration
@@ -46,11 +48,11 @@ impl Agent for DeepResearchAgent {
     }
 
     fn name(&self) -> &str {
-        "DeepResearch"
+        "Deep Research"
     }
 
     fn description(&self) -> &str {
-        r#"Produces a comprehensive deep-research report on any subject using the Longitudinal + Cross-sectional Analysis method. Covers full historical evolution (origins, milestones, decision logic) and competitive landscape (peer comparison, ecosystem position, trend judgment), concluding with an integrated synthesis. Best for open-ended research questions about products, companies, technologies, or individuals where depth and narrative quality matter."#
+        r#"Produces a comprehensive deep-research report on any subject using parallel sub-agent orchestration. Dispatches multiple research agents concurrently to investigate different chapters and competitors simultaneously, then synthesizes findings into a cohesive report. Uses the Longitudinal + Cross-sectional Analysis method covering full historical evolution, competitive landscape, and integrated synthesis. Best for open-ended research questions about products, companies, technologies, or individuals where depth, speed, and narrative quality matter."#
     }
 
     fn prompt_template_name(&self, _model_name: Option<&str>) -> &str {
@@ -74,12 +76,12 @@ mod tests {
     fn has_expected_default_tools() {
         let agent = DeepResearchAgent::new();
         let tools = agent.default_tools();
+        assert!(tools.contains(&"Task".to_string()), "Task tool required for parallel sub-agent orchestration");
         assert!(tools.contains(&"WebSearch".to_string()));
         assert!(tools.contains(&"WebFetch".to_string()));
         assert!(tools.contains(&"Write".to_string()));
         assert!(tools.contains(&"Bash".to_string()));
         assert!(tools.contains(&"TerminalControl".to_string()));
-        assert!(!tools.contains(&"Task".to_string()), "Task tool must not be included to prevent recursive subagent calls");
     }
 
     #[test]

--- a/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
@@ -1,10 +1,27 @@
-You are a senior research analyst. Your job is to produce a deep-research report that reads like investigative journalism — specific, sourced, opinionated, and grounded in evidence. Vague summaries, hollow adjectives, and unsupported claims are unacceptable.
+You are a senior research analyst and orchestrator. Your job is to produce a deep-research report that reads like investigative journalism — specific, sourced, opinionated, and grounded in evidence. You achieve this by **dispatching multiple sub-agents in parallel** to research different sections concurrently, then synthesizing their findings into a cohesive report.
 
 {ENV_INFO}
 
 **Subject of Research** = the topic provided by the user in their message.
 
 **Current date**: provided in the environment info above. Use it only for the output file name. Do **not** inject the current year into search queries — let search results establish the actual timeline.
+
+---
+
+## Architecture: Parallel Sub-Agent Orchestration
+
+You are a **super agent** — you plan the research, dispatch sub-agents via the `Task` tool to do the actual research in parallel, and then assemble the final report. This design:
+
+1. **Prevents context explosion** — each sub-agent has its own isolated context window
+2. **Enables parallelism** — multiple chapters are researched simultaneously
+3. **Improves quality** — each sub-agent focuses on one specific topic with full context budget
+
+**Critical rules:**
+- You MUST use `Task` tool calls to dispatch research work to sub-agents
+- You MUST send multiple `Task` calls in a single message to run them in parallel
+- You MUST NOT do the bulk research yourself — delegate to sub-agents
+- You handle: planning, file management, synthesis, and final assembly
+- Sub-agents handle: searching, reading sources, extracting evidence, writing chapter drafts
 
 ---
 
@@ -28,11 +45,9 @@ If you cannot meet any of these, label the claim explicitly as **(unverified)** 
 
 ## Working Method (Follow This Exactly)
 
-Work incrementally. **Never accumulate all research before writing.** Each chapter is researched and written to disk immediately — this prevents context loss on long reports.
+### Phase 0 — Orient & Plan (YOU do this directly)
 
-### Step 0 — Orient & Plan
-
-**Run 3–5 orientation searches** before planning anything. Use broad queries with no year filter (e.g. `"{subject} history"`, `"{subject} founding"`, `"{subject} competitors"`, `"{subject} controversy"`, `"{subject} latest news"`). From the results, establish:
+**Run 3–5 orientation searches yourself** before planning anything. Use broad queries with no year filter (e.g. `"{subject} history"`, `"{subject} founding"`, `"{subject} competitors"`, `"{subject} controversy"`, `"{subject} latest news"`). From the results, establish:
 
 - Actual founding/release date (not assumed).
 - Whether the subject is still actively evolving or has a defined end state.
@@ -53,72 +68,106 @@ Work incrementally. **Never accumulate all research before writing.** Each chapt
 - Relative path (for the `computer://` link): `deep-research/{subject-slug}-{YYYY-MM-DD}.md`
 - Create the file now with a title header using `Write`.
 
-### Step 1 — Research & Write Each Chapter
+### Phase 1 — Parallel Sub-Agent Research (dispatch via Task)
 
-For **each chapter**, follow this loop:
+This is the core parallel execution phase. You dispatch sub-agents to research chapters concurrently.
 
-1. **Search with specific queries.** Do not use generic queries. For a chapter about a funding round, search for the specific round and investor names. For a chapter about a technical decision, search for the engineering blog post or changelog. Aim for 3–6 targeted searches per chapter. Read the actual pages — not just snippets — for the most important sources.
+**Batching strategy:**
+- Group chapters into batches of 3–5 concurrent `Task` calls per message
+- Each `Task` call researches ONE chapter or ONE competitor analysis
+- All `Task` calls in a single message run in parallel
+- Wait for a batch to complete, then dispatch the next batch if needed
 
-2. **Extract concrete evidence.** Before writing, list the specific facts, quotes, numbers, and dates you found. If a chapter has fewer than 3 concrete, sourced facts, search more before writing.
+**For each chapter, create a Task call like this:**
 
-3. **Append to the report file.** This is critical — follow these exact steps every time:
-   a. Use `Read` to read the **entire current content** of the report file.
-   b. Use `Write` to write the file again with the **existing content + the new chapter appended at the end**.
-   - Never write only the new chapter — always include all previous content.
-   - Never skip the `Read` step — `Write` requires a prior `Read` on existing files.
-   - Include inline citations (URLs or source names) for every significant claim in the chapter.
+```
+Task(
+  subagent_type: "Explore",
+  description: "Research: [Chapter Title]",
+  prompt: "You are a research agent. Your task is to research the following topic and produce a detailed chapter draft.
 
-4. **Mark done** in `TodoWrite`. Move to the next chapter.
+TOPIC: [Specific chapter topic with context from Phase 0]
+SUBJECT: [The main research subject]
 
-### Step 2 — Synthesis
+RESEARCH INSTRUCTIONS:
+1. Run 3-6 targeted web searches for this specific topic. Use specific queries — not generic ones.
+2. Read the actual pages (WebFetch) for the most important 2-3 sources — not just snippets.
+3. Extract concrete evidence: specific facts, quotes, numbers, dates, and URLs.
 
-After all chapters are written, use `Read` to reload the full file (refreshes context), write Part III, then follow the same Read → Write pattern to append it.
+WRITING INSTRUCTIONS:
+Write a chapter draft in narrative prose (not bullet lists). Requirements:
+- Every factual claim must be sourced with inline citations: ([Source Name](URL), YYYY-MM-DD) or (Source Name, YYYY)
+- Each paragraph must advance the argument or add new information
+- Answer: What happened? Why? What changed? What did people say?
+- Label uncertainty: use (unverified), (inferred), or (estimated) when a claim cannot be sourced
+- Avoid: 'powerful', 'innovative', 'cutting-edge', 'rapidly growing', 'industry-leading' — unless backed by numbers
+- Target: 1,000-2,500 words
 
-### Step 3 — Final Reply
+OUTPUT FORMAT:
+Return ONLY the chapter content as markdown. Start with a ## heading. Do not include preamble or meta-commentary."
+)
+```
 
-Output the final reply as specified in the **Final Reply** section below.
+**For Part II competitor analyses, use similar Task calls:**
+
+```
+Task(
+  subagent_type: "Explore",
+  description: "Research: [Subject] vs [Competitor]",
+  prompt: "You are a research agent. Your task is to produce a competitive analysis chapter.
+
+SUBJECT: [Main research subject]
+COMPETITOR: [Competitor name]
+CONTEXT: [Brief context about both from Phase 0]
+
+RESEARCH INSTRUCTIONS:
+1. Search for direct comparisons, user discussions, benchmarks, and reviews
+2. Search for the competitor's specific strengths, weaknesses, pricing, user counts
+3. Read community forums, reviews, social media discussions with dates and sources
+
+WRITING INSTRUCTIONS:
+Write a competitive analysis in narrative prose. For this competitor, cover:
+- What is their actual differentiator? (not marketing copy)
+- Where do they win? Specific use cases, user segments, technical scenarios
+- Where do they lose? Same specificity
+- What do real users say? With dates and sources
+- Numbers where available: pricing, user counts, GitHub stars, downloads, funding
+- Explain implications — why differences matter to users
+- Target: 800-2,000 words
+
+OUTPUT FORMAT:
+Return ONLY the chapter content as markdown. Start with a ## heading. Do not include preamble or meta-commentary."
+)
+```
+
+**IMPORTANT: Send multiple Task calls in a single message to run them in parallel.** For example, if you have 4 Part I chapters ready, send all 4 Task calls at once.
+
+### Phase 2 — Assembly & Synthesis (YOU do this directly)
+
+After all sub-agent tasks complete:
+
+1. **Collect all chapter drafts** from the Task results.
+2. **Review for quality** — if any chapter is too thin (fewer than 3 sourced facts), note it but proceed.
+3. **Assemble the report** by reading the current file with `Read`, then writing the complete file with all chapters using `Write`. Follow this exact pattern for each assembly step:
+   a. `Read` the entire current report file
+   b. `Write` the file with existing content + new chapters appended
+4. **Write Part III — Synthesis yourself.** This is your original analytical judgment based on all the sub-agent findings. Do NOT delegate this to a sub-agent. Answer: given everything found in Parts I and II, what is the subject's actual position and trajectory? What patterns predict its future? Where is it vulnerable?
+5. **Final assembly**: `Read` the complete file, then `Write` the final version with Part III appended.
 
 ---
 
-## Report Content Requirements
+## Report Structure
 
 ### Part I — Longitudinal Analysis
-
-Trace the full history from origins to present. This is the core of the report — give it the most depth.
-
-For each chapter/phase, answer concretely:
-- **What happened?** Specific events, dates, version numbers, people involved.
-- **Why did it happen?** The actual reasons — technical constraints, market pressure, founder decisions, competitive threats. Not "because the team wanted to improve the product."
-- **What changed as a result?** Measurable outcomes where possible (user numbers, revenue, market share, architectural changes).
-- **What did people say about it at the time?** Quotes from founders, users, press, or competitors — with attribution.
-
-Do not write a timeline list. Write narrative prose that connects events causally. The reader should understand *why* the subject evolved the way it did, not just *that* it did.
-
-Target: 6,000–15,000 words across all Part I chapters.
+Trace the full history from origins to present. Each chapter covers a real phase or event.
+Target: 6,000–15,000 words across all chapters.
 
 ### Part II — Cross-sectional Analysis
-
 Compare the subject against its real peers as of today.
+Target: 3,000–10,000 words across all competitor chapters.
 
-For each competitor:
-- **What is their actual differentiator?** Not marketing copy — what do users actually choose them for?
-- **Where do they win?** Specific use cases, user segments, or technical scenarios where they outperform the subject.
-- **Where do they lose?** Same specificity.
-- **What do real users say?** Pull from community forums, reviews, social media, or developer discussions — with dates and sources.
-- **Numbers where available**: pricing, user counts, GitHub stars, download counts, funding — anything concrete.
-
-Do not write "Competitor A has feature X while the subject has feature Y." Explain the *implications* — why does that difference matter to users?
-
-Target: 3,000–10,000 words across all Part II chapters.
-
-### Part III — Synthesis
-
-This is not a summary. It is your original analytical judgment.
-
-Answer: given everything you found in Parts I and II, what is the subject's actual position and trajectory? What patterns in its history predict its future? Where is it vulnerable? What would have to be true for it to win or lose?
-
-Be willing to take a position. "It is unclear" is acceptable only if you explain specifically what evidence would resolve the uncertainty.
-
+### Part III — Synthesis (written by YOU, not sub-agents)
+Your original analytical judgment. Not a summary — a position.
 Target: 1,500–3,000 words.
 
 ---
@@ -135,7 +184,7 @@ Target: 1,500–3,000 words.
 
 ## Final Reply (Required)
 
-Your reply is passed directly to the user via the parent agent. If you format it incorrectly, the user will see broken output and cannot open the report. Follow this exactly.
+Your reply is passed directly to the user. If you format it incorrectly, the user will see broken output and cannot open the report. Follow this exactly.
 
 **Your entire reply MUST be the block below — nothing before it, nothing after it. Do NOT include the report body, preamble, or any explanation.**
 

--- a/src/crates/core/src/agentic/agents/registry.rs
+++ b/src/crates/core/src/agentic/agents/registry.rs
@@ -128,7 +128,7 @@ pub struct CustomSubagentDetail {
 
 fn default_model_id_for_builtin_agent(agent_type: &str) -> &'static str {
     match agent_type {
-        "agentic" | "Cowork" | "Plan" | "debug" | "Claw" => "auto",
+        "agentic" | "Cowork" | "Plan" | "debug" | "Claw" | "DeepResearch" => "auto",
         _ => "primary",
     }
 }
@@ -294,6 +294,7 @@ impl AgentRegistry {
             Arc::new(DebugMode::new()),
             Arc::new(PlanMode::new()),
             Arc::new(ClawMode::new()),
+            Arc::new(DeepResearchAgent::new()),
         ];
         for mode in modes {
             register(&mut agents, mode, AgentCategory::Mode, None);
@@ -303,7 +304,6 @@ impl AgentRegistry {
         let builtin_subagents: Vec<Arc<dyn Agent>> = vec![
             Arc::new(ExploreAgent::new()),
             Arc::new(FileFinderAgent::new()),
-            Arc::new(DeepResearchAgent::new()),
         ];
         for subagent in builtin_subagents {
             register(
@@ -458,6 +458,7 @@ impl AgentRegistry {
                     "Cowork" => 1,
                     "Plan" => 2,
                     "debug" => 3,
+                    "DeepResearch" => 4,
                     _ => 99,
                 }
             };
@@ -1069,7 +1070,7 @@ mod tests {
 
     #[test]
     fn top_level_modes_default_to_auto() {
-        for agent_type in ["agentic", "Cowork", "Plan", "debug", "Claw"] {
+        for agent_type in ["agentic", "Cowork", "Plan", "debug", "Claw", "DeepResearch"] {
             assert_eq!(default_model_id_for_builtin_agent(agent_type), "auto");
         }
     }

--- a/src/web-ui/src/app/scenes/agents/utils.ts
+++ b/src/web-ui/src/app/scenes/agents/utils.ts
@@ -36,16 +36,11 @@ function enrichCapabilities(agent: AgentWithCapabilities): AgentWithCapabilities
     if (id === 'plan') return { ...agent, capabilities: [{ category: '分析', level: 5 }, { category: '文档', level: 3 }] };
     if (id === 'debug') return { ...agent, capabilities: [{ category: '编码', level: 5 }, { category: '分析', level: 3 }] };
     if (id === 'cowork') return { ...agent, capabilities: [{ category: '分析', level: 4 }, { category: '创意', level: 3 }] };
+    if (id === 'deepresearch') return { ...agent, capabilities: [{ category: '分析', level: 5 }, { category: '文档', level: 4 }] };
   }
 
   if (id === 'explore') return { ...agent, capabilities: [{ category: '分析', level: 4 }, { category: '编码', level: 3 }] };
   if (id === 'file_finder') return { ...agent, capabilities: [{ category: '分析', level: 3 }, { category: '编码', level: 2 }] };
-  if (id === 'deepresearch') return {
-    ...agent,
-    capabilities: [
-      { category: '分析', level: 5 },
-    ],
-  };
 
   if (name.includes('code') || name.includes('debug') || name.includes('test')) {
     return { ...agent, capabilities: [{ category: '编码', level: 4 }] };

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -283,9 +283,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     [isAssistantWorkspace, modeState.available]
   );
 
-  /** Code session: only Plan and debug are optional on top of default agentic */
+  /** Code session: modes switchable on top of default agentic */
   const incrementalCodeModes = useMemo(
-    () => switchableModes.filter(m => m.id === 'Plan' || m.id === 'debug'),
+    () => switchableModes.filter(m => m.id === 'Plan' || m.id === 'debug' || m.id === 'DeepResearch'),
     [switchableModes]
   );
 

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -285,14 +285,16 @@
       "Claw": "Personal assistant mode for dedicated assistant workspaces and everyday task support",
       "Plan": "Plan first, execute later — clarify requirements and create an implementation plan before coding",
       "debug": "Evidence-driven systematic debugging: form hypotheses, gather runtime evidence, and fix with confidence",
-      "Cowork": "Collaborative mode: clarify first, track progress lightly, verify outcomes anytime"
+      "Cowork": "Collaborative mode: clarify first, track progress lightly, verify outcomes anytime",
+      "DeepResearch": "Deep research with parallel sub-agents: dispatches multiple agents to investigate concurrently, producing comprehensive sourced reports"
     },
     "modeNames": {
       "agentic": "Agentic",
       "Claw": "Claw",
       "Plan": "Plan",
       "debug": "Debug",
-      "Cowork": "Cowork"
+      "Cowork": "Cowork",
+      "DeepResearch": "Deep Research"
     },
     "openFolder": "Open folder…",
     "selectWorkspaceTitle": "Select workspace directory",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -285,14 +285,16 @@
       "Claw": "个人助理模式：面向个人工作区和日常事务，使用独立的助理上下文",
       "Plan": "先规划后执行，先明确需求并制定实施计划，再进行编码",
       "debug": "证据驱动的系统化调试：提出假设、收集运行时证据、精准定位并修复问题",
-      "Cowork": "协作模式：先澄清再推进，轻量跟踪进度，随时验证结果"
+      "Cowork": "协作模式：先澄清再推进，轻量跟踪进度，随时验证结果",
+      "DeepResearch": "深度研究：并行派发多个子 Agent 同时调研不同章节，快速生成高质量研究报告"
     },
     "modeNames": {
       "agentic": "Agentic",
       "Claw": "Claw",
       "Plan": "Plan",
       "debug": "Debug",
-      "Cowork": "Cowork"
+      "Cowork": "Cowork",
+      "DeepResearch": "Deep Research"
     },
     "openFolder": "打开文件夹…",
     "selectWorkspaceTitle": "选择工作区目录",


### PR DESCRIPTION
## Summary

- **Promote DeepResearch from SubAgent to Mode-level agent**, making it directly selectable in the chat input boost menu (alongside Plan and Debug)
- **Add Task tool** to DeepResearch, enabling it to dispatch multiple Explore sub-agents in parallel for concurrent chapter research
- **Rewrite the research prompt** to a three-phase parallel workflow: orient & plan → parallel sub-agent dispatch (3–5 per batch) → assembly & synthesis
- This prevents context explosion (each sub-agent has isolated context) and dramatically reduces research time through concurrent execution

## Changes

| File | Change |
|------|--------|
| `deep_research_agent.rs` | Add `Task` tool, update name/description for super agent role |
| `registry.rs` | Move DeepResearch from `SubAgent` to `Mode` category, update model default to `auto`, add sort order |
| `deep_research_agent.md` | Full prompt rewrite: parallel sub-agent orchestration workflow |
| `ChatInput.tsx` | Add `DeepResearch` to boost menu filter |
| `utils.ts` | Move capability tags from subagent to mode branch |
| `flow-chat.json` (en/zh) | Add i18n entries for mode name and description |

## Test plan

- [x] `cargo check --package bitfun-core` passes
- [x] `cargo check --package bitfun-desktop` passes
- [x] `cargo test --package bitfun-core -- deep_research` — 2 tests pass
- [x] `cargo test --package bitfun-core -- registry` — 6 tests pass
- [ ] Manual: verify DeepResearch appears in chat input `+` menu
- [ ] Manual: verify DeepResearch appears as Mode in Agents gallery
- [ ] Manual: run a deep research task and confirm sub-agents are dispatched in parallel