### PR TITLE
fix: session index completeness, ReviewTeamPage layout, and tool card refactor

### DIFF
--- a/src/crates/core/src/agentic/persistence/manager.rs
+++ b/src/crates/core/src/agentic/persistence/manager.rs
@@ -1227,6 +1227,41 @@ impl PersistenceManager {
         Ok(metadata_list)
     }
 
+    async fn count_session_metadata_dirs(
+        &self,
+        workspace_path: &Path,
+    ) -> BitFunResult<usize> {
+        let Some(sessions_root) = self.existing_project_sessions_dir(workspace_path) else {
+            return Ok(0);
+        };
+        let mut count = 0;
+        let mut entries = fs::read_dir(&sessions_root)
+            .await
+            .map_err(|e| BitFunError::io(format!("Failed to read sessions root: {}", e)))?;
+
+        while let Some(entry) = entries.next_entry().await.map_err(|e| {
+            BitFunError::io(format!("Failed to read session directory entry: {}", e))
+        })? {
+            let file_type = entry
+                .file_type()
+                .await
+                .map_err(|e| BitFunError::io(format!("Failed to get file type: {}", e)))?;
+            if !file_type.is_dir() {
+                continue;
+            }
+
+            let session_id = entry.file_name().to_string_lossy().to_string();
+            if self
+                .metadata_path(workspace_path, &session_id)
+                .exists()
+            {
+                count += 1;
+            }
+        }
+
+        Ok(count)
+    }
+
     async fn rebuild_index_locked(
         &self,
         workspace_path: &Path,
@@ -1353,6 +1388,18 @@ impl PersistenceManager {
                 );
                 return self.rebuild_index_locked(workspace_path).await;
             }
+
+            let disk_count = self.count_session_metadata_dirs(workspace_path).await?;
+            if index.sessions.len() != disk_count {
+                warn!(
+                    "Session index incomplete (index: {}, disk: {}), rebuilding: {}",
+                    index.sessions.len(),
+                    disk_count,
+                    index_path.display()
+                );
+                return self.rebuild_index_locked(workspace_path).await;
+            }
+
             return Ok(index.sessions);
         }
 

