### PR TITLE
feat(usage): complete session usage report

### DIFF
--- a/docs/features/session-runtime-usage-report-design.md
+++ b/docs/features/session-runtime-usage-report-design.md
@@ -1,6 +1,6 @@
 # Session Runtime Usage Report Design
 
-> Status: P0 and P1 implemented; P2 Desktop analysis surface partially implemented and under hardening review as of 2026-05-11
+> Status: P0 and P1 implemented; P2 Desktop analysis surface hardening mostly implemented as of 2026-05-11
 > Scope: `/usage`, Desktop Flow Chat usage reports, CLI usage reports, session runtime metrics, Chat-bottom usage entry
 > Non-goal: this document does not prescribe exact code edits or final UI copy.
 
@@ -14,16 +14,16 @@ Long BitFun sessions can include model streaming, tool execution, Git operations
 - Did context compression reduce or increase token pressure?
 - Can this summary be read later in the conversation, not only in a temporary popover?
 
-Claude Code's `/usage` is the closest product reference. Its current documentation says `/usage` shows detailed token statistics for the current session, including locally estimated cost, API duration, wall duration, and code changes. The same page also recommends using `/usage` or a status line for proactive context management. GitHub Copilot cloud agent exposes a session overview/log where users can track progress, token usage, session count, and session length. OpenAI Agents SDK and LangSmith are useful engineering references: both model agent work as traces/spans, with LLM generations, tool calls, custom events, token usage, cost, and timing breakdowns.
+Claude Code's `/usage` is the closest product reference. Anthropic describes it as a command that helps users understand Claude Code usage in the context of session and context-window management. GitHub Copilot cloud agent exposes a session overview/log where users can track progress, token usage, session count, and session length. OpenAI Agents SDK is the useful engineering reference: its usage API tracks requests and tokens per run/request, while tracing models agent work as spans for model generations, tool calls, handoffs, guardrails, and custom events.
 
 References:
 
