### PR TITLE
refactor: migrate workspace runtime layout and path handling

### DIFF
--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -2,13 +2,19 @@
 
 use crate::api::app_state::AppState;
 use crate::api::dto::WorkspaceInfoDto;
+use crate::api::path_target::{
+    create_directory as create_desktop_directory, create_empty_file,
+    delete_directory as delete_desktop_directory, delete_file as delete_desktop_file,
+    get_path_metadata, path_exists, read_text_file, rename_path, resolve_desktop_path_target,
+    write_text_file, DesktopPathTarget,
+};
 use bitfun_core::infrastructure::{
-    BatchedFileSearchProgressSink, FileOperationOptions, FileSearchResult, FileSearchResultGroup,
-    FileTreeNode, SearchMatchType,
+    BatchedFileSearchProgressSink, FileSearchResult, FileSearchResultGroup, FileTreeNode,
+    SearchMatchType,
 };
 use bitfun_core::service::file_watch;
+use bitfun_core::service::remote_ssh::get_remote_workspace_manager;
 use bitfun_core::service::remote_ssh::workspace_state::is_remote_path;
-use bitfun_core::service::remote_ssh::{get_remote_workspace_manager, RemoteWorkspaceEntry};
 use bitfun_core::service::workspace::{
     ScanOptions, WorkspaceInfo, WorkspaceKind, WorkspaceOpenOptions,
 };
@@ -46,22 +52,6 @@ fn remote_workspace_from_info(info: &WorkspaceInfo) -> Option<crate::api::Remote
         connection_name: name,
         ssh_host,
     })
-}
-
-/// Resolves which SSH connection owns `path`. `request_preferred` comes from the workspace/session
-/// (explicit scoping); legacy UI omits it and we fall back to the last single-remote pointer.
-async fn lookup_remote_entry_for_path(
-    state: &State<'_, AppState>,
-    path: &str,
-    request_preferred: Option<&str>,
-) -> Option<RemoteWorkspaceEntry> {
-    let manager = get_remote_workspace_manager()?;
-    let legacy = state
-        .get_remote_workspace_async()
-        .await
-        .map(|w| w.connection_id);
-    let preferred: Option<String> = request_preferred.map(|s| s.to_string()).or(legacy);
-    manager.lookup_connection(path, preferred.as_deref()).await
 }
 
 fn lock_active_searches<'a>(
