### PR TITLE
feat(ui): memory library overlay and agentic OS memory paths

### DIFF
--- a/src/apps/desktop/src/api/storage_commands.rs
+++ b/src/apps/desktop/src/api/storage_commands.rs
@@ -14,6 +14,7 @@ pub struct StoragePathsInfo {
     pub cache_root: PathBuf,
     pub logs_dir: PathBuf,
     pub temp_dir: PathBuf,
+    pub agentic_os_memory_dir: PathBuf,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -37,6 +38,7 @@ pub async fn get_storage_paths(state: State<'_, AppState>) -> Result<StoragePath
         cache_root: path_manager.cache_root(),
         logs_dir: path_manager.logs_dir(),
         temp_dir: path_manager.temp_dir(),
+        agentic_os_memory_dir: path_manager.agentic_os_memory_dir(),
     })
 }
 

--- a/src/web-ui/src/app/components/WorkspaceFooterActions/WorkspaceFooterActions.tsx
+++ b/src/web-ui/src/app/components/WorkspaceFooterActions/WorkspaceFooterActions.tsx
@@ -6,6 +6,7 @@ import {
   Orbit,
   RotateCcw,
   User,
+  Brain,
   AppWindow,
   ChevronDown,
   Puzzle,
@@ -136,6 +137,11 @@ const WorkspaceFooterActions: React.FC = () => {
     switchLeftPanelTab,
   ]);
 
