### PR TITLE
[codex] Fix stale Remote SSH restore entries

### DIFF
--- a/src/apps/desktop/src/api/app_state.rs
+++ b/src/apps/desktop/src/api/app_state.rs
@@ -254,6 +254,15 @@ impl AppState {
         // Load persisted remote workspaces (may be multiple)
         match manager.load_remote_workspace().await {
             Ok(_) => {
+                if let Err(e) = manager
+                    .prune_remote_workspaces_without_saved_connections()
+                    .await
+                {
+                    log::warn!(
+                        "Failed to prune stale persisted remote workspaces on startup: {}",
+                        e
+                    );
+                }
                 let workspaces = manager.get_remote_workspaces().await;
                 if !workspaces.is_empty() {
                     log::info!("Loaded {} persisted remote workspace(s)", workspaces.len());

--- a/src/apps/desktop/src/api/ssh_api.rs
+++ b/src/apps/desktop/src/api/ssh_api.rs
@@ -122,20 +122,20 @@ pub async fn ssh_connect(
         }
     }
 
-    // First save the connection config so it persists across restarts
-    log::info!("ssh_connect: about to save connection config");
-    if let Err(e) = manager.save_connection(&config).await {
-        log::warn!(
-            "ssh_connect: Failed to save connection config before connect: {}",
-            e
-        );
-        // Continue anyway - connection might still work
-    } else {
-        log::info!("ssh_connect: Connection config saved successfully");
-    }
-
     log::info!("ssh_connect: about to establish connection");
+    let config_to_save = config.clone();
     let result = manager.connect(config).await.map_err(|e| e.to_string());
+    if result.is_ok() {
+        log::info!("ssh_connect: about to save successful connection config");
+        if let Err(e) = manager.save_connection(&config_to_save).await {
+            log::warn!(
+                "ssh_connect: Failed to save successful connection config: {}",
+                e
+            );
+        } else {
+            log::info!("ssh_connect: Connection config saved successfully");
+        }
+    }
     log::info!("ssh_connect result: {:?}", result);
     result
 }
@@ -450,6 +450,23 @@ pub async fn remote_open_workspace(
 pub async fn remote_close_workspace(state: State<'_, AppState>) -> Result<(), String> {
     state.clear_remote_workspace().await;
     log::info!("Closed remote workspace");
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn remote_remove_workspace(
+    state: State<'_, AppState>,
+    connection_id: String,
+    remote_path: String,
+) -> Result<(), String> {
+    state
+        .unregister_remote_workspace_entry(&connection_id, &remote_path)
+        .await;
+    log::info!(
+        "Removed remote workspace restore entry: connection_id={}, remote_path={}",
+        connection_id,
+        remote_path
+    );
     Ok(())
 }
 

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -759,6 +759,7 @@ pub async fn run() {
             api::ssh_api::remote_execute,
             api::ssh_api::remote_open_workspace,
             api::ssh_api::remote_close_workspace,
+            api::ssh_api::remote_remove_workspace,
             api::ssh_api::remote_get_workspace_info,
             // Announcement / feature-demo / tips API
             api::announcement_api::get_pending_announcements,

--- a/src/crates/core/src/service/remote_ssh/manager.rs
+++ b/src/crates/core/src/service/remote_ssh/manager.rs
@@ -510,6 +510,42 @@ impl SSHConnectionManager {
         self.remote_workspaces.read().await.clone()
     }
 
+    /// Drop persisted remote workspace restore entries whose saved SSH profile is gone.
+    pub async fn prune_remote_workspaces_without_saved_connections(
+        &self,
+    ) -> anyhow::Result<Vec<crate::service::remote_ssh::types::RemoteWorkspace>> {
+        let saved_ids: Vec<String> = self
+            .saved_connections
+            .read()
+            .await
+            .iter()
+            .map(|c| c.id.clone())
+            .collect();
+
+        let removed = {
+            let mut guard = self.remote_workspaces.write().await;
+            let mut removed = Vec::new();
+            guard.retain(|w| {
+                let keep = saved_ids.iter().any(|id| id == &w.connection_id);
+                if !keep {
+                    removed.push(w.clone());
+                }
+                keep
+            });
+            removed
+        };
+
+        if !removed.is_empty() {
+            log::warn!(
+                "Removed {} persisted remote workspace(s) without saved SSH connection",
+                removed.len()
+            );
+            self.save_remote_workspaces().await?;
+        }
+
+        Ok(removed)
+    }
+
     /// Get first persisted remote workspace (legacy compat)
     pub async fn get_remote_workspace(
         &self,
@@ -734,7 +770,17 @@ impl SSHConnectionManager {
 
         let mut guard = self.saved_connections.write().await;
         *guard = saved;
+        drop(guard);
 
+        let removed = self.prune_saved_connections_without_credentials().await?;
+        if !removed.is_empty() {
+            log::warn!(
+                "Removed {} saved SSH connection(s) with unavailable local credentials during load",
+                removed.len()
+            );
+        }
+
+        let guard = self.saved_connections.read().await;
         log::info!("load_saved_connections: loaded {} connections", guard.len());
         Ok(())
     }
@@ -762,7 +808,63 @@ impl SSHConnectionManager {
 
     /// Get list of saved connections
     pub async fn get_saved_connections(&self) -> Vec<SavedConnection> {
+        if let Err(e) = self.prune_saved_connections_without_credentials().await {
+            log::warn!("Failed to prune unavailable saved SSH connections: {}", e);
+        }
         self.saved_connections.read().await.clone()
+    }
+
+    /// Remove saved profiles that cannot reconnect without user input, plus their
+    /// persisted remote-workspace restore records. Passwords from older clients
+    /// may not have a vault entry after an upgrade; keeping those profiles causes
+    /// startup restore loops and hides matching SSH config hosts in the dialog.
+    pub async fn prune_saved_connections_without_credentials(&self) -> anyhow::Result<Vec<String>> {
+        let saved_snapshot = self.saved_connections.read().await.clone();
+        let mut removed_ids = Vec::new();
+        for conn in saved_snapshot {
+            if !matches!(
+                conn.auth_type,
+                crate::service::remote_ssh::types::SavedAuthType::Password
+            ) {
+                continue;
+            }
+            match self.password_vault.load(&conn.id).await {
+                Ok(Some(_)) => {}
+                Ok(None) => removed_ids.push(conn.id),
+                Err(e) => {
+                    log::warn!(
+                        "Treating saved SSH password profile as unavailable: id={}, error={}",
+                        conn.id,
+                        e
+                    );
+                    removed_ids.push(conn.id);
+                }
+            }
+        }
+
+        if removed_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let removed_ids = {
+            let mut guard = self.saved_connections.write().await;
+            guard.retain(|conn| !removed_ids.iter().any(|id| id == &conn.id));
+            removed_ids
+        };
+
+        for id in &removed_ids {
+            if let Err(e) = self.password_vault.remove(id).await {
+                log::warn!(
+                    "Failed to remove SSH password vault entry for {}: {}",
+                    id,
+                    e
+                );
+            }
+        }
+        self.remove_remote_workspaces_for_connections(&removed_ids)
+            .await?;
+        self.save_connections().await?;
+        Ok(removed_ids)
     }
 
     /// SSH `host` field from the saved profile with this `connection_id` (works when not connected).
@@ -782,6 +884,25 @@ impl SSHConnectionManager {
 
     /// Save a connection configuration
     pub async fn save_connection(&self, config: &SSHConnectionConfig) -> anyhow::Result<()> {
+        match &config.auth {
+            SSHAuthMethod::Password { password } => {
+                if password.is_empty() && self.password_vault.load(&config.id).await?.is_none() {
+                    anyhow::bail!(
+                        "Cannot save password SSH connection without a password or stored vault entry"
+                    );
+                }
+                if !password.is_empty() {
+                    self.password_vault
+                        .store(&config.id, password)
+                        .await
+                        .with_context(|| format!("store ssh password vault for {}", config.id))?;
+                }
+            }
+            SSHAuthMethod::PrivateKey { .. } => {
+                self.password_vault.remove(&config.id).await?;
+            }
+        }
+
         let mut guard = self.saved_connections.write().await;
 
         // Remove existing entry with same id OR same host+port+username (dedup)
@@ -815,20 +936,6 @@ impl SSHConnectionManager {
 
         drop(guard);
 
-        match &config.auth {
-            SSHAuthMethod::Password { password } => {
-                if !password.is_empty() {
-                    self.password_vault
-                        .store(&config.id, password)
-                        .await
-                        .with_context(|| format!("store ssh password vault for {}", config.id))?;
-                }
-            }
-            SSHAuthMethod::PrivateKey { .. } => {
-                self.password_vault.remove(&config.id).await?;
-            }
-        }
-
         self.save_connections().await
     }
 
@@ -857,7 +964,32 @@ impl SSHConnectionManager {
         guard.retain(|c| c.id != connection_id);
         drop(guard);
         self.password_vault.remove(connection_id).await?;
+        self.remove_remote_workspaces_for_connections(&[connection_id.to_string()])
+            .await?;
         self.save_connections().await
+    }
+
+    async fn remove_remote_workspaces_for_connections(
+        &self,
+        connection_ids: &[String],
+    ) -> anyhow::Result<()> {
+        if connection_ids.is_empty() {
+            return Ok(());
+        }
+        let removed = {
+            let mut guard = self.remote_workspaces.write().await;
+            let before = guard.len();
+            guard.retain(|w| !connection_ids.iter().any(|id| id == &w.connection_id));
+            before - guard.len()
+        };
+        if removed > 0 {
+            log::warn!(
+                "Removed {} persisted remote workspace(s) for unavailable SSH connection(s)",
+                removed
+            );
+            self.save_remote_workspaces().await?;
+        }
+        Ok(())
     }
 
     /// Connect to a remote SSH server
@@ -2113,5 +2245,109 @@ impl PortForwardManager {
 impl Default for PortForwardManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::remote_ssh::types::{RemoteWorkspace, SavedAuthType, SavedConnection};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_data_dir(name: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "bitfun-remote-ssh-manager-{}-{}-{}",
+            name,
+            std::process::id(),
+            nanos
+        ))
+    }
+
+    #[tokio::test]
+    async fn prunes_password_connection_without_vault_entry() {
+        let dir = test_data_dir("missing-vault");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        let manager = SSHConnectionManager::new(dir.clone());
+
+        let saved = vec![SavedConnection {
+            id: "ssh-root@example.com:22".to_string(),
+            name: "root@example.com".to_string(),
+            host: "example.com".to_string(),
+            port: 22,
+            username: "root".to_string(),
+            auth_type: SavedAuthType::Password,
+            default_workspace: None,
+            last_connected: Some(1),
+        }];
+        tokio::fs::write(
+            dir.join("ssh_connections.json"),
+            serde_json::to_string_pretty(&saved).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        manager.load_saved_connections().await.unwrap();
+
+        assert!(manager.get_saved_connections().await.is_empty());
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn rejects_saving_password_connection_without_password() {
+        let dir = test_data_dir("empty-password-save");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        let manager = SSHConnectionManager::new(dir.clone());
+
+        let result = manager
+            .save_connection(&SSHConnectionConfig {
+                id: "ssh-root@example.com:22".to_string(),
+                name: "root@example.com".to_string(),
+                host: "example.com".to_string(),
+                port: 22,
+                username: "root".to_string(),
+                auth: SSHAuthMethod::Password {
+                    password: String::new(),
+                },
+                default_workspace: None,
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert!(manager.get_saved_connections().await.is_empty());
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn prunes_remote_workspaces_without_saved_connection() {
+        let dir = test_data_dir("missing-saved");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        let manager = SSHConnectionManager::new(dir.clone());
+
+        let workspaces = vec![RemoteWorkspace {
+            connection_id: "ssh-root@example.com:22".to_string(),
+            remote_path: "/root/project".to_string(),
+            connection_name: "root@example.com".to_string(),
+            ssh_host: "example.com".to_string(),
+        }];
+        tokio::fs::write(
+            dir.join("remote_workspace.json"),
+            serde_json::to_string_pretty(&workspaces).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        manager.load_remote_workspace().await.unwrap();
+        let removed = manager
+            .prune_remote_workspaces_without_saved_connections()
+            .await
+            .unwrap();
+
+        assert_eq!(removed.len(), 1);
+        assert!(manager.get_remote_workspaces().await.is_empty());
+        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 }

--- a/src/web-ui/src/features/ssh-remote/SSHConnectionDialog.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHConnectionDialog.tsx
@@ -200,7 +200,6 @@ export const SSHConnectionDialog: React.FC<SSHConnectionDialogProps> = ({
     setIsConnecting(true);
     setLocalError(null);
     try {
-      await sshApi.saveConnection(config);
       await connect(config.id, config);
       // Don't call onClose() here - connect() handles closing the dialog via context
     } catch (e) {
@@ -329,7 +328,6 @@ export const SSHConnectionDialog: React.FC<SSHConnectionDialogProps> = ({
           auth,
         };
         await connect(conn.id, full);
-        await sshApi.saveConnection(full);
       } else {
         const { entry, connectHost, port } = credentialsPrompt;
         const connectionId = generateConnectionId(connectHost, port, resolvedUsername);
@@ -342,7 +340,6 @@ export const SSHConnectionDialog: React.FC<SSHConnectionDialogProps> = ({
           auth,
         };
         await connect(connectionId, full);
-        await sshApi.saveConnection(full);
         await loadSavedConnections();
       }
       setCredentialsPrompt(null);

--- a/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.tsx
@@ -92,6 +92,27 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
     setWorkspaceStatuses(prev => ({ ...prev, [connId]: st }));
   }, []);
 
+  const clearWorkspaceStatus = useCallback((connId: string) => {
+    setWorkspaceStatuses(prev => {
+      if (!(connId in prev)) return prev;
+      const next = { ...prev };
+      delete next[connId];
+      return next;
+    });
+  }, []);
+
+  const forgetRemoteWorkspace = useCallback(async (workspace: RemoteWorkspace) => {
+    log.info('Forgetting remote workspace restore entry', {
+      connectionId: workspace.connectionId,
+      remotePath: workspace.remotePath,
+    });
+    clearWorkspaceStatus(workspace.connectionId);
+    await Promise.allSettled([
+      workspaceManager.removeRemoteWorkspace(workspace.connectionId, workspace.remotePath),
+      sshApi.removeWorkspace(workspace.connectionId, workspace.remotePath),
+    ]);
+  }, [clearWorkspaceStatus]);
+
   // Cleanup heartbeat on unmount
   useEffect(() => {
     return () => {
@@ -273,8 +294,13 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
       const savedConnectionsList = await sshApi.listSavedConnections();
 
       const skipPasswordAutoReconnect = new Set<string>();
+      const missingSavedConnections = new Set<string>();
       for (const ws of reconnectList) {
         const sc = savedConnectionsList.find(c => c.id === ws.connectionId);
+        if (!sc) {
+          missingSavedConnections.add(ws.connectionId);
+          continue;
+        }
         if (sc?.authType.type === 'Password') {
           let hasVault = false;
           try {
@@ -290,7 +316,9 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
 
       const initialStatuses: Record<string, ConnectionStatus> = {};
       for (const [, ws] of toReconnect) {
-        initialStatuses[ws.connectionId] = skipPasswordAutoReconnect.has(ws.connectionId)
+        initialStatuses[ws.connectionId] =
+          skipPasswordAutoReconnect.has(ws.connectionId) ||
+          missingSavedConnections.has(ws.connectionId)
           ? 'error'
           : 'connecting';
       }
@@ -328,10 +356,20 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
             return { ok: true as const, connected: { workspace, connectionId: workspace.connectionId } };
           }
 
+          if (missingSavedConnections.has(workspace.connectionId)) {
+            log.info('Skipping remote workspace restore because its saved connection is gone', {
+              connectionId: workspace.connectionId,
+              remotePath: workspace.remotePath,
+            });
+            await forgetRemoteWorkspace(workspace);
+            return { ok: false as const };
+          }
+
           if (skipPasswordAutoReconnect.has(workspace.connectionId)) {
             log.info('Skipping auto-reconnect: password auth but no stored password', {
               connectionId: workspace.connectionId,
             });
+            await forgetRemoteWorkspace(workspace);
             return { ok: false as const };
           }
 
@@ -339,7 +377,7 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
             connectionId: workspace.connectionId,
             remotePath: workspace.remotePath,
           });
-          const result = await tryReconnectWithRetry(workspace, 5, 5000);
+          const result = await tryReconnectWithRetry(workspace, 1, 5000);
 
           if (result !== false) {
             log.info('Reconnection successful', { newConnectionId: result.connectionId });
@@ -371,14 +409,7 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
             connectionId: workspace.connectionId,
             auth: savedConn?.authType.type,
           });
-          if (savedConn?.authType.type === 'Password') {
-            // Keep workspace in sidebar; user reconnects manually. No auto password dialog.
-            setWorkspaceStatus(workspace.connectionId, 'error');
-          } else {
-            await workspaceManager
-              .removeRemoteWorkspace(workspace.connectionId, workspace.remotePath)
-              .catch(() => {});
-          }
+          await forgetRemoteWorkspace(workspace);
           return { ok: false as const };
         })
       );
@@ -397,7 +428,7 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
     } catch (e) {
       log.error('checkRemoteWorkspace failed', e);
     }
-  }, [setWorkspaceStatus, tryReconnectWithRetry]);
+  }, [forgetRemoteWorkspace, setWorkspaceStatus, tryReconnectWithRetry]);
   checkRemoteWorkspaceRef.current = checkRemoteWorkspace;
 
   // Wait for workspace manager to finish loading, then check remote workspaces

--- a/src/web-ui/src/features/ssh-remote/sshApi.ts
+++ b/src/web-ui/src/features/ssh-remote/sshApi.ts
@@ -228,6 +228,13 @@ export const sshApi = {
   },
 
   /**
+   * Remove one persisted remote workspace restore entry without requiring it to be active.
+   */
+  async removeWorkspace(connectionId: string, remotePath: string): Promise<void> {
+    return api.invoke('remote_remove_workspace', { connectionId, remotePath });
+  },
+
+  /**
    * Get current remote workspace info
    */
   async getWorkspaceInfo(): Promise<RemoteWorkspace | null> {


### PR DESCRIPTION
## Summary
- prune saved Remote SSH password profiles that cannot be restored because their local password vault entry is missing
- remove stale remote workspace restore records when their saved SSH connection is gone or reconnect cannot recover them
- save SSH profiles only after a successful connection, and reject saving password profiles without a password or existing vault entry
- add a precise desktop API for removing a single persisted remote workspace restore record

## Root Cause
Remote SSH profiles could be persisted before authentication completed. After a client upgrade, this could leave password-based saved connections without a recoverable local password. Startup restore then kept retrying or showing the remote workspace in an error state, and the broken saved profile could hide the matching SSH config host from the connection dialog.

## Validation
- `cargo test -p bitfun-core remote_ssh::manager::tests -- --nocapture`
- `pnpm --dir src/web-ui run type-check`
- `pnpm run lint:web`
- `cargo check -p bitfun-desktop`
- previously also ran `pnpm --dir src/web-ui run test:run`, `cargo test -p bitfun-desktop`, and `cargo check --workspace`
