### PR TITLE
feat(agentic): harden tool pipeline, execution, and SSE streaming

### DIFF
--- a/src/crates/ai-adapters/src/client/sse.rs
+++ b/src/crates/ai-adapters/src/client/sse.rs
@@ -2,8 +2,52 @@ use crate::client::utils::elapsed_ms_u64;
 use crate::client::StreamResponse;
 use crate::stream::UnifiedResponse;
 use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
 use log::{debug, error, warn};
+use reqwest::{
+    header::{HeaderMap, RETRY_AFTER},
+    StatusCode,
+};
 use tokio::sync::mpsc;
+
+const BASE_RETRY_DELAY_MS: u64 = 500;
+const MAX_RETRY_AFTER_DELAY_MS: u64 = 30_000;
+
+fn is_retryable_http_status(status: StatusCode) -> bool {
+    status.is_server_error() || matches!(status.as_u16(), 408 | 409 | 425 | 429)
+}
+
+fn exponential_retry_delay_ms(attempt: usize) -> u64 {
+    BASE_RETRY_DELAY_MS * (1 << attempt.min(3))
+}
+
+fn retry_after_delay_ms(headers: &HeaderMap) -> Option<u64> {
+    let value = headers.get(RETRY_AFTER)?.to_str().ok()?.trim();
+
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(seconds.saturating_mul(1000).min(MAX_RETRY_AFTER_DELAY_MS));
+    }
+
+    let retry_at = DateTime::parse_from_rfc2822(value)
+        .ok()?
+        .with_timezone(&Utc);
+    let now = Utc::now();
+    if retry_at <= now {
+        return Some(0);
+    }
+
+    Some(
+        retry_at
+            .signed_duration_since(now)
+            .num_milliseconds()
+            .max(0) as u64,
+    )
+    .map(|delay| delay.min(MAX_RETRY_AFTER_DELAY_MS))
+}
+
+fn retry_delay_ms(attempt: usize, headers: &HeaderMap) -> u64 {
+    retry_after_delay_ms(headers).unwrap_or_else(|| exponential_retry_delay_ms(attempt))
+}
 
 pub(crate) async fn execute_sse_request<BuildRequest, SpawnHandler>(
     label: &str,
@@ -22,8 +66,6 @@ where
     ),
 {
     let mut last_error = None;
-    let base_wait_time_ms = 500;
-
     for attempt in 0..max_tries {
         let request_start_time = std::time::Instant::now();
         let response_result = build_request().json(request_body).send().await;
@@ -32,8 +74,9 @@ where
             Ok(resp) => {
                 let connect_time = elapsed_ms_u64(request_start_time);
                 let status = resp.status();
+                let headers = resp.headers().clone();
 
-                if status.is_client_error() {
+                if status.is_client_error() && !is_retryable_http_status(status) {
                     let error_text = resp
                         .text()
                         .await
@@ -69,12 +112,13 @@ where
                     last_error = Some(error);
 
                     if attempt < max_tries - 1 {
-                        let delay_ms = base_wait_time_ms * (1 << attempt.min(3));
+                        let delay_ms = retry_delay_ms(attempt, &headers);
                         debug!(
-                            "Retrying {} after {}ms (attempt {})",
+                            "Retrying {} after {}ms (attempt {}, status {})",
                             label,
                             delay_ms,
-                            attempt + 2
+                            attempt + 2,
+                            status
                         );
                         tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
                     }
@@ -95,7 +139,7 @@ where
                 last_error = Some(error);
 
                 if attempt < max_tries - 1 {
-                    let delay_ms = base_wait_time_ms * (1 << attempt.min(3));
+                    let delay_ms = exponential_retry_delay_ms(attempt);
                     debug!(
                         "Retrying {} after {}ms (attempt {})",
                         label,
@@ -126,4 +170,42 @@ where
     );
     error!("{}", error_msg);
     Err(anyhow!(error_msg))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::HeaderValue;
+
+    #[test]
+    fn retryable_http_statuses_include_rate_limit_and_server_errors() {
+        assert!(is_retryable_http_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_retryable_http_status(StatusCode::REQUEST_TIMEOUT));
+        assert!(is_retryable_http_status(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_retryable_http_status(StatusCode::BAD_GATEWAY));
+
+        assert!(!is_retryable_http_status(StatusCode::UNAUTHORIZED));
+        assert!(!is_retryable_http_status(StatusCode::BAD_REQUEST));
+        assert!(!is_retryable_http_status(StatusCode::NOT_FOUND));
+    }
+
+    #[test]
+    fn retry_after_seconds_is_capped() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("120"));
+
+        assert_eq!(
+            retry_after_delay_ms(&headers),
+            Some(MAX_RETRY_AFTER_DELAY_MS)
+        );
+    }
+
+    #[test]
+    fn retry_delay_falls_back_to_exponential_backoff() {
+        let headers = HeaderMap::new();
+
+        assert_eq!(retry_delay_ms(0, &headers), 500);
+        assert_eq!(retry_delay_ms(1, &headers), 1000);
+        assert_eq!(retry_delay_ms(4, &headers), 4000);
+    }
 }

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -8,8 +8,8 @@ use crate::agentic::agents::{
     get_agent_registry, PromptBuilder, PromptBuilderContext, RemoteExecutionHints,
 };
 use crate::agentic::core::{
-    render_system_reminder, Message, MessageContent, MessageHelper, MessageSemanticKind,
-    RequestReasoningTokenPolicy, Session,
+    render_system_reminder, Message, MessageContent, MessageHelper, MessageRole,
+    MessageSemanticKind, RequestReasoningTokenPolicy, Session,
 };
 use crate::agentic::events::{AgenticEvent, EventPriority, EventQueue};
 use crate::agentic::execution::types::FinishReason;
@@ -78,6 +78,8 @@ pub struct ExecutionEngine {
 }
 
 impl ExecutionEngine {
+    const FINALIZE_AFTER_TOOL_USE_REMINDER: &'static str = "Tool execution for this turn has already completed, but the turn is ending at this round boundary. Do not call any more tools. Provide the final response to the user based on the tool results already available.";
+
     pub fn new(
         round_executor: Arc<RoundExecutor>,
         event_queue: Arc<EventQueue>,
@@ -115,6 +117,26 @@ impl ExecutionEngine {
             truncate_at_char_boundary(args_str, 64),
             args_str.len()
         )
+    }
+
+    fn assistant_has_tool_calls(message: &Message) -> bool {
+        matches!(
+            &message.content,
+            MessageContent::Mixed { tool_calls, .. } if !tool_calls.is_empty()
+        )
+    }
+
+    fn has_tool_result_after_last_assistant(messages: &[Message]) -> bool {
+        let Some(last_assistant_index) = messages
+            .iter()
+            .rposition(|message| message.role == MessageRole::Assistant)
+        else {
+            return false;
+        };
+
+        messages[last_assistant_index + 1..]
+            .iter()
+            .any(|message| matches!(message.content, MessageContent::ToolResult { .. }))
     }
 
     /// Emergency truncation: drop oldest API rounds (assistant+tool pairs)
@@ -1189,8 +1211,10 @@ impl ExecutionEngine {
         messages.extend(initial_messages);
 
         let mut round_index = 0;
+        let mut completed_rounds = 0usize;
         let mut total_tools = 0;
         let mut last_assistant_message = Message::assistant("".to_string());
+        let mut finalization_reason: Option<&'static str> = None;
         let mut consecutive_compression_failures: u32 = 0;
         const MAX_CONSECUTIVE_COMPRESSION_FAILURES: u32 = 3;
 
@@ -1298,11 +1322,12 @@ impl ExecutionEngine {
         // Loop to execute model rounds
         loop {
             // Check round limit
-            if round_index >= self.config.max_rounds {
+            if completed_rounds >= self.config.max_rounds {
                 warn!(
                     "Reached max rounds limit: {}, stopping execution",
                     self.config.max_rounds
                 );
+                finalization_reason = Some("max_rounds");
                 break;
             }
 
@@ -1498,6 +1523,7 @@ impl ExecutionEngine {
                 round_result.has_more_rounds,
                 round_result.tool_calls.len()
             );
+            completed_rounds += 1;
             last_assistant_message = round_result.assistant_message.clone();
 
             // Save the last token usage statistics (update each time, keep the last one)
@@ -1566,6 +1592,7 @@ impl ExecutionEngine {
                         max_consec
                     );
                     loop_detected = true;
+                    finalization_reason = Some("loop_detected");
                     break;
                 }
             }
@@ -1591,6 +1618,7 @@ impl ExecutionEngine {
                         "Yielding dialog turn after model round (queued user message): session_id={}, dialog_turn_id={}, round_index={}",
                         context.session_id, context.dialog_turn_id, round_index
                     );
+                    finalization_reason = Some("queued_user_message");
                     break;
                 }
             }
@@ -1629,13 +1657,88 @@ impl ExecutionEngine {
             );
         }
 
+        if let Some(reason) = finalization_reason {
+            if Self::assistant_has_tool_calls(&last_assistant_message)
+                && Self::has_tool_result_after_last_assistant(&messages)
+            {
+                info!(
+                    "Finalizing dialog turn after assistant tool use: session_id={}, turn_id={}, reason={}",
+                    context.session_id, context.dialog_turn_id, reason
+                );
+
+                let mut final_ai_messages = Self::build_ai_messages_for_send(
+                    &messages,
+                    &ai_client.config.format,
+                    context
+                        .workspace
+                        .as_ref()
+                        .map(|workspace| workspace.root_path()),
+                    &context.dialog_turn_id,
+                    primary_supports_image_understanding,
+                    request_context_reminder.as_deref(),
+                )
+                .await?;
+                final_ai_messages.push(AIMessage::user(
+                    Self::FINALIZE_AFTER_TOOL_USE_REMINDER.to_string(),
+                ));
+
+                let round_context = RoundContext {
+                    session_id: context.session_id.clone(),
+                    subagent_parent_info: context.subagent_parent_info.clone(),
+                    dialog_turn_id: context.dialog_turn_id.clone(),
+                    turn_index: context.turn_index,
+                    round_number: completed_rounds,
+                    workspace: context.workspace.clone(),
+                    messages: messages.clone(),
+                    available_tools: Vec::new(),
+                    model_name: ai_client.config.model.clone(),
+                    agent_type: agent_type.clone(),
+                    context_vars: execution_context_vars.clone(),
+                    runtime_tool_restrictions: context.runtime_tool_restrictions.clone(),
+                    cancellation_token: CancellationToken::new(),
+                    workspace_services: context.workspace_services.clone(),
+                };
+
+                let final_round_result = self
+                    .round_executor
+                    .execute_round(
+                        ai_client.clone(),
+                        round_context,
+                        final_ai_messages,
+                        None,
+                        Some(context_window),
+                    )
+                    .await?;
+
+                if Self::assistant_has_tool_calls(&final_round_result.assistant_message) {
+                    warn!(
+                        "Finalization round still returned tool calls; keeping prior messages: session_id={}, turn_id={}",
+                        context.session_id, context.dialog_turn_id
+                    );
+                } else {
+                    completed_rounds += 1;
+                    if let Some(ref usage) = final_round_result.usage {
+                        last_usage = Some(usage.clone());
+                    }
+                    last_assistant_message = final_round_result.assistant_message.clone();
+                    messages.push(final_round_result.assistant_message.clone());
+
+                    if let Err(e) = self
+                        .session_manager
+                        .add_message(&context.session_id, final_round_result.assistant_message)
+                        .await
+                    {
+                        warn!("Failed to update final assistant message in memory: {}", e);
+                    }
+                }
+            }
+        }
+
         let duration_ms = elapsed_ms_u64(start_time);
 
         info!(
             "Dialog turn loop completed: turn={}, rounds={}, total_tools={}",
-            context.dialog_turn_id,
-            round_index + 1,
-            total_tools
+            context.dialog_turn_id, completed_rounds, total_tools
         );
 
         // Emit dialog turn completed event
@@ -1647,7 +1750,7 @@ impl ExecutionEngine {
                 AgenticEvent::DialogTurnCompleted {
                     session_id: context.session_id.clone(),
                     turn_id: context.dialog_turn_id.clone(),
-                    total_rounds: round_index + 1,
+                    total_rounds: completed_rounds,
                     total_tools,
                     duration_ms,
                     subagent_parent_info: event_subagent_parent_info,
@@ -1663,7 +1766,7 @@ impl ExecutionEngine {
             info!(
                 "Dialog turn completed - Token stats: turn_id={}, rounds={}, tools={}, duration={}ms, prompt_tokens={}, completion_tokens={}, total_tokens={}",
                 context.dialog_turn_id,
-                round_index + 1,
+                completed_rounds,
                 total_tools,
                 duration_ms,
                 usage.prompt_token_count,
@@ -1690,25 +1793,24 @@ impl ExecutionEngine {
         // Determine finish reason
         let finish_reason = if loop_detected {
             FinishReason::LoopDetected
-        } else if round_index >= self.config.max_rounds {
+        } else if completed_rounds >= self.config.max_rounds {
             FinishReason::MaxRounds
         } else {
             FinishReason::Complete
         };
 
-        let success = !loop_detected && round_index < self.config.max_rounds;
+        let success = !loop_detected && completed_rounds < self.config.max_rounds;
 
         if loop_detected {
             warn!(
                 "Dialog turn stopped due to loop detection: turn={}, rounds={}",
-                context.dialog_turn_id,
-                round_index + 1
+                context.dialog_turn_id, completed_rounds
             );
         }
 
         Ok(ExecutionResult {
             final_message: last_assistant_message,
-            total_rounds: round_index + 1,
+            total_rounds: completed_rounds,
             success,
             new_messages,
             finish_reason,
@@ -1846,8 +1948,10 @@ impl ExecutionEngine {
 #[cfg(test)]
 mod tests {
     use super::ExecutionEngine;
+    use crate::agentic::core::{Message, ToolCall, ToolResult};
     use crate::service::config::types::AIConfig;
     use crate::service::config::types::AIModelConfig;
+    use serde_json::json;
 
     fn build_model(id: &str, name: &str, model_name: &str) -> AIModelConfig {
         AIModelConfig {
@@ -1908,5 +2012,55 @@ mod tests {
         let summary = ExecutionEngine::tool_signature_args_summary(args);
 
         assert_eq!(summary, args);
+    }
+
+    #[test]
+    fn assistant_has_tool_calls_detects_mixed_tool_message() {
+        let message = Message::assistant_with_tools(
+            String::new(),
+            vec![ToolCall {
+                tool_id: "tool-1".to_string(),
+                tool_name: "Read".to_string(),
+                arguments: json!({ "path": "README.md" }),
+                is_error: false,
+            }],
+        );
+
+        assert!(ExecutionEngine::assistant_has_tool_calls(&message));
+        assert!(!ExecutionEngine::assistant_has_tool_calls(
+            &Message::assistant("done".to_string())
+        ));
+    }
+
+    #[test]
+    fn detects_tool_result_after_last_assistant() {
+        let assistant = Message::assistant_with_tools(
+            String::new(),
+            vec![ToolCall {
+                tool_id: "tool-1".to_string(),
+                tool_name: "Read".to_string(),
+                arguments: json!({ "path": "README.md" }),
+                is_error: false,
+            }],
+        );
+        let tool_result = Message::tool_result(ToolResult {
+            tool_id: "tool-1".to_string(),
+            tool_name: "Read".to_string(),
+            result: json!({ "content": "hello" }),
+            result_for_assistant: Some("hello".to_string()),
+            is_error: false,
+            duration_ms: Some(1),
+            image_attachments: None,
+        });
+
+        assert!(ExecutionEngine::has_tool_result_after_last_assistant(&[
+            Message::user("read it".to_string()),
+            assistant.clone(),
+            tool_result,
+        ]));
+        assert!(!ExecutionEngine::has_tool_result_after_last_assistant(&[
+            Message::user("read it".to_string()),
+            assistant,
+        ]));
     }
 }

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -2,14 +2,14 @@
 //!
 //! Executes a single model round: calls AI, processes streaming responses, executes tools
 
-use super::stream_processor::StreamProcessor;
+use super::stream_processor::{StreamProcessor, StreamResult};
 use super::types::{FinishReason, RoundContext, RoundResult};
-use crate::agentic::MessageContent;
-use crate::agentic::core::Message;
-use crate::agentic::events::{AgenticEvent, EventPriority, EventQueue};
+use crate::agentic::core::{Message, ToolCall};
+use crate::agentic::events::{AgenticEvent, EventPriority, EventQueue, ToolEventData};
 use crate::agentic::tools::computer_use_host::ComputerUseHostRef;
 use crate::agentic::tools::pipeline::{ToolExecutionContext, ToolExecutionOptions, ToolPipeline};
 use crate::agentic::tools::registry::get_global_tool_registry;
+use crate::agentic::MessageContent;
 use crate::infrastructure::ai::AIClient;
 use crate::service::config::GlobalConfigManager;
 use crate::util::errors::{BitFunError, BitFunResult};
@@ -174,6 +174,39 @@ impl RoundExecutor {
                 .await
             {
                 Ok(result) => {
+                    if Self::is_interrupted_invalid_tool_only(&result) {
+                        let err_msg = result.partial_recovery_reason.clone().unwrap_or_else(|| {
+                            "Interrupted while streaming tool arguments".to_string()
+                        });
+                        self.emit_failed_partial_tool_calls(
+                            &context,
+                            &result.tool_calls,
+                            &err_msg,
+                            event_subagent_parent_info.clone(),
+                        )
+                        .await;
+
+                        if attempt_index < max_attempts - 1
+                            && Self::is_transient_network_error(&err_msg)
+                        {
+                            let delay_ms = Self::retry_delay_ms(attempt_index);
+                            warn!(
+                                "Retrying stream because tool arguments were interrupted before valid JSON completed: session_id={}, round_id={}, attempt={}/{}, delay_ms={}, error={}",
+                                context.session_id,
+                                round_id,
+                                attempt_index + 1,
+                                max_attempts,
+                                delay_ms,
+                                err_msg
+                            );
+                            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                            attempt_index += 1;
+                            continue;
+                        }
+
+                        return Err(BitFunError::AIClient(err_msg));
+                    }
+
                     let no_effective_output = !result.has_effective_output;
                     if no_effective_output && attempt_index < max_attempts - 1 {
                         let delay_ms = Self::retry_delay_ms(attempt_index);
@@ -575,6 +608,41 @@ impl RoundExecutor {
         let _ = self.event_queue.enqueue(event, Some(priority)).await;
     }
 
+    async fn emit_failed_partial_tool_calls(
+        &self,
+        context: &RoundContext,
+        tool_calls: &[ToolCall],
+        error: &str,
+        subagent_parent_info: Option<crate::agentic::events::SubagentParentInfo>,
+    ) {
+        for tool_call in tool_calls {
+            self.emit_event(
+                AgenticEvent::ToolEvent {
+                    session_id: context.session_id.clone(),
+                    turn_id: context.dialog_turn_id.clone(),
+                    tool_event: ToolEventData::Failed {
+                        tool_id: tool_call.tool_id.clone(),
+                        tool_name: tool_call.tool_name.clone(),
+                        error: format!("Tool arguments stream interrupted: {}", error),
+                    },
+                    subagent_parent_info: subagent_parent_info.clone(),
+                },
+                EventPriority::High,
+            )
+            .await;
+        }
+    }
+
+    fn is_interrupted_invalid_tool_only(result: &StreamResult) -> bool {
+        result.partial_recovery_reason.is_some()
+            && result.full_text.is_empty()
+            && !result.tool_calls.is_empty()
+            && result
+                .tool_calls
+                .iter()
+                .all(|tool_call| !tool_call.is_valid())
+    }
+
     fn retry_delay_ms(attempt_index: usize) -> u64 {
         Self::RETRY_BASE_DELAY_MS * (1u64 << attempt_index.min(3))
     }
@@ -689,5 +757,47 @@ mod tests {
 
         assert!(!RoundExecutor::is_transient_network_error(auth));
         assert!(!RoundExecutor::is_transient_network_error(billing));
+    }
+
+    #[test]
+    fn detects_interrupted_invalid_tool_only_recovery() {
+        let result = crate::agentic::execution::stream_processor::StreamResult {
+            full_thinking: String::new(),
+            thinking_signature: None,
+            full_text: String::new(),
+            tool_calls: vec![crate::agentic::core::ToolCall {
+                tool_id: "call_1".to_string(),
+                tool_name: "Write".to_string(),
+                arguments: serde_json::json!({}),
+                is_error: true,
+            }],
+            usage: None,
+            provider_metadata: None,
+            has_effective_output: true,
+            partial_recovery_reason: Some("Stream processing error: SSE stream error".to_string()),
+        };
+
+        assert!(RoundExecutor::is_interrupted_invalid_tool_only(&result));
+    }
+
+    #[test]
+    fn keeps_partial_text_recovery_as_non_retryable_output() {
+        let result = crate::agentic::execution::stream_processor::StreamResult {
+            full_thinking: String::new(),
+            thinking_signature: None,
+            full_text: "I started answering before the stream failed.".to_string(),
+            tool_calls: vec![crate::agentic::core::ToolCall {
+                tool_id: "call_1".to_string(),
+                tool_name: "Write".to_string(),
+                arguments: serde_json::json!({}),
+                is_error: true,
+            }],
+            usage: None,
+            provider_metadata: None,
+            has_effective_output: true,
+            partial_recovery_reason: Some("Stream processing error: SSE stream error".to_string()),
+        };
+
+        assert!(!RoundExecutor::is_interrupted_invalid_tool_only(&result));
     }
 }

--- a/src/crates/core/src/agentic/tools/implementations/file_edit_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_edit_tool.rs
@@ -7,6 +7,9 @@ use tool_runtime::fs::edit_file::{apply_edit_to_content, edit_file};
 
 pub struct FileEditTool;
 
+const LARGE_EDIT_SOFT_LINE_LIMIT: usize = 200;
+const LARGE_EDIT_SOFT_BYTE_LIMIT: usize = 20 * 1024;
+
 impl Default for FileEditTool {
     fn default() -> Self {
         Self::new()
@@ -35,7 +38,7 @@ Usage:
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.
 - The edit will FAIL if `old_string` is not unique in the file. Either provide a larger string with more surrounding context to make it unique or use `replace_all` to change every instance of `old_string`.
-- Keep edits focused. Avoid replacing huge multi-hundred-line blocks in one call when a smaller targeted edit would work.
+- Keep edits focused. The 200-line / 20KB guideline is a soft reliability threshold, not a hard cap. If a large change is required, split it into several focused Edit calls by section, function, or component instead of truncating or doing one huge replacement.
 - Use `replace_all` for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance."#
         .to_string())
     }
@@ -51,11 +54,11 @@ Usage:
                 "old_string": {
                     "type": "string",
                     "default": "",
-                    "description": "The text to replace (must be unique within the file, and must match the file contents exactly, including all whitespace and indentation). Include enough surrounding context to avoid broad replacements."
+                    "description": "The text to replace (must be unique within the file, and must match the file contents exactly, including all whitespace and indentation). Include enough surrounding context to avoid broad replacements, but avoid huge multi-hundred-line old_string payloads."
                 },
                 "new_string": {
                     "type": "string",
-                    "description": "The text to replace it with (must be different from old_string). Keep edits targeted; avoid replacing huge multi-hundred-line blocks in one call when smaller edits are possible."
+                    "description": "The text to replace it with (must be different from old_string). Keep edits targeted. The 200-line / 20KB guideline is a soft reliability threshold; for larger changes, split the work into several focused Edit calls by section, function, or component."
                 },
                 "replace_all": {
                     "type": "boolean",
@@ -136,6 +139,35 @@ Usage:
                     meta: None,
                 };
             }
+        }
+
+        let old_string = input
+            .get("old_string")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let new_string = input
+            .get("new_string")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let largest_lines = old_string.lines().count().max(new_string.lines().count());
+        let largest_bytes = old_string.len().max(new_string.len());
+        if largest_lines > LARGE_EDIT_SOFT_LINE_LIMIT || largest_bytes > LARGE_EDIT_SOFT_BYTE_LIMIT
+        {
+            return ValidationResult {
+                result: true,
+                message: Some(format!(
+                    "Large Edit payload: largest side is {} lines, {} bytes. This is allowed when necessary, but prefer a staged approach: split the change into several focused Edit calls by section, function, or component instead of one huge replacement.",
+                    largest_lines, largest_bytes
+                )),
+                error_code: None,
+                meta: Some(json!({
+                    "large_edit": true,
+                    "largest_line_count": largest_lines,
+                    "largest_byte_count": largest_bytes,
+                    "soft_line_limit": LARGE_EDIT_SOFT_LINE_LIMIT,
+                    "soft_byte_limit": LARGE_EDIT_SOFT_BYTE_LIMIT
+                })),
+            };
         }
 
         ValidationResult::default()

--- a/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -10,6 +10,9 @@ use tokio::fs;
 
 pub struct FileWriteTool;
 
+const LARGE_WRITE_SOFT_LINE_LIMIT: usize = 200;
+const LARGE_WRITE_SOFT_BYTE_LIMIT: usize = 20 * 1024;
+
 impl Default for FileWriteTool {
     fn default() -> Self {
         Self::new()
@@ -36,7 +39,8 @@ Usage:
 - If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first.
 - The file_path parameter must be either an absolute path or an exact `bitfun://runtime/...` URI returned by another tool.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
-- Keep writes focused. Avoid sending hundreds of lines in one Write call; prefer Read + Edit for targeted updates, and split large rewrites into smaller chunks when possible.
+- Keep writes focused. The 200-line / 20KB guideline is a soft reliability threshold, not a hard cap. If a task genuinely needs more content, preserve correctness and use a staged plan instead of truncating.
+- For existing files, prefer Read + targeted Edit calls. For large new files or rewrites, write the stable scaffold first, then fill or revise sections with focused Edit calls. Do not replace an entire existing file just to change a few sections.
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
 - Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked."#.to_string())
     }
@@ -51,7 +55,7 @@ Usage:
                 },
                 "content": {
                     "type": "string",
-                    "description": "The content to write to the file. Keep writes focused; avoid sending hundreds of lines in one call. Prefer Read + Edit for targeted changes, and split large rewrites into smaller chunks when possible."
+                    "description": "The content to write to the file. 200 lines / 20KB is a soft reliability threshold, not a hard cap. For existing files prefer Read + focused Edit calls. For large new files, write a stable scaffold first, then add sections in follow-up focused edits unless a complete initial body is required."
                 }
             },
             "required": ["file_path", "content"],
@@ -97,6 +101,22 @@ Usage:
             };
         }
 
+        let large_write_warning =
+            input
+                .get("content")
+                .and_then(|v| v.as_str())
+                .and_then(|content| {
+                    let line_count = content.lines().count();
+                    let byte_count = content.len();
+                    if line_count > LARGE_WRITE_SOFT_LINE_LIMIT
+                        || byte_count > LARGE_WRITE_SOFT_BYTE_LIMIT
+                    {
+                        Some((line_count, byte_count))
+                    } else {
+                        None
+                    }
+                });
+
         if let Some(ctx) = context {
             let resolved = match ctx.resolve_tool_path(file_path) {
                 Ok(resolved) => resolved,
@@ -118,6 +138,24 @@ Usage:
                     meta: None,
                 };
             }
+        }
+
+        if let Some((line_count, byte_count)) = large_write_warning {
+            return ValidationResult {
+                result: true,
+                message: Some(format!(
+                    "Large Write payload: {} lines, {} bytes. This is allowed when necessary, but prefer a staged approach: for existing files use Read + focused Edit calls; for large new files write a stable scaffold first, then add sections in follow-up edits unless a complete initial body is required.",
+                    line_count, byte_count
+                )),
+                error_code: None,
+                meta: Some(json!({
+                    "large_write": true,
+                    "line_count": line_count,
+                    "byte_count": byte_count,
+                    "soft_line_limit": LARGE_WRITE_SOFT_LINE_LIMIT,
+                    "soft_byte_limit": LARGE_WRITE_SOFT_BYTE_LIMIT
+                })),
+            };
         }
 
         ValidationResult::default()

--- a/src/crates/core/src/agentic/tools/implementations/generative_ui_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/generative_ui_tool.rs
@@ -8,6 +8,9 @@ use serde_json::{json, Value};
 
 pub struct GenerativeUITool;
 
+const LARGE_WIDGET_CODE_SOFT_LINE_LIMIT: usize = 260;
+const LARGE_WIDGET_CODE_SOFT_BYTE_LIMIT: usize = 28 * 1024;
+
 struct ThemePromptSnapshot {
     id: &'static str,
     theme_type: &'static str,
@@ -272,6 +275,7 @@ Input rules:
 4. Put CSS first, then HTML, then scripts last so the preview can stream progressively.
 5. Keep the first useful content visible early. Avoid giant style blocks.
 6. Prefer self-contained widgets. CDN scripts are allowed when needed, but keep them minimal.
+6a. Keep `widget_code` compact. The 260-line / 28KB guideline is a soft reliability threshold, not a hard cap. If the widget is larger, reduce repeated static DOM with data-driven loops, shared CSS classes, and simpler markup rather than truncating required behavior.
 7. If the user only needs text, do not use this tool.
 8. Prefer compact, scroll-light layouts. Avoid large CSS resets, fixed overlays, oversized app chrome, and nested scrolling.
 9. IMPORTANT sizing rule: the default target is an inline FlowChat card, not a full browser page. Build responsive widgets that fit a narrow card without horizontal scrolling.
@@ -328,7 +332,7 @@ Input rules:
                 "widget_code": {
                     "type": "string",
                     "description": format!(
-                        "Raw HTML fragment or raw SVG. No Markdown code fences. For HTML: no <!DOCTYPE>, <html>, <head>, or <body>. {} If the widget should match BitFun, rely on the host CSS variables instead of hard-coded colors or spacing. If the user asked for file navigation, do not finish this field until each clickable node has verified file metadata or is intentionally non-clickable.",
+                        "Raw HTML fragment or raw SVG. No Markdown code fences. For HTML: no <!DOCTYPE>, <html>, <head>, or <body>. The 260-line / 28KB guideline is a soft reliability threshold. For larger widgets, use data-driven loops, shared CSS classes, and simpler markup rather than truncating required behavior. {} If the widget should match BitFun, rely on the host CSS variables instead of hard-coded colors or spacing. If the user asked for file navigation, do not finish this field until each clickable node has verified file metadata or is intentionally non-clickable.",
                         Self::combined_reminder()
                     )
                 },
@@ -451,6 +455,28 @@ Input rules:
                 ),
                 error_code: Some(400),
                 meta: None,
+            };
+        }
+
+        let line_count = widget_code.lines().count();
+        let byte_count = widget_code.len();
+        if line_count > LARGE_WIDGET_CODE_SOFT_LINE_LIMIT
+            || byte_count > LARGE_WIDGET_CODE_SOFT_BYTE_LIMIT
+        {
+            return ValidationResult {
+                result: true,
+                message: Some(format!(
+                    "Large GenerativeUI widget_code: {} lines, {} bytes. This is allowed when necessary, but prefer a staged design approach: keep the first version compact, use data-driven loops/shared classes, and iterate rather than emitting a huge static widget payload.",
+                    line_count, byte_count
+                )),
+                error_code: None,
+                meta: Some(json!({
+                    "large_widget_code": true,
+                    "line_count": line_count,
+                    "byte_count": byte_count,
+                    "soft_line_limit": LARGE_WIDGET_CODE_SOFT_LINE_LIMIT,
+                    "soft_byte_limit": LARGE_WIDGET_CODE_SOFT_BYTE_LIMIT
+                })),
             };
         }
 

--- a/src/crates/core/src/agentic/tools/implementations/mermaid_interactive_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/mermaid_interactive_tool.rs
@@ -13,6 +13,9 @@ use serde_json::{json, Value};
 /// Mermaid interactive diagram tool
 pub struct MermaidInteractiveTool;
 
+const LARGE_MERMAID_CODE_SOFT_LINE_LIMIT: usize = 220;
+const LARGE_MERMAID_CODE_SOFT_BYTE_LIMIT: usize = 18 * 1024;
+
 impl Default for MermaidInteractiveTool {
     fn default() -> Self {
         Self::new()
@@ -287,6 +290,7 @@ Key Rules:
 - file_path must be ABSOLUTE path that exists in the workspace
 - line_number must be a positive integer (1, 2, 3, ...), pointing to meaningful code location
 - For abstract/conceptual nodes (like "Database", "External API"), omit from node_metadata entirely - they will be non-clickable
+- Keep mermaid_code compact. The 220-line / 18KB guideline is a soft reliability threshold, not a hard cap. For large architecture maps, split the work into several focused diagrams by subsystem, flow, or layer instead of truncating important nodes.
 - Use style statements for colors: style NodeID fill:#color,stroke:#border,color:#text
 - Use highlights for execution state: {"executed": ["A"], "current": "B", "failed": ["E"]}
 
@@ -303,7 +307,7 @@ Mermaid Syntax:
             "properties": {
                 "mermaid_code": {
                     "type": "string",
-                    "description": "Mermaid diagram code. Use standard Mermaid syntax. Node IDs should match the keys in node_metadata for interactive features. Add style statements for custom colors."
+                    "description": "Mermaid diagram code. Use standard Mermaid syntax. Node IDs should match the keys in node_metadata for interactive features. Add style statements for custom colors. The 220-line / 18KB guideline is a soft reliability threshold; for larger maps, split into focused diagrams by subsystem, flow, or layer."
                 },
                 "title": {
                     "type": "string",
@@ -468,6 +472,28 @@ Mermaid Syntax:
                     "field": "mermaid_code",
                     "error_detail": error_message,
                     "suggestion": "Please fix the syntax errors and regenerate the Mermaid code. Common issues: missing diagram type, unclosed brackets, invalid node definitions, or malformed arrows."
+                })),
+            };
+        }
+
+        let line_count = mermaid_code.lines().count();
+        let byte_count = mermaid_code.len();
+        if line_count > LARGE_MERMAID_CODE_SOFT_LINE_LIMIT
+            || byte_count > LARGE_MERMAID_CODE_SOFT_BYTE_LIMIT
+        {
+            return ValidationResult {
+                result: true,
+                message: Some(format!(
+                    "Large Mermaid code: {} lines, {} bytes. This is allowed when necessary, but prefer a staged diagramming approach: split large architecture maps into focused diagrams by subsystem, flow, or layer instead of one huge diagram payload.",
+                    line_count, byte_count
+                )),
+                error_code: None,
+                meta: Some(json!({
+                    "large_mermaid_code": true,
+                    "line_count": line_count,
+                    "byte_count": byte_count,
+                    "soft_line_limit": LARGE_MERMAID_CODE_SOFT_LINE_LIMIT,
+                    "soft_byte_limit": LARGE_MERMAID_CODE_SOFT_BYTE_LIMIT
                 })),
             };
         }

--- a/src/crates/core/src/agentic/tools/implementations/task_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/task_tool.rs
@@ -15,6 +15,9 @@ use std::path::Path;
 
 pub struct TaskTool;
 
+const LARGE_TASK_PROMPT_SOFT_LINE_LIMIT: usize = 180;
+const LARGE_TASK_PROMPT_SOFT_BYTE_LIMIT: usize = 16 * 1024;
+
 impl Default for TaskTool {
     fn default() -> Self {
         Self::new()
@@ -178,7 +181,7 @@ impl Tool for TaskTool {
                 },
                 "prompt": {
                     "type": "string",
-                    "description": "The task for the agent to perform"
+                    "description": "The task for the agent to perform. Keep it scoped and concise. The 180-line / 16KB guideline is a soft reliability threshold, not a hard cap. For large delegations, split into multiple Task calls with clear ownership, and pass file paths, symbols, constraints, and exact questions instead of pasting large file contents."
                 },
                 "subagent_type": {
                     "type": "string",
@@ -231,10 +234,39 @@ impl Tool for TaskTool {
         input: &Value,
         _context: Option<&ToolUseContext>,
     ) -> ValidationResult {
-        InputValidator::new(input)
+        let validation = InputValidator::new(input)
             .validate_required("prompt")
             .validate_required("subagent_type")
-            .finish()
+            .finish();
+        if !validation.result {
+            return validation;
+        }
+
+        if let Some(prompt) = input.get("prompt").and_then(|value| value.as_str()) {
+            let line_count = prompt.lines().count();
+            let byte_count = prompt.len();
+            if line_count > LARGE_TASK_PROMPT_SOFT_LINE_LIMIT
+                || byte_count > LARGE_TASK_PROMPT_SOFT_BYTE_LIMIT
+            {
+                return ValidationResult {
+                    result: true,
+                    message: Some(format!(
+                        "Large Task prompt: {} lines, {} bytes. This is allowed when necessary, but prefer staged delegation: split large work into multiple Task calls with clear ownership, and pass file paths, symbols, constraints, and exact questions instead of large pasted context.",
+                        line_count, byte_count
+                    )),
+                    error_code: None,
+                    meta: Some(json!({
+                        "large_task_prompt": true,
+                        "line_count": line_count,
+                        "byte_count": byte_count,
+                        "soft_line_limit": LARGE_TASK_PROMPT_SOFT_LINE_LIMIT,
+                        "soft_byte_limit": LARGE_TASK_PROMPT_SOFT_BYTE_LIMIT
+                    })),
+                };
+            }
+        }
+
+        validation
     }
 
     fn render_tool_use_message(&self, input: &Value, options: &ToolRenderOptions) -> String {
@@ -494,13 +526,11 @@ mod tests {
         let schema = TaskTool::new().input_schema();
 
         assert_eq!(schema["properties"]["model_id"]["type"], "string");
-        assert!(
-            !schema["required"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .any(|value| value.as_str() == Some("model_id"))
-        );
+        assert!(!schema["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value.as_str() == Some("model_id")));
     }
 
     #[test]

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -17,7 +17,7 @@ use futures::future::join_all;
 use log::{debug, error, info, warn};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Instant, SystemTime};
 use tokio::sync::{oneshot, RwLock as TokioRwLock};
 use tokio::time::{timeout, Duration};
 use tokio_util::sync::CancellationToken;
@@ -197,6 +197,61 @@ fn convert_to_framework_result(model_result: &ModelToolResult) -> FrameworkToolR
     }
 }
 
+fn elapsed_ms_since(time: SystemTime) -> u64 {
+    time.elapsed()
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+fn build_error_execution_result(
+    task_id: &str,
+    task: Option<ToolTask>,
+    error: &BitFunError,
+) -> ToolExecutionResult {
+    let (tool_id, tool_name, execution_time_ms) = if let Some(task) = task {
+        (
+            task.tool_call.tool_id,
+            task.tool_call.tool_name,
+            elapsed_ms_since(task.created_at),
+        )
+    } else {
+        warn!("Task not found in state manager: {}", task_id);
+        (task_id.to_string(), "unknown".to_string(), 0)
+    };
+    let error_message = error.to_string();
+
+    ToolExecutionResult {
+        tool_id: tool_id.clone(),
+        tool_name: tool_name.clone(),
+        result: ModelToolResult {
+            tool_id,
+            tool_name,
+            result: serde_json::json!({
+                "error": error_message,
+                "message": format!("Tool execution failed: {}", error_message)
+            }),
+            result_for_assistant: Some(format!("Tool execution failed: {}", error_message)),
+            is_error: true,
+            duration_ms: Some(execution_time_ms),
+            image_attachments: None,
+        },
+        execution_time_ms,
+    }
+}
+
+fn should_retry_tool_error(error: &BitFunError) -> bool {
+    matches!(
+        error,
+        BitFunError::Timeout(_)
+            | BitFunError::Io(_)
+            | BitFunError::Http(_)
+            | BitFunError::Service(_)
+            | BitFunError::MCPError(_)
+            | BitFunError::ProcessError(_)
+            | BitFunError::Other(_)
+    )
+}
+
 /// Confirmation response type
 #[derive(Debug, Clone)]
 pub enum ConfirmationResponse {
@@ -359,35 +414,12 @@ impl ToolPipeline {
                 Ok(r) => all_results.push(r),
                 Err(e) => {
                     error!("Tool execution failed: error={}", e);
-
                     let task_id = &task_ids[idx];
-                    let (tool_id, tool_name) =
-                        if let Some(task) = self.state_manager.get_task(task_id) {
-                            (
-                                task.tool_call.tool_id.clone(),
-                                task.tool_call.tool_name.clone(),
-                            )
-                        } else {
-                            warn!("Task not found in state manager: {}", task_id);
-                            (task_id.clone(), "unknown".to_string())
-                        };
-                    let error_result = ToolExecutionResult {
-                        tool_id: tool_id.clone(),
-                        tool_name: tool_name.clone(),
-                        result: ModelToolResult {
-                            tool_id,
-                            tool_name,
-                            result: serde_json::json!({
-                                "error": e.to_string(),
-                                "message": format!("Tool execution failed: {}", e)
-                            }),
-                            result_for_assistant: Some(format!("Tool execution failed: {}", e)),
-                            is_error: true,
-                            duration_ms: None,
-                            image_attachments: None,
-                        },
-                        execution_time_ms: 0,
-                    };
+                    let error_result = build_error_execution_result(
+                        task_id,
+                        self.state_manager.get_task(task_id),
+                        &e,
+                    );
                     all_results.push(error_result);
                 }
             }
@@ -408,34 +440,11 @@ impl ToolPipeline {
                 Ok(result) => results.push(result),
                 Err(e) => {
                     error!("Tool execution failed: error={}", e);
-
-                    let (tool_id, tool_name) =
-                        if let Some(task) = self.state_manager.get_task(&task_id) {
-                            (
-                                task.tool_call.tool_id.clone(),
-                                task.tool_call.tool_name.clone(),
-                            )
-                        } else {
-                            warn!("Task not found in state manager: {}", task_id);
-                            (task_id.clone(), "unknown".to_string())
-                        };
-                    let error_result = ToolExecutionResult {
-                        tool_id: tool_id.clone(),
-                        tool_name: tool_name.clone(),
-                        result: ModelToolResult {
-                            tool_id,
-                            tool_name,
-                            result: serde_json::json!({
-                                "error": e.to_string(),
-                                "message": format!("Tool execution failed: {}", e)
-                            }),
-                            result_for_assistant: Some(format!("Tool execution failed: {}", e)),
-                            is_error: true,
-                            duration_ms: None,
-                            image_attachments: None,
-                        },
-                        execution_time_ms: 0,
-                    };
+                    let error_result = build_error_execution_result(
+                        &task_id,
+                        self.state_manager.get_task(&task_id),
+                        &e,
+                    );
                     results.push(error_result);
                 }
             }
@@ -532,13 +541,6 @@ impl ToolPipeline {
             return Err(err);
         }
 
-        // Create cancellation token
-        let cancellation_token = CancellationToken::new();
-        self.cancellation_tokens
-            .insert(tool_id.clone(), cancellation_token.clone());
-
-        debug!("Executing tool: tool_name={}", tool_name);
-
         let tool = {
             let registry = self.tool_registry.read().await;
             registry
@@ -552,6 +554,40 @@ impl ToolPipeline {
                     BitFunError::tool(error_msg)
                 })?
         };
+
+        let cancellation_token = CancellationToken::new();
+        let tool_context = self.build_tool_use_context(&task, cancellation_token.clone());
+        let validation = tool.validate_input(&tool_args, Some(&tool_context)).await;
+        if !validation.result {
+            let error_msg = validation
+                .message
+                .unwrap_or_else(|| format!("Invalid input for tool '{}'", tool_name));
+            self.state_manager
+                .update_state(
+                    &tool_id,
+                    ToolExecutionState::Failed {
+                        error: error_msg.clone(),
+                        is_retryable: false,
+                    },
+                )
+                .await;
+            return Err(BitFunError::Validation(error_msg));
+        }
+        if let Some(message) = validation
+            .message
+            .filter(|message| !message.trim().is_empty())
+        {
+            warn!(
+                "Tool input validation warning: tool_name={}, warning={}",
+                tool_name, message
+            );
+        }
+
+        // Register cancellation only after deterministic validation and registry lookup succeed.
+        self.cancellation_tokens
+            .insert(tool_id.clone(), cancellation_token.clone());
+
+        debug!("Executing tool: tool_name={}", tool_name);
 
         let is_streaming = tool.supports_streaming();
 
@@ -622,6 +658,8 @@ impl ToolPipeline {
                     )));
                 }
                 Some(Err(_)) => {
+                    self.confirmation_channels.remove(&tool_id);
+
                     // Channel closed
                     self.state_manager
                         .update_state(
@@ -635,6 +673,8 @@ impl ToolPipeline {
                     return Err(BitFunError::service("Confirmation channel closed"));
                 }
                 None => {
+                    self.confirmation_channels.remove(&tool_id);
+
                     self.state_manager
                         .update_state(
                             &tool_id,
@@ -702,6 +742,8 @@ impl ToolPipeline {
         match result {
             Ok(tool_result) => {
                 let duration_ms = elapsed_ms_u64(start_time);
+                let mut tool_result = tool_result;
+                tool_result.duration_ms = Some(duration_ms);
 
                 self.state_manager
                     .update_state(
@@ -794,7 +836,7 @@ impl ToolPipeline {
             match result {
                 Ok(r) => return Ok(r),
                 Err(e) => {
-                    if attempts >= max_attempts {
+                    if attempts >= max_attempts || !should_retry_tool_error(&e) {
                         return Err(e);
                     }
 
@@ -824,8 +866,48 @@ impl ToolPipeline {
             ));
         }
 
-        // Build tool context (pass all resource IDs)
-        let tool_context = ToolUseContext {
+        let tool_context = self.build_tool_use_context(task, cancellation_token);
+
+        let execution_future = tool.call(&task.tool_call.arguments, &tool_context);
+
+        let tool_results = match task.options.timeout_secs {
+            Some(timeout_secs) => {
+                let timeout_duration = Duration::from_secs(timeout_secs);
+                let result = timeout(timeout_duration, execution_future)
+                    .await
+                    .map_err(|_| {
+                        BitFunError::Timeout(format!(
+                            "Tool execution timeout: {}",
+                            task.tool_call.tool_name
+                        ))
+                    })?;
+                result?
+            }
+            None => execution_future.await?,
+        };
+
+        if tool.supports_streaming() && tool_results.len() > 1 {
+            self.handle_streaming_results(task, &tool_results).await?;
+        }
+
+        tool_results
+            .into_iter()
+            .last()
+            .map(|r| convert_tool_result(r, &task.tool_call.tool_id, &task.tool_call.tool_name))
+            .ok_or_else(|| {
+                BitFunError::Tool(format!(
+                    "Tool did not return result: {}",
+                    task.tool_call.tool_name
+                ))
+            })
+    }
+
+    fn build_tool_use_context(
+        &self,
+        task: &ToolTask,
+        cancellation_token: CancellationToken,
+    ) -> ToolUseContext {
+        ToolUseContext {
             tool_call_id: Some(task.tool_call.tool_id.clone()),
             agent_type: Some(task.context.agent_type.clone()),
             session_id: Some(task.context.session_id.clone()),
@@ -867,40 +949,7 @@ impl ToolPipeline {
             cancellation_token: Some(cancellation_token),
             runtime_tool_restrictions: task.context.runtime_tool_restrictions.clone(),
             workspace_services: task.context.workspace_services.clone(),
-        };
-
-        let execution_future = tool.call(&task.tool_call.arguments, &tool_context);
-
-        let tool_results = match task.options.timeout_secs {
-            Some(timeout_secs) => {
-                let timeout_duration = Duration::from_secs(timeout_secs);
-                let result = timeout(timeout_duration, execution_future)
-                    .await
-                    .map_err(|_| {
-                        BitFunError::Timeout(format!(
-                            "Tool execution timeout: {}",
-                            task.tool_call.tool_name
-                        ))
-                    })?;
-                result?
-            }
-            None => execution_future.await?,
-        };
-
-        if tool.supports_streaming() && tool_results.len() > 1 {
-            self.handle_streaming_results(task, &tool_results).await?;
         }
-
-        tool_results
-            .into_iter()
-            .last()
-            .map(|r| convert_tool_result(r, &task.tool_call.tool_id, &task.tool_call.tool_name))
-            .ok_or_else(|| {
-                BitFunError::Tool(format!(
-                    "Tool did not return result: {}",
-                    task.tool_call.tool_name
-                ))
-            })
     }
 
     /// Handle streaming results


### PR DESCRIPTION
## Summary
- Harden the agentic tool pipeline with structured error execution results, transient-error retries, and clearer timing/telemetry.
- Extend the execution engine and round executor to coordinate tool failures and round flow.
- Align file edit/write, generative UI, mermaid, and task tools with the updated pipeline.
- Improve SSE client behavior in `ai-adapters` for more robust streaming.

## Verification
- `cargo check --workspace`
- `cargo test -p bitfun-core --test stream_processor_openai --test stream_processor_anthropic`