### PR TITLE
Fix nav workspace row overflow

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -519,6 +519,8 @@ $_section-header-height: 24px;
 
   &__sections {
     flex: 1 1 auto;
+    min-width: 0;
+    max-width: 100%;
     overflow-y: auto;
     overflow-x: hidden;
     // No padding-top: separation from top-actions is only .bitfun-nav-panel__top-actions padding-bottom.
@@ -1029,6 +1031,8 @@ $_section-header-height: 24px;
   &__collapsible-inner {
     overflow: visible;
     min-height: 0;
+    min-width: 0;
+    max-width: 100%;
   }
 
   // ──────────────────────────────────────────────
@@ -1038,6 +1042,8 @@ $_section-header-height: 24px;
   &__items {
     display: flex;
     flex-direction: column;
+    min-width: 0;
+    max-width: 100%;
     padding: 2px $size-gap-2;
     gap: 2px;
 

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
@@ -12,6 +12,8 @@
   &__inline-list {
     display: flex;
     flex-direction: column;
+    min-width: 0;
+    max-width: 100%;
     padding: 2px $size-gap-2 2px;
     gap: 1px;
     // No vertical margin: spacing between assistant blocks comes from 2px top/bottom padding only
@@ -59,6 +61,8 @@
     display: flex;
     align-items: center;
     gap: 5px;
+    min-width: 0;
+    max-width: 100%;
     height: 26px;
     padding: 0 $size-gap-1;
     border: none;
@@ -69,6 +73,7 @@
     font-weight: 400;
     cursor: pointer;
     width: 100%;
+    overflow: hidden;
     text-align: left;
     transition: color $motion-fast $easing-standard,
                 background $motion-fast $easing-standard;
@@ -181,6 +186,8 @@
   &__inline-item-main {
     flex: 1;
     min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
     display: flex;
     align-items: center;
     gap: 6px;

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
@@ -5,6 +5,9 @@
   &__workspace-list {
     display: flex;
     flex-direction: column;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
     gap: 0;
     padding: 2px 0 0;
 
@@ -18,6 +21,9 @@
   &__workspace-group {
     display: flex;
     flex-direction: column;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
     gap: $size-gap-1;
   }
 
@@ -75,6 +81,10 @@
     position: relative;
     display: flex;
     flex-direction: column;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
     gap: 2px;
     padding: 2px $size-gap-1;
     border-radius: $size-radius-base;
@@ -154,7 +164,9 @@
     display: flex;
     align-items: center;
     width: 100%;
+    min-width: 0;
     min-height: 30px;
+    overflow: hidden;
     border-radius: 6px;
     color: var(--color-text-primary);
     background: var(--color-bg-primary);
@@ -237,7 +249,7 @@
     align-items: center;
     gap: 6px;
     min-height: 30px;
-    padding: 0 58px 0 4px;
+    padding: 0 4px;
     border: none;
     border-radius: 0 6px 6px 0;
     background: transparent;
@@ -466,13 +478,12 @@
   }
 
   &__workspace-item-menu {
-    position: absolute;
-    top: 50%;
-    right: 6px;
-    transform: translateY(-50%);
     display: inline-flex;
     align-items: center;
+    flex: 0 0 auto;
     gap: 4px;
+    margin-left: 4px;
+    padding-right: 2px;
     transition: opacity $motion-fast $easing-standard,
                 visibility $motion-fast $easing-standard;
   }
@@ -580,6 +591,11 @@
   }
 
   &__workspace-item-sessions {
+    position: relative;
+    z-index: 0;
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: clip;
     transition: opacity $motion-fast $easing-standard;
     opacity: 1;
 
@@ -605,6 +621,9 @@
     border-radius: $size-radius-base;
     display: flex;
     flex-direction: column;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
     gap: 0;
 
     &.is-drag-active {
@@ -635,6 +654,10 @@
     position: relative;
     display: flex;
     flex-direction: column;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
     gap: 2px;
     padding: $size-gap-1;
     border-radius: $size-radius-base;
@@ -673,6 +696,8 @@
     display: flex;
     align-items: center;
     width: 100%;
+    min-width: 0;
+    overflow: hidden;
     border-radius: 6px;
     color: var(--color-text-secondary);
     background: var(--color-bg-primary);
@@ -800,7 +825,7 @@
     align-items: center;
     gap: 6px;
     min-height: 44px;
-    padding: 0 58px 0 6px;
+    padding: 0 6px;
     border: none;
     border-radius: 0 6px 6px 0;
     background: transparent;
@@ -843,13 +868,12 @@
   }
 
   &__assistant-item-menu {
-    position: absolute;
-    top: 50%;
-    right: 6px;
-    transform: translateY(-50%);
     display: inline-flex;
     align-items: center;
+    flex: 0 0 auto;
     gap: 4px;
+    margin-left: 4px;
+    padding-right: 2px;
     transition: opacity $motion-fast $easing-standard,
                 visibility $motion-fast $easing-standard;
   }
@@ -876,6 +900,11 @@
   }
 
   &__assistant-item-sessions {
+    position: relative;
+    z-index: 0;
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: clip;
     transition: opacity $motion-fast $easing-standard;
     opacity: 1;
 

--- a/src/web-ui/src/app/scenes/session/SessionScene.scss
+++ b/src/web-ui/src/app/scenes/session/SessionScene.scss
@@ -10,6 +10,8 @@
   display: flex;
   flex-direction: row;
   flex: 1;
+  min-width: 0;
+  max-width: 100%;
   height: 100%;
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
## Summary
- Constrain nav panel/workspace/session flex containers to prevent long session titles from widening the left nav
- Keep workspace and assistant row action buttons in the row flow so they remain visible

## Tests
- pnpm run lint:web
- pnpm run type-check:web
- pnpm --dir src/web-ui run test:run