### PR TITLE
fix(docs): restore README badges and screenshot images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 [中文](README.zh-CN.md) | **English**
 
+<div align="center">
 
+![BitFun](./png/BitFun_title.png)
 
-BitFun
+</div>
+<div align="center">
 
+[![GitHub release](https://img.shields.io/github/v/release/GCWing/BitFun?style=flat-square&color=blue)](https://github.com/GCWing/BitFun/releases)
+[![Website](https://img.shields.io/badge/Website-openbitfun.com-6f42c1?style=flat-square)](https://openbitfun.com/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](https://github.com/GCWing/BitFun/blob/main/LICENSE)
+[![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue?style=flat-square)](https://github.com/GCWing/BitFun)
 
-
-[GitHub release](https://github.com/GCWing/BitFun/releases)
-[Website](https://openbitfun.com/)
-[License: MIT](https://github.com/GCWing/BitFun/blob/main/LICENSE)
-[Platform](https://github.com/GCWing/BitFun)
-
-
+</div>
 
 ---
 
@@ -23,7 +24,7 @@ You do not need to care about underlying structures such as sessions, workspaces
 
 You only need to state what you want. Whether you start directly from the **desktop app** or direct it remotely through your **phone or bots**, **BitFun organizes tasks, carries context forward, and keeps AI working continuously in the background, gradually adapting to your personal workflow**.
 
-first_screen_screenshot
+![first_screen_screenshot](./png/first_screen_screenshot.png)
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,11 +1,18 @@
 **中文**  [English](README.md)
 
-BitFun
+<div align="center">
 
-[GitHub release](https://github.com/GCWing/BitFun/releases)
-[Website](https://openbitfun.com/)
-[License: MIT](https://github.com/GCWing/BitFun/blob/main/LICENSE)
-[Platform](https://github.com/GCWing/BitFun)
+![BitFun](./png/BitFun_title.png)
+
+</div>
+<div align="center">
+
+[![GitHub release](https://img.shields.io/github/v/release/GCWing/BitFun?style=flat-square&color=blue)](https://github.com/GCWing/BitFun/releases)
+[![Website](https://img.shields.io/badge/Website-openbitfun.com-6f42c1?style=flat-square)](https://openbitfun.com/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](https://github.com/GCWing/BitFun/blob/main/LICENSE)
+[![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue?style=flat-square)](https://github.com/GCWing/BitFun)
+
+</div>
 
 ---
 
@@ -17,7 +24,7 @@ BitFun 是面向AI时代打造的Agentic OS，承载各类**智能应用**调度
 
 你只需要提出需求，无论是在**桌面端**直接发起，还是通过**手机、机器人**等入口远程指挥，**BitFun 都会在背后组织任务、衔接上下文，并让 AI 持续工作、持续沉淀，逐步贴合你的个人流程**。
 
-first_screen_screenshot
+![first_screen_screenshot](./png/first_screen_screenshot_CN.png)
 
 ---
 


### PR DESCRIPTION
## Summary

Restores GitHub-rendered visuals in README that were lost when badge and image markup was replaced with plain links and placeholder text.

## Changes

- **README.md**: Centered title image (BitFun_title.png), Shields.io badges (release, website, license, platform), and ![first_screen_screenshot](./png/first_screen_screenshot.png) for the intro screenshot.
- **README.zh-CN.md**: Same header badges and title image; Chinese screenshot uses irst_screen_screenshot_CN.png as before.

No application code changes.