### PR TITLE
feat(dev): streamline desktop debug preview

### DIFF
--- a/AGENTS-CN.md
+++ b/AGENTS-CN.md
@@ -21,7 +21,7 @@ BitFun 是一个由 Rust workspace 与共享 React 前端组成的项目。
 ## 3 步快速上手
 
 1. 在修改架构敏感代码前，先阅读 `README.md`、`CONTRIBUTING.md` 和本文件。
-2. 常规本地开发使用 `pnpm run desktop:dev`；仅前端改动使用 `pnpm run dev:web`。
+2. 共享前端改动或 Rust / Tauri 改动后的本地桌面快速人工验证，都优先使用 `pnpm run desktop:preview:debug`。它会在已有 debug 桌面二进制可复用时直接预览，并在二进制缺失或 Rust / Tauri 输入更新后自动执行一次快速本地重编译。`pnpm run desktop:dev` 保留给完整 Tauri dev 流程、首次初始化，或启动 / 构建链路本身的调试；仅浏览器前端验证时使用 `pnpm run dev:web`。
 3. 改完后按下方最小验证集合执行检查。
 
 ## 核心命令
@@ -33,6 +33,7 @@ pnpm run e2e:install
 
 # 主要开发流程
 pnpm run desktop:dev
+pnpm run desktop:preview:debug
 pnpm run dev:web
 pnpm run cli:dev
 pnpm run installer:dev
@@ -53,6 +54,25 @@ cargo build -p bitfun-desktop
 pnpm run e2e:test:l0
 pnpm --dir tests/e2e exec wdio run ./config/wdio.conf.ts --spec "./specs/<file>.spec.ts"
 ```
+
+## 本地桌面快速迭代
+
+- `pnpm run desktop:preview:debug` 会启动或复用 web dev server，并直接拉起 `target/debug/bitfun-desktop(.exe)`，不会经过 `tauri dev`。当已有 debug 二进制仍然可复用时它会直接预览；当二进制缺失，或 Rust / Tauri 输入比当前二进制更新时，它会先以 `CARGO_PROFILE_DEV_DEBUG=0` 和更高并行 codegen 快速重编 `bitfun-desktop`，再进入预览。
+- `pnpm run desktop:preview:debug -- --force-rebuild` 是显式强制重编后再预览的兜底入口，只有在你明确想忽略时间戳复用判断时才使用。
+- 上面的 preview 流程只是本地迭代加速手段，不能替代下方与改动范围匹配的最小验证集合。
+- 如果用户的意图是“快速看看效果”“本地跑起来看一下”这类人工预览，即使表述里同时出现了“编译”或“调试版本”，也优先使用上面的 preview 命令。
+- `pnpm run desktop:build:fast` 只保留给“明确要一个 debug 构建产物，且不需要顺手启动预览”的场景。
+- 意图示例：
+  - “本地编译一个调试版本快速看看效果” -> `pnpm run desktop:preview:debug`
+  - “只编一个 debug 产物给我，不用启动” -> `pnpm run desktop:build:fast`
+
+## 打包请求
+
+- 当用户提出打包、release 或构建可分发桌面产物，但没有明确点名产物形式时，先确认目标打包类型，再执行构建。
+- 要区分“本地临时产物”和“正式 release 交付物”。除非用户明确要求，否则不要把 `desktop:preview:*`、debug 构建，或 `--no-bundle` 的快速产物当成最终给用户分发的 release。
+- 如果用户的语义明显是“给 Windows 最终用户安装”，优先使用 `pnpm run desktop:build:nsis`。
+- 如果用户明确要“独立可执行文件”而不是安装器，优先使用 `pnpm run desktop:build:exe`。
+- 如果用户已经明确点名目标格式，就不要重复确认，直接走对应打包流程。
 
 ## 架构
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Repository rule: **keep product logic platform-agnostic, then expose it through 
 ## 3-step onboarding
 
 1. Read `README.md`, `CONTRIBUTING.md`, and this file before architecture-sensitive changes.
-2. Use `pnpm run desktop:dev` for normal local development, or `pnpm run dev:web` for frontend-only work.
+2. Prefer `pnpm run desktop:preview:debug` for fast local desktop checks. It reuses the existing debug binary after shared frontend changes and automatically does a fast local rebuild before preview when Rust / Tauri inputs are newer or the binary is missing. Keep `pnpm run desktop:dev` for the full Tauri dev flow, first-time setup, or startup/build-pipeline debugging, and use `pnpm run dev:web` for browser-only frontend work.
 3. After changes, run the smallest matching verification set below.
 
 ## Core commands
@@ -33,6 +33,7 @@ pnpm run e2e:install
 
 # Main dev flows
 pnpm run desktop:dev
+pnpm run desktop:preview:debug
 pnpm run dev:web
 pnpm run cli:dev
 pnpm run installer:dev
@@ -53,6 +54,25 @@ cargo build -p bitfun-desktop
 pnpm run e2e:test:l0
 pnpm --dir tests/e2e exec wdio run ./config/wdio.conf.ts --spec "./specs/<file>.spec.ts"
 ```
