### PR TITLE
feat(web-ui): new session dialog, session history tool card, header cleanup

### DIFF
--- a/src/web-ui/src/app/components/SessionCapsule/NewSessionDialog.scss
+++ b/src/web-ui/src/app/components/SessionCapsule/NewSessionDialog.scss
@@ -1,0 +1,133 @@
+/**
+ * New session dialog — tall vertical “magazine” card: masthead, numbered sections, accent rule.
+ */
+
+@use '../../../component-library/styles/tokens.scss' as *;
+
+// Taller content area inside Modal (narrow width + generous height).
+// Do not use modal__content--fill-flex here — it sets overflow:hidden and blocks scroll on short viewports.
+.new-session-dialog__modal-surface {
+  display: flex;
+  flex-direction: column;
+  min-height: min(580px, 78vh);
+  overflow-x: hidden;
+  overflow-y: auto;
+  // Space below modal title bar — text was flush against header border
+  padding-top: $size-gap-5;
+  padding-bottom: $size-gap-2;
+}
+
+.new-session-dialog {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-height: min(560px, 76vh);
+  padding-block: 0 2px;
+}
+
+// ── Masthead (intro line; full content width — no narrow measure) ──
+.new-session-dialog__masthead {
+  flex-shrink: 0;
+  padding-bottom: 18px;
+}
+
+.new-session-dialog__lede {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: 1.65;
+  letter-spacing: 0.01em;
+  color: var(--color-text-secondary);
+  max-width: none;
+  width: 100%;
+}
+
+// ── Editorial “page” card ───────────────────────────────
+.new-session-dialog__card {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 28px;
+  min-height: 0;
+  padding: 28px 22px 30px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: var(--color-bg-elevated, var(--color-bg-primary));
+  box-shadow: none;
+}
+
+.new-session-dialog__section {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.new-session-dialog__section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.new-session-dialog__index {
+  flex-shrink: 0;
+  font-family: ui-monospace, 'Cascadia Code', 'SF Mono', Consolas, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+
+.new-session-dialog__section-title {
+  margin: 0;
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.25;
+  color: var(--color-text-primary);
+}
+
+.new-session-dialog__control {
+  min-width: 0;
+}
+
+.new-session-dialog__divider {
+  flex-shrink: 0;
+  height: 1px;
+  margin: 2px 0;
+  background: var(--border-subtle);
+  opacity: 1;
+}
+
+.new-session-dialog__browse {
+  margin-top: 14px;
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+// ── Footer ─────────────────────────────────────────────
+.new-session-dialog__actions {
+  flex-shrink: 0;
+  margin-top: auto;
+  padding-top: 20px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: $size-gap-2;
+}
+
+@media (max-height: 560px) {
+  .new-session-dialog__modal-surface {
+    min-height: min(480px, 85vh);
+  }
+
+  .new-session-dialog__card {
+    padding-block: 20px;
+    gap: 22px;
+  }
+}
+

--- a/src/web-ui/src/app/components/SessionCapsule/NewSessionDialog.tsx
+++ b/src/web-ui/src/app/components/SessionCapsule/NewSessionDialog.tsx
@@ -1,0 +1,321 @@
+/**
+ * Dialog to create a chat session with explicit agent mode and workspace.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { FolderOpen } from 'lucide-react';
+import { open } from '@tauri-apps/plugin-dialog';
+import { Modal, Select, Button } from '@/component-library';
+import { useI18n } from '@/infrastructure/i18n';
+import {
+  getWorkspaceDisplayName,
+  useWorkspaceContext,
+} from '@/infrastructure/contexts/WorkspaceContext';
+import { flowChatManager } from '@/flow_chat/services/FlowChatManager';
+import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
+import { findReusableEmptySessionId } from '@/app/utils/projectSessionWorkspace';
+import { openMainSession } from '@/flow_chat/services/openBtwSession';
+import { useSessionModeStore } from '@/app/stores/sessionModeStore';
+import { isRemoteWorkspace, type WorkspaceInfo } from '@/shared/types';
+import { notificationService } from '@/shared/notification-system';
+import { createLogger } from '@/shared/utils/logger';
+import './NewSessionDialog.scss';
+
+const log = createLogger('NewSessionDialog');
+
+const LS_AGENT = 'bitfun.newSessionDialog.agent';
+const LS_WORKSPACE = 'bitfun.newSessionDialog.workspaceId';
+
+export type NewSessionAgentChoice = 'agentic' | 'Cowork' | 'Claw';
+
+export interface NewSessionDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function sessionModeToChoice(mode: string | undefined): NewSessionAgentChoice {
+  if (!mode || mode === 'Dispatcher') return 'agentic';
+  const m = mode.toLowerCase();
+  if (m === 'cowork') return 'Cowork';
+  if (m === 'claw') return 'Claw';
+  return 'agentic';
+}
+
+function pickDefaultWorkspaceId(
+  opened: WorkspaceInfo[],
+  recent: WorkspaceInfo[],
+  current: WorkspaceInfo | null,
+  storedId: string | null
+): string | null {
+  if (storedId && opened.some(w => w.id === storedId)) {
+    return storedId;
+  }
+  for (const r of recent) {
+    if (opened.some(w => w.id === r.id)) {
+      return r.id;
+    }
+  }
+  if (current && opened.some(w => w.id === current.id)) {
+    return current.id;
+  }
+  return opened[0]?.id ?? null;
+}
+
+export const NewSessionDialog: React.FC<NewSessionDialogProps> = ({ open: isOpen, onClose }) => {
+  const { t } = useI18n('common');
+  const {
+    openedWorkspacesList,
+    recentWorkspaces,
+    currentWorkspace,
+    setActiveWorkspace,
+    openWorkspace,
+  } = useWorkspaceContext();
+
+  const [agentChoice, setAgentChoice] = useState<NewSessionAgentChoice>('agentic');
+  const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const resetDefaults = useCallback(() => {
+    let storedAgent: NewSessionAgentChoice | null = null;
+    let storedWs: string | null = null;
+    try {
+      const a = localStorage.getItem(LS_AGENT) as NewSessionAgentChoice | null;
+      if (a === 'agentic' || a === 'Cowork' || a === 'Claw') {
+        storedAgent = a;
+      }
+      const w = localStorage.getItem(LS_WORKSPACE);
+      if (w) storedWs = w;
+    } catch {
+      /* ignore */
+    }
+
+    const activeId = flowChatStore.getState().activeSessionId;
+    const active = activeId ? flowChatStore.getState().sessions.get(activeId) : undefined;
+    const fromSession = sessionModeToChoice(active?.mode);
+
+    setAgentChoice(storedAgent ?? fromSession);
+    setWorkspaceId(
+      pickDefaultWorkspaceId(openedWorkspacesList, recentWorkspaces, currentWorkspace, storedWs)
+    );
+  }, [openedWorkspacesList, recentWorkspaces, currentWorkspace]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    resetDefaults();
+  }, [isOpen, resetDefaults]);
+
+  const workspaceOptions = useMemo(() => {
+    const recentOrder = new Map(recentWorkspaces.map((w, i) => [w.id, i]));
+    const sorted = [...openedWorkspacesList].sort((a, b) => {
+      const ra = recentOrder.has(a.id) ? (recentOrder.get(a.id) as number) : 9999;
+      const rb = recentOrder.has(b.id) ? (recentOrder.get(b.id) as number) : 9999;
+      if (ra !== rb) return ra - rb;
+      return getWorkspaceDisplayName(a).localeCompare(getWorkspaceDisplayName(b));
+    });
+    return sorted.map(w => ({
+      label: getWorkspaceDisplayName(w),
+      value: w.id,
+    }));
+  }, [openedWorkspacesList, recentWorkspaces]);
+
+  const agentOptions = useMemo(
+    () => [
+      {
+        value: 'agentic',
+        label: t('nav.sessions.modeCode'),
+      },
+      {
+        value: 'Cowork',
+        label: t('nav.sessions.modeCowork'),
+      },
+      {
+        value: 'Claw',
+        label: t('nav.sessions.newClawSession'),
+      },
+    ],
+    [t]
+  );
+
+  const handleBrowse = useCallback(async () => {
+    try {
+      const selected = await open({
+        directory: true,
+        multiple: false,
+        title: t('header.selectProjectDirectory'),
+      });
+      if (selected && typeof selected === 'string') {
+        const ws = await openWorkspace(selected);
+        setWorkspaceId(ws.id);
+      }
+    } catch (e) {
+      log.error('Browse workspace failed', e);
+      notificationService.error(
+        e instanceof Error ? e.message : t('nav.workspaces.createSessionFailed'),
+        { duration: 3000 }
+      );
+    }
+  }, [openWorkspace, t]);
+
+  const handleConfirm = useCallback(async () => {
+    const workspace = openedWorkspacesList.find(w => w.id === workspaceId);
+    if (!workspace) {
+      notificationService.error(t('nav.sessionCapsule.workspaceMissing'), { duration: 4000 });
+      return;
+    }
+
+    const resolvedMode =
+      agentChoice === 'agentic'
+        ? 'agentic'
+        : agentChoice === 'Cowork'
+          ? 'Cowork'
+          : 'Claw';
+
+    setSubmitting(true);
+    try {
+      if (resolvedMode === 'Cowork') {
+        useSessionModeStore.getState().setMode('cowork');
+      } else {
+        useSessionModeStore.getState().setMode('code');
+      }
+
+      const reusableId = findReusableEmptySessionId(workspace, resolvedMode);
+      if (reusableId) {
+        await openMainSession(reusableId, {
+          workspaceId: workspace.id,
+          activateWorkspace: setActiveWorkspace,
+        });
+      } else {
+        await flowChatManager.createChatSession(
+          {
+            workspacePath: workspace.rootPath,
+            ...(isRemoteWorkspace(workspace) && workspace.connectionId
+              ? { remoteConnectionId: workspace.connectionId }
+              : {}),
+            ...(isRemoteWorkspace(workspace) && workspace.sshHost
+              ? { remoteSshHost: workspace.sshHost }
+              : {}),
+          },
+          resolvedMode
+        );
+        await setActiveWorkspace(workspace.id);
+      }
+
+      try {
+        localStorage.setItem(LS_AGENT, agentChoice);
+        localStorage.setItem(LS_WORKSPACE, workspace.id);
+      } catch {
+        /* ignore */
+      }
+
+      onClose();
+    } catch (e) {
+      log.error('Create session from dialog failed', e);
+      notificationService.error(
+        e instanceof Error ? e.message : t('nav.workspaces.createSessionFailed'),
+        { duration: 4000 }
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    agentChoice,
+    onClose,
+    openedWorkspacesList,
+    setActiveWorkspace,
+    t,
+    workspaceId,
+  ]);
+
+  const noWorkspaces = openedWorkspacesList.length === 0;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('nav.sessionCapsule.newSessionDialogTitle')}
+      size="medium"
+      contentInset
+      contentClassName="new-session-dialog__modal-surface"
+      showCloseButton
+    >
+      <div className="new-session-dialog">
+        <header className="new-session-dialog__masthead">
+          <p className="new-session-dialog__lede">{t('nav.sessionCapsule.newSessionLede')}</p>
+        </header>
+
+        <div className="new-session-dialog__card">
+          <section className="new-session-dialog__section" aria-labelledby="new-session-agent-heading">
+            <div className="new-session-dialog__section-head">
+              <span className="new-session-dialog__index" aria-hidden>
+                01
+              </span>
+              <h2 className="new-session-dialog__section-title" id="new-session-agent-heading">
+                {t('nav.sessionCapsule.newSessionSectionAgent')}
+              </h2>
+            </div>
+            <div className="new-session-dialog__control">
+              <Select
+                size="medium"
+                options={agentOptions}
+                value={agentChoice}
+                onChange={v => setAgentChoice(v as NewSessionAgentChoice)}
+                searchable={false}
+              />
+            </div>
+          </section>
+
+          <div className="new-session-dialog__divider" role="presentation" />
+
+          <section className="new-session-dialog__section" aria-labelledby="new-session-ws-heading">
+            <div className="new-session-dialog__section-head">
+              <span className="new-session-dialog__index" aria-hidden>
+                02
+              </span>
+              <h2 className="new-session-dialog__section-title" id="new-session-ws-heading">
+                {t('nav.sessionCapsule.newSessionSectionWorkspace')}
+              </h2>
+            </div>
+            <div className="new-session-dialog__control">
+              <Select
+                size="medium"
+                options={workspaceOptions}
+                value={workspaceId ?? ''}
+                onChange={v => setWorkspaceId(String(v))}
+                placeholder={t('nav.sessionCapsule.workspacePlaceholder')}
+                disabled={noWorkspaces}
+                searchable
+                emptyText={t('nav.sessionCapsule.noOpenWorkspace')}
+              />
+            </div>
+            <Button
+              type="button"
+              variant="dashed"
+              size="medium"
+              className="new-session-dialog__browse"
+              onClick={() => void handleBrowse()}
+            >
+              <FolderOpen size={16} aria-hidden />
+              {t('nav.sessionCapsule.browseWorkspace')}
+            </Button>
+          </section>
+        </div>
+
+        <footer className="new-session-dialog__actions">
+          <Button type="button" variant="ghost" size="medium" onClick={onClose} disabled={submitting}>
+            {t('nav.sessions.cancelEdit')}
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="medium"
+            isLoading={submitting}
+            onClick={() => void handleConfirm()}
+            disabled={!workspaceId || noWorkspaces}
+          >
+            {t('nav.sessionCapsule.confirmCreate')}
+          </Button>
+        </footer>
+      </div>
+    </Modal>
+  );
+};

