### PR TITLE
fix(web-ui): flow chat compact tool card dense headers

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/CompactToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CompactToolCard.tsx
@@ -70,7 +70,7 @@ export const CompactToolCard: React.FC<CompactToolCardProps> = ({
 
   return (
     <div
-      className={`compact-tool-card-wrapper${loadingShimmer ? ' compact-tool-card-wrapper--loading-shimmer' : ''} ${className}`.trim()}
+      className={`compact-tool-card-wrapper compact-tool-card-wrapper--dense-command${loadingShimmer ? ' compact-tool-card-wrapper--loading-shimmer' : ''} ${className}`.trim()}
     >
       <div
         className={`compact-tool-card status-${status} ${clickable ? 'clickable' : ''} ${isExpanded ? 'expanded' : ''}`}

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -875,7 +875,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
       <CompactToolCard
         status={status}
         isExpanded={false}
-        className="read-file-card delete-file-card compact-tool-card-wrapper--dense-command"
+        className="read-file-card delete-file-card"
         clickable={false}
         header={
           <CompactToolCardHeader

--- a/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.scss
@@ -19,7 +19,7 @@
   cursor: pointer;
 }
 
-.compact-tool-card-wrapper.git-tool-display.compact-tool-card-wrapper--dense-command {
+.compact-tool-card-wrapper.git-tool-display {
   .tool-card-icon-slot {
     width: 24px;
     margin-right: 7px;

--- a/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.tsx
@@ -326,7 +326,7 @@ export const GitToolDisplay: React.FC<ToolCardProps> = ({
         status={status}
         isExpanded={isExpanded}
         onClick={handleCardClick}
-        className="git-tool-display compact-tool-card-wrapper--dense-command"
+        className="git-tool-display"
         clickable
         header={renderHeader()}
         expandedContent={expandedContent}

--- a/src/web-ui/src/flow_chat/tool-cards/GlobSearchDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GlobSearchDisplay.tsx
@@ -192,7 +192,7 @@ export const GlobSearchDisplay: React.FC<ToolCardProps> = ({
         status={status}
         isExpanded={isExpanded}
         onClick={handleClick}
-        className="glob-search-card compact-tool-card-wrapper--dense-command"
+        className="glob-search-card"
         clickable={hasDetails}
         header={
           <CompactToolCardHeader

--- a/src/web-ui/src/flow_chat/tool-cards/GrepSearchDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GrepSearchDisplay.tsx
@@ -147,7 +147,7 @@ export const GrepSearchDisplay: React.FC<ToolCardProps> = ({
         status={status}
         isExpanded={isExpanded}
         onClick={handleClick}
-        className="grep-search-card compact-tool-card-wrapper--dense-command"
+        className="grep-search-card"
         clickable={hasDetails}
         header={
           <CompactToolCardHeader

--- a/src/web-ui/src/flow_chat/tool-cards/LSDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/LSDisplay.tsx
@@ -188,7 +188,7 @@ export const LSDisplay: React.FC<ToolCardProps> = ({
         status={status}
         isExpanded={isExpanded}
         onClick={handleClick}
-        className="ls-display-card compact-tool-card-wrapper--dense-command"
+        className="ls-display-card"
         clickable={hasDetails}
         header={
           <CompactToolCardHeader

--- a/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx
@@ -130,7 +130,7 @@ export const ReadFileDisplay: React.FC<ToolCardProps> = React.memo(({
       status={status}
       isExpanded={false}
       onClick={() => canOpenFile && handleOpenInEditor()}
-      className="read-file-card compact-tool-card-wrapper--dense-command"
+      className="read-file-card"
       clickable={canOpenFile}
       header={
         <CompactToolCardHeader

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
@@ -626,7 +626,7 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
           status={status}
           isExpanded={false}
           onClick={handleCardClick}
-          className="terminal-tool-card terminal-tool-card--compact-collapsed compact-tool-card-wrapper--dense-command"
+          className="terminal-tool-card terminal-tool-card--compact-collapsed"
           clickable
           header={renderCompactHeader()}
         />


### PR DESCRIPTION
## Summary

- Tighten compact tool card headers for file operations and related tool cards.
- Centralize \compact-tool-card-wrapper--dense-command\ on \CompactToolCard\ so dense header styling is consistent and callers do not repeat the modifier class.

## Verification

- \pnpm run lint:web\ / \pnpm run type-check:web\ (recommended for web-ui changes)
- \pnpm --dir src/web-ui run test:run\ if CI requires it.