### PR TITLE
fix(deep-review): honor reviewer strategy models

### DIFF
--- a/src/crates/core/src/agentic/agents/prompts/deep_review_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/deep_review_agent.md
@@ -23,7 +23,7 @@ The first three reviewers must run **in parallel** using separate Task tool call
 
 The user request may also include a **configured team manifest** with additional reviewer agents. Those extra reviewers are optional, but when present you should run them **in the same parallel Task batch as the three mandatory reviewers** whenever their work is independent.
 
-The configured manifest may also include an **execution policy** with reviewer timeout, judge timeout, a team review strategy, per-reviewer strategy overrides, and file-split parameters. Treat that policy as authoritative.
+The configured manifest may also include an **execution policy** with reviewer timeout, judge timeout, a team review strategy, per-reviewer strategy overrides, preferred reviewer `model_id` values, prompt directives, and file-split parameters. Treat that policy and roster as authoritative.
 
 ### File splitting for large review targets
 
@@ -115,19 +115,21 @@ If extra reviewers are configured, launch them in the **same message** as additi
 
 If the execution policy says `reviewer_timeout_seconds > 0`, pass `timeout_seconds` with that value to every reviewer Task call in this batch.
 
+If a configured reviewer entry provides `model_id`, pass `model_id` with that value to the matching reviewer Task call.
+
 If the configured team manifest provides a preferred display label or nickname for a reviewer, reuse that nickname in the Task `description` so the user can easily track each reviewer in the session UI.
 
 Each reviewer Task prompt must include:
 
 - the exact review target (for split instances: the assigned file group only)
 - any user-provided focus text
-- the reviewer-specific strategy from the configured manifest (`quick`, `normal`, or `deep`) and its prompt directive
+- the reviewer-specific strategy from the configured manifest (`quick`, `normal`, or `deep`) and its exact `prompt_directive`
 - a reminder to stay read-only
 - a request for concrete findings only
 - a strict output format that is easy to verify later
 - for split instances: an explicit list of the files this instance is responsible for, and an instruction not to review files outside the assigned group unless a cross-file dependency is critical
 
-Strategy guidance:
+Strategy guidance (fallback only; the configured `prompt_directive` is the source of truth):
 
 - `quick`: brief the reviewer to stay diff-focused and report only high-confidence correctness, security, or regression risks.
 - `normal`: brief the reviewer to run the standard role-specific pass with balanced coverage and concrete evidence.
@@ -143,6 +145,8 @@ After the reviewer batch finishes, launch `ReviewJudge` with:
 - an instruction to validate, reject, merge, or downgrade findings, and to deduplicate any overlapping findings from same-role instances
 
 If the execution policy says `judge_timeout_seconds > 0`, pass `timeout_seconds` with that value to the judge Task call.
+
+If the configured ReviewJudge entry provides `model_id`, pass `model_id` with that value to the ReviewJudge Task call.
 
 The judge must explicitly call out:
 

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -2534,6 +2534,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
     /// - subagent_parent_info: Parent info (tool call context)
     /// - context: Additional context
     /// - cancel_token: Optional cancel token (for async cancellation)
+    /// - model_id: Optional model override for the subagent session
     ///
     /// Returns SubagentResult with the final text response
     pub async fn execute_subagent(
@@ -2544,6 +2545,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         workspace_path: Option<String>,
         context: Option<HashMap<String, String>>,
         cancel_token: Option<&CancellationToken>,
+        model_id: Option<String>,
         timeout_seconds: Option<u64>,
     ) -> BitFunResult<SubagentResult> {
         let workspace_path = workspace_path.ok_or_else(|| {
@@ -2551,6 +2553,9 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 "workspace_path is required when creating a subagent session".to_string(),
             )
         })?;