@@ -1912,34 +1902,12 @@ pub async fn read_file_content(
     state: State<'_, AppState>,
     request: ReadFileContentRequest,
 ) -> Result<String, String> {
-    if let Some(entry) = lookup_remote_entry_for_path(
+    read_text_file(
         &state,
         &request.file_path,
         request.remote_connection_id.as_deref(),
     )
     .await
-    {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-        let bytes = remote_fs
-            .read_file(&entry.connection_id, &request.file_path)
-            .await
-            .map_err(|e| format!("Failed to read remote file: {}", e))?;
-        return String::from_utf8(bytes).map_err(|e| format!("File is not valid UTF-8: {}", e));
-    }
-
-    match state.filesystem_service.read_file(&request.file_path).await {
-        Ok(result) => Ok(result.content),
-        Err(e) => {
-            error!(
-                "Failed to read file content: path={}, error={}",
-                request.file_path, e
-            );
-            Err(format!("Failed to read file content: {}", e))
-        }
-    }
 }
 
 #[tauri::command]
@@ -1947,45 +1915,13 @@ pub async fn write_file_content(
     state: State<'_, AppState>,
     request: WriteFileContentRequest,
 ) -> Result<(), String> {
-    if let Some(entry) = lookup_remote_entry_for_path(
+    write_text_file(
         &state,
         &request.file_path,
+        &request.content,
         request.remote_connection_id.as_deref(),
     )
     .await
-    {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-        remote_fs
-            .write_file(
-                &entry.connection_id,
-                &request.file_path,
-                request.content.as_bytes(),
-            )
-            .await
-            .map_err(|e| format!("Failed to write remote file: {}", e))?;
-        return Ok(());
-    }
-
-    let full_path = request.file_path;
-    let options = FileOperationOptions {
-        backup_on_overwrite: false,
-        ..FileOperationOptions::default()
-    };
-
-    match state
-        .filesystem_service
-        .write_file_with_options(&full_path, &request.content, options)
-        .await
-    {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            error!("Failed to write file: path={}, error={}", full_path, e);
-            Err(format!("Failed to write file {}, error: {}", full_path, e))
-        }
-    }
 }
 
 #[tauri::command]
@@ -2028,19 +1964,7 @@ pub async fn check_path_exists(
     state: State<'_, AppState>,
     request: CheckPathExistsRequest,
 ) -> Result<bool, String> {
-    if let Some(entry) = lookup_remote_entry_for_path(&state, &request.path, None).await {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-        return remote_fs
-            .exists(&entry.connection_id, &request.path)
-            .await
-            .map_err(|e| format!("Failed to check remote path: {}", e));
-    }
-
-    let path = std::path::Path::new(&request.path);
-    Ok(path.exists())
+    path_exists(&state, &request.path).await
 }
 
 #[tauri::command]
@@ -2048,71 +1972,7 @@ pub async fn get_file_metadata(
     state: State<'_, AppState>,
     request: GetFileMetadataRequest,
 ) -> Result<serde_json::Value, String> {
-    use std::time::SystemTime;
-
-    if let Some(entry) = lookup_remote_entry_for_path(&state, &request.path, None).await {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-
-        // Use SFTP stat for stable mtime/size. Returning `SystemTime::now()` as `modified` caused
-        // the editor's 5s poll to always see a "newer" file and spam the external-change dialog.
-        let stat_entry = remote_fs
-            .stat(&entry.connection_id, &request.path)
-            .await
-            .map_err(|e| format!("Failed to stat remote file: {}", e))?;
-
-        let (is_file, is_dir, size, modified) = match stat_entry {
-            Some(e) => (
-                e.is_file,
-                e.is_dir,
-                e.size.unwrap_or(0),
-                e.modified.unwrap_or(0),
-            ),
-            None => (false, false, 0, 0),
-        };
-
-        return Ok(serde_json::json!({
-            "path": request.path,
-            "modified": modified,
-            "size": size,
-            "is_file": is_file,
-            "is_dir": is_dir,
-            "is_remote": true
-        }));
-    }
-
-    let path = std::path::Path::new(&request.path);
-    match std::fs::metadata(path) {
-        Ok(metadata) => {
-            let modified = metadata
-                .modified()
-                .unwrap_or(SystemTime::UNIX_EPOCH)
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64;
-
-            let size = metadata.len();
-            let is_file = metadata.is_file();
-            let is_dir = metadata.is_dir();
-
-            Ok(serde_json::json!({
-                "path": request.path,
-                "modified": modified,
-                "size": size,
-                "is_file": is_file,
-                "is_dir": is_dir
-            }))
-        }
-        Err(e) => {
-            error!(
-                "Failed to get file metadata: path={}, error={}",
-                request.path, e
-            );
-            Err(format!("Failed to get file metadata: {}", e))
-        }
-    }
+    get_path_metadata(&state, &request.path).await
 }
 
 /// Returns SHA-256 hex (lowercase) of file bytes after the same normalization as the web editor
@@ -2122,35 +1982,41 @@ pub async fn get_file_editor_sync_hash(
     state: State<'_, AppState>,
     request: GetFileMetadataRequest,
 ) -> Result<serde_json::Value, String> {
-    if let Some(entry) = lookup_remote_entry_for_path(&state, &request.path, None).await {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-        let bytes = remote_fs
-            .read_file(&entry.connection_id, &request.path)
-            .await
-            .map_err(|e| format!("Failed to read remote file: {}", e))?;
-        let hash = state
-            .filesystem_service
-            .editor_sync_sha256_hex_from_raw_bytes(&bytes);
-        return Ok(serde_json::json!({
-            "path": request.path,
-            "hash": hash,
-            "is_remote": true
-        }));
+    match resolve_desktop_path_target(&state, &request.path, None).await? {
+        DesktopPathTarget::Remote {
+            requested_path,
+            entry,
+        } => {
+            let remote_fs = state
+                .get_remote_file_service_async()
+                .await
+                .map_err(|e| format!("Remote file service not available: {}", e))?;
+            let bytes = remote_fs
+                .read_file(&entry.connection_id, &requested_path)
+                .await
+                .map_err(|e| format!("Failed to read remote file: {}", e))?;
+            let hash = state
+                .filesystem_service
+                .editor_sync_sha256_hex_from_raw_bytes(&bytes);
+            Ok(serde_json::json!({
+                "path": requested_path,
+                "hash": hash,
+                "is_remote": true
+            }))
+        }
+        DesktopPathTarget::Local { resolved_path, .. } => {
+            let hash = state
+                .filesystem_service
+                .editor_sync_content_sha256_hex(&resolved_path.to_string_lossy())
+                .await
+                .map_err(|e| e.to_string())?;
+
+            Ok(serde_json::json!({
+                "path": request.path,
+                "hash": hash
+            }))
+        }
     }
-
-    let hash = state
-        .filesystem_service
-        .editor_sync_content_sha256_hex(&request.path)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    Ok(serde_json::json!({
-        "path": request.path,
-        "hash": hash
-    }))
 }
 
 #[tauri::command]
@@ -2158,25 +2024,7 @@ pub async fn rename_file(
     state: State<'_, AppState>,
     request: RenameFileRequest,
 ) -> Result<(), String> {
-    if let Some(entry) = lookup_remote_entry_for_path(&state, &request.old_path, None).await {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-        remote_fs
-            .rename(&entry.connection_id, &request.old_path, &request.new_path)
-            .await
-            .map_err(|e| format!("Failed to rename remote file: {}", e))?;
-        return Ok(());
-    }
-
-    state
-        .filesystem_service
-        .move_file(&request.old_path, &request.new_path)
-        .await
-        .map_err(|e| format!("Failed to rename file: {}", e))?;
-
-    Ok(())
+    rename_path(&state, &request.old_path, &request.new_path).await
 }
 
 /// Copy a local file to another local path (binary-safe). Used for export and drag-upload into local workspaces.
@@ -2203,25 +2051,7 @@ pub async fn delete_file(
     state: State<'_, AppState>,
     request: DeleteFileRequest,
 ) -> Result<(), String> {
-    if let Some(entry) = lookup_remote_entry_for_path(&state, &request.path, None).await {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-        remote_fs
-            .remove_file(&entry.connection_id, &request.path)
-            .await
-            .map_err(|e| format!("Failed to delete remote file: {}", e))?;
-        return Ok(());
-    }
-
-    state
-        .filesystem_service
-        .delete_file(&request.path)
-        .await
-        .map_err(|e| format!("Failed to delete file: {}", e))?;
-
-    Ok(())
+    delete_desktop_file(&state, &request.path).await
 }
 
 #[tauri::command]
@@ -2230,33 +2060,7 @@ pub async fn delete_directory(
     request: DeleteDirectoryRequest,
 ) -> Result<(), String> {
     let recursive = request.recursive.unwrap_or(false);
-
-    if let Some(entry) = lookup_remote_entry_for_path(&state, &request.path, None).await {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-        if recursive {
-            remote_fs
-                .remove_dir_all(&entry.connection_id, &request.path)
-                .await
-                .map_err(|e| format!("Failed to delete remote directory: {}", e))?;
-        } else {
-            remote_fs
-                .remove_dir_all(&entry.connection_id, &request.path)
-                .await
-                .map_err(|e| format!("Failed to delete remote directory: {}", e))?;
-        }
-        return Ok(());
-    }
-
-    state
-        .filesystem_service
-        .delete_directory(&request.path, recursive)
-        .await
-        .map_err(|e| format!("Failed to delete directory: {}", e))?;
-
-    Ok(())
+    delete_desktop_directory(&state, &request.path, recursive).await
 }
 
 #[tauri::command]
@@ -2264,26 +2068,7 @@ pub async fn create_file(
     state: State<'_, AppState>,
     request: CreateFileRequest,
 ) -> Result<(), String> {
-    if let Some(entry) = lookup_remote_entry_for_path(&state, &request.path, None).await {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-        remote_fs
-            .write_file(&entry.connection_id, &request.path, b"")
-            .await
-            .map_err(|e| format!("Failed to create remote file: {}", e))?;
-        return Ok(());
-    }
-
-    let options = FileOperationOptions::default();
-    state
-        .filesystem_service
-        .write_file_with_options(&request.path, "", options)
-        .await
-        .map_err(|e| format!("Failed to create file: {}", e))?;
-
-    Ok(())
+    create_empty_file(&state, &request.path).await
 }
 
 #[tauri::command]
@@ -2291,25 +2076,7 @@ pub async fn create_directory(
     state: State<'_, AppState>,
     request: CreateDirectoryRequest,
 ) -> Result<(), String> {
-    if let Some(entry) = lookup_remote_entry_for_path(&state, &request.path, None).await {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-        remote_fs
-            .create_dir_all(&entry.connection_id, &request.path)
-            .await
-            .map_err(|e| format!("Failed to create remote directory: {}", e))?;
-        return Ok(());
-    }
-
-    state
-        .filesystem_service
-        .create_directory(&request.path)
-        .await
-        .map_err(|e| format!("Failed to create directory: {}", e))?;
-
-    Ok(())
+    create_desktop_directory(&state, &request.path).await
 }
 
 #[derive(Debug, Deserialize)]
@@ -2325,89 +2092,108 @@ pub async fn list_directory_files(
 ) -> Result<Vec<String>, String> {
     use std::path::Path;
 
-    if let Some(entry) = lookup_remote_entry_for_path(&state, &request.path, None).await {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-        let entries = remote_fs
-            .read_dir(&entry.connection_id, &request.path)
-            .await
-            .map_err(|e| format!("Failed to read remote directory: {}", e))?;
-        let mut files: Vec<String> = entries
-            .into_iter()
-            .filter(|e| !e.is_dir)
-            .filter(|e| {
-                if let Some(ref extensions) = request.extensions {
-                    if let Some(ext) = Path::new(&e.name).extension().and_then(|x| x.to_str()) {
-                        extensions.iter().any(|x| x.eq_ignore_ascii_case(ext))
+    match resolve_desktop_path_target(&state, &request.path, None).await? {
+        DesktopPathTarget::Remote {
+            requested_path,
+            entry,
+        } => {
+            let remote_fs = state
+                .get_remote_file_service_async()
+                .await
+                .map_err(|e| format!("Remote file service not available: {}", e))?;
+            let entries = remote_fs
+                .read_dir(&entry.connection_id, &requested_path)
+                .await
+                .map_err(|e| format!("Failed to read remote directory: {}", e))?;
+            let mut files: Vec<String> = entries
+                .into_iter()
+                .filter(|e| !e.is_dir)
+                .filter(|e| {
+                    if let Some(ref extensions) = request.extensions {
+                        if let Some(ext) = Path::new(&e.name).extension().and_then(|x| x.to_str()) {
+                            extensions.iter().any(|x| x.eq_ignore_ascii_case(ext))
+                        } else {
+                            false
+                        }
                     } else {
-                        false
+                        true
                     }
-                } else {
-                    true
-                }
-            })
-            .map(|e| e.name)
-            .collect();
-        files.sort();
-        return Ok(files);
-    }
+                })
+                .map(|e| e.name)
+                .collect();
+            files.sort();
+            Ok(files)
+        }
+        DesktopPathTarget::Local { resolved_path, .. } => {
+            let dir_path = resolved_path.as_path();
+            if !dir_path.exists() {
+                return Ok(Vec::new());
+            }
 
-    let dir_path = Path::new(&request.path);
-    if !dir_path.exists() {
-        return Ok(Vec::new());
-    }
+            if !dir_path.is_dir() {
+                return Err("Path is not a directory".to_string());
+            }
 
-    if !dir_path.is_dir() {
-        return Err("Path is not a directory".to_string());
-    }
+            let mut files = Vec::new();
+            let entries = std::fs::read_dir(dir_path)
+                .map_err(|e| format!("Failed to read directory: {}", e))?;
 
-    let mut files = Vec::new();
-    let entries =
-        std::fs::read_dir(dir_path).map_err(|e| format!("Failed to read directory: {}", e))?;
+            for entry in entries {
+                let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+                let path = entry.path();
 
-    for entry in entries {
-        let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
-        let path = entry.path();
-
-        if path.is_file() {
-            if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
-                if let Some(ref extensions) = request.extensions {
-                    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-                        if extensions.iter().any(|e| e.eq_ignore_ascii_case(ext)) {
+                if path.is_file() {
+                    if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
+                        if let Some(ref extensions) = request.extensions {
+                            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                                if extensions.iter().any(|e| e.eq_ignore_ascii_case(ext)) {
+                                    files.push(file_name.to_string());
+                                }
+                            }
+                        } else {
                             files.push(file_name.to_string());
                         }
                     }
-                } else {
-                    files.push(file_name.to_string());
                 }
             }
+
+            files.sort();
+            Ok(files)
         }
     }
-
-    files.sort();
-    Ok(files)
 }
 
 #[tauri::command]
-pub async fn reveal_in_explorer(request: RevealInExplorerRequest) -> Result<(), String> {
-    let path = std::path::Path::new(&request.path);
+pub async fn reveal_in_explorer(
+    state: State<'_, AppState>,
+    request: RevealInExplorerRequest,
+) -> Result<(), String> {
+    let target = resolve_desktop_path_target(&state, &request.path, None).await?;
+    let path = match target.as_local_path() {
+        Some(path) => path,
+        None => {
+            return Err(format!(
+                "Cannot reveal remote path in local file explorer: {}",
+                request.path
+            ))
+        }
+    };
     if !path.exists() {
         return Err(format!("Path does not exist: {}", request.path));
     }
     let is_directory = path.is_dir();
+    let path_str = path.to_string_lossy().to_string();
 
     #[cfg(target_os = "windows")]
     {
         if is_directory {
-            let normalized_path = request.path.replace("/", "\\");
+            let normalized_path = path_str.replace("/", "\\");
             bitfun_core::util::process_manager::create_command("explorer")
                 .arg(&normalized_path)
                 .spawn()
                 .map_err(|e| format!("Failed to open explorer: {}", e))?;
         } else {
-            let normalized_path = request.path.replace("/", "\\");
+            let normalized_path = path_str.replace("/", "\\");
             bitfun_core::util::process_manager::create_command("explorer")
                 .args(["/select,", &normalized_path])
                 .spawn()
@@ -2419,12 +2205,12 @@ pub async fn reveal_in_explorer(request: RevealInExplorerRequest) -> Result<(), 
     {
         if is_directory {
             bitfun_core::util::process_manager::create_command("open")
-                .arg(&request.path)
+                .arg(&path_str)
                 .spawn()
                 .map_err(|e| format!("Failed to open finder: {}", e))?;
         } else {
             bitfun_core::util::process_manager::create_command("open")
-                .args(&["-R", &request.path])
+                .args(["-R", &path_str])
                 .spawn()
                 .map_err(|e| format!("Failed to open finder: {}", e))?;
         }

--- a/src/apps/desktop/src/api/mod.rs
+++ b/src/apps/desktop/src/api/mod.rs
@@ -24,6 +24,7 @@ pub mod lsp_api;
 pub mod lsp_workspace_api;
 pub mod mcp_api;
 pub mod miniapp_api;
+pub mod path_target;
 pub mod project_context_api;
 pub mod remote_connect_api;
 pub mod runtime_api;

--- a/src/apps/desktop/src/api/path_target.rs
+++ b/src/apps/desktop/src/api/path_target.rs
@@ -1,0 +1,499 @@
+//! Shared desktop resolution and access helpers for local, runtime, and remote paths.
+
+use crate::api::app_state::AppState;
+use bitfun_core::agentic::tools::workspace_paths::{
+    is_bitfun_runtime_uri, parse_bitfun_runtime_uri,
+};
+use bitfun_core::infrastructure::get_path_manager_arc;
+use bitfun_core::infrastructure::FileOperationOptions;
+use bitfun_core::service::remote_ssh::workspace_state::remote_workspace_runtime_root;
+use bitfun_core::service::remote_ssh::{
+    get_remote_workspace_manager, normalize_remote_workspace_path, RemoteWorkspaceEntry,
+};
+use bitfun_core::service::workspace::{WorkspaceInfo, WorkspaceKind};
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+#[derive(Debug, Clone)]
+pub enum DesktopPathTarget {
+    Local {
+        requested_path: String,
+        resolved_path: PathBuf,
+        is_runtime_artifact: bool,
+    },
+    Remote {
+        requested_path: String,
+        entry: RemoteWorkspaceEntry,
+    },
+}
+
+impl DesktopPathTarget {
+    pub fn requested_path(&self) -> &str {
+        match self {
+            Self::Local { requested_path, .. } | Self::Remote { requested_path, .. } => {
+                requested_path.as_str()
+            }
+        }
+    }
+
+    pub fn as_local_path(&self) -> Option<&Path> {
+        match self {
+            Self::Local { resolved_path, .. } => Some(resolved_path.as_path()),
+            Self::Remote { .. } => None,
+        }
+    }
+
+    pub fn is_runtime_artifact(&self) -> bool {
+        matches!(
+            self,
+            Self::Local {
+                is_runtime_artifact: true,
+                ..
+            }
+        )
+    }
+}
+
+fn runtime_root_for_workspace_info(workspace: &WorkspaceInfo) -> Result<PathBuf, String> {
+    if workspace.workspace_kind == WorkspaceKind::Remote {
+        let ssh_host = workspace
+            .metadata
+            .get("sshHost")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                format!(
+                    "Remote workspace '{}' is missing sshHost metadata",
+                    workspace.id
+                )
+            })?;
+
+        let remote_root = normalize_remote_workspace_path(&workspace.root_path.to_string_lossy());
+        return Ok(remote_workspace_runtime_root(ssh_host, &remote_root));
+    }
+
+    Ok(get_path_manager_arc().project_runtime_root(&workspace.root_path))
+}
+
+async fn resolve_runtime_artifact_path(
+    app_state: &AppState,
+    raw_path: &str,
+) -> Result<Option<PathBuf>, String> {
+    if !is_bitfun_runtime_uri(raw_path) {
+        return Ok(None);
+    }
+
+    let parsed = parse_bitfun_runtime_uri(raw_path).map_err(|e| e.to_string())?;
+    let workspace = if parsed.workspace_scope == "current" {
+        app_state.workspace_service.get_current_workspace().await
+    } else {
+        app_state
+            .workspace_service
+            .list_workspace_infos()
+            .await
+            .into_iter()
+            .find(|workspace| workspace.id == parsed.workspace_scope)
+    }
+    .ok_or_else(|| {
+        format!(
+            "Unable to resolve runtime URI scope '{}'",
+            parsed.workspace_scope
+        )
+    })?;
+
+    let mut resolved = runtime_root_for_workspace_info(&workspace)?;
+    for segment in parsed.relative_path.split('/') {
+        resolved.push(segment);
+    }
+
+    Ok(Some(resolved))
+}
+
+async fn lookup_remote_entry_for_path(
+    app_state: &AppState,
+    path: &str,
+    request_preferred: Option<&str>,
+) -> Option<RemoteWorkspaceEntry> {
+    let manager = get_remote_workspace_manager()?;
+    let legacy = app_state
+        .get_remote_workspace_async()
+        .await
+        .map(|workspace| workspace.connection_id);
+    let preferred = request_preferred.map(|s| s.to_string()).or(legacy);
+    manager.lookup_connection(path, preferred.as_deref()).await
+}
+
+pub async fn resolve_desktop_path_target(
+    app_state: &AppState,
+    raw_path: &str,
+    preferred_remote_connection_id: Option<&str>,
+) -> Result<DesktopPathTarget, String> {
+    if let Some(resolved_path) = resolve_runtime_artifact_path(app_state, raw_path).await? {
+        return Ok(DesktopPathTarget::Local {
+            requested_path: raw_path.to_string(),
+            resolved_path,
+            is_runtime_artifact: true,
+        });
+    }
+
+    if let Some(entry) =
+        lookup_remote_entry_for_path(app_state, raw_path, preferred_remote_connection_id).await
+    {
+        return Ok(DesktopPathTarget::Remote {
+            requested_path: raw_path.to_string(),
+            entry,
+        });
+    }
+
+    Ok(DesktopPathTarget::Local {
+        requested_path: raw_path.to_string(),
+        resolved_path: PathBuf::from(raw_path),
+        is_runtime_artifact: false,
+    })
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalFileMetadata {
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_path: Option<String>,
+    pub modified: u64,
+    pub size: u64,
+    pub is_file: bool,
+    pub is_dir: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_remote: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_runtime_artifact: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteFileMetadata {
+    pub path: String,
+    pub modified: u64,
+    pub size: u64,
+    pub is_file: bool,
+    pub is_dir: bool,
+    pub is_remote: bool,
+}
+
+pub fn stat_local_path_metadata(
+    requested_path: &str,
+    resolved_path: &Path,
+    is_runtime_artifact: bool,
+) -> Result<LocalFileMetadata, String> {
+    let metadata = std::fs::metadata(resolved_path).map_err(|e| {
+        format!(
+            "Failed to stat local file '{}': {}",
+            resolved_path.display(),
+            e
+        )
+    })?;
+
+    let modified = metadata
+        .modified()
+        .unwrap_or(SystemTime::UNIX_EPOCH)
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+
+    Ok(LocalFileMetadata {
+        path: requested_path.to_string(),
+        resolved_path: is_runtime_artifact.then(|| resolved_path.to_string_lossy().to_string()),
+        modified,
+        size: metadata.len(),
+        is_file: metadata.is_file(),
+        is_dir: metadata.is_dir(),
+        is_remote: Some(false),
+        is_runtime_artifact: is_runtime_artifact.then_some(true),
+    })
+}
+
+pub async fn read_text_file(
+    app_state: &AppState,
+    raw_path: &str,
+    preferred_remote_connection_id: Option<&str>,
+) -> Result<String, String> {
+    match resolve_desktop_path_target(app_state, raw_path, preferred_remote_connection_id).await? {
+        DesktopPathTarget::Local { resolved_path, .. } => app_state
+            .filesystem_service
+            .read_file(&resolved_path.to_string_lossy())
+            .await
+            .map(|result| result.content)
+            .map_err(|e| format!("Failed to read file content: {}", e)),
+        DesktopPathTarget::Remote {
+            requested_path,
+            entry,
+        } => {
+            let remote_fs = app_state
+                .get_remote_file_service_async()
+                .await
+                .map_err(|e| format!("Remote file service not available: {}", e))?;
+            let bytes = remote_fs
+                .read_file(&entry.connection_id, &requested_path)
+                .await
+                .map_err(|e| format!("Failed to read remote file: {}", e))?;
+            String::from_utf8(bytes).map_err(|e| format!("File is not valid UTF-8: {}", e))
+        }
+    }
+}
+
+pub async fn write_text_file(
+    app_state: &AppState,
+    raw_path: &str,
+    content: &str,
+    preferred_remote_connection_id: Option<&str>,
+) -> Result<(), String> {
+    match resolve_desktop_path_target(app_state, raw_path, preferred_remote_connection_id).await? {
+        DesktopPathTarget::Local { resolved_path, .. } => {
+            let options = FileOperationOptions {
+                backup_on_overwrite: false,
+                ..FileOperationOptions::default()
+            };
+            app_state
+                .filesystem_service
+                .write_file_with_options(&resolved_path.to_string_lossy(), content, options)
+                .await
+                .map(|_| ())
+                .map_err(|e| format!("Failed to write file {}: {}", raw_path, e))
+        }
+        DesktopPathTarget::Remote {
+            requested_path,
+            entry,
+        } => {
+            let remote_fs = app_state
+                .get_remote_file_service_async()
+                .await
+                .map_err(|e| format!("Remote file service not available: {}", e))?;
+            remote_fs
+                .write_file(&entry.connection_id, &requested_path, content.as_bytes())
+                .await
+                .map_err(|e| format!("Failed to write remote file: {}", e))
+        }
+    }
+}
+
+pub async fn path_exists(app_state: &AppState, raw_path: &str) -> Result<bool, String> {
+    match resolve_desktop_path_target(app_state, raw_path, None).await? {
+        DesktopPathTarget::Local { resolved_path, .. } => Ok(resolved_path.exists()),
+        DesktopPathTarget::Remote {
+            requested_path,
+            entry,
+        } => {
+            let remote_fs = app_state
+                .get_remote_file_service_async()
+                .await
+                .map_err(|e| format!("Remote file service not available: {}", e))?;
+            remote_fs
+                .exists(&entry.connection_id, &requested_path)
+                .await
+                .map_err(|e| format!("Failed to check remote path: {}", e))
+        }
+    }
+}
+
+pub async fn get_path_metadata(
+    app_state: &AppState,
+    raw_path: &str,
+) -> Result<serde_json::Value, String> {
+    match resolve_desktop_path_target(app_state, raw_path, None).await? {
+        DesktopPathTarget::Local {
+            requested_path,
+            resolved_path,
+            is_runtime_artifact,
+        } => {
+            let metadata =
+                stat_local_path_metadata(&requested_path, &resolved_path, is_runtime_artifact)?;
+            serde_json::to_value(metadata)
+                .map_err(|e| format!("Failed to serialize file metadata: {}", e))
+        }
+        DesktopPathTarget::Remote {
+            requested_path,
+            entry,
+        } => {
+            let remote_fs = app_state
+                .get_remote_file_service_async()
+                .await
+                .map_err(|e| format!("Remote file service not available: {}", e))?;
+
+            let stat_entry = remote_fs
+                .stat(&entry.connection_id, &requested_path)
+                .await
+                .map_err(|e| format!("Failed to stat remote file: {}", e))?;
+
+            let (is_file, is_dir, size, modified) = match stat_entry {
+                Some(entry) => (
+                    entry.is_file,
+                    entry.is_dir,
+                    entry.size.unwrap_or(0),
+                    entry.modified.unwrap_or(0),
+                ),
+                None => (false, false, 0, 0),
+            };
+
+            serde_json::to_value(RemoteFileMetadata {
+                path: requested_path,
+                modified,
+                size,
+                is_file,
+                is_dir,
+                is_remote: true,
+            })
+            .map_err(|e| format!("Failed to serialize remote file metadata: {}", e))
+        }
+    }
+}
+
+pub async fn rename_path(
+    app_state: &AppState,
+    old_path: &str,
+    new_path: &str,
+) -> Result<(), String> {
+    match resolve_desktop_path_target(app_state, old_path, None).await? {
+        DesktopPathTarget::Local {
+            resolved_path: old_resolved_path,
+            ..
+        } => {
+            let new_resolved_path =
+                match resolve_desktop_path_target(app_state, new_path, None).await? {
+                    DesktopPathTarget::Local { resolved_path, .. } => resolved_path,
+                    DesktopPathTarget::Remote { .. } => {
+                        return Err(format!(
+                            "Cannot rename local path '{}' to remote destination '{}'",
+                            old_path, new_path
+                        ))
+                    }
+                };
+
+            app_state
+                .filesystem_service
+                .move_file(
+                    &old_resolved_path.to_string_lossy(),
+                    &new_resolved_path.to_string_lossy(),
+                )
+                .await
+                .map_err(|e| format!("Failed to rename file: {}", e))
+        }
+        DesktopPathTarget::Remote { entry, .. } => {
+            let remote_fs = app_state
+                .get_remote_file_service_async()
+                .await
+                .map_err(|e| format!("Remote file service not available: {}", e))?;
+            remote_fs
+                .rename(&entry.connection_id, old_path, new_path)
+                .await
+                .map_err(|e| format!("Failed to rename remote file: {}", e))
+        }
+    }
+}
+
+pub async fn delete_file(app_state: &AppState, raw_path: &str) -> Result<(), String> {
+    match resolve_desktop_path_target(app_state, raw_path, None).await? {
+        DesktopPathTarget::Local { resolved_path, .. } => app_state
+            .filesystem_service
+            .delete_file(&resolved_path.to_string_lossy())
+            .await
+            .map_err(|e| format!("Failed to delete file: {}", e)),
+        DesktopPathTarget::Remote {
+            requested_path,
+            entry,
+        } => {
+            let remote_fs = app_state
+                .get_remote_file_service_async()
+                .await
+                .map_err(|e| format!("Remote file service not available: {}", e))?;
+            remote_fs
+                .remove_file(&entry.connection_id, &requested_path)
+                .await
+                .map_err(|e| format!("Failed to delete remote file: {}", e))
+        }
+    }
+}
+
+pub async fn delete_directory(
+    app_state: &AppState,
+    raw_path: &str,
+    recursive: bool,
+) -> Result<(), String> {
+    match resolve_desktop_path_target(app_state, raw_path, None).await? {
+        DesktopPathTarget::Local { resolved_path, .. } => app_state
+            .filesystem_service
+            .delete_directory(&resolved_path.to_string_lossy(), recursive)
+            .await
+            .map_err(|e| format!("Failed to delete directory: {}", e)),
+        DesktopPathTarget::Remote {
+            requested_path,
+            entry,
+        } => {
+            let remote_fs = app_state
+                .get_remote_file_service_async()
+                .await
+                .map_err(|e| format!("Remote file service not available: {}", e))?;
+            if recursive {
+                remote_fs
+                    .remove_dir_all(&entry.connection_id, &requested_path)
+                    .await
+                    .map_err(|e| format!("Failed to delete remote directory: {}", e))
+            } else {
+                remote_fs
+                    .remove_dir_all(&entry.connection_id, &requested_path)
+                    .await
+                    .map_err(|e| format!("Failed to delete remote directory: {}", e))
+            }
+        }
+    }
+}
+
+pub async fn create_empty_file(app_state: &AppState, raw_path: &str) -> Result<(), String> {
+    match resolve_desktop_path_target(app_state, raw_path, None).await? {
+        DesktopPathTarget::Local { resolved_path, .. } => {
+            let options = FileOperationOptions::default();
+            app_state
+                .filesystem_service
+                .write_file_with_options(&resolved_path.to_string_lossy(), "", options)
+                .await
+                .map(|_| ())
+                .map_err(|e| format!("Failed to create file: {}", e))
+        }
+        DesktopPathTarget::Remote {
+            requested_path,
+            entry,
+        } => {
+            let remote_fs = app_state
+                .get_remote_file_service_async()
+                .await
+                .map_err(|e| format!("Remote file service not available: {}", e))?;
+            remote_fs
+                .write_file(&entry.connection_id, &requested_path, b"")
+                .await
+                .map_err(|e| format!("Failed to create remote file: {}", e))
+        }
+    }
+}
+
+pub async fn create_directory(app_state: &AppState, raw_path: &str) -> Result<(), String> {
+    match resolve_desktop_path_target(app_state, raw_path, None).await? {
+        DesktopPathTarget::Local { resolved_path, .. } => app_state
+            .filesystem_service
+            .create_directory(&resolved_path.to_string_lossy())
+            .await
+            .map_err(|e| format!("Failed to create directory: {}", e)),
+        DesktopPathTarget::Remote {
+            requested_path,
+            entry,
+        } => {
+            let remote_fs = app_state
+                .get_remote_file_service_async()
+                .await
+                .map_err(|e| format!("Remote file service not available: {}", e))?;
+            remote_fs
+                .create_dir_all(&entry.connection_id, &requested_path)
+                .await
+                .map_err(|e| format!("Failed to create remote directory: {}", e))
+        }
+    }
+}

--- a/src/apps/desktop/src/api/snapshot_service.rs
+++ b/src/apps/desktop/src/api/snapshot_service.rs
@@ -823,14 +823,6 @@ pub async fn get_snapshot_system_stats(
     Ok(stats)
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CleanupSnapshotDataRequest {
-    #[serde(rename = "maxAgeDays")]
-    pub max_age_days: u64,
-    #[serde(alias = "workspacePath")]
-    pub workspace_path: String,
-}
-
 #[tauri::command]
 pub async fn get_snapshot_sessions(
     request: SnapshotWorkspaceRequest,
@@ -841,24 +833,6 @@ pub async fn get_snapshot_sessions(
         .list_sessions()
         .await
         .map_err(|e| format!("Failed to list snapshot sessions: {}", e))
-}
-
-#[tauri::command]
-pub async fn cleanup_snapshot_data(
-    request: CleanupSnapshotDataRequest,
-) -> Result<serde_json::Value, String> {
-    let manager = ensure_snapshot_manager_ready(&request.workspace_path).await?;
-
-    manager
-        .cleanup_snapshot_data(request.max_age_days)
-        .await
-        .map_err(|e| format!("Failed to cleanup snapshot data: {}", e))?;
-
-    Ok(serde_json::json!({
-        "success": true,
-        "message": "Snapshot data cleanup completed",
-        "keep_recent_days": request.max_age_days,
-    }))
 }
 
 #[tauri::command]

--- a/src/apps/desktop/src/api/storage_commands.rs
+++ b/src/apps/desktop/src/api/storage_commands.rs
@@ -13,9 +13,7 @@ pub struct StoragePathsInfo {
     pub user_data_dir: PathBuf,
     pub cache_root: PathBuf,
     pub logs_dir: PathBuf,
-    pub backups_dir: PathBuf,
     pub temp_dir: PathBuf,
-    pub workspaces_dir: PathBuf,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -38,9 +36,7 @@ pub async fn get_storage_paths(state: State<'_, AppState>) -> Result<StoragePath
         user_data_dir: path_manager.user_data_dir(),
         cache_root: path_manager.cache_root(),
         logs_dir: path_manager.logs_dir(),
-        backups_dir: path_manager.backups_dir(),
         temp_dir: path_manager.temp_dir(),
-        workspaces_dir: path_manager.workspaces_dir(),
     })
 }
 
@@ -56,11 +52,11 @@ pub async fn get_project_storage_paths(
 
     Ok(ProjectStoragePathsInfo {
         project_root: path_manager.project_root(&workspace_path),
-        config_file: path_manager.project_config_file(&workspace_path),
+        runtime_root: path_manager.project_runtime_root(&workspace_path),
         agents_dir: path_manager.project_agents_dir(&workspace_path),
         sessions_dir: path_manager.project_sessions_dir(&workspace_path),
-        cache_dir: path_manager.project_cache_dir(&workspace_path),
-        logs_dir: path_manager.project_logs_dir(&workspace_path),
+        memory_dir: path_manager.project_memory_dir(&workspace_path),
+        plans_dir: path_manager.project_plans_dir(&workspace_path),
     })
 }
 
@@ -68,11 +64,11 @@ pub async fn get_project_storage_paths(
 #[serde(rename_all = "camelCase")]
 pub struct ProjectStoragePathsInfo {
     pub project_root: PathBuf,
-    pub config_file: PathBuf,
+    pub runtime_root: PathBuf,
     pub agents_dir: PathBuf,
     pub sessions_dir: PathBuf,
-    pub cache_dir: PathBuf,
-    pub logs_dir: PathBuf,
+    pub memory_dir: PathBuf,
+    pub plans_dir: PathBuf,
 }
 
 #[tauri::command]
@@ -132,14 +128,15 @@ pub async fn initialize_project_storage(
     workspace_path: String,
 ) -> Result<(), String> {
     let workspace_service = &state.workspace_service;
-    let path_manager = workspace_service.path_manager();
+    let runtime_service = workspace_service.runtime_service();
 
     let workspace_path = PathBuf::from(workspace_path);
 
-    path_manager
-        .initialize_project_directories(&workspace_path)
+    runtime_service
+        .ensure_local_workspace_runtime(&workspace_path)
         .await
-        .map_err(|e| format!("Failed to initialize project directories: {}", e))
+        .map(|_| ())
+        .map_err(|e| format!("Failed to initialize project runtime: {}", e))
 }
 
 fn calculate_dir_size(

--- a/src/apps/desktop/src/computer_use/desktop_host.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host.rs
@@ -1713,10 +1713,16 @@ end tell"#])
                 let new_w = (frame.width() / scale_factor).max(1);
                 let new_h = (frame.height() / scale_factor).max(1);
                 let dyn_img = DynamicImage::ImageRgb8(frame);
-                let resized = dyn_img.resize_exact(new_w, new_h, image::imageops::FilterType::Lanczos3);
+                let resized =
+                    dyn_img.resize_exact(new_w, new_h, image::imageops::FilterType::Lanczos3);
                 let scaled_pointer_x = pointer_image_x.map(|px| px / scale_factor as i32);
                 let scaled_pointer_y = pointer_image_y.map(|py| py / scale_factor as i32);
-                (resized.to_rgb8(), scale_factor as f64, scaled_pointer_x, scaled_pointer_y)
+                (
+                    resized.to_rgb8(),
+                    scale_factor as f64,
+                    scaled_pointer_x,
+                    scaled_pointer_y,
+                )
             } else {
                 (frame, 1.0_f64, pointer_image_x, pointer_image_y)
             }
@@ -2082,10 +2088,7 @@ fn flash_click_highlight_cg(gx: f64, gy: f64) {
         // The bitmap is drawn; sleep then discard (the visual feedback is best-effort).
         // On macOS the actual overlay window requires AppKit; as a lightweight alternative
         // we just log the click location for debugging.
-        debug!(
-            "computer_use: click highlight at ({:.0}, {:.0})",
-            gx, gy
-        );
+        debug!("computer_use: click highlight at ({:.0}, {:.0})", gx, gy);
         std::thread::sleep(Duration::from_millis(DURATION_MS));
     });
 }
@@ -2275,7 +2278,7 @@ impl ComputerUseHost for DesktopComputerUseHost {
                 rgba,
                 screen,
                 vec![], // No SoM labels for peek screenshots
-                None, // No UI tree text for peek screenshots
+                None,   // No UI tree text for peek screenshots
                 false,
             )
         })

--- a/src/apps/desktop/src/computer_use/macos_ax_ui.rs
+++ b/src/apps/desktop/src/computer_use/macos_ax_ui.rs
@@ -26,10 +26,7 @@ unsafe extern "C" {
         attribute: CFStringRef,
         value: *mut CFTypeRef,
     ) -> i32;
-    fn AXUIElementCopyActionNames(
-        element: AXUIElementRef,
-        names: *mut CFArrayRef,
-    ) -> i32;
+    fn AXUIElementCopyActionNames(element: AXUIElementRef, names: *mut CFArrayRef) -> i32;
     fn AXUIElementCopyElementAtPosition(
         element: AXUIElementRef,
         x: f32,
@@ -158,9 +155,7 @@ unsafe fn is_ax_enabled(elem: AXUIElementRef) -> bool {
     enabled
 }
 
-unsafe fn read_value_desc(
-    elem: AXUIElementRef,
-) -> (Option<String>, Option<String>) {
+unsafe fn read_value_desc(elem: AXUIElementRef) -> (Option<String>, Option<String>) {
     let value = ax_copy_attr(elem, "AXValue").and_then(|v| {
         let s = cfstring_to_string(v);
         ax_release(v);
@@ -511,7 +506,6 @@ pub fn locate_ui_element_center(
     )
 }
 
-
 unsafe fn is_ax_interactive(elem: AXUIElementRef, role: &str) -> bool {
     let actions = ax_copy_action_names(elem);
     let interactive_actions = [
@@ -611,7 +605,10 @@ pub fn enumerate_interactive_elements(max_elements: usize) -> (Vec<SomElement>, 
                             let wy_f = wy as f64;
                             let ww_f = ww as f64;
                             let wh_f = wh as f64;
-                            on_screen = bl < wx_f + ww_f && bl + bw > wx_f && bt < wy_f + wh_f && bt + bh > wy_f;
+                            on_screen = bl < wx_f + ww_f
+                                && bl + bw > wx_f
+                                && bt < wy_f + wh_f
+                                && bt + bh > wy_f;
                         }
                         if on_screen {
                             let (val_s, desc_s) = unsafe { read_value_desc(cur.ax) };
@@ -691,8 +688,16 @@ pub fn enumerate_interactive_elements(max_elements: usize) -> (Vec<SomElement>, 
         if let Some(d) = &el.description {
             attrs.push_str(&format!(" description: \"{}\"", d));
         }
-        attrs.push_str(&format!(" (w,h): \"{}, {}\"", el.bounds_width as i32, el.bounds_height as i32));
-        ui_tree_lines.push(format!("{}[:]<{} {}>", el.label, el.role, attrs.trim_start()));
+        attrs.push_str(&format!(
+            " (w,h): \"{}, {}\"",
+            el.bounds_width as i32, el.bounds_height as i32
+        ));
+        ui_tree_lines.push(format!(
+            "{}[:]<{} {}>",
+            el.label,
+            el.role,
+            attrs.trim_start()
+        ));
     }
     let ui_tree_text = if ui_tree_lines.is_empty() {
         None

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -479,7 +479,6 @@ pub async fn run() {
             get_session_stats,
             get_snapshot_system_stats,
             get_snapshot_sessions,
-            cleanup_snapshot_data,
             check_git_isolation,
             get_file_change_history,
             get_all_modified_files,

--- a/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
@@ -13,6 +13,8 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 
+const AI_STREAM_RESPONSE_TARGET: &str = "ai::anthropic_stream_response";
+
 /// Convert a byte stream into a structured response stream
 ///
 /// # Arguments
@@ -56,7 +58,7 @@ pub async fn handle_anthropic_stream(
             }
         };
 
-        trace!("Anthropic SSE: {:?}", sse);
+        trace!(target: AI_STREAM_RESPONSE_TARGET, "Anthropic SSE: {:?}", sse);
         let event_type = sse.event;
         let data = sse.data;
         stats.record_sse_event(&event_type);
@@ -95,7 +97,11 @@ pub async fn handle_anthropic_stream(
                     ContentBlock::ToolUse { .. }
                 ) {
                     let unified_response = UnifiedResponse::from(content_block_start);
-                    trace!("Anthropic unified response: {:?}", unified_response);
+                    trace!(
+                        target: AI_STREAM_RESPONSE_TARGET,
+                        "Anthropic unified response: {:?}",
+                        unified_response
+                    );
                     stats.record_unified_response(&unified_response);
                     let _ = tx_event.send(Ok(unified_response));
                 }
@@ -112,7 +118,11 @@ pub async fn handle_anthropic_stream(
                 };
                 match UnifiedResponse::try_from(content_block_delta) {
                     Ok(unified_response) => {
-                        trace!("Anthropic unified response: {:?}", unified_response);
+                        trace!(
+                            target: AI_STREAM_RESPONSE_TARGET,
+                            "Anthropic unified response: {:?}",
+                            unified_response
+                        );
                         stats.record_unified_response(&unified_response);
                         let _ = tx_event.send(Ok(unified_response));
                     }
@@ -141,7 +151,11 @@ pub async fn handle_anthropic_stream(
                     Some(usage.clone())
                 };
                 let unified_response = UnifiedResponse::from(message_delta);
-                trace!("Anthropic unified response: {:?}", unified_response);
+                trace!(
+                    target: AI_STREAM_RESPONSE_TARGET,
+                    "Anthropic unified response: {:?}",
+                    unified_response
+                );
                 stats.record_unified_response(&unified_response);
                 let _ = tx_event.send(Ok(unified_response));
             }

--- a/src/crates/ai-adapters/src/stream/stream_handler/gemini.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/gemini.rs
@@ -12,6 +12,8 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 
+const AI_STREAM_RESPONSE_TARGET: &str = "ai::gemini_stream_response";
+
 static GEMINI_STREAM_ID_SEQ: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug)]
@@ -118,7 +120,7 @@ pub async fn handle_gemini_stream(
 
         let raw = sse.data;
         stats.record_sse_event("data");
-        trace!("Gemini SSE: {:?}", raw);
+        trace!(target: AI_STREAM_RESPONSE_TARGET, "Gemini SSE: {:?}", raw);
 
         if let Some(ref tx) = tx_raw_sse {
             let _ = tx.send(raw.clone());
@@ -179,6 +181,12 @@ pub async fn handle_gemini_stream(
                 tool_call_state.on_non_tool_response();
             }
         }
+
+        trace!(
+            target: AI_STREAM_RESPONSE_TARGET,
+            "Gemini unified responses: {:?}",
+            unified_responses
+        );
 
         for unified_response in unified_responses {
             stats.record_unified_response(&unified_response);

--- a/src/crates/ai-adapters/src/stream/stream_handler/openai.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/openai.rs
@@ -16,6 +16,7 @@ use tokio::time::timeout;
 const OPENAI_CHAT_COMPLETION_CHUNK_OBJECT: &str = "chat.completion.chunk";
 const INLINE_THINK_OPEN_TAG: &str = "<think>";
 const INLINE_THINK_CLOSE_TAG: &str = "</think>";
+const AI_STREAM_RESPONSE_TARGET: &str = "ai::openai_stream_response";
 
 #[derive(Debug, Default)]
 struct OpenAIToolCallFilter {
@@ -485,7 +486,7 @@ pub async fn handle_openai_stream(
 
         let raw = sse.data;
         stats.record_sse_event("data");
-        trace!("OpenAI SSE: {:?}", raw);
+        trace!(target: AI_STREAM_RESPONSE_TARGET, "OpenAI SSE: {:?}", raw);
         if let Some(ref tx) = tx_raw_sse {
             let _ = tx.send(raw.clone());
         }
@@ -558,7 +559,11 @@ pub async fn handle_openai_stream(
 
         let has_empty_choices = sse_data.is_choices_empty();
         let unified_responses = sse_data.into_unified_responses();
-        trace!("OpenAI unified responses: {:?}", unified_responses);
+        trace!(
+            target: AI_STREAM_RESPONSE_TARGET,
+            "OpenAI unified responses: {:?}",
+            unified_responses
+        );
         if unified_responses.is_empty() {
             if has_empty_choices {
                 stats.increment("skip:empty_choices_no_usage");
@@ -825,7 +830,10 @@ mod tests {
         );
 
         assert_eq!(responses.len(), 1);
-        let tool_call = responses[0].tool_call.as_ref().expect("tool call should exist");
+        let tool_call = responses[0]
+            .tool_call
+            .as_ref()
+            .expect("tool call should exist");
         assert_eq!(tool_call.id.as_deref(), Some("call_1"));
         assert_eq!(tool_call.name.as_deref(), Some("read_file"));
         assert_eq!(tool_call.arguments.as_deref(), Some("{\"path\":\"a.txt\"}"));
@@ -836,19 +844,17 @@ mod tests {
     fn drops_orphan_id_only_tool_call_when_it_shares_sse_with_redundant_empty_tail() {
         let mut filter = OpenAIToolCallFilter::default();
 
-        assert!(
-            filter
-                .normalize_response(UnifiedResponse {
-                    tool_call: Some(UnifiedToolCall {
-                        id: Some("call_1".to_string()),
-                        name: Some("read_file".to_string()),
-                        arguments: Some("{\"path\":\"a.txt\"}".to_string()),
-                        arguments_is_snapshot: false,
-                    }),
-                    ..Default::default()
-                })
-                .is_some()
-        );
+        assert!(filter
+            .normalize_response(UnifiedResponse {
+                tool_call: Some(UnifiedToolCall {
+                    id: Some("call_1".to_string()),
+                    name: Some("read_file".to_string()),
+                    arguments: Some("{\"path\":\"a.txt\"}".to_string()),
+                    arguments_is_snapshot: false,
+                }),
+                ..Default::default()
+            })
+            .is_some());
 
         let responses = normalize_raw_with_filter(
             &mut filter,

--- a/src/crates/ai-adapters/src/stream/stream_handler/responses.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/responses.rs
@@ -14,6 +14,8 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 
+const AI_STREAM_RESPONSE_TARGET: &str = "ai::responses_stream_response";
+
 #[derive(Debug, Default, Clone)]
 struct InProgressToolCall {
     call_id: Option<String>,
@@ -44,6 +46,20 @@ impl InProgressToolCall {
     }
 }
 
+fn emit_unified_response(
+    tx_event: &mpsc::UnboundedSender<Result<UnifiedResponse>>,
+    stats: &mut StreamStats,
+    unified_response: UnifiedResponse,
+) {
+    trace!(
+        target: AI_STREAM_RESPONSE_TARGET,
+        "Responses unified response: {:?}",
+        unified_response
+    );
+    stats.record_unified_response(&unified_response);
+    let _ = tx_event.send(Ok(unified_response));
+}
+
 fn emit_tool_call_item(
     tx_event: &mpsc::UnboundedSender<Result<UnifiedResponse>>,
     stats: &mut StreamStats,
@@ -51,8 +67,7 @@ fn emit_tool_call_item(
 ) {
     if let Some(unified_response) = parse_responses_output_item(item_value) {
         if unified_response.tool_call.is_some() {
-            stats.record_unified_response(&unified_response);
-            let _ = tx_event.send(Ok(unified_response));
+            emit_unified_response(tx_event, stats, unified_response);
         }
     }
 }
@@ -130,8 +145,7 @@ fn handle_function_call_output_item_done(
                 }),
                 ..Default::default()
             };
-            stats.record_unified_response(&unified_response);
-            let _ = tx_event.send(Ok(unified_response));
+            emit_unified_response(tx_event, stats, unified_response);
         }
     }
 
@@ -210,7 +224,7 @@ pub async fn handle_responses_stream(
 
         let raw = sse.data;
         stats.record_sse_event("data");
-        trace!("Responses SSE: {:?}", raw);
+        trace!(target: AI_STREAM_RESPONSE_TARGET, "Responses SSE: {:?}", raw);
         if let Some(ref tx) = tx_raw_sse {
             let _ = tx.send(raw.clone());
         }
@@ -277,8 +291,7 @@ pub async fn handle_responses_stream(
                         text: Some(delta),
                         ..Default::default()
                     };
-                    stats.record_unified_response(&unified_response);
-                    let _ = tx_event.send(Ok(unified_response));
+                    emit_unified_response(&tx_event, &mut stats, unified_response);
                 }
             }
             "response.reasoning_text.delta" | "response.reasoning_summary_text.delta" => {
@@ -287,8 +300,7 @@ pub async fn handle_responses_stream(
                         reasoning_content: Some(delta),
                         ..Default::default()
                     };
-                    stats.record_unified_response(&unified_response);
-                    let _ = tx_event.send(Ok(unified_response));
+                    emit_unified_response(&tx_event, &mut stats, unified_response);
                 }
             }
             "response.function_call_arguments.delta" => {
@@ -323,8 +335,7 @@ pub async fn handle_responses_stream(
                     }),
                     ..Default::default()
                 };
-                stats.record_unified_response(&unified_response);
-                let _ = tx_event.send(Ok(unified_response));
+                emit_unified_response(&tx_event, &mut stats, unified_response);
             }
             "response.output_item.done" => {
                 let Some(item_value) = event.item else {
@@ -349,8 +360,7 @@ pub async fn handle_responses_stream(
                         unified_response.text = None;
                     }
                     if unified_response.text.is_some() || unified_response.tool_call.is_some() {
-                        stats.record_unified_response(&unified_response);
-                        let _ = tx_event.send(Ok(unified_response));
+                        emit_unified_response(&tx_event, &mut stats, unified_response);
                     }
                 }
             }
@@ -395,8 +405,7 @@ pub async fn handle_responses_stream(
                                         ),
                                         ..Default::default()
                                     };
-                                    stats.record_unified_response(&unified_response);
-                                    let _ = tx_event.send(Ok(unified_response));
+                                    emit_unified_response(&tx_event, &mut stats, unified_response);
                                 }
                             }
                         }
@@ -413,8 +422,7 @@ pub async fn handle_responses_stream(
                             finish_reason: Some("stop".to_string()),
                             ..Default::default()
                         };
-                        stats.record_unified_response(&unified_response);
-                        let _ = tx_event.send(Ok(unified_response));
+                        emit_unified_response(&tx_event, &mut stats, unified_response);
                         continue;
                     }
                     Some(Err(e)) => {
@@ -432,8 +440,7 @@ pub async fn handle_responses_stream(
                             finish_reason: Some("stop".to_string()),
                             ..Default::default()
                         };
-                        stats.record_unified_response(&unified_response);
-                        let _ = tx_event.send(Ok(unified_response));
+                        emit_unified_response(&tx_event, &mut stats, unified_response);
                         continue;
                     }
                 }
@@ -450,8 +457,7 @@ pub async fn handle_responses_stream(
                             finish_reason: Some("stop".to_string()),
                             ..Default::default()
                         };
-                        stats.record_unified_response(&unified_response);
-                        let _ = tx_event.send(Ok(unified_response));
+                        emit_unified_response(&tx_event, &mut stats, unified_response);
                         continue;
                     }
                     Some(Err(e)) => {
@@ -468,8 +474,7 @@ pub async fn handle_responses_stream(
                             finish_reason: Some("stop".to_string()),
                             ..Default::default()
                         };
-                        stats.record_unified_response(&unified_response);
-                        let _ = tx_event.send(Ok(unified_response));
+                        emit_unified_response(&tx_event, &mut stats, unified_response);
                         continue;
                     }
                 }
@@ -521,8 +526,7 @@ pub async fn handle_responses_stream(
                     finish_reason: Some(finish_reason),
                     ..Default::default()
                 };
-                stats.record_unified_response(&unified_response);
-                let _ = tx_event.send(Ok(unified_response));
+                emit_unified_response(&tx_event, &mut stats, unified_response);
                 continue;
             }
             _ => {}

--- a/src/crates/core/src/agentic/agents/deep_research_agent.rs
+++ b/src/crates/core/src/agentic/agents/deep_research_agent.rs
@@ -76,7 +76,10 @@ mod tests {
     fn has_expected_default_tools() {
         let agent = DeepResearchAgent::new();
         let tools = agent.default_tools();
-        assert!(tools.contains(&"Task".to_string()), "Task tool required for parallel sub-agent orchestration");
+        assert!(
+            tools.contains(&"Task".to_string()),
+            "Task tool required for parallel sub-agent orchestration"
+        );
         assert!(tools.contains(&"WebSearch".to_string()));
         assert!(tools.contains(&"WebFetch".to_string()));
         assert!(tools.contains(&"Write".to_string()));
@@ -87,7 +90,10 @@ mod tests {
     #[test]
     fn always_uses_default_prompt_template() {
         let agent = DeepResearchAgent::new();
-        assert_eq!(agent.prompt_template_name(Some("gpt-5.1")), "deep_research_agent");
+        assert_eq!(
+            agent.prompt_template_name(Some("gpt-5.1")),
+            "deep_research_agent"
+        );
         assert_eq!(agent.prompt_template_name(None), "deep_research_agent");
     }
 }

--- a/src/crates/core/src/agentic/agents/mod.rs
+++ b/src/crates/core/src/agentic/agents/mod.rs
@@ -35,7 +35,6 @@ pub use file_finder_agent::FileFinderAgent;
 pub use generate_doc_agent::GenerateDocAgent;
 pub use init_agent::InitAgent;
 pub use plan_mode::PlanMode;
-pub use team_mode::TeamMode;
 pub use prompt_builder::{
     PromptBuilder, PromptBuilderContext, RemoteExecutionHints, RequestContextPolicy,
     RequestContextSection,
@@ -45,6 +44,7 @@ pub use registry::{
     CustomSubagentDetail, SubAgentSource,
 };
 use std::any::Any;
+pub use team_mode::TeamMode;
 
 // Include embedded prompts generated at compile time
 include!(concat!(env!("OUT_DIR"), "/embedded_agents_prompt.rs"));

--- a/src/crates/core/src/agentic/agents/prompt_builder/mod.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/mod.rs
@@ -1,5 +1,5 @@
-mod request_context;
 mod prompt_builder_impl;
+mod request_context;
 
 pub use prompt_builder_impl::{PromptBuilder, PromptBuilderContext, RemoteExecutionHints};
 pub use request_context::{RequestContextPolicy, RequestContextSection};

--- a/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
@@ -128,7 +128,7 @@ IMPORTANT: Whenever you mention a file path that the user might want to open, ma
 - Source file: [filename.ts](src/filename.ts)
 - Specific line: [filename.ts:42](src/filename.ts#L42)
 - Generated report: [report.md](computer://deep-research/report.md)
-- Plan file: [my-plan.plan.md](computer://.bitfun/plans/my-plan.plan.md)
+- Plan file returned by a tool: [my-plan.plan.md](computer:///Users/alice/.bitfun/projects/my-project/plans/my-plan.plan.md)
 </good-examples>
 <bad-examples>
 - Bare path: src/filename.ts

--- a/src/crates/core/src/agentic/agents/prompts/plan_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/plan_mode.md
@@ -44,7 +44,7 @@ At any point in time through this workflow you should feel free to ask the user 
 
 1. When you're done researching, present your plan by calling the CreatePlan tool, which creates a plan file for user approval. Do NOT make any file changes or run any tools that modify the system state in any way.
 
-2. After the CreatePlan tool succeeds, briefly tell the user the plan is ready and wait for user approval. Your final reply in that turn MUST include the clickable `computer://` link returned by the tool (e.g. `[plan-name.plan.md](computer://.bitfun/plans/plan-name.plan.md)`). Do NOT output the path as plain text or wrap it in backticks. Do not continue with more research or additional planning work in the same turn.
+2. After the CreatePlan tool succeeds, briefly tell the user the plan is ready and wait for user approval. Your final reply in that turn MUST include the clickable `computer://` link returned by the tool (e.g. `[plan-name.plan.md](computer:///Users/alice/.bitfun/projects/my-project/plans/plan-name.plan.md`). Do NOT output the path as plain text or wrap it in backticks. Do not continue with more research or additional planning work in the same turn.
 
 3. To update the plan, edit the plan file returned by the CreatePlan tool directly.
 

--- a/src/crates/core/src/agentic/agents/registry.rs
+++ b/src/crates/core/src/agentic/agents/registry.rs
@@ -1,5 +1,5 @@
 use super::{
-    Agent, AgenticMode, ClawMode, CodeReviewAgent, CoworkMode, DeepResearchAgent, DebugMode,
+    Agent, AgenticMode, ClawMode, CodeReviewAgent, CoworkMode, DebugMode, DeepResearchAgent,
     ExploreAgent, FileFinderAgent, GenerateDocAgent, InitAgent, PlanMode, TeamMode,
 };
 use crate::agentic::agents::custom_subagents::{
@@ -1072,7 +1072,15 @@ mod tests {
 
     #[test]
     fn top_level_modes_default_to_auto() {
-        for agent_type in ["agentic", "Cowork", "Plan", "debug", "Claw", "DeepResearch", "Team"] {
+        for agent_type in [
+            "agentic",
+            "Cowork",
+            "Plan",
+            "debug",
+            "Claw",
+            "DeepResearch",
+            "Team",
+        ] {
             assert_eq!(default_model_id_for_builtin_agent(agent_type), "auto");
         }
     }

--- a/src/crates/core/src/agentic/execution/stream_processor.rs
+++ b/src/crates/core/src/agentic/execution/stream_processor.rs
@@ -497,7 +497,8 @@ impl StreamProcessor {
             if ctx.pending_tool_call.has_pending() {
                 ctx.has_effective_output = true;
                 if arguments_is_snapshot {
-                    ctx.pending_tool_call.replace_arguments(&tool_call_arguments);
+                    ctx.pending_tool_call
+                        .replace_arguments(&tool_call_arguments);
                 } else {
                     ctx.pending_tool_call.append_arguments(&tool_call_arguments);
                 }

--- a/src/crates/core/src/agentic/insights/session_paths.rs
+++ b/src/crates/core/src/agentic/insights/session_paths.rs
@@ -1,13 +1,17 @@
 //! Resolve on-disk session roots for insights (local + remote SSH mirror).
 
+use crate::infrastructure::get_path_manager_arc;
 use crate::service::remote_ssh::workspace_state::get_effective_session_path;
 use crate::service::workspace::{get_global_workspace_service, WorkspaceInfo};
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-/// Map a workspace record to the directory where `.bitfun/sessions` lives
-/// (local project root or `~/.bitfun/remote_ssh/...` mirror).
+/// Map a workspace record to the directory where persisted sessions live.
 pub async fn effective_session_storage_path_for_workspace(ws: &WorkspaceInfo) -> PathBuf {
+    if ws.remote_ssh_connection_id().is_none() {
+        return get_path_manager_arc().project_sessions_dir(&ws.root_path);
+    }
+
     let path_str = ws.root_path.to_string_lossy().to_string();
     let conn = ws.remote_ssh_connection_id().map(|s| s.to_string());
     let mut host = ws
@@ -28,7 +32,7 @@ pub async fn effective_session_storage_path_for_workspace(ws: &WorkspaceInfo) ->
     get_effective_session_path(&path_str, conn.as_deref(), host.as_deref()).await
 }
 
-/// Unique effective roots that have a `.bitfun/sessions` directory.
+/// Unique effective session directories for all tracked workspaces.
 pub async fn collect_effective_session_storage_roots() -> Vec<PathBuf> {
     let mut paths = Vec::new();
     let mut seen = HashSet::new();
@@ -38,10 +42,9 @@ pub async fn collect_effective_session_storage_roots() -> Vec<PathBuf> {
     };
 
     for ws in ws_service.list_workspace_infos().await {
-        let root = effective_session_storage_path_for_workspace(&ws).await;
-        let sessions_dir = root.join(".bitfun").join("sessions");
-        if sessions_dir.exists() && seen.insert(root.clone()) {
-            paths.push(root);
+        let sessions_dir = effective_session_storage_path_for_workspace(&ws).await;
+        if sessions_dir.exists() && seen.insert(sessions_dir.clone()) {
+            paths.push(sessions_dir);
         }
     }
 

--- a/src/crates/core/src/agentic/persistence/manager.rs
+++ b/src/crates/core/src/agentic/persistence/manager.rs
@@ -14,6 +14,7 @@ use crate::service::session::{
     DialogTurnData, SessionMetadata, SessionStatus, SessionTranscriptExport,
     SessionTranscriptExportOptions, SessionTranscriptIndexEntry, ToolItemData, TranscriptLineRange,
 };
+use crate::service::workspace_runtime::WorkspaceRuntimeService;
 use crate::util::errors::{BitFunError, BitFunResult};
 use log::{info, warn};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -166,16 +167,24 @@ struct ParsedTranscriptTurnSelector {
 
 pub struct PersistenceManager {
     path_manager: Arc<PathManager>,
+    runtime_service: Arc<WorkspaceRuntimeService>,
 }
 
 impl PersistenceManager {
     pub fn new(path_manager: Arc<PathManager>) -> BitFunResult<Self> {
-        Ok(Self { path_manager })
+        Ok(Self {
+            runtime_service: Arc::new(WorkspaceRuntimeService::new(path_manager.clone())),
+            path_manager,
+        })
     }
 
     /// Get PathManager reference
     pub fn path_manager(&self) -> &Arc<PathManager> {
         &self.path_manager
+    }
+
+    pub fn runtime_service(&self) -> &Arc<WorkspaceRuntimeService> {
+        &self.runtime_service
     }
 
     fn project_sessions_dir(&self, workspace_path: &Path) -> PathBuf {
@@ -239,15 +248,21 @@ impl PersistenceManager {
         self.project_sessions_dir(workspace_path).join("index.json")
     }
 
-    async fn ensure_project_sessions_dir(&self, workspace_path: &Path) -> BitFunResult<PathBuf> {
+    fn existing_project_sessions_dir(&self, workspace_path: &Path) -> Option<PathBuf> {
         let dir = self.project_sessions_dir(workspace_path);
-        fs::create_dir_all(&dir).await.map_err(|e| {
-            BitFunError::io(format!(
-                "Failed to create project sessions directory: {}",
-                e
-            ))
-        })?;
-        Ok(dir)
+        dir.exists().then_some(dir)
+    }
+
+    async fn ensure_runtime_for_write(&self, workspace_path: &Path) -> BitFunResult<()> {
+        let remote_mirror_root = PathManager::remote_ssh_mirror_root();
+        if workspace_path.starts_with(&remote_mirror_root) {
+            return Ok(());
+        }
+
+        self.runtime_service
+            .ensure_local_workspace_runtime(workspace_path)
+            .await
+            .map(|_| ())
     }
 
     async fn ensure_session_dir(
@@ -1165,7 +1180,9 @@ impl PersistenceManager {
         &self,
         workspace_path: &Path,
     ) -> BitFunResult<Vec<SessionMetadata>> {
-        let sessions_root = self.ensure_project_sessions_dir(workspace_path).await?;
+        let Some(sessions_root) = self.existing_project_sessions_dir(workspace_path) else {
+            return Ok(Vec::new());
+        };
         let mut metadata_list = Vec::new();
         let mut entries = fs::read_dir(&sessions_root)
             .await
@@ -1307,6 +1324,10 @@ impl PersistenceManager {
             return Ok(Vec::new());
         }
 
+        if self.existing_project_sessions_dir(workspace_path).is_none() {
+            return Ok(Vec::new());
+        }
+
         let lock = self.get_session_index_lock(workspace_path).await;
         let _guard = lock.lock().await;
         let index_path = self.index_path(workspace_path);
@@ -1340,6 +1361,10 @@ impl PersistenceManager {
             return Ok(Vec::new());
         }
 
+        if self.existing_project_sessions_dir(workspace_path).is_none() {
+            return Ok(Vec::new());
+        }
+
         self.scan_session_metadata_dirs(workspace_path).await
     }
 
@@ -1348,6 +1373,7 @@ impl PersistenceManager {
         workspace_path: &Path,
         metadata: &SessionMetadata,
     ) -> BitFunResult<()> {
+        self.ensure_runtime_for_write(workspace_path).await?;
         self.ensure_session_dir(workspace_path, &metadata.session_id)
             .await?;
 
@@ -1411,6 +1437,7 @@ impl PersistenceManager {
         turn_index: usize,
         messages: &[Message],
     ) -> BitFunResult<()> {
+        self.ensure_runtime_for_write(workspace_path).await?;
         self.ensure_snapshots_dir(workspace_path, session_id)
             .await?;
 
@@ -1537,6 +1564,7 @@ impl PersistenceManager {
 
     /// Save session
     pub async fn save_session(&self, workspace_path: &Path, session: &Session) -> BitFunResult<()> {
+        self.ensure_runtime_for_write(workspace_path).await?;
         self.ensure_session_dir(workspace_path, &session.session_id)
             .await?;
 
@@ -1631,6 +1659,7 @@ impl PersistenceManager {
         session_id: &str,
         state: &SessionState,
     ) -> BitFunResult<()> {
+        self.ensure_runtime_for_write(workspace_path).await?;
         let mut stored_state = self
             .load_stored_session_state(workspace_path, session_id)
             .await?
@@ -1711,6 +1740,7 @@ impl PersistenceManager {
         workspace_path: &Path,
         turn: &DialogTurnData,
     ) -> BitFunResult<()> {
+        self.ensure_runtime_for_write(workspace_path).await?;
         let mut metadata = self
             .load_session_metadata(workspace_path, &turn.session_id)
             .await?
@@ -2308,5 +2338,58 @@ mod tests {
         assert!(visible.is_empty());
         assert_eq!(raw.len(), 1);
         assert!(raw[0].is_legacy_leaked_subagent_candidate());
+    }
+
+    #[tokio::test]
+    async fn listing_sessions_does_not_create_sessions_dir_for_uninitialized_runtime() {
+        let workspace = TestWorkspace::new();
+        let manager = PersistenceManager::new(Arc::new(PathManager::new().expect("path manager")))
+            .expect("persistence manager");
+
+        let visible = manager
+            .list_session_metadata(workspace.path())
+            .await
+            .expect("visible listing should succeed");
+        let raw = manager
+            .list_session_metadata_including_internal(workspace.path())
+            .await
+            .expect("raw listing should succeed");
+
+        assert!(visible.is_empty());
+        assert!(raw.is_empty());
+        assert!(
+            !manager.project_sessions_dir(workspace.path()).exists(),
+            "listing sessions should not create the runtime sessions directory"
+        );
+    }
+
+    #[tokio::test]
+    async fn saving_session_metadata_ensures_runtime_layout_before_writing() {
+        let workspace = TestWorkspace::new();
+        let manager = PersistenceManager::new(Arc::new(PathManager::new().expect("path manager")))
+            .expect("persistence manager");
+
+        let metadata = SessionMetadata::new(
+            Uuid::new_v4().to_string(),
+            "Runtime ensure".to_string(),
+            "agent".to_string(),
+            "model".to_string(),
+        );
+
+        manager
+            .save_session_metadata(workspace.path(), &metadata)
+            .await
+            .expect("metadata should save");
+
+        let runtime = manager
+            .runtime_service()
+            .context_for_local_workspace(workspace.path());
+        assert!(runtime.runtime_root.exists());
+        assert!(runtime.sessions_dir.exists());
+        assert!(runtime.snapshot_by_hash_dir.exists());
+        assert!(runtime.snapshot_metadata_dir.exists());
+        assert!(runtime.snapshot_operations_dir.exists());
+        assert!(runtime.plans_dir.exists());
+        assert!(runtime.layout_state_file.exists());
     }
 }

--- a/src/crates/core/src/agentic/persistence/session_workspace_maintenance.rs
+++ b/src/crates/core/src/agentic/persistence/session_workspace_maintenance.rs
@@ -115,6 +115,7 @@ mod tests {
     use crate::agentic::persistence::PersistenceManager;
     use crate::infrastructure::PathManager;
     use crate::service::session::SessionMetadata;
+    use crate::service::workspace_runtime::WorkspaceRuntimeService;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use uuid::Uuid;
@@ -213,5 +214,64 @@ mod tests {
             .expect("second maintenance should succeed");
         assert!(second_report.skipped);
         assert_eq!(second_report.deleted_sessions, 0);
+    }
+
+    #[tokio::test]
+    async fn legacy_hidden_sessions_are_migrated_then_cleaned_after_runtime_ensure() {
+        let workspace = TestWorkspace::new();
+        let path_manager = Arc::new(PathManager::new().expect("path manager"));
+        let runtime_service = WorkspaceRuntimeService::new(path_manager.clone());
+        let persistence_manager =
+            Arc::new(PersistenceManager::new(path_manager.clone()).expect("persistence manager"));
+        let maintenance = SessionWorkspaceMaintenanceService::new(persistence_manager.clone());
+
+        let mut legacy_hidden = SessionMetadata::new(
+            Uuid::new_v4().to_string(),
+            "Subagent: stale task".to_string(),
+            "agent".to_string(),
+            "model".to_string(),
+        );
+        legacy_hidden.created_by = Some("session-parent".to_string());
+
+        persistence_manager
+            .save_session_metadata(workspace.path(), &legacy_hidden)
+            .await
+            .expect("metadata should save");
+
+        let runtime_context = runtime_service.context_for_local_workspace(workspace.path());
+        let legacy_sessions_root = workspace.path().join(".bitfun").join("sessions");
+        std::fs::create_dir_all(&legacy_sessions_root).expect("legacy sessions root should exist");
+        std::fs::rename(
+            runtime_context.sessions_dir.join(&legacy_hidden.session_id),
+            legacy_sessions_root.join(&legacy_hidden.session_id),
+        )
+        .expect("session directory should move back to legacy location");
+        let _ = std::fs::remove_dir_all(&runtime_context.runtime_root);
+
+        runtime_service
+            .ensure_local_workspace_runtime(workspace.path())
+            .await
+            .expect("runtime ensure should migrate legacy sessions");
+
+        let report = maintenance
+            .ensure_workspace_maintained(workspace.path())
+            .await
+            .expect("maintenance should succeed");
+
+        assert_eq!(report.hidden_sessions, 1);
+        assert_eq!(report.deleted_sessions, 1);
+        assert!(
+            !runtime_context
+                .sessions_dir
+                .join(&legacy_hidden.session_id)
+                .exists(),
+            "hidden session should be deleted from migrated runtime storage"
+        );
+        assert!(
+            !legacy_sessions_root
+                .join(&legacy_hidden.session_id)
+                .exists(),
+            "legacy session directory should not remain after migration and cleanup"
+        );
     }
 }

--- a/src/crates/core/src/agentic/tools/framework.rs
+++ b/src/crates/core/src/agentic/tools/framework.rs
@@ -1,14 +1,55 @@
 //! Tool framework - Tool interface definition and execution context
+use crate::agentic::tools::workspace_paths::{
+    build_bitfun_runtime_uri, is_bitfun_runtime_uri, normalize_runtime_relative_path,
+    parse_bitfun_runtime_uri,
+};
 use crate::agentic::workspace::WorkspaceServices;
 use crate::agentic::WorkspaceBinding;
+use crate::infrastructure::get_path_manager_arc;
+use crate::service::remote_ssh::workspace_state::remote_workspace_runtime_root;
+use crate::service::{get_workspace_runtime_service_arc, WorkspaceRuntimeContext};
 use crate::util::errors::BitFunResult;
 use crate::util::types::ToolImageAttachment;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolPathBackend {
+    Local,
+    RemoteWorkspace,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolPathResolution {
+    pub requested_path: String,
+    pub logical_path: String,
+    pub resolved_path: String,
+    pub backend: ToolPathBackend,
+    pub runtime_scope: Option<String>,
+    pub runtime_root: Option<PathBuf>,
+}
+
+impl ToolPathResolution {
+    pub fn uses_remote_workspace_backend(&self) -> bool {
+        matches!(self.backend, ToolPathBackend::RemoteWorkspace)
+    }
+
+    pub fn is_runtime_artifact(&self) -> bool {
+        self.runtime_scope.is_some()
+    }
+
+    pub fn logical_child_path(&self, absolute_child_path: &Path) -> Option<String> {
+        let scope = self.runtime_scope.as_deref()?;
+        let root = self.runtime_root.as_ref()?;
+        let relative = absolute_child_path.strip_prefix(root).ok()?;
+        let relative_str = relative.to_string_lossy().replace('\\', "/");
+        build_bitfun_runtime_uri(scope, &relative_str).ok()
+    }
+}
 
 /// Tool use context
 #[derive(Debug, Clone)]
@@ -69,8 +110,159 @@ impl ToolUseContext {
         )
     }
 
+    pub fn current_workspace_runtime_root(&self) -> BitFunResult<PathBuf> {
+        let workspace = self.workspace.as_ref().ok_or_else(|| {
+            crate::util::errors::BitFunError::tool(
+                "A workspace is required to resolve runtime artifacts".to_string(),
+            )
+        })?;
+
+        if workspace.is_remote() {
+            let identity = &workspace.session_identity;
+            Ok(remote_workspace_runtime_root(
+                &identity.hostname,
+                &identity.workspace_path,
+            ))
+        } else {
+            Ok(get_path_manager_arc().project_runtime_root(workspace.root_path()))
+        }
+    }
+
+    pub fn current_workspace_scope(&self) -> Option<String> {
+        self.workspace
+            .as_ref()
+            .and_then(|workspace| workspace.workspace_id.clone())
+    }
+
+    pub async fn ensure_current_workspace_runtime(&self) -> BitFunResult<WorkspaceRuntimeContext> {
+        let workspace = self.workspace.as_ref().ok_or_else(|| {
+            crate::util::errors::BitFunError::tool(
+                "A workspace is required to ensure runtime artifacts".to_string(),
+            )
+        })?;
+
+        let runtime_service = get_workspace_runtime_service_arc();
+        Ok(runtime_service
+            .ensure_runtime_for_workspace_binding(workspace)
+            .await?
+            .context)
+    }
+
+    pub fn should_emit_runtime_uri(&self) -> bool {
+        self.is_remote()
+    }
+
+    pub fn build_runtime_uri(&self, relative_path: &str) -> BitFunResult<String> {
+        let scope = self
+            .current_workspace_scope()
+            .unwrap_or_else(|| "current".to_string());
+        build_bitfun_runtime_uri(&scope, &normalize_runtime_relative_path(relative_path)?)
+    }
+
+    pub fn build_runtime_artifact_reference(&self, relative_path: &str) -> BitFunResult<String> {
+        let normalized_relative_path = normalize_runtime_relative_path(relative_path)?;
+        if self.should_emit_runtime_uri() {
+            return self.build_runtime_uri(&normalized_relative_path);
+        }
+
+        let mut resolved_path = self.current_workspace_runtime_root()?;
+        for segment in normalized_relative_path.split('/') {
+            resolved_path.push(segment);
+        }
+
+        Ok(resolved_path.to_string_lossy().to_string())
+    }
+
+    pub fn build_session_runtime_artifact_reference(
+        &self,
+        session_id: &str,
+        relative_path: &str,
+    ) -> BitFunResult<String> {
+        let normalized_relative_path = normalize_runtime_relative_path(relative_path)?;
+        self.build_runtime_artifact_reference(&format!(
+            "sessions/{}/{}",
+            session_id, normalized_relative_path
+        ))
+    }
+
+    pub fn current_workspace_session_dir(&self, session_id: &str) -> BitFunResult<PathBuf> {
+        Ok(self
+            .current_workspace_runtime_root()?
+            .join("sessions")
+            .join(session_id))
+    }
+
+    pub fn current_workspace_session_tool_results_dir(
+        &self,
+        session_id: &str,
+    ) -> BitFunResult<PathBuf> {
+        Ok(self
+            .current_workspace_session_dir(session_id)?
+            .join("tool-results"))
+    }
+
+    pub fn current_workspace_session_tool_result_path(
+        &self,
+        session_id: &str,
+        file_name: &str,
+    ) -> BitFunResult<PathBuf> {
+        Ok(self
+            .current_workspace_session_tool_results_dir(session_id)?
+            .join(file_name))
+    }
+
+    pub fn resolve_tool_path(&self, path: &str) -> BitFunResult<ToolPathResolution> {
+        if is_bitfun_runtime_uri(path) {
+            let parsed = parse_bitfun_runtime_uri(path)?;
+            let workspace_scope = self.current_workspace_scope();
+            let scope_matches = parsed.workspace_scope == "current"
+                || workspace_scope.as_deref() == Some(parsed.workspace_scope.as_str());
+            if !scope_matches {
+                return Err(crate::util::errors::BitFunError::tool(format!(
+                    "Runtime URI scope '{}' does not match the current workspace",
+                    parsed.workspace_scope
+                )));
+            }
+
+            let runtime_root = self.current_workspace_runtime_root()?;
+            let mut resolved_path = runtime_root.clone();
+            for segment in parsed.relative_path.split('/') {
+                resolved_path.push(segment);
+            }
+
+            let effective_scope = workspace_scope.unwrap_or_else(|| parsed.workspace_scope.clone());
+            let logical_path = build_bitfun_runtime_uri(&effective_scope, &parsed.relative_path)?;
+
+            return Ok(ToolPathResolution {
+                requested_path: path.to_string(),
+                logical_path,
+                resolved_path: resolved_path.to_string_lossy().to_string(),
+                backend: ToolPathBackend::Local,
+                runtime_scope: Some(effective_scope),
+                runtime_root: Some(runtime_root),
+            });
+        }
+
+        let resolved_path = self.resolve_workspace_tool_path(path)?;
+        Ok(ToolPathResolution {
+            requested_path: path.to_string(),
+            logical_path: resolved_path.clone(),
+            resolved_path,
+            backend: if self.is_remote() {
+                ToolPathBackend::RemoteWorkspace
+            } else {
+                ToolPathBackend::Local
+            },
+            runtime_scope: None,
+            runtime_root: None,
+        })
+    }
+
     /// Whether `path` is absolute for the active workspace (POSIX `/` for remote SSH).
     pub fn workspace_path_is_effectively_absolute(&self, path: &str) -> bool {
+        if is_bitfun_runtime_uri(path) {
+            return true;
+        }
         if self.is_remote() {
             crate::agentic::tools::workspace_paths::posix_style_path_is_absolute(path)
         } else {

--- a/src/crates/core/src/agentic/tools/implementations/bash_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/bash_tool.rs
@@ -781,6 +781,19 @@ Usage notes:
 }
 
 impl BashTool {
+    fn background_output_file_path(
+        context: &ToolUseContext,
+        chat_session_id: &str,
+        tool_use_id: &str,
+    ) -> Option<std::path::PathBuf> {
+        context
+            .current_workspace_session_tool_result_path(
+                chat_session_id,
+                &format!("{}.txt", tool_use_id),
+            )
+            .ok()
+    }
+
     /// Execute a command in a new background terminal session.
     /// Returns immediately with the new session ID.
     #[allow(clippy::too_many_arguments)]
@@ -845,12 +858,11 @@ impl BashTool {
             bg_session_id, chat_session_id
         );
 
-        // Determine output file path: <workspace>/.bitfun/terminals/<bg_session_id>.txt
-        let output_file_path = context.workspace_root().map(|ws| {
-            ws.join(".bitfun")
-                .join("terminals")
-                .join(format!("{}.txt", bg_session_id))
-        });
+        // Store background output under the session-scoped runtime tool-results tree:
+        // local:  ~/.bitfun/projects/<project-slug>/sessions/<chat-session-id>/tool-results/<tool-use-id>.txt
+        // remote: ~/.bitfun/remote_ssh/<host>/<remote-path>/sessions/<chat-session-id>/tool-results/<tool-use-id>.txt
+        let output_file_path =
+            Self::background_output_file_path(context, chat_session_id, &tool_use_id);
 
         // Spawn task: write PTY output to file, delete when session ends
         if let Some(file_path) = output_file_path.clone() {
@@ -859,7 +871,7 @@ impl BashTool {
                 if let Some(parent) = file_path.parent() {
                     if let Err(e) = tokio::fs::create_dir_all(parent).await {
                         error!(
-                            "Failed to create terminals output dir for bg session {}: {}",
+                            "Failed to create tool-results output dir for bg session {}: {}",
                             bg_id_for_log, e
                         );
                         return;
@@ -912,8 +924,15 @@ impl BashTool {
         let execution_time_ms = start_time.elapsed().as_millis() as u64;
 
         let output_file_str = output_file_path.as_deref().map(|p| p.display().to_string());
+        let output_file_reference = context
+            .build_session_runtime_artifact_reference(
+                chat_session_id,
+                &format!("tool-results/{}.txt", tool_use_id),
+            )
+            .ok()
+            .or_else(|| output_file_str.clone());
 
-        let output_file_note = output_file_str
+        let output_file_note = output_file_reference
             .as_deref()
             .map(|s| format!("\nOutput is being written to: {}", s))
             .unwrap_or_default();
@@ -927,7 +946,7 @@ impl BashTool {
             "working_directory": initial_cwd,
             "execution_time_ms": execution_time_ms,
             "terminal_session_id": bg_session_id,
-            "output_file": output_file_str,
+            "output_file": output_file_reference,
         });
 
         let result_for_assistant = format!(

--- a/src/crates/core/src/agentic/tools/implementations/computer_use_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/computer_use_tool.rs
@@ -1545,9 +1545,7 @@ impl Tool for ComputerUseTool {
                 let scroll_pos_x = input.get("scroll_x").and_then(|v| v.as_i64());
                 let scroll_pos_y = input.get("scroll_y").and_then(|v| v.as_i64());
                 if let (Some(sx), Some(sy)) = (scroll_pos_x, scroll_pos_y) {
-                    host_ref
-                        .mouse_move_global_f64(sx as f64, sy as f64)
-                        .await?;
+                    host_ref.mouse_move_global_f64(sx as f64, sy as f64).await?;
                     host_ref.wait_ms(30).await?;
                 }
                 host_ref.scroll(dx, dy).await?;

--- a/src/crates/core/src/agentic/tools/implementations/create_plan_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/create_plan_tool.rs
@@ -3,7 +3,6 @@
 //! Used to create and store plan files during the planning phase
 
 use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
-use crate::infrastructure::get_path_manager_arc;
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
 use serde::Serialize;
@@ -70,7 +69,7 @@ You should provide a structured list of implementation todos:
 
 UPDATING THE PLAN:
 - This tool creates a NEW plan file each time it is called
-- The plan file URI will be returned in the tool result
+- The plan file path returned in the tool result may be an absolute runtime path (local) or a `bitfun://runtime/...` URI (remote)
 - To update an existing plan, read and edit the plan file directly using your file editing tools
 - Do NOT call CreatePlan again to update an existing plan
 
@@ -181,51 +180,13 @@ Additional guidelines:
 
         let file_content = generate_plan_file_content(name, overview, plan, todos);
 
-        let plan_file_path_str = if context.is_remote() {
-            let ws_fs = context.ws_fs().ok_or_else(|| {
-                BitFunError::tool(
-                    "Workspace file system not available for remote CreatePlan".to_string(),
-                )
-            })?;
-            let ws_shell = context.ws_shell().ok_or_else(|| {
-                BitFunError::tool("Workspace shell not available for remote CreatePlan".to_string())
-            })?;
-            let root = context
-                .workspace
-                .as_ref()
-                .map(|w| w.root_path_string())
-                .ok_or_else(|| BitFunError::tool("Workspace path not set".to_string()))?;
-            ws_shell
-                .exec("mkdir -p .bitfun/plans", Some(30_000))
-                .await
-                .map_err(|e| {
-                    BitFunError::tool(format!("Failed to create plans directory: {}", e))
-                })?;
-            let plan_path = format!(
-                "{}/.bitfun/plans/{}",
-                root.trim_end_matches('/'),
-                plan_file_name
-            );
-            ws_fs
-                .write_file(&plan_path, file_content.as_bytes())
-                .await
-                .map_err(|e| BitFunError::tool(format!("Failed to write plan file: {}", e)))?;
-            plan_path
-        } else {
-            let workspace_path = context
-                .workspace_root()
-                .ok_or(BitFunError::tool("Workspace path not set".to_string()))?;
-            let path_manager = get_path_manager_arc();
-            let plans_dir = path_manager.project_plans_dir(workspace_path);
-            let plan_file_path = plans_dir.join(&plan_file_name);
-            path_manager.ensure_dir(&plans_dir).await.map_err(|e| {
-                BitFunError::tool(format!("Failed to create plans directory: {}", e))
-            })?;
-            fs::write(&plan_file_path, &file_content)
-                .await
-                .map_err(|e| BitFunError::tool(format!("Failed to write plan file: {}", e)))?;
-            plan_file_path.to_string_lossy().to_string()
-        };
+        let runtime_context = context.ensure_current_workspace_runtime().await?;
+        let plans_dir = runtime_context.plans_dir.clone();
+        let plan_file_path = plans_dir.join(&plan_file_name);
+        fs::write(&plan_file_path, &file_content)
+            .await
+            .map_err(|e| BitFunError::tool(format!("Failed to write plan file: {}", e)))?;
+        let plan_file_path_str = plan_file_path.to_string_lossy().to_string();
 
         // Process todos for return result
         let processed_todos: Vec<Value> = if let Some(todos_arr) = todos {
@@ -246,9 +207,8 @@ Additional guidelines:
             vec![]
         };
 
-        // Build a workspace-relative path for the computer:// link so the user can
-        // click it directly in the chat interface. Falls back to the absolute path
-        // for remote workspaces where a relative path cannot be derived.
+        // Prefer workspace-relative computer:// links, but fall back to an
+        // absolute computer:// path when plans live outside the workspace tree.
         let computer_link = context
             .workspace_root()
             .and_then(|root| {
@@ -257,20 +217,24 @@ Additional guidelines:
                     .ok()
                     .map(|rel| format!("computer://{}", rel.to_string_lossy().replace('\\', "/")))
             })
-            .unwrap_or_else(|| plan_file_path_str.clone());
+            .unwrap_or_else(|| format!("computer://{}", plan_file_path_str.replace('\\', "/")));
+
+        let plan_reference =
+            context.build_runtime_artifact_reference(&format!("plans/{}", plan_file_name))?;
 
         let result_for_assistant = format!(
-            "Plan file created. Absolute path: {}\nLink for user: [{}]({})\nYour next reply MUST show the clickable link [{}]({}) and then end the conversation turn. Do not continue with more planning details or additional questions.",
-            plan_file_path_str,
-            plan_file_name,
-            computer_link,
+            "Plan file created at: {}
+Clickable link for user: [{}]({})
+Your next reply MUST show the clickable link and then end the conversation turn. Do not continue with more planning details or additional questions.",
+            plan_reference,
             plan_file_name,
             computer_link,
         );
 
         let result = json!({
             "success": true,
-            "plan_file_path": plan_file_path_str,
+            "plan_file_path": plan_reference,
+            "computer_link": computer_link.clone(),
             "plan_file_name": plan_file_name,
             "name": name,
             "overview": overview,

--- a/src/crates/core/src/agentic/tools/implementations/delete_file_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/delete_file_tool.rs
@@ -1,6 +1,7 @@
 use crate::agentic::tools::framework::{
     Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
+use crate::agentic::tools::workspace_paths::is_bitfun_runtime_uri;
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
 use log::debug;
@@ -46,7 +47,7 @@ Usage guidelines:
    - Be careful with recursive deletion as it will remove all contents
 
 3. **Path Requirements**:
-   - You can use either relative paths (e.g., "temp/data.txt") or absolute paths (e.g., "/workspace/temp/data.txt")
+   - You can use either relative paths (e.g., "temp/data.txt"), absolute paths (e.g., "/workspace/temp/data.txt"), or exact `bitfun://runtime/...` URIs returned by another tool
    - Relative paths will be automatically resolved relative to the workspace directory
    - The path must exist in the filesystem
 
@@ -88,7 +89,7 @@ Important notes:
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "The absolute path to the file or directory to delete"
+                    "description": "The absolute path to the file or directory to delete, or an exact bitfun://runtime URI returned by another tool"
                 },
                 "recursive": {
                     "type": "boolean",
@@ -137,25 +138,62 @@ Important notes:
             };
         }
 
-        let is_abs = context
-            .map(|c| c.workspace_path_is_effectively_absolute(path_str))
-            .unwrap_or_else(|| Path::new(path_str).is_absolute());
-        if !is_abs {
-            return ValidationResult {
-                result: false,
-                message: Some("path must be an absolute path".to_string()),
-                error_code: Some(400),
-                meta: None,
-            };
-        }
+        let resolved = match context.map(|ctx| ctx.resolve_tool_path(path_str)) {
+            Some(Ok(value)) => value,
+            Some(Err(err)) => {
+                return ValidationResult {
+                    result: false,
+                    message: Some(err.to_string()),
+                    error_code: Some(400),
+                    meta: None,
+                };
+            }
+            None => {
+                if is_bitfun_runtime_uri(path_str) {
+                    return ValidationResult {
+                        result: false,
+                        message: Some(
+                            "Tool context is required to resolve bitfun runtime URIs".to_string(),
+                        ),
+                        error_code: Some(400),
+                        meta: None,
+                    };
+                }
 
-        let is_remote = context.map(|c| c.is_remote()).unwrap_or(false);
-        if !is_remote {
-            let local_path = Path::new(path_str);
+                let local_path = Path::new(path_str);
+                if !local_path.is_absolute() {
+                    return ValidationResult {
+                        result: false,
+                        message: Some("path must be an absolute path".to_string()),
+                        error_code: Some(400),
+                        meta: None,
+                    };
+                }
+
+                if !local_path.exists() {
+                    return ValidationResult {
+                        result: false,
+                        message: Some(format!("Path does not exist: {}", path_str)),
+                        error_code: Some(404),
+                        meta: None,
+                    };
+                }
+
+                return ValidationResult {
+                    result: true,
+                    message: None,
+                    error_code: None,
+                    meta: None,
+                };
+            }
+        };
+
+        if !resolved.uses_remote_workspace_backend() {
+            let local_path = Path::new(&resolved.resolved_path);
             if !local_path.exists() {
                 return ValidationResult {
                     result: false,
-                    message: Some(format!("Path does not exist: {}", path_str)),
+                    message: Some(format!("Path does not exist: {}", resolved.logical_path)),
                     error_code: Some(404),
                     meta: None,
                 };
@@ -174,11 +212,11 @@ Important notes:
 
                 if !is_empty && !recursive {
                     return ValidationResult {
-                        result: false,
-                        message: Some(format!("Directory is not empty: {}. Set recursive=true to delete non-empty directories", path_str)),
-                        error_code: Some(400),
-                        meta: Some(json!({
-                            "is_directory": true,
+                            result: false,
+                            message: Some(format!("Directory is not empty: {}. Set recursive=true to delete non-empty directories", resolved.logical_path)),
+                            error_code: Some(400),
+                            meta: Some(json!({
+                                "is_directory": true,
                             "is_empty": false,
                             "requires_recursive": true
                         })),
@@ -242,18 +280,18 @@ Important notes:
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        let resolved_path = context.resolve_workspace_tool_path(path_str)?;
+        let resolved = context.resolve_tool_path(path_str)?;
 
-        // Remote workspace: delete via shell command
-        if context.is_remote() {
+        // Remote workspace path: delete via shell command
+        if resolved.uses_remote_workspace_backend() {
             let ws_shell = context.ws_shell().ok_or_else(|| {
                 BitFunError::tool("Workspace shell not available for remote Delete".to_string())
             })?;
 
             let rm_cmd = if recursive {
-                format!("rm -rf '{}'", resolved_path.replace('\'', "'\\''"))
+                format!("rm -rf '{}'", resolved.resolved_path.replace('\'', "'\\''"))
             } else {
-                format!("rm -f '{}'", resolved_path.replace('\'', "'\\''"))
+                format!("rm -f '{}'", resolved.resolved_path.replace('\'', "'\\''"))
             };
 
             let (_stdout, stderr, exit_code) = ws_shell
@@ -270,7 +308,7 @@ Important notes:
 
             let result_data = json!({
                 "success": true,
-                "path": resolved_path,
+                "path": resolved.logical_path,
                 "is_directory": recursive,
                 "recursive": recursive,
                 "is_remote": true
@@ -283,13 +321,13 @@ Important notes:
             }]);
         }
 
-        let path = Path::new(&resolved_path);
+        let path = Path::new(&resolved.resolved_path);
         let is_directory = path.is_dir();
 
         debug!(
             "DeleteFile tool deleting {}: {}",
             if is_directory { "directory" } else { "file" },
-            resolved_path
+            resolved.logical_path
         );
 
         if is_directory {
@@ -310,7 +348,7 @@ Important notes:
 
         let result_data = json!({
             "success": true,
-            "path": resolved_path,
+            "path": resolved.logical_path,
             "is_directory": is_directory,
             "recursive": recursive
         });

--- a/src/crates/core/src/agentic/tools/implementations/file_edit_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_edit_tool.rs
@@ -29,6 +29,7 @@ impl Tool for FileEditTool {
 
 Usage:
 - You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file.
+- The file_path parameter must be either an absolute path or an exact `bitfun://runtime/...` URI returned by another tool.
 - When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: spaces + line number + tab. Everything after that tab is the actual file content to match. Never include any part of the line number prefix in the old_string or new_string.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.
@@ -43,7 +44,7 @@ Usage:
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "The absolute path to the file to modify"
+                    "description": "The absolute path to the file to modify, or an exact bitfun://runtime URI returned by another tool"
                 },
                 "old_string": {
                     "type": "string",
@@ -102,28 +103,28 @@ Usage:
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        let resolved_path = context.resolve_workspace_tool_path(file_path)?;
+        let resolved = context.resolve_tool_path(file_path)?;
 
-        // For remote workspaces, use the abstract FS to read → edit in memory → write back.
-        if context.is_remote() {
+        // For remote workspace paths, use the abstract FS to read → edit in memory → write back.
+        if resolved.uses_remote_workspace_backend() {
             let ws_fs = context.ws_fs().ok_or_else(|| {
                 BitFunError::tool("Remote workspace file system is unavailable".to_string())
             })?;
             let content = ws_fs
-                .read_file_text(&resolved_path)
+                .read_file_text(&resolved.resolved_path)
                 .await
                 .map_err(|e| BitFunError::tool(format!("Failed to read file: {}", e)))?;
             let edit_result = apply_edit_to_content(&content, old_string, new_string, replace_all)
                 .map_err(BitFunError::tool)?;
 
             ws_fs
-                .write_file(&resolved_path, edit_result.new_content.as_bytes())
+                .write_file(&resolved.resolved_path, edit_result.new_content.as_bytes())
                 .await
                 .map_err(|e| BitFunError::tool(format!("Failed to write file: {}", e)))?;
 
             let result = ToolResult::Result {
                 data: json!({
-                    "file_path": resolved_path,
+                    "file_path": resolved.logical_path,
                     "old_string": old_string,
                     "new_string": new_string,
                     "success": true,
@@ -132,18 +133,21 @@ Usage:
                     "old_end_line": edit_result.edit_result.old_end_line,
                     "new_end_line": edit_result.edit_result.new_end_line,
                 }),
-                result_for_assistant: Some(format!("Successfully edited {}", resolved_path)),
+                result_for_assistant: Some(format!(
+                    "Successfully edited {}",
+                    resolved.logical_path
+                )),
                 image_attachments: None,
             };
             return Ok(vec![result]);
         }
 
         // Local: direct local edit via tool-runtime
-        let edit_result = edit_file(&resolved_path, old_string, new_string, replace_all)?;
+        let edit_result = edit_file(&resolved.resolved_path, old_string, new_string, replace_all)?;
 
         let result = ToolResult::Result {
             data: json!({
-                "file_path": resolved_path,
+                "file_path": resolved.logical_path,
                 "old_string": old_string,
                 "new_string": new_string,
                 "success": true,
@@ -151,7 +155,7 @@ Usage:
                 "old_end_line": edit_result.old_end_line,
                 "new_end_line": edit_result.new_end_line,
             }),
-            result_for_assistant: Some(format!("Successfully edited {}", resolved_path)),
+            result_for_assistant: Some(format!("Successfully edited {}", resolved.logical_path)),
             image_attachments: None,
         };
 

--- a/src/crates/core/src/agentic/tools/implementations/file_read_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_read_tool.rs
@@ -1,7 +1,7 @@
 use crate::agentic::tools::framework::{
     Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
-use crate::agentic::tools::workspace_paths::resolve_workspace_tool_path;
+use crate::agentic::tools::workspace_paths::is_bitfun_runtime_uri;
 use crate::service::ai_rules::get_global_ai_rules_service;
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
@@ -164,7 +164,7 @@ impl Tool for FileReadTool {
 Assume this tool is able to read all files on the machine. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.
 
 Usage:
-- The file_path parameter must be an absolute path, not a relative path.
+- The file_path parameter must be either an absolute path or an exact `bitfun://runtime/...` URI returned by another tool.
 - By default, it reads up to {} lines starting from the beginning of the file. 
 - You can optionally specify a start_line and limit. For large files, prefer reading targeted ranges instead of starting over from the beginning every time.
 - Any lines longer than {} characters will be truncated.
@@ -183,7 +183,7 @@ Usage:
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "The absolute path to the file to read"
+                    "description": "The absolute path to the file to read, or an exact bitfun://runtime URI returned by another tool"
                 },
                 "start_line": {
                     "type": "number",
@@ -236,15 +236,9 @@ Usage:
             }
         };
 
-        let root_owned =
-            context.and_then(|ctx| ctx.workspace.as_ref().map(|w| w.root_path_string()));
-        let resolved_path = match resolve_workspace_tool_path(
-            file_path,
-            root_owned.as_deref(),
-            context.map(|c| c.is_remote()).unwrap_or(false),
-        ) {
-            Ok(path) => path,
-            Err(err) => {
+        let resolved = match context.map(|ctx| ctx.resolve_tool_path(file_path)) {
+            Some(Ok(path)) => path,
+            Some(Err(err)) => {
                 return ValidationResult {
                     result: false,
                     message: Some(err.to_string()),
@@ -252,17 +246,56 @@ Usage:
                     meta: None,
                 }
             }
+            None => {
+                if is_bitfun_runtime_uri(file_path) {
+                    return ValidationResult {
+                        result: false,
+                        message: Some(
+                            "Tool context is required to resolve bitfun runtime URIs".to_string(),
+                        ),
+                        error_code: Some(400),
+                        meta: None,
+                    };
+                }
+
+                let path = Path::new(file_path);
+                if !path.is_absolute() {
+                    return ValidationResult {
+                        result: false,
+                        message: Some("file_path must be absolute".to_string()),
+                        error_code: Some(400),
+                        meta: None,
+                    };
+                }
+
+                if !path.exists() {
+                    return ValidationResult {
+                        result: false,
+                        message: Some(format!("File does not exist: {}", file_path)),
+                        error_code: Some(404),
+                        meta: None,
+                    };
+                }
+
+                if !path.is_file() {
+                    return ValidationResult {
+                        result: false,
+                        message: Some(format!("Path is not a file: {}", file_path)),
+                        error_code: Some(400),
+                        meta: None,
+                    };
+                }
+
+                return ValidationResult::default();
+            }
         };
 
-        // For remote workspaces, skip local filesystem checks — the actual
-        // read goes through WorkspaceFileSystem in call_impl.
-        let is_remote = context.map(|c| c.is_remote()).unwrap_or(false);
-        if !is_remote {
-            let path = Path::new(&resolved_path);
+        if !resolved.uses_remote_workspace_backend() {
+            let path = Path::new(&resolved.resolved_path);
             if !path.exists() {
                 return ValidationResult {
                     result: false,
-                    message: Some(format!("File does not exist: {}", resolved_path)),
+                    message: Some(format!("File does not exist: {}", resolved.logical_path)),
                     error_code: Some(404),
                     meta: None,
                 };
@@ -270,7 +303,7 @@ Usage:
             if !path.is_file() {
                 return ValidationResult {
                     result: false,
-                    message: Some(format!("Path is not a file: {}", resolved_path)),
+                    message: Some(format!("Path is not a file: {}", resolved.logical_path)),
                     error_code: Some(400),
                     meta: None,
                 };
@@ -312,15 +345,14 @@ Usage:
             .and_then(|v| v.as_u64())
             .unwrap_or(self.default_max_lines_to_read as u64) as usize;
 
-        let resolved_path = context.resolve_workspace_tool_path(file_path)?;
+        let resolved = context.resolve_tool_path(file_path)?;
 
-        // Use the workspace file system from context — works for both local and remote.
-        let read_file_result = if context.is_remote() {
-            self.read_remote_window(&resolved_path, start_line, limit, context)
+        let read_file_result = if resolved.uses_remote_workspace_backend() {
+            self.read_remote_window(&resolved.resolved_path, start_line, limit, context)
                 .await?
         } else {
             read_file(
-                &resolved_path,
+                &resolved.resolved_path,
                 start_line,
                 limit,
                 self.max_line_chars,
@@ -329,17 +361,27 @@ Usage:
             .map_err(BitFunError::tool)?
         };
 
-        let file_rules = match get_global_ai_rules_service().await {
-            Ok(rules_service) => {
-                rules_service
-                    .get_rules_for_file_with_workspace(&resolved_path, context.workspace_root())
-                    .await
+        let file_rules = if resolved.is_runtime_artifact() {
+            crate::service::ai_rules::FileRulesResult {
+                matched_count: 0,
+                formatted_content: None,
             }
-            Err(e) => {
-                debug!("Failed to get AIRulesService: {}", e);
-                crate::service::ai_rules::FileRulesResult {
-                    matched_count: 0,
-                    formatted_content: None,
+        } else {
+            match get_global_ai_rules_service().await {
+                Ok(rules_service) => {
+                    rules_service
+                        .get_rules_for_file_with_workspace(
+                            &resolved.resolved_path,
+                            context.workspace_root(),
+                        )
+                        .await
+                }
+                Err(e) => {
+                    debug!("Failed to get AIRulesService: {}", e);
+                    crate::service::ai_rules::FileRulesResult {
+                        matched_count: 0,
+                        formatted_content: None,
+                    }
                 }
             }
         };
@@ -348,7 +390,7 @@ Usage:
             "Read lines {}-{} from {} ({} total lines)\n<file_content>\n{}\n</file_content>",
             read_file_result.start_line,
             read_file_result.end_line,
-            resolved_path,
+            resolved.logical_path,
             read_file_result.total_lines,
             read_file_result.content
         );
@@ -372,7 +414,7 @@ Usage:
 
         let result = ToolResult::Result {
             data: json!({
-                "file_path": resolved_path,
+                "file_path": resolved.logical_path,
                 "content": read_file_result.content,
                 "total_lines": read_file_result.total_lines,
                 "lines_read": lines_read,

--- a/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -1,7 +1,6 @@
 use crate::agentic::tools::framework::{
     Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
-use crate::agentic::tools::workspace_paths::resolve_workspace_tool_path;
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
 use serde_json::{json, Value};
@@ -34,6 +33,7 @@ impl Tool for FileWriteTool {
 Usage:
 - This tool will overwrite the existing file if there is one at the provided path.
 - If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first.
+- The file_path parameter must be either an absolute path or an exact `bitfun://runtime/...` URI returned by another tool.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
 - Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked."#.to_string())
@@ -45,7 +45,7 @@ Usage:
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "The absolute path to the file to write (must be absolute, not relative)"
+                    "description": "The absolute path to the file to write, or an exact bitfun://runtime URI returned by another tool"
                 },
                 "content": {
                     "type": "string",
@@ -95,19 +95,15 @@ Usage:
             };
         }
 
-        let root_owned =
-            context.and_then(|ctx| ctx.workspace.as_ref().map(|w| w.root_path_string()));
-        if let Err(err) = resolve_workspace_tool_path(
-            file_path,
-            root_owned.as_deref(),
-            context.map(|c| c.is_remote()).unwrap_or(false),
-        ) {
-            return ValidationResult {
-                result: false,
-                message: Some(err.to_string()),
-                error_code: Some(400),
-                meta: None,
-            };
+        if let Some(ctx) = context {
+            if let Err(err) = ctx.resolve_tool_path(file_path) {
+                return ValidationResult {
+                    result: false,
+                    message: Some(err.to_string()),
+                    error_code: Some(400),
+                    meta: None,
+                };
+            }
         }
 
         ValidationResult::default()
@@ -140,36 +136,44 @@ Usage:
             .and_then(|v| v.as_str())
             .ok_or_else(|| BitFunError::tool("file_path is required".to_string()))?;
 
-        let resolved_path = context.resolve_workspace_tool_path(file_path)?;
+        let resolved = context.resolve_tool_path(file_path)?;
 
         let content = input
             .get("content")
             .and_then(|v| v.as_str())
             .ok_or_else(|| BitFunError::tool("content is required".to_string()))?;
 
-        if let Some(ws_fs) = context.ws_fs() {
+        if resolved.uses_remote_workspace_backend() {
+            let ws_fs = context.ws_fs().ok_or_else(|| {
+                BitFunError::tool("Remote workspace file system is unavailable".to_string())
+            })?;
             ws_fs
-                .write_file(&resolved_path, content.as_bytes())
+                .write_file(&resolved.resolved_path, content.as_bytes())
                 .await
                 .map_err(|e| BitFunError::tool(format!("Failed to write file: {}", e)))?;
         } else {
-            if let Some(parent) = Path::new(&resolved_path).parent() {
+            if let Some(parent) = Path::new(&resolved.resolved_path).parent() {
                 fs::create_dir_all(parent)
                     .await
                     .map_err(|e| BitFunError::tool(format!("Failed to create directory: {}", e)))?;
             }
-            fs::write(&resolved_path, content).await.map_err(|e| {
-                BitFunError::tool(format!("Failed to write file {}: {}", resolved_path, e))
-            })?;
+            fs::write(&resolved.resolved_path, content)
+                .await
+                .map_err(|e| {
+                    BitFunError::tool(format!(
+                        "Failed to write file {}: {}",
+                        resolved.logical_path, e
+                    ))
+                })?;
         }
 
         let result = ToolResult::Result {
             data: json!({
-                "file_path": resolved_path,
+                "file_path": resolved.logical_path,
                 "bytes_written": content.len(),
                 "success": true
             }),
-            result_for_assistant: Some(format!("Successfully wrote to {}", resolved_path)),
+            result_for_assistant: Some(format!("Successfully wrote to {}", resolved.logical_path)),
             image_attachments: None,
         };
 

--- a/src/crates/core/src/agentic/tools/implementations/get_file_diff_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/get_file_diff_tool.rs
@@ -1,7 +1,7 @@
 use crate::agentic::tools::framework::{
     Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
-use crate::agentic::tools::workspace_paths::resolve_workspace_tool_path;
+use crate::agentic::tools::workspace_paths::is_bitfun_runtime_uri;
 use crate::service::git::git_service::GitService;
 use crate::service::git::git_types::GitDiffParams;
 use crate::service::git::git_utils::get_repository_root;
@@ -295,7 +295,7 @@ This tool compares the current file content against:
 3. Full file content (if neither baseline nor git is available)
 
 Usage:
-- The file_path parameter must be an absolute path, not a relative path.
+- The file_path parameter must be either an absolute path or an exact `bitfun://runtime/...` URI returned by another tool.
 - The diff is returned in unified diff format, showing additions (+) and deletions (-).
 - The response includes diff_type indicating the source: "baseline", "git", or "full".
 - The response includes stats for additions and deletions.
@@ -311,7 +311,7 @@ Usage:
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "The absolute path to the file to get diff for"
+                    "description": "The absolute path to the file to get diff for, or an exact bitfun://runtime URI returned by another tool"
                 }
             },
             "required": ["file_path"],
@@ -346,29 +346,68 @@ Usage:
                 };
             }
 
-            let is_remote = context.map(|c| c.is_remote()).unwrap_or(false);
-
-            let root_owned =
-                context.and_then(|c| c.workspace.as_ref().map(|w| w.root_path_string()));
-            let resolved_path =
-                match resolve_workspace_tool_path(file_path, root_owned.as_deref(), is_remote) {
-                    Ok(p) => p,
-                    Err(e) => {
+            let resolved = match context.map(|ctx| ctx.resolve_tool_path(file_path)) {
+                Some(Ok(value)) => value,
+                Some(Err(err)) => {
+                    return ValidationResult {
+                        result: false,
+                        message: Some(err.to_string()),
+                        error_code: Some(400),
+                        meta: None,
+                    };
+                }
+                None => {
+                    if is_bitfun_runtime_uri(file_path) {
                         return ValidationResult {
                             result: false,
-                            message: Some(e.to_string()),
+                            message: Some(
+                                "Tool context is required to resolve bitfun runtime URIs"
+                                    .to_string(),
+                            ),
                             error_code: Some(400),
                             meta: None,
                         };
                     }
-                };
+                    let path = Path::new(file_path);
+                    if !path.is_absolute() {
+                        return ValidationResult {
+                            result: false,
+                            message: Some("file_path must be absolute".to_string()),
+                            error_code: Some(400),
+                            meta: None,
+                        };
+                    }
+                    if !path.exists() {
+                        return ValidationResult {
+                            result: false,
+                            message: Some(format!("File does not exist: {}", file_path)),
+                            error_code: Some(404),
+                            meta: None,
+                        };
+                    }
+                    if !path.is_file() {
+                        return ValidationResult {
+                            result: false,
+                            message: Some(format!("Path is not a file: {}", file_path)),
+                            error_code: Some(400),
+                            meta: None,
+                        };
+                    }
+                    return ValidationResult {
+                        result: true,
+                        message: None,
+                        error_code: None,
+                        meta: None,
+                    };
+                }
+            };
 
-            if !is_remote {
-                let path = Path::new(&resolved_path);
+            if !resolved.uses_remote_workspace_backend() {
+                let path = Path::new(&resolved.resolved_path);
                 if !path.exists() {
                     return ValidationResult {
                         result: false,
-                        message: Some(format!("File does not exist: {}", resolved_path)),
+                        message: Some(format!("File does not exist: {}", resolved.logical_path)),
                         error_code: Some(404),
                         meta: None,
                     };
@@ -377,7 +416,7 @@ Usage:
                 if !path.is_file() {
                     return ValidationResult {
                         result: false,
-                        message: Some(format!("Path is not a file: {}", resolved_path)),
+                        message: Some(format!("Path is not a file: {}", resolved.logical_path)),
                         error_code: Some(400),
                         meta: None,
                     };
@@ -434,24 +473,24 @@ Usage:
             .and_then(|v| v.as_str())
             .ok_or_else(|| BitFunError::tool("file_path is required".to_string()))?;
 
-        let resolved_path = context.resolve_workspace_tool_path(file_path)?;
+        let resolved = context.resolve_tool_path(file_path)?;
 
         debug!(
             "GetFileDiff tool starting diff retrieval for file: {:?}",
-            resolved_path
+            resolved.logical_path
         );
 
-        if context.is_remote() {
+        if resolved.uses_remote_workspace_backend() {
             let ws_fs = context.ws_fs().ok_or_else(|| {
                 BitFunError::tool("Workspace file system not available for remote diff".to_string())
             })?;
             let content = ws_fs
-                .read_file_text(&resolved_path)
+                .read_file_text(&resolved.resolved_path)
                 .await
                 .map_err(|e| BitFunError::tool(format!("Failed to read file: {}", e)))?;
             let total_lines = content.lines().count();
             let data = json!({
-                "file_path": resolved_path,
+                "file_path": resolved.logical_path,
                 "diff_type": "full",
                 "diff_format": "unified",
                 "diff_content": content.clone(),
@@ -473,7 +512,33 @@ Usage:
         }
 
         // Priority 1: Try baseline diff
-        let path = Path::new(&resolved_path);
+        let path = Path::new(&resolved.resolved_path);
+        if resolved.is_runtime_artifact() {
+            let content = fs::read_to_string(path)
+                .map_err(|e| BitFunError::tool(format!("Failed to read file: {}", e)))?;
+            let total_lines = content.lines().count();
+            let data = json!({
+                "file_path": resolved.logical_path,
+                "diff_type": "full",
+                "diff_format": "unified",
+                "diff_content": content.clone(),
+                "original_content": "",
+                "modified_content": content,
+                "stats": {
+                    "additions": 0,
+                    "deletions": 0,
+                    "total_lines": total_lines
+                },
+                "message": "Runtime artifact full content (baseline/git diff not available)"
+            });
+            let result_for_assistant = self.render_tool_result_message(&data);
+            return Ok(vec![ToolResult::Result {
+                data,
+                result_for_assistant: Some(result_for_assistant),
+                image_attachments: None,
+            }]);
+        }
+
         if let Some(result) = self.try_baseline_diff(path, context.workspace_root()).await {
             match result {
                 Ok(data) => {

--- a/src/crates/core/src/agentic/tools/implementations/glob_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/glob_tool.rs
@@ -413,6 +413,7 @@ impl Tool for GlobTool {
 - Supports glob patterns like "**/*.js" or "src/**/*.ts"
 - Returns matching file paths
 - Use this tool when you need to find files by name patterns
+- The path parameter may be an absolute path or an exact `bitfun://runtime/...` URI returned by another tool
 - You can call multiple tools in a single response. It is always better to speculatively perform multiple searches in parallel if they are potentially useful.
 <example>
 - List files in path: path = "/path/to/search", pattern = "*"
@@ -431,7 +432,7 @@ impl Tool for GlobTool {
                 },
                 "path": {
                     "type": "string",
-                    "description": "The directory to search in. If not specified, the current working directory will be used. IMPORTANT: Omit this field to use the default directory. DO NOT enter \"undefined\" or \"null\" - simply omit it for the default behavior. Must be a valid absolute path if provided."
+                    "description": "The directory to search in. If not specified, the current working directory will be used. IMPORTANT: Omit this field to use the default directory. DO NOT enter \"undefined\" or \"null\" - simply omit it for the default behavior. Must be a valid absolute path or exact bitfun://runtime URI if provided."
                 },
                 "limit": {
                     "type": "number",
@@ -464,19 +465,32 @@ impl Tool for GlobTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| BitFunError::tool("pattern is required".to_string()))?;
 
-        let resolved_str = match input.get("path").and_then(|v| v.as_str()) {
-            Some(user_path) => context.resolve_workspace_tool_path(user_path)?,
-            None => context
-                .workspace
-                .as_ref()
-                .map(|w| w.root_path_string())
-                .ok_or_else(|| {
-                    BitFunError::tool(
-                        "workspace_path is required when Glob path is omitted".to_string(),
-                    )
-                })?,
+        let resolved = match input.get("path").and_then(|v| v.as_str()) {
+            Some(user_path) => context.resolve_tool_path(user_path)?,
+            None => {
+                let root = context
+                    .workspace
+                    .as_ref()
+                    .map(|w| w.root_path_string())
+                    .ok_or_else(|| {
+                        BitFunError::tool(
+                            "workspace_path is required when Glob path is omitted".to_string(),
+                        )
+                    })?;
+                crate::agentic::tools::framework::ToolPathResolution {
+                    requested_path: root.clone(),
+                    logical_path: root.clone(),
+                    resolved_path: root,
+                    backend: if context.is_remote() {
+                        crate::agentic::tools::framework::ToolPathBackend::RemoteWorkspace
+                    } else {
+                        crate::agentic::tools::framework::ToolPathBackend::Local
+                    },
+                    runtime_scope: None,
+                    runtime_root: None,
+                }
+            }
         };
-
         let limit = input
             .get("limit")
             .and_then(|v| v.as_u64())
@@ -484,12 +498,12 @@ impl Tool for GlobTool {
             .unwrap_or(100);
 
         // Remote workspace: prefer `rg --files --glob`, but fall back to `find`
-        if context.is_remote() {
+        if resolved.uses_remote_workspace_backend() {
             let ws_shell = context
                 .ws_shell()
                 .ok_or_else(|| BitFunError::tool("Workspace shell not available".to_string()))?;
 
-            let search_dir = resolved_str.clone();
+            let search_dir = resolved.resolved_path.clone();
             let (_stdout, _stderr, exit_code) = ws_shell
                 .exec("command -v rg >/dev/null 2>&1", Some(5_000))
                 .await
@@ -524,7 +538,14 @@ impl Tool for GlobTool {
                     normalize_path(&Path::new(&search_dir).join(relative_path))
                 })
                 .collect();
-            let limited = limit_paths(&matches, limit);
+            let limited = limit_paths(&matches, limit)
+                .into_iter()
+                .map(|path| {
+                    resolved
+                        .logical_child_path(Path::new(&path))
+                        .unwrap_or(path)
+                })
+                .collect::<Vec<_>>();
             let result_text = if limited.is_empty() {
                 format!("No files found matching pattern '{}'", pattern)
             } else {
@@ -534,7 +555,7 @@ impl Tool for GlobTool {
             return Ok(vec![ToolResult::Result {
                 data: json!({
                     "pattern": pattern,
-                    "path": search_dir,
+                    "path": resolved.logical_path,
                     "matches": limited,
                     "match_count": limited.len()
                 }),
@@ -543,6 +564,7 @@ impl Tool for GlobTool {
             }]);
         }
 
+        let resolved_str = resolved.resolved_path.clone();
         let resolved_str_for_rg = resolved_str.clone();
         let pattern_for_rg = pattern.to_string();
         let matches = tokio::task::spawn_blocking(move || {
@@ -551,6 +573,15 @@ impl Tool for GlobTool {
         .await
         .map_err(|err| BitFunError::tool(format!("Glob tool task failed: {}", err)))?
         .map_err(BitFunError::tool)?;
+
+        let matches = matches
+            .into_iter()
+            .map(|path| {
+                resolved
+                    .logical_child_path(Path::new(&path))
+                    .unwrap_or(path)
+            })
+            .collect::<Vec<_>>();
 
         let result_text = if matches.is_empty() {
             format!("No files found matching pattern '{}'", pattern)
@@ -561,7 +592,7 @@ impl Tool for GlobTool {
         let result = ToolResult::Result {
             data: json!({
                 "pattern": pattern,
-                "path": resolved_str,
+                "path": resolved.logical_path,
                 "matches": matches,
                 "match_count": matches.len()
             }),

--- a/src/crates/core/src/agentic/tools/implementations/grep_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/grep_tool.rs
@@ -109,7 +109,8 @@ impl GrepTool {
             .ok_or_else(|| BitFunError::tool("pattern is required".to_string()))?;
 
         let search_path = input.get("path").and_then(|v| v.as_str()).unwrap_or(".");
-        let resolved_path = context.resolve_workspace_tool_path(search_path)?;
+        let resolved = context.resolve_tool_path(search_path)?;
+        let resolved_path = resolved.resolved_path.clone();
 
         let case_insensitive = input.get("-i").and_then(|v| v.as_bool()).unwrap_or(false);
         let head_limit = Self::resolve_head_limit(input);
@@ -210,7 +211,7 @@ impl GrepTool {
         Ok(vec![ToolResult::Result {
             data: json!({
                 "pattern": pattern,
-                "path": resolved_path,
+                "path": resolved.logical_path,
                 "output_mode": output_mode,
                 "total_matches": total_matches,
                 "applied_limit": head_limit,
@@ -233,7 +234,8 @@ impl GrepTool {
             .ok_or_else(|| BitFunError::tool("pattern is required".to_string()))?;
 
         let search_path = input.get("path").and_then(|v| v.as_str()).unwrap_or(".");
-        let resolved_path = context.resolve_workspace_tool_path(search_path)?;
+        let resolved = context.resolve_tool_path(search_path)?;
+        let resolved_path = resolved.resolved_path.clone();
 
         let case_insensitive = input.get("-i").and_then(|v| v.as_bool()).unwrap_or(false);
         let multiline = input
@@ -271,7 +273,11 @@ impl GrepTool {
             .output_mode(output_mode)
             .show_line_numbers(show_line_numbers);
 
-        if let Some(display_base) = Self::display_base(context) {
+        if resolved.is_runtime_artifact() {
+            if let Some(runtime_root) = &resolved.runtime_root {
+                options = options.display_base(runtime_root.to_string_lossy().to_string());
+            }
+        } else if let Some(display_base) = Self::display_base(context) {
             options = options.display_base(display_base);
         }
 
@@ -347,6 +353,7 @@ Usage:
 - ALWAYS use Grep for search tasks. NEVER invoke `grep` or `rg` as a Bash command. The Grep tool has been optimized for correct permissions and access.
 - Supports full regex syntax (e.g., "log.*Error", "function\s+\w+")
 - Filter files with glob parameter (e.g., "*.js", "**/*.tsx") or type parameter (e.g., "js", "py", "rust")
+- The path parameter may be an absolute path or an exact `bitfun://runtime/...` URI returned by another tool
 - Output modes: "content" shows matching lines, "files_with_matches" shows only file paths (default), "count" shows match counts
 - Use Task tool for open-ended searches requiring multiple rounds
 - Pattern syntax: Uses ripgrep (not grep) - literal braces need escaping (use `interface\{\}` to find `interface{}` in Go code)
@@ -363,7 +370,7 @@ Usage:
                 },
                 "path": {
                     "type": "string",
-                    "description": "File or directory to search in (rg PATH). Defaults to current working directory."
+                    "description": "File or directory to search in (rg PATH). Defaults to current working directory. May be an absolute path or an exact bitfun://runtime URI."
                 },
                 "glob": {
                     "type": "string",
@@ -446,13 +453,16 @@ Usage:
         context: &ToolUseContext,
     ) -> BitFunResult<Vec<ToolResult>> {
         // Remote workspace: use shell-based grep/rg
-        if context.is_remote() {
+        let search_path = input.get("path").and_then(|v| v.as_str()).unwrap_or(".");
+        let resolved = context.resolve_tool_path(search_path)?;
+
+        if resolved.uses_remote_workspace_backend() {
             return self.call_remote(input, context).await;
         }
 
         let grep_options = self.build_grep_options(input, context)?;
         let pattern = grep_options.pattern.clone();
-        let path = grep_options.path.clone();
+        let path = resolved.logical_path.clone();
         let output_mode = grep_options.output_mode.to_string();
 
         let event_system = crate::infrastructure::events::event_system::get_global_event_system();

--- a/src/crates/core/src/agentic/tools/implementations/ls_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/ls_tool.rs
@@ -5,6 +5,7 @@
 use crate::agentic::tools::framework::{
     Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
+use crate::agentic::tools::workspace_paths::is_bitfun_runtime_uri;
 use crate::service::filesystem::{format_directory_listing, list_directory_entries};
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
@@ -51,7 +52,7 @@ impl Tool for LSTool {
         Ok(r#"Recursively lists files and directories in a given path.
 
 Usage:
-- The path parameter must be an absolute path, not a relative path
+- The path parameter must be either an absolute path or an exact `bitfun://runtime/...` URI returned by another tool
 - Hidden files (files starting with '.') are automatically excluded
 - Results are sorted by modification time (newest first)"#
             .to_string())
@@ -63,7 +64,7 @@ Usage:
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "The absolute path to the directory to list (must be absolute, not relative)"
+                    "description": "The absolute path to the directory to list, or an exact bitfun://runtime URI returned by another tool"
                 },
                 "limit": {
                     "type": "number",
@@ -102,25 +103,75 @@ Usage:
                 };
             }
 
-            let is_abs = context
-                .map(|c| c.workspace_path_is_effectively_absolute(path))
-                .unwrap_or_else(|| Path::new(path).is_absolute());
-            if !is_abs {
-                return ValidationResult {
-                    result: false,
-                    message: Some(format!("path must be an absolute path, got: {}", path)),
-                    error_code: Some(400),
-                    meta: None,
-                };
-            }
+            let resolved = match context.map(|ctx| ctx.resolve_tool_path(path)) {
+                Some(Ok(value)) => value,
+                Some(Err(err)) => {
+                    return ValidationResult {
+                        result: false,
+                        message: Some(err.to_string()),
+                        error_code: Some(400),
+                        meta: None,
+                    };
+                }
+                None => {
+                    if is_bitfun_runtime_uri(path) {
+                        return ValidationResult {
+                            result: false,
+                            message: Some(
+                                "Tool context is required to resolve bitfun runtime URIs"
+                                    .to_string(),
+                            ),
+                            error_code: Some(400),
+                            meta: None,
+                        };
+                    }
 
-            let is_remote = context.map(|c| c.is_remote()).unwrap_or(false);
-            if !is_remote {
-                let local_path = Path::new(path);
+                    let local_path = Path::new(path);
+                    if !local_path.is_absolute() {
+                        return ValidationResult {
+                            result: false,
+                            message: Some(format!("path must be an absolute path, got: {}", path)),
+                            error_code: Some(400),
+                            meta: None,
+                        };
+                    }
+
+                    if !local_path.exists() {
+                        return ValidationResult {
+                            result: false,
+                            message: Some(format!("Directory does not exist: {}", path)),
+                            error_code: Some(404),
+                            meta: None,
+                        };
+                    }
+
+                    if !local_path.is_dir() {
+                        return ValidationResult {
+                            result: false,
+                            message: Some(format!("Path is not a directory: {}", path)),
+                            error_code: Some(400),
+                            meta: None,
+                        };
+                    }
+
+                    return ValidationResult {
+                        result: true,
+                        message: None,
+                        error_code: None,
+                        meta: None,
+                    };
+                }
+            };
+
+            if !resolved.uses_remote_workspace_backend() {
+                let local_path = Path::new(&resolved.resolved_path);
                 if !local_path.exists() {
                     return ValidationResult {
                         result: false,
-                        message: Some(format!("Directory does not exist: {}", path)),
+                        message: Some(format!(
+                            "Directory does not exist: {}",
+                            resolved.logical_path
+                        )),
                         error_code: Some(404),
                         meta: None,
                     };
@@ -129,7 +180,10 @@ Usage:
                 if !local_path.is_dir() {
                     return ValidationResult {
                         result: false,
-                        message: Some(format!("Path is not a directory: {}", path)),
+                        message: Some(format!(
+                            "Path is not a directory: {}",
+                            resolved.logical_path
+                        )),
                         error_code: Some(400),
                         meta: None,
                     };
@@ -180,16 +234,18 @@ Usage:
             .map(|v| v as usize)
             .unwrap_or(self.default_limit);
 
-        // Remote workspace: execute ls via SSH shell
-        if context.is_remote() {
+        let resolved = context.resolve_tool_path(path)?;
+
+        // Remote workspace path: execute ls via SSH shell
+        if resolved.uses_remote_workspace_backend() {
             let ws_shell = context.ws_shell().ok_or_else(|| {
                 BitFunError::tool("Workspace shell not available for remote LS".to_string())
             })?;
 
             let ls_cmd = format!(
                 "find {} -maxdepth 1 -not -name '.*' -not -path {} | head -n {} | sort",
-                shell_escape(path),
-                shell_escape(path),
+                shell_escape(&resolved.resolved_path),
+                shell_escape(&resolved.resolved_path),
                 limit + 1
             );
 
@@ -217,14 +273,18 @@ Usage:
             // Use a simpler stat-based listing for the text output
             let stat_cmd = format!(
                 "ls -la --time-style=long-iso {} 2>/dev/null || ls -la {}",
-                shell_escape(path),
-                shell_escape(path)
+                shell_escape(&resolved.resolved_path),
+                shell_escape(&resolved.resolved_path)
             );
             let (ls_output, _, _) = ws_shell.exec(&stat_cmd, Some(15_000)).await.map_err(|e| {
                 BitFunError::tool(format!("Failed to list remote directory: {}", e))
             })?;
 
-            let result_text = format!("Directory listing: {}\n\n{}", path, ls_output.trim());
+            let result_text = format!(
+                "Directory listing: {}\n\n{}",
+                resolved.logical_path,
+                ls_output.trim()
+            );
 
             let entries_json: Vec<Value> = stdout
                 .lines()
@@ -245,7 +305,7 @@ Usage:
             let total_entries = entries_json.len();
             let result = ToolResult::Result {
                 data: json!({
-                    "path": path,
+                    "path": resolved.logical_path,
                     "entries": entries_json,
                     "total": total_entries,
                     "limit": limit,
@@ -258,15 +318,19 @@ Usage:
         }
 
         // Local: original implementation
-        let entries = list_directory_entries(path, limit).map_err(BitFunError::tool)?;
+        let entries =
+            list_directory_entries(&resolved.resolved_path, limit).map_err(BitFunError::tool)?;
 
         let entries_json = entries
             .iter()
             .filter(|entry| entry.depth == 1)
             .map(|entry| {
+                let entry_path = resolved
+                    .logical_child_path(&entry.path)
+                    .unwrap_or_else(|| entry.path.to_string_lossy().to_string());
                 json!({
                     "name": entry.path.file_name().unwrap_or_default().to_string_lossy(),
-                    "path": entry.path.to_string_lossy(),
+                    "path": entry_path,
                     "is_dir": entry.is_dir,
                     "modified_time": format_time(entry.modified_time)
                 })
@@ -274,7 +338,12 @@ Usage:
             .collect::<Vec<Value>>();
         let total_entries = entries.len();
 
-        let mut result_text = format_directory_listing(&entries, path);
+        let mut result_text = format_directory_listing(&entries, &resolved.resolved_path);
+        if resolved.logical_path != resolved.resolved_path {
+            let physical_header = resolved.resolved_path.replace('\\', "/");
+            let logical_header = resolved.logical_path.replace('\\', "/");
+            result_text = result_text.replacen(&physical_header, &logical_header, 1);
+        }
         if total_entries == 0 {
             result_text.push_str("\n(no entries found)");
         } else if total_entries >= limit {
@@ -283,7 +352,7 @@ Usage:
 
         let result = ToolResult::Result {
             data: json!({
-                "path": path,
+                "path": resolved.logical_path,
                 "entries": entries_json,
                 "total": total_entries,
                 "limit": limit

--- a/src/crates/core/src/agentic/tools/workspace_paths.rs
+++ b/src/crates/core/src/agentic/tools/workspace_paths.rs
@@ -7,6 +7,14 @@
 use crate::util::errors::{BitFunError, BitFunResult};
 use std::path::{Component, Path, PathBuf};
 
+pub const BITFUN_RUNTIME_URI_PREFIX: &str = "bitfun://runtime/";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedBitFunRuntimeUri {
+    pub workspace_scope: String,
+    pub relative_path: String,
+}
+
 pub fn normalize_path(path: &str) -> String {
     let path = Path::new(path);
     let mut components = Vec::new();
@@ -50,6 +58,83 @@ pub fn resolve_path_with_workspace(
 
 pub fn resolve_path(path: &str) -> BitFunResult<String> {
     resolve_path_with_workspace(path, None)
+}
+
+pub fn is_bitfun_runtime_uri(path: &str) -> bool {
+    path.trim().starts_with(BITFUN_RUNTIME_URI_PREFIX)
+}
+
+pub fn normalize_runtime_relative_path(path: &str) -> BitFunResult<String> {
+    let normalized = path.trim().replace('\\', "/");
+    let trimmed = normalized.trim_matches('/');
+    if trimmed.is_empty() {
+        return Err(BitFunError::tool(
+            "Runtime artifact path cannot be empty".to_string(),
+        ));
+    }
+
+    let mut segments = Vec::new();
+    for part in trimmed.split('/') {
+        match part {
+            "" | "." => continue,
+            ".." => {
+                return Err(BitFunError::tool(
+                    "Runtime artifact path cannot escape its root".to_string(),
+                ))
+            }
+            value => segments.push(value.to_string()),
+        }
+    }
+
+    if segments.is_empty() {
+        return Err(BitFunError::tool(
+            "Runtime artifact path cannot be empty".to_string(),
+        ));
+    }
+
+    Ok(segments.join("/"))
+}
+
+pub fn parse_bitfun_runtime_uri(path: &str) -> BitFunResult<ParsedBitFunRuntimeUri> {
+    let trimmed = path.trim();
+    let suffix = trimmed
+        .strip_prefix(BITFUN_RUNTIME_URI_PREFIX)
+        .ok_or_else(|| BitFunError::tool(format!("Unsupported runtime URI: {}", path)))?;
+
+    let mut parts = suffix.splitn(2, '/');
+    let workspace_scope = parts
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| BitFunError::tool("Runtime URI is missing workspace scope".to_string()))?
+        .to_string();
+    let relative_path = parts
+        .next()
+        .ok_or_else(|| BitFunError::tool("Runtime URI is missing artifact path".to_string()))?;
+
+    Ok(ParsedBitFunRuntimeUri {
+        workspace_scope,
+        relative_path: normalize_runtime_relative_path(relative_path)?,
+    })
+}
+
+pub fn build_bitfun_runtime_uri(
+    workspace_scope: &str,
+    relative_path: &str,
+) -> BitFunResult<String> {
+    let scope = workspace_scope.trim();
+    if scope.is_empty() {
+        return Err(BitFunError::tool(
+            "Runtime URI workspace scope cannot be empty".to_string(),
+        ));
+    }
+
+    Ok(format!(
+        "{}{}/{}",
+        BITFUN_RUNTIME_URI_PREFIX,
+        scope,
+        normalize_runtime_relative_path(relative_path)?
+    ))
 }
 
 /// POSIX absolute: after normalizing backslashes, path starts with `/`.
@@ -151,5 +236,23 @@ mod tests {
     fn posix_relative_joins_workspace() {
         let r = posix_resolve_path_with_workspace("src/main.rs", Some("/home/proj")).unwrap();
         assert_eq!(r, "/home/proj/src/main.rs");
+    }
+
+    #[test]
+    fn runtime_uri_round_trips_and_normalizes_separators() {
+        let uri = build_bitfun_runtime_uri("workspace-123", r"plans\demo.plan.md").unwrap();
+        assert_eq!(uri, "bitfun://runtime/workspace-123/plans/demo.plan.md");
+
+        let parsed = parse_bitfun_runtime_uri(&uri).unwrap();
+        assert_eq!(parsed.workspace_scope, "workspace-123");
+        assert_eq!(parsed.relative_path, "plans/demo.plan.md");
+    }
+
+    #[test]
+    fn runtime_uri_rejects_parent_directory_escape() {
+        let err = build_bitfun_runtime_uri("workspace-123", "../secret.txt")
+            .expect_err("runtime URI should reject parent directory escape");
+
+        assert!(err.to_string().contains("cannot escape"));
     }
 }

--- a/src/crates/core/src/infrastructure/app_paths/mod.rs
+++ b/src/crates/core/src/infrastructure/app_paths/mod.rs
@@ -4,6 +4,4 @@
 
 pub mod path_manager;
 
-pub use path_manager::{
-    get_path_manager_arc, try_get_path_manager_arc, CacheType, PathManager, StorageLevel,
-};
+pub use path_manager::{get_path_manager_arc, try_get_path_manager_arc, PathManager, StorageLevel};

--- a/src/crates/core/src/infrastructure/app_paths/path_manager.rs
+++ b/src/crates/core/src/infrastructure/app_paths/path_manager.rs
@@ -5,8 +5,12 @@
 use crate::util::errors::*;
 use log::{debug, error};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+
+const MAX_PROJECT_SLUG_LEN: usize = 120;
 
 /// Storage level
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -21,19 +25,6 @@ pub enum StorageLevel {
     Temporary,
 }
 
-/// Cache type
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum CacheType {
-    /// AI model cache
-    Models,
-    /// Vector embedding cache
-    Embeddings,
-    /// Git repository metadata cache
-    Git,
-    /// Code index cache
-    Index,
-}
-
 /// Path manager
 ///
 /// Manages all app storage paths consistently across platforms
@@ -41,6 +32,11 @@ pub enum CacheType {
 pub struct PathManager {
     /// User config root directory
     user_root: PathBuf,
+    /// Optional override for the BitFun home directory, used by tests to avoid
+    /// touching the real user home.
+    bitfun_home_override: Option<PathBuf>,
+    /// Cache of runtime slugs keyed by the original and canonical workspace paths.
+    project_runtime_slug_cache: Arc<Mutex<HashMap<PathBuf, String>>>,
 }
 
 impl PathManager {
@@ -48,7 +44,11 @@ impl PathManager {
     pub fn new() -> BitFunResult<Self> {
         let user_root = Self::get_user_config_root()?;
 
-        Ok(Self { user_root })
+        Ok(Self {
+            user_root,
+            bitfun_home_override: None,
+            project_runtime_slug_cache: Arc::new(Mutex::new(HashMap::new())),
+        })
     }
 
     /// Get user config root directory
@@ -63,13 +63,11 @@ impl PathManager {
         Ok(config_dir.join("bitfun"))
     }
 
-    /// Get user config root directory
-    pub fn user_root(&self) -> &Path {
-        &self.user_root
-    }
-
     /// Get assistant home root directory: ~/.bitfun/
     pub fn bitfun_home_dir(&self) -> PathBuf {
+        if let Some(path) = &self.bitfun_home_override {
+            return path.clone();
+        }
         dirs::home_dir()
             .unwrap_or_else(|| self.user_root.clone())
             .join(".bitfun")
@@ -182,11 +180,6 @@ impl PathManager {
         self.user_root.join("agents")
     }
 
-    /// Get agent templates directory: ~/.config/bitfun/agents/templates/
-    pub fn agent_templates_dir(&self) -> PathBuf {
-        self.user_agents_dir().join("templates")
-    }
-
     /// Get user skills directory:
     /// - Windows: C:\Users\xxx\AppData\Roaming\BitFun\skills\
     /// - macOS: ~/Library/Application Support/BitFun/skills/
@@ -212,11 +205,6 @@ impl PathManager {
         }
     }
 
-    /// Get workspaces directory: ~/.config/bitfun/workspaces/
-    pub fn workspaces_dir(&self) -> PathBuf {
-        self.user_root.join("workspaces")
-    }
-
     /// Get cache root directory: ~/.config/bitfun/cache/
     pub fn cache_root(&self) -> PathBuf {
         self.user_root.join("cache")
@@ -229,55 +217,9 @@ impl PathManager {
         self.user_root.join("runtimes")
     }
 
-    /// Get cache directory for a specific type
-    pub fn cache_dir(&self, cache_type: CacheType) -> PathBuf {
-        let subdir = match cache_type {
-            CacheType::Models => "models",
-            CacheType::Embeddings => "embeddings",
-            CacheType::Git => "git",
-            CacheType::Index => "index",
-        };
-        self.cache_root().join(subdir)
-    }
-
     /// Get user data directory: ~/.config/bitfun/data/
     pub fn user_data_dir(&self) -> PathBuf {
         self.user_root.join("data")
-    }
-
-    /// Root directory for **local** persistence of SSH remote workspace sessions (chat history,
-    /// session metadata, etc.). This is always on the client machine — never the remote POSIX path.
-    ///
-    /// **Canonical (all platforms):** [`Self::user_data_dir`]`/remote-workspaces/` — same tree as
-    /// other BitFun app data (`PathManager::user_root` / `config_dir`/`bitfun` on each OS).
-    ///
-    /// **Legacy:** Older builds used `{data_local_dir}/BitFun/remote-workspaces/`. If that folder
-    /// exists and the canonical path does not, this returns the legacy path so existing installs
-    /// keep working. On Windows this avoided splitting data between `AppData\Local\BitFun` and
-    /// `AppData\Roaming\bitfun`; new installs use the canonical Roaming `bitfun\data` tree only.
-    ///
-    /// New remote session data should use [`Self::remote_ssh_mirror_root`] instead.
-    pub fn remote_ssh_sessions_root() -> PathBuf {
-        let legacy = dirs::data_local_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("BitFun")
-            .join("remote-workspaces");
-
-        let canonical = match Self::new() {
-            Ok(pm) => pm.user_data_dir().join("remote-workspaces"),
-            Err(_) => legacy.clone(),
-        };
-
-        let canonical_exists = canonical.exists();
-        let legacy_exists = legacy.exists();
-
-        if canonical_exists {
-            canonical.clone()
-        } else if legacy_exists {
-            legacy.clone()
-        } else {
-            canonical.clone()
-        }
     }
 
     /// Root for per-host, per-remote-path workspace mirrors: `~/.bitfun/remote_ssh/`.
@@ -320,29 +262,9 @@ impl PathManager {
         self.user_data_dir().join("rules")
     }
 
-    /// Get history directory: ~/.config/bitfun/data/history/
-    pub fn history_dir(&self) -> PathBuf {
-        self.user_data_dir().join("history")
-    }
-
-    /// Get snippets directory: ~/.config/bitfun/data/snippets/
-    pub fn snippets_dir(&self) -> PathBuf {
-        self.user_data_dir().join("snippets")
-    }
-
-    /// Get templates directory: ~/.config/bitfun/data/templates/
-    pub fn templates_dir(&self) -> PathBuf {
-        self.user_data_dir().join("templates")
-    }
-
     /// Get logs directory: ~/.config/bitfun/logs/
     pub fn logs_dir(&self) -> PathBuf {
         self.user_root.join("logs")
-    }
-
-    /// Get backups directory: ~/.config/bitfun/backups/
-    pub fn backups_dir(&self) -> PathBuf {
-        self.user_root.join("backups")
     }
 
     /// Get temp directory: ~/.config/bitfun/temp/
@@ -355,9 +277,15 @@ impl PathManager {
         workspace_path.join(".bitfun")
     }
 
-    /// Get project config file: {project}/.bitfun/config.json
-    pub fn project_config_file(&self, workspace_path: &Path) -> PathBuf {
-        self.project_root(workspace_path).join("config.json")
+    /// Get the shared runtime projects root directory: ~/.bitfun/projects/
+    pub fn projects_root(&self) -> PathBuf {
+        self.bitfun_home_dir().join("projects")
+    }
+
+    /// Get the runtime root for a workspace: ~/.bitfun/projects/<workspace-slug>/
+    pub fn project_runtime_root(&self, workspace_path: &Path) -> PathBuf {
+        self.projects_root()
+            .join(self.project_runtime_slug(workspace_path))
     }
 
     /// Get project internal config directory: {project}/.bitfun/config/
@@ -371,11 +299,6 @@ impl PathManager {
             .join("mode_skills.json")
     }
 
-    /// Get project .gitignore file: {project}/.bitfun/.gitignore
-    pub fn project_gitignore_file(&self, workspace_path: &Path) -> PathBuf {
-        self.project_root(workspace_path).join(".gitignore")
-    }
-
     /// Get project agent directory: {project}/.bitfun/agents/
     pub fn project_agents_dir(&self, workspace_path: &Path) -> PathBuf {
         self.project_root(workspace_path).join("agents")
@@ -386,69 +309,97 @@ impl PathManager {
         self.project_root(workspace_path).join("rules")
     }
 
-    /// Get project snapshots directory: {project}/.bitfun/snapshots/
+    /// Get project snapshots directory: ~/.bitfun/projects/<workspace-slug>/snapshots/
     pub fn project_snapshots_dir(&self, workspace_path: &Path) -> PathBuf {
-        self.project_root(workspace_path).join("snapshots")
+        self.project_runtime_root(workspace_path).join("snapshots")
     }
 
-    /// Get project sessions directory: {project}/.bitfun/sessions/
+    /// Get project sessions directory: ~/.bitfun/projects/<workspace-slug>/sessions/
     pub fn project_sessions_dir(&self, workspace_path: &Path) -> PathBuf {
-        self.project_root(workspace_path).join("sessions")
+        self.project_runtime_root(workspace_path).join("sessions")
     }
 
-    /// Get project diffs cache directory: {project}/.bitfun/diffs/
-    pub fn project_diffs_dir(&self, workspace_path: &Path) -> PathBuf {
-        self.project_root(workspace_path).join("diffs")
-    }
-
-    /// Get project checkpoints directory: {project}/.bitfun/checkpoints/
-    pub fn project_checkpoints_dir(&self, workspace_path: &Path) -> PathBuf {
-        self.project_root(workspace_path).join("checkpoints")
-    }
-
-    /// Get project context directory: {project}/.bitfun/context/
-    pub fn project_context_dir(&self, workspace_path: &Path) -> PathBuf {
-        self.project_root(workspace_path).join("context")
-    }
-
-    /// Get project local data directory: {project}/.bitfun/local/
-    pub fn project_local_dir(&self, workspace_path: &Path) -> PathBuf {
-        self.project_root(workspace_path).join("local")
-    }
-
-    /// Get project local cache directory: {project}/.bitfun/local/cache/
-    pub fn project_cache_dir(&self, workspace_path: &Path) -> PathBuf {
-        self.project_local_dir(workspace_path).join("cache")
-    }
-
-    /// Get project local logs directory: {project}/.bitfun/local/logs/
-    pub fn project_logs_dir(&self, workspace_path: &Path) -> PathBuf {
-        self.project_local_dir(workspace_path).join("logs")
-    }
-
-    /// Get project local temp directory: {project}/.bitfun/local/temp/
-    pub fn project_temp_dir(&self, workspace_path: &Path) -> PathBuf {
-        self.project_local_dir(workspace_path).join("temp")
-    }
-
-    /// Get project tasks directory: {project}/.bitfun/tasks/
-    pub fn project_tasks_dir(&self, workspace_path: &Path) -> PathBuf {
-        self.project_root(workspace_path).join("tasks")
-    }
-
-    /// Get project plans directory: {project}/.bitfun/plans/
+    /// Get project plans directory: ~/.bitfun/projects/<workspace-slug>/plans/
     pub fn project_plans_dir(&self, workspace_path: &Path) -> PathBuf {
-        self.project_root(workspace_path).join("plans")
+        self.project_runtime_root(workspace_path).join("plans")
     }
 
-    /// Compute a hash of the workspace path (used for directory names)
-    pub fn workspace_hash(workspace_path: &Path) -> String {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
+    /// Get project memory directory: ~/.bitfun/projects/<workspace-slug>/memory/
+    pub fn project_memory_dir(&self, workspace_path: &Path) -> PathBuf {
+        self.project_runtime_root(workspace_path).join("memory")
+    }
 
-        let mut hasher = DefaultHasher::new();
-        workspace_path.to_string_lossy().hash(&mut hasher);
-        format!("{:x}", hasher.finish())
+    /// Get project AI memories file: ~/.bitfun/projects/<workspace-slug>/ai_memories.json
+    pub fn project_ai_memories_file(&self, workspace_path: &Path) -> PathBuf {
+        self.project_runtime_root(workspace_path)
+            .join("ai_memories.json")
+    }
+
+    fn project_runtime_slug(&self, workspace_path: &Path) -> String {
+        let requested_path = workspace_path.to_path_buf();
+        if let Some(slug) = self.cached_project_runtime_slug(&requested_path) {
+            return slug;
+        }
+
+        let canonical_path =
+            dunce::canonicalize(workspace_path).unwrap_or_else(|_| requested_path.clone());
+        if canonical_path != requested_path {
+            if let Some(slug) = self.cached_project_runtime_slug(&canonical_path) {
+                self.store_project_runtime_slug(&requested_path, &slug);
+                return slug;
+            }
+        }
+
+        let canonical = canonical_path.to_string_lossy().to_string();
+        let slug = Self::build_project_runtime_slug(&canonical);
+
+        self.store_project_runtime_slug(&canonical_path, &slug);
+        if canonical_path != requested_path {
+            self.store_project_runtime_slug(&requested_path, &slug);
+        }
+
+        slug
+    }
+
+    fn cached_project_runtime_slug(&self, workspace_path: &Path) -> Option<String> {
+        self.project_runtime_slug_cache
+            .lock()
+            .expect("project runtime slug cache poisoned")
+            .get(workspace_path)
+            .cloned()
+    }
+
+    fn store_project_runtime_slug(&self, workspace_path: &Path, slug: &str) {
+        self.project_runtime_slug_cache
+            .lock()
+            .expect("project runtime slug cache poisoned")
+            .insert(workspace_path.to_path_buf(), slug.to_string());
+    }
+
+    fn build_project_runtime_slug(canonical: &str) -> String {
+        let slug: String = canonical
+            .chars()
+            .map(|ch| {
+                if ch.is_ascii_alphanumeric() {
+                    ch.to_ascii_lowercase()
+                } else {
+                    '-'
+                }
+            })
+            .collect();
+
+        let slug = slug.trim_matches('-');
+        let slug = if slug.is_empty() { "workspace" } else { slug };
+
+        if slug.len() <= MAX_PROJECT_SLUG_LEN {
+            return slug.to_string();
+        }
+
+        let hash = hex::encode(Sha256::digest(canonical.as_bytes()));
+        let suffix = &hash[..12];
+        let max_prefix_len = MAX_PROJECT_SLUG_LEN.saturating_sub(suffix.len() + 1);
+        let prefix = slug[..max_prefix_len].trim_end_matches('-');
+        format!("{}-{}", prefix, suffix)
     }
 
     /// Ensure directory exists
@@ -465,25 +416,16 @@ impl PathManager {
     pub async fn initialize_user_directories(&self) -> BitFunResult<()> {
         let dirs = vec![
             self.bitfun_home_dir(),
+            self.projects_root(),
             self.assistant_workspace_base_dir(None),
             self.user_config_dir(),
             self.user_agents_dir(),
-            self.agent_templates_dir(),
-            self.workspaces_dir(),
             self.cache_root(),
-            self.cache_dir(CacheType::Models),
-            self.cache_dir(CacheType::Embeddings),
-            self.cache_dir(CacheType::Git),
-            self.cache_dir(CacheType::Index),
             self.user_data_dir(),
             self.user_cron_dir(),
             self.user_rules_dir(),
-            self.history_dir(),
-            self.snippets_dir(),
-            self.templates_dir(),
             self.miniapps_dir(),
             self.logs_dir(),
-            self.backups_dir(),
             self.temp_dir(),
         ];
 
@@ -492,76 +434,6 @@ impl PathManager {
         }
 
         debug!("User-level directories initialized");
-        Ok(())
-    }
-
-    /// Initialize project-level directory structure
-    pub async fn initialize_project_directories(&self, workspace_path: &Path) -> BitFunResult<()> {
-        let dirs = vec![
-            self.project_root(workspace_path),
-            self.project_internal_config_dir(workspace_path),
-            self.project_agents_dir(workspace_path),
-            self.project_rules_dir(workspace_path),
-            self.project_snapshots_dir(workspace_path),
-            self.project_sessions_dir(workspace_path),
-            self.project_diffs_dir(workspace_path),
-            self.project_checkpoints_dir(workspace_path),
-            self.project_context_dir(workspace_path),
-            self.project_local_dir(workspace_path),
-            self.project_cache_dir(workspace_path),
-            self.project_logs_dir(workspace_path),
-            self.project_temp_dir(workspace_path),
-            self.project_tasks_dir(workspace_path),
-        ];
-
-        for dir in dirs {
-            self.ensure_dir(&dir).await?;
-        }
-
-        self.generate_project_gitignore(workspace_path).await?;
-
-        debug!(
-            "Project-level directories initialized for {:?}",
-            workspace_path
-        );
-        Ok(())
-    }
-
-    /// Generate project-level .gitignore file
-    async fn generate_project_gitignore(&self, workspace_path: &Path) -> BitFunResult<()> {
-        let gitignore_path = self.project_gitignore_file(workspace_path);
-
-        if gitignore_path.exists() {
-            return Ok(());
-        }
-
-        let content = r#"# BitFun local data (auto-generated)
-
-# Snapshots and cache
-snapshots/
-diffs/
-local/
-
-# Personal sessions and checkpoints
-sessions/
-checkpoints/
-
-# Logs and temporary files
-*.log
-temp/
-
-# Note: The following files SHOULD be committed to version control
-# config.json
-# agents/
-# context/
-# tasks/
-"#;
-
-        tokio::fs::write(&gitignore_path, content)
-            .await
-            .map_err(|e| BitFunError::service(format!("Failed to create .gitignore: {}", e)))?;
-
-        debug!("Generated .gitignore for project");
         Ok(())
     }
 }
@@ -577,8 +449,25 @@ impl Default for PathManager {
                 );
                 Self {
                     user_root: std::env::temp_dir().join("bitfun"),
+                    bitfun_home_override: None,
+                    project_runtime_slug_cache: Arc::new(Mutex::new(HashMap::new())),
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+impl PathManager {
+    pub(crate) fn with_user_root_for_tests(user_root: PathBuf) -> Self {
+        let base = user_root
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| user_root.clone());
+        Self {
+            user_root,
+            bitfun_home_override: Some(base.join("home").join(".bitfun")),
+            project_runtime_slug_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -628,6 +517,7 @@ pub fn try_get_path_manager_arc() -> BitFunResult<Arc<PathManager>> {
 #[cfg(test)]
 mod tests {
     use super::PathManager;
+    use std::path::Path;
 
     #[test]
     fn assistant_workspace_paths_use_personal_assistant_subdir() {
@@ -682,5 +572,18 @@ mod tests {
         let legacy = pm.legacy_assistant_workspace_dir("xyz", None);
         assert!(pm.is_local_assistant_workspace_path(&legacy.to_string_lossy()));
         assert!(!pm.is_local_assistant_workspace_path("/tmp/not-bitfun"));
+    }
+
+    #[test]
+    fn project_runtime_root_uses_human_readable_workspace_slug() {
+        let pm = PathManager::default();
+        let runtime_root = pm.project_runtime_root(Path::new(r"E:\Projects\OpenBitFun\BitFun"));
+        let slug = runtime_root
+            .file_name()
+            .and_then(|value| value.to_str())
+            .expect("runtime root should have terminal component");
+
+        assert!(slug.starts_with("e--projects-openbitfun-bitfun"));
+        assert_eq!(runtime_root.parent(), Some(pm.projects_root().as_path()));
     }
 }

--- a/src/crates/core/src/infrastructure/mod.rs
+++ b/src/crates/core/src/infrastructure/mod.rs
@@ -10,9 +10,7 @@ pub mod filesystem;
 pub mod storage;
 
 pub use ai::AIClient;
-pub use app_paths::{
-    get_path_manager_arc, try_get_path_manager_arc, CacheType, PathManager, StorageLevel,
-};
+pub use app_paths::{get_path_manager_arc, try_get_path_manager_arc, PathManager, StorageLevel};
 pub use events::BackendEventManager;
 pub use filesystem::{
     BatchedFileSearchProgressSink, FileContentSearchOptions, FileInfo, FileNameSearchOptions,

--- a/src/crates/core/src/infrastructure/storage/cleanup.rs
+++ b/src/crates/core/src/infrastructure/storage/cleanup.rs
@@ -14,7 +14,6 @@ use tokio::fs;
 pub struct CleanupPolicy {
     pub temp_retention_days: u64,
     pub log_retention_days: u64,
-    pub session_retention_days: u64,
     pub max_cache_size_mb: u64,
     pub backup_retention_count: usize,
     pub auto_cleanup_enabled: bool,
@@ -25,7 +24,6 @@ impl Default for CleanupPolicy {
         Self {
             temp_retention_days: 7,
             log_retention_days: 30,
-            session_retention_days: 90,
             max_cache_size_mb: 1024,
             backup_retention_count: 10,
             auto_cleanup_enabled: true,
@@ -78,10 +76,6 @@ impl CleanupService {
             result.merge(log_result, "Old Logs");
         }
 
-        if let Ok(session_result) = self.cleanup_old_sessions().await {
-            result.merge(session_result, "Expired Sessions");
-        }
-
         if let Ok(cache_result) = self.cleanup_oversized_cache().await {
             result.merge(cache_result, "Oversized Cache");
         }
@@ -108,37 +102,6 @@ impl CleanupService {
         let retention = Duration::from_secs(self.policy.log_retention_days * 24 * 3600);
 
         self.cleanup_old_files(&logs_dir, retention).await
-    }
-
-    async fn cleanup_old_sessions(&self) -> BitFunResult<CleanupResult> {
-        let mut result = CleanupResult::default();
-
-        let workspaces_dir = self.path_manager.workspaces_dir();
-
-        if !workspaces_dir.exists() {
-            return Ok(result);
-        }
-
-        let retention = Duration::from_secs(self.policy.session_retention_days * 24 * 3600);
-
-        let mut read_dir = fs::read_dir(&workspaces_dir)
-            .await
-            .map_err(|e| BitFunError::service(format!("Failed to read workspaces: {}", e)))?;
-
-        while let Some(entry) = read_dir
-            .next_entry()
-            .await
-            .map_err(|e| BitFunError::service(format!("Failed to read workspace entry: {}", e)))?
-        {
-            if entry.file_type().await.map(|t| t.is_dir()).unwrap_or(false) {
-                let session_result = self.cleanup_old_files(&entry.path(), retention).await?;
-                result.files_deleted += session_result.files_deleted;
-                result.directories_deleted += session_result.directories_deleted;
-                result.bytes_freed += session_result.bytes_freed;
-            }
-        }
-
-        Ok(result)
     }
 
     async fn cleanup_oversized_cache(&self) -> BitFunResult<CleanupResult> {

--- a/src/crates/core/src/infrastructure/storage/persistence.rs
+++ b/src/crates/core/src/infrastructure/storage/persistence.rs
@@ -79,8 +79,7 @@ impl PersistenceService {
         path_manager: Arc<PathManager>,
         workspace_path: PathBuf,
     ) -> BitFunResult<Self> {
-        let base_dir = path_manager.project_root(&workspace_path);
-        path_manager.ensure_dir(&base_dir).await?;
+        let base_dir = path_manager.project_runtime_root(&workspace_path);
 
         Ok(Self {
             base_dir,

--- a/src/crates/core/src/service/agent_memory/auto_memory.rs
+++ b/src/crates/core/src/service/agent_memory/auto_memory.rs
@@ -1,17 +1,25 @@
+use crate::infrastructure::get_path_manager_arc;
 use crate::util::errors::*;
 use log::debug;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 
 const MEMORY_DIR_NAME: &str = "memory";
-const BITFUN_DIR_NAME: &str = ".bitfun";
 const MEMORY_INDEX_FILE: &str = "memory.md";
 const MEMORY_INDEX_TEMPLATE: &str = "# Memory Index\n";
 const MEMORY_INDEX_MAX_LINES: usize = 200;
 const TOPIC_MEMORY_MAX_FILES: usize = 30;
 
 fn memory_dir_path(workspace_root: &Path) -> PathBuf {
-    workspace_root.join(BITFUN_DIR_NAME).join(MEMORY_DIR_NAME)
+    let path_manager = get_path_manager_arc();
+    let path = path_manager.project_memory_dir(workspace_root);
+    debug!(
+        "Resolved workspace memory directory: workspace={} memory_dir={} storage_subdir={}",
+        workspace_root.display(),
+        path.display(),
+        MEMORY_DIR_NAME
+    );
+    path
 }
 
 fn format_path_for_prompt(path: &Path) -> String {

--- a/src/crates/core/src/service/agent_memory/mod.rs
+++ b/src/crates/core/src/service/agent_memory/mod.rs
@@ -1,6 +1,6 @@
-mod instruction_context;
 mod auto_memory;
+mod instruction_context;
 
-pub(crate) use instruction_context::build_workspace_instruction_files_context;
 pub(crate) use auto_memory::build_workspace_agent_memory_prompt;
 pub(crate) use auto_memory::build_workspace_memory_files_context;
+pub(crate) use instruction_context::build_workspace_instruction_files_context;

--- a/src/crates/core/src/service/ai_memory/manager.rs
+++ b/src/crates/core/src/service/ai_memory/manager.rs
@@ -50,7 +50,7 @@ impl AIMemoryManager {
         workspace_path: &str,
     ) -> BitFunResult<Self> {
         let workspace_path = PathBuf::from(workspace_path);
-        let storage_path = workspace_path.join(".bitfun").join("ai_memories.json");
+        let storage_path = path_manager.project_ai_memories_file(&workspace_path);
 
         if let Some(parent) = storage_path.parent() {
             fs::create_dir_all(parent).await.map_err(|e| {

--- a/src/crates/core/src/service/ai_rules/service.rs
+++ b/src/crates/core/src/service/ai_rules/service.rs
@@ -619,10 +619,7 @@ The rules section has a number of possible rules/memories/context that you shoul
         let mut rules = Vec::new();
 
         if !dir.exists() {
-            if let Err(e) = tokio::fs::create_dir_all(dir).await {
-                warn!("Failed to create rules directory {:?}: {}", dir, e);
-                return Ok(rules);
-            }
+            return Ok(rules);
         }
 
         let mut entries = match tokio::fs::read_dir(dir).await {
@@ -908,5 +905,38 @@ The rules section has a number of possible rules/memories/context that you shoul
         if current_workspace.as_deref() == Some(workspace) {
             *self.project_rules.write().await = rules.to_vec();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AIRulesService;
+    use crate::infrastructure::PathManager;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn loading_missing_project_rules_does_not_create_rules_dir() {
+        let test_root =
+            std::env::temp_dir().join(format!("bitfun-ai-rules-test-{}", Uuid::new_v4()));
+        let workspace_root = test_root.join("workspace");
+        std::fs::create_dir_all(&workspace_root).expect("test workspace should be created");
+
+        let path_manager = Arc::new(PathManager::with_user_root_for_tests(
+            test_root.join("user-root"),
+        ));
+        let service = AIRulesService::new(path_manager.clone())
+            .await
+            .expect("ai rules service should initialize");
+
+        let rules = service
+            .get_project_rules_for_workspace(&workspace_root)
+            .await
+            .expect("loading project rules should succeed");
+
+        assert!(rules.is_empty());
+        assert!(!path_manager.project_rules_dir(&workspace_root).exists());
+
+        let _ = std::fs::remove_dir_all(&test_root);
     }
 }

--- a/src/crates/core/src/service/mod.rs
+++ b/src/crates/core/src/service/mod.rs
@@ -25,6 +25,7 @@ pub mod snapshot; // Snapshot-based change tracking
 pub mod system; // System command detection and execution
 pub mod token_usage; // Token usage tracking
 pub mod workspace; // Workspace management // Diff calculation and merge service
+pub mod workspace_runtime; // Workspace runtime layout / migration / initialization
 
 // Terminal is a standalone crate; re-export it here.
 pub use terminal_core as terminal;
@@ -63,3 +64,8 @@ pub use token_usage::{
     TokenUsageService, TokenUsageSummary,
 };
 pub use workspace::{WorkspaceManager, WorkspaceProvider, WorkspaceService};
+pub use workspace_runtime::{
+    get_workspace_runtime_service_arc, try_get_workspace_runtime_service_arc,
+    RuntimeMigrationRecord, WorkspaceRuntimeContext, WorkspaceRuntimeEnsureResult,
+    WorkspaceRuntimeService, WorkspaceRuntimeTarget,
+};

--- a/src/crates/core/src/service/remote_ssh/workspace_state.rs
+++ b/src/crates/core/src/service/remote_ssh/workspace_state.rs
@@ -197,11 +197,15 @@ pub fn remote_root_to_mirror_subpath(remote_root_norm: &str) -> PathBuf {
 }
 
 /// Local directory where persisted sessions for this remote workspace root are stored.
-pub fn remote_workspace_session_mirror_dir(ssh_host: &str, remote_root_norm: &str) -> PathBuf {
+pub fn remote_workspace_runtime_root(ssh_host: &str, remote_root_norm: &str) -> PathBuf {
     PathManager::remote_ssh_mirror_root()
         .join(sanitize_ssh_hostname_for_mirror(ssh_host))
         .join(remote_root_to_mirror_subpath(remote_root_norm))
-        .join("sessions")
+}
+
+/// Local directory where persisted sessions for this remote workspace root are stored.
+pub fn remote_workspace_session_mirror_dir(ssh_host: &str, remote_root_norm: &str) -> PathBuf {
+    remote_workspace_runtime_root(ssh_host, remote_root_norm).join("sessions")
 }
 
 /// Human-readable logical key: `{host}:{normalized_absolute_root}` (for logs / UI; not a directory name).

--- a/src/crates/core/src/service/snapshot/file_lock_manager.rs
+++ b/src/crates/core/src/service/snapshot/file_lock_manager.rs
@@ -1,4 +1,5 @@
 use crate::service::snapshot::types::{SnapshotError, SnapshotResult};
+use crate::service::workspace_runtime::WorkspaceRuntimeContext;
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -34,27 +35,22 @@ pub struct FileLockStatus {
 pub struct FileLockManager {
     locks: RwLock<HashMap<PathBuf, FileLock>>,
     waiting_queue: RwLock<HashMap<PathBuf, Vec<WaitingQueueItem>>>,
-    bitfun_dir: PathBuf,
+    runtime_context: WorkspaceRuntimeContext,
 }
 
 impl FileLockManager {
     /// Creates a new file lock manager.
-    pub fn new(bitfun_dir: PathBuf) -> Self {
+    pub fn new(runtime_context: WorkspaceRuntimeContext) -> Self {
         Self {
             locks: RwLock::new(HashMap::new()),
             waiting_queue: RwLock::new(HashMap::new()),
-            bitfun_dir,
+            runtime_context,
         }
     }
 
     /// Initializes the file lock manager.
     pub async fn initialize(&self) -> SnapshotResult<()> {
         info!("Initializing file lock manager");
-
-        let locks_dir = self.bitfun_dir.join("locks");
-        if !locks_dir.exists() {
-            std::fs::create_dir_all(&locks_dir)?;
-        }
 
         self.load_lock_state().await?;
 
@@ -245,7 +241,7 @@ impl FileLockManager {
 
     /// Loads lock state.
     async fn load_lock_state(&self) -> SnapshotResult<()> {
-        let locks_file = self.bitfun_dir.join("locks").join("file_locks.json");
+        let locks_file = self.runtime_context.locks_dir.join("file_locks.json");
 
         if !locks_file.exists() {
             return Ok(());
@@ -272,7 +268,7 @@ impl FileLockManager {
     /// Saves lock state.
     async fn save_lock_state(&self) -> SnapshotResult<()> {
         let lock_status = self.get_full_lock_status().await;
-        let locks_file = self.bitfun_dir.join("locks").join("file_locks.json");
+        let locks_file = self.runtime_context.locks_dir.join("file_locks.json");
 
         let content = serde_json::to_string_pretty(&lock_status)?;
         std::fs::write(&locks_file, content)?;

--- a/src/crates/core/src/service/snapshot/isolation_manager.rs
+++ b/src/crates/core/src/service/snapshot/isolation_manager.rs
@@ -1,25 +1,21 @@
 use crate::service::snapshot::types::{SnapshotError, SnapshotResult};
-use log::{debug, info};
-use std::fs::{self, OpenOptions};
-use std::io::Write;
+use crate::service::workspace_runtime::WorkspaceRuntimeContext;
+use log::info;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Git isolation manager
 pub struct IsolationManager {
-    bitfun_dir: PathBuf,
+    runtime_context: WorkspaceRuntimeContext,
     workspace_dir: PathBuf,
-    gitignore_managed: bool,
 }
 
 impl IsolationManager {
     /// Creates a new isolation manager.
-    pub fn new(workspace_dir: PathBuf) -> Self {
-        let bitfun_dir = workspace_dir.join(".bitfun");
-
+    pub fn new(workspace_dir: PathBuf, runtime_context: WorkspaceRuntimeContext) -> Self {
         Self {
-            bitfun_dir,
+            runtime_context,
             workspace_dir,
-            gitignore_managed: false,
         }
     }
 
@@ -27,8 +23,7 @@ impl IsolationManager {
     pub async fn ensure_complete_isolation(&mut self) -> SnapshotResult<()> {
         info!("Ensuring complete Git isolation");
 
-        self.create_bitfun_directory_structure().await?;
-        self.ensure_gitignore_entry().await?;
+        self.verify_runtime_layout().await?;
         self.verify_no_git_operations().await?;
         self.set_directory_permissions().await?;
         self.create_isolation_status_file().await?;
@@ -37,69 +32,24 @@ impl IsolationManager {
         Ok(())
     }
 
-    /// Creates the `.bitfun` directory structure.
-    async fn create_bitfun_directory_structure(&self) -> SnapshotResult<()> {
-        let directories = [
-            &self.bitfun_dir,
-            &self.bitfun_dir.join("snapshots"),
-            &self.bitfun_dir.join("snapshots/by_hash"),
-            &self.bitfun_dir.join("snapshots/metadata"),
-            &self.bitfun_dir.join("sessions"),
-            &self.bitfun_dir.join("diffs"),
-            &self.bitfun_dir.join("diffs/small"),
-            &self.bitfun_dir.join("diffs/large"),
-            &self.bitfun_dir.join("checkpoints"),
-            &self.bitfun_dir.join("temp"),
-            &self.bitfun_dir.join("config"),
-        ];
-
-        for dir in &directories {
+    async fn verify_runtime_layout(&self) -> SnapshotResult<()> {
+        for dir in self.runtime_context.required_directories() {
             if !dir.exists() {
-                fs::create_dir_all(dir)?;
-                debug!("Created directory: path={}", dir.display());
+                return Err(SnapshotError::ConfigError(format!(
+                    "Workspace runtime directory is missing: {}",
+                    dir.display()
+                )));
             }
         }
-
-        Ok(())
-    }
-
-    /// Automatically manages `.gitignore`.
-    async fn ensure_gitignore_entry(&mut self) -> SnapshotResult<()> {
-        let gitignore_path = self.workspace_dir.join(".gitignore");
-        let bitfun_entry = ".bitfun/";
-        let comment = "# BitFun snapshot data - auto managed";
-
-        if gitignore_path.exists() {
-            let content = fs::read_to_string(&gitignore_path)?;
-
-            if !content.contains(bitfun_entry) {
-                debug!("Adding .bitfun entry to existing .gitignore");
-                let mut file = OpenOptions::new().append(true).open(&gitignore_path)?;
-
-                writeln!(file, "\n{}", comment)?;
-                writeln!(file, "{}", bitfun_entry)?;
-
-                self.gitignore_managed = true;
-            } else {
-                debug!(".bitfun entry already exists in .gitignore");
-                self.gitignore_managed = true;
-            }
-        } else {
-            debug!("Creating new .gitignore file");
-            let content = format!("{}\n{}\n", comment, bitfun_entry);
-            fs::write(&gitignore_path, content)?;
-            self.gitignore_managed = true;
-        }
-
         Ok(())
     }
 
     /// Verifies no Git operations are impacted.
     async fn verify_no_git_operations(&self) -> SnapshotResult<()> {
         let git_dir = self.workspace_dir.join(".git");
-        if git_dir.exists() && self.bitfun_dir.starts_with(&git_dir) {
+        if git_dir.exists() && self.runtime_context.runtime_root.starts_with(&git_dir) {
             return Err(SnapshotError::GitIsolationFailure(
-                ".bitfun directory should not be inside .git directory".to_string(),
+                "Snapshot runtime directory should not be inside .git directory".to_string(),
             ));
         }
 
@@ -112,7 +62,7 @@ impl IsolationManager {
     async fn verify_isolation_integrity(&self) -> SnapshotResult<()> {
         let forbidden_files = [".git", ".gitignore", ".gitmodules"];
 
-        for entry in fs::read_dir(&self.bitfun_dir)? {
+        for entry in fs::read_dir(&self.runtime_context.runtime_root)? {
             let entry = entry?;
             let file_name = entry.file_name();
             let file_name_str = file_name.to_string_lossy();
@@ -138,7 +88,7 @@ impl IsolationManager {
             use std::os::unix::fs::PermissionsExt;
 
             let permissions = fs::Permissions::from_mode(0o755);
-            fs::set_permissions(&self.bitfun_dir, permissions)?;
+            fs::set_permissions(&self.runtime_context.runtime_root, permissions)?;
         }
 
         Ok(())
@@ -146,10 +96,9 @@ impl IsolationManager {
 
     /// Creates the isolation status file.
     async fn create_isolation_status_file(&self) -> SnapshotResult<()> {
-        let status_file = self.bitfun_dir.join("config/isolation_status.json");
+        let status_file = self.runtime_context.isolation_status_file.clone();
         let status = serde_json::json!({
             "git_isolated": true,
-            "gitignore_managed": self.gitignore_managed,
             "created_at": chrono::Utc::now().to_rfc3339(),
             "version": "1.0"
         });
@@ -161,7 +110,7 @@ impl IsolationManager {
 
     /// Checks isolation status.
     pub async fn check_isolation_status(&self) -> SnapshotResult<bool> {
-        let status_file = self.bitfun_dir.join("config/isolation_status.json");
+        let status_file = self.runtime_context.isolation_status_file.clone();
 
         if !status_file.exists() {
             return Ok(false);
@@ -176,9 +125,9 @@ impl IsolationManager {
             .unwrap_or(false))
     }
 
-    /// Returns the `.bitfun` directory path.
+    /// Returns the snapshot runtime directory path.
     pub fn get_bitfun_dir(&self) -> &Path {
-        &self.bitfun_dir
+        &self.runtime_context.runtime_root
     }
 
     /// Returns the workspace directory path.
@@ -186,67 +135,9 @@ impl IsolationManager {
         &self.workspace_dir
     }
 
-    /// Cleans snapshot data (while preserving Git isolation).
-    pub async fn cleanup_snapshot_data(&self, keep_recent_days: u64) -> SnapshotResult<()> {
-        info!(
-            "Cleaning up snapshot data: keep_recent_days={}",
-            keep_recent_days
-        );
-
-        let cutoff_time = std::time::SystemTime::now()
-            - std::time::Duration::from_secs(keep_recent_days * 24 * 3600);
-
-        let sessions_dir = self.bitfun_dir.join("sessions");
-        self.cleanup_directory_by_time(&sessions_dir, cutoff_time)
-            .await?;
-
-        let checkpoints_dir = self.bitfun_dir.join("checkpoints");
-        self.cleanup_directory_by_time(&checkpoints_dir, cutoff_time)
-            .await?;
-
-        let temp_dir = self.bitfun_dir.join("temp");
-        if temp_dir.exists() {
-            fs::remove_dir_all(&temp_dir)?;
-            fs::create_dir(&temp_dir)?;
-        }
-
-        Ok(())
-    }
-
-    /// Cleans directories by time.
-    async fn cleanup_directory_by_time(
-        &self,
-        dir: &Path,
-        cutoff_time: std::time::SystemTime,
-    ) -> SnapshotResult<()> {
-        if !dir.exists() {
-            return Ok(());
-        }
-
-        for entry in fs::read_dir(dir)? {
-            let entry = entry?;
-            let metadata = entry.metadata()?;
-
-            if let Ok(modified_time) = metadata.modified() {
-                if modified_time < cutoff_time {
-                    let path = entry.path();
-                    if path.is_file() {
-                        fs::remove_file(&path)?;
-                        debug!("Removed expired file: path={}", path.display());
-                    } else if path.is_dir() {
-                        fs::remove_dir_all(&path)?;
-                        debug!("Removed expired directory: path={}", path.display());
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
     /// Validates that a file path is within the snapshot system scope.
     pub fn is_path_in_sandbox(&self, path: &Path) -> bool {
-        path.starts_with(&self.bitfun_dir)
+        path.starts_with(&self.runtime_context.runtime_root)
     }
 
     /// Validates that a file path is safe (does not impact Git).
@@ -260,7 +151,7 @@ impl IsolationManager {
             return false;
         }
 
-        if path.starts_with(&self.bitfun_dir) {
+        if path.starts_with(&self.runtime_context.runtime_root) {
             return false;
         }
 

--- a/src/crates/core/src/service/snapshot/manager.rs
+++ b/src/crates/core/src/service/snapshot/manager.rs
@@ -5,6 +5,7 @@ use crate::service::snapshot::service::SnapshotService;
 use crate::service::snapshot::types::{
     OperationType, SnapshotConfig, SnapshotError, SnapshotResult,
 };
+use crate::service::workspace_runtime::get_workspace_runtime_service_arc;
 use async_trait::async_trait;
 use log::{debug, error, info, warn};
 use serde_json::Value;
@@ -31,7 +32,14 @@ impl SnapshotManager {
             workspace_dir.display()
         );
 
-        let mut snapshot_service = SnapshotService::new(workspace_dir, config);
+        let runtime_service = get_workspace_runtime_service_arc();
+        let runtime_context = runtime_service
+            .ensure_local_workspace_runtime(&workspace_dir)
+            .await
+            .map_err(|e| SnapshotError::ConfigError(e.to_string()))?
+            .context;
+
+        let mut snapshot_service = SnapshotService::new(workspace_dir, runtime_context, config);
         snapshot_service.initialize().await?;
         let snapshot_service = Arc::new(RwLock::new(snapshot_service));
         Ok(Self { snapshot_service })
@@ -192,13 +200,6 @@ impl SnapshotManager {
     pub async fn list_sessions(&self) -> SnapshotResult<Vec<String>> {
         let snapshot_service = self.snapshot_service.read().await;
         snapshot_service.list_sessions().await
-    }
-
-    pub async fn cleanup_snapshot_data(&self, keep_recent_days: u64) -> SnapshotResult<()> {
-        let snapshot_service = self.snapshot_service.read().await;
-        snapshot_service
-            .cleanup_snapshot_data(keep_recent_days)
-            .await
     }
 
     /// Tries to acquire a file lock.

--- a/src/crates/core/src/service/snapshot/service.rs
+++ b/src/crates/core/src/service/snapshot/service.rs
@@ -6,6 +6,7 @@ use crate::service::snapshot::snapshot_system::FileSnapshotSystem;
 use crate::service::snapshot::types::{
     OperationType, SessionInfo, SnapshotConfig, SnapshotError, SnapshotResult,
 };
+use crate::service::workspace_runtime::WorkspaceRuntimeContext;
 use log::info;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -18,19 +19,27 @@ pub struct SnapshotService {
     file_lock_manager: Arc<FileLockManager>,
     snapshot_core: Arc<RwLock<SnapshotCore>>,
     workspace_dir: PathBuf,
-    bitfun_dir: PathBuf,
+    runtime_context: WorkspaceRuntimeContext,
     initialized: bool,
 }
 
 impl SnapshotService {
-    pub fn new(workspace_dir: PathBuf, config: Option<SnapshotConfig>) -> Self {
+    pub fn new(
+        workspace_dir: PathBuf,
+        runtime_context: WorkspaceRuntimeContext,
+        config: Option<SnapshotConfig>,
+    ) -> Self {
         let config = config.unwrap_or_default();
-        let bitfun_dir = workspace_dir.join(".bitfun");
-
-        let isolation_manager = Arc::new(RwLock::new(IsolationManager::new(workspace_dir.clone())));
-        let snapshot_system = FileSnapshotSystem::new(&bitfun_dir);
-        let snapshot_core = Arc::new(RwLock::new(SnapshotCore::new(&bitfun_dir, snapshot_system)));
-        let file_lock_manager = Arc::new(FileLockManager::new(bitfun_dir.clone()));
+        let isolation_manager = Arc::new(RwLock::new(IsolationManager::new(
+            workspace_dir.clone(),
+            runtime_context.clone(),
+        )));
+        let snapshot_system = FileSnapshotSystem::new(runtime_context.clone());
+        let snapshot_core = Arc::new(RwLock::new(SnapshotCore::new(
+            runtime_context.clone(),
+            snapshot_system,
+        )));
+        let file_lock_manager = Arc::new(FileLockManager::new(runtime_context.clone()));
 
         Self {
             config,
@@ -38,7 +47,7 @@ impl SnapshotService {
             file_lock_manager,
             snapshot_core,
             workspace_dir,
-            bitfun_dir,
+            runtime_context,
             initialized: false,
         }
     }
@@ -70,7 +79,7 @@ impl SnapshotService {
         info!(
             "Snapshot service initialized: git_isolated={} bitfun_dir={}",
             isolation_status,
-            self.bitfun_dir.display()
+            self.runtime_context.runtime_root.display()
         );
 
         Ok(())
@@ -363,7 +372,7 @@ impl SnapshotService {
         };
         Ok(SystemStats {
             git_isolated: isolation_status,
-            bitfun_dir: self.bitfun_dir.clone(),
+            bitfun_dir: self.runtime_context.runtime_root.clone(),
         })
     }
 
@@ -371,14 +380,6 @@ impl SnapshotService {
         self.ensure_initialized().await?;
         let snapshot_core = self.snapshot_core.read().await;
         Ok(snapshot_core.list_session_ids())
-    }
-
-    pub async fn cleanup_snapshot_data(&self, keep_recent_days: u64) -> SnapshotResult<()> {
-        self.ensure_initialized().await?;
-        let isolation_manager = self.isolation_manager.read().await;
-        isolation_manager
-            .cleanup_snapshot_data(keep_recent_days)
-            .await
     }
 
     pub async fn get_file_change_history(
@@ -520,7 +521,7 @@ impl SnapshotService {
     }
 
     pub fn get_bitfun_dir(&self) -> &Path {
-        &self.bitfun_dir
+        &self.runtime_context.runtime_root
     }
 
     pub async fn check_git_isolation(&self) -> SnapshotResult<bool> {

--- a/src/crates/core/src/service/snapshot/snapshot_core.rs
+++ b/src/crates/core/src/service/snapshot/snapshot_core.rs
@@ -2,6 +2,7 @@ use crate::service::snapshot::snapshot_system::FileSnapshotSystem;
 use crate::service::snapshot::types::{
     DiffSummary, FileOperation, OperationType, SnapshotError, SnapshotResult, ToolContext,
 };
+use crate::service::workspace_runtime::WorkspaceRuntimeContext;
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -86,8 +87,11 @@ pub struct SnapshotCore {
 }
 
 impl SnapshotCore {
-    pub fn new(bitfun_dir: &Path, snapshot_system: FileSnapshotSystem) -> Self {
-        let sessions_dir = bitfun_dir.join("snapshots").join("operations");
+    pub fn new(
+        runtime_context: WorkspaceRuntimeContext,
+        snapshot_system: FileSnapshotSystem,
+    ) -> Self {
+        let sessions_dir = runtime_context.snapshot_operations_dir.clone();
         Self {
             sessions: HashMap::new(),
             operation_index: HashMap::new(),
@@ -98,11 +102,6 @@ impl SnapshotCore {
 
     pub async fn initialize(&mut self) -> SnapshotResult<()> {
         info!("Initializing operation history system");
-        if !self.sessions_dir.exists() {
-            tokio::fs::create_dir_all(&self.sessions_dir)
-                .await
-                .map_err(SnapshotError::Io)?;
-        }
 
         self.snapshot_system.initialize().await?;
         self.load_all_sessions().await?;

--- a/src/crates/core/src/service/snapshot/snapshot_system.rs
+++ b/src/crates/core/src/service/snapshot/snapshot_system.rs
@@ -2,6 +2,7 @@ use crate::service::snapshot::types::{
     FileMetadata, FileSnapshot, OptimizedContent, SnapshotError, SnapshotResult, SnapshotType,
     StorageStats,
 };
+use crate::service::workspace_runtime::WorkspaceRuntimeContext;
 use log::{debug, error, info, warn};
 use std::collections::HashMap;
 use std::fs;
@@ -23,17 +24,7 @@ pub struct BaselineCache {
 
 impl BaselineCache {
     /// Creates a new baseline cache.
-    pub fn new(bitfun_dir: &Path) -> Self {
-        let baseline_dir = bitfun_dir.join("snapshots").join("baselines");
-
-        if let Err(e) = std::fs::create_dir_all(&baseline_dir) {
-            warn!(
-                "Failed to create baseline directory: path={} error={}",
-                baseline_dir.display(),
-                e
-            );
-        }
-
+    pub fn new(baseline_dir: PathBuf) -> Self {
         debug!(
             "BaselineCache initialized: directory={}",
             baseline_dir.display()
@@ -211,6 +202,8 @@ impl BaselineCache {
 /// Only stores snapshots of file content; does not manage a change queue.
 pub struct FileSnapshotSystem {
     snapshot_dir: PathBuf,
+    snapshot_by_hash_dir: PathBuf,
+    snapshot_metadata_dir: PathBuf,
     hash_to_path: HashMap<String, PathBuf>,
     active_snapshots: HashMap<String, FileSnapshot>,
     compression_enabled: bool,
@@ -220,16 +213,18 @@ pub struct FileSnapshotSystem {
 
 impl FileSnapshotSystem {
     /// Creates a new file snapshot system.
-    pub fn new(bitfun_dir: &Path) -> Self {
-        let snapshot_dir = bitfun_dir.join("snapshots");
+    pub fn new(runtime_context: WorkspaceRuntimeContext) -> Self {
+        let snapshot_dir = runtime_context.snapshots_dir.clone();
 
         Self {
+            snapshot_by_hash_dir: runtime_context.snapshot_by_hash_dir.clone(),
+            snapshot_metadata_dir: runtime_context.snapshot_metadata_dir.clone(),
             snapshot_dir,
             hash_to_path: HashMap::new(),
             active_snapshots: HashMap::new(),
             compression_enabled: true,
             dedup_enabled: true,
-            baseline_cache: BaselineCache::new(bitfun_dir),
+            baseline_cache: BaselineCache::new(runtime_context.snapshot_baselines_dir.clone()),
         }
     }
 
@@ -252,14 +247,17 @@ impl FileSnapshotSystem {
     async fn ensure_directories(&self) -> SnapshotResult<()> {
         let directories = [
             &self.snapshot_dir,
-            &self.snapshot_dir.join("by_hash"),
-            &self.snapshot_dir.join("metadata"),
+            &self.snapshot_by_hash_dir,
+            &self.snapshot_metadata_dir,
+            &self.baseline_cache.baseline_dir,
         ];
 
         for dir in &directories {
             if !dir.exists() {
-                fs::create_dir_all(dir)?;
-                debug!("Created snapshot directory: path={}", dir.display());
+                return Err(SnapshotError::ConfigError(format!(
+                    "Snapshot runtime directory is missing: {}",
+                    dir.display()
+                )));
             }
         }
 
@@ -268,7 +266,7 @@ impl FileSnapshotSystem {
 
     /// Loads the existing snapshot index.
     async fn load_snapshot_index(&mut self) -> SnapshotResult<()> {
-        let metadata_dir = self.snapshot_dir.join("metadata");
+        let metadata_dir = self.snapshot_metadata_dir.clone();
 
         if !metadata_dir.exists() {
             return Ok(());
@@ -501,20 +499,18 @@ impl FileSnapshotSystem {
 
     /// Returns the content file path.
     fn get_content_path(&self, content_hash: &str) -> PathBuf {
-        self.snapshot_dir
-            .join("by_hash")
+        self.snapshot_by_hash_dir
             .join(format!("{}.snap", content_hash))
     }
 
     /// Returns the metadata file path.
     fn get_metadata_path(&self, snapshot_id: &str) -> PathBuf {
         if snapshot_id.starts_with("baseline_") {
-            self.snapshot_dir
-                .join("baselines")
+            self.baseline_cache
+                .baseline_dir
                 .join(format!("{}.json", snapshot_id))
         } else {
-            self.snapshot_dir
-                .join("metadata")
+            self.snapshot_metadata_dir
                 .join(format!("{}.json", snapshot_id))
         }
     }
@@ -685,7 +681,7 @@ impl FileSnapshotSystem {
 
         let total_snapshots = self.active_snapshots.len();
 
-        let content_dir = self.snapshot_dir.join("by_hash");
+        let content_dir = self.snapshot_by_hash_dir.clone();
         if content_dir.exists() {
             for entry in fs::read_dir(&content_dir)? {
                 let entry = entry?;
@@ -731,7 +727,7 @@ impl FileSnapshotSystem {
         info!("Cleaning up orphaned snapshots");
 
         let mut cleaned_count = 0;
-        let content_dir = self.snapshot_dir.join("by_hash");
+        let content_dir = self.snapshot_by_hash_dir.clone();
 
         if !content_dir.exists() {
             return Ok(0);

--- a/src/crates/core/src/service/workspace/service.rs
+++ b/src/crates/core/src/service/workspace/service.rs
@@ -12,6 +12,9 @@ use crate::infrastructure::storage::{PersistenceService, StorageOptions};
 use crate::infrastructure::{try_get_path_manager_arc, PathManager};
 use crate::service::bootstrap::initialize_workspace_persona_files;
 use crate::service::remote_ssh::workspace_state::local_workspace_roots_equal;
+use crate::service::workspace_runtime::{
+    try_get_workspace_runtime_service_arc, WorkspaceRuntimeService,
+};
 use crate::util::errors::*;
 use log::{info, warn};
 
@@ -29,6 +32,7 @@ pub struct WorkspaceService {
     config: WorkspaceManagerConfig,
     persistence: Arc<PersistenceService>,
     path_manager: Arc<PathManager>,
+    runtime_service: Arc<WorkspaceRuntimeService>,
     session_workspace_maintenance: Arc<SessionWorkspaceMaintenanceService>,
 }
 
@@ -96,6 +100,62 @@ struct AssistantWorkspaceDescriptor {
 }
 
 impl WorkspaceService {
+    fn collect_startup_restored_workspaces(
+        manager: &WorkspaceManager,
+    ) -> Vec<(PathBuf, WorkspaceKind)> {
+        let mut targets = Vec::new();
+        let mut seen_workspace_ids = HashSet::new();
+
+        if let Some(workspace) = manager.get_current_workspace() {
+            Self::push_startup_restored_workspace(&mut targets, &mut seen_workspace_ids, workspace);
+        }
+
+        for workspace in manager.get_opened_workspace_infos() {
+            Self::push_startup_restored_workspace(&mut targets, &mut seen_workspace_ids, workspace);
+        }
+
+        targets
+    }
+
+    fn push_startup_restored_workspace(
+        targets: &mut Vec<(PathBuf, WorkspaceKind)>,
+        seen_workspace_ids: &mut HashSet<String>,
+        workspace: &WorkspaceInfo,
+    ) {
+        if seen_workspace_ids.insert(workspace.id.clone()) {
+            targets.push((
+                workspace.root_path.clone(),
+                workspace.workspace_kind.clone(),
+            ));
+        }
+    }
+
+    async fn prepare_startup_restored_workspaces(&self, workspaces: Vec<(PathBuf, WorkspaceKind)>) {
+        for (workspace_path, workspace_kind) in workspaces {
+            if workspace_kind == WorkspaceKind::Remote || !workspace_path.exists() {
+                continue;
+            }
+
+            if let Err(e) = self
+                .runtime_service
+                .ensure_local_workspace_runtime(&workspace_path)
+                .await
+            {
+                warn!(
+                    "Failed to initialize restored project storage: workspace_path={} error={}",
+                    workspace_path.display(),
+                    e
+                );
+            }
+
+            self.maintain_workspace_sessions_best_effort(
+                &workspace_path,
+                "workspace_history_restored",
+            )
+            .await;
+        }
+    }
+
     async fn maintain_workspace_sessions_best_effort(&self, workspace_path: &Path, trigger: &str) {
         match self
             .session_workspace_maintenance
@@ -133,6 +193,7 @@ impl WorkspaceService {
     /// Creates a workspace service with a custom configuration.
     pub async fn with_config(config: WorkspaceManagerConfig) -> BitFunResult<Self> {
         let path_manager = try_get_path_manager_arc()?;
+        let runtime_service = try_get_workspace_runtime_service_arc()?;
 
         path_manager.initialize_user_directories().await?;
 
@@ -154,6 +215,7 @@ impl WorkspaceService {
             config,
             persistence,
             path_manager,
+            runtime_service,
             session_workspace_maintenance,
         };
 
@@ -185,6 +247,10 @@ impl WorkspaceService {
         &self.persistence
     }
 
+    pub fn runtime_service(&self) -> &Arc<WorkspaceRuntimeService> {
+        &self.runtime_service
+    }
+
     /// Opens a workspace.
     pub async fn open_workspace(&self, path: PathBuf) -> BitFunResult<WorkspaceInfo> {
         self.open_workspace_with_options(path, WorkspaceCreateOptions::default())
@@ -204,6 +270,22 @@ impl WorkspaceService {
                 .open_workspace_with_options(path, Self::to_manager_open_options(&options))
                 .await
         };
+
+        if let Ok(workspace) = result.as_ref() {
+            if workspace.workspace_kind != WorkspaceKind::Remote {
+                if let Err(e) = self
+                    .runtime_service
+                    .ensure_local_workspace_runtime(&workspace.root_path)
+                    .await
+                {
+                    warn!(
+                        "Failed to initialize project storage: workspace_path={} error={}",
+                        workspace.root_path.display(),
+                        e
+                    );
+                }
+            }
+        }
 
         if result.is_ok() {
             if let Err(e) = self.save_workspace_data().await {
@@ -347,6 +429,19 @@ impl WorkspaceService {
 
         if result.is_ok() {
             if let Some(workspace) = self.get_workspace(workspace_id).await {
+                if workspace.workspace_kind != WorkspaceKind::Remote {
+                    if let Err(e) = self
+                        .runtime_service
+                        .ensure_local_workspace_runtime(&workspace.root_path)
+                        .await
+                    {
+                        warn!(
+                            "Failed to initialize activated project storage: workspace_path={} error={}",
+                            workspace.root_path.display(),
+                            e
+                        );
+                    }
+                }
                 self.maintain_workspace_sessions_best_effort(
                     &workspace.root_path,
                     "workspace_activated",
@@ -1108,7 +1203,7 @@ impl WorkspaceService {
             .await
             .map_err(|e| BitFunError::service(format!("Failed to load workspace data: {}", e)))?;
 
-        let mut workspace_to_maintain: Option<PathBuf> = None;
+        let mut workspaces_to_restore = Vec::new();
 
         if let Some(data) = workspace_data {
             let mut manager = self.manager.write().await;
@@ -1166,22 +1261,15 @@ impl WorkspaceService {
                 if manager.get_workspaces().contains_key(&current_id) {
                     if let Err(e) = manager.set_current_workspace(current_id) {
                         warn!("Failed to restore current workspace on startup: {}", e);
-                    } else {
-                        workspace_to_maintain = manager
-                            .get_current_workspace()
-                            .map(|workspace| workspace.root_path.clone());
                     }
                 }
             }
+
+            workspaces_to_restore = Self::collect_startup_restored_workspaces(&manager);
         }
 
-        if let Some(workspace_path) = workspace_to_maintain {
-            self.maintain_workspace_sessions_best_effort(
-                &workspace_path,
-                "workspace_history_restored",
-            )
+        self.prepare_startup_restored_workspaces(workspaces_to_restore)
             .await;
-        }
 
         Ok(())
     }
@@ -1723,4 +1811,192 @@ pub fn set_global_workspace_service(service: Arc<WorkspaceService>) {
 
 pub fn get_global_workspace_service() -> Option<Arc<WorkspaceService>> {
     GLOBAL_WORKSPACE_SERVICE.get().cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::storage::{PersistenceService, StorageOptions};
+    use crate::service::session::SessionMetadata;
+    use std::collections::HashMap;
+    use uuid::Uuid;
+
+    struct TestEnvironment {
+        root: PathBuf,
+        path_manager: Arc<PathManager>,
+    }
+
+    impl TestEnvironment {
+        fn new() -> Self {
+            let root = std::env::temp_dir()
+                .join(format!("bitfun-workspace-service-test-{}", Uuid::new_v4()));
+            std::fs::create_dir_all(&root).expect("test root should be created");
+
+            let path_manager = Arc::new(PathManager::with_user_root_for_tests(
+                root.join("user-root"),
+            ));
+
+            Self { root, path_manager }
+        }
+
+        fn create_workspace_dir(&self, name: &str) -> PathBuf {
+            let path = self.root.join(name);
+            std::fs::create_dir_all(&path).expect("workspace directory should be created");
+            path
+        }
+    }
+
+    impl Drop for TestEnvironment {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    async fn build_test_workspace_service(path_manager: Arc<PathManager>) -> WorkspaceService {
+        path_manager
+            .initialize_user_directories()
+            .await
+            .expect("user directories should initialize");
+
+        let config = WorkspaceManagerConfig::default();
+        let persistence = Arc::new(
+            PersistenceService::new_user_level(path_manager.clone())
+                .await
+                .expect("persistence should initialize"),
+        );
+        let runtime_service = Arc::new(WorkspaceRuntimeService::new(path_manager.clone()));
+        let session_workspace_maintenance =
+            Arc::new(SessionWorkspaceMaintenanceService::new(Arc::new(
+                PersistenceManager::new(path_manager.clone())
+                    .expect("persistence manager should initialize"),
+            )));
+
+        WorkspaceService {
+            manager: Arc::new(RwLock::new(WorkspaceManager::new(config.clone()))),
+            config,
+            persistence,
+            path_manager,
+            runtime_service,
+            session_workspace_maintenance,
+        }
+    }
+
+    #[tokio::test]
+    async fn load_workspace_history_only_ensures_all_opened_local_workspaces() {
+        let env = TestEnvironment::new();
+        let service = build_test_workspace_service(env.path_manager.clone()).await;
+        let persistence_manager = PersistenceManager::new(env.path_manager.clone())
+            .expect("persistence manager should initialize");
+
+        let first_workspace_root = env.create_workspace_dir("workspace-one");
+        let second_workspace_root = env.create_workspace_dir("workspace-two");
+
+        let first_workspace = WorkspaceInfo::new(
+            first_workspace_root.clone(),
+            WorkspaceOpenOptions {
+                auto_set_current: false,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("first workspace should initialize");
+        let second_workspace = WorkspaceInfo::new(
+            second_workspace_root.clone(),
+            WorkspaceOpenOptions {
+                auto_set_current: false,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("second workspace should initialize");
+
+        let legacy_session = SessionMetadata::new(
+            Uuid::new_v4().to_string(),
+            "Legacy Session".to_string(),
+            "agent".to_string(),
+            "model".to_string(),
+        );
+        persistence_manager
+            .save_session_metadata(&second_workspace_root, &legacy_session)
+            .await
+            .expect("legacy session metadata should save");
+
+        let second_runtime = persistence_manager
+            .runtime_service()
+            .context_for_local_workspace(&second_workspace_root);
+        let legacy_sessions_root = second_workspace_root.join(".bitfun").join("sessions");
+        std::fs::create_dir_all(&legacy_sessions_root)
+            .expect("legacy sessions root should be created");
+        std::fs::rename(
+            second_runtime.sessions_dir.join(&legacy_session.session_id),
+            legacy_sessions_root.join(&legacy_session.session_id),
+        )
+        .expect("session directory should move to legacy path");
+        let _ = std::fs::remove_dir_all(&second_runtime.runtime_root);
+
+        let first_runtime = service
+            .runtime_service
+            .context_for_local_workspace(&first_workspace_root);
+        assert!(
+            !first_runtime.runtime_root.exists(),
+            "startup should begin without a runtime root for the first workspace"
+        );
+        assert!(
+            !second_runtime.runtime_root.exists(),
+            "startup should begin without a runtime root for the second workspace"
+        );
+
+        let workspace_data = WorkspacePersistenceData {
+            workspaces: HashMap::from([
+                (first_workspace.id.clone(), first_workspace.clone()),
+                (second_workspace.id.clone(), second_workspace.clone()),
+            ]),
+            opened_workspace_ids: vec![first_workspace.id.clone(), second_workspace.id.clone()],
+            current_workspace_id: Some(first_workspace.id.clone()),
+            recent_workspaces: vec![first_workspace.id.clone(), second_workspace.id.clone()],
+            recent_assistant_workspaces: Vec::new(),
+            saved_at: chrono::Utc::now(),
+        };
+
+        service
+            .persistence
+            .save_json("workspace_data", &workspace_data, StorageOptions::default())
+            .await
+            .expect("workspace data should save");
+
+        service
+            .load_workspace_history_only()
+            .await
+            .expect("workspace history should restore");
+
+        let restored_current = service
+            .get_current_workspace()
+            .await
+            .expect("current workspace should be restored");
+        assert_eq!(restored_current.id, first_workspace.id);
+        assert!(
+            first_runtime.runtime_root.exists(),
+            "active workspace runtime should be ensured on startup"
+        );
+        assert!(
+            second_runtime
+                .sessions_dir
+                .join(&legacy_session.session_id)
+                .exists(),
+            "non-active opened workspace sessions should migrate into the shared runtime root"
+        );
+
+        let restored_sessions = persistence_manager
+            .list_session_metadata(&second_workspace_root)
+            .await
+            .expect("restored workspace sessions should list successfully");
+        assert_eq!(restored_sessions.len(), 1);
+        assert_eq!(restored_sessions[0].session_id, legacy_session.session_id);
+        assert!(
+            !legacy_sessions_root
+                .join(&legacy_session.session_id)
+                .exists(),
+            "legacy session directory should be removed after startup migration"
+        );
+    }
 }

--- a/src/crates/core/src/service/workspace_runtime/mod.rs
+++ b/src/crates/core/src/service/workspace_runtime/mod.rs
@@ -1,0 +1,11 @@
+pub mod service;
+pub mod types;
+
+pub use service::{
+    get_workspace_runtime_service_arc, try_get_workspace_runtime_service_arc,
+    WorkspaceRuntimeService,
+};
+pub use types::{
+    RuntimeMigrationRecord, WorkspaceRuntimeContext, WorkspaceRuntimeEnsureResult,
+    WorkspaceRuntimeTarget,
+};

--- a/src/crates/core/src/service/workspace_runtime/service.rs
+++ b/src/crates/core/src/service/workspace_runtime/service.rs
@@ -1,0 +1,540 @@
+use super::types::{
+    RuntimeMigrationRecord, WorkspaceRuntimeContext, WorkspaceRuntimeEnsureResult,
+    WorkspaceRuntimeTarget, WORKSPACE_RUNTIME_LAYOUT_VERSION,
+};
+use crate::agentic::WorkspaceBinding;
+use crate::infrastructure::{get_path_manager_arc, PathManager};
+use crate::service::remote_ssh::workspace_state::remote_workspace_runtime_root;
+use crate::util::errors::{BitFunError, BitFunResult};
+use log::debug;
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use tokio::sync::Mutex as AsyncMutex;
+
+#[derive(Debug)]
+pub struct WorkspaceRuntimeService {
+    path_manager: Arc<PathManager>,
+    verified_runtime_roots: Mutex<HashSet<PathBuf>>,
+}
+
+#[derive(Debug, Serialize)]
+struct RuntimeLayoutState {
+    layout_version: u32,
+    runtime_root: String,
+    target_kind: String,
+    target_descriptor: String,
+    migrated_entries: Vec<RuntimeMigrationRecordState>,
+}
+
+#[derive(Debug, Serialize)]
+struct RuntimeMigrationRecordState {
+    source: String,
+    target: String,
+    strategy: String,
+}
+
+impl WorkspaceRuntimeService {
+    pub fn new(path_manager: Arc<PathManager>) -> Self {
+        Self {
+            path_manager,
+            verified_runtime_roots: Mutex::new(HashSet::new()),
+        }
+    }
+
+    pub fn path_manager(&self) -> &Arc<PathManager> {
+        &self.path_manager
+    }
+
+    pub fn context_for_local_workspace(&self, workspace_path: &Path) -> WorkspaceRuntimeContext {
+        WorkspaceRuntimeContext::new(
+            WorkspaceRuntimeTarget::LocalWorkspace {
+                workspace_root: workspace_path.to_path_buf(),
+            },
+            self.path_manager.project_runtime_root(workspace_path),
+        )
+    }
+
+    pub fn context_for_remote_workspace(
+        &self,
+        ssh_host: &str,
+        remote_root: &str,
+    ) -> WorkspaceRuntimeContext {
+        WorkspaceRuntimeContext::new(
+            WorkspaceRuntimeTarget::RemoteWorkspaceMirror {
+                ssh_host: ssh_host.to_string(),
+                remote_root: remote_root.to_string(),
+            },
+            remote_workspace_runtime_root(ssh_host, remote_root),
+        )
+    }
+
+    pub async fn ensure_local_workspace_runtime(
+        &self,
+        workspace_path: &Path,
+    ) -> BitFunResult<WorkspaceRuntimeEnsureResult> {
+        let context = self.context_for_local_workspace(workspace_path);
+        let legacy_project_root = self.path_manager.project_root(workspace_path);
+        self.ensure_runtime_context(context, Some(legacy_project_root))
+            .await
+    }
+
+    pub async fn ensure_remote_workspace_runtime(
+        &self,
+        ssh_host: &str,
+        remote_root: &str,
+    ) -> BitFunResult<WorkspaceRuntimeEnsureResult> {
+        let context = self.context_for_remote_workspace(ssh_host, remote_root);
+        self.ensure_runtime_context(context, None).await
+    }
+
+    pub async fn ensure_runtime_for_workspace_binding(
+        &self,
+        workspace: &WorkspaceBinding,
+    ) -> BitFunResult<WorkspaceRuntimeEnsureResult> {
+        if workspace.is_remote() {
+            self.ensure_remote_workspace_runtime(
+                &workspace.session_identity.hostname,
+                &workspace.session_identity.workspace_path,
+            )
+            .await
+        } else {
+            self.ensure_local_workspace_runtime(workspace.root_path())
+                .await
+        }
+    }
+
+    async fn ensure_runtime_context(
+        &self,
+        context: WorkspaceRuntimeContext,
+        legacy_project_root: Option<PathBuf>,
+    ) -> BitFunResult<WorkspaceRuntimeEnsureResult> {
+        if self.is_runtime_verified(&context.runtime_root) {
+            return Ok(Self::cached_ensure_result(context));
+        }
+
+        let runtime_lock = runtime_lock_for(&context.runtime_root);
+        let _guard = runtime_lock.lock().await;
+
+        if self.is_runtime_verified(&context.runtime_root) {
+            return Ok(Self::cached_ensure_result(context));
+        }
+
+        let mut migrated_entries = Vec::new();
+        if let Some(legacy_project_root) = legacy_project_root.as_deref() {
+            migrated_entries = self
+                .migrate_legacy_project_runtime_data(legacy_project_root, &context)
+                .await?;
+        }
+
+        let mut created_directories = Vec::new();
+        for dir in context.required_directories() {
+            if !dir.exists() {
+                self.path_manager.ensure_dir(dir).await?;
+                created_directories.push(dir.to_path_buf());
+            }
+        }
+
+        if !context.layout_state_file.exists()
+            || !created_directories.is_empty()
+            || !migrated_entries.is_empty()
+        {
+            self.persist_layout_state(&context, &migrated_entries)
+                .await?;
+        }
+
+        self.mark_runtime_verified(&context.runtime_root);
+
+        if !created_directories.is_empty() || !migrated_entries.is_empty() {
+            debug!(
+                "Workspace runtime ensured: root={} created_dirs={} migrated_entries={}",
+                context.runtime_root.display(),
+                created_directories.len(),
+                migrated_entries.len()
+            );
+        }
+
+        Ok(WorkspaceRuntimeEnsureResult {
+            context,
+            created_directories,
+            migrated_entries,
+        })
+    }
+
+    fn cached_ensure_result(context: WorkspaceRuntimeContext) -> WorkspaceRuntimeEnsureResult {
+        WorkspaceRuntimeEnsureResult {
+            context,
+            created_directories: Vec::new(),
+            migrated_entries: Vec::new(),
+        }
+    }
+
+    fn is_runtime_verified(&self, runtime_root: &Path) -> bool {
+        self.verified_runtime_roots
+            .lock()
+            .expect("workspace runtime verified cache poisoned")
+            .contains(runtime_root)
+    }
+
+    fn mark_runtime_verified(&self, runtime_root: &Path) {
+        self.verified_runtime_roots
+            .lock()
+            .expect("workspace runtime verified cache poisoned")
+            .insert(runtime_root.to_path_buf());
+    }
+
+    async fn persist_layout_state(
+        &self,
+        context: &WorkspaceRuntimeContext,
+        migrated_entries: &[RuntimeMigrationRecord],
+    ) -> BitFunResult<()> {
+        let target_descriptor = match &context.target {
+            WorkspaceRuntimeTarget::LocalWorkspace { workspace_root } => {
+                workspace_root.display().to_string()
+            }
+            WorkspaceRuntimeTarget::RemoteWorkspaceMirror {
+                ssh_host,
+                remote_root,
+            } => {
+                format!("{}:{}", ssh_host, remote_root)
+            }
+        };
+
+        let state = RuntimeLayoutState {
+            layout_version: WORKSPACE_RUNTIME_LAYOUT_VERSION,
+            runtime_root: context.runtime_root.display().to_string(),
+            target_kind: context.target.kind().to_string(),
+            target_descriptor,
+            migrated_entries: migrated_entries
+                .iter()
+                .map(|record| RuntimeMigrationRecordState {
+                    source: record.source.display().to_string(),
+                    target: record.target.display().to_string(),
+                    strategy: record.strategy.clone(),
+                })
+                .collect(),
+        };
+
+        let bytes = serde_json::to_vec_pretty(&state).map_err(|e| {
+            BitFunError::service(format!("Failed to serialize runtime state: {}", e))
+        })?;
+        tokio::fs::write(&context.layout_state_file, bytes)
+            .await
+            .map_err(|e| {
+                BitFunError::service(format!(
+                    "Failed to write runtime layout state '{}': {}",
+                    context.layout_state_file.display(),
+                    e
+                ))
+            })?;
+        Ok(())
+    }
+
+    async fn migrate_legacy_project_runtime_data(
+        &self,
+        legacy_project_root: &Path,
+        context: &WorkspaceRuntimeContext,
+    ) -> BitFunResult<Vec<RuntimeMigrationRecord>> {
+        if !legacy_project_root.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut migrated_entries = Vec::new();
+        let mappings = vec![
+            (
+                vec![legacy_project_root.join("sessions")],
+                context.sessions_dir.clone(),
+            ),
+            (
+                vec![legacy_project_root.join("memory")],
+                context.memory_dir.clone(),
+            ),
+            (
+                vec![legacy_project_root.join("plans")],
+                context.plans_dir.clone(),
+            ),
+            (
+                vec![legacy_project_root.join("snapshots")],
+                context.snapshots_dir.clone(),
+            ),
+            (
+                vec![legacy_project_root.join("ai_memories.json")],
+                context.runtime_root.join("ai_memories.json"),
+            ),
+        ];
+
+        for (candidates, target) in mappings {
+            if let Some(record) = self
+                .migrate_first_existing_path(&candidates, &target)
+                .await?
+            {
+                migrated_entries.push(record);
+            }
+        }
+
+        Ok(migrated_entries)
+    }
+
+    async fn migrate_first_existing_path(
+        &self,
+        candidates: &[PathBuf],
+        target: &Path,
+    ) -> BitFunResult<Option<RuntimeMigrationRecord>> {
+        if target.exists() {
+            return Ok(None);
+        }
+
+        for candidate in candidates {
+            if !candidate.exists() {
+                continue;
+            }
+
+            return self.move_legacy_path(candidate, target).await.map(Some);
+        }
+
+        Ok(None)
+    }
+
+    async fn move_legacy_path(
+        &self,
+        source: &Path,
+        target: &Path,
+    ) -> BitFunResult<RuntimeMigrationRecord> {
+        if let Some(parent) = target.parent() {
+            self.path_manager.ensure_dir(parent).await?;
+        }
+
+        match tokio::fs::rename(source, target).await {
+            Ok(()) => Ok(RuntimeMigrationRecord {
+                source: source.to_path_buf(),
+                target: target.to_path_buf(),
+                strategy: "rename".to_string(),
+            }),
+            Err(_) if source.is_dir() => {
+                copy_dir_recursive(source, target)?;
+                std::fs::remove_dir_all(source).map_err(|e| {
+                    BitFunError::service(format!(
+                        "Failed to remove legacy directory {}: {}",
+                        source.display(),
+                        e
+                    ))
+                })?;
+                Ok(RuntimeMigrationRecord {
+                    source: source.to_path_buf(),
+                    target: target.to_path_buf(),
+                    strategy: "copy_dir".to_string(),
+                })
+            }
+            Err(_) => {
+                std::fs::copy(source, target).map_err(|e| {
+                    BitFunError::service(format!(
+                        "Failed to copy legacy file {} to {}: {}",
+                        source.display(),
+                        target.display(),
+                        e
+                    ))
+                })?;
+                std::fs::remove_file(source).map_err(|e| {
+                    BitFunError::service(format!(
+                        "Failed to remove legacy file {}: {}",
+                        source.display(),
+                        e
+                    ))
+                })?;
+                Ok(RuntimeMigrationRecord {
+                    source: source.to_path_buf(),
+                    target: target.to_path_buf(),
+                    strategy: "copy_file".to_string(),
+                })
+            }
+        }
+    }
+}
+
+fn copy_dir_recursive(source: &Path, target: &Path) -> BitFunResult<()> {
+    std::fs::create_dir_all(target).map_err(|e| {
+        BitFunError::service(format!(
+            "Failed to create target directory {}: {}",
+            target.display(),
+            e
+        ))
+    })?;
+
+    for entry in std::fs::read_dir(source).map_err(|e| {
+        BitFunError::service(format!(
+            "Failed to read legacy directory {}: {}",
+            source.display(),
+            e
+        ))
+    })? {
+        let entry = entry.map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to inspect legacy directory entry under {}: {}",
+                source.display(),
+                e
+            ))
+        })?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let file_type = entry.file_type().map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to read file type for {}: {}",
+                source_path.display(),
+                e
+            ))
+        })?;
+
+        if file_type.is_dir() {
+            copy_dir_recursive(&source_path, &target_path)?;
+        } else if file_type.is_file() {
+            std::fs::copy(&source_path, &target_path).map_err(|e| {
+                BitFunError::service(format!(
+                    "Failed to copy legacy file {} to {}: {}",
+                    source_path.display(),
+                    target_path.display(),
+                    e
+                ))
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn runtime_lock_for(runtime_root: &Path) -> Arc<AsyncMutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>> = OnceLock::new();
+
+    let locks = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = locks.lock().expect("workspace runtime lock store poisoned");
+    guard
+        .entry(runtime_root.to_path_buf())
+        .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+}
+
+static GLOBAL_WORKSPACE_RUNTIME_SERVICE: OnceLock<Arc<WorkspaceRuntimeService>> = OnceLock::new();
+
+fn init_global_workspace_runtime_service() -> Arc<WorkspaceRuntimeService> {
+    Arc::new(WorkspaceRuntimeService::new(get_path_manager_arc()))
+}
+
+pub fn get_workspace_runtime_service_arc() -> Arc<WorkspaceRuntimeService> {
+    GLOBAL_WORKSPACE_RUNTIME_SERVICE
+        .get_or_init(init_global_workspace_runtime_service)
+        .clone()
+}
+
+pub fn try_get_workspace_runtime_service_arc() -> BitFunResult<Arc<WorkspaceRuntimeService>> {
+    Ok(get_workspace_runtime_service_arc())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WorkspaceRuntimeService;
+    use crate::infrastructure::PathManager;
+    use std::fs;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn ensure_local_workspace_runtime_creates_complete_layout_without_project_dot_dir() {
+        let test_root =
+            std::env::temp_dir().join(format!("bitfun-runtime-test-{}", Uuid::new_v4()));
+        let workspace_root = test_root.join("workspace");
+        fs::create_dir_all(&workspace_root).expect("workspace should exist");
+
+        let path_manager = Arc::new(PathManager::with_user_root_for_tests(
+            test_root.join("user"),
+        ));
+        let service = WorkspaceRuntimeService::new(path_manager.clone());
+
+        let ensured = service
+            .ensure_local_workspace_runtime(&workspace_root)
+            .await
+            .expect("runtime should be ensured");
+
+        let context = ensured.context;
+        assert!(context.runtime_root.exists());
+        assert!(context.sessions_dir.exists());
+        assert!(context.snapshot_by_hash_dir.exists());
+        assert!(context.snapshot_metadata_dir.exists());
+        assert!(context.snapshot_baselines_dir.exists());
+        assert!(context.snapshot_operations_dir.exists());
+        assert!(context.locks_dir.exists());
+        assert!(context.layout_state_file.exists());
+        assert!(!path_manager
+            .project_root(&workspace_root)
+            .join("context")
+            .exists());
+
+        let _ = fs::remove_dir_all(&test_root);
+    }
+
+    #[tokio::test]
+    async fn ensure_local_workspace_runtime_migrates_legacy_runtime_entries() {
+        let test_root =
+            std::env::temp_dir().join(format!("bitfun-runtime-test-{}", Uuid::new_v4()));
+        let workspace_root = test_root.join("workspace");
+        let legacy_root = workspace_root.join(".bitfun");
+        fs::create_dir_all(legacy_root.join("sessions")).expect("legacy sessions should exist");
+        fs::write(legacy_root.join("sessions").join("s1.json"), "{}")
+            .expect("legacy session file should be written");
+
+        let path_manager = Arc::new(PathManager::with_user_root_for_tests(
+            test_root.join("user"),
+        ));
+        let service = WorkspaceRuntimeService::new(path_manager.clone());
+
+        let ensured = service
+            .ensure_local_workspace_runtime(&workspace_root)
+            .await
+            .expect("runtime should be ensured");
+
+        assert!(ensured.context.sessions_dir.join("s1.json").exists());
+        assert!(!legacy_root.join("sessions").exists());
+        assert_eq!(ensured.migrated_entries.len(), 1);
+
+        let _ = fs::remove_dir_all(&test_root);
+    }
+
+    #[tokio::test]
+    async fn ensure_local_workspace_runtime_uses_verified_cache_on_repeat_calls() {
+        let test_root =
+            std::env::temp_dir().join(format!("bitfun-runtime-test-{}", Uuid::new_v4()));
+        let workspace_root = test_root.join("workspace");
+        fs::create_dir_all(&workspace_root).expect("workspace should exist");
+
+        let path_manager = Arc::new(PathManager::with_user_root_for_tests(
+            test_root.join("user"),
+        ));
+        let service = WorkspaceRuntimeService::new(path_manager);
+
+        let first = service
+            .ensure_local_workspace_runtime(&workspace_root)
+            .await
+            .expect("first ensure should succeed");
+        let first_modified = fs::metadata(&first.context.layout_state_file)
+            .expect("layout state should exist")
+            .modified()
+            .expect("layout state should have modified time");
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let second = service
+            .ensure_local_workspace_runtime(&workspace_root)
+            .await
+            .expect("second ensure should succeed");
+        let second_modified = fs::metadata(&second.context.layout_state_file)
+            .expect("layout state should still exist")
+            .modified()
+            .expect("layout state should have modified time");
+
+        assert!(second.created_directories.is_empty());
+        assert!(second.migrated_entries.is_empty());
+        assert_eq!(first_modified, second_modified);
+
+        let _ = fs::remove_dir_all(&test_root);
+    }
+}

--- a/src/crates/core/src/service/workspace_runtime/types.rs
+++ b/src/crates/core/src/service/workspace_runtime/types.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+pub const WORKSPACE_RUNTIME_LAYOUT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WorkspaceRuntimeTarget {
+    LocalWorkspace {
+        workspace_root: PathBuf,
+    },
+    RemoteWorkspaceMirror {
+        ssh_host: String,
+        remote_root: String,
+    },
+}
+
+impl WorkspaceRuntimeTarget {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::LocalWorkspace { .. } => "local_workspace",
+            Self::RemoteWorkspaceMirror { .. } => "remote_workspace_mirror",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceRuntimeContext {
+    pub target: WorkspaceRuntimeTarget,
+    pub runtime_root: PathBuf,
+    pub sessions_dir: PathBuf,
+    pub snapshots_dir: PathBuf,
+    pub snapshot_by_hash_dir: PathBuf,
+    pub snapshot_metadata_dir: PathBuf,
+    pub snapshot_baselines_dir: PathBuf,
+    pub snapshot_operations_dir: PathBuf,
+    pub memory_dir: PathBuf,
+    pub plans_dir: PathBuf,
+    pub locks_dir: PathBuf,
+    pub config_dir: PathBuf,
+    pub isolation_status_file: PathBuf,
+    pub layout_state_file: PathBuf,
+}
+
+impl WorkspaceRuntimeContext {
+    pub fn new(target: WorkspaceRuntimeTarget, runtime_root: PathBuf) -> Self {
+        let snapshots_dir = runtime_root.join("snapshots");
+        let config_dir = runtime_root.join("config");
+
+        Self {
+            target,
+            sessions_dir: runtime_root.join("sessions"),
+            snapshot_by_hash_dir: snapshots_dir.join("by_hash"),
+            snapshot_metadata_dir: snapshots_dir.join("metadata"),
+            snapshot_baselines_dir: snapshots_dir.join("baselines"),
+            snapshot_operations_dir: snapshots_dir.join("operations"),
+            memory_dir: runtime_root.join("memory"),
+            plans_dir: runtime_root.join("plans"),
+            locks_dir: runtime_root.join("locks"),
+            isolation_status_file: config_dir.join("isolation_status.json"),
+            layout_state_file: config_dir.join("runtime_layout_state.json"),
+            runtime_root,
+            snapshots_dir,
+            config_dir,
+        }
+    }
+
+    pub fn required_directories(&self) -> Vec<&Path> {
+        vec![
+            self.runtime_root.as_path(),
+            self.sessions_dir.as_path(),
+            self.snapshots_dir.as_path(),
+            self.snapshot_by_hash_dir.as_path(),
+            self.snapshot_metadata_dir.as_path(),
+            self.snapshot_baselines_dir.as_path(),
+            self.snapshot_operations_dir.as_path(),
+            self.memory_dir.as_path(),
+            self.plans_dir.as_path(),
+            self.locks_dir.as_path(),
+            self.config_dir.as_path(),
+        ]
+    }
+
+    pub fn session_dir(&self, session_id: &str) -> PathBuf {
+        self.sessions_dir.join(session_id)
+    }
+
+    pub fn session_tool_results_dir(&self, session_id: &str) -> PathBuf {
+        self.session_dir(session_id).join("tool-results")
+    }
+
+    pub fn session_tool_result_path(&self, session_id: &str, file_name: &str) -> PathBuf {
+        self.session_tool_results_dir(session_id).join(file_name)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeMigrationRecord {
+    pub source: PathBuf,
+    pub target: PathBuf,
+    pub strategy: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceRuntimeEnsureResult {
+    pub context: WorkspaceRuntimeContext,
+    pub created_directories: Vec<PathBuf>,
+    pub migrated_entries: Vec<RuntimeMigrationRecord>,
+}

--- a/src/crates/core/tests/common/stream_test_harness.rs
+++ b/src/crates/core/tests/common/stream_test_harness.rs
@@ -1,11 +1,11 @@
 use super::fixture_loader::load_fixture_bytes;
 use super::sse_fixture_server::{FixtureSseServer, FixtureSseServerOptions};
-use bitfun_core::agentic::events::{AgenticEvent, EventQueue, EventQueueConfig};
-use bitfun_core::agentic::execution::{StreamProcessError, StreamResult};
 use bitfun_ai_adapters::stream::{
     handle_anthropic_stream, handle_gemini_stream, handle_openai_stream, handle_responses_stream,
     UnifiedResponse,
 };
+use bitfun_core::agentic::events::{AgenticEvent, EventQueue, EventQueueConfig};
+use bitfun_core::agentic::execution::{StreamProcessError, StreamResult};
 use bitfun_core::StreamProcessor;
 use futures::StreamExt;
 use std::sync::Arc;

--- a/src/crates/core/tests/stream_processor_openai.rs
+++ b/src/crates/core/tests/stream_processor_openai.rs
@@ -210,7 +210,10 @@ async fn openai_fixture_reattaches_id_only_prelude_to_following_payload_chunk() 
             } if tool_id == "call_1" && tool_name == "tool_a"
         )
     });
-    assert!(early_detected, "expected reattached tool id to trigger early detection");
+    assert!(
+        early_detected,
+        "expected reattached tool id to trigger early detection"
+    );
 
     let partial_params: Vec<&str> = output
         .events
@@ -258,7 +261,10 @@ async fn openai_fixture_replaces_snapshot_tool_args_after_stop_reason_chunk() {
             _ => None,
         })
         .collect();
-    assert_eq!(partial_params, vec!["{\"city\":\"Bei", "{\"city\":\"Beijing\"}"]);
+    assert_eq!(
+        partial_params,
+        vec!["{\"city\":\"Bei", "{\"city\":\"Beijing\"}"]
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -284,8 +290,8 @@ async fn openai_fixture_filters_unseen_id_only_orphan_tool_chunk() {
         matches!(
             event,
             AgenticEvent::ToolEvent {
-                tool_event:
-                    ToolEventData::EarlyDetected { .. } | ToolEventData::ParamsPartial { .. },
+                tool_event: ToolEventData::EarlyDetected { .. }
+                    | ToolEventData::ParamsPartial { .. },
                 ..
             }
         )

--- a/src/web-ui/src/app/hooks/useSnapshot.ts
+++ b/src/web-ui/src/app/hooks/useSnapshot.ts
@@ -69,7 +69,6 @@ export interface UseSnapshotReturn {
   acceptOperation: (sessionId: string, operationId: string) => Promise<void>;
   rejectOperation: (sessionId: string, operationId: string) => Promise<void>;
   rollbackSession: (sessionId: string) => Promise<void>;
-  cleanupExpiredData: (maxAgeDays?: number) => Promise<void>;
   
   // Utilities
   clearError: () => void;
@@ -202,23 +201,6 @@ export const useSnapshot = (): UseSnapshotReturn => {
     }
   }, [loadSessionOperations, loadStats, loadSessions, t, workspacePath]);
 
-  // Cleanup expired data
-  const cleanupExpiredData = useCallback(async (maxAgeDays: number = 30) => {
-    try {
-      setError(null);
-      await snapshotAPI.cleanupSnapshotData(maxAgeDays, workspacePath || undefined);
-      
-      // Reload stats
-      await Promise.all([
-        loadStats(),
-        loadSessions()
-      ]);
-    } catch (err) {
-      log.error('Failed to cleanup expired data', err);
-      setError(t('snapshot.cleanupFailed'));
-    }
-  }, [loadStats, loadSessions, t, workspacePath]);
-
   // Update snapshot session info (called on backend create)
   const updateSnapshotSession = useCallback((session: SnapshotSession) => {
     setSessions(prevSessions => {
@@ -262,7 +244,6 @@ export const useSnapshot = (): UseSnapshotReturn => {
     acceptOperation,
     rejectOperation,
     rollbackSession,
-    cleanupExpiredData,
     
     // Utilities
     clearError

--- a/src/web-ui/src/app/scenes/session/ChatPane.tsx
+++ b/src/web-ui/src/app/scenes/session/ChatPane.tsx
@@ -11,6 +11,7 @@ import { useCanvasStore } from '../../components/panels/content-canvas/stores/ca
 import type { LineRange } from '@/component-library';
 import path from 'path-browserify';
 import { createLogger } from '@/shared/utils/logger';
+import { hasNonFileUriScheme } from '@/shared/utils/pathUtils';
 
 import './ChatPane.scss';
 
@@ -47,8 +48,9 @@ const ChatPaneInner: React.FC<ChatPaneProps> = ({
 
     let absoluteFilePath = filePath;
     const isWindowsAbsolutePath = /^[A-Za-z]:[\\/]/.test(filePath);
+    const isProtocolPath = hasNonFileUriScheme(filePath);
 
-    if (!isWindowsAbsolutePath && !path.isAbsolute(filePath) && workspacePath) {
+    if (!isProtocolPath && !isWindowsAbsolutePath && !path.isAbsolute(filePath) && workspacePath) {
       absoluteFilePath = path.join(workspacePath, filePath);
       log.debug('Converting relative path to absolute', {
         relative: filePath,

--- a/src/web-ui/src/component-library/components/registry.tsx
+++ b/src/web-ui/src/component-library/components/registry.tsx
@@ -1799,7 +1799,7 @@ console.log(user.greet());`);
               toolItem={createMockToolItem('CreatePlan',
                 {},
                 {
-                  plan_file_path: '/project/.bitfun/plans/refactor-user-module.md',
+                  plan_file_path: '/Users/demo/.bitfun/projects/project-slug/plans/refactor-user-module.plan.md',
                   name: 'Refactor Module',
                   overview: 'Plan overview',
                   todos: [
@@ -1822,7 +1822,7 @@ console.log(user.greet());`);
               toolItem={createMockToolItem('CreatePlan',
                 {},
                 {
-                  plan_file_path: '/project/.bitfun/plans/add-dark-mode.md',
+                  plan_file_path: '/Users/demo/.bitfun/projects/project-slug/plans/add-dark-mode.plan.md',
                   name: 'Dark Mode',
                   overview: 'Add dark mode support',
                   todos: [

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFileActions.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFileActions.ts
@@ -8,6 +8,7 @@ import { createLogger } from '@/shared/utils/logger';
 import { notificationService } from '@/shared/notification-system';
 import { fileTabManager } from '@/shared/services/FileTabManager';
 import type { LineRange } from '@/component-library';
+import { hasNonFileUriScheme } from '@/shared/utils/pathUtils';
 
 const log = createLogger('useFlowChatFileActions');
 
@@ -39,8 +40,9 @@ export function useFlowChatFileActions({
 
     let absoluteFilePath = filePath;
     const isWindowsAbsolutePath = /^[A-Za-z]:[\\/]/.test(filePath);
+    const isProtocolPath = hasNonFileUriScheme(filePath);
 
-    if (!isWindowsAbsolutePath && !path.isAbsolute(filePath) && workspacePath) {
+    if (!isProtocolPath && !isWindowsAbsolutePath && !path.isAbsolute(filePath) && workspacePath) {
       absoluteFilePath = path.join(workspacePath, filePath);
       log.debug('Converted relative path to absolute', {
         relative: filePath,

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -1536,8 +1536,8 @@ function detectModifiedPlanFiles(dialogTurn: DialogTurn): string[] {
       const toolItem = item as FlowToolItem;
       
       if (toolItem.toolName === 'CreatePlan' && toolItem.toolResult?.success) {
-        const path = toolItem.toolResult.result?.plan_file_path;
-        if (path) createPlanFiles.add(path);
+        const planPath = toolItem.toolResult.result?.plan_file_path;
+        if (planPath) createPlanFiles.add(planPath);
       }
       
       if (['Edit', 'Write'].includes(toolItem.toolName) && toolItem.toolResult?.success) {

--- a/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.tsx
@@ -18,6 +18,7 @@ import yaml from 'yaml';
 import { Tooltip } from '@/component-library';
 import { createLogger } from '@/shared/utils/logger';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
+import { basenamePath, dirnameAbsolutePath } from '@/shared/utils/pathUtils';
 import './CreatePlanDisplay.scss';
 
 const log = createLogger('PlanDisplay');
@@ -137,10 +138,7 @@ export const PlanDisplay: React.FC<PlanDisplayProps> = ({
     }
 
     const normalizedPlanPath = planFilePath.replace(/\\/g, '/');
-    // Keep original format for FileSystemService.startsWith comparisons.
-    const dirPath = planFilePath.substring(0, planFilePath.lastIndexOf('\\') >= 0 
-      ? planFilePath.lastIndexOf('\\') 
-      : planFilePath.lastIndexOf('/'));
+    const dirPath = dirnameAbsolutePath(planFilePath);
 
     const loadFromFile = async () => {
       // Skip refresh while writing to avoid feedback loops.
@@ -176,6 +174,10 @@ export const PlanDisplay: React.FC<PlanDisplayProps> = ({
     if (!hasAutoLoaded.current) {
       hasAutoLoaded.current = true;
       loadFromFile();
+    }
+
+    if (!dirPath) {
+      return;
     }
 
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -230,16 +232,14 @@ export const PlanDisplay: React.FC<PlanDisplayProps> = ({
   }, [buildStatus, isBuildStarted]);
 
   const planFileName = useMemo(() => {
-    if (!planData?.planFilePath) return '';
-    const parts = planData.planFilePath.replace(/\\/g, '/').split('/');
-    return parts[parts.length - 1] || '';
-  }, [planData]);
+    return basenamePath(planFilePath);
+  }, [planFilePath]);
 
   const handleViewPlan = useCallback(() => {
-    if (planData?.planFilePath) {
-      ideControl.navigation.goToFile(planData.planFilePath);
+    if (planFilePath) {
+      ideControl.navigation.goToFile(planFilePath);
     }
-  }, [planData]);
+  }, [planFilePath]);
 
   const handleBuild = useCallback(async () => {
     if (!planFilePath || buildStatus !== 'build') return;
@@ -474,7 +474,7 @@ export const CreatePlanDisplay: React.FC<ToolCardProps> = ({
     }
     return [];
   }, [isParamsStreaming, partialParams, toolResult, useStreamingInputFallback, toolInput]);
-  
+
   return (
     <PlanDisplay
       planFilePath={planFilePath}

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -43,6 +43,7 @@ import { diffLines } from 'diff';
 import { createLogger } from '@/shared/utils/logger';
 import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
+import { hasNonFileUriScheme } from '@/shared/utils/pathUtils';
 import './FileOperationToolCard.scss';
 
 const log = createLogger('FileOperationToolCard');
@@ -358,7 +359,16 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   };
 
   const handleOpenInCodeEditor = useCallback(async () => {
-    if (!sessionId || !currentFilePath) return;
+    if (!currentFilePath) return;
+
+    if (!sessionId || !currentFilePath || hasNonFileUriScheme(currentFilePath)) {
+      fileTabManager.openFile({
+        filePath: currentFilePath,
+        fileName,
+        mode: 'agent',
+      });
+      return;
+    }
 
     try {
       const { snapshotAPI } = await import('../../infrastructure/api');

--- a/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx
@@ -7,6 +7,7 @@ import { Loader2, Clock, Check } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { ToolCardProps } from '../types/flow-chat';
 import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
+
 export const ReadFileDisplay: React.FC<ToolCardProps> = React.memo(({
   toolItem,
   onOpenInEditor

--- a/src/web-ui/src/infrastructure/api/service-api/SnapshotAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SnapshotAPI.ts
@@ -335,19 +335,6 @@ export class SnapshotAPI {
     }
   }
 
-   
-  async cleanupSnapshotData(maxAgeDays: number = 30, workspacePath?: string): Promise<any> {
-    try {
-      const resolvedWorkspacePath = requireWorkspacePath(workspacePath);
-      return await api.invoke('cleanup_snapshot_data', {
-        request: { maxAgeDays, workspacePath: resolvedWorkspacePath } 
-      });
-    } catch (error) {
-      throw createTauriCommandError('cleanup_snapshot_data', error, { maxAgeDays, workspacePath });
-    }
-  }
-
-   
   async cleanupEmptySessions(): Promise<any> {
     try {
       return await api.invoke('cleanup_empty_sessions', { 

--- a/src/web-ui/src/infrastructure/api/service-api/WorkspaceAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/WorkspaceAPI.ts
@@ -27,6 +27,17 @@ interface FileSearchStreamCallbacks {
   onProgress?: (event: FileSearchProgressEvent) => void;
 }
 
+export interface FileMetadata {
+  path: string;
+  resolvedPath?: string;
+  modified: number;
+  size: number;
+  isFile: boolean;
+  isDir: boolean;
+  isRemote?: boolean;
+  isRuntimeArtifact?: boolean;
+}
+
 function groupSearchResultsByFile(results: FileSearchResult[]): FileSearchResultGroup[] {
   const groups = new Map<string, FileSearchResultGroup>();
 
@@ -242,6 +253,27 @@ export class WorkspaceAPI {
       });
     } catch (error) {
       throw createTauriCommandError('read_file_content', error, { filePath, encoding });
+    }
+  }
+
+  async getFileMetadata(path: string): Promise<FileMetadata> {
+    try {
+      const raw = await api.invoke<Record<string, unknown>>('get_file_metadata', {
+        request: { path }
+      });
+      return {
+        path: String(raw.path ?? path),
+        resolvedPath: typeof raw.resolvedPath === 'string' ? raw.resolvedPath : undefined,
+        modified: Number(raw.modified ?? 0),
+        size: Number(raw.size ?? 0),
+        isFile: raw.isFile === true,
+        isDir: raw.isDir === true,
+        isRemote: typeof raw.isRemote === 'boolean' ? raw.isRemote : undefined,
+        isRuntimeArtifact:
+          typeof raw.isRuntimeArtifact === 'boolean' ? raw.isRuntimeArtifact : undefined,
+      };
+    } catch (error) {
+      throw createTauriCommandError('get_file_metadata', error, { path });
     }
   }
 

--- a/src/web-ui/src/shared/context-system/core/types/ImageContextImpl.tsx
+++ b/src/web-ui/src/shared/context-system/core/types/ImageContextImpl.tsx
@@ -87,7 +87,9 @@ export class ImageContextValidator implements ContextValidator<'image'> {
       if (context.isLocal && context.imagePath) {
         try {
           const exists = await invoke<boolean>('check_path_exists', {
-            path: context.imagePath
+            request: {
+              path: context.imagePath
+            }
           });
           
           if (!exists) {

--- a/src/web-ui/src/shared/utils/fsErrorUtils.ts
+++ b/src/web-ui/src/shared/utils/fsErrorUtils.ts
@@ -14,10 +14,11 @@ export function isLikelyFileNotFoundError(err: unknown): boolean {
   );
 }
 
-/** Metadata from get_file_metadata: missing remote file uses is_file false and is_dir false. */
-export function isFileMissingFromMetadata(fileInfo: Record<string, unknown> | null | undefined): boolean {
+/** Metadata from get_file_metadata uses camelCase fields from desktop commands. */
+export function isFileMissingFromMetadata(fileInfo: unknown): boolean {
   if (!fileInfo || typeof fileInfo !== 'object') {
     return true;
   }
-  return fileInfo.is_file !== true;
+  const metadata = fileInfo as { isFile?: unknown };
+  return metadata.isFile !== true;
 }

--- a/src/web-ui/src/shared/utils/pathUtils.ts
+++ b/src/web-ui/src/shared/utils/pathUtils.ts
@@ -15,8 +15,21 @@ export function normalizeRemoteWorkspacePath(path: string): string {
   return s.replace(/\/+$/, '');
 }
 
+export function hasNonFileUriScheme(path: string): boolean {
+  if (typeof path !== 'string') return false;
+  return /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(path) && !path.startsWith('file://');
+}
+
+export function isBitFunRuntimeUri(path: string): boolean {
+  return typeof path === 'string' && path.startsWith('bitfun://runtime/');
+}
+
 export function normalizePath(path: string): string {
   if (typeof path !== 'string') return path;
+
+  if (hasNonFileUriScheme(path)) {
+    return path;
+  }
   
   
   

--- a/src/web-ui/src/tools/editor/components/CodeEditor.tsx
+++ b/src/web-ui/src/tools/editor/components/CodeEditor.tsx
@@ -1268,6 +1268,11 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
     });
   }, []);
 
+  const fetchFileMetadata = useCallback(async () => {
+    const { workspaceAPI } = await import('@/infrastructure/api');
+    return workspaceAPI.getFileMetadata(filePath);
+  }, [filePath]);
+
   const handleEncodingConfirm = useCallback(async (newEncoding: string) => {
     setEncoding(newEncoding);
     if (!filePath) return;
@@ -1281,8 +1286,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
       hasChangesRef.current = false;
       applyExternalContentToModel(content);
       try {
-        const { invoke } = await import('@tauri-apps/api/core');
-        const fileInfo: any = await invoke('get_file_metadata', { request: { path: filePath } });
+        const fileInfo = await fetchFileMetadata();
         if (isFileMissingFromMetadata(fileInfo)) {
           reportFileMissingFromDisk(true);
         } else {
@@ -1310,7 +1314,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
       }
       log.warn('Failed to reload file with new encoding', err);
     }
-  }, [applyExternalContentToModel, filePath, reportFileMissingFromDisk, updateLargeFileMode]);
+  }, [applyExternalContentToModel, fetchFileMetadata, filePath, reportFileMissingFromDisk, updateLargeFileMode]);
 
   const handleLanguageConfirm = useCallback((languageId: string) => {
     userLanguageOverrideRef.current = true;
@@ -1332,10 +1336,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
       setLoading(false);
       void (async () => {
         try {
-          const { invoke } = await import('@tauri-apps/api/core');
-          const fileInfo: any = await invoke('get_file_metadata', {
-            request: { path: filePath }
-          });
+          const fileInfo = await fetchFileMetadata();
           if (isFileMissingFromMetadata(fileInfo)) {
             reportFileMissingFromDisk(true);
             return;
@@ -1361,15 +1362,12 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
 
     try {
       const { workspaceAPI } = await import('@/infrastructure/api');
-      const { invoke } = await import('@tauri-apps/api/core');
 
       const fileContent = await workspaceAPI.readFileContent(filePath);
       reportFileMissingFromDisk(false);
       let fileSizeBytes: number | undefined;
       try {
-        const fileInfoAfter: any = await invoke('get_file_metadata', {
-          request: { path: filePath }
-        });
+        const fileInfoAfter = await fetchFileMetadata();
         if (isFileMissingFromMetadata(fileInfoAfter)) {
           reportFileMissingFromDisk(true);
         } else {
@@ -1432,7 +1430,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
         isLoadingContentRef.current = false;
       });
     }
-  }, [applyExternalContentToModel, filePath, reportFileMissingFromDisk, t, updateLargeFileMode]);
+  }, [applyExternalContentToModel, fetchFileMetadata, filePath, reportFileMissingFromDisk, t, updateLargeFileMode]);
 
   // Save file content
   const saveFileContent = useCallback(async () => {
@@ -1452,11 +1450,8 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
 
     try {
       const { workspaceAPI } = await import('@/infrastructure/api');
-      const { invoke } = await import('@tauri-apps/api/core');
 
-      const fileInfoPre: any = await invoke('get_file_metadata', {
-        request: { path: filePath }
-      });
+      const fileInfoPre = await fetchFileMetadata();
       if (isFileMissingFromMetadata(fileInfoPre)) {
         reportFileMissingFromDisk(true);
       } else {
@@ -1476,9 +1471,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
         });
         if (!overwrite) {
           const diskContent = await workspaceAPI.readFileContent(filePath);
-          const fileInfoAfter: any = await invoke('get_file_metadata', {
-            request: { path: filePath }
-          });
+          const fileInfoAfter = await fetchFileMetadata();
           const vAfter = diskVersionFromMetadata(fileInfoAfter);
           applyDiskSnapshotToEditor(diskContent, vAfter);
           return;
@@ -1500,9 +1493,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
       onSave?.(currentContent);
 
       try {
-        const fileInfo: any = await invoke('get_file_metadata', {
-          request: { path: filePath }
-        });
+        const fileInfo = await fetchFileMetadata();
         if (!isFileMissingFromMetadata(fileInfo)) {
           reportFileMissingFromDisk(false);
           const v = diskVersionFromMetadata(fileInfo);
@@ -1522,7 +1513,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
     } finally {
       setSaving(false);
     }
-  }, [filePath, workspacePath, onSave, reportFileMissingFromDisk, t, applyDiskSnapshotToEditor]);
+  }, [applyDiskSnapshotToEditor, fetchFileMetadata, filePath, onSave, reportFileMissingFromDisk, t, workspacePath]);
   
   useEffect(() => {
     saveFileContentRef.current = saveFileContent;
@@ -1586,9 +1577,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
       }
 
       const { invoke } = await import('@tauri-apps/api/core');
-      const fileInfo: any = await invoke('get_file_metadata', {
-        request: { path: filePath }
-      });
+      const fileInfo = await fetchFileMetadata();
       if (isFileMissingFromMetadata(fileInfo)) {
         outcome = 'missing-on-disk';
         reportFileMissingFromDisk(true);
@@ -1714,7 +1703,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
       }
       isCheckingFileRef.current = false;
     }
-  }, [applyDiskSnapshotToEditor, filePath, isActiveTab, reportFileMissingFromDisk, t]);
+  }, [applyDiskSnapshotToEditor, fetchFileMetadata, filePath, isActiveTab, reportFileMissingFromDisk, t]);
 
   // Initial file load - only run once when filePath changes
   const loadFileContentCalledRef = useRef(false);
@@ -1948,9 +1937,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
             const editorHash = await editorSyncContentSha256Hex(editorMid);
             if (editorHash === diskHash) {
               try {
-                const fileInfo: any = await invoke('get_file_metadata', {
-                  request: { path: filePath },
-                });
+                const fileInfo = await fetchFileMetadata();
                 const v = diskVersionFromMetadata(fileInfo);
                 if (v) {
                   diskVersionRef.current = v;
@@ -1982,9 +1969,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
           diskContentMatchesEditorForExternalSync(diskContent, editorBuffer)
         ) {
           try {
-            const fileInfo: any = await invoke('get_file_metadata', {
-              request: { path: filePath },
-            });
+            const fileInfo = await fetchFileMetadata();
             const v = diskVersionFromMetadata(fileInfo);
             if (v) {
               diskVersionRef.current = v;
@@ -2006,9 +1991,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
           });
           if (!shouldReload) {
             try {
-              const fileInfo: any = await invoke('get_file_metadata', {
-                request: { path: filePath }
-              });
+              const fileInfo = await fetchFileMetadata();
               const v = diskVersionFromMetadata(fileInfo);
               if (v) {
                 diskVersionRef.current = v;
@@ -2020,9 +2003,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
           }
         }
 
-        const fileInfo: any = await invoke('get_file_metadata', {
-          request: { path: filePath }
-        });
+        const fileInfo = await fetchFileMetadata();
         const ver = diskVersionFromMetadata(fileInfo);
         const currentPosition = editor?.getPosition() ?? null;
         applyDiskSnapshotToEditor(diskContent, ver, { restoreCursor: currentPosition });
@@ -2042,7 +2023,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
     return () => {
       unsubscribers.forEach(unsub => unsub());
     };
-  }, [applyDiskSnapshotToEditor, monacoReady, filePath, t, workspacePath]);
+  }, [applyDiskSnapshotToEditor, fetchFileMetadata, monacoReady, filePath, t, workspacePath]);
 
   useEffect(() => {
     userLanguageOverrideRef.current = false;

--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.tsx
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.tsx
@@ -167,6 +167,14 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     setUnsafeViewMode('source');
   }, [filePath, initialContent]);
 
+  const fetchFileMetadata = useCallback(async () => {
+    if (!filePath) {
+      throw new Error('Missing file path');
+    }
+    const { workspaceAPI } = await import('@/infrastructure/api');
+    return workspaceAPI.getFileMetadata(filePath);
+  }, [filePath]);
+
   const loadFileContent = useCallback(async () => {
     if (!filePath || isUnmountedRef.current) return;
 
@@ -175,15 +183,12 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
 
     try {
       const { workspaceAPI } = await import('@/infrastructure/api');
-      const { invoke } = await import('@tauri-apps/api/core');
 
       const fileContent = await workspaceAPI.readFileContent(filePath);
       reportFileMissingFromDisk(false);
 
       try {
-        const fileInfo: any = await invoke('get_file_metadata', {
-          request: { path: filePath },
-        });
+        const fileInfo = await fetchFileMetadata();
         if (isFileMissingFromMetadata(fileInfo)) {
           reportFileMissingFromDisk(true);
         } else {
@@ -234,7 +239,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         setLoading(false);
       }
     }
-  }, [filePath, reportFileMissingFromDisk, t, toNormalizedMarkdown]);
+  }, [fetchFileMetadata, filePath, reportFileMissingFromDisk, t, toNormalizedMarkdown]);
 
   // Initial file load - only run once when filePath changes
   const loadFileContentCalledRef = useRef(false);
@@ -283,10 +288,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     let probeError: string | null = null;
     try {
       const { workspaceAPI } = await import('@/infrastructure/api');
-      const { invoke } = await import('@tauri-apps/api/core');
-      const fileInfo: any = await invoke('get_file_metadata', {
-        request: { path: filePath },
-      });
+      const fileInfo = await fetchFileMetadata();
       if (isFileMissingFromMetadata(fileInfo)) {
         outcome = 'missing-on-disk';
         reportFileMissingFromDisk(true);
@@ -352,9 +354,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         reportFileMissingFromDisk(false);
       }
 
-      const fileInfoAfter: any = await invoke('get_file_metadata', {
-        request: { path: filePath },
-      });
+      const fileInfoAfter = await fetchFileMetadata();
       if (!isFileMissingFromMetadata(fileInfoAfter)) {
         const vAfter = diskVersionFromMetadata(fileInfoAfter);
         if (vAfter) {
@@ -388,7 +388,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       }
       isCheckingDiskRef.current = false;
     }
-  }, [filePath, isActiveTab, reportFileMissingFromDisk, t, toNormalizedMarkdown]);
+  }, [fetchFileMetadata, filePath, isActiveTab, reportFileMissingFromDisk, t, toNormalizedMarkdown]);
 
   const isUnsafeSplitUi =
     !!filePath &&
@@ -426,11 +426,8 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     try {
       if (filePath && workspacePath) {
         const { workspaceAPI } = await import('@/infrastructure/api');
-        const { invoke } = await import('@tauri-apps/api/core');
 
-        const fileInfoPre: any = await invoke('get_file_metadata', {
-          request: { path: filePath },
-        });
+        const fileInfoPre = await fetchFileMetadata();
         if (isFileMissingFromMetadata(fileInfoPre)) {
           reportFileMissingFromDisk(true);
         } else {
@@ -465,9 +462,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               reportFileMissingFromDisk(false);
             }
             try {
-              const fileInfoAfter: any = await invoke('get_file_metadata', {
-                request: { path: filePath },
-              });
+              const fileInfoAfter = await fetchFileMetadata();
               if (!isFileMissingFromMetadata(fileInfoAfter)) {
                 const v = diskVersionFromMetadata(fileInfoAfter);
                 if (v) {
@@ -484,9 +479,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         await workspaceAPI.writeFileContent(workspacePath, filePath, content);
 
         try {
-          const fileInfo: any = await invoke('get_file_metadata', {
-            request: { path: filePath },
-          });
+          const fileInfo = await fetchFileMetadata();
           if (!isFileMissingFromMetadata(fileInfo)) {
             reportFileMissingFromDisk(false);
             const v = diskVersionFromMetadata(fileInfo);
@@ -520,7 +513,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         setError(t('editor.common.saveFailedWithMessage', { message: errorMessage }));
       }
     }
-  }, [content, filePath, workspacePath, hasChanges, onSave, reportFileMissingFromDisk, t, toNormalizedMarkdown]);
+  }, [content, fetchFileMetadata, filePath, hasChanges, onSave, reportFileMissingFromDisk, t, toNormalizedMarkdown, workspacePath]);
 
   const handleContentChange = useCallback((newContent: string) => {
     contentRef.current = newContent;

--- a/src/web-ui/src/tools/editor/components/PlanViewer.tsx
+++ b/src/web-ui/src/tools/editor/components/PlanViewer.tsx
@@ -14,6 +14,7 @@ import { flowChatManager } from '@/flow_chat/services/FlowChatManager';
 import { fileSystemService } from '@/tools/file-system/services/FileSystemService';
 import { planBuildStateService } from '@/shared/services/PlanBuildStateService';
 import { globalEventBus } from '@/infrastructure/event-bus';
+import { basenamePath, dirnameAbsolutePath } from '@/shared/utils/pathUtils';
 import './PlanViewer.scss';
 
 const log = createLogger('PlanViewer');
@@ -102,9 +103,7 @@ const PlanViewer: React.FC<PlanViewerProps> = ({
 
   const displayFileName = useMemo(() => {
     if (fileName) return fileName;
-    if (!filePath) return '';
-    const parts = filePath.replace(/\\/g, '/').split('/');
-    return parts[parts.length - 1] || '';
+    return basenamePath(filePath);
   }, [filePath, fileName]);
 
   const hasTodos = !!(planData?.todos && planData.todos.length > 0);
@@ -188,9 +187,11 @@ const PlanViewer: React.FC<PlanViewerProps> = ({
     if (!filePath) return;
 
     const normalizedPlanPath = filePath.replace(/\\/g, '/');
-    const dirPath = filePath.substring(0, filePath.lastIndexOf('\\') >= 0 
-      ? filePath.lastIndexOf('\\') 
-      : filePath.lastIndexOf('/'));
+    const dirPath = dirnameAbsolutePath(filePath);
+
+    if (!dirPath) {
+      return;
+    }
 
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 

--- a/src/web-ui/src/tools/file-system/services/FileSystemService.ts
+++ b/src/web-ui/src/tools/file-system/services/FileSystemService.ts
@@ -2,6 +2,7 @@ import { FileSystemNode, FileSystemOptions, IFileSystemService, FileSystemChange
 import { workspaceAPI } from '@/infrastructure/api';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { createLogger } from '@/shared/utils/logger';
+import { normalizePath } from '@/shared/utils/pathUtils';
 
 const log = createLogger('FileSystemService');
 
@@ -82,22 +83,47 @@ class FileSystemService implements IFileSystemService {
     let unlisten: UnlistenFn | null = null;
     let isActive = true;
 
-    // Normalize separators and trailing slash for robust cross-platform comparison.
-    // Case is preserved intentionally: paths are case-sensitive.
     const normalizeForCompare = (p: string) =>
-      p.replace(/\\/g, '/').replace(/\/+$/, '');
+      normalizePath(p).replace(/\\/g, '/').replace(/\/+$/, '');
 
-    const normalizedRoot = normalizeForCompare(rootPath);
+    const logicalRoot = normalizeForCompare(rootPath);
 
     const initWatcher = async () => {
       try {
+        let resolvedRoot = logicalRoot;
+        try {
+          const metadata = await workspaceAPI.getFileMetadata(rootPath);
+          if (!isActive) return;
+          if (typeof metadata.resolvedPath === 'string' && metadata.resolvedPath.trim()) {
+            resolvedRoot = normalizeForCompare(metadata.resolvedPath);
+          }
+        } catch (error) {
+          log.debug('Falling back to watch root without metadata resolution', {
+            rootPath,
+            error,
+          });
+        }
+
+        const toLogicalPath = (path: string | undefined) => {
+          if (!path) return path;
+          const normalizedPath = normalizeForCompare(path);
+          if (normalizedPath === resolvedRoot) {
+            return logicalRoot;
+          }
+          if (normalizedPath.startsWith(`${resolvedRoot}/`)) {
+            const suffix = normalizedPath.slice(resolvedRoot.length).replace(/^\/+/, '');
+            return suffix ? `${logicalRoot}/${suffix}` : logicalRoot;
+          }
+          return normalizePath(path);
+        };
+
         unlisten = await listen<FileWatchEvent[]>('file-system-changed', (event) => {
           if (!isActive) return;
 
           const events = event.payload;
 
           const isUnderRoot = (absPath: string) =>
-            absPath === normalizedRoot || absPath.startsWith(`${normalizedRoot}/`);
+            absPath === resolvedRoot || absPath.startsWith(`${resolvedRoot}/`);
 
           events.forEach((fileEvent) => {
             const normalizedEventPath = normalizeForCompare(fileEvent.path);
@@ -115,8 +141,8 @@ class FileSystemService implements IFileSystemService {
 
             const fsEvent: FileSystemChangeEvent = {
               type: this.mapEventKind(fileEvent.kind),
-              path: fileEvent.path,
-              oldPath: fileEvent.from,
+              path: toLogicalPath(fileEvent.path) ?? fileEvent.path,
+              oldPath: toLogicalPath(fileEvent.from),
               timestamp: new Date(fileEvent.timestamp * 1000)
             };
 


### PR DESCRIPTION
- introduce a dedicated workspace runtime service to centralize runtime layout initialization and verification
- migrate legacy runtime data from the project-local `.bitfun` directory into the managed runtime root
- unify local, remote, and runtime artifact path resolution in the desktop API layer
- update workspace and file APIs to expose runtime-aware metadata and filesystem operations
- align frontend and related core services with the new runtime directory structure
