### PR TITLE
fix: subagent timeout disable button not working due to serde format mismatch

### DIFF
--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -522,10 +522,10 @@ export class AgentAPI {
     action: { type: 'disable' } | { type: 'restore' } | { type: 'extend'; seconds: number },
   ): Promise<void> {
     const actionPayload = action.type === 'disable'
-      ? 'Disable'
+      ? { type: 'Disable', payload: null }
       : action.type === 'restore'
-        ? 'Restore'
-        : { Extend: { seconds: action.seconds } };
+        ? { type: 'Restore', payload: null }
+        : { type: 'Extend', payload: { seconds: action.seconds } };
     try {
       await api.invoke<void>('set_subagent_timeout', {
         request: { session_id: sessionId, action: actionPayload },


### PR DESCRIPTION
## Problem

When clicking the disable timeout button on a subagent timeout tag, the timeout was not actually disabled -- the subagent would still time out after the original deadline.

## Root Cause

The frontend AgentAPI.setSubagentTimeout was sending payloads in a format that did not match the Rust backend DTO:

- Backend SetSubagentTimeoutActionDTO uses #[serde(tag = "type", content = "payload")] (adjacently-tagged enum), expecting: { "type": "Disable", "payload": null }
- Frontend was sending bare strings "Disable" / "Restore" and internally-tagged objects { "Extend": { "seconds": 120 } }, which serde could not deserialize

This caused the Tauri command to fail silently, so the timeout was never disabled on the backend.

## Fix

Changed the frontend payload construction in AgentAPI.ts to use the correct adjacently-tagged format:

- Before: 'Disable' / 'Restore' / { Extend: { seconds } }
- After: { type: 'Disable', payload: null } / { type: 'Restore', payload: null } / { type: 'Extend', payload: { seconds } }

## Testing

- pnpm run type-check:web passed
- Business logic review verified the payload format matches the Rust serde definition correctly
