### PR TITLE
support ACP permission options

### DIFF
--- a/src/web-ui/src/flow_chat/components/FlowItemRenderer.tsx
+++ b/src/web-ui/src/flow_chat/components/FlowItemRenderer.tsx
@@ -15,8 +15,8 @@ interface FlowItemRendererProps {
   item: FlowItem;
   onFileViewRequest?: (filePath: string) => void;
   onTabOpen?: (tabInfo: any) => void;
-  onConfirm?: (toolId: string, updatedInput?: any) => void;
-  onReject?: (toolId: string) => void;
+  onConfirm?: (toolId: string, updatedInput?: any, permissionOptionId?: string, approve?: boolean) => void;
+  onReject?: (toolId: string, permissionOptionId?: string) => void;
   sessionId?: string;
 }
 
@@ -85,6 +85,7 @@ export const FlowItemRenderer = React.memo(
       // Compare streaming params to re-render when they update
       return prevTool.toolResult === nextTool.toolResult &&
              prevTool.interruptionReason === nextTool.interruptionReason &&
+             prevTool.acpPermission === nextTool.acpPermission &&
              prevTool.isParamsStreaming === nextTool.isParamsStreaming &&
              JSON.stringify(prevTool.partialParams) === JSON.stringify(nextTool.partialParams);
     }
@@ -94,4 +95,3 @@ export const FlowItemRenderer = React.memo(
 );
 
 FlowItemRenderer.displayName = 'FlowItemRenderer';
-

