### PR TITLE
fix(flow-chat): improve deep review interruption UX

### DIFF
--- a/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.tsx
@@ -10,8 +10,7 @@ import {
   ChevronUp,
   X,
   MessageSquare,
-  RotateCcw,
-  Settings,
+  Play,
   Copy,
 } from 'lucide-react';
 import { Button, Checkbox, Tooltip } from '@/component-library';
@@ -23,7 +22,8 @@ import { flowChatManager } from '../../services/FlowChatManager';
 import { globalEventBus } from '@/infrastructure/event-bus';
 import { notificationService } from '@/shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
-import { openModelSettings } from '@/shared/ai-errors/aiErrorActions';
+import { getAiErrorPresentation } from '@/shared/ai-errors/aiErrorPresenter';
+import { confirmWarning } from '@/component-library/components/ConfirmDialog/confirmService';
 import './DeepReviewActionBar.scss';
 
 const log = createLogger('DeepReviewActionBar');
@@ -162,11 +162,22 @@ export const DeepReviewActionBar: React.FC = () => {
 
   const handleContinueReview = useCallback(async () => {
     if (!interruption) return;
+
     if (!interruption.canResume) {
-      notificationService.warning(t('deepReviewActionBar.resumeBlockedHint', {
-        defaultValue: 'Resolve the model configuration or quota issue before continuing.',
-      }));
-      return;
+      const confirmed = await confirmWarning(
+        t('deepReviewActionBar.resumeBlockedConfirmTitle', {
+          defaultValue: 'Continue review?',
+        }),
+        t('deepReviewActionBar.resumeBlockedConfirmMessage', {
+          defaultValue: 'The error that interrupted the review has not been resolved. Continuing may fail again. Do you want to proceed?',
+        }),
+        {
+          confirmText: t('deepReviewActionBar.resumeBlockedConfirmAction', {
+            defaultValue: 'Continue anyway',
+          }),
+        },
+      );
+      if (!confirmed) return;
     }
 
     store.setActiveAction('resume');
@@ -174,7 +185,7 @@ export const DeepReviewActionBar: React.FC = () => {
     try {
       await continueDeepReviewSession(interruption, t('deepReviewActionBar.resumeRequestDisplay', {
         defaultValue: 'Continue interrupted Deep Review',
-      }));
+      }), { force: !interruption.canResume });
     } catch (error) {
       log.error('Failed to continue interrupted Deep Review', { childSessionId, error });
       const message = t('deepReviewActionBar.resumeFailedMessage', {
@@ -187,18 +198,44 @@ export const DeepReviewActionBar: React.FC = () => {
     }
   }, [childSessionId, interruption, store, t]);
 
-  const handleOpenModelSettings = useCallback(() => {
-    openModelSettings();
-  }, []);
-
   const handleCopyDiagnostics = useCallback(() => {
     const detail = interruption?.errorDetail;
-    const diagnostics = [
-      `category=${detail?.category ?? 'unknown'}`,
-      detail?.provider ? `provider=${detail.provider}` : null,
-      detail?.providerCode ? `code=${detail.providerCode}` : null,
-      detail?.requestId ? `request_id=${detail.requestId}` : null,
-    ].filter(Boolean).join(', ');
+    if (!detail) return;
+
+    const presentation = getAiErrorPresentation(detail);
+
+    const lines: string[] = [];
+    lines.push(t('deepReviewActionBar.diagnosticsTitle', { defaultValue: '=== Deep Review Interruption Diagnostics ===' }));
+    lines.push('');
+
+    const categoryLabel = t(presentation.titleKey, { defaultValue: presentation.category });
+    const categoryMessage = t(presentation.messageKey, { defaultValue: '' });
+    lines.push(`${t('deepReviewActionBar.diagnosticsErrorType', { defaultValue: 'Error type' })}: ${categoryLabel} (${presentation.category})`);
+    if (categoryMessage) {
+      lines.push(`${t('deepReviewActionBar.diagnosticsDescription', { defaultValue: 'Description' })}: ${categoryMessage}`);
+    }
+    lines.push('');
+
+    if (presentation.actions.length > 0) {
+      const actionLabels = presentation.actions.map((action) => {
+        return t(action.labelKey, { defaultValue: action.code });
+      });
+      lines.push(`${t('deepReviewActionBar.diagnosticsSuggestedActions', { defaultValue: 'Suggested actions' })}: ${actionLabels.join(', ')}`);
+      lines.push('');
+    }
+
+    lines.push(`${t('deepReviewActionBar.diagnosticsTechnicalDetails', { defaultValue: 'Technical details' })}:`);
+    lines.push(`  - category: ${detail.category ?? 'unknown'}`);
+    if (detail.provider) lines.push(`  - provider: ${detail.provider}`);
+    if (detail.providerCode) lines.push(`  - provider code: ${detail.providerCode}`);
+    if (detail.providerMessage) lines.push(`  - provider message: ${detail.providerMessage}`);
+    if (detail.httpStatus) lines.push(`  - HTTP status: ${detail.httpStatus}`);
+    if (detail.requestId) lines.push(`  - request ID: ${detail.requestId}`);
+    if (detail.rawMessage) {
+      lines.push(`  - raw message: ${detail.rawMessage}`);
+    }
+
+    const diagnostics = lines.join('\n');
     void navigator.clipboard?.writeText(diagnostics);
     notificationService.success(t('deepReviewActionBar.diagnosticsCopied', {
       defaultValue: 'Diagnostics copied',
@@ -398,24 +435,14 @@ export const DeepReviewActionBar: React.FC = () => {
 
         {hasInterruption && (
           <>
-            {interruption?.recommendedActions.some((action) => action.code === 'open_model_settings') && (
-              <Button
-                variant={interruption.canResume ? 'secondary' : 'primary'}
-                size="small"
-                onClick={handleOpenModelSettings}
-              >
-                <Settings size={13} />
-                {t('deepReviewActionBar.openModelSettings', { defaultValue: 'Open model settings' })}
-              </Button>
-            )}
             <Button
-              variant={interruption?.canResume ? 'primary' : 'secondary'}
+              variant="primary"
               size="small"
               isLoading={activeAction === 'resume'}
-              disabled={activeAction !== null || !interruption?.canResume}
+              disabled={activeAction !== null}
               onClick={() => void handleContinueReview()}
             >
-              <RotateCcw size={13} />
+              <Play size={13} />
               {t('deepReviewActionBar.resumeReview', { defaultValue: 'Continue review' })}
             </Button>
             <Button

--- a/src/web-ui/src/flow_chat/services/DeepReviewContinuationService.ts
+++ b/src/web-ui/src/flow_chat/services/DeepReviewContinuationService.ts
@@ -7,8 +7,9 @@ import {
 export async function continueDeepReviewSession(
   interruption: DeepReviewInterruption,
   displayMessage: string,
+  { force = false }: { force?: boolean } = {},
 ): Promise<void> {
-  if (!interruption.canResume) {
+  if (!interruption.canResume && !force) {
     throw new Error('deep_review_resume_blocked');
   }
 

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -388,12 +388,20 @@
     "resumeRunning": "Continuing review...",
     "resumeFailed": "Continue failed",
     "resumeBlockedHint": "Resolve the model configuration or quota issue before continuing.",
+    "resumeBlockedConfirmTitle": "Continue review?",
+    "resumeBlockedConfirmMessage": "The error that interrupted the review has not been resolved. Continuing may fail again. Do you want to proceed?",
+    "resumeBlockedConfirmAction": "Continue anyway",
     "resumeReview": "Continue review",
     "resumeRequestDisplay": "Continue interrupted Deep Review",
     "resumeFailedMessage": "Unable to continue Deep Review. Check the model settings or try again later.",
     "openModelSettings": "Open model settings",
     "copyDiagnostics": "Copy diagnostics",
-    "diagnosticsCopied": "Diagnostics copied"
+    "diagnosticsCopied": "Diagnostics copied",
+    "diagnosticsTitle": "=== Deep Review Interruption Diagnostics ===",
+    "diagnosticsErrorType": "Error type",
+    "diagnosticsDescription": "Description",
+    "diagnosticsSuggestedActions": "Suggested actions",
+    "diagnosticsTechnicalDetails": "Technical details"
   },
   "deepReviewConsent": {
     "windowTitle": "Deep Review",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -388,12 +388,20 @@
     "resumeRunning": "正在继续审查...",
     "resumeFailed": "继续失败",
     "resumeBlockedHint": "请先处理模型配置或额度问题，再继续审查。",
+    "resumeBlockedConfirmTitle": "继续审查？",
+    "resumeBlockedConfirmMessage": "导致审查中断的错误尚未解决，继续审查可能会再次失败。是否仍要继续？",
+    "resumeBlockedConfirmAction": "仍然继续",
     "resumeReview": "继续审查",
     "resumeRequestDisplay": "继续中断的深度审查",
     "resumeFailedMessage": "无法继续深度审查。请检查模型设置，或稍后重试。",
     "openModelSettings": "打开模型设置",
     "copyDiagnostics": "复制诊断信息",
-    "diagnosticsCopied": "诊断信息已复制"
+    "diagnosticsCopied": "诊断信息已复制",
+    "diagnosticsTitle": "=== 深度审查中断诊断信息 ===",
+    "diagnosticsErrorType": "错误类型",
+    "diagnosticsDescription": "错误描述",
+    "diagnosticsSuggestedActions": "建议操作",
+    "diagnosticsTechnicalDetails": "技术详情"
   },
   "deepReviewConsent": {
     "windowTitle": "深度审查",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -379,12 +379,20 @@
     "resumeRunning": "正在繼續審查...",
     "resumeFailed": "繼續失敗",
     "resumeBlockedHint": "請先處理模型配置或額度問題，再繼續審查。",
+    "resumeBlockedConfirmTitle": "繼續審查？",
+    "resumeBlockedConfirmMessage": "導致審查中斷的錯誤尚未解決，繼續審查可能會再次失敗。是否仍要繼續？",
+    "resumeBlockedConfirmAction": "仍然繼續",
     "resumeReview": "繼續審查",
     "resumeRequestDisplay": "繼續中斷的深度審查",
     "resumeFailedMessage": "無法繼續深度審查。請檢查模型設置，或稍後重試。",
     "openModelSettings": "打開模型設置",
     "copyDiagnostics": "複製診斷信息",
-    "diagnosticsCopied": "診斷信息已複製"
+    "diagnosticsCopied": "診斷信息已複製",
+    "diagnosticsTitle": "=== 深度審查中斷診斷信息 ===",
+    "diagnosticsErrorType": "錯誤類型",
+    "diagnosticsDescription": "錯誤描述",
+    "diagnosticsSuggestedActions": "建議操作",
+    "diagnosticsTechnicalDetails": "技術詳情"
   },
   "deepReviewConsent": {
     "windowTitle": "深度審查",


### PR DESCRIPTION
- Replace hard-block on resume with user confirmation dialog when canResume is false, allowing users to proceed at their own discretion
- Remove meaningless "Open model settings" button from interruption action bar
- Change continue-review icon from RotateCcw to Play to avoid confusion with restart/retry semantics
- Enrich "Copy diagnostics" output with full error description, suggested actions, and structured technical details instead of bare key=value pairs
- Add force option to continueDeepReviewSession for confirmed bypass
- Add zh-CN/en-US/zh-TW locale keys for confirmation dialog and diagnostic labels