+  const handleOpenMemory = useCallback(() => {
+    closeMenu();
+    openOverlay('memory');
+  }, [closeMenu, openOverlay]);
+
   const handleOpenApps = useCallback(() => {
     closeMenu();
     openOverlay('apps');
@@ -162,6 +168,7 @@ const WorkspaceFooterActions: React.FC = () => {
   }, [closeMenu, openOverlay]);
 
   const isAssistantActive = activeOverlay === 'assistant';
+  const isMemoryActive = activeOverlay === 'memory';
   const isAppsActive = activeOverlay === 'apps'
     || (typeof activeOverlay === 'string' && activeOverlay.startsWith('live-app:'));
   const isSkillsActive = activeOverlay === 'skills';
@@ -213,6 +220,16 @@ const WorkspaceFooterActions: React.FC = () => {
                     >
                       <User size={14} />
                       <span>{t('nav.items.persona')}</span>
+                    </button>
+
+                    <button
+                      type="button"
+                      className={`bitfun-nav-panel__footer-menu-item${isMemoryActive ? ' is-active' : ''}`}
+                      role="menuitem"
+                      onClick={handleOpenMemory}
+                    >
+                      <Brain size={14} />
+                      <span>{t('nav.items.memory')}</span>
                     </button>
 
                     <button

--- a/src/web-ui/src/app/overlay/OverlaySceneRenderer.tsx
+++ b/src/web-ui/src/app/overlay/OverlaySceneRenderer.tsx
@@ -17,6 +17,7 @@ import AssistantScene from '../scenes/assistant/AssistantScene';
 
 const TerminalScene     = lazy(() => import('../scenes/terminal/TerminalScene'));
 const FileViewerScene   = lazy(() => import('../scenes/file-viewer/FileViewerScene'));
+const MemoryScene       = lazy(() => import('../scenes/memory/MemoryScene'));
 const ProfileScene      = lazy(() => import('../scenes/profile/ProfileScene'));
 import AppsScene from '../scenes/apps/AppsScene';
 const SubagentsScene    = lazy(() => import('../scenes/subagents/SubagentsScene'));
@@ -66,6 +67,8 @@ function renderOverlayScene(id: OverlaySceneId, workspacePath?: string): React.R
       return <SettingsScene />;
     case 'file-viewer':
       return <FileViewerScene workspacePath={workspacePath} />;
+    case 'memory':
+      return <MemoryScene />;
     case 'profile':
       return <ProfileScene />;
     case 'apps':

--- a/src/web-ui/src/app/overlay/overlayRegistry.ts
+++ b/src/web-ui/src/app/overlay/overlayRegistry.ts
@@ -9,6 +9,7 @@ import {
   Terminal,
   Settings,
   FileCode2,
+  Brain,
   CircleUserRound,
   Users,
   Puzzle,
@@ -38,6 +39,12 @@ export const OVERLAY_SCENE_REGISTRY: OverlaySceneDef[] = [
     label: 'File Viewer',
     labelKey: 'scenes.fileViewer',
     Icon: FileCode2,
+  },
+  {
+    id: 'memory',
+    label: 'Memory',
+    labelKey: 'scenes.memory',
+    Icon: Brain,
   },
   {
     id: 'profile',

--- a/src/web-ui/src/app/overlay/types.ts
+++ b/src/web-ui/src/app/overlay/types.ts
@@ -13,6 +13,7 @@ export type OverlaySceneId =
   | 'terminal'
   | 'settings'
   | 'file-viewer'
+  | 'memory'
   | 'profile'
   | 'apps'
   | 'subagents'

--- a/src/web-ui/src/app/scenes/memory/MemoryLibraryAPI.ts
+++ b/src/web-ui/src/app/scenes/memory/MemoryLibraryAPI.ts
@@ -1,0 +1,302 @@
+import { api } from '@/infrastructure/api/service-api/ApiClient';
+import { configManager } from '@/infrastructure/config/services/ConfigManager';
+import { workspaceAPI, type FileMetadata } from '@/infrastructure/api/service-api/WorkspaceAPI';
+import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
+import { createLogger } from '@/shared/utils/logger';
+
+const log = createLogger('MemoryLibraryAPI');
+
+const MEMORY_INDEX_FILE = 'MEMORY.md';
+const MAX_MEMORY_FILES = 250;
+
+export type MemoryScopeKey = 'global' | 'workspace';
+export type MemoryRecordType = 'index' | 'user' | 'feedback' | 'project' | 'reference' | 'workspace_overview' | 'unknown';
+
+export interface MemoryStoragePaths {
+  userConfigDir: string;
+  userDataDir: string;
+  cacheRoot: string;
+  logsDir: string;
+  tempDir: string;
+  agenticOsMemoryDir: string;
+}
+
+export interface ProjectStoragePaths {
+  projectRoot: string;
+  runtimeRoot: string;
+  agentsDir: string;
+  sessionsDir: string;
+  memoryDir: string;
+  plansDir: string;
+}
+
+export interface MemorySpace {
+  scope: MemoryScopeKey;
+  label: string;
+  memoryDir: string;
+  available: boolean;
+}
+
+export interface MemoryRecord {
+  id: string;
+  scope: MemoryScopeKey;
+  memoryDir: string;
+  path: string;
+  relativePath: string;
+  title: string;
+  description: string;
+  type: MemoryRecordType;
+  content: string;
+  body: string;
+  updatedAt?: number;
+  size?: number;
+  isIndex: boolean;
+  isWorkspaceOverview: boolean;
+}
+
+export interface AutoMemoryStatus {
+  globalEnabled: boolean;
+  globalEvery: number;
+  workspaceEnabled: boolean;
+  workspaceEvery: number;
+}
+
+interface FrontmatterResult {
+  data: Record<string, string>;
+  body: string;
+}
+
+const normalizePath = (path: string) => path.replace(/\\/g, '/');
+
+const joinPath = (basePath: string, child: string): string => {
+  const separator = basePath.includes('\\') ? '\\' : '/';
+  return `${basePath.replace(/[\\/]+$/, '')}${separator}${child.replace(/^[\\/]+/, '')}`;
+};
+
+const relativePath = (memoryDir: string, path: string): string => {
+  const base = normalizePath(memoryDir).replace(/\/+$/, '');
+  const target = normalizePath(path);
+  return target.startsWith(`${base}/`) ? target.slice(base.length + 1) : target;
+};
+
+const parseFrontmatter = (content: string): FrontmatterResult => {
+  if (!content.startsWith('---')) {
+    return { data: {}, body: content };
+  }
+
+  const lines = content.split(/\r?\n/);
+  const endIndex = lines.findIndex((line, index) => index > 0 && line.trim() === '---');
+  if (endIndex < 0) {
+    return { data: {}, body: content };
+  }
+
+  const data: Record<string, string> = {};
+  for (const line of lines.slice(1, endIndex)) {
+    const separatorIndex = line.indexOf(':');
+    if (separatorIndex <= 0) {
+      continue;
+    }
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim().replace(/^['"]|['"]$/g, '');
+    if (key) {
+      data[key] = value;
+    }
+  }
+
+  return {
+    data,
+    body: lines.slice(endIndex + 1).join('\n').trimStart(),
+  };
+};
+
+const titleFromPath = (path: string): string => {
+  const fileName = normalizePath(path).split('/').pop() ?? path;
+  return fileName.replace(/\.md$/i, '').replace(/[-_]+/g, ' ');
+};
+
+const normalizeRecordType = (value: string | undefined, relative: string): MemoryRecordType => {
+  const type = value?.trim().toLowerCase();
+  if (relative === MEMORY_INDEX_FILE) return 'index';
+  if (relative.startsWith('workspaces_overview/')) return 'workspace_overview';
+  if (type === 'user' || type === 'feedback' || type === 'project' || type === 'reference') {
+    return type;
+  }
+  return 'unknown';
+};
+
+async function readMetadata(path: string): Promise<Partial<FileMetadata>> {
+  try {
+    return await workspaceAPI.getFileMetadata(path);
+  } catch (error) {
+    log.warn('Failed to read memory file metadata', { path, error });
+    return {};
+  }
+}
+
+export class MemoryLibraryAPI {
+  async getStoragePaths(): Promise<MemoryStoragePaths> {
+    return api.invoke<MemoryStoragePaths>('get_storage_paths', {});
+  }
+
+  async getProjectStoragePaths(workspacePath: string): Promise<ProjectStoragePaths> {
+    return api.invoke<ProjectStoragePaths>('get_project_storage_paths', { workspacePath });
+  }
+
+  async getAutoMemoryStatus(): Promise<AutoMemoryStatus> {
+    const [
+      globalEnabled,
+      globalEvery,
+      workspaceEnabled,
+      workspaceEvery,
+    ] = await Promise.all([
+      configManager.getConfig<boolean>('ai.auto_memory.global.enabled'),
+      configManager.getConfig<number>('ai.auto_memory.global.extract_every_eligible_turns'),
+      configManager.getConfig<boolean>('ai.auto_memory.workspace.enabled'),
+      configManager.getConfig<number>('ai.auto_memory.workspace.extract_every_eligible_turns'),
+    ]);
+
+    return {
+      globalEnabled: globalEnabled ?? true,
+      globalEvery: globalEvery ?? 6,
+      workspaceEnabled: workspaceEnabled ?? true,
+      workspaceEvery: workspaceEvery ?? 1,
+    };
+  }
+
+  async ensureMemorySpace(memoryDir: string): Promise<void> {
+    const exists = await systemAPI.checkPathExists(memoryDir);
+    if (!exists) {
+      await workspaceAPI.createDirectory(memoryDir);
+    }
+
+    const indexPath = joinPath(memoryDir, MEMORY_INDEX_FILE);
+    const indexExists = await systemAPI.checkPathExists(indexPath);
+    if (!indexExists) {
+      await workspaceAPI.writeFileContent(memoryDir, indexPath, '');
+    }
+  }
+
+  async listMemoryRecords(space: MemorySpace): Promise<MemoryRecord[]> {
+    if (!space.available) {
+      return [];
+    }
+
+    await this.ensureMemorySpace(space.memoryDir);
+    const files = await this.collectMarkdownFiles(space.memoryDir);
+    const sortedFiles = files.sort((left, right) => {
+      if (relativePath(space.memoryDir, left) === MEMORY_INDEX_FILE) return -1;
+      if (relativePath(space.memoryDir, right) === MEMORY_INDEX_FILE) return 1;
+      return relativePath(space.memoryDir, left).localeCompare(relativePath(space.memoryDir, right));
+    });
+
+    const records = await Promise.all(
+      sortedFiles.slice(0, MAX_MEMORY_FILES).map((path) => this.readMemoryRecord(space, path))
+    );
+
+    return records.filter((record): record is MemoryRecord => Boolean(record));
+  }
+
+  async saveMemoryRecord(record: MemoryRecord, content: string): Promise<MemoryRecord> {
+    await workspaceAPI.writeFileContent(record.path, record.path, content);
+    const refreshed = await this.readMemoryRecord(
+      {
+        scope: record.scope,
+        label: record.scope,
+        memoryDir: record.memoryDir,
+        available: true,
+      },
+      record.path
+    );
+    return refreshed ?? { ...record, content };
+  }
+
+  async deleteMemoryRecord(record: MemoryRecord): Promise<void> {
+    await workspaceAPI.deleteFile(record.path);
+  }
+
+  async revealMemoryRecord(record: MemoryRecord): Promise<void> {
+    await workspaceAPI.revealInExplorer(record.path);
+  }
+
+  private async collectMarkdownFiles(memoryDir: string): Promise<string[]> {
+    const collected: string[] = [];
+
+    const visit = async (dir: string): Promise<void> => {
+      if (collected.length >= MAX_MEMORY_FILES) {
+        return;
+      }
+
+      let children;
+      try {
+        children = await workspaceAPI.getDirectoryChildren(dir);
+      } catch (error) {
+        log.warn('Failed to list memory directory', { dir, error });
+        return;
+      }
+
+      for (const child of children) {
+        if (collected.length >= MAX_MEMORY_FILES) {
+          return;
+        }
+        if (child.isDirectory) {
+          await visit(child.path);
+        } else if (child.name.toLowerCase().endsWith('.md')) {
+          collected.push(child.path);
+        }
+      }
+    };
+
+    await visit(memoryDir);
+
+    const indexPath = joinPath(memoryDir, MEMORY_INDEX_FILE);
+    if (!collected.some((path) => normalizePath(path) === normalizePath(indexPath))) {
+      collected.unshift(indexPath);
+    }
+
+    return collected;
+  }
+
+  private async readMemoryRecord(space: MemorySpace, path: string): Promise<MemoryRecord | null> {
+    try {
+      const content = await workspaceAPI.readFileContent(path);
+      const metadata = await readMetadata(path);
+      const rel = relativePath(space.memoryDir, path);
+      const frontmatter = parseFrontmatter(content);
+      const type = normalizeRecordType(frontmatter.data.type, rel);
+      const isIndex = type === 'index';
+      const isWorkspaceOverview = type === 'workspace_overview';
+      const title = isIndex
+        ? 'MEMORY.md'
+        : frontmatter.data.name || titleFromPath(rel);
+
+      return {
+        id: `${space.scope}:${rel}`,
+        scope: space.scope,
+        memoryDir: space.memoryDir,
+        path,
+        relativePath: rel,
+        title,
+        description: frontmatter.data.description || firstContentLine(frontmatter.body),
+        type,
+        content,
+        body: frontmatter.body,
+        updatedAt: typeof metadata.modified === 'number' ? metadata.modified : undefined,
+        size: typeof metadata.size === 'number' ? metadata.size : undefined,
+        isIndex,
+        isWorkspaceOverview,
+      };
+    } catch (error) {
+      log.warn('Failed to read memory record', { path, error });
+      return null;
+    }
+  }
+}
+
+function firstContentLine(content: string): string {
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^#+\s*/, '').trim())
+    .find(Boolean) ?? '';
+}
+
+export const memoryLibraryAPI = new MemoryLibraryAPI();

--- a/src/web-ui/src/app/scenes/memory/MemoryScene.scss
+++ b/src/web-ui/src/app/scenes/memory/MemoryScene.scss
@@ -1,0 +1,463 @@
+@use '../../../component-library/styles/tokens.scss' as *;
+
+.memory-scene {
+  --memory-seal-red: #b23a35;
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  background: var(--color-bg-base);
+  color: var(--color-text-primary);
+  overflow: hidden;
+}
+
+.memory-scene__sidebar {
+  width: 260px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px 14px;
+  border-right: 1px solid var(--border-subtle);
+  background: var(--color-bg-scene, var(--color-bg-primary));
+  overflow-y: auto;
+}
+
+.memory-scene__brand {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  padding: 4px 4px 10px;
+
+  h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 650;
+    letter-spacing: -0.02em;
+  }
+
+  p {
+    margin: 4px 0 0;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 1.45;
+  }
+}
+
+.memory-scene__brand-icon {
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 12px;
+  color: var(--memory-seal-red);
+  background: var(--element-bg-soft);
+}
+
+.memory-scene__scope-list {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.memory-scene__scope-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  min-height: 34px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: $size-radius-sm;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  text-align: left;
+  position: relative;
+  transition: background $motion-fast $easing-standard,
+              color $motion-fast $easing-standard,
+              border-color $motion-fast $easing-standard;
+
+  strong {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+  }
+
+  &:hover {
+    background: var(--element-bg-soft);
+    color: var(--color-text-primary);
+  }
+
+  &.is-active {
+    color: var(--color-text-primary);
+    border-color: var(--border-subtle);
+    background: var(--element-bg-soft);
+
+    &::before {
+      content: '';
+      width: 5px;
+      height: 5px;
+      border-radius: 50%;
+      background: var(--memory-seal-red);
+      position: absolute;
+      left: 4px;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+  }
+}
+
+.memory-scene__status-card,
+.memory-scene__path-card {
+  padding: 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: $size-radius-base;
+  background: color-mix(in srgb, var(--element-bg-soft) 70%, transparent);
+}
+
+.memory-scene__status-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.memory-scene__status-card {
+  p {
+    margin: 8px 0 10px;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 1.45;
+  }
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 28px;
+    padding: 0 10px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 999px;
+    background: var(--element-bg-soft);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-xs);
+    cursor: pointer;
+
+    &:hover {
+      color: var(--color-text-primary);
+      background: var(--element-bg-medium);
+    }
+  }
+}
+
+.memory-scene__path-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  span {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+  }
+
+  code {
+    color: var(--color-text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+    word-break: break-all;
+  }
+}
+
+.memory-scene__main {
+  flex: 1;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(320px, 0.42fr) minmax(420px, 0.58fr);
+  height: 100%;
+  min-height: 0;
+}
+
+.memory-scene__list-pane {
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-right: 1px solid var(--border-subtle);
+  background: var(--color-bg-scene, var(--color-bg-primary));
+}
+
+.memory-scene__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 16px 10px;
+}
+
+.memory-scene__toolbar .search {
+  flex: 1;
+}
+
+.memory-scene__icon-btn {
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: $size-radius-sm;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+
+  &:hover {
+    background: var(--element-bg-soft);
+    color: var(--color-text-primary);
+  }
+}
+
+.memory-scene__type-pills {
+  display: flex;
+  gap: 6px;
+  padding: 0 16px 12px;
+  overflow-x: auto;
+}
+
+.memory-scene__type-pill {
+  height: 28px;
+  padding: 0 11px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--color-text-secondary);
+    background: var(--element-bg-soft);
+  }
+
+  &.is-active {
+    color: var(--color-text-primary);
+    border-color: var(--border-base);
+    background: var(--element-bg-soft);
+
+    &::before {
+      content: '';
+      display: inline-block;
+      width: 5px;
+      height: 5px;
+      margin-right: 6px;
+      border-radius: 50%;
+      vertical-align: 1px;
+      background: var(--memory-seal-red);
+    }
+  }
+}
+
+.memory-scene__records {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 10px 14px;
+}
+
+.memory-scene__record-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  padding: 11px 10px;
+  border: 1px solid transparent;
+  border-radius: $size-radius-base;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background $motion-fast $easing-standard,
+              border-color $motion-fast $easing-standard;
+
+  &:hover {
+    background: var(--element-bg-soft);
+  }
+
+  &.is-selected {
+    background: var(--element-bg-soft);
+    border-color: var(--border-base);
+  }
+}
+
+.memory-scene__record-icon {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 10px;
+  color: var(--color-text-muted);
+  background: var(--element-bg-soft);
+}
+
+.memory-scene__record-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.memory-scene__record-title {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.memory-scene__record-desc {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.memory-scene__record-meta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+  color: var(--color-text-muted);
+  font-size: 11px;
+}
+
+.memory-scene__detail-pane {
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--color-bg-base);
+}
+
+.memory-scene__detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 22px 24px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+
+  h3 {
+    margin: 3px 0 6px;
+    font-size: 22px;
+    font-weight: 650;
+    letter-spacing: -0.02em;
+  }
+
+  p {
+    margin: 0;
+    max-width: 720px;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+  }
+}
+
+.memory-scene__detail-kicker {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  word-break: break-all;
+}
+
+.memory-scene__detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.memory-scene__explain-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 16px 24px 0;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: $size-radius-base;
+  background: var(--element-bg-soft);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  line-height: 1.45;
+
+  svg {
+    color: var(--memory-seal-red);
+  }
+}
+
+.memory-scene__markdown {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 20px 24px 32px;
+}
+
+.memory-scene__editor {
+  flex: 1;
+  min-height: 0;
+  margin: 18px 24px 24px;
+  padding: 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: $size-radius-base;
+  outline: none;
+  resize: none;
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  line-height: 1.55;
+
+  &:focus {
+    border-color: color-mix(in srgb, var(--memory-seal-red) 42%, var(--border-base));
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--memory-seal-red) 10%, transparent);
+  }
+}
+
+.memory-scene__empty,
+.memory-scene__detail-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.memory-scene__detail-empty {
+  flex: 1;
+}
+
+@media (max-width: 1120px) {
+  .memory-scene__sidebar {
+    width: 230px;
+  }
+
+  .memory-scene__main {
+    grid-template-columns: 360px minmax(360px, 1fr);
+  }
+}

