### PR TITLE
fix(core, web-ui): session finishing sync, explicit skills, companion activity

### DIFF
--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -35,6 +35,10 @@ impl RoundExecutor {
     const MAX_RETRIES_WITHOUT_OUTPUT: usize = 1;
     const RETRY_BASE_DELAY_MS: u64 = 500;
 
+    fn has_user_visible_assistant_text(text: &str) -> bool {
+        !text.trim().is_empty()
+    }
+
     pub fn new(
         stream_processor: Arc<StreamProcessor>,
         event_queue: Arc<EventQueue>,
@@ -417,7 +421,7 @@ impl RoundExecutor {
                 usage: stream_result.usage.clone(),
                 provider_metadata: stream_result.provider_metadata.clone(),
                 partial_recovery_reason: stream_result.partial_recovery_reason.clone(),
-                had_assistant_text: !stream_result.full_text.is_empty(),
+                had_assistant_text: Self::has_user_visible_assistant_text(&stream_result.full_text),
                 had_thinking_content: !stream_result.full_thinking.is_empty(),
             });
         }
@@ -637,7 +641,7 @@ impl RoundExecutor {
             usage: stream_result.usage.clone(),
             provider_metadata: stream_result.provider_metadata.clone(),
             partial_recovery_reason: stream_result.partial_recovery_reason.clone(),
-            had_assistant_text: !stream_result.full_text.is_empty(),
+            had_assistant_text: Self::has_user_visible_assistant_text(&stream_result.full_text),
             had_thinking_content: !stream_result.full_thinking.is_empty(),
         })
     }
@@ -877,5 +881,13 @@ mod tests {
         };
 
         assert!(!RoundExecutor::is_interrupted_invalid_tool_only(&result));
+    }
+
+    #[test]
+    fn whitespace_only_text_is_not_user_visible_assistant_text() {
+        assert!(!RoundExecutor::has_user_visible_assistant_text("\n\n "));
+        assert!(RoundExecutor::has_user_visible_assistant_text(
+            "I can help with that."
+        ));
     }
 }

