### PR TITLE
fix(web-ui): nav footer browser shortcut and insights in menu

### DIFF
--- a/src/apps/desktop/src/computer_use/desktop_host.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host.rs
@@ -26,7 +26,7 @@ use bitfun_core::util::errors::{BitFunError, BitFunResult};
 use enigo::{Axis, Button, Coordinate, Direction, Enigo, Key, Keyboard, Mouse, Settings};
 use image::codecs::jpeg::JpegEncoder;
 use image::{DynamicImage, Rgb, RgbImage};
-use log::{debug, warn};
+use log::{debug, info, warn};
 use resvg::tiny_skia::{Pixmap, Transform};
 use resvg::usvg;
 use screenshots::display_info::DisplayInfo;

--- a/src/web-ui/src/app/components/NavPanel/components/PersistentFooterActions.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/PersistentFooterActions.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
   Settings,
   Info,
@@ -8,10 +8,8 @@ import {
   Terminal,
   Smartphone,
   Globe,
-  Layers,
-  PanelsTopLeft,
+  ExternalLink,
   BarChart3,
-  LineChart,
   ChevronUp,
 } from 'lucide-react';
 import { Tooltip, Modal } from '@/component-library';
@@ -53,8 +51,6 @@ const PersistentFooterActions: React.FC = () => {
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuClosing, setMenuClosing] = useState(false);
-  const [multimodalOpen, setMultimodalOpen] = useState(false);
-  const multimodalHoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [showAbout, setShowAbout] = useState(false);
   const [showRemoteConnect, setShowRemoteConnect] = useState(false);
   const [showRemoteDisclaimer, setShowRemoteDisclaimer] = useState(false);
@@ -106,22 +102,10 @@ const PersistentFooterActions: React.FC = () => {
     }
   }, [activeTabId, openScene, t]);
 
-  const handleMultimodalEnter = useCallback(() => {
-    if (multimodalHoverTimerRef.current) clearTimeout(multimodalHoverTimerRef.current);
-    multimodalHoverTimerRef.current = setTimeout(() => setMultimodalOpen(true), 100);
-  }, []);
-
-  const handleMultimodalLeave = useCallback(() => {
-    if (multimodalHoverTimerRef.current) clearTimeout(multimodalHoverTimerRef.current);
-    multimodalHoverTimerRef.current = setTimeout(() => setMultimodalOpen(false), 180);
-  }, []);
-
   const handleOpenInsights = useCallback(() => {
+    closeMenu();
     openScene('insights');
-  }, [openScene]);
-
-  const insightsTooltip = t('nav.items.insights');
-  const isInsightsActive = activeTabId === 'insights';
+  }, [closeMenu, openScene]);
 
   const handleShowAbout = () => {
     closeMenu();
@@ -156,6 +140,9 @@ const PersistentFooterActions: React.FC = () => {
     setShowRemoteDisclaimer(false);
     setShowRemoteConnect(true);
   }, []);
+
+  const isBrowserActive =
+    activeTabId === 'browser' || (activeTabId === 'session' && isBrowserPanelActiveInCanvas);
 
   return (
     <>
@@ -222,6 +209,15 @@ const PersistentFooterActions: React.FC = () => {
                     type="button"
                     className="bitfun-nav-panel__footer-menu-item"
                     role="menuitem"
+                    onClick={handleOpenInsights}
+                  >
+                    <BarChart3 size={14} />
+                    <span>{t('scenes.insights')}</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="bitfun-nav-panel__footer-menu-item"
+                    role="menuitem"
                     onClick={handleOpenSettings}
                   >
                     <Settings size={14} />
@@ -256,62 +252,17 @@ const PersistentFooterActions: React.FC = () => {
             </button>
           </Tooltip>
 
-        <div
-          className="bitfun-nav-panel__footer-multimodal-wrap"
-          onMouseEnter={handleMultimodalEnter}
-          onMouseLeave={handleMultimodalLeave}
-        >
-          {(() => {
-            const isBrowserActive = activeTabId === 'browser' || (activeTabId === 'session' && isBrowserPanelActiveInCanvas);
-            const isAnyActive = isBrowserActive;
-            return (
-              <>
-                <button
-                  type="button"
-                  className={`bitfun-nav-panel__footer-btn bitfun-nav-panel__footer-btn--icon${isAnyActive ? ' is-active' : ''}${multimodalOpen ? ' is-hover-open' : ''}`}
-                  aria-label={t('nav.multimodalTools')}
-                  aria-expanded={multimodalOpen}
-                  aria-haspopup="menu"
-                >
-                  <span className="bitfun-nav-panel__footer-btn-icon-swap" aria-hidden="true">
-                    <Layers size={15} className="bitfun-nav-panel__footer-btn-icon-swap-default" />
-                    <PanelsTopLeft size={15} className="bitfun-nav-panel__footer-btn-icon-swap-hover" />
-                  </span>
-                </button>
-
-                {multimodalOpen && (
-                  <div
-                    className="bitfun-nav-panel__footer-multimodal-menu"
-                    role="menu"
-                    aria-label={t('nav.multimodalTools')}
-                  >
-                    <button
-                      type="button"
-                      className={`bitfun-nav-panel__footer-multimodal-item${isBrowserActive ? ' is-active' : ''}`}
-                      role="menuitem"
-                      aria-pressed={isBrowserActive}
-                      onClick={handleOpenBrowser}
-                    >
-                      <Globe size={13} className="bitfun-nav-panel__footer-multimodal-item-icon" />
-                      <span className="bitfun-nav-panel__footer-multimodal-item-label">{t('scenes.browser')}</span>
-                    </button>
-                  </div>
-                )}
-              </>
-            );
-          })()}
-        </div>
-
-          <Tooltip content={insightsTooltip} placement="right" followCursor>
+          <Tooltip content={t('scenes.browser')} placement="right">
             <button
               type="button"
-              className={`bitfun-nav-panel__footer-btn bitfun-nav-panel__footer-btn--icon${isInsightsActive ? ' is-active' : ''}`}
-              onClick={handleOpenInsights}
-              aria-label={insightsTooltip}
+              className={`bitfun-nav-panel__footer-btn bitfun-nav-panel__footer-btn--icon${isBrowserActive ? ' is-active' : ''}`}
+              aria-label={t('scenes.browser')}
+              aria-pressed={isBrowserActive}
+              onClick={handleOpenBrowser}
             >
               <span className="bitfun-nav-panel__footer-btn-icon-swap" aria-hidden="true">
-                <BarChart3 size={15} className="bitfun-nav-panel__footer-btn-icon-swap-default" />
-                <LineChart size={15} className="bitfun-nav-panel__footer-btn-icon-swap-hover" />
+                <Globe size={15} className="bitfun-nav-panel__footer-btn-icon-swap-default" />
+                <ExternalLink size={15} className="bitfun-nav-panel__footer-btn-icon-swap-hover" />
               </span>
             </button>
           </Tooltip>


### PR DESCRIPTION
## Summary

- Footer primary control opens **Browser** directly (Globe / ExternalLink swap) instead of a multimodal hover submenu with a single Browser item.
- **Insights** is available from the overflow (kebab) menu alongside other entries; opening Insights closes the menu.
- Browser active highlighting still covers the session canvas when the browser side panel is active.

## Verification

- `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run`
