### PR TITLE
feat(miniapp): i18n framework + Daily Coding Snapshot built-in app

### DIFF
--- a/MiniApp/Skills/miniapp-dev/SKILL.md
+++ b/MiniApp/Skills/miniapp-dev/SKILL.md
@@ -200,6 +200,57 @@ body {
 - iframe 加载后 bridge 会向宿主发送 `bitfun/request-theme`，宿主回推当前主题变量，iframe 内 `_applyThemeVars` 写入 `:root`。
 - 主应用切换主题时，宿主会向 iframe 发送 `themeChange` 事件，bridge 更新变量并触发 `onThemeChange` 回调。
 
+## 国际化（i18n）
+
+MiniApp 框架在 V2 之后内置 i18n 支持，开发者**必须**为多语言用户考虑两类文案：
+
+1. **Gallery 元数据**（`name` / `description` / `tags`）—— 在 `meta.json` 顶层加 `i18n.locales` 块，宿主 Gallery / Card / Scene 标题自动按当前语言挑选。
+2. **应用内文案**（HTML / JS 中的所有可见字符串）—— 通过 `window.app.locale`、`window.app.onLocaleChange(fn)` 与 `window.app.t(table, fallback)` 实现。
+
+### `meta.json` 多语言示例
+
+```json
+{
+  "id": "your-app",
+  "name": "默认名（兜底）",
+  "description": "默认描述",
+  "tags": ["默认标签"],
+  "i18n": {
+    "locales": {
+      "zh-CN": { "name": "中文名", "description": "中文描述", "tags": ["中文"] },
+      "en-US": { "name": "English Name", "description": "English desc", "tags": ["en"] }
+    }
+  }
+}
+```
+
+回退顺序：`current` → `en-US` → `zh-CN` → 顶层默认值。
+
+### `window.app` i18n 运行时 API
+
+| 成员 | 说明 |
+|------|------|
+| `app.locale` | 当前语言 ID（如 `'zh-CN'` / `'en-US'`），随宿主切换更新 |
+| `app.onLocaleChange(fn)` | 注册语言切换回调，参数为新 locale 字符串 |
+| `app.t(table, fallback)` | 从 `{ 'zh-CN': '...', 'en-US': '...' }` 表挑选字符串；解析顺序：current → en-US → zh-CN → 表的第一项 → fallback |
+
+### HTML 静态文案：`data-i18n` 约定
+
+宿主不强制要求该写法，但推荐 MiniApp 内部统一约定：
+
+- `<span data-i18n="key">默认</span>` —— 切换语言时 `applyStaticI18n()` 读取 `data-i18n` 并替换 `textContent`
+- `<div data-i18n="ariaKey" data-i18n-attr="aria-label">...</div>` —— 设置某个属性而非文本
+
+参考 `builtin/assets/gomoku/ui.js` 等内置应用的 `I18N` 表 + `applyStaticI18n()` + `app.onLocaleChange` 三件套即可复用。
+
+### 编写自检清单
+
+- [ ] `meta.json` 已加 `i18n.locales`（至少 `zh-CN` / `en-US`）
+- [ ] HTML 中静态文案均带 `data-i18n` 属性
+- [ ] JS 内动态拼接的字符串使用 `app.t()` 或自有 `I18N` 表
+- [ ] 注册了 `app.onLocaleChange`，切换语言时重新渲染（包括动态列表、aria-label、title）
+- [ ] 持久化数据（`app.storage`）保存语言无关的索引/键，而非已翻译的字符串
+
 ## 开发约定
 
 ### 新增 Agent 工具

--- a/MiniApp/Skills/miniapp-dev/api-reference.md
+++ b/MiniApp/Skills/miniapp-dev/api-reference.md
@@ -88,6 +88,7 @@ app.appId        // string — 当前 MiniApp 的 ID
 app.appDataDir   // string — 应用数据目录绝对路径
 app.workspaceDir // string — 当前工作区路径
 app.theme        // 'dark' | 'light' — 当前主题
+app.locale       // string — 当前语言 ID（如 'zh-CN' / 'en-US'），随宿主切换更新
 app.platform     // 'win32' | 'darwin' | 'linux'
 app.mode         // 'hosted'
 ```
@@ -268,7 +269,29 @@ app.onDeactivate(() => { /* Tab 切走 */ });
 app.onThemeChange((payload) => {
   // payload: { type: 'dark'|'light', vars: { '--bitfun-bg': '...', ... } }
 });
+app.onLocaleChange((locale) => {
+  // locale: 新的语言 ID 字符串（如 'zh-CN' / 'en-US'）
+});
 ```
+
+## 国际化 i18n
+
+### `app.t(table, fallback)` — 多语言字符串挑选
+
+```javascript
+const label = app.t({ 'zh-CN': '保存', 'en-US': 'Save' }, 'Save');
+```
+
+挑选顺序：`app.locale` → `'en-US'` → `'zh-CN'` → 表的第一个值 → `fallback`。适合在 JS 里就地写少量翻译。
+
+更完整的做法（推荐）：
+
+1. 在 `meta.json` 顶层加 `i18n.locales` 块翻译 `name` / `description` / `tags`，宿主 Gallery 自动按当前语言显示。
+2. 在 HTML 静态文案上加 `data-i18n="key"`（可选 `data-i18n-attr="aria-label"` 翻译属性）。
+3. 在 `ui.js` 中维护 `I18N` 字典，封装 `t(key)` 与 `applyStaticI18n()`，并 `app.onLocaleChange(...)` 时重新渲染动态内容。
+4. `app.storage` 持久化的字段保存语言无关的索引/键，避免存了翻译后字符串导致切换语言失效。
+
+参考实现：`builtin/assets/gomoku/ui.js`、`builtin/assets/regex-playground/ui.js`。
 
 ## 自定义事件
 

--- a/src/crates/core/src/miniapp/bridge_builder.rs
+++ b/src/crates/core/src/miniapp/bridge_builder.rs
@@ -45,9 +45,13 @@ pub fn build_bridge_script(
   }}
 
   let _theme = {theme_esc};
+  // Default to en-US until the host pushes the real locale via 'bitfun:event'.
+  // The script below proactively requests it on startup.
+  let _locale = 'en-US';
 
   const app = {{
     get theme() {{ return _theme; }},
+    get locale() {{ return _locale; }},
     appId: {app_id_esc},
     appDataDir: {app_data_esc},
     workspaceDir: {workspace_esc},
@@ -115,10 +119,25 @@ pub fn build_bridge_script(
       readText:  () => _rpc('clipboard.readText', {{}}),
     }},
 
-    _lifecycleHandlers: {{ activate: [], deactivate: [], themeChange: [] }},
-    onActivate:   (fn) => app._lifecycleHandlers.activate.push(fn),
-    onDeactivate: (fn) => app._lifecycleHandlers.deactivate.push(fn),
+    _lifecycleHandlers: {{ activate: [], deactivate: [], themeChange: [], localeChange: [] }},
+    onActivate:    (fn) => app._lifecycleHandlers.activate.push(fn),
+    onDeactivate:  (fn) => app._lifecycleHandlers.deactivate.push(fn),
     onThemeChange: (fn) => app._lifecycleHandlers.themeChange.push(fn),
+    /// Subscribe to host locale changes. Callback receives the locale id (e.g. "zh-CN").
+    onLocaleChange: (fn) => app._lifecycleHandlers.localeChange.push(fn),
+
+    /// Pick the best-matching string from an i18n table for the current locale.
+    /// Resolution: current → en-US → zh-CN → first value → fallback.
+    /// Usage: app.t({{'en-US':'Hello','zh-CN':'你好'}}, 'Hello')
+    t: (table, fallback) => {{
+      if (!table || typeof table !== 'object') return fallback != null ? fallback : '';
+      if (table[_locale]) return table[_locale];
+      if (table['en-US']) return table['en-US'];
+      if (table['zh-CN']) return table['zh-CN'];
+      const keys = Object.keys(table);
+      if (keys.length) return table[keys[0]];
+      return fallback != null ? fallback : '';
+    }},
 
     _eventHandlers: {{}},
     on:  (event, fn) => {{ (app._eventHandlers[event] = app._eventHandlers[event] || []).push(fn); }},
@@ -140,6 +159,13 @@ pub fn build_bridge_script(
         }}
         app._lifecycleHandlers.themeChange.forEach(f => f(payload));
         (app._eventHandlers[event] || []).forEach(f => f(payload));
