### PR TITLE
feat(web-ui): task management panel and task detail scene

### DIFF
--- a/src/web-ui/src/app/components/SessionCapsule/SessionCapsule.tsx
+++ b/src/web-ui/src/app/components/SessionCapsule/SessionCapsule.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Code2, ListChecks, LayoutList, ListTodo, Pin, Plus, Sparkles } from 'lucide-react';
+import { Code2, ListChecks, LayoutDashboard, ListTodo, Pin, Plus, Sparkles } from 'lucide-react';
 import { Search, Tooltip } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
@@ -36,6 +36,7 @@ import { compareSessionsForDisplay, findOpenedWorkspaceForSession } from '../../
 import { useAgentCanvasStore } from '@/app/components/panels/content-canvas/stores';
 import { createLogger } from '@/shared/utils/logger';
 import { useOverlayStore } from '../../stores/overlayStore';
+import { useSessionCapsuleStore } from '../../stores/sessionCapsuleStore';
 import SessionsSection from '../NavPanel/sections/sessions/SessionsSection';
 import { NewSessionDialog } from './NewSessionDialog';
 import './SessionCapsule.scss';
@@ -91,6 +92,8 @@ function writePinnedToStorage(value: boolean): void {
 const SessionCapsule: React.FC = () => {
   const { t } = useI18n('common');
   const activeOverlay = useOverlayStore((s) => s.activeOverlay);
+  const openOverlay = useOverlayStore((s) => s.openOverlay);
+  const openTaskDetail = useSessionCapsuleStore((s) => s.openTaskDetail);
   const { openedWorkspacesList, setActiveWorkspace, currentWorkspace } = useWorkspaceContext();
   const activeBtwSessionTab = useAgentCanvasStore((state) => selectActiveBtwSessionTab(state as any));
   const activeBtwSessionData = activeBtwSessionTab?.content.data as
@@ -211,6 +214,16 @@ const SessionCapsule: React.FC = () => {
     [activeSessionId, currentWorkspace?.id, openedWorkspacesList, setActiveWorkspace]
   );
 
+  const handleOpenTaskDetail = useCallback(() => {
+    const state = flowChatStore.getState();
+    const targetId =
+      state.activeSessionId ??
+      Array.from(state.sessions.values()).sort(compareSessionsForDisplay)[0]?.sessionId;
+    if (!targetId) return;
+    openTaskDetail(targetId);
+    openOverlay('task-detail');
+  }, [openTaskDetail, openOverlay]);
+
   const toggle = useCallback(() => {
     setExpanded((v) => {
       const next = !v;
@@ -312,8 +325,9 @@ const SessionCapsule: React.FC = () => {
                 type="button"
                 className="session-capsule__icon-btn"
                 aria-label={t('nav.sessionCapsule.viewDetails')}
+                onClick={handleOpenTaskDetail}
               >
-                <LayoutList size={13} strokeWidth={2.25} />
+                <LayoutDashboard size={13} strokeWidth={2.25} />
               </button>
             </Tooltip>
             <Tooltip

--- a/src/web-ui/src/app/components/SessionListDialog/SessionListDialog.scss
+++ b/src/web-ui/src/app/components/SessionListDialog/SessionListDialog.scss
@@ -1,0 +1,37 @@
+/**
+ * SessionListDialog — additional styles for the session list item with detail button.
+ */
+
+@use '../../../component-library/styles/tokens.scss' as *;
+
+.bitfun-session-list-item {
+  &:hover .bitfun-session-list-item__detail-btn,
+  &.bitfun-nav-search-dialog__item--active .bitfun-session-list-item__detail-btn {
+    opacity: 1;
+  }
+}
+
+.bitfun-session-list-item__detail-btn {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: $size-radius-sm;
+  border: none;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.16s ease,
+    background 0.16s ease,
+    color 0.16s ease;
+
+  &:hover {
+    background: var(--element-bg-medium);
+    color: var(--color-accent-500);
+    opacity: 1 !important;
+  }
+}

--- a/src/web-ui/src/app/components/SessionListDialog/SessionListDialog.tsx
+++ b/src/web-ui/src/app/components/SessionListDialog/SessionListDialog.tsx
@@ -7,8 +7,8 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { ListChecks } from 'lucide-react';
-import { Search } from '@/component-library';
+import { LayoutDashboard, ListChecks } from 'lucide-react';
+import { Search, Tooltip } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n';
 import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
@@ -17,7 +17,9 @@ import { openMainSession } from '@/flow_chat/services/openBtwSession';
 import { compareSessionsForDisplay } from '@/flow_chat/utils/sessionOrdering';
 import type { FlowChatState, Session } from '@/flow_chat/types/flow-chat';
 import { useSessionCapsuleStore } from '../../stores/sessionCapsuleStore';
+import { useOverlayStore } from '../../stores/overlayStore';
 import '../NavPanel/NavSearchDialog.scss';
+import './SessionListDialog.scss';
 
 const getTitle = (s: Session): string =>
   s.title?.trim() || `Task ${s.sessionId.slice(0, 6)}`;
@@ -31,6 +33,8 @@ const SessionListDialog: React.FC = () => {
   const { t } = useI18n('common');
   const open = useSessionCapsuleStore((s) => s.sessionListDialogOpen);
   const close = useSessionCapsuleStore((s) => s.closeSessionListDialog);
+  const openTaskDetail = useSessionCapsuleStore((s) => s.openTaskDetail);
+  const openOverlay = useOverlayStore((s) => s.openOverlay);
 
   const { openedWorkspacesList, setActiveWorkspace, currentWorkspace } = useWorkspaceContext();
   const [query, setQuery] = useState('');
@@ -101,6 +105,13 @@ const SessionListDialog: React.FC = () => {
     );
   }, [close, openedWorkspacesList, currentWorkspace?.id, setActiveWorkspace]);
 
+  const handleOpenDetail = useCallback((e: React.MouseEvent, session: Session) => {
+    e.stopPropagation();
+    openTaskDetail(session.sessionId);
+    openOverlay('task-detail');
+    close();
+  }, [openTaskDetail, openOverlay, close]);
+
   const handleInputKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Escape') {
       e.preventDefault();
@@ -162,12 +173,14 @@ const SessionListDialog: React.FC = () => {
                 {t('nav.search.groupSessions')}
               </div>
               {filtered.map(({ session, workspaceName }, i) => (
-                <button
+                <div
                   key={session.sessionId}
-                  type="button"
-                  className={`bitfun-nav-search-dialog__item${i === activeIndex ? ' bitfun-nav-search-dialog__item--active' : ''}`}
+                  className={`bitfun-nav-search-dialog__item bitfun-session-list-item${i === activeIndex ? ' bitfun-nav-search-dialog__item--active' : ''}`}
                   onMouseEnter={() => setActiveIndex(i)}
                   onClick={() => void handleSelect(session)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={e => e.key === 'Enter' && void handleSelect(session)}
                 >
                   <span className="bitfun-nav-search-dialog__item-icon">
                     <ListChecks size={14} />
@@ -182,7 +195,17 @@ const SessionListDialog: React.FC = () => {
                       </span>
                     )}
                   </span>
-                </button>
+                  <Tooltip content="查看详情" placement="top">
+                    <button
+                      type="button"
+                      className="bitfun-session-list-item__detail-btn"
+                      onClick={(e) => handleOpenDetail(e, session)}
+                      aria-label="查看任务详情"
+                    >
+                      <LayoutDashboard size={12} />
+                    </button>
+                  </Tooltip>
+                </div>
               ))}
             </div>
           )}

--- a/src/web-ui/src/app/components/TaskManagementPanel/TaskManagementPanel.scss
+++ b/src/web-ui/src/app/components/TaskManagementPanel/TaskManagementPanel.scss
@@ -1,0 +1,84 @@
+/**
+ * TaskManagementPanel — left-side floating task management drawer styles.
+ *
+ * The panel slides in from the left, positioned below the 40px top bar.
+ * A semi-transparent backdrop covers the rest of the viewport.
+ */
+
+@use '../../../component-library/styles/tokens.scss' as *;
+
+$_header-h: 40px;
+// Wide drawer: task center uses a chat-like split (majority left + session rail).
+$_panel-w: min(1180px, 92vw);
+
+// ── Entry animations ───────────────────────────────────────────────────────
+
+@keyframes task-mgmt-backdrop-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes task-mgmt-panel-in {
+  from { transform: translateX(-100%); opacity: 0; }
+  to   { transform: translateX(0);     opacity: 1; }
+}
+
+// ── Root ──────────────────────────────────────────────────────────────────
+
+.task-mgmt-panel-root {
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+  pointer-events: none;
+}
+
+// ── Backdrop ──────────────────────────────────────────────────────────────
+
+.task-mgmt-panel-backdrop {
+  position: absolute;
+  top: $_header-h;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.18);
+  pointer-events: all;
+  animation: task-mgmt-backdrop-in 180ms ease both;
+}
+
+// ── Panel ─────────────────────────────────────────────────────────────────
+
+.task-mgmt-panel {
+  position: absolute;
+  top: $_header-h;
+  left: 0;
+  bottom: 0;
+  width: $_panel-w;
+  max-width: 100%;
+  pointer-events: all;
+  overflow: hidden;
+  border-right: 1px solid var(--border-subtle);
+  box-shadow:
+    4px 0 8px rgba(0, 0, 0, 0.06),
+    8px 0 32px rgba(0, 0, 0, 0.12);
+  animation: task-mgmt-panel-in 220ms cubic-bezier(0.25, 1, 0.5, 1) both;
+}
+
+// ── Loading state ─────────────────────────────────────────────────────────
+
+.task-mgmt-panel__loading {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-scene);
+}
+
+// ── Reduced motion ────────────────────────────────────────────────────────
+
+@media (prefers-reduced-motion: reduce) {
+  .task-mgmt-panel,
+  .task-mgmt-panel-backdrop {
+    animation: none;
+  }
+}

--- a/src/web-ui/src/app/components/TaskManagementPanel/TaskManagementPanel.tsx
+++ b/src/web-ui/src/app/components/TaskManagementPanel/TaskManagementPanel.tsx
@@ -1,0 +1,65 @@
+/**
+ * TaskManagementPanel — left-side floating task management drawer.
+ *
+ * Renders as a portal directly into document.body so it floats above
+ * both the base session layer and any active overlay.
+ *
+ * Opened exclusively via the header icon button (in agent scenarios).
+ * Closed by: ESC key, backdrop click, or calling closeTaskPanel.
+ */
+
+import React, { useEffect, lazy, Suspense } from 'react';
+import { createPortal } from 'react-dom';
+import { useSessionCapsuleStore } from '../../stores/sessionCapsuleStore';
+import { ProcessingIndicator } from '@/flow_chat/components/modern/ProcessingIndicator';
+import './TaskManagementPanel.scss';
+
+const TaskDetailScene = lazy(() => import('../../scenes/task-detail/TaskDetailScene'));
+
+const TaskManagementPanel: React.FC = () => {
+  const open = useSessionCapsuleStore((s) => s.taskPanelOpen);
+  const close = useSessionCapsuleStore((s) => s.closeTaskPanel);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        close();
+      }
+    };
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
+  }, [open, close]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="task-mgmt-panel-root">
+      <div
+        className="task-mgmt-panel-backdrop"
+        aria-hidden="true"
+        onClick={close}
+      />
+      <div
+        className="task-mgmt-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="任务管理"
+      >
+        <Suspense
+          fallback={
+            <div className="task-mgmt-panel__loading">
+              <ProcessingIndicator visible />
+            </div>
+          }
+        >
+          <TaskDetailScene />
+        </Suspense>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default TaskManagementPanel;

--- a/src/web-ui/src/app/components/UnifiedTopBar/UnifiedTopBar.scss
+++ b/src/web-ui/src/app/components/UnifiedTopBar/UnifiedTopBar.scss
@@ -78,37 +78,6 @@
     user-select: none;
   }
 
