### PR TITLE
fix(desktop): main window close on non-macOS and Windows process cleanup

### DIFF
--- a/src/apps/desktop/src/computer_use/desktop_host.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host.rs
@@ -3718,7 +3718,7 @@ tell application "System Events" to get unix id of first process whose frontmost
         {
             let pid = resolve_pid_macos(self, &params.app).await?;
             let self_pid = std::process::id() as i32;
-            info!(
+            log::info!(
                 target: "computer_use::app_click",
                 "app_click.enter pid={} self_pid={} same_process={} target={:?} button={} click_count={} modifier_keys={:?}",
                 pid,
@@ -3894,7 +3894,7 @@ tell application "System Events" to get unix id of first process whose frontmost
                     _ => crate::computer_use::macos_bg_input::BgMouseButton::Left,
                 };
                 let cnt = params.click_count.max(1) as u32;
-                info!(
+                log::info!(
                     target: "computer_use::app_click",
                     "app_click.bg_dispatch pid={} self_pid={} same_process={} resolved_x={:.2} resolved_y={:.2} click_count={}",
                     pid, self_pid, pid == self_pid, x, y, cnt
@@ -4020,7 +4020,7 @@ tell application "System Events" to get unix id of first process whose frontmost
                 let _ = self.app_click(click).await?;
             }
             require_macos_background_input()?;
-            info!(
+            log::info!(
                 target: "computer_use::app_type_text",
                 "app_type_text.bg_dispatch pid={} char_count={}",
                 pid,

--- a/src/apps/desktop/src/computer_use/desktop_host.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host.rs
@@ -26,7 +26,7 @@ use bitfun_core::util::errors::{BitFunError, BitFunResult};
 use enigo::{Axis, Button, Coordinate, Direction, Enigo, Key, Keyboard, Mouse, Settings};
 use image::codecs::jpeg::JpegEncoder;
 use image::{DynamicImage, Rgb, RgbImage};
-use log::{debug, info, warn};
+use log::{debug, warn};
 use resvg::tiny_skia::{Pixmap, Transform};
 use resvg::usvg;
 use screenshots::display_info::DisplayInfo;

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -487,48 +487,48 @@ pub async fn run() {
         })
         .on_window_event({
             move |window, event| {
+                #[cfg(target_os = "macos")]
                 if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                     if window.label() == "main" {
-                        #[cfg(target_os = "macos")]
-                        {
-                            api.prevent_close();
-                            if !begin_main_window_close_request_on_macos() {
-                                return;
-                            }
-
-                            if let Err(error) = window.emit(MAIN_WINDOW_CLOSE_REQUESTED_EVENT, ()) {
-                                log::warn!(
-                                    "Failed to emit macOS main window close request event: {}",
-                                    error
-                                );
-                            }
-
-                            let app_handle = window.app_handle().clone();
-                            tauri::async_runtime::spawn(async move {
-                                tokio::time::sleep(std::time::Duration::from_millis(
-                                    MAIN_WINDOW_CLOSE_FALLBACK_HIDE_MS,
-                                ))
-                                .await;
-
-                                if take_main_window_close_request_on_macos() {
-                                    if let Err(error) =
-                                        hide_main_window_on_macos(&app_handle, "frontend_timeout")
-                                    {
-                                        log::warn!(
-                                            "macOS close fallback hide failed after frontend timeout: {}",
-                                            error
-                                        );
-                                    }
-                                }
-                            });
+                        api.prevent_close();
+                        if !begin_main_window_close_request_on_macos() {
+                            return;
                         }
 
-                        #[cfg(not(target_os = "macos"))]
-                        {
-                            if perform_process_exit_cleanup() {
-                                log::info!("Main window close requested, cleaning up");
-                                window.app_handle().exit(0);
+                        if let Err(error) = window.emit(MAIN_WINDOW_CLOSE_REQUESTED_EVENT, ()) {
+                            log::warn!(
+                                "Failed to emit macOS main window close request event: {}",
+                                error
+                            );
+                        }
+
+                        let app_handle = window.app_handle().clone();
+                        tauri::async_runtime::spawn(async move {
+                            tokio::time::sleep(std::time::Duration::from_millis(
+                                MAIN_WINDOW_CLOSE_FALLBACK_HIDE_MS,
+                            ))
+                            .await;
+
+                            if take_main_window_close_request_on_macos() {
+                                if let Err(error) =
+                                    hide_main_window_on_macos(&app_handle, "frontend_timeout")
+                                {
+                                    log::warn!(
+                                        "macOS close fallback hide failed after frontend timeout: {}",
+                                        error
+                                    );
+                                }
                             }
+                        });
+                    }
+                }
+
+                #[cfg(not(target_os = "macos"))]
+                if let tauri::WindowEvent::CloseRequested { .. } = event {
+                    if window.label() == "main" {
+                        if perform_process_exit_cleanup() {
+                            log::info!("Main window close requested, cleaning up");
+                            window.app_handle().exit(0);
                         }
                     }
                 }
@@ -1002,23 +1002,28 @@ pub async fn run() {
 
     match app {
         Ok(app) => {
-            app.run(|app_handle, event| match event {
-                tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit => {
-                    perform_process_exit_cleanup();
+            app.run(|app_handle, event| {
+                #[cfg(not(target_os = "macos"))]
+                let _ = app_handle;
+
+                match event {
+                    tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit => {
+                        perform_process_exit_cleanup();
+                    }
+                    #[cfg(target_os = "macos")]
+                    tauri::RunEvent::Reopen {
+                        has_visible_windows,
+                        ..
+                    } => {
+                        let reason = if has_visible_windows {
+                            "dock_reopen_with_visible_aux_window"
+                        } else {
+                            "dock_reopen_no_visible_windows"
+                        };
+                        show_main_window_on_macos(app_handle, reason);
+                    }
+                    _ => {}
                 }
-                #[cfg(target_os = "macos")]
-                tauri::RunEvent::Reopen {
-                    has_visible_windows,
-                    ..
-                } => {
-                    let reason = if has_visible_windows {
-                        "dock_reopen_with_visible_aux_window"
-                    } else {
-                        "dock_reopen_no_visible_windows"
-                    };
-                    show_main_window_on_macos(app_handle, reason);
-                }
-                _ => {}
             });
         }
         Err(e) => {

--- a/src/crates/core/src/util/process_manager.rs
+++ b/src/crates/core/src/util/process_manager.rs
@@ -4,7 +4,9 @@ use std::io;
 use std::process::Command;
 use std::sync::LazyLock;
 use tokio::process::{Child, Command as TokioCommand};
-use tokio::time::{timeout, Duration};
+use tokio::time::Duration;
+#[cfg(unix)]
+use tokio::time::timeout;
 
 #[cfg(windows)]
 use log::warn;
@@ -119,11 +121,18 @@ pub fn configure_process_group(command: &mut TokioCommand) {
     {
         command.process_group(0);
     }
+    #[cfg(not(unix))]
+    {
+        let _ = command;
+    }
 }
 
 pub async fn terminate_child_process_tree(
     child: &mut Child,
+    #[cfg(unix)]
     graceful_timeout: Duration,
+    #[cfg(not(unix))]
+    _graceful_timeout: Duration,
 ) -> io::Result<()> {
     let pid = child.id();
 


### PR DESCRIPTION
## Summary
- Gate macOS-only main window close handling so Windows/Linux exit path works.
- Make \process_manager\ terminate/configure paths safe on Windows (non-unix).
- Remove unused \log::info\ import in \desktop_host\.

## Verification
- \cargo check -p bitfun-desktop\
