### PR TITLE
feat(deep-review): harden queued reviewer execution and action workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,12 @@ before editing. The guardrail document defines product-behavior invariants,
 crate ownership targets, forbidden dependency directions, feature safety rules,
 and milestone verification gates.
 
+### DeepReview guardrails
+
+Deep Review / Code Review Team work spans the core runtime and web UI. Keep
+target resolution and manifest construction on the frontend; keep policy
+validation, queue/retry state, and report enrichment in shared core.
+
 ### Backend flow
 
 Trace most features in this order:
@@ -151,7 +157,7 @@ Session data is stored under `.bitfun/sessions/{session_id}/`.
 | Feature | Key paths |
 |---|---|
 | Agent modes | `src/crates/core/src/agentic/agents/`, `src/crates/core/src/agentic/agents/prompts/`, `src/web-ui/src/locales/*/scenes/agents.json` |
-| Deep Review / Code Review Team | `src/crates/core/src/agentic/deep_review_policy.rs`, `src/crates/core/src/agentic/agents/deep_review_agent.rs`, `src/crates/core/src/agentic/tools/implementations/{task_tool.rs,code_review_tool.rs}`, `src/web-ui/src/shared/services/reviewTeamService.ts`, `src/web-ui/src/flow_chat/services/DeepReviewService.ts`, `src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.tsx` |
+| Deep Review / Code Review Team | `src/crates/core/src/agentic/deep_review/`, `src/crates/core/src/agentic/deep_review_policy.rs`, `src/crates/core/src/agentic/agents/deep_review_agent.rs`, `src/crates/core/src/agentic/tools/implementations/{task_tool.rs,code_review_tool.rs}`, `src/web-ui/src/shared/services/review-team/`, `src/web-ui/src/flow_chat/deep-review/`, `src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.tsx` |
 | Session usage report (`/usage`) | `src/crates/core/src/service/session_usage/`, `src/web-ui/src/flow_chat/components/usage/`, `src/web-ui/src/locales/*/flow-chat.json` |
 | Tools | `src/crates/core/src/agentic/tools/implementations/`, `src/crates/core/src/agentic/tools/registry.rs` |
 | MCP / LSP / remote | `src/crates/core/src/service/mcp/`, `src/crates/core/src/service/lsp/`, `src/crates/core/src/service/remote_connect/`, `src/crates/core/src/service/remote_ssh/` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,12 @@ For `bitfun-core` decomposition or build-speed refactors, follow
 [`docs/architecture/core-decomposition.md`](docs/architecture/core-decomposition.md)
 and do not change product feature sets or release scripts as a side effect.
 
+For Deep Review / Code Review Team changes, keep
+[`docs/architecture/deep-review.md`](docs/architecture/deep-review.md),
+`src/crates/core/src/agentic/deep_review/CONTRIBUTING.md`, and
+`src/web-ui/src/flow_chat/deep-review/CONTRIBUTING.md` aligned with the
+implementation.
+
 ### Tauri command conventions
 
 - Command names use `snake_case`

--- a/docs/architecture/deep-review.md
+++ b/docs/architecture/deep-review.md
@@ -1,0 +1,295 @@
+# DeepReview Architecture
+
+## Scope
+
+DeepReview is a child-session workflow that runs a configurable Code Review Team against a review target. The current implementation has three layers:
+
+- Frontend launch and UI orchestration in `src/web-ui`.
+- Platform adapter commands in `src/apps/desktop/src/api/agentic_api.rs`.
+- Platform-agnostic runtime policy, task admission, queue state, retry metadata, and report enrichment in `src/crates/core/src/agentic`.
+
+The backend does not choose the review target or build the launch manifest. The frontend builds the effective `ReviewTeamRunManifest`, persists it on the DeepReview child session, and sends it with the first user message.
+
+## Runtime Roles
+
+`src/crates/core/src/agentic/agents/deep_review_agent.rs` defines the writable `DeepReview` orchestrator. It can call `Task`, read/search/git tools, `submit_code_review`, `AskUserQuestion`, and write/edit/bash tools for user-approved remediation.
+
+`src/crates/core/src/agentic/agents/review_specialist_agents.rs` defines read-only reviewer agents:
+
+- `ReviewBusinessLogic`
+- `ReviewPerformance`
+- `ReviewSecurity`
+- `ReviewArchitecture`
+- `ReviewFrontend`
+- `ReviewJudge`
+
+The reviewer agents use instruction-only context and read/search/git/diff tools. `ReviewFrontend` is a conditional role. `ReviewJudge` validates reviewer evidence and consistency instead of performing a full independent review pass.
+
+`ReviewFixer` exists as a separate remediation agent, but DeepReview runtime policy rejects it during review execution. Remediation is launched later only from the frontend action surface after user approval.
+
+## Launch Flow
+
+DeepReview can be launched from session-file review controls or a `/DeepReview` slash command.
+
+Frontend launch code lives in `src/web-ui/src/flow_chat/deep-review/launch`:
+
+- `commandParser.ts` identifies `/DeepReview` commands and optional file or git targets.
+- `targetResolver.ts` resolves slash-command targets from git status, changed files, and diffs when a workspace is available.
+- `launchPrompt.ts` formats the user-facing launch prompt.
+- `DeepReviewService.ts` builds the review-team manifest, creates a child session, opens it in the auxiliary pane, sends the launch prompt, and inserts the parent-session summary marker.
+- `src/web-ui/src/flow_chat/services/DeepReviewService.ts` is a compatibility re-export.
+
+`launchDeepReviewSession` creates a child session with:
+
+- `sessionKind: 'deep_review'`
+- `agentType: 'DeepReview'`
+- tools enabled
+- safe mode enabled
+- auto-compaction enabled
+- context compression enabled
+- `deepReviewRunManifest` stored on the child session metadata
+
+If launch fails after the child session is created, the frontend closes the auxiliary pane, deletes the backend session when possible, discards local session state, and reports cleanup issues with the launch error.
+
+## Review Team Configuration
+
+The default review team contract is mirrored in Rust and TypeScript.
+
+Rust source:
+
+- `src/crates/core/src/agentic/deep_review/team_definition.rs`
+- `src/crates/core/src/agentic/deep_review_policy.rs`
+- `src/apps/desktop/src/api/agentic_api.rs`
+
+Frontend source:
+
+- `src/web-ui/src/shared/services/review-team/defaults.ts`
+- `src/web-ui/src/shared/services/review-team/types.ts`
+- `src/web-ui/src/shared/services/review-team/index.ts`
+
+The desktop command `get_default_review_team_definition` returns the backend default definition. The frontend normalizes that response and falls back to its TypeScript default if the command is unavailable.
+
+The persisted config path is `ai.review_teams.default`. The frontend config shape includes:
+
+- extra subagent ids
+- team strategy level
+- per-member strategy overrides
+- reviewer and judge timeouts
+- reviewer file-split threshold
+- max same-role instances
+- max retries per role
+- max parallel reviewers
+- max queue wait seconds
+- provider capacity queue enablement
+- bounded auto-retry enablement and elapsed guard
+
+Extra team members must be enabled subagents with read-only review tooling. Core team members, `DeepReview`, and `ReviewFixer` are disallowed as extra members.
+
+## Manifest Shape
+
+`buildEffectiveReviewTeamManifest` in `src/web-ui/src/shared/services/review-team/index.ts` builds the launch manifest. The manifest has `reviewMode: 'deep'` and may include:
+
+- workspace path
+- policy source
+- target classification
+- final strategy level
+- scope profile
+- frontend and backend strategy recommendations
+- strategy decision
+- execution policy
+- concurrency policy
+- change stats
+- pre-review summary
+- evidence pack
+- shared-context cache plan
+- incremental-review cache plan
+- token-budget plan
+- active core reviewers
+- quality-gate reviewer
+- enabled extra reviewers
+- skipped reviewers
+- work packets
+
+The target classifier drives conditional reviewer selection. `ReviewFrontend` is included only when the target matches frontend-oriented files.
+
+The evidence pack is metadata-only. It lists changed file paths, aggregate diff stats, domain/risk tags, packet ids, hunk hints, contract hints, and budget counts. It explicitly excludes source text, full diff text, model output, provider raw bodies, and full file contents.
+
+## Strategies and Scope
+
+The frontend owns strategy profile text and manifest planning in `src/web-ui/src/shared/services/review-team/strategy.ts` and `scopeProfile.ts`.
+
+Supported strategy levels are `quick`, `normal`, and `deep`.
+
+- `quick` uses high-risk-only scope, zero dependency hops, risk-matched optional reviewers, and no broad tool exploration.
+- `normal` uses risk-expanded scope, one dependency hop, configured optional reviewers, and no broad tool exploration.
+- `deep` uses full-depth scope, policy-limited dependency context, full optional reviewer policy, and broad tool exploration.
+
+The backend parses the strategy from the manifest/config and uses it for runtime guardrails such as timeouts, policy classification, and retry limits. Backend strategy scoring is advisory and does not replace the frontend manifest decision.
+
+## Work Packets
+
+`src/web-ui/src/shared/services/review-team/workPackets.ts` creates pure launch-plan metadata. Work packets do not inspect file contents and do not make runtime retry or queue decisions.
+
+Each work packet includes:
+
+- packet id
+- phase (`reviewer` or `judge`)
+- launch batch
+- subagent id and labels
+- assigned scope
+- allowed tools
+- timeout seconds
+- required output fields
+- strategy level and directive
+- model slot
+
+If the included file count exceeds the reviewer file-split threshold and same-role instances are allowed, reviewer scopes are split into module-aware groups. Reviewer packets are then assigned launch batches using the concurrency policy. The judge packet, when present, runs in the batch after the final reviewer batch.
+
+## Backend Policy and Admission
+
+`DeepReviewExecutionPolicy` in `src/crates/core/src/agentic/deep_review/execution_policy.rs` parses runtime policy from config and classifies subagent launches.
+
+Allowed DeepReview runtime launches are:
+
+- core reviewer roles
+- conditional reviewer roles when active in the manifest
+- configured extra reviewer roles
+- `ReviewJudge`
+
+Rejected launches include:
+
+- `ReviewFixer` during review execution
+- nested `DeepReview`
+- any subagent not configured for the review team
+- subagents skipped or absent from the run manifest
+
+`DeepReviewRunManifestGate` in `manifest.rs` reads active subagent ids from `workPackets`, `coreReviewers`, `enabledExtraReviewers`, and `qualityGateReviewer`. It also records skipped reviewer reasons so policy failures can explain why a reviewer is inactive.
+
+## Task Execution and Queue State
+
+The generic `Task` tool is adapted for DeepReview in:
+
+- `src/crates/core/src/agentic/tools/implementations/task_tool.rs`
+- `src/crates/core/src/agentic/deep_review/task_adapter.rs`
+- `src/crates/core/src/agentic/deep_review/queue.rs`
+- `src/crates/core/src/agentic/deep_review/budget.rs`
+
+DeepReview task execution uses the manifest and tool context to:
+
+- identify reviewer role and packet id
+- attach incremental review cache data
+- enforce policy and retry coverage
+- cap active reviewers
+- preserve launch-batch ordering
+- wait for transient capacity when allowed
+- emit queue state events
+- record runtime diagnostics and capacity skips
+
+Queueable capacity reasons are:
+
+- `provider_rate_limit`
+- `provider_concurrency_limit`
+- `retry_after`
+- `local_concurrency_cap`
+- `launch_batch_blocked`
+- `temporary_overload`
+
+Queue states are:
+
+- `queued_for_capacity`
+- `paused_by_user`
+- `running`
+- `capacity_skipped`
+
+Queue wait time is tracked separately from reviewer run time. Paused and queued time does not consume reviewer timeout.
+
+The desktop command `control_deep_review_queue` validates `sessionId`, `dialogTurnId`, and `toolId`, then applies one of:
+
+- `pause`
+- `continue`
+- `cancel`
+- `skip_optional`
+
+Pause, continue, and cancel are scoped to a specific turn and tool id. `skip_optional` is turn-scoped.
+
+## Runtime Events
+
+Queue state events are defined in `src/crates/events/src/agentic.rs` as `AgenticEvent::DeepReviewQueueStateChanged`.
+
+The frontend listens through `AgentAPI.onDeepReviewQueueStateChanged` on `agentic://deep-review-queue-state-changed`. The TypeScript event shape mirrors the Rust event fields:
+
+- tool id
+- subagent type
+- queue status
+- optional reason
+- queued reviewer count
+- optional active reviewer count
+- optional effective parallel instances
+- optional optional-reviewer count
+- optional queue/run elapsed time
+- optional max queue wait
+- session concurrency flag
+
+`src/web-ui/src/flow_chat/utils/deepReviewQueueStateEvents.ts` applies queue events only to `deep_review` sessions.
+
+## Report Submission
+
+Review results are submitted through `submit_code_review` in `src/crates/core/src/agentic/tools/implementations/code_review_tool.rs`.
+
+In DeepReview context, the tool requires the deep-review fields in addition to the standard summary/issues/positive-points shape:
+
+- `review_mode`
+- `review_scope`
+- `reviewers`
+- `remediation_plan`
+
+DeepReview report enrichment lives in `src/crates/core/src/agentic/deep_review/report.rs`. It fills missing reviewer packet metadata when a unique packet can be inferred, adds runtime diagnostics, updates incremental cache data, and adds reliability signals for cache hits, cache misses, partial coverage, capacity skips, retry guidance, queue waits, reduced scope, and evidence-pack metadata.
+
+Report enrichment is guarded by the tool context. Standard Code Review output should not receive DeepReview-only metadata unless the active tool context proves `agent_type == 'DeepReview'`.
+
+## Frontend Report and Action UI
+
+DeepReview report rendering lives under `src/web-ui/src/flow_chat/deep-review/report` and is consumed by `CodeReviewToolCard`.
+
+The action surface is shared with standard Code Review but includes DeepReview-specific phases and capacity state:
+
+- `src/web-ui/src/flow_chat/store/deepReviewActionBarStore.ts`
+- `src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx`
+- `src/web-ui/src/flow_chat/deep-review/action-bar`
+
+`BtwSessionPanel` detects `sessionKind === 'deep_review'`, reads the latest code-review result, derives interrupted DeepReview state, restores persisted action-bar state, and renders `ReviewActionBar`.
+
+The action bar can show:
+
+- capacity queue notice and inline controls
+- partial results
+- recovery plan preview
+- remediation item selection
+- needs-decision gate
+- fix, fix-and-review, resume, and retry controls
+
+The action bar dispatches queue controls through `agentAPI.controlDeepReviewQueue` when backend queue-control identifiers are available. Otherwise it falls back to local/session-stop-only behavior exposed by the store.
+
+## Persistence
+
+The DeepReview child session stores `deepReviewRunManifest` in frontend session state, session metadata, and history metadata. The backend also reads `deep_review_run_manifest` from tool context/session metadata when a DeepReview tool call needs manifest data.
+
+The review action bar persists UI state separately through `ReviewActionBarPersistenceService` so historical review sessions can restore visible remediation progress without rerunning the review.
+
+## Boundary Rules
+
+- Frontend components do not call Tauri directly; they use infrastructure APIs such as `agentAPI`.
+- Shared core stays platform-agnostic and uses event/config/tool abstractions instead of Tauri handles.
+- The frontend owns target resolution, team manifest construction, strategy profile wording, prompt-block construction, consent, and action UI.
+- The backend owns policy validation, runtime admission, queue/retry state, event emission, and report enrichment.
+- Reviewer subagents stay read-only. Remediation runs after user approval through the action surface, not during the reviewer pass.
+- Work packets and evidence packs are planning metadata; they must not embed file contents or full diffs.
+
+## Change Checklist
+
+When changing DeepReview behavior, update all affected contracts together:
+
+- Backend constants, team definition, execution policy, manifest gate, task adapter, queue events, and report enrichment.
+- Frontend review-team defaults/types, manifest builder, prompt block, launch service, action-bar store, event mapping, report rendering, and locales.
+- Desktop Tauri command DTOs when queue controls or default team definition contracts change.
+- Tests near the touched module, especially policy tests, review-team manifest tests, queue event tests, launch tests, action-bar tests, and locale completeness tests.

--- a/src/crates/core/AGENTS.md
+++ b/src/crates/core/AGENTS.md
@@ -40,6 +40,14 @@ Narrower rules already exist:
 
 - `src/crates/ai-adapters/AGENTS.md`
 - `src/agentic/execution/AGENTS.md`
+- `src/agentic/deep_review/AGENTS.md`
+
+## DeepReview notes
+
+- Keep policy, manifest gate, queue state, Task adapter, and report enrichment
+  aligned when changing `src/agentic/deep_review*` or review agents.
+- Keep reviewer subagents read-only; user-approved remediation is outside the
+  reviewer pass.
 
 ## Commands
 

--- a/src/crates/core/src/agentic/deep_review/AGENTS.md
+++ b/src/crates/core/src/agentic/deep_review/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+## Scope
+
+This file applies to DeepReview runtime internals in this directory.
+
+## Local rules
+
+- Keep this code platform-agnostic; use shared events, config, and tool context.
+- Keep policy, manifest admission, queue state, retry metadata, task adapter,
+  and report enrichment aligned.
+- Keep default team/runtime contracts aligned with `deep_review_policy.rs` and
+  reviewer agents in `src/crates/core/src/agentic/agents`.
+- Reviewer subagents stay read-only; `ReviewFixer` is not part of the review
+  pass.
+- When queue or report fields change, update the matching frontend DTOs and
+  DeepReview UI state.

--- a/src/crates/core/src/agentic/deep_review/CONTRIBUTING.md
+++ b/src/crates/core/src/agentic/deep_review/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# DeepReview Runtime Contributions
+
+Use this guide for backend DeepReview changes in `src/crates/core`.
+
+- Runtime changes belong in shared core, without Tauri or desktop-only APIs.
+- Keep policy, manifest gate, queue state, retry behavior, task adapter, and
+  report enrichment in sync.
+- Preserve read-only reviewer execution; remediation requires user approval
+  outside the reviewer pass.
+- If event or report fields change, update the matching frontend types and UI.
+- Run the narrowest relevant Rust checks; avoid broad `cargo` commands unless
+  the change requires them.

--- a/src/crates/core/src/agentic/deep_review/budget.rs
+++ b/src/crates/core/src/agentic/deep_review/budget.rs
@@ -21,7 +21,7 @@ use super::shared_context::{
     DeepReviewSharedContextMeasurementSnapshot, DeepReviewSharedContextUseRecord,
 };
 use dashmap::DashMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -39,6 +39,7 @@ struct DeepReviewTurnBudget {
     reviewer_calls_by_subagent: HashMap<String, usize>,
     retries_used_by_subagent: HashMap<String, usize>,
     active_reviewers: usize,
+    active_reviewer_launch_batches: BTreeMap<u64, usize>,
     concurrency_cap_rejections: usize,
     capacity_skips: usize,
     shared_context_uses: HashMap<DeepReviewSharedContextKey, DeepReviewSharedContextUseRecord>,
@@ -56,6 +57,7 @@ impl DeepReviewTurnBudget {
             reviewer_calls_by_subagent: HashMap::new(),
             retries_used_by_subagent: HashMap::new(),
             active_reviewers: 0,
+            active_reviewer_launch_batches: BTreeMap::new(),
             concurrency_cap_rejections: 0,
             capacity_skips: 0,
             shared_context_uses: HashMap::new(),
@@ -81,6 +83,7 @@ impl DeepReviewTurnBudget {
 pub struct DeepReviewActiveReviewerGuard<'a> {
     tracker: &'a DeepReviewBudgetTracker,
     parent_dialog_turn_id: String,
+    launch_batch: Option<u64>,
     released: bool,
 }
 
@@ -88,7 +91,7 @@ impl Drop for DeepReviewActiveReviewerGuard<'_> {
     fn drop(&mut self) {
         if !self.released {
             self.tracker
-                .finish_active_reviewer(&self.parent_dialog_turn_id);
+                .finish_active_reviewer(&self.parent_dialog_turn_id, self.launch_batch);
             self.released = true;
         }
     }
@@ -519,6 +522,7 @@ impl DeepReviewBudgetTracker {
         DeepReviewActiveReviewerGuard {
             tracker: self,
             parent_dialog_turn_id: parent_dialog_turn_id.to_string(),
+            launch_batch: None,
             released: false,
         }
     }
@@ -542,13 +546,76 @@ impl DeepReviewBudgetTracker {
         Some(DeepReviewActiveReviewerGuard {
             tracker: self,
             parent_dialog_turn_id: parent_dialog_turn_id.to_string(),
+            launch_batch: None,
             released: false,
         })
     }
 
-    fn finish_active_reviewer(&self, parent_dialog_turn_id: &str) {
+    pub fn try_begin_active_reviewer_for_launch_batch<'a>(
+        &'a self,
+        parent_dialog_turn_id: &str,
+        max_active_reviewers: usize,
+        launch_batch: u64,
+        packet_id: Option<&str>,
+    ) -> Result<Option<DeepReviewActiveReviewerGuard<'a>>, DeepReviewPolicyViolation> {
+        let now = Instant::now();
+        let mut budget = self
+            .turns
+            .entry(parent_dialog_turn_id.to_string())
+            .or_insert_with(|| DeepReviewTurnBudget::new(now));
+
+        if let Some((&earliest_active_batch, _)) =
+            budget.active_reviewer_launch_batches.iter().next()
+        {
+            if earliest_active_batch < launch_batch {
+                let packet_label = packet_id
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or("unknown");
+                return Err(DeepReviewPolicyViolation::new(
+                    "deep_review_launch_batch_blocked",
+                    format!(
+                        "Reviewer packet '{}' is in launch_batch {}, but launch_batch {} still has active reviewer(s). Wait for earlier-batch reviewers to finish, timeout, or be cancelled before launching this packet. If the queue remains blocked, pause or cancel the queued reviewers from the Review Team action bar and retry with a lower max parallel reviewer setting.",
+                        packet_label, launch_batch, earliest_active_batch
+                    ),
+                ));
+            }
+        }
+
+        if budget.active_reviewers >= max_active_reviewers {
+            return Ok(None);
+        }
+
+        budget.active_reviewers = budget.active_reviewers.saturating_add(1);
+        *budget
+            .active_reviewer_launch_batches
+            .entry(launch_batch)
+            .or_insert(0) += 1;
+        budget.updated_at = now;
+        Ok(Some(DeepReviewActiveReviewerGuard {
+            tracker: self,
+            parent_dialog_turn_id: parent_dialog_turn_id.to_string(),
+            launch_batch: Some(launch_batch),
+            released: false,
+        }))
+    }
+
+    fn finish_active_reviewer(&self, parent_dialog_turn_id: &str, launch_batch: Option<u64>) {
         if let Some(mut budget) = self.turns.get_mut(parent_dialog_turn_id) {
             budget.active_reviewers = budget.active_reviewers.saturating_sub(1);
+            if let Some(launch_batch) = launch_batch {
+                let should_remove_batch = if let Some(count) =
+                    budget.active_reviewer_launch_batches.get_mut(&launch_batch)
+                {
+                    *count = (*count).saturating_sub(1);
+                    *count == 0
+                } else {
+                    false
+                };
+                if should_remove_batch {
+                    budget.active_reviewer_launch_batches.remove(&launch_batch);
+                }
+            }
             budget.updated_at = Instant::now();
         }
     }
@@ -748,4 +815,66 @@ fn normalize_budget_subagent_type(
     }
 
     Ok(normalized.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn launch_batch_admission_blocks_later_batch_while_earlier_batch_is_active() {
+        let tracker = DeepReviewBudgetTracker::default();
+        let turn_id = "turn-launch-batch-blocked";
+        let _first_batch = tracker
+            .try_begin_active_reviewer_for_launch_batch(turn_id, 2, 1, Some("packet-a"))
+            .expect("batch admission should not fail")
+            .expect("first reviewer should start");
+
+        let violation = match tracker.try_begin_active_reviewer_for_launch_batch(
+            turn_id,
+            2,
+            2,
+            Some("packet-b"),
+        ) {
+            Err(violation) => violation,
+            Ok(_) => panic!("later launch batch should wait while earlier batch is active"),
+        };
+
+        assert_eq!(violation.code, "deep_review_launch_batch_blocked");
+        assert!(violation.message.contains("packet-b"));
+        assert!(violation.message.contains("launch_batch 2"));
+        assert!(violation.message.contains("launch_batch 1"));
+        assert!(violation
+            .message
+            .contains("Wait for earlier-batch reviewers"));
+    }
+
+    #[test]
+    fn launch_batch_admission_allows_same_batch_and_next_batch_after_release() {
+        let tracker = DeepReviewBudgetTracker::default();
+        let turn_id = "turn-launch-batch-release";
+        let first = tracker
+            .try_begin_active_reviewer_for_launch_batch(turn_id, 2, 1, Some("packet-a"))
+            .expect("first batch should not violate launch order")
+            .expect("first reviewer should start");
+        let second = tracker
+            .try_begin_active_reviewer_for_launch_batch(turn_id, 2, 1, Some("packet-b"))
+            .expect("same batch should not violate launch order")
+            .expect("second reviewer should start");
+        assert!(
+            tracker
+                .try_begin_active_reviewer_for_launch_batch(turn_id, 2, 1, Some("packet-c"))
+                .expect("same batch should not violate launch order")
+                .is_none(),
+            "same-batch admission should still respect active reviewer capacity"
+        );
+
+        drop(first);
+        drop(second);
+
+        assert!(tracker
+            .try_begin_active_reviewer_for_launch_batch(turn_id, 2, 2, Some("packet-c"))
+            .expect("next batch should start after the previous batch releases")
+            .is_some());
+    }
 }

--- a/src/crates/core/src/agentic/deep_review/queue.rs
+++ b/src/crates/core/src/agentic/deep_review/queue.rs
@@ -16,6 +16,7 @@ pub enum DeepReviewCapacityQueueReason {
     ProviderConcurrencyLimit,
     RetryAfter,
     LocalConcurrencyCap,
+    LaunchBatchBlocked,
     TemporaryOverload,
 }
 
@@ -26,6 +27,7 @@ impl DeepReviewCapacityQueueReason {
             Self::ProviderConcurrencyLimit => "provider_concurrency_limit",
             Self::RetryAfter => "retry_after",
             Self::LocalConcurrencyCap => "local_concurrency_cap",
+            Self::LaunchBatchBlocked => "launch_batch_blocked",
             Self::TemporaryOverload => "temporary_overload",
         }
     }

--- a/src/crates/core/src/agentic/deep_review/task_adapter.rs
+++ b/src/crates/core/src/agentic/deep_review/task_adapter.rs
@@ -10,17 +10,18 @@ use crate::agentic::coordination::get_global_coordinator;
 use crate::agentic::deep_review::queue::extract_retry_after_seconds;
 use crate::agentic::deep_review_policy::{
     classify_deep_review_capacity_error, clear_deep_review_queue_control_for_tool,
-    deep_review_active_reviewer_count, deep_review_effective_parallel_instances,
-    deep_review_max_retries_per_role, deep_review_queue_control_snapshot,
-    record_deep_review_capacity_skip_for_reason,
+    deep_review_active_reviewer_count, deep_review_effective_concurrency_snapshot,
+    deep_review_effective_parallel_instances, deep_review_max_retries_per_role,
+    deep_review_queue_control_snapshot, record_deep_review_capacity_skip_for_reason,
     record_deep_review_effective_concurrency_capacity_error,
     record_deep_review_runtime_provider_capacity_queue,
     record_deep_review_runtime_provider_capacity_retry,
     record_deep_review_runtime_provider_capacity_retry_success,
     record_deep_review_runtime_queue_wait, try_begin_deep_review_active_reviewer,
-    DeepReviewActiveReviewerGuard, DeepReviewCapacityFailFastReason,
-    DeepReviewCapacityQueueDecision, DeepReviewCapacityQueueReason, DeepReviewConcurrencyPolicy,
-    DeepReviewExecutionPolicy, DeepReviewPolicyViolation,
+    try_begin_deep_review_active_reviewer_for_launch_batch, DeepReviewActiveReviewerGuard,
+    DeepReviewCapacityFailFastReason, DeepReviewCapacityQueueDecision,
+    DeepReviewCapacityQueueReason, DeepReviewConcurrencyPolicy, DeepReviewExecutionPolicy,
+    DeepReviewPolicyViolation,
 };
 use crate::agentic::events::{
     DeepReviewQueueReason, DeepReviewQueueState, DeepReviewQueueStatus, ErrorCategory,
@@ -51,6 +52,7 @@ pub(crate) enum DeepReviewQueueWaitOutcome {
     Skipped {
         queue_elapsed_ms: u64,
         skip_reason: DeepReviewQueueWaitSkipReason,
+        capacity_reason: DeepReviewCapacityQueueReason,
     },
 }
 
@@ -62,6 +64,12 @@ pub(crate) enum DeepReviewProviderQueueWaitOutcome {
         queue_elapsed_ms: u64,
         skip_reason: DeepReviewQueueWaitSkipReason,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DeepReviewLaunchBatchInfo {
+    pub packet_id: Option<String>,
+    pub launch_batch: u64,
 }
 
 pub(crate) fn string_for_any_key<'a>(value: &'a Value, keys: &[&str]) -> Option<&'a str> {
@@ -204,6 +212,26 @@ pub(crate) fn manifest_packet_by_id<'a>(
         })
 }
 
