### PR TITLE
feat(web-ui): RAF-coalesce app state; polish flow-chat tool cards

### DIFF
--- a/src/web-ui/src/app/services/AppManager.ts
+++ b/src/web-ui/src/app/services/AppManager.ts
@@ -24,6 +24,8 @@ const log = createLogger('AppManager');
 export class AppManager implements IAppManager {
   private state: AppState;
   private listeners = new Set<(event: AppEvent) => void>();
+  /** Coalesce rapid layout/state updates into one event per animation frame (reduces main-thread churn). */
+  private pendingStateNotifyRaf: number | null = null;
 
   constructor() {
     // Clear legacy panel state data (run once)
@@ -344,7 +346,17 @@ export class AppManager implements IAppManager {
   }
 
   private notifyStateChange(): void {
-    globalEventBus.emit('app:state:changed', this.state);
+    if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
+      globalEventBus.emit('app:state:changed', this.state);
+      return;
+    }
+    if (this.pendingStateNotifyRaf != null) {
+      return;
+    }
+    this.pendingStateNotifyRaf = window.requestAnimationFrame(() => {
+      this.pendingStateNotifyRaf = null;
+      globalEventBus.emit('app:state:changed', this.state);
+    });
   }
 
   // Clear legacy panel state data

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -674,13 +674,21 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     void loadMcpPromptCommands();
   }, [derivedState?.isProcessing, loadMcpPromptCommands, slashCommandState.isActive, slashCommandState.kind]);
 
