### PR TITLE
fix(ui): remove dense dividers in todo list and fix window state sync

### DIFF
--- a/src/web-ui/src/app/hooks/useWindowControls.ts
+++ b/src/web-ui/src/app/hooks/useWindowControls.ts
@@ -141,9 +141,10 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
     const setupListener = async () => {
       try {
         const appWindow = getCurrentWindow();
-        
-        // Get initial state (only when visible)
-        await updateWindowState(appWindow);
+
+        // Get initial state (skip visibility check so we still sync
+        // when the window is maximized before it becomes visible)
+        await updateWindowState(appWindow, true);
         await restoreMacOSOverlayTitlebar(appWindow);
         
         // Listen for resize (with debounce and visibility checks)

--- a/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.scss
@@ -239,15 +239,10 @@
   .todo-item {
     display: flex;
     align-items: center;
-    padding: 5px 10px;
+    padding: 6px 10px;
     font-size: 11px;
     transition: background 0.12s ease;
-    border-bottom: 1px solid var(--border-subtle);
     position: relative;
-
-    &:last-child {
-      border-bottom: none;
-    }
 
     &:hover {
       background: var(--element-bg-subtle, rgba(255, 255, 255, 0.04));


### PR DESCRIPTION
- Remove border-bottom from todo items in TodoWriteDisplay for cleaner look
- Slightly increase todo item padding (5px -> 6px)
- Fix useWindowControls to sync maximized state even when window not yet visible