### PR TITLE
refactor(core): extract shared types for function agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ tests/e2e/reports/
 .bitfun/
 .cursor
 .cursor/rules/no-cargo.mdc
+.sisyphus/
 
 ASSETS_LICENSES.md
 

--- a/src/crates/core/src/function_agents/common.rs
+++ b/src/crates/core/src/function_agents/common.rs
@@ -1,0 +1,85 @@
+/*!
+ * Function Agents Common Module
+ *
+ * Shared types, errors, and utilities for function agents
+ */
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+// ==================== Shared Types ====================
+
+/// Language selection for agent outputs
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Language {
+    Chinese,
+    English,
+}
+
+impl Language {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Language::Chinese => "Chinese",
+            Language::English => "English",
+        }
+    }
+}
+
+// ==================== Shared Error Types ====================
+
+/// Error types for function agents
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum AgentErrorType {
+    GitError,
+    AnalysisError,
+    InvalidInput,
+    InternalError,
+}
+
+/// Error struct for function agents
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentError {
+    pub message: String,
+    pub error_type: AgentErrorType,
+}
+
+impl fmt::Display for AgentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{:?}] {}", self.error_type, self.message)
+    }
+}
+
+impl std::error::Error for AgentError {}
+
+impl AgentError {
+    pub fn git_error(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            error_type: AgentErrorType::GitError,
+        }
+    }
+
+    pub fn analysis_error(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            error_type: AgentErrorType::AnalysisError,
+        }
+    }
+
+    pub fn invalid_input(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            error_type: AgentErrorType::InvalidInput,
+        }
+    }
+
+    pub fn internal_error(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            error_type: AgentErrorType::InternalError,
+        }
+    }
+}
+
+/// Result type for function agents
+pub type AgentResult<T> = Result<T, AgentError>;

--- a/src/crates/core/src/function_agents/git-func-agent/ai_service.rs
+++ b/src/crates/core/src/function_agents/git-func-agent/ai_service.rs
@@ -1,7 +1,5 @@
-use super::types::{
-    AICommitAnalysis, AgentError, AgentResult, CommitFormat, CommitMessageOptions, CommitType,
-    Language, ProjectContext,
-};
+use super::types::{AICommitAnalysis, CommitFormat, CommitMessageOptions, CommitType, ProjectContext};
+use crate::function_agents::common::{AgentError, AgentResult, Language};
 use crate::infrastructure::ai::AIClient;
 use crate::util::types::Message;
 /**

--- a/src/crates/core/src/function_agents/git-func-agent/commit_generator.rs
+++ b/src/crates/core/src/function_agents/git-func-agent/commit_generator.rs
@@ -1,6 +1,7 @@
 use super::ai_service::AIAnalysisService;
 use super::context_analyzer::ContextAnalyzer;
 use super::types::*;
+use crate::function_agents::common::{AgentError, AgentResult};
 use crate::infrastructure::ai::AIClientFactory;
 use crate::service::git::{GitDiffParams, GitService};
 /**

--- a/src/crates/core/src/function_agents/git-func-agent/context_analyzer.rs
+++ b/src/crates/core/src/function_agents/git-func-agent/context_analyzer.rs
@@ -1,4 +1,5 @@
 use super::types::*;
+use crate::function_agents::common::AgentResult;
 /**
  * Context analyzer
  *

--- a/src/crates/core/src/function_agents/git-func-agent/types.rs
+++ b/src/crates/core/src/function_agents/git-func-agent/types.rs
@@ -6,6 +6,9 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+// Re-export shared types for backward compatibility and relative import
+pub use crate::function_agents::common::{AgentError, AgentErrorType, AgentResult, Language};
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommitMessageOptions {
@@ -63,12 +66,6 @@ pub enum CommitFormat {
     Simple,
     /// Custom format
     Custom,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum Language {
-    Chinese,
-    English,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -185,60 +182,6 @@ pub enum ChangePattern {
     TestUpdate,
     StyleChange,
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentError {
-    pub message: String,
-    pub error_type: AgentErrorType,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum AgentErrorType {
-    GitError,
-    AnalysisError,
-    InvalidInput,
-    InternalError,
-}
-
-impl fmt::Display for AgentError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{:?}] {}", self.error_type, self.message)
-    }
-}
-
-impl std::error::Error for AgentError {}
-
-impl AgentError {
-    pub fn git_error(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            error_type: AgentErrorType::GitError,
-        }
-    }
-
-    pub fn analysis_error(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            error_type: AgentErrorType::AnalysisError,
-        }
-    }
-
-    pub fn invalid_input(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            error_type: AgentErrorType::InvalidInput,
-        }
-    }
-
-    pub fn internal_error(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            error_type: AgentErrorType::InternalError,
-        }
-    }
-}
-
-pub type AgentResult<T> = Result<T, AgentError>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectContext {

--- a/src/crates/core/src/function_agents/mod.rs
+++ b/src/crates/core/src/function_agents/mod.rs
@@ -1,8 +1,10 @@
-﻿/*!
+/*!
  * Function Agents module
  *
  * Provides various function agents for automating specific tasks
  */