--- a/src/crates/core/src/agentic/tools/implementations/skill_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skill_tool.rs
@@ -9,10 +9,10 @@ use crate::agentic::tools::framework::{
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
 use log::debug;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 // Use skills module
-use super::skills::{get_skill_registry, SkillLocation};
+use super::skills::{SkillLocation, get_skill_registry};
 
 /// Skill tool
 pub struct SkillTool;
@@ -265,14 +265,15 @@ impl Default for SkillTool {
 #[cfg(test)]
 mod tests {
     use super::SkillTool;
-    use crate::agentic::tools::framework::Tool;
+    use crate::agentic::WorkspaceBinding;
+    use crate::agentic::tools::framework::{Tool, ToolResult};
     use crate::agentic::workspace::{
         WorkspaceCommandOptions, WorkspaceCommandResult, WorkspaceDirEntry, WorkspaceFileSystem,
         WorkspaceServices, WorkspaceShell,
     };
-    use crate::agentic::WorkspaceBinding;
     use crate::service::remote_ssh::workspace_state::workspace_session_identity;
     use async_trait::async_trait;
+    use serde_json::json;
     use std::path::PathBuf;
     use std::sync::Arc;
 
@@ -390,6 +391,52 @@ Use the remote project skill.
         assert!(description.contains("remote-only-skill-for-test"));
         assert!(
             description.contains("Remote project skill visible only through workspace services.")
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_call_loads_default_hidden_builtin_team_skill_when_explicitly_invoked() {
+        let identity =
+            workspace_session_identity("/remote/project", Some("conn-1"), Some("remote-host"))
+                .expect("remote identity");
+        let workspace = WorkspaceBinding::new_remote(
+            Some("remote-workspace".to_string()),
+            PathBuf::from("/remote/project"),
+            "conn-1".to_string(),
+            "Remote".to_string(),
+            identity,
+        );
+        let context = crate::agentic::tools::framework::ToolUseContext {
+            tool_call_id: None,
+            agent_type: Some("agentic".to_string()),
+            session_id: None,
+            dialog_turn_id: None,
+            workspace: Some(workspace),
+            custom_data: Default::default(),
+            computer_use_host: None,
+            cancellation_token: None,
+            runtime_tool_restrictions: Default::default(),
+            workspace_services: Some(WorkspaceServices {
+                fs: Arc::new(FakeRemoteFs),
+                shell: Arc::new(FakeShell),
+            }),
+        };
+
+        let results = SkillTool::new()
+            .call_impl(&json!({ "command": "cso" }), &context)
+            .await
+            .expect("explicit cso invocation should load the local built-in skill");
+
+        let ToolResult::Result { data, .. } = &results[0] else {
+            panic!("expected result payload");
+        };
+        assert_eq!(data["skill_name"], "cso");
+        assert_eq!(data["location"], "user");
+        assert!(
+            data["content"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("# /cso")
         );
     }
 }

--- a/src/crates/core/src/agentic/tools/implementations/skills/registry.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skills/registry.rs
@@ -5,10 +5,10 @@
 use super::builtin::{
     builtin_skill_group_key, ensure_builtin_skills_installed, is_builtin_skill_dir_name,
 };
-use super::default_profiles::is_skill_enabled_for_mode;
+use super::default_profiles::{is_enabled_by_default_for_mode, is_skill_enabled_for_mode};
 use super::mode_overrides::{
-    load_disabled_mode_skills_local, load_disabled_mode_skills_remote,
-    load_user_mode_skill_overrides, UserModeSkillOverrides,
+    UserModeSkillOverrides, load_disabled_mode_skills_local, load_disabled_mode_skills_remote,
+    load_user_mode_skill_overrides,
 };
 use super::types::{SkillData, SkillInfo, SkillLocation};
 use crate::agentic::workspace::WorkspaceFileSystem;
@@ -519,6 +519,91 @@ impl SkillRegistry {
             .collect()
     }
 
+    fn find_default_hidden_builtin_for_explicit_invocation(
+        skill_name: &str,
+        candidates: Vec<SkillCandidate>,
+        agent_type: Option<&str>,
+    ) -> BitFunResult<SkillInfo> {
+        let Some(mode_id) = agent_type.map(str::trim).filter(|value| !value.is_empty()) else {
+            return Err(BitFunError::tool(format!(
+                "Skill '{}' not found",
+                skill_name
+            )));
+        };
+
+        let info = resolve_visible_skills(candidates)
+            .into_iter()
+            .find(|skill| skill.name == skill_name)
+            .ok_or_else(|| BitFunError::tool(format!("Skill '{}' not found", skill_name)))?;
+
+        if info.level == SkillLocation::User
+            && info.is_builtin
+            && info.group_key.as_deref() == Some("team")
+            && !is_enabled_by_default_for_mode(&info, mode_id)
+        {
+            return Ok(info);
+        }
+
+        Err(BitFunError::tool(format!(
+            "Skill '{}' is disabled for mode '{}'. Enable it in mode skill settings or switch to a mode where it is enabled.",
+            skill_name, mode_id
+        )))
+    }
+
+    async fn find_skill_info_for_explicit_invocation_workspace(
+        &self,
+        skill_name: &str,
+        workspace_root: Option<&Path>,
+        agent_type: Option<&str>,
+    ) -> BitFunResult<SkillInfo> {
+        let candidates = self
+            .scan_skill_candidates_for_workspace(workspace_root)
+            .await;
+        let filtered = self
+            .apply_mode_filters_for_workspace(candidates.clone(), workspace_root, agent_type)
+            .await;
+        if let Some(info) = resolve_visible_skills(filtered)
+            .into_iter()
+            .find(|skill| skill.name == skill_name)
+        {
+            return Ok(info);
+        }
+
+        Self::find_default_hidden_builtin_for_explicit_invocation(
+            skill_name, candidates, agent_type,
+        )
+    }
+
+    async fn find_skill_info_for_explicit_invocation_remote_workspace(
+        &self,
+        skill_name: &str,
+        fs: &dyn WorkspaceFileSystem,
+        remote_root: &str,
+        agent_type: Option<&str>,
+    ) -> BitFunResult<SkillInfo> {
+        let candidates = self
+            .scan_skill_candidates_for_remote_workspace(fs, remote_root)
+            .await;
+        let filtered = self
+            .apply_mode_filters_for_remote_workspace(
+                candidates.clone(),
+                fs,
+                remote_root,
+                agent_type,
+            )
+            .await;
+        if let Some(info) = resolve_visible_skills(filtered)
+            .into_iter()
+            .find(|skill| skill.name == skill_name)
+        {
+            return Ok(info);
+        }
+
+        Self::find_default_hidden_builtin_for_explicit_invocation(
+            skill_name, candidates, agent_type,
+        )
+    }
+
     async fn ensure_loaded(&self) {
         let cache = self.cache.read().await;
         if cache.is_empty() {
@@ -625,11 +710,12 @@ impl SkillRegistry {
         agent_type: Option<&str>,
     ) -> BitFunResult<SkillData> {
         let info = self
-            .get_resolved_skills_for_workspace(workspace_root, agent_type)
-            .await
-            .into_iter()
-            .find(|skill| skill.name == skill_name)
-            .ok_or_else(|| BitFunError::tool(format!("Skill '{}' not found", skill_name)))?;
+            .find_skill_info_for_explicit_invocation_workspace(
+                skill_name,
+                workspace_root,
+                agent_type,
+            )
+            .await?;
 
         let skill_md_path = PathBuf::from(&info.path).join("SKILL.md");
         let content = fs::read_to_string(&skill_md_path)
@@ -651,11 +737,13 @@ impl SkillRegistry {
         agent_type: Option<&str>,
     ) -> BitFunResult<SkillData> {
         let info = self
-            .get_resolved_skills_for_remote_workspace(fs, remote_root, agent_type)
-            .await
-            .into_iter()
-            .find(|skill| skill.name == skill_name)
-            .ok_or_else(|| BitFunError::tool(format!("Skill '{}' not found", skill_name)))?;
+            .find_skill_info_for_explicit_invocation_remote_workspace(
+                skill_name,
+                fs,
+                remote_root,
+                agent_type,
+            )
+            .await?;
 
         let content = Self::read_skill_md_for_remote_merge(&info, fs).await?;
         let mut data = SkillData::from_markdown(info.path.clone(), &content, info.level, true)?;

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
@@ -2,13 +2,15 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { normalizeSubagentParentInfo } from './subagentParentInfo';
 import {
   formatDialogErrorForNotification,
+  handleSessionStateChanged,
   insertSteeringItemIfAbsent,
   shouldProcessEvent,
 } from './EventHandlerModule';
 import { stateMachineManager } from '../../state-machine';
-import { SessionExecutionState } from '../../state-machine/types';
+import { SessionExecutionEvent, SessionExecutionState } from '../../state-machine/types';
 import { FlowChatStore } from '../../store/FlowChatStore';
-import type { DialogTurn, FlowUserSteeringItem, ModelRound } from '../../types/flow-chat';
+import type { DialogTurn, FlowUserSteeringItem, ModelRound, Session } from '../../types/flow-chat';
+import type { FlowChatContext } from './types';
 
 vi.mock('@/infrastructure/i18n/core/I18nService', () => ({
   i18nService: {
@@ -180,6 +182,80 @@ function createSessionWithTurn(turn: DialogTurn): void {
   store.addDialogTurn('session-1', turn);
 }
 
+function createFinishingTurn(): DialogTurn {
+  return {
+    id: 'turn-1',
+    sessionId: 'session-1',
+    userMessage: {
+      id: 'user-1',
+      content: 'Initial request',
+      timestamp: 900,
+    },
+    modelRounds: [{
+      ...makeRound('round-1'),
+      items: [],
+    }],
+    status: 'finishing',
+    startTime: 900,
+  };
+}
+
+function createFinishingSession(): Session {
+  return {
+    sessionId: 'session-1',
+    title: 'Session 1',
+    dialogTurns: [createFinishingTurn()],
+    status: 'idle',
+    config: { agentType: 'agentic' },
+    createdAt: 800,
+    lastActiveAt: 1000,
+    error: null,
+    isTransient: true,
+  };
+}
+
+function createFlowChatContext(): FlowChatContext {
+  return {
+    flowChatStore: FlowChatStore.getInstance(),
+    processingManager: {
+      clearSessionStatus: vi.fn(),
+    } as any,
+    eventBatcher: {
+      getBufferSize: vi.fn(() => 0),
+      flushNow: vi.fn(),
+      clear: vi.fn(),
+    } as any,
+    pendingTurnCompletions: new Map(),
+    pendingHistoryLoads: new Map(),
+    contentBuffers: new Map(),
+    activeTextItems: new Map(),
+    saveDebouncers: new Map(),
+    lastSaveTimestamps: new Map(),
+    lastSaveHashes: new Map(),
+    turnSaveInFlight: new Map(),
+    turnSavePending: new Set(),
+    runtimeStatusTimers: new Map(),
+    userCancelledSessionIds: new Set(),
+    handledTerminalTurnEvents: new Set(),
+    currentWorkspacePath: null,
+  };
+}
+
+async function setFinishingMachine(): Promise<void> {
+  await stateMachineManager.transition('session-1', SessionExecutionEvent.START, {
+    taskId: 'session-1',
+    dialogTurnId: 'turn-1',
+  });
+  await stateMachineManager.transition('session-1', SessionExecutionEvent.BACKEND_STREAM_COMPLETED);
+}
+
+function putFinishingSessionInStore(): void {
+  FlowChatStore.getInstance().setState(() => ({
+    sessions: new Map([['session-1', createFinishingSession()]]),
+    activeSessionId: 'session-1',
+  }));
+}
+
 describe('insertSteeringItemIfAbsent', () => {
   beforeEach(() => {
     resetFlowChatStore();
@@ -277,5 +353,54 @@ describe('insertSteeringItemIfAbsent', () => {
       status: 'completed',
       roundIndex: 1,
     });
+  });
+});
+
+describe('handleSessionStateChanged', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetFlowChatStore();
+    stateMachineManager.clear();
+  });
+
+  afterEach(() => {
+    resetFlowChatStore();
+    stateMachineManager.clear();
+  });
+
+  it('finalizes pending turn completion when backend reports idle during finishing', async () => {
+    putFinishingSessionInStore();
+    const context = createFlowChatContext();
+    context.pendingTurnCompletions.set('session-1', {
+      turnId: 'turn-1',
+      lastActivityAt: Date.now(),
+      timer: null,
+    });
+    await setFinishingMachine();
+
+    handleSessionStateChanged(context, { sessionId: 'session-1', newState: 'Idle' });
+
+    const turn = FlowChatStore.getInstance()
+      .getState()
+      .sessions.get('session-1')
+      ?.dialogTurns[0];
+    expect(turn?.status).toBe('completed');
+    expect(context.pendingTurnCompletions.has('session-1')).toBe(false);
+    expect(stateMachineManager.getCurrentState('session-1')).toBe(SessionExecutionState.IDLE);
+  });
+
+  it('finalizes a finishing turn even if the pending completion record was lost', async () => {
+    putFinishingSessionInStore();
+    const context = createFlowChatContext();
+    await setFinishingMachine();
+
+    handleSessionStateChanged(context, { sessionId: 'session-1', newState: 'Idle' });
+
+    const turn = FlowChatStore.getInstance()
+      .getState()
+      .sessions.get('session-1')
+      ?.dialogTurns[0];
+    expect(turn?.status).toBe('completed');
+    expect(stateMachineManager.getCurrentState('session-1')).toBe(SessionExecutionState.IDLE);
   });
 });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -374,7 +374,7 @@ export async function initializeEventListeners(
       handleSessionDeleted(context, event);
     },
     onSessionStateChanged: (event) => {
-      handleSessionStateChanged(event);
+      handleSessionStateChanged(context, event);
     },
     onImageAnalysisStarted: (event) => {
       handleImageAnalysisStarted(context, event as ImageAnalysisEvent);
@@ -726,6 +726,27 @@ function finalizePendingTurnCompletionNow(context: FlowChatContext, sessionId: s
   finalizeTurnCompletionState(context, sessionId, pending.turnId);
 }
 
+function findFinishingTurnForBackendIdle(
+  context: FlowChatContext,
+  sessionId: string,
+  turnId?: string | null
+): string | null {
+  const session = context.flowChatStore.getState().sessions.get(sessionId);
+  if (!session) {
+    return null;
+  }
+
+  if (turnId) {
+    const trackedTurn = session.dialogTurns.find(turn => turn.id === turnId);
+    if (trackedTurn?.status === 'finishing') {
+      return trackedTurn.id;
+    }
+  }
+
+  const latestTurn = session.dialogTurns[session.dialogTurns.length - 1];
+  return latestTurn?.status === 'finishing' ? latestTurn.id : null;
+}
+
 /**
  * Handle session title generated event (AI or fallback auto-generation)
  */
@@ -900,7 +921,7 @@ function handleSessionDeleted(context: FlowChatContext, event: any): void {
 /**
  * Handle backend session state sync event
  */
-function handleSessionStateChanged(event: any): void {
+export function handleSessionStateChanged(context: FlowChatContext, event: any): void {
   const { sessionId, newState } = event;
   
   const machine = stateMachineManager.get(sessionId);
@@ -915,8 +936,29 @@ function handleSessionStateChanged(event: any): void {
     currentFrontendState === SessionExecutionState.FINISHING &&
     frontendState === SessionExecutionState.IDLE;
   
-  const context = machine.getContext();
-  (context as any).backendSyncedAt = Date.now();
+  const machineContext = machine.getContext();
+  machineContext.backendSyncedAt = Date.now();
+
+  if (isExpectedFinishingDrift) {
+    finalizePendingTurnCompletionNow(context, sessionId);
+    if (stateMachineManager.getCurrentState(sessionId) === SessionExecutionState.FINISHING) {
+      const finishingTurnId = findFinishingTurnForBackendIdle(
+        context,
+        sessionId,
+        machineContext.currentDialogTurnId,
+      );
+      if (finishingTurnId) {
+        finalizeTurnCompletionState(context, sessionId, finishingTurnId);
+      } else {
+        void stateMachineManager
+          .transition(sessionId, SessionExecutionEvent.FINISHING_SETTLED)
+          .catch(error => {
+            log.error('State machine transition failed on backend idle sync', { sessionId, error });
+          });
+      }
+    }
+    return;
+  }
   
   if (currentFrontendState !== frontendState && !isExpectedFinishingDrift) {
     log.warn('Frontend and backend state mismatch', {

--- a/src/web-ui/src/flow_chat/utils/agentCompanionActivity.test.ts
+++ b/src/web-ui/src/flow_chat/utils/agentCompanionActivity.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { flowChatStore } from '../store/FlowChatStore';
+import { stateMachineManager } from '../state-machine/SessionStateMachineManager';
+import { ProcessingPhase, SessionExecutionEvent, SessionExecutionState } from '../state-machine/types';
+import type { DialogTurn, Session } from '../types/flow-chat';
+import { buildAgentCompanionActivity } from './agentCompanionActivity';
+
+function resetState(): void {
+  flowChatStore.setState(() => ({
+    sessions: new Map(),
+    activeSessionId: null,
+  }));
+  stateMachineManager.clear();
+}
+
+function createTurn(status: DialogTurn['status']): DialogTurn {
+  return {
+    id: 'turn-1',
+    sessionId: 'session-1',
+    userMessage: {
+      id: 'user-1',
+      content: 'Help me',
+      timestamp: 1000,
+    },
+    modelRounds: [],
+    status,
+    startTime: 1000,
+    endTime: status === 'completed' ? 2000 : undefined,
+  };
+}
+
+function createSession(turnStatus: DialogTurn['status']): Session {
+  return {
+    sessionId: 'session-1',
+    title: 'Remote Task',
+    dialogTurns: [createTurn(turnStatus)],
+    status: 'idle',
+    config: { agentType: 'agentic' },
+    createdAt: 900,
+    lastActiveAt: 2000,
+    updatedAt: 2000,
+    error: null,
+    isTransient: false,
+  };
+}
+
+async function putStateMachineInFinishing(): Promise<void> {
+  await stateMachineManager.transition('session-1', SessionExecutionEvent.START, {
+    taskId: 'session-1',
+    dialogTurnId: 'turn-1',
+  });
+  await stateMachineManager.transition('session-1', SessionExecutionEvent.BACKEND_STREAM_COMPLETED);
+}
+
+describe('buildAgentCompanionActivity', () => {
+  afterEach(() => {
+    resetState();
+  });
+
+  it('keeps showing finishing while the tracked turn is still finishing', async () => {
+    flowChatStore.setState(() => ({
+      sessions: new Map([['session-1', createSession('finishing')]]),
+      activeSessionId: 'session-1',
+    }));
+    await putStateMachineInFinishing();
+
+    const activity = buildAgentCompanionActivity();
+
+    expect(activity.tasks).toHaveLength(1);
+    expect(activity.tasks[0]).toMatchObject({
+      sessionId: 'session-1',
+      labelKey: 'agentCompanion.activity.finishing',
+    });
+  });
+
+  it('drops a stale finishing machine once the tracked turn is completed', async () => {
+    flowChatStore.setState(() => ({
+      sessions: new Map([['session-1', createSession('completed')]]),
+      activeSessionId: 'session-1',
+    }));
+    await putStateMachineInFinishing();
+
+    const snapshot = stateMachineManager.getSnapshot('session-1');
+    expect(snapshot?.currentState).toBe(SessionExecutionState.FINISHING);
+    expect(snapshot?.context.processingPhase).toBe(ProcessingPhase.FINALIZING);
+
+    expect(buildAgentCompanionActivity()).toEqual({
+      mood: 'rest',
+      tasks: [],
+    });
+  });
+});

--- a/src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts
+++ b/src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts
@@ -2,7 +2,7 @@ import { FlowChatStore } from '../store/FlowChatStore';
 import { stateMachineManager } from '../state-machine/SessionStateMachineManager';
 import { ProcessingPhase, type SessionStateMachine } from '../state-machine/types';
 import { deriveChatInputPetMood, type ChatInputPetMood } from './chatInputPetMood';
-import type { Session } from '../types/flow-chat';
+import type { DialogTurn, Session } from '../types/flow-chat';
 
 export type AgentCompanionTaskState =
   | 'running'
@@ -35,6 +35,13 @@ const EMPTY_ACTIVITY: AgentCompanionActivityPayload = {
 
 const taskOrderBySessionId = new Map<string, number>();
 let nextTaskOrder = 0;
+const TRANSIENT_TURN_STATUSES = new Set<DialogTurn['status']>([
+  'pending',
+  'image_analyzing',
+  'processing',
+  'finishing',
+  'cancelling',
+]);
 
 function ensureTaskOrder(sessionId: string): number {
   const existingOrder = taskOrderBySessionId.get(sessionId);
@@ -59,6 +66,30 @@ function pruneTaskOrder(activeTasks: AgentCompanionTaskStatus[]): void {
 
 function sessionTitle(session: Session): string {
   return session.title?.trim() || 'Session';
+}
+
+function trackedDialogTurn(
+  session: Session,
+  snapshot: SessionStateMachine | null,
+): DialogTurn | undefined {
+  const trackedTurnId = snapshot?.context.currentDialogTurnId;
+  if (trackedTurnId) {
+    return session.dialogTurns.find(turn => turn.id === trackedTurnId);
+  }
+
+  return session.dialogTurns[session.dialogTurns.length - 1];
+}
+
+function hasActiveTrackedTurn(
+  session: Session,
+  snapshot: SessionStateMachine | null,
+): boolean {
+  if (!snapshot) {
+    return false;
+  }
+
+  const turn = trackedDialogTurn(session, snapshot);
+  return !!turn && TRANSIENT_TURN_STATUSES.has(turn.status);
 }
 
 function runningLabel(snapshot: SessionStateMachine | null): {
@@ -211,7 +242,9 @@ export function buildAgentCompanionActivity(): AgentCompanionActivityPayload {
 
   sessions.forEach(session => {
     const snapshot = stateMachineManager.getSnapshot(session.sessionId);
-    const mood = deriveChatInputPetMood(snapshot);
+    const mood = hasActiveTrackedTurn(session, snapshot)
+      ? deriveChatInputPetMood(snapshot)
+      : 'rest';
 
     if (mood !== 'rest') {
       const label = runningLabel(snapshot);


### PR DESCRIPTION
## Summary

- **Round executor**: Treat whitespace-only assistant text as non-visible so retry / completion semantics match user-visible output.
- **Skill tool**: Explicit invocations can load default-hidden builtin **team** skills (including remote workspace); adds regression test for remote `cso` load.
- **Flow chat**: When backend reports `Idle` while the frontend is finishing, finalize pending turn completion and complete the finishing turn (or advance the state machine); extends `handleSessionStateChanged` with `FlowChatContext`.
- **Agent companion**: Use **rest** mood when there is no active transient tracked dialog turn (avoids stale "finishing" UI); Vitest coverage for companion activity and session state handler.

## Verification

- `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run`
- `cargo check --workspace && cargo test -p bitfun-core`