### PR TITLE
fix(ai): preserve tool argument replay stability to avoid prompt caching misses

### DIFF
--- a/src/apps/desktop/src/api/skill_api.rs
+++ b/src/apps/desktop/src/api/skill_api.rs
@@ -22,8 +22,8 @@ use bitfun_core::agentic::tools::implementations::skills::mode_overrides::{
     set_mode_skill_disabled_in_document, set_user_mode_skill_state,
 };
 use bitfun_core::agentic::tools::implementations::skills::{
-    resolver::resolve_skill_default_enabled_for_mode,
-    ModeSkillInfo, SkillData, SkillInfo, SkillLocation, SkillRegistry,
+    resolver::resolve_skill_default_enabled_for_mode, ModeSkillInfo, SkillData, SkillInfo,
+    SkillLocation, SkillRegistry,
 };
 use bitfun_core::agentic::workspace::RemoteWorkspaceFs;
 use bitfun_core::infrastructure::get_path_manager_arc;
@@ -208,7 +208,9 @@ async fn get_mode_skill_infos_for_workspace_input(
         // Mode-scoped built-in and user-level skills should still be available even
         // when no project workspace is open. In that case there are simply no
         // project-level overrides to apply.
-        Ok(registry.get_mode_skill_infos_for_workspace(None, mode_id).await)
+        Ok(registry
+            .get_mode_skill_infos_for_workspace(None, mode_id)
+            .await)
     }
 }
 

--- a/src/crates/ai-adapters/src/client/response_aggregator.rs
+++ b/src/crates/ai-adapters/src/client/response_aggregator.rs
@@ -67,11 +67,12 @@ pub(crate) async fn aggregate_stream_response(
                                 finalized.raw_arguments.len()
                             );
                         } else {
-                            let arguments = finalized.arguments_as_object_map();
                             tool_calls.push(ToolCall {
                                 id: finalized.tool_id,
                                 name: finalized.tool_name,
-                                arguments,
+                                arguments: finalized.arguments,
+                                raw_arguments: (!finalized.raw_arguments.is_empty())
+                                    .then_some(finalized.raw_arguments),
                             });
                         }
                     }
@@ -95,11 +96,12 @@ pub(crate) async fn aggregate_stream_response(
                                 finalized.raw_arguments.len()
                             );
                         } else {
-                            let arguments = finalized.arguments_as_object_map();
                             tool_calls.push(ToolCall {
                                 id: finalized.tool_id,
                                 name: finalized.tool_name,
-                                arguments,
+                                arguments: finalized.arguments,
+                                raw_arguments: (!finalized.raw_arguments.is_empty())
+                                    .then_some(finalized.raw_arguments),
                             });
                         }
                     }
@@ -135,11 +137,12 @@ pub(crate) async fn aggregate_stream_response(
                 finalized.raw_arguments.len()
             );
         } else {
-            let arguments = finalized.arguments_as_object_map();
             tool_calls.push(ToolCall {
                 id: finalized.tool_id,
                 name: finalized.tool_name,
-                arguments,
+                arguments: finalized.arguments,
+                raw_arguments: (!finalized.raw_arguments.is_empty())
+                    .then_some(finalized.raw_arguments),
             });
         }
     }