-  &__sessions-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    padding: 0;
-    border: none;
-    border-radius: $size-radius-sm;
-    background: transparent;
-    color: var(--color-text-muted);
-    cursor: pointer;
-    flex-shrink: 0;
-    transition: color $motion-fast $easing-standard,
-                background $motion-fast $easing-standard;
-
-    &:hover {
-      color: var(--color-accent-500);
-      background: var(--element-bg-soft);
-    }
-
-    &:active {
-      background: var(--element-bg-medium);
-    }
-
-    &:focus-visible {
-      outline: 2px solid var(--color-accent-500);
-      outline-offset: -1px;
-    }
-  }
-
   // Portaled to document.body — must sit above FlowChat's glass header (z-index 20) and other scene chrome.
   &__menu-backdrop {
     position: fixed;
@@ -400,7 +369,6 @@
 @media (prefers-reduced-motion: reduce) {
   .unified-top-bar {
     &__back-btn,
-    &__sessions-btn,
     &__search-trigger {
       transition: none;
     }

--- a/src/web-ui/src/app/components/UnifiedTopBar/UnifiedTopBar.tsx
+++ b/src/web-ui/src/app/components/UnifiedTopBar/UnifiedTopBar.tsx
@@ -20,7 +20,7 @@
 
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { ArrowLeft, Info, ListChecks, PictureInPicture2, Search, FolderOpen, Settings } from 'lucide-react';
+import { ArrowLeft, Info, PictureInPicture2, Search, FolderOpen, Settings } from 'lucide-react';
 import { Modal, Tooltip, WindowControls } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
 import { useToolbarModeContext } from '@/flow_chat/components/toolbar-mode/ToolbarModeContext';
@@ -252,10 +252,12 @@ const UnifiedTopBar: React.FC<UnifiedTopBarProps> = ({
     sessionContext?.mode?.toLowerCase() === 'dispatcher';
 
   const sessionWorkspaceName = useMemo(() => {
+    const explicit = sessionContext?.workspaceDisplayName?.trim();
+    if (explicit) return explicit;
     const p = sessionContext?.workspacePath;
     if (!p) return '';
     return p.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? p;
-  }, [sessionContext?.workspacePath]);
+  }, [sessionContext?.workspacePath, sessionContext?.workspaceDisplayName]);
 
   const sessionTitle = useMemo(() => {
     if (!sessionContext) return '';
@@ -269,8 +271,6 @@ const UnifiedTopBar: React.FC<UnifiedTopBarProps> = ({
   const showBackBtn = hasOverlay || (!!sessionContext && !isDispatcherSession);
   const contextTitle = hasOverlay ? overlayTitle : sessionTitle;
   const backTooltip = t('overlay.returnToAgenticOS');
-  const showHeaderSessionListBtn =
-    activeOverlay === 'settings' || activeOverlay === 'shell';
 
   const handleContextBack = useCallback(() => {
     if (hasOverlay) {
@@ -403,23 +403,6 @@ const UnifiedTopBar: React.FC<UnifiedTopBarProps> = ({
               document.body
             )}
         </div>
-
-        {showHeaderSessionListBtn && (
-          <Tooltip
-            content={t('header.openSessionsList')}
-            placement="bottom"
-            followCursor
-          >
-            <button
-              type="button"
-              className="unified-top-bar__sessions-btn"
-              onClick={() => openSessionListDialog()}
-              aria-label={t('header.openSessionsList')}
-            >
-              <ListChecks size={14} strokeWidth={2.25} aria-hidden="true" />
-            </button>
-          </Tooltip>
-        )}
 
         {showContextNav && (
           <div className="unified-top-bar__context-nav">

--- a/src/web-ui/src/app/overlay/OverlaySceneRenderer.tsx
+++ b/src/web-ui/src/app/overlay/OverlaySceneRenderer.tsx
@@ -24,6 +24,7 @@ const MiniAppGalleryScene = lazy(() => import('../scenes/miniapps/MiniAppGallery
 const ShellScene        = lazy(() => import('../scenes/shell/ShellScene'));
 const MiniAppScene      = lazy(() => import('../scenes/miniapps/MiniAppScene'));
 const PanelViewScene    = lazy(() => import('../scenes/panel-view/PanelViewScene'));
+const TaskDetailScene   = lazy(() => import('../scenes/task-detail/TaskDetailScene'));
 
 interface OverlaySceneRendererProps {
   overlayId: OverlaySceneId;
@@ -78,6 +79,8 @@ function renderOverlayScene(id: OverlaySceneId, workspacePath?: string): React.R
       return <ShellScene isActive />;
     case 'panel-view':
       return <PanelViewScene workspacePath={workspacePath} />;
+    case 'task-detail':
+      return <TaskDetailScene />;
     default:
       if (typeof id === 'string' && id.startsWith('miniapp:')) {
         return <MiniAppScene appId={id.slice('miniapp:'.length)} />;

--- a/src/web-ui/src/app/overlay/overlayRegistry.ts
+++ b/src/web-ui/src/app/overlay/overlayRegistry.ts
@@ -15,6 +15,7 @@ import {
   Boxes,
   User,
   ExternalLink,
+  LayoutDashboard,
 } from 'lucide-react';
 import type { OverlaySceneDef, OverlaySceneId } from './types';
 
@@ -78,6 +79,12 @@ export const OVERLAY_SCENE_REGISTRY: OverlaySceneDef[] = [
     label: 'Panel View',
     labelKey: 'scenes.panelView',
     Icon: ExternalLink,
+  },
+  {
+    id: 'task-detail',
+    label: 'Task Detail',
+    labelKey: 'scenes.taskDetail',
+    Icon: LayoutDashboard,
   },
 ];
 

--- a/src/web-ui/src/app/overlay/types.ts
+++ b/src/web-ui/src/app/overlay/types.ts
@@ -20,6 +20,7 @@ export type OverlaySceneId =
   | 'assistant'
   | 'shell'
   | 'panel-view'
+  | 'task-detail'
   | `miniapp:${string}`;
 
 /** Full scene identifier — base or overlay. */

--- a/src/web-ui/src/app/scenes/task-detail/TaskDetailScene.scss
+++ b/src/web-ui/src/app/scenes/task-detail/TaskDetailScene.scss
@@ -1,0 +1,625 @@
+/**
+ * TaskDetailScene — styles mirroring AssistantConfigPage (acp-layout).
+ *
+ * Variables, spacing rhythm, and visual language are intentionally kept
+ * in sync with NurseryView.scss / AssistantConfigPage so the two panels
+ * feel like siblings inside the same design system.
+ */
+
+@use '../../../component-library/styles/tokens.scss' as *;
+
+// ── Shared metrics (match acp- variables exactly) ──────────────────────────
+
+$tds-gutter:      clamp(36px, 5.5vw, 72px);
+$tds-col-gap:     clamp(20px, 2.2vw, 32px);
+$tds-content-top: clamp(40px, 4.5vh, 52px);
+
+// ── Fade-in animation ─────────────────────────────────────────────────────
+
+@keyframes tds-fade-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes tds-spin {
+  to { transform: rotate(360deg); }
+}
+
+// ── Root ──────────────────────────────────────────────────────────────────
+
+.tds {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: var(--color-bg-scene);
+  animation: tds-fade-in 200ms cubic-bezier(0.25, 1, 0.5, 1) both;
+}
+
+// ── Two-column layout — mirrors .acp-layout exactly ──────────────────────
+
+.tds-layout {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+  padding: 0 $tds-gutter;
+  gap: $tds-col-gap;
+
+  // Left: majority (60 %) — search box + dual panes
+  &__left {
+    flex: 0 0 60%;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    --tds-left-pad: #{$size-gap-6};
+  }
+
+  // Right: rail (40 %) — workspace sessions
+  &__right {
+    flex: 0 0 40%;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+}
+
+// ── Left: page title / header ─────────────────────────────────────────────
+
+.tds-left-header {
+  flex-shrink: 0;
+  padding: $tds-content-top var(--tds-left-pad, #{$size-gap-6}) $size-gap-4;
+  display: flex;
+  flex-direction: column;
+  gap: $size-gap-2;
+
+  &__title {
+    font-size: clamp(26px, 2.8vw, 30px);
+    font-weight: $font-weight-semibold;
+    color: var(--color-text-primary);
+    letter-spacing: -0.03em;
+    line-height: 1.12;
+    margin: 0;
+  }
+
+  &__subtitle {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    margin: 0;
+  }
+}
+
+// ── Left: search — wrapper + Search component overrides ──────────────────
+
+.tds-search-wrap {
+  flex-shrink: 0;
+  padding: 0 var(--tds-left-pad, #{$size-gap-6}) $size-gap-5;
+}
+
+// Override Search component to use xl border-radius and subtle border
+.tds-search .search__wrapper {
+  border-radius: $size-radius-xl;
+  border-color: var(--border-subtle);
+  background: color-mix(in srgb, var(--element-bg-subtle) 94%, transparent);
+  transition:
+    border-color $motion-fast $easing-standard,
+    background $motion-fast $easing-standard,
+    box-shadow $motion-fast $easing-standard;
+}
+
+.tds-search.search--focused .search__wrapper {
+  border-color: transparent;
+  background: var(--element-bg-soft);
+  box-shadow:
+    0 0 0 2px var(--color-accent-500),
+    0 12px 30px -8px color-mix(in srgb, var(--color-accent-500) 14%, transparent);
+}
+
+.tds-search.search--hovered:not(.search--focused) .search__wrapper {
+  border-color: var(--border-medium);
+  background: color-mix(in srgb, var(--element-bg-base) 90%, transparent);
+}
+
+// ── Left: dual panes (OS sessions | workspaces) ───────────────────────────
+
+// Wrapper keeps the two panes at the same horizontal inset as the search box
+.tds-left-split-wrap {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: 0 var(--tds-left-pad, #{$size-gap-6});
+}
+
+.tds-left-split {
+  height: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.tds-left-pane {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  &:first-child {
+    padding-right: $size-gap-4;
+    border-right: 1px solid var(--border-subtle);
+  }
+
+  &:last-child {
+    padding-left: $size-gap-4;
+  }
+}
+
+// ── Pane section header ───────────────────────────────────────────────────
+
+.tds-pane-head {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: $size-gap-2;
+  padding: 0 $size-gap-1 $size-gap-3;
+  margin-bottom: $size-gap-1;
+  border-bottom: 1px solid var(--border-subtle);
+
+  &__icon {
+    flex-shrink: 0;
+
+    &--dispatcher { color: var(--color-purple-500); }
+    &--ws         { color: var(--color-accent-500); }
+  }
+
+  &__title {
+    font-size: var(--font-size-2xs);
+    font-weight: $font-weight-semibold;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+    flex: 1;
+  }
+
+  &__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 16px;
+    padding: 0 5px;
+    border-radius: $size-radius-full;
+    background: var(--element-bg-medium);
+    font-size: 10px;
+    font-weight: $font-weight-semibold;
+    color: var(--color-text-muted);
+  }
+
+  &__chip {
+    height: 20px;
+    padding: 0 $size-gap-2;
+    border-radius: $size-radius-full;
+    border: 1px solid transparent;
+    background: transparent;
+    font-size: 10px;
+    font-weight: $font-weight-semibold;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: background $motion-fast $easing-standard,
+                border-color $motion-fast $easing-standard,
+                color $motion-fast $easing-standard;
+
+    &:hover {
+      border-color: var(--border-subtle);
+      color: var(--color-text-secondary);
+    }
+
+    &.is-active {
+      background: var(--color-accent-100);
+      border-color: var(--border-accent-soft);
+      color: var(--color-accent-500);
+    }
+  }
+}
+
+// ── Pane scrollable list ──────────────────────────────────────────────────
+
+.tds-pane-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-block: $size-gap-1;
+  padding-right: $size-gap-1;
+
+  &::-webkit-scrollbar { width: 3px; }
+  &::-webkit-scrollbar-thumb {
+    background: var(--border-subtle);
+    border-radius: 2px;
+  }
+  &::-webkit-scrollbar-track { background: transparent; }
+}
+
+// ── Right: rail shell — mirrors .acp-right-shell ─────────────────────────
+
+.tds-rail-shell {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-subtle);
+  border-radius: $size-radius-xl;
+  overflow: hidden;
+  background: transparent;
+  margin: $tds-content-top 0 clamp(#{$size-gap-10}, 6vh, #{$size-gap-12});
+}
+
+// ── Rail header ───────────────────────────────────────────────────────────
+
+.tds-rail-head {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: $size-gap-2;
+  padding: $size-gap-4 $size-gap-5 $size-gap-3;
+  border-bottom: 1px solid var(--border-subtle);
+
+  &__icon { flex-shrink: 0; color: var(--color-accent-500); }
+
+  &__title {
+    font-size: var(--font-size-2xs);
+    font-weight: $font-weight-semibold;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+  }
+
+  &__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 16px;
+    padding: 0 5px;
+    border-radius: $size-radius-full;
+    background: var(--element-bg-medium);
+    font-size: 10px;
+    font-weight: $font-weight-semibold;
+    color: var(--color-text-muted);
+  }
+
+  &__running {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    font-weight: $font-weight-semibold;
+    color: var(--color-accent-500);
+    padding: 2px 7px;
+    border-radius: $size-radius-full;
+    background: var(--color-accent-50);
+    border: 1px solid var(--color-accent-100);
+
+    svg { animation: tds-spin 2s linear infinite; }
+  }
+
+  &__filters {
+    display: flex;
+    align-items: center;
+    gap: $size-gap-2;
+    margin-left: auto;
+    flex-wrap: wrap;
+  }
+}
+
+// ── Rail scrollable list ──────────────────────────────────────────────────
+
+.tds-rail-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: $size-gap-2 $size-gap-3 $size-gap-5;
+
+  &::-webkit-scrollbar { width: 3px; }
+  &::-webkit-scrollbar-thumb {
+    background: var(--border-subtle);
+    border-radius: 2px;
+  }
+  &::-webkit-scrollbar-track { background: transparent; }
+}
+
+// ── Rail: Select component width constraint ───────────────────────────────
+
+.tds-rail-select {
+  width: 130px;
+  flex-shrink: 0;
+}
+
+// ── Empty state ───────────────────────────────────────────────────────────
+
+.tds-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: $size-gap-3;
+  padding: $size-gap-8 $size-gap-4;
+  color: var(--color-text-muted);
+  text-align: center;
+
+  svg { opacity: 0.18; }
+
+  p {
+    font-size: var(--font-size-sm);
+    margin: 0;
+    opacity: 0.55;
+    font-style: italic;
+  }
+
+  &--compact {
+    padding: $size-gap-5 $size-gap-2;
+    gap: $size-gap-2;
+
+    p { font-size: var(--font-size-xs); }
+  }
+}
+
+// ── Session row — mirrors .bitfun-nav-panel__inline-item in acp-sessions-area ─
+
+.tds-row {
+  display: flex;
+  align-items: center;
+  gap: $size-gap-3;
+  min-height: 40px;
+  padding: $size-gap-2 $size-gap-3;
+  border-radius: $size-radius-lg;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  transition: background $motion-fast $easing-standard;
+  margin-bottom: 1px;
+  outline: none;
+
+  &:hover {
+    background: var(--element-bg-soft);
+    .tds-row__arrow { opacity: 1; }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--border-accent-soft);
+    outline-offset: -2px;
+  }
+
+  &.is-highlighted {
+    background: color-mix(in srgb, var(--color-accent-100) 60%, transparent);
+  }
+
+  &.is-running .tds-row__icon--spin {
+    animation: tds-spin 1.2s linear infinite;
+  }
+}
+
+.tds-row__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+
+  &--running { background: var(--color-accent-500); box-shadow: 0 0 0 2px var(--color-accent-100); }
+  &--active  { background: #10b981; box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.14); }
+  &--error   { background: var(--color-error); }
+  &--idle    { background: var(--border-medium); }
+}
+
+.tds-row__icon-wrap {
+  width: 28px;
+  height: 28px;
+  border-radius: $size-radius-sm;
+  background: var(--element-bg-medium);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.tds-row__icon {
+  &--code       { color: var(--color-accent-500); }
+  &--cowork     { color: #10b981; }
+  &--claw       { color: #f59e0b; }
+  &--dispatcher { color: var(--color-purple-500); }
+  &--spin       { color: var(--color-accent-500); }
+}
+
+.tds-row__body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tds-row__title {
+  font-size: var(--font-size-sm);
+  font-weight: $font-weight-medium;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tds-row__meta {
+  display: flex;
+  align-items: center;
+  gap: $size-gap-1;
+  flex-wrap: wrap;
+}
+
+.tds-row__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 5px;
+  border-radius: $size-radius-full;
+  font-size: 10px;
+  font-weight: $font-weight-semibold;
+
+  &--code   { background: var(--color-accent-100);          color: var(--color-accent-500); }
+  &--cowork { background: rgba(16, 185, 129, 0.10);         color: #10b981; }
+  &--claw   { background: rgba(245, 158, 11, 0.10);         color: #f59e0b; }
+  &--ws {
+    background: var(--element-bg-medium);
+    color: var(--color-text-muted);
+    font-weight: $font-weight-medium;
+    max-width: 110px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.tds-row__meta-dot {
+  font-size: 10px;
+  color: var(--border-medium);
+}
+
+.tds-row__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  color: var(--color-text-muted);
+}
+
+.tds-row__arrow {
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+  opacity: 0;
+  transition: opacity $motion-fast $easing-standard;
+}
+
+// ── Workspace row (opened workspaces pane) ────────────────────────────────
+
+.tds-ws-row {
+  display: flex;
+  align-items: center;
+  gap: $size-gap-3;
+  min-height: 40px;
+  padding: $size-gap-2 $size-gap-3;
+  border-radius: $size-radius-lg;
+  cursor: pointer;
+  background: transparent;
+  outline: none;
+  transition: background $motion-fast $easing-standard;
+  margin-bottom: 1px;
+
+  &:hover {
+    background: var(--element-bg-soft);
+    .tds-ws-row__arrow { opacity: 1; }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--border-accent-soft);
+    outline-offset: -2px;
+  }
+
+  &.is-filter {
+    background: color-mix(in srgb, var(--color-accent-100) 60%, transparent);
+  }
+}
+
+.tds-ws-row__icon-wrap {
+  width: 28px;
+  height: 28px;
+  border-radius: $size-radius-sm;
+  background: var(--element-bg-medium);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.tds-ws-row__icon { color: var(--color-accent-500); }
+
+.tds-ws-row__body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tds-ws-row__title {
+  font-size: var(--font-size-sm);
+  font-weight: $font-weight-medium;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tds-ws-row__meta {
+  display: flex;
+  align-items: center;
+  gap: $size-gap-1;
+}
+
+.tds-ws-row__badge {
+  font-size: 10px;
+  font-weight: $font-weight-semibold;
+  padding: 0 5px;
+  border-radius: $size-radius-full;
+  background: var(--color-accent-100);
+  color: var(--color-accent-500);
+}
+
+.tds-ws-row__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  color: var(--color-text-muted);
+}
+
+.tds-ws-row__arrow {
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+  opacity: 0;
+  transition: opacity $motion-fast $easing-standard;
+}
+
+.tds-ws-row__close {
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity $motion-fast $easing-standard;
+
+  .tds-ws-row:hover & {
+    opacity: 1;
+  }
+}
+
+// ── Responsive ────────────────────────────────────────────────────────────
+
+@media (max-width: 860px) {
+  .tds-layout {
+    flex-direction: column;
+    gap: $size-gap-5;
+
+    &__left  { flex: none; max-height: 55vh; }
+    &__right { flex: 1; min-height: 200px; }
+  }
+
+  .tds-rail-shell {
+    margin-top: 0;
+    margin-bottom: $size-gap-4;
+  }
+}
+
+// ── Reduced motion ────────────────────────────────────────────────────────
+
+@media (prefers-reduced-motion: reduce) {
+  .tds { animation: none; }
+  .tds-row__icon--spin,
+  .tds-rail-head__running svg { animation: none; }
+}

--- a/src/web-ui/src/app/scenes/task-detail/TaskDetailScene.tsx
+++ b/src/web-ui/src/app/scenes/task-detail/TaskDetailScene.tsx
@@ -1,0 +1,545 @@
+/**
+ * TaskDetailScene — Task Management Center.
+ *
+ * Assistant-style split: left (majority) = search + OS sessions | opened workspaces;
+ * right rail = execution sessions for opened workspaces.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Code2,
+  FolderOpen,
+  FolderPlus,
+  LayoutDashboard,
+  ListTodo,
+  Loader2,
+  MessageSquare,
+  Sparkles,
+  ArrowRight,
+  Clock,
+  Radio,
+  X,
+} from 'lucide-react';
+import { Search, FilterPill, FilterPillGroup, Select, IconButton } from '@/component-library';
+import type { SelectOption } from '@/component-library';
+import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
+import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
+import type { WorkspaceInfo } from '@/shared/types';
+import {
+  findOpenedWorkspaceForSession,
+  compareSessionsForDisplay,
+} from '@/flow_chat/utils/sessionOrdering';
+import { openMainSession } from '@/flow_chat/services/openBtwSession';
+import { useSessionCapsuleStore } from '../../stores/sessionCapsuleStore';
+import { useOverlayStore } from '../../stores/overlayStore';
+import { stateMachineManager } from '@/flow_chat/state-machine';
+import { SessionExecutionState } from '@/flow_chat/state-machine/types';
+import type { FlowChatState, Session } from '@/flow_chat/types/flow-chat';
+import { createLogger } from '@/shared/utils/logger';
+import './TaskDetailScene.scss';
+
+const log = createLogger('TaskDetailScene');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const getSessionTitle = (s: Session): string =>
+  s.title?.trim() || `Task ${s.sessionId.slice(0, 6)}`;
+
+function formatRelativeTime(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return '刚刚';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`;
+  if (diff < 7 * 86_400_000) return `${Math.floor(diff / 86_400_000)} 天前`;
+  return new Date(ts).toLocaleDateString('zh-CN', { month: 'short', day: 'numeric' });
+}
+
+type ExecMode = 'code' | 'cowork' | 'claw';
+
+function resolveExecMode(s: Session): ExecMode {
+  const m = s.mode?.toLowerCase();
+  if (m === 'cowork') return 'cowork';
+  if (m === 'claw') return 'claw';
+  return 'code';
+}
+
+const MODE_LABELS: Record<ExecMode, string> = {
+  code: 'Code',
+  cowork: 'Cowork',
+  claw: 'Claw',
+};
+
+function ModeIcon({ mode, size = 13, className }: { mode: ExecMode; size?: number; className?: string }) {
+  switch (mode) {
+    case 'cowork': return <ListTodo size={size} className={className} />;
+    case 'claw': return <Sparkles size={size} className={className} />;
+    default: return <Code2 size={size} className={className} />;
+  }
+}
+
+type StatusVariant = 'running' | 'active' | 'error' | 'idle';
+
+function getStatusVariant(s: Session, runningIds: Set<string>): StatusVariant {
+  if (runningIds.has(s.sessionId)) return 'running';
+  if (s.status === 'error') return 'error';
+  if (s.status === 'active') return 'active';
+  return 'idle';
+}
+
+// ── Session row ───────────────────────────────────────────────────────────────
+
+interface SessionRowProps {
+  session: Session;
+  isHighlighted: boolean;
+  statusVariant: StatusVariant;
+  showMode?: boolean;
+  workspaceName?: string;
+  onOpen: (s: Session) => void;
+}
+
+const SessionRow: React.FC<SessionRowProps> = ({
+  session, isHighlighted, statusVariant, showMode = true, workspaceName, onOpen,
+}) => {
+  const isRunning = statusVariant === 'running';
+  const isDispatcher = session.mode?.toLowerCase() === 'dispatcher';
+  const mode = resolveExecMode(session);
+
+  return (
+    <div
+      className={[
+        'tds-row',
+        isHighlighted && 'is-highlighted',
+        isRunning && 'is-running',
+      ].filter(Boolean).join(' ')}
+      role="button"
+      tabIndex={0}
+      onClick={() => onOpen(session)}
+      onKeyDown={e => e.key === 'Enter' && onOpen(session)}
+    >
+      <span className={`tds-row__dot tds-row__dot--${statusVariant}`} />
+
+      <span className="tds-row__icon-wrap">
+        {isRunning ? (
+          <Loader2 size={13} className="tds-row__icon tds-row__icon--spin" />
+        ) : isDispatcher ? (
+          <LayoutDashboard size={13} className="tds-row__icon tds-row__icon--dispatcher" />
+        ) : (
+          <ModeIcon mode={mode} size={13} className={`tds-row__icon tds-row__icon--${mode}`} />
+        )}
+      </span>
+
+      <span className="tds-row__body">
+        <span className="tds-row__title">{getSessionTitle(session)}</span>
+        <span className="tds-row__meta">
+          {showMode && !isDispatcher && (
+            <span className={`tds-row__badge tds-row__badge--${mode}`}>{MODE_LABELS[mode]}</span>
+          )}
+          {workspaceName && (
+            <span className="tds-row__badge tds-row__badge--ws">
+              <FolderOpen size={9} />
+              {workspaceName}
+            </span>
+          )}
+          <span className="tds-row__meta-dot">·</span>
+          <span className="tds-row__meta-item"><Clock size={9} />{formatRelativeTime(session.lastActiveAt)}</span>
+          <span className="tds-row__meta-dot">·</span>
+          <span className="tds-row__meta-item"><MessageSquare size={9} />{session.dialogTurns.length}</span>
+        </span>
+      </span>
+
+      <ArrowRight size={12} className="tds-row__arrow" />
+    </div>
+  );
+};
+
+// ── Mode filter type ──────────────────────────────────────────────────────────
+
+type ModeFilter = 'all' | ExecMode;
+
+const MODE_CHIPS: Array<{ id: ModeFilter; label: string }> = [
+  { id: 'all', label: '全部' },
+  { id: 'code', label: 'Code' },
+  { id: 'cowork', label: 'Cowork' },
+  { id: 'claw', label: 'Claw' },
+];
+
+function normalizeQuery(q: string): string {
+  return q.trim().toLowerCase();
+}
+
+function matchesQuery(haystack: string, q: string): boolean {
+  if (!q) return true;
+  return haystack.toLowerCase().includes(q);
+}
+
+// ── Workspace row (opened workspaces pane) ───────────────────────────────────
+
+interface WorkspaceRowProps {
+  workspace: WorkspaceInfo;
+  sessionCount: number;
+  isActiveWorkspace: boolean;
+  isFilterSelected: boolean;
+  onSelect: (workspaceId: string) => void;
+  onClose: (e: React.MouseEvent, workspaceId: string) => void;
+}
+
+const WorkspaceRow: React.FC<WorkspaceRowProps> = ({
+  workspace,
+  sessionCount,
+  isActiveWorkspace,
+  isFilterSelected,
+  onSelect,
+  onClose,
+}) => (
+  <div
+    className={[
+      'tds-ws-row',
+      isFilterSelected && 'is-filter',
+      isActiveWorkspace && 'is-current',
+    ].filter(Boolean).join(' ')}
+    role="button"
+    tabIndex={0}
+    onClick={() => onSelect(workspace.id)}
+    onKeyDown={e => e.key === 'Enter' && onSelect(workspace.id)}
+  >
+    <span className="tds-ws-row__icon-wrap">
+      <FolderOpen size={13} className="tds-ws-row__icon" />
+    </span>
+    <span className="tds-ws-row__body">
+      <span className="tds-ws-row__title">{workspace.name}</span>
+      <span className="tds-ws-row__meta">
+        {isActiveWorkspace && <span className="tds-ws-row__badge">当前</span>}
+        <span className="tds-ws-row__meta-item">
+          <MessageSquare size={9} />
+          {sessionCount}
+        </span>
+      </span>
+    </span>
+    <IconButton
+      size="xs"
+      variant="ghost"
+      className="tds-ws-row__close"
+      tooltip="关闭工作区"
+      onClick={e => onClose(e, workspace.id)}
+      aria-label="关闭工作区"
+    >
+      <X size={11} />
+    </IconButton>
+  </div>
+);
+
+// ── Main Scene ────────────────────────────────────────────────────────────────
+
+const TaskDetailScene: React.FC = () => {
+  const taskDetailSessionId = useSessionCapsuleStore(s => s.taskDetailSessionId);
+  const closeTaskDetail = useSessionCapsuleStore(s => s.closeTaskDetail);
+  const closeOverlay = useOverlayStore(s => s.closeOverlay);
+
+  const { openedWorkspacesList, setActiveWorkspace, currentWorkspace, openWorkspace, closeWorkspaceById } = useWorkspaceContext();
+
+  const [flowChatState, setFlowChatState] = useState<FlowChatState>(() => flowChatStore.getState());
+  const [runningIds, setRunningIds] = useState<Set<string>>(new Set());
+  const [wsFilter, setWsFilter] = useState<string>('all');
+  const [modeFilter, setModeFilter] = useState<ModeFilter>('all');
+  const [listQuery, setListQuery] = useState('');
+
+  useEffect(() => {
+    setFlowChatState(flowChatStore.getState());
+    return flowChatStore.subscribe(s => setFlowChatState(s));
+  }, []);
+
+  useEffect(() => {
+    const update = () => {
+      const running = new Set<string>();
+      for (const s of flowChatState.sessions.values()) {
+        const m = stateMachineManager.get(s.sessionId);
+        if (m && (
+          m.getCurrentState() === SessionExecutionState.PROCESSING ||
+          m.getCurrentState() === SessionExecutionState.FINISHING
+        )) running.add(s.sessionId);
+      }
+      setRunningIds(running);
+    };
+    update();
+    return stateMachineManager.subscribeGlobal(update);
+  }, [flowChatState.sessions]);
+
+  // Dispatcher (Agentic OS) sessions — not tied to a project workspace
+  const qNorm = useMemo(() => normalizeQuery(listQuery), [listQuery]);
+
+  const dispatcherSessions = useMemo(
+    () => Array.from(flowChatState.sessions.values())
+      .filter(s => s.mode?.toLowerCase() === 'dispatcher')
+      .filter(s => matchesQuery(getSessionTitle(s), qNorm))
+      .sort(compareSessionsForDisplay),
+    [flowChatState.sessions, qNorm]
+  );
+
+  // Execution sessions tied to an opened workspace only
+  const execSessions = useMemo(() => {
+    return Array.from(flowChatState.sessions.values())
+      .filter(s => s.mode?.toLowerCase() !== 'dispatcher')
+      .sort(compareSessionsForDisplay)
+      .map(session => {
+        const ws = findOpenedWorkspaceForSession(session, openedWorkspacesList);
+        return { session, workspace: ws ?? null };
+      })
+      .filter((row): row is { session: Session; workspace: WorkspaceInfo } => row.workspace !== null);
+  }, [flowChatState.sessions, openedWorkspacesList]);
+
+  const sessionCountByWorkspaceId = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const { workspace } of execSessions) {
+      m.set(workspace.id, (m.get(workspace.id) ?? 0) + 1);
+    }
+    return m;
+  }, [execSessions]);
+
+  const filteredWorkspaces = useMemo(() => {
+    return openedWorkspacesList.filter(ws =>
+      matchesQuery(ws.name, qNorm) || matchesQuery(ws.rootPath ?? '', qNorm)
+    );
+  }, [openedWorkspacesList, qNorm]);
+
+  const wsSelectOptions = useMemo<SelectOption[]>(
+    () => [
+      { label: '全部工作区', value: 'all' },
+      ...openedWorkspacesList.map(ws => ({ label: ws.name, value: ws.id })),
+    ],
+    [openedWorkspacesList]
+  );
+
+  const showWorkspaceLabelsOnSessions = openedWorkspacesList.length > 1;
+
+  // Filtered exec sessions (opened workspaces only)
+  const filteredExec = useMemo(() => {
+    return execSessions.filter(({ session, workspace }) => {
+      if (modeFilter !== 'all' && resolveExecMode(session) !== modeFilter) return false;
+      if (wsFilter !== 'all' && workspace.id !== wsFilter) return false;
+      if (
+        qNorm &&
+        !matchesQuery(getSessionTitle(session), qNorm) &&
+        !matchesQuery(workspace.name, qNorm)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [execSessions, modeFilter, wsFilter, qNorm]);
+
+  const runningExecCount = useMemo(
+    () => filteredExec.filter(({ session }) => runningIds.has(session.sessionId)).length,
+    [filteredExec, runningIds]
+  );
+
+  const handleWorkspacePaneSelect = useCallback((workspaceId: string) => {
+    setWsFilter(prev => (prev === workspaceId ? 'all' : workspaceId));
+  }, []);
+
+  const handleOpenNewWorkspace = useCallback(async () => {
+    try {
+      const { open } = await import('@tauri-apps/plugin-dialog');
+      const selected = await open({ directory: true, multiple: false });
+      if (selected && typeof selected === 'string') {
+        await openWorkspace(selected);
+      }
+    } catch (e) {
+      log.error('Failed to open workspace', e);
+    }
+  }, [openWorkspace]);
+
+  const handleCloseWorkspace = useCallback(async (e: React.MouseEvent, workspaceId: string) => {
+    e.stopPropagation();
+    try {
+      if (wsFilter === workspaceId) setWsFilter('all');
+      await closeWorkspaceById(workspaceId);
+    } catch (e) {
+      log.error('Failed to close workspace', e);
+    }
+  }, [closeWorkspaceById, wsFilter]);
+
+  const handleOpenSession = useCallback(async (session: Session) => {
+    try {
+      const ws = findOpenedWorkspaceForSession(session, openedWorkspacesList);
+      const mustActivate = ws && ws.id !== currentWorkspace?.id;
+      await openMainSession(session.sessionId, {
+        workspaceId: ws?.id,
+        activateWorkspace: mustActivate ? setActiveWorkspace : undefined,
+      });
+      window.dispatchEvent(
+        new CustomEvent('flowchat:switch-session', { detail: { sessionId: session.sessionId } })
+      );
+      closeTaskDetail();
+      closeOverlay();
+    } catch (e) {
+      log.error('Failed to open session', e);
+    }
+  }, [openedWorkspacesList, currentWorkspace?.id, setActiveWorkspace, closeTaskDetail, closeOverlay]);
+
+  return (
+    <div className="tds">
+      <div className="tds-layout">
+
+        {/* ── Left: title + search box + dual panes ───────────────────── */}
+        <div className="tds-layout__left">
+
+          <div className="tds-left-header">
+            <h1 className="tds-left-header__title">任务中心</h1>
+            <p className="tds-left-header__subtitle">管理所有 Agentic OS 会话与已打开的工作区</p>
+          </div>
+
+          <div className="tds-search-wrap">
+            <Search
+              className="tds-search"
+              size="large"
+              value={listQuery}
+              onChange={setListQuery}
+              placeholder="搜索会话或工作区…"
+              clearable
+            />
+          </div>
+
+          <div className="tds-left-split-wrap">
+          <div className="tds-left-split">
+            {/* Agentic OS sessions */}
+            <div className="tds-left-pane">
+              <div className="tds-pane-head">
+                <LayoutDashboard size={12} className="tds-pane-head__icon tds-pane-head__icon--dispatcher" />
+                <span className="tds-pane-head__title">Agentic OS 会话</span>
+                <span className="tds-pane-head__count">{dispatcherSessions.length}</span>
+              </div>
+              <div className="tds-pane-list">
+                {dispatcherSessions.length === 0 ? (
+                  <div className="tds-empty tds-empty--compact">
+                    <LayoutDashboard size={26} />
+                    <p>{qNorm ? '无匹配的 OS 会话' : '暂无 Agentic OS 会话'}</p>
+                  </div>
+                ) : (
+                  dispatcherSessions.map(s => (
+                    <SessionRow
+                      key={s.sessionId}
+                      session={s}
+                      isHighlighted={s.sessionId === taskDetailSessionId}
+                      statusVariant={getStatusVariant(s, runningIds)}
+                      showMode={false}
+                      onOpen={handleOpenSession}
+                    />
+                  ))
+                )}
+              </div>
+            </div>
+
+            {/* Opened workspaces */}
+            <div className="tds-left-pane">
+              <div className="tds-pane-head">
+                <FolderOpen size={12} className="tds-pane-head__icon tds-pane-head__icon--ws" />
+                <span className="tds-pane-head__title">已打开工作区</span>
+                <span className="tds-pane-head__count">{filteredWorkspaces.length}</span>
+                <FilterPill
+                  label="全部"
+                  active={wsFilter === 'all'}
+                  onClick={() => setWsFilter('all')}
+                  className="tds-pane-head__chip"
+                />
+                <IconButton
+                  size="xs"
+                  variant="ghost"
+                  tooltip="打开工作区"
+                  onClick={handleOpenNewWorkspace}
+                  aria-label="打开工作区"
+                >
+                  <FolderPlus size={12} />
+                </IconButton>
+              </div>
+              <div className="tds-pane-list">
+                {filteredWorkspaces.length === 0 ? (
+                  <div className="tds-empty tds-empty--compact">
+                    <FolderOpen size={26} />
+                    <p>{qNorm ? '无匹配的工作区' : '暂无已打开工作区'}</p>
+                  </div>
+                ) : (
+                  filteredWorkspaces.map(ws => (
+                  <WorkspaceRow
+                    key={ws.id}
+                    workspace={ws}
+                    sessionCount={sessionCountByWorkspaceId.get(ws.id) ?? 0}
+                    isActiveWorkspace={currentWorkspace?.id === ws.id}
+                    isFilterSelected={wsFilter === ws.id}
+                    onSelect={handleWorkspacePaneSelect}
+                    onClose={handleCloseWorkspace}
+                  />
+                  ))
+                )}
+              </div>
+            </div>
+          </div>
+          </div>
+        </div>
+
+        {/* ── Right rail: workspace execution sessions ─────────────────── */}
+        <div className="tds-layout__right">
+          <div className="tds-rail-shell">
+            <div className="tds-rail-head">
+              <Code2 size={13} className="tds-rail-head__icon" />
+              <span className="tds-rail-head__title">工作区会话</span>
+              <span className="tds-rail-head__count">{filteredExec.length}</span>
+
+              {runningExecCount > 0 && (
+                <span className="tds-rail-head__running">
+                  <Radio size={9} />
+                  {runningExecCount} 运行中
+                </span>
+              )}
+
+              <div className="tds-rail-head__filters">
+                {showWorkspaceLabelsOnSessions && (
+                  <Select
+                    className="tds-rail-select"
+                    size="small"
+                    options={wsSelectOptions}
+                    value={wsFilter}
+                    onChange={v => setWsFilter(String(v))}
+                  />
+                )}
+                <FilterPillGroup>
+                  {MODE_CHIPS.map(chip => (
+                    <FilterPill
+                      key={chip.id}
+                      label={chip.label}
+                      active={modeFilter === chip.id}
+                      onClick={() => setModeFilter(chip.id)}
+                    />
+                  ))}
+                </FilterPillGroup>
+              </div>
+            </div>
+
+            <div className="tds-rail-list">
+              {filteredExec.length === 0 ? (
+                <div className="tds-empty">
+                  <Code2 size={32} />
+                  <p>{execSessions.length === 0 ? '暂无工作区会话' : '无匹配的会话'}</p>
+                </div>
+              ) : (
+                filteredExec.map(({ session, workspace }) => (
+                  <SessionRow
+                    key={session.sessionId}
+                    session={session}
+                    isHighlighted={session.sessionId === taskDetailSessionId}
+                    statusVariant={getStatusVariant(session, runningIds)}
+                    showMode
+                    workspaceName={showWorkspaceLabelsOnSessions ? workspace.name : undefined}
+                    onOpen={handleOpenSession}
+                  />
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+};
+
+export default TaskDetailScene;

--- a/src/web-ui/src/app/stores/headerStore.ts
+++ b/src/web-ui/src/app/stores/headerStore.ts
@@ -20,6 +20,8 @@ export interface SessionHeaderContext {
   mode: string;
   /** Workspace root path shown next to the mode label. */
   workspacePath?: string;
+  /** Resolved display name (same as sidebar), not the raw path basename. */
+  workspaceDisplayName?: string;
   /** Assistant workspace used when creating a new Dispatcher session. */
   assistantWorkspace?: AssistantWorkspaceRef | null;
 }

--- a/src/web-ui/src/app/stores/sessionCapsuleStore.ts
+++ b/src/web-ui/src/app/stores/sessionCapsuleStore.ts
@@ -1,7 +1,9 @@
 /**
- * sessionCapsuleStore — controls the centered session-list dialog.
+ * sessionCapsuleStore — controls the centered session-list dialog, task detail dialog,
+ * and the left-side floating task management panel.
  *
- * UnifiedTopBar calls openSessionListDialog; SessionListDialog reads the state.
+ * UnifiedTopBar calls openSessionListDialog / toggleTaskPanel;
+ * SessionListDialog and SessionCapsule read/write this state.
  */
 
 import { create } from 'zustand';
@@ -10,10 +12,29 @@ interface SessionCapsuleStore {
   sessionListDialogOpen: boolean;
   openSessionListDialog: () => void;
   closeSessionListDialog: () => void;
+
+  taskDetailSessionId: string | null;
+  openTaskDetail: (sessionId: string) => void;
+  closeTaskDetail: () => void;
+
+  /** Whether the left-side floating task management panel is open. */
+  taskPanelOpen: boolean;
+  openTaskPanel: () => void;
+  closeTaskPanel: () => void;
+  toggleTaskPanel: () => void;
 }
 
 export const useSessionCapsuleStore = create<SessionCapsuleStore>((set) => ({
   sessionListDialogOpen: false,
   openSessionListDialog: () => set({ sessionListDialogOpen: true }),
   closeSessionListDialog: () => set({ sessionListDialogOpen: false }),
+
+  taskDetailSessionId: null,
+  openTaskDetail: (sessionId: string) => set({ taskDetailSessionId: sessionId }),
+  closeTaskDetail: () => set({ taskDetailSessionId: null }),
+
+  taskPanelOpen: false,
+  openTaskPanel: () => set({ taskPanelOpen: true }),
+  closeTaskPanel: () => set({ taskPanelOpen: false }),
+  toggleTaskPanel: () => set((s) => ({ taskPanelOpen: !s.taskPanelOpen })),
 }));

--- a/src/web-ui/src/flow_chat/components/WelcomePanel.css
+++ b/src/web-ui/src/flow_chat/components/WelcomePanel.css
@@ -93,6 +93,25 @@
   letter-spacing: -0.02em;
 }
 
+/* Agentic OS (dispatcher): Orbit icon (larger than nav footer for heading scale) */
+.welcome-panel__heading--dispatcher {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.welcome-panel__dispatcher-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+}
+
+.welcome-panel__dispatcher-icon svg {
+  display: block;
+}
+
 .welcome-panel__tagline {
   margin: 6px 0 0;
   font-size: 15px;

--- a/src/web-ui/src/flow_chat/components/WelcomePanel.tsx
+++ b/src/web-ui/src/flow_chat/components/WelcomePanel.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FolderOpen, ChevronDown, Check } from 'lucide-react';
+import { FolderOpen, ChevronDown, Check, Orbit } from 'lucide-react';
 import { createLogger } from '@/shared/utils/logger';
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
 import type { WorkspaceInfo } from '@/shared/types';
@@ -114,11 +114,22 @@ export const WelcomePanel: React.FC<WelcomePanelProps> = ({
               </div>
             )}
             <div className="welcome-panel__greeting-text">
-              <h1 className="welcome-panel__heading">
-                {isDispatcherSession
-                  ? greeting.title
-                  : <>{greeting.title}，{t(aiPartnerKey)}{isClawSession && assistantName ? `，${assistantName}` : ''}</>
-                }
+              <h1
+                className={`welcome-panel__heading${isDispatcherSession ? ' welcome-panel__heading--dispatcher' : ''}`}
+              >
+                {isDispatcherSession ? (
+                  <>
+                    <span className="welcome-panel__dispatcher-icon" aria-hidden>
+                      <Orbit size={30} strokeWidth={2} />
+                    </span>
+                    {greeting.title}
+                  </>
+                ) : (
+                  <>
+                    {greeting.title}，{t(aiPartnerKey)}
+                    {isClawSession && assistantName ? `，${assistantName}` : ''}
+                  </>
+                )}
               </h1>
               <p className="welcome-panel__tagline">{tagline}</p>
             </div>

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -25,7 +25,8 @@ import { useFlowChatSearch } from './useFlowChatSearch';
 import { useVirtualItems, useActiveSession, useVisibleTurnInfo, type VisibleTurnInfo } from '../../store/modernFlowChatStore';
 import type { FlowChatConfig } from '../../types/flow-chat';
 import type { LineRange } from '@/component-library';
-import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
+import { getWorkspaceDisplayName, useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
+import { fallbackWorkspaceFolderLabel, resolveWorkspaceForSession } from '../../utils/sessionOrdering';
 import './ModernFlowChatContainer.scss';
 
 interface ModernFlowChatContainerProps {
@@ -59,7 +60,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const virtualListRef = useRef<VirtualMessageListRef>(null);
   const chatScopeRef = useRef<HTMLDivElement>(null);
   const turnListSidebarRef = useRef<HTMLElement | null>(null);
-  const { workspacePath, assistantWorkspacesList } = useWorkspaceContext();
+  const { workspacePath, assistantWorkspacesList, openedWorkspacesList } = useWorkspaceContext();
   const defaultAssistantWorkspace = useMemo(
     () => assistantWorkspacesList.find(w => !w.assistantId) ?? assistantWorkspacesList[0] ?? null,
     [assistantWorkspacesList]
@@ -270,6 +271,16 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   // Publish session context to UnifiedTopBar via headerStore so the unified
   // back button and title can be rendered there.
   const { setSessionContext, clearSessionContext } = useHeaderStore.getState();
+  const workspaceDisplayName = useMemo(() => {
+    if (!activeSession?.workspacePath?.trim()) return '';
+    const ws = resolveWorkspaceForSession(activeSession, openedWorkspacesList);
+    if (ws) {
+      const label = getWorkspaceDisplayName(ws).trim();
+      if (label) return label;
+    }
+    return fallbackWorkspaceFolderLabel(activeSession.workspacePath);
+  }, [activeSession, openedWorkspacesList]);
+
   useEffect(() => {
     if (!activeSession) {
       clearSessionContext();
@@ -278,11 +289,12 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     setSessionContext({
       mode: activeSession.mode ?? '',
       workspacePath: activeSession.workspacePath,
+      workspaceDisplayName,
       assistantWorkspace: defaultAssistantWorkspace
         ? { id: defaultAssistantWorkspace.id, rootPath: defaultAssistantWorkspace.rootPath }
         : null,
     });
-  }, [activeSession, defaultAssistantWorkspace, setSessionContext, clearSessionContext]);
+  }, [activeSession, defaultAssistantWorkspace, workspaceDisplayName, setSessionContext, clearSessionContext]);
 
   useShortcut(
     'chat.stopGeneration',

--- a/src/web-ui/src/flow_chat/utils/sessionOrdering.ts
+++ b/src/web-ui/src/flow_chat/utils/sessionOrdering.ts
@@ -3,6 +3,38 @@ import type { WorkspaceInfo } from '@/shared/types';
 import { isRemoteWorkspace } from '@/shared/types';
 import { isSamePath, normalizeRemoteWorkspacePath } from '@/shared/utils/pathUtils';
 
+/**
+ * Prefer stable `workspaceId` when matching opened workspaces (path strings can differ slightly).
+ */
+export function resolveWorkspaceForSession(
+  session: Pick<Session, 'workspaceId' | 'workspacePath' | 'remoteConnectionId' | 'remoteSshHost'> | undefined,
+  openedWorkspaces: WorkspaceInfo[]
+): WorkspaceInfo | undefined {
+  if (!session) return undefined;
+  const wid = session.workspaceId?.trim();
+  if (wid) {
+    const byId = openedWorkspaces.find(w => w.id === wid);
+    if (byId) return byId;
+  }
+  return findOpenedWorkspaceForSession(session, openedWorkspaces);
+}
+
+/**
+ * Short folder label when `WorkspaceInfo` is not available. Assistant roots often end with
+ * `.../personal_assistant/workspace` or legacy `.../.bitfun/workspace` — using only the last
+ * segment yields the meaningless word "workspace".
+ */
+export function fallbackWorkspaceFolderLabel(workspacePath: string): string {
+  const norm = workspacePath.replace(/\\/g, '/').replace(/\/+$/, '');
+  const parts = norm.split('/').filter(Boolean);
+  if (parts.length === 0) return '';
+  const last = parts[parts.length - 1];
+  if (last.toLowerCase() === 'workspace' && parts.length >= 2) {
+    return parts[parts.length - 2] || last;
+  }
+  return last;
+}
+
 /** Extract `host` from our saved form `ssh-{user}@{host}:{port}` (used when metadata omits `remoteSshHost`). */
 function hostFromSshConnectionId(connectionId: string): string | null {
   const t = connectionId.trim();

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -42,6 +42,7 @@
     "about": "About",
     "openMenu": "Open Menu",
     "openSessionsList": "Open task list",
+    "openTaskManagement": "Task Management",
     "closeMenu": "Close Menu",
     "selectProjectDirectory": "Select a project directory to open",
     "configCenter": "Settings",
@@ -841,7 +842,8 @@
     "mermaidEditor": "Mermaid",
     "assistant": "Assistant",
     "shell": "Shell",
-    "panelView": "Panel View"
+    "panelView": "Panel View",
+    "taskDetail": "Task Manager"
   },
   "overlay": {
     "returnToAgenticOS": "Return to Agentic OS"

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -42,6 +42,7 @@
     "about": "关于",
     "openMenu": "打开菜单",
     "openSessionsList": "打开任务列表",
+    "openTaskManagement": "任务管理",
     "closeMenu": "关闭菜单",
     "selectProjectDirectory": "选择要打开的工作区目录",
     "configCenter": "配置中心",
@@ -841,7 +842,8 @@
     "mermaidEditor": "Mermaid 图表",
     "assistant": "助理",
     "shell": "Shell",
-    "panelView": "面板视图"
+    "panelView": "面板视图",
+    "taskDetail": "任务管理"
   },
   "overlay": {
     "returnToAgenticOS": "返回 Agentic OS"


### PR DESCRIPTION
## Summary
This PR adds the Task Management floating panel and Task Detail scene (task center with session/workspace browsing), plus related session list, welcome panel, and ordering improvements.

## Changes
- New \TaskManagementPanel\ (portal) and \TaskDetailScene\ overlay integration
- Session list dialog styling; session capsule and header store updates
- \sessionOrdering\ helpers; Welcome panel and ModernFlowChatContainer tweaks
- i18n strings (en-US, zh-CN)

## Testing
- [ ] Manual smoke test: open task panel from header, ESC/backdrop close, navigate sessions