--- a/src/web-ui/src/app/components/SessionCapsule/SessionCapsule.scss
+++ b/src/web-ui/src/app/components/SessionCapsule/SessionCapsule.scss
@@ -485,6 +485,7 @@ $session-capsule-inline-pad: $size-gap-3;
 .session-capsule__footer {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: $size-gap-1;
   padding: $size-gap-1 $session-capsule-inline-pad;
   flex-shrink: 0;

--- a/src/web-ui/src/app/components/SessionCapsule/SessionCapsule.tsx
+++ b/src/web-ui/src/app/components/SessionCapsule/SessionCapsule.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Code2, ListChecks, LayoutList, ListTodo, Pin, Sparkles } from 'lucide-react';
+import { Code2, ListChecks, LayoutList, ListTodo, Pin, Plus, Sparkles } from 'lucide-react';
 import { Search, Tooltip } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
@@ -37,6 +37,7 @@ import { useAgentCanvasStore } from '@/app/components/panels/content-canvas/stor
 import { createLogger } from '@/shared/utils/logger';
 import { useOverlayStore } from '../../stores/overlayStore';
 import SessionsSection from '../NavPanel/sections/sessions/SessionsSection';
+import { NewSessionDialog } from './NewSessionDialog';
 import './SessionCapsule.scss';
 
 const log = createLogger('SessionCapsule');
