### PR TITLE
fix(web-ui): clarify Deep Review queue waits

### DIFF
--- a/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.test.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.test.tsx
@@ -474,8 +474,8 @@ describeWithJsdom('DeepReviewActionBar', () => {
       root.render(<DeepReviewActionBar />);
     });
 
-    expect(container.textContent).toContain('Reviewers waiting for capacity');
-    expect(container.textContent).toContain('Queue wait does not count against reviewer runtime.');
+    expect(container.textContent).toContain('Waiting for model capacity');
+    expect(container.textContent).toContain('BitFun is waiting for temporary model capacity.');
     expect(container.textContent).toContain('Reason: provider concurrency limit');
     expect(container.textContent).toContain('Waited 12s of 1m 0s');
     expect(container.textContent).toContain('Your active session is busy.');

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/CapacityQueueNotice.test.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/CapacityQueueNotice.test.tsx
@@ -46,8 +46,8 @@ describe('CapacityQueueNotice', () => {
       />,
     );
 
-    expect(html).toContain('Reviewers waiting for capacity');
-    expect(html).toContain('Queue wait does not count against reviewer runtime.');
+    expect(html).toContain('Waiting for model capacity');
+    expect(html).toContain('BitFun is waiting for temporary model capacity.');
     expect(html).toContain('Reason: provider concurrency limit');
     expect(html).toContain('The model provider rejected another concurrent reviewer.');
     expect(html).toContain('Waited 12s of 1m 0s');
@@ -79,7 +79,36 @@ describe('CapacityQueueNotice', () => {
 
     expect(html).toContain('Reason: previous launch batch still running');
     expect(html).toContain('Waiting preserves the planned review order');
-    expect(html).toContain('Waited 4s of 1m 0s');
+    expect(html).toContain('Waiting for running reviewers');
+    expect(html).toContain('Running reviewers: 2');
+    expect(html).not.toContain('Waited 4s of 1m 0s');
+  });
+
+  it('explains active-reviewer waits without presenting max wait as a hard timeout', () => {
+    const html = renderToStaticMarkup(
+      <CapacityQueueNotice
+        capacityQueueState={{
+          status: 'queued_for_capacity',
+          reason: 'local_concurrency_cap',
+          queuedReviewerCount: 1,
+          activeReviewerCount: 2,
+          queueElapsedMs: 70_000,
+          maxQueueWaitSeconds: 60,
+        }}
+        supportsInlineQueueControls
+        onPauseQueue={vi.fn()}
+        onContinueQueue={vi.fn()}
+        onSkipOptionalQueuedReviewers={vi.fn()}
+        onCancelQueuedReviewers={vi.fn()}
+        onRunSlowerNextTime={vi.fn()}
+        onOpenReviewSettings={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('Waiting for running reviewers');
+    expect(html).toContain('Queued reviewers start when a running reviewer frees capacity.');
+    expect(html).toContain('Running reviewers: 2');
+    expect(html).not.toContain('Waited 1m 10s of 1m 0s');
   });
 
   it('renders the specific reviewers currently waiting', () => {

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/CapacityQueueNotice.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/CapacityQueueNotice.tsx
@@ -64,6 +64,31 @@ const CAPACITY_QUEUE_REASON_DETAIL_KEYS: Record<DeepReviewCapacityQueueReason, {
   },
 };
 
+type CapacityQueueWaitMode = 'active_reviewer' | 'provider_capacity' | 'generic';
+
+function getCapacityQueueWaitMode(
+  capacityQueueState: DeepReviewCapacityQueueState,
+): CapacityQueueWaitMode {
+  if (
+    (capacityQueueState.reason === 'local_concurrency_cap'
+      || capacityQueueState.reason === 'launch_batch_blocked')
+    && (capacityQueueState.activeReviewerCount ?? 0) > 0
+  ) {
+    return 'active_reviewer';
+  }
+
+  if (
+    capacityQueueState.reason === 'provider_rate_limit'
+    || capacityQueueState.reason === 'provider_concurrency_limit'
+    || capacityQueueState.reason === 'retry_after'
+    || capacityQueueState.reason === 'temporary_overload'
+  ) {
+    return 'provider_capacity';
+  }
+
+  return 'generic';
+}
+
 function reviewerLabel(
   reviewer: NonNullable<DeepReviewCapacityQueueState['waitingReviewers']>[number],
 ): string {
@@ -97,7 +122,40 @@ export const CapacityQueueNotice: React.FC<CapacityQueueNoticeProps> = ({
   const capacityQueueMaxWaitLabel = capacityQueueState.maxQueueWaitSeconds !== undefined
     ? formatElapsedTime(capacityQueueState.maxQueueWaitSeconds * 1000)
     : null;
+  const capacityQueueWaitMode = getCapacityQueueWaitMode(capacityQueueState);
+  const activeReviewerCount = capacityQueueState.activeReviewerCount ?? 0;
+  const capacityQueueTitle = capacityQueueState.status === 'paused_by_user'
+    ? t('deepReviewActionBar.capacityQueue.pausedTitle', {
+      defaultValue: 'Queue paused',
+    })
+    : capacityQueueWaitMode === 'active_reviewer'
+      ? t('deepReviewActionBar.capacityQueue.activeReviewerTitle', {
+        defaultValue: 'Waiting for running reviewers',
+      })
+      : capacityQueueWaitMode === 'provider_capacity'
+        ? t('deepReviewActionBar.capacityQueue.providerTitle', {
+          defaultValue: 'Waiting for model capacity',
+        })
+        : t('deepReviewActionBar.capacityQueue.title', {
+          defaultValue: 'Reviewers waiting for capacity',
+        });
+  const capacityQueueDetail = capacityQueueWaitMode === 'active_reviewer'
+    ? t('deepReviewActionBar.capacityQueue.activeReviewerDetail', {
+      defaultValue: 'Queued reviewers start when a running reviewer frees capacity. Queue wait does not count against reviewer runtime.',
+    })
+    : capacityQueueWaitMode === 'provider_capacity'
+      ? t('deepReviewActionBar.capacityQueue.providerDetail', {
+        defaultValue: 'BitFun is waiting for temporary model capacity. This wait does not count against reviewer runtime.',
+      })
+      : t('deepReviewActionBar.capacityQueue.detail', {
+        defaultValue: 'Queue wait does not count against reviewer runtime.',
+      });
   const waitingReviewers = capacityQueueState.waitingReviewers ?? [];
+  const showCapacityQueueMeta = Boolean(
+    capacityQueueReasonLabel
+      || capacityQueueElapsedLabel
+      || capacityQueueWaitMode === 'active_reviewer',
+  );
 
   return (
     <div className="deep-review-action-bar__capacity-queue" aria-live="polite">
@@ -105,20 +163,12 @@ export const CapacityQueueNotice: React.FC<CapacityQueueNoticeProps> = ({
         <Clock size={14} className="deep-review-action-bar__capacity-queue-icon" />
         <div className="deep-review-action-bar__capacity-queue-copy">
           <span className="deep-review-action-bar__capacity-queue-title">
-            {capacityQueueState.status === 'paused_by_user'
-              ? t('deepReviewActionBar.capacityQueue.pausedTitle', {
-                defaultValue: 'Queue paused',
-              })
-              : t('deepReviewActionBar.capacityQueue.title', {
-                defaultValue: 'Reviewers waiting for capacity',
-              })}
+            {capacityQueueTitle}
           </span>
           <span className="deep-review-action-bar__capacity-queue-detail">
-            {t('deepReviewActionBar.capacityQueue.detail', {
-              defaultValue: 'Queue wait does not count against reviewer runtime.',
-            })}
+            {capacityQueueDetail}
           </span>
-          {(capacityQueueReasonLabel || capacityQueueElapsedLabel) && (
+          {showCapacityQueueMeta && (
             <span className="deep-review-action-bar__capacity-queue-meta">
               {capacityQueueReasonLabel && (
                 <span className="deep-review-action-bar__capacity-queue-chip">
@@ -130,7 +180,7 @@ export const CapacityQueueNotice: React.FC<CapacityQueueNoticeProps> = ({
               )}
               {capacityQueueElapsedLabel && (
                 <span className="deep-review-action-bar__capacity-queue-chip">
-                  {capacityQueueMaxWaitLabel
+                  {capacityQueueMaxWaitLabel && capacityQueueWaitMode !== 'active_reviewer'
                     ? t('deepReviewActionBar.capacityQueue.elapsedWithMax', {
                       elapsed: capacityQueueElapsedLabel,
                       max: capacityQueueMaxWaitLabel,
@@ -140,6 +190,14 @@ export const CapacityQueueNotice: React.FC<CapacityQueueNoticeProps> = ({
                       elapsed: capacityQueueElapsedLabel,
                       defaultValue: `Waited ${capacityQueueElapsedLabel}`,
                     })}
+                </span>
+              )}
+              {capacityQueueWaitMode === 'active_reviewer' && activeReviewerCount > 0 && (
+                <span className="deep-review-action-bar__capacity-queue-chip">
+                  {t('deepReviewActionBar.capacityQueue.activeReviewerCount', {
+                    count: activeReviewerCount,
+                    defaultValue: `Running reviewers: ${activeReviewerCount}`,
+                  })}
                 </span>
               )}
             </span>

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -707,10 +707,15 @@
     "capacityQueue": {
       "title": "Reviewers waiting for capacity",
       "pausedTitle": "Queue paused",
+      "activeReviewerTitle": "Waiting for running reviewers",
+      "providerTitle": "Waiting for model capacity",
       "detail": "Queue wait does not count against reviewer runtime.",
+      "activeReviewerDetail": "Queued reviewers start when a running reviewer frees capacity. Queue wait does not count against reviewer runtime.",
+      "providerDetail": "BitFun is waiting for temporary model capacity. This wait does not count against reviewer runtime.",
       "reason": "Reason: {{reason}}",
       "elapsed": "Waited {{elapsed}}",
       "elapsedWithMax": "Waited {{elapsed}} of {{max}}",
+      "activeReviewerCount": "Running reviewers: {{count}}",
       "reasons": {
         "providerRateLimit": "provider rate limit",
         "providerConcurrencyLimit": "provider concurrency limit",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -707,10 +707,15 @@
     "capacityQueue": {
       "title": "审核员正在等待容量",
       "pausedTitle": "队列已暂停",
+      "activeReviewerTitle": "等待运行中的审核员",
+      "providerTitle": "等待模型容量",
       "detail": "排队等待时间不会计入审核员运行时长。",
+      "activeReviewerDetail": "排队审核员会在运行中的审核员释放容量后继续启动。排队等待时间不会计入审核员运行时长。",
+      "providerDetail": "BitFun 正在等待临时模型容量恢复。这里的等待不会计入审核员运行时长。",
       "reason": "原因：{{reason}}",
       "elapsed": "已等待 {{elapsed}}",
       "elapsedWithMax": "已等待 {{elapsed}} / {{max}}",
+      "activeReviewerCount": "运行中的审核员：{{count}}",
       "reasons": {
         "providerRateLimit": "模型服务限速",
         "providerConcurrencyLimit": "模型服务并发限制",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -707,10 +707,15 @@
     "capacityQueue": {
       "title": "審核員正在等待容量",
       "pausedTitle": "佇列已暫停",
+      "activeReviewerTitle": "等待執行中的審核員",
+      "providerTitle": "等待模型容量",
       "detail": "排隊等待時間不會計入審核員執行時長。",
+      "activeReviewerDetail": "排隊審核員會在執行中的審核員釋放容量後繼續啟動。排隊等待時間不會計入審核員執行時長。",
+      "providerDetail": "BitFun 正在等待暫時模型容量恢復。這裡的等待不會計入審核員執行時長。",
       "reason": "原因：{{reason}}",
       "elapsed": "已等待 {{elapsed}}",
       "elapsedWithMax": "已等待 {{elapsed}} / {{max}}",
+      "activeReviewerCount": "執行中的審核員：{{count}}",
       "reasons": {
         "providerRateLimit": "模型服務限速",
         "providerConcurrencyLimit": "模型服務並發限制",


### PR DESCRIPTION
﻿## Summary
- Distinguish Deep Review queue waits caused by running reviewers from waits caused by model capacity.
- Keep provider-capacity waits showing the configured max wait, but avoid presenting local reviewer-capacity waits as a hard timeout.
- Add localized copy and regression coverage for the queue notice and action bar integration.

## Validation
- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run`
