### PR TITLE
feat(config): add global stream idle timeout setting

### DIFF
--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -763,6 +763,7 @@ pub async fn initialize_ai(state: State<'_, AppState>) -> Result<String, String>
         .get_config(None)
         .await
         .map_err(|e| format!("Failed to get configuration: {}", e))?;
+    let stream_options = bitfun_core::infrastructure::ai::build_stream_options(&global_config.ai);
 
     let primary_model_id = global_config.ai.default_models.primary.ok_or_else(|| {
         "Primary model not configured, please configure it in settings".to_string()
@@ -776,7 +777,11 @@ pub async fn initialize_ai(state: State<'_, AppState>) -> Result<String, String>
 
     let ai_config = bitfun_core::util::types::AIConfig::try_from(model_config.clone())
         .map_err(|e| format!("Failed to convert AI configuration: {}", e))?;
-    let ai_client = bitfun_core::infrastructure::ai::AIClient::new(ai_config);
+    let ai_client = bitfun_core::infrastructure::ai::AIClient::new_with_runtime_options(
+        ai_config,
+        None,
+        stream_options,
+    );
 
     {
         let mut ai_client_guard = state.ai_client.write().await;

--- a/src/apps/desktop/src/api/config_api.rs
+++ b/src/apps/desktop/src/api/config_api.rs
@@ -75,6 +75,7 @@ pub async fn set_config(
             if request.path.starts_with("ai.models")
                 || request.path.starts_with("ai.default_models")
                 || request.path.starts_with("ai.agent_models")
+                || request.path.starts_with("ai.stream_idle_timeout_secs")
                 || request.path.starts_with("ai.proxy")
             {
                 state.ai_client_factory.invalidate_cache();

--- a/src/crates/ai-adapters/src/client.rs
+++ b/src/crates/ai-adapters/src/client.rs
@@ -18,6 +18,7 @@ use crate::types::*;
 use anyhow::Result;
 use format::ApiFormat;
 use reqwest::Client;
+use std::time::Duration;
 use tokio::sync::mpsc;
 
 /// Streamed response result with the parsed stream and optional raw SSE receiver.
@@ -28,10 +29,18 @@ pub struct StreamResponse {
     pub raw_sse_rx: Option<mpsc::UnboundedReceiver<String>>,
 }
 
+/// Runtime stream behavior shared across provider implementations.
+#[derive(Debug, Clone, Default)]
+pub struct StreamOptions {
+    /// Maximum idle time between streamed chunks. `None` means wait indefinitely.
+    pub idle_timeout: Option<Duration>,
+}
+
 #[derive(Debug, Clone)]
 pub struct AIClient {
     pub(crate) client: Client,
     pub config: AIConfig,
+    pub(crate) stream_options: StreamOptions,
 }
 
 impl AIClient {
@@ -44,14 +53,26 @@ impl AIClient {
 
     /// Create an AIClient without proxy.
     pub fn new(config: AIConfig) -> Self {
-        let client = http::create_http_client(None, config.skip_ssl_verify);
-        Self { client, config }
+        Self::new_with_runtime_options(config, None, StreamOptions::default())
     }
 
     /// Create an AIClient with proxy configuration.
     pub fn new_with_proxy(config: AIConfig, proxy_config: Option<ProxyConfig>) -> Self {
+        Self::new_with_runtime_options(config, proxy_config, StreamOptions::default())
+    }
+
+    /// Create an AIClient with proxy and runtime stream options.
+    pub fn new_with_runtime_options(
+        config: AIConfig,
+        proxy_config: Option<ProxyConfig>,
+        stream_options: StreamOptions,
+    ) -> Self {
         let client = http::create_http_client(proxy_config, config.skip_ssl_verify);
-        Self { client, config }
+        Self {
+            client,
+            config,
+            stream_options,
+        }
     }
 
     pub async fn send_message_stream(

--- a/src/crates/ai-adapters/src/lib.rs
+++ b/src/crates/ai-adapters/src/lib.rs
@@ -6,7 +6,7 @@ pub mod stream;
 pub mod tool_call_accumulator;
 pub mod types;
 
-pub use client::{AIClient, StreamResponse};
+pub use client::{AIClient, StreamOptions, StreamResponse};
 pub use stream::{UnifiedResponse, UnifiedTokenUsage, UnifiedToolCall};
 pub use types::{
     resolve_request_url, AIConfig, ConnectionTestMessageCode, ConnectionTestResult, GeminiResponse,

--- a/src/crates/ai-adapters/src/providers/anthropic/request.rs
+++ b/src/crates/ai-adapters/src/providers/anthropic/request.rs
@@ -218,6 +218,8 @@ pub(crate) async fn send_stream(
         anthropic_tools,
         extra_body,
     );
+    let inline_think_in_text = client.config.inline_think_in_text;
+    let idle_timeout = client.stream_options.idle_timeout;
 
     execute_sse_request(
         "Anthropic Streaming API",
@@ -230,7 +232,8 @@ pub(crate) async fn send_stream(
                 response,
                 tx,
                 tx_raw,
-                client.config.inline_think_in_text,
+                inline_think_in_text,
+                idle_timeout,
             ));
         },
     )

--- a/src/crates/ai-adapters/src/providers/gemini/request.rs
+++ b/src/crates/ai-adapters/src/providers/gemini/request.rs
@@ -333,6 +333,7 @@ pub(crate) async fn send_stream(
         gemini_tools,
         extra_body,
     );
+    let idle_timeout = client.stream_options.idle_timeout;
 
     execute_sse_request(
         "Gemini Streaming API",
@@ -341,7 +342,7 @@ pub(crate) async fn send_stream(
         max_tries,
         || apply_headers(client, client.client.post(&url)),
         move |response, tx, tx_raw| {
-            tokio::spawn(handle_gemini_stream(response, tx, tx_raw));
+            tokio::spawn(handle_gemini_stream(response, tx, tx_raw, idle_timeout));
         },
     )
     .await

--- a/src/crates/ai-adapters/src/providers/openai/chat.rs
+++ b/src/crates/ai-adapters/src/providers/openai/chat.rs
@@ -87,6 +87,7 @@ pub(crate) async fn send_stream(
     let openai_tools = OpenAIMessageConverter::convert_tools(tools);
     let request_body = build_request_body(client, &url, openai_messages, openai_tools, extra_body);
     let inline_think_in_text = client.config.inline_think_in_text;
+    let idle_timeout = client.stream_options.idle_timeout;
 
     execute_sse_request(
         "OpenAI Streaming API",
@@ -100,6 +101,7 @@ pub(crate) async fn send_stream(
                 tx,
                 tx_raw,
                 inline_think_in_text,
+                idle_timeout,
             ));
         },
     )

--- a/src/crates/ai-adapters/src/providers/openai/responses.rs
+++ b/src/crates/ai-adapters/src/providers/openai/responses.rs
@@ -109,6 +109,7 @@ pub(crate) async fn send_stream(
         openai_tools,
         extra_body,
     );
+    let idle_timeout = client.stream_options.idle_timeout;
 
     execute_sse_request(
         "Responses API",
@@ -117,7 +118,7 @@ pub(crate) async fn send_stream(
         max_tries,
         || common::apply_headers(client, client.client.post(&url)),
         move |response, tx, tx_raw| {
-            tokio::spawn(handle_responses_stream(response, tx, tx_raw));
+            tokio::spawn(handle_responses_stream(response, tx, tx_raw, idle_timeout));
         },
     )
     .await

--- a/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
@@ -1,5 +1,6 @@
 use super::inline_think::InlineThinkParser;
 use super::stream_stats::StreamStats;
+use super::{next_stream_item, TimedStreamItem};
 use crate::stream::types::anthropic::{
     AnthropicSSEError, ContentBlock, ContentBlockDelta, ContentBlockStart, MessageDelta,
     MessageStart, Usage,
@@ -7,12 +8,10 @@ use crate::stream::types::anthropic::{
 use crate::stream::types::unified::UnifiedResponse;
 use anyhow::{anyhow, Result};
 use eventsource_stream::Eventsource;
-use futures::StreamExt;
 use log::{error, trace};
 use reqwest::Response;
 use std::time::Duration;
 use tokio::sync::mpsc;
-use tokio::time::timeout;
 
 const AI_STREAM_RESPONSE_TARGET: &str = "ai::anthropic_stream_response";
 
@@ -27,33 +26,36 @@ pub async fn handle_anthropic_stream(
     tx_event: mpsc::UnboundedSender<Result<UnifiedResponse>>,
     tx_raw_sse: Option<mpsc::UnboundedSender<String>>,
     inline_think_in_text: bool,
+    idle_timeout: Option<Duration>,
 ) {
     let mut stream = response.bytes_stream().eventsource();
-    let idle_timeout = Duration::from_secs(600);
     let mut usage = Usage::default();
     let mut stats = StreamStats::new("Anthropic");
     let mut inline_think_parser = InlineThinkParser::new(inline_think_in_text);
 
     loop {
-        let sse_event = timeout(idle_timeout, stream.next()).await;
-        let sse = match sse_event {
-            Ok(Some(Ok(sse))) => sse,
-            Ok(None) => {
+        let sse = match next_stream_item(&mut stream, idle_timeout).await {
+            TimedStreamItem::Item(Ok(sse)) => sse,
+            TimedStreamItem::End => {
                 let error_msg = "SSE Error: stream closed before response completed";
                 stats.log_summary("stream_closed_before_completion");
                 error!("{}", error_msg);
                 let _ = tx_event.send(Err(anyhow!(error_msg)));
                 return;
             }
-            Ok(Some(Err(e))) => {
+            TimedStreamItem::Item(Err(e)) => {
                 let error_msg = format!("SSE Error: {}", e);
                 stats.log_summary("sse_stream_error");
                 error!("{}", error_msg);
                 let _ = tx_event.send(Err(anyhow!(error_msg)));
                 return;
             }
-            Err(_) => {
-                let error_msg = "SSE Timeout: idle timeout waiting for SSE";
+            TimedStreamItem::TimedOut => {
+                let timeout_secs = idle_timeout.map(|timeout| timeout.as_secs()).unwrap_or(0);
+                let error_msg = format!(
+                    "SSE Timeout: idle timeout waiting for SSE after {}s",
+                    timeout_secs
+                );
                 stats.log_summary("sse_stream_timeout");
                 error!("{}", error_msg);
                 let _ = tx_event.send(Err(anyhow!(error_msg)));

--- a/src/crates/ai-adapters/src/stream/stream_handler/gemini.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/gemini.rs
@@ -1,16 +1,15 @@
 use super::stream_stats::StreamStats;
+use super::{next_stream_item, TimedStreamItem};
 use crate::stream::types::gemini::GeminiSSEData;
 use crate::stream::types::unified::UnifiedResponse;
 use anyhow::{anyhow, Result};
 use eventsource_stream::Eventsource;
-use futures::StreamExt;
 use log::{error, trace};
 use reqwest::Response;
 use serde_json::Value;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::sync::mpsc;
-use tokio::time::timeout;
 
 const AI_STREAM_RESPONSE_TARGET: &str = "ai::gemini_stream_response";
 
@@ -77,18 +76,17 @@ pub async fn handle_gemini_stream(
     response: Response,
     tx_event: mpsc::UnboundedSender<Result<UnifiedResponse>>,
     tx_raw_sse: Option<mpsc::UnboundedSender<String>>,
+    idle_timeout: Option<Duration>,
 ) {
     let mut stream = response.bytes_stream().eventsource();
-    let idle_timeout = Duration::from_secs(600);
     let mut received_finish_reason = false;
     let mut tool_call_state = GeminiToolCallState::new();
     let mut stats = StreamStats::new("Gemini");
 
     loop {
-        let sse_event = timeout(idle_timeout, stream.next()).await;
-        let sse = match sse_event {
-            Ok(Some(Ok(sse))) => sse,
-            Ok(None) => {
+        let sse = match next_stream_item(&mut stream, idle_timeout).await {
+            TimedStreamItem::Item(Ok(sse)) => sse,
+            TimedStreamItem::End => {
                 if received_finish_reason {
                     stats.log_summary("stream_closed_after_finish_reason");
                     return;
@@ -99,18 +97,16 @@ pub async fn handle_gemini_stream(
                 let _ = tx_event.send(Err(anyhow!(error_msg)));
                 return;
             }
-            Ok(Some(Err(e))) => {
+            TimedStreamItem::Item(Err(e)) => {
                 let error_msg = format!("Gemini SSE stream error: {}", e);
                 stats.log_summary("sse_stream_error");
                 error!("{}", error_msg);
                 let _ = tx_event.send(Err(anyhow!(error_msg)));
                 return;
             }
-            Err(_) => {
-                let error_msg = format!(
-                    "Gemini SSE stream timeout after {}s",
-                    idle_timeout.as_secs()
-                );
+            TimedStreamItem::TimedOut => {
+                let timeout_secs = idle_timeout.map(|timeout| timeout.as_secs()).unwrap_or(0);
+                let error_msg = format!("Gemini SSE stream timeout after {}s", timeout_secs);
                 stats.log_summary("sse_stream_timeout");
                 error!("{}", error_msg);
                 let _ = tx_event.send(Err(anyhow!(error_msg)));

--- a/src/crates/ai-adapters/src/stream/stream_handler/mod.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/mod.rs
@@ -5,7 +5,36 @@ mod openai;
 mod responses;
 mod stream_stats;
 
+use futures::{Stream, StreamExt};
+use std::time::Duration;
+
 pub use anthropic::handle_anthropic_stream;
 pub use gemini::handle_gemini_stream;
 pub use openai::handle_openai_stream;
 pub use responses::handle_responses_stream;
+
+pub(super) enum TimedStreamItem<T> {
+    Item(T),
+    End,
+    TimedOut,
+}
+
+pub(super) async fn next_stream_item<S>(
+    stream: &mut S,
+    idle_timeout: Option<Duration>,
+) -> TimedStreamItem<S::Item>
+where
+    S: Stream + Unpin,
+{
+    match idle_timeout {
+        Some(idle_timeout) => match tokio::time::timeout(idle_timeout, stream.next()).await {
+            Ok(Some(item)) => TimedStreamItem::Item(item),
+            Ok(None) => TimedStreamItem::End,
+            Err(_) => TimedStreamItem::TimedOut,
+        },
+        None => match stream.next().await {
+            Some(item) => TimedStreamItem::Item(item),
+            None => TimedStreamItem::End,
+        },
+    }
+}

--- a/src/crates/ai-adapters/src/stream/stream_handler/openai.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/openai.rs
@@ -1,16 +1,15 @@
 use super::inline_think::InlineThinkParser;
 use super::stream_stats::StreamStats;
+use super::{next_stream_item, TimedStreamItem};
 use crate::stream::types::openai::{OpenAISSEData, OpenAIToolCallArgumentsNormalizer};
 use crate::stream::types::unified::UnifiedResponse;
 use anyhow::{anyhow, Result};
 use eventsource_stream::Eventsource;
-use futures::StreamExt;
 use log::{error, trace, warn};
 use reqwest::Response;
 use serde_json::Value;
 use std::time::Duration;
 use tokio::sync::mpsc;
-use tokio::time::timeout;
 
 const OPENAI_CHAT_COMPLETION_CHUNK_OBJECT: &str = "chat.completion.chunk";
 const AI_STREAM_RESPONSE_TARGET: &str = "ai::openai_stream_response";
@@ -71,9 +70,9 @@ pub async fn handle_openai_stream(
     tx_event: mpsc::UnboundedSender<Result<UnifiedResponse>>,
     tx_raw_sse: Option<mpsc::UnboundedSender<String>>,
     inline_think_in_text: bool,
+    idle_timeout: Option<Duration>,
 ) {
     let mut stream = response.bytes_stream().eventsource();
-    let idle_timeout = Duration::from_secs(600);
     let mut stats = StreamStats::new("OpenAI");
     // Track whether a chunk with `finish_reason` was received.
     // Some providers (e.g. MiniMax) close the stream after the final chunk
@@ -83,10 +82,9 @@ pub async fn handle_openai_stream(
     let mut normalizer = OpenAIResponseNormalizer::new(inline_think_in_text);
 
     loop {
-        let sse_event = timeout(idle_timeout, stream.next()).await;
-        let sse = match sse_event {
-            Ok(Some(Ok(sse))) => sse,
-            Ok(None) => {
+        let sse = match next_stream_item(&mut stream, idle_timeout).await {
+            TimedStreamItem::Item(Ok(sse)) => sse,
+            TimedStreamItem::End => {
                 if received_finish_reason {
                     for normalized_response in normalizer.flush() {
                         stats.record_unified_response(&normalized_response);
@@ -101,15 +99,16 @@ pub async fn handle_openai_stream(
                 let _ = tx_event.send(Err(anyhow!(error_msg)));
                 return;
             }
-            Ok(Some(Err(e))) => {
+            TimedStreamItem::Item(Err(e)) => {
                 let error_msg = format!("SSE stream error: {}", e);
                 stats.log_summary("sse_stream_error");
                 error!("{}", error_msg);
                 let _ = tx_event.send(Err(anyhow!(error_msg)));
                 return;
             }
-            Err(_) => {
-                let error_msg = format!("SSE stream timeout after {}s", idle_timeout.as_secs());
+            TimedStreamItem::TimedOut => {
+                let timeout_secs = idle_timeout.map(|timeout| timeout.as_secs()).unwrap_or(0);
+                let error_msg = format!("SSE stream timeout after {}s", timeout_secs);
                 stats.log_summary("sse_stream_timeout");
                 error!("{}", error_msg);
                 let _ = tx_event.send(Err(anyhow!(error_msg)));

--- a/src/crates/ai-adapters/src/stream/stream_handler/responses.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/responses.rs
@@ -1,18 +1,17 @@
 use super::stream_stats::StreamStats;
+use super::{next_stream_item, TimedStreamItem};
 use crate::stream::types::responses::{
     parse_responses_output_item, ResponsesCompleted, ResponsesDone, ResponsesStreamEvent,
 };
 use crate::stream::types::unified::UnifiedResponse;
 use anyhow::{anyhow, Result};
 use eventsource_stream::Eventsource;
-use futures::StreamExt;
 use log::{error, trace};
 use reqwest::Response;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::time::Duration;
 use tokio::sync::mpsc;
-use tokio::time::timeout;
 
 const AI_STREAM_RESPONSE_TARGET: &str = "ai::responses_stream_response";
 
@@ -180,9 +179,9 @@ pub async fn handle_responses_stream(
     response: Response,
     tx_event: mpsc::UnboundedSender<Result<UnifiedResponse>>,
     tx_raw_sse: Option<mpsc::UnboundedSender<String>>,
+    idle_timeout: Option<Duration>,
 ) {
     let mut stream = response.bytes_stream().eventsource();
-    let idle_timeout = Duration::from_secs(600);
     // Some providers close the stream after emitting the terminal event and may not send `[DONE]`.
     let mut received_finish_reason = false;
     let mut received_text_delta = false;
@@ -191,10 +190,9 @@ pub async fn handle_responses_stream(
     let mut stats = StreamStats::new("Responses");
 
     loop {
-        let sse_event = timeout(idle_timeout, stream.next()).await;
-        let sse = match sse_event {
-            Ok(Some(Ok(sse))) => sse,
-            Ok(None) => {
+        let sse = match next_stream_item(&mut stream, idle_timeout).await {
+            TimedStreamItem::Item(Ok(sse)) => sse,
+            TimedStreamItem::End => {
                 if received_finish_reason {
                     stats.log_summary("stream_closed_after_finish_reason");
                     return;
@@ -205,18 +203,16 @@ pub async fn handle_responses_stream(
                 let _ = tx_event.send(Err(anyhow!(error_msg)));
                 return;
             }
-            Ok(Some(Err(e))) => {
+            TimedStreamItem::Item(Err(e)) => {
                 let error_msg = format!("Responses SSE stream error: {}", e);
                 stats.log_summary("sse_stream_error");
                 error!("{}", error_msg);
                 let _ = tx_event.send(Err(anyhow!(error_msg)));
                 return;
             }
-            Err(_) => {
-                let error_msg = format!(
-                    "Responses SSE stream timeout after {}s",
-                    idle_timeout.as_secs()
-                );
+            TimedStreamItem::TimedOut => {
+                let timeout_secs = idle_timeout.map(|timeout| timeout.as_secs()).unwrap_or(0);
+                let error_msg = format!("Responses SSE stream timeout after {}s", timeout_secs);
                 stats.log_summary("sse_stream_timeout");
                 error!("{}", error_msg);
                 let _ = tx_event.send(Err(anyhow!(error_msg)));

--- a/src/crates/core/src/infrastructure/ai/client_factory.rs
+++ b/src/crates/core/src/infrastructure/ai/client_factory.rs
@@ -6,7 +6,7 @@
 //! 3. Invalidate cache when configuration changes
 //! 4. Provide global singleton access
 
-use crate::infrastructure::ai::AIClient;
+use crate::infrastructure::ai::{build_stream_options, AIClient};
 use crate::service::config::{get_global_config_service, ConfigService};
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::types::AIConfig;
@@ -176,7 +176,12 @@ impl AIClientFactory {
             None
         };
 
-        let client = Arc::new(AIClient::new_with_proxy(ai_config, proxy_config));
+        let stream_options = build_stream_options(&global_config.ai);
+        let client = Arc::new(AIClient::new_with_runtime_options(
+            ai_config,
+            proxy_config,
+            stream_options,
+        ));
 
         {
             let mut cache = match self.client_cache.write() {

--- a/src/crates/core/src/infrastructure/ai/mod.rs
+++ b/src/crates/core/src/infrastructure/ai/mod.rs
@@ -5,10 +5,18 @@
 pub mod client_factory;
 pub mod tool_call_accumulator;
 
+use std::time::Duration;
+
 pub use bitfun_ai_adapters::providers;
 pub use bitfun_ai_adapters::stream as ai_stream_handlers;
 
-pub use bitfun_ai_adapters::{AIClient, StreamResponse};
+pub use bitfun_ai_adapters::{AIClient, StreamOptions, StreamResponse};
 pub use client_factory::{
     get_global_ai_client_factory, initialize_global_ai_client_factory, AIClientFactory,
 };
+
+pub fn build_stream_options(config: &crate::service::config::types::AIConfig) -> StreamOptions {
+    StreamOptions {
+        idle_timeout: config.stream_idle_timeout_secs.map(Duration::from_secs),
+    }
+}

--- a/src/crates/core/src/service/config/providers.rs
+++ b/src/crates/core/src/service/config/providers.rs
@@ -39,6 +39,14 @@ impl ConfigProvider for AIConfigProvider {
         let mut warnings = Vec::new();
 
         if let Ok(ai_config) = serde_json::from_value::<AIConfig>(config.clone()) {
+            if let Some(stream_idle_timeout_secs) = ai_config.stream_idle_timeout_secs {
+                if stream_idle_timeout_secs == 0 {
+                    return Err(BitFunError::validation(
+                        "AI stream_idle_timeout_secs must be greater than 0".to_string(),
+                    ));
+                }
+            }
+
             for (index, model) in ai_config.models.iter().enumerate() {
                 if model.name.trim().is_empty() {
                     return Err(BitFunError::validation(format!(

--- a/src/crates/core/src/service/config/types.rs
+++ b/src/crates/core/src/service/config/types.rs
@@ -420,6 +420,10 @@ pub struct AIConfig {
     /// Global proxy configuration.
     pub proxy: ProxyConfig,
 
+    /// Streaming idle timeout in seconds; `None` means wait indefinitely.
+    #[serde(default = "default_stream_idle_timeout")]
+    pub stream_idle_timeout_secs: Option<u64>,
+
     /// Tool execution timeout in seconds; `None` means wait indefinitely.
     #[serde(default = "default_tool_execution_timeout")]
     pub tool_execution_timeout_secs: Option<u64>,
@@ -526,6 +530,11 @@ pub struct ModeConfigView {
 
 fn default_true() -> bool {
     true
+}
+
+/// Default is no timeout (wait forever).
+fn default_stream_idle_timeout() -> Option<u64> {
+    None
 }
 
 /// Default is no timeout (wait forever).
@@ -1307,6 +1316,7 @@ impl Default for AIConfig {
             mode_configs: std::collections::HashMap::new(),
             subagent_configs: std::collections::HashMap::new(),
             proxy: ProxyConfig::default(),
+            stream_idle_timeout_secs: default_stream_idle_timeout(),
             tool_execution_timeout_secs: default_tool_execution_timeout(),
             tool_confirmation_timeout_secs: default_tool_confirmation_timeout(),
             skip_tool_confirmation: true,
@@ -1515,7 +1525,7 @@ impl AIModelConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{AIModelConfig, ReasoningMode};
+    use super::{AIConfig, AIModelConfig, ReasoningMode};
 
     #[test]
     fn deserializes_compatibility_thinking_flag_into_reasoning_mode() {
@@ -1596,5 +1606,31 @@ mod tests {
         .expect("config without inline_think_in_text should deserialize");
 
         assert!(config.inline_think_in_text);
+    }
+
+    #[test]
+    fn default_ai_config_uses_no_stream_idle_timeout() {
+        let config = AIConfig::default();
+
+        assert_eq!(config.stream_idle_timeout_secs, None);
+    }
+
+    #[test]
+    fn deserializes_missing_stream_idle_timeout_as_none() {
+        let config: AIConfig = serde_json::from_value(serde_json::json!({
+            "models": [],
+            "agent_models": {},
+            "func_agent_models": {},
+            "default_models": {},
+            "mode_configs": {},
+            "subagent_configs": {},
+            "proxy": {
+                "enabled": false,
+                "url": ""
+            }
+        }))
+        .expect("config without stream_idle_timeout_secs should deserialize");
+
+        assert_eq!(config.stream_idle_timeout_secs, None);
     }
 }

--- a/src/crates/core/tests/common/stream_test_harness.rs
+++ b/src/crates/core/tests/common/stream_test_harness.rs
@@ -87,6 +87,7 @@ pub async fn run_stream_fixture_with_options(
                 tx_event,
                 Some(tx_raw_sse),
                 options.openai_inline_think_in_text,
+                None,
             ));
         }
         StreamFixtureProvider::Anthropic => {
@@ -95,16 +96,23 @@ pub async fn run_stream_fixture_with_options(
                 tx_event,
                 Some(tx_raw_sse),
                 options.anthropic_inline_think_in_text,
+                None,
             ));
         }
         StreamFixtureProvider::Gemini => {
-            tokio::spawn(handle_gemini_stream(response, tx_event, Some(tx_raw_sse)));
+            tokio::spawn(handle_gemini_stream(
+                response,
+                tx_event,
+                Some(tx_raw_sse),
+                None,
+            ));
         }
         StreamFixtureProvider::Responses => {
             tokio::spawn(handle_responses_stream(
                 response,
                 tx_event,
                 Some(tx_raw_sse),
+                None,
             ));
         }
     }

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -173,6 +173,24 @@ function formatTokenCountShort(n: number): string {
   return String(n);
 }
 
+function parseOptionalPositiveIntegerInput(value: string): number | null | undefined {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return null;
+  }
+
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
 /** Last line of defense: same logical model name once per save; prefer draft tied to an existing config id. */
 function dedupeSelectedModelDraftsByModelName(drafts: SelectedModelDraft[]): SelectedModelDraft[] {
   const out: SelectedModelDraft[] = [];
@@ -266,6 +284,8 @@ const AIModelConfig: React.FC = () => {
     username: '',
     password: ''
   });
+  const [streamIdleTimeoutInput, setStreamIdleTimeoutInput] = useState('');
+  const [isStreamIdleTimeoutSaving, setIsStreamIdleTimeoutSaving] = useState(false);
   const [isProxySaving, setIsProxySaving] = useState(false);
   const [remoteModelOptions, setRemoteModelOptions] = useState<RemoteModelOption[]>([]);
   const [isFetchingRemoteModels, setIsFetchingRemoteModels] = useState(false);
@@ -347,6 +367,11 @@ const AIModelConfig: React.FC = () => {
     }),
     [t]
   );
+  const parsedStreamIdleTimeout = useMemo(
+    () => parseOptionalPositiveIntegerInput(streamIdleTimeoutInput),
+    [streamIdleTimeoutInput]
+  );
+  const isStreamIdleTimeoutInvalid = parsedStreamIdleTimeout === undefined;
 
   const getCustomRequestBodyTrimHint = useCallback((provider?: string): string => {
     switch (provider) {
@@ -371,12 +396,18 @@ const AIModelConfig: React.FC = () => {
   
   const loadConfig = useCallback(async () => {
     try {
-      const models = await configManager.getConfig<AIModelConfigType[]>('ai.models') || [];
-      const proxy = await configManager.getConfig<ProxyConfig>('ai.proxy');
+      const [models, proxy, streamIdleTimeoutSecs] = await Promise.all([
+        configManager.getConfig<AIModelConfigType[]>('ai.models'),
+        configManager.getConfig<ProxyConfig>('ai.proxy'),
+        configManager.getConfig<number | null>('ai.stream_idle_timeout_secs'),
+      ]);
       setAiModels(models);
       if (proxy) {
         setProxyConfig(proxy);
       }
+      setStreamIdleTimeoutInput(
+        streamIdleTimeoutSecs != null ? String(streamIdleTimeoutSecs) : ''
+      );
     } catch (error) {
       log.error('Failed to load AI config', error);
     }
@@ -1136,6 +1167,30 @@ const AIModelConfig: React.FC = () => {
       notification.error(t('messages.saveFailed'));
     } finally {
       setIsProxySaving(false);
+    }
+  };
+
+  const handleSaveStreamIdleTimeout = async () => {
+    if (isStreamIdleTimeoutInvalid) {
+      notification.warning(t('streamIdleTimeout.invalid'));
+      return;
+    }
+
+    setIsStreamIdleTimeoutSaving(true);
+    try {
+      await configManager.setConfig(
+        'ai.stream_idle_timeout_secs',
+        parsedStreamIdleTimeout ?? null
+      );
+      setStreamIdleTimeoutInput(
+        parsedStreamIdleTimeout != null ? String(parsedStreamIdleTimeout) : ''
+      );
+      notification.success(t('streamIdleTimeout.saveSuccess'));
+    } catch (error) {
+      log.error('Failed to save stream idle timeout', error);
+      notification.error(t('messages.saveFailed'));
+    } finally {
+      setIsStreamIdleTimeoutSaving(false);
     }
   };
 
@@ -2211,6 +2266,37 @@ const AIModelConfig: React.FC = () => {
               ))}
             </div>
           )}
+        </ConfigPageSection>
+
+        <ConfigPageSection
+          title={t('streamIdleTimeout.title')}
+          description={t('streamIdleTimeout.hint')}
+          extra={(
+            <Button
+              variant="primary"
+              size="small"
+              onClick={handleSaveStreamIdleTimeout}
+              disabled={isStreamIdleTimeoutSaving || isStreamIdleTimeoutInvalid}
+            >
+              {isStreamIdleTimeoutSaving ? (
+                <Loader size={16} className="spinning" />
+              ) : (
+                t('streamIdleTimeout.save')
+              )}
+            </Button>
+          )}
+        >
+          <ConfigPageRow
+            label={t('streamIdleTimeout.label')}
+            align="center"
+          >
+            <Input
+              value={streamIdleTimeoutInput}
+              onChange={(e) => setStreamIdleTimeoutInput(e.target.value)}
+              placeholder={t('streamIdleTimeout.placeholder')}
+              inputSize="small"
+            />
+          </ConfigPageRow>
         </ConfigPageSection>
 
         <ConfigPageSection

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -162,6 +162,7 @@ export interface AIConfig {
   streaming: boolean;
   auto_save_conversations: boolean;
   conversation_history_limit: number;
+  stream_idle_timeout_secs?: number | null;
   tool_execution_timeout_secs?: number | null;
   tool_confirmation_timeout_secs?: number | null;
   skip_tool_confirmation?: boolean;

--- a/src/web-ui/src/locales/en-US/settings/ai-model.json
+++ b/src/web-ui/src/locales/en-US/settings/ai-model.json
@@ -195,6 +195,15 @@
     "save": "Save Proxy Configuration",
     "saveSuccess": "Proxy configuration saved, restart IDE to take effect"
   },
+  "streamIdleTimeout": {
+    "title": "Streaming Timeout",
+    "label": "Idle Timeout (seconds)",
+    "hint": "Global idle timeout between streamed chunks. Leave empty to wait indefinitely.",
+    "placeholder": "Leave empty for no timeout",
+    "invalid": "Enter a positive integer in seconds, or leave this field empty.",
+    "save": "Save Streaming Timeout",
+    "saveSuccess": "Streaming timeout saved"
+  },
   "capabilities": {
     "text_chat": "Chat",
     "image_understanding": "Vision",

--- a/src/web-ui/src/locales/zh-CN/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-CN/settings/ai-model.json
@@ -195,6 +195,15 @@
     "save": "保存代理配置",
     "saveSuccess": "代理配置已保存，重启IDE后生效"
   },
+  "streamIdleTimeout": {
+    "title": "流式超时",
+    "label": "空闲超时（秒）",
+    "hint": "全局控制流式响应在两次 chunk 之间的最大等待时间。留空表示无限等待。",
+    "placeholder": "留空表示不设超时",
+    "invalid": "请输入正整数秒数，或留空。",
+    "save": "保存流式超时",
+    "saveSuccess": "流式超时已保存"
+  },
   "capabilities": {
     "text_chat": "对话",
     "image_understanding": "多模态",


### PR DESCRIPTION
- add global `ai.stream_idle_timeout_secs` config with `None` as no timeout
- pass stream idle timeout via runtime stream options instead of per-model AI config
- apply the timeout consistently across OpenAI, Responses, Anthropic, and Gemini stream handlers
- add models settings UI entry above proxy for configuring the global stream timeout
- update frontend config types, i18n copy, and targeted tests/checks
