### PR TITLE
feat(web-ui): workspace flashgrep index modal and row layout

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { Folder, FolderOpen, MoreHorizontal, FolderSearch, Plus, ChevronDown, Trash2, RotateCcw, Copy, FileText, GitBranch } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { DotMatrixArrowRightIcon } from './DotMatrixArrowRightIcon';
-import { Button, ConfirmDialog, Tooltip } from '@/component-library';
+import { Button, ConfirmDialog, Modal, Tooltip } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n';
 import { i18nService } from '@/infrastructure/i18n';
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
@@ -130,6 +130,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
   const [isDeletingWorktree, setIsDeletingWorktree] = useState(false);
   const [isResettingWorkspace, setIsResettingWorkspace] = useState(false);
   const [sessionsCollapsed, setSessionsCollapsed] = useState(false);
+  const [searchIndexModalOpen, setSearchIndexModalOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuAnchorRef = useRef<HTMLDivElement>(null);
   const menuPopoverRef = useRef<HTMLDivElement>(null);
@@ -825,13 +826,131 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
             </span>
           </span>
         </button>
-        <button
-          type="button"
-          className="bitfun-nav-panel__workspace-item-name-btn"
-          onClick={() => { void handleCardNameClick(); }}
-        >
-          <span className={`bitfun-nav-panel__workspace-item-title${isRemoteWorkspace(workspace) ? ' is-remote' : ''}`}>
-            <span className="bitfun-nav-panel__workspace-item-label">{workspaceDisplayName}</span>
+        <div className="bitfun-nav-panel__workspace-item-name-cluster">
+          <div className="bitfun-nav-panel__workspace-item-name-stack">
+            <div className="bitfun-nav-panel__workspace-item-name-row">
+              <button
+                type="button"
+                className="bitfun-nav-panel__workspace-item-name-btn"
+                onClick={() => { void handleCardNameClick(); }}
+              >
+                <span className="bitfun-nav-panel__workspace-item-name-line">
+                  <span className="bitfun-nav-panel__workspace-item-label">{workspaceDisplayName}</span>
+                </span>
+              </button>
+              {searchIndexIndicator && (
+                <>
+                  <Tooltip
+                    placement="right"
+                    content={tFiles('search.index.indicator.hoverTooltip', {
+                      status: [
+                        searchIndexIndicator.title,
+                        searchIndexIndicator.activeTaskLabel ?? searchIndexIndicator.phaseLabel,
+                      ].join(' · '),
+                    })}
+                  >
+                    <button
+                      type="button"
+                      className={`bitfun-nav-panel__workspace-index-indicator is-${searchIndexIndicator.tone}`}
+                      aria-label={searchIndexIndicator.ariaLabel}
+                      aria-expanded={searchIndexModalOpen}
+                      onClick={e => {
+                        e.stopPropagation();
+                        setSearchIndexModalOpen(true);
+                      }}
+                    />
+                  </Tooltip>
+                  <Modal
+                    isOpen={searchIndexModalOpen}
+                    onClose={() => setSearchIndexModalOpen(false)}
+                    title={tFiles('search.index.indicator.label')}
+                    size="small"
+                    contentInset
+                    contentClassName="bitfun-nav-panel__workspace-index-modal-content"
+                  >
+                    <div className={`bitfun-nav-panel__workspace-index-tooltip is-${searchIndexIndicator.tone}`}>
+                      <div className="bitfun-nav-panel__workspace-index-tooltip-header">
+                        <div className="bitfun-nav-panel__workspace-index-tooltip-heading">
+                          <span className={`bitfun-nav-panel__workspace-index-tooltip-dot is-${searchIndexIndicator.tone}`} aria-hidden="true" />
+                          <div className="bitfun-nav-panel__workspace-index-tooltip-title-wrap">
+                            <span className="bitfun-nav-panel__workspace-index-tooltip-title">
+                              {searchIndexIndicator.title}
+                            </span>
+                            <span className="bitfun-nav-panel__workspace-index-tooltip-phase">
+                              {searchIndexIndicator.activeTaskLabel ?? searchIndexIndicator.phaseLabel}
+                            </span>
+                          </div>
+                        </div>
+                        <span className={`bitfun-nav-panel__workspace-index-tooltip-badge is-${searchIndexIndicator.tone}`}>
+                          {searchIndexIndicator.phaseLabel}
+                        </span>
+                      </div>
+                      <div className="bitfun-nav-panel__workspace-index-tooltip-summary">
+                        {searchIndexIndicator.activeTaskMessage ?? searchIndexIndicator.summary}
+                      </div>
+                      {searchIndexIndicator.progressLabel ? (
+                        <div className="bitfun-nav-panel__workspace-index-tooltip-progress">
+                          <div className="bitfun-nav-panel__workspace-index-tooltip-progress-head">
+                            <span>{searchIndexIndicator.progressLabel}</span>
+                            {searchIndexIndicator.progressPercentLabel ? (
+                              <span className="bitfun-nav-panel__workspace-index-tooltip-progress-value">
+                                {searchIndexIndicator.progressPercentLabel}
+                              </span>
+                            ) : null}
+                          </div>
+                          {typeof searchIndexIndicator.progressPercent === 'number' ? (
+                            <div className="bitfun-nav-panel__workspace-index-tooltip-progress-bar" aria-hidden="true">
+                              <span
+                                className={`bitfun-nav-panel__workspace-index-tooltip-progress-fill is-${searchIndexIndicator.tone}`}
+                                style={{ width: `${searchIndexIndicator.progressPercent}%` }}
+                              />
+                            </div>
+                          ) : null}
+                        </div>
+                      ) : null}
+                      {searchIndexIndicator.dirtyFilesLabel ? (
+                        <div className="bitfun-nav-panel__workspace-index-tooltip-meta">
+                          {searchIndexIndicator.dirtyFilesLabel}
+                        </div>
+                      ) : null}
+                      {searchIndexIndicator.rebuildRecommended ? (
+                        <div className="bitfun-nav-panel__workspace-index-tooltip-meta is-warning">
+                          {tFiles('search.index.indicator.rebuildRecommended')}
+                        </div>
+                      ) : null}
+                      {!searchIndexIndicator.probeHealthy ? (
+                        <div className="bitfun-nav-panel__workspace-index-tooltip-meta is-warning">
+                          {tFiles('search.index.indicator.probeDegraded')}
+                        </div>
+                      ) : null}
+                      {searchIndexIndicator.errorText ? (
+                        <div className="bitfun-nav-panel__workspace-index-tooltip-error">
+                          {searchIndexIndicator.errorText}
+                        </div>
+                      ) : null}
+                      <div className="bitfun-nav-panel__workspace-index-tooltip-actions">
+                        <Button
+                          size="small"
+                          variant={searchIndexActionKind === 'build' ? 'accent' : 'secondary'}
+                          onClick={() => {
+                            void handleSearchIndexAction();
+                          }}
+                          disabled={
+                            workspaceSearchIndex.loading
+                            || workspaceSearchIndex.actionRunning
+                            || workspaceSearchIndex.hasActiveTask
+                          }
+                        >
+                          {workspaceSearchIndex.actionRunning || workspaceSearchIndex.hasActiveTask
+                            ? tFiles('search.index.actions.running')
+                            : searchIndexActionLabel}
+                        </Button>
+                      </div>
+                    </div>
+                  </Modal>
+                </>
+              )}
+            </div>
             {isRemoteWorkspace(workspace) && (
               <span className="bitfun-nav-panel__workspace-item-subtitle">
                 <span
@@ -841,104 +960,10 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
                 <span>{workspace.connectionName}</span>
               </span>
             )}
-          </span>
-        </button>
+          </div>
+        </div>
 
         <div className="bitfun-nav-panel__workspace-item-actions">
-          {searchIndexIndicator && (
-            <Tooltip
-              interactive
-              placement="right"
-              content={(
-                <div className={`bitfun-nav-panel__workspace-index-tooltip is-${searchIndexIndicator.tone}`}>
-                  <div className="bitfun-nav-panel__workspace-index-tooltip-header">
-                    <div className="bitfun-nav-panel__workspace-index-tooltip-heading">
-                      <span className={`bitfun-nav-panel__workspace-index-tooltip-dot is-${searchIndexIndicator.tone}`} aria-hidden="true" />
-                      <div className="bitfun-nav-panel__workspace-index-tooltip-title-wrap">
-                        <span className="bitfun-nav-panel__workspace-index-tooltip-title">
-                          {searchIndexIndicator.title}
-                        </span>
-                        <span className="bitfun-nav-panel__workspace-index-tooltip-phase">
-                          {searchIndexIndicator.activeTaskLabel ?? searchIndexIndicator.phaseLabel}
-                        </span>
-                      </div>
-                    </div>
-                    <span className={`bitfun-nav-panel__workspace-index-tooltip-badge is-${searchIndexIndicator.tone}`}>
-                      {searchIndexIndicator.phaseLabel}
-                    </span>
-                  </div>
-                  <div className="bitfun-nav-panel__workspace-index-tooltip-summary">
-                    {searchIndexIndicator.activeTaskMessage ?? searchIndexIndicator.summary}
-                  </div>
-                  {searchIndexIndicator.progressLabel ? (
-                    <div className="bitfun-nav-panel__workspace-index-tooltip-progress">
-                      <div className="bitfun-nav-panel__workspace-index-tooltip-progress-head">
-                        <span>{searchIndexIndicator.progressLabel}</span>
-                        {searchIndexIndicator.progressPercentLabel ? (
-                          <span className="bitfun-nav-panel__workspace-index-tooltip-progress-value">
-                            {searchIndexIndicator.progressPercentLabel}
-                          </span>
-                        ) : null}
-                      </div>
-                      {typeof searchIndexIndicator.progressPercent === 'number' ? (
-                        <div className="bitfun-nav-panel__workspace-index-tooltip-progress-bar" aria-hidden="true">
-                          <span
-                            className={`bitfun-nav-panel__workspace-index-tooltip-progress-fill is-${searchIndexIndicator.tone}`}
-                            style={{ width: `${searchIndexIndicator.progressPercent}%` }}
-                          />
-                        </div>
-                      ) : null}
-                    </div>
-                  ) : null}
-                  {searchIndexIndicator.dirtyFilesLabel ? (
-                    <div className="bitfun-nav-panel__workspace-index-tooltip-meta">
-                      {searchIndexIndicator.dirtyFilesLabel}
-                    </div>
-                  ) : null}
-                  {searchIndexIndicator.rebuildRecommended ? (
-                    <div className="bitfun-nav-panel__workspace-index-tooltip-meta is-warning">
-                      {tFiles('search.index.indicator.rebuildRecommended')}
-                    </div>
-                  ) : null}
-                  {!searchIndexIndicator.probeHealthy ? (
-                    <div className="bitfun-nav-panel__workspace-index-tooltip-meta is-warning">
-                      {tFiles('search.index.indicator.probeDegraded')}
-                    </div>
-                  ) : null}
-                  {searchIndexIndicator.errorText ? (
-                    <div className="bitfun-nav-panel__workspace-index-tooltip-error">
-                      {searchIndexIndicator.errorText}
-                    </div>
-                  ) : null}
-                  <div className="bitfun-nav-panel__workspace-index-tooltip-actions">
-                    <Button
-                      size="small"
-                      variant={searchIndexActionKind === 'build' ? 'accent' : 'secondary'}
-                      onClick={() => {
-                        void handleSearchIndexAction();
-                      }}
-                      disabled={
-                        workspaceSearchIndex.loading
-                        || workspaceSearchIndex.actionRunning
-                        || workspaceSearchIndex.hasActiveTask
-                      }
-                    >
-                      {workspaceSearchIndex.actionRunning || workspaceSearchIndex.hasActiveTask
-                        ? tFiles('search.index.actions.running')
-                        : searchIndexActionLabel}
-                    </Button>
-                  </div>
-                </div>
-              )}
-            >
-              <span
-                className={`bitfun-nav-panel__workspace-index-indicator is-${searchIndexIndicator.tone}`}
-                aria-label={searchIndexIndicator.ariaLabel}
-                role="status"
-              />
-            </Tooltip>
-          )}
-
           <div className="bitfun-nav-panel__workspace-item-menu" ref={menuRef}>
             <Tooltip content={t('nav.items.project')} placement="right" followCursor>
               <button

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
@@ -12,7 +12,7 @@
 
     &.is-dragging {
       .bitfun-nav-panel__workspace-item {
-        cursor: grabbing;
+        cursor: default;
       }
     }
   }
