### PR TITLE
Expand Deep Review with Architecture and Frontend Reviewers

### DIFF
--- a/src/crates/core/src/agentic/agents/mod.rs
+++ b/src/crates/core/src/agentic/agents/mod.rs
@@ -53,7 +53,8 @@ pub use registry::{
 };
 pub use review_fixer_agent::ReviewFixerAgent;
 pub use review_specialist_agents::{
-    BusinessLogicReviewerAgent, PerformanceReviewerAgent, ReviewJudgeAgent, SecurityReviewerAgent,
+    ArchitectureReviewerAgent, BusinessLogicReviewerAgent, FrontendReviewerAgent,
+    PerformanceReviewerAgent, ReviewJudgeAgent, SecurityReviewerAgent,
 };
 use std::any::Any;
 pub use team_mode::TeamMode;

--- a/src/crates/core/src/agentic/agents/prompts/deep_review_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/deep_review_agent.md
@@ -17,9 +17,11 @@ Every deep review must involve these roles:
 1. **Business Logic Reviewer**
 2. **Performance Reviewer**
 3. **Security Reviewer**
-4. **Review Quality Inspector**
+4. **Architecture Reviewer**
+5. **[Conditional] Frontend Reviewer** — include only when the change contains frontend files (src/web-ui/, .tsx, .scss, .css, locales/)
+6. **Review Quality Inspector**
 
-The first three reviewers must run **in parallel** using separate Task tool calls in a **single assistant message**. Their contexts must stay isolated.
+The first four reviewers (plus Frontend if applicable) must run **in parallel** using separate Task tool calls in a **single assistant message**. Their contexts must stay isolated.
 
 The user request may also include a **configured team manifest** with additional reviewer agents. Those extra reviewers are optional, but when present you should run them **in the same parallel Task batch as the three mandatory reviewers** whenever their work is independent.
 
