### PR TITLE
fix(web-ui): align subagent items padding with tool card header

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/SubagentItems.scss
+++ b/src/web-ui/src/flow_chat/components/modern/SubagentItems.scss
@@ -19,7 +19,9 @@
 
 // Subagent container for items under the same parent task.
 .subagent-items-container {
-  padding: 12px 0;
+  // Match header right padding (10px). Left padding aligns subagent content
+  // with the header content column (past the icon rail).
+  padding: 12px 10px 12px var(--tool-card-header-icon-slot, 34px);
 
   // Continue the task card border on left/right/bottom; top border is hidden.
   background: var(--color-bg-flowchat);


### PR DESCRIPTION
## Summary
Aligns `.subagent-items-container` horizontal padding with the tool card header: left uses `--tool-card-header-icon-slot` and right matches the header's 10px inset so nested subagent content lines up with the header text column.

## Verification
- `pnpm run lint:web`