### PR TITLE
fix(browser-control): accurate tab count, real browser detection, hide selector when CDP connected

### DIFF
--- a/src/apps/desktop/src/api/browser_control_api.rs
+++ b/src/apps/desktop/src/api/browser_control_api.rs
@@ -104,26 +104,31 @@ pub async fn browser_control_get_status(
 ) -> Result<BrowserControlStatusResponse, String> {
     let port = request.port;
     let available = BrowserLauncher::is_cdp_available(port).await;
-    let kind = selected_browser_kind().await?;
+    let configured_kind = selected_browser_kind().await?;
 
-    let (version, page_count) = if available {
-        let ver = CdpClient::get_version(port)
-            .await
-            .ok()
-            .and_then(|v| v.browser);
+    let (version, page_count, actual_kind) = if available {
+        let ver_info = CdpClient::get_version(port).await.ok();
+        let ver = ver_info.as_ref().and_then(|v| v.browser.clone());
+        // Identify the actual browser from CDP version response.
+        let kind = ver
+            .as_deref()
+            .and_then(|v| BrowserLauncher::browser_kind_from_cdp_version(v))
+            .unwrap_or_else(|| configured_kind.clone());
+        // Only count targets of type "page" (real browser tabs),
+        // not service workers, browser targets, etc.
         let pages = CdpClient::list_pages(port)
             .await
             .ok()
-            .map(|p| p.len())
+            .map(|p| p.iter().filter(|t| t.page_type.as_deref() == Some("page")).count())
             .unwrap_or(0);
-        (ver, pages)
+        (ver, pages, kind)
     } else {
-        (None, 0)
+        (None, 0, configured_kind)
     };
 
     Ok(BrowserControlStatusResponse {
         cdp_available: available,
-        browser_kind: kind.to_string(),
+        browser_kind: actual_kind.to_string(),
         browser_version: version,
         port,
         page_count,

--- a/src/crates/core/src/agentic/tools/browser_control/browser_launcher.rs
+++ b/src/crates/core/src/agentic/tools/browser_control/browser_launcher.rs
@@ -254,6 +254,27 @@ impl BrowserLauncher {
         *cache = None;
     }
 
+    /// Parse a `BrowserKind` from the CDP `/json/version` "Browser" field.
+    /// The field typically looks like `"HeadlessChrome/130.0..."` or
+    /// `"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"`
+    /// or `"Microsoft Edge/130.0..."`.
+    pub fn browser_kind_from_cdp_version(version_str: &str) -> Option<BrowserKind> {
+        let lower = version_str.to_ascii_lowercase();
+        if lower.contains("edg") || lower.contains("edge") {
+            Some(BrowserKind::Edge)
+        } else if lower.contains("brave") {
+            Some(BrowserKind::Brave)
+        } else if lower.contains("chromium") {
+            Some(BrowserKind::Chromium)
+        } else if lower.contains("chrome") {
+            Some(BrowserKind::Chrome)
+        } else if lower.contains("arc") {
+            Some(BrowserKind::Arc)
+        } else {
+            None
+        }
+    }
+
     pub fn browser_kind_from_config(value: &str) -> Option<BrowserKind> {
         match value.trim().to_ascii_lowercase().as_str() {
             "" | "default" => None,

--- a/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.scss
@@ -53,6 +53,11 @@
   opacity: 0.5;
 }
 
+.duration-timeout--infinity {
+  vertical-align: middle;
+  opacity: 0.8;
+}
+
 .duration-timeout--warning {
   color: var(--color-warning, #f59e0b);
   opacity: 1;

--- a/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.tsx
@@ -122,7 +122,7 @@ export const ToolTimeoutIndicator: React.FC<ToolTimeoutIndicatorProps> = ({
               className={`duration-timeout ${isTimeoutDisabled ? 'duration-timeout--disabled' : ''} ${isWarning ? 'duration-timeout--warning' : ''}`}
             >
               {isTimeoutDisabled
-                ? formatDurationLive(timeoutMs!)
+                ? <InfinityIcon size={14} className="duration-timeout--infinity" />
                 : displayRemaining != null
                   ? formatDurationLive(displayRemaining)
                   : formatDurationLive(timeoutMs!)}

--- a/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
@@ -1091,6 +1091,8 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
         >
           {IS_TAURI_DESKTOP ? (
             <>
+              {/* Only show browser selector when CDP is not connected */}
+              {!browserCdpAvailable && (
               <ConfigPageRow
                 label={t('browserControl.preferredBrowser')}
                 description={t('browserControl.preferredBrowserDesc')}
@@ -1109,6 +1111,7 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
                   />
                 </div>
               </ConfigPageRow>
+              )}
               <ConfigPageRow
                 label={t('browserControl.status')}
                 description={t('browserControl.statusDesc') || undefined}


### PR DESCRIPTION
Fix 3 browser control issues:

1. **Tab count inaccurate**: Only count CDP targets of type page (ignore service workers, browser targets, etc.)
2. **Browser detection wrong**: Detect actual connected browser from CDP /json/version instead of user config
3. **Hide browser selector**: Hide browser selection dropdown when CDP is already connected; only show when not connected

Added browser_kind_from_cdp_version() to parse browser identity from CDP version string.