### PR TITLE
fix(ui): AgentDispatch session state, toasts, and notification layout

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/AgentDispatchCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentDispatchCard.tsx
@@ -12,13 +12,19 @@ import { DotMatrixLoader } from '@/component-library';
 import type { ToolCardProps } from '../types/flow-chat';
 import { BaseToolCard } from './BaseToolCard';
 import { openMainSession } from '../services/openBtwSession';
+import { flowChatStore } from '../store/FlowChatStore';
 import { useSessionsExecutionRunning } from '../hooks/useSessionsExecutionRunning';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
+import { sessionAPI } from '@/infrastructure/api';
+import { notificationService } from '@/shared/notification-system';
+import { createLogger } from '@/shared/utils/logger';
 import './AgentDispatchCard.scss';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+const log = createLogger('AgentDispatchCard');
 
 function parseData<T>(value: unknown): T | null {
   if (!value) return null;
@@ -68,6 +74,41 @@ interface AgentDispatchResult {
   workspaces?: WorkspaceEntry[];
   dispatcher_session_count?: number;
   sessions?: DispatcherSession[];
+}
+
+async function ensureSessionAvailable(sessionId: string, workspace?: string): Promise<boolean> {
+  if (flowChatStore.getState().sessions.has(sessionId)) {
+    return true;
+  }
+
+  const workspacePath = workspace?.trim();
+  if (!workspacePath || workspacePath === 'global') {
+    return false;
+  }
+
+  try {
+    const metadata = await sessionAPI.loadSessionMetadata(sessionId, workspacePath);
+    if (!metadata) {
+      return false;
+    }
+
+    await flowChatStore.hydrateWorkspaceSessionsMetadata(
+      [metadata],
+      metadata.workspacePath || workspacePath,
+      metadata.remoteConnectionId,
+      metadata.remoteSshHost,
+      metadata.storageScope
+    );
+
+    return flowChatStore.getState().sessions.has(sessionId);
+  } catch (error) {
+    log.warn('Failed to hydrate dispatched session before navigation', {
+      sessionId,
+      workspacePath,
+      error,
+    });
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -206,17 +247,39 @@ export const AgentDispatchCard: React.FC<ToolCardProps> = React.memo(
     const canNavigate =
       action === 'create' && status === 'completed' && !!createdSessionId;
 
+    const openDispatchedSession = useCallback(
+      async (sessionId: string, sessionWorkspace?: string) => {
+        const available = await ensureSessionAvailable(sessionId, sessionWorkspace);
+        if (!available) {
+          notificationService.warning(t('toolCards.agentDispatch.sessionUnavailable'), {
+            duration: 4000,
+          });
+          return;
+        }
+
+        try {
+          await openMainSession(sessionId);
+        } catch (error) {
+          log.warn('Failed to open dispatched session', { sessionId, error });
+          notificationService.warning(t('toolCards.agentDispatch.openSessionFailed'), {
+            duration: 4000,
+          });
+        }
+      },
+      [t]
+    );
+
     const handleCardClick = useCallback(
       () => {
         if (action === 'create' && status === 'completed' && createdSessionId) {
-          void openMainSession(createdSessionId);
+          void openDispatchedSession(createdSessionId, workspace);
           return;
         }
         if (action !== 'create' || !createdSessionId) {
           applyExpandedState(isExpanded, !isExpanded, setIsExpanded);
         }
       },
-      [action, applyExpandedState, createdSessionId, isExpanded, status]
+      [action, applyExpandedState, createdSessionId, isExpanded, openDispatchedSession, status, workspace]
     );
 
     // Expanded content (for list/status or create details)
@@ -283,7 +346,7 @@ export const AgentDispatchCard: React.FC<ToolCardProps> = React.memo(
                 <div
                   key={sid ?? `row-${i}`}
                   className={`agent-dispatch-session-item${sid ? ' agent-dispatch-session-item--clickable' : ''}`}
-                  onClick={sid ? () => openMainSession(sid) : undefined}
+                  onClick={sid ? () => void openDispatchedSession(sid, s.workspace) : undefined}
                 >
                   <div className="agent-dispatch-session-item-main">
                     <span className="agent-dispatch-session-name">{s.session_name ?? s.session_id}</span>
@@ -323,7 +386,7 @@ export const AgentDispatchCard: React.FC<ToolCardProps> = React.memo(
       }
 
       return null;
-    }, [action, createdSessionId, resultData, runningSessionIds, t, workspace]);
+    }, [action, createdSessionId, openDispatchedSession, resultData, runningSessionIds, t, workspace]);
 
     const hasExpandedContent = !!expandedContent;
 

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -440,7 +440,9 @@
       "noSessions": "No sessions created in Agentic OS yet",
       "sessionRunning": "Session running",
       "sessionIdle": "Idle",
-      "globalTag": "Global"
+      "globalTag": "Global",
+      "sessionUnavailable": "This agent session is no longer available. It may have been deleted.",
+      "openSessionFailed": "Unable to open this agent session."
     },
     "file": {
       "write": "Write File",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -432,7 +432,9 @@
       "noSessions": "Agentic OS 中尚未创建任何会话",
       "sessionRunning": "会话执行中",
       "sessionIdle": "空闲",
-      "globalTag": "全局"
+      "globalTag": "全局",
+      "sessionUnavailable": "这个 Agent 会话已不可用，可能已被删除。",
+      "openSessionFailed": "无法打开这个 Agent 会话。"
     },
     "file": {
       "write": "写入文件",

--- a/src/web-ui/src/shared/notification-system/components/NotificationContainer.scss
+++ b/src/web-ui/src/shared/notification-system/components/NotificationContainer.scss
@@ -13,27 +13,43 @@
   @include search-surface.match-nav-search-card-dark-shadow;
 }
 
