### PR TITLE
feat(i18n): centralize locale registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev:web": "pnpm --dir src/web-ui dev",
     "lint:web": "pnpm --dir src/web-ui run lint",
     "lint:web:fix": "pnpm --dir src/web-ui run lint:fix",
+    "i18n:audit": "node scripts/i18n-audit.mjs",
     "prebuild": "pnpm run prebuild:web",
     "prebuild:web": "pnpm run copy-assets --silent && pnpm run generate-all --silent",
     "type-check:web": "pnpm --dir src/web-ui run type-check",

--- a/scripts/i18n-audit.mjs
+++ b/scripts/i18n-audit.mjs
@@ -1,0 +1,238 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const webLocalesDir = path.join(root, 'src', 'web-ui', 'src', 'locales');
+const namespaceRegistryPath = path.join(
+  root,
+  'src',
+  'web-ui',
+  'src',
+  'infrastructure',
+  'i18n',
+  'presets',
+  'namespaceRegistry.ts',
+);
+const localeRegistryPath = path.join(
+  root,
+  'src',
+  'web-ui',
+  'src',
+  'infrastructure',
+  'i18n',
+  'presets',
+  'localeRegistry.ts',
+);
+const webSourceDir = path.join(root, 'src', 'web-ui', 'src');
+const supportedLocales = fs
+  .readdirSync(webLocalesDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+const baselineLocale = supportedLocales.includes('en-US') ? 'en-US' : supportedLocales[0];
+
+let errorCount = 0;
+let warningCount = 0;
+
+function reportError(message) {
+  errorCount += 1;
+  console.error(`[i18n:audit] ERROR ${message}`);
+}
+
+function reportWarning(message) {
+  warningCount += 1;
+  console.warn(`[i18n:audit] WARN ${message}`);
+}
+
+function toPosixPath(value) {
+  return value.split(path.sep).join('/');
+}
+
+function listFiles(dir, predicate) {
+  const output = [];
+  if (!fs.existsSync(dir)) return output;
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      output.push(...listFiles(fullPath, predicate));
+    } else if (!predicate || predicate(fullPath)) {
+      output.push(fullPath);
+    }
+  }
+
+  return output;
+}
+
+function listLocaleNamespaces(locale) {
+  const localeDir = path.join(webLocalesDir, locale);
+  return listFiles(localeDir, (file) => file.endsWith('.json'))
+    .map((file) => toPosixPath(path.relative(localeDir, file)).replace(/\.json$/, ''))
+    .sort();
+}
+
+function readRegistryNamespaces() {
+  const source = fs.readFileSync(namespaceRegistryPath, 'utf8');
+  const match = source.match(/ALL_NAMESPACES\s*=\s*\[([\s\S]*?)\]\s*as const/);
+  if (!match) {
+    reportError(`Could not parse ALL_NAMESPACES from ${namespaceRegistryPath}`);
+    return [];
+  }
+
+  return Array.from(match[1].matchAll(/['"]([^'"]+)['"]/g))
+    .map((item) => item[1])
+    .sort();
+}
+
+function readRegistryLocales() {
+  const source = fs.readFileSync(localeRegistryPath, 'utf8');
+  return Array.from(source.matchAll(/\bid:\s*['"]([^'"]+)['"]/g))
+    .map((item) => item[1])
+    .sort();
+}
+
+function flattenKeys(value, prefix = '') {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return prefix ? [prefix] : [];
+  }
+
+  const keys = [];
+  for (const [key, child] of Object.entries(value)) {
+    const nextPrefix = prefix ? `${prefix}.${key}` : key;
+    if (child != null && typeof child === 'object' && !Array.isArray(child)) {
+      keys.push(...flattenKeys(child, nextPrefix));
+    } else {
+      keys.push(nextPrefix);
+    }
+  }
+  return keys.sort();
+}
+
+function readJsonKeys(locale, namespace) {
+  const file = path.join(webLocalesDir, locale, `${namespace}.json`);
+  try {
+    return flattenKeys(JSON.parse(fs.readFileSync(file, 'utf8')));
+  } catch (error) {
+    reportError(`Failed to parse ${toPosixPath(path.relative(root, file))}: ${error.message}`);
+    return [];
+  }
+}
+
+function diffSets(left, right) {
+  const rightSet = new Set(right);
+  return left.filter((item) => !rightSet.has(item));
+}
+
+function auditNamespaceCoverage() {
+  const registryLocales = readRegistryLocales();
+  for (const locale of supportedLocales.filter((item) => !registryLocales.includes(item))) {
+    reportError(`${locale} locale directory exists but is not in builtinLocales`);
+  }
+  for (const locale of registryLocales.filter((item) => !supportedLocales.includes(item))) {
+    reportError(`builtinLocales includes ${locale} but no matching locale directory exists`);
+  }
+
+  const registryNamespaces = readRegistryNamespaces();
+  const registrySet = new Set(registryNamespaces);
+
+  for (const locale of supportedLocales) {
+    const localeNamespaces = listLocaleNamespaces(locale);
+    const missingFromRegistry = localeNamespaces.filter((item) => !registrySet.has(item));
+    const missingFromLocale = registryNamespaces.filter((item) => !localeNamespaces.includes(item));
+
+    for (const namespace of missingFromRegistry) {
+      reportError(`${locale} namespace "${namespace}" exists on disk but is not in ALL_NAMESPACES`);
+    }
+    for (const namespace of missingFromLocale) {
+      reportError(`ALL_NAMESPACES includes "${namespace}" but ${locale} has no matching JSON file`);
+    }
+  }
+
+  const baselineNamespaces = listLocaleNamespaces(baselineLocale);
+  for (const locale of supportedLocales.filter((item) => item !== baselineLocale)) {
+    const localeNamespaces = listLocaleNamespaces(locale);
+    for (const namespace of diffSets(baselineNamespaces, localeNamespaces)) {
+      reportError(`${locale} is missing namespace "${namespace}"`);
+    }
+    for (const namespace of diffSets(localeNamespaces, baselineNamespaces)) {
+      reportError(`${locale} has extra namespace "${namespace}"`);
+    }
+  }
+
+  return registryNamespaces;
+}
+
+function auditKeyParity(namespaces) {
+  for (const namespace of namespaces) {
+    const baselineKeys = readJsonKeys(baselineLocale, namespace);
+    for (const locale of supportedLocales.filter((item) => item !== baselineLocale)) {
+      const localeKeys = readJsonKeys(locale, namespace);
+      const missing = diffSets(baselineKeys, localeKeys);
+      const extra = diffSets(localeKeys, baselineKeys);
+
+      if (missing.length > 0) {
+        reportWarning(`${locale}/${namespace}.json is missing ${missing.length} key(s): ${missing.slice(0, 8).join(', ')}`);
+      }
+      if (extra.length > 0) {
+        reportWarning(`${locale}/${namespace}.json has ${extra.length} extra key(s): ${extra.slice(0, 8).join(', ')}`);
+      }
+    }
+  }
+}
+
+function shouldSkipSourceScan(file) {
+  const normalized = toPosixPath(path.relative(root, file));
+  return (
+    normalized.includes('/locales/') ||
+    normalized.endsWith('.test.ts') ||
+    normalized.endsWith('.test.tsx') ||
+    normalized.endsWith('.spec.ts') ||
+    normalized.endsWith('.spec.tsx') ||
+    normalized.includes('/component-library/components/registry.tsx')
+  );
+}
+
+function auditSourceText() {
+  const sourceFiles = listFiles(
+    webSourceDir,
+    (file) => (file.endsWith('.ts') || file.endsWith('.tsx')) && !shouldSkipSourceScan(file),
+  );
+
+  const fallbackFindings = [];
+  const cjkFindings = [];
+  const fallbackPattern = /\bt\s*\(\s*(['"`])(?:\\.|(?!\1).)+\1\s*,\s*(['"`])/g;
+  const cjkPattern = /\p{Script=Han}/u;
+
+  for (const file of sourceFiles) {
+    const text = fs.readFileSync(file, 'utf8');
+    const lines = text.split(/\r?\n/);
+    lines.forEach((line, index) => {
+      if (fallbackPattern.test(line)) {
+        fallbackFindings.push(`${toPosixPath(path.relative(root, file))}:${index + 1}`);
+      }
+      fallbackPattern.lastIndex = 0;
+
+      if (cjkPattern.test(line)) {
+        cjkFindings.push(`${toPosixPath(path.relative(root, file))}:${index + 1}`);
+      }
+    });
+  }
+
+  if (fallbackFindings.length > 0) {
+    reportWarning(`Found ${fallbackFindings.length} t(key, "literal fallback") candidate(s). First entries: ${fallbackFindings.slice(0, 12).join(', ')}`);
+  }
+  if (cjkFindings.length > 0) {
+    reportWarning(`Found ${cjkFindings.length} CJK source line candidate(s). First entries: ${cjkFindings.slice(0, 12).join(', ')}`);
+  }
+}
+
+const namespaces = auditNamespaceCoverage();
+auditKeyParity(namespaces);
+auditSourceText();
+
+if (errorCount > 0) {
+  console.error(`[i18n:audit] Failed with ${errorCount} error(s) and ${warningCount} warning(s).`);
+  process.exit(1);
+}
+
+console.log(`[i18n:audit] Passed with ${warningCount} warning(s).`);

--- a/src/apps/desktop/src/api/i18n_api.rs
+++ b/src/apps/desktop/src/api/i18n_api.rs
@@ -1,7 +1,7 @@
 //! I18n API
 
 use crate::api::app_state::AppState;
-use bitfun_core::service::i18n::{get_global_i18n_service, LocaleId};
+use bitfun_core::service::i18n::{get_global_i18n_service, LocaleId, LocaleMetadata};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -48,8 +48,7 @@ pub async fn i18n_set_language(
     _app: tauri::AppHandle,
     request: SetLanguageRequest,
 ) -> Result<String, String> {
-    let supported = ["zh-CN", "en-US"];
-    if !supported.contains(&request.language.as_str()) {
+    if LocaleId::from_str(&request.language).is_none() {
         return Err(format!("Unsupported language: {}", request.language));
     }
 
@@ -105,24 +104,16 @@ pub async fn i18n_set_language(
 
 #[tauri::command]
 pub async fn i18n_get_supported_languages() -> Result<Vec<LocaleMetadataResponse>, String> {
-    let locales = vec![
-        LocaleMetadataResponse {
-            id: "zh-CN".to_string(),
-            name: "简体中文".to_string(),
-            english_name: "Simplified Chinese".to_string(),
-            native_name: "简体中文".to_string(),
-            rtl: false,
-        },
-        LocaleMetadataResponse {
-            id: "en-US".to_string(),
-            name: "English".to_string(),
-            english_name: "English (US)".to_string(),
-            native_name: "English".to_string(),
-            rtl: false,
-        },
-    ];
-
-    Ok(locales)
+    Ok(LocaleMetadata::all()
+        .into_iter()
+        .map(|locale| LocaleMetadataResponse {
+            id: locale.id.as_str().to_string(),
+            name: locale.name,
+            english_name: locale.english_name,
+            native_name: locale.native_name,
+            rtl: locale.rtl,
+        })
+        .collect())
 }
 
 #[tauri::command]

--- a/src/apps/server/src/rpc_dispatcher.rs
+++ b/src/apps/server/src/rpc_dispatcher.rs
@@ -8,6 +8,7 @@ use crate::bootstrap::ServerAppState;
 use anyhow::{anyhow, Result};
 use bitfun_core::agentic::coordination::{DialogSubmissionPolicy, DialogTriggerSource};
 use bitfun_core::agentic::core::SessionConfig;
+use bitfun_core::service::i18n::{LocaleId, LocaleMetadata};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -328,11 +329,19 @@ pub async fn dispatch(
                 .get_config(Some("app.language"))
                 .await
                 .unwrap_or_else(|_| "zh-CN".to_string());
+            let lang = if LocaleId::from_str(&lang).is_some() {
+                lang
+            } else {
+                "zh-CN".to_string()
+            };
             Ok(serde_json::json!(lang))
         }
         "i18n_set_language" => {
             let request = extract_request(&params)?;
             let language = get_string(&request, "language")?;
+            if LocaleId::from_str(&language).is_none() {
+                return Err(anyhow!("Unsupported language: {}", language));
+            }
             state
                 .config_service
                 .set_config("app.language", language.clone())
@@ -340,10 +349,21 @@ pub async fn dispatch(
                 .map_err(|e| anyhow!("{}", e))?;
             Ok(serde_json::json!(language))
         }
-        "i18n_get_supported_languages" => Ok(serde_json::json!([
-            {"id": "zh-CN", "name": "Chinese (Simplified)", "englishName": "Chinese (Simplified)", "nativeName": "简体中文", "rtl": false},
-            {"id": "en-US", "name": "English", "englishName": "English", "nativeName": "English", "rtl": false}
-        ])),
+        "i18n_get_supported_languages" => {
+            let locales: Vec<_> = LocaleMetadata::all()
+                .into_iter()
+                .map(|locale| {
+                    serde_json::json!({
+                        "id": locale.id.as_str(),
+                        "name": locale.name,
+                        "englishName": locale.english_name,
+                        "nativeName": locale.native_name,
+                        "rtl": locale.rtl,
+                    })
+                })
+                .collect();
+            Ok(serde_json::json!(locales))
+        }
 
         // ── Tools ────────────────────────────────────────────
         "get_all_tools_info" => {

--- a/src/crates/core/src/service/config/app_language.rs
+++ b/src/crates/core/src/service/config/app_language.rs
@@ -6,15 +6,17 @@
 //! `I18nService::get_current_locale`, which historically synced from `i18n.currentLanguage` only.
 
 use super::GlobalConfigManager;
+use crate::service::i18n::LocaleId;
 use log::debug;
 
-/// Returns `zh-CN` or `en-US` from global config when valid; otherwise `zh-CN` (matches [`crate::service::config::AppConfig::default`]).
+/// Returns a supported `app.language` from global config; otherwise `zh-CN`
+/// (matches [`crate::service::config::AppConfig::default`]).
 pub async fn get_app_language_code() -> String {
     let Ok(svc) = GlobalConfigManager::get_service().await else {
         return "zh-CN".to_string();
     };
     match svc.get_config::<String>(Some("app.language")).await {
-        Ok(code) if code == "zh-CN" || code == "en-US" => code,
+        Ok(code) if LocaleId::from_str(&code).is_some() => code,
         Ok(other) => {
             debug!("Unknown app.language {}, defaulting to zh-CN", other);
             "zh-CN".to_string()

--- a/src/crates/core/src/service/i18n/types.rs
+++ b/src/crates/core/src/service/i18n/types.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Locale identifier.
-/// Currently supports Chinese and English only.
+/// Add new variants here when a backend-supported locale is introduced.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub enum LocaleId {
     #[serde(rename = "zh-CN")]
@@ -61,7 +61,6 @@ pub struct LocaleMetadata {
 
 impl LocaleMetadata {
     /// Returns metadata for all locales.
-    /// Currently supports Chinese and English only.
     pub fn all() -> Vec<LocaleMetadata> {
         vec![
             LocaleMetadata {
@@ -79,6 +78,31 @@ impl LocaleMetadata {
                 rtl: false,
             },
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locale_parser_accepts_registered_locales_only() {
+        for locale in LocaleId::all() {
+            assert_eq!(LocaleId::from_str(locale.as_str()), Some(locale));
+        }
+
+        assert_eq!(LocaleId::from_str("fr-FR"), None);
+    }
+
+    #[test]
+    fn locale_metadata_matches_supported_locale_ids() {
+        let ids: Vec<_> = LocaleId::all();
+        let metadata_ids: Vec<_> = LocaleMetadata::all()
+            .into_iter()
+            .map(|metadata| metadata.id)
+            .collect();
+
+        assert_eq!(metadata_ids, ids);
     }
 }
 

--- a/src/web-ui/src/app/components/NavBar/NavBar.tsx
+++ b/src/web-ui/src/app/components/NavBar/NavBar.tsx
@@ -16,6 +16,7 @@ import { useNavSceneStore } from '../../stores/navSceneStore';
 import { useI18n } from '../../../infrastructure/i18n';
 import { PanelLeftIcon } from '../TitleBar/PanelIcons';
 import { createLogger } from '@/shared/utils/logger';
+import { isMacOSDesktopRuntime, supportsNativeWindowDragging } from '@/infrastructure/runtime';
 import './NavBar.scss';
 
 const log = createLogger('NavBar');
@@ -38,14 +39,9 @@ const NavBar: React.FC<NavBarProps> = ({
 }) => {
   const { t } = useI18n('common');
   const isMacOS = useMemo(() => {
-    const isTauri = typeof window !== 'undefined' && '__TAURI__' in window;
-    return (
-      isTauri &&
-      typeof navigator !== 'undefined' &&
-      typeof navigator.platform === 'string' &&
-      navigator.platform.toUpperCase().includes('MAC')
-    );
+    return isMacOSDesktopRuntime();
   }, []);
+  const canDragWindow = supportsNativeWindowDragging();
   const showSceneNav = useNavSceneStore(s => s.showSceneNav);
   const navSceneId   = useNavSceneStore(s => s.navSceneId);
   const goBack       = useNavSceneStore(s => s.goBack);
@@ -55,6 +51,8 @@ const NavBar: React.FC<NavBarProps> = ({
   const lastMouseDownTimeRef = useRef<number>(0);
 
   const handleBarMouseDown = useCallback((e: React.MouseEvent) => {
+    if (!canDragWindow) return;
+
     const now = Date.now();
     const timeSinceLastMouseDown = now - lastMouseDownTimeRef.current;
     lastMouseDownTimeRef.current = now;
@@ -73,7 +71,7 @@ const NavBar: React.FC<NavBarProps> = ({
         log.debug('startDragging failed', error);
       }
     })();
-  }, []);
+  }, [canDragWindow]);
 
   const handleBarDoubleClick = useCallback((e: React.MouseEvent) => {
     const target = e.target as HTMLElement | null;

--- a/src/web-ui/src/app/components/SceneBar/SceneBar.tsx
+++ b/src/web-ui/src/app/components/SceneBar/SceneBar.tsx
@@ -13,6 +13,7 @@ import { useCurrentSessionTitle } from '../../hooks/useCurrentSessionTitle';
 import { useCurrentSettingsTabTitle } from '../../hooks/useCurrentSettingsTabTitle';
 import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
 import { createLogger } from '@/shared/utils/logger';
+import { supportsNativeWindowDragging } from '@/infrastructure/runtime';
 import './SceneBar.scss';
 
 const log = createLogger('SceneBar');
@@ -42,6 +43,7 @@ const SceneBar: React.FC<SceneBarProps> = ({
   const hasWindowControls = !!(onMinimize && onMaximize && onClose);
   const sceneBarClassName = `bitfun-scene-bar ${!hasWindowControls ? 'bitfun-scene-bar--no-controls' : ''} ${className}`.trim();
   const isSingleTab = openTabs.length <= 1;
+  const canDragWindow = supportsNativeWindowDragging();
   const tabCount = Math.max(openTabs.length, 1);
   const tabsStyle = {
     ['--scene-tab-count' as string]: tabCount,
@@ -49,6 +51,7 @@ const SceneBar: React.FC<SceneBarProps> = ({
   const lastMouseDownTimeRef = useRef<number>(0);
 
   const handleBarMouseDown = useCallback((e: React.MouseEvent) => {
+    if (!canDragWindow) return;
     if (!isSingleTab) return;
 
     const now = Date.now();
@@ -69,7 +72,7 @@ const SceneBar: React.FC<SceneBarProps> = ({
         log.debug('startDragging failed', error);
       }
     })();
-  }, [isSingleTab]);
+  }, [canDragWindow, isSingleTab]);
 
   const handleBarDoubleClick = useCallback((e: React.MouseEvent) => {
     if (!isSingleTab) return;

--- a/src/web-ui/src/app/hooks/useWindowControls.ts
+++ b/src/web-ui/src/app/hooks/useWindowControls.ts
@@ -5,6 +5,7 @@ import { notificationService } from '@/shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
 import { sendDebugProbe } from '@/shared/utils/debugProbe';
 import { useI18n } from '@/infrastructure/i18n';
+import { isMacOSDesktopRuntime, supportsNativeWindowControls } from '@/infrastructure/runtime';
 
 const log = createLogger('useWindowControls');
 
@@ -18,6 +19,7 @@ const formatErrorMessage = (error: unknown) =>
 export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
   const { t } = useI18n('errors');
   const isToolbarMode = options?.isToolbarMode ?? false;
+  const canUseNativeWindowControls = supportsNativeWindowControls();
   const { hasWorkspace, closeWorkspace } = useWorkspaceContext();
   
   // Maximized state
@@ -31,17 +33,14 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
 
   // Listen for window state changes
   useEffect(() => {
+    if (!canUseNativeWindowControls) return;
+
     let unlistenResized: (() => void) | undefined;
     
     // Debounce timer
     let resizeTimer: NodeJS.Timeout | null = null;
 
-    const isMacOSDesktop =
-      typeof window !== 'undefined' &&
-      '__TAURI__' in window &&
-      typeof navigator !== 'undefined' &&
-      typeof navigator.platform === 'string' &&
-      navigator.platform.toUpperCase().includes('MAC');
+    const isMacOSDesktop = isMacOSDesktopRuntime();
 
     const restoreMacOSOverlayTitlebar = async (appWindow: any) => {
       if (!isMacOSDesktop || isToolbarMode) return;
@@ -189,10 +188,12 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
       // Remove page visibility listener
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [isToolbarMode]);
+  }, [canUseNativeWindowControls, isToolbarMode]);
 
   // Window control handlers
   const handleMinimize = useCallback(async () => {
+    if (!canUseNativeWindowControls) return;
+
     // Save active element to restore focus after window restore
     const activeElement = document.activeElement as HTMLElement;
     const wasInputFocused = activeElement && (
@@ -241,9 +242,11 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
       log.error('Failed to minimize window', error);
       // Avoid error toast when minimized to prevent UI blockage
     }
-  }, []);
+  }, [canUseNativeWindowControls]);
 
   const handleMaximize = useCallback(async () => {
+    if (!canUseNativeWindowControls) return;
+
     // Debounce: ignore while in progress
     if (isMaximizeInProgress.current) {
       return;
@@ -327,9 +330,11 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
         shouldSkipStateUpdate.current = false;
       }, 200);
     }
-  }, [t]);
+  }, [canUseNativeWindowControls, t]);
 
   const handleClose = useCallback(async () => {
+    if (!canUseNativeWindowControls) return;
+
     try {
       const appWindow = getCurrentWindow();
       await appWindow.close();
@@ -337,7 +342,7 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
       log.error('Failed to close window', error);
       notificationService.error(t('window.closeFailed', { error: formatErrorMessage(error) }));
     }
-  }, [t]);
+  }, [canUseNativeWindowControls, t]);
 
   // Home button: reset to startup page
   const handleHomeClick = useCallback(async () => {
@@ -359,6 +364,7 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
     handleMaximize,
     handleClose,
     handleHomeClick,
-    isMaximized
+    isMaximized,
+    canUseNativeWindowControls
   };
 };

--- a/src/web-ui/src/app/layout/AppLayout.tsx
+++ b/src/web-ui/src/app/layout/AppLayout.tsx
@@ -34,6 +34,7 @@ import { WorkspaceKind } from '@/shared/types';
 import { SSHContext } from '@/features/ssh-remote/SSHRemoteContext';
 import { shortcutManager, parseStoredKeybindings } from '@/infrastructure/services/ShortcutManager';
 import { useSessionModeStore } from '../stores/sessionModeStore';
+import { isMacOSDesktopRuntime } from '@/infrastructure/runtime';
 import './AppLayout.scss';
 
 const log = createLogger('AppLayout');
@@ -62,7 +63,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
   const { isToolbarMode } = useToolbarModeContext();
   const { ensureForWorkspace: ensureAssistantBootstrapForWorkspace } = useAssistantBootstrap();
 
-  const { handleMinimize, handleMaximize, handleClose, isMaximized } =
+  const { handleMinimize, handleMaximize, handleClose, isMaximized, canUseNativeWindowControls } =
     useWindowControls({ isToolbarMode });
 
   const { state, switchLeftPanelTab, toggleLeftPanel, toggleRightPanel } = useApp();
@@ -158,8 +159,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
 
   // macOS native menubar events (previously in TitleBar)
   const isMacOS = useMemo(() => {
-    const isTauri = typeof window !== 'undefined' && '__TAURI__' in window;
-    return isTauri && typeof navigator?.platform === 'string' && navigator.platform.toUpperCase().includes('MAC');
+    return isMacOSDesktopRuntime();
   }, []);
 
   useEffect(() => {
@@ -295,6 +295,8 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
     let unlistenFn: (() => void) | null = null;
 
     const setupWindowCloseListener = async () => {
+      if (!canUseNativeWindowControls) return;
+
       try {
         const { getCurrentWindow } = await import('@tauri-apps/api/window');
         const currentWindow = getCurrentWindow();
@@ -317,7 +319,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
 
     setupWindowCloseListener();
     return () => { if (unlistenFn) unlistenFn(); };
-  }, []);
+  }, [canUseNativeWindowControls]);
 
   // Handle switch-to-files-panel event
   React.useEffect(() => {
@@ -456,9 +458,9 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
         {/* Main content — always render WorkspaceBody; WelcomeScene in viewport handles no-workspace state */}
         <main className="bitfun-app-main-workspace" data-testid="app-main-content">
           <WorkspaceBody
-            onMinimize={isMacOS ? undefined : handleMinimize}
-            onMaximize={handleMaximize}
-            onClose={isMacOS ? undefined : handleClose}
+            onMinimize={canUseNativeWindowControls && !isMacOS ? handleMinimize : undefined}
+            onMaximize={canUseNativeWindowControls ? handleMaximize : undefined}
+            onClose={canUseNativeWindowControls && !isMacOS ? handleClose : undefined}
             isMaximized={isMaximized}
             isEntering={transitionDir === 'entering'}
             isExiting={transitionDir === 'returning'}

--- a/src/web-ui/src/infrastructure/api/adapters/index.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/index.ts
@@ -3,6 +3,7 @@
 import { ITransportAdapter } from './base';
 import { TauriTransportAdapter } from './tauri-adapter';
 import { WebSocketTransportAdapter } from './websocket-adapter';
+import { isTauriRuntime } from '@/infrastructure/runtime';
 export * from './base';
 export * from './tauri-adapter';
 export * from './websocket-adapter';
@@ -10,17 +11,11 @@ export * from './websocket-adapter';
  
 export function detectEnvironment(): 'tauri' | 'web' {
   
-  if (typeof window !== 'undefined' && '__TAURI__' in window) {
+  if (isTauriRuntime()) {
     return 'tauri';
   }
-  
-  
-  if (import.meta.env.VITE_BUILD_TARGET === 'web') {
-    return 'web';
-  }
-  
-  
-  return 'tauri';
+
+  return 'web';
 }
 
  

--- a/src/web-ui/src/infrastructure/i18n/core/I18nService.ts
+++ b/src/web-ui/src/infrastructure/i18n/core/I18nService.ts
@@ -1,6 +1,6 @@
  
 
-import i18next, { i18n as I18nInstance, TFunction } from 'i18next';
+import i18next, { i18n as I18nInstance, Resource, TFunction } from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
 import type {
@@ -17,165 +17,39 @@ import {
   DEFAULT_LOCALE,
   DEFAULT_FALLBACK_LOCALE,
   DEFAULT_NAMESPACE,
+  ALL_NAMESPACES,
   isLocaleSupported,
 } from '../presets';
 import { useI18nStore } from '../store/i18nStore';
 import { i18nAPI } from '@/infrastructure/api/service-api/I18nAPI';
 
-
-import zhCNCommon from '../../../locales/zh-CN/common.json';
-import zhCNFlowChat from '../../../locales/zh-CN/flow-chat.json';
-import zhCNTools from '../../../locales/zh-CN/tools.json';
-import zhCNSettings from '../../../locales/zh-CN/settings.json';
-import zhCNErrors from '../../../locales/zh-CN/errors.json';
-import zhCNNotifications from '../../../locales/zh-CN/notifications.json';
-import zhCNComponents from '../../../locales/zh-CN/components.json';
-
-import zhCNScenesCapabilities from '../../../locales/zh-CN/scenes/capabilities.json';
-import zhCNScenesAgents from '../../../locales/zh-CN/scenes/agents.json';
-import zhCNScenesProfile from '../../../locales/zh-CN/scenes/profile.json';
-import zhCNScenesSkills from '../../../locales/zh-CN/scenes/skills.json';
-import zhCNScenesMiniapp from '../../../locales/zh-CN/scenes/miniapp.json';
-import zhCNPanelsFiles from '../../../locales/zh-CN/panels/files.json';
-import zhCNPanelsGit from '../../../locales/zh-CN/panels/git.json';
-import zhCNPanelsTerminal from '../../../locales/zh-CN/panels/terminal.json';
-
-import zhCNSettingsAiModel from '../../../locales/zh-CN/settings/ai-model.json';
-import zhCNSettingsAgenticTools from '../../../locales/zh-CN/settings/agentic-tools.json';
-import zhCNSettingsMcp from '../../../locales/zh-CN/settings/mcp.json';
-import zhCNSettingsMcpTools from '../../../locales/zh-CN/settings/mcp-tools.json';
-import zhCNSettingsBasics from '../../../locales/zh-CN/settings/basics.json';
-import zhCNSettingsAiFeatures from '../../../locales/zh-CN/settings/ai-features.json';
-import zhCNSettingsSessionConfig from '../../../locales/zh-CN/settings/session-config.json';
-import zhCNSettingsLsp from '../../../locales/zh-CN/settings/lsp.json';
-import zhCNSettingsDebug from '../../../locales/zh-CN/settings/debug.json';
-import zhCNSettingsEditor from '../../../locales/zh-CN/settings/editor.json';
-import zhCNSettingsSkills from '../../../locales/zh-CN/settings/skills.json';
-import zhCNSettingsAiRules from '../../../locales/zh-CN/settings/ai-rules.json';
-import zhCNSettingsAiMemory from '../../../locales/zh-CN/settings/ai-memory.json';
-import zhCNSettingsAiContext from '../../../locales/zh-CN/settings/ai-context.json';
-import zhCNSettingsAgents from '../../../locales/zh-CN/settings/agents.json';
-import zhCNSettingsDefaultModel from '../../../locales/zh-CN/settings/default-model.json';
-
-import zhCNMermaidEditor from '../../../locales/zh-CN/mermaid-editor.json';
-
-import enUSCommon from '../../../locales/en-US/common.json';
-import enUSFlowChat from '../../../locales/en-US/flow-chat.json';
-import enUSTools from '../../../locales/en-US/tools.json';
-import enUSSettings from '../../../locales/en-US/settings.json';
-import enUSErrors from '../../../locales/en-US/errors.json';
-import enUSNotifications from '../../../locales/en-US/notifications.json';
-import enUSComponents from '../../../locales/en-US/components.json';
-
-import enUSScenesCapabilities from '../../../locales/en-US/scenes/capabilities.json';
-import enUSScenesAgents from '../../../locales/en-US/scenes/agents.json';
-import enUSScenesProfile from '../../../locales/en-US/scenes/profile.json';
-import enUSScenesSkills from '../../../locales/en-US/scenes/skills.json';
-import enUSScenesMiniapp from '../../../locales/en-US/scenes/miniapp.json';
-import enUSPanelsFiles from '../../../locales/en-US/panels/files.json';
-import enUSPanelsGit from '../../../locales/en-US/panels/git.json';
-import enUSPanelsTerminal from '../../../locales/en-US/panels/terminal.json';
-
-import enUSSettingsAiModel from '../../../locales/en-US/settings/ai-model.json';
-import enUSSettingsAgenticTools from '../../../locales/en-US/settings/agentic-tools.json';
-import enUSSettingsMcp from '../../../locales/en-US/settings/mcp.json';
-import enUSSettingsMcpTools from '../../../locales/en-US/settings/mcp-tools.json';
-import enUSSettingsBasics from '../../../locales/en-US/settings/basics.json';
-import enUSSettingsAiFeatures from '../../../locales/en-US/settings/ai-features.json';
-import enUSSettingsSessionConfig from '../../../locales/en-US/settings/session-config.json';
-import enUSSettingsLsp from '../../../locales/en-US/settings/lsp.json';
-import enUSSettingsDebug from '../../../locales/en-US/settings/debug.json';
-import enUSSettingsEditor from '../../../locales/en-US/settings/editor.json';
-import enUSSettingsSkills from '../../../locales/en-US/settings/skills.json';
-import enUSSettingsAiRules from '../../../locales/en-US/settings/ai-rules.json';
-import enUSSettingsAiMemory from '../../../locales/en-US/settings/ai-memory.json';
-import enUSSettingsAiContext from '../../../locales/en-US/settings/ai-context.json';
-import enUSSettingsAgents from '../../../locales/en-US/settings/agents.json';
-import enUSSettingsDefaultModel from '../../../locales/en-US/settings/default-model.json';
-
-import enUSMermaidEditor from '../../../locales/en-US/mermaid-editor.json';
-
 import { createLogger } from '@/shared/utils/logger';
 
 const log = createLogger('I18nService');
 
- 
-const resources = {
-  'zh-CN': {
-    common: zhCNCommon,
-    'flow-chat': zhCNFlowChat,
-    tools: zhCNTools,
-    settings: zhCNSettings,
-    errors: zhCNErrors,
-    notifications: zhCNNotifications,
-    components: zhCNComponents,
-    
-    'scenes/capabilities': zhCNScenesCapabilities,
-    'scenes/agents': zhCNScenesAgents,
-    'scenes/profile': zhCNScenesProfile,
-    'scenes/skills': zhCNScenesSkills,
-    'scenes/miniapp': zhCNScenesMiniapp,
-    'panels/files': zhCNPanelsFiles,
-    'panels/git': zhCNPanelsGit,
-    'panels/terminal': zhCNPanelsTerminal,
-    
-    'settings/ai-model': zhCNSettingsAiModel,
-    'settings/agentic-tools': zhCNSettingsAgenticTools,
-    'settings/mcp': zhCNSettingsMcp,
-    'settings/mcp-tools': zhCNSettingsMcpTools,
-    'settings/basics': zhCNSettingsBasics,
-    'settings/ai-features': zhCNSettingsAiFeatures,
-    'settings/session-config': zhCNSettingsSessionConfig,
-    'settings/lsp': zhCNSettingsLsp,
-    'settings/debug': zhCNSettingsDebug,
-    'settings/editor': zhCNSettingsEditor,
-    'settings/skills': zhCNSettingsSkills,
-    'settings/ai-rules': zhCNSettingsAiRules,
-    'settings/ai-memory': zhCNSettingsAiMemory,
-    'settings/ai-context': zhCNSettingsAiContext,
-    'settings/agents': zhCNSettingsAgents,
-    'settings/default-model': zhCNSettingsDefaultModel,
-    
-    'mermaid-editor': zhCNMermaidEditor,
-  },
-  'en-US': {
-    common: enUSCommon,
-    'flow-chat': enUSFlowChat,
-    tools: enUSTools,
-    settings: enUSSettings,
-    errors: enUSErrors,
-    notifications: enUSNotifications,
-    components: enUSComponents,
-    
-    'scenes/capabilities': enUSScenesCapabilities,
-    'scenes/agents': enUSScenesAgents,
-    'scenes/profile': enUSScenesProfile,
-    'scenes/skills': enUSScenesSkills,
-    'scenes/miniapp': enUSScenesMiniapp,
-    'panels/files': enUSPanelsFiles,
-    'panels/git': enUSPanelsGit,
-    'panels/terminal': enUSPanelsTerminal,
-    
-    'settings/ai-model': enUSSettingsAiModel,
-    'settings/agentic-tools': enUSSettingsAgenticTools,
-    'settings/mcp': enUSSettingsMcp,
-    'settings/mcp-tools': enUSSettingsMcpTools,
-    'settings/basics': enUSSettingsBasics,
-    'settings/ai-features': enUSSettingsAiFeatures,
-    'settings/session-config': enUSSettingsSessionConfig,
-    'settings/lsp': enUSSettingsLsp,
-    'settings/debug': enUSSettingsDebug,
-    'settings/editor': enUSSettingsEditor,
-    'settings/skills': enUSSettingsSkills,
-    'settings/ai-rules': enUSSettingsAiRules,
-    'settings/ai-memory': enUSSettingsAiMemory,
-    'settings/ai-context': enUSSettingsAiContext,
-    'settings/agents': enUSSettingsAgents,
-    'settings/default-model': enUSSettingsDefaultModel,
-    
-    'mermaid-editor': enUSMermaidEditor,
-  },
-};
+// Eager glob preserves the previous startup behavior while removing the
+// per-locale manual import list. Adding locales now only needs registry and
+// JSON files; the build discovers matching resources automatically.
+const localeModules = import.meta.glob('../../../locales/**/*.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, Record<string, unknown>>;
+
+function buildResources(): Resource {
+  return Object.entries(localeModules).reduce<Resource>((acc, [modulePath, messages]) => {
+    const match = modulePath.match(/locales\/([^/]+)\/(.+)\.json$/);
+    if (!match) return acc;
+
+    const [, locale, namespace] = match;
+    acc[locale] = {
+      ...(acc[locale] ?? {}),
+      [namespace]: messages,
+    };
+    return acc;
+  }, {});
+}
+
+const resources = buildResources();
 
  
 export class I18nService {
@@ -198,42 +72,7 @@ export class I18nService {
         lng: DEFAULT_LOCALE,
         fallbackLng: DEFAULT_FALLBACK_LOCALE,
         defaultNS: DEFAULT_NAMESPACE,
-        ns: [
-          'common', 
-          'flow-chat', 
-          'tools', 
-          'settings', 
-          'errors', 
-          'notifications', 
-          'components',
-          
-          'scenes/capabilities',
-          'scenes/agents',
-          'scenes/profile',
-          'scenes/skills',
-          'scenes/miniapp',
-          'panels/files',
-          'panels/git',
-          'panels/terminal',
-          
-          'settings/ai-model',
-          'settings/agentic-tools',
-          'settings/mcp',
-          'settings/mcp-tools',
-          'settings/basics',
-          'settings/ai-features',
-          'settings/lsp',
-          'settings/debug',
-          'settings/editor',
-          'settings/skills',
-          'settings/ai-rules',
-          'settings/ai-memory',
-          'settings/ai-context',
-          'settings/agents',
-          'settings/default-model',
-          
-          'mermaid-editor',
-        ],
+        ns: [...ALL_NAMESPACES],
         interpolation: {
           escapeValue: false,
         },

--- a/src/web-ui/src/infrastructure/i18n/hooks/useI18n.ts
+++ b/src/web-ui/src/infrastructure/i18n/hooks/useI18n.ts
@@ -62,7 +62,7 @@ export function useI18n(
 
   const currentLocaleMetadata = useMemo(
     () => i18nService.getCurrentLocaleMetadata(),
-    []
+    [currentLanguage]
   );
 
   const supportedLocales = useMemo(
@@ -100,7 +100,7 @@ export function useI18n(
 
   const isRTL = useMemo(
     () => i18nService.isRTL(),
-    []
+    [currentLanguage]
   );
 
   return {

--- a/src/web-ui/src/infrastructure/i18n/presets/index.ts
+++ b/src/web-ui/src/infrastructure/i18n/presets/index.ts
@@ -1,42 +1,13 @@
  
 
-import type { LocaleId, LocaleMetadata } from '../types';
+import { builtinLocales } from './localeRegistry';
+import type { LocaleId, LocaleMetadata } from './localeRegistry';
+export { ALL_NAMESPACES } from './namespaceRegistry';
+export { builtinLocales };
 
- 
-export const DEFAULT_LOCALE: LocaleId = 'zh-CN';
+export const DEFAULT_LOCALE = 'zh-CN' satisfies LocaleId;
 
- 
-export const DEFAULT_FALLBACK_LOCALE: LocaleId = 'en-US';
-
- 
-export const builtinLocales: LocaleMetadata[] = [
-  {
-    id: 'zh-CN',
-    name: '简体中文',
-    englishName: 'Simplified Chinese',
-    nativeName: '简体中文',
-    rtl: false,
-    dateFormat: 'YYYY年MM月DD日',
-    numberFormat: {
-      decimal: '.',
-      thousands: ',',
-    },
-    builtin: true,
-  },
-  {
-    id: 'en-US',
-    name: 'English',
-    englishName: 'English (US)',
-    nativeName: 'English',
-    rtl: false,
-    dateFormat: 'MM/DD/YYYY',
-    numberFormat: {
-      decimal: '.',
-      thousands: ',',
-    },
-    builtin: true,
-  },
-];
+export const DEFAULT_FALLBACK_LOCALE = 'en-US' satisfies LocaleId;
 
  
 export function getLocaleMetadata(localeId: LocaleId): LocaleMetadata | undefined {
@@ -55,14 +26,3 @@ export function getSupportedLocaleIds(): LocaleId[] {
 
  
 export const DEFAULT_NAMESPACE = 'common';
-
- 
-export const ALL_NAMESPACES = [
-  'common',
-  'flow-chat',
-  'tools',
-  'settings',
-  'errors',
-  'notifications',
-  'components',
-] as const;

--- a/src/web-ui/src/infrastructure/i18n/presets/localeRegistry.test.ts
+++ b/src/web-ui/src/infrastructure/i18n/presets/localeRegistry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_FALLBACK_LOCALE,
+  DEFAULT_LOCALE,
+  getSupportedLocaleIds,
+  isLocaleSupported,
+} from './index';
+import { builtinLocales, LOCALE_IDS } from './localeRegistry';
+
+describe('localeRegistry', () => {
+  it('keeps locale ids and metadata in the same order', () => {
+    expect(builtinLocales.map(locale => locale.id)).toEqual([...LOCALE_IDS]);
+  });
+
+  it('contains unique ids with complete display metadata', () => {
+    const ids = builtinLocales.map(locale => locale.id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    for (const locale of builtinLocales) {
+      expect(locale.name.length).toBeGreaterThan(0);
+      expect(locale.englishName.length).toBeGreaterThan(0);
+      expect(locale.nativeName.length).toBeGreaterThan(0);
+      expect(locale.dateFormat.length).toBeGreaterThan(0);
+      expect(locale.numberFormat.decimal.length).toBeGreaterThan(0);
+      expect(locale.numberFormat.thousands.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('derives support checks from the registry', () => {
+    expect(getSupportedLocaleIds()).toEqual([...LOCALE_IDS]);
+    expect(isLocaleSupported(DEFAULT_LOCALE)).toBe(true);
+    expect(isLocaleSupported(DEFAULT_FALLBACK_LOCALE)).toBe(true);
+    expect(isLocaleSupported('fr-FR')).toBe(false);
+  });
+});

--- a/src/web-ui/src/infrastructure/i18n/presets/localeRegistry.ts
+++ b/src/web-ui/src/infrastructure/i18n/presets/localeRegistry.ts
@@ -1,0 +1,52 @@
+/**
+ * Single Web UI registry for selectable locales.
+ *
+ * To add a locale, add one metadata entry here and provide the matching
+ * `src/web-ui/src/locales/<locale-id>/*.json` files. The i18n audit checks
+ * that the registry and locale folders stay in sync.
+ */
+export const LOCALE_IDS = ['zh-CN', 'en-US'] as const;
+export type LocaleId = (typeof LOCALE_IDS)[number];
+
+export const builtinLocales = [
+  {
+    id: 'zh-CN',
+    name: '简体中文',
+    englishName: 'Simplified Chinese',
+    nativeName: '简体中文',
+    rtl: false,
+    dateFormat: 'YYYY年MM月DD日',
+    numberFormat: {
+      decimal: '.',
+      thousands: ',',
+    },
+    builtin: true,
+  },
+  {
+    id: 'en-US',
+    name: 'English',
+    englishName: 'English (US)',
+    nativeName: 'English',
+    rtl: false,
+    dateFormat: 'MM/DD/YYYY',
+    numberFormat: {
+      decimal: '.',
+      thousands: ',',
+    },
+    builtin: true,
+  },
+] satisfies LocaleMetadata[];
+
+export interface LocaleMetadata {
+  id: LocaleId;
+  name: string;
+  englishName: string;
+  nativeName: string;
+  rtl: boolean;
+  dateFormat: string;
+  numberFormat: {
+    decimal: string;
+    thousands: string;
+  };
+  builtin: boolean;
+}

--- a/src/web-ui/src/infrastructure/i18n/presets/namespaceRegistry.test.ts
+++ b/src/web-ui/src/infrastructure/i18n/presets/namespaceRegistry.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { ALL_NAMESPACES } from './namespaceRegistry';
+
+describe('namespaceRegistry', () => {
+  it('contains unique namespaces in stable sorted order', () => {
+    const namespaces = [...ALL_NAMESPACES];
+
+    expect(new Set(namespaces).size).toBe(namespaces.length);
+    expect(namespaces).toEqual([...namespaces].sort());
+  });
+
+  it('includes the default common namespace', () => {
+    expect(ALL_NAMESPACES).toContain('common');
+  });
+});

--- a/src/web-ui/src/infrastructure/i18n/presets/namespaceRegistry.ts
+++ b/src/web-ui/src/infrastructure/i18n/presets/namespaceRegistry.ts
@@ -1,0 +1,40 @@
+/**
+ * Single namespace list consumed by i18next and the i18n audit.
+ *
+ * Keep this aligned with every locale folder under `src/web-ui/src/locales`.
+ * Adding a namespace should require this file plus one JSON file per locale.
+ */
+export const ALL_NAMESPACES = [
+  'common',
+  'components',
+  'errors',
+  'flow-chat',
+  'mermaid-editor',
+  'notifications',
+  'panels/files',
+  'panels/git',
+  'panels/terminal',
+  'scenes/agents',
+  'scenes/capabilities',
+  'scenes/miniapp',
+  'scenes/profile',
+  'scenes/skills',
+  'settings',
+  'settings/agentic-tools',
+  'settings/agents',
+  'settings/ai-context',
+  'settings/ai-features',
+  'settings/ai-memory',
+  'settings/ai-model',
+  'settings/ai-rules',
+  'settings/basics',
+  'settings/debug',
+  'settings/default-model',
+  'settings/editor',
+  'settings/lsp',
+  'settings/mcp',
+  'settings/mcp-tools',
+  'settings/session-config',
+  'settings/skills',
+  'tools',
+] as const;

--- a/src/web-ui/src/infrastructure/i18n/types/index.ts
+++ b/src/web-ui/src/infrastructure/i18n/types/index.ts
@@ -1,48 +1,11 @@
  
 
- 
-export type LocaleId = 'zh-CN' | 'en-US';
+import type { ALL_NAMESPACES } from '../presets/namespaceRegistry';
+import type { LocaleId, LocaleMetadata } from '../presets/localeRegistry';
 
- 
-export interface LocaleMetadata {
-   
-  id: LocaleId;
-   
-  name: string;
-   
-  englishName: string;
-   
-  nativeName: string;
-   
-  rtl: boolean;
-   
-  dateFormat: string;
-   
-  numberFormat: {
-    decimal: string;
-    thousands: string;
-  };
-   
-  builtin: boolean;
-}
+export type { LocaleId, LocaleMetadata };
 
- 
-export type I18nNamespace = 
-  | 'common'           
-  | 'flow-chat'        
-  | 'tools'            
-  | 'settings'         
-  | 'errors'           
-  | 'notifications'    
-  | 'components'
-  | 'panels/git'
-  | 'panels/terminal'
-  | 'mermaid-editor'
-  | 'scenes/miniapp'
-  | 'scenes/capabilities'
-  | 'scenes/agents'
-  | 'scenes/profile'
-  | 'scenes/skills';      
+export type I18nNamespace = (typeof ALL_NAMESPACES)[number];
 
  
 export interface I18nConfig {

--- a/src/web-ui/src/infrastructure/runtime/environment.test.ts
+++ b/src/web-ui/src/infrastructure/runtime/environment.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isTauriRuntime, supportsNativeWindowControls } from './environment';
+
+const setTauriInternals = (value: unknown) => {
+  vi.stubGlobal('window', {
+    __TAURI_INTERNALS__: value,
+  });
+};
+
+describe('runtime environment', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('treats a plain browser as non-Tauri without native window controls', () => {
+    vi.stubGlobal('window', {});
+
+    expect(isTauriRuntime()).toBe(false);
+    expect(supportsNativeWindowControls()).toBe(false);
+  });
+
+  it('requires current window metadata before enabling native window controls', () => {
+    setTauriInternals({ invoke: vi.fn() });
+
+    expect(isTauriRuntime()).toBe(true);
+    expect(supportsNativeWindowControls()).toBe(false);
+  });
+
+  it('enables native window controls for a complete Tauri window runtime', () => {
+    setTauriInternals({
+      invoke: vi.fn(),
+      metadata: {
+        currentWindow: {
+          label: 'main',
+        },
+      },
+    });
+
+    expect(isTauriRuntime()).toBe(true);
+    expect(supportsNativeWindowControls()).toBe(true);
+  });
+});

--- a/src/web-ui/src/infrastructure/runtime/environment.ts
+++ b/src/web-ui/src/infrastructure/runtime/environment.ts
@@ -1,0 +1,32 @@
+type TauriInternals = {
+  invoke?: unknown;
+  metadata?: {
+    currentWindow?: {
+      label?: string;
+    };
+  };
+};
+
+const getTauriInternals = (): TauriInternals | undefined => {
+  if (typeof window === 'undefined') return undefined;
+  return (window as unknown as { __TAURI_INTERNALS__?: TauriInternals }).__TAURI_INTERNALS__;
+};
+
+export const isTauriRuntime = (): boolean => {
+  const internals = getTauriInternals();
+  return typeof internals?.invoke === 'function';
+};
+
+export const supportsNativeWindowControls = (): boolean => {
+  // Tauri window APIs read metadata.currentWindow; browser builds must not call them without it.
+  const currentWindow = getTauriInternals()?.metadata?.currentWindow;
+  return isTauriRuntime() && typeof currentWindow?.label === 'string';
+};
+
+export const supportsNativeWindowDragging = supportsNativeWindowControls;
+
+export const isMacOSDesktopRuntime = (): boolean =>
+  supportsNativeWindowControls() &&
+  typeof navigator !== 'undefined' &&
+  typeof navigator.platform === 'string' &&
+  navigator.platform.toUpperCase().includes('MAC');

--- a/src/web-ui/src/infrastructure/runtime/index.ts
+++ b/src/web-ui/src/infrastructure/runtime/index.ts
@@ -1,0 +1,1 @@
+export * from './environment';

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -398,9 +398,17 @@
     "toolCallLabel": "🔧 工具调用: {{name}}"
   },
   "exploreRegion": {
+    "readFiles_one": "读取了 {{count}} 个文件",
+    "readFiles_other": "读取了 {{count}} 个文件",
     "readFiles": "读取了 {{count}} 个文件",
+    "searchCount_one": "进行了 {{count}} 次搜索",
+    "searchCount_other": "进行了 {{count}} 次搜索",
     "searchCount": "进行了 {{count}} 次搜索",
+    "thinkingCount_one": "思考了 {{count}} 次",
+    "thinkingCount_other": "思考了 {{count}} 次",
     "thinkingCount": "思考了 {{count}} 次",
+    "exploreCount_one": "执行了 {{count}} 次探索",
+    "exploreCount_other": "执行了 {{count}} 次探索",
     "exploreCount": "执行了 {{count}} 次探索",
     "separator": "，",
     "collapse": "收起探索过程"


### PR DESCRIPTION
## Summary

- Centralize Web UI locale and namespace registration into dedicated registries.
- Replace manual i18n JSON imports with eager glob-based resource discovery.
- Reuse backend `LocaleId` / `LocaleMetadata` for Desktop and Server language validation and supported-language responses.
- Add an executable i18n audit script plus frontend/backend registry consistency tests.
- Fix missing zh-CN plural keys in `flow-chat.json`.

## Motivation

The previous i18n implementation duplicated supported languages and namespaces across multiple frontend and backend files. Adding a new language or namespace required editing scattered hardcoded lists, which made expansion error-prone and increased the risk of frontend/backend inconsistency.

This change keeps current behavior stable while reducing duplicated registration points and making future language expansion easier to reason about.

## Key Changes

### Web UI

- Added `localeRegistry.ts` as the Web UI source for supported locale metadata.
- Added `namespaceRegistry.ts` as the namespace source consumed by i18next and audit tooling.
- Updated `I18nService` to discover locale JSON files via `import.meta.glob`.
- Derived `LocaleId`, `LocaleMetadata`, and `I18nNamespace` from registry files.
- Updated `useI18n` memo dependencies so locale metadata and RTL state react to language changes.
- Added missing zh-CN pluralization keys for flow-chat exploration counters.

### Backend

- Updated Desktop i18n APIs to validate languages through `LocaleId::from_str`.
- Updated Desktop supported-language response to use `LocaleMetadata::all()`.
- Updated Server RPC language validation and supported-language response to use shared backend locale metadata.
- Updated app language validation to rely on backend `LocaleId` instead of inline `zh-CN` / `en-US` checks.

### Tooling / Tests

- Added `scripts/i18n-audit.mjs`.
- Added `pnpm run i18n:audit`.
- Added Web UI tests for locale and namespace registry consistency.
- Added Rust tests for locale parsing and metadata consistency.

## Validation

- `node scripts\i18n-audit.mjs`
- `npm.cmd --prefix src\web-ui run test:run -- src/infrastructure/i18n/presets/localeRegistry.test.ts src/infrastructure/i18n/presets/namespaceRegistry.test.ts`
- `npm.cmd --prefix src\web-ui run type-check`
- `cargo test -p bitfun-core service::i18n::types`
- `node_modules\.bin\pnpm.cmd run build`

## Notes

`i18n:audit` currently passes with warnings for existing hardcoded text risks:

- `t(key, "literal fallback")` candidates
- CJK source line candidates

These warnings describe pre-existing broader i18n cleanup work and are not newly introduced by this PR.
