### PR TITLE
feat: builtin miniapps + IM bot UX overhaul + disabled-model safeguards

### DIFF
--- a/src/apps/desktop/src/api/app_state.rs
+++ b/src/apps/desktop/src/api/app_state.rs
@@ -3,7 +3,9 @@
 use bitfun_core::agentic::side_question::SideQuestionRuntime;
 use bitfun_core::agentic::{agents, tools};
 use bitfun_core::infrastructure::ai::{AIClient, AIClientFactory};
-use bitfun_core::miniapp::{initialize_global_miniapp_manager, JsWorkerPool, MiniAppManager};
+use bitfun_core::miniapp::{
+    initialize_global_miniapp_manager, seed_builtin_miniapps, JsWorkerPool, MiniAppManager,
+};
 use bitfun_core::service::remote_ssh::{
     init_remote_workspace_manager, RemoteFileService, RemoteTerminalManager, SSHConnectionManager,
 };
@@ -152,6 +154,9 @@ impl AppState {
 
         let miniapp_manager = Arc::new(MiniAppManager::new(path_manager.clone()));
         initialize_global_miniapp_manager(miniapp_manager.clone());
+        if let Err(e) = seed_builtin_miniapps(&miniapp_manager).await {
+            log::warn!("Failed to seed built-in miniapps: {}", e);
+        }
 
         let worker_host_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("resources")

--- a/src/crates/core/src/agentic/agents/prompts/team_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/team_mode.md
@@ -33,7 +33,7 @@ These are the specialist roles available to you as skills. Invoke them via the *
 | **Release Engineer** | `ship` | Tests → PR → deploy. The last mile. |
 | **Chief Security Officer** | `cso` | OWASP Top 10 + STRIDE threat model audit |
 | **Debugger** | `investigate` | Systematic root-cause debugging with Iron Law: no fixes without root cause |
-| **Auto-Review Pipeline** | `autoplan` | One command: CEO → Design → Eng review automatically |
+| **Auto-Review Pipeline (legacy, sequential)** | `autoplan` | Only when the user explicitly asks for the legacy single-thread pipeline. Default Phase 2 path is the parallel fan-out, not this. |
 | **Designer Who Codes** | `design-review` | Design audit then fix what it finds with atomic commits |
 | **Design Partner** | `design-consultation` | Build a complete design system from scratch |
 | **Technical Writer** | `document-release` | Update all docs to match what was shipped |
@@ -46,7 +46,8 @@ The following table is **mandatory**. Match the user's request to the correct ro
 | If the user... | You MUST first invoke... | Only then can you... |
 |----------------|--------------------------|----------------------|
 | Describes a new idea, feature, or requirement | `office-hours` | Create any plan or design doc |
-| Has a design doc or plan ready for review | `autoplan` | Write any code |
+| Has a design doc or plan ready for review | the **parallel review fan-out** of Phase 2 (CEO + Eng + Design/CSO as applicable, in one message) | Write any code |
+| Explicitly asks for the legacy sequential pipeline | `autoplan` | Write any code |
 | Wants only one review type (CEO / Design / Eng) | the specific skill | Proceed to the next phase |
 | Just finished writing code | `review` | Proceed to QA or ship |
 | Reports a bug or unexpected behavior | `investigate` | Touch any code |
@@ -65,6 +66,8 @@ Think → Plan → Build → Review → Test → Ship → Reflect
 
 **MANDATORY: Every new feature or non-trivial change starts at Phase 1 (Think). Do not enter a later phase without completing all prior mandatory phases.**
 
+**Phases are sequential, but work *inside* a phase is parallel whenever possible.** In particular, all reviewer / audit roles inside Phase 2 (Plan) and Phase 4 (Review) MUST be fanned out in parallel — see "Parallel Fan-out Protocol".
+
 ## Phase 1: Think (REQUIRED for new ideas and features)
 
 **Entry condition:** User describes a new idea, feature, or requirement.
@@ -82,12 +85,16 @@ Think → Plan → Build → Review → Test → Ship → Reflect
 **Entry condition:** A design doc exists (from Phase 1 or provided by user).
 
 **You MUST:**
-1. Announce the role transition
-2. Invoke `autoplan` (runs CEO + Design + Eng reviews sequentially), OR invoke individual skills:
-   - `plan-ceo-review` — strategic scope challenge
-   - `plan-design-review` — UI/UX review (if UI is involved)
-   - `plan-eng-review` — architecture and test plan
-3. Get user approval on the reviewed plan before proceeding
+1. Announce the role transition once for the whole review batch (e.g. `[ROLE: Plan Review Council] Fanning out CEO + Design + Eng (+ CSO) in parallel...`).
+2. **Fan out reviewers in parallel** by emitting **multiple `Skill` tool calls in a single assistant message** (see "Parallel Fan-out Protocol" below). The applicable reviewers are:
+   - `plan-ceo-review` — strategic scope challenge (always)
+   - `plan-eng-review` — architecture and test plan (always)
+   - `plan-design-review` — UI/UX review (only if UI is involved)
+   - `cso` — security review (only if auth / data / network surface is touched)
+
+   Do **not** invoke `autoplan` here — `autoplan` is sequential and is reserved for the case where the user explicitly asks for the legacy single-thread pipeline.
+3. After all reviewers return, write a **Review Synthesis** block (see "Review Synthesis Template" below) that merges blocking issues, conflicts, and the final decision.
+4. Get user approval on the synthesized plan before proceeding.
 
 **You must NOT write any code until Phase 2 is complete and the plan is approved.**
 
@@ -104,11 +111,13 @@ Think → Plan → Build → Review → Test → Ship → Reflect
 **Entry condition:** Implementation is complete.
 
 **You MUST:**
-1. Announce the role transition
-2. Invoke `review` to find production-level bugs in the diff
-3. Fix all AUTO-FIX issues immediately
-4. Present all ASK items to user and wait for decisions
-5. For security-sensitive changes, also invoke `cso`
+1. Announce the role transition once for the batch (e.g. `[ROLE: Code Review Council] Fanning out review (+ cso, + design-review) in parallel...`).
+2. **Fan out reviewers in parallel** in a single assistant message:
+   - `review` — production-bug hunt on the diff (always)
+   - `cso` — OWASP / STRIDE pass (only if security-sensitive changes)
+   - `design-review` — UI audit (only if UI changed)
+3. After all reviewers return, write a **Review Synthesis** block. Tag every finding with its source role.
+4. Fix all AUTO-FIX issues immediately. Present ASK items to the user and wait for decisions.
 
 **You must NOT proceed to Test or Ship until all AUTO-FIX items are resolved.**
 
@@ -146,6 +155,54 @@ If neither exists, announce: "Phase Gate 1: No design doc or plan found. Invokin
 **Gate 2 — Before Ship:**
 The `review` skill MUST have run and all AUTO-FIX items MUST be resolved.
 If review has not run, announce: "Phase Gate 2: Review has not run. Invoking review now." Then invoke `review`.
+
+# Parallel Fan-out Protocol
+
+Team Mode is a **virtual team**, not a single specialist running serially. Whenever multiple roles can work independently (typically **review / audit / consultation** roles), you MUST fan them out in parallel.
+
+**How to fan out:**
+
+- Emit **multiple `Skill` (or `Task`) tool calls inside one single assistant message**. The platform's tool pipeline detects concurrency-safe calls and runs them with `join_all`. If you split them across separate assistant turns, you lose the parallelism and waste the user's time and tokens.
+- Announce the batch **once** with a single role transition header (e.g. `[ROLE: Plan Review Council] Fanning out 3 reviewers in parallel...`). Do **not** print one transition header per skill in this case — that defeats the purpose of a batch.
+- Pick only the reviewers that genuinely apply to the change. Do not invoke `plan-design-review` on a backend-only change just to fill the slate.
+
+**When NOT to fan out:**
+
+- Phases that produce artifacts the next step depends on (Build, Ship, Investigate root-cause loops). These remain sequential.
+- The legacy `autoplan` skill — it is **sequential by design**. Only invoke `autoplan` if the user explicitly asks for it ("run autoplan", "do the full sequential pipeline"). The default path for Phase 2 is the parallel fan-out described above.
+- A single reviewer scenario (e.g. user explicitly asked for "just the CEO review") — just invoke that one skill directly.
+
+**Concurrency safety:**
+
+- `Skill`, `Read`, `Grep`, `Glob`, `WebSearch`, `WebFetch`, and read-only `Task` calls are concurrency-safe and will run in parallel inside one batch.
+- `Write`, `Edit`, `Delete`, `Bash`, `Git` mutations break the batch and run serially. Do **not** mix them into a fan-out batch.
+
+# Review Synthesis Template
+
+After every parallel review batch (Phase 2 or Phase 4), you MUST emit a Review Synthesis block before continuing. Use this exact structure:
+
+```
+---
+## Review Synthesis (sources: <role-1>, <role-2>, ...)
+
+### Blocking issues (must resolve before next phase)
+- [<role>] <issue> — proposed fix: <fix>
+
+### Non-blocking suggestions
+- [<role>] <suggestion>
+
+### Conflicts between roles
+- <role A> says X, <role B> says Y. Resolution: <your call, with reasoning>.
+
+### Agreements / consensus
+- <one-line summary>
+
+### Decision
+- Proceed to <next phase> / Block on user input / Re-run <role> with <focus>.
+---
+```
+
+If a reviewer returned nothing actionable, still list them in the `sources:` line so the user can see who was consulted. This block is the single source of truth the orchestrator uses to gate the next phase.
 
 # Role Transition Protocol
 

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -2159,6 +2159,31 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .await;
     }
 
+    /// Emit a `SessionModelAutoMigrated` event with `High` priority so the
+    /// frontend can refresh its model selector and surface a notice promptly.
+    ///
+    /// Callers (e.g. `SessionManager`) reach this method via
+    /// [`get_global_coordinator`] so they don't need to thread an
+    /// `Arc<EventQueue>` through every constructor.
+    pub async fn emit_session_model_auto_migrated(
+        &self,
+        session_id: &str,
+        previous_model_id: &str,
+        new_model_id: &str,
+        reason: &str,
+    ) {
+        let event = AgenticEvent::SessionModelAutoMigrated {
+            session_id: session_id.to_string(),
+            previous_model_id: previous_model_id.to_string(),
+            new_model_id: new_model_id.to_string(),
+            reason: reason.to_string(),
+        };
+        let _ = self
+            .event_queue
+            .enqueue(event, Some(EventPriority::High))
+            .await;
+    }
+
     /// Get SessionManager reference (for advanced features like mode management)
     pub fn get_session_manager(&self) -> &Arc<SessionManager> {
         &self.session_manager

--- a/src/crates/core/src/agentic/insights/session_paths.rs
+++ b/src/crates/core/src/agentic/insights/session_paths.rs
@@ -6,10 +6,15 @@ use crate::service::workspace::{get_global_workspace_service, WorkspaceInfo};
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-/// Map a workspace record to the directory where persisted sessions live.
+/// Resolve the workspace path to pass to [`PersistenceManager`] for session lookups.
+///
+/// For local workspaces this is the workspace root path itself — the persistence layer
+/// derives the actual sessions directory via [`PathManager::project_sessions_dir`].
+/// For remote workspaces this is the local SSH mirror directory, which the persistence
+/// layer treats as the storage root directly.
 pub async fn effective_session_storage_path_for_workspace(ws: &WorkspaceInfo) -> PathBuf {
     if ws.remote_ssh_connection_id().is_none() {
-        return get_path_manager_arc().project_sessions_dir(&ws.root_path);
+        return ws.root_path.clone();
     }
 
     let path_str = ws.root_path.to_string_lossy().to_string();
@@ -32,7 +37,9 @@ pub async fn effective_session_storage_path_for_workspace(ws: &WorkspaceInfo) ->
     get_effective_session_path(&path_str, conn.as_deref(), host.as_deref()).await
 }
 
-/// Unique effective session directories for all tracked workspaces.
+/// Unique workspace paths whose persisted session directories exist on disk.
+///
+/// Each returned path is the value to pass to [`PersistenceManager::list_sessions`].
 pub async fn collect_effective_session_storage_roots() -> Vec<PathBuf> {
     let mut paths = Vec::new();
     let mut seen = HashSet::new();
@@ -41,10 +48,22 @@ pub async fn collect_effective_session_storage_roots() -> Vec<PathBuf> {
         return paths;
     };
 
+    let path_manager = get_path_manager_arc();
+
     for ws in ws_service.list_workspace_infos().await {
-        let sessions_dir = effective_session_storage_path_for_workspace(&ws).await;
-        if sessions_dir.exists() && seen.insert(sessions_dir.clone()) {
-            paths.push(sessions_dir);
+        let workspace_path = effective_session_storage_path_for_workspace(&ws).await;
+
+        // For local workspaces the actual sessions directory is derived from the
+        // workspace root via the path manager. For remote workspaces the mirror
+        // directory itself is the sessions root.
+        let sessions_dir = if ws.remote_ssh_connection_id().is_none() {
+            path_manager.project_sessions_dir(&workspace_path)
+        } else {
+            workspace_path.clone()
+        };
+
+        if sessions_dir.exists() && seen.insert(workspace_path.clone()) {
+            paths.push(workspace_path);
         }
     }
 

--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -10,7 +10,10 @@ use crate::agentic::image_analysis::ImageContextData;
 use crate::agentic::persistence::PersistenceManager;
 use crate::agentic::session::SessionContextStore;
 use crate::infrastructure::ai::get_global_ai_client_factory;
-use crate::service::config::{get_app_language_code, short_model_user_language_instruction};
+use crate::service::config::{
+    get_app_language_code, get_global_config_service, short_model_user_language_instruction,
+    subscribe_config_updates, ConfigUpdateEvent,
+};
 use crate::service::session::{
     DialogTurnData, DialogTurnKind, ModelRoundData, TextItemData, TurnStatus, UserMessageData,
 };
@@ -20,6 +23,7 @@ use crate::util::sanitize_plain_model_output;
 use dashmap::DashMap;
 use log::{debug, error, info, warn};
 use serde_json::json;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -384,8 +388,163 @@ impl SessionManager {
             manager.spawn_auto_save_task();
         }
         manager.spawn_cleanup_task();
+        manager.spawn_model_reconciliation_listener();
 
         manager
+    }
+
+    /// Decide whether the given session model id is still usable.
+    ///
+    /// `model_id` is treated as "usable" when:
+    /// - it is a special selector (`auto` / `primary` / `fast` / `default` /
+    ///   empty) — these are evaluated again at request time against
+    ///   `default_models`, so their long-term validity is governed elsewhere;
+    /// - it resolves to a model that exists AND is enabled.
+    fn is_session_model_id_usable(
+        ai_config: &crate::service::config::types::AIConfig,
+        model_id: &str,
+    ) -> bool {
+        let trimmed = model_id.trim();
+        if trimmed.is_empty()
+            || trimmed == "auto"
+            || trimmed == "default"
+            || trimmed == "primary"
+            || trimmed == "fast"
+        {
+            return true;
+        }
+        ai_config.is_model_reference_active(trimmed)
+    }
+
+    /// Reset every active session whose bound model id is in
+    /// `invalidated_model_ids` back to `"auto"`. Persists the change and emits
+    /// `AgenticEvent::SessionModelAutoMigrated` for every migrated session so
+    /// the UI can refresh its model selector and surface a notice.
+    async fn migrate_sessions_off_invalidated_models(
+        &self,
+        invalidated_model_ids: &[String],
+        reason: &'static str,
+    ) {
+        if invalidated_model_ids.is_empty() {
+            return;
+        }
+        let invalid: HashSet<&str> = invalidated_model_ids.iter().map(String::as_str).collect();
+
+        // Snapshot affected sessions first to avoid holding DashMap iterators
+        // across async writes.
+        let affected: Vec<(String, String)> = self
+            .sessions
+            .iter()
+            .filter_map(|entry| {
+                let session = entry.value();
+                let current = session.config.model_id.as_deref()?.trim().to_string();
+                if invalid.contains(current.as_str()) {
+                    Some((session.session_id.clone(), current))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if affected.is_empty() {
+            return;
+        }
+
+        for (session_id, previous_model_id) in affected {
+            if let Err(e) = self.update_session_model_id(&session_id, "auto").await {
+                warn!(
+                    "Failed to auto-migrate session model after reconcile: session_id={}, previous={}, error={}",
+                    session_id, previous_model_id, e
+                );
+                continue;
+            }
+            info!(
+                "Session model auto-migrated to 'auto': session_id={}, previous_model_id={}, reason={}",
+                session_id, previous_model_id, reason
+            );
+
+            if let Some(coordinator) =
+                crate::agentic::coordination::get_global_coordinator()
+            {
+                coordinator
+                    .emit_session_model_auto_migrated(
+                        &session_id,
+                        &previous_model_id,
+                        "auto",
+                        reason,
+                    )
+                    .await;
+            }
+        }
+    }
+
+    /// Best-effort: drop cached AI clients for invalidated models so the next
+    /// request rebuilds against the reconciled config.
+    async fn invalidate_ai_clients_for_models(invalidated_model_ids: &[String]) {
+        if invalidated_model_ids.is_empty() {
+            return;
+        }
+        if let Ok(factory) = get_global_ai_client_factory().await {
+            for model_id in invalidated_model_ids {
+                factory.invalidate_model(model_id);
+            }
+        }
+    }
+
+    fn spawn_model_reconciliation_listener(&self) {
+        let sessions = self.sessions.clone();
+        let session_workspace_index = self.session_workspace_index.clone();
+        let context_store = self.context_store.clone();
+        let persistence_manager = self.persistence_manager.clone();
+        let manager_config = self.config.clone();
+
+        tokio::spawn(async move {
+            let Some(mut receiver) = subscribe_config_updates() else {
+                debug!(
+                    "SessionManager: config update subscription unavailable; skipping model reconciliation listener"
+                );
+                return;
+            };
+
+            // Re-build a thin handle that mirrors `self` for the listener loop.
+            // We can't move `self` into a 'static task, so we recreate the
+            // surface area we need from the cloned shared fields above.
+            let manager = Self {
+                sessions,
+                session_workspace_index,
+                context_store,
+                persistence_manager,
+                config: manager_config,
+            };
+
+            loop {
+                match receiver.recv().await {
+                    Ok(ConfigUpdateEvent::ModelsReconciled {
+                        invalidated_model_ids,
+                        ..
+                    }) => {
+                        Self::invalidate_ai_clients_for_models(&invalidated_model_ids).await;
+                        manager
+                            .migrate_sessions_off_invalidated_models(
+                                &invalidated_model_ids,
+                                "model_reconciled",
+                            )
+                            .await;
+                    }
+                    Ok(_) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        debug!("SessionManager model reconciliation listener: channel closed");
+                        break;
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(
+                            "SessionManager model reconciliation listener lagged by {} events; continuing",
+                            n
+                        );
+                    }
+                }
+            }
+        });
     }
 
     // ============ Session CRUD ============
@@ -819,6 +978,48 @@ impl SessionManager {
             .persistence_manager
             .load_session(&session_storage_path, session_id)
             .await?;
+
+        // Lazy migration: if the persisted model_id is no longer usable
+        // (model deleted or disabled while the session was on disk), repoint
+        // it to "auto" before the session re-enters memory. The next request
+        // will pick a model via the normal auto/agent/default pipeline.
+        if let Some(persisted_model_id) = session.config.model_id.as_deref() {
+            let trimmed = persisted_model_id.trim();
+            let needs_migration = if trimmed.is_empty() {
+                false
+            } else if let Ok(ai_config) = get_global_config_service()
+                .await
+                .map_err(|e| BitFunError::config(e.to_string()))?
+                .get_config::<crate::service::config::types::AIConfig>(Some("ai"))
+                .await
+            {
+                !Self::is_session_model_id_usable(&ai_config, trimmed)
+            } else {
+                false
+            };
+
+            if needs_migration {
+                warn!(
+                    "Session restore detected stale model_id; migrating to auto: session_id={}, previous_model_id={}",
+                    session_id, trimmed
+                );
+                let previous_model_id = trimmed.to_string();
+                session.config.model_id = Some("auto".to_string());
+
+                if let Some(coordinator) =
+                    crate::agentic::coordination::get_global_coordinator()
+                {
+                    coordinator
+                        .emit_session_model_auto_migrated(
+                            session_id,
+                            &previous_model_id,
+                            "auto",
+                            "model_unavailable_on_restore",
+                        )
+                        .await;
+                }
+            }
+        }
 
         // Reset session state to Idle
         // After application restart, previous Processing state is invalid and must be reset

--- a/src/crates/core/src/infrastructure/ai/client_factory.rs
+++ b/src/crates/core/src/infrastructure/ai/client_factory.rs
@@ -171,6 +171,14 @@ impl AIClientFactory {
             })
             .ok_or_else(|| anyhow!("Model configuration not found: {}", normalized_model_id))?;
 
+        if !model_config.enabled {
+            return Err(anyhow!(
+                "Model '{}' (id={}) is currently disabled; enable it in settings or pick another model",
+                model_config.name,
+                model_config.id
+            ));
+        }
+
         let mut ai_config = AIConfig::try_from(model_config.clone())
             .map_err(|e| anyhow!("AI configuration conversion failed: {}", e))?;
         apply_cli_credential(&model_config.auth, &mut ai_config).await?;

--- a/src/crates/core/src/miniapp/builtin/assets/divination/index.html
+++ b/src/crates/core/src/miniapp/builtin/assets/divination/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme-type="dark">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>每日占卜</title>
+</head>
+<body>
+  <div id="app" class="div-app">
+    <div class="aurora aurora--1"></div>
+    <div class="aurora aurora--2"></div>
+    <div class="aurora aurora--3"></div>
+
+    <header class="header">
+      <div class="header__title">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3z"/><path d="M19 15l.6 1.6 1.6.6-1.6.6L19 19l-.6-1.6-1.6-.6 1.6-.6L19 15z"/><path d="M5 16l.5 1.3L7 18l-1.5.7L5 20l-.5-1.3L3 18l1.5-.7L5 16z"/></svg>
+        <span>每日占卜</span>
+      </div>
+      <div class="header__date" id="date-label"></div>
+    </header>
+
+    <main class="stage">
+      <!-- Phase 1: card not yet revealed -->
+      <section class="reveal" id="reveal-stage">
+        <div class="card-back" id="card-back" tabindex="0" role="button" aria-label="抽取今日卡片">
+          <div class="card-back__pattern"></div>
+          <div class="card-back__inner">
+            <div class="card-back__symbol">✦</div>
+            <div class="card-back__hint">轻触翻牌 · 揭晓今日运势</div>
+          </div>
+        </div>
+        <p class="reveal__tip">每天仅可抽取一次 · 翌日 00:00 焕新</p>
+      </section>
+
+      <!-- Phase 2: card revealed -->
+      <section class="result" id="result-stage" hidden>
+        <article class="card-front" id="card-front">
+          <div class="card-front__top">
+            <span class="card-front__index" id="card-index">No. 01</span>
+            <span class="card-front__tag" id="card-tag">机缘</span>
+          </div>
+          <div class="card-front__art" id="card-art">✦</div>
+          <h2 class="card-front__name" id="card-name">命运之轮</h2>
+          <p class="card-front__keyword" id="card-keyword">流转 · 节奏</p>
+          <p class="card-front__quote" id="card-quote"></p>
+        </article>
+
+        <div class="result__panels">
+          <section class="panel panel--fortunes">
+            <div class="panel__title">运势矩阵</div>
+            <ul class="fortunes" id="fortunes"></ul>
+          </section>
+
+          <div class="panel-row">
+            <section class="panel panel--good">
+              <div class="panel__title">
+                <span class="dot dot--good"></span> 今日宜
+              </div>
+              <ul class="suit" id="suit-good"></ul>
+            </section>
+            <section class="panel panel--bad">
+              <div class="panel__title">
+                <span class="dot dot--bad"></span> 今日忌
+              </div>
+              <ul class="suit" id="suit-bad"></ul>
+            </section>
+          </div>
+
+          <section class="panel panel--lucky">
+            <div class="panel__title">机缘提示</div>
+            <div class="lucky">
+              <div class="lucky__cell">
+                <div class="lucky__label">幸运色</div>
+                <div class="lucky__value">
+                  <span class="lucky__swatch" id="lucky-color-swatch"></span>
+                  <span id="lucky-color-name">—</span>
+                </div>
+              </div>
+              <div class="lucky__cell">
+                <div class="lucky__label">幸运数字</div>
+                <div class="lucky__value" id="lucky-number">—</div>
+              </div>
+              <div class="lucky__cell">
+                <div class="lucky__label">推荐时段</div>
+                <div class="lucky__value" id="lucky-hour">—</div>
+              </div>
+              <div class="lucky__cell">
+                <div class="lucky__label">咒语</div>
+                <div class="lucky__value lucky__value--mantra" id="lucky-mantra">—</div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <button id="btn-share" class="link-btn" type="button" hidden>
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="9" height="8" rx="1"/><path d="M5 6V4a3 3 0 0 1 6 0v2"/></svg>
+        复制运势文本
+      </button>
+      <span class="footer__hint" id="footer-hint">愿你今日的代码无 bug，commit 总能通过 review。</span>
+    </footer>
+
+    <div id="toast" class="toast" hidden></div>
+  </div>
+</body>
+</html>

--- a/src/crates/core/src/miniapp/builtin/assets/divination/meta.json
+++ b/src/crates/core/src/miniapp/builtin/assets/divination/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "builtin-daily-divination",
+  "name": "每日占卜",
+  "description": "每日一卡程序员塔罗：综合/工作/灵感/财运四维运势，含今日宜忌与机缘提示，每天 0 点焕新。",
+  "icon": "Sparkles",
+  "category": "lifestyle",
+  "tags": ["占卜", "运势", "趣味", "内置"],
+  "version": 1,
+  "created_at": 0,
+  "updated_at": 0,
+  "permissions": {
+    "fs": { "read": ["{appdata}"], "write": ["{appdata}"] },
+    "shell": { "allow": [] },
+    "net": { "allow": [] },
+    "node": { "enabled": true, "max_memory_mb": 128, "timeout_ms": 5000 }
+  },
+  "ai_context": null
+}

--- a/src/crates/core/src/miniapp/builtin/assets/divination/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/divination/style.css
@@ -1,0 +1,307 @@
+*, *::before, *::after { box-sizing: border-box; }
+body, html { margin: 0; padding: 0; height: 100%; }
+
+body {
+  font-family: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  font-size: 13px;
+  color: var(--bitfun-text, #e8e8e8);
+  background: var(--bitfun-bg, #0d0c12);
+  overflow: hidden;
+}
+button { font-family: inherit; cursor: pointer; }
+
+.div-app {
+  position: relative;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background:
+    radial-gradient(1200px 600px at 50% -20%, rgba(99, 102, 241, 0.18), transparent 60%),
+    var(--bitfun-bg, #0d0c12);
+  overflow: hidden;
+}
+
+/* ── Aurora glow background ──────────────────────────── */
+.aurora {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.35;
+  pointer-events: none;
+  animation: drift 22s ease-in-out infinite alternate;
+}
+.aurora--1 { width: 480px; height: 480px; left: -120px; top: -100px; background: radial-gradient(circle, #8b5cf6, transparent 70%); }
+.aurora--2 { width: 520px; height: 520px; right: -160px; top: 30%; background: radial-gradient(circle, #ec4899, transparent 70%); animation-delay: -8s; }
+.aurora--3 { width: 460px; height: 460px; left: 30%; bottom: -160px; background: radial-gradient(circle, #06b6d4, transparent 70%); animation-delay: -14s; }
+@keyframes drift {
+  0% { transform: translate(0, 0) scale(1); }
+  100% { transform: translate(40px, -30px) scale(1.05); }
+}
+[data-theme-type="light"] .aurora { opacity: 0.18; }
+
+/* ── Header ──────────────────────────────────────────── */
+.header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 22px;
+  border-bottom: 1px solid var(--bitfun-border-subtle, #27272a);
+  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 60%, transparent);
+  backdrop-filter: blur(14px);
+}
+.header__title { display: flex; align-items: center; gap: 8px; font-weight: 600; letter-spacing: 0.4px; }
+.header__date { font-size: 12px; color: var(--bitfun-text-muted, #858585); font-variant-numeric: tabular-nums; }
+
+/* ── Stage ───────────────────────────────────────────── */
+.stage {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 22px;
+  display: flex;
+  justify-content: center;
+}
+
+/* ── Reveal (back of card) ───────────────────────────── */
+.reveal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  margin: auto;
+}
+.card-back {
+  width: 240px;
+  height: 360px;
+  border-radius: 20px;
+  position: relative;
+  border: 1px solid rgba(255,255,255,0.08);
+  background:
+    linear-gradient(135deg, #1d1b2e 0%, #2a1d44 50%, #1d1b2e 100%);
+  box-shadow:
+    0 30px 80px -20px rgba(0,0,0,0.65),
+    0 0 0 1px rgba(255,255,255,0.05) inset,
+    0 0 60px rgba(139,92,246,0.18) inset;
+  cursor: pointer;
+  outline: none;
+  overflow: hidden;
+  transition: transform .35s cubic-bezier(.2,.8,.2,1), box-shadow .35s ease;
+}
+.card-back:hover { transform: translateY(-6px) rotate(-1deg); box-shadow: 0 36px 90px -20px rgba(139,92,246,0.45), 0 0 0 1px rgba(255,255,255,0.06) inset; }
+.card-back:focus-visible { box-shadow: 0 0 0 3px var(--bitfun-accent, #60a5fa); }
+.card-back__pattern {
+  position: absolute; inset: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background-image:
+    radial-gradient(circle at 50% 50%, rgba(255,255,255,0.06) 0, transparent 40%),
+    repeating-linear-gradient(45deg, rgba(255,255,255,0.03) 0 4px, transparent 4px 8px);
+}
+.card-back__inner {
+  position: absolute; inset: 0;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 16px;
+  text-align: center;
+}
+.card-back__symbol {
+  font-size: 64px;
+  background: linear-gradient(135deg, #c4b5fd, #f9a8d4);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 0 12px rgba(196,181,253,0.4));
+  animation: pulse 2.6s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { transform: scale(1); opacity: 0.95; }
+  50% { transform: scale(1.06); opacity: 1; }
+}
+.card-back__hint { font-size: 12px; color: rgba(255,255,255,0.65); padding: 0 24px; }
+.reveal__tip { font-size: 11px; color: var(--bitfun-text-muted, #858585); text-align: center; }
+
+/* ── Result ──────────────────────────────────────────── */
+.result {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 22px;
+  width: 100%;
+  max-width: 980px;
+  align-items: start;
+  animation: rise .5s ease;
+}
+@keyframes rise { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+
+.card-front {
+  position: relative;
+  border-radius: 20px;
+  padding: 22px 22px 24px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: linear-gradient(160deg, var(--card-tone-1, #2a1d44) 0%, var(--card-tone-2, #1d1b2e) 100%);
+  box-shadow:
+    0 30px 80px -20px rgba(0,0,0,0.55),
+    0 0 0 1px rgba(255,255,255,0.05) inset;
+  color: #fff;
+  min-height: 360px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.card-front::after {
+  content: '';
+  position: absolute; inset: 8px;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.08);
+  pointer-events: none;
+}
+.card-front__top {
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 11px; letter-spacing: 1px; text-transform: uppercase;
+  color: rgba(255,255,255,0.65);
+}
+.card-front__tag {
+  background: rgba(255,255,255,0.12);
+  padding: 3px 10px; border-radius: 999px;
+  letter-spacing: 0.6px;
+  font-size: 10px;
+}
+.card-front__art {
+  font-size: 96px;
+  line-height: 1;
+  text-align: center;
+  margin: 28px 0 16px;
+  filter: drop-shadow(0 4px 12px rgba(0,0,0,0.4));
+}
+.card-front__name {
+  font-size: 22px;
+  font-weight: 600;
+  text-align: center;
+  margin: 0 0 6px;
+  letter-spacing: 1px;
+}
+.card-front__keyword { text-align: center; color: rgba(255,255,255,0.7); font-size: 12px; margin: 0 0 16px; }
+.card-front__quote { text-align: center; font-size: 12px; color: rgba(255,255,255,0.85); line-height: 1.7; margin: auto 0 0; padding: 0 8px; }
+
+/* Right panels */
+.result__panels { display: flex; flex-direction: column; gap: 14px; }
+.panel {
+  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 88%, transparent);
+  border: 1px solid var(--bitfun-border-subtle, #27272a);
+  border-radius: 14px;
+  padding: 14px 16px;
+  backdrop-filter: blur(10px);
+}
+.panel__title {
+  font-size: 11px;
+  color: var(--bitfun-text-muted, #858585);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  margin-bottom: 12px;
+  display: flex; align-items: center; gap: 6px;
+}
+.dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.dot--good { background: var(--bitfun-success, #34d399); box-shadow: 0 0 6px rgba(52,211,153,0.6); }
+.dot--bad  { background: var(--bitfun-error, #ef4444); box-shadow: 0 0 6px rgba(239,68,68,0.6); }
+
+.fortunes { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.fortune { display: flex; align-items: center; gap: 10px; }
+.fortune__label { width: 56px; font-size: 12px; color: var(--bitfun-text-secondary, #b0b0b0); }
+.fortune__bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--bitfun-element-bg, #27272a);
+  overflow: hidden;
+  position: relative;
+}
+.fortune__fill {
+  position: absolute; left: 0; top: 0; bottom: 0;
+  border-radius: 3px;
+  background: linear-gradient(90deg, var(--bitfun-accent, #60a5fa), #8b5cf6);
+  transition: width .8s cubic-bezier(.2,.8,.2,1);
+}
+.fortune__stars { width: 70px; text-align: right; font-size: 11px; color: var(--bitfun-text-muted, #858585); letter-spacing: 1.5px; }
+
+.panel-row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.suit { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 7px; }
+.suit li {
+  font-size: 12.5px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  background: var(--bitfun-element-bg, #27272a);
+  color: var(--bitfun-text-secondary, #b0b0b0);
+  border-left: 2px solid transparent;
+  transition: background .15s ease;
+}
+.panel--good .suit li { border-left-color: var(--bitfun-success, #34d399); }
+.panel--bad  .suit li { border-left-color: var(--bitfun-error, #ef4444); }
+
+.lucky {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+}
+.lucky__cell {
+  background: var(--bitfun-element-bg, #27272a);
+  padding: 10px 12px;
+  border-radius: 10px;
+}
+.lucky__label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.6px; color: var(--bitfun-text-muted, #858585); margin-bottom: 4px; }
+.lucky__value { font-size: 13px; font-weight: 500; display: flex; align-items: center; gap: 8px; }
+.lucky__swatch { width: 16px; height: 16px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.15); display: inline-block; }
+.lucky__value--mantra { font-size: 11.5px; color: var(--bitfun-text-secondary, #b0b0b0); font-style: italic; }
+
+/* ── Footer ──────────────────────────────────────────── */
+.footer {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 22px;
+  border-top: 1px solid var(--bitfun-border-subtle, #27272a);
+  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 60%, transparent);
+}
+.footer__hint { font-size: 11px; color: var(--bitfun-text-muted, #858585); }
+.link-btn {
+  background: transparent;
+  border: 1px solid var(--bitfun-border, #2e2e32);
+  color: var(--bitfun-text-secondary, #b0b0b0);
+  padding: 6px 12px;
+  border-radius: 8px;
+  font-size: 11px;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: all .15s ease;
+}
+.link-btn:hover { color: var(--bitfun-text, #e8e8e8); background: var(--bitfun-element-bg, #27272a); }
+
+/* ── Toast ───────────────────────────────────────────── */
+.toast {
+  position: fixed;
+  left: 50%; bottom: 60px;
+  transform: translateX(-50%);
+  background: var(--bitfun-bg-elevated, #18181a);
+  color: var(--bitfun-text, #e8e8e8);
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--bitfun-border, #2e2e32);
+  font-size: 12px;
+  box-shadow: 0 10px 30px -8px rgba(0,0,0,0.5);
+  animation: toastIn .25s ease;
+  z-index: 9;
+}
+@keyframes toastIn { from { opacity: 0; transform: translate(-50%, 8px); } to { opacity: 1; transform: translate(-50%, 0); } }
+
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-thumb { background: var(--bitfun-scrollbar-thumb, rgba(255,255,255,0.12)); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--bitfun-scrollbar-thumb-hover, rgba(255,255,255,0.22)); }
+
+/* ── Responsive ──────────────────────────────────────── */
+@media (max-width: 720px) {
+  .result { grid-template-columns: 1fr; }
+  .card-front { min-height: 320px; }
+  .panel-row { grid-template-columns: 1fr; }
+}

--- a/src/crates/core/src/miniapp/builtin/assets/divination/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/divination/style.css
@@ -1,5 +1,6 @@
 *, *::before, *::after { box-sizing: border-box; }
 body, html { margin: 0; padding: 0; height: 100%; }
+[hidden] { display: none !important; }
 
 body {
   font-family: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);

--- a/src/crates/core/src/miniapp/builtin/assets/divination/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/divination/style.css
@@ -1,44 +1,94 @@
+/* Daily Divination — arcane tarot theme.
+ * Palette: deep indigo / royal purple / antique gold / rose mauve.
+ * Type: serif display for ritual text, sans for utility chrome.
+ */
+
 *, *::before, *::after { box-sizing: border-box; }
 body, html { margin: 0; padding: 0; height: 100%; }
 [hidden] { display: none !important; }
 
+:root {
+  --d-bg: #0a0617;
+  --d-bg-deep: #06030f;
+  --d-panel: #15102b;
+  --d-panel-2: #1d1638;
+  --d-line: rgba(212, 175, 55, 0.22);
+  --d-line-soft: rgba(212, 175, 55, 0.10);
+  --d-gold: #d4af37;
+  --d-gold-bright: #f0c674;
+  --d-rose: #c084fc;
+  --d-rose-deep: #9d4edd;
+  --d-bad: #b03050;
+  --d-good: #a8d08d;
+  --d-text: #f3e8ff;
+  --d-text-soft: #c4b5fd;
+  --d-text-mute: #8b7fa8;
+  --d-serif: ui-serif, "Cormorant Garamond", "Cormorant", "EB Garamond",
+             "Noto Serif SC", "Songti SC", "Source Han Serif SC", Georgia, serif;
+  --d-sans: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+}
+
 body {
-  font-family: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  font-family: var(--d-sans);
   font-size: 13px;
-  color: var(--bitfun-text, #e8e8e8);
-  background: var(--bitfun-bg, #0d0c12);
+  color: var(--d-text);
+  background: var(--d-bg-deep);
   overflow: hidden;
 }
+
 button { font-family: inherit; cursor: pointer; }
 
+/* ── Stage canvas ────────────────────────────────────── */
 .div-app {
   position: relative;
   height: 100vh;
   display: flex;
   flex-direction: column;
-  background:
-    radial-gradient(1200px 600px at 50% -20%, rgba(99, 102, 241, 0.18), transparent 60%),
-    var(--bitfun-bg, #0d0c12);
   overflow: hidden;
+  background:
+    radial-gradient(1200px 600px at 50% -15%, rgba(157, 78, 221, 0.22), transparent 60%),
+    radial-gradient(800px 500px at 100% 100%, rgba(212, 175, 55, 0.10), transparent 60%),
+    var(--d-bg);
 }
+/* Starfield: a quiet layer of pinpoint stars + a brighter sparkle layer. */
+.div-app::before, .div-app::after {
+  content: '';
+  position: absolute; inset: 0;
+  pointer-events: none;
+  background-repeat: repeat;
+}
+.div-app::before {
+  background-image:
+    radial-gradient(1px 1px at 20px 30px, rgba(255,255,255,0.55), transparent 50%),
+    radial-gradient(1px 1px at 70px 110px, rgba(255,255,255,0.40), transparent 50%),
+    radial-gradient(1px 1px at 130px 60px, rgba(255,255,255,0.35), transparent 50%),
+    radial-gradient(1.4px 1.4px at 200px 180px, rgba(240,198,116,0.45), transparent 50%),
+    radial-gradient(1px 1px at 280px 40px, rgba(255,255,255,0.30), transparent 50%);
+  background-size: 320px 220px;
+  opacity: 0.75;
+}
+.div-app::after {
+  background-image:
+    radial-gradient(1.6px 1.6px at 40px 80px, rgba(240,198,116,0.55), transparent 60%),
+    radial-gradient(1.2px 1.2px at 220px 140px, rgba(196,181,253,0.55), transparent 60%);
+  background-size: 280px 200px;
+  opacity: 0.5;
+  animation: twinkle 6s ease-in-out infinite alternate;
+}
+@keyframes twinkle { from { opacity: 0.30; } to { opacity: 0.65; } }
 
-/* ── Aurora glow background ──────────────────────────── */
 .aurora {
   position: absolute;
   border-radius: 50%;
-  filter: blur(80px);
+  filter: blur(90px);
   opacity: 0.35;
   pointer-events: none;
-  animation: drift 22s ease-in-out infinite alternate;
+  animation: drift 24s ease-in-out infinite alternate;
 }
-.aurora--1 { width: 480px; height: 480px; left: -120px; top: -100px; background: radial-gradient(circle, #8b5cf6, transparent 70%); }
-.aurora--2 { width: 520px; height: 520px; right: -160px; top: 30%; background: radial-gradient(circle, #ec4899, transparent 70%); animation-delay: -8s; }
-.aurora--3 { width: 460px; height: 460px; left: 30%; bottom: -160px; background: radial-gradient(circle, #06b6d4, transparent 70%); animation-delay: -14s; }
-@keyframes drift {
-  0% { transform: translate(0, 0) scale(1); }
-  100% { transform: translate(40px, -30px) scale(1.05); }
-}
-[data-theme-type="light"] .aurora { opacity: 0.18; }
+.aurora--1 { width: 480px; height: 480px; left: -120px; top: -100px; background: radial-gradient(circle, #7c3aed, transparent 70%); }
+.aurora--2 { width: 520px; height: 520px; right: -160px; top: 30%; background: radial-gradient(circle, #c026d3, transparent 70%); animation-delay: -8s; }
+.aurora--3 { width: 460px; height: 460px; left: 30%; bottom: -160px; background: radial-gradient(circle, #d4af37, transparent 75%); animation-delay: -14s; opacity: 0.22; }
+@keyframes drift { 0% { transform: translate(0,0) scale(1); } 100% { transform: translate(40px,-30px) scale(1.06); } }
 
 /* ── Header ──────────────────────────────────────────── */
 .header {
@@ -47,13 +97,29 @@ button { font-family: inherit; cursor: pointer; }
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 22px;
-  border-bottom: 1px solid var(--bitfun-border-subtle, #27272a);
-  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 60%, transparent);
+  padding: 14px 24px;
+  border-bottom: 1px solid var(--d-line);
+  background:
+    linear-gradient(180deg, rgba(10,6,23,0.85), rgba(10,6,23,0.55));
   backdrop-filter: blur(14px);
 }
-.header__title { display: flex; align-items: center; gap: 8px; font-weight: 600; letter-spacing: 0.4px; }
-.header__date { font-size: 12px; color: var(--bitfun-text-muted, #858585); font-variant-numeric: tabular-nums; }
+.header__title {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--d-serif);
+  font-weight: 500;
+  font-size: 17px;
+  letter-spacing: 4px;
+  color: var(--d-gold-bright);
+  text-shadow: 0 0 12px rgba(240,198,116,0.25);
+}
+.header__title svg { color: var(--d-gold); filter: drop-shadow(0 0 6px rgba(212,175,55,0.4)); }
+.header__date {
+  font-family: var(--d-serif);
+  font-size: 13px;
+  letter-spacing: 2px;
+  color: var(--d-text-soft);
+  font-variant-numeric: tabular-nums;
+}
 
 /* ── Stage ───────────────────────────────────────────── */
 .stage {
@@ -62,7 +128,7 @@ button { font-family: inherit; cursor: pointer; }
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 22px;
+  padding: 28px 24px;
   display: flex;
   justify-content: center;
 }
@@ -72,81 +138,115 @@ button { font-family: inherit; cursor: pointer; }
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 18px;
+  gap: 22px;
   margin: auto;
 }
 .card-back {
   width: 240px;
   height: 360px;
-  border-radius: 20px;
+  border-radius: 14px;
   position: relative;
-  border: 1px solid rgba(255,255,255,0.08);
+  border: 1px solid rgba(212,175,55,0.45);
   background:
-    linear-gradient(135deg, #1d1b2e 0%, #2a1d44 50%, #1d1b2e 100%);
+    radial-gradient(circle at 50% 35%, rgba(157,78,221,0.35), transparent 70%),
+    linear-gradient(160deg, #1d1438 0%, #2c1054 50%, #160a2c 100%);
   box-shadow:
-    0 30px 80px -20px rgba(0,0,0,0.65),
-    0 0 0 1px rgba(255,255,255,0.05) inset,
-    0 0 60px rgba(139,92,246,0.18) inset;
+    0 30px 80px -20px rgba(0,0,0,0.7),
+    0 0 0 1px rgba(212,175,55,0.18) inset,
+    0 0 80px rgba(157,78,221,0.20) inset,
+    0 0 30px rgba(212,175,55,0.10);
   cursor: pointer;
   outline: none;
   overflow: hidden;
   transition: transform .35s cubic-bezier(.2,.8,.2,1), box-shadow .35s ease;
 }
-.card-back:hover { transform: translateY(-6px) rotate(-1deg); box-shadow: 0 36px 90px -20px rgba(139,92,246,0.45), 0 0 0 1px rgba(255,255,255,0.06) inset; }
-.card-back:focus-visible { box-shadow: 0 0 0 3px var(--bitfun-accent, #60a5fa); }
+.card-back:hover {
+  transform: translateY(-6px) rotate(-1deg);
+  box-shadow:
+    0 36px 90px -20px rgba(157,78,221,0.55),
+    0 0 0 1px rgba(212,175,55,0.30) inset,
+    0 0 60px rgba(212,175,55,0.20);
+}
+.card-back:focus-visible { box-shadow: 0 0 0 3px var(--d-gold); }
 .card-back__pattern {
   position: absolute; inset: 12px;
-  border-radius: 14px;
-  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 8px;
+  border: 1px solid rgba(212,175,55,0.30);
   background-image:
-    radial-gradient(circle at 50% 50%, rgba(255,255,255,0.06) 0, transparent 40%),
-    repeating-linear-gradient(45deg, rgba(255,255,255,0.03) 0 4px, transparent 4px 8px);
+    radial-gradient(circle at 50% 50%, rgba(212,175,55,0.06) 0, transparent 40%),
+    repeating-linear-gradient(45deg, rgba(212,175,55,0.04) 0 4px, transparent 4px 9px);
 }
+.card-back__pattern::before, .card-back__pattern::after {
+  /* gilded corner ornaments */
+  content: '';
+  position: absolute;
+  width: 22px; height: 22px;
+  border: 1px solid var(--d-gold);
+  opacity: 0.7;
+}
+.card-back__pattern::before { top: 8px; left: 8px; border-right: 0; border-bottom: 0; }
+.card-back__pattern::after  { bottom: 8px; right: 8px; border-left: 0; border-top: 0; }
+
 .card-back__inner {
   position: absolute; inset: 0;
   display: flex; flex-direction: column;
   align-items: center; justify-content: center;
-  gap: 16px;
+  gap: 18px;
   text-align: center;
 }
 .card-back__symbol {
-  font-size: 64px;
-  background: linear-gradient(135deg, #c4b5fd, #f9a8d4);
+  font-family: var(--d-serif);
+  font-size: 84px;
+  background: linear-gradient(135deg, #f0c674 0%, #d4af37 50%, #c084fc 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-  filter: drop-shadow(0 0 12px rgba(196,181,253,0.4));
+  filter: drop-shadow(0 0 14px rgba(212,175,55,0.45));
   animation: pulse 2.6s ease-in-out infinite;
 }
 @keyframes pulse {
   0%, 100% { transform: scale(1); opacity: 0.95; }
   50% { transform: scale(1.06); opacity: 1; }
 }
-.card-back__hint { font-size: 12px; color: rgba(255,255,255,0.65); padding: 0 24px; }
-.reveal__tip { font-size: 11px; color: var(--bitfun-text-muted, #858585); text-align: center; }
+.card-back__hint {
+  font-family: var(--d-serif);
+  font-size: 13px;
+  letter-spacing: 2px;
+  color: rgba(243,232,255,0.78);
+  padding: 0 24px;
+}
+.reveal__tip {
+  font-family: var(--d-serif);
+  font-size: 12px;
+  letter-spacing: 1.5px;
+  color: var(--d-text-mute);
+  text-align: center;
+}
 
 /* ── Result ──────────────────────────────────────────── */
 .result {
   display: grid;
   grid-template-columns: 320px 1fr;
-  gap: 22px;
+  gap: 24px;
   width: 100%;
   max-width: 980px;
   align-items: start;
-  animation: rise .5s ease;
+  animation: rise .55s ease;
 }
 @keyframes rise { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
 
+/* ── Card front ──────────────────────────────────────── */
 .card-front {
   position: relative;
-  border-radius: 20px;
-  padding: 22px 22px 24px;
-  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 14px;
+  padding: 26px 24px 28px;
+  border: 1px solid rgba(212,175,55,0.45);
   background: linear-gradient(160deg, var(--card-tone-1, #2a1d44) 0%, var(--card-tone-2, #1d1b2e) 100%);
   box-shadow:
-    0 30px 80px -20px rgba(0,0,0,0.55),
-    0 0 0 1px rgba(255,255,255,0.05) inset;
+    0 30px 80px -20px rgba(0,0,0,0.65),
+    0 0 0 1px rgba(212,175,55,0.18) inset,
+    0 0 50px rgba(212,175,55,0.10);
   color: #fff;
-  min-height: 360px;
+  min-height: 380px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -154,106 +254,241 @@ button { font-family: inherit; cursor: pointer; }
 .card-front::after {
   content: '';
   position: absolute; inset: 8px;
-  border-radius: 14px;
-  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 8px;
+  border: 1px solid rgba(212,175,55,0.28);
   pointer-events: none;
+}
+/* Gilded corner flourishes */
+.card-front::before {
+  content: '';
+  position: absolute;
+  inset: 8px;
+  border-radius: 8px;
+  pointer-events: none;
+  background:
+    linear-gradient(to right, var(--d-gold) 0, var(--d-gold) 18px, transparent 18px) top left/100% 1px no-repeat,
+    linear-gradient(to bottom, var(--d-gold) 0, var(--d-gold) 18px, transparent 18px) top left/1px 100% no-repeat,
+    linear-gradient(to left, var(--d-gold) 0, var(--d-gold) 18px, transparent 18px) top right/100% 1px no-repeat,
+    linear-gradient(to bottom, var(--d-gold) 0, var(--d-gold) 18px, transparent 18px) top right/1px 100% no-repeat,
+    linear-gradient(to right, var(--d-gold) 0, var(--d-gold) 18px, transparent 18px) bottom left/100% 1px no-repeat,
+    linear-gradient(to top, var(--d-gold) 0, var(--d-gold) 18px, transparent 18px) bottom left/1px 100% no-repeat,
+    linear-gradient(to left, var(--d-gold) 0, var(--d-gold) 18px, transparent 18px) bottom right/100% 1px no-repeat,
+    linear-gradient(to top, var(--d-gold) 0, var(--d-gold) 18px, transparent 18px) bottom right/1px 100% no-repeat;
+  opacity: 0.85;
 }
 .card-front__top {
   display: flex; align-items: center; justify-content: space-between;
-  font-size: 11px; letter-spacing: 1px; text-transform: uppercase;
-  color: rgba(255,255,255,0.65);
+  font-family: var(--d-serif);
+  font-size: 11px; letter-spacing: 3px; text-transform: uppercase;
+  color: rgba(255,255,255,0.7);
+  position: relative; z-index: 1;
 }
 .card-front__tag {
-  background: rgba(255,255,255,0.12);
+  background: rgba(212,175,55,0.18);
+  color: var(--d-gold-bright);
+  border: 1px solid rgba(212,175,55,0.5);
   padding: 3px 10px; border-radius: 999px;
-  letter-spacing: 0.6px;
+  letter-spacing: 1.5px;
   font-size: 10px;
+  text-transform: none;
+  font-family: var(--d-serif);
 }
 .card-front__art {
-  font-size: 96px;
+  font-family: var(--d-serif);
+  font-size: 110px;
   line-height: 1;
   text-align: center;
-  margin: 28px 0 16px;
-  filter: drop-shadow(0 4px 12px rgba(0,0,0,0.4));
+  margin: 30px 0 18px;
+  background: linear-gradient(135deg, #fff 0%, var(--d-gold-bright) 60%, var(--d-gold) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 4px 12px rgba(0,0,0,0.45)) drop-shadow(0 0 18px rgba(212,175,55,0.3));
+  position: relative; z-index: 1;
 }
 .card-front__name {
-  font-size: 22px;
-  font-weight: 600;
+  font-family: var(--d-serif);
+  font-size: 28px;
+  font-weight: 500;
   text-align: center;
-  margin: 0 0 6px;
-  letter-spacing: 1px;
+  margin: 0 0 8px;
+  letter-spacing: 8px;
+  color: var(--d-gold-bright);
+  position: relative; z-index: 1;
 }
-.card-front__keyword { text-align: center; color: rgba(255,255,255,0.7); font-size: 12px; margin: 0 0 16px; }
-.card-front__quote { text-align: center; font-size: 12px; color: rgba(255,255,255,0.85); line-height: 1.7; margin: auto 0 0; padding: 0 8px; }
+.card-front__keyword {
+  text-align: center;
+  color: rgba(255,255,255,0.78);
+  font-family: var(--d-serif);
+  font-size: 13px;
+  letter-spacing: 4px;
+  margin: 0 0 18px;
+  position: relative; z-index: 1;
+}
+.card-front__keyword::before, .card-front__keyword::after {
+  content: '✦'; color: var(--d-gold); margin: 0 10px; font-size: 10px;
+}
+.card-front__quote {
+  text-align: center;
+  font-family: var(--d-serif);
+  font-style: italic;
+  font-size: 13.5px;
+  color: rgba(255,255,255,0.88);
+  line-height: 1.85;
+  margin: auto 0 0;
+  padding: 0 12px;
+  position: relative; z-index: 1;
+}
 
-/* Right panels */
-.result__panels { display: flex; flex-direction: column; gap: 14px; }
+/* ── Right panels: stay arcane ───────────────────────── */
+.result__panels { display: flex; flex-direction: column; gap: 16px; }
 .panel {
-  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 88%, transparent);
-  border: 1px solid var(--bitfun-border-subtle, #27272a);
-  border-radius: 14px;
-  padding: 14px 16px;
+  position: relative;
+  background:
+    linear-gradient(180deg, rgba(45,28,80,0.55), rgba(21,16,43,0.70));
+  border: 1px solid var(--d-line);
+  border-radius: 12px;
+  padding: 16px 18px;
   backdrop-filter: blur(10px);
+  box-shadow: 0 0 0 1px rgba(212,175,55,0.06) inset, 0 8px 22px -10px rgba(0,0,0,0.6);
 }
+/* gilded micro-corners */
+.panel::before, .panel::after {
+  content: '';
+  position: absolute;
+  width: 14px; height: 14px;
+  border: 1px solid var(--d-gold);
+  opacity: 0.55;
+  pointer-events: none;
+}
+.panel::before { top: 4px; left: 4px; border-right: 0; border-bottom: 0; border-top-left-radius: 8px; }
+.panel::after  { bottom: 4px; right: 4px; border-left: 0; border-top: 0; border-bottom-right-radius: 8px; }
+
 .panel__title {
-  font-size: 11px;
-  color: var(--bitfun-text-muted, #858585);
+  font-family: var(--d-serif);
+  font-size: 12px;
+  color: var(--d-gold-bright);
   text-transform: uppercase;
-  letter-spacing: 0.6px;
-  margin-bottom: 12px;
-  display: flex; align-items: center; gap: 6px;
+  letter-spacing: 4px;
+  margin-bottom: 14px;
+  display: flex; align-items: center; gap: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px dashed var(--d-line);
 }
 .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
-.dot--good { background: var(--bitfun-success, #34d399); box-shadow: 0 0 6px rgba(52,211,153,0.6); }
-.dot--bad  { background: var(--bitfun-error, #ef4444); box-shadow: 0 0 6px rgba(239,68,68,0.6); }
+.dot--good { background: var(--d-gold-bright); box-shadow: 0 0 8px rgba(240,198,116,0.7); }
+.dot--bad  { background: var(--d-bad); box-shadow: 0 0 8px rgba(176,48,80,0.7); }
 
-.fortunes { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
-.fortune { display: flex; align-items: center; gap: 10px; }
-.fortune__label { width: 56px; font-size: 12px; color: var(--bitfun-text-secondary, #b0b0b0); }
+/* Fortune matrix — five-stars with golden glow, no SaaS bars */
+.fortunes { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }
+.fortune {
+  display: grid;
+  grid-template-columns: 64px 1fr auto;
+  gap: 12px;
+  align-items: center;
+}
+.fortune__label {
+  font-family: var(--d-serif);
+  font-size: 14px;
+  letter-spacing: 3px;
+  color: var(--d-text-soft);
+}
 .fortune__bar {
-  flex: 1;
-  height: 6px;
-  border-radius: 3px;
-  background: var(--bitfun-element-bg, #27272a);
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(212,175,55,0.12);
   overflow: hidden;
   position: relative;
 }
 .fortune__fill {
   position: absolute; left: 0; top: 0; bottom: 0;
-  border-radius: 3px;
-  background: linear-gradient(90deg, var(--bitfun-accent, #60a5fa), #8b5cf6);
-  transition: width .8s cubic-bezier(.2,.8,.2,1);
+  border-radius: 2px;
+  background: linear-gradient(90deg, var(--d-rose-deep), var(--d-gold-bright));
+  box-shadow: 0 0 10px rgba(240,198,116,0.45);
+  transition: width .9s cubic-bezier(.2,.8,.2,1);
 }
-.fortune__stars { width: 70px; text-align: right; font-size: 11px; color: var(--bitfun-text-muted, #858585); letter-spacing: 1.5px; }
+.fortune__stars {
+  font-family: var(--d-serif);
+  font-size: 16px;
+  letter-spacing: 4px;
+  color: var(--d-gold-bright);
+  text-shadow: 0 0 8px rgba(240,198,116,0.4);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.fortune__stars .ghost { color: rgba(212,175,55,0.22); text-shadow: none; }
 
-.panel-row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
-.suit { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 7px; }
+.panel-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.suit { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
 .suit li {
-  font-size: 12.5px;
-  padding: 7px 10px;
-  border-radius: 8px;
-  background: var(--bitfun-element-bg, #27272a);
-  color: var(--bitfun-text-secondary, #b0b0b0);
-  border-left: 2px solid transparent;
-  transition: background .15s ease;
+  font-family: var(--d-serif);
+  font-size: 14px;
+  letter-spacing: 1px;
+  padding: 8px 12px 8px 26px;
+  border-radius: 6px;
+  background: rgba(20,12,40,0.55);
+  border: 1px solid rgba(212,175,55,0.10);
+  position: relative;
+  color: var(--d-text);
 }
-.panel--good .suit li { border-left-color: var(--bitfun-success, #34d399); }
-.panel--bad  .suit li { border-left-color: var(--bitfun-error, #ef4444); }
+.suit li::before {
+  position: absolute;
+  left: 10px; top: 50%; transform: translateY(-50%);
+  font-size: 12px;
+}
+.panel--good .suit li {
+  background: linear-gradient(180deg, rgba(212,175,55,0.10), rgba(212,175,55,0.04));
+  border-color: rgba(212,175,55,0.32);
+}
+.panel--good .suit li::before { content: '✦'; color: var(--d-gold-bright); }
+.panel--bad .suit li {
+  background: linear-gradient(180deg, rgba(176,48,80,0.14), rgba(176,48,80,0.04));
+  border-color: rgba(176,48,80,0.40);
+  color: rgba(243,232,255,0.85);
+}
+.panel--bad .suit li::before { content: '✕'; color: var(--d-bad); font-weight: 600; }
 
+/* Lucky cells — sealed parchment look */
 .lucky {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 10px;
+  gap: 12px;
 }
 .lucky__cell {
-  background: var(--bitfun-element-bg, #27272a);
-  padding: 10px 12px;
-  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(212,175,55,0.06), rgba(20,12,40,0.55));
+  border: 1px solid rgba(212,175,55,0.22);
+  padding: 12px 14px;
+  border-radius: 8px;
+  position: relative;
 }
-.lucky__label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.6px; color: var(--bitfun-text-muted, #858585); margin-bottom: 4px; }
-.lucky__value { font-size: 13px; font-weight: 500; display: flex; align-items: center; gap: 8px; }
-.lucky__swatch { width: 16px; height: 16px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.15); display: inline-block; }
-.lucky__value--mantra { font-size: 11.5px; color: var(--bitfun-text-secondary, #b0b0b0); font-style: italic; }
+.lucky__label {
+  font-family: var(--d-serif);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 2.5px;
+  color: var(--d-gold);
+  margin-bottom: 6px;
+}
+.lucky__value {
+  font-family: var(--d-serif);
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: 1.5px;
+  color: var(--d-text);
+  display: flex; align-items: center; gap: 8px;
+}
+.lucky__swatch {
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  border: 1px solid rgba(212,175,55,0.55);
+  box-shadow: 0 0 10px rgba(255,255,255,0.10);
+  display: inline-block;
+}
+.lucky__value--mantra {
+  font-size: 13px;
+  font-style: italic;
+  color: var(--d-text-soft);
+  letter-spacing: 0.5px;
+}
 
 /* ── Footer ──────────────────────────────────────────── */
 .footer {
@@ -262,43 +497,57 @@ button { font-family: inherit; cursor: pointer; }
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 22px;
-  border-top: 1px solid var(--bitfun-border-subtle, #27272a);
-  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 60%, transparent);
+  padding: 12px 24px;
+  border-top: 1px solid var(--d-line);
+  background: linear-gradient(0deg, rgba(10,6,23,0.85), rgba(10,6,23,0.55));
 }
-.footer__hint { font-size: 11px; color: var(--bitfun-text-muted, #858585); }
+.footer__hint {
+  font-family: var(--d-serif);
+  font-size: 12px;
+  letter-spacing: 1.5px;
+  color: var(--d-text-mute);
+  font-style: italic;
+}
 .link-btn {
   background: transparent;
-  border: 1px solid var(--bitfun-border, #2e2e32);
-  color: var(--bitfun-text-secondary, #b0b0b0);
-  padding: 6px 12px;
-  border-radius: 8px;
-  font-size: 11px;
+  border: 1px solid rgba(212,175,55,0.45);
+  color: var(--d-gold-bright);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-family: var(--d-serif);
+  font-size: 12px;
+  letter-spacing: 1.5px;
   display: inline-flex; align-items: center; gap: 6px;
-  transition: all .15s ease;
+  transition: all .18s ease;
 }
-.link-btn:hover { color: var(--bitfun-text, #e8e8e8); background: var(--bitfun-element-bg, #27272a); }
+.link-btn:hover {
+  color: #fff;
+  background: rgba(212,175,55,0.14);
+  box-shadow: 0 0 14px rgba(212,175,55,0.25);
+}
 
 /* ── Toast ───────────────────────────────────────────── */
 .toast {
   position: fixed;
   left: 50%; bottom: 60px;
   transform: translateX(-50%);
-  background: var(--bitfun-bg-elevated, #18181a);
-  color: var(--bitfun-text, #e8e8e8);
-  padding: 8px 14px;
+  background: var(--d-panel-2);
+  color: var(--d-gold-bright);
+  padding: 9px 16px;
   border-radius: 8px;
-  border: 1px solid var(--bitfun-border, #2e2e32);
-  font-size: 12px;
-  box-shadow: 0 10px 30px -8px rgba(0,0,0,0.5);
+  border: 1px solid rgba(212,175,55,0.45);
+  font-family: var(--d-serif);
+  font-size: 13px;
+  letter-spacing: 1.5px;
+  box-shadow: 0 10px 30px -8px rgba(0,0,0,0.55), 0 0 24px rgba(212,175,55,0.18);
   animation: toastIn .25s ease;
   z-index: 9;
 }
 @keyframes toastIn { from { opacity: 0; transform: translate(-50%, 8px); } to { opacity: 1; transform: translate(-50%, 0); } }
 
 ::-webkit-scrollbar { width: 8px; height: 8px; }
-::-webkit-scrollbar-thumb { background: var(--bitfun-scrollbar-thumb, rgba(255,255,255,0.12)); border-radius: 4px; }
-::-webkit-scrollbar-thumb:hover { background: var(--bitfun-scrollbar-thumb-hover, rgba(255,255,255,0.22)); }
+::-webkit-scrollbar-thumb { background: rgba(212,175,55,0.18); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: rgba(212,175,55,0.32); }
 
 /* ── Responsive ──────────────────────────────────────── */
 @media (max-width: 720px) {

--- a/src/crates/core/src/miniapp/builtin/assets/divination/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/divination/ui.js
@@ -1,0 +1,311 @@
+// Daily Divination — built-in MiniApp.
+// Programmer-themed tarot: 24 cards, 4 fortune dimensions, daily-locked via app.storage.
+
+const CARDS = [
+  { name: '命运之轮', tag: '机缘', symbol: '✦', keyword: '流转 · 节奏', tone: ['#5b21b6', '#1e1b4b'],
+    quote: '每个 commit 都在改变命运的曲率，今天值得一次推送。' },
+  { name: '星辰指引', tag: '希望', symbol: '✶', keyword: '远方 · 灵感', tone: ['#1e3a8a', '#0c1230'],
+    quote: '当你卡住时，抬头看看 documentation 之外的世界。' },
+  { name: '熔炉之心', tag: '锻造', symbol: '✺', keyword: '精炼 · 重构', tone: ['#9a3412', '#2a0e0a'],
+    quote: '今日适合一次果敢的重构，删除即创造。' },
+  { name: '寂静之钟', tag: '冥想', symbol: '☾', keyword: '深思 · 沉潜', tone: ['#1e293b', '#0f172a'],
+    quote: '让 IDE 暂停十分钟，答案常在白板上浮现。' },
+  { name: '银河书简', tag: '智识', symbol: '☄', keyword: '阅读 · 累积', tone: ['#4c1d95', '#1f0a3d'],
+    quote: '今天读完一个长 issue 的讨论，比写十行代码值钱。' },
+  { name: '红宝匠人', tag: '创造', symbol: '◆', keyword: '雕琢 · 细节', tone: ['#7f1d1d', '#260a0a'],
+    quote: '把一个边界条件想清楚，就是今天最好的输出。' },
+  { name: '青铜之蛇', tag: '蜕变', symbol: '∞', keyword: '环路 · 蜕变', tone: ['#065f46', '#04241c'],
+    quote: '一个 retry-loop 修好了，整条链路都活了过来。' },
+  { name: '光之回响', tag: '协作', symbol: '✧', keyword: '回声 · 共振', tone: ['#0e7490', '#06262e'],
+    quote: '一句"我来帮你看看"，就是今日最强的 buff。' },
+  { name: '苔藓低语', tag: '休憩', symbol: '❀', keyword: '生长 · 留白', tone: ['#14532d', '#031708'],
+    quote: '让进度条慢一点，让创造力快一点。' },
+  { name: '星海罗盘', tag: '抉择', symbol: '⊛', keyword: '方向 · 决断', tone: ['#1e40af', '#0a163b'],
+    quote: '别再纠结技术选型，先把第一行代码写出来。' },
+  { name: '黄昏炉火', tag: '专注', symbol: '✦', keyword: '心流 · 燃烧', tone: ['#92400e', '#2d1305'],
+    quote: '关闭 Slack，今天属于你和编辑器的二人世界。' },
+  { name: '悬浮之环', tag: '平衡', symbol: '◌', keyword: '取舍 · 张力', tone: ['#3730a3', '#0f0e2c'],
+    quote: '完美与上线之间，请选择上线。' },
+  { name: '镜面湖', tag: '复盘', symbol: '☼', keyword: '映照 · 觉察', tone: ['#155e75', '#03222b'],
+    quote: '回看一周前自己写的代码，会比 review 更诚实。' },
+  { name: '深林信使', tag: '消息', symbol: '✉', keyword: '传达 · 链接', tone: ['#166534', '#03200d'],
+    quote: '一封写得清楚的邮件，胜过三场会议。' },
+  { name: '夜之提琴', tag: '诗意', symbol: '♪', keyword: '韵律 · 优雅', tone: ['#581c87', '#1a0830'],
+    quote: '为变量起一个动听的名字，命名是程序员的诗。' },
+  { name: '黎明铸铁', tag: '勇气', symbol: '⚔', keyword: '直面 · 挑战', tone: ['#9f1239', '#2c0710'],
+    quote: '今天直面那个一直被你跳过的 TODO。' },
+  { name: '极光之纱', tag: '灵感', symbol: '✤', keyword: '迸发 · 流动', tone: ['#0d9488', '#02322f'],
+    quote: '保持沐浴或散步的状态，bug 多半在水流声里被冲掉。' },
+  { name: '羽落之笔', tag: '记录', symbol: '✎', keyword: '书写 · 沉淀', tone: ['#3f3f46', '#101013'],
+    quote: '今日适合写一篇文档，未来的你会感谢现在的自己。' },
+  { name: '潮汐之环', tag: '节奏', symbol: '∽', keyword: '起伏 · 周期', tone: ['#0369a1', '#021c33'],
+    quote: '高效与低谷皆是潮汐，重要的是别在退潮时责怪自己。' },
+  { name: '紫晶圣杯', tag: '丰饶', symbol: '♥', keyword: '滋养 · 馈赠', tone: ['#86198f', '#2a0833'],
+    quote: '别忘了喝水。也别忘了夸自己一句。' },
+  { name: '金色齿轮', tag: '系统', symbol: '✦', keyword: '机制 · 架构', tone: ['#a16207', '#2c1a05'],
+    quote: '一个清晰的模块边界，胜过十个聪明的 hack。' },
+  { name: '晨曦之翼', tag: '启程', symbol: '✿', keyword: '出发 · 第一步', tone: ['#be185d', '#310a1f'],
+    quote: '把"等我准备好"换成"先 push 一个 draft PR"。' },
+  { name: '寒星之刃', tag: '清算', symbol: '✝', keyword: '剔除 · 净化', tone: ['#0f766e', '#02211f'],
+    quote: '今天适合删一些过时的依赖，少即是多。' },
+  { name: '月光石阶', tag: '指引', symbol: '☽', keyword: '夜行 · 步步', tone: ['#312e81', '#0a0928'],
+    quote: '不必看清整个阶梯，先迈出眼前的这一步。' },
+];
+
+const FORTUNE_KEYS = [
+  { key: 'overall', label: '综合' },
+  { key: 'work', label: '工作' },
+  { key: 'inspire', label: '灵感' },
+  { key: 'wealth', label: '财运' },
+];
+
+const SUITS_GOOD = [
+  '重构一段陈年代码', '写一篇技术笔记', '认真做一次 Code Review', 'Pair programming',
+  '提一个 draft PR', '关闭通知专注 90 分钟', '用便签理清需求', '部署一次到测试环境',
+  '认真补单元测试', '把一个 TODO 注释清掉', '请同事喝一杯咖啡', '早一点下班，散步回家',
+  '给变量起个好听的名字', '更新依赖小版本', '阅读一份开源项目 README',
+];
+
+const SUITS_BAD = [
+  '周五傍晚发布到生产', '直接改 main 分支', 'git push --force', '跳过测试就合并',
+  'rm -rf 不看路径', '在没备份时改数据库', 'npm install -g 不看版本', '关掉 CI 通知',
+  '在情绪激动时回复评论', '把 try { ... } catch {} 留在 PR 里', '熬夜调一个一行就能改的 bug',
+];
+
+const COLORS = [
+  { name: '靛青', hex: '#4f46e5' },
+  { name: '玫珀', hex: '#f472b6' },
+  { name: '湖蓝', hex: '#06b6d4' },
+  { name: '森绿', hex: '#10b981' },
+  { name: '橙金', hex: '#f59e0b' },
+  { name: '雾紫', hex: '#a78bfa' },
+  { name: '砖红', hex: '#ef4444' },
+  { name: '雪白', hex: '#f5f5f7' },
+  { name: '炭黑', hex: '#1f2937' },
+];
+
+const HOURS = ['上午 09:30 — 11:00', '下午 14:00 — 15:30', '下午 16:00 — 17:30', '夜晚 20:00 — 21:30', '深夜 22:00 — 23:30'];
+
+const MANTRAS = [
+  'It compiles. Ship it.',
+  'Make it work, make it right, make it fast.',
+  'Done is better than perfect.',
+  '最好的代码，是不必写的代码。',
+  '一次只解决一个问题。',
+  '能跑起来，就先跑起来。',
+  '相信你的下一个 git commit。',
+  '今天的我，不评判过去的我。',
+];
+
+// ── Random utilities (seeded) ────────────────────────
+function dateKey(d = new Date()) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function hashSeed(s) {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function () {
+    t = (t + 0x6d2b79f5) >>> 0;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r = (r + Math.imul(r ^ (r >>> 7), 61 | r)) ^ r;
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pick(rand, arr) {
+  return arr[Math.floor(rand() * arr.length)];
+}
+
+function pickN(rand, arr, n) {
+  const copy = arr.slice();
+  const out = [];
+  for (let i = 0; i < n && copy.length > 0; i++) {
+    const idx = Math.floor(rand() * copy.length);
+    out.push(copy.splice(idx, 1)[0]);
+  }
+  return out;
+}
+
+// ── Fortune generation ───────────────────────────────
+function generateFortune(date) {
+  const seed = hashSeed('bitfun-divination-' + date);
+  const rand = mulberry32(seed);
+  const card = CARDS[Math.floor(rand() * CARDS.length)];
+
+  // Each dimension 1..5 stars, biased towards 3-4.
+  const fortunes = FORTUNE_KEYS.map(({ key, label }) => {
+    const r = rand();
+    const stars = r < 0.06 ? 1 : r < 0.2 ? 2 : r < 0.55 ? 3 : r < 0.85 ? 4 : 5;
+    return { key, label, stars };
+  });
+
+  const goods = pickN(rand, SUITS_GOOD, 3);
+  const bads = pickN(rand, SUITS_BAD, 2);
+  const color = pick(rand, COLORS);
+  const luckyNumber = 1 + Math.floor(rand() * 99);
+  const hour = pick(rand, HOURS);
+  const mantra = pick(rand, MANTRAS);
+
+  return { card, fortunes, goods, bads, color, luckyNumber, hour, mantra };
+}
+
+// ── DOM ──────────────────────────────────────────────
+const dom = {
+  dateLabel: document.getElementById('date-label'),
+  revealStage: document.getElementById('reveal-stage'),
+  resultStage: document.getElementById('result-stage'),
+  cardBack: document.getElementById('card-back'),
+  cardFront: document.getElementById('card-front'),
+  cardIndex: document.getElementById('card-index'),
+  cardTag: document.getElementById('card-tag'),
+  cardArt: document.getElementById('card-art'),
+  cardName: document.getElementById('card-name'),
+  cardKeyword: document.getElementById('card-keyword'),
+  cardQuote: document.getElementById('card-quote'),
+  fortunes: document.getElementById('fortunes'),
+  suitGood: document.getElementById('suit-good'),
+  suitBad: document.getElementById('suit-bad'),
+  luckyColorSwatch: document.getElementById('lucky-color-swatch'),
+  luckyColorName: document.getElementById('lucky-color-name'),
+  luckyNumber: document.getElementById('lucky-number'),
+  luckyHour: document.getElementById('lucky-hour'),
+  luckyMantra: document.getElementById('lucky-mantra'),
+  btnShare: document.getElementById('btn-share'),
+  toast: document.getElementById('toast'),
+};
+
+let currentResult = null;
+
+function fmtDate(date) {
+  const [y, m, d] = date.split('-');
+  return `${y} 年 ${parseInt(m, 10)} 月 ${parseInt(d, 10)} 日`;
+}
+
+async function init() {
+  const today = dateKey();
+  dom.dateLabel.textContent = fmtDate(today);
+  let saved = null;
+  try { saved = await app.storage.get('lastReading'); } catch (_e) { /* ignore */ }
+  if (saved && saved.date === today) {
+    revealCard(today, true);
+  } else {
+    setupReveal(today);
+  }
+}
+
+function setupReveal(today) {
+  dom.revealStage.hidden = false;
+  dom.resultStage.hidden = true;
+  const handler = () => revealCard(today, false);
+  dom.cardBack.addEventListener('click', handler, { once: true });
+  dom.cardBack.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); revealCard(today, false); }
+  }, { once: true });
+}
+
+function revealCard(date, immediate) {
+  const fortune = generateFortune(date);
+  currentResult = { date, ...fortune };
+  if (!immediate) {
+    dom.cardBack.style.transition = 'transform .35s ease, opacity .35s ease';
+    dom.cardBack.style.transform = 'rotateY(90deg) scale(0.96)';
+    dom.cardBack.style.opacity = '0';
+    setTimeout(() => paintResult(fortune), 320);
+  } else {
+    paintResult(fortune);
+  }
+  app.storage.set('lastReading', { date, cardName: fortune.card.name }).catch(() => {});
+}
+
+function paintResult(f) {
+  dom.revealStage.hidden = true;
+  dom.resultStage.hidden = false;
+  dom.btnShare.hidden = false;
+
+  const idx = CARDS.indexOf(f.card) + 1;
+  dom.cardIndex.textContent = `No. ${String(idx).padStart(2, '0')}`;
+  dom.cardTag.textContent = f.card.tag;
+  dom.cardArt.textContent = f.card.symbol;
+  dom.cardName.textContent = f.card.name;
+  dom.cardKeyword.textContent = f.card.keyword;
+  dom.cardQuote.textContent = `"${f.card.quote}"`;
+  dom.cardFront.style.setProperty('--card-tone-1', f.card.tone[0]);
+  dom.cardFront.style.setProperty('--card-tone-2', f.card.tone[1]);
+
+  dom.fortunes.innerHTML = '';
+  for (const item of f.fortunes) {
+    const li = document.createElement('li');
+    li.className = 'fortune';
+    li.innerHTML = `
+      <span class="fortune__label">${item.label}</span>
+      <span class="fortune__bar"><span class="fortune__fill" style="width:0"></span></span>
+      <span class="fortune__stars">${'★'.repeat(item.stars)}${'☆'.repeat(5 - item.stars)}</span>
+    `;
+    dom.fortunes.appendChild(li);
+    requestAnimationFrame(() => {
+      li.querySelector('.fortune__fill').style.width = `${item.stars * 20}%`;
+    });
+  }
+
+  dom.suitGood.innerHTML = f.goods.map((s) => `<li>${escapeHtml(s)}</li>`).join('');
+  dom.suitBad.innerHTML = f.bads.map((s) => `<li>${escapeHtml(s)}</li>`).join('');
+
+  dom.luckyColorSwatch.style.background = f.color.hex;
+  dom.luckyColorName.textContent = f.color.name;
+  dom.luckyNumber.textContent = String(f.luckyNumber);
+  dom.luckyHour.textContent = f.hour;
+  dom.luckyMantra.textContent = `"${f.mantra}"`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
+}
+
+dom.btnShare.addEventListener('click', async () => {
+  if (!currentResult) return;
+  const f = currentResult;
+  const lines = [];
+  lines.push(`【${f.card.name}】 ${f.card.keyword}`);
+  lines.push(f.card.quote);
+  lines.push('');
+  for (const item of f.fortunes) {
+    lines.push(`${item.label}：${'★'.repeat(item.stars)}${'☆'.repeat(5 - item.stars)}`);
+  }
+  lines.push('');
+  lines.push(`今日宜：${f.goods.join('、')}`);
+  lines.push(`今日忌：${f.bads.join('、')}`);
+  lines.push('');
+  lines.push(`幸运色：${f.color.name}　幸运数字：${f.luckyNumber}　推荐时段：${f.hour}`);
+  lines.push(`咒语：${f.mantra}`);
+  const text = lines.join('\n');
+  try {
+    await app.clipboard.writeText(text);
+    showToast('已复制到剪贴板');
+  } catch (_e) {
+    showToast('复制失败');
+  }
+});
+
+let toastTimer = null;
+function showToast(msg) {
+  dom.toast.textContent = msg;
+  dom.toast.hidden = false;
+  if (toastTimer) clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => { dom.toast.hidden = true; }, 1600);
+}
+
+init();

--- a/src/crates/core/src/miniapp/builtin/assets/divination/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/divination/ui.js
@@ -251,7 +251,7 @@ function paintResult(f) {
     li.innerHTML = `
       <span class="fortune__label">${item.label}</span>
       <span class="fortune__bar"><span class="fortune__fill" style="width:0"></span></span>
-      <span class="fortune__stars">${'★'.repeat(item.stars)}${'☆'.repeat(5 - item.stars)}</span>
+      <span class="fortune__stars">${'★'.repeat(item.stars)}<span class="ghost">${'★'.repeat(5 - item.stars)}</span></span>
     `;
     dom.fortunes.appendChild(li);
     requestAnimationFrame(() => {

--- a/src/crates/core/src/miniapp/builtin/assets/divination/worker.js
+++ b/src/crates/core/src/miniapp/builtin/assets/divination/worker.js
@@ -1,0 +1,2 @@
+// Built-in MiniApp: Daily Divination — no node-side logic; storage handled by the runtime host.
+module.exports = {};

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/index.html
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme-type="dark">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>五子棋</title>
+</head>
+<body>
+  <div id="app" class="gomoku">
+    <header class="topbar">
+      <div class="brand">
+        <div class="brand__logo">
+          <span class="brand__dot brand__dot--black"></span>
+          <span class="brand__dot brand__dot--white"></span>
+        </div>
+        <div class="brand__text">
+          <h1 class="brand__title">五子棋</h1>
+          <p class="brand__subtitle">先连成五子者胜</p>
+        </div>
+      </div>
+      <div class="topbar__actions">
+        <div class="seg" id="mode-seg" role="tablist" aria-label="对战模式">
+          <button class="seg__btn is-active" data-mode="pvp" type="button">双人对战</button>
+          <button class="seg__btn" data-mode="pve" type="button">人机对弈</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="board-wrap">
+        <div class="board-frame">
+          <svg id="board" class="board" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg" aria-label="棋盘"></svg>
+          <div id="result-overlay" class="result-overlay" hidden>
+            <div class="result-card">
+              <div class="result-card__icon" id="result-icon">★</div>
+              <div class="result-card__title" id="result-title">黑棋胜</div>
+              <div class="result-card__sub" id="result-sub">连成五子</div>
+              <button id="result-restart" class="btn btn--primary" type="button">再来一局</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <aside class="sidepanel">
+        <div class="card turn-card">
+          <div class="card__label">当前回合</div>
+          <div class="turn">
+            <span class="turn__stone" id="turn-stone"></span>
+            <span class="turn__name" id="turn-name">黑棋</span>
+          </div>
+          <div class="turn__hint" id="turn-hint">点击棋盘任意交叉点落子</div>
+        </div>
+
+        <div class="card actions-card">
+          <button id="btn-undo" class="btn btn--ghost" type="button">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8a5 5 0 1 0 5-5"/><path d="M3 3v5h5"/></svg>
+            悔棋
+          </button>
+          <button id="btn-restart" class="btn btn--ghost" type="button">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="5"/><path d="M8 5v3l2 2"/></svg>
+            重新开始
+          </button>
+        </div>
+
+        <div class="card stats-card">
+          <div class="card__title">战绩</div>
+          <div class="stats">
+            <div class="stat">
+              <div class="stat__label">
+                <span class="stone stone--mini stone--black"></span>
+                黑棋胜
+              </div>
+              <div class="stat__value" id="stat-black">0</div>
+            </div>
+            <div class="stat">
+              <div class="stat__label">
+                <span class="stone stone--mini stone--white"></span>
+                白棋胜
+              </div>
+              <div class="stat__value" id="stat-white">0</div>
+            </div>
+            <div class="stat" id="stat-pve-row" hidden>
+              <div class="stat__label">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="4" width="12" height="9" rx="2"/><circle cx="6" cy="8" r="0.8" fill="currentColor"/><circle cx="10" cy="8" r="0.8" fill="currentColor"/></svg>
+                AI 胜
+              </div>
+              <div class="stat__value" id="stat-ai">0</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card history-card">
+          <div class="card__title">手数</div>
+          <div class="history" id="history">
+            <span class="history__empty">尚未落子</span>
+          </div>
+        </div>
+      </aside>
+    </main>
+  </div>
+</body>
+</html>

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/index.html
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/index.html
@@ -20,8 +20,8 @@
       </div>
       <div class="topbar__actions">
         <div class="seg" id="mode-seg" role="tablist" aria-label="对战模式">
-          <button class="seg__btn is-active" data-mode="pvp" type="button">双人对战</button>
-          <button class="seg__btn" data-mode="pve" type="button">人机对弈</button>
+          <button class="seg__btn" data-mode="pvp" type="button">双人对战</button>
+          <button class="seg__btn is-active" data-mode="pve" type="button">人机对弈</button>
         </div>
       </div>
     </header>

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/meta.json
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "builtin-gomoku",
+  "name": "五子棋",
+  "description": "经典 15×15 棋盘，支持双人对战与人机对弈，内置悔棋、重开与战绩统计。",
+  "icon": "Grid3x3",
+  "category": "game",
+  "tags": ["游戏", "策略", "内置"],
+  "version": 1,
+  "created_at": 0,
+  "updated_at": 0,
+  "permissions": {
+    "fs": { "read": ["{appdata}"], "write": ["{appdata}"] },
+    "shell": { "allow": [] },
+    "net": { "allow": [] },
+    "node": { "enabled": true, "max_memory_mb": 128, "timeout_ms": 5000 }
+  },
+  "ai_context": null
+}

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/style.css
@@ -1,0 +1,290 @@
+*, *::before, *::after { box-sizing: border-box; }
+body, html { margin: 0; padding: 0; height: 100%; }
+
+body {
+  font-family: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  font-size: 13px;
+  color: var(--bitfun-text, #e8e8e8);
+  background: var(--bitfun-bg, #121214);
+  overflow: hidden;
+}
+
+button { font-family: inherit; cursor: pointer; }
+
+.gomoku {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background:
+    radial-gradient(1200px 600px at 80% -10%, color-mix(in srgb, var(--bitfun-accent, #60a5fa) 9%, transparent), transparent 60%),
+    radial-gradient(900px 500px at -10% 110%, color-mix(in srgb, var(--bitfun-accent, #60a5fa) 6%, transparent), transparent 60%),
+    var(--bitfun-bg, #121214);
+}
+
+/* ── Top bar ─────────────────────────────────────────── */
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--bitfun-border-subtle, #27272a);
+  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 80%, transparent);
+  backdrop-filter: blur(10px);
+}
+.brand { display: flex; align-items: center; gap: 12px; }
+.brand__logo {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #2a2a30, #18181a);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--bitfun-border, #2e2e32);
+  overflow: hidden;
+}
+.brand__dot {
+  width: 12px; height: 12px; border-radius: 50%;
+  position: absolute;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.4);
+}
+.brand__dot--black { background: radial-gradient(circle at 30% 30%, #4a4a52, #0a0a0c); left: 7px; top: 12px; }
+.brand__dot--white { background: radial-gradient(circle at 30% 30%, #ffffff, #c8c8d0); right: 7px; top: 12px; }
+.brand__title { margin: 0; font-size: 14px; font-weight: 600; letter-spacing: 0.5px; }
+.brand__subtitle { margin: 1px 0 0; font-size: 11px; color: var(--bitfun-text-muted, #858585); }
+
+.seg {
+  display: inline-flex;
+  background: var(--bitfun-element-bg, #27272a);
+  border-radius: 999px;
+  padding: 3px;
+  border: 1px solid var(--bitfun-border-subtle, #27272a);
+}
+.seg__btn {
+  border: 0;
+  background: transparent;
+  color: var(--bitfun-text-secondary, #b0b0b0);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  transition: all .15s ease;
+}
+.seg__btn:hover { color: var(--bitfun-text, #e8e8e8); }
+.seg__btn.is-active {
+  background: var(--bitfun-bg, #121214);
+  color: var(--bitfun-text, #e8e8e8);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+}
+
+/* ── Layout ──────────────────────────────────────────── */
+.layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 20px;
+  padding: 20px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* ── Board ───────────────────────────────────────────── */
+.board-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+}
+.board-frame {
+  position: relative;
+  width: min(100%, calc(100vh - 110px));
+  aspect-ratio: 1 / 1;
+  padding: 14px;
+  border-radius: 18px;
+  background:
+    linear-gradient(145deg, #d8b780 0%, #c89a5a 60%, #b3823f 100%);
+  box-shadow:
+    0 18px 36px -12px rgba(0,0,0,0.55),
+    inset 0 0 0 1px rgba(255,255,255,0.06),
+    inset 0 -8px 18px rgba(0,0,0,0.18);
+}
+[data-theme-type="light"] .board-frame {
+  background: linear-gradient(145deg, #ecd1a0 0%, #d4a96e 60%, #b8854a 100%);
+}
+.board {
+  display: block;
+  width: 100%;
+  height: 100%;
+  touch-action: none;
+  user-select: none;
+  cursor: pointer;
+}
+
+/* SVG visual classes */
+.board .grid-line { stroke: rgba(60, 30, 10, 0.55); stroke-width: 1; }
+.board .star { fill: rgba(60, 30, 10, 0.7); }
+.board .hover-stone { opacity: 0.4; pointer-events: none; }
+.board .hover-stone--black { fill: #1a1a1c; }
+.board .hover-stone--white { fill: #f5f5f7; }
+.board .stone-black {
+  fill: url(#g-black);
+  stroke: rgba(0,0,0,0.5);
+  stroke-width: 0.5;
+  filter: drop-shadow(0 1px 2px rgba(0,0,0,0.4));
+}
+.board .stone-white {
+  fill: url(#g-white);
+  stroke: rgba(0,0,0,0.18);
+  stroke-width: 0.5;
+  filter: drop-shadow(0 1px 2px rgba(0,0,0,0.3));
+}
+.board .last-marker {
+  fill: none;
+  stroke: var(--bitfun-accent, #60a5fa);
+  stroke-width: 1.6;
+  pointer-events: none;
+}
+.board .win-marker {
+  fill: none;
+  stroke: var(--bitfun-warning, #f59e0b);
+  stroke-width: 2;
+  stroke-linecap: round;
+  pointer-events: none;
+  filter: drop-shadow(0 0 4px rgba(245,158,11,0.6));
+}
+
+/* ── Result overlay ──────────────────────────────────── */
+.result-overlay {
+  position: absolute;
+  inset: 14px;
+  border-radius: 14px;
+  background: rgba(8, 8, 10, 0.55);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: fadeIn .22s ease;
+}
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+.result-card {
+  background: var(--bitfun-bg-elevated, #18181a);
+  border: 1px solid var(--bitfun-border, #2e2e32);
+  padding: 28px 36px;
+  border-radius: 14px;
+  text-align: center;
+  box-shadow: 0 20px 50px -10px rgba(0,0,0,0.6);
+  min-width: 220px;
+}
+.result-card__icon {
+  font-size: 32px;
+  color: var(--bitfun-warning, #f59e0b);
+  margin-bottom: 6px;
+}
+.result-card__title { font-size: 18px; font-weight: 600; margin-bottom: 4px; color: var(--bitfun-text, #e8e8e8); }
+.result-card__sub { font-size: 12px; color: var(--bitfun-text-muted, #858585); margin-bottom: 18px; }
+
+/* ── Side panel ─────────────────────────────────────── */
+.sidepanel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  overflow-y: auto;
+}
+.card {
+  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 96%, transparent);
+  border: 1px solid var(--bitfun-border-subtle, #27272a);
+  border-radius: 12px;
+  padding: 14px 16px;
+}
+.card__label { font-size: 11px; color: var(--bitfun-text-muted, #858585); text-transform: uppercase; letter-spacing: 0.6px; margin-bottom: 8px; }
+.card__title { font-size: 12px; color: var(--bitfun-text-secondary, #b0b0b0); margin-bottom: 10px; font-weight: 500; }
+
+.turn { display: flex; align-items: center; gap: 10px; }
+.turn__stone {
+  width: 22px; height: 22px; border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #4a4a52, #0a0a0c);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+  transition: background .25s ease;
+}
+.turn__stone.is-white { background: radial-gradient(circle at 30% 30%, #ffffff, #c8c8d0); }
+.turn__name { font-size: 16px; font-weight: 600; }
+.turn__hint { margin-top: 8px; font-size: 11px; color: var(--bitfun-text-muted, #858585); }
+
+.actions-card {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--bitfun-border, #2e2e32);
+  background: var(--bitfun-element-bg, #27272a);
+  color: var(--bitfun-text, #e8e8e8);
+  font-size: 12px;
+  transition: all .15s ease;
+  flex: 1;
+}
+.btn:hover { background: var(--bitfun-element-hover, #3f3f46); }
+.btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.btn--ghost { background: transparent; }
+.btn--ghost:hover { background: var(--bitfun-element-bg, #27272a); }
+.btn--primary {
+  background: var(--bitfun-accent, #60a5fa);
+  color: #fff;
+  border-color: transparent;
+  flex: initial;
+  padding: 9px 18px;
+}
+.btn--primary:hover { background: var(--bitfun-accent-hover, #3b82f6); }
+
+.stats { display: flex; flex-direction: column; gap: 10px; }
+.stat { display: flex; align-items: center; justify-content: space-between; }
+.stat__label { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--bitfun-text-secondary, #b0b0b0); }
+.stat__value { font-size: 16px; font-weight: 600; font-variant-numeric: tabular-nums; }
+.stone { display: inline-block; border-radius: 50%; }
+.stone--mini { width: 12px; height: 12px; }
+.stone--black { background: radial-gradient(circle at 30% 30%, #4a4a52, #0a0a0c); }
+.stone--white { background: radial-gradient(circle at 30% 30%, #ffffff, #c8c8d0); border: 1px solid #999; }
+
+.history {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  max-height: 160px;
+  overflow-y: auto;
+  font-variant-numeric: tabular-nums;
+}
+.history__empty { font-size: 11px; color: var(--bitfun-text-muted, #858585); }
+.move-pill {
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--bitfun-element-bg, #27272a);
+  color: var(--bitfun-text-secondary, #b0b0b0);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.move-pill .stone--mini { width: 8px; height: 8px; }
+
+/* ── Scrollbar ──────────────────────────────────────── */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-thumb {
+  background: var(--bitfun-scrollbar-thumb, rgba(255,255,255,0.12));
+  border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover { background: var(--bitfun-scrollbar-thumb-hover, rgba(255,255,255,0.22)); }
+
+/* ── Responsive ──────────────────────────────────────── */
+@media (max-width: 720px) {
+  .layout { grid-template-columns: 1fr; padding: 12px; }
+  .sidepanel { flex-direction: row; overflow-x: auto; }
+  .sidepanel .card { min-width: 160px; flex-shrink: 0; }
+  .board-frame { width: min(100%, 92vw); }
+}

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/style.css
@@ -1,15 +1,41 @@
+/* Gomoku — traditional Chinese game-room theme.
+ * Palette: ebony / rosewood / parchment ivory / vermilion / antique gold.
+ * Type: serif display for titles & player names, sans for utility chrome.
+ */
+
 *, *::before, *::after { box-sizing: border-box; }
 body, html { margin: 0; padding: 0; height: 100%; }
 [hidden] { display: none !important; }
 
-body {
-  font-family: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
-  font-size: 13px;
-  color: var(--bitfun-text, #e8e8e8);
-  background: var(--bitfun-bg, #121214);
-  overflow: hidden;
+:root {
+  --g-bg: #161210;
+  --g-bg-deep: #0f0c0a;
+  --g-wood-dark: #2a201a;
+  --g-wood: #3a2c22;
+  --g-wood-soft: #4a382b;
+  --g-paper: #efe4cc;
+  --g-paper-deep: #d9c89f;
+  --g-ink: #1a1410;
+  --g-ink-soft: #43342a;
+  --g-vermilion: #b9483b;
+  --g-vermilion-soft: #d97863;
+  --g-gold: #c9a563;
+  --g-text: #f0e5cf;
+  --g-text-soft: #c8b896;
+  --g-text-mute: #8a7a62;
+  --g-line: rgba(201, 165, 99, 0.22);
+  --g-serif: ui-serif, "Noto Serif SC", "Songti SC", "STSong",
+             "Source Han Serif SC", "EB Garamond", Georgia, serif;
+  --g-sans: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
 }
 
+body {
+  font-family: var(--g-sans);
+  font-size: 13px;
+  color: var(--g-text);
+  background: var(--g-bg);
+  overflow: hidden;
+}
 button { font-family: inherit; cursor: pointer; }
 
 .gomoku {
@@ -17,74 +43,95 @@ button { font-family: inherit; cursor: pointer; }
   display: flex;
   flex-direction: column;
   background:
-    radial-gradient(1200px 600px at 80% -10%, color-mix(in srgb, var(--bitfun-accent, #60a5fa) 9%, transparent), transparent 60%),
-    radial-gradient(900px 500px at -10% 110%, color-mix(in srgb, var(--bitfun-accent, #60a5fa) 6%, transparent), transparent 60%),
-    var(--bitfun-bg, #121214);
+    radial-gradient(1100px 600px at 80% -10%, rgba(201,165,99,0.10), transparent 60%),
+    radial-gradient(900px 500px at -10% 110%, rgba(185,72,59,0.07), transparent 60%),
+    var(--g-bg);
 }
 
-/* ── Top bar ─────────────────────────────────────────── */
+/* ── Top bar — rosewood plank ─────────────────────────── */
 .topbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 20px;
-  border-bottom: 1px solid var(--bitfun-border-subtle, #27272a);
-  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 80%, transparent);
-  backdrop-filter: blur(10px);
+  padding: 14px 22px;
+  border-bottom: 1px solid var(--g-line);
+  background:
+    linear-gradient(180deg, rgba(58,44,34,0.95) 0%, rgba(42,32,26,0.95) 100%),
+    repeating-linear-gradient(90deg, rgba(0,0,0,0.04) 0 2px, transparent 2px 6px);
+  background-blend-mode: multiply;
+  box-shadow: 0 1px 0 rgba(201,165,99,0.10) inset, 0 -1px 0 rgba(0,0,0,0.4) inset;
 }
-.brand { display: flex; align-items: center; gap: 12px; }
+.brand { display: flex; align-items: center; gap: 14px; }
 .brand__logo {
   position: relative;
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
-  background: linear-gradient(135deg, #2a2a30, #18181a);
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 28%, #6a5236, #2a1c12);
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--bitfun-border, #2e2e32);
+  border: 1px solid rgba(201,165,99,0.45);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.5), 0 0 0 1px rgba(201,165,99,0.10) inset;
   overflow: hidden;
 }
 .brand__dot {
-  width: 12px; height: 12px; border-radius: 50%;
+  width: 13px; height: 13px; border-radius: 50%;
   position: absolute;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.4);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.5);
 }
-.brand__dot--black { background: radial-gradient(circle at 30% 30%, #4a4a52, #0a0a0c); left: 7px; top: 12px; }
-.brand__dot--white { background: radial-gradient(circle at 30% 30%, #ffffff, #c8c8d0); right: 7px; top: 12px; }
-.brand__title { margin: 0; font-size: 14px; font-weight: 600; letter-spacing: 0.5px; }
-.brand__subtitle { margin: 1px 0 0; font-size: 11px; color: var(--bitfun-text-muted, #858585); }
+.brand__dot--black { background: radial-gradient(circle at 30% 28%, #4a4a52, #050507); left: 7px; top: 12px; }
+.brand__dot--white { background: radial-gradient(circle at 30% 28%, #ffffff, #d6c89e); right: 7px; top: 12px; }
+.brand__title {
+  margin: 0;
+  font-family: var(--g-serif);
+  font-size: 19px;
+  font-weight: 500;
+  letter-spacing: 8px;
+  color: var(--g-paper);
+}
+.brand__subtitle {
+  margin: 2px 0 0;
+  font-family: var(--g-serif);
+  font-size: 12px;
+  letter-spacing: 4px;
+  color: var(--g-text-mute);
+}
 
+/* Mode tabs — parchment slips */
 .seg {
   display: inline-flex;
-  background: var(--bitfun-element-bg, #27272a);
-  border-radius: 999px;
+  background: rgba(15,12,10,0.55);
+  border-radius: 4px;
   padding: 3px;
-  border: 1px solid var(--bitfun-border-subtle, #27272a);
+  border: 1px solid rgba(201,165,99,0.30);
+  box-shadow: inset 0 1px 0 rgba(0,0,0,0.3);
 }
 .seg__btn {
   border: 0;
   background: transparent;
-  color: var(--bitfun-text-secondary, #b0b0b0);
-  padding: 6px 14px;
-  border-radius: 999px;
-  font-size: 12px;
+  color: var(--g-text-soft);
+  padding: 7px 16px;
+  border-radius: 2px;
+  font-family: var(--g-serif);
+  font-size: 13px;
+  letter-spacing: 3px;
   transition: all .15s ease;
 }
-.seg__btn:hover { color: var(--bitfun-text, #e8e8e8); }
+.seg__btn:hover { color: var(--g-paper); background: rgba(201,165,99,0.06); }
 .seg__btn.is-active {
-  background: var(--bitfun-bg, #121214);
-  color: var(--bitfun-text, #e8e8e8);
-  box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+  background: linear-gradient(180deg, var(--g-paper) 0%, var(--g-paper-deep) 100%);
+  color: var(--g-ink);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.45), 0 0 0 1px rgba(185,72,59,0.30) inset;
 }
 
 /* ── Layout ──────────────────────────────────────────── */
 .layout {
   flex: 1;
   display: grid;
-  grid-template-columns: 1fr 280px;
-  gap: 20px;
-  padding: 20px;
+  grid-template-columns: 1fr 290px;
+  gap: 22px;
+  padding: 22px;
   min-height: 0;
   overflow: hidden;
 }
@@ -100,14 +147,23 @@ button { font-family: inherit; cursor: pointer; }
   position: relative;
   width: min(100%, calc(100vh - 110px));
   aspect-ratio: 1 / 1;
-  padding: 14px;
-  border-radius: 18px;
+  padding: 16px;
+  border-radius: 12px;
   background:
     linear-gradient(145deg, #d8b780 0%, #c89a5a 60%, #b3823f 100%);
   box-shadow:
-    0 18px 36px -12px rgba(0,0,0,0.55),
+    0 22px 44px -14px rgba(0,0,0,0.6),
     inset 0 0 0 1px rgba(255,255,255,0.06),
-    inset 0 -8px 18px rgba(0,0,0,0.18);
+    inset 0 -8px 18px rgba(0,0,0,0.18),
+    inset 0 0 0 6px rgba(120,82,40,0.18);
+}
+.board-frame::after {
+  content: '';
+  position: absolute;
+  inset: 8px;
+  border: 1px solid rgba(58,32,12,0.35);
+  border-radius: 6px;
+  pointer-events: none;
 }
 [data-theme-type="light"] .board-frame {
   background: linear-gradient(145deg, #ecd1a0 0%, #d4a96e 60%, #b8854a 100%);
@@ -119,6 +175,8 @@ button { font-family: inherit; cursor: pointer; }
   touch-action: none;
   user-select: none;
   cursor: pointer;
+  position: relative;
+  z-index: 1;
 }
 
 /* SVG visual classes */
@@ -141,151 +199,252 @@ button { font-family: inherit; cursor: pointer; }
 }
 .board .last-marker {
   fill: none;
-  stroke: var(--bitfun-accent, #60a5fa);
+  stroke: var(--g-vermilion);
   stroke-width: 1.6;
   pointer-events: none;
 }
 .board .win-marker {
   fill: none;
-  stroke: var(--bitfun-warning, #f59e0b);
-  stroke-width: 2;
+  stroke: var(--g-vermilion);
+  stroke-width: 2.5;
   stroke-linecap: round;
   pointer-events: none;
-  filter: drop-shadow(0 0 4px rgba(245,158,11,0.6));
+  filter: drop-shadow(0 0 4px rgba(185,72,59,0.7));
 }
 
 /* ── Result overlay ──────────────────────────────────── */
 .result-overlay {
   position: absolute;
-  inset: 14px;
-  border-radius: 14px;
-  background: rgba(8, 8, 10, 0.55);
+  inset: 16px;
+  border-radius: 8px;
+  background: rgba(15,10,6,0.55);
   backdrop-filter: blur(8px);
   display: flex;
   align-items: center;
   justify-content: center;
+  z-index: 2;
   animation: fadeIn .22s ease;
 }
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
 .result-card {
-  background: var(--bitfun-bg-elevated, #18181a);
-  border: 1px solid var(--bitfun-border, #2e2e32);
-  padding: 28px 36px;
-  border-radius: 14px;
+  position: relative;
+  background: linear-gradient(180deg, var(--g-paper) 0%, var(--g-paper-deep) 100%);
+  border: 1px solid var(--g-vermilion);
+  padding: 30px 42px 24px;
+  border-radius: 6px;
   text-align: center;
-  box-shadow: 0 20px 50px -10px rgba(0,0,0,0.6);
-  min-width: 220px;
+  box-shadow: 0 22px 50px -10px rgba(0,0,0,0.6), inset 0 0 0 4px rgba(255,255,255,0.18);
+  min-width: 240px;
+  color: var(--g-ink);
+}
+.result-card::before {
+  /* vermilion seal corner ornament */
+  content: '';
+  position: absolute;
+  inset: 6px;
+  border: 1px dashed rgba(185,72,59,0.45);
+  border-radius: 3px;
+  pointer-events: none;
 }
 .result-card__icon {
-  font-size: 32px;
-  color: var(--bitfun-warning, #f59e0b);
+  font-family: var(--g-serif);
+  font-size: 38px;
+  color: var(--g-vermilion);
   margin-bottom: 6px;
+  letter-spacing: 4px;
 }
-.result-card__title { font-size: 18px; font-weight: 600; margin-bottom: 4px; color: var(--bitfun-text, #e8e8e8); }
-.result-card__sub { font-size: 12px; color: var(--bitfun-text-muted, #858585); margin-bottom: 18px; }
+.result-card__title {
+  font-family: var(--g-serif);
+  font-size: 22px;
+  font-weight: 500;
+  margin-bottom: 4px;
+  color: var(--g-ink);
+  letter-spacing: 8px;
+}
+.result-card__sub {
+  font-family: var(--g-serif);
+  font-size: 13px;
+  color: var(--g-ink-soft);
+  margin-bottom: 22px;
+  letter-spacing: 3px;
+}
 
 /* ── Side panel ─────────────────────────────────────── */
 .sidepanel {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
   min-width: 0;
   overflow-y: auto;
 }
 .card {
-  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 96%, transparent);
-  border: 1px solid var(--bitfun-border-subtle, #27272a);
-  border-radius: 12px;
-  padding: 14px 16px;
+  position: relative;
+  background:
+    linear-gradient(180deg, rgba(239,228,204,0.07) 0%, rgba(239,228,204,0.02) 100%),
+    rgba(58,44,34,0.55);
+  border: 1px solid rgba(201,165,99,0.28);
+  border-radius: 8px;
+  padding: 16px 18px;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.02), 0 8px 22px -12px rgba(0,0,0,0.5);
 }
-.card__label { font-size: 11px; color: var(--bitfun-text-muted, #858585); text-transform: uppercase; letter-spacing: 0.6px; margin-bottom: 8px; }
-.card__title { font-size: 12px; color: var(--bitfun-text-secondary, #b0b0b0); margin-bottom: 10px; font-weight: 500; }
+.card__label {
+  font-family: var(--g-serif);
+  font-size: 11px;
+  color: var(--g-gold);
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  margin-bottom: 10px;
+}
+.card__title {
+  font-family: var(--g-serif);
+  font-size: 13px;
+  color: var(--g-gold);
+  margin-bottom: 12px;
+  letter-spacing: 4px;
+}
 
-.turn { display: flex; align-items: center; gap: 10px; }
+/* Turn card */
+.turn { display: flex; align-items: center; gap: 12px; }
 .turn__stone {
-  width: 22px; height: 22px; border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, #4a4a52, #0a0a0c);
-  box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+  width: 26px; height: 26px; border-radius: 50%;
+  background: radial-gradient(circle at 30% 28%, #4a4a52, #050507);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.5), 0 0 0 1px rgba(201,165,99,0.20);
   transition: background .25s ease;
 }
-.turn__stone.is-white { background: radial-gradient(circle at 30% 30%, #ffffff, #c8c8d0); }
-.turn__name { font-size: 16px; font-weight: 600; }
-.turn__hint { margin-top: 8px; font-size: 11px; color: var(--bitfun-text-muted, #858585); }
+.turn__stone.is-white { background: radial-gradient(circle at 30% 28%, #ffffff, #d6c89e); }
+.turn__name {
+  font-family: var(--g-serif);
+  font-size: 19px;
+  font-weight: 500;
+  letter-spacing: 4px;
+  color: var(--g-paper);
+}
+.turn__hint {
+  margin-top: 10px;
+  font-family: var(--g-serif);
+  font-size: 12px;
+  letter-spacing: 1.5px;
+  color: var(--g-text-mute);
+  font-style: italic;
+}
 
+/* Actions */
 .actions-card {
   display: flex;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: 10px;
+  padding: 12px 14px;
 }
 .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  padding: 8px 12px;
-  border-radius: 8px;
-  border: 1px solid var(--bitfun-border, #2e2e32);
-  background: var(--bitfun-element-bg, #27272a);
-  color: var(--bitfun-text, #e8e8e8);
-  font-size: 12px;
+  gap: 7px;
+  padding: 9px 14px;
+  border-radius: 4px;
+  border: 1px solid rgba(201,165,99,0.35);
+  background: rgba(15,12,10,0.55);
+  color: var(--g-text);
+  font-family: var(--g-serif);
+  font-size: 13px;
+  letter-spacing: 3px;
   transition: all .15s ease;
   flex: 1;
 }
-.btn:hover { background: var(--bitfun-element-hover, #3f3f46); }
-.btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.btn--ghost { background: transparent; }
-.btn--ghost:hover { background: var(--bitfun-element-bg, #27272a); }
-.btn--primary {
-  background: var(--bitfun-accent, #60a5fa);
-  color: #fff;
-  border-color: transparent;
-  flex: initial;
-  padding: 9px 18px;
+.btn:hover {
+  background: rgba(201,165,99,0.10);
+  border-color: var(--g-gold);
+  color: var(--g-paper);
 }
-.btn--primary:hover { background: var(--bitfun-accent-hover, #3b82f6); }
+.btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.btn--primary {
+  background: linear-gradient(180deg, var(--g-vermilion) 0%, #93362d 100%);
+  color: #fff7e6;
+  border-color: rgba(185,72,59,0.85);
+  flex: initial;
+  padding: 10px 22px;
+  letter-spacing: 4px;
+  box-shadow: 0 2px 8px rgba(185,72,59,0.35), inset 0 1px 0 rgba(255,255,255,0.18);
+}
+.btn--primary:hover {
+  background: linear-gradient(180deg, var(--g-vermilion-soft) 0%, var(--g-vermilion) 100%);
+  border-color: var(--g-vermilion-soft);
+}
+.btn--ghost { /* alias kept for backwards compat */ }
 
+/* Stats */
 .stats { display: flex; flex-direction: column; gap: 10px; }
-.stat { display: flex; align-items: center; justify-content: space-between; }
-.stat__label { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--bitfun-text-secondary, #b0b0b0); }
-.stat__value { font-size: 16px; font-weight: 600; font-variant-numeric: tabular-nums; }
-.stone { display: inline-block; border-radius: 50%; }
-.stone--mini { width: 12px; height: 12px; }
-.stone--black { background: radial-gradient(circle at 30% 30%, #4a4a52, #0a0a0c); }
-.stone--white { background: radial-gradient(circle at 30% 30%, #ffffff, #c8c8d0); border: 1px solid #999; }
+.stat {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 4px 0;
+  border-bottom: 1px dashed rgba(201,165,99,0.15);
+}
+.stat:last-child { border-bottom: 0; }
+.stat__label {
+  display: flex; align-items: center; gap: 9px;
+  font-family: var(--g-serif);
+  font-size: 13px;
+  letter-spacing: 2px;
+  color: var(--g-text-soft);
+}
+.stat__value {
+  font-family: var(--g-serif);
+  font-size: 22px;
+  font-weight: 500;
+  color: var(--g-paper);
+  font-variant-numeric: tabular-nums;
+}
 
+.stone { display: inline-block; border-radius: 50%; }
+.stone--mini { width: 14px; height: 14px; box-shadow: 0 1px 2px rgba(0,0,0,0.5); }
+.stone--black { background: radial-gradient(circle at 30% 28%, #4a4a52, #050507); }
+.stone--white { background: radial-gradient(circle at 30% 28%, #ffffff, #d6c89e); border: 1px solid rgba(201,165,99,0.4); }
+
+/* History — 棋谱 */
+.history-card .card__title::before {
+  content: '⌬';
+  margin-right: 6px;
+  color: var(--g-vermilion);
+  font-style: normal;
+}
 .history {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  max-height: 160px;
+  max-height: 170px;
   overflow-y: auto;
   font-variant-numeric: tabular-nums;
 }
-.history__empty { font-size: 11px; color: var(--bitfun-text-muted, #858585); }
+.history__empty {
+  font-family: var(--g-serif);
+  font-style: italic;
+  font-size: 13px;
+  letter-spacing: 2px;
+  color: var(--g-text-mute);
+}
 .move-pill {
-  font-size: 11px;
-  padding: 3px 8px;
-  border-radius: 999px;
-  background: var(--bitfun-element-bg, #27272a);
-  color: var(--bitfun-text-secondary, #b0b0b0);
+  font-family: var(--g-serif);
+  font-size: 12px;
+  letter-spacing: 1px;
+  padding: 4px 9px;
+  border-radius: 3px;
+  background: rgba(15,12,10,0.55);
+  border: 1px solid rgba(201,165,99,0.20);
+  color: var(--g-text-soft);
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 5px;
 }
-.move-pill .stone--mini { width: 8px; height: 8px; }
+.move-pill .stone--mini { width: 9px; height: 9px; }
 
 /* ── Scrollbar ──────────────────────────────────────── */
 ::-webkit-scrollbar { width: 8px; height: 8px; }
-::-webkit-scrollbar-thumb {
-  background: var(--bitfun-scrollbar-thumb, rgba(255,255,255,0.12));
-  border-radius: 4px;
-}
-::-webkit-scrollbar-thumb:hover { background: var(--bitfun-scrollbar-thumb-hover, rgba(255,255,255,0.22)); }
+::-webkit-scrollbar-thumb { background: rgba(201,165,99,0.20); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: rgba(201,165,99,0.35); }
 
 /* ── Responsive ──────────────────────────────────────── */
 @media (max-width: 720px) {
-  .layout { grid-template-columns: 1fr; padding: 12px; }
+  .layout { grid-template-columns: 1fr; padding: 14px; }
   .sidepanel { flex-direction: row; overflow-x: auto; }
-  .sidepanel .card { min-width: 160px; flex-shrink: 0; }
+  .sidepanel .card { min-width: 170px; flex-shrink: 0; }
   .board-frame { width: min(100%, 92vw); }
 }

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/style.css
@@ -1,5 +1,6 @@
 *, *::before, *::after { box-sizing: border-box; }
 body, html { margin: 0; padding: 0; height: 100%; }
+[hidden] { display: none !important; }
 
 body {
   font-family: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/ui.js
@@ -1,0 +1,448 @@
+// Gomoku — built-in MiniApp.
+// Pure-frontend 15x15 Gomoku with PvP + simple PvE AI; persists win stats via app.storage.
+
+const SIZE = 15;
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const VIEWBOX = 600;
+const PADDING = 24;
+const STEP = (VIEWBOX - PADDING * 2) / (SIZE - 1);
+const STAR_POINTS = [
+  [3, 3], [3, 7], [3, 11],
+  [7, 3], [7, 7], [7, 11],
+  [11, 3], [11, 7], [11, 11],
+];
+
+const EMPTY = 0, BLACK = 1, WHITE = 2;
+const DIRS = [[1, 0], [0, 1], [1, 1], [1, -1]];
+
+const state = {
+  board: createBoard(),
+  history: [],
+  current: BLACK,
+  mode: 'pvp', // 'pvp' | 'pve'
+  winner: 0,
+  winLine: null,
+  hover: null,
+  busy: false,
+  stats: { black: 0, white: 0, ai: 0 },
+};
+
+const dom = {
+  board: document.getElementById('board'),
+  modeSeg: document.getElementById('mode-seg'),
+  turnStone: document.getElementById('turn-stone'),
+  turnName: document.getElementById('turn-name'),
+  turnHint: document.getElementById('turn-hint'),
+  btnUndo: document.getElementById('btn-undo'),
+  btnRestart: document.getElementById('btn-restart'),
+  history: document.getElementById('history'),
+  statBlack: document.getElementById('stat-black'),
+  statWhite: document.getElementById('stat-white'),
+  statAi: document.getElementById('stat-ai'),
+  statPveRow: document.getElementById('stat-pve-row'),
+  resultOverlay: document.getElementById('result-overlay'),
+  resultIcon: document.getElementById('result-icon'),
+  resultTitle: document.getElementById('result-title'),
+  resultSub: document.getElementById('result-sub'),
+  resultRestart: document.getElementById('result-restart'),
+};
+
+function createBoard() {
+  return Array.from({ length: SIZE }, () => Array(SIZE).fill(EMPTY));
+}
+
+// ── Init ──────────────────────────────────────────────
+async function init() {
+  await loadStats();
+  buildBoardSvg();
+  bindEvents();
+  render();
+}
+
+async function loadStats() {
+  try {
+    const v = await app.storage.get('stats');
+    if (v && typeof v === 'object') {
+      state.stats = { black: v.black | 0, white: v.white | 0, ai: v.ai | 0 };
+    }
+  } catch (_e) { /* ignore */ }
+}
+
+function persistStats() {
+  app.storage.set('stats', state.stats).catch(() => {});
+}
+
+function buildBoardSvg() {
+  const svg = dom.board;
+  svg.innerHTML = '';
+
+  const defs = el('defs');
+  defs.innerHTML = `
+    <radialGradient id="g-black" cx="35%" cy="32%" r="60%">
+      <stop offset="0%" stop-color="#5a5a64"/>
+      <stop offset="60%" stop-color="#1c1c20"/>
+      <stop offset="100%" stop-color="#050507"/>
+    </radialGradient>
+    <radialGradient id="g-white" cx="35%" cy="32%" r="60%">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="70%" stop-color="#e2e2e8"/>
+      <stop offset="100%" stop-color="#b8b8c0"/>
+    </radialGradient>
+  `;
+  svg.appendChild(defs);
+
+  // Grid lines
+  const grid = el('g', { class: 'grid' });
+  for (let i = 0; i < SIZE; i++) {
+    const p = PADDING + i * STEP;
+    grid.appendChild(el('line', { class: 'grid-line', x1: PADDING, y1: p, x2: VIEWBOX - PADDING, y2: p }));
+    grid.appendChild(el('line', { class: 'grid-line', x1: p, y1: PADDING, x2: p, y2: VIEWBOX - PADDING }));
+  }
+  // Star points
+  for (const [r, c] of STAR_POINTS) {
+    grid.appendChild(el('circle', { class: 'star', cx: PADDING + c * STEP, cy: PADDING + r * STEP, r: 3 }));
+  }
+  svg.appendChild(grid);
+
+  // Stones layer
+  const stones = el('g', { id: 'stones' });
+  svg.appendChild(stones);
+  // Markers layer (last move + win line)
+  svg.appendChild(el('g', { id: 'markers' }));
+  // Hover layer
+  svg.appendChild(el('g', { id: 'hover' }));
+}
+
+function el(name, attrs = {}) {
+  const node = document.createElementNS(SVG_NS, name);
+  for (const k of Object.keys(attrs)) node.setAttribute(k, attrs[k]);
+  return node;
+}
+
+function bindEvents() {
+  dom.modeSeg.addEventListener('click', (e) => {
+    const btn = e.target.closest('.seg__btn');
+    if (!btn) return;
+    const mode = btn.dataset.mode;
+    if (!mode || mode === state.mode) return;
+    state.mode = mode;
+    for (const b of dom.modeSeg.querySelectorAll('.seg__btn')) {
+      b.classList.toggle('is-active', b.dataset.mode === mode);
+    }
+    dom.statPveRow.hidden = mode !== 'pve';
+    restart();
+  });
+
+  dom.btnUndo.addEventListener('click', undo);
+  dom.btnRestart.addEventListener('click', restart);
+  dom.resultRestart.addEventListener('click', restart);
+
+  dom.board.addEventListener('mousemove', onHover);
+  dom.board.addEventListener('mouseleave', () => { state.hover = null; renderHover(); });
+  dom.board.addEventListener('click', onClick);
+}
+
+function pointFromEvent(e) {
+  const rect = dom.board.getBoundingClientRect();
+  const px = ((e.clientX - rect.left) / rect.width) * VIEWBOX;
+  const py = ((e.clientY - rect.top) / rect.height) * VIEWBOX;
+  const c = Math.round((px - PADDING) / STEP);
+  const r = Math.round((py - PADDING) / STEP);
+  if (r < 0 || r >= SIZE || c < 0 || c >= SIZE) return null;
+  return { r, c };
+}
+
+function onHover(e) {
+  if (state.winner || state.busy) { state.hover = null; renderHover(); return; }
+  const p = pointFromEvent(e);
+  if (!p || state.board[p.r][p.c] !== EMPTY) { state.hover = null; renderHover(); return; }
+  if (state.hover && state.hover.r === p.r && state.hover.c === p.c) return;
+  state.hover = p;
+  renderHover();
+}
+
+function onClick(e) {
+  if (state.winner || state.busy) return;
+  const p = pointFromEvent(e);
+  if (!p) return;
+  if (state.board[p.r][p.c] !== EMPTY) return;
+  placeStone(p.r, p.c, state.current);
+  if (!state.winner && state.mode === 'pve' && state.current === WHITE) {
+    state.busy = true;
+    setTimeout(() => {
+      const move = computeAiMove();
+      if (move) placeStone(move.r, move.c, WHITE);
+      state.busy = false;
+      render();
+    }, 240);
+  }
+}
+
+function placeStone(r, c, color) {
+  state.board[r][c] = color;
+  state.history.push({ r, c, color });
+  const win = checkWin(r, c, color);
+  if (win) {
+    state.winner = color;
+    state.winLine = win;
+    if (state.mode === 'pve') {
+      if (color === BLACK) state.stats.black += 1;
+      else state.stats.ai += 1;
+    } else {
+      if (color === BLACK) state.stats.black += 1;
+      else state.stats.white += 1;
+    }
+    persistStats();
+  } else {
+    state.current = color === BLACK ? WHITE : BLACK;
+  }
+  state.hover = null;
+  render();
+}
+
+function undo() {
+  if (state.busy) return;
+  if (state.winner) {
+    // After a win, undo just resets current game without changing stats.
+    restart();
+    return;
+  }
+  if (state.history.length === 0) return;
+  const popOnce = () => {
+    const last = state.history.pop();
+    if (!last) return;
+    state.board[last.r][last.c] = EMPTY;
+    state.current = last.color;
+  };
+  popOnce();
+  // In PvE, undo two plies so the human moves again.
+  if (state.mode === 'pve' && state.history.length > 0 && state.current === WHITE) {
+    popOnce();
+  }
+  render();
+}
+
+function restart() {
+  state.board = createBoard();
+  state.history = [];
+  state.current = BLACK;
+  state.winner = 0;
+  state.winLine = null;
+  state.hover = null;
+  state.busy = false;
+  render();
+}
+
+// ── Win detection ─────────────────────────────────────
+function checkWin(r, c, color) {
+  for (const [dr, dc] of DIRS) {
+    const line = [{ r, c }];
+    for (let k = 1; k < 5; k++) {
+      const nr = r + dr * k, nc = c + dc * k;
+      if (nr < 0 || nr >= SIZE || nc < 0 || nc >= SIZE) break;
+      if (state.board[nr][nc] !== color) break;
+      line.push({ r: nr, c: nc });
+    }
+    for (let k = 1; k < 5; k++) {
+      const nr = r - dr * k, nc = c - dc * k;
+      if (nr < 0 || nr >= SIZE || nc < 0 || nc >= SIZE) break;
+      if (state.board[nr][nc] !== color) break;
+      line.unshift({ r: nr, c: nc });
+    }
+    if (line.length >= 5) return line.slice(0, 5);
+  }
+  return null;
+}
+
+// ── AI ────────────────────────────────────────────────
+// Simple heuristic: score each empty cell by combining own threat + opponent threat.
+function computeAiMove() {
+  if (state.history.length === 0) return { r: 7, c: 7 };
+  let best = null;
+  let bestScore = -Infinity;
+  const candidates = candidateCells();
+  for (const { r, c } of candidates) {
+    if (state.board[r][c] !== EMPTY) continue;
+    const own = scoreAt(r, c, WHITE);
+    const opp = scoreAt(r, c, BLACK) * 0.95;
+    const center = -Math.abs(r - 7) - Math.abs(c - 7);
+    const score = Math.max(own, opp) * 100 + (own + opp) + center;
+    if (score > bestScore) { bestScore = score; best = { r, c }; }
+  }
+  return best;
+}
+
+function candidateCells() {
+  const seen = new Set();
+  const out = [];
+  for (const m of state.history) {
+    for (let dr = -2; dr <= 2; dr++) {
+      for (let dc = -2; dc <= 2; dc++) {
+        const r = m.r + dr, c = m.c + dc;
+        if (r < 0 || r >= SIZE || c < 0 || c >= SIZE) continue;
+        if (state.board[r][c] !== EMPTY) continue;
+        const k = r * SIZE + c;
+        if (seen.has(k)) continue;
+        seen.add(k);
+        out.push({ r, c });
+      }
+    }
+  }
+  return out;
+}
+
+function scoreAt(r, c, color) {
+  // Estimate the strongest pattern formed by placing `color` at (r,c).
+  let best = 0;
+  for (const [dr, dc] of DIRS) {
+    let count = 1;
+    let openA = false, openB = false;
+    for (let k = 1; k < 5; k++) {
+      const nr = r + dr * k, nc = c + dc * k;
+      if (nr < 0 || nr >= SIZE || nc < 0 || nc >= SIZE) break;
+      const v = state.board[nr][nc];
+      if (v === color) count += 1;
+      else { if (v === EMPTY) openA = true; break; }
+    }
+    for (let k = 1; k < 5; k++) {
+      const nr = r - dr * k, nc = c - dc * k;
+      if (nr < 0 || nr >= SIZE || nc < 0 || nc >= SIZE) break;
+      const v = state.board[nr][nc];
+      if (v === color) count += 1;
+      else { if (v === EMPTY) openB = true; break; }
+    }
+    let s = 0;
+    if (count >= 5) s = 100000;
+    else if (count === 4) s = openA && openB ? 10000 : (openA || openB ? 1000 : 0);
+    else if (count === 3) s = openA && openB ? 800 : (openA || openB ? 80 : 0);
+    else if (count === 2) s = openA && openB ? 60 : (openA || openB ? 12 : 0);
+    else if (count === 1) s = openA && openB ? 6 : 1;
+    if (s > best) best = s;
+  }
+  return best;
+}
+
+// ── Render ────────────────────────────────────────────
+function render() {
+  renderStones();
+  renderMarkers();
+  renderHover();
+  renderTurn();
+  renderHistory();
+  renderStats();
+  renderResult();
+  dom.btnUndo.disabled = state.history.length === 0 && !state.winner;
+}
+
+function renderStones() {
+  const layer = dom.board.querySelector('#stones');
+  layer.innerHTML = '';
+  for (let r = 0; r < SIZE; r++) {
+    for (let c = 0; c < SIZE; c++) {
+      const v = state.board[r][c];
+      if (v === EMPTY) continue;
+      const cx = PADDING + c * STEP;
+      const cy = PADDING + r * STEP;
+      layer.appendChild(el('circle', {
+        class: v === BLACK ? 'stone-black' : 'stone-white',
+        cx, cy, r: STEP * 0.42,
+      }));
+    }
+  }
+}
+
+function renderMarkers() {
+  const layer = dom.board.querySelector('#markers');
+  layer.innerHTML = '';
+  const last = state.history[state.history.length - 1];
+  if (last) {
+    layer.appendChild(el('circle', {
+      class: 'last-marker',
+      cx: PADDING + last.c * STEP,
+      cy: PADDING + last.r * STEP,
+      r: STEP * 0.18,
+    }));
+  }
+  if (state.winLine) {
+    const a = state.winLine[0];
+    const b = state.winLine[state.winLine.length - 1];
+    layer.appendChild(el('line', {
+      class: 'win-marker',
+      x1: PADDING + a.c * STEP, y1: PADDING + a.r * STEP,
+      x2: PADDING + b.c * STEP, y2: PADDING + b.r * STEP,
+    }));
+  }
+}
+
+function renderHover() {
+  const layer = dom.board.querySelector('#hover');
+  layer.innerHTML = '';
+  if (!state.hover) return;
+  if (state.winner || state.busy) return;
+  layer.appendChild(el('circle', {
+    class: 'hover-stone hover-stone--' + (state.current === BLACK ? 'black' : 'white'),
+    cx: PADDING + state.hover.c * STEP,
+    cy: PADDING + state.hover.r * STEP,
+    r: STEP * 0.42,
+  }));
+}
+
+function renderTurn() {
+  const isWhite = state.current === WHITE;
+  dom.turnStone.classList.toggle('is-white', isWhite);
+  if (state.mode === 'pve') {
+    dom.turnName.textContent = isWhite ? 'AI 思考中…' : '你（黑棋）';
+    dom.turnHint.textContent = isWhite ? '请稍候' : '点击棋盘任意交叉点落子';
+  } else {
+    dom.turnName.textContent = isWhite ? '白棋' : '黑棋';
+    dom.turnHint.textContent = '点击棋盘任意交叉点落子';
+  }
+}
+
+function renderHistory() {
+  if (state.history.length === 0) {
+    dom.history.innerHTML = '<span class="history__empty">尚未落子</span>';
+    return;
+  }
+  dom.history.innerHTML = '';
+  state.history.forEach((m, i) => {
+    const pill = document.createElement('span');
+    pill.className = 'move-pill';
+    const dot = document.createElement('span');
+    dot.className = 'stone stone--mini ' + (m.color === BLACK ? 'stone--black' : 'stone--white');
+    pill.appendChild(dot);
+    pill.appendChild(document.createTextNode(`${i + 1} · ${columnLabel(m.c)}${SIZE - m.r}`));
+    dom.history.appendChild(pill);
+  });
+  dom.history.scrollTop = dom.history.scrollHeight;
+}
+
+function columnLabel(c) {
+  // A..O (skip I to follow Go convention? Keep simple A..O including I)
+  return String.fromCharCode(65 + c);
+}
+
+function renderStats() {
+  dom.statBlack.textContent = state.stats.black;
+  dom.statWhite.textContent = state.stats.white;
+  dom.statAi.textContent = state.stats.ai;
+  dom.statPveRow.hidden = state.mode !== 'pve';
+}
+
+function renderResult() {
+  if (!state.winner) { dom.resultOverlay.hidden = true; return; }
+  dom.resultOverlay.hidden = false;
+  const isBlack = state.winner === BLACK;
+  if (state.mode === 'pve') {
+    dom.resultTitle.textContent = isBlack ? '你赢了！' : 'AI 获胜';
+    dom.resultSub.textContent = isBlack ? '稳如老 G' : '再战一局，把场子赢回来';
+  } else {
+    dom.resultTitle.textContent = isBlack ? '黑棋胜' : '白棋胜';
+    dom.resultSub.textContent = '连成五子';
+  }
+  dom.resultIcon.textContent = isBlack ? '●' : '○';
+  dom.resultIcon.style.color = isBlack ? '#1c1c20' : '#f5f5f7';
+  if (!isBlack) dom.resultIcon.style.textShadow = '0 0 0 1px #555';
+}
+
+init();

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/ui.js
@@ -19,7 +19,7 @@ const state = {
   board: createBoard(),
   history: [],
   current: BLACK,
-  mode: 'pvp', // 'pvp' | 'pve'
+  mode: 'pve', // 'pvp' | 'pve'
   winner: 0,
   winLine: null,
   hover: null,

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/ui.js
@@ -441,8 +441,8 @@ function renderResult() {
     dom.resultSub.textContent = '连成五子';
   }
   dom.resultIcon.textContent = isBlack ? '●' : '○';
-  dom.resultIcon.style.color = isBlack ? '#1c1c20' : '#f5f5f7';
-  if (!isBlack) dom.resultIcon.style.textShadow = '0 0 0 1px #555';
+  dom.resultIcon.style.color = '';
+  dom.resultIcon.style.textShadow = '';
 }
 
 init();

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/worker.js
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/worker.js
@@ -1,0 +1,2 @@
+// Built-in MiniApp: Gomoku — no node-side logic; storage handled by the runtime host.
+module.exports = {};

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/index.html
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/index.html
@@ -73,6 +73,27 @@
           </div>
         </div>
 
+        <div class="card matches-card">
+          <div class="matches-card__header">
+            <div class="card__title" style="margin: 0;">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M2 8l3 3 9-9"/></svg>
+              匹配明细
+              <span class="hint" id="matches-summary">尚未匹配</span>
+            </div>
+            <div class="matches-card__actions">
+              <button id="btn-prev-match" class="link-btn" type="button" title="上一处" disabled>
+                <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3l-5 5 5 5"/></svg>
+              </button>
+              <button id="btn-next-match" class="link-btn" type="button" title="下一处" disabled>
+                <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3l5 5-5 5"/></svg>
+              </button>
+            </div>
+          </div>
+          <div class="matches" id="matches">
+            <div class="empty">输入正则与文本，匹配结果将在这里展示。</div>
+          </div>
+        </div>
+
         <div class="card replace-card">
           <div class="card__title">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M4 4h6a3 3 0 010 6H7"/><path d="M9 8L7 10l2 2"/></svg>
@@ -85,13 +106,6 @@
       </section>
 
       <aside class="side-col">
-        <div class="card matches-card">
-          <div class="card__title">匹配明细</div>
-          <div class="matches" id="matches">
-            <div class="empty">输入正则与文本，匹配结果将在这里展示。</div>
-          </div>
-        </div>
-
         <div class="card library-card">
           <div class="card__title">常用模式</div>
           <div class="library" id="library"></div>

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/index.html
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme-type="dark">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>正则游乐场</title>
+</head>
+<body>
+  <div id="app" class="rx">
+    <header class="topbar">
+      <div class="brand">
+        <div class="brand__icon">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M17 3v6"/><path d="M14 6h6"/>
+            <circle cx="6.5" cy="17.5" r="1.5"/>
+            <path d="M14 12l-4 4"/><path d="M14 16l-4-4"/>
+          </svg>
+        </div>
+        <div class="brand__text">
+          <h1 class="brand__title">正则游乐场</h1>
+          <p class="brand__subtitle">RegExp 实时调试 · ECMAScript 风格</p>
+        </div>
+      </div>
+      <div class="topbar__status">
+        <span class="status status--ok" id="status-pill">就绪</span>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="main-col">
+        <div class="card pattern-card">
+          <div class="pattern-row">
+            <span class="slash">/</span>
+            <input
+              id="pattern"
+              type="text"
+              class="pattern-input"
+              spellcheck="false"
+              autocomplete="off"
+              placeholder="\b[A-Z][a-zA-Z0-9_]*\b"
+            />
+            <span class="slash">/</span>
+            <div class="flags" id="flags">
+              <button type="button" class="flag" data-flag="g" title="全局匹配 (global)">g</button>
+              <button type="button" class="flag" data-flag="i" title="忽略大小写 (ignore case)">i</button>
+              <button type="button" class="flag" data-flag="m" title="多行模式 (multiline)">m</button>
+              <button type="button" class="flag" data-flag="s" title="dotAll · . 匹配换行">s</button>
+              <button type="button" class="flag" data-flag="u" title="Unicode 模式">u</button>
+              <button type="button" class="flag" data-flag="y" title="粘连匹配 (sticky)">y</button>
+            </div>
+          </div>
+          <div class="pattern-error" id="pattern-error" hidden></div>
+        </div>
+
+        <div class="card test-card">
+          <div class="test-card__header">
+            <div class="card__title">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="3" width="12" height="10" rx="1"/><path d="M4 7h8M4 10h5"/></svg>
+              测试文本
+            </div>
+            <div class="test-card__actions">
+              <span class="match-count" id="match-count">0 处匹配</span>
+              <button id="btn-clear" class="link-btn" type="button" title="清空">
+                <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4l1 9h4l1-9"/></svg>
+                清空
+              </button>
+            </div>
+          </div>
+          <div class="editor">
+            <textarea id="test-text" spellcheck="false" autocomplete="off" autocorrect="off"
+              placeholder="把要匹配的文本粘贴到这里…"></textarea>
+            <pre id="highlight" class="highlight" aria-hidden="true"></pre>
+          </div>
+        </div>
+
+        <div class="card replace-card">
+          <div class="card__title">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M4 4h6a3 3 0 010 6H7"/><path d="M9 8L7 10l2 2"/></svg>
+            替换预览
+            <span class="hint">支持 $1 $2 $&lt;name&gt; 反向引用</span>
+          </div>
+          <input id="replace-input" type="text" class="replace-input" placeholder="替换为…（留空则不展示预览）" spellcheck="false" autocomplete="off"/>
+          <pre id="replace-output" class="replace-output" hidden></pre>
+        </div>
+      </section>
+
+      <aside class="side-col">
+        <div class="card matches-card">
+          <div class="card__title">匹配明细</div>
+          <div class="matches" id="matches">
+            <div class="empty">输入正则与文本，匹配结果将在这里展示。</div>
+          </div>
+        </div>
+
+        <div class="card library-card">
+          <div class="card__title">常用模式</div>
+          <div class="library" id="library"></div>
+        </div>
+
+        <div class="card ref-card">
+          <div class="card__title">速查</div>
+          <ul class="ref">
+            <li><code>\d</code> 数字 · <code>\D</code> 非数字</li>
+            <li><code>\w</code> 字母数字下划线 · <code>\W</code> 反之</li>
+            <li><code>\s</code> 空白 · <code>\S</code> 非空白</li>
+            <li><code>^ $</code> 行首/行尾（配合 m）</li>
+            <li><code>(?:…)</code> 非捕获 · <code>(?&lt;n&gt;…)</code> 命名捕获</li>
+            <li><code>(?=…)</code> 正向先行 · <code>(?!…)</code> 反向先行</li>
+            <li><code>{n,m}</code> 区间量词 · <code>?</code> 非贪婪</li>
+          </ul>
+        </div>
+      </aside>
+    </main>
+  </div>
+</body>
+</html>

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/meta.json
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "builtin-regex-playground",
+  "name": "正则游乐场",
+  "description": "实时高亮匹配、捕获组明细、替换预览，内置常用模式速取库（邮箱 / URL / IP / UUID 等）。",
+  "icon": "Regex",
+  "category": "developer",
+  "tags": ["正则", "工具", "开发", "内置"],
+  "version": 1,
+  "created_at": 0,
+  "updated_at": 0,
+  "permissions": {
+    "fs": { "read": ["{appdata}"], "write": ["{appdata}"] },
+    "shell": { "allow": [] },
+    "net": { "allow": [] },
+    "node": { "enabled": true, "max_memory_mb": 128, "timeout_ms": 5000 }
+  },
+  "ai_context": null
+}

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/style.css
@@ -251,15 +251,30 @@ input, textarea { font-family: inherit; }
 }
 
 /* ── Matches list ────────────────────────────────────── */
-.matches-card { display: flex; flex-direction: column; min-height: 0; flex: 1; }
+.matches-card { display: flex; flex-direction: column; min-height: 0; padding: 12px 14px; }
+.matches-card__header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 10px;
+  gap: 8px;
+}
+.matches-card__actions { display: flex; align-items: center; gap: 4px; }
+.matches-card__actions .link-btn { padding: 4px 7px; }
+.matches-card__actions .link-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 .matches {
-  flex: 1;
+  max-height: 240px;
   overflow-y: auto;
-  display: flex; flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 8px;
   padding-right: 2px;
 }
-.empty { color: var(--bitfun-text-muted, #858585); font-size: 11.5px; padding: 8px 0; }
+.matches:empty { display: none; }
+.empty {
+  grid-column: 1 / -1;
+  color: var(--bitfun-text-muted, #858585);
+  font-size: 11.5px;
+  padding: 8px 0;
+}
 .match {
   background: var(--bitfun-element-bg, #27272a);
   border: 1px solid transparent;
@@ -267,31 +282,63 @@ input, textarea { font-family: inherit; }
   padding: 8px 10px;
   cursor: pointer;
   transition: all .12s ease;
+  min-width: 0;
 }
 .match:hover { border-color: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 50%, transparent); }
-.match.is-active { border-color: var(--bitfun-accent, #60a5fa); }
+.match.is-active {
+  border-color: var(--bitfun-accent, #60a5fa);
+  background: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 10%, var(--bitfun-element-bg, #27272a));
+}
 .match__head {
   display: flex; align-items: center; justify-content: space-between;
   font-size: 11px; color: var(--bitfun-text-muted, #858585);
+  font-variant-numeric: tabular-nums;
 }
-.match__index { color: var(--bitfun-accent, #60a5fa); font-weight: 600; }
+.match__index {
+  color: var(--bitfun-accent, #60a5fa);
+  font-weight: 600;
+  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+}
+.match__loc { font-family: var(--bitfun-font-mono, ui-monospace, monospace); }
 .match__text {
-  margin-top: 4px;
+  margin-top: 5px;
   font-family: var(--bitfun-font-mono, ui-monospace, monospace);
   font-size: 12px;
   color: var(--bitfun-text, #e8e8e8);
   word-break: break-all;
+  background: var(--bitfun-bg, #121214);
+  border: 1px solid var(--bitfun-border-subtle, #27272a);
+  border-radius: 6px;
+  padding: 5px 7px;
+  max-height: 60px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
+.match__text--empty { color: var(--bitfun-text-muted, #858585); font-style: italic; }
 .match__groups {
-  margin-top: 6px;
+  margin-top: 7px;
   display: flex; flex-direction: column; gap: 3px;
+  border-top: 1px dashed var(--bitfun-border-subtle, #27272a);
+  padding-top: 6px;
 }
 .match__group {
   font-family: var(--bitfun-font-mono, ui-monospace, monospace);
   font-size: 11px;
   color: var(--bitfun-text-secondary, #b0b0b0);
+  display: flex;
+  gap: 6px;
+  word-break: break-all;
 }
-.match__group b { color: var(--bitfun-warning, #f59e0b); font-weight: 600; }
+.match__group-tag {
+  color: var(--bitfun-warning, #f59e0b);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.match__group-val { min-width: 0; }
+.match__group-val--empty { opacity: 0.5; font-style: italic; }
 
 /* ── Library ─────────────────────────────────────────── */
 .library { display: flex; flex-direction: column; gap: 6px; }

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/style.css
@@ -1,0 +1,336 @@
+*, *::before, *::after { box-sizing: border-box; }
+body, html { margin: 0; padding: 0; height: 100%; }
+
+body {
+  font-family: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  font-size: 13px;
+  color: var(--bitfun-text, #e8e8e8);
+  background: var(--bitfun-bg, #121214);
+  overflow: hidden;
+}
+button { font-family: inherit; cursor: pointer; }
+input, textarea { font-family: inherit; }
+
+.rx {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background:
+    radial-gradient(800px 400px at 100% -10%, color-mix(in srgb, var(--bitfun-accent, #60a5fa) 7%, transparent), transparent 60%),
+    var(--bitfun-bg, #121214);
+}
+
+/* ── Top bar ─────────────────────────────────────────── */
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--bitfun-border-subtle, #27272a);
+  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 80%, transparent);
+  backdrop-filter: blur(10px);
+}
+.brand { display: flex; align-items: center; gap: 12px; }
+.brand__icon {
+  width: 34px; height: 34px;
+  border-radius: 9px;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--bitfun-accent, #60a5fa) 35%, transparent), color-mix(in srgb, var(--bitfun-accent, #60a5fa) 12%, transparent));
+  border: 1px solid var(--bitfun-border, #2e2e32);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--bitfun-accent, #60a5fa);
+}
+.brand__title { margin: 0; font-size: 14px; font-weight: 600; }
+.brand__subtitle { margin: 1px 0 0; font-size: 11px; color: var(--bitfun-text-muted, #858585); }
+
+.status {
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--bitfun-element-bg, #27272a);
+  color: var(--bitfun-text-secondary, #b0b0b0);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.status::before {
+  content: ''; width: 6px; height: 6px; border-radius: 50%; background: currentColor;
+}
+.status--ok { color: var(--bitfun-success, #34d399); }
+.status--err { color: var(--bitfun-error, #ef4444); background: color-mix(in srgb, var(--bitfun-error, #ef4444) 12%, transparent); }
+.status--idle { color: var(--bitfun-text-muted, #858585); }
+
+/* ── Layout ──────────────────────────────────────────── */
+.layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 16px;
+  padding: 16px 20px;
+  min-height: 0;
+  overflow: hidden;
+}
+.main-col, .side-col {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 0;
+}
+.side-col { overflow-y: auto; }
+.main-col { min-width: 0; }
+
+/* ── Card ────────────────────────────────────────────── */
+.card {
+  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 96%, transparent);
+  border: 1px solid var(--bitfun-border-subtle, #27272a);
+  border-radius: 12px;
+  padding: 14px 16px;
+}
+.card__title {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12px;
+  color: var(--bitfun-text-secondary, #b0b0b0);
+  margin-bottom: 12px;
+  font-weight: 500;
+}
+.hint { margin-left: auto; font-size: 10px; color: var(--bitfun-text-muted, #858585); font-weight: 400; }
+
+/* ── Pattern row ─────────────────────────────────────── */
+.pattern-card { padding: 12px 14px; }
+.pattern-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--bitfun-bg, #121214);
+  border: 1px solid var(--bitfun-border, #2e2e32);
+  border-radius: 10px;
+  padding: 6px 10px;
+  transition: border-color .15s ease, box-shadow .15s ease;
+}
+.pattern-row:focus-within {
+  border-color: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 60%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--bitfun-accent, #60a5fa) 18%, transparent);
+}
+.slash {
+  color: var(--bitfun-accent, #60a5fa);
+  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-size: 16px;
+  user-select: none;
+}
+.pattern-input {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  outline: none;
+  color: var(--bitfun-text, #e8e8e8);
+  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-size: 14px;
+  padding: 6px 0;
+}
+.flags { display: flex; gap: 2px; }
+.flag {
+  width: 24px; height: 24px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: var(--bitfun-element-bg, #27272a);
+  color: var(--bitfun-text-muted, #858585);
+  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: all .12s ease;
+}
+.flag:hover { color: var(--bitfun-text, #e8e8e8); }
+.flag.is-active {
+  background: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 22%, transparent);
+  color: var(--bitfun-accent, #60a5fa);
+  border-color: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 50%, transparent);
+}
+.pattern-error {
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--bitfun-error, #ef4444);
+  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+}
+
+/* ── Test editor (overlay highlight) ─────────────────── */
+.test-card { display: flex; flex-direction: column; min-height: 0; flex: 1; }
+.test-card__header {
+  display: flex; align-items: center; justify-content: space-between;
+}
+.test-card__actions { display: flex; align-items: center; gap: 10px; }
+.match-count { font-size: 11px; color: var(--bitfun-text-muted, #858585); font-variant-numeric: tabular-nums; }
+.link-btn {
+  background: transparent;
+  border: 1px solid var(--bitfun-border, #2e2e32);
+  color: var(--bitfun-text-secondary, #b0b0b0);
+  padding: 4px 9px;
+  border-radius: 7px;
+  font-size: 11px;
+  display: inline-flex; align-items: center; gap: 5px;
+  transition: all .15s ease;
+}
+.link-btn:hover { color: var(--bitfun-text, #e8e8e8); background: var(--bitfun-element-bg, #27272a); }
+
+.editor {
+  position: relative;
+  flex: 1;
+  min-height: 200px;
+  border: 1px solid var(--bitfun-border, #2e2e32);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--bitfun-bg, #121214);
+}
+.editor textarea, .editor .highlight {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  padding: 12px 14px;
+  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-size: 13px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+  border: 0;
+  margin: 0;
+  overflow: auto;
+  tab-size: 2;
+}
+.editor textarea {
+  background: transparent;
+  color: var(--bitfun-text, #e8e8e8);
+  caret-color: var(--bitfun-accent, #60a5fa);
+  resize: none;
+  outline: none;
+  z-index: 2;
+}
+.editor .highlight {
+  pointer-events: none;
+  color: transparent;
+  z-index: 1;
+}
+.editor .highlight mark {
+  background: color-mix(in srgb, var(--bitfun-warning, #f59e0b) 28%, transparent);
+  color: transparent;
+  border-radius: 3px;
+  padding: 1px 0;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--bitfun-warning, #f59e0b) 40%, transparent);
+}
+.editor .highlight mark.is-active {
+  background: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 30%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--bitfun-accent, #60a5fa) 60%, transparent);
+}
+
+/* ── Replace ─────────────────────────────────────────── */
+.replace-input {
+  width: 100%;
+  background: var(--bitfun-bg, #121214);
+  border: 1px solid var(--bitfun-border, #2e2e32);
+  color: var(--bitfun-text, #e8e8e8);
+  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-size: 13px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  outline: none;
+  transition: border-color .15s ease;
+}
+.replace-input:focus {
+  border-color: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 60%, transparent);
+}
+.replace-output {
+  margin: 10px 0 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--bitfun-bg, #121214);
+  border: 1px solid var(--bitfun-border-subtle, #27272a);
+  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--bitfun-text-secondary, #b0b0b0);
+  max-height: 160px;
+  overflow: auto;
+}
+
+/* ── Matches list ────────────────────────────────────── */
+.matches-card { display: flex; flex-direction: column; min-height: 0; flex: 1; }
+.matches {
+  flex: 1;
+  overflow-y: auto;
+  display: flex; flex-direction: column;
+  gap: 8px;
+  padding-right: 2px;
+}
+.empty { color: var(--bitfun-text-muted, #858585); font-size: 11.5px; padding: 8px 0; }
+.match {
+  background: var(--bitfun-element-bg, #27272a);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 8px 10px;
+  cursor: pointer;
+  transition: all .12s ease;
+}
+.match:hover { border-color: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 50%, transparent); }
+.match.is-active { border-color: var(--bitfun-accent, #60a5fa); }
+.match__head {
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 11px; color: var(--bitfun-text-muted, #858585);
+}
+.match__index { color: var(--bitfun-accent, #60a5fa); font-weight: 600; }
+.match__text {
+  margin-top: 4px;
+  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  color: var(--bitfun-text, #e8e8e8);
+  word-break: break-all;
+}
+.match__groups {
+  margin-top: 6px;
+  display: flex; flex-direction: column; gap: 3px;
+}
+.match__group {
+  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--bitfun-text-secondary, #b0b0b0);
+}
+.match__group b { color: var(--bitfun-warning, #f59e0b); font-weight: 600; }
+
+/* ── Library ─────────────────────────────────────────── */
+.library { display: flex; flex-direction: column; gap: 6px; }
+.lib-item {
+  background: var(--bitfun-element-bg, #27272a);
+  border: 1px solid transparent;
+  padding: 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all .12s ease;
+}
+.lib-item:hover { border-color: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 50%, transparent); }
+.lib-item__name { font-size: 12px; color: var(--bitfun-text, #e8e8e8); margin-bottom: 2px; }
+.lib-item__pattern {
+  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-size: 10.5px;
+  color: var(--bitfun-text-muted, #858585);
+  word-break: break-all;
+}
+
+/* ── Ref ─────────────────────────────────────────────── */
+.ref { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.ref li { font-size: 11.5px; color: var(--bitfun-text-secondary, #b0b0b0); }
+.ref code {
+  background: var(--bitfun-element-bg, #27272a);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  color: var(--bitfun-accent, #60a5fa);
+  font-size: 11px;
+  margin-right: 2px;
+}
+
+/* ── Scrollbar ──────────────────────────────────────── */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-thumb { background: var(--bitfun-scrollbar-thumb, rgba(255,255,255,0.12)); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--bitfun-scrollbar-thumb-hover, rgba(255,255,255,0.22)); }
+
+/* ── Responsive ──────────────────────────────────────── */
+@media (max-width: 880px) {
+  .layout { grid-template-columns: 1fr; }
+  .side-col { max-height: 280px; }
+}

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/style.css
@@ -1,5 +1,6 @@
 *, *::before, *::after { box-sizing: border-box; }
 body, html { margin: 0; padding: 0; height: 100%; }
+[hidden] { display: none !important; }
 
 body {
   font-family: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/style.css
@@ -1,79 +1,131 @@
+/* Regex Playground — IDE / terminal theme.
+ * Palette inspired by Tokyo-Night-ish editor: deep ink, indigo blue,
+ * pastel green/orange/pink/purple as syntax accents.
+ * Type: monospace first; sans only for very small UI labels.
+ */
+
 *, *::before, *::after { box-sizing: border-box; }
 body, html { margin: 0; padding: 0; height: 100%; }
 [hidden] { display: none !important; }
 
+:root {
+  --rx-bg: #0d1117;
+  --rx-bg-2: #11161f;
+  --rx-panel: #151b27;
+  --rx-panel-2: #1a2030;
+  --rx-line: #1f2733;
+  --rx-line-bright: #2c3548;
+  --rx-text: #c0caf5;
+  --rx-text-soft: #a9b1d6;
+  --rx-text-mute: #565f89;
+  --rx-blue: #7aa2f7;
+  --rx-cyan: #7dcfff;
+  --rx-green: #9ece6a;
+  --rx-orange: #e0af68;
+  --rx-pink: #f7768e;
+  --rx-purple: #bb9af7;
+  --rx-mono: var(--bitfun-font-mono, ui-monospace, "JetBrains Mono", "Fira Code",
+              "SFMono-Regular", Menlo, "Cascadia Code", Consolas, monospace);
+  --rx-sans: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+}
+
 body {
-  font-family: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  font-family: var(--rx-mono);
   font-size: 13px;
-  color: var(--bitfun-text, #e8e8e8);
-  background: var(--bitfun-bg, #121214);
+  color: var(--rx-text);
+  background: var(--rx-bg);
   overflow: hidden;
 }
-button { font-family: inherit; cursor: pointer; }
-input, textarea { font-family: inherit; }
+button, input, textarea { font-family: inherit; }
 
 .rx {
   height: 100vh;
   display: flex;
   flex-direction: column;
   background:
-    radial-gradient(800px 400px at 100% -10%, color-mix(in srgb, var(--bitfun-accent, #60a5fa) 7%, transparent), transparent 60%),
-    var(--bitfun-bg, #121214);
+    linear-gradient(180deg, #0e141d 0%, var(--rx-bg) 100%);
 }
 
-/* ── Top bar ─────────────────────────────────────────── */
+/* ── Top bar — IDE titlebar ──────────────────────────── */
 .topbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 20px;
-  border-bottom: 1px solid var(--bitfun-border-subtle, #27272a);
-  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 80%, transparent);
-  backdrop-filter: blur(10px);
+  padding: 9px 16px;
+  border-bottom: 1px solid var(--rx-line);
+  background: var(--rx-bg-2);
+  font-family: var(--rx-mono);
 }
 .brand { display: flex; align-items: center; gap: 12px; }
 .brand__icon {
-  width: 34px; height: 34px;
-  border-radius: 9px;
-  background: linear-gradient(135deg, color-mix(in srgb, var(--bitfun-accent, #60a5fa) 35%, transparent), color-mix(in srgb, var(--bitfun-accent, #60a5fa) 12%, transparent));
-  border: 1px solid var(--bitfun-border, #2e2e32);
+  width: 28px; height: 28px;
+  border-radius: 6px;
+  background: linear-gradient(135deg, rgba(122,162,247,0.18), rgba(187,154,247,0.10));
+  border: 1px solid var(--rx-line-bright);
   display: flex; align-items: center; justify-content: center;
-  color: var(--bitfun-accent, #60a5fa);
+  color: var(--rx-blue);
 }
-.brand__title { margin: 0; font-size: 14px; font-weight: 600; }
-.brand__subtitle { margin: 1px 0 0; font-size: 11px; color: var(--bitfun-text-muted, #858585); }
+.brand__title {
+  margin: 0;
+  font-family: var(--rx-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--rx-text);
+  letter-spacing: 0;
+}
+.brand__title::before {
+  content: '~/';
+  color: var(--rx-text-mute);
+  font-weight: 400;
+  margin-right: 2px;
+}
+.brand__subtitle {
+  margin: 1px 0 0;
+  font-family: var(--rx-mono);
+  font-size: 11px;
+  color: var(--rx-text-mute);
+}
+.brand__subtitle::before {
+  content: '// ';
+  color: var(--rx-green);
+}
 
+/* IDE-style status pill */
 .status {
+  font-family: var(--rx-mono);
   font-size: 11px;
   padding: 4px 10px;
-  border-radius: 999px;
-  background: var(--bitfun-element-bg, #27272a);
-  color: var(--bitfun-text-secondary, #b0b0b0);
+  border-radius: 4px;
+  background: var(--rx-panel);
+  color: var(--rx-text-soft);
+  border: 1px solid var(--rx-line-bright);
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
+  letter-spacing: 0.3px;
 }
 .status::before {
   content: ''; width: 6px; height: 6px; border-radius: 50%; background: currentColor;
+  box-shadow: 0 0 6px currentColor;
 }
-.status--ok { color: var(--bitfun-success, #34d399); }
-.status--err { color: var(--bitfun-error, #ef4444); background: color-mix(in srgb, var(--bitfun-error, #ef4444) 12%, transparent); }
-.status--idle { color: var(--bitfun-text-muted, #858585); }
+.status--ok { color: var(--rx-green); border-color: rgba(158,206,106,0.35); }
+.status--err { color: var(--rx-pink); border-color: rgba(247,118,142,0.35); background: rgba(247,118,142,0.06); }
+.status--idle { color: var(--rx-text-mute); }
 
 /* ── Layout ──────────────────────────────────────────── */
 .layout {
   flex: 1;
   display: grid;
   grid-template-columns: 1fr 320px;
-  gap: 16px;
-  padding: 16px 20px;
+  gap: 14px;
+  padding: 14px 16px;
   min-height: 0;
   overflow: hidden;
 }
 .main-col, .side-col {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
   min-height: 0;
 }
 .side-col { overflow-y: auto; }
@@ -81,40 +133,59 @@ input, textarea { font-family: inherit; }
 
 /* ── Card ────────────────────────────────────────────── */
 .card {
-  background: color-mix(in srgb, var(--bitfun-bg-secondary, #18181a) 96%, transparent);
-  border: 1px solid var(--bitfun-border-subtle, #27272a);
-  border-radius: 12px;
-  padding: 14px 16px;
+  background: var(--rx-panel);
+  border: 1px solid var(--rx-line);
+  border-radius: 6px;
+  padding: 12px 14px;
 }
 .card__title {
   display: flex; align-items: center; gap: 8px;
-  font-size: 12px;
-  color: var(--bitfun-text-secondary, #b0b0b0);
-  margin-bottom: 12px;
+  font-family: var(--rx-mono);
+  font-size: 11.5px;
+  color: var(--rx-text-soft);
+  margin-bottom: 10px;
   font-weight: 500;
+  letter-spacing: 0.3px;
+  text-transform: lowercase;
 }
-.hint { margin-left: auto; font-size: 10px; color: var(--bitfun-text-muted, #858585); font-weight: 400; }
+.card__title svg { color: var(--rx-blue); }
+.hint {
+  margin-left: auto;
+  font-family: var(--rx-mono);
+  font-size: 10.5px;
+  color: var(--rx-text-mute);
+  font-weight: 400;
+}
 
-/* ── Pattern row ─────────────────────────────────────── */
-.pattern-card { padding: 12px 14px; }
+/* ── Pattern row — looks like an interactive REPL line */
+.pattern-card { padding: 10px 12px; }
 .pattern-row {
   display: flex;
   align-items: center;
   gap: 6px;
-  background: var(--bitfun-bg, #121214);
-  border: 1px solid var(--bitfun-border, #2e2e32);
-  border-radius: 10px;
-  padding: 6px 10px;
+  background: var(--rx-bg);
+  border: 1px solid var(--rx-line-bright);
+  border-radius: 5px;
+  padding: 6px 10px 6px 12px;
   transition: border-color .15s ease, box-shadow .15s ease;
+  position: relative;
+}
+.pattern-row::before {
+  content: '$';
+  color: var(--rx-green);
+  font-family: var(--rx-mono);
+  font-size: 13px;
+  margin-right: 4px;
+  user-select: none;
 }
 .pattern-row:focus-within {
-  border-color: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 60%, transparent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--bitfun-accent, #60a5fa) 18%, transparent);
+  border-color: var(--rx-blue);
+  box-shadow: 0 0 0 3px rgba(122,162,247,0.18);
 }
 .slash {
-  color: var(--bitfun-accent, #60a5fa);
-  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
-  font-size: 16px;
+  color: var(--rx-orange);
+  font-family: var(--rx-mono);
+  font-size: 15px;
   user-select: none;
 }
 .pattern-input {
@@ -122,71 +193,84 @@ input, textarea { font-family: inherit; }
   background: transparent;
   border: 0;
   outline: none;
-  color: var(--bitfun-text, #e8e8e8);
-  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  color: var(--rx-text);
+  font-family: var(--rx-mono);
   font-size: 14px;
   padding: 6px 0;
+  caret-color: var(--rx-blue);
 }
-.flags { display: flex; gap: 2px; }
+.pattern-input::placeholder { color: var(--rx-text-mute); }
+.flags { display: flex; gap: 3px; }
 .flag {
   width: 24px; height: 24px;
-  border-radius: 6px;
-  border: 1px solid transparent;
-  background: var(--bitfun-element-bg, #27272a);
-  color: var(--bitfun-text-muted, #858585);
-  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  border-radius: 4px;
+  border: 1px solid var(--rx-line-bright);
+  background: var(--rx-bg-2);
+  color: var(--rx-text-mute);
+  font-family: var(--rx-mono);
   font-size: 12px;
   display: inline-flex; align-items: center; justify-content: center;
   transition: all .12s ease;
 }
-.flag:hover { color: var(--bitfun-text, #e8e8e8); }
+.flag:hover { color: var(--rx-text-soft); border-color: var(--rx-blue); }
 .flag.is-active {
-  background: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 22%, transparent);
-  color: var(--bitfun-accent, #60a5fa);
-  border-color: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 50%, transparent);
+  background: rgba(122,162,247,0.18);
+  color: var(--rx-blue);
+  border-color: rgba(122,162,247,0.55);
+  box-shadow: 0 0 8px rgba(122,162,247,0.20);
 }
 .pattern-error {
   margin-top: 8px;
+  font-family: var(--rx-mono);
   font-size: 11px;
-  color: var(--bitfun-error, #ef4444);
-  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  color: var(--rx-pink);
+  padding: 6px 10px;
+  background: rgba(247,118,142,0.06);
+  border-left: 2px solid var(--rx-pink);
+  border-radius: 0 4px 4px 0;
 }
 
-/* ── Test editor (overlay highlight) ─────────────────── */
+/* ── Test editor — looks like editor panel ───────────── */
 .test-card { display: flex; flex-direction: column; min-height: 0; flex: 1; }
 .test-card__header {
   display: flex; align-items: center; justify-content: space-between;
 }
 .test-card__actions { display: flex; align-items: center; gap: 10px; }
-.match-count { font-size: 11px; color: var(--bitfun-text-muted, #858585); font-variant-numeric: tabular-nums; }
+.match-count {
+  font-family: var(--rx-mono);
+  font-size: 11px;
+  color: var(--rx-text-mute);
+  font-variant-numeric: tabular-nums;
+}
 .link-btn {
-  background: transparent;
-  border: 1px solid var(--bitfun-border, #2e2e32);
-  color: var(--bitfun-text-secondary, #b0b0b0);
+  background: var(--rx-bg-2);
+  border: 1px solid var(--rx-line-bright);
+  color: var(--rx-text-soft);
   padding: 4px 9px;
-  border-radius: 7px;
+  border-radius: 4px;
+  font-family: var(--rx-mono);
   font-size: 11px;
   display: inline-flex; align-items: center; gap: 5px;
   transition: all .15s ease;
 }
-.link-btn:hover { color: var(--bitfun-text, #e8e8e8); background: var(--bitfun-element-bg, #27272a); }
+.link-btn:hover { color: var(--rx-text); border-color: var(--rx-blue); }
 
 .editor {
   position: relative;
   flex: 1;
   min-height: 200px;
-  border: 1px solid var(--bitfun-border, #2e2e32);
-  border-radius: 8px;
+  border: 1px solid var(--rx-line-bright);
+  border-radius: 5px;
   overflow: hidden;
-  background: var(--bitfun-bg, #121214);
+  background: var(--rx-bg);
 }
 .editor textarea, .editor .highlight {
   position: absolute; inset: 0;
   width: 100%; height: 100%;
   padding: 12px 14px;
-  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-family: var(--rx-mono);
   font-size: 13px;
-  line-height: 1.55;
+  line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;
   border: 0;
@@ -196,8 +280,8 @@ input, textarea { font-family: inherit; }
 }
 .editor textarea {
   background: transparent;
-  color: var(--bitfun-text, #e8e8e8);
-  caret-color: var(--bitfun-accent, #60a5fa);
+  color: var(--rx-text);
+  caret-color: var(--rx-blue);
   resize: none;
   outline: none;
   z-index: 2;
@@ -208,50 +292,54 @@ input, textarea { font-family: inherit; }
   z-index: 1;
 }
 .editor .highlight mark {
-  background: color-mix(in srgb, var(--bitfun-warning, #f59e0b) 28%, transparent);
+  background: rgba(224,175,104,0.22);
   color: transparent;
-  border-radius: 3px;
+  border-radius: 2px;
   padding: 1px 0;
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--bitfun-warning, #f59e0b) 40%, transparent);
+  box-shadow: 0 0 0 1px rgba(224,175,104,0.55);
 }
 .editor .highlight mark.is-active {
-  background: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 30%, transparent);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--bitfun-accent, #60a5fa) 60%, transparent);
+  background: rgba(122,162,247,0.32);
+  box-shadow: 0 0 0 1px var(--rx-blue), 0 0 8px rgba(122,162,247,0.45);
 }
 
 /* ── Replace ─────────────────────────────────────────── */
 .replace-input {
   width: 100%;
-  background: var(--bitfun-bg, #121214);
-  border: 1px solid var(--bitfun-border, #2e2e32);
-  color: var(--bitfun-text, #e8e8e8);
-  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  background: var(--rx-bg);
+  border: 1px solid var(--rx-line-bright);
+  color: var(--rx-text);
+  font-family: var(--rx-mono);
   font-size: 13px;
   padding: 8px 10px;
-  border-radius: 8px;
+  border-radius: 4px;
   outline: none;
+  caret-color: var(--rx-blue);
   transition: border-color .15s ease;
 }
+.replace-input::placeholder { color: var(--rx-text-mute); }
 .replace-input:focus {
-  border-color: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 60%, transparent);
+  border-color: var(--rx-blue);
+  box-shadow: 0 0 0 3px rgba(122,162,247,0.18);
 }
 .replace-output {
   margin: 10px 0 0;
   padding: 10px 12px;
-  border-radius: 8px;
-  background: var(--bitfun-bg, #121214);
-  border: 1px solid var(--bitfun-border-subtle, #27272a);
-  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  border-radius: 4px;
+  background: var(--rx-bg);
+  border: 1px solid var(--rx-line);
+  border-left: 2px solid var(--rx-green);
+  font-family: var(--rx-mono);
   font-size: 12px;
   white-space: pre-wrap;
   word-break: break-word;
-  color: var(--bitfun-text-secondary, #b0b0b0);
+  color: var(--rx-text-soft);
   max-height: 160px;
   overflow: auto;
 }
 
 /* ── Matches list ────────────────────────────────────── */
-.matches-card { display: flex; flex-direction: column; min-height: 0; padding: 12px 14px; }
+.matches-card { display: flex; flex-direction: column; min-height: 0; padding: 10px 14px 12px; }
 .matches-card__header {
   display: flex; align-items: center; justify-content: space-between;
   margin-bottom: 10px;
@@ -271,44 +359,48 @@ input, textarea { font-family: inherit; }
 .matches:empty { display: none; }
 .empty {
   grid-column: 1 / -1;
-  color: var(--bitfun-text-muted, #858585);
+  color: var(--rx-text-mute);
+  font-family: var(--rx-mono);
   font-size: 11.5px;
   padding: 8px 0;
 }
 .match {
-  background: var(--bitfun-element-bg, #27272a);
-  border: 1px solid transparent;
-  border-radius: 8px;
+  background: var(--rx-bg-2);
+  border: 1px solid var(--rx-line);
+  border-left: 2px solid var(--rx-orange);
+  border-radius: 4px;
   padding: 8px 10px;
   cursor: pointer;
   transition: all .12s ease;
   min-width: 0;
 }
-.match:hover { border-color: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 50%, transparent); }
+.match:hover { border-color: var(--rx-line-bright); border-left-color: var(--rx-blue); }
 .match.is-active {
-  border-color: var(--bitfun-accent, #60a5fa);
-  background: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 10%, var(--bitfun-element-bg, #27272a));
+  border-color: var(--rx-blue);
+  border-left-color: var(--rx-blue);
+  background: rgba(122,162,247,0.08);
 }
 .match__head {
   display: flex; align-items: center; justify-content: space-between;
-  font-size: 11px; color: var(--bitfun-text-muted, #858585);
+  font-family: var(--rx-mono);
+  font-size: 11px; color: var(--rx-text-mute);
   font-variant-numeric: tabular-nums;
 }
 .match__index {
-  color: var(--bitfun-accent, #60a5fa);
+  color: var(--rx-orange);
   font-weight: 600;
-  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-family: var(--rx-mono);
 }
-.match__loc { font-family: var(--bitfun-font-mono, ui-monospace, monospace); }
+.match__loc { font-family: var(--rx-mono); }
 .match__text {
   margin-top: 5px;
-  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-family: var(--rx-mono);
   font-size: 12px;
-  color: var(--bitfun-text, #e8e8e8);
+  color: var(--rx-text);
   word-break: break-all;
-  background: var(--bitfun-bg, #121214);
-  border: 1px solid var(--bitfun-border-subtle, #27272a);
-  border-radius: 6px;
+  background: var(--rx-bg);
+  border: 1px solid var(--rx-line);
+  border-radius: 3px;
   padding: 5px 7px;
   max-height: 60px;
   overflow: hidden;
@@ -317,65 +409,88 @@ input, textarea { font-family: inherit; }
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }
-.match__text--empty { color: var(--bitfun-text-muted, #858585); font-style: italic; }
+.match__text--empty { color: var(--rx-text-mute); font-style: italic; }
 .match__groups {
   margin-top: 7px;
   display: flex; flex-direction: column; gap: 3px;
-  border-top: 1px dashed var(--bitfun-border-subtle, #27272a);
+  border-top: 1px dashed var(--rx-line-bright);
   padding-top: 6px;
 }
 .match__group {
-  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-family: var(--rx-mono);
   font-size: 11px;
-  color: var(--bitfun-text-secondary, #b0b0b0);
+  color: var(--rx-text-soft);
   display: flex;
   gap: 6px;
   word-break: break-all;
 }
 .match__group-tag {
-  color: var(--bitfun-warning, #f59e0b);
+  color: var(--rx-purple);
   font-weight: 600;
   flex-shrink: 0;
 }
-.match__group-val { min-width: 0; }
-.match__group-val--empty { opacity: 0.5; font-style: italic; }
+.match__group-val { min-width: 0; color: var(--rx-green); }
+.match__group-val--empty { opacity: 0.5; font-style: italic; color: var(--rx-text-mute); }
 
-/* ── Library ─────────────────────────────────────────── */
+/* ── Library — code-snippet style cards ──────────────── */
+.library-card .card__title::before {
+  content: '> ';
+  color: var(--rx-green);
+}
 .library { display: flex; flex-direction: column; gap: 6px; }
 .lib-item {
-  background: var(--bitfun-element-bg, #27272a);
-  border: 1px solid transparent;
+  background: var(--rx-bg-2);
+  border: 1px solid var(--rx-line);
+  border-left: 2px solid var(--rx-purple);
   padding: 8px 10px;
-  border-radius: 8px;
+  border-radius: 4px;
   cursor: pointer;
   transition: all .12s ease;
 }
-.lib-item:hover { border-color: color-mix(in srgb, var(--bitfun-accent, #60a5fa) 50%, transparent); }
-.lib-item__name { font-size: 12px; color: var(--bitfun-text, #e8e8e8); margin-bottom: 2px; }
+.lib-item:hover {
+  border-color: var(--rx-line-bright);
+  border-left-color: var(--rx-blue);
+}
+.lib-item__name {
+  font-family: var(--rx-sans);
+  font-size: 12px;
+  color: var(--rx-text);
+  margin-bottom: 3px;
+}
 .lib-item__pattern {
-  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
+  font-family: var(--rx-mono);
   font-size: 10.5px;
-  color: var(--bitfun-text-muted, #858585);
+  color: var(--rx-cyan);
   word-break: break-all;
 }
 
 /* ── Ref ─────────────────────────────────────────────── */
-.ref { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
-.ref li { font-size: 11.5px; color: var(--bitfun-text-secondary, #b0b0b0); }
+.ref-card .card__title::before {
+  content: '? ';
+  color: var(--rx-orange);
+}
+.ref { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.ref li {
+  font-family: var(--rx-sans);
+  font-size: 11.5px;
+  color: var(--rx-text-soft);
+  line-height: 1.55;
+}
 .ref code {
-  background: var(--bitfun-element-bg, #27272a);
+  background: var(--rx-bg);
+  border: 1px solid var(--rx-line-bright);
   padding: 1px 6px;
-  border-radius: 4px;
-  font-family: var(--bitfun-font-mono, ui-monospace, monospace);
-  color: var(--bitfun-accent, #60a5fa);
+  border-radius: 3px;
+  font-family: var(--rx-mono);
+  color: var(--rx-cyan);
   font-size: 11px;
   margin-right: 2px;
 }
 
 /* ── Scrollbar ──────────────────────────────────────── */
 ::-webkit-scrollbar { width: 8px; height: 8px; }
-::-webkit-scrollbar-thumb { background: var(--bitfun-scrollbar-thumb, rgba(255,255,255,0.12)); border-radius: 4px; }
-::-webkit-scrollbar-thumb:hover { background: var(--bitfun-scrollbar-thumb-hover, rgba(255,255,255,0.22)); }
+::-webkit-scrollbar-thumb { background: rgba(122,162,247,0.18); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: rgba(122,162,247,0.32); }
 
 /* ── Responsive ──────────────────────────────────────── */
 @media (max-width: 880px) {

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/ui.js
@@ -41,11 +41,16 @@ const dom = {
   matchCount: document.getElementById('match-count'),
   btnClear: document.getElementById('btn-clear'),
   matches: document.getElementById('matches'),
+  matchesSummary: document.getElementById('matches-summary'),
+  btnPrevMatch: document.getElementById('btn-prev-match'),
+  btnNextMatch: document.getElementById('btn-next-match'),
   library: document.getElementById('library'),
   replaceInput: document.getElementById('replace-input'),
   replaceOutput: document.getElementById('replace-output'),
   statusPill: document.getElementById('status-pill'),
 };
+
+let lastMatches = [];
 
 const state = {
   flags: new Set(['g', 'm']),
@@ -114,6 +119,16 @@ function bindEditorSync() {
     recompute();
     dom.testText.focus();
   });
+  dom.btnPrevMatch.addEventListener('click', () => stepActiveMatch(-1));
+  dom.btnNextMatch.addEventListener('click', () => stepActiveMatch(1));
+}
+
+function stepActiveMatch(delta) {
+  if (lastMatches.length === 0) return;
+  const next = state.activeMatchIndex < 0
+    ? (delta > 0 ? 0 : lastMatches.length - 1)
+    : (state.activeMatchIndex + delta + lastMatches.length) % lastMatches.length;
+  selectMatch(next, true);
 }
 
 async function restore() {
@@ -206,7 +221,11 @@ function recompute() {
     dom.statusPill.textContent = '语法错误';
     dom.statusPill.className = 'status status--err';
     dom.matchCount.textContent = '— 处匹配';
+    dom.matchesSummary.textContent = '正则语法错误';
     dom.matches.innerHTML = `<div class="empty">${escapeHtml(compiled.error)}</div>`;
+    lastMatches = [];
+    state.activeMatchIndex = -1;
+    updateNavButtons();
     renderHighlight([]);
     renderReplace();
     return;
@@ -216,18 +235,31 @@ function recompute() {
 
   const text = dom.testText.value;
   const matches = findAllMatches(compiled.regex, text);
+  lastMatches = matches;
   dom.matchCount.textContent = `${matches.length} 处匹配`;
   if (matches.length === 0) {
     dom.statusPill.textContent = '无匹配';
     dom.statusPill.className = 'status status--idle';
+    dom.matchesSummary.textContent = text ? '无匹配' : '尚未匹配';
   } else {
     dom.statusPill.textContent = `命中 ${matches.length} 处`;
     dom.statusPill.className = 'status status--ok';
+    const totalGroups = matches.reduce((acc, m) => acc + m.groups.length + m.namedGroups.length, 0);
+    dom.matchesSummary.textContent = totalGroups > 0
+      ? `${matches.length} 处 · ${totalGroups} 个分组`
+      : `${matches.length} 处`;
   }
   state.activeMatchIndex = -1;
+  updateNavButtons();
   renderHighlight(matches);
   renderMatches(matches);
   renderReplace();
+}
+
+function updateNavButtons() {
+  const has = lastMatches.length > 0;
+  dom.btnPrevMatch.disabled = !has;
+  dom.btnNextMatch.disabled = !has;
 }
 
 // ── Render helpers ───────────────────────────────────
@@ -255,44 +287,69 @@ function renderMatches(matches) {
     return;
   }
   dom.matches.innerHTML = '';
+  const text = dom.testText.value;
   matches.forEach((m, i) => {
     const el = document.createElement('div');
     el.className = 'match';
-    let groupsHtml = '';
+    el.dataset.idx = String(i);
     const allGroups = [...m.groups, ...m.namedGroups];
+    let groupsHtml = '';
     if (allGroups.length > 0) {
       groupsHtml = '<div class="match__groups">' + allGroups.map((g) => {
         const tag = g.name != null ? `&lt;${escapeHtml(g.name)}&gt;` : `$${g.idx}`;
-        const val = g.value === undefined ? '<i style="opacity:.5">undefined</i>' : escapeHtml(g.value);
-        return `<div class="match__group"><b>${tag}</b> = ${val}</div>`;
+        const val = g.value === undefined || g.value === ''
+          ? `<span class="match__group-val match__group-val--empty">${g.value === undefined ? 'undefined' : '(空)'}</span>`
+          : `<span class="match__group-val">${escapeHtml(g.value)}</span>`;
+        return `<div class="match__group"><span class="match__group-tag">${tag}</span>${val}</div>`;
       }).join('') + '</div>';
     }
+    const { line, col } = lineColAt(text, m.index);
+    const isEmpty = m.text === '';
+    const matchTextHtml = isEmpty
+      ? '<div class="match__text match__text--empty">空匹配（零宽）</div>'
+      : `<div class="match__text" title="${escapeHtml(m.text)}">${escapeHtml(m.text)}</div>`;
     el.innerHTML = `
       <div class="match__head">
         <span class="match__index">#${i + 1}</span>
-        <span>idx ${m.index}–${m.end}</span>
+        <span class="match__loc">L${line}:${col} · ${m.index}–${m.end}</span>
       </div>
-      <div class="match__text">${escapeHtml(m.text) || '<i style="opacity:.5">空匹配</i>'}</div>
+      ${matchTextHtml}
       ${groupsHtml}
     `;
-    el.addEventListener('click', () => {
-      state.activeMatchIndex = i;
-      for (const node of dom.matches.querySelectorAll('.match')) node.classList.remove('is-active');
-      el.classList.add('is-active');
-      // Highlight active mark in overlay
-      for (const mk of dom.highlight.querySelectorAll('mark')) mk.classList.remove('is-active');
-      const target = dom.highlight.querySelector(`mark[data-idx="${i}"]`);
-      if (target) target.classList.add('is-active');
-      // Scroll textarea to the match
-      const before = dom.testText.value.slice(0, m.index);
-      const lineNo = before.split('\n').length - 1;
-      const lineHeight = 13 * 1.55;
-      dom.testText.scrollTop = Math.max(0, lineNo * lineHeight - 60);
-      dom.testText.setSelectionRange(m.index, m.end);
-      dom.testText.focus();
-    });
+    el.addEventListener('click', () => selectMatch(i, true));
     dom.matches.appendChild(el);
   });
+}
+
+function selectMatch(i, scrollIntoText) {
+  state.activeMatchIndex = i;
+  const m = lastMatches[i];
+  if (!m) return;
+  for (const node of dom.matches.querySelectorAll('.match')) {
+    node.classList.toggle('is-active', node.dataset.idx === String(i));
+  }
+  const activeCard = dom.matches.querySelector(`.match[data-idx="${i}"]`);
+  if (activeCard) activeCard.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  for (const mk of dom.highlight.querySelectorAll('mark')) mk.classList.remove('is-active');
+  const target = dom.highlight.querySelector(`mark[data-idx="${i}"]`);
+  if (target) target.classList.add('is-active');
+  if (scrollIntoText) {
+    const before = dom.testText.value.slice(0, m.index);
+    const lineNo = before.split('\n').length - 1;
+    const lineHeight = 13 * 1.55;
+    dom.testText.scrollTop = Math.max(0, lineNo * lineHeight - 60);
+    dom.testText.setSelectionRange(m.index, m.end);
+    dom.testText.focus();
+  }
+}
+
+function lineColAt(text, offset) {
+  let line = 1;
+  let lastBreak = -1;
+  for (let i = 0; i < offset; i++) {
+    if (text.charCodeAt(i) === 10) { line += 1; lastBreak = i; }
+  }
+  return { line, col: offset - lastBreak };
 }
 
 function renderReplace() {

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/ui.js
@@ -1,0 +1,319 @@
+// Regex Playground — built-in MiniApp.
+// Real-time matching, capture groups, replace preview, and a quick pattern library.
+
+const PATTERN_LIBRARY = [
+  { name: '邮箱地址', pattern: "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}", flags: 'g' },
+  { name: '中国大陆手机号', pattern: "(?<!\\d)1[3-9]\\d{9}(?!\\d)", flags: 'g' },
+  { name: 'URL（http/https）', pattern: "https?:\\/\\/[\\w\\-._~:\\/?#\\[\\]@!$&'()*+,;=%]+", flags: 'gi' },
+  { name: 'IPv4 地址', pattern: "\\b(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)\\b", flags: 'g' },
+  { name: 'IPv6 地址（简化）', pattern: "([0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}", flags: 'g' },
+  { name: 'UUID v4', pattern: "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}", flags: 'gi' },
+  { name: '十六进制颜色', pattern: "#(?:[0-9a-fA-F]{3}){1,2}\\b", flags: 'g' },
+  { name: '日期 YYYY-MM-DD', pattern: "\\b(\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])\\b", flags: 'g' },
+  { name: '时间 HH:MM(:SS)', pattern: "\\b([01]?\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d)?\\b", flags: 'g' },
+  { name: 'Semver 版本号', pattern: "\\b\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?\\b", flags: 'g' },
+  { name: 'Git 短 SHA', pattern: "\\b[0-9a-f]{7,40}\\b", flags: 'g' },
+  { name: '驼峰标识符', pattern: "\\b[a-z]+(?:[A-Z][a-z0-9]*)+\\b", flags: 'g' },
+  { name: '中文字符', pattern: "[\\u4e00-\\u9fa5]+", flags: 'g' },
+  { name: '前后空白', pattern: "^[ \\t]+|[ \\t]+$", flags: 'gm' },
+  { name: '行首注释 //', pattern: "^\\s*\\/\\/.*$", flags: 'gm' },
+];
+
+const SAMPLE_TEXT = `# 把任意文本粘到这里，正则会实时高亮匹配项。
+
+联系：alice@example.com / 13800138000
+项目主页：https://github.com/cursor/bitfun
+内部 IP：192.168.1.10 与 10.0.0.1
+追踪 ID：8f2c3a01-4e6b-4d1c-9bb1-1f3a6d2c0a55
+今日发版 v1.4.0-beta.2，对应 commit 7a3f9d2
+
+// TODO: 抽取上面这一段为一个工具函数
+const userName = "Bitfun";
+`;
+
+// ── DOM ──────────────────────────────────────────────
+const dom = {
+  pattern: document.getElementById('pattern'),
+  flagsRow: document.getElementById('flags'),
+  patternError: document.getElementById('pattern-error'),
+  testText: document.getElementById('test-text'),
+  highlight: document.getElementById('highlight'),
+  matchCount: document.getElementById('match-count'),
+  btnClear: document.getElementById('btn-clear'),
+  matches: document.getElementById('matches'),
+  library: document.getElementById('library'),
+  replaceInput: document.getElementById('replace-input'),
+  replaceOutput: document.getElementById('replace-output'),
+  statusPill: document.getElementById('status-pill'),
+};
+
+const state = {
+  flags: new Set(['g', 'm']),
+  activeMatchIndex: -1,
+};
+
+// ── Init ─────────────────────────────────────────────
+async function init() {
+  buildLibrary();
+  bindFlags();
+  bindEditorSync();
+  await restore();
+  bindPersistence();
+  recompute();
+}
+
+function buildLibrary() {
+  dom.library.innerHTML = '';
+  for (const item of PATTERN_LIBRARY) {
+    const el = document.createElement('div');
+    el.className = 'lib-item';
+    el.innerHTML = `
+      <div class="lib-item__name">${escapeHtml(item.name)}</div>
+      <div class="lib-item__pattern">/${escapeHtml(item.pattern)}/${escapeHtml(item.flags)}</div>
+    `;
+    el.addEventListener('click', () => {
+      dom.pattern.value = item.pattern;
+      state.flags = new Set(item.flags.split(''));
+      syncFlagsUi();
+      recompute();
+      dom.pattern.focus();
+    });
+    dom.library.appendChild(el);
+  }
+}
+
+function bindFlags() {
+  syncFlagsUi();
+  dom.flagsRow.addEventListener('click', (e) => {
+    const btn = e.target.closest('.flag');
+    if (!btn) return;
+    const f = btn.dataset.flag;
+    if (state.flags.has(f)) state.flags.delete(f); else state.flags.add(f);
+    syncFlagsUi();
+    recompute();
+  });
+}
+
+function syncFlagsUi() {
+  for (const btn of dom.flagsRow.querySelectorAll('.flag')) {
+    btn.classList.toggle('is-active', state.flags.has(btn.dataset.flag));
+  }
+}
+
+function bindEditorSync() {
+  // Sync scroll between textarea and the highlight overlay.
+  dom.testText.addEventListener('scroll', () => {
+    dom.highlight.scrollTop = dom.testText.scrollTop;
+    dom.highlight.scrollLeft = dom.testText.scrollLeft;
+  });
+  dom.testText.addEventListener('input', recompute);
+  dom.pattern.addEventListener('input', recompute);
+  dom.replaceInput.addEventListener('input', renderReplace);
+  dom.btnClear.addEventListener('click', () => {
+    dom.testText.value = '';
+    recompute();
+    dom.testText.focus();
+  });
+}
+
+async function restore() {
+  let saved = null;
+  try { saved = await app.storage.get('regex-state'); } catch (_e) { /* ignore */ }
+  if (saved && typeof saved === 'object') {
+    dom.pattern.value = typeof saved.pattern === 'string' ? saved.pattern : '';
+    if (typeof saved.text === 'string') dom.testText.value = saved.text;
+    if (typeof saved.replacement === 'string') dom.replaceInput.value = saved.replacement;
+    if (Array.isArray(saved.flags) && saved.flags.length) state.flags = new Set(saved.flags);
+    syncFlagsUi();
+  }
+  if (!dom.pattern.value) dom.pattern.value = "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}";
+  if (!dom.testText.value) dom.testText.value = SAMPLE_TEXT;
+}
+
+function bindPersistence() {
+  const save = debounce(() => {
+    app.storage.set('regex-state', {
+      pattern: dom.pattern.value,
+      text: dom.testText.value,
+      replacement: dom.replaceInput.value,
+      flags: Array.from(state.flags),
+    }).catch(() => {});
+  }, 350);
+  for (const target of [dom.pattern, dom.testText, dom.replaceInput]) {
+    target.addEventListener('input', save);
+  }
+  dom.flagsRow.addEventListener('click', save);
+}
+
+function debounce(fn, delay) {
+  let t = null;
+  return (...args) => {
+    if (t) clearTimeout(t);
+    t = setTimeout(() => fn(...args), delay);
+  };
+}
+
+// ── Compile + match ──────────────────────────────────
+function compileRegex() {
+  const flagStr = Array.from(state.flags).join('');
+  try {
+    return { ok: true, regex: new RegExp(dom.pattern.value, flagStr) };
+  } catch (e) {
+    return { ok: false, error: String(e.message || e) };
+  }
+}
+
+function findAllMatches(regex, text) {
+  const out = [];
+  if (!text) return out;
+  const isGlobalLike = regex.global || regex.sticky;
+  if (!isGlobalLike) {
+    const m = regex.exec(text);
+    if (m) out.push(matchSnapshot(m));
+    return out;
+  }
+  let lastIndex = -1;
+  let safety = 0;
+  while (safety++ < 10000) {
+    const m = regex.exec(text);
+    if (!m) break;
+    if (m.index === lastIndex && m[0] === '') {
+      regex.lastIndex += 1;
+      continue;
+    }
+    lastIndex = m.index;
+    out.push(matchSnapshot(m));
+    if (m[0] === '') regex.lastIndex += 1;
+  }
+  return out;
+}
+
+function matchSnapshot(m) {
+  return {
+    text: m[0],
+    index: m.index,
+    end: m.index + m[0].length,
+    groups: m.slice(1).map((v, i) => ({ idx: i + 1, name: null, value: v })),
+    namedGroups: m.groups ? Object.entries(m.groups).map(([k, v]) => ({ idx: null, name: k, value: v })) : [],
+  };
+}
+
+function recompute() {
+  const compiled = compileRegex();
+  if (!compiled.ok) {
+    dom.patternError.hidden = false;
+    dom.patternError.textContent = compiled.error;
+    dom.statusPill.textContent = '语法错误';
+    dom.statusPill.className = 'status status--err';
+    dom.matchCount.textContent = '— 处匹配';
+    dom.matches.innerHTML = `<div class="empty">${escapeHtml(compiled.error)}</div>`;
+    renderHighlight([]);
+    renderReplace();
+    return;
+  }
+  dom.patternError.hidden = true;
+  dom.patternError.textContent = '';
+
+  const text = dom.testText.value;
+  const matches = findAllMatches(compiled.regex, text);
+  dom.matchCount.textContent = `${matches.length} 处匹配`;
+  if (matches.length === 0) {
+    dom.statusPill.textContent = '无匹配';
+    dom.statusPill.className = 'status status--idle';
+  } else {
+    dom.statusPill.textContent = `命中 ${matches.length} 处`;
+    dom.statusPill.className = 'status status--ok';
+  }
+  state.activeMatchIndex = -1;
+  renderHighlight(matches);
+  renderMatches(matches);
+  renderReplace();
+}
+
+// ── Render helpers ───────────────────────────────────
+function renderHighlight(matches) {
+  const text = dom.testText.value;
+  if (matches.length === 0) {
+    dom.highlight.innerHTML = escapeHtml(text) + '\n';
+    return;
+  }
+  let html = '';
+  let cursor = 0;
+  matches.forEach((m, i) => {
+    if (m.index > cursor) html += escapeHtml(text.slice(cursor, m.index));
+    const cls = i === state.activeMatchIndex ? 'is-active' : '';
+    html += `<mark data-idx="${i}" class="${cls}">${escapeHtml(text.slice(m.index, m.end))}</mark>`;
+    cursor = m.end;
+  });
+  if (cursor < text.length) html += escapeHtml(text.slice(cursor));
+  dom.highlight.innerHTML = html + '\n';
+}
+
+function renderMatches(matches) {
+  if (matches.length === 0) {
+    dom.matches.innerHTML = '<div class="empty">没有匹配项。试着调整正则或测试文本。</div>';
+    return;
+  }
+  dom.matches.innerHTML = '';
+  matches.forEach((m, i) => {
+    const el = document.createElement('div');
+    el.className = 'match';
+    let groupsHtml = '';
+    const allGroups = [...m.groups, ...m.namedGroups];
+    if (allGroups.length > 0) {
+      groupsHtml = '<div class="match__groups">' + allGroups.map((g) => {
+        const tag = g.name != null ? `&lt;${escapeHtml(g.name)}&gt;` : `$${g.idx}`;
+        const val = g.value === undefined ? '<i style="opacity:.5">undefined</i>' : escapeHtml(g.value);
+        return `<div class="match__group"><b>${tag}</b> = ${val}</div>`;
+      }).join('') + '</div>';
+    }
+    el.innerHTML = `
+      <div class="match__head">
+        <span class="match__index">#${i + 1}</span>
+        <span>idx ${m.index}–${m.end}</span>
+      </div>
+      <div class="match__text">${escapeHtml(m.text) || '<i style="opacity:.5">空匹配</i>'}</div>
+      ${groupsHtml}
+    `;
+    el.addEventListener('click', () => {
+      state.activeMatchIndex = i;
+      for (const node of dom.matches.querySelectorAll('.match')) node.classList.remove('is-active');
+      el.classList.add('is-active');
+      // Highlight active mark in overlay
+      for (const mk of dom.highlight.querySelectorAll('mark')) mk.classList.remove('is-active');
+      const target = dom.highlight.querySelector(`mark[data-idx="${i}"]`);
+      if (target) target.classList.add('is-active');
+      // Scroll textarea to the match
+      const before = dom.testText.value.slice(0, m.index);
+      const lineNo = before.split('\n').length - 1;
+      const lineHeight = 13 * 1.55;
+      dom.testText.scrollTop = Math.max(0, lineNo * lineHeight - 60);
+      dom.testText.setSelectionRange(m.index, m.end);
+      dom.testText.focus();
+    });
+    dom.matches.appendChild(el);
+  });
+}
+
+function renderReplace() {
+  const replacement = dom.replaceInput.value;
+  if (replacement === '') { dom.replaceOutput.hidden = true; return; }
+  const compiled = compileRegex();
+  if (!compiled.ok) { dom.replaceOutput.hidden = true; return; }
+  let result;
+  try {
+    result = dom.testText.value.replace(compiled.regex, replacement);
+  } catch (e) {
+    result = `[替换失败] ${e.message}`;
+  }
+  dom.replaceOutput.hidden = false;
+  dom.replaceOutput.textContent = result;
+}
+
+function escapeHtml(s) {
+  return String(s == null ? '' : s).replace(/[&<>]/g, (c) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;',
+  }[c]));
+}
+
+init();

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/worker.js
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/worker.js
@@ -1,0 +1,2 @@
+// Built-in MiniApp: Regex Playground — no node-side logic; storage handled by the runtime host.
+module.exports = {};

--- a/src/crates/core/src/miniapp/builtin/mod.rs
+++ b/src/crates/core/src/miniapp/builtin/mod.rs
@@ -51,7 +51,7 @@ pub const BUILTIN_APPS: &[BuiltinApp] = &[
     },
     BuiltinApp {
         id: "builtin-regex-playground",
-        version: 2,
+        version: 3,
         meta_json: include_str!("assets/regex-playground/meta.json"),
         html: include_str!("assets/regex-playground/index.html"),
         css: include_str!("assets/regex-playground/style.css"),

--- a/src/crates/core/src/miniapp/builtin/mod.rs
+++ b/src/crates/core/src/miniapp/builtin/mod.rs
@@ -31,7 +31,7 @@ pub struct BuiltinApp {
 pub const BUILTIN_APPS: &[BuiltinApp] = &[
     BuiltinApp {
         id: "builtin-gomoku",
-        version: 2,
+        version: 3,
         meta_json: include_str!("assets/gomoku/meta.json"),
         html: include_str!("assets/gomoku/index.html"),
         css: include_str!("assets/gomoku/style.css"),

--- a/src/crates/core/src/miniapp/builtin/mod.rs
+++ b/src/crates/core/src/miniapp/builtin/mod.rs
@@ -1,0 +1,162 @@
+//! Built-in MiniApps — bundled, seeded into miniapps_dir on first launch / upgrade.
+//!
+//! Each built-in app has a fixed id (so it can be located across runs) and a schema
+//! `version`. On startup we compare the on-disk marker file `.builtin-version` with
+//! the bundled version and only rewrite source files when newer code is available.
+//! The user's `storage.json` is preserved across upgrades.
+
+use crate::miniapp::manager::MiniAppManager;
+use crate::miniapp::types::MiniAppMeta;
+use crate::util::errors::{BitFunError, BitFunResult};
+use chrono::Utc;
+use std::sync::Arc;
+
+const BUILTIN_MARKER: &str = ".builtin-version";
+
+/// A built-in MiniApp bundled with the application binary.
+pub struct BuiltinApp {
+    /// Stable id used as on-disk directory name (also exposed in the gallery).
+    pub id: &'static str,
+    /// Schema version of the bundled assets — bump when sources change to trigger reseed.
+    pub version: u32,
+    pub meta_json: &'static str,
+    pub html: &'static str,
+    pub css: &'static str,
+    pub ui_js: &'static str,
+    pub worker_js: &'static str,
+    pub esm_dependencies_json: &'static str,
+}
+
+/// All built-in apps that ship with BitFun.
+pub const BUILTIN_APPS: &[BuiltinApp] = &[
+    BuiltinApp {
+        id: "builtin-gomoku",
+        version: 1,
+        meta_json: include_str!("assets/gomoku/meta.json"),
+        html: include_str!("assets/gomoku/index.html"),
+        css: include_str!("assets/gomoku/style.css"),
+        ui_js: include_str!("assets/gomoku/ui.js"),
+        worker_js: include_str!("assets/gomoku/worker.js"),
+        esm_dependencies_json: "[]",
+    },
+    BuiltinApp {
+        id: "builtin-daily-divination",
+        version: 1,
+        meta_json: include_str!("assets/divination/meta.json"),
+        html: include_str!("assets/divination/index.html"),
+        css: include_str!("assets/divination/style.css"),
+        ui_js: include_str!("assets/divination/ui.js"),
+        worker_js: include_str!("assets/divination/worker.js"),
+        esm_dependencies_json: "[]",
+    },
+    BuiltinApp {
+        id: "builtin-regex-playground",
+        version: 1,
+        meta_json: include_str!("assets/regex-playground/meta.json"),
+        html: include_str!("assets/regex-playground/index.html"),
+        css: include_str!("assets/regex-playground/style.css"),
+        ui_js: include_str!("assets/regex-playground/ui.js"),
+        worker_js: include_str!("assets/regex-playground/worker.js"),
+        esm_dependencies_json: "[]",
+    },
+];
+
+/// Seed all built-in MiniApps into the user data directory. Idempotent: skips apps
+/// whose on-disk marker version is >= the bundled version. User's `storage.json`
+/// is preserved across reseeds; source files & meta.json (without timestamps) are
+/// overwritten.
+pub async fn seed_builtin_miniapps(manager: &Arc<MiniAppManager>) -> BitFunResult<()> {
+    for app in BUILTIN_APPS {
+        if let Err(e) = seed_one(manager, app).await {
+            log::warn!("seed builtin miniapp '{}' failed: {}", app.id, e);
+        }
+    }
+    Ok(())
+}
+
+async fn seed_one(manager: &Arc<MiniAppManager>, app: &BuiltinApp) -> BitFunResult<()> {
+    let app_dir = manager.path_manager().miniapp_dir(app.id);
+    let marker_path = app_dir.join(BUILTIN_MARKER);
+
+    // Skip if marker indicates same or newer version is already on disk.
+    if let Ok(content) = tokio::fs::read_to_string(&marker_path).await {
+        if let Ok(installed) = content.trim().parse::<u32>() {
+            if installed >= app.version {
+                return Ok(());
+            }
+        }
+    }
+
+    let source_dir = app_dir.join("source");
+    tokio::fs::create_dir_all(&source_dir)
+        .await
+        .map_err(|e| BitFunError::io(format!("create dir failed: {}", e)))?;
+
+    // meta.json — parse bundled meta, then set id/timestamps. Preserve created_at if present.
+    let mut meta: MiniAppMeta = serde_json::from_str(app.meta_json)
+        .map_err(|e| BitFunError::parse(format!("invalid bundled meta.json: {}", e)))?;
+    meta.id = app.id.to_string();
+    let now = Utc::now().timestamp_millis();
+
+    let meta_path = app_dir.join("meta.json");
+    let preserved_created_at = match tokio::fs::read_to_string(&meta_path).await {
+        Ok(existing) => serde_json::from_str::<MiniAppMeta>(&existing)
+            .ok()
+            .map(|m| m.created_at)
+            .unwrap_or(now),
+        Err(_) => now,
+    };
+    meta.created_at = preserved_created_at;
+    meta.updated_at = now;
+
+    let meta_json = serde_json::to_string_pretty(&meta).map_err(BitFunError::from)?;
+    tokio::fs::write(&meta_path, meta_json)
+        .await
+        .map_err(|e| BitFunError::io(format!("write meta.json failed: {}", e)))?;
+
+    // Source files (always overwrite).
+    write_file(source_dir.join("index.html"), app.html).await?;
+    write_file(source_dir.join("style.css"), app.css).await?;
+    write_file(source_dir.join("ui.js"), app.ui_js).await?;
+    write_file(source_dir.join("worker.js"), app.worker_js).await?;
+    write_file(
+        source_dir.join("esm_dependencies.json"),
+        app.esm_dependencies_json,
+    )
+    .await?;
+
+    // package.json — overwrite with empty deps; built-in apps must not require npm install.
+    let pkg = serde_json::json!({
+        "name": format!("miniapp-{}", app.id),
+        "private": true,
+        "dependencies": {}
+    });
+    let pkg_json = serde_json::to_string_pretty(&pkg).map_err(BitFunError::from)?;
+    write_file(app_dir.join("package.json"), &pkg_json).await?;
+
+    // Preserve user's storage.json if present, otherwise initialize to "{}".
+    let storage_path = app_dir.join("storage.json");
+    if !storage_path.exists() {
+        write_file(storage_path, "{}").await?;
+    }
+
+    // Placeholder compiled.html so storage::load() doesn't fail before recompile.
+    write_file(
+        app_dir.join("compiled.html"),
+        "<!DOCTYPE html><html><body>Loading...</body></html>",
+    )
+    .await?;
+
+    // Recompile to assemble the final compiled.html with bridge + theme + import map.
+    manager.recompile(app.id, "dark", None).await?;
+
+    write_file(marker_path, &app.version.to_string()).await?;
+    log::info!("seeded builtin miniapp '{}' (v{})", app.id, app.version);
+    Ok(())
+}
+
+async fn write_file<P: AsRef<std::path::Path>>(path: P, content: &str) -> BitFunResult<()> {
+    tokio::fs::write(path.as_ref(), content)
+        .await
+        .map_err(|e| BitFunError::io(format!("write {} failed: {}", path.as_ref().display(), e)))
+}

--- a/src/crates/core/src/miniapp/builtin/mod.rs
+++ b/src/crates/core/src/miniapp/builtin/mod.rs
@@ -31,7 +31,7 @@ pub struct BuiltinApp {
 pub const BUILTIN_APPS: &[BuiltinApp] = &[
     BuiltinApp {
         id: "builtin-gomoku",
-        version: 3,
+        version: 4,
         meta_json: include_str!("assets/gomoku/meta.json"),
         html: include_str!("assets/gomoku/index.html"),
         css: include_str!("assets/gomoku/style.css"),
@@ -41,7 +41,7 @@ pub const BUILTIN_APPS: &[BuiltinApp] = &[
     },
     BuiltinApp {
         id: "builtin-daily-divination",
-        version: 2,
+        version: 3,
         meta_json: include_str!("assets/divination/meta.json"),
         html: include_str!("assets/divination/index.html"),
         css: include_str!("assets/divination/style.css"),
@@ -51,7 +51,7 @@ pub const BUILTIN_APPS: &[BuiltinApp] = &[
     },
     BuiltinApp {
         id: "builtin-regex-playground",
-        version: 3,
+        version: 4,
         meta_json: include_str!("assets/regex-playground/meta.json"),
         html: include_str!("assets/regex-playground/index.html"),
         css: include_str!("assets/regex-playground/style.css"),

--- a/src/crates/core/src/miniapp/builtin/mod.rs
+++ b/src/crates/core/src/miniapp/builtin/mod.rs
@@ -31,7 +31,7 @@ pub struct BuiltinApp {
 pub const BUILTIN_APPS: &[BuiltinApp] = &[
     BuiltinApp {
         id: "builtin-gomoku",
-        version: 1,
+        version: 2,
         meta_json: include_str!("assets/gomoku/meta.json"),
         html: include_str!("assets/gomoku/index.html"),
         css: include_str!("assets/gomoku/style.css"),
@@ -41,7 +41,7 @@ pub const BUILTIN_APPS: &[BuiltinApp] = &[
     },
     BuiltinApp {
         id: "builtin-daily-divination",
-        version: 1,
+        version: 2,
         meta_json: include_str!("assets/divination/meta.json"),
         html: include_str!("assets/divination/index.html"),
         css: include_str!("assets/divination/style.css"),
@@ -51,7 +51,7 @@ pub const BUILTIN_APPS: &[BuiltinApp] = &[
     },
     BuiltinApp {
         id: "builtin-regex-playground",
-        version: 1,
+        version: 2,
         meta_json: include_str!("assets/regex-playground/meta.json"),
         html: include_str!("assets/regex-playground/index.html"),
         css: include_str!("assets/regex-playground/style.css"),

--- a/src/crates/core/src/miniapp/mod.rs
+++ b/src/crates/core/src/miniapp/mod.rs
@@ -1,6 +1,7 @@
 //! MiniApp module — V2: ESM UI + Node Worker, Runtime Adapter, permission policy.
 
 pub mod bridge_builder;
+pub mod builtin;
 pub mod compiler;
 pub mod exporter;
 pub mod js_worker;
@@ -11,6 +12,7 @@ pub mod runtime_detect;
 pub mod storage;
 pub mod types;
 
+pub use builtin::{seed_builtin_miniapps, BuiltinApp, BUILTIN_APPS};
 pub use exporter::{ExportCheckResult, ExportOptions, ExportResult, ExportTarget, MiniAppExporter};
 pub use js_worker_pool::{InstallResult, JsWorkerPool};
 pub use manager::{

--- a/src/crates/core/src/service/config/global.rs
+++ b/src/crates/core/src/service/config/global.rs
@@ -53,6 +53,22 @@ pub enum ConfigUpdateEvent {
         /// New runtime log level.
         new_level: String,
     },
+    /// AI models / default-model slots / agent-model mappings were reconciled
+    /// after a model became unavailable (disabled, deleted, or otherwise
+    /// invalid). Emitted whenever the config layer had to silently rewrite
+    /// `ai.default_models`, `ai.agent_models`, or `ai.func_agent_models` so they
+    /// only reference enabled models.
+    ModelsReconciled {
+        /// Model ids that just became unusable (disabled or deleted) and that
+        /// any active session, default slot, or agent mapping was pointing at
+        /// before this reconcile pass.
+        invalidated_model_ids: Vec<String>,
+        /// Whether `ai.default_models` was rewritten as part of the reconcile.
+        default_models_changed: bool,
+        /// Whether `ai.agent_models` or `ai.func_agent_models` were rewritten
+        /// as part of the reconcile.
+        agent_models_changed: bool,
+    },
 }
 
 /// Global configuration service manager.

--- a/src/crates/core/src/service/config/service.rs
+++ b/src/crates/core/src/service/config/service.rs
@@ -6,6 +6,7 @@ use super::manager::{ConfigManager, ConfigManagerSettings, ConfigStatistics};
 use super::types::*;
 use crate::util::errors::*;
 use log::{info, warn};
+use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -51,12 +52,22 @@ impl ConfigService {
     }
 
     /// Creates a configuration service with custom settings.
+    ///
+    /// Runs an initial [`Self::reconcile_models`] pass so any pre-existing
+    /// persisted config that points at a now-disabled / missing model (e.g.
+    /// from before this guard was introduced) is cleaned up on startup.
     pub async fn with_settings(settings: ConfigManagerSettings) -> BitFunResult<Self> {
         let manager = ConfigManager::new(settings).await?;
 
-        Ok(Self {
+        let service = Self {
             manager: Arc::new(RwLock::new(manager)),
-        })
+        };
+
+        if let Err(e) = service.reconcile_models("startup").await {
+            warn!("Model reconcile at startup failed: {}", e);
+        }
+
+        Ok(service)
     }
 
     /// Gets a configuration value (supports dot-paths).
@@ -76,18 +87,64 @@ impl ConfigService {
     }
 
     /// Sets a configuration value (supports dot-paths).
+    ///
+    /// When the path touches AI models / default model slots / agent-model
+    /// mappings, runs [`Self::reconcile_models`] afterwards so the config can
+    /// never end up referencing a disabled or deleted model.
     pub async fn set_config<T>(&self, path: &str, value: T) -> BitFunResult<()>
     where
         T: serde::Serialize,
     {
-        let mut manager = self.manager.write().await;
-        manager.set(path, value).await
+        {
+            let mut manager = self.manager.write().await;
+            manager.set(path, value).await?;
+        }
+
+        if Self::path_touches_models(path) {
+            if let Err(e) = self.reconcile_models("set_config").await {
+                warn!(
+                    "Model reconcile after set_config failed: path={}, error={}",
+                    path, e
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn path_touches_models(path: &str) -> bool {
+        path == "ai"
+            || path.starts_with("ai.models")
+            || path.starts_with("ai.default_models")
+            || path.starts_with("ai.agent_models")
+            || path.starts_with("ai.func_agent_models")
     }
 
     /// Resets configuration.
+    ///
+    /// When the reset target touches AI models (or is a global reset),
+    /// triggers [`Self::reconcile_models`] so default-slot / agent-model
+    /// references can never linger pointing at a now-missing model.
     pub async fn reset_config(&self, path: Option<&str>) -> BitFunResult<()> {
-        let mut manager = self.manager.write().await;
-        manager.reset(path).await
+        {
+            let mut manager = self.manager.write().await;
+            manager.reset(path).await?;
+        }
+
+        let needs_reconcile = match path {
+            None => true,
+            Some(p) => Self::path_touches_models(p),
+        };
+        if needs_reconcile {
+            if let Err(e) = self.reconcile_models("reset_config").await {
+                warn!(
+                    "Model reconcile after reset_config failed: path={:?}, error={}",
+                    path, e
+                );
+            }
+        }
+
+        Ok(())
     }
 
     /// Validates configuration.
@@ -109,19 +166,28 @@ impl ConfigService {
         })
     }
 
-    /// Imports configuration.
+    /// Imports configuration. Triggers a model reconcile pass on success so an
+    /// imported config that references missing / disabled models is brought
+    /// back into a self-consistent state.
     pub async fn import_config(&self, export: ConfigExport) -> BitFunResult<ConfigImportResult> {
-        let mut manager = self.manager.write().await;
+        let import_result = {
+            let mut manager = self.manager.write().await;
+            manager
+                .import_config(serde_json::to_value(export.config)?)
+                .await
+        };
 
-        match manager
-            .import_config(serde_json::to_value(export.config)?)
-            .await
-        {
-            Ok(_) => Ok(ConfigImportResult {
-                success: true,
-                errors: Vec::new(),
-                warnings: Vec::new(),
-            }),
+        match import_result {
+            Ok(_) => {
+                if let Err(e) = self.reconcile_models("import_config").await {
+                    warn!("Model reconcile after import_config failed: {}", e);
+                }
+                Ok(ConfigImportResult {
+                    success: true,
+                    errors: Vec::new(),
+                    warnings: Vec::new(),
+                })
+            }
             Err(e) => Ok(ConfigImportResult {
                 success: false,
                 errors: vec![e.to_string()],
@@ -189,10 +255,16 @@ impl ConfigService {
         let settings = ConfigManagerSettings::default();
         let new_manager = ConfigManager::new(settings).await?;
 
-        let mut manager = self.manager.write().await;
-        *manager = new_manager;
+        {
+            let mut manager = self.manager.write().await;
+            *manager = new_manager;
+        }
 
         info!("Configuration reloaded");
+
+        if let Err(e) = self.reconcile_models("reload").await {
+            warn!("Model reconcile after reload failed: {}", e);
+        }
         Ok(())
     }
 
@@ -250,30 +322,231 @@ impl ConfigService {
             )));
         }
 
-        for (agent_name, configured_model_id) in config.ai.agent_models.clone().iter() {
-            if configured_model_id == model_id {
-                warn!(
-                    "Deleted model {} is used by agent {}, clearing configuration",
-                    model_id, agent_name
-                );
-                config.ai.agent_models.remove(agent_name);
+        // Persist the list deletion. The follow-up reconcile pass triggered by
+        // `set_config` (and explicitly by `update_ai_model`) is responsible for
+        // cleaning every other place the deleted id might still be referenced
+        // (default slots, agent / func-agent mappings).
+        self.set_config("ai.models", &config.ai.models).await
+    }
+
+    /// Bring `ai.default_models`, `ai.agent_models`, and `ai.func_agent_models`
+    /// back into a consistent state with `ai.models`.
+    ///
+    /// This is the single integrity guard the rest of the system relies on:
+    /// - any agent / func-agent mapping pointing at a model that no longer
+    ///   exists or that became disabled is dropped;
+    /// - `default_models.primary` / `.fast` are repointed to the first enabled
+    ///   model when their current target is missing or disabled (or cleared
+    ///   when no enabled model exists at all);
+    /// - on every change, a [`ConfigUpdateEvent::ModelsReconciled`] is
+    ///   broadcast so [`SessionManager`](crate::agentic::session::SessionManager)
+    ///   and the AI client cache can react in lockstep.
+    ///
+    /// `caller` is logged for diagnostics (e.g. `set_config`, `update_ai_model`).
+    pub async fn reconcile_models(&self, caller: &str) -> BitFunResult<ReconcileModelsReport> {
+        let mut config: GlobalConfig = self.get_config(None).await?;
+
+        let enabled_ids: HashSet<String> = config
+            .ai
+            .models
+            .iter()
+            .filter(|m| m.enabled)
+            .map(|m| m.id.clone())
+            .collect();
+        let known_ids: HashSet<String> = config.ai.models.iter().map(|m| m.id.clone()).collect();
+
+        // Precompute lookup tables so the closures below do not need to
+        // borrow `config.ai` (which would conflict with the later mutations
+        // of `config.ai.agent_models` / `config.ai.default_models`).
+        let mut active_refs: HashSet<String> = HashSet::new();
+        let mut any_ref_to_id: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        for m in &config.ai.models {
+            any_ref_to_id.entry(m.id.clone()).or_insert_with(|| m.id.clone());
+            any_ref_to_id.entry(m.name.clone()).or_insert_with(|| m.id.clone());
+            any_ref_to_id
+                .entry(m.model_name.clone())
+                .or_insert_with(|| m.id.clone());
+            if m.enabled {
+                active_refs.insert(m.id.clone());
+                active_refs.insert(m.name.clone());
+                active_refs.insert(m.model_name.clone());
             }
         }
-        for (func_agent_name, configured_model_id) in config.ai.func_agent_models.clone().iter() {
-            if configured_model_id == model_id {
-                warn!(
-                    "Deleted model {} is used by func agent {}, clearing configuration",
-                    model_id, func_agent_name
-                );
-                config.ai.func_agent_models.remove(func_agent_name);
-            }
+        let is_active = |reference: &str| -> bool {
+            // Special selectors are always considered active; their actual
+            // resolution happens at runtime against the (already reconciled)
+            // default slots.
+            matches!(reference, "auto" | "primary" | "fast")
+                || active_refs.contains(reference)
+        };
+
+        let classify_invalid =
+            |reference: &str, invalidated: &mut HashSet<String>| -> bool {
+                if is_active(reference) {
+                    return false;
+                }
+                // Resolve back to the canonical id (if the reference is by
+                // name / model_name pointing at a now-disabled model) so we
+                // can report a stable identifier.
+                let canonical = any_ref_to_id
+                    .get(reference)
+                    .cloned()
+                    .unwrap_or_else(|| reference.to_string());
+                invalidated.insert(canonical);
+                true
+            };
+
+        let mut invalidated: HashSet<String> = HashSet::new();
+        let mut agent_models_changed = false;
+        let mut default_models_changed = false;
+
+        // 1. agent_models
+        let agent_keys_to_remove: Vec<String> = config
+            .ai
+            .agent_models
+            .iter()
+            .filter_map(|(agent, model_ref)| {
+                if classify_invalid(model_ref, &mut invalidated) {
+                    Some(agent.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for agent in agent_keys_to_remove {
+            warn!(
+                "Reconcile ({caller}): clearing ai.agent_models[{agent}] because target model is missing or disabled"
+            );
+            config.ai.agent_models.remove(&agent);
+            agent_models_changed = true;
         }
 
-        self.set_config("ai.models", &config.ai.models).await?;
-        self.set_config("ai.agent_models", &config.ai.agent_models)
-            .await?;
-        self.set_config("ai.func_agent_models", &config.ai.func_agent_models)
-            .await?;
-        Ok(())
+        // 2. func_agent_models
+        let func_keys_to_remove: Vec<String> = config
+            .ai
+            .func_agent_models
+            .iter()
+            .filter_map(|(agent, model_ref)| {
+                if classify_invalid(model_ref, &mut invalidated) {
+                    Some(agent.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for agent in func_keys_to_remove {
+            warn!(
+                "Reconcile ({caller}): clearing ai.func_agent_models[{agent}] because target model is missing or disabled"
+            );
+            config.ai.func_agent_models.remove(&agent);
+            agent_models_changed = true;
+        }
+
+        // 3. default_models.primary / .fast
+        let fallback_id = config.ai.first_enabled_model_id();
+        let mut repoint_default_slot = |slot: &mut Option<String>, slot_name: &str| {
+            let needs_fix = match slot.as_deref() {
+                Some("") => true,
+                Some(value) => !is_active(value),
+                None => false,
+            };
+            if !needs_fix {
+                return;
+            }
+
+            if let Some(current) = slot.as_deref() {
+                classify_invalid(current, &mut invalidated);
+            }
+
+            match fallback_id.as_ref() {
+                Some(new_id) => {
+                    info!(
+                        "Reconcile ({caller}): default_models.{slot_name} repointed: {:?} -> {}",
+                        slot, new_id
+                    );
+                    *slot = Some(new_id.clone());
+                }
+                None => {
+                    info!(
+                        "Reconcile ({caller}): default_models.{slot_name} cleared (no enabled model available); previous={:?}",
+                        slot
+                    );
+                    *slot = None;
+                }
+            }
+            default_models_changed = true;
+        };
+
+        repoint_default_slot(&mut config.ai.default_models.primary, "primary");
+        repoint_default_slot(&mut config.ai.default_models.fast, "fast");
+
+        // Ensure `invalidated` doesn't contain a still-existing-and-enabled id
+        // (defensive: classify_invalid only inserts for inactive refs, but a
+        // callsite could have re-resolved via name).
+        invalidated.retain(|id| !enabled_ids.contains(id));
+
+        // Persist any changes. We deliberately use the inner manager (and not
+        // `self.set_config`) to avoid triggering a recursive reconcile pass.
+        if agent_models_changed {
+            let mut manager = self.manager.write().await;
+            manager
+                .set("ai.agent_models", &config.ai.agent_models)
+                .await?;
+            manager
+                .set("ai.func_agent_models", &config.ai.func_agent_models)
+                .await?;
+        }
+        if default_models_changed {
+            let mut manager = self.manager.write().await;
+            manager
+                .set("ai.default_models", &config.ai.default_models)
+                .await?;
+        }
+
+        let _ = known_ids; // currently unused, kept for future diagnostics
+
+        let report = ReconcileModelsReport {
+            invalidated_model_ids: invalidated.into_iter().collect(),
+            default_models_changed,
+            agent_models_changed,
+        };
+
+        if report.is_noop() {
+            log::debug!("Reconcile ({caller}): no changes");
+        } else {
+            info!(
+                "Reconcile ({caller}): invalidated={:?}, default_changed={}, agent_changed={}",
+                report.invalidated_model_ids,
+                report.default_models_changed,
+                report.agent_models_changed
+            );
+            super::global::GlobalConfigManager::broadcast_update(
+                super::global::ConfigUpdateEvent::ModelsReconciled {
+                    invalidated_model_ids: report.invalidated_model_ids.clone(),
+                    default_models_changed: report.default_models_changed,
+                    agent_models_changed: report.agent_models_changed,
+                },
+            )
+            .await;
+        }
+
+        Ok(report)
+    }
+}
+
+/// Outcome of [`ConfigService::reconcile_models`].
+#[derive(Debug, Clone, Default)]
+pub struct ReconcileModelsReport {
+    pub invalidated_model_ids: Vec<String>,
+    pub default_models_changed: bool,
+    pub agent_models_changed: bool,
+}
+
+impl ReconcileModelsReport {
+    pub fn is_noop(&self) -> bool {
+        self.invalidated_model_ids.is_empty()
+            && !self.default_models_changed
+            && !self.agent_models_changed
     }
 }

--- a/src/crates/core/src/service/config/types.rs
+++ b/src/crates/core/src/service/config/types.rs
@@ -447,20 +447,55 @@ pub struct AIConfig {
 
 impl AIConfig {
     /// Resolves a configured model reference by `id`, `name`, or `model_name`.
+    ///
+    /// Returns the model id only when the matched model is `enabled`. This is the
+    /// single source of truth for "is this model usable right now?" and is the
+    /// variant every runtime path (client factory, execution engine, etc.) should
+    /// use. UI / migration code that needs to look up disabled entries should call
+    /// [`Self::resolve_model_reference_any`] instead.
     pub fn resolve_model_reference(&self, model_ref: &str) -> Option<String> {
+        self.models
+            .iter()
+            .find(|m| {
+                m.enabled
+                    && (m.id == model_ref || m.name == model_ref || m.model_name == model_ref)
+            })
+            .map(|m| m.id.clone())
+    }
+
+    /// Resolves a model reference regardless of `enabled` state. UI / migration
+    /// only — never use this on the runtime model-selection path.
+    pub fn resolve_model_reference_any(&self, model_ref: &str) -> Option<String> {
         self.models
             .iter()
             .find(|m| m.id == model_ref || m.name == model_ref || m.model_name == model_ref)
             .map(|m| m.id.clone())
     }
 
+    /// Returns true if the given reference points to a model that exists and is
+    /// currently enabled.
+    pub fn is_model_reference_active(&self, model_ref: &str) -> bool {
+        self.resolve_model_reference(model_ref).is_some()
+    }
+
+    /// Returns the id of the first enabled model, if any. Used as a final
+    /// fallback when a configured default points to a disabled / missing model.
+    pub fn first_enabled_model_id(&self) -> Option<String> {
+        self.models
+            .iter()
+            .find(|m| m.enabled)
+            .map(|m| m.id.clone())
+    }
+
     /// Resolves a model selector value.
     ///
     /// Special values:
-    /// - `primary`: must resolve to a valid primary model
+    /// - `primary`: must resolve to a valid (enabled) primary model
     /// - `fast`: first tries the configured fast model, then falls back to primary
     ///
-    /// Regular values are resolved by `id`, `name`, or `model_name`.
+    /// Regular values are resolved by `id`, `name`, or `model_name`. All lookups
+    /// require the target model to be enabled — disabled models are treated as if
+    /// they did not exist.
     pub fn resolve_model_selection(&self, model_ref: &str) -> Option<String> {
         match model_ref {
             "primary" => self

--- a/src/crates/core/src/service/remote_connect/bot/command_router.rs
+++ b/src/crates/core/src/service/remote_connect/bot/command_router.rs
@@ -1,8 +1,18 @@
-//! Shared command router for bot-based connections (Telegram & Feishu).
+//! Shared command router for IM-bot connections (Telegram / Feishu / WeChat).
 //!
-//! Provides platform-agnostic command parsing, per-chat state management, and
-//! dispatch to workspace / session services.  Each platform adapter handles
-//! message I/O while this module owns the business logic.
+//! All user-facing menu/command logic lives here.  Platform adapters only
+//! handle message I/O and render the platform-agnostic [`HandleResult`] /
+//! [`crate::service::remote_connect::bot::menu::MenuView`] returned from
+//! [`handle_command`].
+//!
+//! Public surface kept stable so existing adapters keep compiling:
+//!   - Types: `BotChatState`, `BotCommand`, `BotAction`, `BotActionStyle`,
+//!     `BotInteractiveRequest`, `BotInteractionHandler`, `BotMessageSender`,
+//!     `BotQuestion`, `BotQuestionOption`, `BotDisplayMode`, `BotLanguage`,
+//!     `HandleResult`, `ForwardRequest`, `ForwardedTurnResult`, `PendingAction`.
+//!   - Functions: `parse_command`, `handle_command`, `welcome_message`,
+//!     `complete_im_bot_pairing`, `current_bot_language`,
+//!     `execute_forwarded_turn`, `apply_interactive_request`.
 
 use log::{error, info};
 use serde::{Deserialize, Serialize};
@@ -11,29 +21,26 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-// ── Per-chat state ──────────────────────────────────────────────────
+pub use super::locale::{current_bot_language, BotLanguage};
+use super::locale::{fmt_count, strings_for, BotStrings};
+use super::menu::{MenuItem, MenuItemStyle, MenuView};
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub enum BotLanguage {
-    #[serde(rename = "zh-CN")]
-    ZhCN,
-    #[serde(rename = "en-US")]
-    EnUS,
-}
+// ── Constants ──────────────────────────────────────────────────────
 
-impl BotLanguage {
-    pub fn is_chinese(self) -> bool {
-        matches!(self, Self::ZhCN)
-    }
-}
+/// How long a pending interactive prompt stays valid before auto-clearing.
+const PENDING_TTL_SECS: i64 = 5 * 60;
+/// How many invalid replies are tolerated before pending state is auto-cleared.
+const PENDING_INVALID_LIMIT: u8 = 3;
 
-/// Display mode for bot sessions - Professional or Assistant
+// ── Per-chat state ─────────────────────────────────────────────────
+
+/// Display mode for IM bot sessions.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub enum BotDisplayMode {
-    /// Professional mode: can create Code/Cowork sessions
+    /// Expert mode: can create Code / Cowork sessions on real workspaces.
     #[serde(rename = "pro")]
     Pro,
-    /// Assistant mode: can create Claw sessions
+    /// Default assistant mode: Claw sessions on the assistant workspace.
     #[serde(rename = "assistant")]
     #[default]
     Assistant,
@@ -46,19 +53,31 @@ pub struct BotChatState {
     pub current_workspace: Option<String>,
     pub current_assistant: Option<String>,
     pub current_session_id: Option<String>,
-    /// Display mode: Professional (Pro) or Assistant
     #[serde(default)]
     pub display_mode: BotDisplayMode,
-    #[serde(skip)]
-    pub pending_action: Option<PendingAction>,
-    /// Pending file downloads awaiting user confirmation.
-    /// Key: short token embedded in the download button callback.
-    /// Value: absolute file path on the desktop.
+
+    /// Active interactive prompt awaiting a user reply.
     /// Not persisted — cleared on bot restart.
     #[serde(skip)]
+    pub pending_action: Option<PendingAction>,
+    /// Unix timestamp (seconds) when the current `pending_action` becomes
+    /// invalid.  Refreshed whenever a new pending action is set.
+    #[serde(skip)]
+    pub pending_expires_at: i64,
+    /// How many invalid replies the user has sent against the current
+    /// pending action.  Resets on every successful transition.
+    #[serde(skip)]
+    pub pending_invalid_count: u8,
+
+    /// Pending file downloads awaiting user confirmation.
+    /// Key: short token embedded in the download button callback.
+    /// Value: absolute file path on the desktop.  Not persisted.
+    #[serde(skip)]
     pub pending_files: std::collections::HashMap<String, String>,
-    /// Commands for the last bot message that had quick actions (1 → `actions[0].command`).
-    /// Not persisted — used so numeric replies work like OpenClaw menu numbers.
+
+    /// Commands corresponding to the items in the most recent menu, used so
+    /// numeric replies (`1` ~ `last_menu_commands.len()`) work without
+    /// platform-native buttons.  Not persisted.
     #[serde(skip, default)]
     pub last_menu_commands: Vec<String>,
 }
@@ -73,22 +92,38 @@ impl BotChatState {
             current_session_id: None,
             display_mode: BotDisplayMode::Assistant,
             pending_action: None,
+            pending_expires_at: 0,
+            pending_invalid_count: 0,
             pending_files: std::collections::HashMap::new(),
             last_menu_commands: Vec::new(),
         }
     }
-}
 
-pub async fn current_bot_language() -> BotLanguage {
-    if let Some(service) = crate::service::get_global_i18n_service().await {
-        match service.get_current_locale().await {
-            crate::service::LocaleId::ZhCN => BotLanguage::ZhCN,
-            crate::service::LocaleId::EnUS => BotLanguage::EnUS,
-        }
-    } else {
-        BotLanguage::ZhCN
+    fn set_pending(&mut self, action: PendingAction) {
+        self.pending_action = Some(action);
+        self.pending_expires_at = now_secs() + PENDING_TTL_SECS;
+        self.pending_invalid_count = 0;
+    }
+
+    fn clear_pending(&mut self) {
+        self.pending_action = None;
+        self.pending_expires_at = 0;
+        self.pending_invalid_count = 0;
+    }
+
+    fn pending_expired(&self) -> bool {
+        self.pending_action.is_some() && now_secs() > self.pending_expires_at
     }
 }
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+// ── Pending action ─────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
 pub enum PendingAction {
@@ -111,65 +146,14 @@ pub enum PendingAction {
         awaiting_custom_text: bool,
         pending_answer: Option<Value>,
     },
+    /// Confirm switching to the other display mode and then run `target_cmd`.
+    ConfirmModeSwitch {
+        target_mode: BotDisplayMode,
+        target_cmd: String,
+    },
 }
 
-// ── Parsed command ──────────────────────────────────────────────────
-
-#[derive(Debug)]
-pub enum BotCommand {
-    Start,
-    SwitchWorkspace,
-    SwitchAssistant,
-    SwitchMode(BotDisplayMode),
-    ResumeSession,
-    NewCodeSession,
-    NewCoworkSession,
-    NewClawSession,
-    CancelTask(Option<String>),
-    Help,
-    PairingCode(String),
-    NumberSelection(usize),
-    NextPage,
-    ChatMessage(String),
-}
-
-// ── Handle result ───────────────────────────────────────────────────
-
-pub struct HandleResult {
-    pub reply: String,
-    pub actions: Vec<BotAction>,
-    pub forward_to_session: Option<ForwardRequest>,
-}
-
-#[derive(Debug, Clone)]
-pub struct BotInteractiveRequest {
-    pub reply: String,
-    pub actions: Vec<BotAction>,
-    pub pending_action: PendingAction,
-}
-
-pub type BotInteractionHandler =
-    Arc<dyn Fn(BotInteractiveRequest) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
-
-pub type BotMessageSender =
-    Arc<dyn Fn(String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
-
-pub struct ForwardRequest {
-    pub session_id: String,
-    pub content: String,
-    pub agent_type: String,
-    pub turn_id: String,
-    pub image_contexts: Vec<crate::agentic::image_analysis::ImageContextData>,
-}
-
-/// Result returned by [`execute_forwarded_turn`].
-pub struct ForwardedTurnResult {
-    /// Truncated text suitable for display in bot messages (≤ 4000 chars).
-    pub display_text: String,
-    /// Full untruncated response text from the tracker, suitable for
-    /// downloadable file link extraction.  Not affected by broadcast lag.
-    pub full_text: String,
-}
+// ── Question DTOs ──────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BotQuestionOption {
@@ -190,17 +174,19 @@ pub struct BotQuestion {
     pub multi_select: bool,
 }
 
-#[derive(Debug, Clone)]
-pub struct BotAction {
-    pub label: String,
-    pub command: String,
-    pub style: BotActionStyle,
-}
+// ── Action / handle result (compat surface) ────────────────────────
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BotActionStyle {
     Primary,
     Default,
+}
+
+#[derive(Debug, Clone)]
+pub struct BotAction {
+    pub label: String,
+    pub command: String,
+    pub style: BotActionStyle,
 }
 
 impl BotAction {
@@ -211,7 +197,6 @@ impl BotAction {
             style: BotActionStyle::Primary,
         }
     }
-
     pub fn secondary(label: impl Into<String>, command: impl Into<String>) -> Self {
         Self {
             label: label.into(),
@@ -221,7 +206,95 @@ impl BotAction {
     }
 }
 
-// ── Command parsing ─────────────────────────────────────────────────
+impl From<MenuItem> for BotAction {
+    fn from(item: MenuItem) -> Self {
+        let style = match item.style {
+            MenuItemStyle::Primary => BotActionStyle::Primary,
+            // Danger and Default both map to non-primary on platforms that
+            // don't have a native danger style.
+            _ => BotActionStyle::Default,
+        };
+        BotAction {
+            label: item.label,
+            command: item.command,
+            style,
+        }
+    }
+}
+
+pub struct HandleResult {
+    pub reply: String,
+    pub actions: Vec<BotAction>,
+    pub forward_to_session: Option<ForwardRequest>,
+    /// Same content as [`MenuView`] — adapters that want to render a richer
+    /// view (Telegram inline keyboard, Feishu card, WeChat numbered text)
+    /// can read this directly instead of `actions`.
+    pub menu: MenuView,
+}
+
+#[derive(Debug, Clone)]
+pub struct BotInteractiveRequest {
+    pub reply: String,
+    pub actions: Vec<BotAction>,
+    pub menu: MenuView,
+    pub pending_action: PendingAction,
+}
+
+pub type BotInteractionHandler =
+    Arc<dyn Fn(BotInteractiveRequest) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+
+pub type BotMessageSender =
+    Arc<dyn Fn(String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+
+pub struct ForwardRequest {
+    pub session_id: String,
+    pub content: String,
+    pub agent_type: String,
+    pub turn_id: String,
+    pub image_contexts: Vec<crate::agentic::image_analysis::ImageContextData>,
+}
+
+pub struct ForwardedTurnResult {
+    pub display_text: String,
+    pub full_text: String,
+}
+
+// ── BotCommand ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BotCommand {
+    /// Show welcome (unpaired) or main menu (paired).  Triggered by
+    /// `/start`, `/menu`, `/m`, `菜单`, or `0` at the top level.
+    Menu,
+    /// Show settings sub-menu.
+    Settings,
+    /// Show help text.
+    Help,
+    /// Switch display mode.
+    SwitchMode(BotDisplayMode),
+    /// Toggle verbose execution-detail mode (persisted globally).
+    SetVerbose(bool),
+    /// Generic "switch" entry — picks workspace or assistant by mode.
+    SwitchContext,
+    /// Generic "new session" entry — picks the right session type by mode.
+    NewSession,
+    /// Specific session creators (kept as hidden aliases).
+    NewCodeSession,
+    NewCoworkSession,
+    NewClawSession,
+    /// Resume an existing session (workspace or assistant by mode).
+    ResumeSession,
+    /// Cancel currently running task.
+    CancelTask(Option<String>),
+    /// Pairing code submitted before pairing.
+    PairingCode(String),
+    /// Numeric reply to a menu / pending action.
+    NumberSelection(usize),
+    /// Free-form chat message forwarded to the AI session.
+    ChatMessage(String),
+}
+
+// ── Command parsing ────────────────────────────────────────────────
 
 fn normalize_im_command_text(text: &str) -> String {
     text.trim()
@@ -235,7 +308,6 @@ fn normalize_im_command_text(text: &str) -> String {
         .collect()
 }
 
-/// Strip trailing list punctuation so "1." / "1、" / "1）" still parse as menu numbers.
 fn strip_numeric_reply_suffix(s: &str) -> &str {
     s.trim_end_matches(|c: char| {
         matches!(
@@ -257,137 +329,277 @@ pub fn parse_command(text: &str) -> BotCommand {
             BotCommand::CancelTask(Some(arg.to_string()))
         };
     }
-    match trimmed {
-        "/start" => BotCommand::Start,
-        "/switch_workspace" => BotCommand::SwitchWorkspace,
-        "/switch_assistant" => BotCommand::SwitchAssistant,
-        "/pro" => BotCommand::SwitchMode(BotDisplayMode::Pro),
-        "/assistant" => BotCommand::SwitchMode(BotDisplayMode::Assistant),
-        "/resume_session" => BotCommand::ResumeSession,
-        "/new_code_session" => BotCommand::NewCodeSession,
-        "/new_cowork_session" => BotCommand::NewCoworkSession,
-        "/new_claw_session" => BotCommand::NewClawSession,
-        "/help" => BotCommand::Help,
-        "0" => BotCommand::NextPage,
-        _ => {
-            if trimmed.len() == 6 && trimmed.chars().all(|c| c.is_ascii_digit()) {
-                BotCommand::PairingCode(trimmed.to_string())
-            } else {
-                let num_token = strip_numeric_reply_suffix(trimmed);
-                if let Ok(n) = num_token.parse::<usize>() {
-                    if (1..=99).contains(&n) {
-                        BotCommand::NumberSelection(n)
-                    } else {
-                        BotCommand::ChatMessage(trimmed.to_string())
-                    }
-                } else {
-                    BotCommand::ChatMessage(trimmed.to_string())
-                }
-            }
+    if let Some(rest) = trimmed.strip_prefix("/cancel") {
+        let arg = rest.trim();
+        return if arg.is_empty() {
+            BotCommand::CancelTask(None)
+        } else {
+            BotCommand::CancelTask(Some(arg.to_string()))
+        };
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    match lower.as_str() {
+        // Top-level navigation / settings.
+        "/start" | "/menu" | "/m" | "菜单" => return BotCommand::Menu,
+        "/settings" | "/s" | "设置" => return BotCommand::Settings,
+        "/help" | "/?" | "/h" | "帮助" | "？" => return BotCommand::Help,
+
+        // Mode switches (visible).
+        "/expert" | "/pro" | "专业模式" => {
+            return BotCommand::SwitchMode(BotDisplayMode::Pro);
+        }
+        "/assistant" | "助理模式" => {
+            return BotCommand::SwitchMode(BotDisplayMode::Assistant);
+        }
+
+        // Verbose toggles.
+        "/verbose" | "详细" => return BotCommand::SetVerbose(true),
+        "/concise" | "简洁" => return BotCommand::SetVerbose(false),
+
+        // Generic switch (picks workspace or assistant by mode).
+        "/switch" | "切换" => return BotCommand::SwitchContext,
+        // Hidden aliases.
+        "/switch_workspace" | "切换工作区" => return BotCommand::SwitchContext,
+        "/switch_assistant" | "切换助理" => return BotCommand::SwitchContext,
+
+        // Generic "new" picks the right session type by mode.
+        "/new" | "/n" | "新建" | "新建会话" | "新会话" => return BotCommand::NewSession,
+        // Hidden aliases / power users.
+        "/new_code_session" | "新建编码会话" => return BotCommand::NewCodeSession,
+        "/new_cowork_session" | "新建协作会话" => {
+            return BotCommand::NewCoworkSession;
+        }
+        "/new_claw_session" | "新建助理会话" => return BotCommand::NewClawSession,
+
+        // Resume.
+        "/resume" | "/r" | "/resume_session" | "恢复" | "恢复会话" => {
+            return BotCommand::ResumeSession;
+        }
+        _ => {}
+    }
+
+    if trimmed.len() == 6 && trimmed.chars().all(|c| c.is_ascii_digit()) {
+        return BotCommand::PairingCode(trimmed.to_string());
+    }
+
+    let num_token = strip_numeric_reply_suffix(trimmed);
+    if let Ok(n) = num_token.parse::<usize>() {
+        if n <= 99 {
+            // `0` is intentionally returned as `NumberSelection(0)` so context
+            // such as "next page" inside SelectSession can override the
+            // default "0 = back to menu" interpretation.  See `handle_number`.
+            return BotCommand::NumberSelection(n);
+        }
+    }
+    BotCommand::ChatMessage(trimmed.to_string())
+}
+
+// ── Public welcome / help text (compat) ───────────────────────────
+
+pub fn welcome_message(language: BotLanguage) -> &'static str {
+    strings_for(language).welcome
+}
+
+// ── MenuView -> HandleResult helpers ───────────────────────────────
+
+fn result_from_menu(state: &mut BotChatState, view: MenuView) -> HandleResult {
+    let actions: Vec<BotAction> = view.items.iter().cloned().map(BotAction::from).collect();
+    state.last_menu_commands = view.numeric_commands();
+    HandleResult {
+        reply: view.render_text_block(),
+        actions,
+        forward_to_session: None,
+        menu: view,
+    }
+}
+
+fn result_from_menu_with_forward(
+    state: &mut BotChatState,
+    view: MenuView,
+    forward: Option<ForwardRequest>,
+) -> HandleResult {
+    let mut r = result_from_menu(state, view);
+    r.forward_to_session = forward;
+    r
+}
+
+// ── Menu builders ──────────────────────────────────────────────────
+
+fn welcome_view(s: &'static BotStrings) -> MenuView {
+    MenuView::plain(s.welcome_title)
+        .with_body(s.welcome)
+        .with_footer(s.welcome_body)
+}
+
+fn ready_to_chat_body(state: &BotChatState, s: &'static BotStrings) -> Option<String> {
+    if state.current_session_id.is_some() {
+        Some(format!(
+            "{}: {}",
+            s.current_session_label,
+            short_session_label(state, s)
+        ))
+    } else if state.display_mode == BotDisplayMode::Pro {
+        match &state.current_workspace {
+            Some(p) => Some(format!(
+                "{}: {}",
+                s.current_workspace_label,
+                short_path_name(p)
+            )),
+            None => Some(s.no_workspace.to_string()),
+        }
+    } else {
+        match &state.current_assistant {
+            Some(p) => Some(format!(
+                "{}: {}",
+                s.current_assistant_label,
+                short_path_name(p)
+            )),
+            None => Some(s.no_assistant.to_string()),
         }
     }
 }
 
-// ── Static messages ─────────────────────────────────────────────────
-
-pub fn welcome_message(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "\
-欢迎使用 BitFun！
-
-要连接你的 BitFun 桌面端，请发送 BitFun Remote Connect 面板里显示的 6 位配对码。
-
-如果你还没有配对码，请打开 BitFun Desktop -> Remote Connect -> Telegram/飞书/微信机器人，复制 6 位配对码并发送到这里。"
-    } else {
-        "\
-Welcome to BitFun!
-
-To connect your BitFun desktop app, please enter the 6-digit pairing code shown in your BitFun Remote Connect panel.
-
-Need a pairing code? Open BitFun Desktop -> Remote Connect -> Telegram/Feishu/WeChat bot -> copy the 6-digit code and send it here."
-    }
+fn short_session_label(state: &BotChatState, s: &'static BotStrings) -> String {
+    state
+        .current_session_id
+        .as_deref()
+        .map(|id| {
+            // Show only the short tail to avoid showing full UUIDs.
+            let tail = id.rsplit('-').next().unwrap_or(id);
+            tail.to_string()
+        })
+        .unwrap_or_else(|| s.no_session.to_string())
 }
 
-pub fn help_message(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "\
-可用命令：
-/switch_workspace - 列出并切换工作区（专业模式）
-/switch_assistant - 列出并切换助理（助理模式）
-/pro - 切换到专业模式（可创建 Code/Cowork 会话）
-/assistant - 切换到助理模式（可创建助理会话）
-/verbose - 开启详细模式（显示任务执行过程）
-/concise - 开启简洁模式（仅显示最终结果）
-/new_code_session - 创建新的编码会话（专业模式）
-/new_cowork_session - 创建新的协作会话（专业模式）
-/new_claw_session - 创建新的助理会话（助理模式）
-/cancel_task - 取消当前任务
-/help - 显示帮助信息"
-    } else {
-        "\
-Available commands:
-/switch_workspace - List and switch workspaces (Expert mode)
-/switch_assistant - List and switch assistants (Assistant mode)
-/pro - Switch to Expert mode (can create Code/Cowork sessions)
-/assistant - Switch to Assistant mode (can create Claw sessions)
-/verbose - Enable verbose mode (show task execution progress)
-/concise - Enable concise mode (only show final results)
-/new_code_session - Create a new coding session (Expert mode)
-/new_cowork_session - Create a new cowork session (Expert mode)
-/new_claw_session - Create a new claw session (Assistant mode)
-/cancel_task - Cancel the current task
-/help - Show this help message"
-    }
+fn short_path_name(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| path.to_string())
 }
 
-pub fn paired_success_message(language: BotLanguage) -> String {
-    if language.is_chinese() {
-        format!("配对成功！BitFun 已连接。\n\n{}", help_message(language))
+fn main_menu_view(state: &BotChatState, s: &'static BotStrings) -> MenuView {
+    let title = if state.display_mode == BotDisplayMode::Pro {
+        s.main_title_expert
     } else {
-        format!(
-            "Pairing successful! BitFun is now connected.\n\n{}",
-            help_message(language)
-        )
+        s.main_title_assistant
+    };
+    let body = ready_to_chat_body(state, s);
+    let mut items: Vec<MenuItem> = Vec::new();
+    if state.display_mode == BotDisplayMode::Pro {
+        items.push(MenuItem::primary(s.item_new_code_session, "/new_code_session"));
+        items.push(MenuItem::default(
+            s.item_new_cowork_session,
+            "/new_cowork_session",
+        ));
+        items.push(MenuItem::default(s.item_resume_session, "/resume"));
+        items.push(MenuItem::default(s.item_switch_workspace, "/switch"));
+    } else {
+        items.push(MenuItem::primary(s.item_new_session, "/new"));
+        items.push(MenuItem::default(s.item_resume_session, "/resume"));
+        items.push(MenuItem::default(s.item_switch_assistant, "/switch"));
     }
+    items.push(MenuItem::default(s.item_settings, "/settings"));
+    let mut view = MenuView::plain(title).with_items(items);
+    if let Some(b) = body {
+        view = view.with_body(b);
+    }
+    view
 }
 
-/// After IM pairing: assistant mode, default assistant workspace, create a fresh Claw session.
-/// Always creates a new session so the user starts with a clean context in the IM channel.
-/// Mutates `state` (`display_mode`, `current_assistant`, `current_session_id`). Does not set `paired`.
+fn settings_menu_view(verbose: bool, state: &BotChatState, s: &'static BotStrings) -> MenuView {
+    let mut items: Vec<MenuItem> = Vec::new();
+    if state.display_mode == BotDisplayMode::Pro {
+        items.push(MenuItem::default(s.item_switch_to_assistant, "/assistant"));
+    } else {
+        items.push(MenuItem::default(s.item_switch_to_expert, "/expert"));
+    }
+    if verbose {
+        items.push(MenuItem::default(s.item_verbose_off, "/concise"));
+    } else {
+        items.push(MenuItem::default(s.item_verbose_on, "/verbose"));
+    }
+    items.push(MenuItem::default(s.item_help, "/help"));
+    items.push(MenuItem::default(s.item_back, "/menu"));
+    let body = format!(
+        "{} · {}: {}",
+        if state.display_mode == BotDisplayMode::Pro {
+            s.mode_expert
+        } else {
+            s.mode_assistant
+        },
+        s.verbose_label,
+        if verbose {
+            s.verbose_status_on
+        } else {
+            s.verbose_status_off
+        },
+    );
+    MenuView::plain(s.settings_title)
+        .with_body(body)
+        .with_items(items)
+}
+
+fn need_session_view(state: &BotChatState, s: &'static BotStrings) -> MenuView {
+    let mut items = Vec::new();
+    if state.display_mode == BotDisplayMode::Pro {
+        items.push(MenuItem::primary(s.item_new_code_session, "/new_code_session"));
+        items.push(MenuItem::default(
+            s.item_new_cowork_session,
+            "/new_cowork_session",
+        ));
+    } else {
+        items.push(MenuItem::primary(s.item_new_session, "/new"));
+    }
+    items.push(MenuItem::default(s.item_resume_session, "/resume"));
+    items.push(MenuItem::default(s.item_back, "/menu"));
+    MenuView::plain(s.need_session_title).with_items(items)
+}
+
+fn confirm_mode_switch_view(
+    target_mode: BotDisplayMode,
+    s: &'static BotStrings,
+) -> MenuView {
+    let target_label = if target_mode == BotDisplayMode::Pro {
+        s.mode_expert
+    } else {
+        s.mode_assistant
+    };
+    let body = format!(
+        "{} → {}",
+        s.mode_confirm_switch_prefix, target_label
+    );
+    MenuView::plain(s.settings_title)
+        .with_body(body)
+        .with_items(vec![
+            MenuItem::primary(s.item_confirm_switch, "1"),
+            MenuItem::default(s.item_back, "/menu"),
+        ])
+}
+
+// ── Public entry points ────────────────────────────────────────────
+
+/// IM pairing bootstrap: assistant mode + default assistant workspace + new
+/// Claw session.  Mutates `state.display_mode/current_assistant/
+/// current_session_id` on success.
 pub async fn bootstrap_im_chat_after_pairing(state: &mut BotChatState) -> String {
     use crate::service::workspace::get_global_workspace_service;
 
     state.display_mode = BotDisplayMode::Assistant;
     let language = current_bot_language().await;
+    let s = strings_for(language);
 
     let ws_service = match get_global_workspace_service() {
         Some(s) => s,
-        None => {
-            return if language.is_chinese() {
-                "自动准备未能完成：工作区服务不可用。请稍后在 BitFun 桌面端打开工作区后再试。"
-                    .to_string()
-            } else {
-                "Auto-setup incomplete: workspace service unavailable. Open a workspace in BitFun Desktop and try again."
-                    .to_string()
-            };
-        }
+        None => return s.bootstrap_workspace_unavailable.to_string(),
     };
 
     let mut assistants = ws_service.get_assistant_workspaces().await;
     if assistants.is_empty() {
         match ws_service.create_assistant_workspace(None).await {
             Ok(w) => assistants.push(w),
-            Err(e) => {
-                return if language.is_chinese() {
-                    format!(
-                        "自动准备未能完成：无法创建助理工作区（{e}）。请使用 /switch_assistant。"
-                    )
-                } else {
-                    format!(
-                        "Auto-setup incomplete: could not create assistant workspace ({e}). Use /switch_assistant."
-                    )
-                };
-            }
+            Err(e) => return format!("{}{e}", s.assistant_create_failed_prefix),
         }
     }
 
@@ -398,20 +610,12 @@ pub async fn bootstrap_im_chat_after_pairing(state: &mut BotChatState) -> String
         .or_else(|| assistants.first().cloned());
 
     let Some(ws_info) = picked else {
-        return if language.is_chinese() {
-            "自动准备未能完成：没有可用助理。请使用 /switch_assistant。".to_string()
-        } else {
-            "Auto-setup incomplete: no assistant found. Use /switch_assistant.".to_string()
-        };
+        return s.bootstrap_workspace_unavailable.to_string();
     };
 
     let path_buf = ws_info.root_path.clone();
     if let Err(e) = ws_service.open_workspace(path_buf.clone()).await {
-        return if language.is_chinese() {
-            format!("自动准备未能完成：无法打开助理工作区（{e}）。")
-        } else {
-            format!("Auto-setup incomplete: failed to open assistant workspace ({e}).")
-        };
+        return format!("{}{e}", s.workspace_open_failed_prefix);
     }
     if let Err(e) =
         crate::service::snapshot::initialize_snapshot_manager_for_workspace(path_buf, None).await
@@ -422,430 +626,49 @@ pub async fn bootstrap_im_chat_after_pairing(state: &mut BotChatState) -> String
     state.current_assistant = Some(ws_info.root_path.to_string_lossy().to_string());
     state.current_session_id = None;
 
-    let create_res = handle_new_session(state, "Claw").await;
+    let create_res = create_session(state, "Claw").await;
     if state.current_session_id.is_none() {
-        return if language.is_chinese() {
-            format!(
-                "已进入助理模式，但未能自动创建会话：{}",
-                create_res.reply.lines().next().unwrap_or("未知错误")
-            )
-        } else {
-            format!(
-                "Assistant mode is on, but session creation failed: {}",
-                create_res.reply.lines().next().unwrap_or("unknown error")
-            )
-        };
+        let detail = create_res
+            .reply
+            .lines()
+            .next()
+            .unwrap_or("")
+            .to_string();
+        return format!("{}{detail}", s.bootstrap_session_failed_prefix);
     }
 
-    if language.is_chinese() {
-        "已进入助理模式，已为你新建助理会话。直接发送消息即可开始。".to_string()
-    } else {
-        "Assistant mode is on; a new assistant session was created. Send a message to start."
-            .to_string()
-    }
+    s.bootstrap_ready.to_string()
 }
 
-/// Mark chat paired, run assistant/session bootstrap, return first user-visible message + main menu actions.
+/// Mark chat paired, run assistant/session bootstrap, return main menu.
 pub async fn complete_im_bot_pairing(state: &mut BotChatState) -> HandleResult {
     state.paired = true;
     let language = current_bot_language().await;
+    let s = strings_for(language);
     let note = bootstrap_im_chat_after_pairing(state).await;
-    let reply = format!("{}\n\n{}", paired_success_message(language), note);
-    let actions = main_menu_actions(language, state.display_mode);
-    state.last_menu_commands = actions.iter().map(|a| a.command.clone()).collect();
-    HandleResult {
-        reply,
-        actions,
-        forward_to_session: None,
-    }
+
+    let mut view = main_menu_view(state, s);
+    let combined_body = match view.body.take() {
+        Some(b) => format!("{}\n\n{}\n\n{}", s.paired_success, note, b),
+        None => format!("{}\n\n{}", s.paired_success, note),
+    };
+    view = view.with_body(combined_body);
+    result_from_menu(state, view)
 }
 
-fn label_switch_workspace(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "切换工作区"
-    } else {
-        "Switch Workspace"
-    }
+/// Public adapter helper: install an interactive request received from the
+/// session executor onto the chat state and refresh its TTL.
+pub fn apply_interactive_request(state: &mut BotChatState, req: &BotInteractiveRequest) {
+    state.set_pending(req.pending_action.clone());
+    state.last_menu_commands = req
+        .menu
+        .items
+        .iter()
+        .map(|i| i.command.clone())
+        .collect();
 }
 
-fn label_resume_session(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "恢复会话"
-    } else {
-        "Resume Session"
-    }
-}
-
-fn label_new_code_session(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "新建编码会话"
-    } else {
-        "New Code Session"
-    }
-}
-
-fn label_new_cowork_session(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "新建协作会话"
-    } else {
-        "New Cowork Session"
-    }
-}
-
-fn label_new_claw_session(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "新建助理会话"
-    } else {
-        "New Claw Session"
-    }
-}
-
-fn label_switch_assistant(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "切换助理"
-    } else {
-        "Switch Assistant"
-    }
-}
-
-fn label_help(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "帮助"
-    } else {
-        "Help"
-    }
-}
-
-fn label_cancel_task(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "取消任务"
-    } else {
-        "Cancel Task"
-    }
-}
-
-fn label_next_page(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "下一页"
-    } else {
-        "Next Page"
-    }
-}
-
-fn label_switch_pro_mode(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "专业模式"
-    } else {
-        "Expert Mode"
-    }
-}
-
-fn label_switch_assistant_mode(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "助理模式"
-    } else {
-        "Assistant Mode"
-    }
-}
-
-fn other_label(language: BotLanguage) -> &'static str {
-    if language.is_chinese() {
-        "其他"
-    } else {
-        "Other"
-    }
-}
-
-pub fn main_menu_actions(language: BotLanguage, display_mode: BotDisplayMode) -> Vec<BotAction> {
-    let is_pro = display_mode == BotDisplayMode::Pro;
-
-    if is_pro {
-        // Pro mode: show workspace switch
-        vec![
-            BotAction::primary(label_switch_workspace(language), "/switch_workspace"),
-            BotAction::secondary(label_resume_session(language), "/resume_session"),
-            BotAction::secondary(label_switch_assistant_mode(language), "/assistant"),
-            BotAction::secondary(label_new_code_session(language), "/new_code_session"),
-            BotAction::secondary(label_new_cowork_session(language), "/new_cowork_session"),
-            BotAction::secondary(label_help(language), "/help"),
-        ]
-    } else {
-        // Assistant mode: show assistant switch (not workspace)
-        vec![
-            BotAction::primary(label_switch_assistant(language), "/switch_assistant"),
-            BotAction::secondary(label_resume_session(language), "/resume_session"),
-            BotAction::secondary(label_switch_pro_mode(language), "/pro"),
-            BotAction::secondary(label_new_claw_session(language), "/new_claw_session"),
-            BotAction::secondary(label_help(language), "/help"),
-        ]
-    }
-}
-
-fn pro_mode_actions(language: BotLanguage) -> Vec<BotAction> {
-    vec![
-        BotAction::primary(label_new_code_session(language), "/new_code_session"),
-        BotAction::secondary(label_new_cowork_session(language), "/new_cowork_session"),
-        BotAction::secondary(label_switch_workspace(language), "/switch_workspace"),
-        BotAction::secondary(label_switch_assistant_mode(language), "/assistant"),
-        BotAction::secondary(label_help(language), "/help"),
-    ]
-}
-
-fn assistant_mode_actions(language: BotLanguage) -> Vec<BotAction> {
-    vec![
-        BotAction::primary(label_new_claw_session(language), "/new_claw_session"),
-        BotAction::secondary(label_switch_assistant(language), "/switch_assistant"),
-        BotAction::secondary(label_switch_pro_mode(language), "/pro"),
-        BotAction::secondary(label_help(language), "/help"),
-    ]
-}
-
-fn workspace_required_actions(language: BotLanguage) -> Vec<BotAction> {
-    vec![BotAction::primary(
-        label_switch_workspace(language),
-        "/switch_workspace",
-    )]
-}
-
-fn assistant_required_actions(language: BotLanguage) -> Vec<BotAction> {
-    vec![BotAction::primary(
-        label_switch_assistant(language),
-        "/switch_assistant",
-    )]
-}
-
-fn session_entry_actions(language: BotLanguage, display_mode: BotDisplayMode) -> Vec<BotAction> {
-    let is_pro = display_mode == BotDisplayMode::Pro;
-    if is_pro {
-        vec![
-            BotAction::primary(label_resume_session(language), "/resume_session"),
-            BotAction::secondary(label_new_code_session(language), "/new_code_session"),
-            BotAction::secondary(label_new_cowork_session(language), "/new_cowork_session"),
-            BotAction::secondary(label_switch_workspace(language), "/switch_workspace"),
-            BotAction::secondary(label_switch_assistant_mode(language), "/assistant"),
-            BotAction::secondary(label_help(language), "/help"),
-        ]
-    } else {
-        vec![
-            BotAction::primary(label_resume_session(language), "/resume_session"),
-            BotAction::secondary(label_new_claw_session(language), "/new_claw_session"),
-            BotAction::secondary(label_switch_assistant(language), "/switch_assistant"),
-            BotAction::secondary(label_switch_pro_mode(language), "/pro"),
-            BotAction::secondary(label_help(language), "/help"),
-        ]
-    }
-}
-
-fn new_session_actions(language: BotLanguage, display_mode: BotDisplayMode) -> Vec<BotAction> {
-    let is_pro = display_mode == BotDisplayMode::Pro;
-    if is_pro {
-        vec![
-            BotAction::primary(label_new_code_session(language), "/new_code_session"),
-            BotAction::secondary(label_new_cowork_session(language), "/new_cowork_session"),
-            BotAction::secondary(label_switch_workspace(language), "/switch_workspace"),
-            BotAction::secondary(label_switch_assistant_mode(language), "/assistant"),
-            BotAction::secondary(label_help(language), "/help"),
-        ]
-    } else {
-        vec![
-            BotAction::primary(label_new_claw_session(language), "/new_claw_session"),
-            BotAction::secondary(label_switch_assistant(language), "/switch_assistant"),
-            BotAction::secondary(label_switch_pro_mode(language), "/pro"),
-            BotAction::secondary(label_help(language), "/help"),
-        ]
-    }
-}
-
-fn cancel_task_actions(language: BotLanguage, command: impl Into<String>) -> Vec<BotAction> {
-    vec![BotAction::secondary(
-        label_cancel_task(language),
-        command.into(),
-    )]
-}
-
-// ── Main dispatch ───────────────────────────────────────────────────
-
-async fn dispatch_im_bot_command(
-    state: &mut BotChatState,
-    cmd: BotCommand,
-    image_contexts: Vec<crate::agentic::image_analysis::ImageContextData>,
-) -> HandleResult {
-    let r = dispatch_im_bot_command_inner(state, cmd, image_contexts).await;
-    if !r.actions.is_empty() {
-        state.last_menu_commands = r.actions.iter().map(|a| a.command.clone()).collect();
-    }
-    r
-}
-
-async fn dispatch_im_bot_command_inner(
-    state: &mut BotChatState,
-    cmd: BotCommand,
-    image_contexts: Vec<crate::agentic::image_analysis::ImageContextData>,
-) -> HandleResult {
-    let language = current_bot_language().await;
-    match cmd {
-        BotCommand::Start | BotCommand::Help => {
-            if state.paired {
-                HandleResult {
-                    reply: help_message(language).to_string(),
-                    actions: main_menu_actions(language, state.display_mode),
-                    forward_to_session: None,
-                }
-            } else {
-                HandleResult {
-                    reply: welcome_message(language).to_string(),
-                    actions: vec![],
-                    forward_to_session: None,
-                }
-            }
-        }
-        BotCommand::SwitchMode(new_mode) => {
-            if !state.paired {
-                not_paired(language)
-            } else {
-                state.display_mode = new_mode;
-                let mode_name = if new_mode == BotDisplayMode::Pro {
-                    if language.is_chinese() {
-                        "专业模式"
-                    } else {
-                        "Expert Mode"
-                    }
-                } else {
-                    if language.is_chinese() {
-                        "助理模式"
-                    } else {
-                        "Assistant Mode"
-                    }
-                };
-                let desc = if new_mode == BotDisplayMode::Pro {
-                    if language.is_chinese() {
-                        "适合目标明确、一次完成的即时任务。"
-                    } else {
-                        "Best for focused, one-shot tasks with a clear goal."
-                    }
-                } else {
-                    if language.is_chinese() {
-                        "适合持续推进、需要延续上下文和个人偏好的任务。"
-                    } else {
-                        "Best for ongoing work with context and personal preferences."
-                    }
-                };
-                HandleResult {
-                    reply: if language.is_chinese() {
-                        format!("已切换到 {}\n\n{}\n\n你现在可以：", mode_name, desc)
-                    } else {
-                        format!("Switched to {}\n\n{}\n\nYou can now:", mode_name, desc)
-                    },
-                    actions: if new_mode == BotDisplayMode::Pro {
-                        pro_mode_actions(language)
-                    } else {
-                        assistant_mode_actions(language)
-                    },
-                    forward_to_session: None,
-                }
-            }
-        }
-        BotCommand::PairingCode(_) => HandleResult {
-            reply: if language.is_chinese() {
-                "配对码会自动处理。如果你需要重新配对，请在 BitFun Desktop 中重新启动连接。"
-                    .to_string()
-            } else {
-                "Pairing codes are handled automatically. If you need to re-pair, please restart the connection from BitFun Desktop."
-                    .to_string()
-            },
-            actions: vec![],
-            forward_to_session: None,
-        },
-        BotCommand::SwitchWorkspace => {
-            if !state.paired {
-                return not_paired(language);
-            }
-            handle_switch_workspace(state).await
-        }
-        BotCommand::SwitchAssistant => {
-            if !state.paired {
-                return not_paired(language);
-            }
-            handle_switch_assistant(state).await
-        }
-        BotCommand::ResumeSession => {
-            if !state.paired {
-                return not_paired(language);
-            }
-            if state.display_mode == BotDisplayMode::Pro {
-                if state.current_workspace.is_none() {
-                    return need_workspace(language);
-                }
-            } else {
-                if state.current_assistant.is_none() {
-                    return need_assistant(language);
-                }
-            }
-            handle_resume_session(state, 0).await
-        }
-        BotCommand::NewCodeSession => {
-            if !state.paired {
-                return not_paired(language);
-            }
-            // Code session only available in Pro mode
-            if state.display_mode != BotDisplayMode::Pro {
-                return wrong_mode_for_pro(language);
-            }
-            if state.current_workspace.is_none() {
-                return need_workspace(language);
-            }
-            handle_new_session(state, "agentic").await
-        }
-        BotCommand::NewCoworkSession => {
-            if !state.paired {
-                return not_paired(language);
-            }
-            // Cowork session only available in Pro mode
-            if state.display_mode != BotDisplayMode::Pro {
-                return wrong_mode_for_pro(language);
-            }
-            if state.current_workspace.is_none() {
-                return need_workspace(language);
-            }
-            handle_new_session(state, "Cowork").await
-        }
-        BotCommand::NewClawSession => {
-            if !state.paired {
-                return not_paired(language);
-            }
-            // Claw session only available in Assistant mode
-            if state.display_mode != BotDisplayMode::Assistant {
-                return wrong_mode_for_assistant(language);
-            }
-            // Claw sessions don't need workspace
-            handle_new_session(state, "Claw").await
-        }
-        BotCommand::CancelTask(turn_id) => {
-            if !state.paired {
-                return not_paired(language);
-            }
-            handle_cancel_task(state, turn_id.as_deref()).await
-        }
-        BotCommand::NumberSelection(n) => {
-            if !state.paired {
-                return not_paired(language);
-            }
-            handle_number_selection(state, n).await
-        }
-        BotCommand::NextPage => {
-            if !state.paired {
-                return not_paired(language);
-            }
-            handle_next_page(state).await
-        }
-        BotCommand::ChatMessage(msg) => {
-            if !state.paired {
-                return not_paired(language);
-            }
-            handle_chat_message(state, &msg, image_contexts).await
-        }
-    }
-}
+// ── Dispatch ───────────────────────────────────────────────────────
 
 pub async fn handle_command(
     state: &mut BotChatState,
@@ -858,847 +681,303 @@ pub async fn handle_command(
         } else {
             Some(&images)
         });
-    dispatch_im_bot_command(state, cmd, image_contexts).await
+    dispatch(state, cmd, image_contexts).await
 }
 
-// ── Helpers ─────────────────────────────────────────────────────────
-
-fn not_paired(language: BotLanguage) -> HandleResult {
-    HandleResult {
-        reply: if language.is_chinese() {
-            "尚未连接到 BitFun Desktop。请先发送 6 位配对码。".to_string()
-        } else {
-            "Not connected to BitFun Desktop. Please enter the 6-digit pairing code first."
-                .to_string()
-        },
-        actions: vec![],
-        forward_to_session: None,
-    }
-}
-
-fn need_workspace(language: BotLanguage) -> HandleResult {
-    HandleResult {
-        reply: if language.is_chinese() {
-            "尚未选择工作区。请先使用 /switch_workspace。".to_string()
-        } else {
-            "No workspace selected. Use /switch_workspace first.".to_string()
-        },
-        actions: workspace_required_actions(language),
-        forward_to_session: None,
-    }
-}
-
-fn need_assistant(language: BotLanguage) -> HandleResult {
-    HandleResult {
-        reply: if language.is_chinese() {
-            "尚未选择助理。请先使用 /switch_assistant。".to_string()
-        } else {
-            "No assistant selected. Use /switch_assistant first.".to_string()
-        },
-        actions: assistant_required_actions(language),
-        forward_to_session: None,
-    }
-}
-
-fn wrong_mode_for_pro(language: BotLanguage) -> HandleResult {
-    HandleResult {
-        reply: if language.is_chinese() {
-            "该会话只能在专业模式下创建。请先发送 /pro 切换到专业模式。".to_string()
-        } else {
-            "This session can only be created in Expert mode. Please send /pro to switch to Expert mode.".to_string()
-        },
-        actions: pro_mode_actions(language),
-        forward_to_session: None,
-    }
-}
-
-fn wrong_mode_for_assistant(language: BotLanguage) -> HandleResult {
-    HandleResult {
-        reply: if language.is_chinese() {
-            "该会话只能在助理模式下创建。请先发送 /assistant 切换到助理模式。".to_string()
-        } else {
-            "This session can only be created in Assistant mode. Please send /assistant to switch to Assistant mode.".to_string()
-        },
-        actions: assistant_mode_actions(language),
-        forward_to_session: None,
-    }
-}
-
-fn question_option_line(index: usize, option: &BotQuestionOption) -> String {
-    if option.description.is_empty() {
-        format!("{}. {}", index + 1, option.label)
-    } else {
-        format!("{}. {} - {}", index + 1, option.label, option.description)
-    }
-}
-
-fn truncate_action_label(label: &str, max_chars: usize) -> String {
-    let trimmed = label.trim();
-    if trimmed.chars().count() <= max_chars {
-        trimmed.to_string()
-    } else {
-        let truncated: String = trimmed.chars().take(max_chars.saturating_sub(3)).collect();
-        format!("{truncated}...")
-    }
-}
-
-fn numbered_actions(labels: &[String]) -> Vec<BotAction> {
-    labels
-        .iter()
-        .enumerate()
-        .map(|(idx, label)| {
-            BotAction::secondary(truncate_action_label(label, 28), (idx + 1).to_string())
-        })
-        .collect()
-}
-
-fn build_question_prompt(
-    language: BotLanguage,
-    tool_id: String,
-    questions: Vec<BotQuestion>,
-    current_index: usize,
-    answers: Vec<Value>,
-    awaiting_custom_text: bool,
-    pending_answer: Option<Value>,
-) -> BotInteractiveRequest {
-    let question = &questions[current_index];
-    let mut actions = Vec::new();
-    let mut reply = format!(
-        "{} {}/{}\n",
-        if language.is_chinese() {
-            "问题"
-        } else {
-            "Question"
-        },
-        current_index + 1,
-        questions.len(),
-    );
-    if !question.header.is_empty() {
-        reply.push_str(&format!("{}\n", question.header));
-    }
-    reply.push_str(&format!("{}\n\n", question.question));
-    for (idx, option) in question.options.iter().enumerate() {
-        reply.push_str(&format!("{}\n", question_option_line(idx, option)));
-    }
-    reply.push_str(&format!(
-        "{}. {}\n\n",
-        question.options.len() + 1,
-        other_label(language),
-    ));
-    if awaiting_custom_text {
-        reply.push_str(if language.is_chinese() {
-            "请输入你的自定义答案。"
-        } else {
-            "Please type your custom answer."
-        });
-    } else if question.multi_select {
-        reply.push_str(if language.is_chinese() {
-            "请回复一个或多个选项编号，用逗号分隔，例如：1,3"
-        } else {
-            "Reply with one or more option numbers, separated by commas. Example: 1,3"
-        });
-    } else {
-        reply.push_str(if language.is_chinese() {
-            "请回复单个选项编号。"
-        } else {
-            "Reply with a single option number."
-        });
-        let mut labels: Vec<String> = question
-            .options
-            .iter()
-            .map(|option| option.label.clone())
-            .collect();
-        labels.push(other_label(language).to_string());
-        actions = numbered_actions(&labels);
-    }
-
-    BotInteractiveRequest {
-        reply,
-        actions,
-        pending_action: PendingAction::AskUserQuestion {
-            tool_id,
-            questions,
-            current_index,
-            answers,
-            awaiting_custom_text,
-            pending_answer,
-        },
-    }
-}
-
-fn parse_question_numbers(input: &str) -> Option<Vec<usize>> {
-    let mut result = Vec::new();
-    for part in input.split(',') {
-        let trimmed = part.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let value = trimmed.parse::<usize>().ok()?;
-        result.push(value);
-    }
-    if result.is_empty() {
-        None
-    } else {
-        Some(result)
-    }
-}
-
-async fn handle_switch_workspace(state: &mut BotChatState) -> HandleResult {
-    use crate::service::workspace::get_global_workspace_service;
+async fn dispatch(
+    state: &mut BotChatState,
+    cmd: BotCommand,
+    image_contexts: Vec<crate::agentic::image_analysis::ImageContextData>,
+) -> HandleResult {
     let language = current_bot_language().await;
+    let s = strings_for(language);
+
+    // Auto-expire pending actions before any branch.
+    if state.pending_expired() {
+        state.clear_pending();
+        let mut view = main_menu_view(state, s);
+        view = view.with_body(s.pending_expired);
+        return result_from_menu(state, view);
+    }
+
+    // Universal escape hatches: /menu and /start always return the main menu
+    // and clear any pending action.
+    if matches!(cmd, BotCommand::Menu) {
+        state.clear_pending();
+        return menu_or_welcome(state, s);
+    }
+
+    // Pairing-code submitted after pairing already completed → just nudge.
+    if let BotCommand::PairingCode(_) = &cmd {
+        if state.paired {
+            let view = MenuView::plain(s.main_title_assistant)
+                .with_body(s.paired_success)
+                .with_items(main_menu_view(state, s).items);
+            return result_from_menu(state, view);
+        }
+        // Not paired path is handled by the platform wait_for_pairing loop.
+    }
+
+    if !state.paired {
+        return result_from_menu(state, welcome_view(s));
+    }
+
+    // Handle /cancel as task cancellation when an active session exists.
+    if let BotCommand::CancelTask(turn_id) = &cmd {
+        return handle_cancel_task(state, turn_id.as_deref(), s).await;
+    }
+
+    // Numeric replies: when there is a pending action, route to it.  When
+    // there isn't, treat the number as an index into `last_menu_commands`.
+    if let BotCommand::NumberSelection(n) = cmd {
+        return handle_number(state, n, s).await;
+    }
+
+    match cmd {
+        BotCommand::Help => result_from_menu(
+            state,
+            MenuView::plain(s.welcome_title)
+                .with_body(s.help_body)
+                .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+        ),
+        BotCommand::Settings => {
+            let verbose = super::load_bot_persistence().verbose_mode;
+            result_from_menu(state, settings_menu_view(verbose, state, s))
+        }
+        BotCommand::SwitchMode(target) => switch_mode(state, target, s).await,
+        BotCommand::SetVerbose(on) => set_verbose(state, on, s).await,
+        BotCommand::SwitchContext => start_switch(state, s).await,
+        BotCommand::NewSession => new_session_for_mode(state, s).await,
+        BotCommand::NewCodeSession => guarded_new(state, "agentic", s).await,
+        BotCommand::NewCoworkSession => guarded_new(state, "Cowork", s).await,
+        BotCommand::NewClawSession => guarded_new(state, "Claw", s).await,
+        BotCommand::ResumeSession => start_resume(state, 0, s).await,
+        BotCommand::ChatMessage(msg) => handle_chat(state, &msg, image_contexts, s).await,
+        BotCommand::Menu
+        | BotCommand::CancelTask(_)
+        | BotCommand::NumberSelection(_)
+        | BotCommand::PairingCode(_) => menu_or_welcome(state, s), // already handled
+    }
+}
+
+fn menu_or_welcome(state: &mut BotChatState, s: &'static BotStrings) -> HandleResult {
+    if state.paired {
+        result_from_menu(state, main_menu_view(state, s))
+    } else {
+        result_from_menu(state, welcome_view(s))
+    }
+}
+
+// ── Mode switching ─────────────────────────────────────────────────
+
+async fn switch_mode(
+    state: &mut BotChatState,
+    target: BotDisplayMode,
+    s: &'static BotStrings,
+) -> HandleResult {
+    if state.display_mode == target {
+        let body = if target == BotDisplayMode::Pro {
+            s.mode_already_expert
+        } else {
+            s.mode_already_assistant
+        };
+        let mut view = main_menu_view(state, s);
+        view = view.with_body(body);
+        return result_from_menu(state, view);
+    }
+    state.display_mode = target;
+    let body = if target == BotDisplayMode::Pro {
+        s.mode_switched_to_expert
+    } else {
+        s.mode_switched_to_assistant
+    };
+    let mut view = main_menu_view(state, s);
+    view = view.with_body(body);
+    result_from_menu(state, view)
+}
+
+async fn confirm_then_run(
+    state: &mut BotChatState,
+    target: BotDisplayMode,
+    target_cmd: String,
+    s: &'static BotStrings,
+) -> HandleResult {
+    state.set_pending(PendingAction::ConfirmModeSwitch {
+        target_mode: target,
+        target_cmd,
+    });
+    result_from_menu(state, confirm_mode_switch_view(target, s))
+}
+
+async fn set_verbose(
+    state: &mut BotChatState,
+    on: bool,
+    s: &'static BotStrings,
+) -> HandleResult {
+    let mut data = super::load_bot_persistence();
+    data.verbose_mode = on;
+    super::save_bot_persistence(&data);
+
+    let body = if on {
+        s.verbose_enabled
+    } else {
+        s.verbose_disabled
+    };
+    let mut view = settings_menu_view(on, state, s);
+    view = view.with_body(body);
+    result_from_menu(state, view)
+}
+
+// ── Switch context (workspace or assistant) ────────────────────────
+
+async fn start_switch(
+    state: &mut BotChatState,
+    s: &'static BotStrings,
+) -> HandleResult {
+    use crate::service::workspace::get_global_workspace_service;
 
     let ws_service = match get_global_workspace_service() {
         Some(s) => s,
         None => {
-            return HandleResult {
-                reply: if language.is_chinese() {
-                    "工作区服务不可用。".to_string()
-                } else {
-                    "Workspace service not available.".to_string()
-                },
-                actions: vec![],
-                forward_to_session: None,
-            };
-        }
-    };
-
-    let workspaces = ws_service.get_recent_workspaces().await;
-    if workspaces.is_empty() {
-        return HandleResult {
-            reply: if language.is_chinese() {
-                "未找到工作区。请先在 BitFun Desktop 中打开一个项目。".to_string()
-            } else {
-                "No workspaces found. Please open a project in BitFun Desktop first.".to_string()
-            },
-            actions: vec![],
-            forward_to_session: None,
-        };
-    }
-
-    let effective_current: Option<&str> = state.current_workspace.as_deref();
-
-    let mut text = if language.is_chinese() {
-        String::from("请选择工作区：\n\n")
-    } else {
-        String::from("Select a workspace:\n\n")
-    };
-    let mut options: Vec<(String, String)> = Vec::new();
-    for (i, ws) in workspaces.iter().enumerate() {
-        let path = ws.root_path.to_string_lossy().to_string();
-        let is_current = effective_current == Some(path.as_str());
-        let marker = if is_current {
-            if language.is_chinese() {
-                " [当前]"
-            } else {
-                " [current]"
-            }
-        } else {
-            ""
-        };
-        text.push_str(&format!("{}. {}{}\n   {}\n", i + 1, ws.name, marker, path));
-        options.push((path, ws.name.clone()));
-    }
-    text.push_str(if language.is_chinese() {
-        "\n请回复工作区编号。"
-    } else {
-        "\nReply with the workspace number."
-    });
-
-    let action_labels: Vec<String> = options.iter().map(|(_, name)| name.clone()).collect();
-    state.pending_action = Some(PendingAction::SelectWorkspace { options });
-    HandleResult {
-        reply: text,
-        actions: numbered_actions(&action_labels),
-        forward_to_session: None,
-    }
-}
-
-async fn handle_switch_assistant(state: &mut BotChatState) -> HandleResult {
-    use crate::service::workspace::get_global_workspace_service;
-    let language = current_bot_language().await;
-
-    let ws_service = match get_global_workspace_service() {
-        Some(s) => s,
-        None => {
-            return HandleResult {
-                reply: if language.is_chinese() {
-                    "工作区服务不可用。".to_string()
-                } else {
-                    "Workspace service not available.".to_string()
-                },
-                actions: vec![],
-                forward_to_session: None,
-            };
-        }
-    };
-
-    let assistants = ws_service.get_assistant_workspaces().await;
-    if assistants.is_empty() {
-        return HandleResult {
-            reply: if language.is_chinese() {
-                "未找到助理。请先在 BitFun Desktop 中创建助理。".to_string()
-            } else {
-                "No assistants found. Please create an assistant in BitFun Desktop first."
-                    .to_string()
-            },
-            actions: assistant_mode_actions(language),
-            forward_to_session: None,
-        };
-    }
-
-    let effective_current: Option<&str> = state.current_assistant.as_deref();
-
-    let mut text = if language.is_chinese() {
-        String::from("请选择助理：\n\n")
-    } else {
-        String::from("Select an assistant:\n\n")
-    };
-    let mut options: Vec<(String, String)> = Vec::new();
-    for (i, ws) in assistants.iter().enumerate() {
-        let path = ws.root_path.to_string_lossy().to_string();
-        let is_current = effective_current == Some(path.as_str());
-        let marker = if is_current {
-            if language.is_chinese() {
-                " [当前]"
-            } else {
-                " [current]"
-            }
-        } else {
-            ""
-        };
-        text.push_str(&format!("{}. {}{}\n", i + 1, ws.name, marker));
-        options.push((path, ws.name.clone()));
-    }
-    text.push_str(if language.is_chinese() {
-        "\n请回复助理编号。"
-    } else {
-        "\nReply with the assistant number."
-    });
-
-    let action_labels: Vec<String> = options.iter().map(|(_, name)| name.clone()).collect();
-    state.pending_action = Some(PendingAction::SelectAssistant { options });
-    HandleResult {
-        reply: text,
-        actions: numbered_actions(&action_labels),
-        forward_to_session: None,
-    }
-}
-
-async fn handle_resume_session(state: &mut BotChatState, page: usize) -> HandleResult {
-    use crate::agentic::persistence::PersistenceManager;
-    use crate::infrastructure::PathManager;
-    let language = current_bot_language().await;
-
-    let ws_path = if state.display_mode == BotDisplayMode::Pro {
-        match &state.current_workspace {
-            Some(p) => std::path::PathBuf::from(p),
-            None => return need_workspace(language),
-        }
-    } else {
-        match &state.current_assistant {
-            Some(p) => std::path::PathBuf::from(p),
-            None => return need_assistant(language),
-        }
-    };
-
-    let page_size = 10usize;
-    let offset = page * page_size;
-
-    let pm = match PathManager::new() {
-        Ok(pm) => std::sync::Arc::new(pm),
-        Err(e) => {
-            return HandleResult {
-                reply: if language.is_chinese() {
-                    format!("加载会话失败：{e}")
-                } else {
-                    format!("Failed to load sessions: {e}")
-                },
-                actions: vec![],
-                forward_to_session: None,
-            };
-        }
-    };
-
-    let store = match PersistenceManager::new(pm) {
-        Ok(store) => store,
-        Err(e) => {
-            return HandleResult {
-                reply: if language.is_chinese() {
-                    format!("加载会话失败：{e}")
-                } else {
-                    format!("Failed to load sessions: {e}")
-                },
-                actions: vec![],
-                forward_to_session: None,
-            };
-        }
-    };
-
-    let all_meta = match store.list_session_metadata(&ws_path).await {
-        Ok(m) => m,
-        Err(e) => {
-            return HandleResult {
-                reply: if language.is_chinese() {
-                    format!("列出会话失败：{e}")
-                } else {
-                    format!("Failed to list sessions: {e}")
-                },
-                actions: vec![],
-                forward_to_session: None,
-            };
-        }
-    };
-
-    if all_meta.is_empty() {
-        let reply = if language.is_chinese() {
-            if state.display_mode == BotDisplayMode::Pro {
-                "当前工作区没有会话。请使用 /new_code_session 或 /new_cowork_session 创建一个。"
-                    .to_string()
-            } else {
-                "当前工作区没有会话。请使用 /new_claw_session 创建一个。".to_string()
-            }
-        } else {
-            if state.display_mode == BotDisplayMode::Pro {
-                "No sessions found in this workspace. Use /new_code_session or /new_cowork_session to create one.".to_string()
-            } else {
-                "No sessions found in this workspace. Use /new_claw_session to create one."
-                    .to_string()
-            }
-        };
-        return HandleResult {
-            reply,
-            actions: new_session_actions(language, state.display_mode),
-            forward_to_session: None,
-        };
-    }
-
-    let total = all_meta.len();
-    let has_more = offset + page_size < total;
-    let sessions: Vec<_> = all_meta.into_iter().skip(offset).take(page_size).collect();
-
-    let ws_name = ws_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| {
-            if language.is_chinese() {
-                "未知".to_string()
-            } else {
-                "Unknown".to_string()
-            }
-        });
-
-    let mut text = if language.is_chinese() {
-        format!("{} 中的会话（第 {} 页）：\n\n", ws_name, page + 1)
-    } else {
-        format!("Sessions in {} (page {}):\n\n", ws_name, page + 1)
-    };
-    let mut options: Vec<(String, String)> = Vec::new();
-    for (i, s) in sessions.iter().enumerate() {
-        let is_current = state.current_session_id.as_deref() == Some(&s.session_id);
-        let marker = if is_current {
-            if language.is_chinese() {
-                " [当前]"
-            } else {
-                " [current]"
-            }
-        } else {
-            ""
-        };
-        let ts = chrono::DateTime::from_timestamp(s.last_active_at as i64 / 1000, 0)
-            .map(|dt| dt.format("%m-%d %H:%M").to_string())
-            .unwrap_or_default();
-        let turn_count = s.turn_count;
-        let msg_hint = if turn_count == 0 {
-            if language.is_chinese() {
-                "无消息".to_string()
-            } else {
-                "no messages".to_string()
-            }
-        } else if turn_count == 1 {
-            if language.is_chinese() {
-                "1 条消息".to_string()
-            } else {
-                "1 message".to_string()
-            }
-        } else {
-            if language.is_chinese() {
-                format!("{turn_count} 条消息")
-            } else {
-                format!("{turn_count} messages")
-            }
-        };
-        text.push_str(&format!(
-            "{}. [{}] {}{}\n   {} · {}\n",
-            i + 1,
-            s.agent_type,
-            s.session_name,
-            marker,
-            ts,
-            msg_hint,
-        ));
-        options.push((s.session_id.clone(), s.session_name.clone()));
-    }
-    if has_more {
-        text.push_str(if language.is_chinese() {
-            "\n0 - 下一页\n"
-        } else {
-            "\n0 - Next page\n"
-        });
-    }
-    text.push_str(if language.is_chinese() {
-        "\n请回复会话编号。"
-    } else {
-        "\nReply with the session number."
-    });
-
-    state.pending_action = Some(PendingAction::SelectSession {
-        options,
-        page,
-        has_more,
-    });
-    let mut action_labels: Vec<String> = sessions
-        .iter()
-        .map(|session| format!("[{}] {}", session.agent_type, session.session_name))
-        .collect();
-    let mut actions = numbered_actions(&action_labels);
-    if has_more {
-        action_labels.push(label_next_page(language).to_string());
-        actions.push(BotAction::secondary(label_next_page(language), "0"));
-    }
-    HandleResult {
-        reply: text,
-        actions,
-        forward_to_session: None,
-    }
-}
-
-async fn handle_new_session(state: &mut BotChatState, agent_type: &str) -> HandleResult {
-    use crate::agentic::coordination::get_global_coordinator;
-    use crate::agentic::core::SessionConfig;
-    use crate::service::workspace::get_global_workspace_service;
-
-    let language = current_bot_language().await;
-    let is_claw = agent_type == "Claw";
-
-    let coordinator = match get_global_coordinator() {
-        Some(c) => c,
-        None => {
-            return HandleResult {
-                reply: if language.is_chinese() {
-                    "BitFun 会话系统尚未就绪。".to_string()
-                } else {
-                    "BitFun session system not ready.".to_string()
-                },
-                actions: vec![],
-                forward_to_session: None,
-            };
-        }
-    };
-
-    let ws_path = if is_claw {
-        // For Claw sessions, prefer current_assistant, or get/create default
-        if let Some(ref assistant_path) = state.current_assistant {
-            Some(assistant_path.clone())
-        } else {
-            let ws_service = match get_global_workspace_service() {
-                Some(s) => s,
-                None => {
-                    return HandleResult {
-                        reply: if language.is_chinese() {
-                            "工作区服务不可用。".to_string()
-                        } else {
-                            "Workspace service not available.".to_string()
-                        },
-                        actions: vec![],
-                        forward_to_session: None,
-                    };
-                }
-            };
-
-            // Get or create default assistant workspace
-            let workspaces = ws_service.get_assistant_workspaces().await;
-            let resolved = if let Some(default_ws) =
-                workspaces.into_iter().find(|w| w.assistant_id.is_none())
-            {
-                Some(default_ws.root_path.to_string_lossy().to_string())
-            } else {
-                match ws_service.create_assistant_workspace(None).await {
-                    Ok(ws_info) => Some(ws_info.root_path.to_string_lossy().to_string()),
-                    Err(e) => {
-                        return HandleResult {
-                            reply: if language.is_chinese() {
-                                format!("创建助理工作区失败：{}", e)
-                            } else {
-                                format!("Failed to create assistant workspace: {}", e)
-                            },
-                            actions: vec![],
-                            forward_to_session: None,
-                        };
-                    }
-                }
-            };
-            if let Some(ref path) = resolved {
-                state.current_assistant = Some(path.clone());
-            }
-            resolved
-        }
-    } else {
-        // For Code/Cowork sessions, use current workspace
-        state.current_workspace.clone()
-    };
-
-    let session_name = match agent_type {
-        "Cowork" => {
-            if language.is_chinese() {
-                "远程协作会话"
-            } else {
-                "Remote Cowork Session"
-            }
-        }
-        "Claw" => {
-            if language.is_chinese() {
-                "远程助理会话"
-            } else {
-                "Remote Claw Session"
-            }
-        }
-        _ => {
-            if language.is_chinese() {
-                "远程编码会话"
-            } else {
-                "Remote Code Session"
-            }
-        }
-    };
-
-    let Some(workspace_path) = ws_path else {
-        return if is_claw {
-            need_assistant(language)
-        } else {
-            need_workspace(language)
-        };
-    };
-
-    match coordinator
-        .create_session_with_workspace(
-            None,
-            session_name.to_string(),
-            agent_type.to_string(),
-            SessionConfig {
-                workspace_path: Some(workspace_path.clone()),
-                ..Default::default()
-            },
-            workspace_path.clone(),
-        )
-        .await
-    {
-        Ok(session) => {
-            let session_id = session.session_id.clone();
-            state.current_session_id = Some(session_id.clone());
-            let label = match agent_type {
-                "Cowork" => {
-                    if language.is_chinese() {
-                        "协作"
-                    } else {
-                        "cowork"
-                    }
-                }
-                "Claw" => {
-                    if language.is_chinese() {
-                        "助理"
-                    } else {
-                        "claw"
-                    }
-                }
-                _ => {
-                    if language.is_chinese() {
-                        "编码"
-                    } else {
-                        "coding"
-                    }
-                }
-            };
-            let workspace_display = workspace_path.clone();
-            HandleResult {
-                reply: if language.is_chinese() {
-                    format!(
-                        "已创建新的{}会话：{}\n工作区：{}\n\n你现在可以发送消息与 AI 助手交互。",
-                        label, session_name, workspace_display
-                    )
-                } else {
-                    format!(
-                        "Created new {} session: {}\nWorkspace: {}\n\nYou can now send messages to interact with the AI agent.",
-                        label, session_name, workspace_display
-                    )
-                },
-                actions: vec![],
-                forward_to_session: None,
-            }
-        }
-        Err(e) => HandleResult {
-            reply: if language.is_chinese() {
-                format!("创建会话失败：{e}")
-            } else {
-                format!("Failed to create session: {e}")
-            },
-            actions: vec![],
-            forward_to_session: None,
-        },
-    }
-}
-
-async fn handle_number_selection(state: &mut BotChatState, n: usize) -> HandleResult {
-    let language = current_bot_language().await;
-    let pending = state.pending_action.take();
-    match pending {
-        Some(PendingAction::SelectWorkspace { options }) => {
-            if n < 1 || n > options.len() {
-                state.pending_action = Some(PendingAction::SelectWorkspace { options });
-                return HandleResult {
-                    reply: if language.is_chinese() {
-                        format!(
-                            "无效选择。请输入 1-{}。",
-                            state
-                                .pending_action
-                                .as_ref()
-                                .map(|a| match a {
-                                    PendingAction::SelectWorkspace { options } => options.len(),
-                                    _ => 0,
-                                })
-                                .unwrap_or(0)
-                        )
-                    } else {
-                        format!(
-                            "Invalid selection. Please enter 1-{}.",
-                            state
-                                .pending_action
-                                .as_ref()
-                                .map(|a| match a {
-                                    PendingAction::SelectWorkspace { options } => options.len(),
-                                    _ => 0,
-                                })
-                                .unwrap_or(0)
-                        )
-                    },
-                    actions: vec![],
-                    forward_to_session: None,
-                };
-            }
-            let (path, name) = options[n - 1].clone();
-            select_workspace(state, &path, &name).await
-        }
-        Some(PendingAction::SelectAssistant { options }) => {
-            if n < 1 || n > options.len() {
-                state.pending_action = Some(PendingAction::SelectAssistant { options });
-                return HandleResult {
-                    reply: if language.is_chinese() {
-                        format!(
-                            "无效选择。请输入 1-{}。",
-                            state
-                                .pending_action
-                                .as_ref()
-                                .map(|a| match a {
-                                    PendingAction::SelectAssistant { options } => options.len(),
-                                    _ => 0,
-                                })
-                                .unwrap_or(0)
-                        )
-                    } else {
-                        format!(
-                            "Invalid selection. Please enter 1-{}.",
-                            state
-                                .pending_action
-                                .as_ref()
-                                .map(|a| match a {
-                                    PendingAction::SelectAssistant { options } => options.len(),
-                                    _ => 0,
-                                })
-                                .unwrap_or(0)
-                        )
-                    },
-                    actions: vec![],
-                    forward_to_session: None,
-                };
-            }
-            let (path, name) = options[n - 1].clone();
-            select_assistant(state, &path, &name).await
-        }
-        Some(PendingAction::SelectSession {
-            options,
-            page,
-            has_more,
-        }) => {
-            if n < 1 || n > options.len() {
-                let max = options.len();
-                state.pending_action = Some(PendingAction::SelectSession {
-                    options,
-                    page,
-                    has_more,
-                });
-                return HandleResult {
-                    reply: if language.is_chinese() {
-                        format!("无效选择。请输入 1-{max}。")
-                    } else {
-                        format!("Invalid selection. Please enter 1-{max}.")
-                    },
-                    actions: vec![],
-                    forward_to_session: None,
-                };
-            }
-            let (session_id, session_name) = options[n - 1].clone();
-            select_session(state, &session_id, &session_name).await
-        }
-        Some(PendingAction::AskUserQuestion {
-            tool_id,
-            questions,
-            current_index,
-            answers,
-            awaiting_custom_text,
-            pending_answer,
-        }) => {
-            handle_question_reply(
+            return result_from_menu(
                 state,
-                tool_id,
-                questions,
-                current_index,
-                answers,
-                awaiting_custom_text,
-                pending_answer,
-                &n.to_string(),
-            )
-            .await
-        }
-        None => {
-            if n >= 1 && n <= state.last_menu_commands.len() {
-                let cmd_str = state.last_menu_commands[n - 1].clone();
-                let next_cmd = parse_command(&cmd_str);
-                Box::pin(dispatch_im_bot_command(state, next_cmd, vec![])).await
-            } else {
-                handle_chat_message(state, &n.to_string(), vec![]).await
-            }
-        }
-    }
-}
-
-async fn select_workspace(state: &mut BotChatState, path: &str, name: &str) -> HandleResult {
-    use crate::service::workspace::get_global_workspace_service;
-    let language = current_bot_language().await;
-
-    let ws_service = match get_global_workspace_service() {
-        Some(s) => s,
-        None => {
-            return HandleResult {
-                reply: if language.is_chinese() {
-                    "工作区服务不可用。".to_string()
-                } else {
-                    "Workspace service not available.".to_string()
-                },
-                actions: vec![],
-                forward_to_session: None,
-            };
+                MenuView::plain(s.workspace_service_unavailable)
+                    .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+            );
         }
     };
 
+    if state.display_mode == BotDisplayMode::Pro {
+        let workspaces = ws_service.get_recent_workspaces().await;
+        if workspaces.is_empty() {
+            return result_from_menu(
+                state,
+                MenuView::plain(s.switch_no_workspaces)
+                    .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+            );
+        }
+        let options: Vec<(String, String)> = workspaces
+            .iter()
+            .map(|ws| (ws.root_path.to_string_lossy().to_string(), ws.name.clone()))
+            .collect();
+        let view = workspace_selection_view(state, &options, s);
+        state.set_pending(PendingAction::SelectWorkspace { options });
+        result_from_menu(state, view)
+    } else {
+        let assistants = ws_service.get_assistant_workspaces().await;
+        if assistants.is_empty() {
+            return result_from_menu(
+                state,
+                MenuView::plain(s.switch_no_assistants)
+                    .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+            );
+        }
+        let options: Vec<(String, String)> = assistants
+            .iter()
+            .map(|ws| (ws.root_path.to_string_lossy().to_string(), ws.name.clone()))
+            .collect();
+        let view = assistant_selection_view(state, &options, s);
+        state.set_pending(PendingAction::SelectAssistant { options });
+        result_from_menu(state, view)
+    }
+}
+
+fn workspace_selection_view(
+    state: &BotChatState,
+    options: &[(String, String)],
+    s: &'static BotStrings,
+) -> MenuView {
+    let mut items = Vec::new();
+    let mut body = String::new();
+    for (i, (path, name)) in options.iter().enumerate() {
+        let is_current = state.current_workspace.as_deref() == Some(path.as_str());
+        let marker = if is_current { s.current_marker } else { "" };
+        body.push_str(&format!("{}. {}{}\n", i + 1, name, marker));
+        items.push(MenuItem::default(
+            truncate_label(name, 24),
+            (i + 1).to_string(),
+        ));
+    }
+    items.push(MenuItem::default(s.item_back, "/menu"));
+    MenuView::plain(s.switch_pick_workspace)
+        .with_body(body.trim_end().to_string())
+        .with_items(items)
+        .with_footer(s.footer_reply_workspace)
+}
+
+fn assistant_selection_view(
+    state: &BotChatState,
+    options: &[(String, String)],
+    s: &'static BotStrings,
+) -> MenuView {
+    let mut items = Vec::new();
+    let mut body = String::new();
+    for (i, (path, name)) in options.iter().enumerate() {
+        let is_current = state.current_assistant.as_deref() == Some(path.as_str());
+        let marker = if is_current { s.current_marker } else { "" };
+        body.push_str(&format!("{}. {}{}\n", i + 1, name, marker));
+        items.push(MenuItem::default(
+            truncate_label(name, 24),
+            (i + 1).to_string(),
+        ));
+    }
+    items.push(MenuItem::default(s.item_back, "/menu"));
+    MenuView::plain(s.switch_pick_assistant)
+        .with_body(body.trim_end().to_string())
+        .with_items(items)
+        .with_footer(s.footer_reply_assistant)
+}
+
+fn session_selection_view(
+    state: &BotChatState,
+    options: &[(String, String)],
+    page: usize,
+    has_more: bool,
+    s: &'static BotStrings,
+) -> MenuView {
+    let mut items = Vec::new();
+    let mut body = String::new();
+    for (i, (id, name)) in options.iter().enumerate() {
+        let is_current = state.current_session_id.as_deref() == Some(id.as_str());
+        let marker = if is_current { s.current_marker } else { "" };
+        body.push_str(&format!("{}. {}{}\n", i + 1, name, marker));
+        items.push(MenuItem::default(
+            truncate_label(name, 26),
+            (i + 1).to_string(),
+        ));
+    }
+    if has_more {
+        items.push(MenuItem::default(s.item_next_page, "0"));
+    }
+    items.push(MenuItem::default(s.item_back, "/menu"));
+    let footer = if has_more {
+        s.footer_reply_session_or_next
+    } else {
+        s.footer_reply_session
+    };
+    MenuView::plain(format!("{} · #{}", s.resume_page_label, page + 1))
+        .with_body(body.trim_end().to_string())
+        .with_items(items)
+        .with_footer(footer)
+}
+
+async fn select_workspace(
+    state: &mut BotChatState,
+    path: &str,
+    name: &str,
+    s: &'static BotStrings,
+) -> HandleResult {
+    use crate::service::workspace::get_global_workspace_service;
+
+    let ws_service = match get_global_workspace_service() {
+        Some(svc) => svc,
+        None => {
+            return result_from_menu(
+                state,
+                MenuView::plain(s.workspace_service_unavailable),
+            );
+        }
+    };
     let path_buf = std::path::PathBuf::from(path);
     match ws_service.open_workspace(path_buf).await {
         Ok(info) => {
@@ -1715,50 +994,40 @@ async fn select_workspace(state: &mut BotChatState, path: &str, name: &str) -> H
             info!("Bot switched workspace to: {path}");
 
             let session_count = count_workspace_sessions(path).await;
-            let reply =
-                build_workspace_switched_reply(language, name, session_count, state.display_mode);
-            let actions = if session_count > 0 {
-                session_entry_actions(language, state.display_mode)
-            } else {
-                new_session_actions(language, state.display_mode)
-            };
-            HandleResult {
-                reply,
-                actions,
-                forward_to_session: None,
-            }
+            let body = format!(
+                "{}: {} · {}",
+                s.current_workspace_label,
+                name,
+                fmt_count(s.workspace_session_count_fmt, session_count),
+            );
+            let mut view = main_menu_view(state, s);
+            view = view.with_body(body);
+            result_from_menu(state, view)
         }
-        Err(e) => HandleResult {
-            reply: if language.is_chinese() {
-                format!("切换工作区失败：{e}")
-            } else {
-                format!("Failed to switch workspace: {e}")
-            },
-            actions: vec![],
-            forward_to_session: None,
-        },
+        Err(e) => result_from_menu(
+            state,
+            MenuView::plain(format!("{}{e}", s.workspace_open_failed_prefix)),
+        ),
     }
 }
 
-async fn select_assistant(state: &mut BotChatState, path: &str, name: &str) -> HandleResult {
+async fn select_assistant(
+    state: &mut BotChatState,
+    path: &str,
+    name: &str,
+    s: &'static BotStrings,
+) -> HandleResult {
     use crate::service::workspace::get_global_workspace_service;
-    let language = current_bot_language().await;
 
     let ws_service = match get_global_workspace_service() {
-        Some(s) => s,
+        Some(svc) => svc,
         None => {
-            return HandleResult {
-                reply: if language.is_chinese() {
-                    "工作区服务不可用。".to_string()
-                } else {
-                    "Workspace service not available.".to_string()
-                },
-                actions: vec![],
-                forward_to_session: None,
-            };
+            return result_from_menu(
+                state,
+                MenuView::plain(s.workspace_service_unavailable),
+            );
         }
     };
-
     let path_buf = std::path::PathBuf::from(path);
     match ws_service.open_workspace(path_buf).await {
         Ok(info) => {
@@ -1775,34 +1044,20 @@ async fn select_assistant(state: &mut BotChatState, path: &str, name: &str) -> H
             info!("Bot switched assistant to: {path}");
 
             let session_count = count_workspace_sessions(path).await;
-            let reply = if language.is_chinese() {
-                format!("已切换到助理：{}\n\n会话数：{}", name, session_count)
-            } else {
-                format!(
-                    "Switched to assistant: {}\n\nSessions: {}",
-                    name, session_count
-                )
-            };
-            let actions = if session_count > 0 {
-                session_entry_actions(language, state.display_mode)
-            } else {
-                new_session_actions(language, state.display_mode)
-            };
-            HandleResult {
-                reply,
-                actions,
-                forward_to_session: None,
-            }
+            let body = format!(
+                "{}: {} · {}",
+                s.current_assistant_label,
+                name,
+                fmt_count(s.workspace_session_count_fmt, session_count),
+            );
+            let mut view = main_menu_view(state, s);
+            view = view.with_body(body);
+            result_from_menu(state, view)
         }
-        Err(e) => HandleResult {
-            reply: if language.is_chinese() {
-                format!("切换助理失败：{e}")
-            } else {
-                format!("Failed to switch assistant: {e}")
-            },
-            actions: vec![],
-            forward_to_session: None,
-        },
+        Err(e) => result_from_menu(
+            state,
+            MenuView::plain(format!("{}{e}", s.workspace_open_failed_prefix)),
+        ),
     }
 }
 
@@ -1826,139 +1081,182 @@ async fn count_workspace_sessions(workspace_path: &str) -> usize {
         .unwrap_or(0)
 }
 
-fn build_workspace_switched_reply(
-    language: BotLanguage,
-    name: &str,
-    session_count: usize,
-    display_mode: BotDisplayMode,
-) -> String {
-    let is_pro = display_mode == BotDisplayMode::Pro;
-    let mode_label = if is_pro {
-        if language.is_chinese() {
-            "专业模式"
-        } else {
-            "Expert Mode"
+fn truncate_label(label: &str, max_chars: usize) -> String {
+    let trimmed = label.trim();
+    if trimmed.chars().count() <= max_chars {
+        trimmed.to_string()
+    } else {
+        let truncated: String = trimmed.chars().take(max_chars.saturating_sub(1)).collect();
+        format!("{truncated}…")
+    }
+}
+
+// ── Resume / new session ──────────────────────────────────────────
+
+async fn start_resume(
+    state: &mut BotChatState,
+    page: usize,
+    s: &'static BotStrings,
+) -> HandleResult {
+    use crate::agentic::persistence::PersistenceManager;
+    use crate::infrastructure::PathManager;
+
+    let ws_path = if state.display_mode == BotDisplayMode::Pro {
+        match &state.current_workspace {
+            Some(p) => std::path::PathBuf::from(p),
+            None => {
+                return result_from_menu(
+                    state,
+                    MenuView::plain(s.no_workspace).with_items(vec![
+                        MenuItem::primary(s.item_switch_workspace, "/switch"),
+                        MenuItem::default(s.item_back, "/menu"),
+                    ]),
+                );
+            }
         }
     } else {
-        if language.is_chinese() {
-            "助理模式"
-        } else {
-            "Assistant Mode"
+        match &state.current_assistant {
+            Some(p) => std::path::PathBuf::from(p),
+            None => {
+                return result_from_menu(
+                    state,
+                    MenuView::plain(s.no_assistant).with_items(vec![
+                        MenuItem::primary(s.item_switch_assistant, "/switch"),
+                        MenuItem::default(s.item_back, "/menu"),
+                    ]),
+                );
+            }
         }
     };
 
-    let mut reply = if language.is_chinese() {
-        format!("已切换到工作区：{}\n当前模式：{}\n\n", name, mode_label)
-    } else {
-        format!(
-            "Switched to workspace: {}\nCurrent mode: {}\n\n",
-            name, mode_label
-        )
+    let page_size = 10usize;
+    let offset = page * page_size;
+
+    let pm = match PathManager::new() {
+        Ok(pm) => std::sync::Arc::new(pm),
+        Err(e) => {
+            return result_from_menu(
+                state,
+                MenuView::plain(format!("{}{e}", s.session_create_failed_prefix)),
+            );
+        }
+    };
+    let store = match PersistenceManager::new(pm) {
+        Ok(store) => store,
+        Err(e) => {
+            return result_from_menu(
+                state,
+                MenuView::plain(format!("{}{e}", s.session_create_failed_prefix)),
+            );
+        }
+    };
+    let all_meta = match store.list_session_metadata(&ws_path).await {
+        Ok(m) => m,
+        Err(e) => {
+            return result_from_menu(
+                state,
+                MenuView::plain(format!("{}{e}", s.session_create_failed_prefix)),
+            );
+        }
     };
 
-    if session_count > 0 {
-        if language.is_chinese() {
-            reply.push_str(&format!(
-                "这个工作区已有 {session_count} 个会话。你想做什么？\n\n"
-            ));
-        } else {
-            let s = if session_count == 1 { "" } else { "s" };
-            reply.push_str(&format!(
-                "This workspace has {session_count} existing session{s}. What would you like to do?\n\n"
-            ));
-        }
-    } else {
-        if language.is_chinese() {
-            reply.push_str("这个工作区还没有会话。你想做什么？\n\n");
-        } else {
-            reply.push_str("No sessions found in this workspace. What would you like to do?\n\n");
-        }
+    if all_meta.is_empty() {
+        return result_from_menu(state, need_session_view(state, s));
     }
 
-    if is_pro {
-        if language.is_chinese() {
-            reply.push_str(
-                "/resume_session - 恢复已有会话\n\
-                 /new_code_session - 开始新的编码会话\n\
-                 /new_cowork_session - 开始新的协作会话\n\
-                 /assistant - 切换到助理模式",
-            );
-        } else {
-            reply.push_str(
-                "/resume_session - Resume an existing session\n\
-                 /new_code_session - Start a new coding session\n\
-                 /new_cowork_session - Start a new cowork session\n\
-                 /assistant - Switch to Assistant mode",
-            );
-        }
-    } else {
-        if language.is_chinese() {
-            reply.push_str(
-                "/resume_session - 恢复已有会话\n\
-                 /new_claw_session - 开始新的助理会话\n\
-                 /pro - 切换到专业模式",
-            );
-        } else {
-            reply.push_str(
-                "/resume_session - Resume an existing session\n\
-                 /new_claw_session - Start a new claw session\n\
-                 /pro - Switch to Expert mode",
-            );
-        }
+    let total = all_meta.len();
+    let has_more = offset + page_size < total;
+    let sessions: Vec<_> = all_meta.into_iter().skip(offset).take(page_size).collect();
+
+    let mut body = String::new();
+    let mut items = Vec::new();
+    let mut options = Vec::new();
+    for (i, sess) in sessions.iter().enumerate() {
+        let is_current = state.current_session_id.as_deref() == Some(&sess.session_id);
+        let marker = if is_current { s.current_marker } else { "" };
+        let ts = chrono::DateTime::from_timestamp(sess.last_active_at as i64 / 1000, 0)
+            .map(|dt| dt.format("%m-%d %H:%M").to_string())
+            .unwrap_or_default();
+        let msg_hint = match sess.turn_count {
+            0 => s.resume_msg_count_zero.to_string(),
+            1 => s.resume_msg_count_one.to_string(),
+            n => fmt_count(s.resume_msg_count_many_fmt, n),
+        };
+        body.push_str(&format!(
+            "{}. [{}] {}{}\n   {} · {}\n",
+            i + 1,
+            sess.agent_type,
+            sess.session_name,
+            marker,
+            ts,
+            msg_hint,
+        ));
+        items.push(MenuItem::default(
+            truncate_label(
+                &format!("[{}] {}", sess.agent_type, sess.session_name),
+                26,
+            ),
+            (i + 1).to_string(),
+        ));
+        options.push((sess.session_id.clone(), sess.session_name.clone()));
     }
-    reply
+    if has_more {
+        items.push(MenuItem::default(s.item_next_page, "0"));
+    }
+    items.push(MenuItem::default(s.item_back, "/menu"));
+
+    state.set_pending(PendingAction::SelectSession {
+        options,
+        page,
+        has_more,
+    });
+
+    let footer = if has_more {
+        s.footer_reply_session_or_next
+    } else {
+        s.footer_reply_session
+    };
+    let view = MenuView::plain(format!(
+        "{} · #{}",
+        s.resume_page_label,
+        page + 1
+    ))
+    .with_body(body.trim_end().to_string())
+    .with_items(items)
+    .with_footer(footer);
+    result_from_menu(state, view)
 }
 
 async fn select_session(
     state: &mut BotChatState,
     session_id: &str,
     session_name: &str,
+    s: &'static BotStrings,
 ) -> HandleResult {
-    let language = current_bot_language().await;
     state.current_session_id = Some(session_id.to_string());
     info!("Bot resumed session: {session_id}");
 
     let last_pair =
         load_last_dialog_pair_from_turns(state.current_workspace.as_deref(), session_id).await;
-
-    let mut reply = if language.is_chinese() {
-        format!("已恢复会话：{session_name}\n\n")
+    let mut body = format!("{}{}\n", s.resume_resumed_prefix, session_name);
+    if let Some((user_text, ai_text)) = last_pair {
+        body.push('\n');
+        body.push_str(s.resume_last_dialog_header);
+        body.push('\n');
+        body.push_str(&format!("{}: {}\n\n", s.resume_you_label, user_text));
+        body.push_str(&format!("AI: {}\n\n", ai_text));
+        body.push_str(s.resume_continue_hint);
     } else {
-        format!("Resumed session: {session_name}\n\n")
-    };
-    if let Some((user_text, assistant_text)) = last_pair {
-        reply.push_str(if language.is_chinese() {
-            "— 最近一次对话 —\n"
-        } else {
-            "— Last conversation —\n"
-        });
-        reply.push_str(&format!(
-            "{}: {user_text}\n\n",
-            if language.is_chinese() { "你" } else { "You" }
-        ));
-        reply.push_str(&format!("{}: {assistant_text}\n\n", "AI"));
-        reply.push_str(if language.is_chinese() {
-            "你可以继续对话。"
-        } else {
-            "You can continue the conversation."
-        });
-    } else {
-        reply.push_str(if language.is_chinese() {
-            "你现在可以发送消息与 AI 助手交互。"
-        } else {
-            "You can now send messages to interact with the AI agent."
-        });
+        body.push('\n');
+        body.push_str(s.resume_first_message_hint);
     }
 
-    HandleResult {
-        reply,
-        actions: vec![],
-        forward_to_session: None,
-    }
+    // Resumed session leaves the user ready to chat — show no menu so the
+    // chat surface stays uncluttered.
+    let view = MenuView::plain("").with_body(body);
+    result_from_menu(state, view)
 }
 
-/// Load the last user/assistant dialog pair from the unified project session store,
-/// the same data source the desktop frontend uses.
 async fn load_last_dialog_pair_from_turns(
     workspace_path: Option<&str>,
     session_id: &str,
@@ -1994,18 +1292,15 @@ async fn load_last_dialog_pair_from_turns(
             }
         }
     }
-
     if ai_text.is_empty() {
         return None;
     }
-
     Some((
         truncate_text(&user_text, MAX_USER_LEN),
         truncate_text(&ai_text, MAX_AI_LEN),
     ))
 }
 
-/// Strip prompt markup injected before storing the message.
 fn strip_user_message_tags(raw: &str) -> String {
     crate::agentic::core::strip_prompt_markup(raw)
 }
@@ -2016,97 +1311,504 @@ fn truncate_text(text: &str, max_chars: usize) -> String {
         trimmed.to_string()
     } else {
         let truncated: String = trimmed.chars().take(max_chars).collect();
-        format!("{truncated}...")
+        format!("{truncated}…")
     }
 }
+
+async fn new_session_for_mode(
+    state: &mut BotChatState,
+    s: &'static BotStrings,
+) -> HandleResult {
+    let agent_type = if state.display_mode == BotDisplayMode::Pro {
+        "agentic"
+    } else {
+        "Claw"
+    };
+    guarded_new(state, agent_type, s).await
+}
+
+async fn guarded_new(
+    state: &mut BotChatState,
+    agent_type: &str,
+    s: &'static BotStrings,
+) -> HandleResult {
+    let needs_pro = matches!(agent_type, "agentic" | "Cowork");
+    let needs_assistant = matches!(agent_type, "Claw");
+
+    if needs_pro && state.display_mode != BotDisplayMode::Pro {
+        let target_cmd = match agent_type {
+            "agentic" => "/new_code_session",
+            "Cowork" => "/new_cowork_session",
+            _ => "/new_code_session",
+        };
+        return confirm_then_run(state, BotDisplayMode::Pro, target_cmd.to_string(), s).await;
+    }
+    if needs_assistant && state.display_mode != BotDisplayMode::Assistant {
+        return confirm_then_run(
+            state,
+            BotDisplayMode::Assistant,
+            "/new_claw_session".to_string(),
+            s,
+        )
+        .await;
+    }
+    if needs_pro && state.current_workspace.is_none() {
+        return result_from_menu(
+            state,
+            MenuView::plain(s.no_workspace).with_items(vec![
+                MenuItem::primary(s.item_switch_workspace, "/switch"),
+                MenuItem::default(s.item_back, "/menu"),
+            ]),
+        );
+    }
+    create_session(state, agent_type).await
+}
+
+async fn create_session(state: &mut BotChatState, agent_type: &str) -> HandleResult {
+    use crate::agentic::coordination::get_global_coordinator;
+    use crate::agentic::core::SessionConfig;
+    use crate::service::workspace::get_global_workspace_service;
+
+    let language = current_bot_language().await;
+    let s = strings_for(language);
+    let is_claw = agent_type == "Claw";
+
+    let coordinator = match get_global_coordinator() {
+        Some(c) => c,
+        None => {
+            return result_from_menu(state, MenuView::plain(s.session_system_unavailable));
+        }
+    };
+
+    let ws_path = if is_claw {
+        if let Some(p) = state.current_assistant.clone() {
+            Some(p)
+        } else {
+            let ws_service = match get_global_workspace_service() {
+                Some(s) => s,
+                None => {
+                    return result_from_menu(
+                        state,
+                        MenuView::plain(s.workspace_service_unavailable),
+                    );
+                }
+            };
+            let workspaces = ws_service.get_assistant_workspaces().await;
+            let resolved = if let Some(default_ws) =
+                workspaces.into_iter().find(|w| w.assistant_id.is_none())
+            {
+                Some(default_ws.root_path.to_string_lossy().to_string())
+            } else {
+                match ws_service.create_assistant_workspace(None).await {
+                    Ok(ws_info) => Some(ws_info.root_path.to_string_lossy().to_string()),
+                    Err(e) => {
+                        return result_from_menu(
+                            state,
+                            MenuView::plain(format!(
+                                "{}{e}",
+                                s.assistant_create_failed_prefix
+                            )),
+                        );
+                    }
+                }
+            };
+            if let Some(ref path) = resolved {
+                state.current_assistant = Some(path.clone());
+            }
+            resolved
+        }
+    } else {
+        state.current_workspace.clone()
+    };
+
+    let session_name = match agent_type {
+        "Cowork" => {
+            if language.is_chinese() {
+                "远程协作会话"
+            } else {
+                "Remote Cowork Session"
+            }
+        }
+        "Claw" => {
+            if language.is_chinese() {
+                "远程助理会话"
+            } else {
+                "Remote Claw Session"
+            }
+        }
+        _ => {
+            if language.is_chinese() {
+                "远程编码会话"
+            } else {
+                "Remote Code Session"
+            }
+        }
+    };
+
+    let Some(workspace_path) = ws_path else {
+        let view = if is_claw {
+            MenuView::plain(s.no_assistant).with_items(vec![
+                MenuItem::primary(s.item_switch_assistant, "/switch"),
+                MenuItem::default(s.item_back, "/menu"),
+            ])
+        } else {
+            MenuView::plain(s.no_workspace).with_items(vec![
+                MenuItem::primary(s.item_switch_workspace, "/switch"),
+                MenuItem::default(s.item_back, "/menu"),
+            ])
+        };
+        return result_from_menu(state, view);
+    };
+
+    match coordinator
+        .create_session_with_workspace(
+            None,
+            session_name.to_string(),
+            agent_type.to_string(),
+            SessionConfig {
+                workspace_path: Some(workspace_path.clone()),
+                ..Default::default()
+            },
+            workspace_path.clone(),
+        )
+        .await
+    {
+        Ok(session) => {
+            state.current_session_id = Some(session.session_id.clone());
+            let body = format!(
+                "{}{}\n{}{}\n\n{}",
+                s.session_created_prefix,
+                session_name,
+                s.session_workspace_label,
+                short_path_name(&workspace_path),
+                s.session_start_hint,
+            );
+            let view = MenuView::plain("").with_body(body);
+            result_from_menu(state, view)
+        }
+        Err(e) => result_from_menu(
+            state,
+            MenuView::plain(format!("{}{e}", s.session_create_failed_prefix)),
+        ),
+    }
+}
+
+// ── Cancel ─────────────────────────────────────────────────────────
 
 async fn handle_cancel_task(
     state: &mut BotChatState,
     requested_turn_id: Option<&str>,
+    s: &'static BotStrings,
 ) -> HandleResult {
     use crate::service::remote_connect::remote_server::get_or_init_global_dispatcher;
-    let language = current_bot_language().await;
 
     let session_id = match state.current_session_id.clone() {
         Some(id) => id,
         None => {
-            return HandleResult {
-                reply: if language.is_chinese() {
-                    "当前没有可取消的活动会话。".to_string()
-                } else {
-                    "No active session to cancel.".to_string()
-                },
-                actions: session_entry_actions(language, state.display_mode),
-                forward_to_session: None,
-            };
+            return result_from_menu(state, MenuView::plain(s.task_no_active));
         }
     };
-
     let dispatcher = get_or_init_global_dispatcher();
     match dispatcher.cancel_task(&session_id, requested_turn_id).await {
         Ok(_) => {
-            state.pending_action = None;
-            HandleResult {
-                reply: if language.is_chinese() {
-                    "已请求取消当前任务。".to_string()
-                } else {
-                    "Cancellation requested for the current task.".to_string()
-                },
-                actions: vec![],
-                forward_to_session: None,
+            state.clear_pending();
+            result_from_menu(state, MenuView::plain(s.task_cancel_requested))
+        }
+        Err(e) => result_from_menu(
+            state,
+            MenuView::plain(format!("{}{e}", s.task_cancel_failed_prefix)),
+        ),
+    }
+}
+
+// ── Numeric reply routing ─────────────────────────────────────────
+
+async fn handle_number(
+    state: &mut BotChatState,
+    n: usize,
+    s: &'static BotStrings,
+) -> HandleResult {
+    if let Some(pending) = state.pending_action.clone() {
+        return route_pending(state, pending, &n.to_string(), s).await;
+    }
+    // No pending action: 0 always returns to main menu.
+    if n == 0 {
+        return menu_or_welcome(state, s);
+    }
+    if n >= 1 && n <= state.last_menu_commands.len() {
+        let cmd_str = state.last_menu_commands[n - 1].clone();
+        let next_cmd = parse_command(&cmd_str);
+        return Box::pin(dispatch(state, next_cmd, vec![])).await;
+    }
+    handle_chat(state, &n.to_string(), vec![], s).await
+}
+
+async fn route_pending(
+    state: &mut BotChatState,
+    pending: PendingAction,
+    raw_input: &str,
+    s: &'static BotStrings,
+) -> HandleResult {
+    match pending {
+        PendingAction::SelectWorkspace { options } => {
+            let parsed: Option<usize> = raw_input.parse().ok();
+            match parsed {
+                Some(0) => {
+                    state.clear_pending();
+                    menu_or_welcome(state, s)
+                }
+                Some(n) if n >= 1 && n <= options.len() => {
+                    state.clear_pending();
+                    let (path, name) = options[n - 1].clone();
+                    select_workspace(state, &path, &name, s).await
+                }
+                _ => {
+                    state.set_pending(PendingAction::SelectWorkspace { options });
+                    Box::pin(pending_invalid(state, s)).await
+                }
             }
         }
-        Err(e) => HandleResult {
-            reply: if language.is_chinese() {
-                format!("取消任务失败：{e}")
-            } else {
-                format!("Failed to cancel task: {e}")
-            },
-            actions: vec![],
-            forward_to_session: None,
-        },
+        PendingAction::SelectAssistant { options } => {
+            let parsed: Option<usize> = raw_input.parse().ok();
+            match parsed {
+                Some(0) => {
+                    state.clear_pending();
+                    menu_or_welcome(state, s)
+                }
+                Some(n) if n >= 1 && n <= options.len() => {
+                    state.clear_pending();
+                    let (path, name) = options[n - 1].clone();
+                    select_assistant(state, &path, &name, s).await
+                }
+                _ => {
+                    state.set_pending(PendingAction::SelectAssistant { options });
+                    Box::pin(pending_invalid(state, s)).await
+                }
+            }
+        }
+        PendingAction::SelectSession {
+            options,
+            page,
+            has_more,
+        } => {
+            let parsed: Option<usize> = raw_input.parse().ok();
+            match parsed {
+                Some(0) if has_more => {
+                    state.clear_pending();
+                    start_resume(state, page + 1, s).await
+                }
+                Some(0) => {
+                    state.clear_pending();
+                    menu_or_welcome(state, s)
+                }
+                Some(n) if n >= 1 && n <= options.len() => {
+                    state.clear_pending();
+                    let (id, name) = options[n - 1].clone();
+                    select_session(state, &id, &name, s).await
+                }
+                _ => {
+                    state.set_pending(PendingAction::SelectSession {
+                        options,
+                        page,
+                        has_more,
+                    });
+                    Box::pin(pending_invalid(state, s)).await
+                }
+            }
+        }
+        PendingAction::AskUserQuestion {
+            tool_id,
+            questions,
+            current_index,
+            answers,
+            awaiting_custom_text,
+            pending_answer,
+        } => {
+            handle_question_reply(
+                state,
+                tool_id,
+                questions,
+                current_index,
+                answers,
+                awaiting_custom_text,
+                pending_answer,
+                raw_input,
+                s,
+            )
+            .await
+        }
+        PendingAction::ConfirmModeSwitch {
+            target_mode,
+            target_cmd,
+        } => {
+            let parsed: Option<usize> = raw_input.parse().ok();
+            match parsed {
+                Some(1) => {
+                    state.clear_pending();
+                    state.display_mode = target_mode;
+                    let next_cmd = parse_command(&target_cmd);
+                    Box::pin(dispatch(state, next_cmd, vec![])).await
+                }
+                Some(0) => {
+                    state.clear_pending();
+                    menu_or_welcome(state, s)
+                }
+                _ => {
+                    state.set_pending(PendingAction::ConfirmModeSwitch {
+                        target_mode,
+                        target_cmd,
+                    });
+                    Box::pin(pending_invalid(state, s)).await
+                }
+            }
+        }
     }
 }
 
-fn restore_question_pending_action(
+/// Re-show the current pending view with an "invalid input" prefix so the
+/// user retains context.  After [`PENDING_INVALID_LIMIT`] consecutive invalid
+/// replies the pending state is cleared and the user is returned to the main
+/// menu.
+async fn pending_invalid(
     state: &mut BotChatState,
-    tool_id: String,
-    questions: Vec<BotQuestion>,
-    current_index: usize,
-    answers: Vec<Value>,
-    awaiting_custom_text: bool,
-    pending_answer: Option<Value>,
-) {
-    state.pending_action = Some(PendingAction::AskUserQuestion {
-        tool_id,
-        questions,
-        current_index,
-        answers,
-        awaiting_custom_text,
-        pending_answer,
-    });
+    s: &'static BotStrings,
+) -> HandleResult {
+    state.pending_invalid_count = state.pending_invalid_count.saturating_add(1);
+    if state.pending_invalid_count >= PENDING_INVALID_LIMIT {
+        state.clear_pending();
+        let mut view = main_menu_view(state, s);
+        view = view.with_body(s.pending_invalid_after_retries);
+        return result_from_menu(state, view);
+    }
+    // Re-render the pending prompt with an invalid-input notice so the user
+    // sees the option list again instead of just an opaque error.
+    let pending = match state.pending_action.clone() {
+        Some(p) => p,
+        None => {
+            return result_from_menu(state, main_menu_view(state, s));
+        }
+    };
+    let mut view = match &pending {
+        PendingAction::SelectWorkspace { options } => {
+            workspace_selection_view(state, options, s)
+        }
+        PendingAction::SelectAssistant { options } => {
+            assistant_selection_view(state, options, s)
+        }
+        PendingAction::SelectSession {
+            options,
+            page,
+            has_more,
+        } => session_selection_view(state, options, *page, *has_more, s),
+        PendingAction::AskUserQuestion {
+            questions,
+            current_index,
+            awaiting_custom_text,
+            ..
+        } => build_question_view(s, questions, *current_index, *awaiting_custom_text),
+        PendingAction::ConfirmModeSwitch { target_mode, .. } => {
+            confirm_mode_switch_view(*target_mode, s)
+        }
+    };
+    let original_body = view.body.take().unwrap_or_default();
+    let new_body = if original_body.is_empty() {
+        s.pending_invalid_input.to_string()
+    } else {
+        format!("{}\n\n{}", s.pending_invalid_input, original_body)
+    };
+    view = view.with_body(new_body);
+    result_from_menu(state, view)
 }
 
-async fn submit_question_answers(tool_id: &str, answers: &[Value]) -> HandleResult {
-    use crate::agentic::tools::user_input_manager::get_user_input_manager;
+// ── Question handling ─────────────────────────────────────────────
 
-    let mut payload = serde_json::Map::new();
-    for (idx, value) in answers.iter().enumerate() {
-        payload.insert(idx.to_string(), value.clone());
+fn question_option_line(index: usize, option: &BotQuestionOption) -> String {
+    if option.description.is_empty() {
+        format!("{}. {}", index + 1, option.label)
+    } else {
+        format!(
+            "{}. {} - {}",
+            index + 1,
+            option.label,
+            option.description
+        )
     }
+}
 
-    let manager = get_user_input_manager();
-    match manager.send_answer(tool_id, Value::Object(payload)) {
-        Ok(_) => HandleResult {
-            reply: "Answers submitted. Waiting for the assistant to continue...".to_string(),
-            actions: vec![],
-            forward_to_session: None,
-        },
-        Err(e) => HandleResult {
-            reply: format!("Failed to submit answers: {e}"),
-            actions: vec![],
-            forward_to_session: None,
-        },
+fn build_question_view(
+    s: &'static BotStrings,
+    questions: &[BotQuestion],
+    current_index: usize,
+    awaiting_custom_text: bool,
+) -> MenuView {
+    let question = &questions[current_index];
+    let title = format!(
+        "{} {}/{}",
+        s.question_title,
+        current_index + 1,
+        questions.len()
+    );
+
+    let mut body = String::new();
+    if !question.header.is_empty() {
+        body.push_str(&question.header);
+        body.push('\n');
+    }
+    body.push_str(&question.question);
+    body.push_str("\n\n");
+    for (idx, option) in question.options.iter().enumerate() {
+        body.push_str(&question_option_line(idx, option));
+        body.push('\n');
+    }
+    body.push_str(&format!(
+        "{}. {}\n",
+        question.options.len() + 1,
+        s.item_other,
+    ));
+
+    let footer = if awaiting_custom_text {
+        s.footer_question_custom
+    } else if question.multi_select {
+        s.footer_question_multi
+    } else {
+        s.footer_question_single
+    };
+
+    let mut items: Vec<MenuItem> = Vec::new();
+    if !awaiting_custom_text && !question.multi_select {
+        for (idx, option) in question.options.iter().enumerate() {
+            items.push(MenuItem::default(
+                truncate_label(&option.label, 24),
+                (idx + 1).to_string(),
+            ));
+        }
+        items.push(MenuItem::default(
+            s.item_other,
+            (question.options.len() + 1).to_string(),
+        ));
+    }
+    items.push(MenuItem::default(s.item_back, "/menu"));
+
+    MenuView::plain(title)
+        .with_body(body.trim_end().to_string())
+        .with_items(items)
+        .with_footer(footer)
+}
+
+fn parse_question_numbers(input: &str) -> Option<Vec<usize>> {
+    let mut result = Vec::new();
+    for part in input.split(',') {
+        let trimmed = part.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let value = trimmed.parse::<usize>().ok()?;
+        result.push(value);
+    }
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
     }
 }
 
@@ -2120,49 +1822,30 @@ async fn handle_question_reply(
     awaiting_custom_text: bool,
     pending_answer: Option<Value>,
     message: &str,
+    s: &'static BotStrings,
 ) -> HandleResult {
-    let language = current_bot_language().await;
     let Some(question) = questions.get(current_index).cloned() else {
-        return HandleResult {
-            reply: if language.is_chinese() {
-                "问题状态无效。".to_string()
-            } else {
-                "Question state is invalid.".to_string()
-            },
-            actions: vec![],
-            forward_to_session: None,
-        };
+        return result_from_menu(state, MenuView::plain(s.question_invalid_state));
     };
 
     if awaiting_custom_text {
         let custom_text = message.trim();
         if custom_text.is_empty() {
-            restore_question_pending_action(
-                state,
+            state.set_pending(PendingAction::AskUserQuestion {
                 tool_id,
                 questions,
                 current_index,
                 answers,
-                true,
+                awaiting_custom_text: true,
                 pending_answer,
-            );
-            return HandleResult {
-                reply: if language.is_chinese() {
-                    "自定义答案不能为空。请输入你的自定义答案。".to_string()
-                } else {
-                    "Custom answer cannot be empty. Please type your custom answer.".to_string()
-                },
-                actions: vec![],
-                forward_to_session: None,
-            };
+            });
+            return result_from_menu(state, MenuView::plain(s.question_custom_required));
         }
-
         let final_value = match pending_answer {
-            Some(Value::String(_)) => Value::String(custom_text.to_string()),
             Some(Value::Array(existing)) => {
                 let mut values: Vec<Value> = existing
                     .into_iter()
-                    .filter(|value| value.as_str() != Some("Other"))
+                    .filter(|v| v.as_str() != Some("Other"))
                     .collect();
                 values.push(Value::String(custom_text.to_string()));
                 Value::Array(values)
@@ -2174,299 +1857,146 @@ async fn handle_question_reply(
         let selections = match parse_question_numbers(message) {
             Some(values) => values,
             None => {
-                restore_question_pending_action(
-                    state,
+                state.set_pending(PendingAction::AskUserQuestion {
                     tool_id,
                     questions,
                     current_index,
                     answers,
-                    false,
-                    None,
-                );
-                return HandleResult {
-                    reply: if question.multi_select {
-                        if language.is_chinese() {
-                            "输入无效。请回复选项编号，例如 `1,3`。".to_string()
-                        } else {
-                            "Invalid input. Reply with option numbers like `1,3`.".to_string()
-                        }
-                    } else {
-                        if language.is_chinese() {
-                            "输入无效。请回复单个选项编号。".to_string()
-                        } else {
-                            "Invalid input. Reply with a single option number.".to_string()
-                        }
-                    },
-                    actions: vec![],
-                    forward_to_session: None,
-                };
+                    awaiting_custom_text: false,
+                    pending_answer: None,
+                });
+                return Box::pin(pending_invalid(state, s)).await;
             }
         };
-
         if !question.multi_select && selections.len() != 1 {
-            restore_question_pending_action(
-                state,
+            state.set_pending(PendingAction::AskUserQuestion {
                 tool_id,
                 questions,
                 current_index,
                 answers,
-                false,
-                None,
-            );
-            return HandleResult {
-                reply: if language.is_chinese() {
-                    "请回复单个选项编号。".to_string()
-                } else {
-                    "Please reply with a single option number.".to_string()
-                },
-                actions: vec![],
-                forward_to_session: None,
-            };
+                awaiting_custom_text: false,
+                pending_answer: None,
+            });
+            return Box::pin(pending_invalid(state, s)).await;
         }
-
         let other_index = question.options.len() + 1;
         let mut labels = Vec::new();
         let mut includes_other = false;
         for selection in selections {
             if selection == other_index {
                 includes_other = true;
-                labels.push(Value::String(other_label(language).to_string()));
+                labels.push(Value::String(s.item_other.to_string()));
             } else if selection >= 1 && selection <= question.options.len() {
                 labels.push(Value::String(question.options[selection - 1].label.clone()));
             } else {
-                restore_question_pending_action(
-                    state,
+                state.set_pending(PendingAction::AskUserQuestion {
                     tool_id,
                     questions,
                     current_index,
                     answers,
-                    false,
-                    None,
-                );
-                return HandleResult {
-                    reply: format!(
-                        "{} 1 {} {}。",
-                        if language.is_chinese() {
-                            "无效选择。请选择"
-                        } else {
-                            "Invalid selection. Please choose between"
-                        },
-                        if language.is_chinese() { "到" } else { "and" },
-                        other_index
-                    ),
-                    actions: vec![],
-                    forward_to_session: None,
-                };
+                    awaiting_custom_text: false,
+                    pending_answer: None,
+                });
+                let _ = other_index;
+                return Box::pin(pending_invalid(state, s)).await;
             }
         }
-
-        let pending_answer = if question.multi_select {
+        let pending_answer_next = if question.multi_select {
             Some(Value::Array(labels.clone()))
         } else {
             labels.into_iter().next()
         };
-
         if includes_other {
-            restore_question_pending_action(
-                state,
+            state.set_pending(PendingAction::AskUserQuestion {
                 tool_id,
                 questions,
                 current_index,
                 answers,
-                true,
-                pending_answer,
+                awaiting_custom_text: true,
+                pending_answer: pending_answer_next,
+            });
+            return result_from_menu(
+                state,
+                MenuView::plain(s.question_custom_for_other_prefix),
             );
-            return HandleResult {
-                reply: if language.is_chinese() {
-                    format!("请为“{}”输入你的自定义答案。", other_label(language))
-                } else {
-                    "Please type your custom answer for `Other`.".to_string()
-                },
-                actions: vec![],
-                forward_to_session: None,
-            };
         }
-
         answers.push(if question.multi_select {
-            pending_answer.unwrap_or_else(|| Value::Array(Vec::new()))
+            pending_answer_next.unwrap_or_else(|| Value::Array(Vec::new()))
         } else {
-            pending_answer.unwrap_or_else(|| Value::String(String::new()))
+            pending_answer_next.unwrap_or_else(|| Value::String(String::new()))
         });
     }
 
     if current_index + 1 < questions.len() {
-        let prompt = build_question_prompt(
-            language,
+        let view = build_question_view(s, &questions, current_index + 1, false);
+        state.set_pending(PendingAction::AskUserQuestion {
             tool_id,
             questions,
-            current_index + 1,
+            current_index: current_index + 1,
             answers,
-            false,
-            None,
-        );
-        restore_question_pending_action(
-            state,
-            match &prompt.pending_action {
-                PendingAction::AskUserQuestion { tool_id, .. } => tool_id.clone(),
-                _ => String::new(),
-            },
-            match &prompt.pending_action {
-                PendingAction::AskUserQuestion { questions, .. } => questions.clone(),
-                _ => Vec::new(),
-            },
-            match &prompt.pending_action {
-                PendingAction::AskUserQuestion { current_index, .. } => *current_index,
-                _ => 0,
-            },
-            match &prompt.pending_action {
-                PendingAction::AskUserQuestion { answers, .. } => answers.clone(),
-                _ => Vec::new(),
-            },
-            false,
-            None,
-        );
-        return HandleResult {
-            reply: prompt.reply,
-            actions: prompt.actions,
+            awaiting_custom_text: false,
+            pending_answer: None,
+        });
+        return result_from_menu(state, view);
+    }
+
+    state.clear_pending();
+    submit_question_answers(&tool_id, &answers, s).await
+}
+
+async fn submit_question_answers(
+    tool_id: &str,
+    answers: &[Value],
+    s: &'static BotStrings,
+) -> HandleResult {
+    use crate::agentic::tools::user_input_manager::get_user_input_manager;
+
+    let mut payload = serde_json::Map::new();
+    for (idx, value) in answers.iter().enumerate() {
+        payload.insert(idx.to_string(), value.clone());
+    }
+    let manager = get_user_input_manager();
+    match manager.send_answer(tool_id, Value::Object(payload)) {
+        Ok(_) => HandleResult {
+            reply: s.answers_submitted.to_string(),
+            actions: vec![],
             forward_to_session: None,
-        };
-    }
-
-    let mut result = submit_question_answers(&tool_id, &answers).await;
-    if language.is_chinese()
-        && result.reply == "Answers submitted. Waiting for the assistant to continue..."
-    {
-        result.reply = "答案已提交，等待助手继续...".to_string();
-    }
-    result
-}
-
-async fn handle_next_page(state: &mut BotChatState) -> HandleResult {
-    let language = current_bot_language().await;
-    let pending = state.pending_action.take();
-    match pending {
-        Some(PendingAction::SelectSession { page, has_more, .. }) if has_more => {
-            handle_resume_session(state, page + 1).await
-        }
-        Some(action) => {
-            state.pending_action = Some(action);
-            HandleResult {
-                reply: if language.is_chinese() {
-                    "没有更多页面了。".to_string()
-                } else {
-                    "No more pages available.".to_string()
-                },
-                actions: vec![],
-                forward_to_session: None,
-            }
-        }
-        None => handle_chat_message(state, "0", vec![]).await,
+            menu: MenuView::plain(s.answers_submitted),
+        },
+        Err(e) => HandleResult {
+            reply: format!("{}{e}", s.answers_submit_failed_prefix),
+            actions: vec![],
+            forward_to_session: None,
+            menu: MenuView::plain(format!("{}{e}", s.answers_submit_failed_prefix)),
+        },
     }
 }
 
-async fn handle_chat_message(
+// ── Free-form chat handling ───────────────────────────────────────
+
+async fn handle_chat(
     state: &mut BotChatState,
     message: &str,
     image_contexts: Vec<crate::agentic::image_analysis::ImageContextData>,
+    s: &'static BotStrings,
 ) -> HandleResult {
-    let language = current_bot_language().await;
-    if let Some(PendingAction::AskUserQuestion {
-        tool_id,
-        questions,
-        current_index,
-        answers,
-        awaiting_custom_text,
-        pending_answer,
-    }) = state.pending_action.take()
-    {
-        return handle_question_reply(
-            state,
-            tool_id,
-            questions,
-            current_index,
-            answers,
-            awaiting_custom_text,
-            pending_answer,
-            message,
-        )
-        .await;
-    }
+    // If there is a pending action, route the message to it (text answer for
+    // questions, "ignore" for menu-style pendings).
     if let Some(pending) = state.pending_action.clone() {
-        return match pending {
-            PendingAction::SelectWorkspace { .. } => HandleResult {
-                reply: if language.is_chinese() {
-                    "请回复工作区编号。".to_string()
-                } else {
-                    "Please reply with the workspace number.".to_string()
-                },
-                actions: vec![],
-                forward_to_session: None,
-            },
-            PendingAction::SelectAssistant { .. } => HandleResult {
-                reply: if language.is_chinese() {
-                    "请回复助理编号。".to_string()
-                } else {
-                    "Please reply with the assistant number.".to_string()
-                },
-                actions: vec![],
-                forward_to_session: None,
-            },
-            PendingAction::SelectSession { has_more, .. } => HandleResult {
-                reply: if has_more {
-                    if language.is_chinese() {
-                        "请回复会话编号，或回复 `0` 查看下一页。".to_string()
-                    } else {
-                        "Please reply with the session number, or `0` for the next page."
-                            .to_string()
-                    }
-                } else {
-                    if language.is_chinese() {
-                        "请回复会话编号。".to_string()
-                    } else {
-                        "Please reply with the session number.".to_string()
-                    }
-                },
-                actions: vec![],
-                forward_to_session: None,
-            },
-            PendingAction::AskUserQuestion { .. } => unreachable!(),
-        };
+        return route_pending(state, pending, message, s).await;
     }
 
     if state.display_mode == BotDisplayMode::Pro && state.current_workspace.is_none() {
-        return HandleResult {
-            reply: if language.is_chinese() {
-                "尚未选择工作区。请先使用 /switch_workspace 选择工作区。".to_string()
-            } else {
-                "No workspace selected. Use /switch_workspace to select one first.".to_string()
-            },
-            actions: workspace_required_actions(language),
-            forward_to_session: None,
-        };
+        return result_from_menu(
+            state,
+            MenuView::plain(s.no_workspace).with_items(vec![
+                MenuItem::primary(s.item_switch_workspace, "/switch"),
+                MenuItem::default(s.item_back, "/menu"),
+            ]),
+        );
     }
     if state.current_session_id.is_none() {
-        let reply = if language.is_chinese() {
-            if state.display_mode == BotDisplayMode::Pro {
-                "当前没有活动会话。请使用 /resume_session 恢复已有会话，或使用 /new_code_session、/new_cowork_session 创建新会话。"
-                    .to_string()
-            } else {
-                "当前没有活动会话。请使用 /resume_session 恢复已有会话，或使用 /new_claw_session 创建新会话。"
-                    .to_string()
-            }
-        } else {
-            if state.display_mode == BotDisplayMode::Pro {
-                "No active session. Use /resume_session to resume one or /new_code_session, /new_cowork_session to create a new one."
-                    .to_string()
-            } else {
-                "No active session. Use /resume_session to resume one or /new_claw_session to create a new one."
-                    .to_string()
-            }
-        };
-        return HandleResult {
-            reply,
-            actions: session_entry_actions(language, state.display_mode),
-            forward_to_session: None,
-        };
+        return result_from_menu(state, need_session_view(state, s));
     }
 
     let session_id = state.current_session_id.clone().unwrap();
@@ -2480,67 +2010,33 @@ async fn handle_chat_message(
             .is_some_and(|s| matches!(s.state, SessionState::Processing { .. }))
     };
 
-    if session_busy {
-        return HandleResult {
-            reply: if language.is_chinese() {
-                "消息已加入队列，将在当前助手步骤结束后自动处理。".to_string()
-            } else {
-                "Your message was queued and will run after the current assistant step finishes."
-                    .to_string()
-            },
-            actions: vec![],
-            forward_to_session: Some(ForwardRequest {
-                session_id,
-                content: message.to_string(),
-                agent_type: "agentic".to_string(),
-                turn_id,
-                image_contexts,
-            }),
-        };
-    }
+    let view = if session_busy {
+        MenuView::plain(s.queued).with_items(vec![
+            MenuItem::danger(s.item_cancel_task, format!("/cancel_task {turn_id}")),
+            MenuItem::default(s.item_back, "/menu"),
+        ])
+    } else {
+        MenuView::plain(s.processing)
+            .with_items(vec![
+                MenuItem::danger(s.item_cancel_task, format!("/cancel_task {turn_id}")),
+                MenuItem::default(s.item_back, "/menu"),
+            ])
+            .with_footer(s.footer_processing_cancel_hint)
+    };
 
-    let cancel_command = format!("/cancel_task {}", turn_id);
-    let verbose_mode = super::load_bot_persistence().verbose_mode;
-    let processing_line = if language.is_chinese() {
-        "正在处理你的消息..."
-    } else {
-        "Processing your message..."
+    let forward = ForwardRequest {
+        session_id,
+        content: message.to_string(),
+        agent_type: "agentic".to_string(),
+        turn_id,
+        image_contexts,
     };
-    let reply = if verbose_mode {
-        format!(
-            "{}\n\n{}",
-            processing_line,
-            if language.is_chinese() {
-                format!("如需停止本次请求，请发送 `{}`。", cancel_command)
-            } else {
-                format!("If needed, send `{}` to stop this request.", cancel_command)
-            },
-        )
-    } else {
-        processing_line.to_string()
-    };
-    HandleResult {
-        reply,
-        actions: cancel_task_actions(language, cancel_command),
-        forward_to_session: Some(ForwardRequest {
-            session_id,
-            content: message.to_string(),
-            agent_type: "agentic".to_string(),
-            turn_id,
-            image_contexts,
-        }),
-    }
+
+    result_from_menu_with_forward(state, view, Some(forward))
 }
 
-// ── Forwarded-turn execution ────────────────────────────────────────
+// ── Forwarded turn execution (largely unchanged) ──────────────────
 
-/// Execute a forwarded dialog turn and return the AI response text.
-///
-/// Called from the bot implementations after `handle_command` returns a
-/// `ForwardRequest`.  Dispatches the command through
-/// `RemoteExecutionDispatcher` (the same path used by mobile), then
-/// subscribes to the tracker's broadcast channel for real-time events.
-///
 pub async fn execute_forwarded_turn(
     forward: ForwardRequest,
     interaction_handler: Option<BotInteractionHandler>,
@@ -2551,10 +2047,11 @@ pub async fn execute_forwarded_turn(
     use crate::service::remote_connect::remote_server::{
         get_or_init_global_dispatcher, TrackerEvent,
     };
+
     let language = current_bot_language().await;
+    let s = strings_for(language);
 
     let dispatcher = get_or_init_global_dispatcher();
-
     let tracker = dispatcher.ensure_tracker(&forward.session_id);
     let mut event_rx = tracker.subscribe();
 
@@ -2571,11 +2068,7 @@ pub async fn execute_forwarded_turn(
         )
         .await
     {
-        let msg = if language.is_chinese() {
-            format!("发送消息失败：{e}")
-        } else {
-            format!("Failed to send message: {e}")
-        };
+        let msg = format!("{}{e}", s.send_failed_prefix);
         return ForwardedTurnResult {
             display_text: msg.clone(),
             full_text: msg,
@@ -2585,14 +2078,13 @@ pub async fn execute_forwarded_turn(
     let result = tokio::time::timeout(std::time::Duration::from_secs(3600), async {
         let mut response = String::new();
         let mut thinking_buf = String::new();
-        // Cache tool params from ToolStarted so we can display them on ToolCompleted.
         let mut tool_params_cache: std::collections::HashMap<String, Option<serde_json::Value>> =
             std::collections::HashMap::new();
 
         let streams_our_turn = || {
             tracker
                 .snapshot_active_turn()
-                .map(|s| s.turn_id == target_turn_id)
+                .map(|st| st.turn_id == target_turn_id)
                 .unwrap_or(false)
         };
 
@@ -2612,11 +2104,7 @@ pub async fn execute_forwarded_turn(
                         if verbose_mode && !thinking_buf.trim().is_empty() {
                             if let Some(sender) = message_sender.as_ref() {
                                 let content = truncate_at_char_boundary(&thinking_buf, 500);
-                                let msg = if language.is_chinese() {
-                                    format!("[思考过程]\n{content}")
-                                } else {
-                                    format!("[Thinking]\n{content}")
-                                };
+                                let msg = format!("[{}] {}", s.thinking_label, content);
                                 sender(msg).await;
                             }
                         }
@@ -2643,15 +2131,22 @@ pub async fn execute_forwarded_turn(
                                 if let Ok(questions) =
                                     serde_json::from_value::<Vec<BotQuestion>>(questions_value)
                                 {
-                                    let request = build_question_prompt(
-                                        language,
-                                        tool_id,
-                                        questions,
-                                        0,
-                                        Vec::new(),
-                                        false,
-                                        None,
-                                    );
+                                    let view = build_question_view(s, &questions, 0, false);
+                                    let actions: Vec<BotAction> =
+                                        view.items.iter().cloned().map(BotAction::from).collect();
+                                    let request = BotInteractiveRequest {
+                                        reply: view.render_text_block(),
+                                        actions,
+                                        menu: view,
+                                        pending_action: PendingAction::AskUserQuestion {
+                                            tool_id,
+                                            questions,
+                                            current_index: 0,
+                                            answers: Vec::new(),
+                                            awaiting_custom_text: false,
+                                            pending_answer: None,
+                                        },
+                                    };
                                     if let Some(handler) = interaction_handler.as_ref() {
                                         handler(request).await;
                                     }
@@ -2682,7 +2177,7 @@ pub async fn execute_forwarded_turn(
                                         if ms >= 1000 {
                                             format!("{:.1}s", ms as f64 / 1000.0)
                                         } else {
-                                            format!("{}ms", ms)
+                                            format!("{ms}ms")
                                         }
                                     })
                                     .unwrap_or_default();
@@ -2705,11 +2200,7 @@ pub async fn execute_forwarded_turn(
                     }
                     TrackerEvent::TurnFailed { turn_id, error } => {
                         if turn_id == target_turn_id {
-                            let msg = if language.is_chinese() {
-                                format!("错误: {error}")
-                            } else {
-                                format!("Error: {error}")
-                            };
+                            let msg = format!("{}{}", s.error_prefix, error);
                             return ForwardedTurnResult {
                                 display_text: msg.clone(),
                                 full_text: msg,
@@ -2718,14 +2209,9 @@ pub async fn execute_forwarded_turn(
                     }
                     TrackerEvent::TurnCancelled { turn_id } => {
                         if turn_id == target_turn_id {
-                            let msg = if language.is_chinese() {
-                                "任务已取消。".to_string()
-                            } else {
-                                "Task was cancelled.".to_string()
-                            };
                             return ForwardedTurnResult {
-                                display_text: msg.clone(),
-                                full_text: msg,
+                                display_text: s.task_cancelled.to_string(),
+                                full_text: s.task_cancelled.to_string(),
                             };
                         }
                     }
@@ -2740,11 +2226,7 @@ pub async fn execute_forwarded_turn(
         }
 
         let full_text = tracker.accumulated_text();
-        let full_text = if full_text.is_empty() {
-            response
-        } else {
-            full_text
-        };
+        let full_text = if full_text.is_empty() { response } else { full_text };
 
         let mut display_text = full_text.clone();
         const MAX_BOT_MSG_LEN: usize = 4000;
@@ -2759,11 +2241,7 @@ pub async fn execute_forwarded_turn(
 
         ForwardedTurnResult {
             display_text: if display_text.is_empty() {
-                if language.is_chinese() {
-                    "（无回复）".to_string()
-                } else {
-                    "(No response)".to_string()
-                }
+                s.no_response.to_string()
             } else {
                 display_text
             },
@@ -2773,11 +2251,7 @@ pub async fn execute_forwarded_turn(
     .await;
 
     result.unwrap_or_else(|_| ForwardedTurnResult {
-        display_text: if language.is_chinese() {
-            "等待 1 小时后响应超时。".to_string()
-        } else {
-            "Response timed out after 1 hour.".to_string()
-        },
+        display_text: s.timeout_one_hour.to_string(),
         full_text: String::new(),
     })
 }
@@ -2793,8 +2267,6 @@ fn truncate_at_char_boundary(s: &str, max_len: usize) -> String {
     format!("{}...", &s[..end])
 }
 
-/// Format tool params into a compact display string for bot messages.
-/// Filters out large string values and truncates remaining ones.
 fn format_tool_params_slim(params: &serde_json::Value) -> Option<String> {
     const MAX_VAL_LEN: usize = 120;
     match params {
@@ -2834,27 +2306,163 @@ fn format_tool_params_slim(params: &serde_json::Value) -> Option<String> {
     }
 }
 
+// ── Tests ─────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod parse_command_tests {
-    use super::{parse_command, BotCommand};
+    use super::*;
 
     #[test]
     fn numeric_menu_with_trailing_dot() {
-        assert!(matches!(
-            parse_command("1."),
-            BotCommand::NumberSelection(1)
-        ));
-        assert!(matches!(
-            parse_command("2。"),
-            BotCommand::NumberSelection(2)
-        ));
+        assert!(matches!(parse_command("1."), BotCommand::NumberSelection(1)));
+        assert!(matches!(parse_command("2。"), BotCommand::NumberSelection(2)));
     }
 
     #[test]
     fn fullwidth_digit_one() {
+        assert!(matches!(parse_command("１"), BotCommand::NumberSelection(1)));
+    }
+
+    #[test]
+    fn zero_parsed_as_number_selection() {
+        // `0` stays as a numeric selection so it can mean "next page" or
+        // "back" depending on which pending action is active.  The
+        // top-level "no pending" → main-menu fallback is implemented in
+        // `handle_number`.
+        assert!(matches!(parse_command("0"), BotCommand::NumberSelection(0)));
+    }
+
+    #[test]
+    fn menu_aliases() {
+        assert!(matches!(parse_command("/menu"), BotCommand::Menu));
+        assert!(matches!(parse_command("/m"), BotCommand::Menu));
+        assert!(matches!(parse_command("菜单"), BotCommand::Menu));
+        assert!(matches!(parse_command("/start"), BotCommand::Menu));
+    }
+
+    #[test]
+    fn settings_aliases() {
+        assert!(matches!(parse_command("/settings"), BotCommand::Settings));
+        assert!(matches!(parse_command("设置"), BotCommand::Settings));
+    }
+
+    #[test]
+    fn verbose_concise_real_commands() {
+        assert!(matches!(parse_command("/verbose"), BotCommand::SetVerbose(true)));
+        assert!(matches!(parse_command("/concise"), BotCommand::SetVerbose(false)));
+    }
+
+    #[test]
+    fn switch_aliases() {
+        assert!(matches!(parse_command("/switch"), BotCommand::SwitchContext));
         assert!(matches!(
-            parse_command("１"),
-            BotCommand::NumberSelection(1)
+            parse_command("/switch_workspace"),
+            BotCommand::SwitchContext
         ));
+        assert!(matches!(
+            parse_command("/switch_assistant"),
+            BotCommand::SwitchContext
+        ));
+        assert!(matches!(parse_command("切换"), BotCommand::SwitchContext));
+    }
+
+    #[test]
+    fn new_session_aliases() {
+        assert!(matches!(parse_command("/new"), BotCommand::NewSession));
+        assert!(matches!(
+            parse_command("/new_code_session"),
+            BotCommand::NewCodeSession
+        ));
+        assert!(matches!(
+            parse_command("/new_cowork_session"),
+            BotCommand::NewCoworkSession
+        ));
+        assert!(matches!(
+            parse_command("/new_claw_session"),
+            BotCommand::NewClawSession
+        ));
+    }
+
+    #[test]
+    fn resume_aliases() {
+        assert!(matches!(parse_command("/resume"), BotCommand::ResumeSession));
+        assert!(matches!(parse_command("/r"), BotCommand::ResumeSession));
+        assert!(matches!(
+            parse_command("/resume_session"),
+            BotCommand::ResumeSession
+        ));
+    }
+
+    #[test]
+    fn cancel_aliases() {
+        assert!(matches!(parse_command("/cancel"), BotCommand::CancelTask(None)));
+        match parse_command("/cancel_task turn_abc") {
+            BotCommand::CancelTask(Some(id)) => assert_eq!(id, "turn_abc"),
+            _ => panic!("expected cancel task with id"),
+        }
+    }
+
+    #[test]
+    fn pairing_code_detected() {
+        match parse_command("123456") {
+            BotCommand::PairingCode(c) => assert_eq!(c, "123456"),
+            _ => panic!("expected pairing code"),
+        }
+    }
+
+    #[test]
+    fn chat_message_fallback() {
+        assert!(matches!(parse_command("hello world"), BotCommand::ChatMessage(_)));
+    }
+}
+
+#[cfg(test)]
+mod state_tests {
+    use super::*;
+
+    #[test]
+    fn pending_expires_after_ttl() {
+        let mut state = BotChatState::new("c".into());
+        state.set_pending(PendingAction::SelectWorkspace { options: vec![] });
+        assert!(state.pending_action.is_some());
+        assert!(!state.pending_expired());
+        state.pending_expires_at = now_secs() - 1;
+        assert!(state.pending_expired());
+    }
+
+    #[test]
+    fn clear_pending_resets_counters() {
+        let mut state = BotChatState::new("c".into());
+        state.set_pending(PendingAction::SelectWorkspace { options: vec![] });
+        state.pending_invalid_count = 2;
+        state.clear_pending();
+        assert!(state.pending_action.is_none());
+        assert_eq!(state.pending_invalid_count, 0);
+        assert_eq!(state.pending_expires_at, 0);
+    }
+}
+
+#[cfg(test)]
+mod menu_tests {
+    use super::*;
+
+    #[test]
+    fn main_menu_assistant_has_four_items() {
+        let state = BotChatState::new("c".into());
+        let view = main_menu_view(&state, strings_for(BotLanguage::ZhCN));
+        assert_eq!(view.items.len(), 4);
+        assert!(view.items.iter().any(|i| i.command == "/new"));
+        assert!(view.items.iter().any(|i| i.command == "/resume"));
+        assert!(view.items.iter().any(|i| i.command == "/switch"));
+        assert!(view.items.iter().any(|i| i.command == "/settings"));
+    }
+
+    #[test]
+    fn main_menu_expert_has_five_items() {
+        let mut state = BotChatState::new("c".into());
+        state.display_mode = BotDisplayMode::Pro;
+        let view = main_menu_view(&state, strings_for(BotLanguage::ZhCN));
+        assert_eq!(view.items.len(), 5);
+        assert!(view.items.iter().any(|i| i.command == "/new_code_session"));
     }
 }

--- a/src/crates/core/src/service/remote_connect/bot/feishu.rs
+++ b/src/crates/core/src/service/remote_connect/bot/feishu.rs
@@ -563,10 +563,15 @@ impl FeishuBot {
 
     async fn send_handle_result(&self, chat_id: &str, result: &HandleResult) -> Result<()> {
         let language = current_bot_language().await;
-        if result.actions.is_empty() {
-            self.send_message(chat_id, &result.reply).await
+        let text = if result.menu.items.is_empty() && result.menu.title.is_empty() {
+            result.reply.clone()
         } else {
-            self.send_action_card(chat_id, language, &result.reply, &result.actions)
+            result.menu.render_text_block()
+        };
+        if result.actions.is_empty() {
+            self.send_message(chat_id, &text).await
+        } else {
+            self.send_action_card(chat_id, language, &text, &result.actions)
                 .await
         }
     }
@@ -654,6 +659,7 @@ impl FeishuBot {
     /// markdown hyperlinks to local files), store them as pending downloads and
     /// send an interactive card with one download button per file.
     async fn notify_files_ready(&self, chat_id: &str, text: &str) {
+        let language = super::locale::current_bot_language().await;
         let result = {
             let mut states = self.chat_states.write().await;
             let state = states.entry(chat_id.to_string()).or_insert_with(|| {
@@ -666,6 +672,7 @@ impl FeishuBot {
                 text,
                 state,
                 workspace_root.as_deref().map(std::path::Path::new),
+                language,
             )
         };
         if let Some(result) = result {
@@ -1577,7 +1584,7 @@ impl FeishuBot {
             s.paired = true;
             s
         });
-        state.pending_action = Some(interaction.pending_action.clone());
+        super::command_router::apply_interactive_request(state, &interaction);
         self.persist_chat_state(chat_id, state).await;
         drop(states);
 
@@ -1585,6 +1592,7 @@ impl FeishuBot {
             reply: interaction.reply,
             actions: interaction.actions,
             forward_to_session: None,
+            menu: interaction.menu,
         };
         self.send_handle_result(chat_id, &result).await.ok();
     }

--- a/src/crates/core/src/service/remote_connect/bot/locale.rs
+++ b/src/crates/core/src/service/remote_connect/bot/locale.rs
@@ -1,0 +1,463 @@
+//! Centralised IM-bot strings for the simplified bot UX.
+//!
+//! All user-facing IM bot strings live here so command routing, menu
+//! rendering, and platform adapters can share a single source of truth.
+//! New languages add one more `static BotStrings` and one match arm in
+//! [`strings_for`].
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum BotLanguage {
+    #[serde(rename = "zh-CN")]
+    ZhCN,
+    #[serde(rename = "en-US")]
+    EnUS,
+}
+
+impl BotLanguage {
+    pub fn is_chinese(self) -> bool {
+        matches!(self, Self::ZhCN)
+    }
+}
+
+pub async fn current_bot_language() -> BotLanguage {
+    if let Some(service) = crate::service::get_global_i18n_service().await {
+        match service.get_current_locale().await {
+            crate::service::LocaleId::ZhCN => BotLanguage::ZhCN,
+            crate::service::LocaleId::EnUS => BotLanguage::EnUS,
+        }
+    } else {
+        BotLanguage::ZhCN
+    }
+}
+
+/// Centralised string table consumed by command router, menu builder, and
+/// platform adapters.  Add new strings here, then translate in both
+/// [`STRINGS_ZH`] and [`STRINGS_EN`].
+pub struct BotStrings {
+    // ── Onboarding ───────────────────────────────────────────────
+    pub welcome: &'static str,
+    pub paired_success: &'static str,
+    pub need_pairing: &'static str,
+    pub invalid_pairing_code: &'static str,
+    pub bootstrap_workspace_unavailable: &'static str,
+    pub bootstrap_session_failed_prefix: &'static str,
+    pub bootstrap_ready: &'static str,
+
+    // ── Mode / context labels ────────────────────────────────────
+    pub mode_assistant: &'static str,
+    pub mode_expert: &'static str,
+    pub current_session_label: &'static str,
+    pub current_workspace_label: &'static str,
+    pub current_assistant_label: &'static str,
+    pub no_session: &'static str,
+    pub no_workspace: &'static str,
+    pub no_assistant: &'static str,
+
+    // ── Main menu (one-line title) ───────────────────────────────
+    pub main_title_assistant: &'static str,
+    pub main_title_expert: &'static str,
+    pub settings_title: &'static str,
+    pub welcome_title: &'static str,
+    pub need_session_title: &'static str,
+
+    // ── Menu item labels (≤ 14 chars target) ─────────────────────
+    pub item_new_session: &'static str,
+    pub item_new_code_session: &'static str,
+    pub item_new_cowork_session: &'static str,
+    pub item_resume_session: &'static str,
+    pub item_switch_assistant: &'static str,
+    pub item_switch_workspace: &'static str,
+    pub item_settings: &'static str,
+    pub item_back: &'static str,
+    pub item_help: &'static str,
+    pub item_switch_to_expert: &'static str,
+    pub item_switch_to_assistant: &'static str,
+    pub item_verbose_on: &'static str,
+    pub item_verbose_off: &'static str,
+    pub item_cancel_task: &'static str,
+    pub item_confirm_switch: &'static str,
+    pub item_next_page: &'static str,
+    pub item_other: &'static str,
+
+    // ── Auxiliary labels ─────────────────────────────────────────
+    pub question_title: &'static str,
+    pub verbose_label: &'static str,
+    pub workspace_session_count_fmt: &'static str,
+
+    // ── Footer hints ─────────────────────────────────────────────
+    pub footer_reply_or_menu: &'static str,
+    pub footer_reply_workspace: &'static str,
+    pub footer_reply_assistant: &'static str,
+    pub footer_reply_session_or_next: &'static str,
+    pub footer_reply_session: &'static str,
+    pub footer_question_single: &'static str,
+    pub footer_question_multi: &'static str,
+    pub footer_question_custom: &'static str,
+    pub footer_processing_cancel_hint: &'static str,
+
+    // ── Body / inline texts ──────────────────────────────────────
+    pub welcome_body: &'static str,
+    pub paired_body_intro: &'static str,
+    pub help_body: &'static str,
+
+    pub switch_pick_workspace: &'static str,
+    pub switch_pick_assistant: &'static str,
+    pub switch_no_workspaces: &'static str,
+    pub switch_no_assistants: &'static str,
+    pub current_marker: &'static str,
+
+    pub resume_no_sessions: &'static str,
+    pub resume_page_label: &'static str,
+    pub resume_msg_count_zero: &'static str,
+    pub resume_msg_count_one: &'static str,
+    pub resume_msg_count_many_fmt: &'static str,
+    pub resume_resumed_prefix: &'static str,
+    pub resume_last_dialog_header: &'static str,
+    pub resume_you_label: &'static str,
+    pub resume_continue_hint: &'static str,
+    pub resume_first_message_hint: &'static str,
+
+    pub processing: &'static str,
+    pub queued: &'static str,
+    pub no_response: &'static str,
+    pub task_cancelled: &'static str,
+    pub task_cancel_requested: &'static str,
+    pub task_cancel_failed_prefix: &'static str,
+    pub task_no_active: &'static str,
+    pub timeout_one_hour: &'static str,
+    pub error_prefix: &'static str,
+    pub send_failed_prefix: &'static str,
+
+    pub mode_switched_to_expert: &'static str,
+    pub mode_switched_to_assistant: &'static str,
+    pub mode_already_expert: &'static str,
+    pub mode_already_assistant: &'static str,
+    pub mode_confirm_switch_prefix: &'static str,
+
+    pub verbose_enabled: &'static str,
+    pub verbose_disabled: &'static str,
+    pub verbose_status_on: &'static str,
+    pub verbose_status_off: &'static str,
+
+    pub session_created_prefix: &'static str,
+    pub session_workspace_label: &'static str,
+    pub session_start_hint: &'static str,
+    pub session_create_failed_prefix: &'static str,
+    pub session_system_unavailable: &'static str,
+    pub workspace_service_unavailable: &'static str,
+    pub workspace_open_failed_prefix: &'static str,
+    pub assistant_create_failed_prefix: &'static str,
+
+    pub pending_expired: &'static str,
+    pub pending_invalid_input: &'static str,
+    pub pending_invalid_after_retries: &'static str,
+    pub pending_back_hint: &'static str,
+
+    pub answers_submitted: &'static str,
+    pub answers_submit_failed_prefix: &'static str,
+    pub question_invalid_state: &'static str,
+    pub question_custom_required: &'static str,
+    pub question_custom_for_other_prefix: &'static str,
+
+    pub thinking_label: &'static str,
+
+    pub file_intro_one: &'static str,
+    pub file_intro_many_fmt: &'static str,
+    pub file_download_expired: &'static str,
+    pub file_sending_prefix: &'static str,
+    pub file_send_failed_prefix: &'static str,
+}
+
+const STRINGS_ZH: BotStrings = BotStrings {
+    welcome: "\
+欢迎使用 BitFun。
+
+请在 BitFun 桌面端打开 Remote Connect 面板，复制 6 位配对码并发送到这里完成连接。",
+    paired_success: "配对成功，BitFun 已连接。",
+    need_pairing: "尚未连接 BitFun 桌面端。请先发送 6 位配对码。",
+    invalid_pairing_code: "配对码无效或已过期，请到桌面端重新生成后再发送。",
+    bootstrap_workspace_unavailable: "工作区服务暂时不可用，请稍后再试。",
+    bootstrap_session_failed_prefix: "已进入助理模式，但创建会话失败：",
+    bootstrap_ready: "已为你新建助理会话，直接发送消息即可开始。",
+
+    mode_assistant: "助理模式",
+    mode_expert: "专业模式",
+    current_session_label: "当前会话",
+    current_workspace_label: "当前工作区",
+    current_assistant_label: "当前助理",
+    no_session: "尚未选择会话",
+    no_workspace: "尚未选择工作区",
+    no_assistant: "尚未选择助理",
+
+    main_title_assistant: "BitFun · 助理模式",
+    main_title_expert: "BitFun · 专业模式",
+    settings_title: "设置",
+    welcome_title: "BitFun",
+    need_session_title: "请先选择或新建会话",
+
+    item_new_session: "新建会话",
+    item_new_code_session: "新建编码会话",
+    item_new_cowork_session: "新建协作会话",
+    item_resume_session: "恢复会话",
+    item_switch_assistant: "切换助理",
+    item_switch_workspace: "切换工作区",
+    item_settings: "设置",
+    item_back: "返回",
+    item_help: "帮助",
+    item_switch_to_expert: "切换到专业模式",
+    item_switch_to_assistant: "切换到助理模式",
+    item_verbose_on: "开启执行细节",
+    item_verbose_off: "关闭执行细节",
+    item_cancel_task: "取消任务",
+    item_confirm_switch: "切换并继续",
+    item_next_page: "下一页",
+    item_other: "其他",
+
+    question_title: "问题",
+    verbose_label: "执行细节",
+    workspace_session_count_fmt: "{n} 个会话",
+
+    footer_reply_or_menu: "回复编号，或发送 /menu 返回主菜单",
+    footer_reply_workspace: "回复工作区编号，或发送 0 返回",
+    footer_reply_assistant: "回复助理编号，或发送 0 返回",
+    footer_reply_session_or_next: "回复会话编号；发送 0 查看下一页或返回",
+    footer_reply_session: "回复会话编号，或发送 0 返回",
+    footer_question_single: "回复单个选项编号；发送 /menu 退出",
+    footer_question_multi: "回复一个或多个选项编号（如 1,3）；发送 /menu 退出",
+    footer_question_custom: "请输入你的自定义答案；发送 /menu 退出",
+    footer_processing_cancel_hint: "如需中止，回复 /cancel 或点击「取消任务」",
+
+    welcome_body: "当前未配对。",
+    paired_body_intro: "可以直接发送消息开始对话。",
+    help_body: "\
+常用命令：
+/menu  返回主菜单
+/new   新建会话
+/resume  恢复历史会话
+/switch  切换助理或工作区
+/cancel  取消当前任务
+/expert  /assistant  切换模式
+/verbose /concise  开关执行细节
+/help  显示本帮助",
+
+    switch_pick_workspace: "请选择要切换的工作区：",
+    switch_pick_assistant: "请选择要切换的助理：",
+    switch_no_workspaces: "尚未发现工作区，请先在 BitFun 桌面端打开一个项目。",
+    switch_no_assistants: "尚未发现助理，请先在 BitFun 桌面端创建一个助理。",
+    current_marker: " · 当前",
+
+    resume_no_sessions: "当前还没有会话，可以发送 /new 直接新建。",
+    resume_page_label: "会话历史",
+    resume_msg_count_zero: "无消息",
+    resume_msg_count_one: "1 条消息",
+    resume_msg_count_many_fmt: "{n} 条消息",
+    resume_resumed_prefix: "已恢复会话：",
+    resume_last_dialog_header: "— 最近一次对话 —",
+    resume_you_label: "你",
+    resume_continue_hint: "可以继续对话。",
+    resume_first_message_hint: "发送一条消息即可开始。",
+
+    processing: "正在处理你的消息……",
+    queued: "消息已加入队列，等当前步骤结束会自动接续。",
+    no_response: "（无回复）",
+    task_cancelled: "任务已取消。",
+    task_cancel_requested: "已请求取消当前任务。",
+    task_cancel_failed_prefix: "取消任务失败：",
+    task_no_active: "当前没有正在运行的任务。",
+    timeout_one_hour: "等待响应超时（1 小时）。",
+    error_prefix: "错误：",
+    send_failed_prefix: "发送失败：",
+
+    mode_switched_to_expert: "已切换到专业模式，可创建编码 / 协作会话。",
+    mode_switched_to_assistant: "已切换到助理模式，适合日常持续对话。",
+    mode_already_expert: "当前已在专业模式。",
+    mode_already_assistant: "当前已在助理模式。",
+    mode_confirm_switch_prefix: "该操作需要切换到另一种模式，确认继续吗？",
+
+    verbose_enabled: "已开启「执行细节」，下一次任务会显示思考与工具过程。",
+    verbose_disabled: "已关闭「执行细节」，仅显示最终结果。",
+    verbose_status_on: "开",
+    verbose_status_off: "关",
+
+    session_created_prefix: "已创建新会话：",
+    session_workspace_label: "工作区：",
+    session_start_hint: "可以发送消息开始对话。",
+    session_create_failed_prefix: "创建会话失败：",
+    session_system_unavailable: "BitFun 会话系统尚未就绪，请稍后再试。",
+    workspace_service_unavailable: "工作区服务暂时不可用。",
+    workspace_open_failed_prefix: "打开工作区失败：",
+    assistant_create_failed_prefix: "创建助理工作区失败：",
+
+    pending_expired: "上一步已超时，已为你返回主菜单。",
+    pending_invalid_input: "输入无效，请按提示回复或发送 /menu 返回主菜单。",
+    pending_invalid_after_retries: "多次输入无效，已为你返回主菜单。",
+    pending_back_hint: "发送 0 或 /menu 返回主菜单。",
+
+    answers_submitted: "答案已提交，等待助手继续……",
+    answers_submit_failed_prefix: "提交答案失败：",
+    question_invalid_state: "问题状态无效，请重新发起对话。",
+    question_custom_required: "自定义答案不能为空，请重新输入。",
+    question_custom_for_other_prefix: "请为「其他」输入你的自定义答案：",
+
+    thinking_label: "思考中",
+
+    file_intro_one: "已生成 1 个文件，可点击下方按钮下载。",
+    file_intro_many_fmt: "已生成 {n} 个文件，可点击下方按钮下载。",
+    file_download_expired: "下载链接已过期，请重新让助手生成一次。",
+    file_sending_prefix: "正在发送：",
+    file_send_failed_prefix: "发送文件失败：",
+};
+
+const STRINGS_EN: BotStrings = BotStrings {
+    welcome: "\
+Welcome to BitFun.
+
+Open Remote Connect in BitFun Desktop and send the 6-digit pairing code here to connect.",
+    paired_success: "Pairing successful. BitFun is now connected.",
+    need_pairing: "Not connected yet. Please send the 6-digit pairing code first.",
+    invalid_pairing_code: "Invalid or expired pairing code. Generate a new one in BitFun Desktop and try again.",
+    bootstrap_workspace_unavailable: "Workspace service is unavailable. Please try again shortly.",
+    bootstrap_session_failed_prefix: "Assistant mode is on but session creation failed: ",
+    bootstrap_ready: "A new assistant session is ready. Send a message to start.",
+
+    mode_assistant: "Assistant Mode",
+    mode_expert: "Expert Mode",
+    current_session_label: "Current session",
+    current_workspace_label: "Current workspace",
+    current_assistant_label: "Current assistant",
+    no_session: "No session selected",
+    no_workspace: "No workspace selected",
+    no_assistant: "No assistant selected",
+
+    main_title_assistant: "BitFun · Assistant",
+    main_title_expert: "BitFun · Expert",
+    settings_title: "Settings",
+    welcome_title: "BitFun",
+    need_session_title: "Pick or create a session first",
+
+    item_new_session: "New Session",
+    item_new_code_session: "New Code Session",
+    item_new_cowork_session: "New Cowork Session",
+    item_resume_session: "Resume Session",
+    item_switch_assistant: "Switch Assistant",
+    item_switch_workspace: "Switch Workspace",
+    item_settings: "Settings",
+    item_back: "Back",
+    item_help: "Help",
+    item_switch_to_expert: "Switch to Expert Mode",
+    item_switch_to_assistant: "Switch to Assistant Mode",
+    item_verbose_on: "Show Execution Details",
+    item_verbose_off: "Hide Execution Details",
+    item_cancel_task: "Cancel Task",
+    item_confirm_switch: "Switch & Continue",
+    item_next_page: "Next Page",
+    item_other: "Other",
+
+    question_title: "Question",
+    verbose_label: "Execution details",
+    workspace_session_count_fmt: "{n} sessions",
+
+    footer_reply_or_menu: "Reply with a number, or send /menu to return.",
+    footer_reply_workspace: "Reply with a workspace number, or 0 to go back.",
+    footer_reply_assistant: "Reply with an assistant number, or 0 to go back.",
+    footer_reply_session_or_next: "Reply with a session number; send 0 for next page or to go back.",
+    footer_reply_session: "Reply with a session number, or 0 to go back.",
+    footer_question_single: "Reply with one option number; send /menu to exit.",
+    footer_question_multi: "Reply with one or more option numbers (e.g. 1,3); send /menu to exit.",
+    footer_question_custom: "Type your custom answer; send /menu to exit.",
+    footer_processing_cancel_hint: "To stop, reply /cancel or tap Cancel Task.",
+
+    welcome_body: "Not paired yet.",
+    paired_body_intro: "Send a message to start the conversation.",
+    help_body: "\
+Common commands:
+/menu  Return to the main menu
+/new   Create a new session
+/resume  Resume an existing session
+/switch  Switch assistant or workspace
+/cancel  Cancel the current task
+/expert  /assistant  Switch modes
+/verbose /concise  Toggle execution details
+/help  Show this help",
+
+    switch_pick_workspace: "Pick a workspace to switch to:",
+    switch_pick_assistant: "Pick an assistant to switch to:",
+    switch_no_workspaces: "No workspaces found. Open a project in BitFun Desktop first.",
+    switch_no_assistants: "No assistants found. Create one in BitFun Desktop first.",
+    current_marker: " · current",
+
+    resume_no_sessions: "No sessions yet. Send /new to create one.",
+    resume_page_label: "Sessions",
+    resume_msg_count_zero: "no messages",
+    resume_msg_count_one: "1 message",
+    resume_msg_count_many_fmt: "{n} messages",
+    resume_resumed_prefix: "Resumed session: ",
+    resume_last_dialog_header: "— Last conversation —",
+    resume_you_label: "You",
+    resume_continue_hint: "You can continue the conversation.",
+    resume_first_message_hint: "Send a message to start.",
+
+    processing: "Processing your message…",
+    queued: "Message queued. It will run when the current step finishes.",
+    no_response: "(no response)",
+    task_cancelled: "Task cancelled.",
+    task_cancel_requested: "Cancellation requested.",
+    task_cancel_failed_prefix: "Failed to cancel: ",
+    task_no_active: "No active task to cancel.",
+    timeout_one_hour: "Response timed out after 1 hour.",
+    error_prefix: "Error: ",
+    send_failed_prefix: "Send failed: ",
+
+    mode_switched_to_expert: "Switched to Expert mode. You can create code or cowork sessions.",
+    mode_switched_to_assistant: "Switched to Assistant mode. Best for ongoing conversations.",
+    mode_already_expert: "Already in Expert mode.",
+    mode_already_assistant: "Already in Assistant mode.",
+    mode_confirm_switch_prefix: "This action needs the other mode. Switch and continue?",
+
+    verbose_enabled: "Execution details enabled. The next task will show thinking and tool steps.",
+    verbose_disabled: "Execution details disabled. Only final results will be shown.",
+    verbose_status_on: "on",
+    verbose_status_off: "off",
+
+    session_created_prefix: "New session created: ",
+    session_workspace_label: "Workspace: ",
+    session_start_hint: "Send a message to start the conversation.",
+    session_create_failed_prefix: "Failed to create session: ",
+    session_system_unavailable: "BitFun session system is not ready yet.",
+    workspace_service_unavailable: "Workspace service unavailable.",
+    workspace_open_failed_prefix: "Failed to open workspace: ",
+    assistant_create_failed_prefix: "Failed to create assistant workspace: ",
+
+    pending_expired: "Previous step expired. Returned to the main menu.",
+    pending_invalid_input: "Invalid input. Follow the prompt above, or send /menu to return.",
+    pending_invalid_after_retries: "Too many invalid replies. Returned to the main menu.",
+    pending_back_hint: "Send 0 or /menu to return to the main menu.",
+
+    answers_submitted: "Answers submitted. Waiting for the assistant to continue…",
+    answers_submit_failed_prefix: "Failed to submit answers: ",
+    question_invalid_state: "Question state is invalid; please restart the conversation.",
+    question_custom_required: "Custom answer cannot be empty. Please type it again.",
+    question_custom_for_other_prefix: "Type your custom answer for `Other`: ",
+
+    thinking_label: "Thinking",
+
+    file_intro_one: "1 file is ready. Tap to download.",
+    file_intro_many_fmt: "{n} files are ready. Tap to download.",
+    file_download_expired: "Download link expired. Ask the assistant to generate it again.",
+    file_sending_prefix: "Sending: ",
+    file_send_failed_prefix: "Failed to send file: ",
+};
+
+pub fn strings_for(language: BotLanguage) -> &'static BotStrings {
+    match language {
+        BotLanguage::ZhCN => &STRINGS_ZH,
+        BotLanguage::EnUS => &STRINGS_EN,
+    }
+}
+
+/// Substitute `{n}` placeholder in formatted strings.
+pub fn fmt_count(template: &str, n: usize) -> String {
+    template.replace("{n}", &n.to_string())
+}

--- a/src/crates/core/src/service/remote_connect/bot/menu.rs
+++ b/src/crates/core/src/service/remote_connect/bot/menu.rs
@@ -1,0 +1,201 @@
+//! Unified menu model shared by all IM bot adapters.
+//!
+//! The command router builds a [`MenuView`] for every reply.  Each platform
+//! adapter renders the view to its native primitive: Telegram inline
+//! keyboards, Feishu interactive cards, or WeChat numbered text lines.
+//!
+//! There is intentionally no per-platform menu state in this module — menu
+//! semantics live in `command_router::dispatch_im_bot_command_inner`.
+
+use serde::{Deserialize, Serialize};
+
+use super::locale::{strings_for, BotLanguage, BotStrings};
+
+/// Visual style of a menu item.  Adapters map this to their own primitive
+/// (e.g. Telegram has no styling, Feishu uses a `type` field).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MenuItemStyle {
+    Primary,
+    Default,
+    Danger,
+}
+
+/// One row in a [`MenuView`].
+#[derive(Debug, Clone)]
+pub struct MenuItem {
+    /// Short, button-friendly label shown to the user.  Should be ≤ 14 chars.
+    pub label: String,
+    /// Real command string the bot will execute when the item is selected.
+    /// For platforms with native buttons this becomes `callback_data`; for
+    /// WeChat it is mapped via [`MenuView::numeric_commands`] for `1` ~ `n`
+    /// numeric replies.
+    pub command: String,
+    pub style: MenuItemStyle,
+}
+
+impl MenuItem {
+    pub fn primary(label: impl Into<String>, command: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            command: command.into(),
+            style: MenuItemStyle::Primary,
+        }
+    }
+    pub fn default(label: impl Into<String>, command: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            command: command.into(),
+            style: MenuItemStyle::Default,
+        }
+    }
+    pub fn danger(label: impl Into<String>, command: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            command: command.into(),
+            style: MenuItemStyle::Danger,
+        }
+    }
+}
+
+/// Unified, platform-agnostic menu/reply view.
+///
+/// Always provide a short `title` and at most 5 items.  The body field is
+/// optional and used for context like "Current session: …" or last dialog
+/// playback.
+#[derive(Debug, Clone, Default)]
+pub struct MenuView {
+    /// One-line context header (≤ 30 chars target).
+    pub title: String,
+    /// Optional secondary body text.
+    pub body: Option<String>,
+    pub items: Vec<MenuItem>,
+    /// Optional footer hint shown below items (telegram/feishu silently
+    /// drop this; weixin shows it as the last text line).
+    pub footer_hint: Option<String>,
+}
+
+impl MenuView {
+    pub fn plain(title: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            body: None,
+            items: Vec::new(),
+            footer_hint: None,
+        }
+    }
+
+    pub fn with_body(mut self, body: impl Into<String>) -> Self {
+        self.body = Some(body.into());
+        self
+    }
+
+    pub fn with_items(mut self, items: Vec<MenuItem>) -> Self {
+        self.items = items;
+        self
+    }
+
+    pub fn with_footer(mut self, hint: impl Into<String>) -> Self {
+        self.footer_hint = Some(hint.into());
+        self
+    }
+
+    pub fn push_item(&mut self, item: MenuItem) {
+        self.items.push(item);
+    }
+
+    /// Commands corresponding to numeric replies `1..=items.len()`.
+    pub fn numeric_commands(&self) -> Vec<String> {
+        self.items.iter().map(|i| i.command.clone()).collect()
+    }
+
+    /// Render the menu as plain text suitable for IM platforms without
+    /// native buttons (e.g. WeChat iLink).
+    pub fn render_plain_text(&self, language: BotLanguage) -> String {
+        let s = strings_for(language);
+        let mut out = String::new();
+        if !self.title.is_empty() {
+            out.push_str(&self.title);
+        }
+        if let Some(body) = &self.body {
+            if !body.is_empty() {
+                if !out.is_empty() {
+                    out.push_str("\n\n");
+                }
+                out.push_str(body);
+            }
+        }
+        if !self.items.is_empty() {
+            if !out.is_empty() {
+                out.push_str("\n\n");
+            }
+            for (i, item) in self.items.iter().enumerate() {
+                if i > 0 {
+                    out.push('\n');
+                }
+                out.push_str(&format!("{} {}", i + 1, item.label));
+            }
+        }
+        let hint = self
+            .footer_hint
+            .clone()
+            .filter(|h| !h.is_empty())
+            .unwrap_or_else(|| {
+                if self.items.is_empty() {
+                    String::new()
+                } else {
+                    s.footer_reply_or_menu.to_string()
+                }
+            });
+        if !hint.is_empty() {
+            if !out.is_empty() {
+                out.push_str("\n\n");
+            }
+            out.push_str(&hint);
+        }
+        out
+    }
+
+    /// Render the title and optional body as a single text block, used by
+    /// adapters with native buttons (Telegram / Feishu) where the items are
+    /// shown separately as buttons.
+    pub fn render_text_block(&self) -> String {
+        let mut out = String::new();
+        if !self.title.is_empty() {
+            out.push_str(&self.title);
+        }
+        if let Some(body) = &self.body {
+            if !body.is_empty() {
+                if !out.is_empty() {
+                    out.push_str("\n\n");
+                }
+                out.push_str(body);
+            }
+        }
+        if let Some(hint) = &self.footer_hint {
+            if !hint.is_empty() {
+                if !out.is_empty() {
+                    out.push_str("\n\n");
+                }
+                out.push_str(hint);
+            }
+        }
+        if out.is_empty() {
+            // Telegram refuses empty messages; fall back to a single space.
+            " ".to_string()
+        } else {
+            out
+        }
+    }
+}
+
+/// Common menu builder helpers used by command router and platforms.
+pub mod build {
+    use super::*;
+
+    /// Append the standard `back to main menu` item if not already present.
+    pub fn with_back(view: &mut MenuView, s: &BotStrings) {
+        if !view.items.iter().any(|i| i.command == "/menu") {
+            view.push_item(MenuItem::default(s.item_back, "/menu"));
+        }
+    }
+}

--- a/src/crates/core/src/service/remote_connect/bot/mod.rs
+++ b/src/crates/core/src/service/remote_connect/bot/mod.rs
@@ -6,12 +6,16 @@
 
 pub mod command_router;
 pub mod feishu;
+pub mod locale;
+pub mod menu;
 pub mod telegram;
 pub mod weixin;
 
 use serde::{Deserialize, Serialize};
 
 pub use command_router::{BotChatState, ForwardRequest, ForwardedTurnResult, HandleResult};
+pub use locale::BotLanguage;
+pub use menu::{MenuItem, MenuItemStyle, MenuView};
 
 /// Configuration for a bot-based connection.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -498,23 +502,28 @@ pub fn prepare_file_download_actions(
     text: &str,
     state: &mut command_router::BotChatState,
     workspace_root: Option<&std::path::Path>,
+    language: BotLanguage,
 ) -> Option<command_router::HandleResult> {
     use command_router::BotAction;
+    use locale::{fmt_count, strings_for};
 
     let file_paths = extract_downloadable_file_paths(text, workspace_root);
     if file_paths.is_empty() {
         return None;
     }
 
+    let strings = strings_for(language);
+
     let mut actions: Vec<BotAction> = Vec::new();
+    let mut menu_items: Vec<MenuItem> = Vec::new();
     for path in &file_paths {
         if let Some((name, size)) = get_file_metadata(path, workspace_root) {
             let token = generate_download_token(&state.chat_id);
             state.pending_files.insert(token.clone(), path.clone());
-            actions.push(BotAction::secondary(
-                format!("📥 {} ({})", name, format_file_size(size)),
-                format!("download_file:{token}"),
-            ));
+            let label = format!("{} ({})", name, format_file_size(size));
+            let command = format!("download_file:{token}");
+            actions.push(BotAction::secondary(label.clone(), command.clone()));
+            menu_items.push(MenuItem::default(label, command));
         }
     }
 
@@ -523,15 +532,19 @@ pub fn prepare_file_download_actions(
     }
 
     let intro = if actions.len() == 1 {
-        "📎 1 file ready to download:".to_string()
+        strings.file_intro_one.to_string()
     } else {
-        format!("📎 {} files ready to download:", actions.len())
+        fmt_count(strings.file_intro_many_fmt, actions.len())
     };
+
+    let menu = MenuView::plain(intro.clone()).with_items(menu_items);
+    state.last_menu_commands = menu.numeric_commands();
 
     Some(command_router::HandleResult {
         reply: intro,
         actions,
         forward_to_session: None,
+        menu,
     })
 }
 

--- a/src/crates/core/src/service/remote_connect/bot/telegram.rs
+++ b/src/crates/core/src/service/remote_connect/bot/telegram.rs
@@ -77,14 +77,6 @@ impl TelegramBot {
         }
     }
 
-    fn cancel_button_hint(language: BotLanguage) -> &'static str {
-        if language.is_chinese() {
-            "如需停止本次请求，请点击下方的“取消任务”按钮。"
-        } else {
-            "If needed, tap the Cancel Task button below to stop this request."
-        }
-    }
-
     pub fn new(config: TelegramConfig) -> Self {
         Self {
             config,
@@ -205,6 +197,7 @@ impl TelegramBot {
     /// markdown hyperlinks to local files), store them as pending downloads and
     /// send a notification with one inline-keyboard button per file.
     async fn notify_files_ready(&self, chat_id: i64, text: &str) {
+        let language = super::locale::current_bot_language().await;
         let result = {
             let mut states = self.chat_states.write().await;
             let state = states.entry(chat_id).or_insert_with(|| {
@@ -217,6 +210,7 @@ impl TelegramBot {
                 text,
                 state,
                 workspace_root.as_deref().map(std::path::Path::new),
+                language,
             )
         };
         if let Some(result) = result {
@@ -292,40 +286,20 @@ impl TelegramBot {
     /// text is replaced with a friendlier prompt, and a Cancel Task button is
     /// added via the inline keyboard.
     async fn send_handle_result(&self, chat_id: i64, result: &HandleResult) {
-        let language = current_bot_language().await;
-        let text = Self::clean_reply_text(language, &result.reply, !result.actions.is_empty());
+        let text = if result.menu.items.is_empty() && result.menu.title.is_empty() {
+            result.reply.clone()
+        } else {
+            result.menu.render_text_block()
+        };
         if result.actions.is_empty() {
             self.send_message(chat_id, &text).await.ok();
-        } else {
-            if let Err(e) = self
-                .send_message_with_keyboard(chat_id, &text, &result.actions)
-                .await
-            {
-                warn!("Failed to send Telegram keyboard message: {e}; falling back to plain text");
-                self.send_message(chat_id, &result.reply).await.ok();
-            }
+        } else if let Err(e) = self
+            .send_message_with_keyboard(chat_id, &text, &result.actions)
+            .await
+        {
+            warn!("Failed to send Telegram keyboard message: {e}; falling back to plain text");
+            self.send_message(chat_id, &result.reply).await.ok();
         }
-    }
-
-    /// Remove raw `/cancel_task <turn_id>` instruction lines and replace them
-    /// with a short hint that the button below can be used instead.
-    fn clean_reply_text(language: BotLanguage, text: &str, has_actions: bool) -> String {
-        let mut lines: Vec<String> = Vec::new();
-        let mut replaced_cancel = false;
-
-        for line in text.lines() {
-            let trimmed = line.trim();
-            if trimmed.contains("/cancel_task ") {
-                if has_actions && !replaced_cancel {
-                    lines.push(Self::cancel_button_hint(language).to_string());
-                    replaced_cancel = true;
-                }
-                continue;
-            }
-            lines.push(line.to_string());
-        }
-
-        lines.join("\n").trim().to_string()
     }
 
     /// Register the bot command menu visible in Telegram's "/" menu.
@@ -333,15 +307,15 @@ impl TelegramBot {
         let client = reqwest::Client::new();
         let commands = serde_json::json!({
             "commands": [
-                { "command": "switch_workspace", "description": "List and switch workspaces" },
-                { "command": "pro", "description": "Switch to Expert mode (Code/Cowork)" },
-                { "command": "assistant", "description": "Switch to Assistant mode (Claw)" },
-                { "command": "resume_session", "description": "Resume an existing session" },
-                { "command": "new_code_session", "description": "Create coding session (Expert)" },
-                { "command": "new_cowork_session", "description": "Create cowork session (Expert)" },
-                { "command": "new_claw_session", "description": "Create claw session (Assistant)" },
-                { "command": "cancel_task", "description": "Cancel the current task" },
-                { "command": "help", "description": "Show available commands" },
+                { "command": "menu", "description": "Show the main menu" },
+                { "command": "new", "description": "Create a new session" },
+                { "command": "resume", "description": "Resume an existing session" },
+                { "command": "switch", "description": "Switch assistant or workspace" },
+                { "command": "cancel", "description": "Cancel the current task" },
+                { "command": "expert", "description": "Switch to Expert mode" },
+                { "command": "assistant", "description": "Switch to Assistant mode" },
+                { "command": "settings", "description": "Open settings" },
+                { "command": "help", "description": "Show help" },
             ]
         });
         let resp = client
@@ -722,7 +696,7 @@ impl TelegramBot {
             s.paired = true;
             s
         });
-        state.pending_action = Some(interaction.pending_action.clone());
+        super::command_router::apply_interactive_request(state, &interaction);
         self.persist_chat_state(chat_id, state).await;
         drop(states);
 
@@ -730,6 +704,7 @@ impl TelegramBot {
             reply: interaction.reply,
             actions: interaction.actions,
             forward_to_session: None,
+            menu: interaction.menu,
         };
         self.send_handle_result(chat_id, &result).await;
     }

--- a/src/crates/core/src/service/remote_connect/bot/weixin.rs
+++ b/src/crates/core/src/service/remote_connect/bot/weixin.rs
@@ -22,7 +22,7 @@ use tokio::sync::RwLock;
 
 use super::command_router::{
     complete_im_bot_pairing, current_bot_language, execute_forwarded_turn, handle_command,
-    parse_command, welcome_message, BotAction, BotChatState, BotInteractionHandler,
+    parse_command, welcome_message, BotChatState, BotInteractionHandler,
     BotInteractiveRequest, BotLanguage, BotMessageSender, HandleResult,
 };
 use super::{load_bot_persistence, save_bot_persistence, BotConfig, SavedBotConnection};
@@ -1332,56 +1332,23 @@ impl WeixinBot {
         false
     }
 
-    fn format_actions_footer(language: BotLanguage, actions: &[BotAction]) -> String {
-        if actions.is_empty() {
-            return String::new();
-        }
-        let header = if language.is_chinese() {
-            "\n\n——\n快捷操作（可发送对应命令或回复数字）：\n"
-        } else {
-            "\n\n——\nQuick actions (send the command or reply with the number):\n"
-        };
-        let mut s = header.to_string();
-        for (i, a) in actions.iter().enumerate() {
-            let n = i + 1;
-            s.push_str(&format!("{n}. {} → {}\n", a.label, a.command));
-        }
-        s
-    }
-
-    fn clean_reply_text(language: BotLanguage, text: &str, has_actions: bool) -> String {
-        let mut lines: Vec<String> = Vec::new();
-        let mut replaced_cancel = false;
-        for line in text.lines() {
-            let trimmed = line.trim();
-            if trimmed.contains("/cancel_task ") {
-                if has_actions && !replaced_cancel {
-                    let hint = if language.is_chinese() {
-                        "如需停止本次请求，请发送命令 /cancel_task 或下方列出的取消命令。"
-                    } else {
-                        "To stop this request, send /cancel_task or the cancel command listed below."
-                    };
-                    lines.push(hint.to_string());
-                    replaced_cancel = true;
-                }
-                continue;
-            }
-            lines.push(line.to_string());
-        }
-        lines.join("\n").trim().to_string()
-    }
-
     async fn send_handle_result(&self, peer_id: &str, result: &HandleResult) {
         let language = current_bot_language().await;
-        let footer = Self::format_actions_footer(language, &result.actions);
-        let body = Self::clean_reply_text(language, &result.reply, !result.actions.is_empty());
-        let combined = format!("{body}{footer}");
-        if let Err(e) = self.send_text(peer_id, &combined).await {
+        let text = if result.menu.items.is_empty() && result.menu.title.is_empty() {
+            result.reply.clone()
+        } else {
+            result.menu.render_plain_text(language)
+        };
+        if text.trim().is_empty() {
+            return;
+        }
+        if let Err(e) = self.send_text(peer_id, &text).await {
             warn!("weixin send_handle_result: {e}");
         }
     }
 
     async fn notify_files_ready(&self, peer_id: &str, text: &str) {
+        let language = super::locale::current_bot_language().await;
         let result = {
             let mut states = self.chat_states.write().await;
             let state = states.entry(peer_id.to_string()).or_insert_with(|| {
@@ -1394,6 +1361,7 @@ impl WeixinBot {
                 text,
                 state,
                 workspace_root.as_deref().map(std::path::Path::new),
+                language,
             )
         };
         if let Some(result) = result {
@@ -1498,10 +1466,7 @@ impl WeixinBot {
                                 .insert(peer.clone(), state.clone());
                             self.persist_chat_state(&peer, &state).await;
 
-                            let footer = Self::format_actions_footer(language, &result.actions);
-                            let _ = self
-                                .send_text(&peer, &format!("{}{}", result.reply, footer))
-                                .await;
+                            self.send_handle_result(&peer, &result).await;
                             return Ok(peer);
                         } else {
                             let err = if language.is_chinese() {
@@ -1654,10 +1619,7 @@ impl WeixinBot {
                     let result = complete_im_bot_pairing(state).await;
                     self.persist_chat_state(&peer_id, state).await;
                     drop(states);
-                    let footer = Self::format_actions_footer(language, &result.actions);
-                    let _ = self
-                        .send_text(&peer_id, &format!("{}{}", result.reply, footer))
-                        .await;
+                    self.send_handle_result(&peer_id, &result).await;
                     return;
                 } else {
                     let err = if language.is_chinese() {
@@ -1741,7 +1703,7 @@ impl WeixinBot {
             s.paired = true;
             s
         });
-        state.pending_action = Some(interaction.pending_action.clone());
+        super::command_router::apply_interactive_request(state, &interaction);
         self.persist_chat_state(&peer_id, state).await;
         drop(states);
 
@@ -1749,6 +1711,7 @@ impl WeixinBot {
             reply: interaction.reply,
             actions: interaction.actions,
             forward_to_session: None,
+            menu: interaction.menu,
         };
         self.send_handle_result(&peer_id, &result).await;
     }

--- a/src/crates/events/src/agentic.rs
+++ b/src/crates/events/src/agentic.rs
@@ -184,6 +184,22 @@ pub enum AgenticEvent {
         error: String,
         recoverable: bool,
     },
+
+    /// A session's bound model has been automatically migrated because the
+    /// previously bound model became unavailable (disabled or deleted).
+    /// The frontend should refresh its model selector for the session and
+    /// surface a non-blocking notice so the user knows what happened.
+    SessionModelAutoMigrated {
+        session_id: String,
+        /// The model id the session was using before the migration.
+        previous_model_id: String,
+        /// The model id (or selector such as `"auto"`) the session is now bound
+        /// to. This is what `SessionConfig.model_id` was rewritten to.
+        new_model_id: String,
+        /// Why the migration happened, e.g. `"model_disabled"` or
+        /// `"model_deleted"`.
+        reason: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -326,7 +342,8 @@ impl AgenticEvent {
             | Self::TextChunk { session_id, .. }
             | Self::ThinkingChunk { session_id, .. }
             | Self::ModelRoundCompleted { session_id, .. }
-            | Self::ToolEvent { session_id, .. } => Some(session_id),
+            | Self::ToolEvent { session_id, .. }
+            | Self::SessionModelAutoMigrated { session_id, .. } => Some(session_id),
             Self::SystemError { session_id, .. } => session_id.as_deref(),
         }
     }
@@ -340,6 +357,7 @@ impl AgenticEvent {
 
             Self::SessionStateChanged { .. }
             | Self::SessionTitleGenerated { .. }
+            | Self::SessionModelAutoMigrated { .. }
             | Self::ContextCompressionFailed { .. } => AgenticEventPriority::High,
 
             Self::ImageAnalysisStarted { .. }

--- a/src/crates/transport/src/adapters/tauri.rs
+++ b/src/crates/transport/src/adapters/tauri.rs
@@ -355,6 +355,22 @@ impl TransportAdapter for TauriTransportAdapter {
                     }),
                 )?;
             }
+            AgenticEvent::SessionModelAutoMigrated {
+                session_id,
+                previous_model_id,
+                new_model_id,
+                reason,
+            } => {
+                self.app_handle.emit(
+                    "agentic://session-model-auto-migrated",
+                    json!({
+                        "sessionId": session_id,
+                        "previousModelId": previous_model_id,
+                        "newModelId": new_model_id,
+                        "reason": reason,
+                    }),
+                )?;
+            }
             AgenticEvent::ModelRoundCompleted {
                 session_id,
                 turn_id,

--- a/src/web-ui/src/component-library/components/Tooltip/Tooltip.tsx
+++ b/src/web-ui/src/component-library/components/Tooltip/Tooltip.tsx
@@ -275,6 +275,15 @@ export const Tooltip: React.FC<TooltipProps> = ({
     setActualPlacement(placement);
   }, [placement]);
 
+  // When the tooltip becomes disabled (e.g. parent opens a menu/popover that
+  // covers the trigger), cancel any pending show timer and force-hide so a
+  // tooltip cannot appear or linger above the new overlay.
+  useEffect(() => {
+    if (disabled) {
+      hideTooltip();
+    }
+  }, [disabled, hideTooltip]);
+
   useEffect(() => {
     if (visible) {
       requestAnimationFrame(() => {
@@ -327,6 +336,13 @@ export const Tooltip: React.FC<TooltipProps> = ({
   };
 
   const handleClick = (e: React.MouseEvent) => {
+    // Always cancel any pending show timer so a click before the tooltip
+    // appears won't surface a stale tooltip after the trigger is covered
+    // by a menu/backdrop (which prevents the natural mouseleave).
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
     // Always hide tooltip on click for better UX (e.g., button tooltips)
     if (visible) {
       hideTooltip();

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
@@ -162,6 +162,31 @@ During those transitions, the DOM may report intermediate sizes for multiple fra
 
 `layoutTransitionCountRef` prevents us from consuming compensation too early while the layout is still animating. If you remove this guard, compensation can disappear mid-transition and reintroduce vertical drift.
 
+## C. Follow-Output Mode (continuous tail)
+
+When the viewport is in follow-output mode and the latest turn is still
+streaming, the user's intent is "keep the tail visible", which is the
+opposite of "preserve the upper anchor". To avoid the visible
+"stutter then jump" behavior caused by collapse pre-compensation
+freezing the viewport mid-animation, follow mode short-circuits the
+protection path:
+
+1. `handleToolCardCollapseIntent` returns early without writing
+   `pendingCollapseIntent`, without adding `collapse` reservation, and
+   without activating anchor lock.
+2. The shrink branch of `measureHeightChange` returns early without
+   adding fallback footer compensation.
+3. A continuous RAF loop in `useFlowChatFollowOutput` runs every frame
+   while `isFollowing && isStreaming`, calling `performAutoFollowScroll`
+   to chase the bottom and `reconcileStickyPinReservation` to keep the
+   sticky-latest pin floor aligned with the live DOM.
+4. The loop is cancelled as soon as follow exits (user upward scroll,
+   session change, streaming ends, or an explicit navigation).
+
+This branch coexists with the legacy collapse compensation path. Outside
+follow mode (user reading older content), all original protections still
+apply unchanged.
+
 ## Why `overflow-anchor: none` Must Stay
 
 `VirtualMessageList.scss` disables native browser scroll anchoring on:
@@ -217,6 +242,11 @@ If a future collapsible component shows the same "header drops" or "flash on col
 - Removing `overflow-anchor: none`.
 - Removing transition-aware delayed measurement.
 - Simplifying anchor restore to a one-shot restore without the scroll listener fallback.
+- Removing the follow-mode short-circuit in `handleToolCardCollapseIntent` /
+  `measureHeightChange`. Without it, follow-output streaming will visibly stall
+  during collapse animations and then snap to the latest token.
+- Removing the continuous RAF follow loop. Event-driven follow alone cannot
+  keep up with collapse animations + dense token streams without visible jitter.
 
 ## If You Need To Change This Logic
 

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -261,6 +261,12 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     scheduleFollowToLatest: () => {},
   });
   const deferredFollowReasonRef = useRef<string | null>(null);
+  // Mirror of `isFollowingOutput` for use inside listeners that are registered
+  // once per mount. When follow mode is active we deliberately bypass collapse
+  // pre-compensation and anchor lock so the continuous follow loop can keep
+  // tracking the bottom without fighting the layout-stability machinery.
+  const isFollowingOutputRef = useRef(false);
+  const isStreamingOutputRef = useRef(false);
 
   const isInputActive = useChatInputState(state => state.isActive);
   const isInputExpanded = useChatInputState(state => state.isExpanded);
@@ -443,6 +449,13 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     // Content shrank: preserve the current visual anchor by extending the footer
     // when the user does not already have enough distance from the bottom.
     const shrinkAmount = -heightDelta;
+    // Follow-output mode wants to chase the bottom; absorbing the shrink with
+    // synthetic footer would visually freeze the viewport mid-animation. The
+    // continuous follow loop will scroll back to the tail on the next frame.
+    if (isFollowingOutputRef.current && isStreamingOutputRef.current) {
+      previousScrollTopRef.current = currentScrollTop;
+      return;
+    }
     const collapseIntent = pendingCollapseIntentRef.current;
     const now = performance.now();
     const hasValidCollapseIntent = collapseIntent.active && collapseIntent.expiresAtMs >= now;
@@ -1263,6 +1276,17 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
         filePath?: string | null;
         reason?: string | null;
       }>).detail;
+      // In follow-output mode, the user wants the viewport pinned to the
+      // latest streaming token. Reserving footer space + locking an upper
+      // anchor would freeze the viewport on older content during the
+      // collapse animation, producing the "stutter then jump" effect. Skip
+      // the protection path entirely and let the continuous follow loop
+      // absorb the shrink frame-by-frame.
+      if (isFollowingOutputRef.current && isStreamingOutputRef.current) {
+        scheduleVisibleTurnMeasure(2);
+        schedulePinReservationReconcile(2);
+        return;
+      }
       const baseTotalCompensationPx = getTotalBottomCompensationPx();
       const distanceFromBottom = Math.max(
         0,
@@ -1606,6 +1630,13 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     getAutoFollowDistanceFromBottom: (scroller) => (
       Math.max(0, scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop - getTotalBottomCompensationPx())
     ),
+    onContinuousFollowFrame: () => {
+      // Keep sticky-latest pin floor aligned with the live DOM as collapses
+      // shrink the layout. Without this the pin reservation would lag for one
+      // RAF tick and the viewport would briefly land below the latest user
+      // message.
+      reconcileStickyPinReservation();
+    },
   });
 
   useEffect(() => {
@@ -1721,6 +1752,8 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     handleScroll: handleFollowOutputScroll,
     scheduleFollowToLatest,
   };
+  isFollowingOutputRef.current = isFollowingOutput;
+  isStreamingOutputRef.current = isStreamingOutput;
 
   const scrollToTurn = useCallback((turnIndex: number) => {
     if (!virtuosoRef.current) return;

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
@@ -29,8 +29,21 @@ interface UseFlowChatFollowOutputOptions {
   performUserFollowScroll: () => void;
   performAutoFollowScroll: () => void;
   performLatestTurnStickyPin: () => void;
+  /**
+   * Returns true when auto-follow should be suspended for layout-protection
+   * reasons (collapse animation, etc.). The continuous follow loop ignores
+   * this signal because follow mode actively wants to track the bottom even
+   * while intermediate cards collapse; only the event-driven `scheduleFollowToLatest`
+   * still respects it for backward compatibility with anchor restore paths.
+   */
   shouldSuspendAutoFollow?: () => boolean;
   getAutoFollowDistanceFromBottom?: (scroller: HTMLElement) => number;
+  /**
+   * Optional per-frame hook invoked from inside the continuous follow loop.
+   * Used to reconcile sticky-latest pin floor in lockstep with the scroll
+   * adjustment so the pin reservation never lags behind a shrinking layout.
+   */
+  onContinuousFollowFrame?: () => void;
 }
 
 interface UseFlowChatFollowOutputResult {
@@ -60,6 +73,7 @@ export function useFlowChatFollowOutput({
   performLatestTurnStickyPin,
   shouldSuspendAutoFollow,
   getAutoFollowDistanceFromBottom,
+  onContinuousFollowFrame,
 }: UseFlowChatFollowOutputOptions): UseFlowChatFollowOutputResult {
   const [isFollowingOutput, setIsFollowingOutput] = useState(false);
 
@@ -70,10 +84,24 @@ export function useFlowChatFollowOutput({
   const lastObservedScrollTopRef = useRef(0);
   const previousSessionIdRef = useRef<string | undefined>(activeSessionId);
   const armedAutoFollowTurnIdRef = useRef<string | null>(null);
+  const continuousFollowFrameRef = useRef<number | null>(null);
+  const isStreamingRef = useRef(isStreaming);
+  const performAutoFollowScrollRef = useRef(performAutoFollowScroll);
+  const onContinuousFollowFrameRef = useRef(onContinuousFollowFrame);
+  const getAutoFollowDistanceFromBottomRef = useRef(getAutoFollowDistanceFromBottom);
+
+  isStreamingRef.current = isStreaming;
+  performAutoFollowScrollRef.current = performAutoFollowScroll;
+  onContinuousFollowFrameRef.current = onContinuousFollowFrame;
+  getAutoFollowDistanceFromBottomRef.current = getAutoFollowDistanceFromBottom;
 
   const setFollowingOutput = useCallback((nextValue: boolean) => {
     isFollowingOutputRef.current = nextValue;
     setIsFollowingOutput(prev => (prev === nextValue ? prev : nextValue));
+    if (!nextValue && continuousFollowFrameRef.current !== null) {
+      cancelAnimationFrame(continuousFollowFrameRef.current);
+      continuousFollowFrameRef.current = null;
+    }
   }, []);
 
   const cancelScheduledFollow = useCallback(() => {
@@ -82,6 +110,72 @@ export function useFlowChatFollowOutput({
       followFrameRef.current = null;
     }
   }, []);
+
+  const stopContinuousFollowLoop = useCallback(() => {
+    if (continuousFollowFrameRef.current !== null) {
+      cancelAnimationFrame(continuousFollowFrameRef.current);
+      continuousFollowFrameRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Continuous RAF-driven follow loop.
+   *
+   * Why this exists:
+   *  - Streaming text + auto-collapsing tool cards generate dense bursts of
+   *    DOM mutations and CSS transitions. Event-driven follow (via observers)
+   *    is gated by `shouldSuspendAutoFollow` during transitions, which makes
+   *    the viewport visibly stall and then jump after the transition ends.
+   *  - This loop runs every animation frame while follow + streaming is
+   *    active, pushing scrollTop toward the latest token regardless of any
+   *    intermediate layout shrink. The result is a smooth, continuous tail.
+   *
+   * Safety:
+   *  - Programmatic scrolls inside this loop bump
+   *    `programmaticScrollUntilMsRef` so the user-intent detector does not
+   *    misclassify them as upward scrolls.
+   *  - The loop bails out as soon as follow is exited, streaming ends, the
+   *    scroller disappears, or the viewport is already pinned to the bottom.
+   */
+  const runContinuousFollowFrame = useCallback(() => {
+    continuousFollowFrameRef.current = null;
+
+    if (!isFollowingOutputRef.current || !isStreamingRef.current) {
+      return;
+    }
+
+    const scroller = scrollerRef.current;
+    if (!scroller) {
+      return;
+    }
+
+    onContinuousFollowFrameRef.current?.();
+
+    const rawDistance = getDistanceFromBottom(scroller);
+    const measuredDistance = getAutoFollowDistanceFromBottomRef.current?.(scroller) ?? rawDistance;
+    if (measuredDistance > AUTO_FOLLOW_BOTTOM_THRESHOLD_PX) {
+      programmaticScrollUntilMsRef.current = performance.now() + PROGRAMMATIC_SCROLL_GUARD_MS;
+      explicitUserScrollIntentUntilMsRef.current = 0;
+      performAutoFollowScrollRef.current();
+      lastObservedScrollTopRef.current = scroller.scrollTop;
+    }
+
+    if (!isFollowingOutputRef.current || !isStreamingRef.current) {
+      return;
+    }
+
+    continuousFollowFrameRef.current = requestAnimationFrame(runContinuousFollowFrame);
+  }, [scrollerRef]);
+
+  const startContinuousFollowLoop = useCallback(() => {
+    if (continuousFollowFrameRef.current !== null) {
+      return;
+    }
+    if (!isFollowingOutputRef.current || !isStreamingRef.current) {
+      return;
+    }
+    continuousFollowFrameRef.current = requestAnimationFrame(runContinuousFollowFrame);
+  }, [runContinuousFollowFrame]);
 
   const cancelPendingAutoFollowArm = useCallback(() => {
     armedAutoFollowTurnIdRef.current = null;
@@ -310,17 +404,20 @@ export function useFlowChatFollowOutput({
 
   useEffect(() => {
     if (!isFollowingOutput || !isStreaming) {
+      stopContinuousFollowLoop();
       return;
     }
 
     scheduleFollowToLatest('streaming-started');
-  }, [isFollowingOutput, isStreaming, scheduleFollowToLatest]);
+    startContinuousFollowLoop();
+  }, [isFollowingOutput, isStreaming, scheduleFollowToLatest, startContinuousFollowLoop, stopContinuousFollowLoop]);
 
   useEffect(() => {
     return () => {
       cancelScheduledFollow();
+      stopContinuousFollowLoop();
     };
-  }, [cancelScheduledFollow]);
+  }, [cancelScheduledFollow, stopContinuousFollowLoop]);
 
   return {
     isFollowingOutput,

--- a/src/web-ui/src/flow_chat/services/AgenticEventListener.ts
+++ b/src/web-ui/src/flow_chat/services/AgenticEventListener.ts
@@ -8,7 +8,14 @@
  */
 
 import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
-import type { TextChunkEvent, ToolEvent, AgenticEvent, SessionTitleGeneratedEvent, ImageAnalysisEvent } from '@/infrastructure/api/service-api/AgentAPI';
+import type {
+  TextChunkEvent,
+  ToolEvent,
+  AgenticEvent,
+  SessionTitleGeneratedEvent,
+  SessionModelAutoMigratedEvent,
+  ImageAnalysisEvent,
+} from '@/infrastructure/api/service-api/AgentAPI';
 import { createLogger } from '@/shared/utils/logger';
 
 type UnlistenFn = () => void;
@@ -33,6 +40,7 @@ export interface AgenticEventCallbacks {
   onContextCompressionCompleted?: (event: AgenticEvent) => void;
   onContextCompressionFailed?: (event: AgenticEvent) => void;
   onSessionTitleGenerated?: (event: SessionTitleGeneratedEvent) => void;
+  onSessionModelAutoMigrated?: (event: SessionModelAutoMigratedEvent) => void;
 }
 
 export class AgenticEventListener {
@@ -178,6 +186,14 @@ export class AgenticEventListener {
         const unlisten = agentAPI.onSessionTitleGenerated((event) => {
           logger.debug('Session title generated:', event);
           callbacks.onSessionTitleGenerated?.(event);
+        });
+        this.unlistenFunctions.push(unlisten);
+      }
+
+      if (callbacks.onSessionModelAutoMigrated) {
+        const unlisten = agentAPI.onSessionModelAutoMigrated((event) => {
+          logger.info('Session model auto-migrated:', event);
+          callbacks.onSessionModelAutoMigrated?.(event);
         });
         this.unlistenFunctions.push(unlisten);
       }

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -19,7 +19,11 @@ import {
 } from '../EventBatcher';
 import { notificationService } from '../../../shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
-import type { ImageAnalysisEvent } from '@/infrastructure/api/service-api/AgentAPI';
+import type {
+  ImageAnalysisEvent,
+  SessionModelAutoMigratedEvent,
+} from '@/infrastructure/api/service-api/AgentAPI';
+import { i18nService } from '@/infrastructure/i18n';
 import { MCPAPI } from '@/infrastructure/api/service-api/MCPAPI';
 import { globalEventBus } from '@/infrastructure/event-bus';
 import type { FlowChatContext, DialogTurn, ModelRound, FlowToolItem } from './types';
@@ -244,6 +248,9 @@ export async function initializeEventListeners(
     },
     onSessionTitleGenerated: (event) => {
       handleSessionTitleGenerated(event);
+    },
+    onSessionModelAutoMigrated: (event) => {
+      handleSessionModelAutoMigrated(event);
     }
   };
 
@@ -522,6 +529,27 @@ function handleSessionTitleGenerated(event: any): void {
 
   const store = FlowChatStore.getInstance();
   store.updateSessionTitle(sessionId, title, 'generated');
+}
+
+function handleSessionModelAutoMigrated(event: SessionModelAutoMigratedEvent): void {
+  const { sessionId, previousModelId, newModelId, reason } = event;
+  if (!sessionId || !newModelId) return;
+
+  const store = FlowChatStore.getInstance();
+  store.updateSessionModelName(sessionId, newModelId);
+
+  const description = i18nService.t('flow-chat:model.autoMigrated.description', {
+    previous: previousModelId || 'unknown',
+    next: newModelId,
+  });
+  const reasonText = reason
+    ? ' ' + i18nService.t('flow-chat:model.autoMigrated.reason', { reason })
+    : '';
+
+  notificationService.warning(description + reasonText, {
+    title: i18nService.t('flow-chat:model.autoMigrated.title'),
+    duration: 6000,
+  });
 }
 
 /**

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -13,6 +13,13 @@ export interface SessionTitleGeneratedEvent {
   timestamp: number;
 }
 
+export interface SessionModelAutoMigratedEvent {
+  sessionId: string;
+  previousModelId: string;
+  newModelId: string;
+  reason: string;
+}
+
  
 export interface SessionConfig {
   modelName?: string;
@@ -351,6 +358,15 @@ export class AgentAPI {
 
   onSessionStateChanged(callback: (event: AgenticEvent) => void): () => void {
     return api.listen<AgenticEvent>('agentic://session-state-changed', callback);
+  }
+
+  onSessionModelAutoMigrated(
+    callback: (event: SessionModelAutoMigratedEvent) => void
+  ): () => void {
+    return api.listen<SessionModelAutoMigratedEvent>(
+      'agentic://session-model-auto-migrated',
+      callback
+    );
   }
 
    

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -160,7 +160,12 @@
     "temperature": "Temperature",
     "maxTokens": "Max Tokens",
     "topP": "Top P",
-    "streaming": "Streaming"
+    "streaming": "Streaming",
+    "autoMigrated": {
+      "title": "Model auto-switched",
+      "description": "Session model \"{{previous}}\" is no longer available. Switched to \"{{next}}\".",
+      "reason": "Reason: {{reason}}"
+    }
   },
   "toolbar": {
     "newSession": "New Session",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -160,7 +160,12 @@
     "temperature": "温度",
     "maxTokens": "最大令牌数",
     "topP": "Top P",
-    "streaming": "流式输出"
+    "streaming": "流式输出",
+    "autoMigrated": {
+      "title": "模型已自动切换",
+      "description": "会话原模型\"{{previous}}\"不可用，已切换为\"{{next}}\"。",
+      "reason": "原因：{{reason}}"
+    }
   },
   "toolbar": {
     "newSession": "新建会话",


### PR DESCRIPTION
## Summary

- **Built-in MiniApps**: bundles three apps (gomoku, daily-divination, regex-playground) and seeds them into `miniapps_dir` on first launch; reseeds on schema-version bump while preserving the user's `storage.json`.
- **IM bot UX overhaul**: introduces a shared `locale` (zh-CN / en-US `BotStrings`) and `MenuView` model under `service/remote_connect/bot/`, rewrites `command_router` on top of it, and updates Telegram / Feishu / WeChat adapters to render the same menu through their native primitives.
- **Disabled-model safeguards**: `AIClientFactory` now rejects requests routed to a disabled model with a clear error; `SessionManager` subscribes to config updates and auto-migrates active sessions back to `auto` when their bound model is disabled or removed, emitting a new `SessionModelAutoMigrated` event so the UI can refresh its model selector.
- **FlowChat scroll stability**: tightens `VirtualMessageList` / `useFlowChatFollowOutput` so streaming output no longer fights the user's scroll position; updated companion notes in `FLOWCHAT_SCROLL_STABILITY.md`.
- Misc: Tooltip a11y tweak, AgentAPI gains the new auto-migration hook, locale strings for new flows.

## Test plan

> Compilation has not been re-verified locally — please run `pnpm run desktop:dev` (or `cargo check -p bitfun-core`) before merging if you want a clean build signal.

### 1. Built-in MiniApps
- [ ] Launch desktop app on a fresh profile (or remove `<appdata>/miniapps/builtin-*`).
- [ ] Open the MiniApp gallery and confirm three new entries appear: **五子棋 / Gomoku**, **每日占卜**, **Regex Playground**.
- [ ] Open each one, interact briefly, then restart the app and confirm:
  - the apps still appear (no duplicate seeding),
  - any state stored via `storage.json` (e.g. divination cards, regex input) survives restart.
- [ ] Manually edit `<appdata>/miniapps/builtin-gomoku/.builtin-version` to `0`, restart, and confirm the source files are rewritten but `storage.json` is untouched.

### 2. IM bot UX (covers Telegram / Feishu / WeChat)
For each platform you have configured:
- [ ] Send `/help` (or the platform's equivalent text) and confirm the new menu renders with native controls (Telegram inline buttons, Feishu interactive card, WeChat numbered list).
- [ ] Switch app language between zh-CN and en-US, trigger the menu again, and confirm all labels/replies localize correctly.
- [ ] Walk through one full command flow (e.g. select an agent → ask a question → receive answer) and confirm there are no regressions vs the previous router behavior.
- [ ] Confirm WeChat numeric shortcuts (`1`, `2`, …) still resolve to the correct command.

### 3. Disabled / removed models
- [ ] Open settings → AI models, disable the model that an active chat session is currently using, and save.
  - The chat should immediately fall back to `auto` (model selector refreshes; a notice may appear in the chat).
  - Sending a new message should succeed via the auto-routed model.
- [ ] Manually invoke a disabled model (e.g. by editing the request) and confirm the backend returns a clear `Model '...' is currently disabled` error instead of silently failing.
- [ ] Delete a model that a session is bound to and confirm the same auto-migration happens.

### 4. FlowChat scroll stability
- [ ] Start a long streaming agent reply and scroll up while output is still streaming — the viewport should stay where you left it (no auto-jump-to-bottom).
- [ ] Scroll back to the bottom and confirm follow-output resumes automatically.
- [ ] Resize the window mid-stream and confirm no flicker / scroll jump.

### 5. Smoke
- [ ] Tooltip still renders correctly on hover/focus across the app (no a11y regressions).
- [ ] App language switch (zh-CN ↔ en-US) updates new strings in flow-chat without restart.