+pub(crate) fn launch_batch_for_manifest_packet(packet: &Value) -> Option<u64> {
+    u64_for_any_key(packet, &["launchBatch", "launch_batch"])
+        .filter(|launch_batch| *launch_batch > 0)
+}
+
+pub(crate) fn deep_review_launch_batch_for_task(
+    subagent_type: &str,
+    description: Option<&str>,
+    run_manifest: Option<&Value>,
+) -> Option<DeepReviewLaunchBatchInfo> {
+    let packet_id = deep_review_packet_id_for_cache(subagent_type, description, run_manifest)?;
+    let packet = manifest_packet_by_id(run_manifest, &packet_id, subagent_type)?;
+    let launch_batch = launch_batch_for_manifest_packet(packet)?;
+
+    Some(DeepReviewLaunchBatchInfo {
+        packet_id: Some(packet_id),
+        launch_batch,
+    })
+}
+
 pub(crate) fn file_paths_for_manifest_packet(
     packet: &Value,
 ) -> Result<Vec<String>, DeepReviewPolicyViolation> {
@@ -220,6 +248,7 @@ pub(crate) fn is_retryable_capacity_reason(reason: &str) -> bool {
     matches!(
         reason,
         "local_concurrency_cap"
+            | "launch_batch_blocked"
             | "provider_rate_limit"
             | "provider_concurrency_limit"
             | "retry_after"
@@ -411,6 +440,9 @@ pub(crate) fn queue_reason_to_event_reason(
         DeepReviewCapacityQueueReason::LocalConcurrencyCap => {
             DeepReviewQueueReason::LocalConcurrencyCap
         }
+        DeepReviewCapacityQueueReason::LaunchBatchBlocked => {
+            DeepReviewQueueReason::LaunchBatchBlocked
+        }
         DeepReviewCapacityQueueReason::TemporaryOverload => {
             DeepReviewQueueReason::TemporaryOverload
         }
@@ -469,7 +501,8 @@ pub(crate) fn provider_capacity_queue_wait_seconds(
         | DeepReviewCapacityQueueReason::ProviderConcurrencyLimit
         | DeepReviewCapacityQueueReason::RetryAfter
         | DeepReviewCapacityQueueReason::TemporaryOverload => {}
-        DeepReviewCapacityQueueReason::LocalConcurrencyCap => return None,
+        DeepReviewCapacityQueueReason::LocalConcurrencyCap
+        | DeepReviewCapacityQueueReason::LaunchBatchBlocked => return None,
     }
 
     Some(
@@ -497,6 +530,76 @@ pub(crate) fn capacity_skip_result_for_provider_reason(
         0,
         None,
     )
+}
+
+pub(crate) fn capacity_skip_result_for_local_queue_outcome(
+    dialog_turn_id: &str,
+    subagent_type: &str,
+    conc_policy: &DeepReviewConcurrencyPolicy,
+    capacity_reason: DeepReviewCapacityQueueReason,
+    skip_reason: DeepReviewQueueWaitSkipReason,
+    queue_elapsed_ms: u64,
+    duration_ms: u128,
+) -> (Value, String) {
+    let queue_skip_reason = match skip_reason {
+        DeepReviewQueueWaitSkipReason::QueueExpired => "queue_expired",
+        DeepReviewQueueWaitSkipReason::UserCancelled => "user_cancelled",
+        DeepReviewQueueWaitSkipReason::OptionalSkipped => "optional_skipped",
+    };
+    let capacity_reason_code = queue_reason_to_snake_case(capacity_reason);
+    let assistant_message = match skip_reason {
+        DeepReviewQueueWaitSkipReason::QueueExpired => {
+            let reason_message = match capacity_reason {
+                DeepReviewCapacityQueueReason::LaunchBatchBlocked => {
+                    "the previous launch batch did not finish before the queue wait limit"
+                }
+                DeepReviewCapacityQueueReason::LocalConcurrencyCap => {
+                    "the local reviewer capacity queue reached its maximum wait"
+                }
+                _ => "the DeepReview capacity queue reached its maximum wait",
+            };
+            let recommended_action = match capacity_reason {
+                DeepReviewCapacityQueueReason::LaunchBatchBlocked => {
+                    "Wait for the earlier reviewer batch to finish or cancel stuck queued reviewers, then retry this packet with a lower max parallel reviewer setting if it repeats."
+                }
+                _ => {
+                    "Run the review again with a lower max parallel reviewer setting or wait for active reviewers to finish."
+                }
+            };
+            format!(
+                "Subagent '{}' was skipped because {} ({}s). Recommended action: {}\n<queue_result status=\"capacity_skipped\" reason=\"{}\" queue_elapsed_ms=\"{}\" />",
+                subagent_type,
+                reason_message,
+                conc_policy.max_queue_wait_seconds,
+                recommended_action,
+                capacity_reason_code,
+                queue_elapsed_ms
+            )
+        }
+        DeepReviewQueueWaitSkipReason::UserCancelled => format!(
+            "Subagent '{}' was skipped because the DeepReview capacity queue was cancelled by the user.\n<queue_result status=\"capacity_skipped\" reason=\"user_cancelled\" queue_elapsed_ms=\"{}\" />",
+            subagent_type, queue_elapsed_ms
+        ),
+        DeepReviewQueueWaitSkipReason::OptionalSkipped => format!(
+            "Subagent '{}' was skipped because optional DeepReview queued reviewers were skipped by the user.\n<queue_result status=\"capacity_skipped\" reason=\"optional_skipped\" queue_elapsed_ms=\"{}\" />",
+            subagent_type, queue_elapsed_ms
+        ),
+    };
+
+    let data = json!({
+        "duration": u64::try_from(duration_ms).unwrap_or(u64::MAX),
+        "status": "capacity_skipped",
+        "queue_elapsed_ms": queue_elapsed_ms,
+        "max_queue_wait_seconds": conc_policy.max_queue_wait_seconds,
+        "queue_skip_reason": queue_skip_reason,
+        "capacity_reason": capacity_reason_code,
+        "effective_parallel_instances": deep_review_effective_concurrency_snapshot(
+            dialog_turn_id,
+            conc_policy.max_parallel_instances,
+        ).effective_parallel_instances
+    });
+
+    (data, assistant_message)
 }
 
 pub(crate) fn capacity_skip_result_for_provider_queue_outcome(
@@ -734,17 +837,58 @@ pub(crate) async fn wait_for_reviewer_capacity(
     conc_policy: &DeepReviewConcurrencyPolicy,
     is_optional_reviewer: bool,
 ) -> BitFunResult<DeepReviewQueueWaitOutcome> {
+    wait_for_reviewer_admission(
+        session_id,
+        dialog_turn_id,
+        tool_id,
+        subagent_type,
+        conc_policy,
+        is_optional_reviewer,
+        None,
+    )
+    .await
+}
+
+pub(crate) fn try_begin_reviewer_admission(
+    dialog_turn_id: &str,
+    effective_parallel_instances: usize,
+    launch_batch_info: Option<&DeepReviewLaunchBatchInfo>,
+) -> Result<Option<DeepReviewActiveReviewerGuard<'static>>, DeepReviewPolicyViolation> {
+    match launch_batch_info {
+        Some(info) => try_begin_deep_review_active_reviewer_for_launch_batch(
+            dialog_turn_id,
+            effective_parallel_instances,
+            info.launch_batch,
+            info.packet_id.as_deref(),
+        ),
+        None => Ok(try_begin_deep_review_active_reviewer(
+            dialog_turn_id,
+            effective_parallel_instances,
+        )),
+    }
+}
+
+pub(crate) async fn wait_for_reviewer_admission(
+    session_id: &str,
+    dialog_turn_id: &str,
+    tool_id: &str,
+    subagent_type: &str,
+    conc_policy: &DeepReviewConcurrencyPolicy,
+    is_optional_reviewer: bool,
+    launch_batch_info: Option<&DeepReviewLaunchBatchInfo>,
+) -> BitFunResult<DeepReviewQueueWaitOutcome> {
     let decision = classify_deep_review_capacity_error(
         "deep_review_concurrency_cap_reached",
         "Maximum parallel reviewer instances reached",
         None,
     );
-    let reason = decision
+    let local_capacity_reason = decision
         .reason
         .unwrap_or(DeepReviewCapacityQueueReason::LocalConcurrencyCap);
     let mut queue_timer = QueueWaitTimer::start(Instant::now());
     let max_wait = Duration::from_secs(conc_policy.max_queue_wait_seconds);
     let optional_reviewer_count = is_optional_reviewer.then_some(1);
+    let mut last_wait_reason = local_capacity_reason;
 
     loop {
         let now = Instant::now();
@@ -756,11 +900,12 @@ pub(crate) async fn wait_for_reviewer_capacity(
             dialog_turn_id,
             conc_policy.max_parallel_instances,
         );
+        let mut current_reason = last_wait_reason;
 
         let control_snapshot = deep_review_queue_control_snapshot(dialog_turn_id, tool_id);
         if control_snapshot.cancelled || (is_optional_reviewer && control_snapshot.skip_optional) {
             record_deep_review_runtime_queue_wait(dialog_turn_id, queue_elapsed_ms);
-            record_deep_review_capacity_skip_for_reason(dialog_turn_id, reason);
+            record_deep_review_capacity_skip_for_reason(dialog_turn_id, current_reason);
             clear_deep_review_queue_control_for_tool(dialog_turn_id, tool_id);
             emit_queue_state(
                 session_id,
@@ -768,7 +913,7 @@ pub(crate) async fn wait_for_reviewer_capacity(
                 tool_id,
                 subagent_type,
                 DeepReviewQueueStatus::CapacitySkipped,
-                Some(reason),
+                Some(current_reason),
                 0,
                 active_reviewers,
                 optional_reviewer_count,
@@ -784,6 +929,7 @@ pub(crate) async fn wait_for_reviewer_capacity(
                 } else {
                     DeepReviewQueueWaitSkipReason::OptionalSkipped
                 },
+                capacity_reason: current_reason,
             });
         }
 
@@ -795,7 +941,7 @@ pub(crate) async fn wait_for_reviewer_capacity(
                 tool_id,
                 subagent_type,
                 DeepReviewQueueStatus::PausedByUser,
-                Some(reason),
+                Some(current_reason),
                 1,
                 active_reviewers,
                 optional_reviewer_count,
@@ -810,39 +956,65 @@ pub(crate) async fn wait_for_reviewer_capacity(
 
         queue_timer.continue_now(now);
 
-        if let Some(guard) =
-            try_begin_deep_review_active_reviewer(dialog_turn_id, effective_parallel_instances)
-        {
-            let active_reviewer_count = deep_review_active_reviewer_count(dialog_turn_id);
-            record_deep_review_runtime_queue_wait(dialog_turn_id, queue_elapsed_ms);
-            clear_deep_review_queue_control_for_tool(dialog_turn_id, tool_id);
-            emit_queue_state(
-                session_id,
-                dialog_turn_id,
-                tool_id,
-                subagent_type,
-                DeepReviewQueueStatus::Running,
-                None,
-                0,
-                active_reviewer_count,
-                optional_reviewer_count,
-                Some(effective_parallel_instances),
-                queue_elapsed_ms,
-                conc_policy.max_queue_wait_seconds,
-            )
-            .await;
-            return Ok(DeepReviewQueueWaitOutcome::Ready { guard });
+        match try_begin_reviewer_admission(
+            dialog_turn_id,
+            effective_parallel_instances,
+            launch_batch_info,
+        ) {
+            Ok(Some(guard)) => {
+                let active_reviewer_count = deep_review_active_reviewer_count(dialog_turn_id);
+                record_deep_review_runtime_queue_wait(dialog_turn_id, queue_elapsed_ms);
+                clear_deep_review_queue_control_for_tool(dialog_turn_id, tool_id);
+                emit_queue_state(
+                    session_id,
+                    dialog_turn_id,
+                    tool_id,
+                    subagent_type,
+                    DeepReviewQueueStatus::Running,
+                    None,
+                    0,
+                    active_reviewer_count,
+                    optional_reviewer_count,
+                    Some(effective_parallel_instances),
+                    queue_elapsed_ms,
+                    conc_policy.max_queue_wait_seconds,
+                )
+                .await;
+                return Ok(DeepReviewQueueWaitOutcome::Ready { guard });
+            }
+            Ok(None) => {
+                current_reason = local_capacity_reason;
+            }
+            Err(violation) if violation.code == "deep_review_launch_batch_blocked" => {
+                current_reason = DeepReviewCapacityQueueReason::LaunchBatchBlocked;
+            }
+            Err(violation) => {
+                return Err(BitFunError::tool(format!(
+                    "DeepReview Task policy violation: {}",
+                    violation.to_tool_error_message()
+                )));
+            }
         }
+        last_wait_reason = current_reason;
 
-        if queue_snapshot.is_expired(max_wait) {
-            let snapshot = record_deep_review_effective_concurrency_capacity_error(
-                dialog_turn_id,
-                conc_policy.max_parallel_instances,
-                reason,
-                decision.retry_after_seconds.map(Duration::from_secs),
-            );
+        let queue_expired_without_active_reviewer =
+            queue_snapshot.is_expired(max_wait) && active_reviewers == 0;
+
+        if queue_expired_without_active_reviewer {
+            let effective_parallel_instances =
+                if current_reason == DeepReviewCapacityQueueReason::LaunchBatchBlocked {
+                    effective_parallel_instances
+                } else {
+                    record_deep_review_effective_concurrency_capacity_error(
+                        dialog_turn_id,
+                        conc_policy.max_parallel_instances,
+                        current_reason,
+                        decision.retry_after_seconds.map(Duration::from_secs),
+                    )
+                    .effective_parallel_instances
+                };
             record_deep_review_runtime_queue_wait(dialog_turn_id, queue_elapsed_ms);
-            record_deep_review_capacity_skip_for_reason(dialog_turn_id, reason);
+            record_deep_review_capacity_skip_for_reason(dialog_turn_id, current_reason);
             clear_deep_review_queue_control_for_tool(dialog_turn_id, tool_id);
             emit_queue_state(
                 session_id,
@@ -850,11 +1022,11 @@ pub(crate) async fn wait_for_reviewer_capacity(
                 tool_id,
                 subagent_type,
                 DeepReviewQueueStatus::CapacitySkipped,
-                Some(reason),
+                Some(current_reason),
                 0,
                 active_reviewers,
                 optional_reviewer_count,
-                Some(snapshot.effective_parallel_instances),
+                Some(effective_parallel_instances),
                 queue_elapsed_ms,
                 conc_policy.max_queue_wait_seconds,
             )
@@ -862,6 +1034,7 @@ pub(crate) async fn wait_for_reviewer_capacity(
             return Ok(DeepReviewQueueWaitOutcome::Skipped {
                 queue_elapsed_ms,
                 skip_reason: DeepReviewQueueWaitSkipReason::QueueExpired,
+                capacity_reason: current_reason,
             });
         }
 
@@ -871,7 +1044,7 @@ pub(crate) async fn wait_for_reviewer_capacity(
             tool_id,
             subagent_type,
             DeepReviewQueueStatus::QueuedForCapacity,
-            Some(reason),
+            Some(current_reason),
             1,
             active_reviewers,
             optional_reviewer_count,
@@ -881,7 +1054,11 @@ pub(crate) async fn wait_for_reviewer_capacity(
         )
         .await;
 
-        let remaining = max_wait.saturating_sub(queue_elapsed);
-        sleep(DEEP_REVIEW_QUEUE_POLL_INTERVAL.min(remaining)).await;
+        let sleep_duration = if queue_snapshot.is_expired(max_wait) {
+            DEEP_REVIEW_QUEUE_POLL_INTERVAL
+        } else {
+            DEEP_REVIEW_QUEUE_POLL_INTERVAL.min(max_wait.saturating_sub(queue_elapsed))
+        };
+        sleep(sleep_duration).await;
     }
 }

--- a/src/crates/core/src/agentic/deep_review_policy.rs
+++ b/src/crates/core/src/agentic/deep_review_policy.rs
@@ -203,6 +203,20 @@ pub fn try_begin_deep_review_active_reviewer(
         .try_begin_active_reviewer(parent_dialog_turn_id, max_active_reviewers)
 }
 
+pub fn try_begin_deep_review_active_reviewer_for_launch_batch(
+    parent_dialog_turn_id: &str,
+    max_active_reviewers: usize,
+    launch_batch: u64,
+    packet_id: Option<&str>,
+) -> Result<Option<DeepReviewActiveReviewerGuard<'static>>, DeepReviewPolicyViolation> {
+    GLOBAL_DEEP_REVIEW_BUDGET_TRACKER.try_begin_active_reviewer_for_launch_batch(
+        parent_dialog_turn_id,
+        max_active_reviewers,
+        launch_batch,
+        packet_id,
+    )
+}
+
 pub fn deep_review_effective_concurrency_snapshot(
     parent_dialog_turn_id: &str,
     configured_max_parallel_instances: usize,

--- a/src/crates/core/src/agentic/tools/framework.rs
+++ b/src/crates/core/src/agentic/tools/framework.rs
@@ -1,7 +1,7 @@
 //! Tool framework - Tool interface definition and execution context
 use crate::agentic::coordination::get_global_coordinator;
-use crate::agentic::deep_review::tool_measurement;
 use crate::agentic::session::EvidenceLedgerCheckpoint;
+use crate::agentic::tools::post_call_hooks;
 use crate::agentic::tools::restrictions::{
     is_local_path_within_root, is_remote_posix_path_within_root, ToolPathOperation,
     ToolRuntimeRestrictions,
@@ -703,7 +703,7 @@ pub trait Tool: Send + Sync {
             self.call_impl(input, context).await
         };
         if result.is_ok() {
-            tool_measurement::maybe_record_shared_context_tool_use(self.name(), input, context);
+            post_call_hooks::record_successful_tool_call(self.name(), input, context);
         }
         result
     }

--- a/src/crates/core/src/agentic/tools/implementations/task_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/task_tool.rs
@@ -1,16 +1,15 @@
 use crate::agentic::agents::{get_agent_registry, AgentInfo};
 use crate::agentic::coordination::get_global_coordinator;
 use crate::agentic::deep_review::task_adapter::{
-    self as deep_review_task_adapter, DeepReviewProviderQueueWaitOutcome,
-    DeepReviewQueueWaitOutcome, DeepReviewQueueWaitSkipReason,
+    self as deep_review_task_adapter, DeepReviewLaunchBatchInfo,
+    DeepReviewProviderQueueWaitOutcome, DeepReviewQueueWaitOutcome, DeepReviewQueueWaitSkipReason,
 };
 use crate::agentic::deep_review_policy::{
-    deep_review_active_reviewer_count, deep_review_effective_concurrency_snapshot,
-    deep_review_effective_parallel_instances, deep_review_has_judge_been_launched,
-    deep_review_turn_elapsed_seconds, load_default_deep_review_policy,
-    record_deep_review_effective_concurrency_success, record_deep_review_runtime_auto_retry,
-    record_deep_review_runtime_auto_retry_suppressed, record_deep_review_runtime_manual_retry,
-    record_deep_review_task_budget, try_begin_deep_review_active_reviewer,
+    deep_review_active_reviewer_count, deep_review_effective_parallel_instances,
+    deep_review_has_judge_been_launched, deep_review_turn_elapsed_seconds,
+    load_default_deep_review_policy, record_deep_review_effective_concurrency_success,
+    record_deep_review_runtime_auto_retry, record_deep_review_runtime_auto_retry_suppressed,
+    record_deep_review_runtime_manual_retry, record_deep_review_task_budget,
     DeepReviewActiveReviewerGuard, DeepReviewCapacityQueueReason, DeepReviewConcurrencyPolicy,
     DeepReviewExecutionPolicy, DeepReviewIncrementalCache, DeepReviewPolicyViolation,
     DeepReviewRunManifestGate, DeepReviewSubagentRole, DEEP_REVIEW_AGENT_TYPE,
@@ -56,6 +55,18 @@ impl TaskTool {
         )
     }
 
+    fn deep_review_launch_batch_for_task(
+        subagent_type: &str,
+        description: Option<&str>,
+        run_manifest: Option<&Value>,
+    ) -> Option<DeepReviewLaunchBatchInfo> {
+        deep_review_task_adapter::deep_review_launch_batch_for_task(
+            subagent_type,
+            description,
+            run_manifest,
+        )
+    }
+
     fn attach_deep_review_cache(run_manifest: &mut Value, cache_value: Option<Value>) {
         deep_review_task_adapter::attach_deep_review_cache(run_manifest, cache_value);
     }
@@ -77,7 +88,10 @@ impl TaskTool {
     ) -> bool {
         is_partial_timeout
             && !is_retry
-            && matches!(deep_review_subagent_role, Some(DeepReviewSubagentRole::Reviewer))
+            && matches!(
+                deep_review_subagent_role,
+                Some(DeepReviewSubagentRole::Reviewer)
+            )
     }
 
     fn ensure_deep_review_retry_coverage(
@@ -285,48 +299,60 @@ impl TaskTool {
         .await
     }
 
+    fn try_begin_deep_review_reviewer_admission(
+        dialog_turn_id: &str,
+        effective_parallel_instances: usize,
+        launch_batch_info: Option<&DeepReviewLaunchBatchInfo>,
+    ) -> Result<Option<DeepReviewActiveReviewerGuard<'static>>, DeepReviewPolicyViolation> {
+        deep_review_task_adapter::try_begin_reviewer_admission(
+            dialog_turn_id,
+            effective_parallel_instances,
+            launch_batch_info,
+        )
+    }
+
+    async fn wait_for_deep_review_reviewer_admission(
+        session_id: &str,
+        dialog_turn_id: &str,
+        tool_id: &str,
+        subagent_type: &str,
+        conc_policy: &DeepReviewConcurrencyPolicy,
+        is_optional_reviewer: bool,
+        launch_batch_info: Option<&DeepReviewLaunchBatchInfo>,
+    ) -> BitFunResult<DeepReviewQueueWaitOutcome> {
+        deep_review_task_adapter::wait_for_reviewer_admission(
+            session_id,
+            dialog_turn_id,
+            tool_id,
+            subagent_type,
+            conc_policy,
+            is_optional_reviewer,
+            launch_batch_info,
+        )
+        .await
+    }
+
     fn deep_review_local_capacity_skip_tool_result(
         dialog_turn_id: &str,
         subagent_type: &str,
         conc_policy: &DeepReviewConcurrencyPolicy,
+        capacity_reason: DeepReviewCapacityQueueReason,
         skip_reason: DeepReviewQueueWaitSkipReason,
         queue_elapsed_ms: u64,
         duration_ms: u128,
     ) -> ToolResult {
-        let queue_skip_reason = match skip_reason {
-            DeepReviewQueueWaitSkipReason::QueueExpired => "queue_expired",
-            DeepReviewQueueWaitSkipReason::UserCancelled => "user_cancelled",
-            DeepReviewQueueWaitSkipReason::OptionalSkipped => "optional_skipped",
-        };
-        let assistant_message = match skip_reason {
-            DeepReviewQueueWaitSkipReason::QueueExpired => format!(
-                "Subagent '{}' was skipped because the DeepReview capacity queue reached its maximum wait ({}s).\n<queue_result status=\"capacity_skipped\" reason=\"local_concurrency_cap\" queue_elapsed_ms=\"{}\" />",
+        let (data, assistant_message) =
+            deep_review_task_adapter::capacity_skip_result_for_local_queue_outcome(
+                dialog_turn_id,
                 subagent_type,
-                conc_policy.max_queue_wait_seconds,
-                queue_elapsed_ms
-            ),
-            DeepReviewQueueWaitSkipReason::UserCancelled => format!(
-                "Subagent '{}' was skipped because the DeepReview capacity queue was cancelled by the user.\n<queue_result status=\"capacity_skipped\" reason=\"user_cancelled\" queue_elapsed_ms=\"{}\" />",
-                subagent_type, queue_elapsed_ms
-            ),
-            DeepReviewQueueWaitSkipReason::OptionalSkipped => format!(
-                "Subagent '{}' was skipped because optional DeepReview queued reviewers were skipped by the user.\n<queue_result status=\"capacity_skipped\" reason=\"optional_skipped\" queue_elapsed_ms=\"{}\" />",
-                subagent_type, queue_elapsed_ms
-            ),
-        };
-
+                conc_policy,
+                capacity_reason,
+                skip_reason,
+                queue_elapsed_ms,
+                duration_ms,
+            );
         ToolResult::Result {
-            data: json!({
-                "duration": duration_ms,
-                "status": "capacity_skipped",
-                "queue_elapsed_ms": queue_elapsed_ms,
-                "max_queue_wait_seconds": conc_policy.max_queue_wait_seconds,
-                "queue_skip_reason": queue_skip_reason,
-                "effective_parallel_instances": deep_review_effective_concurrency_snapshot(
-                    dialog_turn_id,
-                    conc_policy.max_parallel_instances,
-                ).effective_parallel_instances
-            }),
+            data,
             result_for_assistant: Some(assistant_message),
             image_attachments: None,
         }
@@ -527,7 +553,7 @@ impl Tool for TaskTool {
                         },
                         "capacity_reason": {
                             "type": "string",
-                            "description": "Required for capacity_skipped; must be a transient capacity reason such as local_concurrency_cap, provider_rate_limit, provider_concurrency_limit, retry_after, or temporary_overload."
+                            "description": "Required for capacity_skipped; must be a transient capacity reason such as local_concurrency_cap, launch_batch_blocked, provider_rate_limit, provider_concurrency_limit, retry_after, or temporary_overload."
                         },
                         "covered_files": {
                             "type": "array",
@@ -776,6 +802,7 @@ impl Tool for TaskTool {
         let mut deep_review_reviewer_configured_max_parallel_instances: Option<usize> = None;
         let mut deep_review_concurrency_policy: Option<DeepReviewConcurrencyPolicy> = None;
         let mut deep_review_is_optional_reviewer = false;
+        let mut deep_review_launch_batch_info: Option<DeepReviewLaunchBatchInfo> = None;
         let mut deep_review_retry_scope_files: Option<Vec<String>> = None;
         let mut deep_review_subagent_role: Option<DeepReviewSubagentRole> = None;
 
@@ -858,25 +885,27 @@ impl Tool for TaskTool {
                 .concurrency_policy_from_manifest(run_manifest.as_ref().unwrap_or(&Value::Null));
             deep_review_concurrency_policy = Some(conc_policy.clone());
             if is_retry && role == DeepReviewSubagentRole::Reviewer {
-                deep_review_retry_scope_files = Some(match Self::ensure_deep_review_retry_coverage(
-                    input,
-                    &subagent_type,
-                    run_manifest.as_ref(),
-                ) {
-                    Ok(retry_scope_files) => retry_scope_files,
-                    Err(violation) => {
-                        if is_auto_retry {
-                            record_deep_review_runtime_auto_retry_suppressed(
-                                &dialog_turn_id,
-                                Self::auto_retry_suppression_reason(violation.code),
-                            );
+                deep_review_retry_scope_files = Some(
+                    match Self::ensure_deep_review_retry_coverage(
+                        input,
+                        &subagent_type,
+                        run_manifest.as_ref(),
+                    ) {
+                        Ok(retry_scope_files) => retry_scope_files,
+                        Err(violation) => {
+                            if is_auto_retry {
+                                record_deep_review_runtime_auto_retry_suppressed(
+                                    &dialog_turn_id,
+                                    Self::auto_retry_suppression_reason(violation.code),
+                                );
+                            }
+                            return Err(BitFunError::tool(format!(
+                                "DeepReview Task policy violation: {}",
+                                violation.to_tool_error_message()
+                            )));
                         }
-                        return Err(BitFunError::tool(format!(
-                            "DeepReview Task policy violation: {}",
-                            violation.to_tool_error_message()
-                        )));
-                    }
-                });
+                    },
+                );
                 if is_auto_retry {
                     Self::ensure_deep_review_auto_retry_allowed(&conc_policy, &dialog_turn_id)
                         .map_err(|violation| {
@@ -965,40 +994,62 @@ impl Tool for TaskTool {
                         .iter()
                         .any(|id| id == &subagent_type);
                     deep_review_is_optional_reviewer = is_optional_reviewer;
-                    if let Some(guard) = try_begin_deep_review_active_reviewer(
+                    deep_review_launch_batch_info = Self::deep_review_launch_batch_for_task(
+                        &subagent_type,
+                        description.as_deref(),
+                        run_manifest.as_ref(),
+                    );
+                    match Self::try_begin_deep_review_reviewer_admission(
                         &dialog_turn_id,
                         effective_parallel_instances,
+                        deep_review_launch_batch_info.as_ref(),
                     ) {
-                        deep_review_active_guard = Some(guard);
-                    } else {
-                        match Self::wait_for_deep_review_reviewer_capacity(
-                            &session_id,
-                            &dialog_turn_id,
-                            &tool_call_id,
-                            &subagent_type,
-                            &conc_policy,
-                            is_optional_reviewer,
-                        )
-                        .await?
-                        {
-                            DeepReviewQueueWaitOutcome::Ready { guard } => {
-                                deep_review_active_guard = Some(guard);
+                        Ok(Some(guard)) => {
+                            deep_review_active_guard = Some(guard);
+                        }
+                        Ok(None)
+                        | Err(DeepReviewPolicyViolation {
+                            code: "deep_review_launch_batch_blocked",
+                            ..
+                        }) => {
+                            match Self::wait_for_deep_review_reviewer_admission(
+                                &session_id,
+                                &dialog_turn_id,
+                                &tool_call_id,
+                                &subagent_type,
+                                &conc_policy,
+                                is_optional_reviewer,
+                                deep_review_launch_batch_info.as_ref(),
+                            )
+                            .await?
+                            {
+                                DeepReviewQueueWaitOutcome::Ready { guard } => {
+                                    deep_review_active_guard = Some(guard);
+                                }
+                                DeepReviewQueueWaitOutcome::Skipped {
+                                    queue_elapsed_ms,
+                                    skip_reason,
+                                    capacity_reason,
+                                } => {
+                                    return Ok(vec![
+                                        Self::deep_review_local_capacity_skip_tool_result(
+                                            &dialog_turn_id,
+                                            &subagent_type,
+                                            &conc_policy,
+                                            capacity_reason,
+                                            skip_reason,
+                                            queue_elapsed_ms,
+                                            start_time.elapsed().as_millis(),
+                                        ),
+                                    ]);
+                                }
                             }
-                            DeepReviewQueueWaitOutcome::Skipped {
-                                queue_elapsed_ms,
-                                skip_reason,
-                            } => {
-                                return Ok(vec![
-                                    Self::deep_review_local_capacity_skip_tool_result(
-                                        &dialog_turn_id,
-                                        &subagent_type,
-                                        &conc_policy,
-                                        skip_reason,
-                                        queue_elapsed_ms,
-                                        start_time.elapsed().as_millis(),
-                                    ),
-                                ]);
-                            }
+                        }
+                        Err(violation) => {
+                            return Err(BitFunError::tool(format!(
+                                "DeepReview Task policy violation: {}",
+                                violation.to_tool_error_message()
+                            )));
                         }
                     }
                 }
@@ -1171,40 +1222,57 @@ impl Tool for TaskTool {
                                                     &dialog_turn_id,
                                                     conc_policy.max_parallel_instances,
                                                 );
-                                            if let Some(guard) =
-                                                try_begin_deep_review_active_reviewer(
-                                                    &dialog_turn_id,
-                                                    effective_parallel_instances,
-                                                )
-                                            {
-                                                deep_review_active_guard = Some(guard);
-                                            } else {
-                                                match Self::wait_for_deep_review_reviewer_capacity(
-                                                    &session_id,
-                                                    &dialog_turn_id,
-                                                    &tool_call_id,
-                                                    &subagent_type,
-                                                    conc_policy,
-                                                    deep_review_is_optional_reviewer,
-                                                )
-                                                .await?
-                                                {
-                                                    DeepReviewQueueWaitOutcome::Ready { guard } => {
-                                                        deep_review_active_guard = Some(guard);
-                                                    }
-                                                    DeepReviewQueueWaitOutcome::Skipped {
-                                                        queue_elapsed_ms,
-                                                        skip_reason,
-                                                    } => {
-                                                        return Ok(vec![Self::deep_review_local_capacity_skip_tool_result(
-                                                            &dialog_turn_id,
-                                                            &subagent_type,
-                                                            conc_policy,
-                                                            skip_reason,
+                                            match Self::try_begin_deep_review_reviewer_admission(
+                                                &dialog_turn_id,
+                                                effective_parallel_instances,
+                                                deep_review_launch_batch_info.as_ref(),
+                                            ) {
+                                                Ok(Some(guard)) => {
+                                                    deep_review_active_guard = Some(guard);
+                                                }
+                                                Ok(None)
+                                                | Err(DeepReviewPolicyViolation {
+                                                    code: "deep_review_launch_batch_blocked",
+                                                    ..
+                                                }) => {
+                                                    match Self::wait_for_deep_review_reviewer_admission(
+                                                        &session_id,
+                                                        &dialog_turn_id,
+                                                        &tool_call_id,
+                                                        &subagent_type,
+                                                        conc_policy,
+                                                        deep_review_is_optional_reviewer,
+                                                        deep_review_launch_batch_info.as_ref(),
+                                                    )
+                                                    .await?
+                                                    {
+                                                        DeepReviewQueueWaitOutcome::Ready { guard } => {
+                                                            deep_review_active_guard = Some(guard);
+                                                        }
+                                                        DeepReviewQueueWaitOutcome::Skipped {
                                                             queue_elapsed_ms,
-                                                            start_time.elapsed().as_millis(),
-                                                        )]);
+                                                            skip_reason,
+                                                            capacity_reason,
+                                                        } => {
+                                                            return Ok(vec![
+                                                                Self::deep_review_local_capacity_skip_tool_result(
+                                                                    &dialog_turn_id,
+                                                                    &subagent_type,
+                                                                    conc_policy,
+                                                                    capacity_reason,
+                                                                    skip_reason,
+                                                                    queue_elapsed_ms,
+                                                                    start_time.elapsed().as_millis(),
+                                                                ),
+                                                            ]);
+                                                        }
                                                     }
+                                                }
+                                                Err(violation) => {
+                                                    return Err(BitFunError::tool(format!(
+                                                        "DeepReview Task policy violation: {}",
+                                                        violation.to_tool_error_message()
+                                                    )));
                                                 }
                                             }
                                             provider_capacity_retry_reason = Some(reason);
@@ -1542,16 +1610,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn deep_review_capacity_queue_skips_after_max_wait() {
+    async fn deep_review_capacity_queue_waits_while_active_reviewer_is_running() {
         use crate::agentic::deep_review_policy::{
             deep_review_capacity_skip_count, deep_review_concurrency_cap_rejection_count,
             deep_review_effective_parallel_instances, try_begin_deep_review_active_reviewer,
             DeepReviewConcurrencyPolicy,
         };
 
-        let _occupied_a = try_begin_deep_review_active_reviewer("turn-queue-skip", 2)
+        let turn_id = "turn-queue-active-wait";
+        let tool_id = "tool-queue-active-wait";
+        let occupied_a = try_begin_deep_review_active_reviewer(turn_id, 2)
             .expect("precondition should occupy first reviewer capacity");
-        let _occupied_b = try_begin_deep_review_active_reviewer("turn-queue-skip", 2)
+        let occupied_b = try_begin_deep_review_active_reviewer(turn_id, 2)
             .expect("precondition should occupy second reviewer capacity");
         let policy = DeepReviewConcurrencyPolicy {
             max_parallel_instances: 2,
@@ -1561,37 +1631,110 @@ mod tests {
             allow_bounded_auto_retry: false,
             auto_retry_elapsed_guard_seconds: 180,
         };
+        let turn_id_owned = turn_id.to_string();
+        let tool_id_owned = tool_id.to_string();
 
-        let outcome = TaskTool::wait_for_deep_review_reviewer_capacity(
-            "session-queue-skip",
-            "turn-queue-skip",
-            "tool-queue-skip",
-            "ReviewSecurity",
-            &policy,
-            false,
-        )
-        .await
-        .expect("queue wait should resolve");
+        let handle = tokio::spawn(async move {
+            TaskTool::wait_for_deep_review_reviewer_capacity(
+                "session-queue-active-wait",
+                &turn_id_owned,
+                &tool_id_owned,
+                "ReviewSecurity",
+                &policy,
+                false,
+            )
+            .await
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(30)).await;
+        assert!(
+            !handle.is_finished(),
+            "active Deep Review reviewers should keep the queued reviewer alive"
+        );
+
+        drop(occupied_a);
+        drop(occupied_b);
+
+        let outcome = tokio::time::timeout(tokio::time::Duration::from_millis(500), handle)
+            .await
+            .expect("queue should become ready after active reviewers finish")
+            .expect("spawned wait should not panic")
+            .expect("queue wait should resolve");
 
         match outcome {
-            super::DeepReviewQueueWaitOutcome::Skipped {
-                queue_elapsed_ms, ..
-            } => {
-                assert!(queue_elapsed_ms < 100);
-            }
-            super::DeepReviewQueueWaitOutcome::Ready { .. } => {
-                panic!("occupied capacity should skip with maxQueueWaitSeconds=0");
+            super::DeepReviewQueueWaitOutcome::Ready { .. } => {}
+            super::DeepReviewQueueWaitOutcome::Skipped { .. } => {
+                panic!("active Deep Review reviewers should not cause a queue-expired skip");
             }
         }
-        assert_eq!(deep_review_capacity_skip_count("turn-queue-skip"), 1);
-        assert_eq!(
-            deep_review_concurrency_cap_rejection_count("turn-queue-skip"),
-            0
+        assert_eq!(deep_review_capacity_skip_count(turn_id), 0);
+        assert_eq!(deep_review_concurrency_cap_rejection_count(turn_id), 0);
+        assert_eq!(deep_review_effective_parallel_instances(turn_id, 2), 2);
+    }
+
+    #[tokio::test]
+    async fn deep_review_capacity_queue_waits_for_previous_launch_batch_without_lowering_cap() {
+        use crate::agentic::deep_review::task_adapter::DeepReviewLaunchBatchInfo;
+        use crate::agentic::deep_review_policy::{
+            deep_review_capacity_skip_count, deep_review_effective_parallel_instances,
+            try_begin_deep_review_active_reviewer_for_launch_batch, DeepReviewConcurrencyPolicy,
+        };
+
+        let turn_id = "turn-launch-batch-queue-wait";
+        let tool_id = "tool-launch-batch-queue-wait";
+        let occupied =
+            try_begin_deep_review_active_reviewer_for_launch_batch(turn_id, 2, 1, Some("packet-a"))
+                .expect("launch batch admission should not fail")
+                .expect("first batch reviewer should start");
+        let policy = DeepReviewConcurrencyPolicy {
+            max_parallel_instances: 2,
+            stagger_seconds: 0,
+            max_queue_wait_seconds: 0,
+            batch_extras_separately: true,
+            allow_bounded_auto_retry: false,
+            auto_retry_elapsed_guard_seconds: 180,
+        };
+        let launch_batch_info = DeepReviewLaunchBatchInfo {
+            packet_id: Some("packet-b".to_string()),
+            launch_batch: 2,
+        };
+        let turn_id_owned = turn_id.to_string();
+        let tool_id_owned = tool_id.to_string();
+
+        let handle = tokio::spawn(async move {
+            TaskTool::wait_for_deep_review_reviewer_admission(
+                "session-launch-batch-queue-wait",
+                &turn_id_owned,
+                &tool_id_owned,
+                "ReviewSecurity",
+                &policy,
+                false,
+                Some(&launch_batch_info),
+            )
+            .await
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(30)).await;
+        assert!(
+            !handle.is_finished(),
+            "later launch batch should wait while an earlier batch is active"
         );
-        assert_eq!(
-            deep_review_effective_parallel_instances("turn-queue-skip", 2),
-            1
-        );
+        drop(occupied);
+
+        let outcome = tokio::time::timeout(tokio::time::Duration::from_millis(500), handle)
+            .await
+            .expect("later launch batch should become ready after earlier batch finishes")
+            .expect("spawned wait should not panic")
+            .expect("queue wait should resolve");
+
+        match outcome {
+            super::DeepReviewQueueWaitOutcome::Ready { .. } => {}
+            super::DeepReviewQueueWaitOutcome::Skipped { .. } => {
+                panic!("later launch batch should not expire while an earlier batch is active");
+            }
+        }
+        assert_eq!(deep_review_capacity_skip_count(turn_id), 0);
+        assert_eq!(deep_review_effective_parallel_instances(turn_id, 2), 2);
     }
 
     #[tokio::test]
@@ -1707,7 +1850,7 @@ mod tests {
 
         let turn_id = "turn-queue-pause";
         let tool_id = "tool-queue-pause";
-        let _occupied = try_begin_deep_review_active_reviewer(turn_id, 1)
+        let occupied = try_begin_deep_review_active_reviewer(turn_id, 1)
             .expect("precondition should occupy reviewer capacity");
         apply_deep_review_queue_control(turn_id, tool_id, DeepReviewQueueControlAction::Pause);
         let policy = DeepReviewConcurrencyPolicy {
@@ -1740,19 +1883,22 @@ mod tests {
         );
 
         apply_deep_review_queue_control(turn_id, tool_id, DeepReviewQueueControlAction::Continue);
+        tokio::time::sleep(tokio::time::Duration::from_millis(30)).await;
+        assert!(
+            !handle.is_finished(),
+            "continued queue wait should stay alive while reviewer capacity is still active"
+        );
+        drop(occupied);
+
         let outcome = tokio::time::timeout(tokio::time::Duration::from_millis(500), handle)
             .await
             .expect("continued queue wait should finish")
             .expect("spawned wait should not panic")
             .expect("queue wait should resolve");
         match outcome {
-            super::DeepReviewQueueWaitOutcome::Skipped {
-                queue_elapsed_ms, ..
-            } => {
-                assert!(queue_elapsed_ms < 100);
-            }
-            super::DeepReviewQueueWaitOutcome::Ready { .. } => {
-                panic!("occupied capacity should skip after pause is continued");
+            super::DeepReviewQueueWaitOutcome::Ready { .. } => {}
+            super::DeepReviewQueueWaitOutcome::Skipped { .. } => {
+                panic!("continued queue wait should run after reviewer capacity frees");
             }
         }
     }

--- a/src/crates/core/src/agentic/tools/mod.rs
+++ b/src/crates/core/src/agentic/tools/mod.rs
@@ -9,6 +9,7 @@ pub mod framework;
 pub mod image_context;
 pub mod implementations;
 pub mod pipeline;
+pub(crate) mod post_call_hooks;
 pub mod registry;
 pub mod restrictions;
 pub mod user_input_manager;

--- a/src/crates/core/src/agentic/tools/post_call_hooks.rs
+++ b/src/crates/core/src/agentic/tools/post_call_hooks.rs
@@ -1,0 +1,17 @@
+//! Post-call hooks for generic tool execution.
+//!
+//! The tool framework stays generic and calls this module after successful
+//! tool execution. Domain-specific hooks must keep their own gating inside the
+//! owning domain module.
+
+use crate::agentic::deep_review::tool_measurement;
+use crate::agentic::tools::framework::ToolUseContext;
+use serde_json::Value;
+
+pub(crate) fn record_successful_tool_call(
+    tool_name: &str,
+    input: &Value,
+    context: &ToolUseContext,
+) {
+    tool_measurement::maybe_record_shared_context_tool_use(tool_name, input, context);
+}

--- a/src/crates/events/src/agentic.rs
+++ b/src/crates/events/src/agentic.rs
@@ -37,6 +37,7 @@ pub enum DeepReviewQueueReason {
     ProviderConcurrencyLimit,
     RetryAfter,
     LocalConcurrencyCap,
+    LaunchBatchBlocked,
     TemporaryOverload,
 }
 

--- a/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx
@@ -297,6 +297,8 @@ export const BtwSessionPanel: React.FC<BtwSessionPanelProps> = ({
   const actionBarChildSessionId = useReviewActionBarStore((s) => s.childSessionId);
   const actionBarCompletedIds = useReviewActionBarStore((s) => s.completedRemediationIds);
   const actionBarRemediationItems = useReviewActionBarStore((s) => s.remediationItems);
+  const actionBarSelectedIds = useReviewActionBarStore((s) => s.selectedRemediationIds);
+  const actionBarFixingIds = useReviewActionBarStore((s) => s.fixingRemediationIds);
   const actionBarLastSubmittedAction = useReviewActionBarStore((s) => s.lastSubmittedAction);
   const isDeepReview = childKind === 'deep_review';
   const isReviewSession = childKind === 'review' || childKind === 'deep_review';
@@ -329,6 +331,14 @@ export const BtwSessionPanel: React.FC<BtwSessionPanelProps> = ({
 
   const remainingCount = actionBarRemediationItems.length - actionBarCompletedIds.size;
   const totalCount = actionBarRemediationItems.length;
+  const fixScopedIds = actionBarFixingIds.size > 0 ? actionBarFixingIds : actionBarSelectedIds;
+  const fixScopedCompletedCount = [...fixScopedIds].filter((id) => actionBarCompletedIds.has(id)).length;
+  const minimizedCountLabel = (
+    ['fix_running', 'fix_completed', 'fix_failed', 'fix_timeout', 'fix_interrupted'].includes(actionBarPhase) &&
+    fixScopedIds.size > 0
+  )
+    ? `${fixScopedCompletedCount}/${fixScopedIds.size}`
+    : `${remainingCount}/${totalCount}`;
   const minimizedActionLabel = useMemo(() => {
     switch (actionBarPhase) {
       case 'fix_running':
@@ -404,6 +414,16 @@ export const BtwSessionPanel: React.FC<BtwSessionPanelProps> = ({
 
     // Only activate if the action bar is idle or not yet shown for this session
     if (store.childSessionId === childSessionId && store.phase !== 'idle') {
+      // A fix request briefly coexists with the previous completed review turn
+      // until FlowChatManager creates the new fix turn; ignore that stale terminal state.
+      const currentFixTurnHasStarted = store.phase !== 'fix_running' ||
+        !store.fixingBaselineTurnId ||
+        lastTurn?.id !== store.fixingBaselineTurnId;
+
+      if (store.phase === 'fix_running' && !currentFixTurnHasStarted && (isComplete || isError)) {
+        return;
+      }
+
       // Update phase based on turn status if currently showing
       if (isError && store.phase === 'resume_running') {
         store.updatePhase('resume_failed', childSession.error ?? undefined);
@@ -721,7 +741,7 @@ export const BtwSessionPanel: React.FC<BtwSessionPanelProps> = ({
               </span>
               {totalCount > 0 && (
                 <span className="btw-session-panel__minimized-count">
-                  {remainingCount}/{totalCount}
+                  {minimizedCountLabel}
                 </span>
               )}
             </button>

--- a/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.i18n.test.ts
+++ b/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.i18n.test.ts
@@ -33,20 +33,43 @@ const REQUIRED_ACTION_BAR_KEYS = [
   'deepReviewActionBar.fixInterrupted',
   'deepReviewActionBar.continueFix',
   'deepReviewActionBar.skipRemaining',
+  'deepReviewActionBar.decisionGate.title',
+  'deepReviewActionBar.decisionGate.description',
+  'deepReviewActionBar.decisionGate.supplementLabel',
+  'deepReviewActionBar.decisionGate.supplementPlaceholder',
+  'deepReviewActionBar.decisionGate.missingSelection',
+  'deepReviewActionBar.decisionGate.noOptionsHint',
+  'deepReviewActionBar.decisionGate.confirmFix',
+  'deepReviewActionBar.decisionGate.confirmFixAndReview',
+  'deepReviewActionBar.decisionGate.cancel',
   'deepReviewActionBar.switchModel',
   'deepReviewActionBar.capacityQueue.title',
   'deepReviewActionBar.capacityQueue.pausedTitle',
   'deepReviewActionBar.capacityQueue.detail',
   'deepReviewActionBar.capacityQueue.sessionBusy',
+  'deepReviewActionBar.capacityQueue.waitingReviewersTitle',
+  'deepReviewActionBar.capacityQueue.reviewerStatusQueued',
+  'deepReviewActionBar.capacityQueue.reviewerStatusPaused',
+  'deepReviewActionBar.capacityQueue.optionalReviewer',
   'deepReviewActionBar.capacityQueue.pauseQueue',
   'deepReviewActionBar.capacityQueue.continueQueue',
   'deepReviewActionBar.capacityQueue.cancelQueued',
   'deepReviewActionBar.capacityQueue.skipOptionalQueued',
   'deepReviewActionBar.capacityQueue.runSlowerNextTime',
   'deepReviewActionBar.capacityQueue.openReviewSettings',
+  'deepReviewActionBar.capacityQueue.reasons.launchBatchBlocked',
+  'deepReviewActionBar.capacityQueue.reasonDetails.providerRateLimit',
+  'deepReviewActionBar.capacityQueue.reasonDetails.providerConcurrencyLimit',
+  'deepReviewActionBar.capacityQueue.reasonDetails.retryAfter',
+  'deepReviewActionBar.capacityQueue.reasonDetails.localConcurrencyCap',
+  'deepReviewActionBar.capacityQueue.reasonDetails.launchBatchBlocked',
+  'deepReviewActionBar.capacityQueue.reasonDetails.temporaryOverload',
   'deepReviewActionBar.capacityQueue.runSlowerSaved',
   'deepReviewActionBar.capacityQueue.runSlowerFailed',
+  'deepReviewActionBar.capacityQueue.runSlowerFailedWithReason',
   'deepReviewActionBar.capacityQueue.controlFailed',
+  'deepReviewActionBar.capacityQueue.controlFailedWithReason',
+  'deepReviewActionBar.capacityQueue.controlPartiallyFailedWithReason',
   'reviewActionBar.noIssuesFound',
 ];
 
@@ -66,6 +89,10 @@ const REQUIRED_CODE_REVIEW_CARD_KEYS = [
   'toolCards.codeReview.reviewerStatuses.running',
   'toolCards.codeReview.reviewerStatuses.partial',
   'toolCards.codeReview.reviewerStatuses.unknown',
+];
+
+const USER_VISIBLE_TEXT_KEYS_MUST_NOT_CONTAIN_ESCAPED_UNICODE = [
+  'toolCards.codeReview.remediationActions.fixAndReview',
 ];
 
 const REQUIRED_REVIEW_TEAM_PAGE_KEYS = [
@@ -108,6 +135,16 @@ describe('DeepReviewActionBar i18n', () => {
       });
 
       expect(missingKeys, `${locale} missing keys`).toEqual([]);
+    }
+  });
+
+  it('does not show escaped unicode sequences in user-visible action text', () => {
+    for (const [locale, messages] of Object.entries(LOCALES)) {
+      for (const key of USER_VISIBLE_TEXT_KEYS_MUST_NOT_CONTAIN_ESCAPED_UNICODE) {
+        const value = getMessageValue(messages, key);
+        expect(typeof value, `${locale} ${key} should be a string`).toBe('string');
+        expect(value, `${locale} ${key} should not contain literal unicode escape text`).not.toMatch(/\\u[0-9a-fA-F]{4}/);
+      }
     }
   });
 

--- a/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.scss
+++ b/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.scss
@@ -66,7 +66,7 @@
     right: 8px;
     display: flex;
     align-items: center;
-    gap: 3px;
+    gap: 4px;
   }
 
   &__controls-divider {
@@ -81,8 +81,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
-    height: 24px;
+    width: 28px;
+    height: 28px;
     border-radius: 5px;
     background: transparent;
     border: none;
@@ -99,12 +99,12 @@
   &__controls .code-review-report-actions {
     display: inline-flex;
     align-items: center;
-    gap: 1px;
+    gap: 4px;
   }
 
   &__controls .code-review-report-actions__button {
-    width: 24px;
-    height: 24px;
+    width: 28px;
+    height: 28px;
     padding: 0;
     border: none;
     border-radius: 5px;
@@ -129,7 +129,7 @@
     display: flex;
     align-items: center;
     gap: 6px;
-    padding-right: 90px;
+    padding-right: 136px;
   }
 
   &__icon {
@@ -240,8 +240,25 @@
       background: var(--element-bg-subtle);
     }
 
-    .checkbox {
-      pointer-events: none;
+    .bitfun-checkbox {
+      width: 100%;
+      align-items: center;
+    }
+
+    .bitfun-checkbox__wrapper {
+      margin-top: 0;
+    }
+
+    .bitfun-checkbox__content {
+      min-width: 0;
+    }
+
+    .bitfun-checkbox__label {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+      width: 100%;
     }
   }
 
@@ -288,12 +305,42 @@
         color: var(--color-text-muted);
       }
     }
+
+    &--fixing {
+      background: color-mix(in srgb, var(--color-accent-500, #60a5fa) 8%, transparent);
+    }
+
+    &--locked {
+      cursor: default;
+    }
   }
 
   &__completed-icon {
     color: var(--color-success, #22c55e);
     margin-right: 4px;
     flex-shrink: 0;
+    vertical-align: text-bottom;
+  }
+
+  &__fixing-icon {
+    color: var(--color-accent-500, #60a5fa);
+    margin-right: 4px;
+    flex-shrink: 0;
+    vertical-align: text-bottom;
+    animation: deep-review-action-bar-spin 1s linear infinite;
+  }
+
+  &__remediation-status {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 5px;
+    padding: 1px 5px;
+    border-radius: 4px;
+    background: var(--element-bg-subtle);
+    color: var(--color-text-muted);
+    font-size: 10px;
+    font-weight: 500;
+    line-height: 1.3;
     vertical-align: text-bottom;
   }
 
@@ -445,6 +492,172 @@
   &__empty-selection-icon {
     flex-shrink: 0;
     color: var(--color-warning, #f59e0b);
+  }
+
+  /* Execution decision gate */
+  &__decision-gate {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px 12px;
+    border: 1px solid color-mix(in srgb, var(--color-warning, #f59e0b) 28%, var(--border-base));
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--color-bg-primary) 74%, var(--color-warning, #f59e0b) 8%);
+  }
+
+  &__decision-gate-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  &__decision-gate-icon {
+    flex-shrink: 0;
+    margin-top: 2px;
+    color: var(--color-warning, #f59e0b);
+  }
+
+  &__decision-gate-title {
+    color: var(--color-text-primary);
+    font-size: 13px;
+    font-weight: 650;
+  }
+
+  &__decision-gate-desc {
+    margin-top: 2px;
+    color: var(--color-text-secondary);
+    font-size: 12px;
+    line-height: 1.45;
+  }
+
+  &__decision-gate-items {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__decision-card {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 9px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 7px;
+    background: color-mix(in srgb, var(--color-bg-elevated) 72%, transparent);
+  }
+
+  &__decision-question {
+    color: var(--color-text-primary);
+    font-weight: 600;
+    line-height: 1.45;
+  }
+
+  &__decision-plan,
+  &__decision-tradeoffs,
+  &__decision-gate-note,
+  &__decision-gate-warning {
+    color: var(--color-text-secondary);
+    font-size: 12px;
+    line-height: 1.45;
+  }
+
+  &__decision-tradeoffs {
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  &__decision-gate-options {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  &__decision-gate-option {
+    display: flex;
+    align-items: flex-start;
+    gap: 7px;
+    width: 100%;
+    padding: 7px 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--color-text-secondary);
+    font-size: 12px;
+    line-height: 1.45;
+    text-align: left;
+    cursor: pointer;
+    transition:
+      background 160ms ease,
+      border-color 160ms ease,
+      color 160ms ease;
+
+    &:hover {
+      background: var(--element-bg-subtle);
+      border-color: var(--border-medium);
+      color: var(--color-text-primary);
+    }
+
+    &.is-selected {
+      border-color: color-mix(in srgb, var(--color-accent-500, #60a5fa) 62%, var(--border-medium));
+      background: color-mix(in srgb, var(--color-accent-500, #60a5fa) 12%, transparent);
+      color: var(--color-text-primary);
+    }
+
+    &.is-recommended .deep-review-action-bar__decision-gate-option-text {
+      font-weight: 600;
+    }
+  }
+
+  &__decision-gate-option-marker {
+    flex-shrink: 0;
+    color: var(--color-accent-500, #60a5fa);
+  }
+
+  &__decision-gate-option-text {
+    min-width: 0;
+    word-break: break-word;
+  }
+
+  &__decision-gate-supplement {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    color: var(--color-text-secondary);
+    font-size: 12px;
+  }
+
+  &__decision-gate-supplement textarea {
+    width: 100%;
+    min-height: 52px;
+    max-height: 120px;
+    padding: 8px 10px;
+    border: 1px solid var(--border-base);
+    border-radius: 7px;
+    background: var(--color-bg-primary);
+    color: var(--color-text-primary);
+    font-size: 12px;
+    line-height: 1.5;
+    resize: vertical;
+
+    &::placeholder {
+      color: var(--color-text-muted);
+    }
+
+    &:focus {
+      outline: none;
+      border-color: var(--color-accent-500, #60a5fa);
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent-500, #60a5fa) 20%, transparent);
+    }
+  }
+
+  &__decision-gate-warning {
+    color: color-mix(in srgb, var(--color-warning, #f59e0b) 82%, var(--color-text-primary));
+  }
+
+  &__decision-gate-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
   }
 
   /* No issues found */
@@ -602,8 +815,8 @@
     justify-content: space-between;
     gap: 10px;
     padding: 8px 10px;
-    border-radius: 6px;
-    border: 1px solid color-mix(in srgb, var(--color-warning, #f59e0b) 30%, var(--border-base));
+    border-left: 2px solid color-mix(in srgb, var(--color-warning, #f59e0b) 56%, var(--border-base));
+    border-radius: 0 6px 6px 0;
     background: color-mix(in srgb, var(--color-warning, #f59e0b) 8%, var(--deep-review-action-bar-surface));
   }
 
@@ -655,6 +868,48 @@
     background: color-mix(in srgb, var(--color-warning, #f59e0b) 10%, transparent);
     color: var(--color-text-secondary);
     line-height: 1.35;
+  }
+
+  &__capacity-queue-reviewers {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    margin-top: 4px;
+  }
+
+  &__capacity-queue-reviewers-title {
+    color: var(--color-text-secondary);
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  &__capacity-queue-reviewer-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  &__capacity-queue-reviewer {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 22px;
+    max-width: 100%;
+    padding: 2px 7px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--color-bg-primary) 72%, transparent);
+    color: var(--color-text-secondary);
+    line-height: 1.35;
+  }
+
+  &__capacity-queue-reviewer-name {
+    color: var(--color-text-primary);
+    font-weight: 600;
+  }
+
+  &__capacity-queue-reviewer-meta {
+    color: var(--color-text-muted);
+    font-size: 12px;
   }
 
   &__capacity-queue-actions {

--- a/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.test.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.test.tsx
@@ -46,12 +46,32 @@ vi.mock('@/component-library', () => ({
   ),
   Checkbox: ({
     checked,
+    disabled,
+    indeterminate,
+    label,
     onChange,
   }: {
     checked?: boolean;
+    disabled?: boolean;
+    indeterminate?: boolean;
+    label?: React.ReactNode;
     onChange?: () => void;
   }) => (
-    <input type="checkbox" checked={checked} readOnly onClick={onChange} />
+    <label>
+      <input
+        type="checkbox"
+        aria-checked={indeterminate ? 'mixed' : checked ? 'true' : 'false'}
+        checked={checked}
+        disabled={disabled}
+        readOnly
+        onClick={() => {
+          if (!disabled) {
+            onChange?.();
+          }
+        }}
+      />
+      {label}
+    </label>
   ),
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -198,6 +218,18 @@ describeWithJsdom('DeepReviewActionBar', () => {
   it('keeps remediation in progress after submitting a fix turn', async () => {
     const { DeepReviewActionBar } = await import('./DeepReviewActionBar');
 
+    flowChatSessionsMock.set('child-session', {
+      sessionId: 'child-session',
+      sessionKind: 'review',
+      dialogTurns: [
+        {
+          id: 'review-turn-1',
+          status: 'completed',
+          modelRounds: [],
+        },
+      ],
+    });
+
     useReviewActionBarStore.getState().showActionBar({
       childSessionId: 'child-session',
       parentSessionId: 'parent-session',
@@ -231,7 +263,15 @@ describeWithJsdom('DeepReviewActionBar', () => {
     });
 
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
-    expect(useReviewActionBarStore.getState().phase).toBe('fix_running');
+    const state = useReviewActionBarStore.getState();
+    expect(state.phase).toBe('fix_running');
+    expect(state.fixingBaselineTurnId).toBe('review-turn-1');
+    expect(container.textContent).toContain('Fix the incorrect branch.');
+    expect(container.textContent).toContain('Fixing');
+    const itemCheckbox = container.querySelector<HTMLInputElement>(
+      '.deep-review-action-bar__remediation-item input[type="checkbox"]',
+    );
+    expect(itemCheckbox?.disabled).toBe(true);
   });
 
   it('uses standard review mode when starting Code Review remediation', async () => {
@@ -492,9 +532,72 @@ describeWithJsdom('DeepReviewActionBar', () => {
         subagentType: 'ReviewSecurity',
         dialogTurnId: 'turn-queue-1',
         status: 'queued_for_capacity',
-        queuedReviewerCount: 1,
+        queuedReviewerCount: 2,
         activeReviewerCount: 1,
         optionalReviewerCount: 1,
+        controlMode: 'backend',
+        waitingReviewers: [
+          {
+            toolId: 'task-queue-1',
+            subagentType: 'ReviewSecurity',
+            displayName: 'Security reviewer',
+            status: 'queued_for_capacity',
+          },
+          {
+            toolId: 'task-queue-2',
+            subagentType: 'ReviewFrontend',
+            displayName: 'Frontend reviewer',
+            status: 'queued_for_capacity',
+          },
+        ],
+      },
+    });
+
+    await act(async () => {
+      root.render(<DeepReviewActionBar />);
+    });
+
+    const pauseButton = Array.from(container.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('Pause queue'));
+    expect(pauseButton).toBeTruthy();
+
+    await act(async () => {
+      pauseButton!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(controlDeepReviewQueueMock).toHaveBeenCalledTimes(2);
+    expect(controlDeepReviewQueueMock).toHaveBeenCalledWith({
+      sessionId: 'child-session',
+      dialogTurnId: 'turn-queue-1',
+      toolId: 'task-queue-1',
+      action: 'pause',
+    });
+    expect(controlDeepReviewQueueMock).toHaveBeenCalledWith({
+      sessionId: 'child-session',
+      dialogTurnId: 'turn-queue-1',
+      toolId: 'task-queue-2',
+      action: 'pause',
+    });
+    expect((useReviewActionBarStore.getState() as unknown as {
+      capacityQueueState: { status: string };
+    }).capacityQueueState.status).toBe('paused_by_user');
+  });
+
+  it('shows the backend reason when queue control fails', async () => {
+    const { DeepReviewActionBar } = await import('./DeepReviewActionBar');
+    const { notificationService } = await import('@/shared/notification-system');
+    controlDeepReviewQueueMock.mockRejectedValueOnce(new Error('backend queue already closed'));
+
+    useReviewActionBarStore.getState().showCapacityQueueBar({
+      childSessionId: 'child-session',
+      parentSessionId: 'parent-session',
+      capacityQueueState: {
+        toolId: 'task-queue-1',
+        subagentType: 'ReviewSecurity',
+        dialogTurnId: 'turn-queue-1',
+        status: 'queued_for_capacity',
+        queuedReviewerCount: 1,
         controlMode: 'backend',
       },
     });
@@ -512,15 +615,109 @@ describeWithJsdom('DeepReviewActionBar', () => {
       await Promise.resolve();
     });
 
-    expect(controlDeepReviewQueueMock).toHaveBeenCalledWith({
-      sessionId: 'child-session',
-      dialogTurnId: 'turn-queue-1',
-      toolId: 'task-queue-1',
-      action: 'pause',
+    expect(notificationService.error).toHaveBeenCalledWith(
+      expect.stringContaining('backend queue already closed'),
+    );
+    expect(notificationService.error).toHaveBeenCalledWith(
+      expect.stringContaining('use Stop to interrupt the review'),
+    );
+  });
+
+  it('reports partial backend queue control failures without claiming full success', async () => {
+    const { DeepReviewActionBar } = await import('./DeepReviewActionBar');
+    const { notificationService } = await import('@/shared/notification-system');
+    controlDeepReviewQueueMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('tool already running'));
+
+    useReviewActionBarStore.getState().showCapacityQueueBar({
+      childSessionId: 'child-session',
+      parentSessionId: 'parent-session',
+      capacityQueueState: {
+        toolId: 'task-queue-1',
+        subagentType: 'ReviewSecurity',
+        dialogTurnId: 'turn-queue-1',
+        status: 'queued_for_capacity',
+        queuedReviewerCount: 2,
+        controlMode: 'backend',
+        waitingReviewers: [
+          {
+            toolId: 'task-queue-1',
+            subagentType: 'ReviewSecurity',
+            displayName: 'Security reviewer',
+            status: 'queued_for_capacity',
+          },
+          {
+            toolId: 'task-queue-2',
+            subagentType: 'ReviewFrontend',
+            displayName: 'Frontend reviewer',
+            status: 'queued_for_capacity',
+          },
+        ],
+      },
     });
+
+    await act(async () => {
+      root.render(<DeepReviewActionBar />);
+    });
+
+    const pauseButton = Array.from(container.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('Pause queue'));
+    expect(pauseButton).toBeTruthy();
+
+    await act(async () => {
+      pauseButton!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(controlDeepReviewQueueMock).toHaveBeenCalledTimes(2);
+    expect(notificationService.error).toHaveBeenCalledWith(
+      expect.stringContaining('1 of 2 reviewers failed'),
+    );
+    expect(notificationService.error).toHaveBeenCalledWith(
+      expect.stringContaining('tool already running'),
+    );
     expect((useReviewActionBarStore.getState() as unknown as {
       capacityQueueState: { status: string };
-    }).capacityQueueState.status).toBe('paused_by_user');
+    }).capacityQueueState.status).toBe('queued_for_capacity');
+  });
+
+  it('shows the settings update reason when run-slower fails', async () => {
+    const { DeepReviewActionBar } = await import('./DeepReviewActionBar');
+    const { notificationService } = await import('@/shared/notification-system');
+    lowerDefaultReviewTeamMaxParallelReviewersMock.mockRejectedValueOnce(
+      new Error('config store unavailable'),
+    );
+
+    useReviewActionBarStore.getState().showCapacityQueueBar({
+      childSessionId: 'child-session',
+      parentSessionId: 'parent-session',
+      capacityQueueState: {
+        status: 'queued_for_capacity',
+        reason: 'local_concurrency_cap',
+        queuedReviewerCount: 1,
+      },
+    });
+
+    await act(async () => {
+      root.render(<DeepReviewActionBar />);
+    });
+
+    const runSlowerButton = Array.from(container.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('Run slower next time'));
+    expect(runSlowerButton).toBeTruthy();
+
+    await act(async () => {
+      runSlowerButton!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(notificationService.error).toHaveBeenCalledWith(
+      expect.stringContaining('config store unavailable'),
+    );
+    expect(notificationService.error).toHaveBeenCalledWith(
+      expect.stringContaining('Open Review settings'),
+    );
   });
 
   it('starts a structured retry turn for explicit incomplete Deep Review slices', async () => {
@@ -633,6 +830,78 @@ describeWithJsdom('DeepReviewActionBar', () => {
     });
 
     expect(container.textContent).toContain('Fixing and preparing re-review...');
+  });
+
+  it('requires explicit decision confirmation before executing selected decision remediation', async () => {
+    const { DeepReviewActionBar } = await import('./DeepReviewActionBar');
+
+    useReviewActionBarStore.getState().showActionBar({
+      childSessionId: 'child-session',
+      parentSessionId: 'parent-session',
+      reviewData: {
+        review_mode: 'deep',
+        summary: { recommended_action: 'request_changes' },
+        report_sections: {
+          remediation_groups: {
+            needs_decision: [{
+              question: 'Which migration strategy should we use?',
+              plan: 'Choose a migration strategy before editing.',
+              options: ['Fast path', 'Staged path'],
+              tradeoffs: 'Fast path is risky; staged path is safer.',
+              recommendation: 1,
+            }],
+          },
+        },
+      },
+      phase: 'review_completed',
+    });
+    useReviewActionBarStore.getState().setSelectedRemediationIds(new Set(['remediation-needs_decision-0']));
+
+    await act(async () => {
+      root.render(<DeepReviewActionBar />);
+    });
+
+    const startFixButton = Array.from(container.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('Start fixing'));
+    expect(startFixButton).toBeTruthy();
+
+    await act(async () => {
+      startFixButton!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('Confirm decision items before fixing');
+    expect(container.textContent).toContain('Which migration strategy should we use?');
+    expect(container.textContent).toContain('Fast path is risky; staged path is safer.');
+
+    const confirmBeforeSelection = Array.from(container.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('Confirm and start')) as HTMLButtonElement | undefined;
+    expect(confirmBeforeSelection?.disabled).toBe(true);
+
+    const stagedPathButton = Array.from(container.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('Staged path'));
+    expect(stagedPathButton).toBeTruthy();
+
+    await act(async () => {
+      stagedPathButton!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    const confirmButton = Array.from(container.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('Confirm and start')) as HTMLButtonElement | undefined;
+    expect(confirmButton).toBeTruthy();
+    expect(confirmButton?.disabled).toBe(false);
+
+    await act(async () => {
+      confirmButton!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    const [prompt] = sendMessageMock.mock.calls[0];
+    expect(prompt).toContain('User chose option 2: Staged path');
+    expect(prompt).not.toContain('Recommended option 2: Staged path');
   });
 
   it('marks completed remediation items when fix completes', async () => {

--- a/src/web-ui/src/flow_chat/deep-review/AGENTS.md
+++ b/src/web-ui/src/flow_chat/deep-review/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Scope
+
+This file applies to DeepReview launch, report, queue, and action UI code.
+
+## Local rules
+
+- The frontend resolves targets, builds the review-team manifest, and owns
+  consent/action UI.
+- The backend validates and executes the manifest; do not duplicate runtime
+  policy in components.
+- Keep `src/shared/services/review-team`, launch services, `AgentAPI`, action
+  state, report rendering, and locales in sync.
+- Work packets and evidence packs are metadata-only; do not embed file contents,
+  full diffs, raw provider bodies, or model output.
+- Use infrastructure APIs such as `agentAPI`; do not call Tauri directly from UI
+  components.

--- a/src/web-ui/src/flow_chat/deep-review/CONTRIBUTING.md
+++ b/src/web-ui/src/flow_chat/deep-review/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# DeepReview Frontend Contributions
+
+Use this guide for frontend DeepReview changes in `src/web-ui`.
+
+- Keep launch, manifest building, queue UI, report rendering, and remediation
+  actions aligned with backend contracts.
+- Keep review-team types/defaults, event mapping, action-bar state, report
+  components, and locale strings in sync.
+- Keep manifest planning metadata-only; never include source text or full diffs.
+- Use infrastructure APIs instead of direct Tauri calls from components.
+- Verify with the narrowest matching web checks for the files touched.

--- a/src/web-ui/src/flow_chat/deep-review/README.md
+++ b/src/web-ui/src/flow_chat/deep-review/README.md
@@ -7,7 +7,7 @@ This directory owns Flow Chat integration for Deep Review. Keep the historical i
 | Area | Owns | Should not own |
 |---|---|---|
 | `launch/` | Slash command parsing, review target resolution, launch prompt formatting, launch error shaping, child-session launch orchestration. | Review Team manifest policy internals, direct Tauri calls, action-bar state. |
-| `action-bar/` | Shared review action bar rendering, Deep Review queue notice, recovery/remediation UI, compact status/header formatting. | Launch target parsing, report markdown semantics, backend queue classification. |
+| `action-bar/` | Shared review action bar rendering, Deep Review queue notice, partial-results panel, recovery-plan preview, remediation selection, action controls, diagnostics text building, compact status/header formatting. | Launch target parsing, report markdown semantics, backend queue classification. |
 | `report/` | Code review report types, retryable slice extraction, reliability notices, run-manifest markdown sections, report section normalization, markdown export. | UI rendering, session launch, raw source/diff/model output storage. |
 
 ## Guardrails
@@ -21,7 +21,7 @@ This directory owns Flow Chat integration for Deep Review. Keep the historical i
 ## Focused Verification
 
 ```powershell
-pnpm --dir src/web-ui exec vitest run src/flow_chat/services/DeepReviewService.test.ts src/flow_chat/components/btw/DeepReviewActionBar.test.tsx src/flow_chat/utils/codeReviewReport.test.ts
+pnpm --dir src/web-ui exec vitest run src/flow_chat/services/DeepReviewService.test.ts src/flow_chat/deep-review/action-bar/PartialResultsPanel.test.tsx src/flow_chat/deep-review/action-bar/RecoveryPlanPreview.test.tsx src/flow_chat/deep-review/action-bar/RemediationSelectionPanel.test.tsx src/flow_chat/deep-review/action-bar/ReviewActionControls.test.tsx src/flow_chat/deep-review/action-bar/interruptionDiagnostics.test.ts src/flow_chat/components/btw/DeepReviewActionBar.test.tsx src/flow_chat/utils/codeReviewReport.test.ts
 pnpm run type-check:web
 pnpm run lint:web
 ```

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/CapacityQueueNotice.test.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/CapacityQueueNotice.test.tsx
@@ -6,6 +6,9 @@ import { CapacityQueueNotice } from './CapacityQueueNotice';
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (_key: string, options?: Record<string, unknown> & { defaultValue?: string }) => {
+      if (_key === 'deepReviewActionBar.capacityQueue.reasons.launchBatchBlocked') {
+        return 'previous launch batch still running';
+      }
       const template = options?.defaultValue ?? _key;
       return template.replace(/{{(\w+)}}/g, (_match, token: string) => String(options?.[token] ?? _match));
     },
@@ -46,10 +49,79 @@ describe('CapacityQueueNotice', () => {
     expect(html).toContain('Reviewers waiting for capacity');
     expect(html).toContain('Queue wait does not count against reviewer runtime.');
     expect(html).toContain('Reason: provider concurrency limit');
+    expect(html).toContain('The model provider rejected another concurrent reviewer.');
     expect(html).toContain('Waited 12s of 1m 0s');
     expect(html).toContain('Pause queue');
     expect(html).toContain('Skip optional extras');
     expect(html).toContain('Run slower next time');
+  });
+
+  it('renders launch-batch waiting as a concrete queue reason', () => {
+    const html = renderToStaticMarkup(
+      <CapacityQueueNotice
+        capacityQueueState={{
+          status: 'queued_for_capacity',
+          reason: 'launch_batch_blocked',
+          queuedReviewerCount: 1,
+          activeReviewerCount: 2,
+          queueElapsedMs: 4_000,
+          maxQueueWaitSeconds: 60,
+        }}
+        supportsInlineQueueControls
+        onPauseQueue={vi.fn()}
+        onContinueQueue={vi.fn()}
+        onSkipOptionalQueuedReviewers={vi.fn()}
+        onCancelQueuedReviewers={vi.fn()}
+        onRunSlowerNextTime={vi.fn()}
+        onOpenReviewSettings={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('Reason: previous launch batch still running');
+    expect(html).toContain('Waiting preserves the planned review order');
+    expect(html).toContain('Waited 4s of 1m 0s');
+  });
+
+  it('renders the specific reviewers currently waiting', () => {
+    const html = renderToStaticMarkup(
+      <CapacityQueueNotice
+        capacityQueueState={{
+          status: 'queued_for_capacity',
+          reason: 'local_concurrency_cap',
+          queuedReviewerCount: 2,
+          waitingReviewers: [
+            {
+              toolId: 'task-security',
+              subagentType: 'ReviewSecurity',
+              displayName: 'Security reviewer',
+              status: 'queued_for_capacity',
+              reason: 'local_concurrency_cap',
+              queueElapsedMs: 9_000,
+            },
+            {
+              toolId: 'task-frontend',
+              subagentType: 'ReviewFrontend',
+              displayName: 'Frontend reviewer',
+              status: 'paused_by_user',
+              reason: 'launch_batch_blocked',
+            },
+          ],
+        }}
+        supportsInlineQueueControls
+        onPauseQueue={vi.fn()}
+        onContinueQueue={vi.fn()}
+        onSkipOptionalQueuedReviewers={vi.fn()}
+        onCancelQueuedReviewers={vi.fn()}
+        onRunSlowerNextTime={vi.fn()}
+        onOpenReviewSettings={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('Waiting reviewers');
+    expect(html).toContain('Security reviewer');
+    expect(html).toContain('Frontend reviewer');
+    expect(html).toContain('Paused');
+    expect(html).toContain('Waited 9s');
   });
 
   it('renders the stop hint when inline queue controls are unavailable', () => {

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/CapacityQueueNotice.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/CapacityQueueNotice.tsx
@@ -30,8 +30,45 @@ const CAPACITY_QUEUE_REASON_KEYS: Record<DeepReviewCapacityQueueReason, string> 
   provider_concurrency_limit: 'deepReviewActionBar.capacityQueue.reasons.providerConcurrencyLimit',
   retry_after: 'deepReviewActionBar.capacityQueue.reasons.retryAfter',
   local_concurrency_cap: 'deepReviewActionBar.capacityQueue.reasons.localConcurrencyCap',
+  launch_batch_blocked: 'deepReviewActionBar.capacityQueue.reasons.launchBatchBlocked',
   temporary_overload: 'deepReviewActionBar.capacityQueue.reasons.temporaryOverload',
 };
+
+const CAPACITY_QUEUE_REASON_DETAIL_KEYS: Record<DeepReviewCapacityQueueReason, {
+  key: string;
+  defaultValue: string;
+}> = {
+  provider_rate_limit: {
+    key: 'deepReviewActionBar.capacityQueue.reasonDetails.providerRateLimit',
+    defaultValue: 'The model provider is rate-limiting requests. BitFun will wait briefly; reducing Review Team parallel reviewers can help if this repeats.',
+  },
+  provider_concurrency_limit: {
+    key: 'deepReviewActionBar.capacityQueue.reasonDetails.providerConcurrencyLimit',
+    defaultValue: 'The model provider rejected another concurrent reviewer. BitFun will retry after capacity opens; lower reviewer parallelism if it keeps happening.',
+  },
+  retry_after: {
+    key: 'deepReviewActionBar.capacityQueue.reasonDetails.retryAfter',
+    defaultValue: 'The model provider asked BitFun to retry later. Waiting here avoids spending reviewer runtime while the provider cools down.',
+  },
+  local_concurrency_cap: {
+    key: 'deepReviewActionBar.capacityQueue.reasonDetails.localConcurrencyCap',
+    defaultValue: 'The configured Review Team reviewer limit is full. This reviewer will start after an active reviewer finishes.',
+  },
+  launch_batch_blocked: {
+    key: 'deepReviewActionBar.capacityQueue.reasonDetails.launchBatchBlocked',
+    defaultValue: 'An earlier launch batch is still running. Waiting preserves the planned review order and prevents a later batch from overtaking it.',
+  },
+  temporary_overload: {
+    key: 'deepReviewActionBar.capacityQueue.reasonDetails.temporaryOverload',
+    defaultValue: 'The model provider reported temporary overload. BitFun will wait briefly and then continue or mark the reviewer as capacity skipped.',
+  },
+};
+
+function reviewerLabel(
+  reviewer: NonNullable<DeepReviewCapacityQueueState['waitingReviewers']>[number],
+): string {
+  return reviewer.displayName || reviewer.subagentType || 'Reviewer';
+}
 
 export const CapacityQueueNotice: React.FC<CapacityQueueNoticeProps> = ({
   capacityQueueState,
@@ -49,12 +86,18 @@ export const CapacityQueueNotice: React.FC<CapacityQueueNoticeProps> = ({
       defaultValue: capacityQueueState.reason.split('_').join(' '),
     })
     : null;
+  const capacityQueueReasonDetail = capacityQueueState.reason
+    ? t(CAPACITY_QUEUE_REASON_DETAIL_KEYS[capacityQueueState.reason].key, {
+      defaultValue: CAPACITY_QUEUE_REASON_DETAIL_KEYS[capacityQueueState.reason].defaultValue,
+    })
+    : null;
   const capacityQueueElapsedLabel = capacityQueueState.queueElapsedMs !== undefined
     ? formatElapsedTime(capacityQueueState.queueElapsedMs)
     : null;
   const capacityQueueMaxWaitLabel = capacityQueueState.maxQueueWaitSeconds !== undefined
     ? formatElapsedTime(capacityQueueState.maxQueueWaitSeconds * 1000)
     : null;
+  const waitingReviewers = capacityQueueState.waitingReviewers ?? [];
 
   return (
     <div className="deep-review-action-bar__capacity-queue" aria-live="polite">
@@ -101,12 +144,71 @@ export const CapacityQueueNotice: React.FC<CapacityQueueNoticeProps> = ({
               )}
             </span>
           )}
+          {capacityQueueReasonDetail && (
+            <span className="deep-review-action-bar__capacity-queue-detail">
+              {capacityQueueReasonDetail}
+            </span>
+          )}
           {capacityQueueState.sessionConcurrencyHigh && (
             <span className="deep-review-action-bar__capacity-queue-detail">
               {t('deepReviewActionBar.capacityQueue.sessionBusy', {
                 defaultValue: 'Your active session is busy. Pause Deep Review or continue later.',
               })}
             </span>
+          )}
+          {waitingReviewers.length > 0 && (
+            <div className="deep-review-action-bar__capacity-queue-reviewers">
+              <span className="deep-review-action-bar__capacity-queue-reviewers-title">
+                {t('deepReviewActionBar.capacityQueue.waitingReviewersTitle', {
+                  defaultValue: 'Waiting reviewers',
+                })}
+              </span>
+              <div className="deep-review-action-bar__capacity-queue-reviewer-list">
+                {waitingReviewers.map((reviewer) => {
+                  const label = reviewerLabel(reviewer);
+                  const reviewerElapsed = reviewer.queueElapsedMs !== undefined
+                    ? formatElapsedTime(reviewer.queueElapsedMs)
+                    : null;
+                  const statusLabel = reviewer.status === 'paused_by_user'
+                    ? t('deepReviewActionBar.capacityQueue.reviewerStatusPaused', {
+                      defaultValue: 'Paused',
+                    })
+                    : t('deepReviewActionBar.capacityQueue.reviewerStatusQueued', {
+                      defaultValue: 'Waiting',
+                    });
+                  return (
+                    <span
+                      key={reviewer.toolId || reviewer.subagentType || label}
+                      className="deep-review-action-bar__capacity-queue-reviewer"
+                    >
+                      <span className="deep-review-action-bar__capacity-queue-reviewer-name">
+                        {label}
+                      </span>
+                      <span className="deep-review-action-bar__capacity-queue-reviewer-meta">
+                        {statusLabel}
+                        {reviewer.optional && (
+                          <>
+                            {' / '}
+                            {t('deepReviewActionBar.capacityQueue.optionalReviewer', {
+                              defaultValue: 'Optional',
+                            })}
+                          </>
+                        )}
+                        {reviewerElapsed && (
+                          <>
+                            {' / '}
+                            {t('deepReviewActionBar.capacityQueue.elapsed', {
+                              elapsed: reviewerElapsed,
+                              defaultValue: `Waited ${reviewerElapsed}`,
+                            })}
+                          </>
+                        )}
+                      </span>
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
           )}
           {!supportsInlineQueueControls && (
             <span className="deep-review-action-bar__capacity-queue-detail">

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/DecisionExecutionGate.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/DecisionExecutionGate.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/component-library';
+import type { ReviewRemediationItem } from '../../utils/codeReviewRemediation';
+
+interface DecisionExecutionGateProps {
+  items: ReviewRemediationItem[];
+  decisionSelections: Record<string, number>;
+  customInstructions: string;
+  rerunReview: boolean;
+  confirmDisabled: boolean;
+  onSelectDecision: (itemId: string, optionIndex: number) => void;
+  onCustomInstructionsChange: (value: string) => void;
+  onConfirm: () => void | Promise<void>;
+  onCancel: () => void;
+}
+
+export const DecisionExecutionGate: React.FC<DecisionExecutionGateProps> = ({
+  items,
+  decisionSelections,
+  customInstructions,
+  rerunReview,
+  confirmDisabled,
+  onSelectDecision,
+  onCustomInstructionsChange,
+  onConfirm,
+  onCancel,
+}) => {
+  const { t } = useTranslation('flow-chat');
+
+  return (
+    <div className="deep-review-action-bar__decision-gate" role="dialog" aria-modal="false">
+      <div className="deep-review-action-bar__decision-gate-header">
+        <AlertTriangle size={16} className="deep-review-action-bar__decision-gate-icon" />
+        <div>
+          <div className="deep-review-action-bar__decision-gate-title">
+            {t('deepReviewActionBar.decisionGate.title', {
+              defaultValue: 'Confirm decision items before fixing',
+            })}
+          </div>
+          <div className="deep-review-action-bar__decision-gate-desc">
+            {t('deepReviewActionBar.decisionGate.description', {
+              defaultValue: 'Choose how each selected decision should be handled before BitFun starts editing.',
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className="deep-review-action-bar__decision-gate-items">
+        {items.map((item) => {
+          const decision = item.decisionContext;
+          const options = decision?.options ?? [];
+          const selectedOption = decisionSelections[item.id];
+
+          return (
+            <section key={item.id} className="deep-review-action-bar__decision-card">
+              <div className="deep-review-action-bar__decision-question">
+                {decision?.question ?? item.plan}
+              </div>
+              {decision?.plan && decision.plan !== decision.question && (
+                <div className="deep-review-action-bar__decision-plan">
+                  {decision.plan}
+                </div>
+              )}
+              {decision?.tradeoffs && (
+                <div className="deep-review-action-bar__decision-tradeoffs">
+                  {decision.tradeoffs}
+                </div>
+              )}
+              {options.length > 0 ? (
+                <div className="deep-review-action-bar__decision-gate-options">
+                  {options.map((option, optionIndex) => {
+                    const isSelected = selectedOption === optionIndex;
+                    const isRecommended = decision?.recommendation === optionIndex;
+                    return (
+                      <button
+                        key={optionIndex}
+                        type="button"
+                        className={`deep-review-action-bar__decision-gate-option ${
+                          isSelected ? 'is-selected' : ''
+                        } ${isRecommended ? 'is-recommended' : ''}`}
+                        onClick={() => onSelectDecision(item.id, optionIndex)}
+                      >
+                        <span className="deep-review-action-bar__decision-gate-option-marker">
+                          {isSelected ? '\u25CF' : '\u25CB'}
+                        </span>
+                        <span className="deep-review-action-bar__decision-gate-option-text">
+                          {option}
+                          {isRecommended ? ` (${t('toolCards.codeReview.remediationActions.recommended', { defaultValue: 'recommended' })})` : ''}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="deep-review-action-bar__decision-gate-note">
+                  {t('deepReviewActionBar.decisionGate.noOptionsHint', {
+                    defaultValue: 'This item has no structured options. Confirm only if you want the selected plan to be executed as written.',
+                  })}
+                </div>
+              )}
+            </section>
+          );
+        })}
+      </div>
+
+      <label className="deep-review-action-bar__decision-gate-supplement">
+        <span>
+          {t('deepReviewActionBar.decisionGate.supplementLabel', {
+            defaultValue: 'Additional requirements',
+          })}
+        </span>
+        <textarea
+          value={customInstructions}
+          onChange={(event) => onCustomInstructionsChange(event.target.value)}
+          placeholder={t('deepReviewActionBar.decisionGate.supplementPlaceholder', {
+            defaultValue: 'Optional: add constraints, scope limits, or implementation preferences before starting.',
+          })}
+          rows={2}
+        />
+      </label>
+
+      {confirmDisabled && (
+        <div className="deep-review-action-bar__decision-gate-warning" role="note">
+          {t('deepReviewActionBar.decisionGate.missingSelection', {
+            defaultValue: 'Choose an option for each selected decision item before starting.',
+          })}
+        </div>
+      )}
+
+      <div className="deep-review-action-bar__decision-gate-actions">
+        <Button
+          variant="primary"
+          size="small"
+          disabled={confirmDisabled}
+          onClick={() => void onConfirm()}
+        >
+          {t(rerunReview
+            ? 'deepReviewActionBar.decisionGate.confirmFixAndReview'
+            : 'deepReviewActionBar.decisionGate.confirmFix', {
+            defaultValue: rerunReview ? 'Confirm and re-review' : 'Confirm and start',
+          })}
+        </Button>
+        <Button
+          variant="secondary"
+          size="small"
+          onClick={onCancel}
+        >
+          {t('deepReviewActionBar.decisionGate.cancel', {
+            defaultValue: 'Back to selection',
+          })}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/DeepReviewActionBar.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/DeepReviewActionBar.tsx
@@ -6,24 +6,16 @@ import {
   AlertCircle,
   Clock,
   Loader2,
-  ChevronDown,
-  ChevronUp,
   MessageSquare,
-  Play,
-  Copy,
-  Info,
-  SkipForward,
-  RotateCcw,
-  Eye,
 } from 'lucide-react';
-import { Button, Checkbox, Tooltip } from '@/component-library';
+import { Button } from '@/component-library';
 import {
   useReviewActionBarStore,
   type DeepReviewCapacityQueueAction,
+  type DeepReviewCapacityQueueState,
   type ReviewActionPhase,
 } from '../../store/deepReviewActionBarStore';
-import type { ReviewRemediationItem } from '../../utils/codeReviewRemediation';
-import { buildSelectedReviewRemediationPrompt, REMEDIATION_GROUP_ORDER } from '../../utils/codeReviewRemediation';
+import { buildSelectedReviewRemediationPrompt } from '../../utils/codeReviewRemediation';
 import {
   buildDeepReviewRetryPrompt,
   extractDeepReviewRetryableSlices,
@@ -32,7 +24,6 @@ import {
 import { continueDeepReviewSession } from '../../services/DeepReviewContinuationService';
 import { flowChatManager } from '../../services/FlowChatManager';
 import { globalEventBus } from '@/infrastructure/event-bus';
-import { DEEP_REVIEW_SCROLL_TO_EVENT } from '../../events/flowchatNavigation';
 import { notificationService } from '@/shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
 import { getAiErrorPresentation } from '@/shared/ai-errors/aiErrorPresenter';
@@ -53,6 +44,12 @@ import { useSceneStore } from '@/app/stores/sceneStore';
 import type { ConfigTab } from '@/app/scenes/settings/settingsConfig';
 import { formatElapsedTime } from './actionBarFormatting';
 import { CapacityQueueNotice } from './CapacityQueueNotice';
+import { DecisionExecutionGate } from './DecisionExecutionGate';
+import { buildInterruptionDiagnostics } from './interruptionDiagnostics';
+import { PartialResultsPanel } from './PartialResultsPanel';
+import { RemediationSelectionPanel } from './RemediationSelectionPanel';
+import { RecoveryPlanPreview } from './RecoveryPlanPreview';
+import { ReviewActionControls } from './ReviewActionControls';
 import { ReviewActionHeader } from './ReviewActionHeader';
 import '../../components/btw/DeepReviewActionBar.scss';
 
@@ -61,6 +58,47 @@ const log = createLogger('DeepReviewActionBar');
 function openSettingsTab(tab: ConfigTab) {
   useSettingsStore.getState().setActiveTab(tab);
   useSceneStore.getState().openScene('settings');
+}
+
+function normalizeActionErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+  if (typeof error === 'string' && error.trim()) {
+    return error.trim();
+  }
+  return 'unknown error';
+}
+
+function buildCapacityQueueControlToolIds(
+  capacityQueueState: DeepReviewCapacityQueueState,
+  action: DeepReviewCapacityQueueAction,
+): string[] {
+  const waitingReviewers = capacityQueueState.waitingReviewers ?? [];
+  const targetReviewers = action === 'skip_optional'
+    ? waitingReviewers.filter((reviewer) => reviewer.optional)
+    : waitingReviewers;
+  const toolIds = targetReviewers
+    .map((reviewer) => reviewer.toolId)
+    .filter((toolId): toolId is string => Boolean(toolId));
+
+  if (toolIds.length > 0) {
+    return [...new Set(toolIds)];
+  }
+
+  return capacityQueueState.toolId ? [capacityQueueState.toolId] : [];
+}
+
+const stopNestedScrollPropagation = (event: React.WheelEvent | React.TouchEvent) => {
+  event.stopPropagation();
+  if ('nativeEvent' in event && typeof event.nativeEvent.stopImmediatePropagation === 'function') {
+    event.nativeEvent.stopImmediatePropagation();
+  }
+};
+
+interface PendingDecisionAction {
+  rerunReview: boolean;
+  selectedIds: Set<string>;
 }
 
 const PHASE_CONFIG: Record<ReviewActionPhase, {
@@ -83,20 +121,6 @@ const PHASE_CONFIG: Record<ReviewActionPhase, {
   review_error: { icon: AlertTriangle, iconClass: 'deep-review-action-bar__icon--error', variant: 'error' },
 };
 
-const GROUP_PRIORITY_META: Record<RemediationGroupId, { color: string }> = {
-  must_fix: { color: 'var(--color-error, #ef4444)' },
-  should_improve: { color: 'var(--color-warning, #f59e0b)' },
-  needs_decision: { color: 'var(--color-accent-500, #60a5fa)' },
-  verification: { color: 'var(--color-success, #22c55e)' },
-};
-
-const stopNestedScrollPropagation = (event: React.WheelEvent | React.TouchEvent) => {
-  event.stopPropagation();
-  if ('nativeEvent' in event && typeof event.nativeEvent.stopImmediatePropagation === 'function') {
-    event.nativeEvent.stopImmediatePropagation();
-  }
-};
-
 export const ReviewActionBar: React.FC = () => {
   const { t } = useTranslation('flow-chat');
   const store = useReviewActionBarStore();
@@ -114,6 +138,7 @@ export const ReviewActionBar: React.FC = () => {
     errorMessage,
     interruption,
     completedRemediationIds,
+    fixingRemediationIds,
     remainingFixIds,
     decisionSelections,
     capacityQueueState,
@@ -123,12 +148,11 @@ export const ReviewActionBar: React.FC = () => {
   const [showRemediationList, setShowRemediationList] = useState(true);
   const [showPartialResults, setShowPartialResults] = useState(false);
   const [expandedDecisionIds, setExpandedDecisionIds] = useState<Set<string>>(new Set());
+  const [pendingDecisionAction, setPendingDecisionAction] = useState<PendingDecisionAction | null>(null);
   const [elapsedMs, setElapsedMs] = useState(0);
   const [longRunningNotified, setLongRunningNotified] = useState(false);
 
   const selectedCount = selectedRemediationIds.size;
-  const totalCount = remediationItems.length;
-  const allSelected = totalCount > 0 && selectedCount === totalCount;
   const isFixDisabled = activeAction !== null || selectedCount === 0;
   const isDeepReview = reviewMode === 'deep';
   const hasInterruption = isDeepReview && Boolean(interruption);
@@ -137,10 +161,16 @@ export const ReviewActionBar: React.FC = () => {
     Boolean(capacityQueueState) &&
     capacityQueueState?.status !== 'running' &&
     capacityQueueState?.status !== 'capacity_skipped';
+  const backendQueueControlToolIds = useMemo(
+    () => capacityQueueState
+      ? buildCapacityQueueControlToolIds(capacityQueueState, 'cancel')
+      : [],
+    [capacityQueueState],
+  );
   const hasBackendQueueControlTarget = Boolean(
     childSessionId &&
     capacityQueueState?.dialogTurnId &&
-    capacityQueueState?.toolId,
+    backendQueueControlToolIds.length > 0,
   );
   const supportsInlineQueueControls =
     capacityQueueState?.controlMode === 'backend'
@@ -159,27 +189,44 @@ export const ReviewActionBar: React.FC = () => {
       return;
     }
 
-    if (!childSessionId || !capacityQueueState.dialogTurnId || !capacityQueueState.toolId) {
+    const toolIds = buildCapacityQueueControlToolIds(capacityQueueState, action);
+    if (!childSessionId || !capacityQueueState.dialogTurnId || toolIds.length === 0) {
       notificationService.error(t('deepReviewActionBar.capacityQueue.controlFailed', {
-        defaultValue: 'Queue control is unavailable for this reviewer.',
+        defaultValue: 'Queue control is unavailable because this reviewer is missing session, turn, or tool identifiers. Use Stop to interrupt the review, or wait for the queue state to refresh.',
       }));
       return;
     }
 
-    try {
-      await agentAPI.controlDeepReviewQueue({
-        sessionId: childSessionId,
-        dialogTurnId: capacityQueueState.dialogTurnId,
-        toolId: capacityQueueState.toolId,
-        action,
-      });
-      applyLocalAction();
-    } catch (error) {
-      log.warn('Failed to control DeepReview capacity queue', error);
-      notificationService.error(t('deepReviewActionBar.capacityQueue.controlFailed', {
-        defaultValue: 'Queue control failed. Please try again or stop the review.',
+    const dialogTurnId = capacityQueueState.dialogTurnId;
+    const controlResults = await Promise.allSettled(toolIds.map((toolId) => agentAPI.controlDeepReviewQueue({
+      sessionId: childSessionId,
+      dialogTurnId,
+      toolId,
+      action,
+    })));
+    const failedResults = controlResults.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    );
+    if (failedResults.length > 0) {
+      const reason = normalizeActionErrorMessage(failedResults[0].reason);
+      log.warn('Failed to control DeepReview capacity queue', failedResults[0].reason);
+      if (failedResults.length < toolIds.length) {
+        notificationService.error(t('deepReviewActionBar.capacityQueue.controlPartiallyFailedWithReason', {
+          failed: failedResults.length,
+          total: toolIds.length,
+          reason,
+          defaultValue: `Queue control partly applied; ${failedResults.length} of ${toolIds.length} reviewers failed: ${reason}. Wait for the queue state to refresh, then retry or use Stop if it is stuck.`,
+        }));
+        return;
+      }
+      notificationService.error(t('deepReviewActionBar.capacityQueue.controlFailedWithReason', {
+        reason,
+        defaultValue: 'Queue control failed: {{reason}}. Try again, or use Stop to interrupt the review if the queue is stuck.',
       }));
+      return;
     }
+
+    applyLocalAction();
   }, [capacityQueueState, childSessionId, t]);
 
   const handleRunSlowerNextTime = useCallback(async () => {
@@ -191,8 +238,9 @@ export const ReviewActionBar: React.FC = () => {
       }));
     } catch (error) {
       log.warn('Failed to lower DeepReview max parallel reviewers', error);
-      notificationService.error(t('deepReviewActionBar.capacityQueue.runSlowerFailed', {
-        defaultValue: 'Failed to update Review settings.',
+      notificationService.error(t('deepReviewActionBar.capacityQueue.runSlowerFailedWithReason', {
+        reason: normalizeActionErrorMessage(error),
+        defaultValue: 'Failed to update Review settings: {{reason}}. Open Review settings and lower Review Team max parallel reviewers manually.',
       }));
     }
   }, [t]);
@@ -286,25 +334,23 @@ export const ReviewActionBar: React.FC = () => {
   const phaseConfig = PHASE_CONFIG[phase];
   const PhaseIcon = phaseConfig.icon;
 
-  // Group items by priority
-  const groupedItems = useMemo(() => {
-    const groups: Record<string, ReviewRemediationItem[]> = {};
-    for (const item of remediationItems) {
-      const gid = item.groupId ?? 'ungrouped';
-      if (!groups[gid]) groups[gid] = [];
-      groups[gid].push(item);
+  const decisionGateItems = useMemo(() => {
+    if (!pendingDecisionAction) {
+      return [];
     }
-    return groups;
-  }, [remediationItems]);
+    return remediationItems.filter((item) => (
+      pendingDecisionAction.selectedIds.has(item.id) &&
+      item.requiresDecision &&
+      !completedRemediationIds.has(item.id)
+    ));
+  }, [completedRemediationIds, pendingDecisionAction, remediationItems]);
 
-  const groupOrder = useMemo(() => {
-    const ordered: string[] = [];
-    for (const gid of REMEDIATION_GROUP_ORDER) {
-      if (groupedItems[gid]?.length) ordered.push(gid);
-    }
-    if (groupedItems.ungrouped?.length) ordered.push('ungrouped');
-    return ordered;
-  }, [groupedItems]);
+  const decisionGateMissingSelection = useMemo(() => (
+    decisionGateItems.some((item) => (
+      (item.decisionContext?.options?.length ?? 0) > 0 &&
+      decisionSelections[item.id] == null
+    ))
+  ), [decisionGateItems, decisionSelections]);
 
   const handleToggleRemediation = useCallback((id: string) => {
     store.toggleRemediation(id);
@@ -319,10 +365,39 @@ export const ReviewActionBar: React.FC = () => {
     store.toggleGroupRemediation(groupId as RemediationGroupId);
   }, [store]);
 
-  const handleStartFixing = useCallback(async (rerunReview: boolean, overrideSelectedIds?: Set<string>) => {
+  const handleToggleDecisionExpansion = useCallback((id: string) => {
+    setExpandedDecisionIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleStartFixing = useCallback(async (
+    rerunReview: boolean,
+    overrideSelectedIds?: Set<string>,
+    options?: { skipDecisionGate?: boolean },
+  ) => {
     if (!reviewData || !childSessionId) return;
 
     const idsToFix = overrideSelectedIds ?? selectedRemediationIds;
+    const selectedDecisionItems = remediationItems.filter((item) => (
+      idsToFix.has(item.id) &&
+      item.requiresDecision &&
+      !completedRemediationIds.has(item.id)
+    ));
+    if (!options?.skipDecisionGate && selectedDecisionItems.length > 0) {
+      const decisionIds = selectedDecisionItems.map((item) => item.id);
+      setPendingDecisionAction({ rerunReview, selectedIds: new Set(idsToFix) });
+      setShowRemediationList(true);
+      setExpandedDecisionIds((current) => new Set([...current, ...decisionIds]));
+      return;
+    }
+
     const action = rerunReview ? 'fix-review' : 'fix';
     let prompt = buildSelectedReviewRemediationPrompt({
       reviewData,
@@ -339,7 +414,8 @@ export const ReviewActionBar: React.FC = () => {
       prompt = `${prompt}\n\n## User Instructions\n${customInstructions.trim()}`;
     }
 
-    store.setActiveAction(action);
+    const baselineTurnId = childSession?.dialogTurns.at(-1)?.id ?? null;
+    store.setActiveAction(action, { baselineTurnId });
     store.updatePhase('fix_running');
 
     try {
@@ -380,7 +456,21 @@ export const ReviewActionBar: React.FC = () => {
     } finally {
       store.setActiveAction(null);
     }
-  }, [reviewData, childSessionId, selectedRemediationIds, customInstructions, reviewMode, isDeepReview, store, t, completedRemediationIds]);
+  }, [reviewData, childSessionId, childSession, selectedRemediationIds, remediationItems, completedRemediationIds, customInstructions, reviewMode, isDeepReview, store, t]);
+
+  const handleConfirmDecisionGate = useCallback(async () => {
+    if (!pendingDecisionAction || decisionGateMissingSelection) {
+      return;
+    }
+
+    const action = pendingDecisionAction;
+    setPendingDecisionAction(null);
+    await handleStartFixing(action.rerunReview, action.selectedIds, { skipDecisionGate: true });
+  }, [decisionGateMissingSelection, handleStartFixing, pendingDecisionAction]);
+
+  const handleCancelDecisionGate = useCallback(() => {
+    setPendingDecisionAction(null);
+  }, []);
 
   const handleRetryIncompleteSlices = useCallback(async () => {
     if (!childSessionId || retryableSlices.length === 0) return;
@@ -543,52 +633,7 @@ export const ReviewActionBar: React.FC = () => {
     const detail = interruption?.errorDetail;
     if (!detail) return;
 
-    const presentation = getAiErrorPresentation(detail);
-
-    // Prefer the sanitized diagnostics from aiErrorPresenter if available
-    let diagnostics = presentation.diagnostics;
-    if (!diagnostics) {
-      const lines: string[] = [];
-      lines.push(t('deepReviewActionBar.diagnosticsTitle', { defaultValue: '=== Deep Review Interruption Diagnostics ===' }));
-      lines.push('');
-
-      const categoryLabel = t(presentation.titleKey, { defaultValue: presentation.category });
-      const categoryMessage = t(presentation.messageKey, { defaultValue: '' });
-      lines.push(`${t('deepReviewActionBar.diagnosticsErrorType', { defaultValue: 'Error type' })}: ${categoryLabel} (${presentation.category})`);
-      if (categoryMessage) {
-        lines.push(`${t('deepReviewActionBar.diagnosticsDescription', { defaultValue: 'Description' })}: ${categoryMessage}`);
-      }
-      lines.push('');
-
-      if (presentation.actions.length > 0) {
-        const actionLabels = presentation.actions.map((action) => {
-          return t(action.labelKey, { defaultValue: action.code });
-        });
-        lines.push(`${t('deepReviewActionBar.diagnosticsSuggestedActions', { defaultValue: 'Suggested actions' })}: ${actionLabels.join(', ')}`);
-        lines.push('');
-      }
-
-      lines.push(`${t('deepReviewActionBar.diagnosticsTechnicalDetails', { defaultValue: 'Technical details' })}:`);
-      lines.push(`  - category: ${detail.category ?? 'unknown'}`);
-      if (detail.provider) lines.push(`  - provider: ${detail.provider}`);
-      if (detail.providerCode) lines.push(`  - provider code: ${detail.providerCode}`);
-      if (detail.providerMessage) {
-        const msg = detail.providerMessage.length > 500
-          ? `${detail.providerMessage.slice(0, 500)}... [truncated]`
-          : detail.providerMessage;
-        lines.push(`  - provider message: ${msg}`);
-      }
-      if (detail.httpStatus) lines.push(`  - HTTP status: ${detail.httpStatus}`);
-      if (detail.requestId) lines.push(`  - request ID: ${detail.requestId}`);
-      if (detail.rawMessage) {
-        const raw = detail.rawMessage.length > 500
-          ? `${detail.rawMessage.slice(0, 500)}... [truncated]`
-          : detail.rawMessage;
-        lines.push(`  - raw message: ${raw}`);
-      }
-
-      diagnostics = lines.join('\n');
-    }
+    const diagnostics = buildInterruptionDiagnostics(detail, getAiErrorPresentation(detail), t);
 
     try {
       await navigator.clipboard.writeText(diagnostics);
@@ -749,54 +794,12 @@ export const ReviewActionBar: React.FC = () => {
         />
       )}
 
-      {/* Partial results summary on interruption */}
-      {hasInterruption && progressSummary && progressSummary.completed > 0 && (
-        <div className="deep-review-action-bar__partial-summary">
-          <span className="deep-review-action-bar__partial-count">
-            {t('deepReviewActionBar.partialResultsDescription', {
-              completed: progressSummary.completed,
-              total: progressSummary.total,
-              defaultValue: '{{completed}}/{{total}} reviewers completed',
-            })}
-          </span>
-          <button
-            type="button"
-            className="deep-review-action-bar__partial-link"
-            onClick={() => setShowPartialResults(!showPartialResults)}
-          >
-            <Eye size={12} />
-            {showPartialResults
-              ? t('deepReviewActionBar.hidePartialResults', { defaultValue: 'Hide partial results' })
-              : t('deepReviewActionBar.viewPartialResults', { defaultValue: 'View partial results' })}
-          </button>
-        </div>
-      )}
-
-      {/* Partial results detail */}
-      {showPartialResults && partialResults && (
-        <div className="deep-review-action-bar__partial-detail">
-          {partialResults.completedIssues.length > 0 && (
-            <div className="deep-review-action-bar__partial-section">
-              <span className="deep-review-action-bar__partial-section-title">
-                {t('deepReviewActionBar.partialIssues', {
-                  count: partialResults.completedIssues.length,
-                  defaultValue: '{{count}} issues found',
-                })}
-              </span>
-            </div>
-          )}
-          {partialResults.completedRemediationItems.length > 0 && (
-            <div className="deep-review-action-bar__partial-section">
-              <span className="deep-review-action-bar__partial-section-title">
-                {t('deepReviewActionBar.partialRemediationItems', {
-                  count: partialResults.completedRemediationItems.length,
-                  defaultValue: '{{count}} remediation items',
-                })}
-              </span>
-            </div>
-          )}
-        </div>
-      )}
+      <PartialResultsPanel
+        progressSummary={hasInterruption ? progressSummary : null}
+        partialResults={partialResults}
+        showPartialResults={showPartialResults}
+        onTogglePartialResults={() => setShowPartialResults(!showPartialResults)}
+      />
 
       {/* Error attribution card */}
       {hasInterruption && errorAttribution && (
@@ -835,43 +838,7 @@ export const ReviewActionBar: React.FC = () => {
 
       {/* Recovery plan preview */}
       {hasInterruption && recoveryPlan && (
-        <div className="deep-review-action-bar__recovery-plan">
-          <div className="deep-review-action-bar__recovery-plan-detail">
-            {recoveryPlan.willPreserve.length > 0 && (
-              <div className="deep-review-action-bar__recovery-item">
-                <CheckCircle size={12} className="deep-review-action-bar__recovery-icon--preserve" />
-                <span>
-                  {t('deepReviewActionBar.recoveryPreserve', {
-                    count: recoveryPlan.willPreserve.length,
-                    defaultValue: '{{count}} completed reviewers will be preserved',
-                  })}
-                </span>
-              </div>
-            )}
-            {recoveryPlan.willRerun.length > 0 && (
-              <div className="deep-review-action-bar__recovery-item">
-                <RotateCcw size={12} className="deep-review-action-bar__recovery-icon--rerun" />
-                <span>
-                  {t('deepReviewActionBar.recoveryRerun', {
-                    count: recoveryPlan.willRerun.length,
-                    defaultValue: '{{count}} reviewers will be rerun',
-                  })}
-                </span>
-              </div>
-            )}
-            {recoveryPlan.willSkip.length > 0 && (
-              <div className="deep-review-action-bar__recovery-item">
-                <SkipForward size={12} className="deep-review-action-bar__recovery-icon--skip" />
-                <span>
-                  {t('deepReviewActionBar.recoverySkip', {
-                    count: recoveryPlan.willSkip.length,
-                    defaultValue: '{{count}} reviewers will be skipped',
-                  })}
-                </span>
-              </div>
-            )}
-          </div>
-        </div>
+        <RecoveryPlanPreview recoveryPlan={recoveryPlan} />
       )}
 
       {/* Context overflow degradation options */}
@@ -901,200 +868,38 @@ export const ReviewActionBar: React.FC = () => {
         </div>
       )}
 
-      {/* Remediation selection (only when review completed and has items) */}
-      {phase === 'review_completed' && remediationItems.length > 0 && (
-        <div className="deep-review-action-bar__remediation">
-          <button
-            type="button"
-            className="deep-review-action-bar__remediation-toggle"
-            onClick={() => setShowRemediationList(!showRemediationList)}
-          >
-            <Checkbox
-              checked={allSelected}
-              indeterminate={!allSelected && selectedCount > 0}
-              onChange={handleToggleAll}
-              size="small"
-            />
-            <span className="deep-review-action-bar__remediation-label">
-              {t('toolCards.codeReview.remediationActions.selectionCount', {
-                selected: selectedCount,
-                total: totalCount,
-                defaultValue: '{{selected}}/{{total}} selected',
-              })}
-            </span>
-            {showRemediationList ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-          </button>
+      {/* Remediation selection stays visible while fixes run so progress remains inspectable. */}
+      {['review_completed', 'fix_running', 'fix_completed', 'fix_interrupted'].includes(phase) && remediationItems.length > 0 && (
+        <RemediationSelectionPanel
+          remediationItems={remediationItems}
+          selectedRemediationIds={selectedRemediationIds}
+          completedRemediationIds={completedRemediationIds}
+          fixingRemediationIds={fixingRemediationIds}
+          decisionSelections={decisionSelections}
+          showRemediationList={showRemediationList}
+          expandedDecisionIds={expandedDecisionIds}
+          selectionDisabled={phase === 'fix_running' || phase === 'fix_completed'}
+          onToggleRemediation={handleToggleRemediation}
+          onToggleAll={handleToggleAll}
+          onToggleGroup={handleToggleGroup}
+          onToggleList={() => setShowRemediationList(!showRemediationList)}
+          onToggleDecisionExpansion={handleToggleDecisionExpansion}
+          onSetDecisionSelection={store.setDecisionSelection}
+        />
+      )}
 
-          {showRemediationList && (
-            <div
-              className="deep-review-action-bar__remediation-list"
-              onWheel={stopNestedScrollPropagation}
-              onTouchMove={stopNestedScrollPropagation}
-            >
-              {groupOrder.map((groupId) => {
-                const items = groupedItems[groupId]!;
-                const groupSelectedCount = items.filter((i) => selectedRemediationIds.has(i.id)).length;
-                const groupAllSelected = groupSelectedCount === items.length;
-                const groupPartial = groupSelectedCount > 0 && !groupAllSelected;
-                const groupTitle = groupId === 'ungrouped'
-                  ? t('toolCards.codeReview.remediationActions.ungrouped', { defaultValue: 'Other' })
-                  : t(`toolCards.codeReview.groups.${groupId}`, { defaultValue: groupId });
-                const groupMeta = groupId !== 'ungrouped' ? GROUP_PRIORITY_META[groupId as RemediationGroupId] : undefined;
-
-                return (
-                  <div key={groupId} className="deep-review-action-bar__remediation-group">
-                    <button
-                      type="button"
-                      className="deep-review-action-bar__remediation-group-header"
-                      onClick={() => handleToggleGroup(groupId)}
-                    >
-                      <Checkbox
-                        checked={groupAllSelected}
-                        indeterminate={groupPartial}
-                        onChange={() => handleToggleGroup(groupId)}
-                        size="small"
-                      />
-                      <span
-                        className="deep-review-action-bar__remediation-group-title"
-                        style={groupMeta ? { color: groupMeta.color } : undefined}
-                      >
-                        {groupTitle}
-                      </span>
-                      <span className="deep-review-action-bar__remediation-group-count">
-                        {groupSelectedCount}/{items.length}
-                      </span>
-                    </button>
-                    <div className="deep-review-action-bar__remediation-group-items">
-                      {items.map((item: ReviewRemediationItem) => {
-                        const isCompleted = completedRemediationIds.has(item.id);
-                        return (
-                          <label
-                            key={item.id}
-                            className={`deep-review-action-bar__remediation-item ${
-                              isCompleted ? 'deep-review-action-bar__remediation-item--completed' : ''
-                            }`}
-                          >
-                            <Checkbox
-                              checked={selectedRemediationIds.has(item.id)}
-                              onChange={() => !isCompleted && handleToggleRemediation(item.id)}
-                              disabled={isCompleted}
-                              size="small"
-                            />
-                            <span
-                              className="deep-review-action-bar__remediation-text"
-                              title={item.decisionContext ? item.plan : undefined}
-                            >
-                              {isCompleted && (
-                                <CheckCircle size={12} className="deep-review-action-bar__completed-icon" />
-                              )}
-                              {item.requiresDecision && (
-                                <span className="deep-review-action-bar__remediation-tag">
-                                  {t('reviewActionBar.needsDecisionTag', { defaultValue: 'Decision' })}
-                                </span>
-                              )}
-                              {item.groupId === 'verification' ? (
-                                <span className="deep-review-action-bar__remediation-text-plain">
-                                  {item.decisionContext?.question ?? item.plan}
-                                </span>
-                              ) : (
-                                <a
-                                  className="deep-review-action-bar__remediation-link"
-                                  href={`#review-remediation-${item.groupId ?? 'ungrouped'}-${item.groupIndex}`}
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    if (item.groupId != null) {
-                                      globalEventBus.emit(DEEP_REVIEW_SCROLL_TO_EVENT, {
-                                        groupId: item.groupId,
-                                        groupIndex: item.groupIndex,
-                                        issueIndex: item.issueIndex ?? -1,
-                                      });
-                                    }
-                                  }}
-                                >
-                                  {item.decisionContext?.question ?? item.plan}
-                                </a>
-                              )}
-                              {item.decisionContext?.tradeoffs && (
-                                <span className="deep-review-action-bar__remediation-tradeoffs">
-                                  {item.decisionContext.tradeoffs}
-                                </span>
-                              )}
-                              {item.decisionContext?.options && item.decisionContext.options.length > 0 && (
-                                <button
-                                  type="button"
-                                  className="deep-review-action-bar__decision-toggle"
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    setExpandedDecisionIds((prev) => {
-                                      const next = new Set(prev);
-                                      if (next.has(item.id)) {
-                                        next.delete(item.id);
-                                      } else {
-                                        next.add(item.id);
-                                      }
-                                      return next;
-                                    });
-                                  }}
-                                >
-                                  {expandedDecisionIds.has(item.id)
-                                    ? t('toolCards.codeReview.remediationActions.collapseOptions', { defaultValue: 'Hide options' })
-                                    : t('toolCards.codeReview.remediationActions.expandOptions', { defaultValue: 'Show options' })
-                                  }
-                                </button>
-                              )}
-                              {expandedDecisionIds.has(item.id) && item.decisionContext?.options && (
-                                <ul className="deep-review-action-bar__decision-options">
-                                  {item.decisionContext.options.map((opt, oi) => {
-                                    const isSelected = decisionSelections[item.id] === oi;
-                                    const isRecommended = item.decisionContext?.recommendation === oi;
-                                    return (
-                                      <li key={oi} className={`deep-review-action-bar__decision-option ${isSelected ? 'is-selected' : ''} ${isRecommended ? 'is-recommended' : ''}`}>
-                                        <button
-                                          type="button"
-                                          onClick={(e) => {
-                                            e.preventDefault();
-                                            e.stopPropagation();
-                                            store.setDecisionSelection(item.id, oi);
-                                          }}
-                                        >
-                                          <span className="deep-review-action-bar__decision-option-marker">
-                                            {isSelected ? '\u25CF' : '\u25CB'}
-                                          </span>
-                                          <span className="deep-review-action-bar__decision-option-text">
-                                            {opt}
-                                            {isRecommended ? ` (${t('toolCards.codeReview.remediationActions.recommended', { defaultValue: 'recommended' })})` : ''}
-                                          </span>
-                                        </button>
-                                      </li>
-                                    );
-                                  })}
-                                </ul>
-                              )}
-                            </span>
-                          </label>
-                        );
-                      })}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-
-          {/* Empty selection hint */}
-          {selectedCount === 0 && (
-            <div className="deep-review-action-bar__empty-selection" role="note">
-              <Info size={14} className="deep-review-action-bar__empty-selection-icon" />
-              <span>
-                {t('toolCards.codeReview.remediationActions.noSelectionHint', {
-                  defaultValue: 'Select at least one remediation item to start fixing.',
-                })}
-              </span>
-            </div>
-          )}
-        </div>
+      {phase === 'review_completed' && pendingDecisionAction && decisionGateItems.length > 0 && (
+        <DecisionExecutionGate
+          items={decisionGateItems}
+          decisionSelections={decisionSelections}
+          customInstructions={customInstructions}
+          rerunReview={pendingDecisionAction.rerunReview}
+          confirmDisabled={decisionGateMissingSelection}
+          onSelectDecision={store.setDecisionSelection}
+          onCustomInstructionsChange={store.setCustomInstructions}
+          onConfirm={handleConfirmDecisionGate}
+          onCancel={handleCancelDecisionGate}
+        />
       )}
 
       {/* Friendly message when review completed with no remediation items */}
@@ -1122,7 +927,7 @@ export const ReviewActionBar: React.FC = () => {
       )}
 
       {/* Custom instructions input */}
-      {phase === 'review_completed' && remediationItems.length > 0 && (
+      {phase === 'review_completed' && remediationItems.length > 0 && !pendingDecisionAction && (
         <div className="deep-review-action-bar__custom">
           <button
             type="button"
@@ -1150,145 +955,29 @@ export const ReviewActionBar: React.FC = () => {
         </div>
       )}
 
-      {/* Action buttons */}
-      <div className="deep-review-action-bar__actions">
-        {phase === 'review_completed' && isDeepReview && retryableSlices.length > 0 && (
-          <Button
-            variant="secondary"
-            size="small"
-            isLoading={activeAction === 'retry'}
-            disabled={activeAction !== null}
-            onClick={() => void handleRetryIncompleteSlices()}
-          >
-            <RotateCcw size={14} />
-            {t('deepReviewActionBar.retryIncompleteSlices', {
-              count: retryableSlices.length,
-              defaultValue: `Retry incomplete slices (${retryableSlices.length})`,
-            })}
-          </Button>
-        )}
-        {phase === 'review_completed' && remediationItems.length > 0 && (
-          <>
-            <Button
-              variant="primary"
-              size="small"
-              isLoading={activeAction === 'fix'}
-              disabled={isFixDisabled}
-              onClick={() => void handleStartFixing(false)}
-            >
-              {t('toolCards.codeReview.remediationActions.startFix', { defaultValue: 'Start fixing' })}
-            </Button>
-            <Button
-              variant="secondary"
-              size="small"
-              isLoading={activeAction === 'fix-review'}
-              disabled={isFixDisabled}
-              onClick={() => void handleStartFixing(true)}
-            >
-              {t('toolCards.codeReview.remediationActions.fixAndReview', { defaultValue: 'Fix and re-review' })}
-            </Button>
-            <Tooltip content={t('deepReviewActionBar.fillBackInputHint', {
-              defaultValue: 'Copy selected fix plan to the input box for manual editing',
-            })}>
-              <Button
-                variant="ghost"
-                size="small"
-                disabled={isFixDisabled}
-                onClick={() => void handleFillBackInput()}
-              >
-                {t('deepReviewActionBar.fillBackInput', { defaultValue: 'Fill to input' })}
-              </Button>
-            </Tooltip>
-          </>
-        )}
-
-        {hasInterruption && (
-          <>
-            <Button
-              variant="primary"
-              size="small"
-              isLoading={activeAction === 'resume'}
-              disabled={activeAction !== null || isResumeRunning}
-              onClick={() => void handleContinueReview()}
-            >
-              <Play size={14} />
-              {t('deepReviewActionBar.resumeReview', { defaultValue: 'Continue review' })}
-            </Button>
-            {modelRecoveryAction && (
-              <Button
-                variant="secondary"
-                size="small"
-                disabled={activeAction !== null}
-                onClick={() => void handleOpenModelSettings()}
-              >
-                {modelRecoveryAction === 'switch_model'
-                  ? t('deepReviewActionBar.switchModel', { defaultValue: 'Switch model' })
-                  : t('deepReviewActionBar.openModelSettings', { defaultValue: 'Open model settings' })}
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="small"
-              onClick={handleCopyDiagnostics}
-            >
-              <Copy size={14} />
-              {t('deepReviewActionBar.copyDiagnostics', { defaultValue: 'Copy diagnostics' })}
-            </Button>
-            {partialResults?.hasPartialResults && (
-              <Button
-                variant="ghost"
-                size="small"
-                onClick={handleViewPartialResults}
-              >
-                <Eye size={14} />
-                {t('deepReviewActionBar.viewPartialResults', { defaultValue: 'View partial results' })}
-              </Button>
-            )}
-          </>
-        )}
-
-        {phase === 'fix_interrupted' && (
-          <>
-            <div className="deep-review-action-bar__interruption-notice">
-              <AlertTriangle size={16} className="deep-review-action-bar__interruption-icon" />
-              <span>
-                {t('deepReviewActionBar.fixInterrupted', {
-                  defaultValue: 'Fix was interrupted. {{count}} items remain.',
-                  count: remainingFixIds.length,
-                })}
-              </span>
-            </div>
-            <Button
-              variant="primary"
-              size="small"
-              onClick={() => void handleContinueFix()}
-            >
-              <Play size={14} />
-              {t('deepReviewActionBar.continueFix', {
-                defaultValue: 'Continue fixing {{count}} items',
-                count: remainingFixIds.length,
-              })}
-            </Button>
-            <Button
-              variant="secondary"
-              size="small"
-              onClick={() => store.skipRemainingFixes()}
-            >
-              {t('deepReviewActionBar.skipRemaining', { defaultValue: 'Skip remaining' })}
-            </Button>
-          </>
-        )}
-
-        {(phase === 'fix_completed' || phase === 'fix_failed' || phase === 'fix_timeout' || phase === 'review_error') && (
-          <Button
-            variant="ghost"
-            size="small"
-            onClick={handleMinimize}
-          >
-            {t('deepReviewActionBar.minimize', { defaultValue: 'Minimize' })}
-          </Button>
-        )}
-      </div>
+      <ReviewActionControls
+        phase={phase}
+        isDeepReview={isDeepReview}
+        retryableSliceCount={retryableSlices.length}
+        remediationItemCount={remediationItems.length}
+        hasInterruption={hasInterruption}
+        partialResultsAvailable={Boolean(partialResults?.hasPartialResults)}
+        activeAction={activeAction}
+        isFixDisabled={isFixDisabled}
+        isResumeRunning={isResumeRunning}
+        remainingFixIds={remainingFixIds}
+        modelRecoveryAction={modelRecoveryAction}
+        onRetryIncompleteSlices={handleRetryIncompleteSlices}
+        onStartFixing={handleStartFixing}
+        onFillBackInput={handleFillBackInput}
+        onContinueReview={handleContinueReview}
+        onOpenModelSettings={handleOpenModelSettings}
+        onCopyDiagnostics={handleCopyDiagnostics}
+        onViewPartialResults={handleViewPartialResults}
+        onContinueFix={handleContinueFix}
+        onSkipRemainingFixes={store.skipRemainingFixes}
+        onMinimize={handleMinimize}
+      />
     </div>
   );
 };

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/PartialResultsPanel.test.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/PartialResultsPanel.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { PartialResultsPanel } from './PartialResultsPanel';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: Record<string, unknown> & { defaultValue?: string }) => {
+      const template = options?.defaultValue ?? _key;
+      return template.replace(/{{(\w+)}}/g, (_match, token: string) => String(options?.[token] ?? _match));
+    },
+  }),
+}));
+
+describe('PartialResultsPanel', () => {
+  const progressSummary = {
+    completed: 2,
+    failed: 1,
+    timedOut: 0,
+    running: 1,
+    skipped: 0,
+    unknown: 1,
+    total: 4,
+    text: '2/4 completed',
+  };
+
+  const partialResults = {
+    hasPartialResults: true,
+    completedReviewerCount: 2,
+    totalReviewerCount: 4,
+    completedIssues: [{ title: 'Race condition' }],
+    completedRemediationItems: ['Guard async state'],
+    completedReviewerSummaries: ['Security completed'],
+  };
+
+  it('renders interruption summary in collapsed state', () => {
+    const html = renderToStaticMarkup(
+      <PartialResultsPanel
+        progressSummary={progressSummary}
+        partialResults={partialResults}
+        showPartialResults={false}
+        onTogglePartialResults={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('2/4 reviewers completed');
+    expect(html).toContain('View partial results');
+    expect(html).not.toContain('1 issues found');
+  });
+
+  it('renders partial result details when expanded', () => {
+    const html = renderToStaticMarkup(
+      <PartialResultsPanel
+        progressSummary={progressSummary}
+        partialResults={partialResults}
+        showPartialResults
+        onTogglePartialResults={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('Hide partial results');
+    expect(html).toContain('1 issues found');
+    expect(html).toContain('1 remediation items');
+  });
+});

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/PartialResultsPanel.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/PartialResultsPanel.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Eye } from 'lucide-react';
+import type {
+  PartialReviewData,
+  ReviewerProgressSummary,
+} from '../../utils/deepReviewExperience';
+
+interface PartialResultsPanelProps {
+  progressSummary: ReviewerProgressSummary | null;
+  partialResults: PartialReviewData | null;
+  showPartialResults: boolean;
+  onTogglePartialResults: () => void;
+}
+
+export const PartialResultsPanel: React.FC<PartialResultsPanelProps> = ({
+  progressSummary,
+  partialResults,
+  showPartialResults,
+  onTogglePartialResults,
+}) => {
+  const { t } = useTranslation('flow-chat');
+  const showSummary = Boolean(progressSummary && progressSummary.completed > 0);
+
+  return (
+    <>
+      {showSummary && progressSummary && (
+        <div className="deep-review-action-bar__partial-summary">
+          <span className="deep-review-action-bar__partial-count">
+            {t('deepReviewActionBar.partialResultsDescription', {
+              completed: progressSummary.completed,
+              total: progressSummary.total,
+              defaultValue: '{{completed}}/{{total}} reviewers completed',
+            })}
+          </span>
+          <button
+            type="button"
+            className="deep-review-action-bar__partial-link"
+            onClick={onTogglePartialResults}
+          >
+            <Eye size={12} />
+            {showPartialResults
+              ? t('deepReviewActionBar.hidePartialResults', { defaultValue: 'Hide partial results' })
+              : t('deepReviewActionBar.viewPartialResults', { defaultValue: 'View partial results' })}
+          </button>
+        </div>
+      )}
+
+      {showPartialResults && partialResults && (
+        <div className="deep-review-action-bar__partial-detail">
+          {partialResults.completedIssues.length > 0 && (
+            <div className="deep-review-action-bar__partial-section">
+              <span className="deep-review-action-bar__partial-section-title">
+                {t('deepReviewActionBar.partialIssues', {
+                  count: partialResults.completedIssues.length,
+                  defaultValue: '{{count}} issues found',
+                })}
+              </span>
+            </div>
+          )}
+          {partialResults.completedRemediationItems.length > 0 && (
+            <div className="deep-review-action-bar__partial-section">
+              <span className="deep-review-action-bar__partial-section-title">
+                {t('deepReviewActionBar.partialRemediationItems', {
+                  count: partialResults.completedRemediationItems.length,
+                  defaultValue: '{{count}} remediation items',
+                })}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/RecoveryPlanPreview.test.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/RecoveryPlanPreview.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { RecoveryPlanPreview } from './RecoveryPlanPreview';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: Record<string, unknown> & { defaultValue?: string }) => {
+      const template = options?.defaultValue ?? _key;
+      return template.replace(/{{(\w+)}}/g, (_match, token: string) => String(options?.[token] ?? _match));
+    },
+  }),
+}));
+
+describe('RecoveryPlanPreview', () => {
+  it('renders preserve, rerun, and skip recovery counts', () => {
+    const html = renderToStaticMarkup(
+      <RecoveryPlanPreview
+        recoveryPlan={{
+          willPreserve: ['ReviewSecurity', 'ReviewArchitecture'],
+          willRerun: ['ReviewPerformance'],
+          willSkip: ['ReviewFrontend'],
+          summaryText: 'Recovery summary',
+        }}
+      />,
+    );
+
+    expect(html).toContain('2 completed reviewers will be preserved');
+    expect(html).toContain('1 reviewers will be rerun');
+    expect(html).toContain('1 reviewers will be skipped');
+    expect(html).toContain('deep-review-action-bar__recovery-plan');
+  });
+});

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/RecoveryPlanPreview.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/RecoveryPlanPreview.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  CheckCircle,
+  RotateCcw,
+  SkipForward,
+} from 'lucide-react';
+import type { RecoveryPlan } from '../../utils/deepReviewExperience';
+
+interface RecoveryPlanPreviewProps {
+  recoveryPlan: RecoveryPlan;
+}
+
+export const RecoveryPlanPreview: React.FC<RecoveryPlanPreviewProps> = ({
+  recoveryPlan,
+}) => {
+  const { t } = useTranslation('flow-chat');
+
+  return (
+    <div className="deep-review-action-bar__recovery-plan">
+      <div className="deep-review-action-bar__recovery-plan-detail">
+        {recoveryPlan.willPreserve.length > 0 && (
+          <div className="deep-review-action-bar__recovery-item">
+            <CheckCircle size={12} className="deep-review-action-bar__recovery-icon--preserve" />
+            <span>
+              {t('deepReviewActionBar.recoveryPreserve', {
+                count: recoveryPlan.willPreserve.length,
+                defaultValue: '{{count}} completed reviewers will be preserved',
+              })}
+            </span>
+          </div>
+        )}
+        {recoveryPlan.willRerun.length > 0 && (
+          <div className="deep-review-action-bar__recovery-item">
+            <RotateCcw size={12} className="deep-review-action-bar__recovery-icon--rerun" />
+            <span>
+              {t('deepReviewActionBar.recoveryRerun', {
+                count: recoveryPlan.willRerun.length,
+                defaultValue: '{{count}} reviewers will be rerun',
+              })}
+            </span>
+          </div>
+        )}
+        {recoveryPlan.willSkip.length > 0 && (
+          <div className="deep-review-action-bar__recovery-item">
+            <SkipForward size={12} className="deep-review-action-bar__recovery-icon--skip" />
+            <span>
+              {t('deepReviewActionBar.recoverySkip', {
+                count: recoveryPlan.willSkip.length,
+                defaultValue: '{{count}} reviewers will be skipped',
+              })}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/RemediationSelectionPanel.test.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/RemediationSelectionPanel.test.tsx
@@ -1,0 +1,277 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RemediationSelectionPanel } from './RemediationSelectionPanel';
+import type { ReviewRemediationItem } from '../../utils/codeReviewRemediation';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: Record<string, unknown> & { defaultValue?: string }) => {
+      const template = options?.defaultValue ?? _key;
+      return template.replace(/{{(\w+)}}/g, (_match, token: string) => String(options?.[token] ?? _match));
+    },
+  }),
+}));
+
+vi.mock('@/component-library', () => ({
+  Button: ({
+    children,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+  }) => <button type="button" disabled={disabled}>{children}</button>,
+  Checkbox: ({
+    checked,
+    className,
+    disabled,
+    indeterminate,
+    label,
+    onChange,
+  }: {
+    checked?: boolean;
+    className?: string;
+    disabled?: boolean;
+    indeterminate?: boolean;
+    label?: React.ReactNode;
+    onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  }) => (
+    <label className={className}>
+      <input
+        type="checkbox"
+        aria-checked={indeterminate ? 'mixed' : checked ? 'true' : 'false'}
+        checked={checked}
+        disabled={disabled}
+        onChange={onChange}
+        readOnly={!onChange}
+      />
+      {label}
+    </label>
+  ),
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/infrastructure/event-bus', () => ({
+  globalEventBus: {
+    emit: vi.fn(),
+  },
+}));
+
+const baseProps = {
+  showRemediationList: true,
+  onToggleRemediation: vi.fn(),
+  onToggleAll: vi.fn(),
+  onToggleGroup: vi.fn(),
+  onToggleList: vi.fn(),
+  onToggleDecisionExpansion: vi.fn(),
+  onSetDecisionSelection: vi.fn(),
+};
+
+let JSDOMCtor: (new (
+  html?: string,
+  options?: { pretendToBeVisual?: boolean; url?: string }
+) => { window: Window & typeof globalThis }) | null = null;
+
+try {
+  const jsdom = await import('jsdom');
+  JSDOMCtor = jsdom.JSDOM as typeof JSDOMCtor;
+} catch {
+  JSDOMCtor = null;
+}
+
+const describeWithJsdom = JSDOMCtor ? describe : describe.skip;
+
+describe('RemediationSelectionPanel', () => {
+  it('renders grouped remediation counts and the empty-selection hint', () => {
+    const remediationItems: ReviewRemediationItem[] = [
+      {
+        id: 'must-fix-1',
+        index: 0,
+        groupIndex: 0,
+        plan: 'Fix critical issue',
+        issueIndex: 0,
+        groupId: 'must_fix',
+        defaultSelected: true,
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      <RemediationSelectionPanel
+        {...baseProps}
+        remediationItems={remediationItems}
+        selectedRemediationIds={new Set()}
+        completedRemediationIds={new Set()}
+        decisionSelections={{}}
+        expandedDecisionIds={new Set()}
+      />,
+    );
+
+    expect(html).toContain('0/1 selected');
+    expect(html).toContain('must_fix');
+    expect(html).toContain('0/1');
+    expect(html).toContain('Select at least one remediation item to start fixing.');
+  });
+
+  it('renders completed and expanded decision remediation items', () => {
+    const remediationItems: ReviewRemediationItem[] = [
+      {
+        id: 'decision-1',
+        index: 0,
+        groupIndex: 0,
+        plan: 'Choose a migration strategy',
+        issueIndex: 0,
+        groupId: 'needs_decision',
+        requiresDecision: true,
+        decisionContext: {
+          question: 'Which migration strategy should we use?',
+          tradeoffs: 'Fast path is risky; staged path is safer.',
+          options: ['Fast path', 'Staged path'],
+          recommendation: 1,
+        },
+        defaultSelected: true,
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      <RemediationSelectionPanel
+        {...baseProps}
+        remediationItems={remediationItems}
+        selectedRemediationIds={new Set(['decision-1'])}
+        completedRemediationIds={new Set(['decision-1'])}
+        decisionSelections={{ 'decision-1': 1 }}
+        expandedDecisionIds={new Set(['decision-1'])}
+      />,
+    );
+
+    expect(html).toContain('Decision');
+    expect(html).toContain('Which migration strategy should we use?');
+    expect(html).toContain('Fast path is risky; staged path is safer.');
+    expect(html).toContain('Staged path (recommended)');
+    expect(html).toContain('deep-review-action-bar__remediation-item--completed');
+  });
+});
+
+describeWithJsdom('RemediationSelectionPanel interactions', () => {
+  let dom: { window: Window & typeof globalThis };
+  let container: HTMLDivElement;
+  let root: Root;
+
+  function mount(element: React.ReactElement): void {
+    act(() => {
+      root.render(element);
+    });
+  }
+
+  function remediationItems(): ReviewRemediationItem[] {
+    return [
+      {
+        id: 'remediation-should-improve-1',
+        index: 0,
+        groupIndex: 0,
+        plan: 'Improve error copy',
+        issueIndex: -1,
+        groupId: 'should_improve',
+        defaultSelected: false,
+      },
+      {
+        id: 'remediation-should-improve-2',
+        index: 1,
+        groupIndex: 1,
+        plan: 'Improve retry state',
+        issueIndex: -1,
+        groupId: 'should_improve',
+        defaultSelected: false,
+      },
+    ];
+  }
+
+  beforeEach(() => {
+    dom = new JSDOMCtor!('<!doctype html><html><body></body></html>', {
+      pretendToBeVisual: true,
+      url: 'http://localhost',
+    });
+
+    const { window } = dom;
+    vi.stubGlobal('window', window);
+    vi.stubGlobal('document', window.document);
+    vi.stubGlobal('navigator', window.navigator);
+    vi.stubGlobal('HTMLElement', window.HTMLElement);
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    dom.window.close();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('toggles a remediation group once when clicking the root checkbox', () => {
+    const onToggleGroup = vi.fn();
+
+    mount(
+      <RemediationSelectionPanel
+        {...baseProps}
+        remediationItems={remediationItems()}
+        selectedRemediationIds={new Set()}
+        completedRemediationIds={new Set()}
+        decisionSelections={{}}
+        expandedDecisionIds={new Set()}
+        onToggleGroup={onToggleGroup}
+      />,
+    );
+
+    const groupCheckbox = container.querySelector<HTMLInputElement>(
+      '.deep-review-action-bar__remediation-group-header input[type="checkbox"]',
+    );
+    expect(groupCheckbox).toBeTruthy();
+
+    act(() => {
+      groupCheckbox!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onToggleGroup).toHaveBeenCalledTimes(1);
+    expect(onToggleGroup).toHaveBeenCalledWith('should_improve');
+  });
+
+  it('keeps the tree visible but disables selection while fixing', () => {
+    const onToggleRemediation = vi.fn();
+    const onToggleGroup = vi.fn();
+
+    mount(
+      <RemediationSelectionPanel
+        {...baseProps}
+        remediationItems={remediationItems()}
+        selectedRemediationIds={new Set(['remediation-should-improve-1'])}
+        completedRemediationIds={new Set()}
+        fixingRemediationIds={new Set(['remediation-should-improve-1'])}
+        decisionSelections={{}}
+        expandedDecisionIds={new Set()}
+        selectionDisabled
+        onToggleRemediation={onToggleRemediation}
+        onToggleGroup={onToggleGroup}
+      />,
+    );
+
+    expect(container.textContent).toContain('Improve error copy');
+    expect(container.textContent).toContain('Fixing');
+    const checkboxes = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'));
+    expect(checkboxes.length).toBeGreaterThan(0);
+    expect(checkboxes.every((checkbox) => checkbox.disabled)).toBe(true);
+
+    act(() => {
+      checkboxes[checkboxes.length - 1].dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onToggleRemediation).not.toHaveBeenCalled();
+    expect(onToggleGroup).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/RemediationSelectionPanel.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/RemediationSelectionPanel.tsx
@@ -1,0 +1,301 @@
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CheckCircle, ChevronDown, ChevronUp, Info, Loader2 } from 'lucide-react';
+import { Checkbox } from '@/component-library';
+import type { ReviewRemediationItem } from '../../utils/codeReviewRemediation';
+import { REMEDIATION_GROUP_ORDER } from '../../utils/codeReviewRemediation';
+import type { RemediationGroupId } from '../../utils/codeReviewReport';
+import { globalEventBus } from '@/infrastructure/event-bus';
+import { DEEP_REVIEW_SCROLL_TO_EVENT } from '../../events/flowchatNavigation';
+
+interface RemediationSelectionPanelProps {
+  remediationItems: ReviewRemediationItem[];
+  selectedRemediationIds: Set<string>;
+  completedRemediationIds: Set<string>;
+  fixingRemediationIds?: Set<string>;
+  decisionSelections: Record<string, number>;
+  showRemediationList: boolean;
+  expandedDecisionIds: Set<string>;
+  selectionDisabled?: boolean;
+  onToggleRemediation: (id: string) => void;
+  onToggleAll: () => void;
+  onToggleGroup: (groupId: string) => void;
+  onToggleList: () => void;
+  onToggleDecisionExpansion: (id: string) => void;
+  onSetDecisionSelection: (id: string, optionIndex: number) => void;
+}
+
+const EMPTY_FIXING_REMEDIATION_IDS = new Set<string>();
+
+const GROUP_PRIORITY_META: Record<RemediationGroupId, { color: string }> = {
+  must_fix: { color: 'var(--color-error, #ef4444)' },
+  should_improve: { color: 'var(--color-warning, #f59e0b)' },
+  needs_decision: { color: 'var(--color-accent-500, #60a5fa)' },
+  verification: { color: 'var(--color-success, #22c55e)' },
+};
+
+const stopNestedScrollPropagation = (event: React.WheelEvent | React.TouchEvent) => {
+  event.stopPropagation();
+  if ('nativeEvent' in event && typeof event.nativeEvent.stopImmediatePropagation === 'function') {
+    event.nativeEvent.stopImmediatePropagation();
+  }
+};
+
+export const RemediationSelectionPanel: React.FC<RemediationSelectionPanelProps> = ({
+  remediationItems,
+  selectedRemediationIds,
+  completedRemediationIds,
+  fixingRemediationIds = EMPTY_FIXING_REMEDIATION_IDS,
+  decisionSelections,
+  showRemediationList,
+  expandedDecisionIds,
+  selectionDisabled = false,
+  onToggleRemediation,
+  onToggleAll,
+  onToggleGroup,
+  onToggleList,
+  onToggleDecisionExpansion,
+  onSetDecisionSelection,
+}) => {
+  const { t } = useTranslation('flow-chat');
+
+  const selectableItems = useMemo(
+    () => remediationItems.filter((item) => !completedRemediationIds.has(item.id)),
+    [completedRemediationIds, remediationItems],
+  );
+  const selectedCount = selectableItems.filter((item) => selectedRemediationIds.has(item.id)).length;
+  const totalCount = selectableItems.length;
+  const allSelected = totalCount > 0 && selectedCount === totalCount;
+
+  const groupedItems = useMemo(() => {
+    const groups: Record<string, ReviewRemediationItem[]> = {};
+    for (const item of remediationItems) {
+      const gid = item.groupId ?? 'ungrouped';
+      if (!groups[gid]) groups[gid] = [];
+      groups[gid].push(item);
+    }
+    return groups;
+  }, [remediationItems]);
+
+  const groupOrder = useMemo(() => {
+    const ordered: string[] = [];
+    for (const gid of REMEDIATION_GROUP_ORDER) {
+      if (groupedItems[gid]?.length) ordered.push(gid);
+    }
+    if (groupedItems.ungrouped?.length) ordered.push('ungrouped');
+    return ordered;
+  }, [groupedItems]);
+
+  return (
+    <div className="deep-review-action-bar__remediation">
+      <button
+        type="button"
+        className="deep-review-action-bar__remediation-toggle"
+        onClick={onToggleList}
+      >
+        <Checkbox
+          checked={allSelected}
+          indeterminate={!allSelected && selectedCount > 0}
+          onChange={() => {
+            if (!selectionDisabled) {
+              onToggleAll();
+            }
+          }}
+          disabled={selectionDisabled || totalCount === 0}
+          size="small"
+        />
+        <span className="deep-review-action-bar__remediation-label">
+          {t('toolCards.codeReview.remediationActions.selectionCount', {
+            selected: selectedCount,
+            total: totalCount,
+            defaultValue: '{{selected}}/{{total}} selected',
+          })}
+        </span>
+        {showRemediationList ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+      </button>
+
+      {showRemediationList && (
+        <div
+          className="deep-review-action-bar__remediation-list"
+          onWheel={stopNestedScrollPropagation}
+          onTouchMove={stopNestedScrollPropagation}
+        >
+          {groupOrder.map((groupId) => {
+            const items = groupedItems[groupId]!;
+            const selectableGroupItems = items.filter((item) => !completedRemediationIds.has(item.id));
+            const groupSelectedCount = selectableGroupItems.filter((i) => selectedRemediationIds.has(i.id)).length;
+            const groupTotalCount = selectableGroupItems.length;
+            const groupAllSelected = groupTotalCount > 0 && groupSelectedCount === groupTotalCount;
+            const groupPartial = groupSelectedCount > 0 && !groupAllSelected;
+            const groupTitle = groupId === 'ungrouped'
+              ? t('toolCards.codeReview.remediationActions.ungrouped', { defaultValue: 'Other' })
+              : t(`toolCards.codeReview.groups.${groupId}`, { defaultValue: groupId });
+            const groupMeta = groupId !== 'ungrouped' ? GROUP_PRIORITY_META[groupId as RemediationGroupId] : undefined;
+
+            return (
+              <div key={groupId} className="deep-review-action-bar__remediation-group">
+                <div
+                  className="deep-review-action-bar__remediation-group-header"
+                >
+                  <Checkbox
+                    checked={groupAllSelected}
+                    indeterminate={groupPartial}
+                    onChange={() => {
+                      if (!selectionDisabled) {
+                        onToggleGroup(groupId);
+                      }
+                    }}
+                    size="small"
+                    disabled={selectionDisabled || groupTotalCount === 0}
+                    label={(
+                      <>
+                        <span
+                          className="deep-review-action-bar__remediation-group-title"
+                          style={groupMeta ? { color: groupMeta.color } : undefined}
+                        >
+                          {groupTitle}
+                        </span>
+                        <span className="deep-review-action-bar__remediation-group-count">
+                          {groupSelectedCount}/{groupTotalCount}
+                        </span>
+                      </>
+                    )}
+                  />
+                </div>
+                <div className="deep-review-action-bar__remediation-group-items">
+                  {items.map((item) => {
+                    const isCompleted = completedRemediationIds.has(item.id);
+                    const isFixing = !isCompleted && fixingRemediationIds.has(item.id);
+                    const isLocked = selectionDisabled || isCompleted;
+                    return (
+                      <label
+                        key={item.id}
+                        className={`deep-review-action-bar__remediation-item ${
+                          isCompleted ? 'deep-review-action-bar__remediation-item--completed' : ''
+                        } ${isFixing ? 'deep-review-action-bar__remediation-item--fixing' : ''} ${
+                          isLocked ? 'deep-review-action-bar__remediation-item--locked' : ''
+                        }`}
+                      >
+                        <Checkbox
+                          checked={isCompleted || selectedRemediationIds.has(item.id)}
+                          onChange={() => !isLocked && onToggleRemediation(item.id)}
+                          disabled={isLocked}
+                          size="small"
+                        />
+                        <span
+                          className="deep-review-action-bar__remediation-text"
+                          title={item.decisionContext ? item.plan : undefined}
+                        >
+                          {isCompleted && (
+                            <CheckCircle size={12} className="deep-review-action-bar__completed-icon" />
+                          )}
+                          {isFixing && (
+                            <Loader2 size={12} className="deep-review-action-bar__fixing-icon" />
+                          )}
+                          {(isCompleted || isFixing) && (
+                            <span className="deep-review-action-bar__remediation-status">
+                              {isCompleted
+                                ? t('deepReviewActionBar.remediationStatus.fixed', { defaultValue: 'Fixed' })
+                                : t('deepReviewActionBar.remediationStatus.fixing', { defaultValue: 'Fixing' })}
+                            </span>
+                          )}
+                          {item.requiresDecision && (
+                            <span className="deep-review-action-bar__remediation-tag">
+                              {t('reviewActionBar.needsDecisionTag', { defaultValue: 'Decision' })}
+                            </span>
+                          )}
+                          {item.groupId === 'verification' ? (
+                            <span className="deep-review-action-bar__remediation-text-plain">
+                              {item.decisionContext?.question ?? item.plan}
+                            </span>
+                          ) : (
+                            <a
+                              className="deep-review-action-bar__remediation-link"
+                              href={`#review-remediation-${item.groupId ?? 'ungrouped'}-${item.groupIndex}`}
+                              onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                if (item.groupId != null) {
+                                  globalEventBus.emit(DEEP_REVIEW_SCROLL_TO_EVENT, {
+                                    groupId: item.groupId,
+                                    groupIndex: item.groupIndex,
+                                    issueIndex: item.issueIndex ?? -1,
+                                  });
+                                }
+                              }}
+                            >
+                              {item.decisionContext?.question ?? item.plan}
+                            </a>
+                          )}
+                          {item.decisionContext?.tradeoffs && (
+                            <span className="deep-review-action-bar__remediation-tradeoffs">
+                              {item.decisionContext.tradeoffs}
+                            </span>
+                          )}
+                          {item.decisionContext?.options && item.decisionContext.options.length > 0 && (
+                            <button
+                              type="button"
+                              className="deep-review-action-bar__decision-toggle"
+                              onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                onToggleDecisionExpansion(item.id);
+                              }}
+                            >
+                              {expandedDecisionIds.has(item.id)
+                                ? t('toolCards.codeReview.remediationActions.collapseOptions', { defaultValue: 'Hide options' })
+                                : t('toolCards.codeReview.remediationActions.expandOptions', { defaultValue: 'Show options' })}
+                            </button>
+                          )}
+                          {expandedDecisionIds.has(item.id) && item.decisionContext?.options && (
+                            <ul className="deep-review-action-bar__decision-options">
+                              {item.decisionContext.options.map((opt, oi) => {
+                                const isSelected = decisionSelections[item.id] === oi;
+                                const isRecommended = item.decisionContext?.recommendation === oi;
+                                return (
+                                  <li key={oi} className={`deep-review-action-bar__decision-option ${isSelected ? 'is-selected' : ''} ${isRecommended ? 'is-recommended' : ''}`}>
+                                    <button
+                                      type="button"
+                                      onClick={(event) => {
+                                        event.preventDefault();
+                                        event.stopPropagation();
+                                        onSetDecisionSelection(item.id, oi);
+                                      }}
+                                    >
+                                      <span className="deep-review-action-bar__decision-option-marker">
+                                        {isSelected ? '\u25CF' : '\u25CB'}
+                                      </span>
+                                      <span className="deep-review-action-bar__decision-option-text">
+                                        {opt}
+                                        {isRecommended ? ` (${t('toolCards.codeReview.remediationActions.recommended', { defaultValue: 'recommended' })})` : ''}
+                                      </span>
+                                    </button>
+                                  </li>
+                                );
+                              })}
+                            </ul>
+                          )}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {!selectionDisabled && totalCount > 0 && selectedCount === 0 && (
+        <div className="deep-review-action-bar__empty-selection" role="note">
+          <Info size={14} className="deep-review-action-bar__empty-selection-icon" />
+          <span>
+            {t('toolCards.codeReview.remediationActions.noSelectionHint', {
+              defaultValue: 'Select at least one remediation item to start fixing.',
+            })}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/ReviewActionControls.test.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/ReviewActionControls.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { ReviewActionControls } from './ReviewActionControls';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: Record<string, unknown> & { defaultValue?: string }) => {
+      const template = options?.defaultValue ?? _key;
+      return template.replace(/{{(\w+)}}/g, (_match, token: string) => String(options?.[token] ?? _match));
+    },
+  }),
+}));
+
+vi.mock('@/component-library', () => ({
+  Button: ({
+    children,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+  }) => <button type="button" disabled={disabled}>{children}</button>,
+  Checkbox: ({
+    checked,
+    disabled,
+  }: {
+    checked?: boolean;
+    disabled?: boolean;
+  }) => <input type="checkbox" checked={checked} disabled={disabled} readOnly />,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const baseProps = {
+  isDeepReview: true,
+  retryableSliceCount: 0,
+  remediationItemCount: 0,
+  hasInterruption: false,
+  partialResultsAvailable: false,
+  activeAction: null,
+  isFixDisabled: false,
+  isResumeRunning: false,
+  remainingFixIds: [],
+  modelRecoveryAction: null,
+  onRetryIncompleteSlices: vi.fn(),
+  onStartFixing: vi.fn(),
+  onFillBackInput: vi.fn(),
+  onContinueReview: vi.fn(),
+  onOpenModelSettings: vi.fn(),
+  onCopyDiagnostics: vi.fn(),
+  onViewPartialResults: vi.fn(),
+  onContinueFix: vi.fn(),
+  onSkipRemainingFixes: vi.fn(),
+  onMinimize: vi.fn(),
+};
+
+describe('ReviewActionControls', () => {
+  it('renders Deep Review retry and remediation actions for completed reviews', () => {
+    const html = renderToStaticMarkup(
+      <ReviewActionControls
+        {...baseProps}
+        phase="review_completed"
+        retryableSliceCount={2}
+        remediationItemCount={1}
+      />,
+    );
+
+    expect(html).toContain('Retry incomplete slices (2)');
+    expect(html).toContain('Start fixing');
+    expect(html).toContain('Fix and re-review');
+    expect(html).toContain('Fill to input');
+  });
+
+  it('renders interruption recovery, diagnostics, and partial-results actions', () => {
+    const html = renderToStaticMarkup(
+      <ReviewActionControls
+        {...baseProps}
+        phase="review_interrupted"
+        hasInterruption
+        partialResultsAvailable
+        modelRecoveryAction="switch_model"
+      />,
+    );
+
+    expect(html).toContain('Continue review');
+    expect(html).toContain('Switch model');
+    expect(html).toContain('Copy diagnostics');
+    expect(html).toContain('View partial results');
+  });
+
+  it('renders interrupted fix continuation actions', () => {
+    const html = renderToStaticMarkup(
+      <ReviewActionControls
+        {...baseProps}
+        phase="fix_interrupted"
+        remainingFixIds={['remediation-1', 'remediation-2']}
+      />,
+    );
+
+    expect(html).toContain('Fix was interrupted. 2 items remain.');
+    expect(html).toContain('Continue fixing 2 items');
+    expect(html).toContain('Skip remaining');
+  });
+});

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/ReviewActionControls.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/ReviewActionControls.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, Copy, Eye, Play, RotateCcw } from 'lucide-react';
+import { Button, Tooltip } from '@/component-library';
+import type { ReviewActionPhase } from '../../store/deepReviewActionBarStore';
+
+interface ReviewActionControlsProps {
+  phase: ReviewActionPhase;
+  isDeepReview: boolean;
+  retryableSliceCount: number;
+  remediationItemCount: number;
+  hasInterruption: boolean;
+  partialResultsAvailable: boolean;
+  activeAction: 'fix' | 'fix-review' | 'resume' | 'retry' | null;
+  isFixDisabled: boolean;
+  isResumeRunning: boolean;
+  remainingFixIds: string[];
+  modelRecoveryAction: 'switch_model' | 'open_model_settings' | null;
+  onRetryIncompleteSlices: () => void | Promise<void>;
+  onStartFixing: (rerunReview: boolean) => void | Promise<void>;
+  onFillBackInput: () => void | Promise<void>;
+  onContinueReview: () => void | Promise<void>;
+  onOpenModelSettings: () => void | Promise<void>;
+  onCopyDiagnostics: () => void | Promise<void>;
+  onViewPartialResults: () => void;
+  onContinueFix: () => void | Promise<void>;
+  onSkipRemainingFixes: () => void;
+  onMinimize: () => void;
+}
+
+export const ReviewActionControls: React.FC<ReviewActionControlsProps> = ({
+  phase,
+  isDeepReview,
+  retryableSliceCount,
+  remediationItemCount,
+  hasInterruption,
+  partialResultsAvailable,
+  activeAction,
+  isFixDisabled,
+  isResumeRunning,
+  remainingFixIds,
+  modelRecoveryAction,
+  onRetryIncompleteSlices,
+  onStartFixing,
+  onFillBackInput,
+  onContinueReview,
+  onOpenModelSettings,
+  onCopyDiagnostics,
+  onViewPartialResults,
+  onContinueFix,
+  onSkipRemainingFixes,
+  onMinimize,
+}) => {
+  const { t } = useTranslation('flow-chat');
+
+  return (
+    <div className="deep-review-action-bar__actions">
+      {phase === 'review_completed' && isDeepReview && retryableSliceCount > 0 && (
+        <Button
+          variant="secondary"
+          size="small"
+          isLoading={activeAction === 'retry'}
+          disabled={activeAction !== null}
+          onClick={() => void onRetryIncompleteSlices()}
+        >
+          <RotateCcw size={14} />
+          {t('deepReviewActionBar.retryIncompleteSlices', {
+            count: retryableSliceCount,
+            defaultValue: `Retry incomplete slices (${retryableSliceCount})`,
+          })}
+        </Button>
+      )}
+      {phase === 'review_completed' && remediationItemCount > 0 && (
+        <>
+          <Button
+            variant="primary"
+            size="small"
+            isLoading={activeAction === 'fix'}
+            disabled={isFixDisabled}
+            onClick={() => void onStartFixing(false)}
+          >
+            {t('toolCards.codeReview.remediationActions.startFix', { defaultValue: 'Start fixing' })}
+          </Button>
+          <Button
+            variant="secondary"
+            size="small"
+            isLoading={activeAction === 'fix-review'}
+            disabled={isFixDisabled}
+            onClick={() => void onStartFixing(true)}
+          >
+            {t('toolCards.codeReview.remediationActions.fixAndReview', { defaultValue: 'Fix and re-review' })}
+          </Button>
+          <Tooltip content={t('deepReviewActionBar.fillBackInputHint', {
+            defaultValue: 'Copy selected fix plan to the input box for manual editing',
+          })}>
+            <Button
+              variant="ghost"
+              size="small"
+              disabled={isFixDisabled}
+              onClick={() => void onFillBackInput()}
+            >
+              {t('deepReviewActionBar.fillBackInput', { defaultValue: 'Fill to input' })}
+            </Button>
+          </Tooltip>
+        </>
+      )}
+
+      {hasInterruption && (
+        <>
+          <Button
+            variant="primary"
+            size="small"
+            isLoading={activeAction === 'resume'}
+            disabled={activeAction !== null || isResumeRunning}
+            onClick={() => void onContinueReview()}
+          >
+            <Play size={14} />
+            {t('deepReviewActionBar.resumeReview', { defaultValue: 'Continue review' })}
+          </Button>
+          {modelRecoveryAction && (
+            <Button
+              variant="secondary"
+              size="small"
+              disabled={activeAction !== null}
+              onClick={() => void onOpenModelSettings()}
+            >
+              {modelRecoveryAction === 'switch_model'
+                ? t('deepReviewActionBar.switchModel', { defaultValue: 'Switch model' })
+                : t('deepReviewActionBar.openModelSettings', { defaultValue: 'Open model settings' })}
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="small"
+            onClick={() => void onCopyDiagnostics()}
+          >
+            <Copy size={14} />
+            {t('deepReviewActionBar.copyDiagnostics', { defaultValue: 'Copy diagnostics' })}
+          </Button>
+          {partialResultsAvailable && (
+            <Button
+              variant="ghost"
+              size="small"
+              onClick={onViewPartialResults}
+            >
+              <Eye size={14} />
+              {t('deepReviewActionBar.viewPartialResults', { defaultValue: 'View partial results' })}
+            </Button>
+          )}
+        </>
+      )}
+
+      {phase === 'fix_interrupted' && (
+        <>
+          <div className="deep-review-action-bar__interruption-notice">
+            <AlertTriangle size={16} className="deep-review-action-bar__interruption-icon" />
+            <span>
+              {t('deepReviewActionBar.fixInterrupted', {
+                defaultValue: 'Fix was interrupted. {{count}} items remain.',
+                count: remainingFixIds.length,
+              })}
+            </span>
+          </div>
+          <Button
+            variant="primary"
+            size="small"
+            onClick={() => void onContinueFix()}
+          >
+            <Play size={14} />
+            {t('deepReviewActionBar.continueFix', {
+              defaultValue: 'Continue fixing {{count}} items',
+              count: remainingFixIds.length,
+            })}
+          </Button>
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={onSkipRemainingFixes}
+          >
+            {t('deepReviewActionBar.skipRemaining', { defaultValue: 'Skip remaining' })}
+          </Button>
+        </>
+      )}
+
+      {(phase === 'fix_completed' || phase === 'fix_failed' || phase === 'fix_timeout' || phase === 'review_error') && (
+        <Button
+          variant="ghost"
+          size="small"
+          onClick={onMinimize}
+        >
+          {t('deepReviewActionBar.minimize', { defaultValue: 'Minimize' })}
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/interruptionDiagnostics.test.ts
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/interruptionDiagnostics.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import type { AiErrorPresentation } from '@/shared/ai-errors/aiErrorPresenter';
+import { buildInterruptionDiagnostics } from './interruptionDiagnostics';
+
+const t = (_key: string, options?: Record<string, unknown> & { defaultValue?: string }) => {
+  const template = options?.defaultValue ?? _key;
+  return template.replace(/{{(\w+)}}/g, (_match, token: string) => String(options?.[token] ?? _match));
+};
+
+const presentation: AiErrorPresentation = {
+  category: 'provider_unavailable',
+  titleKey: 'errors:ai.providerUnavailable.title',
+  messageKey: 'errors:ai.providerUnavailable.message',
+  severity: 'warning',
+  retryable: true,
+  actions: [
+    { code: 'wait_and_retry', labelKey: 'errors:ai.actions.waitAndRetry' },
+    { code: 'copy_diagnostics', labelKey: 'errors:ai.actions.copyDiagnostics' },
+  ],
+  diagnostics: '',
+};
+
+describe('buildInterruptionDiagnostics', () => {
+  it('prefers sanitized diagnostics produced by the AI error presenter', () => {
+    expect(buildInterruptionDiagnostics(
+      { category: 'network', rawMessage: 'raw' },
+      { ...presentation, diagnostics: 'sanitized diagnostics' },
+      t,
+    )).toBe('sanitized diagnostics');
+  });
+
+  it('builds fallback diagnostics without unbounded provider payloads', () => {
+    const diagnostics = buildInterruptionDiagnostics(
+      {
+        category: 'provider_unavailable',
+        provider: 'anthropic',
+        providerCode: 'overloaded_error',
+        providerMessage: 'x'.repeat(520),
+        httpStatus: 529,
+        requestId: 'req-1',
+        rawMessage: 'y'.repeat(520),
+      },
+      presentation,
+      t,
+    );
+
+    expect(diagnostics).toContain('=== Deep Review Interruption Diagnostics ===');
+    expect(diagnostics).toContain('Error type: provider_unavailable (provider_unavailable)');
+    expect(diagnostics).toContain('Suggested actions: wait_and_retry, copy_diagnostics');
+    expect(diagnostics).toContain('  - provider: anthropic');
+    expect(diagnostics).toContain('  - provider message: ');
+    expect(diagnostics).toContain('... [truncated]');
+    expect(diagnostics.length).toBeLessThan(1500);
+  });
+});

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/interruptionDiagnostics.ts
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/interruptionDiagnostics.ts
@@ -1,0 +1,55 @@
+import type {
+  AiErrorDetail,
+  AiErrorPresentation,
+} from '@/shared/ai-errors/aiErrorPresenter';
+
+type Translate = (key: string, options?: Record<string, unknown> & { defaultValue?: string }) => string;
+
+function truncateDiagnosticValue(value: string): string {
+  return value.length > 500 ? `${value.slice(0, 500)}... [truncated]` : value;
+}
+
+export function buildInterruptionDiagnostics(
+  detail: AiErrorDetail,
+  presentation: AiErrorPresentation,
+  t: Translate,
+): string {
+  if (presentation.diagnostics) {
+    return presentation.diagnostics;
+  }
+
+  const lines: string[] = [];
+  lines.push(t('deepReviewActionBar.diagnosticsTitle', { defaultValue: '=== Deep Review Interruption Diagnostics ===' }));
+  lines.push('');
+
+  const categoryLabel = t(presentation.titleKey, { defaultValue: presentation.category });
+  const categoryMessage = t(presentation.messageKey, { defaultValue: '' });
+  lines.push(`${t('deepReviewActionBar.diagnosticsErrorType', { defaultValue: 'Error type' })}: ${categoryLabel} (${presentation.category})`);
+  if (categoryMessage) {
+    lines.push(`${t('deepReviewActionBar.diagnosticsDescription', { defaultValue: 'Description' })}: ${categoryMessage}`);
+  }
+  lines.push('');
+
+  if (presentation.actions.length > 0) {
+    const actionLabels = presentation.actions.map((action) => {
+      return t(action.labelKey, { defaultValue: action.code });
+    });
+    lines.push(`${t('deepReviewActionBar.diagnosticsSuggestedActions', { defaultValue: 'Suggested actions' })}: ${actionLabels.join(', ')}`);
+    lines.push('');
+  }
+
+  lines.push(`${t('deepReviewActionBar.diagnosticsTechnicalDetails', { defaultValue: 'Technical details' })}:`);
+  lines.push(`  - category: ${detail.category ?? 'unknown'}`);
+  if (detail.provider) lines.push(`  - provider: ${detail.provider}`);
+  if (detail.providerCode) lines.push(`  - provider code: ${detail.providerCode}`);
+  if (detail.providerMessage) {
+    lines.push(`  - provider message: ${truncateDiagnosticValue(detail.providerMessage)}`);
+  }
+  if (detail.httpStatus) lines.push(`  - HTTP status: ${detail.httpStatus}`);
+  if (detail.requestId) lines.push(`  - request ID: ${detail.requestId}`);
+  if (detail.rawMessage) {
+    lines.push(`  - raw message: ${truncateDiagnosticValue(detail.rawMessage)}`);
+  }
+
+  return lines.join('\n');
+}

--- a/src/web-ui/src/flow_chat/deep-review/report/codeReviewReport.ts
+++ b/src/web-ui/src/flow_chat/deep-review/report/codeReviewReport.ts
@@ -214,6 +214,7 @@ const RETRYABLE_CAPACITY_REASONS = new Set([
   'provider_rate_limit',
   'provider_concurrency_limit',
   'retry_after',
+  'launch_batch_blocked',
   'temporary_overload',
 ]);
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -120,8 +120,13 @@ function handleDeepReviewQueueStateChanged(event: DeepReviewQueueStateChangedEve
 
   const actionBar = useReviewActionBarStore.getState();
   if (actionBar.childSessionId === event.sessionId) {
-    actionBar.setCapacityQueueState(queueState);
-    if (actionBar.phase === 'idle') {
+    actionBar.applyCapacityQueueState(queueState);
+    const nextActionBar = useReviewActionBarStore.getState();
+    if (
+      queueState.status !== 'running' &&
+      queueState.status !== 'capacity_skipped' &&
+      nextActionBar.phase === 'idle'
+    ) {
       actionBar.updatePhase('review_waiting_capacity');
     }
     return;

--- a/src/web-ui/src/flow_chat/store/deepReviewActionBarStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/deepReviewActionBarStore.test.ts
@@ -119,9 +119,10 @@ describe('deepReviewActionBarStore', () => {
       });
 
       bar().setSelectedRemediationIds(new Set(['remediation-0']));
-      bar().setActiveAction('fix');
+      bar().setActiveAction('fix', { baselineTurnId: 'review-turn-1' });
 
       expect(bar().fixingRemediationIds.has('remediation-0')).toBe(true);
+      expect(bar().fixingBaselineTurnId).toBe('review-turn-1');
     });
 
     it('moves fixing IDs to completed when fix completes', () => {
@@ -142,6 +143,7 @@ describe('deepReviewActionBarStore', () => {
       const s = bar();
       expect(s.completedRemediationIds.has('remediation-0')).toBe(true);
       expect(s.fixingRemediationIds.size).toBe(0);
+      expect(s.fixingBaselineTurnId).toBeNull();
       expect(s.phase).toBe('fix_completed');
     });
 
@@ -162,6 +164,7 @@ describe('deepReviewActionBarStore', () => {
 
       const s = bar();
       expect(s.completedRemediationIds.has('remediation-0')).toBe(false);
+      expect(s.fixingBaselineTurnId).toBeNull();
       expect(s.phase).toBe('fix_failed');
       expect(s.errorMessage).toBe('Something went wrong');
     });
@@ -277,6 +280,73 @@ describe('deepReviewActionBarStore', () => {
       expect(state.queuedReviewerCount).toBe(1);
       expect(state.optionalReviewerCount).toBe(0);
     });
+
+    it('merges reviewer queue events and closes the queue when the last reviewer leaves', () => {
+      bar().showCapacityQueueBar({
+        childSessionId: 'child-1',
+        parentSessionId: 'parent-1',
+        capacityQueueState: {
+          toolId: 'task-security',
+          subagentType: 'ReviewSecurity',
+          status: 'queued_for_capacity',
+          reason: 'local_concurrency_cap',
+          queuedReviewerCount: 1,
+          waitingReviewers: [{
+            toolId: 'task-security',
+            subagentType: 'ReviewSecurity',
+            displayName: 'Security reviewer',
+            status: 'queued_for_capacity',
+            reason: 'local_concurrency_cap',
+          }],
+        },
+      });
+
+      bar().applyCapacityQueueState({
+        toolId: 'task-frontend',
+        subagentType: 'ReviewFrontend',
+        status: 'queued_for_capacity',
+        reason: 'launch_batch_blocked',
+        queuedReviewerCount: 1,
+        waitingReviewers: [{
+          toolId: 'task-frontend',
+          subagentType: 'ReviewFrontend',
+          displayName: 'Frontend reviewer',
+          status: 'queued_for_capacity',
+          reason: 'launch_batch_blocked',
+        }],
+      });
+
+      expect(bar().capacityQueueState?.queuedReviewerCount).toBe(2);
+      expect(bar().capacityQueueState?.waitingReviewers?.map((reviewer) => reviewer.displayName)).toEqual([
+        'Security reviewer',
+        'Frontend reviewer',
+      ]);
+
+      bar().applyCapacityQueueState({
+        toolId: 'task-security',
+        subagentType: 'ReviewSecurity',
+        status: 'running',
+        queuedReviewerCount: 0,
+        waitingReviewers: [],
+      });
+
+      expect(bar().capacityQueueState?.queuedReviewerCount).toBe(1);
+      expect(bar().capacityQueueState?.waitingReviewers?.map((reviewer) => reviewer.displayName)).toEqual([
+        'Frontend reviewer',
+      ]);
+      expect(bar().phase).toBe('review_waiting_capacity');
+
+      bar().applyCapacityQueueState({
+        toolId: 'task-frontend',
+        subagentType: 'ReviewFrontend',
+        status: 'capacity_skipped',
+        queuedReviewerCount: 0,
+        waitingReviewers: [],
+      });
+
+      expect(bar().capacityQueueState).toBeNull();
+      expect(bar().phase).toBe('idle');
+    });
   });
 
   describe('toggleRemediation with completed items', () => {
@@ -298,6 +368,53 @@ describe('deepReviewActionBarStore', () => {
       bar().setSelectedRemediationIds(new Set());
       bar().toggleRemediation('remediation-1');
       expect(bar().selectedRemediationIds.has('remediation-1')).toBe(true);
+
+      bar().toggleRemediation('remediation-0');
+      expect(bar().selectedRemediationIds.has('remediation-0')).toBe(false);
+    });
+
+    it('does not select completed items through select-all', () => {
+      bar().showActionBar({
+        childSessionId: 'child-1',
+        parentSessionId: 'parent-1',
+        reviewData: {
+          summary: { recommended_action: 'request_changes' },
+          remediation_plan: ['Fix issue 1', 'Fix issue 2'],
+        },
+        completedRemediationIds: new Set(['remediation-0']),
+      });
+
+      bar().setSelectedRemediationIds(new Set());
+      bar().toggleAllRemediation();
+
+      expect([...bar().selectedRemediationIds].sort()).toEqual(['remediation-1']);
+    });
+
+    it('does not select completed items through a remediation group root toggle', () => {
+      bar().showActionBar({
+        childSessionId: 'child-1',
+        parentSessionId: 'parent-1',
+        reviewData: {
+          review_mode: 'deep',
+          report_sections: {
+            remediation_groups: {
+              should_improve: [
+                'Improve error copy',
+                'Improve retry state',
+              ],
+            },
+          },
+        },
+        completedRemediationIds: new Set(['remediation-should_improve-0']),
+      });
+
+      bar().setSelectedRemediationIds(new Set());
+      bar().toggleGroupRemediation('should_improve');
+
+      expect([...bar().selectedRemediationIds].sort()).toEqual(['remediation-should_improve-1']);
+
+      bar().toggleGroupRemediation('should_improve');
+      expect(bar().selectedRemediationIds.size).toBe(0);
     });
   });
 

--- a/src/web-ui/src/flow_chat/store/deepReviewActionBarStore.ts
+++ b/src/web-ui/src/flow_chat/store/deepReviewActionBarStore.ts
@@ -54,7 +54,19 @@ export type DeepReviewCapacityQueueReason =
   | 'provider_concurrency_limit'
   | 'retry_after'
   | 'local_concurrency_cap'
+  | 'launch_batch_blocked'
   | 'temporary_overload';
+
+export interface DeepReviewCapacityWaitingReviewer {
+  toolId?: string;
+  subagentType?: string;
+  displayName?: string;
+  status: Exclude<DeepReviewCapacityQueueStatus, 'running' | 'capacity_skipped'>;
+  reason?: DeepReviewCapacityQueueReason;
+  optional?: boolean;
+  queueElapsedMs?: number;
+  maxQueueWaitSeconds?: number;
+}
 
 export interface DeepReviewCapacityQueueState {
   toolId?: string;
@@ -71,6 +83,7 @@ export interface DeepReviewCapacityQueueState {
   maxQueueWaitSeconds?: number;
   sessionConcurrencyHigh?: boolean;
   controlMode?: 'local' | 'session_stop_only' | 'backend';
+  waitingReviewers?: DeepReviewCapacityWaitingReviewer[];
 }
 
 export interface ReviewActionBarState {
@@ -106,6 +119,8 @@ export interface ReviewActionBarState {
   completedRemediationIds: Set<string>;
   /** IDs of items being fixed in the current fix_running session (snapshot at start) */
   fixingRemediationIds: Set<string>;
+  /** Last dialog turn that existed before the current fix request was submitted */
+  fixingBaselineTurnId: string | null;
   /** IDs of items remaining when a fix was interrupted */
   remainingFixIds: string[];
   /** User's option choice for needs_decision items: map of item id -> option index */
@@ -139,7 +154,10 @@ export interface ReviewActionBarState {
   toggleRemediation: (id: string) => void;
   toggleAllRemediation: () => void;
   toggleGroupRemediation: (groupId: RemediationGroupId) => void;
-  setActiveAction: (action: 'fix' | 'fix-review' | 'resume' | 'retry' | null) => void;
+  setActiveAction: (
+    action: 'fix' | 'fix-review' | 'resume' | 'retry' | null,
+    options?: { baselineTurnId?: string | null },
+  ) => void;
   setCustomInstructions: (value: string) => void;
   setSelectedRemediationIds: (ids: Set<string>) => void;
   dismiss: () => void;
@@ -147,6 +165,7 @@ export interface ReviewActionBarState {
   restore: () => void;
   skipRemainingFixes: () => void;
   setCapacityQueueState: (state: DeepReviewCapacityQueueState | null) => void;
+  applyCapacityQueueState: (state: DeepReviewCapacityQueueState) => void;
   pauseCapacityQueue: () => void;
   continueCapacityQueue: () => void;
   cancelQueuedReviewers: () => void;
@@ -174,11 +193,100 @@ const initialState = {
   interruption: null as DeepReviewInterruption | null,
   completedRemediationIds: new Set<string>(),
   fixingRemediationIds: new Set<string>(),
+  fixingBaselineTurnId: null as string | null,
   remainingFixIds: [] as string[],
   decisionSelections: {} as Record<string, number>,
   capacityQueueState: null as DeepReviewCapacityQueueState | null,
   lastCapacityQueueAction: null as DeepReviewCapacityQueueAction | null,
 };
+
+function isTerminalQueueStatus(status: DeepReviewCapacityQueueStatus): boolean {
+  return status === 'running' || status === 'capacity_skipped';
+}
+
+function queueReviewerKey(
+  reviewer: Pick<DeepReviewCapacityWaitingReviewer, 'toolId' | 'subagentType'>,
+): string {
+  return reviewer.toolId || reviewer.subagentType || 'unknown-reviewer';
+}
+
+function waitingReviewerFromQueueState(
+  state: DeepReviewCapacityQueueState,
+): DeepReviewCapacityWaitingReviewer | null {
+  if (state.status === 'running' || state.status === 'capacity_skipped') {
+    return null;
+  }
+
+  return {
+    toolId: state.toolId,
+    subagentType: state.subagentType,
+    status: state.status,
+    reason: state.reason,
+    optional: (state.optionalReviewerCount ?? 0) > 0,
+    queueElapsedMs: state.queueElapsedMs,
+    maxQueueWaitSeconds: state.maxQueueWaitSeconds,
+  };
+}
+
+function normalizeWaitingReviewers(
+  state: DeepReviewCapacityQueueState,
+): DeepReviewCapacityWaitingReviewer[] {
+  if (state.waitingReviewers) {
+    return state.waitingReviewers;
+  }
+
+  const reviewer = waitingReviewerFromQueueState(state);
+  return reviewer ? [reviewer] : [];
+}
+
+function withNormalizedWaitingReviewers(
+  state: DeepReviewCapacityQueueState,
+): DeepReviewCapacityQueueState {
+  return {
+    ...state,
+    waitingReviewers: normalizeWaitingReviewers(state),
+  };
+}
+
+function mergeCapacityQueueState(
+  current: DeepReviewCapacityQueueState | null,
+  incoming: DeepReviewCapacityQueueState,
+): DeepReviewCapacityQueueState | null {
+  const currentReviewers = current?.waitingReviewers ?? normalizeWaitingReviewers(current ?? incoming);
+  const reviewerMap = new Map(
+    currentReviewers.map((reviewer) => [queueReviewerKey(reviewer), reviewer]),
+  );
+  const incomingReviewers = normalizeWaitingReviewers(incoming);
+  const fallbackIncomingKey = queueReviewerKey(incoming);
+
+  if (isTerminalQueueStatus(incoming.status)) {
+    reviewerMap.delete(fallbackIncomingKey);
+    for (const reviewer of incomingReviewers) {
+      reviewerMap.delete(queueReviewerKey(reviewer));
+    }
+  } else {
+    for (const reviewer of incomingReviewers) {
+      reviewerMap.set(queueReviewerKey(reviewer), reviewer);
+    }
+  }
+
+  const waitingReviewers = [...reviewerMap.values()];
+  if (waitingReviewers.length === 0) {
+    return null;
+  }
+
+  const queuedReviewerCount = Math.max(waitingReviewers.length, incoming.queuedReviewerCount ?? 0);
+  const optionalReviewerCount = waitingReviewers.filter((reviewer) => reviewer.optional).length;
+  const allPaused = waitingReviewers.every((reviewer) => reviewer.status === 'paused_by_user');
+
+  return {
+    ...incoming,
+    status: allPaused ? 'paused_by_user' : 'queued_for_capacity',
+    queuedReviewerCount,
+    optionalReviewerCount,
+    waitingReviewers,
+  };
+}
 
 export const useReviewActionBarStore = create<ReviewActionBarState>((set, get) => ({
   ...initialState,
@@ -215,6 +323,7 @@ export const useReviewActionBarStore = create<ReviewActionBarState>((set, get) =
       interruption: null,
       completedRemediationIds: preservedCompleted,
       fixingRemediationIds: new Set(),
+      fixingBaselineTurnId: null,
       remainingFixIds: [],
       decisionSelections: {},
       capacityQueueState: null,
@@ -240,6 +349,7 @@ export const useReviewActionBarStore = create<ReviewActionBarState>((set, get) =
       interruption,
       completedRemediationIds: new Set(),
       fixingRemediationIds: new Set(),
+      fixingBaselineTurnId: null,
       remainingFixIds: [],
       decisionSelections: {},
       capacityQueueState: null,
@@ -267,9 +377,10 @@ export const useReviewActionBarStore = create<ReviewActionBarState>((set, get) =
         ? get().completedRemediationIds
         : new Set(),
       fixingRemediationIds: new Set(),
+      fixingBaselineTurnId: null,
       remainingFixIds: [],
       decisionSelections: {},
-      capacityQueueState,
+      capacityQueueState: withNormalizedWaitingReviewers(capacityQueueState),
       lastCapacityQueueAction: null,
     });
   },
@@ -287,15 +398,25 @@ export const useReviewActionBarStore = create<ReviewActionBarState>((set, get) =
         errorMessage: errorMessage ?? null,
         completedRemediationIds: nextCompleted,
         fixingRemediationIds: new Set(),
+        fixingBaselineTurnId: null,
         remainingFixIds: [],
       });
     } else {
-      set({ phase, errorMessage: errorMessage ?? null });
+      set({
+        phase,
+        errorMessage: errorMessage ?? null,
+        ...(phase !== 'fix_running' ? { fixingBaselineTurnId: null } : {}),
+      });
     }
   },
 
   toggleRemediation: (id) => {
-    const next = new Set(get().selectedRemediationIds);
+    const { completedRemediationIds, selectedRemediationIds } = get();
+    if (completedRemediationIds.has(id)) {
+      return;
+    }
+
+    const next = new Set(selectedRemediationIds);
     if (next.has(id)) {
       next.delete(id);
     } else {
@@ -305,23 +426,46 @@ export const useReviewActionBarStore = create<ReviewActionBarState>((set, get) =
   },
 
   toggleAllRemediation: () => {
-    const { remediationItems, selectedRemediationIds } = get();
-    const allSelected = remediationItems.length > 0 &&
-      selectedRemediationIds.size === remediationItems.length;
-    if (allSelected) {
-      set({ selectedRemediationIds: new Set() });
-    } else {
-      set({ selectedRemediationIds: new Set(remediationItems.map((i) => i.id)) });
+    const { remediationItems, selectedRemediationIds, completedRemediationIds } = get();
+    const selectableIds = remediationItems
+      .filter((item) => !completedRemediationIds.has(item.id))
+      .map((item) => item.id);
+    const allSelected = selectableIds.length > 0 &&
+      selectableIds.every((id) => selectedRemediationIds.has(id));
+    const next = new Set(selectedRemediationIds);
+
+    for (const id of completedRemediationIds) {
+      next.delete(id);
     }
+
+    if (allSelected) {
+      for (const id of selectableIds) {
+        next.delete(id);
+      }
+    } else {
+      for (const id of selectableIds) {
+        next.add(id);
+      }
+    }
+
+    set({ selectedRemediationIds: next });
   },
 
   toggleGroupRemediation: (groupId) => {
-    const { remediationItems, selectedRemediationIds } = get();
-    const groupIds = new Set(remediationItems.filter((i) => i.groupId === groupId).map((i) => i.id));
+    const { remediationItems, selectedRemediationIds, completedRemediationIds } = get();
+    const groupIds = new Set(
+      remediationItems
+        .filter((item) => (item.groupId ?? 'ungrouped') === groupId && !completedRemediationIds.has(item.id))
+        .map((item) => item.id),
+    );
     if (groupIds.size === 0) return;
 
     const allGroupSelected = [...groupIds].every((id) => selectedRemediationIds.has(id));
     const next = new Set(selectedRemediationIds);
+
+    for (const id of completedRemediationIds) {
+      next.delete(id);
+    }
 
     if (allGroupSelected) {
       for (const id of groupIds) {
@@ -336,12 +480,13 @@ export const useReviewActionBarStore = create<ReviewActionBarState>((set, get) =
     set({ selectedRemediationIds: next });
   },
 
-  setActiveAction: (action) => {
+  setActiveAction: (action, options) => {
     if (action === 'fix' || action === 'fix-review') {
       set({
         activeAction: action,
         lastSubmittedAction: action,
         fixingRemediationIds: new Set(get().selectedRemediationIds),
+        fixingBaselineTurnId: options?.baselineTurnId ?? null,
       });
     } else if (action === 'resume' || action === 'retry') {
       set({
@@ -364,18 +509,38 @@ export const useReviewActionBarStore = create<ReviewActionBarState>((set, get) =
   skipRemainingFixes: () => set({
     phase: 'review_completed',
     remainingFixIds: [],
+    fixingBaselineTurnId: null,
     activeAction: null,
     lastSubmittedAction: null,
   }),
   setCapacityQueueState: (capacityQueueState) => set({
-    capacityQueueState,
+    capacityQueueState: capacityQueueState
+      ? withNormalizedWaitingReviewers(capacityQueueState)
+      : null,
     lastCapacityQueueAction: null,
   }),
+  applyCapacityQueueState: (capacityQueueState) => {
+    const nextQueueState = mergeCapacityQueueState(get().capacityQueueState, capacityQueueState);
+    set((state) => ({
+      capacityQueueState: nextQueueState,
+      lastCapacityQueueAction: null,
+      ...(nextQueueState === null && state.phase === 'review_waiting_capacity'
+        ? { phase: 'idle' as ReviewActionPhase }
+        : {}),
+    }));
+  },
   pauseCapacityQueue: () => {
     const current = get().capacityQueueState;
     if (!current || current.status === 'capacity_skipped') return;
     set({
-      capacityQueueState: { ...current, status: 'paused_by_user' },
+      capacityQueueState: {
+        ...current,
+        status: 'paused_by_user',
+        waitingReviewers: current.waitingReviewers?.map((reviewer) => ({
+          ...reviewer,
+          status: 'paused_by_user',
+        })),
+      },
       lastCapacityQueueAction: 'pause',
     });
   },
@@ -383,7 +548,14 @@ export const useReviewActionBarStore = create<ReviewActionBarState>((set, get) =
     const current = get().capacityQueueState;
     if (!current || current.status !== 'paused_by_user') return;
     set({
-      capacityQueueState: { ...current, status: 'queued_for_capacity' },
+      capacityQueueState: {
+        ...current,
+        status: 'queued_for_capacity',
+        waitingReviewers: current.waitingReviewers?.map((reviewer) => ({
+          ...reviewer,
+          status: 'queued_for_capacity',
+        })),
+      },
       lastCapacityQueueAction: 'continue',
     });
   },
@@ -396,6 +568,7 @@ export const useReviewActionBarStore = create<ReviewActionBarState>((set, get) =
         status: 'capacity_skipped',
         queuedReviewerCount: 0,
         optionalReviewerCount: 0,
+        waitingReviewers: [],
       },
       lastCapacityQueueAction: 'cancel',
     });
@@ -414,6 +587,7 @@ export const useReviewActionBarStore = create<ReviewActionBarState>((set, get) =
         status: queuedReviewerCount > 0 ? current.status : 'capacity_skipped',
         queuedReviewerCount,
         optionalReviewerCount: 0,
+        waitingReviewers: current.waitingReviewers?.filter((reviewer) => !reviewer.optional),
       },
       lastCapacityQueueAction: 'skip_optional',
     });

--- a/src/web-ui/src/flow_chat/tool-cards/CodeReviewReportExportActions.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CodeReviewReportExportActions.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { CodeReviewReportExportActions } from './CodeReviewReportExportActions';
+
+function Icon({ name }: { name: string }) {
+  return <svg data-icon={name} />;
+}
+
+vi.mock('lucide-react', () => ({
+  Check: () => <Icon name="check" />,
+  ClipboardCopy: () => <Icon name="clipboard-copy" />,
+  Copy: () => <Icon name="copy" />,
+  FileDown: () => <Icon name="file-down" />,
+  FilePenLine: () => <Icon name="file-pen-line" />,
+  Loader2: () => <Icon name="loader" />,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock('@/component-library', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/shared/notification-system', () => ({
+  notificationService: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/utils/tabUtils', () => ({
+  createMarkdownEditorTab: vi.fn(),
+}));
+
+vi.mock('../utils/codeReviewReport', () => ({
+  formatCodeReviewReportMarkdown: () => '# Review',
+}));
+
+describe('CodeReviewReportExportActions', () => {
+  it('uses the same copy icon as other copy buttons', () => {
+    const html = renderToStaticMarkup(
+      <CodeReviewReportExportActions reviewData={{ summary: { recommended_action: 'approve' } }} />,
+    );
+
+    expect(html).toContain('aria-label="Copy Markdown"');
+    expect(html).toContain('data-icon="copy"');
+    expect(html).not.toContain('data-icon="clipboard-copy"');
+  });
+});

--- a/src/web-ui/src/flow_chat/tool-cards/CodeReviewReportExportActions.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CodeReviewReportExportActions.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { Check, ClipboardCopy, FileDown, FilePenLine, Loader2 } from 'lucide-react';
+import { Check, Copy, FileDown, FilePenLine, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from '@/component-library';
 import { notificationService } from '@/shared/notification-system';
@@ -221,7 +221,7 @@ export const CodeReviewReportExportActions: React.FC<CodeReviewReportExportActio
           onClick={handleCopy}
           aria-label={t('toolCards.codeReview.export.copyMarkdown', { defaultValue: 'Copy Markdown' })}
         >
-          {copied ? <Check size={13} /> : <ClipboardCopy size={13} />}
+          {copied ? <Check size={14} /> : <Copy size={14} />}
         </button>
       </Tooltip>
       <Tooltip content={t('toolCards.codeReview.export.openMarkdown', { defaultValue: 'Open as Markdown' })} placement="top">
@@ -231,7 +231,7 @@ export const CodeReviewReportExportActions: React.FC<CodeReviewReportExportActio
           onClick={handleOpenInEditor}
           aria-label={t('toolCards.codeReview.export.openMarkdown', { defaultValue: 'Open as Markdown' })}
         >
-          <FilePenLine size={13} />
+          <FilePenLine size={14} />
         </button>
       </Tooltip>
       <Tooltip content={t('toolCards.codeReview.export.saveMarkdown', { defaultValue: 'Save Markdown' })} placement="top">
@@ -242,7 +242,7 @@ export const CodeReviewReportExportActions: React.FC<CodeReviewReportExportActio
           disabled={saving}
           aria-label={t('toolCards.codeReview.export.saveMarkdown', { defaultValue: 'Save Markdown' })}
         >
-          {saving ? <Loader2 className="animate-spin" size={13} /> : <FileDown size={13} />}
+          {saving ? <Loader2 className="animate-spin" size={14} /> : <FileDown size={14} />}
         </button>
       </Tooltip>
     </div>

--- a/src/web-ui/src/flow_chat/tool-cards/CodeReviewToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/CodeReviewToolCard.scss
@@ -27,8 +27,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 20px;
-    height: 20px;
+    width: 24px;
+    height: 24px;
     padding: 0;
     border: none;
     border-radius: 4px;

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.test.tsx
@@ -1,0 +1,149 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskToolDisplay } from './TaskToolDisplay';
+import { taskCollapseStateManager } from '../store/TaskCollapseStateManager';
+import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: Record<string, unknown> & { defaultValue?: string }) =>
+      options?.defaultValue ?? String(options?.agentType ?? _key),
+  }),
+}));
+
+vi.mock('../../component-library', () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button type="button" disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+  CubeLoading: () => <span data-testid="cube-loading" />,
+}));
+
+vi.mock('@/component-library/components/Markdown/Markdown', () => ({
+  Markdown: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+vi.mock('@/shared/services/reviewTeamService', () => ({
+  getReviewerContextBySubagentId: () => null,
+}));
+
+vi.mock('./ToolTimeoutIndicator', () => ({
+  ToolTimeoutIndicator: () => <span data-testid="tool-timeout-indicator" />,
+}));
+
+let JSDOMCtor: (new (
+  html?: string,
+  options?: { pretendToBeVisual?: boolean; url?: string }
+) => { window: Window & typeof globalThis }) | null = null;
+
+try {
+  const jsdom = await import('jsdom');
+  JSDOMCtor = jsdom.JSDOM as typeof JSDOMCtor;
+} catch {
+  JSDOMCtor = null;
+}
+
+const describeWithJsdom = JSDOMCtor ? describe : describe.skip;
+
+const config: ToolCardConfig = {
+  toolName: 'Task',
+  displayName: 'Task',
+  icon: 'task',
+  requiresConfirmation: false,
+  resultDisplayType: 'summary',
+};
+
+function failedTaskItem(): FlowToolItem {
+  return {
+    id: 'task-tool-1',
+    type: 'tool',
+    toolName: 'Task',
+    timestamp: Date.now(),
+    status: 'error',
+    toolCall: {
+      id: 'task-call-1',
+      input: {
+        description: 'Review frontend',
+        prompt: 'Review frontend code',
+        subagent_type: 'ReviewFrontend',
+      },
+    },
+    toolResult: {
+      success: false,
+      result: null,
+      error: 'Subagent failed before finishing.',
+    },
+  };
+}
+
+describeWithJsdom('TaskToolDisplay', () => {
+  let dom: { window: Window & typeof globalThis };
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    dom = new JSDOMCtor!('<!doctype html><html><body></body></html>', {
+      pretendToBeVisual: true,
+      url: 'http://localhost',
+    });
+
+    const { window } = dom;
+    vi.stubGlobal('window', window);
+    vi.stubGlobal('document', window.document);
+    vi.stubGlobal('navigator', window.navigator);
+    vi.stubGlobal('HTMLElement', window.HTMLElement);
+    vi.stubGlobal('CustomEvent', window.CustomEvent);
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+    taskCollapseStateManager.clearAll();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    dom.window.close();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    taskCollapseStateManager.clearAll();
+  });
+
+  it('allows a failed subagent task card to collapse after it was expanded', async () => {
+    taskCollapseStateManager.setCollapsed('task-tool-1', false);
+
+    await act(async () => {
+      root.render(
+        <TaskToolDisplay
+          toolItem={failedTaskItem()}
+          config={config}
+          sessionId="parent-session"
+        />,
+      );
+    });
+
+    expect(taskCollapseStateManager.isCollapsed('task-tool-1')).toBe(false);
+
+    const card = container.querySelector<HTMLElement>('.base-tool-card');
+    expect(card).toBeTruthy();
+
+    await act(async () => {
+      card!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(taskCollapseStateManager.isCollapsed('task-tool-1')).toBe(true);
+  });
+});

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
@@ -230,20 +230,16 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
       return;
     }
 
-    if (isFailed) {
-      return;
-    }
-
     // Pause auto-scroll while the user toggles the card.
     updateCardExpandedState(!isExpanded);
-  }, [isFailed, isExpanded, updateCardExpandedState]);
+  }, [isExpanded, updateCardExpandedState]);
 
   const showHeaderExpandHint =
-    !isFailed &&
-    (hasInterruptionNote ||
-      hasRealPrompt ||
-      needsConfirmation ||
-      Boolean(taskInput?.reviewerContext));
+    isFailed ||
+    hasInterruptionNote ||
+    hasRealPrompt ||
+    needsConfirmation ||
+    Boolean(taskInput?.reviewerContext);
 
   const taskHeaderLine = useMemo(() => {
     const desc =

--- a/src/web-ui/src/flow_chat/utils/deepReviewQueueStateEvents.test.ts
+++ b/src/web-ui/src/flow_chat/utils/deepReviewQueueStateEvents.test.ts
@@ -60,7 +60,118 @@ describe('buildDeepReviewCapacityQueueStateFromEvent', () => {
       maxQueueWaitSeconds: 60,
       sessionConcurrencyHigh: true,
       controlMode: 'backend',
+      waitingReviewers: [{
+        toolId: 'task-1',
+        subagentType: 'ReviewSecurity',
+        displayName: undefined,
+        status: 'queued_for_capacity',
+        reason: 'provider_concurrency_limit',
+        optional: true,
+        queueElapsedMs: 1200,
+        maxQueueWaitSeconds: 60,
+      }],
     });
+  });
+
+  it('uses the run manifest display name for the waiting reviewer list', () => {
+    const session = createSession('deep_review');
+    session.deepReviewRunManifest = {
+      reviewMode: 'deep',
+      policySource: 'default-review-team-config',
+      target: { source: 'session_files', resolution: 'resolved', files: [], tags: [], evidence: [], warnings: [] },
+      strategyLevel: 'normal',
+      strategyDecision: {
+        teamDefaultStrategy: 'normal',
+        finalStrategy: 'normal',
+        frontendRecommendation: { strategyLevel: 'normal', reasons: [] },
+        backendRecommendation: { strategyLevel: 'normal', reasons: [] },
+        decisionSource: 'team_default',
+        rationale: [],
+      },
+      preReviewSummary: {
+        targetSummary: 'No target files',
+        riskSummary: 'No risk summary',
+        recommendedStrategy: 'normal',
+        reviewerSummary: 'Reviewers selected',
+        warnings: [],
+      },
+      concurrencyPolicy: {
+        maxParallelInstances: 2,
+        staggerSeconds: 0,
+        batchExtrasSeparately: true,
+        allowProviderCapacityQueue: true,
+        maxQueueWaitSeconds: 60,
+      },
+      executionPolicy: {
+        reviewerTimeoutSeconds: 300,
+        judgeTimeoutSeconds: 300,
+        maxSameRoleInstances: 1,
+        reviewerFileSplitThreshold: 20,
+      },
+      sharedContextCache: {
+        source: 'work_packets',
+        entries: [],
+      },
+      incrementalReviewCache: {
+        source: 'target_manifest',
+        strategy: 'reuse_completed_packets_when_fingerprint_matches',
+        cacheKey: 'cache',
+        fingerprint: 'fingerprint',
+        filePaths: [],
+        workspaceAreas: [],
+        targetTags: [],
+        reviewerPacketIds: [],
+        lineCountSource: 'unknown',
+        invalidatesOn: [],
+      },
+      tokenBudget: {
+        mode: 'balanced',
+        estimatedPromptTokens: 0,
+        estimatedReviewerTokens: 0,
+        estimatedJudgeTokens: 0,
+        estimatedTotalTokens: 0,
+        activeReviewerCalls: 1,
+        eligibleExtraReviewerCount: 0,
+        maxExtraReviewers: 0,
+        skippedReviewerIds: [],
+        warnings: [],
+      },
+      coreReviewers: [],
+      enabledExtraReviewers: [],
+      skippedReviewers: [],
+      workPackets: [{
+        packetId: 'reviewer:ReviewSecurity',
+        phase: 'reviewer',
+        launchBatch: 1,
+        subagentId: 'ReviewSecurity',
+        displayName: 'Security reviewer',
+        roleName: 'Security reviewer',
+        assignedScope: {
+          kind: 'review_target',
+          targetSource: 'session_files',
+          targetResolution: 'resolved',
+          targetTags: [],
+          fileCount: 0,
+          files: [],
+          excludedFileCount: 0,
+        },
+        allowedTools: ['Read'],
+        timeoutSeconds: 300,
+        requiredOutputFields: ['packet_id', 'status'],
+        strategyLevel: 'normal',
+        strategyDirective: 'Review security risks.',
+        model: 'fast',
+      }],
+    };
+
+    const state = buildDeepReviewCapacityQueueStateFromEvent(createQueueEvent(), session);
+
+    expect(state?.waitingReviewers).toEqual([
+      expect.objectContaining({
+        subagentType: 'ReviewSecurity',
+        displayName: 'Security reviewer',
+      }),
+    ]);
   });
 
   it('ignores queue events for non-Deep Review sessions', () => {

--- a/src/web-ui/src/flow_chat/utils/deepReviewQueueStateEvents.ts
+++ b/src/web-ui/src/flow_chat/utils/deepReviewQueueStateEvents.ts
@@ -1,6 +1,53 @@
 import type { DeepReviewQueueStateChangedEvent } from '@/infrastructure/api/service-api/AgentAPI';
-import type { DeepReviewCapacityQueueState } from '../store/deepReviewActionBarStore';
+import type {
+  DeepReviewCapacityQueueState,
+  DeepReviewCapacityWaitingReviewer,
+} from '../store/deepReviewActionBarStore';
 import type { Session } from '../types/flow-chat';
+
+function resolveWaitingReviewerDisplayName(
+  session: Session | undefined,
+  subagentType: string | undefined,
+): string | undefined {
+  if (!subagentType) {
+    return undefined;
+  }
+
+  const manifest = session?.deepReviewRunManifest;
+  const packet = manifest?.workPackets?.find((item) => item.subagentId === subagentType);
+  if (packet?.displayName) {
+    return packet.displayName;
+  }
+
+  const manifestMember = [
+    ...(manifest?.coreReviewers ?? []),
+    ...(manifest?.enabledExtraReviewers ?? []),
+    ...(manifest?.qualityGateReviewer ? [manifest.qualityGateReviewer] : []),
+  ].find((member) => member.subagentId === subagentType);
+
+  return manifestMember?.displayName;
+}
+
+function buildWaitingReviewerFromEvent(
+  event: DeepReviewQueueStateChangedEvent,
+  session: Session | undefined,
+): DeepReviewCapacityWaitingReviewer | null {
+  const queueState = event.queueState;
+  if (queueState.status === 'running' || queueState.status === 'capacity_skipped') {
+    return null;
+  }
+
+  return {
+    toolId: queueState.toolId,
+    subagentType: queueState.subagentType,
+    displayName: resolveWaitingReviewerDisplayName(session, queueState.subagentType),
+    status: queueState.status,
+    reason: queueState.reason,
+    optional: (queueState.optionalReviewerCount ?? 0) > 0,
+    queueElapsedMs: queueState.queueElapsedMs,
+    maxQueueWaitSeconds: queueState.maxQueueWaitSeconds,
+  };
+}
 
 export function buildDeepReviewCapacityQueueStateFromEvent(
   event: DeepReviewQueueStateChangedEvent,
@@ -14,6 +61,7 @@ export function buildDeepReviewCapacityQueueStateFromEvent(
   if (!queueState) {
     return null;
   }
+  const waitingReviewer = buildWaitingReviewerFromEvent(event, session);
 
   return {
     toolId: queueState.toolId,
@@ -30,5 +78,6 @@ export function buildDeepReviewCapacityQueueStateFromEvent(
     maxQueueWaitSeconds: queueState.maxQueueWaitSeconds,
     sessionConcurrencyHigh: queueState.sessionConcurrencyHigh,
     controlMode: 'backend',
+    waitingReviewers: waitingReviewer ? [waitingReviewer] : [],
   };
 }

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -167,6 +167,7 @@ export type DeepReviewQueueReason =
   | 'provider_concurrency_limit'
   | 'retry_after'
   | 'local_concurrency_cap'
+  | 'launch_batch_blocked'
   | 'temporary_overload';
 
 export interface DeepReviewQueueStateEventData {

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -644,6 +644,21 @@
     "showCustomInput": "Add instructions",
     "hideCustomInput": "Hide instructions",
     "customInstructionsPlaceholder": "Describe additional requirements or context for the fix...",
+    "remediationStatus": {
+      "fixing": "Fixing",
+      "fixed": "Fixed"
+    },
+    "decisionGate": {
+      "title": "Confirm decision items before fixing",
+      "description": "Choose how each selected decision should be handled before BitFun starts editing.",
+      "supplementLabel": "Additional requirements",
+      "supplementPlaceholder": "Optional: add constraints, scope limits, or implementation preferences before starting.",
+      "missingSelection": "Choose an option for each selected decision item before starting.",
+      "noOptionsHint": "This item has no structured options. Confirm only if you want the selected plan to be executed as written.",
+      "confirmFix": "Confirm and start",
+      "confirmFixAndReview": "Confirm and re-review",
+      "cancel": "Back to selection"
+    },
     "fillBackInput": "Fill to input",
     "fillBackInputHint": "Copy selected fix plan to the input box for manual editing",
     "retryIncompleteSlices": "Retry incomplete slices ({{count}})",
@@ -701,10 +716,23 @@
         "providerConcurrencyLimit": "provider concurrency limit",
         "retryAfter": "provider retry-after",
         "localConcurrencyCap": "local reviewer capacity",
+        "launchBatchBlocked": "previous launch batch still running",
         "temporaryOverload": "temporary provider overload"
+      },
+      "reasonDetails": {
+        "providerRateLimit": "The model provider is rate-limiting requests. BitFun will wait briefly; reducing Review Team parallel reviewers can help if this repeats.",
+        "providerConcurrencyLimit": "The model provider rejected another concurrent reviewer. BitFun will retry after capacity opens; lower reviewer parallelism if it keeps happening.",
+        "retryAfter": "The model provider asked BitFun to retry later. Waiting here avoids spending reviewer runtime while the provider cools down.",
+        "localConcurrencyCap": "The configured Review Team reviewer limit is full. This reviewer will start after an active reviewer finishes.",
+        "launchBatchBlocked": "An earlier launch batch is still running. Waiting preserves the planned review order and prevents a later batch from overtaking it.",
+        "temporaryOverload": "The model provider reported temporary overload. BitFun will wait briefly and then continue or mark the reviewer as capacity skipped."
       },
       "sessionBusy": "Your active session is busy. Pause Deep Review or continue later.",
       "stopHint": "Use Stop to interrupt this review queue.",
+      "waitingReviewersTitle": "Waiting reviewers",
+      "reviewerStatusQueued": "Waiting",
+      "reviewerStatusPaused": "Paused",
+      "optionalReviewer": "Optional",
       "pauseQueue": "Pause queue",
       "continueQueue": "Continue queue",
       "cancelQueued": "Cancel queued reviewers",
@@ -713,7 +741,10 @@
       "openReviewSettings": "Open Review settings",
       "runSlowerSaved": "Next Deep Review will use up to {{count}} parallel reviewers.",
       "runSlowerFailed": "Failed to update Review settings.",
-      "controlFailed": "Queue control failed. Please try again or stop the review."
+      "runSlowerFailedWithReason": "Failed to update Review settings: {{reason}}. Open Review settings and lower Review Team max parallel reviewers manually.",
+      "controlFailed": "Queue control is unavailable because this reviewer is missing session, turn, or tool identifiers. Use Stop to interrupt the review, or wait for the queue state to refresh.",
+      "controlFailedWithReason": "Queue control failed: {{reason}}. Try again, or use Stop to interrupt the review if the queue is stuck.",
+      "controlPartiallyFailedWithReason": "Queue control partly applied; {{failed}} of {{total}} reviewers failed: {{reason}}. Wait for the queue state to refresh, then retry or use Stop if it is stuck."
     },
     "degradation": {
       "reduceReviewers": "Run with core reviewers only",
@@ -1655,7 +1686,7 @@
         "noSelectionHint": "Select at least one remediation item to start fixing.",
         "ungrouped": "Other",
         "startFix": "Start fixing",
-        "fixAndReview": "Fix \\u0026 re-review",
+        "fixAndReview": "Fix & re-review",
         "cancel": "Cancel",
         "fixUnavailable": "Unable to start remediation because the review session is unavailable.",
         "fixRequestDisplay": "Start fixing Deep Review findings",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -644,6 +644,21 @@
     "showCustomInput": "补充说明",
     "hideCustomInput": "收起说明",
     "customInstructionsPlaceholder": "描述修复的额外要求或上下文信息...",
+    "remediationStatus": {
+      "fixing": "修复中",
+      "fixed": "已修复"
+    },
+    "decisionGate": {
+      "title": "修复前确认待决策项",
+      "description": "请先选择每个待决策项的处理方案，BitFun 会按你的选择开始修改。",
+      "supplementLabel": "补充要求",
+      "supplementPlaceholder": "可选：补充约束、范围边界或实现偏好。",
+      "missingSelection": "开始前需要先为每个待决策项选择一个方案。",
+      "noOptionsHint": "该项没有结构化选项。只有在确认按当前计划执行时再继续。",
+      "confirmFix": "确认并开始",
+      "confirmFixAndReview": "确认并重审",
+      "cancel": "返回选择"
+    },
     "fillBackInput": "填入输入框",
     "fillBackInputHint": "将选中的修复计划填入输入框，供手动编辑",
     "retryIncompleteSlices": "重试未完成切片（{{count}}）",
@@ -701,10 +716,23 @@
         "providerConcurrencyLimit": "模型服务并发限制",
         "retryAfter": "模型服务要求稍后重试",
         "localConcurrencyCap": "本地审核员容量",
+        "launchBatchBlocked": "前一启动批次仍在运行",
         "temporaryOverload": "模型服务临时过载"
+      },
+      "reasonDetails": {
+        "providerRateLimit": "模型服务正在限速。BitFun 会短暂等待；如果反复出现，可以降低 Review Team 并行审核员数量。",
+        "providerConcurrencyLimit": "模型服务拒绝了新的并发审核员。BitFun 会在容量恢复后重试；如果持续发生，建议降低审核员并行数。",
+        "retryAfter": "模型服务要求稍后重试。这里的等待不会消耗审核员运行时间。",
+        "localConcurrencyCap": "当前 Review Team 审核员并行上限已满。已有审核员完成后，该审核员会继续启动。",
+        "launchBatchBlocked": "前一启动批次仍在运行。等待可以保持计划中的审核顺序，避免后续批次提前执行。",
+        "temporaryOverload": "模型服务报告临时过载。BitFun 会短暂等待，然后继续或将该审核员标记为容量跳过。"
       },
       "sessionBusy": "当前会话较忙，可暂停 Deep Review 或稍后继续。",
       "stopHint": "可使用停止按钮中断当前审核队列。",
+      "waitingReviewersTitle": "等待中的审核员",
+      "reviewerStatusQueued": "等待中",
+      "reviewerStatusPaused": "已暂停",
+      "optionalReviewer": "可选",
       "pauseQueue": "暂停队列",
       "continueQueue": "继续队列",
       "cancelQueued": "取消排队审核员",
@@ -713,7 +741,10 @@
       "openReviewSettings": "打开审核设置",
       "runSlowerSaved": "下次 Deep Review 最多会使用 {{count}} 个并行审核员。",
       "runSlowerFailed": "更新审核设置失败。",
-      "controlFailed": "\u961f\u5217\u63a7\u5236\u5931\u8d25\uff0c\u8bf7\u91cd\u8bd5\u6216\u505c\u6b62\u5ba1\u6838\u3002"
+      "runSlowerFailedWithReason": "更新审核设置失败：{{reason}}。可以打开审核设置并手动降低 Review Team 最大并行审核员数量。",
+      "controlFailed": "队列控制不可用，因为该审核员缺少会话、轮次或工具标识。可使用停止按钮中断审核，或等待队列状态刷新后再试。",
+      "controlFailedWithReason": "队列控制失败：{{reason}}。请重试；如果队列卡住，可以使用停止来中断审核。",
+      "controlPartiallyFailedWithReason": "队列控制已部分生效；{{total}} 位审核员中有 {{failed}} 位失败：{{reason}}。请等待队列状态刷新后重试；如果队列卡住，可以使用停止来中断审核。"
     },
     "degradation": {
       "reduceReviewers": "仅运行核心 reviewer",
@@ -1218,8 +1249,8 @@
       "restoreShort": "恢复（剩余 {{seconds}} 秒）",
       "durationTooltip": "耗时 {{duration}}",
       "completedDurationTooltip": "已完成，耗时 {{duration}}",
-      "failedDurationTooltip": "失败于 {{duration}} 后",
-      "failedDurationTooltipWithReason": "失败于 {{duration}} 后：{{reason}}",
+      "failedDurationTooltip": "执行失败，耗时 {{duration}}",
+      "failedDurationTooltipWithReason": "执行失败，耗时 {{duration}}：{{reason}}",
       "cancelledDurationTooltip": "已取消，耗时 {{duration}}"
     },
     "template": {
@@ -1655,7 +1686,7 @@
         "noSelectionHint": "至少选择一项修复计划后才能开始修复。",
         "ungrouped": "其他",
         "startFix": "开始修复",
-        "fixAndReview": "修复\\u0026重审",
+        "fixAndReview": "修复&重审",
         "cancel": "取消",
         "fixUnavailable": "无法开始修复：审核会话不可用。",
         "fixRequestDisplay": "开始修复深度审核问题",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -644,6 +644,21 @@
     "showCustomInput": "補充說明",
     "hideCustomInput": "收起說明",
     "customInstructionsPlaceholder": "描述修復的額外要求或上下文信息...",
+    "remediationStatus": {
+      "fixing": "修復中",
+      "fixed": "已修復"
+    },
+    "decisionGate": {
+      "title": "修復前確認待決策項",
+      "description": "請先選擇每個待決策項的處理方案，BitFun 會依你的選擇開始修改。",
+      "supplementLabel": "補充要求",
+      "supplementPlaceholder": "可選：補充限制、範圍邊界或實作偏好。",
+      "missingSelection": "開始前需要先為每個待決策項選擇一個方案。",
+      "noOptionsHint": "該項沒有結構化選項。只有在確認依目前計畫執行時再繼續。",
+      "confirmFix": "確認並開始",
+      "confirmFixAndReview": "確認並重審",
+      "cancel": "返回選擇"
+    },
     "fillBackInput": "填入輸入框",
     "fillBackInputHint": "將選中的修復計劃填入輸入框，供手動編輯",
     "retryIncompleteSlices": "重試未完成切片（{{count}}）",
@@ -701,10 +716,23 @@
         "providerConcurrencyLimit": "模型服務並發限制",
         "retryAfter": "模型服務要求稍後重試",
         "localConcurrencyCap": "本地審核員容量",
+        "launchBatchBlocked": "前一啟動批次仍在執行",
         "temporaryOverload": "模型服務暫時過載"
+      },
+      "reasonDetails": {
+        "providerRateLimit": "模型服務正在限速。BitFun 會短暫等待；如果反覆出現，可以降低 Review Team 並行審核員數量。",
+        "providerConcurrencyLimit": "模型服務拒絕了新的並發審核員。BitFun 會在容量恢復後重試；如果持續發生，建議降低審核員並行數。",
+        "retryAfter": "模型服務要求稍後重試。這裡的等待不會消耗審核員執行時間。",
+        "localConcurrencyCap": "目前 Review Team 審核員並行上限已滿。已有審核員完成後，該審核員會繼續啟動。",
+        "launchBatchBlocked": "前一啟動批次仍在執行。等待可以保持計畫中的審核順序，避免後續批次提前執行。",
+        "temporaryOverload": "模型服務回報暫時過載。BitFun 會短暫等待，然後繼續或將該審核員標記為容量略過。"
       },
       "sessionBusy": "目前會話較忙，可暫停 Deep Review 或稍後繼續。",
       "stopHint": "可使用停止按鈕中斷目前審核佇列。",
+      "waitingReviewersTitle": "等待中的審核員",
+      "reviewerStatusQueued": "等待中",
+      "reviewerStatusPaused": "已暫停",
+      "optionalReviewer": "選用",
       "pauseQueue": "暫停佇列",
       "continueQueue": "繼續佇列",
       "cancelQueued": "取消排隊審核員",
@@ -713,7 +741,10 @@
       "openReviewSettings": "開啟審核設定",
       "runSlowerSaved": "下次 Deep Review 最多會使用 {{count}} 個並行審核員。",
       "runSlowerFailed": "更新審核設定失敗。",
-      "controlFailed": "\u4f47\u5217\u63a7\u5236\u5931\u6557\uff0c\u8acb\u91cd\u8a66\u6216\u505c\u6b62\u5be9\u6838\u3002"
+      "runSlowerFailedWithReason": "更新審核設定失敗：{{reason}}。可以開啟審核設定並手動降低 Review Team 最大並行審核員數量。",
+      "controlFailed": "佇列控制不可用，因為該審核員缺少會話、輪次或工具識別碼。可使用停止按鈕中斷審核，或等待佇列狀態重新整理後再試。",
+      "controlFailedWithReason": "佇列控制失敗：{{reason}}。請重試；如果佇列卡住，可以使用停止來中斷審核。",
+      "controlPartiallyFailedWithReason": "佇列控制已部分生效；{{total}} 位審核員中有 {{failed}} 位失敗：{{reason}}。請等待佇列狀態重新整理後重試；如果佇列卡住，可以使用停止來中斷審核。"
     },
     "degradation": {
       "reduceReviewers": "僅運行核心 reviewer",
@@ -1218,8 +1249,8 @@
       "restoreShort": "恢復（剩餘 {{seconds}} 秒）",
       "durationTooltip": "耗時 {{duration}}",
       "completedDurationTooltip": "已完成，耗時 {{duration}}",
-      "failedDurationTooltip": "失敗於 {{duration}} 後",
-      "failedDurationTooltipWithReason": "失敗於 {{duration}} 後：{{reason}}",
+      "failedDurationTooltip": "執行失敗，耗時 {{duration}}",
+      "failedDurationTooltipWithReason": "執行失敗，耗時 {{duration}}：{{reason}}",
       "cancelledDurationTooltip": "已取消，耗時 {{duration}}"
     },
     "template": {
@@ -1655,7 +1686,7 @@
         "noSelectionHint": "至少選擇一項修復計劃後才能開始修復。",
         "ungrouped": "其他",
         "startFix": "開始修復",
-        "fixAndReview": "修復\\u0026重審",
+        "fixAndReview": "修復&重審",
         "cancel": "取消",
         "fixUnavailable": "無法開始修復：審核會話不可用。",
         "fixRequestDisplay": "開始修復深度審核問題",

--- a/src/web-ui/src/shared/services/review-team/workPackets.ts
+++ b/src/web-ui/src/shared/services/review-team/workPackets.ts
@@ -265,22 +265,38 @@ export function buildWorkPackets(params: {
   const reviewerSeeds = params.reviewerMembers.flatMap((member) =>
     reviewerScopes.map((scope) => ({ member, scope })),
   );
-  const orderedReviewerSeeds = params.concurrencyPolicy.batchExtrasSeparately
-    ? [
-      ...reviewerSeeds.filter((seed) => seed.member.source === 'core'),
-      ...reviewerSeeds.filter((seed) => seed.member.source === 'extra'),
-    ]
-    : reviewerSeeds;
-  const reviewerPackets = orderedReviewerSeeds.map((seed, index) =>
+  const buildReviewerPacketsForSeeds = (
+    seeds: typeof reviewerSeeds,
+    firstLaunchBatch: number,
+  ): ReviewTeamWorkPacket[] => seeds.map((seed, index) =>
     buildWorkPacket({
       member: seed.member,
       phase: 'reviewer',
       launchBatch:
-        Math.floor(index / params.concurrencyPolicy.maxParallelInstances) + 1,
+        firstLaunchBatch +
+        Math.floor(index / params.concurrencyPolicy.maxParallelInstances),
       scope: seed.scope,
       timeoutSeconds: params.executionPolicy.reviewerTimeoutSeconds,
     }),
   );
+  const reviewerPackets = params.concurrencyPolicy.batchExtrasSeparately
+    ? (() => {
+      const coreReviewerPackets = buildReviewerPacketsForSeeds(
+        reviewerSeeds.filter((seed) => seed.member.source === 'core'),
+        1,
+      );
+      const extraFirstLaunchBatch = coreReviewerPackets.length > 0
+        ? Math.max(...coreReviewerPackets.map((packet) => packet.launchBatch)) + 1
+        : 1;
+      return [
+        ...coreReviewerPackets,
+        ...buildReviewerPacketsForSeeds(
+          reviewerSeeds.filter((seed) => seed.member.source === 'extra'),
+          extraFirstLaunchBatch,
+        ),
+      ];
+    })()
+    : buildReviewerPacketsForSeeds(reviewerSeeds, 1);
   const finalReviewerBatch = reviewerPackets.reduce(
     (maxBatch, packet) => Math.max(maxBatch, packet.launchBatch),
     0,

--- a/src/web-ui/src/shared/services/reviewTeamService.test.ts
+++ b/src/web-ui/src/shared/services/reviewTeamService.test.ts
@@ -1275,6 +1275,41 @@ describe('reviewTeamService', () => {
     expect(promptBlock).toContain('"launch_batch": 2');
   });
 
+  it('keeps extra reviewers in a separate launch batch when requested', () => {
+    const team = resolveDefaultReviewTeam(
+      [
+        ...coreSubagents(),
+        subagent('ReviewProductExtra'),
+      ],
+      storedConfigWithExtra(['ReviewProductExtra'], {
+        max_parallel_reviewers: 6,
+      }),
+    );
+    const target = classifyReviewTargetFromFiles([
+      'src/web-ui/src/components/ReviewPanel.tsx',
+      'src/web-ui/src/components/ReviewPanel.css',
+    ], 'session_files');
+
+    const manifest = buildEffectiveReviewTeamManifest(team, { target });
+    const reviewerPackets = manifest.workPackets?.filter(
+      (packet) => packet.phase === 'reviewer',
+    ) ?? [];
+    const corePackets = reviewerPackets.filter(
+      (packet) => packet.subagentId !== 'ReviewProductExtra',
+    );
+    const extraPackets = reviewerPackets.filter(
+      (packet) => packet.subagentId === 'ReviewProductExtra',
+    );
+
+    expect(corePackets).toHaveLength(5);
+    expect(extraPackets).toHaveLength(1);
+    expect(corePackets.map((packet) => packet.launchBatch)).toEqual([1, 1, 1, 1, 1]);
+    expect(extraPackets.map((packet) => packet.launchBatch)).toEqual([2]);
+    expect(manifest.qualityGateReviewer && manifest.workPackets?.find(
+      (packet) => packet.subagentId === manifest.qualityGateReviewer?.subagentId,
+    )?.launchBatch).toBe(3);
+  });
+
   it('reduces reviewer concurrency when rate limit remaining is tight', () => {
     const team = resolveDefaultReviewTeam(
       coreSubagents(),


### PR DESCRIPTION
## Summary

This PR improves Deep Review reliability and operability when multiple reviewers are launched under runtime capacity constraints. It hardens the backend queue admission path so reviewer batches execute in the intended order, keeps active reviewers from causing premature capacity skips, and reports clearer queue state back to the UI.

On the frontend, it expands the Review Team action bar from a compact control strip into a more complete workflow surface. Users can now see why reviewers are waiting, which reviewers are queued or paused, inspect partial results, preview recovery guidance, select remediation items more deliberately, and confirm decision-required fixes before BitFun starts editing.

## Changes

### Runtime queue control

- Add launch-batch-aware reviewer admission for Deep Review tasks.
- Prevent later reviewer batches from overtaking earlier active batches.
- Track active reviewer counts per launch batch and release them through the existing guard lifecycle.
- Add `launch_batch_blocked` as a first-class queue reason in runtime state and emitted events.
- Keep queued reviewers waiting while active reviewers are still running instead of treating capacity as immediately expired.
- Return clearer capacity-skipped results with queue elapsed time, capacity reason, and recommended next action.
- Add post-call tool hooks so successful shared-context tool usage can be recorded without making the generic tool framework Deep Review-specific.

### Review Team action workflows

- Split the Deep Review action bar into focused UI pieces:
  - queue capacity notice
  - remediation selection
  - decision confirmation gate
  - partial results panel
  - recovery plan preview
  - action controls
  - interruption diagnostics
- Show concrete queue reasons and reviewer-level waiting state in the capacity queue notice.
- Surface waiting reviewer names from the run manifest when available.
- Preserve remediation progress by tracking completed and currently fixing items.
- Require explicit confirmation for decision-required remediation items before starting fix execution.
- Add partial-results affordances so interrupted or incomplete reviews still expose useful completed work.
- Improve recovery and model-remediation actions for interrupted review flows.

### UI and polish

- Update Deep Review action bar styling for the expanded workflow states.
- Improve report export action icons for consistency with the rest of the tool-card UI.
- Allow failed subagent task cards to collapse after expansion.
- Update Flow Chat locale strings across `en-US`, `zh-CN`, and `zh-TW`.
- Refresh Deep Review frontend README guidance to match the new action-bar module layout.

### Tests and coverage

- Add and update tests for launch-batch queue admission and queue wait behavior.
- Add frontend tests for:
  - capacity queue reason rendering
  - waiting reviewer display
  - remediation selection
  - decision-gated execution
  - partial results
  - recovery plan previews
  - action controls
  - interruption diagnostics
  - report export icons
  - failed task-card collapse behavior
- Update store and queue-state event tests for the richer queue/remediation state.

## Why

Deep Review can run multiple reviewer packets under local and provider capacity limits. Before this change, queued reviewers could be hard to reason about from the UI, and runtime queue state did not distinguish ordinary local capacity pressure from launch-order blocking. That made stalled or interrupted review flows harder to diagnose and could lead users to retry without knowing whether they should wait, pause, cancel, lower concurrency, or inspect partial results.

This PR makes the runtime state more explicit and gives the user-facing workflow enough structure to act on that state safely.

## Verification

Not run in this drafting pass. Recommended before merge:

- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run`
- `cargo test -p bitfun-core deep_review -- --nocapture`
