### PR TITLE
fix(desktop): tighten companion pet bubble width measurement

### DIFF
--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
@@ -14,8 +14,11 @@ const PET_SIZE = 96;
 const WINDOW_MAX_WIDTH = 360;
 const WINDOW_MAX_HEIGHT = 240;
 const WINDOW_HORIZONTAL_GAP = 8;
-const MAX_VISIBLE_BUBBLES = 3;
+const MAX_VISIBLE_BUBBLES = 2;
 const BUBBLE_GAP = 6;
+const BUBBLE_MIN_WIDTH = 132;
+const BUBBLE_MAX_WIDTH = 252;
+const WINDOW_EDGE_BUFFER = 4;
 
 export const AgentCompanionDesktopPet: React.FC = () => {
   const { t } = useTranslation('flow-chat');
@@ -84,12 +87,27 @@ export const AgentCompanionDesktopPet: React.FC = () => {
     const nextHeight = bubbleCount > 0
       ? Math.max(PET_SIZE, Math.min(WINDOW_MAX_HEIGHT, targetBubbleHeight))
       : PET_SIZE;
-    const measuredDockWidth = dockRef.current
-      ? Math.max(
-        dockRef.current.scrollWidth,
-        dockRef.current.getBoundingClientRect().width,
+    const measuredBubbleWidth = bubbleCount > 0
+      ? Math.min(
+        BUBBLE_MAX_WIDTH,
+        Math.max(
+          BUBBLE_MIN_WIDTH,
+          bubblesRef.current?.scrollWidth ?? 0,
+          bubblesRef.current?.getBoundingClientRect().width ?? 0,
+          ...Array.from(bubblesRef.current?.children ?? []).map(child => {
+            const element = child as HTMLElement;
+            return Math.max(element.scrollWidth, element.getBoundingClientRect().width);
+          }),
+        ),
       )
-      : PET_SIZE;
+      : 0;
+    const measuredDockWidth = bubbleCount > 0
+      ? measuredBubbleWidth + WINDOW_HORIZONTAL_GAP + PET_SIZE + WINDOW_EDGE_BUFFER
+      : Math.max(
+        PET_SIZE,
+        dockRef.current?.scrollWidth ?? 0,
+        dockRef.current?.getBoundingClientRect().width ?? 0,
+      );
     const nextWidth = Math.max(
       PET_SIZE,
       Math.min(WINDOW_MAX_WIDTH, Math.ceil(measuredDockWidth)),


### PR DESCRIPTION
## Summary
- Measure each companion pet bubble child individually and clamp width to a min/max range, so the floating window hugs the bubble content instead of leaving a wide trailing gap next to the pet.
- Reduce the visible bubble count from 3 to 2 and reserve a small edge buffer so text no longer clips on the right edge.

## Test plan
- [x] `pnpm run lint:web`
- [x] `pnpm run type-check:web`
- [ ] Manual: launch desktop pet, confirm bubble window width tracks bubble content and no text is clipped.