### PR TITLE
fix(web-ui): handle failed dialog completion in flow chat and notifications

### DIFF
--- a/src/web-ui/src/app/hooks/dialogCompletionNotifyPolicy.ts
+++ b/src/web-ui/src/app/hooks/dialogCompletionNotifyPolicy.ts
@@ -10,6 +10,8 @@ interface DialogCompletionNotificationInput {
 
 interface DialogCompletionNotificationCopyInput {
   sessionTitle?: string | null;
+  success?: boolean | null;
+  finishReason?: string | null;
   t: (key: string, options?: Record<string, unknown>) => string;
 }
 
@@ -41,14 +43,23 @@ export function shouldSendDialogCompletionNotification({
 
 export function buildDialogCompletionNotificationCopy({
   sessionTitle,
+  success,
+  finishReason,
   t,
 }: DialogCompletionNotificationCopyInput): { title: string; body: string } {
   const trimmedTitle = sessionTitle?.trim();
+  const failed = success === false;
+  const options = {
+    sessionTitle: trimmedTitle,
+    finishReason,
+  };
 
   return {
-    title: t('notify.dialogCompletedTitle'),
+    title: failed
+      ? t('notify.dialogFailedTitle')
+      : t('notify.dialogCompletedTitle'),
     body: trimmedTitle
-      ? t('notify.dialogCompletedWithSession', { sessionTitle: trimmedTitle })
-      : t('notify.dialogCompletedFallback'),
+      ? t(failed ? 'notify.dialogFailedWithSession' : 'notify.dialogCompletedWithSession', options)
+      : t(failed ? 'notify.dialogFailedFallback' : 'notify.dialogCompletedFallback', options),
   };
 }

--- a/src/web-ui/src/app/hooks/useDialogCompletionNotify.test.ts
+++ b/src/web-ui/src/app/hooks/useDialogCompletionNotify.test.ts
@@ -103,6 +103,20 @@ describe('shouldSendDialogCompletionNotification', () => {
       }),
     ).toBe(true);
   });