+
+pub mod common;
 
 #[path = "git-func-agent/mod.rs"]
 pub mod git_func_agent;
@@ -10,12 +12,12 @@ pub mod git_func_agent;
 #[path = "startchat-func-agent/mod.rs"]
 pub mod startchat_func_agent;
 
-pub use git_func_agent::GitFunctionAgent;
-pub use startchat_func_agent::StartchatFunctionAgent;
+// Re-export shared types from common module
+pub use common::{AgentError, AgentErrorType, AgentResult, Language};
 
-pub use git_func_agent::{CommitFormat, CommitMessage, CommitMessageOptions, CommitType};
-
+// Re-export agents and specific types
+pub use git_func_agent::{GitFunctionAgent, CommitFormat, CommitMessage, CommitMessageOptions, CommitType};
 pub use startchat_func_agent::{
-    CurrentWorkState, GitWorkState, GreetingMessage, PredictedAction, QuickAction,
+    StartchatFunctionAgent, CurrentWorkState, GitWorkState, GreetingMessage, PredictedAction, QuickAction,
     WorkStateAnalysis, WorkStateOptions,
 };

--- a/src/crates/core/src/function_agents/startchat-func-agent/ai_service.rs
+++ b/src/crates/core/src/function_agents/startchat-func-agent/ai_service.rs
@@ -1,4 +1,5 @@
 use super::types::*;
+use crate::function_agents::common::{AgentError, AgentResult, Language};
 use crate::infrastructure::ai::AIClient;
 use crate::util::types::Message;
 /**

--- a/src/crates/core/src/function_agents/startchat-func-agent/mod.rs
+++ b/src/crates/core/src/function_agents/startchat-func-agent/mod.rs
@@ -38,7 +38,7 @@ impl StartchatFunctionAgent {
     pub async fn quick_analyze(
         &self,
         repo_path: &Path,
-        language: Language,
+        language: crate::function_agents::Language,
     ) -> AgentResult<WorkStateAnalysis> {
         let options = WorkStateOptions {
             language,
@@ -53,7 +53,7 @@ impl StartchatFunctionAgent {
             analyze_git: false,
             predict_next_actions: false,
             include_quick_actions: false,
-            language: Language::Chinese,
+            language: crate::function_agents::Language::Chinese,
         };
 
         self.analyze_work_state(repo_path, options).await

--- a/src/crates/core/src/function_agents/startchat-func-agent/types.rs
+++ b/src/crates/core/src/function_agents/startchat-func-agent/types.rs
@@ -6,6 +6,9 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+// Re-export shared types for backward compatibility and relative import
+pub use crate::function_agents::common::{AgentError, AgentErrorType, AgentResult, Language};
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkStateOptions {
@@ -39,12 +42,6 @@ impl Default for WorkStateOptions {
             language: Language::English,
         }
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum Language {
-    Chinese,
-    English,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -278,57 +275,3 @@ pub struct AIGeneratedAnalysis {
 
     pub quick_actions: Vec<QuickAction>,
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentError {
-    pub message: String,
-    pub error_type: AgentErrorType,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum AgentErrorType {
-    GitError,
-    AnalysisError,
-    InvalidInput,
-    InternalError,
-}
-
-impl fmt::Display for AgentError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{:?}] {}", self.error_type, self.message)
-    }
-}
-
-impl std::error::Error for AgentError {}
-
-impl AgentError {
-    pub fn git_error(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            error_type: AgentErrorType::GitError,
-        }
-    }
-
-    pub fn analysis_error(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            error_type: AgentErrorType::AnalysisError,
-        }
-    }
-
-    pub fn invalid_input(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            error_type: AgentErrorType::InvalidInput,
-        }
-    }
-
-    pub fn internal_error(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            error_type: AgentErrorType::InternalError,
-        }
-    }
-}
-
-pub type AgentResult<T> = Result<T, AgentError>;

--- a/src/crates/core/src/function_agents/startchat-func-agent/work_state_analyzer.rs
+++ b/src/crates/core/src/function_agents/startchat-func-agent/work_state_analyzer.rs
@@ -1,4 +1,5 @@
 use super::types::*;
+use crate::function_agents::common::{AgentError, AgentResult};
 use crate::infrastructure::ai::AIClientFactory;
 use chrono::{Local, Timelike};
 /**


### PR DESCRIPTION
Extract duplicated types from git-func-agent and startchat-func-agent into a shared common module:

- Language enum (Chinese, English)
- AgentError struct with Display and Error traits
- AgentErrorType enum (GitError, AnalysisError, InvalidInput, InternalError)
- AgentResult<T> type alias

Changes:
- Add function_agents/common.rs with shared type definitions
- Re-export shared types from both agent type modules for backward compatibility
- Update imports in ai_service.rs, commit_generator.rs, context_analyzer.rs, work_state_analyzer.rs
- Update function_agents/mod.rs to include common module and re-export shared types

This is a pure refactoring with no functional changes. All existing APIs remain unchanged through re-exports.

Generated with BitFun

Co-Authored-By: BitFun