### PR TITLE
feat(agentic,ai-adapters,web-ui): harden streaming tool arguments and pipeline

### DIFF
--- a/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
@@ -101,8 +101,10 @@ pub async fn handle_anthropic_stream(
                     Err(e) => {
                         stats.increment("error:sse_parsing");
                         let err_str = format!("SSE Parsing Error: {e}, data: {}", &data);
+                        stats.log_summary("sse_parsing_error");
                         error!("{}", err_str);
-                        continue;
+                        let _ = tx_event.send(Err(anyhow!(err_str)));
+                        return;
                     }
                 };
                 // Emit for Thinking and ToolUse content_block_start events.
@@ -128,8 +130,10 @@ pub async fn handle_anthropic_stream(
                     Err(e) => {
                         stats.increment("error:sse_parsing");
                         let err_str = format!("SSE Parsing Error: {e}, data: {}", &data);
+                        stats.log_summary("sse_parsing_error");
                         error!("{}", err_str);
-                        continue;
+                        let _ = tx_event.send(Err(anyhow!(err_str)));
+                        return;
                     }
                 };
                 match UnifiedResponse::try_from(content_block_delta) {

--- a/src/crates/ai-adapters/src/stream/stream_handler/responses.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/responses.rs
@@ -84,6 +84,54 @@ fn cleanup_tool_call_tracking(
     }
 }
 