+        let model_id = model_id
+            .map(|model_id| model_id.trim().to_string())
+            .filter(|model_id| !model_id.is_empty());
 
         self.execute_hidden_subagent_internal(
             HiddenSubagentExecutionRequest {
@@ -2558,6 +2563,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 agent_type,
                 session_config: SessionConfig {
                     workspace_path: Some(workspace_path),
+                    model_id,
                     ..SessionConfig::default()
                 },
                 initial_messages: vec![Message::user(task_description)],

--- a/src/crates/core/src/agentic/tools/implementations/task_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/task_tool.rs
@@ -73,6 +73,7 @@ Usage notes:
 - Provide clear, detailed prompt so the agent can work autonomously and return exactly the information you need.
 - If 'workspace_path' is omitted, the task inherits the current workspace by default.
 - The 'workspace_path' parameter must still be provided explicitly for the Explore and FileFinder agent.
+- Use 'model_id' when a caller needs a specific model or model slot for the subagent. Omit it to use the agent default.
 - Use 'timeout_seconds' when you need a hard deadline for the subagent. Omit it or set it to 0 to disable the timeout.
 - Launch multiple agents concurrently whenever possible, to maximize performance; to do that, use a single message with multiple tool calls
 - When the agent is done, it will return a single message back to you.
@@ -187,6 +188,10 @@ impl Tool for TaskTool {
                     "type": "string",
                     "description": "The absolute path of the workspace for this task. If omitted, inherits the current workspace. Explore/FileFinder must provide it explicitly."
                 },
+                "model_id": {
+                    "type": "string",
+                    "description": "Optional model ID or model slot alias for this subagent task. Omit it to use the agent default."
+                },
                 "timeout_seconds": {
                     "type": "integer",
                     "minimum": 0,
@@ -283,6 +288,16 @@ impl Tool for TaskTool {
             .get("workspace_path")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        let model_id = match input.get("model_id") {
+            Some(value) => {
+                let value = value
+                    .as_str()
+                    .ok_or_else(|| BitFunError::tool("model_id must be a string".to_string()))?;
+                let value = value.trim();
+                (!value.is_empty()).then(|| value.to_string())
+            }
+            None => None,
+        };
         let mut timeout_seconds = match input.get("timeout_seconds") {
             Some(value) => {
                 let parsed = value.as_u64().ok_or_else(|| {
@@ -447,6 +462,7 @@ impl Tool for TaskTool {
                 Some(effective_workspace_path.clone()),
                 None,
                 context.cancellation_token.as_ref(),
+                model_id,
                 timeout_seconds,
             )
             .await?;
@@ -466,10 +482,26 @@ impl Tool for TaskTool {
 
 #[cfg(test)]
 mod tests {
+    use super::TaskTool;
     use crate::agentic::deep_review_policy::{
         DeepReviewBudgetTracker, DeepReviewExecutionPolicy, DeepReviewSubagentRole,
     };
+    use crate::agentic::tools::framework::Tool;
     use serde_json::json;
+
+    #[test]
+    fn task_schema_accepts_optional_model_id() {
+        let schema = TaskTool::new().input_schema();
+
+        assert_eq!(schema["properties"]["model_id"]["type"], "string");
+        assert!(
+            !schema["required"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|value| value.as_str() == Some("model_id"))
+        );
+    }
 
     #[test]
     fn deep_review_policy_allows_only_configured_team_members() {

--- a/src/crates/core/src/service/project_context/service.rs
+++ b/src/crates/core/src/service/project_context/service.rs
@@ -285,6 +285,7 @@ impl ProjectContextService {
                 None,
                 Some(&cancel_token),
                 None,
+                None,
             )
             .await;
 

--- a/src/web-ui/src/shared/services/reviewTeamService.test.ts
+++ b/src/web-ui/src/shared/services/reviewTeamService.test.ts
@@ -3,6 +3,7 @@ import { configAPI } from '@/infrastructure/api/service-api/ConfigAPI';
 import {
   DEFAULT_REVIEW_TEAM_EXECUTION_POLICY,
   DEFAULT_REVIEW_TEAM_STRATEGY_LEVEL,
+  REVIEW_STRATEGY_DEFINITIONS,
   buildEffectiveReviewTeamManifest,
   buildReviewTeamPromptBlock,
   canUseSubagentAsReviewTeamMember,
@@ -278,28 +279,40 @@ describe('reviewTeamService', () => {
         subagentId: 'ReviewBusinessLogic',
         strategyLevel: 'quick',
         strategySource: 'team',
+        defaultModelSlot: 'fast',
+        strategyDirective: REVIEW_STRATEGY_DEFINITIONS.quick.promptDirective,
       }),
       expect.objectContaining({
         subagentId: 'ReviewPerformance',
         strategyLevel: 'quick',
         strategySource: 'team',
+        defaultModelSlot: 'fast',
+        strategyDirective: REVIEW_STRATEGY_DEFINITIONS.quick.promptDirective,
       }),
       expect.objectContaining({
         subagentId: 'ReviewSecurity',
         strategyLevel: 'deep',
         strategySource: 'member',
+        model: 'primary',
+        defaultModelSlot: 'primary',
+        strategyDirective: REVIEW_STRATEGY_DEFINITIONS.deep.promptDirective,
       }),
     ]);
     expect(manifest.enabledExtraReviewers[0]).toMatchObject({
       subagentId: 'ExtraEnabled',
       strategyLevel: 'normal',
       strategySource: 'member',
+      defaultModelSlot: 'fast',
+      strategyDirective: REVIEW_STRATEGY_DEFINITIONS.normal.promptDirective,
     });
 
     const promptBlock = buildReviewTeamPromptBlock(team, manifest);
     expect(promptBlock).toContain('- team_strategy: quick');
     expect(promptBlock).toContain('subagent_type: ReviewSecurity');
     expect(promptBlock).toContain('strategy: deep');
+    expect(promptBlock).toContain('model_id: primary');
+    expect(promptBlock).toContain(`prompt_directive: ${REVIEW_STRATEGY_DEFINITIONS.deep.promptDirective}`);
+    expect(promptBlock).toContain('pass model_id with that value to the matching Task call');
     expect(promptBlock).toContain('Token/time impact: approximately 1.8-2.5x token usage and 1.5-2.5x runtime.');
   });
 

--- a/src/web-ui/src/shared/services/reviewTeamService.ts
+++ b/src/web-ui/src/shared/services/reviewTeamService.ts
@@ -22,7 +22,11 @@ export type ReviewMemberStrategyLevel = ReviewStrategyLevel | 'inherit';
 export type ReviewStrategySource = 'team' | 'member';
 export type ReviewModelFallbackReason = 'model_removed';
 
-export interface ReviewStrategyDefinition {
+export interface ReviewStrategyCommonRules {
+  reviewerPromptRules: string[];
+}
+
+export interface ReviewStrategyProfile {
   level: ReviewStrategyLevel;
   label: string;
   summary: string;
@@ -38,9 +42,17 @@ export const REVIEW_STRATEGY_LEVELS: ReviewStrategyLevel[] = [
   'deep',
 ];
 
-export const REVIEW_STRATEGY_DEFINITIONS: Record<
+export const REVIEW_STRATEGY_COMMON_RULES: ReviewStrategyCommonRules = {
+  reviewerPromptRules: [
+    'Each reviewer must follow its own strategy field.',
+    'Member-level strategy overrides take precedence over the team strategy.',
+    'The reviewer Task prompt must include the resolved prompt_directive.',
+  ],
+};
+
+export const REVIEW_STRATEGY_PROFILES: Record<
   ReviewStrategyLevel,
-  ReviewStrategyDefinition
+  ReviewStrategyProfile
 > = {
   quick: {
     level: 'quick',
@@ -76,6 +88,15 @@ export const REVIEW_STRATEGY_DEFINITIONS: Record<
       'Run a thorough role-specific pass. Inspect edge cases, cross-file interactions, failure modes, and remediation tradeoffs before finalizing findings.',
   },
 };
+
+export const REVIEW_STRATEGY_DEFINITIONS = REVIEW_STRATEGY_PROFILES;
+export type ReviewStrategyDefinition = ReviewStrategyProfile;
+
+export function getReviewStrategyProfile(
+  strategyLevel: ReviewStrategyLevel,
+): ReviewStrategyProfile {
+  return REVIEW_STRATEGY_PROFILES[strategyLevel];
+}
 
 export type ReviewTeamCoreRoleKey =
   | 'businessLogic'
@@ -152,8 +173,10 @@ export interface ReviewTeamManifestMember {
   model: string;
   configuredModel: string;
   modelFallbackReason?: ReviewModelFallbackReason;
+  defaultModelSlot: ReviewStrategyProfile['defaultModelSlot'];
   strategyLevel: ReviewStrategyLevel;
   strategySource: ReviewStrategySource;
+  strategyDirective: string;
   locked: boolean;
   source: ReviewTeamMember['source'];
   subagentSource: ReviewTeamMember['subagentSource'];
@@ -541,8 +564,7 @@ function resolveMemberModel(
   modelFallbackReason?: ReviewModelFallbackReason;
 } {
   const normalizedConfiguredModel = configuredModel?.trim() || '';
-  const defaultModelSlot =
-    REVIEW_STRATEGY_DEFINITIONS[strategyLevel].defaultModelSlot;
+  const defaultModelSlot = getReviewStrategyProfile(strategyLevel).defaultModelSlot;
 
   if (
     !normalizedConfiguredModel ||
@@ -755,6 +777,7 @@ function toManifestMember(
   member: ReviewTeamMember,
   reason?: ReviewTeamManifestMember['reason'],
 ): ReviewTeamManifestMember {
+  const strategyProfile = getReviewStrategyProfile(member.strategyLevel);
   return {
     subagentId: member.subagentId,
     displayName: member.displayName,
@@ -762,8 +785,10 @@ function toManifestMember(
     model: member.model || DEFAULT_REVIEW_TEAM_MODEL,
     configuredModel: member.configuredModel || member.model || DEFAULT_REVIEW_TEAM_MODEL,
     modelFallbackReason: member.modelFallbackReason,
+    defaultModelSlot: strategyProfile.defaultModelSlot,
     strategyLevel: member.strategyLevel,
     strategySource: member.strategySource,
+    strategyDirective: strategyProfile.promptDirective,
     locked: member.locked,
     source: member.source,
     subagentSource: member.subagentSource,
@@ -820,7 +845,7 @@ function formatResponsibilities(items: string[]): string {
 }
 
 function formatStrategyImpact(strategyLevel: ReviewStrategyLevel): string {
-  const definition = REVIEW_STRATEGY_DEFINITIONS[strategyLevel];
+  const definition = getReviewStrategyProfile(strategyLevel);
   return `Token/time impact: approximately ${definition.tokenImpact} token usage and ${definition.runtimeImpact} runtime.`;
 }
 
@@ -852,24 +877,39 @@ export function buildReviewTeamPromptBlock(
       ? [manifest.qualityGateReviewer.subagentId]
       : []),
   ]);
+  const activeManifestMembers = [
+    ...manifest.coreReviewers,
+    ...(manifest.qualityGateReviewer ? [manifest.qualityGateReviewer] : []),
+    ...manifest.enabledExtraReviewers,
+  ];
+  const manifestMemberBySubagentId = new Map(
+    activeManifestMembers.map((member) => [member.subagentId, member]),
+  );
   const members = team.members
     .filter((member) => member.available && activeSubagentIds.has(member.subagentId))
-    .map((member) => [
-      `- ${member.displayName}`,
-      `  - subagent_type: ${member.subagentId}`,
-      `  - preferred_task_label: ${member.displayName}`,
-      `  - role: ${member.roleName}`,
-      `  - locked_core_role: ${member.locked ? 'yes' : 'no'}`,
-      `  - strategy: ${member.strategyLevel}`,
-      `  - strategy_source: ${member.strategySource}`,
-      `  - model: ${member.model || DEFAULT_REVIEW_TEAM_MODEL}`,
-      `  - configured_model: ${member.configuredModel || member.model || DEFAULT_REVIEW_TEAM_MODEL}`,
-      ...(member.modelFallbackReason
-        ? [`  - model_fallback: ${member.modelFallbackReason}`]
-        : []),
-      '  - responsibilities:',
-      formatResponsibilities(member.responsibilities),
-    ].join('\n'))
+    .map((member) => {
+      const manifestMember =
+        manifestMemberBySubagentId.get(member.subagentId) ?? toManifestMember(member);
+      return [
+        `- ${manifestMember.displayName}`,
+        `  - subagent_type: ${manifestMember.subagentId}`,
+        `  - preferred_task_label: ${manifestMember.displayName}`,
+        `  - role: ${manifestMember.roleName}`,
+        `  - locked_core_role: ${manifestMember.locked ? 'yes' : 'no'}`,
+        `  - strategy: ${manifestMember.strategyLevel}`,
+        `  - strategy_source: ${manifestMember.strategySource}`,
+        `  - default_model_slot: ${manifestMember.defaultModelSlot}`,
+        `  - model: ${manifestMember.model || DEFAULT_REVIEW_TEAM_MODEL}`,
+        `  - model_id: ${manifestMember.model || DEFAULT_REVIEW_TEAM_MODEL}`,
+        `  - configured_model: ${manifestMember.configuredModel || manifestMember.model || DEFAULT_REVIEW_TEAM_MODEL}`,
+        ...(manifestMember.modelFallbackReason
+          ? [`  - model_fallback: ${manifestMember.modelFallbackReason}`]
+          : []),
+        `  - prompt_directive: ${manifestMember.strategyDirective}`,
+        '  - responsibilities:',
+        formatResponsibilities(member.responsibilities),
+      ].join('\n');
+    })
     .join('\n');
   const executionPolicy = [
     `- reviewer_timeout_seconds: ${team.executionPolicy.reviewerTimeoutSeconds}`,
@@ -894,7 +934,7 @@ export function buildReviewTeamPromptBlock(
       : ['  - none']),
   ].join('\n');
   const strategyRules = REVIEW_STRATEGY_LEVELS.map((level) => {
-    const definition = REVIEW_STRATEGY_DEFINITIONS[level];
+    const definition = getReviewStrategyProfile(level);
     return [
       `- ${level}: ${definition.summary}`,
       `  - ${formatStrategyImpact(level)}`,
@@ -902,6 +942,9 @@ export function buildReviewTeamPromptBlock(
       `  - Prompt directive: ${definition.promptDirective}`,
     ].join('\n');
   }).join('\n');
+  const commonStrategyRules = REVIEW_STRATEGY_COMMON_RULES.reviewerPromptRules
+    .map((rule) => `- ${rule}`)
+    .join('\n');
 
   return [
     manifestBlock,
@@ -913,6 +956,7 @@ export function buildReviewTeamPromptBlock(
     '- Always run the three locked reviewer roles first: ReviewBusinessLogic, ReviewPerformance, and ReviewSecurity.',
     '- Run ReviewJudge only after the reviewer batch finishes, as the quality-gate pass.',
     '- If extra reviewers are configured and enabled, run them in parallel with the three locked reviewers whenever possible.',
+    '- When a configured member entry provides model_id, pass model_id with that value to the matching Task call.',
     '- If reviewer_timeout_seconds is greater than 0, pass timeout_seconds with that value to every reviewer Task call.',
     '- If judge_timeout_seconds is greater than 0, pass timeout_seconds with that value to the ReviewJudge Task call.',
     '- If reviewer_file_split_threshold is greater than 0 and the target file count exceeds it, split files across multiple same-role reviewer instances (up to max_same_role_instances per role). Launch all split instances in the same parallel message.',
@@ -922,7 +966,8 @@ export function buildReviewTeamPromptBlock(
     '- The Review Quality Inspector must validate findings from every reviewer (including all same-role instances) before the final report.',
     'Review strategy rules:',
     `- Team strategy: ${team.strategyLevel}. ${formatStrategyImpact(team.strategyLevel)}`,
-    '- Each reviewer must follow its own strategy field. Member-level strategy overrides take precedence over the team strategy.',
+    commonStrategyRules,
+    'Review strategy profiles:',
     strategyRules,
   ].join('\n');
 }


### PR DESCRIPTION
## Summary
- Split Deep Review strategy profiles from shared strategy rules for easier extension.
- Include resolved `model_id` and `prompt_directive` in the review-team prompt roster.
- Allow `Task` calls to pass `model_id` into hidden subagent sessions.

## Verification
- pnpm --dir src/web-ui run test:run reviewTeamService
- cargo test -p bitfun-core task_schema_accepts_optional_model_id -- --nocapture
- cargo test -p bitfun-core deep_review -- --nocapture
- pnpm run lint:web
- pnpm run type-check:web
- pnpm --dir src/web-ui run test:run
- cargo check --workspace
- cargo test --workspace
- git diff --check
