### PR TITLE
feat(ai): support DeepSeek reasoning effort and preserve empty reasoning replay

### DIFF
--- a/BitFun-Installer/src/data/modelProviders.ts
+++ b/BitFun-Installer/src/data/modelProviders.ts
@@ -99,7 +99,7 @@ export const PROVIDER_TEMPLATES: Record<string, ProviderTemplate> = {
     descriptionKey: 'model.providers.deepseek.description',
     baseUrl: 'https://api.deepseek.com/v1',
     format: 'openai',
-    models: ['deepseek-chat', 'deepseek-reasoner'],
+    models: ['deepseek-v4-flash', 'deepseek-v4-pro'],
     helpUrl: 'https://platform.deepseek.com/api_keys',
   },
   zhipu: {

--- a/BitFun-Installer/src/i18n/locales/en.json
+++ b/BitFun-Installer/src/i18n/locales/en.json
@@ -51,7 +51,7 @@
     "installDone": "Installation complete",
     "provider": "Provider",
     "config": "Connection",
-    "modelName": "Model name (e.g. deepseek-chat)",
+    "modelName": "Model name (e.g. deepseek-v4-flash)",
     "apiKey": "API key",
     "back": "Back",
     "skip": "Skip for now",

--- a/BitFun-Installer/src/i18n/locales/zh-TW.json
+++ b/BitFun-Installer/src/i18n/locales/zh-TW.json
@@ -51,7 +51,7 @@
     "installDone": "安裝完成",
     "provider": "服務商",
     "config": "連接信息",
-    "modelName": "模型名稱（如 deepseek-chat）",
+    "modelName": "模型名稱（如 deepseek-v4-flash）",
     "apiKey": "API Key",
     "back": "返回",
     "skip": "稍後配置",

--- a/BitFun-Installer/src/i18n/locales/zh.json
+++ b/BitFun-Installer/src/i18n/locales/zh.json
@@ -51,7 +51,7 @@
     "installDone": "安装完成",
     "provider": "服务商",
     "config": "连接信息",
-    "modelName": "模型名称（如 deepseek-chat）",
+    "modelName": "模型名称（如 deepseek-v4-flash）",
     "apiKey": "API Key",
     "back": "返回",
     "skip": "稍后配置",

--- a/src/crates/ai-adapters/src/client.rs
+++ b/src/crates/ai-adapters/src/client.rs
@@ -422,7 +422,80 @@ mod tests {
 
         assert_eq!(request_body["thinking"]["type"], "enabled");
         assert!(request_body.get("enable_thinking").is_none());
+        assert!(request_body.get("reasoning_effort").is_none());
         assert!(request_body.get("reasoning_split").is_none());
+    }
+
+    #[test]
+    fn build_openai_request_body_adds_deepseek_reasoning_effort() {
+        let client = AIClient::new(AIConfig {
+            name: "deepseek".to_string(),
+            base_url: "https://api.deepseek.com/v1".to_string(),
+            request_url: "https://api.deepseek.com/v1/chat/completions".to_string(),
+            api_key: "test-key".to_string(),
+            model: "deepseek-v4-pro".to_string(),
+            format: "openai".to_string(),
+            context_window: 128000,
+            max_tokens: Some(4096),
+            temperature: None,
+            top_p: None,
+            reasoning_mode: ReasoningMode::Enabled,
+            inline_think_in_text: false,
+            custom_headers: None,
+            custom_headers_mode: None,
+            skip_ssl_verify: false,
+            reasoning_effort: Some("xhigh".to_string()),
+            thinking_budget_tokens: None,
+            custom_request_body: None,
+            custom_request_body_mode: None,
+        });
+
+        let request_body = openai::chat::build_request_body(
+            &client,
+            &client.config.request_url,
+            vec![json!({ "role": "user", "content": "hello" })],
+            None,
+            None,
+        );
+
+        assert_eq!(request_body["thinking"]["type"], "enabled");
+        assert_eq!(request_body["reasoning_effort"], "max");
+    }
+
+    #[test]
+    fn build_openai_request_body_omits_deepseek_reasoning_effort_when_disabled() {
+        let client = AIClient::new(AIConfig {
+            name: "deepseek".to_string(),
+            base_url: "https://api.deepseek.com/v1".to_string(),
+            request_url: "https://api.deepseek.com/v1/chat/completions".to_string(),
+            api_key: "test-key".to_string(),
+            model: "deepseek-v4-flash".to_string(),
+            format: "openai".to_string(),
+            context_window: 128000,
+            max_tokens: Some(4096),
+            temperature: None,
+            top_p: None,
+            reasoning_mode: ReasoningMode::Disabled,
+            inline_think_in_text: false,
+            custom_headers: None,
+            custom_headers_mode: None,
+            skip_ssl_verify: false,
+            reasoning_effort: Some("max".to_string()),
+            thinking_budget_tokens: None,
+            custom_request_body: None,
+            custom_request_body_mode: None,
+        });
+
+        let request_body = openai::chat::build_request_body(
+            &client,
+            &client.config.request_url,
+            vec![json!({ "role": "user", "content": "hello" })],
+            None,
+            None,
+        );
+
+        assert_eq!(request_body["thinking"]["type"], "disabled");
+        assert!(request_body.get("reasoning_effort").is_none());
     }
 
     #[test]
@@ -537,9 +610,51 @@ mod tests {
     }
 
     #[test]
+    fn build_anthropic_request_body_adds_deepseek_reasoning_effort() {
+        let client = AIClient::new(AIConfig {
+            name: "deepseek".to_string(),
+            base_url: "https://api.deepseek.com/anthropic".to_string(),
+            request_url: "https://api.deepseek.com/anthropic/v1/messages".to_string(),
+            api_key: "test-key".to_string(),
+            model: "deepseek-v4-pro".to_string(),
+            format: "anthropic".to_string(),
+            context_window: 200000,
+            max_tokens: Some(8192),
+            temperature: None,
+            top_p: None,
+            reasoning_mode: ReasoningMode::Enabled,
+            inline_think_in_text: false,
+            custom_headers: None,
+            custom_headers_mode: None,
+            skip_ssl_verify: false,
+            reasoning_effort: Some("xhigh".to_string()),
+            thinking_budget_tokens: None,
+            custom_request_body: None,
+            custom_request_body_mode: None,
+        });
+
+        let request_body = anthropic::request::build_request_body(
+            &client,
+            &client.config.request_url,
+            None,
+            vec![json!({ "role": "user", "content": [{ "type": "text", "text": "hello" }] })],
+            None,
+            None,
+        );
+
+        assert_eq!(request_body["thinking"]["type"], "enabled");
+        assert_eq!(request_body["output_config"]["effort"], "max");
+    }
+
+    #[test]
     fn build_openai_request_body_trim_mode_preserves_essential_fields() {
         let mut client = make_trim_test_client("openai");
+        client.config.base_url = "https://api.deepseek.com/v1".to_string();
+        client.config.request_url = "https://api.deepseek.com/v1/chat/completions".to_string();
+        client.config.model = "deepseek-v4-pro".to_string();
         client.config.max_tokens = Some(8192);
+        client.config.reasoning_mode = ReasoningMode::Enabled;
+        client.config.reasoning_effort = Some("high".to_string());
         let messages = vec![json!({ "role": "user", "content": "hello" })];
 
         let request_body = openai::chat::build_request_body(
@@ -557,13 +672,14 @@ mod tests {
             })),
         );
 