--- a/src/crates/ai-adapters/src/providers/gemini/message_converter.rs
+++ b/src/crates/ai-adapters/src/providers/gemini/message_converter.rs
@@ -652,13 +652,9 @@ mod tests {
     use super::GeminiMessageConverter;
     use crate::types::{Message, ToolCall, ToolDefinition};
     use serde_json::json;
-    use std::collections::HashMap;
 
     #[test]
     fn converts_messages_to_gemini_format() {
-        let mut args = HashMap::new();
-        args.insert("city".to_string(), json!("Beijing"));
-
         let messages = vec![
             Message::system("You are helpful".to_string()),
             Message::user("Hello".to_string()),
@@ -670,7 +666,8 @@ mod tests {
                 tool_calls: Some(vec![ToolCall {
                     id: "call_1".to_string(),
                     name: "get_weather".to_string(),
-                    arguments: args.clone(),
+                    arguments: json!({"city": "Beijing"}),
+                    raw_arguments: None,
                 }]),
                 tool_call_id: None,
                 name: None,
@@ -714,9 +711,6 @@ mod tests {
 
     #[test]
     fn injects_skip_signature_for_first_synthetic_gemini_3_tool_call() {
-        let mut args = HashMap::new();
-        args.insert("city".to_string(), json!("Paris"));
-
         let messages = vec![Message {
             role: "assistant".to_string(),
             content: None,
@@ -725,7 +719,8 @@ mod tests {
             tool_calls: Some(vec![ToolCall {
                 id: "call_1".to_string(),
                 name: "get_weather".to_string(),
-                arguments: args,
+                arguments: json!({"city": "Paris"}),
+                raw_arguments: None,
             }]),
             tool_call_id: None,
             name: None,

--- a/src/crates/ai-adapters/src/providers/openai/message_converter.rs
+++ b/src/crates/ai-adapters/src/providers/openai/message_converter.rs
@@ -44,8 +44,7 @@ impl OpenAIMessageConverter {
                                 "type": "function_call",
                                 "call_id": tool_call.id,
                                 "name": tool_call.name,
-                                "arguments": serde_json::to_string(&tool_call.arguments)
-                                    .unwrap_or_else(|_| "{}".to_string()),
+                                "arguments": tool_call.serialized_arguments(),
                             }));
                         }
                     }
@@ -324,8 +323,7 @@ impl OpenAIMessageConverter {
                         "type": "function",
                         "function": {
                             "name": tc.name,
-                            "arguments": serde_json::to_string(&tc.arguments)
-                                .unwrap_or_default()
+                            "arguments": tc.serialized_arguments()
                         }
                     })
                 })
@@ -368,20 +366,17 @@ mod tests {
     use super::OpenAIMessageConverter;
     use crate::types::{Message, ToolCall, ToolImageAttachment};
     use serde_json::json;
-    use std::collections::HashMap;
 
     #[test]
     fn converts_messages_to_responses_input() {
-        let mut args = HashMap::new();
-        args.insert("city".to_string(), json!("Beijing"));
-
         let messages = vec![
             Message::system("You are helpful".to_string()),
             Message::user("Hello".to_string()),
             Message::assistant_with_tools(vec![ToolCall {
                 id: "call_1".to_string(),
                 name: "get_weather".to_string(),
-                arguments: args.clone(),
+                arguments: json!({"city": "Beijing"}),
+                raw_arguments: None,
             }]),
             Message {
                 role: "tool".to_string(),
@@ -403,7 +398,44 @@ mod tests {
         assert_eq!(input.len(), 3);
         assert_eq!(input[0]["type"], json!("message"));
         assert_eq!(input[1]["type"], json!("function_call"));
+        assert_eq!(input[1]["arguments"], json!("{\"city\":\"Beijing\"}"));
         assert_eq!(input[2]["type"], json!("function_call_output"));
+    }
+
+    #[test]
+    fn preserves_raw_tool_arguments_for_openai_replay() {
+        let openai =
+            OpenAIMessageConverter::convert_messages(vec![Message::assistant_with_tools(vec![
+                ToolCall {
+                    id: "call_1".to_string(),
+                    name: "get_weather".to_string(),
+                    arguments: json!({"city": "Beijing", "unit": "celsius"}),
+                    raw_arguments: Some("{\"unit\":\"celsius\",\"city\":\"Beijing\"}".to_string()),
+                },
+            ])]);
+
+        assert_eq!(
+            openai[0]["tool_calls"][0]["function"]["arguments"],
+            json!("{\"unit\":\"celsius\",\"city\":\"Beijing\"}")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_stable_serialization_when_raw_arguments_are_invalid() {
+        let openai =
+            OpenAIMessageConverter::convert_messages(vec![Message::assistant_with_tools(vec![
+                ToolCall {
+                    id: "call_1".to_string(),
+                    name: "get_weather".to_string(),
+                    arguments: json!({"city": "Beijing", "unit": "celsius"}),
+                    raw_arguments: Some("{\"city\":\"Beijing\"".to_string()),
+                },
+            ])]);
+
+        assert_eq!(
+            openai[0]["tool_calls"][0]["function"]["arguments"],
+            json!("{\"city\":\"Beijing\",\"unit\":\"celsius\"}")
+        );
     }
 
     #[test]

--- a/src/crates/ai-adapters/src/tool_call_accumulator.rs
+++ b/src/crates/ai-adapters/src/tool_call_accumulator.rs
@@ -1,6 +1,6 @@
 use log::error;
 use serde_json::{json, Value};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolCallBoundary {
@@ -53,15 +53,6 @@ pub struct FinalizedToolCall {
     pub raw_arguments: String,
     pub arguments: Value,
     pub is_error: bool,
-}
-
-impl FinalizedToolCall {
-    pub fn arguments_as_object_map(&self) -> HashMap<String, Value> {
-        match &self.arguments {
-            Value::Object(map) => map.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
-            _ => HashMap::new(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -533,7 +524,7 @@ mod tests {
     }
 
     #[test]
-    fn arguments_as_object_map_returns_hash_map_for_objects() {
+    fn finalized_arguments_preserve_object_fields() {
         let mut pending = PendingToolCall::default();
         pending.start_new("call_1".to_string(), Some("tool_a".to_string()));
         pending.append_arguments("{\"a\":1,\"b\":\"x\"}");
@@ -541,10 +532,9 @@ mod tests {
         let finalized = pending
             .finalize(ToolCallBoundary::EndOfAggregation)
             .expect("finalized tool");
-        let map = finalized.arguments_as_object_map();
 
-        assert_eq!(map.get("a"), Some(&json!(1)));
-        assert_eq!(map.get("b"), Some(&json!("x")));
+        assert_eq!(finalized.arguments["a"], json!(1));
+        assert_eq!(finalized.arguments["b"], json!("x"));
     }
 
     #[test]

--- a/src/crates/ai-adapters/src/types/tool.rs
+++ b/src/crates/ai-adapters/src/types/tool.rs
@@ -1,11 +1,26 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolCall {
     pub id: String,
     pub name: String,
-    pub arguments: HashMap<String, serde_json::Value>,
+    pub arguments: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_arguments: Option<String>,
+}
+
+impl ToolCall {
+    pub fn serialized_arguments(&self) -> String {
+        self.raw_arguments
+            .as_deref()
+            .filter(|raw| serde_json::from_str::<Value>(raw).is_ok())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| {
+                serde_json::to_string(&self.arguments).unwrap_or_else(|_| "{}".to_string())
+            })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/crates/core/src/agentic/core/message.rs
+++ b/src/crates/core/src/agentic/core/message.rs
@@ -243,20 +243,11 @@ impl From<Message> for AIMessage {
                     Some(
                         tool_calls
                             .into_iter()
-                            .map(|tc| {
-                                // Convert serde_json::Value to HashMap
-                                let arguments = if let serde_json::Value::Object(map) = tc.arguments
-                                {
-                                    map.into_iter().collect()
-                                } else {
-                                    std::collections::HashMap::new()
-                                };
-
-                                AIToolCall {
-                                    id: tc.tool_id,
-                                    name: tc.tool_name,
-                                    arguments,
-                                }
+                            .map(|tc| AIToolCall {
+                                id: tc.tool_id,
+                                name: tc.tool_name,
+                                arguments: tc.arguments,
+                                raw_arguments: tc.raw_arguments,
                             })
                             .collect(),
                     )
@@ -525,9 +516,15 @@ impl Message {
 
                 for tool_call in tool_calls {
                     total += TokenCounter::estimate_tokens(&tool_call.tool_name);
-                    if let Ok(json_str) = serde_json::to_string(&tool_call.arguments) {
-                        total += TokenCounter::estimate_tokens(&json_str);
-                    }
+                    let serialized_arguments = tool_call
+                        .raw_arguments
+                        .clone()
+                        .filter(|raw| serde_json::from_str::<serde_json::Value>(raw).is_ok())
+                        .unwrap_or_else(|| {
+                            serde_json::to_string(&tool_call.arguments)
+                                .unwrap_or_else(|_| "{}".to_string())
+                        });
+                    total += TokenCounter::estimate_tokens(&serialized_arguments);
                     total += 10;
                 }
             }
@@ -634,7 +631,7 @@ pub struct ToolCall {
     pub tool_id: String,
     pub tool_name: String,
     pub arguments: serde_json::Value,
-    /// Original streamed argument text, preserved for diagnostics when parsing failed.
+    /// Original provider-emitted argument JSON, preserved for replay stability when available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_arguments: Option<String>,
     /// Record whether tool parameters are valid
@@ -662,17 +659,11 @@ pub struct ToolResult {
 
 impl From<ToolCall> for AIToolCall {
     fn from(tc: ToolCall) -> Self {
-        // Convert serde_json::Value to HashMap
-        let arguments = if let serde_json::Value::Object(map) = &tc.arguments {
-            map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
-        } else {
-            std::collections::HashMap::new()
-        };
-
         Self {
             id: tc.tool_id.clone(),
             name: tc.tool_name.clone(),
-            arguments,
+            arguments: tc.arguments,
+            raw_arguments: tc.raw_arguments,
         }
     }
 }

--- a/src/crates/core/src/agentic/execution/stream_processor.rs
+++ b/src/crates/core/src/agentic/execution/stream_processor.rs
@@ -262,8 +262,7 @@ impl StreamContext {
             tool_id,
             tool_name,
             arguments: finalized.arguments.clone(),
-            raw_arguments: finalized
-                .is_error
+            raw_arguments: (!finalized.raw_arguments.is_empty())
                 .then_some(finalized.raw_arguments.clone()),
             is_error: finalized.is_error,
         });
@@ -988,6 +987,10 @@ mod tests {
         assert_eq!(result.tool_calls[0].tool_id, "call_1");
         assert_eq!(result.tool_calls[0].tool_name, "tool_a");
         assert_eq!(result.tool_calls[0].arguments, json!({"a": 1}));
+        assert_eq!(
+            result.tool_calls[0].raw_arguments.as_deref(),
+            Some("{\"a\":1}")
+        );
         assert!(!result.tool_calls[0].is_error);
         assert_eq!(result.usage.as_ref().map(|u| u.total_token_count), Some(7));
     }
@@ -1143,6 +1146,10 @@ mod tests {
         assert_eq!(result.tool_calls[0].tool_id, "call_1");
         assert_eq!(result.tool_calls[0].tool_name, "tool_a");
         assert_eq!(result.tool_calls[0].arguments, json!({"city": "Beijing"}));
+        assert_eq!(
+            result.tool_calls[0].raw_arguments.as_deref(),
+            Some("{\"city\":\"Beijing\"}")
+        );
         assert!(!result.tool_calls[0].is_error);
     }
 

--- a/src/crates/core/src/agentic/tools/implementations/skills/catalog.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skills/catalog.rs
@@ -197,14 +197,20 @@ mod tests {
         assert_eq!(builtin_skill_group_key("xlsx"), Some("office"));
         assert_eq!(builtin_skill_group_key("find-skills"), Some("meta"));
         assert_eq!(builtin_skill_group_key("writing-skills"), Some("meta"));
-        assert_eq!(builtin_skill_group_key("agent-browser"), Some("computer-use"));
+        assert_eq!(
+            builtin_skill_group_key("agent-browser"),
+            Some("computer-use")
+        );
         assert_eq!(builtin_skill_group_key("gstack-review"), Some("team"));
         assert_eq!(builtin_skill_group("unknown-skill"), None);
     }
 
     #[test]
     fn catalog_covers_all_embedded_builtin_skills() {
-        let known: HashSet<&'static str> = BUILTIN_SKILL_SPECS.iter().map(|spec| spec.dir_name).collect();
+        let known: HashSet<&'static str> = BUILTIN_SKILL_SPECS
+            .iter()
+            .map(|spec| spec.dir_name)
+            .collect();
 
         for dir_name in builtin_skill_dir_names() {
             assert!(

--- a/src/crates/core/src/agentic/tools/implementations/skills/policy.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skills/policy.rs
@@ -124,9 +124,9 @@ pub fn policy_for_mode(mode_id: &str) -> ModeSkillPolicy {
         SkillModeId::Agentic | SkillModeId::Claw => AGENTIC_POLICY,
         SkillModeId::Cowork => COWORK_POLICY,
         SkillModeId::Team => TEAM_POLICY,
-        SkillModeId::ComputerUse
-        | SkillModeId::DeepResearch
-        | SkillModeId::Other => OPEN_META_ONLY_POLICY,
+        SkillModeId::ComputerUse | SkillModeId::DeepResearch | SkillModeId::Other => {
+            OPEN_META_ONLY_POLICY
+        }
     }
 }
 
@@ -137,10 +137,7 @@ fn selector_matches(selector: SkillSelector, spec: &BuiltinSkillSpec) -> bool {
     }
 }
 
-pub fn resolve_builtin_default_effect(
-    spec: &BuiltinSkillSpec,
-    mode_id: &str,
-) -> PolicyEffect {
+pub fn resolve_builtin_default_effect(spec: &BuiltinSkillSpec, mode_id: &str) -> PolicyEffect {
     let policy = policy_for_mode(mode_id);
     let mut current = policy.builtin_default;
 
@@ -157,7 +154,8 @@ pub fn resolve_builtin_default_effect(
 }
 
 pub fn resolve_builtin_default_enabled(dir_name: &str, mode_id: &str) -> Option<bool> {
-    builtin_skill_spec(dir_name).map(|spec| resolve_builtin_default_effect(spec, mode_id).is_enabled())
+    builtin_skill_spec(dir_name)
+        .map(|spec| resolve_builtin_default_effect(spec, mode_id).is_enabled())
 }
 
 #[cfg(test)]
@@ -170,15 +168,36 @@ mod tests {
         assert_eq!(SkillModeId::parse("debug"), SkillModeId::Debug);
         assert_eq!(SkillModeId::parse("something-else"), SkillModeId::Other);
 
-        assert_eq!(resolve_builtin_default_enabled("pdf", "agentic"), Some(false));
-        assert_eq!(resolve_builtin_default_enabled("agent-browser", "agentic"), Some(true));
+        assert_eq!(
+            resolve_builtin_default_enabled("pdf", "agentic"),
+            Some(false)
+        );
+        assert_eq!(
+            resolve_builtin_default_enabled("agent-browser", "agentic"),
+            Some(true)
+        );
         assert_eq!(resolve_builtin_default_enabled("pdf", "Cowork"), Some(true));
-        assert_eq!(resolve_builtin_default_enabled("agent-browser", "Cowork"), Some(false));
-        assert_eq!(resolve_builtin_default_enabled("gstack-review", "Team"), Some(true));
+        assert_eq!(
+            resolve_builtin_default_enabled("agent-browser", "Cowork"),
+            Some(false)
+        );
+        assert_eq!(
+            resolve_builtin_default_enabled("gstack-review", "Team"),
+            Some(true)
+        );
         assert_eq!(resolve_builtin_default_enabled("pdf", "Team"), Some(false));
-        assert_eq!(resolve_builtin_default_enabled("find-skills", "DeepResearch"), Some(true));
-        assert_eq!(resolve_builtin_default_enabled("pdf", "DeepResearch"), Some(false));
-        assert_eq!(resolve_builtin_default_enabled("agent-browser", "Claw"), Some(true));
+        assert_eq!(
+            resolve_builtin_default_enabled("find-skills", "DeepResearch"),
+            Some(true)
+        );
+        assert_eq!(
+            resolve_builtin_default_enabled("pdf", "DeepResearch"),
+            Some(false)
+        );
+        assert_eq!(
+            resolve_builtin_default_enabled("agent-browser", "Claw"),
+            Some(true)
+        );
         assert_eq!(resolve_builtin_default_enabled("pdf", "Claw"), Some(false));
         assert_eq!(resolve_builtin_default_enabled("pdf", "Other"), Some(false));
     }

--- a/src/crates/core/src/agentic/tools/implementations/skills/registry.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skills/registry.rs
@@ -746,7 +746,9 @@ impl SkillRegistry {
         workspace_root: Option<&Path>,
         mode_id: &str,
     ) -> Vec<ModeSkillInfo> {
-        let candidates = self.scan_skill_candidates_for_workspace(workspace_root).await;
+        let candidates = self
+            .scan_skill_candidates_for_workspace(workspace_root)
+            .await;
         let all_skills = sort_skills(annotate_shadowed_skills(candidates.clone()));
         let user_overrides = load_user_mode_skill_overrides(mode_id)
             .await
@@ -760,12 +762,8 @@ impl SkillRegistry {
         let disabled_project: HashSet<String> = dedupe_preserving_order(disabled_project)
             .into_iter()
             .collect();
-        let filtered = filter_candidates_for_mode(
-            candidates,
-            mode_id,
-            &user_overrides,
-            &disabled_project,
-        );
+        let filtered =
+            filter_candidates_for_mode(candidates, mode_id, &user_overrides, &disabled_project);
         let resolved = resolve_visible_skills(filtered);
 
         Self::build_mode_skill_infos(
@@ -796,12 +794,8 @@ impl SkillRegistry {
         let disabled_project: HashSet<String> = dedupe_preserving_order(disabled_project)
             .into_iter()
             .collect();
-        let filtered = filter_candidates_for_mode(
-            candidates,
-            mode_id,
-            &user_overrides,
-            &disabled_project,
-        );
+        let filtered =
+            filter_candidates_for_mode(candidates, mode_id, &user_overrides, &disabled_project);
         let resolved = resolve_visible_skills(filtered);
 
         Self::build_mode_skill_infos(

--- a/src/crates/core/src/util/token_counter.rs
+++ b/src/crates/core/src/util/token_counter.rs
@@ -40,9 +40,7 @@ impl TokenCounter {
         if let Some(tool_calls) = &message.tool_calls {
             for tool_call in tool_calls {
                 total += Self::estimate_tokens(&tool_call.name);
-                if let Ok(json_str) = serde_json::to_string(&tool_call.arguments) {
-                    total += Self::estimate_tokens(&json_str);
-                }
+                total += Self::estimate_tokens(&tool_call.serialized_arguments());
                 total += 10;
             }
         }


### PR DESCRIPTION
- keep tool call arguments as serde_json::Value across core and adapter boundaries
- preserve raw tool arguments for valid streamed tool calls during replay
- prefer raw arguments for OpenAI-compatible message serialization when JSON is valid
- fall back to stable serialization when raw arguments are missing or invalid
- align token estimation and stream tests with the new tool argument replay behavior
