### PR TITLE
feat(desktop): agent companion pet dynamic window sizing

### DIFF
--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -387,6 +387,14 @@ fn resize_agent_companion_window(
     width: f64,
     height: f64,
 ) {
+    let width = width.clamp(
+        AGENT_COMPANION_WINDOW_MIN_SIZE,
+        AGENT_COMPANION_WINDOW_MAX_WIDTH,
+    );
+    let height = height.clamp(
+        AGENT_COMPANION_WINDOW_MIN_SIZE,
+        AGENT_COMPANION_WINDOW_MAX_HEIGHT,
+    );
     let monitor: Option<tauri::Monitor> = window
         .current_monitor()
         .ok()

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
@@ -20,19 +20,31 @@
   background: transparent;
   user-select: none;
 
+  &__dock {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--bitfun-agent-companion-gap, 8px);
+    width: max-content;
+    max-height: 100vh;
+    pointer-events: none;
+  }
+
   &__pet {
     width: min(96px, 100vw);
     height: min(96px, 100vh);
     max-width: 96px;
     max-height: 96px;
     transform-origin: center bottom;
-    filter: drop-shadow(0 12px 18px rgba(15, 23, 42, 0.18));
   }
 
   &__pet-hitbox {
-    position: absolute;
-    right: 0;
-    bottom: 0;
+    position: relative;
+    flex-shrink: 0;
     width: min(96px, 100vw);
     height: min(96px, 100vh);
     display: grid;
@@ -46,10 +58,10 @@
   }
 
   &__bubbles {
-    position: absolute;
-    right: calc(var(--bitfun-agent-companion-pet-size, 96px) - var(--bitfun-agent-companion-gap, 8px));
-    bottom: 0;
-    width: min(252px, calc(100vw - var(--bitfun-agent-companion-pet-size, 96px) - var(--bitfun-agent-companion-gap, 8px)));
+    position: relative;
+    flex-shrink: 0;
+    width: max-content;
+    max-width: 252px;
     max-height: 100vh;
     display: flex;
     flex-direction: column;
@@ -75,20 +87,20 @@
     appearance: none;
     text-align: left;
     font: inherit;
+    width: max-content;
     max-width: 100%;
     min-width: 132px;
+    box-sizing: border-box;
     padding: 7px 10px;
     border: 1px solid rgba(15, 23, 42, 0.1);
     border-radius: 10px 10px 2px 10px;
     background: rgba(255, 255, 255, 0.92);
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.14);
     color: #1f2937;
     backdrop-filter: blur(10px);
     cursor: pointer;
 
     &:hover {
       transform: translateY(-1px);
-      box-shadow: 0 12px 26px rgba(15, 23, 42, 0.18);
     }
 
     &:focus-visible {

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
@@ -11,7 +11,7 @@ import './AgentCompanionDesktopPet.scss';
 
 const log = createLogger('AgentCompanionDesktopPet');
 const PET_SIZE = 96;
-const WINDOW_WIDTH_WITH_BUBBLES = 360;
+const WINDOW_MAX_WIDTH = 360;
 const WINDOW_MAX_HEIGHT = 240;
 const WINDOW_HORIZONTAL_GAP = 8;
 const MAX_VISIBLE_BUBBLES = 3;
@@ -26,6 +26,7 @@ export const AgentCompanionDesktopPet: React.FC = () => {
   const [tasks, setTasks] = useState<AgentCompanionTaskStatus[]>([]);
   const [isHoveringPet, setIsHoveringPet] = useState(false);
   const [isDraggingPet, setIsDraggingPet] = useState(false);
+  const dockRef = useRef<HTMLDivElement>(null);
   const bubblesRef = useRef<HTMLDivElement>(null);
   const displayTasks = [...tasks].reverse();
 
@@ -70,7 +71,6 @@ export const AgentCompanionDesktopPet: React.FC = () => {
 
   useLayoutEffect(() => {
     const bubbleCount = tasks.length;
-    const nextWidth = bubbleCount > 0 ? WINDOW_WIDTH_WITH_BUBBLES : PET_SIZE;
     const bubbleElements = Array.from(bubblesRef.current?.children ?? [])
       .slice(0, MAX_VISIBLE_BUBBLES);
     const visibleBubbleHeight = bubbleElements.reduce(
@@ -84,6 +84,16 @@ export const AgentCompanionDesktopPet: React.FC = () => {
     const nextHeight = bubbleCount > 0
       ? Math.max(PET_SIZE, Math.min(WINDOW_MAX_HEIGHT, targetBubbleHeight))
       : PET_SIZE;
+    const measuredDockWidth = dockRef.current
+      ? Math.max(
+        dockRef.current.scrollWidth,
+        dockRef.current.getBoundingClientRect().width,
+      )
+      : PET_SIZE;
+    const nextWidth = Math.max(
+      PET_SIZE,
+      Math.min(WINDOW_MAX_WIDTH, Math.ceil(measuredDockWidth)),
+    );
 
     void import('@tauri-apps/api/core')
       .then(({ invoke }) => invoke('resize_agent_companion_desktop_pet', {
@@ -133,49 +143,56 @@ export const AgentCompanionDesktopPet: React.FC = () => {
     }
   };
 
+  const dockVars = {
+    '--bitfun-agent-companion-pet-size': `${PET_SIZE}px`,
+    '--bitfun-agent-companion-gap': `${WINDOW_HORIZONTAL_GAP}px`,
+  } as React.CSSProperties;
+
   return (
     <main
       className="bitfun-agent-companion-window"
     >
-      {tasks.length > 0 && (
-        <div
-          ref={bubblesRef}
-          className="bitfun-agent-companion-window__bubbles"
-          aria-live="polite"
-          onDoubleClick={event => event.stopPropagation()}
-          style={{
-            '--bitfun-agent-companion-pet-size': `${PET_SIZE}px`,
-            '--bitfun-agent-companion-gap': `${WINDOW_HORIZONTAL_GAP}px`,
-          } as React.CSSProperties}
-        >
-          {displayTasks.map(task => (
-            <button
-              type="button"
-              key={task.sessionId}
-              className={`bitfun-agent-companion-window__bubble bitfun-agent-companion-window__bubble--${task.state}`}
-              onClick={() => void openTaskSession(task)}
-            >
-              <span className="bitfun-agent-companion-window__bubble-title">
-                {task.title}
-              </span>
-              <span className="bitfun-agent-companion-window__bubble-status">
-                {t(task.labelKey, { defaultValue: task.defaultLabel })}
-              </span>
-            </button>
-          ))}
-        </div>
-      )}
       <div
-        className="bitfun-agent-companion-window__pet-hitbox"
-        onPointerEnter={() => setIsHoveringPet(true)}
-        onPointerLeave={() => setIsHoveringPet(false)}
-        onPointerDown={startDrag}
+        ref={dockRef}
+        className="bitfun-agent-companion-window__dock"
+        style={dockVars}
       >
-        <ChatInputPixelPet
-          mood={displayMood}
-          pet={pet}
-          className="bitfun-agent-companion-window__pet"
-        />
+        {tasks.length > 0 && (
+          <div
+            ref={bubblesRef}
+            className="bitfun-agent-companion-window__bubbles"
+            aria-live="polite"
+            onDoubleClick={event => event.stopPropagation()}
+          >
+            {displayTasks.map(task => (
+              <button
+                type="button"
+                key={task.sessionId}
+                className={`bitfun-agent-companion-window__bubble bitfun-agent-companion-window__bubble--${task.state}`}
+                onClick={() => void openTaskSession(task)}
+              >
+                <span className="bitfun-agent-companion-window__bubble-title">
+                  {task.title}
+                </span>
+                <span className="bitfun-agent-companion-window__bubble-status">
+                  {t(task.labelKey, { defaultValue: task.defaultLabel })}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+        <div
+          className="bitfun-agent-companion-window__pet-hitbox"
+          onPointerEnter={() => setIsHoveringPet(true)}
+          onPointerLeave={() => setIsHoveringPet(false)}
+          onPointerDown={startDrag}
+        >
+          <ChatInputPixelPet
+            mood={displayMood}
+            pet={pet}
+            className="bitfun-agent-companion-window__pet"
+          />
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- Measure the dock container width in the web UI and pass it to `resize_agent_companion_desktop_pet` so the Tauri companion window sizes to content (capped at max width) instead of a fixed width.
- Clamp `resize_agent_companion_window` in Rust to configured min/max dimensions.
- Adjust Agent Companion bubble dock CSS (`max-content`, bubble max width, box-sizing) for tighter layout.

## Test plan
- `pnpm run lint:web` / `pnpm run type-check:web` / `pnpm --dir src/web-ui run test:run`
- `cargo check -p bitfun-desktop`