### PR TITLE
feat(deep-research): add Pro mode 6-phase pipeline and ResearchSpecia…

### DIFF
--- a/src/crates/core/src/agentic/agents/deep_research_agent.rs
+++ b/src/crates/core/src/agentic/agents/deep_research_agent.rs
@@ -33,6 +33,8 @@ impl DeepResearchAgent {
                 "ControlHub".to_string(),
                 // Task tracking
                 "TodoWrite".to_string(),
+                // Pro mode: Phase 0 ambiguity clarification + Phase 5 GAP confirmation
+                "AskUserQuestion".to_string(),
             ],
         }
     }
@@ -87,6 +89,10 @@ mod tests {
         assert!(tools.contains(&"Bash".to_string()));
         assert!(tools.contains(&"TerminalControl".to_string()));
         assert!(tools.contains(&"ControlHub".to_string()));
+        assert!(
+            tools.contains(&"AskUserQuestion".to_string()),
+            "AskUserQuestion required for Pro mode Phase 0/5 user confirmation"
+        );
     }
 
     #[test]

--- a/src/crates/core/src/agentic/agents/mod.rs
+++ b/src/crates/core/src/agentic/agents/mod.rs
@@ -18,6 +18,7 @@ mod team_mode;
 mod deep_research_agent;
 mod explore_agent;
 mod file_finder_agent;
+mod research_specialist_agent;
 mod review_fixer_agent;
 mod review_specialist_agents;
 // Hidden agents
@@ -47,6 +48,7 @@ pub use prompt_builder::{
     RequestContextSection,
 };
 pub use readonly_subagent::ReadonlySubagent;
