### PR TITLE
fix: reset chat input mode after assistant sessions

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -39,6 +39,7 @@ import { Tooltip, IconButton } from '@/component-library';
 import { useAgentCanvasStore } from '@/app/components/panels/content-canvas/stores';
 import { openBtwSessionInAuxPane, selectActiveBtwSessionTab } from '../services/openBtwSession';
 import { resolveSessionRelationship } from '../utils/sessionMetadata';
+import { resolveWorkspaceChatInputMode } from '../utils/chatInputMode';
 import { useSceneStore } from '@/app/stores/sceneStore';
 import type { SceneTabId } from '@/app/components/SceneBar/types';
 import type { SkillInfo } from '@/infrastructure/config/types';
@@ -270,6 +271,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const [tokenUsage, setTokenUsage] = React.useState({ current: 0, max: 128128 });
   const isAssistantWorkspace = workspace?.workspaceKind === WorkspaceKind.Assistant;
   const currentMode = modeState.current;
+  const activeSessionMode = effectiveTargetSessionId
+    ? flowChatState.sessions.get(effectiveTargetSessionId)?.mode
+    : undefined;
   const canSwitchModes = !isAssistantWorkspace && currentMode !== 'Cowork';
 
   // Session-level mode policy: Cowork sessions are fixed; code sessions should not switch into Cowork.
@@ -769,30 +773,27 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   }, []);
 
   React.useEffect(() => {
-    if (!effectiveTargetSessionId) return;
-    
-    const store = FlowChatStore.getInstance();
-    const state = store.getState();
-    const session = state.sessions.get(effectiveTargetSessionId);
-    
-    if (session?.mode) {
-      log.debug('Session ID changed, syncing mode', { sessionId: effectiveTargetSessionId, mode: session.mode });
-      dispatchMode({ type: 'SET_CURRENT_MODE', payload: session.mode });
+    const nextMode = resolveWorkspaceChatInputMode({
+      currentMode,
+      isAssistantWorkspace,
+      sessionMode: activeSessionMode,
+    });
+
+    if (nextMode) {
+      log.debug('Syncing mode with workspace and session', {
+        sessionId: effectiveTargetSessionId,
+        mode: nextMode,
+        sessionMode: activeSessionMode,
+        isAssistantWorkspace,
+      });
+      dispatchMode({ type: 'SET_CURRENT_MODE', payload: nextMode });
       try {
-        sessionStorage.setItem('bitfun:flowchat:lastMode', session.mode);
+        sessionStorage.setItem('bitfun:flowchat:lastMode', nextMode);
       } catch {
         // ignore
       }
     }
-  }, [effectiveTargetSessionId]);
-
-  React.useEffect(() => {
-    if (!isAssistantWorkspace || currentMode === 'Claw') {
-      return;
-    }
-
-    dispatchMode({ type: 'SET_CURRENT_MODE', payload: 'Claw' });
-  }, [currentMode, isAssistantWorkspace]);
+  }, [activeSessionMode, currentMode, effectiveTargetSessionId, isAssistantWorkspace]);
 
   React.useEffect(() => {
     const queuedInput = derivedState?.queuedInput;

--- a/src/web-ui/src/flow_chat/utils/chatInputMode.test.ts
+++ b/src/web-ui/src/flow_chat/utils/chatInputMode.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveWorkspaceChatInputMode } from './chatInputMode';
+
+describe('resolveWorkspaceChatInputMode', () => {
+  it('forces Claw inside assistant workspaces', () => {
+    expect(
+      resolveWorkspaceChatInputMode({
+        currentMode: 'agentic',
+        isAssistantWorkspace: true,
+        sessionMode: 'agentic',
+      })
+    ).toBe('Claw');
+  });
+
+  it('keeps non-Claw project modes unchanged', () => {
+    expect(
+      resolveWorkspaceChatInputMode({
+        currentMode: 'Plan',
+        isAssistantWorkspace: false,
+        sessionMode: 'Plan',
+      })
+    ).toBeNull();
+  });
+
+  it('syncs when switching between project sessions with different modes', () => {
+    expect(
+      resolveWorkspaceChatInputMode({
+        currentMode: 'Plan',
+        isAssistantWorkspace: false,
+        sessionMode: 'agentic',
+      })
+    ).toBe('agentic');
+  });
+
+  it('restores a project session mode after a transient assistant workspace state', () => {
+    expect(
+      resolveWorkspaceChatInputMode({
+        currentMode: 'Claw',
+        isAssistantWorkspace: false,
+        sessionMode: 'agentic',
+      })
+    ).toBe('agentic');
+  });
+
+  it('restores Cowork when a project Cowork session inherited the Claw UI mode', () => {
+    expect(
+      resolveWorkspaceChatInputMode({
+        currentMode: 'Claw',
+        isAssistantWorkspace: false,
+        sessionMode: 'Cowork',
+      })
+    ).toBe('Cowork');
+  });
+
+  it('falls back to agentic if a project session has no mode yet', () => {
+    expect(
+      resolveWorkspaceChatInputMode({
+        currentMode: 'Claw',
+        isAssistantWorkspace: false,
+        sessionMode: undefined,
+      })
+    ).toBe('agentic');
+  });
+});

--- a/src/web-ui/src/flow_chat/utils/chatInputMode.ts
+++ b/src/web-ui/src/flow_chat/utils/chatInputMode.ts
@@ -1,0 +1,25 @@
+export function resolveWorkspaceChatInputMode(params: {
+  currentMode: string;
+  isAssistantWorkspace: boolean;
+  sessionMode?: string | null;
+}): string | null {
+  const normalizedSessionMode = params.sessionMode?.trim();
+
+  if (params.isAssistantWorkspace) {
+    return params.currentMode === 'Claw' ? null : 'Claw';
+  }
+
+  if (normalizedSessionMode?.toLowerCase() === 'claw') {
+    return null;
+  }
+
+  if (normalizedSessionMode && normalizedSessionMode !== params.currentMode) {
+    return normalizedSessionMode;
+  }
+
+  if (!normalizedSessionMode && params.currentMode === 'Claw') {
+    return 'agentic';
+  }
+
+  return null;
+}

--- a/src/web-ui/src/tools/generative-widget/GenerativeWidgetFrame.tsx
+++ b/src/web-ui/src/tools/generative-widget/GenerativeWidgetFrame.tsx
@@ -519,7 +519,7 @@ export const GENERATIVE_WIDGET_SHELL_HTML = `<!DOCTYPE html>
       }
 
       function normalizeSpace(value) {
-        return String(value || '').replace(/\s+/g, ' ').trim();
+        return String(value || '').replace(/\\s+/g, ' ').trim();
       }
 
       function truncateText(value, maxLength) {
@@ -593,7 +593,7 @@ export const GENERATIVE_WIDGET_SHELL_HTML = `<!DOCTYPE html>
         }
         var className = normalizeSpace(element.getAttribute('class'));
         if (className) {
-          parts.push('.' + className.split(/\s+/).slice(0, 2).join('.'));
+          parts.push('.' + className.split(/\\s+/).slice(0, 2).join('.'));
         }
         return truncateText(parts.join(' '), 96);
       }


### PR DESCRIPTION
## Summary
- Reset the chat input mode from the active session when leaving assistant workspaces, preventing stale `Claw` tags in newly opened Code or Cowork sessions.
- Add focused regression coverage for assistant-to-project mode transitions.
- Fix escaped whitespace regexes in the generative widget shell template so lint stays clean and iframe scripts receive the intended regex.

## Test plan
- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run`