### PR TITLE
refactor(web-ui): polish flow chat tool cards (file, task, terminal)

### DIFF
--- a/src/web-ui/src/flow_chat/components/FlowToolCard.tsx
+++ b/src/web-ui/src/flow_chat/components/FlowToolCard.tsx
@@ -73,9 +73,10 @@ export const FlowToolCard: React.FC<FlowToolCardProps> = React.memo(({
           onOpenInPanel={onOpenInPanel}
           onExpand={handleExpand}
           sessionId={sessionId}
+          interruptionNote={interruptionNote}
         />
       </FlowToolCardErrorBoundary>
-      {interruptionNote && (
+      {interruptionNote && !config.inlineInterruptionNote && (
         <div className="flow-tool-card-note" role="note">
           {interruptionNote}
         </div>

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.scss
@@ -71,17 +71,48 @@
   }
 
   /*
-   * Git rail lives under ToolCardHeader in .tool-card-extra; by default extra shrinks to its children so the
-   * rail is only icon-tall and the vertical line / hover baseline cannot span the header padding. Stretch
-   * to the header row height, then use negative inset to fill edge-to-edge.
+   * Header extras: stretch vertically so editor rail hit/hover fills full header row (match Task rail).
+   * Parent header uses align-items:center; tool-card-extra must stretch, then inner row stretch children.
    */
-  .base-tool-card-header .tool-card-extra:has(.file-op-git-rail) {
+  .base-tool-card-header .tool-card-extra:has(.file-op-header-extras) {
     align-self: stretch;
     display: flex;
     flex-direction: row;
-    align-items: center;
-    gap: 2px;
+    align-items: stretch;
     min-height: 0;
+  }
+}
+
+.file-op-header-extras {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 6px;
+  flex-shrink: 0;
+
+  .params-streaming-indicator,
+  .error-expand-indicator {
+    align-self: center;
+  }
+}
+
+.diff-preview-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+  font-family: var(--tool-card-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  line-height: 1;
+
+  .additions {
+    color: var(--color-success);
+  }
+
+  .deletions {
+    color: var(--color-error);
   }
 }
 
@@ -123,28 +154,53 @@
   color: var(--color-text-muted);
 }
 
-.diff-preview-group {
-  display: flex;
+/* After file name: git icon (if repo) + +/- stats in one pill; hover opens diff. */
+.file-op-diff-capsule {
+  display: inline-flex;
+  flex-direction: row;
   align-items: center;
-  gap: 3px;
+  justify-content: center;
+  gap: 6px;
   flex-shrink: 0;
-  font-family: var(--tool-card-font-mono);
-  font-size: 10px;
-  font-weight: 600;
+  margin: 0;
+  padding: 3px 10px;
+  border: none;
+  border-radius: 999px;
+  background: var(--color-bg-secondary, rgba(255, 255, 255, 0.04));
   color: var(--color-text-muted);
   line-height: 1;
+  cursor: pointer;
+  appearance: none;
+  transition: background-color 0.15s ease, color 0.15s ease;
 
-  .additions {
-    color: var(--color-success);
+  .diff-preview-group {
+    color: inherit;
   }
 
-  .deletions {
-    color: var(--color-error);
+  &:hover:not(:disabled):not(.file-op-diff-capsule--disabled) {
+    background: var(--tool-card-bg-hover, var(--color-bg-hover, rgba(255, 255, 255, 0.09)));
+    color: var(--color-text-primary);
+  }
+
+  &--disabled,
+  &:disabled {
+    opacity: 0.45;
+    cursor: default;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent-500, #60a5fa);
+    outline-offset: 2px;
   }
 }
 
-/* Right rail for “View Git diff” — aligned with Task tool header rail (TaskToolDisplay). */
-.file-op-git-rail {
+.file-op-diff-capsule__git-icon {
+  flex-shrink: 0;
+  stroke: currentColor;
+}
+
+/* Open in editor — right rail aligned with TaskToolDisplay .task-header-rail */
+.file-op-editor-rail {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -152,9 +208,9 @@
   justify-content: center;
   align-self: stretch;
   flex-shrink: 0;
-  min-width: 32px;
+  min-width: 40px;
   padding: 0 0 0 8px;
-  margin-left: 4px;
+  margin-left: 2px;
 
   &::before {
     content: '';
@@ -170,11 +226,11 @@
     z-index: 0;
   }
 
-  &:hover:not(.file-op-git-rail--disabled)::before {
+  &:hover::before {
     background-color: var(--tool-card-bg-hover, var(--color-bg-hover, rgba(255, 255, 255, 0.09)));
   }
 
-  &:hover:not(.file-op-git-rail--disabled) .file-op-git-rail__visual {
+  &:hover .file-op-editor-rail__visual {
     color: var(--color-text-primary);
   }
 
@@ -189,17 +245,9 @@
     pointer-events: none;
     z-index: 1;
   }
-
-  &--disabled {
-    opacity: 0.45;
-
-    .file-op-git-rail__visual {
-      color: var(--color-text-muted);
-    }
-  }
 }
 
-.file-op-git-rail__hit {
+.file-op-editor-rail__hit {
   position: absolute;
   left: 0;
   top: calc(-1 * var(--tool-card-header-pad-y, 10px));
@@ -220,7 +268,7 @@
   }
 }
 
-.file-op-git-rail__visual {
+.file-op-editor-rail__visual {
   position: relative;
   z-index: 1;
   display: flex;
@@ -230,8 +278,6 @@
   pointer-events: none;
 
   svg {
-    width: 16px;
-    height: 16px;
     flex-shrink: 0;
     stroke: currentColor;
   }

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -20,6 +20,7 @@ import {
   GitBranch,
   FileText,
   ChevronDown,
+  ChevronRight,
   ChevronUp,
   FileEdit,
   FilePlus,
@@ -43,11 +44,12 @@ import { diffLines } from 'diff';
 import { createLogger } from '@/shared/utils/logger';
 import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
-import { hasNonFileUriScheme } from '@/shared/utils/pathUtils';
+import { hasNonFileUriScheme, joinPath } from '@/shared/utils/pathUtils';
+import { WorkspaceKind } from '@/shared/types/global-state';
 import './FileOperationToolCard.scss';
 
 const log = createLogger('FileOperationToolCard');
-const FILE_OPERATION_PREVIEW_ROWS = 4;
+const FILE_OPERATION_PREVIEW_ROWS = 8;
 const FILE_OPERATION_PREVIEW_ROW_HEIGHT = 22;
 // Keep streaming and completed previews at the same height to avoid layout jumps.
 const FILE_OPERATION_PREVIEW_MAX_HEIGHT =
@@ -61,7 +63,6 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   toolItem,
   config,
   sessionId,
-  onOpenInEditor
 }) => {
   const { t } = useTranslation('flow-chat');
   const { toolCall, toolResult, status, isParamsStreaming, partialParams } = toolItem;
@@ -90,6 +91,37 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   } = useSnapshotState(sessionId);
   const eventBus = SnapshotEventBus.getInstance();
   const { workspace: currentWorkspace } = useCurrentWorkspace();
+  const [workspaceIsGitRepo, setWorkspaceIsGitRepo] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const ws = currentWorkspace;
+    const root = ws?.rootPath?.trim();
+    if (!ws || !root || ws.workspaceKind === WorkspaceKind.Assistant) {
+      setWorkspaceIsGitRepo(false);
+      return;
+    }
+
+    setWorkspaceIsGitRepo(null);
+    (async () => {
+      try {
+        const { systemAPI } = await import('../../infrastructure/api');
+        const marker = joinPath(root, '.git');
+        const exists = await systemAPI.checkPathExists(marker);
+        if (!cancelled) {
+          setWorkspaceIsGitRepo(exists);
+        }
+      } catch {
+        if (!cancelled) {
+          setWorkspaceIsGitRepo(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentWorkspace?.id, currentWorkspace?.rootPath, currentWorkspace?.workspaceKind]);
 
   const getFilePath = useCallback((): string => {
     const params = partialParams || toolCall?.input;
@@ -423,47 +455,6 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
     }
   }, [sessionId, currentFilePath, toolCall?.id, fileName, toolItem.toolName]);
 
-  const handleCardClick = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    if (
-      (e.target as HTMLElement).closest(
-        '.file-op-git-rail:not(.file-op-git-rail--disabled)',
-      )
-    ) {
-      return;
-    }
-    
-    if (isFailed) {
-      applyErrorExpandedState(!isErrorExpanded, 'manual');
-      return;
-    }
-
-    if (toolItem.toolName === 'Delete') {
-      return;
-    }
-    
-    if (currentFilePath && sessionId && status === 'completed') {
-      handleOpenInCodeEditor();
-      return;
-    }
-
-    if (currentFilePath && onOpenInEditor) {
-      onOpenInEditor(currentFilePath);
-    }
-  }, [
-    applyErrorExpandedState,
-    currentFilePath,
-    handleOpenInCodeEditor,
-    isErrorExpanded,
-    isFailed,
-    onOpenInEditor,
-    sessionId,
-    status,
-    toolItem.toolName,
-  ]);
-
   const handleOpenBaselineDiff = useCallback(async () => {
     if (!currentFilePath || !currentWorkspace || !sessionId) {
       log.warn('Cannot open diff: missing required info', {
@@ -677,7 +668,6 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
 
   const expandedContent = renderExpandedContent();
   const hasExpandableContent =
-    status === 'completed' &&
     !isFailed &&
     !isDeleteTool &&
     Boolean(expandedContent);
@@ -685,22 +675,82 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   const isCardContentExpanded =
     !isDeleteTool &&
     !isFailed &&
-    (status === 'completed' ? isContentExpanded : true);
+    (hasExpandableContent ? isContentExpanded : false);
 
-  const opensPanelOnClick =
-    !isFailed &&
+  const hasDiffStats =
+    currentFileDiffStats.additions > 0 || currentFileDiffStats.deletions > 0;
+  const diffCapsuleBaseReady =
     !isDeleteTool &&
-    (Boolean(currentFilePath && sessionId && status === 'completed') ||
-      Boolean(currentFilePath && onOpenInEditor));
+    !isFailed &&
+    !isLoading &&
+    !isParamsStreaming &&
+    status === 'completed' &&
+    Boolean(currentFilePath) &&
+    Boolean(currentWorkspace) &&
+    Boolean(sessionId);
+  const showInlineDiffCapsule =
+    diffCapsuleBaseReady &&
+    (hasDiffStats || workspaceIsGitRepo === true);
+  const showGitIconInDiffCapsule = workspaceIsGitRepo === true;
+  const diffCapsuleDisabled = !currentFilePath || !currentWorkspace || !sessionId;
+  const showEditorRail =
+    diffCapsuleBaseReady && Boolean(currentFilePath);
+
+  const handleCardClick = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const target = e.target as HTMLElement;
+    if (target.closest('.file-op-diff-capsule')) {
+      return;
+    }
+    if (target.closest('.file-op-editor-rail')) {
+      return;
+    }
+
+    if (isFailed) {
+      applyErrorExpandedState(!isErrorExpanded, 'manual');
+      return;
+    }
+
+    if (toolItem.toolName === 'Delete') {
+      return;
+    }
+
+    if (hasExpandableContent) {
+      applyContentExpandedState(!isContentExpanded, 'manual');
+    }
+  }, [
+    applyContentExpandedState,
+    applyErrorExpandedState,
+    hasExpandableContent,
+    isContentExpanded,
+    isErrorExpanded,
+    isFailed,
+    toolItem.toolName,
+  ]);
 
   const renderHeader = () => {
     const { className: iconClassName } = getToolIconInfo();
-    const gitRailDisabled =
-      !currentFilePath || !currentWorkspace || !sessionId;
 
     const actionText = isDeleteTool
       ? ''
       : (isFailed ? `${toolDisplayInfo.name}${t('toolCards.file.failed')}` : `${toolDisplayInfo.name}:`);
+
+    const gitDiffTooltip = t('toolCards.file.viewGitDiff');
+    const baselineDiffTooltip = t('toolCards.file.viewBaselineDiff');
+    const diffCapsuleTooltip = showGitIconInDiffCapsule ? gitDiffTooltip : baselineDiffTooltip;
+
+    const diffStatsInner = (
+      <span className="diff-preview-group">
+        {currentFileDiffStats.additions > 0 && (
+          <span className="additions">+{currentFileDiffStats.additions}</span>
+        )}
+        {currentFileDiffStats.deletions > 0 && (
+          <span className="deletions">-{currentFileDiffStats.deletions}</span>
+        )}
+      </span>
+    );
 
     return (
       <ToolCardHeader
@@ -716,7 +766,9 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
         onAffordanceClick={
           hasExpandableContent
             ? () => applyContentExpandedState(!isContentExpanded, 'manual')
-            : undefined
+            : isFailed
+              ? () => applyErrorExpandedState(!isErrorExpanded, 'manual')
+              : undefined
         }
         action={actionText}
       content={
@@ -726,61 +778,61 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
               {fileName}
             </span>
           </Tooltip>
-          {!isDeleteTool && !isParamsStreaming && !isFailed && !isLoading && (
-            (currentFileDiffStats.additions > 0 || currentFileDiffStats.deletions > 0)
-          ) && (
-            <span className="diff-preview-group">
-              {currentFileDiffStats.additions > 0 && (
-                <span className="additions">+{currentFileDiffStats.additions}</span>
-              )}
-              {currentFileDiffStats.deletions > 0 && (
-                <span className="deletions">-{currentFileDiffStats.deletions}</span>
-              )}
-            </span>
+          {showInlineDiffCapsule && (
+            <Tooltip content={diffCapsuleTooltip} placement="top">
+              <button
+                type="button"
+                className={`file-op-diff-capsule${diffCapsuleDisabled ? ' file-op-diff-capsule--disabled' : ''}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!diffCapsuleDisabled) {
+                    void handleOpenBaselineDiff();
+                  }
+                }}
+                disabled={diffCapsuleDisabled}
+                aria-label={diffCapsuleTooltip}
+              >
+                {showGitIconInDiffCapsule ? (
+                  <GitBranch size={14} strokeWidth={2} className="file-op-diff-capsule__git-icon" aria-hidden />
+                ) : null}
+                {hasDiffStats ? diffStatsInner : null}
+              </button>
+            </Tooltip>
           )}
         </>
       }
       extra={
-        <>
+        <div className="file-op-header-extras">
           {isParamsStreaming && (status === 'preparing' || status === 'streaming') && (
             <span className="params-streaming-indicator">
               {currentFilePath ? t('toolCards.file.receivingParams') : t('toolCards.file.analyzing')}
             </span>
           )}
-          {!isDeleteTool &&
-            !isFailed &&
-            !isLoading &&
-            status === 'completed' &&
-            currentFilePath && (
-              <Tooltip content={t('toolCards.file.viewGitDiff')} placement="top">
-                <div
-                  className={`file-op-git-rail${gitRailDisabled ? ' file-op-git-rail--disabled' : ''}`}
-                >
-                  {!gitRailDisabled && (
-                    <button
-                      type="button"
-                      className="file-op-git-rail__hit"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleOpenBaselineDiff();
-                      }}
-                      aria-label={t('toolCards.file.viewGitDiff')}
-                      title={t('toolCards.file.viewGitDiff')}
-                    />
-                  )}
-                  <div className="file-op-git-rail__visual" aria-hidden>
-                    <GitBranch size={16} strokeWidth={2} />
-                  </div>
+          {showEditorRail && (
+            <Tooltip content={t('toolCards.file.openInEditor')} placement="top">
+              <div className="file-op-editor-rail">
+                <button
+                  type="button"
+                  className="file-op-editor-rail__hit"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void handleOpenInCodeEditor();
+                  }}
+                  aria-label={t('toolCards.file.openInEditor')}
+                  title={t('toolCards.file.openInEditor')}
+                />
+                <div className="file-op-editor-rail__visual" aria-hidden>
+                  <ChevronRight size={18} strokeWidth={2} absoluteStrokeWidth />
                 </div>
-              </Tooltip>
-            )}
-
+              </div>
+            </Tooltip>
+          )}
           {isFailed && (
             <div className="error-expand-indicator">
               {isErrorExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
             </div>
           )}
-        </>
+        </div>
       }
       statusIcon={isDeleteTool ? null : renderStatusIcon()}
     />
@@ -815,14 +867,8 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
         expandedContent={expandedContent}
         errorContent={isFailed && isErrorExpanded ? renderErrorContent() : null}
         isFailed={isFailed}
-        headerExpandAffordance={hasExpandableContent || opensPanelOnClick || isFailed}
-        headerAffordanceKind={
-          hasExpandableContent
-            ? 'expand'
-            : opensPanelOnClick
-              ? 'open-panel-right'
-              : 'expand'
-        }
+        headerExpandAffordance={hasExpandableContent || isFailed}
+        headerAffordanceKind="expand"
       />
     </div>
   );

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.scss
@@ -299,6 +299,10 @@
     margin-left: 0;
     padding-left: 0;
     border-left: none;
+
+    &:empty {
+      display: none;
+    }
   }
 
   /* Prompt uses ModelThinkingDisplay shell + .thinking-markdown (see ModelThinkingDisplay.scss). */
@@ -353,7 +357,40 @@
   .task-expanded-content {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
+  }
+
+  /* Interruption note: full width to card inner edges (counters .base-tool-card-expanded padding). */
+  .task-tool-card-interruption {
+    flex-shrink: 0;
+    align-self: stretch;
+    width: auto;
+    margin: 0 -10px;
+    box-sizing: border-box;
+    padding: 0 10px 10px;
+
+    .flow-tool-card-note {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin: 0;
+      padding: 6px 8px;
+      border-radius: 6px;
+      background: rgba(245, 158, 11, 0.1);
+      color: var(--color-text-secondary);
+      font-size: 0.82em;
+      line-height: 1.45;
+      opacity: 0.9;
+
+      svg {
+        flex-shrink: 0;
+        color: var(--color-warning, #f59e0b);
+      }
+    }
+
+    &--has-below {
+      border-bottom: 1px solid var(--border-base);
+    }
   }
 
 
@@ -444,41 +481,64 @@
 
 /**
  * Unified task + subagent card wrapper.
- * Wraps the task tool header card and the subagent items container so they
- * behave as a single card with a shared hover/shadow effect.
+ * Wraps the task tool header card and the subagent items container.
+ * Do not add an outer box-shadow or radius here when expanded: the inner
+ * .base-tool-card-wrapper + .subagent-items-container already draw one card;
+ * an extra layer caused a double rounded-rectangle (overlap with
+ * .flow-tool-card-wrapper’s subtree).
  */
 .task-with-subagent-wrapper {
   position: relative;
-  border-radius: 8px;
   margin-bottom: 10px;
-  transition: box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-
-  // Expanded state: subtle default elevation.
-  &:has(.subagent-items-wrapper--expanded) {
-    box-shadow:
-      0 2px 6px rgba(0, 0, 0, 0.15),
-      0 1px 3px rgba(0, 0, 0, 0.1);
-  }
-
-  // Hover over expanded card: stronger elevation.
-  &:has(.subagent-items-wrapper--expanded):hover {
-    box-shadow:
-      0 4px 16px rgba(0, 0, 0, 0.25),
-      0 2px 8px rgba(0, 0, 0, 0.15),
-      inset 0 1px 0 rgba(255, 255, 255, 0.04);
-  }
 
   // Square the bottom corners of the task header card when expanded.
   &:has(.subagent-items-wrapper--expanded) {
+    // The paired task is rendered by ModelRoundItem's local FlowItemRenderer,
+    // which uses .flowchat-flow-item. Keep .flowchat-tool-wrapper for older call sites.
+    > .flowchat-flow-item,
+    > .flowchat-tool-wrapper {
+      margin: 0;
+    }
+
+    // Plain flex host only — avoid a second implied frame behind the real card.
+    > .flowchat-flow-item .flow-tool-card-wrapper,
+    > .flowchat-tool-wrapper .flow-tool-card-wrapper {
+      border-radius: 0;
+      background: transparent;
+      box-shadow: none;
+      gap: 0;
+    }
+
     .flow-tool-card-wrapper .base-tool-card-wrapper.task-tool-display {
       border-radius: 8px 8px 0 0;
-      // Remove bottom margin so the subagent container connects flush.
-      margin-bottom: 0;
-      // Suppress the base card's own hover shadow; the wrapper handles it.
-      &:hover {
-        box-shadow: none;
-      }
+      // BaseToolCard uses margin: 6px 0; in the paired task/subagent card it
+      // must be flush so the lower subagent border can physically connect.
+      margin: 0;
     }
+
+    // Remove expanded-body bottom padding so the seam meets the subagent flush.
+    .flow-tool-card-wrapper .base-tool-card-wrapper.task-tool-display > .base-tool-card-expanded {
+      padding-bottom: 0;
+    }
+
+    // Keep the subagent block directly after the task card. The task card's
+    // bottom border is the divider between prompt and subagent content.
+    > .subagent-items-wrapper {
+      margin-top: 0;
+    }
+
+    > .subagent-items-wrapper .subagent-items-container {
+      margin-top: 0;
+      padding-top: 10px;
+      border: 1px solid var(--border-base);
+      border-top: none;
+      box-shadow: none;
+    }
+  }
+
+  // Whole-group hover: sync subagent panel border with BaseToolCard hover.
+  &:has(.subagent-items-wrapper--expanded):hover .subagent-items-container {
+    border-color: var(--border-medium);
   }
 }
 

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
@@ -8,6 +8,7 @@ import {
   Timer,
   ChevronRight,
   ChevronDown,
+  AlertTriangle,
 } from 'lucide-react';
 
 import { useTranslation } from 'react-i18next';
@@ -25,7 +26,8 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
   onConfirm,
   onReject,
   onOpenInPanel,
-  sessionId
+  sessionId,
+  interruptionNote,
 }) => {
   const { t } = useTranslation('flow-chat');
   const { toolCall, toolResult, status, requiresConfirmation, userConfirmed } = toolItem;
@@ -164,6 +166,14 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
       'success' in toolResult &&
       toolResult.success === false);
 
+  // Surface inline interruption copy once; avoids deps on isExpanded (would re-open after manual collapse).
+  useEffect(() => {
+    if (interruptionNote && !isFailed) {
+      updateCardExpandedState(true, 'auto');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only when note / id / failure state changes
+  }, [interruptionNote, isFailed, toolItem.id]);
+
   const handleCardClick = useCallback((e: React.MouseEvent) => {
     const target = e.target as HTMLElement;
     if (
@@ -184,7 +194,7 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
   }, [isFailed, isExpanded, updateCardExpandedState]);
 
   const showHeaderExpandHint =
-    !isFailed && (hasRealPrompt || needsConfirmation);
+    !isFailed && (hasRealPrompt || needsConfirmation || Boolean(interruptionNote));
 
   const taskHeaderLine = useMemo(() => {
     const desc =
@@ -300,12 +310,27 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
       return null;
     }
 
-    if (!hasRealPrompt && !needsConfirmation) {
+    if (!hasRealPrompt && !needsConfirmation && !interruptionNote) {
       return null;
     }
 
+    const hasBodyBelowInterruption = Boolean(hasRealPrompt || needsConfirmation);
+
     return (
       <div className="task-expanded-content">
+        {interruptionNote && (
+          <div
+            className={
+              'task-tool-card-interruption' +
+              (hasBodyBelowInterruption ? ' task-tool-card-interruption--has-below' : '')
+            }
+          >
+            <div className="flow-tool-card-note" role="note">
+              <AlertTriangle size={13} strokeWidth={2} aria-hidden />
+              {interruptionNote}
+            </div>
+          </div>
+        )}
         {hasRealPrompt && (
           <div
             className={`thinking-content-wrapper${promptScrollState.hasScroll ? ' has-scroll' : ''}${

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
@@ -30,8 +30,11 @@
   border-radius: 0 0 7px 7px;
 }
 
-/* Collapsed terminal cards should sit with compact read/search tool rows instead of looking like a callout. */
-.base-tool-card-wrapper.terminal-tool-card:not(:has(> .base-tool-card-expanded)):not(:has(> .base-tool-card-error)) {
+/*
+ * Inline row (class set from TerminalToolCard.tsx): same visual rhythm as .compact-tool-card-wrapper + ReadFileDisplay.
+ * Class-based so we do not rely on :has() and `inherit` through `<code>` / UA quirks.
+ */
+.base-tool-card-wrapper.terminal-tool-card.terminal-tool-card--collapsed-row {
   margin: 0;
   border-color: transparent;
   border-radius: 0;
@@ -39,6 +42,8 @@
   box-shadow: none;
   backdrop-filter: none;
   overflow: visible;
+  font-size: var(--flowchat-font-size-base);
+  line-height: 1.65;
 
   &:hover,
   &:active {
@@ -65,11 +70,41 @@
     gap: 8px;
     padding: 0 8px 0 0;
     line-height: 1.65;
+    font-size: inherit;
     overflow: visible;
 
     &::before,
     &::after {
       display: none;
+    }
+
+    /* Nest under header so specificity beats loose `.tool-card-action { font-size: 12px }` regardless of bundle order. */
+    .tool-card-action,
+    .tool-card-content {
+      font-size: var(--flowchat-font-size-base);
+      line-height: 1.65;
+      color: var(--color-text-muted);
+      letter-spacing: normal;
+    }
+
+    .tool-card-content {
+      font-weight: 400;
+    }
+
+    .terminal-command,
+    .terminal-command-input {
+      font-family: inherit;
+      font-size: var(--flowchat-font-size-base);
+      font-weight: 400;
+      line-height: 1.65;
+      color: inherit;
+    }
+  }
+
+  &:hover .base-tool-card-header {
+    .tool-card-action,
+    .tool-card-content {
+      color: var(--color-text-primary);
     }
   }
 
@@ -91,24 +126,6 @@
   .tool-card-icon.tool-identifier-icon.tool-card-icon-main svg {
     width: 12px;
     height: 12px;
-  }
-
-  .tool-card-action,
-  .tool-card-content {
-    font-size: var(--flowchat-font-size-base);
-    line-height: 1.65;
-    color: var(--color-text-muted);
-  }
-
-  &:hover {
-    .tool-card-action,
-    .tool-card-content {
-      color: var(--color-text-primary);
-    }
-
-    .terminal-command {
-      color: var(--color-text-primary);
-    }
   }
 }
 
@@ -561,10 +578,13 @@
       width: auto !important;
       justify-content: flex-start !important;
     }
-    
-    .terminal-command,
-    .terminal-command-input {
-      font-size: 11px;
+
+    /* Keep collapsed row at flowchat base size (matches compact read cards); shrink only when the output panel is open. */
+    .base-tool-card-wrapper.terminal-tool-card:has(> .base-tool-card-expanded) {
+      .terminal-command,
+      .terminal-command-input {
+        font-size: 11px;
+      }
     }
   }
 }

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
@@ -361,6 +361,8 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
     status,
   ]);
   const waitingMessage = viewState.waitingMessageKey ? t(viewState.waitingMessageKey) : null;
+  /** Matches compact tool rows (e.g. Read): no separate BaseToolCard action text in collapsed mode. */
+  const compactInlineRow = !isExpanded && !viewState.isFailed;
 
   const handleExecute = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -444,11 +446,12 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
   };
 
   const renderCommandContent = () => {
+    const commandContent = command
+      || <span className="command-empty">{t(showConfirmButtons ? 'toolCards.terminal.commandEmpty' : 'toolCards.terminal.noCommand')}</span>;
     const commandNode = (
-      <code ref={commandRef} className="terminal-command">
-        {command
-          || <span className="command-empty">{t(showConfirmButtons ? 'toolCards.terminal.commandEmpty' : 'toolCards.terminal.noCommand')}</span>}
-      </code>
+      compactInlineRow
+        ? <span ref={commandRef} className="terminal-command">{commandContent}</span>
+        : <code ref={commandRef} className="terminal-command">{commandContent}</code>
     );
 
     if (command && isCommandTruncated) {
@@ -483,8 +486,12 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
     <ToolCardHeader
       icon={<Terminal size={16} />}
       iconClassName="terminal-icon"
-      action={t('toolCards.terminal.executeCommand')}
-      content={renderCommandContent()}
+      action={compactInlineRow ? undefined : t('toolCards.terminal.executeCommand')}
+      content={compactInlineRow ? (
+        <>
+          {t('toolCards.terminal.executeCommand')} {renderCommandContent()}
+        </>
+      ) : renderCommandContent()}
       extra={viewState.hasHeaderExtra ? (
         <>
           {renderStatusText()}
@@ -546,7 +553,7 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
         status={status}
         isExpanded={isExpanded}
         onClick={handleCardClick}
-        className="terminal-tool-card"
+        className={['terminal-tool-card', compactInlineRow ? 'terminal-tool-card--collapsed-row' : ''].filter(Boolean).join(' ')}
         header={renderHeader()}
         expandedContent={expandedContent}
         errorContent={errorContent}

--- a/src/web-ui/src/flow_chat/tool-cards/index.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/index.ts
@@ -155,7 +155,8 @@ export const TOOL_CARD_CONFIGS: Record<string, ToolCardConfig> = {
     resultDisplayType: 'detailed',
     description: 'Run a specialized AI task',
     displayMode: 'detailed',
-    primaryColor: '#7c3aed'
+    primaryColor: '#7c3aed',
+    inlineInterruptionNote: true,
   },
   'TodoWrite': {
     toolName: 'TodoWrite',

--- a/src/web-ui/src/flow_chat/types/flow-chat.ts
+++ b/src/web-ui/src/flow_chat/types/flow-chat.ts
@@ -305,6 +305,11 @@ export interface ToolCardConfig {
   description?: string;
   displayMode?: 'compact' | 'standard' | 'detailed' | 'terminal';
   primaryColor?: string;
+  /**
+   * When set, the shell renders the interruption note inside the tool card
+   * (e.g. task expanded body) instead of after the card wrapper.
+   */
+  inlineInterruptionNote?: boolean;
 }
 
 export interface ToolCardProps {
@@ -318,6 +323,8 @@ export interface ToolCardProps {
   sessionId?: string;
   /** Callback for MCP App ui/message requests. Returns whether the message was handled successfully. */
   onMcpAppMessage?: (params: import('@/infrastructure/api/service-api/MCPAPI').McpUiMessageParams) => Promise<import('@/infrastructure/api/service-api/MCPAPI').McpUiMessageResult>;
+  /** Interruption / cancellation note; placement depends on tool card config. */
+  interruptionNote?: string | null;
 }
 
 // Flow Chat callbacks for layered events.

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -474,7 +474,8 @@
       "expandPreview": "Expand preview",
       "collapsePreview": "Collapse preview",
       "viewGitDiff": "View Diff",
-      "viewBaselineDiff": "View Baseline Diff"
+      "viewBaselineDiff": "View Baseline Diff",
+      "openInEditor": "Open in editor"
     },
     "getFileDiff": {
       "diffFile": "Diff",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -464,7 +464,8 @@
       "expandPreview": "展开预览",
       "collapsePreview": "收起预览",
       "viewGitDiff": "查看 Diff",
-      "viewBaselineDiff": "查看基线 Diff"
+      "viewBaselineDiff": "查看基线 Diff",
+      "openInEditor": "在编辑器中打开"
     },
     "getFileDiff": {
       "diffFile": "文件差异",


### PR DESCRIPTION
## Summary

- Refine FileOperation, Task, and Terminal flow chat tool card layout and styles.
- Extend `flow-chat` types and en-US/zh-CN locale strings; adjust `FlowToolCard` wiring.

## Testing

- `pnpm run type-check:web`
