### PR TITLE
feat(skills): add suite mode tab reset and grouped visibility controls

### DIFF
--- a/src/apps/desktop/src/api/app_state.rs
+++ b/src/apps/desktop/src/api/app_state.rs
@@ -10,9 +10,7 @@ use bitfun_core::miniapp::{
 use bitfun_core::service::remote_ssh::{
     init_remote_workspace_manager, RemoteFileService, RemoteTerminalManager, SSHConnectionManager,
 };
-use bitfun_core::service::{
-    announcement, config, filesystem, mcp, search, token_usage, workspace,
-};
+use bitfun_core::service::{announcement, config, filesystem, mcp, search, token_usage, workspace};
 use bitfun_core::util::errors::*;
 
 use serde::{Deserialize, Serialize};

--- a/src/apps/desktop/src/api/browser_control_api.rs
+++ b/src/apps/desktop/src/api/browser_control_api.rs
@@ -119,7 +119,11 @@ pub async fn browser_control_get_status(
         let pages = CdpClient::list_pages(port)
             .await
             .ok()
-            .map(|p| p.iter().filter(|t| t.page_type.as_deref() == Some("page")).count())
+            .map(|p| {
+                p.iter()
+                    .filter(|t| t.page_type.as_deref() == Some("page"))
+                    .count()
+            })
             .unwrap_or(0);
         (ver, pages, kind)
     } else {

--- a/src/apps/desktop/src/api/skill_api.rs
+++ b/src/apps/desktop/src/api/skill_api.rs
@@ -17,9 +17,10 @@ use tokio::time::{timeout, Duration};
 
 use crate::api::app_state::AppState;
 use bitfun_core::agentic::tools::implementations::skills::mode_overrides::{
-    load_project_mode_skills_document_local, project_mode_skills_path_for_remote,
-    save_project_mode_skills_document_local, set_disabled_mode_skills_in_document,
-    set_mode_skill_disabled_in_document, set_user_mode_skill_state,
+    clear_user_mode_skill_overrides, load_project_mode_skills_document_local,
+    project_mode_skills_path_for_remote, save_project_mode_skills_document_local,
+    set_disabled_mode_skills_in_document, set_mode_skill_disabled_in_document,
+    set_user_mode_skill_state,
 };
 use bitfun_core::agentic::tools::implementations::skills::{
     resolver::resolve_skill_default_enabled_for_mode, ModeSkillInfo, SkillData, SkillInfo,
@@ -87,6 +88,13 @@ pub struct SkillMarketDownloadResponse {
 pub struct ReplaceModeSkillSelectionRequest {
     pub mode_id: String,
     pub enabled_skill_keys: Vec<String>,
+    pub workspace_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResetModeSkillSelectionRequest {
+    pub mode_id: String,
     pub workspace_path: Option<String>,
 }
 
@@ -353,6 +361,104 @@ async fn persist_project_mode_skill_selection_remote(
     Ok(())
 }
 
+async fn clear_project_mode_skill_selection_local(
+    mode_id: &str,
+    workspace_root: &Path,
+) -> Result<(), String> {
+    let path = get_path_manager_arc().project_mode_skills_file(workspace_root);
+    let exists = tokio::fs::try_exists(&path)
+        .await
+        .map_err(|e| format!("Failed to check project mode skills file: {}", e))?;
+    if !exists {
+        return Ok(());
+    }
+
+    let mut document = load_project_mode_skills_document_local(workspace_root)
+        .await
+        .map_err(|e| format!("Failed to load project mode skills: {}", e))?;
+    set_disabled_mode_skills_in_document(&mut document, mode_id, Vec::new())
+        .map_err(|e| format!("Failed to clear project skill overrides: {}", e))?;
+
+    let document_is_empty = document
+        .as_object()
+        .map(|obj| obj.is_empty())
+        .unwrap_or(true);
+
+    if document_is_empty {
+        match tokio::fs::remove_file(&path).await {
+            Ok(_) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(format!(
+                "Failed to remove project mode skills file: {}",
+                error
+            )),
+        }
+    } else {
+        save_project_mode_skills_document_local(workspace_root, &document)
+            .await
+            .map_err(|e| format!("Failed to save project mode skills: {}", e))
+    }
+}
+
+async fn clear_project_mode_skill_selection_remote(
+    state: &State<'_, AppState>,
+    remote_root: &str,
+    entry: &RemoteWorkspaceEntry,
+    mode_id: &str,
+) -> Result<(), String> {
+    let remote_fs = state
+        .get_remote_file_service_async()
+        .await
+        .map_err(|e| format!("Remote file service not available: {}", e))?;
+    let config_path = project_mode_skills_path_for_remote(remote_root);
+    let exists = remote_fs
+        .exists(&entry.connection_id, &config_path)
+        .await
+        .map_err(|e| format!("Failed to check remote project skill overrides: {}", e))?;
+    if !exists {
+        return Ok(());
+    }
+
+    let content = remote_fs
+        .read_file(&entry.connection_id, &config_path)
+        .await
+        .map_err(|e| format!("Failed to read remote project skill overrides: {}", e))?;
+    let content = String::from_utf8(content)
+        .map_err(|e| format!("Remote project skill overrides are not valid UTF-8: {}", e))?;
+    let mut document = serde_json::from_str::<Value>(&content)
+        .map_err(|e| format!("Invalid remote project skill overrides JSON: {}", e))?;
+
+    set_disabled_mode_skills_in_document(&mut document, mode_id, Vec::new())
+        .map_err(|e| format!("Failed to clear remote project skill overrides: {}", e))?;
+
+    let document_is_empty = document
+        .as_object()
+        .map(|obj| obj.is_empty())
+        .unwrap_or(true);
+
+    if document_is_empty {
+        remote_fs
+            .remove_file(&entry.connection_id, &config_path)
+            .await
+            .map_err(|e| format!("Failed to remove remote project skill overrides: {}", e))?;
+    } else {
+        remote_fs
+            .write_file(
+                &entry.connection_id,
+                &config_path,
+                serde_json::to_vec_pretty(&document)
+                    .map_err(|e| {
+                        format!("Failed to serialize remote project skill overrides: {}", e)
+                    })?
+                    .as_slice(),
+            )
+            .await
+            .map_err(|e| format!("Failed to write remote project skill overrides: {}", e))?;
+    }
+
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn get_skill_configs(
     state: State<'_, AppState>,
@@ -593,6 +699,40 @@ pub async fn replace_mode_skill_selection(
 
     Ok(format!(
         "Mode '{}' skill selection updated successfully",
+        request.mode_id
+    ))
+}
+
+#[tauri::command]
+pub async fn reset_mode_skill_selection(
+    state: State<'_, AppState>,
+    request: ResetModeSkillSelectionRequest,
+) -> Result<String, String> {
+    clear_user_mode_skill_overrides(&request.mode_id)
+        .await
+        .map_err(|e| format!("Failed to reset user skill overrides: {}", e))?;
+
+    if let Some((remote_root, entry)) =
+        resolve_remote_workspace(&state, request.workspace_path.as_deref()).await?
+    {
+        clear_project_mode_skill_selection_remote(&state, &remote_root, &entry, &request.mode_id)
+            .await?;
+    } else if let Some(workspace_root) =
+        workspace_root_from_input(request.workspace_path.as_deref())
+    {
+        clear_project_mode_skill_selection_local(&request.mode_id, &workspace_root).await?;
+    }
+
+    if let Err(e) = bitfun_core::service::config::reload_global_config().await {
+        log::warn!(
+            "Failed to reload global config after resetting skill selection: mode_id={}, error={}",
+            request.mode_id,
+            e
+        );
+    }
+
+    Ok(format!(
+        "Mode '{}' skill selection reset successfully",
         request.mode_id
     ))
 }

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -675,6 +675,7 @@ pub async fn run() {
             download_skill_market,
             set_mode_skill_disabled,
             replace_mode_skill_selection,
+            reset_mode_skill_selection,
             validate_skill_path,
             add_skill,
             delete_skill,

--- a/src/apps/desktop/src/tray.rs
+++ b/src/apps/desktop/src/tray.rs
@@ -149,11 +149,7 @@ async fn collect_recent_sessions(app: &AppHandle, limit: usize) -> Vec<TraySessi
             if session.session_kind != SessionKind::Standard {
                 continue;
             }
-            let label = session_label(
-                &session.session_name,
-                &session.session_id,
-                &workspace_name,
-            );
+            let label = session_label(&session.session_name, &session.session_id, &workspace_name);
             all.push((
                 session.last_active_at,
                 TraySessionItem {
@@ -202,14 +198,13 @@ async fn rebuild_tray_menu(app: &AppHandle) {
 
     // ── Session items ─────────────────────────────────────────────────────────
     if sessions.is_empty() {
-        let no_sessions =
-            match MenuItemBuilder::with_id("no_sessions", s.no_recent_sessions)
-                .enabled(false)
-                .build(app)
-            {
-                Ok(i) => i,
-                Err(_) => return,
-            };
+        let no_sessions = match MenuItemBuilder::with_id("no_sessions", s.no_recent_sessions)
+            .enabled(false)
+            .build(app)
+        {
+            Ok(i) => i,
+            Err(_) => return,
+        };
         builder = builder.item(&no_sessions);
     } else {
         for item in &sessions {
@@ -257,9 +252,10 @@ async fn rebuild_tray_menu(app: &AppHandle) {
 pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // Build the initial (placeholder) menu; it will be replaced by rebuild_tray_menu
     // shortly after startup once the locale and sessions are known.
-    let no_sessions_item = MenuItemBuilder::with_id("no_sessions", STRINGS_EN_US.no_recent_sessions)
-        .enabled(false)
-        .build(app)?;
+    let no_sessions_item =
+        MenuItemBuilder::with_id("no_sessions", STRINGS_EN_US.no_recent_sessions)
+            .enabled(false)
+            .build(app)?;
     let show_item = MenuItemBuilder::with_id("show_window", STRINGS_EN_US.show_app).build(app)?;
     let quit_item = MenuItemBuilder::with_id("quit", STRINGS_EN_US.quit_app).build(app)?;
 

--- a/src/crates/core/src/agentic/tools/implementations/skills/catalog.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skills/catalog.rs
@@ -35,7 +35,7 @@ pub enum BuiltinSkillGroup {
     Office,
     Meta,
     ComputerUse,
-    Team,
+    Gstack,
 }
 
 impl BuiltinSkillGroup {
@@ -44,7 +44,7 @@ impl BuiltinSkillGroup {
             Self::Office => "office",
             Self::Meta => "meta",
             Self::ComputerUse => "computer-use",
-            Self::Team => "team",
+            Self::Gstack => "gstack",
         }
     }
 }
@@ -75,77 +75,77 @@ const BUILTIN_SKILL_SPECS: &[BuiltinSkillSpec] = &[
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackAutoplan,
         dir_name: "gstack-autoplan",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackCso,
         dir_name: "gstack-cso",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackDesignConsultation,
         dir_name: "gstack-design-consultation",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackDesignReview,
         dir_name: "gstack-design-review",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackDocumentRelease,
         dir_name: "gstack-document-release",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackInvestigate,
         dir_name: "gstack-investigate",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackOfficeHours,
         dir_name: "gstack-office-hours",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackPlanCeoReview,
         dir_name: "gstack-plan-ceo-review",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackPlanDesignReview,
         dir_name: "gstack-plan-design-review",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackPlanEngReview,
         dir_name: "gstack-plan-eng-review",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackQa,
         dir_name: "gstack-qa",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackQaOnly,
         dir_name: "gstack-qa-only",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackRetro,
         dir_name: "gstack-retro",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackReview,
         dir_name: "gstack-review",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::GstackShip,
         dir_name: "gstack-ship",
-        group: BuiltinSkillGroup::Team,
+        group: BuiltinSkillGroup::Gstack,
     },
     BuiltinSkillSpec {
         id: BuiltinSkillId::Pdf,
@@ -201,7 +201,7 @@ mod tests {
             builtin_skill_group_key("agent-browser"),
             Some("computer-use")
         );
-        assert_eq!(builtin_skill_group_key("gstack-review"), Some("team"));
+        assert_eq!(builtin_skill_group_key("gstack-review"), Some("gstack"));
         assert_eq!(builtin_skill_group("unknown-skill"), None);
     }
 

--- a/src/crates/core/src/agentic/tools/implementations/skills/mode_overrides.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skills/mode_overrides.rs
@@ -104,6 +104,21 @@ pub async fn set_user_mode_skill_state(
     load_user_mode_skill_overrides(mode_id).await
 }
 
+pub async fn clear_user_mode_skill_overrides(
+    mode_id: &str,
+) -> BitFunResult<UserModeSkillOverrides> {
+    persist_mode_config_from_value(
+        mode_id,
+        json!({
+            "disabled_user_skills": Vec::<String>::new(),
+            "enabled_user_skills": Vec::<String>::new(),
+        }),
+    )
+    .await?;
+
+    load_user_mode_skill_overrides(mode_id).await
+}
+
 pub fn project_mode_skills_path_for_remote(remote_root: &str) -> String {
     format!(
         "{}/.bitfun/config/{}",

--- a/src/crates/core/src/agentic/tools/implementations/skills/policy.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skills/policy.rs
@@ -70,8 +70,8 @@ const DISABLE_OFFICE: SkillPolicyRule = SkillPolicyRule {
     effect: PolicyEffect::Disable,
 };
 
-const DISABLE_TEAM: SkillPolicyRule = SkillPolicyRule {
-    selector: SkillSelector::Group(BuiltinSkillGroup::Team),
+const DISABLE_GSTACK: SkillPolicyRule = SkillPolicyRule {
+    selector: SkillSelector::Group(BuiltinSkillGroup::Gstack),
     effect: PolicyEffect::Disable,
 };
 
@@ -101,7 +101,7 @@ const DEBUG_POLICY: ModeSkillPolicy = PLAN_POLICY;
 
 const AGENTIC_POLICY: ModeSkillPolicy = ModeSkillPolicy {
     builtin_default: PolicyEffect::Enable,
-    rules: &[DISABLE_OFFICE, DISABLE_TEAM],
+    rules: &[DISABLE_OFFICE, DISABLE_GSTACK],
 };
 
 const COWORK_POLICY: ModeSkillPolicy = ModeSkillPolicy {

--- a/src/crates/core/src/agentic/tools/implementations/skills/registry.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skills/registry.rs
@@ -599,7 +599,7 @@ impl SkillRegistry {
 
         if info.level == SkillLocation::User
             && info.is_builtin
-            && info.group_key.as_deref() == Some("team")
+            && info.group_key.as_deref() == Some("gstack")
             && !resolve_skill_default_enabled_for_mode(&info, mode_id)
         {
             return Ok(info);

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -694,11 +694,7 @@ impl ToolPipeline {
         // Loop detection: refuse to execute the same tool call repeatedly with
         // identical arguments. Triggered on the (THRESHOLD + 1)-th consecutive
         // identical call within the per-session sliding window.
-        if self.check_and_record_tool_call(
-            &task.context.session_id,
-            &tool_name,
-            &tool_args,
-        ) {
+        if self.check_and_record_tool_call(&task.context.session_id, &tool_name, &tool_args) {
             let error_msg = format!(
                 "Tool-call loop blocked: '{}' was already called {} times in a row in this session with identical arguments. Refusing to execute this {}th identical call. Issue a different tool call, or stop tool-calling and respond to the user. If you wrote a file recently and want to continue it, its full content is already visible in your earlier tool_use message — use Edit with `old_string` taken from the end of that content; do not Read the file again.",
                 tool_name,

--- a/src/crates/core/src/service/config/types.rs
+++ b/src/crates/core/src/service/config/types.rs
@@ -1854,7 +1854,10 @@ mod tests {
         assert_eq!(actions[0].label, "Run tests");
 
         let serialized = serde_json::to_value(&config).expect("config should serialize");
-        assert_eq!(serialized["app"]["ai_experience"]["quick_actions"][0]["id"], "custom_1");
+        assert_eq!(
+            serialized["app"]["ai_experience"]["quick_actions"][0]["id"],
+            "custom_1"
+        );
     }
 
     #[test]

--- a/src/crates/core/src/util/process_manager.rs
+++ b/src/crates/core/src/util/process_manager.rs
@@ -4,9 +4,9 @@ use std::io;
 use std::process::Command;
 use std::sync::LazyLock;
 use tokio::process::{Child, Command as TokioCommand};
-use tokio::time::Duration;
 #[cfg(unix)]
 use tokio::time::timeout;
+use tokio::time::Duration;
 
 #[cfg(windows)]
 use log::warn;

--- a/src/web-ui/src/app/scenes/skills/SkillsScene.scss
+++ b/src/web-ui/src/app/scenes/skills/SkillsScene.scss
@@ -325,6 +325,307 @@
   }
 }
 
+// ── Suite Page ───────────────────────────────────────────────────────────────
+
+.skills-suite {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 20px 24px 18px;
+  overflow: hidden;
+}
+
+.skills-suite__hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 1px solid color-mix(in srgb, var(--color-accent-500) 18%, var(--border-subtle));
+  border-radius: $size-radius-lg;
+  background:
+    radial-gradient(circle at top right, color-mix(in srgb, var(--color-accent-500) 12%, transparent), transparent 42%),
+    linear-gradient(180deg, color-mix(in srgb, var(--color-accent-500) 7%, var(--color-bg-secondary)), var(--color-bg-secondary));
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+}
+
+.skills-suite__hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.skills-suite__eyebrow {
+  font-size: 11px;
+  font-weight: $font-weight-semibold;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-accent-500);
+}
+
+.skills-suite__title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: $font-weight-semibold;
+  line-height: $line-height-tight;
+  color: var(--color-text-primary);
+}
+
+.skills-suite__subtitle {
+  margin: 0;
+  max-width: 720px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.55;
+}
+
+.skills-suite__mode-toolbar {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  padding: 0 2px 2px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.skills-suite__modes {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: flex-end;
+  gap: 18px;
+  overflow-x: auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.skills-suite__mode-tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 0 12px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color $motion-fast $easing-standard;
+
+  &:hover:not(:disabled):not(.is-active) {
+    color: var(--color-text-primary);
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 2px;
+    border-radius: 999px;
+    background: transparent;
+    transition: background $motion-fast $easing-standard;
+  }
+
+  &.is-active {
+    color: var(--color-text-primary);
+
+    &::after {
+      background: var(--color-accent-500);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent-500);
+    outline-offset: 4px;
+    border-radius: 4px;
+  }
+
+  &:disabled {
+    cursor: wait;
+    opacity: 0.75;
+  }
+}
+
+.skills-suite__mode-tab-label {
+  font-size: 13px;
+  font-weight: $font-weight-semibold;
+  line-height: 1.2;
+}
+
+.skills-suite__mode-reset {
+  flex-shrink: 0;
+  margin-bottom: 4px;
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  padding: 0;
+  border-radius: 999px;
+
+  &.btn-loading .btn-loading-text {
+    display: none;
+  }
+}
+
+.skills-suite__mode-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
+.skills-suite__loading {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--color-text-muted);
+}
+
+.skills-suite__loading-icon {
+  animation: skills-suite-spin 0.9s linear infinite;
+}
+
+.skills-suite__grid {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 14px;
+  align-content: start;
+  padding-right: 4px;
+
+  &::-webkit-scrollbar { width: 5px; }
+  &::-webkit-scrollbar-thumb { background: var(--border-subtle); border-radius: 3px; }
+}
+
+.skills-suite__group-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px 18px;
+  border: 1px solid var(--border-subtle);
+  border-radius: $size-radius-lg;
+  background: var(--color-bg-secondary);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.04);
+}
+
+.skills-suite__group-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.skills-suite__group-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.skills-suite__group-title-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.skills-suite__group-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.skills-suite__group-title {
+  font-size: 13px;
+  font-weight: $font-weight-semibold;
+  color: var(--color-text-primary);
+}
+
+.skills-suite__group-count {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
+.skills-suite__skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.skills-suite__skill-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--element-bg-subtle);
+  color: var(--color-text-muted);
+  font-size: 11px;
+  font-weight: $font-weight-medium;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background $motion-fast $easing-standard,
+    border-color $motion-fast $easing-standard,
+    color $motion-fast $easing-standard,
+    opacity $motion-fast $easing-standard;
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent-500);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: wait;
+    opacity: 0.7;
+  }
+
+  &.is-enabled {
+    background: color-mix(in srgb, var(--color-success) 12%, var(--element-bg-subtle));
+    border-color: color-mix(in srgb, var(--color-success) 28%, var(--border-subtle));
+    color: var(--color-text-primary);
+  }
+
+  &.is-disabled {
+    opacity: 0.72;
+  }
+
+  &.is-shadowed {
+    text-decoration: line-through;
+  }
+
+  &.is-dirty {
+    border-color: color-mix(in srgb, var(--color-accent-500) 34%, var(--border-subtle));
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent-500) 12%, transparent);
+  }
+}
+
+.skills-suite__skill-chip-name {
+  min-width: 0;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@keyframes skills-suite-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 // ── Card Grid ──
 
 .skills-main__grid {
@@ -887,6 +1188,27 @@
   .skills-main__grid {
     grid-template-columns: 1fr;
     padding: 12px 16px;
+  }
+
+  .skills-suite {
+    padding: 14px 16px 16px;
+  }
+
+  .skills-suite__hero {
+    flex-direction: column;
+    padding: 16px;
+  }
+
+  .skills-suite__mode-toolbar {
+    align-items: center;
+  }
+
+  .skills-suite__modes {
+    gap: 14px;
+  }
+
+  .skills-suite__grid {
+    grid-template-columns: 1fr;
   }
 
   .skills-discover__hero {

--- a/src/web-ui/src/app/scenes/skills/SkillsScene.tsx
+++ b/src/web-ui/src/app/scenes/skills/SkillsScene.tsx
@@ -31,6 +31,7 @@ import { getCardGradient } from '@/shared/utils/cardGradients';
 import { useInstalledSkills } from './hooks/useInstalledSkills';
 import { useSkillMarket } from './hooks/useSkillMarket';
 import SkillCard from './components/SkillCard';
+import SkillsSuiteView from './components/SkillsSuiteView';
 import './SkillsScene.scss';
 import { useSkillsSceneStore, type InstalledFilter } from './skillsSceneStore';
 import { useGallerySceneAutoRefresh } from '@/app/hooks/useGallerySceneAutoRefresh';
@@ -216,188 +217,194 @@ const SkillsScene: React.FC = () => {
             </aside>
 
             <div className="skills-main">
-              <div className="skills-main__toolbar">
-                <Search
-                  className="skills-main__toolbar-search"
-                  value={installedSearch}
-                  onChange={setInstalledSearch}
-                  onClear={() => setInstalledSearch('')}
-                  placeholder={t('toolbar.searchPlaceholder')}
-                  size="small"
-                  clearable
-                />
-                <button
-                  type="button"
-                  className={`skills-main__chip-btn${hideDuplicates ? ' is-active' : ''}`}
-                  onClick={() => setHideDuplicates(!hideDuplicates)}
-                >
-                  <Filter size={13} />
-                  <span>{t('toolbar.hideDuplicates')}</span>
-                </button>
-                <button type="button" className="skills-main__add-btn" onClick={toggleAddForm}>
-                  <Plus size={13} />
-                  <span>{t('toolbar.addTooltip')}</span>
-                </button>
-              </div>
-
-              {installed.loading && (
-                <div className="skills-main__loading" aria-busy="true" aria-label={t('list.loading')}>
-                  {Array.from({ length: 8 }).map((_, i) => (
-                    <div
-                      key={`ins-sk-${i}`}
-                      className="skills-card-skeleton"
-                      style={{ '--card-index': i } as React.CSSProperties}
-                    />
-                  ))}
-                </div>
-              )}
-
-              {!installed.loading && installed.error && (
-                <div className="skills-main__empty skills-main__empty--error">
-                  <Package size={28} strokeWidth={1.2} />
-                  <span>{installed.error}</span>
-                </div>
-              )}
-
-              {!installed.loading && !installed.error && installedFiltered.length === 0 && (
-                <div className="skills-main__empty">
-                  <Package size={28} strokeWidth={1.2} />
-                  <span>
-                    {installed.skills.length === 0
-                      ? t('list.empty.noSkills')
-                      : t('list.empty.noMatch')}
-                  </span>
-                </div>
-              )}
-
-              {!installed.loading && !installed.error && (
+              {installedFilter === 'suite' ? (
+                <SkillsSuiteView />
+              ) : (
                 <>
-                  <div className="skills-main__grid">
-                    {pagedInstalledSkills.map((skill, index) => (
-                      <div
-                        key={skill.key}
-                        className={[
-                          'skills-card',
-                          skill.isShadowed && 'is-shadowed',
-                        ].filter(Boolean).join(' ')}
-                        style={{ '--card-index': index } as React.CSSProperties}
-                        onClick={() => setSelectedDetail({ type: 'installed', skill })}
-                        role="button"
-                        tabIndex={0}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            setSelectedDetail({ type: 'installed', skill });
-                          }
-                        }}
-                        aria-label={skill.name}
-                      >
-                        <div className="skills-card__top">
-                          <div className="skills-card__icon">
-                            <Puzzle size={18} strokeWidth={1.6} />
-                          </div>
-                          <div className="skills-card__info">
-                            <span className="skills-card__name">{skill.name}</span>
-                            {skill.description?.trim() && (
-                              <span className="skills-card__desc">{skill.description}</span>
-                            )}
-                          </div>
-                          {skill.isBuiltin && (
-                            <Badge variant="accent">
-                              <ShieldCheck size={11} />
-                              {t('list.item.builtin')}
-                            </Badge>
-                          )}
-                        </div>
-
-                        <div className="skills-card__meta">
-                          {skill.isShadowed && (
-                            <span title={t('list.item.shadowedTooltip')}>
-                              <Badge variant="warning">
-                                <ShieldAlert size={11} />
-                                {t('list.item.shadowed')}
-                              </Badge>
-                            </span>
-                          )}
-                          <Badge
-                            variant={skill.level === 'user' ? 'info' : 'purple'}
-                          >
-                            {skill.level === 'user'
-                              ? <User size={11} />
-                              : <FolderOpen size={11} />}
-                            {skill.level === 'user' ? t('list.item.user') : t('list.item.project')}
-                          </Badge>
-                          {skill.path && (
-                            <button
-                              type="button"
-                              className="skills-card__path"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleRevealSkillPath(skill.path);
-                              }}
-                              title={skill.path}
-                            >
-                              {skill.path}
-                            </button>
-                          )}
-                        </div>
-
-                        <div
-                          className="skills-card__actions"
-                          onClick={(e) => e.stopPropagation()}
-                          onKeyDown={(e) => e.stopPropagation()}
-                        >
-                          <Button
-                            variant="ghost"
-                            size="small"
-                            onClick={() => setSelectedDetail({ type: 'installed', skill })}
-                          >
-                            <span>{t('list.item.detail')}</span>
-                            <ArrowRight size={12} />
-                          </Button>
-                          {!skill.isBuiltin && (
-                            <button
-                              type="button"
-                              className="skills-card__delete"
-                              onClick={() => setDeleteTarget(skill)}
-                              aria-label={t('list.item.deleteTooltip')}
-                              title={t('list.item.deleteTooltip')}
-                            >
-                              <Trash2 size={13} />
-                            </button>
-                          )}
-                        </div>
-                      </div>
-                    ))}
+                  <div className="skills-main__toolbar">
+                    <Search
+                      className="skills-main__toolbar-search"
+                      value={installedSearch}
+                      onChange={setInstalledSearch}
+                      onClear={() => setInstalledSearch('')}
+                      placeholder={t('toolbar.searchPlaceholder')}
+                      size="small"
+                      clearable
+                    />
+                    <button
+                      type="button"
+                      className={`skills-main__chip-btn${hideDuplicates ? ' is-active' : ''}`}
+                      onClick={() => setHideDuplicates(!hideDuplicates)}
+                    >
+                      <Filter size={13} />
+                      <span>{t('toolbar.hideDuplicates')}</span>
+                    </button>
+                    <button type="button" className="skills-main__add-btn" onClick={toggleAddForm}>
+                      <Plus size={13} />
+                      <span>{t('toolbar.addTooltip')}</span>
+                    </button>
                   </div>
 
-                  {installedFiltered.length > 0 && installedTotalPages > 1 && (
-                    <div className="skills-installed__pagination">
-                      <button
-                        type="button"
-                        className="skills-installed__page-btn"
-                        onClick={() => setInstalledListPage((p) => Math.max(0, p - 1))}
-                        disabled={currentInstalledPage === 0}
-                        aria-label={t('market.pagination.prev')}
-                      >
-                        <ChevronLeft size={14} />
-                      </button>
-                      <span className="skills-installed__page-info">
-                        {t('market.pagination.info', {
-                          current: currentInstalledPage + 1,
-                          total: installedTotalPages,
-                        })}
-                      </span>
-                      <button
-                        type="button"
-                        className="skills-installed__page-btn"
-                        onClick={() => setInstalledListPage((p) => Math.min(installedTotalPages - 1, p + 1))}
-                        disabled={currentInstalledPage >= installedTotalPages - 1}
-                        aria-label={t('market.pagination.next')}
-                      >
-                        <ChevronRight size={14} />
-                      </button>
+                  {installed.loading && (
+                    <div className="skills-main__loading" aria-busy="true" aria-label={t('list.loading')}>
+                      {Array.from({ length: 8 }).map((_, i) => (
+                        <div
+                          key={`ins-sk-${i}`}
+                          className="skills-card-skeleton"
+                          style={{ '--card-index': i } as React.CSSProperties}
+                        />
+                      ))}
                     </div>
+                  )}
+
+                  {!installed.loading && installed.error && (
+                    <div className="skills-main__empty skills-main__empty--error">
+                      <Package size={28} strokeWidth={1.2} />
+                      <span>{installed.error}</span>
+                    </div>
+                  )}
+
+                  {!installed.loading && !installed.error && installedFiltered.length === 0 && (
+                    <div className="skills-main__empty">
+                      <Package size={28} strokeWidth={1.2} />
+                      <span>
+                        {installed.skills.length === 0
+                          ? t('list.empty.noSkills')
+                          : t('list.empty.noMatch')}
+                      </span>
+                    </div>
+                  )}
+
+                  {!installed.loading && !installed.error && (
+                    <>
+                      <div className="skills-main__grid">
+                        {pagedInstalledSkills.map((skill, index) => (
+                          <div
+                            key={skill.key}
+                            className={[
+                              'skills-card',
+                              skill.isShadowed && 'is-shadowed',
+                            ].filter(Boolean).join(' ')}
+                            style={{ '--card-index': index } as React.CSSProperties}
+                            onClick={() => setSelectedDetail({ type: 'installed', skill })}
+                            role="button"
+                            tabIndex={0}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                setSelectedDetail({ type: 'installed', skill });
+                              }
+                            }}
+                            aria-label={skill.name}
+                          >
+                            <div className="skills-card__top">
+                              <div className="skills-card__icon">
+                                <Puzzle size={18} strokeWidth={1.6} />
+                              </div>
+                              <div className="skills-card__info">
+                                <span className="skills-card__name">{skill.name}</span>
+                                {skill.description?.trim() && (
+                                  <span className="skills-card__desc">{skill.description}</span>
+                                )}
+                              </div>
+                              {skill.isBuiltin && (
+                                <Badge variant="accent">
+                                  <ShieldCheck size={11} />
+                                  {t('list.item.builtin')}
+                                </Badge>
+                              )}
+                            </div>
+
+                            <div className="skills-card__meta">
+                              {skill.isShadowed && (
+                                <span title={t('list.item.shadowedTooltip')}>
+                                  <Badge variant="warning">
+                                    <ShieldAlert size={11} />
+                                    {t('list.item.shadowed')}
+                                  </Badge>
+                                </span>
+                              )}
+                              <Badge
+                                variant={skill.level === 'user' ? 'info' : 'purple'}
+                              >
+                                {skill.level === 'user'
+                                  ? <User size={11} />
+                                  : <FolderOpen size={11} />}
+                                {skill.level === 'user' ? t('list.item.user') : t('list.item.project')}
+                              </Badge>
+                              {skill.path && (
+                                <button
+                                  type="button"
+                                  className="skills-card__path"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleRevealSkillPath(skill.path);
+                                  }}
+                                  title={skill.path}
+                                >
+                                  {skill.path}
+                                </button>
+                              )}
+                            </div>
+
+                            <div
+                              className="skills-card__actions"
+                              onClick={(e) => e.stopPropagation()}
+                              onKeyDown={(e) => e.stopPropagation()}
+                            >
+                              <Button
+                                variant="ghost"
+                                size="small"
+                                onClick={() => setSelectedDetail({ type: 'installed', skill })}
+                              >
+                                <span>{t('list.item.detail')}</span>
+                                <ArrowRight size={12} />
+                              </Button>
+                              {!skill.isBuiltin && (
+                                <button
+                                  type="button"
+                                  className="skills-card__delete"
+                                  onClick={() => setDeleteTarget(skill)}
+                                  aria-label={t('list.item.deleteTooltip')}
+                                  title={t('list.item.deleteTooltip')}
+                                >
+                                  <Trash2 size={13} />
+                                </button>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+
+                      {installedFiltered.length > 0 && installedTotalPages > 1 && (
+                        <div className="skills-installed__pagination">
+                          <button
+                            type="button"
+                            className="skills-installed__page-btn"
+                            onClick={() => setInstalledListPage((p) => Math.max(0, p - 1))}
+                            disabled={currentInstalledPage === 0}
+                            aria-label={t('market.pagination.prev')}
+                          >
+                            <ChevronLeft size={14} />
+                          </button>
+                          <span className="skills-installed__page-info">
+                            {t('market.pagination.info', {
+                              current: currentInstalledPage + 1,
+                              total: installedTotalPages,
+                            })}
+                          </span>
+                          <button
+                            type="button"
+                            className="skills-installed__page-btn"
+                            onClick={() => setInstalledListPage((p) => Math.min(installedTotalPages - 1, p + 1))}
+                            disabled={currentInstalledPage >= installedTotalPages - 1}
+                            aria-label={t('market.pagination.next')}
+                          >
+                            <ChevronRight size={14} />
+                          </button>
+                        </div>
+                      )}
+                    </>
                   )}
                 </>
               )}

--- a/src/web-ui/src/app/scenes/skills/components/SkillsSuiteView.tsx
+++ b/src/web-ui/src/app/scenes/skills/components/SkillsSuiteView.tsx
@@ -1,0 +1,581 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Package, RefreshCw, RotateCcw, ShieldAlert, ShieldCheck } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Badge, Button } from '@/component-library';
+import { confirmDialog } from '@/component-library/components/ConfirmDialog/confirmService';
+import { configAPI } from '@/infrastructure/api';
+import { useWorkspaceManagerSync } from '@/infrastructure/hooks/useWorkspaceManagerSync';
+import { useGallerySceneAutoRefresh } from '@/app/hooks/useGallerySceneAutoRefresh';
+import type { ModeSkillInfo } from '@/infrastructure/config/types';
+import { useNotification } from '@/shared/notification-system';
+import { createLogger } from '@/shared/utils/logger';
+import type { SuiteModeId } from '../skillsSceneStore';
+import { useSkillsSceneStore } from '../skillsSceneStore';
+
+const log = createLogger('SkillsSuiteView');
+
+const UNGROUPED_SKILL_GROUP = '__ungrouped__';
+
+const SKILL_GROUP_ORDER: Record<string, number> = {
+  meta: 0,
+  'computer-use': 1,
+  office: 2,
+  gstack: 3,
+  [UNGROUPED_SKILL_GROUP]: 99,
+};
+
+const SUITE_MODES = [
+  { id: 'agentic', labelKey: 'suite.modes.agentic', descKey: 'suite.modeDescriptions.agentic' },
+  { id: 'Cowork', labelKey: 'suite.modes.cowork', descKey: 'suite.modeDescriptions.cowork' },
+  { id: 'Claw', labelKey: 'suite.modes.claw', descKey: 'suite.modeDescriptions.claw' },
+  { id: 'Team', labelKey: 'suite.modes.team', descKey: 'suite.modeDescriptions.team' },
+] as const;
+
+type SuiteMode = typeof SUITE_MODES[number];
+
+interface SuiteSkillGroup {
+  key: string;
+  label: string;
+  skills: ModeSkillInfo[];
+  enabledCount: number;
+  totalCount: number;
+}
+
+type SavingAction = {
+  groupKey: string;
+  kind: 'save' | 'toggle';
+} | null;
+
+function uniqueKeys(keys: Iterable<string>): string[] {
+  return [...new Set([...keys].filter(Boolean))];
+}
+
+function buildEnabledKeySet(skills: ModeSkillInfo[]): string[] {
+  return uniqueKeys(skills.filter((skill) => skill.effectiveEnabled).map((skill) => skill.key));
+}
+
+function cloneSet(keys: Iterable<string>): Set<string> {
+  return new Set(keys);
+}
+
+function getSkillGroupKey(skill: ModeSkillInfo): string {
+  return skill.groupKey?.trim() || UNGROUPED_SKILL_GROUP;
+}
+
+function getSkillGroupLabel(groupKey: string, t: (key: string) => string): string {
+  switch (groupKey) {
+    case 'office':
+      return t('suite.groups.office');
+    case 'computer-use':
+      return t('suite.groups.computerUse');
+    case 'meta':
+      return t('suite.groups.meta');
+    case 'gstack':
+      return t('suite.groups.gstack');
+    default:
+      return t('suite.groups.other');
+  }
+}
+
+function buildBuiltinSkillGroups(
+  skills: ModeSkillInfo[],
+  enabledKeySet: Set<string>,
+  t: (key: string) => string,
+): SuiteSkillGroup[] {
+  const groups = new Map<string, ModeSkillInfo[]>();
+
+  for (const skill of skills) {
+    if (!skill.isBuiltin) {
+      continue;
+    }
+
+    const groupKey = getSkillGroupKey(skill);
+    const items = groups.get(groupKey);
+    if (items) {
+      items.push(skill);
+    } else {
+      groups.set(groupKey, [skill]);
+    }
+  }
+
+  return [...groups.entries()]
+    .map(([groupKey, groupSkills]) => ({
+      key: groupKey,
+      label: getSkillGroupLabel(groupKey, t),
+      skills: [...groupSkills].sort((a, b) => {
+        const aEnabled = enabledKeySet.has(a.key);
+        const bEnabled = enabledKeySet.has(b.key);
+        if (aEnabled && !bEnabled) return -1;
+        if (!aEnabled && bEnabled) return 1;
+        return a.name.localeCompare(b.name) || a.key.localeCompare(b.key);
+      }),
+      enabledCount: groupSkills.filter((skill) => enabledKeySet.has(skill.key)).length,
+      totalCount: groupSkills.length,
+    }))
+    .sort((a, b) => {
+      const orderDiff = (SKILL_GROUP_ORDER[a.key] ?? 50) - (SKILL_GROUP_ORDER[b.key] ?? 50);
+      if (orderDiff !== 0) {
+        return orderDiff;
+      }
+      return a.label.localeCompare(b.label);
+    });
+}
+
+function buildSkillTitle(skill: ModeSkillInfo, enabled: boolean, t: (key: string) => string): string {
+  return [
+    skill.description || skill.name,
+    enabled ? t('suite.groupState.enabled') : t('suite.groupState.disabled'),
+    enabled && skill.isShadowed ? t('list.item.shadowedTooltip') : null,
+  ].filter(Boolean).join('\n');
+}
+
+function buildGroupKeySet(group: SuiteSkillGroup): Set<string> {
+  return new Set(group.skills.map((skill) => skill.key));
+}
+
+function isSameKeySet(leftKeys: string[], rightKeys: string[]): boolean {
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+
+  const rightKeySet = new Set(rightKeys);
+  return leftKeys.every((key) => rightKeySet.has(key));
+}
+
+const SkillsSuiteView: React.FC = () => {
+  const { t } = useTranslation('scenes/skills');
+  const notification = useNotification();
+  const { workspacePath } = useWorkspaceManagerSync();
+  const suiteModeId = useSkillsSceneStore((state) => state.suiteModeId);
+  const setSuiteModeId = useSkillsSceneStore((state) => state.setSuiteModeId);
+
+  const [modeSkills, setModeSkills] = useState<ModeSkillInfo[]>([]);
+  const [committedEnabledKeys, setCommittedEnabledKeys] = useState<string[]>([]);
+  const [draftEnabledKeys, setDraftEnabledKeys] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [savingAction, setSavingAction] = useState<SavingAction>(null);
+  const [resettingModeId, setResettingModeId] = useState<SuiteModeId | null>(null);
+  const loadRequestIdRef = useRef(0);
+
+  const currentMode = useMemo(
+    () => SUITE_MODES.find((mode) => mode.id === suiteModeId) ?? SUITE_MODES[0],
+    [suiteModeId],
+  );
+
+  const committedEnabledKeySet = useMemo(
+    () => cloneSet(committedEnabledKeys),
+    [committedEnabledKeys],
+  );
+  const draftEnabledKeySet = useMemo(
+    () => cloneSet(draftEnabledKeys),
+    [draftEnabledKeys],
+  );
+
+  const suiteGroups = useMemo(
+    () => buildBuiltinSkillGroups(modeSkills, draftEnabledKeySet, t),
+    [modeSkills, draftEnabledKeySet, t],
+  );
+
+  const hasUnsavedChanges = useMemo(
+    () => !isSameKeySet(draftEnabledKeys, committedEnabledKeys),
+    [committedEnabledKeys, draftEnabledKeys],
+  );
+
+  const isSaving = savingAction !== null || resettingModeId !== null;
+
+  const loadModeSkills = useCallback(async (forceRefresh?: boolean) => {
+    const requestId = ++loadRequestIdRef.current;
+
+    try {
+      setLoading(true);
+      setError(null);
+      const skills = await configAPI.getModeSkillConfigs({
+        modeId: suiteModeId,
+        forceRefresh,
+        workspacePath: workspacePath || undefined,
+      });
+
+      if (requestId !== loadRequestIdRef.current) {
+        return;
+      }
+
+      setModeSkills(skills);
+      const enabledKeys = buildEnabledKeySet(skills);
+      setCommittedEnabledKeys(enabledKeys);
+      setDraftEnabledKeys(enabledKeys);
+    } catch (loadError) {
+      if (requestId !== loadRequestIdRef.current) {
+        return;
+      }
+
+      const message = loadError instanceof Error ? loadError.message : String(loadError);
+      log.error('Failed to load skill suite mode configs', {
+        modeId: suiteModeId,
+        workspacePath,
+        error: loadError,
+      });
+      setError(message);
+    } finally {
+      if (requestId === loadRequestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [suiteModeId, workspacePath]);
+
+  useEffect(() => {
+    void loadModeSkills();
+  }, [loadModeSkills]);
+
+  useGallerySceneAutoRefresh({
+    sceneId: 'skills',
+    refetch: () => loadModeSkills(true),
+    enabled: !hasUnsavedChanges,
+  });
+
+  const refresh = useCallback(async () => {
+    if (hasUnsavedChanges) {
+      notification.warning(t('suite.messages.saveFirst'));
+      return;
+    }
+    try {
+      await loadModeSkills(true);
+    } catch (refreshError) {
+      notification.error(
+        t('suite.messages.refreshFailed', {
+          error: refreshError instanceof Error ? refreshError.message : String(refreshError),
+        }),
+      );
+    }
+  }, [hasUnsavedChanges, loadModeSkills, notification, t]);
+
+  const handleModeSelect = useCallback((modeId: typeof SUITE_MODES[number]['id']) => {
+    if (hasUnsavedChanges) {
+      notification.warning(t('suite.messages.saveFirst'));
+      return;
+    }
+
+    setSuiteModeId(modeId);
+  }, [hasUnsavedChanges, notification, setSuiteModeId, t]);
+
+  const resetMode = useCallback(async (mode: SuiteMode) => {
+    const shouldReset = await confirmDialog({
+      title: t('suite.resetDialog.title', { mode: t(mode.labelKey) }),
+      message: t(
+        mode.id === suiteModeId && hasUnsavedChanges
+          ? 'suite.resetDialog.messageWithUnsaved'
+          : 'suite.resetDialog.message',
+        { mode: t(mode.labelKey) },
+      ),
+      confirmText: t('suite.resetDialog.confirm'),
+      cancelText: t('suite.resetDialog.cancel'),
+      confirmDanger: true,
+      type: 'warning',
+    });
+
+    if (!shouldReset) {
+      return;
+    }
+
+    setResettingModeId(mode.id);
+
+    try {
+      await configAPI.resetModeSkillSelection({
+        modeId: mode.id,
+        workspacePath: workspacePath || undefined,
+      });
+
+      if (mode.id === suiteModeId) {
+        await loadModeSkills(true);
+      }
+
+      const { globalEventBus } = await import('@/infrastructure/event-bus');
+      globalEventBus.emit('mode:config:updated');
+      notification.success(t('suite.messages.resetSuccess', { mode: t(mode.labelKey) }));
+    } catch (resetError) {
+      log.error('Failed to reset skill suite visibility', {
+        modeId: mode.id,
+        workspacePath,
+        error: resetError,
+      });
+      notification.error(t('suite.messages.resetFailed', {
+        error: resetError instanceof Error ? resetError.message : String(resetError),
+      }));
+    } finally {
+      setResettingModeId(null);
+    }
+  }, [hasUnsavedChanges, loadModeSkills, notification, suiteModeId, t, workspacePath]);
+
+  const saveGroup = useCallback(async (group: SuiteSkillGroup) => {
+    setSavingAction({ groupKey: group.key, kind: 'save' });
+    const nextCommitted = uniqueKeys(draftEnabledKeys);
+
+    try {
+      await configAPI.replaceModeSkillSelection({
+        modeId: suiteModeId,
+        enabledSkillKeys: nextCommitted,
+        workspacePath: workspacePath || undefined,
+      });
+
+      const refreshedSkills = await configAPI.getModeSkillConfigs({
+        modeId: suiteModeId,
+        forceRefresh: true,
+        workspacePath: workspacePath || undefined,
+      });
+      setModeSkills(refreshedSkills);
+      const refreshedEnabledKeys = buildEnabledKeySet(refreshedSkills);
+      setCommittedEnabledKeys(refreshedEnabledKeys);
+      setDraftEnabledKeys(refreshedEnabledKeys);
+
+      const { globalEventBus } = await import('@/infrastructure/event-bus');
+      globalEventBus.emit('mode:config:updated');
+
+      notification.success(
+        t('suite.messages.saveSuccess', {
+          mode: t(currentMode.labelKey),
+        }),
+      );
+    } catch (saveError) {
+      log.error('Failed to update skill suite visibility', {
+        modeId: suiteModeId,
+        groupKey: group.key,
+        workspacePath,
+        error: saveError,
+      });
+      notification.error(
+        t('suite.messages.saveFailed', {
+          error: saveError instanceof Error ? saveError.message : String(saveError),
+        }),
+      );
+    } finally {
+      setSavingAction(null);
+    }
+  }, [currentMode.labelKey, draftEnabledKeys, notification, suiteModeId, t, workspacePath]);
+
+  const saveGroupVisibility = useCallback(async (group: SuiteSkillGroup, enabled: boolean) => {
+    const groupKeys = buildGroupKeySet(group);
+    const previousDraft = draftEnabledKeys;
+    const baseDraft = draftEnabledKeys.filter((key) => !groupKeys.has(key));
+    const finalDraft = enabled
+      ? uniqueKeys([...baseDraft, ...group.skills.map((skill) => skill.key)])
+      : uniqueKeys(baseDraft);
+    setSavingAction({ groupKey: group.key, kind: 'toggle' });
+    setDraftEnabledKeys(finalDraft);
+    try {
+      await configAPI.replaceModeSkillSelection({
+        modeId: suiteModeId,
+        enabledSkillKeys: finalDraft,
+        workspacePath: workspacePath || undefined,
+      });
+      const refreshedSkills = await configAPI.getModeSkillConfigs({
+        modeId: suiteModeId,
+        forceRefresh: true,
+        workspacePath: workspacePath || undefined,
+      });
+      setModeSkills(refreshedSkills);
+      const refreshedEnabledKeys = buildEnabledKeySet(refreshedSkills);
+      setCommittedEnabledKeys(refreshedEnabledKeys);
+      setDraftEnabledKeys(refreshedEnabledKeys);
+      const { globalEventBus } = await import('@/infrastructure/event-bus');
+      globalEventBus.emit('mode:config:updated');
+      notification.success(t('suite.messages.saveSuccess', { mode: t(currentMode.labelKey) }));
+    } catch (saveError) {
+      log.error('Failed to update skill suite visibility', {
+        modeId: suiteModeId,
+        groupKey: group.key,
+        workspacePath,
+        error: saveError,
+      });
+      notification.error(t('suite.messages.saveFailed', {
+        error: saveError instanceof Error ? saveError.message : String(saveError),
+      }));
+      setDraftEnabledKeys(previousDraft);
+    } finally {
+      setSavingAction(null);
+    }
+  }, [currentMode.labelKey, draftEnabledKeys, notification, suiteModeId, t, workspacePath]);
+
+  return (
+    <div className="skills-suite">
+      <div className="skills-suite__hero">
+        <div className="skills-suite__hero-copy">
+          <h2 className="skills-suite__title">{t('suite.title')}</h2>
+          <p className="skills-suite__subtitle">{t('suite.subtitle')}</p>
+        </div>
+        <Button
+          variant="secondary"
+          size="small"
+          onClick={() => void refresh()}
+          title={t('suite.refreshTooltip')}
+          aria-label={t('suite.refreshTooltip')}
+          disabled={loading || isSaving || hasUnsavedChanges}
+        >
+          <RefreshCw size={13} />
+          <span>{t('suite.refreshAction')}</span>
+        </Button>
+      </div>
+
+      <div className="skills-suite__mode-toolbar">
+        <div className="skills-suite__modes" role="tablist" aria-label={t('suite.modeLabel')}>
+        {SUITE_MODES.map((mode) => (
+            <button
+              key={mode.id}
+              id={`skills-suite-tab-${mode.id}`}
+              type="button"
+              role="tab"
+              aria-selected={suiteModeId === mode.id}
+              aria-controls={`skills-suite-panel-${mode.id}`}
+              className={`skills-suite__mode-tab${suiteModeId === mode.id ? ' is-active' : ''}`}
+              onClick={() => handleModeSelect(mode.id)}
+              disabled={isSaving}
+              title={t(mode.descKey)}
+            >
+              <span className="skills-suite__mode-tab-label">{t(mode.labelKey)}</span>
+            </button>
+        ))}
+        </div>
+        <Button
+          variant="secondary"
+          size="small"
+          className="skills-suite__mode-reset"
+          iconOnly
+          isLoading={resettingModeId === suiteModeId}
+          disabled={isSaving}
+          onClick={() => { void resetMode(currentMode); }}
+          title={t('suite.modeActions.reset', { mode: t(currentMode.labelKey) })}
+          aria-label={t('suite.modeActions.reset', { mode: t(currentMode.labelKey) })}
+        >
+          <RotateCcw size={13} />
+        </Button>
+      </div>
+
+      {loading && (
+        <div className="skills-suite__loading" aria-busy="true" aria-label={t('suite.loading')}>
+          <RefreshCw size={16} className="skills-suite__loading-icon" />
+          <span>{t('suite.loading')}</span>
+        </div>
+      )}
+
+      {!loading && error && (
+        <div className="skills-main__empty skills-main__empty--error">
+          <Package size={28} strokeWidth={1.2} />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {!loading && !error && suiteGroups.length === 0 && (
+        <div className="skills-main__empty">
+          <Package size={28} strokeWidth={1.2} />
+          <span>{t('suite.empty')}</span>
+        </div>
+      )}
+
+      {!loading && !error && suiteGroups.length > 0 && (
+        <div
+          id={`skills-suite-panel-${suiteModeId}`}
+          role="tabpanel"
+          aria-labelledby={`skills-suite-tab-${suiteModeId}`}
+          className="skills-suite__grid"
+        >
+          {suiteGroups.map((group) => {
+            const allEnabled = group.enabledCount === group.totalCount;
+            const someEnabled = group.enabledCount > 0;
+            const groupDirty = group.skills.some(
+              (skill) => committedEnabledKeySet.has(skill.key) !== draftEnabledKeySet.has(skill.key),
+            );
+            const showSaveButton = groupDirty
+              && !(savingAction?.groupKey === group.key && savingAction.kind === 'toggle');
+            const groupStateVariant = allEnabled ? 'success' : someEnabled ? 'warning' : 'neutral';
+            const groupStateLabel = allEnabled
+              ? t('suite.groupState.enabled')
+              : someEnabled
+                ? t('suite.groupState.partial')
+                : t('suite.groupState.disabled');
+
+            return (
+              <section key={group.key} className="skills-suite__group-card">
+                <div className="skills-suite__group-head">
+                  <div className="skills-suite__group-title-wrap">
+                    <div className="skills-suite__group-title-row">
+                      <span className="skills-suite__group-title">{group.label}</span>
+                      <Badge variant={groupStateVariant}>{groupStateLabel}</Badge>
+                    </div>
+                    <span className="skills-suite__group-count">
+                      {t('suite.groupCount', { total: group.totalCount })}
+                    </span>
+                  </div>
+
+                  <div className="skills-suite__group-actions">
+                    {showSaveButton ? (
+                      <Button
+                        variant="primary"
+                        size="small"
+                        isLoading={savingAction?.groupKey === group.key && savingAction.kind === 'save'}
+                        disabled={isSaving}
+                        onClick={() => void saveGroup(group)}
+                      >
+                        {t('suite.groupActions.save')}
+                      </Button>
+                    ) : null}
+                    <Button
+                      variant={allEnabled ? 'secondary' : 'primary'}
+                      size="small"
+                      isLoading={savingAction?.groupKey === group.key && savingAction.kind === 'toggle'}
+                      disabled={isSaving}
+                      onClick={() => void saveGroupVisibility(group, !allEnabled)}
+                    >
+                      {allEnabled ? t('suite.groupActions.disableGroup') : t('suite.groupActions.enableGroup')}
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="skills-suite__skills">
+                  {group.skills.map((skill) => {
+                    const draftEnabled = draftEnabledKeySet.has(skill.key);
+                    const dirty = committedEnabledKeySet.has(skill.key) !== draftEnabled;
+                    const shadowed = draftEnabled && skill.isShadowed;
+
+                    return (
+                      <button
+                        type="button"
+                        key={skill.key}
+                        className={[
+                          'skills-suite__skill-chip',
+                          draftEnabled ? 'is-enabled' : 'is-disabled',
+                          shadowed ? 'is-shadowed' : '',
+                          dirty ? 'is-dirty' : '',
+                        ].filter(Boolean).join(' ')}
+                        title={buildSkillTitle(skill, draftEnabled, t)}
+                        disabled={isSaving}
+                        onClick={() => {
+                          setDraftEnabledKeys((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(skill.key)) {
+                              next.delete(skill.key);
+                            } else {
+                              next.add(skill.key);
+                            }
+                            return uniqueKeys(next);
+                          });
+                        }}
+                      >
+                        <span className="skills-suite__skill-chip-name">{skill.name}</span>
+                        {draftEnabled ? (
+                          <ShieldCheck size={11} />
+                        ) : (
+                          <ShieldAlert size={11} />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SkillsSuiteView;

--- a/src/web-ui/src/app/scenes/skills/hooks/useInstalledSkills.ts
+++ b/src/web-ui/src/app/scenes/skills/hooks/useInstalledSkills.ts
@@ -176,7 +176,7 @@ export function useInstalledSkills({ searchQuery, activeFilter }: UseInstalledSk
       } else if (activeFilter === 'builtin') {
         matchesFilter = skill.isBuiltin;
       } else if (activeFilter === 'suite') {
-        matchesFilter = false;
+        matchesFilter = skill.isBuiltin;
       }
 
       const matchesQuery = !normalizedQuery || [
@@ -193,7 +193,7 @@ export function useInstalledSkills({ searchQuery, activeFilter }: UseInstalledSk
     builtin: skills.filter((skill) => skill.isBuiltin).length,
     user: skills.filter((skill) => skill.level === 'user' && !skill.isBuiltin).length,
     project: skills.filter((skill) => skill.level === 'project' && !skill.isBuiltin).length,
-    suite: 0,
+    suite: skills.filter((skill) => skill.isBuiltin).length,
   }), [skills]);
 
   return {

--- a/src/web-ui/src/app/scenes/skills/skillsSceneStore.ts
+++ b/src/web-ui/src/app/scenes/skills/skillsSceneStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 
 export type InstalledFilter = 'all' | 'builtin' | 'user' | 'project' | 'suite';
+export type SuiteModeId = 'agentic' | 'Cowork' | 'Claw' | 'Team';
 
 interface SkillsSceneState {
   searchDraft: string;
@@ -8,12 +9,14 @@ interface SkillsSceneState {
   installedFilter: InstalledFilter;
   hideDuplicates: boolean;
   isAddFormOpen: boolean;
+  suiteModeId: SuiteModeId;
   setSearchDraft: (value: string) => void;
   submitMarketQuery: () => void;
   setInstalledFilter: (filter: InstalledFilter) => void;
   setHideDuplicates: (hide: boolean) => void;
   setAddFormOpen: (open: boolean) => void;
   toggleAddForm: () => void;
+  setSuiteModeId: (modeId: SuiteModeId) => void;
 }
 
 export const useSkillsSceneStore = create<SkillsSceneState>((set) => ({
@@ -22,10 +25,12 @@ export const useSkillsSceneStore = create<SkillsSceneState>((set) => ({
   installedFilter: 'all',
   hideDuplicates: false,
   isAddFormOpen: false,
+  suiteModeId: 'agentic',
   setSearchDraft: (value) => set({ searchDraft: value }),
   submitMarketQuery: () => set((state) => ({ marketQuery: state.searchDraft.trim() })),
   setInstalledFilter: (filter) => set({ installedFilter: filter }),
   setHideDuplicates: (hide) => set({ hideDuplicates: hide }),
   setAddFormOpen: (open) => set({ isAddFormOpen: open }),
   toggleAddForm: () => set((state) => ({ isAddFormOpen: !state.isAddFormOpen })),
+  setSuiteModeId: (modeId) => set({ suiteModeId: modeId }),
 }));

--- a/src/web-ui/src/infrastructure/api/service-api/ConfigAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ConfigAPI.ts
@@ -37,6 +37,11 @@ export interface ReplaceModeSkillSelectionParams {
   workspacePath?: string;
 }
 
+export interface ResetModeSkillSelectionParams {
+  modeId: string;
+  workspacePath?: string;
+}
+
 export interface AddSkillParams {
   sourcePath: string;
   level: SkillLevel;
@@ -301,6 +306,22 @@ export class ConfigAPI {
       throw createTauriCommandError('replace_mode_skill_selection', error, {
         modeId,
         enabledSkillKeys,
+        workspacePath,
+      });
+    }
+  }
+
+  async resetModeSkillSelection({
+    modeId,
+    workspacePath,
+  }: ResetModeSkillSelectionParams): Promise<string> {
+    try {
+      return await api.invoke('reset_mode_skill_selection', {
+        request: { modeId, workspacePath },
+      });
+    } catch (error) {
+      throw createTauriCommandError('reset_mode_skill_selection', error, {
+        modeId,
         workspacePath,
       });
     }

--- a/src/web-ui/src/locales/en-US/scenes/skills.json
+++ b/src/web-ui/src/locales/en-US/scenes/skills.json
@@ -51,7 +51,7 @@
     "builtin": "Core skills shipped with the app. They cannot be deleted.",
     "user": "User-level skills installed globally for your account.",
     "project": "Project-level skills for the current workspace.",
-    "suite": "Curated skill bundles that package related skills together (coming soon)."
+    "suite": "Built-in skill suites grouped by mode, with one-click visibility controls."
   },
   "section": {
     "user": {
@@ -98,6 +98,64 @@
     "detail": {
       "installsLabel": "Installs",
       "linkLabel": "Link"
+    }
+  },
+  "suite": {
+    "title": "Built-in Skill Suites",
+    "subtitle": "Pick a mode to manage built-in skill groups. Group actions apply immediately, while individual skill edits can be saved per group.",
+    "modeLabel": "Mode",
+    "refreshTooltip": "Refresh current mode",
+    "refreshAction": "Refresh",
+    "loading": "Loading built-in skill suites...",
+    "empty": "No built-in skills are available.",
+    "groups": {
+      "office": "Office",
+      "computerUse": "Computer Use",
+      "meta": "Meta",
+      "gstack": "gstack",
+      "other": "Other"
+    },
+    "modes": {
+      "agentic": "agentic",
+      "cowork": "Cowork",
+      "claw": "Claw",
+      "team": "Team"
+    },
+    "modeDescriptions": {
+      "agentic": "Coding-first default profile",
+      "cowork": "Office workflow profile",
+      "claw": "Assistant mode",
+      "team": "Team mode"
+    },
+    "modeActions": {
+      "reset": "Reset {{mode}}",
+      "resetShort": "Reset"
+    },
+    "groupActions": {
+      "save": "Save",
+      "enableGroup": "Enable group",
+      "disableGroup": "Disable group"
+    },
+    "resetDialog": {
+      "title": "Reset {{mode}}?",
+      "message": "This will restore the mode's skill visibility to the default state.",
+      "messageWithUnsaved": "This will restore the mode's skill visibility to the default state and discard the current unsaved edits.",
+      "confirm": "Reset",
+      "cancel": "Cancel"
+    },
+    "groupState": {
+      "enabled": "Visible",
+      "disabled": "Hidden",
+      "partial": "Partial"
+    },
+    "groupCount": "{{total}} skills",
+    "messages": {
+      "saveSuccess": "Updated {{mode}} suite visibility",
+      "saveFailed": "Failed to update suite: {{error}}",
+      "resetSuccess": "Restored {{mode}} suite defaults",
+      "resetFailed": "Failed to reset suite: {{error}}",
+      "refreshFailed": "Failed to refresh suite: {{error}}",
+      "saveFirst": "Save the current skill edits first."
     }
   },
   "form": {

--- a/src/web-ui/src/locales/zh-CN/scenes/skills.json
+++ b/src/web-ui/src/locales/zh-CN/scenes/skills.json
@@ -51,7 +51,7 @@
     "builtin": "系统出厂自带的核心技能，不可删除。",
     "user": "全局安装到当前账户的用户级技能。",
     "project": "当前工作区下的项目级技能。",
-    "suite": "精选技能套件将多个相关技能打包提供（敬请期待）。"
+    "suite": "按模式分组的内置技能套件，可一键控制可见性。"
   },
   "section": {
     "user": {
@@ -98,6 +98,64 @@
     "detail": {
       "installsLabel": "安装量",
       "linkLabel": "链接"
+    }
+  },
+  "suite": {
+    "title": "内置技能套件",
+    "subtitle": "选择一个模式后，可一键控制各组内置技能的可见性；也可逐个调整技能后按组保存。",
+    "modeLabel": "模式",
+    "refreshTooltip": "刷新当前模式",
+    "refreshAction": "刷新",
+    "loading": "正在加载内置技能套件...",
+    "empty": "当前没有可用的内置技能。",
+    "groups": {
+      "office": "Office",
+      "computerUse": "Computer Use",
+      "meta": "Meta",
+      "gstack": "gstack",
+      "other": "其他"
+    },
+    "modes": {
+      "agentic": "agentic",
+      "cowork": "Cowork",
+      "claw": "Claw",
+      "team": "Team"
+    },
+    "modeDescriptions": {
+      "agentic": "偏编码的默认模式",
+      "cowork": "办公协作模式",
+      "claw": "助理模式",
+      "team": "团队模式"
+    },
+    "modeActions": {
+      "reset": "重置 {{mode}}",
+      "resetShort": "重置"
+    },
+    "groupActions": {
+      "save": "保存",
+      "enableGroup": "启用分组",
+      "disableGroup": "禁用分组"
+    },
+    "resetDialog": {
+      "title": "重置 {{mode}}？",
+      "message": "这会将该模式的技能可见性恢复为默认状态。",
+      "messageWithUnsaved": "这会将该模式的技能可见性恢复为默认状态，并丢弃当前未保存的改动。",
+      "confirm": "重置",
+      "cancel": "取消"
+    },
+    "groupState": {
+      "enabled": "可见",
+      "disabled": "隐藏",
+      "partial": "部分"
+    },
+    "groupCount": "{{total}} 个",
+    "messages": {
+      "saveSuccess": "已更新 {{mode}} 套件可见性",
+      "saveFailed": "更新套件失败: {{error}}",
+      "resetSuccess": "已恢复 {{mode}} 套件默认设置",
+      "resetFailed": "重置套件失败: {{error}}",
+      "refreshFailed": "刷新套件失败: {{error}}",
+      "saveFirst": "请先保存当前技能改动。"
     }
   },
   "form": {

--- a/src/web-ui/src/locales/zh-TW/scenes/skills.json
+++ b/src/web-ui/src/locales/zh-TW/scenes/skills.json
@@ -51,7 +51,7 @@
     "builtin": "系統出廠內建的核心技能，不可刪除。",
     "user": "為目前帳戶全域安裝的用戶級技能。",
     "project": "目前工作區底下的項目級技能。",
-    "suite": "精選技能套件將多個相關技能打包提供（敬請期待）。"
+    "suite": "依模式分組的內建技能套件，可一鍵控制可見性。"
   },
   "section": {
     "user": {
@@ -98,6 +98,64 @@
     "detail": {
       "installsLabel": "安裝量",
       "linkLabel": "鏈接"
+    }
+  },
+  "suite": {
+    "title": "內建技能套件",
+    "subtitle": "選擇一個模式後，可一鍵控制各組內建技能的可見性；也可逐個調整技能後按組保存。",
+    "modeLabel": "模式",
+    "refreshTooltip": "刷新當前模式",
+    "refreshAction": "刷新",
+    "loading": "正在載入內建技能套件...",
+    "empty": "當前沒有可用的內建技能。",
+    "groups": {
+      "office": "Office",
+      "computerUse": "Computer Use",
+      "meta": "Meta",
+      "gstack": "gstack",
+      "other": "其他"
+    },
+    "modes": {
+      "agentic": "agentic",
+      "cowork": "Cowork",
+      "claw": "Claw",
+      "team": "Team"
+    },
+    "modeDescriptions": {
+      "agentic": "偏編碼的預設模式",
+      "cowork": "辦公協作模式",
+      "claw": "助理模式",
+      "team": "團隊模式"
+    },
+    "modeActions": {
+      "reset": "重置 {{mode}}",
+      "resetShort": "重置"
+    },
+    "groupActions": {
+      "save": "保存",
+      "enableGroup": "啟用分組",
+      "disableGroup": "禁用分組"
+    },
+    "resetDialog": {
+      "title": "重置 {{mode}}？",
+      "message": "這會將該模式的技能可見性恢復為預設狀態。",
+      "messageWithUnsaved": "這會將該模式的技能可見性恢復為預設狀態，並丟棄當前未保存的改動。",
+      "confirm": "重置",
+      "cancel": "取消"
+    },
+    "groupState": {
+      "enabled": "可見",
+      "disabled": "隱藏",
+      "partial": "部分"
+    },
+    "groupCount": "{{total}} 個",
+    "messages": {
+      "saveSuccess": "已更新 {{mode}} 套件可見性",
+      "saveFailed": "更新套件失敗: {{error}}",
+      "resetSuccess": "已恢復 {{mode}} 套件預設設定",
+      "resetFailed": "重置套件失敗: {{error}}",
+      "refreshFailed": "刷新套件失敗: {{error}}",
+      "saveFirst": "請先保存當前技能改動。"
     }
   },
   "form": {


### PR DESCRIPTION
- Add a dedicated `suite` view for built-in skills with mode tabs and grouped chips
- Support per-group save/reset flows while keeping unsaved skill edits draft-only until saved
- Add backend APIs to reset mode skill overrides without touching tool configuration
- Update skill suite copy, counts, and mode labels across locales
