### PR TITLE
feat: remote SSH resilience, session-path correctness, and explorer/miniapp polish

### DIFF
--- a/src/apps/desktop/src/api/app_state.rs
+++ b/src/apps/desktop/src/api/app_state.rs
@@ -141,6 +141,16 @@ impl AppState {
         };
         let path_manager = workspace_service.path_manager().clone();
 
+        // One-time migration: relocate remote SSH sessions that were misplaced under
+        // `~/.bitfun/projects/<slug>/sessions/` (caused by the workspace runtime layout
+        // refactor) back to the canonical
+        // `~/.bitfun/remote_ssh/{host}/{path}/sessions/` mirror dirs. Idempotent.
+        if let Ok(persistence) =
+            bitfun_core::agentic::persistence::PersistenceManager::new(path_manager.clone())
+        {
+            persistence.migrate_misplaced_remote_sessions().await;
+        }
+
         let announcement_scheduler = Arc::new(
             announcement::AnnouncementScheduler::new(&path_manager)
                 .await

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -573,10 +573,13 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         turn_index: usize,
         user_input: &str,
         workspace_path: &str,
+        // Pre-resolved on-disk session storage path (mirror dir for remote workspaces).
+        // When present we use it directly so we never re-resolve without remote SSH info
+        // (which would slugify a raw remote POSIX path under `~/.bitfun/projects/`).
+        resolved_session_storage_path: Option<&std::path::Path>,
         status: crate::service::session::TurnStatus,
         user_message_metadata: Option<serde_json::Value>,
     ) {
-        use crate::agentic::core::SessionConfig;
         use crate::agentic::persistence::PersistenceManager;
         use crate::infrastructure::PathManager;
         use crate::service::session::{
@@ -588,16 +591,9 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             Err(_) => return,
         };
 
-        let workspace_path_buf = {
-            let binding = Self::build_workspace_binding(&SessionConfig {
-                workspace_path: Some(workspace_path.to_string()),
-                ..Default::default()
-            })
-            .await;
-            binding
-                .as_ref()
-                .map(|b| b.session_storage_path().to_path_buf())
-                .unwrap_or_else(|| std::path::PathBuf::from(workspace_path))
+        let workspace_path_buf = match resolved_session_storage_path {
+            Some(p) => p.to_path_buf(),
+            None => std::path::PathBuf::from(workspace_path),
         };
         let persistence_manager = match PersistenceManager::new(path_manager) {
             Ok(manager) => manager,
@@ -1419,6 +1415,12 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         let session_workspace_path = session_workspace
             .as_ref()
             .map(|workspace| workspace.root_path_string());
+        // Pre-resolve the on-disk session storage path (mirror dir for remote workspaces)
+        // so the safety-net writer never has to re-resolve without remote_connection_id /
+        // remote_ssh_host (which would silently fall back to a slugified raw remote path).
+        let session_storage_path = session_workspace
+            .as_ref()
+            .map(|workspace| workspace.session_storage_path().to_path_buf());
 
         let execution_context = ExecutionContext {
             session_id: session_id.clone(),
@@ -1481,6 +1483,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         let session_id_clone = session_id.clone();
         let turn_id_clone = turn_id.clone();
         let user_input_for_workspace = wrapped_user_input.clone();
+        let session_storage_path_for_finalize = session_storage_path.clone();
         let effective_agent_type_clone = effective_agent_type.clone();
         let user_message_metadata_clone = user_message_metadata;
         let scheduler_notify_tx = self.scheduler_notify_tx.get().cloned();
@@ -1655,6 +1658,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     turn_index,
                     &user_input_for_workspace,
                     wp,
+                    session_storage_path_for_finalize.as_deref(),
                     status,
                     user_message_metadata_clone,
                 )

--- a/src/crates/core/src/agentic/persistence/manager.rs
+++ b/src/crates/core/src/agentic/persistence/manager.rs
@@ -8,6 +8,7 @@ use crate::agentic::core::{
 };
 use crate::infrastructure::PathManager;
 use crate::service::remote_ssh::workspace_state::{
+    normalize_remote_workspace_path, remote_workspace_session_mirror_dir,
     resolve_workspace_session_identity, LOCAL_WORKSPACE_SSH_HOST,
 };
 use crate::service::session::{
@@ -187,7 +188,26 @@ impl PersistenceManager {
         &self.runtime_service
     }
 
+    /// Resolve the on-disk sessions directory for `workspace_path`.
+    ///
+    /// For local workspaces this delegates to `PathManager::project_sessions_dir`,
+    /// which slugifies the workspace root under `~/.bitfun/projects/`.
+    ///
+    /// For remote SSH workspaces, callers (notably `desktop_effective_session_storage_path`)
+    /// pass an already-resolved mirror path under `~/.bitfun/remote_ssh/{host}/{path}/sessions`.
+    /// In that case we MUST use the path as-is; otherwise the slug pipeline would treat the
+    /// mirror path as a workspace root and write/read to a bogus
+    /// `~/.bitfun/projects/<slug-of-mirror-path>/sessions/` location.
     fn project_sessions_dir(&self, workspace_path: &Path) -> PathBuf {
+        let remote_mirror_root = PathManager::remote_ssh_mirror_root();
+        if workspace_path.starts_with(&remote_mirror_root) {
+            // Already resolved: either the mirror runtime root, the mirror sessions dir,
+            // or a session sub-dir. Treat the path as the sessions root directly.
+            // (Inputs that already include a trailing `sessions` segment stay correct;
+            // inputs at the mirror runtime root would historically fall back to the
+            // legacy slug, but no current call-site uses that shape.)
+            return workspace_path.to_path_buf();
+        }
         self.path_manager.project_sessions_dir(workspace_path)
     }
 
@@ -2147,6 +2167,178 @@ impl PersistenceManager {
                 .await?;
         }
         Ok(())
+    }
+
+    /// Migrate sessions that were saved to the wrong on-disk location prior to the fix.
+    ///
+    /// Two failure modes existed for remote SSH workspaces:
+    ///
+    /// 1. The frontend-saved sessions for a remote workspace went through
+    ///    `desktop_effective_session_storage_path`, which returns
+    ///    `~/.bitfun/remote_ssh/{host}/{path}/sessions`. That path was then
+    ///    re-slugified by `PathManager::project_sessions_dir` and ended up at
+    ///    `~/.bitfun/projects/<slug-of-mirror-path>/sessions/`.
+    /// 2. The coordinator's safety-net writer did not pass remote SSH info, so
+    ///    the raw remote POSIX root (e.g. `/root/lwb/repo/BitFun`) was treated
+    ///    as a local workspace and slugified to
+    ///    `~/.bitfun/projects/<slug-of-remote-root>/sessions/Recovered Session…`.
+    ///
+    /// This routine scans `~/.bitfun/projects/*/sessions/` for any session whose
+    /// `metadata.json` records a non-`localhost` `workspaceHostname`, and moves
+    /// the session directory to the correct mirror dir at
+    /// `~/.bitfun/remote_ssh/{host}/{normalized path}/sessions/`.
+    /// Empty source `sessions` and project dirs are removed afterwards.
+    ///
+    /// Safe to call repeatedly; sessions already at the destination are left in place.
+    pub async fn migrate_misplaced_remote_sessions(&self) {
+        let projects_root = self.path_manager.projects_root();
+        let mut project_iter = match fs::read_dir(&projects_root).await {
+            Ok(it) => it,
+            Err(e) if e.kind() == ErrorKind::NotFound => return,
+            Err(e) => {
+                warn!(
+                    "migrate_misplaced_remote_sessions: cannot read {}: {}",
+                    projects_root.display(),
+                    e
+                );
+                return;
+            }
+        };
+
+        let mut moved_total: usize = 0;
+        let mut scanned_projects: usize = 0;
+
+        while let Ok(Some(project_entry)) = project_iter.next_entry().await {
+            let project_dir = project_entry.path();
+            let sessions_dir = project_dir.join("sessions");
+            if !sessions_dir.is_dir() {
+                continue;
+            }
+            scanned_projects += 1;
+
+            let mut session_iter = match fs::read_dir(&sessions_dir).await {
+                Ok(it) => it,
+                Err(_) => continue,
+            };
+
+            let mut moved_in_project: usize = 0;
+            let mut session_count: usize = 0;
+            while let Ok(Some(session_entry)) = session_iter.next_entry().await {
+                let session_dir = session_entry.path();
+                if !session_dir.is_dir() {
+                    continue;
+                }
+                session_count += 1;
+
+                let metadata_path = session_dir.join("metadata.json");
+                let raw = match fs::read(&metadata_path).await {
+                    Ok(b) => b,
+                    Err(_) => continue,
+                };
+                let stored: StoredSessionMetadataFile = match serde_json::from_slice(&raw) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                let metadata = stored.metadata;
+                let hostname = metadata
+                    .workspace_hostname
+                    .as_deref()
+                    .map(str::trim)
+                    .unwrap_or("");
+                let workspace_path = metadata
+                    .workspace_path
+                    .as_deref()
+                    .map(str::trim)
+                    .unwrap_or("");
+                if workspace_path.is_empty() {
+                    continue;
+                }
+                // Only handle records that are clearly remote workspaces.
+                if hostname.is_empty()
+                    || hostname == LOCAL_WORKSPACE_SSH_HOST
+                    || hostname == "_unresolved"
+                {
+                    continue;
+                }
+
+                let target_sessions_dir = remote_workspace_session_mirror_dir(
+                    hostname,
+                    &normalize_remote_workspace_path(workspace_path),
+                );
+                let target_dir = target_sessions_dir.join(&metadata.session_id);
+                if target_dir.exists() {
+                    // Destination already populated — drop the legacy copy.
+                    if let Err(e) = fs::remove_dir_all(&session_dir).await {
+                        warn!(
+                            "migrate_misplaced_remote_sessions: failed to remove duplicate {}: {}",
+                            session_dir.display(),
+                            e
+                        );
+                    } else {
+                        moved_in_project += 1;
+                    }
+                    continue;
+                }
+
+                if let Err(e) = fs::create_dir_all(&target_sessions_dir).await {
+                    warn!(
+                        "migrate_misplaced_remote_sessions: cannot create {}: {}",
+                        target_sessions_dir.display(),
+                        e
+                    );
+                    continue;
+                }
+                if let Err(e) = fs::rename(&session_dir, &target_dir).await {
+                    warn!(
+                        "migrate_misplaced_remote_sessions: failed to move {} -> {}: {}",
+                        session_dir.display(),
+                        target_dir.display(),
+                        e
+                    );
+                    continue;
+                }
+                info!(
+                    "migrate_misplaced_remote_sessions: moved session {} from {} to {}",
+                    metadata.session_id,
+                    session_dir.display(),
+                    target_dir.display()
+                );
+                moved_in_project += 1;
+
+                // Force the destination index to rebuild on next read.
+                let dest_index = target_sessions_dir.join("index.json");
+                if dest_index.exists() {
+                    let _ = fs::remove_file(&dest_index).await;
+                }
+            }
+
+            // If we drained every session from this legacy project dir, clean it up so
+            // it doesn't keep showing as an empty entry under ~/.bitfun/projects/.
+            if moved_in_project > 0 && moved_in_project == session_count {
+                let _ = fs::remove_file(sessions_dir.join("index.json")).await;
+                let _ = fs::remove_dir(&sessions_dir).await;
+                // Best-effort: only drop the project dir if it is now empty.
+                if let Ok(mut leftover) = fs::read_dir(&project_dir).await {
+                    if leftover
+                        .next_entry()
+                        .await
+                        .map(|e| e.is_none())
+                        .unwrap_or(false)
+                    {
+                        let _ = fs::remove_dir(&project_dir).await;
+                    }
+                }
+            }
+
+            moved_total += moved_in_project;
+        }
+
+        if moved_total > 0 {
+            info!(
+                "migrate_misplaced_remote_sessions: relocated {} session(s) across {} project dir(s)",
+                moved_total, scanned_projects
+            );
+        }
     }
 }
 

--- a/src/crates/core/src/miniapp/builtin/assets/coding-selfie/style.css
+++ b/src/crates/core/src/miniapp/builtin/assets/coding-selfie/style.css
@@ -170,9 +170,9 @@ html, body {
   white-space: nowrap;
 }
 
-/* ─── Hero Tile (8 cols) ──────────────────────────── */
+/* ─── Hero Tile (9 cols ~ 3/4 width) ───────────────── */
 .cs-tile-hero {
-  grid-column: span 8;
+  grid-column: span 9;
   padding: clamp(10px, 1.5vh, 16px) clamp(14px, 1.8vw, 20px);
   background:
     radial-gradient(circle at 80% 0%, rgba(var(--cs-accent-rgb), 0.10), transparent 55%),
@@ -314,38 +314,54 @@ html, body {
 }
 .cs-meta-repo { font-weight: 500; color: var(--cs-text-2); }
 
-/* ─── Streak Tile (4 cols) ────────────────────────── */
+/* ─── Streak Tile (3 cols ~ 1/4 width, compact vertical) ─ */
 .cs-tile-streak {
-  grid-column: span 4;
+  grid-column: span 3;
   background:
     linear-gradient(140deg, rgba(var(--cs-accent-rgb), 0.10), transparent 70%),
     var(--cs-card);
   border-color: rgba(var(--cs-accent-rgb), 0.22);
-  flex-direction: row;
-  align-items: center;
-  gap: clamp(8px, 1.5vw, 14px);
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  grid-template-rows: auto 1fr auto;
+  column-gap: clamp(6px, 0.8vw, 10px);
+  row-gap: clamp(2px, 0.5vh, 6px);
 }
-.cs-tile-streak .cs-tile-head { margin-bottom: 0; flex-shrink: 0; }
+.cs-tile-streak .cs-tile-head {
+  grid-column: 1 / -1;
+  grid-row: 1;
+  margin-bottom: 0;
+}
 .cs-tile-streak .cs-streak-num {
-  font-size: clamp(28px, 5.5vh, 48px);
+  grid-column: 1;
+  grid-row: 2;
+  font-size: clamp(22px, 4.4vh, 36px);
   font-weight: 600;
   line-height: 1;
   color: var(--cs-accent);
   text-shadow: var(--cs-accent-glow);
   letter-spacing: -0.04em;
+  align-self: end;
 }
 .cs-streak-unit {
+  grid-column: 2;
+  grid-row: 2;
   font-family: var(--cs-mono);
-  font-size: clamp(9px, 1.2vh, 10.5px);
-  letter-spacing: 0.2em;
+  font-size: clamp(8.5px, 1.05vh, 10px);
+  letter-spacing: 0.18em;
   color: var(--cs-text-muted);
+  white-space: nowrap;
+  align-self: end;
+  padding-bottom: clamp(2px, 0.4vh, 4px);
 }
 .cs-streak-foot {
-  margin-left: auto;
-  font-size: clamp(10px, 1.4vh, 11.5px);
+  grid-column: 1 / -1;
+  grid-row: 3;
+  margin-left: 0;
+  font-size: clamp(9.5px, 1.2vh, 11px);
   color: var(--cs-text-2);
-  text-align: right;
-  max-width: 50%;
+  text-align: left;
+  max-width: 100%;
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -391,8 +407,8 @@ html, body {
 .cs-stat-foot.down { color: var(--cs-del); }
 .cs-stat-foot svg { width: 10px; height: 10px; flex-shrink: 0; }
 
-/* ─── Donut Tile (5 cols) ─────────────────────────── */
-.cs-tile-donut { grid-column: span 5; min-height: 0; }
+/* ─── Donut Tile (6 cols ~ 1/2 width) ──────────────── */
+.cs-tile-donut { grid-column: span 6; min-height: 0; }
 .cs-donut-row {
   display: flex;
   align-items: center;
@@ -403,8 +419,8 @@ html, body {
 }
 .cs-donut-wrap {
   position: relative;
-  width: clamp(60px, 11vh, 100px);
-  height: clamp(60px, 11vh, 100px);
+  width: clamp(80px, 16vh, 150px);
+  height: clamp(80px, 16vh, 150px);
   flex: 0 0 auto;
 }
 .cs-donut { width: 100%; height: 100%; transform: rotate(-90deg); display: block; }
@@ -418,7 +434,7 @@ html, body {
   pointer-events: none;
 }
 .cs-donut-value {
-  font-size: clamp(15px, 2.6vh, 20px);
+  font-size: clamp(18px, 3.2vh, 28px);
   font-weight: 600;
   letter-spacing: -0.03em;
   color: var(--cs-text);
@@ -448,7 +464,7 @@ html, body {
 }
 .cs-legend-row {
   display: grid;
-  grid-template-columns: 8px 1fr auto;
+  grid-template-columns: 8px minmax(0, 1fr) minmax(40px, 1.4fr) auto;
   gap: 8px;
   align-items: center;
   font-size: clamp(10px, 1.45vh, 12px);
@@ -462,14 +478,29 @@ html, body {
   white-space: nowrap;
   min-width: 0;
 }
+.cs-legend-bar {
+  display: block;
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--cs-card-2);
+  overflow: hidden;
+  position: relative;
+}
+.cs-legend-bar > i {
+  display: block;
+  height: 100%;
+  border-radius: 3px;
+  transition: width 220ms ease;
+}
 .cs-legend-pct {
   font-family: var(--cs-mono);
   color: var(--cs-text-muted);
   font-size: clamp(9.5px, 1.3vh, 11px);
 }
 
-/* ─── Hours Tile (7 cols) ─────────────────────────── */
-.cs-tile-hours { grid-column: span 7; }
+/* ─── Hours Tile (6 cols ~ 1/2 width) ──────────────── */
+.cs-tile-hours { grid-column: span 6; }
 .cs-hours {
   display: grid;
   grid-template-columns: repeat(24, 1fr);
@@ -578,6 +609,23 @@ html, body {
 .cs-heat-4 {
   background: var(--cs-accent);
   box-shadow: 0 0 10px rgba(var(--cs-accent-rgb), 0.35);
+}
+
+/* Custom hover tooltip for heatmap cells (replaces native title delay). */
+.cs-heat-tooltip {
+  position: fixed;
+  z-index: 9999;
+  pointer-events: none;
+  padding: 5px 9px;
+  border-radius: 6px;
+  background: var(--cs-card);
+  border: 1px solid var(--cs-border-strong);
+  color: var(--cs-text);
+  font-family: var(--cs-mono);
+  font-size: 11.5px;
+  line-height: 1.3;
+  white-space: nowrap;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
 }
 
 .cs-heatmap-legend {

--- a/src/crates/core/src/miniapp/builtin/assets/coding-selfie/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/coding-selfie/ui.js
@@ -121,8 +121,8 @@ const I18N = {
     loadingTitleFirst: '正在扫描你的代码足迹',
     errNoWs: '还没有打开工作区',
     errNoWsDesc: '请先在 BitFun 侧边栏选择一个 Git 仓库的工作区。',
-    errNotGit: '当前工作区不是 Git 仓库',
-    errNotGitDesc: (p) => `${p} · 执行 git init 或切换到 Git 仓库`,
+    errNotGit: '当前工作区不是 Git 仓库或远程工作区',
+    errNotGitDesc: (p) => `${p} · 执行 git init 或切换到本地 Git 仓库`,
     errNoWsShort: '未检测到工作区',
     errNoWsShortDesc: '请先打开一个工作区',
     errScan: '扫描失败',
@@ -215,8 +215,8 @@ const I18N = {
     loadingTitleFirst: 'Scanning your code footprint',
     errNoWs: 'No workspace open',
     errNoWsDesc: 'Open a Git repo workspace from the BitFun sidebar first.',
-    errNotGit: 'Workspace is not a Git repo',
-    errNotGitDesc: (p) => `${p} · run \`git init\` or switch to a Git repo`,
+    errNotGit: 'Workspace is not a local Git repo (or it is a remote workspace)',
+    errNotGitDesc: (p) => `${p} · run \`git init\` or switch to a local Git repo`,
     errNoWsShort: 'No workspace detected',
     errNoWsShortDesc: 'Open a workspace first',
     errScan: 'Scan failed',
@@ -362,14 +362,24 @@ function renderDonut(langs) {
 
   const legend = $('lang-legend');
   legend.innerHTML = '';
+  // The bar widths are normalized to the dominant slice (max), so the leading
+  // language always shows a full bar — this reads as a per-language ranking
+  // chart rather than each slice being scaled against the full pie (which
+  // would leave bars visually identical to the percentage text).
+  const maxWeight = Math.max(1, ...slices.map((s) => s.weight));
   slices.forEach((s, i) => {
     const li = document.createElement('li');
     li.className = 'cs-legend-row';
     const color = s.isOther ? 'rgba(148,163,184,0.35)' : LANG_COLORS[i % LANG_COLORS.length];
+    const pct = (s.weight / total) * 100;
+    const barPct = (s.weight / maxWeight) * 100;
+    const safeName = escapeHtml(s.name);
+    const safeAttr = escapeAttr(s.name);
     li.innerHTML = `
       <span class="cs-legend-swatch" style="background:${color}"></span>
-      <span class="cs-legend-name" title="${s.name}">${s.name}</span>
-      <span class="cs-legend-pct">${(s.weight / total * 100).toFixed(1)}%</span>
+      <span class="cs-legend-name" title="${safeAttr}">${safeName}</span>
+      <span class="cs-legend-bar" aria-hidden="true"><i style="width:${barPct.toFixed(1)}%;background:${color}"></i></span>
+      <span class="cs-legend-pct">${pct.toFixed(1)}%</span>
     `;
     legend.appendChild(li);
   });
@@ -421,17 +431,25 @@ function renderHeatmap(heatmap) {
     return;
   }
 
-  const counts = heatmap.map((d) => d.count);
-  const max = Math.max(1, ...counts);
+  // Align the data so the cell grid is exactly N full Sun→Sat weeks (no
+  // leading partial week, only trailing padding to finish the current week).
+  // Without this we'd land on 53 columns total, which forces fitHeatmap to
+  // use bands with one orphan week column at the end of the second row. By
+  // dropping the partial leading week we always render an even 52-week grid
+  // that splits cleanly into 2 rows × 26 columns.
   const firstDate = new Date(heatmap[0].date + 'T00:00:00');
-  const leadingEmpty = firstDate.getDay();
-
-  for (let i = 0; i < leadingEmpty; i++) {
-    _heatmapCells.push({ empty: true });
+  const firstDay = firstDate.getDay();
+  const dropLeading = firstDay === 0 ? 0 : 7 - firstDay;
+  const aligned = dropLeading > 0 ? heatmap.slice(dropLeading) : heatmap;
+  if (!aligned.length) {
+    $('heatmap-hint').textContent = '';
+    return;
   }
+  const counts = aligned.map((d) => d.count);
+  const max = Math.max(1, ...counts);
 
   let total = 0, activeDays = 0;
-  heatmap.forEach((d) => {
+  aligned.forEach((d) => {
     const ratio = d.count / max;
     let lvl = 0;
     if (d.count > 0) {
@@ -445,7 +463,7 @@ function renderHeatmap(heatmap) {
     if (d.count > 0) activeDays += 1;
   });
 
-  const lastDate = new Date(heatmap[heatmap.length - 1].date + 'T00:00:00');
+  const lastDate = new Date(aligned[aligned.length - 1].date + 'T00:00:00');
   const trailing = 6 - lastDate.getDay();
   for (let i = 0; i < trailing; i++) _heatmapCells.push({ empty: true });
 
@@ -503,12 +521,90 @@ function fitHeatmap() {
         cell.className = 'cs-heat-cell cs-heat-empty';
       } else {
         cell.className = `cs-heat-cell cs-heat-${c.lvl}`;
-        cell.title = t('perCellTitle')(c.date, c.count);
+        cell.dataset.date = c.date;
+        cell.dataset.count = String(c.count);
       }
       grid.appendChild(cell);
     });
     body.appendChild(grid);
   }
+  ensureHeatmapTooltip();
+}
+
+// Lightweight shared tooltip for heatmap cells. Native `title` has a long
+// activation delay and inconsistent styling across platforms; this overlay
+// shows immediately on hover with the formatted date + commit count.
+let _heatTooltipEl = null;
+let _heatTooltipBound = false;
+
+function ensureHeatmapTooltip() {
+  const tile = document.querySelector('.cs-tile-heatmap');
+  if (!tile) return;
+  if (!_heatTooltipEl) {
+    _heatTooltipEl = document.createElement('div');
+    _heatTooltipEl.className = 'cs-heat-tooltip';
+    _heatTooltipEl.setAttribute('hidden', '');
+    document.body.appendChild(_heatTooltipEl);
+  }
+  if (_heatTooltipBound) return;
+  _heatTooltipBound = true;
+  const body = $('heatmap-body');
+  if (!body) return;
+  body.addEventListener('mouseover', onHeatHover);
+  body.addEventListener('mousemove', onHeatMove);
+  body.addEventListener('mouseleave', hideHeatTooltip);
+  body.addEventListener('mouseout', (ev) => {
+    const to = ev.relatedTarget;
+    if (!to || !body.contains(to)) hideHeatTooltip();
+  });
+}
+
+function onHeatHover(ev) {
+  const cell = ev.target.closest('.cs-heat-cell');
+  if (!cell || cell.classList.contains('cs-heat-empty')) {
+    hideHeatTooltip();
+    return;
+  }
+  const date = cell.dataset.date;
+  const count = parseInt(cell.dataset.count || '0', 10);
+  if (!date) return;
+  _heatTooltipEl.textContent = t('perCellTitle')(fmtDate(date + 'T00:00:00'), count);
+  _heatTooltipEl.removeAttribute('hidden');
+  positionHeatTooltip(ev);
+}
+
+function onHeatMove(ev) {
+  if (!_heatTooltipEl || _heatTooltipEl.hasAttribute('hidden')) return;
+  const cell = ev.target.closest('.cs-heat-cell');
+  if (!cell || cell.classList.contains('cs-heat-empty')) {
+    hideHeatTooltip();
+    return;
+  }
+  // Refresh content if the cursor moved to a new cell.
+  const date = cell.dataset.date;
+  const count = parseInt(cell.dataset.count || '0', 10);
+  if (date) {
+    const txt = t('perCellTitle')(fmtDate(date + 'T00:00:00'), count);
+    if (_heatTooltipEl.textContent !== txt) _heatTooltipEl.textContent = txt;
+  }
+  positionHeatTooltip(ev);
+}
+
+function positionHeatTooltip(ev) {
+  if (!_heatTooltipEl) return;
+  const pad = 12;
+  const w = _heatTooltipEl.offsetWidth || 160;
+  const h = _heatTooltipEl.offsetHeight || 28;
+  let x = ev.clientX + pad;
+  let y = ev.clientY - h - pad;
+  if (x + w + 4 > window.innerWidth) x = ev.clientX - w - pad;
+  if (y < 4) y = ev.clientY + pad;
+  _heatTooltipEl.style.left = `${Math.max(4, x)}px`;
+  _heatTooltipEl.style.top = `${Math.max(4, y)}px`;
+}
+
+function hideHeatTooltip() {
+  if (_heatTooltipEl) _heatTooltipEl.setAttribute('hidden', '');
 }
 
 let _heatmapRO = null;

--- a/src/crates/core/src/miniapp/builtin/mod.rs
+++ b/src/crates/core/src/miniapp/builtin/mod.rs
@@ -61,7 +61,7 @@ pub const BUILTIN_APPS: &[BuiltinApp] = &[
     },
     BuiltinApp {
         id: "builtin-coding-selfie",
-        version: 21,
+        version: 27,
         meta_json: include_str!("assets/coding-selfie/meta.json"),
         html: include_str!("assets/coding-selfie/index.html"),
         css: include_str!("assets/coding-selfie/style.css"),

--- a/src/crates/core/src/service/remote_ssh/manager.rs
+++ b/src/crates/core/src/service/remote_ssh/manager.rs
@@ -17,6 +17,7 @@ use russh_sftp::client::SftpSession;
 #[cfg(feature = "ssh_config")]
 use ssh_config::SSHConfig;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::net::TcpStream;
 
@@ -58,6 +59,13 @@ struct ActiveConnection {
     sftp_session: Arc<tokio::sync::RwLock<Option<Arc<SftpSession>>>>,
     #[allow(dead_code)]
     server_key: Option<PublicKey>,
+    /// Liveness flag; flipped to false from `SSHHandler::disconnected`.
+    /// Allows `is_connected` and SFTP/exec entry points to detect a dead session
+    /// without waiting for the next failed I/O.
+    alive: Arc<AtomicBool>,
+    /// Per-connection lock to serialize transparent reconnect attempts and
+    /// avoid stampedes when multiple SFTP/exec calls hit a dead session at once.
+    reconnect_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 /// SSH client handler with host key verification
@@ -76,6 +84,9 @@ struct SSHHandler {
     /// surface them after connect_stream() returns.
     /// Uses std::sync::Mutex so it can be read from sync map_err closures.
     disconnect_reason: Arc<std::sync::Mutex<Option<String>>>,
+    /// Shared liveness flag, flipped to false on disconnect so the manager
+    /// can detect dead sessions and trigger transparent reconnect.
+    alive: Arc<AtomicBool>,
 }
 
 type HostKeyVerifyCallback = dyn Fn(String, u16, &PublicKey) -> bool + Send + Sync;
@@ -90,6 +101,7 @@ impl SSHHandler {
             host: None,
             port: None,
             disconnect_reason: Arc::new(std::sync::Mutex::new(None)),
+            alive: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -102,6 +114,7 @@ impl SSHHandler {
             host: None,
             port: None,
             disconnect_reason: Arc::new(std::sync::Mutex::new(None)),
+            alive: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -117,6 +130,7 @@ impl SSHHandler {
             host: None,
             port: None,
             disconnect_reason: Arc::new(std::sync::Mutex::new(None)),
+            alive: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -124,8 +138,13 @@ impl SSHHandler {
         host: String,
         port: u16,
         known_hosts: Arc<tokio::sync::RwLock<HashMap<String, KnownHostEntry>>>,
-    ) -> (Self, Arc<std::sync::Mutex<Option<String>>>) {
+    ) -> (
+        Self,
+        Arc<std::sync::Mutex<Option<String>>>,
+        Arc<AtomicBool>,
+    ) {
         let disconnect_reason = Arc::new(std::sync::Mutex::new(None));
+        let alive = Arc::new(AtomicBool::new(true));
         let handler = Self {
             expected_key: None,
             verify_callback: None,
@@ -133,8 +152,9 @@ impl SSHHandler {
             host: Some(host),
             port: Some(port),
             disconnect_reason: disconnect_reason.clone(),
+            alive: alive.clone(),
         };
-        (handler, disconnect_reason)
+        (handler, disconnect_reason, alive)
     }
 }
 
@@ -271,6 +291,9 @@ impl Handler for SSHHandler {
         if let Ok(mut guard) = self.disconnect_reason.lock() {
             *guard = Some(msg);
         }
+        // Flip the shared liveness flag so the manager can detect the dead
+        // session and trigger transparent reconnect on the next SFTP/exec call.
+        self.alive.store(false, Ordering::SeqCst);
         // Propagate errors so russh surfaces them; swallow clean server disconnect.
         match reason {
             DisconnectReason::ReceivedDisconnect(_) => Ok(()),
@@ -854,6 +877,42 @@ impl SSHConnectionManager {
         config: SSHConnectionConfig,
         timeout_secs: u64,
     ) -> anyhow::Result<SSHConnectionResult> {
+        let (handle, alive, server_info) = self
+            .establish_session(&config, timeout_secs)
+            .await?;
+
+        let connection_id = config.id.clone();
+
+        let mut guard = self.connections.write().await;
+        guard.insert(
+            connection_id.clone(),
+            ActiveConnection {
+                handle: Arc::new(handle),
+                config,
+                server_info: server_info.clone(),
+                sftp_session: Arc::new(tokio::sync::RwLock::new(None)),
+                server_key: None,
+                alive,
+                reconnect_lock: Arc::new(tokio::sync::Mutex::new(())),
+            },
+        );
+
+        Ok(SSHConnectionResult {
+            success: true,
+            connection_id: Some(connection_id),
+            error: None,
+            server_info,
+        })
+    }
+
+    /// Build a fresh SSH session (handshake + auth + server info probe) without
+    /// touching the connection map. Reused by both [`Self::connect_with_timeout`]
+    /// and the transparent reconnect path in [`Self::ensure_alive_or_reconnect`].
+    async fn establish_session(
+        &self,
+        config: &SSHConnectionConfig,
+        timeout_secs: u64,
+    ) -> anyhow::Result<(Handle<SSHHandler>, Arc<AtomicBool>, Option<ServerInfo>)> {
         let addr = format!("{}:{}", config.host, config.port);
 
         // Connect to the server with timeout
@@ -920,9 +979,14 @@ impl SSHConnectionManager {
         };
 
         let ssh_config = Arc::new(russh::client::Config {
-            inactivity_timeout: Some(std::time::Duration::from_secs(60)),
+            // Tolerate brief network blips (NAT timeouts, Wi-Fi roaming) by
+            // widening the inactivity window and allowing more missed keepalives
+            // before declaring the session dead. Combined with transparent
+            // reconnect, this prevents the user-visible "early eof" cascade
+            // while idly browsing the remote file picker.
+            inactivity_timeout: Some(std::time::Duration::from_secs(180)),
             keepalive_interval: Some(std::time::Duration::from_secs(30)),
-            keepalive_max: 3,
+            keepalive_max: 6,
             // Broad algorithm list for compatibility with both modern and legacy SSH servers.
             // Modern algorithms first (preferred), legacy ones appended as fallback.
             preferred: russh::Preferred {
@@ -952,7 +1016,7 @@ impl SSHConnectionManager {
         });
 
         // Create handler with known_hosts for verification
-        let (handler, disconnect_reason) = SSHHandler::with_known_hosts(
+        let (handler, disconnect_reason, alive) = SSHHandler::with_known_hosts(
             config.host.clone(),
             config.port,
             self.known_hosts.clone(),
@@ -1072,27 +1136,7 @@ impl SSHConnectionManager {
             }
         }
 
-        let connection_id = config.id.clone();
-
-        // Store connection
-        let mut guard = self.connections.write().await;
-        guard.insert(
-            connection_id.clone(),
-            ActiveConnection {
-                handle: Arc::new(handle),
-                config,
-                server_info: server_info.clone(),
-                sftp_session: Arc::new(tokio::sync::RwLock::new(None)),
-                server_key: None,
-            },
-        );
-
-        Ok(SSHConnectionResult {
-            success: true,
-            connection_id: Some(connection_id),
-            error: None,
-            server_info,
-        })
+        Ok((handle, alive, server_info))
     }
 
     /// Get server information (partial lines allowed so we can still fill `home_dir` via [`Self::probe_remote_home_dir`]).
@@ -1194,10 +1238,105 @@ impl SSHConnectionManager {
         guard.clear();
     }
 
-    /// Check if connected
+    /// Check if connected.
+    ///
+    /// Returns true only when there is an entry in the connections map AND its
+    /// liveness flag is still set. A previously-connected session that the
+    /// server (or network) tore down is considered NOT connected even though
+    /// the entry has not yet been pruned, so the UI cannot mistakenly believe
+    /// the session is healthy.
     pub async fn is_connected(&self, connection_id: &str) -> bool {
         let guard = self.connections.read().await;
-        guard.contains_key(connection_id)
+        guard
+            .get(connection_id)
+            .map(|c| c.alive.load(Ordering::SeqCst))
+            .unwrap_or(false)
+    }
+
+    /// Ensure the connection is alive; if it was torn down (network blip,
+    /// server-side timeout), transparently reconnect using the saved config
+    /// and (for password auth) the encrypted password vault.
+    ///
+    /// Uses a per-connection mutex to prevent reconnect stampedes when many
+    /// concurrent SFTP/exec calls hit a dead session at the same time.
+    /// Idempotent: returns Ok(()) immediately when the session is already alive.
+    async fn ensure_alive_or_reconnect(&self, connection_id: &str) -> anyhow::Result<()> {
+        let (alive_flag, reconnect_lock, mut config) = {
+            let guard = self.connections.read().await;
+            let conn = guard
+                .get(connection_id)
+                .ok_or_else(|| anyhow!("Connection {} not found", connection_id))?;
+            (
+                conn.alive.clone(),
+                conn.reconnect_lock.clone(),
+                conn.config.clone(),
+            )
+        };
+
+        if alive_flag.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        // Serialize concurrent reconnect attempts for the same connection.
+        let _guard = reconnect_lock.lock().await;
+        // Re-check under lock; another task may have already restored the session.
+        if alive_flag.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        log::warn!(
+            "SSH session {} is dead; attempting transparent reconnect",
+            connection_id
+        );
+
+        // Refresh the password from the encrypted vault if password auth was
+        // configured but the in-memory copy is empty (defensive — covers cases
+        // where callers cleared it intentionally).
+        if let SSHAuthMethod::Password { ref password } = config.auth {
+            if password.is_empty() {
+                match self.password_vault.load(connection_id).await {
+                    Ok(Some(pwd)) => {
+                        config.auth = SSHAuthMethod::Password { password: pwd };
+                    }
+                    Ok(None) => {
+                        return Err(anyhow!(
+                            "SSH session {} is dead and no stored password is available for reconnect",
+                            connection_id
+                        ));
+                    }
+                    Err(e) => {
+                        return Err(anyhow!("Failed to load stored SSH password: {}", e));
+                    }
+                }
+            }
+        }
+
+        let (handle, alive, server_info) = self.establish_session(&config, 30).await?;
+
+        // Replace the handle and clear the cached SFTP session so subsequent
+        // operations open a fresh channel on the new transport.
+        {
+            let mut guard = self.connections.write().await;
+            if let Some(conn) = guard.get_mut(connection_id) {
+                conn.handle = Arc::new(handle);
+                conn.alive = alive;
+                if let Some(si) = server_info {
+                    conn.server_info = Some(si);
+                }
+                let mut sftp_guard = conn.sftp_session.write().await;
+                *sftp_guard = None;
+            } else {
+                // Entry was removed concurrently (e.g. user-triggered disconnect);
+                // nothing to restore.
+                return Err(anyhow!(
+                    "Connection {} was removed during reconnect",
+                    connection_id
+                ));
+            }
+        }
+
+        log::info!("SSH session {} reconnected successfully", connection_id);
+        Ok(())
     }
 
     /// Execute a command on the remote server
@@ -1206,12 +1345,17 @@ impl SSHConnectionManager {
         connection_id: &str,
         command: &str,
     ) -> anyhow::Result<(String, String, i32)> {
-        let guard = self.connections.read().await;
-        let conn = guard
-            .get(connection_id)
-            .ok_or_else(|| anyhow!("Connection {} not found", connection_id))?;
+        self.ensure_alive_or_reconnect(connection_id).await?;
+        let handle = {
+            let guard = self.connections.read().await;
+            guard
+                .get(connection_id)
+                .ok_or_else(|| anyhow!("Connection {} not found", connection_id))?
+                .handle
+                .clone()
+        };
 
-        Self::execute_command_internal(&conn.handle, command)
+        Self::execute_command_internal(&handle, command)
             .await
             .map_err(|e| anyhow!("Command execution failed: {}", e))
     }
@@ -1311,8 +1455,15 @@ impl SSHConnectionManager {
         }
     }
 
-    /// Get or create SFTP session for a connection
+    /// Get or create SFTP session for a connection.
+    ///
+    /// Detects dead transports up-front via [`Self::ensure_alive_or_reconnect`]
+    /// so a transient SSH disconnect (e.g. NAT timeout while the user is idly
+    /// browsing the remote folder picker) is recovered transparently instead
+    /// of cascading into a stale cached SFTP handle that fails forever.
     pub async fn get_sftp(&self, connection_id: &str) -> anyhow::Result<Arc<SftpSession>> {
+        self.ensure_alive_or_reconnect(connection_id).await?;
+
         // First check if we have an existing SFTP session
         {
             let guard = self.connections.read().await;
@@ -1405,15 +1556,53 @@ impl SSHConnectionManager {
         Ok(())
     }
 
-    /// Read directory via SFTP
+    /// Read directory via SFTP.
+    ///
+    /// Retries once after dropping the cached SFTP session and forcing a
+    /// reconnect attempt, so a stale SFTP channel left over from a prior
+    /// network blip does not permanently break the remote folder picker.
     pub async fn sftp_read_dir(&self, connection_id: &str, path: &str) -> anyhow::Result<ReadDir> {
-        let path = self.resolve_sftp_path(connection_id, path).await?;
+        let resolved = self.resolve_sftp_path(connection_id, path).await?;
         let sftp = self.get_sftp(connection_id).await?;
-        let entries = sftp
-            .read_dir(&path)
-            .await
-            .map_err(|e| anyhow!("Failed to read directory '{}': {}", path, e))?;
-        Ok(entries)
+        match sftp.read_dir(&resolved).await {
+            Ok(entries) => Ok(entries),
+            Err(first_err) => {
+                log::warn!(
+                    "SFTP read_dir '{}' failed (will retry once after refreshing session): {}",
+                    resolved,
+                    first_err
+                );
+                self.invalidate_sftp_session(connection_id).await;
+                // Force the alive flag to false so ensure_alive_or_reconnect rebuilds
+                // the underlying SSH transport too — the previous failure may indicate
+                // the channel was torn down even though the keepalive callback has not
+                // fired yet.
+                self.mark_dead(connection_id).await;
+                let sftp = self.get_sftp(connection_id).await?;
+                sftp.read_dir(&resolved)
+                    .await
+                    .map_err(|e| anyhow!("Failed to read directory '{}': {}", resolved, e))
+            }
+        }
+    }
+
+    /// Drop the cached SFTP session for a connection so the next call opens a
+    /// fresh channel. Safe to call when no session is cached.
+    async fn invalidate_sftp_session(&self, connection_id: &str) {
+        let guard = self.connections.read().await;
+        if let Some(conn) = guard.get(connection_id) {
+            let mut sftp_guard = conn.sftp_session.write().await;
+            *sftp_guard = None;
+        }
+    }
+
+    /// Force the liveness flag to false. Triggers a transparent reconnect on
+    /// the next call to [`Self::ensure_alive_or_reconnect`].
+    async fn mark_dead(&self, connection_id: &str) {
+        let guard = self.connections.read().await;
+        if let Some(conn) = guard.get(connection_id) {
+            conn.alive.store(false, Ordering::SeqCst);
+        }
     }
 
     /// Create directory via SFTP

--- a/src/web-ui/src/app/components/panels/FilesPanel.tsx
+++ b/src/web-ui/src/app/components/panels/FilesPanel.tsx
@@ -143,6 +143,7 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
     selectFile,
     expandFolder,
     expandFolderLazy,
+    expandFolderEnsure,
   } = useFileSystem({
     rootPath: workspacePath,
     autoLoad: true,
@@ -355,24 +356,24 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
     if (!data.path || !workspacePath) {
       return;
     }
-    
+
     log.debug('Navigating to path', { path: data.path, scrollIntoView: data.scrollIntoView });
-    
+
     const normalizedTarget = data.path.replace(/\\/g, '/');
     const normalizedWorkspace = workspacePath.replace(/\\/g, '/');
-    
+
     let relativePath = normalizedTarget;
     if (normalizedTarget.toLowerCase().startsWith(normalizedWorkspace.toLowerCase())) {
       relativePath = normalizedTarget.slice(normalizedWorkspace.length).replace(/^\//, '');
     }
-    
+
     const parts = relativePath.split('/').filter(Boolean);
     let currentPath = normalizedWorkspace;
     const isWindowsPath = workspacePath.includes('\\');
-    
+
     const targetPaths = new Set<string>();
     targetPaths.add(isWindowsPath ? normalizedWorkspace.replace(/\//g, '\\') : normalizedWorkspace);
-    
+
     let finalExpandPath = '';
     const pathsToExpand: string[] = [];
     for (const part of parts) {
@@ -382,31 +383,40 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
       targetPaths.add(expandPath);
       pathsToExpand.push(expandPath);
     }
-    
+
     expandedFolders.forEach(folderPath => {
       if (!targetPaths.has(folderPath)) {
         expandFolder(folderPath, false);
       }
     });
-    
-    for (const expandPath of pathsToExpand) {
-      expandFolder(expandPath, true);
-    }
-    
-    if (data.scrollIntoView && finalExpandPath) {
-      setTimeout(() => {
-        const escapedPath = finalExpandPath.replace(/\\/g, '\\\\');
-        const targetElement = document.querySelector(`[data-file-path="${escapedPath}"]`);
-        if (targetElement) {
-          targetElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          targetElement.classList.add('bitfun-file-explorer__node-content--highlighted');
-          setTimeout(() => {
-            targetElement.classList.remove('bitfun-file-explorer__node-content--highlighted');
-          }, 2000);
+
+    const performScroll = () => {
+      if (!data.scrollIntoView || !finalExpandPath) {
+        return;
+      }
+      const escapedPath = finalExpandPath.replace(/\\/g, '\\\\');
+      const targetElement = document.querySelector(`[data-file-path="${escapedPath}"]`);
+      if (targetElement) {
+        targetElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        targetElement.classList.add('bitfun-file-explorer__node-content--highlighted');
+        setTimeout(() => {
+          targetElement.classList.remove('bitfun-file-explorer__node-content--highlighted');
+        }, 2000);
+      }
+    };
+
+    void (async () => {
+      for (const expandPath of pathsToExpand) {
+        try {
+          await expandFolderEnsure(expandPath);
+        } catch (err) {
+          log.warn('Failed to expand path during navigation', { expandPath, err });
+          break;
         }
-      }, 300);
-    }
-  }, [workspacePath, expandFolder, expandedFolders]);
+      }
+      setTimeout(performScroll, 100);
+    })();
+  }, [workspacePath, expandFolder, expandFolderEnsure, expandedFolders]);
 
   const getParentDirectory = useCallback((filePath: string): string => {
     return dirnameAbsolutePath(filePath);
@@ -692,6 +702,18 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
     onFileSelect?.(filePath, fileName);
   }, [selectFile, onFileSelect]);
 
+  const handleSearchFolderNavigate = useCallback((folderPath: string, _folderName: string) => {
+    if (onViewModeChange) {
+      onViewModeChange('tree');
+    } else {
+      setInternalViewMode('tree');
+    }
+    selectFile(folderPath);
+    setTimeout(() => {
+      handleNavigateToPath({ path: folderPath, scrollIntoView: true });
+    }, 0);
+  }, [onViewModeChange, selectFile, handleNavigateToPath]);
+
   const handleClearSearch = useCallback(() => {
     clearSearch();
   }, [clearSearch]);
@@ -887,6 +909,7 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
                   results={searchResults}
                   searchQuery={searchQuery}
                   onFileSelect={handleSearchResultSelect}
+                  onFolderNavigate={handleSearchFolderNavigate}
                   workspacePath={workspacePath}
                   className="bitfun-files-panel__search-results"
                 />

--- a/src/web-ui/src/features/ssh-remote/RemoteFileBrowser.tsx
+++ b/src/web-ui/src/features/ssh-remote/RemoteFileBrowser.tsx
@@ -112,12 +112,28 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
   const [transferBusy, setTransferBusy] = useState(false);
   const contextMenuRef = useRef<HTMLDivElement>(null);
 
+  // One-shot retry: when the SSH session was torn down by a transient network
+  // blip, the backend transparently reconnects on the next call but the
+  // already-in-flight request still fails. Retrying once gives the recovery
+  // path a chance to succeed before surfacing an error to the user.
   const loadDirectory = useCallback(async (path: string) => {
     setLoading(true);
     setError(null);
+    const fetchOnce = () => sshApi.readDir(connectionId, path);
     try {
-      const result = await sshApi.readDir(connectionId, path);
-      // Sort: directories first, then by name
+      let result;
+      try {
+        result = await fetchOnce();
+      } catch (firstErr) {
+        // Brief pause lets the backend complete its reconnect handshake before
+        // we hammer it again.
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        try {
+          result = await fetchOnce();
+        } catch {
+          throw firstErr;
+        }
+      }
       result.sort((a, b) => {
         if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
         return a.name.localeCompare(b.name);
@@ -478,6 +494,14 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
           {error && (
             <div className="remote-file-browser__error">
               <span>{error}</span>
+              <button
+                type="button"
+                onClick={() => loadDirectory(currentPath)}
+                title={t('actions.retry') || 'Retry'}
+                style={{ marginLeft: 'auto', marginRight: 8 }}
+              >
+                <RefreshCw size={14} />
+              </button>
               <button onClick={() => setError(null)}>×</button>
             </div>
           )}

--- a/src/web-ui/src/tools/file-explorer/controller/ExplorerController.ts
+++ b/src/web-ui/src/tools/file-explorer/controller/ExplorerController.ts
@@ -216,6 +216,24 @@ export class ExplorerController {
     await this.resolveDirectory(folderPath, true);
   }
 
+  async expandFolderEnsure(folderPath: string): Promise<void> {
+    const currentExpanded = expandedFoldersContains(this.model.getExpandedFolders(), folderPath);
+    if (!currentExpanded) {
+      this.model.expand(folderPath, true);
+      this.emit();
+    }
+
+    const node = this.model.getNode(folderPath);
+    const needsResolve =
+      !node ||
+      (node.kind === 'directory' &&
+        (node.childrenState === 'unresolved' || node.childrenState === 'error' || node.stale));
+
+    if (needsResolve) {
+      await this.resolveDirectory(folderPath, true);
+    }
+  }
+
   dispose(): void {
     this.disposed = true;
     this.stopWatchers();

--- a/src/web-ui/src/tools/file-system/components/FileSearchResults.tsx
+++ b/src/web-ui/src/tools/file-system/components/FileSearchResults.tsx
@@ -21,6 +21,7 @@ interface FileSearchResultsProps {
   results: FileSearchResultGroup[];
   searchQuery: string;
   onFileSelect: (filePath: string, fileName: string) => void;
+  onFolderNavigate?: (folderPath: string, folderName: string) => void;
   workspacePath?: string;
   className?: string;
 }
@@ -300,6 +301,7 @@ export const FileSearchResults: React.FC<FileSearchResultsProps> = ({
   results,
   searchQuery,
   onFileSelect,
+  onFolderNavigate,
   workspacePath,
   className = ''
 }) => {
@@ -409,9 +411,13 @@ export const FileSearchResults: React.FC<FileSearchResultsProps> = ({
   }, [workspacePath]);
 
   const handleFileClick = useCallback((target: SearchResultTarget) => {
+    if (target.isDirectory) {
+      onFolderNavigate?.(target.path, target.name);
+      return;
+    }
     onFileSelect(target.path, target.name);
     openResultTarget(target);
-  }, [onFileSelect, openResultTarget]);
+  }, [onFileSelect, openResultTarget, onFolderNavigate]);
 
   const handleLineClick = useCallback((target: SearchResultTarget, lineNumber?: number) => {
     onFileSelect(target.path, target.name);

--- a/src/web-ui/src/tools/file-system/hooks/useFileSystem.ts
+++ b/src/web-ui/src/tools/file-system/hooks/useFileSystem.ts
@@ -20,6 +20,7 @@ export interface UseFileSystemReturn {
   selectFile: (filePath: string) => void;
   expandFolder: (folderPath: string, expanded?: boolean) => void;
   expandFolderLazy: (folderPath: string) => Promise<void>;
+  expandFolderEnsure: (folderPath: string) => Promise<void>;
   searchFiles: (query: string) => Promise<FileSystemNode[]>;
   refreshFileTree: () => Promise<void>;
   updateOptions: (options: Partial<FileSystemOptions>) => void;
@@ -73,6 +74,10 @@ export function useFileSystem(options: UseFileSystemOptions = {}): UseFileSystem
     return controller.expandFolderLazy(folderPath);
   }, [controller]);
 
+  const expandFolderEnsure = useCallback((folderPath: string) => {
+    return controller.expandFolderEnsure(folderPath);
+  }, [controller]);
+
   const refreshFileTree = useCallback(() => {
     return controller.loadFileTree(undefined, false);
   }, [controller]);
@@ -110,6 +115,7 @@ export function useFileSystem(options: UseFileSystemOptions = {}): UseFileSystem
     selectFile,
     expandFolder,
     expandFolderLazy,
+    expandFolderEnsure,
     searchFiles,
     refreshFileTree,
     updateOptions,


### PR DESCRIPTION
## Summary

- **Remote SSH transport**: per-connection liveness flag flipped on `disconnected`, wider keepalive window (180s / max 6), and transparent reconnect (serialized by a per-connection mutex, reusing the encrypted password vault) on the next SFTP/exec call. `sftp_read_dir` retries once after invalidating the cached SFTP session, and `RemoteFileBrowser` adds a one-shot client retry plus an inline retry button — fixes the cascading "early eof" failures in the remote folder picker after brief network blips / NAT timeouts.
- **Session storage path correctness for remote workspaces**: `PersistenceManager` now treats already-resolved `~/.bitfun/remote_ssh/{host}/{path}/sessions` paths as the sessions root directly (no re-slugification); `ConversationCoordinator` pre-resolves the on-disk session storage path on the main task and passes it into the safety-net writer so recovered turns no longer fall back to a slugified raw remote POSIX path; `AppState` runs a one-time, idempotent startup migration that relocates any sessions whose metadata records a non-`localhost` `workspaceHostname` from `~/.bitfun/projects/<slug>/sessions/` into the canonical mirror dir.
- **File explorer UX**: new `expandFolderEnsure` (controller + hook) that awaits lazy resolution; `FilesPanel` "navigate to path" now awaits each expansion before scrolling so the highlight no longer fires before deep folders have loaded; file-search directory hits now route through `onFolderNavigate`, switching back to tree view and revealing the folder instead of trying to open it as a file.
- **Coding-selfie built-in miniapp** (bumped to v27): per-language ranking bars normalized to the dominant slice with HTML/attr escaping; heatmap aligned to a clean 52-week (2 × 26) grid with a shared hover-tooltip overlay replacing the laggy native `title`; clearer "not a Git repo / remote workspace" empty-state copy in en-US and zh-CN.

## Test plan

- [x] Remote SSH: open a remote workspace, idle until the server tears the session down (or simulate by killing the TCP connection), then trigger a directory read — expect transparent reconnect with no user-visible error, and `is_connected` to flip to `false` immediately on disconnect.
- [x] Remote sessions: start the desktop app with legacy sessions sitting under `~/.bitfun/projects/<slug>/sessions/` whose `metadata.json` has a non-`localhost` `workspaceHostname`, confirm they are relocated under `~/.bitfun/remote_ssh/{host}/{path}/sessions/` on first launch and that the legacy project dir is cleaned up when emptied.
- [x] File explorer: from the file-search results, click a directory hit and confirm the panel switches back to tree view and the folder is expanded + highlighted; click a deep file path via "navigate to path" and confirm scroll-to-target only fires after every ancestor has finished loading.
- [x] Coding-selfie: open the miniapp on a Git repo, confirm the language legend shows ranked bars (top language full-width), the heatmap renders 2 rows × 26 columns with no orphan trailing column, and hovering a cell shows the custom tooltip immediately. On a non-Git / remote workspace, confirm the updated empty-state copy in both languages.