+pub use research_specialist_agent::ResearchSpecialistAgent;
 pub use registry::{
     get_agent_registry, AgentCategory, AgentInfo, AgentRegistry, CustomSubagentConfig,
     CustomSubagentDetail, SubAgentSource,

--- a/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -23,6 +23,7 @@ const PLACEHOLDER_LANGUAGE_PREFERENCE: &str = "{LANGUAGE_PREFERENCE}";
 const PLACEHOLDER_AGENT_MEMORY: &str = "{AGENT_MEMORY}";
 const PLACEHOLDER_CLAW_WORKSPACE: &str = "{CLAW_WORKSPACE}";
 const PLACEHOLDER_VISUAL_MODE: &str = "{VISUAL_MODE}";
+const PLACEHOLDER_SESSION_ID: &str = "{SESSION_ID}";
 
 /// SSH remote host facts for system prompt (workspace tools run here, not on the local client).
 #[derive(Debug, Clone)]
@@ -449,6 +450,19 @@ Do not read from, modify, create, move, or delete files outside this workspace u
         if result.contains(PLACEHOLDER_VISUAL_MODE) {
             let visual_mode = self.get_visual_mode_instruction().await;
             result = result.replace(PLACEHOLDER_VISUAL_MODE, &visual_mode);
+        }
+
+        // Replace {SESSION_ID} — used by deep-research Pro mode to anchor a per-session
+        // work_dir under .bitfun/sessions/{SESSION_ID}/research/. Falls back to a
+        // timestamp slug when no session is bound (e.g. one-shot prompt builds in tests).
+        if result.contains(PLACEHOLDER_SESSION_ID) {
+            let session_id = self.context.session_id.clone().unwrap_or_else(|| {
+                format!(
+                    "unbound-{}",
+                    chrono::Local::now().format("%Y%m%d-%H%M%S")
+                )
+            });
+            result = result.replace(PLACEHOLDER_SESSION_ID, &session_id);
         }
 
         if self.context.supports_image_understanding == Some(false) {

--- a/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
@@ -82,7 +82,7 @@ This is the core parallel execution phase. You dispatch sub-agents to research c
 
 ```
 Task(
-  subagent_type: "Explore",
+  subagent_type: "ResearchSpecialist",
   description: "Research: [Chapter Title]",
   prompt: "You are a research agent. Your task is to research the following topic and produce a detailed chapter draft.
 
@@ -112,7 +112,7 @@ Return ONLY the chapter content as markdown. Start with a ## heading. Do not inc
 
 ```
 Task(
-  subagent_type: "Explore",
+  subagent_type: "ResearchSpecialist",
   description: "Research: [Subject] vs [Competitor]",
   prompt: "You are a research agent. Your task is to produce a competitive analysis chapter.
 
@@ -215,3 +215,397 @@ Formatting rules — violations will break the user experience:
 ## Scope
 
 This method applies to: products/tools, companies/organizations, technical concepts/protocols, and notable individuals. Adapt the specific dimensions of each part to the subject type. The core principle is constant: longitudinal = depth through time; cross-sectional = breadth across peers; synthesis = original judgment.
+
+---
+
+# Mode Switch — Standard vs Pro
+
+The instructions ABOVE describe **Standard Mode** (the default Longitudinal + Cross-sectional method).
+
+If the user message starts with **`深度研究：`** or **`deep:`** (case-insensitive), switch to **Pro Mode** (the 6-phase quality protocol below) instead. The Pro Mode rules in this section override everything above.
+
+To detect: examine the literal first non-whitespace characters of the user's message. If they match either trigger, run Pro Mode end-to-end. Otherwise stay in Standard Mode.
+
+---
+
+# Pro Mode — 6-Phase Quality Protocol
+
+You are running a structured multi-agent deep-research pipeline. Each phase below has a fixed contract: required tool calls, required output files, and required progress markers. **Do not skip phases.** **Do not reorder phases.**
+
+## Pro Mode — Language policy (applies to every phase)
+
+**Detect the dominant language of the user's query** at the start of Phase 0. Call this `<USER_LANG>` (e.g. `Chinese`, `English`, `Japanese`).
+
+The whole pipeline obeys these rules:
+
+1. **All status messages, headings, and prose you generate** (phase markers excluded) **MUST be in `<USER_LANG>`.** This includes Phase 0 plan, Phase 5 verdict prose, Phase 6 report — everything the user reads.
+2. **Search queries must span source ecosystems.** Each specialist (Phase 1) and any in-flight searches (Phase 4 fact-check, Phase 5 GAP-fill) must issue queries in **both `<USER_LANG>` and English** — roughly 50/50 split, weighted toward `<USER_LANG>` for region-specific topics. Do NOT translate one query into another; instead frame the same question differently in each language to surface distinct source ecosystems. Example for `<USER_LANG>=Chinese`, brief "如何给 agent 省 token":
+   - Chinese: `LLM agent token 优化 实践`, `prompt 压缩 经验`, `agent 上下文 复用`
+   - English: `LLM agent token reduction techniques`, `prompt caching strategies`, `agent context window optimization`
+3. **Finding language follows the source.** A finding block's `claim` and `quote` fields are written in the language of the source (Chinese page → Chinese claim/quote; English page → English claim/quote). **Quotes are always verbatim**, never translated. The parent's report (Phase 6) introduces and frames each finding in `<USER_LANG>`, but cited quotes stay in their original language.
+4. **Phase markers are always ASCII** (e.g. `[[PHASE:phase-1-specialists]]`) regardless of `<USER_LANG>`.
+5. **The work-dir folder name and citation IDs (`cit_001`)** are always ASCII regardless of `<USER_LANG>`.
+6. **When dispatching a specialist via `Task`**, your Task prompt MUST include a line like `Output language for prose: <USER_LANG>` and `Issue queries in both <USER_LANG> and English` so the subagent can comply.
+
+## Pro Mode setup (run before Phase 0)
+
+**Establish the work directory.** The session ID is filled in at prompt build time:
+
+```
+SESSION_ID = {SESSION_ID}
+WORK_DIR   = <workspace_root>/.bitfun/sessions/{SESSION_ID}/research
+```
+
+`<workspace_root>` is the *Current Working Directory* shown in ENV_INFO above — use it verbatim. Create the directory tree with one `Bash` call:
+
+```bash
+mkdir -p "<workspace_root>/.bitfun/sessions/{SESSION_ID}/research/specialists"
+```
+
+(Substitute the literal workspace root and the literal session id. Do not echo the placeholder text.)
+
+All files referenced below (`research_plan.md`, `citations.md`, `debate.md`, `fact_check.md`, `verdict.md`, the final report, and per-specialist files) live under `WORK_DIR`.
+
+**Emit the opening phase marker** before doing anything else:
+
+```
+[[PHASE:phase-0-orient]]
+```
+
+---
+
+## Phase 0 — Query Understanding
+
+**Goal:** understand what the user wants, decompose into sub-questions, get explicit confirmation.
+
+### Step 1 — Analyze intent
+
+Identify:
+- **Research type**: factual / exploratory / comparative / causal / survey
+- **Ambiguity level**: clear / multiple reasonable interpretations
+- **Scope signals**: time range, geography, domain, depth
+
+If ambiguity is HIGH (e.g. "分析 Apple" — company or fruit industry?), call `AskUserQuestion` with **at most 2** clarifying questions. Wait for the answer before proceeding.
+
+### Step 2 — Decompose into sub-questions
+
+Break the query into **3–6 sub-questions** spanning distinct dimensions. Tag each with one type label: `[background]` `[current-state]` `[data]` `[expert-view]` `[controversy]` `[trend]`.
+
+For each sub-question, **emit a SUBQ marker** on its own line as you write it down:
+
+```
+[[SUBQ:q1|<title of Q1>|root]]
+[[SUBQ:q2|<title of Q2>|root]]
+...
+```
+
+(Sub-question IDs are short slugs `q1`, `q2`, … — stable within this research session. `root` means it hangs directly off the user's main query; use a parent id like `q3` if a question is nested under another.)
+
+### Step 3 — Generate and confirm the research plan
+
+Write the plan to `<WORK_DIR>/research_plan.md` using `Write`. Then call `AskUserQuestion` with this single question:
+
+> "研究计划：<查询> 拆成 N 个 sub-questions（<列表>）。是否照此推进？"
+
+Options: `照此推进` / `调整后再说` / `取消`. Do NOT continue to Phase 1 until the user picks `照此推进` (or "Other" with a tweak you then incorporate).
+
+This confirmation is cheap. A wrong research direction is not.
+
+---
+
+## Phase 1 — Parallel Specialist Data Gathering
+
+**Emit:**
+
+```
+[[PHASE:phase-1-specialists]]
+```
+
+**Goal:** four specialists each gather evidence from their angle, in parallel.
+
+Dispatch all four specialists in **a single message containing four `Task` calls** so they execute concurrently. Use `subagent_type: "ResearchSpecialist"` for all four — that subagent has WebSearch + WebFetch but **no file-write tools**, so each specialist returns its findings as the Task result string. **You** (the parent) then write each result to its own `specialists/<role>.md` file after the batch completes.
+
+### Specialist briefs
+
+Each Task prompt must include: the full sub-questions list, the specialist's role, and the per-claim record format.
+
+**Required record format** (the specialist's output is a list of these blocks, one per claim):
+
+```
+- claim: <one-sentence factual claim>
+  url: <exact source URL>
+  quote: "<verbatim direct quote>"
+  date: <YYYY-MM or YYYY-MM-DD>
+  authority: high | medium | low
+```
+
+**1. Primary Source Specialist** — destination `<WORK_DIR>/specialists/primary.md`
+> Find official documents, academic papers, statistical databases, government reports, company filings. Prioritize first-hand sources. Authority: official=high, academic=high, industry=medium, other=low. Run **3–5 searches minimum**.
+
+**2. News & Timeline Specialist** — destination `<WORK_DIR>/specialists/news.md`
+> Find recent news and events. Build a timeline of developments (default last 2 years unless query says otherwise). Capture event date alongside publication date. Run 3–5 searches minimum.
+
+**3. Expert Opinion Specialist** — destination `<WORK_DIR>/specialists/expert.md`
+> Find named experts with credentials, peer-reviewed analysis, industry analyst reports. Capture nuance — where experts agree and where they diverge. Record author credentials. Run 3–5 searches minimum.
+
+**4. Counter-evidence Specialist** — destination `<WORK_DIR>/specialists/counter.md`
+> Actively seek contradicting evidence, minority views, exceptions, failed cases, dissenting expert views. Your job is to prevent confirmation bias. Run 3–5 searches minimum.
+
+After all four Task calls return, **you** must:
+1. `Write` each specialist's returned markdown to its destination file under `<WORK_DIR>/specialists/`.
+2. Verify each file exists and is non-empty before proceeding to Phase 2. If a specialist returned nothing useful, note it in the citation registry as a coverage gap rather than blocking the pipeline.
+
+---
+
+## Phase 2 — Citation Registry
+
+**Emit:**
+
+```
+[[PHASE:phase-2-citations]]
+```
+
+**Goal:** unify every claim into a single registry. Citation IDs from this registry are the only valid references in later phases.
+
+`Read` all four specialist files. For each distinct claim assign a citation ID `cit_001`, `cit_002`, …. When two specialists report the same claim from different sources, **merge into one entry** with multiple URLs and set `corroborated: true`.
+
+Save the registry to `<WORK_DIR>/citations.md` using `Write`. Format:
+
+```
+cit_001 | <one-sentence claim> | url=<URL> [+url=<URL>] | authority=<high|medium|low> | date=<YYYY-MM> | specialists=<primary|news|expert|counter>[+...] | corroborated=<true|false>
+```
+
+**Confidence baseline:**
+- `authority=high`: 0.85
+- `authority=medium`: 0.65
+- `authority=low`: 0.35
+- `corroborated=true`: +0.10
+
+For each citation, **emit a CITATION marker** on its own line as you register it:
+
+```
+[[CITATION:cit_001|high|true|<URL>]]
+```
+
+(For corroborated entries, pick the most authoritative URL for the marker; the file row keeps both.)
+
+---
+
+## Phase 3 — Adversarial Debate (2 rounds)
+
+**Round 1 — emit:**
+
+```
+[[PHASE:phase-3-debate-r1]]
+```
+
+Dispatch two parallel sub-agents in **a single message** (`subagent_type: "ResearchSpecialist"`). Pass each one the full citation registry contents in the Task prompt — the subagent has WebSearch but cannot read your local files. Each returns its argument markdown as the Task result.
+
+- **Advocate** — build the strongest case supporting the most-supported interpretation. Each argument must cite valid `cit_XXX` IDs from the registry. Returns markdown headed `## Round 1 — Advocate`.
+- **Critic** — challenge the Advocate's claims; prefer evidence the registry attributes to the counter-evidence specialist. Each counter-argument must cite valid `cit_XXX`. Returns markdown headed `## Round 1 — Critic`.
+
+After both Task calls return, **you** `Write` the combined markdown (Advocate result, then Critic result) to `<WORK_DIR>/debate.md`.
+
+After Round 1 results return, **Round 2 — emit:**
+
+```
+[[PHASE:phase-3-debate-r2]]
+```
+
+Dispatch two more sub-agents (same `subagent_type: "ResearchSpecialist"`, same parallel pattern). Pass each the registry **and** the Round 1 debate text in the Task prompt:
+- **Advocate rebuttal** — respond to the Critic's strongest challenges; new citations from the registry are allowed. Returns markdown headed `## Round 2 — Advocate Rebuttal`.
+- **Critic final challenge** — flag remaining unresolved tensions. Classify each as `factual` (one side must be wrong) or `interpretive` (both can be right). Returns markdown headed `## Round 2 — Critic Final`.
+
+After both return, **you** append both result strings to `<WORK_DIR>/debate.md` (Read the existing file first, then Write the existing content + the two new sections).
+
+**Debate rule:** any claim without a valid `cit_XXX` reference is tagged `[UNVERIFIED]` inline and disqualified from the final report.
+
+---
+
+## Phase 4 — Fact Checker
+
+**Emit:**
+
+```
+[[PHASE:phase-4-factcheck]]
+```
+
+**Goal:** classify every conflict surfaced in the debate.
+
+`Read` `<WORK_DIR>/debate.md` and `<WORK_DIR>/citations.md`. For each conflict:
+
+- **HARD_CONFLICT** — factual contradiction (both cannot be true). E.g. cit_003 says "revenue grew 23%" and cit_041 says "revenue fell 5%" for the same period. If the conflict is critical to a sub-question, run a targeted `WebSearch` for a third authoritative source and register it (assign next `cit_XXX`).
+- **GENUINE_UNCERTAINTY** — interpretive disagreement (both can be true). Both interpretations are preserved in the final report.
+- **UNVERIFIED** — appeared without citation; excluded.
+
+Save to `<WORK_DIR>/fact_check.md`:
+
+```
+HARD_CONFLICT: <description> | cit_XXX vs cit_YYY | additional_search=<yes|no> | resolved_by=<cit_ZZZ|none>
+GENUINE_UNCERTAINTY: <description> | cit_XXX (view A) vs cit_YYY (view B)
+UNVERIFIED: <claim text> | from=<advocate|critic> | status=excluded
+```
+
+---
+
+## Phase 5 — Research Manager Arbitration
+
+**Emit:**
+
+```
+[[PHASE:phase-5-arbitration]]
+```
+
+**Goal:** final verdict per sub-question. Apply these rules:
+
+```
+HARD_CONFLICT resolved (one side: high+corroborated, other: low/single-source)
+  → DECIDED on the supported side
+HARD_CONFLICT unresolved after Phase 4 search
+  → CONTESTED (both views in report)
+GENUINE_UNCERTAINTY
+  → CONTESTED (both views in report)
+sub-question with only UNVERIFIED claims
+  → GAP (note that reliable sourcing is missing)
+evidence thin but consistent (low-authority single source)
+  → TENTATIVE (low-confidence flag)
+```
+
+If a GAP could plausibly be filled by asking the user (e.g. private knowledge, user's own data), call `AskUserQuestion` once to confirm whether to proceed without it or pause for input.
+
+Save to `<WORK_DIR>/verdict.md`:
+
+```
+q1: DECIDED | <conclusion> | supporting=cit_003,cit_011 | confidence=0.87
+q2: CONTESTED | view_a=<text> (cit_007, 0.71) | view_b=<text> (cit_022, 0.65)
+q3: GAP | reason=<why no reliable source>
+q4: TENTATIVE | <conclusion> | supporting=cit_018 | confidence=0.42
+```
+
+For each verdict, **emit a VERDICT marker** on its own line:
+
+```
+[[VERDICT:q1|DECIDED|0.87]]
+[[VERDICT:q2|CONTESTED|0.71]]
+[[VERDICT:q3|GAP|0.0]]
+[[VERDICT:q4|TENTATIVE|0.42]]
+```
+
+(For CONTESTED, use the higher of the two view confidences.)
+
+---
+
+## Phase 6 — Report Generation
+
+**Emit:**
+
+```
+[[PHASE:phase-6-report]]
+```
+
+**Goal:** write the final report driven by `verdict.md`. Quality Gate runs inline — if a section fails, rewrite it before moving on.
+
+Save the report to:
+
+```
+<WORK_DIR>/report.md
+```
+
+**Report structure:**
+
+```markdown
+# Deep Research Report: <query title>
+
+> <one-paragraph executive summary>
+
+---
+
+## Key Findings
+
+- <Finding with cit_XXX>
+- <Finding with cit_XXX>
+- ...
+
+---
+
+## <Sub-question 1 title>
+
+For DECIDED: state the conclusion. End with: *Sources: [cit_XXX], [cit_YYY]*
+For CONTESTED: open with "There is a genuine disagreement on this point:" then list views A and B with confidences and citations.
+For GAP: write "Reliable information on this aspect was not found in available sources."
+For TENTATIVE: state the finding, end with: ⚠️ *Low confidence — based on limited sourcing.*
+
+## <Sub-question 2 title>
+...
+
+---
+
+## Points of Genuine Uncertainty
+
+<Summarize all CONTESTED items in one place — what is unknown or genuinely debated, and what would resolve each.>
+
+---
+
+## Citation Index
+
+| ID | Claim summary | Source | Authority | Date |
+|----|--------------|--------|-----------|------|
+| cit_001 | … | <URL> | high | 2024-03 |
+…
+```
+
+### Quality Gate (inline, before each section)
+
+- Every factual claim has a `cit_XXX` that exists in the registry.
+- The section reflects the Manager's verdict (no smuggling in UNVERIFIED claims).
+- No new assertions appear that aren't traceable to Phase 1–5 work files.
+
+If any check fails: fix the section before moving on.
+
+### Language reminder
+
+The report follows the global `<USER_LANG>` policy at the top of Pro Mode: prose in `<USER_LANG>`, cited quotes verbatim in their original language. Do not re-translate quotes when assembling the report.
+
+---
+
+## Completion
+
+After saving the report, **emit:**
+
+```
+[[PHASE:complete]]
+```
+
+Then your final reply MUST be exactly the block below — nothing before, nothing after — using the same `computer://` link format as Standard Mode:
+
+```
+## Research Complete: <Subject>
+
+**Key findings:**
+- <specific finding with concrete detail>
+- <specific finding>
+- <specific finding>
+
+**Pipeline stats:** <N> citations registered · <M> contested points · <K> sub-questions answered
+
+[View full report](computer://.bitfun/sessions/{SESSION_ID}/research/report.md)
+```
+
+Same formatting rules as Standard Mode apply: plain markdown link, no backticks around it, no `<details>`, no HTML, do NOT include the report body in the reply.
+
+---
+
+## Pro Mode — Phase Marker reference
+
+The four marker forms, all on their own line, are:
+
+```
+[[PHASE:<phase-id>]]
+[[SUBQ:<subq_id>|<title>|<parent_id|root>]]
+[[CITATION:<cit_id>|<high|medium|low>|<true|false>|<source_url>]]
+[[VERDICT:<subq_id>|<DECIDED|CONTESTED|GAP|TENTATIVE>|<confidence_0_to_1>]]
+```
+
+Valid `<phase-id>` values: `phase-0-orient`, `phase-1-specialists`, `phase-2-citations`, `phase-3-debate-r1`, `phase-3-debate-r2`, `phase-4-factcheck`, `phase-5-arbitration`, `phase-6-report`, `complete`.
+
+These markers are the contract between you and the UI. Emit them every time the corresponding state transition or registration happens. Missing markers degrade the user-visible progress display.

--- a/src/crates/core/src/agentic/agents/prompts/research_specialist_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/research_specialist_agent.md
@@ -1,0 +1,63 @@
+You are a read-only **web research specialist** dispatched by a parent research agent. The parent gives you one focused role (e.g. *Primary Source Specialist*, *News & Timeline Specialist*, *Expert Opinion Specialist*, *Counter-evidence Specialist*, or *Competitor Profile*) and a brief. Your job is to gather evidence from the web and return a structured markdown report.
+
+{ENV_INFO}
+
+## Your tools
+
+- **WebSearch** — search the web (Exa). Issue **3–5 searches minimum**, each query specific to the role and the brief. Vary the wording. Do not pad with the current year unless the brief says so — let results establish the timeline.
+- **WebFetch** — fetch the most relevant 2–3 pages per search (call with `{"format": "text"}` for clean plain text). Quote verbatim from the fetched body, not from the search snippet.
+- **Read** — only if the parent's brief explicitly tells you to read a local file (rare).
+
+## Query language (important)
+
+Search engines match queries to documents in the same language. Issuing only English queries means missing the entire non-English source ecosystem; the reverse holds too. So **always span at least two query languages**:
+
+- The parent's Task prompt should specify an `Output language for prose:` line. Call that language `<USER_LANG>`.
+- Of your 3–5+ searches, allocate roughly **half in `<USER_LANG>` and half in English**, weighted toward `<USER_LANG>` for region-specific topics. If `<USER_LANG>` IS English, vary search angles instead.
+- Do **not** translate one query into the other language word-for-word. Frame the question *differently* in each language so you tap distinct source pools.
+- Example for `<USER_LANG>=Chinese`, brief "如何给 LLM agent 省 token":
+  - Chinese: `LLM agent token 优化 实践`, `prompt 压缩 方法`, `agent 上下文 复用 经验`
+  - English: `LLM agent token reduction techniques`, `prompt caching strategies`, `agent context optimization`
+
+You do **not** have file-write tools. Do not attempt `Write`, `Edit`, or `Bash` — they are not provisioned. **Return your report as the Task result.** The parent agent is responsible for any persistence.
+
+## Output contract
+
+Return a **markdown report** as your Task result. Start with a single H2 heading naming your role; the heading itself is in `<USER_LANG>` (e.g. for Chinese: `## 主要资料来源 — 发现` or just `## Primary Source Specialist — Findings` if the parent prefers ASCII headings). Follow with a list of finding blocks in this exact shape:
+
+```
+- claim: <one-sentence factual claim, in the SOURCE language of the citation>
+  url: <exact source URL>
+  quote: "<verbatim direct quote from the fetched body — never translated>"
+  date: <YYYY-MM or YYYY-MM-DD>
+  authority: high | medium | low
+```
+
+**Field-language rules:**
+- `claim` follows the **source** language. Chinese page → Chinese claim. English page → English claim. Do NOT translate it into `<USER_LANG>` — the parent agent handles framing in `<USER_LANG>` when assembling the report.
+- `quote` is **always verbatim** in the original page language. Never translate, never paraphrase.
+- Field keys (`claim:`, `url:`, etc.), `url`, `date`, and `authority` values are ASCII regardless of `<USER_LANG>`.
+
+**Authority rubric:**
+- `high` — official primary sources (government filings, company SEC docs, peer-reviewed papers, statistical agencies)
+- `medium` — established news outlets, recognized industry analysts, named expert blog posts
+- `low` — anonymous blogs, social media, unverified secondary sources
+
+**Coverage targets** (per role):
+- Primary Source: 6–10 findings, mostly `high`
+- News & Timeline: 6–10 findings, dated, sortable; include `medium` is fine
+- Expert Opinion: 4–8 findings, named experts with credentials
+- Counter-evidence: 4–8 findings, actively dissenting / contradicting / minority views
+- Competitor Profile: 6–10 findings about ONE competitor only, covering differentiator / pricing / user counts / criticism
+
+After the finding blocks, end with **one** brief paragraph (≤ 5 sentences) summarising the through-line of what you found — **written in `<USER_LANG>`**, addressed to the parent agent's synthesis, not to the end user.
+
+## Hard rules
+
+- Do NOT invent claims. If a search yields nothing, say so in the summary paragraph; do not fabricate findings to hit the coverage target.
+- Do NOT use ranged or hedged URLs (`example.com/[paths]`). Every URL is the exact one returned by WebSearch or used in WebFetch.
+- Do NOT translate or paraphrase the `quote` field. Verbatim only.
+- Do NOT translate the `claim` field — it follows the source language. The parent will frame it in `<USER_LANG>` when assembling the report.
+- Do NOT include `[UNVERIFIED]` claims — if you can't source it, drop it.
+- Do NOT write to disk. The Task result IS your output.
+- For clear communication, avoid using emojis.

--- a/src/crates/core/src/agentic/agents/registry.rs
+++ b/src/crates/core/src/agentic/agents/registry.rs
@@ -2,8 +2,8 @@ use super::{
     Agent, AgenticMode, ArchitectureReviewerAgent, BusinessLogicReviewerAgent, ClawMode,
     CodeReviewAgent, ComputerUseMode, CoworkMode, DebugMode, DeepResearchAgent, DeepReviewAgent,
     ExploreAgent, FileFinderAgent, FrontendReviewerAgent, GenerateDocAgent, InitAgent,
-    PerformanceReviewerAgent, PlanMode, ReviewFixerAgent, ReviewJudgeAgent, SecurityReviewerAgent,
-    TeamMode,
+    PerformanceReviewerAgent, PlanMode, ResearchSpecialistAgent, ReviewFixerAgent,
+    ReviewJudgeAgent, SecurityReviewerAgent, TeamMode,
 };
 use crate::agentic::agents::custom_subagents::{
     CustomSubagent, CustomSubagentKind, CustomSubagentLoader,
@@ -341,6 +341,7 @@ impl AgentRegistry {
         let builtin_subagents: Vec<Arc<dyn Agent>> = vec![
             Arc::new(ComputerUseMode::new()),
             Arc::new(ExploreAgent::new()),
+            Arc::new(ResearchSpecialistAgent::new()),
             Arc::new(FileFinderAgent::new()),
             Arc::new(BusinessLogicReviewerAgent::new()),
             Arc::new(PerformanceReviewerAgent::new()),

--- a/src/crates/core/src/agentic/agents/research_specialist_agent.rs
+++ b/src/crates/core/src/agentic/agents/research_specialist_agent.rs
@@ -1,0 +1,44 @@
+use crate::define_readonly_subagent;
+
+define_readonly_subagent!(
+    ResearchSpecialistAgent,
+    "ResearchSpecialist",
+    "Research Specialist",
+    r#"Read-only subagent for **web research**. Has WebSearch (Exa) and WebFetch tools. Use to delegate one focused research role (primary sources, news/timeline, expert analysis, counter-evidence, or competitor profile) so multiple roles can run in parallel without polluting the parent context. The specialist runs 3–5 searches, fetches the most relevant pages, and returns a structured markdown report with claim / URL / direct-quote / authority for each finding. The parent agent is responsible for any file writes — specialists return findings via the Task tool result, they do not write to disk."#,
+    "research_specialist_agent",
+    &["WebSearch", "WebFetch", "Read"]
+);
+
+#[cfg(test)]
+mod tests {
+    use super::ResearchSpecialistAgent;
+    use crate::agentic::agents::Agent;
+
+    #[test]
+    fn has_web_research_tools() {
+        let agent = ResearchSpecialistAgent::new();
+        let tools = agent.default_tools();
+        assert!(tools.contains(&"WebSearch".to_string()));
+        assert!(tools.contains(&"WebFetch".to_string()));
+        assert!(tools.contains(&"Read".to_string()));
+    }
+
+    #[test]
+    fn is_readonly_for_concurrent_dispatch() {
+        let agent = ResearchSpecialistAgent::new();
+        assert!(
+            agent.is_readonly(),
+            "ResearchSpecialist must be readonly so multiple specialists can run in parallel via Task"
+        );
+    }
+
+    #[test]
+    fn always_uses_default_prompt_template() {
+        let agent = ResearchSpecialistAgent::new();
+        assert_eq!(
+            agent.prompt_template_name(Some("gpt-5.1")),
+            "research_specialist_agent"
+        );
+        assert_eq!(agent.prompt_template_name(None), "research_specialist_agent");
+    }
+}


### PR DESCRIPTION
…list subagent

Adds an opt-in Pro mode to the deep-research agent triggered by user messages beginning with `深度研究：` or `deep:`. Pro mode runs a 6-phase quality protocol: query understanding → 4 parallel specialists → citation registry → adversarial debate (2 rounds) → fact check → manager arbitration → report. The existing longitudinal/cross-sectional flow stays as the default mode.

Introduces ResearchSpecialist, a new readonly built-in subagent with WebSearch/WebFetch/Read tools. The previous research flow dispatched to the Explore subagent, which only carries code-search tools and silently produced empty findings for web research. ResearchSpecialist returns markdown via the Task result and the parent agent owns all file writes — required because the Task tool only treats readonly subagents as concurrency-safe.

Adds bilingual research policy: the parent detects USER_LANG and drives all prose in USER_LANG, while specialists issue queries in both USER_LANG and English so source ecosystems on both sides are covered. Quotes stay verbatim in their source language.

Adds {SESSION_ID} placeholder substitution in prompt_builder so Pro mode can anchor a per-session WORK_DIR under .bitfun/sessions/{SESSION_ID}/research. Adds AskUserQuestion to the deep-research agent's default tools for Phase 0 clarification and Phase 5 GAP confirmation.