+
+## Fast Local Desktop Loops
+
+- `pnpm run desktop:preview:debug` starts or reuses the web dev server and launches `target/debug/bitfun-desktop(.exe)` without `tauri dev`. It reuses the existing binary when possible and automatically fast-rebuilds `bitfun-desktop` with `CARGO_PROFILE_DEV_DEBUG=0` and high codegen parallelism when Rust / Tauri inputs are newer or the binary is missing.
+- `pnpm run desktop:preview:debug -- --force-rebuild` is the escape hatch when you explicitly want to rebuild before preview even if the timestamp check says the binary is current.
+- This preview flow is for local iteration speed only. It does not replace the minimum verification set below before you finish the task.
+- If the user intent is to "quickly check the effect", "run locally for a quick look", or similar manual inspection, prefer the preview commands above even when the request also mentions "build" or "debug version".
+- Reserve `pnpm run desktop:build:fast` for cases where the user explicitly wants a debug build artifact and does not need the app launched for preview.
+- Intent examples:
+  - "build a local debug version and quickly inspect it" -> `pnpm run desktop:preview:debug`
+  - "build me a debug artifact only, no need to launch it" -> `pnpm run desktop:build:fast`
+
+## Packaging Requests
+
+- When the user asks to package, release, or build a distributable desktop artifact without naming the exact output form, confirm the intended package type before running the build.
+- Distinguish local temporary artifacts from real release deliverables. Do not treat `desktop:preview:*`, debug builds, or `--no-bundle` fast outputs as the final user-facing release unless the user explicitly asks for that form.
+- If the user clearly wants a Windows installer for end users, prefer `pnpm run desktop:build:nsis`.
+- If the user clearly wants a standalone Windows executable instead of an installer, prefer `pnpm run desktop:build:exe`.
+- If the user already names the exact target format, do not ask again; just use the requested packaging flow.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Be respectful, kind, and constructive. We welcome contributors of all background
 
 The desktop app includes SSH remote support, which pulls in OpenSSL. On Windows the workspace **does not use vendored OpenSSL**; link against **pre-built** binaries (no Perl/NASM/OpenSSL source build).
 
-- **Default**: `pnpm run desktop:dev` calls `ensure-openssl-windows.mjs` on Windows. Every `desktop:build*` script runs via `scripts/desktop-tauri-build.mjs`, which does the same before `tauri build` (first run downloads FireDaemon OpenSSL 3.5.5 into `.bitfun/cache/`; later runs reuse the cache). Extra args: `pnpm run desktop:build -- <tauri-build-args>`.
+- **Default**: `pnpm run desktop:dev` calls `ensure-openssl-windows.mjs` on Windows. `pnpm run desktop:preview:debug` does the same whenever it needs to fast-rebuild `bitfun-desktop` before preview. Every `desktop:build*` script runs via `scripts/desktop-tauri-build.mjs`, which does the same before `tauri build` (first run downloads FireDaemon OpenSSL 3.5.5 into `.bitfun/cache/`; later runs reuse the cache). Extra args: `pnpm run desktop:build -- <tauri-build-args>`.
 - **Manual / CI**: Download the [FireDaemon OpenSSL 3.5.5 LTS ZIP](https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip), extract, set `OPENSSL_DIR` to the `x64` folder, `OPENSSL_STATIC=1`, or run `scripts/ci/setup-openssl-windows.ps1`.
 - **Opt out of auto-download**: `BITFUN_SKIP_OPENSSL_BOOTSTRAP=1` and configure `OPENSSL_DIR` yourself.
 - **`desktop:dev:raw`** skips the dev script (no OpenSSL bootstrap); set `OPENSSL_DIR` yourself, run `scripts/ci/setup-openssl-windows.ps1`, or `node scripts/ensure-openssl-windows.mjs` (warms `.bitfun/cache/` and prints PowerShell `OPENSSL_*` lines to paste).
@@ -37,11 +37,25 @@ pnpm install
 ```bash
 # Desktop
 pnpm run desktop:dev
+pnpm run desktop:preview:debug
 pnpm run desktop:build
 
 # E2E
 pnpm run e2e:test
 ```
+
+For local iteration:
+
+- `desktop:preview:debug` avoids `tauri dev`, reuses the existing debug desktop binary when it is still current, and automatically does a fast rebuild with reduced debug info before preview when Rust / Tauri inputs are newer or the binary is missing.
+- Add `-- --force-rebuild` only when you explicitly want to rebuild before preview even if the timestamp check says the binary is current.
+- Keep `desktop:dev` for the full Tauri watcher/startup flow, and keep the project verification commands aligned with the actual files you changed.
+
+For packaging and release work:
+
+- Confirm the intended output format if the request only says "package" or "release" without naming the artifact type.
+- For Windows end-user installer delivery, prefer `pnpm run desktop:build:nsis`.
+- For a standalone Windows executable, use `pnpm run desktop:build:exe` only when that is the explicit ask.
+- Do not confuse local fast/debug artifacts with real release deliverables.
 
 > Note: More granular scripts are available (e.g. `dev:web`, `cli:dev`, `website:dev`). See `package.json` for details.
 

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -21,7 +21,7 @@
 
 桌面端包含 SSH 远程功能，会链接 OpenSSL。Windows 上**不使用 OpenSSL 源码编译（vendored）**，需使用**预编译**库。
 
