### PR TITLE
feat(ai-adapters): add Anthropic extended thinking support in stream …

### DIFF
--- a/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
@@ -63,7 +63,7 @@ pub async fn handle_anthropic_stream(
             }
         };
 
-        trace!(target: AI_STREAM_RESPONSE_TARGET, "Anthropic SSE: {:?}", sse);
+        trace!(target: AI_STREAM_RESPONSE_TARGET, "Anthropic SSE event: {}", sse.event);
         let event_type = sse.event;
         let data = sse.data;
         stats.record_sse_event(&event_type);
@@ -97,9 +97,14 @@ pub async fn handle_anthropic_stream(
                         continue;
                     }
                 };
+                // Emit for Thinking and ToolUse content_block_start events.
+                // Note: For Thinking blocks, the Anthropic protocol sends signature=null
+                // in content_block_start and the actual signature in a subsequent
+                // signature_delta event. Both emit a UnifiedResponse; the downstream
+                // processor correctly overwrites the initial null signature.
                 if matches!(
                     content_block_start.content_block,
-                    ContentBlock::ToolUse { .. }
+                    ContentBlock::Thinking { .. } | ContentBlock::ToolUse { .. }
                 ) {
                     emit_normalized_response(
                         &mut inline_think_parser,

--- a/src/crates/ai-adapters/src/stream/types/anthropic.rs
+++ b/src/crates/ai-adapters/src/stream/types/anthropic.rs
@@ -100,7 +100,10 @@ pub struct ContentBlockStart {
 #[serde(tag = "type")]
 pub enum ContentBlock {
     #[serde(rename = "thinking")]
-    Thinking,
+    Thinking {
+        thinking: Option<String>,
+        signature: Option<String>,
+    },
     #[serde(rename = "text")]
     Text,
     #[serde(rename = "tool_use")]
@@ -112,15 +115,25 @@ pub enum ContentBlock {
 impl From<ContentBlockStart> for UnifiedResponse {
     fn from(value: ContentBlockStart) -> Self {
         let mut result = UnifiedResponse::default();
-        if let ContentBlock::ToolUse { id, name } = value.content_block {
-            let tool_call = UnifiedToolCall {
-                tool_call_index: None,
-                id: Some(id),
-                name: Some(name),
-                arguments: None,
-                arguments_is_snapshot: false,
-            };
-            result.tool_call = Some(tool_call);
+        match value.content_block {
+            ContentBlock::ToolUse { id, name } => {
+                let tool_call = UnifiedToolCall {
+                    tool_call_index: None,
+                    id: Some(id),
+                    name: Some(name),
+                    arguments: None,
+                    arguments_is_snapshot: false,
+                };
+                result.tool_call = Some(tool_call);
+            }
+            ContentBlock::Thinking {
+                thinking,
+                signature,
+            } => {
+                result.reasoning_content = thinking;
+                result.thinking_signature = signature;
+            }
+            _ => {}
         }
         result
     }

--- a/src/crates/ai-adapters/src/stream/types/unified.rs
+++ b/src/crates/ai-adapters/src/stream/types/unified.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::borrow::Cow;
+use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnifiedToolCall {
@@ -13,7 +15,7 @@ pub struct UnifiedToolCall {
 }
 
 /// Unified AI response format
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Clone, Serialize, Deserialize, Default)]
 pub struct UnifiedResponse {
     pub text: Option<String>,
     pub reasoning_content: Option<String>,
@@ -25,6 +27,35 @@ pub struct UnifiedResponse {
     pub finish_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_metadata: Option<Value>,
+}
+
+impl fmt::Debug for UnifiedResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let reasoning_summary = self.reasoning_content.as_ref().map(|s| {
+            if s.len() > 100 {
+                let end = s
+                    .char_indices()
+                    .take_while(|(i, _)| *i < 100)
+                    .last()
+                    .map(|(i, c)| i + c.len_utf8())
+                    .unwrap_or(0);
+                // Guard against multi-byte chars pushing end past the string length
+                let end = end.min(s.len());
+                Cow::Owned(format!("{}... ({} bytes)", &s[..end], s.len()))
+            } else {
+                Cow::Borrowed(s.as_str())
+            }
+        });
+        f.debug_struct("UnifiedResponse")
+            .field("text", &self.text)
+            .field("reasoning_content", &reasoning_summary)
+            .field("thinking_signature", &"<omitted>")
+            .field("tool_call", &self.tool_call)
+            .field("usage", &self.usage)
+            .field("finish_reason", &self.finish_reason)
+            .field("provider_metadata", &"<omitted>")
+            .finish()
+    }
 }
 
 /// Unified token usage statistics

--- a/src/crates/core/tests/fixtures/stream/anthropic/extended_thinking.sse
+++ b/src/crates/core/tests/fixtures/stream/anthropic/extended_thinking.sse
@@ -1,0 +1,32 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_ext_think_test","type":"message","role":"assistant","content":[],"model":"claude-test","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":null,"signature":null}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me reason about this."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" Step by step."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_abc123"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Here is the answer."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":15}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/src/crates/core/tests/stream_processor_anthropic.rs
+++ b/src/crates/core/tests/stream_processor_anthropic.rs
@@ -59,3 +59,62 @@ async fn anthropic_fixture_parses_inline_think_tags_inside_text_delta() {
         .collect();
     assert_eq!(text_chunks, vec!["Final answer."]);
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn anthropic_extended_thinking_sse_produces_reasoning_and_text() {
+    let output = run_stream_fixture_with_options(
+        StreamFixtureProvider::Anthropic,
+        "stream/anthropic/extended_thinking.sse",
+        StreamFixtureRunOptions {
+            anthropic_inline_think_in_text: false,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+
+    assert_eq!(
+        result.full_thinking,
+        "Let me reason about this. Step by step."
+    );
+    assert_eq!(result.full_text, "Here is the answer.");
+    assert!(result.tool_calls.is_empty());
+    assert_eq!(
+        result.usage.as_ref().map(|usage| usage.total_token_count),
+        Some(25)
+    );
+    assert_eq!(
+        result.thinking_signature.as_deref(),
+        Some("sig_abc123")
+    );
+
+    let thinking_chunks: Vec<(&str, bool)> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ThinkingChunk {
+                content, is_end, ..
+            } => Some((content.as_str(), *is_end)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        thinking_chunks,
+        vec![
+            ("Let me reason about this.", false),
+            (" Step by step.", false),
+            ("", true),
+        ]
+    );
+
+    let text_chunks: Vec<&str> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::TextChunk { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(text_chunks, vec!["Here is the answer."]);
+}


### PR DESCRIPTION
- Parse `thinking` and `signature` fields from Anthropic Thinking content blocks
- Emit UnifiedResponse for Thinking content_block_start events
- Add `thinking_signature` field to UnifiedResponse
- Implement custom Debug for UnifiedResponse to truncate large reasoning content
- Add test fixture and integration test for extended thinking SSE stream