-- [Claude Code usage and costs](https://code.claude.com/docs/en/costs)
+- [Claude Code session management and `/usage`](https://claude.com/blog/using-claude-code-session-management-and-1m-context)
 - [GitHub Copilot agent session tracking](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/track-copilot-sessions)
+- [OpenAI Agents SDK usage](https://openai.github.io/openai-agents-python/usage/)
 - [OpenAI Agents SDK tracing](https://openai.github.io/openai-agents-python/tracing/)
-- [LangSmith cost tracking](https://docs.langchain.com/langsmith/cost-tracking)
 
-External reference check: as of 2026-05-09, these sources still support the high-level direction above. Claude Code documents `/usage` as current-session token/cost/duration/change reporting with local cost estimates; GitHub Copilot exposes session overview/log surfaces with progress, token usage, session count, and session length; OpenAI Agents SDK models agent work as traces/spans for LLM generations and tool calls; LangSmith cost tracking depends on provider/model metadata and token-detail categories. Treat these as product references, not compatibility requirements. BitFun's implemented boundary is intentionally narrower: cost-adjacent reporting stops at token counts and token coverage.
+External reference check: as of 2026-05-11, these sources support a narrow usage-report scope. Claude Code frames `/usage` around understanding session usage and managing context; GitHub Copilot exposes session progress, token usage, session count, session length, and logs; OpenAI Agents SDK separates per-run/request token usage from deeper span tracing. Treat these as product references, not compatibility requirements. BitFun's boundary is intentionally narrower than a full tracing dashboard: it reports the current session's recorded runtime facts, their coverage, and safe navigation points back to the transcript or existing diff surfaces.
 
 ## Product Direction
 
@@ -33,9 +33,21 @@ The key product decision is:
 
 > `/usage` creates a durable, readable session report in the current conversation, while Desktop also exposes the same action from one compact button in the Chat input footer.
 
-The implemented report is intentionally a persisted-data report. It does not claim pure model streaming throughput, first-token latency, token-per-second speed, monetary cost, or live per-model timing unless a future runtime span contract provides those fields.
+The implemented report is intentionally a persisted-data report. It does not claim pure model streaming throughput, first-token latency, token-per-second speed, or live per-model timing unless a stable runtime span contract provides those fields.
 
 This avoids making usage insight feel hidden behind a temporary button. Users should be able to run `/usage`, scroll back to the report, search it, export it with the session, and compare it with file changes.
+
+## Closed Product Scope
+
+The closed product is a current-session runtime report. It answers:
+
+- How long the session spans and how much recorded work happened inside it.
+- Which token, model, tool, file, error, compression, and slow-work facts were recorded.
+- Which facts are complete, partial, or unavailable, with user-facing reasons near the affected values.
+- Which transcript turn or existing diff surface can be opened for verification.
+- Which report metadata should be copyable or exportable without exposing unnecessary path detail by default.
+
+The product is complete when `/usage` can generate a durable, model-invisible report from the current session, the Chat-bottom entry exposes the same action, the detail panel makes recorded facts understandable, and partial data is clearly labeled. Anything that changes runtime policy, recommends workflow changes, aggregates across sessions, or shows live status belongs outside this closed scope.
 
 ## Independent Third-Party Review
 
@@ -44,17 +56,17 @@ Verdict: the direction is reasonable, but the current draft needs a few product 
 - Use one structured report contract and surface-specific renderers instead of separate CLI/Desktop counters.
 - Store Desktop `/usage` as user-visible but model-invisible local output.
 - Start with existing persisted data, then improve accuracy with additive runtime spans.
-- Exclude monetary cost estimates, charts, and cross-session analytics until they have separate product ownership; keep the Chat-bottom action as a compact entry point backed by the same session-level contract.
+- Exclude charts, cross-session summaries, and automated optimization advice from the closed product scope; keep the Chat-bottom action as a compact entry point backed by the same session-level contract.
 
-The main remaining risk is not that the feature is too ambitious. The risk is that "usage reporting" accidentally becomes a second runtime control plane for budget, scheduler, retry, artifact, or context mutation behavior. The report should be an observability projection. It may consume runtime facts, but it must not decide scheduling, retries, context compaction, permissions, or cost governance.
+The main remaining risk is not that the feature is too ambitious. The risk is that "usage reporting" accidentally becomes a second runtime control plane for budget, scheduler, retry, artifact, or context mutation behavior. The report should be an observability projection. It may consume runtime facts, but it must not decide scheduling, retries, context compaction, permissions, or runtime governance.
 
-Before implementation, the design should explicitly define:
+The current implementation resolves the important boundaries as follows:
 
-- What exact session scope `/usage` reports: current session only, parent plus hidden subagents, visible side sessions, or all linked sessions.
-- How overlapping time is counted when model calls, tools, subagents, retries, and queues run concurrently.
-- Whether `/usage` can run during an active turn, and if so whether it inserts immediately, appends after the turn, or shows a point-in-time preview.
-- How cached tokens, reasoning tokens, local models, model aliases, and provider-specific token details are represented when data is partial.
-- What sensitive command, path, error, or metadata fields are allowed in a durable/exportable report.
+- Standard `/usage` reports the current session only.
+- Overlapping recorded spans use union accounting where supported, and the UI labels approximations.
+- `/usage` requires an idle session and returns friendly local feedback while a turn is active.
+- Cached tokens, reasoning tokens, local models, model aliases, and provider-specific token details are marked partial or unavailable when the source cannot prove them.
+- Durable/exportable reports use bounded labels, workspace-relative paths where possible, and copy/export path redaction by default.
 
 ## Relationship to Adjacent Runtime Plans
 
@@ -148,18 +160,9 @@ The detailed visual report exists alongside the Markdown snapshot. It uses the s
 
 ### Desktop Chat-Bottom Usage Entry
 
-The implemented Flow Chat entry is a compact action in the Chat input footer (`ChatInputWorkspaceStrip`) that generates `/usage` in the current chat. It intentionally avoids title/header placement and live timing shares until runtime span data is reliable enough.
+The implemented Flow Chat entry is a compact action in the Chat input footer (`ChatInputWorkspaceStrip`) that generates `/usage` in the current chat. It intentionally avoids title/header placement and live timing values.
 
-Possible future live states:
-
-| Width / available space | Display |
-| --- | --- |
-| Wide | `18m active | 61% model | 24% tools | 2 compact | 3 errors` |
-| Medium | `18m | model 61% | tools 24%` |
-| Narrow | small clock/activity icon + `18m` |
-| Very narrow | icon only, tooltip contains the summary |
-
-The Chat-bottom entry should never compete with the title/header row. It must preserve the input footer's workspace/branch controls, model selector, and send affordances. If future live values are added, lower-priority segments must hide before shrinking text beyond legibility.
+The Chat-bottom entry should never compete with the title/header row. It must preserve the input footer's workspace/branch controls, model selector, and send affordances. Its job is to start report generation, not to become a live status display.
 
 ## Current Reusable Capabilities
 
@@ -223,23 +226,24 @@ It also provides summary aggregation by model and session.
 The subsections below preserve the original gap analysis so later reviews can
 see why each work item existed. The current code review on 2026-05-11 checked
 the plan against `origin/main..HEAD` and found P0/P1 implemented, with P2
-partially implemented. "Done" means code and automated coverage exist in this
-branch; "Partial" means the foundation exists, but the remaining work below
-still needs product or technical signoff before the item should be considered
-complete.
+hardening implemented except for real long-session smoke checks and items now
+outside the closed scope. "Done" means code and automated coverage exist in
+this branch; "Partial" means the foundation exists, but the remaining work
+below still needs product or technical signoff before the item should be
+considered complete.
 
 | Area | Current status | Code evidence | Remaining work |
 | --- | --- | --- | --- |
-| Shared report service | Done | `src/crates/core/src/service/session_usage/{service.rs,types.rs,render.rs}` and `SessionAPI.getSessionUsageReport` | Keep the API contract stable while adding future analytics. |
+| Shared report service | Done | `src/crates/core/src/service/session_usage/{service.rs,types.rs,render.rs}` and `SessionAPI.getSessionUsageReport` | Keep the API contract stable while adding future report fields. |
 | Durable local report message | Done | `DialogTurnKind::LocalCommand`, `localCommandKind: 'usage_report'`, `modelVisible: false` | Keep usage report snapshots model-invisible through future history, export, and transcript changes. |
-| CLI `/usage` coverage | Done for interactive CLI | CLI `usage_*` coverage and the shared renderer | Top-level `bitfun usage --session` remains deferred. |
-| Model timing | Mostly done | Optional event and persisted fields for duration, provider/model identity, first chunk, visible output, stream duration, attempts, failure category, and token details | Throughput/TPS and provider-latency claims stay deferred until semantics are stable enough to avoid misleading users. |
+| CLI `/usage` coverage | Done for interactive CLI | CLI `usage_*` coverage and the shared renderer | Top-level `bitfun usage --session` is outside the closed product scope. |
+| Model timing | Mostly done | Optional event and persisted fields for duration, provider/model identity, first chunk, visible output, stream duration, attempts, failure category, and token details | Throughput/TPS and provider-latency claims are outside the closed product scope. |
 | Tool phase timing/classification | Mostly done | Optional terminal tool duration fields and `session_usage::classifier` coverage | Scheduler, budget, and backoff facts still depend on owning modules emitting typed facts. |
-| File correlation and diff links | Partial | Snapshot summaries, `UsageFileRow.operationIds`, and `SessionUsagePanel` diff actions | Transcript/tool-card anchor links and long-session row virtualization remain follow-up work. |
-| Token-only cost boundary | Done | Token-only locale guard coverage and no monetary DTO fields | Future billing or cost analytics must remain a separate feature surface. |
-| i18n and theme | Mostly done | Flow Chat locale alignment coverage, semantic style guard coverage, and quick-action localization coverage | Manual light/dark screenshot, keyboard, and accessibility pass is still needed before final UX signoff. |
-| Scope and workspace identity | Done for current session | Request carries workspace path/remote identity and DTO exposes `UsageWorkspace` | Hidden subagent and visible side-session aggregation remain open decisions. |
-| Redaction/export policy | Partial | Bounded labels, privacy flags, workspace-relative display, and copied metadata | Exact exported path redaction rules for local and remote paths still need a dedicated policy. |
+| File correlation and diff links | Mostly done | Snapshot summaries, `UsageFileRow.operationIds`, representative model/tool/error anchors, `SessionUsagePanel` diff actions, file-row turn jumps, tool-input-only file-row tool anchors, and panel-local long-session row caps | Exact per-call deep anchors for every aggregate row are outside the closed product scope. |
+| Token reporting boundary | Done | Token-focused locale guard coverage and DTO fields limited to runtime/session facts | Keep `/usage` centered on current-session observability. |
+| i18n and theme | Mostly done | Flow Chat locale alignment coverage, semantic style guard coverage, quick-action localization coverage, detail-panel tab keyboard semantics, and manual preview checks across Light, Slate, Dark, Midnight, Ink Charm, Ink Night, Cyber, and Tokyo Night | Final real-App long-session smoke and keyboard/focus pass are still needed before final UX signoff. |
+| Scope and workspace identity | Done for current session | Request carries workspace path/remote identity and DTO exposes `UsageWorkspace` | Hidden subagent and visible side-session aggregation are outside the closed product scope. |
+| Redaction/export policy | Mostly done | Bounded labels, privacy flags, workspace-relative display, copied metadata, and copy/export path redaction preference | Broader export formats stay outside the closed product scope. |
 
 ### 1. Shared session usage report service
 
@@ -341,19 +345,19 @@ Required change:
 - Add report fields for files changed, additions, deletions, and top changed files.
 - Link report rows to existing operation/turn/session/git diff opening paths.
 
-### 9. Token-only cost boundary
+### 9. Token reporting boundary
 
 Missing:
 
-- TokenUsageService stores tokens but not authoritative billing/cost data.
-- Different providers have different billing semantics for cache, reasoning tokens, subscriptions, local models, or gateway pricing.
+- TokenUsageService stores tokens, but not every provider reports the same token detail categories.
+- Cache, reasoning, audio/image, local-model, and gateway-mediated token details may be unavailable or partial.
 
 Required change:
 
-- `/usage` treats token counts as the only supported cost proxy.
-- Do not add monetary amounts, currencies, package/subscription language, price source metadata, or provider billing estimates to this report.
-- If the UI needs "cost" wording, it must point back to token counts and token coverage only.
-- Keep provider billing, pricing tables, and package semantics out of this milestone and out of persisted historical reports.
+- `/usage` reports token counts and token coverage only when the source data can support them.
+- Keep unavailable token categories visible as partial coverage instead of showing misleading zeros.
+- Keep token detail categories provider-agnostic in the DTO; provider-specific values can be optional structured fields, not prose.
+- Do not let token reporting become a recommendation, quota, or policy surface.
 
 ### 10. Internationalization and theme integration
 
@@ -374,14 +378,14 @@ Required change:
 Missing:
 
 - The current draft mostly keys reports by `sessionId`, but persisted session ids are only meaningful within a workspace/runtime identity.
-- It is not yet clear whether a parent session report includes hidden subagent sessions, visible `/btw` side sessions, Deep Review child sessions, or only the active chat.
+- The closed product reports only the active chat session. Hidden subagent sessions, visible `/btw` side sessions, and Deep Review child sessions are not silently aggregated.
 - Remote sessions need `remote_connection_id` / `remote_ssh_host` context, and snapshot data may be unavailable for remote workspaces.
 
 Required change:
 
 - Every report request and API adapter should include the same workspace identity fields used by session persistence: workspace path plus remote identity when present.
-- P0 default scope should be "current user-visible session". Hidden subagent usage may be included only when records carry reliable parent linkage; otherwise mark `subagent_scope` as partial.
-- Visible side sessions such as `/btw` should not be silently folded into the parent report in P0. They can be linked or summarized later when the relationship model is explicit.
+- Default scope is "current user-visible session".
+- Hidden subagent usage and visible side sessions such as `/btw` should not be silently folded into the parent report.
 - Add coverage keys such as `workspace_identity`, `subagent_scope`, and `remote_snapshot_stats`.
 
 ### 12. Time accounting and overlapping spans
@@ -424,7 +428,6 @@ Required change:
 - Do not render "Cached" as an authoritative P0 metric unless the source actually records it.
 - Add coverage metadata for `cached_tokens` and `token_detail_breakdown`.
 - Later span/event enrichment should carry provider token details as structured optional fields, not as provider-specific prose.
-- Cost-adjacent reporting must stop at token categories and counts; provider/model prices remain out of scope.
 
 ### 15. Privacy, redaction, and durable export policy
 
@@ -490,7 +493,6 @@ type SessionUsageReport = {
       | 'subagent_scope'
       | 'remote_snapshot_stats'
       | 'file_line_stats'
-      | 'cost_estimates' // missing/out-of-scope marker only; never a monetary data field
       | string
     >;
   };
@@ -602,12 +604,12 @@ Exact field names can change during implementation. The important boundary is th
 - The report is a point-in-time snapshot. It is not expected to update after more turns run.
 - Running `/usage` multiple times should append multiple reports in P0.
 - If `/usage` is invoked during an active turn, the implementation must either reject it with a friendly local-only message or insert a clearly marked in-progress snapshot without touching the active model/tool state.
-- A standard session report should not silently include visible side sessions. Hidden subagent inclusion requires reliable parent linkage and an explicit scope marker.
+- A standard session report should not silently include visible side sessions or hidden subagents.
 
 ### Chat-bottom usage entry
 
 - The Chat-bottom usage entry is a convenience, not the source of truth.
-- It should remain action-only at constrained widths; live metrics belong to a later design.
+- It should remain action-only at constrained widths; live metrics are outside the closed product scope.
 - It must not introduce horizontal overflow.
 - It must support keyboard focus, screen-reader labels, and tooltip summaries.
 - It should hide itself automatically when no active session or no reportable data exists.
@@ -625,9 +627,8 @@ Recommended tabs:
 - Errors
 - Slowest
 
-Timeline remains a future option. Current P2 uses the Slowest tab plus
-turn-level navigation because stable transcript/tool-card anchors are not yet
-available for every row type.
+Timeline is outside the closed product scope. Current P2 uses the Slowest tab
+plus representative transcript links instead of a full trace timeline.
 
 ## Milestone Execution Plan
 
@@ -639,7 +640,7 @@ Current milestone progress, verified against the current branch on 2026-05-11:
 | --- | --- | --- | --- |
 | P0: Safe `/usage` foundation | Complete | Shared report service/renderers, model-invisible local report items, CLI interactive `/usage`, Desktop report cards, repeated-report exclusion, and old-session/cache-unavailable fixtures are covered by Rust and Web UI tests. | Keep future changes within the same local-only and model-invisible contract. |
 | P1: Runtime spans and file correlation | Complete for the approved P1 scope | Optional model/tool runtime facts persist and aggregate; local usage reports are excluded from the next report span; snapshot-backed and recognized tool-input file rows are surfaced; missing model identity uses legacy-session copy instead of implementation labels. | Scheduler/budget/context/artifact facts remain projections only when their owning modules emit typed facts. Hidden subagents remain excluded by default. |
-| P2: Desktop analysis surface | Partial | Chat-bottom entry, detail panel tabs, copyable metadata, file diff actions, slow-span turn jumps, i18n coverage, and semantic style tests are present. | Stable transcript/tool-card anchors, long-session caps or virtualization, manual light/dark/accessibility checks, and exported path redaction policy still need completion. |
+| P2: Desktop analysis surface | Almost complete | Chat-bottom entry, detail panel tabs, accessible tab keyboard semantics, copyable metadata, file diff actions, slow-span turn jumps, representative model/tool/error anchors, file-row turn/tool-input anchors, panel-local long-list caps, user-confirmed Markdown copy path redaction, i18n coverage, semantic style tests, duplicate-localized-header guard, and manual preview checks across all built-in themes are present. | Real-App long-session smoke remains before final UX signoff. |
 
 ### Milestone P0: Safe `/usage` Foundation
 
@@ -663,7 +664,7 @@ Functional guardrails:
 
 - `/usage` must never call the model, enqueue an agent turn, mutate runtime scheduling, or trigger context compression.
 - The Desktop report must be stored as a local command/report item that is visible to the user but excluded from model-visible history.
-- P0 must not introduce cost estimates, live header UI, charts, cross-session analytics, or new runtime span persistence.
+- P0 must not introduce live header UI, charts, cross-session summaries, or new runtime span persistence.
 - Missing data must be represented by coverage metadata and partial-data copy, not by misleading zero values.
 - Old sessions must still deserialize and replay; sessions without token/snapshot data should still produce a partial report instead of failing.
 - P0 must not show cached-token counts as real if current events only record them as `0`.
@@ -788,7 +789,7 @@ P1 must move `/usage` from P0 approximation toward factual runtime accounting wi
    - Files: `src/web-ui/src/flow_chat/components/usage/*`, `src/web-ui/src/flow_chat/store/FlowChatStore.ts`, `src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts`, and `src/web-ui/src/locales/*/flow-chat.json`.
    - Show model duration only when at least one model duration is recorded.
    - Keep error and coverage explanations visible through concise hover text plus detail-page descriptions.
-   - Avoid new claims such as exact token pricing or file-line changes unless the backend has the underlying fact.
+   - Avoid new claims such as exact throughput or file-line changes unless the backend has the underlying fact.
 
 5. Verify and review consistency.
    - Required checks: `pnpm run lint:web`, `pnpm run type-check:web`, `pnpm --dir src/web-ui run test:run`, `cargo check --workspace`, and `cargo test --workspace`.
@@ -831,7 +832,7 @@ P1 implementation review note (2026-05-11):
 
 ### Milestone P2: Responsive Desktop Analysis Surface
 
-Goal: add the interactive Desktop analysis panel and keep a compact Chat-bottom entry point after the report contract is stable. The implemented entry is a lightweight `/usage` trigger in the Chat input footer; title/header placement and live timing values remain deferred until span quality and layout needs justify a separate design.
+Goal: add the interactive Desktop analysis panel and keep a compact Chat-bottom entry point after the report contract is stable. The implemented entry is a lightweight `/usage` trigger in the Chat input footer; title/header placement and live timing values are outside the closed product scope.
 
 Included task groups:
 
@@ -840,7 +841,7 @@ Included task groups:
 | P2.0 | Chat-bottom action contract | Task 11 | Entry point that can generate the current session report |
 | P2.1 | Responsive Chat-bottom entry | Task 11 | `ChatInputWorkspaceStrip` usage action as a stable icon/text trigger |
 | P2.2 | Detailed report panel | Task 12 | Overview, Models, Tools, Files, Errors, and Slowest tabs using the shared DTO |
-| P2.3 | Diff and transcript links | Tasks 10, 12 | Snapshot-backed file rows open existing diff viewers; slow-span rows can jump to known turns; stable tool-card anchors remain follow-up |
+| P2.3 | Diff and transcript links | Tasks 10, 12 | Snapshot-backed file rows open existing diff viewers; slow-span rows can jump to known turns; model/tool/error aggregate rows expose representative anchors; file rows can jump to transcript turns; tool-input-only file rows can request tool-card focus when a single stable tool item id exists |
 | P2.4 | i18n, theme, accessibility hardening | Tasks 7, 11, 12 | Locale-safe labels, semantic colors, keyboard access, tooltips, and screen-reader labels |
 
 Functional guardrails:
@@ -858,7 +859,7 @@ Risk and drift controls:
 | Risk or drift | Mitigation | Stop condition |
 | --- | --- | --- |
 | Small windows become cluttered | Use container-aware priority collapse and icon-only fallback | Chat footer controls overlap or disappear in narrow desktop widths |
-| Future live summary causes reflow while streaming | Throttle updates and keep footer content dimensionally stable | Streaming causes visible layout jitter |
+| Live summary creeps back into the footer | Keep the entry action-only | Streaming causes visible layout jitter |
 | Panel becomes a debugger replacement | Keep default view summary-first and deep links back to existing transcript/diff surfaces | Panel starts duplicating raw tool output or full diffs |
 | i18n text overflows | Test `en-US`, `zh-CN`, and `zh-TW`; prefer card/list fallback over wide tables | Any required label clips in supported locales |
 | Theme contrast regresses | Use semantic tokens and light/dark checks | New colors bypass theme tokens |
@@ -870,7 +871,7 @@ Required verification before merging P2:
 - `pnpm --dir src/web-ui run test:run`
 - Component/layout tests for the usage trigger in wide and narrow Chat footer states.
 - Locale smoke checks for `en-US`, `zh-CN`, and `zh-TW`.
-- Light and dark theme screenshot or manual checks.
+- Manual preview checks across all built-in themes: Light, Slate, Dark, Midnight, Ink Charm, Ink Night, Cyber, and Tokyo Night.
 - Manual proof that existing file diff buttons and report-linked diff buttons open the same scopes.
 
 Rollback boundary:
@@ -881,23 +882,57 @@ Rollback boundary:
 P2 implementation progress note (2026-05-11):
 
 - P2.0/P2.1 entry placement matches current code: the usage action lives in `ChatInputWorkspaceStrip` at the Chat bottom, not in `FlowChatHeader` or the window title/header area.
-- P2.2 is implemented as a single detail-panel module today: `SessionUsagePanel.tsx`, `SessionUsagePanel.scss`, `sessionUsagePanelTypes.ts`, and `openSessionUsageReport.ts`. The panel includes Overview, Models, Tools, Files, Errors, and Slowest tabs. Splitting tab bodies into separate files is deferred until component size or ownership makes that cheaper than a consolidated module.
-- P2.3 is partially implemented. File rows open the existing snapshot diff viewer through `snapshotAPI.getOperationDiff` and `createDiffEditorTab`; no new diff renderer or mutation path is introduced. Slowest rows can jump to known turns through the existing Flow Chat pin-to-top event.
+- P2.2 is implemented as a single detail-panel module today: `SessionUsagePanel.tsx`, `SessionUsagePanel.scss`, `sessionUsagePanelTypes.ts`, and `openSessionUsageReport.ts`. The panel includes Overview, Models, Tools, Files, Errors, and Slowest tabs. Splitting tab bodies into separate files is a maintenance choice, not product scope.
+- P2.3 is partially implemented. File rows open the existing snapshot diff viewer through `snapshotAPI.getOperationDiff` and `createDiffEditorTab`; no new diff renderer or mutation path is introduced. Slowest rows can jump to known turns through the existing Flow Chat pin-to-top event. Model, tool, and error aggregate rows now carry optional representative anchors from core and route through the existing Flow Chat focus event. File-row turn indexes also use the focus event for transcript jumps, and tool-input-only file rows request tool-card focus only when a single stable tool item id is available.
 - The file diff action is intentionally enabled only for trustworthy snapshot-backed rows with a visible path and session id. Redacted rows, tool-input-only rows, and unavailable rows show a disabled placeholder with an explanation instead of attempting a best-effort open.
-- Remaining P2.3 work: stable transcript/tool-card anchors are still needed because the current report can preserve turn indexes and operation ids, but not every row type has a durable virtual-list anchor.
-- Remaining P2 hardening: add long-session row caps or virtualization, complete manual light/dark/accessibility checks, and finalize exported path redaction rules.
-- Verification evidence for current P2 slices: `SessionUsageComponents` covers detail tabs, file diff action, slowest turn jumps, copyable metadata, unavailable help, token-only copy, i18n behavior, and semantic color usage; broader web/Rust verification is tracked in the P1 review note above.
+- Exact per-call deep anchors are outside the closed product scope; aggregate rows link to representative sources instead of becoming a full occurrence explorer.
+- Remaining P2 hardening: complete real-App long-session smoke for scroll/jump feel. Panel-local long-session row caps, Markdown copy/export path redaction, detail-panel tab keyboard semantics, representative aggregate anchors, file-row turn/tool-input anchors, duplicate-localized-table-header guards, and built-in-theme preview checks are implemented in this branch. Do not touch Flow Chat's global virtual list or scroll layout for this work unless a separate navigation design is approved.
+- Verification evidence for current P2 slices: `SessionUsageComponents` covers detail tabs, file diff action, slowest turn jumps, copyable metadata, unavailable help, token-only copy, i18n behavior, duplicate localized table headers, and semantic color usage; manual preview checks covered Light, Slate, Dark, Midnight, Ink Charm, Ink Night, Cyber, and Tokyo Night. Broader web/Rust verification is tracked in the P1 review note above.
 
-### Deferred Beyond P2
+### Final Merge-Ready Execution Plan
 
-The following work is intentionally not part of the first three milestones:
+This plan was re-reviewed on 2026-05-11 after refreshing `origin/main`. The
+current branch is based on latest `origin/main`, and main has recent Flow Chat
+scroll-position, follow-output jitter, settings/usage, and theme work. The
+remaining usage-report work must therefore stay local to the usage-report
+surface.
 
-- Monetary cost estimates with provider/model pricing metadata.
-- Cross-session or project-level analytics.
+Compatibility guardrails for the final hardening batch:
+
+- Run `git fetch origin main:refs/remotes/origin/main` before starting.
+- Run `git merge-base --is-ancestor origin/main HEAD`; stop and rebase if it fails.
+- Run `git diff --name-only origin/main..HEAD` and confirm the batch does not touch unrelated mainline areas.
+- Do not modify `src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx`, `src/web-ui/src/flow_chat/utils/flowChatScrollLayout.ts`, theme preset files, tray files, installer files, or settings basics files for P2 hardening unless a separate design review approves that scope.
+- Keep every final P2 change reversible by hiding the usage detail action or disabling one panel tab while leaving `/usage` Markdown reports available.
+
+Next executable stage:
+
+| Stage | Recommendation | Files allowed by default | Verification | Stop condition |
+| --- | --- | --- | --- | --- |
+| Final smoke and merge readiness | Run real Desktop long-session smoke, fix only usage-local defects, then prepare commit/PR | Usage panel/card styles, usage component tests, locale files, and this document | `pnpm run lint:web`, `pnpm run type-check:web`, `pnpm --dir src/web-ui run test:run`, `cargo check --workspace`, `cargo test --workspace`, real-App long-session smoke | Any fix requires Flow Chat global scroll/session-switch changes or shared theme token changes. |
+
+Detailed executable checklist:
+
+1. Launch the real Desktop app from this branch.
+2. Open or create a long session with enough model, tool, file, and error rows to exercise every detail tab.
+3. Generate `/usage` from the Chat-bottom entry and from the slash command if available.
+4. Check the report card, detail panel tabs, file table sticky action column, copy/export redaction toggle, representative transcript jumps, file diff actions, and keyboard focus order.
+5. Confirm that report generation does not trigger a model request, does not appear in the next report span, and does not make session switching or follow-output feel slower.
+6. Fix only usage-local issues found during the smoke pass.
+7. Re-run the full frontend and Rust verification commands.
+8. Rebase onto latest `origin/main`, split into a small commit set, and update the PR description around the closed product scope.
+
+### Explicitly Out Of Closed Scope
+
+The following work is intentionally not queued as follow-up for this usage-report product:
+
+- Cross-session or project-level summaries.
 - Export formats beyond existing conversation export behavior.
-- Automated recommendations such as "context is dominating cost" or "tool failures caused retry loops."
+- Automated recommendations such as context optimization advice or retry-loop diagnosis.
+- Live status metrics in the Chat footer or title/header.
+- Exact per-call occurrence browsing for every aggregate row.
 
-These items depend on trustworthy session-level data and should be planned as a separate economics/analytics effort after P2 is stable.
+If any of these become important later, they should start from a new product question instead of being treated as incomplete work in this milestone.
 
 ## Fine-Grained Execution Breakdown
 
@@ -907,7 +942,7 @@ This section turns the milestone plan into implementation-sized tasks. Each task
 
 - `/usage` must never trigger a model request.
 - `/usage` output must not be included in future model context unless a user explicitly quotes or references it in a later prompt.
-- P0 reports tokens and available timing only. P0 does not introduce cost estimates, charts, cross-session analytics, or live header UI.
+- P0 reports tokens and available timing only. P0 does not introduce charts, cross-session summaries, or live header UI.
 - Runtime metrics collection must be append-only or summary-only; do not add per-token persistence.
 - Shared report logic belongs in platform-agnostic Rust core or api-layer. Desktop, server, and CLI are adapters.
 - Desktop UI must use existing i18n, theme tokens, and component-library primitives.
@@ -973,7 +1008,7 @@ Files:
 Steps:
 
 1. Add `SessionUsageReport`, `UsageCoverage`, `UsageTimeBreakdown`, `UsageTokenBreakdown`, `UsageModelBreakdown`, `UsageToolBreakdown`, `UsageFileBreakdown`, `UsageCompressionBreakdown`, `UsageErrorBreakdown`, and `UsageSlowSpan` structs.
-2. Add `CoverageLevel::{Complete, Partial}` plus a stable list of missing-data keys such as `model_round_timing`, `tool_phase_timing`, `file_line_stats`, and `cost_estimates`.
+2. Add `CoverageLevel::{Complete, Partial}` plus a stable list of missing-data keys such as `model_round_timing`, `tool_phase_timing`, and `file_line_stats`.
 3. Use milliseconds and token counts in DTOs; keep formatting out of DTOs.
 4. Make optional fields explicit for data that is not reliable in P0.
 5. Add `schema_version`, `report_id`, `generated_at`, workspace identity, report scope, in-progress marker, and redaction metadata.
@@ -1065,7 +1100,7 @@ Files:
 
 Steps:
 
-1. Aggregate token records with `include_subagent=true` so parent and subagent usage can be reported together and separated later.
+1. Aggregate token records for the current session. Preserve subagent markers only as coverage metadata; do not silently fold hidden subagent usage into the default report.
 2. Aggregate persisted dialog turn durations for wall and active lower-bound estimates.
 3. Aggregate tool result `duration_ms` from persisted model round items.
 4. Identify context compression items by existing `ContextCompression` tool records and compression event metadata when available.
@@ -1073,7 +1108,7 @@ Steps:
 6. Resolve workspace identity before reading session, token, or snapshot data.
 7. Mark cached tokens as unavailable when the source records only subscriber-filled zeroes.
 8. Mark remote snapshot stats as unavailable when snapshot tracking is skipped for remote workspaces.
-9. Mark missing coverage keys for model round timing, tool phase timing, cached token detail, subagent scope, remote snapshot stats, and cost estimates in P0.
+9. Mark missing coverage keys for model round timing, tool phase timing, cached token detail, subagent scope, and remote snapshot stats in P0.
 
 Functional guardrails:
 
@@ -1118,7 +1153,7 @@ Steps:
 2. Add `render_usage_report_markdown(report)` for Desktop P0.
 3. Keep rendering deterministic: stable sort models/tools by duration or token count, then by label.
 4. Include a partial-data note when `coverage.level == Partial`.
-5. Do not render cost, money, price, billing, package, subscription, or invoice lines; render token counts and token coverage only.
+5. Render token counts and token coverage only; omit unrelated account, plan, or quota language.
 6. Render scope, generated time, and in-progress state in a compact way when they affect interpretation.
 7. Render unavailable cached tokens as unavailable/partial, not as `0`, unless the source proves the true value is zero.
 8. Bound and redact slowest-work labels, error examples, and path displays.
@@ -1309,8 +1344,8 @@ Functional guardrails:
 - Do not break existing event names or required fields consumed by Desktop, server, or CLI.
 - Do not emit per-token events.
 - Do not change model retry behavior as part of metrics instrumentation.
-- Do not derive authoritative cost from token details in this task.
-- Do not use display aliases such as `fast` for provider cost or model-level aggregation when the resolved model id is known.
+- Do not derive user-facing optimization conclusions from token details in this task.
+- Do not use display aliases such as `fast` for model-level aggregation when the resolved model id is known.
 
 Risks and mitigations:
 
@@ -1421,7 +1456,7 @@ Verification:
 
 ### Task 11: Responsive Chat-bottom usage entry
 
-Goal: add one compact Chat-bottom entry that generates the current session usage report without displaying live metrics. A live summary or header entry can be planned later when runtime spans and layout needs are reliable.
+Goal: add one compact Chat-bottom entry that generates the current session usage report without displaying live metrics. Live summaries and header entries are outside the closed product scope.
 
 Files:
 
@@ -1437,7 +1472,7 @@ Steps:
 3. Preserve Chat input footer workspace, branch, model, attachment, and send-control layout priority.
 4. Add tooltip and accessible label that describe the action, not live report values.
 5. Hide the entry when no active session exists.
-6. Keep live values out of the entry until a later span contract can support them.
+6. Keep live values out of the entry.
 7. Do not add a duplicate title/header entry while the Chat-bottom action is the product-approved entry point.
 
 Functional guardrails:
@@ -1454,7 +1489,7 @@ Risks and mitigations:
 | Risk | Mitigation |
 | --- | --- |
 | Small windows become cluttered | Use container-query or measured available-space collapse |
-| The Chat footer becomes too dynamic while streaming | Keep the implemented entry action-only; require a separate design before adding live values |
+| The Chat footer becomes too dynamic while streaming | Keep the implemented entry action-only |
 | Accessibility suffers in icon-only mode | Provide aria-label and tooltip with text summary |
 | Users confuse live action and historical report | Label report generated time and keep the entry action-only |
 
@@ -1481,7 +1516,7 @@ Steps:
 
 1. Open the panel from the Markdown/report-card action and Chat-bottom usage entry.
 2. Add tabs: Overview, Models, Tools, Files, Errors, Slowest.
-3. Use virtualized or capped lists for slowest spans and file rows.
+3. Use panel-local capped lists for slowest spans and file rows first; consider virtualization only in a separate design if caps are insufficient.
 4. Link file rows to existing diff open paths.
 5. Show partial coverage explanations close to affected metrics.
 6. Keep detail expansion routed through existing transcript/diff permissions instead of embedding raw details in the panel.
@@ -1498,7 +1533,7 @@ Risks and mitigations:
 | Risk | Mitigation |
 | --- | --- |
 | Panel becomes a second debugger UI | Keep the default view summary-first and hide raw detail behind existing transcript links |
-| Large sessions cause UI jank | Cap rows and virtualize long lists |
+| Large sessions cause UI jank | Cap rows inside the usage panel first; do not touch Flow Chat global virtualization without a separate design |
 | File links open wrong scope | Include explicit scope metadata and route through existing diff helpers |
 | Panel exposes more sensitive detail than transcript | Reuse existing detail surfaces and redaction policy |
 
@@ -1508,45 +1543,43 @@ Verification:
 - Manual checks on long sessions.
 - Existing Flow Chat rendering tests still pass.
 
-### Task 13: Token-only cost boundary and cross-session analytics
+### Task 13: Closed product scope guardrails
 
-Goal: lock the economics boundary so `/usage` remains token-level observability, not billing or package analytics.
+Goal: keep `/usage` focused on current-session observability and prevent scope drift into cross-session summaries, recommendations, or live runtime control.
 
 Files:
 
 - Harden: `src/crates/core/src/service/session_usage/render.rs`
 - Harden: `src/apps/cli/src/main.rs`
 - Update: `session-runtime-usage-report-design.md`
-- Test: token-only report and top-level CLI scope tests
+- Test: current-session report and top-level CLI scope tests
 
 Steps:
 
-1. Do not add optional monetary cost fields to the report DTO.
-2. Keep cost-adjacent reporting at input/output/total/cached token counts and token coverage.
-3. Separate cache read, cache write, input, output, and reasoning token categories only when providers expose them reliably.
-4. Add cross-session aggregation as a separate command or dashboard, not part of `/usage` P0.
-5. Keep top-level `bitfun usage --session <id>` out of scope until workspace-scoped persisted session lookup is designed.
+1. Keep the DTO limited to current-session runtime facts: tokens, timing, models, tools, files, errors, coverage, privacy, and navigation metadata.
+2. Separate cache read, cache write, input, output, and reasoning token categories only when providers expose them reliably.
+3. Keep cross-session aggregation, live footer metrics, and automated recommendations out of the closed product scope.
+4. Keep top-level `bitfun usage --session <id>` out of scope until workspace-scoped persisted session lookup is designed.
 
 Functional guardrails:
 
-- Do not show money, currency, price source, package, subscription, invoice, or billing language.
-- Do not imply token counts are authoritative billing.
-- Do not make cost estimates block or change `/usage` token reporting.
-- Do not backfill or rewrite historical reports with monetary cost data.
+- Do not show charts, cross-session trends, live runtime percentages, optimization recommendations, or scheduler actions in this report.
+- Do not imply token counts are a quota or policy decision.
+- Do not backfill or rewrite historical reports when newer runtime facts become available.
+- Preserve current-session scope markers and partial-coverage copy.
 
 Risks and mitigations:
 
 | Risk | Mitigation |
 | --- | --- |
-| User trusts estimate as invoice | Do not render monetary estimates at all |
-| Provider semantics drift | Keep provider billing outside the report contract |
-| Scope expands into analytics platform too early | Keep cross-session analytics behind a later milestone |
-| Historical reports become inconsistent after price updates | Persist token counts only; never rewrite them into monetary estimates |
+| User reads the report as an instruction to change workflow | Keep the copy descriptive and avoid recommendations |
+| Provider token semantics drift | Keep token detail fields optional and covered by partial-data markers |
+| Scope expands beyond the current session too early | Keep cross-session views out of this milestone |
+| Historical reports become inconsistent after runtime schema updates | Treat persisted reports as snapshots and regenerate a new report when needed |
 
 Verification:
 
 - Tests assert token reporting is present.
-- Tests assert monetary, price, billing, and package language is absent.
 - CLI test asserts top-level `usage` is not registered.
 
 ## Product Risks and Mitigations
@@ -1555,7 +1588,7 @@ Verification:
 | --- | --- | --- |
 | Usage report pollutes future model context | Higher token usage, confusing self-reference | Store as non-model-visible local command output |
 | Metrics look authoritative when data is partial | User mistrust | Include coverage state and "partial data" notes |
-| Token-count proxy is mistaken for provider billing | Billing confusion | Do not render money, price sources, packages, or invoice language |
+| Token counts are mistaken for a workflow instruction | User changes behavior based on partial data | Keep the report descriptive, show coverage, and avoid recommendations |
 | Chat footer becomes noisy or breaks small windows | Worse chat UX | Responsive priority collapse and tooltip-only narrow mode |
 | Report exposes sensitive command/file details | Privacy concern | Default to aggregate labels; detailed command/file rows follow existing transcript visibility rules |
 | Runtime tracing adds overhead | Slower sessions | Persist request/tool terminal summaries, not per-token events |
@@ -1581,7 +1614,7 @@ Minimum checks for implementation milestones:
 - Locale smoke tests for `en-US`, `zh-CN`, and `zh-TW`.
 - Theme screenshot/manual checks for dark and light modes.
 - Regression check that running `/usage` does not trigger a model request.
-- Fixture tests for old sessions, missing token records, cache-unavailable records, remote workspaces without snapshot stats, hidden subagent linkage, repeated reports, and active-session behavior.
+- Fixture tests for old sessions, missing token records, cache-unavailable records, remote workspaces without snapshot stats, hidden subagent exclusion, repeated reports, and active-session behavior.
 - Time-accounting tests where parent and child spans overlap, proving percentages use the intended denominator.
 - Redaction tests covering command labels, file paths, error examples, and omitted tool params/results.
 - Workspace identity tests proving a report cannot read a same-id session from another local or remote workspace.
@@ -1601,29 +1634,23 @@ cargo check --workspace
 cargo test --workspace
 ```
 
-## Open Decisions
+## Closed Product Decisions
 
-- Resolved in the current implementation: Desktop renders `/usage` as a dedicated local report card backed by structured metadata and Markdown fallback.
-- Resolved in the current implementation: CLI supports interactive chat `/usage`; top-level `bitfun usage --session <id>` waits for a separate workspace-scoped analytics design.
-- Resolved in the current implementation: monetary cost estimates are hidden entirely; token counts and token coverage are the only supported cost proxy.
-- Resolved after product review: BitFun startup does not force-run ACP requirement probes, because probing CLIs such as `opencode --version` can create surprising side effects.
-- Resolved after product review: packaged flashgrep resources are injected per target at build time instead of bundling every platform binary into each installer.
-- Resolved after product review: the compact usage entry lives in the Chat input footer as a lightweight `/usage` trigger; it does not display live model/tool percentages and no longer appears in the title/header area.
-- Resolved after product review: unavailable cache, tool timing, and file metrics include user-facing reasons in hover/help text.
-- Resolved after product review: model timing is labeled as recorded model-round time; per-model duration columns appear only when at least one model row has recorded duration facts.
-- Resolved after product review: the detail panel shows generated time, session ID, and project path as separate rows with copy controls for long values.
-- Resolved in P1: idle gap is computed as wall time minus the union of recorded active turn spans when those spans are available.
-- Resolved in the current implementation: report generation itself is a user-visible local command card, but it is excluded from report scope, timing, model/tool/file/error rows, and session activity ordering.
-- Resolved in the current implementation: `/usage` requires an idle session and returns local feedback while a turn is active.
-- Should a standard session report include hidden subagents by default when parent linkage is reliable, or should subagent totals be opt-in until the scheduler/event model is complete?
-- Should visible side sessions such as `/btw` appear only as links in the parent report, or be aggregated into a parent-with-side-sessions mode later?
-- Resolved in the current implementation: cached tokens are shown as unavailable when the source cannot prove a value; unknown cache metrics are never shown as `0`.
-- What exact path redaction rule should apply to workspace-relative, absolute local, and remote paths in exported usage reports?
-- What stable navigation contract should usage rows use for transcript and tool-card jumps beyond the current turn-level slow-span jump?
-- What row cap or virtualization threshold should P2 use for long model, tool, file, error, and slowest lists?
-- Should the detail panel stay as one consolidated module, or split into per-tab components once the current P2 hardening work is complete?
-- What manual acceptance baseline is required for light theme, dark theme, keyboard navigation, screen-reader labels, and small desktop widths before marking P2 complete?
-- Resolved in the current implementation: Desktop renders localized reports from DTOs when structured metadata exists, while Markdown remains a fallback and exportable snapshot.
+No remaining product decision blocks closure. The current implementation and this document define the closed scope as:
+
+- Desktop renders `/usage` as a dedicated local report card backed by structured metadata and Markdown fallback.
+- CLI supports interactive chat `/usage`; top-level `bitfun usage --session <id>` is outside the closed product scope.
+- The compact usage entry lives in the Chat input footer as a lightweight `/usage` trigger; it does not display live model/tool percentages and no longer appears in the title/header area.
+- Unavailable cache, tool timing, and file metrics include user-facing reasons in hover/help text.
+- Model timing is labeled as recorded model-round time; per-model duration columns appear only when at least one model row has recorded duration facts.
+- The detail panel shows generated time, session ID, and project path as separate rows with copy controls for long values.
+- Idle gap is computed as wall time minus the union of recorded active turn spans when those spans are available.
+- Report generation itself is a user-visible local command card, but it is excluded from report scope, timing, model/tool/file/error rows, and session activity ordering.
+- `/usage` requires an idle session and returns local feedback while a turn is active.
+- Cached tokens are shown as unavailable when the source cannot prove a value; unknown cache metrics are never shown as `0`.
+- Hidden subagents, visible side sessions, full trace timelines, exact per-call occurrence browsing, live status metrics, and cross-session summaries are outside the closed product scope.
+- Path redaction for Markdown copy/export defaults on, can be user-confirmed by checkbox, and remembers the last preference.
+- The detail panel stays consolidated unless normal maintenance proves a split is needed.
 
 ## Recommended First Cut
 
@@ -1637,5 +1664,5 @@ Historical first cut, now complete in the current branch, started with Milestone
 6. Keep one compact Chat-bottom entry point until live runtime values have a separate, reliable span contract and placement review.
 
 This delivered immediate user value while avoiding risky runtime rewrites. The
-remaining work is now concentrated in P2 hardening and explicitly deferred
-cross-session analytics, not the P0/P1 report contract.
+remaining work is now concentrated in P2 hardening, not the P0/P1 report
+contract.

--- a/src/apps/cli/src/modes/chat.rs
+++ b/src/apps/cli/src/modes/chat.rs
@@ -85,7 +85,6 @@ fn usage_report_from_cli_session(session: &Session) -> SessionUsageReport {
                 UsageCoverageKey::SubagentScope,
                 UsageCoverageKey::RemoteSnapshotStats,
                 UsageCoverageKey::FileLineStats,
-                UsageCoverageKey::CostEstimates,
             ],
             notes: vec![
                 "CLI P0 report uses current in-memory session metadata only.".to_string(),

--- a/src/crates/core/src/service/session_usage/render.rs
+++ b/src/crates/core/src/service/session_usage/render.rs
@@ -404,7 +404,6 @@ fn coverage_key_label(key: &UsageCoverageKey) -> &'static str {
         UsageCoverageKey::SubagentScope => "subagent_scope",
         UsageCoverageKey::RemoteSnapshotStats => "remote_snapshot_stats",
         UsageCoverageKey::FileLineStats => "file_line_stats",
-        UsageCoverageKey::CostEstimates => "cost_estimates",
         UsageCoverageKey::WorkspaceIdentity => "workspace_identity",
     }
 }

--- a/src/crates/core/src/service/session_usage/service.rs
+++ b/src/crates/core/src/service/session_usage/service.rs
@@ -233,7 +233,6 @@ fn build_coverage(
         UsageCoverageKey::CachedTokens,
         UsageCoverageKey::TokenDetailBreakdown,
         UsageCoverageKey::FileLineStats,
-        UsageCoverageKey::CostEstimates,
     ];
     if !available.contains(&UsageCoverageKey::ModelRoundTiming) {
         missing.push(UsageCoverageKey::ModelRoundTiming);
@@ -420,6 +419,10 @@ fn build_model_breakdown(
 ) -> Vec<UsageModelBreakdown> {
     let mut by_model: HashMap<String, UsageModelBreakdown> = HashMap::new();
     let mut span_counts_by_model: HashMap<String, u64> = HashMap::new();
+    let turn_indexes_by_id: HashMap<&str, usize> = turns
+        .iter()
+        .map(|turn| (turn.turn_id.as_str(), turn.turn_index))
+        .collect();
     for record in token_records {
         let row = by_model
             .entry(record.model_id.clone())
@@ -431,6 +434,8 @@ fn build_model_breakdown(
                 total_tokens: Some(0),
                 cached_tokens: None,
                 duration_ms: None,
+                sample_turn_id: None,
+                sample_turn_index: None,
             });
 
         row.call_count += 1;
@@ -440,27 +445,43 @@ fn build_model_breakdown(
         if record.cached_tokens_available {
             row.cached_tokens = Some(row.cached_tokens.unwrap_or(0) + record.cached_tokens as u64);
         }
+        set_turn_anchor_if_missing(
+            &mut row.sample_turn_id,
+            &mut row.sample_turn_index,
+            &record.turn_id,
+            turn_indexes_by_id.get(record.turn_id.as_str()).copied(),
+        );
     }
 
-    for round in turns.iter().flat_map(|turn| turn.model_rounds.iter()) {
-        let Some(duration_ms) = model_round_duration_ms(round) else {
-            continue;
-        };
-        let model_id = model_round_label(round);
-        let row = by_model
-            .entry(model_id.clone())
-            .or_insert_with(|| UsageModelBreakdown {
-                model_id: model_id.clone(),
-                call_count: 0,
-                input_tokens: None,
-                output_tokens: None,
-                total_tokens: None,
-                cached_tokens: None,
-                duration_ms: Some(0),
-            });
+    for turn in turns {
+        for round in &turn.model_rounds {
+            let Some(duration_ms) = model_round_duration_ms(round) else {
+                continue;
+            };
+            let model_id = model_round_label(round);
+            let row = by_model
+                .entry(model_id.clone())
+                .or_insert_with(|| UsageModelBreakdown {
+                    model_id: model_id.clone(),
+                    call_count: 0,
+                    input_tokens: None,
+                    output_tokens: None,
+                    total_tokens: None,
+                    cached_tokens: None,
+                    duration_ms: Some(0),
+                    sample_turn_id: None,
+                    sample_turn_index: None,
+                });
 
-        row.duration_ms = Some(row.duration_ms.unwrap_or(0) + duration_ms);
-        *span_counts_by_model.entry(model_id).or_default() += 1;
+            row.duration_ms = Some(row.duration_ms.unwrap_or(0) + duration_ms);
+            set_turn_anchor_if_missing(
+                &mut row.sample_turn_id,
+                &mut row.sample_turn_index,
+                &turn.turn_id,
+                Some(turn.turn_index),
+            );
+            *span_counts_by_model.entry(model_id).or_default() += 1;
+        }
     }
 
     for (model_id, span_count) in span_counts_by_model {
@@ -478,43 +499,56 @@ fn build_tool_breakdown(turns: &[DialogTurnData]) -> Vec<UsageToolBreakdown> {
     let mut by_tool: HashMap<String, UsageToolBreakdown> = HashMap::new();
     let mut durations_by_tool: HashMap<String, Vec<u64>> = HashMap::new();
 
-    for tool in iter_tools(turns) {
-        let label = redact_usage_label(&tool.tool_name, 80);
-        let row = by_tool
-            .entry(label.value.clone())
-            .or_insert_with(|| UsageToolBreakdown {
-                tool_name: label.value.clone(),
-                category: classify_tool_usage(&tool.tool_name, Some(&tool.tool_call.input)),
-                call_count: 0,
-                success_count: 0,
-                error_count: 0,
-                duration_ms: Some(0),
-                p95_duration_ms: None,
-                queue_wait_ms: None,
-                preflight_ms: None,
-                confirmation_wait_ms: None,
-                execution_ms: None,
-                redacted: label.redacted,
-            });
-        row.call_count += 1;
-        match tool.tool_result.as_ref().map(|result| result.success) {
-            Some(true) => row.success_count += 1,
-            Some(false) => row.error_count += 1,
-            None => {}
-        }
-        let duration_ms = tool_duration_ms(tool).unwrap_or(0);
-        row.duration_ms = Some(row.duration_ms.unwrap_or(0) + duration_ms);
-        if duration_ms > 0 {
-            durations_by_tool
+    for turn in turns {
+        for tool in iter_turn_tools(turn) {
+            let label = redact_usage_label(&tool.tool_name, 80);
+            let row = by_tool
                 .entry(label.value.clone())
-                .or_default()
-                .push(duration_ms);
+                .or_insert_with(|| UsageToolBreakdown {
+                    tool_name: label.value.clone(),
+                    category: classify_tool_usage(&tool.tool_name, Some(&tool.tool_call.input)),
+                    call_count: 0,
+                    success_count: 0,
+                    error_count: 0,
+                    duration_ms: Some(0),
+                    p95_duration_ms: None,
+                    queue_wait_ms: None,
+                    preflight_ms: None,
+                    confirmation_wait_ms: None,
+                    execution_ms: None,
+                    sample_turn_id: None,
+                    sample_turn_index: None,
+                    sample_item_id: None,
+                    redacted: label.redacted,
+                });
+            row.call_count += 1;
+            match tool.tool_result.as_ref().map(|result| result.success) {
+                Some(true) => row.success_count += 1,
+                Some(false) => row.error_count += 1,
+                None => {}
+            }
+            let duration_ms = tool_duration_ms(tool).unwrap_or(0);
+            row.duration_ms = Some(row.duration_ms.unwrap_or(0) + duration_ms);
+            if duration_ms > 0 {
+                durations_by_tool
+                    .entry(label.value.clone())
+                    .or_default()
+                    .push(duration_ms);
+            }
+            add_optional_duration(&mut row.queue_wait_ms, tool.queue_wait_ms);
+            add_optional_duration(&mut row.preflight_ms, tool.preflight_ms);
+            add_optional_duration(&mut row.confirmation_wait_ms, tool.confirmation_wait_ms);
+            add_optional_duration(&mut row.execution_ms, tool.execution_ms);
+            set_item_anchor_if_missing(
+                &mut row.sample_turn_id,
+                &mut row.sample_turn_index,
+                &mut row.sample_item_id,
+                &turn.turn_id,
+                turn.turn_index,
+                &tool.id,
+            );
+            row.redacted |= label.redacted;
         }
-        add_optional_duration(&mut row.queue_wait_ms, tool.queue_wait_ms);
-        add_optional_duration(&mut row.preflight_ms, tool.preflight_ms);
-        add_optional_duration(&mut row.confirmation_wait_ms, tool.confirmation_wait_ms);
-        add_optional_duration(&mut row.execution_ms, tool.execution_ms);
-        row.redacted |= label.redacted;
     }
 
     let mut rows: Vec<_> = by_tool
@@ -732,29 +766,46 @@ fn build_error_breakdown(turns: &[DialogTurnData]) -> UsageErrorBreakdown {
     let mut examples = Vec::new();
 
     if model_errors > 0 {
+        let sample_model_error_turn = turns.iter().find(|turn| turn.status == TurnStatus::Error);
         examples.push(UsageErrorExample {
             label: "Model/runtime turn errors".to_string(),
             count: model_errors,
+            sample_turn_id: sample_model_error_turn.map(|turn| turn.turn_id.clone()),
+            sample_turn_index: sample_model_error_turn.map(|turn| turn.turn_index),
+            sample_item_id: None,
             redacted: false,
         });
     }
 
     let mut tool_error_counts: HashMap<String, UsageErrorExample> = HashMap::new();
-    for tool in iter_tools(turns).filter(|tool| {
-        tool.tool_result
-            .as_ref()
-            .is_some_and(|result| !result.success)
-    }) {
-        let label = redact_usage_label(&tool.tool_name, 80);
-        let row = tool_error_counts
-            .entry(label.value.clone())
-            .or_insert_with(|| UsageErrorExample {
-                label: label.value.clone(),
-                count: 0,
-                redacted: label.redacted,
-            });
-        row.count += 1;
-        row.redacted |= label.redacted;
+    for turn in turns {
+        for tool in iter_turn_tools(turn).filter(|tool| {
+            tool.tool_result
+                .as_ref()
+                .is_some_and(|result| !result.success)
+        }) {
+            let label = redact_usage_label(&tool.tool_name, 80);
+            let row = tool_error_counts
+                .entry(label.value.clone())
+                .or_insert_with(|| UsageErrorExample {
+                    label: label.value.clone(),
+                    count: 0,
+                    sample_turn_id: None,
+                    sample_turn_index: None,
+                    sample_item_id: None,
+                    redacted: label.redacted,
+                });
+            row.count += 1;
+            set_item_anchor_if_missing(
+                &mut row.sample_turn_id,
+                &mut row.sample_turn_index,
+                &mut row.sample_item_id,
+                &turn.turn_id,
+                turn.turn_index,
+                &tool.id,
+            );
+            row.redacted |= label.redacted;
+        }
     }
 
     let mut tool_examples: Vec<_> = tool_error_counts.into_values().collect();
@@ -893,6 +944,34 @@ fn tool_duration_ms(tool: &ToolItemData) -> Option<u64> {
 fn add_optional_duration(total: &mut Option<u64>, value: Option<u64>) {
     if let Some(value) = value {
         *total = Some(total.unwrap_or(0) + value);
+    }
+}
+
+fn set_turn_anchor_if_missing(
+    sample_turn_id: &mut Option<String>,
+    sample_turn_index: &mut Option<usize>,
+    turn_id: &str,
+    turn_index: Option<usize>,
+) {
+    if sample_turn_id.is_none() {
+        *sample_turn_id = Some(turn_id.to_string());
+    }
+    if sample_turn_index.is_none() {
+        *sample_turn_index = turn_index;
+    }
+}
+
+fn set_item_anchor_if_missing(
+    sample_turn_id: &mut Option<String>,
+    sample_turn_index: &mut Option<usize>,
+    sample_item_id: &mut Option<String>,
+    turn_id: &str,
+    turn_index: usize,
+    item_id: &str,
+) {
+    set_turn_anchor_if_missing(sample_turn_id, sample_turn_index, turn_id, Some(turn_index));
+    if sample_item_id.is_none() {
+        *sample_item_id = Some(item_id.to_string());
     }
 }
 
@@ -1204,6 +1283,73 @@ mod tests {
             assert_eq!(span.turn_id.as_deref(), Some("turn-7"));
             assert_eq!(span.turn_index, Some(7));
         }
+    }
+
+    #[test]
+    fn report_adds_representative_anchors_to_model_tool_and_error_rows() {
+        let request = test_request(None);
+        let mut failed_turn = test_turn_with_tools(
+            "turn-2",
+            2,
+            DialogTurnKind::UserDialog,
+            vec![test_tool_item(
+                "tool-failed",
+                "write_file",
+                Some(false),
+                120,
+                "D:/workspace/bitfun/src/main.rs",
+            )],
+        );
+        failed_turn.model_rounds[0].model_id = Some("model-a".to_string());
+        failed_turn.model_rounds[0].model_alias = Some("model-a".to_string());
+        failed_turn.model_rounds[0].duration_ms = Some(220);
+        let mut model_error_turn =
+            test_turn_with_tools("turn-4", 4, DialogTurnKind::UserDialog, vec![]);
+        model_error_turn.status = TurnStatus::Error;
+
+        let report = build_session_usage_report_from_turns(
+            request,
+            &[failed_turn, model_error_turn],
+            &[],
+            1_778_347_200_000,
+        );
+
+        let model = report
+            .models
+            .iter()
+            .find(|model| model.model_id == "model-a")
+            .expect("model row");
+        assert_eq!(model.sample_turn_id.as_deref(), Some("turn-2"));
+        assert_eq!(model.sample_turn_index, Some(2));
+
+        let tool = report
+            .tools
+            .iter()
+            .find(|tool| tool.tool_name == "write_file")
+            .expect("tool row");
+        assert_eq!(tool.sample_turn_id.as_deref(), Some("turn-2"));
+        assert_eq!(tool.sample_turn_index, Some(2));
+        assert_eq!(tool.sample_item_id.as_deref(), Some("tool-failed"));
+
+        let tool_error = report
+            .errors
+            .examples
+            .iter()
+            .find(|example| example.label == "write_file")
+            .expect("tool error example");
+        assert_eq!(tool_error.sample_turn_id.as_deref(), Some("turn-2"));
+        assert_eq!(tool_error.sample_turn_index, Some(2));
+        assert_eq!(tool_error.sample_item_id.as_deref(), Some("tool-failed"));
+
+        let model_error = report
+            .errors
+            .examples
+            .iter()
+            .find(|example| example.label == "Model/runtime turn errors")
+            .expect("model error example");
+        assert_eq!(model_error.sample_turn_id.as_deref(), Some("turn-4"));
+        assert_eq!(model_error.sample_turn_index, Some(4));
+        assert_eq!(model_error.sample_item_id, None);
     }
 
     #[test]

--- a/src/crates/core/src/service/session_usage/types.rs
+++ b/src/crates/core/src/service/session_usage/types.rs
@@ -99,7 +99,6 @@ pub enum UsageCoverageKey {
     SubagentScope,
     RemoteSnapshotStats,
     FileLineStats,
-    CostEstimates,
     WorkspaceIdentity,
 }
 
@@ -170,6 +169,10 @@ pub struct UsageModelBreakdown {
     pub total_tokens: Option<u64>,
     pub cached_tokens: Option<u64>,
     pub duration_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_turn_index: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -191,6 +194,12 @@ pub struct UsageToolBreakdown {
     pub confirmation_wait_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_turn_index: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_item_id: Option<String>,
     pub redacted: bool,
 }
 
@@ -272,6 +281,12 @@ pub struct UsageErrorBreakdown {
 pub struct UsageErrorExample {
     pub label: String,
     pub count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_turn_index: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_item_id: Option<String>,
     pub redacted: bool,
 }
 
@@ -335,7 +350,6 @@ impl SessionUsageReport {
                 missing: vec![
                     UsageCoverageKey::CachedTokens,
                     UsageCoverageKey::TokenDetailBreakdown,
-                    UsageCoverageKey::CostEstimates,
                 ],
                 notes: vec![
                     "P0 report uses existing persisted session facts and marks not-reported metrics explicitly."
@@ -414,7 +428,6 @@ pub(crate) fn test_report() -> SessionUsageReport {
     report.coverage.missing = vec![
         UsageCoverageKey::CachedTokens,
         UsageCoverageKey::TokenDetailBreakdown,
-        UsageCoverageKey::CostEstimates,
     ];
     report.time = UsageTimeBreakdown {
         accounting: UsageTimeAccounting::Approximate,
@@ -441,6 +454,8 @@ pub(crate) fn test_report() -> SessionUsageReport {
         total_tokens: Some(1540),
         cached_tokens: None,
         duration_ms: None,
+        sample_turn_id: Some("turn-1".to_string()),
+        sample_turn_index: Some(0),
     }];
     report.tools = vec![UsageToolBreakdown {
         tool_name: "read_file".to_string(),
@@ -454,6 +469,9 @@ pub(crate) fn test_report() -> SessionUsageReport {
         preflight_ms: None,
         confirmation_wait_ms: None,
         execution_ms: None,
+        sample_turn_id: Some("turn-1".to_string()),
+        sample_turn_index: Some(0),
+        sample_item_id: Some("tool-1".to_string()),
         redacted: false,
     }];
     report.files = UsageFileBreakdown {

--- a/src/web-ui/src/flow_chat/components/modern/ExploreGroupRenderer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ExploreGroupRenderer.tsx
@@ -283,15 +283,17 @@ const ExploreItemRenderer = React.memo<ExploreItemRendererProps>(({ item, turnId
     
     case 'tool':
       return (
-        <FlowToolCard
-          toolItem={item as FlowToolItem}
-          onConfirm={handleConfirm}
-          onReject={handleReject}
-          onOpenInEditor={handleOpenInEditor}
-          onOpenInPanel={handleOpenInPanel}
-          sessionId={sessionId}
-          turnId={turnId}
-        />
+        <div className="flowchat-flow-item" data-flow-item-id={item.id} data-flow-item-type="tool">
+          <FlowToolCard
+            toolItem={item as FlowToolItem}
+            onConfirm={handleConfirm}
+            onReject={handleReject}
+            onOpenInEditor={handleOpenInEditor}
+            onOpenInPanel={handleOpenInPanel}
+            sessionId={sessionId}
+            turnId={turnId}
+          />
+        </div>
       );
 
     default:

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
@@ -572,15 +572,17 @@ const SubagentItemRenderer = React.memo<{ item: FlowItem; turnId: string; roundI
     
     case 'tool':
       return (
-        <FlowToolCard
-          toolItem={item as FlowToolItem}
-          onConfirm={handleConfirm}
-          onReject={handleReject}
-          onOpenInEditor={handleOpenInEditor}
-          onOpenInPanel={handleOpenInPanel}
-          sessionId={sessionId}
-          turnId={turnId}
-        />
+        <div className="flowchat-flow-item" data-flow-item-id={item.id} data-flow-item-type="tool">
+          <FlowToolCard
+            toolItem={item as FlowToolItem}
+            onConfirm={handleConfirm}
+            onReject={handleReject}
+            onOpenInEditor={handleOpenInEditor}
+            onOpenInPanel={handleOpenInPanel}
+            sessionId={sessionId}
+            turnId={turnId}
+          />
+        </div>
       );
 
     default:

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -88,6 +88,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     activeSessionId: activeSession?.sessionId,
     virtualItems,
     virtualListRef,
+    onExpandExploreGroup: handleExpandGroup,
   });
 
   const contextValue: FlowChatContextValue = useMemo(() => ({

--- a/src/web-ui/src/flow_chat/components/modern/flowChatFocusTarget.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatFocusTarget.ts
@@ -1,0 +1,70 @@
+import type { FlowChatFocusItemRequest } from '../../events/flowchatNavigation';
+import type { VirtualItem } from '../../store/modernFlowChatStore';
+import type { Session } from '../../types/flow-chat';
+
+export interface ResolvedFocusTarget {
+  resolvedVirtualIndex?: number;
+  resolvedTurnId?: string;
+  resolvedTurnIndex?: number;
+  focusItemId?: string;
+  expandExploreGroupId?: string;
+  preferPinnedTurnNavigation: boolean;
+}
+
+export function resolveFlowChatFocusTarget(
+  request: FlowChatFocusItemRequest,
+  currentVirtualItems: VirtualItem[],
+  targetSession?: Session,
+): ResolvedFocusTarget {
+  const { turnIndex, itemId, source } = request;
+  let resolvedVirtualIndex: number | undefined = undefined;
+  let resolvedTurnIndex = turnIndex;
+  let resolvedTurnId: string | undefined = undefined;
+  let expandExploreGroupId: string | undefined = undefined;
+
+  if (targetSession && turnIndex && turnIndex >= 1 && turnIndex <= targetSession.dialogTurns.length) {
+    resolvedTurnId = targetSession.dialogTurns[turnIndex - 1]?.id;
+  }
+
+  if (itemId) {
+    if (targetSession) {
+      for (let i = 0; i < targetSession.dialogTurns.length; i += 1) {
+        const turn = targetSession.dialogTurns[i];
+        const found = turn.modelRounds?.some(round => round.items?.some(item => item.id === itemId));
+        if (found) {
+          resolvedTurnIndex = i + 1;
+          resolvedTurnId = turn.id;
+          break;
+        }
+      }
+    }
+
+    for (let i = 0; i < currentVirtualItems.length; i += 1) {
+      const item = currentVirtualItems[i];
+      if (item.type === 'model-round') {
+        const hit = item.data?.items?.some(flowItem => flowItem?.id === itemId);
+        if (hit) {
+          resolvedVirtualIndex = i;
+          break;
+        }
+      } else if (item.type === 'explore-group') {
+        const hit = item.data?.allItems?.some(flowItem => flowItem?.id === itemId);
+        if (hit) {
+          resolvedVirtualIndex = i;
+          resolvedTurnId = resolvedTurnId ?? item.turnId;
+          expandExploreGroupId = item.data.groupId;
+          break;
+        }
+      }
+    }
+  }
+
+  return {
+    resolvedVirtualIndex,
+    resolvedTurnId,
+    resolvedTurnIndex,
+    focusItemId: itemId,
+    expandExploreGroupId,
+    preferPinnedTurnNavigation: source === 'btw-back',
+  };
+}

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatNavigation.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatNavigation.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import type { FlowToolItem, ModelRound, Session } from '../../types/flow-chat';
+import type { VirtualItem } from '../../store/modernFlowChatStore';
+import { resolveFlowChatFocusTarget } from './flowChatFocusTarget';
+
+function makeReadTool(id: string): FlowToolItem {
+  return {
+    id,
+    type: 'tool',
+    toolName: 'Read',
+    timestamp: 1000,
+    status: 'completed',
+    toolCall: {
+      id,
+      input: { file_path: 'src/main.rs' },
+    },
+    toolResult: {
+      result: 'file contents',
+      success: true,
+    },
+  };
+}
+
+function makeRound(items: FlowToolItem[]): ModelRound {
+  return {
+    id: 'round-1',
+    index: 0,
+    items,
+    isStreaming: false,
+    isComplete: true,
+    status: 'completed',
+    startTime: 1000,
+  };
+}
+
+function makeSession(round: ModelRound): Session {
+  return {
+    sessionId: 'session-1',
+    dialogTurns: [{
+      id: 'turn-1',
+      sessionId: 'session-1',
+      userMessage: {
+        id: 'user-1',
+        content: 'Inspect the file',
+        timestamp: 900,
+      },
+      modelRounds: [round],
+      status: 'completed',
+      startTime: 900,
+    }],
+    status: 'idle',
+    config: {},
+    createdAt: 800,
+    lastActiveAt: 1000,
+    error: null,
+    sessionKind: 'flow_chat',
+  };
+}
+
+describe('useFlowChatNavigation focus resolution', () => {
+  it('requests explore group expansion before focusing a grouped tool item', () => {
+    const tool = makeReadTool('tool-1');
+    const round = makeRound([tool]);
+    const session = makeSession(round);
+    const virtualItems: VirtualItem[] = [
+      {
+        type: 'user-message',
+        data: session.dialogTurns[0].userMessage,
+        turnId: 'turn-1',
+      },
+      {
+        type: 'explore-group',
+        turnId: 'turn-1',
+        data: {
+          groupId: 'round-1',
+          rounds: [round],
+          allItems: [tool],
+          stats: {
+            readCount: 1,
+            searchCount: 0,
+            commandCount: 0,
+          },
+          isGroupStreaming: false,
+          isLastGroupInTurn: true,
+        },
+      },
+    ];
+
+    const target = resolveFlowChatFocusTarget({
+      sessionId: session.sessionId,
+      turnIndex: 1,
+      itemId: tool.id,
+      source: 'usage-report',
+    }, virtualItems, session);
+
+    expect(target).toMatchObject({
+      resolvedVirtualIndex: 1,
+      resolvedTurnId: 'turn-1',
+      resolvedTurnIndex: 1,
+      expandExploreGroupId: 'round-1',
+      focusItemId: tool.id,
+      preferPinnedTurnNavigation: false,
+    });
+  });
+});

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatNavigation.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatNavigation.ts
@@ -18,6 +18,7 @@ import {
   type FlowChatPinTurnToTopRequest,
 } from '../../events/flowchatNavigation';
 import type { VirtualMessageListRef } from './VirtualMessageList';
+import { resolveFlowChatFocusTarget, type ResolvedFocusTarget } from './flowChatFocusTarget';
 
 const log = createLogger('useFlowChatNavigation');
 
@@ -25,13 +26,7 @@ interface UseFlowChatNavigationOptions {
   activeSessionId?: string;
   virtualItems: VirtualItem[];
   virtualListRef: RefObject<VirtualMessageListRef | null>;
-}
-
-interface ResolvedFocusTarget {
-  resolvedVirtualIndex?: number;
-  resolvedTurnId?: string;
-  resolvedTurnIndex?: number;
-  preferPinnedTurnNavigation: boolean;
+  onExpandExploreGroup?: (groupId: string) => void;
 }
 
 async function waitForCondition(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
@@ -49,59 +44,6 @@ async function waitForAnimationFrames(frameCount: number): Promise<void> {
     await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
     remaining -= 1;
   }
-}
-
-function resolveFocusTarget(
-  request: FlowChatFocusItemRequest,
-  currentVirtualItems: VirtualItem[],
-): ResolvedFocusTarget {
-  const { sessionId, turnIndex, itemId, source } = request;
-  let resolvedVirtualIndex: number | undefined = undefined;
-  let resolvedTurnIndex = turnIndex;
-  let resolvedTurnId: string | undefined = undefined;
-  const targetSession = flowChatStore.getState().sessions.get(sessionId);
-
-  if (targetSession && turnIndex && turnIndex >= 1 && turnIndex <= targetSession.dialogTurns.length) {
-    resolvedTurnId = targetSession.dialogTurns[turnIndex - 1]?.id;
-  }
-
-  if (itemId) {
-    if (targetSession) {
-      for (let i = 0; i < targetSession.dialogTurns.length; i += 1) {
-        const turn = targetSession.dialogTurns[i];
-        const found = turn.modelRounds?.some(round => round.items?.some(item => item.id === itemId));
-        if (found) {
-          resolvedTurnIndex = i + 1;
-          resolvedTurnId = turn.id;
-          break;
-        }
-      }
-    }
-
-    for (let i = 0; i < currentVirtualItems.length; i += 1) {
-      const item = currentVirtualItems[i];
-      if (item.type === 'model-round') {
-        const hit = item.data?.items?.some(flowItem => flowItem?.id === itemId);
-        if (hit) {
-          resolvedVirtualIndex = i;
-          break;
-        }
-      } else if (item.type === 'explore-group') {
-        const hit = item.data?.allItems?.some(flowItem => flowItem?.id === itemId);
-        if (hit) {
-          resolvedVirtualIndex = i;
-          break;
-        }
-      }
-    }
-  }
-
-  return {
-    resolvedVirtualIndex,
-    resolvedTurnId,
-    resolvedTurnIndex,
-    preferPinnedTurnNavigation: source === 'btw-back',
-  };
 }
 
 function navigateToResolvedTarget(
@@ -130,6 +72,7 @@ export function useFlowChatNavigation({
   activeSessionId,
   virtualItems,
   virtualListRef,
+  onExpandExploreGroup,
 }: UseFlowChatNavigationOptions): void {
   const [pendingTurnPinRequest, setPendingTurnPinRequest] = useState<FlowChatPinTurnToTopRequest | null>(null);
 
@@ -180,10 +123,16 @@ export function useFlowChatNavigation({
         return modernActiveSessionId === sessionId && !!virtualListRef.current;
       }, 1500);
 
-      const resolvedTarget = resolveFocusTarget(
+      const targetSession = flowChatStore.getState().sessions.get(sessionId);
+      const resolvedTarget = resolveFlowChatFocusTarget(
         request,
         useModernFlowChatStore.getState().virtualItems,
+        targetSession,
       );
+
+      if (resolvedTarget.expandExploreGroupId) {
+        onExpandExploreGroup?.(resolvedTarget.expandExploreGroupId);
+      }
 
       navigateToResolvedTarget(virtualListRef, resolvedTarget);
 
@@ -195,7 +144,8 @@ export function useFlowChatNavigation({
       let attempts = 0;
       const tryFocus = () => {
         attempts += 1;
-        const element = document.querySelector(`[data-flow-item-id="${CSS.escape(itemId)}"]`) as HTMLElement | null;
+        const focusItemId = resolvedTarget.focusItemId ?? itemId;
+        const element = document.querySelector(`[data-flow-item-id="${CSS.escape(focusItemId)}"]`) as HTMLElement | null;
         if (!element) {
           if (attempts % 12 === 0 && !resolvedTarget.preferPinnedTurnNavigation) {
             navigateToResolvedTarget(virtualListRef, resolvedTarget);
@@ -206,6 +156,7 @@ export function useFlowChatNavigation({
           return;
         }
 
+        element.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'auto' });
         element.classList.add('flowchat-flow-item--focused');
         window.setTimeout(() => element.classList.remove('flowchat-flow-item--focused'), 1600);
       };
@@ -214,5 +165,5 @@ export function useFlowChatNavigation({
     });
 
     return unsubscribe;
-  }, [activeSessionId, virtualListRef]);
+  }, [activeSessionId, onExpandExploreGroup, virtualListRef]);
 }

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsageComponents.test.tsx
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsageComponents.test.tsx
@@ -10,10 +10,16 @@ import { globalEventBus } from '@/infrastructure/event-bus';
 import enFlowChat from '@/locales/en-US/flow-chat.json';
 import zhCnFlowChat from '@/locales/zh-CN/flow-chat.json';
 import zhTwFlowChat from '@/locales/zh-TW/flow-chat.json';
-import { FLOWCHAT_PIN_TURN_TO_TOP_EVENT, type FlowChatPinTurnToTopRequest } from '../../events/flowchatNavigation';
+import {
+  FLOWCHAT_FOCUS_ITEM_EVENT,
+  FLOWCHAT_PIN_TURN_TO_TOP_EVENT,
+  type FlowChatFocusItemRequest,
+  type FlowChatPinTurnToTopRequest,
+} from '../../events/flowchatNavigation';
 import { SessionRuntimeStatusEntry } from './SessionRuntimeStatusEntry';
 import { SessionUsagePanel } from './SessionUsagePanel';
 import { SessionUsageReportCard } from './SessionUsageReportCard';
+import { USAGE_EXPORT_REDACT_PATHS_STORAGE_KEY } from './usageReportUtils';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -81,6 +87,7 @@ vi.mock('react-i18next', () => ({
         'usage.status.noFileChanges': 'No file changes',
         'usage.status.notRecorded': 'Not recorded',
         'usage.status.modelNotRecorded': 'Model not recorded',
+        'usage.status.p95SampleInsufficient': 'Not enough samples',
         'usage.status.legacyModel': 'Legacy model not tracked',
         'usage.status.inferredModel': '{{model}} (inferred)',
         'usage.card.heading': 'Session statistics',
@@ -172,6 +179,9 @@ vi.mock('react-i18next', () => ({
         'usage.table.duration': 'Recorded time',
         'usage.table.p95': 'P95',
         'usage.table.execution': 'Execution',
+        'usage.table.toolDuration': 'Total time',
+        'usage.table.toolP95Duration': 'P95 total',
+        'usage.table.toolExecutionDuration': 'Execution time',
         'usage.table.file': 'File',
         'usage.table.operations': 'Ops',
         'usage.table.added': 'Added',
@@ -193,6 +203,9 @@ vi.mock('react-i18next', () => ({
         'usage.table.rowLimitSummary': 'Showing {{visible}} of {{total}} rows',
         'usage.table.showAllRows': 'Show all {{count}} rows',
         'usage.table.showFewerRows': 'Show first {{count}} rows',
+        'usage.export.redactPaths': 'Redact paths',
+        'usage.export.redactPathsHelp': 'Replace workspace and file paths when copying Markdown.',
+        'usage.export.redactedPath': '[redacted path]',
       };
       return interpolate(labels[key] ?? key, options);
     },
@@ -239,7 +252,7 @@ function usageReport(overrides: Partial<SessionUsageReport> = {}): SessionUsageR
     coverage: {
       level: 'partial',
       available: ['workspace_identity'],
-      missing: ['cost_estimates'],
+      missing: ['token_detail_breakdown'],
       notes: [],
     },
     time: {
@@ -364,6 +377,7 @@ describe('Session usage report UI components', () => {
     tabUtilsMocks.createDiffEditorTab.mockReset();
     dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
       pretendToBeVisual: true,
+      url: 'http://localhost/',
     });
     vi.stubGlobal('window', dom.window);
     vi.stubGlobal('document', dom.window.document);
@@ -517,6 +531,7 @@ describe('Session usage report UI components', () => {
   });
 
   it('keeps chat card file names visible and labels model tokens', () => {
+    dom.window.localStorage.setItem(USAGE_EXPORT_REDACT_PATHS_STORAGE_KEY, 'false');
     const longPath = 'src/features/session-usage/reports/components/very/deeply/nested/UsageReportCardFilePathThatWouldNormallyOverflow.tsx';
     const fileName = 'UsageReportCardFilePathThatWouldNormallyOverflow.tsx';
     const report = usageReport({
@@ -560,6 +575,67 @@ describe('Session usage report UI components', () => {
     expect(container.textContent).not.toContain('/.../');
     expect(container.querySelector(`[data-tooltip="${longPath}"]`)).not.toBeNull();
     expect(container.textContent).toContain('1,500 tokens');
+  });
+
+  it('syncs path redaction between the chat card and detail panel', () => {
+    const report = usageReport({
+      workspace: {
+        kind: 'local',
+        pathLabel: 'D:/workspace/bitfun',
+      },
+      files: {
+        scope: 'snapshot_summary',
+        changedFiles: 1,
+        addedLines: 4,
+        deletedLines: 2,
+        files: [
+          {
+            pathLabel: 'src/private/secret.ts',
+            operationCount: 2,
+            addedLines: 4,
+            deletedLines: 2,
+            turnIndexes: [1],
+            operationIds: ['operation-1'],
+            redacted: false,
+          },
+        ],
+      },
+    });
+
+    render(
+      <>
+        <SessionUsageReportCard report={report} markdown="## Session Usage" />
+        <SessionUsagePanel
+          report={report}
+          markdown="## Session Usage"
+          sessionId="session-1"
+          workspacePath="D:/workspace/bitfun"
+          initialTab="files"
+        />
+      </>
+    );
+
+    const redactionInputs = Array.from(container.querySelectorAll<HTMLInputElement>(
+      `input[aria-label="Redact paths"]`
+    ));
+    expect(redactionInputs).toHaveLength(2);
+    expect(redactionInputs.every(input => input.checked)).toBe(true);
+    expect(container.textContent).toContain('[redacted path]');
+    expect(container.textContent).toContain('secret.ts');
+    expect(container.textContent).not.toContain('D:/workspace/bitfun');
+    expect(container.textContent).not.toContain('src/private/secret.ts');
+    expect(container.querySelector('[data-tooltip="[redacted path]/secret.ts"]')).not.toBeNull();
+
+    act(() => {
+      redactionInputs[0]?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    const updatedInputs = Array.from(container.querySelectorAll<HTMLInputElement>(
+      `input[aria-label="Redact paths"]`
+    ));
+    expect(updatedInputs.every(input => input.checked)).toBe(false);
+    expect(container.textContent).toContain('D:/workspace/bitfun');
+    expect(container.querySelector('[data-tooltip="src/private/secret.ts"]')).not.toBeNull();
   });
 
   it('does not append a token unit when chat card model tokens are unavailable', () => {
@@ -697,7 +773,7 @@ describe('Session usage report UI components', () => {
     expect(container.textContent).not.toContain('Timing not recorded');
   });
 
-  it('renders missing tool timings as subdued values', () => {
+  it('hides unavailable tool execution timing and uses explicit tool timing headers', () => {
     const report = usageReport({
       tools: [
         {
@@ -722,8 +798,12 @@ describe('Session usage report UI components', () => {
       toolsTab?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
     });
 
+    expect(container.textContent).toContain('Total time');
+    expect(container.textContent).toContain('P95 total');
+    expect(container.textContent).not.toContain('Execution time');
+
     const missingValues = container.querySelectorAll('.session-usage-panel__missing-value');
-    expect(missingValues).toHaveLength(3);
+    expect(missingValues).toHaveLength(2);
     expect(Array.from(missingValues).every(value => value.textContent === 'Timing not recorded')).toBe(true);
   });
 
@@ -788,6 +868,109 @@ describe('Session usage report UI components', () => {
 
     expect(container.querySelectorAll('tbody tr')).toHaveLength(55);
     expect(container.textContent).toContain('Tool 55');
+  });
+
+  it('links model tool and error aggregate rows to representative transcript anchors', () => {
+    const report = usageReport({
+      models: [
+        {
+          modelId: 'gpt-5.4',
+          callCount: 1,
+          totalTokens: 120,
+          durationMs: 12_000,
+          sampleTurnId: 'turn-2',
+          sampleTurnIndex: 1,
+        },
+      ],
+      tools: [
+        {
+          toolName: 'write_file',
+          category: 'file',
+          callCount: 1,
+          successCount: 1,
+          errorCount: 0,
+          durationMs: 2_000,
+          sampleTurnIndex: 2,
+          sampleItemId: 'tool-3',
+          redacted: false,
+        },
+      ],
+      errors: {
+        totalErrors: 1,
+        toolErrors: 1,
+        modelErrors: 0,
+        examples: [
+          {
+            label: 'write_file',
+            count: 1,
+            sampleTurnIndex: 3,
+            sampleItemId: 'tool-4',
+            redacted: false,
+          },
+        ],
+      },
+    });
+    const focusEvents: FlowChatFocusItemRequest[] = [];
+    const unsubscribe = globalEventBus.on<FlowChatFocusItemRequest>(
+      FLOWCHAT_FOCUS_ITEM_EVENT,
+      event => focusEvents.push(event),
+    );
+
+    render(<SessionUsagePanel report={report} markdown="## Session Usage" sessionId="session-1" />);
+
+    const modelsTab = Array.from(container.querySelectorAll('.session-usage-panel__tab'))
+      .find(button => button.textContent === 'Models');
+    act(() => {
+      modelsTab?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+    const modelAnchor = container.querySelector<HTMLButtonElement>('.session-usage-panel__row-anchor-link');
+    expect(modelAnchor?.textContent).toContain('gpt-5.4');
+    act(() => {
+      modelAnchor?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    const toolsTab = Array.from(container.querySelectorAll('.session-usage-panel__tab'))
+      .find(button => button.textContent === 'Tools');
+    act(() => {
+      toolsTab?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+    const toolAnchor = container.querySelector<HTMLButtonElement>('.session-usage-panel__row-anchor-link');
+    expect(toolAnchor?.textContent).toContain('write_file');
+    act(() => {
+      toolAnchor?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    const errorsTab = Array.from(container.querySelectorAll('.session-usage-panel__tab'))
+      .find(button => button.textContent === 'Errors');
+    act(() => {
+      errorsTab?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+    const errorAnchor = container.querySelector<HTMLButtonElement>('.session-usage-panel__row-anchor-link');
+    expect(errorAnchor?.textContent).toContain('write_file');
+    act(() => {
+      errorAnchor?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(focusEvents).toEqual([
+      {
+        sessionId: 'session-1',
+        turnIndex: 2,
+        source: 'usage-report',
+      },
+      {
+        sessionId: 'session-1',
+        turnIndex: 3,
+        itemId: 'tool-3',
+        source: 'usage-report',
+      },
+      {
+        sessionId: 'session-1',
+        turnIndex: 4,
+        itemId: 'tool-4',
+        source: 'usage-report',
+      },
+    ]);
+    unsubscribe();
   });
 
   it('opens the detail panel on a requested usage tab', () => {
@@ -945,6 +1128,7 @@ describe('Session usage report UI components', () => {
   });
 
   it('keeps file diff actions visible and exposes full paths for long file rows', () => {
+    dom.window.localStorage.setItem(USAGE_EXPORT_REDACT_PATHS_STORAGE_KEY, 'false');
     const longPath = 'src/web-ui/src/component-library/components/Markdown/Markdown.tsx';
     const report = usageReport({
       files: {

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsagePanel.scss
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsagePanel.scss
@@ -43,6 +43,8 @@
     align-items: center;
     gap: 6px;
     flex: 0 0 auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
   }
 
   &__badge {
@@ -123,6 +125,36 @@
 
   &__copy {
     flex: 0 0 auto;
+  }
+
+  &__export-option {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--color-text-secondary);
+    font-size: var(--flowchat-font-size-xs);
+    line-height: 1;
+    white-space: nowrap;
+    cursor: pointer;
+
+    input {
+      width: 12px;
+      height: 12px;
+      margin: 0;
+      accent-color: var(--accent-primary);
+
+      &:focus-visible {
+        outline: 2px solid color-mix(in srgb, var(--accent-primary) 70%, transparent);
+        outline-offset: 2px;
+      }
+    }
+
+    span {
+      max-width: 92px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   }
 
   &__help-value {
@@ -483,7 +515,8 @@
     color: var(--color-text-muted);
   }
 
-  &__turn-link {
+  &__turn-link,
+  &__row-anchor-link {
     display: block;
     max-width: 260px;
     padding: 0;
@@ -509,6 +542,41 @@
       outline-offset: 2px;
       border-radius: 3px;
     }
+  }
+
+  &__turn-indexes {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    max-width: 160px;
+  }
+
+  &__turn-index-link {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--accent-primary);
+    font: inherit;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+    cursor: pointer;
+
+    &:hover {
+      color: var(--accent-primary-hover, var(--accent-primary));
+    }
+
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--accent-primary) 70%, transparent);
+      outline-offset: 2px;
+      border-radius: 3px;
+    }
+  }
+
+  &__turn-index-overflow {
+    color: var(--color-text-muted);
+    font-size: 11px;
+    white-space: nowrap;
   }
 
   &__table-footer {

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsagePanel.tsx
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsagePanel.tsx
@@ -19,11 +19,14 @@ import { globalEventBus } from '@/infrastructure/event-bus';
 import { createDiffEditorTab } from '@/shared/utils/tabUtils';
 import { createLogger } from '@/shared/utils/logger';
 import {
+  FLOWCHAT_FOCUS_ITEM_EVENT,
   FLOWCHAT_PIN_TURN_TO_TOP_EVENT,
+  type FlowChatFocusItemRequest,
   type FlowChatPinTurnToTopRequest,
 } from '../../events/flowchatNavigation';
 import {
   calculateShare,
+  buildSessionUsageExportMarkdown,
   formatUsageDuration,
   formatUsageNumber,
   formatUsagePercent,
@@ -34,12 +37,16 @@ import {
   getFileScopeHelp,
   getFileScopeLabel,
   getFileSummaryLabel,
+  getUsageDisplayPathLabel,
   getModelHelp,
   getModelLabel,
   getRedactedLabel,
   getSlowSpanHelp,
   getSlowSpanLabel,
   getToolCategoryLabel,
+  getUsageExportRedactPathsPreference,
+  setUsageExportRedactPathsPreference,
+  subscribeUsageExportRedactPathsPreference,
 } from './usageReportUtils';
 import type { SessionUsagePanelTab } from './sessionUsagePanelTypes';
 import './SessionUsagePanel.scss';
@@ -75,6 +82,7 @@ export const SessionUsagePanel: React.FC<SessionUsagePanelProps> = ({
   const [activeTab, setActiveTab] = useState<SessionUsagePanelTab>(initialTab ?? 'overview');
   const [copied, setCopied] = useState(false);
   const [copiedMeta, setCopiedMeta] = useState<'session' | 'workspace' | null>(null);
+  const [redactExportPaths, setRedactExportPaths] = useState(getUsageExportRedactPathsPreference);
   const tabRefs = useRef<Partial<Record<SessionUsagePanelTab, HTMLButtonElement | null>>>({});
 
   useEffect(() => {
@@ -83,15 +91,26 @@ export const SessionUsagePanel: React.FC<SessionUsagePanelProps> = ({
     }
   }, [initialTab]);
 
+  useEffect(() => (
+    subscribeUsageExportRedactPathsPreference(setRedactExportPaths)
+  ), []);
+
   const handleCopy = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(markdown);
+      await navigator.clipboard.writeText(buildSessionUsageExportMarkdown(markdown, report, {
+        redactPaths: redactExportPaths,
+        t,
+      }));
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1800);
     } catch {
       setCopied(false);
     }
-  }, [markdown]);
+  }, [markdown, redactExportPaths, report, t]);
+
+  const handleRedactExportPathsChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setUsageExportRedactPathsPreference(event.target.checked);
+  }, []);
 
   const handleCopyMeta = useCallback(async (
     value: string,
@@ -155,7 +174,10 @@ export const SessionUsagePanel: React.FC<SessionUsagePanelProps> = ({
 
   const coverageTone = getCoverageTone(report.coverage.level);
   const effectiveSessionId = sessionId ?? report.sessionId;
-  const effectiveWorkspacePath = workspacePath ?? report.workspace.pathLabel ?? t('usage.unavailable');
+  const effectiveWorkspacePath = workspacePath ?? report.workspace.pathLabel;
+  const displayedWorkspacePath = getUsageDisplayPathLabel(effectiveWorkspacePath, t, {
+    redactPaths: redactExportPaths,
+  });
   const coverageBadgeClassName =
     `session-usage-panel__badge session-usage-panel__badge--${coverageTone}` +
     (report.coverage.level !== 'complete' ? ' session-usage-panel__badge--hint' : '');
@@ -185,10 +207,10 @@ export const SessionUsagePanel: React.FC<SessionUsagePanelProps> = ({
               />
               <UsageMetaRow
                 label={t('usage.meta.workspacePath')}
-                value={effectiveWorkspacePath}
+                value={displayedWorkspacePath}
                 copyLabel={copiedMeta === 'workspace' ? t('usage.actions.copied') : t('usage.actions.copyWorkspacePath')}
                 copied={copiedMeta === 'workspace'}
-                onCopy={() => handleCopyMeta(effectiveWorkspacePath, 'workspace')}
+                onCopy={() => handleCopyMeta(displayedWorkspacePath, 'workspace')}
               />
             </div>
           </div>
@@ -199,6 +221,11 @@ export const SessionUsagePanel: React.FC<SessionUsagePanelProps> = ({
               {coverageBadge}
             </Tooltip>
           ) : coverageBadge}
+          <UsageExportRedactionToggle
+            checked={redactExportPaths}
+            onChange={handleRedactExportPathsChange}
+            className="session-usage-panel__export-option"
+          />
           <Tooltip content={copied ? t('usage.actions.copied') : t('usage.actions.copyMarkdown')}>
             <IconButton
               className="session-usage-panel__copy"
@@ -247,21 +274,47 @@ export const SessionUsagePanel: React.FC<SessionUsagePanelProps> = ({
         aria-labelledby={tabId(activeTab)}
       >
         {activeTab === 'overview' && <UsageOverview report={report} />}
-        {activeTab === 'models' && <UsageModels report={report} />}
-        {activeTab === 'tools' && <UsageTools report={report} />}
+        {activeTab === 'models' && <UsageModels report={report} sessionId={effectiveSessionId} />}
+        {activeTab === 'tools' && <UsageTools report={report} sessionId={effectiveSessionId} />}
         {activeTab === 'files' && (
           <UsageFiles
             report={report}
             sessionId={effectiveSessionId}
             workspacePath={workspacePath ?? report.workspace.pathLabel}
+            redactPaths={redactExportPaths}
           />
         )}
-        {activeTab === 'errors' && <UsageErrors report={report} />}
+        {activeTab === 'errors' && <UsageErrors report={report} sessionId={effectiveSessionId} />}
         {activeTab === 'slowest' && <UsageSlowest report={report} sessionId={effectiveSessionId} />}
       </main>
     </div>
   );
 };
+
+function UsageExportRedactionToggle({
+  checked,
+  onChange,
+  className,
+}: {
+  checked: boolean;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  className: string;
+}) {
+  const { t } = useTranslation('flow-chat');
+  return (
+    <Tooltip content={t('usage.export.redactPathsHelp')}>
+      <label className={className}>
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={onChange}
+          aria-label={t('usage.export.redactPaths')}
+        />
+        <span>{t('usage.export.redactPaths')}</span>
+      </label>
+    </Tooltip>
+  );
+}
 
 function UsageMetaRow({
   label,
@@ -313,6 +366,7 @@ type UsageTableCell = string | UsageTableValueCell | UsageTableNodeCell;
 interface UsageTableHeader {
   id: string;
   label: string;
+  help?: string;
 }
 
 interface UsageTableRow {
@@ -354,6 +408,58 @@ function missingUsageValue(value: string, help?: string): UsageTableCell {
   };
 }
 
+function UsageRowAnchorLink({
+  label,
+  help,
+  sessionId,
+  turnIndex,
+  itemId,
+}: {
+  label: string;
+  help?: string;
+  sessionId?: string;
+  turnIndex?: number;
+  itemId?: string;
+}) {
+  const { t } = useTranslation('flow-chat');
+  const displayTurnIndex = typeof turnIndex === 'number' && Number.isFinite(turnIndex)
+    ? getDisplayTurnIndex(turnIndex)
+    : undefined;
+  const canJump = Boolean(sessionId && displayTurnIndex);
+
+  if (!canJump) {
+    return <UsageValue value={label} help={help} />;
+  }
+
+  const jumpHelp = t('usage.actions.jumpToTurn');
+  const node = (
+    <button
+      type="button"
+      className="session-usage-panel__row-anchor-link"
+      onClick={() => {
+        const request: FlowChatFocusItemRequest = {
+          sessionId: sessionId as string,
+          turnIndex: displayTurnIndex as number,
+          source: 'usage-report',
+        };
+        if (itemId) {
+          request.itemId = itemId;
+        }
+        globalEventBus.emit(FLOWCHAT_FOCUS_ITEM_EVENT, request, 'SessionUsagePanel');
+      }}
+      aria-label={`${jumpHelp}: ${label}`}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <Tooltip content={help ? `${help} ${jumpHelp}` : jumpHelp}>
+      {node}
+    </Tooltip>
+  );
+}
+
 function UsageFilePathValue({ pathLabel }: { pathLabel: string }) {
   const node = (
     <span className="session-usage-panel__file-path-display">
@@ -362,6 +468,81 @@ function UsageFilePathValue({ pathLabel }: { pathLabel: string }) {
   );
 
   return <Tooltip content={pathLabel}>{node}</Tooltip>;
+}
+
+function UsageFileTurnIndexesValue({
+  file,
+  sessionId,
+  onJumpToTurn,
+}: {
+  file: SessionUsageReport['files']['files'][number];
+  sessionId?: string;
+  onJumpToTurn: (file: SessionUsageReport['files']['files'][number], rawTurnIndex: number) => void;
+}) {
+  const { t } = useTranslation('flow-chat');
+  const turnIndexes = (file.turnIndexes ?? []).filter(index => Number.isFinite(index));
+
+  if (turnIndexes.length === 0) {
+    return <UsageMissingValue value={t('usage.status.notRecorded')} help={t('usage.help.fileTurnIndexes')} />;
+  }
+
+  const displayIndexes = turnIndexes.map(getDisplayTurnIndex);
+  if (!sessionId) {
+    return (
+      <UsageValue
+        value={displayIndexes.map(index => formatUsageNumber(index, t)).join(', ')}
+        help={t('usage.help.fileTurnIndexes')}
+      />
+    );
+  }
+
+  const visibleTurnIndexes = turnIndexes.slice(0, 3);
+  const hiddenCount = Math.max(0, turnIndexes.length - visibleTurnIndexes.length);
+  return (
+    <span className="session-usage-panel__turn-indexes">
+      {visibleTurnIndexes.map(rawTurnIndex => {
+        const displayTurnIndex = getDisplayTurnIndex(rawTurnIndex);
+        const displayTurnText = formatUsageNumber(displayTurnIndex, t);
+        return (
+          <Tooltip key={rawTurnIndex} content={t('usage.actions.jumpToTurn')}>
+            <button
+              type="button"
+              className="session-usage-panel__turn-index-link"
+              onClick={() => onJumpToTurn(file, rawTurnIndex)}
+              aria-label={`${t('usage.actions.jumpToTurn')}: ${displayTurnText}`}
+            >
+              {displayTurnText}
+            </button>
+          </Tooltip>
+        );
+      })}
+      {hiddenCount > 0 && (
+        <Tooltip content={displayIndexes.map(index => formatUsageNumber(index, t)).join(', ')}>
+          <span className="session-usage-panel__turn-index-overflow">
+            +{formatUsageNumber(hiddenCount, t)}
+          </span>
+        </Tooltip>
+      )}
+    </span>
+  );
+}
+
+function getDisplayTurnIndex(rawTurnIndex: number): number {
+  return Math.max(0, Math.trunc(rawTurnIndex)) + 1;
+}
+
+function getStableFileToolAnchorId(
+  scope: SessionUsageReport['files']['scope'],
+  file: SessionUsageReport['files']['files'][number]
+): string | undefined {
+  if (
+    scope !== 'tool_inputs_only' ||
+    (file.turnIndexes?.length ?? 0) !== 1 ||
+    (file.operationIds?.length ?? 0) !== 1
+  ) {
+    return undefined;
+  }
+  return file.operationIds?.[0];
 }
 
 function getCompactFilePathLabel(pathLabel: string): string {
@@ -491,7 +672,7 @@ function UsageOverview({ report }: { report: SessionUsageReport }) {
   );
 }
 
-function UsageModels({ report }: { report: SessionUsageReport }) {
+function UsageModels({ report, sessionId }: { report: SessionUsageReport; sessionId?: string }) {
   const { t } = useTranslation('flow-chat');
   const hasModelDuration = report.models.some(model => model.durationMs !== undefined);
   const headers: UsageTableHeader[] = [
@@ -512,10 +693,18 @@ function UsageModels({ report }: { report: SessionUsageReport }) {
         const cached = formatUsageNumber(model.cachedTokens, t);
         const source = model.modelIdSource ?? (model.modelId === 'unknown_model' ? 'legacy_missing' : undefined);
         const modelHelp = getModelHelp(source, t, model.modelId);
+        const modelLabel = getModelLabel(model.modelId, t, source);
         const cells: UsageTableCell[] = [
-          modelHelp
-            ? { value: getModelLabel(model.modelId, t, source), help: modelHelp }
-            : getModelLabel(model.modelId, t, source),
+          {
+            node: (
+              <UsageRowAnchorLink
+                label={modelLabel}
+                help={modelHelp}
+                sessionId={sessionId}
+                turnIndex={model.sampleTurnIndex}
+              />
+            ),
+          },
           formatUsageNumber(model.callCount, t),
         ];
         if (hasModelDuration) {
@@ -541,47 +730,70 @@ function UsageModels({ report }: { report: SessionUsageReport }) {
   );
 }
 
-function UsageTools({ report }: { report: SessionUsageReport }) {
+function UsageTools({ report, sessionId }: { report: SessionUsageReport; sessionId?: string }) {
   const { t } = useTranslation('flow-chat');
+  const hasExecutionDuration = report.tools.some(tool => tool.executionMs !== undefined);
+  const headers: UsageTableHeader[] = [
+    { id: 'tool', label: t('usage.table.tool') },
+    { id: 'category', label: t('usage.table.category') },
+    { id: 'calls', label: t('usage.table.calls') },
+    { id: 'success', label: t('usage.table.success') },
+    { id: 'errors', label: t('usage.table.errors') },
+    { id: 'duration', label: t('usage.table.toolDuration'), help: t('usage.help.toolDuration') },
+    { id: 'p95', label: t('usage.table.toolP95Duration'), help: t('usage.help.toolP95') },
+    ...(hasExecutionDuration
+      ? [{ id: 'execution', label: t('usage.table.toolExecutionDuration'), help: t('usage.help.toolExecution') }]
+      : []),
+  ];
   return (
     <UsageTable
       empty={report.tools.length === 0}
       emptyLabel={t('usage.empty.tools')}
       emptyDescription={t('usage.empty.toolsDescription')}
-      headers={[
-        { id: 'tool', label: t('usage.table.tool') },
-        { id: 'category', label: t('usage.table.category') },
-        { id: 'calls', label: t('usage.table.calls') },
-        { id: 'success', label: t('usage.table.success') },
-        { id: 'errors', label: t('usage.table.errors') },
-        { id: 'duration', label: t('usage.table.duration') },
-        { id: 'p95', label: t('usage.table.p95') },
-        { id: 'execution', label: t('usage.table.execution') },
-      ]}
+      headers={headers}
       rows={report.tools.map((tool, index) => {
         const duration = formatUsageDuration(tool.durationMs, t);
         const p95 = formatUsageDuration(tool.p95DurationMs, t);
         const execution = formatUsageDuration(tool.executionMs, t);
+        const cells: UsageTableCell[] = [
+          {
+            node: (
+              <UsageRowAnchorLink
+                label={tool.redacted ? getRedactedLabel(t) : tool.toolName}
+                sessionId={sessionId}
+                turnIndex={tool.sampleTurnIndex}
+                itemId={tool.sampleItemId}
+              />
+            ),
+          },
+          getToolCategoryLabel(tool.category, t),
+          formatUsageNumber(tool.callCount, t),
+          formatUsageNumber(tool.successCount, t),
+          formatUsageNumber(tool.errorCount, t),
+          tool.durationMs === undefined
+            ? missingUsageValue(t('usage.status.timingNotRecorded'), t('usage.help.toolDuration'))
+            : duration,
+          tool.p95DurationMs === undefined
+            ? missingUsageValue(
+              tool.durationMs === undefined
+                ? t('usage.status.timingNotRecorded')
+                : t('usage.status.p95SampleInsufficient'),
+              t('usage.help.toolP95')
+            )
+            : p95,
+        ];
+        if (hasExecutionDuration) {
+          cells.push(
+            tool.executionMs === undefined
+              ? missingUsageValue(t('usage.status.timingNotRecorded'), t('usage.help.toolExecution'))
+              : execution
+          );
+        }
         return {
           id: tool.redacted
             ? `tool-${index}-redacted-${tool.category}`
             : `tool-${index}-${tool.category}-${tool.toolName}`,
-          cells: [
-            tool.redacted ? getRedactedLabel(t) : tool.toolName,
-            getToolCategoryLabel(tool.category, t),
-            formatUsageNumber(tool.callCount, t),
-            formatUsageNumber(tool.successCount, t),
-            formatUsageNumber(tool.errorCount, t),
-            tool.durationMs === undefined
-              ? missingUsageValue(t('usage.status.timingNotRecorded'), t('usage.help.toolDuration'))
-              : duration,
-            tool.p95DurationMs === undefined
-              ? missingUsageValue(t('usage.status.timingNotRecorded'), t('usage.help.toolP95'))
-              : p95,
-            tool.executionMs === undefined
-              ? missingUsageValue(t('usage.status.timingNotRecorded'), t('usage.help.toolExecution'))
-              : execution,
-          ],
+          cells,
         };
       })}
     />
@@ -592,14 +804,38 @@ function UsageFiles({
   report,
   sessionId,
   workspacePath,
+  redactPaths,
 }: {
   report: SessionUsageReport;
   sessionId?: string;
   workspacePath?: string;
+  redactPaths: boolean;
 }) {
   const { t } = useTranslation('flow-chat');
   const fileScopeHelp = getFileScopeHelp(report, t);
   const [openingDiffKey, setOpeningDiffKey] = useState<string | null>(null);
+
+  const handleJumpToFileTurn = useCallback((
+    file: SessionUsageReport['files']['files'][number],
+    rawTurnIndex: number
+  ) => {
+    const targetSessionId = file.sessionId ?? sessionId;
+    if (!targetSessionId) {
+      return;
+    }
+
+    const turnIndex = getDisplayTurnIndex(rawTurnIndex);
+    const request: FlowChatFocusItemRequest = {
+      sessionId: targetSessionId,
+      turnIndex,
+      source: 'usage-report',
+    };
+    const itemId = getStableFileToolAnchorId(report.files.scope, file);
+    if (itemId) {
+      request.itemId = itemId;
+    }
+    globalEventBus.emit(FLOWCHAT_FOCUS_ITEM_EVENT, request, 'SessionUsagePanel');
+  }, [report.files.scope, sessionId]);
 
   const handleOpenFileDiff = useCallback(async (file: SessionUsageReport['files']['files'][number]) => {
     if (!sessionId || file.redacted || report.files.scope !== 'snapshot_summary') {
@@ -649,6 +885,10 @@ function UsageFiles({
   const rows = useMemo(() => report.files.files.map((file, index) => {
     const operationId = file.operationIds?.[0];
     const resolvedPath = resolveUsageFilePath(file.pathLabel, workspacePath);
+    const displayPathLabel = getUsageDisplayPathLabel(file.pathLabel, t, {
+      redactPaths,
+      keepFileName: true,
+    });
     const diffKey = `${resolvedPath}:${operationId ?? ''}`;
     const canOpenDiff = canOpenUsageFileDiff(report.files.scope, file, sessionId);
     const actionCell: UsageTableNodeCell = {
@@ -681,17 +921,25 @@ function UsageFiles({
       file.redacted
         ? getRedactedLabel(t)
         : {
-          node: <UsageFilePathValue pathLabel={file.pathLabel} />,
+          node: <UsageFilePathValue pathLabel={displayPathLabel} />,
           className: 'session-usage-panel__file-path-cell',
         },
-      formatUsageNumber(file.operationCount, t),
-      formatUsageNumber(file.addedLines, t),
-      formatUsageNumber(file.deletedLines, t),
-      (file.turnIndexes ?? []).join(', ') || { value: t('usage.status.notRecorded'), help: t('usage.help.fileTurnIndexes') },
-      actionCell,
+        formatUsageNumber(file.operationCount, t),
+        formatUsageNumber(file.addedLines, t),
+        formatUsageNumber(file.deletedLines, t),
+        {
+          node: (
+            <UsageFileTurnIndexesValue
+              file={file}
+              sessionId={file.sessionId ?? sessionId}
+              onJumpToTurn={handleJumpToFileTurn}
+            />
+          ),
+        },
+        actionCell,
       ],
     };
-  }), [handleOpenFileDiff, openingDiffKey, report.files.files, report.files.scope, sessionId, t, workspacePath]);
+  }), [handleJumpToFileTurn, handleOpenFileDiff, openingDiffKey, redactPaths, report.files.files, report.files.scope, sessionId, t, workspacePath]);
 
   return (
     <section className="session-usage-panel__section">
@@ -722,7 +970,7 @@ function UsageFiles({
   );
 }
 
-function UsageErrors({ report }: { report: SessionUsageReport }) {
+function UsageErrors({ report, sessionId }: { report: SessionUsageReport; sessionId?: string }) {
   const { t } = useTranslation('flow-chat');
   return (
     <section className="session-usage-panel__section">
@@ -779,8 +1027,15 @@ function UsageErrors({ report }: { report: SessionUsageReport }) {
             : `error-${index}-${example.label}-${example.count}`,
           cells: [
             {
-              value: example.redacted ? getRedactedLabel(t) : example.label,
-              help: t('usage.help.errorExampleRow'),
+              node: (
+                <UsageRowAnchorLink
+                  label={example.redacted ? getRedactedLabel(t) : example.label}
+                  help={t('usage.help.errorExampleRow')}
+                  sessionId={sessionId}
+                  turnIndex={example.sampleTurnIndex}
+                  itemId={example.sampleItemId}
+                />
+              ),
             },
             {
               value: formatUsageNumber(example.count, t),
@@ -923,7 +1178,11 @@ function UsageTable({ empty, emptyLabel, emptyDescription, emptyHelp, headers, r
         <table className={['session-usage-panel__table', tableClassName].filter(Boolean).join(' ')}>
           <thead>
             <tr>
-              {headers.map(header => <th key={header.id}>{header.label}</th>)}
+              {headers.map(header => (
+                <th key={header.id}>
+                  <UsageTableHeaderLabel header={header} />
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>
@@ -967,6 +1226,14 @@ function UsageTable({ empty, emptyLabel, emptyDescription, emptyHelp, headers, r
       )}
     </>
   );
+}
+
+function UsageTableHeaderLabel({ header }: { header: UsageTableHeader }) {
+  if (!header.help) {
+    return <span>{header.label}</span>;
+  }
+
+  return <UsageValue value={header.label} help={header.help} />;
 }
 
 SessionUsagePanel.displayName = 'SessionUsagePanel';

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsageReportCard.scss
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsageReportCard.scss
@@ -95,28 +95,63 @@
   }
 
   &__title {
-    flex: 0 1 auto;
+    flex: 0 0 auto;
     margin: 0;
     color: var(--color-text-primary);
     font-size: var(--flowchat-font-size-lg);
     font-weight: 650;
     line-height: 1.25;
+    white-space: nowrap;
   }
 
   &__actions {
     flex: 0 0 auto;
     gap: 4px;
+    justify-content: flex-end;
+    flex-wrap: wrap;
   }
 
   &__header-actions {
     display: inline-flex;
     align-items: center;
     gap: 4px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
   }
 
   &__copy-action {
     width: 26px;
     height: 26px;
+  }
+
+  &__export-option {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--color-text-secondary);
+    font-size: var(--flowchat-font-size-xs);
+    line-height: 1;
+    white-space: nowrap;
+    cursor: pointer;
+
+    input {
+      width: 12px;
+      height: 12px;
+      margin: 0;
+      accent-color: var(--accent-primary);
+
+      &:focus-visible {
+        outline: 2px solid color-mix(in srgb, var(--accent-primary) 70%, transparent);
+        outline-offset: 2px;
+      }
+    }
+
+    span {
+      max-width: 84px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   }
 
   &__details-button {
@@ -303,6 +338,11 @@
       background: color-mix(in srgb, var(--element-bg-soft) 72%, transparent);
     }
 
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--accent-primary) 70%, transparent);
+      outline-offset: 2px;
+    }
+
     span {
       white-space: nowrap;
     }
@@ -431,6 +471,10 @@
       max-width: 96px;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+
+    &__actions {
+      width: 100%;
     }
   }
 

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsageReportCard.tsx
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsageReportCard.tsx
@@ -13,6 +13,7 @@ import {
 import { IconButton, MarkdownRenderer, ToolProcessingDots, Tooltip } from '@/component-library';
 import type { SessionUsageReport } from '@/infrastructure/api/service-api/SessionAPI';
 import {
+  buildSessionUsageExportMarkdown,
   formatUsageDuration,
   formatUsageNumber,
   formatUsageTimestamp,
@@ -20,6 +21,7 @@ import {
   getCoverageTone,
   getFileScopeHelp,
   getFileSummaryLabel,
+  getUsageDisplayPathLabel,
   getModelHelp,
   getModelLabel,
   getRedactedLabel,
@@ -27,7 +29,10 @@ import {
   getTopModels,
   getTopTools,
   getToolCategoryLabel,
+  getUsageExportRedactPathsPreference,
   getUsageFileNameFromPath,
+  setUsageExportRedactPathsPreference,
+  subscribeUsageExportRedactPathsPreference,
 } from './usageReportUtils';
 import type { SessionUsagePanelTab } from './sessionUsagePanelTypes';
 import './SessionUsageReportCard.scss';
@@ -52,17 +57,25 @@ export const SessionUsageReportCard: React.FC<SessionUsageReportCardProps> = ({
   const { t } = useTranslation('flow-chat');
   const [copied, setCopied] = useState(false);
   const [loadingStep, setLoadingStep] = useState(0);
+  const [redactExportPaths, setRedactExportPaths] = useState(getUsageExportRedactPathsPreference);
 
   const handleCopy = useCallback(async (event: React.MouseEvent) => {
     event.stopPropagation();
     try {
-      await navigator.clipboard.writeText(markdown);
+      await navigator.clipboard.writeText(buildSessionUsageExportMarkdown(markdown, report, {
+        redactPaths: redactExportPaths,
+        t,
+      }));
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1800);
     } catch {
       setCopied(false);
     }
-  }, [markdown]);
+  }, [markdown, redactExportPaths, report, t]);
+
+  const handleRedactExportPathsChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setUsageExportRedactPathsPreference(event.target.checked);
+  }, []);
 
   const handleOpenDetails = useCallback((event: React.MouseEvent) => {
     event.stopPropagation();
@@ -98,6 +111,10 @@ export const SessionUsageReportCard: React.FC<SessionUsageReportCardProps> = ({
 
     return () => window.clearInterval(timer);
   }, [isLoading, loadingHints.length]);
+
+  useEffect(() => (
+    subscribeUsageExportRedactPathsPreference(setRedactExportPaths)
+  ), []);
 
   if (isLoading) {
     return (
@@ -147,6 +164,9 @@ export const SessionUsageReportCard: React.FC<SessionUsageReportCardProps> = ({
       ? t('usage.help.cachedTokensPartial')
     : undefined;
   const fileMetricHelp = getFileScopeHelp(report, t);
+  const workspacePathLabel = getUsageDisplayPathLabel(report.workspace.pathLabel, t, {
+    redactPaths: redactExportPaths,
+  });
 
   const metrics = [
     {
@@ -205,7 +225,7 @@ export const SessionUsageReportCard: React.FC<SessionUsageReportCardProps> = ({
           <div className="session-usage-report-card__meta">
             <span>{formatUsageTimestamp(generatedAt ?? report.generatedAt, t)}</span>
             <span>{t('usage.card.turns', { count: report.scope.turnCount })}</span>
-            <span>{report.workspace.pathLabel || t('usage.unavailable')}</span>
+            <span>{workspacePathLabel}</span>
           </div>
         </div>
         <div className="session-usage-report-card__actions">
@@ -221,6 +241,17 @@ export const SessionUsageReportCard: React.FC<SessionUsageReportCardProps> = ({
             </span>
           )}
           <div className="session-usage-report-card__header-actions">
+            <Tooltip content={t('usage.export.redactPathsHelp')}>
+              <label className="session-usage-report-card__export-option">
+                <input
+                  type="checkbox"
+                  checked={redactExportPaths}
+                  onChange={handleRedactExportPathsChange}
+                  aria-label={t('usage.export.redactPaths')}
+                />
+                <span>{t('usage.export.redactPaths')}</span>
+              </label>
+            </Tooltip>
             <Tooltip content={copied ? t('usage.actions.copied') : t('usage.actions.copyMarkdown')}>
               <IconButton
                 className="session-usage-report-card__copy-action"
@@ -316,23 +347,29 @@ export const SessionUsageReportCard: React.FC<SessionUsageReportCardProps> = ({
             t,
             onClick: onOpenDetails ? handleOpenSectionDetails('files') : undefined,
           })}
-          items={topFiles.map(file => ({
-            label: file.redacted
-              ? getRedactedLabel(t)
-              : {
-                node: <UsageMiniListFilePathLabel pathLabel={file.pathLabel} />,
-                text: file.pathLabel,
-                help: file.pathLabel,
-              },
-            value: t('usage.card.operations', { count: file.operationCount }),
-            detail: (
-              <UsageFileChangeDetail
-                addedLines={file.addedLines}
-                deletedLines={file.deletedLines}
-                t={t}
-              />
-            ),
-          }))}
+          items={topFiles.map(file => {
+            const pathLabel = getUsageDisplayPathLabel(file.pathLabel, t, {
+              redactPaths: redactExportPaths,
+              keepFileName: true,
+            });
+            return {
+              label: file.redacted
+                ? getRedactedLabel(t)
+                : {
+                  node: <UsageMiniListFilePathLabel pathLabel={file.pathLabel} />,
+                  text: pathLabel,
+                  help: pathLabel,
+                },
+              value: t('usage.card.operations', { count: file.operationCount }),
+              detail: (
+                <UsageFileChangeDetail
+                  addedLines={file.addedLines}
+                  deletedLines={file.deletedLines}
+                  t={t}
+                />
+              ),
+            };
+          })}
           emptyLabel={getFileSummaryLabel(report, t)}
           emptyDescription={fileMetricHelp ?? t('usage.empty.filesDescription')}
         />

--- a/src/web-ui/src/flow_chat/components/usage/usageReportUtils.test.ts
+++ b/src/web-ui/src/flow_chat/components/usage/usageReportUtils.test.ts
@@ -46,7 +46,7 @@ function usageReport(overrides: Partial<SessionUsageReport> = {}): SessionUsageR
     coverage: {
       level: 'partial',
       available: ['workspace_identity'],
-      missing: ['cost_estimates'],
+      missing: ['token_detail_breakdown'],
       notes: [],
     },
     time: {

--- a/src/web-ui/src/flow_chat/components/usage/usageReportUtils.ts
+++ b/src/web-ui/src/flow_chat/components/usage/usageReportUtils.ts
@@ -6,6 +6,9 @@ type ModelIdentitySource = SessionUsageReport['models'][number]['modelIdSource']
 const UNKNOWN_MODEL_ID = 'unknown_model';
 const LEGACY_MODEL_ROUND_LABEL_PATTERN = /^model\s+round\s+\d+$/i;
 const FILE_PATH_MIDDLE_ELLIPSIS_THRESHOLD = 48;
+export const USAGE_EXPORT_REDACT_PATHS_STORAGE_KEY = 'bitfun.sessionUsage.export.redactPaths';
+type UsageRedactPathsPreferenceListener = (redactPaths: boolean) => void;
+const usageRedactPathsPreferenceListeners = new Set<UsageRedactPathsPreferenceListener>();
 
 export function hasNoRecordedFileChanges(report: SessionUsageReport): boolean {
   return report.files.files.length === 0 &&
@@ -277,6 +280,113 @@ export function getUsageFileNameFromPath(pathLabel: string): string {
   return segments.at(-1) ?? pathLabel;
 }
 
+export function getUsageDisplayPathLabel(
+  pathLabel: string | undefined,
+  t: Translator,
+  options: {
+    redactPaths: boolean;
+    keepFileName?: boolean;
+  }
+): string {
+  const normalizedPath = pathLabel?.trim();
+  if (!normalizedPath) {
+    return t('usage.unavailable');
+  }
+  if (!options.redactPaths) {
+    return normalizedPath;
+  }
+
+  const redactedPath = t('usage.export.redactedPath');
+  if (!options.keepFileName) {
+    return redactedPath;
+  }
+
+  const fileName = getUsageFileNameFromPath(normalizedPath);
+  return fileName && fileName !== normalizedPath ? `${redactedPath}/${fileName}` : redactedPath;
+}
+
 export function getRedactedLabel(t: Translator): string {
   return t('usage.redacted');
+}
+
+export function getUsageExportRedactPathsPreference(): boolean {
+  try {
+    const stored = globalThis.window?.localStorage?.getItem(USAGE_EXPORT_REDACT_PATHS_STORAGE_KEY);
+    return stored === null ? true : stored !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+export function setUsageExportRedactPathsPreference(redactPaths: boolean): void {
+  try {
+    globalThis.window?.localStorage?.setItem(
+      USAGE_EXPORT_REDACT_PATHS_STORAGE_KEY,
+      redactPaths ? 'true' : 'false',
+    );
+  } catch {
+    // Ignore storage failures; the export action should still work.
+  }
+  usageRedactPathsPreferenceListeners.forEach(listener => listener(redactPaths));
+}
+
+export function subscribeUsageExportRedactPathsPreference(
+  listener: UsageRedactPathsPreferenceListener
+): () => void {
+  usageRedactPathsPreferenceListeners.add(listener);
+  return () => {
+    usageRedactPathsPreferenceListeners.delete(listener);
+  };
+}
+
+export function buildSessionUsageExportMarkdown(
+  markdown: string,
+  report: SessionUsageReport | undefined,
+  options: {
+    redactPaths: boolean;
+    t: Translator;
+  }
+): string {
+  if (!options.redactPaths || !report) {
+    return markdown;
+  }
+
+  const redactedPath = options.t('usage.export.redactedPath');
+  const replacements = new Map<string, string>();
+
+  addPathReplacement(replacements, report.workspace.pathLabel, redactedPath);
+  for (const file of report.files.files) {
+    if (!file.redacted) {
+      const fileName = getUsageFileNameFromPath(file.pathLabel);
+      addPathReplacement(replacements, file.pathLabel, `${redactedPath}/${fileName}`);
+    }
+  }
+
+  return [...replacements.entries()]
+    .sort((a, b) => b[0].length - a[0].length)
+    .reduce((value, [pathLabel, replacement]) => (
+      value.replace(new RegExp(escapeRegExp(pathLabel), 'g'), replacement)
+    ), markdown);
+}
+
+function addPathReplacement(
+  replacements: Map<string, string>,
+  value: string | undefined,
+  replacement: string
+): void {
+  const normalizedValue = value?.trim();
+  if (!normalizedValue) {
+    return;
+  }
+  replacements.set(normalizedValue, replacement);
+  const alternateSeparatorValue = normalizedValue.includes('\\')
+    ? normalizedValue.replace(/\\/g, '/')
+    : normalizedValue.replace(/\//g, '\\');
+  if (alternateSeparatorValue !== normalizedValue) {
+    replacements.set(alternateSeparatorValue, replacement);
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/web-ui/src/flow_chat/events/flowchatNavigation.ts
+++ b/src/web-ui/src/flow_chat/events/flowchatNavigation.ts
@@ -5,7 +5,7 @@
 export const FLOWCHAT_FOCUS_ITEM_EVENT = 'flowchat:focus-item';
 export const FLOWCHAT_PIN_TURN_TO_TOP_EVENT = 'flowchat:pin-turn-to-top';
 
-export type FlowChatFocusItemSource = 'btw-back';
+export type FlowChatFocusItemSource = 'btw-back' | 'usage-report';
 export type FlowChatPinTurnToTopSource = 'send-message' | 'usage-report';
 export type FlowChatPinTurnToTopMode = 'transient' | 'sticky-latest';
 

--- a/src/web-ui/src/infrastructure/api/service-api/SessionAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SessionAPI.ts
@@ -64,6 +64,8 @@ export interface SessionUsageReport {
     totalTokens?: number;
     cachedTokens?: number;
     durationMs?: number;
+    sampleTurnId?: string;
+    sampleTurnIndex?: number;
   }>;
   tools: Array<{
     toolName: string;
@@ -77,6 +79,9 @@ export interface SessionUsageReport {
     preflightMs?: number;
     confirmationWaitMs?: number;
     executionMs?: number;
+    sampleTurnId?: string;
+    sampleTurnIndex?: number;
+    sampleItemId?: string;
     redacted: boolean;
   }>;
   files: {
@@ -108,6 +113,9 @@ export interface SessionUsageReport {
     examples: Array<{
       label: string;
       count: number;
+      sampleTurnId?: string;
+      sampleTurnIndex?: number;
+      sampleItemId?: string;
       redacted: boolean;
     }>;
   };

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -62,7 +62,14 @@
       "openSectionDetails": "Open {{section}} details",
       "jumpToTurn": "Jump to this turn",
       "viewDetails": "Details",
-      "viewAllSection": "View all {{count}}"
+      "viewAllSection": "View all {{count}}",
+      "showAllRows": "Show all {{count}}",
+      "showFewerRows": "Show fewer"
+    },
+    "export": {
+      "redactPaths": "Redact paths",
+      "redactPathsHelp": "Replace workspace and file paths when copying Markdown.",
+      "redactedPath": "[redacted path]"
     },
     "coverage": {
       "complete": "Complete data",
@@ -93,7 +100,8 @@
       "notRecorded": "Not recorded",
       "modelNotRecorded": "Model not recorded",
       "legacyModel": "Legacy model not tracked",
-      "inferredModel": "{{model}} (inferred)"
+      "inferredModel": "{{model}} (inferred)",
+      "p95SampleInsufficient": "Not enough samples"
     },
     "cacheCoverage": {
       "available": "Reported",
@@ -154,9 +162,9 @@
       "toolTime": "Recorded tool-call duration. The percentage uses recorded turn time and is approximate.",
       "cachedTokens": "The provider did not report cache-read token metadata for this session. Total token counts are still shown when available.",
       "cachedTokensPartial": "Only some calls reported cache-read token metadata, so the cached-token total covers those calls only.",
-      "toolDuration": "This tool call did not report timing metadata.",
-      "toolP95": "P95 appears after at least two timed calls are recorded for this tool.",
-      "toolExecution": "This tool did not report a separate execution-duration field.",
+      "toolDuration": "Total recorded time for this tool name in the report scope. It may include queueing, preflight checks, confirmation wait, and execution.",
+      "toolP95": "95th percentile of recorded total call durations for this tool. It is shown only after at least two timed calls.",
+      "toolExecution": "Time spent inside the tool execution phase after queueing, preflight checks, and confirmation wait. Older sessions may not have this field.",
       "legacyModel": "Older sessions did not store per-round model names, so this report cannot identify the exact model.",
       "inferredModel": "Inferred from the session model setting because older turns did not store per-round model names.",
       "filesUnavailable": "No file snapshot or file-edit tool record was found for this session.",
@@ -222,6 +230,9 @@
       "duration": "Recorded time",
       "p95": "P95",
       "execution": "Execution",
+      "toolDuration": "Total time",
+      "toolP95Duration": "P95 total",
+      "toolExecutionDuration": "Execution time",
       "file": "File",
       "operations": "Ops",
       "added": "Added",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -62,7 +62,14 @@
       "openSectionDetails": "打开{{section}}详情",
       "jumpToTurn": "跳转到该轮次",
       "viewDetails": "详情",
-      "viewAllSection": "查看全部 {{count}} 项"
+      "viewAllSection": "查看全部 {{count}} 项",
+      "showAllRows": "显示全部 {{count}} 项",
+      "showFewerRows": "收起"
+    },
+    "export": {
+      "redactPaths": "脱敏路径",
+      "redactPathsHelp": "复制 Markdown 时替换项目和文件路径。",
+      "redactedPath": "[已脱敏路径]"
     },
     "coverage": {
       "complete": "数据完整",
@@ -93,7 +100,8 @@
       "notRecorded": "未记录",
       "modelNotRecorded": "未记录模型名称",
       "legacyModel": "旧会话模型未统计",
-      "inferredModel": "{{model}}（推测）"
+      "inferredModel": "{{model}}（推测）",
+      "p95SampleInsufficient": "样本不足"
     },
     "cacheCoverage": {
       "available": "已上报",
@@ -188,6 +196,9 @@
       "duration": "记录耗时",
       "p95": "P95",
       "execution": "执行",
+      "toolDuration": "总耗时",
+      "toolP95Duration": "P95 总耗时",
+      "toolExecutionDuration": "执行耗时",
       "file": "文件",
       "operations": "操作",
       "added": "新增",
@@ -220,9 +231,9 @@
       "toolTime": "基于已记录工具调用耗时计算；占比按已记录轮次耗时近似计算。",
       "cachedTokens": "当前服务商没有为这个会话上报缓存读取 Token 元数据；可用时仍会显示总 Token。",
       "cachedTokensPartial": "只有部分调用上报了缓存读取 Token 元数据，因此缓存 Token 合计只覆盖这些调用。",
-      "toolDuration": "该工具调用没有上报耗时元数据。",
-      "toolP95": "同一工具至少记录两次带耗时调用后才会显示 P95。",
-      "toolExecution": "该工具没有单独上报执行耗时字段。",
+      "toolDuration": "当前报告范围内该工具名称的总记录耗时，可能包含排队、预检查、确认等待和实际执行。",
+      "toolP95": "该工具总耗时的 95 分位值；同一工具至少有两次带耗时调用后才会显示。",
+      "toolExecution": "扣除排队、预检查和确认等待后的工具执行阶段耗时。旧会话可能没有这个字段。",
       "legacyModel": "这个会话创建时尚未记录逐轮模型名称，因此报告无法确认精确模型。",
       "inferredModel": "旧会话缺少逐轮模型名称，已根据会话的模型设置推测。",
       "filesUnavailable": "当前会话没有找到本地快照或可识别的文件编辑工具记录。",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -62,7 +62,14 @@
       "openSectionDetails": "開啟{{section}}詳情",
       "jumpToTurn": "跳轉到該回合",
       "viewDetails": "詳情",
-      "viewAllSection": "查看全部 {{count}} 項"
+      "viewAllSection": "查看全部 {{count}} 項",
+      "showAllRows": "顯示全部 {{count}} 項",
+      "showFewerRows": "收合"
+    },
+    "export": {
+      "redactPaths": "遮蔽路徑",
+      "redactPathsHelp": "複製 Markdown 時替換專案與檔案路徑。",
+      "redactedPath": "[已遮蔽路徑]"
     },
     "coverage": {
       "complete": "資料完整",
@@ -93,7 +100,8 @@
       "notRecorded": "未記錄",
       "modelNotRecorded": "未記錄模型名稱",
       "legacyModel": "舊會話模型未統計",
-      "inferredModel": "{{model}}（推測）"
+      "inferredModel": "{{model}}（推測）",
+      "p95SampleInsufficient": "樣本不足"
     },
     "cacheCoverage": {
       "available": "已回報",
@@ -188,6 +196,9 @@
       "duration": "記錄耗時",
       "p95": "P95",
       "execution": "執行",
+      "toolDuration": "總耗時",
+      "toolP95Duration": "P95 總耗時",
+      "toolExecutionDuration": "執行耗時",
       "file": "檔案",
       "operations": "操作",
       "added": "新增",
@@ -220,9 +231,9 @@
       "toolTime": "基於已記錄工具呼叫耗時計算；占比按已記錄回合耗時近似計算。",
       "cachedTokens": "目前服務商沒有為這個工作階段回報快取讀取 Token 中繼資料；可用時仍會顯示總 Token。",
       "cachedTokensPartial": "只有部分呼叫回報了快取讀取 Token 中繼資料，因此快取 Token 合計只涵蓋這些呼叫。",
-      "toolDuration": "該工具呼叫沒有回報耗時中繼資料。",
-      "toolP95": "同一工具至少記錄兩次帶耗時呼叫後才會顯示 P95。",
-      "toolExecution": "該工具沒有單獨回報執行耗時欄位。",
+      "toolDuration": "目前報告範圍內該工具名稱的總記錄耗時，可能包含排隊、預檢查、確認等待和實際執行。",
+      "toolP95": "該工具總耗時的 95 分位值；同一工具至少有兩次帶耗時呼叫後才會顯示。",
+      "toolExecution": "扣除排隊、預檢查和確認等待後的工具執行階段耗時。舊工作階段可能沒有這個欄位。",
       "legacyModel": "這個工作階段建立時尚未記錄逐回合模型名稱，因此報告無法確認精確模型。",
       "inferredModel": "舊工作階段缺少逐回合模型名稱，已根據工作階段的模型設定推測。",
       "filesUnavailable": "目前工作階段沒有找到本機快照或可識別的檔案編輯工具記錄。",


### PR DESCRIPTION
## Summary

This PR completes the approved P1 scope for the current-session `/usage` report and tightens the remaining Desktop analysis surface work into a closed product boundary.

- Adds richer session usage aggregation across persisted runtime facts, token/model/tool/file/error summaries, workspace identity, and privacy metadata.
- Hardens the Desktop usage report card and detail panel with localized copy, partial-data explanations, metadata copy controls, path redaction preference, file diff actions, and representative transcript anchors.
- Fixes usage-detail navigation for grouped or auto-collapsed tool cards by expanding the relevant explore group and focusing the real tool item anchor.
- Updates the design document to describe the closed product scope: current session only, durable model-invisible local report, Chat-bottom entry point, no live metrics, no cross-session analytics, and no billing/cost reporting.
- Removes residual `cost_estimates` coverage markers so the report stays token-focused and does not imply a billing feature.

## Product Boundary

The report is intentionally an observability projection, not a runtime control plane. It reports recorded current-session facts and coverage gaps, but it does not change scheduling, retries, context compaction, permissions, or workflow policy. Hidden subagents, visible side sessions, full trace timelines, exact per-call occurrence browsing, live status metrics, cross-session summaries, and billing/cost views remain outside the closed scope.

## Validation

- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run` - 76 files / 454 tests passed
- `cargo check --workspace`
- `cargo test --workspace`
- `git diff --check`
- `git diff --cached --check`

`cargo check` and `cargo test` still report the existing `src/apps/desktop/src/tray.rs` unused import warning, which is unrelated to this usage-report change.

## Notes

The design doc still calls out one final UX signoff item: a real-App long-session smoke pass for scroll/jump feel. The branch keeps this explicit instead of overstating P2 as fully complete.