### PR TITLE
fix(web-ui): preserve dispatcher model selection and defer workspace session creation

### DIFF
--- a/src/web-ui/src/app/components/SessionCapsule/NewSessionDialog.tsx
+++ b/src/web-ui/src/app/components/SessionCapsule/NewSessionDialog.tsx
@@ -14,6 +14,10 @@ import {
 import { flowChatManager } from '@/flow_chat/services/FlowChatManager';
 import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
 import { findReusableEmptySessionId } from '@/app/utils/projectSessionWorkspace';
+import {
+  clearDeferredNewSessionWorkspace,
+  markDeferredNewSessionWorkspace,
+} from '@/app/utils/deferredWorkspaceSession';
 import { openMainSession } from '@/flow_chat/services/openBtwSession';
 import { useSessionModeStore } from '@/app/stores/sessionModeStore';
 import { isRemoteWorkspace, type WorkspaceInfo } from '@/shared/types';
@@ -25,6 +29,7 @@ const log = createLogger('NewSessionDialog');
 
 const LS_AGENT = 'bitfun.newSessionDialog.agent';
 const LS_WORKSPACE = 'bitfun.newSessionDialog.workspaceId';
+const BROWSED_WORKSPACE_VALUE = '__browsed_workspace__';
 
 export type NewSessionAgentChoice = 'agentic' | 'Cowork' | 'Design' | 'Claw';
 
@@ -61,6 +66,26 @@ function pickDefaultWorkspaceId(
     return current.id;
   }
   return opened[0]?.id ?? null;
+}
+
+function normalizeWorkspacePath(path: string): string {
+  return path.trim().replace(/\\/g, '/');
+}
+
+function findOpenedWorkspaceByPath(
+  openedWorkspaces: WorkspaceInfo[],
+  path: string
+): WorkspaceInfo | undefined {
+  const normalizedPath = normalizeWorkspacePath(path);
+  return openedWorkspaces.find(
+    workspace => normalizeWorkspacePath(workspace.rootPath) === normalizedPath
+  );
+}
+
+function getBrowsedWorkspaceLabel(path: string): string {
+  const segments = path.split(/[\\/]+/).filter(Boolean);
+  const name = segments[segments.length - 1] || path;
+  return `${name} (${path})`;
 }
 
 function resolveModeFromChoice(agentChoice: NewSessionAgentChoice): 'agentic' | 'Cowork' | 'Design' | 'Claw' {
@@ -133,6 +158,7 @@ export const NewSessionDialog: React.FC<NewSessionDialogProps> = ({
 
   const [agentChoice, setAgentChoice] = useState<NewSessionAgentChoice>('agentic');
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const [browsedWorkspacePath, setBrowsedWorkspacePath] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const resetDefaults = useCallback(() => {
@@ -154,6 +180,7 @@ export const NewSessionDialog: React.FC<NewSessionDialogProps> = ({
     const fromSession = sessionModeToChoice(active?.mode);
 
     setAgentChoice(initialAgentChoice ?? storedAgent ?? fromSession);
+    setBrowsedWorkspacePath(null);
     setWorkspaceId(
       pickDefaultWorkspaceId(openedWorkspacesList, recentWorkspaces, currentWorkspace, storedWs)
     );
@@ -172,11 +199,18 @@ export const NewSessionDialog: React.FC<NewSessionDialogProps> = ({
       if (ra !== rb) return ra - rb;
       return getWorkspaceDisplayName(a).localeCompare(getWorkspaceDisplayName(b));
     });
-    return sorted.map(w => ({
+    const options = sorted.map(w => ({
       label: getWorkspaceDisplayName(w),
       value: w.id,
     }));
-  }, [openedWorkspacesList, recentWorkspaces]);
+    if (browsedWorkspacePath) {
+      options.unshift({
+        label: getBrowsedWorkspaceLabel(browsedWorkspacePath),
+        value: BROWSED_WORKSPACE_VALUE,
+      });
+    }
+    return options;
+  }, [browsedWorkspacePath, openedWorkspacesList, recentWorkspaces]);
 
   const agentOptions = useMemo(
     () => [
@@ -208,8 +242,15 @@ export const NewSessionDialog: React.FC<NewSessionDialogProps> = ({
         title: t('header.selectProjectDirectory'),
       });
       if (selected && typeof selected === 'string') {
-        const ws = await openWorkspace(selected);
-        setWorkspaceId(ws.id);
+        const openedWorkspace = findOpenedWorkspaceByPath(openedWorkspacesList, selected);
+        if (openedWorkspace) {
+          setBrowsedWorkspacePath(null);
+          setWorkspaceId(openedWorkspace.id);
+          return;
+        }
+
+        setBrowsedWorkspacePath(selected);
+        setWorkspaceId(BROWSED_WORKSPACE_VALUE);
       }
     } catch (e) {
       log.error('Browse workspace failed', e);
@@ -218,17 +259,32 @@ export const NewSessionDialog: React.FC<NewSessionDialogProps> = ({
         { duration: 3000 }
       );
     }
-  }, [openWorkspace, t]);
+  }, [openedWorkspacesList, t]);
 
   const handleConfirm = useCallback(async () => {
-    const workspace = openedWorkspacesList.find(w => w.id === workspaceId);
-    if (!workspace) {
+    let workspace = openedWorkspacesList.find(w => w.id === workspaceId);
+    const shouldOpenBrowsedWorkspace =
+      workspaceId === BROWSED_WORKSPACE_VALUE && !!browsedWorkspacePath;
+
+    if (!workspace && !shouldOpenBrowsedWorkspace) {
       notificationService.error(t('nav.sessionCapsule.workspaceMissing'), { duration: 4000 });
       return;
     }
 
     setSubmitting(true);
+    let openedBrowsedWorkspace = false;
     try {
+      if (!workspace && browsedWorkspacePath) {
+        markDeferredNewSessionWorkspace(browsedWorkspacePath);
+        workspace = await openWorkspace(browsedWorkspacePath);
+        openedBrowsedWorkspace = true;
+      }
+
+      if (!workspace) {
+        notificationService.error(t('nav.sessionCapsule.workspaceMissing'), { duration: 4000 });
+        return;
+      }
+
       await launchSessionForChoice({ agentChoice, workspace, setActiveWorkspace });
 
       try {
@@ -245,19 +301,24 @@ export const NewSessionDialog: React.FC<NewSessionDialogProps> = ({
         e instanceof Error ? e.message : t('nav.workspaces.createSessionFailed'),
         { duration: 4000 }
       );
+      if (!openedBrowsedWorkspace && browsedWorkspacePath) {
+        clearDeferredNewSessionWorkspace(browsedWorkspacePath);
+      }
     } finally {
       setSubmitting(false);
     }
   }, [
     agentChoice,
+    browsedWorkspacePath,
     onClose,
+    openWorkspace,
     openedWorkspacesList,
     setActiveWorkspace,
     t,
     workspaceId,
   ]);
 
-  const noWorkspaces = openedWorkspacesList.length === 0;
+  const noWorkspaces = workspaceOptions.length === 0;
 
   return (
     <Modal
@@ -311,7 +372,13 @@ export const NewSessionDialog: React.FC<NewSessionDialogProps> = ({
                 size="medium"
                 options={workspaceOptions}
                 value={workspaceId ?? ''}
-                onChange={v => setWorkspaceId(String(v))}
+                onChange={v => {
+                  const selectedValue = String(v);
+                  setWorkspaceId(selectedValue);
+                  if (selectedValue !== BROWSED_WORKSPACE_VALUE) {
+                    setBrowsedWorkspacePath(null);
+                  }
+                }}
                 placeholder={t('nav.sessionCapsule.workspacePlaceholder')}
                 disabled={noWorkspaces}
                 searchable

--- a/src/web-ui/src/app/layout/AppLayout.tsx
+++ b/src/web-ui/src/app/layout/AppLayout.tsx
@@ -32,6 +32,7 @@ import { WorkspaceKind } from '@/shared/types';
 import { SSHContext } from '@/features/ssh-remote/SSHRemoteContext';
 import { shortcutManager, parseStoredKeybindings } from '@/infrastructure/services/ShortcutManager';
 import { useSessionModeStore } from '../stores/sessionModeStore';
+import { consumeDeferredNewSessionWorkspace } from '../utils/deferredWorkspaceSession';
 import './AppLayout.scss';
 
 const log = createLogger('AppLayout');
@@ -205,6 +206,9 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
           currentWorkspace.workspaceKind === WorkspaceKind.Assistant
             ? 'Claw'
             : explicitPreferredMode;
+        const suppressAutoSessionSelection = consumeDeferredNewSessionWorkspace(
+          currentWorkspace.rootPath
+        );
 
         const flowChatManager = FlowChatManager.getInstance();
         const hasHistoricalSessions = await flowChatManager.initialize(
@@ -215,12 +219,14 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
             : undefined,
           currentWorkspace.workspaceKind === WorkspaceKind.Remote
             ? currentWorkspace.sshHost
-            : undefined
+            : undefined,
+          undefined,
+          { skipAutoSelectSession: suppressAutoSessionSelection }
         );
 
         let sessionId: string | undefined;
         const { flowChatStore } = await import('@/flow_chat/store/FlowChatStore');
-        if (!hasHistoricalSessions) {
+        if (!hasHistoricalSessions && !suppressAutoSessionSelection) {
           const initialSessionMode =
             currentWorkspace.workspaceKind === WorkspaceKind.Assistant
               ? 'Claw'

--- a/src/web-ui/src/app/utils/deferredWorkspaceSession.ts
+++ b/src/web-ui/src/app/utils/deferredWorkspaceSession.ts
@@ -1,0 +1,45 @@
+const DEFERRED_NEW_SESSION_WORKSPACE_KEY = 'bitfun:newSessionDialog:deferredWorkspacePath';
+
+function normalizeWorkspacePath(path: string): string {
+  return path.trim().replace(/\\/g, '/');
+}
+
+export function markDeferredNewSessionWorkspace(path: string): void {
+  try {
+    sessionStorage.setItem(
+      DEFERRED_NEW_SESSION_WORKSPACE_KEY,
+      normalizeWorkspacePath(path)
+    );
+  } catch {
+    /* ignore */
+  }
+}
+
+export function consumeDeferredNewSessionWorkspace(path: string): boolean {
+  try {
+    const storedPath = sessionStorage.getItem(DEFERRED_NEW_SESSION_WORKSPACE_KEY);
+    if (!storedPath || storedPath !== normalizeWorkspacePath(path)) {
+      return false;
+    }
+    sessionStorage.removeItem(DEFERRED_NEW_SESSION_WORKSPACE_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearDeferredNewSessionWorkspace(path?: string): void {
+  try {
+    if (!path) {
+      sessionStorage.removeItem(DEFERRED_NEW_SESSION_WORKSPACE_KEY);
+      return;
+    }
+
+    const storedPath = sessionStorage.getItem(DEFERRED_NEW_SESSION_WORKSPACE_KEY);
+    if (storedPath === normalizeWorkspacePath(path)) {
+      sessionStorage.removeItem(DEFERRED_NEW_SESSION_WORKSPACE_KEY);
+    }
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -49,6 +49,7 @@ import { ChatInputPixelPet } from './ChatInputPixelPet';
 import './ChatInput.scss';
 
 const log = createLogger('ChatInput');
+const EXPLICIT_ASSISTANT_MODES = new Set(['Dispatcher', 'dispatcher']);
 
 export interface ChatInputProps {
   className?: string;
@@ -767,7 +768,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   }, [effectiveTargetSessionId]);
 
   React.useEffect(() => {
-    if (!isAssistantWorkspace || currentMode === 'Claw') {
+    if (
+      !isAssistantWorkspace ||
+      currentMode === 'Claw' ||
+      EXPLICIT_ASSISTANT_MODES.has(currentMode)
+    ) {
       return;
     }
 

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -202,7 +202,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     const model = allModels.find(m => m.id === configuredModelId);
     return model ? configuredModelId : 'auto';
   }, [allModels, currentMode, agentModels, defaultModels]);
-
+  
   const currentModel = useMemo((): ModelInfo | null => {
     const modelId = getCurrentModelId();
 

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -92,7 +92,10 @@ export class FlowChatManager {
     preferredMode?: string,
     remoteConnectionId?: string,
     remoteSshHost?: string,
-    storageScope?: import('@/shared/types/session-history').SessionStorageScope
+    storageScope?: import('@/shared/types/session-history').SessionStorageScope,
+    options?: {
+      skipAutoSelectSession?: boolean;
+    }
   ): Promise<boolean> {
     try {
       await this.initializeEventListeners();
@@ -130,7 +133,11 @@ export class FlowChatManager {
       const activeSessionBelongsToWorkspace =
         !!activeSession && sessionMatchesWorkspace(activeSession);
 
-      if (hasHistoricalSessions && !activeSessionBelongsToWorkspace) {
+      if (
+        hasHistoricalSessions &&
+        !activeSessionBelongsToWorkspace &&
+        !options?.skipAutoSelectSession
+      ) {
         const sortedWorkspaceSessions = [...workspaceSessions].sort(compareSessionsForDisplay);
         const latestSession = (preferredMode
           ? sortedWorkspaceSessions.find(session => session.mode === preferredMode)


### PR DESCRIPTION
- allow assistant workspaces to keep explicit Dispatcher mode so the chat input and model selector use Dispatcher-specific model settings after switching back from Claw
- stop the new-session dialog from opening a browsed workspace immediately
- defer workspace activation until the user confirms session creation
- suppress the one-shot auto session bootstrap when the workspace was opened from the deferred new-session flow to avoid creating a session before the dialog submit