+.notification-container .notification-item,
+.notification-container .progress-notification,
+.notification-container .loading-notification {
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--color-text-primary) 4%, transparent);
+}
+
+:root[data-theme-type='dark'] .notification-container .notification-item,
+:root[data-theme-type='dark'] .notification-container .progress-notification,
+:root[data-theme-type='dark'] .notification-container .loading-notification {
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, #fff 6%, transparent),
+    0 1px 0 color-mix(in srgb, #fff 5%, transparent);
+}
+
 .notification-container {
   position: fixed;
-  right: 16px;
+  right: -8px;
   left: auto;
-  bottom: 60px;
+  bottom: 36px;
   z-index: $z-notification;
   display: flex;
   flex-direction: column-reverse;
   align-items: flex-end;
-  gap: 8px;
+  gap: 10px;
+  padding: 24px;
   pointer-events: none;
 
   > * {
     pointer-events: auto;
+    flex-shrink: 0;
   }
 
-  
-  max-height: calc(100vh - 120px); 
+  max-height: calc(100vh - 72px);
   overflow-y: auto;
-  
-  
+  overscroll-behavior: contain;
+
   scrollbar-width: none;
   &::-webkit-scrollbar {
     display: none;
@@ -51,15 +67,18 @@
 
 @media (max-width: 768px) {
   .notification-container {
-    right: 12px;
+    right: -8px;
     left: auto;
-    max-width: calc(100vw - 24px);
-    bottom: 64px; 
+    max-width: calc(100vw - 4px);
+    bottom: 44px;
+    padding: 20px;
 
     .notification-item,
-    .progress-notification {
+    .progress-notification,
+    .loading-notification {
+      width: min(320px, calc(100vw - 48px));
       min-width: unset;
-      max-width: unset;
+      max-width: calc(100vw - 48px);
     }
   }
 }


### PR DESCRIPTION
## Summary
- **AgentDispatchCard**: Header rail shows live execution state after create completes; status list shows idle vs running with external-link affordance; user-facing warnings when a dispatched session is missing or cannot be opened.
- **Locales**: Add \sessionUnavailable\ and \openSessionFailed\ strings (en-US, zh-CN).
- **Notifications**: Tweak container position, padding, subtle borders, mobile width caps, and overscroll behavior.

## Testing
- \pnpm run type-check:web\ (pass)