-- **默认**：Windows 下 `pnpm run desktop:dev` 会调用 `ensure-openssl-windows.mjs`；所有 `desktop:build*` 均通过 `scripts/desktop-tauri-build.mjs` 执行，在 `tauri build` 前做相同引导（首次下载到 `.bitfun/cache/`，之后走缓存）。额外参数：`pnpm run desktop:build -- <tauri build 参数>`。
+- **默认**：Windows 下 `pnpm run desktop:dev` 会调用 `ensure-openssl-windows.mjs`；`pnpm run desktop:preview:debug` 在需要为预览执行快速本地 `cargo build -p bitfun-desktop` 时，也会做同样的 OpenSSL 引导。所有 `desktop:build*` 均通过 `scripts/desktop-tauri-build.mjs` 执行，在 `tauri build` 前做相同引导（首次下载到 `.bitfun/cache/`，之后走缓存）。额外参数：`pnpm run desktop:build -- <tauri build 参数>`。
 - **手动 / CI**：下载 [FireDaemon ZIP](https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip)，解压后将 `OPENSSL_DIR` 指向 `x64`，并设 `OPENSSL_STATIC=1`，或运行 `scripts/ci/setup-openssl-windows.ps1`。
 - **关闭自动下载**：设置 `BITFUN_SKIP_OPENSSL_BOOTSTRAP=1` 并自行配置 `OPENSSL_DIR`。
 - **`desktop:dev:raw`** 不经过 `dev.cjs`（无 OpenSSL 引导）；请自行设置 `OPENSSL_DIR`、运行 `scripts/ci/setup-openssl-windows.ps1`，或执行 `node scripts/ensure-openssl-windows.mjs`（会预热 `.bitfun/cache/` 并打印可在 PowerShell 中粘贴的 `OPENSSL_*` 命令）。
@@ -37,11 +37,25 @@ pnpm install
 ```bash
 # Desktop
 pnpm run desktop:dev
+pnpm run desktop:preview:debug
 pnpm run desktop:build
 
 # E2E
 pnpm run e2e:test
 ```
+
+本地迭代时建议这样选：
+
+- `desktop:preview:debug` 不经过 `tauri dev`；当已有 debug 桌面二进制仍然可复用时会直接预览，而在 Rust / Tauri 输入更新或二进制缺失时，会先用较轻的 dev 调试信息配置快速重编 `bitfun-desktop` 再预览。
+- 只有在你明确想忽略时间戳复用判断、强制先重编时，才额外使用 `pnpm run desktop:preview:debug -- --force-rebuild`。
+- `desktop:dev` 保留给完整的 Tauri watcher / 启动链路；正式收尾时，仍要按真实改动范围执行对应验证命令。
+
+涉及打包与 release 时建议这样处理：
+
+- 如果请求里只说“打包”或“release”，但没有明确产物类型，先确认目标输出形式。
+- 对于 Windows 最终用户安装交付，优先使用 `pnpm run desktop:build:nsis`。
+- 对于独立 Windows 可执行文件，只有在用户明确提出时才使用 `pnpm run desktop:build:exe`。
+- 不要把本地快速/debug 产物与正式 release 交付物混淆。
 
 > 说明：仓库提供更细粒度的脚本（例如 `dev:web`、`cli:dev`、`website:dev`），详情见 `package.json`。
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prepare:mobile-web": "node scripts/mobile-web-build.cjs",
     "preview": "pnpm --dir src/web-ui preview",
     "desktop:dev": "node scripts/dev.cjs desktop",
+    "desktop:preview:debug": "node scripts/dev.cjs desktop-preview",
     "desktop:dev:raw": "cross-env-shell CI=true \"cd src/apps/desktop && tauri dev\"",
     "desktop:build": "node scripts/desktop-tauri-build.mjs",
     "desktop:build:fast": "node scripts/desktop-tauri-build.mjs --debug --no-bundle",

--- a/scripts/dev.cjs
+++ b/scripts/dev.cjs
@@ -5,6 +5,8 @@
  * Manages pre-build tasks and dev server startup
  */
 
+const fs = require('fs');
+const net = require('net');
 const { execSync, spawn } = require('child_process');
 const path = require('path');
 const { pathToFileURL } = require('url');