--- a/src/crates/core/src/service/lsp/workspace_manager.rs
+++ b/src/crates/core/src/service/lsp/workspace_manager.rs
@@ -432,7 +432,9 @@ impl WorkspaceLspManager {
                 let is_related = (language == "c" && lang == "cpp")
                     || (language == "cpp" && lang == "c")
                     || (language == "javascript" && lang == "typescript")
-                    || (language == "typescript" && lang == "javascript");
+                    || (language == "typescript" && lang == "javascript")
+                    || (language == "javascriptreact" && lang == "javascript")
+                    || (language == "typescriptreact" && lang == "typescript");
 
                 if is_related {
                     return Some(lang.clone());
@@ -458,7 +460,9 @@ impl WorkspaceLspManager {
                 let is_related = (language == "c" && lang == "cpp")
                     || (language == "cpp" && lang == "c")
                     || (language == "javascript" && lang == "typescript")
-                    || (language == "typescript" && lang == "javascript");
+                    || (language == "typescript" && lang == "javascript")
+                    || (language == "javascriptreact" && lang == "javascript")
+                    || (language == "typescriptreact" && lang == "typescript");
 
                 if is_related {
                     return lang.clone();

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
@@ -580,15 +580,15 @@
   }
 
   &__workspace-item-sessions {
-    overflow: hidden;
-    max-height: 600px;
-    transition: max-height $motion-base $easing-standard,
-                opacity $motion-fast $easing-standard;
+    overflow-y: auto;
+    overflow-x: hidden;
+    transition: opacity $motion-fast $easing-standard;
     opacity: 1;
 
     &.is-collapsed {
       max-height: 0;
       opacity: 0;
+      overflow: hidden;
       pointer-events: none;
     }
 
@@ -876,15 +876,15 @@
   }
 
   &__assistant-item-sessions {
-    overflow: hidden;
-    max-height: 600px;
-    transition: max-height $motion-base $easing-standard,
-                opacity $motion-fast $easing-standard;
+    overflow-y: auto;
+    overflow-x: hidden;
+    transition: opacity $motion-fast $easing-standard;
     opacity: 1;
 
     &.is-collapsed {
       max-height: 0;
       opacity: 0;
+      overflow: hidden;
       pointer-events: none;
     }
 

--- a/src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.scss
+++ b/src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.scss
@@ -1,8 +1,11 @@
 @use '../../../../component-library/styles/tokens' as *;
 
 .review-team-page {
+  --config-page-content-max-width: 1480px;
+  --config-page-content-inline-padding: clamp(40px, 6vw, 80px);
+
   .bitfun-config-page-content__inner {
-    max-width: 1600px;
+    max-width: 1480px;
   }
 
   &__summary-grid {
@@ -435,6 +438,7 @@
 
   &__detail-description {
     margin: 0;
+    padding: 0 0 16px;
     font-size: var(--font-size-sm);
     line-height: 1.7;
     color: var(--color-text-secondary);

--- a/src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.tsx
+++ b/src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.tsx
@@ -505,11 +505,11 @@ const ReviewTeamPage: React.FC = () => {
                         ) : null}
                       </div>
                     </div>
-                    <p className="review-team-page__detail-description">
-                      {getLocalizedMemberDescription(selectedMember)}
-                    </p>
                   </div>
                 </div>
+                <p className="review-team-page__detail-description">
+                  {getLocalizedMemberDescription(selectedMember)}
+                </p>
 
                 <div className="review-team-page__responsibilities">
                   <span className="review-team-page__block-label">

--- a/src/web-ui/src/flow_chat/components/FlowToolCardErrorBoundary.tsx
+++ b/src/web-ui/src/flow_chat/components/FlowToolCardErrorBoundary.tsx
@@ -72,7 +72,7 @@ function RenderFallback({
         isExpanded={true}
         header={(
           <CompactToolCardHeader
-            statusIcon={<AlertTriangle size={12} />}
+            icon={<AlertTriangle size={16} />}
             action={displayName}
             content="Tool card render failed"
           />

--- a/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.tsx
@@ -56,7 +56,7 @@ export const VirtualItemRenderer = React.memo<VirtualItemRendererProps>(
                 status="running"
                 header={
                   <CompactToolCardHeader
-                    statusIcon={<Loader2 className="animate-spin" size={12} />}
+                    icon={<Loader2 className="animate-spin" size={16} />}
                     content="Analyzing image with image understanding model..."
                   />
                 }

--- a/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.scss
@@ -3,16 +3,6 @@
  * Provides unified card appearance and interaction effects
  */
 
-/* ========== Shared header variables ========== */
-:root {
-  --tool-card-header-pad-y: 7px;
-  --tool-card-header-pad-x: 0px;
-  /* Inset for header trailing controls (e.g. open-in-panel). Left stays 0 for icon rail alignment. */
-  --tool-card-header-pad-right: 10px;
-  --tool-card-header-icon-rail: 24px;
-  --tool-card-header-icon-slot: calc(var(--tool-card-header-icon-rail) + 10px);
-}
-
 /* ========== Card wrapper ========== */
 .base-tool-card-wrapper {
   display: flex;
@@ -135,105 +125,6 @@
 
 }
 
-/* ========== Header sub-element styles ========== */
-
-/* Left rail: fixed icon box + vertical divider from card inner top to bottom of header row. */
-.tool-card-icon-slot {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  align-self: stretch;
-  width: var(--tool-card-header-icon-slot);
-  margin-right: 8px;
-  box-sizing: border-box;
-  min-height: 0;
-}
-
-.tool-card-icon-slot::after {
-  content: '';
-  position: absolute;
-  right: 0;
-  top: calc(-1 * var(--tool-card-header-pad-y));
-  bottom: calc(-1 * var(--tool-card-header-pad-y));
-  width: 0;
-  border-right: 1px solid var(--border-base);
-  pointer-events: none;
-  z-index: 0;
-}
-
-.tool-card-icon-affordance-hit {
-  position: absolute;
-  inset: 0;
-  z-index: 2;
-  margin: 0;
-  padding: 0;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  appearance: none;
-
-  &:focus-visible {
-    outline: 2px solid var(--color-accent-500, #60a5fa);
-    outline-offset: 2px;
-    border-radius: 6px;
-  }
-}
-
-/* Same square box so tool glyph and chevron share center (no circular fill). */
-.tool-card-icon-marks {
-  position: relative;
-  z-index: 1;
-  width: var(--tool-card-header-icon-rail);
-  height: var(--tool-card-header-icon-rail);
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.tool-card-icon.tool-identifier-icon.tool-card-icon-main {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition: opacity 0.18s ease;
-
-  svg {
-    width: 16px;
-    height: 16px;
-  }
-}
-
-.tool-card-icon-slot--expandable .tool-card-icon-expand-hint {
-  position: absolute;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 0;
-  padding: 0;
-  opacity: 0;
-  pointer-events: none;
-  color: var(--color-text-secondary);
-  transition: opacity 0.18s ease;
-
-  svg {
-    width: 16px;
-    height: 16px;
-    flex-shrink: 0;
-    transition: transform 0.2s ease;
-  }
-}
-
-.tool-card-icon-slot--expandable .tool-card-icon-expand-hint--open svg {
-  transform: rotate(180deg);
-}
-
 /* Chevron swap: only when card opts in via headerExpandAffordance (includes status-error with collapsible details). */
 .base-tool-card-wrapper:hover .base-tool-card.base-tool-card--header-expandable:not(.status-cancelled) .tool-card-icon-slot--expandable .tool-card-icon-main {
   opacity: 0;
@@ -241,49 +132,6 @@
 
 .base-tool-card-wrapper:hover .base-tool-card.base-tool-card--header-expandable:not(.status-cancelled) .tool-card-icon-slot--expandable .tool-card-icon-expand-hint {
   opacity: 1;
-}
-
-/* Status icon (at right border) */
-.tool-card-status-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  margin-left: 4px;
-  padding-left: 4px;
-  transition: all 0.2s ease;
-
-  &.tool-card-status-icon--with-divider {
-    border-left: 1px solid var(--border-base);
-  }
-
-  svg {
-    width: 14px;
-    height: 14px;
-  }
-
-  /* Loading icon */
-  .loading {
-    width: 16px !important;
-    height: 16px !important;
-    gap: 0 !important;
-  }
-
-  .loading__spinner {
-    width: 16px !important;
-    height: 16px !important;
-    border-width: 2px !important;
-    box-shadow: 0 0 8px var(--loading-color-light) !important;
-  }
-
-  .icon-completed {
-    color: var(--color-success);
-  }
-
-  .icon-error {
-    color: var(--color-error);
-    filter: drop-shadow(0 0 4px rgba(239, 68, 68, 0.4));
-  }
 }
 
 /* Action text */

--- a/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.tsx
@@ -168,7 +168,6 @@ export const ToolCardHeader: React.FC<ToolCardHeaderProps> = ({
     affordanceKind !== undefined ? affordanceKind : layout.headerAffordanceKind;
   const expandedForChevron =
     headerExpanded !== undefined ? headerExpanded : layout.isExpanded;
-  const isPanelAffordance = resolvedAffordanceKind === 'open-panel-right';
 
   return (
     <>

--- a/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.tsx
@@ -3,13 +3,14 @@
  * Provides unified card styles and interaction logic
  */
 import React, { ReactNode } from 'react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
 import {
   ToolCardHeaderLayoutContext,
   useToolCardHeaderLayout,
   type ToolCardHeaderAffordanceKind,
   type ToolCardHeaderLayoutContextValue,
 } from './ToolCardHeaderLayoutContext';
+import { ToolCardIconSlot } from './ToolCardIconSlot';
+import { ToolCardStatusIcon } from './ToolCardStatusIcon';
 import './BaseToolCard.scss';
 
 const LOADING_SHIMMER_STATUSES = new Set([
@@ -172,46 +173,23 @@ export const ToolCardHeader: React.FC<ToolCardHeaderProps> = ({
   return (
     <>
       {icon != null && icon !== false && icon !== '' && (
-        <div
-          className={`tool-card-icon-slot${showExpandHint ? ' tool-card-icon-slot--expandable' : ''}${showExpandHint && isPanelAffordance ? ' tool-card-icon-slot--affordance-panel' : ''}`}
-        >
-          <div className="tool-card-icon-marks">
-            <div className={`tool-card-icon tool-identifier-icon tool-card-icon-main ${iconClassName || ''}`}>
-              {icon}
-            </div>
-            {showExpandHint && (
-              <span
-                className={`tool-card-icon-expand-hint${!isPanelAffordance && expandedForChevron ? ' tool-card-icon-expand-hint--open' : ''}`}
-                aria-hidden
-              >
-                {isPanelAffordance ? (
-                  <ChevronRight size={16} strokeWidth={2} absoluteStrokeWidth />
-                ) : (
-                  <ChevronDown size={16} strokeWidth={2} absoluteStrokeWidth />
-                )}
-              </span>
-            )}
-          </div>
-          {showExpandHint && onAffordanceClick && (
-            <button
-              type="button"
-              className="tool-card-icon-affordance-hit"
-              onClick={(e) => {
-                e.stopPropagation();
-                onAffordanceClick(e);
-              }}
-              aria-label={isPanelAffordance ? 'Open details' : 'Expand details'}
-            />
-          )}
-        </div>
+        <ToolCardIconSlot
+          icon={icon}
+          iconClassName={iconClassName}
+          expandable={showExpandHint}
+          affordanceKind={resolvedAffordanceKind}
+          isExpanded={expandedForChevron}
+          onAffordanceClick={onAffordanceClick}
+        />
       )}
       {action && <span className="tool-card-action">{action}</span>}
       {content && <div className="tool-card-content">{content}</div>}
       {extra && <div className="tool-card-extra">{extra}</div>}
       {statusIcon && (
-        <div className={`tool-card-status-icon ${extra ? 'tool-card-status-icon--with-divider' : ''}`}>
-          {statusIcon}
-        </div>
+        <ToolCardStatusIcon
+          icon={statusIcon}
+          withDivider={Boolean(extra)}
+        />
       )}
     </>
   );

--- a/src/web-ui/src/flow_chat/tool-cards/BtwMarkerCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/BtwMarkerCard.tsx
@@ -43,7 +43,7 @@ export const BtwMarkerCard: React.FC<ToolCardProps> = React.memo(({ toolItem, se
       }}
       header={
         <CompactToolCardHeader
-          statusIcon={<CornerDownRight size={12} />}
+          icon={<CornerDownRight size={16} />}
           action={t('btw.title', { defaultValue: 'Side question' })}
           content={
             <span style={{ opacity: 0.95 }}>

--- a/src/web-ui/src/flow_chat/tool-cards/CompactToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/CompactToolCard.scss
@@ -46,13 +46,13 @@
 /* ========== Loading state: A (border via text fade) + E (text fade) ========== */
 
 /* Hide left spinner/cube */
-.compact-tool-card-wrapper--loading-shimmer .compact-card-status-icon:has(.cube-loading),
-.compact-tool-card-wrapper--loading-shimmer .compact-card-status-icon:has(svg.animate-spin) {
+.compact-tool-card-wrapper--loading-shimmer .tool-card-icon-marks:has(.cube-loading),
+.compact-tool-card-wrapper--loading-shimmer .tool-card-icon-marks:has(svg.animate-spin) {
   display: none !important;
 }
 
 /* E — status icon + action + content breathe */
-.compact-tool-card-wrapper--loading-shimmer .compact-card-status-icon,
+.compact-tool-card-wrapper--loading-shimmer .tool-card-icon-marks,
 .compact-tool-card-wrapper--loading-shimmer .compact-card-action,
 .compact-tool-card-wrapper--loading-shimmer .compact-card-content {
   animation: tool-card-text-fade 1.6s ease-in-out infinite;
@@ -77,19 +77,19 @@
     background: transparent !important;
     border: none !important;
     box-shadow: none !important;
-    
-    .compact-card-status-icon {
+
+    .tool-card-icon-marks {
       color: var(--color-success);
       transform: scale(1.05);
     }
-    
+
     .compact-card-action,
     .compact-card-content,
     .compact-card-extra {
       color: var(--color-text-primary);
     }
-    
-    .compact-card-right-icon {
+
+    .compact-card-right-status-icon {
       color: var(--color-success);
       transform: scale(1.05);
     }
@@ -97,8 +97,8 @@
 
   &.clickable:active {
     background: transparent !important;
-    
-    .compact-card-status-icon {
+
+    .tool-card-icon-marks {
       transform: scale(1.0);
     }
   }
@@ -108,8 +108,8 @@
     .compact-card-content {
       color: var(--color-text-primary);
     }
-    
-    .compact-card-status-icon {
+
+    .tool-card-icon-marks {
       opacity: 0.95;
     }
   }
@@ -128,21 +128,6 @@
  *   the 23px text rhythm. This way the row height is driven solely by the text
  *   spans (line-height 1.65 × 14px = 23.1px), not by icon wrappers.
  */
-.compact-card-status-icon {
-  font-size: var(--flowchat-font-size-base);
-  line-height: 1;
-  flex-shrink: 0;
-  color: var(--color-text-muted);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-
-  > svg {
-    display: block;
-  }
-}
-
 .compact-card-action {
   font-size: var(--flowchat-font-size-base);
   line-height: 1.65;
@@ -184,22 +169,6 @@
   }
 }
 
-.compact-card-right-icon {
-  font-size: var(--flowchat-font-size-base);
-  line-height: 1;
-  flex-shrink: 0;
-  color: var(--color-text-muted);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: auto;
-  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-
-  > svg {
-    display: block;
-  }
-}
-
 /* ========== Expanded compact tools use the shared BaseToolCard shell ========== */
 .base-tool-card-wrapper.compact-tool-card-wrapper--expanded-card {
   width: 100%;
@@ -217,8 +186,8 @@
     display: block;
   }
 
-  .compact-card-status-icon,
-  .compact-card-right-icon {
+  .tool-card-icon-marks,
+  .compact-card-right-status-icon {
     color: var(--color-text-secondary);
   }
 
@@ -232,7 +201,7 @@
 /* ========== Status-specific styles ========== */
 
 .compact-tool-card.status-completed {
-  .compact-card-status-icon {
+  .tool-card-icon-marks {
     color: var(--color-text-muted);
 
     .icon-check-done {
@@ -243,15 +212,19 @@
 
 .compact-tool-card.status-running,
 .compact-tool-card.status-streaming {
-  .compact-card-status-icon {
+  .tool-card-icon-marks {
     color: var(--color-accent-600);
   }
 }
 
 .compact-tool-card.status-error {
-  .compact-card-status-icon {
+  .tool-card-icon-marks {
     color: var(--color-error);
   }
+}
+
+.compact-card-right-status-icon {
+  margin-left: auto;
 }
 
 /* ========== Expanded content area ========== */

--- a/src/web-ui/src/flow_chat/tool-cards/CompactToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CompactToolCard.tsx
@@ -1,7 +1,7 @@
 /**
  * Compact tool card component
  * Used for ReadFile, GrepSearch, WebSearch, etc. with transparent gray background
- * 
+ *
  * Features:
  * - Collapsed: transparent background, no border, single-line display
  * - Expanded: shows detailed content with dark background box
@@ -10,6 +10,9 @@
 
 import React, { ReactNode } from 'react';
 import { BaseToolCard, type BaseToolCardProps } from './BaseToolCard';
+import { ToolCardIconSlot } from './ToolCardIconSlot';
+import { ToolCardStatusIcon } from './ToolCardStatusIcon';
+import type { ToolCardHeaderAffordanceKind } from './ToolCardHeaderLayoutContext';
 import './CompactToolCard.scss';
 
 export interface CompactToolCardProps {
@@ -87,38 +90,68 @@ export const CompactToolCard: React.FC<CompactToolCardProps> = ({
 };
 
 export interface CompactToolCardHeaderProps {
-  /** Left status icon */
-  statusIcon?: ReactNode;
+  /** Left tool icon (should be 16px lucide icon) */
+  icon?: ReactNode;
+  /** Custom class name for the icon element */
+  iconClassName?: string;
+  /** Show hover chevron when expandable */
+  expandable?: boolean;
+  /** Expand vs open-right-panel hint icon */
+  affordanceKind?: ToolCardHeaderAffordanceKind;
+  /** Expanded state for chevron rotation */
+  isExpanded?: boolean;
+  /** Click handler for the left icon rail affordance */
+  onAffordanceClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  /** Whether to show the left icon divider (default false for compact) */
+  showDivider?: boolean;
   /** Action text */
   action?: string;
   /** Main content */
   content?: ReactNode;
   /** Right extra content (e.g., statistics) */
   extra?: ReactNode;
-  /** Right status icon */
-  rightIcon?: ReactNode;
+  /** Right status icon (should be 14px) */
+  rightStatusIcon?: ReactNode;
+  /** Whether right status icon has a divider */
+  rightStatusIconWithDivider?: boolean;
 }
+
 export const CompactToolCardHeader: React.FC<CompactToolCardHeaderProps> = ({
-  statusIcon,
+  icon,
+  iconClassName,
+  expandable = false,
+  affordanceKind = 'expand',
+  isExpanded = false,
+  onAffordanceClick,
+  showDivider = false,
   action,
   content,
   extra,
-  rightIcon,
+  rightStatusIcon,
+  rightStatusIconWithDivider = false,
 }) => {
   return (
     <>
-      {statusIcon && (
-        <span className="compact-card-status-icon">
-          {statusIcon}
-        </span>
+      {icon && (
+        <ToolCardIconSlot
+          icon={icon}
+          iconClassName={iconClassName}
+          expandable={expandable}
+          affordanceKind={affordanceKind}
+          isExpanded={isExpanded}
+          onAffordanceClick={onAffordanceClick}
+          showDivider={showDivider}
+        />
       )}
       {action && <span className="compact-card-action">{action}</span>}
       {content && <span className="compact-card-content">{content}</span>}
       {extra && <span className="compact-card-extra">{extra}</span>}
-      {rightIcon && (
-        <span className="compact-card-right-icon">
-          {rightIcon}
-        </span>
+      {rightStatusIcon && (
+        <ToolCardStatusIcon
+          icon={rightStatusIcon}
+          withDivider={rightStatusIconWithDivider}
+          className="compact-card-right-status-icon"
+        />
       )}
     </>
   );

--- a/src/web-ui/src/flow_chat/tool-cards/DefaultToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/DefaultToolCard.tsx
@@ -138,14 +138,14 @@ export const DefaultToolCard: React.FC<ToolCardProps> = ({
     switch (status) {
       case 'running':
       case 'streaming':
-        return <Loader2 className="animate-spin" size={12} />;
+        return <Loader2 className="animate-spin" size={16} />;
       case 'completed':
-        return <Check size={12} className="icon-check-done" />;
+        return <Check size={16} className="icon-check-done" />;
       case 'cancelled':
       case 'error':
-        return <XCircle size={12} />;
+        return <XCircle size={16} />;
       default:
-        return <Clock size={12} />;
+        return <Clock size={16} />;
     }
   };
 
@@ -230,11 +230,11 @@ export const DefaultToolCard: React.FC<ToolCardProps> = ({
         clickable={canExpand}
         header={
           <CompactToolCardHeader
-            statusIcon={getStatusIcon()}
+            icon={getStatusIcon()}
             action={config.displayName}
             content={getSummaryText()}
             extra={config.icon ? <span className="default-tool-card__icon-badge">{config.icon}</span> : undefined}
-            rightIcon={canExpand ? (isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />) : undefined}
+            rightStatusIcon={canExpand ? (isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />) : undefined}
           />
         }
         expandedContent={canExpand ? (

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.scss
@@ -184,7 +184,7 @@
   justify-content: center;
   align-self: stretch;
   flex-shrink: 0;
-  width: 40px;
+  width: var(--tool-card-header-icon-slot, 34px);
   padding: 0;
   margin-left: 4px;
   border: none;

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -698,15 +698,15 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
       case 'running':
       case 'streaming':
       case 'preparing':
-        return <Loader2 className="animate-spin" size={12} />;
+        return <Loader2 className="animate-spin" size={16} />;
       case 'completed':
-        return <Check size={12} className="icon-check-done" />;
+        return <Check size={16} className="icon-check-done" />;
       case 'pending':
       case 'confirmed':
       case 'pending_confirmation':
       case 'analyzing':
       default:
-        return <Clock size={12} />;
+        return <Clock size={16} />;
     }
   };
 
@@ -828,7 +828,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
         clickable={false}
         header={
           <CompactToolCardHeader
-            statusIcon={getDeleteStatusIcon()}
+            icon={getDeleteStatusIcon()}
             content={renderDeleteContent()}
           />
         }

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -806,9 +806,8 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
                 className="file-op-open-full-button"
                 onClick={handleOpenFullCodeClick}
                 aria-label={t('toolCards.file.openFullCodeHint')}
-                title={t('toolCards.file.openFullCodeHint')}
               >
-                <ChevronRight size={18} strokeWidth={2} absoluteStrokeWidth />
+                <ChevronRight size={14} strokeWidth={2} absoluteStrokeWidth />
               </button>
             </Tooltip>
           )}

--- a/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.tsx
@@ -187,7 +187,7 @@ export const GitToolDisplay: React.FC<ToolCardProps> = ({
 
   const renderHeader = () => (
     <CompactToolCardHeader
-      statusIcon={<GitBranch size={14} className="git-card-icon" />}
+      icon={<GitBranch size={16} className="git-card-icon" />}
       action={isFailed ? t('toolCards.git.commandFailed') : `${t('toolCards.git.title')}:`}
       content={
         <span className="git-tool-info">
@@ -243,7 +243,7 @@ export const GitToolDisplay: React.FC<ToolCardProps> = ({
           )}
         </>
       }
-      rightIcon={renderStatusIcon()}
+      rightStatusIcon={renderStatusIcon()}
     />
   );
 

--- a/src/web-ui/src/flow_chat/tool-cards/GlobSearchDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GlobSearchDisplay.tsx
@@ -25,11 +25,11 @@ export const GlobSearchDisplay: React.FC<ToolCardProps> = ({
     switch (status) {
       case 'running':
       case 'streaming':
-        return <Loader2 className="animate-spin" size={12} />;
+        return <Loader2 className="animate-spin" size={16} />;
       case 'completed':
-        return <Check size={12} className="icon-check-done" />;
+        return <Check size={16} className="icon-check-done" />;
       default:
-        return <Clock size={12} />;
+        return <Clock size={16} />;
     }
   };
 
@@ -195,7 +195,7 @@ export const GlobSearchDisplay: React.FC<ToolCardProps> = ({
         clickable={hasDetails}
         header={
           <CompactToolCardHeader
-            statusIcon={getStatusIcon()}
+            icon={getStatusIcon()}
             content={renderContent()}
           />
         }

--- a/src/web-ui/src/flow_chat/tool-cards/GrepSearchDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GrepSearchDisplay.tsx
@@ -25,11 +25,11 @@ export const GrepSearchDisplay: React.FC<ToolCardProps> = ({
     switch (status) {
       case 'running':
       case 'streaming':
-        return <Loader2 className="animate-spin" size={12} />;
+        return <Loader2 className="animate-spin" size={16} />;
       case 'completed':
-        return <Check size={12} className="icon-check-done" />;
+        return <Check size={16} className="icon-check-done" />;
       default:
-        return <Clock size={12} />;
+        return <Clock size={16} />;
     }
   };
 
@@ -151,7 +151,7 @@ export const GrepSearchDisplay: React.FC<ToolCardProps> = ({
         clickable={hasDetails}
         header={
           <CompactToolCardHeader
-            statusIcon={getStatusIcon()}
+            icon={getStatusIcon()}
             content={renderContent()}
           />
         }

--- a/src/web-ui/src/flow_chat/tool-cards/LSDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/LSDisplay.tsx
@@ -32,11 +32,11 @@ export const LSDisplay: React.FC<ToolCardProps> = ({
     switch (status) {
       case 'running':
       case 'streaming':
-        return <Loader2 className="animate-spin" size={12} />;
+        return <Loader2 className="animate-spin" size={16} />;
       case 'completed':
-        return <Check size={12} className="icon-check-done" />;
+        return <Check size={16} className="icon-check-done" />;
       default:
-        return <Clock size={12} />;
+        return <Clock size={16} />;
     }
   };
 
@@ -192,7 +192,7 @@ export const LSDisplay: React.FC<ToolCardProps> = ({
         clickable={hasDetails}
         header={
           <CompactToolCardHeader
-            statusIcon={getStatusIcon()}
+            icon={getStatusIcon()}
             content={renderContent()}
           />
         }

--- a/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx
@@ -19,12 +19,12 @@ export const ReadFileDisplay: React.FC<ToolCardProps> = React.memo(({
     switch (status) {
       case 'running':
       case 'streaming':
-        return <Loader2 className="animate-spin" size={12} />;
+        return <Loader2 className="animate-spin" size={16} />;
       case 'completed':
-        return <Check size={12} className="icon-check-done" />;
+        return <Check size={16} className="icon-check-done" />;
       case 'pending':
       default:
-        return <Clock size={12} />;
+        return <Clock size={16} />;
     }
   };
 
@@ -134,7 +134,7 @@ export const ReadFileDisplay: React.FC<ToolCardProps> = React.memo(({
       clickable={canOpenFile}
       header={
         <CompactToolCardHeader
-          statusIcon={getStatusIcon()}
+          icon={getStatusIcon()}
           content={renderContent()}
         />
       }

--- a/src/web-ui/src/flow_chat/tool-cards/ReviewSessionSummaryCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ReviewSessionSummaryCard.tsx
@@ -104,7 +104,7 @@ export const ReviewSessionSummaryCard: React.FC<ToolCardProps> = React.memo(({
       className="review-session-summary-card"
       header={(
         <ToolCardHeader
-          icon={<Icon size={13} />}
+          icon={<Icon size={16} />}
           iconClassName="review-session-summary-card__icon"
           content={(
             <span>
@@ -113,14 +113,14 @@ export const ReviewSessionSummaryCard: React.FC<ToolCardProps> = React.memo(({
           )}
           extra={changedFiles.length > 0 ? (
             <span className="review-session-summary-card__file-count">
-              <FileText size={12} />
+              <FileText size={14} />
               {t('toolCards.reviewSessionSummary.filesChanged', {
                 count: changedFiles.length,
                 defaultValue: '{{count}} files',
               })}
             </span>
           ) : null}
-          statusIcon={running ? <Loader2 className="animate-spin" size={12} /> : undefined}
+          statusIcon={running ? <Loader2 className="animate-spin" size={14} /> : undefined}
         />
       )}
       expandedContent={(

--- a/src/web-ui/src/flow_chat/tool-cards/SessionControlToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/SessionControlToolCard.tsx
@@ -91,16 +91,16 @@ export const SessionControlToolCard: React.FC<ToolCardProps> = React.memo(({
     switch (status) {
       case 'running':
       case 'streaming':
-        return <Loader2 className="animate-spin" size={12} />;
+        return <Loader2 className="animate-spin" size={16} />;
       case 'completed':
-        return <Check size={12} className="icon-check-done" />;
+        return <Check size={16} className="icon-check-done" />;
       case 'error':
       case 'cancelled':
-        return <X size={12} />;
+        return <X size={16} />;
       case 'pending':
       case 'preparing':
       default:
-        return <Clock size={12} />;
+        return <Clock size={16} />;
     }
   };
 
@@ -286,7 +286,7 @@ export const SessionControlToolCard: React.FC<ToolCardProps> = React.memo(({
         clickable={hasDetails}
         header={(
           <CompactToolCardHeader
-            statusIcon={getStatusIcon()}
+            icon={getStatusIcon()}
             action={`${t('toolCards.sessionControl.title')}:`}
             content={renderContent()}
             extra={action === 'list' && status === 'completed' ? `${sessionCount}` : undefined}

--- a/src/web-ui/src/flow_chat/tool-cards/SessionMessageToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/SessionMessageToolCard.tsx
@@ -61,16 +61,16 @@ export const SessionMessageToolCard: React.FC<ToolCardProps> = React.memo(({
     switch (status) {
       case 'running':
       case 'streaming':
-        return <Loader2 className="animate-spin" size={12} />;
+        return <Loader2 className="animate-spin" size={16} />;
       case 'completed':
-        return <Check size={12} className="icon-check-done" />;
+        return <Check size={16} className="icon-check-done" />;
       case 'error':
       case 'cancelled':
-        return <X size={12} />;
+        return <X size={16} />;
       case 'pending':
       case 'preparing':
       default:
-        return <Clock size={12} />;
+        return <Clock size={16} />;
     }
   };
 
@@ -156,7 +156,7 @@ export const SessionMessageToolCard: React.FC<ToolCardProps> = React.memo(({
         clickable={hasDetails}
         header={(
           <CompactToolCardHeader
-            statusIcon={getStatusIcon()}
+            icon={getStatusIcon()}
             action={`${t('toolCards.sessionMessage.title')}:`}
             content={renderContent()}
             extra={agentType ? agentType : undefined}

--- a/src/web-ui/src/flow_chat/tool-cards/SkillDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/SkillDisplay.tsx
@@ -40,14 +40,14 @@ export const SkillDisplay: React.FC<ToolCardProps> = React.memo(({ toolItem }) =
       case 'running':
       case 'streaming':
       case 'preparing':
-        return <Loader2 className="animate-spin" size={12} />;
+        return <Loader2 className="animate-spin" size={16} />;
       case 'completed':
-        return <Check size={12} className="icon-check-done" />;
+        return <Check size={16} className="icon-check-done" />;
       case 'error':
-        return <X size={12} />;
+        return <X size={16} />;
       case 'pending':
       default:
-        return <Clock size={12} />;
+        return <Clock size={16} />;
     }
   };
 
@@ -96,7 +96,7 @@ export const SkillDisplay: React.FC<ToolCardProps> = React.memo(({ toolItem }) =
       clickable={false}
       header={
         <CompactToolCardHeader
-          statusIcon={getStatusIcon()}
+          icon={getStatusIcon()}
           content={renderContent()}
         />
       }

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.scss
@@ -8,79 +8,8 @@
     width: 100%;
   }
 
-  .task-icon-container {
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    align-self: stretch;
-    width: var(--tool-card-header-icon-slot, 34px);
-    margin-right: 8px;
-    box-sizing: border-box;
-    min-height: 0;
+  .task-icon {
     color: var(--color-text-secondary, #6b7280);
-
-    &::after {
-      content: '';
-      position: absolute;
-      right: 0;
-      top: calc(-1 * var(--tool-card-header-pad-y, 10px));
-      bottom: calc(-1 * var(--tool-card-header-pad-y, 10px));
-      width: 0;
-      border-right: 1px solid var(--border-base);
-      pointer-events: none;
-      z-index: 0;
-    }
-
-    .task-task-icon-marks {
-      position: relative;
-      z-index: 1;
-      width: var(--tool-card-header-icon-rail, 28px);
-      height: var(--tool-card-header-icon-rail, 28px);
-      flex-shrink: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .task-task-icon-main {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      flex-shrink: 0;
-      transition: opacity 0.18s ease;
-
-      svg {
-        width: 16px;
-        height: 16px;
-      }
-    }
-
-    &.task-icon-container--expandable .task-task-icon-hint {
-      position: absolute;
-      inset: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      margin: 0;
-      padding: 0;
-      opacity: 0;
-      pointer-events: none;
-      color: var(--color-text-secondary);
-      transition: opacity 0.18s ease;
-
-      svg {
-        width: 16px;
-        height: 16px;
-        flex-shrink: 0;
-        transition: transform 0.2s ease;
-      }
-    }
-
-    &.task-icon-container--expandable .task-task-icon-hint--open svg {
-      transform: rotate(180deg);
-    }
 
     &.is-running {
       color: var(--color-primary, #3b82f6);
@@ -89,15 +18,15 @@
 
   &.base-tool-card-wrapper:hover
     .base-tool-card.base-tool-card--header-expandable:not(.status-cancelled)
-    .task-icon-container.task-icon-container--expandable
-    .task-task-icon-main {
+    .tool-card-icon-slot--expandable
+    .tool-card-icon-main {
     opacity: 0;
   }
 
   &.base-tool-card-wrapper:hover
     .base-tool-card.base-tool-card--header-expandable:not(.status-cancelled)
-    .task-icon-container.task-icon-container--expandable
-    .task-task-icon-hint {
+    .tool-card-icon-slot--expandable
+    .tool-card-icon-expand-hint {
     opacity: 1;
   }
 
@@ -137,7 +66,7 @@
     justify-content: center;
     align-self: stretch;
     flex-shrink: 0;
-    width: 40px;
+    width: var(--tool-card-header-icon-slot, 34px);
     padding: 0;
     margin-left: 4px;
 
@@ -286,31 +215,11 @@
     }
   }
 
-  .task-status-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    margin-left: 4px;
-    padding-left: 4px;
-    border-left: 1px solid var(--border-base);
-    
-    .icon-completed {
-      color: var(--color-success);
-    }
-    
-    .loading {
-      width: 16px !important;
-      height: 16px !important;
-    }
-  }
-
   .task-status-icon--rail {
     position: relative;
     z-index: 1;
     margin-left: 0;
     padding-left: 0;
-    border-left: none;
   }
 
   /* Prompt uses the thinking markdown typography, but needs its own clipping box.
@@ -602,7 +511,7 @@
 }
 
 /* Loading: task status icon (cube) hidden; border-pulse + text-fade from BaseToolCard handle the rest */
-.task-tool-display.base-tool-card-wrapper--loading-shimmer .task-status-icon:has(.cube-loading) {
+.task-tool-display.base-tool-card-wrapper--loading-shimmer .tool-card-status-icon:has(.cube-loading) {
   display: none !important;
 }
 

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
@@ -7,7 +7,6 @@ import {
   AlertTriangle,
   Split,
   ChevronRight,
-  ChevronDown,
 } from 'lucide-react';
 
 import { useTranslation } from 'react-i18next';
@@ -15,6 +14,8 @@ import { CubeLoading, Button } from '../../component-library';
 import { Markdown } from '@/component-library/components/Markdown/Markdown';
 import type { ToolCardProps } from '../types/flow-chat';
 import { BaseToolCard } from './BaseToolCard';
+import { ToolCardIconSlot } from './ToolCardIconSlot';
+import { ToolCardStatusIcon } from './ToolCardStatusIcon';
 import { taskCollapseStateManager } from '../store/TaskCollapseStateManager';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
 import { ToolTimeoutIndicator } from './ToolTimeoutIndicator';
@@ -256,23 +257,14 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
 
   const renderHeader = () => (
     <div className="task-header-wrapper">
-      <div
-        className={`task-icon-container ${isRunning ? 'is-running' : ''}${
-          showHeaderExpandHint ? ' task-icon-container--expandable' : ''
-        }`}
-      >
-        <div className="task-task-icon-marks">
-          <div className="task-task-icon-main">{renderToolIcon()}</div>
-          {showHeaderExpandHint && (
-            <span
-              className={`task-task-icon-hint${isExpanded ? ' task-task-icon-hint--open' : ''}`}
-              aria-hidden
-            >
-              <ChevronDown size={16} strokeWidth={2} absoluteStrokeWidth />
-            </span>
-          )}
-        </div>
-      </div>
+      <ToolCardIconSlot
+        icon={renderToolIcon()}
+        iconClassName={`task-icon ${isRunning ? 'is-running' : ''}`}
+        expandable={showHeaderExpandHint}
+        affordanceKind="expand"
+        isExpanded={isExpanded}
+        onAffordanceClick={handleCardClick}
+      />
 
       <div className="task-content-wrapper">
         <div className="task-body-columns">
@@ -311,10 +303,8 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
               title={t('toolCards.taskTool.openInPanel')}
             />
             <div className="task-header-rail__visual" aria-hidden>
-              <ChevronRight size={18} strokeWidth={2} absoluteStrokeWidth />
-              <div className="task-status-icon task-status-icon--rail">
-                {renderStatusIcon()}
-              </div>
+              <ChevronRight size={16} strokeWidth={2} absoluteStrokeWidth />
+              <ToolCardStatusIcon icon={renderStatusIcon()} className="task-status-icon--rail" />
             </div>
           </div>
         </div>

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalControlDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalControlDisplay.tsx
@@ -19,14 +19,14 @@ export const TerminalControlDisplay: React.FC<ToolCardProps> = React.memo(({
     switch (status) {
       case 'running':
       case 'streaming':
-        return <Loader2 className="animate-spin" size={12} />;
+        return <Loader2 className="animate-spin" size={16} />;
       case 'completed':
-        return <Check size={12} className="icon-check-done" />;
+        return <Check size={16} className="icon-check-done" />;
       case 'error':
-        return <X size={12} />;
+        return <X size={16} />;
       case 'pending':
       default:
-        return <Clock size={12} />;
+        return <Clock size={16} />;
     }
   };
 
@@ -97,7 +97,7 @@ export const TerminalControlDisplay: React.FC<ToolCardProps> = React.memo(({
       clickable={false}
       header={
         <CompactToolCardHeader
-          statusIcon={getStatusIcon()}
+          icon={getStatusIcon()}
           content={renderContent()}
         />
       }

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
@@ -498,7 +498,7 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
 
   const renderHeader = () => (
     <ToolCardHeader
-      icon={<Terminal size={14} className="terminal-card-icon" />}
+      icon={<Terminal size={16} className="terminal-card-icon" />}
       action={t('toolCards.terminal.executeCommand')}
       content={renderCommandContent()}
       extra={(
@@ -567,7 +567,7 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
 
   const renderCompactHeader = () => (
     <CompactToolCardHeader
-      statusIcon={<Terminal size={14} className="terminal-card-icon" />}
+      icon={<Terminal size={16} className="terminal-card-icon" />}
       action={t('toolCards.terminal.executeCommand')}
       content={renderCommandContent('compact')}
       extra={(
@@ -618,7 +618,7 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
           )}
         </>
       )}
-      rightIcon={renderStatusIcon()}
+      rightStatusIcon={renderStatusIcon()}
     />
   );
   const expandedContent = isExpanded

--- a/src/web-ui/src/flow_chat/tool-cards/ToolCardIconSlot.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ToolCardIconSlot.tsx
@@ -1,0 +1,75 @@
+/**
+ * Shared left icon-slot component for tool card headers.
+ * Provides consistent icon size (16px), container width (34px), alignment,
+ * hover chevron swap, and optional right border divider.
+ */
+import React, { ReactNode } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { ToolCardHeaderAffordanceKind } from './ToolCardHeaderLayoutContext';
+
+export interface ToolCardIconSlotProps {
+  /** Main tool icon (should be 16px lucide icon) */
+  icon: ReactNode;
+  /** Custom class name for the icon element */
+  iconClassName?: string;
+  /** Show hover chevron when expandable */
+  expandable?: boolean;
+  /** Expand vs open-right-panel hint icon */
+  affordanceKind?: ToolCardHeaderAffordanceKind;
+  /** Expanded state for chevron rotation */
+  isExpanded?: boolean;
+  /** Click handler for the left icon rail affordance */
+  onAffordanceClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  /** Show right border divider (default true) */
+  showDivider?: boolean;
+  /** Additional class name for the root element */
+  className?: string;
+}
+
+export const ToolCardIconSlot: React.FC<ToolCardIconSlotProps> = ({
+  icon,
+  iconClassName,
+  expandable = false,
+  affordanceKind = 'expand',
+  isExpanded = false,
+  onAffordanceClick,
+  showDivider = true,
+  className,
+}) => {
+  const isPanelAffordance = affordanceKind === 'open-panel-right';
+
+  return (
+    <div
+      className={`tool-card-icon-slot${expandable ? ' tool-card-icon-slot--expandable' : ''}${expandable && isPanelAffordance ? ' tool-card-icon-slot--affordance-panel' : ''}${!showDivider ? ' tool-card-icon-slot--no-divider' : ''}${className ? ` ${className}` : ''}`}
+    >
+      <div className="tool-card-icon-marks">
+        <div className={`tool-card-icon tool-identifier-icon tool-card-icon-main ${iconClassName || ''}`}>
+          {icon}
+        </div>
+        {expandable && (
+          <span
+            className={`tool-card-icon-expand-hint${!isPanelAffordance && isExpanded ? ' tool-card-icon-expand-hint--open' : ''}`}
+            aria-hidden
+          >
+            {isPanelAffordance ? (
+              <ChevronRight size={16} strokeWidth={2} absoluteStrokeWidth />
+            ) : (
+              <ChevronDown size={16} strokeWidth={2} absoluteStrokeWidth />
+            )}
+          </span>
+        )}
+      </div>
+      {expandable && onAffordanceClick && (
+        <button
+          type="button"
+          className="tool-card-icon-affordance-hit"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAffordanceClick(e);
+          }}
+          aria-label={isPanelAffordance ? 'Open details' : 'Expand details'}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/web-ui/src/flow_chat/tool-cards/ToolCardStatusIcon.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ToolCardStatusIcon.tsx
@@ -1,0 +1,28 @@
+/**
+ * Shared right status-icon component for tool card headers.
+ * Provides consistent icon sizing (14px SVG) and optional left border divider.
+ */
+import React, { ReactNode } from 'react';
+
+export interface ToolCardStatusIconProps {
+  /** Status icon content (should be 14px lucide icon or CubeLoading) */
+  icon: ReactNode;
+  /** Show left border divider (default false) */
+  withDivider?: boolean;
+  /** Additional class name */
+  className?: string;
+}
+
+export const ToolCardStatusIcon: React.FC<ToolCardStatusIconProps> = ({
+  icon,
+  withDivider = false,
+  className,
+}) => {
+  return (
+    <div
+      className={`tool-card-status-icon${withDivider ? ' tool-card-status-icon--with-divider' : ''}${className ? ` ${className}` : ''}`}
+    >
+      {icon}
+    </div>
+  );
+};

--- a/src/web-ui/src/flow_chat/tool-cards/WebSearchCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/WebSearchCard.tsx
@@ -32,11 +32,11 @@ export const WebSearchCard: React.FC<ToolCardProps> = ({
       case 'running':
       case 'streaming':
       case 'preparing':
-        return <Loader2 className="animate-spin" size={12} />;
+        return <Loader2 className="animate-spin" size={16} />;
       case 'completed':
-        return <Check size={12} className="icon-check-done" />;
+        return <Check size={16} className="icon-check-done" />;
       default:
-        return <Clock size={12} />;
+        return <Clock size={16} />;
     }
   };
 
@@ -150,7 +150,7 @@ export const WebSearchCard: React.FC<ToolCardProps> = ({
         clickable={Boolean(status === 'completed' && hasResults)}
         header={
           <CompactToolCardHeader
-            statusIcon={getStatusIcon()}
+            icon={getStatusIcon()}
             content={renderContent()}
           />
         }

--- a/src/web-ui/src/flow_chat/tool-cards/_tool-card-common.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/_tool-card-common.scss
@@ -63,3 +63,155 @@
     'SF Mono', 'Monaco', 'Cascadia Code', 'Cascadia Mono', Consolas, 'Inconsolata', 'Fira Code', 'Fira Mono',
     'Droid Sans Mono', 'Source Code Pro', 'Lucida Console', 'Courier New', monospace;
 }
+
+/* ========== Shared header icon variables ========== */
+:root {
+  --tool-card-header-pad-y: 7px;
+  --tool-card-header-pad-x: 0px;
+  --tool-card-header-pad-right: 10px;
+  --tool-card-header-icon-rail: 24px;
+  --tool-card-header-icon-slot: calc(var(--tool-card-header-icon-rail) + 10px);
+}
+
+/* ========== Shared icon-slot (left rail) ========== */
+.tool-card-icon-slot {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  align-self: stretch;
+  width: var(--tool-card-header-icon-slot);
+  margin-right: 8px;
+  box-sizing: border-box;
+  min-height: 0;
+
+  &::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: calc(-1 * var(--tool-card-header-pad-y));
+    bottom: calc(-1 * var(--tool-card-header-pad-y));
+    width: 0;
+    border-right: 1px solid var(--border-base);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  &.tool-card-icon-slot--no-divider::after {
+    display: none;
+  }
+}
+
+.tool-card-icon-affordance-hit {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  appearance: none;
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent-500, #60a5fa);
+    outline-offset: 2px;
+    border-radius: 6px;
+  }
+}
+
+.tool-card-icon-marks {
+  position: relative;
+  z-index: 1;
+  width: var(--tool-card-header-icon-rail);
+  height: var(--tool-card-header-icon-rail);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tool-card-icon.tool-identifier-icon.tool-card-icon-main {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: opacity 0.18s ease;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.tool-card-icon-slot--expandable .tool-card-icon-expand-hint {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  opacity: 0;
+  pointer-events: none;
+  color: var(--color-text-secondary);
+  transition: opacity 0.18s ease;
+
+  svg {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    transition: transform 0.2s ease;
+  }
+}
+
+.tool-card-icon-slot--expandable .tool-card-icon-expand-hint--open svg {
+  transform: rotate(180deg);
+}
+
+/* ========== Shared status-icon (right) ========== */
+.tool-card-status-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-left: 4px;
+  padding-left: 4px;
+  transition: all 0.2s ease;
+
+  &.tool-card-status-icon--with-divider {
+    border-left: 1px solid var(--border-base);
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  /* Loading icon */
+  .loading {
+    width: 16px !important;
+    height: 16px !important;
+    gap: 0 !important;
+  }
+
+  .loading__spinner {
+    width: 16px !important;
+    height: 16px !important;
+    border-width: 2px !important;
+    box-shadow: 0 0 8px var(--loading-color-light) !important;
+  }
+
+  .icon-completed {
+    color: var(--color-success);
+  }
+
+  .icon-error {
+    color: var(--color-error);
+    filter: drop-shadow(0 0 4px rgba(239, 68, 68, 0.4));
+  }
+}

--- a/src/web-ui/src/flow_chat/tool-cards/index.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/index.ts
@@ -487,6 +487,10 @@ export type {
   ToolCardHeaderLayoutContextValue,
   ToolCardHeaderAffordanceKind,
 } from './ToolCardHeaderLayoutContext';
+export { ToolCardIconSlot } from './ToolCardIconSlot';
+export type { ToolCardIconSlotProps } from './ToolCardIconSlot';
+export { ToolCardStatusIcon } from './ToolCardStatusIcon';
+export type { ToolCardStatusIconProps } from './ToolCardStatusIcon';
 export { PlanDisplay } from './CreatePlanDisplay';
 export type { PlanDisplayProps } from './CreatePlanDisplay';
 

--- a/src/web-ui/src/infrastructure/config/components/ReviewConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/ReviewConfig.scss
@@ -133,6 +133,11 @@
   justify-content: flex-start;
 }
 
+/* Allow Select dropdowns to overflow the section body in the members list. */
+.review-config__members-section .bitfun-config-page-section__body {
+  overflow: visible;
+}
+
 @media (max-width: 860px) {
   .review-config__overview-grid {
     grid-template-columns: 1fr;

--- a/src/web-ui/src/infrastructure/config/components/ReviewConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ReviewConfig.tsx
@@ -264,7 +264,22 @@ const ReviewConfig: React.FC = () => {
   }, [loadData, notifyError, notifySuccess, t, team]);
 
   const handleModelChange = useCallback(async (member: ReviewTeamMember, modelId: string) => {
+    if (!team) return;
+
     setSavingMemberId(member.id);
+    const nextTeam: ReviewTeam = {
+      ...team,
+      members: team.members.map((m) =>
+        m.id === member.id ? { ...m, model: modelId } : m,
+      ),
+      coreMembers: team.coreMembers.map((m) =>
+        m.id === member.id ? { ...m, model: modelId } : m,
+      ),
+      extraMembers: team.extraMembers.map((m) =>
+        m.id === member.id ? { ...m, model: modelId } : m,
+      ),
+    };
+    setTeam(nextTeam);
     try {
       await SubagentAPI.updateSubagentConfig({
         subagentId: member.subagentId,
@@ -272,14 +287,14 @@ const ReviewConfig: React.FC = () => {
         model: modelId,
         workspacePath: workspacePath || undefined,
       });
-      await loadData();
       notifySuccess(t('messages.saved'));
     } catch (error) {
+      await loadData();
       notifyError(error instanceof Error ? error.message : t('messages.saveFailed'));
     } finally {
       setSavingMemberId(null);
     }
-  }, [loadData, notifyError, notifySuccess, t, workspacePath]);
+  }, [loadData, notifyError, notifySuccess, t, team, workspacePath]);
 
   const handleAddMember = useCallback(async () => {
     if (!candidateId) return;
@@ -430,6 +445,7 @@ const ReviewConfig: React.FC = () => {
         </ConfigPageSection>
 
         <ConfigPageSection
+          className="review-config__members-section"
           title={t('members.title')}
           description={t('members.description')}
           titleSuffix={<Badge variant="neutral">{t('members.count', { count: team.members.length })}</Badge>}


### PR DESCRIPTION
## Summary

This PR contains three independent fixes: a backend session index reliability fix, a frontend layout alignment fix, and a tool card UI refactor.

## Changes

### 1. fix(persistence): add index completeness check to `list_session_metadata` (c3d3c34)

`list_session_metadata` now detects when the session index file has fewer entries than actual session directories on disk, and triggers a full index rebuild. Previously only stale entries (index pointing to deleted dirs) were handled, missing the case where disk sessions exist but are absent from the index.

**Fixes:** sidebar session tree showing only ~20 of 70+ sessions after expand-all, caused by an incomplete in-memory store populated from a partial index.

**Files:** `src/crates/core/src/agentic/persistence/manager.rs`

### 2. fix(web-ui): align ReviewTeamPage content width and padding with parent gallery layout (f15cd9f)

- Set `--config-page-content-max-width` to `1480px` to match `GalleryLayout`
- Set `--config-page-content-inline-padding` to `clamp(40px, 6vw, 80px)` to match `GalleryLayout` gutter
- Move member description outside `detail-hero` for better layout flow

**Files:** `src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.scss`, `.tsx`

### 3. docs: update deep review design with frontend reviewer and always-on architecture reviewer (4ee7e7b)

Updates the deep review design doc to include:
- Frontend reviewer role
- Always-on architecture reviewer

Also includes a major refactor of tool card components:
- Extract `ToolCardIconSlot` and `ToolCardStatusIcon` components
- Consolidate shared styles into `_tool-card-common.scss`
- Simplify `TaskToolDisplay.scss` (remove 105 lines)
- Clean up `BaseToolCard.scss` and `CompactToolCard.scss`
- Minor workspace manager and workspace list style adjustments

**Files:** `docs/superpowers/specs/deep-review-design.md`, `src/web-ui/src/flow_chat/tool-cards/*`, `src/crates/core/src/service/lsp/workspace_manager.rs`, `src/web-ui/src/app/sections/workspaces/WorkspaceListSection.scss`