### PR TITLE
fix(flow-chat): polish AgentDispatchCard layout and create header

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/AgentDispatchCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentDispatchCard.scss
@@ -3,71 +3,80 @@
 .agent-dispatch-card {
   cursor: pointer;
 
-  /* Let left/right divider lines span the full header row (no vertical gap vs card padding) */
-  &.base-tool-card-wrapper .base-tool-card-header {
-    padding-top: 0;
-    padding-bottom: 0;
-  }
-
-  /* Header layout — mirrors TaskToolDisplay */
+  /* Header layout — matches TaskToolDisplay / BaseToolCard standard */
   .agent-dispatch-header-wrapper {
     display: flex;
-    /* Stretch all columns to the same height so left/right dividers run the full header row */
     align-items: stretch;
-    gap: 8px;
+    gap: 4px;
     width: 100%;
-    min-height: 24px;
   }
 
-  /* Left icon column with a right separator line */
+  /* Left icon column — same as .tool-card-icon-slot */
   .agent-dispatch-icon-col {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
     align-self: stretch;
     padding-right: 10px;
-    margin-right: 4px;
-    position: relative;
+    margin-right: 8px;
+    box-sizing: border-box;
+    min-height: 0;
 
     &::after {
       content: '';
       position: absolute;
       right: 0;
-      top: 0;
-      bottom: 0;
+      top: calc(-1 * var(--tool-card-header-pad-y, 10px));
+      bottom: calc(-1 * var(--tool-card-header-pad-y, 10px));
       width: 0;
       border-right: 1px solid var(--border-base);
       pointer-events: none;
+      z-index: 0;
+    }
+
+    .agent-dispatch-icon-marks {
+      position: relative;
+      z-index: 1;
+      width: var(--tool-card-header-icon-rail, 28px);
+      height: var(--tool-card-header-icon-rail, 28px);
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .agent-dispatch-icon {
-      width: 22px;
-      height: 22px;
+      width: 20px;
+      height: 20px;
       flex-shrink: 0;
-      color: var(--border-base);
+      color: var(--color-text-secondary, #6b7280);
     }
   }
 
-  /* Main content area — vertical padding lives here so icon/rail borders run edge-to-edge */
+  /* Main content area */
   .agent-dispatch-body {
     display: flex;
-    flex-direction: column;
-    justify-content: center;
+    flex-direction: row;
+    align-items: center;
+    align-self: stretch;
+    justify-content: flex-start;
     flex: 1;
     min-width: 0;
-    min-height: 0;
-    gap: 2px;
-    padding-top: var(--tool-card-header-pad-y, 10px);
-    padding-bottom: var(--tool-card-header-pad-y, 10px);
-    box-sizing: border-box;
+    gap: 6px;
   }
 
-  .agent-dispatch-header-main {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    min-height: 20px;
+  .agent-dispatch-body-path {
+    font-size: 11px;
+    color: var(--color-text-muted, #9ca3af);
+    font-family: var(--tool-card-font-mono, monospace);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1 1 0;
+    min-width: 0;
+    text-align: right;
   }
 
   .agent-dispatch-label {
@@ -81,41 +90,45 @@
     min-width: 0;
   }
 
-  /* Sub-line workspace hint */
-  .agent-dispatch-workspace-hint {
-    font-size: 11px;
-    color: var(--color-text-muted, #9ca3af);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
   /* Agent type badge — colored by agent */
   .agent-dispatch-badge {
     display: inline-flex;
     align-items: center;
-    padding: 1px 6px;
+    padding: 2px 6px;
     border-radius: 4px;
     font-size: 10px;
-    font-weight: 600;
+    font-weight: 500;
     flex-shrink: 0;
-    letter-spacing: 0.03em;
+    letter-spacing: 0.02em;
     color: var(--agent-badge-color, #6366f1);
     background: color-mix(in srgb, var(--agent-badge-color, #6366f1) 14%, transparent);
     border: 1px solid color-mix(in srgb, var(--agent-badge-color, #6366f1) 28%, transparent);
   }
 
-  /* Right rail — border spans full row height (parent align-items: stretch) */
+  /* Right rail — border extends to card edges via ::after negative offsets, same as icon col */
   .agent-dispatch-rail {
+    position: relative;
     display: flex;
     align-items: center;
-    gap: 4px;
-    flex-shrink: 0;
+    justify-content: center;
     align-self: stretch;
+    flex-shrink: 0;
+    min-width: 40px;
     margin-left: 4px;
     padding-left: 8px;
-    border-left: 1px solid var(--border-base);
-    justify-content: center;
+    gap: 4px;
+
+    &::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: calc(-1 * var(--tool-card-header-pad-y, 10px));
+      bottom: calc(-1 * var(--tool-card-header-pad-y, 10px));
+      width: 0;
+      border-left: 1px solid var(--border-base);
+      pointer-events: none;
+      z-index: 1;
+    }
   }
 
   /* DotMatrixLoader — matches ProcessingIndicator / TaskDetailPanel */
@@ -185,8 +198,10 @@
 
   .agent-dispatch-workspace-item {
     display: flex;
-    flex-direction: column;
-    gap: 2px;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
     padding: 8px 10px;
     border-radius: 6px;
     background: var(--color-bg-subtle, rgba(255, 255, 255, 0.04));
@@ -202,12 +217,19 @@
     display: flex;
     align-items: center;
     gap: 6px;
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: 36%;
   }
 
   .agent-dispatch-workspace-name {
     font-size: 12px;
     font-weight: 500;
     color: var(--color-text-primary);
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /* "Global" tag shown for assistant workspaces */
@@ -232,11 +254,20 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    flex: 1 1 0;
+    min-width: 0;
+    text-align: right;
   }
 
   .agent-dispatch-workspace-count {
     font-size: 11px;
     color: var(--color-text-secondary, #6b7280);
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
+  .agent-dispatch-workspace-item--no-path .agent-dispatch-workspace-count {
+    margin-left: auto;
   }
 
   /* Session list (action=status) */
@@ -271,6 +302,19 @@
     gap: 6px;
     flex: 1;
     min-width: 0;
+  }
+
+  .agent-dispatch-session-path {
+    font-size: 11px;
+    color: var(--color-text-muted, #9ca3af);
+    font-family: var(--tool-card-font-mono, monospace);
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: min(48%, 280px);
+    text-align: right;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .agent-dispatch-session-item-rail {

--- a/src/web-ui/src/flow_chat/tool-cards/AgentDispatchCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentDispatchCard.tsx
@@ -149,10 +149,10 @@ export const AgentDispatchCard: React.FC<ToolCardProps> = React.memo(
             </span>
           );
         case 'completed':
-          return <Check size={13} className="agent-dispatch-status-icon agent-dispatch-status-icon--done" />;
+          return <Check size={14} className="agent-dispatch-status-icon agent-dispatch-status-icon--done" />;
         case 'error':
         case 'cancelled':
-          return <X size={13} className="agent-dispatch-status-icon agent-dispatch-status-icon--error" />;
+          return <X size={14} className="agent-dispatch-status-icon agent-dispatch-status-icon--error" />;
         default:
           return null;
       }
@@ -190,18 +190,16 @@ export const AgentDispatchCard: React.FC<ToolCardProps> = React.memo(
         }
         return t('toolCards.agentDispatch.checkingStatus');
       }
-      // create
-      const label = sessionName || agentType || t('toolCards.agentDispatch.agent');
-      if (status === 'completed') {
-        return t('toolCards.agentDispatch.createdAgent', { agent: label });
-      }
-      if (status === 'running' || status === 'streaming') {
-        return t('toolCards.agentDispatch.creatingAgent', { agent: label });
-      }
+      // create — format mirrors TaskToolDisplay: "AgentType 智能体：SessionName"
+      const agentTypeLabel = agentType || t('toolCards.agentDispatch.agent');
+      const sessionLabel = sessionName || t('toolCards.agentDispatch.agent');
       if (status === 'error' || status === 'cancelled') {
         return t('toolCards.agentDispatch.actionFailed');
       }
-      return t('toolCards.agentDispatch.preparingCreate', { agent: label });
+      return t('toolCards.agentDispatch.headerLine', {
+        agentType: agentTypeLabel,
+        session: sessionLabel,
+      });
     }, [action, agentType, resultData, sessionName, status, t]);
 
     // Jump to the created session when the card is clicked (create action, completed)
@@ -249,14 +247,21 @@ export const AgentDispatchCard: React.FC<ToolCardProps> = React.memo(
         return (
           <div className="agent-dispatch-workspace-list">
             {workspaces.map((ws, i) => (
-              <div key={i} className={`agent-dispatch-workspace-item${ws.kind === 'global' ? ' agent-dispatch-workspace-item--global' : ''}`}>
+              <div
+                key={i}
+                className={`agent-dispatch-workspace-item${ws.kind === 'global' ? ' agent-dispatch-workspace-item--global' : ''}${!ws.path ? ' agent-dispatch-workspace-item--no-path' : ''}`}
+              >
                 <div className="agent-dispatch-workspace-header">
                   <span className="agent-dispatch-workspace-name">{ws.name ?? ws.path}</span>
                   {ws.kind === 'global' && (
                     <span className="agent-dispatch-global-tag">{t('toolCards.agentDispatch.globalTag')}</span>
                   )}
                 </div>
-                <span className="agent-dispatch-workspace-path">{ws.path}</span>
+                {ws.path ? (
+                  <span className="agent-dispatch-workspace-path" title={ws.path}>
+                    {ws.path}
+                  </span>
+                ) : null}
                 <span className="agent-dispatch-workspace-count">
                   {t('toolCards.agentDispatch.sessionCount', { count: ws.session_count ?? 0 })}
                 </span>
@@ -284,6 +289,11 @@ export const AgentDispatchCard: React.FC<ToolCardProps> = React.memo(
                     <span className="agent-dispatch-session-name">{s.session_name ?? s.session_id}</span>
                     {s.agent_type && <AgentBadge agentType={s.agent_type} />}
                   </div>
+                  {s.workspace ? (
+                    <span className="agent-dispatch-session-path" title={s.workspace}>
+                      {s.workspace}
+                    </span>
+                  ) : null}
                   <div className="agent-dispatch-session-item-rail">
                     {sid ? (
                       isRunning ? (
@@ -322,25 +332,22 @@ export const AgentDispatchCard: React.FC<ToolCardProps> = React.memo(
       <div className="agent-dispatch-header-wrapper">
         {/* Left icon column */}
         <div className="agent-dispatch-icon-col">
-          <Bot size={22} className="agent-dispatch-icon" />
+          <div className="agent-dispatch-icon-marks">
+            <Bot className="agent-dispatch-icon" />
+          </div>
         </div>
 
         {/* Main content */}
         <div className="agent-dispatch-body">
-          <div className="agent-dispatch-header-main">
-            <span className="agent-dispatch-label">{headerLine}</span>
-            {agentType && action === 'create' && <AgentBadge agentType={agentType} />}
-          </div>
+          <span className="agent-dispatch-label">{headerLine}</span>
           {workspace && action === 'create' && (
-            <div className="agent-dispatch-workspace-hint">
-              {workspace === 'global'
-                ? <span className="agent-dispatch-global-tag">{t('toolCards.agentDispatch.globalTag')}</span>
-                : workspace}
-            </div>
+            workspace === 'global'
+              ? <span className="agent-dispatch-global-tag agent-dispatch-global-tag--body">{t('toolCards.agentDispatch.globalTag')}</span>
+              : <span className="agent-dispatch-body-path" title={workspace}>{workspace}</span>
           )}
         </div>
 
-        {/* Right rail: status (whole card click navigates when create completed) */}
+        {/* Right rail: status icon only */}
         <div className="agent-dispatch-rail">
           {headerRailIcon}
         </div>

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -406,6 +406,7 @@
       "title": "Agent Dispatch",
       "agent": "Agent",
       "agentBadge": "Agent",
+      "headerLine": "{{agentType}} agent: {{session}}",
       "preparingCreate": "Preparing to create {{agent}}",
       "creatingAgent": "Creating {{agent}}...",
       "createdAgent": "Created {{agent}}",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -398,6 +398,7 @@
       "title": "Agent 调度",
       "agent": "Agent",
       "agentBadge": "Agent",
+      "headerLine": "{{agentType}} 智能体：{{session}}",
       "preparingCreate": "准备创建 {{agent}}",
       "creatingAgent": "正在创建 {{agent}}...",
       "createdAgent": "已创建 {{agent}}",


### PR DESCRIPTION
## Summary
Polishes the Agent Dispatch tool card in flow chat: create-action header text now follows the same pattern as TaskToolDisplay (agent type + session via \headerLine\ i18n). Workspace list and session rows show paths where helpful; empty workspace paths are omitted. Minor SCSS and status icon sizing updates.

## Changes
- \AgentDispatchCard.tsx\: header line for create action, workspace/session path display, icon size
- \AgentDispatchCard.scss\: layout and styling for new states
- \low-chat.json\ (en-US, zh-CN): \headerLine\ strings for agent dispatch

## Testing
- [ ] Manual: open flow chat with agent dispatch tool results and verify copy and layout