### PR TITLE
fix(web-ui): clarify terminal tool execution phases

### DIFF
--- a/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
@@ -63,7 +63,7 @@ pub async fn handle_anthropic_stream(
             }
         };
 
-        trace!(target: AI_STREAM_RESPONSE_TARGET, "Anthropic SSE event: {}", sse.event);
+        trace!(target: AI_STREAM_RESPONSE_TARGET, "Anthropic SSE: {:?}", sse);
         let event_type = sse.event;
         let data = sse.data;
         stats.record_sse_event(&event_type);

--- a/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.tsx
@@ -15,6 +15,7 @@ import './BaseToolCard.scss';
 const LOADING_SHIMMER_STATUSES = new Set([
   'preparing',
   'streaming',
+  'receiving',
   'running',
   'analyzing',
 ]);
@@ -25,7 +26,7 @@ function statusUsesLoadingShimmer(status: string): boolean {
 
 export interface BaseToolCardProps {
   /** Tool status */
-  status: 'pending' | 'preparing' | 'streaming' | 'running' | 'completed' | 'error' | 'cancelled' | 'analyzing' | 'pending_confirmation' | 'confirmed';
+  status: 'pending' | 'preparing' | 'streaming' | 'receiving' | 'running' | 'completed' | 'error' | 'cancelled' | 'analyzing' | 'pending_confirmation' | 'confirmed';
   /** Whether expanded */
   isExpanded?: boolean;
   /** Card click callback */

--- a/src/web-ui/src/flow_chat/tool-cards/CompactToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CompactToolCard.tsx
@@ -17,6 +17,7 @@ export interface CompactToolCardProps {
     | 'pending'
     | 'preparing'
     | 'streaming'
+    | 'receiving'
     | 'running'
     | 'completed'
     | 'error'
@@ -56,6 +57,7 @@ export const CompactToolCard: React.FC<CompactToolCardProps> = ({
   const loadingShimmer =
     status === 'preparing' ||
     status === 'streaming' ||
+    status === 'receiving' ||
     status === 'running' ||
     status === 'analyzing';
 

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
@@ -1,6 +1,9 @@
 /**
  * Terminal tool card component
- * Displays command execution output (streaming progress + final result)
+ * Displays command execution lifecycle:
+ * - receive tool parameters
+ * - wait for terminal output after launch
+ * - stream real output and final result
  *
  * Design notes:
  * - Final lifecycle always comes from backend tool status
@@ -12,7 +15,6 @@
 
 import React, { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { TFunction } from 'i18next';
 import type { ToolCardProps } from '../types/flow-chat';
 import { Terminal, Play, X, ExternalLink, Square } from 'lucide-react';
 import { createTerminalTab } from '@/shared/utils/tabUtils';
@@ -21,6 +23,7 @@ import { CubeLoading, IconButton, Tooltip } from '../../component-library';
 import { TerminalOutputRenderer } from '@/tools/terminal/components';
 import { createLogger } from '@/shared/utils/logger';
 import { useToolCardHeightContract, type ToolCardCollapseReason } from './useToolCardHeightContract';
+import { getTerminalViewState, type TerminalViewState } from './terminalToolCardState';
 import './TerminalToolCard.scss';
 
 const log = createLogger('TerminalToolCard');
@@ -42,19 +45,6 @@ interface ParsedTerminalResult {
   executionTimeMs?: number;
   wasInterrupted: boolean;
   terminalSessionId?: string;
-}
-
-interface TerminalViewState {
-  isLoading: boolean;
-  isFailed: boolean;
-  showInterruptButton: boolean;
-  showLiveOutput: boolean;
-  showWaiting: boolean;
-  showCompletedResult: boolean;
-  showCancelledResult: boolean;
-  hasHeaderExtra: boolean;
-  statusLabel: string | null;
-  statusClassName: string | null;
 }
 
 function normalizeTerminalSessionId(value: unknown): string | undefined {
@@ -85,60 +75,18 @@ function getAutoExpandedStateForTerminalStatus(status: string): boolean | null {
   return null;
 }
 
-function getTerminalViewState(params: {
-  status: string;
-  liveOutput: string;
-  interruptRequested: boolean;
-  showConfirmButtons: boolean;
-  wasInterrupted: boolean;
-  t: TFunction<'flow-chat'>;
-}): TerminalViewState {
-  const { status, liveOutput, interruptRequested, showConfirmButtons, wasInterrupted, t } = params;
-  const isRunning = status === 'running';
-  const isStreaming = status === 'streaming';
-  const isActive = isRunning || isStreaming;
-  const isLoading = status === 'preparing' || isActive;
-  const showInterruptButton = isRunning && !interruptRequested;
-
-  let statusLabel: string | null = null;
-  let statusClassName: string | null = null;
-
-  if (status === 'rejected') {
-    statusLabel = t('toolCards.terminal.rejected');
-    statusClassName = 'status-rejected';
-  } else if ((interruptRequested && isRunning) || wasInterrupted || status === 'cancelled') {
-    statusLabel = t('toolCards.terminal.cancelled');
-    statusClassName = 'status-cancelled';
-  } else if (status === 'error') {
-    statusLabel = t('toolCards.terminal.failed');
-    statusClassName = 'status-error';
-  }
-
-  return {
-    isLoading,
-    isFailed: status === 'error',
-    showInterruptButton,
-    showLiveOutput: isActive && liveOutput.length > 0,
-    showWaiting: isActive && liveOutput.length === 0,
-    showCompletedResult: status === 'completed',
-    showCancelledResult: status === 'cancelled' && liveOutput.length > 0,
-    hasHeaderExtra: Boolean(statusLabel || showConfirmButtons || showInterruptButton),
-    statusLabel,
-    statusClassName,
-  };
-}
-
 function renderTerminalExpandedContent(params: {
   viewState: TerminalViewState;
   liveOutput: string;
   parsedResult: ParsedTerminalResult;
-  t: TFunction<'flow-chat'>;
+  waitingMessage: string | null;
+  t: (key: string, options?: Record<string, unknown>) => string;
 }): React.ReactNode {
-  const { viewState, liveOutput, parsedResult, t } = params;
+  const { viewState, liveOutput, parsedResult, waitingMessage, t } = params;
 
   return (
     <>
-      {viewState.showLiveOutput && (
+      {viewState.displayPhase === 'live_output' && (
         <div className="terminal-execution-output">
           <TerminalOutputRenderer
             content={liveOutput}
@@ -148,9 +96,9 @@ function renderTerminalExpandedContent(params: {
         </div>
       )}
 
-      {viewState.showWaiting && (
+      {(viewState.displayPhase === 'receiving_params' || viewState.displayPhase === 'executing') && waitingMessage && (
         <div className="terminal-execution-output terminal-waiting">
-          <span className="waiting-text">{t('toolCards.terminal.executingCommand')}</span>
+          <span className="waiting-text">{waitingMessage}</span>
         </div>
       )}
 
@@ -267,6 +215,7 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
   const toolResult = toolItem.toolResult;
   const command = toolCall?.input?.command;
   const status = toolItem.status || 'pending';
+  const isParamsStreaming = Boolean(toolItem.isParamsStreaming);
   const progressMessage = typeof (toolItem as any)._progressMessage === 'string'
     ? (toolItem as any)._progressMessage
     : '';
@@ -398,19 +347,20 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
     return getTerminalViewState({
       status,
       liveOutput,
+      isParamsStreaming,
       interruptRequested,
       showConfirmButtons,
       wasInterrupted: parsedResult.wasInterrupted,
-      t,
     });
   }, [
+    isParamsStreaming,
     interruptRequested,
     liveOutput,
     parsedResult.wasInterrupted,
     showConfirmButtons,
     status,
-    t,
   ]);
+  const waitingMessage = viewState.waitingMessageKey ? t(viewState.waitingMessageKey) : null;
 
   const handleExecute = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -524,7 +474,7 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
 
     return (
       <span className={`terminal-status-text ${viewState.statusClassName}`}>
-        {viewState.statusLabel}
+        {t(`toolCards.terminal.${viewState.statusLabel}`)}
       </span>
     );
   };
@@ -584,7 +534,7 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
     />
   );
   const expandedContent = isExpanded
-    ? renderTerminalExpandedContent({ viewState, liveOutput, parsedResult, t })
+    ? renderTerminalExpandedContent({ viewState, liveOutput, parsedResult, waitingMessage, t })
     : null;
   const errorContent = viewState.isFailed
     ? renderTerminalErrorContent(toolResult?.error || t('toolCards.terminal.executionFailed'))

--- a/src/web-ui/src/flow_chat/tool-cards/terminalToolCardState.test.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/terminalToolCardState.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTerminalViewState } from './terminalToolCardState';
+
+describe('terminalToolCardState', () => {
+  it('shows receiving params while bash input is still streaming', () => {
+    const state = getTerminalViewState({
+      status: 'streaming',
+      liveOutput: '',
+      isParamsStreaming: true,
+      interruptRequested: false,
+      showConfirmButtons: false,
+      wasInterrupted: false,
+    });
+
+    expect(state.displayPhase).toBe('receiving_params');
+    expect(state.waitingMessageKey).toBe('toolCards.terminal.receivingParams');
+  });
+
+  it('shows executing after params finish but before command output arrives', () => {
+    const state = getTerminalViewState({
+      status: 'running',
+      liveOutput: '',
+      isParamsStreaming: false,
+      interruptRequested: false,
+      showConfirmButtons: false,
+      wasInterrupted: false,
+    });
+
+    expect(state.displayPhase).toBe('executing');
+    expect(state.waitingMessageKey).toBe('toolCards.terminal.executingCommand');
+  });
+
+  it('prefers real terminal output even if params streaming flag lags behind', () => {
+    const state = getTerminalViewState({
+      status: 'streaming',
+      liveOutput: 'npm test\n',
+      isParamsStreaming: true,
+      interruptRequested: false,
+      showConfirmButtons: false,
+      wasInterrupted: false,
+    });
+
+    expect(state.displayPhase).toBe('live_output');
+    expect(state.waitingMessageKey).toBeNull();
+  });
+
+  it('switches to completed result once the tool finishes', () => {
+    const state = getTerminalViewState({
+      status: 'completed',
+      liveOutput: 'partial output',
+      isParamsStreaming: false,
+      interruptRequested: false,
+      showConfirmButtons: false,
+      wasInterrupted: false,
+    });
+
+    expect(state.displayPhase).toBe('completed');
+    expect(state.showCompletedResult).toBe(true);
+  });
+});

--- a/src/web-ui/src/flow_chat/tool-cards/terminalToolCardState.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/terminalToolCardState.ts
@@ -1,0 +1,135 @@
+export type TerminalWaitingMessageKey =
+  | 'toolCards.terminal.receivingParams'
+  | 'toolCards.terminal.executingCommand';
+
+export type TerminalDisplayPhase =
+  | 'idle'
+  | 'receiving_params'
+  | 'executing'
+  | 'live_output'
+  | 'completed'
+  | 'cancelled_output';
+
+export interface TerminalViewState {
+  isLoading: boolean;
+  isFailed: boolean;
+  showInterruptButton: boolean;
+  showCompletedResult: boolean;
+  showCancelledResult: boolean;
+  hasHeaderExtra: boolean;
+  statusLabel: 'rejected' | 'cancelled' | 'failed' | null;
+  statusClassName: 'status-rejected' | 'status-cancelled' | 'status-error' | null;
+  displayPhase: TerminalDisplayPhase;
+  waitingMessageKey: TerminalWaitingMessageKey | null;
+}
+
+interface GetTerminalViewStateParams {
+  status: string;
+  liveOutput: string;
+  isParamsStreaming: boolean;
+  interruptRequested: boolean;
+  showConfirmButtons: boolean;
+  wasInterrupted: boolean;
+}
+
+function deriveDisplayPhase(params: {
+  status: string;
+  liveOutput: string;
+  isParamsStreaming: boolean;
+}): Pick<TerminalViewState, 'displayPhase' | 'waitingMessageKey'> {
+  const { status, liveOutput, isParamsStreaming } = params;
+  const hasLiveOutput = liveOutput.length > 0;
+
+  if (status === 'completed') {
+    return {
+      displayPhase: 'completed',
+      waitingMessageKey: null,
+    };
+  }
+
+  if (status === 'cancelled' && hasLiveOutput) {
+    return {
+      displayPhase: 'cancelled_output',
+      waitingMessageKey: null,
+    };
+  }
+
+  if (hasLiveOutput && (status === 'streaming' || status === 'running' || status === 'receiving')) {
+    return {
+      displayPhase: 'live_output',
+      waitingMessageKey: null,
+    };
+  }
+
+  if (isParamsStreaming && (status === 'preparing' || status === 'streaming' || status === 'receiving')) {
+    return {
+      displayPhase: 'receiving_params',
+      waitingMessageKey: 'toolCards.terminal.receivingParams',
+    };
+  }
+
+  if (status === 'running' || status === 'streaming' || status === 'receiving') {
+    return {
+      displayPhase: 'executing',
+      waitingMessageKey: 'toolCards.terminal.executingCommand',
+    };
+  }
+
+  return {
+    displayPhase: 'idle',
+    waitingMessageKey: null,
+  };
+}
+
+export function getTerminalViewState(
+  params: GetTerminalViewStateParams,
+): TerminalViewState {
+  const {
+    status,
+    liveOutput,
+    isParamsStreaming,
+    interruptRequested,
+    showConfirmButtons,
+    wasInterrupted,
+  } = params;
+  const isRunning = status === 'running';
+  const isLoading =
+    status === 'preparing' ||
+    status === 'streaming' ||
+    status === 'receiving' ||
+    status === 'running';
+  const showInterruptButton = isRunning && !interruptRequested;
+
+  let statusLabel: TerminalViewState['statusLabel'] = null;
+  let statusClassName: TerminalViewState['statusClassName'] = null;
+
+  if (status === 'rejected') {
+    statusLabel = 'rejected';
+    statusClassName = 'status-rejected';
+  } else if ((interruptRequested && isRunning) || wasInterrupted || status === 'cancelled') {
+    statusLabel = 'cancelled';
+    statusClassName = 'status-cancelled';
+  } else if (status === 'error') {
+    statusLabel = 'failed';
+    statusClassName = 'status-error';
+  }
+
+  const { displayPhase, waitingMessageKey } = deriveDisplayPhase({
+    status,
+    liveOutput,
+    isParamsStreaming,
+  });
+
+  return {
+    isLoading,
+    isFailed: status === 'error',
+    showInterruptButton,
+    showCompletedResult: displayPhase === 'completed',
+    showCancelledResult: displayPhase === 'cancelled_output',
+    hasHeaderExtra: Boolean(statusLabel || showConfirmButtons || showInterruptButton),
+    statusLabel,
+    statusClassName,
+    displayPhase,
+    waitingMessageKey,
+  };
+}

--- a/src/web-ui/src/flow_chat/types/flow-chat.ts
+++ b/src/web-ui/src/flow_chat/types/flow-chat.ts
@@ -14,7 +14,7 @@ export interface FlowItem {
   id: string;
   type: 'text' | 'tool' | 'image-analysis' | 'thinking';
   timestamp: number;
-  status: 'pending' | 'preparing' | 'running' | 'streaming' | 'completed' | 'cancelled' | 'error' | 'analyzing' | 'pending_confirmation' | 'confirmed'; // Includes error, analyzing, and confirmation states.
+  status: 'pending' | 'preparing' | 'running' | 'streaming' | 'receiving' | 'completed' | 'cancelled' | 'error' | 'analyzing' | 'pending_confirmation' | 'confirmed'; // Includes error, analyzing, and confirmation states.
   
   // Subagent markers.
   parentTaskToolId?: string; // Parent Task tool ID.

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -542,6 +542,7 @@
       "cancelled": "Cancelled",
       "completed": "Completed",
       "failed": "Execution failed",
+      "receivingParams": "Receiving parameters...",
       "executingCommand": "Executing command...",
       "workingDirectory": "Working directory:",
       "exitCode": "Exit code: {{code}}",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -542,6 +542,7 @@
       "cancelled": "已取消",
       "completed": "已完成",
       "failed": "执行失败",
+      "receivingParams": "接收参数中...",
       "executingCommand": "正在执行命令...",
       "workingDirectory": "工作目录:",
       "exitCode": "退出码: {{code}}",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -512,6 +512,7 @@
       "cancelled": "已取消",
       "completed": "已完成",
       "failed": "執行失敗",
+      "receivingParams": "接收參數中...",
       "executingCommand": "正在執行命令...",
       "workingDirectory": "工作目錄:",
       "exitCode": "退出碼: {{code}}",


### PR DESCRIPTION
- show "receiving parameters" while bash tool args are still streaming
- show "executing command" only after params are complete and before first output arrives
- render live terminal output as soon as ToolExecutionProgress is received
- extract terminal card phase logic into a dedicated state helper with tests
- add terminal receivingParams locale copy and align receiving status types
