### PR TITLE
fix(web-ui): pad CLI auth empty state in AI model settings

### DIFF
--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
@@ -2025,7 +2025,7 @@
   }
 
   &__cli-empty {
-    padding: $size-gap-3 0;
+    padding: var(--size-gap-4, 16px);
 
     p {
       margin: 0;


### PR DESCRIPTION
## Summary
The local CLI accounts empty state in AI model settings used vertical-only padding inside \ConfigPageSection__body\, so the hint text sat flush against the left border.

## Change
- Use uniform \padding: var(--size-gap-4, 16px)\ on \.bitfun-ai-model-config__cli-empty\ to match \ConfigPageRow\ spacing.