--- a/src/web-ui/src/flow_chat/components/FlowToolCard.tsx
+++ b/src/web-ui/src/flow_chat/components/FlowToolCard.tsx
@@ -15,8 +15,8 @@ const log = createLogger('FlowToolCard');
 
 interface FlowToolCardProps {
   toolItem: FlowToolItem;
-  onConfirm?: (toolId: string, updatedInput?: any) => void;
-  onReject?: (toolId: string) => void;
+  onConfirm?: (toolId: string, updatedInput?: any, permissionOptionId?: string, approve?: boolean) => void;
+  onReject?: (toolId: string, permissionOptionId?: string) => void;
   onOpenInEditor?: (filePath: string) => void;
   onOpenInPanel?: (panelType: string, data: any) => void;
   onExpand?: (toolId: string) => void;
@@ -41,18 +41,20 @@ export const FlowToolCard: React.FC<FlowToolCardProps> = React.memo(({
   const interruptionNote = getToolInterruptionNote(toolItem, t);
   const cardHandlesInterruptionNote = toolItem.toolName === 'Task';
 
-  const handleConfirm = React.useCallback((updatedInput?: any) => {
+  const handleConfirm = React.useCallback((updatedInput?: any, permissionOptionId?: string, approve?: boolean) => {
     log.debug('handleConfirm called', {
       toolId: toolItem.id,
       toolName: toolItem.toolName,
       hasUpdatedInput: updatedInput !== undefined,
-      updatedInputKeys: updatedInput ? Object.keys(updatedInput) : []
+      updatedInputKeys: updatedInput ? Object.keys(updatedInput) : [],
+      hasPermissionOption: Boolean(permissionOptionId),
+      approve
     });
-    onConfirm?.(toolItem.id, updatedInput);
+    onConfirm?.(toolItem.id, updatedInput, permissionOptionId, approve);
   }, [toolItem.id, toolItem.toolName, onConfirm]);
 
-  const handleReject = React.useCallback(() => {
-    onReject?.(toolItem.id);
+  const handleReject = React.useCallback((permissionOptionId?: string) => {
+    onReject?.(toolItem.id, permissionOptionId);
   }, [toolItem.id, onReject]);
 
   const handleExpand = React.useCallback(() => {
@@ -97,6 +99,7 @@ export const FlowToolCard: React.FC<FlowToolCardProps> = React.memo(({
     prevProps.toolItem.interruptionReason === nextProps.toolItem.interruptionReason &&
     prevProps.toolItem.terminalSessionId === nextProps.toolItem.terminalSessionId &&
     prevProps.toolItem.userConfirmed === nextProps.toolItem.userConfirmed &&
+    prevProps.toolItem.acpPermission === nextProps.toolItem.acpPermission &&
     prevProps.toolItem.isParamsStreaming === nextProps.toolItem.isParamsStreaming &&
     prevProgress === nextProgress &&
     prevProps.toolItem.partialParams === nextProps.toolItem.partialParams &&

--- a/src/web-ui/src/flow_chat/components/modern/ExploreGroupRenderer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ExploreGroupRenderer.tsx
@@ -242,17 +242,17 @@ const ExploreItemRenderer = React.memo<ExploreItemRendererProps>(({ item, turnId
     sessionId,
   } = useFlowChatContext();
   
-  const handleConfirm = useCallback(async (toolId: string, updatedInput?: any) => {
+  const handleConfirm = useCallback(async (toolId: string, updatedInput?: any, permissionOptionId?: string, approve?: boolean) => {
     if (onToolConfirm) {
-      await onToolConfirm(toolId, updatedInput);
+      await onToolConfirm(toolId, updatedInput, permissionOptionId, approve);
     }
   }, [onToolConfirm]);
   
-  const handleReject = useCallback(async () => {
+  const handleReject = useCallback(async (toolId: string, permissionOptionId?: string) => {
     if (onToolReject) {
-      await onToolReject(item.id);
+      await onToolReject(toolId, permissionOptionId);
     }
-  }, [onToolReject, item.id]);
+  }, [onToolReject]);
   
   const handleOpenInEditor = useCallback((filePath: string) => {
     if (onFileViewRequest) {

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatContext.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatContext.tsx
@@ -15,8 +15,8 @@ export interface FlowChatContextValue {
   onSwitchToChatPanel?: () => void;
 
   // Tool actions
-  onToolConfirm?: (toolId: string, updatedInput?: any) => Promise<void>;
-  onToolReject?: (toolId: string) => Promise<void>;
+  onToolConfirm?: (toolId: string, updatedInput?: any, permissionOptionId?: string, approve?: boolean) => Promise<void>;
+  onToolReject?: (toolId: string, permissionOptionId?: string) => Promise<void>;
 
   // Session info
   sessionId?: string;
@@ -67,4 +67,3 @@ export const FlowChatContext = createContext<FlowChatContextValue>({});
 export const useFlowChatContext = () => {
   return useContext(FlowChatContext);
 };
-

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
@@ -532,17 +532,17 @@ const SubagentItemRenderer = React.memo<{ item: FlowItem; turnId: string; roundI
     sessionId,
   } = useFlowChatContext();
   
-  const handleConfirm = useCallback(async (toolId: string, updatedInput?: any) => {
+  const handleConfirm = useCallback(async (toolId: string, updatedInput?: any, permissionOptionId?: string, approve?: boolean) => {
     if (onToolConfirm) {
-      await onToolConfirm(toolId, updatedInput);
+      await onToolConfirm(toolId, updatedInput, permissionOptionId, approve);
     }
   }, [onToolConfirm]);
   
-  const handleReject = useCallback(async () => {
+  const handleReject = useCallback(async (toolId: string, permissionOptionId?: string) => {
     if (onToolReject) {
-      await onToolReject(item.id);
+      await onToolReject(toolId, permissionOptionId);
     }
-  }, [onToolReject, item.id]);
+  }, [onToolReject]);
   
   const handleOpenInEditor = useCallback((filePath: string) => {
     if (onFileViewRequest) {
@@ -664,14 +664,14 @@ const FlowItemRenderer: React.FC<FlowItemRendererProps> = ({ item, turnId, isLas
         <div className="flowchat-flow-item" data-flow-item-id={item.id} data-flow-item-type="tool">
           <FlowToolCard
             toolItem={item as FlowToolItem}
-            onConfirm={async (toolId: string, updatedInput?: any) => {
+            onConfirm={async (toolId: string, updatedInput?: any, permissionOptionId?: string, approve?: boolean) => {
               if (onToolConfirm) {
-                await onToolConfirm(toolId, updatedInput);
+                await onToolConfirm(toolId, updatedInput, permissionOptionId, approve);
               }
             }}
-            onReject={async () => {
+            onReject={async (_toolId: string, permissionOptionId?: string) => {
               if (onToolReject) {
-                await onToolReject(item.id);
+                await onToolReject(item.id, permissionOptionId);
               }
             }}
             onOpenInEditor={(filePath: string) => {

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatToolActions.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatToolActions.ts
@@ -56,7 +56,12 @@ function resolveToolContext(toolId: string): ResolvedToolContext {
 }
 
 export function useFlowChatToolActions() {
-  const handleToolConfirm = useCallback(async (toolId: string, updatedInput?: any) => {
+  const handleToolConfirm = useCallback(async (
+    toolId: string,
+    updatedInput?: any,
+    permissionOptionId?: string,
+    approve = true,
+  ) => {
     try {
       const { sessionId, toolItem, turnId } = resolveToolContext(toolId);
 
@@ -68,8 +73,8 @@ export function useFlowChatToolActions() {
       const finalInput = updatedInput || toolItem.toolCall?.input;
 
       flowChatStore.updateModelRoundItem(sessionId, turnId, toolId, {
-        userConfirmed: true,
-        status: 'confirmed',
+        userConfirmed: approve,
+        status: approve ? 'confirmed' : 'cancelled',
         toolCall: {
           ...toolItem.toolCall,
           input: finalInput,
@@ -80,7 +85,8 @@ export function useFlowChatToolActions() {
       if (acpPermission?.permissionId) {
         await ACPClientAPI.submitPermissionResponse({
           permissionId: acpPermission.permissionId,
-          approve: true,
+          approve,
+          optionId: permissionOptionId,
         });
         return;
       }
@@ -98,7 +104,7 @@ export function useFlowChatToolActions() {
     }
   }, []);
 
-  const handleToolReject = useCallback(async (toolId: string) => {
+  const handleToolReject = useCallback(async (toolId: string, permissionOptionId?: string) => {
     try {
       const { sessionId, toolItem, turnId } = resolveToolContext(toolId);
 
@@ -117,6 +123,7 @@ export function useFlowChatToolActions() {
         await ACPClientAPI.submitPermissionResponse({
           permissionId: acpPermission.permissionId,
           approve: false,
+          optionId: permissionOptionId,
         });
         return;
       }

--- a/src/web-ui/src/flow_chat/tool-cards/AcpPermissionActions.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/AcpPermissionActions.scss
@@ -1,0 +1,44 @@
+.acp-permission-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.acp-permission-actions--text {
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.acp-permission-actions__text-button {
+  min-height: 26px;
+  padding: 0 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-surface, transparent);
+  color: var(--color-text);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.acp-permission-actions__text-button:hover:not(:disabled) {
+  background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.08));
+}
+
+.acp-permission-actions__text-button--allow {
+  border-color: color-mix(in srgb, var(--color-success, #22c55e) 55%, var(--color-border, rgba(255, 255, 255, 0.12)));
+  color: var(--color-success, #22c55e);
+}
+
+.acp-permission-actions__text-button--reject {
+  border-color: color-mix(in srgb, var(--color-danger, #ef4444) 55%, var(--color-border, rgba(255, 255, 255, 0.12)));
+  color: var(--color-danger, #ef4444);
+}
+
+.acp-permission-actions__text-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}

--- a/src/web-ui/src/flow_chat/tool-cards/AcpPermissionActions.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AcpPermissionActions.tsx
@@ -1,0 +1,140 @@
+import React, { useMemo } from 'react';
+import { Check, ShieldCheck, ShieldX, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
+import { IconButton } from '../../component-library';
+import type { FlowToolItem, ToolCardProps } from '../types/flow-chat';
+import type { AcpPermissionOption } from '@/infrastructure/api/service-api/ACPClientAPI';
+import './AcpPermissionActions.scss';
+
+const KIND_ORDER: Record<AcpPermissionOption['kind'], number> = {
+  allow_once: 0,
+  allow_always: 1,
+  reject_once: 2,
+  reject_always: 3,
+};
+
+interface AcpPermissionActionsProps {
+  toolItem: FlowToolItem;
+  input?: any;
+  disabled?: boolean;
+  presentation?: 'icon' | 'text';
+  className?: string;
+  buttonClassName?: string;
+  onConfirm?: ToolCardProps['onConfirm'];
+  onReject?: ToolCardProps['onReject'];
+}
+
+export function hasAcpPermissionOptions(toolItem: FlowToolItem): boolean {
+  return Boolean(toolItem.acpPermission?.options?.length);
+}
+
+function isApprovalKind(kind: AcpPermissionOption['kind']): boolean {
+  return kind === 'allow_once' || kind === 'allow_always';
+}
+
+function fallbackLabel(kind: AcpPermissionOption['kind'], t: TFunction<'flow-chat'>): string {
+  switch (kind) {
+    case 'allow_once':
+      return t('toolCards.acpPermission.allowOnce');
+    case 'allow_always':
+      return t('toolCards.acpPermission.allowAlways');
+    case 'reject_once':
+      return t('toolCards.acpPermission.reject');
+    case 'reject_always':
+      return t('toolCards.acpPermission.rejectAlways');
+    default:
+      return t('toolCards.acpPermission.selectOption');
+  }
+}
+
+function optionIcon(kind: AcpPermissionOption['kind']): React.ReactNode {
+  switch (kind) {
+    case 'allow_once':
+      return <Check size={12} />;
+    case 'allow_always':
+      return <ShieldCheck size={12} />;
+    case 'reject_always':
+      return <ShieldX size={12} />;
+    case 'reject_once':
+    default:
+      return <X size={12} />;
+  }
+}
+
+function buttonVariant(kind: AcpPermissionOption['kind']): 'success' | 'danger' {
+  return isApprovalKind(kind) ? 'success' : 'danger';
+}
+
+export const AcpPermissionActions: React.FC<AcpPermissionActionsProps> = ({
+  toolItem,
+  input,
+  disabled = false,
+  presentation = 'icon',
+  className = '',
+  buttonClassName = '',
+  onConfirm,
+  onReject,
+}) => {
+  const { t } = useTranslation('flow-chat');
+  const options = useMemo(() => {
+    return [...(toolItem.acpPermission?.options ?? [])].sort(
+      (a, b) => KIND_ORDER[a.kind] - KIND_ORDER[b.kind],
+    );
+  }, [toolItem.acpPermission?.options]);
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  return (
+    <span className={`acp-permission-actions acp-permission-actions--${presentation} ${className}`}>
+      {options.map((option) => {
+        const approve = isApprovalKind(option.kind);
+        const label = fallbackLabel(option.kind, t);
+        const tooltip = option.name && option.name !== label ? `${label}: ${option.name}` : label;
+        const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+          event.preventDefault();
+          event.stopPropagation();
+
+          if (approve) {
+            onConfirm?.(input, option.optionId, true);
+          } else {
+            onReject?.(option.optionId);
+          }
+        };
+
+        if (presentation === 'text') {
+          return (
+            <button
+              key={option.optionId}
+              type="button"
+              className={`acp-permission-actions__text-button acp-permission-actions__text-button--${approve ? 'allow' : 'reject'} ${buttonClassName}`}
+              onClick={handleClick}
+              disabled={disabled}
+              title={tooltip}
+              aria-label={tooltip}
+            >
+              {label}
+            </button>
+          );
+        }
+
+        return (
+          <IconButton
+            key={option.optionId}
+            className={`tool-card-header-action acp-permission-actions__icon-button acp-permission-actions__icon-button--${option.kind} ${buttonClassName}`}
+            variant={buttonVariant(option.kind)}
+            size="xs"
+            onClick={handleClick}
+            disabled={disabled}
+            tooltip={tooltip}
+            aria-label={tooltip}
+          >
+            {optionIcon(option.kind)}
+          </IconButton>
+        );
+      })}
+    </span>
+  );
+};

--- a/src/web-ui/src/flow_chat/tool-cards/AcpPermissionActions.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AcpPermissionActions.tsx
@@ -25,10 +25,6 @@ interface AcpPermissionActionsProps {
   onReject?: ToolCardProps['onReject'];
 }
 
-export function hasAcpPermissionOptions(toolItem: FlowToolItem): boolean {
-  return Boolean(toolItem.acpPermission?.options?.length);
-}
-
 function isApprovalKind(kind: AcpPermissionOption['kind']): boolean {
   return kind === 'allow_once' || kind === 'allow_always';
 }

--- a/src/web-ui/src/flow_chat/tool-cards/AcpPermissionActions.utils.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/AcpPermissionActions.utils.ts
@@ -1,0 +1,5 @@
+import type { FlowToolItem } from '../types/flow-chat';
+
+export function hasAcpPermissionOptions(toolItem: FlowToolItem): boolean {
+  return Boolean(toolItem.acpPermission?.options?.length);
+}

--- a/src/web-ui/src/flow_chat/tool-cards/DefaultToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/DefaultToolCard.tsx
@@ -10,6 +10,7 @@ import type { ToolCardProps } from '../types/flow-chat';
 import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
 import { ToolCardStatusSlot } from './ToolCardStatusSlot';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
+import { AcpPermissionActions, hasAcpPermissionOptions } from './AcpPermissionActions';
 import './DefaultToolCard.scss';
 
 const MAX_PREVIEW_CHARS = 4000;
@@ -240,22 +241,35 @@ export const DefaultToolCard: React.FC<ToolCardProps> = ({
 
           {showConfirmationActions && (
             <div className="default-tool-card__actions">
-              <button
-                type="button"
-                className="default-tool-card__button default-tool-card__button--confirm"
-                onClick={handleConfirm}
-                disabled={status === 'streaming'}
-              >
-                {t('toolCards.mcp.confirmExecute')}
-              </button>
-              <button
-                type="button"
-                className="default-tool-card__button default-tool-card__button--reject"
-                onClick={handleReject}
-                disabled={status === 'streaming'}
-              >
-                {t('toolCards.mcp.cancel')}
-              </button>
+              {hasAcpPermissionOptions(toolItem) ? (
+                <AcpPermissionActions
+                  toolItem={toolItem}
+                  input={toolCall?.input}
+                  presentation="text"
+                  disabled={status === 'streaming'}
+                  onConfirm={onConfirm}
+                  onReject={onReject}
+                />
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    className="default-tool-card__button default-tool-card__button--confirm"
+                    onClick={handleConfirm}
+                    disabled={status === 'streaming'}
+                  >
+                    {t('toolCards.mcp.confirmExecute')}
+                  </button>
+                  <button
+                    type="button"
+                    className="default-tool-card__button default-tool-card__button--reject"
+                    onClick={handleReject}
+                    disabled={status === 'streaming'}
+                  >
+                    {t('toolCards.mcp.cancel')}
+                  </button>
+                </>
+              )}
             </div>
           )}
 
@@ -275,5 +289,4 @@ export const DefaultToolCard: React.FC<ToolCardProps> = ({
     </div>
   );
 };
-
 

--- a/src/web-ui/src/flow_chat/tool-cards/DefaultToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/DefaultToolCard.tsx
@@ -10,7 +10,8 @@ import type { ToolCardProps } from '../types/flow-chat';
 import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
 import { ToolCardStatusSlot } from './ToolCardStatusSlot';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
-import { AcpPermissionActions, hasAcpPermissionOptions } from './AcpPermissionActions';
+import { hasAcpPermissionOptions } from './AcpPermissionActions.utils';
+import { AcpPermissionActions } from './AcpPermissionActions';
 import './DefaultToolCard.scss';
 
 const MAX_PREVIEW_CHARS = 4000;
@@ -289,4 +290,3 @@ export const DefaultToolCard: React.FC<ToolCardProps> = ({
     </div>
   );
 };
-

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -46,6 +46,7 @@ import { hasNonFileUriScheme } from '@/shared/utils/pathUtils';
 import { notificationService } from '@/shared/notification-system';
 import { useGitState } from '@/tools/git/hooks/useGitState';
 import { ToolCardHeaderActions } from './ToolCardHeaderActions';
+import { AcpPermissionActions, hasAcpPermissionOptions } from './AcpPermissionActions';
 import './FileOperationToolCard.scss';
 
 const log = createLogger('FileOperationToolCard');
@@ -829,26 +830,36 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
             </span>
           )}
           {showConfirmationActions && (
-            <>
-              <IconButton
-                className="tool-card-header-action file-op-header-action file-op-confirm-btn"
-                variant="success"
-                size="xs"
-                onClick={handleConfirmClick}
-                tooltip={t('toolCards.mcp.confirmExecute')}
-              >
-                <Check size={12} />
-              </IconButton>
-              <IconButton
-                className="tool-card-header-action file-op-header-action file-op-reject-btn"
-                variant="danger"
-                size="xs"
-                onClick={handleRejectClick}
-                tooltip={t('toolCards.mcp.cancel')}
-              >
-                <X size={12} />
-              </IconButton>
-            </>
+            hasAcpPermissionOptions(toolItem) ? (
+              <AcpPermissionActions
+                toolItem={toolItem}
+                input={toolCall?.input}
+                buttonClassName="file-op-header-action"
+                onConfirm={onConfirm}
+                onReject={onReject}
+              />
+            ) : (
+              <>
+                <IconButton
+                  className="tool-card-header-action file-op-header-action file-op-confirm-btn"
+                  variant="success"
+                  size="xs"
+                  onClick={handleConfirmClick}
+                  tooltip={t('toolCards.mcp.confirmExecute')}
+                >
+                  <Check size={12} />
+                </IconButton>
+                <IconButton
+                  className="tool-card-header-action file-op-header-action file-op-reject-btn"
+                  variant="danger"
+                  size="xs"
+                  onClick={handleRejectClick}
+                  tooltip={t('toolCards.mcp.cancel')}
+                >
+                  <X size={12} />
+                </IconButton>
+              </>
+            )
           )}
           {canOpenFullCode && (
             <Tooltip content={t('toolCards.file.openFullCodeHint')} placement="top">
@@ -882,24 +893,36 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
             content={renderDeleteContent()}
             extra={showConfirmationActions ? (
               <ToolCardHeaderActions className="file-op-header-actions">
-                <IconButton
-                  className="tool-card-header-action file-op-header-action file-op-confirm-btn"
-                  variant="success"
-                  size="xs"
-                  onClick={handleConfirmClick}
-                  tooltip={t('toolCards.mcp.confirmExecute')}
-                >
-                  <Check size={12} />
-                </IconButton>
-                <IconButton
-                  className="tool-card-header-action file-op-header-action file-op-reject-btn"
-                  variant="danger"
-                  size="xs"
-                  onClick={handleRejectClick}
-                  tooltip={t('toolCards.mcp.cancel')}
-                >
-                  <X size={12} />
-                </IconButton>
+                {hasAcpPermissionOptions(toolItem) ? (
+                  <AcpPermissionActions
+                    toolItem={toolItem}
+                    input={toolCall?.input}
+                    buttonClassName="file-op-header-action"
+                    onConfirm={onConfirm}
+                    onReject={onReject}
+                  />
+                ) : (
+                  <>
+                    <IconButton
+                      className="tool-card-header-action file-op-header-action file-op-confirm-btn"
+                      variant="success"
+                      size="xs"
+                      onClick={handleConfirmClick}
+                      tooltip={t('toolCards.mcp.confirmExecute')}
+                    >
+                      <Check size={12} />
+                    </IconButton>
+                    <IconButton
+                      className="tool-card-header-action file-op-header-action file-op-reject-btn"
+                      variant="danger"
+                      size="xs"
+                      onClick={handleRejectClick}
+                      tooltip={t('toolCards.mcp.cancel')}
+                    >
+                      <X size={12} />
+                    </IconButton>
+                  </>
+                )}
               </ToolCardHeaderActions>
             ) : undefined}
           />

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -46,7 +46,8 @@ import { hasNonFileUriScheme } from '@/shared/utils/pathUtils';
 import { notificationService } from '@/shared/notification-system';
 import { useGitState } from '@/tools/git/hooks/useGitState';
 import { ToolCardHeaderActions } from './ToolCardHeaderActions';
-import { AcpPermissionActions, hasAcpPermissionOptions } from './AcpPermissionActions';
+import { hasAcpPermissionOptions } from './AcpPermissionActions.utils';
+import { AcpPermissionActions } from './AcpPermissionActions';
 import './FileOperationToolCard.scss';
 
 const log = createLogger('FileOperationToolCard');

--- a/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.tsx
@@ -14,7 +14,8 @@ import { ToolCardCopyAction, ToolCardHeaderActions } from './ToolCardHeaderActio
 import { ToolCommandPreview } from './ToolCommandPreview';
 import { createLogger } from '@/shared/utils/logger';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
-import { AcpPermissionActions, hasAcpPermissionOptions } from './AcpPermissionActions';
+import { hasAcpPermissionOptions } from './AcpPermissionActions.utils';
+import { AcpPermissionActions } from './AcpPermissionActions';
 import './GitToolDisplay.scss';
 
 const log = createLogger('GitToolDisplay');

--- a/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.tsx
@@ -14,6 +14,7 @@ import { ToolCardCopyAction, ToolCardHeaderActions } from './ToolCardHeaderActio
 import { ToolCommandPreview } from './ToolCommandPreview';
 import { createLogger } from '@/shared/utils/logger';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
+import { AcpPermissionActions, hasAcpPermissionOptions } from './AcpPermissionActions';
 import './GitToolDisplay.scss';
 
 const log = createLogger('GitToolDisplay');
@@ -190,28 +191,38 @@ export const GitToolDisplay: React.FC<ToolCardProps> = ({
           ariaLabel={t('toolCards.git.copyCommand', { defaultValue: 'Copy git command' })}
         />
         {requiresConfirmation && !userConfirmed && status !== 'completed' && (
-          <>
-            <IconButton
-              className="tool-card-header-action git-confirm-btn"
-              variant="success"
-              size="xs"
-              onClick={(e) => { e.stopPropagation(); onConfirm?.(toolCall?.input); }}
+          hasAcpPermissionOptions(toolItem) ? (
+            <AcpPermissionActions
+              toolItem={toolItem}
+              input={toolCall?.input}
               disabled={status === 'streaming'}
-              tooltip={t('toolCards.git.confirmExecute')}
-            >
-              <Check size={12} />
-            </IconButton>
-            <IconButton
-              className="tool-card-header-action git-reject-btn"
-              variant="danger"
-              size="xs"
-              onClick={(e) => { e.stopPropagation(); onReject?.(); }}
-              disabled={status === 'streaming'}
-              tooltip={t('toolCards.git.cancel')}
-            >
-              <X size={12} />
-            </IconButton>
-          </>
+              onConfirm={onConfirm}
+              onReject={onReject}
+            />
+          ) : (
+            <>
+              <IconButton
+                className="tool-card-header-action git-confirm-btn"
+                variant="success"
+                size="xs"
+                onClick={(e) => { e.stopPropagation(); onConfirm?.(toolCall?.input); }}
+                disabled={status === 'streaming'}
+                tooltip={t('toolCards.git.confirmExecute')}
+              >
+                <Check size={12} />
+              </IconButton>
+              <IconButton
+                className="tool-card-header-action git-reject-btn"
+                variant="danger"
+                size="xs"
+                onClick={(e) => { e.stopPropagation(); onReject?.(); }}
+                disabled={status === 'streaming'}
+                tooltip={t('toolCards.git.cancel')}
+              >
+                <X size={12} />
+              </IconButton>
+            </>
+          )
         )}
       </ToolCardHeaderActions>
     </span>
@@ -261,26 +272,38 @@ export const GitToolDisplay: React.FC<ToolCardProps> = ({
       extra={
         requiresConfirmation && !userConfirmed && status !== 'completed' ? (
           <span className="git-confirm-actions">
-            <IconButton
-              className="tool-card-header-action git-confirm-btn"
-              variant="success"
-              size="xs"
-              onClick={(e) => { e.stopPropagation(); onConfirm?.(toolCall?.input); }}
-              disabled={status === 'streaming'}
-              tooltip={t('toolCards.git.confirmExecute')}
-            >
-              <Check size={12} />
-            </IconButton>
-            <IconButton
-              className="tool-card-header-action git-reject-btn"
-              variant="danger"
-              size="xs"
-              onClick={(e) => { e.stopPropagation(); onReject?.(); }}
-              disabled={status === 'streaming'}
-              tooltip={t('toolCards.git.cancel')}
-            >
-              <X size={12} />
-            </IconButton>
+            {hasAcpPermissionOptions(toolItem) ? (
+              <AcpPermissionActions
+                toolItem={toolItem}
+                input={toolCall?.input}
+                disabled={status === 'streaming'}
+                onConfirm={onConfirm}
+                onReject={onReject}
+              />
+            ) : (
+              <>
+                <IconButton
+                  className="tool-card-header-action git-confirm-btn"
+                  variant="success"
+                  size="xs"
+                  onClick={(e) => { e.stopPropagation(); onConfirm?.(toolCall?.input); }}
+                  disabled={status === 'streaming'}
+                  tooltip={t('toolCards.git.confirmExecute')}
+                >
+                  <Check size={12} />
+                </IconButton>
+                <IconButton
+                  className="tool-card-header-action git-reject-btn"
+                  variant="danger"
+                  size="xs"
+                  onClick={(e) => { e.stopPropagation(); onReject?.(); }}
+                  disabled={status === 'streaming'}
+                  tooltip={t('toolCards.git.cancel')}
+                >
+                  <X size={12} />
+                </IconButton>
+              </>
+            )}
           </span>
         ) : undefined
       }

--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.tsx
@@ -15,6 +15,7 @@ import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
 import { globalEventBus } from '@/infrastructure/event-bus';
 import { isMcpToolName, parseMcpToolName } from '@/infrastructure/mcp/toolName';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
+import { AcpPermissionActions, hasAcpPermissionOptions } from './AcpPermissionActions';
 import './MCPToolDisplay.scss';
 
 const log = createLogger('MCPToolDisplay');
@@ -611,32 +612,45 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
           
           {requiresConfirmation && !userConfirmed && status !== 'completed' && (
             <div className="mcp-action-buttons">
-              <IconButton
-                className="mcp-icon-button mcp-confirm-btn"
-                variant="success"
-                size="xs"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onConfirm?.(toolCall?.input);
-                }}
-                disabled={status === 'streaming'}
-                tooltip={t('toolCards.mcp.confirmExecute')}
-              >
-                <Check size={14} />
-              </IconButton>
-              <IconButton
-                className="mcp-icon-button mcp-reject-btn"
-                variant="danger"
-                size="xs"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onReject?.();
-                }}
-                disabled={status === 'streaming'}
-                tooltip={t('toolCards.mcp.cancel')}
-              >
-                <X size={14} />
-              </IconButton>
+              {hasAcpPermissionOptions(toolItem) ? (
+                <AcpPermissionActions
+                  toolItem={toolItem}
+                  input={toolCall?.input}
+                  disabled={status === 'streaming'}
+                  buttonClassName="mcp-icon-button"
+                  onConfirm={onConfirm}
+                  onReject={onReject}
+                />
+              ) : (
+                <>
+                  <IconButton
+                    className="mcp-icon-button mcp-confirm-btn"
+                    variant="success"
+                    size="xs"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onConfirm?.(toolCall?.input);
+                    }}
+                    disabled={status === 'streaming'}
+                    tooltip={t('toolCards.mcp.confirmExecute')}
+                  >
+                    <Check size={14} />
+                  </IconButton>
+                  <IconButton
+                    className="mcp-icon-button mcp-reject-btn"
+                    variant="danger"
+                    size="xs"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onReject?.();
+                    }}
+                    disabled={status === 'streaming'}
+                    tooltip={t('toolCards.mcp.cancel')}
+                  >
+                    <X size={14} />
+                  </IconButton>
+                </>
+              )}
             </div>
           )}
           

--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.tsx
@@ -15,7 +15,8 @@ import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
 import { globalEventBus } from '@/infrastructure/event-bus';
 import { isMcpToolName, parseMcpToolName } from '@/infrastructure/mcp/toolName';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
-import { AcpPermissionActions, hasAcpPermissionOptions } from './AcpPermissionActions';
+import { hasAcpPermissionOptions } from './AcpPermissionActions.utils';
+import { AcpPermissionActions } from './AcpPermissionActions';
 import './MCPToolDisplay.scss';
 
 const log = createLogger('MCPToolDisplay');

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
@@ -21,7 +21,8 @@ import { useToolCardHeightContract } from './useToolCardHeightContract';
 import { ToolTimeoutIndicator } from './ToolTimeoutIndicator';
 import { getReviewerContextBySubagentId } from '@/shared/services/reviewTeamService';
 import type { ReviewerContext } from '@/shared/services/reviewTeamService';
-import { AcpPermissionActions, hasAcpPermissionOptions } from './AcpPermissionActions';
+import { hasAcpPermissionOptions } from './AcpPermissionActions.utils';
+import { AcpPermissionActions } from './AcpPermissionActions';
 import './TaskToolDisplay.scss';
 import './ModelThinkingDisplay.scss';
 

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
@@ -21,6 +21,7 @@ import { useToolCardHeightContract } from './useToolCardHeightContract';
 import { ToolTimeoutIndicator } from './ToolTimeoutIndicator';
 import { getReviewerContextBySubagentId } from '@/shared/services/reviewTeamService';
 import type { ReviewerContext } from '@/shared/services/reviewTeamService';
+import { AcpPermissionActions, hasAcpPermissionOptions } from './AcpPermissionActions';
 import './TaskToolDisplay.scss';
 import './ModelThinkingDisplay.scss';
 
@@ -393,24 +394,37 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
         )}
         {needsConfirmation && (
           <div className="tool-actions">
-            <Button
-              className="confirm-button"
-              variant="primary"
-              size="small"
-              onClick={() => onConfirm?.(toolCall?.input)}
-              disabled={status === 'streaming'}
-            >
-              {t('toolCards.taskTool.confirmDelegate')}
-            </Button>
-            <Button
-              className="reject-button"
-              variant="ghost"
-              size="small"
-              onClick={() => onReject?.()}
-              disabled={status === 'streaming'}
-            >
-              {t('toolCards.taskTool.cancel')}
-            </Button>
+            {hasAcpPermissionOptions(toolItem) ? (
+              <AcpPermissionActions
+                toolItem={toolItem}
+                input={toolCall?.input}
+                presentation="text"
+                disabled={status === 'streaming'}
+                onConfirm={onConfirm}
+                onReject={onReject}
+              />
+            ) : (
+              <>
+                <Button
+                  className="confirm-button"
+                  variant="primary"
+                  size="small"
+                  onClick={() => onConfirm?.(toolCall?.input)}
+                  disabled={status === 'streaming'}
+                >
+                  {t('toolCards.taskTool.confirmDelegate')}
+                </Button>
+                <Button
+                  className="reject-button"
+                  variant="ghost"
+                  size="small"
+                  onClick={() => onReject?.()}
+                  disabled={status === 'streaming'}
+                >
+                  {t('toolCards.taskTool.cancel')}
+                </Button>
+              </>
+            )}
           </div>
         )}
       </div>

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
@@ -29,6 +29,7 @@ import { getTerminalViewState, type TerminalViewState } from './terminalToolCard
 import { ToolTimeoutIndicator } from './ToolTimeoutIndicator';
 import { ToolCardCopyAction, ToolCardHeaderActions } from './ToolCardHeaderActions';
 import { ToolCommandPreview } from './ToolCommandPreview';
+import { AcpPermissionActions, hasAcpPermissionOptions } from './AcpPermissionActions';
 import './TerminalToolCard.scss';
 
 const log = createLogger('TerminalToolCard');
@@ -514,29 +515,42 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
         <span className="terminal-critical-actions">
           {showConfirmButtons && (
             <span className="terminal-confirm-actions" onClick={(e) => e.stopPropagation()}>
-              <IconButton
-                className="terminal-action-btn execute-btn"
-                variant="success"
-                size="xs"
-                onClick={handleExecute}
-                disabled={!canExecuteCommand}
-                tooltip={
-                  canExecuteCommand
-                    ? t('toolCards.terminal.executeCommandTitle')
-                    : t('toolCards.terminal.commandEmptyWarning')
-                }
-              >
-                <Play size={12} fill="currentColor" />
-              </IconButton>
-              <IconButton
-                className="terminal-action-btn cancel-btn"
-                variant="danger"
-                size="xs"
-                onClick={handleReject}
-                tooltip={t('toolCards.terminal.cancel')}
-              >
-                <X size={14} />
-              </IconButton>
+              {hasAcpPermissionOptions(toolItem) ? (
+                <AcpPermissionActions
+                  toolItem={toolItem}
+                  input={toolCall?.input}
+                  disabled={!canExecuteCommand}
+                  buttonClassName="terminal-action-btn"
+                  onConfirm={onConfirm}
+                  onReject={onReject}
+                />
+              ) : (
+                <>
+                  <IconButton
+                    className="terminal-action-btn execute-btn"
+                    variant="success"
+                    size="xs"
+                    onClick={handleExecute}
+                    disabled={!canExecuteCommand}
+                    tooltip={
+                      canExecuteCommand
+                        ? t('toolCards.terminal.executeCommandTitle')
+                        : t('toolCards.terminal.commandEmptyWarning')
+                    }
+                  >
+                    <Play size={12} fill="currentColor" />
+                  </IconButton>
+                  <IconButton
+                    className="terminal-action-btn cancel-btn"
+                    variant="danger"
+                    size="xs"
+                    onClick={handleReject}
+                    tooltip={t('toolCards.terminal.cancel')}
+                  >
+                    <X size={14} />
+                  </IconButton>
+                </>
+              )}
             </span>
           )}
           {includeInterrupt && viewState.showInterruptButton && (

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
@@ -29,7 +29,8 @@ import { getTerminalViewState, type TerminalViewState } from './terminalToolCard
 import { ToolTimeoutIndicator } from './ToolTimeoutIndicator';
 import { ToolCardCopyAction, ToolCardHeaderActions } from './ToolCardHeaderActions';
 import { ToolCommandPreview } from './ToolCommandPreview';
-import { AcpPermissionActions, hasAcpPermissionOptions } from './AcpPermissionActions';
+import { hasAcpPermissionOptions } from './AcpPermissionActions.utils';
+import { AcpPermissionActions } from './AcpPermissionActions';
 import './TerminalToolCard.scss';
 
 const log = createLogger('TerminalToolCard');

--- a/src/web-ui/src/flow_chat/types/flow-chat.ts
+++ b/src/web-ui/src/flow_chat/types/flow-chat.ts
@@ -400,8 +400,8 @@ export interface ToolCardProps {
   toolItem: FlowToolItem;
   config: ToolCardConfig;
   interruptionNote?: string | null;
-  onConfirm?: (updatedInput?: any) => void;  // toolId is known within the card.
-  onReject?: () => void;
+  onConfirm?: (updatedInput?: any, permissionOptionId?: string, approve?: boolean) => void;  // toolId is known within the card.
+  onReject?: (permissionOptionId?: string) => void;
   onOpenInEditor?: (filePath: string) => void;
   onOpenInPanel?: (panelType: string, data: any) => void;
   onExpand?: () => void;

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1096,6 +1096,13 @@
       "failedLabel": "MCP failed",
       "executionFailed": "MCP execution failed"
     },
+    "acpPermission": {
+      "allowOnce": "Allow once",
+      "allowAlways": "Always allow",
+      "reject": "Reject once",
+      "rejectAlways": "Always reject",
+      "selectOption": "Select option"
+    },
     "default": {
       "waitingConfirm": "Waiting for confirmation",
       "executing": "Executing...",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1096,6 +1096,13 @@
       "failedLabel": "MCP 失败",
       "executionFailed": "MCP 执行失败"
     },
+    "acpPermission": {
+      "allowOnce": "允许一次",
+      "allowAlways": "始终允许",
+      "reject": "拒绝一次",
+      "rejectAlways": "始终拒绝",
+      "selectOption": "选择操作"
+    },
     "default": {
       "waitingConfirm": "等待确认",
       "executing": "执行中...",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1096,6 +1096,13 @@
       "failedLabel": "MCP 失敗",
       "executionFailed": "MCP 執行失敗"
     },
+    "acpPermission": {
+      "allowOnce": "允許一次",
+      "allowAlways": "始終允許",
+      "reject": "拒絕一次",
+      "rejectAlways": "始終拒絕",
+      "selectOption": "選擇操作"
+    },
     "default": {
       "waitingConfirm": "等待確認",
       "executing": "執行中...",


### PR DESCRIPTION
What changed

- Surface ACP permission options in FlowChat tool cards instead of collapsing them to confirm/reject.
- Thread the selected ACP option ID through the frontend action path and backend submission API.
- Add localized labels for allow once / always allow / reject once / always reject.

Validation

- pnpm --dir src/web-ui run type-check (repo already has unrelated modern-screenshot type errors).
