### PR TITLE
fix(ai-adapters): surface provider code 1305 in OpenAI stream errors

### DIFF
--- a/src/crates/ai-adapters/src/stream/stream_handler/openai.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/openai.rs
@@ -51,6 +51,22 @@ fn is_valid_chat_completion_chunk_weak(event_json: &Value) -> bool {
 fn extract_sse_api_error_message(event_json: &Value) -> Option<String> {
     let error = event_json.get("error")?;
     if let Some(message) = error.get("message").and_then(|value| value.as_str()) {
+        if let Some(code) = error
+            .get("code")
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+            .or_else(|| error.get("code").map(|value| value.to_string()))
+        {
+            let mut formatted = format!("code={}, message={}", code, message);
+            if let Some(request_id) = event_json
+                .get("request_id")
+                .or_else(|| event_json.get("requestId"))
+                .and_then(|value| value.as_str())
+            {
+                formatted.push_str(&format!(", request_id={}", request_id));
+            }
+            return Some(formatted);
+        }
         return Some(message.to_string());
     }
     if let Some(message) = error.as_str() {
@@ -271,6 +287,24 @@ mod tests {
         assert_eq!(
             extract_sse_api_error_message(&event).as_deref(),
             Some("provider error")
+        );
+    }
+
+    #[test]
+    fn extracts_api_error_code_message_and_request_id_from_object_shape() {
+        let event = serde_json::json!({
+            "error": {
+                "code": "1305",
+                "message": "该模型当前访问量过大，请您稍后再试"
+            },
+            "request_id": "20260410100425fab0cd73dea74cc3"
+        });
+
+        assert_eq!(
+            extract_sse_api_error_message(&event).as_deref(),
+            Some(
+                "code=1305, message=该模型当前访问量过大，请您稍后再试, request_id=20260410100425fab0cd73dea74cc3"
+            )
         );
     }
 

--- a/src/crates/core/tests/fixtures/stream/openai/provider_error_with_code.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/provider_error_with_code.sse
@@ -1,0 +1,1 @@
+data: {"error":{"code":"1305","message":"provider temporarily overloaded"},"request_id":"req_1305"}

--- a/src/crates/core/tests/stream_processor_openai.rs
+++ b/src/crates/core/tests/stream_processor_openai.rs
@@ -181,6 +181,29 @@ async fn openai_fixture_parses_inline_think_tags_into_reasoning_content() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn openai_fixture_preserves_provider_error_code_and_request_id() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::OpenAi,
+        "stream/openai/provider_error_with_code.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let error = output
+        .result
+        .expect_err("provider error fixture should fail")
+        .error
+        .to_string();
+
+    assert!(error.contains("SSE API error"));
+    assert!(error.contains("code=1305"));
+    assert!(error.contains("message=provider temporarily overloaded"));
+    assert!(error.contains("request_id=req_1305"));
+    assert!(!error.contains("missing field"));
+    assert!(!error.contains("SSE data schema error"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn openai_fixture_reattaches_id_only_prelude_to_following_payload_chunk() {
     let output = run_stream_fixture(
         StreamFixtureProvider::OpenAi,


### PR DESCRIPTION
## Summary

Preserve provider error metadata from OpenAI-compatible SSE error payloads.

When a provider sends an SSE data payload like:

```json
{"error":{"code":"1305","message":"provider temporarily overloaded"},"request_id":"req_1305"}
```

BitFun already recognizes it as an API error before deserializing it as a normal chat chunk. This follow-up keeps the provider `code` and `request_id` in the surfaced error message instead of reducing the error to message-only text.

## Motivation

Issue #380 shows a provider overload response where the useful debugging fields were:

- `code`
- `message`
- `request_id`

Keeping those fields visible makes model overload, quota, gateway, and provider-side failures easier to diagnose from BitFun's runtime errors and raw SSE logs.

## Changes

- Include `error.code` in OpenAI-compatible SSE API error messages when present.
- Include top-level `request_id` / `requestId` when present.
- Keep existing behavior unchanged for message-only and string-shaped `error` payloads.
- Add an adapter unit test for the `code + message + request_id` shape.
- Add a `bitfun-core` stream fixture test so existing CI covers the end-to-end StreamProcessor error path.

## Test Plan

```sh
git diff --check
```

Result: passed.

Attempted focused Rust tests:

```sh
cargo test -p bitfun-ai-adapters stream::stream_handler::openai::tests::extracts_api_error_code_message_and_request_id_from_object_shape
cargo test -p bitfun-core --test stream_processor_openai openai_fixture_preserves_provider_error_code_and_request_id
```

Result: not run locally because this machine does not currently have `cargo` / `rustc` installed. The new core integration test is under `src/crates/core/tests`, which is covered by the existing Linux CI job:

```sh
cargo test --locked -p bitfun-core
```

## Risk

Low. This only changes formatting for OpenAI-compatible stream error payloads that already contain an `error` object. Normal chat completion chunks, tool-call chunks, and message-only error payloads keep their current behavior.

## Related Issue

Refs #380.