@@ -20,6 +22,59 @@ const {
 const { buildMobileWeb } = require('./mobile-web-build.cjs');
 
 const ROOT_DIR = path.resolve(__dirname, '..');
+const DEV_SERVER_PORT = 1422;
+const DEV_SERVER_HOSTS = ['localhost', '127.0.0.1', '::1'];
+const DESKTOP_PREVIEW_REBUILD_INPUTS = [
+  path.join(ROOT_DIR, 'Cargo.toml'),
+  path.join(ROOT_DIR, 'src', 'apps', 'desktop'),
+  path.join(ROOT_DIR, 'src', 'crates', 'core'),
+  path.join(ROOT_DIR, 'src', 'crates', 'transport'),
+  path.join(ROOT_DIR, 'src', 'crates', 'api-layer'),
+  path.join(ROOT_DIR, 'src', 'crates', 'events'),
+  path.join(ROOT_DIR, 'src', 'crates', 'ai-adapters'),
+  path.join(ROOT_DIR, 'src', 'crates', 'webdriver'),
+];
+const DESKTOP_PREVIEW_REBUILD_IGNORED_DIRS = new Set([
+  '.bitfun',
+  '.git',
+  'coverage',
+  'dist',
+  'node_modules',
+  'target',
+]);
+const DESKTOP_PREVIEW_REBUILD_RELEVANT_EXTENSIONS = new Set([
+  '.ftl',
+  '.json',
+  '.md',
+  '.rs',
+  '.toml',
+  '.yaml',
+  '.yml',
+]);
+const DESKTOP_PREVIEW_REBUILD_IGNORED_BASENAMES = new Set([
+  'AGENTS-CN.md',
+  'AGENTS.md',
+  'CONTRIBUTING.md',
+  'CONTRIBUTING_CN.md',
+  'README.md',
+  'README.zh-CN.md',
+  'README_CN.md',
+]);
+
+function isDesktopMode(mode) {
+  return mode === 'desktop' || mode === 'desktop-preview';
+}
+
+function getDesktopBinaryPath() {
+  const suffix = process.platform === 'win32' ? '.exe' : '';
+  const binaryName = `bitfun-desktop${suffix}`;
+
+  if (process.platform === 'darwin') {
+    return path.join(ROOT_DIR, 'target', 'debug', 'BitFun.app', 'Contents', 'MacOS', 'BitFun');
+  }
+
+  return path.join(ROOT_DIR, 'target', 'debug', binaryName);
+}
 
 /**
  * Run command synchronously (silent mode)
@@ -110,12 +165,13 @@ function runCommand(command, cwd = ROOT_DIR) {
 /**
  * Spawn a command with explicit args array (no shell interpolation, safe for paths with spaces)
  */
-function spawnCommand(cmd, args, cwd = ROOT_DIR) {
+function spawnCommand(cmd, args, cwd = ROOT_DIR, env = process.env, shell = false) {
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, args, {
       cwd,
       stdio: 'inherit',
-      shell: true,
+      shell,
+      env,
     });
 
     child.on('close', (code) => {
@@ -130,21 +186,391 @@ function spawnCommand(cmd, args, cwd = ROOT_DIR) {
   });
 }
 
+function spawnBackgroundCommand(cmd, args, cwd = ROOT_DIR, env = process.env) {
+  return spawn(cmd, args, {
+    cwd,
+    stdio: 'inherit',
+    env,
+  });
+}
+
+function spawnWindowsCommand(command, cwd = ROOT_DIR, env = process.env) {
+  return spawn(process.env.ComSpec || 'C:\\Windows\\System32\\cmd.exe', ['/d', '/s', '/c', command], {
+    cwd,
+    stdio: 'inherit',
+    env,
+  });
+}
+
+function spawnWindowsCommandArgs(command, args, cwd = ROOT_DIR, env = process.env) {
+  return spawn(process.env.ComSpec || 'C:\\Windows\\System32\\cmd.exe', ['/d', '/s', '/c', command, ...args], {
+    cwd,
+    stdio: 'inherit',
+    env,
+  });
+}
+
+function runWindowsCommandArgs(command, args, cwd = ROOT_DIR, env = process.env) {
+  return new Promise((resolve, reject) => {
+    const child = spawnWindowsCommandArgs(command, args, cwd, env);
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Command failed with code ${code}`));
+      }
+    });
+
+    child.on('error', reject);
+  });
+}
+
+function stopChildProcess(child) {
+  if (!child || child.exitCode !== null) {
+    return;
+  }
+
+  if (process.platform === 'win32') {
+    try {
+      execSync(`taskkill /pid ${child.pid} /T /F >nul 2>&1`);
+      return;
+    } catch (error) {
+      // Fall through to a best-effort kill below.
+    }
+  }
+
+  try {
+    child.kill('SIGTERM');
+  } catch (error) {
+    // Ignore cleanup failures on shutdown paths.
+  }
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function isPortOpen(port, hosts = DEV_SERVER_HOSTS) {
+  return Promise.any(hosts.map((host) => {
+    return new Promise((resolve, reject) => {
+      const client = new net.Socket();
+      client.setTimeout(1500);
+      client.connect(port, host, () => {
+        client.destroy();
+        resolve(true);
+      });
+      client.on('error', (error) => {
+        client.destroy();
+        reject(error);
+      });
+      client.on('timeout', () => {
+        client.destroy();
+        reject(new Error(`Timeout connecting to ${host}:${port}`));
+      });
+    });
+  })).then(() => true).catch(() => false);
+}
+
+async function waitForPort(port, hosts = DEV_SERVER_HOSTS, timeoutMs = 30000) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await isPortOpen(port, hosts)) {
+      return;
+    }
+    await wait(500);
+  }
+
+  throw new Error(`Port ${port} did not become ready within ${timeoutMs}ms`);
+}
+
+async function ensureDesktopOpenSslIfNeeded() {
+  if (process.platform !== 'win32') {
+    return;
+  }
+
+  printInfo('Windows: ensuring prebuilt OpenSSL (cached under .bitfun/cache/)');
+  try {
+    const { ensureOpenSslWindows } = await import(
+      pathToFileURL(path.join(__dirname, 'ensure-openssl-windows.mjs')).href
+    );
+    await ensureOpenSslWindows();
+  } catch (error) {
+    printError('OpenSSL bootstrap failed');
+    printError(error.message || String(error));
+    process.exit(1);
+  }
+}
+
+async function rebuildDesktopDebugBinary() {
+  await ensureDesktopOpenSslIfNeeded();
+
+  const buildEnv = {
+    ...process.env,
+    CARGO_PROFILE_DEV_DEBUG: process.env.CARGO_PROFILE_DEV_DEBUG || '0',
+    CARGO_PROFILE_DEV_INCREMENTAL: process.env.CARGO_PROFILE_DEV_INCREMENTAL || 'true',
+    CARGO_PROFILE_DEV_CODEGEN_UNITS: process.env.CARGO_PROFILE_DEV_CODEGEN_UNITS || '256',
+  };
+
+  printInfo('Building bitfun-desktop in dev mode with reduced debug info for faster local relink');
+  printInfo(
+    `Fast local build env: CARGO_PROFILE_DEV_DEBUG=${buildEnv.CARGO_PROFILE_DEV_DEBUG}, ` +
+    `CARGO_PROFILE_DEV_CODEGEN_UNITS=${buildEnv.CARGO_PROFILE_DEV_CODEGEN_UNITS}`
+  );
+
+  await spawnCommand(
+    process.platform === 'win32' ? 'cargo.exe' : 'cargo',
+    ['build', '-p', 'bitfun-desktop'],
+    ROOT_DIR,
+    buildEnv,
+  );
+}
+
+function getNewestTrackedInput(entryPath) {
+  if (!fs.existsSync(entryPath)) {
+    return null;
+  }
+
+  const stat = fs.lstatSync(entryPath);
+  if (stat.isSymbolicLink()) {
+    return null;
+  }
+
+  if (stat.isFile()) {
+    const basename = path.basename(entryPath);
+    if (DESKTOP_PREVIEW_REBUILD_IGNORED_BASENAMES.has(basename)) {
+      return null;
+    }
+
+    const ext = path.extname(entryPath).toLowerCase();
+    if (!DESKTOP_PREVIEW_REBUILD_RELEVANT_EXTENSIONS.has(ext)) {
+      return null;
+    }
+
+    if (ext === '.md' && !entryPath.includes(`${path.sep}prompts${path.sep}`)) {
+      return null;
+    }
+
+    return {
+      path: entryPath,
+      mtimeMs: stat.mtimeMs,
+    };
+  }
+
+  if (!stat.isDirectory()) {
+    return null;
+  }
+
+  let newest = null;
+  for (const entry of fs.readdirSync(entryPath, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    if (entry.isDirectory() && DESKTOP_PREVIEW_REBUILD_IGNORED_DIRS.has(entry.name)) {
+      continue;
+    }
+
+    const candidate = getNewestTrackedInput(path.join(entryPath, entry.name));
+    if (candidate && (!newest || candidate.mtimeMs > newest.mtimeMs)) {
+      newest = candidate;
+    }
+  }
+
+  return newest;
+}
+
+function getDesktopPreviewRebuildPlan(desktopBinary, forceRebuild = false) {
+  if (forceRebuild) {
+    return {
+      shouldRebuild: true,
+      reason: 'Force rebuild requested for desktop preview',
+    };
+  }
+
+  if (!fs.existsSync(desktopBinary)) {
+    return {
+      shouldRebuild: true,
+      reason: 'Debug desktop binary is missing',
+    };
+  }
+
+  const binaryMtimeMs = fs.statSync(desktopBinary).mtimeMs;
+  let newestInput = null;
+
+  for (const input of DESKTOP_PREVIEW_REBUILD_INPUTS) {
+    const candidate = getNewestTrackedInput(input);
+    if (candidate && (!newestInput || candidate.mtimeMs > newestInput.mtimeMs)) {
+      newestInput = candidate;
+    }
+  }
+
+  if (newestInput && newestInput.mtimeMs > binaryMtimeMs) {
+    return {
+      shouldRebuild: true,
+      reason: `Rust / Tauri inputs changed since the last preview (${path.relative(ROOT_DIR, newestInput.path)})`,
+    };
+  }
+
+  return {
+    shouldRebuild: false,
+    reason: `Reusing debug desktop binary: ${path.relative(ROOT_DIR, desktopBinary)}`,
+  };
+}
+
+async function ensureDesktopDebugBinaryForPreview(forceRebuild = false) {
+  const desktopBinary = getDesktopBinaryPath();
+  const rebuildPlan = getDesktopPreviewRebuildPlan(desktopBinary, forceRebuild);
+
+  if (!rebuildPlan.shouldRebuild) {
+    printInfo(rebuildPlan.reason);
+    return desktopBinary;
+  }
+
+  printInfo(`${rebuildPlan.reason}; rebuilding before preview`);
+  await rebuildDesktopDebugBinary();
+  printSuccess('Debug desktop binary rebuilt for preview');
+  return desktopBinary;
+}
+
+async function startDesktopPreview() {
+  const desktopBinary = getDesktopBinaryPath();
+
+  if (!fs.existsSync(desktopBinary)) {
+    printError(`Debug desktop binary not found: ${desktopBinary}`);
+    printInfo('Retry with `pnpm run desktop:preview:debug -- --force-rebuild` or build it with `cargo build -p bitfun-desktop`');
+    process.exit(1);
+  }
+
+  let appProcess = null;
+  let devServerProcess = null;
+  let ownsDevServer = false;
+  let shuttingDown = false;
+
+  const cleanup = () => {
+    stopChildProcess(appProcess);
+    if (ownsDevServer) {
+      stopChildProcess(devServerProcess);
+    }
+  };
+
+  const shutdown = (exitCode = 0) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    cleanup();
+    process.exit(exitCode);
+  };
+
+  process.on('SIGINT', () => {
+    printInfo('Stopping desktop preview...');
+    shutdown(0);
+  });
+  process.on('SIGTERM', () => {
+    printInfo('Stopping desktop preview...');
+    shutdown(0);
+  });
+
+  if (await isPortOpen(DEV_SERVER_PORT)) {
+    printInfo(`Reusing web UI dev server on http://localhost:${DEV_SERVER_PORT}`);
+  } else {
+    printInfo(`Starting web UI dev server on http://localhost:${DEV_SERVER_PORT}`);
+    const viteArgs = ['--dir', 'src/web-ui', 'exec', 'vite', '--host', 'localhost', '--port', String(DEV_SERVER_PORT)];
+    const viteEnv = {
+      ...process.env,
+      TAURI_DEV_HOST: 'localhost',
+    };
+
+    devServerProcess = process.platform === 'win32'
+      ? spawnWindowsCommand(`pnpm ${viteArgs.join(' ')}`, ROOT_DIR, viteEnv)
+      : spawnBackgroundCommand('pnpm', viteArgs, ROOT_DIR, viteEnv);
+    ownsDevServer = true;
+
+    devServerProcess.on('error', (error) => {
+      printError(`Web UI dev server failed to start: ${error.message || String(error)}`);
+      shutdown(1);
+    });
+
+    devServerProcess.on('exit', (code, signal) => {
+      devServerProcess = null;
+      ownsDevServer = false;
+      if (!appProcess && !shuttingDown && code !== 0) {
+        printError(`Web UI dev server exited before desktop launch (code=${code ?? 'null'}, signal=${signal ?? 'null'})`);
+        shutdown(code ?? 1);
+        return;
+      }
+      if (appProcess && appProcess.exitCode === null && !shuttingDown) {
+        printError(`Web UI dev server exited unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'null'})`);
+        shutdown(code ?? 1);
+      }
+    });
+
+    try {
+      await waitForPort(DEV_SERVER_PORT);
+    } catch (error) {
+      printError(error.message || String(error));
+      shutdown(1);
+    }
+
+    printSuccess(`Web UI dev server is ready on http://localhost:${DEV_SERVER_PORT}`);
+  }
+
+  printInfo(`Launching debug desktop binary: ${desktopBinary}`);
+
+  appProcess = spawnBackgroundCommand(desktopBinary, [], ROOT_DIR, {
+    ...process.env,
+  });
+
+  appProcess.on('error', (error) => {
+    printError(`Desktop preview failed to start: ${error.message || String(error)}`);
+    shutdown(1);
+  });
+
+  appProcess.on('exit', (code, signal) => {
+    if (!shuttingDown) {
+      printInfo(`Desktop preview exited (code=${code ?? 'null'}, signal=${signal ?? 'null'})`);
+    }
+    shutdown(code ?? 0);
+  });
+
+  printSuccess('Desktop preview is running');
+  printInfo('Front-end edits continue to use Vite HMR; rebuild Rust only when desktop-side code changes');
+
+  await new Promise(() => {});
+}
+
 /**
  * Main entry
  */
 async function main() {
   const startTime = Date.now();
-  const mode = process.argv[2] || 'web'; // web | desktop
-  const modeLabel = mode === 'desktop' ? 'Desktop' : 'Web';
+  let mode = process.argv[2] || 'web'; // web | desktop
+  const extraArgs = process.argv.slice(3);
+  let forceDesktopPreviewRebuild = extraArgs.includes('--force-rebuild');
+
+  if (mode === 'desktop-preview-rebuild') {
+    mode = 'desktop-preview';
+    forceDesktopPreviewRebuild = true;
+  }
+
+  const desktopMode = isDesktopMode(mode);
+  const modeLabelMap = {
+    desktop: 'Desktop',
+    'desktop-preview': 'Desktop Debug Preview',
+    web: 'Web',
+  };
+  const modeLabel = modeLabelMap[mode] || 'Web';
   
   printHeader(`BitFun ${modeLabel} Development`);
   printBlank();
 
-  const totalSteps = mode === 'desktop' ? 4 : 3;
+  const totalSteps = desktopMode ? 4 : 3;
+  let currentStep = 1;
 
   // Step 1: Copy resources
-  printStep(1, totalSteps, 'Copy resources');
+  printStep(currentStep++, totalSteps, 'Copy resources');
   const copyResult = runSilent('pnpm run copy-monaco --silent');
   if (copyResult.ok) {
     printSuccess('Monaco Editor resources ready');
@@ -164,7 +590,7 @@ async function main() {
   }
   
   // Step 2: Generate version info
-  printStep(2, totalSteps, 'Generate version info');
+  printStep(currentStep++, totalSteps, 'Generate version info');
   const versionResult = runInherit('node scripts/generate-version.cjs');
   if (!versionResult.ok) {
     printError('Generate version info failed');
@@ -180,8 +606,8 @@ async function main() {
   const prepTime = ((Date.now() - startTime) / 1000).toFixed(1);
   
   // Step 3: Build mobile-web (desktop only)
-  if (mode === 'desktop') {
-    printStep(3, 4, 'Build mobile-web');
+  if (desktopMode) {
+    printStep(currentStep++, totalSteps, 'Build mobile-web');
     const mobileWebResult = buildMobileWeb({
       install: true,
       logInfo: printInfo,
@@ -194,35 +620,40 @@ async function main() {
   }
 
   // Final step: Start dev server
-  printStep(totalSteps, totalSteps, 'Start dev server');
+  const startStepLabel = mode === 'desktop-preview'
+    ? 'Start desktop preview'
+    : 'Start dev server';
+  printStep(currentStep, totalSteps, startStepLabel);
   printInfo(`Prep took ${prepTime}s`);
   
   printComplete('Initialization complete');
   
   try {
     if (mode === 'desktop') {
-      if (process.platform === 'win32') {
-        printInfo('Windows: ensuring prebuilt OpenSSL (cached under .bitfun/cache/)');
-        try {
-          const { ensureOpenSslWindows } = await import(
-            pathToFileURL(path.join(__dirname, 'ensure-openssl-windows.mjs')).href
-          );
-          await ensureOpenSslWindows();
-        } catch (error) {
-          printError('OpenSSL bootstrap failed');
-          printError(error.message || String(error));
-          process.exit(1);
-        }
-      }
+      await ensureDesktopOpenSslIfNeeded();
       const desktopDir = path.join(ROOT_DIR, 'src/apps/desktop');
       const tauriConfig = path.join(desktopDir, 'tauri.conf.json');
-      const tauriBin = path.join(ROOT_DIR, 'node_modules', '.bin', 'tauri');
-      await spawnCommand(tauriBin, ['dev', '--config', tauriConfig], desktopDir);
+      if (process.platform === 'win32') {
+        // Running the generated .cmd shim directly via spawn is flaky on Windows.
+        // Use cmd.exe with an explicit args array so the desktop app directory
+        // stays the Tauri project root without pnpm workspace path rewriting.
+        const tauriBin = path.join(ROOT_DIR, 'node_modules', '.bin', 'tauri.cmd');
+        await runWindowsCommandArgs(tauriBin, ['dev', '--config', tauriConfig], desktopDir, process.env);
+      } else {
+        const tauriBin = path.join(ROOT_DIR, 'node_modules', '.bin', 'tauri');
+        await spawnCommand(tauriBin, ['dev', '--config', tauriConfig], desktopDir);
+      }
+    } else if (mode === 'desktop-preview') {
+      await ensureDesktopDebugBinaryForPreview(forceDesktopPreviewRebuild);
+      await startDesktopPreview();
     } else {
       await runCommand('pnpm exec vite', path.join(ROOT_DIR, 'src/web-ui'));
     }
   } catch (error) {
     printError('Dev server failed to start');
+    if (error?.message) {
+      printError(error.message);
+    }
     process.exit(1);
   }
 }

--- a/src/apps/desktop/AGENTS-CN.md
+++ b/src/apps/desktop/AGENTS-CN.md
@@ -22,6 +22,8 @@
 
 - 保持 Tauri command 一致：名称使用 `snake_case`，调用使用结构化 `request`
 - 桌面端专属集成留在这里，不要下沉到共享 core
+- 本地临时调试时，无论是共享前端改动还是 Rust / Tauri 改动，都优先使用 `pnpm run desktop:preview:debug`；它会在现有 debug 二进制仍然可复用时直接预览，并在桌面侧输入更新或二进制缺失时自动重编后再预览。只有在需要完整 Tauri dev watcher，或正在排查启动 / 构建集成本身时，才回到 `pnpm run desktop:dev`
+- 当表述里同时出现“编译/调试版本”和“快速看看效果/先看一下”时，按更高层的“预览”意图处理，优先使用 preview 命令，而不是 `pnpm run desktop:build:fast`
 
 推荐命令形状：
 
@@ -41,6 +43,7 @@ await api.invoke('your_command', { request: { ... } });
 
 ```bash
 pnpm run desktop:dev
+pnpm run desktop:preview:debug
 cargo check -p bitfun-desktop
 cargo test -p bitfun-desktop
 cargo build -p bitfun-desktop
@@ -58,3 +61,15 @@ cargo check -p bitfun-desktop && cargo test -p bitfun-desktop
 ```bash
 cargo build -p bitfun-desktop
 ```
+
+上面的 preview 命令只是迭代捷径，完成任务前仍要按要求执行最小 Rust 检查，以及必要的 build / E2E 验证。
+
+只有在你明确想忽略时间戳复用判断、强制先重编再预览时，才使用 `pnpm run desktop:preview:debug -- --force-rebuild`。
+
+`pnpm run desktop:build:fast` 只用于用户明确要 debug 构建产物、且不需要启动应用预览的场景。
+
+涉及打包或 release 请求时：
+
+- 如果用户没有明确说明要的是本地快速产物、独立可执行文件，还是安装器，先确认目标打包形式。
+- 不要用 preview/debug 产物替代正式 release 交付物。
+- 在 Windows 上，面向安装交付优先使用 `pnpm run desktop:build:nsis`；只有用户明确要独立可执行文件时，才使用 `pnpm run desktop:build:exe`。

--- a/src/apps/desktop/AGENTS.md
+++ b/src/apps/desktop/AGENTS.md
@@ -22,6 +22,8 @@ If a change affects shared product behavior across runtimes, the implementation 
 
 - Keep Tauri commands consistent: `snake_case` names, structured `request`
 - Keep desktop-only integrations here; do not move them into shared core
+- For local temporary debugging, prefer `pnpm run desktop:preview:debug` for both frontend-only shared-UI changes and Rust / Tauri changes. It reuses the existing debug binary when it is still current and auto-rebuilds before preview when desktop-side inputs are newer or the binary is missing. Use `pnpm run desktop:dev` only when you need the full Tauri dev watcher or are debugging startup/build integration itself
+- When the wording mixes "build/debug version" with "quickly inspect the effect", treat the higher-level intent as preview and use the preview commands instead of `pnpm run desktop:build:fast`
 
 Preferred command shape:
 
@@ -41,6 +43,7 @@ await api.invoke('your_command', { request: { ... } });
 
 ```bash
 pnpm run desktop:dev
+pnpm run desktop:preview:debug
 cargo check -p bitfun-desktop
 cargo test -p bitfun-desktop
 cargo build -p bitfun-desktop
@@ -58,3 +61,15 @@ If the change affects startup, WebDriver, browser/computer-use, or packaged beha
 ```bash
 cargo build -p bitfun-desktop
 ```
+
+The preview commands above are iteration shortcuts only; keep using the minimum Rust checks and any required build / E2E verification before finishing.
+
+Use `pnpm run desktop:preview:debug -- --force-rebuild` only when you explicitly want to rebuild before preview even if the timestamp check says the binary is current.
+
+Use `pnpm run desktop:build:fast` only when the user explicitly wants a debug build artifact without launching the app.
+
+For packaging or release asks:
+
+- Confirm the package form when the user did not specify whether they want a local fast artifact, a standalone executable, or an installer.
+- Do not substitute preview/debug outputs for a real release deliverable.
+- On Windows, prefer `pnpm run desktop:build:nsis` for installer-style delivery and `pnpm run desktop:build:exe` only when the user explicitly wants a standalone executable.

--- a/src/web-ui/AGENTS-CN.md
+++ b/src/web-ui/AGENTS-CN.md
@@ -27,11 +27,13 @@
 - 不要在 UI 组件里直接调用 Tauri API；应通过 adapter / infrastructure 层访问
 - 新增前端基础设施前，先复用已有的 theme、i18n、component-library 和 Zustand stores
 - 遵循 `src/web-ui/LOGGING.md`：仅英文、无 emoji、结构化日志
+- 共享前端改动后的桌面人工验证，优先使用 `pnpm run desktop:preview:debug` 而不是 `pnpm run desktop:dev`；只有在要验证的就是 Tauri 启动 / dev 流程本身时，才切回完整桌面链路
 
 ## 命令
 
 ```bash
 pnpm --dir src/web-ui dev
+pnpm run desktop:preview:debug
 pnpm --dir src/web-ui run lint
 pnpm --dir src/web-ui run type-check
 pnpm --dir src/web-ui run test:run

--- a/src/web-ui/AGENTS.md
+++ b/src/web-ui/AGENTS.md
@@ -27,11 +27,13 @@ Most changes start in:
 - Do not call Tauri APIs directly from UI components; go through the adapter / infrastructure layer
 - Reuse existing theme, i18n, component-library, and Zustand stores before adding new frontend primitives
 - Follow `src/web-ui/LOGGING.md`: English only, no emojis, structured logs
+- For quick manual desktop verification of shared frontend changes, prefer `pnpm run desktop:preview:debug` over `pnpm run desktop:dev`; switch back to the full desktop flow only when the Tauri startup/dev pipeline itself is part of what you are validating
 
 ## Commands
 
 ```bash
 pnpm --dir src/web-ui dev
+pnpm run desktop:preview:debug
 pnpm --dir src/web-ui run lint
 pnpm --dir src/web-ui run type-check
 pnpm --dir src/web-ui run test:run


### PR DESCRIPTION
## Summary

- unify local desktop preview behind `pnpm run desktop:preview:debug`
- auto-reuse the existing debug desktop binary when it is still current
- auto-fast-rebuild the debug desktop binary before preview when Rust or Tauri inputs changed
- align agent and contributing docs with the single preview workflow and clearer build-vs-preview guidance

## Changes

- add a single public desktop preview entry in `package.json`
- update `scripts/dev.cjs` so desktop preview:
  - reuses `target/debug/bitfun-desktop.exe` when possible
  - rebuilds automatically when the binary is missing or stale
  - supports `-- --force-rebuild` for an explicit rebuild
- remove the separate public `desktop:preview:debug:rebuild` script in favor of one preview command
- clarify that `desktop:build:fast` is for generating a debug artifact, not for launching a preview flow
- update English and Chinese agent/contributing docs across the root, desktop, and web-ui scopes

## Why

- reduce local iteration time when checking desktop changes
- avoid forcing developers to remember two overlapping preview commands
- keep agent behavior aligned with the faster preview path instead of choosing artifact-only build commands for quick local checks
- reduce confusion between debug preview workflows and actual packaging outputs

## Validation

- `node -c scripts/dev.cjs`
- `pnpm run desktop:preview:debug -- --force-rebuild`
- `pnpm run desktop:preview:debug`
