### PR TITLE
fix(flow-chat): prevent bottom spacer inflation

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -472,7 +472,8 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     // protected collapse, and subtracting it here makes the list think the
     // viewport is still pinned near the bottom when the user has already moved
     // away. That misclassification re-arms anchor restore and causes jitter.
-    const fallbackAdditionalCompensation = Math.max(0, shrinkAmount - distanceFromBottom);
+    const currentCollapseCompensation = getReservationTotalPx(bottomReservationStateRef.current.collapse);
+    const fallbackRequiredCollapseCompensation = Math.max(0, shrinkAmount - distanceFromBottom);
     const cumulativeShrinkPx = hasValidCollapseIntent
       ? collapseIntent.cumulativeShrinkPx + shrinkAmount
       : 0;
@@ -485,7 +486,10 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
           ? Math.max(currentTotalCompensation, resolvedIntentCompensation)
           : resolvedIntentCompensation
       )
-      : currentTotalCompensation + fallbackAdditionalCompensation;
+      : getReservationTotalPx(bottomReservationStateRef.current.pin) + Math.max(
+        currentCollapseCompensation,
+        fallbackRequiredCollapseCompensation,
+      );
     if (hasValidCollapseIntent) {
       pendingCollapseIntentRef.current = {
         ...collapseIntent,
@@ -493,7 +497,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       };
     }
 
-    if (!hasValidCollapseIntent && fallbackAdditionalCompensation <= COMPENSATION_EPSILON_PX) {
+    if (!hasValidCollapseIntent && fallbackRequiredCollapseCompensation <= COMPENSATION_EPSILON_PX) {
       // If the user is already far enough from the bottom, this shrink does not
       // need protection. Reusing stale bottom compensation here makes the
       // scroll listener restore an older anchor during upward scroll and causes
@@ -707,13 +711,6 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       )
     );
     const preservedPx = shouldPreserveCurrentPx ? currentPinReservation.px : 0;
-    const additiveRetryPx = (
-      shouldPreserveCurrentPx &&
-      pinMode === 'transient' &&
-      resolvedRequiredTailSpacePx > COMPENSATION_EPSILON_PX
-    )
-      ? currentPinReservation.px + resolvedRequiredTailSpacePx
-      : 0;
     const shouldRetainTarget = (
       pinMode === 'sticky-latest' ||
       resolvedRequiredTailSpacePx > COMPENSATION_EPSILON_PX ||
@@ -722,7 +719,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
 
     return {
       kind: 'pin',
-      px: Math.max(nextFloorPx, resolvedRequiredTailSpacePx, preservedPx, additiveRetryPx),
+      px: Math.max(nextFloorPx, resolvedRequiredTailSpacePx, preservedPx),
       floorPx: nextFloorPx,
       mode: pinMode,
       targetTurnId: shouldRetainTarget ? turnId : null,
@@ -1451,6 +1448,44 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
   }, [pendingTurnPin, scheduleVisibleTurnMeasure, tryResolvePendingTurnPin]);
 
   // ── Navigation helpers ────────────────────────────────────────────────
+  const clearAllBottomReservationsForUserNavigation = useCallback(() => {
+    const currentState = bottomReservationStateRef.current;
+    const scroller = scrollerElementRef.current;
+    const nextReservationState = createInitialBottomReservationState();
+    const hasActiveReservation = !areBottomReservationStatesEqual(currentState, nextReservationState);
+
+    releaseAnchorLock('user-navigation');
+    setPendingTurnPin(null);
+    pendingCollapseIntentRef.current = {
+      active: false,
+      anchorScrollTop: 0,
+      toolId: null,
+      toolName: null,
+      expiresAtMs: 0,
+      distanceFromBottomBeforeCollapse: 0,
+      baseTotalCompensationPx: 0,
+      cumulativeShrinkPx: 0,
+    };
+
+    if (!hasActiveReservation) {
+      return;
+    }
+
+    bottomReservationStateRef.current = nextReservationState;
+    updateBottomReservationState(nextReservationState);
+    applyFooterCompensationNow(nextReservationState);
+
+    if (scroller) {
+      previousScrollTopRef.current = scroller.scrollTop;
+      previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller, nextReservationState);
+    }
+  }, [
+    applyFooterCompensationNow,
+    releaseAnchorLock,
+    snapshotMeasuredContentHeight,
+    updateBottomReservationState,
+  ]);
+
   const clearPinReservationForUserNavigation = useCallback(() => {
     const currentState = bottomReservationStateRef.current;
     const scroller = scrollerElementRef.current;
@@ -1517,13 +1552,16 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     return lastDialogTurn.modelRounds.some(round => round.isStreaming);
   }, [activeSession, isProcessing]);
 
-  const scrollToLatestEndPositionInternal = useCallback((behavior: ScrollBehavior) => {
+  const scrollToLatestEndPositionInternal = useCallback((behavior: 'auto' | 'smooth') => {
     if (virtuosoRef.current && virtualItems.length > 0) {
-      releaseAnchorLock('scroll-to-latest');
-      setPendingTurnPin(null);
-      virtuosoRef.current.scrollTo({ top: 999999999, behavior });
+      clearAllBottomReservationsForUserNavigation();
+      virtuosoRef.current.scrollToIndex({
+        index: virtualItems.length - 1,
+        align: 'end',
+        behavior,
+      });
     }
-  }, [releaseAnchorLock, virtualItems.length]);
+  }, [clearAllBottomReservationsForUserNavigation, virtualItems.length]);
 
   const requestTurnPinToTop = useCallback((turnId: string, options?: { behavior?: ScrollBehavior; pinMode?: FlowChatPinTurnToTopMode }) => {
     const requestedPinMode = options?.pinMode ?? 'transient';
@@ -1859,10 +1897,14 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
 
   const scrollToPhysicalBottomAndClearPin = useCallback(() => {
     if (virtuosoRef.current && virtualItems.length > 0) {
-      clearPinReservationForUserNavigation();
-      virtuosoRef.current.scrollTo({ top: 999999999, behavior: 'smooth' });
+      clearAllBottomReservationsForUserNavigation();
+      virtuosoRef.current.scrollToIndex({
+        index: virtualItems.length - 1,
+        align: 'end',
+        behavior: 'smooth',
+      });
     }
-  }, [clearPinReservationForUserNavigation, virtualItems.length]);
+  }, [clearAllBottomReservationsForUserNavigation, virtualItems.length]);
 
   const scrollToLatestEndPosition = useCallback(() => {
     enterFollowOutput('jump-to-latest');

--- a/src/web-ui/src/flow_chat/utils/flowChatScrollLayout.ts
+++ b/src/web-ui/src/flow_chat/utils/flowChatScrollLayout.ts
@@ -7,7 +7,7 @@
 export const CHAT_INPUT_DROP_ZONE_BOTTOM_PX = 4;
 
 /** Space between the top edge of the input block and the end of scroll content */
-export const FLOWCHAT_MESSAGE_TAIL_CLEARANCE_PX = 4;
+export const FLOWCHAT_MESSAGE_TAIL_CLEARANCE_PX = 24;
 
 /** Space above the scroll-to-latest control (tighter than message tail; sits in overlay) */
 export const SCROLL_TO_LATEST_INPUT_CLEARANCE_PX = 6;


### PR DESCRIPTION
## Summary
- cap fallback bottom compensation so shrink measurements do not inflate the synthetic footer indefinitely
- avoid additive transient pin reservation retries and clear synthetic reservations before jumping to latest
- increase normal input tail clearance so focused input does not cover the last text

## Verification
- pnpm run type-check:web