### PR TITLE
fix(web-ui): tool card header inset for trailing controls

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.scss
@@ -7,6 +7,8 @@
 :root {
   --tool-card-header-pad-y: 7px;
   --tool-card-header-pad-x: 0px;
+  /* Inset for header trailing controls (e.g. open-in-panel). Left stays 0 for icon rail alignment. */
+  --tool-card-header-pad-right: 10px;
   --tool-card-header-icon-rail: 24px;
   --tool-card-header-icon-slot: calc(var(--tool-card-header-icon-rail) + 10px);
 }
@@ -101,7 +103,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: var(--tool-card-header-pad-y) var(--tool-card-header-pad-x);
+  padding: var(--tool-card-header-pad-y) var(--tool-card-header-pad-right) var(--tool-card-header-pad-y) var(--tool-card-header-pad-x);
   position: relative;
   z-index: 11;
   flex-shrink: 0;

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.scss
@@ -200,7 +200,7 @@
     content: '';
     position: absolute;
     left: 0;
-    right: calc(-1 * var(--tool-card-header-pad-x, 10px));
+    right: calc(-1 * var(--tool-card-header-pad-right, 10px));
     top: calc(-1 * var(--tool-card-header-pad-y, 10px));
     bottom: calc(-1 * var(--tool-card-header-pad-y, 10px));
     background-color: transparent;

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.scss
@@ -146,7 +146,7 @@
       content: '';
       position: absolute;
       left: 0;
-      right: calc(-1 * var(--tool-card-header-pad-x, 10px));
+      right: calc(-1 * var(--tool-card-header-pad-right, 10px));
       top: calc(-1 * var(--tool-card-header-pad-y, 10px));
       bottom: calc(-1 * var(--tool-card-header-pad-y, 10px));
       background-color: transparent;
@@ -181,7 +181,7 @@
     position: absolute;
     left: 0;
     top: calc(-1 * var(--tool-card-header-pad-y, 10px));
-    right: calc(-1 * var(--tool-card-header-pad-x, 10px));
+    right: calc(-1 * var(--tool-card-header-pad-right, 10px));
     bottom: calc(-1 * var(--tool-card-header-pad-y, 10px));
     z-index: 2;
     margin: 0;


### PR DESCRIPTION
## Summary

- Add \--tool-card-header-pad-right\ for header horizontal inset (trailing controls / open-in-panel).
- Use the variable in header padding and in FileOperation/Task tool overlay extents so layout stays consistent with the icon rail.

## Verification

- [ ] \pnpm run lint:web && pnpm run type-check:web\ (SCSS-only; optional full web-ui tests)