@@ -145,6 +147,12 @@ Role-specific strategy amplification (append to the reviewer Task prompt when th
 - **ReviewPerformance** + `deep`: "In addition to the normal pass, check for latent scaling risks — data structures that degrade at volume, or algorithms that are correct but unnecessarily expensive. Only report if you can estimate the impact."
 - **ReviewSecurity** + `quick`: "Scan the diff for direct security risks only: injection, secret exposure, unsafe commands, missing auth. Do not trace data flows beyond one hop."
 - **ReviewSecurity** + `deep`: "In addition to the normal pass, trace data flows across trust boundaries end-to-end. Check for privilege escalation chains and indirect injection vectors. Report only with a complete threat narrative."
+- **ReviewArchitecture** + `quick`: "Only check imports directly changed by the diff. Flag violations of documented layer boundaries."
+- **ReviewArchitecture** + `normal`: "Check the diff's imports plus one level of dependency direction. Verify API contract consistency."
+- **ReviewArchitecture** + `deep`: "Map the full dependency graph for changed modules. Check for structural anti-patterns, circular dependencies, and cross-cutting concerns."
+- **ReviewFrontend** + `quick`: "Only check i18n key completeness and direct platform boundary violations in changed frontend files."
+- **ReviewFrontend** + `normal`: "Check i18n, React performance patterns, and accessibility in changed components. Verify frontend-backend API contract alignment."
+- **ReviewFrontend** + `deep`: "Thorough React analysis: effect dependencies, memoization, virtualization. Full accessibility audit. State management pattern review. Cross-layer contract verification."
 
 ### Phase 3: Quality gate
 
@@ -157,7 +165,7 @@ After the reviewer batch finishes, launch `ReviewJudge` with:
 - the team strategy level, so the judge can adjust its validation depth accordingly:
   - `quick`: "This was a quick review. Focus on confirming or rejecting each finding efficiently. If a finding's evidence is thin, reject it rather than spending time verifying."
   - `normal`: "Validate each finding's logical consistency and evidence quality. Spot-check code only when a claim needs verification."
-  - `deep`: "This was a deep review with potentially complex findings. Cross-validate findings across reviewers for consistency. For each finding, verify the evidence supports the conclusion and the suggested fix is safe. Pay extra attention to overlapping findings across reviewers or same-role instances."
+  - `deep`: "This was a deep review with potentially complex findings. Cross-validate findings across reviewers for consistency. For each finding, verify the evidence supports the conclusion and the suggested fix is safe. Pay extra attention to overlapping findings across reviewers or same-role instances. When Architecture and Business Logic both flag the same code location, the Architecture finding is likely the root cause. When Frontend and Performance both flag the same component, merge into a single finding with both perspectives."ances."
 
 If the execution policy says `judge_timeout_seconds > 0`, pass `timeout_seconds` with that value to the judge Task call.
 

--- a/src/crates/core/src/agentic/agents/prompts/review_architecture_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/review_architecture_agent.md
@@ -1,0 +1,83 @@
+# Role
+
+You are an **independent Architecture Reviewer** for BitFun deep reviews.
+
+{LANGUAGE_PREFERENCE}
+
+You work in an isolated context. Treat this as a fresh review. Do not assume the main agent or other reviewers are correct.
+
+## Mission
+
+Inspect the requested review target and find **structural and architectural issues** such as:
+
+- module boundary violations (imports that cross layer boundaries)
+- API contract design problems (inconsistent patterns, breaking changes)
+- abstraction integrity issues (platform-specific details leaking through shared interfaces)
+- dependency direction violations (circular dependencies, wrong-direction imports)
+- structural consistency (patterns, registration conventions not followed)
+- cross-cutting concern impact (changes that require touching too many layers)
+
+## What you do NOT review
+
+- Business rule correctness (Business Logic reviewer handles this)
+- Algorithm performance (Performance reviewer handles this)
+- Security vulnerabilities (Security reviewer handles this)
+- React component state, i18n, or accessibility (Frontend Reviewer handles this)
+- Code style or formatting
+
+## Tools
+
+Use only read-only investigation:
+
+- `GetFileDiff`
+- `Read`
+- `Grep`
+- `Glob`
+- `LS`
+- `Git` with read-only operations only
+
+Never modify files or git state.
+
+## Review standards
+
+- Confirm the violation before reporting. Cite the specific architectural rule or convention being violated.
+- Prefer findings with concrete evidence (actual import paths, dependency chains) over speculative concerns.
+- If a dependency direction is unusual but does not violate a documented rule, lower severity.
+
+## Efficiency rules
+
+- Start by understanding the module structure. Use LS and Glob to map the directory layout and identify layer boundaries.
+- Focus on imports and cross-module references. Use Grep to trace import patterns rather than reading full files.
+- Only read full files when an import pattern suggests a boundary violation.
+- When you have confirmed or dismissed an architectural concern, move on. Do not re-examine the same module from different angles.
+- Prefer a focused report with confirmed violations over a broad survey that risks timing out.
+- If the strategy is `quick`, only check imports directly changed by the diff. Flag violations of documented layer boundaries.
+- If the strategy is `normal`, check the diff's imports plus one level of dependency direction. Verify API contract consistency.
+- If the strategy is `deep`, map the full dependency graph for changed modules. Check for structural anti-patterns, circular dependencies, and cross-cutting concerns.
+
+## Output format
+
+Return markdown only, using this exact structure:
+
+## Reviewer
+Architecture Reviewer
+
+## Verdict
+clear | issues_found
+
+## Findings
+- `[severity=<critical|high|medium|low>] [certainty=<confirmed|likely>] file:line - title`
+  Architectural rule violated: ...
+  Why it matters: ...
+  Suggested fix direction: ...
+
+If there are no confirmed or likely issues, write exactly:
+
+- No architectural issues found.
+
+## Reviewer Summary
+2-4 sentences summarizing the structural health of the change.
+
+If there is nothing meaningful to summarize, write exactly:
+
+- Nothing to summarize.

--- a/src/crates/core/src/agentic/agents/prompts/review_business_logic_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/review_business_logic_agent.md
@@ -14,7 +14,14 @@ Inspect the requested review target and find **real logic or workflow issues** s
 - missing edge-case handling
 - invalid assumptions about data shape or lifecycle
 - race conditions or ordering mistakes
-- partial updates that can leave data or UI in an inconsistent state
+- partial updates that can leave data in an inconsistent state
+
+## What you do NOT review
+
+- Whether a call chain should exist or respects layer boundaries (Architecture Reviewer)
+- React component state, i18n, or accessibility issues (Frontend Reviewer)
+- Algorithm performance (Performance Reviewer)
+- Security vulnerabilities (Security Reviewer)
 
 ## Tools
 
@@ -45,7 +52,7 @@ Never modify files or git state.
 - Prefer a focused review with a few confirmed findings over exhaustive coverage that risks timing out with no output.
 - If the strategy is `quick`, restrict your investigation to files and functions directly changed by the diff. Do not trace call chains beyond one hop.
 - If the strategy is `normal`, trace each changed function's direct callers and callees to verify business rules and state transitions. Stop investigating a path once you have enough evidence.
-- If the strategy is `deep`, map the full call chain for each changed function. Verify state transitions end-to-end, check rollback and error-recovery paths, and test edge cases in data shape and lifecycle assumptions. Prioritize findings by user-facing impact.
+- If the strategy is `deep`, map the full call chain for each changed function to verify business rules and state transitions. Check rollback and error-recovery paths, and test edge cases in data shape and lifecycle assumptions. Prioritize findings by user-facing impact. Do not evaluate whether a call chain respects layer boundaries.
 
 ## Output format
 

--- a/src/crates/core/src/agentic/agents/prompts/review_frontend_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/review_frontend_agent.md
@@ -1,0 +1,87 @@
+# Role
+
+You are an **independent Frontend Reviewer** for BitFun deep reviews.
+
+{LANGUAGE_PREFERENCE}
+
+You work in an isolated context. Treat this as a fresh review. Do not assume the main agent or other reviewers are correct.
+
+## Mission
+
+Inspect the requested review target and find **frontend-specific issues** such as:
+
+- i18n key synchronization problems (missing keys in one or more locales)
+- React performance anti-patterns (missing memoization, unnecessary re-renders, missing virtualization)
+- Accessibility violations (missing ARIA attributes, keyboard navigation, focus management)
+- State management issues (Zustand selector granularity, store dependency problems, stale closures)
+- Frontend-backend API contract drift (Tauri command type mismatches, event payload changes without frontend updates)
+- Platform boundary violations in frontend (direct @tauri-apps/api imports outside the adapter layer)
+- CSS/theme consistency issues (ThemeService misuse, component library pattern violations)
+
+## What you do NOT review
+
+- Business rule correctness (Business Logic reviewer handles this)
+- Non-React algorithm performance (Performance reviewer handles this)
+- Security vulnerabilities (Security reviewer handles this)
+- Backend architectural issues (Architecture reviewer handles this)
+- Code style or formatting
+
+## Tools
+
+Use only read-only investigation:
+
+- `GetFileDiff`
+- `Read`
+- `Grep`
+- `Glob`
+- `LS`
+- `Git` with read-only operations only
+
+Never modify files or git state.
+
+## Review standards
+
+- Confirm the issue before reporting. Show the specific code that has the problem.
+- For i18n issues: verify that a key exists in one locale but is missing in another.
+- For React performance issues: explain the concrete performance impact, not just the pattern violation.
+- For accessibility issues: reference WCAG guidelines where applicable.
+- If a pattern is unusual but functional, lower severity.
+
+## Efficiency rules
+
+- Start from the diff. Identify changed frontend files (.tsx, .ts, .scss, locale JSON).
+- For i18n: use Grep to find all `t('...')` calls in changed files, then check each key across all locale files.
+- For React performance: check changed components for common anti-patterns (inline functions in JSX, missing keys, missing memo).
+- For accessibility: check changed components for ARIA attributes, keyboard handlers, and focus management.
+- For API contracts: compare changed Tauri command types with corresponding TypeScript API clients.
+- When you have confirmed or dismissed a frontend concern, move on. Do not re-examine the same component from different angles.
+- Prefer a focused report with confirmed issues over a broad survey that risks timing out.
+- If the strategy is `quick`, only check i18n key completeness and direct platform boundary violations in changed frontend files.
+- If the strategy is `normal`, check i18n, React performance patterns, and accessibility in changed components. Verify frontend-backend API contract alignment.
+- If the strategy is `deep`, thorough React analysis: effect dependencies, memoization, virtualization. Full accessibility audit. State management pattern review. Cross-layer contract verification.
+
+## Output format
+
+Return markdown only, using this exact structure:
+
+## Reviewer
+Frontend Reviewer
+
+## Verdict
+clear | issues_found
+
+## Findings
+- `[severity=<critical|high|medium|low>] [certainty=<confirmed|likely>] file:line - title`
+  Why it matters: ...
+  Suggested fix: ...
+
+If there are no confirmed or likely issues, write exactly:
+
+- No frontend issues found.
+
+## Reviewer Summary
+2-4 sentences summarizing the frontend health of the change.
+
+If there is nothing meaningful to summarize, write exactly:
+
+- Nothing to summarize.

--- a/src/crates/core/src/agentic/agents/prompts/review_performance_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/review_performance_agent.md
@@ -11,11 +11,18 @@ Inspect the requested review target and find **real performance or scalability r
 - unnecessary repeated work
 - N+1 queries or repeated fetches
 - avoidable blocking calls on hot paths
-- expensive renders or recomputations
-- oversized diffs / payloads / serialization
+- expensive computations on hot paths
+- oversized payloads or serialization on data paths
 - unnecessary allocations or copies
 - algorithmic regressions that matter at realistic scale
 - optimization suggestions that are unsafe should be avoided rather than recommended
+
+## What you do NOT review
+
+- React rendering performance or component memoization (Frontend Reviewer)
+- Whether a data path respects layer boundaries (Architecture Reviewer)
+- Security vulnerabilities (Security Reviewer)
+- Business rule correctness (Business Logic Reviewer)
 
 ## Tools
 
@@ -39,7 +46,7 @@ Never modify files or git state.
 
 ## Efficiency rules
 
-- Start from the diff. Scan for known performance anti-patterns first: loops inside loops, repeated fetches, blocking calls on hot paths, unnecessary re-renders, large allocations.
+- Start from the diff. Scan for known performance anti-patterns first: loops inside loops, repeated fetches, blocking calls on hot paths, large allocations.
 - Only read surrounding code when a potential pattern in the diff needs confirmation of its context (e.g. is this on a hot path? is this called in a loop?).
 - Do not read entire modules to speculate about hypothetical scaling problems.
 - When you have confirmed or dismissed a performance concern, move on. Do not re-examine the same code from different angles.

--- a/src/crates/core/src/agentic/agents/prompts/review_quality_gate_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/review_quality_gate_agent.md
@@ -10,7 +10,7 @@ You will receive:
 
 - the original review target
 - the user focus, if any
-- the outputs from the Business Logic Reviewer, Performance Reviewer, and Security Reviewer
+- the outputs from the Business Logic Reviewer, Performance Reviewer, Security Reviewer, Architecture Reviewer, and Frontend Reviewer (if present)
 - if file splitting was used, outputs from **multiple same-role instances** (e.g. "Security Reviewer [group 1/3]", "Security Reviewer [group 2/3]")
 
 ## Mission
@@ -43,6 +43,15 @@ Be especially skeptical of:
 - If the team strategy was `quick`, focus on confirming or rejecting each finding efficiently. If a finding's evidence is thin, reject it rather than spending time verifying.
 - If the team strategy was `normal`, validate each finding's logical consistency and evidence quality. Spot-check code only when a claim needs verification.
 - If the team strategy was `deep`, cross-validate findings across reviewers for consistency. For each finding, verify the evidence supports the conclusion and the suggested fix is safe. Pay extra attention to findings that overlap across reviewers or across same-role instances from file splitting.
+
+## Cross-reviewer overlap handling
+
+When multiple reviewers report findings about the same code location:
+
+- **Architecture + Business Logic**: If Architecture Reviewer flags a layer violation and Business Logic Reviewer flags a call chain issue at the same location, the Architecture finding is likely the root cause. Keep both but note the architectural root cause may address both.
+- **Architecture + Security**: If Architecture flags a boundary violation and Security flags a trust-boundary issue, keep both but note the structural fix may resolve the security concern.
+- **Frontend + Performance**: If Frontend Reviewer flags a React rendering issue and Performance Reviewer flags a general performance issue at the same component, merge into a single finding with both perspectives.
+- **Frontend + Business Logic**: If Frontend flags a state management issue and Business Logic flags a data inconsistency, the Frontend finding provides the mechanism; keep both but link them.
 
 ## Tools
 

--- a/src/crates/core/src/agentic/agents/prompts/review_security_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/review_security_agent.md
@@ -13,9 +13,16 @@ Inspect the requested review target and find **real security issues** such as:
 - secret exposure
 - unsafe command or filesystem handling
 - path traversal
-- trust-boundary violations
-- insecure defaults
+- trust-boundary violations that create exploitable security risks
+- insecure defaults in authentication, authorization, or data handling
 - data leaks across sessions, users, or tenants
+
+## What you do NOT review
+
+- Structural layer violations without exploitable security impact (Architecture Reviewer)
+- Frontend-specific security concerns like XSS in React components (Frontend Reviewer)
+- Business rule correctness (Business Logic Reviewer)
+- Algorithm performance (Performance Reviewer)
 
 ## Tools
 

--- a/src/crates/core/src/agentic/agents/registry.rs
+++ b/src/crates/core/src/agentic/agents/registry.rs
@@ -1,15 +1,16 @@
 use super::{
-    Agent, AgenticMode, BusinessLogicReviewerAgent, ClawMode, CodeReviewAgent, ComputerUseMode,
-    CoworkMode, DebugMode, DeepResearchAgent, DeepReviewAgent, ExploreAgent, FileFinderAgent,
-    GenerateDocAgent, InitAgent, PerformanceReviewerAgent, PlanMode, ReviewFixerAgent,
-    ReviewJudgeAgent, SecurityReviewerAgent, TeamMode,
+    Agent, AgenticMode, ArchitectureReviewerAgent, BusinessLogicReviewerAgent, ClawMode,
+    CodeReviewAgent, ComputerUseMode, CoworkMode, DebugMode, DeepResearchAgent, DeepReviewAgent,
+    ExploreAgent, FileFinderAgent, FrontendReviewerAgent, GenerateDocAgent, InitAgent,
+    PerformanceReviewerAgent, PlanMode, ReviewFixerAgent, ReviewJudgeAgent, SecurityReviewerAgent,
+    TeamMode,
 };
 use crate::agentic::agents::custom_subagents::{
     CustomSubagent, CustomSubagentKind, CustomSubagentLoader,
 };
 use crate::agentic::deep_review_policy::{
-    REVIEWER_BUSINESS_LOGIC_AGENT_TYPE, REVIEWER_PERFORMANCE_AGENT_TYPE,
-    REVIEWER_SECURITY_AGENT_TYPE, REVIEW_JUDGE_AGENT_TYPE,
+    REVIEWER_ARCHITECTURE_AGENT_TYPE, REVIEWER_BUSINESS_LOGIC_AGENT_TYPE,
+    REVIEWER_PERFORMANCE_AGENT_TYPE, REVIEWER_SECURITY_AGENT_TYPE, REVIEW_JUDGE_AGENT_TYPE,
 };
 use crate::agentic::tools::{get_all_registered_tool_names, get_readonly_registered_tool_names};
 use crate::service::config::global::GlobalConfigManager;
@@ -146,6 +147,7 @@ fn is_review_agent_entry(entry: &AgentEntry) -> bool {
         REVIEWER_BUSINESS_LOGIC_AGENT_TYPE
             | REVIEWER_PERFORMANCE_AGENT_TYPE
             | REVIEWER_SECURITY_AGENT_TYPE
+            | REVIEWER_ARCHITECTURE_AGENT_TYPE
             | REVIEW_JUDGE_AGENT_TYPE
     )
 }
