### PR TITLE
fix(deep-review): subagent ignore-timeout, session recovery, UI polish & frontend reviewer generalization

### DIFF
--- a/src/apps/cli/src/agent/core_adapter.rs
+++ b/src/apps/cli/src/agent/core_adapter.rs
@@ -199,6 +199,7 @@ impl Agent for CoreAgentAdapter {
                             tool_id,
                             tool_name,
                             params,
+                            timeout_seconds: _,
                         } => {
                             tool_map.entry(tool_id.clone()).or_insert_with(|| ToolCall {
                                 tool_id: Some(tool_id.clone()),

--- a/src/crates/core/src/agentic/agents/prompts/deep_review_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/deep_review_agent.md
@@ -151,8 +151,8 @@ Role-specific strategy amplification (append to the reviewer Task prompt when th
 - **ReviewArchitecture** + `normal`: "Check the diff's imports plus one level of dependency direction. Verify API contract consistency."
 - **ReviewArchitecture** + `deep`: "Map the full dependency graph for changed modules. Check for structural anti-patterns, circular dependencies, and cross-cutting concerns."
 - **ReviewFrontend** + `quick`: "Only check i18n key completeness and direct platform boundary violations in changed frontend files."
-- **ReviewFrontend** + `normal`: "Check i18n, React performance patterns, and accessibility in changed components. Verify frontend-backend API contract alignment."
-- **ReviewFrontend** + `deep`: "Thorough React analysis: effect dependencies, memoization, virtualization. Full accessibility audit. State management pattern review. Cross-layer contract verification."
+- **ReviewFrontend** + `normal`: "Check i18n, frontend performance patterns, and accessibility in changed components. Verify frontend-backend API contract alignment."
+- **ReviewFrontend** + `deep`: "Thorough frontend framework analysis: effect/reactivity dependencies, memoization, virtualization. Full accessibility audit. State management pattern review. Cross-layer contract verification."
 
 ### Phase 3: Quality gate
 

--- a/src/crates/core/src/agentic/agents/review_specialist_agents.rs
+++ b/src/crates/core/src/agentic/agents/review_specialist_agents.rs
@@ -45,7 +45,7 @@ define_readonly_subagent!(
     FrontendReviewerAgent,
     REVIEWER_FRONTEND_AGENT_TYPE,
     "Frontend Reviewer",
-    r#"Independent read-only reviewer focused on frontend-specific issues such as i18n key synchronization, React performance patterns, accessibility, state management, frontend-backend API contract alignment, and platform boundary compliance in the review target."#,
+    r#"Independent read-only reviewer focused on frontend-specific issues such as i18n key synchronization, frontend performance patterns (e.g., memoization, virtualization, effect/reactivity dependencies), accessibility, state management, frontend-backend API contract alignment, and platform boundary compliance in the review target."#,
     "review_frontend_agent",
     &["Read", "Grep", "Glob", "LS", "GetFileDiff", "Git"]
 );

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -2356,6 +2356,26 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             dialog_turn_id: dialog_turn_id.clone(),
         };
 
+        // Emit DialogTurnStarted with subagent_parent_info so the frontend can
+        // associate the subagent session ID with the parent tool (enabling the
+        // "ignore timeout" feature for deep-review subagents).
+        let user_input_text = initial_messages
+            .first()
+            .map(|m| match &m.content {
+                MessageContent::Text(text) => text.clone(),
+                _ => String::new(),
+            })
+            .unwrap_or_default();
+        self.emit_event(AgenticEvent::DialogTurnStarted {
+            session_id: session_id.clone(),
+            turn_id: dialog_turn_id.clone(),
+            turn_index: 0,
+            user_input: user_input_text,
+            original_user_input: None,
+            user_message_metadata: None,
+            subagent_parent_info: subagent_parent_info.clone().map(Into::into),
+        }).await;
+
         let subagent_workspace = Self::build_workspace_binding(&session.config).await;
         let subagent_services = Self::build_workspace_services(&subagent_workspace).await;
         let execution_context = ExecutionContext {

--- a/src/crates/core/src/agentic/deep_review_policy.rs
+++ b/src/crates/core/src/agentic/deep_review_policy.rs
@@ -15,11 +15,12 @@ pub const REVIEWER_PERFORMANCE_AGENT_TYPE: &str = "ReviewPerformance";
 pub const REVIEWER_SECURITY_AGENT_TYPE: &str = "ReviewSecurity";
 pub const REVIEWER_ARCHITECTURE_AGENT_TYPE: &str = "ReviewArchitecture";
 pub const REVIEWER_FRONTEND_AGENT_TYPE: &str = "ReviewFrontend";
-pub const CORE_REVIEWER_AGENT_TYPES: [&str; 4] = [
+pub const CORE_REVIEWER_AGENT_TYPES: [&str; 5] = [
     REVIEWER_BUSINESS_LOGIC_AGENT_TYPE,
     REVIEWER_PERFORMANCE_AGENT_TYPE,
     REVIEWER_SECURITY_AGENT_TYPE,
     REVIEWER_ARCHITECTURE_AGENT_TYPE,
+    REVIEWER_FRONTEND_AGENT_TYPE,
 ];
 const DEFAULT_REVIEW_TEAM_CONFIG_PATH: &str = "ai.review_teams.default";
 
@@ -715,13 +716,13 @@ mod tests {
         })));
         let tracker = DeepReviewBudgetTracker::default();
 
-        // Default policy: 4 core reviewers * 2 max instances = 8 reviewer calls allowed
-        for _ in 0..8 {
+        // Default policy: 5 core reviewers * 2 max instances = 10 reviewer calls allowed
+        for _ in 0..10 {
             tracker
                 .record_task("turn-1", &policy, DeepReviewSubagentRole::Reviewer)
                 .unwrap();
         }
-        // 9th reviewer call should be rejected
+        // 11th reviewer call should be rejected
         assert!(tracker
             .record_task("turn-1", &policy, DeepReviewSubagentRole::Reviewer)
             .is_err());

--- a/src/crates/core/src/agentic/tools/pipeline/state_manager.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/state_manager.rs
@@ -164,6 +164,7 @@ impl ToolStateManager {
                 tool_id: task.tool_call.tool_id.clone(),
                 tool_name: task.tool_call.tool_name.clone(),
                 params: task.tool_call.arguments.clone(),
+                timeout_seconds: task.options.timeout_secs,
             },
 
             ToolExecutionState::Streaming {

--- a/src/crates/events/src/agentic.rs
+++ b/src/crates/events/src/agentic.rs
@@ -295,6 +295,8 @@ pub enum ToolEventData {
         tool_id: String,
         tool_name: String,
         params: serde_json::Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        timeout_seconds: Option<u64>,
     },
     Progress {
         tool_id: String,

--- a/src/web-ui/src/component-library/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/web-ui/src/component-library/components/ConfirmDialog/ConfirmDialog.tsx
@@ -83,7 +83,6 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
 
   const handleConfirm = () => {
     onConfirm();
-    onClose();
   };
 
   const handleCancel = () => {

--- a/src/web-ui/src/flow_chat/components/ChatInput.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInput.scss
@@ -49,17 +49,17 @@
   
   &--collapsed {
     cursor: text;
-    max-width: 300px;
+    max-width: min(380px, 80%);
     margin: 0 auto;
     transform: translateY(3px);
-    
+
     .bitfun-chat-input__box {
       position: relative;
       overflow: hidden;
-      min-height: 42px;
-      max-height: 42px;
+      min-height: 48px;
+      max-height: 48px;
       padding: 0 18px;
-      border-radius: 21px;
+      border-radius: 24px;
       cursor: text;
       background: rgba(18, 18, 28, 0.22);
       border: 1px solid rgba(255, 255, 255, 0.08);
@@ -123,31 +123,31 @@
       top: 50%;
       left: 50%;
       width: calc(100% - 36px);
-      min-height: 24px;
-      max-height: 24px;
+      min-height: 28px;
+      max-height: 28px;
       display: flex;
       align-items: center;
       justify-content: center;
       transform: translate(-50%, -50%);
       pointer-events: none;
-      
+
       .rich-text-input {
-        min-height: 24px !important;
-        max-height: 24px !important;
+        min-height: 28px !important;
+        max-height: 28px !important;
         max-width: 100%;
         font-size: var(--flowchat-font-size-base);
-        line-height: 24px;
+        line-height: 28px;
         overflow: hidden;
         padding: 0 !important;
         margin: 0 auto;
         text-align: center;
         width: 100%;
-        
+
         &:empty::before {
           display: block;
           color: color-mix(in srgb, var(--color-text-muted) 52%, transparent);
           font-size: var(--flowchat-font-size-base);
-          line-height: 24px;
+          line-height: 28px;
           text-align: center;
           width: 100%;
         }
@@ -162,7 +162,7 @@
         gap: 6px;
         width: 100%;
         font-size: var(--flowchat-font-size-sm);
-        line-height: 24px;
+        line-height: 28px;
         color: color-mix(in srgb, var(--color-text-muted) 48%, transparent);
         white-space: nowrap;
         pointer-events: none;

--- a/src/web-ui/src/flow_chat/services/EventBatcher.ts
+++ b/src/web-ui/src/flow_chat/services/EventBatcher.ts
@@ -224,6 +224,7 @@ export interface WaitingToolEvent extends BaseToolEvent<'Waiting'> {
 
 export interface StartedToolEvent extends BaseToolEvent<'Started'> {
   params: unknown;
+  timeout_seconds?: number;
 }
 
 export interface ProgressToolEvent extends BaseToolEvent<'Progress'> {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -284,9 +284,10 @@ export async function sendMessage(
     
     const currentState = stateMachineManager.getCurrentState(sessionId);
     if (currentState === SessionExecutionState.PROCESSING) {
-      stateMachineManager.transition(sessionId, SessionExecutionEvent.ERROR_OCCURRED, {
+      await stateMachineManager.transition(sessionId, SessionExecutionEvent.ERROR_OCCURRED, {
         error: errorMessage
       });
+      await stateMachineManager.transition(sessionId, SessionExecutionEvent.RESET);
     }
     
     const state = context.flowChatStore.getState();

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
@@ -324,12 +324,17 @@ function handleStarted(
 ): void {
   const existingItem = store.findToolItem(sessionId, turnId, toolEvent.tool_id);
   
+  const toolCallData = {
+    input: toolEvent.params,
+    id: toolEvent.tool_id,
+    ...(typeof toolEvent.timeout_seconds === 'number' && {
+      timeout_seconds: toolEvent.timeout_seconds
+    })
+  };
+
   if (existingItem) {
     store.updateModelRoundItem(sessionId, turnId, toolEvent.tool_id, {
-      toolCall: {
-        input: toolEvent.params,
-        id: toolEvent.tool_id
-      },
+      toolCall: toolCallData,
       status: 'running',
       isParamsStreaming: false,
       partialParams: undefined
@@ -341,10 +346,7 @@ function handleStarted(
       type: 'tool',
       toolName: toolEvent.tool_name,
       terminalSessionId: pendingTerminalSessionIds.get(toolEvent.tool_id),
-      toolCall: {
-        input: toolEvent.params,
-        id: toolEvent.tool_id
-      },
+      toolCall: toolCallData,
       timestamp: options?.parentTimestamp ? options.parentTimestamp + 2 : Date.now(),
       status: 'running',
       requiresConfirmation: false,

--- a/src/web-ui/src/flow_chat/state-machine/SessionStateMachine.ts
+++ b/src/web-ui/src/flow_chat/state-machine/SessionStateMachine.ts
@@ -115,6 +115,8 @@ export class SessionStateMachineImpl {
       SessionExecutionEvent.TOOL_REJECTED,
       SessionExecutionEvent.USER_CANCEL,
       SessionExecutionEvent.START,
+      SessionExecutionEvent.ERROR_OCCURRED,
+      SessionExecutionEvent.RESET,
     ];
     
     if (toolRelatedEvents.includes(event)) {

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
@@ -283,7 +283,9 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
                   startTime={toolItem.startTime}
                   isRunning={isRunning}
                   timeoutMs={
-                    typeof toolCall?.input?.timeout_seconds === 'number' && toolCall.input.timeout_seconds > 0
+                    typeof toolCall?.timeout_seconds === 'number' && toolCall.timeout_seconds > 0
+                      ? toolCall.timeout_seconds * 1000
+                      : typeof toolCall?.input?.timeout_seconds === 'number' && toolCall.input.timeout_seconds > 0
                       ? toolCall.input.timeout_seconds * 1000
                       : undefined
                   }

--- a/src/web-ui/src/flow_chat/types/flow-chat.ts
+++ b/src/web-ui/src/flow_chat/types/flow-chat.ts
@@ -44,6 +44,7 @@ export interface FlowToolItem extends FlowItem {
   toolCall: {
     input: any;
     id: string;
+    timeout_seconds?: number;
   };
   toolResult?: {
     result: any;

--- a/src/web-ui/src/locales/en-US/scenes/agents.json
+++ b/src/web-ui/src/locales/en-US/scenes/agents.json
@@ -304,10 +304,10 @@
       "frontend": {
         "funName": "Frontend Reviewer",
         "role": "Frontend Reviewer",
-        "description": "A UI specialist that checks i18n synchronization, React performance patterns, accessibility, and frontend-backend contract alignment.",
+        "description": "A UI specialist that checks i18n synchronization, frontend performance patterns, accessibility, and frontend-backend contract alignment.",
         "responsibilities": [
           "Verify i18n key completeness across all locales.",
-          "Check React performance patterns (memoization, virtualization, effect dependencies).",
+          "Check frontend performance patterns (memoization, virtualization, effect/reactivity dependencies).",
           "Flag accessibility violations and frontend-backend API contract drift."
         ]
       }

--- a/src/web-ui/src/locales/zh-CN/scenes/agents.json
+++ b/src/web-ui/src/locales/zh-CN/scenes/agents.json
@@ -304,10 +304,10 @@
       "frontend": {
         "funName": "前端审核员",
         "role": "前端审核员",
-        "description": "检查国际化同步、React 性能模式、无障碍访问和前后端契约一致性的 UI 专家。",
+        "description": "检查国际化同步、前端性能模式、无障碍访问和前后端契约一致性的 UI 专家。",
         "responsibilities": [
           "验证所有语言区域的国际化键完整性。",
-          "检查 React 性能模式（记忆化、虚拟化、effect 依赖）。",
+          "检查前端性能模式（记忆化、虚拟化、effect/reactivity 依赖）。",
           "标记无障碍访问违规和前后端 API 契约偏差。"
         ]
       }

--- a/src/web-ui/src/locales/zh-TW/scenes/agents.json
+++ b/src/web-ui/src/locales/zh-TW/scenes/agents.json
@@ -304,10 +304,10 @@
       "frontend": {
         "funName": "前端審核員",
         "role": "前端審核員",
-        "description": "檢查國際化同步、React 效能模式、無障礙訪問和前後端契約一致性的 UI 專家。",
+        "description": "檢查國際化同步、前端效能模式、無障礙訪問和前後端契約一致性的 UI 專家。",
         "responsibilities": [
           "驗證所有語言區域的國際化鍵完整性。",
-          "檢查 React 效能模式（記憶化、虛擬化、effect 依賴）。",
+          "檢查前端效能模式（記憶化、虛擬化、effect/reactivity 依賴）。",
           "標記無障礙訪問違規和前後端 API 契約偏差。"
         ]
       }


### PR DESCRIPTION
### 1. fix(deep-review): make subagent ignore-timeout work correctly

- Propagate `timeout_seconds` through backend events and frontend tool state
- Emit `DialogTurnStarted` with `subagent_parent_info` so frontend can link subagent sessions to parent tools

### 2. fix(web-ui): reset session state to idle after send message failure

- Transition to `RESET` after `ERROR_OCCURRED` to prevent stuck sessions
- Add `ERROR_OCCURRED` and `RESET` to state transition logging whitelist

### 3. style(chat-input): relax collapsed input capsule sizing

- Height `42px` → `48px`, max-width `300px` → `min(380px, 80%)`
- Line-height `24px` → `28px`, border-radius `21px` → `24px`

### 4. refactor(core): generalize frontend reviewer description beyond React

- Replace React-specific terms with generic frontend framework language
- Add `ReviewFrontend` to `CORE_REVIEWER_AGENT_TYPES`, update budget tracker test
- Update i18n strings for en-US, zh-CN, zh-TW