-        assert_eq!(request_body["model"], "test-model");
+        assert_eq!(request_body["model"], "deepseek-v4-pro");
         assert_eq!(request_body["messages"], json!(messages));
         assert_eq!(request_body["stream"], true);
         assert_eq!(request_body["max_tokens"], 8192);
         assert_eq!(request_body["temperature"], 0.7);
         assert_eq!(request_body["response_format"]["type"], "json_object");
         assert!(request_body.get("thinking").is_none());
+        assert!(request_body.get("reasoning_effort").is_none());
     }
 
     #[test]

--- a/src/crates/ai-adapters/src/client/quirks.rs
+++ b/src/crates/ai-adapters/src/client/quirks.rs
@@ -8,6 +8,29 @@ pub(crate) fn is_siliconflow_url(url: &str) -> bool {
     url.contains("api.siliconflow.cn")
 }
 
+pub(crate) fn is_deepseek_url(url: &str) -> bool {
+    url.contains("api.deepseek.com")
+}
+
+pub(crate) fn is_deepseek_reasoning_effort_model(model_name: &str) -> bool {
+    matches!(
+        model_name.trim().to_ascii_lowercase().as_str(),
+        "deepseek-v4-flash" | "deepseek-v4-pro"
+    )
+}
+
+pub(crate) fn normalize_deepseek_reasoning_effort(effort: &str) -> Option<&'static str> {
+    match effort.trim().to_ascii_lowercase().as_str() {
+        "" => None,
+        "high" => Some("high"),
+        "max" => Some("max"),
+        "low" | "medium" => Some("high"),
+        "xhigh" => Some("max"),
+        "none" | "minimal" => None,
+        _ => Some("high"),
+    }
+}
+
 pub(crate) fn parse_glm_major_minor(model_name: &str) -> Option<(u32, u32)> {
     let lower = model_name.to_ascii_lowercase();
     let tail = lower.strip_prefix("glm-")?;
@@ -40,7 +63,9 @@ pub(crate) fn should_append_tool_stream(url: &str, model_name: &str) -> bool {
 pub(crate) fn apply_openai_compatible_reasoning_fields(
     request_body: &mut serde_json::Value,
     mode: ReasoningMode,
+    reasoning_effort: Option<&str>,
     url: &str,
+    model_name: &str,
 ) {
     let normalized_mode = if mode == ReasoningMode::Adaptive {
         ReasoningMode::Enabled
@@ -65,5 +90,17 @@ pub(crate) fn apply_openai_compatible_reasoning_fields(
             request_body["thinking"] = serde_json::json!({ "type": "disabled" });
         }
         ReasoningMode::Adaptive => unreachable!("adaptive mode is normalized above"),
+    }
+
+    if normalized_mode == ReasoningMode::Disabled {
+        return;
+    }
+
+    if !(is_deepseek_url(url) || is_deepseek_reasoning_effort_model(model_name)) {
+        return;
+    }
+
+    if let Some(effort) = reasoning_effort.and_then(normalize_deepseek_reasoning_effort) {
+        request_body["reasoning_effort"] = serde_json::json!(effort);
     }
 }

--- a/src/crates/ai-adapters/src/providers/anthropic/message_converter.rs
+++ b/src/crates/ai-adapters/src/providers/anthropic/message_converter.rs
@@ -249,7 +249,9 @@ mod tests {
         };
 
         let (_, messages) = AnthropicMessageConverter::convert_messages(vec![msg]);
-        let content = messages[0]["content"].as_array().expect("assistant content");
+        let content = messages[0]["content"]
+            .as_array()
+            .expect("assistant content");
 
         assert_eq!(content[0]["type"], json!("thinking"));
         assert_eq!(content[0]["thinking"], json!(""));

--- a/src/crates/ai-adapters/src/providers/anthropic/message_converter.rs
+++ b/src/crates/ai-adapters/src/providers/anthropic/message_converter.rs
@@ -129,18 +129,15 @@ impl AnthropicMessageConverter {
     fn convert_assistant_message(msg: Message) -> Option<Value> {
         let mut content = Vec::new();
 
-        if let Some(thinking) = msg.reasoning_content.as_ref() {
-            if !thinking.is_empty() {
-                let mut thinking_block = json!({
-                    "type": "thinking",
-                    "thinking": thinking
-                });
+        if msg.reasoning_content.is_some() || msg.thinking_signature.is_some() {
+            let mut thinking_block = json!({
+                "type": "thinking",
+                "thinking": msg.reasoning_content.as_deref().unwrap_or("")
+            });
 
-                thinking_block["signature"] =
-                    json!(msg.thinking_signature.as_deref().unwrap_or(""));
+            thinking_block["signature"] = json!(msg.thinking_signature.as_deref().unwrap_or(""));
 
-                content.push(thinking_block);
-            }
+            content.push(thinking_block);
         }
 
         if let Some(text) = msg.content {
@@ -228,5 +225,34 @@ impl AnthropicMessageConverter {
                 })
                 .collect()
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AnthropicMessageConverter;
+    use crate::types::Message;
+    use serde_json::json;
+
+    #[test]
+    fn preserves_empty_thinking_block_when_signature_exists() {
+        let msg = Message {
+            role: "assistant".to_string(),
+            content: Some("Answer".to_string()),
+            reasoning_content: Some(String::new()),
+            thinking_signature: Some("sig_1".to_string()),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+            is_error: None,
+            tool_image_attachments: None,
+        };
+
+        let (_, messages) = AnthropicMessageConverter::convert_messages(vec![msg]);
+        let content = messages[0]["content"].as_array().expect("assistant content");
+
+        assert_eq!(content[0]["type"], json!("thinking"));
+        assert_eq!(content[0]["thinking"], json!(""));
+        assert_eq!(content[0]["signature"], json!("sig_1"));
     }
 }

--- a/src/crates/ai-adapters/src/providers/anthropic/request.rs
+++ b/src/crates/ai-adapters/src/providers/anthropic/request.rs
@@ -1,5 +1,8 @@
 use super::AnthropicMessageConverter;
-use crate::client::quirks::should_append_tool_stream;
+use crate::client::quirks::{
+    is_deepseek_reasoning_effort_model, is_deepseek_url, normalize_deepseek_reasoning_effort,
+    should_append_tool_stream,
+};
 use crate::client::sse::execute_sse_request;
 use crate::client::{AIClient, StreamResponse};
 use crate::providers::shared;
@@ -54,13 +57,26 @@ fn default_anthropic_budget_tokens(max_tokens: Option<u32>) -> Option<u32> {
 fn apply_reasoning_fields(
     request_body: &mut serde_json::Value,
     mode: ReasoningMode,
+    url: &str,
     model_name: &str,
     max_tokens: Option<u32>,
     reasoning_effort: Option<&str>,
     thinking_budget_tokens: Option<u32>,
 ) {
+    let is_deepseek_reasoning_target =
+        is_deepseek_url(url) || is_deepseek_reasoning_effort_model(model_name);
+
     match mode {
-        ReasoningMode::Default => {}
+        ReasoningMode::Default => {
+            if is_deepseek_reasoning_target {
+                if let Some(effort) = reasoning_effort.and_then(normalize_deepseek_reasoning_effort)
+                {
+                    request_body["output_config"] = serde_json::json!({
+                        "effort": effort
+                    });
+                }
+            }
+        }
         ReasoningMode::Disabled => {
             request_body["thinking"] = serde_json::json!({ "type": "disabled" });
         }
@@ -74,6 +90,14 @@ fn apply_reasoning_fields(
                 }
             }
             request_body["thinking"] = thinking;
+            if is_deepseek_reasoning_target {
+                if let Some(effort) = reasoning_effort.and_then(normalize_deepseek_reasoning_effort)
+                {
+                    request_body["output_config"] = serde_json::json!({
+                        "effort": effort
+                    });
+                }
+            }
         }
         ReasoningMode::Adaptive => {
             if anthropic_supports_adaptive_reasoning(model_name) {
@@ -92,6 +116,7 @@ fn apply_reasoning_fields(
                 apply_reasoning_fields(
                     request_body,
                     ReasoningMode::Enabled,
+                    url,
                     model_name,
                     max_tokens,
                     None,
@@ -138,6 +163,7 @@ pub(crate) fn build_request_body(
     apply_reasoning_fields(
         &mut request_body,
         client.config.reasoning_mode,
+        url,
         &model_name,
         Some(max_tokens),
         client.config.reasoning_effort.as_deref(),

--- a/src/crates/ai-adapters/src/providers/openai/common.rs
+++ b/src/crates/ai-adapters/src/providers/openai/common.rs
@@ -36,7 +36,13 @@ pub(crate) fn apply_reasoning_fields(
     client: &AIClient,
     url: &str,
 ) {
-    apply_openai_compatible_reasoning_fields(request_body, client.config.reasoning_mode, url);
+    apply_openai_compatible_reasoning_fields(
+        request_body,
+        client.config.reasoning_mode,
+        client.config.reasoning_effort.as_deref(),
+        url,
+        &client.config.model,
+    );
 }
 
 pub(crate) fn resolve_models_url(client: &AIClient) -> String {

--- a/src/crates/ai-adapters/src/providers/openai/message_converter.rs
+++ b/src/crates/ai-adapters/src/providers/openai/message_converter.rs
@@ -308,13 +308,11 @@ impl OpenAIMessageConverter {
         }
 
         if let Some(reasoning) = msg.reasoning_content {
-            if !reasoning.is_empty() {
-                // Official OpenAI Chat Completions may ignore replayed reasoning_content, but
-                // many OpenAI-compatible providers require it to continue interleaved thinking.
-                // Replaying it here is therefore the compatibility default; at worst this only
-                // adds transport cost for providers that ignore the field.
-                openai_msg["reasoning_content"] = Value::String(reasoning);
-            }
+            // Official OpenAI Chat Completions may ignore replayed reasoning_content, but
+            // many OpenAI-compatible providers require it to continue interleaved thinking.
+            // Preserve even the empty-string case so providers like DeepSeek can validate the
+            // original assistant turn shape on follow-up requests.
+            openai_msg["reasoning_content"] = Value::String(reasoning);
         }
 
         if let Some(tool_calls) = msg.tool_calls {
@@ -496,5 +494,24 @@ mod tests {
         assert_eq!(content[0]["type"], json!("image_url"));
         assert_eq!(content[1]["type"], json!("text"));
         assert_eq!(content[1]["text"], json!("ok"));
+    }
+
+    #[test]
+    fn preserves_empty_reasoning_content_for_chat_completions() {
+        let msg = Message {
+            role: "assistant".to_string(),
+            content: Some("Answer".to_string()),
+            reasoning_content: Some(String::new()),
+            thinking_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+            is_error: None,
+            tool_image_attachments: None,
+        };
+
+        let openai = OpenAIMessageConverter::convert_messages(vec![msg]);
+
+        assert_eq!(openai[0]["reasoning_content"], json!(""));
     }
 }

--- a/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
@@ -1,12 +1,12 @@
 use super::inline_think::InlineThinkParser;
 use super::stream_stats::StreamStats;
-use super::{TimedStreamItem, next_stream_item};
+use super::{next_stream_item, TimedStreamItem};
 use crate::stream::types::anthropic::{
     AnthropicSSEError, ContentBlock, ContentBlockDelta, ContentBlockStart, MessageDelta,
     MessageStart, Usage,
 };
 use crate::stream::types::unified::UnifiedResponse;
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use eventsource_stream::Eventsource;
 use log::{error, trace};
 use reqwest::Response;

--- a/src/crates/ai-adapters/src/stream/types/openai.rs
+++ b/src/crates/ai-adapters/src/stream/types/openai.rs
@@ -214,10 +214,11 @@ impl OpenAISSEData {
             ..
         } = delta;
 
-        // Treat empty strings the same as absent fields (MiniMax sends `content: ""` in
-        // reasoning-only chunks).
+        // Treat empty strings the same as absent fields for assistant text (MiniMax sends
+        // `content: ""` in reasoning-only chunks). Keep empty reasoning content so downstream
+        // can replay structurally present thinking blocks when a provider requires it.
         let content = content.filter(|s| !s.is_empty());
-        let reasoning_content = reasoning_content.filter(|s| !s.is_empty());
+        let reasoning_content = reasoning_content;
 
         // MiniMax uses `reasoning_details` instead of `reasoning_content`.
         // Collect all "reasoning.text" entries and join them as a fallback.
@@ -376,6 +377,29 @@ mod tests {
         assert!(responses[1].finish_reason.is_none());
         assert!(responses[0].usage.is_some());
         assert!(responses[1].usage.is_none());
+    }
+
+    #[test]
+    fn preserves_empty_reasoning_content_chunk() {
+        let raw = r#"{
+            "id": "chatcmpl_test",
+            "created": 123,
+            "model": "deepseek-test",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "reasoning_content": ""
+                },
+                "finish_reason": "stop"
+            }]
+        }"#;
+
+        let sse_data: OpenAISSEData = serde_json::from_str(raw).expect("valid openai sse data");
+        let responses = sse_data.into_unified_responses();
+
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0].reasoning_content.as_deref(), Some(""));
+        assert_eq!(responses[0].finish_reason.as_deref(), Some("stop"));
     }
 
     #[test]

--- a/src/crates/core/src/agentic/core/message.rs
+++ b/src/crates/core/src/agentic/core/message.rs
@@ -273,7 +273,7 @@ impl From<Message> for AIMessage {
                 Self {
                     role: "assistant".to_string(),
                     content,
-                    reasoning_content: reasoning_content.filter(|r| !r.is_empty()),
+                    reasoning_content,
                     thinking_signature: thinking_signature.clone(),
                     tool_calls: converted_tool_calls,
                     tool_call_id: None,
@@ -607,6 +607,23 @@ impl Display for MessageContent {
                     .join(", ")
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Message;
+    use crate::util::types::Message as AIMessage;
+
+    #[test]
+    fn preserves_empty_reasoning_content_for_provider_replay() {
+        let msg = Message::assistant_with_reasoning(Some(String::new()), String::new(), vec![])
+            .with_thinking_signature(Some("sig_1".to_string()));
+
+        let ai_msg = AIMessage::from(msg);
+
+        assert_eq!(ai_msg.reasoning_content.as_deref(), Some(""));
+        assert_eq!(ai_msg.thinking_signature.as_deref(), Some("sig_1"));
     }
 }
 

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -375,7 +375,11 @@ impl RoundExecutor {
 
             // Create assistant message (includes thinking content, supports interleaved thinking mode)
             let reasoning = if stream_result.full_thinking.is_empty() {
-                None
+                if stream_result.reasoning_content_present {
+                    Some(String::new())
+                } else {
+                    None
+                }
             } else {
                 Some(stream_result.full_thinking.clone())
             };
@@ -552,7 +556,11 @@ impl RoundExecutor {
 
         // Create assistant message (includes tool calls and thinking content, supports interleaved thinking mode)
         let reasoning = if stream_result.full_thinking.is_empty() {
-            None
+            if stream_result.reasoning_content_present {
+                Some(String::new())
+            } else {
+                None
+            }
         } else {
             Some(stream_result.full_thinking.clone())
         };
@@ -832,6 +840,7 @@ mod tests {
     fn detects_interrupted_invalid_tool_only_recovery() {
         let result = crate::agentic::execution::stream_processor::StreamResult {
             full_thinking: String::new(),
+            reasoning_content_present: false,
             thinking_signature: None,
             full_text: String::new(),
             tool_calls: vec![crate::agentic::core::ToolCall {
@@ -855,6 +864,7 @@ mod tests {
     fn keeps_partial_text_recovery_as_non_retryable_output() {
         let result = crate::agentic::execution::stream_processor::StreamResult {
             full_thinking: String::new(),
+            reasoning_content_present: false,
             thinking_signature: None,
             full_text: "I started answering before the stream failed.".to_string(),
             tool_calls: vec![crate::agentic::core::ToolCall {

--- a/src/crates/core/src/agentic/execution/stream_processor.rs
+++ b/src/crates/core/src/agentic/execution/stream_processor.rs
@@ -112,6 +112,8 @@ const UNKNOWN_TOOL_PLACEHOLDER: &str = "unknown_tool";
 #[derive(Debug, Clone)]
 pub struct StreamResult {
     pub full_thinking: String,
+    /// Whether the provider emitted a reasoning/thinking field even if its content was empty.
+    pub reasoning_content_present: bool,
     /// Signature of Anthropic extended thinking (passed back in multi-turn conversations)
     pub thinking_signature: Option<String>,
     pub full_text: String,
@@ -158,6 +160,7 @@ struct StreamContext {
 
     // Accumulated results
     full_thinking: String,
+    reasoning_content_present: bool,
     /// Signature of Anthropic extended thinking (passed back in multi-turn conversations)
     thinking_signature: Option<String>,
     full_text: String,
@@ -194,6 +197,7 @@ impl StreamContext {
             event_subagent_parent_info,
             subagent_parent_info,
             full_thinking: String::new(),
+            reasoning_content_present: false,
             thinking_signature: None,
             full_text: String::new(),
             tool_calls: Vec::new(),
@@ -214,6 +218,7 @@ impl StreamContext {
     fn into_result(self) -> StreamResult {
         StreamResult {
             full_thinking: self.full_thinking,
+            reasoning_content_present: self.reasoning_content_present,
             thinking_signature: self.thinking_signature,
             full_text: self.full_text,
             tool_calls: self.tool_calls,
@@ -821,6 +826,7 @@ impl StreamProcessor {
                     // Handle thinking_signature
                     if let Some(signature) = thinking_signature {
                         if !signature.is_empty() {
+                            ctx.reasoning_content_present = true;
                             ctx.thinking_signature = Some(signature);
                             trace!("Received thinking_signature");
                         }
@@ -830,12 +836,14 @@ impl StreamProcessor {
                     // Normalize empty strings to None
                     //  (some models send empty text alongside reasoning content)
                     let text = text.filter(|t| !t.is_empty());
-                    let reasoning_content = reasoning_content.filter(|t| !t.is_empty());
 
                     if let Some(thinking_content) = reasoning_content {
-                        self.handle_thinking_chunk(&mut ctx, thinking_content).await;
-                        if let Some(err) = self.check_cancellation(&mut ctx, cancellation_token, "processing thinking chunk").await {
-                            return err;
+                        ctx.reasoning_content_present = true;
+                        if !thinking_content.is_empty() {
+                            self.handle_thinking_chunk(&mut ctx, thinking_content).await;
+                            if let Some(err) = self.check_cancellation(&mut ctx, cancellation_token, "processing thinking chunk").await {
+                                return err;
+                            }
                         }
                     }
 
@@ -1196,5 +1204,34 @@ mod tests {
         assert_eq!(result.tool_calls[1].tool_id, "call_1");
         assert_eq!(result.tool_calls[1].tool_name, "tool_b");
         assert_eq!(result.tool_calls[1].arguments, json!({"b": 2}));
+    }
+
+    #[tokio::test]
+    async fn preserves_empty_reasoning_presence_for_replay() {
+        let processor = build_processor();
+        let stream = iter(vec![Ok(UnifiedResponse {
+            reasoning_content: Some(String::new()),
+            finish_reason: Some("stop".to_string()),
+            ..Default::default()
+        })])
+        .boxed();
+
+        let result = processor
+            .process_stream(
+                stream,
+                None,
+                None,
+                "session_1".to_string(),
+                "turn_1".to_string(),
+                "round_1".to_string(),
+                None,
+                &CancellationToken::new(),
+            )
+            .await
+            .expect("stream result");
+
+        assert!(result.reasoning_content_present);
+        assert!(result.full_thinking.is_empty());
+        assert!(!result.has_effective_output);
     }
 }

--- a/src/crates/core/tests/fixtures/stream/anthropic/empty_thinking_signature_text_and_tool_use.sse
+++ b/src/crates/core/tests/fixtures/stream/anthropic/empty_thinking_signature_text_and_tool_use.sse
@@ -1,0 +1,36 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_empty_think_tool_test","type":"message","role":"assistant","content":[],"model":"claude-test","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":null}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_empty_123"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Let me check that for you."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: content_block_start
+data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_ds_1","name":"lookup_status"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"ticket_id\":\"BF-123\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":2}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":15}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/src/crates/core/tests/fixtures/stream/openai/empty_reasoning_content_text_and_tool_call.sse
+++ b/src/crates/core/tests/fixtures/stream/openai/empty_reasoning_content_text_and_tool_call.sse
@@ -1,0 +1,10 @@
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":400,"model":"deepseek-v4-test","choices":[{"index":0,"delta":{"reasoning_content":""},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":401,"model":"deepseek-v4-test","choices":[{"index":0,"delta":{"content":"Let me check that for you."},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":402,"model":"deepseek-v4-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_ds_1","type":"function","function":{"name":"lookup_status","arguments":"{\"ticket_id\":\"BF-"}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":403,"model":"deepseek-v4-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":null,"type":"function","function":{"arguments":"123\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":4,"completion_tokens":6,"total_tokens":10}}
+
+data: [DONE]
+

--- a/src/crates/core/tests/stream_replay_regressions.rs
+++ b/src/crates/core/tests/stream_replay_regressions.rs
@@ -1,0 +1,179 @@
+mod common;
+
+use bitfun_ai_adapters::providers::{AnthropicMessageConverter, openai::OpenAIMessageConverter};
+use bitfun_core::agentic::core::Message as CoreMessage;
+use bitfun_core::agentic::events::{AgenticEvent, ToolEventData};
+use bitfun_core::util::types::Message as AIMessage;
+use common::sse_fixture_server::FixtureSseServerOptions;
+use common::stream_test_harness::{
+    run_stream_fixture, run_stream_fixture_with_options, StreamFixtureProvider,
+    StreamFixtureRunOptions,
+};
+use serde_json::json;
+
+fn build_replay_assistant_message(
+    result: &bitfun_core::agentic::execution::StreamResult,
+) -> CoreMessage {
+    let reasoning = if result.full_thinking.is_empty() {
+        if result.reasoning_content_present {
+            Some(String::new())
+        } else {
+            None
+        }
+    } else {
+        Some(result.full_thinking.clone())
+    };
+
+    CoreMessage::assistant_with_reasoning(
+        reasoning,
+        result.full_text.clone(),
+        result.tool_calls.clone(),
+    )
+    .with_thinking_signature(result.thinking_signature.clone())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn replays_structurally_empty_openai_reasoning_content_with_tool_call() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::OpenAi,
+        "stream/openai/empty_reasoning_content_text_and_tool_call.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+
+    assert!(result.reasoning_content_present);
+    assert!(result.full_thinking.is_empty());
+    assert_eq!(result.full_text, "Let me check that for you.");
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].tool_id, "call_ds_1");
+    assert_eq!(result.tool_calls[0].tool_name, "lookup_status");
+    assert_eq!(result.tool_calls[0].arguments, json!({ "ticket_id": "BF-123" }));
+    assert!(!result.tool_calls[0].is_error);
+    assert_eq!(
+        result.usage.as_ref().map(|usage| usage.total_token_count),
+        Some(10)
+    );
+
+    let thinking_chunks: Vec<(&str, bool)> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ThinkingChunk {
+                content, is_end, ..
+            } => Some((content.as_str(), *is_end)),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        thinking_chunks.is_empty(),
+        "empty reasoning content should not emit visible thinking chunks"
+    );
+
+    let tool_events: Vec<(&str, &str)> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ToolEvent {
+                tool_event:
+                    ToolEventData::ParamsPartial {
+                        tool_id, params, ..
+                    },
+                ..
+            } => Some((tool_id.as_str(), params.as_str())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        tool_events,
+        vec![("call_ds_1", "{\"ticket_id\":\"BF-"), ("call_ds_1", "123\"}")]
+    );
+
+    let replay_message: AIMessage = build_replay_assistant_message(&result).into();
+    let openai_payload = OpenAIMessageConverter::convert_messages(vec![replay_message]);
+
+    assert_eq!(openai_payload.len(), 1);
+    assert_eq!(openai_payload[0]["content"], json!("Let me check that for you."));
+    assert_eq!(openai_payload[0]["reasoning_content"], json!(""));
+    assert_eq!(openai_payload[0]["tool_calls"][0]["id"], json!("call_ds_1"));
+    assert_eq!(
+        openai_payload[0]["tool_calls"][0]["function"]["name"],
+        json!("lookup_status")
+    );
+    assert_eq!(
+        openai_payload[0]["tool_calls"][0]["function"]["arguments"],
+        json!("{\"ticket_id\":\"BF-123\"}")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn replays_structurally_empty_anthropic_thinking_with_signature_and_tool_use() {
+    let output = run_stream_fixture_with_options(
+        StreamFixtureProvider::Anthropic,
+        "stream/anthropic/empty_thinking_signature_text_and_tool_use.sse",
+        StreamFixtureRunOptions {
+            anthropic_inline_think_in_text: false,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+
+    assert!(result.reasoning_content_present);
+    assert!(result.full_thinking.is_empty());
+    assert_eq!(result.full_text, "Let me check that for you.");
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].tool_id, "toolu_ds_1");
+    assert_eq!(result.tool_calls[0].tool_name, "lookup_status");
+    assert_eq!(result.tool_calls[0].arguments, json!({ "ticket_id": "BF-123" }));
+    assert!(!result.tool_calls[0].is_error);
+    assert_eq!(result.thinking_signature.as_deref(), Some("sig_empty_123"));
+    assert_eq!(
+        result.usage.as_ref().map(|usage| usage.total_token_count),
+        Some(25)
+    );
+
+    let thinking_chunks: Vec<(&str, bool)> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ThinkingChunk {
+                content, is_end, ..
+            } => Some((content.as_str(), *is_end)),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        thinking_chunks.is_empty(),
+        "empty thinking content should not emit visible thinking chunks"
+    );
+
+    let early_detected = output.events.iter().any(|event| {
+        matches!(
+            event,
+            AgenticEvent::ToolEvent {
+                tool_event: ToolEventData::EarlyDetected { tool_id, tool_name },
+                ..
+            } if tool_id == "toolu_ds_1" && tool_name == "lookup_status"
+        )
+    });
+    assert!(early_detected, "expected tool_use block to trigger early detection");
+
+    let replay_message: AIMessage = build_replay_assistant_message(&result).into();
+    let (_, anthropic_messages) = AnthropicMessageConverter::convert_messages(vec![replay_message]);
+    let content = anthropic_messages[0]["content"]
+        .as_array()
+        .expect("assistant content");
+
+    assert_eq!(content[0]["type"], json!("thinking"));
+    assert_eq!(content[0]["thinking"], json!(""));
+    assert_eq!(content[0]["signature"], json!("sig_empty_123"));
+    assert_eq!(content[1]["type"], json!("text"));
+    assert_eq!(content[1]["text"], json!("Let me check that for you."));
+    assert_eq!(content[2]["type"], json!("tool_use"));
+    assert_eq!(content[2]["id"], json!("toolu_ds_1"));
+    assert_eq!(content[2]["name"], json!("lookup_status"));
+    assert_eq!(content[2]["input"], json!({ "ticket_id": "BF-123" }));
+}

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -11,7 +11,7 @@ import {
 } from '../types';
 import { configManager } from '../services/ConfigManager';
 import { PROVIDER_TEMPLATES, getModelDisplayName, getProviderDisplayName, getProviderTemplateId } from '../services/modelConfigs';
-import { DEFAULT_REASONING_MODE, getEffectiveReasoningMode, supportsAnthropicAdaptive, supportsAnthropicReasoning, supportsAnthropicThinkingBudget, supportsResponsesReasoning } from '../utils/reasoning';
+import { DEFAULT_REASONING_MODE, getEffectiveReasoningMode, supportsAnthropicAdaptive, supportsAnthropicReasoning, supportsAnthropicThinkingBudget, supportsDeepSeekReasoningEffort, supportsResponsesReasoning } from '../utils/reasoning';
 import { aiApi, systemAPI } from '@/infrastructure/api';
 import type { DiscoveredCliCredential } from '@/infrastructure/api/service-api/AIApi';
 import { useNotification } from '@/shared/notification-system';
@@ -72,8 +72,9 @@ function createModelDraft(
 
 function normalizeDraftReasoningForProvider(
   draft: SelectedModelDraft,
-  provider?: string
+  config?: Partial<Pick<AIModelConfigType, 'name' | 'provider' | 'base_url'>>
 ): SelectedModelDraft {
+  const provider = config?.provider;
   let reasoningMode = draft.reasoningMode;
 
   if (supportsResponsesReasoning(provider)) {
@@ -86,8 +87,14 @@ function normalizeDraftReasoningForProvider(
     reasoningMode = 'enabled';
   }
 
+  const supportsDeepSeekEffort = supportsDeepSeekReasoningEffort({
+    name: config?.name,
+    base_url: config?.base_url,
+    model_name: draft.modelName,
+  });
   const keepReasoningEffort = supportsResponsesReasoning(provider)
-    || (supportsAnthropicReasoning(provider) && reasoningMode === 'adaptive');
+    || (supportsAnthropicReasoning(provider) && reasoningMode === 'adaptive')
+    || (supportsDeepSeekEffort && reasoningMode !== 'disabled');
   const keepThinkingBudget = supportsAnthropicReasoning(provider)
     && reasoningMode === 'enabled'
     && supportsAnthropicThinkingBudget(draft.modelName);
@@ -339,6 +346,14 @@ const AIModelConfig: React.FC = () => {
     []
   );
 
+  const deepSeekReasoningEffortOptions = useMemo(
+    () => [
+      { label: 'High', value: 'high' },
+      { label: 'Max', value: 'max' },
+    ],
+    []
+  );
+
   const buildReasoningModeOptions = useCallback((provider?: string, modelName?: string, currentMode?: ReasoningMode): SelectOption[] => {
     const options: SelectOption[] = [
       { label: t('thinking.optionDefault'), value: DEFAULT_REASONING_MODE },
@@ -510,6 +525,11 @@ const AIModelConfig: React.FC = () => {
     baseConfig?: Partial<AIModelConfigType>,
     singleSelection = false
   ) => {
+    const reasoningProviderConfig = {
+      name: baseConfig?.name ?? editingConfig?.name ?? currentTemplate?.name,
+      provider: baseConfig?.provider ?? editingConfig?.provider ?? currentTemplate?.format,
+      base_url: baseConfig?.base_url ?? editingConfig?.base_url ?? currentTemplate?.baseUrl,
+    };
     const providerName = (
       baseConfig?.name ||
       editingConfig?.name ||
@@ -538,17 +558,17 @@ const AIModelConfig: React.FC = () => {
 
         if (existingDraft) {
           const configId = pinnedRowId ?? configuredModel?.id ?? existingDraft.configId;
-          return {
+          return normalizeDraftReasoningForProvider({
             ...existingDraft,
             modelName,
             configId,
             key: configId ?? modelName,
-          };
+          }, reasoningProviderConfig);
         }
 
-        return createModelDraft(modelName, configuredModel || baseConfig, {
+        return normalizeDraftReasoningForProvider(createModelDraft(modelName, configuredModel || baseConfig, {
           configId: pinnedRowId ?? configuredModel?.id,
-        });
+        }), reasoningProviderConfig);
       })
     );
 
@@ -1493,12 +1513,18 @@ const AIModelConfig: React.FC = () => {
       return parts.join(' · ');
     };
 
-    const getDraftReasoningEffortOptions = (provider?: string) => {
-      if (supportsResponsesReasoning(provider)) {
+    const getDraftReasoningEffortOptions = (
+      config?: Partial<Pick<AIModelConfigType, 'name' | 'provider' | 'base_url' | 'model_name'>>
+    ) => {
+      if (supportsDeepSeekReasoningEffort(config)) {
+        return deepSeekReasoningEffortOptions;
+      }
+
+      if (supportsResponsesReasoning(config?.provider)) {
         return responsesReasoningEffortOptions;
       }
 
-      if (supportsAnthropicReasoning(provider)) {
+      if (supportsAnthropicReasoning(config?.provider)) {
         return anthropicReasoningEffortOptions;
       }
 
@@ -1522,12 +1548,19 @@ const AIModelConfig: React.FC = () => {
             const canToggleExpand = selectedModelDrafts.length > 1;
             const modelDisplayName = draft.modelName;
             const reasoningModeOptions = buildReasoningModeOptions(editingConfig.provider, draft.modelName, draft.reasoningMode);
-            const reasoningEffortOptions = getDraftReasoningEffortOptions(editingConfig.provider);
+            const reasoningCapabilityConfig = {
+              name: editingConfig.name,
+              provider: editingConfig.provider,
+              base_url: editingConfig.base_url,
+              model_name: draft.modelName,
+            };
+            const reasoningEffortOptions = getDraftReasoningEffortOptions(reasoningCapabilityConfig);
             const showReasoningModeControl = !supportsResponsesReasoning(editingConfig.provider);
             const showReasoningEffortControl = reasoningEffortOptions.length > 0
               && (
                 supportsResponsesReasoning(editingConfig.provider)
                 || (supportsAnthropicReasoning(editingConfig.provider) && draft.reasoningMode === 'adaptive')
+                || (supportsDeepSeekReasoningEffort(reasoningCapabilityConfig) && draft.reasoningMode !== 'disabled')
               );
             const showThinkingBudgetControl = supportsAnthropicReasoning(editingConfig.provider)
               && draft.reasoningMode === 'enabled'
@@ -1817,7 +1850,11 @@ const AIModelConfig: React.FC = () => {
                       const provider = value as string;
                       resetRemoteModelDiscovery();
                       setSelectedModelDrafts(prevDrafts =>
-                        prevDrafts.map(draft => normalizeDraftReasoningForProvider(draft, provider))
+                        prevDrafts.map(draft => normalizeDraftReasoningForProvider(draft, {
+                          name: editingConfig?.name,
+                          provider,
+                          base_url: editingConfig?.base_url,
+                        }))
                       );
                       setEditingConfig(prev => ({
                         ...prev,
@@ -1922,7 +1959,11 @@ const AIModelConfig: React.FC = () => {
                         const provider = value as string;
                         resetRemoteModelDiscovery();
                         setSelectedModelDrafts(prevDrafts =>
-                          prevDrafts.map(draft => normalizeDraftReasoningForProvider(draft, provider))
+                          prevDrafts.map(draft => normalizeDraftReasoningForProvider(draft, {
+                            name: editingConfig?.name,
+                            provider,
+                            base_url: editingConfig?.base_url,
+                          }))
                         );
                         setEditingConfig(prev => ({
                           ...prev,

--- a/src/web-ui/src/infrastructure/config/schemas/ai-models.json
+++ b/src/web-ui/src/infrastructure/config/schemas/ai-models.json
@@ -353,7 +353,7 @@
                         "dataType": "string",
                         "key": "reasoning_effort",
                         "title": "推理深度 (Reasoning Effort)",
-                        "description": "控制 provider 支持的推理强度，适用于 Responses API 与支持自适应推理的 Claude 模型",
+                        "description": "控制 provider 支持的推理强度，适用于 DeepSeek、Responses API 与支持自适应推理的 Claude 模型",
                         "ui": {
                           "placeholder": "使用 API 默认值",
                           "allowClear": true,

--- a/src/web-ui/src/infrastructure/config/services/modelConfigs.ts
+++ b/src/web-ui/src/infrastructure/config/services/modelConfigs.ts
@@ -121,7 +121,7 @@ export const PROVIDER_TEMPLATES: Record<string, ProviderTemplate> = {
     name: t('settings/ai-model:providers.deepseek.name'),
     baseUrl: 'https://api.deepseek.com/v1',
     format: 'openai',
-    models: ['deepseek-chat', 'deepseek-reasoner'],
+    models: ['deepseek-v4-flash', 'deepseek-v4-pro'],
     requiresApiKey: true,
     description: t('settings/ai-model:providers.deepseek.description'),
     helpUrl: 'https://platform.deepseek.com/api_keys'

--- a/src/web-ui/src/infrastructure/config/utils/reasoning.ts
+++ b/src/web-ui/src/infrastructure/config/utils/reasoning.ts
@@ -1,6 +1,12 @@
 import type { AIModelConfig, ReasoningMode } from '../types';
+import { getProviderTemplateId } from '../services/modelConfigs';
 
 export const DEFAULT_REASONING_MODE: ReasoningMode = 'default';
+
+const DEEPSEEK_REASONING_EFFORT_MODELS = new Set([
+  'deepseek-v4-flash',
+  'deepseek-v4-pro',
+]);
 
 export function getEffectiveReasoningMode(
   config?: Pick<AIModelConfig, 'reasoning_mode'> | null
@@ -29,4 +35,19 @@ export function supportsAnthropicAdaptive(modelName?: string): boolean {
 
 export function supportsAnthropicThinkingBudget(modelName?: string): boolean {
   return (modelName || '').trim().toLowerCase().startsWith('claude');
+}
+
+export function supportsDeepSeekReasoningEffort(
+  config?: Partial<Pick<AIModelConfig, 'name' | 'base_url' | 'model_name'>> | null
+): boolean {
+  const normalizedModelName = (config?.model_name || '').trim().toLowerCase();
+  if (DEEPSEEK_REASONING_EFFORT_MODELS.has(normalizedModelName)) {
+    return true;
+  }
+
+  return getProviderTemplateId({
+    name: config?.name,
+    base_url: config?.base_url,
+    model_name: config?.model_name,
+  }) === 'deepseek';
 }

--- a/src/web-ui/src/locales/en-US/settings/ai-model.json
+++ b/src/web-ui/src/locales/en-US/settings/ai-model.json
@@ -190,7 +190,7 @@
   },
   "reasoningEffort": {
     "label": "Reasoning Effort",
-    "hint": "Controls provider-specific reasoning depth for Responses API and supported Claude adaptive reasoning models",
+    "hint": "Controls provider-specific reasoning depth for DeepSeek, the Responses API, and supported Claude adaptive reasoning models",
     "placeholder": "Use API default"
   },
   "details": {

--- a/src/web-ui/src/locales/zh-CN/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-CN/settings/ai-model.json
@@ -190,7 +190,7 @@
   },
   "reasoningEffort": {
     "label": "推理深度",
-    "hint": "控制 provider 支持的推理强度，适用于 Responses API 与支持自适应推理的 Claude 模型",
+    "hint": "控制 provider 支持的推理强度，适用于 DeepSeek、Responses API 与支持自适应推理的 Claude 模型",
     "placeholder": "使用 API 默认值"
   },
   "details": {

--- a/src/web-ui/src/locales/zh-TW/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-TW/settings/ai-model.json
@@ -190,7 +190,7 @@
   },
   "reasoningEffort": {
     "label": "推理深度",
-    "hint": "控制 provider 支持的推理強度，適用於 Responses API 與支持自適應推理的 Claude 模型",
+    "hint": "控制 provider 支持的推理強度，適用於 DeepSeek、Responses API 與支持自適應推理的 Claude 模型",
     "placeholder": "使用 API 默認值"
   },
   "details": {


### PR DESCRIPTION
## Summary

- add DeepSeek reasoning effort support for OpenAI-compatible and Anthropic-compatible requests
- show DeepSeek reasoning effort as `high` / `max` in model config
- preserve empty reasoning / thinking blocks during replay