### PR TITLE
feat(flow-chat): increase expanded preview max height for file operat…

### DIFF
--- a/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
@@ -69,7 +69,23 @@ I've found some existing telemetry code. Let me mark the first todo as in_progre
 </example>
 
 # Asking questions as you work
-You have access to the AskUserQuestion tool to ask the user questions when you need clarification, want to validate assumptions, or need to make a decision you're unsure about. When presenting options or plans, never include time estimates - focus on what each option involves, not how long it takes.
+You have access to the AskUserQuestion tool to ask the user questions when you need clarification, want to validate assumptions, or need to make a decision you're unsure about.
+
+Use this tool when:
+- The request is ambiguous or underspecified
+- Multiple valid approaches exist with different trade-offs
+- The change affects more than 3 files or modifies critical configuration
+- The action is destructive (delete, overwrite, git reset, schema migration, etc.)
+- You are unsure about the user's intent or preferences
+- The decision has security, performance, or architectural implications
+
+When presenting options:
+- State your recommendation clearly and explain WHY
+- Make your recommended option the first option and add "(Recommended)"
+- Provide 2-4 concrete options with trade-off descriptions
+- Wait for the user's reply before proceeding
+
+When presenting options or plans, never include time estimates - focus on what each option involves, not how long it takes.
 
 {VISUAL_MODE}
 # Doing tasks