--- a/src/web-ui/src/app/scenes/memory/MemoryScene.tsx
+++ b/src/web-ui/src/app/scenes/memory/MemoryScene.tsx
@@ -1,0 +1,420 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Brain,
+  Database,
+  ExternalLink,
+  FileText,
+  FolderOpen,
+  RefreshCcw,
+  Save,
+  Settings,
+  Sparkles,
+  Trash2,
+  X,
+} from 'lucide-react';
+import { Badge, Button, ConfirmDialog, Markdown, Search } from '@/component-library';
+import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
+import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
+import { WorkspaceKind } from '@/shared/types';
+import { notificationService } from '@/shared/notification-system';
+import { useOverlayManager } from '../../hooks/useOverlayManager';
+import { useSettingsStore } from '../settings/settingsStore';
+import {
+  memoryLibraryAPI,
+  type AutoMemoryStatus,
+  type MemoryRecord,
+  type MemoryRecordType,
+  type MemoryScopeKey,
+  type MemorySpace,
+} from './MemoryLibraryAPI';
+import './MemoryScene.scss';
+
+type ScopeFilter = 'all' | MemoryScopeKey | 'workspace_overview';
+type TypeFilter = 'all' | MemoryRecordType;
+
+const MEMORY_TYPES: TypeFilter[] = [
+  'all',
+  'index',
+  'user',
+  'feedback',
+  'project',
+  'reference',
+  'workspace_overview',
+  'unknown',
+];
+
+const SCOPE_FILTERS: ScopeFilter[] = ['all', 'global', 'workspace', 'workspace_overview'];
+
+function formatDate(timestamp?: number): string {
+  if (!timestamp) return '';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(timestamp));
+}
+
+const MemoryScene: React.FC = () => {
+  const { t } = useI18n('common');
+  const { workspace, workspacePath, hasWorkspace } = useCurrentWorkspace();
+  const { openOverlay } = useOverlayManager();
+  const setSettingsTab = useSettingsStore((state) => state.setActiveTab);
+
+  const [records, setRecords] = useState<MemoryRecord[]>([]);
+  const [spaces, setSpaces] = useState<MemorySpace[]>([]);
+  const [autoMemoryStatus, setAutoMemoryStatus] = useState<AutoMemoryStatus | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [scopeFilter, setScopeFilter] = useState<ScopeFilter>('all');
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftContent, setDraftContent] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState<MemoryRecord | null>(null);
+
+  const loadRecords = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const [storagePaths, status] = await Promise.all([
+        memoryLibraryAPI.getStoragePaths(),
+        memoryLibraryAPI.getAutoMemoryStatus(),
+      ]);
+
+      const nextSpaces: MemorySpace[] = [
+        {
+          scope: 'global',
+          label: t('memoryLibrary.scopes.global'),
+          memoryDir: storagePaths.agenticOsMemoryDir,
+          available: true,
+        },
+      ];
+
+      if (hasWorkspace && workspacePath && workspace?.workspaceKind !== WorkspaceKind.Remote) {
+        try {
+          const projectPaths = await memoryLibraryAPI.getProjectStoragePaths(workspacePath);
+          nextSpaces.push({
+            scope: 'workspace',
+            label: t('memoryLibrary.scopes.workspace'),
+            memoryDir: projectPaths.memoryDir,
+            available: true,
+          });
+        } catch {
+          nextSpaces.push({
+            scope: 'workspace',
+            label: t('memoryLibrary.scopes.workspace'),
+            memoryDir: '',
+            available: false,
+          });
+        }
+      }
+
+      const nextRecords = (await Promise.all(
+        nextSpaces.map((space) => memoryLibraryAPI.listMemoryRecords(space))
+      )).flat();
+
+      setSpaces(nextSpaces);
+      setAutoMemoryStatus(status);
+      setRecords(nextRecords);
+      setSelectedId((current) => {
+        if (current && nextRecords.some((record) => record.id === current)) return current;
+        return nextRecords[0]?.id ?? null;
+      });
+    } catch (error) {
+      notificationService.error(t('memoryLibrary.messages.loadFailed'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [hasWorkspace, t, workspace, workspacePath]);
+
+  useEffect(() => {
+    void loadRecords();
+  }, [loadRecords]);
+
+  const filteredRecords = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return records.filter((record) => {
+      if (scopeFilter === 'global' && record.scope !== 'global') return false;
+      if (scopeFilter === 'workspace' && record.scope !== 'workspace') return false;
+      if (scopeFilter === 'workspace_overview' && !record.isWorkspaceOverview) return false;
+      if (typeFilter !== 'all' && record.type !== typeFilter) return false;
+      if (!normalizedQuery) return true;
+      const haystack = [
+        record.title,
+        record.description,
+        record.relativePath,
+        record.type,
+        record.scope,
+        record.content,
+      ].join(' ').toLowerCase();
+      return haystack.includes(normalizedQuery);
+    });
+  }, [query, records, scopeFilter, typeFilter]);
+
+  const selectedRecord = useMemo(
+    () => records.find((record) => record.id === selectedId) ?? filteredRecords[0] ?? null,
+    [filteredRecords, records, selectedId]
+  );
+
+  useEffect(() => {
+    if (selectedRecord && !filteredRecords.some((record) => record.id === selectedRecord.id)) {
+      setSelectedId(filteredRecords[0]?.id ?? null);
+    }
+  }, [filteredRecords, selectedRecord]);
+
+  useEffect(() => {
+    setIsEditing(false);
+    setDraftContent(selectedRecord?.content ?? '');
+  }, [selectedRecord?.id, selectedRecord?.content]);
+
+  const counts = useMemo(() => ({
+    global: records.filter((record) => record.scope === 'global').length,
+    workspace: records.filter((record) => record.scope === 'workspace').length,
+    overview: records.filter((record) => record.isWorkspaceOverview).length,
+  }), [records]);
+
+  const handleSave = async () => {
+    if (!selectedRecord) return;
+    setIsSaving(true);
+    try {
+      const refreshed = await memoryLibraryAPI.saveMemoryRecord(selectedRecord, draftContent);
+      setRecords((current) => current.map((record) => (
+        record.id === selectedRecord.id ? refreshed : record
+      )));
+      setSelectedId(refreshed.id);
+      setIsEditing(false);
+      notificationService.success(t('memoryLibrary.messages.saveSuccess'));
+    } catch {
+      notificationService.error(t('memoryLibrary.messages.saveFailed'));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (record: MemoryRecord) => {
+    try {
+      await memoryLibraryAPI.deleteMemoryRecord(record);
+      setRecords((current) => current.filter((item) => item.id !== record.id));
+      setSelectedId((current) => current === record.id ? null : current);
+      notificationService.success(t('memoryLibrary.messages.deleteSuccess'));
+    } catch {
+      notificationService.error(t('memoryLibrary.messages.deleteFailed'));
+    }
+  };
+
+  const handleOpenSettings = () => {
+    setSettingsTab('memory');
+    openOverlay('settings');
+  };
+
+  const selectedCanDelete = selectedRecord && !selectedRecord.isIndex;
+
+  return (
+    <div className="memory-scene">
+      <aside className="memory-scene__sidebar">
+        <div className="memory-scene__brand">
+          <span className="memory-scene__brand-icon"><Brain size={18} /></span>
+          <div>
+            <h2>{t('memoryLibrary.title')}</h2>
+            <p>{t('memoryLibrary.subtitle')}</p>
+          </div>
+        </div>
+
+        <div className="memory-scene__scope-list">
+          {SCOPE_FILTERS.map((scope) => (
+            <button
+              key={scope}
+              type="button"
+              className={`memory-scene__scope-item${scopeFilter === scope ? ' is-active' : ''}`}
+              onClick={() => setScopeFilter(scope)}
+            >
+              <span>{t(`memoryLibrary.scopeFilters.${scope}`)}</span>
+              <strong>
+                {scope === 'all'
+                  ? records.length
+                  : scope === 'global'
+                    ? counts.global
+                    : scope === 'workspace'
+                      ? counts.workspace
+                      : counts.overview}
+              </strong>
+            </button>
+          ))}
+        </div>
+
+        <div className="memory-scene__status-card">
+          <div className="memory-scene__status-title">
+            <Sparkles size={14} />
+            {t('memoryLibrary.autoMemory.title')}
+          </div>
+          <p>
+            {autoMemoryStatus
+              ? t('memoryLibrary.autoMemory.summary', {
+                global: autoMemoryStatus.globalEnabled
+                  ? t('memoryLibrary.autoMemory.enabledEvery', { count: autoMemoryStatus.globalEvery })
+                  : t('memoryLibrary.autoMemory.disabled'),
+                workspace: autoMemoryStatus.workspaceEnabled
+                  ? t('memoryLibrary.autoMemory.enabledEvery', { count: autoMemoryStatus.workspaceEvery })
+                  : t('memoryLibrary.autoMemory.disabled'),
+              })
+              : t('memoryLibrary.autoMemory.loading')}
+          </p>
+          <button type="button" onClick={handleOpenSettings}>
+            <Settings size={13} />
+            {t('memoryLibrary.actions.openSettings')}
+          </button>
+        </div>
+
+        {spaces.map((space) => (
+          <div key={space.scope} className="memory-scene__path-card">
+            <span>{space.label}</span>
+            <code>{space.available ? space.memoryDir : t('memoryLibrary.empty.unavailable')}</code>
+          </div>
+        ))}
+      </aside>
+
+      <main className="memory-scene__main">
+        <section className="memory-scene__list-pane">
+          <div className="memory-scene__toolbar">
+            <Search
+              value={query}
+              onChange={setQuery}
+              onClear={() => setQuery('')}
+              placeholder={t('memoryLibrary.searchPlaceholder')}
+              size="medium"
+            />
+            <button type="button" className="memory-scene__icon-btn" onClick={() => void loadRecords()}>
+              <RefreshCcw size={15} />
+            </button>
+          </div>
+
+          <div className="memory-scene__type-pills">
+            {MEMORY_TYPES.map((type) => (
+              <button
+                key={type}
+                type="button"
+                className={`memory-scene__type-pill${typeFilter === type ? ' is-active' : ''}`}
+                onClick={() => setTypeFilter(type)}
+              >
+                {t(`memoryLibrary.types.${type}`)}
+              </button>
+            ))}
+          </div>
+
+          <div className="memory-scene__records" aria-busy={isLoading}>
+            {isLoading ? (
+              <div className="memory-scene__empty">{t('memoryLibrary.loading')}</div>
+            ) : filteredRecords.length === 0 ? (
+              <div className="memory-scene__empty">{t('memoryLibrary.empty.noResults')}</div>
+            ) : filteredRecords.map((record) => (
+              <button
+                key={record.id}
+                type="button"
+                className={`memory-scene__record-card${selectedRecord?.id === record.id ? ' is-selected' : ''}`}
+                onClick={() => setSelectedId(record.id)}
+              >
+                <span className="memory-scene__record-icon">
+                  {record.isIndex ? <Database size={15} /> : <FileText size={15} />}
+                </span>
+                <span className="memory-scene__record-body">
+                  <span className="memory-scene__record-title">{record.title}</span>
+                  <span className="memory-scene__record-desc">
+                    {record.description || record.relativePath}
+                  </span>
+                  <span className="memory-scene__record-meta">
+                    <Badge variant="neutral">{t(`memoryLibrary.types.${record.type}`)}</Badge>
+                    <span>{t(`memoryLibrary.scopes.${record.scope}`)}</span>
+                    {record.updatedAt ? <span>{formatDate(record.updatedAt)}</span> : null}
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="memory-scene__detail-pane">
+          {selectedRecord ? (
+            <>
+              <header className="memory-scene__detail-header">
+                <div>
+                  <div className="memory-scene__detail-kicker">
+                    {t(`memoryLibrary.scopes.${selectedRecord.scope}`)} / {selectedRecord.relativePath}
+                  </div>
+                  <h3>{selectedRecord.title}</h3>
+                  {selectedRecord.description ? <p>{selectedRecord.description}</p> : null}
+                </div>
+                <div className="memory-scene__detail-actions">
+                  {isEditing ? (
+                    <>
+                      <Button size="small" variant="primary" onClick={() => void handleSave()} disabled={isSaving}>
+                        <Save size={14} />
+                        {t('memoryLibrary.actions.save')}
+                      </Button>
+                      <Button size="small" variant="secondary" onClick={() => setIsEditing(false)} disabled={isSaving}>
+                        <X size={14} />
+                        {t('memoryLibrary.actions.cancel')}
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <Button size="small" variant="secondary" onClick={() => setIsEditing(true)}>
+                        {t('memoryLibrary.actions.edit')}
+                      </Button>
+                      <Button size="small" variant="secondary" onClick={() => void memoryLibraryAPI.revealMemoryRecord(selectedRecord)}>
+                        <FolderOpen size={14} />
+                        {t('memoryLibrary.actions.reveal')}
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="danger"
+                        disabled={!selectedCanDelete}
+                        onClick={() => selectedCanDelete && setDeleteTarget(selectedRecord)}
+                      >
+                        <Trash2 size={14} />
+                        {t('memoryLibrary.actions.forget')}
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </header>
+
+              <div className="memory-scene__explain-card">
+                <ExternalLink size={14} />
+                <span>{t(`memoryLibrary.usageHints.${selectedRecord.type}`)}</span>
+              </div>
+
+              {isEditing ? (
+                <textarea
+                  className="memory-scene__editor"
+                  value={draftContent}
+                  onChange={(event) => setDraftContent(event.target.value)}
+                  spellCheck={false}
+                />
+              ) : (
+                <div className="memory-scene__markdown">
+                  <Markdown content={selectedRecord.content || t('memoryLibrary.empty.emptyFile')} />
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="memory-scene__detail-empty">{t('memoryLibrary.empty.noSelection')}</div>
+          )}
+        </section>
+      </main>
+
+      <ConfirmDialog
+        isOpen={Boolean(deleteTarget)}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={() => deleteTarget && void handleDelete(deleteTarget)}
+        title={t('memoryLibrary.deleteDialog.title')}
+        message={t('memoryLibrary.deleteDialog.message', { name: deleteTarget?.title ?? '' })}
+        confirmText={t('memoryLibrary.actions.forget')}
+        confirmDanger
+        preview={deleteTarget?.relativePath}
+      />
+    </div>
+  );
+};
+
+export default MemoryScene;

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.scss
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.scss
@@ -813,6 +813,24 @@
   .table-wrapper tbody tr:hover {
     background: #eef4ff;
   }
+
+  /*
+   * Blockquotes: base styles use white-alpha tints for dark UIs. On light / cream
+   * scene surfaces (e.g. Agentic OS) those read as “no background”. Mix against
+   * the scene + text tokens so the fill and left rule stay legible.
+   */
+  blockquote,
+  .custom-blockquote {
+    background: color-mix(in srgb, var(--color-text-primary) 5%, var(--color-bg-scene, #ffffff));
+    border-left-color: color-mix(in srgb, var(--color-text-primary) 30%, var(--color-bg-scene, #ffffff));
+    color: var(--color-text-secondary, var(--color-text-muted, #4b5563));
+  }
+
+  blockquote:hover,
+  .custom-blockquote:hover {
+    background: color-mix(in srgb, var(--color-text-primary) 7.5%, var(--color-bg-scene, #ffffff));
+    border-left-color: color-mix(in srgb, var(--color-text-primary) 40%, var(--color-bg-scene, #ffffff));
+  }
 }
 
 

--- a/src/web-ui/src/component-library/styles/flowchat-markdown-code-vars.scss
+++ b/src/web-ui/src/component-library/styles/flowchat-markdown-code-vars.scss
@@ -50,7 +50,8 @@
   --flowchat-md-pre-hover-shadow: 0 6px 20px rgba(15, 23, 42, 0.08);
   --flowchat-md-pre-code-fg: var(--color-text-primary, #24292f);
 
-  --flowchat-md-bq-bg: rgba(0, 0, 0, 0.03);
-  --flowchat-md-bq-border: rgba(0, 0, 0, 0.12);
-  --flowchat-md-bq-fg: var(--color-text-muted, #57606a);
+  /* Match Markdown.scss light blockquotes: scene-aware fill/border (cream/off-white scenes). */
+  --flowchat-md-bq-bg: color-mix(in srgb, var(--color-text-primary) 5%, var(--color-bg-scene, #ffffff));
+  --flowchat-md-bq-border: color-mix(in srgb, var(--color-text-primary) 30%, var(--color-bg-scene, #ffffff));
+  --flowchat-md-bq-fg: var(--color-text-secondary, var(--color-text-muted, #57606a));
 }

--- a/src/web-ui/src/flow_chat/components/ChatInput.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInput.scss
@@ -1546,6 +1546,10 @@
         border: none !important;
         box-shadow: none !important;
       }
+      
+      &:hover .bitfun-chat-input__breathing-circle {
+        background: #941f1c;
+      }
     }
   }
   
@@ -1559,11 +1563,24 @@
   }
   
   &__breathing-circle {
+    position: relative;
+    flex-shrink: 0;
     width: 20px;
     height: 20px;
     border-radius: 50%;
-    background: rgba(234, 179, 8, 0.6); // yellow-500 with opacity
+    background: #b22c28;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.06);
     animation: breathing-pulse 2.5s ease-in-out infinite;
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      margin: auto;
+      width: 8px;
+      height: 8px;
+      background: #fff;
+    }
   }
 
   &__queued-badge {

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -93,6 +93,7 @@
       "sessions": "Tasks",
       "project": "Directory",
       "persona": "Nursery",
+      "memory": "Memory",
       "agents": "Think AApp",
       "skills": "Skills",
       "tools": "Tools",
@@ -860,6 +861,7 @@
     "git": "Git",
     "settings": "Settings",
     "fileViewer": "File Viewer",
+    "memory": "Memory",
     "projectContext": "Profile",
     "apps": "Apps",
     "subagents": "SubAgents",
@@ -873,6 +875,73 @@
   },
   "overlay": {
     "returnToAgenticOS": "Return to Agentic OS"
+  },
+  "memoryLibrary": {
+    "title": "Memory Library",
+    "subtitle": "Review what Agentic OS remembers about preferences, collaboration feedback, and workspace context.",
+    "loading": "Loading memories...",
+    "searchPlaceholder": "Search memories, types, or content...",
+    "scopeFilters": {
+      "all": "All memories",
+      "global": "Agentic OS",
+      "workspace": "Current workspace",
+      "workspace_overview": "Workspace overview"
+    },
+    "scopes": {
+      "global": "Global memory",
+      "workspace": "Workspace memory"
+    },
+    "types": {
+      "all": "All",
+      "index": "Index",
+      "user": "User",
+      "feedback": "Feedback",
+      "project": "Project",
+      "reference": "Reference",
+      "workspace_overview": "Workspace overview",
+      "unknown": "Unclassified"
+    },
+    "autoMemory": {
+      "title": "Auto memory",
+      "loading": "Loading auto-memory status...",
+      "summary": "Global: {{global}}; workspace: {{workspace}}.",
+      "enabledEvery": "every {{count}} turns",
+      "disabled": "off"
+    },
+    "actions": {
+      "openSettings": "Auto-memory settings",
+      "edit": "Edit",
+      "save": "Save",
+      "cancel": "Cancel",
+      "reveal": "Open location",
+      "forget": "Forget"
+    },
+    "usageHints": {
+      "index": "The index is loaded first so the agent can quickly decide which memories are available.",
+      "user": "This memory shapes how the agent understands the user's identity, preferences, and communication style.",
+      "feedback": "This memory guides future agent behavior and helps avoid repeating rejected collaboration patterns.",
+      "project": "This memory adds background, motivation, and non-obvious context for the current workspace.",
+      "reference": "This memory points to external systems or sources of truth the agent may need later.",
+      "workspace_overview": "This memory helps Agentic OS decide which workspace a task should route to.",
+      "unknown": "This memory has no clear type. Add frontmatter so future use can be more precise."
+    },
+    "empty": {
+      "noResults": "No matching memories",
+      "noSelection": "Select a memory to view details",
+      "emptyFile": "This memory file is empty.",
+      "unavailable": "Unavailable"
+    },
+    "messages": {
+      "loadFailed": "Failed to load memories",
+      "saveSuccess": "Memory saved",
+      "saveFailed": "Failed to save memory",
+      "deleteSuccess": "Memory forgotten",
+      "deleteFailed": "Failed to forget memory"
+    },
+    "deleteDialog": {
+      "title": "Forget this memory?",
+      "message": "\"{{name}}\" will be removed from the memory library and the agent will no longer use it proactively."
+    }
   },
   "taskDetailScene": {
     "pageTitle": "Task Center",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -93,6 +93,7 @@
       "sessions": "任务",
       "project": "目录",
       "persona": "助理",
+      "memory": "记忆",
       "agents": "思维应用",
       "skills": "技能",
       "tools": "工具",
@@ -860,6 +861,7 @@
     "git": "Git",
     "settings": "设置",
     "fileViewer": "文件查看",
+    "memory": "记忆",
     "projectContext": "项目概况",
     "apps": "应用",
     "subagents": "SubAgent",
@@ -873,6 +875,73 @@
   },
   "overlay": {
     "returnToAgenticOS": "返回 Agentic OS"
+  },
+  "memoryLibrary": {
+    "title": "记忆库",
+    "subtitle": "查看 Agentic OS 长期记住的用户偏好、协作反馈和工作区背景。",
+    "loading": "正在读取记忆…",
+    "searchPlaceholder": "搜索记忆、类型或内容…",
+    "scopeFilters": {
+      "all": "全部记忆",
+      "global": "Agentic OS",
+      "workspace": "当前工作区",
+      "workspace_overview": "工作区概览"
+    },
+    "scopes": {
+      "global": "全局记忆",
+      "workspace": "工作区记忆"
+    },
+    "types": {
+      "all": "全部",
+      "index": "索引",
+      "user": "用户",
+      "feedback": "反馈",
+      "project": "项目",
+      "reference": "引用",
+      "workspace_overview": "工作区概览",
+      "unknown": "未分类"
+    },
+    "autoMemory": {
+      "title": "自动记忆",
+      "loading": "正在读取自动记忆状态…",
+      "summary": "全局：{{global}}；工作区：{{workspace}}。",
+      "enabledEvery": "每 {{count}} 轮",
+      "disabled": "已关闭"
+    },
+    "actions": {
+      "openSettings": "自动记忆设置",
+      "edit": "编辑",
+      "save": "保存",
+      "cancel": "取消",
+      "reveal": "打开位置",
+      "forget": "遗忘"
+    },
+    "usageHints": {
+      "index": "索引会被优先加载，用来帮助 Agent 快速判断有哪些记忆可用。",
+      "user": "这类记忆会影响 Agent 如何理解用户身份、偏好和沟通方式。",
+      "feedback": "这类记忆会约束 Agent 未来的工作方式，避免重复违背已确认的协作规则。",
+      "project": "这类记忆补充当前工作区的背景、动机和非代码可推导的信息。",
+      "reference": "这类记忆记录外部系统或信息源，帮助 Agent 在需要时找到权威上下文。",
+      "workspace_overview": "这类记忆帮助 Agentic OS 判断工作应路由到哪个工作区。",
+      "unknown": "这条记忆缺少明确类型；建议补充 frontmatter 以便未来更准确地使用。"
+    },
+    "empty": {
+      "noResults": "没有匹配的记忆",
+      "noSelection": "选择一条记忆查看详情",
+      "emptyFile": "这个记忆文件还是空的。",
+      "unavailable": "当前不可用"
+    },
+    "messages": {
+      "loadFailed": "记忆加载失败",
+      "saveSuccess": "记忆已保存",
+      "saveFailed": "记忆保存失败",
+      "deleteSuccess": "记忆已遗忘",
+      "deleteFailed": "遗忘失败"
+    },
+    "deleteDialog": {
+      "title": "遗忘这条记忆？",
+      "message": "“{{name}}” 将从记忆库中移除，未来 Agent 不会再主动使用它。"
+    }
   },
   "taskDetailScene": {
     "pageTitle": "任务中心",


### PR DESCRIPTION
## Summary
- Add Memory Library overlay scene (browse/manage memory records, scope filters, i18n).
- Expose \genticOsMemoryDir\ via \get_storage_paths\ for desktop.
- Wire overlay registry, footer action, and polish Markdown / chat input styling.

## Testing
- \pnpm run type-check:web\ (pass)

## Notes
Targets \gentic_os\ branch.