### PR TITLE
fix: flashgrep lifecycle cleanup

### DIFF
--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -71,6 +71,116 @@ struct WebdriverBridgeResultRequest {
     payload: serde_json::Value,
 }
 
+#[cfg(target_os = "macos")]
+static MAIN_WINDOW_HIDDEN_ON_MACOS: AtomicBool = AtomicBool::new(false);
+
+#[cfg(target_os = "macos")]
+static MAIN_WINDOW_CLOSE_PENDING_ON_MACOS: AtomicBool = AtomicBool::new(false);
+
+#[cfg(target_os = "macos")]
+const MAIN_WINDOW_CLOSE_REQUESTED_EVENT: &str = "bitfun_main_window_close_requested";
+
+#[cfg(target_os = "macos")]
+const MAIN_WINDOW_CLOSE_FALLBACK_HIDE_MS: u64 = 2_500;
+
+#[cfg(target_os = "macos")]
+pub(crate) fn mark_main_window_hidden_on_macos(hidden: bool) {
+    MAIN_WINDOW_HIDDEN_ON_MACOS.store(hidden, Ordering::SeqCst);
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn cancel_main_window_close_request_on_macos() {
+    MAIN_WINDOW_CLOSE_PENDING_ON_MACOS.store(false, Ordering::SeqCst);
+}
+
+#[cfg(target_os = "macos")]
+fn begin_main_window_close_request_on_macos() -> bool {
+    MAIN_WINDOW_CLOSE_PENDING_ON_MACOS
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+}
+
+#[cfg(target_os = "macos")]
+fn take_main_window_close_request_on_macos() -> bool {
+    MAIN_WINDOW_CLOSE_PENDING_ON_MACOS
+        .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+}
+
+#[cfg(target_os = "macos")]
+fn hide_main_window_on_macos(app: &tauri::AppHandle, reason: &str) -> Result<(), String> {
+    let Some(main_window) = app.get_webview_window("main") else {
+        mark_main_window_hidden_on_macos(false);
+        return Err("Main window not found".to_string());
+    };
+
+    main_window.hide().map_err(|error| {
+        mark_main_window_hidden_on_macos(false);
+        log::warn!(
+            "Failed to hide main window on macOS close request: reason={}, error={}",
+            reason,
+            error
+        );
+        format!("Failed to hide main window: {}", error)
+    })?;
+
+    mark_main_window_hidden_on_macos(true);
+    log::info!(
+        "Main window close requested on macOS; hid window instead of exiting: reason={}",
+        reason
+    );
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn show_main_window_on_macos(app: &tauri::AppHandle, reason: &str) {
+    cancel_main_window_close_request_on_macos();
+
+    let Some(main_window) = app.get_webview_window("main") else {
+        log::warn!(
+            "Failed to show main window on macOS reopen event: reason={}, error=main window not found",
+            reason
+        );
+        return;
+    };
+
+    let _ = main_window.unminimize();
+    if let Err(error) = main_window.show() {
+        mark_main_window_hidden_on_macos(false);
+        log::warn!(
+            "Failed to show main window on macOS reopen event: reason={}, error={}",
+            reason,
+            error
+        );
+        return;
+    }
+
+    mark_main_window_hidden_on_macos(false);
+    if let Err(error) = main_window.set_focus() {
+        log::warn!(
+            "Failed to focus main window on macOS reopen event: reason={}, error={}",
+            reason,
+            error
+        );
+    }
+}
+
+#[tauri::command]
+async fn hide_main_window_after_close_request(app: tauri::AppHandle) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        if take_main_window_close_request_on_macos() {
+            hide_main_window_on_macos(&app, "frontend_ack")?;
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+    }
+
+    Ok(())
+}
+
 #[tauri::command]
 async fn webdriver_bridge_result(request: WebdriverBridgeResultRequest) -> Result<(), String> {
     log::debug!("webdriver_bridge_result command invoked");
@@ -376,11 +486,48 @@ pub async fn run() {
         })
         .on_window_event({
             move |window, event| {
-                if let tauri::WindowEvent::CloseRequested { .. } = event {
+                if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                     if window.label() == "main" {
-                        if perform_process_exit_cleanup() {
-                            log::info!("Main window close requested, cleaning up");
-                            window.app_handle().exit(0);
+                        #[cfg(target_os = "macos")]
+                        {
+                            api.prevent_close();
+                            if !begin_main_window_close_request_on_macos() {
+                                return;
+                            }
+
+                            if let Err(error) = window.emit(MAIN_WINDOW_CLOSE_REQUESTED_EVENT, ()) {
+                                log::warn!(
+                                    "Failed to emit macOS main window close request event: {}",
+                                    error
+                                );
+                            }
+
+                            let app_handle = window.app_handle().clone();
+                            tauri::async_runtime::spawn(async move {
+                                tokio::time::sleep(std::time::Duration::from_millis(
+                                    MAIN_WINDOW_CLOSE_FALLBACK_HIDE_MS,
+                                ))
+                                .await;
+
+                                if take_main_window_close_request_on_macos() {
+                                    if let Err(error) =
+                                        hide_main_window_on_macos(&app_handle, "frontend_timeout")
+                                    {
+                                        log::warn!(
+                                            "macOS close fallback hide failed after frontend timeout: {}",
+                                            error
+                                        );
+                                    }
+                                }
+                            });
+                        }
+
+                        #[cfg(not(target_os = "macos"))]
+                        {
+                            if perform_process_exit_cleanup() {
+                                log::info!("Main window close requested, cleaning up");
+                                window.app_handle().exit(0);
+                            }
                         }
                     }
                 }
@@ -388,6 +535,7 @@ pub async fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             theme::show_main_window,
+            hide_main_window_after_close_request,
             api::agentic_api::create_session,
             api::agentic_api::update_session_model,
             api::agentic_api::update_session_title,
@@ -848,13 +996,23 @@ pub async fn run() {
 
     match app {
         Ok(app) => {
-            app.run(|_app_handle, event| {
-                if matches!(
-                    event,
-                    tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit
-                ) {
+            app.run(|app_handle, event| match event {
+                tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit => {
                     perform_process_exit_cleanup();
                 }
+                #[cfg(target_os = "macos")]
+                tauri::RunEvent::Reopen {
+                    has_visible_windows,
+                    ..
+                } => {
+                    let reason = if has_visible_windows {
+                        "dock_reopen_with_visible_aux_window"
+                    } else {
+                        "dock_reopen_no_visible_windows"
+                    };
+                    show_main_window_on_macos(app_handle, reason);
+                }
+                _ => {}
             });
         }
         Err(e) => {

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1056,33 +1056,7 @@ fn perform_process_exit_cleanup() -> bool {
     }
 
     if let Some(search_service) = get_global_workspace_search_service() {
-        let shutdown_thread = std::thread::Builder::new()
-            .name("workspace-search-shutdown".to_string())
-            .spawn(move || {
-                match tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                {
-                    Ok(runtime) => {
-                        runtime.block_on(async move {
-                            search_service.shutdown_all_daemons().await;
-                        });
-                    }
-                    Err(error) => {
-                        log::warn!(
-                            "Failed to create runtime for workspace search shutdown: {}",
-                            error
-                        );
-                    }
-                }
-            });
-
-        if let Err(error) = shutdown_thread {
-            log::warn!(
-                "Failed to spawn workspace search shutdown thread: {}",
-                error
-            );
-        }
+        search_service.shutdown_blocking();
     }
     bitfun_core::util::process_manager::cleanup_all_processes();
     api::remote_connect_api::cleanup_on_exit();

--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -533,6 +533,12 @@ pub async fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
             format!("Failed to show main window: {}", e)
         })?;
 
+        #[cfg(target_os = "macos")]
+        {
+            crate::cancel_main_window_close_request_on_macos();
+            crate::mark_main_window_hidden_on_macos(false);
+        }
+
         main_window.set_focus().map_err(|e| {
             error!("Failed to focus main window: {}", e);
             format!("Failed to focus main window: {}", e)

--- a/src/crates/core/src/service/search/flashgrep/client.rs
+++ b/src/crates/core/src/service/search/flashgrep/client.rs
@@ -4,7 +4,7 @@ use std::{
     process::Stdio,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
-        Arc,
+        Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard,
     },
     time::{Duration, Instant},
 };
@@ -35,6 +35,7 @@ const CLIENT_NAME: &str = "bitfun-workspace-search";
 const REPO_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
 const SHUTDOWN_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const DROP_CLEANUP_TIMEOUT: Duration = Duration::from_millis(150);
 
 type PendingResponseSender = oneshot::Sender<Result<ResponseEnvelope>>;
 type PendingResponses = HashMap<u64, PendingResponseSender>;
@@ -62,18 +63,30 @@ struct ManagedClientState {
 
 #[derive(Debug)]
 struct AsyncDaemonClient {
-    child: Mutex<Option<Child>>,
+    child: StdMutex<Option<Child>>,
     writer: Mutex<BufWriter<ChildStdin>>,
     shared: Arc<DaemonShared>,
     next_id: AtomicU64,
-    reader_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
-    stderr_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    reader_task: StdMutex<Option<tokio::task::JoinHandle<()>>>,
+    stderr_task: StdMutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 #[derive(Debug, Default)]
 struct DaemonShared {
     pending: Mutex<PendingResponses>,
     closed: AtomicBool,
+}
+
+fn lock_std_mutex<T>(mutex: &StdMutex<T>) -> StdMutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn take_std_option<T>(mutex: &StdMutex<Option<T>>) -> Option<T> {
+    let mut guard = lock_std_mutex(mutex);
+    guard.take()
 }
 
 impl Default for ManagedClient {
@@ -404,6 +417,7 @@ impl AsyncDaemonClient {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+        process_manager::configure_process_group(&mut command);
 
         let mut child = command.spawn()?;
         let stdin = child.stdin.take().ok_or_else(|| {
@@ -415,17 +429,30 @@ impl AsyncDaemonClient {
         let stderr = child.stderr.take();
 
         let client = Self {
-            child: Mutex::new(Some(child)),
+            child: StdMutex::new(Some(child)),
             writer: Mutex::new(BufWriter::new(stdin)),
             shared: Arc::new(DaemonShared::default()),
             next_id: AtomicU64::new(1),
-            reader_task: Mutex::new(None),
-            stderr_task: Mutex::new(None),
+            reader_task: StdMutex::new(None),
+            stderr_task: StdMutex::new(None),
         };
 
         client.spawn_reader_task(stdout).await;
         client.spawn_stderr_task(stderr).await;
-        client.initialize().await?;
+        if let Err(error) = client.initialize().await {
+            client.mark_closed();
+            client
+                .reject_pending("flashgrep stdio backend failed during startup")
+                .await;
+            if let Err(terminate_error) = client.wait_for_child_exit().await {
+                log::debug!(
+                    "Flashgrep stdio daemon cleanup after failed startup errored: {}",
+                    terminate_error
+                );
+            }
+            client.stop_background_tasks().await;
+            return Err(error);
+        }
         Ok(client)
     }
 
@@ -542,7 +569,7 @@ impl AsyncDaemonClient {
     }
 
     async fn wait_for_child_exit(&self) -> Result<()> {
-        let mut child = self.child.lock().await.take();
+        let mut child = take_std_option(&self.child);
         let Some(child) = child.as_mut() else {
             return Ok(());
         };
@@ -552,20 +579,23 @@ impl AsyncDaemonClient {
                 wait_result?;
                 Ok(())
             }
-            Err(_) => {
-                child.kill().await?;
-                child.wait().await?;
-                Ok(())
-            }
+            Err(_) => process_manager::terminate_child_process_tree(
+                child,
+                Duration::from_millis(750),
+            )
+            .await
+            .map_err(AppError::Io),
         }
     }
 
     async fn stop_background_tasks(&self) {
-        if let Some(handle) = self.reader_task.lock().await.take() {
+        let reader_handle = take_std_option(&self.reader_task);
+        if let Some(handle) = reader_handle {
             handle.abort();
             let _ = handle.await;
         }
-        if let Some(handle) = self.stderr_task.lock().await.take() {
+        let stderr_handle = take_std_option(&self.stderr_task);
+        if let Some(handle) = stderr_handle {
             handle.abort();
             let _ = handle.await;
         }
@@ -595,7 +625,7 @@ impl AsyncDaemonClient {
             }
         });
 
-        *self.reader_task.lock().await = Some(handle);
+        *lock_std_mutex(&self.reader_task) = Some(handle);
     }
 
     async fn spawn_stderr_task(&self, stderr: Option<ChildStderr>) {
@@ -619,11 +649,34 @@ impl AsyncDaemonClient {
             }
         });
 
-        *self.stderr_task.lock().await = Some(handle);
+        *lock_std_mutex(&self.stderr_task) = Some(handle);
     }
 
     async fn reject_pending(&self, message: impl Into<String>) {
         reject_pending_requests(&self.shared.pending, message.into()).await;
+    }
+
+    fn take_child_for_drop(&self) -> Option<Child> {
+        take_std_option(&self.child)
+    }
+
+    fn abort_background_tasks_for_drop(&self) {
+        if let Some(handle) = take_std_option(&self.reader_task) {
+            handle.abort();
+        }
+        if let Some(handle) = take_std_option(&self.stderr_task) {
+            handle.abort();
+        }
+    }
+}
+
+impl Drop for AsyncDaemonClient {
+    fn drop(&mut self) {
+        self.mark_closed();
+        self.abort_background_tasks_for_drop();
+        if let Some(child) = self.take_child_for_drop() {
+            process_manager::spawn_child_process_tree_cleanup(child, DROP_CLEANUP_TIMEOUT);
+        }
     }
 }
 

--- a/src/crates/core/src/service/search/service.rs
+++ b/src/crates/core/src/service/search/service.rs
@@ -11,7 +11,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicU64, Ordering},
-    Arc, OnceLock,
+    Arc, LazyLock, Mutex as StdMutex, Weak,
 };
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, RwLock};
@@ -22,7 +22,8 @@ use super::types::{
     WorkspaceSearchHit,
 };
 
-static GLOBAL_WORKSPACE_SEARCH_SERVICE: OnceLock<Arc<WorkspaceSearchService>> = OnceLock::new();
+static GLOBAL_WORKSPACE_SEARCH_SERVICE: LazyLock<StdMutex<Weak<WorkspaceSearchService>>> =
+    LazyLock::new(|| StdMutex::new(Weak::new()));
 
 const DEFAULT_TOP_K_TOKENS: usize = 6;
 const DEFAULT_SESSION_IDLE_GRACE: Duration = Duration::from_secs(45);
@@ -260,9 +261,14 @@ impl WorkspaceSearchService {
         let Ok(repo_root) = normalize_repo_root(repo_root.as_ref()) else {
             return;
         };
-        let service = Arc::clone(self);
+        let delay = self.session_idle_grace;
+        let service = Arc::downgrade(self);
         tokio::spawn(async move {
-            service.release_repo_after_grace(repo_root).await;
+            tokio::time::sleep(delay).await;
+            let Some(service) = service.upgrade() else {
+                return;
+            };
+            service.release_repo_if_idle(repo_root).await;
         });
     }
 
@@ -291,6 +297,40 @@ impl WorkspaceSearchService {
         }
         if let Err(error) = self.client.stop_daemon().await {
             log::debug!("Workspace search daemon stop skipped: {}", error);
+        }
+    }
+
+    pub fn shutdown_blocking(self: &Arc<Self>) {
+        let service = Arc::clone(self);
+        match std::thread::Builder::new()
+            .name("workspace-search-shutdown".to_string())
+            .spawn(move || match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => {
+                    runtime.block_on(async move {
+                        service.shutdown_all_daemons().await;
+                    });
+                }
+                Err(error) => {
+                    log::warn!(
+                        "Failed to create runtime for workspace search shutdown: {}",
+                        error
+                    );
+                }
+            }) {
+            Ok(handle) => {
+                if handle.join().is_err() {
+                    log::warn!("Workspace search shutdown thread panicked during blocking shutdown");
+                }
+            }
+            Err(error) => {
+                log::warn!(
+                    "Failed to spawn workspace search shutdown thread: {}",
+                    error
+                );
+            }
         }
     }
 
@@ -380,7 +420,7 @@ impl WorkspaceSearchService {
         })
     }
 
-    async fn release_repo_after_grace(self: Arc<Self>, repo_root: PathBuf) {
+    async fn release_repo_if_idle(&self, repo_root: PathBuf) {
         let Some(expected_epoch) = self
             .sessions
             .read()
@@ -390,8 +430,6 @@ impl WorkspaceSearchService {
         else {
             return;
         };
-
-        tokio::time::sleep(self.session_idle_grace).await;
 
         let entry = {
             let mut sessions = self.sessions.write().await;
@@ -428,11 +466,19 @@ impl Default for WorkspaceSearchService {
 }
 
 pub fn set_global_workspace_search_service(service: Arc<WorkspaceSearchService>) {
-    let _ = GLOBAL_WORKSPACE_SEARCH_SERVICE.set(service);
+    let mut global = match GLOBAL_WORKSPACE_SEARCH_SERVICE.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    *global = Arc::downgrade(&service);
 }
 
 pub fn get_global_workspace_search_service() -> Option<Arc<WorkspaceSearchService>> {
-    GLOBAL_WORKSPACE_SEARCH_SERVICE.get().cloned()
+    let global = match GLOBAL_WORKSPACE_SEARCH_SERVICE.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    global.upgrade()
 }
 
 pub fn workspace_search_daemon_binary_names() -> &'static [&'static str] {

--- a/src/crates/core/src/util/process_manager.rs
+++ b/src/crates/core/src/util/process_manager.rs
@@ -1,8 +1,10 @@
 //! Unified process management to avoid Windows child process leaks
 
+use std::io;
 use std::process::Command;
 use std::sync::LazyLock;
-use tokio::process::Command as TokioCommand;
+use tokio::process::{Child, Command as TokioCommand};
+use tokio::time::{timeout, Duration};
 
 #[cfg(windows)]
 use log::warn;
@@ -110,6 +112,77 @@ pub fn create_tokio_command<S: AsRef<std::ffi::OsStr>>(program: S) -> TokioComma
 
     #[cfg(not(windows))]
     cmd
+}
+
+pub fn configure_process_group(command: &mut TokioCommand) {
+    #[cfg(unix)]
+    {
+        command.process_group(0);
+    }
+}
+
+pub async fn terminate_child_process_tree(
+    child: &mut Child,
+    graceful_timeout: Duration,
+) -> io::Result<()> {
+    let pid = child.id();
+
+    #[cfg(unix)]
+    if let Some(pid) = pid {
+        let process_group = format!("-{}", pid);
+        let _ = create_tokio_command("kill")
+            .arg("-TERM")
+            .arg(&process_group)
+            .status()
+            .await;
+
+        match timeout(graceful_timeout, child.wait()).await {
+            Ok(wait_result) => return wait_result.map(|_| ()),
+            Err(_) => {
+                let _ = create_tokio_command("kill")
+                    .arg("-KILL")
+                    .arg(&process_group)
+                    .status()
+                    .await;
+                return child.wait().await.map(|_| ());
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    if let Some(pid) = pid {
+        let _ = create_tokio_command("taskkill")
+            .arg("/PID")
+            .arg(pid.to_string())
+            .arg("/T")
+            .arg("/F")
+            .status()
+            .await;
+        return child.wait().await.map(|_| ());
+    }
+
+    child.start_kill()?;
+    child.wait().await.map(|_| ())
+}
+
+pub fn spawn_child_process_tree_cleanup(child: Child, graceful_timeout: Duration) {
+    let _ = std::thread::Builder::new()
+        .name("process-tree-cleanup".to_string())
+        .spawn(move || match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(runtime) => {
+                runtime.block_on(async move {
+                    let mut child = child;
+                    let _ = terminate_child_process_tree(&mut child, graceful_timeout).await;
+                });
+            }
+            Err(_) => {
+                let mut child = child;
+                let _ = child.start_kill();
+            }
+        });
 }
 
 pub fn cleanup_all_processes() {

--- a/src/web-ui/src/app/layout/AppLayout.tsx
+++ b/src/web-ui/src/app/layout/AppLayout.tsx
@@ -74,6 +74,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
     useWindowControls({ isToolbarMode });
 
   const { state, switchLeftPanelTab, toggleLeftPanel, toggleRightPanel } = useApp();
+  const allowNextNativeCloseRef = useRef(false);
 
   // ── Load user keybinding overrides from config on startup ────────────────
   useEffect(() => {
@@ -298,26 +299,65 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
     t,
   ]);
 
-  // Save in-progress conversations on window close
+  // Save in-progress conversations before the native window is closed/hidden.
   React.useEffect(() => {
     let unlistenFn: (() => void) | null = null;
+    let handlingMacOSClose = false;
 
     const setupWindowCloseListener = async () => {
       if (!canUseNativeWindowControls) return;
 
       try {
+        if (isMacOS) {
+          const [{ listen }, { invoke }] = await Promise.all([
+            import('@tauri-apps/api/event'),
+            import('@tauri-apps/api/core'),
+          ]);
+
+          unlistenFn = await listen('bitfun_main_window_close_requested', async () => {
+            if (handlingMacOSClose) return;
+            handlingMacOSClose = true;
+            try {
+              const flowChatManager = FlowChatManager.getInstance();
+              await flowChatManager.saveAllInProgressTurns();
+            } catch (error) {
+              log.error('Failed to save conversations before hiding main window', error);
+            } finally {
+              try {
+                await invoke('hide_main_window_after_close_request');
+              } catch (error) {
+                log.error('Failed to hide main window after close request', error);
+              } finally {
+                handlingMacOSClose = false;
+              }
+            }
+          });
+          return;
+        }
+
         const { getCurrentWindow } = await import('@tauri-apps/api/window');
         const currentWindow = getCurrentWindow();
 
         unlistenFn = await currentWindow.onCloseRequested(async (event: { preventDefault: () => void }) => {
+          if (allowNextNativeCloseRef.current) {
+            allowNextNativeCloseRef.current = false;
+            return;
+          }
+
           try {
             event.preventDefault();
             const flowChatManager = FlowChatManager.getInstance();
             await flowChatManager.saveAllInProgressTurns();
-            await currentWindow.close();
           } catch (error) {
             log.error('Failed to save conversations, closing anyway', error);
+          }
+
+          try {
+            allowNextNativeCloseRef.current = true;
             await currentWindow.close();
+          } catch (error) {
+            allowNextNativeCloseRef.current = false;
+            throw error;
           }
         });
       } catch (error) {
@@ -327,7 +367,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
 
     setupWindowCloseListener();
     return () => { if (unlistenFn) unlistenFn(); };
-  }, [canUseNativeWindowControls]);
+  }, [canUseNativeWindowControls, isMacOS]);
 
   // Handle switch-to-files-panel event
   React.useEffect(() => {


### PR DESCRIPTION
## Summary

This change tightens flashgrep lifecycle management so the workspace search daemon is owned and cleaned up through a unified core path instead of relying on desktop-only exit cleanup.

## What changed

- moved flashgrep daemon cleanup responsibility into the core-owned search runtime path
- added a drop fallback for the async daemon client so leaked ownership still triggers best-effort process tree cleanup
- switched workspace search global registration from a strong global `Arc` to a `Weak` reference so the service can actually drop
- updated idle repo release scheduling to avoid keeping the search service alive unnecessarily
- replaced desktop-specific shutdown thread wiring with the shared blocking shutdown entrypoint
- unified platform process cleanup helpers around process-group or process-tree termination semantics

## Why

Users reported that `flashgrep` could remain alive after BitFun exited. The root issue was that lifecycle ownership was not strict RAII: the search service was globally strongly referenced, and daemon cleanup depended too much on explicit desktop shutdown plumbing.

This refactor makes the ownership model tighter and gives the daemon both an explicit shutdown path and a drop-time fallback.

## Impact

- desktop shutdown now uses the shared core lifecycle entrypoint
- workspace search resources can be released without being pinned forever by a global strong reference
- Windows, macOS, and Linux share the same lifecycle contract while still using platform-appropriate process cleanup primitives underneath

## Validation

- `cargo check --workspace`
- `cargo test --workspace`