--- a/src/crates/core/src/agentic/tools/implementations/ask_user_question_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/ask_user_question_tool.rs
@@ -171,11 +171,29 @@ impl Tool for AskUserQuestionTool {
     }
 
     async fn description(&self) -> BitFunResult<String> {
-        Ok(r#"Use this tool when you need to ask the user question during execution. This allows you to:
+        Ok(r#"Use this tool when you need to ask the user questions during execution. This allows you to:
 1. Gather user preferences or requirements
 2. Clarify ambiguous instructions
 3. Get decisions on implementation choices as you work
-4. Offer choices to the user about what direction to take.
+4. Offer choices to the user about what direction to take
+
+WHEN TO USE:
+- The request is ambiguous or could be interpreted in multiple ways
+- Multiple valid approaches exist with different trade-offs
+- The change affects critical files or has significant impact
+- You are unsure about the user's intent or preferences
+- The decision has security, performance, or architectural implications
+
+WHEN NOT TO USE:
+- The request is clear and specific
+- You are following an already-approved plan exactly
+- The change is trivial and clearly correct
+
+RECOMMENDATION GUIDELINES:
+- Always state your recommendation and reasoning
+- Make your recommended option the first option in the list
+- Add "(Recommended)" at the end of the recommended option's label
+- Provide 2-4 clear options with descriptions of trade-offs
 
 Usage notes:
 - This tool ends the current dialog turn and waits for the user's reply before the assistant continues

--- a/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.scss
@@ -3,11 +3,18 @@
  * Provides unified card appearance and interaction effects
  */
 
+/* ========== Shared header variables ========== */
+:root {
+  --tool-card-header-pad-y: 7px;
+  --tool-card-header-pad-x: 10px;
+  --tool-card-header-icon-rail: 24px;
+}
+
 /* ========== Card wrapper ========== */
 .base-tool-card-wrapper {
   display: flex;
   flex-direction: column;
-  margin: 6px 0;
+  margin: 4px 0;
   border-radius: 8px;
   border: 1px solid var(--border-base);
   background: var(--color-bg-flowchat);
@@ -88,11 +95,6 @@
 
 /* ========== Header row styles ========== */
 .base-tool-card-header {
-  /* Used by icon-rail divider to meet card inner top/bottom for this row */
-  --tool-card-header-pad-y: 10px;
-  --tool-card-header-pad-x: 10px;
-  --tool-card-header-icon-rail: 28px;
-
   display: flex;
   align-items: center;
   gap: 4px;

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -442,7 +442,12 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
       return;
     }
     
-    if (currentFilePath && sessionId && status === 'completed') {
+    if (status !== 'completed') {
+      applyContentExpandedState(!isContentExpanded, 'manual');
+      return;
+    }
+
+    if (currentFilePath && sessionId) {
       handleOpenInCodeEditor();
       return;
     }
@@ -451,9 +456,11 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
       onOpenInEditor(currentFilePath);
     }
   }, [
+    applyContentExpandedState,
     applyErrorExpandedState,
     currentFilePath,
     handleOpenInCodeEditor,
+    isContentExpanded,
     isErrorExpanded,
     isFailed,
     onOpenInEditor,
@@ -691,7 +698,6 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
 
   const expandedContent = renderExpandedContent();
   const hasExpandableContent =
-    status === 'completed' &&
     !isFailed &&
     !isDeleteTool &&
     Boolean(expandedContent);
@@ -699,7 +705,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   const isCardContentExpanded =
     !isDeleteTool &&
     !isFailed &&
-    (status === 'completed' ? isContentExpanded : true);
+    isContentExpanded;
 
   const opensPanelOnClick =
     !isFailed &&

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
@@ -1,9 +1,9 @@
 /**
  * Terminal tool card styles
- * Specific styles based on CompactToolCard
+ * Specific styles based on BaseToolCard
  */
 
-@use './CompactToolCard.scss';
+@use './BaseToolCard.scss';
 @use '../../component-library/styles/_extended-mixins' as mixins;
 
 /* ========== Terminal card specific styles ========== */
@@ -15,33 +15,33 @@
   }
 }
 
-/* Entire compact card shows pointer (card toggles expand); children must not force default cursor. */
-.compact-tool-card.terminal-tool-card {
+/* Entire base card shows pointer (card toggles expand); children must not force default cursor. */
+.base-tool-card-wrapper.terminal-tool-card .base-tool-card {
   cursor: pointer;
 }
 
-/* Footer bar: full width + background to bottom inner edge of expanded content (matches .compact-tool-card-expanded padding). */
-.compact-tool-card.terminal-tool-card .terminal-result-footer {
-  margin-left: -8px;
-  margin-right: -8px;
-  margin-bottom: -8px;
-  padding: 6px 8px;
+/* Footer bar: full width + background to bottom inner edge of expanded content (matches .base-tool-card-expanded padding). */
+.base-tool-card-wrapper.terminal-tool-card .terminal-result-footer {
+  margin-left: -12px;
+  margin-right: -12px;
+  margin-bottom: -12px;
+  padding: 6px 12px;
   border-radius: 0 0 6px 6px;
 }
 
 /* ========== Fix scrollbar visibility on card hover ========== */
-.compact-tool-card.terminal-tool-card:hover {
+.base-tool-card-wrapper.terminal-tool-card:hover {
   .terminal-execution-output,
   .terminal-result-output,
   .xterm-viewport {
     &::-webkit-scrollbar-thumb {
       background: var(--scrollbar-thumb, rgba(255, 255, 255, 0.12));
     }
-    
+
     &::-webkit-scrollbar-thumb:hover {
       background: var(--scrollbar-thumb-hover, rgba(255, 255, 255, 0.22));
     }
-    
+
     /* Firefox */
     scrollbar-color: var(--scrollbar-thumb, rgba(255, 255, 255, 0.12)) transparent;
   }
@@ -460,26 +460,26 @@
 /* ========== Narrow width adaptation (Toolbar mode) ========== */
 .bitfun-toolbar-mode__flowchat-container {
   .terminal-tool-card {
-    .compact-card-action {
+    .tool-card-action {
       display: none;
     }
-    
-    .compact-tool-card-header {
+
+    .base-tool-card-header {
       padding: 2px 4px;
       gap: 2px;
     }
-    
+
     .terminal-action-btn {
       width: 16px;
       height: 16px;
     }
-    
+
     .terminal-confirm-actions {
       gap: 1px;
       width: auto !important;
       justify-content: flex-start !important;
     }
-    
+
     .terminal-command,
     .terminal-command-input {
       font-size: 11px;

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import type { ToolCardProps } from '../types/flow-chat';
 import { Terminal, Play, X, ExternalLink, Square } from 'lucide-react';
 import { createTerminalTab } from '@/shared/utils/tabUtils';
-import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
+import { BaseToolCard, ToolCardHeader } from './BaseToolCard';
 import { CubeLoading, IconButton, Tooltip } from '../../component-library';
 import { TerminalOutputRenderer } from '@/tools/terminal/components';
 import { createLogger } from '@/shared/utils/logger';
@@ -487,8 +487,8 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
   };
 
   const renderHeader = () => (
-    <CompactToolCardHeader
-      statusIcon={<Terminal size={14} className="terminal-card-icon" />}
+    <ToolCardHeader
+      icon={<Terminal size={14} className="terminal-card-icon" />}
       action={t('toolCards.terminal.executeCommand')}
       content={renderCommandContent()}
       extra={(
@@ -551,7 +551,7 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
           )}
         </>
       )}
-      rightIcon={renderStatusIcon()}
+      statusIcon={renderStatusIcon()}
     />
   );
   const expandedContent = isExpanded
@@ -563,14 +563,16 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
 
   return (
     <div ref={cardRootRef} data-tool-card-id={toolId ?? ''}>
-      <CompactToolCard
+      <BaseToolCard
         status={status}
         isExpanded={isExpanded}
         onClick={handleCardClick}
         className="terminal-tool-card"
-        clickable
         header={renderHeader()}
-        expandedContent={expandedContent || errorContent}
+        expandedContent={expandedContent}
+        errorContent={errorContent}
+        isFailed={viewState.isFailed}
+        requiresConfirmation={showConfirmButtons}
       />
     </div>
   );


### PR DESCRIPTION
Split single preview max-height constants into streaming vs expanded variants:

FileOperationToolCard:
- FILE_OPERATION_STREAMING_MAX_HEIGHT (88px) for compact streaming preview
- FILE_OPERATION_DIFF_MAX_HEIGHT (330px) for comfortable diff reading when manually expanded after completion

TerminalToolCard:
- TERMINAL_OUTPUT_STREAMING_MAX_HEIGHT (88px) for compact live output during execution
- TERMINAL_OUTPUT_EXPANDED_MAX_HEIGHT (286px) for comfortable output reading when manually expanded after completion/cancellation

Also fix TerminalToolCard extra prop to conditionally render only when there is actual content, preventing empty DOM elements from breaking card layout (border/width).

Both use max-height (not fixed height) so content shorter than the limit shrinks naturally without blank space.