@@ -99,6 +100,7 @@ const SessionCapsule: React.FC = () => {
   const [expanded, setExpanded] = useState<boolean>(readExpandedFromStorage);
   const [pinned, setPinned] = useState<boolean>(readPinnedFromStorage);
   const [listFilterQuery, setListFilterQuery] = useState('');
+  const [newSessionDialogOpen, setNewSessionDialogOpen] = useState(false);
   const [flowChatState, setFlowChatState] = useState<FlowChatState>(() => flowChatStore.getState());
   const [runningSessionIds, setRunningSessionIds] = useState<Set<string>>(() => new Set());
   const panelRef = useRef<HTMLDivElement>(null);
@@ -239,6 +241,7 @@ const SessionCapsule: React.FC = () => {
       if (panelRef.current?.contains(target)) return;
       const root = target instanceof Element ? target : target.parentElement;
       if (root?.closest?.('[data-bitfun-ignore-session-capsule-outside]')) return;
+      if (root?.closest?.('.modal-overlay')) return;
       setExpanded(false);
       writeExpandedToStorage(false);
     };
@@ -292,8 +295,18 @@ const SessionCapsule: React.FC = () => {
             <SessionsSection listAllSessions listFilterQuery={listFilterQuery} />
           </div>
 
-          {/* 底部工具栏：详情 + 固定展开 */}
+          {/* 底部：新建会话 + 详情 + 固定展开 */}
           <div className="session-capsule__footer">
+            <Tooltip content={t('nav.sessionCapsule.newSessionButton')} placement="top">
+              <button
+                type="button"
+                className="session-capsule__icon-btn"
+                onClick={() => setNewSessionDialogOpen(true)}
+                aria-label={t('nav.sessionCapsule.newSessionButton')}
+              >
+                <Plus size={13} strokeWidth={2.25} />
+              </button>
+            </Tooltip>
             <Tooltip content={t('nav.sessionCapsule.viewDetails')} placement="top">
               <button
                 type="button"
@@ -318,6 +331,7 @@ const SessionCapsule: React.FC = () => {
               </button>
             </Tooltip>
           </div>
+          <NewSessionDialog open={newSessionDialogOpen} onClose={() => setNewSessionDialogOpen(false)} />
         </>
       ) : runningSessionsOrdered.length > 0 ? (
         /* ── Running sessions card — wider panel showing each active task ── */

--- a/src/web-ui/src/flow_chat/components/FlowToolCard.tsx
+++ b/src/web-ui/src/flow_chat/components/FlowToolCard.tsx
@@ -80,6 +80,7 @@ export const FlowToolCard: React.FC<FlowToolCardProps> = React.memo(({
   
   return (
     prevProps.toolItem.id === nextProps.toolItem.id &&
+    prevProps.toolItem.toolName === nextProps.toolItem.toolName &&
     prevProps.toolItem.status === nextProps.toolItem.status &&
     prevProps.toolItem.terminalSessionId === nextProps.toolItem.terminalSessionId &&
     prevProps.toolItem.userConfirmed === nextProps.toolItem.userConfirmed &&

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.scss
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.scss
@@ -35,12 +35,6 @@
     }
   }
 
-  &__turn-steppers {
-    display: flex;
-    align-items: center;
-    gap: 0;
-  }
-
   &__turn-nav {
     position: relative;
     display: flex;

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
@@ -1,5 +1,5 @@
 /**
- * FlowChat header — turn navigation, search and BTW back controls.
+ * FlowChat header — message search (when turn list is collapsed), turn list toggle, BTW back.
  *
  * The session title and the "return to Agentic OS" button have been moved to
  * UnifiedTopBar so the whole application shares a single top chrome.
@@ -8,7 +8,7 @@
 
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { ChevronDown, ChevronUp, CornerUpLeft, List, Search, X } from 'lucide-react';
-import { Tooltip, IconButton, Input } from '@/component-library';
+import { IconButton, Input } from '@/component-library';
 import { useTranslation } from 'react-i18next';
 import { globalEventBus } from '@/infrastructure/event-bus';
 import { SessionFilesBadge } from './SessionFilesBadge';
@@ -23,12 +23,6 @@ export interface FlowChatHeaderTurnSummary {
 }
 
 export interface FlowChatHeaderProps {
-  /** Current turn index. */
-  currentTurn: number;
-  /** Total turns. */
-  totalTurns: number;
-  /** Current user message (kept for turn list tooltip). */
-  currentUserMessage: string;
   /** Whether the header is visible. */
   visible: boolean;
   /** Session ID. */
@@ -39,12 +33,8 @@ export interface FlowChatHeaderProps {
   btwParentTitle?: string;
   /** Ordered turn summaries used by header navigation. */
   turns?: FlowChatHeaderTurnSummary[];
-  /** Jump to a specific turn. */
+  /** Jump to a specific turn (used by turn list sidebar). */
   onJumpToTurn?: (turnId: string) => void;
-  /** Jump to the previous turn. */
-  onJumpToPreviousTurn?: () => void;
-  /** Jump to the next turn. */
-  onJumpToNextTurn?: () => void;
 
   // ========== Search ==========
   /** Current search query string. */
@@ -70,17 +60,12 @@ export interface FlowChatHeaderProps {
   onTurnListOpenChange?: (open: boolean) => void;
 }
 export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
-  currentTurn,
-  totalTurns,
-  currentUserMessage: _currentUserMessage,
   visible,
   sessionId,
   btwOrigin,
   btwParentTitle = '',
   turns = [],
   onJumpToTurn,
-  onJumpToPreviousTurn,
-  onJumpToNextTurn,
   searchQuery = '',
   onSearchChange,
   searchMatchCount = 0,
@@ -110,31 +95,37 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
   const turnListTooltip = t('flowChatHeader.turnList', {
     defaultValue: 'Turn list',
   });
-  const previousTurnDisabled = currentTurn <= 1;
-  const nextTurnDisabled = currentTurn <= 0 || currentTurn >= totalTurns;
   const hasTurnNavigation = turns.length > 0 && !!onJumpToTurn;
+
+  // When collapsing the turn list with an active query, reopen the header search bar.
+  const prevTurnListOpenRef = useRef(turnListOpen);
+  useEffect(() => {
+    if (prevTurnListOpenRef.current && !turnListOpen && searchQuery.trim().length > 0) {
+      setIsSearchOpen(true);
+    }
+    prevTurnListOpenRef.current = turnListOpen;
+  }, [turnListOpen, searchQuery]);
 
   // Sync open state from parent (e.g. Ctrl+F shortcut).
   // Using a counter so every new request opens the bar, even after a prior close.
   const prevSearchOpenRequestRef = useRef(0);
   useEffect(() => {
+    if (turnListOpen) return;
     if (searchOpenRequest > 0 && searchOpenRequest !== prevSearchOpenRequestRef.current) {
       prevSearchOpenRequestRef.current = searchOpenRequest;
       setIsSearchOpen(true);
     }
-  }, [searchOpenRequest]);
+  }, [searchOpenRequest, turnListOpen]);
 
-  // Focus the search input whenever it opens.
+  // Focus the search input whenever it opens (header search is hidden while turn list is open).
   useEffect(() => {
-    if (isSearchOpen) {
-      const frameId = requestAnimationFrame(() => {
-        searchInputRef.current?.focus();
-        searchInputRef.current?.select();
-      });
-      return () => cancelAnimationFrame(frameId);
-    }
-    return undefined;
-  }, [isSearchOpen]);
+    if (turnListOpen || !isSearchOpen) return undefined;
+    const frameId = requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    });
+    return () => cancelAnimationFrame(frameId);
+  }, [isSearchOpen, turnListOpen]);
 
   const handleOpenSearch = useCallback(() => {
     setIsSearchOpen(true);
@@ -193,7 +184,7 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
       </div>
 
       <div className="flowchat-header__actions">
-        {isSearchOpen ? (
+        {!turnListOpen && isSearchOpen ? (
           <div className="flowchat-header__search" role="search" data-testid="flowchat-header-search-bar">
             <Input
               ref={searchInputRef}
@@ -251,7 +242,7 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
             </IconButton>
           </div>
         ) : null}
-        {!isSearchOpen && (
+        {!turnListOpen && !isSearchOpen && (
           <IconButton
             className="flowchat-header__search-btn"
             variant="ghost"
@@ -263,34 +254,6 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
           >
             <Search size={14} />
           </IconButton>
-        )}
-        {!isSearchOpen && (
-          <div className="flowchat-header__turn-steppers">
-            <IconButton
-              className="flowchat-header__turn-nav-button"
-              variant="ghost"
-              size="xs"
-              onClick={onJumpToPreviousTurn}
-              tooltip={t('flowChatHeader.previousTurn', { defaultValue: 'Previous turn' })}
-              disabled={previousTurnDisabled || !onJumpToPreviousTurn}
-              aria-label={t('flowChatHeader.previousTurn', { defaultValue: 'Previous turn' })}
-              data-testid="flowchat-header-turn-prev"
-            >
-              <ChevronUp size={14} />
-            </IconButton>
-            <IconButton
-              className="flowchat-header__turn-nav-button"
-              variant="ghost"
-              size="xs"
-              onClick={onJumpToNextTurn}
-              tooltip={t('flowChatHeader.nextTurn', { defaultValue: 'Next turn' })}
-              disabled={nextTurnDisabled || !onJumpToNextTurn}
-              aria-label={t('flowChatHeader.nextTurn', { defaultValue: 'Next turn' })}
-              data-testid="flowchat-header-turn-next"
-            >
-              <ChevronDown size={14} />
-            </IconButton>
-          </div>
         )}
         {!!btwOrigin?.parentSessionId && (
           <IconButton
@@ -306,24 +269,22 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
             <CornerUpLeft size={12} />
           </IconButton>
         )}
-        {!isSearchOpen && (
-          <div className="flowchat-header__turn-nav">
-            <IconButton
-              className={`flowchat-header__turn-nav-button${turnListOpen ? ' flowchat-header__turn-nav-button--active' : ''}`}
-              variant="ghost"
-              size="xs"
-              onClick={handleToggleTurnList}
-              tooltip={turnListTooltip}
-              disabled={!hasTurnNavigation}
-              aria-label={turnListTooltip}
-              aria-expanded={turnListOpen}
-              aria-controls="flowchat-turn-list-sidebar"
-              data-testid="flowchat-header-turn-list"
-            >
-              <List size={14} />
-            </IconButton>
-          </div>
-        )}
+        <div className="flowchat-header__turn-nav">
+          <IconButton
+            className={`flowchat-header__turn-nav-button${turnListOpen ? ' flowchat-header__turn-nav-button--active' : ''}`}
+            variant="ghost"
+            size="xs"
+            onClick={handleToggleTurnList}
+            tooltip={turnListTooltip}
+            disabled={!hasTurnNavigation}
+            aria-label={turnListTooltip}
+            aria-expanded={turnListOpen}
+            aria-controls="flowchat-turn-list-sidebar"
+            data-testid="flowchat-header-turn-list"
+          >
+            <List size={14} />
+          </IconButton>
+        </div>
       </div>
     </div>
   );

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatTurnListSidebar.scss
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatTurnListSidebar.scss
@@ -46,12 +46,56 @@
   &__header {
     flex: 0 0 auto;
     display: flex;
-    align-items: center;
-    justify-content: flex-start;
+    flex-direction: column;
+    align-items: stretch;
+    gap: $size-gap-2;
     padding: $size-gap-2 $size-gap-3;
     border-bottom: 1px solid var(--border-base);
     font-size: var(--flowchat-font-size-xs);
     color: var(--color-text-secondary);
+  }
+
+  &__search {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  &__search-field {
+    flex: 1;
+    min-width: 0;
+
+    &.bitfun-input-wrapper {
+      gap: 0;
+    }
+
+    &.bitfun-input-wrapper--error .bitfun-input {
+      color: var(--color-error, #c77070);
+    }
+
+    .bitfun-input-container {
+      padding-right: 6px;
+    }
+  }
+
+  &__search-prefix-icon {
+    flex-shrink: 0;
+    color: var(--color-text-secondary);
+    opacity: 0.75;
+  }
+
+  &__search-count {
+    flex-shrink: 0;
+    font-size: var(--flowchat-font-size-xs);
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+    text-align: right;
+    padding-left: 2px;
+
+    &:empty {
+      display: none;
+    }
   }
 
   &__heading {

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatTurnListSidebar.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatTurnListSidebar.tsx
@@ -2,8 +2,10 @@
  * Right-side turn list panel — pushes the message area when open.
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ChevronDown, ChevronUp, Search, X } from 'lucide-react';
+import { IconButton, Input } from '@/component-library';
 import './FlowChatTurnListSidebar.scss';
 
 export interface FlowChatTurnListEntry {
@@ -20,16 +22,57 @@ export interface FlowChatTurnListSidebarProps {
   onSelectTurn: (turnId: string) => void;
   /** Dialog turns that contain the active search query (whole-turn search). */
   searchMatchedTurnIds?: ReadonlySet<string>;
+
+  // Message search (shown here while the panel is open; header search is hidden)
+  searchQuery?: string;
+  onSearchChange?: (query: string) => void;
+  searchMatchCount?: number;
+  searchCurrentMatch?: number;
+  onSearchNext?: () => void;
+  onSearchPrev?: () => void;
+  onSearchClose?: () => void;
+  /** Increments when parent requests focus (e.g. Ctrl+F while panel is open). */
+  searchFocusRequest?: number;
 }
 
 export const FlowChatTurnListSidebar = React.forwardRef<HTMLElement, FlowChatTurnListSidebarProps>(
   function FlowChatTurnListSidebar(
-    { open, turns, currentTurn, totalTurns, onSelectTurn, searchMatchedTurnIds },
+    {
+      open,
+      turns,
+      currentTurn,
+      totalTurns,
+      onSelectTurn,
+      searchMatchedTurnIds,
+      searchQuery = '',
+      onSearchChange,
+      searchMatchCount = 0,
+      searchCurrentMatch = 0,
+      onSearchNext,
+      onSearchPrev,
+      onSearchClose,
+      searchFocusRequest = 0,
+    },
     ref,
   ) {
     const { t } = useTranslation('flow-chat');
     const activeTurnItemRef = useRef<HTMLButtonElement | null>(null);
+    const searchInputRef = useRef<HTMLInputElement | null>(null);
     const listTitle = t('flowChatHeader.turnList', { defaultValue: 'Turn list' });
+
+    const prevFocusRequestRef = useRef(0);
+    useEffect(() => {
+      if (!open) return;
+      if (searchFocusRequest > 0 && searchFocusRequest !== prevFocusRequestRef.current) {
+        prevFocusRequestRef.current = searchFocusRequest;
+        const frameId = requestAnimationFrame(() => {
+          searchInputRef.current?.focus();
+          searchInputRef.current?.select();
+        });
+        return () => cancelAnimationFrame(frameId);
+      }
+      return undefined;
+    }, [open, searchFocusRequest]);
 
     useEffect(() => {
       if (!open) return;
@@ -45,6 +88,24 @@ export const FlowChatTurnListSidebar = React.forwardRef<HTMLElement, FlowChatTur
         cancelAnimationFrame(frameId);
       };
     }, [open, currentTurn, turns.length]);
+
+    const handleSearchKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Escape') {
+          onSearchClose?.();
+        } else if (e.key === 'Enter') {
+          if (e.shiftKey) {
+            onSearchPrev?.();
+          } else {
+            onSearchNext?.();
+          }
+          e.preventDefault();
+        }
+      },
+      [onSearchClose, onSearchNext, onSearchPrev],
+    );
+
+    const hasNoResults = searchQuery.trim().length > 0 && searchMatchCount === 0;
 
     return (
       <aside
@@ -62,6 +123,64 @@ export const FlowChatTurnListSidebar = React.forwardRef<HTMLElement, FlowChatTur
                 {currentTurn}/{totalTurns}
               </span>
             </div>
+            {open ? (
+              <div className="flowchat-turn-sidebar__search" role="search" data-testid="flowchat-turn-list-search-bar">
+                <Input
+                  ref={searchInputRef}
+                  className="flowchat-turn-sidebar__search-field"
+                  variant="filled"
+                  inputSize="small"
+                  prefix={<Search size={12} className="flowchat-turn-sidebar__search-prefix-icon" aria-hidden="true" />}
+                  type="text"
+                  value={searchQuery}
+                  onChange={e => onSearchChange?.(e.target.value)}
+                  onKeyDown={handleSearchKeyDown}
+                  placeholder={t('flowChatHeader.searchPlaceholder', { defaultValue: 'Search messages' })}
+                  aria-label={t('flowChatHeader.searchPlaceholder', { defaultValue: 'Search messages' })}
+                  error={hasNoResults}
+                />
+                <span className="flowchat-turn-sidebar__search-count" aria-live="polite">
+                  {searchQuery.trim()
+                    ? hasNoResults
+                      ? t('flowChatHeader.searchNoResults', { defaultValue: 'No results' })
+                      : t('flowChatHeader.searchResult', {
+                          current: searchCurrentMatch,
+                          total: searchMatchCount,
+                          defaultValue: `${searchCurrentMatch} / ${searchMatchCount}`,
+                        })
+                    : null}
+                </span>
+                <IconButton
+                  variant="ghost"
+                  size="xs"
+                  onClick={onSearchPrev}
+                  disabled={searchMatchCount === 0}
+                  tooltip={t('flowChatHeader.searchPrevious', { defaultValue: 'Previous match' })}
+                  aria-label={t('flowChatHeader.searchPrevious', { defaultValue: 'Previous match' })}
+                >
+                  <ChevronUp size={14} />
+                </IconButton>
+                <IconButton
+                  variant="ghost"
+                  size="xs"
+                  onClick={onSearchNext}
+                  disabled={searchMatchCount === 0}
+                  tooltip={t('flowChatHeader.searchNext', { defaultValue: 'Next match' })}
+                  aria-label={t('flowChatHeader.searchNext', { defaultValue: 'Next match' })}
+                >
+                  <ChevronDown size={14} />
+                </IconButton>
+                <IconButton
+                  variant="ghost"
+                  size="xs"
+                  onClick={onSearchClose}
+                  tooltip={t('flowChatHeader.searchClose', { defaultValue: 'Close search' })}
+                  aria-label={t('flowChatHeader.searchClose', { defaultValue: 'Close search' })}
+                >
+                  <X size={14} />
+                </IconButton>
+              </div>
+            ) : null}
           </div>
           <div className="flowchat-turn-sidebar__list" role="list">
             {turns.map(turn => (

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -53,6 +53,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const visibleTurnInfo = useVisibleTurnInfo();
   const [pendingHeaderTurnId, setPendingHeaderTurnId] = useState<string | null>(null);
   const [searchOpenRequest, setSearchOpenRequest] = useState(0);
+  const [turnListSearchFocusRequest, setTurnListSearchFocusRequest] = useState(0);
   const [turnListOpen, setTurnListOpen] = useState(false);
   const autoPinnedSessionIdRef = useRef<string | null>(null);
   const virtualListRef = useRef<VirtualMessageListRef>(null);
@@ -266,20 +267,6 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     [handleJumpToTurn],
   );
 
-  const handleJumpToPreviousTurn = useCallback(() => {
-    if (!effectiveVisibleTurnInfo || effectiveVisibleTurnInfo.turnIndex <= 1) return;
-    const previousTurn = turnSummaries[effectiveVisibleTurnInfo.turnIndex - 2];
-    if (!previousTurn) return;
-    handleJumpToTurn(previousTurn.turnId);
-  }, [effectiveVisibleTurnInfo, handleJumpToTurn, turnSummaries]);
-
-  const handleJumpToNextTurn = useCallback(() => {
-    if (!effectiveVisibleTurnInfo || effectiveVisibleTurnInfo.turnIndex >= turnSummaries.length) return;
-    const nextTurn = turnSummaries[effectiveVisibleTurnInfo.turnIndex];
-    if (!nextTurn) return;
-    handleJumpToTurn(nextTurn.turnId);
-  }, [effectiveVisibleTurnInfo, handleJumpToTurn, turnSummaries]);
-
   // Publish session context to UnifiedTopBar via headerStore so the unified
   // back button and title can be rendered there.
   const { setSessionContext, clearSessionContext } = useHeaderStore.getState();
@@ -337,7 +324,11 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     'chat.search',
     { key: 'F', ctrl: true, scope: 'chat', allowInInput: false },
     () => {
-      setSearchOpenRequest(prev => prev + 1);
+      if (turnListOpen && turnSummaries.length > 0) {
+        setTurnListSearchFocusRequest(prev => prev + 1);
+      } else {
+        setSearchOpenRequest(prev => prev + 1);
+      }
     },
     { priority: 15, description: 'keyboard.shortcuts.chat.search' }
   );
@@ -350,17 +341,12 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
         data-shortcut-scope="chat"
       >
         <FlowChatHeader
-          currentTurn={effectiveVisibleTurnInfo?.turnIndex ?? 0}
-          totalTurns={effectiveVisibleTurnInfo?.totalTurns ?? 0}
-          currentUserMessage={effectiveVisibleTurnInfo?.userMessage ?? ''}
           visible={!!activeSession}
           sessionId={activeSession?.sessionId}
           btwOrigin={btwOrigin}
           btwParentTitle={btwParentTitle}
           turns={turnSummaries}
           onJumpToTurn={handleJumpToTurn}
-          onJumpToPreviousTurn={handleJumpToPreviousTurn}
-          onJumpToNextTurn={handleJumpToNextTurn}
           searchQuery={searchQuery}
           onSearchChange={onSearchChange}
           searchMatchCount={searchMatches.length}
@@ -403,6 +389,14 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
             totalTurns={effectiveVisibleTurnInfo?.totalTurns ?? turnSummaries.length}
             onSelectTurn={handleTurnListSelect}
             searchMatchedTurnIds={searchQuery.trim().length > 0 ? searchMatchedTurnIds : undefined}
+            searchQuery={searchQuery}
+            onSearchChange={onSearchChange}
+            searchMatchCount={searchMatches.length}
+            searchCurrentMatch={searchMatches.length > 0 ? searchCurrentMatchIndex + 1 : 0}
+            onSearchNext={handleSearchNext}
+            onSearchPrev={handleSearchPrev}
+            onSearchClose={clearSearch}
+            searchFocusRequest={turnListSearchFocusRequest}
           />
         </div>
       </div>

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
@@ -326,6 +326,8 @@ function handleStarted(
   
   if (existingItem) {
     store.updateModelRoundItem(sessionId, turnId, toolEvent.tool_id, {
+      // Early events may omit tool_name; Started carries the canonical name — keep card registry in sync.
+      toolName: toolEvent.tool_name,
       toolCall: {
         input: toolEvent.params,
         id: toolEvent.tool_id
@@ -393,6 +395,7 @@ function handleCompleted(
   }
   
   const updates = {
+    toolName: toolEvent.tool_name,
     toolResult: {
       result: toolEvent.result,
       success: true,
@@ -420,6 +423,7 @@ function handleFailed(
   toolEvent: FailedToolEvent
 ): void {
   store.updateModelRoundItem(sessionId, turnId, toolEvent.tool_id, {
+    toolName: toolEvent.tool_name,
     toolResult: {
       result: null,
       success: false,

--- a/src/web-ui/src/flow_chat/tool-cards/SessionHistoryDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/SessionHistoryDisplay.tsx
@@ -1,0 +1,174 @@
+/**
+ * Compact display for SessionHistory (read another session's transcript, analogous to Read file).
+ * Resolves the target session display name from:
+ * 1) FlowChatStore (in-memory title)
+ * 2) Persisted metadata on disk (list_sessions / metadata.json) via sessionAPI.loadSessionMetadata
+ *
+ * useSyncExternalStore getSnapshot must return stable string primitives (Object.is equality).
+ */
+
+import React, { useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import { Loader2, Clock, Check } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { ToolCardProps } from '../types/flow-chat';
+import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
+import { FlowChatStore } from '../store/FlowChatStore';
+import { sessionAPI } from '@/infrastructure/api';
+
+/** Internal sentinels — must not collide with real session titles. */
+const SNAP_PARSE = '\u2060bf:sessionHistory:parse\u2060';
+const SNAP_MISS = '\u2060bf:sessionHistory:missing\u2060';
+const SNAP_UNTITLED = '\u2060bf:sessionHistory:untitled\u2060';
+
+function normalizeWorkspacePath(a: string, b: string): boolean {
+  return a.replace(/\\/g, '/').toLowerCase() === b.replace(/\\/g, '/').toLowerCase();
+}
+
+function readSessionNameSnapshotString(targetSessionId: string | undefined): string {
+  if (!targetSessionId?.trim()) {
+    return SNAP_PARSE;
+  }
+  const session = FlowChatStore.getInstance().getState().sessions.get(targetSessionId.trim());
+  if (!session) {
+    return SNAP_MISS;
+  }
+  const title = session.title?.trim();
+  if (!title) {
+    return SNAP_UNTITLED;
+  }
+  return title;
+}
+
+export const SessionHistoryDisplay: React.FC<ToolCardProps> = React.memo(({
+  toolItem,
+  sessionId: hostSessionId,
+}) => {
+  const { t } = useTranslation('flow-chat');
+  const { toolCall, status } = toolItem;
+
+  const targetSessionId = useMemo(() => {
+    const sid = toolCall?.input?.session_id ?? toolCall?.input?.sessionId;
+    return typeof sid === 'string' && sid.trim() ? sid.trim() : undefined;
+  }, [toolCall?.input]);
+
+  const toolWorkspace = useMemo(() => {
+    const w = toolCall?.input?.workspace;
+    return typeof w === 'string' && w.trim() ? w.trim() : undefined;
+  }, [toolCall?.input]);
+
+  const nameSnap = useSyncExternalStore(
+    (onChange) => FlowChatStore.getInstance().subscribe(onChange),
+    () => readSessionNameSnapshotString(targetSessionId),
+    () => readSessionNameSnapshotString(targetSessionId)
+  );
+
+  const [persistedName, setPersistedName] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPersistedName(null);
+  }, [targetSessionId, toolWorkspace]);
+
+  useEffect(() => {
+    if (!targetSessionId || !toolWorkspace) {
+      return;
+    }
+    if (nameSnap !== SNAP_MISS && nameSnap !== SNAP_UNTITLED) {
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const host = hostSessionId
+          ? FlowChatStore.getInstance().getState().sessions.get(hostSessionId)
+          : undefined;
+        const wsMatch =
+          host?.workspacePath && normalizeWorkspacePath(host.workspacePath, toolWorkspace);
+        const meta = await sessionAPI.loadSessionMetadata(
+          targetSessionId,
+          toolWorkspace,
+          wsMatch ? host?.remoteConnectionId : undefined,
+          wsMatch ? host?.remoteSshHost : undefined
+        );
+        if (!cancelled && meta?.sessionName?.trim()) {
+          setPersistedName(meta.sessionName.trim());
+        }
+      } catch {
+        // Metadata unavailable (e.g. path mismatch); keep sentinel-based label.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [targetSessionId, toolWorkspace, nameSnap, hostSessionId]);
+
+  const displaySessionName = useMemo(() => {
+    if (nameSnap === SNAP_PARSE) {
+      return t('toolCards.sessionHistory.parsingParams');
+    }
+    if (nameSnap !== SNAP_PARSE && nameSnap !== SNAP_MISS && nameSnap !== SNAP_UNTITLED) {
+      return nameSnap;
+    }
+    if (persistedName) {
+      return persistedName;
+    }
+    if (nameSnap === SNAP_UNTITLED) {
+      return t('session.untitled');
+    }
+    if (nameSnap === SNAP_MISS) {
+      return t('toolCards.sessionHistory.fallbackDisplayName');
+    }
+    return t('session.untitled');
+  }, [nameSnap, persistedName, t]);
+
+  const getStatusIcon = () => {
+    switch (status) {
+      case 'running':
+      case 'streaming':
+        return <Loader2 className="animate-spin" size={12} />;
+      case 'completed':
+        return <Check size={12} className="icon-check-done" />;
+      case 'pending':
+      default:
+        return <Clock size={12} />;
+    }
+  };
+
+  const renderContent = () => {
+    if (nameSnap === SNAP_PARSE) {
+      return displaySessionName;
+    }
+    if (status === 'completed') {
+      return t('toolCards.sessionHistory.lineCompleted', { name: displaySessionName });
+    }
+    if (status === 'running' || status === 'streaming') {
+      return (
+        <>
+          {t('toolCards.sessionHistory.lineRunning', { name: displaySessionName })}
+          ...
+        </>
+      );
+    }
+    return t('toolCards.sessionHistory.linePending', { name: displaySessionName });
+  };
+
+  if (status === 'error') {
+    return null;
+  }
+
+  return (
+    <CompactToolCard
+      status={status}
+      isExpanded={false}
+      className="session-history-card"
+      clickable={false}
+      header={
+        <CompactToolCardHeader
+          statusIcon={getStatusIcon()}
+          content={renderContent()}
+        />
+      }
+    />
+  );
+});

--- a/src/web-ui/src/flow_chat/tool-cards/index.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/index.ts
@@ -8,6 +8,17 @@ import { createLogger } from '@/shared/utils/logger';
 import { isMcpToolName, parseMcpToolName } from '@/infrastructure/mcp/toolName';
 
 const log = createLogger('ToolCardRegistry');
+
+/** Provider / stream quirks (e.g. snake_case) — map to TOOL_CARD_CONFIGS keys. */
+const TOOL_REGISTRY_ALIASES: Record<string, string> = {
+  session_history: 'SessionHistory',
+};
+
+function resolveToolRegistryKey(raw: string): string {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed) return trimmed;
+  return TOOL_REGISTRY_ALIASES[trimmed] ?? TOOL_REGISTRY_ALIASES[trimmed.toLowerCase()] ?? trimmed;
+}
 // Tool display components
 import { ReadFileDisplay } from './ReadFileDisplay';
 import { GrepSearchDisplay } from './GrepSearchDisplay';
@@ -31,6 +42,7 @@ import { InitMiniAppDisplay } from './MiniAppToolDisplay';
 import { BtwMarkerCard } from './BtwMarkerCard';
 import { SessionControlToolCard } from './SessionControlToolCard';
 import { SessionMessageToolCard } from './SessionMessageToolCard';
+import { SessionHistoryDisplay } from './SessionHistoryDisplay';
 import { AgentDispatchCard } from './AgentDispatchCard';
 
 // Tool card config map - uses backend tool names
@@ -278,6 +290,17 @@ export const TOOL_CARD_CONFIGS: Record<string, ToolCardConfig> = {
     primaryColor: '#8b5cf6'
   },
 
+  'SessionHistory': {
+    toolName: 'SessionHistory',
+    displayName: 'Read session history',
+    icon: 'SH',
+    requiresConfirmation: false,
+    resultDisplayType: 'summary',
+    description: 'Export and read another session transcript',
+    displayMode: 'compact',
+    primaryColor: '#3b82f6'
+  },
+
   // Bash terminal tool
   'Bash': {
     toolName: 'Bash',
@@ -352,6 +375,7 @@ export const TOOL_CARD_COMPONENTS = {
   // Session tools
   'SessionControl': SessionControlToolCard,
   'SessionMessage': SessionMessageToolCard,
+  'SessionHistory': SessionHistoryDisplay,
 
   // Bash tool
   'Bash': TerminalToolCard,
@@ -364,14 +388,15 @@ export const TOOL_CARD_COMPONENTS = {
  * Get tool card config.
  */
 export function getToolCardConfig(toolName: string): ToolCardConfig {
+  const raw = (toolName ?? '').trim();
   // Check MCP tools (prefix: mcp__).
-  if (isMcpToolName(toolName)) {
-    const parsed = parseMcpToolName(toolName);
-    const actualToolName = parsed?.toolName ?? toolName;
+  if (isMcpToolName(raw)) {
+    const parsed = parseMcpToolName(raw);
+    const actualToolName = parsed?.toolName ?? raw;
 
     return {
-      toolName,
-      displayName: actualToolName || toolName,
+      toolName: raw,
+      displayName: actualToolName || raw,
       icon: 'MCP',
       requiresConfirmation: false,
       resultDisplayType: 'detailed',
@@ -380,15 +405,16 @@ export function getToolCardConfig(toolName: string): ToolCardConfig {
       primaryColor: '#8b5cf6'
     };
   }
-  
+
+  const key = resolveToolRegistryKey(raw);
   // Match by name or fall back to defaults.
-  return TOOL_CARD_CONFIGS[toolName] || {
-    toolName,
-    displayName: `Tool: ${toolName}`,
+  return TOOL_CARD_CONFIGS[key] || {
+    toolName: raw,
+    displayName: `Tool: ${raw}`,
     icon: 'TOOL',
     requiresConfirmation: false,
     resultDisplayType: 'summary',
-    description: `Run ${toolName} tool`,
+    description: `Run ${raw} tool`,
     displayMode: 'standard',
     primaryColor: '#6b7280'
   };
@@ -398,16 +424,18 @@ export function getToolCardConfig(toolName: string): ToolCardConfig {
  * Get tool card component.
  */
 export function getToolCardComponent(toolName: string) {
+  const raw = (toolName ?? '').trim();
   // Check MCP tools (prefix: mcp__).
-  if (isMcpToolName(toolName)) {
+  if (isMcpToolName(raw)) {
     return MCPToolDisplay;
   }
-  
-  const component = TOOL_CARD_COMPONENTS[toolName as keyof typeof TOOL_CARD_COMPONENTS];
+
+  const key = resolveToolRegistryKey(raw);
+  const component = TOOL_CARD_COMPONENTS[key as keyof typeof TOOL_CARD_COMPONENTS];
   
   // Debug log (only when a component is missing).
   if (!component) {
-    log.warn('Tool card component not found, using default', { toolName });
+    log.warn('Tool card component not found, using default', { toolName: raw, resolvedKey: key });
   }
   
   return component || DefaultToolCard;

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -123,7 +123,19 @@
       "viewDetails": "Task details",
       "runningSwitchTooltip": "{{title}} · Click to switch",
       "openTaskList": "View all tasks",
-      "runningSessionsGroupLabel": "Running"
+      "runningSessionsGroupLabel": "Running",
+      "newSessionButton": "New process",
+      "newSessionDialogTitle": "New process",
+      "agentLabel": "Agent",
+      "workspaceLabel": "Workspace",
+      "workspacePlaceholder": "Choose an open workspace",
+      "browseWorkspace": "Browse folder…",
+      "confirmCreate": "Create",
+      "noOpenWorkspace": "No workspace open yet",
+      "workspaceMissing": "Select a valid workspace",
+      "newSessionLede": "Choose an agent mode and workspace — start a fresh process.",
+      "newSessionSectionAgent": "Agent",
+      "newSessionSectionWorkspace": "Workspace"
     },
     "badges": {
       "comingSoon": "Soon"

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -708,6 +708,13 @@
       "readingFile": "Reading",
       "preparingRead": "Preparing to read"
     },
+    "sessionHistory": {
+      "parsingParams": "Parsing parameters...",
+      "fallbackDisplayName": "Another session",
+      "lineCompleted": "Read history: {{name}}",
+      "lineRunning": "Reading history: {{name}}",
+      "linePending": "Preparing to read history: {{name}}"
+    },
     "terminalControl": {
       "terminatingSession": "Terminating terminal",
       "sessionKilled": "Terminal killed",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -123,7 +123,19 @@
       "viewDetails": "任务详情",
       "runningSwitchTooltip": "{{title}} · 点击切换",
       "openTaskList": "查看全部任务",
-      "runningSessionsGroupLabel": "运行中"
+      "runningSessionsGroupLabel": "运行中",
+      "newSessionButton": "新建进程",
+      "newSessionDialogTitle": "新建进程",
+      "agentLabel": "Agent",
+      "workspaceLabel": "工作路径",
+      "workspacePlaceholder": "选择已打开的工作区",
+      "browseWorkspace": "浏览文件夹…",
+      "confirmCreate": "创建",
+      "noOpenWorkspace": "暂无已打开的工作区",
+      "workspaceMissing": "请选择有效的工作区",
+      "newSessionLede": "选择 Agent 与项目路径，开启一条新的任务进程。",
+      "newSessionSectionAgent": "Agent",
+      "newSessionSectionWorkspace": "工作路径"
     },
     "badges": {
       "comingSoon": "即将上线"

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -700,6 +700,13 @@
       "readingFile": "正在读取",
       "preparingRead": "准备读取"
     },
+    "sessionHistory": {
+      "parsingParams": "解析参数中...",
+      "fallbackDisplayName": "其它会话",
+      "lineCompleted": "读取 {{name}} 的历史",
+      "lineRunning": "正在读取 {{name}} 的历史",
+      "linePending": "准备读取 {{name}} 的历史"
+    },
     "terminalControl": {
       "terminatingSession": "正在终止终端",
       "sessionKilled": "终端已终止",


### PR DESCRIPTION
## Summary
- New session creation dialog wired from SessionCapsule.
- Session history surfaced as a flow-chat tool card (SessionHistoryDisplay) with sidebar integration.
- Flow chat header simplified; turn list sidebar styling/behavior updates.
- i18n updates (en-US / zh-CN).

## Testing
- Not run in this environment (UI change). Please verify desktop/web flow-chat session flows manually.

## Notes
- AI-assisted implementation; lightly reviewed locally (lint clean on touched TSX).