### PR TITLE
fix(web-ui): tighten compact tool card headers for file ops

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -875,7 +875,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
       <CompactToolCard
         status={status}
         isExpanded={false}
-        className="read-file-card delete-file-card"
+        className="read-file-card delete-file-card compact-tool-card-wrapper--dense-command"
         clickable={false}
         header={
           <CompactToolCardHeader

--- a/src/web-ui/src/flow_chat/tool-cards/GlobSearchDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GlobSearchDisplay.tsx
@@ -192,13 +192,13 @@ export const GlobSearchDisplay: React.FC<ToolCardProps> = ({
         status={status}
         isExpanded={isExpanded}
         onClick={handleClick}
+        className="glob-search-card compact-tool-card-wrapper--dense-command"
         clickable={hasDetails}
         header={
           <CompactToolCardHeader
             icon={<FolderSearch size={16} className="glob-search-card-icon" />}
             content={renderContent()}
             rightStatusIcon={getStatusIcon()}
-            rightStatusIconWithDivider
           />
         }
         expandedContent={hasDetails ? renderExpandedContent() : undefined}

--- a/src/web-ui/src/flow_chat/tool-cards/GrepSearchDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GrepSearchDisplay.tsx
@@ -147,14 +147,13 @@ export const GrepSearchDisplay: React.FC<ToolCardProps> = ({
         status={status}
         isExpanded={isExpanded}
         onClick={handleClick}
-        className="grep-search-card"
+        className="grep-search-card compact-tool-card-wrapper--dense-command"
         clickable={hasDetails}
         header={
           <CompactToolCardHeader
             icon={<Search size={16} className="grep-search-card-icon" />}
             content={renderContent()}
             rightStatusIcon={getStatusIcon()}
-            rightStatusIconWithDivider
           />
         }
         expandedContent={hasDetails ? renderExpandedContent() : undefined}

--- a/src/web-ui/src/flow_chat/tool-cards/LSDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/LSDisplay.tsx
@@ -188,14 +188,13 @@ export const LSDisplay: React.FC<ToolCardProps> = ({
         status={status}
         isExpanded={isExpanded}
         onClick={handleClick}
-        className="ls-display-card"
+        className="ls-display-card compact-tool-card-wrapper--dense-command"
         clickable={hasDetails}
         header={
           <CompactToolCardHeader
             icon={<FolderOpen size={16} className="ls-display-card-icon" />}
             content={renderContent()}
             rightStatusIcon={getStatusIcon()}
-            rightStatusIconWithDivider
           />
         }
         expandedContent={hasDetails ? renderExpandedContent() : undefined}

--- a/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx
@@ -130,14 +130,13 @@ export const ReadFileDisplay: React.FC<ToolCardProps> = React.memo(({
       status={status}
       isExpanded={false}
       onClick={() => canOpenFile && handleOpenInEditor()}
-      className="read-file-card"
+      className="read-file-card compact-tool-card-wrapper--dense-command"
       clickable={canOpenFile}
       header={
         <CompactToolCardHeader
           icon={<FileText size={16} className="read-file-card-icon" />}
           content={renderContent()}
           rightStatusIcon={getStatusIcon()}
-          rightStatusIconWithDivider
         />
       }
     />


### PR DESCRIPTION
## Summary

Flow chat compact tool cards for file operations (read, grep, glob, list directory, delete) now use the `compact-tool-card-wrapper--dense-command` layout class for consistent header density with other command cards.

Removed `rightStatusIconWithDivider` from several headers where the divider adds visual noise next to the status icon.

## Verification

- `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run`