@@ -93,7 +93,7 @@
       opacity: 0.42;
 
       .bitfun-nav-panel__workspace-item-card {
-        cursor: grabbing;
+        cursor: default;
       }
     }
 
@@ -129,8 +129,12 @@
         }
       }
 
-      .bitfun-nav-panel__workspace-item-name-btn {
+      .bitfun-nav-panel__workspace-item-name-cluster {
         border-radius: 0 6px 6px 0;
+      }
+
+      .bitfun-nav-panel__workspace-item-name-btn {
+        border-radius: 0;
       }
     }
 
@@ -172,10 +176,6 @@
                 box-shadow $motion-fast $easing-standard;
 
 
-
-    &[draggable='true'] {
-      cursor: grab;
-    }
 
     &:hover {
       .bitfun-nav-panel__workspace-item-icon-default {
@@ -239,16 +239,43 @@
     }
   }
 
-  &__workspace-item-name-btn {
+  &__workspace-item-name-cluster {
+    display: inline-flex;
+    align-items: stretch;
     flex: 1 1 0;
     min-width: 0;
+  }
+
+  &__workspace-item-name-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1px;
+    flex: 1 1 0;
+    min-width: 0;
+    max-width: 100%;
+    padding: 0 4px;
+  }
+
+  &__workspace-item-name-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+    width: 100%;
+  }
+
+  &__workspace-item-name-btn {
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: 100%;
     display: flex;
     align-items: center;
     gap: 6px;
     min-height: 30px;
-    padding: 0 4px;
+    padding: 0;
     border: none;
-    border-radius: 0 6px 6px 0;
+    border-radius: 0;
     background: transparent;
     color: inherit;
     cursor: pointer;
@@ -256,25 +283,23 @@
     text-align: left;
   }
 
