### PR TITLE
fix(web-ui): stabilize review and ACP settings flows

### DIFF
--- a/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.review-action.test.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.review-action.test.tsx
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { BtwSessionPanel } from './BtwSessionPanel';
+import { useReviewActionBarStore } from '../../store/deepReviewActionBarStore';
+import type { FlowChatState, Session } from '../../types/flow-chat';
+
+let flowChatState: FlowChatState;
+const translate = (_key: string, options?: Record<string, unknown> & { defaultValue?: string }) => (
+  options?.defaultValue ?? _key
+);
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn(),
+  },
+  useTranslation: () => ({
+    t: translate,
+  }),
+}));
+
+vi.mock('../modern/VirtualItemRenderer', () => ({
+  VirtualItemRenderer: () => <div />,
+}));
+
+vi.mock('../modern/ProcessingIndicator', () => ({
+  ProcessingIndicator: () => <div />,
+}));
+
+vi.mock('../modern/processingIndicatorVisibility', () => ({
+  shouldReserveProcessingIndicatorSpace: () => false,
+  shouldShowProcessingIndicator: () => false,
+}));
+
+vi.mock('../modern/useExploreGroupState', () => ({
+  useExploreGroupState: () => ({
+    exploreGroupStates: {},
+    onExploreGroupToggle: vi.fn(),
+    onExpandGroup: vi.fn(),
+    onExpandAllInTurn: vi.fn(),
+    onCollapseGroup: vi.fn(),
+  }),
+}));
+
+vi.mock('@/flow_chat', () => ({
+  ScrollToBottomButton: () => <div />,
+}));
+
+vi.mock('./DeepReviewActionBar', () => ({
+  ReviewActionBar: () => <div data-testid="review-action-bar" />,
+}));
+
+vi.mock('@/component-library', () => ({
+  IconButton: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/shared/services/FileTabManager', () => ({
+  fileTabManager: {
+    openFile: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/utils/tabUtils', () => ({
+  createTab: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/api', () => ({
+  agentAPI: {
+    cancelSession: vi.fn(),
+  },
+}));
+
+vi.mock('@/infrastructure/event-bus', () => ({
+  globalEventBus: {
+    emit: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/notification-system', () => ({
+  notificationService: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+vi.mock('../../store/FlowChatStore', () => ({
+  FlowChatStore: {
+    getInstance: () => ({
+      getState: () => flowChatState,
+      subscribe: () => () => {},
+      loadSessionHistory: vi.fn(),
+    }),
+  },
+  flowChatStore: {
+    getState: () => flowChatState,
+    subscribe: () => () => {},
+    loadSessionHistory: vi.fn(),
+  },
+}));
+
+vi.mock('../../store/modernFlowChatStore', () => ({
+  sessionToVirtualItems: () => [],
+}));
+
+vi.mock('../../utils/reviewSessionStop', () => ({
+  settleStoppedReviewSessionState: vi.fn(),
+}));
+
+vi.mock('../../services/ReviewActionBarPersistenceService', () => ({
+  loadPersistedReviewState: vi.fn(() => Promise.resolve(null)),
+}));
+
+function createReviewSession(): Session {
+  return {
+    sessionId: 'deep-review-child',
+    title: 'Deep review',
+    dialogTurns: [{
+      id: 'turn-1',
+      sessionId: 'deep-review-child',
+      userMessage: { id: 'user-1', content: 'review', timestamp: 1 },
+      modelRounds: [{
+        id: 'round-1',
+        index: 0,
+        isStreaming: false,
+        isComplete: true,
+        status: 'completed',
+        startTime: 1,
+        items: [{
+          id: 'review-result',
+          type: 'tool',
+          timestamp: 2,
+          status: 'completed',
+          toolName: 'submit_code_review',
+          toolCall: { id: 'tool-1', input: {} },
+          toolResult: {
+            success: true,
+            result: JSON.stringify({
+              summary: {
+                overall_assessment: 'Looks safe.',
+                risk_level: 'low',
+                recommended_action: 'approve',
+              },
+              issues: [],
+              positive_points: ['No risky changes found.'],
+              review_mode: 'deep',
+              remediation_plan: [],
+            }),
+          },
+        }],
+      }],
+      status: 'completed',
+      startTime: 1,
+    }],
+    status: 'idle',
+    config: {},
+    createdAt: 1,
+    lastActiveAt: 1,
+    error: null,
+    sessionKind: 'deep_review',
+    parentSessionId: 'parent-session',
+    workspacePath: 'D:/workspace/project',
+  } as Session;
+}
+
+describe('BtwSessionPanel review action bar integration', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    useReviewActionBarStore.getState().reset();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    const childSession = createReviewSession();
+    flowChatState = {
+      sessions: new Map([
+        ['deep-review-child', childSession],
+        ['parent-session', {
+          sessionId: 'parent-session',
+          title: 'Parent',
+          dialogTurns: [],
+          status: 'idle',
+          config: {},
+          createdAt: 1,
+          lastActiveAt: 1,
+          error: null,
+        } as Session],
+      ]),
+      activeSessionId: 'deep-review-child',
+    } as FlowChatState;
+
+    globalThis.ResizeObserver = class {
+      observe() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    useReviewActionBarStore.getState().reset();
+  });
+
+  it('shows the completed Deep Review action bar even when the report has no remediation items', async () => {
+    await act(async () => {
+      root.render(
+        <BtwSessionPanel
+          childSessionId="deep-review-child"
+          parentSessionId="parent-session"
+          workspacePath="D:/workspace/project"
+        />,
+      );
+    });
+
+    expect(useReviewActionBarStore.getState()).toMatchObject({
+      childSessionId: 'deep-review-child',
+      phase: 'review_completed',
+    });
+    expect(useReviewActionBarStore.getState().remediationItems).toEqual([]);
+  });
+});

--- a/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx
@@ -482,15 +482,13 @@ export const BtwSessionPanel: React.FC<BtwSessionPanelProps> = ({
       return;
     }
 
-    if (hasRemediationPlan) {
-      store.showActionBar({
-        childSessionId,
-        parentSessionId: parentSessionId ?? null,
-        reviewData: latestReviewData,
-        reviewMode,
-        phase: 'review_completed',
-      });
-    }
+    store.showActionBar({
+      childSessionId,
+      parentSessionId: parentSessionId ?? null,
+      reviewData: latestReviewData,
+      reviewMode,
+      phase: 'review_completed',
+    });
   }, [childSession, childSessionId, parentSessionId, isReviewSession, isDeepReview]);
 
   // Restore persisted review action state on mount

--- a/src/web-ui/src/flow_chat/store/deepReviewActionBarStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/deepReviewActionBarStore.test.ts
@@ -347,6 +347,45 @@ describe('deepReviewActionBarStore', () => {
       expect(bar().capacityQueueState).toBeNull();
       expect(bar().phase).toBe('idle');
     });
+
+    it('keeps the capacity queue visible when a terminal reviewer event reports more queued reviewers', () => {
+      bar().showCapacityQueueBar({
+        childSessionId: 'child-1',
+        parentSessionId: 'parent-1',
+        capacityQueueState: {
+          toolId: 'task-security',
+          subagentType: 'ReviewSecurity',
+          status: 'queued_for_capacity',
+          reason: 'local_concurrency_cap',
+          queuedReviewerCount: 1,
+          waitingReviewers: [{
+            toolId: 'task-security',
+            subagentType: 'ReviewSecurity',
+            displayName: 'Security reviewer',
+            status: 'queued_for_capacity',
+            reason: 'local_concurrency_cap',
+          }],
+        },
+      });
+
+      bar().applyCapacityQueueState({
+        toolId: 'task-security',
+        subagentType: 'ReviewSecurity',
+        status: 'running',
+        reason: 'launch_batch_blocked',
+        queuedReviewerCount: 1,
+        activeReviewerCount: 1,
+        waitingReviewers: [],
+      });
+
+      expect(bar().capacityQueueState).toMatchObject({
+        status: 'queued_for_capacity',
+        queuedReviewerCount: 1,
+        activeReviewerCount: 1,
+      });
+      expect(bar().capacityQueueState?.waitingReviewers).toEqual([]);
+      expect(bar().phase).toBe('review_waiting_capacity');
+    });
   });
 
   describe('toggleRemediation with completed items', () => {

--- a/src/web-ui/src/flow_chat/store/deepReviewActionBarStore.ts
+++ b/src/web-ui/src/flow_chat/store/deepReviewActionBarStore.ts
@@ -272,6 +272,16 @@ function mergeCapacityQueueState(
 
   const waitingReviewers = [...reviewerMap.values()];
   if (waitingReviewers.length === 0) {
+    if (isTerminalQueueStatus(incoming.status) && incoming.queuedReviewerCount > 0) {
+      return {
+        ...incoming,
+        status: current?.status === 'paused_by_user' ? 'paused_by_user' : 'queued_for_capacity',
+        queuedReviewerCount: incoming.queuedReviewerCount,
+        optionalReviewerCount: incoming.optionalReviewerCount ?? 0,
+        waitingReviewers: [],
+      };
+    }
+
     return null;
   }
 

--- a/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import AcpAgentsConfig from './AcpAgentsConfig';
+
+const loadJsonConfigMock = vi.hoisted(() => vi.fn());
+const getClientsMock = vi.hoisted(() => vi.fn());
+const probeClientRequirementsMock = vi.hoisted(() => vi.fn());
+const notifyErrorMock = vi.hoisted(() => vi.fn());
+const notifySuccessMock = vi.hoisted(() => vi.fn());
+const translate = (_key: string, options?: Record<string, unknown> & { defaultValue?: string }) => (
+  options?.defaultValue ?? _key
+);
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: translate,
+  }),
+}));
+
+vi.mock('@/component-library', () => ({
+  Button: ({
+    children,
+    disabled,
+    isLoading,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+    isLoading?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button type="button" disabled={disabled || isLoading} onClick={onClick}>
+      {children}
+    </button>
+  ),
+  Input: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value?: string;
+    onChange?: React.ChangeEventHandler<HTMLInputElement>;
+    placeholder?: string;
+  }) => <input value={value} onChange={onChange} placeholder={placeholder} />,
+  Select: ({
+    value,
+    onChange,
+    options,
+  }: {
+    value?: string;
+    onChange?: (value: string) => void;
+    options?: Array<{ value: string; label: string }>;
+  }) => (
+    <select value={value} onChange={(event) => onChange?.(event.target.value)}>
+      {(options ?? []).map((option) => (
+        <option key={option.value} value={option.value}>{option.label}</option>
+      ))}
+    </select>
+  ),
+  Textarea: React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
+    (props, ref) => <textarea ref={ref} {...props} />,
+  ),
+}));
+
+vi.mock('./common', () => ({
+  ConfigPageContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ConfigPageHeader: ({ title, subtitle }: { title: string; subtitle: string }) => (
+    <header>
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+    </header>
+  ),
+  ConfigPageLayout: ({ children }: { children: React.ReactNode }) => <main>{children}</main>,
+  ConfigPageSection: ({
+    children,
+    title,
+    description,
+  }: {
+    children: React.ReactNode;
+    title: string;
+    description?: string;
+  }) => (
+    <section>
+      <h2>{title}</h2>
+      {description ? <p>{description}</p> : null}
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('../../api/service-api/ACPClientAPI', () => ({
+  ACPClientAPI: {
+    loadJsonConfig: loadJsonConfigMock,
+    getClients: getClientsMock,
+    probeClientRequirements: probeClientRequirementsMock,
+    installClientCli: vi.fn(),
+    saveJsonConfig: vi.fn(),
+  },
+}));
+
+vi.mock('../../api/service-api/SystemAPI', () => ({
+  systemAPI: {
+    openExternal: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/notification-system', () => ({
+  useNotification: () => ({
+    error: notifyErrorMock,
+    success: notifySuccessMock,
+  }),
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+  }),
+}));
+
+describe('AcpAgentsConfig', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    loadJsonConfigMock.mockResolvedValue(JSON.stringify({
+      acpClients: {
+        opencode: {
+          name: 'opencode',
+          command: 'opencode',
+          args: ['acp'],
+          env: {},
+          enabled: true,
+          readonly: false,
+          permissionMode: 'ask',
+        },
+      },
+    }));
+    getClientsMock.mockResolvedValue([{
+      id: 'opencode',
+      name: 'opencode',
+      command: 'opencode',
+      args: ['acp'],
+      enabled: true,
+      readonly: false,
+      permissionMode: 'ask',
+      status: 'configured',
+      sessionCount: 0,
+      toolName: 'acp__opencode__prompt',
+    }]);
+    probeClientRequirementsMock.mockResolvedValue([]);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root.unmount();
+      });
+    }
+    container?.remove();
+    vi.clearAllMocks();
+  });
+
+  it('does not probe external ACP CLIs just by opening the settings tab', async () => {
+    await act(async () => {
+      root.render(<AcpAgentsConfig />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(loadJsonConfigMock).toHaveBeenCalledTimes(1);
+    expect(getClientsMock).toHaveBeenCalledTimes(1);
+    expect(probeClientRequirementsMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.tsx
@@ -7,6 +7,7 @@ import {
   FileJson,
   LoaderCircle,
   Plus,
+  RefreshCw,
   Save,
   Search,
   Terminal,
@@ -199,12 +200,13 @@ function getAgentRowStatus({
 }: {
   configured: boolean;
   enabled: boolean;
-  runnable: boolean;
+  runnable?: boolean;
   probePending: boolean;
 }): AgentRowStatus {
   if (probePending) return 'checking';
   if (!configured) return runnable ? 'ready' : 'not_installed';
-  return enabled && runnable ? 'enabled' : 'invalid';
+  if (!enabled) return 'invalid';
+  return runnable === false ? 'invalid' : 'enabled';
 }
 
 function CapabilityBadge({
@@ -385,7 +387,7 @@ const AcpAgentsConfig: React.FC = () => {
     options: { showLoading?: boolean; refreshRequirements?: boolean } = {}
   ) => {
     const showLoading = options.showLoading ?? true;
-    const refreshRequirements = options.refreshRequirements ?? true;
+    const refreshRequirements = options.refreshRequirements ?? false;
     try {
       if (showLoading) {
         setLoading(true);
@@ -505,7 +507,8 @@ const AcpAgentsConfig: React.FC = () => {
       setConfig(configToSave);
       setJsonConfig(formatConfig(configToSave));
       setDirty(false);
-      void refreshRequirementProbes({ force: true, notifyOnError: false });
+      requirementProbeCache = null;
+      setRequirementProbes([]);
       notifySuccess(t('notifications.saveSuccess'));
     } catch (error) {
       log.error('Failed to save ACP agent config', error);
@@ -620,6 +623,15 @@ const AcpAgentsConfig: React.FC = () => {
               >
                 <FileJson size={14} />
                 {showJsonEditor ? t('actions.closeJson') : t('actions.editJson')}
+              </Button>
+              <Button
+                variant="secondary"
+                size="small"
+                onClick={() => { void refreshRequirementProbes({ force: true }); }}
+                isLoading={probingRequirements}
+              >
+                <RefreshCw size={14} />
+                {t('actions.refresh')}
               </Button>
               <Button
                 variant="secondary"


### PR DESCRIPTION
## Summary

- Keep the Deep Review capacity queue notice visible when a terminal reviewer event still reports queued reviewers, preventing the waiting panel from disappearing and reappearing during review execution.
- Show the review action/result bar for completed Deep Review sessions even when the report has no remediation items, so users can confirm the finished review state.
- Stop the ACP Agents settings page from probing external CLIs on initial load or save; requirement checks now run only from the explicit Refresh action.

## Root Cause

- Queue events are per reviewer, but the action-bar store treated a terminal event with an empty waiting list as meaning the whole queue was closed.
- The review completion path only opened the action bar when remediation items existed, even though the action bar already supports the no-issues completion state.
- ACP settings loaded requirement probes automatically, which can execute configured third-party CLIs such as `opencode --version` just by opening the page.

## Validation

- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run`
