### PR TITLE
feat(web-ui): polish dispatcher session UI and compact message rows

### DIFF
--- a/src/web-ui/src/app/overlay/AgenticOSWorkspace.scss
+++ b/src/web-ui/src/app/overlay/AgenticOSWorkspace.scss
@@ -34,6 +34,14 @@
     box-shadow: 0 10px 32px -8px rgba(0, 0, 0, 0.55);
   }
 
+  &--dispatcher {
+    border-radius: 0;
+    border-width: 0;
+    border-color: transparent;
+    box-shadow: none;
+    background: var(--color-bg-primary);
+  }
+
   // ── Content area ───────────────────────────────────────
 
   &__content {

--- a/src/web-ui/src/app/overlay/AgenticOSWorkspace.tsx
+++ b/src/web-ui/src/app/overlay/AgenticOSWorkspace.tsx
@@ -14,6 +14,7 @@
 
 import React from 'react';
 import { useOverlayStore } from '../stores/overlayStore';
+import { useHeaderStore } from '../stores/headerStore';
 import { useCurrentWorkspace } from '../../infrastructure/contexts/WorkspaceContext';
 import { useDialogCompletionNotify } from '../hooks/useDialogCompletionNotify';
 import SessionScene from '../scenes/session/SessionScene';
@@ -32,13 +33,17 @@ const AgenticOSWorkspace: React.FC<AgenticOSWorkspaceProps> = ({
   isEntering = false,
 }) => {
   const activeOverlay = useOverlayStore(s => s.activeOverlay);
+  const sessionMode = useHeaderStore((s) => s.sessionContext?.mode);
   const { workspace: currentWorkspace } = useCurrentWorkspace();
   const hasOverlay = activeOverlay !== null;
+  const isDispatcherSession = sessionMode?.toLowerCase() === 'dispatcher';
 
   useDialogCompletionNotify();
 
   return (
-    <div className="agentic-os-workspace">
+    <div
+      className={`agentic-os-workspace${isDispatcherSession ? ' agentic-os-workspace--dispatcher' : ''}`}
+    >
       {/* Content area — single slot visible at a time, no stacking */}
       <div className="agentic-os-workspace__content">
 

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.scss
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.scss
@@ -49,3 +49,69 @@
     border-top: 1px solid var(--color-border, #3a3a3a);
   }
 }
+
+.modern-flowchat-container--dispatcher {
+  .flowchat-turn-sidebar {
+    border-left: none;
+    background: transparent;
+
+    &--open {
+      border-left: none;
+    }
+
+    &__header {
+      border-bottom: none;
+      background: transparent;
+    }
+  }
+
+  .flowchat-header {
+    background: transparent;
+  }
+
+  .session-files-badge__popover {
+    background: var(--color-bg-primary);
+    border: none;
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+
+    &::before {
+      content: none;
+    }
+  }
+
+  .session-file-modifications-bar {
+    background: transparent;
+    border-top: none;
+    border-bottom: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  .bitfun-chat-input__box {
+    background: var(--color-bg-primary);
+    border: none;
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+
+    &:focus-within,
+    &:hover {
+      background: var(--color-bg-primary);
+      border: none;
+      box-shadow: none;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+  }
+
+  .bitfun-chat-input__target-switcher {
+    border-bottom: none;
+  }
+
+  .modern-flowchat-container__input {
+    background: transparent;
+    border-top: none;
+  }
+}

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
@@ -158,19 +158,22 @@
   }
 }
 
-// Expanded state: add rounded border for system / human compact rows.
+// Expanded state: show border for system / human compact rows (padding + 1px border
+// match collapsed — see --system/--human — so width does not jump on toggle).
 .user-message-item--expanded {
   &.user-message-item--system,
   &.user-message-item--human {
-    border: 1px solid var(--border-medium);
-    border-radius: 8px;
-    padding: 0.35rem 0.75rem;
     opacity: 1;
 
     .user-message-item__expanded-body {
       max-height: 40vh;
       overflow-y: auto;
     }
+  }
+
+  &.user-message-item--system:not(.user-message-item--failed),
+  &.user-message-item--human:not(.user-message-item--failed) {
+    border-color: var(--border-medium);
   }
 }
 
@@ -182,15 +185,17 @@
 // Compact rows: human (--human) + system-triggered (--system), understated
 // ────────────────────────────────────────────────────────────────────────────
 
-// Human + system-triggered: same compact inline row (no card).
+// Human + system-triggered: same compact inline row (no visible card until expand).
+// Use transparent 1px border + expanded padding always so expand/collapse does not shift width.
 .user-message-item--system,
 .user-message-item--human {
   background: transparent;
-  border: none;
+  border: 1px solid transparent;
+  border-radius: 8px;
   margin: 1rem 3rem 0 3rem;
-  padding: 0.15rem 0;
+  padding: 0.35rem 0.75rem;
   opacity: 0.6;
-  transition: opacity 0.2s ease;
+  transition: opacity 0.2s ease, border-color 0.2s ease;
 
   &:hover {
     opacity: 1;
@@ -198,6 +203,11 @@
     .user-message-item__copy-btn {
       opacity: 1;
     }
+  }
+
+  // Cancel base `.user-message-item:hover { border-color: ... }` while collapsed (keep invisible frame).
+  &:hover:not(.user-message-item--expanded) {
+    border-color: transparent;
   }
 }
 
@@ -334,9 +344,12 @@
   }
 }
 
-// Compact human row: no dashed frame; mute text only.
-.user-message-item--human.user-message-item--failed {
-  border: none;
+// Compact system / human rows: no dashed frame on failure; mute text only.
+// Keep 1px transparent border (same box as non-failed) to avoid layout jump vs expanded.
+.user-message-item--human.user-message-item--failed,
+.user-message-item--system.user-message-item--failed {
+  border: 1px solid transparent;
+  border-style: solid;
   background: transparent;
 
   .user-message-item__system-content {


### PR DESCRIPTION
## Summary

This PR targets the \gentic_os\ branch.

### Changes

- **AgenticOS workspace**: When the session mode is \dispatcher\, apply a flat workspace chrome (no rounded card shadow) for a cleaner Agentic OS shell.
- **Modern flow chat**: Add dispatcher-scoped styles so the turn sidebar, header, session files popover, file modifications bar, and chat input align with a flat, primary-background layout.
- **User message items**: Use a consistent transparent 1px border and padding for compact system/human rows so expanding/collapsing does not shift width; show border color only when expanded (except failed state).

### Testing

- [ ] Dispatcher session: workspace and chat chrome look correct
- [ ] Toggle expand on system/human compact rows: no horizontal jump