### PR TITLE
feat(deep-review): enhance error and interruption experience

### DIFF
--- a/src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.test.tsx
+++ b/src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.test.tsx
@@ -158,15 +158,23 @@ describeWithJsdom('ReviewTeamPage', () => {
     vi.clearAllMocks();
   });
 
+  async function waitForText(text: string, maxTicks = 20) {
+    for (let i = 0; i < maxTicks; i++) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+      if (container.textContent?.includes(text)) return;
+    }
+    throw new Error(`waitForText: "${text}" not found after ${maxTicks} ticks`);
+  }
+
   it('loads review team data only once on initial render', async () => {
     const { default: ReviewTeamPage } = await import('./ReviewTeamPage');
 
     await act(async () => {
       root.render(<ReviewTeamPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await waitForText('Team Overview');
 
     expect(loadDefaultReviewTeam).toHaveBeenCalledTimes(1);
   });
@@ -177,9 +185,7 @@ describeWithJsdom('ReviewTeamPage', () => {
     await act(async () => {
       root.render(<ReviewTeamPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await waitForText('Team Overview');
 
     expect(container.textContent).toContain('Team Overview');
     expect(container.textContent).toContain('Current Policy');
@@ -200,9 +206,7 @@ describeWithJsdom('ReviewTeamPage', () => {
     await act(async () => {
       root.render(<ReviewTeamPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await waitForText('Team Overview');
 
     const settingsButton = Array.from(container.querySelectorAll('button'))
       .find((button) => button.textContent?.includes('Review settings'));
@@ -227,9 +231,7 @@ describeWithJsdom('ReviewTeamPage', () => {
     await act(async () => {
       root.render(<ReviewTeamPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await waitForText('Team Overview');
 
     const policyPanel = container.querySelector<HTMLButtonElement>('.review-team-page__policy-panel');
     expect(policyPanel).toBeTruthy();
@@ -287,9 +289,7 @@ describeWithJsdom('ReviewTeamPage', () => {
     await act(async () => {
       root.render(<ReviewTeamPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await waitForText('Logic');
 
     const memberButton = Array.from(container.querySelectorAll('button'))
       .find((button) => button.textContent?.includes('Logic'));

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -7,10 +7,10 @@ import React, { useRef, useCallback, useEffect, useReducer, useState, useMemo } 
 import { Trans, useTranslation } from 'react-i18next';
 import { ArrowUp, Image, Maximize2, Minimize2, RotateCcw, Plus, X, Sparkles, Loader2, ChevronRight, Files, MessageSquarePlus } from 'lucide-react';
 import { ContextDropZone, useContextStore } from '../../shared/context-system';
-import { useActiveSessionState } from '../hooks/useActiveSessionState';
+import { useActiveSessionState } from '@/flow_chat/hooks';
 import { RichTextInput, type MentionState } from './RichTextInput';
 import { FileMentionPicker } from './FileMentionPicker';
-import { globalEventBus } from '../../infrastructure/event-bus';
+import { globalEventBus } from '@/infrastructure';
 import {
   useSessionDerivedState,
   useSessionStateMachine,
@@ -20,7 +20,7 @@ import { SessionExecutionEvent } from '../state-machine/types';
 import { ModelSelector } from './ModelSelector';
 import { FlowChatStore } from '../store/FlowChatStore';
 import type { FlowChatState } from '../types/flow-chat';
-import type { FileContext, DirectoryContext, ImageContext } from '../../shared/types/context';
+import type { FileContext, DirectoryContext, ImageContext } from '@/types/context.ts';
 import { SmartRecommendations } from './smart-recommendations';
 import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
 import { WorkspaceKind } from '@/shared/types';
@@ -33,10 +33,11 @@ import { useMessageSender } from '../hooks/useMessageSender';
 import { useChatInputState } from '../store/chatInputStateStore';
 import { useInputHistoryStore } from '../store/inputHistoryStore';
 import { startBtwThread } from '../services/BtwThreadService';
-import { FlowChatManager } from '../services/FlowChatManager';
+import { FlowChatManager } from '@/flow_chat';
 import {
   DEEP_REVIEW_SLASH_COMMAND,
   buildDeepReviewPromptFromSlashCommand,
+  getDeepReviewLaunchErrorMessage,
   isDeepReviewSlashCommand,
   launchDeepReviewSession,
 } from '../services/DeepReviewService';
@@ -1137,8 +1138,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     if (text.startsWith('/')) {
       const afterSlash = text.slice(1);
       const hasWhitespace = /\s/.test(afterSlash);
-      const firstToken = afterSlash.trimStart().split(/\s+/, 1)[0]?.toLowerCase?.() ?? '';
-      const query = firstToken;
+      const query = afterSlash.trimStart().split(/\s+/, 1)[0]?.toLowerCase?.() ?? '';
       const matchedMcpPrompt = resolveTypedMcpPromptCommand(text);
 
       // While the main session is running, expose a single quick action (/btw) via the same picker UX.
@@ -1453,7 +1453,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       dispatchInput({ type: 'ACTIVATE' });
       dispatchInput({ type: 'SET_VALUE', payload: message });
       notificationService.error(
-        error instanceof Error ? error.message : t('error.unknown'),
+        getDeepReviewLaunchErrorMessage(error, t, t('error.unknown')),
         {
           title: t('chatInput.deepreviewFailed', { defaultValue: 'Deep review failed' }),
           duration: 5000,
@@ -2255,7 +2255,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
   const isCollapsedProcessing = !inputState.isActive && !!derivedState?.isProcessing;
   const petReplacesStopChrome = agentCompanionEnabled && isCollapsedProcessing;
-  const petStopClickable = petReplacesStopChrome && !!derivedState?.canCancel;
+  const petStopClickable = petReplacesStopChrome && derivedState?.canCancel;
   const collapsedPetSplitSend =
     petReplacesStopChrome && derivedState?.sendButtonMode === 'split';
 

--- a/src/web-ui/src/flow_chat/components/DeepReviewConsentDialog.scss
+++ b/src/web-ui/src/flow_chat/components/DeepReviewConsentDialog.scss
@@ -143,6 +143,14 @@
   line-height: 1.35;
 }
 
+.deep-review-consent__token-estimate {
+  margin: 6px 0 0;
+  color: var(--color-text-muted);
+  font-size: 11px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
 .deep-review-consent__footer {
   display: flex;
   align-items: center;

--- a/src/web-ui/src/flow_chat/components/DeepReviewConsentDialog.tsx
+++ b/src/web-ui/src/flow_chat/components/DeepReviewConsentDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { Clock, Coins, ShieldCheck, X } from 'lucide-react';
+import { estimateTokenConsumption, formatTokenCount } from '../utils/deepReviewExperience';
 import { useTranslation } from 'react-i18next';
 import { Button, Checkbox, Modal } from '@/component-library';
 import { createLogger } from '@/shared/utils/logger';
@@ -106,6 +107,16 @@ export function useDeepReviewConsent(): DeepReviewConsentControls {
                 {t('deepReviewConsent.costLabel', { defaultValue: 'Higher token usage' })}
               </span>
               <p>{t('deepReviewConsent.cost')}</p>
+              <p className="deep-review-consent__token-estimate">
+                {(() => {
+                  const est = estimateTokenConsumption(5);
+                  return t('deepReviewConsent.estimatedTokens', {
+                    min: formatTokenCount(est.min),
+                    max: formatTokenCount(est.max),
+                    defaultValue: 'Estimated: {{min}} - {{max}} tokens',
+                  });
+                })()}
+              </p>
             </div>
           </div>
           <div className="deep-review-consent__fact">

--- a/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.scss
+++ b/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.scss
@@ -394,6 +394,224 @@
     flex-shrink: 0;
   }
 
+  /* Progress tracking */
+  &__progress {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    background: var(--element-bg-subtle);
+    font-size: 12px;
+  }
+
+  &__progress-text {
+    color: var(--color-text-secondary);
+    font-weight: 500;
+  }
+
+  &__elapsed {
+    margin-left: auto;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Partial results */
+  &__partial-summary {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: var(--element-bg-subtle);
+    font-size: 12px;
+  }
+
+  &__partial-count {
+    color: var(--color-text-secondary);
+  }
+
+  &__partial-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
+    color: var(--color-accent-500, #60a5fa);
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 12px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    transition: background 0.2s;
+
+    &:hover {
+      background: color-mix(in srgb, var(--color-accent-500, #60a5fa) 10%, transparent);
+    }
+  }
+
+  &__partial-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    background: var(--color-bg-primary);
+    border: 1px solid var(--border-base);
+  }
+
+  &__partial-section {
+    font-size: 12px;
+    color: var(--color-text-secondary);
+  }
+
+  &__partial-section-title {
+    font-weight: 500;
+  }
+
+  /* Error attribution */
+  &__attribution {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    font-size: 12px;
+
+    &--warning {
+      background: color-mix(in srgb, var(--color-warning, #f59e0b) 8%, var(--color-bg-secondary));
+      border: 1px solid color-mix(in srgb, var(--color-warning, #f59e0b) 18%, transparent);
+    }
+
+    &--error {
+      background: color-mix(in srgb, var(--color-error, #ef4444) 8%, var(--color-bg-secondary));
+      border: 1px solid color-mix(in srgb, var(--color-error, #ef4444) 18%, transparent);
+    }
+  }
+
+  &__attribution-message {
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+  }
+
+  &__attribution-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  /* Recovery plan */
+  &__recovery-plan {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  &__recovery-plan-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border-radius: 6px;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--color-text-muted);
+    font-size: 12px;
+    cursor: pointer;
+    transition: background 0.2s, border-color 0.2s, color 0.2s;
+    width: fit-content;
+
+    &:hover {
+      background: var(--element-bg-subtle);
+      border-color: var(--border-base);
+      color: var(--color-text-primary);
+    }
+  }
+
+  &__recovery-plan-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: var(--color-bg-primary);
+    border: 1px solid var(--border-base);
+  }
+
+  &__recovery-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--color-text-secondary);
+  }
+
+  &__recovery-icon {
+    &--preserve {
+      color: var(--color-success, #22c55e);
+    }
+
+    &--rerun {
+      color: var(--color-accent-500, #60a5fa);
+    }
+
+    &--skip {
+      color: var(--color-text-muted);
+    }
+  }
+
+  /* Degradation options */
+  &__degradation {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    background: var(--color-bg-primary);
+    border: 1px solid var(--border-base);
+  }
+
+  &__degradation-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+  }
+
+  &__degradation-option {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px 10px;
+    border-radius: 6px;
+    background: var(--element-bg-subtle);
+    border: 1px solid transparent;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.2s, border-color 0.2s;
+
+    &:hover:not(:disabled) {
+      background: var(--element-bg-base);
+      border-color: var(--border-base);
+    }
+
+    &:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+  }
+
+  &__degradation-label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--color-text-primary);
+  }
+
+  &__degradation-desc {
+    font-size: 11px;
+    color: var(--color-text-muted);
+  }
+
   /* Animations */
   @keyframes deep-review-action-bar-spin {
     from {

--- a/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.test.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.test.tsx
@@ -8,6 +8,10 @@ const eventBusEmitMock = vi.hoisted(() => vi.fn());
 const confirmWarningMock = vi.hoisted(() => vi.fn());
 
 vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn(),
+  },
   useTranslation: () => ({
     t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
   }),
@@ -58,12 +62,50 @@ vi.mock('@/component-library/components/ConfirmDialog/confirmService', () => ({
 vi.mock('@/shared/notification-system', () => ({
   notificationService: {
     error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
   },
 }));
 
 vi.mock('@/shared/utils/logger', () => ({
   createLogger: () => ({
     error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('../../store/FlowChatStore', () => ({
+  flowChatStore: {
+    getState: () => ({
+      sessions: new Map(),
+      activeSessionId: null,
+    }),
+    subscribe: () => () => {},
+  },
+}));
+
+vi.mock('../../utils/deepReviewExperience', () => ({
+  aggregateReviewerProgress: () => [],
+  buildReviewerProgressSummary: () => null,
+  extractPartialReviewData: () => null,
+  buildErrorAttribution: () => null,
+  buildRecoveryPlan: () => null,
+  evaluateDegradationOptions: () => [],
+}));
+
+vi.mock('../../services/DeepReviewContinuationService', () => ({
+  continueDeepReviewSession: vi.fn(),
+}));
+
+vi.mock('@/shared/ai-errors/aiErrorPresenter', () => ({
+  getAiErrorPresentation: () => ({
+    category: 'network',
+    titleKey: 'test',
+    messageKey: 'test',
+    diagnostics: 'test diagnostics',
+    actions: [],
   }),
 }));
 

--- a/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   CheckCircle,
@@ -13,6 +13,9 @@ import {
   Play,
   Copy,
   Info,
+  SkipForward,
+  RotateCcw,
+  Eye,
 } from 'lucide-react';
 import { Button, Checkbox, Tooltip } from '@/component-library';
 import { useReviewActionBarStore, type ReviewActionPhase } from '../../store/deepReviewActionBarStore';
@@ -26,6 +29,15 @@ import { notificationService } from '@/shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
 import { getAiErrorPresentation } from '@/shared/ai-errors/aiErrorPresenter';
 import { confirmWarning } from '@/component-library/components/ConfirmDialog/confirmService';
+import {
+  aggregateReviewerProgress,
+  buildErrorAttribution,
+  buildRecoveryPlan,
+  buildReviewerProgressSummary,
+  evaluateDegradationOptions,
+  extractPartialReviewData,
+} from '../../utils/deepReviewExperience';
+import { flowChatStore } from '../../store/FlowChatStore';
 import './DeepReviewActionBar.scss';
 
 const log = createLogger('DeepReviewActionBar');
@@ -84,6 +96,10 @@ export const ReviewActionBar: React.FC = () => {
 
   const [showCustomInput, setShowCustomInput] = useState(false);
   const [showRemediationList, setShowRemediationList] = useState(true);
+  const [showPartialResults, setShowPartialResults] = useState(false);
+  const [showRecoveryPlan, setShowRecoveryPlan] = useState(false);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [longRunningNotified, setLongRunningNotified] = useState(false);
 
   const selectedCount = selectedRemediationIds.size;
   const totalCount = remediationItems.length;
@@ -91,6 +107,70 @@ export const ReviewActionBar: React.FC = () => {
   const isFixDisabled = activeAction !== null || selectedCount === 0;
   const isDeepReview = reviewMode === 'deep';
   const hasInterruption = isDeepReview && Boolean(interruption);
+
+  // ---- progress tracking ----
+  const sessions = flowChatStore.getState().sessions;
+  const childSession = useMemo(() => {
+    if (!childSessionId) return null;
+    return Array.from(sessions.values()).find((s) => s.sessionId === childSessionId) ?? null;
+  }, [sessions, childSessionId]);
+
+  const reviewerProgress = useMemo(() => {
+    if (!childSession || childSession.sessionKind !== 'deep_review') return [];
+    return aggregateReviewerProgress(childSession);
+  }, [childSession]);
+
+  const progressSummary = useMemo(() => {
+    if (reviewerProgress.length === 0) return null;
+    return buildReviewerProgressSummary(reviewerProgress);
+  }, [reviewerProgress]);
+
+  const partialResults = useMemo(() => {
+    if (!childSession || childSession.sessionKind !== 'deep_review') return null;
+    return extractPartialReviewData(childSession);
+  }, [childSession]);
+
+  // ---- error attribution ----
+  const errorAttribution = useMemo(() => {
+    if (!interruption) return null;
+    return buildErrorAttribution(interruption);
+  }, [interruption]);
+
+  // ---- recovery plan ----
+  const recoveryPlan = useMemo(() => {
+    if (!interruption) return null;
+    return buildRecoveryPlan(interruption);
+  }, [interruption]);
+
+  // ---- degradation options ----
+  const degradationOptions = useMemo(() => {
+    if (!interruption) return [];
+    return evaluateDegradationOptions(interruption);
+  }, [interruption]);
+
+  // ---- long-running hint ----
+  useEffect(() => {
+    if (phase !== 'fix_running' && phase !== 'resume_running') {
+      setElapsedMs(0);
+      setLongRunningNotified(false);
+      return;
+    }
+    const startTime = Date.now();
+    const interval = setInterval(() => {
+      const elapsed = Date.now() - startTime;
+      setElapsedMs(elapsed);
+      if (elapsed > 3 * 60 * 1000 && !longRunningNotified) {
+        setLongRunningNotified(true);
+        notificationService.info(
+          t('deepReviewActionBar.longRunningHint', {
+            defaultValue: 'Review is still running. This may take a few more minutes.',
+          }),
+          { duration: 5000 },
+        );
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [phase, longRunningNotified, t]);
 
   const phaseConfig = PHASE_CONFIG[phase];
   const PhaseIcon = phaseConfig.icon;
@@ -287,6 +367,40 @@ export const ReviewActionBar: React.FC = () => {
     await handleStartFixing(false, remainingSet);
   }, [reviewData, childSessionId, remainingFixIds, store, handleStartFixing]);
 
+  const handleRetryResume = useCallback(async () => {
+    if (!interruption) return;
+    await handleContinueReview();
+  }, [interruption, handleContinueReview]);
+
+  const handleRetryWithDifferentModel = useCallback(async () => {
+    if (!interruption) return;
+    globalEventBus.emit('settings:open', { tab: 'models' });
+  }, [interruption]);
+
+  const handleViewPartialResults = useCallback(() => {
+    setShowPartialResults(true);
+  }, []);
+
+  const handleDegradationAction = useCallback((type: string) => {
+    if (type === 'view_partial') {
+      setShowPartialResults(true);
+    } else if (type === 'reduce_reviewers') {
+      notificationService.info(
+        t('deepReviewActionBar.degradation.reduceReviewersPending', {
+          defaultValue: 'Reduced reviewer mode will be supported in a future update.',
+        }),
+        { duration: 3000 },
+      );
+    } else if (type === 'compress_context') {
+      notificationService.info(
+        t('deepReviewActionBar.degradation.compressContextPending', {
+          defaultValue: 'Context compression will be supported in a future update.',
+        }),
+        { duration: 3000 },
+      );
+    }
+  }, [t]);
+
   const handleCopyDiagnostics = useCallback(async () => {
     const detail = interruption?.errorDetail;
     if (!detail) return;
@@ -351,6 +465,34 @@ export const ReviewActionBar: React.FC = () => {
   }, [interruption, t]);
 
   const phaseTitle = useMemo(() => {
+    if (hasInterruption && interruption?.errorDetail && errorAttribution) {
+      const categoryLabel = t(errorAttribution.title, { defaultValue: errorAttribution.category });
+      if (phase === 'review_interrupted') {
+        return t('deepReviewActionBar.reviewInterruptedWithReason', {
+          reason: categoryLabel,
+          defaultValue: `Deep review interrupted: ${categoryLabel}`,
+        });
+      }
+      if (phase === 'resume_blocked') {
+        return t('deepReviewActionBar.resumeBlockedWithReason', {
+          reason: categoryLabel,
+          defaultValue: `Cannot continue: ${categoryLabel}`,
+        });
+      }
+      if (phase === 'resume_failed') {
+        return t('deepReviewActionBar.resumeFailedWithReason', {
+          reason: categoryLabel,
+          defaultValue: `Continue failed: ${categoryLabel}`,
+        });
+      }
+      if (phase === 'review_error') {
+        return t('deepReviewActionBar.reviewErrorWithReason', {
+          reason: categoryLabel,
+          defaultValue: `Review error: ${categoryLabel}`,
+        });
+      }
+    }
+
     switch (phase) {
       case 'review_completed':
         return t(isDeepReview ? 'reviewActionBar.reviewCompletedDeep' : 'reviewActionBar.reviewCompletedStandard', {
@@ -395,7 +537,7 @@ export const ReviewActionBar: React.FC = () => {
       default:
         return '';
     }
-  }, [phase, isDeepReview, t]);
+  }, [phase, isDeepReview, t, hasInterruption, interruption, errorAttribution]);
 
   if (dismissed || phase === 'idle' || !childSessionId) {
     return null;
@@ -427,6 +569,189 @@ export const ReviewActionBar: React.FC = () => {
           <span className="deep-review-action-bar__error-message">{errorMessage}</span>
         )}
       </div>
+
+      {/* Running progress */}
+      {(phase === 'fix_running' || phase === 'resume_running') && progressSummary && (
+        <div className="deep-review-action-bar__progress">
+          <span className="deep-review-action-bar__progress-text">
+            {progressSummary.text}
+          </span>
+          {elapsedMs > 0 && (
+            <span className="deep-review-action-bar__elapsed">
+              {t('deepReviewActionBar.elapsedTime', {
+                time: formatElapsedTime(elapsedMs),
+                defaultValue: `Running for ${formatElapsedTime(elapsedMs)}`,
+              })}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Partial results summary on interruption */}
+      {hasInterruption && progressSummary && progressSummary.completed > 0 && (
+        <div className="deep-review-action-bar__partial-summary">
+          <span className="deep-review-action-bar__partial-count">
+            {t('deepReviewActionBar.partialResultsDescription', {
+              completed: progressSummary.completed,
+              total: progressSummary.total,
+              defaultValue: '{{completed}}/{{total}} reviewers completed',
+            })}
+          </span>
+          <button
+            type="button"
+            className="deep-review-action-bar__partial-link"
+            onClick={() => setShowPartialResults(!showPartialResults)}
+          >
+            <Eye size={12} />
+            {showPartialResults
+              ? t('deepReviewActionBar.hidePartialResults', { defaultValue: 'Hide partial results' })
+              : t('deepReviewActionBar.viewPartialResults', { defaultValue: 'View partial results' })}
+          </button>
+        </div>
+      )}
+
+      {/* Partial results detail */}
+      {showPartialResults && partialResults && (
+        <div className="deep-review-action-bar__partial-detail">
+          {partialResults.completedIssues.length > 0 && (
+            <div className="deep-review-action-bar__partial-section">
+              <span className="deep-review-action-bar__partial-section-title">
+                {t('deepReviewActionBar.partialIssues', {
+                  count: partialResults.completedIssues.length,
+                  defaultValue: '{{count}} issues found',
+                })}
+              </span>
+            </div>
+          )}
+          {partialResults.completedRemediationItems.length > 0 && (
+            <div className="deep-review-action-bar__partial-section">
+              <span className="deep-review-action-bar__partial-section-title">
+                {t('deepReviewActionBar.partialRemediationItems', {
+                  count: partialResults.completedRemediationItems.length,
+                  defaultValue: '{{count}} remediation items',
+                })}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Error attribution card */}
+      {hasInterruption && errorAttribution && (
+        <div className={`deep-review-action-bar__attribution deep-review-action-bar__attribution--${errorAttribution.severity}`}>
+          <span className="deep-review-action-bar__attribution-message">
+            {t(errorAttribution.description, { defaultValue: '' })}
+          </span>
+          {errorAttribution.actions.length > 0 && (
+            <div className="deep-review-action-bar__attribution-actions">
+              {errorAttribution.actions.map((action) => (
+                <Button
+                  key={action.code}
+                  variant="secondary"
+                  size="small"
+                  onClick={() => {
+                    if (action.code === 'open_model_settings') {
+                      globalEventBus.emit('settings:open', { tab: 'models' });
+                    } else if (action.code === 'switch_model') {
+                      globalEventBus.emit('settings:open', { tab: 'models' });
+                    } else if (action.code === 'retry' || action.code === 'continue') {
+                      void handleContinueReview();
+                    } else if (action.code === 'wait_and_retry') {
+                      void handleContinueReview();
+                    } else if (action.code === 'copy_diagnostics') {
+                      void handleCopyDiagnostics();
+                    }
+                  }}
+                >
+                  {t(action.labelKey, { defaultValue: action.code })}
+                </Button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Recovery plan preview */}
+      {hasInterruption && recoveryPlan && (
+        <div className="deep-review-action-bar__recovery-plan">
+          <button
+            type="button"
+            className="deep-review-action-bar__recovery-plan-toggle"
+            onClick={() => setShowRecoveryPlan(!showRecoveryPlan)}
+          >
+            <Info size={12} />
+            <span>
+              {showRecoveryPlan
+                ? t('deepReviewActionBar.hideRecoveryPlan', { defaultValue: 'Hide recovery plan' })
+                : t('deepReviewActionBar.showRecoveryPlan', { defaultValue: 'Show recovery plan' })}
+            </span>
+          </button>
+          {showRecoveryPlan && (
+            <div className="deep-review-action-bar__recovery-plan-detail">
+              {recoveryPlan.willPreserve.length > 0 && (
+                <div className="deep-review-action-bar__recovery-item">
+                  <CheckCircle size={12} className="deep-review-action-bar__recovery-icon--preserve" />
+                  <span>
+                    {t('deepReviewActionBar.recoveryPreserve', {
+                      count: recoveryPlan.willPreserve.length,
+                      defaultValue: '{{count}} completed reviewers will be preserved',
+                    })}
+                  </span>
+                </div>
+              )}
+              {recoveryPlan.willRerun.length > 0 && (
+                <div className="deep-review-action-bar__recovery-item">
+                  <RotateCcw size={12} className="deep-review-action-bar__recovery-icon--rerun" />
+                  <span>
+                    {t('deepReviewActionBar.recoveryRerun', {
+                      count: recoveryPlan.willRerun.length,
+                      defaultValue: '{{count}} reviewers will be rerun',
+                    })}
+                  </span>
+                </div>
+              )}
+              {recoveryPlan.willSkip.length > 0 && (
+                <div className="deep-review-action-bar__recovery-item">
+                  <SkipForward size={12} className="deep-review-action-bar__recovery-icon--skip" />
+                  <span>
+                    {t('deepReviewActionBar.recoverySkip', {
+                      count: recoveryPlan.willSkip.length,
+                      defaultValue: '{{count}} reviewers will be skipped',
+                    })}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Context overflow degradation options */}
+      {hasInterruption && interruption?.errorDetail?.category === 'context_overflow' && (
+        <div className="deep-review-action-bar__degradation">
+          <span className="deep-review-action-bar__degradation-title">
+            {t('deepReviewActionBar.contextOverflowTitle', {
+              defaultValue: 'Context limit reached. Choose how to proceed:',
+            })}
+          </span>
+          {degradationOptions.map((option) => (
+            <button
+              key={option.type}
+              type="button"
+              className="deep-review-action-bar__degradation-option"
+              disabled={!option.enabled}
+              onClick={() => handleDegradationAction(option.type)}
+            >
+              <span className="deep-review-action-bar__degradation-label">
+                {t(option.labelKey, { defaultValue: option.type })}
+              </span>
+              <span className="deep-review-action-bar__degradation-desc">
+                {t(option.descriptionKey, { defaultValue: '' })}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Remediation selection (only when review completed and has items) */}
       {phase === 'review_completed' && remediationItems.length > 0 && (
@@ -675,7 +1000,38 @@ export const ReviewActionBar: React.FC = () => {
           </>
         )}
 
-        {(phase === 'fix_completed' || phase === 'fix_failed' || phase === 'fix_timeout' || phase === 'review_error' || phase === 'resume_failed') && (
+        {phase === 'resume_failed' && (
+          <>
+            <Button
+              variant="primary"
+              size="small"
+              isLoading={activeAction === 'resume'}
+              onClick={() => void handleRetryResume()}
+            >
+              <RotateCcw size={14} />
+              {t('deepReviewActionBar.retryResume', { defaultValue: 'Retry' })}
+            </Button>
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={() => void handleRetryWithDifferentModel()}
+            >
+              {t('deepReviewActionBar.retryWithDifferentModel', { defaultValue: 'Try different model' })}
+            </Button>
+            {partialResults?.hasPartialResults && (
+              <Button
+                variant="ghost"
+                size="small"
+                onClick={handleViewPartialResults}
+              >
+                <Eye size={14} />
+                {t('deepReviewActionBar.viewPartialResults', { defaultValue: 'View partial results' })}
+              </Button>
+            )}
+          </>
+        )}
+
+        {(phase === 'fix_completed' || phase === 'fix_failed' || phase === 'fix_timeout' || phase === 'review_error') && (
           <Button
             variant="ghost"
             size="small"
@@ -688,5 +1044,15 @@ export const ReviewActionBar: React.FC = () => {
     </div>
   );
 };
+
+function formatElapsedTime(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes > 0) {
+    return `${minutes}m ${remainingSeconds}s`;
+  }
+  return `${seconds}s`;
+}
 
 export const DeepReviewActionBar = ReviewActionBar;

--- a/src/web-ui/src/flow_chat/services/DeepReviewService.test.ts
+++ b/src/web-ui/src/flow_chat/services/DeepReviewService.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import {
   DEEP_REVIEW_SLASH_COMMAND,
   buildDeepReviewPromptFromSlashCommand,
+  getDeepReviewLaunchErrorMessage,
   isDeepReviewSlashCommand,
   launchDeepReviewSession,
 } from './DeepReviewService';
@@ -128,14 +129,26 @@ describe('launchDeepReviewSession', () => {
   it('throws and does not cleanup when createBtwChildSession fails', async () => {
     mockCreateBtwChildSession.mockRejectedValue(new Error('Session creation failed'));
 
-    await expect(
-      launchDeepReviewSession({
+    let caughtError: unknown;
+    try {
+      await launchDeepReviewSession({
         parentSessionId: 'parent-123',
         workspacePath: 'D:\\workspace\\repo',
         prompt: 'Review these files',
         displayMessage: 'Deep review started',
-      }),
-    ).rejects.toThrow('Session creation failed');
+      });
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).toBeInstanceOf(Error);
+    expect((caughtError as Error).message).toBe('Deep review failed to start. Please try again.');
+    expect((caughtError as { launchErrorMessageKey?: string }).launchErrorMessageKey).toBe(
+      'deepReviewActionBar.launchError.unknown',
+    );
+    expect(
+      getDeepReviewLaunchErrorMessage(caughtError, (key: string) => `translated:${key}`),
+    ).toBe('translated:deepReviewActionBar.launchError.unknown');
 
     expect(mockCloseBtwSessionInAuxPane).not.toHaveBeenCalled();
     expect(mockDeleteSession).not.toHaveBeenCalled();
@@ -172,23 +185,33 @@ describe('launchDeepReviewSession', () => {
     expect(mockDiscardLocalSession).toHaveBeenCalledWith('child-123');
   });
 
-  it('throws and performs full cleanup when sendMessage fails', async () => {
+  it('classifies sendMessage launch failures after cleanup', async () => {
     mockCreateBtwChildSession.mockResolvedValue({
       childSessionId: 'child-123',
       parentDialogTurnId: 'turn-456',
     });
-    mockSendMessage.mockRejectedValue(new Error('Send failed'));
+    mockSendMessage.mockRejectedValue(new Error('SSE stream connection timeout'));
     mockDeleteSession.mockResolvedValue(undefined);
     mockSessionsMap.set('child-123', { workspacePath: 'D:\\workspace\\repo' });
 
-    await expect(
-      launchDeepReviewSession({
+    let caughtError: unknown;
+    try {
+      await launchDeepReviewSession({
         parentSessionId: 'parent-123',
         workspacePath: 'D:\\workspace\\repo',
         prompt: 'Review these files',
         displayMessage: 'Deep review started',
-      }),
-    ).rejects.toThrow('Send failed');
+      });
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).toBeInstanceOf(Error);
+    expect((caughtError as Error).message).toBe('Network connection was interrupted before Deep Review could start.');
+    expect((caughtError as { launchErrorMessageKey?: string }).launchErrorMessageKey).toBe(
+      'deepReviewActionBar.launchError.network',
+    );
+    expect((caughtError as { launchErrorCategory?: string }).launchErrorCategory).toBe('network');
 
     expect(mockCloseBtwSessionInAuxPane).toHaveBeenCalledWith('child-123');
     expect(mockDeleteSession).toHaveBeenCalled();

--- a/src/web-ui/src/flow_chat/services/DeepReviewService.ts
+++ b/src/web-ui/src/flow_chat/services/DeepReviewService.ts
@@ -11,6 +11,7 @@ import {
   prepareDefaultReviewTeamForLaunch,
 } from '@/shared/services/reviewTeamService';
 import { DEEP_REVIEW_COMMAND_RE } from '../utils/deepReviewConstants';
+import { classifyLaunchError } from '../utils/deepReviewExperience';
 
 const log = createLogger('DeepReviewService');
 
@@ -34,6 +35,23 @@ interface FailedDeepReviewCleanupResult {
   cleanupCompleted: boolean;
   cleanupIssues: string[];
 }
+
+interface DeepReviewLaunchError extends Error {
+  launchErrorCategory?: string;
+  launchErrorActions?: string[];
+  launchErrorMessageKey?: string;
+  launchErrorStep?: string;
+  originalMessage?: string;
+  childSessionId?: string;
+  cleanupCompleted?: boolean;
+  cleanupIssues?: string[];
+}
+
+const LAUNCH_ERROR_DEFAULT_MESSAGES: Record<string, string> = {
+  'deepReviewActionBar.launchError.modelConfig': 'Deep review could not create a review session. Check the model configuration.',
+  'deepReviewActionBar.launchError.network': 'Network connection was interrupted before Deep Review could start.',
+  'deepReviewActionBar.launchError.unknown': 'Deep review failed to start. Please try again.',
+};
 
 function normalizeErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message.trim()) {
@@ -63,6 +81,53 @@ function describeLaunchStep(step: DeepReviewLaunchStep): string {
     default:
       return 'launching deep review';
   }
+}
+
+function createDeepReviewLaunchError(
+  launchStep: DeepReviewLaunchStep,
+  originalError: unknown,
+  childSessionId?: string,
+  cleanupResult?: FailedDeepReviewCleanupResult,
+): DeepReviewLaunchError {
+  const classified = classifyLaunchError(launchStep, originalError);
+  const friendlyError = new Error(
+    LAUNCH_ERROR_DEFAULT_MESSAGES[classified.messageKey] ??
+      LAUNCH_ERROR_DEFAULT_MESSAGES['deepReviewActionBar.launchError.unknown'],
+  ) as DeepReviewLaunchError;
+
+  friendlyError.launchErrorCategory = classified.category;
+  friendlyError.launchErrorActions = classified.actions;
+  friendlyError.launchErrorMessageKey = classified.messageKey;
+  friendlyError.launchErrorStep = classified.step;
+  friendlyError.originalMessage = normalizeErrorMessage(originalError);
+  if (childSessionId) {
+    friendlyError.childSessionId = childSessionId;
+  }
+  if (cleanupResult) {
+    friendlyError.cleanupCompleted = cleanupResult.cleanupCompleted;
+    friendlyError.cleanupIssues = cleanupResult.cleanupIssues;
+  }
+
+  return friendlyError;
+}
+
+export function getDeepReviewLaunchErrorMessage(
+  error: unknown,
+  translate: (key: string, options?: { defaultValue?: string }) => string,
+  fallback = LAUNCH_ERROR_DEFAULT_MESSAGES['deepReviewActionBar.launchError.unknown'],
+): string {
+  const launchError = error as DeepReviewLaunchError | null | undefined;
+  if (launchError?.launchErrorMessageKey) {
+    return translate(launchError.launchErrorMessageKey, {
+      defaultValue: launchError.message || fallback,
+    });
+  }
+
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+
+  return fallback;
 }
 
 function buildLaunchCleanupError(
@@ -254,7 +319,7 @@ export async function launchDeepReviewSession({
     return { childSessionId };
   } catch (error) {
     if (!childSessionId) {
-      throw error;
+      throw createDeepReviewLaunchError(launchStep, error);
     }
 
     const cleanupResult = await cleanupFailedDeepReviewLaunch(childSessionId, launchStep);
@@ -273,6 +338,10 @@ export async function launchDeepReviewSession({
       cleanupIssues: cleanupResult.cleanupIssues,
       error,
     });
+
+    if (launchStep === 'send_start_message' && cleanupResult.cleanupCompleted) {
+      throw createDeepReviewLaunchError(launchStep, error, childSessionId, cleanupResult);
+    }
 
     throw wrappedError;
   }

--- a/src/web-ui/src/flow_chat/utils/deepReviewContinuation.ts
+++ b/src/web-ui/src/flow_chat/utils/deepReviewContinuation.ts
@@ -100,7 +100,7 @@ function findOriginalTarget(session: Session): string {
   return firstTurn?.userMessage?.content?.trim() || 'Unknown Deep Review target.';
 }
 
-function collectReviewerProgress(session: Session): DeepReviewReviewerProgress[] {
+export function collectReviewerProgress(session: Session): DeepReviewReviewerProgress[] {
   const byReviewer = new Map<string, DeepReviewReviewerProgress>();
 
   for (const turn of session.dialogTurns) {

--- a/src/web-ui/src/flow_chat/utils/deepReviewExperience.ts
+++ b/src/web-ui/src/flow_chat/utils/deepReviewExperience.ts
@@ -1,0 +1,391 @@
+/**
+ * Deep Review experience utilities.
+ *
+ * Aggregates raw session/tool state into user-friendly experience data
+ * such as reviewer progress, error attribution, partial results, and
+ * degradation options. All functions are pure and side-effect free.
+ */
+
+import { getAiErrorPresentation } from '@/shared/ai-errors/aiErrorPresenter';
+import type { Session } from '../types/flow-chat';
+import type { CodeReviewRemediationData } from './codeReviewRemediation';
+import type { DeepReviewInterruption, DeepReviewReviewerProgress } from './deepReviewContinuation';
+import { collectReviewerProgress } from './deepReviewContinuation';
+
+// ---------------------------------------------------------------------------
+// Reviewer progress
+// ---------------------------------------------------------------------------
+
+export interface ReviewerProgressItem extends DeepReviewReviewerProgress {
+  /** Human-readable display name */
+  displayName: string;
+}
+
+export interface ReviewerProgressSummary {
+  completed: number;
+  failed: number;
+  timedOut: number;
+  running: number;
+  skipped: number;
+  unknown: number;
+  total: number;
+  /** Localised short text, e.g. "3/5 completed" */
+  text: string;
+}
+
+/**
+ * Aggregate reviewer progress from a live session.
+ * Reuses the existing `collectReviewerProgress` logic.
+ */
+export function aggregateReviewerProgress(
+  session: Session,
+): ReviewerProgressItem[] {
+  const progress = collectReviewerProgress(session);
+  return progress.map((p) => ({
+    ...p,
+    displayName: p.reviewer,
+  }));
+}
+
+export function buildReviewerProgressSummary(
+  progress: ReviewerProgressItem[],
+): ReviewerProgressSummary {
+  const completed = progress.filter((p) => p.status === 'completed').length;
+  const failed = progress.filter((p) => p.status === 'failed').length;
+  const timedOut = progress.filter((p) => p.status === 'timed_out').length;
+  const running = progress.filter((p) => p.status === 'unknown').length;
+  const skipped = progress.filter((p) => p.status === 'cancelled').length;
+  const unknown = progress.filter((p) => p.status === 'unknown').length;
+  const total = progress.length;
+
+  return {
+    completed,
+    failed,
+    timedOut,
+    running,
+    skipped,
+    unknown,
+    total,
+    text: `${completed}/${total} completed`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Partial results extraction
+// ---------------------------------------------------------------------------
+
+export interface PartialReviewData {
+  /** Whether any reviewer completed successfully */
+  hasPartialResults: boolean;
+  /** Number of completed reviewers */
+  completedReviewerCount: number;
+  /** Total reviewer count */
+  totalReviewerCount: number;
+  /** Issues found by completed reviewers */
+  completedIssues: NonNullable<CodeReviewRemediationData['issues']>;
+  /** Remediation items from completed reviewers */
+  completedRemediationItems: string[];
+  /** Summaries from completed reviewers */
+  completedReviewerSummaries: string[];
+}
+
+/**
+ * Extract partial review data from a session that may have been
+ * interrupted before all reviewers finished.
+ */
+export function extractPartialReviewData(
+  session: Session,
+): PartialReviewData | null {
+  const progress = collectReviewerProgress(session);
+  const completedReviewers = progress.filter((p) => p.status === 'completed');
+
+  if (completedReviewers.length === 0) {
+    return null;
+  }
+
+  const completedIssues: NonNullable<CodeReviewRemediationData['issues']> = [];
+  const completedRemediationItems: string[] = [];
+  const completedReviewerSummaries: string[] = [];
+
+  for (const turn of session.dialogTurns) {
+    for (const round of turn.modelRounds) {
+      for (const item of round.items) {
+        if (item.type !== 'tool' || item.toolName !== 'Task') {
+          continue;
+        }
+        const reviewer = String(
+          (item.toolCall.input as Record<string, unknown>)?.subagent_type ??
+            (item.toolCall.input as Record<string, unknown>)?.subagentType ??
+            '',
+        ).trim();
+
+        const isCompleted = completedReviewers.some(
+          (p) => p.reviewer === reviewer,
+        );
+        if (!isCompleted || !item.toolResult?.success) {
+          continue;
+        }
+
+        // Try to parse the tool result for review data.
+        const result = item.toolResult.result;
+        if (typeof result === 'string') {
+          try {
+            const parsed = JSON.parse(result) as Record<string, unknown>;
+            if (parsed.issues && Array.isArray(parsed.issues)) {
+              const issues = parsed.issues as NonNullable<CodeReviewRemediationData['issues']>;
+              completedIssues.push(...issues);
+            }
+            if (parsed.remediation_plan && Array.isArray(parsed.remediation_plan)) {
+              completedRemediationItems.push(...(parsed.remediation_plan as string[]));
+            }
+            if (parsed.summary) {
+              completedReviewerSummaries.push(String(parsed.summary));
+            }
+          } catch {
+            // Not JSON, treat as plain text summary
+            completedReviewerSummaries.push(result);
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    hasPartialResults: true,
+    completedReviewerCount: completedReviewers.length,
+    totalReviewerCount: progress.length,
+    completedIssues,
+    completedRemediationItems,
+    completedReviewerSummaries,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Error attribution
+// ---------------------------------------------------------------------------
+
+export interface ErrorAttribution {
+  category: string;
+  title: string;
+  description: string;
+  severity: 'warning' | 'error';
+  actions: Array<{ code: string; labelKey: string }>;
+}
+
+/**
+ * Build a user-friendly error attribution from an interruption.
+ * Leverages the existing `getAiErrorPresentation` system.
+ */
+export function buildErrorAttribution(
+  interruption: DeepReviewInterruption,
+): ErrorAttribution {
+  const presentation = getAiErrorPresentation(interruption.errorDetail);
+
+  return {
+    category: presentation.category,
+    title: presentation.titleKey,
+    description: presentation.messageKey,
+    severity: presentation.severity,
+    actions: presentation.actions.map((a) => ({
+      code: a.code,
+      labelKey: a.labelKey,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Recovery plan
+// ---------------------------------------------------------------------------
+
+export interface RecoveryPlan {
+  willRerun: string[];
+  willPreserve: string[];
+  willSkip: string[];
+  summaryText: string;
+}
+
+/**
+ * Build a recovery plan that describes what will happen when the user
+ * chooses to continue an interrupted deep review.
+ */
+export function buildRecoveryPlan(
+  interruption: DeepReviewInterruption,
+): RecoveryPlan {
+  const reviewers = interruption.reviewers;
+
+  const willPreserve = reviewers
+    .filter((r) => r.status === 'completed')
+    .map((r) => r.reviewer);
+
+  const willRerun = reviewers
+    .filter(
+      (r) =>
+        r.status === 'failed' ||
+        r.status === 'timed_out' ||
+        r.status === 'cancelled' ||
+        r.status === 'unknown',
+    )
+    .map((r) => r.reviewer);
+
+  const willSkip: string[] = [];
+
+  const parts: string[] = [];
+  if (willPreserve.length > 0) {
+    parts.push(`${willPreserve.length} completed reviewers will be preserved`);
+  }
+  if (willRerun.length > 0) {
+    parts.push(`${willRerun.length} reviewers will be rerun`);
+  }
+  if (willSkip.length > 0) {
+    parts.push(`${willSkip.length} reviewers will be skipped`);
+  }
+
+  return {
+    willRerun,
+    willPreserve,
+    willSkip,
+    summaryText: parts.join('; ') || 'No recovery plan available.',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Degradation options
+// ---------------------------------------------------------------------------
+
+export interface DegradationOption {
+  type: 'reduce_reviewers' | 'compress_context' | 'view_partial';
+  labelKey: string;
+  descriptionKey: string;
+  enabled: boolean;
+}
+
+/**
+ * Evaluate available degradation options when a deep review fails
+ * (especially for context_overflow).
+ */
+export function evaluateDegradationOptions(
+  interruption: DeepReviewInterruption,
+): DegradationOption[] {
+  const hasPartialResults = interruption.reviewers.some(
+    (r) => r.status === 'completed',
+  );
+
+  return [
+    {
+      type: 'reduce_reviewers',
+      labelKey: 'deepReviewActionBar.degradation.reduceReviewers',
+      descriptionKey: 'deepReviewActionBar.degradation.reduceReviewersDesc',
+      enabled: false, // Requires backend support
+    },
+    {
+      type: 'compress_context',
+      labelKey: 'deepReviewActionBar.degradation.compressContext',
+      descriptionKey: 'deepReviewActionBar.degradation.compressContextDesc',
+      enabled: false, // Requires backend support
+    },
+    {
+      type: 'view_partial',
+      labelKey: 'deepReviewActionBar.degradation.viewPartial',
+      descriptionKey: 'deepReviewActionBar.degradation.viewPartialDesc',
+      enabled: hasPartialResults,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Token estimation
+// ---------------------------------------------------------------------------
+
+export interface TokenEstimate {
+  min: number;
+  max: number;
+}
+
+const BASE_TOKENS = 5000;
+const PER_REVIEWER_MIN = 8000;
+const PER_REVIEWER_MAX = 25000;
+
+/**
+ * Rough token consumption estimate for a deep review run.
+ */
+export function estimateTokenConsumption(
+  reviewerCount: number,
+): TokenEstimate {
+  return {
+    min: BASE_TOKENS + reviewerCount * PER_REVIEWER_MIN,
+    max: BASE_TOKENS + reviewerCount * PER_REVIEWER_MAX,
+  };
+}
+
+export function formatTokenCount(count: number): string {
+  if (count >= 1000000) {
+    return `${(count / 1000000).toFixed(1)}M`;
+  }
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(0)}k`;
+  }
+  return String(count);
+}
+
+// ---------------------------------------------------------------------------
+// Launch error classification
+// ---------------------------------------------------------------------------
+
+export interface LaunchErrorInfo {
+  step: string;
+  category: 'model_config' | 'network' | 'unknown';
+  messageKey: string;
+  actions: Array<'retry' | 'open_model_settings'>;
+}
+
+/**
+ * Classify a launch failure into a user-friendly error description.
+ */
+export function classifyLaunchError(
+  step: string,
+  error: unknown,
+): LaunchErrorInfo {
+  const message = error instanceof Error ? error.message : String(error);
+  const lower = message.toLowerCase();
+
+  if (step === 'create_child_session') {
+    if (/model|provider|api key|authentication|unauthorized/i.test(lower)) {
+      return {
+        step,
+        category: 'model_config',
+        messageKey: 'deepReviewActionBar.launchError.modelConfig',
+        actions: ['open_model_settings', 'retry'],
+      };
+    }
+    return {
+      step,
+      category: 'unknown',
+      messageKey: 'deepReviewActionBar.launchError.unknown',
+      actions: ['retry'],
+    };
+  }
+
+  if (step === 'send_start_message') {
+    if (/network|timeout|connection|sse|stream/i.test(lower)) {
+      return {
+        step,
+        category: 'network',
+        messageKey: 'deepReviewActionBar.launchError.network',
+        actions: ['retry'],
+      };
+    }
+    return {
+      step,
+      category: 'unknown',
+      messageKey: 'deepReviewActionBar.launchError.unknown',
+      actions: ['retry'],
+    };
+  }
+
+  return {
+    step,
+    category: 'unknown',
+    messageKey: 'deepReviewActionBar.launchError.unknown',
+    actions: ['retry'],
+  };
+}

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -405,7 +405,41 @@
     "diagnosticsErrorType": "Error type",
     "diagnosticsDescription": "Description",
     "diagnosticsSuggestedActions": "Suggested actions",
-    "diagnosticsTechnicalDetails": "Technical details"
+    "diagnosticsTechnicalDetails": "Technical details",
+    "reviewInterruptedWithReason": "Deep review interrupted: {{reason}}",
+    "resumeBlockedWithReason": "Cannot continue: {{reason}}",
+    "resumeFailedWithReason": "Continue failed: {{reason}}",
+    "reviewErrorWithReason": "Review error: {{reason}}",
+    "retryResume": "Retry",
+    "retryWithDifferentModel": "Try different model",
+    "viewPartialResults": "View partial results",
+    "hidePartialResults": "Hide partial results",
+    "partialResultsDescription": "{{completed}}/{{total}} reviewers completed",
+    "partialIssues": "{{count}} issues found",
+    "partialRemediationItems": "{{count}} remediation items",
+    "contextOverflowTitle": "Context limit reached. Choose how to proceed:",
+    "longRunningHint": "Review is still running. This may take a few more minutes.",
+    "elapsedTime": "Running for {{time}}",
+    "showRecoveryPlan": "Show recovery plan",
+    "hideRecoveryPlan": "Hide recovery plan",
+    "recoveryPreserve": "{{count}} completed reviewers will be preserved",
+    "recoveryRerun": "{{count}} reviewers will be rerun",
+    "recoverySkip": "{{count}} reviewers will be skipped",
+    "degradation": {
+      "reduceReviewers": "Run with core reviewers only",
+      "reduceReviewersDesc": "Skip extra reviewers and keep only core reviewers",
+      "reduceReviewersPending": "Reduced reviewer mode will be supported in a future update.",
+      "compressContext": "Compress context and retry",
+      "compressContextDesc": "Compress completed reviewer results to free up context space",
+      "compressContextPending": "Context compression will be supported in a future update.",
+      "viewPartial": "View partial results",
+      "viewPartialDesc": "View completed reviewer results"
+    },
+    "launchError": {
+      "modelConfig": "Failed to create review session. Please check model configuration.",
+      "network": "Network connection interrupted. Review failed to start.",
+      "unknown": "Review launch failed. Please retry."
+    }
   },
   "reviewActionBar": {
     "reviewCompletedStandard": "Review completed",
@@ -429,7 +463,8 @@
     "time": "You can keep working while it runs; we will only notify you when the whole Deep Review finishes in the background.",
     "dontShowAgain": "Do not show this again",
     "cancel": "Cancel",
-    "confirm": "Start Deep Review"
+    "confirm": "Start Deep Review",
+    "estimatedTokens": "Estimated: {{min}} - {{max}} tokens"
   },
   "flowChatHeader": {
     "turnList": "Turn list",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -405,7 +405,41 @@
     "diagnosticsErrorType": "错误类型",
     "diagnosticsDescription": "错误描述",
     "diagnosticsSuggestedActions": "建议操作",
-    "diagnosticsTechnicalDetails": "技术详情"
+    "diagnosticsTechnicalDetails": "技术详情",
+    "reviewInterruptedWithReason": "深度审核已中断：{{reason}}",
+    "resumeBlockedWithReason": "无法继续：{{reason}}",
+    "resumeFailedWithReason": "继续失败：{{reason}}",
+    "reviewErrorWithReason": "审核出错：{{reason}}",
+    "retryResume": "重试",
+    "retryWithDifferentModel": "尝试其他模型",
+    "viewPartialResults": "查看部分结果",
+    "hidePartialResults": "隐藏部分结果",
+    "partialResultsDescription": "{{completed}}/{{total}} 个 reviewer 已完成",
+    "partialIssues": "发现 {{count}} 个问题",
+    "partialRemediationItems": "{{count}} 个修复项",
+    "contextOverflowTitle": "上下文超出限制，请选择处理方式：",
+    "longRunningHint": "审核仍在进行中，可能需要更长时间...",
+    "elapsedTime": "已运行 {{time}}",
+    "showRecoveryPlan": "显示恢复计划",
+    "hideRecoveryPlan": "隐藏恢复计划",
+    "recoveryPreserve": "{{count}} 个已完成的 reviewer 将保留",
+    "recoveryRerun": "{{count}} 个 reviewer 将重新运行",
+    "recoverySkip": "{{count}} 个 reviewer 将被跳过",
+    "degradation": {
+      "reduceReviewers": "仅运行核心 reviewer",
+      "reduceReviewersDesc": "跳过额外 reviewer，只保留核心 reviewer",
+      "reduceReviewersPending": "精简 reviewer 模式将在后续版本中支持",
+      "compressContext": "压缩上下文后重试",
+      "compressContextDesc": "压缩已完成的 reviewer 结果以释放上下文空间",
+      "compressContextPending": "上下文压缩将在后续版本中支持",
+      "viewPartial": "查看部分结果",
+      "viewPartialDesc": "查看已完成的 reviewer 结果"
+    },
+    "launchError": {
+      "modelConfig": "无法创建审核会话，请检查模型配置",
+      "network": "网络连接中断，审核未能启动",
+      "unknown": "审核启动失败，请重试"
+    }
   },
   "reviewActionBar": {
     "reviewCompletedStandard": "审核已完成",
@@ -429,7 +463,8 @@
     "time": "运行期间可以继续工作；只有整个深度审核在后台完成时才会通知你。",
     "dontShowAgain": "下次不再提示",
     "cancel": "取消",
-    "confirm": "开始深度审核"
+    "confirm": "开始深度审核",
+    "estimatedTokens": "预计消耗：{{min}} - {{max}} tokens"
   },
   "flowChatHeader": {
     "turnList": "轮次列表",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -396,7 +396,41 @@
     "diagnosticsErrorType": "錯誤類型",
     "diagnosticsDescription": "錯誤描述",
     "diagnosticsSuggestedActions": "建議操作",
-    "diagnosticsTechnicalDetails": "技術詳情"
+    "diagnosticsTechnicalDetails": "技術詳情",
+    "reviewInterruptedWithReason": "深度審核已中斷：{{reason}}",
+    "resumeBlockedWithReason": "無法繼續：{{reason}}",
+    "resumeFailedWithReason": "繼續失敗：{{reason}}",
+    "reviewErrorWithReason": "審核出錯：{{reason}}",
+    "retryResume": "重試",
+    "retryWithDifferentModel": "嘗試其他模型",
+    "viewPartialResults": "查看部分結果",
+    "hidePartialResults": "隱藏部分結果",
+    "partialResultsDescription": "{{completed}}/{{total}} 個 reviewer 已完成",
+    "partialIssues": "發現 {{count}} 個問題",
+    "partialRemediationItems": "{{count}} 個修復項",
+    "contextOverflowTitle": "上下文超出限制，請選擇處理方式：",
+    "longRunningHint": "審核仍在進行中，可能需要更長時間...",
+    "elapsedTime": "已運行 {{time}}",
+    "showRecoveryPlan": "顯示恢復計劃",
+    "hideRecoveryPlan": "隱藏恢復計劃",
+    "recoveryPreserve": "{{count}} 個已完成的 reviewer 將保留",
+    "recoveryRerun": "{{count}} 個 reviewer 將重新運行",
+    "recoverySkip": "{{count}} 個 reviewer 將被跳過",
+    "degradation": {
+      "reduceReviewers": "僅運行核心 reviewer",
+      "reduceReviewersDesc": "跳過額外 reviewer，只保留核心 reviewer",
+      "reduceReviewersPending": "精簡 reviewer 模式將在後續版本中支持",
+      "compressContext": "壓縮上下文後重試",
+      "compressContextDesc": "壓縮已完成的 reviewer 結果以釋放上下文空間",
+      "compressContextPending": "上下文壓縮將在後續版本中支持",
+      "viewPartial": "查看部分結果",
+      "viewPartialDesc": "查看已完成的 reviewer 結果"
+    },
+    "launchError": {
+      "modelConfig": "無法創建審核會話，請檢查模型配置",
+      "network": "網絡連接中斷，審核未能啟動",
+      "unknown": "審核啟動失敗，請重試"
+    }
   },
   "reviewActionBar": {
     "reviewCompletedStandard": "審核已完成",
@@ -420,7 +454,8 @@
     "time": "運行期間可以繼續工作；只有整個深度審核在後台完成時才會通知你。",
     "dontShowAgain": "下次不再提示",
     "cancel": "取消",
-    "confirm": "開始深度審核"
+    "confirm": "開始深度審核",
+    "estimatedTokens": "預計消耗：{{min}} - {{max}} tokens"
   },
   "flowChatHeader": {
     "turnList": "輪次列表",


### PR DESCRIPTION
Add comprehensive error handling, progress tracking, and recovery options for deep review interruptions and failures.

- Add deepReviewExperience.ts utility for progress aggregation, error attribution, recovery plans, and degradation options
- Extend DeepReviewActionBar with reviewer progress display, partial results visibility, error attribution cards, recovery plan preview, and context overflow degradation
- Add retry options for resume_failed state (retry, switch model, view partial results)
- Add token consumption estimate to consent dialog
- Add friendly launch error classification in DeepReviewService
- Add long-running hint after 3 minutes
- Add i18n strings for all new UI elements (zh-CN, en-US, zh-TW)
- Update DeepReviewService test for new error format