### PR TITLE
fix: unify remote workspace runtime and session storage

### DIFF
--- a/src/apps/desktop/src/api/app_state.rs
+++ b/src/apps/desktop/src/api/app_state.rs
@@ -173,24 +173,40 @@ impl AppState {
             uptime_seconds: 0,
         }));
 
-        let initial_workspace_path = workspace_service
-            .get_current_workspace()
-            .await
-            .map(|workspace| workspace.root_path);
+        let initial_workspace = workspace_service.get_current_workspace().await;
+        let initial_workspace_path = initial_workspace
+            .as_ref()
+            .map(|workspace| workspace.root_path.clone());
 
         if let Some(workspace_path) = initial_workspace_path.clone() {
-            if let Err(e) =
-                bitfun_core::service::snapshot::initialize_snapshot_manager_for_workspace(
-                    workspace_path.clone(),
-                    None,
-                )
-                .await
-            {
-                log::warn!(
-                    "Failed to restore snapshot system on startup: path={}, error={}",
-                    workspace_path.display(),
-                    e
+            let skip_startup_snapshot_restore = initial_workspace
+                .as_ref()
+                .map(|workspace| {
+                    matches!(
+                        workspace.workspace_kind,
+                        bitfun_core::service::workspace::WorkspaceKind::Remote
+                    )
+                })
+                .unwrap_or(false);
+            if skip_startup_snapshot_restore {
+                log::debug!(
+                    "Skipping snapshot restore on startup for remote workspace: path={}",
+                    workspace_path.display()
                 );
+            } else {
+                if let Err(e) =
+                    bitfun_core::service::snapshot::initialize_snapshot_manager_for_workspace(
+                        workspace_path.clone(),
+                        None,
+                    )
+                    .await
+                {
+                    log::warn!(
+                        "Failed to restore snapshot system on startup: path={}, error={}",
+                        workspace_path.display(),
+                        e
+                    );
+                }
             }
         }
 

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -141,17 +141,20 @@ impl ConversationCoordinator {
                 .await
                 .map(|e| e.connection_name)
                 .unwrap_or_else(|| rid.to_string());
-
-            return Some(WorkspaceBinding::new_remote(
+            let binding = WorkspaceBinding::new_remote(
                 None,
                 path_buf,
                 rid.to_string(),
                 connection_name,
                 identity,
-            ));
+            );
+
+            return Some(binding);
         }
 
-        Some(WorkspaceBinding::new(None, path_buf))
+        let binding = WorkspaceBinding::new(None, path_buf);
+
+        Some(binding)
     }
 
     /// Build `WorkspaceServices` from a resolved `WorkspaceBinding`.

--- a/src/crates/core/src/agentic/persistence/manager.rs
+++ b/src/crates/core/src/agentic/persistence/manager.rs
@@ -12,7 +12,8 @@ use crate::service::remote_ssh::workspace_state::{
 };
 use crate::service::session::{
     DialogTurnData, SessionMetadata, SessionStatus, SessionTranscriptExport,
-    SessionTranscriptExportOptions, SessionTranscriptIndexEntry, ToolItemData, TranscriptLineRange,
+    SessionTranscriptExportOptions, SessionTranscriptIndexEntry, StoredSessionIndexFile,
+    StoredSessionMetadataFile, ToolItemData, TranscriptLineRange, SESSION_STORAGE_SCHEMA_VERSION,
 };
 use crate::service::workspace_runtime::WorkspaceRuntimeService;
 use crate::util::errors::{BitFunError, BitFunResult};
@@ -27,7 +28,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::fs;
 use tokio::sync::Mutex;
 
-const SESSION_SCHEMA_VERSION: u32 = 2;
 const TRANSCRIPT_SCHEMA_VERSION: u32 = 1;
 const JSON_WRITE_MAX_RETRIES: usize = 5;
 const JSON_WRITE_RETRY_BASE_DELAY_MS: u64 = 30;
@@ -35,13 +35,6 @@ const SESSION_TRANSCRIPT_PREVIEW_CHAR_LIMIT: usize = 120;
 
 static JSON_FILE_WRITE_LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
 static SESSION_INDEX_LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct StoredSessionMetadataFile {
-    schema_version: u32,
-    #[serde(flatten)]
-    metadata: SessionMetadata,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct StoredDialogTurnFile {
@@ -65,13 +58,6 @@ struct StoredTurnContextSnapshotFile {
     session_id: String,
     turn_index: usize,
     messages: Vec<Message>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct StoredSessionIndex {
-    schema_version: u32,
-    updated_at: u64,
-    sessions: Vec<SessionMetadata>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -622,7 +608,7 @@ impl PersistenceManager {
 
         let workspace_root = resolved_identity
             .as_ref()
-            .map(|identity| identity.workspace_path.clone())
+            .map(|identity| identity.logical_workspace_path().to_string())
             .or_else(|| session.config.workspace_path.clone())
             .or_else(|| existing.and_then(|value| value.workspace_path.clone()))
             .unwrap_or_else(|| workspace_path.to_string_lossy().to_string());
@@ -1247,11 +1233,10 @@ impl PersistenceManager {
             .filter(|metadata| !metadata.should_hide_from_user_lists())
             .collect::<Vec<_>>();
 
-        let index = StoredSessionIndex {
-            schema_version: SESSION_SCHEMA_VERSION,
-            updated_at: Self::system_time_to_unix_ms(SystemTime::now()),
-            sessions: visible_sessions.clone(),
-        };
+        let index = StoredSessionIndexFile::new(
+            Self::system_time_to_unix_ms(SystemTime::now()),
+            visible_sessions.clone(),
+        );
         self.write_json_atomic(&self.index_path(workspace_path), &index)
             .await?;
 
@@ -1265,10 +1250,10 @@ impl PersistenceManager {
     ) -> BitFunResult<()> {
         let index_path = self.index_path(workspace_path);
         let mut index = self
-            .read_json_optional::<StoredSessionIndex>(&index_path)
+            .read_json_optional::<StoredSessionIndexFile>(&index_path)
             .await?
-            .unwrap_or(StoredSessionIndex {
-                schema_version: SESSION_SCHEMA_VERSION,
+            .unwrap_or(StoredSessionIndexFile {
+                schema_version: SESSION_STORAGE_SCHEMA_VERSION,
                 updated_at: 0,
                 sessions: Vec::new(),
             });
@@ -1287,7 +1272,7 @@ impl PersistenceManager {
             .sessions
             .sort_by(|a, b| b.last_active_at.cmp(&a.last_active_at));
         index.updated_at = Self::system_time_to_unix_ms(SystemTime::now());
-        index.schema_version = SESSION_SCHEMA_VERSION;
+        index.schema_version = SESSION_STORAGE_SCHEMA_VERSION;
         self.write_json_atomic(&index_path, &index).await
     }
 
@@ -1298,7 +1283,7 @@ impl PersistenceManager {
     ) -> BitFunResult<()> {
         let index_path = self.index_path(workspace_path);
         let Some(mut index) = self
-            .read_json_optional::<StoredSessionIndex>(&index_path)
+            .read_json_optional::<StoredSessionIndexFile>(&index_path)
             .await?
         else {
             return Ok(());
@@ -1349,7 +1334,7 @@ impl PersistenceManager {
         let _guard = lock.lock().await;
         let index_path = self.index_path(workspace_path);
         if let Some(index) = self
-            .read_json_optional::<StoredSessionIndex>(&index_path)
+            .read_json_optional::<StoredSessionIndexFile>(&index_path)
             .await?
         {
             let has_stale_entry = index.sessions.iter().any(|metadata| {
@@ -1394,10 +1379,7 @@ impl PersistenceManager {
         self.ensure_session_dir(workspace_path, &metadata.session_id)
             .await?;
 
-        let file = StoredSessionMetadataFile {
-            schema_version: SESSION_SCHEMA_VERSION,
-            metadata: metadata.clone(),
-        };
+        let file = StoredSessionMetadataFile::new(metadata.clone());
 
         self.write_json_atomic(
             &self.metadata_path(workspace_path, &metadata.session_id),
@@ -1459,7 +1441,7 @@ impl PersistenceManager {
             .await?;
 
         let snapshot = StoredTurnContextSnapshotFile {
-            schema_version: SESSION_SCHEMA_VERSION,
+            schema_version: SESSION_STORAGE_SCHEMA_VERSION,
             session_id: session_id.to_string(),
             turn_index,
             messages: Self::sanitize_messages_for_persistence(messages),
@@ -1595,7 +1577,7 @@ impl PersistenceManager {
             .await?;
 
         let state = StoredSessionStateFile {
-            schema_version: SESSION_SCHEMA_VERSION,
+            schema_version: SESSION_STORAGE_SCHEMA_VERSION,
             config: session.config.clone(),
             snapshot_session_id: session.snapshot_session_id.clone(),
             compression_state: session.compression_state.clone(),
@@ -1681,7 +1663,7 @@ impl PersistenceManager {
             .load_stored_session_state(workspace_path, session_id)
             .await?
             .unwrap_or(StoredSessionStateFile {
-                schema_version: SESSION_SCHEMA_VERSION,
+                schema_version: SESSION_STORAGE_SCHEMA_VERSION,
                 config: SessionConfig {
                     workspace_path: None,
                     ..Default::default()
@@ -1690,7 +1672,7 @@ impl PersistenceManager {
                 compression_state: CompressionState::default(),
                 runtime_state: SessionState::Idle,
             });
-        stored_state.schema_version = SESSION_SCHEMA_VERSION;
+        stored_state.schema_version = SESSION_STORAGE_SCHEMA_VERSION;
         stored_state.runtime_state = Self::sanitize_runtime_state(state);
         self.save_stored_session_state(workspace_path, session_id, &stored_state)
             .await
@@ -1769,7 +1751,7 @@ impl PersistenceManager {
             .await?;
 
         let file = StoredDialogTurnFile {
-            schema_version: SESSION_SCHEMA_VERSION,
+            schema_version: SESSION_STORAGE_SCHEMA_VERSION,
             turn: turn.clone(),
         };
         self.write_json_atomic(

--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -209,12 +209,12 @@ impl SessionManager {
         if identity.hostname
             == crate::service::remote_ssh::workspace_state::LOCAL_WORKSPACE_SSH_HOST
         {
-            Some(PathBuf::from(identity.workspace_path))
+            Some(PathBuf::from(identity.logical_workspace_path()))
         } else if identity.hostname == "_unresolved" {
             Some(
                 crate::service::remote_ssh::workspace_state::unresolved_remote_session_storage_dir(
                     identity.remote_connection_id.as_deref().unwrap_or_default(),
-                    &identity.workspace_path,
+                    identity.logical_workspace_path(),
                 ),
             )
         } else {

--- a/src/crates/core/src/agentic/tools/framework.rs
+++ b/src/crates/core/src/agentic/tools/framework.rs
@@ -121,7 +121,7 @@ impl ToolUseContext {
             let identity = &workspace.session_identity;
             Ok(remote_workspace_runtime_root(
                 &identity.hostname,
-                &identity.workspace_path,
+                identity.logical_workspace_path(),
             ))
         } else {
             Ok(get_path_manager_arc().project_runtime_root(workspace.root_path()))

--- a/src/crates/core/src/agentic/workspace.rs
+++ b/src/crates/core/src/agentic/workspace.rs
@@ -29,17 +29,17 @@ pub struct WorkspaceBinding {
 
 impl WorkspaceBinding {
     pub fn new(workspace_id: Option<String>, root_path: PathBuf) -> Self {
-        let workspace_path = root_path.to_string_lossy().to_string();
+        let logical_workspace_path = root_path.to_string_lossy().to_string();
         let session_identity =
             crate::service::remote_ssh::workspace_state::workspace_session_identity(
-                &workspace_path,
+                &logical_workspace_path,
                 None,
                 None,
             )
             .unwrap_or(WorkspaceSessionIdentity {
                 hostname: crate::service::remote_ssh::workspace_state::LOCAL_WORKSPACE_SSH_HOST
                     .to_string(),
-                workspace_path,
+                logical_workspace_path,
                 remote_connection_id: None,
             });
         Self {
@@ -88,8 +88,37 @@ impl WorkspaceBinding {
     }
 
     /// The path to use for session persistence.
-    pub fn session_storage_path(&self) -> &Path {
-        Path::new(&self.session_identity.workspace_path)
+    pub fn session_storage_path(&self) -> PathBuf {
+        self.session_identity.session_storage_path()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WorkspaceBackend, WorkspaceBinding};
+    use crate::service::remote_ssh::workspace_state::{
+        remote_workspace_session_mirror_dir, workspace_session_identity,
+    };
+    use std::path::PathBuf;
+
+    #[test]
+    fn remote_workspace_binding_uses_session_identity_storage_path() {
+        let session_identity =
+            workspace_session_identity("/home/wsp/projects/test", Some("conn-1"), Some("127.0.0.1"))
+                .expect("remote identity should resolve");
+        let binding = WorkspaceBinding::new_remote(
+            Some("workspace-1".to_string()),
+            PathBuf::from("/home/wsp/projects/test"),
+            "conn-1".to_string(),
+            "Localhost".to_string(),
+            session_identity,
+        );
+
+        assert!(matches!(binding.backend, WorkspaceBackend::Remote { .. }));
+        assert_eq!(
+            binding.session_storage_path(),
+            remote_workspace_session_mirror_dir("127.0.0.1", "/home/wsp/projects/test")
+        );
     }
 }
 

--- a/src/crates/core/src/service/remote_ssh/workspace_state.rs
+++ b/src/crates/core/src/service/remote_ssh/workspace_state.rs
@@ -20,7 +20,9 @@ use tokio::sync::RwLock;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WorkspaceSessionIdentity {
     pub hostname: String,
-    pub workspace_path: String,
+    /// Canonical local root or normalized remote root used to identify the
+    /// logical workspace. This is not always the on-disk session storage path.
+    pub logical_workspace_path: String,
     pub remote_connection_id: Option<String>,
 }
 
@@ -29,19 +31,23 @@ impl WorkspaceSessionIdentity {
         self.hostname != LOCAL_WORKSPACE_SSH_HOST
     }
 
+    pub fn logical_workspace_path(&self) -> &str {
+        &self.logical_workspace_path
+    }
+
     pub fn session_storage_path(&self) -> PathBuf {
         if self.is_remote() {
-            remote_workspace_session_mirror_dir(&self.hostname, &self.workspace_path)
+            remote_workspace_session_mirror_dir(&self.hostname, &self.logical_workspace_path)
         } else {
-            PathBuf::from(&self.workspace_path)
+            PathBuf::from(&self.logical_workspace_path)
         }
     }
 }
 
 /// Build a unified session identity for local or remote workspaces.
 ///
-/// Local: `hostname=localhost`, `workspace_path=canonical local root`
-/// Remote: `hostname=ssh_host`, `workspace_path=normalized remote root`
+/// Local: `hostname=localhost`, `logical_workspace_path=canonical local root`
+/// Remote: `hostname=ssh_host`, `logical_workspace_path=normalized remote root`
 pub fn workspace_session_identity(
     workspace_path: &str,
     remote_connection_id: Option<&str>,
@@ -59,7 +65,7 @@ pub fn workspace_session_identity(
             .map(str::to_string)?;
         return Some(WorkspaceSessionIdentity {
             hostname,
-            workspace_path: normalize_remote_workspace_path(workspace_path),
+            logical_workspace_path: normalize_remote_workspace_path(workspace_path),
             remote_connection_id: Some(connection_id),
         });
     }
@@ -68,7 +74,7 @@ pub fn workspace_session_identity(
         normalize_local_workspace_root_for_stable_id(Path::new(workspace_path)).ok()?;
     Some(WorkspaceSessionIdentity {
         hostname: LOCAL_WORKSPACE_SSH_HOST.to_string(),
-        workspace_path: local_root,
+        logical_workspace_path: local_root,
         remote_connection_id: None,
     })
 }
@@ -94,14 +100,14 @@ pub async fn resolve_workspace_session_identity(
         {
             return Some(WorkspaceSessionIdentity {
                 hostname: entry.ssh_host,
-                workspace_path: entry.remote_root,
+                logical_workspace_path: entry.remote_root,
                 remote_connection_id: Some(entry.connection_id),
             });
         }
 
         return Some(WorkspaceSessionIdentity {
             hostname: "_unresolved".to_string(),
-            workspace_path: normalize_remote_workspace_path(workspace_path),
+            logical_workspace_path: normalize_remote_workspace_path(workspace_path),
             remote_connection_id: Some(connection_id.to_string()),
         });
     }
@@ -639,7 +645,7 @@ pub async fn get_effective_session_path(
             if let Some(connection_id) = identity.remote_connection_id.as_deref() {
                 return unresolved_remote_session_storage_dir(
                     connection_id,
-                    &identity.workspace_path,
+                    identity.logical_workspace_path(),
                 );
             }
         }
@@ -686,8 +692,13 @@ pub async fn is_remote_workspace_active() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_remote_workspace_path, sanitize_ssh_connection_id_for_local_dir};
+    use super::{
+        normalize_remote_workspace_path, remote_workspace_session_mirror_dir,
+        sanitize_ssh_connection_id_for_local_dir, workspace_session_identity,
+        LOCAL_WORKSPACE_SSH_HOST,
+    };
     use crate::infrastructure::PathManager;
+    use std::path::PathBuf;
 
     #[tokio::test]
     async fn local_assistant_path_not_remote_without_connection_id() {
@@ -833,5 +844,42 @@ mod tests {
         let name = a.file_name().and_then(|n| n.to_str()).unwrap();
         assert_eq!(name, "sessions");
         assert!(a.to_string_lossy().contains("_unresolved"));
+    }
+
+    #[test]
+    fn remote_workspace_session_identity_uses_mirror_dir_for_storage() {
+        let identity = workspace_session_identity("/home/wsp/projects/test", Some("conn-1"), Some("127.0.0.1"))
+            .expect("remote identity should resolve");
+
+        assert_eq!(identity.hostname, "127.0.0.1");
+        assert_eq!(identity.logical_workspace_path(), "/home/wsp/projects/test");
+        assert_eq!(
+            identity.session_storage_path(),
+            remote_workspace_session_mirror_dir("127.0.0.1", "/home/wsp/projects/test")
+        );
+    }
+
+    #[test]
+    fn local_workspace_session_identity_uses_workspace_root_for_storage() {
+        let workspace_root = std::env::temp_dir().join(format!(
+            "bitfun-workspace-identity-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&workspace_root).expect("workspace should exist");
+
+        let identity = workspace_session_identity(
+            &workspace_root.to_string_lossy(),
+            None,
+            None,
+        )
+        .expect("local identity should resolve");
+
+        assert_eq!(identity.hostname, LOCAL_WORKSPACE_SSH_HOST);
+        assert_eq!(
+            identity.session_storage_path(),
+            PathBuf::from(identity.logical_workspace_path())
+        );
+
+        let _ = std::fs::remove_dir_all(workspace_root);
     }
 }

--- a/src/crates/core/src/service/session/types.rs
+++ b/src/crates/core/src/service/session/types.rs
@@ -3,6 +3,8 @@
 use crate::agentic::core::{SessionKind, SessionStorageScope};
 use serde::{Deserialize, Serialize};
 
+pub const SESSION_STORAGE_SCHEMA_VERSION: u32 = 2;
+
 /// Session metadata
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -113,6 +115,39 @@ pub struct SessionList {
     #[serde(alias = "last_updated")]
     pub last_updated: u64,
     pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredSessionMetadataFile {
+    pub schema_version: u32,
+    #[serde(flatten)]
+    pub metadata: SessionMetadata,
+}
+
+impl StoredSessionMetadataFile {
+    pub fn new(metadata: SessionMetadata) -> Self {
+        Self {
+            schema_version: SESSION_STORAGE_SCHEMA_VERSION,
+            metadata,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredSessionIndexFile {
+    pub schema_version: u32,
+    pub updated_at: u64,
+    pub sessions: Vec<SessionMetadata>,
+}
+
+impl StoredSessionIndexFile {
+    pub fn new(updated_at: u64, sessions: Vec<SessionMetadata>) -> Self {
+        Self {
+            schema_version: SESSION_STORAGE_SCHEMA_VERSION,
+            updated_at,
+            sessions,
+        }
+    }
 }
 
 impl Default for SessionList {

--- a/src/crates/core/src/service/workspace/service.rs
+++ b/src/crates/core/src/service/workspace/service.rs
@@ -100,9 +100,7 @@ struct AssistantWorkspaceDescriptor {
 }
 
 impl WorkspaceService {
-    fn collect_startup_restored_workspaces(
-        manager: &WorkspaceManager,
-    ) -> Vec<(PathBuf, WorkspaceKind)> {
+    fn collect_startup_restored_workspaces(manager: &WorkspaceManager) -> Vec<WorkspaceInfo> {
         let mut targets = Vec::new();
         let mut seen_workspace_ids = HashSet::new();
 
@@ -118,41 +116,70 @@ impl WorkspaceService {
     }
 
     fn push_startup_restored_workspace(
-        targets: &mut Vec<(PathBuf, WorkspaceKind)>,
+        targets: &mut Vec<WorkspaceInfo>,
         seen_workspace_ids: &mut HashSet<String>,
         workspace: &WorkspaceInfo,
     ) {
         if seen_workspace_ids.insert(workspace.id.clone()) {
-            targets.push((
-                workspace.root_path.clone(),
-                workspace.workspace_kind.clone(),
-            ));
+            targets.push(workspace.clone());
         }
     }
 
-    async fn prepare_startup_restored_workspaces(&self, workspaces: Vec<(PathBuf, WorkspaceKind)>) {
-        for (workspace_path, workspace_kind) in workspaces {
-            if workspace_kind == WorkspaceKind::Remote || !workspace_path.exists() {
-                continue;
-            }
-
-            if let Err(e) = self
-                .runtime_service
-                .ensure_local_workspace_runtime(&workspace_path)
-                .await
-            {
-                warn!(
-                    "Failed to initialize restored project storage: workspace_path={} error={}",
-                    workspace_path.display(),
-                    e
-                );
-            }
-
+    async fn prepare_startup_restored_workspaces(&self, workspaces: Vec<WorkspaceInfo>) {
+        for workspace in workspaces {
+            self.ensure_workspace_runtime_best_effort(&workspace, "restored")
+                .await;
             self.maintain_workspace_sessions_best_effort(
-                &workspace_path,
+                &workspace.root_path,
                 "workspace_history_restored",
             )
             .await;
+        }
+    }
+
+    async fn ensure_workspace_runtime_best_effort(&self, workspace: &WorkspaceInfo, trigger: &str) {
+        let result = match workspace.workspace_kind {
+            WorkspaceKind::Remote => {
+                let Some(ssh_host) = workspace
+                    .metadata
+                    .get("sshHost")
+                    .and_then(|value| value.as_str())
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                else {
+                    warn!(
+                        "Skipping remote runtime ensure due to missing sshHost: workspace_id={} trigger={}",
+                        workspace.id,
+                        trigger
+                    );
+                    return;
+                };
+
+                self.runtime_service
+                    .ensure_remote_workspace_runtime(
+                        ssh_host,
+                        &workspace.root_path.to_string_lossy(),
+                    )
+                    .await
+            }
+            _ => {
+                if !workspace.root_path.exists() {
+                    return;
+                }
+
+                self.runtime_service
+                    .ensure_local_workspace_runtime(&workspace.root_path)
+                    .await
+            }
+        };
+
+        if let Err(e) = result {
+            warn!(
+                "Failed to initialize workspace runtime: workspace_path={} trigger={} error={}",
+                workspace.root_path.display(),
+                trigger,
+                e
+            );
         }
     }
 
@@ -272,19 +299,8 @@ impl WorkspaceService {
         };
 
         if let Ok(workspace) = result.as_ref() {
-            if workspace.workspace_kind != WorkspaceKind::Remote {
-                if let Err(e) = self
-                    .runtime_service
-                    .ensure_local_workspace_runtime(&workspace.root_path)
-                    .await
-                {
-                    warn!(
-                        "Failed to initialize project storage: workspace_path={} error={}",
-                        workspace.root_path.display(),
-                        e
-                    );
-                }
-            }
+            self.ensure_workspace_runtime_best_effort(workspace, "opened")
+                .await;
         }
 
         if result.is_ok() {
@@ -429,19 +445,8 @@ impl WorkspaceService {
 
         if result.is_ok() {
             if let Some(workspace) = self.get_workspace(workspace_id).await {
-                if workspace.workspace_kind != WorkspaceKind::Remote {
-                    if let Err(e) = self
-                        .runtime_service
-                        .ensure_local_workspace_runtime(&workspace.root_path)
-                        .await
-                    {
-                        warn!(
-                            "Failed to initialize activated project storage: workspace_path={} error={}",
-                            workspace.root_path.display(),
-                            e
-                        );
-                    }
-                }
+                self.ensure_workspace_runtime_best_effort(&workspace, "activated")
+                    .await;
                 self.maintain_workspace_sessions_best_effort(
                     &workspace.root_path,
                     "workspace_activated",

--- a/src/crates/core/src/service/workspace_runtime/service.rs
+++ b/src/crates/core/src/service/workspace_runtime/service.rs
@@ -4,13 +4,18 @@ use super::types::{
 };
 use crate::agentic::WorkspaceBinding;
 use crate::infrastructure::{get_path_manager_arc, PathManager};
-use crate::service::remote_ssh::workspace_state::remote_workspace_runtime_root;
+use crate::service::remote_ssh::workspace_state::{
+    normalize_remote_workspace_path, remote_root_to_mirror_subpath,
+    sanitize_ssh_hostname_for_mirror,
+};
+use crate::service::session::{StoredSessionIndexFile, StoredSessionMetadataFile};
 use crate::util::errors::{BitFunError, BitFunResult};
 use log::debug;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex as AsyncMutex;
 
 #[derive(Debug)]
@@ -35,6 +40,19 @@ struct RuntimeMigrationRecordState {
     strategy: String,
 }
 
+#[derive(Debug, Clone)]
+struct RuntimeMigrationSpec {
+    source: PathBuf,
+    target: PathBuf,
+    strategy: RuntimeMigrationStrategy,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RuntimeMigrationStrategy {
+    MoveIfTargetMissing,
+    MergeSessions,
+}
+
 impl WorkspaceRuntimeService {
     pub fn new(path_manager: Arc<PathManager>) -> Self {
         Self {
@@ -45,6 +63,18 @@ impl WorkspaceRuntimeService {
 
     pub fn path_manager(&self) -> &Arc<PathManager> {
         &self.path_manager
+    }
+
+    pub fn context_for_target(&self, target: WorkspaceRuntimeTarget) -> WorkspaceRuntimeContext {
+        match target {
+            WorkspaceRuntimeTarget::LocalWorkspace { workspace_root } => {
+                self.context_for_local_workspace(&workspace_root)
+            }
+            WorkspaceRuntimeTarget::RemoteWorkspaceMirror {
+                ssh_host,
+                remote_root,
+            } => self.context_for_remote_workspace(&ssh_host, &remote_root),
+        }
     }
 
     pub fn context_for_local_workspace(&self, workspace_path: &Path) -> WorkspaceRuntimeContext {
@@ -61,21 +91,33 @@ impl WorkspaceRuntimeService {
         ssh_host: &str,
         remote_root: &str,
     ) -> WorkspaceRuntimeContext {
+        let normalized_remote_root = normalize_remote_workspace_path(remote_root);
         WorkspaceRuntimeContext::new(
             WorkspaceRuntimeTarget::RemoteWorkspaceMirror {
                 ssh_host: ssh_host.to_string(),
-                remote_root: remote_root.to_string(),
+                remote_root: normalized_remote_root.clone(),
             },
-            remote_workspace_runtime_root(ssh_host, remote_root),
+            self.remote_workspace_runtime_root(ssh_host, &normalized_remote_root),
         )
+    }
+
+    pub async fn ensure_workspace_runtime(
+        &self,
+        target: WorkspaceRuntimeTarget,
+    ) -> BitFunResult<WorkspaceRuntimeEnsureResult> {
+        let context = self.context_for_target(target);
+        let migration_specs = self.migration_specs_for_context(&context);
+        self.ensure_runtime_context(context, migration_specs).await
     }
 
     pub async fn ensure_local_workspace_runtime(
         &self,
         workspace_path: &Path,
     ) -> BitFunResult<WorkspaceRuntimeEnsureResult> {
-        let context = self.context_for_local_workspace(workspace_path);
-        self.ensure_runtime_context(context).await
+        self.ensure_workspace_runtime(WorkspaceRuntimeTarget::LocalWorkspace {
+            workspace_root: workspace_path.to_path_buf(),
+        })
+        .await
     }
 
     pub async fn ensure_remote_workspace_runtime(
@@ -83,8 +125,11 @@ impl WorkspaceRuntimeService {
         ssh_host: &str,
         remote_root: &str,
     ) -> BitFunResult<WorkspaceRuntimeEnsureResult> {
-        let context = self.context_for_remote_workspace(ssh_host, remote_root);
-        self.ensure_runtime_context(context).await
+        self.ensure_workspace_runtime(WorkspaceRuntimeTarget::RemoteWorkspaceMirror {
+            ssh_host: ssh_host.to_string(),
+            remote_root: remote_root.to_string(),
+        })
+        .await
     }
 
     pub async fn ensure_runtime_for_workspace_binding(
@@ -94,7 +139,7 @@ impl WorkspaceRuntimeService {
         if workspace.is_remote() {
             self.ensure_remote_workspace_runtime(
                 &workspace.session_identity.hostname,
-                &workspace.session_identity.workspace_path,
+                workspace.session_identity.logical_workspace_path(),
             )
             .await
         } else {
@@ -106,6 +151,7 @@ impl WorkspaceRuntimeService {
     async fn ensure_runtime_context(
         &self,
         context: WorkspaceRuntimeContext,
+        migration_specs: Vec<RuntimeMigrationSpec>,
     ) -> BitFunResult<WorkspaceRuntimeEnsureResult> {
         if self.is_runtime_verified(&context.runtime_root) {
             return Ok(Self::cached_ensure_result(context));
@@ -118,6 +164,8 @@ impl WorkspaceRuntimeService {
             return Ok(Self::cached_ensure_result(context));
         }
 
+        let migrated_entries = self.apply_migration_specs(&migration_specs).await?;
+        self.cleanup_legacy_artifacts_for_context(&context).await?;
         let mut created_directories = Vec::new();
         for dir in context.required_directories() {
             if !dir.exists() {
@@ -126,25 +174,28 @@ impl WorkspaceRuntimeService {
             }
         }
 
-        if !context.layout_state_file.exists() || !created_directories.is_empty() {
-            self.persist_layout_state(&context, &[]).await?;
+        if !context.layout_state_file.exists()
+            || !created_directories.is_empty()
+            || !migrated_entries.is_empty()
+        {
+            self.persist_layout_state(&context, &migrated_entries).await?;
         }
 
         self.mark_runtime_verified(&context.runtime_root);
 
-        if !created_directories.is_empty() {
+        if !created_directories.is_empty() || !migrated_entries.is_empty() {
             debug!(
                 "Workspace runtime ensured: root={} created_dirs={} migrated_entries={}",
                 context.runtime_root.display(),
                 created_directories.len(),
-                0
+                migrated_entries.len()
             );
         }
 
         Ok(WorkspaceRuntimeEnsureResult {
             context,
             created_directories,
-            migrated_entries: Vec::new(),
+            migrated_entries,
         })
     }
 
@@ -216,6 +267,685 @@ impl WorkspaceRuntimeService {
             })?;
         Ok(())
     }
+    fn remote_workspace_runtime_root(&self, ssh_host: &str, remote_root_norm: &str) -> PathBuf {
+        self.path_manager
+            .bitfun_home_dir()
+            .join("remote_ssh")
+            .join(sanitize_ssh_hostname_for_mirror(ssh_host))
+            .join(remote_root_to_mirror_subpath(remote_root_norm))
+    }
+
+    fn migration_specs_for_context(
+        &self,
+        context: &WorkspaceRuntimeContext,
+    ) -> Vec<RuntimeMigrationSpec> {
+        match &context.target {
+            WorkspaceRuntimeTarget::LocalWorkspace { workspace_root } => {
+                let legacy_project_root = self.path_manager.project_root(workspace_root);
+                vec![
+                    RuntimeMigrationSpec {
+                        source: legacy_project_root.join("sessions"),
+                        target: context.sessions_dir.clone(),
+                        strategy: RuntimeMigrationStrategy::MoveIfTargetMissing,
+                    },
+                    RuntimeMigrationSpec {
+                        source: legacy_project_root.join("memory"),
+                        target: context.memory_dir.clone(),
+                        strategy: RuntimeMigrationStrategy::MoveIfTargetMissing,
+                    },
+                    RuntimeMigrationSpec {
+                        source: legacy_project_root.join("plans"),
+                        target: context.plans_dir.clone(),
+                        strategy: RuntimeMigrationStrategy::MoveIfTargetMissing,
+                    },
+                    RuntimeMigrationSpec {
+                        source: legacy_project_root.join("snapshots"),
+                        target: context.snapshots_dir.clone(),
+                        strategy: RuntimeMigrationStrategy::MoveIfTargetMissing,
+                    },
+                    RuntimeMigrationSpec {
+                        source: legacy_project_root.join("ai_memories.json"),
+                        target: context.runtime_root.join("ai_memories.json"),
+                        strategy: RuntimeMigrationStrategy::MoveIfTargetMissing,
+                    },
+                ]
+            }
+            WorkspaceRuntimeTarget::RemoteWorkspaceMirror {
+                ssh_host,
+                remote_root,
+            } => {
+                let runtime_root = self.remote_workspace_runtime_root(ssh_host, remote_root);
+                let legacy_sessions_root = runtime_root
+                    .join("sessions")
+                    .join(".bitfun")
+                    .join("sessions");
+                vec![RuntimeMigrationSpec {
+                    source: legacy_sessions_root,
+                    target: context.sessions_dir.clone(),
+                    strategy: RuntimeMigrationStrategy::MergeSessions,
+                }]
+            }
+        }
+    }
+
+    async fn apply_migration_specs(
+        &self,
+        specs: &[RuntimeMigrationSpec],
+    ) -> BitFunResult<Vec<RuntimeMigrationRecord>> {
+        let mut migrated_entries = Vec::new();
+
+        for spec in specs {
+            let migrated = match spec.strategy {
+                RuntimeMigrationStrategy::MoveIfTargetMissing => {
+                    self.migrate_if_target_missing(&spec.source, &spec.target)
+                        .await?
+                }
+                RuntimeMigrationStrategy::MergeSessions => {
+                    self.merge_session_store(&spec.source, &spec.target).await?
+                }
+            };
+
+            if let Some(record) = migrated {
+                migrated_entries.push(record);
+            }
+        }
+
+        Ok(migrated_entries)
+    }
+
+    async fn cleanup_legacy_artifacts_for_context(
+        &self,
+        context: &WorkspaceRuntimeContext,
+    ) -> BitFunResult<()> {
+        if let WorkspaceRuntimeTarget::RemoteWorkspaceMirror {
+            ssh_host,
+            remote_root,
+        } = &context.target
+        {
+            let runtime_root = self.remote_workspace_runtime_root(ssh_host, remote_root);
+            self.remove_dir_if_empty(&runtime_root.join("sessions").join(".bitfun"))
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn migrate_if_target_missing(
+        &self,
+        source: &Path,
+        target: &Path,
+    ) -> BitFunResult<Option<RuntimeMigrationRecord>> {
+        if !source.exists() || target.exists() {
+            return Ok(None);
+        }
+
+        self.move_legacy_path(source, target).await.map(Some)
+    }
+
+    async fn move_legacy_path(
+        &self,
+        source: &Path,
+        target: &Path,
+    ) -> BitFunResult<RuntimeMigrationRecord> {
+        if let Some(parent) = target.parent() {
+            self.path_manager.ensure_dir(parent).await?;
+        }
+
+        match tokio::fs::rename(source, target).await {
+            Ok(()) => Ok(RuntimeMigrationRecord {
+                source: source.to_path_buf(),
+                target: target.to_path_buf(),
+                strategy: "rename".to_string(),
+            }),
+            Err(_) if source.is_dir() => {
+                copy_dir_recursive(source, target)?;
+                std::fs::remove_dir_all(source).map_err(|e| {
+                    BitFunError::service(format!(
+                        "Failed to remove legacy directory {}: {}",
+                        source.display(),
+                        e
+                    ))
+                })?;
+                Ok(RuntimeMigrationRecord {
+                    source: source.to_path_buf(),
+                    target: target.to_path_buf(),
+                    strategy: "copy_dir".to_string(),
+                })
+            }
+            Err(_) => {
+                std::fs::copy(source, target).map_err(|e| {
+                    BitFunError::service(format!(
+                        "Failed to copy legacy file {} to {}: {}",
+                        source.display(),
+                        target.display(),
+                        e
+                    ))
+                })?;
+                std::fs::remove_file(source).map_err(|e| {
+                    BitFunError::service(format!(
+                        "Failed to remove legacy file {}: {}",
+                        source.display(),
+                        e
+                    ))
+                })?;
+                Ok(RuntimeMigrationRecord {
+                    source: source.to_path_buf(),
+                    target: target.to_path_buf(),
+                    strategy: "copy_file".to_string(),
+                })
+            }
+        }
+    }
+
+    async fn merge_session_store(
+        &self,
+        source: &Path,
+        target: &Path,
+    ) -> BitFunResult<Option<RuntimeMigrationRecord>> {
+        if !source.exists() {
+            return Ok(None);
+        }
+
+        std::fs::create_dir_all(target).map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to create target sessions directory {}: {}",
+                target.display(),
+                e
+            ))
+        })?;
+
+        for entry in std::fs::read_dir(source).map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to read legacy sessions directory {}: {}",
+                source.display(),
+                e
+            ))
+        })? {
+            let entry = entry.map_err(|e| {
+                BitFunError::service(format!(
+                    "Failed to inspect legacy sessions entry under {}: {}",
+                    source.display(),
+                    e
+                ))
+            })?;
+            let source_path = entry.path();
+            let file_name = entry.file_name();
+            let file_type = entry.file_type().map_err(|e| {
+                BitFunError::service(format!(
+                    "Failed to read file type for {}: {}",
+                    source_path.display(),
+                    e
+                ))
+            })?;
+
+            if file_name
+                .to_string_lossy()
+                .eq_ignore_ascii_case("index.json")
+            {
+                remove_path_if_exists(&source_path)?;
+                continue;
+            }
+
+            if !file_type.is_dir() {
+                let target_path = target.join(&file_name);
+                if !target_path.exists() {
+                    move_path_best_effort(&source_path, &target_path)?;
+                } else if files_are_equal(&source_path, &target_path)? {
+                    remove_path_if_exists(&source_path)?;
+                } else {
+                    replace_target_if_source_newer(&source_path, &target_path)?;
+                }
+                continue;
+            }
+
+            let target_path = target.join(&file_name);
+            if !target_path.exists() {
+                move_path_best_effort(&source_path, &target_path)?;
+                continue;
+            }
+
+            merge_session_directory(&source_path, &target_path)?;
+            remove_path_if_exists(&source_path)?;
+        }
+
+        self.rebuild_session_index(target).await?;
+        remove_path_if_exists(&source.join("index.json"))?;
+        remove_path_if_exists(source)?;
+
+        Ok(Some(RuntimeMigrationRecord {
+            source: source.to_path_buf(),
+            target: target.to_path_buf(),
+            strategy: "merge_sessions".to_string(),
+        }))
+    }
+
+    async fn rebuild_session_index(&self, sessions_dir: &Path) -> BitFunResult<()> {
+        if !sessions_dir.exists() {
+            return Ok(());
+        }
+
+        let mut sessions = Vec::new();
+        for entry in std::fs::read_dir(sessions_dir).map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to read merged sessions directory {}: {}",
+                sessions_dir.display(),
+                e
+            ))
+        })? {
+            let entry = entry.map_err(|e| {
+                BitFunError::service(format!(
+                    "Failed to inspect merged sessions entry under {}: {}",
+                    sessions_dir.display(),
+                    e
+                ))
+            })?;
+            let path = entry.path();
+            let file_type = entry.file_type().map_err(|e| {
+                BitFunError::service(format!(
+                    "Failed to read file type for {}: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+            if !file_type.is_dir() {
+                continue;
+            }
+
+            let metadata_path = path.join("metadata.json");
+            let Some(stored) =
+                read_json_optional_sync::<StoredSessionMetadataFile>(&metadata_path)?
+            else {
+                continue;
+            };
+            if stored.metadata.should_hide_from_user_lists() {
+                continue;
+            }
+            sessions.push(stored.metadata);
+        }
+
+        sessions.sort_by(|a, b| b.last_active_at.cmp(&a.last_active_at));
+        let index = StoredSessionIndexFile::new(unix_now_ms(), sessions);
+        write_json_pretty_async(&sessions_dir.join("index.json"), &index).await
+    }
+
+    async fn remove_dir_if_empty(&self, path: &Path) -> BitFunResult<()> {
+        if !path.is_dir() {
+            return Ok(());
+        }
+
+        let is_empty = match tokio::fs::read_dir(path).await {
+            Ok(mut entries) => entries
+                .next_entry()
+                .await
+                .map(|entry| entry.is_none())
+                .unwrap_or(false),
+            Err(e) => {
+                return Err(BitFunError::service(format!(
+                    "Failed to inspect directory {}: {}",
+                    path.display(),
+                    e
+                )));
+            }
+        };
+
+        if is_empty {
+            tokio::fs::remove_dir(path).await.map_err(|e| {
+                BitFunError::service(format!(
+                    "Failed to remove empty legacy directory {}: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+        }
+
+        Ok(())
+    }
+}
+
+fn merge_session_directory(source: &Path, target: &Path) -> BitFunResult<()> {
+    std::fs::create_dir_all(target).map_err(|e| {
+        BitFunError::service(format!(
+            "Failed to create target session directory {}: {}",
+            target.display(),
+            e
+        ))
+    })?;
+
+    for entry in std::fs::read_dir(source).map_err(|e| {
+        BitFunError::service(format!(
+            "Failed to read legacy session directory {}: {}",
+            source.display(),
+            e
+        ))
+    })? {
+        let entry = entry.map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to inspect legacy session entry under {}: {}",
+                source.display(),
+                e
+            ))
+        })?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let file_type = entry.file_type().map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to read file type for {}: {}",
+                source_path.display(),
+                e
+            ))
+        })?;
+
+        if file_type.is_dir() {
+            if !target_path.exists() {
+                move_path_best_effort(&source_path, &target_path)?;
+            } else {
+                merge_session_directory(&source_path, &target_path)?;
+                remove_path_if_exists(&source_path)?;
+            }
+            continue;
+        }
+
+        if file_name_eq(&source_path, "metadata.json") && target_path.exists() {
+            merge_session_metadata_file(&source_path, &target_path)?;
+            remove_path_if_exists(&source_path)?;
+            continue;
+        }
+
+        if !target_path.exists() {
+            move_path_best_effort(&source_path, &target_path)?;
+        } else if files_are_equal(&source_path, &target_path)? {
+            remove_path_if_exists(&source_path)?;
+        } else {
+            replace_target_if_source_newer(&source_path, &target_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn merge_session_metadata_file(source: &Path, target: &Path) -> BitFunResult<()> {
+    let source_file =
+        read_json_optional_sync::<StoredSessionMetadataFile>(source)?.ok_or_else(|| {
+            BitFunError::service(format!(
+                "Missing readable session metadata in {}",
+                source.display()
+            ))
+        })?;
+    let target_file =
+        read_json_optional_sync::<StoredSessionMetadataFile>(target)?.ok_or_else(|| {
+            BitFunError::service(format!(
+                "Missing readable session metadata in {}",
+                target.display()
+            ))
+        })?;
+
+    let chosen = if source_file.metadata.last_active_at > target_file.metadata.last_active_at {
+        source_file
+    } else {
+        target_file
+    };
+
+    write_json_pretty_sync(target, &chosen)?;
+    Ok(())
+}
+
+fn replace_target_if_source_newer(source: &Path, target: &Path) -> BitFunResult<()> {
+    if source_is_newer(source, target)? {
+        remove_path_if_exists(target)?;
+        move_path_best_effort(source, target)
+    } else {
+        remove_path_if_exists(source)
+    }
+}
+
+fn copy_dir_recursive(source: &Path, target: &Path) -> BitFunResult<()> {
+    std::fs::create_dir_all(target).map_err(|e| {
+        BitFunError::service(format!(
+            "Failed to create target directory {}: {}",
+            target.display(),
+            e
+        ))
+    })?;
+
+    for entry in std::fs::read_dir(source).map_err(|e| {
+        BitFunError::service(format!(
+            "Failed to read legacy directory {}: {}",
+            source.display(),
+            e
+        ))
+    })? {
+        let entry = entry.map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to inspect legacy directory entry under {}: {}",
+                source.display(),
+                e
+            ))
+        })?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let file_type = entry.file_type().map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to read file type for {}: {}",
+                source_path.display(),
+                e
+            ))
+        })?;
+
+        if file_type.is_dir() {
+            copy_dir_recursive(&source_path, &target_path)?;
+        } else if file_type.is_file() {
+            std::fs::copy(&source_path, &target_path).map_err(|e| {
+                BitFunError::service(format!(
+                    "Failed to copy legacy file {} to {}: {}",
+                    source_path.display(),
+                    target_path.display(),
+                    e
+                ))
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn read_json_optional_sync<T>(path: &Path) -> BitFunResult<Option<T>>
+where
+    T: DeserializeOwned,
+{
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let bytes = std::fs::read(path).map_err(|e| {
+        BitFunError::service(format!(
+            "Failed to read JSON file {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    let value = serde_json::from_slice(&bytes).map_err(|e| {
+        BitFunError::service(format!(
+            "Failed to deserialize JSON file {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    Ok(Some(value))
+}
+
+async fn write_json_pretty_async<T>(path: &Path, value: &T) -> BitFunResult<()>
+where
+    T: Serialize,
+{
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to create parent directory {}: {}",
+                parent.display(),
+                e
+            ))
+        })?;
+    }
+
+    let bytes = serde_json::to_vec_pretty(value).map_err(|e| {
+        BitFunError::service(format!(
+            "Failed to serialize JSON for {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    tokio::fs::write(path, bytes).await.map_err(|e| {
+        BitFunError::service(format!(
+            "Failed to write JSON file {}: {}",
+            path.display(),
+            e
+        ))
+    })
+}
+
+fn write_json_pretty_sync<T>(path: &Path, value: &T) -> BitFunResult<()>
+where
+    T: Serialize,
+{
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to create parent directory {}: {}",
+                parent.display(),
+                e
+            ))
+        })?;
+    }
+
+    let bytes = serde_json::to_vec_pretty(value).map_err(|e| {
+        BitFunError::service(format!(
+            "Failed to serialize JSON for {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    std::fs::write(path, bytes).map_err(|e| {
+        BitFunError::service(format!(
+            "Failed to write JSON file {}: {}",
+            path.display(),
+            e
+        ))
+    })
+}
+
+fn move_path_best_effort(source: &Path, target: &Path) -> BitFunResult<()> {
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to create target parent directory {}: {}",
+                parent.display(),
+                e
+            ))
+        })?;
+    }
+
+    match std::fs::rename(source, target) {
+        Ok(()) => Ok(()),
+        Err(_) if source.is_dir() => {
+            copy_dir_recursive(source, target)?;
+            std::fs::remove_dir_all(source).map_err(|e| {
+                BitFunError::service(format!(
+                    "Failed to remove moved directory {}: {}",
+                    source.display(),
+                    e
+                ))
+            })
+        }
+        Err(_) => {
+            std::fs::copy(source, target).map_err(|e| {
+                BitFunError::service(format!(
+                    "Failed to copy file {} to {}: {}",
+                    source.display(),
+                    target.display(),
+                    e
+                ))
+            })?;
+            std::fs::remove_file(source).map_err(|e| {
+                BitFunError::service(format!(
+                    "Failed to remove moved file {}: {}",
+                    source.display(),
+                    e
+                ))
+            })
+        }
+    }
+}
+
+fn remove_path_if_exists(path: &Path) -> BitFunResult<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    if path.is_dir() {
+        std::fs::remove_dir_all(path).map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to remove directory {}: {}",
+                path.display(),
+                e
+            ))
+        })
+    } else {
+        std::fs::remove_file(path).map_err(|e| {
+            BitFunError::service(format!("Failed to remove file {}: {}", path.display(), e))
+        })
+    }
+}
+
+fn files_are_equal(left: &Path, right: &Path) -> BitFunResult<bool> {
+    let left_bytes = std::fs::read(left).map_err(|e| {
+        BitFunError::service(format!("Failed to read file {}: {}", left.display(), e))
+    })?;
+    let right_bytes = std::fs::read(right).map_err(|e| {
+        BitFunError::service(format!("Failed to read file {}: {}", right.display(), e))
+    })?;
+    Ok(left_bytes == right_bytes)
+}
+
+fn source_is_newer(source: &Path, target: &Path) -> BitFunResult<bool> {
+    let source_modified = std::fs::metadata(source)
+        .map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to stat source file {}: {}",
+                source.display(),
+                e
+            ))
+        })?
+        .modified()
+        .ok();
+    let target_modified = std::fs::metadata(target)
+        .map_err(|e| {
+            BitFunError::service(format!(
+                "Failed to stat target file {}: {}",
+                target.display(),
+                e
+            ))
+        })?
+        .modified()
+        .ok();
+
+    Ok(match (source_modified, target_modified) {
+        (Some(source_time), Some(target_time)) => source_time > target_time,
+        (Some(_), None) => true,
+        _ => false,
+    })
+}
+
+fn file_name_eq(path: &Path, expected: &str) -> bool {
+    path.file_name()
+        .and_then(|value| value.to_str())
+        .is_some_and(|value| value.eq_ignore_ascii_case(expected))
+}
+
+fn unix_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
 }
 
 fn runtime_lock_for(runtime_root: &Path) -> Arc<AsyncMutex<()>> {
@@ -249,7 +979,11 @@ pub fn try_get_workspace_runtime_service_arc() -> BitFunResult<Arc<WorkspaceRunt
 mod tests {
     use super::WorkspaceRuntimeService;
     use crate::infrastructure::PathManager;
+    use crate::service::session::{
+        SessionMetadata, StoredSessionIndexFile, StoredSessionMetadataFile,
+    };
     use std::fs;
+    use std::path::Path;
     use std::sync::Arc;
     use std::time::Duration;
     use uuid::Uuid;
@@ -284,6 +1018,132 @@ mod tests {
             .project_root(&workspace_root)
             .join("context")
             .exists());
+
+        let _ = fs::remove_dir_all(&test_root);
+    }
+
+    #[tokio::test]
+    async fn ensure_local_workspace_runtime_migrates_legacy_runtime_entries() {
+        let test_root =
+            std::env::temp_dir().join(format!("bitfun-runtime-test-{}", Uuid::new_v4()));
+        let workspace_root = test_root.join("workspace");
+        let legacy_root = workspace_root.join(".bitfun");
+        fs::create_dir_all(legacy_root.join("sessions")).expect("legacy sessions should exist");
+        fs::write(legacy_root.join("sessions").join("s1.json"), "{}")
+            .expect("legacy session file should be written");
+
+        let path_manager = Arc::new(PathManager::with_user_root_for_tests(
+            test_root.join("user"),
+        ));
+        let service = WorkspaceRuntimeService::new(path_manager.clone());
+
+        let ensured = service
+            .ensure_local_workspace_runtime(&workspace_root)
+            .await
+            .expect("runtime should be ensured");
+
+        assert!(ensured.context.sessions_dir.join("s1.json").exists());
+        assert!(!legacy_root.join("sessions").exists());
+        assert_eq!(ensured.migrated_entries.len(), 1);
+
+        let _ = fs::remove_dir_all(&test_root);
+    }
+
+    #[tokio::test]
+    async fn ensure_remote_workspace_runtime_merges_legacy_sessions_only() {
+        let test_root =
+            std::env::temp_dir().join(format!("bitfun-runtime-test-{}", Uuid::new_v4()));
+        let path_manager = Arc::new(PathManager::with_user_root_for_tests(
+            test_root.join("user"),
+        ));
+        let service = WorkspaceRuntimeService::new(path_manager);
+
+        let context = service.context_for_remote_workspace("example-host", "/root/repo");
+        let legacy_sessions_root = context
+            .runtime_root
+            .join("sessions")
+            .join(".bitfun")
+            .join("sessions");
+
+        fs::create_dir_all(&legacy_sessions_root).expect("legacy remote sessions should exist");
+        fs::create_dir_all(context.sessions_dir.join("existing-session"))
+            .expect("new sessions root should exist");
+
+        let mut newer_metadata = SessionMetadata::new(
+            "existing-session".to_string(),
+            "Existing Session".to_string(),
+            "agent".to_string(),
+            "model".to_string(),
+        );
+        newer_metadata.last_active_at = 200;
+        write_session_metadata(
+            &context.sessions_dir.join("existing-session"),
+            &newer_metadata,
+        );
+
+        let mut older_metadata = newer_metadata.clone();
+        older_metadata.last_active_at = 100;
+        write_session_metadata(
+            &legacy_sessions_root.join("existing-session"),
+            &older_metadata,
+        );
+        fs::create_dir_all(legacy_sessions_root.join("legacy-session"))
+            .expect("legacy-only session dir should exist");
+        let mut legacy_only_metadata = SessionMetadata::new(
+            "legacy-session".to_string(),
+            "Legacy Session".to_string(),
+            "agent".to_string(),
+            "model".to_string(),
+        );
+        legacy_only_metadata.last_active_at = 150;
+        write_session_metadata(
+            &legacy_sessions_root.join("legacy-session"),
+            &legacy_only_metadata,
+        );
+        write_session_index(
+            &legacy_sessions_root.join("index.json"),
+            vec![older_metadata.clone(), legacy_only_metadata.clone()],
+        );
+        write_session_index(
+            &context.sessions_dir.join("index.json"),
+            vec![newer_metadata.clone()],
+        );
+
+        let ensured = service
+            .ensure_remote_workspace_runtime("example-host", "/root/repo")
+            .await
+            .expect("remote runtime should be ensured");
+
+        assert!(context.sessions_dir.join("legacy-session").exists());
+        assert!(context.sessions_dir.join("existing-session").exists());
+        assert!(
+            !legacy_sessions_root.exists(),
+            "legacy sessions root should be removed after merge"
+        );
+
+        let merged_metadata: StoredSessionMetadataFile = serde_json::from_slice(
+            &fs::read(
+                context
+                    .sessions_dir
+                    .join("existing-session")
+                    .join("metadata.json"),
+            )
+            .expect("merged metadata should exist"),
+        )
+        .expect("merged metadata should deserialize");
+        assert_eq!(merged_metadata.metadata.last_active_at, 200);
+
+        let merged_index: StoredSessionIndexFile = serde_json::from_slice(
+            &fs::read(context.sessions_dir.join("index.json"))
+                .expect("merged session index should exist"),
+        )
+        .expect("merged session index should deserialize");
+        assert_eq!(merged_index.sessions.len(), 2);
+        assert!(ensured
+            .migrated_entries
+            .iter()
+            .any(|record| record.strategy == "merge_sessions"));
+        assert_eq!(ensured.migrated_entries.len(), 1);
 
         let _ = fs::remove_dir_all(&test_root);
     }
@@ -325,5 +1185,24 @@ mod tests {
         assert_eq!(first_modified, second_modified);
 
         let _ = fs::remove_dir_all(&test_root);
+    }
+
+    fn write_session_metadata(session_dir: &Path, metadata: &SessionMetadata) {
+        fs::create_dir_all(session_dir).expect("session dir should exist");
+        let stored = StoredSessionMetadataFile::new(metadata.clone());
+        fs::write(
+            session_dir.join("metadata.json"),
+            serde_json::to_string_pretty(&stored).expect("metadata should serialize"),
+        )
+        .expect("metadata should write");
+    }
+
+    fn write_session_index(path: &Path, sessions: Vec<SessionMetadata>) {
+        let index = StoredSessionIndexFile::new(0, sessions);
+        fs::write(
+            path,
+            serde_json::to_string_pretty(&index).expect("index should serialize"),
+        )
+        .expect("index should write");
     }
 }


### PR DESCRIPTION
- unify workspace session identity around logical workspace paths
- route remote session persistence through canonical mirror storage paths
- move legacy runtime/session migration into WorkspaceRuntimeService
- merge legacy remote session stores and rebuild session indexes
- ensure runtime setup for restored/opened workspaces and skip remote snapshot restore on startup
