### PR TITLE
fix: skip unread marking for user-cancelled sessions

### DIFF
--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -66,6 +66,7 @@ export class FlowChatManager {
       lastSaveHashes: new Map(),
       turnSaveInFlight: new Map(),
       turnSavePending: new Set(),
+      userCancelledSessionIds: new Set(),
       currentWorkspacePath: null
     };
     

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -1844,11 +1844,12 @@ function handleDialogTurnCancelled(
       });
   }
 
-  // Mark unread completion for non-active sessions
+  // Mark unread completion for non-active sessions (skip if user explicitly cancelled)
   const activeSessionIdForCancelled = store.getState().activeSessionId;
-  if (sessionId !== activeSessionIdForCancelled) {
+  if (sessionId !== activeSessionIdForCancelled && !context.userCancelledSessionIds.has(sessionId)) {
     context.flowChatStore.markSessionUnreadCompletion(sessionId, 'completed');
   }
+  context.userCancelledSessionIds.delete(sessionId);
 }
 
 /**

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -304,6 +304,7 @@ export async function cancelCurrentTask(context: FlowChatContext): Promise<boole
       : false;
     
     if (success) {
+      context.userCancelledSessionIds.add(sessionId);
       markCurrentTurnItemsAsCancelled(context, sessionId);
       cleanupSessionBuffers(context, sessionId);
     }

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/types.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/types.ts
@@ -35,6 +35,8 @@ export interface FlowChatContext {
   turnSaveInFlight: Map<string, Promise<void>>;
   /** Pending save marks for coalesced serial execution */
   turnSavePending: Set<string>;
+  /** Session IDs that the user explicitly cancelled; used to skip unread marking */
+  userCancelledSessionIds: Set<string>;
   currentWorkspacePath: string | null;
 }
 


### PR DESCRIPTION
When a user manually aborts a session and then switches to another session before the DialogTurnCancelled event arrives, the aborted session was incorrectly marked as unread.

Track explicitly user-cancelled session IDs in FlowChatContext and skip the unread-completion mark in handleDialogTurnCancelled for those sessions.

Generated with BitFun

Co-Authored-By: BitFun