### PR TITLE
Fix companion activity ordering and permission prompts

### DIFF
--- a/src/apps/desktop/src/api/computer_use_api.rs
+++ b/src/apps/desktop/src/api/computer_use_api.rs
@@ -50,12 +50,7 @@ pub async fn computer_use_get_status(
 #[tauri::command]
 pub async fn computer_use_request_permissions() -> Result<(), String> {
     let host = DesktopComputerUseHost::new();
-    host.request_accessibility_permission()
-        .await
-        .map_err(|e| e.to_string())?;
-    host.request_screen_capture_permission()
-        .await
-        .map_err(|e| e.to_string())?;
+    host.prompt_for_missing_permissions();
     Ok(())
 }
 

--- a/src/apps/desktop/src/computer_use/desktop_host.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host.rs
@@ -809,11 +809,13 @@ impl Default for DesktopComputerUseHost {
 
 impl DesktopComputerUseHost {
     pub fn new() -> Self {
-        let host = Self {
+        Self {
             state: Mutex::new(ComputerUseSessionMutableState::new()),
-        };
-        host.run_background_input_self_check();
-        host
+        }
+    }
+
+    pub fn prompt_for_missing_permissions(&self) {
+        self.run_background_input_self_check();
     }
 
     fn next_screenshot_id() -> String {

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
@@ -34,6 +34,8 @@ export const AgentCompanionDesktopPet: React.FC = () => {
   const [petFrameSize, setPetFrameSize] = useState<{ width: number; height: number } | null>(null);
   const dockRef = useRef<HTMLDivElement>(null);
   const bubblesRef = useRef<HTMLDivElement>(null);
+  const lastActivitySequenceRef = useRef(0);
+  const lastActivityEmittedAtRef = useRef(0);
   const displayTasks = [...tasks].reverse();
   const activePetSize = pet && petFrameSize
     ? petFrameSize
@@ -65,6 +67,16 @@ export const AgentCompanionDesktopPet: React.FC = () => {
 
     let removeActivityListener: (() => void) | null = null;
     void listen<AgentCompanionActivityPayload>('agent-companion://activity-updated', event => {
+      const emittedAt = event.payload.emittedAt ?? 0;
+      const sequence = event.payload.sequence ?? 0;
+      if (
+        emittedAt < lastActivityEmittedAtRef.current
+        || (emittedAt === lastActivityEmittedAtRef.current && sequence <= lastActivitySequenceRef.current)
+      ) {
+        return;
+      }
+      lastActivityEmittedAtRef.current = emittedAt;
+      lastActivitySequenceRef.current = sequence;
       setMood(event.payload.mood);
       setTasks(event.payload.tasks);
     }).then(unlisten => {

--- a/src/web-ui/src/flow_chat/services/AgentCompanionActivityBridge.ts
+++ b/src/web-ui/src/flow_chat/services/AgentCompanionActivityBridge.ts
@@ -3,15 +3,22 @@ import { createLogger } from '@/shared/utils/logger';
 import type { AgentCompanionActivityPayload } from '../utils/agentCompanionActivity';
 
 const log = createLogger('AgentCompanionActivityBridge');
+let activitySequence = 0;
 
 export async function emitAgentCompanionActivity(
   activity: AgentCompanionActivityPayload,
 ): Promise<void> {
   if (!isTauriRuntime()) return;
 
+  const sequencedActivity: AgentCompanionActivityPayload = {
+    ...activity,
+    sequence: activitySequence += 1,
+    emittedAt: Date.now(),
+  };
+
   try {
     const { emit } = await import('@tauri-apps/api/event');
-    await emit('agent-companion://activity-updated', activity);
+    await emit('agent-companion://activity-updated', sequencedActivity);
   } catch (error) {
     log.warn('Failed to emit Agent companion activity update', error);
   }

--- a/src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts
+++ b/src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts
@@ -26,6 +26,8 @@ export interface AgentCompanionTaskStatus {
 export interface AgentCompanionActivityPayload {
   mood: ChatInputPetMood;
   tasks: AgentCompanionTaskStatus[];
+  sequence?: number;
+  emittedAt?: number;
 }
 
 const EMPTY_ACTIVITY: AgentCompanionActivityPayload = {


### PR DESCRIPTION
## Summary
- Add sequencing metadata to Agent Companion activity events and ignore stale updates in the desktop pet UI.
- Avoid running the computer-use background input self-check when constructing the desktop host.
- Trigger missing permission prompts explicitly from the request-permissions command.

## Verification
- pnpm run lint:web
- pnpm run type-check:web
- cargo check -p bitfun-desktop

## Collaborator
- @openBitFun

Generated with BitFun

Co-Authored-By: BitFun