-  &__workspace-item.is-active &__workspace-item-name-btn {
+  &__workspace-item.is-active &__workspace-item-name-stack {
     padding-right: calc(
+      4px +
       var(--bitfun-nav-row-action-size) +
-      var(--bitfun-nav-row-action-offset) +
-      4px
+      var(--bitfun-nav-row-action-offset)
     );
   }
 
-  &__workspace-item:hover &__workspace-item-name-btn,
-  &__workspace-item.is-menu-open &__workspace-item-name-btn,
-  &__workspace-item:focus-within &__workspace-item-name-btn {
+  &__workspace-item:hover &__workspace-item-name-stack,
+  &__workspace-item.is-menu-open &__workspace-item-name-stack,
+  &__workspace-item:focus-within &__workspace-item-name-stack {
     padding-right: calc(
-      var(--bitfun-nav-row-action-size) +
-      var(--bitfun-nav-row-action-size) +
+      4px +
       var(--bitfun-nav-row-action-size) +
       var(--bitfun-nav-row-action-gap) +
-      var(--bitfun-nav-row-action-gap) +
-      var(--bitfun-nav-row-action-offset) +
-      4px
+      var(--bitfun-nav-row-action-size) +
+      var(--bitfun-nav-row-action-offset)
     );
   }
 
@@ -416,6 +441,14 @@
     }
   }
 