+
+  it('allows failed completion notifications in the background', () => {
+    expect(
+      shouldSendDialogCompletionNotification({
+        event: event({
+          success: false,
+          finishReason: 'empty_round',
+        }),
+        session: session(),
+        isBackground: true,
+        notificationsEnabled: true,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe('buildDialogCompletionNotificationCopy', () => {
@@ -110,6 +124,10 @@ describe('buildDialogCompletionNotificationCopy', () => {
     if (key === 'notify.dialogCompletedTitle') return 'BitFun finished a task';
     if (key === 'notify.dialogCompletedWithSession') {
       return `${options?.sessionTitle} is ready.`;
+    }
+    if (key === 'notify.dialogFailedTitle') return 'BitFun task stopped';
+    if (key === 'notify.dialogFailedWithSession') {
+      return `${options?.sessionTitle} stopped unexpectedly.`;
     }
     return 'A BitFun session is ready.';
   };
@@ -135,6 +153,20 @@ describe('buildDialogCompletionNotificationCopy', () => {
     ).toEqual({
       title: 'BitFun finished a task',
       body: 'A BitFun session is ready.',
+    });
+  });
+
+  it('uses failure copy when the backend completed with an unsuccessful result', () => {
+    expect(
+      buildDialogCompletionNotificationCopy({
+        sessionTitle: 'Browser control fix',
+        success: false,
+        finishReason: 'empty_round',
+        t,
+      }),
+    ).toEqual({
+      title: 'BitFun task stopped',
+      body: 'Browser control fix stopped unexpectedly.',
     });
   });
 });

--- a/src/web-ui/src/app/hooks/useDialogCompletionNotify.ts
+++ b/src/web-ui/src/app/hooks/useDialogCompletionNotify.ts
@@ -66,6 +66,8 @@ export const useDialogCompletionNotify = () => {
 
       const notificationCopy = buildDialogCompletionNotificationCopy({
         sessionTitle: session?.title,
+        success: event?.success,
+        finishReason: event?.finishReason ?? event?.finish_reason,
         t,
       });
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { normalizeSubagentParentInfo } from './subagentParentInfo';
 import {
   formatDialogErrorForNotification,
+  handleDialogTurnComplete,
   handleSessionStateChanged,
   insertSteeringItemIfAbsent,
   shouldProcessEvent,
@@ -15,10 +16,20 @@ import type { FlowChatContext } from './types';
 vi.mock('@/infrastructure/i18n/core/I18nService', () => ({
   i18nService: {
     t: (key: string) => ({
+      'errors:ai.unknown.title': 'AI request failed',
+      'errors:ai.unknown.message': 'The model stopped before returning a usable response. Try again or switch models.',
       'errors:ai.invalidRequest.title': 'Model request invalid',
       'errors:ai.invalidRequest.message': 'The provider rejected the request format, parameters, model name, or payload size. Adjust the request or choose another model.',
       'errors:ai.actions.copyDiagnostics': 'Copy diagnostics',
     }[key] ?? key),
+  },
+}));
+
+vi.mock('../../../shared/notification-system/services/NotificationService', () => ({
+  notificationService: {
+    error: vi.fn(),
+    warning: vi.fn(),
+    success: vi.fn(),
   },
 }));
 
@@ -401,6 +412,41 @@ describe('handleSessionStateChanged', () => {
       .sessions.get('session-1')
       ?.dialogTurns[0];
     expect(turn?.status).toBe('completed');
+    expect(stateMachineManager.getCurrentState('session-1')).toBe(SessionExecutionState.IDLE);
+  });
+});
+
+describe('handleDialogTurnComplete', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetFlowChatStore();
+    stateMachineManager.clear();
+  });
+
+  afterEach(() => {
+    resetFlowChatStore();
+    stateMachineManager.clear();
+  });
+
+  it('treats unsuccessful completed events as errors instead of normal completion', async () => {
+    putFinishingSessionInStore();
+    const context = createFlowChatContext();
+    await setFinishingMachine();
+
+    handleDialogTurnComplete(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      success: false,
+      finishReason: 'empty_round',
+    }, vi.fn());
+
+    const turn = FlowChatStore.getInstance()
+      .getState()
+      .sessions.get('session-1')
+      ?.dialogTurns[0];
+
+    expect(turn?.status).toBe('error');
+    expect(turn?.error).toContain('empty response');
     expect(stateMachineManager.getCurrentState('session-1')).toBe(SessionExecutionState.IDLE);
   });
 });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -1707,7 +1707,17 @@ function handleCompressionFailed(context: FlowChatContext, event: any): void {
 /**
  * Handle dialog turn completed event
  */
-function handleDialogTurnComplete(
+function buildUnsuccessfulCompletionError(finishReason?: string): string {
+  if (finishReason === 'empty_round') {
+    return 'Model returned an empty response after retrying. finish_reason=empty_round';
+  }
+
+  return finishReason
+    ? `Dialog turn ended without a usable result. finish_reason=${finishReason}`
+    : 'Dialog turn ended without a usable result.';
+}
+
+export function handleDialogTurnComplete(
   context: FlowChatContext,
   event: any,
   _onTodoWriteResult: (sessionId: string, turnId: string, result: any) => void
@@ -1723,13 +1733,33 @@ function handleDialogTurnComplete(
   if (subagentParentInfo) {
     if (sessionId) {
       attachSubagentSessionToParentTool(subagentParentInfo, sessionId);
-      settleSubagentItems(context, subagentParentInfo, sessionId, 'completed');
+      if (success === false) {
+        settleSubagentItems(
+          context,
+          subagentParentInfo,
+          sessionId,
+          'error',
+          buildUnsuccessfulCompletionError(finishReason),
+        );
+      } else {
+        settleSubagentItems(context, subagentParentInfo, sessionId, 'completed');
+      }
     }
     return;
   }
 
   if (!sessionId || !turnId) {
     log.warn('DialogTurnCompleted missing sessionId or turnId', { event });
+    return;
+  }
+
+  if (success === false) {
+    handleDialogTurnFailed(context, {
+      ...event,
+      sessionId,
+      turnId,
+      error: event?.error || buildUnsuccessfulCompletionError(finishReason),
+    });
     return;
   }
 

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -1038,6 +1038,9 @@
     "dialogCompleted": "AI agent has finished the task.",
     "dialogCompletedTitle": "BitFun task finished",
     "dialogCompletedWithSession": "\"{{sessionTitle}}\" is ready. Return to BitFun to review the result.",
-    "dialogCompletedFallback": "A BitFun session is ready. Return to BitFun to review the result."
+    "dialogCompletedFallback": "A BitFun session is ready. Return to BitFun to review the result.",
+    "dialogFailedTitle": "BitFun task stopped",
+    "dialogFailedWithSession": "\"{{sessionTitle}}\" stopped unexpectedly. Return to BitFun to review the reason.",
+    "dialogFailedFallback": "A BitFun session stopped unexpectedly. Return to BitFun to review the reason."
   }
 }

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -1038,6 +1038,9 @@
     "dialogCompleted": "AI 助手已完成任务。",
     "dialogCompletedTitle": "BitFun 任务已完成",
     "dialogCompletedWithSession": "“{{sessionTitle}}” 已完成，可以回到 BitFun 查看结果。",
-    "dialogCompletedFallback": "有一个 BitFun 会话已完成，可以回到应用查看结果。"
+    "dialogCompletedFallback": "有一个 BitFun 会话已完成，可以回到应用查看结果。",
+    "dialogFailedTitle": "BitFun 任务已中断",
+    "dialogFailedWithSession": "“{{sessionTitle}}” 已异常停止，可以回到 BitFun 查看原因。",
+    "dialogFailedFallback": "有一个 BitFun 会话已异常停止，可以回到应用查看原因。"
   }
 }

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -1038,6 +1038,9 @@
     "dialogCompleted": "AI 助手已完成任務。",
     "dialogCompletedTitle": "BitFun 任務已完成",
     "dialogCompletedWithSession": "「{{sessionTitle}}」已完成，可以回到 BitFun 查看結果。",
-    "dialogCompletedFallback": "有一個 BitFun 會話已完成，可以回到應用查看結果。"
+    "dialogCompletedFallback": "有一個 BitFun 會話已完成，可以回到應用查看結果。",
+    "dialogFailedTitle": "BitFun 任務已中斷",
+    "dialogFailedWithSession": "「{{sessionTitle}}」已異常停止，可以回到 BitFun 查看原因。",
+    "dialogFailedFallback": "有一個 BitFun 會話已異常停止，可以回到應用查看原因。"
   }
 }


### PR DESCRIPTION
## Summary

- Treat `DialogTurnCompleted` with `success: false` as a failed turn: invoke failure handling and settle subagent tool items as error with contextual `finish_reason`.
- Background completion notifications distinguish success vs failure and pass through `finishReason`.
- Add `notify.*` strings for failed dialog completion (en, zh-CN, zh-TW).
- Extend unit tests for `EventHandlerModule` and `useDialogCompletionNotify`.

## Verification

- `pnpm run lint:web`
- `pnpm run type-check:web`
- Targeted Vitest: hooks and EventHandlerModule test files.