### PR TITLE
fix: avoid windows startup console flicker

### DIFF
--- a/src/apps/desktop/src/computer_use/desktop_host.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host.rs
@@ -3138,7 +3138,7 @@ tell application "System Events" to get unix id of first process whose frontmost
         #[cfg(target_os = "windows")]
         {
             let result = tokio::task::spawn_blocking(move || -> BitFunResult<OpenAppResult> {
-                let output = std::process::Command::new("cmd")
+                let output = bitfun_core::util::process_manager::create_command("cmd")
                     .args(["/c", "start", "", &name])
                     .output()
                     .map_err(|e| BitFunError::tool(format!("open_app: {}", e)))?;

--- a/src/crates/acp/src/client/manager.rs
+++ b/src/crates/acp/src/client/manager.rs
@@ -353,7 +353,7 @@ impl AcpClientService {
 
         let program =
             resolve_configured_command(&connection.config.command, &connection.config.env);
-        let mut command = Command::new(&program);
+        let mut command = bitfun_core::util::process_manager::create_tokio_command(&program);
         command
             .args(&connection.config.args)
             .stdin(Stdio::piped())
@@ -1345,7 +1345,7 @@ async fn terminate_child_process_tree(client_id: &str, mut child: Child) {
     #[cfg(unix)]
     if let Some(pid) = pid {
         let process_group = format!("-{}", pid);
-        match Command::new("kill")
+        match bitfun_core::util::process_manager::create_tokio_command("kill")
             .arg("-TERM")
             .arg(&process_group)
             .status()
@@ -1377,7 +1377,7 @@ async fn terminate_child_process_tree(client_id: &str, mut child: Child) {
             Err(_) => {}
         }
 
-        if let Err(error) = Command::new("kill")
+        if let Err(error) = bitfun_core::util::process_manager::create_tokio_command("kill")
             .arg("-KILL")
             .arg(&process_group)
             .status()
@@ -1394,7 +1394,7 @@ async fn terminate_child_process_tree(client_id: &str, mut child: Child) {
 
     #[cfg(windows)]
     if let Some(pid) = pid {
-        match Command::new("taskkill")
+        match bitfun_core::util::process_manager::create_tokio_command("taskkill")
             .arg("/PID")
             .arg(pid.to_string())
             .arg("/T")

--- a/src/crates/acp/src/client/requirements.rs
+++ b/src/crates/acp/src/client/requirements.rs
@@ -250,7 +250,7 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    let mut command = Command::new(program);
+    let mut command = bitfun_core::util::process_manager::create_tokio_command(program);
     command.args(args);
     apply_command_environment(&mut command, None);
     match tokio::time::timeout(timeout, command.output()).await {

--- a/src/crates/core/src/agentic/tools/implementations/computer_use_actions.rs
+++ b/src/crates/core/src/agentic/tools/implementations/computer_use_actions.rs
@@ -1426,7 +1426,7 @@ impl ComputerUseActions {
                 let mut chosen_cmd = String::new();
                 let mut chosen_args: Vec<String> = vec![];
                 for (cmd, args) in &attempts {
-                    match std::process::Command::new(cmd).args(args).output() {
+                    match crate::util::process_manager::create_command(cmd).args(args).output() {
                         Ok(out) => {
                             if out.status.success() {
                                 chosen_cmd = cmd.clone();
@@ -2056,7 +2056,7 @@ fn read_os_version() -> Option<String> {
     }
     #[cfg(target_os = "windows")]
     {
-        let out = std::process::Command::new("cmd")
+        let out = crate::util::process_manager::create_command("cmd")
             .args(["/C", "ver"])
             .output()
             .ok()?;

--- a/src/crates/core/src/miniapp/host_dispatch.rs
+++ b/src/crates/core/src/miniapp/host_dispatch.rs
@@ -29,7 +29,6 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use tokio::process::Command;
 
 /// Namespaces handled by the host-side dispatch (no Worker required).
 const HOST_NAMESPACES: &[&str] = &["fs", "shell", "os", "net"];
@@ -377,13 +376,13 @@ async fn dispatch_shell(
 
     #[cfg(target_os = "windows")]
     let mut cmd = {
-        let mut c = Command::new("cmd");
+        let mut c = crate::util::process_manager::create_tokio_command("cmd");
         c.args(["/C", &command]);
         c
     };
     #[cfg(not(target_os = "windows"))]
     let mut cmd = {
-        let mut c = Command::new("sh");
+        let mut c = crate::util::process_manager::create_tokio_command("sh");
         c.args(["-c", &command]);
         c
     };

--- a/src/crates/core/src/miniapp/js_worker.rs
+++ b/src/crates/core/src/miniapp/js_worker.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::{Child, ChildStdin, Command};
+use tokio::process::{Child, ChildStdin};
 use tokio::sync::{oneshot, Mutex};
 
 type JsWorkerResponse = Result<Value, String>;
@@ -36,7 +36,7 @@ impl JsWorker {
     ) -> Result<Self, String> {
         let exe = runtime.path.to_string_lossy();
         let host = worker_host_path.to_string_lossy();
-        let mut child = Command::new(&*exe)
+        let mut child = crate::util::process_manager::create_tokio_command(&*exe)
             .arg(&*host)
             .arg(policy_json)
             .current_dir(app_dir)

--- a/src/crates/core/src/miniapp/js_worker_pool.rs
+++ b/src/crates/core/src/miniapp/js_worker_pool.rs
@@ -7,7 +7,6 @@ use crate::util::errors::{BitFunError, BitFunResult};
 use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::process::Command;
 use tokio::sync::Mutex;
 
 const MAX_WORKERS: usize = 5;
@@ -276,7 +275,7 @@ impl JsWorkerPool {
             }
         };
 
-        let output = Command::new(cmd)
+        let output = crate::util::process_manager::create_tokio_command(cmd)
             .args(args)
             .current_dir(&app_dir)
             .output()

--- a/src/crates/core/src/miniapp/runtime_detect.rs
+++ b/src/crates/core/src/miniapp/runtime_detect.rs
@@ -13,7 +13,6 @@
 //!      picked up regardless of the active version.
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeKind {
@@ -116,7 +115,9 @@ fn is_executable(p: &Path) -> bool {
 }
 
 fn get_version(executable: &std::path::Path) -> Result<String, std::io::Error> {
-    let out = Command::new(executable).arg("--version").output()?;
+    let out = crate::util::process_manager::create_command(executable)
+        .arg("--version")
+        .output()?;
     if out.status.success() {
         let v = String::from_utf8_lossy(&out.stdout);
         Ok(v.trim().to_string())


### PR DESCRIPTION
## Summary
- route Windows child-process launches through `bitfun_core::util::process_manager`
- suppress console flicker during desktop startup runtime detection and JS worker spawn
- align ACP / MiniApp / computer-use related process creation with `CREATE_NO_WINDOW`

## Verification
- `cargo check -p bitfun-core -p bitfun-desktop`
- `cargo build -p bitfun-desktop`