### PR TITLE
feat: align Codex client_version with local CLI; honor proxy in AI config tests

### DIFF
--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -795,8 +795,43 @@ pub async fn initialize_ai(state: State<'_, AppState>) -> Result<String, String>
     ))
 }
 
+async fn create_transient_ai_client_for_config(
+    state: &State<'_, AppState>,
+    model_config: bitfun_core::service::config::types::AIModelConfig,
+) -> Result<bitfun_core::infrastructure::ai::AIClient, String> {
+    let auth = model_config.auth.clone();
+    let mut ai_config: bitfun_core::util::types::AIConfig = model_config
+        .try_into()
+        .map_err(|e| format!("Failed to convert configuration: {}", e))?;
+
+    bitfun_core::infrastructure::ai::client_factory::apply_cli_credential(&auth, &mut ai_config)
+        .await
+        .map_err(|e| format!("Failed to resolve CLI credential: {}", e))?;
+
+    let global_config: bitfun_core::service::config::GlobalConfig = state
+        .config_service
+        .get_config(None)
+        .await
+        .map_err(|e| format!("Failed to get configuration: {}", e))?;
+    let proxy_config = if global_config.ai.proxy.enabled {
+        Some(global_config.ai.proxy.clone())
+    } else {
+        None
+    };
+    let stream_options = bitfun_core::infrastructure::ai::build_stream_options(&global_config.ai);
+
+    Ok(
+        bitfun_core::infrastructure::ai::AIClient::new_with_runtime_options(
+            ai_config,
+            proxy_config,
+            stream_options,
+        ),
+    )
+}
+
 #[tauri::command]
 pub async fn test_ai_config_connection(
+    state: State<'_, AppState>,
     request: TestAIConfigConnectionRequest,
 ) -> Result<bitfun_core::util::types::ConnectionTestResult, String> {
     let model_name = request.config.name.clone();
@@ -810,24 +845,12 @@ pub async fn test_ai_config_connection(
         bitfun_core::service::config::types::ModelCategory::Multimodal
     );
 
-    let auth = request.config.auth.clone();
-    let mut ai_config: bitfun_core::util::types::AIConfig = match request.config.try_into() {
-        Ok(config) => config,
-        Err(e) => {
-            error!("Failed to convert AI config: {}", e);
-            return Err(format!("Failed to convert configuration: {}", e));
-        }
-    };
-
-    if let Err(e) =
-        bitfun_core::infrastructure::ai::client_factory::apply_cli_credential(&auth, &mut ai_config)
-            .await
-    {
-        error!("Failed to resolve CLI credential during test: {}", e);
-        return Err(format!("Failed to resolve CLI credential: {}", e));
-    }
-
-    let ai_client = bitfun_core::infrastructure::ai::AIClient::new(ai_config);
+    let ai_client = create_transient_ai_client_for_config(&state, request.config)
+        .await
+        .map_err(|e| {
+            error!("Failed to create AI client during test: {}", e);
+            e
+        })?;
 
     match ai_client.test_connection().await {
         Ok(result) => {
@@ -903,18 +926,11 @@ pub async fn test_ai_config_connection(
 
 #[tauri::command]
 pub async fn list_ai_models_by_config(
+    state: State<'_, AppState>,
     request: ListAIModelsByConfigRequest,
 ) -> Result<Vec<bitfun_core::util::types::RemoteModelInfo>, String> {
     let config_name = request.config.name.clone();
-    let auth = request.config.auth.clone();
-    let mut ai_config: bitfun_core::util::types::AIConfig = request
-        .config
-        .try_into()
-        .map_err(|e| format!("Failed to convert configuration: {}", e))?;
-    bitfun_core::infrastructure::ai::client_factory::apply_cli_credential(&auth, &mut ai_config)
-        .await
-        .map_err(|e| format!("Failed to resolve CLI credential: {}", e))?;
-    let ai_client = bitfun_core::infrastructure::ai::AIClient::new(ai_config);
+    let ai_client = create_transient_ai_client_for_config(&state, request.config).await?;
 
     ai_client.list_models().await.map_err(|e| {
         error!(

--- a/src/crates/ai-adapters/src/providers/openai/common.rs
+++ b/src/crates/ai-adapters/src/providers/openai/common.rs
@@ -108,26 +108,46 @@ struct CodexBackendModelEntry {
 
 /// `chatgpt.com/backend-api/codex/models` returns each model's
 /// `minimal_client_version`, and only emits entries whose minimum is satisfied
-/// by the `client_version` query param. Sending BitFun's own
-/// `CARGO_PKG_VERSION` (e.g. `"0.2.3"`) makes the backend hide every modern
-/// model and only return the legacy `gpt-5.2` (whose minimum is `0.0.1`). We
-/// mirror a current Codex CLI release so the model picker matches what the
-/// user sees in `codex /model`. Bump this when codex CLI bumps further.
-const CODEX_CLIENT_VERSION_HEADER: &str = "0.121.0";
+/// by the `client_version` query param. Codex CLI credentials inject a
+/// Codex-shaped `User-Agent` containing the locally installed CLI version; use
+/// that same version here so the model picker matches what the user sees in
+/// `codex /model`.
+fn codex_client_version(client: &AIClient) -> Option<String> {
+    let headers = client.config.custom_headers.as_ref()?;
+    let user_agent = headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case("User-Agent"))?
+        .1
+        .trim();
+    let version = user_agent
+        .strip_prefix("codex_cli_rs/")
+        .or_else(|| user_agent.strip_prefix("codex/"))?
+        .trim();
+
+    if version.is_empty() {
+        None
+    } else {
+        Some(version.to_string())
+    }
+}
 
 async fn list_codex_chatgpt_models(
     client: &AIClient,
     base_models_url: &str,
 ) -> Result<Vec<RemoteModelInfo>> {
-    let separator = if base_models_url.contains('?') {
-        '&'
+    let url = if let Some(version) = codex_client_version(client) {
+        let separator = if base_models_url.contains('?') {
+            '&'
+        } else {
+            '?'
+        };
+        format!("{base_models_url}{separator}client_version={version}")
     } else {
-        '?'
+        log::warn!(
+            "Codex backend model discovery is missing a codex CLI client version; requesting models without client_version"
+        );
+        base_models_url.to_string()
     };
-    let url = format!(
-        "{base_models_url}{separator}client_version={version}",
-        version = CODEX_CLIENT_VERSION_HEADER
-    );
 
     let response = apply_headers(client, client.client.get(&url))
         .send()

--- a/src/crates/core/src/infrastructure/cli_credentials/codex.rs
+++ b/src/crates/core/src/infrastructure/cli_credentials/codex.rs
@@ -134,6 +134,43 @@ fn jwt_chatgpt_account_id(token: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+fn parse_codex_cli_version(output: &str) -> Option<String> {
+    output.split_whitespace().find_map(|token| {
+        let version = token
+            .trim()
+            .trim_start_matches('v')
+            .trim_matches(|ch: char| matches!(ch, ',' | ';' | ')' | '('));
+        if version.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+            && version.contains('.')
+            && version
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '+'))
+        {
+            Some(version.to_string())
+        } else {
+            None
+        }
+    })
+}
+
+async fn resolve_codex_cli_version() -> Option<String> {
+    let check = crate::service::system::check_command("codex");
+    let command = check.path.as_deref()?;
+    let args = vec!["--version".to_string()];
+    let output = crate::service::system::run_command(command, &args, None, None)
+        .await
+        .ok()?;
+    if !output.success {
+        log::debug!(
+            "codex CLI version command failed: exit_code={}, stderr={}",
+            output.exit_code,
+            output.stderr.trim()
+        );
+        return None;
+    }
+    parse_codex_cli_version(&output.stdout).or_else(|| parse_codex_cli_version(&output.stderr))
+}
+
 fn detect_mode(file: &CodexAuthFile) -> Option<CliCredentialMode> {
     let declared = file.auth_mode.as_deref().unwrap_or("");
     if declared.eq_ignore_ascii_case("chatgpt") {
@@ -346,10 +383,17 @@ impl CredentialResolver for CodexResolver {
                 // on a Codex-shaped User-Agent. Mirror the CLI's format
                 // (`codex_cli_rs/<ver>`) so requests aren't silently rejected
                 // / served an empty list.
-                headers.insert(
-                    "User-Agent".to_string(),
-                    format!("codex_cli_rs/{}", env!("CARGO_PKG_VERSION")),
-                );
+                let codex_cli_version = resolve_codex_cli_version().await;
+                let user_agent = codex_cli_version
+                    .as_deref()
+                    .map(|version| format!("codex_cli_rs/{version}"))
+                    .unwrap_or_else(|| {
+                        log::warn!(
+                            "Unable to detect codex CLI version; using BitFun user agent for Codex backend requests"
+                        );
+                        format!("BitFun/{}", env!("CARGO_PKG_VERSION"))
+                    });
+                headers.insert("User-Agent".to_string(), user_agent);
                 let exp = tokens.access_token.as_deref().and_then(jwt_exp);
                 Ok(ResolvedCredential {
                     api_key: access_token,
@@ -362,5 +406,27 @@ impl CredentialResolver for CodexResolver {
             }
             CliCredentialMode::OauthPersonal => Err(anyhow!("codex never uses OauthPersonal mode")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_codex_cli_version;
+
+    #[test]
+    fn parses_codex_cli_version_output() {
+        assert_eq!(
+            parse_codex_cli_version("codex-cli 0.124.0\n").as_deref(),
+            Some("0.124.0")
+        );
+        assert_eq!(
+            parse_codex_cli_version("codex v0.125.1-beta.2").as_deref(),
+            Some("0.125.1-beta.2")
+        );
+    }
+
+    #[test]
+    fn ignores_output_without_semver_like_token() {
+        assert_eq!(parse_codex_cli_version("codex-cli unknown"), None);
     }
 }


### PR DESCRIPTION
## Summary
- Resolve the installed Codex CLI version via `codex --version` and use it in the ChatGPT Codex User-Agent so backend model discovery matches `codex /model`.
- Derive the `client_version` query parameter for Codex model listing from the client User-Agent instead of a hardcoded constant.
- Refactor desktop `test_ai_config_connection` / `list_ai_models_by_config` to build a transient `AIClient` with global proxy and stream options (same as other code paths).

## Test plan
- [x] `cargo check -p bitfun-desktop -p bitfun-core -p bitfun-ai-adapters`
- [x] `cargo test -p bitfun-core codex::tests`