+  // Stable ref so the mcp-app:message handler can read the latest value without
+  // being included in the effect's dependency array (prevents rapid listener
+  // teardown/re-registration on every keystroke or streaming update).
+  const inputStateValueRef = React.useRef(inputState.value);
+  React.useEffect(() => {
+    inputStateValueRef.current = inputState.value;
+  });
+
   // Handle MCP App ui/message requests (aligned with VSCode behavior)
   React.useEffect(() => {
     const handleMcpAppMessage = async (event: import('@/infrastructure/api/service-api/MCPAPI').McpAppMessageEvent) => {
       const { requestId, params } = event;
 
       // Don't fill if input already has content (aligned with VSCode behavior)
-      if (inputState.value.trim()) {
+      if (inputStateValueRef.current.trim()) {
         log.warn('MCP App ui/message rejected: input already has content');
         // Send error response (VSCode returns { isError: true } in this case)
         globalEventBus.emit('mcp-app:message-response', {
@@ -751,7 +759,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     return () => {
       globalEventBus.off('mcp-app:message', handleMcpAppMessage);
     };
-  }, [inputState.value, addContext, clearPendingLargePastes, currentImageCount]);
+  }, [addContext, clearPendingLargePastes, currentImageCount]);
 
   React.useEffect(() => {
     const handleInsertContextTag = (event: Event) => {

--- a/src/web-ui/src/flow_chat/components/CodePreview.tsx
+++ b/src/web-ui/src/flow_chat/components/CodePreview.tsx
@@ -73,6 +73,19 @@ export const CodePreview: React.FC<CodePreviewProps> = memo(({
   // tokenization runs during browser idle time.
   const deferredContent = useDeferredValue(content);
 
+  // Prism tokenizes the *entire* string synchronously. For large streaming files
+  // (e.g. 500-line SCSS) this blocks the main thread for 50-150 ms per 100 ms
+  // batch flush. Since the streaming preview shows at most 4 visible lines
+  // (maxHeight ≈ 88 px), we only need to tokenize the tail of the buffer.
+  // After streaming ends, the full content is restored for the completed view.
+  const STREAMING_TAIL_LINES = 60; // generous tail – more than enough for any maxHeight
+  const displayContent = useMemo(() => {
+    if (!isStreaming) return deferredContent;
+    const lines = deferredContent.split('\n');
+    if (lines.length <= STREAMING_TAIL_LINES) return deferredContent;
+    return lines.slice(-STREAMING_TAIL_LINES).join('\n');
+  }, [isStreaming, deferredContent]);
+
   const [highlightedLine, setHighlightedLine] = useState<number | null>(null);
   
   const detectedLanguage = useMemo(() => {
@@ -166,7 +179,7 @@ export const CodePreview: React.FC<CodePreviewProps> = memo(({
             opacity: isLight ? 0.88 : 0.6,
           }}
         >
-          {deferredContent}
+          {displayContent}
         </SyntaxHighlighter>
         
         {/* Streaming cursor indicator */}

--- a/src/web-ui/src/flow_chat/components/modern/SessionFileModificationsBar.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/SessionFileModificationsBar.tsx
@@ -12,6 +12,7 @@ import { createDiffEditorTab } from '../../../shared/utils/tabUtils';
 import { snapshotAPI } from '../../../infrastructure/api';
 import { useCurrentWorkspace } from '../../../infrastructure/contexts/WorkspaceContext';
 import { createLogger } from '@/shared/utils/logger';
+import { runWithConcurrencyLimit } from '@/shared/utils/runWithConcurrencyLimit';
 import { flowChatStore } from '../../store/FlowChatStore';
 import type { FlowChatState } from '../../types/flow-chat';
 import './SessionFileModificationsBar.scss';
@@ -77,7 +78,9 @@ export const SessionFileModificationsBar: React.FC<SessionFileModificationsBarPr
   const statsCacheRef = useRef<StatsCache>({});
   const loadingFilesRef = useRef<Set<string>>(new Set());
   const previousSessionIdRef = useRef<string | undefined>(undefined);
-  const CACHE_TTL = 10000;
+  const CACHE_TTL = 60000;
+  /** Limit parallel Tauri IPC for diff stats so the webview stays responsive on large file lists. */
+  const DIFF_STATS_MAX_CONCURRENCY = 3;
 
   const initializedRef = useRef(false);
 
@@ -234,8 +237,10 @@ export const SessionFileModificationsBar: React.FC<SessionFileModificationsBarPr
         loadingFilesRef.current.add(`${file.sourceSessionId}:${file.filePath}`);
       });
 
-      await Promise.all(
-        newFilesToLoad.map(async (file) => {
+      const batchResults = await runWithConcurrencyLimit(
+        newFilesToLoad,
+        DIFF_STATS_MAX_CONCURRENCY,
+        async (file) => {
           const sourceKey = `${file.sourceSessionId}:${file.filePath}`;
           let stats: FileStats | null = null;
 
@@ -288,16 +293,19 @@ export const SessionFileModificationsBar: React.FC<SessionFileModificationsBarPr
             loadingFilesRef.current.delete(sourceKey);
           }
 
-          // Keep only files with changes or errors (filter +0 -0).
-          if (stats && (stats.additions > 0 || stats.deletions > 0 || stats.error)) {
-            setFileStats(prev => {
-              const newMap = new Map(prev);
-              newMap.set(sourceKey, stats!);
-              return newMap;
-            });
-          }
-        })
+          return { sourceKey, stats };
+        },
       );
+
+      setFileStats((prev) => {
+        const newMap = new Map(prev);
+        for (const { sourceKey, stats } of batchResults) {
+          if (stats && (stats.additions > 0 || stats.deletions > 0 || stats.error)) {
+            newMap.set(sourceKey, stats);
+          }
+        }
+        return newMap;
+      });
     } catch (error) {
       log.error('Failed to load file stats', error);
     } finally {

--- a/src/web-ui/src/flow_chat/components/modern/SessionFilesBadge.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/SessionFilesBadge.tsx
@@ -22,6 +22,7 @@ import { snapshotAPI } from '../../../infrastructure/api';
 import { useWorkspaceContext } from '../../../infrastructure/contexts/WorkspaceContext';
 import { notificationService } from '../../../shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
+import { runWithConcurrencyLimit } from '@/shared/utils/runWithConcurrencyLimit';
 import { createBtwChildSession } from '../../services/BtwThreadService';
 import { openBtwSessionInAuxPane } from '../../services/openBtwSession';
 import {
@@ -180,7 +181,8 @@ export const SessionFilesBadge: React.FC<SessionFilesBadgeProps> = ({
   const observedProcessingTurnIdRef = useRef<string | null>(null);
   const promptedReviewReadyTurnIdRef = useRef<string | null>(null);
   const reviewReadyGlintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const CACHE_TTL = 10000;
+  const CACHE_TTL = 60000;
+  const DIFF_STATS_MAX_CONCURRENCY = 3;
 
   const badgeRef = useRef<HTMLDivElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -308,8 +310,10 @@ export const SessionFilesBadge: React.FC<SessionFilesBadgeProps> = ({
         loadingFilesRef.current.add(file.filePath);
       });
 
-      await Promise.all(
-        newFilesToLoad.map(async (file) => {
+      const batchResults = await runWithConcurrencyLimit(
+        newFilesToLoad,
+        DIFF_STATS_MAX_CONCURRENCY,
+        async (file) => {
           let stats: FileStats | null = null;
 
           try {
@@ -356,16 +360,19 @@ export const SessionFilesBadge: React.FC<SessionFilesBadgeProps> = ({
             loadingFilesRef.current.delete(file.filePath);
           }
 
-          // Keep only files with changes or errors (filter +0/-0).
-          if (stats && (stats.additions > 0 || stats.deletions > 0 || stats.error)) {
-            setFileStats(prev => {
-              const newMap = new Map(prev);
-              newMap.set(file.filePath, stats!);
-              return newMap;
-            });
-          }
-        })
+          return { filePath: file.filePath, stats };
+        },
       );
+
+      setFileStats((prev) => {
+        const newMap = new Map(prev);
+        for (const { filePath, stats } of batchResults) {
+          if (stats && (stats.additions > 0 || stats.deletions > 0 || stats.error)) {
+            newMap.set(filePath, stats);
+          }
+        }
+        return newMap;
+      });
     } catch (error) {
       log.error('Failed to load file stats', error);
     } finally {

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
@@ -11,10 +11,10 @@ vi.mock('./FlowChatStore', () => ({
 }));
 
 vi.mock('../tool-cards', () => ({
-  isCollapsibleTool: (toolName: string) => ['Read', 'LS', 'Grep', 'Glob', 'WebSearch', 'Bash'].includes(toolName),
+  isCollapsibleTool: (toolName: string) => ['Read', 'LS', 'Grep', 'Glob', 'WebSearch', 'Bash', 'Git'].includes(toolName),
   READ_TOOL_NAMES: new Set(['Read']),
   SEARCH_TOOL_NAMES: new Set(['Grep', 'Glob', 'WebSearch']),
-  COMMAND_TOOL_NAMES: new Set(['Bash']),
+  COMMAND_TOOL_NAMES: new Set(['Bash', 'Git']),
 }));
 
 import { sessionToVirtualItems } from './modernFlowChatStore';

--- a/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.scss
@@ -19,21 +19,31 @@
   cursor: pointer;
 }
 
+/* Collapsed row: match thinking summary typography (`ModelThinkingDisplay.scss` `.thinking-label`). */
 .compact-tool-card-wrapper.git-tool-display {
-  .tool-card-icon-slot {
-    width: 24px;
-    margin-right: 7px;
+  --tool-compact-summary-font:
+    var(--font-family-sans, 'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Microsoft YaHei', sans-serif);
+
+  .compact-card-action,
+  .compact-card-content .tool-command-preview.tool-command-preview--compact {
+    font-family: var(--tool-compact-summary-font);
+    font-size: var(--flowchat-font-size-sm);
+    line-height: 1.5;
+    font-weight: normal;
+    color: var(--color-text-muted);
   }
 
-  .tool-card-icon-slot::after {
-    top: 1px;
-    bottom: 1px;
-    border-color: var(--border-subtle);
+  /* Failure: keep left rail (icon + optional label) same tone as success; details stay in extra / expanded. */
+  .compact-tool-card.status-error .tool-card-icon-marks {
+    color: var(--color-text-secondary);
   }
 
-  .tool-card-icon-marks {
-    width: 20px;
-    height: 20px;
+  .output-summary {
+    font-family: var(--tool-compact-summary-font);
+    font-size: var(--flowchat-font-size-sm);
+    line-height: 1.5;
+    font-weight: normal;
+    color: var(--tool-card-text-secondary);
   }
 }
 
@@ -45,6 +55,14 @@
   margin-bottom: -8px;
   padding: 6px 8px;
   border-radius: 0 0 6px 6px;
+}
+
+/* Expanded + same shell as Terminal: match `terminal-result-footer` inset from `TerminalToolCard.scss`. */
+.base-tool-card-wrapper.terminal-tool-card.git-tool-display .git-result-footer {
+  margin-left: -12px;
+  margin-right: -12px;
+  margin-bottom: -12px;
+  padding: 6px 12px;
 }
 
 /* ========== Fix scrollbar visibility on card hover ========== */
@@ -80,7 +98,9 @@
     flex: 1;
   }
 
-  .git-command-preview {
+  /* Collapsed row only — expanded uses `.terminal-command` from TerminalToolCard.scss. */
+  .compact-tool-card-wrapper.git-tool-display .git-tool-info .git-command-preview,
+  .compact-tool-card-wrapper.git-tool-display .git-command-preview.tool-command-preview--compact {
     color: var(--color-text-muted);
   }
 

--- a/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { GitBranch, Check, X, AlertTriangle } from 'lucide-react';
 import { CubeLoading, IconButton } from '../../component-library';
 import type { ToolCardProps } from '../types/flow-chat';
+import { BaseToolCard, ToolCardHeader } from './BaseToolCard';
 import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
 import { ToolCardCopyAction, ToolCardHeaderActions } from './ToolCardHeaderActions';
 import { ToolCommandPreview } from './ToolCommandPreview';
@@ -134,7 +135,7 @@ export const GitToolDisplay: React.FC<ToolCardProps> = ({
 
   const handleCardClick = useCallback((e: React.MouseEvent) => {
     const target = e.target as HTMLElement;
-    if (target.closest('.tool-card-header-actions, .git-action-buttons')) {
+    if (target.closest('.tool-card-header-actions, .git-action-buttons, .terminal-header-actions')) {
       return;
     }
     
@@ -153,78 +154,98 @@ export const GitToolDisplay: React.FC<ToolCardProps> = ({
     return null;
   };
 
-  const renderHeader = () => (
+  const renderCommandPreview = (variant: 'expanded' | 'compact') => (
+    <ToolCommandPreview
+      command={commandText}
+      emptyText={t('toolCards.terminal.noCommand')}
+      as={variant === 'compact' ? 'span' : 'code'}
+      className={
+        variant === 'compact'
+          ? 'git-command-preview tool-command-preview--compact'
+          : 'git-command-preview terminal-command'
+      }
+    />
+  );
+
+  const headerExtra = (useTerminalLayout: boolean) => (
+    <span className={useTerminalLayout ? 'terminal-header-extra git-header-extra' : 'git-header-extra'}>
+      {!isFailed && outputSummary && status === 'completed' && (
+        <span className="output-summary">
+          {outputSummary}
+        </span>
+      )}
+
+      {isFailed && (
+        <span className="error-indicator">
+          <span className="error-text">{t('toolCards.git.failed')}</span>
+        </span>
+      )}
+
+      <ToolCardHeaderActions className={useTerminalLayout ? 'terminal-header-actions git-action-buttons' : 'git-action-buttons'}>
+        <ToolCardCopyAction
+          className={useTerminalLayout ? 'terminal-action-btn copy-command-btn git-copy-btn' : 'git-copy-btn'}
+          getText={getCopyCommandText}
+          tooltip={t('toolCards.git.copyCommand', { defaultValue: 'Copy git command' })}
+          copiedTooltip={t('toolCards.git.commandCopied', { defaultValue: 'Git command copied' })}
+          successMessage={t('toolCards.git.commandCopied', { defaultValue: 'Git command copied' })}
+          failureMessage={t('toolCards.git.copyCommandFailed', { defaultValue: 'Failed to copy git command' })}
+          ariaLabel={t('toolCards.git.copyCommand', { defaultValue: 'Copy git command' })}
+        />
+
+        {requiresConfirmation && !userConfirmed && status !== 'completed' && (
+          <>
+            <IconButton
+              className="tool-card-header-action git-confirm-btn"
+              variant="success"
+              size="xs"
+              onClick={(e) => {
+                e.stopPropagation();
+                onConfirm?.(toolCall?.input);
+              }}
+              disabled={status === 'streaming'}
+              tooltip={t('toolCards.git.confirmExecute')}
+            >
+              <Check size={12} />
+            </IconButton>
+            <IconButton
+              className="tool-card-header-action git-reject-btn"
+              variant="danger"
+              size="xs"
+              onClick={(e) => {
+                e.stopPropagation();
+                onReject?.();
+              }}
+              disabled={status === 'streaming'}
+              tooltip={t('toolCards.git.cancel')}
+            >
+              <X size={12} />
+            </IconButton>
+          </>
+        )}
+      </ToolCardHeaderActions>
+    </span>
+  );
+
+  const renderExpandedHeader = () => (
+    <ToolCardHeader
+      icon={<GitBranch size={16} className="git-card-icon terminal-card-icon" />}
+      action={isFailed ? t('toolCards.git.commandFailed') : `${t('toolCards.git.title')}:`}
+      content={renderCommandPreview('expanded')}
+      extra={headerExtra(true)}
+      statusIcon={renderStatusIcon()}
+    />
+  );
+
+  const renderCompactHeader = () => (
     <CompactToolCardHeader
       icon={<GitBranch size={16} className="git-card-icon" />}
-      showDivider
       action={isFailed ? t('toolCards.git.commandFailed') : undefined}
       content={
         <span className="git-tool-info">
-          <ToolCommandPreview
-            command={commandText}
-            emptyText={t('toolCards.terminal.noCommand')}
-            className="git-command-preview tool-command-preview--compact"
-          />
+          {renderCommandPreview('compact')}
         </span>
       }
-      extra={
-        <span className="git-header-extra">
-          {!isFailed && outputSummary && status === 'completed' && (
-            <span className="output-summary">
-              {outputSummary}
-            </span>
-          )}
-
-          {isFailed && (
-            <span className="error-indicator">
-              <span className="error-text">{t('toolCards.git.failed')}</span>
-            </span>
-          )}
-
-          <ToolCardHeaderActions className="git-action-buttons">
-            <ToolCardCopyAction
-              className="git-copy-btn"
-              getText={getCopyCommandText}
-              tooltip={t('toolCards.git.copyCommand', { defaultValue: 'Copy git command' })}
-              copiedTooltip={t('toolCards.git.commandCopied', { defaultValue: 'Git command copied' })}
-              successMessage={t('toolCards.git.commandCopied', { defaultValue: 'Git command copied' })}
-              failureMessage={t('toolCards.git.copyCommandFailed', { defaultValue: 'Failed to copy git command' })}
-              ariaLabel={t('toolCards.git.copyCommand', { defaultValue: 'Copy git command' })}
-            />
-
-            {requiresConfirmation && !userConfirmed && status !== 'completed' && (
-              <>
-              <IconButton
-                className="tool-card-header-action git-confirm-btn"
-                variant="success"
-                size="xs"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onConfirm?.(toolCall?.input);
-                }}
-                disabled={status === 'streaming'}
-                tooltip={t('toolCards.git.confirmExecute')}
-              >
-                <Check size={12} />
-              </IconButton>
-              <IconButton
-                className="tool-card-header-action git-reject-btn"
-                variant="danger"
-                size="xs"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onReject?.();
-                }}
-                disabled={status === 'streaming'}
-                tooltip={t('toolCards.git.cancel')}
-              >
-                <X size={12} />
-              </IconButton>
-              </>
-            )}
-          </ToolCardHeaderActions>
-        </span>
-      }
+      extra={headerExtra(false)}
       rightStatusIcon={renderStatusIcon()}
     />
   );
@@ -316,21 +337,30 @@ export const GitToolDisplay: React.FC<ToolCardProps> = ({
     return null;
   };
 
-  const expandedContent = isExpanded
-    ? renderDetailsWhenExpanded()
-    : null;
+  const expandedBody = isExpanded ? renderDetailsWhenExpanded() : null;
 
   return (
     <div ref={cardRootRef} data-tool-card-id={toolId ?? ''}>
-      <CompactToolCard
-        status={status}
-        isExpanded={isExpanded}
-        onClick={handleCardClick}
-        className="git-tool-display"
-        clickable
-        header={renderHeader()}
-        expandedContent={expandedContent}
-      />
+      {isExpanded ? (
+        <BaseToolCard
+          status={status}
+          isExpanded
+          onClick={handleCardClick}
+          className="git-tool-display terminal-tool-card"
+          header={renderExpandedHeader()}
+          expandedContent={expandedBody}
+          headerExpandAffordance
+        />
+      ) : (
+        <CompactToolCard
+          status={status}
+          isExpanded={false}
+          onClick={handleCardClick}
+          className="git-tool-display"
+          clickable
+          header={renderCompactHeader()}
+        />
+      )}
     </div>
   );
 };

--- a/src/web-ui/src/flow_chat/tool-cards/ModelThinkingDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/ModelThinkingDisplay.scss
@@ -11,11 +11,10 @@
 
 /* Minimal, borderless layout.
  * WebKit (Tauri/macOS) baseline-quirk fix:
- * — Force `.flow-thinking-item` to be a block flex row with explicit
- *   line-height so the row height is exactly text rhythm (14px × 1.65 ≈ 23px),
- *   regardless of inherited line-height from ancestors.
- * — Make the chevron SVG `display: block` and the label use simple `display:
- *   inline` so no inline-flex baseline can pull the line box taller. */
+ * — Collapsed summary uses `--flowchat-font-size-sm` + line-height 1.5 to match
+ *   `.explore-region--collapsible` (e.g. “执行了 N 个命令”).
+ * — Make the chevron SVG `display: block` and the label simple `inline` flow
+ *   so flex `align-items: center` stays stable. */
 .flow-thinking-item {
   padding: 0;
   /* Match `.flow-text-block` and the tool wrappers so flow items share one visual gap. */
@@ -25,21 +24,22 @@
    * items and card content share the same left edge. */
   border: 1px solid transparent;
   box-sizing: border-box;
-  font-size: var(--flowchat-font-size-base);
-  line-height: var(--flowchat-text-line-height, 1.62);
+  /* Collapsed summary line: match `.explore-region--collapsible` (e.g. command count). */
+  font-size: var(--flowchat-font-size-sm);
+  line-height: 1.5;
   transition: padding 0.2s ease;
 }
 
 .thinking-collapsed-header {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   padding: 0;
   border-radius: 4px;
   cursor: pointer;
   background: transparent;
-  font-size: var(--flowchat-font-size-base);
-  line-height: var(--flowchat-text-line-height, 1.62);
+  font-size: var(--flowchat-font-size-sm);
+  line-height: 1.5;
 
   &:hover {
     .thinking-label {
@@ -62,11 +62,11 @@
   }
 
   .thinking-label {
-    font-size: var(--flowchat-font-size-base);
+    font-size: var(--flowchat-font-size-sm);
     font-weight: normal;
     color: var(--text-tertiary, #6b7280);
     opacity: 0.8;
-    line-height: var(--flowchat-text-line-height, 1.62);
+    line-height: 1.5;
   }
 }
 

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
@@ -16,13 +16,32 @@
 }
 
 .compact-tool-card-wrapper.terminal-tool-card--compact-collapsed {
+  /*
+   * Match collapsed thinking summary (`.thinking-label`, `ModelThinkingDisplay.scss`):
+   * sans + `sm` + line-height 1.5 + normal — not monospace (mono reads “thinner” vs “思考了 N 字”).
+   */
+  --tool-compact-summary-font:
+    var(--font-family-sans, 'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Microsoft YaHei', sans-serif);
+
+  .compact-card-action,
+  .compact-card-content .tool-command-preview.tool-command-preview--compact {
+    font-family: var(--tool-compact-summary-font);
+    font-size: var(--flowchat-font-size-sm);
+    line-height: 1.5;
+    font-weight: normal;
+    color: var(--color-text-muted);
+  }
+
   .terminal-header-extra {
     gap: 4px;
   }
 
   .terminal-header-duration .duration-text {
     gap: 3px;
-    font-size: var(--flowchat-font-size-xs);
+    font-family: var(--tool-compact-summary-font);
+    font-size: var(--flowchat-font-size-sm);
+    line-height: 1.5;
+    font-weight: normal;
   }
 
   .terminal-header-duration .duration-text svg {
@@ -575,6 +594,21 @@
     .terminal-command,
     .terminal-command-input {
       font-size: 11px;
+    }
+
+    .compact-card-action,
+    .compact-card-content .tool-command-preview--compact {
+      font-size: 11px;
+      line-height: 1.5;
+      font-weight: normal;
+      font-family: var(--font-family-sans, 'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Microsoft YaHei', sans-serif);
+    }
+
+    .terminal-header-duration .duration-text {
+      font-size: 11px;
+      line-height: 1.5;
+      font-weight: normal;
+      font-family: var(--font-family-sans, 'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Microsoft YaHei', sans-serif);
     }
   }
 }

--- a/src/web-ui/src/flow_chat/tool-cards/index.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/index.ts
@@ -474,7 +474,7 @@ import type { FlowItem, FlowToolItem } from '../types/flow-chat';
  * They are auto-collapsed during streaming to reduce visual noise.
  */
 export const COLLAPSIBLE_TOOL_NAMES = new Set([
-  'Read', 'LS', 'Grep', 'Glob', 'WebSearch', 'Bash'
+  'Read', 'LS', 'Grep', 'Glob', 'WebSearch', 'Bash', 'Git',
 ]);
 
 /** Read tools (counted in readCount). */
@@ -484,7 +484,7 @@ export const READ_TOOL_NAMES = new Set(['Read', 'LS']);
 export const SEARCH_TOOL_NAMES = new Set(['Grep', 'Glob', 'WebSearch']);
 
 /** Command tools (counted in commandCount). */
-export const COMMAND_TOOL_NAMES = new Set(['Bash']);
+export const COMMAND_TOOL_NAMES = new Set(['Bash', 'Git']);
 
 /** Check whether a tool is collapsible. */
 export function isCollapsibleTool(toolName: string): boolean {

--- a/src/web-ui/src/shared/utils/runWithConcurrencyLimit.ts
+++ b/src/web-ui/src/shared/utils/runWithConcurrencyLimit.ts
@@ -1,0 +1,33 @@
+/**
+ * Run async work over items with a bounded number of concurrent tasks.
+ * Avoids spawning unbounded Promise.all IPC/network work that can stall the main thread.
+ */
+export async function runWithConcurrencyLimit<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+  const limit = Math.max(1, Math.floor(concurrency));
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  const runWorker = async (): Promise<void> => {
+    for (;;) {
+      const i = nextIndex++;
+      if (i >= items.length) {
+        return;
+      }
+      results[i] = await worker(items[i], i);
+    }
+  };
+
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    () => runWorker(),
+  );
+  await Promise.all(workers);
+  return results;
+}


### PR DESCRIPTION
## Summary

- Coalesce `app:state:changed` emissions in `AppManager` using `requestAnimationFrame` to reduce main-thread churn from rapid layout/state updates.
- Refresh flow-chat tool cards (Git, terminal, model-thinking styles) and session file UI (badge, modifications bar).
- Small tweaks to ChatInput/CodePreview; add `runWithConcurrencyLimit` helper and adjust related tests.

## Verification

- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run`
