### PR TITLE
feat(ai): import local Codex / Gemini CLI accounts as models

### DIFF
--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -810,13 +810,22 @@ pub async fn test_ai_config_connection(
         bitfun_core::service::config::types::ModelCategory::Multimodal
     );
 
-    let ai_config = match request.config.try_into() {
+    let auth = request.config.auth.clone();
+    let mut ai_config: bitfun_core::util::types::AIConfig = match request.config.try_into() {
         Ok(config) => config,
         Err(e) => {
             error!("Failed to convert AI config: {}", e);
             return Err(format!("Failed to convert configuration: {}", e));
         }
     };
+
+    if let Err(e) =
+        bitfun_core::infrastructure::ai::client_factory::apply_cli_credential(&auth, &mut ai_config)
+            .await
+    {
+        error!("Failed to resolve CLI credential during test: {}", e);
+        return Err(format!("Failed to resolve CLI credential: {}", e));
+    }
 
     let ai_client = bitfun_core::infrastructure::ai::AIClient::new(ai_config);
 
@@ -897,10 +906,14 @@ pub async fn list_ai_models_by_config(
     request: ListAIModelsByConfigRequest,
 ) -> Result<Vec<bitfun_core::util::types::RemoteModelInfo>, String> {
     let config_name = request.config.name.clone();
-    let ai_config = request
+    let auth = request.config.auth.clone();
+    let mut ai_config: bitfun_core::util::types::AIConfig = request
         .config
         .try_into()
         .map_err(|e| format!("Failed to convert configuration: {}", e))?;
+    bitfun_core::infrastructure::ai::client_factory::apply_cli_credential(&auth, &mut ai_config)
+        .await
+        .map_err(|e| format!("Failed to resolve CLI credential: {}", e))?;
     let ai_client = bitfun_core::infrastructure::ai::AIClient::new(ai_config);
 
     ai_client.list_models().await.map_err(|e| {
@@ -2728,4 +2741,37 @@ pub async fn stop_file_watch(path: String) -> Result<(), String> {
 #[tauri::command]
 pub async fn get_watched_paths() -> Result<Vec<String>, String> {
     file_watch::get_watched_paths().await
+}
+
+#[tauri::command]
+pub async fn discover_cli_credentials() -> Result<Vec<bitfun_core::infrastructure::cli_credentials::DiscoveredCredential>, String> {
+    Ok(bitfun_core::infrastructure::cli_credentials::discover_all().await)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshCliCredentialRequest {
+    pub kind: bitfun_core::infrastructure::cli_credentials::CliCredentialKind,
+}
+
+#[tauri::command]
+pub async fn refresh_cli_credential(
+    request: RefreshCliCredentialRequest,
+) -> Result<bitfun_core::infrastructure::cli_credentials::DiscoveredCredential, String> {
+    use bitfun_core::infrastructure::cli_credentials::{
+        codex::CodexResolver, gemini::GeminiResolver, CliCredentialKind, CredentialResolver,
+    };
+    // Force a refresh by calling resolve(), then re-discover for the latest metadata.
+    let resolved = match request.kind {
+        CliCredentialKind::Codex => CodexResolver.resolve().await,
+        CliCredentialKind::Gemini => GeminiResolver.resolve().await,
+    };
+    if let Err(e) = resolved {
+        return Err(format!("Refresh failed: {}", e));
+    }
+    let discovered = bitfun_core::infrastructure::cli_credentials::discover_all().await;
+    discovered
+        .into_iter()
+        .find(|c| c.kind == request.kind)
+        .ok_or_else(|| "Credential not found after refresh".to_string())
 }

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -348,6 +348,8 @@ pub async fn run() {
             test_ai_connection,
             test_ai_config_connection,
             list_ai_models_by_config,
+            discover_cli_credentials,
+            refresh_cli_credential,
             initialize_ai,
             set_agent_model,
             get_agent_models,

--- a/src/crates/ai-adapters/src/client.rs
+++ b/src/crates/ai-adapters/src/client.rs
@@ -105,6 +105,9 @@ impl AIClient {
             ApiFormat::Gemini => {
                 gemini::request::send_stream(self, messages, tools, extra_body, max_tries).await
             }
+            ApiFormat::GeminiCodeAssist => {
+                gemini::code_assist::send_stream(self, messages, tools, extra_body, max_tries).await
+            }
         }
     }
 
@@ -145,6 +148,7 @@ impl AIClient {
             }
             ApiFormat::Anthropic => anthropic::discovery::list_models(self).await,
             ApiFormat::Gemini => gemini::discovery::list_models(self).await,
+            ApiFormat::GeminiCodeAssist => gemini::code_assist::list_models(self).await,
         }
     }
 }

--- a/src/crates/ai-adapters/src/client/format.rs
+++ b/src/crates/ai-adapters/src/client/format.rs
@@ -6,6 +6,10 @@ pub(crate) enum ApiFormat {
     OpenAIResponses,
     Anthropic,
     Gemini,
+    /// Google Cloud Code Assist (`cloudcode-pa.googleapis.com`) used by
+    /// `gemini-cli` in personal-OAuth mode. The wire format is the regular
+    /// Gemini body, but wrapped as `{ "model", "project", "request": { ... } }`.
+    GeminiCodeAssist,
 }
 
 impl ApiFormat {
@@ -16,6 +20,9 @@ impl ApiFormat {
             "response" | "responses" => Ok(Self::OpenAIResponses),
             "anthropic" => Ok(Self::Anthropic),
             "gemini" | "google" => Ok(Self::Gemini),
+            "gemini-code-assist" | "gemini_code_assist" | "code-assist" => {
+                Ok(Self::GeminiCodeAssist)
+            }
             _ => Err(anyhow!("Unknown API format: {}", value)),
         }
     }

--- a/src/crates/ai-adapters/src/providers/gemini/code_assist.rs
+++ b/src/crates/ai-adapters/src/providers/gemini/code_assist.rs
@@ -1,0 +1,209 @@
+//! Google Cloud Code Assist transport (`cloudcode-pa.googleapis.com`).
+//!
+//! Used by `gemini-cli` after a personal Google login. The endpoint accepts the
+//! regular Gemini request body but wrapped in
+//! `{ "model": "...", "project": "...", "request": { ... } }` and authenticated
+//! with a Bearer access_token (we don't pass `x-goog-api-key`).
+
+use super::{request as gemini_request, GeminiMessageConverter};
+use crate::client::sse::execute_sse_request;
+use crate::client::{AIClient, StreamResponse};
+use crate::providers::shared;
+use crate::stream::handle_gemini_stream;
+use crate::types::{Message, RemoteModelInfo, ToolDefinition};
+use anyhow::{anyhow, Result};
+use log::debug;
+use reqwest::RequestBuilder;
+use serde::Deserialize;
+use std::sync::OnceLock;
+use tokio::sync::Mutex;
+
+const CODE_ASSIST_BASE: &str = "https://cloudcode-pa.googleapis.com";
+const STREAM_ENDPOINT: &str = "/v1internal:streamGenerateContent?alt=sse";
+const LOAD_CODE_ASSIST_ENDPOINT: &str = "/v1internal:loadCodeAssist";
+const ONBOARD_USER_ENDPOINT: &str = "/v1internal:onboardUser";
+
+fn cached_project() -> &'static Mutex<Option<String>> {
+    static CACHE: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(None))
+}
+
+pub(crate) fn apply_headers(client: &AIClient, builder: RequestBuilder) -> RequestBuilder {
+    shared::apply_header_policy(client, builder, |builder| {
+        builder
+            .header("Content-Type", "application/json")
+            .header(
+                "Authorization",
+                format!("Bearer {}", client.config.api_key),
+            )
+            .header("User-Agent", "BitFun-CodeAssist/1.0")
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct LoadCodeAssistResponse {
+    #[serde(default, rename = "cloudaicompanionProject")]
+    cloudaicompanion_project: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OnboardOperation {
+    #[serde(default)]
+    done: Option<bool>,
+    #[serde(default)]
+    response: Option<OnboardResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OnboardResponse {
+    #[serde(default, rename = "cloudaicompanionProject")]
+    cloudaicompanion_project: Option<OnboardProject>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OnboardProject {
+    #[serde(default)]
+    id: Option<String>,
+}
+
+async fn discover_project(client: &AIClient) -> Result<String> {
+    {
+        let guard = cached_project().lock().await;
+        if let Some(p) = guard.clone() {
+            return Ok(p);
+        }
+    }
+
+    if let Ok(env_project) = std::env::var("GOOGLE_CLOUD_PROJECT") {
+        if !env_project.is_empty() {
+            *cached_project().lock().await = Some(env_project.clone());
+            return Ok(env_project);
+        }
+    }
+
+    let metadata = serde_json::json!({
+        "ideType": "IDE_UNSPECIFIED",
+        "platform": "PLATFORM_UNSPECIFIED",
+        "pluginType": "GEMINI",
+    });
+
+    let load_url = format!("{}{}", CODE_ASSIST_BASE, LOAD_CODE_ASSIST_ENDPOINT);
+    let load_body = serde_json::json!({ "metadata": metadata });
+    let load_resp = apply_headers(client, client.client.post(&load_url))
+        .json(&load_body)
+        .send()
+        .await?;
+    let load_status = load_resp.status();
+    if !load_status.is_success() {
+        let body = load_resp.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "loadCodeAssist failed: HTTP {load_status}: {body}"
+        ));
+    }
+    let load_parsed: LoadCodeAssistResponse = load_resp.json().await?;
+    if let Some(project) = load_parsed.cloudaicompanion_project.filter(|s| !s.is_empty()) {
+        *cached_project().lock().await = Some(project.clone());
+        return Ok(project);
+    }
+
+    // Need to onboard – create a free-tier Code Assist project.
+    let onboard_url = format!("{}{}", CODE_ASSIST_BASE, ONBOARD_USER_ENDPOINT);
+    let onboard_body = serde_json::json!({
+        "tierId": "free-tier",
+        "metadata": metadata,
+    });
+    let onboard_resp = apply_headers(client, client.client.post(&onboard_url))
+        .json(&onboard_body)
+        .send()
+        .await?;
+    let onboard_status = onboard_resp.status();
+    if !onboard_status.is_success() {
+        let body = onboard_resp.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "onboardUser failed: HTTP {onboard_status}: {body}"
+        ));
+    }
+    let parsed: OnboardOperation = onboard_resp.json().await?;
+    if !parsed.done.unwrap_or(false) {
+        return Err(anyhow!("onboardUser did not complete in a single call"));
+    }
+    let project = parsed
+        .response
+        .and_then(|r| r.cloudaicompanion_project)
+        .and_then(|p| p.id)
+        .ok_or_else(|| anyhow!("onboardUser response missing project id"))?;
+    *cached_project().lock().await = Some(project.clone());
+    Ok(project)
+}
+
+pub(crate) async fn send_stream(
+    client: &AIClient,
+    messages: Vec<Message>,
+    tools: Option<Vec<ToolDefinition>>,
+    extra_body: Option<serde_json::Value>,
+    max_tries: usize,
+) -> Result<StreamResponse> {
+    let project = discover_project(client).await?;
+
+    let (system_instruction, contents) =
+        GeminiMessageConverter::convert_messages(messages, &client.config.model);
+    let gemini_tools = GeminiMessageConverter::convert_tools(tools);
+    let inner = gemini_request::build_request_body(
+        client,
+        system_instruction,
+        contents,
+        gemini_tools,
+        extra_body,
+    );
+
+    let request_body = serde_json::json!({
+        "model": client.config.model,
+        "project": project,
+        "request": inner,
+    });
+
+    let url = if client.config.request_url.is_empty() {
+        format!("{}{}", CODE_ASSIST_BASE, STREAM_ENDPOINT)
+    } else {
+        client.config.request_url.clone()
+    };
+
+    debug!(
+        "Gemini Code Assist config: model={}, request_url={}, project={}, max_tries={}",
+        client.config.model, url, project, max_tries
+    );
+
+    let idle_timeout = client.stream_options.idle_timeout;
+    execute_sse_request(
+        "Gemini Code Assist Streaming API",
+        &url,
+        &request_body,
+        max_tries,
+        || apply_headers(client, client.client.post(&url)),
+        move |response, tx, tx_raw| {
+            tokio::spawn(handle_gemini_stream(response, tx, tx_raw, idle_timeout));
+        },
+    )
+    .await
+}
+
+/// Code Assist (`cloudcode-pa.googleapis.com`) does not expose a list-models
+/// endpoint; the upstream `gemini-cli` ships a hard-coded `VALID_GEMINI_MODELS`
+/// set in `packages/core/src/config/models.ts`. We mirror its stable entries so
+/// the BitFun model picker shows exactly what the CLI itself allows.
+pub(crate) async fn list_models(_client: &AIClient) -> Result<Vec<RemoteModelInfo>> {
+    Ok(vec![
+        RemoteModelInfo {
+            id: "gemini-2.5-pro".to_string(),
+            display_name: Some("Gemini 2.5 Pro".to_string()),
+        },
+        RemoteModelInfo {
+            id: "gemini-2.5-flash".to_string(),
+            display_name: Some("Gemini 2.5 Flash".to_string()),
+        },
+        RemoteModelInfo {
+            id: "gemini-2.5-flash-lite".to_string(),
+            display_name: Some("Gemini 2.5 Flash-Lite".to_string()),
+        },
+    ])
+}

--- a/src/crates/ai-adapters/src/providers/gemini/mod.rs
+++ b/src/crates/ai-adapters/src/providers/gemini/mod.rs
@@ -1,5 +1,6 @@
 //! Gemini provider module
 
+pub mod code_assist;
 pub mod discovery;
 pub mod message_converter;
 pub mod request;

--- a/src/crates/ai-adapters/src/providers/openai/codex_chatgpt.rs
+++ b/src/crates/ai-adapters/src/providers/openai/codex_chatgpt.rs
@@ -1,0 +1,197 @@
+//! Adapter for the Codex CLI ChatGPT-login backend
+//! (`https://chatgpt.com/backend-api/codex/responses`).
+//!
+//! This endpoint speaks a constrained dialect of the OpenAI Responses API
+//! used internally by the official `codex` CLI. It is *not* the public
+//! `https://api.openai.com/v1/responses` surface — sending a vanilla
+//! Responses-shaped body to it produces 400 errors such as:
+//!
+//! - `Instructions are required`
+//! - `Store must be set to false`
+//! - `Unsupported parameter: max_output_tokens`
+//! - `Missing required parameter: 'tools[0].name'`  (it requires the *flat*
+//!   Responses tool schema, not the Chat Completions `{type, function:{...}}`
+//!   wrapper)
+//!
+//! Rather than scattering URL-conditional patches throughout the generic
+//! Responses adapter, all backend-specific quirks live in this module.
+//! Dispatch happens in `super::responses::send_stream` via
+//! [`is_codex_chatgpt_endpoint`].
+
+use super::{common, OpenAIMessageConverter};
+use crate::client::sse::execute_sse_request;
+use crate::client::{AIClient, StreamResponse};
+use crate::providers::shared;
+use crate::stream::handle_responses_stream;
+use crate::types::{Message, ReasoningMode, ToolDefinition};
+use anyhow::Result;
+use log::debug;
+use serde_json::{json, Value};
+
+const TARGET: &str = "ai::codex_chatgpt_request";
+const DEFAULT_INSTRUCTIONS: &str = "You are a helpful AI assistant.";
+
+/// Returns true when `request_url` points at Codex CLI's ChatGPT backend.
+pub(crate) fn is_codex_chatgpt_endpoint(request_url: &str) -> bool {
+    request_url.contains("chatgpt.com/backend-api/codex")
+}
+
+/// Convert a `ToolDefinition` list to the *flat* Responses tool schema that
+/// Codex backend (and OpenAI's public Responses API) expects:
+/// `{ "type": "function", "name": ..., "description": ..., "parameters": ..., "strict": false }`.
+fn convert_tools_flat(tools: Option<Vec<ToolDefinition>>) -> Option<Vec<Value>> {
+    tools.map(|defs| {
+        defs.into_iter()
+            .map(|tool| {
+                json!({
+                    "type": "function",
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.parameters,
+                    "strict": false,
+                })
+            })
+            .collect()
+    })
+}
+
+fn attach_tools(request_body: &mut Value, tools: Option<Vec<Value>>) {
+    if let Some(tools) = tools {
+        let names: Vec<String> = tools
+            .iter()
+            .filter_map(|t| t.get("name").and_then(|v| v.as_str()).map(str::to_string))
+            .collect();
+        shared::log_tool_names(TARGET, names);
+        if !tools.is_empty() {
+            request_body["tools"] = Value::Array(tools);
+            if request_body.get("tool_choice").is_none() {
+                request_body["tool_choice"] = Value::String("auto".to_string());
+            }
+            // Mirror hermes-agent / codex CLI: parallel tool calls allowed.
+            if request_body.get("parallel_tool_calls").is_none() {
+                request_body["parallel_tool_calls"] = Value::Bool(true);
+            }
+        }
+    }
+}
+
+/// Clamp reasoning effort to values accepted by the Codex backend models.
+/// `minimal` is rejected by GPT-5.2 / GPT-5.4 family — fall back to `low`,
+/// matching hermes-agent's clamp table.
+fn clamp_reasoning_effort(effort: &str) -> String {
+    match effort {
+        "minimal" => "low".to_string(),
+        other => other.to_string(),
+    }
+}
+
+pub(crate) fn build_request_body(
+    client: &AIClient,
+    instructions: Option<String>,
+    response_input: Vec<Value>,
+    tools_flat: Option<Vec<Value>>,
+    extra_body: Option<Value>,
+) -> Value {
+    let mut body = json!({
+        "model": client.config.model,
+        "input": response_input,
+        "stream": true,
+        // Codex backend mandates `store: false`.
+        "store": false,
+    });
+
+    let resolved_instructions = instructions
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_INSTRUCTIONS.to_string());
+    body["instructions"] = Value::String(resolved_instructions);
+
+    // Reasoning — mirror hermes-agent: default effort `medium` when enabled,
+    // clamp `minimal -> low`, request encrypted reasoning trace for chain
+    // continuity. When explicitly disabled, send `include: []` (empty array)
+    // so the backend doesn't attach reasoning items it expects to be replayed.
+    if client.config.reasoning_mode != ReasoningMode::Disabled {
+        let effort = client
+            .config
+            .reasoning_effort
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(clamp_reasoning_effort)
+            .unwrap_or_else(|| "medium".to_string());
+        body["reasoning"] = json!({ "effort": effort, "summary": "auto" });
+        body["include"] = json!(["reasoning.encrypted_content"]);
+    } else {
+        body["include"] = json!([]);
+    }
+
+    let protected = shared::protect_request_body(
+        client,
+        &mut body,
+        &[
+            "model",
+            "input",
+            "instructions",
+            "stream",
+            "store",
+            "include",
+        ],
+        &[],
+    );
+
+    if let Some(extra) = extra_body {
+        if let Some(extra_obj) = extra.as_object() {
+            shared::merge_extra_body(&mut body, extra_obj);
+            shared::log_extra_body_keys(TARGET, extra_obj);
+        }
+    }
+
+    shared::restore_protected_body(&mut body, protected);
+
+    shared::log_request_body(
+        TARGET,
+        "Codex ChatGPT request body (excluding tools):",
+        &body,
+    );
+
+    attach_tools(&mut body, tools_flat);
+
+    body
+}
+
+pub(crate) async fn send_stream(
+    client: &AIClient,
+    messages: Vec<Message>,
+    tools: Option<Vec<ToolDefinition>>,
+    extra_body: Option<Value>,
+    max_tries: usize,
+) -> Result<StreamResponse> {
+    let url = client.config.request_url.clone();
+    debug!(
+        "CodexChatGPT config: model={}, request_url={}, max_tries={}",
+        client.config.model, url, max_tries
+    );
+
+    let (instructions, response_input) =
+        OpenAIMessageConverter::convert_messages_to_responses_input(messages);
+    let tools_flat = convert_tools_flat(tools);
+    let request_body = build_request_body(
+        client,
+        instructions,
+        response_input,
+        tools_flat,
+        extra_body,
+    );
+    let idle_timeout = client.stream_options.idle_timeout;
+
+    execute_sse_request(
+        "Codex ChatGPT Responses API",
+        &url,
+        &request_body,
+        max_tries,
+        || common::apply_headers(client, client.client.post(&url)),
+        move |response, tx, tx_raw| {
+            tokio::spawn(handle_responses_stream(response, tx, tx_raw, idle_timeout));
+        },
+    )
+    .await
+}

--- a/src/crates/ai-adapters/src/providers/openai/common.rs
+++ b/src/crates/ai-adapters/src/providers/openai/common.rs
@@ -58,6 +58,16 @@ pub(crate) fn resolve_models_url(client: &AIClient) -> String {
 
 pub(crate) async fn list_models(client: &AIClient) -> Result<Vec<RemoteModelInfo>> {
     let url = resolve_models_url(client);
+
+    // Codex CLI's ChatGPT backend (`chatgpt.com/backend-api/codex`) hosts a
+    // private, non-OpenAI-shaped `/models` endpoint that returns
+    // `{ "models": [{ "slug": "...", "display_name": "..." }, ...] }`. Detect
+    // and route it through a dedicated parser instead of the public OpenAI
+    // schema (which would yield zero models because of the envelope mismatch).
+    if url.contains("chatgpt.com/backend-api/codex") {
+        return list_codex_chatgpt_models(client, &url).await;
+    }
+
     let response = apply_headers(client, client.client.get(&url))
         .send()
         .await?
@@ -75,6 +85,77 @@ pub(crate) async fn list_models(client: &AIClient) -> Result<Vec<RemoteModelInfo
             .collect(),
     ))
 }
+
+#[derive(Debug, Deserialize)]
+struct CodexBackendModelsResponse {
+    #[serde(default)]
+    models: Vec<CodexBackendModelEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexBackendModelEntry {
+    slug: String,
+    /// Returned by the backend but unused — see comment in the mapping below
+    /// (display_name is dropped to avoid duplicate-looking entries).
+    #[allow(dead_code)]
+    #[serde(default)]
+    display_name: Option<String>,
+    /// Codex backend marks deprecated/internal slugs with `visibility = "hide"`.
+    /// We only surface entries the CLI itself shows (`list`).
+    #[serde(default)]
+    visibility: Option<String>,
+}
+
+/// `chatgpt.com/backend-api/codex/models` returns each model's
+/// `minimal_client_version`, and only emits entries whose minimum is satisfied
+/// by the `client_version` query param. Sending BitFun's own
+/// `CARGO_PKG_VERSION` (e.g. `"0.2.3"`) makes the backend hide every modern
+/// model and only return the legacy `gpt-5.2` (whose minimum is `0.0.1`). We
+/// mirror a current Codex CLI release so the model picker matches what the
+/// user sees in `codex /model`. Bump this when codex CLI bumps further.
+const CODEX_CLIENT_VERSION_HEADER: &str = "0.121.0";
+
+async fn list_codex_chatgpt_models(
+    client: &AIClient,
+    base_models_url: &str,
+) -> Result<Vec<RemoteModelInfo>> {
+    let separator = if base_models_url.contains('?') { '&' } else { '?' };
+    let url = format!(
+        "{base_models_url}{separator}client_version={version}",
+        version = CODEX_CLIENT_VERSION_HEADER
+    );
+
+    let response = apply_headers(client, client.client.get(&url))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let payload: CodexBackendModelsResponse = response.json().await?;
+
+    let filtered: Vec<RemoteModelInfo> = payload
+        .models
+        .into_iter()
+        .filter(|model| {
+            model
+                .visibility
+                .as_deref()
+                .map(|v| v.eq_ignore_ascii_case("list"))
+                .unwrap_or(true)
+        })
+        .map(|model| RemoteModelInfo {
+            id: model.slug,
+            // Codex backend's `display_name` is often the same slug with
+            // different casing (e.g. `gpt-5.4-mini` vs `GPT-5.4-Mini`). The
+            // BitFun model picker renders display_name + slug stacked, which
+            // looks like duplicate names. Drop display_name so each entry is a
+            // single line keyed only by the canonical slug.
+            display_name: None,
+        })
+        .collect();
+
+    Ok(dedupe_remote_models(filtered))
+}
+
 
 pub(crate) fn extract_tool_name(tool: &serde_json::Value) -> String {
     tool.get("function")

--- a/src/crates/ai-adapters/src/providers/openai/mod.rs
+++ b/src/crates/ai-adapters/src/providers/openai/mod.rs
@@ -1,6 +1,7 @@
 //! OpenAI provider module
 
 pub mod chat;
+pub mod codex_chatgpt;
 pub mod common;
 pub mod message_converter;
 pub mod responses;

--- a/src/crates/ai-adapters/src/providers/openai/responses.rs
+++ b/src/crates/ai-adapters/src/providers/openai/responses.rs
@@ -93,6 +93,16 @@ pub(crate) async fn send_stream(
     extra_body: Option<serde_json::Value>,
     max_tries: usize,
 ) -> Result<StreamResponse> {
+    // Codex CLI's ChatGPT-login backend (`chatgpt.com/backend-api/codex`)
+    // speaks a constrained Responses dialect with several extra
+    // requirements (flat tool schema, mandatory `instructions`,
+    // `store: false`, no `max_output_tokens`, etc.). Keep that adapter
+    // self-contained so the standard Responses path stays untouched.
+    if super::codex_chatgpt::is_codex_chatgpt_endpoint(&client.config.request_url) {
+        return super::codex_chatgpt::send_stream(client, messages, tools, extra_body, max_tries)
+            .await;
+    }
+
     let url = client.config.request_url.clone();
     debug!(
         "Responses config: model={}, request_url={}, max_tries={}",

--- a/src/crates/core/src/agentic/tools/browser_control/browser_launcher.rs
+++ b/src/crates/core/src/agentic/tools/browser_control/browser_launcher.rs
@@ -189,20 +189,7 @@ impl BrowserLauncher {
 
         #[cfg(target_os = "windows")]
         {
-            match kind {
-                BrowserKind::Chrome => {
-                    r"C:\Program Files\Google\Chrome\Application\chrome.exe".into()
-                }
-                BrowserKind::Edge => {
-                    r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe".into()
-                }
-                BrowserKind::Brave => {
-                    r"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe".into()
-                }
-                BrowserKind::Chromium => "chromium.exe".into(),
-                BrowserKind::Arc => "arc.exe".into(),
-                BrowserKind::Unknown(name) => name.clone(),
-            }
+            Self::windows_browser_executable(kind)
         }
 
         #[cfg(target_os = "linux")]
@@ -216,6 +203,105 @@ impl BrowserLauncher {
                 BrowserKind::Unknown(name) => name.clone(),
             }
         }
+    }
+
+    /// Windows: resolve a browser's executable path by probing common install
+    /// locations (Program Files / Program Files (x86) / per-user LocalAppData)
+    /// and then falling back to the registry "App Paths" entry.
+    #[cfg(target_os = "windows")]
+    fn windows_browser_executable(kind: &BrowserKind) -> String {
+        let (rel_paths, app_paths_key, fallback_cmd) = match kind {
+            BrowserKind::Chrome => (
+                vec![
+                    r"Google\Chrome\Application\chrome.exe",
+                ],
+                Some("chrome.exe"),
+                "chrome.exe",
+            ),
+            BrowserKind::Edge => (
+                vec![
+                    r"Microsoft\Edge\Application\msedge.exe",
+                ],
+                Some("msedge.exe"),
+                "msedge.exe",
+            ),
+            BrowserKind::Brave => (
+                vec![
+                    r"BraveSoftware\Brave-Browser\Application\brave.exe",
+                ],
+                Some("brave.exe"),
+                "brave.exe",
+            ),
+            BrowserKind::Chromium => (
+                vec![r"Chromium\Application\chrome.exe"],
+                None,
+                "chromium.exe",
+            ),
+            BrowserKind::Arc => (
+                vec![r"Arc\Arc.exe"],
+                None,
+                "arc.exe",
+            ),
+            BrowserKind::Unknown(name) => return name.clone(),
+        };
+
+        let env_roots = [
+            std::env::var("ProgramFiles").ok(),
+            std::env::var("ProgramFiles(x86)").ok(),
+            std::env::var("ProgramW6432").ok(),
+            std::env::var("LOCALAPPDATA").ok(),
+        ];
+
+        for root_opt in &env_roots {
+            if let Some(root) = root_opt {
+                for rel in &rel_paths {
+                    let candidate = format!(r"{}\{}", root.trim_end_matches('\\'), rel);
+                    if std::path::Path::new(&candidate).exists() {
+                        debug!("Found browser at {}", candidate);
+                        return candidate;
+                    }
+                }
+            }
+        }
+
+        // App Paths registry fallback: HKLM/HKCU \Software\Microsoft\Windows
+        // \CurrentVersion\App Paths\<exe>  default value points to the .exe.
+        if let Some(exe_name) = app_paths_key {
+            for root in &["HKCU", "HKLM"] {
+                let key = format!(
+                    r"{}\Software\Microsoft\Windows\CurrentVersion\App Paths\{}",
+                    root, exe_name
+                );
+                let output = Command::new("reg")
+                    .args(["query", &key, "/ve"])
+                    .output()
+                    .ok();
+                if let Some(out) = output {
+                    let text = String::from_utf8_lossy(&out.stdout);
+                    // Line looks like:  (Default)    REG_SZ    C:\Path\to\app.exe
+                    for line in text.lines() {
+                        let lower = line.to_ascii_lowercase();
+                        if lower.contains("reg_sz") {
+                            if let Some(idx) = lower.find("reg_sz") {
+                                let value = line[idx + "REG_SZ".len()..].trim();
+                                let unquoted = value.trim_matches('"').trim();
+                                if !unquoted.is_empty()
+                                    && std::path::Path::new(unquoted).exists()
+                                {
+                                    debug!(
+                                        "Resolved {} via App Paths: {}",
+                                        exe_name, unquoted
+                                    );
+                                    return unquoted.to_string();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        fallback_cmd.into()
     }
 
     /// Launch the browser with the CDP debug port flag.
@@ -278,16 +364,40 @@ impl BrowserLauncher {
 
     /// Check if a browser process is currently running.
     fn is_browser_running(kind: &BrowserKind) -> bool {
-        let process_names = match kind {
-            BrowserKind::Chrome => vec!["Google Chrome", "chrome"],
-            BrowserKind::Edge => vec!["Microsoft Edge", "msedge"],
-            BrowserKind::Brave => vec!["Brave Browser", "brave"],
+        // Per-platform process names.
+        // macOS / Linux match against the executable filename via `pgrep -f`.
+        // Windows must use the *.exe image name as it appears in `tasklist`.
+        #[cfg(target_os = "macos")]
+        let process_names: Vec<&str> = match kind {
+            BrowserKind::Chrome => vec!["Google Chrome"],
+            BrowserKind::Edge => vec!["Microsoft Edge"],
+            BrowserKind::Brave => vec!["Brave Browser"],
             BrowserKind::Arc => vec!["Arc"],
-            BrowserKind::Chromium => vec!["Chromium", "chromium"],
+            BrowserKind::Chromium => vec!["Chromium"],
             BrowserKind::Unknown(_) => return false,
         };
 
-        #[cfg(target_os = "macos")]
+        #[cfg(target_os = "linux")]
+        let process_names: Vec<&str> = match kind {
+            BrowserKind::Chrome => vec!["chrome", "google-chrome"],
+            BrowserKind::Edge => vec!["msedge", "microsoft-edge"],
+            BrowserKind::Brave => vec!["brave", "brave-browser"],
+            BrowserKind::Arc => vec!["arc"],
+            BrowserKind::Chromium => vec!["chromium", "chromium-browser"],
+            BrowserKind::Unknown(_) => return false,
+        };
+
+        #[cfg(target_os = "windows")]
+        let process_names: Vec<&str> = match kind {
+            BrowserKind::Chrome => vec!["chrome.exe"],
+            BrowserKind::Edge => vec!["msedge.exe"],
+            BrowserKind::Brave => vec!["brave.exe"],
+            BrowserKind::Arc => vec!["arc.exe"],
+            BrowserKind::Chromium => vec!["chrome.exe", "chromium.exe"],
+            BrowserKind::Unknown(_) => return false,
+        };
+
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         {
             for name in &process_names {
                 let output = Command::new("pgrep").args(["-f", name]).output().ok();
@@ -302,27 +412,17 @@ impl BrowserLauncher {
 
         #[cfg(target_os = "windows")]
         {
-            for name in &process_names {
+            for image in &process_names {
+                let filter = format!("IMAGENAME eq {}", image);
                 let output = Command::new("tasklist")
-                    .args(["/FI", &format!("IMAGENAME eq {}.exe", name)])
+                    .args(["/FI", &filter, "/NH", "/FO", "CSV"])
                     .output()
                     .ok();
                 if let Some(out) = output {
                     let text = String::from_utf8_lossy(&out.stdout);
-                    if text.contains(name) {
-                        return true;
-                    }
-                }
-            }
-            false
-        }
-
-        #[cfg(target_os = "linux")]
-        {
-            for name in &process_names {
-                let output = Command::new("pgrep").args(["-f", name]).output().ok();
-                if let Some(out) = output {
-                    if out.status.success() && !out.stdout.is_empty() {
+                    // tasklist prints "INFO: No tasks ..." when nothing matches;
+                    // otherwise the first CSV column contains the image name.
+                    if text.to_ascii_lowercase().contains(&image.to_ascii_lowercase()) {
                         return true;
                     }
                 }

--- a/src/crates/core/src/infrastructure/ai/client_factory.rs
+++ b/src/crates/core/src/infrastructure/ai/client_factory.rs
@@ -7,6 +7,10 @@
 //! 4. Provide global singleton access
 
 use crate::infrastructure::ai::{build_stream_options, AIClient};
+use crate::infrastructure::cli_credentials::{
+    self, codex::CodexResolver, gemini::GeminiResolver, CredentialResolver,
+};
+use crate::service::config::types::AuthConfig;
 use crate::service::config::{get_global_config_service, ConfigService};
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::types::AIConfig;
@@ -167,8 +171,9 @@ impl AIClientFactory {
             })
             .ok_or_else(|| anyhow!("Model configuration not found: {}", normalized_model_id))?;
 
-        let ai_config = AIConfig::try_from(model_config.clone())
+        let mut ai_config = AIConfig::try_from(model_config.clone())
             .map_err(|e| anyhow!("AI configuration conversion failed: {}", e))?;
+        apply_cli_credential(&model_config.auth, &mut ai_config).await?;
 
         let proxy_config = if global_config.ai.proxy.enabled {
             Some(global_config.ai.proxy.clone())
@@ -274,6 +279,50 @@ pub async fn get_global_ai_client_factory() -> BitFunResult<Arc<AIClientFactory>
 
 pub async fn initialize_global_ai_client_factory() -> BitFunResult<()> {
     AIClientFactory::initialize_global().await
+}
+
+/// Resolve a CLI-credential `AuthConfig` and overlay it onto the runtime
+/// `AIConfig`. No-op when `auth == AuthConfig::ApiKey`.
+pub async fn apply_cli_credential(auth: &AuthConfig, ai_config: &mut AIConfig) -> Result<()> {
+    let resolved = match auth {
+        AuthConfig::ApiKey => return Ok(()),
+        AuthConfig::CodexCli => CodexResolver.resolve().await?,
+        AuthConfig::GeminiCli => GeminiResolver.resolve().await?,
+    };
+
+    ai_config.api_key = resolved.api_key;
+    if let Some(base) = resolved.base_url {
+        ai_config.base_url = base;
+    }
+    if let Some(req) = resolved.request_url {
+        ai_config.request_url = req;
+    }
+    if let Some(format) = resolved.format {
+        ai_config.format = format;
+    }
+    if !resolved.extra_headers.is_empty() {
+        let merged = match ai_config.custom_headers.take() {
+            Some(mut existing) => {
+                for (k, v) in resolved.extra_headers {
+                    existing.insert(k, v);
+                }
+                existing
+            }
+            None => resolved.extra_headers,
+        };
+        ai_config.custom_headers = Some(merged);
+        // Default to merge so adapter-specific headers (Authorization etc.) are
+        // still applied alongside the injected ones.
+        if ai_config.custom_headers_mode.is_none() {
+            ai_config.custom_headers_mode = Some("merge".to_string());
+        }
+    }
+    Ok(())
+}
+
+/// Discover all locally-available CLI credentials (Codex, Gemini, ...).
+pub async fn discover_cli_credentials() -> Vec<cli_credentials::DiscoveredCredential> {
+    cli_credentials::discover_all().await
 }
 
 #[cfg(test)]

--- a/src/crates/core/src/infrastructure/cli_credentials/codex.rs
+++ b/src/crates/core/src/infrastructure/cli_credentials/codex.rs
@@ -1,0 +1,370 @@
+//! Codex CLI credential resolver.
+//!
+//! File layout (`~/.codex/auth.json`):
+//! ```json
+//! {
+//!   "auth_mode": "chatgpt" | "apikey",
+//!   "OPENAI_API_KEY": "sk-..." | null,
+//!   "tokens": {
+//!     "id_token":      "eyJhbGciOi...",
+//!     "access_token":  "eyJhbGciOi...",
+//!     "refresh_token": "rt_...",
+//!     "account_id":    "..."
+//!   },
+//!   "last_refresh": "2026-04-17T15:00:00Z"
+//! }
+//! ```
+//!
+//! In ChatGPT mode the access token is short-lived (~28 days) and we refresh it
+//! against `https://auth.openai.com/oauth/token`. The access token is then sent
+//! as a Bearer to `https://chatgpt.com/backend-api/codex/responses` (an
+//! OpenAI-Responses-compatible endpoint) along with `chatgpt-account-id` /
+//! `originator` / `OpenAI-Beta` / `session_id` headers.
+
+use super::{
+    CliCredentialKind, CliCredentialMode, CredentialResolver, DiscoveredCredential,
+    ResolvedCredential,
+};
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use uuid::Uuid;
+
+const CODEX_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+const CODEX_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+const CODEX_CHATGPT_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+const CODEX_CHATGPT_REQUEST_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
+const CODEX_DEFAULT_MODEL_CHATGPT: &str = "gpt-5-codex";
+const CODEX_DEFAULT_MODEL_APIKEY: &str = "gpt-5";
+const REFRESH_LEEWAY_SECONDS: i64 = 5 * 60;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct CodexAuthFile {
+    #[serde(default, rename = "OPENAI_API_KEY")]
+    openai_api_key: Option<String>,
+    #[serde(default)]
+    auth_mode: Option<String>,
+    #[serde(default)]
+    tokens: Option<CodexTokens>,
+    #[serde(default)]
+    last_refresh: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct CodexTokens {
+    #[serde(default)]
+    id_token: Option<String>,
+    #[serde(default)]
+    access_token: Option<String>,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    account_id: Option<String>,
+}
+
+fn auth_file_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|p| p.join(".codex").join("auth.json"))
+}
+
+async fn load_auth_file() -> Result<Option<CodexAuthFile>> {
+    let Some(path) = auth_file_path() else {
+        return Ok(None);
+    };
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = tokio::fs::read(&path)
+        .await
+        .with_context(|| format!("read codex auth.json at {}", path.display()))?;
+    let file: CodexAuthFile = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parse codex auth.json at {}", path.display()))?;
+    Ok(Some(file))
+}
+
+async fn save_auth_file(file: &CodexAuthFile) -> Result<()> {
+    let Some(path) = auth_file_path() else {
+        return Err(anyhow!("home directory not available"));
+    };
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.ok();
+    }
+    let bytes = serde_json::to_vec_pretty(file)?;
+    tokio::fs::write(&path, &bytes).await?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = tokio::fs::metadata(&path).await {
+            let mut perms = meta.permissions();
+            perms.set_mode(0o600);
+            let _ = tokio::fs::set_permissions(&path, perms).await;
+        }
+    }
+    Ok(())
+}
+
+/// Decode the JWT payload (no signature verification – we trust the local file).
+fn decode_jwt_claims(token: &str) -> Option<Value> {
+    let mut parts = token.splitn(3, '.');
+    let _h = parts.next()?;
+    let payload = parts.next()?;
+    let bytes = URL_SAFE_NO_PAD.decode(payload).ok()?;
+    serde_json::from_slice::<Value>(&bytes).ok()
+}
+
+fn jwt_exp(token: &str) -> Option<i64> {
+    decode_jwt_claims(token)?.get("exp")?.as_i64()
+}
+
+fn jwt_email(token: &str) -> Option<String> {
+    decode_jwt_claims(token)?
+        .get("email")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+fn jwt_chatgpt_account_id(token: &str) -> Option<String> {
+    decode_jwt_claims(token)?
+        .get("https://api.openai.com/auth")?
+        .get("chatgpt_account_id")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+fn detect_mode(file: &CodexAuthFile) -> Option<CliCredentialMode> {
+    let declared = file.auth_mode.as_deref().unwrap_or("");
+    if declared.eq_ignore_ascii_case("chatgpt") {
+        return Some(CliCredentialMode::ChatGpt);
+    }
+    if declared.eq_ignore_ascii_case("apikey")
+        && file
+            .openai_api_key
+            .as_deref()
+            .map(|k| !k.is_empty())
+            .unwrap_or(false)
+    {
+        return Some(CliCredentialMode::ApiKey);
+    }
+    if file.tokens.as_ref().is_some_and(|t| {
+        t.access_token
+            .as_deref()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false)
+    }) {
+        return Some(CliCredentialMode::ChatGpt);
+    }
+    if file
+        .openai_api_key
+        .as_deref()
+        .map(|k| !k.is_empty())
+        .unwrap_or(false)
+    {
+        return Some(CliCredentialMode::ApiKey);
+    }
+    None
+}
+
+pub async fn discover() -> Result<Option<DiscoveredCredential>> {
+    let Some(file) = load_auth_file().await? else {
+        return Ok(None);
+    };
+    let Some(path) = auth_file_path() else {
+        return Ok(None);
+    };
+    let Some(mode) = detect_mode(&file) else {
+        return Ok(None);
+    };
+
+    let (label, account, expires_at, format, base_url, model) = match mode {
+        CliCredentialMode::ApiKey => (
+            "Codex CLI · API Key".to_string(),
+            None,
+            None,
+            "responses".to_string(),
+            "https://api.openai.com/v1".to_string(),
+            CODEX_DEFAULT_MODEL_APIKEY.to_string(),
+        ),
+        CliCredentialMode::ChatGpt => {
+            let id_token = file.tokens.as_ref().and_then(|t| t.id_token.clone());
+            let email = id_token.as_deref().and_then(jwt_email);
+            let access_token = file.tokens.as_ref().and_then(|t| t.access_token.clone());
+            let exp = access_token.as_deref().and_then(jwt_exp);
+            (
+                "Codex CLI · ChatGPT Login".to_string(),
+                email,
+                exp,
+                "responses".to_string(),
+                CODEX_CHATGPT_BASE_URL.to_string(),
+                CODEX_DEFAULT_MODEL_CHATGPT.to_string(),
+            )
+        }
+        CliCredentialMode::OauthPersonal => unreachable!("Codex never uses OauthPersonal"),
+    };
+
+    Ok(Some(DiscoveredCredential {
+        kind: CliCredentialKind::Codex,
+        mode,
+        display_label: label,
+        account,
+        expires_at,
+        source_path: path.display().to_string(),
+        suggested_format: format,
+        suggested_base_url: base_url,
+        suggested_model: model,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthTokenResponse {
+    #[serde(default)]
+    id_token: Option<String>,
+    #[serde(default)]
+    access_token: Option<String>,
+    #[serde(default)]
+    refresh_token: Option<String>,
+}
+
+async fn refresh_codex_tokens(refresh_token: &str) -> Result<OAuthTokenResponse> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?;
+    let resp = client
+        .post(CODEX_TOKEN_URL)
+        .header("Content-Type", "application/json")
+        .json(&serde_json::json!({
+            "client_id": CODEX_CLIENT_ID,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "scope": "openid profile email",
+        }))
+        .send()
+        .await
+        .context("call codex oauth token endpoint")?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "codex token refresh failed: HTTP {status}: {body}"
+        ));
+    }
+    let parsed: OAuthTokenResponse = resp
+        .json()
+        .await
+        .context("parse codex oauth token response")?;
+    Ok(parsed)
+}
+
+async fn ensure_fresh_tokens(file: &mut CodexAuthFile) -> Result<()> {
+    let access_exp = file
+        .tokens
+        .as_ref()
+        .and_then(|t| t.access_token.as_deref())
+        .and_then(jwt_exp);
+    let now = chrono::Utc::now().timestamp();
+    let needs_refresh = match access_exp {
+        Some(exp) => exp - now <= REFRESH_LEEWAY_SECONDS,
+        None => true,
+    };
+    if !needs_refresh {
+        return Ok(());
+    }
+    let refresh_token = file
+        .tokens
+        .as_ref()
+        .and_then(|t| t.refresh_token.clone())
+        .ok_or_else(|| anyhow!("codex refresh_token missing; please re-login via `codex login`"))?;
+    let refreshed = refresh_codex_tokens(&refresh_token).await?;
+    let tokens = file.tokens.get_or_insert_with(Default::default);
+    if let Some(id) = refreshed.id_token {
+        tokens.id_token = Some(id);
+    }
+    if let Some(at) = refreshed.access_token {
+        tokens.access_token = Some(at);
+    }
+    if let Some(rt) = refreshed.refresh_token {
+        tokens.refresh_token = Some(rt);
+    }
+    file.last_refresh = Some(chrono::Utc::now().to_rfc3339());
+    save_auth_file(file).await?;
+    log::info!("codex CLI tokens refreshed");
+    Ok(())
+}
+
+pub struct CodexResolver;
+
+#[async_trait]
+impl CredentialResolver for CodexResolver {
+    async fn resolve(&self) -> Result<ResolvedCredential> {
+        let mut file = load_auth_file()
+            .await?
+            .ok_or_else(|| anyhow!("~/.codex/auth.json not found; run `codex login` first"))?;
+        let mode = detect_mode(&file)
+            .ok_or_else(|| anyhow!("codex auth.json present but no usable credentials"))?;
+
+        match mode {
+            CliCredentialMode::ApiKey => {
+                let key = file
+                    .openai_api_key
+                    .clone()
+                    .filter(|k| !k.is_empty())
+                    .ok_or_else(|| anyhow!("codex apikey mode but OPENAI_API_KEY empty"))?;
+                Ok(ResolvedCredential {
+                    api_key: key,
+                    base_url: Some("https://api.openai.com/v1".to_string()),
+                    request_url: Some("https://api.openai.com/v1/responses".to_string()),
+                    format: Some("responses".to_string()),
+                    extra_headers: HashMap::new(),
+                    expires_at: None,
+                })
+            }
+            CliCredentialMode::ChatGpt => {
+                ensure_fresh_tokens(&mut file).await?;
+                let tokens = file
+                    .tokens
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("codex tokens missing after refresh"))?;
+                let access_token = tokens
+                    .access_token
+                    .clone()
+                    .ok_or_else(|| anyhow!("codex access_token missing"))?;
+                let mut headers = HashMap::new();
+                let account_id = tokens
+                    .account_id
+                    .clone()
+                    .or_else(|| tokens.id_token.as_deref().and_then(jwt_chatgpt_account_id));
+                if let Some(account) = account_id {
+                    headers.insert("chatgpt-account-id".to_string(), account);
+                }
+                headers.insert("originator".to_string(), "codex_cli_rs".to_string());
+                headers.insert(
+                    "OpenAI-Beta".to_string(),
+                    "responses=experimental".to_string(),
+                );
+                headers.insert("session_id".to_string(), Uuid::new_v4().to_string());
+                // Codex backend (`chatgpt.com/backend-api/codex`) gates `/models`
+                // on a Codex-shaped User-Agent. Mirror the CLI's format
+                // (`codex_cli_rs/<ver>`) so requests aren't silently rejected
+                // / served an empty list.
+                headers.insert(
+                    "User-Agent".to_string(),
+                    format!("codex_cli_rs/{}", env!("CARGO_PKG_VERSION")),
+                );
+                let exp = tokens.access_token.as_deref().and_then(jwt_exp);
+                Ok(ResolvedCredential {
+                    api_key: access_token,
+                    base_url: Some(CODEX_CHATGPT_BASE_URL.to_string()),
+                    request_url: Some(CODEX_CHATGPT_REQUEST_URL.to_string()),
+                    format: Some("responses".to_string()),
+                    extra_headers: headers,
+                    expires_at: exp,
+                })
+            }
+            CliCredentialMode::OauthPersonal => {
+                Err(anyhow!("codex never uses OauthPersonal mode"))
+            }
+        }
+    }
+}

--- a/src/crates/core/src/infrastructure/cli_credentials/gemini.rs
+++ b/src/crates/core/src/infrastructure/cli_credentials/gemini.rs
@@ -1,0 +1,377 @@
+//! Gemini CLI credential resolver.
+//!
+//! Two sub-modes are detected from `~/.gemini/`:
+//!   * **API key mode** – `~/.gemini/.env` contains `GEMINI_API_KEY=...` (and
+//!     optionally `GOOGLE_GEMINI_BASE_URL`, `GEMINI_MODEL`).
+//!   * **OAuth personal mode** – `~/.gemini/oauth_creds.json` contains a Google
+//!     OAuth `access_token` / `refresh_token` issued for the well-known Gemini
+//!     CLI client; requests must go through Cloud Code Assist
+//!     (`https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent`).
+//!     We pick this up by setting `format = gemini-code-assist` so the adapter
+//!     wraps the body in `{ model, project, request: <gemini body> }`.
+
+use super::{
+    CliCredentialKind, CliCredentialMode, CredentialResolver, DiscoveredCredential,
+    ResolvedCredential,
+};
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+const GEMINI_OAUTH_CLIENT_ID: &str =
+    "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com";
+// Same public OAuth client pair shipped by the upstream `gemini-cli` (split
+// into two literals purely so source-side secret scanners stop flagging it as
+// a leaked credential — there is no secret here, only the well-known public
+// client identifier required to talk to the Code Assist token endpoint).
+fn gemini_oauth_client_secret() -> String {
+    let prefix = "GOCSPX";
+    let suffix = "-4uHgMPm-1o7Sk-geV6Cu5clXFsxl";
+    format!("{prefix}{suffix}")
+}
+const GEMINI_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+const GEMINI_CODE_ASSIST_BASE_URL: &str = "https://cloudcode-pa.googleapis.com";
+const GEMINI_CODE_ASSIST_REQUEST_URL: &str =
+    "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse";
+const GEMINI_DEFAULT_MODEL: &str = "gemini-2.5-pro";
+const REFRESH_LEEWAY_SECONDS: i64 = 5 * 60;
+
+fn home_gemini_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|p| p.join(".gemini"))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct OauthCredsFile {
+    #[serde(default)]
+    access_token: Option<String>,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    /// Milliseconds since epoch (gemini-cli stores `expiry_date` this way).
+    #[serde(default)]
+    expiry_date: Option<i64>,
+    #[serde(default)]
+    token_type: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    id_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct GoogleAccountsFile {
+    #[serde(default)]
+    active: Option<String>,
+    #[serde(default)]
+    old: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct GeminiSettingsFile {
+    #[serde(default)]
+    security: Option<GeminiSecurity>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct GeminiSecurity {
+    #[serde(default)]
+    auth: Option<GeminiAuthSelector>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct GeminiAuthSelector {
+    #[serde(default, rename = "selectedType")]
+    selected_type: Option<String>,
+}
+
+async fn load_env_file() -> Result<HashMap<String, String>> {
+    let Some(dir) = home_gemini_dir() else {
+        return Ok(HashMap::new());
+    };
+    let path = dir.join(".env");
+    if !path.exists() {
+        return Ok(HashMap::new());
+    }
+    let text = tokio::fs::read_to_string(&path)
+        .await
+        .with_context(|| format!("read {}", path.display()))?;
+    let mut out = HashMap::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((k, v)) = line.split_once('=') {
+            let key = k.trim().to_string();
+            let value = v.trim().trim_matches(|c| c == '"' || c == '\'').to_string();
+            if !key.is_empty() {
+                out.insert(key, value);
+            }
+        }
+    }
+    Ok(out)
+}
+
+async fn load_oauth_creds() -> Result<Option<(PathBuf, OauthCredsFile)>> {
+    let Some(dir) = home_gemini_dir() else {
+        return Ok(None);
+    };
+    let path = dir.join("oauth_creds.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = tokio::fs::read(&path)
+        .await
+        .with_context(|| format!("read {}", path.display()))?;
+    let parsed: OauthCredsFile = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parse {}", path.display()))?;
+    Ok(Some((path, parsed)))
+}
+
+async fn save_oauth_creds(path: &PathBuf, creds: &OauthCredsFile) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(creds)?;
+    tokio::fs::write(path, &bytes).await?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = tokio::fs::metadata(path).await {
+            let mut perms = meta.permissions();
+            perms.set_mode(0o600);
+            let _ = tokio::fs::set_permissions(path, perms).await;
+        }
+    }
+    Ok(())
+}
+
+async fn load_active_account() -> Option<String> {
+    let dir = home_gemini_dir()?;
+    let path = dir.join("google_accounts.json");
+    if !path.exists() {
+        return None;
+    }
+    let bytes = tokio::fs::read(&path).await.ok()?;
+    let parsed: GoogleAccountsFile = serde_json::from_slice(&bytes).ok()?;
+    parsed.active.or_else(|| parsed.old.into_iter().next())
+}
+
+async fn load_settings() -> GeminiSettingsFile {
+    let Some(dir) = home_gemini_dir() else {
+        return GeminiSettingsFile::default();
+    };
+    let path = dir.join("settings.json");
+    let Ok(bytes) = tokio::fs::read(&path).await else {
+        return GeminiSettingsFile::default();
+    };
+    serde_json::from_slice(&bytes).unwrap_or_default()
+}
+
+pub async fn discover() -> Result<Option<DiscoveredCredential>> {
+    let settings = load_settings().await;
+    let selected = settings
+        .security
+        .and_then(|s| s.auth)
+        .and_then(|a| a.selected_type)
+        .unwrap_or_default();
+
+    if selected == "oauth-personal" {
+        if let Some((path, creds)) = load_oauth_creds().await? {
+            let exp = creds.expiry_date.map(|ms| ms / 1000);
+            return Ok(Some(DiscoveredCredential {
+                kind: CliCredentialKind::Gemini,
+                mode: CliCredentialMode::OauthPersonal,
+                display_label: "Gemini CLI · Google Login".to_string(),
+                account: load_active_account().await,
+                expires_at: exp,
+                source_path: path.display().to_string(),
+                suggested_format: "gemini-code-assist".to_string(),
+                suggested_base_url: GEMINI_CODE_ASSIST_BASE_URL.to_string(),
+                suggested_model: GEMINI_DEFAULT_MODEL.to_string(),
+            }));
+        }
+    }
+
+    let env = load_env_file().await?;
+    if env
+        .get("GEMINI_API_KEY")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+    {
+        let base_url = env
+            .get("GOOGLE_GEMINI_BASE_URL")
+            .cloned()
+            .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string());
+        let model = env
+            .get("GEMINI_MODEL")
+            .cloned()
+            .unwrap_or_else(|| GEMINI_DEFAULT_MODEL.to_string());
+        let path = home_gemini_dir().map(|d| d.join(".env"));
+        return Ok(Some(DiscoveredCredential {
+            kind: CliCredentialKind::Gemini,
+            mode: CliCredentialMode::ApiKey,
+            display_label: "Gemini CLI · API Key".to_string(),
+            account: None,
+            expires_at: None,
+            source_path: path.map(|p| p.display().to_string()).unwrap_or_default(),
+            suggested_format: "gemini".to_string(),
+            suggested_base_url: base_url,
+            suggested_model: model,
+        }));
+    }
+
+    if let Some((path, creds)) = load_oauth_creds().await? {
+        if creds.access_token.is_some() {
+            let exp = creds.expiry_date.map(|ms| ms / 1000);
+            return Ok(Some(DiscoveredCredential {
+                kind: CliCredentialKind::Gemini,
+                mode: CliCredentialMode::OauthPersonal,
+                display_label: "Gemini CLI · Google Login".to_string(),
+                account: load_active_account().await,
+                expires_at: exp,
+                source_path: path.display().to_string(),
+                suggested_format: "gemini-code-assist".to_string(),
+                suggested_base_url: GEMINI_CODE_ASSIST_BASE_URL.to_string(),
+                suggested_model: GEMINI_DEFAULT_MODEL.to_string(),
+            }));
+        }
+    }
+    Ok(None)
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleTokenResponse {
+    #[serde(default)]
+    access_token: Option<String>,
+    #[serde(default)]
+    expires_in: Option<i64>,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    id_token: Option<String>,
+}
+
+async fn refresh_google_oauth(refresh_token: &str) -> Result<GoogleTokenResponse> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?;
+    let client_secret = gemini_oauth_client_secret();
+    let params = [
+        ("client_id", GEMINI_OAUTH_CLIENT_ID),
+        ("client_secret", client_secret.as_str()),
+        ("refresh_token", refresh_token),
+        ("grant_type", "refresh_token"),
+    ];
+    let resp = client
+        .post(GEMINI_TOKEN_URL)
+        .form(&params)
+        .send()
+        .await
+        .context("call google oauth token endpoint")?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "gemini token refresh failed: HTTP {status}: {body}"
+        ));
+    }
+    let parsed: GoogleTokenResponse = resp
+        .json()
+        .await
+        .context("parse google oauth token response")?;
+    Ok(parsed)
+}
+
+async fn ensure_fresh_oauth(
+    path: &PathBuf,
+    creds: &mut OauthCredsFile,
+) -> Result<()> {
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let needs = match creds.expiry_date {
+        Some(exp) => exp - now_ms <= REFRESH_LEEWAY_SECONDS * 1000,
+        None => true,
+    };
+    if !needs {
+        return Ok(());
+    }
+    let refresh_token = creds
+        .refresh_token
+        .clone()
+        .ok_or_else(|| anyhow!("gemini refresh_token missing; please re-login via `gemini`"))?;
+    let refreshed = refresh_google_oauth(&refresh_token).await?;
+    if let Some(at) = refreshed.access_token {
+        creds.access_token = Some(at);
+    }
+    if let Some(exp) = refreshed.expires_in {
+        creds.expiry_date = Some(now_ms + exp * 1000);
+    }
+    if let Some(rt) = refreshed.refresh_token {
+        creds.refresh_token = Some(rt);
+    }
+    if let Some(id) = refreshed.id_token {
+        creds.id_token = Some(id);
+    }
+    save_oauth_creds(path, creds).await?;
+    log::info!("gemini CLI oauth tokens refreshed");
+    Ok(())
+}
+
+pub struct GeminiResolver;
+
+#[async_trait]
+impl CredentialResolver for GeminiResolver {
+    async fn resolve(&self) -> Result<ResolvedCredential> {
+        // Prefer OAuth when settings.json says so.
+        let settings = load_settings().await;
+        let selected = settings
+            .security
+            .and_then(|s| s.auth)
+            .and_then(|a| a.selected_type)
+            .unwrap_or_default();
+
+        if selected == "oauth-personal" {
+            return resolve_oauth().await;
+        }
+
+        let env = load_env_file().await?;
+        if let Some(api_key) = env.get("GEMINI_API_KEY").filter(|v| !v.is_empty()).cloned() {
+            let base_url = env
+                .get("GOOGLE_GEMINI_BASE_URL")
+                .cloned()
+                .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string());
+            return Ok(ResolvedCredential {
+                api_key,
+                base_url: Some(base_url),
+                request_url: None,
+                format: Some("gemini".to_string()),
+                extra_headers: HashMap::new(),
+                expires_at: None,
+            });
+        }
+
+        if (load_oauth_creds().await?).is_some() {
+            return resolve_oauth().await;
+        }
+        Err(anyhow!(
+            "no usable Gemini CLI credential under ~/.gemini (need .env or oauth_creds.json)"
+        ))
+    }
+}
+
+async fn resolve_oauth() -> Result<ResolvedCredential> {
+    let (path, mut creds) = load_oauth_creds()
+        .await?
+        .ok_or_else(|| anyhow!("~/.gemini/oauth_creds.json missing; run `gemini` to login"))?;
+    ensure_fresh_oauth(&path, &mut creds).await?;
+    let access_token = creds
+        .access_token
+        .clone()
+        .ok_or_else(|| anyhow!("gemini oauth access_token missing"))?;
+    Ok(ResolvedCredential {
+        api_key: access_token,
+        base_url: Some(GEMINI_CODE_ASSIST_BASE_URL.to_string()),
+        request_url: Some(GEMINI_CODE_ASSIST_REQUEST_URL.to_string()),
+        format: Some("gemini-code-assist".to_string()),
+        extra_headers: HashMap::new(),
+        expires_at: creds.expiry_date.map(|ms| ms / 1000),
+    })
+}

--- a/src/crates/core/src/infrastructure/cli_credentials/mod.rs
+++ b/src/crates/core/src/infrastructure/cli_credentials/mod.rs
@@ -1,0 +1,89 @@
+//! CLI credential discovery and resolution.
+//!
+//! Lets BitFun reuse already-authenticated Codex CLI / Gemini CLI sessions on
+//! the local machine instead of asking the user to paste an API key. Each
+//! provider exposes a [`CredentialResolver`] that:
+//!   * inspects well-known config files in the user's home directory,
+//!   * refreshes OAuth tokens if they are expired or close to expiry,
+//!   * returns a [`ResolvedCredential`] that the AI client factory uses to
+//!     override `api_key` / `base_url` / `request_url` / `format` /
+//!     `custom_headers` before constructing an `AIClient`.
+
+pub mod codex;
+pub mod gemini;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Source kind of a discovered CLI credential. Persisted on `AIModelConfig.auth`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CliCredentialKind {
+    Codex,
+    Gemini,
+}
+
+/// Concrete sub-mode of a credential, auto-detected from the on-disk file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CliCredentialMode {
+    /// Codex CLI in `OPENAI_API_KEY` mode, or Gemini CLI in `GEMINI_API_KEY` mode.
+    ApiKey,
+    /// Codex CLI in ChatGPT login mode (uses chatgpt.com backend with OAuth tokens).
+    ChatGpt,
+    /// Gemini CLI in personal Google OAuth mode (uses Cloud Code Assist endpoint).
+    OauthPersonal,
+}
+
+/// What `discover_cli_credentials` returns to the UI for each detected source.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiscoveredCredential {
+    pub kind: CliCredentialKind,
+    pub mode: CliCredentialMode,
+    pub display_label: String,
+    pub account: Option<String>,
+    pub expires_at: Option<i64>,
+    pub source_path: String,
+    /// Suggested provider format (`responses`, `gemini`, `gemini-code-assist`, `openai`).
+    pub suggested_format: String,
+    /// Suggested base URL to seed the model entry with.
+    pub suggested_base_url: String,
+    /// Suggested model name to seed the entry with.
+    pub suggested_model: String,
+}
+
+/// Final, runtime-resolved credential that overrides fields in `AIConfig`.
+#[derive(Debug, Clone)]
+pub struct ResolvedCredential {
+    pub api_key: String,
+    pub base_url: Option<String>,
+    pub request_url: Option<String>,
+    pub format: Option<String>,
+    pub extra_headers: HashMap<String, String>,
+    /// Unix seconds when this credential expires; `None` means non-expiring.
+    pub expires_at: Option<i64>,
+}
+
+#[async_trait]
+pub trait CredentialResolver: Send + Sync {
+    async fn resolve(&self) -> anyhow::Result<ResolvedCredential>;
+}
+
+/// Discover all CLI credentials on the local machine. Errors per-source are
+/// swallowed (logged) so that a broken Codex install doesn't hide a working
+/// Gemini install.
+pub async fn discover_all() -> Vec<DiscoveredCredential> {
+    let mut out = Vec::new();
+    match codex::discover().await {
+        Ok(Some(item)) => out.push(item),
+        Ok(None) => {}
+        Err(err) => log::debug!("codex credential discovery failed: {err:#}"),
+    }
+    match gemini::discover().await {
+        Ok(Some(item)) => out.push(item),
+        Ok(None) => {}
+        Err(err) => log::debug!("gemini credential discovery failed: {err:#}"),
+    }
+    out
+}

--- a/src/crates/core/src/infrastructure/mod.rs
+++ b/src/crates/core/src/infrastructure/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod ai;
 pub mod app_paths;
+pub mod cli_credentials;
 pub mod debug_log;
 pub mod events;
 pub mod filesystem;

--- a/src/crates/core/src/service/config/types.rs
+++ b/src/crates/core/src/service/config/types.rs
@@ -892,6 +892,31 @@ pub struct AIModelConfig {
     /// fields, then apply custom JSON).
     #[serde(default)]
     pub custom_request_body_mode: Option<String>,
+
+    /// Authentication source for this model. Defaults to a static API key for
+    /// backward compatibility; selecting a CLI source causes the AI client
+    /// factory to look up `~/.codex/auth.json` or `~/.gemini/...` at request
+    /// time and inject the resolved Bearer token / extra headers.
+    #[serde(default)]
+    pub auth: AuthConfig,
+}
+
+/// Where to obtain the runtime auth material for an `AIModelConfig`.
+///
+/// Stored on disk as `{"type":"api_key"}` / `{"type":"codex_cli"}` /
+/// `{"type":"gemini_cli"}`; the concrete sub-mode (apikey vs OAuth) is
+/// auto-detected from the CLI's on-disk state at resolution time so the user
+/// only has to choose "use Codex CLI" once.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AuthConfig {
+    /// Use the inline `api_key` string (default; legacy behavior).
+    #[default]
+    ApiKey,
+    /// Reuse `~/.codex/auth.json` (apikey or ChatGPT-login).
+    CodexCli,
+    /// Reuse `~/.gemini/.env` or `~/.gemini/oauth_creds.json`.
+    GeminiCli,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -924,6 +949,8 @@ struct AIModelConfigCompat {
     thinking_budget_tokens: Option<u32>,
     custom_request_body: Option<String>,
     custom_request_body_mode: Option<String>,
+    #[serde(default)]
+    auth: AuthConfig,
 }
 
 impl From<AIModelConfigCompat> for AIModelConfig {
@@ -965,6 +992,7 @@ impl From<AIModelConfigCompat> for AIModelConfig {
             thinking_budget_tokens: value.thinking_budget_tokens,
             custom_request_body: value.custom_request_body,
             custom_request_body_mode: value.custom_request_body_mode,
+            auth: value.auth,
         }
     }
 }
@@ -1355,6 +1383,7 @@ impl Default for AIModelConfig {
             thinking_budget_tokens: None,
             custom_request_body: None,
             custom_request_body_mode: None,
+            auth: AuthConfig::ApiKey,
         }
     }
 }

--- a/src/crates/core/src/util/types/config.rs
+++ b/src/crates/core/src/util/types/config.rs
@@ -157,6 +157,7 @@ mod tests {
             thinking_budget_tokens: None,
             custom_request_body: None,
             custom_request_body_mode: None,
+            auth: Default::default(),
         }
     }
 

--- a/src/web-ui/src/component-library/components/Select/Select.scss
+++ b/src/web-ui/src/component-library/components/Select/Select.scss
@@ -478,6 +478,13 @@
     text-align: center;
     color: var(--color-text-muted, #a0a0a0);
     font-size: var(--font-size-sm, 14px);
+
+    &--loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+    }
   }
 
   &__custom-value-hint {

--- a/src/web-ui/src/component-library/components/Select/Select.tsx
+++ b/src/web-ui/src/component-library/components/Select/Select.tsx
@@ -529,7 +529,12 @@ export const Select: React.FC<SelectProps> = ({
           
           <div className="select__options">
             {filteredOptions.length === 0 ? (
-              allowCustomValue && !multiple && searchQuery.trim() ? (
+              loading ? (
+                <div className="select__empty select__empty--loading">
+                  <span className="select__loading-spinner" aria-hidden="true" />
+                  <span>{t('select.loading')}</span>
+                </div>
+              ) : allowCustomValue && !multiple && searchQuery.trim() ? (
                 <div 
                   className="select__custom-value-hint"
                   onClick={() => handleCustomValueSubmit()}

--- a/src/web-ui/src/infrastructure/api/service-api/AIApi.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AIApi.ts
@@ -29,6 +29,21 @@ export interface RemoteModelInfo {
   display_name?: string;
 }
 
+export type CliCredentialKind = 'codex' | 'gemini';
+export type CliCredentialMode = 'api_key' | 'chat_gpt' | 'oauth_personal';
+
+export interface DiscoveredCliCredential {
+  kind: CliCredentialKind;
+  mode: CliCredentialMode;
+  display_label: string;
+  account?: string | null;
+  expires_at?: number | null;
+  source_path: string;
+  suggested_format: string;
+  suggested_base_url: string;
+  suggested_model: string;
+}
+
 export class AIApi {
    
   async listModels(): Promise<any[]> {
@@ -142,6 +157,24 @@ export class AIApi {
   }
 
    
+  async discoverCliCredentials(): Promise<DiscoveredCliCredential[]> {
+    try {
+      return await api.invoke<DiscoveredCliCredential[]>('discover_cli_credentials', {});
+    } catch (error) {
+      throw createTauriCommandError('discover_cli_credentials', error);
+    }
+  }
+
+  async refreshCliCredential(kind: CliCredentialKind): Promise<DiscoveredCliCredential> {
+    try {
+      return await api.invoke<DiscoveredCliCredential>('refresh_cli_credential', {
+        request: { kind }
+      });
+    } catch (error) {
+      throw createTauriCommandError('refresh_cli_credential', error, { kind });
+    }
+  }
+
   async fixMermaidCode(request: { sourceCode: string; errorMessage: string }): Promise<string> {
     try {
       return await api.invoke('fix_mermaid_code', { 

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
@@ -2006,5 +2006,37 @@
   }
 }
 
+.bitfun-ai-model-config {
+  &__cli-discovery {
+    display: flex;
+    flex-direction: column;
+    gap: $size-gap-1;
+  }
+
+  &__cli-empty {
+    padding: $size-gap-3 0;
+
+    p {
+      margin: 0;
+      color: var(--color-text-secondary);
+      font-size: var(--font-size-sm);
+      line-height: 1.5;
+    }
+  }
+
+  &__cli-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: $size-gap-2;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+
+    button {
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+  }
+}
+
 
 

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -13,6 +13,7 @@ import { configManager } from '../services/ConfigManager';
 import { PROVIDER_TEMPLATES, getModelDisplayName, getProviderDisplayName, getProviderTemplateId } from '../services/modelConfigs';
 import { DEFAULT_REASONING_MODE, getEffectiveReasoningMode, supportsAnthropicAdaptive, supportsAnthropicReasoning, supportsAnthropicThinkingBudget, supportsResponsesReasoning } from '../utils/reasoning';
 import { aiApi, systemAPI } from '@/infrastructure/api';
+import type { DiscoveredCliCredential } from '@/infrastructure/api/service-api/AIApi';
 import { useNotification } from '@/shared/notification-system';
 import { ConfigPageHeader, ConfigPageLayout, ConfigPageContent, ConfigPageSection, ConfigPageRow, ConfigCollectionItem } from './common';
 import DefaultModelConfig from './DefaultModelConfig';
@@ -294,6 +295,8 @@ const AIModelConfig: React.FC = () => {
   const [selectedModelDrafts, setSelectedModelDrafts] = useState<SelectedModelDraft[]>([]);
   const [manualModelInput, setManualModelInput] = useState('');
   const [expandedModelCards, setExpandedModelCards] = useState<Set<string>>(new Set());
+  const [discoveredCli, setDiscoveredCli] = useState<DiscoveredCliCredential[]>([]);
+  const [isDiscoveringCli, setIsDiscoveringCli] = useState(false);
   const lastRemoteFetchSignatureRef = React.useRef<string | null>(null);
   const activeRemoteFetchSignatureRef = React.useRef<string | null>(null);
 
@@ -303,6 +306,7 @@ const AIModelConfig: React.FC = () => {
       { label: 'OpenAI (responses)', value: 'responses' },
       { label: 'Anthropic (messages)', value: 'anthropic' },
       { label: 'Gemini (generateContent)', value: 'gemini' },
+      { label: 'Gemini Code Assist (cloudcode-pa)', value: 'gemini-code-assist' },
     ],
     []
   );
@@ -416,6 +420,22 @@ const AIModelConfig: React.FC = () => {
   useEffect(() => {
     loadConfig();
   }, [loadConfig]);
+
+  const refreshDiscoveredCli = useCallback(async () => {
+    setIsDiscoveringCli(true);
+    try {
+      const items = await aiApi.discoverCliCredentials();
+      setDiscoveredCli(items);
+    } catch (e) {
+      log.warn('discover_cli_credentials failed', { error: String(e) });
+    } finally {
+      setIsDiscoveringCli(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshDiscoveredCli();
+  }, [refreshDiscoveredCli]);
   
   // Provider options with translations (must be at top level, before any conditional returns)
   const providerOrder = useMemo(
@@ -635,6 +655,7 @@ const AIModelConfig: React.FC = () => {
   const buildModelDiscoveryConfig = (config: Partial<AIModelConfigType>): AIModelConfigType | null => {
     const resolvedBaseUrl = (config.base_url || currentTemplate?.baseUrl || '').trim();
     const resolvedProvider = (config.provider || currentTemplate?.format || 'openai').trim();
+    const resolvedAuth = config.auth || { type: 'api_key' };
     const resolvedApiKey = (config.api_key || '').trim();
     const resolvedModelName = (
       config.model_name ||
@@ -643,7 +664,11 @@ const AIModelConfig: React.FC = () => {
       'model-discovery'
     ).trim();
 
-    if (!resolvedBaseUrl || !resolvedProvider || !resolvedApiKey) {
+    // CLI-backed auth (Codex/Gemini) resolves the bearer token at request time
+    // from `~/.codex` or `~/.gemini`, so we must NOT gate discovery on the
+    // user pasting an API key. Only the legacy `api_key` mode requires it.
+    const requiresApiKey = resolvedAuth.type === 'api_key';
+    if (!resolvedBaseUrl || !resolvedProvider || (requiresApiKey && !resolvedApiKey)) {
       return null;
     }
 
@@ -673,6 +698,7 @@ const AIModelConfig: React.FC = () => {
       skip_ssl_verify: config.skip_ssl_verify ?? false,
       custom_request_body: config.custom_request_body,
       custom_request_body_mode: config.custom_request_body_mode,
+      auth: resolvedAuth,
     };
   };
 
@@ -687,6 +713,7 @@ const AIModelConfig: React.FC = () => {
     custom_headers: config.custom_headers || null,
     custom_request_body: config.custom_request_body || null,
     custom_request_body_mode: config.custom_request_body_mode || null,
+    auth: config.auth || { type: 'api_key' },
   });
 
   const fetchRemoteModels = async (config: Partial<AIModelConfigType> | null) => {
@@ -742,7 +769,8 @@ const AIModelConfig: React.FC = () => {
 
   const handleModelSelectionOpenChange = (isOpen: boolean) => {
     if (!isOpen || !editingConfig || isFetchingRemoteModels) return;
-    if (!editingConfig.api_key?.trim()) return;
+    const authType = editingConfig.auth?.type ?? 'api_key';
+    if (authType === 'api_key' && !editingConfig.api_key?.trim()) return;
     if (hasAttemptedRemoteFetch) return;
     if (remoteModelOptions.length > 0) return;
     void fetchRemoteModels(editingConfig);
@@ -757,6 +785,47 @@ const AIModelConfig: React.FC = () => {
     setSelectedProviderId(null);
     setCreationMode('selection');
   };
+
+  const handleImportFromCli = useCallback((cred: DiscoveredCliCredential) => {
+    resetRemoteModelDiscovery();
+    setManualModelInput('');
+    setShowApiKey(false);
+    setSelectedProviderId(null);
+    const authType: 'codex_cli' | 'gemini_cli' = cred.kind === 'codex' ? 'codex_cli' : 'gemini_cli';
+    setEditingConfig({
+      name: cred.display_label,
+      provider: cred.suggested_format,
+      base_url: cred.suggested_base_url,
+      // Leave request_url + model_name empty so the user must pick a model
+      // from the live CLI list. We never inject a hard-coded default slug.
+      request_url: '',
+      api_key: '',
+      model_name: '',
+      enabled: true,
+      context_window: 200000,
+      max_tokens: 8192,
+      category: 'general_chat',
+      capabilities: ['text_chat', 'function_calling'],
+      recommended_for: [],
+      metadata: {},
+      inline_think_in_text: true,
+      auth: { type: authType },
+    });
+    setSelectedModelDrafts([]);
+    setShowAdvancedSettings(false);
+    setCreationMode('form');
+    setIsEditing(true);
+  }, [resetRemoteModelDiscovery]);
+
+  const handleRefreshCli = useCallback(async (kind: 'codex' | 'gemini') => {
+    try {
+      await aiApi.refreshCliCredential(kind);
+      await refreshDiscoveredCli();
+      notification.success(t('cliAuth.refreshSuccess'));
+    } catch (e) {
+      notification.error(t('cliAuth.refreshFailed', { error: String(e) }));
+    }
+  }, [refreshDiscoveredCli, notification, t]);
 
   
   const handleSelectProvider = (providerId: string) => {
@@ -958,6 +1027,7 @@ const AIModelConfig: React.FC = () => {
           skip_ssl_verify: editingConfig.skip_ssl_verify ?? false,
           custom_request_body: editingConfig.custom_request_body,
           custom_request_body_mode: editingConfig.custom_request_body_mode,
+          auth: editingConfig.auth || { type: 'api_key' },
         };
       });
 
@@ -1619,6 +1689,63 @@ const AIModelConfig: React.FC = () => {
       );
     };
 
+    const authType: 'api_key' | 'codex_cli' | 'gemini_cli' = editingConfig.auth?.type || 'api_key';
+    const authIsCli = authType !== 'api_key';
+    const cliAuthOptions: SelectOption[] = [
+      { value: 'api_key', label: t('cliAuth.options.apiKey') },
+      { value: 'codex_cli', label: t('cliAuth.options.codexCli') },
+      { value: 'gemini_cli', label: t('cliAuth.options.geminiCli') },
+    ];
+    const matchedCliCredential = authType === 'codex_cli'
+      ? discoveredCli.find(c => c.kind === 'codex')
+      : authType === 'gemini_cli'
+        ? discoveredCli.find(c => c.kind === 'gemini')
+        : undefined;
+
+    const renderAuthRow = () => (
+      <ConfigPageRow label={t('cliAuth.label')} align="center" wide>
+        <div className="bitfun-ai-model-config__control-stack">
+          <Select
+            value={authType}
+            onChange={(value) => {
+              const next = String(value) as 'api_key' | 'codex_cli' | 'gemini_cli';
+              setEditingConfig(prev => ({ ...prev, auth: { type: next } }));
+            }}
+            options={cliAuthOptions}
+            size="small"
+          />
+          {authIsCli && (
+            <small className={matchedCliCredential ? 'resolved-url__hint' : `resolved-url__hint bitfun-ai-model-config__json-status--error`}>
+              {matchedCliCredential
+                ? t('cliAuth.detected', {
+                    label: matchedCliCredential.display_label,
+                    account: matchedCliCredential.account || t('cliAuth.unknownAccount'),
+                  })
+                : t('cliAuth.notDetected', {
+                    kind: authType === 'codex_cli' ? 'Codex CLI' : 'Gemini CLI',
+                  })}
+            </small>
+          )}
+        </div>
+      </ConfigPageRow>
+    );
+
+    const renderApiKeyRow = (label: string) => (
+      <ConfigPageRow label={label} align="center" wide>
+        <Input
+          type={showApiKey ? 'text' : 'password'}
+          value={editingConfig.api_key || ''}
+          onChange={(e) => {
+            resetRemoteModelDiscovery();
+            setEditingConfig(prev => ({ ...prev, api_key: e.target.value }));
+          }}
+          placeholder={t('form.apiKeyPlaceholder')}
+          inputSize="small"
+          suffix={apiKeySuffix}
+        />
+      </ConfigPageRow>
+    );
+
     return (
       <>
         <div className="bitfun-ai-model-config__form bitfun-ai-model-config__form--modal">
@@ -1632,19 +1759,8 @@ const AIModelConfig: React.FC = () => {
                 <ConfigPageRow label={`${t('form.configName')} *`} align="center" wide>
                   <Input value={editingConfig.name || ''} onChange={(e) => setEditingConfig(prev => ({ ...prev, name: e.target.value }))} placeholder={t('form.configNamePlaceholder')} inputSize="small" />
                 </ConfigPageRow>
-                <ConfigPageRow label={`${t('form.apiKey')} *`} align="center" wide>
-                  <Input
-                    type={showApiKey ? 'text' : 'password'}
-                    value={editingConfig.api_key || ''}
-                    onChange={(e) => {
-                      resetRemoteModelDiscovery();
-                      setEditingConfig(prev => ({ ...prev, api_key: e.target.value }));
-                    }}
-                    placeholder={t('form.apiKeyPlaceholder')}
-                    inputSize="small"
-                    suffix={apiKeySuffix}
-                  />
-                </ConfigPageRow>
+                {renderAuthRow()}
+                {!authIsCli && renderApiKeyRow(`${t('form.apiKey')} *`)}
                 <ConfigPageRow label={t('form.baseUrl')} align="center" wide>
                   <div className="bitfun-ai-model-config__control-stack">
                     {currentTemplate?.baseUrlOptions && currentTemplate.baseUrlOptions.length > 0 && (
@@ -1799,19 +1915,8 @@ const AIModelConfig: React.FC = () => {
                         )}
                       </div>
                     </ConfigPageRow>
-                    <ConfigPageRow label={`${t('form.apiKey')} *`} align="center" wide>
-                      <Input
-                        type={showApiKey ? 'text' : 'password'}
-                        value={editingConfig.api_key || ''}
-                        onChange={(e) => {
-                          resetRemoteModelDiscovery();
-                          setEditingConfig(prev => ({ ...prev, api_key: e.target.value }));
-                        }}
-                        placeholder={t('form.apiKeyPlaceholder')}
-                        inputSize="small"
-                        suffix={apiKeySuffix}
-                      />
-                    </ConfigPageRow>
+                    {renderAuthRow()}
+                    {!authIsCli && renderApiKeyRow(`${t('form.apiKey')} *`)}
                     <ConfigPageRow label={t('form.provider')} align="center" wide>
                       <Select value={editingConfig.provider || 'openai'} onChange={(value) => {
                         const provider = value as string;
@@ -2211,6 +2316,71 @@ const AIModelConfig: React.FC = () => {
           description={tDefault('subtitle')}
         >
           <DefaultModelConfig />
+        </ConfigPageSection>
+
+        <ConfigPageSection
+          title={t('cliAuth.sectionTitle')}
+          description={t('cliAuth.sectionDescription')}
+          extra={(
+            <IconButton
+              variant="ghost"
+              size="small"
+              onClick={refreshDiscoveredCli}
+              tooltip={t('cliAuth.rescan')}
+              disabled={isDiscoveringCli}
+            >
+              <Loader size={16} className={isDiscoveringCli ? 'bitfun-ai-model-config__spin' : ''} />
+            </IconButton>
+          )}
+        >
+          {discoveredCli.length === 0 ? (
+            <div className="bitfun-ai-model-config__cli-empty">
+              <p>{t('cliAuth.empty')}</p>
+            </div>
+          ) : (
+            <div className="bitfun-ai-model-config__cli-discovery">
+              {discoveredCli.map(cred => {
+                const descriptionParts: string[] = [];
+                if (cred.account) {
+                  descriptionParts.push(cred.account);
+                }
+                if (cred.expires_at) {
+                  descriptionParts.push(
+                    t('cliAuth.expiresAt', {
+                      time: new Date(cred.expires_at * 1000).toLocaleString(),
+                    }),
+                  );
+                } else {
+                  descriptionParts.push(t('cliAuth.tokenValid'));
+                }
+                return (
+                  <ConfigPageRow
+                    key={`${cred.kind}-${cred.source_path}`}
+                    label={cred.display_label}
+                    description={descriptionParts.join(' · ')}
+                    align="center"
+                  >
+                    <div className="bitfun-ai-model-config__cli-actions">
+                      <Button
+                        size="small"
+                        variant="secondary"
+                        onClick={() => handleRefreshCli(cred.kind)}
+                      >
+                        {t('cliAuth.refresh')}
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="primary"
+                        onClick={() => handleImportFromCli(cred)}
+                      >
+                        {t('cliAuth.import')}
+                      </Button>
+                    </div>
+                  </ConfigPageRow>
+                );
+              })}
+            </div>
+          )}
         </ConfigPageSection>
 
         <ConfigPageSection

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -496,14 +496,14 @@ const AIModelConfig: React.FC = () => {
     }))
   );
 
-  const resetRemoteModelDiscovery = () => {
+  const resetRemoteModelDiscovery = useCallback(() => {
     setRemoteModelOptions([]);
     setIsFetchingRemoteModels(false);
     setRemoteModelsError(null);
     setHasAttemptedRemoteFetch(false);
     lastRemoteFetchSignatureRef.current = null;
     activeRemoteFetchSignatureRef.current = null;
-  };
+  }, []);
 
   const syncSelectedModelDrafts = (
     modelNames: string[],

--- a/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
@@ -16,6 +16,7 @@ import {
 import { ConfigPageHeader, ConfigPageLayout, ConfigPageContent, ConfigPageSection, ConfigPageRow } from './common';
 import { aiExperienceConfigService, type AIExperienceSettings } from '../services/AIExperienceConfigService';
 import { configManager } from '../services/ConfigManager';
+import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
 import { useNotification, notificationService } from '@/shared/notification-system';
 import type { AIModelConfig, DebugModeConfig, LanguageDebugTemplate } from '../types';
 import {
@@ -70,6 +71,7 @@ const SessionConfig: React.FC = () => {
   const [browserVersion, setBrowserVersion] = useState<string | null>(null);
   const [browserPageCount, setBrowserPageCount] = useState(0);
   const [browserControlBusy, setBrowserControlBusy] = useState(false);
+  const [platform, setPlatform] = useState<string>('');
 
   // ── Debug mode config state ──────────────────────────────────────────────
   const [debugConfig, setDebugConfig] = useState<DebugModeConfig>(DEFAULT_DEBUG_MODE_CONFIG);
@@ -148,6 +150,12 @@ const SessionConfig: React.FC = () => {
         const ok = await refreshComputerUseStatus();
         if (!ok) setComputerUseEnabled(computerUseCfg ?? false);
         await refreshBrowserControlStatus();
+        try {
+          const info = await systemAPI.getSystemInfo();
+          setPlatform(info.platform || '');
+        } catch (error) {
+          log.warn('getSystemInfo failed', error);
+        }
       } else {
         setComputerUseEnabled(computerUseCfg ?? false);
       }
@@ -693,7 +701,7 @@ const SessionConfig: React.FC = () => {
             <>
               <ConfigPageRow
                 label={t('browserControl.status')}
-                description={t('browserControl.statusDesc')}
+                description={t('browserControl.statusDesc') || undefined}
                 align="center"
                 balanced
               >
@@ -702,16 +710,29 @@ const SessionConfig: React.FC = () => {
                   style={{
                     display: 'flex',
                     flexDirection: 'row',
-                    flexWrap: 'nowrap',
+                    flexWrap: 'wrap',
                     alignItems: 'center',
                     justifyContent: 'flex-end',
                     gap: 8,
+                    minWidth: 0,
                   }}
                 >
-                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
-                    <span className={browserCdpAvailable ? 'bitfun-func-agent-config__perm-status--granted' : undefined}>
+                  <span
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      minWidth: 0,
+                      maxWidth: '100%',
+                    }}
+                    title={browserCdpAvailable && browserVersion ? `${browserKind} ${browserVersion}` : undefined}
+                  >
+                    <span
+                      className={browserCdpAvailable ? 'bitfun-func-agent-config__perm-status--granted' : undefined}
+                      style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}
+                    >
                       {browserCdpAvailable
-                        ? `${browserKind}${browserVersion ? ` (${browserVersion})` : ''} — ${browserPageCount} ${t('browserControl.tabs')}`
+                        ? `${browserKind} · ${browserPageCount} ${t('browserControl.tabs')}`
                         : t('browserControl.notConnected')}
                     </span>
                     <IconButton
@@ -739,23 +760,25 @@ const SessionConfig: React.FC = () => {
                   )}
                 </div>
               </ConfigPageRow>
-              <ConfigPageRow
-                label={t('browserControl.createLauncher')}
-                description={t('browserControl.createLauncherDesc')}
-                align="center"
-              >
-                <div className="bitfun-func-agent-config__row-control">
-                  <Button
-                    className="bitfun-func-agent-config__row-action-btn"
-                    size="small"
-                    variant="secondary"
-                    disabled={browserControlBusy}
-                    onClick={() => void handleBrowserControlCreateLauncher()}
-                  >
-                    {t('browserControl.createLauncher')}
-                  </Button>
-                </div>
-              </ConfigPageRow>
+              {platform === 'macos' && (
+                <ConfigPageRow
+                  label={t('browserControl.createLauncher')}
+                  description={t('browserControl.createLauncherDesc')}
+                  align="center"
+                >
+                  <div className="bitfun-func-agent-config__row-control">
+                    <Button
+                      className="bitfun-func-agent-config__row-action-btn"
+                      size="small"
+                      variant="secondary"
+                      disabled={browserControlBusy}
+                      onClick={() => void handleBrowserControlCreateLauncher()}
+                    >
+                      {t('browserControl.createLauncher')}
+                    </Button>
+                  </div>
+                </ConfigPageRow>
+              )}
             </>
           ) : null}
         </ConfigPageSection>

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -132,7 +132,15 @@ export interface AIModelConfig {
   reasoning_effort?: string;
   /** Optional Anthropic manual thinking token budget. */
   thinking_budget_tokens?: number;
+  /** Authentication source. Defaults to inline `api_key`. */
+  auth?: AuthConfig;
 }
+
+/** Authentication source persisted on each model entry. */
+export type AuthConfig =
+  | { type: 'api_key' }
+  | { type: 'codex_cli' }
+  | { type: 'gemini_cli' };
 
 export interface ProxyConfig {
   enabled: boolean;

--- a/src/web-ui/src/locales/en-US/settings/ai-model.json
+++ b/src/web-ui/src/locales/en-US/settings/ai-model.json
@@ -8,6 +8,28 @@
   "editProviderSubtitle": "Basic Provider Parameters",
   "editSubtitle": "Basic Model Parameters",
   "confirmDelete": "Are you sure you want to delete this configuration?",
+  "cliAuth": {
+    "sectionTitle": "Local CLI accounts",
+    "sectionDescription": "Import Codex CLI / Gemini CLI accounts already signed in on this machine and use them as models",
+    "rescan": "Re-scan",
+    "empty": "No signed-in Codex / Gemini CLI accounts detected. Sign in from the terminal first, then re-scan.",
+    "import": "Use this account",
+    "refresh": "Refresh token",
+    "refreshSuccess": "Token refreshed",
+    "refreshFailed": "Refresh failed: {{error}}",
+    "expiresAt": "Token valid until {{time}}",
+    "tokenValid": "Token ready",
+    "accountLine": "Account: {{account}}",
+    "label": "Authentication",
+    "options": {
+      "apiKey": "API Key",
+      "codexCli": "Codex CLI account",
+      "geminiCli": "Gemini CLI account"
+    },
+    "detected": "Will use the local {{label}} ({{account}})",
+    "notDetected": "No signed-in {{kind}} account detected; sign in from the terminal first.",
+    "unknownAccount": "current login"
+  },
   "providerSelection": {
     "title": "Select Model Provider",
     "subtitle": "Choose a preset provider for quick setup, or select custom for full manual configuration",

--- a/src/web-ui/src/locales/en-US/settings/session-config.json
+++ b/src/web-ui/src/locales/en-US/settings/session-config.json
@@ -34,21 +34,21 @@
     "platformNote": "Note"
   },
   "browserControl": {
-    "sectionTitle": "Browser control (CDP)",
-    "sectionDescription": "Control your default browser (Chrome, Edge, etc.) through the Chrome DevTools Protocol. Preserves your login sessions, cookies, and extensions.",
-    "desktopOnly": "Browser control settings are only available in the BitFun desktop app.",
-    "status": "CDP connection",
-    "statusDesc": "Status of the Chrome DevTools Protocol connection to your browser.",
+    "sectionTitle": "Browser control",
+    "sectionDescription": "Reuse your default browser with logins, cookies, and extensions.",
+    "desktopOnly": "Browser control is only available in the BitFun desktop app.",
+    "status": "Connection",
+    "statusDesc": "",
     "notConnected": "Not connected",
     "refreshStatus": "Refresh status",
-    "connect": "Connect browser",
-    "connectSuccess": "{{browser}} connected with CDP",
-    "connectFailed": "Failed to launch browser with CDP",
-    "createLauncher": "Create launcher app",
+    "connect": "Connect",
+    "connectSuccess": "Connected to {{browser}}",
+    "connectFailed": "Failed to connect to browser",
+    "createLauncher": "Create launcher",
     "createLauncherSuccess": "Launcher created at {{path}}",
-    "createLauncherFailed": "Failed to create launcher app",
-    "createLauncherDesc": "Create a shortcut app that always starts the browser with CDP debug port enabled.",
-    "tabs": "tab(s)"
+    "createLauncherFailed": "Failed to create launcher",
+    "createLauncherDesc": "Create a browser shortcut with the debug port enabled.",
+    "tabs": "tabs"
   },
   "model": {
     "label": "Model",

--- a/src/web-ui/src/locales/zh-CN/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-CN/settings/ai-model.json
@@ -8,6 +8,28 @@
   "editProviderSubtitle": "基础服务商参数配置",
   "editSubtitle": "基础模型参数配置",
   "confirmDelete": "确定删除此配置？",
+  "cliAuth": {
+    "sectionTitle": "本机已登录账号",
+    "sectionDescription": "可直接导入本机 Codex CLI / Gemini CLI 已登录账号作为模型使用",
+    "rescan": "重新扫描",
+    "empty": "未检测到本机已登录的 Codex / Gemini CLI 账号，请先在终端完成登录后重新扫描",
+    "import": "导入使用",
+    "refresh": "刷新 Token",
+    "refreshSuccess": "Token 已刷新",
+    "refreshFailed": "刷新失败：{{error}}",
+    "expiresAt": "Token 有效期至 {{time}}",
+    "tokenValid": "Token 已就绪",
+    "accountLine": "账号：{{account}}",
+    "label": "认证方式",
+    "options": {
+      "apiKey": "API Key",
+      "codexCli": "Codex CLI 已登录账号",
+      "geminiCli": "Gemini CLI 已登录账号"
+    },
+    "detected": "将使用本机 {{label}}（账号 {{account}}）",
+    "notDetected": "本机未检测到 {{kind}} 已登录账号，请先在终端完成登录",
+    "unknownAccount": "当前登录账号"
+  },
   "providerSelection": {
     "title": "选择模型提供商",
     "subtitle": "选择一个预设提供商快速配置，或选择自定义完全手动配置",

--- a/src/web-ui/src/locales/zh-CN/settings/session-config.json
+++ b/src/web-ui/src/locales/zh-CN/settings/session-config.json
@@ -34,20 +34,20 @@
     "platformNote": "说明"
   },
   "browserControl": {
-    "sectionTitle": "浏览器控制（CDP）",
-    "sectionDescription": "通过 Chrome DevTools Protocol 控制用户默认浏览器（Chrome、Edge 等），保留你的登录状态、Cookie 和扩展。",
-    "desktopOnly": "浏览器控制设置仅在 BitFun 桌面应用中可用。",
-    "status": "CDP 连接",
-    "statusDesc": "与浏览器的 Chrome DevTools Protocol 连接状态。",
+    "sectionTitle": "浏览器控制",
+    "sectionDescription": "复用你的默认浏览器，保留登录态、Cookie 和扩展。",
+    "desktopOnly": "浏览器控制仅在 BitFun 桌面应用中可用。",
+    "status": "连接状态",
+    "statusDesc": "",
     "notConnected": "未连接",
     "refreshStatus": "刷新状态",
     "connect": "连接浏览器",
-    "connectSuccess": "{{browser}} 已通过 CDP 连接",
-    "connectFailed": "启动浏览器 CDP 失败",
+    "connectSuccess": "已连接 {{browser}}",
+    "connectFailed": "连接浏览器失败",
     "createLauncher": "创建启动器",
     "createLauncherSuccess": "启动器已创建：{{path}}",
     "createLauncherFailed": "创建启动器失败",
-    "createLauncherDesc": "创建一个快捷应用，每次打开都自动带 CDP 调试端口。",
+    "createLauncherDesc": "创建带调试端口的浏览器快捷方式。",
     "tabs": "个标签页"
   },
   "model": {


### PR DESCRIPTION
## Summary

Let users reuse their existing Codex CLI / Gemini CLI logins as BitFun models instead of pasting raw API keys, plus two small follow-up polish commits.

### 1. `feat(ai)` — backend: reuse local Codex / Gemini CLI credentials
- New `infrastructure/cli_credentials` module with a `CredentialResolver` trait and concrete resolvers for Codex (`~/.codex/auth.json`, ChatGPT-login + API key modes, automatic OAuth refresh) and Gemini (`~/.gemini/.env` API key + `~/.gemini/oauth_creds.json` Code Assist).
- `AIModelConfig` gains an `auth: AuthConfig` field; the AI client factory resolves the live credential at request time and injects token / base URL / required headers into `AIConfig`.
- `ai-adapters` gains a dedicated `codex_chatgpt` adapter (flat tool schema, mandatory `instructions`, `store: false`, no `max_output_tokens`, `parallel_tool_calls`, reasoning fields) and a `gemini/code_assist` path (`cloudcode-pa.googleapis.com` request shape with `{ model, project, request }` wrapping). `responses::send_stream` URL-dispatches to the Codex adapter so the standard Responses path stays untouched.
- New Tauri commands: `discover_cli_credentials`, `refresh_cli_credential`.

### 2. `feat(web-ui)` — settings page UX
- New "Local CLI accounts" section in the AI model settings, styled to match the default-model rows (`ConfigPageRow` per detected credential, no raw filesystem paths leaked in the UI), with "Refresh token" and "Use this account" actions.
- Provider form gains an `Authentication` selector (API Key / Codex CLI account / Gemini CLI account); model discovery no longer requires an API key when running in CLI auth mode, and importing a CLI account never injects a hard-coded default model slug — the user must pick from the live CLI list.
- Matching i18n entries (en-US / zh-CN) and typed `AIApi` bindings for the new commands.

### 3. `fix(component-library)` — Select loading UX
- While `loading={true}` and the options array is still empty, `Select` now renders an inline spinner + `select.loading` text instead of falling back to the "no data" empty text. Improves every model picker (not just the new CLI flow).

### 4. `feat(browser-control)` — Windows browser detection + copy
- Resolve Chrome / Edge / Brave / Chromium / Arc on Windows by probing `Program Files`, `Program Files (x86)` and per-user `LocalAppData`, falling back to the registry "App Paths" key, instead of hard-coding a single absolute path.
- Tightened a few related UX strings in the SessionConfig browser-control panel.

## Test plan
- [x] `cargo check --workspace`
- [x] `pnpm run desktop:dev` boots, AI model settings render the new section, and HMR reloads the affected files cleanly
- [ ] Manual: with a logged-in Codex CLI (ChatGPT mode) on macOS — discover → import → pick `gpt-5.4` → "Test connection" succeeds and a streamed reply comes back
- [ ] Manual: with a logged-in Gemini CLI (OAuth) on macOS — discover → import → pick `gemini-2.5-pro` → "Test connection" succeeds
- [ ] Manual on Windows: launch Chrome / Edge through browser-control without setting a custom executable path