### PR TITLE
Fix agent runtime concurrency and cancellation handling

### DIFF
--- a/src/apps/cli/src/modes/chat.rs
+++ b/src/apps/cli/src/modes/chat.rs
@@ -65,7 +65,11 @@ fn usage_report_from_cli_session(session: &Session) -> SessionUsageReport {
         },
         scope: UsageScope {
             kind: UsageScopeKind::EntireSession,
-            turn_count: session.messages.iter().filter(|message| message.role == "user").count(),
+            turn_count: session
+                .messages
+                .iter()
+                .filter(|message| message.role == "user")
+                .count(),
             from_turn_id: session.messages.first().map(|message| message.id.clone()),
             to_turn_id: session.messages.last().map(|message| message.id.clone()),
             includes_subagents: false,
@@ -640,7 +644,10 @@ mod tests {
 
     #[test]
     fn usage_command_renders_without_model_request() {
-        let session = Session::new("agentic".to_string(), Some("D:/workspace/bitfun".to_string()));
+        let session = Session::new(
+            "agentic".to_string(),
+            Some("D:/workspace/bitfun".to_string()),
+        );
         let report = usage_report_from_cli_session(&session);
 
         assert_eq!(report.session_id, session.id);

--- a/src/apps/desktop/src/api/browser_control_api.rs
+++ b/src/apps/desktop/src/api/browser_control_api.rs
@@ -48,11 +48,31 @@ pub struct BrowserControlBrowsersResponse {
 pub async fn browser_control_list_browsers() -> Result<BrowserControlBrowsersResponse, String> {
     let browsers = [
         ("default", "Default browser", true),
-        ("chrome", "Google Chrome", BrowserLauncher::is_browser_installed(&BrowserKind::Chrome)),
-        ("edge", "Microsoft Edge", BrowserLauncher::is_browser_installed(&BrowserKind::Edge)),
-        ("brave", "Brave Browser", BrowserLauncher::is_browser_installed(&BrowserKind::Brave)),
-        ("chromium", "Chromium", BrowserLauncher::is_browser_installed(&BrowserKind::Chromium)),
-        ("arc", "Arc", BrowserLauncher::is_browser_installed(&BrowserKind::Arc)),
+        (
+            "chrome",
+            "Google Chrome",
+            BrowserLauncher::is_browser_installed(&BrowserKind::Chrome),
+        ),
+        (
+            "edge",
+            "Microsoft Edge",
+            BrowserLauncher::is_browser_installed(&BrowserKind::Edge),
+        ),
+        (
+            "brave",
+            "Brave Browser",
+            BrowserLauncher::is_browser_installed(&BrowserKind::Brave),
+        ),
+        (
+            "chromium",
+            "Chromium",
+            BrowserLauncher::is_browser_installed(&BrowserKind::Chromium),
+        ),
+        (
+            "arc",
+            "Arc",
+            BrowserLauncher::is_browser_installed(&BrowserKind::Arc),
+        ),
     ];
 
     Ok(BrowserControlBrowsersResponse {

--- a/src/apps/desktop/src/api/system_api.rs
+++ b/src/apps/desktop/src/api/system_api.rs
@@ -98,10 +98,7 @@ pub struct InstallUpdateRequest {}
 
 /// Downloads and installs the latest update from the updater endpoint (re-checks remote).
 #[tauri::command]
-pub async fn install_update(
-    app: AppHandle,
-    request: InstallUpdateRequest,
-) -> Result<(), String> {
+pub async fn install_update(app: AppHandle, request: InstallUpdateRequest) -> Result<(), String> {
     let _ = request;
     let updater = app.updater().map_err(|e| e.to_string())?;
     let update = updater.check().await.map_err(|e| e.to_string())?;
@@ -116,17 +113,16 @@ pub async fn install_update(
         .download_and_install(
             move |chunk_len, content_len| {
                 let (downloaded, total) = {
-                    let mut g = progress_chunk.lock().expect("update progress mutex poisoned");
+                    let mut g = progress_chunk
+                        .lock()
+                        .expect("update progress mutex poisoned");
                     g.0 = g.0.saturating_add(chunk_len as u64);
                     g.1 = g.1.or(content_len);
                     (g.0, g.1)
                 };
                 let _ = app_chunk.emit(
                     UPDATE_PROGRESS_EVENT,
-                    UpdateProgressPayload {
-                        downloaded,
-                        total,
-                    },
+                    UpdateProgressPayload { downloaded, total },
                 );
             },
             {
@@ -141,10 +137,7 @@ pub async fn install_update(
                     };
                     let _ = app_done.emit(
                         UPDATE_PROGRESS_EVENT,
-                        UpdateProgressPayload {
-                            downloaded,
-                            total,
-                        },
+                        UpdateProgressPayload { downloaded, total },
                     );
                 }
             },

--- a/src/crates/ai-adapters/src/providers/gemini/code_assist.rs
+++ b/src/crates/ai-adapters/src/providers/gemini/code_assist.rs
@@ -204,7 +204,11 @@ fn read_gemini_settings_model(gemini_home: &Path) -> Option<String> {
         Ok(b) => b,
         Err(e) => {
             if e.kind() != std::io::ErrorKind::NotFound {
-                warn!("Failed to read Gemini settings from {}: {}", settings_path.display(), e);
+                warn!(
+                    "Failed to read Gemini settings from {}: {}",
+                    settings_path.display(),
+                    e
+                );
             }
             return None;
         }
@@ -212,7 +216,11 @@ fn read_gemini_settings_model(gemini_home: &Path) -> Option<String> {
     let value: serde_json::Value = match serde_json::from_slice(&bytes) {
         Ok(v) => v,
         Err(e) => {
-            warn!("Failed to parse Gemini settings JSON from {}: {}", settings_path.display(), e);
+            warn!(
+                "Failed to parse Gemini settings JSON from {}: {}",
+                settings_path.display(),
+                e
+            );
             return None;
         }
     };
@@ -230,7 +238,11 @@ fn read_gemini_env_model(gemini_home: &Path) -> Option<String> {
         Ok(t) => t,
         Err(e) => {
             if e.kind() != std::io::ErrorKind::NotFound {
-                warn!("Failed to read Gemini .env from {}: {}", env_path.display(), e);
+                warn!(
+                    "Failed to read Gemini .env from {}: {}",
+                    env_path.display(),
+                    e
+                );
             }
             return None;
         }
@@ -257,8 +269,8 @@ pub(crate) async fn list_models(_client: &AIClient) -> Result<Vec<RemoteModelInf
     let mut models = Vec::new();
 
     if let Some(gemini_home) = gemini_home_dir() {
-        if let Some(model) = read_gemini_settings_model(&gemini_home)
-            .or_else(|| read_gemini_env_model(&gemini_home))
+        if let Some(model) =
+            read_gemini_settings_model(&gemini_home).or_else(|| read_gemini_env_model(&gemini_home))
         {
             models.push(RemoteModelInfo {
                 id: model,

--- a/src/crates/ai-adapters/src/providers/openai/common.rs
+++ b/src/crates/ai-adapters/src/providers/openai/common.rs
@@ -171,7 +171,11 @@ fn read_codex_config_model(codex_home: &Path) -> Option<String> {
         Ok(t) => t,
         Err(e) => {
             if e.kind() != std::io::ErrorKind::NotFound {
-                warn!("Failed to read Codex config from {}: {}", config_path.display(), e);
+                warn!(
+                    "Failed to read Codex config from {}: {}",
+                    config_path.display(),
+                    e
+                );
             }
             return None;
         }
@@ -196,7 +200,11 @@ fn read_codex_cached_models(codex_home: &Path) -> Vec<String> {
         Ok(b) => b,
         Err(e) => {
             if e.kind() != std::io::ErrorKind::NotFound {
-                warn!("Failed to read Codex models cache from {}: {}", cache_path.display(), e);
+                warn!(
+                    "Failed to read Codex models cache from {}: {}",
+                    cache_path.display(),
+                    e
+                );
             }
             return Vec::new();
         }
@@ -204,7 +212,11 @@ fn read_codex_cached_models(codex_home: &Path) -> Vec<String> {
     let payload: CodexBackendModelsResponse = match serde_json::from_slice(&bytes) {
         Ok(p) => p,
         Err(e) => {
-            warn!("Failed to parse Codex models cache JSON from {}: {}", cache_path.display(), e);
+            warn!(
+                "Failed to parse Codex models cache JSON from {}: {}",
+                cache_path.display(),
+                e
+            );
             return Vec::new();
         }
     };
@@ -301,7 +313,9 @@ async fn list_codex_chatgpt_models(
     let mut model_ids = match live_models {
         Ok(models) if !models.is_empty() => models,
         Ok(_) => {
-            log::warn!("Codex backend model discovery returned no models; using local fallback catalog");
+            log::warn!(
+                "Codex backend model discovery returned no models; using local fallback catalog"
+            );
             codex_fallback_model_ids()
         }
         Err(error) => {

--- a/src/crates/core/src/agentic/agents/mod.rs
+++ b/src/crates/core/src/agentic/agents/mod.rs
@@ -48,11 +48,11 @@ pub use prompt_builder::{
     RequestContextSection,
 };
 pub use readonly_subagent::ReadonlySubagent;
-pub use research_specialist_agent::ResearchSpecialistAgent;
 pub use registry::{
     get_agent_registry, AgentCategory, AgentInfo, AgentRegistry, CustomSubagentConfig,
     CustomSubagentDetail, SubAgentSource,
 };
+pub use research_specialist_agent::ResearchSpecialistAgent;
 pub use review_fixer_agent::ReviewFixerAgent;
 pub use review_specialist_agents::{
     ArchitectureReviewerAgent, BusinessLogicReviewerAgent, FrontendReviewerAgent,

--- a/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -457,10 +457,7 @@ Do not read from, modify, create, move, or delete files outside this workspace u
         // timestamp slug when no session is bound (e.g. one-shot prompt builds in tests).
         if result.contains(PLACEHOLDER_SESSION_ID) {
             let session_id = self.context.session_id.clone().unwrap_or_else(|| {
-                format!(
-                    "unbound-{}",
-                    chrono::Local::now().format("%Y%m%d-%H%M%S")
-                )
+                format!("unbound-{}", chrono::Local::now().format("%Y%m%d-%H%M%S"))
             });
             result = result.replace(PLACEHOLDER_SESSION_ID, &session_id);
         }

--- a/src/crates/core/src/agentic/agents/research_specialist_agent.rs
+++ b/src/crates/core/src/agentic/agents/research_specialist_agent.rs
@@ -39,6 +39,9 @@ mod tests {
             agent.prompt_template_name(Some("gpt-5.1")),
             "research_specialist_agent"
         );
-        assert_eq!(agent.prompt_template_name(None), "research_specialist_agent");
+        assert_eq!(
+            agent.prompt_template_name(None),
+            "research_specialist_agent"
+        );
     }
 }

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -1642,6 +1642,39 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             )
             .await?;
 
+        // Register this turn as in-flight immediately after it becomes visible
+        // as Processing. Later await points must not leave a cancel/start
+        // window where wait_session_drained observes zero active work.
+        let active_counter = self
+            .active_turns_per_session
+            .entry(session_id.clone())
+            .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
+            .clone();
+        active_counter.fetch_add(1, Ordering::SeqCst);
+        struct ActiveTurnRegistration {
+            counter: Arc<AtomicUsize>,
+            armed: bool,
+        }
+        impl ActiveTurnRegistration {
+            fn disarm(&mut self) {
+                self.armed = false;
+            }
+        }
+        impl Drop for ActiveTurnRegistration {
+            fn drop(&mut self) {
+                if self.armed {
+                    self.counter.fetch_sub(1, Ordering::SeqCst);
+                }
+            }
+        }
+        let mut active_registration = ActiveTurnRegistration {
+            counter: active_counter.clone(),
+            armed: true,
+        };
+        let cancellation_token = CancellationToken::new();
+        self.execution_engine
+            .register_cancel_token(&turn_id, cancellation_token);
+
         // Send dialog turn started event with original input and image metadata
         // so all frontends (desktop, mobile, bot) can display correctly.
         self.emit_event(AgenticEvent::DialogTurnStarted {
@@ -1660,10 +1693,13 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         .await;
 
         // Get context messages (re-fetch as history may have been restored)
-        let messages = self
-            .session_manager
-            .get_context_messages(&session_id)
-            .await?;
+        let messages = match self.session_manager.get_context_messages(&session_id).await {
+            Ok(messages) => messages,
+            Err(error) => {
+                self.execution_engine.cleanup_cancel_token(&turn_id).await;
+                return Err(error);
+            }
+        };
 
         // Create execution context (pass full config and resource IDs)
         let mut context_vars = std::collections::HashMap::new();
@@ -1770,44 +1806,82 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         let user_message_metadata_clone = user_message_metadata;
         let scheduler_notify_tx = self.scheduler_notify_tx.get().cloned();
 
-        // P0-8: register this turn as in-flight so a subsequent cancel→start
-        // sequence can wait for the spawn task to actually drain before the
-        // new turn touches the in-memory message cache.
-        let active_counter = self
-            .active_turns_per_session
-            .entry(session_id.clone())
-            .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
-            .clone();
-        active_counter.fetch_add(1, Ordering::SeqCst);
-        let active_counter_for_spawn = active_counter.clone();
-
         tokio::spawn(async move {
-            // RAII-style decrement on every exit path of the spawn body.
-            struct DropGuard {
-                counter: Arc<AtomicUsize>,
+            // RAII guard: on drop (ANY exit path, including panic), decrements
+            // the in-flight counter and resets Processing → Idle only if this
+            // task still owns the current turn.
+            //
+            // This is the single source of truth for "is this spawn active?".
+            // Because `Drop` is synchronous we use an in-memory-only state
+            // update here; the async persistence of the state change is done
+            // explicitly in the spawn body below.
+            struct SessionExecutionGuard {
+                session_manager: Arc<SessionManager>,
+                session_id: String,
+                turn_id: String,
+                active_counter: Arc<AtomicUsize>,
             }
-            impl Drop for DropGuard {
-                fn drop(&mut self) {
-                    self.counter.fetch_sub(1, Ordering::SeqCst);
+            impl SessionExecutionGuard {
+                fn new(
+                    session_manager: Arc<SessionManager>,
+                    session_id: String,
+                    turn_id: String,
+                    active_counter: Arc<AtomicUsize>,
+                ) -> Self {
+                    Self {
+                        session_manager,
+                        session_id,
+                        turn_id,
+                        active_counter,
+                    }
                 }
             }
-            let _drop_guard = DropGuard {
-                counter: active_counter_for_spawn,
-            };
+            impl Drop for SessionExecutionGuard {
+                fn drop(&mut self) {
+                    self.active_counter.fetch_sub(1, Ordering::SeqCst);
+                    // If the session is still in Processing (abnormal exit),
+                    // synchronously reset to Idle so the user is never stuck.
+                    self.session_manager
+                        .reset_session_state_if_processing(&self.session_id, &self.turn_id);
+                }
+            }
+
+            let _guard = SessionExecutionGuard::new(
+                session_manager.clone(),
+                session_id_clone.clone(),
+                turn_id_clone.clone(),
+                active_counter,
+            );
 
             // Note: Don't check cancellation here as cancel token hasn't been created yet
             // Cancel token is created in execute_dialog_turn -> execute_round
             // execute_dialog_turn has proper cancellation checks internally
 
-            let _ = session_manager
-                .update_session_state(
+            match session_manager
+                .update_session_state_for_turn_if_processing(
                     &session_id_clone,
+                    &turn_id_clone,
                     SessionState::Processing {
                         current_turn_id: turn_id_clone.clone(),
                         phase: ProcessingPhase::Thinking,
                     },
                 )
-                .await;
+                .await
+            {
+                Ok(true) => {}
+                Ok(false) => {
+                    debug!(
+                        "Skipped refreshing Processing state for stale or cancelled turn: session_id={}, turn_id={}",
+                        session_id_clone, turn_id_clone
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to set session state to Processing: session_id={}, turn_id={}, error={}",
+                        session_id_clone, turn_id_clone, e
+                    );
+                }
+            }
 
             let workspace_turn_status = match execution_engine
                 .execute_dialog_turn(effective_agent_type_clone, messages, execution_context)
@@ -1824,7 +1898,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                         session_id_clone, turn_id_clone, execution_result.total_rounds
                     );
 
-                    let _ = session_manager
+                    if let Err(e) = session_manager
                         .complete_dialog_turn(
                             &session_id_clone,
                             &turn_id_clone,
@@ -1836,20 +1910,44 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                                 duration_ms: 0,
                             },
                         )
-                        .await;
+                        .await
+                    {
+                        error!(
+                            "Failed to complete dialog turn: session_id={}, turn_id={}, error={}",
+                            session_id_clone, turn_id_clone, e
+                        );
+                    }
 
-                    let _ = session_manager
-                        .update_session_state(&session_id_clone, SessionState::Idle)
-                        .await;
+                    match session_manager
+                        .update_session_state_for_turn_if_processing(
+                            &session_id_clone,
+                            &turn_id_clone,
+                            SessionState::Idle,
+                        )
+                        .await
+                    {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            debug!(
+                                "Skipped setting session Idle after completion for stale turn: session_id={}, turn_id={}",
+                                session_id_clone, turn_id_clone
+                            );
+                        }
+                        Err(e) => {
+                            error!("Failed to set session state to Idle after completion: session_id={}, turn_id={}, error={}", session_id_clone, turn_id_clone, e);
+                        }
+                    }
 
                     if let Some(tx) = &scheduler_notify_tx {
-                        let _ = tx.try_send((
+                        if let Err(e) = tx.try_send((
                             session_id_clone.clone(),
                             TurnOutcome::Completed {
                                 turn_id: turn_id_clone.clone(),
                                 final_response,
                             },
-                        ));
+                        )) {
+                            error!("Failed to notify scheduler of turn completion: session_id={}, turn_id={}, error={}", session_id_clone, turn_id_clone, e);
+                        }
                     }
 
                     Some(crate::service::session::TurnStatus::Completed)
@@ -1867,7 +1965,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                         // cancellation is detected between rounds.  If cancellation
                         // interrupted streaming mid-round, no event was emitted.
                         // Emit it here unconditionally (duplicates are harmless).
-                        let _ = event_queue
+                        if let Err(e) = event_queue
                             .enqueue(
                                 AgenticEvent::DialogTurnCancelled {
                                     session_id: session_id_clone.clone(),
@@ -1876,27 +1974,51 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                                 },
                                 Some(EventPriority::Critical),
                             )
-                            .await;
+                            .await
+                        {
+                            error!("Failed to emit DialogTurnCancelled event: session_id={}, turn_id={}, error={}", session_id_clone, turn_id_clone, e);
+                        }
 
                         // Mark the turn as cancelled in persistence so its partial
                         // content appears in historical messages (turns_to_chat_messages
                         // skips InProgress turns) and the frontend can distinguish a
                         // cancellation from a normal completion.
-                        let _ = session_manager
+                        if let Err(e) = session_manager
                             .cancel_dialog_turn(&session_id_clone, &turn_id_clone)
-                            .await;
+                            .await
+                        {
+                            error!("Failed to cancel dialog turn in persistence: session_id={}, turn_id={}, error={}", session_id_clone, turn_id_clone, e);
+                        }
 
-                        let _ = session_manager
-                            .update_session_state(&session_id_clone, SessionState::Idle)
-                            .await;
+                        match session_manager
+                            .update_session_state_for_turn_if_processing(
+                                &session_id_clone,
+                                &turn_id_clone,
+                                SessionState::Idle,
+                            )
+                            .await
+                        {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                debug!(
+                                    "Skipped setting session Idle after cancellation for stale turn: session_id={}, turn_id={}",
+                                    session_id_clone, turn_id_clone
+                                );
+                            }
+                            Err(e) => {
+                                error!("Failed to set session state to Idle after cancellation: session_id={}, turn_id={}, error={}", session_id_clone, turn_id_clone, e);
+                            }
+                        }
 
                         if let Some(tx) = &scheduler_notify_tx {
-                            let _ = tx.try_send((
+                            if let Err(e) = tx.try_send((
                                 session_id_clone.clone(),
                                 TurnOutcome::Cancelled {
                                     turn_id: turn_id_clone.clone(),
                                 },
-                            ));
+                            )) {
+                                error!("Failed to notify scheduler of turn cancellation: session_id={}, turn_id={}, error={}", session_id_clone, turn_id_clone, e);
+                            }
                         }
 
                         Some(crate::service::session::TurnStatus::Cancelled)
@@ -1907,7 +2029,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                         let recoverable =
                             !matches!(&e, BitFunError::AIClient(_) | BitFunError::Timeout(_));
 
-                        let _ = event_queue
+                        if let Err(eq_err) = event_queue
                             .enqueue(
                                 AgenticEvent::DialogTurnFailed {
                                     session_id: session_id_clone.clone(),
@@ -1919,30 +2041,54 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                                 },
                                 Some(EventPriority::Critical),
                             )
-                            .await;
+                            .await
+                        {
+                            error!("Failed to emit DialogTurnFailed event: session_id={}, turn_id={}, error={}", session_id_clone, turn_id_clone, eq_err);
+                        }
 
-                        let _ = session_manager
+                        if let Err(e) = session_manager
                             .fail_dialog_turn(&session_id_clone, &turn_id_clone, error_text.clone())
-                            .await;
+                            .await
+                        {
+                            error!("Failed to mark dialog turn as failed: session_id={}, turn_id={}, error={}", session_id_clone, turn_id_clone, e);
+                        }
 
-                        let _ = session_manager
-                            .update_session_state(
+                        match session_manager
+                            .update_session_state_for_turn_if_processing(
                                 &session_id_clone,
+                                &turn_id_clone,
                                 SessionState::Error {
                                     error: error_text.clone(),
                                     recoverable,
                                 },
                             )
-                            .await;
+                            .await
+                        {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                debug!(
+                                    "Skipped setting session Error after failure for stale turn: session_id={}, turn_id={}",
+                                    session_id_clone, turn_id_clone
+                                );
+                            }
+                            Err(e) => {
+                                error!(
+                                    "Failed to set session state to Error: session_id={}, turn_id={}, error={}",
+                                    session_id_clone, turn_id_clone, e
+                                );
+                            }
+                        }
 
                         if let Some(tx) = &scheduler_notify_tx {
-                            let _ = tx.try_send((
+                            if let Err(e) = tx.try_send((
                                 session_id_clone.clone(),
                                 TurnOutcome::Failed {
                                     turn_id: turn_id_clone.clone(),
                                     error: error_text,
                                 },
-                            ));
+                            )) {
+                                error!("Failed to notify scheduler of turn failure: session_id={}, turn_id={}, error={}", session_id_clone, turn_id_clone, e);
+                            }
                         }
 
                         Some(crate::service::session::TurnStatus::Error)
@@ -1971,6 +2117,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 }
             }
         });
+        active_registration.disarm();
 
         Ok(())
     }
@@ -2018,10 +2165,17 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .unwrap_or_else(|| "Unknown".to_string());
         debug!("Current state: {}", old_state);
 
-        // Step 1: Immediately update session state to Idle (non-blocking, allows immediate new dialog)
-        debug!("Updating session state to Idle");
-        self.session_manager
-            .update_session_state(session_id, SessionState::Idle)
+        // Step 1: Immediately update session state to Idle only if this
+        // cancellation still targets the currently processing turn. A delayed
+        // cancel request for an older turn must not clear a newer turn.
+        debug!("Conditionally updating session state to Idle for cancelled turn");
+        let state_updated = self
+            .session_manager
+            .update_session_state_for_turn_if_processing(
+                session_id,
+                dialog_turn_id,
+                SessionState::Idle,
+            )
             .await?;
 
         let new_state = self
@@ -2031,13 +2185,21 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .unwrap_or_else(|| "Unknown".to_string());
         debug!("State updated: {} -> {}", old_state, new_state);
 
-        // Step 2: Immediately send state change event (notify frontend can start new dialog)
-        self.emit_event(AgenticEvent::SessionStateChanged {
-            session_id: session_id.to_string(),
-            new_state: "idle".to_string(),
-        })
-        .await;
-        debug!("Session state change event sent");
+        // Step 2: Immediately send state change event only when this cancel
+        // actually changed the active turn state.
+        if state_updated {
+            self.emit_event(AgenticEvent::SessionStateChanged {
+                session_id: session_id.to_string(),
+                new_state: "idle".to_string(),
+            })
+            .await;
+            debug!("Session state change event sent");
+        } else {
+            debug!(
+                "Skipped idle event for stale cancellation: session_id={}, dialog_turn_id={}",
+                session_id, dialog_turn_id
+            );
+        }
 
         // Step 3: Trigger cancellation tokens so the running turn unwinds. We
         // do this synchronously (not spawn) because the calls themselves are

--- a/src/crates/core/src/agentic/coordination/state_manager.rs
+++ b/src/crates/core/src/agentic/coordination/state_manager.rs
@@ -38,9 +38,16 @@ impl SessionStateManager {
 
     /// Update session state
     pub async fn update_state(&self, session_id: &str, new_state: SessionState) {
-        if let Some(mut state) = self.states.get_mut(session_id) {
+        // IMPORTANT: keep the DashMap guard scope short -- do NOT hold it across .await.
+        let should_emit = if let Some(mut state) = self.states.get_mut(session_id) {
             *state = new_state.clone();
+            true
+        } else {
+            false
+        };
+        // RefMut guard released here -- DashMap shard lock is free.
 
+        if should_emit {
             self.emit_state_change_event(session_id, new_state).await;
         }
     }

--- a/src/crates/core/src/agentic/events/queue.rs
+++ b/src/crates/core/src/agentic/events/queue.rs
@@ -176,6 +176,13 @@ impl EventQueue {
         self.broadcast_tx.subscribe()
     }
 
+    #[cfg(test)]
+    pub(crate) async fn lock_queue_for_test(
+        &self,
+    ) -> tokio::sync::MutexGuard<'_, BinaryHeap<std::cmp::Reverse<EventEnvelope>>> {
+        self.queue.lock().await
+    }
+
     /// Clear all events for a session
     pub async fn clear_session(&self, session_id: &str) -> BitFunResult<()> {
         // Remove all events for this session from the queue

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -1731,10 +1731,13 @@ impl ExecutionEngine {
                 }
             }
 
-            // Check if cancelled after each round
-            let dialog_turn_cancelled =
-                !self.round_executor.has_active_dialog_turn(&dialog_turn_id);
-            if dialog_turn_cancelled {
+            // Check if cancellation was requested after each round. Tokens stay
+            // registered until final cleanup so early cancellation can be
+            // observed by the first round.
+            if self
+                .round_executor
+                .is_dialog_turn_cancelled(&dialog_turn_id)
+            {
                 debug!(
                     "Dialog turn cancelled, stopping execution: dialog_turn_id={}",
                     dialog_turn_id

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -104,6 +104,16 @@ impl RoundExecutor {
         let max_attempts = Self::MAX_RETRIES_WITHOUT_OUTPUT + 1;
         let mut attempt_index = 0usize;
         let (stream_result, send_to_stream_ms, stream_processing_ms) = loop {
+            // Check cancellation before opening a model stream. This catches
+            // early cancellation registered before the first round starts.
+            if cancel_token.is_cancelled() {
+                debug!(
+                    "Cancel token detected before AI request, stopping execution: session_id={}",
+                    context.session_id
+                );
+                return Err(BitFunError::Cancelled("Execution cancelled".to_string()));
+            }
+
             let request_started_at = Instant::now();
             debug!(
                 "Sending request: model={}, messages={}, tools={}, attempt={}/{}",
@@ -159,10 +169,10 @@ impl RoundExecutor {
             let ai_stream = stream_response.stream;
             let raw_sse_rx = stream_response.raw_sse_rx;
 
-            // Check cancellation token before calling stream processing
+            // Check cancellation token before calling stream processing.
             if cancel_token.is_cancelled() {
                 debug!(
-                    "Cancel token detected before AI call, stopping execution: session_id={}",
+                    "Cancel token detected after AI stream opened, stopping execution: session_id={}",
                     context.session_id
                 );
                 return Err(BitFunError::Cancelled("Execution cancelled".to_string()));
@@ -684,6 +694,13 @@ impl RoundExecutor {
         self.cancellation_tokens.contains_key(dialog_turn_id)
     }
 
+    /// Check if dialog turn cancellation has been requested.
+    pub fn is_dialog_turn_cancelled(&self, dialog_turn_id: &str) -> bool {
+        self.cancellation_tokens
+            .get(dialog_turn_id)
+            .is_some_and(|token| token.is_cancelled())
+    }
+
     /// Register cancellation token (for external control, e.g., execute_subagent)
     pub fn register_cancel_token(&self, dialog_turn_id: &str, token: CancellationToken) {
         self.cancellation_tokens
@@ -694,10 +711,14 @@ impl RoundExecutor {
     pub async fn cancel_dialog_turn(&self, dialog_turn_id: &str) -> BitFunResult<()> {
         debug!("Cancelling dialog turn: dialog_turn_id={}", dialog_turn_id);
 
-        if let Some((_, token)) = self.cancellation_tokens.remove(dialog_turn_id) {
+        if let Some(token) = self
+            .cancellation_tokens
+            .get(dialog_turn_id)
+            .map(|entry| entry.clone())
+        {
             debug!("Found cancel token, triggering cancellation");
             token.cancel();
-            debug!("Cancel token triggered and cleaned up");
+            debug!("Cancel token triggered");
         } else {
             debug!("Cancel token not found (dialog may have completed or not started)");
         }
@@ -867,7 +888,41 @@ fn token_details_from_usage(
 
 #[cfg(test)]
 mod tests {
-    use super::RoundExecutor;
+    use super::{RoundExecutor, StreamProcessor};
+    use crate::agentic::events::{EventQueue, EventQueueConfig};
+    use dashmap::DashMap;
+    use std::sync::Arc;
+    use tokio_util::sync::CancellationToken;
+
+    fn test_round_executor() -> RoundExecutor {
+        let event_queue = Arc::new(EventQueue::new(EventQueueConfig::default()));
+        RoundExecutor {
+            stream_processor: Arc::new(StreamProcessor::new(event_queue.clone())),
+            tool_pipeline: None,
+            event_queue,
+            cancellation_tokens: Arc::new(DashMap::new()),
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_keeps_token_registered_until_cleanup() {
+        let executor = test_round_executor();
+        let token = CancellationToken::new();
+        executor.register_cancel_token("turn-1", token.clone());
+
+        executor
+            .cancel_dialog_turn("turn-1")
+            .await
+            .expect("cancel should succeed");
+
+        assert!(token.is_cancelled());
+        assert!(executor.has_active_dialog_turn("turn-1"));
+        assert!(executor.is_dialog_turn_cancelled("turn-1"));
+
+        executor.cleanup_dialog_turn("turn-1").await;
+        assert!(!executor.has_active_dialog_turn("turn-1"));
+        assert!(!executor.is_dialog_turn_cancelled("turn-1"));
+    }
 
     #[test]
     fn detects_transient_stream_transport_error() {

--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -118,6 +118,139 @@ mod tests {
         )
     }
 
+    fn in_memory_test_manager() -> SessionManager {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(Arc::new(PathManager::new().expect("path manager")))
+                .expect("persistence manager"),
+        );
+        SessionManager::new(
+            Arc::new(SessionContextStore::new()),
+            persistence_manager,
+            SessionManagerConfig {
+                max_active_sessions: 100,
+                session_idle_timeout: Duration::from_secs(3600),
+                auto_save_interval: Duration::from_secs(300),
+                enable_persistence: false,
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn reset_session_state_if_processing_ignores_a_newer_turn() {
+        let manager = in_memory_test_manager();
+        let session_id = Uuid::new_v4().to_string();
+        let mut session = Session::new_with_id(
+            session_id.clone(),
+            "Active session".to_string(),
+            "agent".to_string(),
+            SessionConfig::default(),
+        );
+        session.state = SessionState::Processing {
+            current_turn_id: "turn-2".to_string(),
+            phase: ProcessingPhase::Thinking,
+        };
+        manager.sessions.insert(session_id.clone(), session);
+
+        manager.reset_session_state_if_processing(&session_id, "turn-1");
+
+        let session = manager
+            .get_session(&session_id)
+            .expect("session should remain available");
+        assert!(matches!(
+            session.state,
+            SessionState::Processing {
+                ref current_turn_id,
+                ..
+            } if current_turn_id == "turn-2"
+        ));
+    }
+
+    #[tokio::test]
+    async fn reset_session_state_if_processing_resets_the_matching_turn() {
+        let manager = in_memory_test_manager();
+        let session_id = Uuid::new_v4().to_string();
+        let mut session = Session::new_with_id(
+            session_id.clone(),
+            "Active session".to_string(),
+            "agent".to_string(),
+            SessionConfig::default(),
+        );
+        session.state = SessionState::Processing {
+            current_turn_id: "turn-1".to_string(),
+            phase: ProcessingPhase::Thinking,
+        };
+        manager.sessions.insert(session_id.clone(), session);
+
+        manager.reset_session_state_if_processing(&session_id, "turn-1");
+
+        let session = manager
+            .get_session(&session_id)
+            .expect("session should remain available");
+        assert!(matches!(session.state, SessionState::Idle));
+    }
+
+    #[tokio::test]
+    async fn update_session_state_for_turn_if_processing_ignores_a_newer_turn() {
+        let manager = in_memory_test_manager();
+        let session_id = Uuid::new_v4().to_string();
+        let mut session = Session::new_with_id(
+            session_id.clone(),
+            "Active session".to_string(),
+            "agent".to_string(),
+            SessionConfig::default(),
+        );
+        session.state = SessionState::Processing {
+            current_turn_id: "turn-2".to_string(),
+            phase: ProcessingPhase::Thinking,
+        };
+        manager.sessions.insert(session_id.clone(), session);
+
+        let updated = manager
+            .update_session_state_for_turn_if_processing(&session_id, "turn-1", SessionState::Idle)
+            .await
+            .expect("conditional state update should not fail");
+
+        let session = manager
+            .get_session(&session_id)
+            .expect("session should remain available");
+        assert!(!updated);
+        assert!(matches!(
+            session.state,
+            SessionState::Processing {
+                ref current_turn_id,
+                ..
+            } if current_turn_id == "turn-2"
+        ));
+    }
+
+    #[tokio::test]
+    async fn update_session_state_for_turn_if_processing_updates_matching_turn() {
+        let manager = in_memory_test_manager();
+        let session_id = Uuid::new_v4().to_string();
+        let mut session = Session::new_with_id(
+            session_id.clone(),
+            "Active session".to_string(),
+            "agent".to_string(),
+            SessionConfig::default(),
+        );
+        session.state = SessionState::Processing {
+            current_turn_id: "turn-1".to_string(),
+            phase: ProcessingPhase::Thinking,
+        };
+        manager.sessions.insert(session_id.clone(), session);
+
+        let updated = manager
+            .update_session_state_for_turn_if_processing(&session_id, "turn-1", SessionState::Idle)
+            .await
+            .expect("conditional state update should not fail");
+
+        let session = manager
+            .get_session(&session_id)
+            .expect("session should remain available");
+        assert!(updated);
+        assert!(matches!(session.state, SessionState::Idle));
+    }
+
     #[tokio::test]
     async fn restore_session_resets_processing_state_without_marking_unread_completion() {
         let workspace = TestWorkspace::new();
@@ -863,12 +996,12 @@ impl SessionManager {
         self.context_store.create_session(&session_id);
 
         // 3. Persist to local path (handles remote workspaces correctly)
+        // Use the local `session` directly -- no need to re-fetch from DashMap,
+        // which would hold a Ref guard across the async save_session call.
         if self.config.enable_persistence && Self::should_persist_session(&session) {
-            if let Some(session) = self.sessions.get(&session_id) {
-                self.persistence_manager
-                    .save_session(&session_storage_path, &session)
-                    .await?;
-            }
+            self.persistence_manager
+                .save_session(&session_storage_path, &session)
+                .await?;
         }
 
         info!("Session created: session_name={}", session.session_name);
@@ -881,6 +1014,34 @@ impl SessionManager {
         self.sessions.get(session_id).map(|s| s.clone())
     }
 
+    /// Synchronously reset session state to Idle if it is currently Processing
+    /// the expected turn.
+    ///
+    /// This is an in-memory-only operation intended for RAII-style cleanup in
+    /// spawn tasks.  Because `Drop::drop` is synchronous we cannot do async
+    /// file I/O here, but that is acceptable: the in-memory state is the
+    /// source of truth at runtime, and `restore_session` already resets any
+    /// non-Idle persisted state to Idle on application restart.
+    pub fn reset_session_state_if_processing(&self, session_id: &str, expected_turn_id: &str) {
+        if let Some(mut session) = self.sessions.get_mut(session_id) {
+            if matches!(
+                &session.state,
+                SessionState::Processing {
+                    current_turn_id,
+                    ..
+                } if current_turn_id == expected_turn_id
+            ) {
+                debug!(
+                    "RAII guard resetting stuck Processing state to Idle: session_id={}, turn_id={}",
+                    session_id, expected_turn_id
+                );
+                session.state = SessionState::Idle;
+                session.updated_at = SystemTime::now();
+                session.last_activity_at = SystemTime::now();
+            }
+        }
+    }
+
     /// Update session state
     pub async fn update_session_state(
         &self,
@@ -889,32 +1050,93 @@ impl SessionManager {
     ) -> BitFunResult<()> {
         let effective_path = self.effective_session_workspace_path(session_id).await;
 
-        if let Some(mut session) = self.sessions.get_mut(session_id) {
+        // IMPORTANT: keep the DashMap guard scope short -- do NOT hold it across .await.
+        // Collect the data needed for persistence, then release the guard before doing I/O.
+        let should_persist = if let Some(mut session) = self.sessions.get_mut(session_id) {
             session.state = new_state.clone();
             session.updated_at = SystemTime::now();
             session.last_activity_at = SystemTime::now();
 
-            // Persist state changes
-            if self.config.enable_persistence && Self::should_persist_session(&session) {
-                if let Some(ref workspace_path) = effective_path {
-                    self.persistence_manager
-                        .save_session_state(workspace_path, session_id, &new_state)
-                        .await?;
-                }
-            }
-
-            debug!(
-                "Updated session state: session_id={}, state={:?}",
-                session_id, new_state
-            );
+            let persist = self.config.enable_persistence && Self::should_persist_session(&session);
+            persist
         } else {
             return Err(BitFunError::NotFound(format!(
                 "Session not found: {}",
                 session_id
             )));
+        };
+        // RefMut guard released here -- DashMap shard lock is free.
+
+        // Persist state changes outside the guard scope.
+        if should_persist {
+            if let Some(ref workspace_path) = effective_path {
+                self.persistence_manager
+                    .save_session_state(workspace_path, session_id, &new_state)
+                    .await?;
+            }
         }
 
+        debug!(
+            "Updated session state: session_id={}, state={:?}",
+            session_id, new_state
+        );
+
         Ok(())
+    }
+
+    /// Update session state only when the session is still processing the
+    /// expected turn. Returns `true` when the state was updated.
+    pub async fn update_session_state_for_turn_if_processing(
+        &self,
+        session_id: &str,
+        expected_turn_id: &str,
+        new_state: SessionState,
+    ) -> BitFunResult<bool> {
+        let effective_path = self.effective_session_workspace_path(session_id).await;
+
+        let should_persist = if let Some(mut session) = self.sessions.get_mut(session_id) {
+            let owns_processing_turn = matches!(
+                &session.state,
+                SessionState::Processing {
+                    current_turn_id,
+                    ..
+                } if current_turn_id == expected_turn_id
+            );
+
+            if !owns_processing_turn {
+                debug!(
+                    "Skipped session state update for stale turn: session_id={}, expected_turn_id={}, current_state={:?}",
+                    session_id, expected_turn_id, session.state
+                );
+                return Ok(false);
+            }
+
+            session.state = new_state.clone();
+            session.updated_at = SystemTime::now();
+            session.last_activity_at = SystemTime::now();
+
+            self.config.enable_persistence && Self::should_persist_session(&session)
+        } else {
+            return Err(BitFunError::NotFound(format!(
+                "Session not found: {}",
+                session_id
+            )));
+        };
+
+        if should_persist {
+            if let Some(ref workspace_path) = effective_path {
+                self.persistence_manager
+                    .save_session_state(workspace_path, session_id, &new_state)
+                    .await?;
+            }
+        }
+
+        debug!(
+            "Updated session state for turn: session_id={}, turn_id={}, state={:?}",
+            session_id, expected_turn_id, new_state
+        );
+
+        Ok(true)
     }
 
     /// Update session title (in-memory + persistence)
@@ -941,14 +1163,19 @@ impl SessionManager {
                     session_id
                 )));
             };
-            let Some(session) = self.sessions.get(session_id) else {
-                return Err(BitFunError::NotFound(format!(
-                    "Session not found: {}",
-                    session_id
-                )));
+            // Clone the session data out of the DashMap guard before awaiting I/O.
+            let session_snapshot = {
+                let Some(session) = self.sessions.get(session_id) else {
+                    return Err(BitFunError::NotFound(format!(
+                        "Session not found: {}",
+                        session_id
+                    )));
+                };
+                session.clone()
             };
+            // Ref guard released -- DashMap shard lock is free.
             self.persistence_manager
-                .save_session(workspace_path, &session)
+                .save_session(workspace_path, &session_snapshot)
                 .await?;
         }
 
@@ -1007,9 +1234,9 @@ impl SessionManager {
 
         if self.should_persist_session_id(session_id) {
             let effective_path = self.effective_session_workspace_path(session_id).await;
-            if let (Some(workspace_path), Some(session)) =
-                (effective_path, self.sessions.get(session_id))
-            {
+            let session_snapshot = self.sessions.get(session_id).map(|s| s.clone());
+            // Ref guard released -- DashMap shard lock is free.
+            if let (Some(workspace_path), Some(session)) = (effective_path, session_snapshot) {
                 self.persistence_manager
                     .save_session(&workspace_path, &session)
                     .await?;
@@ -1033,14 +1260,16 @@ impl SessionManager {
         // If the session was evicted from memory (idle > 1h), try to restore it
         // using the workspace path recorded when it was first created/restored.
         if !self.sessions.contains_key(session_id) && self.config.enable_persistence {
-            if let Some(workspace_path) = self.session_workspace_index.get(session_id) {
+            let workspace_path = self
+                .session_workspace_index
+                .get(session_id)
+                .map(|entry| entry.clone());
+            if let Some(workspace_path) = workspace_path {
                 debug!(
                     "Session evicted from memory, restoring for model update: session_id={}",
                     session_id
                 );
-                let _ = self
-                    .restore_session(&workspace_path.clone(), session_id)
-                    .await;
+                let _ = self.restore_session(&workspace_path, session_id).await;
             }
         }
 
@@ -1057,9 +1286,9 @@ impl SessionManager {
 
         if self.should_persist_session_id(session_id) {
             let effective_path = self.effective_session_workspace_path(session_id).await;
-            if let (Some(workspace_path), Some(session)) =
-                (effective_path, self.sessions.get(session_id))
-            {
+            let session_snapshot = self.sessions.get(session_id).map(|s| s.clone());
+            // Ref guard released -- DashMap shard lock is free.
+            if let (Some(workspace_path), Some(session)) = (effective_path, session_snapshot) {
                 self.persistence_manager
                     .save_session(&workspace_path, &session)
                     .await?;
@@ -1397,7 +1626,8 @@ impl SessionManager {
         self.context_store.replace_context(session_id, messages);
 
         // 3) Truncate session turn list & persist
-        if let Some(mut session) = self.sessions.get_mut(session_id) {
+        // IMPORTANT: keep the DashMap guard scope short -- do NOT hold it across .await.
+        let session_snapshot = if let Some(mut session) = self.sessions.get_mut(session_id) {
             if session.dialog_turn_ids.len() > target_turn {
                 session.dialog_turn_ids.truncate(target_turn);
             }
@@ -1405,11 +1635,22 @@ impl SessionManager {
             session.updated_at = SystemTime::now();
             session.last_activity_at = SystemTime::now();
 
-            if Self::should_persist_session(&session) && self.config.enable_persistence {
-                self.persistence_manager
-                    .save_session(workspace_path, &session)
-                    .await?;
+            let should_persist =
+                Self::should_persist_session(&session) && self.config.enable_persistence;
+            if should_persist {
+                Some(session.clone())
+            } else {
+                None
             }
+        } else {
+            None
+        };
+        // RefMut guard released here -- DashMap shard lock is free.
+
+        if let Some(session) = session_snapshot {
+            self.persistence_manager
+                .save_session(workspace_path, &session)
+                .await?;
         }
 
         // 4) Delete snapshots from target_turn (inclusive) onwards
@@ -1510,7 +1751,10 @@ impl SessionManager {
                 },
             );
 
-            if let Some(session) = self.sessions.get(session_id) {
+            // Clone the session data out of the DashMap guard before awaiting I/O.
+            let session_snapshot = self.sessions.get(session_id).map(|s| s.clone());
+            // Ref guard released -- DashMap shard lock is free.
+            if let Some(session) = session_snapshot {
                 self.persistence_manager
                     .save_session(&workspace_path, &session)
                     .await?;
@@ -2045,7 +2289,8 @@ impl SessionManager {
         self.context_store
             .add_message(child_session_id, assistant_message);
 
-        if let Some(mut session) = self.sessions.get_mut(child_session_id) {
+        // IMPORTANT: keep the DashMap guard scope short -- do NOT hold it across .await.
+        let session_snapshot = if let Some(mut session) = self.sessions.get_mut(child_session_id) {
             if !session
                 .dialog_turn_ids
                 .iter()
@@ -2057,10 +2302,19 @@ impl SessionManager {
             session.last_activity_at = SystemTime::now();
 
             if self.config.enable_persistence && Self::should_persist_session(&session) {
-                self.persistence_manager
-                    .save_session(workspace_path, &session)
-                    .await?;
+                Some(session.clone())
+            } else {
+                None
             }
+        } else {
+            None
+        };
+        // RefMut guard released here -- DashMap shard lock is free.
+
+        if let Some(session) = session_snapshot {
+            self.persistence_manager
+                .save_session(workspace_path, &session)
+                .await?;
         }
 
         self.persist_context_snapshot_for_turn_best_effort(
@@ -2151,24 +2405,33 @@ impl SessionManager {
     ) -> BitFunResult<()> {
         let effective_path = self.effective_session_workspace_path(session_id).await;
 
-        if let Some(mut session) = self.sessions.get_mut(session_id) {
+        // IMPORTANT: keep the DashMap guard scope short -- do NOT hold it across .await.
+        let session_snapshot = if let Some(mut session) = self.sessions.get_mut(session_id) {
             session.compression_state = compression_state;
             session.updated_at = SystemTime::now();
             session.last_activity_at = SystemTime::now();
             if self.config.enable_persistence && Self::should_persist_session(&session) {
-                if let Some(ref workspace_path) = effective_path {
-                    self.persistence_manager
-                        .save_session(workspace_path, &session)
-                        .await?;
-                }
+                Some(session.clone())
+            } else {
+                None
             }
-            Ok(())
         } else {
-            Err(BitFunError::NotFound(format!(
+            return Err(BitFunError::NotFound(format!(
                 "Session not found: {}",
                 session_id
-            )))
+            )));
+        };
+        // RefMut guard released here -- DashMap shard lock is free.
+
+        if let Some(session) = session_snapshot {
+            if let Some(ref workspace_path) = effective_path {
+                self.persistence_manager
+                    .save_session(workspace_path, &session)
+                    .await?;
+            }
         }
+
+        Ok(())
     }
 
     async fn try_generate_session_title_with_ai(

--- a/src/crates/core/src/agentic/tools/browser_control/browser_launcher.rs
+++ b/src/crates/core/src/agentic/tools/browser_control/browser_launcher.rs
@@ -197,7 +197,9 @@ impl BrowserLauncher {
 
         // Check cache first.
         {
-            let cache = BROWSER_INSTALL_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+            let cache = BROWSER_INSTALL_CACHE
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             if let Some(ref map) = *cache {
                 if let Some(&cached) = map.get(&cache_key) {
                     return cached;
@@ -210,7 +212,9 @@ impl BrowserLauncher {
 
         // Store in cache.
         {
-            let mut cache = BROWSER_INSTALL_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+            let mut cache = BROWSER_INSTALL_CACHE
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             let map = cache.get_or_insert_with(HashMap::new);
             map.insert(cache_key, result);
         }
@@ -244,7 +248,9 @@ impl BrowserLauncher {
     /// browser installations might have changed.
     #[cfg(test)]
     pub fn clear_install_cache() {
-        let mut cache = BROWSER_INSTALL_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        let mut cache = BROWSER_INSTALL_CACHE
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         *cache = None;
     }
 
@@ -277,7 +283,13 @@ impl BrowserLauncher {
             BrowserKind::Arc => "arc".to_string(),
             BrowserKind::Unknown(name) => name
                 .chars()
-                .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+                .map(|c| {
+                    if c.is_ascii_alphanumeric() {
+                        c.to_ascii_lowercase()
+                    } else {
+                        '-'
+                    }
+                })
                 .collect::<String>()
                 .trim_matches('-')
                 .to_string(),
@@ -315,7 +327,11 @@ impl BrowserLauncher {
     }
 
     #[cfg(target_os = "macos")]
-    fn spawn_macos_browser(kind: &BrowserKind, exe: &str, args: &[String]) -> std::io::Result<std::process::Child> {
+    fn spawn_macos_browser(
+        kind: &BrowserKind,
+        exe: &str,
+        args: &[String],
+    ) -> std::io::Result<std::process::Child> {
         if let Some(app_name) = Self::launch_app_name(kind) {
             let mut command = silent_command("open");
             command.args(["-na", app_name, "--args"]);
@@ -327,12 +343,20 @@ impl BrowserLauncher {
     }
 
     #[cfg(not(target_os = "macos"))]
-    fn spawn_browser(_kind: &BrowserKind, exe: &str, args: &[String]) -> std::io::Result<std::process::Child> {
+    fn spawn_browser(
+        _kind: &BrowserKind,
+        exe: &str,
+        args: &[String],
+    ) -> std::io::Result<std::process::Child> {
         silent_command(exe).args(args).spawn()
     }
 
     #[cfg(target_os = "macos")]
-    fn spawn_browser(kind: &BrowserKind, exe: &str, args: &[String]) -> std::io::Result<std::process::Child> {
+    fn spawn_browser(
+        kind: &BrowserKind,
+        exe: &str,
+        args: &[String],
+    ) -> std::io::Result<std::process::Child> {
         Self::spawn_macos_browser(kind, exe, args)
     }
 

--- a/src/crates/core/src/agentic/tools/implementations/bash_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/bash_tool.rs
@@ -272,6 +272,7 @@ impl BashTool {
         interrupted: bool,
         timed_out: bool,
         exit_code: i32,
+        shell_state: Option<&str>,
     ) -> String {
         let mut result_string = String::new();
 
@@ -297,6 +298,14 @@ impl BashTool {
             } else {
                 result_string.push_str(&format!("<output>{}</output>", cleaned_output));
             }
+        }
+
+        // Post-command terminal state: shows what the shell displayed after the
+        // command finished (e.g., prompt, continuation prompt, or other state).
+        // This gives AI the full picture of the terminal context.
+        if let Some(state) = shell_state {
+            let cleaned_state = strip_ansi(state);
+            result_string.push_str(&format!("<shell_state>{}</shell_state>", cleaned_state));
         }
 
         // Interruption notice
@@ -908,6 +917,7 @@ Usage notes:
         let mut final_exit_code: Option<i32> = None;
         let mut was_interrupted = false;
         let mut timed_out = false;
+        let mut final_shell_state: Option<String> = None;
         let mut command_started_after_ms: Option<u64> = None;
         let mut completion_reason_label = "stream_end".to_string();
         let mut interrupt_drain_deadline: Option<tokio::time::Instant> = None;
@@ -991,6 +1001,7 @@ Usage notes:
                     exit_code,
                     total_output,
                     completion_reason,
+                    shell_state,
                 } => {
                     debug!(
                         "Bash command completed, exit_code: {:?}, tool_id: {}",
@@ -1006,6 +1017,11 @@ Usage notes:
 
                     if !total_output.is_empty() {
                         accumulated_output = total_output;
+                    }
+
+                    // Capture post-command terminal state for the AI agent
+                    if shell_state.is_some() {
+                        final_shell_state = shell_state;
                     }
                     break;
                 }
@@ -1059,6 +1075,7 @@ Usage notes:
             was_interrupted,
             timed_out,
             final_exit_code.unwrap_or(-1),
+            final_shell_state.as_deref(),
         );
 
         Ok(vec![ToolResult::Result {
@@ -1334,7 +1351,8 @@ mod tests {
         let long_output =
             "prefix\n".to_string() + &"y".repeat(MAX_OUTPUT_LENGTH + 100) + "\nfinal-error";
 
-        let rendered = tool.render_result("session-1", "/repo", &long_output, false, false, 1);
+        let rendered =
+            tool.render_result("session-1", "/repo", &long_output, false, false, 1, None);
 
         assert!(rendered.contains("<output truncated=\"true\">"));
         assert!(rendered.contains("tail preserved"));
@@ -1378,6 +1396,7 @@ mod tests {
             false,
             false,
             1,
+            None,
         );
 
         assert!(rendered.contains("<exit_code>1</exit_code>"));

--- a/src/crates/core/src/agentic/tools/pipeline/state_manager.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/state_manager.rs
@@ -61,7 +61,7 @@ impl ToolStateManager {
 
     /// Update task state
     pub async fn update_state(&self, tool_id: &str, new_state: ToolExecutionState) {
-        if let Some(mut task) = self.tasks.get_mut(tool_id) {
+        let task_for_event = if let Some(mut task) = self.tasks.get_mut(tool_id) {
             let old_state = task.state.clone();
             task.state = new_state.clone();
 
@@ -85,8 +85,13 @@ impl ToolStateManager {
                 format!("{:?}", new_state).split('{').next().unwrap_or("")
             );
 
-            // Send state change event
-            self.emit_state_change_event(task.clone()).await;
+            Some(task.clone())
+        } else {
+            None
+        };
+
+        if let Some(task) = task_for_event {
+            self.emit_state_change_event(task).await;
         }
     }
 
@@ -280,6 +285,82 @@ impl ToolStateManager {
         }
 
         stats
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::types::{ToolExecutionContext, ToolExecutionOptions, ToolTask};
+    use super::*;
+    use crate::agentic::core::ToolCall;
+    use crate::agentic::events::EventQueueConfig;
+    use std::collections::HashMap;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    fn test_task(tool_id: &str) -> ToolTask {
+        ToolTask::new(
+            ToolCall {
+                tool_id: tool_id.to_string(),
+                tool_name: "test_tool".to_string(),
+                arguments: serde_json::json!({}),
+                raw_arguments: None,
+                is_error: false,
+            },
+            ToolExecutionContext {
+                session_id: "session-1".to_string(),
+                dialog_turn_id: "turn-1".to_string(),
+                agent_type: "agentic".to_string(),
+                workspace: None,
+                context_vars: HashMap::new(),
+                subagent_parent_info: None,
+                allowed_tools: Vec::new(),
+                runtime_tool_restrictions: Default::default(),
+                steering_interrupt: None,
+                workspace_services: None,
+            },
+            ToolExecutionOptions::default(),
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_state_does_not_hold_task_lock_while_emitting_event() {
+        let event_queue = Arc::new(EventQueue::new(EventQueueConfig::default()));
+        let manager = Arc::new(ToolStateManager::new(event_queue.clone()));
+        let tool_id = manager.create_task(test_task("tool-1")).await;
+
+        let queue_guard = event_queue.lock_queue_for_test().await;
+        let update_manager = manager.clone();
+        let update_tool_id = tool_id.clone();
+        let update_handle = tokio::spawn(async move {
+            update_manager
+                .update_state(
+                    &update_tool_id,
+                    ToolExecutionState::Running {
+                        started_at: std::time::SystemTime::now(),
+                        progress: None,
+                    },
+                )
+                .await;
+        });
+
+        tokio::task::yield_now().await;
+
+        let read_manager = manager.clone();
+        let read_tool_id = tool_id.clone();
+        let read_handle = tokio::task::spawn_blocking(move || read_manager.get_task(&read_tool_id));
+
+        let task = timeout(Duration::from_millis(100), read_handle)
+            .await
+            .expect("reading task state should not wait for event emission")
+            .expect("blocking task should complete");
+        assert!(task.is_some());
+
+        drop(queue_guard);
+        timeout(Duration::from_secs(1), update_handle)
+            .await
+            .expect("state update should finish after event queue is released")
+            .expect("state update task should not panic");
     }
 }
 

--- a/src/crates/core/src/service/search/flashgrep/client.rs
+++ b/src/crates/core/src/service/search/flashgrep/client.rs
@@ -579,12 +579,11 @@ impl AsyncDaemonClient {
                 wait_result?;
                 Ok(())
             }
-            Err(_) => process_manager::terminate_child_process_tree(
-                child,
-                Duration::from_millis(750),
-            )
-            .await
-            .map_err(AppError::Io),
+            Err(_) => {
+                process_manager::terminate_child_process_tree(child, Duration::from_millis(750))
+                    .await
+                    .map_err(AppError::Io)
+            }
         }
     }
 

--- a/src/crates/core/src/service/search/service.rs
+++ b/src/crates/core/src/service/search/service.rs
@@ -304,25 +304,29 @@ impl WorkspaceSearchService {
         let service = Arc::clone(self);
         match std::thread::Builder::new()
             .name("workspace-search-shutdown".to_string())
-            .spawn(move || match tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            {
-                Ok(runtime) => {
-                    runtime.block_on(async move {
-                        service.shutdown_all_daemons().await;
-                    });
-                }
-                Err(error) => {
-                    log::warn!(
-                        "Failed to create runtime for workspace search shutdown: {}",
-                        error
-                    );
+            .spawn(move || {
+                match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => {
+                        runtime.block_on(async move {
+                            service.shutdown_all_daemons().await;
+                        });
+                    }
+                    Err(error) => {
+                        log::warn!(
+                            "Failed to create runtime for workspace search shutdown: {}",
+                            error
+                        );
+                    }
                 }
             }) {
             Ok(handle) => {
                 if handle.join().is_err() {
-                    log::warn!("Workspace search shutdown thread panicked during blocking shutdown");
+                    log::warn!(
+                        "Workspace search shutdown thread panicked during blocking shutdown"
+                    );
                 }
             }
             Err(error) => {

--- a/src/crates/core/src/service/session_usage/render.rs
+++ b/src/crates/core/src/service/session_usage/render.rs
@@ -192,7 +192,9 @@ pub fn render_usage_report_markdown(report: &SessionUsageReport) -> String {
 
     if !report.models.is_empty() {
         out.push_str("## Models\n\n");
-        out.push_str("| Model | Calls | Input | Output | Total |\n| --- | ---: | ---: | ---: | ---: |\n");
+        out.push_str(
+            "| Model | Calls | Input | Output | Total |\n| --- | ---: | ---: | ---: | ---: |\n",
+        );
         for model in &report.models {
             out.push_str(&format!(
                 "| {} | {} | {} | {} | {} |\n",

--- a/src/crates/core/src/service/terminal/src/session/manager.rs
+++ b/src/crates/core/src/service/terminal/src/session/manager.rs
@@ -79,6 +79,12 @@ pub enum CommandStreamEvent {
         exit_code: Option<i32>,
         total_output: String,
         completion_reason: CommandCompletionReason,
+        /// Post-command terminal state: the most recent terminal output that
+        /// was NOT part of the command's own output. This includes the shell
+        /// prompt (e.g., `$ `, `dquote> `) and any other text the shell
+        /// displayed after the command finished. AI agents can use this to
+        /// understand the full terminal context and avoid misjudgments.
+        shell_state: Option<String>,
     },
     /// Command execution failed
     Error { message: String },
@@ -112,6 +118,25 @@ async fn get_integration_output_snapshot(
         .get(session_id)
         .map(|i| i.get_output().to_string())
         .unwrap_or_default()
+}
+
+/// Get the post-command terminal state from shell integration.
+/// Returns the most recent terminal output that was NOT part of the command's
+/// own output — typically the shell prompt (e.g., `$ `, `dquote> `) or any
+/// other text the shell displayed after the command finished.
+async fn get_post_command_terminal_state(
+    session_integrations: &Arc<RwLock<HashMap<String, ShellIntegration>>>,
+    session_id: &str,
+) -> Option<String> {
+    let integrations = session_integrations.read().await;
+    integrations.get(session_id).and_then(|i| {
+        let recent = i.get_recent_plain_output().trim().to_string();
+        if recent.is_empty() {
+            None
+        } else {
+            Some(recent)
+        }
+    })
 }
 
 /// Session manager for terminal sessions
@@ -785,6 +810,7 @@ impl SessionManager {
                     exit_code,
                     total_output,
                     completion_reason,
+                    shell_state: _,
                 } => {
                     if !total_output.is_empty() {
                         output = total_output;
@@ -953,10 +979,14 @@ impl SessionManager {
                         let output =
                             get_integration_output_snapshot(&session_integrations, &session_id)
                                 .await;
+                        let shell_state =
+                            get_post_command_terminal_state(&session_integrations, &session_id)
+                                .await;
                         send(CommandStreamEvent::Completed {
                             exit_code: finished_exit_code.flatten(),
                             total_output: output,
                             completion_reason: CommandCompletionReason::TimedOut,
+                            shell_state,
                         })
                         .await;
                         return;
@@ -1015,6 +1045,11 @@ impl SessionManager {
                             if output_len == last_output_len {
                                 post_finish_idle_count += 1;
                                 if post_finish_idle_count >= post_finish_idle_required {
+                                    let shell_state = get_post_command_terminal_state(
+                                        &session_integrations,
+                                        &session_id,
+                                    )
+                                    .await;
                                     send(CommandStreamEvent::Completed {
                                         exit_code: finished_exit_code.flatten(),
                                         total_output: output,
@@ -1023,6 +1058,7 @@ impl SessionManager {
                                         } else {
                                             CommandCompletionReason::Completed
                                         },
+                                        shell_state,
                                     })
                                     .await;
                                     return;
@@ -1041,6 +1077,11 @@ impl SessionManager {
                                 post_finish_idle_count += 1;
                                 // Wait at least 10 poll cycles (500ms) after seeing Prompt to ensure all output arrived
                                 if post_finish_idle_count >= 10 {
+                                    let shell_state = get_post_command_terminal_state(
+                                        &session_integrations,
+                                        &session_id,
+                                    )
+                                    .await;
                                     send(CommandStreamEvent::Completed {
                                         exit_code: finished_exit_code.flatten(),
                                         total_output: output,
@@ -1049,6 +1090,7 @@ impl SessionManager {
                                         } else {
                                             CommandCompletionReason::Completed
                                         },
+                                        shell_state,
                                     })
                                     .await;
                                     return;
@@ -1063,6 +1105,11 @@ impl SessionManager {
                             if output_len == last_output_len {
                                 idle_count += 1;
                                 if idle_count >= max_idle_checks {
+                                    let shell_state = get_post_command_terminal_state(
+                                        &session_integrations,
+                                        &session_id,
+                                    )
+                                    .await;
                                     send(CommandStreamEvent::Completed {
                                         exit_code: None,
                                         total_output: output,
@@ -1071,6 +1118,7 @@ impl SessionManager {
                                         } else {
                                             CommandCompletionReason::Completed
                                         },
+                                        shell_state,
                                     })
                                     .await;
                                     return;

--- a/src/crates/core/src/service/terminal/src/shell/integration.rs
+++ b/src/crates/core/src/service/terminal/src/shell/integration.rs
@@ -120,6 +120,12 @@ pub struct ShellIntegration {
     /// When true, we are between PromptStart and CommandInputStart,
     /// checking whether prompt text exists to detect ConPTY reordering.
     detecting_conpty_reorder: bool,
+    /// Buffer for plain text that was NOT collected by shell integration
+    /// (i.e., output received while `should_collect()` returned false).
+    /// This captures the terminal state after command execution, including
+    /// prompts (e.g., `$ `, `dquote> `) and other non-command output.
+    /// Cleared when a new command starts executing.
+    recent_plain_output: String,
 }
 
 impl ShellIntegration {
@@ -140,6 +146,7 @@ impl ShellIntegration {
             command_just_finished: false,
             post_command_collecting: false,
             detecting_conpty_reorder: false,
+            recent_plain_output: String::new(),
         }
     }
 
@@ -195,6 +202,13 @@ impl ShellIntegration {
         self.output_buffer.clear();
     }
 
+    /// Get recent plain text that was NOT collected by shell integration.
+    /// This captures terminal state after command execution, including
+    /// prompts (e.g., `$ `, `dquote> `) and other non-command output.
+    pub fn get_recent_plain_output(&self) -> &str {
+        &self.recent_plain_output
+    }
+
     /// Process incoming data and extract events
     pub fn process_data(&mut self, data: &str) -> Vec<ShellIntegrationEvent> {
         let mut events = Vec::new();
@@ -220,14 +234,22 @@ impl ShellIntegration {
                             seq,
                             OscSequence::CommandFinished { .. } | OscSequence::PromptStart
                         );
-                        if should_flush && !plain_output.is_empty() && self.should_collect() {
-                            self.output_buffer.push_str(&plain_output);
-                            if let Some(cmd_id) = &self.current_command_id {
-                                events.push(ShellIntegrationEvent::OutputData {
-                                    command_id: cmd_id.clone(),
-                                    data: std::mem::take(&mut plain_output),
-                                });
+                        if should_flush && !plain_output.is_empty() {
+                            if self.should_collect() {
+                                self.output_buffer.push_str(&plain_output);
+                                if let Some(cmd_id) = &self.current_command_id {
+                                    events.push(ShellIntegrationEvent::OutputData {
+                                        command_id: cmd_id.clone(),
+                                        data: std::mem::take(&mut plain_output),
+                                    });
+                                } else {
+                                    plain_output.clear();
+                                }
                             } else {
+                                // Not collecting output (e.g., shell is showing prompt
+                                // or in continuation mode). Capture this text so the
+                                // AI agent can see the full terminal state.
+                                self.recent_plain_output.push_str(&plain_output);
                                 plain_output.clear();
                             }
                         }
@@ -273,14 +295,19 @@ impl ShellIntegration {
         // Accumulate plain output if we should collect output.
         // Continue collecting after Finished via post_command_collecting flag,
         // because ConPTY may deliver rendered output after shell integration sequences.
-        if !plain_output.is_empty() && self.should_collect() {
-            self.output_buffer.push_str(&plain_output);
+        if !plain_output.is_empty() {
+            if self.should_collect() {
+                self.output_buffer.push_str(&plain_output);
 
-            if let Some(cmd_id) = &self.current_command_id {
-                events.push(ShellIntegrationEvent::OutputData {
-                    command_id: cmd_id.clone(),
-                    data: plain_output,
-                });
+                if let Some(cmd_id) = &self.current_command_id {
+                    events.push(ShellIntegrationEvent::OutputData {
+                        command_id: cmd_id.clone(),
+                        data: plain_output,
+                    });
+                }
+            } else {
+                // Not collecting output — capture as recent terminal state
+                self.recent_plain_output.push_str(&plain_output);
             }
         }
 
@@ -393,6 +420,7 @@ impl ShellIntegration {
             OscSequence::CommandExecutionStart => {
                 self.state = CommandState::Executing;
                 self.output_buffer.clear();
+                self.recent_plain_output.clear();
                 // Clear previous command's exit code when new command starts
                 self.last_exit_code = None;
                 self.command_just_finished = false;
@@ -689,5 +717,29 @@ mod tests {
         assert_eq!(integration.unescape_value("hello"), "hello");
         assert_eq!(integration.unescape_value("hello\\\\world"), "hello\\world");
         assert_eq!(integration.unescape_value("hello\\x3bworld"), "hello;world");
+    }
+
+    #[test]
+    fn post_command_prompt_is_recorded_as_recent_plain_output() {
+        let mut integration = ShellIntegration::new();
+
+        integration.process_data("\x1b]633;E;printf test;nonce123\x07");
+        integration.process_data("\x1b]633;C\x07");
+        integration.process_data("test\n");
+        integration.process_data("\x1b]633;D;0\x07\x1b]633;A\x07$ \x1b]633;B\x07");
+
+        assert_eq!(integration.get_output(), "test\n");
+        assert_eq!(integration.get_recent_plain_output(), "$ ");
+    }
+
+    #[test]
+    fn continuation_prompt_is_recorded_as_recent_plain_output() {
+        let mut integration = ShellIntegration::new();
+
+        integration.process_data("\x1b]633;A\x07$ \x1b]633;B\x07");
+        integration.process_data("\x1b]633;F\x07dquote> ");
+
+        assert_eq!(integration.get_output(), "");
+        assert_eq!(integration.get_recent_plain_output(), "$ dquote> ");
     }
 }

--- a/src/crates/core/src/util/process_manager.rs
+++ b/src/crates/core/src/util/process_manager.rs
@@ -168,19 +168,21 @@ pub async fn terminate_child_process_tree(
 pub fn spawn_child_process_tree_cleanup(child: Child, graceful_timeout: Duration) {
     let _ = std::thread::Builder::new()
         .name("process-tree-cleanup".to_string())
-        .spawn(move || match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(runtime) => {
-                runtime.block_on(async move {
+        .spawn(move || {
+            match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => {
+                    runtime.block_on(async move {
+                        let mut child = child;
+                        let _ = terminate_child_process_tree(&mut child, graceful_timeout).await;
+                    });
+                }
+                Err(_) => {
                     let mut child = child;
-                    let _ = terminate_child_process_tree(&mut child, graceful_timeout).await;
-                });
-            }
-            Err(_) => {
-                let mut child = child;
-                let _ = child.start_kill();
+                    let _ = child.start_kill();
+                }
             }
         });
 }


### PR DESCRIPTION
## Summary
- Tighten session turn ownership so stale turns cannot overwrite newer processing state during completion, cancellation, or failure cleanup.
- Register and preserve cancellation tokens early enough for pre-round cancellation, and check cancellation before opening model streams.
- Avoid DashMap guards across awaits and keep terminal post-command shell state separate from command output.

## Test plan
- [x] cargo test -p bitfun-core cancel_keeps_token_registered_until_cleanup -- --nocapture
- [x] cargo test -p bitfun-core update_session_state_for_turn_if_processing -- --nocapture
- [x] cargo check --workspace
- [x] cargo test --workspace
- [x] pnpm run lint:web
- [x] pnpm run type-check:web
- [x] pnpm --dir src/web-ui run test:run
- [x] git diff --check