### PR TITLE
refactor(stream): unify indexed tool-call accumulation across adapters

### DIFF
--- a/src/crates/ai-adapters/AGENTS.md
+++ b/src/crates/ai-adapters/AGENTS.md
@@ -1,0 +1,1 @@
+If you modify this crate, run the stream integration tests in `src/crates/core/tests` before finishing.

--- a/src/crates/ai-adapters/src/client/response_aggregator.rs
+++ b/src/crates/ai-adapters/src/client/response_aggregator.rs
@@ -1,5 +1,5 @@
 use crate::stream::UnifiedResponse;
-use crate::tool_call_accumulator::{PendingToolCall, ToolCallBoundary};
+use crate::tool_call_accumulator::{PendingToolCalls, ToolCallBoundary, ToolCallStreamKey};
 use crate::types::{GeminiResponse, GeminiUsage, ToolCall};
 use anyhow::Result;
 use futures::StreamExt;
@@ -19,7 +19,7 @@ pub(crate) async fn aggregate_stream_response(
     let mut provider_metadata: Option<serde_json::Value> = None;
 
     let mut tool_calls: Vec<ToolCall> = Vec::new();
-    let mut pending_tool_call = PendingToolCall::default();
+    let mut pending_tool_calls = PendingToolCalls::default();
 
     while let Some(chunk_result) = stream.next().await {
         match chunk_result {
@@ -44,60 +44,48 @@ pub(crate) async fn aggregate_stream_response(
 
                 if let Some(tool_call) = tool_call {
                     let crate::stream::UnifiedToolCall {
+                        tool_call_index,
                         id,
                         name,
                         arguments,
                         arguments_is_snapshot,
                     } = tool_call;
+                    let outcome = pending_tool_calls.apply_delta(
+                        ToolCallStreamKey::from(tool_call_index),
+                        id,
+                        name,
+                        arguments,
+                        arguments_is_snapshot,
+                    );
 
-                    if let Some(tool_call_id) = id {
-                        if !tool_call_id.is_empty() {
-                            let is_new_tool = pending_tool_call.tool_id() != tool_call_id;
-                            if is_new_tool {
-                                if let Some(finalized) =
-                                    pending_tool_call.finalize(ToolCallBoundary::NewTool)
-                                {
-                                    if finalized.is_error {
-                                        warn!(
-                                            "[send_message] Dropping invalid tool call at boundary=new_tool: tool_id={}, tool_name={}, raw_len={}",
-                                            finalized.tool_id,
-                                            finalized.tool_name,
-                                            finalized.raw_arguments.len()
-                                        );
-                                    } else {
-                                        let arguments = finalized.arguments_as_object_map();
-                                        tool_calls.push(ToolCall {
-                                            id: finalized.tool_id,
-                                            name: finalized.tool_name,
-                                            arguments,
-                                        });
-                                    }
-                                }
-                                pending_tool_call.start_new(tool_call_id, name.clone());
-                                debug!(
-                                    "[send_message] Detected tool call: {}",
-                                    pending_tool_call.tool_name()
-                                );
-                            } else {
-                                pending_tool_call.update_tool_name_if_missing(name.clone());
-                            }
+                    if let Some(finalized) = outcome.finalized_previous {
+                        if finalized.is_error {
+                            warn!(
+                                "[send_message] Dropping invalid tool call at boundary=new_tool: tool_id={}, tool_name={}, raw_len={}",
+                                finalized.tool_id,
+                                finalized.tool_name,
+                                finalized.raw_arguments.len()
+                            );
+                        } else {
+                            let arguments = finalized.arguments_as_object_map();
+                            tool_calls.push(ToolCall {
+                                id: finalized.tool_id,
+                                name: finalized.tool_name,
+                                arguments,
+                            });
                         }
                     }
 
-                    if let Some(tool_call_arguments) = arguments {
-                        if pending_tool_call.has_pending() {
-                            if arguments_is_snapshot {
-                                pending_tool_call.replace_arguments(&tool_call_arguments);
-                            } else {
-                                pending_tool_call.append_arguments(&tool_call_arguments);
-                            }
-                        }
+                    if let Some(early_detected) = outcome.early_detected {
+                        debug!(
+                            "[send_message] Detected tool call: {}",
+                            early_detected.tool_name
+                        );
                     }
                 }
 
                 if let Some(finish_reason_) = chunk_finish_reason {
-                    if let Some(finalized) =
-                        pending_tool_call.finalize(ToolCallBoundary::FinishReason)
+                    for finalized in pending_tool_calls.finalize_all(ToolCallBoundary::FinishReason)
                     {
                         if finalized.is_error {
                             warn!(
@@ -138,7 +126,7 @@ pub(crate) async fn aggregate_stream_response(
         }
     }
 
-    if let Some(finalized) = pending_tool_call.finalize(ToolCallBoundary::EndOfAggregation) {
+    for finalized in pending_tool_calls.finalize_all(ToolCallBoundary::EndOfAggregation) {
         if finalized.is_error {
             warn!(
                 "[send_message] Dropping invalid tool call at boundary=end_of_aggregation: tool_id={}, tool_name={}, raw_len={}",

--- a/src/crates/ai-adapters/src/stream/stream_handler/gemini.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/gemini.rs
@@ -205,6 +205,7 @@ mod tests {
         let mut state = GeminiToolCallState::new();
 
         let mut first = UnifiedToolCall {
+            tool_call_index: None,
             id: None,
             name: Some("get_weather".to_string()),
             arguments: Some("{\"city\":".to_string()),
@@ -213,6 +214,7 @@ mod tests {
         state.assign_id(&mut first);
 
         let mut second = UnifiedToolCall {
+            tool_call_index: None,
             id: None,
             name: Some("get_weather".to_string()),
             arguments: Some("\"Paris\"}".to_string()),
@@ -232,6 +234,7 @@ mod tests {
         let mut state = GeminiToolCallState::new();
 
         let mut first = UnifiedToolCall {
+            tool_call_index: None,
             id: None,
             name: Some("get_weather".to_string()),
             arguments: Some("{}".to_string()),
@@ -241,6 +244,7 @@ mod tests {
         state.on_non_tool_response();
 
         let mut second = UnifiedToolCall {
+            tool_call_index: None,
             id: None,
             name: Some("get_weather".to_string()),
             arguments: Some("{}".to_string()),
@@ -261,12 +265,14 @@ mod tests {
         let mut second_state = GeminiToolCallState::new();
 
         let mut first = UnifiedToolCall {
+            tool_call_index: None,
             id: None,
             name: Some("grep".to_string()),
             arguments: Some("{}".to_string()),
             arguments_is_snapshot: false,
         };
         let mut second = UnifiedToolCall {
+            tool_call_index: None,
             id: None,
             name: Some("read".to_string()),
             arguments: Some("{}".to_string()),

--- a/src/crates/ai-adapters/src/stream/stream_handler/openai.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/openai.rs
@@ -8,7 +8,6 @@ use futures::StreamExt;
 use log::{error, trace, warn};
 use reqwest::Response;
 use serde_json::Value;
-use std::collections::HashSet;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
@@ -16,116 +15,9 @@ use tokio::time::timeout;
 const OPENAI_CHAT_COMPLETION_CHUNK_OBJECT: &str = "chat.completion.chunk";
 const AI_STREAM_RESPONSE_TARGET: &str = "ai::openai_stream_response";
 
-#[derive(Debug, Default)]
-struct OpenAIToolCallFilter {
-    seen_tool_call_ids: HashSet<String>,
-    pending_tool_call_id: Option<String>,
-}
-
-impl OpenAIToolCallFilter {
-    fn normalize_response(&mut self, mut response: UnifiedResponse) -> Option<UnifiedResponse> {
-        self.resolve_pending_tool_call_id(&mut response);
-
-        let Some(tool_call) = response.tool_call.as_ref() else {
-            return Some(response);
-        };
-
-        let tool_id = tool_call
-            .id
-            .as_ref()
-            .filter(|value| !value.is_empty())
-            .cloned();
-        let has_name = tool_call
-            .name
-            .as_ref()
-            .is_some_and(|value| !value.is_empty());
-        let has_arguments = tool_call
-            .arguments
-            .as_ref()
-            .is_some_and(|value| !value.is_empty());
-
-        if let Some(tool_id) = tool_id {
-            let seen_before = self.seen_tool_call_ids.contains(&tool_id);
-            self.seen_tool_call_ids.insert(tool_id.clone());
-
-            // Some OpenAI-compatible providers emit "id only" tool-call chunks.
-            // They can be either:
-            // 1. a harmless trailing/orphan chunk that should be dropped, or
-            // 2. a prelude chunk where later deltas carry the actual name/arguments.
-            //
-            // For (2), keep the id around and reattach it to the next meaningful tool-call
-            // delta when that delta omits the id. For (1), stripping this chunk is safe
-            // because it carries no semantic payload on its own.
-            if !has_name && !has_arguments {
-                if !seen_before {
-                    self.pending_tool_call_id = Some(tool_id);
-                }
-                response.tool_call = None;
-                return Self::keep_if_non_empty(response);
-            }
-        } else if !has_name && !has_arguments {
-            response.tool_call = None;
-            return Self::keep_if_non_empty(response);
-        }
-
-        Some(response)
-    }
-
-    fn resolve_pending_tool_call_id(&mut self, response: &mut UnifiedResponse) {
-        let Some(pending_tool_call_id) = self.pending_tool_call_id.clone() else {
-            return;
-        };
-
-        let Some(tool_call) = response.tool_call.as_mut() else {
-            self.pending_tool_call_id = None;
-            return;
-        };
-
-        let has_name = tool_call
-            .name
-            .as_ref()
-            .is_some_and(|value| !value.is_empty());
-        let has_arguments = tool_call
-            .arguments
-            .as_ref()
-            .is_some_and(|value| !value.is_empty());
-        let has_payload = has_name || has_arguments;
-
-        match tool_call.id.as_ref() {
-            Some(id) if !id.is_empty() && id == &pending_tool_call_id => {
-                self.pending_tool_call_id = None;
-            }
-            Some(id) if !id.is_empty() => {
-                self.pending_tool_call_id = None;
-            }
-            _ if has_payload => {
-                tool_call.id = Some(pending_tool_call_id);
-                self.pending_tool_call_id = None;
-            }
-            _ => {}
-        }
-    }
-
-    fn keep_if_non_empty(response: UnifiedResponse) -> Option<UnifiedResponse> {
-        if response.text.is_some()
-            || response.reasoning_content.is_some()
-            || response.thinking_signature.is_some()
-            || response.tool_call.is_some()
-            || response.usage.is_some()
-            || response.finish_reason.is_some()
-            || response.provider_metadata.is_some()
-        {
-            Some(response)
-        } else {
-            None
-        }
-    }
-}
-
 #[derive(Debug)]
 struct OpenAIResponseNormalizer {
     tool_arguments_normalizer: OpenAIToolCallArgumentsNormalizer,
-    tool_call_filter: OpenAIToolCallFilter,
     inline_think_parser: InlineThinkParser,
 }
 
@@ -133,7 +25,6 @@ impl OpenAIResponseNormalizer {
     fn new(inline_think_in_text: bool) -> Self {
         Self {
             tool_arguments_normalizer: OpenAIToolCallArgumentsNormalizer::default(),
-            tool_call_filter: OpenAIToolCallFilter::default(),
             inline_think_parser: InlineThinkParser::new(inline_think_in_text),
         }
     }
@@ -143,10 +34,6 @@ impl OpenAIResponseNormalizer {
     }
 
     fn normalize_response(&mut self, response: UnifiedResponse) -> Vec<UnifiedResponse> {
-        let Some(response) = self.tool_call_filter.normalize_response(response) else {
-            return Vec::new();
-        };
-
         self.inline_think_parser.normalize_response(response)
     }
 
@@ -296,7 +183,7 @@ pub async fn handle_openai_stream(
         if tool_call_count > 1 {
             stats.increment("chunk:multi_tool_call");
             warn!(
-                "OpenAI SSE chunk contains {} tool calls in the first choice; splitting and sending sequentially",
+                "OpenAI SSE chunk contains {} tool calls in the first choice; emitting indexed tool deltas",
                 tool_call_count
             );
         }
@@ -349,23 +236,7 @@ pub async fn handle_openai_stream(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        extract_sse_api_error_message, is_valid_chat_completion_chunk_weak, OpenAIToolCallFilter,
-    };
-    use crate::stream::types::openai::OpenAISSEData;
-    use crate::stream::types::unified::{UnifiedResponse, UnifiedToolCall};
-
-    fn normalize_raw_with_filter(
-        filter: &mut OpenAIToolCallFilter,
-        raw: &str,
-    ) -> Vec<UnifiedResponse> {
-        let sse_data: OpenAISSEData = serde_json::from_str(raw).expect("valid openai sse data");
-        sse_data
-            .into_unified_responses()
-            .into_iter()
-            .filter_map(|response| filter.normalize_response(response))
-            .collect()
-    }
+    use super::{extract_sse_api_error_message, is_valid_chat_completion_chunk_weak};
 
     #[test]
     fn weak_filter_accepts_chat_completion_chunk() {
@@ -421,216 +292,5 @@ mod tests {
             "object": "chat.completion.chunk"
         });
         assert!(extract_sse_api_error_message(&event).is_none());
-    }
-
-    #[test]
-    fn drops_redundant_empty_tool_call_after_same_id_was_seen() {
-        let mut filter = OpenAIToolCallFilter::default();
-
-        let first = UnifiedResponse {
-            tool_call: Some(UnifiedToolCall {
-                id: Some("call_1".to_string()),
-                name: Some("read_file".to_string()),
-                arguments: Some("{\"path\":\"a.txt\"}".to_string()),
-                arguments_is_snapshot: false,
-            }),
-            ..Default::default()
-        };
-        let trailing_empty = UnifiedResponse {
-            tool_call: Some(UnifiedToolCall {
-                id: Some("call_1".to_string()),
-                name: None,
-                arguments: Some(String::new()),
-                arguments_is_snapshot: false,
-            }),
-            ..Default::default()
-        };
-
-        assert!(filter.normalize_response(first).is_some());
-        assert!(filter.normalize_response(trailing_empty).is_none());
-    }
-
-    #[test]
-    fn keeps_finish_reason_when_redundant_tool_call_is_stripped() {
-        let mut filter = OpenAIToolCallFilter::default();
-
-        let first = UnifiedResponse {
-            tool_call: Some(UnifiedToolCall {
-                id: Some("call_1".to_string()),
-                name: Some("read_file".to_string()),
-                arguments: Some("{\"path\":\"a.txt\"}".to_string()),
-                arguments_is_snapshot: false,
-            }),
-            ..Default::default()
-        };
-        let trailing_empty = UnifiedResponse {
-            tool_call: Some(UnifiedToolCall {
-                id: Some("call_1".to_string()),
-                name: None,
-                arguments: None,
-                arguments_is_snapshot: false,
-            }),
-            finish_reason: Some("tool_calls".to_string()),
-            ..Default::default()
-        };
-
-        assert!(filter.normalize_response(first).is_some());
-        let normalized = filter
-            .normalize_response(trailing_empty)
-            .expect("finish_reason should be preserved");
-        assert!(normalized.tool_call.is_none());
-        assert_eq!(normalized.finish_reason.as_deref(), Some("tool_calls"));
-    }
-
-    #[test]
-    fn strips_unseen_id_only_tool_call_but_keeps_finish_reason() {
-        let mut filter = OpenAIToolCallFilter::default();
-
-        let orphan = UnifiedResponse {
-            tool_call: Some(UnifiedToolCall {
-                id: Some("call_orphan".to_string()),
-                name: None,
-                arguments: None,
-                arguments_is_snapshot: false,
-            }),
-            finish_reason: Some("tool_calls".to_string()),
-            ..Default::default()
-        };
-
-        let normalized = filter
-            .normalize_response(orphan)
-            .expect("finish_reason should be preserved");
-        assert!(normalized.tool_call.is_none());
-        assert_eq!(normalized.finish_reason.as_deref(), Some("tool_calls"));
-    }
-
-    #[test]
-    fn reattaches_pending_id_to_following_payload_chunk() {
-        let mut filter = OpenAIToolCallFilter::default();
-
-        let prelude = UnifiedResponse {
-            tool_call: Some(UnifiedToolCall {
-                id: Some("call_1".to_string()),
-                name: None,
-                arguments: None,
-                arguments_is_snapshot: false,
-            }),
-            ..Default::default()
-        };
-        let payload = UnifiedResponse {
-            tool_call: Some(UnifiedToolCall {
-                id: None,
-                name: Some("read_file".to_string()),
-                arguments: Some("{\"path\":\"a.txt\"}".to_string()),
-                arguments_is_snapshot: false,
-            }),
-            ..Default::default()
-        };
-
-        assert!(filter.normalize_response(prelude).is_none());
-        let normalized = filter
-            .normalize_response(payload)
-            .expect("payload chunk should be kept");
-        let tool_call = normalized.tool_call.expect("tool call should exist");
-        assert_eq!(tool_call.id.as_deref(), Some("call_1"));
-        assert_eq!(tool_call.name.as_deref(), Some("read_file"));
-        assert_eq!(tool_call.arguments.as_deref(), Some("{\"path\":\"a.txt\"}"));
-    }
-
-    #[test]
-    fn drops_orphan_id_only_tool_call_when_it_shares_sse_with_normal_final_tool_chunk() {
-        let mut filter = OpenAIToolCallFilter::default();
-
-        let responses = normalize_raw_with_filter(
-            &mut filter,
-            r#"{
-                "id": "chatcmpl_test",
-                "created": 123,
-                "model": "gpt-test",
-                "choices": [{
-                    "index": 0,
-                    "delta": {
-                        "tool_calls": [
-                            {
-                                "index": 0,
-                                "id": "call_1",
-                                "type": "function",
-                                "function": {
-                                    "name": "read_file",
-                                    "arguments": "{\"path\":\"a.txt\"}"
-                                }
-                            },
-                            {
-                                "index": 1,
-                                "id": "call_orphan",
-                                "type": "function",
-                                "function": {}
-                            }
-                        ]
-                    },
-                    "finish_reason": "tool_calls"
-                }]
-            }"#,
-        );
-
-        assert_eq!(responses.len(), 1);
-        let tool_call = responses[0]
-            .tool_call
-            .as_ref()
-            .expect("tool call should exist");
-        assert_eq!(tool_call.id.as_deref(), Some("call_1"));
-        assert_eq!(tool_call.name.as_deref(), Some("read_file"));
-        assert_eq!(tool_call.arguments.as_deref(), Some("{\"path\":\"a.txt\"}"));
-        assert_eq!(responses[0].finish_reason.as_deref(), Some("tool_calls"));
-    }
-
-    #[test]
-    fn drops_orphan_id_only_tool_call_when_it_shares_sse_with_redundant_empty_tail() {
-        let mut filter = OpenAIToolCallFilter::default();
-
-        assert!(filter
-            .normalize_response(UnifiedResponse {
-                tool_call: Some(UnifiedToolCall {
-                    id: Some("call_1".to_string()),
-                    name: Some("read_file".to_string()),
-                    arguments: Some("{\"path\":\"a.txt\"}".to_string()),
-                    arguments_is_snapshot: false,
-                }),
-                ..Default::default()
-            })
-            .is_some());
-
-        let responses = normalize_raw_with_filter(
-            &mut filter,
-            r#"{
-                "id": "chatcmpl_test",
-                "created": 123,
-                "model": "gpt-test",
-                "choices": [{
-                    "index": 0,
-                    "delta": {
-                        "tool_calls": [
-                            {
-                                "index": 0,
-                                "id": "call_1",
-                                "type": "function",
-                                "function": {}
-                            },
-                            {
-                                "index": 1,
-                                "id": "call_orphan",
-                                "type": "function",
-                                "function": {}
-                            }
-                        ]
-                    },
-                    "finish_reason": "tool_calls"
-                }]
-            }"#,
-        );
-
-        assert_eq!(responses.len(), 1);
-        assert!(responses[0].tool_call.is_none());
-        assert_eq!(responses[0].finish_reason.as_deref(), Some("tool_calls"));
     }
 }

--- a/src/crates/ai-adapters/src/stream/stream_handler/responses.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/responses.rs
@@ -63,9 +63,10 @@ fn emit_unified_response(
 fn emit_tool_call_item(
     tx_event: &mpsc::UnboundedSender<Result<UnifiedResponse>>,
     stats: &mut StreamStats,
+    output_index: Option<usize>,
     item_value: Value,
 ) {
-    if let Some(unified_response) = parse_responses_output_item(item_value) {
+    if let Some(unified_response) = parse_responses_output_item(item_value, output_index) {
         if unified_response.tool_call.is_some() {
             emit_unified_response(tx_event, stats, unified_response);
         }
@@ -101,14 +102,14 @@ fn handle_function_call_output_item_done(
     });
 
     let Some(output_index) = output_index else {
-        emit_tool_call_item(tx_event, stats, item_value);
+        emit_tool_call_item(tx_event, stats, event_output_index, item_value);
         return;
     };
 
     let Some(tc) = tool_calls_by_output_index.get_mut(&output_index) else {
         // The provider may send `output_item.done` with an output_index even when the
         // earlier `output_item.added` event was omitted or missed. Fall back to the full item.
-        emit_tool_call_item(tx_event, stats, item_value);
+        emit_tool_call_item(tx_event, stats, Some(output_index), item_value);
         return;
     };
 
@@ -138,6 +139,7 @@ fn handle_function_call_output_item_done(
             };
             let unified_response = UnifiedResponse {
                 tool_call: Some(crate::stream::types::unified::UnifiedToolCall {
+                    tool_call_index: Some(output_index),
                     id,
                     name,
                     arguments: Some(delta),
@@ -328,6 +330,7 @@ pub async fn handle_responses_stream(
 
                 let unified_response = UnifiedResponse {
                     tool_call: Some(crate::stream::types::unified::UnifiedToolCall {
+                        tool_call_index: Some(output_index),
                         id,
                         name,
                         arguments: Some(delta),
@@ -355,7 +358,9 @@ pub async fn handle_responses_stream(
                     continue;
                 }
 
-                if let Some(mut unified_response) = parse_responses_output_item(item_value) {
+                if let Some(mut unified_response) =
+                    parse_responses_output_item(item_value, event.output_index)
+                {
                     if received_text_delta && unified_response.text.is_some() {
                         unified_response.text = None;
                     }
@@ -397,6 +402,7 @@ pub async fn handle_responses_stream(
                                     let unified_response = UnifiedResponse {
                                         tool_call: Some(
                                             crate::stream::types::unified::UnifiedToolCall {
+                                                tool_call_index: Some(idx),
                                                 id,
                                                 name,
                                                 arguments: Some(delta),
@@ -612,6 +618,7 @@ mod tests {
             .expect("tool call event")
             .expect("ok response");
         let tool_call = response.tool_call.expect("tool call");
+        assert_eq!(tool_call.tool_call_index, Some(3));
         assert_eq!(tool_call.id.as_deref(), Some("call_1"));
         assert_eq!(tool_call.name.as_deref(), Some("get_weather"));
         assert_eq!(

--- a/src/crates/ai-adapters/src/stream/types/anthropic.rs
+++ b/src/crates/ai-adapters/src/stream/types/anthropic.rs
@@ -114,6 +114,7 @@ impl From<ContentBlockStart> for UnifiedResponse {
         let mut result = UnifiedResponse::default();
         if let ContentBlock::ToolUse { id, name } = value.content_block {
             let tool_call = UnifiedToolCall {
+                tool_call_index: None,
                 id: Some(id),
                 name: Some(name),
                 arguments: None,
@@ -158,6 +159,7 @@ impl TryFrom<ContentBlockDelta> for UnifiedResponse {
             }
             Delta::InputJson { partial_json } => {
                 let tool_call = UnifiedToolCall {
+                    tool_call_index: None,
                     id: None,
                     name: None,
                     arguments: Some(partial_json),

--- a/src/crates/ai-adapters/src/stream/types/gemini.rs
+++ b/src/crates/ai-adapters/src/stream/types/gemini.rs
@@ -360,6 +360,7 @@ impl GeminiSSEData {
                         reasoning_content: None,
                         thinking_signature,
                         tool_call: Some(UnifiedToolCall {
+                            tool_call_index: None,
                             id: None,
                             name: function_call.name,
                             arguments: serde_json::to_string(&arguments).ok(),

--- a/src/crates/ai-adapters/src/stream/types/openai.rs
+++ b/src/crates/ai-adapters/src/stream/types/openai.rs
@@ -79,6 +79,7 @@ struct OpenAIToolCall {
 impl From<OpenAIToolCall> for UnifiedToolCall {
     fn from(tool_call: OpenAIToolCall) -> Self {
         Self {
+            tool_call_index: Some(tool_call.index),
             id: tool_call.id,
             name: tool_call.function.as_ref().and_then(|f| f.name.clone()),
             arguments: tool_call
@@ -343,6 +344,20 @@ mod tests {
         let responses = sse_data.into_unified_responses();
 
         assert_eq!(responses.len(), 2);
+        assert_eq!(
+            responses[0]
+                .tool_call
+                .as_ref()
+                .and_then(|tool| tool.tool_call_index),
+            Some(0)
+        );
+        assert_eq!(
+            responses[1]
+                .tool_call
+                .as_ref()
+                .and_then(|tool| tool.tool_call_index),
+            Some(1)
+        );
         assert_eq!(
             responses[0]
                 .tool_call

--- a/src/crates/ai-adapters/src/stream/types/responses.rs
+++ b/src/crates/ai-adapters/src/stream/types/responses.rs
@@ -66,7 +66,10 @@ impl From<ResponsesUsage> for UnifiedTokenUsage {
     }
 }
 
-pub fn parse_responses_output_item(item_value: Value) -> Option<UnifiedResponse> {
+pub fn parse_responses_output_item(
+    item_value: Value,
+    tool_call_index: Option<usize>,
+) -> Option<UnifiedResponse> {
     let item_type = item_value.get("type")?.as_str()?;
 
     match item_type {
@@ -75,6 +78,7 @@ pub fn parse_responses_output_item(item_value: Value) -> Option<UnifiedResponse>
             reasoning_content: None,
             thinking_signature: None,
             tool_call: Some(UnifiedToolCall {
+                tool_call_index,
                 id: item_value
                     .get("call_id")
                     .and_then(Value::as_str)
@@ -129,16 +133,19 @@ mod tests {
 
     #[test]
     fn parses_output_text_message_item() {
-        let response = parse_responses_output_item(json!({
-            "type": "message",
-            "role": "assistant",
-            "content": [
-                {
-                    "type": "output_text",
-                    "text": "hello"
-                }
-            ]
-        }))
+        let response = parse_responses_output_item(
+            json!({
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "hello"
+                    }
+                ]
+            }),
+            None,
+        )
         .expect("message item");
 
         assert_eq!(response.text.as_deref(), Some("hello"));
@@ -146,15 +153,19 @@ mod tests {
 
     #[test]
     fn parses_function_call_item() {
-        let response = parse_responses_output_item(json!({
-            "type": "function_call",
-            "call_id": "call_1",
-            "name": "get_weather",
-            "arguments": "{\"city\":\"Beijing\"}"
-        }))
+        let response = parse_responses_output_item(
+            json!({
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "get_weather",
+                "arguments": "{\"city\":\"Beijing\"}"
+            }),
+            Some(3),
+        )
         .expect("function call item");
 
         let tool_call = response.tool_call.expect("tool call");
+        assert_eq!(tool_call.tool_call_index, Some(3));
         assert_eq!(tool_call.id.as_deref(), Some("call_1"));
         assert_eq!(tool_call.name.as_deref(), Some("get_weather"));
     }

--- a/src/crates/ai-adapters/src/stream/types/unified.rs
+++ b/src/crates/ai-adapters/src/stream/types/unified.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnifiedToolCall {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_index: Option<usize>,
     pub id: Option<String>,
     pub name: Option<String>,
     pub arguments: Option<String>,

--- a/src/crates/ai-adapters/src/tool_call_accumulator.rs
+++ b/src/crates/ai-adapters/src/tool_call_accumulator.rs
@@ -1,6 +1,6 @@
 use log::{error, warn};
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolCallBoundary {
@@ -23,11 +23,27 @@ impl ToolCallBoundary {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ToolCallStreamKey {
+    Indexed(usize),
+    Unindexed,
+}
+
+impl From<Option<usize>> for ToolCallStreamKey {
+    fn from(value: Option<usize>) -> Self {
+        match value {
+            Some(index) => Self::Indexed(index),
+            None => Self::Unindexed,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct PendingToolCall {
     tool_id: String,
     tool_name: String,
     raw_arguments: String,
+    early_detected_emitted: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -46,6 +62,31 @@ impl FinalizedToolCall {
             _ => HashMap::new(),
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EarlyDetectedToolCall {
+    pub tool_id: String,
+    pub tool_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCallParamsChunk {
+    pub tool_id: String,
+    pub tool_name: String,
+    pub params_chunk: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ToolCallDeltaOutcome {
+    pub finalized_previous: Option<FinalizedToolCall>,
+    pub early_detected: Option<EarlyDetectedToolCall>,
+    pub params_partial: Option<ToolCallParamsChunk>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PendingToolCalls {
+    pending: BTreeMap<ToolCallStreamKey, PendingToolCall>,
 }
 
 impl PendingToolCall {
@@ -92,6 +133,10 @@ impl PendingToolCall {
         !self.tool_id.is_empty()
     }
 
+    pub fn has_meaningful_payload(&self) -> bool {
+        !self.tool_name.is_empty() || !self.raw_arguments.is_empty()
+    }
+
     pub fn tool_id(&self) -> &str {
         &self.tool_id
     }
@@ -104,6 +149,7 @@ impl PendingToolCall {
         self.tool_id = tool_id;
         self.tool_name = tool_name.unwrap_or_default();
         self.raw_arguments.clear();
+        self.early_detected_emitted = false;
     }
 
     pub fn update_tool_name_if_missing(&mut self, tool_name: Option<String>) {
@@ -126,9 +172,18 @@ impl PendingToolCall {
             return None;
         }
 
+        if !self.has_meaningful_payload() {
+            self.tool_id.clear();
+            self.tool_name.clear();
+            self.raw_arguments.clear();
+            self.early_detected_emitted = false;
+            return None;
+        }
+
         let tool_id = std::mem::take(&mut self.tool_id);
         let tool_name = std::mem::take(&mut self.tool_name);
         let raw_arguments = std::mem::take(&mut self.raw_arguments);
+        self.early_detected_emitted = false;
         let parsed_arguments = Self::parse_arguments(&raw_arguments);
         let is_error = parsed_arguments.is_err();
 
@@ -153,9 +208,97 @@ impl PendingToolCall {
     }
 }
 
+impl PendingToolCalls {
+    pub fn apply_delta(
+        &mut self,
+        key: ToolCallStreamKey,
+        tool_id: Option<String>,
+        tool_name: Option<String>,
+        arguments: Option<String>,
+        arguments_is_snapshot: bool,
+    ) -> ToolCallDeltaOutcome {
+        let mut outcome = ToolCallDeltaOutcome::default();
+
+        let has_tool_id = tool_id.as_ref().is_some_and(|tool_id| !tool_id.is_empty());
+        if !self.pending.contains_key(&key) {
+            if has_tool_id {
+                self.pending.insert(key.clone(), PendingToolCall::default());
+            } else {
+                return outcome;
+            }
+        }
+
+        let Some(pending) = self.pending.get_mut(&key) else {
+            return outcome;
+        };
+
+        if let Some(tool_id) = tool_id.filter(|tool_id| !tool_id.is_empty()) {
+            let is_new_tool = pending.tool_id() != tool_id;
+            if is_new_tool {
+                outcome.finalized_previous = pending.finalize(ToolCallBoundary::NewTool);
+                pending.start_new(tool_id, tool_name.clone());
+            } else {
+                pending.update_tool_name_if_missing(tool_name.clone());
+            }
+        } else if tool_name
+            .as_ref()
+            .is_some_and(|tool_name| !tool_name.is_empty())
+        {
+            pending.update_tool_name_if_missing(tool_name.clone());
+        }
+
+        if pending.has_pending()
+            && !pending.tool_name().is_empty()
+            && !pending.early_detected_emitted
+        {
+            pending.early_detected_emitted = true;
+            outcome.early_detected = Some(EarlyDetectedToolCall {
+                tool_id: pending.tool_id().to_string(),
+                tool_name: pending.tool_name().to_string(),
+            });
+        }
+
+        if let Some(arguments) = arguments.filter(|arguments| !arguments.is_empty()) {
+            if pending.has_pending() {
+                if arguments_is_snapshot {
+                    pending.replace_arguments(&arguments);
+                } else {
+                    pending.append_arguments(&arguments);
+                }
+                outcome.params_partial = Some(ToolCallParamsChunk {
+                    tool_id: pending.tool_id().to_string(),
+                    tool_name: pending.tool_name().to_string(),
+                    params_chunk: arguments,
+                });
+            }
+        }
+
+        outcome
+    }
+
+    pub fn finalize_key(
+        &mut self,
+        key: &ToolCallStreamKey,
+        boundary: ToolCallBoundary,
+    ) -> Option<FinalizedToolCall> {
+        let mut pending = self.pending.remove(key)?;
+        pending.finalize(boundary)
+    }
+
+    pub fn finalize_all(&mut self, boundary: ToolCallBoundary) -> Vec<FinalizedToolCall> {
+        let keys: Vec<_> = self.pending.keys().cloned().collect();
+        keys.into_iter()
+            .filter_map(|key| self.finalize_key(&key, boundary))
+            .collect()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{PendingToolCall, ToolCallBoundary};
+    use super::{
+        EarlyDetectedToolCall, PendingToolCall, PendingToolCalls, ToolCallBoundary,
+        ToolCallParamsChunk, ToolCallStreamKey,
+    };
     use serde_json::json;
 
     #[test]
@@ -232,5 +375,152 @@ mod tests {
 
         assert_eq!(finalized.arguments, json!({"city": "Beijing"}));
         assert!(!finalized.is_error);
+    }
+
+    #[test]
+    fn manages_multiple_pending_tool_calls_by_index() {
+        let mut pending = PendingToolCalls::default();
+
+        assert_eq!(
+            pending
+                .apply_delta(
+                    ToolCallStreamKey::Indexed(0),
+                    Some("call_1".to_string()),
+                    Some("tool_a".to_string()),
+                    None,
+                    false,
+                )
+                .early_detected,
+            Some(EarlyDetectedToolCall {
+                tool_id: "call_1".to_string(),
+                tool_name: "tool_a".to_string(),
+            })
+        );
+        assert_eq!(
+            pending
+                .apply_delta(
+                    ToolCallStreamKey::Indexed(1),
+                    Some("call_2".to_string()),
+                    Some("tool_b".to_string()),
+                    None,
+                    false,
+                )
+                .early_detected,
+            Some(EarlyDetectedToolCall {
+                tool_id: "call_2".to_string(),
+                tool_name: "tool_b".to_string(),
+            })
+        );
+
+        pending.apply_delta(
+            ToolCallStreamKey::Indexed(0),
+            None,
+            None,
+            Some("{\"a\":1}".to_string()),
+            false,
+        );
+        pending.apply_delta(
+            ToolCallStreamKey::Indexed(1),
+            None,
+            None,
+            Some("{\"b\":2}".to_string()),
+            false,
+        );
+
+        let finalized = pending.finalize_all(ToolCallBoundary::FinishReason);
+        assert_eq!(finalized.len(), 2);
+        assert_eq!(finalized[0].tool_id, "call_1");
+        assert_eq!(finalized[0].arguments, json!({"a": 1}));
+        assert_eq!(finalized[1].tool_id, "call_2");
+        assert_eq!(finalized[1].arguments, json!({"b": 2}));
+    }
+
+    #[test]
+    fn id_only_prelude_is_attached_to_following_payload_without_id() {
+        let mut pending = PendingToolCalls::default();
+
+        let prelude = pending.apply_delta(
+            ToolCallStreamKey::Indexed(0),
+            Some("call_1".to_string()),
+            None,
+            None,
+            false,
+        );
+        assert_eq!(prelude.early_detected, None);
+        assert_eq!(prelude.params_partial, None);
+
+        let payload = pending.apply_delta(
+            ToolCallStreamKey::Indexed(0),
+            None,
+            Some("tool_a".to_string()),
+            Some("{\"a\":1}".to_string()),
+            false,
+        );
+        assert_eq!(
+            payload.early_detected,
+            Some(EarlyDetectedToolCall {
+                tool_id: "call_1".to_string(),
+                tool_name: "tool_a".to_string(),
+            })
+        );
+        assert_eq!(
+            payload.params_partial,
+            Some(ToolCallParamsChunk {
+                tool_id: "call_1".to_string(),
+                tool_name: "tool_a".to_string(),
+                params_chunk: "{\"a\":1}".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn id_only_orphan_is_dropped_on_finalize() {
+        let mut pending = PendingToolCalls::default();
+
+        let outcome = pending.apply_delta(
+            ToolCallStreamKey::Indexed(1),
+            Some("call_orphan".to_string()),
+            None,
+            None,
+            false,
+        );
+        assert!(outcome.finalized_previous.is_none());
+        assert!(outcome.early_detected.is_none());
+        assert!(outcome.params_partial.is_none());
+        assert!(pending
+            .finalize_all(ToolCallBoundary::FinishReason)
+            .is_empty());
+    }
+
+    #[test]
+    fn empty_argument_delta_is_ignored() {
+        let mut pending = PendingToolCalls::default();
+
+        let header = pending.apply_delta(
+            ToolCallStreamKey::Indexed(0),
+            Some("call_1".to_string()),
+            Some("tool_a".to_string()),
+            Some(String::new()),
+            false,
+        );
+        assert_eq!(
+            header.early_detected,
+            Some(EarlyDetectedToolCall {
+                tool_id: "call_1".to_string(),
+                tool_name: "tool_a".to_string(),
+            })
+        );
+        assert!(header.params_partial.is_none());
+
+        let empty_delta = pending.apply_delta(
+            ToolCallStreamKey::Indexed(0),
+            None,
+            None,
+            Some(String::new()),
+            false,
+        );
+        assert!(empty_delta.finalized_previous.is_none());
+        assert!(empty_delta.early_detected.is_none());
+        assert!(empty_delta.params_partial.is_none());
     }
 }

--- a/src/crates/core/src/agentic/execution/AGENTS.md
+++ b/src/crates/core/src/agentic/execution/AGENTS.md
@@ -1,0 +1,1 @@
+If you modify `stream_processor.rs`, run the stream integration tests before finishing.

--- a/src/crates/core/src/agentic/execution/stream_processor.rs
+++ b/src/crates/core/src/agentic/execution/stream_processor.rs
@@ -10,7 +10,7 @@ use crate::agentic::events::{
 use crate::agentic::tools::SubagentParentInfo;
 use crate::infrastructure::ai::ai_stream_handlers::UnifiedResponse;
 use crate::infrastructure::ai::tool_call_accumulator::{
-    FinalizedToolCall, PendingToolCall, ToolCallBoundary,
+    FinalizedToolCall, PendingToolCalls, ToolCallBoundary, ToolCallStreamKey,
 };
 use crate::util::errors::BitFunError;
 use crate::util::types::ai::GeminiUsage;
@@ -159,7 +159,7 @@ struct StreamContext {
     provider_metadata: Option<Value>,
 
     // Current tool call state
-    pending_tool_call: PendingToolCall,
+    pending_tool_calls: PendingToolCalls,
 
     // Counters and flags
     text_chunks_count: usize,
@@ -189,7 +189,7 @@ impl StreamContext {
             tool_calls: Vec::new(),
             usage: None,
             provider_metadata: None,
-            pending_tool_call: PendingToolCall::default(),
+            pending_tool_calls: PendingToolCalls::default(),
             text_chunks_count: 0,
             thinking_chunks_count: 0,
             thinking_completed_sent: false,
@@ -215,11 +215,7 @@ impl StreamContext {
         self.has_effective_output
     }
 
-    fn finalize_pending_tool_call(
-        &mut self,
-        boundary: ToolCallBoundary,
-    ) -> Option<FinalizedToolCall> {
-        let finalized = self.pending_tool_call.finalize(boundary)?;
+    fn record_finalized_tool_call(&mut self, finalized: &FinalizedToolCall) {
         let tool_name = if finalized.tool_name.is_empty() {
             UNKNOWN_TOOL_PLACEHOLDER.to_string()
         } else {
@@ -236,13 +232,22 @@ impl StreamContext {
             arguments: finalized.arguments.clone(),
             is_error: finalized.is_error,
         });
-        Some(finalized)
     }
 
-    /// Force finish pending_tool_call, used when the stream is shutting down before a natural tool boundary.
-    fn force_finish_pending_tool_call(&mut self) {
-        if let Some(finalized) = self.finalize_pending_tool_call(ToolCallBoundary::GracefulShutdown)
-        {
+    fn finalize_all_pending_tool_calls(
+        &mut self,
+        boundary: ToolCallBoundary,
+    ) -> Vec<FinalizedToolCall> {
+        let finalized = self.pending_tool_calls.finalize_all(boundary);
+        for tool_call in &finalized {
+            self.record_finalized_tool_call(tool_call);
+        }
+        finalized
+    }
+
+    /// Force finish pending tool calls, used when the stream is shutting down before a natural tool boundary.
+    fn force_finish_pending_tool_calls(&mut self) {
+        for finalized in self.finalize_all_pending_tool_calls(ToolCallBoundary::GracefulShutdown) {
             error!(
                 "force finish pending tool call: tool_id={}, tool_name={}, raw_len={}, is_error={}",
                 finalized.tool_id,
@@ -327,7 +332,7 @@ impl StreamProcessor {
 
     /// Execute graceful shutdown from context
     async fn graceful_shutdown_from_ctx(&self, ctx: &mut StreamContext, reason: String) {
-        ctx.force_finish_pending_tool_call();
+        ctx.force_finish_pending_tool_calls();
         self.graceful_shutdown(
             ctx.session_id.clone(),
             ctx.dialog_turn_id.clone(),
@@ -448,79 +453,62 @@ impl StreamProcessor {
         tool_call: crate::infrastructure::ai::ai_stream_handlers::UnifiedToolCall,
     ) {
         let crate::infrastructure::ai::ai_stream_handlers::UnifiedToolCall {
+            tool_call_index,
             id,
             name,
             arguments,
             arguments_is_snapshot,
         } = tool_call;
+        let outcome = ctx.pending_tool_calls.apply_delta(
+            ToolCallStreamKey::from(tool_call_index),
+            id,
+            name,
+            arguments,
+            arguments_is_snapshot,
+        );
 
-        // Handle tool ID and name
-        if let Some(tool_id) = id {
-            if !tool_id.is_empty() {
-                ctx.has_effective_output = true;
-                // Some providers repeat the tool id on every delta; only treat a new id as a new tool call.
-                let is_new_tool = ctx.pending_tool_call.tool_id() != tool_id;
-                if is_new_tool {
-                    let _ = ctx.finalize_pending_tool_call(ToolCallBoundary::NewTool);
-
-                    // Normally tool_name should not be empty
-                    let tool_name = name.clone().unwrap_or_default();
-                    debug!("Tool detected: {}", tool_name);
-                    ctx.pending_tool_call
-                        .start_new(tool_id.clone(), name.clone());
-
-                    // Send early detection event
-                    let _ = self
-                        .event_queue
-                        .enqueue(
-                            AgenticEvent::ToolEvent {
-                                session_id: ctx.session_id.clone(),
-                                turn_id: ctx.dialog_turn_id.clone(),
-                                tool_event: ToolEventData::EarlyDetected { tool_id, tool_name },
-                                subagent_parent_info: ctx.event_subagent_parent_info.clone(),
-                            },
-                            None,
-                        )
-                        .await;
-                } else if ctx.pending_tool_call.tool_name().is_empty() {
-                    // Best-effort: keep name if provider repeats it.
-                    ctx.pending_tool_call
-                        .update_tool_name_if_missing(name.clone());
-                }
-            }
+        if let Some(finalized) = outcome.finalized_previous {
+            ctx.record_finalized_tool_call(&finalized);
         }
 
-        // Handle tool parameters
-        if let Some(tool_call_arguments) = arguments {
-            // Providers often omit tool_id on follow-up argument deltas. Append as long as we already
-            // have a pending tool call; otherwise treat this as an orphaned delta and ignore it.
-            if ctx.pending_tool_call.has_pending() {
-                ctx.has_effective_output = true;
-                if arguments_is_snapshot {
-                    ctx.pending_tool_call
-                        .replace_arguments(&tool_call_arguments);
-                } else {
-                    ctx.pending_tool_call.append_arguments(&tool_call_arguments);
-                }
-
-                // Send partial parameters event
-                let _ = self
-                    .event_queue
-                    .enqueue(
-                        AgenticEvent::ToolEvent {
-                            session_id: ctx.session_id.clone(),
-                            turn_id: ctx.dialog_turn_id.clone(),
-                            tool_event: ToolEventData::ParamsPartial {
-                                tool_id: ctx.pending_tool_call.tool_id().to_string(),
-                                tool_name: ctx.pending_tool_call.tool_name().to_string(),
-                                params: tool_call_arguments,
-                            },
-                            subagent_parent_info: ctx.event_subagent_parent_info.clone(),
+        if let Some(early_detected) = outcome.early_detected {
+            ctx.has_effective_output = true;
+            debug!("Tool detected: {}", early_detected.tool_name);
+            let _ = self
+                .event_queue
+                .enqueue(
+                    AgenticEvent::ToolEvent {
+                        session_id: ctx.session_id.clone(),
+                        turn_id: ctx.dialog_turn_id.clone(),
+                        tool_event: ToolEventData::EarlyDetected {
+                            tool_id: early_detected.tool_id,
+                            tool_name: early_detected.tool_name,
                         },
-                        None,
-                    )
-                    .await;
-            }
+                        subagent_parent_info: ctx.event_subagent_parent_info.clone(),
+                    },
+                    None,
+                )
+                .await;
+        }
+
+        if let Some(params_partial) = outcome.params_partial {
+            ctx.has_effective_output = true;
+            let _ = self
+                .event_queue
+                .enqueue(
+                    AgenticEvent::ToolEvent {
+                        session_id: ctx.session_id.clone(),
+                        turn_id: ctx.dialog_turn_id.clone(),
+                        tool_event: ToolEventData::ParamsPartial {
+                            tool_id: params_partial.tool_id,
+                            tool_name: params_partial.tool_name,
+                            params: params_partial.params_chunk,
+                        },
+                        subagent_parent_info: ctx.event_subagent_parent_info.clone(),
+                    },
+                    None,
+                )
+                .await;
         }
     }
 
@@ -704,7 +692,7 @@ impl StreamProcessor {
                             if ctx.can_recover_as_partial_result() {
                                 flush_sse_on_error(&sse_collector, &error_msg).await;
                                 self.send_thinking_end_if_needed(&mut ctx).await;
-                                ctx.force_finish_pending_tool_call();
+                                ctx.force_finish_pending_tool_calls();
                                 ctx.partial_recovery_reason = Some(error_msg.clone());
                                 self.log_stream_result(&ctx);
                                 break;
@@ -724,7 +712,7 @@ impl StreamProcessor {
                             flush_sse_on_error(&sse_collector, &error_msg).await;
                             if ctx.can_recover_as_partial_result() {
                                 self.send_thinking_end_if_needed(&mut ctx).await;
-                                ctx.force_finish_pending_tool_call();
+                                ctx.force_finish_pending_tool_calls();
                                 ctx.partial_recovery_reason = Some(error_msg.clone());
                                 self.log_stream_result(&ctx);
                                 break;
@@ -796,7 +784,7 @@ impl StreamProcessor {
                     }
 
                     if finish_reason.is_some() {
-                        let _ = ctx.finalize_pending_tool_call(ToolCallBoundary::FinishReason);
+                        let _ = ctx.finalize_all_pending_tool_calls(ToolCallBoundary::FinishReason);
                     }
                 }
             }
@@ -805,7 +793,7 @@ impl StreamProcessor {
         // Ensure thinking end marker is sent
         self.send_thinking_end_if_needed(&mut ctx).await;
 
-        let _ = ctx.finalize_pending_tool_call(ToolCallBoundary::StreamEnd);
+        let _ = ctx.finalize_all_pending_tool_calls(ToolCallBoundary::StreamEnd);
 
         // Invalid tool payloads that survive to finalization still need detailed SSE logs for diagnosis.
         if ctx.tool_calls.iter().any(|tc| !tc.is_valid()) {
@@ -851,6 +839,7 @@ mod tests {
         let stream = iter(vec![
             Ok(UnifiedResponse {
                 tool_call: Some(UnifiedToolCall {
+                    tool_call_index: None,
                     id: Some("call_1".to_string()),
                     name: Some("tool_a".to_string()),
                     arguments: Some("{\"a\":".to_string()),
@@ -861,6 +850,7 @@ mod tests {
             }),
             Ok(UnifiedResponse {
                 tool_call: Some(UnifiedToolCall {
+                    tool_call_index: None,
                     id: None,
                     name: None,
                     arguments: Some("1}".to_string()),
@@ -898,6 +888,7 @@ mod tests {
         let processor = build_processor();
         let stream = iter(vec![Ok(UnifiedResponse {
             tool_call: Some(UnifiedToolCall {
+                tool_call_index: None,
                 id: Some("call_1".to_string()),
                 name: Some("tool_a".to_string()),
                 arguments: Some("{\"a\":1}".to_string()),
@@ -932,6 +923,7 @@ mod tests {
         let processor = build_processor();
         let stream = iter(vec![Ok(UnifiedResponse {
             tool_call: Some(UnifiedToolCall {
+                tool_call_index: None,
                 id: Some("call_1".to_string()),
                 name: Some("tool_a".to_string()),
                 arguments: Some("{\"a\":1}}".to_string()),
@@ -968,6 +960,7 @@ mod tests {
         let stream = iter(vec![
             Ok(UnifiedResponse {
                 tool_call: Some(UnifiedToolCall {
+                    tool_call_index: None,
                     id: Some("call_1".to_string()),
                     name: Some("tool_a".to_string()),
                     arguments: Some("{\"city\":\"Bei".to_string()),
@@ -977,6 +970,7 @@ mod tests {
             }),
             Ok(UnifiedResponse {
                 tool_call: Some(UnifiedToolCall {
+                    tool_call_index: None,
                     id: None,
                     name: None,
                     arguments: Some("{\"city\":\"Beijing\"}".to_string()),
@@ -1006,5 +1000,75 @@ mod tests {
         assert_eq!(result.tool_calls[0].tool_name, "tool_a");
         assert_eq!(result.tool_calls[0].arguments, json!({"city": "Beijing"}));
         assert!(!result.tool_calls[0].is_error);
+    }
+
+    #[tokio::test]
+    async fn keeps_interleaved_indexed_tool_calls_separate() {
+        let processor = build_processor();
+        let stream = iter(vec![
+            Ok(UnifiedResponse {
+                tool_call: Some(UnifiedToolCall {
+                    tool_call_index: Some(0),
+                    id: Some("call_0".to_string()),
+                    name: Some("tool_a".to_string()),
+                    arguments: None,
+                    arguments_is_snapshot: false,
+                }),
+                ..Default::default()
+            }),
+            Ok(UnifiedResponse {
+                tool_call: Some(UnifiedToolCall {
+                    tool_call_index: Some(1),
+                    id: Some("call_1".to_string()),
+                    name: Some("tool_b".to_string()),
+                    arguments: None,
+                    arguments_is_snapshot: false,
+                }),
+                ..Default::default()
+            }),
+            Ok(UnifiedResponse {
+                tool_call: Some(UnifiedToolCall {
+                    tool_call_index: Some(0),
+                    id: None,
+                    name: None,
+                    arguments: Some("{\"a\":1}".to_string()),
+                    arguments_is_snapshot: false,
+                }),
+                ..Default::default()
+            }),
+            Ok(UnifiedResponse {
+                tool_call: Some(UnifiedToolCall {
+                    tool_call_index: Some(1),
+                    id: None,
+                    name: None,
+                    arguments: Some("{\"b\":2}".to_string()),
+                    arguments_is_snapshot: false,
+                }),
+                finish_reason: Some("tool_calls".to_string()),
+                ..Default::default()
+            }),
+        ])
+        .boxed();
+
+        let result = processor
+            .process_stream(
+                stream,
+                None,
+                "session_1".to_string(),
+                "turn_1".to_string(),
+                "round_1".to_string(),
+                None,
+                &CancellationToken::new(),
+            )
+            .await
+            .expect("stream result");
+
+        assert_eq!(result.tool_calls.len(), 2);
+        assert_eq!(result.tool_calls[0].tool_id, "call_0");
+        assert_eq!(result.tool_calls[0].tool_name, "tool_a");
+        assert_eq!(result.tool_calls[0].arguments, json!({"a": 1}));
+        assert_eq!(result.tool_calls[1].tool_id, "call_1");
+        assert_eq!(result.tool_calls[1].tool_name, "tool_b");
+        assert_eq!(result.tool_calls[1].arguments, json!({"b": 2}));
     }
 }

--- a/src/crates/core/tests/fixtures/stream/openai/interleaved_parallel_tool_args_by_index.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/interleaved_parallel_tool_args_by_index.sse
@@ -1,0 +1,9 @@
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":800,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"tool_one"}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":801,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_2","type":"function","function":{"name":"tool_two"}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":802,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"arguments":"{\"x\":1}"}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":803,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"type":"function","function":{"arguments":"{\"y\":2}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":5,"total_tokens":10}}
+
+data: [DONE]

--- a/src/crates/core/tests/fixtures/stream/openai/tool_call_missing_type_field.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/tool_call_missing_type_field.sse
@@ -1,0 +1,7 @@
+data: {"id":"chatcmpl_azure_001","object":"chat.completion.chunk","created":1711357598,"model":"mistral-large","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_abc123","function":{"name":"test_tool","arguments":""}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_azure_001","object":"chat.completion.chunk","created":1711357599,"model":"mistral-large","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"value\""}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_azure_001","object":"chat.completion.chunk","created":1711357600,"model":"mistral-large","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\"hello\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}
+
+data: [DONE]

--- a/src/crates/core/tests/fixtures/stream/openai/tool_call_trailing_empty_args_finish_chunk.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/tool_call_trailing_empty_args_finish_chunk.sse
@@ -1,0 +1,13 @@
+data: {"id":"chatcmpl_tail_001","object":"chat.completion.chunk","created":1733162241,"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}],"usage":{"prompt_tokens":226,"completion_tokens":0,"total_tokens":226}}
+
+data: {"id":"chatcmpl_tail_001","object":"chat.completion.chunk","created":1733162242,"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_tail_1","type":"function","function":{"name":"search_google"}}]},"finish_reason":null}],"usage":{"prompt_tokens":226,"completion_tokens":7,"total_tokens":233}}
+
+data: {"id":"chatcmpl_tail_001","object":"chat.completion.chunk","created":1733162243,"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"query\":\"latest"}}]},"finish_reason":null}],"usage":{"prompt_tokens":226,"completion_tokens":15,"total_tokens":241}}
+
+data: {"id":"chatcmpl_tail_001","object":"chat.completion.chunk","created":1733162244,"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" news"}}]},"finish_reason":null}],"usage":{"prompt_tokens":226,"completion_tokens":16,"total_tokens":242}}
+
+data: {"id":"chatcmpl_tail_001","object":"chat.completion.chunk","created":1733162245,"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" on ai\"}"}}]},"finish_reason":null}],"usage":{"prompt_tokens":226,"completion_tokens":19,"total_tokens":245}}
+
+data: {"id":"chatcmpl_tail_001","object":"chat.completion.chunk","created":1733162246,"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":""}}]},"finish_reason":"tool_calls","stop_reason":128008}],"usage":{"prompt_tokens":226,"completion_tokens":20,"total_tokens":246}}
+
+data: [DONE]

--- a/src/crates/core/tests/stream_processor_openai.rs
+++ b/src/crates/core/tests/stream_processor_openai.rs
@@ -377,3 +377,154 @@ async fn openai_fixture_filters_orphan_id_only_block_when_it_shares_chunk_with_f
         ]
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn openai_fixture_routes_interleaved_tool_args_by_index() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::OpenAi,
+        "stream/openai/interleaved_parallel_tool_args_by_index.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+
+    assert_eq!(result.tool_calls.len(), 2);
+
+    assert_eq!(result.tool_calls[0].tool_id, "call_1");
+    assert_eq!(result.tool_calls[0].tool_name, "tool_one");
+    assert_eq!(result.tool_calls[0].arguments, json!({ "x": 1 }));
+    assert!(!result.tool_calls[0].is_error);
+
+    assert_eq!(result.tool_calls[1].tool_id, "call_2");
+    assert_eq!(result.tool_calls[1].tool_name, "tool_two");
+    assert_eq!(result.tool_calls[1].arguments, json!({ "y": 2 }));
+    assert!(!result.tool_calls[1].is_error);
+
+    assert_eq!(
+        result.usage.as_ref().map(|usage| usage.total_token_count),
+        Some(10)
+    );
+
+    let early_detected_ids: Vec<&str> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ToolEvent {
+                tool_event: ToolEventData::EarlyDetected { tool_id, .. },
+                ..
+            } => Some(tool_id.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(early_detected_ids, vec!["call_1", "call_2"]);
+
+    let partial_params: Vec<(&str, &str)> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ToolEvent {
+                tool_event:
+                    ToolEventData::ParamsPartial {
+                        tool_id, params, ..
+                    },
+                ..
+            } => Some((tool_id.as_str(), params.as_str())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        partial_params,
+        vec![("call_1", "{\"x\":1}"), ("call_2", "{\"y\":2}")]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn openai_fixture_accepts_tool_call_without_type_field() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::OpenAi,
+        "stream/openai/tool_call_missing_type_field.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].tool_id, "call_abc123");
+    assert_eq!(result.tool_calls[0].tool_name, "test_tool");
+    assert_eq!(result.tool_calls[0].arguments, json!({ "value": "hello" }));
+    assert!(!result.tool_calls[0].is_error);
+    assert_eq!(
+        result.usage.as_ref().map(|usage| usage.total_token_count),
+        Some(15)
+    );
+
+    let early_detected = output.events.iter().any(|event| {
+        matches!(
+            event,
+            AgenticEvent::ToolEvent {
+                tool_event: ToolEventData::EarlyDetected { tool_id, tool_name },
+                ..
+            } if tool_id == "call_abc123" && tool_name == "test_tool"
+        )
+    });
+    assert!(
+        early_detected,
+        "missing type field should still trigger tool early detection"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn openai_fixture_ignores_trailing_empty_tool_args_finish_chunk() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::OpenAi,
+        "stream/openai/tool_call_trailing_empty_args_finish_chunk.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].tool_id, "call_tail_1");
+    assert_eq!(result.tool_calls[0].tool_name, "search_google");
+    assert_eq!(
+        result.tool_calls[0].arguments,
+        json!({ "query": "latest news on ai" })
+    );
+    assert!(!result.tool_calls[0].is_error);
+    assert_eq!(
+        result.usage.as_ref().map(|usage| usage.total_token_count),
+        Some(246)
+    );
+
+    let early_detected_ids: Vec<&str> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ToolEvent {
+                tool_event: ToolEventData::EarlyDetected { tool_id, .. },
+                ..
+            } => Some(tool_id.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(early_detected_ids, vec!["call_tail_1"]);
+
+    let partial_params: Vec<&str> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ToolEvent {
+                tool_event: ToolEventData::ParamsPartial { params, .. },
+                ..
+            } => Some(params.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        partial_params,
+        vec!["{\"query\":\"latest", " news", " on ai\"}"]
+    );
+}


### PR DESCRIPTION
- preserve provider tool-call indices in unified stream types and route interleaved tool deltas by index
- move tool-call buffering/finalization into the shared accumulator and remove OpenAI-specific orphan/prelude filtering
- update stream processor and response aggregators to consume accumulator outcomes for early detection and param streaming
- ignore empty tool argument deltas and keep fallback handling for snapshot/tail-fill edge cases
- add OpenAI stream regression fixtures for interleaved args, missing tool type, and trailing empty finish chunks
- document that changes to stream processor or ai-adapters must run stream integration tests