+  &__workspace-item-name-line {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    flex: 1 1 0;
+    overflow: hidden;
+  }
+
   &__workspace-item-subtitle {
     display: inline-flex;
     align-items: center;
@@ -461,72 +494,43 @@
   }
 
   &__workspace-index-indicator {
-    --bitfun-index-tone: var(--color-text-muted);
-
     display: inline-flex;
     flex-shrink: 0;
-    width: 10px;
-    height: 10px;
+    width: 7px;
+    height: 7px;
     border-radius: 50%;
-    box-shadow:
-      0 0 0 1px color-mix(in srgb, var(--bitfun-index-tone) 18%, transparent),
-      inset 0 1px 0 color-mix(in srgb, #fff 34%, transparent);
-    transition: transform $motion-fast $easing-standard,
-                box-shadow $motion-fast $easing-standard,
-                opacity $motion-fast $easing-standard,
-                filter $motion-fast $easing-standard;
-    cursor: default;
+    appearance: none;
+    padding: 0;
+    margin: 0;
+    border: none;
+    font: inherit;
+    vertical-align: middle;
+    cursor: pointer;
+    transition: opacity $motion-fast $easing-standard;
 
     &:hover {
-      transform: scale(1.08);
-      filter: saturate(1.08);
+      opacity: 0.88;
     }
 
     &.is-green {
-      --bitfun-index-tone: var(--color-success, #36c275);
-      background:
-        radial-gradient(circle at 30% 30%, color-mix(in srgb, #fff 40%, transparent), transparent 45%),
-        var(--bitfun-index-tone);
-      box-shadow:
-        0 0 0 1px color-mix(in srgb, var(--bitfun-index-tone) 30%, transparent),
-        0 0 12px color-mix(in srgb, var(--bitfun-index-tone) 30%, transparent),
-        inset 0 1px 0 color-mix(in srgb, #fff 34%, transparent);
+      background: var(--color-success, #36c275);
     }
 
     &.is-yellow {
-      --bitfun-index-tone: var(--color-warning, #e8b54b);
-      background:
-        radial-gradient(circle at 30% 30%, color-mix(in srgb, #fff 40%, transparent), transparent 45%),
-        var(--bitfun-index-tone);
-      box-shadow:
-        0 0 0 1px color-mix(in srgb, var(--bitfun-index-tone) 30%, transparent),
-        0 0 12px color-mix(in srgb, var(--bitfun-index-tone) 28%, transparent),
-        inset 0 1px 0 color-mix(in srgb, #fff 34%, transparent);
-      animation: bitfun-status-dot-pulse 1.4s ease-in-out infinite;
+      background: var(--color-warning, #e8b54b);
     }
 
     &.is-gray {
-      --bitfun-index-tone: color-mix(in srgb, var(--color-text-muted) 75%, var(--element-bg-medium));
-      background:
-        radial-gradient(circle at 30% 30%, color-mix(in srgb, #fff 28%, transparent), transparent 45%),
-        var(--bitfun-index-tone);
-      box-shadow:
-        0 0 0 1px color-mix(in srgb, var(--bitfun-index-tone) 22%, transparent),
-        inset 0 1px 0 color-mix(in srgb, #fff 22%, transparent);
-      opacity: 0.9;
+      background: color-mix(in srgb, var(--color-text-muted) 78%, var(--element-bg-medium));
     }
 
     &.is-red {
-      --bitfun-index-tone: var(--color-error, #e05d5d);
-      background:
-        radial-gradient(circle at 30% 30%, color-mix(in srgb, #fff 38%, transparent), transparent 45%),
-        var(--bitfun-index-tone);
-      box-shadow:
-        0 0 0 1px color-mix(in srgb, var(--bitfun-index-tone) 30%, transparent),
-        0 0 12px color-mix(in srgb, var(--bitfun-index-tone) 30%, transparent),
-        inset 0 1px 0 color-mix(in srgb, #fff 34%, transparent);
-      animation: bitfun-status-dot-pulse 1s ease-in-out infinite;
+      background: var(--color-error, #e05d5d);
     }
+  }
+
+  &__workspace-index-modal-content {
+    overflow-x: hidden;
   }
 
   &__workspace-index-tooltip {
@@ -535,9 +539,11 @@
     display: flex;
     flex-direction: column;
     gap: 10px;
-    min-width: 236px;
-    max-width: 296px;
-    padding: 2px;
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    box-sizing: border-box;
+    padding: 12px 0 16px;
     color: var(--color-text-primary);
 
     &.is-green {
@@ -1011,7 +1017,7 @@
       opacity: 0.42;
 
       .bitfun-nav-panel__assistant-item-card {
-        cursor: grabbing;
+        cursor: default;
       }
     }
 
@@ -1046,10 +1052,6 @@
     transition: color $motion-fast $easing-standard,
                 background $motion-fast $easing-standard,
                 box-shadow $motion-fast $easing-standard;
-
-    &[draggable='true'] {
-      cursor: grab;
-    }
 
     &:hover {
       .bitfun-nav-panel__assistant-item-avatar-letter {

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
@@ -26,6 +26,7 @@ describe('WorkspaceListSection layout styles', () => {
     const workspaceNameButton = extractBlock(stylesheet, '&__workspace-item-name-btn');
     const workspaceTitle = extractBlock(stylesheet, '&__workspace-item-title');
     const workspaceLabel = extractBlock(stylesheet, '&__workspace-item-label');
+    const workspaceActions = extractBlock(stylesheet, '&__workspace-item-actions');
     const workspaceMenu = extractBlock(stylesheet, '&__workspace-item-menu');
     const assistantItem = extractBlock(stylesheet, '&__assistant-item');
     const assistantCard = extractBlock(stylesheet, '&__assistant-item-card');
@@ -40,20 +41,20 @@ describe('WorkspaceListSection layout styles', () => {
     expect(workspaceItem).toContain('max-width: 100%;');
     expect(workspaceCard).toContain('max-width: 100%;');
     expect(workspaceCard).toContain('overflow: hidden;');
-    expect(workspaceNameButton).toContain('flex: 1 1 0;');
+    expect(workspaceNameButton).toContain('flex: 0 1 auto;');
     expect(workspaceNameButton).toContain('overflow: hidden;');
     expect(workspaceNameButton).not.toContain('58px');
     expect(stylesheet).toContain('var(--bitfun-nav-row-action-size) +\n      var(--bitfun-nav-row-action-size)');
-    expect(stylesheet).toContain('&__workspace-item:hover &__workspace-item-name-btn');
-    expect(stylesheet).toContain('&__workspace-item.is-menu-open &__workspace-item-name-btn');
+    expect(stylesheet).toContain('&__workspace-item:hover &__workspace-item-name-stack');
+    expect(stylesheet).toContain('&__workspace-item.is-menu-open &__workspace-item-name-stack');
     expect(stylesheet).not.toContain('&__workspace-item.is-active &__workspace-item-name-btn');
     expect(stylesheet).toContain('&:not(:hover):not(:focus-within):not(.is-menu-open)');
     expect(workspaceTitle).toContain('flex: 1 1 0;');
     expect(workspaceTitle).toContain('max-width: 100%;');
     expect(workspaceLabel).toContain('flex: 1 1 0;');
     expect(workspaceLabel).toContain('text-overflow: ellipsis;');
-    expect(workspaceMenu).toContain('position: absolute;');
-    expect(workspaceMenu).toContain('right: var(--bitfun-nav-row-action-offset);');
+    expect(workspaceActions).toContain('position: absolute;');
+    expect(workspaceActions).toContain('right: var(--bitfun-nav-row-action-offset);');
     expect(workspaceMenu).toContain('gap: var(--bitfun-nav-row-action-gap);');
 
     expect(assistantItem).toContain('min-width: 0;');

--- a/src/web-ui/src/locales/en-US/panels/files.json
+++ b/src/web-ui/src/locales/en-US/panels/files.json
@@ -58,7 +58,8 @@
         "progressUnknown": "{{processed}} items processed",
         "dirtyFiles": "Pending changes: {{modified}} modified, {{deleted}} deleted, {{new}} new",
         "rebuildRecommended": "A rebuild is recommended.",
-        "probeDegraded": "Workspace probe is degraded and the indexed workspace view may stop tracking changes."
+        "probeDegraded": "Workspace probe is degraded and the indexed workspace view may stop tracking changes.",
+        "hoverTooltip": "Flashgrep index: {{status}}"
       },
       "taskState": {
         "queued": "Queued",

--- a/src/web-ui/src/locales/zh-CN/panels/files.json
+++ b/src/web-ui/src/locales/zh-CN/panels/files.json
@@ -58,7 +58,8 @@
         "progressUnknown": "已处理 {{processed}} 项",
         "dirtyFiles": "待同步变更：修改 {{modified}}，删除 {{deleted}}，新增 {{new}}",
         "rebuildRecommended": "当前建议执行重建。",
-        "probeDegraded": "工作区探测状态异常，工作区索引视图可能不再持续跟进变更。"
+        "probeDegraded": "工作区探测状态异常，工作区索引视图可能不再持续跟进变更。",
+        "hoverTooltip": "Flashgrep 索引：{{status}}"
       },
       "taskState": {
         "queued": "排队中",


### PR DESCRIPTION
## Summary

- Workspace list: clicking the flashgrep index indicator opens a small modal with full status, progress, warnings, and build/rebuild action; hover keeps a short tooltip.
- SCSS: name row layout (name stack / name line), smaller indicator dots, adjusted padding for actions; minor assistant card cursor tweaks.
- Locales: en-US / zh-CN tooltip string for the indicator.
- Updated WorkspaceListSection layout tests to match stylesheet selectors.

## Verification

- pnpm run lint:web
- pnpm run type-check:web
- pnpm --dir src/web-ui run test:run