+      }} else if (event === 'localeChange') {{
+        if (payload && typeof payload === 'object' && typeof payload.locale === 'string') {{
+          _locale = payload.locale;
+          document.documentElement.setAttribute('lang', _locale);
+        }}
+        app._lifecycleHandlers.localeChange.forEach(f => f(_locale));
+        (app._eventHandlers[event] || []).forEach(f => f(_locale));
       }} else if (event === 'ai:stream') {{
         // Route AI stream chunks to the registered callbacks
         if (payload && payload.streamId) {{
@@ -172,6 +198,7 @@ pub fn build_bridge_script(
   window.app = app;
   document.documentElement.setAttribute('data-theme-type', _theme);
   window.parent.postMessage({{ method: 'bitfun/request-theme' }}, '*');
+  window.parent.postMessage({{ method: 'bitfun/request-locale' }}, '*');
 }})();
 "#,
         app_id_esc = app_id_esc,

--- a/src/crates/core/src/miniapp/builtin/assets/coding-selfie/index.html
+++ b/src/crates/core/src/miniapp/builtin/assets/coding-selfie/index.html
@@ -1,0 +1,153 @@
+<div class="cs-shell" id="root">
+  <section class="cs-empty is-loading" id="empty" role="status" aria-live="polite">
+    <div class="cs-empty-art" id="empty-icon" aria-hidden="true"></div>
+    <div class="cs-empty-text">
+      <p class="cs-empty-title" id="empty-title">正在扫描你的代码足迹</p>
+      <p class="cs-empty-desc" id="empty-desc">…</p>
+    </div>
+  </section>
+
+  <main class="cs-bento" id="content" hidden>
+    <!-- HERO TILE -->
+    <section class="cs-tile cs-tile-hero" aria-labelledby="hero-greeting">
+      <div class="cs-hero-glow" aria-hidden="true"></div>
+      <h1 class="cs-hero-greeting" id="hero-greeting" data-i18n="title">每日编码快照</h1>
+      <p class="cs-hero-subtitle" id="hero-subtitle" data-i18n="subtitle">扫描你的本地 Git 仓库，凝结成一张今天的编码画像。</p>
+      <div class="cs-hero-author" id="hero-author"></div>
+    </section>
+
+    <!-- STREAK TILE -->
+    <section class="cs-tile cs-tile-streak" aria-labelledby="streak-label">
+      <div class="cs-tile-head">
+        <svg class="cs-tile-ic" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"/></svg>
+        <span id="streak-label" data-i18n="streakLabel">连续编码</span>
+      </div>
+      <div class="cs-streak-num" id="streak-num">0</div>
+      <div class="cs-streak-unit" data-i18n="streakUnit">DAYS</div>
+      <div class="cs-streak-foot" id="streak-foot"></div>
+    </section>
+
+    <!-- STAT TILES -->
+    <section class="cs-tile cs-tile-stat">
+      <div class="cs-tile-head">
+        <svg class="cs-tile-ic" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><line x1="3" y1="12" x2="9" y2="12"/><line x1="15" y1="12" x2="21" y2="12"/></svg>
+        <span data-i18n="todayCommits">今日提交</span>
+      </div>
+      <div class="cs-stat-num" id="stat-commits">0</div>
+      <div class="cs-stat-foot" id="stat-commits-delta"></div>
+    </section>
+
+    <section class="cs-tile cs-tile-stat">
+      <div class="cs-tile-head">
+        <svg class="cs-tile-ic" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+        <span data-i18n="codeChanges">代码变动</span>
+      </div>
+      <div class="cs-stat-num cs-stat-diff">
+        <span class="cs-add" id="stat-add">+0</span>
+        <span class="cs-sep">/</span>
+        <span class="cs-del" id="stat-del">-0</span>
+      </div>
+      <div class="cs-stat-foot" id="stat-net"></div>
+    </section>
+
+    <section class="cs-tile cs-tile-stat">
+      <div class="cs-tile-head">
+        <svg class="cs-tile-ic" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><path d="m9 18 3-3-3-3"/><path d="m13 18 3-3-3-3"/></svg>
+        <span data-i18n="filesTouched">涉及文件</span>
+      </div>
+      <div class="cs-stat-num" id="stat-files">0</div>
+      <div class="cs-stat-foot" data-i18n="touchedToday">touched today</div>
+    </section>
+
+    <section class="cs-tile cs-tile-stat cs-tile-optional cs-tile-langs-stat">
+      <div class="cs-tile-head">
+        <svg class="cs-tile-ic" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+        <span data-i18n="languagesUsed">使用语言</span>
+      </div>
+      <div class="cs-stat-num" id="stat-langs">0</div>
+      <div class="cs-stat-foot" id="stat-langs-list">--</div>
+    </section>
+
+    <!-- DONUT TILE -->
+    <section class="cs-tile cs-tile-donut" aria-labelledby="donut-title">
+      <div class="cs-tile-head">
+        <svg class="cs-tile-ic" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 2a10 10 0 0 1 10 10"/></svg>
+        <span id="donut-title" data-i18n="donutTitle">本周语言分布</span>
+      </div>
+      <div class="cs-donut-row">
+        <div class="cs-donut-wrap">
+          <svg class="cs-donut" viewBox="0 0 120 120" id="donut" aria-hidden="true"></svg>
+          <div class="cs-donut-center">
+            <div class="cs-donut-value cs-mono" id="donut-total">0</div>
+            <div class="cs-donut-label" data-i18n="commits">commits</div>
+          </div>
+        </div>
+        <ul class="cs-legend" id="lang-legend"></ul>
+      </div>
+    </section>
+
+    <!-- HOURS TILE -->
+    <section class="cs-tile cs-tile-hours cs-tile-optional" aria-labelledby="hours-title">
+      <div class="cs-tile-head cs-tile-head-row">
+        <span class="cs-tile-head-left">
+          <svg class="cs-tile-ic" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+          <span id="hours-title" data-i18n="hoursTitle">24 小时活跃节律</span>
+        </span>
+        <span class="cs-tile-hint" data-i18n="thisWeek">本周</span>
+      </div>
+      <div class="cs-hours" id="hours" role="img" data-i18n-attr="aria-label" data-i18n="hoursAria"></div>
+      <div class="cs-hours-axis">
+        <span>00</span><span>06</span><span>12</span><span>18</span><span>23</span>
+      </div>
+      <div class="cs-style-badge" id="style-badge"></div>
+    </section>
+
+    <!-- HEATMAP TILE -->
+    <section class="cs-tile cs-tile-heatmap" aria-labelledby="heatmap-title">
+      <div class="cs-tile-head cs-tile-head-row">
+        <span class="cs-tile-head-left">
+          <svg class="cs-tile-ic" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+          <span id="heatmap-title" data-i18n="heatmapTitle">编码热力</span>
+        </span>
+        <span class="cs-tile-hint" id="heatmap-hint"></span>
+      </div>
+      <div class="cs-heatmap-body" id="heatmap-body" role="img" data-i18n-attr="aria-label" data-i18n="heatmapAria"></div>
+      <div class="cs-heatmap-legend">
+        <span data-i18n="less">少</span>
+        <span class="cs-heat-cell cs-heat-0"></span>
+        <span class="cs-heat-cell cs-heat-1"></span>
+        <span class="cs-heat-cell cs-heat-2"></span>
+        <span class="cs-heat-cell cs-heat-3"></span>
+        <span class="cs-heat-cell cs-heat-4"></span>
+        <span data-i18n="more">多</span>
+      </div>
+    </section>
+
+    <!-- COMMITS TILE -->
+    <section class="cs-tile cs-tile-commits" aria-labelledby="commits-title">
+      <div class="cs-tile-head cs-tile-head-row">
+        <span class="cs-tile-head-left">
+          <svg class="cs-tile-ic" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><line x1="1.05" y1="12" x2="7" y2="12"/><line x1="17.01" y1="12" x2="22.96" y2="12"/></svg>
+          <span id="commits-title" data-i18n="commitsTitle">今日提交</span>
+        </span>
+        <span class="cs-tile-hint" id="commits-hint"></span>
+      </div>
+      <ul class="cs-commits" id="commits-list"></ul>
+    </section>
+  </main>
+
+  <footer class="cs-meta-footer" id="meta-footer" aria-label="snapshot context">
+    <span class="cs-meta-chip cs-meta-repo">
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>
+      <span id="meta-repo">--</span>
+    </span>
+    <span class="cs-meta-sep" aria-hidden="true">·</span>
+    <span class="cs-meta-chip" id="meta-date">--</span>
+    <span class="cs-meta-sep" aria-hidden="true">·</span>
+    <span class="cs-meta-chip cs-meta-time">
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+      <span id="meta-time">--:--</span>
+    </span>
+    <span class="cs-meta-brand" aria-hidden="true" data-i18n="brand">每日编码快照</span>
+  </footer>
+</div>

--- a/src/crates/core/src/miniapp/builtin/assets/coding-selfie/meta.json
+++ b/src/crates/core/src/miniapp/builtin/assets/coding-selfie/meta.json
@@ -1,0 +1,32 @@
+{
+  "id": "builtin-coding-selfie",
+  "name": "每日编码快照",
+  "description": "扫描当前工作区 git 仓库，一屏呈现今日提交、增删行、语言分布、活跃节律与全年编码热力。",
+  "icon": "Aperture",
+  "category": "developer",
+  "tags": ["git", "统计", "报告", "内置"],
+  "version": 1,
+  "created_at": 0,
+  "updated_at": 0,
+  "permissions": {
+    "fs": { "read": ["{appdata}", "{workspace}"], "write": ["{appdata}"] },
+    "shell": { "allow": ["git"] },
+    "net": { "allow": [] },
+    "node": { "enabled": true, "max_memory_mb": 256, "timeout_ms": 20000 }
+  },
+  "ai_context": null,
+  "i18n": {
+    "locales": {
+      "zh-CN": {
+        "name": "每日编码快照",
+        "description": "扫描当前工作区 git 仓库，一屏呈现今日提交、增删行、语言分布、活跃节律与全年编码热力。",
+        "tags": ["git", "统计", "报告", "内置"]
+      },
+      "en-US": {
+        "name": "Daily Coding Snapshot",
+        "description": "Scans the current workspace git repo and renders today's commits, ±lines, language mix, active rhythm and yearly heatmap on a single screen.",
+        "tags": ["git", "stats", "report", "built-in"]
+      }
+    }
+  }
+}

--- a/src/crates/core/src/miniapp/builtin/assets/coding-selfie/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/coding-selfie/style.css
@@ -1,0 +1,703 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+:root {
+  color-scheme: dark;
+  --cs-bg: #020617;
+  --cs-bg-grad: radial-gradient(ellipse at top, rgba(34, 197, 94, 0.06), transparent 60%), radial-gradient(ellipse at bottom right, rgba(56, 189, 248, 0.04), transparent 50%), #020617;
+  --cs-card: #0a1120;
+  --cs-card-2: #0f172a;
+  --cs-border: rgba(148, 163, 184, 0.10);
+  --cs-border-strong: rgba(148, 163, 184, 0.18);
+  --cs-text: #f1f5f9;
+  --cs-text-2: #cbd5e1;
+  --cs-text-muted: #64748b;
+  --cs-accent: #22c55e;
+  --cs-accent-2: #16a34a;
+  --cs-accent-soft: rgba(34, 197, 94, 0.12);
+  --cs-accent-glow: 0 0 20px rgba(34, 197, 94, 0.18);
+  --cs-add: #22c55e;
+  --cs-del: #f87171;
+  --cs-warn: #fbbf24;
+  --cs-radius: 12px;
+  --cs-radius-sm: 8px;
+  --cs-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  --cs-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+}
+
+[data-theme-type="light"] {
+  color-scheme: light;
+  --cs-bg: #f8fafc;
+  --cs-bg-grad: radial-gradient(ellipse at top, rgba(34, 197, 94, 0.08), transparent 60%), #f8fafc;
+  --cs-card: #ffffff;
+  --cs-card-2: #f1f5f9;
+  --cs-border: rgba(15, 23, 42, 0.08);
+  --cs-border-strong: rgba(15, 23, 42, 0.14);
+  --cs-text: #0f172a;
+  --cs-text-2: #334155;
+  --cs-text-muted: #64748b;
+  --cs-accent: #16a34a;
+  --cs-accent-2: #15803d;
+  --cs-accent-soft: rgba(22, 163, 74, 0.10);
+  --cs-accent-glow: 0 0 0 transparent;
+  --cs-del: #dc2626;
+}
+
+* { box-sizing: border-box; }
+[hidden] { display: none !important; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--cs-bg-grad);
+  color: var(--cs-text);
+  font-family: var(--cs-sans);
+  font-size: clamp(10.5px, 1.7vh, 13px);
+  line-height: 1.4;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'cv11', 'ss01';
+  overflow: hidden;
+}
+
+.cs-mono,
+.cs-stat-num,
+.cs-streak-num,
+.cs-donut-value,
+.cs-chip-mono,
+.cs-hours-axis,
+.cs-commit-hash {
+  font-family: var(--cs-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Shell: full viewport, no chrome, no scroll ──── */
+.cs-shell {
+  width: 100vw;
+  height: 100vh;
+  max-width: none;
+  margin: 0;
+  padding: clamp(6px, 1vh, 10px) clamp(8px, 1vw, 12px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(6px, 1vh, 8px);
+  overflow: hidden;
+}
+
+/* ─── Bento Grid: 4 rows, all proportional ────────── */
+.cs-bento {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  /* Row 1 hero+streak | Row 2 stats | Row 3 donut+hours | Row 4 heatmap+commits */
+  grid-template-rows:
+    minmax(0, 1.25fr)
+    minmax(0, 0.9fr)
+    minmax(0, 1.4fr)
+    minmax(0, 2.4fr);
+  gap: clamp(6px, 1vh, 8px);
+  min-height: 0;
+}
+
+.cs-tile {
+  background: var(--cs-card);
+  border: 1px solid var(--cs-border);
+  border-radius: var(--cs-radius);
+  padding: clamp(8px, 1.3vh, 13px) clamp(10px, 1.5vw, 14px);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  position: relative;
+  overflow: hidden;
+  transition: border-color 180ms ease;
+}
+.cs-tile:hover { border-color: var(--cs-border-strong); }
+
+.cs-tile-head {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: clamp(9px, 1.3vh, 10.5px);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cs-text-muted);
+  margin-bottom: clamp(4px, 0.8vh, 8px);
+  flex-shrink: 0;
+}
+.cs-tile-head-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+.cs-tile-head-left { display: inline-flex; align-items: center; gap: 6px; }
+.cs-tile-ic { color: var(--cs-accent); flex-shrink: 0; }
+.cs-tile-hint {
+  font-size: clamp(9.5px, 1.25vh, 11px);
+  color: var(--cs-text-muted);
+  text-transform: none;
+  letter-spacing: 0;
+  font-family: var(--cs-mono);
+  font-weight: 400;
+  white-space: nowrap;
+}
+
+/* ─── Hero Tile (8 cols) ──────────────────────────── */
+.cs-tile-hero {
+  grid-column: span 8;
+  padding: clamp(10px, 1.5vh, 16px) clamp(14px, 1.8vw, 20px);
+  background:
+    radial-gradient(circle at 80% 0%, rgba(34, 197, 94, 0.10), transparent 55%),
+    radial-gradient(circle at 0% 100%, rgba(56, 189, 248, 0.06), transparent 50%),
+    var(--cs-card);
+  justify-content: center;
+}
+.cs-hero-glow {
+  position: absolute;
+  top: -40%;
+  right: -20%;
+  width: 60%;
+  height: 180%;
+  background: radial-gradient(ellipse, rgba(34, 197, 94, 0.10), transparent 60%);
+  pointer-events: none;
+  filter: blur(10px);
+}
+.cs-hero-greeting {
+  margin: clamp(2px, 0.4vh, 5px) 0 clamp(2px, 0.4vh, 4px);
+  font-size: clamp(16px, 3.2vh, 26px);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+  color: var(--cs-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cs-hero-subtitle {
+  margin: 0;
+  color: var(--cs-text-2);
+  font-size: clamp(10.5px, 1.55vh, 13px);
+  max-width: 60ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  min-height: 0;
+}
+.cs-hero-author {
+  margin-top: clamp(4px, 0.8vh, 10px);
+  font-size: clamp(9.5px, 1.3vh, 11.5px);
+  color: var(--cs-text-muted);
+  font-family: var(--cs-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── Bottom meta footer (replaces in-hero chips) ─── */
+.cs-meta-footer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 clamp(4px, 0.6vw, 8px);
+  font-size: clamp(9.5px, 1.2vh, 11px);
+  font-family: var(--cs-mono);
+  color: var(--cs-text-muted);
+  flex-shrink: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cs-meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cs-meta-chip svg { color: var(--cs-accent); flex-shrink: 0; }
+.cs-meta-time svg { color: var(--cs-text-muted); }
+.cs-meta-sep { color: var(--cs-text-muted); opacity: 0.5; }
+.cs-meta-brand {
+  margin-left: auto;
+  color: var(--cs-text-muted);
+  letter-spacing: 0.06em;
+  font-family: var(--cs-sans);
+  font-weight: 500;
+  flex-shrink: 0;
+}
+.cs-meta-repo { font-weight: 500; color: var(--cs-text-2); }
+
+/* ─── Streak Tile (4 cols) ────────────────────────── */
+.cs-tile-streak {
+  grid-column: span 4;
+  background:
+    linear-gradient(140deg, rgba(34, 197, 94, 0.08), transparent 70%),
+    var(--cs-card);
+  border-color: rgba(34, 197, 94, 0.18);
+  flex-direction: row;
+  align-items: center;
+  gap: clamp(8px, 1.5vw, 14px);
+}
+.cs-tile-streak .cs-tile-head { margin-bottom: 0; flex-shrink: 0; }
+.cs-tile-streak .cs-streak-num {
+  font-size: clamp(28px, 5.5vh, 48px);
+  font-weight: 600;
+  line-height: 1;
+  color: var(--cs-accent);
+  text-shadow: var(--cs-accent-glow);
+  letter-spacing: -0.04em;
+}
+.cs-streak-unit {
+  font-family: var(--cs-mono);
+  font-size: clamp(9px, 1.2vh, 10.5px);
+  letter-spacing: 0.2em;
+  color: var(--cs-text-muted);
+}
+.cs-streak-foot {
+  margin-left: auto;
+  font-size: clamp(10px, 1.4vh, 11.5px);
+  color: var(--cs-text-2);
+  text-align: right;
+  max-width: 50%;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+/* ─── Stat Tiles (3 cols each) ────────────────────── */
+.cs-tile-stat { grid-column: span 3; justify-content: center; }
+.cs-stat-num {
+  font-size: clamp(18px, 3.4vh, 26px);
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: var(--cs-text);
+  margin-top: 0;
+}
+.cs-stat-diff {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  font-size: clamp(14px, 2.6vh, 20px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cs-stat-diff .cs-add { color: var(--cs-add); text-shadow: var(--cs-accent-glow); }
+.cs-stat-diff .cs-del { color: var(--cs-del); }
+.cs-stat-diff .cs-sep { color: var(--cs-text-muted); font-size: 0.7em; opacity: 0.5; }
+.cs-stat-foot {
+  margin-top: auto;
+  padding-top: clamp(2px, 0.5vh, 6px);
+  font-size: clamp(9.5px, 1.3vh, 11px);
+  color: var(--cs-text-muted);
+  font-family: var(--cs-mono);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cs-stat-foot.up { color: var(--cs-add); }
+.cs-stat-foot.down { color: var(--cs-del); }
+.cs-stat-foot svg { width: 10px; height: 10px; flex-shrink: 0; }
+
+/* ─── Donut Tile (5 cols) ─────────────────────────── */
+.cs-tile-donut { grid-column: span 5; min-height: 0; }
+.cs-donut-row {
+  display: flex;
+  align-items: center;
+  gap: clamp(10px, 1.6vw, 16px);
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+}
+.cs-donut-wrap {
+  position: relative;
+  width: clamp(60px, 11vh, 100px);
+  height: clamp(60px, 11vh, 100px);
+  flex: 0 0 auto;
+}
+.cs-donut { width: 100%; height: 100%; transform: rotate(-90deg); display: block; }
+.cs-donut-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.cs-donut-value {
+  font-size: clamp(15px, 2.6vh, 20px);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  color: var(--cs-text);
+}
+.cs-donut-label {
+  font-size: clamp(7px, 0.95vh, 9px);
+  letter-spacing: 0.12em;
+  color: var(--cs-text-muted);
+  text-transform: uppercase;
+  margin-top: 2px;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+}
+.cs-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2px, 0.4vh, 4px);
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  align-self: center;
+}
+.cs-legend-row {
+  display: grid;
+  grid-template-columns: 8px 1fr auto;
+  gap: 8px;
+  align-items: center;
+  font-size: clamp(10px, 1.45vh, 12px);
+  color: var(--cs-text-2);
+  min-width: 0;
+}
+.cs-legend-swatch { width: 8px; height: 8px; border-radius: 2px; }
+.cs-legend-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.cs-legend-pct {
+  font-family: var(--cs-mono);
+  color: var(--cs-text-muted);
+  font-size: clamp(9.5px, 1.3vh, 11px);
+}
+
+/* ─── Hours Tile (7 cols) ─────────────────────────── */
+.cs-tile-hours { grid-column: span 7; }
+.cs-hours {
+  display: grid;
+  grid-template-columns: repeat(24, 1fr);
+  align-items: end;
+  gap: 4px;
+  flex: 1;
+  min-height: 0;
+  padding-top: 4px;
+  border-bottom: 1px solid var(--cs-border);
+  padding-bottom: 4px;
+}
+.cs-hour-bar {
+  background: var(--cs-card-2);
+  border-radius: 2px;
+  min-height: 4px;
+  transition: background 180ms ease;
+  position: relative;
+}
+.cs-hour-bar.has { background: var(--cs-accent-soft); }
+.cs-hour-bar.has::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, var(--cs-accent), var(--cs-accent-2));
+  border-radius: 2px;
+  opacity: 0.85;
+}
+.cs-hour-bar.peak::after { box-shadow: 0 0 12px rgba(34, 197, 94, 0.5); opacity: 1; }
+.cs-hour-bar:hover { filter: brightness(1.2); }
+.cs-hours-axis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 3px;
+  font-size: clamp(8.5px, 1.1vh, 10px);
+  color: var(--cs-text-muted);
+  flex-shrink: 0;
+}
+.cs-style-badge {
+  margin-top: clamp(4px, 0.7vh, 8px);
+  padding: clamp(4px, 0.8vh, 8px) clamp(8px, 1.2vw, 12px);
+  border-radius: var(--cs-radius-sm);
+  background: var(--cs-card-2);
+  border: 1px solid var(--cs-border);
+  font-size: clamp(10px, 1.4vh, 12px);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.cs-style-badge-label {
+  color: var(--cs-text-muted);
+  font-size: clamp(8.5px, 1.1vh, 10px);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.cs-style-badge-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  color: var(--cs-text);
+}
+.cs-style-badge-value svg { color: var(--cs-accent); }
+
+/* ─── Heatmap Tile (6 cols, side-by-side with commits) ─ */
+.cs-tile-heatmap { grid-column: span 6; padding: clamp(8px, 1.2vh, 12px) clamp(10px, 1.5vw, 14px); }
+/* Multi-band container: stacks N rows of week-bands and ALWAYS fills
+   the tile edge-to-edge. JS picks the band count whose cell aspect is
+   closest to 1:1; cells are then stretched (rectangular if needed) so
+   no horizontal/vertical whitespace is left. */
+.cs-heatmap-body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: stretch;
+  gap: 6px;
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+.cs-heatmap {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 2px;
+  min-width: 0;
+  min-height: 0;
+}
+.cs-heat-cell {
+  border-radius: 2px;
+  background: var(--cs-card-2);
+  transition: outline-color 120ms ease;
+  outline: 1px solid transparent;
+  outline-offset: 1px;
+  min-width: 0;
+  min-height: 0;
+}
+.cs-heat-cell:hover { outline-color: var(--cs-accent); }
+.cs-heat-empty { background: transparent; pointer-events: none; }
+.cs-heat-0 { background: var(--cs-card-2); }
+.cs-heat-1 { background: rgba(34, 197, 94, 0.25); }
+.cs-heat-2 { background: rgba(34, 197, 94, 0.45); }
+.cs-heat-3 { background: rgba(34, 197, 94, 0.7); }
+.cs-heat-4 { background: var(--cs-accent); box-shadow: 0 0 10px rgba(34, 197, 94, 0.35); }
+
+.cs-heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: clamp(3px, 0.6vh, 6px);
+  font-size: clamp(9.5px, 1.25vh, 10.5px);
+  color: var(--cs-text-muted);
+  flex-shrink: 0;
+}
+.cs-heatmap-legend .cs-heat-cell {
+  width: 10px;
+  height: 10px;
+  pointer-events: none;
+  aspect-ratio: auto;
+}
+
+/* ─── Commits Tile (6 cols) ───────────────────────── */
+.cs-tile-commits { grid-column: span 6; padding: clamp(8px, 1.2vh, 12px) clamp(10px, 1.5vw, 14px); }
+.cs-commits {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+.cs-commit {
+  display: grid;
+  grid-template-columns: clamp(48px, 6vw, 60px) 1fr auto auto;
+  align-items: center;
+  gap: clamp(6px, 1vw, 10px);
+  padding: clamp(3px, 0.6vh, 6px) clamp(6px, 1vw, 10px);
+  border-radius: var(--cs-radius-sm);
+  background: transparent;
+  border: 1px solid transparent;
+  transition: background 140ms ease, border-color 140ms ease;
+  flex-shrink: 0;
+}
+.cs-commit:hover {
+  background: var(--cs-card-2);
+  border-color: var(--cs-border);
+}
+.cs-commit-hash {
+  font-size: clamp(9.5px, 1.3vh, 11px);
+  color: var(--cs-accent);
+  background: var(--cs-accent-soft);
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-align: center;
+  font-weight: 500;
+}
+.cs-commit-subject {
+  font-size: clamp(11px, 1.55vh, 13px);
+  color: var(--cs-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.cs-commit-time {
+  font-size: clamp(9.5px, 1.25vh, 11px);
+  color: var(--cs-text-muted);
+  font-family: var(--cs-mono);
+  white-space: nowrap;
+}
+.cs-commit-stat {
+  font-size: clamp(9.5px, 1.3vh, 11px);
+  font-family: var(--cs-mono);
+  display: flex;
+  gap: 6px;
+  white-space: nowrap;
+}
+.cs-commit-stat .cs-add { color: var(--cs-add); }
+.cs-commit-stat .cs-del { color: var(--cs-del); }
+.cs-commits-empty {
+  text-align: center;
+  padding: 14px 12px;
+  color: var(--cs-text-muted);
+  font-size: 12.5px;
+}
+
+/* ─── Empty / loading state ───────────────────────── */
+.cs-empty {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  border-radius: var(--cs-radius);
+  background: var(--cs-card);
+  border: 1px solid var(--cs-border);
+  flex: 1;
+}
+.cs-empty.is-error { border-color: rgba(248, 113, 113, 0.25); }
+.cs-empty.is-loading .cs-empty-art { color: var(--cs-accent); }
+.cs-empty.is-loading .cs-empty-art svg { animation: cs-spin 1s linear infinite; }
+.cs-empty-art {
+  color: var(--cs-text-muted);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--cs-card-2);
+  border: 1px solid var(--cs-border);
+}
+.cs-empty-art svg { width: 20px; height: 20px; }
+.cs-empty-text { min-width: 0; flex: 1; }
+.cs-empty-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--cs-text);
+}
+.cs-empty-desc {
+  margin: 3px 0 0;
+  color: var(--cs-text-muted);
+  font-size: 12px;
+  font-family: var(--cs-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cs-empty.is-error .cs-empty-art { color: var(--cs-del); }
+
+/* ─── Adaptive: gracefully shed less-essential tiles ──
+   The dashboard prefers to fit on a single screen on ANY aspect ratio.
+   When space gets tight we hide optional blocks instead of overflowing. */
+
+/* Short viewports: drop hours tile, let donut span full row width. */
+@media (max-height: 560px) {
+  .cs-hero-subtitle { -webkit-line-clamp: 1; }
+  .cs-streak-foot { -webkit-line-clamp: 1; }
+  .cs-tile-hours { display: none; }
+  .cs-tile-donut { grid-column: span 12; }
+  .cs-tile-donut .cs-donut-row { justify-content: flex-start; }
+}
+/* Very short viewports: also drop the 4th stat (langs) — donut already
+   conveys language info; hero greeting compresses further. */
+@media (max-height: 460px) {
+  .cs-tile-langs-stat { display: none; }
+  .cs-tile-stat { grid-column: span 4; }
+  .cs-bento {
+    grid-template-rows:
+      minmax(0, 1.1fr)
+      minmax(0, 0.8fr)
+      minmax(0, 1.2fr)
+      minmax(0, 2.2fr);
+  }
+}
+/* Tiny viewports: drop donut entirely, focus on stats + heatmap + commits. */
+@media (max-height: 380px) {
+  .cs-tile-donut { display: none; }
+  .cs-bento {
+    grid-template-rows:
+      minmax(0, 1.1fr)
+      minmax(0, 0.9fr)
+      minmax(0, 2.5fr);
+  }
+}
+
+/* Narrow viewports (e.g. embedded in side panel): single column stack. */
+@media (max-width: 760px) {
+  .cs-tile-hero,
+  .cs-tile-streak,
+  .cs-tile-donut,
+  .cs-tile-hours,
+  .cs-tile-heatmap,
+  .cs-tile-commits { grid-column: span 12; }
+  .cs-tile-stat { grid-column: span 6; }
+  html, body { overflow: auto; }
+  .cs-shell { height: auto; min-height: 100vh; }
+  .cs-bento { grid-template-rows: none; }
+}
+@media (max-width: 480px) {
+  .cs-tile-stat { grid-column: span 12; }
+  .cs-commit { grid-template-columns: clamp(44px, 12vw, 52px) 1fr auto; }
+  .cs-commit-time { display: none; }
+}
+
+/* ─── Motion ──────────────────────────────────────── */
+@keyframes cs-fade-up {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.cs-tile { animation: cs-fade-up 280ms ease both; }
+.cs-tile:nth-child(2) { animation-delay: 30ms; }
+.cs-tile:nth-child(3) { animation-delay: 60ms; }
+.cs-tile:nth-child(4) { animation-delay: 80ms; }
+.cs-tile:nth-child(5) { animation-delay: 100ms; }
+.cs-tile:nth-child(6) { animation-delay: 120ms; }
+.cs-tile:nth-child(7) { animation-delay: 140ms; }
+.cs-tile:nth-child(8) { animation-delay: 160ms; }
+.cs-tile:nth-child(9) { animation-delay: 180ms; }
+
+@keyframes cs-spin { to { transform: rotate(360deg); } }
+.cs-spin { animation: cs-spin 900ms linear infinite; }
+
+@media (prefers-reduced-motion: reduce) {
+  .cs-tile, .cs-spin { animation: none !important; transition: none !important; }
+}

--- a/src/crates/core/src/miniapp/builtin/assets/coding-selfie/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/coding-selfie/ui.js
@@ -1,0 +1,745 @@
+// Built-in MiniApp: 每日编码快照 — full-page Bento dashboard (OLED dark).
+
+const $ = (id) => document.getElementById(id);
+
+// Single-accent palette: greens for the brand, neutral muted for "other".
+const LANG_COLORS = [
+  '#22c55e', '#10b981', '#06b6d4', '#3b82f6', '#a855f7',
+  '#ec4899', '#f59e0b', '#ef4444', '#14b8a6', '#eab308',
+];
+
+// Lucide-style inline SVG strings.
+const SVG = {
+  loader: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>',
+  camera: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/><circle cx="12" cy="13" r="3"/></svg>',
+  folder: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 1z"/></svg>',
+  gitBranch: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>',
+  alert: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>',
+  trendUp: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>',
+  trendDown: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 18 13.5 8.5 8.5 13.5 1 6"/><polyline points="17 18 23 18 23 12"/></svg>',
+  minus: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/></svg>',
+  moon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>',
+  sun: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>',
+  coffee: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 8h1a4 4 0 1 1 0 8h-1"/><path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4z"/><line x1="6" y1="2" x2="6" y2="4"/><line x1="10" y1="2" x2="10" y2="4"/><line x1="14" y1="2" x2="14" y2="4"/></svg>',
+  zap: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>',
+  star: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>',
+};
+
+// Coding-style classifier driven by the busiest hour of the week.
+// Style label keys are locale-agnostic; resolved via I18N at render time.
+const STYLES = [
+  { range: [0, 5],   icon: SVG.moon,   key: 'styleNight' },
+  { range: [5, 9],   icon: SVG.sun,    key: 'styleMorning' },
+  { range: [9, 12],  icon: SVG.coffee, key: 'styleAm' },
+  { range: [12, 18], icon: SVG.zap,    key: 'stylePm' },
+  { range: [18, 23], icon: SVG.star,   key: 'styleEvening' },
+  { range: [23, 24], icon: SVG.moon,   key: 'styleNight' },
+];
+
+function styleForHour(h) {
+  for (const s of STYLES) if (h >= s.range[0] && h < s.range[1]) return s;
+  return STYLES[STYLES.length - 1];
+}
+
+// ---- i18n -------------------------------------------------------------
+const I18N = {
+  'zh-CN': {
+    title: '每日编码快照',
+    subtitle: '扫描你的本地 Git 仓库，凝结成一张今天的编码画像。',
+    streakLabel: '连续编码',
+    streakUnit: 'DAYS',
+    todayCommits: '今日提交',
+    codeChanges: '代码变动',
+    filesTouched: '涉及文件',
+    touchedToday: '今日变动',
+    languagesUsed: '使用语言',
+    donutTitle: '本周语言分布',
+    commits: 'commits',
+    hoursTitle: '24 小时活跃节律',
+    thisWeek: '本周',
+    hoursAria: '24 小时提交分布',
+    heatmapTitle: '编码热力',
+    heatmapAria: '52 周提交热力',
+    less: '少',
+    more: '多',
+    commitsTitle: '今日提交',
+    brand: '每日编码快照',
+    weekShort: ['日', '一', '二', '三', '四', '五', '六'],
+    just: '刚刚',
+    noCommitsThisWeek: '本周尚无提交',
+    noActivityThisWeek: '本周尚无活动',
+    codingStyle: 'CODING STYLE',
+    other: '其他',
+    last52: (total, days) => `近 52 周 · ${total} 提交 · 活跃 ${days} 天`,
+    perCellTitle: (date, count) => `${date} · ${count} 提交`,
+    hourTitle: (hh, count) => `${hh}:00 — ${count} 提交`,
+    noCommitsToday: '今天还没有提交，去写下第一行代码吧。',
+    showXofY: (shown, total) => `显示 ${shown} / 共 ${total} 次`,
+    totalX: (total) => `共 ${total} 次提交`,
+    greetings: { lateNight: '夜深了', morning: '早上好', am: '上午好', noon: '中午好', pm: '下午好', evening: '晚上好' },
+    greetWith: (part, name) => name ? `${part}，${name}` : part,
+    subtitleEmpty: '今天还没开张 — 一次小提交，就能让今天的画像不再空白。',
+    subtitleSprint: (n) => `今天 ${n} 次提交，全力冲刺中。`,
+    subtitleSteady: (n) => `今天 ${n} 次提交，节奏稳健。`,
+    subtitleStart: (n) => `今天 ${n} 次提交，刚刚起步。`,
+    deltaUp: (n) => `较昨日 +${n}`,
+    deltaDown: (n) => `较昨日 ${n}`,
+    deltaSame: '与昨日持平',
+    firstToday: 'first commits today',
+    streakFoot: [
+      { lt: 1, text: '今日打个卡，开启新连胜' },
+      { lt: 3, text: '坚持下去，节奏才刚开始' },
+      { lt: 7, text: '已经连写了一阵子' },
+      { lt: 30, text: '稳定的产出节奏' },
+      { lt: 100, text: '形成肌肉记忆，状态在线' },
+      { lt: 200, text: '难以置信的坚持力' },
+      { lt: Infinity, text: '你正在创造历史' },
+    ],
+    netPos: (n) => `net +${n}`,
+    netNeg: (n) => `net ${n}`,
+    allBranches: 'all branches',
+    showingAll: 'showing commits from all authors · all branches',
+    authorTitle: (name, emails) => `Filtering commits across all branches by:\n  name: ${name}\n  emails: ${emails.join('\n          ')}`,
+    snapTimeTitle: (s) => `快照时间 ${s}`,
+    loadingTitle: '正在扫描代码足迹',
+    loadingTitleFirst: '正在扫描你的代码足迹',
+    errNoWs: '还没有打开工作区',
+    errNoWsDesc: '请先在 BitFun 侧边栏选择一个 Git 仓库的工作区。',
+    errNotGit: '当前工作区不是 Git 仓库',
+    errNotGitDesc: (p) => `${p} · 执行 git init 或切换到 Git 仓库`,
+    errNoWsShort: '未检测到工作区',
+    errNoWsShortDesc: '请先打开一个工作区',
+    errScan: '扫描失败',
+    errScanReason: (r) => `原因：${r}`,
+    errScanRuntime: '扫描出错',
+    styleNight: '凌晨刺客',
+    styleMorning: '早起鸟',
+    styleAm: '上午型选手',
+    stylePm: '下午冲刺者',
+    styleEvening: '夜猫子',
+  },
+  'en-US': {
+    title: 'Daily Coding Snapshot',
+    subtitle: 'Scans your local Git repo and crystallizes today into one coding portrait.',
+    streakLabel: 'Streak',
+    streakUnit: 'DAYS',
+    todayCommits: 'Commits Today',
+    codeChanges: 'Lines',
+    filesTouched: 'Files',
+    touchedToday: 'touched today',
+    languagesUsed: 'Languages',
+    donutTitle: 'This Week · Languages',
+    commits: 'commits',
+    hoursTitle: '24h Activity Rhythm',
+    thisWeek: 'this week',
+    hoursAria: '24h commit distribution',
+    heatmapTitle: 'Coding Heatmap',
+    heatmapAria: '52-week commit heatmap',
+    less: 'less',
+    more: 'more',
+    commitsTitle: 'Today Commits',
+    brand: 'Daily Coding Snapshot',
+    weekShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+    just: 'just now',
+    noCommitsThisWeek: 'No commits this week',
+    noActivityThisWeek: 'No activity this week',
+    codingStyle: 'CODING STYLE',
+    other: 'Other',
+    last52: (total, days) => `Last 52w · ${total} commits · ${days} active days`,
+    perCellTitle: (date, count) => `${date} · ${count} commits`,
+    hourTitle: (hh, count) => `${hh}:00 — ${count} commits`,
+    noCommitsToday: 'No commits yet today — write that first line.',
+    showXofY: (shown, total) => `Showing ${shown} / ${total}`,
+    totalX: (total) => `${total} commits`,
+    greetings: { lateNight: 'Burning the midnight oil', morning: 'Good morning', am: 'Good morning', noon: 'Good noon', pm: 'Good afternoon', evening: 'Good evening' },
+    greetWith: (part, name) => name ? `${part}, ${name}` : part,
+    subtitleEmpty: 'Nothing yet today — one tiny commit fills the canvas.',
+    subtitleSprint: (n) => `${n} commits today — full sprint mode.`,
+    subtitleSteady: (n) => `${n} commits today — steady rhythm.`,
+    subtitleStart: (n) => `${n} commits today — just getting started.`,
+    deltaUp: (n) => `+${n} vs yesterday`,
+    deltaDown: (n) => `${n} vs yesterday`,
+    deltaSame: 'same as yesterday',
+    firstToday: 'first commits today',
+    streakFoot: [
+      { lt: 1, text: 'Punch in today and start a new streak' },
+      { lt: 3, text: 'Keep going — the rhythm is just starting' },
+      { lt: 7, text: "You've been at it for a while" },
+      { lt: 30, text: 'Solid steady output' },
+      { lt: 100, text: 'Muscle memory — fully in the zone' },
+      { lt: 200, text: 'Unbelievable persistence' },
+      { lt: Infinity, text: "You're making history" },
+    ],
+    netPos: (n) => `net +${n}`,
+    netNeg: (n) => `net ${n}`,
+    allBranches: 'all branches',
+    showingAll: 'showing commits from all authors · all branches',
+    authorTitle: (name, emails) => `Filtering commits across all branches by:\n  name: ${name}\n  emails: ${emails.join('\n          ')}`,
+    snapTimeTitle: (s) => `Snapshot time ${s}`,
+    loadingTitle: 'Scanning your code footprint',
+    loadingTitleFirst: 'Scanning your code footprint',
+    errNoWs: 'No workspace open',
+    errNoWsDesc: 'Open a Git repo workspace from the BitFun sidebar first.',
+    errNotGit: 'Workspace is not a Git repo',
+    errNotGitDesc: (p) => `${p} · run \`git init\` or switch to a Git repo`,
+    errNoWsShort: 'No workspace detected',
+    errNoWsShortDesc: 'Open a workspace first',
+    errScan: 'Scan failed',
+    errScanReason: (r) => `reason: ${r}`,
+    errScanRuntime: 'Scan error',
+    styleNight: 'Midnight Hacker',
+    styleMorning: 'Early Bird',
+    styleAm: 'Morning Brew',
+    stylePm: 'Afternoon Sprinter',
+    styleEvening: 'Night Owl',
+  },
+};
+
+function currentLocale() {
+  const l = window.app && window.app.locale;
+  if (l && I18N[l]) return l;
+  if (l && typeof l === 'string') {
+    const base = l.split('-')[0];
+    for (const k of Object.keys(I18N)) if (k.startsWith(base + '-')) return k;
+  }
+  return 'en-US';
+}
+function t(key) {
+  const dict = I18N[currentLocale()] || I18N['en-US'];
+  return dict[key];
+}
+
+function applyStaticI18n() {
+  const root = document.getElementById('root');
+  if (!root) return;
+  root.querySelectorAll('[data-i18n]').forEach((el) => {
+    const key = el.getAttribute('data-i18n');
+    const v = t(key);
+    if (typeof v !== 'string') return;
+    const attr = el.getAttribute('data-i18n-attr');
+    if (attr) el.setAttribute(attr, v);
+    else el.textContent = v;
+  });
+  document.documentElement.setAttribute('lang', currentLocale());
+}
+
+function fmtDate(d) {
+  const dt = new Date(d);
+  const week = t('weekShort') || ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const dayLabel = currentLocale() === 'zh-CN'
+    ? `周${week[dt.getDay()]}`
+    : week[dt.getDay()];
+  return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')} ${dayLabel}`;
+}
+function fmtShortDate(d) {
+  const dt = new Date(d);
+  return `${dt.getMonth() + 1}/${dt.getDate()}`;
+}
+function relativeTime(iso) {
+  const diff = Math.max(0, Date.now() - new Date(iso).getTime());
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return t('just');
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+function greetingFor(d, name) {
+  const h = d.getHours();
+  const g = t('greetings') || {};
+  const part = h < 5 ? g.lateNight : h < 9 ? g.morning : h < 12 ? g.am : h < 14 ? g.noon : h < 18 ? g.pm : h < 22 ? g.evening : g.lateNight;
+  return t('greetWith')(part, name);
+}
+
+function setEmpty(state, title, desc, icon) {
+  const el = $('empty');
+  el.classList.remove('is-loading', 'is-error');
+  if (state === 'loading') el.classList.add('is-loading');
+  if (state === 'error') el.classList.add('is-error');
+  $('empty-icon').innerHTML = icon || SVG.loader;
+  $('empty-title').textContent = title;
+  $('empty-desc').textContent = desc || '';
+}
+function showEmpty(state, title, desc, icon) {
+  setEmpty(state, title, desc, icon);
+  $('empty').removeAttribute('hidden');
+  $('content').setAttribute('hidden', '');
+}
+function hideEmpty() {
+  $('empty').setAttribute('hidden', '');
+  $('content').removeAttribute('hidden');
+}
+
+function renderDonut(langs) {
+  const svg = $('donut');
+  svg.innerHTML = '';
+  const total = langs.reduce((acc, l) => acc + l.weight, 0);
+  if (total <= 0) {
+    svg.innerHTML = '<circle cx="60" cy="60" r="46" fill="none" stroke="rgba(148,163,184,0.12)" stroke-width="12" />';
+    $('lang-legend').innerHTML = `<li class="cs-legend-row"><span></span><span class="cs-legend-name" style="color:var(--cs-text-muted)">${t('noCommitsThisWeek')}</span><span></span></li>`;
+    return;
+  }
+  const top = langs.slice(0, 5);
+  const otherWeight = langs.slice(5).reduce((acc, l) => acc + l.weight, 0);
+  const slices = otherWeight > 0
+    ? [...top, { name: t('other'), weight: otherWeight, isOther: true }]
+    : top;
+
+  const r = 46;
+  const c = 2 * Math.PI * r;
+  let offset = 0;
+
+  // Track ring
+  const track = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+  track.setAttribute('cx', '60');
+  track.setAttribute('cy', '60');
+  track.setAttribute('r', String(r));
+  track.setAttribute('fill', 'none');
+  track.setAttribute('stroke', 'var(--cs-card-2)');
+  track.setAttribute('stroke-width', '12');
+  svg.appendChild(track);
+
+  for (let i = 0; i < slices.length; i++) {
+    const s = slices[i];
+    const frac = s.weight / total;
+    const dash = c * frac;
+    const color = s.isOther ? 'rgba(148,163,184,0.35)' : LANG_COLORS[i % LANG_COLORS.length];
+    const arc = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    arc.setAttribute('cx', '60');
+    arc.setAttribute('cy', '60');
+    arc.setAttribute('r', String(r));
+    arc.setAttribute('fill', 'none');
+    arc.setAttribute('stroke', color);
+    arc.setAttribute('stroke-width', '12');
+    arc.setAttribute('stroke-linecap', 'butt');
+    arc.setAttribute('stroke-dasharray', `${dash} ${c - dash}`);
+    arc.setAttribute('stroke-dashoffset', String(-offset));
+    svg.appendChild(arc);
+    offset += dash;
+  }
+
+  const legend = $('lang-legend');
+  legend.innerHTML = '';
+  slices.forEach((s, i) => {
+    const li = document.createElement('li');
+    li.className = 'cs-legend-row';
+    const color = s.isOther ? 'rgba(148,163,184,0.35)' : LANG_COLORS[i % LANG_COLORS.length];
+    li.innerHTML = `
+      <span class="cs-legend-swatch" style="background:${color}"></span>
+      <span class="cs-legend-name" title="${s.name}">${s.name}</span>
+      <span class="cs-legend-pct">${(s.weight / total * 100).toFixed(1)}%</span>
+    `;
+    legend.appendChild(li);
+  });
+}
+
+function renderHours(hours) {
+  const wrap = $('hours');
+  wrap.innerHTML = '';
+  const max = Math.max(1, ...hours);
+  let peakHour = 0, peakVal = 0;
+  hours.forEach((v, i) => { if (v > peakVal) { peakVal = v; peakHour = i; } });
+  hours.forEach((v, i) => {
+    const bar = document.createElement('div');
+    bar.className = 'cs-hour-bar';
+    if (v > 0) bar.classList.add('has');
+    if (v > 0 && v === peakVal) bar.classList.add('peak');
+    const h = v > 0 ? Math.max(8, Math.round((v / max) * 100)) : 4;
+    bar.style.height = `${h}%`;
+    bar.title = t('hourTitle')(String(i).padStart(2, '0'), v);
+    wrap.appendChild(bar);
+  });
+
+  const badge = $('style-badge');
+  if (peakVal > 0) {
+    const s = styleForHour(peakHour);
+    badge.innerHTML = `
+      <span class="cs-style-badge-label">${t('codingStyle')}</span>
+      <span class="cs-style-badge-value">
+        <span style="width:14px;height:14px;display:inline-flex">${s.icon}</span>
+        ${t(s.key)} · ${String(peakHour).padStart(2, '0')}:00
+      </span>`;
+  } else {
+    badge.innerHTML = `<span class="cs-style-badge-label">${t('codingStyle')}</span><span class="cs-style-badge-value" style="color:var(--cs-text-muted)">${t('noActivityThisWeek')}</span>`;
+  }
+}
+
+// Heatmap rendering uses an adaptive multi-band layout: instead of forcing a
+// 7×52 strip (which leaves huge empty space in narrow/tall tiles), we split
+// the year into N stacked 7-row bands and pick the N that maximizes the
+// square cell size for the actual tile dimensions.
+
+let _heatmapCells = []; // flat list incl. leading/trailing pads
+let _heatmapMeta = { total: 0, activeDays: 0 };
+
+function renderHeatmap(heatmap) {
+  const body = $('heatmap-body');
+  if (!body) return;
+  body.innerHTML = '';
+  _heatmapCells = [];
+
+  if (!heatmap.length) {
+    $('heatmap-hint').textContent = '';
+    return;
+  }
+
+  const counts = heatmap.map((d) => d.count);
+  const max = Math.max(1, ...counts);
+  const firstDate = new Date(heatmap[0].date + 'T00:00:00');
+  const leadingEmpty = firstDate.getDay();
+
+  // Leading pads (so first column starts on Sunday)
+  for (let i = 0; i < leadingEmpty; i++) {
+    _heatmapCells.push({ empty: true });
+  }
+
+  let total = 0, activeDays = 0;
+  heatmap.forEach((d) => {
+    const ratio = d.count / max;
+    let lvl = 0;
+    if (d.count > 0) {
+      if (ratio < 0.25) lvl = 1;
+      else if (ratio < 0.5) lvl = 2;
+      else if (ratio < 0.85) lvl = 3;
+      else lvl = 4;
+    }
+    _heatmapCells.push({ date: d.date, count: d.count, lvl });
+    total += d.count;
+    if (d.count > 0) activeDays += 1;
+  });
+
+  // Trailing pads to complete the last column
+  const lastDate = new Date(heatmap[heatmap.length - 1].date + 'T00:00:00');
+  const trailing = 6 - lastDate.getDay();
+  for (let i = 0; i < trailing; i++) _heatmapCells.push({ empty: true });
+
+  _heatmapMeta = { total, activeDays };
+  $('heatmap-hint').textContent = t('last52')(total, activeDays);
+  fitHeatmap();
+}
+
+const HEAT_GAP = 2;
+const HEAT_BAND_GAP = 6;
+
+// Adaptive heatmap that ALWAYS fills 100% of the tile. Strategy:
+//   1) Try band counts 1..6 (each band is 7 rows × ceil(N/bands) cols).
+//   2) For each, the resulting cell is a rectangle (cellW x cellH).
+//   3) Score by aspect-ratio closeness to 1 (we prefer near-square cells but
+//      we do NOT enforce squareness — that's what was leaving whitespace).
+//   4) The chosen layout uses width:100% / height:100% with `1fr` tracks so
+//      the grid stretches edge-to-edge regardless of the cell aspect.
+function fitHeatmap() {
+  const body = $('heatmap-body');
+  if (!body || !_heatmapCells.length) return;
+  const totalWeeks = _heatmapCells.length / 7;
+  const availW = Math.max(0, body.clientWidth);
+  const availH = Math.max(0, body.clientHeight);
+  if (availW < 8 || availH < 8) return;
+
+  let best = null;
+  for (const bands of [1, 2, 3, 4, 5, 6]) {
+    const weeksPerBand = Math.ceil(totalWeeks / bands);
+    if (weeksPerBand < 3) continue;
+    const cellW = (availW - (weeksPerBand - 1) * HEAT_GAP) / weeksPerBand;
+    const totalRows = bands * 7;
+    const cellH = (availH - bands * 6 * HEAT_GAP - (bands - 1) * HEAT_BAND_GAP) / totalRows;
+    if (cellW < 1 || cellH < 1) continue;
+    const aspect = Math.max(cellW / cellH, cellH / cellW);
+    if (!best || aspect < best.aspect) {
+      best = { bands, weeksPerBand, cellW, cellH, aspect };
+    }
+  }
+  if (!best) best = { bands: 1, weeksPerBand: totalWeeks, cellW: 4, cellH: 4, aspect: 1 };
+
+  body.innerHTML = '';
+  const cellsPerBand = best.weeksPerBand * 7;
+  for (let b = 0; b < best.bands; b++) {
+    const grid = document.createElement('div');
+    grid.className = 'cs-heatmap';
+    const startIdx = b * cellsPerBand;
+    const endIdx = Math.min(_heatmapCells.length, startIdx + cellsPerBand);
+    const slice = _heatmapCells.slice(startIdx, endIdx);
+    while (slice.length < cellsPerBand) slice.push({ empty: true });
+    const weeks = slice.length / 7;
+    // 1fr tracks fill the band edge-to-edge regardless of cell aspect.
+    grid.style.gridTemplateColumns = `repeat(${weeks}, minmax(0, 1fr))`;
+    grid.style.gridTemplateRows = `repeat(7, minmax(0, 1fr))`;
+    grid.style.gap = `${HEAT_GAP}px`;
+    grid.style.gridAutoFlow = 'column';
+    grid.style.width = '100%';
+    // Each band gets equal vertical share of the body.
+    grid.style.flex = '1 1 0';
+    grid.style.minHeight = '0';
+    slice.forEach((c) => {
+      const cell = document.createElement('div');
+      if (c.empty) {
+        cell.className = 'cs-heat-cell cs-heat-empty';
+      } else {
+        cell.className = `cs-heat-cell cs-heat-${c.lvl}`;
+        cell.title = t('perCellTitle')(c.date, c.count);
+      }
+      grid.appendChild(cell);
+    });
+    body.appendChild(grid);
+  }
+}
+
+let _heatmapRO = null;
+function setupHeatmapResize() {
+  if (_heatmapRO) return;
+  const body = $('heatmap-body');
+  if (!body || typeof ResizeObserver === 'undefined') {
+    window.addEventListener('resize', fitHeatmap);
+    return;
+  }
+  _heatmapRO = new ResizeObserver(() => fitHeatmap());
+  _heatmapRO.observe(body);
+}
+
+function renderCommits(commits, totalToday) {
+  const list = $('commits-list');
+  list.innerHTML = '';
+  if (!commits.length) {
+    const li = document.createElement('li');
+    li.className = 'cs-commits-empty';
+    li.textContent = t('noCommitsToday');
+    list.appendChild(li);
+    return;
+  }
+  commits.forEach((c) => {
+    const li = document.createElement('li');
+    li.className = 'cs-commit';
+    li.innerHTML = `
+      <span class="cs-commit-hash">${c.hash}</span>
+      <span class="cs-commit-subject" title="${escapeAttr(c.subject)}">${escapeHtml(c.subject)}</span>
+      <span class="cs-commit-time">${relativeTime(c.date)}</span>
+      <span class="cs-commit-stat"><span class="cs-add">+${c.added}</span><span class="cs-del">-${c.deleted}</span></span>
+    `;
+    list.appendChild(li);
+  });
+  // Visible count is bounded by CSS overflow:hidden in the list — surface a
+  // clearer breakdown so "10" never reads as a lonely number on the edge.
+  $('commits-hint').textContent = totalToday > commits.length
+    ? t('showXofY')(commits.length, totalToday)
+    : t('totalX')(totalToday);
+}
+
+function renderHero(data) {
+  const now = new Date();
+  $('hero-greeting').textContent = greetingFor(now, data.author.name);
+
+  // Bottom meta footer (replaces the old in-hero chips)
+  const repoEl = $('meta-repo');
+  if (repoEl) {
+    repoEl.textContent = `${data.repo.name}@${data.repo.branch}`;
+    repoEl.parentElement.title = data.repo.path;
+  }
+  const dateEl = $('meta-date');
+  if (dateEl) dateEl.textContent = fmtDate(now);
+  const snap = new Date(data.generatedAt || Date.now());
+  const timeEl = $('meta-time');
+  if (timeEl) {
+    timeEl.textContent = `${String(snap.getHours()).padStart(2, '0')}:${String(snap.getMinutes()).padStart(2, '0')}`;
+    timeEl.parentElement.title = t('snapTimeTitle')(snap.toLocaleTimeString());
+  }
+
+  const td = data.today;
+  let subtitle;
+  if (td.commitCount === 0) {
+    subtitle = t('subtitleEmpty');
+  } else if (td.commitCount >= 8) {
+    subtitle = t('subtitleSprint')(td.commitCount);
+  } else if (td.commitCount >= 4) {
+    subtitle = t('subtitleSteady')(td.commitCount);
+  } else {
+    subtitle = t('subtitleStart')(td.commitCount);
+  }
+  $('hero-subtitle').textContent = subtitle;
+
+  const emails = (data.author.detectedEmails || []).filter(Boolean);
+  const heroAuthor = $('hero-author');
+  const allBranches = t('allBranches');
+  if (data.author.name && emails.length) {
+    const shownEmails = emails.length <= 2
+      ? emails.join(', ')
+      : `${emails.slice(0, 2).join(', ')} +${emails.length - 2}`;
+    heroAuthor.textContent = `${data.author.name} · ${shownEmails} · ${allBranches}`;
+    heroAuthor.title = t('authorTitle')(data.author.name, emails);
+  } else if (data.author.name) {
+    heroAuthor.textContent = `${data.author.name} · ${allBranches}`;
+    heroAuthor.title = '';
+  } else {
+    heroAuthor.textContent = t('showingAll');
+    heroAuthor.title = '';
+  }
+}
+
+function renderStats(data) {
+  const td = data.today;
+  $('stat-commits').textContent = String(td.commitCount);
+  $('stat-add').textContent = `+${td.added}`;
+  $('stat-del').textContent = `-${td.deleted}`;
+  $('stat-files').textContent = String(td.fileCount);
+  $('stat-langs').textContent = String(td.langs.length);
+
+  const net = td.added - td.deleted;
+  $('stat-net').textContent = net >= 0 ? t('netPos')(net) : t('netNeg')(net);
+
+  $('stat-langs-list').textContent = td.langs.length
+    ? td.langs.slice(0, 3).map((l) => l.name).join(' · ')
+    : '—';
+
+  const delta = td.commitCount - data.yesterday.commitCount;
+  const dEl = $('stat-commits-delta');
+  dEl.classList.remove('up', 'down');
+  if (delta > 0) {
+    dEl.innerHTML = `${SVG.trendUp} ${t('deltaUp')(delta)}`;
+    dEl.classList.add('up');
+  } else if (delta < 0) {
+    dEl.innerHTML = `${SVG.trendDown} ${t('deltaDown')(delta)}`;
+    dEl.classList.add('down');
+  } else if (data.yesterday.commitCount > 0) {
+    dEl.innerHTML = `${SVG.minus} ${t('deltaSame')}`;
+  } else {
+    dEl.textContent = t('firstToday');
+  }
+}
+
+function renderStreak(data) {
+  $('streak-num').textContent = String(data.streak);
+  const table = t('streakFoot') || [];
+  let foot = '';
+  for (const row of table) {
+    if (data.streak < row.lt) { foot = row.text; break; }
+  }
+  $('streak-foot').textContent = foot;
+}
+
+function render(data) {
+  hideEmpty();
+  renderHero(data);
+  renderStreak(data);
+  renderStats(data);
+  renderDonut(data.week.langs);
+  $('donut-total').textContent = String(data.week.commitCount);
+  renderHours(data.week.hours);
+  renderHeatmap(data.heatmap);
+  setupHeatmapResize();
+  renderCommits(data.today.commits, data.today.commitCount);
+}
+
+function buildMarkdown(data) {
+  const td = data.today;
+  const date = fmtDate(new Date());
+  const lines = [];
+  lines.push(`# ${t('title')} · ${date}`);
+  lines.push('');
+  lines.push(`> \`${data.repo.name}@${data.repo.branch}\`${data.author.name ? ` · ${data.author.name}` : ''}`);
+  lines.push('');
+  lines.push('| Metric | Today | Yesterday |');
+  lines.push('|---|---|---|');
+  lines.push(`| Commits | **${td.commitCount}** | ${data.yesterday.commitCount} |`);
+  lines.push(`| Lines  | **+${td.added} / -${td.deleted}** | +${data.yesterday.added} / -${data.yesterday.deleted} |`);
+  lines.push(`| Files  | **${td.fileCount}** | ${data.yesterday.fileCount} |`);
+  lines.push(`| Streak | **${data.streak} days** | — |`);
+
+  if (td.langs.length) {
+    lines.push('');
+    lines.push(`**Languages:** ${td.langs.slice(0, 5).map((l) => l.name).join(' · ')}`);
+  }
+
+  let peakHour = 0, peakVal = 0;
+  data.week.hours.forEach((v, i) => { if (v > peakVal) { peakVal = v; peakHour = i; } });
+  if (peakVal > 0) {
+    const s = styleForHour(peakHour);
+    lines.push(`**Style:** ${t(s.key)} (peak ${String(peakHour).padStart(2, '0')}:00)`);
+  }
+
+  if (td.commits.length) {
+    lines.push('');
+    lines.push('**Today commits:**');
+    lines.push('');
+    td.commits.forEach((c) => {
+      lines.push(`- \`${c.hash}\` ${c.subject} _(+${c.added} -${c.deleted})_`);
+    });
+  }
+
+  lines.push('');
+  lines.push('---');
+  lines.push(`_Generated by BitFun · ${t('title')}_`);
+  return lines.join('\n');
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+function escapeAttr(s) {
+  return escapeHtml(s).replace(/"/g, '&quot;');
+}
+
+let lastData = null;
+let scanning = false;
+
+async function scan() {
+  if (scanning) return;
+  scanning = true;
+
+  const ws = (window.app && window.app.workspaceDir) || '';
+
+  if (!ws) {
+    showEmpty('error', t('errNoWs'), t('errNoWsDesc'), SVG.folder);
+    lastData = null;
+    scanning = false;
+    return;
+  }
+
+  // Only show the full loading screen on the very first scan. Subsequent
+  // re-scans (triggered by `onActivate`) silently update the dashboard.
+  if (!lastData) {
+    showEmpty('loading', t('loadingTitle'), shortPath(ws), SVG.loader);
+  }
+
+  try {
+    const result = await window.app.call('workspace.scan', { cwd: ws });
+    if (!result || !result.ok) {
+      const reason = (result && result.reason) || 'unknown';
+      if (reason === 'not-a-git-repo') {
+        showEmpty('error', t('errNotGit'), t('errNotGitDesc')(shortPath(ws)), SVG.gitBranch);
+      } else if (reason === 'no-workspace') {
+        showEmpty('error', t('errNoWsShort'), t('errNoWsShortDesc'), SVG.folder);
+      } else {
+        showEmpty('error', t('errScan'), (result && result.message) || t('errScanReason')(reason), SVG.alert);
+      }
+      lastData = null;
+    } else {
+      lastData = result;
+      render(result);
+    }
+  } catch (err) {
+    showEmpty('error', t('errScanRuntime'), String(err && err.message ? err.message : err), SVG.alert);
+    lastData = null;
+  } finally {
+    scanning = false;
+  }
+}
+
+function shortPath(p) {
+  if (!p) return '';
+  const home = (typeof navigator !== 'undefined' && /Mac|Linux/.test(navigator.platform)) ? null : null;
+  // Truncate from the left, keeping the last 2 segments visible.
+  const segs = p.split(/[\\/]/).filter(Boolean);
+  if (segs.length <= 3) return p;
+  const tail = segs.slice(-2).join('/');
+  return `…/${tail}`;
+}
+
+applyStaticI18n();
+window.app?.onActivate?.(scan);
+window.app?.onLocaleChange?.(() => {
+  applyStaticI18n();
+  if (lastData) render(lastData);
+});
+scan();

--- a/src/crates/core/src/miniapp/builtin/assets/coding-selfie/worker.js
+++ b/src/crates/core/src/miniapp/builtin/assets/coding-selfie/worker.js
@@ -1,0 +1,277 @@
+// Built-in MiniApp: Coding Selfie — Node Worker.
+// Runs `git` against the current workspace to produce today's coding report.
+
+const { execFile } = require('child_process');
+const path = require('path');
+
+const EXT_TO_LANG = {
+  '.ts': 'TypeScript', '.tsx': 'TSX', '.js': 'JavaScript', '.jsx': 'JSX', '.mjs': 'JavaScript',
+  '.cjs': 'JavaScript', '.py': 'Python', '.rs': 'Rust', '.go': 'Go', '.java': 'Java',
+  '.kt': 'Kotlin', '.swift': 'Swift', '.cpp': 'C++', '.cc': 'C++', '.c': 'C', '.h': 'C/C++',
+  '.hpp': 'C++', '.cs': 'C#', '.rb': 'Ruby', '.php': 'PHP', '.scala': 'Scala', '.sh': 'Shell',
+  '.bash': 'Shell', '.zsh': 'Shell', '.css': 'CSS', '.scss': 'SCSS', '.sass': 'Sass',
+  '.less': 'Less', '.html': 'HTML', '.htm': 'HTML', '.json': 'JSON', '.md': 'Markdown',
+  '.mdx': 'MDX', '.yml': 'YAML', '.yaml': 'YAML', '.toml': 'TOML', '.ini': 'INI', '.sql': 'SQL',
+  '.vue': 'Vue', '.svelte': 'Svelte', '.lua': 'Lua', '.dart': 'Dart', '.r': 'R', '.proto': 'Protobuf',
+  '.gradle': 'Gradle', '.tf': 'Terraform', '.hcl': 'HCL', '.ex': 'Elixir', '.exs': 'Elixir',
+  '.erl': 'Erlang', '.elm': 'Elm', '.zig': 'Zig', '.nim': 'Nim', '.jl': 'Julia', '.clj': 'Clojure',
+  '.cljs': 'ClojureScript', '.fs': 'F#', '.ml': 'OCaml', '.coffee': 'CoffeeScript', '.xml': 'XML',
+  '.makefile': 'Make',
+};
+
+function langOf(file) {
+  const base = path.basename(file).toLowerCase();
+  if (base === 'dockerfile' || base.endsWith('.dockerfile')) return 'Docker';
+  if (base === 'makefile') return 'Make';
+  if (base === 'cmakelists.txt') return 'CMake';
+  const ext = path.extname(file).toLowerCase();
+  if (!ext) return null;
+  return EXT_TO_LANG[ext] || null;
+}
+
+function git(cwd, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'git',
+      args,
+      {
+        cwd,
+        encoding: 'utf8',
+        maxBuffer: opts.maxBuffer || 32 * 1024 * 1024,
+        timeout: opts.timeout || 12000,
+        env: { ...process.env, GIT_TERMINAL_PROMPT: '0', LC_ALL: 'C' },
+      },
+      (err, stdout, stderr) => {
+        if (err) reject(new Error(((stderr || '').trim() || err.message || String(err))));
+        else resolve(stdout);
+      },
+    );
+  });
+}
+
+function dayKey(d) {
+  const dt = new Date(d);
+  return (
+    dt.getFullYear() +
+    '-' +
+    String(dt.getMonth() + 1).padStart(2, '0') +
+    '-' +
+    String(dt.getDate()).padStart(2, '0')
+  );
+}
+
+function summarize(cs) {
+  let added = 0, deleted = 0;
+  const langs = new Map();
+  const files = new Set();
+  const hours = new Array(24).fill(0);
+  for (const c of cs) {
+    added += c.added;
+    deleted += c.deleted;
+    for (const f of c.files) {
+      files.add(f.path);
+      const l = f.lang;
+      if (l) {
+        const t = (f.added + f.deleted) || 1;
+        langs.set(l, (langs.get(l) || 0) + t);
+      }
+    }
+    const h = new Date(c.date).getHours();
+    if (h >= 0 && h < 24) hours[h] += 1;
+  }
+  const langArr = Array.from(langs.entries())
+    .map(([name, weight]) => ({ name, weight }))
+    .sort((a, b) => b.weight - a.weight);
+  return {
+    commitCount: cs.length,
+    added,
+    deleted,
+    fileCount: files.size,
+    langs: langArr,
+    hours,
+    commits: cs.slice(0, 12).map((c) => ({
+      hash: c.hash.slice(0, 7),
+      date: c.date,
+      author: c.author,
+      subject: c.subject,
+      added: c.added,
+      deleted: c.deleted,
+    })),
+  };
+}
+
+module.exports = {
+  async 'workspace.scan'(params) {
+    const cwd = (params && (params.cwd || params.workspace)) || '';
+    if (!cwd) {
+      return { ok: false, reason: 'no-workspace' };
+    }
+
+    // 1) Verify it is a git work tree.
+    try {
+      const inside = (await git(cwd, ['rev-parse', '--is-inside-work-tree'])).trim();
+      if (inside !== 'true') {
+        return { ok: false, reason: 'not-a-git-repo' };
+      }
+    } catch (_e) {
+      return { ok: false, reason: 'not-a-git-repo' };
+    }
+
+    // 2) Repo basics.
+    const [topLevelRaw, branchRaw, userNameRaw, userEmailRaw] = await Promise.all([
+      git(cwd, ['rev-parse', '--show-toplevel']).catch(() => cwd),
+      git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']).catch(() => 'HEAD'),
+      git(cwd, ['config', 'user.name']).catch(() => ''),
+      git(cwd, ['config', 'user.email']).catch(() => ''),
+    ]);
+    const topLevel = topLevelRaw.trim() || cwd;
+    const branch = branchRaw.trim() || 'HEAD';
+    const userName = userNameRaw.trim();
+    const userEmail = userEmailRaw.trim();
+    const repoName = path.basename(topLevel);
+
+    // 3) Auto-discover every email the current author has committed with in this
+    //    repo. This handles the very common case where upstream squash-merges
+    //    rewrite your commits to your GitHub no-reply email, or you have
+    //    multiple email identities (work / personal / noreply) for the same
+    //    name. Falls back to user.email only if name lookup fails.
+    const detectedEmails = new Set();
+    if (userEmail) detectedEmails.add(userEmail);
+    if (userName) {
+      try {
+        const emailMap = await git(
+          topLevel,
+          ['log', '--all', '--pretty=format:%aN\t%aE'],
+          { timeout: 12000, maxBuffer: 32 * 1024 * 1024 },
+        );
+        for (const line of emailMap.split('\n')) {
+          const tab = line.indexOf('\t');
+          if (tab < 0) continue;
+          const n = line.slice(0, tab).trim();
+          const e = line.slice(tab + 1).trim();
+          if (n && e && n === userName) detectedEmails.add(e);
+        }
+      } catch (_e) {
+        // best-effort; fall back to user.email only
+      }
+    }
+
+    // Build a single --author regex matching the user's name OR any of the
+    // detected emails. git --author treats the value as a POSIX BRE.
+    const escRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const patterns = [];
+    if (userName) patterns.push(escRe(userName));
+    for (const e of detectedEmails) patterns.push(escRe(e));
+    const authorPattern = patterns.length ? patterns.join('\\|') : '';
+
+    // 4) Pull last 52 weeks of commits with numstat across ALL branches.
+    const SEP = '\x1f';
+    const REC = '\x1e';
+    const fmt = `${REC}%H${SEP}%aI${SEP}%aN${SEP}%aE${SEP}%s`;
+    const args = [
+      'log',
+      '--all',
+      '--since=52.weeks',
+      '--no-merges',
+      `--pretty=format:${fmt}`,
+      '--numstat',
+    ];
+    if (authorPattern) args.push(`--author=${authorPattern}`);
+
+    let raw;
+    try {
+      raw = await git(topLevel, args, { timeout: 30000, maxBuffer: 64 * 1024 * 1024 });
+    } catch (e) {
+      return { ok: false, reason: 'git-log-failed', message: String(e.message || e) };
+    }
+
+    const commits = [];
+    const records = raw.split(REC);
+    for (const rec of records) {
+      const trimmed = rec.replace(/^\n+/, '');
+      if (!trimmed) continue;
+      const lines = trimmed.split('\n');
+      const header = lines[0] || '';
+      const parts = header.split(SEP);
+      if (parts.length < 5) continue;
+      const [hash, date, author, email, subject] = parts;
+      const files = [];
+      let added = 0, deleted = 0;
+      for (let i = 1; i < lines.length; i++) {
+        const ln = lines[i];
+        if (!ln) continue;
+        const m = ln.match(/^(\d+|-)\t(\d+|-)\t(.+)$/);
+        if (!m) continue;
+        const a = m[1] === '-' ? 0 : parseInt(m[1], 10);
+        const d = m[2] === '-' ? 0 : parseInt(m[2], 10);
+        added += a;
+        deleted += d;
+        files.push({ path: m[3], added: a, deleted: d, lang: langOf(m[3]) });
+      }
+      commits.push({ hash, date, author, email, subject, added, deleted, files });
+    }
+
+    // 4) Aggregate by day (local time).
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+    const yesterdayStart = new Date(todayStart);
+    yesterdayStart.setDate(todayStart.getDate() - 1);
+
+    const byDay = new Map();
+    for (const c of commits) {
+      const k = dayKey(c.date);
+      if (!byDay.has(k)) byDay.set(k, []);
+      byDay.get(k).push(c);
+    }
+
+    const todayKey = dayKey(todayStart);
+    const yesterdayKey = dayKey(yesterdayStart);
+    const today = summarize(byDay.get(todayKey) || []);
+    const yesterday = summarize(byDay.get(yesterdayKey) || []);
+
+    const weekCutoff = new Date(todayStart.getTime() - 6 * 86400000);
+    const week = summarize(commits.filter((c) => new Date(c.date) >= weekCutoff));
+    const month = summarize(commits);
+
+    // 5) Streak: consecutive days backwards with at least one commit. Counts today
+    //    if there are commits today; otherwise starts from yesterday.
+    let streak = 0;
+    const cursor = new Date(todayStart);
+    if (!byDay.has(dayKey(cursor))) {
+      cursor.setDate(cursor.getDate() - 1);
+    }
+    while (byDay.has(dayKey(cursor))) {
+      streak += 1;
+      cursor.setDate(cursor.getDate() - 1);
+    }
+
+    // 6) Year heatmap: 7 * 52 = 364 days, oldest → today.
+    const HEATMAP_DAYS = 7 * 52;
+    const heatmap = [];
+    for (let i = HEATMAP_DAYS - 1; i >= 0; i--) {
+      const d = new Date(todayStart);
+      d.setDate(d.getDate() - i);
+      const k = dayKey(d);
+      const list = byDay.get(k) || [];
+      heatmap.push({ date: k, count: list.length });
+    }
+
+    return {
+      ok: true,
+      repo: { name: repoName, path: topLevel, branch },
+      author: {
+        name: userName,
+        email: userEmail,
+        detectedEmails: Array.from(detectedEmails),
+        scope: 'all-branches',
+      },
+      today,
+      yesterday,
+      week,
+      month,
+      streak,
+      heatmap,
+      generatedAt: new Date().toISOString(),
+    };
+  },
+};

--- a/src/crates/core/src/miniapp/builtin/assets/divination/index.html
+++ b/src/crates/core/src/miniapp/builtin/assets/divination/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>每日占卜</title>
+  <title data-i18n="title">每日占卜</title>
 </head>
 <body>
   <div id="app" class="div-app">
@@ -14,26 +14,24 @@
     <header class="header">
       <div class="header__title">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3z"/><path d="M19 15l.6 1.6 1.6.6-1.6.6L19 19l-.6-1.6-1.6-.6 1.6-.6L19 15z"/><path d="M5 16l.5 1.3L7 18l-1.5.7L5 20l-.5-1.3L3 18l1.5-.7L5 16z"/></svg>
-        <span>每日占卜</span>
+        <span data-i18n="title">每日占卜</span>
       </div>
       <div class="header__date" id="date-label"></div>
     </header>
 
     <main class="stage">
-      <!-- Phase 1: card not yet revealed -->
-      <section class="reveal" id="reveal-stage">
-        <div class="card-back" id="card-back" tabindex="0" role="button" aria-label="抽取今日卡片">
-          <div class="card-back__pattern"></div>
-          <div class="card-back__inner">
-            <div class="card-back__symbol">✦</div>
-            <div class="card-back__hint">轻触翻牌 · 揭晓今日运势</div>
-          </div>
+      <!-- Phase 1: shuffle + spread + pick ceremony -->
+      <section class="draw-stage" id="draw-stage">
+        <div class="draw-stage__title">
+          <h2 class="draw-stage__greeting" id="greeting">凝神</h2>
+          <p class="draw-stage__subtitle" id="draw-subtitle">轻触一张牌，揭开今日卦象</p>
         </div>
-        <p class="reveal__tip">每天仅可抽取一次 · 翌日 00:00 焕新</p>
+        <div class="card-spread" id="card-spread" role="group" data-i18n-attr="aria-label" data-i18n="spreadAria"></div>
+        <p class="draw-stage__tip" id="draw-tip">每日卦象一旦显现便已注定 · 翌日 00:00 焕新</p>
       </section>
 
       <!-- Phase 2: card revealed -->
-      <section class="result" id="result-stage" hidden>
+      <section class="result result-stage" id="result-stage" hidden>
         <article class="card-front" id="card-front">
           <div class="card-front__top">
             <span class="card-front__index" id="card-index">No. 01</span>
@@ -43,49 +41,50 @@
           <h2 class="card-front__name" id="card-name">命运之轮</h2>
           <p class="card-front__keyword" id="card-keyword">流转 · 节奏</p>
           <p class="card-front__quote" id="card-quote"></p>
+          <p class="card-front__insight" id="card-insight"></p>
         </article>
 
         <div class="result__panels">
           <section class="panel panel--fortunes">
-            <div class="panel__title">运势矩阵</div>
+            <div class="panel__title" data-i18n="fortuneMatrix">运势矩阵</div>
             <ul class="fortunes" id="fortunes"></ul>
           </section>
 
           <div class="panel-row">
             <section class="panel panel--good">
               <div class="panel__title">
-                <span class="dot dot--good"></span> 今日宜
+                <span class="dot dot--good"></span> <span data-i18n="todayGood">今日宜</span>
               </div>
               <ul class="suit" id="suit-good"></ul>
             </section>
             <section class="panel panel--bad">
               <div class="panel__title">
-                <span class="dot dot--bad"></span> 今日忌
+                <span class="dot dot--bad"></span> <span data-i18n="todayBad">今日忌</span>
               </div>
               <ul class="suit" id="suit-bad"></ul>
             </section>
           </div>
 
           <section class="panel panel--lucky">
-            <div class="panel__title">机缘提示</div>
+            <div class="panel__title" data-i18n="omenTitle">机缘提示</div>
             <div class="lucky">
               <div class="lucky__cell">
-                <div class="lucky__label">幸运色</div>
+                <div class="lucky__label" data-i18n="luckyColor">幸运色</div>
                 <div class="lucky__value">
                   <span class="lucky__swatch" id="lucky-color-swatch"></span>
                   <span id="lucky-color-name">—</span>
                 </div>
               </div>
               <div class="lucky__cell">
-                <div class="lucky__label">幸运数字</div>
+                <div class="lucky__label" data-i18n="luckyNumber">幸运数字</div>
                 <div class="lucky__value" id="lucky-number">—</div>
               </div>
               <div class="lucky__cell">
-                <div class="lucky__label">推荐时段</div>
+                <div class="lucky__label" data-i18n="luckyHour">推荐时段</div>
                 <div class="lucky__value" id="lucky-hour">—</div>
               </div>
               <div class="lucky__cell">
-                <div class="lucky__label">咒语</div>
+                <div class="lucky__label" data-i18n="mantra">咒语</div>
                 <div class="lucky__value lucky__value--mantra" id="lucky-mantra">—</div>
               </div>
             </div>
@@ -97,9 +96,9 @@
     <footer class="footer">
       <button id="btn-share" class="link-btn" type="button" hidden>
         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="9" height="8" rx="1"/><path d="M5 6V4a3 3 0 0 1 6 0v2"/></svg>
-        复制运势文本
+        <span data-i18n="copyText">复制运势文本</span>
       </button>
-      <span class="footer__hint" id="footer-hint">愿你今日的代码无 bug，commit 总能通过 review。</span>
+      <span class="footer__hint" id="footer-hint" data-i18n="footerHint">愿你今日的代码无 bug，commit 总能通过 review。</span>
     </footer>
 
     <div id="toast" class="toast" hidden></div>

--- a/src/crates/core/src/miniapp/builtin/assets/divination/meta.json
+++ b/src/crates/core/src/miniapp/builtin/assets/divination/meta.json
@@ -14,5 +14,19 @@
     "net": { "allow": [] },
     "node": { "enabled": true, "max_memory_mb": 128, "timeout_ms": 5000 }
   },
-  "ai_context": null
+  "ai_context": null,
+  "i18n": {
+    "locales": {
+      "zh-CN": {
+        "name": "每日占卜",
+        "description": "每日一卡程序员塔罗：综合/工作/灵感/财运四维运势，含今日宜忌与机缘提示，每天 0 点焕新。",
+        "tags": ["占卜", "运势", "趣味", "内置"]
+      },
+      "en-US": {
+        "name": "Daily Divination",
+        "description": "A daily programmer-tarot card with overall / work / inspiration / luck scores, today's do's & don'ts, refreshing at midnight.",
+        "tags": ["divination", "fortune", "fun", "built-in"]
+      }
+    }
+  }
 }

--- a/src/crates/core/src/miniapp/builtin/assets/divination/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/divination/style.css
@@ -133,93 +133,206 @@ button { font-family: inherit; cursor: pointer; }
   justify-content: center;
 }
 
-/* ── Reveal (back of card) ───────────────────────────── */
-.reveal {
+/* ── Draw stage — spread of card backs to choose from ──── */
+.draw-stage {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 22px;
+  gap: 18px;
   margin: auto;
+  width: 100%;
+  max-width: 880px;
 }
-.card-back {
-  width: 240px;
-  height: 360px;
+.draw-stage__title {
+  text-align: center;
+  margin-bottom: 4px;
+}
+.draw-stage__greeting {
+  margin: 0;
+  font-family: var(--d-serif);
+  font-size: 26px;
+  font-weight: 500;
+  letter-spacing: 12px;
+  padding-left: 12px; /* compensate letter-spacing on first letter */
+  color: var(--d-gold-bright);
+  text-shadow: 0 0 18px rgba(240,198,116,0.30);
+  animation: greetingFade 1.2s ease both;
+}
+.draw-stage__subtitle {
+  margin: 8px 0 0;
+  font-family: var(--d-serif);
+  font-size: 13.5px;
+  letter-spacing: 3px;
+  color: var(--d-text-soft);
+  animation: greetingFade 1.6s ease both .2s;
+}
+.draw-stage__tip {
+  margin: 0;
+  font-family: var(--d-serif);
+  font-size: 11.5px;
+  letter-spacing: 1.5px;
+  color: var(--d-text-mute);
+  text-align: center;
+  animation: greetingFade 1.8s ease both .4s;
+}
+@keyframes greetingFade {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* The fan of card backs. Cards visually overlap; hover/focus lifts them. */
+.card-spread {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  perspective: 1600px;
+  margin: 26px 0 6px;
+  min-height: 320px;
+  padding: 30px 20px 50px;
+}
+.card-pick {
+  --w: 168px;
+  --h: 248px;
+  width: var(--w);
+  height: var(--h);
+  margin: 0 -32px;
   border-radius: 14px;
   position: relative;
-  border: 1px solid rgba(212,175,55,0.45);
-  background:
-    radial-gradient(circle at 50% 35%, rgba(157,78,221,0.35), transparent 70%),
-    linear-gradient(160deg, #1d1438 0%, #2c1054 50%, #160a2c 100%);
-  box-shadow:
-    0 30px 80px -20px rgba(0,0,0,0.7),
-    0 0 0 1px rgba(212,175,55,0.18) inset,
-    0 0 80px rgba(157,78,221,0.20) inset,
-    0 0 30px rgba(212,175,55,0.10);
   cursor: pointer;
   outline: none;
   overflow: hidden;
-  transition: transform .35s cubic-bezier(.2,.8,.2,1), box-shadow .35s ease;
-}
-.card-back:hover {
-  transform: translateY(-6px) rotate(-1deg);
+  border: 1px solid rgba(212,175,55,0.45);
+  background:
+    radial-gradient(circle at 50% 35%, rgba(157,78,221,0.40), transparent 70%),
+    linear-gradient(160deg, #1d1438 0%, #2c1054 50%, #160a2c 100%);
   box-shadow:
-    0 36px 90px -20px rgba(157,78,221,0.55),
-    0 0 0 1px rgba(212,175,55,0.30) inset,
-    0 0 60px rgba(212,175,55,0.20);
+    0 24px 60px -22px rgba(0,0,0,0.7),
+    0 0 0 1px rgba(212,175,55,0.16) inset,
+    0 0 60px rgba(157,78,221,0.18) inset;
+  transform: translateY(var(--y, 0)) rotate(var(--rot, 0deg));
+  transform-origin: 50% 100%;
+  transition:
+    transform .38s cubic-bezier(.2,.8,.2,1),
+    box-shadow .38s ease,
+    opacity .45s ease,
+    filter .35s ease;
+  opacity: 0;
+  animation: cardEnterFan .55s cubic-bezier(.2,.8,.2,1) both;
+  animation-delay: var(--enter-delay, 0ms);
 }
-.card-back:focus-visible { box-shadow: 0 0 0 3px var(--d-gold); }
-.card-back__pattern {
-  position: absolute; inset: 12px;
+@keyframes cardEnterFan {
+  from {
+    opacity: 0;
+    transform: translateY(60px) rotate(0deg) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(var(--y, 0)) rotate(var(--rot, 0deg)) scale(1);
+  }
+}
+.card-pick:hover,
+.card-pick:focus-visible {
+  transform: translateY(calc(var(--y, 0px) - 28px)) rotate(0deg) scale(1.02);
+  z-index: 99 !important;
+  box-shadow:
+    0 38px 80px -22px rgba(157,78,221,0.55),
+    0 0 0 1px rgba(212,175,55,0.36) inset,
+    0 0 60px rgba(212,175,55,0.22);
+  filter: brightness(1.08);
+}
+.card-pick:focus-visible {
+  outline: 2px solid var(--d-gold-bright);
+  outline-offset: 4px;
+}
+.card-pick__pattern {
+  position: absolute; inset: 10px;
   border-radius: 8px;
   border: 1px solid rgba(212,175,55,0.30);
   background-image:
     radial-gradient(circle at 50% 50%, rgba(212,175,55,0.06) 0, transparent 40%),
     repeating-linear-gradient(45deg, rgba(212,175,55,0.04) 0 4px, transparent 4px 9px);
 }
-.card-back__pattern::before, .card-back__pattern::after {
-  /* gilded corner ornaments */
+.card-pick__pattern::before, .card-pick__pattern::after {
   content: '';
   position: absolute;
-  width: 22px; height: 22px;
+  width: 18px; height: 18px;
   border: 1px solid var(--d-gold);
   opacity: 0.7;
 }
-.card-back__pattern::before { top: 8px; left: 8px; border-right: 0; border-bottom: 0; }
-.card-back__pattern::after  { bottom: 8px; right: 8px; border-left: 0; border-top: 0; }
-
-.card-back__inner {
+.card-pick__pattern::before { top: 6px; left: 6px; border-right: 0; border-bottom: 0; }
+.card-pick__pattern::after  { bottom: 6px; right: 6px; border-left: 0; border-top: 0; }
+.card-pick__inner {
   position: absolute; inset: 0;
-  display: flex; flex-direction: column;
-  align-items: center; justify-content: center;
-  gap: 18px;
-  text-align: center;
+  display: flex; align-items: center; justify-content: center;
 }
-.card-back__symbol {
+.card-pick__symbol {
   font-family: var(--d-serif);
-  font-size: 84px;
-  background: linear-gradient(135deg, #f0c674 0%, #d4af37 50%, #c084fc 100%);
+  font-size: 60px;
+  line-height: 1;
+  background: linear-gradient(135deg, #f0c674 0%, #d4af37 55%, #c084fc 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-  filter: drop-shadow(0 0 14px rgba(212,175,55,0.45));
-  animation: pulse 2.6s ease-in-out infinite;
+  filter: drop-shadow(0 0 10px rgba(212,175,55,0.45));
+  opacity: 0.92;
 }
-@keyframes pulse {
-  0%, 100% { transform: scale(1); opacity: 0.95; }
-  50% { transform: scale(1.06); opacity: 1; }
+/* Subtle moving sheen across the back. */
+.card-pick__shine {
+  position: absolute; inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    115deg,
+    transparent 35%,
+    rgba(255,255,255,0.10) 50%,
+    transparent 65%
+  );
+  background-size: 220% 220%;
+  background-position: 100% 0;
+  animation: sheen 4.2s ease-in-out infinite;
+  mix-blend-mode: screen;
 }
-.card-back__hint {
-  font-family: var(--d-serif);
-  font-size: 13px;
-  letter-spacing: 2px;
-  color: rgba(243,232,255,0.78);
-  padding: 0 24px;
+@keyframes sheen {
+  0%, 100% { background-position: 130% 0; opacity: 0.0; }
+  35%      { opacity: 0.55; }
+  60%      { background-position: -30% 0; opacity: 0; }
 }
-.reveal__tip {
-  font-family: var(--d-serif);
-  font-size: 12px;
-  letter-spacing: 1.5px;
-  color: var(--d-text-mute);
-  text-align: center;
+
+/* Selected card: rises and glows. */
+.card-pick.is-chosen {
+  transform: translateY(-44px) rotate(0deg) scale(1.08);
+  z-index: 200 !important;
+  box-shadow:
+    0 60px 120px -28px rgba(157,78,221,0.70),
+    0 0 0 1px rgba(212,175,55,0.55) inset,
+    0 0 80px rgba(212,175,55,0.35),
+    0 0 140px rgba(157,78,221,0.45);
+  filter: brightness(1.18) saturate(1.1);
+  animation: chosenPulse 1.2s ease-in-out infinite alternate;
+}
+@keyframes chosenPulse {
+  from { box-shadow: 0 60px 120px -28px rgba(157,78,221,0.70),
+                     0 0 0 1px rgba(212,175,55,0.55) inset,
+                     0 0 80px rgba(212,175,55,0.35),
+                     0 0 140px rgba(157,78,221,0.45); }
+  to   { box-shadow: 0 70px 140px -28px rgba(157,78,221,0.85),
+                     0 0 0 1px rgba(240,198,116,0.75) inset,
+                     0 0 110px rgba(240,198,116,0.55),
+                     0 0 180px rgba(157,78,221,0.65); }
+}
+.card-pick.is-chosen .card-pick__symbol {
+  animation: symPulse 0.9s ease-in-out infinite alternate;
+}
+@keyframes symPulse {
+  from { transform: scale(1);    filter: drop-shadow(0 0 10px rgba(212,175,55,0.45)); }
+  to   { transform: scale(1.12); filter: drop-shadow(0 0 22px rgba(240,198,116,0.85)); }
+}
+
+/* Discarded cards fade and drift away. */
+.card-pick.is-discarded {
+  opacity: 0;
+  transform: translateY(80px) rotate(var(--rot, 0deg)) scale(0.85);
+  filter: blur(4px);
+  pointer-events: none;
 }
 
 /* ── Result ──────────────────────────────────────────── */
@@ -230,9 +343,36 @@ button { font-family: inherit; cursor: pointer; }
   width: 100%;
   max-width: 980px;
   align-items: start;
-  animation: rise .55s ease;
 }
-@keyframes rise { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+
+/* Card flips/rises in from where the chosen back was. */
+.result-stage.is-active .card-front {
+  animation: cardEnter .75s cubic-bezier(.2,.8,.2,1) both;
+}
+@keyframes cardEnter {
+  from {
+    opacity: 0;
+    transform: translateY(24px) scale(0.92) rotateY(-22deg);
+    filter: blur(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1) rotateY(0);
+    filter: none;
+  }
+}
+
+/* Right-side panels cascade in. */
+.result-stage.is-active .result__panels > * {
+  animation: panelRise .55s cubic-bezier(.2,.8,.2,1) both;
+}
+.result-stage.is-active .result__panels > *:nth-child(1) { animation-delay: .28s; }
+.result-stage.is-active .result__panels > *:nth-child(2) { animation-delay: .44s; }
+.result-stage.is-active .result__panels > *:nth-child(3) { animation-delay: .60s; }
+@keyframes panelRise {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 
 /* ── Card front ──────────────────────────────────────── */
 .card-front {
@@ -338,6 +478,27 @@ button { font-family: inherit; cursor: pointer; }
   padding: 0 12px;
   position: relative; z-index: 1;
 }
+.card-front__insight {
+  text-align: center;
+  font-family: var(--d-serif);
+  font-size: 11.5px;
+  letter-spacing: 1.2px;
+  color: rgba(240,198,116,0.78);
+  line-height: 1.6;
+  margin: 12px 0 0;
+  padding: 8px 14px 0;
+  border-top: 1px dashed rgba(212,175,55,0.28);
+  position: relative; z-index: 1;
+}
+.card-front__insight-label {
+  display: block;
+  font-size: 10px;
+  letter-spacing: 3px;
+  color: var(--d-gold);
+  opacity: 0.75;
+  margin-bottom: 4px;
+}
+.card-front__insight-text { display: block; }
 
 /* ── Right panels: stay arcane ───────────────────────── */
 .result__panels { display: flex; flex-direction: column; gap: 16px; }
@@ -382,15 +543,16 @@ button { font-family: inherit; cursor: pointer; }
 .fortunes { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }
 .fortune {
   display: grid;
-  grid-template-columns: 64px 1fr auto;
+  grid-template-columns: minmax(64px, max-content) minmax(40px, 1fr) auto;
   gap: 12px;
   align-items: center;
 }
 .fortune__label {
   font-family: var(--d-serif);
   font-size: 14px;
-  letter-spacing: 3px;
+  letter-spacing: 2px;
   color: var(--d-text-soft);
+  white-space: nowrap;
 }
 .fortune__bar {
   height: 4px;
@@ -554,4 +716,14 @@ button { font-family: inherit; cursor: pointer; }
   .result { grid-template-columns: 1fr; }
   .card-front { min-height: 320px; }
   .panel-row { grid-template-columns: 1fr; }
+  .card-pick { --w: 132px; --h: 196px; margin: 0 -42px; }
+  .card-pick__symbol { font-size: 48px; }
+  .card-spread { min-height: 250px; padding: 24px 14px 40px; }
+  .draw-stage__greeting { font-size: 22px; letter-spacing: 8px; padding-left: 8px; }
+  .draw-stage__subtitle { font-size: 12.5px; letter-spacing: 2px; }
+}
+@media (max-width: 460px) {
+  .card-pick { --w: 110px; --h: 162px; margin: 0 -50px; border-radius: 11px; }
+  .card-pick__symbol { font-size: 38px; }
+  .card-spread { min-height: 210px; }
 }

--- a/src/crates/core/src/miniapp/builtin/assets/divination/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/divination/ui.js
@@ -1,101 +1,656 @@
 // Daily Divination — built-in MiniApp.
 // Programmer-themed tarot: 24 cards, 4 fortune dimensions, daily-locked via app.storage.
+//
+// i18n strategy
+// -------------
+// Every locale-dependent dataset (cards / suits / colors / hours / mantras /
+// insights / UI labels) is split into ZH and EN tables of equal length so the
+// daily seed always picks the same *index* — switching languages re-renders
+// the same fortune in the chosen language without invalidating yesterday's
+// stored "drawn" state. Visual fields (symbol/tone) are shared.
 
-const CARDS = [
-  { name: '命运之轮', tag: '机缘', symbol: '✦', keyword: '流转 · 节奏', tone: ['#5b21b6', '#1e1b4b'],
-    quote: '每个 commit 都在改变命运的曲率，今天值得一次推送。' },
-  { name: '星辰指引', tag: '希望', symbol: '✶', keyword: '远方 · 灵感', tone: ['#1e3a8a', '#0c1230'],
-    quote: '当你卡住时，抬头看看 documentation 之外的世界。' },
-  { name: '熔炉之心', tag: '锻造', symbol: '✺', keyword: '精炼 · 重构', tone: ['#9a3412', '#2a0e0a'],
-    quote: '今日适合一次果敢的重构，删除即创造。' },
-  { name: '寂静之钟', tag: '冥想', symbol: '☾', keyword: '深思 · 沉潜', tone: ['#1e293b', '#0f172a'],
-    quote: '让 IDE 暂停十分钟，答案常在白板上浮现。' },
-  { name: '银河书简', tag: '智识', symbol: '☄', keyword: '阅读 · 累积', tone: ['#4c1d95', '#1f0a3d'],
-    quote: '今天读完一个长 issue 的讨论，比写十行代码值钱。' },
-  { name: '红宝匠人', tag: '创造', symbol: '◆', keyword: '雕琢 · 细节', tone: ['#7f1d1d', '#260a0a'],
-    quote: '把一个边界条件想清楚，就是今天最好的输出。' },
-  { name: '青铜之蛇', tag: '蜕变', symbol: '∞', keyword: '环路 · 蜕变', tone: ['#065f46', '#04241c'],
-    quote: '一个 retry-loop 修好了，整条链路都活了过来。' },
-  { name: '光之回响', tag: '协作', symbol: '✧', keyword: '回声 · 共振', tone: ['#0e7490', '#06262e'],
-    quote: '一句"我来帮你看看"，就是今日最强的 buff。' },
-  { name: '苔藓低语', tag: '休憩', symbol: '❀', keyword: '生长 · 留白', tone: ['#14532d', '#031708'],
-    quote: '让进度条慢一点，让创造力快一点。' },
-  { name: '星海罗盘', tag: '抉择', symbol: '⊛', keyword: '方向 · 决断', tone: ['#1e40af', '#0a163b'],
-    quote: '别再纠结技术选型，先把第一行代码写出来。' },
-  { name: '黄昏炉火', tag: '专注', symbol: '✦', keyword: '心流 · 燃烧', tone: ['#92400e', '#2d1305'],
-    quote: '关闭 Slack，今天属于你和编辑器的二人世界。' },
-  { name: '悬浮之环', tag: '平衡', symbol: '◌', keyword: '取舍 · 张力', tone: ['#3730a3', '#0f0e2c'],
-    quote: '完美与上线之间，请选择上线。' },
-  { name: '镜面湖', tag: '复盘', symbol: '☼', keyword: '映照 · 觉察', tone: ['#155e75', '#03222b'],
-    quote: '回看一周前自己写的代码，会比 review 更诚实。' },
-  { name: '深林信使', tag: '消息', symbol: '✉', keyword: '传达 · 链接', tone: ['#166534', '#03200d'],
-    quote: '一封写得清楚的邮件，胜过三场会议。' },
-  { name: '夜之提琴', tag: '诗意', symbol: '♪', keyword: '韵律 · 优雅', tone: ['#581c87', '#1a0830'],
-    quote: '为变量起一个动听的名字，命名是程序员的诗。' },
-  { name: '黎明铸铁', tag: '勇气', symbol: '⚔', keyword: '直面 · 挑战', tone: ['#9f1239', '#2c0710'],
-    quote: '今天直面那个一直被你跳过的 TODO。' },
-  { name: '极光之纱', tag: '灵感', symbol: '✤', keyword: '迸发 · 流动', tone: ['#0d9488', '#02322f'],
-    quote: '保持沐浴或散步的状态，bug 多半在水流声里被冲掉。' },
-  { name: '羽落之笔', tag: '记录', symbol: '✎', keyword: '书写 · 沉淀', tone: ['#3f3f46', '#101013'],
-    quote: '今日适合写一篇文档，未来的你会感谢现在的自己。' },
-  { name: '潮汐之环', tag: '节奏', symbol: '∽', keyword: '起伏 · 周期', tone: ['#0369a1', '#021c33'],
-    quote: '高效与低谷皆是潮汐，重要的是别在退潮时责怪自己。' },
-  { name: '紫晶圣杯', tag: '丰饶', symbol: '♥', keyword: '滋养 · 馈赠', tone: ['#86198f', '#2a0833'],
-    quote: '别忘了喝水。也别忘了夸自己一句。' },
-  { name: '金色齿轮', tag: '系统', symbol: '✦', keyword: '机制 · 架构', tone: ['#a16207', '#2c1a05'],
-    quote: '一个清晰的模块边界，胜过十个聪明的 hack。' },
-  { name: '晨曦之翼', tag: '启程', symbol: '✿', keyword: '出发 · 第一步', tone: ['#be185d', '#310a1f'],
-    quote: '把"等我准备好"换成"先 push 一个 draft PR"。' },
-  { name: '寒星之刃', tag: '清算', symbol: '✝', keyword: '剔除 · 净化', tone: ['#0f766e', '#02211f'],
-    quote: '今天适合删一些过时的依赖，少即是多。' },
-  { name: '月光石阶', tag: '指引', symbol: '☽', keyword: '夜行 · 步步', tone: ['#312e81', '#0a0928'],
-    quote: '不必看清整个阶梯，先迈出眼前的这一步。' },
+// ── Cards: shared visuals + per-locale strings ───────────────────────────
+const CARD_VISUALS = [
+  { symbol: '✦', tone: ['#5b21b6', '#1e1b4b'] },
+  { symbol: '✶', tone: ['#1e3a8a', '#0c1230'] },
+  { symbol: '✺', tone: ['#9a3412', '#2a0e0a'] },
+  { symbol: '☾', tone: ['#1e293b', '#0f172a'] },
+  { symbol: '☄', tone: ['#4c1d95', '#1f0a3d'] },
+  { symbol: '◆', tone: ['#7f1d1d', '#260a0a'] },
+  { symbol: '∞', tone: ['#065f46', '#04241c'] },
+  { symbol: '✧', tone: ['#0e7490', '#06262e'] },
+  { symbol: '❀', tone: ['#14532d', '#031708'] },
+  { symbol: '⊛', tone: ['#1e40af', '#0a163b'] },
+  { symbol: '✦', tone: ['#92400e', '#2d1305'] },
+  { symbol: '◌', tone: ['#3730a3', '#0f0e2c'] },
+  { symbol: '☼', tone: ['#155e75', '#03222b'] },
+  { symbol: '✉', tone: ['#166534', '#03200d'] },
+  { symbol: '♪', tone: ['#581c87', '#1a0830'] },
+  { symbol: '⚔', tone: ['#9f1239', '#2c0710'] },
+  { symbol: '✤', tone: ['#0d9488', '#02322f'] },
+  { symbol: '✎', tone: ['#3f3f46', '#101013'] },
+  { symbol: '∽', tone: ['#0369a1', '#021c33'] },
+  { symbol: '♥', tone: ['#86198f', '#2a0833'] },
+  { symbol: '✦', tone: ['#a16207', '#2c1a05'] },
+  { symbol: '✿', tone: ['#be185d', '#310a1f'] },
+  { symbol: '✝', tone: ['#0f766e', '#02211f'] },
+  { symbol: '☽', tone: ['#312e81', '#0a0928'] },
 ];
 
-const FORTUNE_KEYS = [
-  { key: 'overall', label: '综合' },
-  { key: 'work', label: '工作' },
-  { key: 'inspire', label: '灵感' },
-  { key: 'wealth', label: '财运' },
-];
+const CARD_STRINGS = {
+  'zh-CN': [
+    { name: '命运之轮', tag: '机缘', keyword: '流转 · 节奏', quotes: [
+      '每个 commit 都在改变命运的曲率，今天值得一次推送。',
+      '齿轮自有其转法，你只需在对的时刻按下回车。',
+      '今日属于"先动起来再说"，方向会自己浮现。',
+      '昨天卡住的事，换个时间点再试，常常就通了。',
+    ] },
+    { name: '星辰指引', tag: '希望', keyword: '远方 · 灵感', quotes: [
+      '当你卡住时，抬头看看 documentation 之外的世界。',
+      '把眼光放远一档，眼前的死结就成了路标。',
+      '今天值得收藏一篇与日常项目无关的好文。',
+      '相信那个让你心动的"小副业"念头，它在为你导航。',
+    ] },
+    { name: '熔炉之心', tag: '锻造', keyword: '精炼 · 重构', quotes: [
+      '今日适合一次果敢的重构，删除即创造。',
+      '你心里那段"早晚要改"的代码，今天就是早。',
+      '与其修补，不如把它推回炉火里重铸。',
+      '减法比加法更需要勇气，今天你有这份勇气。',
+    ] },
+    { name: '寂静之钟', tag: '冥想', keyword: '深思 · 沉潜', quotes: [
+      '让 IDE 暂停十分钟，答案常在白板上浮现。',
+      '今天少打字，多想一想。手指会感谢大脑。',
+      '把问题写下来读一遍，半数 bug 当场暴露。',
+      '安静是最被低估的生产力工具。',
+    ] },
+    { name: '银河书简', tag: '智识', keyword: '阅读 · 累积', quotes: [
+      '今天读完一个长 issue 的讨论，比写十行代码值钱。',
+      '允许自己花一小时读源码，那是滚雪球的开始。',
+      '收藏夹里那篇文，今天就读完它。',
+      '一篇好的 RFC，胜过十次会议。',
+    ] },
+    { name: '红宝匠人', tag: '创造', keyword: '雕琢 · 细节', quotes: [
+      '把一个边界条件想清楚，就是今天最好的输出。',
+      '今日适合打磨那个"差不多了"的细节。',
+      '错误信息也是产品的一部分，把它写得人话一点。',
+      '一处微调，往往胜过一次重写。',
+    ] },
+    { name: '青铜之蛇', tag: '蜕变', keyword: '环路 · 蜕变', quotes: [
+      '一个 retry-loop 修好了，整条链路都活了过来。',
+      '让自己经历一次"原来如此"的瞬间。',
+      '今天值得一次彻底的认知刷新。',
+      '换个角度看那个老问题，它会变得很小。',
+    ] },
+    { name: '光之回响', tag: '协作', keyword: '回声 · 共振', quotes: [
+      '一句"我来帮你看看"，就是今日最强的 buff。',
+      '主动 ping 一下卡住的同事，你的 5 分钟可能省他半天。',
+      '今天答一个别人问过你的问题，回声会传得很远。',
+      '感谢一位帮过你的同事，越具体越好。',
+    ] },
+    { name: '苔藓低语', tag: '休憩', keyword: '生长 · 留白', quotes: [
+      '让进度条慢一点，让创造力快一点。',
+      '今日宜偷一会儿懒，灵感不在键盘上。',
+      '允许一天的"看似没产出"，土壤需要时间发酵。',
+      '把椅子推开，去窗边站三分钟。',
+    ] },
+    { name: '星海罗盘', tag: '抉择', keyword: '方向 · 决断', quotes: [
+      '别再纠结技术选型，先把第一行代码写出来。',
+      '今日适合做出那个一直拖着的决定。',
+      '选 A 还是选 B 都行，只要别再选"再等等"。',
+      '把方案写在纸上，多数选择会自我揭晓。',
+    ] },
+    { name: '黄昏炉火', tag: '专注', keyword: '心流 · 燃烧', quotes: [
+      '关闭 Slack，今天属于你和编辑器的二人世界。',
+      '把今天最想做的事排到上午第一格。',
+      '一段不被打断的 90 分钟，胜过一整天的碎片时间。',
+      '让"勿扰模式"成为今天的礼物。',
+    ] },
+    { name: '悬浮之环', tag: '平衡', keyword: '取舍 · 张力', quotes: [
+      '完美与上线之间，请选择上线。',
+      '今天值得为某件事说一次"不"。',
+      '少做一件事，远比多做一件事难。',
+      '把范围缩小一半，效果常常翻倍。',
+    ] },
+    { name: '镜面湖', tag: '复盘', keyword: '映照 · 觉察', quotes: [
+      '回看一周前自己写的代码，会比 review 更诚实。',
+      '今天写一段三行的复盘，明天就用得到。',
+      '问自己：这一周最让我自豪的一件事是什么？',
+      '过去的你犯过的错，未必你今天还在犯。',
+    ] },
+    { name: '深林信使', tag: '消息', keyword: '传达 · 链接', quotes: [
+      '一封写得清楚的邮件，胜过三场会议。',
+      '今天适合主动同步一次进展，让信息走在前面。',
+      '把那条想了三天的话发出去，最坏不过没回复。',
+      '一句"对齐一下"，能省掉一周的猜测。',
+    ] },
+    { name: '夜之提琴', tag: '诗意', keyword: '韵律 · 优雅', quotes: [
+      '为变量起一个动听的名字，命名是程序员的诗。',
+      '今天写一段你愿意拿给朋友看的代码。',
+      '让函数像句子那样易读，让模块像段落那样自洽。',
+      '把空行用得像呼吸一样自然。',
+    ] },
+    { name: '黎明铸铁', tag: '勇气', keyword: '直面 · 挑战', quotes: [
+      '今天直面那个一直被你跳过的 TODO。',
+      '把最难的那件事放在第一个，剩下的会变容易。',
+      '该说的话就说出来，迟到的反馈是没礼貌的反馈。',
+      '把"等我学会再做"换成"边做边学"。',
+    ] },
+    { name: '极光之纱', tag: '灵感', keyword: '迸发 · 流动', quotes: [
+      '保持沐浴或散步的状态，bug 多半在水流声里被冲掉。',
+      '今日的好点子在键盘外，记得带个本子。',
+      '允许自己暂时离开屏幕，灵感会从背后追上来。',
+      '换一个写代码的地方，思路也会跟着挪窝。',
+    ] },
+    { name: '羽落之笔', tag: '记录', keyword: '书写 · 沉淀', quotes: [
+      '今日适合写一篇文档，未来的你会感谢现在的自己。',
+      '把口口相传的规则落到 README 里。',
+      '为今天的小决定写一句"为什么"，半年后它救你。',
+      '把脑子里的图画到 README 里，团队就有了共识。',
+    ] },
+    { name: '潮汐之环', tag: '节奏', keyword: '起伏 · 周期', quotes: [
+      '高效与低谷皆是潮汐，重要的是别在退潮时责怪自己。',
+      '今日宜跟着身体走，效率自有其潮位。',
+      '不必每天都全力奔跑，会跑的人也会走。',
+      '低能量时段，做低能量任务，那叫聪明。',
+    ] },
+    { name: '紫晶圣杯', tag: '丰饶', keyword: '滋养 · 馈赠', quotes: [
+      '别忘了喝水。也别忘了夸自己一句。',
+      '今日给自己留一份小奖励，哪怕是一杯好咖啡。',
+      '吃顿好的，再回去 debug。',
+      '今天对自己温柔一些，世界对你也会。',
+    ] },
+    { name: '金色齿轮', tag: '系统', keyword: '机制 · 架构', quotes: [
+      '一个清晰的模块边界，胜过十个聪明的 hack。',
+      '今日宜画一张架构图，在脑子之外把它显形。',
+      '与其打补丁，不如先想清楚是谁在和谁说话。',
+      '为机制投资一点时间，未来连本带利还你。',
+    ] },
+    { name: '晨曦之翼', tag: '启程', keyword: '出发 · 第一步', quotes: [
+      '把"等我准备好"换成"先 push 一个 draft PR"。',
+      '今日适合开一个新仓库，哪怕只写一个 README。',
+      '0 → 1 永远是最难也最值得的那一步。',
+      '只要开始，就已经领先昨天的自己。',
+    ] },
+    { name: '寒星之刃', tag: '清算', keyword: '剔除 · 净化', quotes: [
+      '今天适合删一些过时的依赖，少即是多。',
+      '把那个一年没人用的功能下线吧。',
+      '收件箱清零一次，整个人都轻盈了。',
+      '过期的待办，不删就是在偷未来你的注意力。',
+    ] },
+    { name: '月光石阶', tag: '指引', keyword: '夜行 · 步步', quotes: [
+      '不必看清整个阶梯，先迈出眼前的这一步。',
+      '今日只问"下一小步是什么"，别的交给明天。',
+      '黑暗里走得稳的人，都不靠看清远方。',
+      '把大目标拆到 30 分钟以内，再开始动手。',
+    ] },
+  ],
+  'en-US': [
+    { name: 'Wheel of Fortune', tag: 'Chance', keyword: 'Flow · Rhythm', quotes: [
+      'Every commit bends the curve of fate — today is worth a push.',
+      'The gears spin themselves; you just press Enter at the right moment.',
+      'Today belongs to "start moving"; direction will reveal itself.',
+      'What blocked you yesterday often unblocks itself at a different hour.',
+    ] },
+    { name: 'Star Compass', tag: 'Hope', keyword: 'Distance · Inspiration', quotes: [
+      'When stuck, look beyond the documentation.',
+      'Zoom out one notch — the knot turns into a signpost.',
+      'Save one good article unrelated to today\'s project.',
+      'Trust that little side-project itch; it knows where to take you.',
+    ] },
+    { name: 'Heart of the Forge', tag: 'Forge', keyword: 'Refine · Refactor', quotes: [
+      'Today rewards a brave refactor — deletion is creation.',
+      'That code you swore you\'d fix "someday" — today is someday.',
+      'Stop patching; cast it back into the fire and reforge it.',
+      'Subtraction takes more courage than addition; today you have it.',
+    ] },
+    { name: 'Silent Bell', tag: 'Meditate', keyword: 'Reflect · Sink', quotes: [
+      'Pause your IDE for ten minutes — answers surface on the whiteboard.',
+      'Type less, think more. Your fingers will thank your brain.',
+      'Write the problem down and read it once — half the bugs reveal themselves.',
+      'Quiet is the most underrated productivity tool.',
+    ] },
+    { name: 'Galactic Codex', tag: 'Knowledge', keyword: 'Read · Compound', quotes: [
+      'Reading one long issue thread today beats writing ten lines of code.',
+      'Allow yourself an hour of source-reading — that\'s how the snowball starts.',
+      'That tab in your "read later" — finish it today.',
+      'A good RFC beats ten meetings.',
+    ] },
+    { name: 'Ruby Artisan', tag: 'Craft', keyword: 'Polish · Detail', quotes: [
+      'Thinking one edge case through clearly is today\'s best output.',
+      'Polish the detail you\'ve been calling "good enough".',
+      'Error messages are part of the product — write them like a human.',
+      'One small tweak often beats one full rewrite.',
+    ] },
+    { name: 'Bronze Serpent', tag: 'Shed', keyword: 'Loop · Renewal', quotes: [
+      'Fix one retry-loop and the whole pipeline comes back to life.',
+      'Let yourself have one "oh, that\'s why" moment today.',
+      'Today deserves a real cognitive refresh.',
+      'View that old problem from another angle — it shrinks.',
+    ] },
+    { name: 'Echo of Light', tag: 'Collab', keyword: 'Echo · Resonance', quotes: [
+      '"Let me take a look" is today\'s strongest buff.',
+      'Ping a stuck teammate — your 5 minutes may save their afternoon.',
+      'Answer a question someone once asked you; the echo travels far.',
+      'Thank someone who helped you — the more specific, the better.',
+    ] },
+    { name: 'Moss Whispers', tag: 'Rest', keyword: 'Grow · Whitespace', quotes: [
+      'Slow the progress bar, speed the imagination.',
+      'Today permits a little laziness — inspiration isn\'t on the keyboard.',
+      'Allow a day that "looks unproductive" — soil needs time to ferment.',
+      'Push the chair back; stand by the window for three minutes.',
+    ] },
+    { name: 'Astrolabe', tag: 'Decide', keyword: 'Direction · Resolve', quotes: [
+      'Stop agonizing over stack choices — write line one first.',
+      'Today is a good day to make that decision you\'ve been postponing.',
+      'A or B is fine — just stop choosing "wait a bit longer".',
+      'Write the options on paper; most choices unmask themselves.',
+    ] },
+    { name: 'Dusk Hearth', tag: 'Focus', keyword: 'Flow · Burn', quotes: [
+      'Close Slack — today belongs to you and your editor.',
+      'Put your most important task in the first slot of the morning.',
+      'Ninety unbroken minutes beat a whole day of fragments.',
+      'Let "Do Not Disturb" be today\'s gift to yourself.',
+    ] },
+    { name: 'Floating Ring', tag: 'Balance', keyword: 'Trade · Tension', quotes: [
+      'Between perfect and shipped, choose shipped.',
+      'Today is worth saying "no" to one thing.',
+      'Doing one thing less is harder than doing one thing more.',
+      'Halve the scope and the impact often doubles.',
+    ] },
+    { name: 'Mirror Lake', tag: 'Reflect', keyword: 'Reflect · Awareness', quotes: [
+      'Re-reading code from a week ago is more honest than any review.',
+      'Write a three-line retro today; tomorrow will use it.',
+      'Ask yourself: what am I most proud of this week?',
+      'Mistakes the past you made — today you may already be past them.',
+    ] },
+    { name: 'Forest Courier', tag: 'Message', keyword: 'Convey · Connect', quotes: [
+      'One clearly written email beats three meetings.',
+      'Sync progress proactively; let information run ahead.',
+      'Send the message you\'ve been drafting for three days — silence is the worst case.',
+      'A simple "let\'s align" saves a week of guessing.',
+    ] },
+    { name: 'Night Violin', tag: 'Poetic', keyword: 'Cadence · Grace', quotes: [
+      'Give a variable a beautiful name — naming is the programmer\'s poetry.',
+      'Today, write code you\'d show a friend.',
+      'Make functions read like sentences and modules cohere like paragraphs.',
+      'Use blank lines as naturally as breath.',
+    ] },
+    { name: 'Dawn Iron', tag: 'Courage', keyword: 'Face · Challenge', quotes: [
+      'Face the TODO you\'ve been skipping.',
+      'Put the hardest task first; the rest become easier.',
+      'Say the thing — late feedback is rude feedback.',
+      'Replace "after I learn it" with "learn while doing".',
+    ] },
+    { name: 'Aurora Veil', tag: 'Inspire', keyword: 'Burst · Flow', quotes: [
+      'Take a shower or a walk — most bugs wash away in running water.',
+      'Today\'s best ideas are off the keyboard; bring a notebook.',
+      'Let yourself leave the screen; inspiration catches up from behind.',
+      'Change where you code and your thinking changes too.',
+    ] },
+    { name: 'Feather Quill', tag: 'Record', keyword: 'Write · Settle', quotes: [
+      'Today is for writing a doc — future-you will be grateful.',
+      'Move tribal knowledge into the README.',
+      'Add one "why" to today\'s small decision; six months later it saves you.',
+      'Draw the picture in your head into the README; the team gets shared truth.',
+    ] },
+    { name: 'Tidal Ring', tag: 'Rhythm', keyword: 'Ebb · Cycle', quotes: [
+      'Both peaks and troughs are tides — don\'t blame yourself at low tide.',
+      'Today, follow your body; productivity has its own waterline.',
+      'You don\'t need to sprint every day; the best runners also walk.',
+      'Match low-energy hours with low-energy tasks — that\'s being smart.',
+    ] },
+    { name: 'Amethyst Chalice', tag: 'Bounty', keyword: 'Nourish · Gift', quotes: [
+      'Don\'t forget to drink water. Or to praise yourself.',
+      'Leave yourself a small reward today, even just a great coffee.',
+      'Eat well, then go back to debugging.',
+      'Be gentle with yourself today; the world will return the favor.',
+    ] },
+    { name: 'Golden Gear', tag: 'System', keyword: 'Mechanism · Architecture', quotes: [
+      'A clear module boundary beats ten clever hacks.',
+      'Today, draw an architecture diagram; make it real outside your head.',
+      'Before patching, ask who is talking to whom.',
+      'Invest in mechanism; the future repays with interest.',
+    ] },
+    { name: 'Dawn Wings', tag: 'Begin', keyword: 'Depart · First step', quotes: [
+      'Replace "when I\'m ready" with "open a draft PR".',
+      'Today is for starting a new repo — even just a README.',
+      '0 → 1 is always the hardest and most worthwhile step.',
+      'The moment you start, you\'re already ahead of yesterday.',
+    ] },
+    { name: 'Frost Star Blade', tag: 'Purge', keyword: 'Prune · Cleanse', quotes: [
+      'Today is for deleting outdated dependencies — less is more.',
+      'Sunset that feature no one has used in a year.',
+      'Inbox-zero once and your whole self feels lighter.',
+      'Stale TODOs steal future-you\'s attention; delete them.',
+    ] },
+    { name: 'Moonlit Steps', tag: 'Guide', keyword: 'Night walk · Step', quotes: [
+      'You don\'t need to see the whole staircase — just take the next step.',
+      'Today, only ask "what is the next small step"; leave the rest to tomorrow.',
+      'Those who walk steadily in the dark don\'t depend on seeing far.',
+      'Cut big goals into 30-minute slices, then begin.',
+    ] },
+  ],
+};
 
-const SUITS_GOOD = [
-  '重构一段陈年代码', '写一篇技术笔记', '认真做一次 Code Review', 'Pair programming',
-  '提一个 draft PR', '关闭通知专注 90 分钟', '用便签理清需求', '部署一次到测试环境',
-  '认真补单元测试', '把一个 TODO 注释清掉', '请同事喝一杯咖啡', '早一点下班，散步回家',
-  '给变量起个好听的名字', '更新依赖小版本', '阅读一份开源项目 README',
-];
+const FORTUNE_KEY_IDS = ['overall', 'work', 'inspire', 'wealth'];
 
-const SUITS_BAD = [
-  '周五傍晚发布到生产', '直接改 main 分支', 'git push --force', '跳过测试就合并',
-  'rm -rf 不看路径', '在没备份时改数据库', 'npm install -g 不看版本', '关掉 CI 通知',
-  '在情绪激动时回复评论', '把 try { ... } catch {} 留在 PR 里', '熬夜调一个一行就能改的 bug',
-];
+const SUITS_GOOD = {
+  'zh-CN': [
+    '重构一段陈年代码', '写一篇技术笔记', '认真做一次 Code Review', 'Pair programming 一小时',
+    '提一个 draft PR', '关闭通知专注 90 分钟', '用便签理清需求', '部署一次到测试环境',
+    '认真补单元测试', '把一个 TODO 注释清掉', '请同事喝一杯咖啡', '早一点下班，散步回家',
+    '给变量起个好听的名字', '更新依赖小版本', '阅读一份开源项目 README',
+    '把脑子里的草图画到白板上', '为某段代码加一段中文注释', '清空一次桌面文件夹',
+    '回顾上周的待办，删掉两条', '把一个老 issue 关掉', '写一段集成测试',
+    '把一个长函数拆成两个', '给项目加一行 logging', '主动同步一次进展',
+    '请教一个不熟悉领域的同事', '为新人写一份"如何上手"', '把一个 TODO 转成 issue',
+    '尝试一个新的快捷键', '把一段 if-else 改成查表', '把一个魔法数字提成常量',
+    '用纸笔思考十分钟', '尝试一种新的休息节奏', '在 commit message 里写"为什么"',
+    '回应一个搁置的 PR comment', '主动 1:1 一位同事', '为今天定一个最重要的目标',
+    '关掉两个长期不看的群', '为周报准备一段亮点', '把混乱的 imports 排好',
+    '为一个边界条件加一个测试', '抽一段时间彻底安静地思考', '感谢一个帮过你的人',
+  ],
+  'en-US': [
+    'Refactor an old piece of code', 'Write a tech note', 'Do a real code review', 'Pair-program for an hour',
+    'Open a draft PR', 'Mute notifications for 90 minutes', 'Lay out the requirements on sticky notes', 'Deploy once to staging',
+    'Backfill some unit tests', 'Resolve one TODO comment', 'Buy a teammate coffee', 'Leave a bit early and walk home',
+    'Pick a beautiful variable name', 'Bump a minor dependency', 'Read an open-source README',
+    'Move the sketch in your head onto a whiteboard', 'Add a doc comment to a tricky block', 'Clean your desktop folder',
+    'Drop two items from last week\'s todos', 'Close an old issue', 'Write one integration test',
+    'Split a long function into two', 'Add one logging line to the project', 'Sync your progress proactively',
+    'Ask an expert in an unfamiliar area', 'Write a "getting started" for newcomers', 'Turn a TODO into an issue',
+    'Try a new keyboard shortcut', 'Replace an if-else chain with a lookup', 'Hoist a magic number into a constant',
+    'Think with paper and pen for ten minutes', 'Try a new rest rhythm', 'Write the "why" in your commit message',
+    'Reply to a stalled PR comment', 'Schedule a 1:1 with a teammate', 'Pick the most important goal of the day',
+    'Mute two long-ignored chat rooms', 'Prep one highlight for the weekly report', 'Tidy up messy imports',
+    'Add a test for an edge case', 'Take a stretch of true quiet thought', 'Thank someone who helped you',
+  ],
+};
 
-const COLORS = [
-  { name: '靛青', hex: '#4f46e5' },
-  { name: '玫珀', hex: '#f472b6' },
-  { name: '湖蓝', hex: '#06b6d4' },
-  { name: '森绿', hex: '#10b981' },
-  { name: '橙金', hex: '#f59e0b' },
-  { name: '雾紫', hex: '#a78bfa' },
-  { name: '砖红', hex: '#ef4444' },
-  { name: '雪白', hex: '#f5f5f7' },
-  { name: '炭黑', hex: '#1f2937' },
-];
+const SUITS_BAD = {
+  'zh-CN': [
+    '周五傍晚发布到生产', '直接改 main 分支', 'git push --force', '跳过测试就合并',
+    'rm -rf 不看路径', '在没备份时改数据库', 'npm install -g 不看版本', '关掉 CI 通知',
+    '在情绪激动时回复评论', '把 try { ... } catch {} 留在 PR 里', '熬夜调一个一行就能改的 bug',
+    '在没看清需求时就动手', '为了赶进度跳过 code review', '同时开十个分支',
+    '在 PR 里夹带不相关的改动', '在饿肚子时做架构决定', '凌晨发线上变更',
+    '在 review 里只说"LGTM"不解释', '为一个细节争论超过 30 分钟', '把 hotfix 直接合到 main',
+    '把"以后再说"写进注释', '把 print 调试当作日志', '在不熟悉的代码里盲目加 try-catch',
+    '一边开会一边写关键代码', '同时承诺三件事都给同一天', '在没充分睡眠时上线',
+    '反复刷新 CI 当作 debug', '在情绪低谷时做职业决定', '在没看 docs 时就重写它',
+    '把 review 当作"挑毛病"',
+  ],
+  'en-US': [
+    'Ship to production on a Friday evening', 'Push straight to main', 'git push --force', 'Merge without running tests',
+    'rm -rf without checking the path', 'Touch the database without a backup', 'npm install -g without checking the version', 'Mute CI notifications',
+    'Reply to a heated comment while heated', 'Leave try { ... } catch {} in the PR', 'Stay up all night for a one-line bug',
+    'Start coding before reading the spec', 'Skip code review to "ship faster"', 'Open ten branches at once',
+    'Sneak unrelated changes into a PR', 'Make architecture decisions while hungry', 'Push a production change at midnight',
+    'Just say "LGTM" without explaining', 'Argue 30+ minutes over one detail', 'Merge a hotfix straight into main',
+    'Write "later" in a comment', 'Use print statements as your logs', 'Wrap unknown code in blind try-catch',
+    'Write critical code during a meeting', 'Promise three things due the same day', 'Deploy on too little sleep',
+    'Re-trigger CI as a debugging strategy', 'Make career decisions during a low mood', 'Rewrite something before reading its docs',
+    'Treat code review as nitpicking',
+  ],
+};
 
-const HOURS = ['上午 09:30 — 11:00', '下午 14:00 — 15:30', '下午 16:00 — 17:30', '夜晚 20:00 — 21:30', '深夜 22:00 — 23:30'];
+const COLORS = {
+  'zh-CN': [
+    { name: '靛青', hex: '#4f46e5' }, { name: '玫珀', hex: '#f472b6' }, { name: '湖蓝', hex: '#06b6d4' },
+    { name: '森绿', hex: '#10b981' }, { name: '橙金', hex: '#f59e0b' }, { name: '雾紫', hex: '#a78bfa' },
+    { name: '砖红', hex: '#ef4444' }, { name: '雪白', hex: '#f5f5f7' }, { name: '炭黑', hex: '#1f2937' },
+    { name: '茶褐', hex: '#92400e' }, { name: '青瓷', hex: '#5eead4' }, { name: '檀香', hex: '#c2956a' },
+    { name: '黛蓝', hex: '#3730a3' }, { name: '银灰', hex: '#94a3b8' }, { name: '苔绿', hex: '#65a30d' },
+    { name: '梅红', hex: '#be185d' },
+  ],
+  'en-US': [
+    { name: 'Indigo', hex: '#4f46e5' }, { name: 'Rose Amber', hex: '#f472b6' }, { name: 'Lake Blue', hex: '#06b6d4' },
+    { name: 'Forest Green', hex: '#10b981' }, { name: 'Amber Gold', hex: '#f59e0b' }, { name: 'Misty Violet', hex: '#a78bfa' },
+    { name: 'Brick Red', hex: '#ef4444' }, { name: 'Snow White', hex: '#f5f5f7' }, { name: 'Charcoal', hex: '#1f2937' },
+    { name: 'Tea Brown', hex: '#92400e' }, { name: 'Celadon', hex: '#5eead4' }, { name: 'Sandalwood', hex: '#c2956a' },
+    { name: 'Slate Blue', hex: '#3730a3' }, { name: 'Silver Gray', hex: '#94a3b8' }, { name: 'Moss Green', hex: '#65a30d' },
+    { name: 'Plum Red', hex: '#be185d' },
+  ],
+};
 
-const MANTRAS = [
-  'It compiles. Ship it.',
-  'Make it work, make it right, make it fast.',
-  'Done is better than perfect.',
-  '最好的代码，是不必写的代码。',
-  '一次只解决一个问题。',
-  '能跑起来，就先跑起来。',
-  '相信你的下一个 git commit。',
-  '今天的我，不评判过去的我。',
-];
+const HOURS = {
+  'zh-CN': [
+    '清晨 07:00 — 08:30', '上午 09:30 — 11:00', '上午 10:30 — 12:00',
+    '正午 12:00 — 13:00', '下午 14:00 — 15:30', '下午 15:30 — 17:00',
+    '黄昏 17:30 — 19:00', '夜晚 20:00 — 21:30', '夜晚 21:00 — 22:30',
+    '深夜 22:00 — 23:30', '深夜 23:00 — 00:30', '凌晨 05:30 — 07:00',
+  ],
+  'en-US': [
+    'Early morning 07:00 — 08:30', 'Morning 09:30 — 11:00', 'Late morning 10:30 — 12:00',
+    'Midday 12:00 — 13:00', 'Afternoon 14:00 — 15:30', 'Afternoon 15:30 — 17:00',
+    'Dusk 17:30 — 19:00', 'Evening 20:00 — 21:30', 'Evening 21:00 — 22:30',
+    'Late night 22:00 — 23:30', 'Late night 23:00 — 00:30', 'Pre-dawn 05:30 — 07:00',
+  ],
+};
+
+const MANTRAS = {
+  'zh-CN': [
+    'It compiles. Ship it.',
+    'Make it work, make it right, make it fast.',
+    'Done is better than perfect.',
+    'Premature optimization is the root of all evil.',
+    'Read the source, Luke.',
+    'Stay hungry, stay foolish.',
+    'Talk is cheap, show me the code.',
+    '最好的代码，是不必写的代码。',
+    '一次只解决一个问题。',
+    '能跑起来，就先跑起来。',
+    '相信你的下一个 git commit。',
+    '今天的我，不评判过去的我。',
+    '简单优于复杂，明确优于聪明。',
+    '宁可写两遍，也别错抽象一次。',
+    '写给人读的代码，顺便能在机器上跑。',
+    '今日少做一些，明天多走一些。',
+    '走得慢一点，但别停下来。',
+    '允许它先丑陋地工作，再优雅地工作。',
+    '名字取得好，bug 就少一半。',
+    '与其完美地做一件事，不如做完一件事。',
+    '别信"以后会重写"，但允许"现在能用"。',
+    '允许自己今天只做一件好事。',
+    '怀疑你的假设，不要怀疑你的价值。',
+    '今天打动你的，未必能打动半年后的你。',
+    '一切代码都是债，今天还一点。',
+    '先有反馈，再有完美。',
+    'Done > Perfect > Started > Nothing.',
+    '相信节奏，相信复利。',
+  ],
+  'en-US': [
+    'It compiles. Ship it.',
+    'Make it work, make it right, make it fast.',
+    'Done is better than perfect.',
+    'Premature optimization is the root of all evil.',
+    'Read the source, Luke.',
+    'Stay hungry, stay foolish.',
+    'Talk is cheap, show me the code.',
+    'The best code is the code you don\'t have to write.',
+    'Solve one problem at a time.',
+    'Get it running first; then get it right.',
+    'Trust your next git commit.',
+    'Today\'s me does not judge yesterday\'s me.',
+    'Simple beats complex; explicit beats clever.',
+    'Better write it twice than abstract it wrong once.',
+    'Write code humans read; the machine runs it as a bonus.',
+    'Do a little less today; walk a little further tomorrow.',
+    'Walk slowly, but don\'t stop.',
+    'Let it work ugly first; make it elegant later.',
+    'A great name halves the bugs.',
+    'Finishing one thing beats perfecting it.',
+    'Don\'t bet on "I\'ll rewrite later" — bet on "this works now".',
+    'Allow yourself one good thing today.',
+    'Question your assumptions, never your worth.',
+    'What moves you today may not move you in six months.',
+    'All code is debt — pay a little today.',
+    'Feedback first, perfection later.',
+    'Done > Perfect > Started > Nothing.',
+    'Trust rhythm; trust compounding.',
+  ],
+};
+
+const INSIGHTS = {
+  'zh-CN': [
+    '今日的注意力比时间更稀缺，请优先分配。',
+    '与其追求"今天做完什么"，不如确认"今天往哪走"。',
+    '碰到第三次的麻烦，就该把它封装成函数。',
+    '与其修十个小 bug，不如挖透一个根因。',
+    '一个干净的桌面，常常带来一个干净的思路。',
+    '把"我感觉"换成"我看到了"。',
+    '当方案太多时，说明问题没问对。',
+    '让别人少猜一次，团队就快一倍。',
+    '高频小同步，胜过偶尔大对齐。',
+    '当代码难写，往往是设计在求救。',
+    '今天的反馈循环越短，明天的不确定越少。',
+    '如果你想加一个特例，先想想是不是模型错了。',
+    '别只问"能不能做"，也问"该不该做"。',
+    '每一次 push，都是给未来的自己写信。',
+    '小决定靠习惯，大决定靠睡一觉。',
+    '一个稳定的工具链，胜过十个炫技。',
+    '把会议变小，把文档变好。',
+    '今日宜留 10% 的余力给意外。',
+    '当兴趣来敲门，请它进来坐 10 分钟。',
+    '观察一次自己的拖延，不评判，只记录。',
+    '把一段重复操作脚本化，未来你会笑出声。',
+    '该写测试时写测试，该睡觉时睡觉。',
+    '专注是种练习，今天又是一个 set。',
+    '当你想放弃，先去倒一杯水再说。',
+    '今天遇到的每一个 stack trace，都是免费的课。',
+    '不熟悉的领域，先复述一遍再动手。',
+    '当代码评审让你不舒服，多半击中了真问题。',
+    '把"难"拆成"先做哪一步"，难就开始消解。',
+    '允许自己今天只交付 60 分，明天再迭代。',
+    '相信复利，但别忘了今天就是利息。',
+  ],
+  'en-US': [
+    'Today, attention is scarcer than time — allocate it first.',
+    'Instead of "what to finish today", decide "which way to head today".',
+    'When trouble hits a third time, wrap it in a function.',
+    'Better to dig through one root cause than patch ten symptoms.',
+    'A clean desktop often brings a clean train of thought.',
+    'Replace "I feel" with "I saw".',
+    'Too many solutions usually means the wrong question.',
+    'When others have to guess less, the team moves twice as fast.',
+    'High-frequency small syncs beat occasional big alignments.',
+    'When code is hard to write, design is asking for help.',
+    'Shorter feedback loop today; less uncertainty tomorrow.',
+    'If you want to add a special case, ask if the model is wrong.',
+    'Don\'t just ask "can we do it" — also ask "should we".',
+    'Every push is a letter to your future self.',
+    'Small decisions ride habits; big decisions ride a good sleep.',
+    'One stable toolchain beats ten flashy tricks.',
+    'Make meetings smaller; make docs better.',
+    'Reserve 10% of today\'s capacity for surprises.',
+    'When curiosity knocks, let it sit for ten minutes.',
+    'Observe your procrastination once — no judgment, just notes.',
+    'Script a repetitive task; future-you will laugh out loud.',
+    'Write tests when you should; sleep when you should.',
+    'Focus is a practice; today is another set.',
+    'When you want to give up, pour a glass of water first.',
+    'Every stack trace today is a free lesson.',
+    'In unfamiliar territory, paraphrase first, code second.',
+    'When code review makes you uncomfortable, it usually struck a real issue.',
+    'Break "hard" into "what\'s the first step" — and hard starts dissolving.',
+    'Allow yourself a 60-point delivery today; iterate tomorrow.',
+    'Trust compounding — but remember: today is the interest payment.',
+  ],
+};
+
+const UI_I18N = {
+  'zh-CN': {
+    title: '每日占卜',
+    spreadAria: '今日牌阵',
+    fortuneMatrix: '运势矩阵',
+    todayGood: '今日宜',
+    todayBad: '今日忌',
+    omenTitle: '机缘提示',
+    luckyColor: '幸运色',
+    luckyNumber: '幸运数字',
+    luckyHour: '推荐时段',
+    mantra: '咒语',
+    copyText: '复制运势文本',
+    footerHint: '愿你今日的代码无 bug，commit 总能通过 review。',
+    greetingFresh: '凝神',
+    greetingDrawn: '今日卦象已立',
+    subtitleFresh: '轻触一张牌，揭开今日卦象',
+    subtitleDrawn: '抽一张牌以重温',
+    tipFresh: '每日卦象一旦显现便已注定 · 翌日 00:00 焕新',
+    tipDrawn: '卦象已注定 · 仪式仅供回味',
+    cardAriaLabel: (i) => `第 ${i} 张牌`,
+    todayInsightLabel: '◇ 今日洞察 ◇',
+    fortuneOverall: '综合', fortuneWork: '工作', fortuneInspire: '灵感', fortuneWealth: '财运',
+    dateFormat: ({ y, m, d }) => `${y} 年 ${m} 月 ${d} 日`,
+    shareCardLine: (name, keyword) => `【${name}】 ${keyword}`,
+    shareInsight: (text) => `今日洞察：${text}`,
+    shareGood: (list) => `今日宜：${list.join('、')}`,
+    shareBad: (list) => `今日忌：${list.join('、')}`,
+    shareLucky: (color, n, hour) => `幸运色：${color}　幸运数字：${n}　推荐时段：${hour}`,
+    shareMantra: (text) => `咒语：${text}`,
+    toastCopied: '已复制到剪贴板',
+    toastCopyFailed: '复制失败',
+  },
+  'en-US': {
+    title: 'Daily Divination',
+    spreadAria: 'Today\'s spread',
+    fortuneMatrix: 'Fortune matrix',
+    todayGood: 'Do',
+    todayBad: 'Don\'t',
+    omenTitle: 'Lucky omens',
+    luckyColor: 'Lucky color',
+    luckyNumber: 'Lucky number',
+    luckyHour: 'Best hours',
+    mantra: 'Mantra',
+    copyText: 'Copy reading',
+    footerHint: 'May your code be bug-free and your commits always pass review.',
+    greetingFresh: 'Center yourself',
+    greetingDrawn: 'Today\'s reading is set',
+    subtitleFresh: 'Tap a card to reveal today\'s fortune',
+    subtitleDrawn: 'Draw any card to revisit',
+    tipFresh: 'Today\'s fortune is fixed once revealed · refreshes at 00:00 tomorrow',
+    tipDrawn: 'The reading is set · the ritual is for reflection',
+    cardAriaLabel: (i) => `Card ${i}`,
+    todayInsightLabel: '◇ Today\'s Insight ◇',
+    fortuneOverall: 'Overall', fortuneWork: 'Work', fortuneInspire: 'Inspiration', fortuneWealth: 'Wealth',
+    dateFormat: ({ y, m, d }) => {
+      const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+      return `${months[Number(m) - 1]} ${Number(d)}, ${y}`;
+    },
+    shareCardLine: (name, keyword) => `[${name}] ${keyword}`,
+    shareInsight: (text) => `Insight: ${text}`,
+    shareGood: (list) => `Do: ${list.join(', ')}`,
+    shareBad: (list) => `Don't: ${list.join(', ')}`,
+    shareLucky: (color, n, hour) => `Lucky color: ${color}   Lucky number: ${n}   Best hours: ${hour}`,
+    shareMantra: (text) => `Mantra: ${text}`,
+    toastCopied: 'Copied to clipboard',
+    toastCopyFailed: 'Copy failed',
+  },
+};
+
+function currentLocale() {
+  return (window.app && window.app.locale) || 'en-US';
+}
+function ui(key) {
+  const lang = currentLocale();
+  const table = UI_I18N[lang] || UI_I18N['en-US'];
+  return table[key];
+}
+
+function getCards() {
+  const lang = currentLocale();
+  const strings = CARD_STRINGS[lang] || CARD_STRINGS['en-US'];
+  return strings.map((s, i) => ({ ...CARD_VISUALS[i], ...s }));
+}
+
+function getFortuneLabels() {
+  return [
+    { key: 'overall', label: ui('fortuneOverall') },
+    { key: 'work',    label: ui('fortuneWork') },
+    { key: 'inspire', label: ui('fortuneInspire') },
+    { key: 'wealth',  label: ui('fortuneWealth') },
+  ];
+}
 
 // ── Random utilities (seeded) ────────────────────────
 function dateKey(d = new Date()) {
@@ -124,49 +679,88 @@ function mulberry32(seed) {
   };
 }
 
-function pick(rand, arr) {
-  return arr[Math.floor(rand() * arr.length)];
+function pickIdx(rand, len) {
+  return Math.floor(rand() * len);
 }
 
-function pickN(rand, arr, n) {
-  const copy = arr.slice();
+function pickIndices(rand, len, n) {
+  // Sample `n` distinct indices in [0, len). Order matches the original
+  // `pickN(rand, arr, n)` so localized arrays of equal length yield matching
+  // selections across languages.
+  const pool = [];
+  for (let i = 0; i < len; i++) pool.push(i);
   const out = [];
-  for (let i = 0; i < n && copy.length > 0; i++) {
-    const idx = Math.floor(rand() * copy.length);
-    out.push(copy.splice(idx, 1)[0]);
+  for (let i = 0; i < n && pool.length > 0; i++) {
+    const idx = Math.floor(rand() * pool.length);
+    out.push(pool.splice(idx, 1)[0]);
   }
   return out;
 }
 
 // ── Fortune generation ───────────────────────────────
-function generateFortune(date) {
+// `generateFortune` returns INDICES + raw stars. Localization happens at render
+// time so changing language re-renders the same reading in another tongue.
+function generateFortuneIndices(date) {
   const seed = hashSeed('bitfun-divination-' + date);
   const rand = mulberry32(seed);
-  const card = CARDS[Math.floor(rand() * CARDS.length)];
 
-  // Each dimension 1..5 stars, biased towards 3-4.
-  const fortunes = FORTUNE_KEYS.map(({ key, label }) => {
+  const cardIdx = Math.floor(rand() * CARD_VISUALS.length);
+
+  const stars = FORTUNE_KEY_IDS.map(() => {
     const r = rand();
-    const stars = r < 0.06 ? 1 : r < 0.2 ? 2 : r < 0.55 ? 3 : r < 0.85 ? 4 : 5;
-    return { key, label, stars };
+    return r < 0.06 ? 1 : r < 0.2 ? 2 : r < 0.55 ? 3 : r < 0.85 ? 4 : 5;
   });
 
-  const goods = pickN(rand, SUITS_GOOD, 3);
-  const bads = pickN(rand, SUITS_BAD, 2);
-  const color = pick(rand, COLORS);
-  const luckyNumber = 1 + Math.floor(rand() * 99);
-  const hour = pick(rand, HOURS);
-  const mantra = pick(rand, MANTRAS);
+  // Quote index inside the chosen card. CARD_STRINGS for both locales must
+  // expose the same number of quotes per card, which is the case here.
+  const zhQuotes = CARD_STRINGS['zh-CN'][cardIdx].quotes;
+  const quoteIdx = Math.floor(rand() * zhQuotes.length);
 
-  return { card, fortunes, goods, bads, color, luckyNumber, hour, mantra };
+  const insightIdx = Math.floor(rand() * INSIGHTS['zh-CN'].length);
+  const goodIndices = pickIndices(rand, SUITS_GOOD['zh-CN'].length, 3);
+  const badIndices  = pickIndices(rand, SUITS_BAD['zh-CN'].length, 2);
+  const colorIdx = Math.floor(rand() * COLORS['zh-CN'].length);
+  const luckyNumber = 1 + Math.floor(rand() * 99);
+  const hourIdx = Math.floor(rand() * HOURS['zh-CN'].length);
+  const mantraIdx = Math.floor(rand() * MANTRAS['zh-CN'].length);
+
+  return { cardIdx, stars, quoteIdx, insightIdx, goodIndices, badIndices, colorIdx, luckyNumber, hourIdx, mantraIdx };
+}
+
+function localizeFortune(indices) {
+  const cards = getCards();
+  const card = cards[indices.cardIdx];
+  const lang = currentLocale();
+  const insights = INSIGHTS[lang] || INSIGHTS['en-US'];
+  const good = SUITS_GOOD[lang] || SUITS_GOOD['en-US'];
+  const bad = SUITS_BAD[lang] || SUITS_BAD['en-US'];
+  const colors = COLORS[lang] || COLORS['en-US'];
+  const hours = HOURS[lang] || HOURS['en-US'];
+  const mantras = MANTRAS[lang] || MANTRAS['en-US'];
+  const fortunes = getFortuneLabels().map((f, i) => ({ ...f, stars: indices.stars[i] }));
+  return {
+    card,
+    quote: card.quotes[indices.quoteIdx % card.quotes.length],
+    insight: insights[indices.insightIdx % insights.length],
+    fortunes,
+    goods: indices.goodIndices.map((i) => good[i % good.length]),
+    bads:  indices.badIndices.map((i) => bad[i % bad.length]),
+    color: colors[indices.colorIdx % colors.length],
+    luckyNumber: indices.luckyNumber,
+    hour: hours[indices.hourIdx % hours.length],
+    mantra: mantras[indices.mantraIdx % mantras.length],
+  };
 }
 
 // ── DOM ──────────────────────────────────────────────
 const dom = {
   dateLabel: document.getElementById('date-label'),
-  revealStage: document.getElementById('reveal-stage'),
+  drawStage: document.getElementById('draw-stage'),
   resultStage: document.getElementById('result-stage'),
-  cardBack: document.getElementById('card-back'),
+  cardSpread: document.getElementById('card-spread'),
+  greeting: document.getElementById('greeting'),
+  drawSubtitle: document.getElementById('draw-subtitle'),
+  drawTip: document.getElementById('draw-tip'),
   cardFront: document.getElementById('card-front'),
   cardIndex: document.getElementById('card-index'),
   cardTag: document.getElementById('card-tag'),
@@ -174,6 +768,7 @@ const dom = {
   cardName: document.getElementById('card-name'),
   cardKeyword: document.getElementById('card-keyword'),
   cardQuote: document.getElementById('card-quote'),
+  cardInsight: document.getElementById('card-insight'),
   fortunes: document.getElementById('fortunes'),
   suitGood: document.getElementById('suit-good'),
   suitBad: document.getElementById('suit-bad'),
@@ -186,61 +781,162 @@ const dom = {
   toast: document.getElementById('toast'),
 };
 
-let currentResult = null;
+// We keep the deterministic *indices* (computed from the date) plus whether the
+// reading was already drawn — so a locale change can simply re-render in place.
+let currentIndices = null;
+let currentDate = null;
+let currentDrawn = false;
 
 function fmtDate(date) {
   const [y, m, d] = date.split('-');
-  return `${y} 年 ${parseInt(m, 10)} 月 ${parseInt(d, 10)} 日`;
+  return ui('dateFormat')({ y, m: String(parseInt(m, 10)), d: String(parseInt(d, 10)) });
 }
+
+function applyStaticI18n() {
+  document.documentElement.setAttribute('lang', currentLocale());
+  document.querySelectorAll('[data-i18n]').forEach((node) => {
+    const key = node.getAttribute('data-i18n');
+    const attr = node.getAttribute('data-i18n-attr');
+    const value = ui(key);
+    if (typeof value !== 'string') return;
+    if (attr) node.setAttribute(attr, value);
+    else node.textContent = value;
+  });
+}
+
+// ── Card-back symbols (purely cosmetic; the actual fortune is fixed by date) ──
+const BACK_SYMBOLS = ['✦', '✶', '☾', '✧', '☄', '✺', '◌', '☼', '✤'];
 
 async function init() {
+  applyStaticI18n();
   const today = dateKey();
+  currentDate = today;
   dom.dateLabel.textContent = fmtDate(today);
+
   let saved = null;
   try { saved = await app.storage.get('lastReading'); } catch (_e) { /* ignore */ }
-  if (saved && saved.date === today) {
-    revealCard(today, true);
-  } else {
-    setupReveal(today);
+  currentDrawn = !!(saved && saved.date === today);
+  setupDraw(today, currentDrawn);
+
+  if (window.app && typeof window.app.onLocaleChange === 'function') {
+    window.app.onLocaleChange(() => {
+      applyStaticI18n();
+      if (currentDate) dom.dateLabel.textContent = fmtDate(currentDate);
+      // If the user hasn't picked yet, refresh draw labels.
+      if (!currentIndices) {
+        setupDraw(currentDate, currentDrawn);
+      } else {
+        // Otherwise re-render the result card in the new language.
+        paintResult(localizeFortune(currentIndices));
+      }
+    });
   }
 }
 
-function setupReveal(today) {
-  dom.revealStage.hidden = false;
+function setupDraw(today, alreadyDrawn) {
+  dom.drawStage.hidden = false;
   dom.resultStage.hidden = true;
-  const handler = () => revealCard(today, false);
-  dom.cardBack.addEventListener('click', handler, { once: true });
-  dom.cardBack.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); revealCard(today, false); }
-  }, { once: true });
+  dom.resultStage.classList.remove('is-active');
+  if (alreadyDrawn) {
+    dom.greeting.textContent = ui('greetingDrawn');
+    dom.drawSubtitle.textContent = ui('subtitleDrawn');
+    dom.drawTip.textContent = ui('tipDrawn');
+  } else {
+    dom.greeting.textContent = ui('greetingFresh');
+    dom.drawSubtitle.textContent = ui('subtitleFresh');
+    dom.drawTip.textContent = ui('tipFresh');
+  }
+
+  dom.cardSpread.innerHTML = '';
+  const seed = hashSeed('spread-' + today);
+  const rand = mulberry32(seed);
+  const symbols = BACK_SYMBOLS.slice();
+  for (let i = symbols.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [symbols[i], symbols[j]] = [symbols[j], symbols[i]];
+  }
+  const fan = symbols.slice(0, 5);
+  fan.forEach((sym, i) => {
+    const angle = (i - 2) * 8;
+    const lift = Math.abs(i - 2) * 14;
+    const card = document.createElement('div');
+    card.className = 'card-pick';
+    card.style.setProperty('--rot', angle + 'deg');
+    card.style.setProperty('--y', lift + 'px');
+    card.style.setProperty('--enter-delay', (i * 90) + 'ms');
+    card.style.zIndex = String(10 - Math.abs(i - 2));
+    card.tabIndex = 0;
+    card.setAttribute('role', 'button');
+    card.setAttribute('aria-label', ui('cardAriaLabel')(i + 1));
+    card.dataset.idx = String(i);
+    card.innerHTML = `
+      <div class="card-pick__pattern"></div>
+      <div class="card-pick__inner">
+        <div class="card-pick__symbol">${sym}</div>
+      </div>
+      <div class="card-pick__shine"></div>
+    `;
+    const handler = () => onPick(card, today, alreadyDrawn);
+    card.addEventListener('click', handler);
+    card.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handler(); }
+    });
+    dom.cardSpread.appendChild(card);
+  });
 }
 
-function revealCard(date, immediate) {
-  const fortune = generateFortune(date);
-  currentResult = { date, ...fortune };
-  if (!immediate) {
-    dom.cardBack.style.transition = 'transform .35s ease, opacity .35s ease';
-    dom.cardBack.style.transform = 'rotateY(90deg) scale(0.96)';
-    dom.cardBack.style.opacity = '0';
-    setTimeout(() => paintResult(fortune), 320);
-  } else {
-    paintResult(fortune);
+let pickInFlight = false;
+function onPick(chosen, today, alreadyDrawn) {
+  if (pickInFlight) return;
+  pickInFlight = true;
+  for (const card of dom.cardSpread.children) {
+    card.style.pointerEvents = 'none';
+    card.tabIndex = -1;
+    if (card !== chosen) card.classList.add('is-discarded');
   }
-  app.storage.set('lastReading', { date, cardName: fortune.card.name }).catch(() => {});
+  chosen.classList.add('is-chosen');
+  setTimeout(() => revealResult(today, alreadyDrawn), 760);
+}
+
+function revealResult(today, alreadyDrawn) {
+  currentIndices = generateFortuneIndices(today);
+  const fortune = localizeFortune(currentIndices);
+  paintResult(fortune);
+  dom.drawStage.hidden = true;
+  dom.resultStage.hidden = false;
+  // eslint-disable-next-line no-unused-expressions
+  dom.resultStage.offsetWidth;
+  dom.resultStage.classList.add('is-active');
+  if (!alreadyDrawn) {
+    app.storage.set('lastReading', { date: today, cardIdx: currentIndices.cardIdx }).catch(() => {});
+    currentDrawn = true;
+  }
+  pickInFlight = false;
 }
 
 function paintResult(f) {
-  dom.revealStage.hidden = true;
-  dom.resultStage.hidden = false;
   dom.btnShare.hidden = false;
 
-  const idx = CARDS.indexOf(f.card) + 1;
-  dom.cardIndex.textContent = `No. ${String(idx).padStart(2, '0')}`;
+  const idx = f.card._index = (CARD_VISUALS.indexOf({ symbol: f.card.symbol, tone: f.card.tone }) + 1) || 0;
+  // Use stable index from currentIndices instead — cleaner.
+  const stableIdx = (currentIndices ? currentIndices.cardIdx : 0) + 1;
+  dom.cardIndex.textContent = `No. ${String(stableIdx).padStart(2, '0')}`;
   dom.cardTag.textContent = f.card.tag;
   dom.cardArt.textContent = f.card.symbol;
   dom.cardName.textContent = f.card.name;
   dom.cardKeyword.textContent = f.card.keyword;
-  dom.cardQuote.textContent = `"${f.card.quote}"`;
+  dom.cardQuote.textContent = `"${f.quote}"`;
+  if (dom.cardInsight) {
+    dom.cardInsight.innerHTML = '';
+    const label = document.createElement('span');
+    label.className = 'card-front__insight-label';
+    label.textContent = ui('todayInsightLabel');
+    const text = document.createElement('span');
+    text.className = 'card-front__insight-text';
+    text.textContent = f.insight;
+    dom.cardInsight.appendChild(label);
+    dom.cardInsight.appendChild(text);
+  }
   dom.cardFront.style.setProperty('--card-tone-1', f.card.tone[0]);
   dom.cardFront.style.setProperty('--card-tone-2', f.card.tone[1]);
 
@@ -249,7 +945,7 @@ function paintResult(f) {
     const li = document.createElement('li');
     li.className = 'fortune';
     li.innerHTML = `
-      <span class="fortune__label">${item.label}</span>
+      <span class="fortune__label">${escapeHtml(item.label)}</span>
       <span class="fortune__bar"><span class="fortune__fill" style="width:0"></span></span>
       <span class="fortune__stars">${'★'.repeat(item.stars)}<span class="ghost">${'★'.repeat(5 - item.stars)}</span></span>
     `;
@@ -276,27 +972,28 @@ function escapeHtml(s) {
 }
 
 dom.btnShare.addEventListener('click', async () => {
-  if (!currentResult) return;
-  const f = currentResult;
+  if (!currentIndices) return;
+  const f = localizeFortune(currentIndices);
   const lines = [];
-  lines.push(`【${f.card.name}】 ${f.card.keyword}`);
-  lines.push(f.card.quote);
+  lines.push(ui('shareCardLine')(f.card.name, f.card.keyword));
+  lines.push(f.quote);
+  if (f.insight) lines.push(ui('shareInsight')(f.insight));
   lines.push('');
   for (const item of f.fortunes) {
-    lines.push(`${item.label}：${'★'.repeat(item.stars)}${'☆'.repeat(5 - item.stars)}`);
+    lines.push(`${item.label}: ${'★'.repeat(item.stars)}${'☆'.repeat(5 - item.stars)}`);
   }
   lines.push('');
-  lines.push(`今日宜：${f.goods.join('、')}`);
-  lines.push(`今日忌：${f.bads.join('、')}`);
+  lines.push(ui('shareGood')(f.goods));
+  lines.push(ui('shareBad')(f.bads));
   lines.push('');
-  lines.push(`幸运色：${f.color.name}　幸运数字：${f.luckyNumber}　推荐时段：${f.hour}`);
-  lines.push(`咒语：${f.mantra}`);
+  lines.push(ui('shareLucky')(f.color.name, f.luckyNumber, f.hour));
+  lines.push(ui('shareMantra')(f.mantra));
   const text = lines.join('\n');
   try {
     await app.clipboard.writeText(text);
-    showToast('已复制到剪贴板');
+    showToast(ui('toastCopied'));
   } catch (_e) {
-    showToast('复制失败');
+    showToast(ui('toastCopyFailed'));
   }
 });
 

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/index.html
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>五子棋</title>
+  <title data-i18n="title">五子棋</title>
 </head>
 <body>
   <div id="app" class="gomoku">
@@ -14,14 +14,14 @@
           <span class="brand__dot brand__dot--white"></span>
         </div>
         <div class="brand__text">
-          <h1 class="brand__title">五子棋</h1>
-          <p class="brand__subtitle">先连成五子者胜</p>
+          <h1 class="brand__title" data-i18n="title">五子棋</h1>
+          <p class="brand__subtitle" data-i18n="subtitle">先连成五子者胜</p>
         </div>
       </div>
       <div class="topbar__actions">
-        <div class="seg" id="mode-seg" role="tablist" aria-label="对战模式">
-          <button class="seg__btn" data-mode="pvp" type="button">双人对战</button>
-          <button class="seg__btn is-active" data-mode="pve" type="button">人机对弈</button>
+        <div class="seg" id="mode-seg" role="tablist" data-i18n-attr="aria-label" data-i18n="modeAria">
+          <button class="seg__btn" data-mode="pvp" type="button" data-i18n="modePvp">双人对战</button>
+          <button class="seg__btn is-active" data-mode="pve" type="button" data-i18n="modePve">人机对弈</button>
         </div>
       </div>
     </header>
@@ -29,13 +29,13 @@
     <main class="layout">
       <section class="board-wrap">
         <div class="board-frame">
-          <svg id="board" class="board" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg" aria-label="棋盘"></svg>
+          <svg id="board" class="board" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg" data-i18n-attr="aria-label" data-i18n="boardAria"></svg>
           <div id="result-overlay" class="result-overlay" hidden>
             <div class="result-card">
               <div class="result-card__icon" id="result-icon">★</div>
               <div class="result-card__title" id="result-title">黑棋胜</div>
               <div class="result-card__sub" id="result-sub">连成五子</div>
-              <button id="result-restart" class="btn btn--primary" type="button">再来一局</button>
+              <button id="result-restart" class="btn btn--primary" type="button" data-i18n="playAgain">再来一局</button>
             </div>
           </div>
         </div>
@@ -43,7 +43,7 @@
 
       <aside class="sidepanel">
         <div class="card turn-card">
-          <div class="card__label">当前回合</div>
+          <div class="card__label" data-i18n="currentTurn">当前回合</div>
           <div class="turn">
             <span class="turn__stone" id="turn-stone"></span>
             <span class="turn__name" id="turn-name">黑棋</span>
@@ -54,35 +54,35 @@
         <div class="card actions-card">
           <button id="btn-undo" class="btn btn--ghost" type="button">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8a5 5 0 1 0 5-5"/><path d="M3 3v5h5"/></svg>
-            悔棋
+            <span data-i18n="undo">悔棋</span>
           </button>
           <button id="btn-restart" class="btn btn--ghost" type="button">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="5"/><path d="M8 5v3l2 2"/></svg>
-            重新开始
+            <span data-i18n="restart">重新开始</span>
           </button>
         </div>
 
         <div class="card stats-card">
-          <div class="card__title">战绩</div>
+          <div class="card__title" data-i18n="record">战绩</div>
           <div class="stats">
             <div class="stat">
               <div class="stat__label">
                 <span class="stone stone--mini stone--black"></span>
-                黑棋胜
+                <span data-i18n="blackWins">黑棋胜</span>
               </div>
               <div class="stat__value" id="stat-black">0</div>
             </div>
             <div class="stat">
               <div class="stat__label">
                 <span class="stone stone--mini stone--white"></span>
-                白棋胜
+                <span data-i18n="whiteWins">白棋胜</span>
               </div>
               <div class="stat__value" id="stat-white">0</div>
             </div>
             <div class="stat" id="stat-pve-row" hidden>
               <div class="stat__label">
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="4" width="12" height="9" rx="2"/><circle cx="6" cy="8" r="0.8" fill="currentColor"/><circle cx="10" cy="8" r="0.8" fill="currentColor"/></svg>
-                AI 胜
+                <span data-i18n="aiWins">AI 胜</span>
               </div>
               <div class="stat__value" id="stat-ai">0</div>
             </div>
@@ -90,9 +90,9 @@
         </div>
 
         <div class="card history-card">
-          <div class="card__title">手数</div>
+          <div class="card__title" data-i18n="moves">手数</div>
           <div class="history" id="history">
-            <span class="history__empty">尚未落子</span>
+            <span class="history__empty" data-i18n="noMoves">尚未落子</span>
           </div>
         </div>
       </aside>

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/meta.json
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/meta.json
@@ -14,5 +14,19 @@
     "net": { "allow": [] },
     "node": { "enabled": true, "max_memory_mb": 128, "timeout_ms": 5000 }
   },
-  "ai_context": null
+  "ai_context": null,
+  "i18n": {
+    "locales": {
+      "zh-CN": {
+        "name": "五子棋",
+        "description": "经典 15×15 棋盘，支持双人对战与人机对弈，内置悔棋、重开与战绩统计。",
+        "tags": ["游戏", "策略", "内置"]
+      },
+      "en-US": {
+        "name": "Gomoku",
+        "description": "Classic 15×15 board with PvP and PvE modes, undo, restart and win/loss tracking.",
+        "tags": ["game", "strategy", "built-in"]
+      }
+    }
+  }
 }

--- a/src/crates/core/src/miniapp/builtin/assets/gomoku/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/gomoku/ui.js
@@ -1,6 +1,96 @@
 // Gomoku — built-in MiniApp.
 // Pure-frontend 15x15 Gomoku with PvP + simple PvE AI; persists win stats via app.storage.
 
+// ── i18n ──────────────────────────────────────────────
+// Static labels go through `applyStaticI18n()` (driven by data-i18n attrs in HTML).
+// Dynamic strings flow through `t(key)` and re-render on `app.onLocaleChange`.
+const I18N = {
+  'zh-CN': {
+    title: '五子棋',
+    subtitle: '先连成五子者胜',
+    modeAria: '对战模式',
+    modePvp: '双人对战',
+    modePve: '人机对弈',
+    boardAria: '棋盘',
+    currentTurn: '当前回合',
+    undo: '悔棋',
+    restart: '重新开始',
+    record: '战绩',
+    blackWins: '黑棋胜',
+    whiteWins: '白棋胜',
+    aiWins: 'AI 胜',
+    moves: '手数',
+    noMoves: '尚未落子',
+    playAgain: '再来一局',
+    turnBlack: '黑棋',
+    turnWhite: '白棋',
+    pveYouTurn: '你（黑棋）',
+    pveAiTurn: 'AI 思考中…',
+    pveYouHint: '点击棋盘任意交叉点落子',
+    pveWaitHint: '请稍候',
+    placeHint: '点击棋盘任意交叉点落子',
+    resultBlack: '黑棋胜',
+    resultWhite: '白棋胜',
+    resultLine: '连成五子',
+    pveYouWinTitle: '你赢了！',
+    pveYouWinSub: '稳如老 G',
+    pveAiWinTitle: 'AI 获胜',
+    pveAiWinSub: '再战一局，把场子赢回来',
+  },
+  'en-US': {
+    title: 'Gomoku',
+    subtitle: 'First to five in a row wins',
+    modeAria: 'Battle mode',
+    modePvp: 'PvP',
+    modePve: 'PvE',
+    boardAria: 'Board',
+    currentTurn: 'Current turn',
+    undo: 'Undo',
+    restart: 'Restart',
+    record: 'Record',
+    blackWins: 'Black wins',
+    whiteWins: 'White wins',
+    aiWins: 'AI wins',
+    moves: 'Moves',
+    noMoves: 'No moves yet',
+    playAgain: 'Play again',
+    turnBlack: 'Black',
+    turnWhite: 'White',
+    pveYouTurn: 'You (Black)',
+    pveAiTurn: 'AI is thinking…',
+    pveYouHint: 'Click any intersection to place a stone',
+    pveWaitHint: 'Please wait',
+    placeHint: 'Click any intersection to place a stone',
+    resultBlack: 'Black wins',
+    resultWhite: 'White wins',
+    resultLine: 'Five in a row',
+    pveYouWinTitle: 'You won!',
+    pveYouWinSub: 'Smooth play.',
+    pveAiWinTitle: 'AI wins',
+    pveAiWinSub: 'One more round — earn it back.',
+  },
+};
+
+function currentLocale() {
+  return (window.app && window.app.locale) || 'en-US';
+}
+
+function t(key) {
+  const lang = currentLocale();
+  return (I18N[lang] && I18N[lang][key]) || I18N['en-US'][key] || key;
+}
+
+function applyStaticI18n() {
+  document.documentElement.setAttribute('lang', currentLocale());
+  document.querySelectorAll('[data-i18n]').forEach((node) => {
+    const key = node.getAttribute('data-i18n');
+    const attr = node.getAttribute('data-i18n-attr');
+    const value = t(key);
+    if (attr) node.setAttribute(attr, value);
+    else node.textContent = value;
+  });
+}
+
 const SIZE = 15;
 const SVG_NS = 'http://www.w3.org/2000/svg';
 const VIEWBOX = 600;
@@ -56,6 +146,13 @@ async function init() {
   await loadStats();
   buildBoardSvg();
   bindEvents();
+  applyStaticI18n();
+  if (window.app && typeof window.app.onLocaleChange === 'function') {
+    window.app.onLocaleChange(() => {
+      applyStaticI18n();
+      render();
+    });
+  }
   render();
 }
 
@@ -391,17 +488,21 @@ function renderTurn() {
   const isWhite = state.current === WHITE;
   dom.turnStone.classList.toggle('is-white', isWhite);
   if (state.mode === 'pve') {
-    dom.turnName.textContent = isWhite ? 'AI 思考中…' : '你（黑棋）';
-    dom.turnHint.textContent = isWhite ? '请稍候' : '点击棋盘任意交叉点落子';
+    dom.turnName.textContent = isWhite ? t('pveAiTurn') : t('pveYouTurn');
+    dom.turnHint.textContent = isWhite ? t('pveWaitHint') : t('pveYouHint');
   } else {
-    dom.turnName.textContent = isWhite ? '白棋' : '黑棋';
-    dom.turnHint.textContent = '点击棋盘任意交叉点落子';
+    dom.turnName.textContent = isWhite ? t('turnWhite') : t('turnBlack');
+    dom.turnHint.textContent = t('placeHint');
   }
 }
 
 function renderHistory() {
   if (state.history.length === 0) {
-    dom.history.innerHTML = '<span class="history__empty">尚未落子</span>';
+    dom.history.innerHTML = '';
+    const span = document.createElement('span');
+    span.className = 'history__empty';
+    span.textContent = t('noMoves');
+    dom.history.appendChild(span);
     return;
   }
   dom.history.innerHTML = '';
@@ -434,11 +535,11 @@ function renderResult() {
   dom.resultOverlay.hidden = false;
   const isBlack = state.winner === BLACK;
   if (state.mode === 'pve') {
-    dom.resultTitle.textContent = isBlack ? '你赢了！' : 'AI 获胜';
-    dom.resultSub.textContent = isBlack ? '稳如老 G' : '再战一局，把场子赢回来';
+    dom.resultTitle.textContent = isBlack ? t('pveYouWinTitle') : t('pveAiWinTitle');
+    dom.resultSub.textContent = isBlack ? t('pveYouWinSub') : t('pveAiWinSub');
   } else {
-    dom.resultTitle.textContent = isBlack ? '黑棋胜' : '白棋胜';
-    dom.resultSub.textContent = '连成五子';
+    dom.resultTitle.textContent = isBlack ? t('resultBlack') : t('resultWhite');
+    dom.resultSub.textContent = t('resultLine');
   }
   dom.resultIcon.textContent = isBlack ? '●' : '○';
   dom.resultIcon.style.color = '';

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/index.html
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>正则游乐场</title>
+  <title data-i18n="title">正则游乐场</title>
 </head>
 <body>
   <div id="app" class="rx">
@@ -17,8 +17,8 @@
           </svg>
         </div>
         <div class="brand__text">
-          <h1 class="brand__title">正则游乐场</h1>
-          <p class="brand__subtitle">RegExp 实时调试 · ECMAScript 风格</p>
+          <h1 class="brand__title" data-i18n="title">正则游乐场</h1>
+          <p class="brand__subtitle" data-i18n="subtitle">RegExp 实时调试 · ECMAScript 风格</p>
         </div>
       </div>
       <div class="topbar__status">
@@ -41,12 +41,12 @@
             />
             <span class="slash">/</span>
             <div class="flags" id="flags">
-              <button type="button" class="flag" data-flag="g" title="全局匹配 (global)">g</button>
-              <button type="button" class="flag" data-flag="i" title="忽略大小写 (ignore case)">i</button>
-              <button type="button" class="flag" data-flag="m" title="多行模式 (multiline)">m</button>
-              <button type="button" class="flag" data-flag="s" title="dotAll · . 匹配换行">s</button>
-              <button type="button" class="flag" data-flag="u" title="Unicode 模式">u</button>
-              <button type="button" class="flag" data-flag="y" title="粘连匹配 (sticky)">y</button>
+              <button type="button" class="flag" data-flag="g" data-i18n-attr="title" data-i18n="flagG">g</button>
+              <button type="button" class="flag" data-flag="i" data-i18n-attr="title" data-i18n="flagI">i</button>
+              <button type="button" class="flag" data-flag="m" data-i18n-attr="title" data-i18n="flagM">m</button>
+              <button type="button" class="flag" data-flag="s" data-i18n-attr="title" data-i18n="flagS">s</button>
+              <button type="button" class="flag" data-flag="u" data-i18n-attr="title" data-i18n="flagU">u</button>
+              <button type="button" class="flag" data-flag="y" data-i18n-attr="title" data-i18n="flagY">y</button>
             </div>
           </div>
           <div class="pattern-error" id="pattern-error" hidden></div>
@@ -56,72 +56,64 @@
           <div class="test-card__header">
             <div class="card__title">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="3" width="12" height="10" rx="1"/><path d="M4 7h8M4 10h5"/></svg>
-              测试文本
+              <span data-i18n="testText">测试文本</span>
             </div>
             <div class="test-card__actions">
               <span class="match-count" id="match-count">0 处匹配</span>
-              <button id="btn-clear" class="link-btn" type="button" title="清空">
+              <button id="btn-clear" class="link-btn" type="button" data-i18n-attr="title" data-i18n="clear">
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4l1 9h4l1-9"/></svg>
-                清空
+                <span data-i18n="clear">清空</span>
               </button>
             </div>
           </div>
           <div class="editor">
             <textarea id="test-text" spellcheck="false" autocomplete="off" autocorrect="off"
-              placeholder="把要匹配的文本粘贴到这里…"></textarea>
+              data-i18n-attr="placeholder" data-i18n="testPlaceholder" placeholder="把要匹配的文本粘贴到这里…"></textarea>
             <pre id="highlight" class="highlight" aria-hidden="true"></pre>
           </div>
         </div>
 
         <div class="card matches-card">
           <div class="matches-card__header">
-            <div class="card__title" style="margin: 0;">
+            <div class="card__title matches-card__title">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M2 8l3 3 9-9"/></svg>
-              匹配明细
+              <span data-i18n="matchesTitle">匹配明细</span>
               <span class="hint" id="matches-summary">尚未匹配</span>
             </div>
             <div class="matches-card__actions">
-              <button id="btn-prev-match" class="link-btn" type="button" title="上一处" disabled>
+              <button id="btn-prev-match" class="link-btn" type="button" data-i18n-attr="title" data-i18n="prevMatch" disabled>
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3l-5 5 5 5"/></svg>
               </button>
-              <button id="btn-next-match" class="link-btn" type="button" title="下一处" disabled>
+              <button id="btn-next-match" class="link-btn" type="button" data-i18n-attr="title" data-i18n="nextMatch" disabled>
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3l5 5-5 5"/></svg>
               </button>
             </div>
           </div>
           <div class="matches" id="matches">
-            <div class="empty">输入正则与文本，匹配结果将在这里展示。</div>
+            <div class="empty" data-i18n="matchesEmpty">输入正则与文本，匹配结果将在这里展示。</div>
           </div>
         </div>
 
         <div class="card replace-card">
           <div class="card__title">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M4 4h6a3 3 0 010 6H7"/><path d="M9 8L7 10l2 2"/></svg>
-            替换预览
-            <span class="hint">支持 $1 $2 $&lt;name&gt; 反向引用</span>
+            <span data-i18n="replaceTitle">替换预览</span>
+            <span class="hint" data-i18n="replaceHint">支持 $1 $2 $&lt;name&gt; 反向引用</span>
           </div>
-          <input id="replace-input" type="text" class="replace-input" placeholder="替换为…（留空则不展示预览）" spellcheck="false" autocomplete="off"/>
+          <input id="replace-input" type="text" class="replace-input" data-i18n-attr="placeholder" data-i18n="replacePlaceholder" placeholder="替换为…（留空则不展示预览）" spellcheck="false" autocomplete="off"/>
           <pre id="replace-output" class="replace-output" hidden></pre>
         </div>
       </section>
 
       <aside class="side-col">
         <div class="card library-card">
-          <div class="card__title">常用模式</div>
+          <div class="card__title" data-i18n="library">常用模式</div>
           <div class="library" id="library"></div>
         </div>
 
         <div class="card ref-card">
-          <div class="card__title">速查</div>
-          <ul class="ref">
-            <li><code>\d</code> 数字 · <code>\D</code> 非数字</li>
-            <li><code>\w</code> 字母数字下划线 · <code>\W</code> 反之</li>
-            <li><code>\s</code> 空白 · <code>\S</code> 非空白</li>
-            <li><code>^ $</code> 行首/行尾（配合 m）</li>
-            <li><code>(?:…)</code> 非捕获 · <code>(?&lt;n&gt;…)</code> 命名捕获</li>
-            <li><code>(?=…)</code> 正向先行 · <code>(?!…)</code> 反向先行</li>
-            <li><code>{n,m}</code> 区间量词 · <code>?</code> 非贪婪</li>
-          </ul>
+          <div class="card__title" data-i18n="cheatsheet">速查</div>
+          <ul class="ref" id="ref-list"></ul>
         </div>
       </aside>
     </main>

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/meta.json
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/meta.json
@@ -14,5 +14,19 @@
     "net": { "allow": [] },
     "node": { "enabled": true, "max_memory_mb": 128, "timeout_ms": 5000 }
   },
-  "ai_context": null
+  "ai_context": null,
+  "i18n": {
+    "locales": {
+      "zh-CN": {
+        "name": "正则游乐场",
+        "description": "实时高亮匹配、捕获组明细、替换预览，内置常用模式速取库（邮箱 / URL / IP / UUID 等）。",
+        "tags": ["正则", "工具", "开发", "内置"]
+      },
+      "en-US": {
+        "name": "Regex Playground",
+        "description": "Live match highlighting, capture-group details, replacement preview, and a built-in library of common patterns (email / URL / IP / UUID, …).",
+        "tags": ["regex", "tool", "developer", "built-in"]
+      }
+    }
+  }
 }

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/style.css
@@ -1,195 +1,236 @@
-/* Regex Playground — IDE / terminal theme.
- * Palette inspired by Tokyo-Night-ish editor: deep ink, indigo blue,
- * pastel green/orange/pink/purple as syntax accents.
- * Type: monospace first; sans only for very small UI labels.
+/* Regex Playground — developer-tool theme.
+ * Design system reference:
+ *   palette  ─ "Code dark + run green"  (#0F172A / #1E293B / #334155 / #22C55E / #F8FAFC)
+ *   type     ─ JetBrains Mono (code) + IBM Plex Sans (UI), system fallbacks
+ *   pattern  ─ bento-style cards on a calm dark surface
+ *   motion   ─ 150-300ms color-shift micro-interactions, no scale jumps
  */
+
+/* Note: mini-app sandbox has net.allow: [], so we don't @import remote fonts.
+ * Rely on the system mono / sans stack — on macOS this resolves to SF Mono / SF Pro,
+ * on Windows to Cascadia / Segoe UI, on Linux to system defaults. */
 
 *, *::before, *::after { box-sizing: border-box; }
 body, html { margin: 0; padding: 0; height: 100%; }
 [hidden] { display: none !important; }
 
 :root {
-  --rx-bg: #0d1117;
-  --rx-bg-2: #11161f;
-  --rx-panel: #151b27;
-  --rx-panel-2: #1a2030;
-  --rx-line: #1f2733;
-  --rx-line-bright: #2c3548;
-  --rx-text: #c0caf5;
-  --rx-text-soft: #a9b1d6;
-  --rx-text-mute: #565f89;
-  --rx-blue: #7aa2f7;
-  --rx-cyan: #7dcfff;
-  --rx-green: #9ece6a;
-  --rx-orange: #e0af68;
-  --rx-pink: #f7768e;
-  --rx-purple: #bb9af7;
-  --rx-mono: var(--bitfun-font-mono, ui-monospace, "JetBrains Mono", "Fira Code",
-              "SFMono-Regular", Menlo, "Cascadia Code", Consolas, monospace);
-  --rx-sans: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+  --rx-bg: #0a0f1a;
+  --rx-bg-2: #0e1422;
+  --rx-surface: #131a2a;
+  --rx-surface-2: #1a2236;
+  --rx-surface-3: #222b42;
+  --rx-border: #1e2638;
+  --rx-border-strong: #2c3852;
+  --rx-border-bright: #3b4866;
+
+  --rx-text: #f1f5f9;
+  --rx-text-soft: #c8d1e0;
+  --rx-text-mute: #7e8aa3;
+  --rx-text-dim: #5b6680;
+
+  --rx-accent: #22c55e;          /* "run green" — primary */
+  --rx-accent-soft: rgba(34,197,94,0.14);
+  --rx-accent-strong: #4ade80;
+  --rx-match: #f59e0b;            /* warm match highlight */
+  --rx-match-soft: rgba(245,158,11,0.18);
+  --rx-error: #ef4444;
+  --rx-info: #38bdf8;
+  --rx-group: #c4a8ff;
+  --rx-string: #86efac;
+
+  --rx-radius: 10px;
+  --rx-radius-sm: 6px;
+  --rx-shadow-card: 0 1px 0 rgba(255,255,255,0.025) inset, 0 4px 14px -8px rgba(0,0,0,0.55);
+  --rx-shadow-elevated: 0 1px 0 rgba(255,255,255,0.035) inset, 0 16px 32px -18px rgba(0,0,0,0.7);
+
+  --rx-mono: var(--bitfun-font-mono, ui-monospace, "SFMono-Regular", "JetBrains Mono",
+              Menlo, "Cascadia Code", Consolas, "Liberation Mono", monospace);
+  --rx-sans: var(--bitfun-font-sans, -apple-system, BlinkMacSystemFont, "SF Pro Text",
+              "Segoe UI", "PingFang SC", "Microsoft YaHei", "Helvetica Neue", sans-serif);
+
+  --rx-dur: 200ms;
+  --rx-ease: cubic-bezier(.2,.8,.2,1);
 }
 
 body {
-  font-family: var(--rx-mono);
+  font-family: var(--rx-sans);
   font-size: 13px;
   color: var(--rx-text);
   background: var(--rx-bg);
-  overflow: hidden;
 }
-button, input, textarea { font-family: inherit; }
+button, input, textarea, select { font-family: inherit; color: inherit; }
 
 .rx {
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   background:
-    linear-gradient(180deg, #0e141d 0%, var(--rx-bg) 100%);
+    radial-gradient(1000px 500px at 90% -10%, rgba(34,197,94,0.06), transparent 60%),
+    radial-gradient(900px 500px at -10% 110%, rgba(56,189,248,0.04), transparent 55%),
+    var(--rx-bg);
 }
 
-/* ── Top bar — IDE titlebar ──────────────────────────── */
+/* ── Topbar ─────────────────────────────────────────── */
 .topbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 9px 16px;
-  border-bottom: 1px solid var(--rx-line);
-  background: var(--rx-bg-2);
-  font-family: var(--rx-mono);
+  padding: 11px 18px;
+  border-bottom: 1px solid var(--rx-border);
+  background: rgba(10,15,26,0.80);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
-.brand { display: flex; align-items: center; gap: 12px; }
+.brand { display: flex; align-items: center; gap: 12px; min-width: 0; }
 .brand__icon {
-  width: 28px; height: 28px;
-  border-radius: 6px;
-  background: linear-gradient(135deg, rgba(122,162,247,0.18), rgba(187,154,247,0.10));
-  border: 1px solid var(--rx-line-bright);
-  display: flex; align-items: center; justify-content: center;
-  color: var(--rx-blue);
+  width: 32px; height: 32px;
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(34,197,94,0.20), rgba(56,189,248,0.10));
+  border: 1px solid rgba(34,197,94,0.32);
+  display: grid; place-items: center;
+  color: var(--rx-accent-strong);
+  box-shadow: 0 4px 14px rgba(34,197,94,0.18);
+  flex-shrink: 0;
 }
+.brand__text { min-width: 0; }
 .brand__title {
   margin: 0;
-  font-family: var(--rx-mono);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--rx-text);
-  letter-spacing: 0;
-}
-.brand__title::before {
-  content: '~/';
-  color: var(--rx-text-mute);
-  font-weight: 400;
-  margin-right: 2px;
+  letter-spacing: 0.1px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .brand__subtitle {
-  margin: 1px 0 0;
+  margin: 2px 0 0;
   font-family: var(--rx-mono);
-  font-size: 11px;
+  font-size: 11.5px;
   color: var(--rx-text-mute);
-}
-.brand__subtitle::before {
-  content: '// ';
-  color: var(--rx-green);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-/* IDE-style status pill */
 .status {
   font-family: var(--rx-mono);
   font-size: 11px;
-  padding: 4px 10px;
-  border-radius: 4px;
-  background: var(--rx-panel);
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: var(--rx-surface);
   color: var(--rx-text-soft);
-  border: 1px solid var(--rx-line-bright);
+  border: 1px solid var(--rx-border-strong);
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   letter-spacing: 0.3px;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 .status::before {
-  content: ''; width: 6px; height: 6px; border-radius: 50%; background: currentColor;
-  box-shadow: 0 0 6px currentColor;
+  content: '';
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 8px currentColor;
 }
-.status--ok { color: var(--rx-green); border-color: rgba(158,206,106,0.35); }
-.status--err { color: var(--rx-pink); border-color: rgba(247,118,142,0.35); background: rgba(247,118,142,0.06); }
-.status--idle { color: var(--rx-text-mute); }
+.status--ok   { color: var(--rx-accent-strong); border-color: rgba(74,222,128,0.40); }
+.status--err  { color: var(--rx-error); border-color: rgba(239,68,68,0.40); background: rgba(239,68,68,0.08); }
+.status--idle { color: var(--rx-text-dim); }
 
-/* ── Layout ──────────────────────────────────────────── */
+/* ── Layout ─────────────────────────────────────────── */
+/* Wide: two columns, each independently scrollable, app fits viewport. */
 .layout {
   flex: 1;
   display: grid;
-  grid-template-columns: 1fr 320px;
+  grid-template-columns: minmax(0, 1fr) 320px;
   gap: 14px;
-  padding: 14px 16px;
+  padding: 14px 16px 16px;
   min-height: 0;
-  overflow: hidden;
 }
-.main-col, .side-col {
+.main-col {
+  display: grid;
+  /* pattern (auto) │ test (auto, fixed editor) │ matches (1fr — absorbs slack) │ replace (auto) */
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: 12px;
+  min-height: 0;
+  min-width: 0;
+}
+.side-col {
   display: flex;
   flex-direction: column;
   gap: 12px;
   min-height: 0;
+  overflow-y: auto;
+  padding-right: 2px;
 }
-.side-col { overflow-y: auto; }
-.main-col { min-width: 0; }
 
-/* ── Card ────────────────────────────────────────────── */
+/* ── Card ───────────────────────────────────────────── */
 .card {
-  background: var(--rx-panel);
-  border: 1px solid var(--rx-line);
-  border-radius: 6px;
-  padding: 12px 14px;
+  background: var(--rx-surface);
+  border: 1px solid var(--rx-border-strong);
+  border-radius: var(--rx-radius);
+  padding: 14px 16px;
+  box-shadow: var(--rx-shadow-card);
+  min-width: 0;
 }
 .card__title {
-  display: flex; align-items: center; gap: 8px;
-  font-family: var(--rx-mono);
-  font-size: 11.5px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--rx-sans);
+  font-size: 12px;
   color: var(--rx-text-soft);
-  margin-bottom: 10px;
-  font-weight: 500;
-  letter-spacing: 0.3px;
-  text-transform: lowercase;
+  margin: 0 0 11px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
 }
-.card__title svg { color: var(--rx-blue); }
+.card__title svg { color: var(--rx-accent-strong); flex-shrink: 0; }
 .hint {
   margin-left: auto;
   font-family: var(--rx-mono);
-  font-size: 10.5px;
+  font-size: 11px;
   color: var(--rx-text-mute);
   font-weight: 400;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
-/* ── Pattern row — looks like an interactive REPL line */
-.pattern-card { padding: 10px 12px; }
+/* ── Pattern card ───────────────────────────────────── */
+.pattern-card { padding: 12px 14px; }
 .pattern-row {
   display: flex;
   align-items: center;
-  gap: 6px;
-  background: var(--rx-bg);
-  border: 1px solid var(--rx-line-bright);
-  border-radius: 5px;
-  padding: 6px 10px 6px 12px;
-  transition: border-color .15s ease, box-shadow .15s ease;
-  position: relative;
-}
-.pattern-row::before {
-  content: '$';
-  color: var(--rx-green);
-  font-family: var(--rx-mono);
-  font-size: 13px;
-  margin-right: 4px;
-  user-select: none;
+  gap: 8px;
+  background: var(--rx-bg-2);
+  border: 1px solid var(--rx-border-strong);
+  border-radius: var(--rx-radius-sm);
+  padding: 6px 10px;
+  transition: border-color var(--rx-dur) var(--rx-ease),
+              box-shadow var(--rx-dur) var(--rx-ease);
 }
 .pattern-row:focus-within {
-  border-color: var(--rx-blue);
-  box-shadow: 0 0 0 3px rgba(122,162,247,0.18);
+  border-color: var(--rx-accent);
+  box-shadow: 0 0 0 3px rgba(34,197,94,0.18);
 }
 .slash {
-  color: var(--rx-orange);
+  color: var(--rx-match);
   font-family: var(--rx-mono);
-  font-size: 15px;
+  font-size: 16px;
+  font-weight: 500;
   user-select: none;
 }
 .pattern-input {
   flex: 1;
+  min-width: 0;
   background: transparent;
   border: 0;
   outline: none;
@@ -197,80 +238,109 @@ button, input, textarea { font-family: inherit; }
   font-family: var(--rx-mono);
   font-size: 14px;
   padding: 6px 0;
-  caret-color: var(--rx-blue);
+  caret-color: var(--rx-accent);
 }
-.pattern-input::placeholder { color: var(--rx-text-mute); }
-.flags { display: flex; gap: 3px; }
+.pattern-input::placeholder { color: var(--rx-text-dim); }
+.flags { display: flex; gap: 4px; flex-shrink: 0; }
 .flag {
-  width: 24px; height: 24px;
-  border-radius: 4px;
-  border: 1px solid var(--rx-line-bright);
-  background: var(--rx-bg-2);
+  min-width: 26px; height: 26px;
+  padding: 0 8px;
+  border-radius: 5px;
+  border: 1px solid var(--rx-border-strong);
+  background: var(--rx-surface-2);
   color: var(--rx-text-mute);
   font-family: var(--rx-mono);
   font-size: 12px;
-  display: inline-flex; align-items: center; justify-content: center;
-  transition: all .12s ease;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: color var(--rx-dur) var(--rx-ease),
+              border-color var(--rx-dur) var(--rx-ease),
+              background-color var(--rx-dur) var(--rx-ease);
 }
-.flag:hover { color: var(--rx-text-soft); border-color: var(--rx-blue); }
+.flag:hover { color: var(--rx-text-soft); border-color: var(--rx-border-bright); }
 .flag.is-active {
-  background: rgba(122,162,247,0.18);
-  color: var(--rx-blue);
-  border-color: rgba(122,162,247,0.55);
-  box-shadow: 0 0 8px rgba(122,162,247,0.20);
+  background: rgba(34,197,94,0.14);
+  color: var(--rx-accent-strong);
+  border-color: rgba(34,197,94,0.55);
 }
 .pattern-error {
   margin-top: 8px;
   font-family: var(--rx-mono);
-  font-size: 11px;
-  color: var(--rx-pink);
-  padding: 6px 10px;
-  background: rgba(247,118,142,0.06);
-  border-left: 2px solid var(--rx-pink);
+  font-size: 11.5px;
+  color: var(--rx-error);
+  padding: 8px 12px;
+  background: rgba(239,68,68,0.08);
+  border-left: 2px solid var(--rx-error);
   border-radius: 0 4px 4px 0;
 }
 
-/* ── Test editor — looks like editor panel ───────────── */
-.test-card { display: flex; flex-direction: column; min-height: 0; flex: 1; }
-.test-card__header {
-  display: flex; align-items: center; justify-content: space-between;
+/* ── Test editor ────────────────────────────────────── */
+.test-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
-.test-card__actions { display: flex; align-items: center; gap: 10px; }
+.test-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  gap: 10px;
+}
+.test-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
 .match-count {
   font-family: var(--rx-mono);
   font-size: 11px;
   color: var(--rx-text-mute);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 .link-btn {
-  background: var(--rx-bg-2);
-  border: 1px solid var(--rx-line-bright);
+  background: var(--rx-surface-2);
+  border: 1px solid var(--rx-border-strong);
   color: var(--rx-text-soft);
-  padding: 4px 9px;
-  border-radius: 4px;
-  font-family: var(--rx-mono);
-  font-size: 11px;
-  display: inline-flex; align-items: center; gap: 5px;
-  transition: all .15s ease;
+  padding: 5px 10px;
+  border-radius: 5px;
+  font-family: var(--rx-sans);
+  font-size: 11.5px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+  transition: color var(--rx-dur) var(--rx-ease),
+              border-color var(--rx-dur) var(--rx-ease),
+              background-color var(--rx-dur) var(--rx-ease);
 }
-.link-btn:hover { color: var(--rx-text); border-color: var(--rx-blue); }
+.link-btn:hover { color: var(--rx-text); border-color: var(--rx-border-bright); }
+.link-btn:focus-visible { outline: 2px solid var(--rx-accent); outline-offset: 1px; }
+.link-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 
 .editor {
   position: relative;
-  flex: 1;
-  min-height: 200px;
-  border: 1px solid var(--rx-line-bright);
-  border-radius: 5px;
+  /* Bounded editor — never dominates the screen, never shifts when match count changes. */
+  height: clamp(160px, 22vh, 240px);
+  flex: 0 0 auto;
+  border: 1px solid var(--rx-border-strong);
+  border-radius: 6px;
   overflow: hidden;
-  background: var(--rx-bg);
+  background: var(--rx-bg-2);
 }
 .editor textarea, .editor .highlight {
-  position: absolute; inset: 0;
+  position: absolute;
+  inset: 0;
   width: 100%; height: 100%;
   padding: 12px 14px;
   font-family: var(--rx-mono);
   font-size: 13px;
-  line-height: 1.6;
+  line-height: 1.65;
   white-space: pre-wrap;
   word-break: break-word;
   border: 0;
@@ -281,7 +351,7 @@ button, input, textarea { font-family: inherit; }
 .editor textarea {
   background: transparent;
   color: var(--rx-text);
-  caret-color: var(--rx-blue);
+  caret-color: var(--rx-accent);
   resize: none;
   outline: none;
   z-index: 2;
@@ -292,43 +362,184 @@ button, input, textarea { font-family: inherit; }
   z-index: 1;
 }
 .editor .highlight mark {
-  background: rgba(224,175,104,0.22);
+  background: var(--rx-match-soft);
   color: transparent;
   border-radius: 2px;
   padding: 1px 0;
-  box-shadow: 0 0 0 1px rgba(224,175,104,0.55);
+  box-shadow: 0 0 0 1px rgba(245,158,11,0.55);
 }
 .editor .highlight mark.is-active {
-  background: rgba(122,162,247,0.32);
-  box-shadow: 0 0 0 1px var(--rx-blue), 0 0 8px rgba(122,162,247,0.45);
+  background: rgba(34,197,94,0.30);
+  box-shadow: 0 0 0 1px var(--rx-accent), 0 0 8px rgba(34,197,94,0.45);
 }
 
-/* ── Replace ─────────────────────────────────────────── */
+/* ── Matches list — git-grep / rg style ─────────────── */
+.matches-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  padding: 12px 14px;
+}
+.matches-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  gap: 10px;
+}
+.matches-card__title {
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+}
+.matches-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.matches-card__actions .link-btn { padding: 4px 8px; }
+
+.matches {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  /* 宽屏下 matches-card 是 1fr，本列表 flex:1 填满；min-height:0 才能让 overflow 生效 */
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+.matches:empty { display: none; }
+.empty {
+  color: var(--rx-text-dim);
+  font-family: var(--rx-mono);
+  font-size: 11.5px;
+  padding: 18px 6px;
+  text-align: center;
+}
+
+.match {
+  display: grid;
+  /* idx | line:col | text | groups badge */
+  grid-template-columns: 36px 64px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px 7px 0;
+  background: var(--rx-bg-2);
+  border: 1px solid var(--rx-border);
+  border-left: 3px solid var(--rx-border-strong);
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background-color var(--rx-dur) var(--rx-ease),
+              border-color var(--rx-dur) var(--rx-ease);
+}
+.match:hover {
+  background: var(--rx-surface-2);
+  border-left-color: var(--rx-match);
+}
+.match:focus-visible { outline: 2px solid var(--rx-accent); outline-offset: 1px; }
+.match.is-active {
+  background: var(--rx-accent-soft);
+  border-color: rgba(34,197,94,0.35);
+  border-left-color: var(--rx-accent);
+}
+.match__index {
+  text-align: center;
+  color: var(--rx-match);
+  font-family: var(--rx-mono);
+  font-weight: 600;
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+}
+.match__loc {
+  font-family: var(--rx-mono);
+  font-size: 11px;
+  color: var(--rx-text-mute);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  text-align: right;
+  padding-right: 4px;
+  border-right: 1px dashed var(--rx-border-strong);
+}
+.match__text {
+  font-family: var(--rx-mono);
+  font-size: 12.5px;
+  color: var(--rx-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.match__text--empty { color: var(--rx-text-dim); font-style: italic; }
+.match__more {
+  font-family: var(--rx-mono);
+  font-size: 10.5px;
+  color: var(--rx-group);
+  background: rgba(196,168,255,0.12);
+  border: 1px solid rgba(196,168,255,0.32);
+  padding: 1px 7px;
+  border-radius: 3px;
+  white-space: nowrap;
+  margin-right: 8px;
+}
+
+.match__groups {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(60px, 140px) minmax(0, 1fr);
+  column-gap: 12px;
+  row-gap: 3px;
+  margin: 6px 10px 0 56px;
+  padding-top: 6px;
+  border-top: 1px dashed var(--rx-border-strong);
+  font-family: var(--rx-mono);
+  font-size: 11px;
+}
+.match__group-tag {
+  color: var(--rx-group);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.match__group-val {
+  color: var(--rx-string);
+  word-break: break-all;
+  min-width: 0;
+}
+.match__group-val--empty {
+  color: var(--rx-text-dim);
+  font-style: italic;
+}
+
+/* ── Replace ────────────────────────────────────────── */
 .replace-input {
   width: 100%;
-  background: var(--rx-bg);
-  border: 1px solid var(--rx-line-bright);
+  background: var(--rx-bg-2);
+  border: 1px solid var(--rx-border-strong);
   color: var(--rx-text);
   font-family: var(--rx-mono);
   font-size: 13px;
-  padding: 8px 10px;
-  border-radius: 4px;
+  padding: 9px 12px;
+  border-radius: 5px;
   outline: none;
-  caret-color: var(--rx-blue);
-  transition: border-color .15s ease;
+  caret-color: var(--rx-accent);
+  transition: border-color var(--rx-dur) var(--rx-ease),
+              box-shadow var(--rx-dur) var(--rx-ease);
 }
-.replace-input::placeholder { color: var(--rx-text-mute); }
+.replace-input::placeholder { color: var(--rx-text-dim); }
 .replace-input:focus {
-  border-color: var(--rx-blue);
-  box-shadow: 0 0 0 3px rgba(122,162,247,0.18);
+  border-color: var(--rx-accent);
+  box-shadow: 0 0 0 3px rgba(34,197,94,0.18);
 }
 .replace-output {
   margin: 10px 0 0;
   padding: 10px 12px;
-  border-radius: 4px;
-  background: var(--rx-bg);
-  border: 1px solid var(--rx-line);
-  border-left: 2px solid var(--rx-green);
+  border-radius: 5px;
+  background: var(--rx-bg-2);
+  border: 1px solid var(--rx-border);
+  border-left: 2px solid var(--rx-accent);
   font-family: var(--rx-mono);
   font-size: 12px;
   white-space: pre-wrap;
@@ -338,162 +549,97 @@ button, input, textarea { font-family: inherit; }
   overflow: auto;
 }
 
-/* ── Matches list ────────────────────────────────────── */
-.matches-card { display: flex; flex-direction: column; min-height: 0; padding: 10px 14px 12px; }
-.matches-card__header {
-  display: flex; align-items: center; justify-content: space-between;
-  margin-bottom: 10px;
-  gap: 8px;
-}
-.matches-card__actions { display: flex; align-items: center; gap: 4px; }
-.matches-card__actions .link-btn { padding: 4px 7px; }
-.matches-card__actions .link-btn:disabled { opacity: 0.35; cursor: not-allowed; }
-.matches {
-  max-height: 240px;
-  overflow-y: auto;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 8px;
-  padding-right: 2px;
-}
-.matches:empty { display: none; }
-.empty {
-  grid-column: 1 / -1;
-  color: var(--rx-text-mute);
-  font-family: var(--rx-mono);
-  font-size: 11.5px;
-  padding: 8px 0;
-}
-.match {
-  background: var(--rx-bg-2);
-  border: 1px solid var(--rx-line);
-  border-left: 2px solid var(--rx-orange);
-  border-radius: 4px;
-  padding: 8px 10px;
-  cursor: pointer;
-  transition: all .12s ease;
-  min-width: 0;
-}
-.match:hover { border-color: var(--rx-line-bright); border-left-color: var(--rx-blue); }
-.match.is-active {
-  border-color: var(--rx-blue);
-  border-left-color: var(--rx-blue);
-  background: rgba(122,162,247,0.08);
-}
-.match__head {
-  display: flex; align-items: center; justify-content: space-between;
-  font-family: var(--rx-mono);
-  font-size: 11px; color: var(--rx-text-mute);
-  font-variant-numeric: tabular-nums;
-}
-.match__index {
-  color: var(--rx-orange);
-  font-weight: 600;
-  font-family: var(--rx-mono);
-}
-.match__loc { font-family: var(--rx-mono); }
-.match__text {
-  margin-top: 5px;
-  font-family: var(--rx-mono);
-  font-size: 12px;
-  color: var(--rx-text);
-  word-break: break-all;
-  background: var(--rx-bg);
-  border: 1px solid var(--rx-line);
-  border-radius: 3px;
-  padding: 5px 7px;
-  max-height: 60px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-.match__text--empty { color: var(--rx-text-mute); font-style: italic; }
-.match__groups {
-  margin-top: 7px;
-  display: flex; flex-direction: column; gap: 3px;
-  border-top: 1px dashed var(--rx-line-bright);
-  padding-top: 6px;
-}
-.match__group {
-  font-family: var(--rx-mono);
-  font-size: 11px;
-  color: var(--rx-text-soft);
-  display: flex;
-  gap: 6px;
-  word-break: break-all;
-}
-.match__group-tag {
-  color: var(--rx-purple);
-  font-weight: 600;
-  flex-shrink: 0;
-}
-.match__group-val { min-width: 0; color: var(--rx-green); }
-.match__group-val--empty { opacity: 0.5; font-style: italic; color: var(--rx-text-mute); }
-
-/* ── Library — code-snippet style cards ──────────────── */
-.library-card .card__title::before {
-  content: '> ';
-  color: var(--rx-green);
-}
+/* ── Library ────────────────────────────────────────── */
 .library { display: flex; flex-direction: column; gap: 6px; }
 .lib-item {
   background: var(--rx-bg-2);
-  border: 1px solid var(--rx-line);
-  border-left: 2px solid var(--rx-purple);
-  padding: 8px 10px;
-  border-radius: 4px;
+  border: 1px solid var(--rx-border);
+  border-left: 2px solid var(--rx-group);
+  padding: 8px 11px;
+  border-radius: 5px;
   cursor: pointer;
-  transition: all .12s ease;
+  transition: background-color var(--rx-dur) var(--rx-ease),
+              border-color var(--rx-dur) var(--rx-ease);
 }
 .lib-item:hover {
-  border-color: var(--rx-line-bright);
-  border-left-color: var(--rx-blue);
+  background: var(--rx-surface-2);
+  border-color: var(--rx-border-strong);
+  border-left-color: var(--rx-accent-strong);
 }
+.lib-item:focus-visible { outline: 2px solid var(--rx-accent); outline-offset: 1px; }
 .lib-item__name {
   font-family: var(--rx-sans);
-  font-size: 12px;
+  font-size: 12.5px;
   color: var(--rx-text);
   margin-bottom: 3px;
+  font-weight: 500;
 }
 .lib-item__pattern {
   font-family: var(--rx-mono);
   font-size: 10.5px;
-  color: var(--rx-cyan);
+  color: var(--rx-text-mute);
   word-break: break-all;
+  line-height: 1.45;
 }
 
-/* ── Ref ─────────────────────────────────────────────── */
-.ref-card .card__title::before {
-  content: '? ';
-  color: var(--rx-orange);
-}
+/* ── Reference list ─────────────────────────────────── */
 .ref { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
 .ref li {
   font-family: var(--rx-sans);
-  font-size: 11.5px;
+  font-size: 12px;
   color: var(--rx-text-soft);
-  line-height: 1.55;
+  line-height: 1.6;
 }
 .ref code {
-  background: var(--rx-bg);
-  border: 1px solid var(--rx-line-bright);
+  background: var(--rx-bg-2);
+  border: 1px solid var(--rx-border-strong);
   padding: 1px 6px;
   border-radius: 3px;
   font-family: var(--rx-mono);
-  color: var(--rx-cyan);
+  color: var(--rx-accent-strong);
   font-size: 11px;
   margin-right: 2px;
 }
 
 /* ── Scrollbar ──────────────────────────────────────── */
 ::-webkit-scrollbar { width: 8px; height: 8px; }
-::-webkit-scrollbar-thumb { background: rgba(122,162,247,0.18); border-radius: 4px; }
-::-webkit-scrollbar-thumb:hover { background: rgba(122,162,247,0.32); }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: rgba(34,197,94,0.18); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: rgba(34,197,94,0.32); }
 
-/* ── Responsive ──────────────────────────────────────── */
-@media (max-width: 880px) {
-  .layout { grid-template-columns: 1fr; }
-  .side-col { max-height: 280px; }
+/* ── Reduced motion ─────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  * { transition-duration: 0ms !important; animation-duration: 0ms !important; }
+}
+
+/* ── Responsive ─────────────────────────────────────── */
+/*
+ * 关键修复：窄屏下不再让任何 column 单独滚动，整个 .rx 改为 auto 高度
+ * 由 body / 滚动容器统一滚动，彻底避免 grid + overflow:hidden 把内容裁掉。
+ */
+@media (max-width: 1080px) {
+  body { overflow: auto; }
+  .rx { min-height: 100vh; height: auto; }
+  .topbar { position: sticky; top: 0; }
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+    overflow: visible;
+  }
+  .main-col {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  /* Stacked mode: editor stays bounded; matches gets its own max-height since
+   * there's no flex parent to absorb slack — page itself scrolls. */
+  .editor { height: clamp(180px, 26vh, 280px); flex: 0 0 auto; }
+  .side-col { overflow: visible; }
+  .matches { flex: 0 0 auto; max-height: clamp(220px, 40vh, 420px); }
+}
+@media (max-width: 560px) {
+  .layout { padding: 10px; gap: 10px; }
+  .topbar { padding: 9px 12px; }
+  .brand__subtitle { display: none; }
+  .match { grid-template-columns: 28px 56px minmax(0, 1fr) auto; gap: 6px; }
+  .match__groups { margin-left: 40px; }
 }

--- a/src/crates/core/src/miniapp/builtin/assets/regex-playground/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/regex-playground/ui.js
@@ -1,35 +1,191 @@
 // Regex Playground — built-in MiniApp.
 // Real-time matching, capture groups, replace preview, and a quick pattern library.
+//
+// i18n: each library item / cheatsheet line / status pill / placeholder uses a
+// language-aware lookup table. Patterns / flags themselves are universal.
 
-const PATTERN_LIBRARY = [
-  { name: '邮箱地址', pattern: "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}", flags: 'g' },
-  { name: '中国大陆手机号', pattern: "(?<!\\d)1[3-9]\\d{9}(?!\\d)", flags: 'g' },
-  { name: 'URL（http/https）', pattern: "https?:\\/\\/[\\w\\-._~:\\/?#\\[\\]@!$&'()*+,;=%]+", flags: 'gi' },
-  { name: 'IPv4 地址', pattern: "\\b(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)\\b", flags: 'g' },
-  { name: 'IPv6 地址（简化）', pattern: "([0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}", flags: 'g' },
-  { name: 'UUID v4', pattern: "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}", flags: 'gi' },
-  { name: '十六进制颜色', pattern: "#(?:[0-9a-fA-F]{3}){1,2}\\b", flags: 'g' },
-  { name: '日期 YYYY-MM-DD', pattern: "\\b(\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])\\b", flags: 'g' },
-  { name: '时间 HH:MM(:SS)', pattern: "\\b([01]?\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d)?\\b", flags: 'g' },
-  { name: 'Semver 版本号', pattern: "\\b\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?\\b", flags: 'g' },
-  { name: 'Git 短 SHA', pattern: "\\b[0-9a-f]{7,40}\\b", flags: 'g' },
-  { name: '驼峰标识符', pattern: "\\b[a-z]+(?:[A-Z][a-z0-9]*)+\\b", flags: 'g' },
-  { name: '中文字符', pattern: "[\\u4e00-\\u9fa5]+", flags: 'g' },
-  { name: '前后空白', pattern: "^[ \\t]+|[ \\t]+$", flags: 'gm' },
-  { name: '行首注释 //', pattern: "^\\s*\\/\\/.*$", flags: 'gm' },
+const PATTERN_KEYS = [
+  { id: 'email',    pattern: "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}", flags: 'g' },
+  { id: 'mobileCN', pattern: "(?<!\\d)1[3-9]\\d{9}(?!\\d)", flags: 'g' },
+  { id: 'url',      pattern: "https?:\\/\\/[\\w\\-._~:\\/?#\\[\\]@!$&'()*+,;=%]+", flags: 'gi' },
+  { id: 'ipv4',     pattern: "\\b(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)\\b", flags: 'g' },
+  { id: 'ipv6',     pattern: "([0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}", flags: 'g' },
+  { id: 'uuid',     pattern: "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}", flags: 'gi' },
+  { id: 'hexColor', pattern: "#(?:[0-9a-fA-F]{3}){1,2}\\b", flags: 'g' },
+  { id: 'dateYmd',  pattern: "\\b(\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])\\b", flags: 'g' },
+  { id: 'timeHms',  pattern: "\\b([01]?\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d)?\\b", flags: 'g' },
+  { id: 'semver',   pattern: "\\b\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?\\b", flags: 'g' },
+  { id: 'gitSha',   pattern: "\\b[0-9a-f]{7,40}\\b", flags: 'g' },
+  { id: 'camel',    pattern: "\\b[a-z]+(?:[A-Z][a-z0-9]*)+\\b", flags: 'g' },
+  { id: 'cjk',      pattern: "[\\u4e00-\\u9fa5]+", flags: 'g' },
+  { id: 'trim',     pattern: "^[ \\t]+|[ \\t]+$", flags: 'gm' },
+  { id: 'lineCmt',  pattern: "^\\s*\\/\\/.*$", flags: 'gm' },
 ];
 
-const SAMPLE_TEXT = `# 把任意文本粘到这里，正则会实时高亮匹配项。
+// Sample text is intentionally locale-agnostic (English) so it doesn't flip
+// when users switch UI language — the textarea is meant to be a regex playground
+// scratchpad, not a piece of localized copy.
+const SAMPLE_TEXT = `# Paste any text here — matches highlight in real time.
 
-联系：alice@example.com / 13800138000
-项目主页：https://github.com/cursor/bitfun
-内部 IP：192.168.1.10 与 10.0.0.1
-追踪 ID：8f2c3a01-4e6b-4d1c-9bb1-1f3a6d2c0a55
-今日发版 v1.4.0-beta.2，对应 commit 7a3f9d2
+Contact: alice@example.com / 13800138000
+Project: https://github.com/GCWing/BitFun
+Internal IP: 192.168.1.10 and 10.0.0.1
+Trace ID: 8f2c3a01-4e6b-4d1c-9bb1-1f3a6d2c0a55
+Releasing v1.4.0-beta.2, commit 7a3f9d2
 
-// TODO: 抽取上面这一段为一个工具函数
+// TODO: Extract the block above into a utility function
 const userName = "Bitfun";
 `;
+
+const I18N = {
+  'zh-CN': {
+    title: '正则游乐场',
+    subtitle: 'RegExp 实时调试 · ECMAScript 风格',
+    flagG: '全局匹配 (global)',
+    flagI: '忽略大小写 (ignore case)',
+    flagM: '多行模式 (multiline)',
+    flagS: 'dotAll · . 匹配换行',
+    flagU: 'Unicode 模式',
+    flagY: '粘连匹配 (sticky)',
+    testText: '测试文本',
+    testPlaceholder: '把要匹配的文本粘贴到这里…',
+    clear: '清空',
+    matchesTitle: '匹配明细',
+    matchesEmpty: '输入正则与文本，匹配结果将在这里展示。',
+    prevMatch: '上一处',
+    nextMatch: '下一处',
+    replaceTitle: '替换预览',
+    replaceHint: '支持 $1 $2 $<name> 反向引用',
+    replacePlaceholder: '替换为…（留空则不展示预览）',
+    library: '常用模式',
+    cheatsheet: '速查',
+    statusReady: '就绪',
+    statusError: '语法错误',
+    statusNoMatch: '无匹配',
+    statusHits: (n) => `命中 ${n} 处`,
+    matchCount: (n) => `${n} 处匹配`,
+    matchCountInvalid: '— 处匹配',
+    summaryWaiting: '尚未匹配',
+    summaryNoMatch: '无匹配',
+    summaryWithGroups: (n, g) => `${n} 处 · ${g} 个分组`,
+    summaryNoGroups: (n) => `${n} 处`,
+    matchEmpty: '空匹配（零宽）',
+    matchGroupEmpty: '(空)',
+    matchGroupCount: (n) => `${n} 组`,
+    syntaxError: '正则语法错误',
+    noMatchHint: '没有匹配项。试着调整正则或测试文本。',
+    replaceFailed: (msg) => `[替换失败] ${msg}`,
+    libNames: {
+      email: '邮箱地址',
+      mobileCN: '中国大陆手机号',
+      url: 'URL（http/https）',
+      ipv4: 'IPv4 地址',
+      ipv6: 'IPv6 地址（简化）',
+      uuid: 'UUID v4',
+      hexColor: '十六进制颜色',
+      dateYmd: '日期 YYYY-MM-DD',
+      timeHms: '时间 HH:MM(:SS)',
+      semver: 'Semver 版本号',
+      gitSha: 'Git 短 SHA',
+      camel: '驼峰标识符',
+      cjk: '中文字符',
+      trim: '前后空白',
+      lineCmt: '行首注释 //',
+    },
+    cheatsheet_lines: [
+      ['\\d', '数字 ·'], ['\\D', '非数字'],
+      ['\\w', '字母数字下划线 ·'], ['\\W', '反之'],
+      ['\\s', '空白 ·'], ['\\S', '非空白'],
+      ['^ $', '行首/行尾（配合 m）'],
+      ['(?:…)', '非捕获 ·'], ['(?<n>…)', '命名捕获'],
+      ['(?=…)', '正向先行 ·'], ['(?!…)', '反向先行'],
+      ['{n,m}', '区间量词 ·'], ['?', '非贪婪'],
+    ],
+    cheatsheet_grouped: [
+      ['<code>\\d</code> 数字 · <code>\\D</code> 非数字'],
+      ['<code>\\w</code> 字母数字下划线 · <code>\\W</code> 反之'],
+      ['<code>\\s</code> 空白 · <code>\\S</code> 非空白'],
+      ['<code>^ $</code> 行首/行尾（配合 m）'],
+      ['<code>(?:…)</code> 非捕获 · <code>(?&lt;n&gt;…)</code> 命名捕获'],
+      ['<code>(?=…)</code> 正向先行 · <code>(?!…)</code> 反向先行'],
+      ['<code>{n,m}</code> 区间量词 · <code>?</code> 非贪婪'],
+    ],
+  },
+  'en-US': {
+    title: 'Regex Playground',
+    subtitle: 'Live RegExp debugger · ECMAScript flavour',
+    flagG: 'Global match (g)',
+    flagI: 'Ignore case (i)',
+    flagM: 'Multiline (m)',
+    flagS: 'dotAll — . matches newlines (s)',
+    flagU: 'Unicode mode (u)',
+    flagY: 'Sticky match (y)',
+    testText: 'Test text',
+    testPlaceholder: 'Paste the text you want to match here…',
+    clear: 'Clear',
+    matchesTitle: 'Match details',
+    matchesEmpty: 'Enter a regex and some text to see matches here.',
+    prevMatch: 'Previous',
+    nextMatch: 'Next',
+    replaceTitle: 'Replace preview',
+    replaceHint: 'Supports $1 $2 $<name> back-references',
+    replacePlaceholder: 'Replacement string… (empty hides the preview)',
+    library: 'Pattern library',
+    cheatsheet: 'Cheatsheet',
+    statusReady: 'Ready',
+    statusError: 'Syntax error',
+    statusNoMatch: 'No match',
+    statusHits: (n) => `${n} match${n === 1 ? '' : 'es'}`,
+    matchCount: (n) => `${n} match${n === 1 ? '' : 'es'}`,
+    matchCountInvalid: '— matches',
+    summaryWaiting: 'Waiting for input',
+    summaryNoMatch: 'No match',
+    summaryWithGroups: (n, g) => `${n} match${n === 1 ? '' : 'es'} · ${g} group${g === 1 ? '' : 's'}`,
+    summaryNoGroups: (n) => `${n} match${n === 1 ? '' : 'es'}`,
+    matchEmpty: 'Empty match (zero-width)',
+    matchGroupEmpty: '(empty)',
+    matchGroupCount: (n) => `${n} group${n === 1 ? '' : 's'}`,
+    syntaxError: 'Regex syntax error',
+    noMatchHint: 'No matches. Try adjusting the regex or the test text.',
+    replaceFailed: (msg) => `[Replace failed] ${msg}`,
+    libNames: {
+      email: 'Email address',
+      mobileCN: 'China mobile number',
+      url: 'URL (http/https)',
+      ipv4: 'IPv4 address',
+      ipv6: 'IPv6 (loose)',
+      uuid: 'UUID v4',
+      hexColor: 'Hex color',
+      dateYmd: 'Date YYYY-MM-DD',
+      timeHms: 'Time HH:MM(:SS)',
+      semver: 'Semver version',
+      gitSha: 'Git short SHA',
+      camel: 'camelCase identifier',
+      cjk: 'CJK characters',
+      trim: 'Leading/trailing spaces',
+      lineCmt: 'Line comment //',
+    },
+    cheatsheet_grouped: [
+      ['<code>\\d</code> digit · <code>\\D</code> non-digit'],
+      ['<code>\\w</code> word char · <code>\\W</code> non-word'],
+      ['<code>\\s</code> whitespace · <code>\\S</code> non-whitespace'],
+      ['<code>^ $</code> start/end of line (with m)'],
+      ['<code>(?:…)</code> non-capturing · <code>(?&lt;n&gt;…)</code> named group'],
+      ['<code>(?=…)</code> lookahead · <code>(?!…)</code> negative lookahead'],
+      ['<code>{n,m}</code> range quantifier · <code>?</code> lazy'],
+    ],
+  },
+};
+
+function currentLocale() {
+  return (window.app && window.app.locale) || 'en-US';
+}
+
+function ui(key) {
+  const lang = currentLocale();
+  const table = I18N[lang] || I18N['en-US'];
+  return table[key];
+}
 
 // ── DOM ──────────────────────────────────────────────
 const dom = {
@@ -59,21 +215,49 @@ const state = {
 
 // ── Init ─────────────────────────────────────────────
 async function init() {
+  if (dom.statusPill) dom.statusPill.textContent = ui('statusReady');
+  applyStaticI18n();
   buildLibrary();
+  buildCheatsheet();
   bindFlags();
   bindEditorSync();
   await restore();
   bindPersistence();
   recompute();
+  if (window.app && typeof window.app.onLocaleChange === 'function') {
+    window.app.onLocaleChange(() => {
+      applyStaticI18n();
+      buildLibrary();
+      buildCheatsheet();
+      recompute();
+    });
+  }
+}
+
+function applyStaticI18n() {
+  document.documentElement.setAttribute('lang', currentLocale());
+  document.querySelectorAll('[data-i18n]').forEach((node) => {
+    const key = node.getAttribute('data-i18n');
+    const attr = node.getAttribute('data-i18n-attr');
+    const value = ui(key);
+    if (typeof value !== 'string') return;
+    if (attr) node.setAttribute(attr, value);
+    else node.textContent = value;
+  });
+  if (dom && dom.statusPill && dom.statusPill.classList.contains('status--ok') && dom.statusPill.textContent === '就绪') {
+    dom.statusPill.textContent = ui('statusReady');
+  }
 }
 
 function buildLibrary() {
   dom.library.innerHTML = '';
-  for (const item of PATTERN_LIBRARY) {
+  const names = ui('libNames') || {};
+  for (const item of PATTERN_KEYS) {
     const el = document.createElement('div');
     el.className = 'lib-item';
+    const displayName = names[item.id] || item.id;
     el.innerHTML = `
-      <div class="lib-item__name">${escapeHtml(item.name)}</div>
+      <div class="lib-item__name">${escapeHtml(displayName)}</div>
       <div class="lib-item__pattern">/${escapeHtml(item.pattern)}/${escapeHtml(item.flags)}</div>
     `;
     el.addEventListener('click', () => {
@@ -85,6 +269,13 @@ function buildLibrary() {
     });
     dom.library.appendChild(el);
   }
+}
+
+function buildCheatsheet() {
+  const list = document.getElementById('ref-list');
+  if (!list) return;
+  const lines = ui('cheatsheet_grouped') || [];
+  list.innerHTML = lines.map((row) => `<li>${row[0]}</li>`).join('');
 }
 
 function bindFlags() {
@@ -142,7 +333,9 @@ async function restore() {
     syncFlagsUi();
   }
   if (!dom.pattern.value) dom.pattern.value = "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}";
-  if (!dom.testText.value) dom.testText.value = SAMPLE_TEXT;
+  if (!dom.testText.value) {
+    dom.testText.value = SAMPLE_TEXT;
+  }
 }
 
 function bindPersistence() {
@@ -218,10 +411,10 @@ function recompute() {
   if (!compiled.ok) {
     dom.patternError.hidden = false;
     dom.patternError.textContent = compiled.error;
-    dom.statusPill.textContent = '语法错误';
+    dom.statusPill.textContent = ui('statusError');
     dom.statusPill.className = 'status status--err';
-    dom.matchCount.textContent = '— 处匹配';
-    dom.matchesSummary.textContent = '正则语法错误';
+    dom.matchCount.textContent = ui('matchCountInvalid');
+    dom.matchesSummary.textContent = ui('syntaxError');
     dom.matches.innerHTML = `<div class="empty">${escapeHtml(compiled.error)}</div>`;
     lastMatches = [];
     state.activeMatchIndex = -1;
@@ -236,18 +429,18 @@ function recompute() {
   const text = dom.testText.value;
   const matches = findAllMatches(compiled.regex, text);
   lastMatches = matches;
-  dom.matchCount.textContent = `${matches.length} 处匹配`;
+  dom.matchCount.textContent = ui('matchCount')(matches.length);
   if (matches.length === 0) {
-    dom.statusPill.textContent = '无匹配';
+    dom.statusPill.textContent = ui('statusNoMatch');
     dom.statusPill.className = 'status status--idle';
-    dom.matchesSummary.textContent = text ? '无匹配' : '尚未匹配';
+    dom.matchesSummary.textContent = text ? ui('summaryNoMatch') : ui('summaryWaiting');
   } else {
-    dom.statusPill.textContent = `命中 ${matches.length} 处`;
+    dom.statusPill.textContent = ui('statusHits')(matches.length);
     dom.statusPill.className = 'status status--ok';
     const totalGroups = matches.reduce((acc, m) => acc + m.groups.length + m.namedGroups.length, 0);
     dom.matchesSummary.textContent = totalGroups > 0
-      ? `${matches.length} 处 · ${totalGroups} 个分组`
-      : `${matches.length} 处`;
+      ? ui('summaryWithGroups')(matches.length, totalGroups)
+      : ui('summaryNoGroups')(matches.length);
   }
   state.activeMatchIndex = -1;
   updateNavButtons();
@@ -283,7 +476,7 @@ function renderHighlight(matches) {
 
 function renderMatches(matches) {
   if (matches.length === 0) {
-    dom.matches.innerHTML = '<div class="empty">没有匹配项。试着调整正则或测试文本。</div>';
+    dom.matches.innerHTML = `<div class="empty">${escapeHtml(ui('noMatchHint'))}</div>`;
     return;
   }
   dom.matches.innerHTML = '';
@@ -293,27 +486,29 @@ function renderMatches(matches) {
     el.className = 'match';
     el.dataset.idx = String(i);
     const allGroups = [...m.groups, ...m.namedGroups];
+    const { line, col } = lineColAt(text, m.index);
+    const isEmpty = m.text === '';
+    const textCellClass = isEmpty ? 'match__text match__text--empty' : 'match__text';
+    const textCellContent = isEmpty ? escapeHtml(ui('matchEmpty')) : escapeHtml(m.text);
+    const moreBadge = allGroups.length > 0
+      ? `<span class="match__more">${escapeHtml(ui('matchGroupCount')(allGroups.length))}</span>`
+      : '<span></span>';
     let groupsHtml = '';
     if (allGroups.length > 0) {
+      const emptyLabel = ui('matchGroupEmpty');
       groupsHtml = '<div class="match__groups">' + allGroups.map((g) => {
         const tag = g.name != null ? `&lt;${escapeHtml(g.name)}&gt;` : `$${g.idx}`;
         const val = g.value === undefined || g.value === ''
-          ? `<span class="match__group-val match__group-val--empty">${g.value === undefined ? 'undefined' : '(空)'}</span>`
+          ? `<span class="match__group-val match__group-val--empty">${g.value === undefined ? 'undefined' : escapeHtml(emptyLabel)}</span>`
           : `<span class="match__group-val">${escapeHtml(g.value)}</span>`;
-        return `<div class="match__group"><span class="match__group-tag">${tag}</span>${val}</div>`;
+        return `<span class="match__group-tag">${tag}</span>${val}`;
       }).join('') + '</div>';
     }
-    const { line, col } = lineColAt(text, m.index);
-    const isEmpty = m.text === '';
-    const matchTextHtml = isEmpty
-      ? '<div class="match__text match__text--empty">空匹配（零宽）</div>'
-      : `<div class="match__text" title="${escapeHtml(m.text)}">${escapeHtml(m.text)}</div>`;
     el.innerHTML = `
-      <div class="match__head">
-        <span class="match__index">#${i + 1}</span>
-        <span class="match__loc">L${line}:${col} · ${m.index}–${m.end}</span>
-      </div>
-      ${matchTextHtml}
+      <span class="match__index">#${i + 1}</span>
+      <span class="match__loc">L${line}:${col}</span>
+      <span class="${textCellClass}" title="${escapeHtml(m.text)}">${textCellContent}</span>
+      ${moreBadge}
       ${groupsHtml}
     `;
     el.addEventListener('click', () => selectMatch(i, true));
@@ -361,7 +556,7 @@ function renderReplace() {
   try {
     result = dom.testText.value.replace(compiled.regex, replacement);
   } catch (e) {
-    result = `[替换失败] ${e.message}`;
+    result = ui('replaceFailed')(e.message);
   }
   dom.replaceOutput.hidden = false;
   dom.replaceOutput.textContent = result;

--- a/src/crates/core/src/miniapp/builtin/mod.rs
+++ b/src/crates/core/src/miniapp/builtin/mod.rs
@@ -31,7 +31,7 @@ pub struct BuiltinApp {
 pub const BUILTIN_APPS: &[BuiltinApp] = &[
     BuiltinApp {
         id: "builtin-gomoku",
-        version: 4,
+        version: 7,
         meta_json: include_str!("assets/gomoku/meta.json"),
         html: include_str!("assets/gomoku/index.html"),
         css: include_str!("assets/gomoku/style.css"),
@@ -41,7 +41,7 @@ pub const BUILTIN_APPS: &[BuiltinApp] = &[
     },
     BuiltinApp {
         id: "builtin-daily-divination",
-        version: 3,
+        version: 10,
         meta_json: include_str!("assets/divination/meta.json"),
         html: include_str!("assets/divination/index.html"),
         css: include_str!("assets/divination/style.css"),
@@ -51,12 +51,22 @@ pub const BUILTIN_APPS: &[BuiltinApp] = &[
     },
     BuiltinApp {
         id: "builtin-regex-playground",
-        version: 4,
+        version: 12,
         meta_json: include_str!("assets/regex-playground/meta.json"),
         html: include_str!("assets/regex-playground/index.html"),
         css: include_str!("assets/regex-playground/style.css"),
         ui_js: include_str!("assets/regex-playground/ui.js"),
         worker_js: include_str!("assets/regex-playground/worker.js"),
+        esm_dependencies_json: "[]",
+    },
+    BuiltinApp {
+        id: "builtin-coding-selfie",
+        version: 16,
+        meta_json: include_str!("assets/coding-selfie/meta.json"),
+        html: include_str!("assets/coding-selfie/index.html"),
+        css: include_str!("assets/coding-selfie/style.css"),
+        ui_js: include_str!("assets/coding-selfie/ui.js"),
+        worker_js: include_str!("assets/coding-selfie/worker.js"),
         esm_dependencies_json: "[]",
     },
 ];

--- a/src/crates/core/src/miniapp/manager.rs
+++ b/src/crates/core/src/miniapp/manager.rs
@@ -182,6 +182,7 @@ impl MiniAppManager {
             permissions,
             ai_context,
             runtime,
+            i18n: None,
         };
 
         self.storage.save(&app).await?;

--- a/src/crates/core/src/miniapp/storage.rs
+++ b/src/crates/core/src/miniapp/storage.rs
@@ -133,6 +133,7 @@ impl MiniAppStorage {
             permissions: meta.permissions,
             ai_context: meta.ai_context,
             runtime: meta.runtime,
+            i18n: meta.i18n,
         })
     }
 

--- a/src/crates/core/src/miniapp/types.rs
+++ b/src/crates/core/src/miniapp/types.rs
@@ -1,6 +1,7 @@
 //! MiniApp types — data model and permissions (V2: ESM UI + Node Worker).
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// ESM dependency for Import Map (browser UI).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -107,6 +108,31 @@ pub struct AiPermissions {
     pub rate_limit_per_minute: Option<u32>,
 }
 
+/// Per-locale overrides for user-facing strings (gallery name / description / tags).
+///
+/// Lives optionally in `meta.json` as `i18n.locales[<locale-id>]`. Whichever fields are
+/// present override the top-level `name`/`description`/`tags`; missing fields fall back
+/// to the top-level value (which itself acts as the default / fallback locale).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MiniAppLocaleStrings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+}
+
+/// MiniApp i18n bundle.
+///
+/// Map key is a locale id (e.g. `"zh-CN"`, `"en-US"`). The frontend picks the best
+/// match using `currentLanguage → "en-US" → "zh-CN" → top-level name/description`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MiniAppI18n {
+    #[serde(default)]
+    pub locales: HashMap<String, MiniAppLocaleStrings>,
+}
+
 /// AI context for iteration (stored in meta, not in compiled HTML).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MiniAppAiContext {
@@ -159,6 +185,10 @@ pub struct MiniApp {
 
     #[serde(default)]
     pub runtime: MiniAppRuntimeState,
+
+    /// Optional per-locale overrides for `name` / `description` / `tags`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub i18n: Option<MiniAppI18n>,
 }
 
 /// MiniApp metadata only (for list views; no source/compiled_html).
@@ -180,6 +210,9 @@ pub struct MiniAppMeta {
     pub ai_context: Option<MiniAppAiContext>,
     #[serde(default)]
     pub runtime: MiniAppRuntimeState,
+    /// Optional per-locale overrides for `name` / `description` / `tags`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub i18n: Option<MiniAppI18n>,
 }
 
 impl From<&MiniApp> for MiniAppMeta {
@@ -197,6 +230,7 @@ impl From<&MiniApp> for MiniAppMeta {
             permissions: app.permissions.clone(),
             ai_context: app.ai_context.clone(),
             runtime: app.runtime.clone(),
+            i18n: app.i18n.clone(),
         }
     }
 }

--- a/src/crates/core/src/service/remote_connect/bot/command_router.rs
+++ b/src/crates/core/src/service/remote_connect/bot/command_router.rs
@@ -69,12 +69,6 @@ pub struct BotChatState {
     #[serde(skip)]
     pub pending_invalid_count: u8,
 
-    /// Pending file downloads awaiting user confirmation.
-    /// Key: short token embedded in the download button callback.
-    /// Value: absolute file path on the desktop.  Not persisted.
-    #[serde(skip)]
-    pub pending_files: std::collections::HashMap<String, String>,
-
     /// Commands corresponding to the items in the most recent menu, used so
     /// numeric replies (`1` ~ `last_menu_commands.len()`) work without
     /// platform-native buttons.  Not persisted.
@@ -94,7 +88,6 @@ impl BotChatState {
             pending_action: None,
             pending_expires_at: 0,
             pending_invalid_count: 0,
-            pending_files: std::collections::HashMap::new(),
             last_menu_commands: Vec::new(),
         }
     }

--- a/src/crates/core/src/service/remote_connect/bot/feishu.rs
+++ b/src/crates/core/src/service/remote_connect/bot/feishu.rs
@@ -25,6 +25,9 @@ type FeishuWsStream =
 type FeishuWsWrite = futures::stream::SplitSink<FeishuWsStream, WsMessage>;
 type SharedFeishuWsWrite = Arc<RwLock<FeishuWsWrite>>;
 
+/// Feishu IM file-upload hard limit (30 MB).
+const MAX_FEISHU_FILE_BYTES: u64 = 30 * 1024 * 1024;
+
 // ── Minimal protobuf codec for Feishu WebSocket binary protocol ─────────
 
 mod pb {
@@ -297,30 +300,6 @@ impl FeishuBot {
         }
     }
 
-    fn expired_download_message(language: BotLanguage) -> &'static str {
-        if language.is_chinese() {
-            "这个下载链接已过期，请重新让助手发送一次。"
-        } else {
-            "This download link has expired. Please ask the agent again."
-        }
-    }
-
-    fn sending_file_message(language: BotLanguage, file_name: &str) -> String {
-        if language.is_chinese() {
-            format!("正在发送“{file_name}”……")
-        } else {
-            format!("Sending \"{file_name}\"…")
-        }
-    }
-
-    fn send_file_failed_message(language: BotLanguage, file_name: &str, error: &str) -> String {
-        if language.is_chinese() {
-            format!("无法发送“{file_name}”：{error}")
-        } else {
-            format!("Could not send \"{file_name}\": {error}")
-        }
-    }
-
     pub fn new(config: FeishuConfig) -> Self {
         Self {
             config,
@@ -577,13 +556,12 @@ impl FeishuBot {
     }
 
     /// Upload a local file to Feishu and return its `file_key`.
-    ///
-    /// Files larger than 30 MB are rejected (Feishu IM file-upload limit).
+    /// Caller is expected to pre-check size against `MAX_FEISHU_FILE_BYTES`.
     async fn upload_file_to_feishu(&self, file_path: &str) -> Result<String> {
         let token = self.get_access_token().await?;
 
-        const MAX_SIZE: u64 = 30 * 1024 * 1024; // Unified 30 MB cap (Feishu API hard limit)
-        let content = super::read_workspace_file(file_path, MAX_SIZE, None).await?;
+        let content =
+            super::read_workspace_file(file_path, MAX_FEISHU_FILE_BYTES, None).await?;
 
         // Feishu uses its own file_type enum rather than MIME types.
         let ext = std::path::Path::new(&content.name)
@@ -655,75 +633,55 @@ impl FeishuBot {
         Ok(())
     }
 
-    /// Scan `text` for downloadable file links (`computer://`, `file://`, and
-    /// markdown hyperlinks to local files), store them as pending downloads and
-    /// send an interactive card with one download button per file.
+    /// Scan `text` for downloadable file references and push every matching
+    /// file directly to the Feishu chat as a `file` message.  Files exceeding
+    /// `MAX_FEISHU_FILE_BYTES` are skipped with a brief notice; per-file
+    /// failures are reported as plain-text replies.
     async fn notify_files_ready(&self, chat_id: &str, text: &str) {
-        let language = super::locale::current_bot_language().await;
-        let result = {
-            let mut states = self.chat_states.write().await;
-            let state = states.entry(chat_id.to_string()).or_insert_with(|| {
-                let mut s = BotChatState::new(chat_id.to_string());
-                s.paired = true;
-                s
-            });
-            let workspace_root = state.current_workspace.clone();
-            super::prepare_file_download_actions(
-                text,
-                state,
-                workspace_root.as_deref().map(std::path::Path::new),
-                language,
-            )
+        let language = current_bot_language().await;
+        let workspace_root = {
+            let states = self.chat_states.read().await;
+            states
+                .get(chat_id)
+                .and_then(|s| s.current_workspace.clone())
         };
-        if let Some(result) = result {
-            if let Err(e) = self.send_handle_result(chat_id, &result).await {
-                warn!("Failed to send file notification to Feishu: {e}");
-            }
+        let files = super::collect_auto_push_files(
+            text,
+            workspace_root.as_deref().map(std::path::Path::new),
+        );
+        if files.is_empty() {
+            return;
         }
-    }
 
-    /// Handle a `download_file:<token>` action: look up the pending file and
-    /// upload it to Feishu.  Sends a plain-text error if the token has expired
-    /// or the transfer fails.
-    async fn handle_download_request(&self, chat_id: &str, token: &str) {
-        let (path, language) = {
-            let mut states = self.chat_states.write().await;
-            let state = states.get_mut(chat_id);
-            let language = current_bot_language().await;
-            let path = state.and_then(|s| s.pending_files.remove(token));
-            (path, language)
-        };
+        let intro = super::auto_push_intro(language, files.len());
+        if let Err(e) = self.send_message(chat_id, &intro).await {
+            warn!("Feishu auto-push intro failed for chat {chat_id}: {e}");
+        }
 
-        match path {
-            None => {
-                let _ = self
-                    .send_message(chat_id, Self::expired_download_message(language))
-                    .await;
+        for file in files {
+            if file.size > MAX_FEISHU_FILE_BYTES {
+                let notice = super::auto_push_skip_too_large_message(
+                    language,
+                    &file.name,
+                    file.size,
+                    MAX_FEISHU_FILE_BYTES,
+                );
+                let _ = self.send_message(chat_id, &notice).await;
+                continue;
             }
-            Some(path) => {
-                let file_name = std::path::Path::new(&path)
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("file")
-                    .to_string();
-                let _ = self
-                    .send_message(chat_id, &Self::sending_file_message(language, &file_name))
-                    .await;
-                match self.send_file_to_feishu_chat(chat_id, &path).await {
-                    Ok(()) => info!("Sent file to Feishu chat {chat_id}: {path}"),
-                    Err(e) => {
-                        warn!("Failed to send file to Feishu: {e}");
-                        let _ = self
-                            .send_message(
-                                chat_id,
-                                &Self::send_file_failed_message(
-                                    language,
-                                    &file_name,
-                                    &e.to_string(),
-                                ),
-                            )
-                            .await;
-                    }
+            match self.send_file_to_feishu_chat(chat_id, &file.abs_path).await {
+                Ok(()) => info!(
+                    "Feishu auto-pushed file to chat {chat_id}: {}",
+                    file.abs_path
+                ),
+                Err(e) => {
+                    warn!(
+                        "Feishu auto-push failed for {} in chat {chat_id}: {e}",
+                        file.name
+                    );
+                    let notice =
+                        super::auto_push_failed_message(language, &file.name, &e.to_string());
+                    let _ = self.send_message(chat_id, &notice).await;
                 }
             }
         }
@@ -1517,14 +1475,6 @@ impl FeishuBot {
             self.send_message(chat_id, Self::enter_pairing_code_message(language))
                 .await
                 .ok();
-            return;
-        }
-
-        // Intercept file download callbacks before normal command routing.
-        if let Some(stripped) = text.strip_prefix("download_file:") {
-            let token = stripped.trim().to_string();
-            drop(states);
-            self.handle_download_request(chat_id, &token).await;
             return;
         }
 

--- a/src/crates/core/src/service/remote_connect/bot/locale.rs
+++ b/src/crates/core/src/service/remote_connect/bot/locale.rs
@@ -163,11 +163,10 @@ pub struct BotStrings {
 
     pub thinking_label: &'static str,
 
-    pub file_intro_one: &'static str,
-    pub file_intro_many_fmt: &'static str,
-    pub file_download_expired: &'static str,
-    pub file_sending_prefix: &'static str,
-    pub file_send_failed_prefix: &'static str,
+    pub auto_push_intro_one: &'static str,
+    pub auto_push_intro_many_fmt: &'static str,
+    pub auto_push_skip_too_large_fmt: &'static str,
+    pub auto_push_failed_fmt: &'static str,
 }
 
 const STRINGS_ZH: BotStrings = BotStrings {
@@ -303,11 +302,10 @@ const STRINGS_ZH: BotStrings = BotStrings {
 
     thinking_label: "思考中",
 
-    file_intro_one: "已生成 1 个文件，可点击下方按钮下载。",
-    file_intro_many_fmt: "已生成 {n} 个文件，可点击下方按钮下载。",
-    file_download_expired: "下载链接已过期，请重新让助手生成一次。",
-    file_sending_prefix: "正在发送：",
-    file_send_failed_prefix: "发送文件失败：",
+    auto_push_intro_one: "正在为你发送 1 个文件……",
+    auto_push_intro_many_fmt: "正在为你发送 {n} 个文件……",
+    auto_push_skip_too_large_fmt: "已跳过「{name}」：{size} 超过 {limit} 上限，请改用桌面端获取。",
+    auto_push_failed_fmt: "发送「{name}」失败：{err}",
 };
 
 const STRINGS_EN: BotStrings = BotStrings {
@@ -443,11 +441,10 @@ Common commands:
 
     thinking_label: "Thinking",
 
-    file_intro_one: "1 file is ready. Tap to download.",
-    file_intro_many_fmt: "{n} files are ready. Tap to download.",
-    file_download_expired: "Download link expired. Ask the assistant to generate it again.",
-    file_sending_prefix: "Sending: ",
-    file_send_failed_prefix: "Failed to send file: ",
+    auto_push_intro_one: "Sending 1 file for you…",
+    auto_push_intro_many_fmt: "Sending {n} files for you…",
+    auto_push_skip_too_large_fmt: "Skipping \"{name}\": {size} exceeds the {limit} limit. Please grab it from BitFun Desktop instead.",
+    auto_push_failed_fmt: "Failed to send \"{name}\": {err}",
 };
 
 pub fn strings_for(language: BotLanguage) -> &'static BotStrings {

--- a/src/crates/core/src/service/remote_connect/bot/mod.rs
+++ b/src/crates/core/src/service/remote_connect/bot/mod.rs
@@ -492,73 +492,70 @@ pub fn extract_downloadable_file_paths(
     paths
 }
 
-// ── Shared file-download action builder ───────────────────────────
+// ── Auto-push file delivery helpers ───────────────────────────────
 
-/// Scan `text` for downloadable file references (`computer://`, `file://`,
-/// and markdown hyperlinks to local files), register them as pending downloads
-/// in `state`, and return a ready-to-send [`HandleResult`] with one download
-/// button per file.  Returns `None` when no downloadable files are found.
-pub fn prepare_file_download_actions(
-    text: &str,
-    state: &mut command_router::BotChatState,
-    workspace_root: Option<&std::path::Path>,
-    language: BotLanguage,
-) -> Option<command_router::HandleResult> {
-    use command_router::BotAction;
-    use locale::{fmt_count, strings_for};
-
-    let file_paths = extract_downloadable_file_paths(text, workspace_root);
-    if file_paths.is_empty() {
-        return None;
-    }
-
-    let strings = strings_for(language);
-
-    let mut actions: Vec<BotAction> = Vec::new();
-    let mut menu_items: Vec<MenuItem> = Vec::new();
-    for path in &file_paths {
-        if let Some((name, size)) = get_file_metadata(path, workspace_root) {
-            let token = generate_download_token(&state.chat_id);
-            state.pending_files.insert(token.clone(), path.clone());
-            let label = format!("{} ({})", name, format_file_size(size));
-            let command = format!("download_file:{token}");
-            actions.push(BotAction::secondary(label.clone(), command.clone()));
-            menu_items.push(MenuItem::default(label, command));
-        }
-    }
-
-    if actions.is_empty() {
-        return None;
-    }
-
-    let intro = if actions.len() == 1 {
-        strings.file_intro_one.to_string()
-    } else {
-        fmt_count(strings.file_intro_many_fmt, actions.len())
-    };
-
-    let menu = MenuView::plain(intro.clone()).with_items(menu_items);
-    state.last_menu_commands = menu.numeric_commands();
-
-    Some(command_router::HandleResult {
-        reply: intro,
-        actions,
-        forward_to_session: None,
-        menu,
-    })
+/// One file to be auto-pushed to the IM peer alongside an agent reply.
+#[derive(Debug, Clone)]
+pub struct AutoPushFile {
+    /// Absolute path on the desktop (already resolved).
+    pub abs_path: String,
+    /// User-visible filename (basename of `abs_path`).
+    pub name: String,
+    /// Plaintext file size in bytes (for size-limit checks and UI).
+    pub size: u64,
 }
 
-/// Produce a short hex token for a pending file download.
-fn generate_download_token(chat_id: &str) -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let ns = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .subsec_nanos();
-    let salt = chat_id
-        .bytes()
-        .fold(0u32, |acc, b| acc.wrapping_add(b as u32));
-    format!("{:08x}", ns ^ salt)
+/// Scan an agent reply for downloadable file references and resolve their
+/// metadata so each platform adapter can push them directly to the user
+/// without an intermediate "tap to download" prompt.
+pub fn collect_auto_push_files(
+    text: &str,
+    workspace_root: Option<&std::path::Path>,
+) -> Vec<AutoPushFile> {
+    extract_downloadable_file_paths(text, workspace_root)
+        .into_iter()
+        .filter_map(|path| {
+            get_file_metadata(&path, workspace_root).map(|(name, size)| AutoPushFile {
+                abs_path: path,
+                name,
+                size,
+            })
+        })
+        .collect()
+}
+
+/// Caption sent once before the first auto-pushed file.
+pub fn auto_push_intro(language: BotLanguage, count: usize) -> String {
+    let strings = locale::strings_for(language);
+    if count <= 1 {
+        strings.auto_push_intro_one.to_string()
+    } else {
+        locale::fmt_count(strings.auto_push_intro_many_fmt, count)
+    }
+}
+
+/// Notice sent when a single file exceeds the platform's size limit and is skipped.
+pub fn auto_push_skip_too_large_message(
+    language: BotLanguage,
+    file_name: &str,
+    size: u64,
+    limit: u64,
+) -> String {
+    let strings = locale::strings_for(language);
+    strings
+        .auto_push_skip_too_large_fmt
+        .replace("{name}", file_name)
+        .replace("{size}", &format_file_size(size))
+        .replace("{limit}", &format_file_size(limit))
+}
+
+/// Notice sent when an upload/send call fails for a single file.
+pub fn auto_push_failed_message(language: BotLanguage, file_name: &str, err: &str) -> String {
+    let strings = locale::strings_for(language);
+    strings
+        .auto_push_failed_fmt
+        .replace("{name}", file_name)
+        .replace("{err}", err)
 }
 
 const REMOTE_CONNECT_PERSISTENCE_FILENAME: &str = "remote_connect_persistence.json";

--- a/src/crates/core/src/service/remote_connect/bot/telegram.rs
+++ b/src/crates/core/src/service/remote_connect/bot/telegram.rs
@@ -36,31 +36,11 @@ struct PendingPairing {
     created_at: i64,
 }
 
+/// Telegram Bot API hard limit for `sendDocument` uploads (50 MB), aligned
+/// across all IM platforms by capping at 30 MB to match Feishu / WeChat.
+const MAX_TELEGRAM_FILE_BYTES: u64 = 30 * 1024 * 1024;
+
 impl TelegramBot {
-    fn expired_download_message(language: BotLanguage) -> &'static str {
-        if language.is_chinese() {
-            "这个下载链接已过期，请重新让助手发送一次。"
-        } else {
-            "This download link has expired. Please ask the agent again."
-        }
-    }
-
-    fn sending_file_message(language: BotLanguage, file_name: &str) -> String {
-        if language.is_chinese() {
-            format!("正在发送“{file_name}”……")
-        } else {
-            format!("Sending \"{file_name}\"…")
-        }
-    }
-
-    fn send_file_failed_message(language: BotLanguage, file_name: &str, error: &str) -> String {
-        if language.is_chinese() {
-            format!("无法发送“{file_name}”：{error}")
-        } else {
-            format!("Could not send \"{file_name}\": {error}")
-        }
-    }
-
     fn invalid_pairing_code_message(language: BotLanguage) -> &'static str {
         if language.is_chinese() {
             "配对码无效或已过期，请重试。"
@@ -164,11 +144,10 @@ impl TelegramBot {
     }
 
     /// Send a local file to a Telegram chat as a document attachment.
-    ///
-    /// Skips files larger than 50 MB (Telegram Bot API hard limit).
+    /// Caller is expected to pre-check the size against `MAX_TELEGRAM_FILE_BYTES`.
     async fn send_file_as_document(&self, chat_id: i64, file_path: &str) -> Result<()> {
-        const MAX_SIZE: u64 = 30 * 1024 * 1024; // Unified 30 MB cap (Feishu API hard limit)
-        let content = super::read_workspace_file(file_path, MAX_SIZE, None).await?;
+        let content =
+            super::read_workspace_file(file_path, MAX_TELEGRAM_FILE_BYTES, None).await?;
 
         let part = reqwest::multipart::Part::bytes(content.bytes)
             .file_name(content.name.clone())
@@ -193,78 +172,55 @@ impl TelegramBot {
         Ok(())
     }
 
-    /// Scan `text` for downloadable file links (`computer://`, `file://`, and
-    /// markdown hyperlinks to local files), store them as pending downloads and
-    /// send a notification with one inline-keyboard button per file.
+    /// Scan `text` for downloadable file references and push every matching
+    /// file directly to the Telegram chat as an attachment.  Files exceeding
+    /// `MAX_TELEGRAM_FILE_BYTES` are skipped with a brief notice; per-file
+    /// upload failures are reported as plain-text replies.
     async fn notify_files_ready(&self, chat_id: i64, text: &str) {
-        let language = super::locale::current_bot_language().await;
-        let result = {
-            let mut states = self.chat_states.write().await;
-            let state = states.entry(chat_id).or_insert_with(|| {
-                let mut s = BotChatState::new(chat_id.to_string());
-                s.paired = true;
-                s
-            });
-            let workspace_root = state.current_workspace.clone();
-            super::prepare_file_download_actions(
-                text,
-                state,
-                workspace_root.as_deref().map(std::path::Path::new),
-                language,
-            )
+        let language = current_bot_language().await;
+        let workspace_root = {
+            let states = self.chat_states.read().await;
+            states
+                .get(&chat_id)
+                .and_then(|s| s.current_workspace.clone())
         };
-        if let Some(result) = result {
-            if let Err(e) = self
-                .send_message_with_keyboard(chat_id, &result.reply, &result.actions)
-                .await
-            {
-                warn!("Failed to send file notification to Telegram: {e}");
-            }
+        let files = super::collect_auto_push_files(
+            text,
+            workspace_root.as_deref().map(std::path::Path::new),
+        );
+        if files.is_empty() {
+            return;
         }
-    }
 
-    /// Handle a `download_file:<token>` callback: look up the pending file and
-    /// send it.  Sends a plain-text error if the token has expired or the
-    /// transfer fails.
-    async fn handle_download_request(&self, chat_id: i64, token: &str) {
-        let (path, language) = {
-            let mut states = self.chat_states.write().await;
-            let state = states.get_mut(&chat_id);
-            let language = current_bot_language().await;
-            let path = state.and_then(|s| s.pending_files.remove(token));
-            (path, language)
-        };
+        let intro = super::auto_push_intro(language, files.len());
+        if let Err(e) = self.send_message(chat_id, &intro).await {
+            warn!("Telegram auto-push intro failed for chat {chat_id}: {e}");
+        }
 
-        match path {
-            None => {
-                let _ = self
-                    .send_message(chat_id, Self::expired_download_message(language))
-                    .await;
+        for file in files {
+            if file.size > MAX_TELEGRAM_FILE_BYTES {
+                let notice = super::auto_push_skip_too_large_message(
+                    language,
+                    &file.name,
+                    file.size,
+                    MAX_TELEGRAM_FILE_BYTES,
+                );
+                let _ = self.send_message(chat_id, &notice).await;
+                continue;
             }
-            Some(path) => {
-                let file_name = std::path::Path::new(&path)
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("file")
-                    .to_string();
-                let _ = self
-                    .send_message(chat_id, &Self::sending_file_message(language, &file_name))
-                    .await;
-                match self.send_file_as_document(chat_id, &path).await {
-                    Ok(()) => info!("Sent file to Telegram chat {chat_id}: {path}"),
-                    Err(e) => {
-                        warn!("Failed to send file to Telegram: {e}");
-                        let _ = self
-                            .send_message(
-                                chat_id,
-                                &Self::send_file_failed_message(
-                                    language,
-                                    &file_name,
-                                    &e.to_string(),
-                                ),
-                            )
-                            .await;
-                    }
+            match self.send_file_as_document(chat_id, &file.abs_path).await {
+                Ok(()) => info!(
+                    "Telegram auto-pushed file to chat {chat_id}: {}",
+                    file.abs_path
+                ),
+                Err(e) => {
+                    warn!(
+                        "Telegram auto-push failed for {} in chat {chat_id}: {e}",
+                        file.name
+                    );
+                    let notice =
+                        super::auto_push_failed_message(language, &file.name, &e.to_string());
+                    let _ = self.send_message(chat_id, &notice).await;
                 }
             }
         }
@@ -638,14 +594,6 @@ impl TelegramBot {
             self.send_message(chat_id, Self::enter_pairing_code_message(language))
                 .await
                 .ok();
-            return;
-        }
-
-        // Intercept file download callbacks before normal command routing.
-        if let Some(stripped) = text.strip_prefix("download_file:") {
-            let token = stripped.trim().to_string();
-            drop(states);
-            self.handle_download_request(chat_id, &token).await;
             return;
         }
 

--- a/src/crates/core/src/service/remote_connect/bot/weixin.rs
+++ b/src/crates/core/src/service/remote_connect/bot/weixin.rs
@@ -23,7 +23,7 @@ use tokio::sync::RwLock;
 use super::command_router::{
     complete_im_bot_pairing, current_bot_language, execute_forwarded_turn, handle_command,
     parse_command, welcome_message, BotChatState, BotInteractionHandler,
-    BotInteractiveRequest, BotLanguage, BotMessageSender, HandleResult,
+    BotInteractiveRequest, BotMessageSender, HandleResult,
 };
 use super::{load_bot_persistence, save_bot_persistence, BotConfig, SavedBotConnection};
 use crate::service::remote_connect::remote_server::ImageAttachment;
@@ -169,6 +169,15 @@ struct UploadedMediaInfo {
     aeskey_hex: String,
     file_size_plain: u64,
     file_size_cipher: usize,
+}
+
+/// Result of `ilink/bot/getuploadurl`: the server may return either a
+/// pre-built complete CDN URL (`upload_full_url`, preferred) or just the
+/// `upload_param` to be combined with `cdn_base_url` and `filekey`.
+#[derive(Debug, Clone)]
+struct UploadUrlResult {
+    upload_full_url: Option<String>,
+    upload_param: Option<String>,
 }
 
 // ── QR login session store (in-memory, same role as OpenClaw installer) ─────
@@ -717,8 +726,22 @@ impl WeixinBot {
         DEFAULT_CDN_BASE_URL
     }
 
-    async fn fetch_weixin_cdn_bytes(&self, encrypted_query_param: &str) -> Result<Vec<u8>> {
-        let url = build_cdn_download_url(self.cdn_base_url(), encrypted_query_param);
+    /// Download CDN bytes.  Prefers `full_url` (when the server pre-builds the
+    /// complete URL, matching `@tencent-weixin/openclaw-weixin@2.x`'s
+    /// `CDNMedia.full_url`); otherwise falls back to building the URL from
+    /// `encrypted_query_param`.
+    async fn fetch_weixin_cdn_bytes(
+        &self,
+        encrypted_query_param: &str,
+        full_url: Option<&str>,
+    ) -> Result<Vec<u8>> {
+        let url = match full_url
+            .map(str::trim)
+            .filter(|s: &&str| !s.is_empty())
+        {
+            Some(u) => u.to_string(),
+            None => build_cdn_download_url(self.cdn_base_url(), encrypted_query_param),
+        };
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(120))
             .build()?;
@@ -738,6 +761,7 @@ impl WeixinBot {
             .as_str()
             .filter(|s| !s.is_empty())
             .ok_or_else(|| anyhow!("image: missing encrypt_query_param"))?;
+        let full_url = img["media"]["full_url"].as_str();
 
         let key: Option<[u8; 16]> = if let Some(hex_s) =
             img["aeskey"].as_str().filter(|s| !s.is_empty())
@@ -755,7 +779,7 @@ impl WeixinBot {
             None
         };
 
-        let enc = self.fetch_weixin_cdn_bytes(param).await?;
+        let enc = self.fetch_weixin_cdn_bytes(param, full_url).await?;
         match key {
             Some(k) => decrypt_aes_128_ecb_pkcs7(&enc, &k),
             None => Ok(enc),
@@ -826,7 +850,10 @@ impl WeixinBot {
         (attachments, skipped)
     }
 
-    /// `ilink/bot/getuploadurl` — returns `upload_param` for CDN POST.
+    /// `ilink/bot/getuploadurl` — returns either `upload_full_url` (preferred,
+    /// when the server pre-builds the complete CDN URL) and/or
+    /// `upload_param` (legacy, requires client-side URL composition).
+    /// Mirrors `getUploadUrl` in `@tencent-weixin/openclaw-weixin@2.x`.
     #[allow(clippy::too_many_arguments)]
     async fn ilink_get_upload_url(
         &self,
@@ -837,7 +864,7 @@ impl WeixinBot {
         rawfilemd5: &str,
         filesize: usize,
         aeskey_hex: &str,
-    ) -> Result<String> {
+    ) -> Result<UploadUrlResult> {
         let body = json!({
             "filekey": filekey,
             "media_type": media_type,
@@ -857,11 +884,22 @@ impl WeixinBot {
             )
             .await?;
         let v: Value = serde_json::from_str(&raw)?;
-        v["upload_param"]
-            .as_str()
-            .map(|s| s.to_string())
-            .filter(|s| !s.is_empty())
-            .ok_or_else(|| anyhow!("getuploadurl: missing upload_param"))
+        let pick = |k: &str| -> Option<String> {
+            v[k].as_str()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        };
+        let upload_full_url = pick("upload_full_url");
+        let upload_param = pick("upload_param");
+        if upload_full_url.is_none() && upload_param.is_none() {
+            return Err(anyhow!(
+                "getuploadurl: missing both upload_full_url and upload_param"
+            ));
+        }
+        Ok(UploadUrlResult {
+            upload_full_url,
+            upload_param,
+        })
     }
 
     async fn post_weixin_cdn_upload(&self, cdn_url: &str, ciphertext: &[u8]) -> Result<String> {
@@ -930,7 +968,7 @@ impl WeixinBot {
         rand::thread_rng().fill_bytes(&mut filekey_raw);
         let filekey = hex::encode(filekey_raw);
 
-        let upload_param = self
+        let url_resp = self
             .ilink_get_upload_url(
                 to_user_id,
                 &filekey,
@@ -942,7 +980,15 @@ impl WeixinBot {
             )
             .await?;
 
-        let cdn_url = build_cdn_upload_url(self.cdn_base_url(), &upload_param, &filekey);
+        let cdn_url = if let Some(full) = url_resp.upload_full_url.as_deref() {
+            full.to_string()
+        } else if let Some(param) = url_resp.upload_param.as_deref() {
+            build_cdn_upload_url(self.cdn_base_url(), param, &filekey)
+        } else {
+            return Err(anyhow!(
+                "getuploadurl: missing both upload_full_url and upload_param"
+            ));
+        };
         debug!(
             "weixin CDN upload: media_type={media_type} rawsize={rawsize} cipher_len={}",
             ciphertext.len()
@@ -1069,80 +1115,6 @@ impl WeixinBot {
             .await?;
         info!("Weixin file sent to peer={peer_id} name={}", content.name);
         Ok(())
-    }
-
-    fn expired_download_message(language: BotLanguage) -> &'static str {
-        if language.is_chinese() {
-            "这个下载链接已过期，请重新让助手发送一次。"
-        } else {
-            "This download link has expired. Please ask the agent again."
-        }
-    }
-
-    fn sending_file_message(language: BotLanguage, file_name: &str) -> String {
-        if language.is_chinese() {
-            format!("正在发送“{file_name}”……")
-        } else {
-            format!("Sending \"{file_name}\"…")
-        }
-    }
-
-    fn send_file_failed_message(language: BotLanguage, file_name: &str, error: &str) -> String {
-        if language.is_chinese() {
-            format!("无法发送“{file_name}”：{error}")
-        } else {
-            format!("Could not send \"{file_name}\": {error}")
-        }
-    }
-
-    async fn handle_download_request(
-        &self,
-        peer_id: &str,
-        token: &str,
-        workspace_root: Option<String>,
-    ) {
-        let (path, language) = {
-            let mut states = self.chat_states.write().await;
-            let state = states.get_mut(peer_id);
-            let language = current_bot_language().await;
-            let path = state.and_then(|s| s.pending_files.remove(token));
-            (path, language)
-        };
-
-        match path {
-            None => {
-                let _ = self
-                    .send_text(peer_id, Self::expired_download_message(language))
-                    .await;
-            }
-            Some(path) => {
-                let file_name = std::path::Path::new(&path)
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("file")
-                    .to_string();
-                let _ = self
-                    .send_text(peer_id, &Self::sending_file_message(language, &file_name))
-                    .await;
-                let root = workspace_root.as_deref().map(std::path::Path::new);
-                match self.send_workspace_file_to_peer(peer_id, &path, root).await {
-                    Ok(()) => info!("Weixin file delivered to {peer_id}: {path}"),
-                    Err(e) => {
-                        warn!("Weixin file send failed: {e}");
-                        let _ = self
-                            .send_text(
-                                peer_id,
-                                &Self::send_file_failed_message(
-                                    language,
-                                    &file_name,
-                                    &e.to_string(),
-                                ),
-                            )
-                            .await;
-                    }
-                }
-            }
-        }
     }
 
     async fn get_updates_once(&self, buf: &str, timeout: Duration) -> Result<Value> {
@@ -1347,25 +1319,61 @@ impl WeixinBot {
         }
     }
 
+    /// Scan `text` for downloadable file references and push each matching
+    /// file directly to the peer via the iLink CDN pipeline.  Files exceeding
+    /// `MAX_WEIXIN_FILE_BYTES` are skipped with a brief notice; per-file
+    /// failures are reported as plain-text replies.
     async fn notify_files_ready(&self, peer_id: &str, text: &str) {
-        let language = super::locale::current_bot_language().await;
-        let result = {
-            let mut states = self.chat_states.write().await;
-            let state = states.entry(peer_id.to_string()).or_insert_with(|| {
-                let mut s = BotChatState::new(peer_id.to_string());
-                s.paired = true;
-                s
-            });
-            let workspace_root = state.current_workspace.clone();
-            super::prepare_file_download_actions(
-                text,
-                state,
-                workspace_root.as_deref().map(std::path::Path::new),
-                language,
-            )
+        let language = current_bot_language().await;
+        let workspace_root = {
+            let states = self.chat_states.read().await;
+            states
+                .get(peer_id)
+                .and_then(|s| s.current_workspace.clone())
         };
-        if let Some(result) = result {
-            self.send_handle_result(peer_id, &result).await;
+        let files = super::collect_auto_push_files(
+            text,
+            workspace_root.as_deref().map(std::path::Path::new),
+        );
+        if files.is_empty() {
+            return;
+        }
+
+        let intro = super::auto_push_intro(language, files.len());
+        if let Err(e) = self.send_text(peer_id, &intro).await {
+            warn!("Weixin auto-push intro failed for peer {peer_id}: {e}");
+        }
+
+        let root_path = workspace_root.as_deref().map(std::path::Path::new);
+        for file in files {
+            if file.size > MAX_WEIXIN_FILE_BYTES {
+                let notice = super::auto_push_skip_too_large_message(
+                    language,
+                    &file.name,
+                    file.size,
+                    MAX_WEIXIN_FILE_BYTES,
+                );
+                let _ = self.send_text(peer_id, &notice).await;
+                continue;
+            }
+            match self
+                .send_workspace_file_to_peer(peer_id, &file.abs_path, root_path)
+                .await
+            {
+                Ok(()) => info!(
+                    "Weixin auto-pushed file to peer {peer_id}: {}",
+                    file.abs_path
+                ),
+                Err(e) => {
+                    warn!(
+                        "Weixin auto-push failed for {} to peer {peer_id}: {e}",
+                        file.name
+                    );
+                    let notice =
+                        super::auto_push_failed_message(language, &file.name, &e.to_string());
+                    let _ = self.send_text(peer_id, &notice).await;
+                }
+            }
         }
     }
 
@@ -1639,16 +1647,6 @@ impl WeixinBot {
                 "Please send the 6-digit pairing code."
             };
             let _ = self.send_text(&peer_id, err).await;
-            return;
-        }
-
-        let trimmed = text.trim();
-        if let Some(stripped) = trimmed.strip_prefix("download_file:") {
-            let token = stripped.trim().to_string();
-            let workspace_root = state.current_workspace.clone();
-            drop(states);
-            self.handle_download_request(&peer_id, &token, workspace_root)
-                .await;
             return;
         }
 

--- a/src/web-ui/src/app/scenes/miniapps/MiniAppScene.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/MiniAppScene.tsx
@@ -15,6 +15,7 @@ import { useSceneManager } from '@/app/hooks/useSceneManager';
 import type { SceneTabId } from '@/app/components/SceneBar/types';
 import { useMiniAppStore } from './miniAppStore';
 import { useI18n } from '@/infrastructure/i18n';
+import { pickLocalizedString } from './utils/pickLocalizedString';
 import './MiniAppScene.scss';
 
 const log = createLogger('MiniAppScene');
@@ -31,7 +32,7 @@ const MiniAppScene: React.FC<MiniAppSceneProps> = ({ appId }) => {
   const { themeType } = useTheme();
   const { workspacePath } = useCurrentWorkspace();
   const { closeScene } = useSceneManager();
-  const { t } = useI18n('scenes/miniapp');
+  const { t, currentLanguage } = useI18n('scenes/miniapp');
 
   const [app, setApp] = useState<MiniApp | null>(null);
   const [loading, setLoading] = useState(false);
@@ -121,7 +122,7 @@ const MiniAppScene: React.FC<MiniAppSceneProps> = ({ appId }) => {
       <div className="miniapp-scene__header">
         <div className="miniapp-scene__header-center">
           {app ? (
-            <span className="miniapp-scene__title">{app.name}</span>
+            <span className="miniapp-scene__title">{pickLocalizedString(app, currentLanguage, 'name')}</span>
           ) : (
             <span className="miniapp-scene__title miniapp-scene__title--loading">Mini App</span>
           )}

--- a/src/web-ui/src/app/scenes/miniapps/components/MiniAppCard.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/components/MiniAppCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Play, Square, Trash2 } from 'lucide-react';
 import type { MiniAppMeta } from '@/infrastructure/api/service-api/MiniAppAPI';
 import { renderMiniAppIcon } from '../utils/miniAppIcons';
+import { pickLocalizedString, pickLocalizedTags } from '../utils/pickLocalizedString';
 import { useI18n } from '@/infrastructure/i18n';
 import './MiniAppCard.scss';
 
@@ -24,7 +25,10 @@ const MiniAppCard: React.FC<MiniAppCardProps> = ({
   onDelete,
   onStop,
 }) => {
-  const { t } = useI18n('scenes/miniapp');
+  const { t, currentLanguage } = useI18n('scenes/miniapp');
+  const localizedName = pickLocalizedString(app, currentLanguage, 'name');
+  const localizedDescription = pickLocalizedString(app, currentLanguage, 'description');
+  const localizedTags = pickLocalizedTags(app, currentLanguage);
   const handleDeleteClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     onDelete(app.id);
@@ -62,7 +66,7 @@ const MiniAppCard: React.FC<MiniAppCardProps> = ({
       role="button"
       tabIndex={0}
       onKeyDown={(e) => e.key === 'Enter' && handleOpenDetails()}
-      aria-label={app.name}
+      aria-label={localizedName}
     >
       {/* Header with icon and title */}
       <div className="miniapp-card__header">
@@ -72,7 +76,7 @@ const MiniAppCard: React.FC<MiniAppCardProps> = ({
           </div>
         </div>
         <div className="miniapp-card__title-group">
-          <span className="miniapp-card__name">{app.name}</span>
+          <span className="miniapp-card__name">{localizedName}</span>
           <span className="miniapp-card__version">v{app.version}</span>
         </div>
         {isRunning && <span className="miniapp-card__run-dot" />}
@@ -80,14 +84,14 @@ const MiniAppCard: React.FC<MiniAppCardProps> = ({
 
       {/* Body: description + tags */}
       <div className="miniapp-card__body">
-        {app.description ? (
+        {localizedDescription ? (
           <div className="miniapp-card__desc">
-            <span className="miniapp-card__desc-inner">{app.description}</span>
+            <span className="miniapp-card__desc-inner">{localizedDescription}</span>
           </div>
         ) : null}
-        {app.tags.length > 0 ? (
+        {localizedTags.length > 0 ? (
           <div className="miniapp-card__tags">
-            {app.tags.slice(0, 3).map((tag) => (
+            {localizedTags.slice(0, 3).map((tag) => (
               <span key={tag} className="miniapp-card__tag">{tag}</span>
             ))}
           </div>

--- a/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppBridge.ts
+++ b/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppBridge.ts
@@ -12,6 +12,7 @@ import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext'
 import { useTheme } from '@/infrastructure/theme/hooks/useTheme';
 import { buildMiniAppThemeVars } from '../utils/buildMiniAppThemeVars';
 import { api } from '@/infrastructure/api/service-api/ApiClient';
+import { useI18n } from '@/infrastructure/i18n';
 
 interface JSONRPC {
   jsonrpc?: string;
@@ -33,10 +34,13 @@ export function useMiniAppBridge(
 ) {
   const { workspacePath } = useCurrentWorkspace();
   const { theme: currentTheme } = useTheme();
+  const { currentLanguage } = useI18n('scenes/miniapp');
   const themeRef = useRef(currentTheme);
   themeRef.current = currentTheme;
   const workspacePathRef = useRef(workspacePath);
   workspacePathRef.current = workspacePath;
+  const localeRef = useRef(currentLanguage);
+  localeRef.current = currentLanguage;
 
   const appIdRef = useRef(app.id);
   useLayoutEffect(() => {
@@ -64,6 +68,19 @@ export function useMiniAppBridge(
         if (payload && iframeRef.current?.contentWindow) {
           iframeRef.current.contentWindow.postMessage(
             { type: 'bitfun:event', event: 'themeChange', payload },
+            '*',
+          );
+        }
+        return;
+      }
+
+      if (method === 'bitfun/request-locale') {
+        // Reply with the current locale id (e.g. "zh-CN" / "en-US"). The MiniApp
+        // can use this both as the initial value and to look up its own i18n bundle.
+        reply({ locale: localeRef.current });
+        if (iframeRef.current?.contentWindow) {
+          iframeRef.current.contentWindow.postMessage(
+            { type: 'bitfun:event', event: 'localeChange', payload: { locale: localeRef.current } },
             '*',
           );
         }
@@ -162,6 +179,16 @@ export function useMiniAppBridge(
       '*',
     );
   }, [currentTheme, iframeRef]);
+
+  // Push locale changes to the iframe so MiniApps can re-render their UI strings
+  // without reloading. MiniApps subscribe via `app.on('localeChange', fn)`.
+  useEffect(() => {
+    if (!iframeRef.current?.contentWindow) return;
+    iframeRef.current.contentWindow.postMessage(
+      { type: 'bitfun:event', event: 'localeChange', payload: { locale: currentLanguage } },
+      '*',
+    );
+  }, [currentLanguage, iframeRef]);
 
   // Listen for AI stream events from Tauri and forward them to the iframe.
   useEffect(() => {

--- a/src/web-ui/src/app/scenes/miniapps/utils/pickLocalizedString.ts
+++ b/src/web-ui/src/app/scenes/miniapps/utils/pickLocalizedString.ts
@@ -1,0 +1,62 @@
+/**
+ * Pick the best-matching localized string for a MiniApp meta field.
+ *
+ * Resolution order:
+ *   1. `meta.i18n.locales[currentLanguage].<field>` (exact match)
+ *   2. `meta.i18n.locales['en-US'].<field>`         (universal fallback)
+ *   3. `meta.i18n.locales['zh-CN'].<field>`         (project default)
+ *   4. The top-level `meta.<field>` value           (author default / legacy apps)
+ *
+ * Apps without an `i18n` block (legacy or user-authored) keep working transparently.
+ */
+
+import type { MiniAppMeta, MiniAppLocaleStrings } from '@/infrastructure/api/service-api/MiniAppAPI';
+
+const FALLBACK_CHAIN = ['en-US', 'zh-CN'] as const;
+
+type LocalizableStringField = 'name' | 'description';
+
+export function pickLocalizedString(
+  meta: Pick<MiniAppMeta, LocalizableStringField | 'i18n'>,
+  currentLanguage: string,
+  field: LocalizableStringField,
+): string {
+  const fromCurrent = meta.i18n?.locales?.[currentLanguage]?.[field];
+  if (fromCurrent) return fromCurrent;
+
+  for (const fallbackLang of FALLBACK_CHAIN) {
+    if (fallbackLang === currentLanguage) continue;
+    const v = meta.i18n?.locales?.[fallbackLang]?.[field];
+    if (v) return v;
+  }
+
+  return meta[field] ?? '';
+}
+
+export function pickLocalizedTags(
+  meta: Pick<MiniAppMeta, 'tags' | 'i18n'>,
+  currentLanguage: string,
+): string[] {
+  const fromCurrent = meta.i18n?.locales?.[currentLanguage]?.tags;
+  if (fromCurrent && fromCurrent.length) return fromCurrent;
+
+  for (const fallbackLang of FALLBACK_CHAIN) {
+    if (fallbackLang === currentLanguage) continue;
+    const v = meta.i18n?.locales?.[fallbackLang]?.tags;
+    if (v && v.length) return v;
+  }
+
+  return meta.tags ?? [];
+}
+
+/** Convenience: project all localizable fields at once. */
+export function pickLocalizedMeta(
+  meta: MiniAppMeta,
+  currentLanguage: string,
+): MiniAppLocaleStrings & { name: string; description: string; tags: string[] } {
+  return {
+    name: pickLocalizedString(meta, currentLanguage, 'name'),
+    description: pickLocalizedString(meta, currentLanguage, 'description'),
+    tags: pickLocalizedTags(meta, currentLanguage),
+  };
+}

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppGalleryView.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppGalleryView.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/app/components';
 import type { SceneTabId } from '@/app/components/SceneBar/types';
 import { getMiniAppIconGradient, renderMiniAppIcon } from '../utils/miniAppIcons';
+import { pickLocalizedString, pickLocalizedTags } from '../utils/pickLocalizedString';
 import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
 import { useMiniAppStore } from '../miniAppStore';
 import { useI18n } from '@/infrastructure/i18n';
@@ -45,7 +46,7 @@ const MiniAppGalleryView: React.FC = () => {
   const markWorkerStopped = useMiniAppStore((state) => state.markWorkerStopped);
   const { workspacePath } = useCurrentWorkspace();
   const { openScene, activateScene, closeScene, openTabs } = useSceneManager();
-  const { t } = useI18n('scenes/miniapp');
+  const { t, currentLanguage } = useI18n('scenes/miniapp');
 
   const [search, setSearch] = useState('');
   const [categoryFilter, setCategoryFilter] = useState('all');
@@ -71,15 +72,23 @@ const MiniAppGalleryView: React.FC = () => {
   const filtered = useMemo(() => {
     return apps.filter((app) => {
       const keyword = search.toLowerCase();
+      // Search across the localized strings + raw fallback so users can search
+      // either the displayed text OR the author's original wording.
+      const localizedName = pickLocalizedString(app, currentLanguage, 'name').toLowerCase();
+      const localizedDesc = pickLocalizedString(app, currentLanguage, 'description').toLowerCase();
+      const localizedTags = pickLocalizedTags(app, currentLanguage).map((t) => t.toLowerCase());
       const matchSearch =
         !search ||
+        localizedName.includes(keyword) ||
+        localizedDesc.includes(keyword) ||
         app.name.toLowerCase().includes(keyword) ||
         app.description.toLowerCase().includes(keyword) ||
+        localizedTags.some((tag) => tag.includes(keyword)) ||
         app.tags.some((tag) => tag.toLowerCase().includes(keyword));
       const matchCategory = categoryFilter === 'all' || app.category === categoryFilter;
       return matchSearch && matchCategory;
     });
-  }, [apps, search, categoryFilter]);
+  }, [apps, search, categoryFilter, currentLanguage]);
 
   const handleOpenApp = useCallback(
     (appId: string) => {
@@ -298,9 +307,9 @@ const MiniAppGalleryView: React.FC = () => {
         onClose={() => setSelectedApp(null)}
         icon={selectedApp ? renderMiniAppIcon(selectedApp.icon || 'box', 24) : <Box size={24} />}
         iconGradient={selectedApp ? getMiniAppIconGradient(selectedApp.icon || 'box') : undefined}
-        title={selectedApp?.name ?? ''}
+        title={selectedApp ? pickLocalizedString(selectedApp, currentLanguage, 'name') : ''}
         badges={selectedApp?.category ? <Badge variant="info">{selectedApp.category}</Badge> : null}
-        description={selectedApp?.description}
+        description={selectedApp ? pickLocalizedString(selectedApp, currentLanguage, 'description') : undefined}
         meta={selectedApp ? <span>v{selectedApp.version}</span> : null}
         actions={selectedApp ? (
           <>
@@ -321,16 +330,19 @@ const MiniAppGalleryView: React.FC = () => {
           </>
         ) : null}
       >
-        {selectedApp?.tags.length ? (
-          <div className="miniapp-gallery__detail-tags">
-            {selectedApp.tags.map((tag) => (
-              <span key={tag} className="miniapp-gallery__detail-tag">
-                <Tag size={11} />
-                {tag}
-              </span>
-            ))}
-          </div>
-        ) : null}
+        {selectedApp ? (() => {
+          const detailTags = pickLocalizedTags(selectedApp, currentLanguage);
+          return detailTags.length ? (
+            <div className="miniapp-gallery__detail-tags">
+              {detailTags.map((tag) => (
+                <span key={tag} className="miniapp-gallery__detail-tag">
+                  <Tag size={11} />
+                  {tag}
+                </span>
+              ))}
+            </div>
+          ) : null;
+        })() : null}
       </GalleryDetailModal>
 
       <ConfirmDialog

--- a/src/web-ui/src/infrastructure/api/service-api/MiniAppAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/MiniAppAPI.ts
@@ -85,6 +85,17 @@ export interface MiniAppRuntimeState {
   ui_recompile_required: boolean;
 }
 
+export interface MiniAppLocaleStrings {
+  name?: string;
+  description?: string;
+  tags?: string[];
+}
+
+export interface MiniAppI18n {
+  /** Map of locale id (e.g. "zh-CN", "en-US") to per-locale string overrides. */
+  locales: Record<string, MiniAppLocaleStrings>;
+}
+
 export interface MiniAppMeta {
   id: string;
   name: string;
@@ -97,6 +108,8 @@ export interface MiniAppMeta {
   updated_at: number;
   permissions: MiniAppPermissions;
   runtime?: MiniAppRuntimeState;
+  /** Optional per-locale overrides for `name` / `description` / `tags`. */
+  i18n?: MiniAppI18n;
 }
 
 export interface MiniApp extends MiniAppMeta {


### PR DESCRIPTION
## Summary

- **MiniApp i18n framework**: optional `i18n` block on `MiniAppMeta` for `name` / `description` / `tags`, plus runtime `app.locale` / `app.onLocaleChange(fn)` / `app.t(table, fallback)` exposed through the bridge. Host (`useMiniAppBridge`) answers `bitfun/request-locale` and pushes `localeChange` events when the UI language changes; new `pickLocalizedString` helper resolves strings with a `current → en-US → zh-CN → top-level` fallback chain and is wired into Gallery cards, search/filter, the detail modal and Scene tab titles.
- **Daily Coding Snapshot** (4th built-in MiniApp): scans the active workspace's git repo via a Node worker and renders a single-screen Bento dashboard — today commits / lines / files / languages, weekly language donut, 24h activity rhythm, and an adaptive 52-week heatmap that picks 1..6 stacked 7-row bands so it fully fills the tile regardless of aspect ratio.
- **Built-in app i18n + polish**: all four built-ins (Gomoku, Daily Divination, Regex Playground, Daily Coding Snapshot) ship full zh-CN / en-US strings in `meta.json` and `ui.js`. Daily Divination's content datasets (cards / suits / colors / hours / mantras / insights) are kept parallel across locales so the daily-seeded random keeps its identity; \"Today's Insight\" label moved out of CSS `::before` so it can be translated; fortune-matrix labels grow to `max-content` so longer English words (e.g. \"Inspiration\") no longer clip. Regex Playground's sample text is now a single English snippet so the scratchpad doesn't flip with the UI language.
- **Bot locale layer**: shared `bot/locale.rs` powers Feishu / Telegram / Weixin adapters with a single locale-aware menu / command / reply surface.
- **Skill docs**: `SKILL.md` and `api-reference.md` document the new `meta.json` `i18n` block, `app.locale` / `app.onLocaleChange` / `app.t`, the `data-i18n` convention, and a self-check list so AI-generated MiniApps default to multi-locale.

Built-in `version` markers bumped so existing installs reseed.

## Test plan

- [x] \`cargo check -p bitfun-core\` clean
- [x] \`tsc --noEmit\` clean
- [ ] Manually switch UI language in Gallery — card name / description / tags / scene tab title and search match all update
- [ ] Open each built-in MiniApp and toggle language at runtime — static labels, dynamic lists, aria-labels, and titles all re-render
- [ ] Open Daily Coding Snapshot on a real git workspace — heatmap fills the tile across various aspect ratios, today/yesterday delta and streak read correctly
- [ ] Reopen Daily Divination after a language switch — same daily card / fortunes / lucky omens, just translated; persisted reading restores correctly
- [ ] Regex Playground sample text stays English in both languages
- [ ] IM bots (Feishu / Telegram / Weixin) menus and replies follow the configured locale