### PR TITLE
feat(nav-panel): add sticky absorption to workspace cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ tests/e2e/reports/
 .cursor
 .cursor/rules/no-cargo.mdc
 .sisyphus/
+.worktrees/
 
 ASSETS_LICENSES.md
 

--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -34,7 +34,7 @@ $_section-header-height: 24px;
   display: flex;
   flex-direction: column;
   background: var(--color-bg-primary);
-  overflow: hidden;
+  overflow: visible;
   user-select: none;
 
   // ── Container ──────────────────────────────
@@ -46,7 +46,7 @@ $_section-header-height: 24px;
     // Dynamic clip-path origin — set via JS from anchor element measurement.
     // Fallback: ~20% from top (roughly the "Files" item in a typical layout).
     position: relative;
-    overflow: hidden;
+    overflow: visible;
 
     --clip-origin-top: 20%;
     --clip-origin-bottom: 80%;
@@ -1027,7 +1027,7 @@ $_section-header-height: 24px;
   }
 
   &__collapsible-inner {
-    overflow: hidden;
+    overflow: visible;
     min-height: 0;
   }
 

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -1,4 +1,57 @@
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
+
+function useStickyObserver(ref: React.RefObject<HTMLDivElement | null>) {
+  const [isStuck, setIsStuck] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    // Find the nearest scrollable ancestor to use as the observer root.
+    // The sticky element is pinned relative to this scroll container.
+    let scrollContainer: Element | null = el.parentElement;
+    while (scrollContainer) {
+      const style = window.getComputedStyle(scrollContainer);
+      const isScrollable =
+        (style.overflowY === 'auto' || style.overflowY === 'scroll') &&
+        scrollContainer.scrollHeight > scrollContainer.clientHeight;
+      if (isScrollable) break;
+      scrollContainer = scrollContainer.parentElement;
+    }
+
+    // Place a sentinel element as a sibling right before the sticky element.
+    // When the sentinel scrolls out of the top of the container,
+    // the sticky element is considered "stuck".
+    const sentinel = document.createElement('div');
+    sentinel.style.position = 'static';
+    sentinel.style.height = '1px';
+    sentinel.style.width = '1px';
+    sentinel.style.pointerEvents = 'none';
+    sentinel.style.visibility = 'hidden';
+    el.parentElement?.insertBefore(sentinel, el);
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        // Sentinel is not intersecting → sticky element has been pushed to the top
+        setIsStuck(!entry.isIntersecting);
+      },
+      {
+        root: scrollContainer,
+        threshold: 0,
+        rootMargin: '-1px 0px 0px 0px',
+      }
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+      sentinel.remove();
+    };
+  }, [ref]);
+
+  return isStuck;
+}
 import { createPortal } from 'react-dom';
 import { Folder, FolderOpen, MoreHorizontal, FolderSearch, Plus, ChevronDown, Trash2, RotateCcw, Copy, FileText, GitBranch } from 'lucide-react';
 import { DotMatrixArrowRightIcon } from './DotMatrixArrowRightIcon';
@@ -70,6 +123,8 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
   const menuRef = useRef<HTMLDivElement>(null);
   const menuAnchorRef = useRef<HTMLDivElement>(null);
   const menuPopoverRef = useRef<HTMLDivElement>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const isCardStuck = useStickyObserver(cardRef);
   const [menuPosition, setMenuPosition] = useState<{ top: number; left: number } | null>(null);
   const isNamedAssistantWorkspace =
     workspace.workspaceKind === WorkspaceKind.Assistant &&
@@ -411,7 +466,11 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
       aria-current={isActive ? 'location' : undefined}
       aria-grabbed={draggable ? isDragging : undefined}>
         <div
-          className="bitfun-nav-panel__assistant-item-card"
+          ref={cardRef}
+          className={[
+            'bitfun-nav-panel__assistant-item-card',
+            isCardStuck && 'is-stuck',
+          ].filter(Boolean).join(' ')}
           draggable={draggable}
           onDragStart={onDragStart}
           onDragEnd={onDragEnd}
@@ -585,7 +644,11 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
     aria-current={isActive ? 'location' : undefined}
     aria-grabbed={draggable ? isDragging : undefined}>
       <div
-        className="bitfun-nav-panel__workspace-item-card"
+        ref={cardRef}
+        className={[
+          'bitfun-nav-panel__workspace-item-card',
+          isCardStuck && 'is-stuck',
+        ].filter(Boolean).join(' ')}
         draggable={draggable}
         onDragStart={onDragStart}
         onDragEnd={onDragEnd}

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
@@ -106,7 +106,6 @@
         gap: 1px;
 
         &:hover {
-          background: transparent;
           color: var(--color-text-secondary);
 
           .bitfun-nav-panel__workspace-item-collapse-btn,
@@ -149,16 +148,21 @@
   }
 
   &__workspace-item-card {
-    position: relative;
+    position: sticky;
+    top: 0;
+    z-index: 2;
     display: flex;
     align-items: center;
     width: 100%;
     min-height: 30px;
     border-radius: 6px;
     color: var(--color-text-primary);
-    background: transparent;
+    background: var(--color-bg-primary);
     transition: color $motion-fast $easing-standard,
-                background $motion-fast $easing-standard;
+                background $motion-fast $easing-standard,
+                box-shadow $motion-fast $easing-standard;
+
+
 
     &[draggable='true'] {
       cursor: grab;
@@ -187,10 +191,6 @@
 
   &__workspace-item.is-active &__workspace-item-card {
     color: var(--color-text-primary);
-
-    &:hover {
-      background: transparent;
-    }
   }
 
   &__workspace-item:not(.is-active) &__workspace-item-icon {
@@ -580,8 +580,6 @@
   }
 
   &__workspace-item-sessions {
-    overflow-y: auto;
-    overflow-x: hidden;
     transition: opacity $motion-fast $easing-standard;
     opacity: 1;
 
@@ -669,15 +667,18 @@
   }
 
   &__assistant-item-card {
-    position: relative;
+    position: sticky;
+    top: 0;
+    z-index: 2;
     display: flex;
     align-items: center;
     width: 100%;
     border-radius: 6px;
     color: var(--color-text-secondary);
-    background: transparent;
+    background: var(--color-bg-primary);
     transition: color $motion-fast $easing-standard,
-                background $motion-fast $easing-standard;
+                background $motion-fast $easing-standard,
+                box-shadow $motion-fast $easing-standard;
 
     &[draggable='true'] {
       cursor: grab;
@@ -701,7 +702,6 @@
 
     &:hover {
       color: var(--color-text-secondary);
-      background: transparent;
     }
   }
 
@@ -876,8 +876,6 @@
   }
 
   &__assistant-item-sessions {
-    overflow-y: auto;
-    overflow-x: hidden;
     transition: opacity $motion-fast $easing-standard;
     opacity: 1;
 

--- a/src/web-ui/src/app/layout/WorkspaceBody.scss
+++ b/src/web-ui/src/app/layout/WorkspaceBody.scss
@@ -36,7 +36,7 @@ $_nav-collapsed-width: 80px;
   width: var(--nav-width, $_nav-width);
   flex-shrink: 0;
   height: 100%;
-  overflow: hidden;
+  overflow: visible;
   position: relative;
   z-index: 3;
   transition: width $motion-base $easing-standard;


### PR DESCRIPTION
Add position: sticky to workspace and assistant item cards so they pin to the top of the nav panel scroll area while their session lists scroll beneath. When a subsequent workspace card scrolls up, it naturally pushes the previous one away (stacking sticky behavior).