### PR TITLE
 refactor(flow-chat): remove subagent waiting placeholder text items 

### DIFF
--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SubagentModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SubagentModule.test.ts
@@ -5,17 +5,6 @@ vi.mock('./ToolEventModule', () => ({
   processToolEvent: vi.fn(),
 }));
 
-vi.mock('@/infrastructure/i18n/core/I18nService', () => ({
-  i18nService: {
-    getT: () => (key: string, options?: { defaultValue?: string }) => {
-      if (key === 'toolCards.taskDetailPanel.waitingForModelResponse') {
-        return '等待模型响应...';
-      }
-      return options?.defaultValue ?? key;
-    },
-  },
-}));
-
 const testStoreState = vi.hoisted(() => ({
   sessions: new Map<string, any>(),
 }));
@@ -153,24 +142,22 @@ describe('SubagentModule', () => {
     resetStore();
   });
 
-  it('shows a waiting placeholder when a subagent model round starts and replaces it on first text chunk', () => {
+  it('creates text item directly from first text chunk without placeholder', () => {
     seedParentTaskTool();
 
+    // ModelRoundStarted no longer creates a placeholder.
     routeModelRoundStartedToToolCard(context, parentSessionId, parentToolId, {
       sessionId: subagentSessionId,
       turnId: subagentTurnId,
       roundId: subagentRoundId,
     });
 
+    // Verify no placeholder was created — the item should not exist yet.
     const itemId = `subagent-text-${parentToolId}-${subagentSessionId}-${subagentRoundId}`;
-    const placeholder = getParentRoundTextItem(itemId);
-    expect(placeholder?.content).toBe('等待模型响应...');
-    expect(placeholder?.status).toBe('running');
-    expect(placeholder?.isStreaming).toBe(true);
-    expect(placeholder?.isSubagentItem).toBe(true);
-    expect(placeholder?.parentTaskToolId).toBe(parentToolId);
-    expect(placeholder?.subagentSessionId).toBe(subagentSessionId);
+    const beforeChunk = getParentRoundTextItem(itemId);
+    expect(beforeChunk).toBeUndefined();
 
+    // First text chunk creates the item directly.
     routeTextChunkToToolCard(context, parentSessionId, parentToolId, {
       sessionId: subagentSessionId,
       turnId: subagentTurnId,
@@ -179,9 +166,12 @@ describe('SubagentModule', () => {
       contentType: 'text',
     });
 
-    const updatedItem = getParentRoundTextItem(itemId);
-    expect(updatedItem?.content).toBe('Review started.');
-    expect(updatedItem?.status).toBe('streaming');
-    expect(updatedItem?.isStreaming).toBe(true);
+    const item = getParentRoundTextItem(itemId);
+    expect(item?.content).toBe('Review started.');
+    expect(item?.status).toBe('streaming');
+    expect(item?.isStreaming).toBe(true);
+    expect(item?.isSubagentItem).toBe(true);
+    expect(item?.parentTaskToolId).toBe(parentToolId);
+    expect(item?.subagentSessionId).toBe(subagentSessionId);
   });
 });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SubagentModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SubagentModule.ts
@@ -4,27 +4,15 @@
 
 import { FlowChatStore } from '../../store/FlowChatStore';
 import { createLogger } from '@/shared/utils/logger';
-import { i18nService } from '@/infrastructure/i18n/core/I18nService';
 import type { FlowChatContext, FlowTextItem, SubagentTextChunkData, SubagentToolEventData } from './types';
 import type { FlowThinkingItem } from '../../types/flow-chat';
 import { processToolEvent } from './ToolEventModule';
 import type { ToolEventData } from '../EventBatcher';
 
 const log = createLogger('SubagentModule');
-const SUBAGENT_WAITING_PLACEHOLDER_FLAG = '_subagentWaitingPlaceholder';
-
-function getSubagentWaitingText(): string {
-  return i18nService.getT()('toolCards.taskDetailPanel.waitingForModelResponse', {
-    defaultValue: 'Waiting for model response...',
-  });
-}
 
 function getSubagentTextItemId(parentToolId: string, sessionId: string, roundId: string): string {
   return `subagent-text-${parentToolId}-${sessionId}-${roundId}`;
-}
-
-function isSubagentWaitingPlaceholder(item: unknown): boolean {
-  return !!(item as any)?.[SUBAGENT_WAITING_PLACEHOLDER_FLAG];
 }
 
 function findParentTurnId(parentSession: { dialogTurns: Array<{ id: string; modelRounds: Array<{ items: Array<{ id: string }> }> }> }, parentToolId: string): string | null {
@@ -41,58 +29,20 @@ function findParentTurnId(parentSession: { dialogTurns: Array<{ id: string; mode
 }
 
 /**
- * Show early progress inside the parent Task card before the first subagent token arrives.
+ * Subagent text items are now created on the first real text chunk only.
+ * The TaskDetailPanel loading state handles the waiting period.
  */
 export function routeModelRoundStartedToToolCard(
   _context: FlowChatContext,
-  parentSessionId: string,
-  parentToolId: string,
-  data: {
+  _parentSessionId: string,
+  _parentToolId: string,
+  _data: {
     sessionId: string;
     turnId: string;
     roundId: string;
   }
 ): void {
-  const store = FlowChatStore.getInstance();
-  const parentSession = store.getState().sessions.get(parentSessionId);
-
-  if (!parentSession) {
-    log.debug('Parent session not found (Subagent ModelRoundStarted)', { parentSessionId });
-    return;
-  }
-
-  const parentTurnId = findParentTurnId(parentSession, parentToolId);
-  if (!parentTurnId) {
-    log.debug('Parent tool DialogTurn not found', { parentSessionId, parentToolId });
-    return;
-  }
-
-  const itemId = getSubagentTextItemId(parentToolId, data.sessionId, data.roundId);
-  const parentTurn = parentSession.dialogTurns.find(turn => turn.id === parentTurnId);
-  const existingItem = parentTurn?.modelRounds.some(round =>
-    round.items.some(item => item.id === itemId)
-  );
-  if (existingItem) {
-    return;
-  }
-
-  const parentTool = store.findToolItem(parentSessionId, parentTurnId, parentToolId);
-  const parentTimestamp = parentTool?.timestamp || Date.now();
-  const newTextItem: FlowTextItem = {
-    id: itemId,
-    type: 'text',
-    content: getSubagentWaitingText(),
-    timestamp: parentTimestamp + 1,
-    isStreaming: true,
-    status: 'running',
-    isMarkdown: false,
-    isSubagentItem: true,
-    parentTaskToolId: parentToolId,
-    subagentSessionId: data.sessionId,
-    [SUBAGENT_WAITING_PLACEHOLDER_FLAG]: true,
-  } as any;
-
-  store.insertModelRoundItemAfterTool(parentSessionId, parentTurnId, parentToolId, newTextItem);
+  // No-op: placeholder items are no longer created.
 }
 
 /**
@@ -143,9 +93,7 @@ export function routeTextChunkToToolCard(
   }
   
   if (existingItem) {
-    const wasWaitingPlaceholder = isSubagentWaitingPlaceholder(existingItem);
-    const existingContent = wasWaitingPlaceholder ? '' : existingItem.content;
-    const content = existingContent + textContent;
+    const content = existingItem.content + textContent;
 
     if (isThinkingEnd) {
       store.updateModelRoundItem(parentSessionId, parentTurnId, itemId, {
@@ -154,7 +102,6 @@ export function routeTextChunkToToolCard(
         isCollapsed: true,
         status: 'completed',
         timestamp: Date.now(),
-        [SUBAGENT_WAITING_PLACEHOLDER_FLAG]: false,
       } as any);
       
     } else {
@@ -164,7 +111,6 @@ export function routeTextChunkToToolCard(
         isMarkdown: !isThinking,
         status: 'streaming',
         timestamp: Date.now(),
-        [SUBAGENT_WAITING_PLACEHOLDER_FLAG]: false,
       } as any);
     }
   } else {

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -749,7 +749,6 @@
       "noData": "Unable to load task data",
       "executionContent": "Execution Content",
       "duration": "Duration",
-      "waitingForModelResponse": "Waiting for model response...",
       "status": {
         "pending": "Pending",
         "running": "Running",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -749,7 +749,6 @@
       "noData": "无法加载任务数据",
       "executionContent": "执行内容",
       "duration": "耗时",
-      "waitingForModelResponse": "等待模型响应...",
       "status": {
         "pending": "等待中",
         "running": "执行中",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -719,7 +719,6 @@
       "noData": "無法加載任務數據",
       "executionContent": "執行內容",
       "duration": "耗時",
-      "waitingForModelResponse": "等待模型回應...",
       "status": {
         "pending": "等待中",
         "running": "執行中",


### PR DESCRIPTION
No longer create 'Waiting for model response...' placeholder items when a subagent model round starts. Instead, subagent text items are created directly from the first real text chunk. The TaskDetailPanel loading state (DotMatrixLoader + running status) covers the gap.

This eliminates repetitive placeholder creation (which fired for every subagent round) and removes the i18n race-window where the static placeholder text could not react to language changes.