### PR TITLE
feat(core, desktop): remote workspace identity for tools and subagents

### DIFF
--- a/src/apps/desktop/src/api/tool_api.rs
+++ b/src/apps/desktop/src/api/tool_api.rs
@@ -12,7 +12,7 @@ use bitfun_core::agentic::{
     WorkspaceBinding,
 };
 use bitfun_core::service::remote_ssh::workspace_state::{
-    get_remote_workspace_manager, lookup_remote_connection, resolve_workspace_session_identity,
+    get_remote_workspace_manager, lookup_remote_connection, workspace_session_identity,
 };
 use bitfun_core::util::elapsed_ms_u64;
 
@@ -92,26 +92,31 @@ async fn build_tool_context(workspace_path: Option<&str>) -> ToolUseContext {
         .filter(|path| !path.is_empty());
 
     let workspace = match normalized_workspace_path {
-        Some(path) => match resolve_workspace_session_identity(path, None, None).await {
-            Some(identity) => {
-                if let Some(connection_id) = identity.remote_connection_id.as_deref() {
-                    let connection_name = lookup_remote_connection(path)
-                        .await
-                        .map(|entry| entry.connection_name)
-                        .unwrap_or_else(|| connection_id.to_string());
-                    Some(WorkspaceBinding::new_remote(
-                        None,
-                        PathBuf::from(path),
-                        connection_id.to_string(),
-                        connection_name,
-                        identity,
-                    ))
-                } else {
-                    Some(WorkspaceBinding::new(None, PathBuf::from(path)))
-                }
+        Some(path) => {
+            if let Some(entry) = lookup_remote_connection(path).await {
+                let identity = workspace_session_identity(
+                    path,
+                    Some(&entry.connection_id),
+                    Some(&entry.ssh_host),
+                )
+                .unwrap_or_else(|| {
+                    bitfun_core::service::remote_ssh::workspace_state::WorkspaceSessionIdentity {
+                        hostname: entry.ssh_host.clone(),
+                        logical_workspace_path: entry.remote_root.clone(),
+                        remote_connection_id: Some(entry.connection_id.clone()),
+                    }
+                });
+                Some(WorkspaceBinding::new_remote(
+                    None,
+                    PathBuf::from(path),
+                    entry.connection_id,
+                    entry.connection_name,
+                    identity,
+                ))
+            } else {
+                Some(WorkspaceBinding::new(None, PathBuf::from(path)))
             }
-            None => Some(WorkspaceBinding::new(None, PathBuf::from(path))),
-        },
+        }
         None => None,
     };
 

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -314,6 +314,30 @@ impl ConversationCoordinator {
         Some(binding)
     }
 
+    async fn build_session_config_for_workspace(
+        workspace_path: String,
+        model_id: Option<String>,
+    ) -> SessionConfig {
+        let remote_entry =
+            crate::service::remote_ssh::workspace_state::lookup_remote_connection(&workspace_path)
+                .await;
+
+        let mut config = SessionConfig {
+            workspace_path: Some(workspace_path),
+            model_id,
+            ..SessionConfig::default()
+        };
+
+        if let Some(entry) = remote_entry {
+            config.remote_connection_id = Some(entry.connection_id);
+            if !entry.ssh_host.trim().is_empty() {
+                config.remote_ssh_host = Some(entry.ssh_host);
+            }
+        }
+
+        config
+    }
+
     /// Build `WorkspaceServices` from a resolved `WorkspaceBinding`.
     /// For remote bindings, wires up SSH-backed FS/shell; for local ones,
     /// returns local implementations.
@@ -2949,11 +2973,8 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             HiddenSubagentExecutionRequest {
                 session_name: format!("Subagent: {}", task_description),
                 agent_type,
-                session_config: SessionConfig {
-                    workspace_path: Some(workspace_path),
-                    model_id,
-                    ..SessionConfig::default()
-                },
+                session_config: Self::build_session_config_for_workspace(workspace_path, model_id)
+                    .await,
                 initial_messages: vec![Message::user(task_description)],
                 created_by: Some(format!("session-{}", subagent_parent_info.session_id)),
                 subagent_parent_info: Some(subagent_parent_info),
@@ -3202,12 +3223,46 @@ pub fn get_global_coordinator() -> Option<Arc<ConversationCoordinator>> {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_subagent_max_concurrency;
+    use super::{normalize_subagent_max_concurrency, ConversationCoordinator};
+    use crate::service::remote_ssh::workspace_state::init_remote_workspace_manager;
 
     #[test]
     fn clamps_subagent_max_concurrency_into_safe_range() {
         assert_eq!(normalize_subagent_max_concurrency(0), 1);
         assert_eq!(normalize_subagent_max_concurrency(5), 5);
         assert_eq!(normalize_subagent_max_concurrency(usize::MAX), 64);
+    }
+
+    #[tokio::test]
+    async fn subagent_session_config_preserves_registered_remote_workspace_identity() {
+        let manager = init_remote_workspace_manager();
+        manager
+            .register_remote_workspace(
+                "/remote/subagent-test".to_string(),
+                "conn-subagent-test".to_string(),
+                "Remote Test".to_string(),
+                "remote-host".to_string(),
+            )
+            .await;
+        manager
+            .set_active_connection_hint(Some("conn-subagent-test".to_string()))
+            .await;
+
+        let config = ConversationCoordinator::build_session_config_for_workspace(
+            "/remote/subagent-test/project".to_string(),
+            Some("model-fast".to_string()),
+        )
+        .await;
+
+        assert_eq!(
+            config.workspace_path.as_deref(),
+            Some("/remote/subagent-test/project")
+        );
+        assert_eq!(
+            config.remote_connection_id.as_deref(),
+            Some("conn-subagent-test")
+        );
+        assert_eq!(config.remote_ssh_host.as_deref(), Some("remote-host"));
+        assert_eq!(config.model_id.as_deref(), Some("model-fast"));
     }
 }

--- a/src/crates/core/src/agentic/tools/implementations/mcp_tools.rs
+++ b/src/crates/core/src/agentic/tools/implementations/mcp_tools.rs
@@ -64,22 +64,12 @@ async fn list_prompts_for_server(
 async fn ensure_mcp_server_available_for_context(
     manager: &Arc<MCPServerManager>,
     server_id: &str,
-    context: &ToolUseContext,
+    _context: &ToolUseContext,
 ) -> BitFunResult<()> {
-    if !context.is_remote() {
-        return Ok(());
-    }
-
-    let connection = manager
+    manager
         .get_connection(server_id)
         .await
         .ok_or_else(|| tool_error(format!("MCP server not connected: {}", server_id)))?;
-    if connection.is_local_stdio() {
-        return Err(tool_error(format!(
-            "MCP server '{}' runs locally and is unavailable in remote workspace sessions",
-            server_id
-        )));
-    }
 
     Ok(())
 }

--- a/src/crates/core/src/miniapp/builtin/assets/coding-selfie/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/coding-selfie/ui.js
@@ -1110,6 +1110,15 @@ async function gitRunOptional(cwd, argv, fallback = '', opts = {}) {
   }
 }
 
+function isGitNotRepositoryError(error) {
+  const message = String(error && error.message ? error.message : error || '').toLowerCase();
+  return (
+    message.includes('not a git repository') ||
+    message.includes('not a git directory') ||
+    message.includes('outside repository')
+  );
+}
+
 function dayKey(d) {
   const dt = new Date(d);
   return (
@@ -1127,8 +1136,15 @@ async function scanGitWorkspace(cwd) {
   let inside;
   try {
     inside = (await gitRun(cwd, ['rev-parse', '--is-inside-work-tree'], { timeout: 8000 })).trim();
-  } catch (_e) {
-    return { ok: false, reason: 'not-a-git-repo' };
+  } catch (e) {
+    if (isGitNotRepositoryError(e)) {
+      return { ok: false, reason: 'not-a-git-repo' };
+    }
+    return {
+      ok: false,
+      reason: 'git-probe-failed',
+      message: String(e && e.message ? e.message : e),
+    };
   }
   if (inside !== 'true') return { ok: false, reason: 'not-a-git-repo' };
 

--- a/src/crates/core/src/miniapp/host_dispatch.rs
+++ b/src/crates/core/src/miniapp/host_dispatch.rs
@@ -141,6 +141,28 @@ fn arg_path(params: &Value, key: &str) -> BitFunResult<PathBuf> {
         .ok_or_else(|| BitFunError::parse(format!("missing param: {}", key)))
 }
 
+fn command_basename_for_allowlist(command: &str) -> String {
+    let file_name = command
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|name| !name.is_empty())
+        .unwrap_or(command);
+    Path::new(file_name)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(file_name)
+        .to_lowercase()
+}
+
+fn resolve_shell_program(command: &str) -> PathBuf {
+    let has_path_separator = command.contains('/') || command.contains('\\');
+    if has_path_separator {
+        return PathBuf::from(command);
+    }
+
+    which::which(command).unwrap_or_else(|_| PathBuf::from(command))
+}
+
 async fn dispatch_fs(policy: &Value, name: &str, params: &Value) -> BitFunResult<Value> {
     // Common path arg ("path" or legacy "p").
     let path_param = params
@@ -366,11 +388,7 @@ async fn dispatch_shell(
         Some(a) => a.first().map(String::as_str).unwrap_or(""),
         None => command.split_whitespace().next().unwrap_or(""),
     };
-    let base = Path::new(first_token)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or(first_token)
-        .to_lowercase();
+    let base = command_basename_for_allowlist(first_token);
     if !allow.is_empty() && !allow.iter().any(|a| a.to_lowercase() == base) {
         return Err(deny(format!("Command not in allowlist: {}", base)));
     }
@@ -389,7 +407,8 @@ async fn dispatch_shell(
         .unwrap_or(30_000);
 
     let mut cmd = if let Some(argv) = argv.as_ref() {
-        let mut c = crate::util::process_manager::create_tokio_command(&argv[0]);
+        let program = resolve_shell_program(&argv[0]);
+        let mut c = crate::util::process_manager::create_tokio_command(program.as_os_str());
         if argv.len() > 1 {
             c.args(&argv[1..]);
         }
@@ -538,4 +557,56 @@ async fn dispatch_net(policy: &Value, name: &str, params: &Value) -> BitFunResul
         "headers": Value::Object(headers_out),
         "body": body,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::miniapp::types::{MiniAppPermissions, ShellPermissions};
+
+    #[test]
+    fn command_basename_allows_windows_git_executable_paths() {
+        assert_eq!(
+            command_basename_for_allowlist(r"C:\Program Files\Git\cmd\git.exe"),
+            "git"
+        );
+        assert_eq!(command_basename_for_allowlist("git.exe"), "git");
+        assert_eq!(command_basename_for_allowlist("/usr/bin/git"), "git");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn host_shell_exec_runs_git_with_workspace_cwd() {
+        let workspace_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let perms = MiniAppPermissions {
+            shell: Some(ShellPermissions {
+                allow: Some(vec!["git".to_string()]),
+            }),
+            ..Default::default()
+        };
+
+        let result = dispatch_host(
+            &perms,
+            "builtin-coding-selfie",
+            workspace_dir,
+            Some(workspace_dir),
+            &[],
+            "shell.exec",
+            json!({
+                "args": ["git", "rev-parse", "--is-inside-work-tree"],
+                "cwd": workspace_dir.to_string_lossy(),
+                "timeout": 8000,
+            }),
+        )
+        .await
+        .expect("git rev-parse should run in the repository workspace");
+
+        assert_eq!(
+            result
+                .get("stdout")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim(),
+            "true"
+        );
+    }
 }

--- a/src/crates/core/src/service/config/types.rs
+++ b/src/crates/core/src/service/config/types.rs
@@ -41,6 +41,9 @@ pub struct GlobalConfig {
     pub terminal: TerminalConfig,
     pub workspace: WorkspaceConfig,
     pub ai: AIConfig,
+    /// Project-scoped overlays stored in the shared config document.
+    #[serde(default, skip_serializing_if = "ProjectConfig::is_empty")]
+    pub project: ProjectConfig,
     /// MCP server configuration (stored uniformly; supports both JSON and structured formats).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mcp_servers: Option<serde_json::Value>,
@@ -56,6 +59,21 @@ pub struct GlobalConfig {
     pub version: String,
     #[serde(with = "chrono::serde::ts_milliseconds")]
     pub last_modified: chrono::DateTime<chrono::Utc>,
+}
+
+/// Project-scoped configuration overlay.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ProjectConfig {
+    /// Project-level MCP server configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcp_servers: Option<serde_json::Value>,
+}
+
+impl ProjectConfig {
+    fn is_empty(&self) -> bool {
+        self.mcp_servers.is_none()
+    }
 }
 
 /// App configuration.
@@ -1192,6 +1210,7 @@ impl Default for GlobalConfig {
             terminal: TerminalConfig::default(),
             workspace: WorkspaceConfig::default(),
             ai: AIConfig::default(),
+            project: ProjectConfig::default(),
             mcp_servers: None,
             acp_clients: None,
             themes: Some(ThemesConfig::default()),
@@ -1670,7 +1689,7 @@ impl AIModelConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{AIConfig, AIExperienceConfig, AIModelConfig, ReasoningMode};
+    use super::{AIConfig, AIExperienceConfig, AIModelConfig, GlobalConfig, ReasoningMode};
 
     #[test]
     fn deserializes_compatibility_thinking_flag_into_reasoning_mode() {
@@ -1688,6 +1707,40 @@ mod tests {
 
         assert_eq!(config.reasoning_mode, Some(ReasoningMode::Enabled));
         assert!(config.enable_thinking_process);
+    }
+
+    #[test]
+    fn global_config_preserves_project_mcp_servers() {
+        let config: GlobalConfig = serde_json::from_value(serde_json::json!({
+            "project": {
+                "mcp_servers": [
+                    {
+                        "id": "project-docs",
+                        "name": "Project Docs",
+                        "server_type": "local",
+                        "command": "docs-mcp",
+                        "args": []
+                    }
+                ]
+            }
+        }))
+        .expect("project scoped MCP config should deserialize");
+
+        assert_eq!(
+            config
+                .project
+                .mcp_servers
+                .as_ref()
+                .and_then(|value| value.as_array())
+                .map(Vec::len),
+            Some(1)
+        );
+
+        let serialized = serde_json::to_value(&config).expect("config should serialize");
+        assert_eq!(
+            serialized["project"]["mcp_servers"][0]["id"],
+            "project-docs"
+        );
     }
 
     #[test]

--- a/src/crates/core/src/service/mcp/adapter/tool.rs
+++ b/src/crates/core/src/service/mcp/adapter/tool.rs
@@ -83,8 +83,8 @@ impl MCPToolWrapper {
         )
     }
 
-    fn is_blocked_in_context(&self, context: Option<&ToolUseContext>) -> bool {
-        context.map(|ctx| ctx.is_remote()).unwrap_or(false) && self.connection.is_local_stdio()
+    fn is_blocked_in_context(&self, _context: Option<&ToolUseContext>) -> bool {
+        false
     }
 }
 
@@ -260,12 +260,7 @@ impl Tool for MCPToolWrapper {
         input: &Value,
         context: &ToolUseContext,
     ) -> BitFunResult<Vec<ToolResult>> {
-        if self.is_blocked_in_context(Some(context)) {
-            return Err(crate::util::errors::BitFunError::tool(format!(
-                "MCP server '{}' runs locally; refusing to invoke it from a remote workspace session.",
-                self.server_name
-            )));
-        }
+        let _ = context;
 
         info!(
             "Calling MCP tool: {} from server: {}",

--- a/src/crates/core/tests/stream_replay_regressions.rs
+++ b/src/crates/core/tests/stream_replay_regressions.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use bitfun_ai_adapters::providers::{AnthropicMessageConverter, openai::OpenAIMessageConverter};
+use bitfun_ai_adapters::providers::{openai::OpenAIMessageConverter, AnthropicMessageConverter};
 use bitfun_core::agentic::core::Message as CoreMessage;
 use bitfun_core::agentic::events::{AgenticEvent, ToolEventData};
 use bitfun_core::util::types::Message as AIMessage;
@@ -49,7 +49,10 @@ async fn replays_structurally_empty_openai_reasoning_content_with_tool_call() {
     assert_eq!(result.tool_calls.len(), 1);
     assert_eq!(result.tool_calls[0].tool_id, "call_ds_1");
     assert_eq!(result.tool_calls[0].tool_name, "lookup_status");
-    assert_eq!(result.tool_calls[0].arguments, json!({ "ticket_id": "BF-123" }));
+    assert_eq!(
+        result.tool_calls[0].arguments,
+        json!({ "ticket_id": "BF-123" })
+    );
     assert!(!result.tool_calls[0].is_error);
     assert_eq!(
         result.usage.as_ref().map(|usage| usage.total_token_count),
@@ -87,14 +90,20 @@ async fn replays_structurally_empty_openai_reasoning_content_with_tool_call() {
         .collect();
     assert_eq!(
         tool_events,
-        vec![("call_ds_1", "{\"ticket_id\":\"BF-"), ("call_ds_1", "123\"}")]
+        vec![
+            ("call_ds_1", "{\"ticket_id\":\"BF-"),
+            ("call_ds_1", "123\"}")
+        ]
     );
 
     let replay_message: AIMessage = build_replay_assistant_message(&result).into();
     let openai_payload = OpenAIMessageConverter::convert_messages(vec![replay_message]);
 
     assert_eq!(openai_payload.len(), 1);
-    assert_eq!(openai_payload[0]["content"], json!("Let me check that for you."));
+    assert_eq!(
+        openai_payload[0]["content"],
+        json!("Let me check that for you.")
+    );
     assert_eq!(openai_payload[0]["reasoning_content"], json!(""));
     assert_eq!(openai_payload[0]["tool_calls"][0]["id"], json!("call_ds_1"));
     assert_eq!(
@@ -127,7 +136,10 @@ async fn replays_structurally_empty_anthropic_thinking_with_signature_and_tool_u
     assert_eq!(result.tool_calls.len(), 1);
     assert_eq!(result.tool_calls[0].tool_id, "toolu_ds_1");
     assert_eq!(result.tool_calls[0].tool_name, "lookup_status");
-    assert_eq!(result.tool_calls[0].arguments, json!({ "ticket_id": "BF-123" }));
+    assert_eq!(
+        result.tool_calls[0].arguments,
+        json!({ "ticket_id": "BF-123" })
+    );
     assert!(!result.tool_calls[0].is_error);
     assert_eq!(result.thinking_signature.as_deref(), Some("sig_empty_123"));
     assert_eq!(
@@ -159,7 +171,10 @@ async fn replays_structurally_empty_anthropic_thinking_with_signature_and_tool_u
             } if tool_id == "toolu_ds_1" && tool_name == "lookup_status"
         )
     });
-    assert!(early_detected, "expected tool_use block to trigger early detection");
+    assert!(
+        early_detected,
+        "expected tool_use block to trigger early detection"
+    );
 
     let replay_message: AIMessage = build_replay_assistant_message(&result).into();
     let (_, anthropic_messages) = AnthropicMessageConverter::convert_messages(vec![replay_message]);


### PR DESCRIPTION
## Summary

- Aligns desktop tool API workspace binding with remote connection lookup and `workspace_session_identity` for consistent remote workspace tooling.
- Propagates `remote_connection_id` and `remote_ssh_host` into subagent `SessionConfig` so hidden subagents inherit the registered remote workspace identity (with a regression test).
- Allows MCP local stdio servers when the active workspace session is remote (removes the blanket rejection).
- Updates miniapp host dispatch, service config types, coding-selfie git error handling, and stream replay regressions.

## Verification

- `cargo check --workspace`
- `cargo test -p bitfun-core subagent_session_config_preserves -- --nocapture`