### PR TITLE
fix: correct remote SSH command completion handling

### DIFF
--- a/src/crates/core/src/agentic/tools/implementations/file_read_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_read_tool.rs
@@ -106,7 +106,10 @@ impl FileReadTool {
         }
 
         let total_lines = total_lines.ok_or_else(|| {
-            BitFunError::tool("Failed to read file: remote line count was unavailable".to_string())
+            BitFunError::tool(
+                "Failed to read file: remote command did not return line-count markers"
+                    .to_string(),
+            )
         })?;
 
         if total_lines == 0 {

--- a/src/crates/core/src/service/remote_ssh/manager.rs
+++ b/src/crates/core/src/service/remote_ssh/manager.rs
@@ -1411,13 +1411,14 @@ impl SSHConnectionManager {
                 Some(russh::ChannelMsg::ExitSignal { signal_name, .. }) => {
                     interrupted = interrupted || matches!(signal_name, Sig::INT | Sig::TERM);
                 }
-                Some(russh::ChannelMsg::Eof) | Some(russh::ChannelMsg::Close) => {
-                    break;
+                Some(russh::ChannelMsg::Eof) => {
+                }
+                Some(russh::ChannelMsg::Close) => {
                 }
                 None => {
                     break;
                 }
-                _ => {}
+                Some(_) => {}
             }
         }
 


### PR DESCRIPTION
- prevent remote exec from stopping at `Eof` before `ExitStatus`
- keep consuming SSH channel messages until the channel actually closes
