### PR TITLE
test: normalize SSE fixture endings and gate raw SSE logging

### DIFF
--- a/src/crates/core/tests/common/stream_test_harness.rs
+++ b/src/crates/core/tests/common/stream_test_harness.rs
@@ -33,6 +33,7 @@ pub struct StreamFixtureRunOptions {
     pub server_options: FixtureSseServerOptions,
     pub openai_inline_think_in_text: bool,
     pub anthropic_inline_think_in_text: bool,
+    pub log_raw_sse: bool,
 }
 
 impl Default for StreamFixtureRunOptions {
@@ -41,6 +42,7 @@ impl Default for StreamFixtureRunOptions {
             server_options: FixtureSseServerOptions::default(),
             openai_inline_think_in_text: false,
             anthropic_inline_think_in_text: false,
+            log_raw_sse: false,
         }
     }
 }
@@ -79,6 +81,23 @@ pub async fn run_stream_fixture_with_options(
 
     let (tx_event, rx_event) = mpsc::unbounded_channel::<Result<UnifiedResponse, anyhow::Error>>();
     let (tx_raw_sse, rx_raw_sse) = mpsc::unbounded_channel::<String>();
+    let raw_sse_rx_for_processor = if options.log_raw_sse {
+        let (tx_raw_sse_for_processor, rx_raw_sse_for_processor) =
+            mpsc::unbounded_channel::<String>();
+        let mut rx_raw_sse = rx_raw_sse;
+        let fixture_label = fixture_relative_path.to_string();
+        tokio::spawn(async move {
+            while let Some(raw_sse) = rx_raw_sse.recv().await {
+                println!("[stream-fixture raw sse][{}] {}", fixture_label, raw_sse);
+                if tx_raw_sse_for_processor.send(raw_sse).is_err() {
+                    break;
+                }
+            }
+        });
+        Some(rx_raw_sse_for_processor)
+    } else {
+        Some(rx_raw_sse)
+    };
 
     match provider {
         StreamFixtureProvider::OpenAi => {
@@ -126,7 +145,7 @@ pub async fn run_stream_fixture_with_options(
         .process_stream(
             unified_stream,
             None,
-            Some(rx_raw_sse),
+            raw_sse_rx_for_processor,
             "session_fixture".to_string(),
             "turn_fixture".to_string(),
             "round_fixture".to_string(),

--- a/src/crates/core/tests/fixtures/stream/anthropic/extended_thinking.sse
+++ b/src/crates/core/tests/fixtures/stream/anthropic/extended_thinking.sse
@@ -30,3 +30,4 @@ data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":
 
 event: message_stop
 data: {"type":"message_stop"}
+

--- a/src/crates/core/tests/fixtures/stream/anthropic/inline_think_text.sse
+++ b/src/crates/core/tests/fixtures/stream/anthropic/inline_think_text.sse
@@ -15,3 +15,4 @@ data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":
 
 event: message_stop
 data: {"type":"message_stop"}
+

--- a/src/crates/core/tests/fixtures/stream/openai/interleaved_parallel_tool_args_by_index.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/interleaved_parallel_tool_args_by_index.sse
@@ -7,3 +7,4 @@ data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":802,"mode
 data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":803,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"type":"function","function":{"arguments":"{\"y\":2}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":5,"total_tokens":10}}
 
 data: [DONE]
+

--- a/src/crates/core/tests/fixtures/stream/openai/thinking_text_three_tools_with_empty_toolcall_anomaly.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/thinking_text_three_tools_with_empty_toolcall_anomaly.sse
@@ -25,3 +25,4 @@ data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":207,"mode
 data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":208,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":2,"id":"call_3","type":"function","function":{"arguments":"}}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":7,"total_tokens":12}}
 
 data: [DONE]
+

--- a/src/crates/core/tests/fixtures/stream/openai/tool_args_snapshot_stop_reason.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/tool_args_snapshot_stop_reason.sse
@@ -5,3 +5,4 @@ data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":501,"mode
 data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":502,"model":"gpt-test","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":6,"total_tokens":9}}
 
 data: [DONE]
+

--- a/src/crates/core/tests/fixtures/stream/openai/tool_args_split_with_usage.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/tool_args_split_with_usage.sse
@@ -3,3 +3,4 @@ data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":123,"mode
 data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":124,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":null,"type":"function","function":{"name":null,"arguments":"1}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":6,"total_tokens":7}}
 
 data: [DONE]
+

--- a/src/crates/core/tests/fixtures/stream/openai/tool_call_missing_type_field.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/tool_call_missing_type_field.sse
@@ -5,3 +5,4 @@ data: {"id":"chatcmpl_azure_001","object":"chat.completion.chunk","created":1711
 data: {"id":"chatcmpl_azure_001","object":"chat.completion.chunk","created":1711357600,"model":"mistral-large","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\"hello\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}
 
 data: [DONE]
+

--- a/src/crates/core/tests/fixtures/stream/openai/tool_call_trailing_empty_args_finish_chunk.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/tool_call_trailing_empty_args_finish_chunk.sse
@@ -11,3 +11,4 @@ data: {"id":"chatcmpl_tail_001","object":"chat.completion.chunk","created":17331
 data: {"id":"chatcmpl_tail_001","object":"chat.completion.chunk","created":1733162246,"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":""}}]},"finish_reason":"tool_calls","stop_reason":128008}],"usage":{"prompt_tokens":226,"completion_tokens":20,"total_tokens":246}}
 
 data: [DONE]
+

--- a/src/crates/core/tests/fixtures/stream/openai/tool_id_only_orphan_filtered.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/tool_id_only_orphan_filtered.sse
@@ -1,3 +1,4 @@
 data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":600,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_orphan","type":"function","function":{}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":4,"completion_tokens":5,"total_tokens":9}}
 
 data: [DONE]
+

--- a/src/crates/core/tests/fixtures/stream/openai/tool_id_prelude_then_payload_without_id.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/tool_id_prelude_then_payload_without_id.sse
@@ -3,3 +3,4 @@ data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":400,"mode
 data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":401,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":null,"type":"function","function":{"name":"tool_a","arguments":"{\"city\":\"Beijing\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":3,"completion_tokens":6,"total_tokens":9}}
 
 data: [DONE]
+

--- a/src/crates/core/tests/fixtures/stream/openai/two_tools_first_final_chunk_contains_orphan_id_only.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/two_tools_first_final_chunk_contains_orphan_id_only.sse
@@ -5,3 +5,4 @@ data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":701,"mode
 data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":702,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_2","type":"function","function":{"name":"tool_two","arguments":"{\"y\":2}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":6,"total_tokens":11}}
 
 data: [DONE]
+


### PR DESCRIPTION
- fix all stream fixture `.sse` files to end with a complete SSE event separator (`\r\n\r\n`)
- make raw SSE fixture logging opt-in via `StreamFixtureRunOptions.log_raw_sse`
- keep raw SSE logging disabled by default to avoid noisy test output
