### PR TITLE
feat(web-ui): Memory scene polish, Switch focus, and i18n

### DIFF
--- a/src/web-ui/src/app/scenes/memory/MemoryLibraryAPI.ts
+++ b/src/web-ui/src/app/scenes/memory/MemoryLibraryAPI.ts
@@ -218,6 +218,10 @@ export class MemoryLibraryAPI {
     await workspaceAPI.revealInExplorer(record.path);
   }
 
+  async revealMemorySpace(space: MemorySpace): Promise<void> {
+    await workspaceAPI.revealInExplorer(space.memoryDir);
+  }
+
   private async collectMarkdownFiles(memoryDir: string): Promise<string[]> {
     const collected: string[] = [];
 

--- a/src/web-ui/src/app/scenes/memory/MemoryScene.scss
+++ b/src/web-ui/src/app/scenes/memory/MemoryScene.scss
@@ -15,8 +15,8 @@
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding: 18px 14px;
+  gap: 22px;
+  padding: 20px 14px;
   border-right: 1px solid var(--border-subtle);
   background: var(--color-bg-scene, var(--color-bg-primary));
   overflow-y: auto;
@@ -25,8 +25,13 @@
 .memory-scene__brand {
   display: flex;
   align-items: flex-start;
-  gap: 11px;
-  padding: 4px 4px 10px;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 2px 4px 0;
+
+  > div {
+    min-width: 0;
+  }
 
   h2 {
     margin: 0;
@@ -43,22 +48,39 @@
   }
 }
 
-.memory-scene__brand-icon {
-  width: 34px;
-  height: 34px;
+.memory-scene__header-settings {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  flex-shrink: 0;
-  border-radius: 12px;
-  color: var(--memory-seal-red);
-  background: var(--element-bg-soft);
+  margin-top: -2px;
+  border: 0;
+  border-radius: $size-radius-sm;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background $motion-fast $easing-standard,
+              color $motion-fast $easing-standard;
+
+  &:hover {
+    background: var(--element-bg-soft);
+    color: var(--color-text-primary);
+  }
 }
 
 .memory-scene__scope-list {
   display: flex;
   flex-direction: column;
   gap: 5px;
+}
+
+.memory-scene__section-label {
+  margin: 0 8px 4px;
+  color: var(--color-text-muted);
+  font-size: 11px;
+  font-weight: 650;
 }
 
 .memory-scene__scope-item {
@@ -68,7 +90,7 @@
   gap: 10px;
   width: 100%;
   min-height: 34px;
-  padding: 0 10px;
+  padding: 0 10px 0 13px;
   border: 1px solid transparent;
   border-radius: $size-radius-sm;
   background: transparent;
@@ -92,86 +114,181 @@
     color: var(--color-text-primary);
   }
 
+  &:disabled {
+    color: var(--color-text-disabled, var(--color-text-muted));
+    cursor: default;
+    opacity: 0.55;
+
+    &:hover {
+      background: transparent;
+    }
+  }
+
   &.is-active {
     color: var(--color-text-primary);
-    border-color: var(--border-subtle);
     background: var(--element-bg-soft);
+    border-color: transparent;
 
     &::before {
       content: '';
-      width: 5px;
-      height: 5px;
-      border-radius: 50%;
+      width: 2px;
+      height: 16px;
+      border-radius: 999px;
       background: var(--memory-seal-red);
       position: absolute;
-      left: 4px;
+      left: 3px;
       top: 50%;
       transform: translateY(-50%);
     }
   }
 }
 
-.memory-scene__status-card,
-.memory-scene__path-card {
-  padding: 12px;
-  border: 1px solid var(--border-subtle);
-  border-radius: $size-radius-base;
-  background: color-mix(in srgb, var(--element-bg-soft) 70%, transparent);
+.memory-scene__scope-note {
+  margin: 3px 8px 0;
+  color: var(--color-text-muted);
+  font-size: 11px;
+  line-height: 1.4;
 }
 
-.memory-scene__status-title {
-  display: inline-flex;
+.memory-scene__status-section {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.memory-scene__section-heading {
+  display: flex;
   align-items: center;
-  gap: 7px;
-  color: var(--color-text-primary);
-  font-size: var(--font-size-sm);
-  font-weight: 600;
-}
+  padding: 0 8px;
 
-.memory-scene__status-card {
-  p {
-    margin: 8px 0 10px;
+  > span {
     color: var(--color-text-muted);
-    font-size: var(--font-size-xs);
-    line-height: 1.45;
+    font-size: 11px;
+    font-weight: 650;
   }
 
-  button {
+}
+
+.memory-scene__status-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.memory-scene__status-row {
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 0 8px;
+  border-radius: $size-radius-sm;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+
+  span {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    height: 28px;
-    padding: 0 10px;
-    border: 1px solid var(--border-subtle);
-    border-radius: 999px;
-    background: var(--element-bg-soft);
-    color: var(--color-text-secondary);
-    font-size: var(--font-size-xs);
-    cursor: pointer;
+    min-width: 0;
+  }
 
-    &:hover {
-      color: var(--color-text-primary);
-      background: var(--element-bg-medium);
-    }
+  svg {
+    color: var(--color-text-muted);
+  }
+
+  strong {
+    flex-shrink: 0;
+    color: var(--color-text-muted);
+    font-size: 11px;
+    font-weight: 550;
+  }
+
+  strong.is-on {
+    color: var(--color-text-secondary);
   }
 }
 
-.memory-scene__path-card {
+.memory-scene__paths {
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 12px;
+
+  summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 28px;
+    padding: 0 8px;
+    border-radius: $size-radius-sm;
+    color: var(--color-text-muted);
+    font-size: 11px;
+    font-weight: 650;
+    cursor: pointer;
+    list-style: none;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &::after {
+      content: '+';
+      color: var(--color-text-muted);
+      font-weight: 500;
+    }
+
+    &:hover {
+      color: var(--color-text-primary);
+      background: var(--element-bg-soft);
+    }
+  }
+
+  &[open] summary::after {
+    content: '-';
+  }
+}
+
+.memory-scene__path-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
+  padding: 10px 8px 0;
+}
+
+.memory-scene__path-row {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
 
   span {
+    min-width: 0;
     color: var(--color-text-secondary);
     font-size: var(--font-size-xs);
     font-weight: 600;
   }
 
-  code {
+  button {
+    flex-shrink: 0;
+    height: 24px;
+    padding: 0 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: $size-radius-sm;
+    background: transparent;
     color: var(--color-text-muted);
     font-size: 11px;
-    line-height: 1.45;
-    word-break: break-all;
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+      color: var(--color-text-primary);
+      background: var(--element-bg-soft);
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.55;
+    }
   }
 }
 
@@ -227,7 +344,7 @@
 .memory-scene__type-pills {
   display: flex;
   gap: 6px;
-  padding: 0 16px 12px;
+  padding: 0 16px 10px;
   overflow-x: auto;
 }
 
@@ -262,6 +379,22 @@
       vertical-align: 1px;
       background: var(--memory-seal-red);
     }
+  }
+}
+
+.memory-scene__result-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 18px 10px;
+  color: var(--color-text-muted);
+  font-size: 11px;
+
+  span:last-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 
@@ -325,6 +458,20 @@
   white-space: nowrap;
 }
 
+.memory-scene__record-title-row {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+
+  > span:last-child {
+    flex-shrink: 0;
+    color: var(--color-text-muted);
+    font-size: 11px;
+  }
+}
+
 .memory-scene__record-desc {
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
@@ -342,6 +489,7 @@
   flex-wrap: wrap;
   color: var(--color-text-muted);
   font-size: 11px;
+
 }
 
 .memory-scene__detail-pane {
@@ -392,10 +540,28 @@
   justify-content: flex-end;
 }
 
-.memory-scene__explain-card {
+.memory-scene__detail-metadata {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+
+  span {
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    padding: 0 9px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 999px;
+    background: var(--element-bg-soft);
+    color: var(--color-text-secondary);
+    font-size: 11px;
+    font-weight: 550;
+  }
+}
+
+.memory-scene__explain-card {
   margin: 16px 24px 0;
   padding: 10px 12px;
   border: 1px solid var(--border-subtle);
@@ -404,10 +570,6 @@
   color: var(--color-text-secondary);
   font-size: var(--font-size-xs);
   line-height: 1.45;
-
-  svg {
-    color: var(--memory-seal-red);
-  }
 }
 
 .memory-scene__markdown {

--- a/src/web-ui/src/app/scenes/memory/MemoryScene.tsx
+++ b/src/web-ui/src/app/scenes/memory/MemoryScene.tsx
@@ -1,8 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  Brain,
   Database,
-  ExternalLink,
   FileText,
   FolderOpen,
   RefreshCcw,
@@ -53,6 +51,12 @@ function formatDate(timestamp?: number): string {
     hour: '2-digit',
     minute: '2-digit',
   }).format(new Date(timestamp));
+}
+
+function getRecordExcerpt(record: MemoryRecord): string {
+  return (record.description || record.body || record.relativePath)
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 const MemoryScene: React.FC = () => {
@@ -174,6 +178,15 @@ const MemoryScene: React.FC = () => {
     overview: records.filter((record) => record.isWorkspaceOverview).length,
   }), [records]);
 
+  const workspaceSpace = spaces.find((space) => space.scope === 'workspace');
+  const workspaceUnavailable = !hasWorkspace || workspaceSpace?.available === false;
+
+  useEffect(() => {
+    if (scopeFilter === 'workspace' && workspaceUnavailable) {
+      setScopeFilter('all');
+    }
+  }, [scopeFilter, workspaceUnavailable]);
+
   const handleSave = async () => {
     if (!selectedRecord) return;
     setIsSaving(true);
@@ -208,70 +221,124 @@ const MemoryScene: React.FC = () => {
     openOverlay('settings');
   };
 
+  const handleOpenMemorySpace = async (space: MemorySpace) => {
+    if (!space.available) return;
+    try {
+      await memoryLibraryAPI.revealMemorySpace(space);
+    } catch {
+      notificationService.error(t('memoryLibrary.messages.revealFailed'));
+    }
+  };
+
   const selectedCanDelete = selectedRecord && !selectedRecord.isIndex;
 
   return (
     <div className="memory-scene">
       <aside className="memory-scene__sidebar">
         <div className="memory-scene__brand">
-          <span className="memory-scene__brand-icon"><Brain size={18} /></span>
           <div>
             <h2>{t('memoryLibrary.title')}</h2>
             <p>{t('memoryLibrary.subtitle')}</p>
           </div>
-        </div>
-
-        <div className="memory-scene__scope-list">
-          {SCOPE_FILTERS.map((scope) => (
-            <button
-              key={scope}
-              type="button"
-              className={`memory-scene__scope-item${scopeFilter === scope ? ' is-active' : ''}`}
-              onClick={() => setScopeFilter(scope)}
-            >
-              <span>{t(`memoryLibrary.scopeFilters.${scope}`)}</span>
-              <strong>
-                {scope === 'all'
-                  ? records.length
-                  : scope === 'global'
-                    ? counts.global
-                    : scope === 'workspace'
-                      ? counts.workspace
-                      : counts.overview}
-              </strong>
-            </button>
-          ))}
-        </div>
-
-        <div className="memory-scene__status-card">
-          <div className="memory-scene__status-title">
-            <Sparkles size={14} />
-            {t('memoryLibrary.autoMemory.title')}
-          </div>
-          <p>
-            {autoMemoryStatus
-              ? t('memoryLibrary.autoMemory.summary', {
-                global: autoMemoryStatus.globalEnabled
-                  ? t('memoryLibrary.autoMemory.enabledEvery', { count: autoMemoryStatus.globalEvery })
-                  : t('memoryLibrary.autoMemory.disabled'),
-                workspace: autoMemoryStatus.workspaceEnabled
-                  ? t('memoryLibrary.autoMemory.enabledEvery', { count: autoMemoryStatus.workspaceEvery })
-                  : t('memoryLibrary.autoMemory.disabled'),
-              })
-              : t('memoryLibrary.autoMemory.loading')}
-          </p>
-          <button type="button" onClick={handleOpenSettings}>
-            <Settings size={13} />
-            {t('memoryLibrary.actions.openSettings')}
+          <button
+            type="button"
+            className="memory-scene__header-settings"
+            onClick={handleOpenSettings}
+            aria-label={t('memoryLibrary.actions.openSettings')}
+            title={t('memoryLibrary.actions.openSettings')}
+          >
+            <Settings size={15} />
           </button>
         </div>
 
-        {spaces.map((space) => (
-          <div key={space.scope} className="memory-scene__path-card">
-            <span>{space.label}</span>
-            <code>{space.available ? space.memoryDir : t('memoryLibrary.empty.unavailable')}</code>
+        <div className="memory-scene__scope-list">
+          <div className="memory-scene__section-label">{t('memoryLibrary.sidebar.scope')}</div>
+          {SCOPE_FILTERS.map((scope) => {
+            const isDisabled = scope === 'workspace' && workspaceUnavailable;
+            return (
+              <button
+                key={scope}
+                type="button"
+                className={`memory-scene__scope-item${scopeFilter === scope ? ' is-active' : ''}`}
+                onClick={() => !isDisabled && setScopeFilter(scope)}
+                disabled={isDisabled}
+              >
+                <span>{t(`memoryLibrary.scopeFilters.${scope}`)}</span>
+                <strong>
+                  {scope === 'all'
+                    ? records.length
+                    : scope === 'global'
+                      ? counts.global
+                      : scope === 'workspace'
+                        ? counts.workspace
+                        : counts.overview}
+                </strong>
+              </button>
+            );
+          })}
+          {workspaceUnavailable ? (
+            <div className="memory-scene__scope-note">
+              {hasWorkspace
+                ? t('memoryLibrary.sidebar.workspaceUnavailable')
+                : t('memoryLibrary.sidebar.noWorkspace')}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="memory-scene__status-section">
+          <div className="memory-scene__section-heading">
+            <span>{t('memoryLibrary.autoMemory.title')}</span>
           </div>
-        ))}
+          <div className="memory-scene__status-rows">
+            <div className="memory-scene__status-row">
+              <span>
+                <Sparkles size={13} />
+                {t('memoryLibrary.scopes.global')}
+              </span>
+              <strong className={autoMemoryStatus?.globalEnabled ? 'is-on' : ''}>
+                {autoMemoryStatus
+                  ? autoMemoryStatus.globalEnabled
+                    ? t('memoryLibrary.autoMemory.enabledEvery', { count: autoMemoryStatus.globalEvery })
+                    : t('memoryLibrary.autoMemory.disabled')
+                  : t('memoryLibrary.autoMemory.loading')}
+              </strong>
+            </div>
+            <div className="memory-scene__status-row">
+              <span>
+                <Sparkles size={13} />
+                {t('memoryLibrary.scopes.workspace')}
+              </span>
+              <strong className={autoMemoryStatus?.workspaceEnabled ? 'is-on' : ''}>
+                {autoMemoryStatus
+                  ? autoMemoryStatus.workspaceEnabled
+                    ? t('memoryLibrary.autoMemory.enabledEvery', { count: autoMemoryStatus.workspaceEvery })
+                    : t('memoryLibrary.autoMemory.disabled')
+                  : t('memoryLibrary.autoMemory.loading')}
+              </strong>
+            </div>
+          </div>
+        </div>
+
+        <details className="memory-scene__paths">
+          <summary>{t('memoryLibrary.sidebar.storage')}</summary>
+          <div className="memory-scene__path-list">
+            {spaces.map((space) => (
+              <div key={space.scope} className="memory-scene__path-row">
+                <span>{space.label}</span>
+                <button
+                  type="button"
+                  title={space.available ? space.memoryDir : t('memoryLibrary.empty.unavailable')}
+                  disabled={!space.available}
+                  onClick={() => void handleOpenMemorySpace(space)}
+                >
+                  {space.available
+                    ? t('memoryLibrary.actions.openStorage')
+                    : t('memoryLibrary.empty.unavailable')}
+                </button>
+              </div>
+            ))}
+          </div>
+        </details>
       </aside>
 
       <main className="memory-scene__main">
@@ -302,6 +369,14 @@ const MemoryScene: React.FC = () => {
             ))}
           </div>
 
+          <div className="memory-scene__result-line">
+            <span>{t('memoryLibrary.results.showing', {
+              shown: filteredRecords.length,
+              total: records.length,
+            })}</span>
+            <span>{t(`memoryLibrary.scopeFilters.${scopeFilter}`)}</span>
+          </div>
+
           <div className="memory-scene__records" aria-busy={isLoading}>
             {isLoading ? (
               <div className="memory-scene__empty">{t('memoryLibrary.loading')}</div>
@@ -318,14 +393,16 @@ const MemoryScene: React.FC = () => {
                   {record.isIndex ? <Database size={15} /> : <FileText size={15} />}
                 </span>
                 <span className="memory-scene__record-body">
-                  <span className="memory-scene__record-title">{record.title}</span>
+                  <span className="memory-scene__record-title-row">
+                    <span className="memory-scene__record-title">{record.title}</span>
+                    {record.updatedAt ? <span>{formatDate(record.updatedAt)}</span> : null}
+                  </span>
                   <span className="memory-scene__record-desc">
-                    {record.description || record.relativePath}
+                    {getRecordExcerpt(record)}
                   </span>
                   <span className="memory-scene__record-meta">
                     <Badge variant="neutral">{t(`memoryLibrary.types.${record.type}`)}</Badge>
                     <span>{t(`memoryLibrary.scopes.${record.scope}`)}</span>
-                    {record.updatedAt ? <span>{formatDate(record.updatedAt)}</span> : null}
                   </span>
                 </span>
               </button>
@@ -343,16 +420,20 @@ const MemoryScene: React.FC = () => {
                   </div>
                   <h3>{selectedRecord.title}</h3>
                   {selectedRecord.description ? <p>{selectedRecord.description}</p> : null}
+                  <div className="memory-scene__detail-metadata">
+                    <span>{t(`memoryLibrary.types.${selectedRecord.type}`)}</span>
+                    {selectedRecord.updatedAt ? <span>{formatDate(selectedRecord.updatedAt)}</span> : null}
+                  </div>
                 </div>
                 <div className="memory-scene__detail-actions">
                   {isEditing ? (
                     <>
                       <Button size="small" variant="primary" onClick={() => void handleSave()} disabled={isSaving}>
-                        <Save size={14} />
+                          <Save size={14} />
                         {t('memoryLibrary.actions.save')}
                       </Button>
                       <Button size="small" variant="secondary" onClick={() => setIsEditing(false)} disabled={isSaving}>
-                        <X size={14} />
+                          <X size={14} />
                         {t('memoryLibrary.actions.cancel')}
                       </Button>
                     </>
@@ -362,7 +443,7 @@ const MemoryScene: React.FC = () => {
                         {t('memoryLibrary.actions.edit')}
                       </Button>
                       <Button size="small" variant="secondary" onClick={() => void memoryLibraryAPI.revealMemoryRecord(selectedRecord)}>
-                        <FolderOpen size={14} />
+                          <FolderOpen size={14} />
                         {t('memoryLibrary.actions.reveal')}
                       </Button>
                       <Button
@@ -371,7 +452,7 @@ const MemoryScene: React.FC = () => {
                         disabled={!selectedCanDelete}
                         onClick={() => selectedCanDelete && setDeleteTarget(selectedRecord)}
                       >
-                        <Trash2 size={14} />
+                          <Trash2 size={14} />
                         {t('memoryLibrary.actions.forget')}
                       </Button>
                     </>
@@ -380,8 +461,7 @@ const MemoryScene: React.FC = () => {
               </header>
 
               <div className="memory-scene__explain-card">
-                <ExternalLink size={14} />
-                <span>{t(`memoryLibrary.usageHints.${selectedRecord.type}`)}</span>
+                {t(`memoryLibrary.usageHints.${selectedRecord.type}`)}
               </div>
 
               {isEditing ? (

--- a/src/web-ui/src/component-library/components/Switch/Switch.scss
+++ b/src/web-ui/src/component-library/components/Switch/Switch.scss
@@ -4,6 +4,11 @@
 @use '../../styles/tokens.scss' as tokens;
 
 .bitfun-switch {
+  --bitfun-switch-on-bg: var(--btn-primary-bg, var(--color-accent-500));
+  --bitfun-switch-on-hover-bg: var(--btn-primary-hover-bg, var(--bitfun-switch-on-bg));
+  --bitfun-switch-on-border: var(--btn-primary-border, var(--bitfun-switch-on-bg));
+  --bitfun-switch-on-thumb-bg: var(--btn-primary-color, var(--color-bg-elevated, #fff));
+
   display: inline-flex;
   align-items: flex-start;
   gap: tokens.$size-gap-3;
@@ -52,12 +57,16 @@
     background: transparent;
     border: 1px solid var(--border-subtle);
     border-radius: 10px;
+    box-shadow: inset 0 0 0 1px transparent;
     transition: all 0.2s ease;
     pointer-events: none;
 
     &--checked {
-      background: var(--color-accent-100);
-      border-color: var(--color-accent-300);
+      background: var(--bitfun-switch-on-bg);
+      border-color: var(--bitfun-switch-on-border);
+      box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--bitfun-switch-on-thumb-bg) 18%, transparent),
+        0 0 0 2px color-mix(in srgb, var(--bitfun-switch-on-bg) 18%, transparent);
     }
   }
 
@@ -95,8 +104,11 @@
 
   &__input:checked + &__track &__thumb {
     left: calc(100% - 18px);
-    background: var(--btn-primary-bg, var(--color-accent-500));
-    border-color: var(--btn-primary-bg, var(--color-accent-500));
+    background: var(--bitfun-switch-on-thumb-bg);
+    border-color: color-mix(in srgb, var(--bitfun-switch-on-bg) 42%, transparent);
+    box-shadow:
+      0 1px 3px color-mix(in srgb, #000 22%, transparent),
+      0 0 0 1px color-mix(in srgb, var(--bitfun-switch-on-thumb-bg) 34%, transparent);
   }
 
   &__input:focus-visible + &__track {
@@ -114,13 +126,16 @@
   }
 
   &:hover:not(&--disabled):not(&--loading) &__input:checked + &__track {
-    background: var(--color-accent-200);
-    border-color: var(--color-accent-400);
+    background: var(--bitfun-switch-on-hover-bg);
+    border-color: var(--bitfun-switch-on-hover-bg);
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--bitfun-switch-on-thumb-bg) 22%, transparent),
+      0 0 0 2px color-mix(in srgb, var(--bitfun-switch-on-hover-bg) 24%, transparent);
   }
 
   &:hover:not(&--disabled):not(&--loading) &__input:checked + &__track &__thumb {
-    background: var(--btn-primary-hover-bg, var(--color-accent-400));
-    border-color: var(--btn-primary-hover-bg, var(--color-accent-400));
+    background: var(--bitfun-switch-on-thumb-bg);
+    border-color: color-mix(in srgb, var(--bitfun-switch-on-hover-bg) 48%, transparent);
   }
 
   &__input:active:not(:disabled) + &__track {
@@ -216,6 +231,19 @@
       font-size: var(--font-size-xs);
     }
   }
+}
+
+:root[data-theme-type='dark'] .bitfun-switch {
+  --bitfun-switch-on-bg: var(--color-accent-500);
+  --bitfun-switch-on-hover-bg: var(--color-accent-600, var(--color-accent-500));
+  --bitfun-switch-on-border: color-mix(in srgb, var(--color-accent-500) 78%, #fff);
+  --bitfun-switch-on-thumb-bg: #ffffff;
+}
+
+:root[data-theme='bitfun-slate'] .bitfun-switch {
+  --bitfun-switch-on-bg: var(--color-purple-500, var(--color-accent-500));
+  --bitfun-switch-on-hover-bg: var(--color-purple-600, var(--color-accent-600));
+  --bitfun-switch-on-border: color-mix(in srgb, var(--color-purple-500, var(--color-accent-500)) 82%, #fff);
 }
 
 @keyframes bitfun-switch-spin {

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -881,6 +881,16 @@
     "subtitle": "Review what Agentic OS remembers about preferences, collaboration feedback, and workspace context.",
     "loading": "Loading memories...",
     "searchPlaceholder": "Search memories, types, or content...",
+    "results": {
+      "showing": "{{shown}} of {{total}} memories"
+    },
+    "sidebar": {
+      "scope": "Scope",
+      "settings": "Settings",
+      "storage": "Storage location",
+      "noWorkspace": "No workspace open",
+      "workspaceUnavailable": "Workspace memory is unavailable"
+    },
     "scopeFilters": {
       "all": "All memories",
       "global": "Agentic OS",
@@ -910,6 +920,8 @@
     },
     "actions": {
       "openSettings": "Auto-memory settings",
+      "refresh": "Refresh",
+      "openStorage": "Open",
       "edit": "Edit",
       "save": "Save",
       "cancel": "Cancel",
@@ -935,6 +947,7 @@
       "loadFailed": "Failed to load memories",
       "saveSuccess": "Memory saved",
       "saveFailed": "Failed to save memory",
+      "revealFailed": "Failed to open location",
       "deleteSuccess": "Memory forgotten",
       "deleteFailed": "Failed to forget memory"
     },

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -881,6 +881,16 @@
     "subtitle": "查看 Agentic OS 长期记住的用户偏好、协作反馈和工作区背景。",
     "loading": "正在读取记忆…",
     "searchPlaceholder": "搜索记忆、类型或内容…",
+    "results": {
+      "showing": "显示 {{shown}} / {{total}} 条记忆"
+    },
+    "sidebar": {
+      "scope": "范围",
+      "settings": "设置",
+      "storage": "存储位置",
+      "noWorkspace": "未打开工作区",
+      "workspaceUnavailable": "当前工作区记忆不可用"
+    },
     "scopeFilters": {
       "all": "全部记忆",
       "global": "Agentic OS",
@@ -910,6 +920,8 @@
     },
     "actions": {
       "openSettings": "自动记忆设置",
+      "refresh": "刷新",
+      "openStorage": "打开",
       "edit": "编辑",
       "save": "保存",
       "cancel": "取消",
@@ -935,6 +947,7 @@
       "loadFailed": "记忆加载失败",
       "saveSuccess": "记忆已保存",
       "saveFailed": "记忆保存失败",
+      "revealFailed": "打开位置失败",
       "deleteSuccess": "记忆已遗忘",
       "deleteFailed": "遗忘失败"
     },


### PR DESCRIPTION
## Summary
Polishes the Memory library scene (layout, styles), refines the Switch component focus/hover treatment, and adds/updates en-US and zh-CN common strings for memory-related UI.

## Verification
- \pnpm run type-check:web\ (pass)

## Files
- \MemoryScene.tsx\ / \MemoryScene.scss\ / \MemoryLibraryAPI.ts\
- \Switch.scss\
- \common.json\ (en-US, zh-CN)