+fn handle_function_call_arguments_delta(
+    tx_event: &mpsc::UnboundedSender<Result<UnifiedResponse>>,
+    stats: &mut StreamStats,
+    output_index: Option<usize>,
+    delta: Option<String>,
+    tool_calls_by_output_index: &mut HashMap<usize, InProgressToolCall>,
+) -> Result<()> {
+    let Some(delta) = delta.filter(|delta| !delta.is_empty()) else {
+        return Ok(());
+    };
+    let Some(output_index) = output_index else {
+        return Err(anyhow!(
+            "Responses function_call_arguments.delta missing output_index"
+        ));
+    };
+    let Some(tc) = tool_calls_by_output_index.get_mut(&output_index) else {
+        return Err(anyhow!(
+            "Responses function_call_arguments.delta for untracked output_index {}",
+            output_index
+        ));
+    };
+
+    tc.saw_any_delta = true;
+    tc.args_so_far.push_str(&delta);
+
+    // Some consumers treat `id` as a "new tool call" marker and reset buffers when it repeats.
+    // Only send id/name once per tool call; deltas that follow carry arguments only.
+    let (id, name) = if tc.sent_header {
+        (None, None)
+    } else {
+        tc.sent_header = true;
+        (tc.call_id.clone(), tc.name.clone())
+    };
+
+    let unified_response = UnifiedResponse {
+        tool_call: Some(crate::stream::types::unified::UnifiedToolCall {
+            tool_call_index: Some(output_index),
+            id,
+            name,
+            arguments: Some(delta),
+            arguments_is_snapshot: false,
+        }),
+        ..Default::default()
+    };
+    emit_unified_response(tx_event, stats, unified_response);
+    Ok(())
+}
+
 fn handle_function_call_output_item_done(
     tx_event: &mpsc::UnboundedSender<Result<UnifiedResponse>>,
     stats: &mut StreamStats,
@@ -272,9 +320,17 @@ pub async fn handle_responses_stream(
         match event.kind.as_str() {
             "response.output_item.added" => {
                 // Track tool calls so we can stream arguments via `response.function_call_arguments.delta`.
-                if let (Some(output_index), Some(item)) = (event.output_index, event.item.as_ref())
-                {
+                if let Some(item) = event.item.as_ref() {
                     if let Some(tc) = InProgressToolCall::from_item_value(item) {
+                        let Some(output_index) = event.output_index else {
+                            let error_msg =
+                                "Responses function_call output_item.added missing output_index";
+                            stats.increment("error:missing_output_index");
+                            stats.log_summary("responses_tool_call_missing_output_index");
+                            error!("{}", error_msg);
+                            let _ = tx_event.send(Err(anyhow!(error_msg)));
+                            return;
+                        };
                         if let Some(ref call_id) = tc.call_id {
                             tool_call_index_by_id.insert(call_id.clone(), output_index);
                         }
@@ -302,39 +358,20 @@ pub async fn handle_responses_stream(
                 }
             }
             "response.function_call_arguments.delta" => {
-                let Some(delta) = event.delta.filter(|delta| !delta.is_empty()) else {
-                    continue;
-                };
-                let Some(output_index) = event.output_index else {
-                    continue;
-                };
-                let Some(tc) = tool_calls_by_output_index.get_mut(&output_index) else {
-                    continue;
-                };
-
-                tc.saw_any_delta = true;
-                tc.args_so_far.push_str(&delta);
-
-                // Some consumers treat `id` as a "new tool call" marker and reset buffers when it repeats.
-                // Only send id/name once per tool call; deltas that follow carry arguments only.
-                let (id, name) = if tc.sent_header {
-                    (None, None)
-                } else {
-                    tc.sent_header = true;
-                    (tc.call_id.clone(), tc.name.clone())
-                };
-
-                let unified_response = UnifiedResponse {
-                    tool_call: Some(crate::stream::types::unified::UnifiedToolCall {
-                        tool_call_index: Some(output_index),
-                        id,
-                        name,
-                        arguments: Some(delta),
-                        arguments_is_snapshot: false,
-                    }),
-                    ..Default::default()
-                };
-                emit_unified_response(&tx_event, &mut stats, unified_response);
+                if let Err(err) = handle_function_call_arguments_delta(
+                    &tx_event,
+                    &mut stats,
+                    event.output_index,
+                    event.delta,
+                    &mut tool_calls_by_output_index,
+                ) {
+                    let error_msg = err.to_string();
+                    stats.increment("error:function_call_arguments_delta");
+                    stats.log_summary("responses_function_call_arguments_delta_error");
+                    error!("{}", error_msg);
+                    let _ = tx_event.send(Err(anyhow!(error_msg)));
+                    return;
+                }
             }
             "response.output_item.done" => {
                 let Some(item_value) = event.item else {
@@ -540,7 +577,8 @@ pub async fn handle_responses_stream(
 mod tests {
     use super::{
         super::stream_stats::StreamStats, extract_api_error_message,
-        handle_function_call_output_item_done, InProgressToolCall,
+        handle_function_call_arguments_delta, handle_function_call_output_item_done,
+        InProgressToolCall,
     };
     use serde_json::json;
     use std::collections::HashMap;
@@ -621,5 +659,41 @@ mod tests {
             tool_call.arguments.as_deref(),
             Some("{\"city\":\"Beijing\"}")
         );
+    }
+
+    #[test]
+    fn function_call_delta_requires_output_index() {
+        let (tx_event, _rx_event) = mpsc::unbounded_channel();
+        let mut tool_calls_by_output_index: HashMap<usize, InProgressToolCall> = HashMap::new();
+        let mut stats = StreamStats::new("Responses");
+
+        let err = handle_function_call_arguments_delta(
+            &tx_event,
+            &mut stats,
+            None,
+            Some("{\"city\"".to_string()),
+            &mut tool_calls_by_output_index,
+        )
+        .expect_err("missing output_index should fail");
+
+        assert!(err.to_string().contains("missing output_index"));
+    }
+
+    #[test]
+    fn function_call_delta_requires_tracked_output_item() {
+        let (tx_event, _rx_event) = mpsc::unbounded_channel();
+        let mut tool_calls_by_output_index: HashMap<usize, InProgressToolCall> = HashMap::new();
+        let mut stats = StreamStats::new("Responses");
+
+        let err = handle_function_call_arguments_delta(
+            &tx_event,
+            &mut stats,
+            Some(2),
+            Some("{\"city\"".to_string()),
+            &mut tool_calls_by_output_index,
+        )
+        .expect_err("untracked output_index should fail");
+
+        assert!(err.to_string().contains("untracked output_index 2"));
     }
 }

--- a/src/crates/ai-adapters/src/stream/types/anthropic.rs
+++ b/src/crates/ai-adapters/src/stream/types/anthropic.rs
@@ -93,6 +93,7 @@ impl From<MessageDelta> for UnifiedResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct ContentBlockStart {
+    pub index: Option<usize>,
     pub content_block: ContentBlock,
 }
 
@@ -118,7 +119,7 @@ impl From<ContentBlockStart> for UnifiedResponse {
         match value.content_block {
             ContentBlock::ToolUse { id, name } => {
                 let tool_call = UnifiedToolCall {
-                    tool_call_index: None,
+                    tool_call_index: value.index,
                     id: Some(id),
                     name: Some(name),
                     arguments: None,
@@ -141,6 +142,7 @@ impl From<ContentBlockStart> for UnifiedResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct ContentBlockDelta {
+    index: Option<usize>,
     delta: Delta,
 }
 
@@ -172,7 +174,7 @@ impl TryFrom<ContentBlockDelta> for UnifiedResponse {
             }
             Delta::InputJson { partial_json } => {
                 let tool_call = UnifiedToolCall {
-                    tool_call_index: None,
+                    tool_call_index: value.index,
                     id: None,
                     name: None,
                     arguments: Some(partial_json),

--- a/src/crates/ai-adapters/src/tool_call_accumulator.rs
+++ b/src/crates/ai-adapters/src/tool_call_accumulator.rs
@@ -1,4 +1,4 @@
-use log::{error, warn};
+use log::error;
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashMap};
 
@@ -90,167 +90,8 @@ pub struct PendingToolCalls {
 }
 
 impl PendingToolCall {
-    const SINGLE_STRING_ARGUMENT_TOOLS: &[(&str, &str)] = &[
-        ("Bash", "command"),
-        ("Skill", "command"),
-        ("Read", "file_path"),
-        ("GetFileDiff", "file_path"),
-        ("LS", "path"),
-        ("Delete", "path"),
-        ("Glob", "pattern"),
-        ("Grep", "pattern"),
-        ("WebSearch", "query"),
-        ("WebFetch", "url"),
-        ("InitMiniApp", "name"),
-    ];
-
-    fn remove_trailing_right_brace_once(raw_arguments: &str) -> Option<String> {
-        let last_non_whitespace_idx = raw_arguments
-            .char_indices()
-            .rev()
-            .find(|(_, ch)| !ch.is_whitespace())
-            .map(|(idx, _)| idx)?;
-
-        if !raw_arguments[last_non_whitespace_idx..].starts_with('}') {
-            return None;
-        }
-
-        let mut repaired = raw_arguments.to_string();
-        repaired.remove(last_non_whitespace_idx);
-        Some(repaired)
-    }
-
-    fn strip_argument_wrapping(raw_arguments: &str) -> &str {
-        let trimmed = raw_arguments.trim();
-        let Some(stripped) = trimmed
-            .strip_prefix("```")
-            .and_then(|value| value.strip_suffix("```"))
-        else {
-            return trimmed.trim_matches('`').trim();
-        };
-
-        let stripped = stripped.trim();
-        if let Some((first_line, rest)) = stripped.split_once('\n') {
-            if first_line
-                .chars()
-                .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
-            {
-                return rest.trim();
-            }
-        }
-
-        stripped
-    }
-
-    fn single_string_argument_field(tool_name: &str) -> Option<&'static str> {
-        Self::SINGLE_STRING_ARGUMENT_TOOLS
-            .iter()
-            .find_map(|(name, field)| (*name == tool_name).then_some(*field))
-    }
-
-    fn repair_single_string_arguments(tool_name: &str, raw_arguments: &str) -> Option<Value> {
-        let field = Self::single_string_argument_field(tool_name)?;
-        let raw = Self::strip_argument_wrapping(raw_arguments);
-        if raw.is_empty() {
-            return None;
-        }
-        Some(json!({ field: raw }))
-    }
-
-    /// Best-effort repair for a Git tool call whose `arguments` came back as a
-    /// raw shell-style command (e.g. `git status`, `"git diff --staged"`).
-    ///
-    /// We deliberately do NOT enforce a subcommand whitelist here — the Git
-    /// tool itself owns the allow-list and produces a clear "operation X is
-    /// not allowed" error when it sees something unexpected. Replicating that
-    /// list at the accumulator layer used to silently fall through to the raw
-    /// JSON parser, which made the model receive a generic "Arguments are
-    /// invalid JSON" instead of the actionable Git-level error.
-    ///
-    /// We still require the subcommand to look like a plain identifier
-    /// (alphanumerics + `-` + `_`) so we don't mistake unrelated payloads for
-    /// Git commands.
-    fn parse_git_command_arguments(raw_arguments: &str) -> Option<Value> {
-        let trimmed = Self::strip_argument_wrapping(raw_arguments);
-        let command = trimmed
-            .strip_prefix("git ")
-            .map(str::trim)
-            .unwrap_or(trimmed);
-        let mut parts = command.splitn(2, char::is_whitespace);
-        let operation = parts.next()?.trim();
-        if operation.is_empty()
-            || !operation
-                .chars()
-                .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
-        {
-            return None;
-        }
-
-        let args = parts.next().map(str::trim).filter(|args| !args.is_empty());
-        let mut value = json!({ "operation": operation });
-        if let Some(args) = args {
-            value["args"] = json!(args);
-        }
-        Some(value)
-    }
-
-    fn normalize_tool_arguments(tool_name: &str, arguments: Value) -> Value {
-        if let Value::String(raw) = &arguments {
-            if tool_name == "Git" {
-                if let Some(repaired) = Self::parse_git_command_arguments(raw) {
-                    warn!("Git tool call arguments repaired from JSON string command");
-                    return repaired;
-                }
-            }
-            if let Some(repaired) = Self::repair_single_string_arguments(tool_name, raw) {
-                warn!(
-                    "{} tool call arguments repaired from JSON string argument",
-                    tool_name
-                );
-                return repaired;
-            }
-        }
-        arguments
-    }
-
-    fn parse_arguments(tool_name: &str, raw_arguments: &str) -> Result<Value, String> {
-        match serde_json::from_str::<Value>(raw_arguments) {
-            Ok(arguments) => Ok(Self::normalize_tool_arguments(tool_name, arguments)),
-            Err(primary_error) => {
-                if tool_name == "Git" {
-                    if let Some(arguments) = Self::parse_git_command_arguments(raw_arguments) {
-                        warn!("Git tool call arguments repaired from raw command");
-                        return Ok(arguments);
-                    }
-                }
-
-                if let Some(arguments) =
-                    Self::repair_single_string_arguments(tool_name, raw_arguments)
-                {
-                    warn!(
-                        "{} tool call arguments repaired from raw string argument",
-                        tool_name
-                    );
-                    return Ok(arguments);
-                }
-
-                if let Some(repaired_arguments) =
-                    Self::remove_trailing_right_brace_once(raw_arguments)
-                {
-                    match serde_json::from_str::<Value>(&repaired_arguments) {
-                        Ok(arguments) => {
-                            warn!(
-                                "Tool call arguments repaired by removing one trailing right brace"
-                            );
-                            Ok(arguments)
-                        }
-                        Err(_) => Err(primary_error.to_string()),
-                    }
-                } else {
-                    Err(primary_error.to_string())
-                }
-            }
-        }
+    fn parse_arguments(_tool_name: &str, raw_arguments: &str) -> Result<Value, String> {
+        serde_json::from_str::<Value>(raw_arguments).map_err(|error| error.to_string())
     }
 
     pub fn has_pending(&self) -> bool {
@@ -457,7 +298,7 @@ mod tests {
     }
 
     #[test]
-    fn repairs_git_raw_command_arguments() {
+    fn git_raw_command_arguments_become_invalid_json_diagnostic() {
         let mut pending = PendingToolCall::default();
         pending.start_new("call_1".to_string(), Some("Git".to_string()));
         pending.append_arguments("git status");
@@ -466,12 +307,13 @@ mod tests {
             .finalize(ToolCallBoundary::FinishReason)
             .expect("finalized tool");
 
-        assert_eq!(finalized.arguments, json!({"operation": "status"}));
-        assert!(!finalized.is_error);
+        assert_eq!(finalized.raw_arguments, "git status");
+        assert_eq!(finalized.arguments, json!({}));
+        assert!(finalized.is_error);
     }
 
     #[test]
-    fn repairs_git_json_string_command_arguments() {
+    fn git_json_string_command_arguments_are_not_rewritten() {
         let mut pending = PendingToolCall::default();
         pending.start_new("call_1".to_string(), Some("Git".to_string()));
         pending.append_arguments("\"git diff --staged\"");
@@ -480,54 +322,72 @@ mod tests {
             .finalize(ToolCallBoundary::FinishReason)
             .expect("finalized tool");
 
+        assert_eq!(finalized.arguments, json!("git diff --staged"));
+        assert!(!finalized.is_error);
+    }
+
+    #[test]
+    fn git_args_only_object_is_left_for_tool_schema_diagnostic() {
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("Git".to_string()));
+        pending.append_arguments("{\"args\": \"--since=\\\"2026-05-02\\\" --oneline\"}");
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason)
+            .expect("finalized tool");
+
         assert_eq!(
             finalized.arguments,
-            json!({"operation": "diff", "args": "--staged"})
+            json!({"args": "--since=\"2026-05-02\" --oneline"})
         );
         assert!(!finalized.is_error);
     }
 
     #[test]
-    fn repairs_raw_string_arguments_for_single_field_tools() {
+    fn git_duplicate_subcommand_in_args_is_left_for_tool_schema_diagnostic() {
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("Git".to_string()));
+        pending.append_arguments("{\"args\": \"log --oneline -10\"}");
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason)
+            .expect("finalized tool");
+
+        assert_eq!(finalized.arguments, json!({"args": "log --oneline -10"}));
+        assert!(!finalized.is_error);
+    }
+
+    #[test]
+    fn does_not_infer_git_operation_from_ambiguous_args_only_object() {
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("Git".to_string()));
+        pending.append_arguments("{\"args\": \"--stat\"}");
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason)
+            .expect("finalized tool");
+
+        assert_eq!(finalized.arguments, json!({"args": "--stat"}));
+        assert!(!finalized.is_error);
+    }
+
+    #[test]
+    fn raw_string_arguments_for_single_field_tools_stay_invalid_json() {
         let cases = [
-            ("Bash", "pnpm test", json!({"command": "pnpm test"})),
-            ("Skill", "openai-docs", json!({"command": "openai-docs"})),
-            ("Read", "src/main.rs", json!({"file_path": "src/main.rs"})),
-            (
-                "GetFileDiff",
-                "src/lib.rs",
-                json!({"file_path": "src/lib.rs"}),
-            ),
-            ("LS", "src/crates", json!({"path": "src/crates"})),
-            (
-                "Delete",
-                "tmp/output.log",
-                json!({"path": "tmp/output.log"}),
-            ),
-            ("Glob", "**/*.rs", json!({"pattern": "**/*.rs"})),
-            (
-                "Grep",
-                "Arguments are invalid JSON",
-                json!({"pattern": "Arguments are invalid JSON"}),
-            ),
-            (
-                "WebSearch",
-                "OpenAI Agents SDK",
-                json!({"query": "OpenAI Agents SDK"}),
-            ),
-            (
-                "WebFetch",
-                "https://example.com",
-                json!({"url": "https://example.com"}),
-            ),
-            (
-                "InitMiniApp",
-                "Markdown Viewer",
-                json!({"name": "Markdown Viewer"}),
-            ),
+            ("Bash", "pnpm test"),
+            ("Skill", "openai-docs"),
+            ("Read", "src/main.rs"),
+            ("GetFileDiff", "src/lib.rs"),
+            ("LS", "src/crates"),
+            ("Delete", "tmp/output.log"),
+            ("Glob", "**/*.rs"),
+            ("Grep", "Arguments are invalid JSON"),
+            ("WebSearch", "OpenAI Agents SDK"),
+            ("WebFetch", "https://example.com"),
+            ("InitMiniApp", "Markdown Viewer"),
         ];
 
-        for (tool_name, raw_arguments, expected) in cases {
+        for (tool_name, raw_arguments) in cases {
             let mut pending = PendingToolCall::default();
             pending.start_new("call_1".to_string(), Some(tool_name.to_string()));
             pending.append_arguments(raw_arguments);
@@ -536,13 +396,87 @@ mod tests {
                 .finalize(ToolCallBoundary::FinishReason)
                 .expect("finalized tool");
 
-            assert_eq!(finalized.arguments, expected, "tool={tool_name}");
-            assert!(!finalized.is_error, "tool={tool_name}");
+            assert_eq!(finalized.arguments, json!({}), "tool={tool_name}");
+            assert!(finalized.is_error, "tool={tool_name}");
         }
     }
 
     #[test]
-    fn repairs_json_string_arguments_for_single_field_tools() {
+    fn incomplete_json_object_for_single_field_tools_stays_invalid() {
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("Bash".to_string()));
+        pending.append_arguments(
+            "{\"command\": \"git log --since=\\\"2026-05-02\\\" --oneline --stat",
+        );
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason)
+            .expect("finalized tool");
+
+        assert_eq!(finalized.arguments, json!({}));
+        assert!(finalized.is_error);
+    }
+
+    #[test]
+    fn does_not_wrap_incomplete_json_object_as_raw_string_argument() {
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("Bash".to_string()));
+        pending.append_arguments("{\"command\": ");
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason)
+            .expect("finalized tool");
+
+        assert_eq!(finalized.arguments, json!({}));
+        assert!(finalized.is_error);
+    }
+
+    #[test]
+    fn does_not_repair_incomplete_json_object_for_multifield_tools() {
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("Task".to_string()));
+        pending.append_arguments(
+            "{\"description\":\"Explore BitFun project structure\",\"prompt\":\"read README\\n\\nthoroughness: very",
+        );
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason)
+            .expect("finalized tool");
+
+        assert_eq!(finalized.arguments, json!({}));
+        assert!(finalized.is_error);
+    }
+
+    #[test]
+    fn does_not_repair_object_without_key_value_payload() {
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("Bash".to_string()));
+        pending.append_arguments("{");
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason)
+            .expect("finalized tool");
+
+        assert_eq!(finalized.arguments, json!({}));
+        assert!(finalized.is_error);
+    }
+
+    #[test]
+    fn does_not_execute_truncated_incomplete_json_object() {
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("Bash".to_string()));
+        pending.append_arguments("{\"command\": \"git log --since=\\\"2026-05-02\\\" --on");
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason)
+            .expect("finalized tool");
+
+        assert_eq!(finalized.arguments, json!({}));
+        assert!(finalized.is_error);
+    }
+
+    #[test]
+    fn json_string_arguments_for_single_field_tools_are_schema_errors_not_rewritten() {
         let mut pending = PendingToolCall::default();
         pending.start_new("call_1".to_string(), Some("Bash".to_string()));
         pending.append_arguments("\"git status\"");
@@ -551,12 +485,12 @@ mod tests {
             .finalize(ToolCallBoundary::FinishReason)
             .expect("finalized tool");
 
-        assert_eq!(finalized.arguments, json!({"command": "git status"}));
+        assert_eq!(finalized.arguments, json!("git status"));
         assert!(!finalized.is_error);
     }
 
     #[test]
-    fn repairs_fenced_raw_arguments_for_single_field_tools() {
+    fn fenced_raw_arguments_for_single_field_tools_stay_invalid_json() {
         let mut pending = PendingToolCall::default();
         pending.start_new("call_1".to_string(), Some("Bash".to_string()));
         pending.append_arguments("```bash\npnpm run lint:web\n```");
@@ -565,8 +499,8 @@ mod tests {
             .finalize(ToolCallBoundary::FinishReason)
             .expect("finalized tool");
 
-        assert_eq!(finalized.arguments, json!({"command": "pnpm run lint:web"}));
-        assert!(!finalized.is_error);
+        assert_eq!(finalized.arguments, json!({}));
+        assert!(finalized.is_error);
     }
 
     #[test]
@@ -584,7 +518,7 @@ mod tests {
     }
 
     #[test]
-    fn repairs_json_with_one_extra_trailing_right_brace() {
+    fn json_with_one_extra_trailing_right_brace_stays_invalid() {
         let mut pending = PendingToolCall::default();
         pending.start_new("call_1".to_string(), Some("tool_a".to_string()));
         pending.append_arguments("{\"a\":1}}");
@@ -594,8 +528,8 @@ mod tests {
             .expect("finalized tool");
 
         assert_eq!(finalized.raw_arguments, "{\"a\":1}}");
-        assert_eq!(finalized.arguments, json!({"a": 1}));
-        assert!(!finalized.is_error);
+        assert_eq!(finalized.arguments, json!({}));
+        assert!(finalized.is_error);
     }
 
     #[test]

--- a/src/crates/core/src/agentic/core/message.rs
+++ b/src/crates/core/src/agentic/core/message.rs
@@ -634,6 +634,9 @@ pub struct ToolCall {
     pub tool_id: String,
     pub tool_name: String,
     pub arguments: serde_json::Value,
+    /// Original streamed argument text, preserved for diagnostics when parsing failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_arguments: Option<String>,
     /// Record whether tool parameters are valid
     pub is_error: bool,
 }

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -2139,6 +2139,7 @@ mod tests {
                 tool_id: "tool-1".to_string(),
                 tool_name: "Read".to_string(),
                 arguments: json!({ "path": "README.md" }),
+                raw_arguments: None,
                 is_error: false,
             }],
         );
@@ -2157,6 +2158,7 @@ mod tests {
                 tool_id: "tool-1".to_string(),
                 tool_name: "Read".to_string(),
                 arguments: json!({ "path": "README.md" }),
+                raw_arguments: None,
                 is_error: false,
             }],
         );

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -230,6 +230,24 @@ impl RoundExecutor {
                     let no_effective_output = !result.has_effective_output;
                     let is_partial_recovery = result.partial_recovery_reason.is_some();
 
+                    if Self::is_invalid_tool_only_without_text(&result)
+                        && attempt_index < max_attempts - 1
+                    {
+                        let delay_ms = Self::retry_delay_ms(attempt_index);
+                        warn!(
+                            "Retrying stream because provider returned only invalid tool arguments: session_id={}, round_id={}, attempt={}/{}, delay_ms={}, tool_calls={}",
+                            context.session_id,
+                            round_id,
+                            attempt_index + 1,
+                            max_attempts,
+                            delay_ms,
+                            result.tool_calls.len()
+                        );
+                        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                        attempt_index += 1;
+                        continue;
+                    }
+
                     if no_effective_output && attempt_index < max_attempts - 1 {
                         let delay_ms = Self::retry_delay_ms(attempt_index);
                         warn!(
@@ -719,6 +737,16 @@ impl RoundExecutor {
                 .all(|tool_call| !tool_call.is_valid())
     }
 
+    fn is_invalid_tool_only_without_text(result: &StreamResult) -> bool {
+        result.partial_recovery_reason.is_none()
+            && !Self::has_user_visible_assistant_text(&result.full_text)
+            && !result.tool_calls.is_empty()
+            && result
+                .tool_calls
+                .iter()
+                .all(|tool_call| !tool_call.is_valid())
+    }
+
     fn retry_delay_ms(attempt_index: usize) -> u64 {
         Self::RETRY_BASE_DELAY_MS * (1u64 << attempt_index.min(3))
     }
@@ -846,6 +874,7 @@ mod tests {
                 tool_id: "call_1".to_string(),
                 tool_name: "Write".to_string(),
                 arguments: serde_json::json!({}),
+                raw_arguments: Some("{\"file_path\":\"src/lib.rs\"".to_string()),
                 is_error: true,
             }],
             usage: None,
@@ -870,6 +899,7 @@ mod tests {
                 tool_id: "call_1".to_string(),
                 tool_name: "Write".to_string(),
                 arguments: serde_json::json!({}),
+                raw_arguments: Some("{\"file_path\":\"src/lib.rs\"".to_string()),
                 is_error: true,
             }],
             usage: None,

--- a/src/crates/core/src/agentic/execution/stream_processor.rs
+++ b/src/crates/core/src/agentic/execution/stream_processor.rs
@@ -262,6 +262,9 @@ impl StreamContext {
             tool_id,
             tool_name,
             arguments: finalized.arguments.clone(),
+            raw_arguments: finalized
+                .is_error
+                .then_some(finalized.raw_arguments.clone()),
             is_error: finalized.is_error,
         });
     }
@@ -769,7 +772,10 @@ impl StreamProcessor {
                         TimedStreamItem::Item(Err(e)) => {
                             let error_msg = format!("Stream processing error: {}", e);
                             error!("{}", error_msg);
-                            if ctx.can_recover_as_partial_result() {
+                            let non_recoverable_stream_error =
+                                error_msg.contains("SSE Parsing Error");
+                            if !non_recoverable_stream_error && ctx.can_recover_as_partial_result()
+                            {
                                 flush_sse_on_error(&sse_collector, &error_msg).await;
                                 self.send_thinking_end_if_needed(&mut ctx).await;
                                 ctx.force_finish_pending_tool_calls();
@@ -1051,7 +1057,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repairs_tool_args_with_one_extra_trailing_right_brace() {
+    async fn does_not_repair_tool_args_with_one_extra_trailing_right_brace() {
         let processor = build_processor();
         let stream = iter(vec![Ok(UnifiedResponse {
             tool_call: Some(UnifiedToolCall {
@@ -1083,8 +1089,12 @@ mod tests {
         assert_eq!(result.tool_calls.len(), 1);
         assert_eq!(result.tool_calls[0].tool_id, "call_1");
         assert_eq!(result.tool_calls[0].tool_name, "tool_a");
-        assert_eq!(result.tool_calls[0].arguments, json!({"a": 1}));
-        assert!(!result.tool_calls[0].is_error);
+        assert_eq!(result.tool_calls[0].arguments, json!({}));
+        assert_eq!(
+            result.tool_calls[0].raw_arguments.as_deref(),
+            Some("{\"a\":1}}")
+        );
+        assert!(result.tool_calls[0].is_error);
     }
 
     #[tokio::test]

--- a/src/crates/core/src/agentic/insights/collector.rs
+++ b/src/crates/core/src/agentic/insights/collector.rs
@@ -447,6 +447,7 @@ fn rebuild_messages_from_turns(turns: &[DialogTurnData]) -> Vec<Message> {
                     tool_id: ti.tool_call.id.clone(),
                     tool_name: ti.tool_name.clone(),
                     arguments: ti.tool_call.input.clone(),
+                    raw_arguments: None,
                     is_error: false,
                 })
                 .collect();

--- a/src/crates/core/src/agentic/session/compression/compressor.rs
+++ b/src/crates/core/src/agentic/session/compression/compressor.rs
@@ -755,6 +755,7 @@ mod tests {
                             {"content": "Add regression tests", "status": "pending"}
                         ]
                     }),
+                    raw_arguments: None,
                     is_error: false,
                 }],
             ),

--- a/src/crates/core/src/agentic/session/compression/fallback/tests.rs
+++ b/src/crates/core/src/agentic/session/compression/fallback/tests.rs
@@ -27,6 +27,7 @@ fn clears_tool_results_from_compressed_history() {
                 "start_line": 1,
                 "limit": 20
             }),
+            raw_arguments: None,
             is_error: false,
         }],
     );
@@ -139,6 +140,7 @@ fn groups_consecutive_assistant_messages_under_single_role_header() {
                     arguments: json!({
                         "file_path": "/workspace/example.txt"
                     }),
+                    raw_arguments: None,
                     is_error: false,
                 }],
             ),
@@ -152,6 +154,7 @@ fn groups_consecutive_assistant_messages_under_single_role_header() {
                         "old_string": "before",
                         "new_string": "after"
                     }),
+                    raw_arguments: None,
                     is_error: false,
                 }],
             ),

--- a/src/crates/core/src/agentic/tools/browser_control/browser_launcher.rs
+++ b/src/crates/core/src/agentic/tools/browser_control/browser_launcher.rs
@@ -1,6 +1,9 @@
 //! Detect and launch the user's default browser with CDP debug port enabled.
 
-use crate::util::{errors::{BitFunError, BitFunResult}, process_manager};
+use crate::util::{
+    errors::{BitFunError, BitFunResult},
+    process_manager,
+};
 #[allow(unused_imports)]
 use log::{debug, info};
 use serde::{Deserialize, Serialize};

--- a/src/crates/core/src/agentic/tools/implementations/file_read_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_read_tool.rs
@@ -107,8 +107,7 @@ impl FileReadTool {
 
         let total_lines = total_lines.ok_or_else(|| {
             BitFunError::tool(
-                "Failed to read file: remote command did not return line-count markers"
-                    .to_string(),
+                "Failed to read file: remote command did not return line-count markers".to_string(),
             )
         })?;
 

--- a/src/crates/core/src/agentic/tools/implementations/git_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/git_tool.rs
@@ -794,6 +794,8 @@ This tool provides a safe and convenient way to execute Git commands. It support
 - The `operation` field already specifies the Git subcommand (e.g. `diff`, `log`, `add`).
 - The `args` field must contain **only additional arguments** for that subcommand.
 - **Do NOT include the subcommand name itself in `args`.** For example, use `{"operation": "diff", "args": "HEAD~2..HEAD --stat"}` — NOT `{"operation": "diff", "args": "diff HEAD~2..HEAD --stat"}`.
+- A raw shell command string is invalid. Use `{"operation": "status"}` instead of `"git status"`.
+- An object with only `args` and no `operation` is invalid, even if `args` contains flags such as `--since` or `--oneline`. Retry with the explicit operation, for example `{"operation": "log", "args": "--since=\"2026-05-02\" --oneline"}`.
 
 ## Safety Notes
 
@@ -839,12 +841,12 @@ When creating commits, use this format for the commit message:
             "properties": {
                 "operation": {
                     "type": "string",
-                    "description": "The Git operation to perform (e.g., status, diff, log, add, commit, branch, checkout, pull, push)",
+                    "description": "Required Git operation/subcommand to perform (e.g., status, diff, log, add, commit, branch, checkout, pull, push). Do not omit this and do not place the subcommand in args.",
                     "enum": ALLOWED_OPERATIONS
                 },
                 "args": {
                     "type": "string",
-                    "description": "Additional arguments for the Git command (e.g., file paths, flags, options)"
+                    "description": "Only additional arguments for the selected Git operation (e.g., file paths, flags, options). Do not include the operation/subcommand itself here."
                 },
                 "working_directory": {
                     "type": "string",
@@ -913,7 +915,10 @@ When creating commits, use this format for the commit message:
             None => {
                 return ValidationResult {
                     result: false,
-                    message: Some("operation is required".to_string()),
+                    message: Some(
+                        "operation is required. Provide an explicit top-level operation such as {\"operation\":\"status\"}; do not send a raw git command string or an args-only object."
+                            .to_string(),
+                    ),
                     error_code: Some(400),
                     meta: None,
                 };
@@ -1129,7 +1134,36 @@ impl Default for GitTool {
 
 #[cfg(test)]
 mod tests {
+    use crate::agentic::tools::framework::Tool;
+
     use super::{GitTool, ParsedDiffArgs};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn git_schema_requires_explicit_operation_instead_of_args_only() {
+        let tool = GitTool::new();
+        let schema = tool.input_schema();
+        assert_eq!(schema["additionalProperties"], false);
+        assert_eq!(schema["required"], json!(["operation"]));
+        assert!(schema["properties"]["operation"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("Do not omit this"));
+        assert!(schema["properties"]["args"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("Do not include the operation"));
+
+        let validation = tool
+            .validate_input(&json!({"args": "--since=\"2026-05-02\" --oneline"}), None)
+            .await;
+        assert!(!validation.result);
+        assert!(validation
+            .message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("operation is required"));
+    }
 
     #[test]
     fn parse_diff_args_empty() {

--- a/src/crates/core/src/agentic/tools/implementations/glob_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/glob_tool.rs
@@ -2,8 +2,8 @@ use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
 use crate::service::search::{
     get_global_workspace_search_service, workspace_search_runtime_available, GlobSearchRequest,
 };
-use crate::util::process_manager;
 use crate::util::errors::{BitFunError, BitFunResult};
+use crate::util::process_manager;
 use async_trait::async_trait;
 use globset::{GlobBuilder, GlobMatcher};
 use ignore::WalkBuilder;

--- a/src/crates/core/src/agentic/tools/implementations/skill_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skill_tool.rs
@@ -9,10 +9,10 @@ use crate::agentic::tools::framework::{
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
 use log::debug;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 // Use skills module
-use super::skills::{SkillLocation, get_skill_registry};
+use super::skills::{get_skill_registry, SkillLocation};
 
 /// Skill tool
 pub struct SkillTool;
@@ -265,12 +265,12 @@ impl Default for SkillTool {
 #[cfg(test)]
 mod tests {
     use super::SkillTool;
-    use crate::agentic::WorkspaceBinding;
     use crate::agentic::tools::framework::{Tool, ToolResult};
     use crate::agentic::workspace::{
         WorkspaceCommandOptions, WorkspaceCommandResult, WorkspaceDirEntry, WorkspaceFileSystem,
         WorkspaceServices, WorkspaceShell,
     };
+    use crate::agentic::WorkspaceBinding;
     use crate::service::remote_ssh::workspace_state::workspace_session_identity;
     use async_trait::async_trait;
     use serde_json::json;
@@ -432,11 +432,9 @@ Use the remote project skill.
         };
         assert_eq!(data["skill_name"], "cso");
         assert_eq!(data["location"], "user");
-        assert!(
-            data["content"]
-                .as_str()
-                .unwrap_or_default()
-                .contains("# /cso")
-        );
+        assert!(data["content"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("# /cso"));
     }
 }

--- a/src/crates/core/src/agentic/tools/implementations/skills/registry.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skills/registry.rs
@@ -7,8 +7,8 @@ use super::builtin::{
 };
 use super::default_profiles::{is_enabled_by_default_for_mode, is_skill_enabled_for_mode};
 use super::mode_overrides::{
-    UserModeSkillOverrides, load_disabled_mode_skills_local, load_disabled_mode_skills_remote,
-    load_user_mode_skill_overrides,
+    load_disabled_mode_skills_local, load_disabled_mode_skills_remote,
+    load_user_mode_skill_overrides, UserModeSkillOverrides,
 };
 use super::types::{SkillData, SkillInfo, SkillLocation};
 use crate::agentic::workspace::WorkspaceFileSystem;

--- a/src/crates/core/src/agentic/tools/implementations/task_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/task_tool.rs
@@ -59,7 +59,7 @@ The Task tool launches specialized agents (subprocesses) that autonomously handl
 Available agents and the tools they have access to:
 {}
 
-When using the Task tool, you must specify a subagent_type parameter to select which agent type to use.
+When using the Task tool, you must specify `subagent_type` as a top-level tool argument to select which agent type to use. Do not put `subagent_type`, `description`, `workspace_path`, `model_id`, or `timeout_seconds` inside the prompt string.
 
 When NOT to use the Task tool:
 - If you want to read a specific file path, use the Read or Glob tool instead of the Task tool, to find the match more quickly
@@ -179,11 +179,11 @@ impl Tool for TaskTool {
                 },
                 "prompt": {
                     "type": "string",
-                    "description": "The task for the agent to perform. Keep it scoped and concise. The 180-line / 16KB guideline is a soft reliability threshold, not a hard cap. For large delegations, split into multiple Task calls with clear ownership, and pass file paths, symbols, constraints, and exact questions instead of pasting large file contents."
+                    "description": "The task for the agent to perform. Keep it scoped and concise. Do not include top-level Task arguments such as subagent_type inside this string. The 180-line / 16KB guideline is a soft reliability threshold, not a hard cap. For large delegations, split into multiple Task calls with clear ownership, and pass file paths, symbols, constraints, and exact questions instead of pasting large file contents."
                 },
                 "subagent_type": {
                     "type": "string",
-                    "description": "The type of specialized agent to use for this task"
+                    "description": "Required top-level agent type id. Use the exact case-sensitive id from the available_agents type attribute, for example Explore, FileFinder, CodeReview, or another listed agent."
                 },
                 "workspace_path": {
                     "type": "string",
@@ -203,7 +203,8 @@ impl Tool for TaskTool {
                 "description",
                 "prompt",
                 "subagent_type"
-            ]
+            ],
+            "additionalProperties": false
         })
     }
 
@@ -233,6 +234,7 @@ impl Tool for TaskTool {
         _context: Option<&ToolUseContext>,
     ) -> ValidationResult {
         let validation = InputValidator::new(input)
+            .validate_required("description")
             .validate_required("prompt")
             .validate_required("subagent_type")
             .finish();
@@ -519,6 +521,26 @@ mod tests {
             .unwrap()
             .iter()
             .any(|value| value.as_str() == Some("model_id")));
+    }
+
+    #[test]
+    fn task_schema_requires_top_level_subagent_type_and_rejects_extra_fields() {
+        let schema = TaskTool::new().input_schema();
+
+        assert_eq!(schema["additionalProperties"], false);
+        assert!(schema["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value.as_str() == Some("subagent_type")));
+        assert!(schema["properties"]["subagent_type"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("top-level"));
+        assert!(schema["properties"]["prompt"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("Do not include top-level Task arguments"));
     }
 
     #[test]

--- a/src/crates/core/src/agentic/tools/implementations/tool-runtime/src/fs/read_file.rs
+++ b/src/crates/core/src/agentic/tools/implementations/tool-runtime/src/fs/read_file.rs
@@ -111,14 +111,21 @@ mod tests {
     use super::read_file;
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
     fn write_temp_file(contents: &str) -> PathBuf {
-        let unique = SystemTime::now()
+        let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("time went backwards")
             .as_nanos();
-        let path = std::env::temp_dir().join(format!("bitfun-read-file-test-{unique}.txt"));
+        let counter = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let process_id = std::process::id();
+        let path = std::env::temp_dir().join(format!(
+            "bitfun-read-file-test-{process_id}-{timestamp}-{counter}.txt"
+        ));
         fs::write(&path, contents).expect("temp file should be written");
         path
     }

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -224,6 +224,17 @@ fn truncate_arguments_preview(value: &serde_json::Value) -> String {
     format!("{}…[truncated, total {} bytes]", &raw[..cut], raw.len())
 }
 
+fn truncate_raw_arguments_preview(raw: &str) -> String {
+    if raw.len() <= TOOL_ERROR_ARGUMENTS_PREVIEW_BYTES {
+        return raw.to_string();
+    }
+    let mut cut = TOOL_ERROR_ARGUMENTS_PREVIEW_BYTES;
+    while cut > 0 && !raw.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!("{}…[truncated, total {} bytes]", &raw[..cut], raw.len())
+}
+
 fn classify_tool_error(error: &BitFunError) -> &'static str {
     match error {
         BitFunError::Validation(_) => "invalid_arguments",
@@ -240,7 +251,12 @@ fn build_error_execution_result(
     error: &BitFunError,
 ) -> ToolExecutionResult {
     let (tool_id, tool_name, execution_time_ms, provided_arguments) = if let Some(task) = task {
-        let preview = truncate_arguments_preview(&task.tool_call.arguments);
+        let preview = task
+            .tool_call
+            .raw_arguments
+            .as_deref()
+            .map(truncate_raw_arguments_preview)
+            .unwrap_or_else(|| truncate_arguments_preview(&task.tool_call.arguments));
         (
             task.tool_call.tool_id,
             task.tool_call.tool_name,
@@ -261,14 +277,21 @@ fn build_error_execution_result(
         "next_step_hint": TOOL_ERROR_NEXT_STEP_HINT,
         "message": format!("Tool '{}' failed ({}): {}", tool_name, category, error_message),
     });
-    if let Some(args_preview) = provided_arguments {
-        result_json["provided_arguments"] = serde_json::Value::String(args_preview);
+    if let Some(args_preview) = provided_arguments.as_ref() {
+        result_json["provided_arguments"] = serde_json::Value::String(args_preview.clone());
     }
 
-    let assistant_text = format!(
-        "Tool '{}' failed ({}): {}\n{}",
-        tool_name, category, error_message, TOOL_ERROR_NEXT_STEP_HINT
-    );
+    let assistant_text = if let Some(args_preview) = provided_arguments.as_ref() {
+        format!(
+            "Tool '{}' failed ({}): {}\nProvided arguments: {}\n{}",
+            tool_name, category, error_message, args_preview, TOOL_ERROR_NEXT_STEP_HINT
+        )
+    } else {
+        format!(
+            "Tool '{}' failed ({}): {}\n{}",
+            tool_name, category, error_message, TOOL_ERROR_NEXT_STEP_HINT
+        )
+    };
 
     ToolExecutionResult {
         tool_id: tool_id.clone(),
@@ -636,12 +659,22 @@ impl ToolPipeline {
         );
 
         if tool_name.is_empty() || tool_is_error {
+            let raw_arguments_preview = task
+                .tool_call
+                .raw_arguments
+                .as_deref()
+                .map(truncate_raw_arguments_preview);
             let error_msg = if tool_name.is_empty() && tool_is_error {
                 "Missing valid tool name and arguments are invalid JSON.".to_string()
             } else if tool_name.is_empty() {
                 "Missing valid tool name.".to_string()
             } else {
                 "Arguments are invalid JSON.".to_string()
+            };
+            let error_msg = if let Some(raw_arguments_preview) = raw_arguments_preview {
+                format!("{error_msg} Raw arguments: {raw_arguments_preview}")
+            } else {
+                error_msg
             };
             self.state_manager
                 .update_state(
@@ -1374,6 +1407,7 @@ mod tests {
                 tool_id: tool_id.to_string(),
                 tool_name: tool_name.to_string(),
                 arguments: json!({ "path": "src/main.rs" }),
+                raw_arguments: None,
                 is_error: false,
             },
             ToolExecutionContext {
@@ -1408,5 +1442,29 @@ mod tests {
             result.result.result_for_assistant.as_deref(),
             Some(USER_STEERING_INTERRUPTED_MESSAGE)
         );
+    }
+
+    #[test]
+    fn error_result_prefers_raw_arguments_preview_when_available() {
+        let mut task = test_tool_task("tool_1", "Git");
+        task.tool_call.arguments = json!({});
+        task.tool_call.raw_arguments = Some("{\"operation\":\"log\"".to_string());
+
+        let result = build_error_execution_result(
+            "tool_1",
+            Some(task),
+            &BitFunError::Validation("Arguments are invalid JSON.".to_string()),
+        );
+
+        assert_eq!(
+            result.result.result["provided_arguments"],
+            serde_json::Value::String("{\"operation\":\"log\"".to_string())
+        );
+        assert!(result
+            .result
+            .result_for_assistant
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Provided arguments: {\"operation\":\"log\""));
     }
 }

--- a/src/crates/core/src/miniapp/builtin/mod.rs
+++ b/src/crates/core/src/miniapp/builtin/mod.rs
@@ -28,6 +28,7 @@ pub struct BuiltinApp {
 }
 
 /// All built-in apps that ship with BitFun.
+/// Each time the BuiltinApp changes, the version needs to be modified to take effect
 pub const BUILTIN_APPS: &[BuiltinApp] = &[
     BuiltinApp {
         id: "builtin-gomoku",

--- a/src/crates/core/src/service/remote_ssh/manager.rs
+++ b/src/crates/core/src/service/remote_ssh/manager.rs
@@ -1411,10 +1411,8 @@ impl SSHConnectionManager {
                 Some(russh::ChannelMsg::ExitSignal { signal_name, .. }) => {
                     interrupted = interrupted || matches!(signal_name, Sig::INT | Sig::TERM);
                 }
-                Some(russh::ChannelMsg::Eof) => {
-                }
-                Some(russh::ChannelMsg::Close) => {
-                }
+                Some(russh::ChannelMsg::Eof) => {}
+                Some(russh::ChannelMsg::Close) => {}
                 None => {
                     break;
                 }

--- a/src/crates/core/tests/fixtures/stream/anthropic/interleaved_parallel_tool_use.sse
+++ b/src/crates/core/tests/fixtures/stream/anthropic/interleaved_parallel_tool_use.sse
@@ -1,0 +1,33 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_parallel_tool_test","type":"message","role":"assistant","content":[],"model":"claude-test","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_parallel_0","name":"tool_a"}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_parallel_1","name":"tool_b"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"a\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"b\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"1}"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"2}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":15}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/src/crates/core/tests/fixtures/stream/anthropic/malformed_content_block_delta.sse
+++ b/src/crates/core/tests/fixtures/stream/anthropic/malformed_content_block_delta.sse
@@ -1,0 +1,15 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_malformed_delta_test","type":"message","role":"assistant","content":[],"model":"claude-test","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_malformed_0","name":"tool_a"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"a\":1}"
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":15}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/src/crates/core/tests/fixtures/stream/anthropic/malformed_tool_arguments_extra_brace.sse
+++ b/src/crates/core/tests/fixtures/stream/anthropic/malformed_tool_arguments_extra_brace.sse
@@ -1,0 +1,18 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_bad_tool_args","type":"message","role":"assistant","content":[],"model":"claude-test","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_bad_json","name":"tool_a"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"a\":1}}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":8}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/src/crates/core/tests/fixtures/stream/gemini/function_call_string_args.sse
+++ b/src/crates/core/tests/fixtures/stream/gemini/function_call_string_args.sse
@@ -1,0 +1,2 @@
+data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"tool_a","args":"git status"}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}
+

--- a/src/crates/core/tests/fixtures/stream/responses/malformed_function_call_arguments.sse
+++ b/src/crates/core/tests/fixtures/stream/responses/malformed_function_call_arguments.sse
@@ -1,0 +1,8 @@
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_bad_json","type":"function_call","call_id":"call_resp_bad_json","name":"tool_a","arguments":"","status":"in_progress"}}
+
+data: {"type":"response.function_call_arguments.delta","output_index":0,"delta":"{\"a\":1}}"}
+
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_bad_json","type":"function_call","call_id":"call_resp_bad_json","name":"tool_a","arguments":"{\"a\":1}}","status":"completed"}}
+
+data: {"type":"response.completed","response":{"id":"resp_bad_json","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2},"output":[]}}
+

--- a/src/crates/core/tests/stream_processor_anthropic.rs
+++ b/src/crates/core/tests/stream_processor_anthropic.rs
@@ -4,6 +4,7 @@ use bitfun_core::agentic::events::AgenticEvent;
 use common::stream_test_harness::{
     run_stream_fixture_with_options, StreamFixtureProvider, StreamFixtureRunOptions,
 };
+use serde_json::json;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn anthropic_fixture_parses_inline_think_tags_inside_text_delta() {
@@ -114,4 +115,49 @@ async fn anthropic_extended_thinking_sse_produces_reasoning_and_text() {
         })
         .collect();
     assert_eq!(text_chunks, vec!["Here is the answer."]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn anthropic_parallel_tool_use_keeps_arguments_separate_by_index() {
+    let output = run_stream_fixture_with_options(
+        StreamFixtureProvider::Anthropic,
+        "stream/anthropic/interleaved_parallel_tool_use.sse",
+        StreamFixtureRunOptions {
+            anthropic_inline_think_in_text: false,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+
+    assert_eq!(result.tool_calls.len(), 2);
+    assert_eq!(result.tool_calls[0].tool_id, "toolu_parallel_0");
+    assert_eq!(result.tool_calls[0].tool_name, "tool_a");
+    assert_eq!(result.tool_calls[0].arguments, json!({ "a": 1 }));
+    assert!(!result.tool_calls[0].is_error);
+    assert_eq!(result.tool_calls[1].tool_id, "toolu_parallel_1");
+    assert_eq!(result.tool_calls[1].tool_name, "tool_b");
+    assert_eq!(result.tool_calls[1].arguments, json!({ "b": 2 }));
+    assert!(!result.tool_calls[1].is_error);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn anthropic_malformed_content_block_delta_fails_stream() {
+    let output = run_stream_fixture_with_options(
+        StreamFixtureProvider::Anthropic,
+        "stream/anthropic/malformed_content_block_delta.sse",
+        StreamFixtureRunOptions {
+            anthropic_inline_think_in_text: false,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let error = output.result.expect_err("malformed SSE delta should fail");
+    assert!(
+        error.error.to_string().contains("SSE Parsing Error"),
+        "unexpected error: {}",
+        error.error
+    );
 }

--- a/src/crates/core/tests/stream_processor_openai.rs
+++ b/src/crates/core/tests/stream_processor_openai.rs
@@ -68,7 +68,7 @@ async fn openai_fixture_keeps_collecting_tool_args_across_usage_chunks() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn openai_fixture_ignores_duplicate_empty_tool_chunk_between_real_tools() {
+async fn openai_fixture_keeps_malformed_tool_arguments_invalid() {
     let output = run_stream_fixture(
         StreamFixtureProvider::OpenAi,
         "stream/openai/thinking_text_three_tools_with_empty_toolcall_anomaly.sse",
@@ -94,10 +94,10 @@ async fn openai_fixture_ignores_duplicate_empty_tool_chunk_between_real_tools() 
 
     assert_eq!(result.tool_calls[2].tool_id, "call_3");
     assert_eq!(result.tool_calls[2].tool_name, "tool_three");
-    assert_eq!(result.tool_calls[2].arguments, json!({ "z": 3 }));
+    assert_eq!(result.tool_calls[2].arguments, json!({}));
     assert!(
-        !result.tool_calls[2].is_error,
-        "the trailing extra right brace should be repaired"
+        result.tool_calls[2].is_error,
+        "malformed JSON must be reported back to the model, not repaired"
     );
 
     assert_eq!(

--- a/src/crates/core/tests/stream_processor_tool_arguments.rs
+++ b/src/crates/core/tests/stream_processor_tool_arguments.rs
@@ -1,0 +1,83 @@
+mod common;
+
+use bitfun_core::agentic::events::AgenticEvent;
+use common::sse_fixture_server::FixtureSseServerOptions;
+use common::stream_test_harness::{run_stream_fixture, StreamFixtureProvider};
+use serde_json::json;
+
+fn assert_no_stream_failure_event(events: &[AgenticEvent]) {
+    let failed_or_cancelled = events.iter().any(|event| {
+        matches!(
+            event,
+            AgenticEvent::DialogTurnFailed { .. } | AgenticEvent::DialogTurnCancelled { .. }
+        )
+    });
+    assert!(
+        !failed_or_cancelled,
+        "malformed tool arguments should be reported as tool-call errors, not stream failures"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn anthropic_malformed_tool_arguments_are_not_repaired() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::Anthropic,
+        "stream/anthropic/malformed_tool_arguments_extra_brace.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+    assert_no_stream_failure_event(&output.events);
+
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].tool_id, "toolu_bad_json");
+    assert_eq!(result.tool_calls[0].tool_name, "tool_a");
+    assert_eq!(result.tool_calls[0].arguments, json!({}));
+    assert_eq!(
+        result.tool_calls[0].raw_arguments.as_deref(),
+        Some("{\"a\":1}}")
+    );
+    assert!(result.tool_calls[0].is_error);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn responses_malformed_tool_arguments_are_not_repaired() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::Responses,
+        "stream/responses/malformed_function_call_arguments.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+    assert_no_stream_failure_event(&output.events);
+
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].tool_id, "call_resp_bad_json");
+    assert_eq!(result.tool_calls[0].tool_name, "tool_a");
+    assert_eq!(result.tool_calls[0].arguments, json!({}));
+    assert_eq!(
+        result.tool_calls[0].raw_arguments.as_deref(),
+        Some("{\"a\":1}}")
+    );
+    assert!(result.tool_calls[0].is_error);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gemini_string_tool_arguments_are_not_coerced_to_object() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::Gemini,
+        "stream/gemini/function_call_string_args.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+    assert_no_stream_failure_event(&output.events);
+
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].tool_name, "tool_a");
+    assert_eq!(result.tool_calls[0].arguments, json!("git status"));
+    assert!(!result.tool_calls[0].is_error);
+}

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
@@ -47,6 +47,26 @@
   gap: 0.5rem;
 }
 
+.user-message-item__steering-tag {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  width: fit-content;
+  padding: 2px 7px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: 0.01em;
+  user-select: none;
+}
+
+.user-message-item__steering-tag--pending {
+  color: var(--color-warning, #f59e0b);
+  background: color-mix(in srgb, var(--color-warning, #f59e0b) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-warning, #f59e0b) 28%, transparent);
+}
+
 .user-message-item__actions {
   display: flex;
   align-items: center;

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.test.tsx
@@ -1,0 +1,131 @@
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+import { FlowChatContext } from './FlowChatContext';
+import { UserMessageItem } from './UserMessageItem';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const labels: Record<string, string> = {
+        'steering.statusPending': '等待触发',
+        'steering.statusInjected': '已触发',
+        'message.copy': '复制',
+        'message.copyFailed': '复制失败',
+      };
+      return labels[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('../../store/modernFlowChatStore', () => ({
+  useActiveSession: () => null,
+}));
+
+vi.mock('../../store/FlowChatStore', () => ({
+  flowChatStore: {
+    truncateDialogTurnsFrom: vi.fn(),
+  },
+}));
+
+vi.mock('@/infrastructure/api', () => ({
+  snapshotAPI: {
+    rollbackToTurn: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/notification-system', () => ({
+  notificationService: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/infrastructure/event-bus', () => ({
+  globalEventBus: {
+    emit: vi.fn(),
+  },
+}));
+
+vi.mock('@/component-library', () => ({
+  ReproductionStepsBlock: ({ steps }: { steps: string }) => <div>{steps}</div>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  confirmDanger: vi.fn(),
+}));
+
+describe('UserMessageItem steering tag', () => {
+  let dom: JSDOM;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      pretendToBeVisual: true,
+    });
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('navigator', {
+      clipboard: {
+        writeText: vi.fn(),
+      },
+    });
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it('renders pending steering tag on the right side of the message row', () => {
+    act(() => {
+      root.render(
+        <FlowChatContext.Provider value={{ allowUserMessageRollback: false }}>
+          <UserMessageItem
+            message={{
+              id: 'user-steering-1',
+              content: 'Please adjust this now',
+              timestamp: 1000,
+            }}
+            turnId="turn-1"
+            steeringStatus="pending"
+          />
+        </FlowChatContext.Provider>,
+      );
+    });
+
+    const main = container.querySelector('.user-message-item__main');
+    const tag = main?.querySelector('.user-message-item__steering-tag');
+
+    expect(tag?.textContent).toBe('等待触发');
+  });
+
+  it('does not render a steering tag after steering is triggered', () => {
+    act(() => {
+      root.render(
+        <FlowChatContext.Provider value={{ allowUserMessageRollback: false }}>
+          <UserMessageItem
+            message={{
+              id: 'user-steering-1',
+              content: 'Please adjust this now',
+              timestamp: 1000,
+            }}
+            turnId="turn-1"
+            steeringStatus="completed"
+          />
+        </FlowChatContext.Provider>,
+      );
+    });
+
+    expect(container.querySelector('.user-message-item__steering-tag')).toBeNull();
+  });
+});

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
@@ -6,7 +6,7 @@
 import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Copy, Check, RotateCcw, Loader2, ArrowDownToLine, X } from 'lucide-react';
-import type { DialogTurn } from '../../types/flow-chat';
+import type { DialogTurn, FlowUserSteeringItem } from '../../types/flow-chat';
 import { useFlowChatContext } from './FlowChatContext';
 import { useActiveSession } from '../../store/modernFlowChatStore';
 import { flowChatStore } from '../../store/FlowChatStore';
@@ -22,10 +22,11 @@ const log = createLogger('UserMessageItem');
 interface UserMessageItemProps {
   message: DialogTurn['userMessage'];
   turnId: string;
+  steeringStatus?: FlowUserSteeringItem['status'];
 }
 
 export const UserMessageItem = React.memo<UserMessageItemProps>(
-  ({ message, turnId }) => {
+  ({ message, turnId, steeringStatus }) => {
     const { t } = useTranslation('flow-chat');
     const {
       config,
@@ -48,7 +49,18 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
     const turnIndex = activeSession?.dialogTurns.findIndex(t => t.id === turnId) ?? -1;
     const dialogTurn = turnIndex >= 0 ? activeSession?.dialogTurns[turnIndex] : null;
     const isFailed = dialogTurn?.status === 'error';
-    const canRollback = allowUserMessageRollback && !!sessionId && turnIndex >= 0 && !isRollingBack;
+    const canRollback =
+      !steeringStatus &&
+      allowUserMessageRollback &&
+      !!sessionId &&
+      turnIndex >= 0 &&
+      !isRollingBack;
+    const steeringTag = steeringStatus === 'pending'
+      ? {
+          className: 'user-message-item__steering-tag--pending',
+          label: t('steering.statusPending'),
+        }
+      : null;
 
     const { displayText, reproductionSteps } = useMemo(() => {
       const reproductionRegex = /<reproduction_steps>([\s\S]*?)<\/reproduction_steps\s*>?/g;
@@ -213,6 +225,11 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
           >
             {displayText}
           </div>
+          {steeringTag && (
+            <div className={`user-message-item__steering-tag ${steeringTag.className}`}>
+              {steeringTag.label}
+            </div>
+          )}
           <div className="user-message-item__actions">
             <button
               className={`user-message-item__copy-btn ${copied ? 'copied' : ''}`}
@@ -230,7 +247,7 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
                   <ArrowDownToLine size={14} />
                 </button>
               </Tooltip>
-            ) : allowUserMessageRollback ? (
+            ) : allowUserMessageRollback && !steeringStatus ? (
               <Tooltip content={canRollback ? t('message.rollbackTo', { index: turnIndex + 1 }) : t('message.cannotRollback')}>
                 <button
                   className="user-message-item__rollback-btn"

--- a/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.tsx
@@ -34,7 +34,13 @@ export const VirtualItemRenderer = React.memo<VirtualItemRendererProps>(
           return <UserMessageItem message={item.data} turnId={item.turnId} />;
 
         case 'user-steering-message':
-          return <UserMessageItem message={item.data} turnId={item.turnId} />;
+          return (
+            <UserMessageItem
+              message={item.data}
+              turnId={item.turnId}
+              steeringStatus={item.steeringStatus}
+            />
+          );
         
         case 'model-round':
           return (

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
@@ -211,6 +211,7 @@ describe('sessionToVirtualItems explore grouping', () => {
       },
       turnId: 'turn-1',
       steeringId: 'steer-1',
+      steeringStatus: 'pending',
     });
   });
 });

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
@@ -39,7 +39,13 @@ export interface ExploreGroupData {
  */
 export type VirtualItem =
   | { type: 'user-message'; data: DialogTurn['userMessage']; turnId: string }
-  | { type: 'user-steering-message'; data: NonNullable<DialogTurn['userMessage']>; turnId: string; steeringId: string }
+  | {
+      type: 'user-steering-message';
+      data: NonNullable<DialogTurn['userMessage']>;
+      turnId: string;
+      steeringId: string;
+      steeringStatus: FlowUserSteeringItem['status'];
+    }
   | { type: 'model-round'; data: ModelRound; turnId: string; isLastRound: boolean }
   | { type: 'explore-group'; data: ExploreGroupData; turnId: string }
   | { type: 'image-analyzing'; turnId: string };
@@ -325,6 +331,7 @@ export function sessionToVirtualItems(session: Session | null): VirtualItem[] {
         data: steeringItemToUserMessage(entry.item),
         turnId: turn.id,
         steeringId: entry.item.steeringId,
+        steeringStatus: entry.item.status,
       });
     });
 

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1482,7 +1482,7 @@
   "steering": {
     "title": "Steer",
     "injectedAt": "Injected before round {{round}}",
-    "statusPending": "Will inject after current step",
-    "statusInjected": "Injected at round {{round}}"
+    "statusPending": "Waiting to trigger",
+    "statusInjected": "Triggered"
   }
 }

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1483,7 +1483,7 @@
   "steering": {
     "title": "立即引导",
     "injectedAt": "已在第 {{round}} 轮前插入",
-    "statusPending": "当前操作完成后注入",
-    "statusInjected": "已在第 {{round}} 轮注入"
+    "statusPending": "等待触发",
+    "statusInjected": "已触发"
   }
 }

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1483,7 +1483,7 @@
   "steering": {
     "title": "立即引導",
     "injectedAt": "已在第 {{round}} 輪前插入",
-    "statusPending": "當前操作完成後注入",
-    "statusInjected": "已在第 {{round}} 輪注入"
+    "statusPending": "等待觸發",
+    "statusInjected": "已觸發"
   }
 }


### PR DESCRIPTION
## Summary
Refactors tool-call accumulation and streaming parsers so malformed tool-argument SSE deltas fail cleanly instead of corrupting execution.

## Changes
- **ai-adapters**: tighten Responses/OpenAI stream handling and `tool_call_accumulator` behavior for edge-case deltas.
- **core**: stream processor / pipeline / executor tweaks; new SSE fixtures and integration tests (`stream_processor_tool_arguments`, Anthropic/OpenAI processor tests).
- **web-ui**: flow chat user message rendering and `modernFlowChatStore`; locale strings; component test.

## Verification
- `cargo check --workspace`
- `cargo test -p bitfun-ai-adapters`
- `cargo test -p bitfun-core stream_processor`
- `cargo test -p bitfun-core --test stream_processor_tool_arguments`
- `cargo test -p bitfun-core --test stream_processor_anthropic`
- `cargo test -p bitfun-core --test stream_processor_openai`
- `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run`