@@ -158,6 +160,8 @@ fn default_model_id_for_builtin_agent(agent_type: &str) -> &'static str {
         | "ReviewBusinessLogic"
         | "ReviewPerformance"
         | "ReviewSecurity"
+        | "ReviewArchitecture"
+        | "ReviewFrontend"
         | "ReviewJudge"
         | "ReviewFixer" => "fast",
         "Explore" | "FileFinder" | "CodeReview" | "GenerateDoc" | "Init" => "primary",
@@ -341,6 +345,8 @@ impl AgentRegistry {
             Arc::new(BusinessLogicReviewerAgent::new()),
             Arc::new(PerformanceReviewerAgent::new()),
             Arc::new(SecurityReviewerAgent::new()),
+            Arc::new(ArchitectureReviewerAgent::new()),
+            Arc::new(FrontendReviewerAgent::new()),
             Arc::new(ReviewJudgeAgent::new()),
             Arc::new(ReviewFixerAgent::new()),
         ];
@@ -1340,6 +1346,8 @@ mod tests {
             "ReviewBusinessLogic",
             "ReviewPerformance",
             "ReviewSecurity",
+            "ReviewArchitecture",
+            "ReviewFrontend",
             "ReviewJudge",
             "ReviewFixer",
         ] {

--- a/src/crates/core/src/agentic/agents/review_specialist_agents.rs
+++ b/src/crates/core/src/agentic/agents/review_specialist_agents.rs
@@ -1,5 +1,6 @@
 use crate::agentic::deep_review_policy::{
-    REVIEWER_BUSINESS_LOGIC_AGENT_TYPE, REVIEWER_PERFORMANCE_AGENT_TYPE,
+    REVIEWER_ARCHITECTURE_AGENT_TYPE, REVIEWER_BUSINESS_LOGIC_AGENT_TYPE,
+    REVIEWER_FRONTEND_AGENT_TYPE, REVIEWER_PERFORMANCE_AGENT_TYPE,
     REVIEWER_SECURITY_AGENT_TYPE, REVIEW_JUDGE_AGENT_TYPE,
 };
 use crate::define_readonly_subagent;
@@ -32,6 +33,24 @@ define_readonly_subagent!(
 );
 
 define_readonly_subagent!(
+    ArchitectureReviewerAgent,
+    REVIEWER_ARCHITECTURE_AGENT_TYPE,
+    "Architecture Reviewer",
+    r#"Independent read-only reviewer focused on structural and architectural issues such as module boundary violations, API contract design, abstraction integrity, dependency direction, and cross-cutting concern impact in the review target."#,
+    "review_architecture_agent",
+    &["Read", "Grep", "Glob", "LS", "GetFileDiff", "Git"]
+);
+
+define_readonly_subagent!(
+    FrontendReviewerAgent,
+    REVIEWER_FRONTEND_AGENT_TYPE,
+    "Frontend Reviewer",
+    r#"Independent read-only reviewer focused on frontend-specific issues such as i18n key synchronization, React performance patterns, accessibility, state management, frontend-backend API contract alignment, and platform boundary compliance in the review target."#,
+    "review_frontend_agent",
+    &["Read", "Grep", "Glob", "LS", "GetFileDiff", "Git"]
+);
+
+define_readonly_subagent!(
     ReviewJudgeAgent,
     REVIEW_JUDGE_AGENT_TYPE,
     "Review Quality Inspector",
@@ -43,8 +62,8 @@ define_readonly_subagent!(
 #[cfg(test)]
 mod tests {
     use super::{
-        BusinessLogicReviewerAgent, PerformanceReviewerAgent, ReviewJudgeAgent,
-        SecurityReviewerAgent,
+        ArchitectureReviewerAgent, BusinessLogicReviewerAgent, FrontendReviewerAgent,
+        PerformanceReviewerAgent, ReviewJudgeAgent, SecurityReviewerAgent,
     };
     use crate::agentic::agents::{Agent, RequestContextPolicy};
 
@@ -54,6 +73,8 @@ mod tests {
             Box::new(BusinessLogicReviewerAgent::new()),
             Box::new(PerformanceReviewerAgent::new()),
             Box::new(SecurityReviewerAgent::new()),
+            Box::new(ArchitectureReviewerAgent::new()),
+            Box::new(FrontendReviewerAgent::new()),
             Box::new(ReviewJudgeAgent::new()),
         ];
 

--- a/src/crates/core/src/agentic/deep_review_policy.rs
+++ b/src/crates/core/src/agentic/deep_review_policy.rs
@@ -13,10 +13,13 @@ pub const REVIEW_FIXER_AGENT_TYPE: &str = "ReviewFixer";
 pub const REVIEWER_BUSINESS_LOGIC_AGENT_TYPE: &str = "ReviewBusinessLogic";
 pub const REVIEWER_PERFORMANCE_AGENT_TYPE: &str = "ReviewPerformance";
 pub const REVIEWER_SECURITY_AGENT_TYPE: &str = "ReviewSecurity";
-pub const CORE_REVIEWER_AGENT_TYPES: [&str; 3] = [
+pub const REVIEWER_ARCHITECTURE_AGENT_TYPE: &str = "ReviewArchitecture";
+pub const REVIEWER_FRONTEND_AGENT_TYPE: &str = "ReviewFrontend";
+pub const CORE_REVIEWER_AGENT_TYPES: [&str; 4] = [
     REVIEWER_BUSINESS_LOGIC_AGENT_TYPE,
     REVIEWER_PERFORMANCE_AGENT_TYPE,
     REVIEWER_SECURITY_AGENT_TYPE,
+    REVIEWER_ARCHITECTURE_AGENT_TYPE,
 ];
 const DEFAULT_REVIEW_TEAM_CONFIG_PATH: &str = "ai.review_teams.default";
 
@@ -712,13 +715,13 @@ mod tests {
         })));
         let tracker = DeepReviewBudgetTracker::default();
 
-        // Default policy: 3 core reviewers * 2 max instances = 6 reviewer calls allowed
-        for _ in 0..6 {
+        // Default policy: 4 core reviewers * 2 max instances = 8 reviewer calls allowed
+        for _ in 0..8 {
             tracker
                 .record_task("turn-1", &policy, DeepReviewSubagentRole::Reviewer)
                 .unwrap();
         }
-        // 7th reviewer call should be rejected
+        // 9th reviewer call should be rejected
         assert!(tracker
             .record_task("turn-1", &policy, DeepReviewSubagentRole::Reviewer)
             .is_err());

--- a/src/web-ui/src/app/scenes/agents/AgentsScene.tsx
+++ b/src/web-ui/src/app/scenes/agents/AgentsScene.tsx
@@ -540,7 +540,7 @@ const AgentsHomeView: React.FC = () => {
                 })}
                 subtitle={t('reviewTeams.default.summary', {
                   defaultValue:
-                    'A deep-review code team with locked logic, performance, security, and quality-gate roles.',
+                    'A deep-review code team with locked logic, performance, security, architecture, and quality-gate roles.',
                 })}
                 localOnlyLabel={t('reviewTeams.detail.localOnly', {
                   defaultValue: 'Code review',

--- a/src/web-ui/src/app/scenes/agents/agentVisibility.ts
+++ b/src/web-ui/src/app/scenes/agents/agentVisibility.ts
@@ -5,6 +5,8 @@ export const HIDDEN_AGENT_IDS = new Set<string>([
   'ReviewBusinessLogic',
   'ReviewPerformance',
   'ReviewSecurity',
+  'ReviewArchitecture',
+  'ReviewFrontend',
   'ReviewJudge',
 ]);
 

--- a/src/web-ui/src/app/scenes/agents/components/AgentTeamCard.scss
+++ b/src/web-ui/src/app/scenes/agents/components/AgentTeamCard.scss
@@ -87,7 +87,7 @@
   &__body {
     display: flex;
     flex-direction: column;
-    gap: $size-gap-2;
+    justify-content: center;
     flex: 1;
     min-height: 0;
     padding: $size-gap-2 $size-gap-3;
@@ -96,49 +96,55 @@
     z-index: 1;
   }
 
-  &__meta {
+  &__metrics {
     display: grid;
-    gap: 4px;
+    grid-template-columns: 1.35fr 1fr 1fr;
+    gap: 8px;
+    min-width: 0;
   }
 
-  &__meta-item {
+  &__metric {
+    min-width: 0;
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 6px;
-    font-size: var(--font-size-xs);
-    line-height: 1.5;
-    color: var(--color-text-muted);
-    min-width: 0;
-    white-space: nowrap;
+    min-height: 42px;
+    padding: 0 9px;
+    border-radius: 12px;
+    border: 1px solid color-mix(in srgb, var(--team-card-accent) 16%, var(--border-subtle));
+    background:
+      linear-gradient(180deg, color-mix(in srgb, var(--team-card-accent) 8%, transparent), transparent),
+      color-mix(in srgb, var(--element-bg-soft) 86%, transparent);
+    color: var(--color-text-secondary);
+    font-size: 11px;
+    line-height: 1.2;
     overflow: hidden;
-    text-overflow: ellipsis;
 
     svg {
       flex-shrink: 0;
+      color: color-mix(in srgb, var(--team-card-accent) 74%, var(--color-text-secondary));
+    }
+
+    span,
+    strong {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    strong {
+      color: var(--color-text-primary);
+      font-weight: $font-weight-semibold;
     }
   }
 
-  &__chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-  }
-
-  &__chip {
-    display: inline-flex;
-    align-items: center;
-    min-height: 22px;
-    padding: 0 8px;
-    border-radius: 999px;
-    border: 1px solid color-mix(in srgb, var(--team-card-accent) 20%, var(--border-subtle));
-    background: color-mix(in srgb, var(--element-bg-soft) 84%, transparent);
-    color: var(--color-text-secondary);
-    font-size: 10px;
-    line-height: 1.4;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  &__metric--primary {
+    justify-content: flex-start;
+    background:
+      radial-gradient(circle at top left, color-mix(in srgb, var(--team-card-accent) 22%, transparent), transparent 62%),
+      color-mix(in srgb, var(--team-card-accent) 9%, var(--element-bg-soft));
   }
 
   &__footer {

--- a/src/web-ui/src/app/scenes/agents/components/AgentTeamCard.tsx
+++ b/src/web-ui/src/app/scenes/agents/components/AgentTeamCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ShieldCheck, Users } from 'lucide-react';
+import { BadgeCheck, GitBranch, ShieldCheck, Users } from 'lucide-react';
 import { Badge } from '@/component-library';
 import './AgentTeamCard.scss';
 
@@ -57,19 +57,19 @@ const AgentTeamCard: React.FC<AgentTeamCardProps> = ({
       </div>
 
       <div className="agent-team-card__body">
-        <div className="agent-team-card__meta">
-          <span className="agent-team-card__meta-item">
-            <Users size={12} />
-            {membersLabel}
+        <div className="agent-team-card__metrics" aria-label={memberNames.join(', ')}>
+          <span className="agent-team-card__metric agent-team-card__metric--primary">
+            <Users size={13} />
+            <strong>{membersLabel}</strong>
           </span>
-        </div>
-
-        <div className="agent-team-card__chips">
-          {memberNames.map((memberName) => (
-            <span key={memberName} className="agent-team-card__chip">
-              {memberName}
-            </span>
-          ))}
+          <span className="agent-team-card__metric">
+            <GitBranch size={13} />
+            <span>{localOnlyLabel}</span>
+          </span>
+          <span className="agent-team-card__metric">
+            <BadgeCheck size={13} />
+            <span>{qualityGateLabel}</span>
+          </span>
         </div>
       </div>
 

--- a/src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.tsx
+++ b/src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.tsx
@@ -2,9 +2,11 @@ import React, { Component, useCallback, useEffect, useMemo, useState } from 'rea
 import {
   ArrowLeft,
   BadgeCheck,
+  Blocks,
   Bot,
   Gauge,
   GitBranch,
+  Layout,
   Lock,
   Settings,
   Shield,
@@ -50,6 +52,10 @@ function getMemberIcon(member: ReviewTeamMember) {
       return Gauge;
     case 'security':
       return Shield;
+    case 'architecture':
+      return Blocks;
+    case 'frontend':
+      return Layout;
     case 'judge':
       return BadgeCheck;
     default:

--- a/src/web-ui/src/flow_chat/components/TaskDetailPanel/TaskDetailPanel.tsx
+++ b/src/web-ui/src/flow_chat/components/TaskDetailPanel/TaskDetailPanel.tsx
@@ -514,7 +514,11 @@ export const TaskDetailPanel: React.FC<TaskDetailPanelProps> = ({ data }) => {
         </span>
         {taskInput?.agentType && (
           <span className="task-detail-panel__header-badge">
-            {taskInput.agentType}
+            {rc
+              ? tAgents(`reviewTeams.members.${rc.definitionKey}.funName`, {
+                  defaultValue: rc.roleName,
+                })
+              : taskInput.agentType}
           </span>
         )}
         <ToolTimeoutIndicator

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
@@ -215,15 +215,22 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
     const desc =
       (taskInput?.description || '').trim() || t('toolCards.taskDetailPanel.untitled');
     const raw = taskInput?.agentType;
-    const agentTypeLabel =
-      raw && raw !== 'Not provided'
-        ? raw
-        : t('toolCards.taskTool.defaultAgentKind');
+    let agentTypeLabel: string;
+    if (raw && raw !== 'Not provided') {
+      const rc = taskInput?.reviewerContext;
+      agentTypeLabel = rc
+        ? tAgents(`reviewTeams.members.${rc.definitionKey}.funName`, {
+            defaultValue: rc.roleName,
+          })
+        : raw;
+    } else {
+      agentTypeLabel = t('toolCards.taskTool.defaultAgentKind');
+    }
     return t('toolCards.taskTool.headerLine', {
       agentType: agentTypeLabel,
       description: desc,
     });
-  }, [taskInput, t]);
+  }, [taskInput, t, tAgents]);
 
   const openTaskDetailPanel = useCallback(
     (e: React.MouseEvent) => {

--- a/src/web-ui/src/flow_chat/utils/codeReviewRemediation.test.ts
+++ b/src/web-ui/src/flow_chat/utils/codeReviewRemediation.test.ts
@@ -116,7 +116,7 @@ describe('buildSelectedReviewRemediationPrompt', () => {
     });
 
     expect(prompt).toContain('follow-up deep review');
-    expect(prompt).toContain('dispatching the review team');
+    expect(prompt).toContain('dispatching all enabled review team reviewers');
   });
 
   it('builds prompt with standard review mode', () => {

--- a/src/web-ui/src/flow_chat/utils/codeReviewRemediation.ts
+++ b/src/web-ui/src/flow_chat/utils/codeReviewRemediation.ts
@@ -211,7 +211,7 @@ export function buildSelectedReviewRemediationPrompt(params: {
   const isDeepReview = params.reviewMode === 'deep';
   const reviewLabel = isDeepReview ? 'Deep Review' : 'Code Review';
   const rerunInstruction = isDeepReview
-    ? 'After implementing fixes, run the most relevant verification. Then launch a full follow-up deep review of the fix diff by dispatching the review team (Business Logic, Performance, Security reviewers in parallel, followed by ReviewJudge). Submit the follow-up review result via submit_code_review.'
+    ? 'After implementing fixes, run the most relevant verification. Then launch a full follow-up deep review of the fix diff by dispatching all enabled review team reviewers in parallel, followed by ReviewJudge. Submit the follow-up review result via submit_code_review.'
     : 'After implementing fixes, run the most relevant verification. Then submit a follow-up standard code review of the fix diff via submit_code_review.';
 
   const lines: string[] = [

--- a/src/web-ui/src/locales/en-US/scenes/agents.json
+++ b/src/web-ui/src/locales/en-US/scenes/agents.json
@@ -150,7 +150,7 @@
   "reviewTeams": {
     "default": {
       "name": "Code Review Team",
-      "summary": "A deep-review code team with locked logic, performance, security, and quality-gate roles.",
+      "summary": "A deep-review code team with locked logic, performance, security, architecture, and quality-gate roles.",
       "members": "{{count}} members"
     },
     "detail": {
@@ -169,7 +169,7 @@
       "localOnly": "Code review",
       "localOnlyDescription": "Runs inside BitFun as read-only Sub-Agents and reports back into this review thread.",
       "parallelLabel": "Parallel reviewers",
-      "parallelDescription": "Logic, performance, security, and extra reviewers work side by side before the judge validates findings.",
+      "parallelDescription": "Logic, performance, security, architecture, and extra reviewers work side by side before the judge validates findings.",
       "warningLabel": "Heavier review",
       "warning": "Use for higher-risk changes; it can take longer and use more tokens than a standard review.",
       "qualityGate": "Quality gate",
@@ -204,7 +204,7 @@
       "remove": "Remove member",
       "removeDescription": "Remove this extra Sub-Agent from the code review team. Core roles cannot be removed.",
       "addTitle": "Add Extra Sub-Agent",
-      "addDescription": "Bring another read-only Sub-Agent into the deep code review team. The four core roles always remain locked in place.",
+      "addDescription": "Bring another read-only Sub-Agent into the deep code review team. The core roles always remain locked in place.",
       "addLabel": "Candidate",
       "addHint": "Only read-only Sub-Agents can join the initial review pass; the quality inspector checks every extra reviewer before final reporting.",
       "addPlaceholder": "Select a Sub-Agent",
@@ -288,6 +288,26 @@
           "Filter out false positives and directionally-wrong optimization advice by examining reviewer reasoning.",
           "Spot-check specific code locations only when a reviewer's claim needs verification.",
           "Ensure every surviving issue has an actionable fix or follow-up plan."
+        ]
+      },
+      "architecture": {
+        "funName": "Architecture Reviewer",
+        "role": "Architecture Reviewer",
+        "description": "A structural watchdog that checks module boundaries, dependency direction, API contract design, and abstraction integrity.",
+        "responsibilities": [
+          "Detect layer boundary violations and wrong-direction imports.",
+          "Verify API contracts, tool schemas, and transport messages stay consistent.",
+          "Ensure platform-agnostic code does not leak platform-specific details."
+        ]
+      },
+      "frontend": {
+        "funName": "Frontend Reviewer",
+        "role": "Frontend Reviewer",
+        "description": "A UI specialist that checks i18n synchronization, React performance patterns, accessibility, and frontend-backend contract alignment.",
+        "responsibilities": [
+          "Verify i18n key completeness across all locales.",
+          "Check React performance patterns (memoization, virtualization, effect dependencies).",
+          "Flag accessibility violations and frontend-backend API contract drift."
         ]
       }
     },

--- a/src/web-ui/src/locales/en-US/settings/review.json
+++ b/src/web-ui/src/locales/en-US/settings/review.json
@@ -70,6 +70,14 @@
     "judge": {
       "name": "Review Quality Inspector",
       "role": "Review Quality Inspector"
+    },
+    "architecture": {
+      "name": "Architecture Reviewer",
+      "role": "Architecture Reviewer"
+    },
+    "frontend": {
+      "name": "Frontend Reviewer",
+      "role": "Frontend Reviewer"
     }
   },
   "extra": {

--- a/src/web-ui/src/locales/zh-CN/scenes/agents.json
+++ b/src/web-ui/src/locales/zh-CN/scenes/agents.json
@@ -150,7 +150,7 @@
   "reviewTeams": {
     "default": {
       "name": "代码审核团队",
-      "summary": "专业深度代码审核团队，内置业务逻辑、性能、安全和质检四个固定角色。",
+      "summary": "专业深度代码审核团队，内置业务逻辑、性能、安全、架构和质检固定角色。",
       "members": "{{count}} 名成员"
     },
     "detail": {
@@ -169,7 +169,7 @@
       "localOnly": "代码审核",
       "localOnlyDescription": "在 BitFun 内以只读 Sub-Agent 运行，并把结果回传到当前审核线程。",
       "parallelLabel": "并行审核",
-      "parallelDescription": "逻辑、性能、安全和额外审核员会并行工作，再由质检员验证结果。",
+      "parallelDescription": "逻辑、性能、安全、架构和额外审核员会并行工作，再由质检员验证结果。",
       "warningLabel": "审核更重",
       "warning": "建议用于风险更高的改动；它可能比普通审核耗时更久并消耗更多 token。",
       "qualityGate": "质检复核",
@@ -204,7 +204,7 @@
       "remove": "移除成员",
       "removeDescription": "将这个额外 Sub-Agent 从代码审核团队中移除。固定角色不可删除。",
       "addTitle": "添加额外 Sub-Agent",
-      "addDescription": "把其他只读 Sub-Agent 加入深度代码审核团队，四个固定角色会始终保留。",
+      "addDescription": "把其他只读 Sub-Agent 加入深度代码审核团队，固定角色会始终保留。",
       "addLabel": "候选成员",
       "addHint": "只有只读 Sub-Agent 可以加入初始审核流程；每个额外审核员的结果仍会由质检员统一复核。",
       "addPlaceholder": "选择一个 Sub-Agent",
@@ -288,6 +288,26 @@
           "通过审核审核员的推理过程，过滤误报以及方向错误的优化建议。",
           "仅在审核员的声明需要验证时，对特定代码位置进行抽查。",
           "确保每条保留的问题都带有明确修复方案或后续计划。"
+        ]
+      },
+      "architecture": {
+        "funName": "架构审核员",
+        "role": "架构审核员",
+        "description": "负责检查模块边界、依赖方向、API 契约设计和抽象完整性的结构守护者。",
+        "responsibilities": [
+          "检测层级边界违规和方向错误的导入。",
+          "验证 API 契约、工具模式和传输消息的一致性。",
+          "确保平台无关代码不会泄露平台特定细节。"
+        ]
+      },
+      "frontend": {
+        "funName": "前端审核员",
+        "role": "前端审核员",
+        "description": "检查国际化同步、React 性能模式、无障碍访问和前后端契约一致性的 UI 专家。",
+        "responsibilities": [
+          "验证所有语言区域的国际化键完整性。",
+          "检查 React 性能模式（记忆化、虚拟化、effect 依赖）。",
+          "标记无障碍访问违规和前后端 API 契约偏差。"
         ]
       }
     },

--- a/src/web-ui/src/locales/zh-CN/settings/review.json
+++ b/src/web-ui/src/locales/zh-CN/settings/review.json
@@ -70,6 +70,14 @@
     "judge": {
       "name": "审核质量检查员",
       "role": "审核质量检查员"
+    },
+    "architecture": {
+      "name": "架构审核员",
+      "role": "架构审核员"
+    },
+    "frontend": {
+      "name": "前端审核员",
+      "role": "前端审核员"
     }
   },
   "extra": {

--- a/src/web-ui/src/locales/zh-TW/scenes/agents.json
+++ b/src/web-ui/src/locales/zh-TW/scenes/agents.json
@@ -150,7 +150,7 @@
   "reviewTeams": {
     "default": {
       "name": "程式碼審核團隊",
-      "summary": "專業深度程式碼審核團隊，內置業務邏輯、性能、安全與質檢四個固定角色。",
+      "summary": "專業深度程式碼審核團隊，內置業務邏輯、性能、安全、架構與質檢固定角色。",
       "members": "{{count}} 名成員"
     },
     "detail": {
@@ -169,7 +169,7 @@
       "localOnly": "程式碼審核",
       "localOnlyDescription": "在 BitFun 內以唯讀 Sub-Agent 運行，並把結果回傳到當前審核線程。",
       "parallelLabel": "並行審核",
-      "parallelDescription": "邏輯、性能、安全和額外審核員會並行工作，再由質檢員驗證結果。",
+      "parallelDescription": "邏輯、性能、安全、架構和額外審核員會並行工作，再由質檢員驗證結果。",
       "warningLabel": "審核更重",
       "warning": "建議用於風險更高的改動；它可能比普通審核耗時更久並消耗更多 token。",
       "qualityGate": "質檢覆核",
@@ -204,7 +204,7 @@
       "remove": "移除成員",
       "removeDescription": "將這個額外 Sub-Agent 從程式碼審核團隊中移除。固定角色不可刪除。",
       "addTitle": "添加額外 Sub-Agent",
-      "addDescription": "把其他唯讀 Sub-Agent 加入深度程式碼審核團隊，四個固定角色會始終保留。",
+      "addDescription": "把其他唯讀 Sub-Agent 加入深度程式碼審核團隊，固定角色會始終保留。",
       "addLabel": "候選成員",
       "addHint": "只有唯讀 Sub-Agent 可以加入初始審核流程；每個額外審核員的結果仍會由質檢員統一覆核。",
       "addPlaceholder": "選擇一個 Sub-Agent",
@@ -288,6 +288,26 @@
           "透過審核審核員的推理過程，過濾誤報以及方向錯誤的優化建議。",
           "僅在審核員的聲明需要驗證時，對特定程式碼位置進行抽查。",
           "確保每條保留的問題都帶有明確修復方案或後續計劃。"
+        ]
+      },
+      "architecture": {
+        "funName": "架構審核員",
+        "role": "架構審核員",
+        "description": "負責檢查模組邊界、依賴方向、API 契約設計和抽象完整性的結構守護者。",
+        "responsibilities": [
+          "檢測層級邊界違規和方向錯誤的匯入。",
+          "驗證 API 契約、工具模式和傳輸訊息的一致性。",
+          "確保平台無關程式碼不會洩露平台特定細節。"
+        ]
+      },
+      "frontend": {
+        "funName": "前端審核員",
+        "role": "前端審核員",
+        "description": "檢查國際化同步、React 效能模式、無障礙訪問和前後端契約一致性的 UI 專家。",
+        "responsibilities": [
+          "驗證所有語言區域的國際化鍵完整性。",
+          "檢查 React 效能模式（記憶化、虛擬化、effect 依賴）。",
+          "標記無障礙訪問違規和前後端 API 契約偏差。"
         ]
       }
     },

--- a/src/web-ui/src/locales/zh-TW/settings/review.json
+++ b/src/web-ui/src/locales/zh-TW/settings/review.json
@@ -70,6 +70,14 @@
     "judge": {
       "name": "審核品質檢查員",
       "role": "審核品質檢查員"
+    },
+    "architecture": {
+      "name": "架構審核員",
+      "role": "架構審核員"
+    },
+    "frontend": {
+      "name": "前端審核員",
+      "role": "前端審核員"
     }
   },
   "extra": {

--- a/src/web-ui/src/shared/services/reviewTeamService.test.ts
+++ b/src/web-ui/src/shared/services/reviewTeamService.test.ts
@@ -74,6 +74,8 @@ describe('reviewTeamService', () => {
     subagent('ReviewBusinessLogic', enabled),
     subagent('ReviewPerformance', enabled),
     subagent('ReviewSecurity', enabled),
+    subagent('ReviewArchitecture', enabled),
+    subagent('ReviewFrontend', enabled),
     subagent('ReviewJudge', enabled),
   ];
 
@@ -144,7 +146,7 @@ describe('reviewTeamService', () => {
 
     await prepareDefaultReviewTeamForLaunch('D:/workspace/project-a');
 
-    expect(SubagentAPI.updateSubagentConfig).toHaveBeenCalledTimes(4);
+    expect(SubagentAPI.updateSubagentConfig).toHaveBeenCalledTimes(6);
     expect(SubagentAPI.updateSubagentConfig).toHaveBeenCalledWith({
       subagentId: 'ReviewBusinessLogic',
       enabled: true,
@@ -157,6 +159,16 @@ describe('reviewTeamService', () => {
     });
     expect(SubagentAPI.updateSubagentConfig).toHaveBeenCalledWith({
       subagentId: 'ReviewSecurity',
+      enabled: true,
+      workspacePath: 'D:/workspace/project-a',
+    });
+    expect(SubagentAPI.updateSubagentConfig).toHaveBeenCalledWith({
+      subagentId: 'ReviewArchitecture',
+      enabled: true,
+      workspacePath: 'D:/workspace/project-a',
+    });
+    expect(SubagentAPI.updateSubagentConfig).toHaveBeenCalledWith({
+      subagentId: 'ReviewFrontend',
       enabled: true,
       workspacePath: 'D:/workspace/project-a',
     });
@@ -187,8 +199,8 @@ describe('reviewTeamService', () => {
 
     expect(promptBlock).toContain('subagent_type: ExtraEnabled');
     expect(promptBlock).not.toContain('subagent_type: ExtraDisabled');
-    expect(promptBlock).toContain('Always run the three locked reviewer roles');
-    expect(promptBlock).not.toContain('Always run the four locked core reviewers');
+    expect(promptBlock).toContain('Always run the four locked core reviewer roles');
+    expect(promptBlock).not.toContain('Always run the three locked reviewer roles');
   });
 
   it('requires extra members to be explicitly marked for review and readonly', () => {
@@ -241,6 +253,8 @@ describe('reviewTeamService', () => {
       'ReviewBusinessLogic',
       'ReviewPerformance',
       'ReviewSecurity',
+      'ReviewArchitecture',
+      'ReviewFrontend',
     ]);
     expect(manifest.qualityGateReviewer?.subagentId).toBe('ReviewJudge');
     expect(manifest.enabledExtraReviewers.map((member) => member.subagentId)).toEqual([
@@ -296,6 +310,20 @@ describe('reviewTeamService', () => {
         model: 'primary',
         defaultModelSlot: 'primary',
         strategyDirective: REVIEW_STRATEGY_DEFINITIONS.deep.roleDirectives.ReviewSecurity,
+      }),
+      expect.objectContaining({
+        subagentId: 'ReviewArchitecture',
+        strategyLevel: 'quick',
+        strategySource: 'team',
+        defaultModelSlot: 'fast',
+        strategyDirective: REVIEW_STRATEGY_DEFINITIONS.quick.roleDirectives.ReviewArchitecture,
+      }),
+      expect.objectContaining({
+        subagentId: 'ReviewFrontend',
+        strategyLevel: 'quick',
+        strategySource: 'team',
+        defaultModelSlot: 'fast',
+        strategyDirective: REVIEW_STRATEGY_DEFINITIONS.quick.roleDirectives.ReviewFrontend,
       }),
     ]);
     expect(manifest.enabledExtraReviewers[0]).toMatchObject({

--- a/src/web-ui/src/shared/services/reviewTeamService.ts
+++ b/src/web-ui/src/shared/services/reviewTeamService.ts
@@ -30,6 +30,8 @@ export type ReviewRoleDirectiveKey =
   | 'ReviewBusinessLogic'
   | 'ReviewPerformance'
   | 'ReviewSecurity'
+  | 'ReviewArchitecture'
+  | 'ReviewFrontend'
   | 'ReviewJudge';
 
 export interface ReviewStrategyProfile {
@@ -80,6 +82,10 @@ export const REVIEW_STRATEGY_PROFILES: Record<
         'Scan the diff for known anti-patterns only: nested loops, repeated fetches, blocking calls on hot paths, unnecessary re-renders. Do not trace call chains or estimate impact beyond what the diff shows.',
       ReviewSecurity:
         'Scan the diff for direct security risks only: injection, secret exposure, unsafe commands, missing auth. Do not trace data flows beyond one hop.',
+      ReviewArchitecture:
+        'Only check imports directly changed by the diff. Flag violations of documented layer boundaries.',
+      ReviewFrontend:
+        'Only check i18n key completeness and direct platform boundary violations in changed frontend files.',
       ReviewJudge:
         'This was a quick review. Focus on confirming or rejecting each finding efficiently. If a finding\'s evidence is thin, reject it rather than spending time verifying.',
     },
@@ -101,6 +107,10 @@ export const REVIEW_STRATEGY_PROFILES: Record<
         'Inspect the diff for anti-patterns, then read surrounding code to confirm impact on hot paths. Report only issues likely to matter at realistic scale.',
       ReviewSecurity:
         'Trace each changed input path from entry point to usage. Check trust boundaries, auth assumptions, and data sanitization. Report only issues with a realistic threat narrative.',
+      ReviewArchitecture:
+        "Check the diff's imports plus one level of dependency direction. Verify API contract consistency.",
+      ReviewFrontend:
+        'Check i18n, React performance patterns, and accessibility in changed components. Verify frontend-backend API contract alignment.',
       ReviewJudge:
         'Validate each finding\'s logical consistency and evidence quality. Spot-check code only when a claim needs verification.',
     },
@@ -122,6 +132,10 @@ export const REVIEW_STRATEGY_PROFILES: Record<
         'In addition to the normal pass, check for latent scaling risks — data structures that degrade at volume, or algorithms that are correct but unnecessarily expensive. Only report if you can estimate the impact. Do not speculate about edge cases or failure modes unrelated to performance.',
       ReviewSecurity:
         'In addition to the normal pass, trace data flows across trust boundaries end-to-end. Check for privilege escalation chains, indirect injection vectors, and failure modes that expose sensitive data. Report only issues with a complete threat narrative.',
+      ReviewArchitecture:
+        'Map the full dependency graph for changed modules. Check for structural anti-patterns, circular dependencies, and cross-cutting concerns.',
+      ReviewFrontend:
+        'Thorough React analysis: effect dependencies, memoization, virtualization. Full accessibility audit. State management pattern review. Cross-layer contract verification.',
       ReviewJudge:
         'This was a deep review with potentially complex findings. Cross-validate findings across reviewers for consistency. For each finding, verify the evidence supports the conclusion and the suggested fix is safe. Pay extra attention to overlapping findings across reviewers or same-role instances.',
     },
@@ -141,6 +155,8 @@ export type ReviewTeamCoreRoleKey =
   | 'businessLogic'
   | 'performance'
   | 'security'
+  | 'architecture'
+  | 'frontend'
   | 'judge';
 
 export interface ReviewTeamCoreRoleDefinition {
@@ -151,6 +167,8 @@ export interface ReviewTeamCoreRoleDefinition {
   description: string;
   responsibilities: string[];
   accentColor: string;
+  /** If true, this reviewer is only included when the change contains relevant files. */
+  conditional?: boolean;
 }
 
 export interface ReviewTeamStoredConfig {
@@ -288,6 +306,35 @@ export const DEFAULT_REVIEW_TEAM_CORE_ROLES: ReviewTeamCoreRoleDefinition[] = [
       'Highlight concrete fixes that reduce risk without broad rewrites.',
     ],
     accentColor: '#dc2626',
+  },
+  {
+    key: 'architecture',
+    subagentId: 'ReviewArchitecture',
+    funName: 'Architecture Reviewer',
+    roleName: 'Architecture Reviewer',
+    description:
+      'A structural watchdog that checks module boundaries, dependency direction, API contract design, and abstraction integrity.',
+    responsibilities: [
+      'Detect layer boundary violations and wrong-direction imports.',
+      'Verify API contracts, tool schemas, and transport messages stay consistent.',
+      'Ensure platform-agnostic code does not leak platform-specific details.',
+    ],
+    accentColor: '#0891b2',
+  },
+  {
+    key: 'frontend',
+    subagentId: 'ReviewFrontend',
+    funName: 'Frontend Reviewer',
+    roleName: 'Frontend Reviewer',
+    description:
+      'A UI specialist that checks i18n synchronization, React performance patterns, accessibility, and frontend-backend contract alignment.',
+    responsibilities: [
+      'Verify i18n key completeness across all locales.',
+      'Check React performance patterns (memoization, virtualization, effect dependencies).',
+      'Flag accessibility violations and frontend-backend API contract drift.',
+    ],
+    accentColor: '#059669',
+    conditional: true,
   },
   {
     key: 'judge',
@@ -775,7 +822,7 @@ export function resolveDefaultReviewTeam(
     id: DEFAULT_REVIEW_TEAM_ID,
     name: 'Code Review Team',
     description:
-      'A multi-reviewer team for deep code review with mandatory logic, performance, security, and quality-gate roles.',
+      'A multi-reviewer team for deep code review with mandatory logic, performance, security, architecture, conditional frontend, and quality-gate roles.',
     warning:
       'Deep review may take longer and usually consumes more tokens than a standard review.',
     strategyLevel: storedConfig.strategy_level,
@@ -1034,9 +1081,10 @@ export function buildReviewTeamPromptBlock(
     'Execution policy:',
     executionPolicy,
     'Team execution rules:',
-    '- Always run the three locked reviewer roles first: ReviewBusinessLogic, ReviewPerformance, and ReviewSecurity.',
+    '- Always run the four locked core reviewer roles first: ReviewBusinessLogic, ReviewPerformance, ReviewSecurity, and ReviewArchitecture.',
     '- Run ReviewJudge only after the reviewer batch finishes, as the quality-gate pass.',
-    '- If extra reviewers are configured and enabled, run them in parallel with the three locked reviewers whenever possible.',
+    '- If the Frontend Reviewer is enabled, run it in parallel with the locked reviewers whenever the change contains frontend files (src/web-ui/, .tsx, .scss, .css, locales/).',
+    '- If other extra reviewers are configured and enabled, run them in parallel with the locked reviewers whenever possible.',
     '- When a configured member entry provides model_id, pass model_id with that value to the matching Task call.',
     '- If reviewer_timeout_seconds is greater than 0, pass timeout_seconds with that value to every reviewer Task call.',
     '- If judge_timeout_seconds is greater than 0, pass timeout_seconds with that value to the ReviewJudge Task call.',


### PR DESCRIPTION
## Summary

This PR expands the Deep Review team with two new specialized reviewer roles and updates the related orchestration, UI, localization, and follow-up review flows.

### New reviewer roles

- Add **Architecture Reviewer** (`ReviewArchitecture`)
  - Focuses on module boundaries, dependency direction, API contracts, abstraction integrity, and structural consistency.
- Add **Frontend Reviewer** (`ReviewFrontend`)
  - Focuses on i18n synchronization, React performance patterns, accessibility, frontend state management, frontend/backend contract drift, and frontend platform-boundary issues.

### Deep Review orchestration updates

- Register the new reviewers in the Rust agent registry and review-specialist agent definitions.
- Add dedicated prompt files for both new reviewers.
- Update the Deep Review orchestrator prompt to include Architecture and Frontend reviewer strategy guidance.
- Update existing reviewer prompts to clarify responsibility boundaries:
  - Business Logic no longer owns architecture or React/UI-specific concerns.
  - Performance no longer owns React render optimization.
  - Security focuses on exploitable security risks rather than structural boundary issues.
- Update the Judge prompt to handle overlapping findings across reviewer roles.

### Review team UI and configuration

- Extend review team metadata and strategy directives for the new roles.
- Update review team tests for the expanded reviewer set.
- Hide the new internal reviewer agents from the general Agents overview.
- Improve the Code Review Team card layout to avoid clipped reviewer tags and provide a cleaner summary-style presentation.
- Add role-specific icons for Architecture and Frontend reviewers on the Review Team page.

### Localization

- Add Architecture and Frontend reviewer translations for:
  - `en-US`
  - `zh-CN`
  - `zh-TW`
- Add missing Settings > Review translations for the new reviewer names.
- Localize review subagent display names in task tool card headers and task detail panels by using `reviewTeams.members.*.funName` instead of raw subagent type identifiers such as `ReviewBusinessLogic`.

### Remediation flow

- Update deep-review remediation follow-up instructions to dispatch all enabled review team reviewers instead of hardcoding only Business Logic, Performance, and Security reviewers.

## Testing

- Updated `reviewTeamService` tests for the expanded reviewer set.
- Updated remediation prompt tests for the new follow-up review wording.