### PR TITLE
Sync local fixes: stream dedup, search remote/fallback, session rollback persistence, companion typewriter

### DIFF
--- a/AGENTS-CN.md
+++ b/AGENTS-CN.md
@@ -95,6 +95,16 @@ await api.invoke('your_command', { request: { ... } });
 - 桌面端专属集成应放在 `src/apps/desktop`，再通过 transport / API layer 回流到共享逻辑。
 - 在共享 core 中避免使用 `tauri::AppHandle` 等宿主 API；优先使用 `bitfun_events::EventEmitter` 等共享抽象。
 
+### 远程兼容
+
+- 新增功能时，从一开始就要考虑远程工作区和远程控制同步适配。只支持本地的行为很容易让远程场景功能缺失。
+- 如果某个功能无法合理支持远程工作区，必须做能力屏蔽，或展示明确的不支持提示，不能让它以通用错误的形式失败。
+
+### Agent loop 行为
+
+- 不要把硬编码限制或模式判断作为处理 agent loop 循环问题的第一反应，例如仅按字符串或次数阻止重复工具调用。
+- 过多硬编码会把 agent loop 变成脆弱的 workflow。应先定位根因：工具行为、模型交互、会话上下文封装、prompt/tool schema 设计，或状态同步问题。
+
 ## 架构
 
 ### Core 拆解护栏

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,16 @@ await api.invoke('your_command', { request: { ... } });
 - Desktop-only integrations belong in `src/apps/desktop`, then flow back through transport/API layers.
 - In shared core, avoid host-specific APIs such as `tauri::AppHandle`; use shared abstractions such as `bitfun_events::EventEmitter`.
 
+### Remote compatibility
+
+- When adding features, consider remote workspace and remote control synchronization support from the start. Local-only behavior can silently leave remote scenarios incomplete.
+- If a feature cannot reasonably support remote workspaces, gate it or show a clear unsupported-state message instead of letting it fail with a generic error.
+
+### Agent loop behavior
+
+- Do not add hard-coded limits or pattern checks to the agent loop as a first response to looping behavior, such as blocking repeated tool calls by string or count alone.
+- Excessive hard-coding turns the agent loop into a brittle workflow engine. Investigate the root cause first: tool behavior, model interaction, session context packaging, prompt/tool schema design, or state synchronization issues.
+
 ## Architecture
 
 ### Core decomposition guardrails

--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -15,16 +15,18 @@ use crate::api::search_api::{
 };
 use crate::api::workspace_activation::spawn_workspace_background_warmup;
 use bitfun_core::infrastructure::{
-    BatchedFileSearchProgressSink, FileSearchResult, FileSearchResultGroup, FileTreeNode,
-    SearchMatchType,
+    BatchedFileSearchProgressSink, FileSearchOutcome, FileSearchProgressSink, FileSearchResult,
+    FileSearchResultGroup, FileTreeNode, SearchMatchType,
 };
 use bitfun_core::service::file_watch;
 use bitfun_core::service::remote_ssh::get_remote_workspace_manager;
 use bitfun_core::service::remote_ssh::workspace_state::is_remote_path;
+use bitfun_core::service::remote_ssh::{RemoteDirEntry, RemoteFileService, RemoteWorkspaceEntry};
 use bitfun_core::service::workspace::{
     ScanOptions, WorkspaceInfo, WorkspaceKind, WorkspaceOpenOptions,
 };
 use log::{debug, error, info, warn};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -587,6 +589,191 @@ fn resolve_search_limit(requested: Option<usize>, fallback: usize) -> usize {
     requested
         .unwrap_or(fallback)
         .clamp(1, HARD_MAX_SEARCH_RESULTS)
+}
+
+fn compile_filename_search_regex(
+    pattern: &str,
+    case_sensitive: bool,
+    use_regex: bool,
+    whole_word: bool,
+) -> Result<Regex, String> {
+    let mut pattern = if use_regex {
+        pattern.to_string()
+    } else {
+        regex::escape(pattern)
+    };
+
+    if whole_word {
+        pattern = format!(r"\b(?:{})\b", pattern);
+    }
+
+    if !case_sensitive {
+        pattern = format!("(?i){}", pattern);
+    }
+
+    Regex::new(&pattern).map_err(|error| format!("Invalid search pattern: {}", error))
+}
+
+fn should_skip_remote_search_directory(name: &str) -> bool {
+    matches!(
+        name,
+        ".git"
+            | ".svn"
+            | ".hg"
+            | "node_modules"
+            | "target"
+            | "dist"
+            | "build"
+            | ".next"
+            | ".nuxt"
+            | ".cache"
+            | ".turbo"
+    )
+}
+
+fn should_skip_remote_search_file(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    matches!(
+        lower.rsplit_once('.').map(|(_, ext)| ext),
+        Some(
+            "png"
+                | "jpg"
+                | "jpeg"
+                | "gif"
+                | "webp"
+                | "ico"
+                | "pdf"
+                | "zip"
+                | "tar"
+                | "gz"
+                | "rar"
+                | "7z"
+                | "exe"
+                | "dll"
+                | "so"
+                | "dylib"
+        )
+    )
+}
+
+fn remote_filename_search_result(entry: &RemoteDirEntry) -> FileSearchResult {
+    FileSearchResult {
+        path: entry.path.clone(),
+        name: entry.name.clone(),
+        is_directory: entry.is_dir,
+        match_type: SearchMatchType::FileName,
+        line_number: None,
+        matched_content: None,
+        preview_before: None,
+        preview_inside: None,
+        preview_after: None,
+    }
+}
+
+async fn search_remote_file_names_with_progress(
+    remote_fs: RemoteFileService,
+    entry: RemoteWorkspaceEntry,
+    root_path: String,
+    pattern: String,
+    case_sensitive: bool,
+    use_regex: bool,
+    whole_word: bool,
+    include_directories: bool,
+    limit: usize,
+    cancel_flag: Option<Arc<AtomicBool>>,
+    progress_sink: Option<Arc<dyn FileSearchProgressSink>>,
+) -> Result<FileSearchOutcome, String> {
+    let matcher = compile_filename_search_regex(&pattern, case_sensitive, use_regex, whole_word)?;
+    let mut stack = vec![root_path];
+    let mut results = Vec::new();
+    let mut truncated = false;
+
+    while let Some(directory) = stack.pop() {
+        if cancel_flag
+            .as_ref()
+            .is_some_and(|flag| flag.load(Ordering::Relaxed))
+        {
+            break;
+        }
+
+        let mut entries = remote_fs
+            .read_dir(&entry.connection_id, &directory)
+            .await
+            .map_err(|error| format!("Failed to read remote directory: {}", error))?;
+        entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => a.name.cmp(&b.name),
+        });
+
+        for child in entries {
+            if cancel_flag
+                .as_ref()
+                .is_some_and(|flag| flag.load(Ordering::Relaxed))
+            {
+                break;
+            }
+
+            if child.is_dir {
+                if should_skip_remote_search_directory(&child.name) {
+                    continue;
+                }
+
+                if include_directories && matcher.is_match(&child.name) {
+                    let result = remote_filename_search_result(&child);
+                    if let Some(sink) = progress_sink.as_ref() {
+                        sink.report(FileSearchResultGroup {
+                            path: result.path.clone(),
+                            name: result.name.clone(),
+                            is_directory: result.is_directory,
+                            file_name_match: Some(result.clone()),
+                            content_matches: Vec::new(),
+                        });
+                    }
+                    results.push(result);
+                    if results.len() >= limit {
+                        truncated = true;
+                        break;
+                    }
+                }
+
+                stack.push(child.path);
+                continue;
+            }
+
+            if !child.is_file || should_skip_remote_search_file(&child.name) {
+                continue;
+            }
+
+            if matcher.is_match(&child.name) {
+                let result = remote_filename_search_result(&child);
+                if let Some(sink) = progress_sink.as_ref() {
+                    sink.report(FileSearchResultGroup {
+                        path: result.path.clone(),
+                        name: result.name.clone(),
+                        is_directory: result.is_directory,
+                        file_name_match: Some(result.clone()),
+                        content_matches: Vec::new(),
+                    });
+                }
+                results.push(result);
+                if results.len() >= limit {
+                    truncated = true;
+                    break;
+                }
+            }
+        }
+
+        if truncated {
+            break;
+        }
+    }
+
+    if let Some(sink) = progress_sink.as_ref() {
+        sink.flush();
+    }
+
+    Ok(FileSearchOutcome { results, truncated })
 }
 
 #[derive(Debug, Deserialize)]
@@ -2682,10 +2869,39 @@ pub async fn search_filenames(
         include_directories: request.include_directories,
     };
 
-    let result = state
-        .filesystem_service
-        .search_file_names(&request.root_path, &request.pattern, options, cancel_flag)
-        .await;
+    let result = match resolve_desktop_path_target(&state, &request.root_path, None).await {
+        Ok(DesktopPathTarget::Remote {
+            requested_path,
+            entry,
+        }) => match state.get_remote_file_service_async().await {
+            Ok(remote_fs) => search_remote_file_names_with_progress(
+                remote_fs,
+                entry,
+                requested_path,
+                request.pattern.clone(),
+                request.case_sensitive,
+                request.use_regex,
+                request.whole_word,
+                request.include_directories,
+                limit,
+                cancel_flag,
+                None,
+            )
+            .await
+            .map_err(bitfun_core::util::errors::BitFunError::service),
+            Err(error) => Err(bitfun_core::util::errors::BitFunError::service(format!(
+                "Remote file service not available: {}",
+                error
+            ))),
+        },
+        Ok(DesktopPathTarget::Local { .. }) => {
+            state
+                .filesystem_service
+                .search_file_names(&request.root_path, &request.pattern, options, cancel_flag)
+                .await
+        }
+        Err(error) => Err(bitfun_core::util::errors::BitFunError::service(error)),
+    };
     unregister_search(&state, search_id.as_deref());
 
     match result {
@@ -2798,10 +3014,36 @@ pub async fn start_search_filenames_stream(
         include_directories: request.include_directories,
     };
 
+    let remote_search_target =
+        match resolve_desktop_path_target(&state, &request.root_path, None).await {
+            Ok(DesktopPathTarget::Remote {
+                requested_path,
+                entry,
+            }) => {
+                let remote_fs = match state.get_remote_file_service_async().await {
+                    Ok(remote_fs) => remote_fs,
+                    Err(error) => {
+                        unregister_search(&state, Some(&search_id));
+                        return Err(format!("Remote file service not available: {}", error));
+                    }
+                };
+                Some((remote_fs, entry, requested_path))
+            }
+            Ok(DesktopPathTarget::Local { .. }) => None,
+            Err(error) => {
+                unregister_search(&state, Some(&search_id));
+                return Err(error);
+            }
+        };
+
     let filesystem_service = state.filesystem_service.clone();
     let active_searches = state.active_searches.clone();
     let root_path = request.root_path.clone();
     let pattern = request.pattern.clone();
+    let case_sensitive = request.case_sensitive;
+    let use_regex = request.use_regex;
+    let whole_word = request.whole_word;
+    let include_directories = request.include_directories;
     let response_search_id = search_id.clone();
     let progress_search_id = search_id.clone();
     let progress_app_handle = app_handle.clone();
@@ -2819,15 +3061,33 @@ pub async fn start_search_filenames_stream(
     ));
 
     tokio::spawn(async move {
-        let result = filesystem_service
-            .search_file_names_with_progress(
-                &root_path,
-                &pattern,
-                options,
-                cancel_flag,
+        let result = if let Some((remote_fs, entry, requested_path)) = remote_search_target {
+            search_remote_file_names_with_progress(
+                remote_fs,
+                entry,
+                requested_path,
+                pattern.clone(),
+                case_sensitive,
+                use_regex,
+                whole_word,
+                include_directories,
+                limit,
+                cancel_flag.clone(),
                 Some(progress_sink),
             )
-            .await;
+            .await
+            .map_err(bitfun_core::util::errors::BitFunError::service)
+        } else {
+            filesystem_service
+                .search_file_names_with_progress(
+                    &root_path,
+                    &pattern,
+                    options,
+                    cancel_flag,
+                    Some(progress_sink),
+                )
+                .await
+        };
 
         unregister_search_registry(&active_searches, Some(&search_id));
 

--- a/src/apps/desktop/src/api/search_api.rs
+++ b/src/apps/desktop/src/api/search_api.rs
@@ -77,12 +77,6 @@ async fn workspace_search_unavailable_message(
     state: &State<'_, AppState>,
     root_path: &str,
 ) -> Option<String> {
-    if !workspace_search_feature_enabled().await {
-        return Some(
-            "Workspace search is disabled. Enable it in Settings > Session Config to use accelerated workspace search.".to_string(),
-        );
-    }
-
     if is_remote_path(root_path.trim()).await {
         if lookup_remote_connection(root_path.trim()).await.is_none() {
             return Some("Remote workspace is not registered with BitFun SSH state".to_string());
@@ -93,6 +87,12 @@ async fn workspace_search_unavailable_message(
             return Some("Remote workspace search services are unavailable".to_string());
         }
         return None;
+    }
+
+    if !workspace_search_feature_enabled().await {
+        return Some(
+            "Workspace search is disabled. Enable it in Settings > Session Config to use accelerated workspace search.".to_string(),
+        );
     }
 
     if !workspace_search_daemon_available() {

--- a/src/crates/agent-stream/src/lib.rs
+++ b/src/crates/agent-stream/src/lib.rs
@@ -14,6 +14,7 @@ use futures::{Stream, StreamExt};
 use log::{debug, error, trace};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
 use std::time::Instant;
@@ -248,6 +249,7 @@ struct StreamContext {
 
     // Current tool call state
     pending_tool_calls: PendingToolCalls,
+    finalized_tool_call_ids: HashSet<String>,
 
     // Counters and flags
     stream_started_at: Instant,
@@ -282,6 +284,7 @@ impl StreamContext {
             usage: None,
             provider_metadata: None,
             pending_tool_calls: PendingToolCalls::default(),
+            finalized_tool_call_ids: HashSet::new(),
             stream_started_at: Instant::now(),
             first_chunk_ms: None,
             first_visible_output_ms: None,
@@ -336,6 +339,13 @@ impl StreamContext {
         } else {
             finalized.tool_id.clone()
         };
+        if !self.finalized_tool_call_ids.insert(tool_id.clone()) {
+            debug!(
+                "Skipping duplicate finalized tool call in stream: tool_id={}, tool_name={}",
+                tool_id, tool_name
+            );
+            return;
+        }
         self.tool_calls.push(ToolCall {
             tool_id,
             tool_name,
@@ -1222,6 +1232,53 @@ mod tests {
         assert_eq!(result.tool_calls.len(), 1);
         assert_eq!(result.tool_calls[0].arguments, json!({"a": 1}));
         assert_eq!(result.usage.as_ref().map(|u| u.total_token_count), Some(9));
+    }
+
+    #[tokio::test]
+    async fn skips_duplicate_finalized_tool_call_id_from_tail_chunks() {
+        let processor = build_processor();
+        let stream = iter(vec![
+            Ok(UnifiedResponse {
+                tool_call: Some(UnifiedToolCall {
+                    tool_call_index: None,
+                    id: Some("call_1".to_string()),
+                    name: Some("tool_a".to_string()),
+                    arguments: Some("{\"a\":1}".to_string()),
+                    arguments_is_snapshot: false,
+                }),
+                finish_reason: Some("tool_calls".to_string()),
+                ..Default::default()
+            }),
+            Ok(UnifiedResponse {
+                tool_call: Some(UnifiedToolCall {
+                    tool_call_index: None,
+                    id: Some("call_1".to_string()),
+                    name: Some("tool_a".to_string()),
+                    arguments: Some("{\"a\":1}".to_string()),
+                    arguments_is_snapshot: false,
+                }),
+                ..Default::default()
+            }),
+        ])
+        .boxed();
+
+        let result = processor
+            .process_stream(
+                stream,
+                None,
+                None,
+                "session_1".to_string(),
+                "turn_1".to_string(),
+                "round_1".to_string(),
+                None,
+                &CancellationToken::new(),
+            )
+            .await
+            .expect("stream result");
+
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].tool_id, "call_1");
+        assert_eq!(result.tool_calls[0].arguments, json!({"a": 1}));
     }
 
     #[tokio::test]

--- a/src/crates/ai-adapters/src/stream/stream_handler/gemini.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/gemini.rs
@@ -7,6 +7,7 @@ use eventsource_stream::Eventsource;
 use log::{error, trace};
 use reqwest::Response;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -17,8 +18,7 @@ static GEMINI_STREAM_ID_SEQ: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug)]
 struct GeminiToolCallState {
-    active_name: Option<String>,
-    active_id: Option<String>,
+    active_calls: HashMap<Option<usize>, (String, Option<String>)>,
     stream_id: u64,
     next_index: usize,
 }
@@ -26,38 +26,42 @@ struct GeminiToolCallState {
 impl GeminiToolCallState {
     fn new() -> Self {
         Self {
-            active_name: None,
-            active_id: None,
+            active_calls: HashMap::new(),
             stream_id: GEMINI_STREAM_ID_SEQ.fetch_add(1, Ordering::Relaxed),
             next_index: 0,
         }
     }
 
     fn on_non_tool_response(&mut self) {
-        self.active_name = None;
-        self.active_id = None;
+        self.active_calls.clear();
     }
 
     fn assign_id(&mut self, tool_call: &mut crate::stream::types::unified::UnifiedToolCall) {
+        let tool_key = tool_call.tool_call_index;
         if let Some(existing_id) = tool_call.id.as_ref().filter(|value| !value.is_empty()) {
-            self.active_id = Some(existing_id.clone());
-            self.active_name = tool_call.name.clone().filter(|value| !value.is_empty());
+            self.active_calls.insert(
+                tool_key,
+                (
+                    existing_id.clone(),
+                    tool_call.name.clone().filter(|value| !value.is_empty()),
+                ),
+            );
             return;
         }
 
         let tool_name = tool_call.name.clone().filter(|value| !value.is_empty());
-        let is_same_active_call = self.active_id.is_some() && self.active_name == tool_name;
-
-        if is_same_active_call {
-            tool_call.id = None;
-            return;
+        if let Some((_, active_name)) = self.active_calls.get(&tool_key) {
+            if active_name == &tool_name {
+                tool_call.id = None;
+                return;
+            }
         }
 
         self.next_index += 1;
         let generated_id = format!("gemini_call_{}_{}", self.stream_id, self.next_index);
         tool_call.id = Some(generated_id.clone());
-        self.active_id = Some(generated_id);
-        self.active_name = tool_name;
+        self.active_calls
+            .insert(tool_key, (generated_id, tool_name));
     }
 }
 
@@ -201,7 +205,7 @@ mod tests {
         let mut state = GeminiToolCallState::new();
 
         let mut first = UnifiedToolCall {
-            tool_call_index: None,
+            tool_call_index: Some(0),
             id: None,
             name: Some("get_weather".to_string()),
             arguments: Some("{\"city\":".to_string()),
@@ -210,7 +214,7 @@ mod tests {
         state.assign_id(&mut first);
 
         let mut second = UnifiedToolCall {
-            tool_call_index: None,
+            tool_call_index: Some(0),
             id: None,
             name: Some("get_weather".to_string()),
             arguments: Some("\"Paris\"}".to_string()),
@@ -226,11 +230,38 @@ mod tests {
     }
 
     #[test]
+    fn assigns_distinct_ids_for_same_named_calls_with_different_indices() {
+        let mut state = GeminiToolCallState::new();
+
+        let mut first = UnifiedToolCall {
+            tool_call_index: Some(0),
+            id: None,
+            name: Some("read_file".to_string()),
+            arguments: Some("{\"path\":\"a.rs\"}".to_string()),
+            arguments_is_snapshot: true,
+        };
+        state.assign_id(&mut first);
+
+        let mut second = UnifiedToolCall {
+            tool_call_index: Some(1),
+            id: None,
+            name: Some("read_file".to_string()),
+            arguments: Some("{\"path\":\"b.rs\"}".to_string()),
+            arguments_is_snapshot: true,
+        };
+        state.assign_id(&mut second);
+
+        let first_id = first.id.expect("first id");
+        let second_id = second.id.expect("second id");
+        assert_ne!(first_id, second_id);
+    }
+
+    #[test]
     fn clears_active_tool_after_non_tool_response() {
         let mut state = GeminiToolCallState::new();
 
         let mut first = UnifiedToolCall {
-            tool_call_index: None,
+            tool_call_index: Some(0),
             id: None,
             name: Some("get_weather".to_string()),
             arguments: Some("{}".to_string()),
@@ -240,7 +271,7 @@ mod tests {
         state.on_non_tool_response();
 
         let mut second = UnifiedToolCall {
-            tool_call_index: None,
+            tool_call_index: Some(0),
             id: None,
             name: Some("get_weather".to_string()),
             arguments: Some("{}".to_string()),

--- a/src/crates/ai-adapters/src/stream/types/gemini.rs
+++ b/src/crates/ai-adapters/src/stream/types/gemini.rs
@@ -342,12 +342,12 @@ impl GeminiSSEData {
         };
 
         let mut responses = Vec::new();
-        let mut finish_reason = candidate.finish_reason;
+        let finish_reason = candidate.finish_reason;
         let grounding_metadata = candidate.grounding_metadata;
         let safety_ratings = candidate.safety_ratings;
 
         if let Some(content) = candidate.content {
-            for part in content.parts {
+            for (part_index, part) in content.parts.into_iter().enumerate() {
                 let has_function_call = part.function_call.is_some();
                 let text = part.text.filter(|text| !text.is_empty());
                 let is_thought = part.thought.unwrap_or(false);
@@ -360,14 +360,14 @@ impl GeminiSSEData {
                         reasoning_content: None,
                         thinking_signature,
                         tool_call: Some(UnifiedToolCall {
-                            tool_call_index: None,
+                            tool_call_index: Some(part_index),
                             id: None,
                             name: function_call.name,
                             arguments: serde_json::to_string(&arguments).ok(),
-                            arguments_is_snapshot: false,
+                            arguments_is_snapshot: true,
                         }),
                         usage: usage.take(),
-                        finish_reason: finish_reason.take(),
+                        finish_reason: None,
                         provider_metadata: None,
                     });
                     continue;
@@ -381,7 +381,7 @@ impl GeminiSSEData {
                             thinking_signature,
                             tool_call: None,
                             usage: usage.take(),
-                            finish_reason: finish_reason.take(),
+                            finish_reason: None,
                             provider_metadata: None,
                         });
                         continue;
@@ -398,7 +398,7 @@ impl GeminiSSEData {
                             thinking_signature,
                             tool_call: None,
                             usage: usage.take(),
-                            finish_reason: finish_reason.take(),
+                            finish_reason: None,
                             provider_metadata: None,
                         });
                         continue;
@@ -412,7 +412,7 @@ impl GeminiSSEData {
                         thinking_signature,
                         tool_call: None,
                         usage: usage.take(),
-                        finish_reason: finish_reason.take(),
+                        finish_reason: None,
                         provider_metadata: None,
                     });
                     continue;
@@ -425,7 +425,7 @@ impl GeminiSSEData {
                         thinking_signature,
                         tool_call: None,
                         usage: usage.take(),
-                        finish_reason: finish_reason.take(),
+                        finish_reason: None,
                         provider_metadata: None,
                     });
                 }
@@ -459,9 +459,23 @@ impl GeminiSSEData {
                 thinking_signature: None,
                 tool_call: None,
                 usage: usage.take(),
-                finish_reason: finish_reason.take(),
+                finish_reason: None,
                 provider_metadata: Some(provider_metadata),
             });
+        }
+
+        if let Some(finish_reason) = finish_reason {
+            if let Some(last_response) = responses.last_mut() {
+                last_response.finish_reason = Some(finish_reason);
+                return responses;
+            }
+
+            responses.push(UnifiedResponse {
+                usage,
+                finish_reason: Some(finish_reason),
+                ..Default::default()
+            });
+            return responses;
         }
 
         if responses.is_empty() {
@@ -560,6 +574,63 @@ mod tests {
                 .and_then(|tool_call| tool_call.name.as_deref()),
             Some("get_weather")
         );
+        assert_eq!(
+            responses[0]
+                .tool_call
+                .as_ref()
+                .and_then(|tool_call| tool_call.tool_call_index),
+            Some(0)
+        );
+        assert!(responses[0]
+            .tool_call
+            .as_ref()
+            .is_some_and(|tool_call| tool_call.arguments_is_snapshot));
+    }
+
+    #[test]
+    fn indexes_parallel_function_call_parts_and_finishes_after_all_tools() {
+        let payload = serde_json::json!({
+            "candidates": [{
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "read_file",
+                                "args": { "path": "a.rs" }
+                            }
+                        },
+                        {
+                            "functionCall": {
+                                "name": "read_file",
+                                "args": { "path": "b.rs" }
+                            }
+                        }
+                    ]
+                },
+                "finishReason": "STOP"
+            }]
+        });
+
+        let data: GeminiSSEData = serde_json::from_value(payload).expect("gemini payload");
+        let responses = data.into_unified_responses();
+
+        assert_eq!(responses.len(), 2);
+        assert_eq!(
+            responses[0]
+                .tool_call
+                .as_ref()
+                .and_then(|tool_call| tool_call.tool_call_index),
+            Some(0)
+        );
+        assert_eq!(
+            responses[1]
+                .tool_call
+                .as_ref()
+                .and_then(|tool_call| tool_call.tool_call_index),
+            Some(1)
+        );
+        assert!(responses[0].finish_reason.is_none());
+        assert_eq!(responses[1].finish_reason.as_deref(), Some("STOP"));
     }
 
     #[test]

--- a/src/crates/ai-adapters/src/stream/types/openai.rs
+++ b/src/crates/ai-adapters/src/stream/types/openai.rs
@@ -205,7 +205,6 @@ impl OpenAISSEData {
             finish_reason,
             ..
         } = first_choice;
-        let mut finish_reason = finish_reason;
         let Delta {
             reasoning_content,
             reasoning_details,
@@ -246,7 +245,7 @@ impl OpenAISSEData {
                 thinking_signature: None,
                 tool_call: None,
                 usage: usage.take(),
-                finish_reason: finish_reason.take(),
+                finish_reason: None,
                 provider_metadata: None,
             });
         }
@@ -260,14 +259,28 @@ impl OpenAISSEData {
                     thinking_signature: None,
                     tool_call: Some(UnifiedToolCall::from(tool_call)),
                     usage: if is_first_event { usage.take() } else { None },
-                    finish_reason: if is_first_event {
-                        finish_reason.take()
-                    } else {
-                        None
-                    },
+                    finish_reason: None,
                     provider_metadata: None,
                 });
             }
+        }
+
+        if let Some(finish_reason) = finish_reason {
+            if let Some(last_response) = responses.last_mut() {
+                last_response.finish_reason = Some(finish_reason);
+                return responses;
+            }
+
+            responses.push(UnifiedResponse {
+                text: None,
+                reasoning_content: None,
+                thinking_signature: None,
+                tool_call: None,
+                usage,
+                finish_reason: Some(finish_reason),
+                provider_metadata: None,
+            });
+            return responses;
         }
 
         if responses.is_empty() {
@@ -373,8 +386,8 @@ mod tests {
                 .and_then(|tool| tool.id.as_deref()),
             Some("call_2")
         );
-        assert_eq!(responses[0].finish_reason.as_deref(), Some("tool_calls"));
-        assert!(responses[1].finish_reason.is_none());
+        assert!(responses[0].finish_reason.is_none());
+        assert_eq!(responses[1].finish_reason.as_deref(), Some("tool_calls"));
         assert!(responses[0].usage.is_some());
         assert!(responses[1].usage.is_none());
     }
@@ -479,7 +492,7 @@ mod tests {
         assert_eq!(responses[0].text.as_deref(), Some("hello"));
         assert!(responses[0].tool_call.is_none());
         assert!(responses[0].usage.is_some());
-        assert_eq!(responses[0].finish_reason.as_deref(), Some("tool_calls"));
+        assert!(responses[0].finish_reason.is_none());
 
         assert!(responses[1].text.is_none());
         assert_eq!(
@@ -490,7 +503,7 @@ mod tests {
             Some("call_1")
         );
         assert!(responses[1].usage.is_none());
-        assert!(responses[1].finish_reason.is_none());
+        assert_eq!(responses[1].finish_reason.as_deref(), Some("tool_calls"));
     }
 
     #[test]

--- a/src/crates/core/src/agentic/deep_review/manifest.rs
+++ b/src/crates/core/src/agentic/deep_review/manifest.rs
@@ -232,7 +232,11 @@ impl DeepReviewEvidencePack {
 
         let diff_stat = required_value_for_any_key(pack, &["diffStat", "diff_stat"], "diffStat")?;
         ensure_object(diff_stat, "diffStat")?;
-        required_u64_for_any_key(diff_stat, &["fileCount", "file_count"], "diffStat.fileCount")?;
+        required_u64_for_any_key(
+            diff_stat,
+            &["fileCount", "file_count"],
+            "diffStat.fileCount",
+        )?;
         required_string_for_any_key(
             diff_stat,
             &["lineCountSource", "line_count_source"],
@@ -268,8 +272,7 @@ impl DeepReviewEvidencePack {
         )?;
         for hint in contract_hints {
             ensure_object(hint, "contractHints[]")?;
-            let kind =
-                required_string_for_any_key(hint, &["kind"], "contractHints[].kind")?;
+            let kind = required_string_for_any_key(hint, &["kind"], "contractHints[].kind")?;
             if !matches!(
                 kind.as_str(),
                 "i18n_key" | "tauri_command" | "api_contract" | "config_key"
@@ -383,7 +386,10 @@ impl fmt::Display for DeepReviewEvidencePackValidationError {
     }
 }
 
-fn ensure_object(value: &Value, field: &'static str) -> Result<(), DeepReviewEvidencePackValidationError> {
+fn ensure_object(
+    value: &Value,
+    field: &'static str,
+) -> Result<(), DeepReviewEvidencePackValidationError> {
     if value.is_object() {
         Ok(())
     } else {
@@ -408,8 +414,9 @@ fn required_string_for_any_key(
     keys: &[&str],
     field: &'static str,
 ) -> Result<String, DeepReviewEvidencePackValidationError> {
-    string_for_any_key(value, keys)
-        .ok_or_else(|| DeepReviewEvidencePackValidationError::invalid_field(field, "expected non-empty string"))
+    string_for_any_key(value, keys).ok_or_else(|| {
+        DeepReviewEvidencePackValidationError::invalid_field(field, "expected non-empty string")
+    })
 }
 
 fn required_u64_for_any_key(
@@ -419,7 +426,9 @@ fn required_u64_for_any_key(
 ) -> Result<u64, DeepReviewEvidencePackValidationError> {
     required_value_for_any_key(value, keys, field)?
         .as_u64()
-        .ok_or_else(|| DeepReviewEvidencePackValidationError::invalid_field(field, "expected unsigned integer"))
+        .ok_or_else(|| {
+            DeepReviewEvidencePackValidationError::invalid_field(field, "expected unsigned integer")
+        })
 }
 
 fn required_array_for_any_key<'a>(
@@ -430,7 +439,9 @@ fn required_array_for_any_key<'a>(
 ) -> Result<&'a Vec<Value>, DeepReviewEvidencePackValidationError> {
     let array = required_value_for_any_key(value, keys, field)?
         .as_array()
-        .ok_or_else(|| DeepReviewEvidencePackValidationError::invalid_field(field, "expected array"))?;
+        .ok_or_else(|| {
+            DeepReviewEvidencePackValidationError::invalid_field(field, "expected array")
+        })?;
     if array.len() > max {
         return Err(DeepReviewEvidencePackValidationError::too_many_items(
             field,
@@ -689,8 +700,8 @@ mod tests {
             }
         });
 
-        let profile = DeepReviewScopeProfile::from_manifest(&manifest)
-            .expect("scope profile should parse");
+        let profile =
+            DeepReviewScopeProfile::from_manifest(&manifest).expect("scope profile should parse");
 
         assert_eq!(profile.review_depth(), "high_risk_only");
         assert_eq!(
@@ -702,7 +713,10 @@ mod tests {
             vec!["security", "cross_boundary_api_contracts"]
         );
         assert_eq!(profile.max_dependency_hops(), Some("0"));
-        assert_eq!(profile.optional_reviewer_policy(), Some("risk_matched_only"));
+        assert_eq!(
+            profile.optional_reviewer_policy(),
+            Some("risk_matched_only")
+        );
         assert!(!profile.allow_broad_tool_exploration());
         assert_eq!(profile.coverage_expectation(), Some("High-risk-only pass."));
         assert!(profile.is_reduced_depth());
@@ -722,8 +736,8 @@ mod tests {
             }
         });
 
-        let profile = DeepReviewScopeProfile::from_manifest(&manifest)
-            .expect("scope profile should parse");
+        let profile =
+            DeepReviewScopeProfile::from_manifest(&manifest).expect("scope profile should parse");
 
         assert_eq!(profile.review_depth(), "full_depth");
         assert_eq!(profile.max_dependency_hops(), Some("policy_limited"));
@@ -877,7 +891,10 @@ mod tests {
             .expect("snake-case evidence pack should validate")
             .expect("evidence pack should be present");
 
-        assert_eq!(pack.changed_files()[0], "src/web-ui/src/locales/en-US/flow-chat.json");
+        assert_eq!(
+            pack.changed_files()[0],
+            "src/web-ui/src/locales/en-US/flow-chat.json"
+        );
         assert_eq!(pack.contract_hint_count(), 1);
     }
 

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -277,20 +277,15 @@ impl RoundExecutor {
                         continue;
                     }
 
-                    if is_partial_recovery && attempt_index < max_attempts - 1 {
-                        let delay_ms = Self::retry_delay_ms(attempt_index);
+                    if is_partial_recovery {
                         warn!(
-                            "Retrying stream after partial recovery: session_id={}, round_id={}, attempt={}/{}, delay_ms={}, reason={}",
+                            "Accepting stream partial recovery without retry: session_id={}, round_id={}, attempt={}/{}, reason={}",
                             context.session_id,
                             round_id,
                             attempt_index + 1,
                             max_attempts,
-                            delay_ms,
                             result.partial_recovery_reason.as_deref().unwrap_or("unknown")
                         );
-                        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-                        attempt_index += 1;
-                        continue;
                     }
 
                     break (result, send_to_stream_ms, stream_processing_ms);
@@ -777,7 +772,11 @@ impl RoundExecutor {
             .filter(|(_, tc)| {
                 tc.tool_name == "Write"
                     && tc.arguments.get("content").is_none()
-                    && tc.arguments.get("file_path").and_then(|v| v.as_str()).is_some()
+                    && tc
+                        .arguments
+                        .get("file_path")
+                        .and_then(|v| v.as_str())
+                        .is_some()
             })
             .map(|(i, _)| i)
             .collect();
@@ -835,10 +834,7 @@ impl RoundExecutor {
             content_messages.push(AIMessage::user(content_prompt));
 
             // Send the content-generation request (no tools, pure text output)
-            let full_text = match ai_client
-                .send_message_stream(content_messages, None)
-                .await
-            {
+            let full_text = match ai_client.send_message_stream(content_messages, None).await {
                 Ok(response) => {
                     let mut text = String::new();
                     let mut stream = response.stream;
@@ -1251,7 +1247,8 @@ mod tests {
 
     #[test]
     fn extract_bitfun_contents_with_tags() {
-        let text = "Some preamble\n<bitfun_contents>\nfn main() {}\n</bitfun_contents>\nSome trailing";
+        let text =
+            "Some preamble\n<bitfun_contents>\nfn main() {}\n</bitfun_contents>\nSome trailing";
         assert_eq!(extract_bitfun_contents(text), "fn main() {}");
     }
 

--- a/src/crates/core/src/agentic/persistence/manager.rs
+++ b/src/crates/core/src/agentic/persistence/manager.rs
@@ -643,9 +643,7 @@ impl PersistenceManager {
             model_name,
             created_at,
             last_active_at,
-            turn_count: existing
-                .map(|value| value.turn_count.max(session.dialog_turn_ids.len()))
-                .unwrap_or(session.dialog_turn_ids.len()),
+            turn_count: session.dialog_turn_ids.len(),
             message_count: existing.map(|value| value.message_count).unwrap_or(0),
             tool_call_count: existing.map(|value| value.tool_call_count).unwrap_or(0),
             status: existing
@@ -1891,6 +1889,61 @@ impl PersistenceManager {
         }
 
         Ok(turns)
+    }
+
+    pub async fn delete_dialog_turns_from(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        turn_index: usize,
+    ) -> BitFunResult<()> {
+        let turns_dir = self.turns_dir(workspace_path, session_id);
+        if !turns_dir.exists() {
+            return Ok(());
+        }
+
+        let mut entries = fs::read_dir(&turns_dir)
+            .await
+            .map_err(|e| BitFunError::io(format!("Failed to read turns directory: {}", e)))?;
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|e| BitFunError::io(format!("Failed to iterate turns directory: {}", e)))?
+        {
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            let Some(index_str) = stem.strip_prefix("turn-") else {
+                continue;
+            };
+            let Ok(index) = index_str.parse::<usize>() else {
+                continue;
+            };
+            if index >= turn_index {
+                fs::remove_file(&path).await.map_err(|e| {
+                    BitFunError::io(format!("Failed to delete dialog turn file: {}", e))
+                })?;
+            }
+        }
+
+        if let Some(mut metadata) = self
+            .load_session_metadata(workspace_path, session_id)
+            .await?
+        {
+            let turns = self.load_session_turns(workspace_path, session_id).await?;
+            metadata.turn_count = turns.len();
+            metadata.message_count = turns.iter().map(Self::estimate_turn_message_count).sum();
+            metadata.tool_call_count = turns.iter().map(DialogTurnData::count_tool_calls).sum();
+            metadata.last_active_at = Self::system_time_to_unix_ms(SystemTime::now());
+            self.save_session_metadata(workspace_path, &metadata)
+                .await?;
+        }
+
+        Ok(())
     }
 
     pub async fn load_recent_turns(

--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -81,6 +81,7 @@ mod tests {
     use crate::agentic::persistence::PersistenceManager;
     use crate::agentic::session::SessionContextStore;
     use crate::infrastructure::PathManager;
+    use crate::service::session::{DialogTurnData, UserMessageData};
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::time::Duration;
@@ -299,6 +300,116 @@ mod tests {
 
         assert!(matches!(restored.state, SessionState::Idle));
         assert_eq!(metadata.unread_completion, None);
+    }
+
+    #[tokio::test]
+    async fn rollback_context_deletes_persisted_turns_from_target() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(Arc::new(PathManager::new().expect("path manager")))
+                .expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Rollback session".to_string(),
+                "agent".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+
+        for index in 0..3 {
+            let turn = DialogTurnData::new(
+                format!("turn-{index}"),
+                index,
+                session.session_id.clone(),
+                UserMessageData {
+                    id: format!("turn-{index}-user"),
+                    content: format!("prompt {index}"),
+                    timestamp: index as u64,
+                    metadata: None,
+                },
+            );
+            persistence_manager
+                .save_dialog_turn(workspace.path(), &turn)
+                .await
+                .expect("turn should save");
+        }
+
+        {
+            let mut active = manager
+                .sessions
+                .get_mut(&session.session_id)
+                .expect("session should be active");
+            active.dialog_turn_ids = vec![
+                "turn-0".to_string(),
+                "turn-1".to_string(),
+                "turn-2".to_string(),
+            ];
+        }
+        persistence_manager
+            .save_turn_context_snapshot(
+                workspace.path(),
+                &session.session_id,
+                0,
+                &[crate::agentic::core::Message::user("prompt 0".to_string())],
+            )
+            .await
+            .expect("snapshot 0 should save");
+        persistence_manager
+            .save_turn_context_snapshot(
+                workspace.path(),
+                &session.session_id,
+                1,
+                &[
+                    crate::agentic::core::Message::user("prompt 0".to_string()),
+                    crate::agentic::core::Message::user("prompt 1".to_string()),
+                ],
+            )
+            .await
+            .expect("snapshot 1 should save");
+
+        manager
+            .rollback_context_to_turn_start(workspace.path(), &session.session_id, 1)
+            .await
+            .expect("rollback should succeed");
+
+        let turns = persistence_manager
+            .load_session_turns(workspace.path(), &session.session_id)
+            .await
+            .expect("turns should load");
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].user_message.content, "prompt 0");
+        assert!(persistence_manager
+            .load_turn_context_snapshot(workspace.path(), &session.session_id, 1)
+            .await
+            .expect("snapshot load should succeed")
+            .is_none());
+
+        manager.sessions.remove(&session.session_id);
+        let restored = manager
+            .restore_session(workspace.path(), &session.session_id)
+            .await
+            .expect("session should restore");
+        assert_eq!(restored.dialog_turn_ids, vec!["turn-0".to_string()]);
+        assert_eq!(
+            manager
+                .context_store
+                .get_context_messages(&session.session_id)
+                .len(),
+            1
+        );
+
+        let metadata = persistence_manager
+            .load_session_metadata(workspace.path(), &session.session_id)
+            .await
+            .expect("metadata should load")
+            .expect("metadata should exist");
+        assert_eq!(metadata.turn_count, 1);
     }
 
     #[test]
@@ -1755,8 +1866,13 @@ impl SessionManager {
                 .await?;
         }
 
-        // 4) Delete snapshots from target_turn (inclusive) onwards
+        // 4) Delete persisted turns and snapshots from target_turn (inclusive) onwards.
+        // Runtime restore rebuilds history from persisted turn files, so removing only
+        // context snapshots would make rolled-back prompts reappear after reload.
         if self.config.enable_persistence {
+            self.persistence_manager
+                .delete_dialog_turns_from(workspace_path, session_id, target_turn)
+                .await?;
             self.persistence_manager
                 .delete_turn_context_snapshots_from(workspace_path, session_id, target_turn)
                 .await?;

--- a/src/crates/core/src/agentic/tools/implementations/code_review_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/code_review_tool.rs
@@ -1146,7 +1146,10 @@ mod tests {
         assert_eq!(diagnostics.shared_context_total_calls, 3);
         assert_eq!(diagnostics.shared_context_duplicate_calls, 1);
         assert_eq!(diagnostics.shared_context_duplicate_context_count, 1);
-        assert_eq!(diagnostics.shared_context_duplicate_savings_candidate_count, 1);
+        assert_eq!(
+            diagnostics.shared_context_duplicate_savings_candidate_count,
+            1
+        );
 
         let tool = CodeReviewTool::new();
         let mut context = tool_context(Some("DeepReview"));

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -695,11 +695,7 @@ impl ToolPipeline {
         // Loop detection: refuse to execute the same tool call repeatedly with
         // identical arguments. Triggered on the (THRESHOLD + 1)-th consecutive
         // identical call within the per-session sliding window.
-        if self.check_and_record_tool_call(
-            &task.context.session_id,
-            &tool_name,
-            &tool_args,
-        ) {
+        if self.check_and_record_tool_call(&task.context.session_id, &tool_name, &tool_args) {
             let error_msg = format!(
                 "Tool-call loop blocked: '{}' was already called {} times in a row in this session with identical arguments. Refusing to execute this {}th identical call. Issue a different tool call, or stop tool-calling and respond to the user. If you wrote a file recently and want to continue it, its full content is already visible in your earlier tool_use message — use Edit with `old_string` taken from the end of that content; do not Read the file again.",
                 tool_name,

--- a/src/crates/core/src/service/search/remote.rs
+++ b/src/crates/core/src/service/search/remote.rs
@@ -11,8 +11,8 @@ use crate::service::search::flashgrep::{
     drain_content_length_messages, ClientCapabilities, ClientInfo, ConsistencyMode, GlobOutcome,
     GlobParams, GlobRequest, InitializeParams, OpenRepoParams, PathScope, ProtocolClient,
     QuerySpec, RefreshPolicyConfig, RepoConfig, RepoRef, RepoStatus, Request, Response,
-    SearchModeConfig, SearchOutcome, SearchParams, SearchRequest, SearchResults, TaskRef,
-    TaskStatus,
+    SearchBackend, SearchModeConfig, SearchOutcome, SearchParams, SearchRequest, SearchResults,
+    TaskRef, TaskStatus,
 };
 use crate::service::search::flashgrep::{error::AppError, FlashgrepRepoSession};
 use crate::service::search::{
@@ -617,8 +617,9 @@ impl RemoteWorkspaceSearchService {
             request.exclude_file_types,
         )?;
         let max_results = request.max_results.filter(|limit| *limit > 0);
+        let primary_search_mode = remote_stdio_search_mode(request.output_mode);
         let query = QuerySpec {
-            pattern: request.pattern,
+            pattern: request.pattern.clone(),
             patterns: Vec::new(),
             case_insensitive: !request.case_sensitive,
             multiline: request.multiline,
@@ -631,12 +632,96 @@ impl RemoteWorkspaceSearchService {
             top_k_tokens: 6,
             max_count: None,
             global_max_results: max_results,
-            search_mode: remote_stdio_search_mode(request.output_mode),
+            search_mode: primary_search_mode,
         };
 
         let output_mode = request.output_mode;
-        let (backend, repo_status, raw_results) = session.search(query, scope).await?;
+        let (backend, repo_status, mut raw_results) = session.search(query, scope.clone()).await?;
+        // The bundled flashgrep daemon (v0.2.6) only emits summary statistics
+        // (`matched_lines`/`matched_occurrences`) when it falls back to the
+        // file-system scanner because the workspace has not been indexed yet.
+        // In that mode `LineMatches` returns no `hits`, no `matched_paths`,
+        // and no `file_counts`, leaving the UI showing "no results" even
+        // though the daemon reports thousands of matches. Re-issue the same
+        // query as `FilesWithMatches`, which the daemon does populate with
+        // the matching file paths, so the user at least sees the hit list
+        // while the index is being built.
+        let primary_has_details = !raw_results.hits.is_empty()
+            || !raw_results.file_counts.is_empty()
+            || !raw_results.file_match_counts.is_empty()
+            || !raw_results.matched_paths.is_empty();
+        if matches!(backend, SearchBackend::ScanFallback)
+            && !primary_has_details
+            && raw_results.matched_lines > 0
+            && !matches!(primary_search_mode, SearchModeConfig::FilesWithMatches)
+        {
+            log::info!(
+                "Remote workspace content search re-issuing as FilesWithMatches because daemon ScanFallback returned only summary statistics: pattern_chars={}, primary_search_mode={:?}, primary_matched_lines={}, primary_matched_occurrences={}",
+                request.pattern.chars().count(),
+                primary_search_mode,
+                raw_results.matched_lines,
+                raw_results.matched_occurrences,
+            );
+            let fallback_query = QuerySpec {
+                pattern: request.pattern.clone(),
+                patterns: Vec::new(),
+                case_insensitive: !request.case_sensitive,
+                multiline: request.multiline,
+                dot_matches_new_line: request.multiline,
+                fixed_strings: !request.use_regex,
+                word_regexp: request.whole_word,
+                line_regexp: false,
+                before_context: request.before_context,
+                after_context: request.after_context,
+                top_k_tokens: 6,
+                max_count: None,
+                global_max_results: max_results,
+                search_mode: SearchModeConfig::FilesWithMatches,
+            };
+            match session.search(fallback_query, scope).await {
+                Ok((_, _, fallback_results)) => {
+                    log::info!(
+                        "Remote workspace content search FilesWithMatches fallback succeeded: matched_paths={}, matched_lines={}, matched_occurrences={}",
+                        fallback_results.matched_paths.len(),
+                        fallback_results.matched_lines,
+                        fallback_results.matched_occurrences,
+                    );
+                    raw_results = fallback_results;
+                }
+                Err(error) => {
+                    // Surface the failure instead of silently keeping the
+                    // summary-only `raw_results` from the primary LineMatches
+                    // call. Otherwise the converter produces an empty result
+                    // list while `matched_lines > 0`, recreating the original
+                    // "found N lines but no results" UI inconsistency.
+                    log::warn!(
+                        "Remote workspace content search FilesWithMatches fallback failed: pattern_chars={}, primary_matched_lines={}, primary_matched_occurrences={}, error={}",
+                        request.pattern.chars().count(),
+                        raw_results.matched_lines,
+                        raw_results.matched_occurrences,
+                        error,
+                    );
+                    return Err(format!(
+                        "Remote workspace search returned only summary statistics for {primary_matched_lines} line(s) and the file-list fallback failed: {error}",
+                        primary_matched_lines = raw_results.matched_lines,
+                    ));
+                }
+            }
+        }
+
         let mut results = convert_stdio_search_results(&raw_results, output_mode);
+        log::debug!(
+            "Remote workspace content search converted: backend={:?}, repo_phase={:?}, hits={}, file_counts={}, file_match_counts={}, matched_paths={}, converted_results={}, matched_lines={}, matched_occurrences={}",
+            backend,
+            repo_status.phase,
+            raw_results.hits.len(),
+            raw_results.file_counts.len(),
+            raw_results.file_match_counts.len(),
+            raw_results.matched_paths.len(),
+            results.len(),
+            raw_results.matched_lines,
+            raw_results.matched_occurrences
+        );
         let truncated = max_results
             .map(|limit| results.len() >= limit)
             .unwrap_or(false);
@@ -1287,7 +1372,23 @@ fn convert_stdio_search_results(
 ) -> Vec<FileSearchResult> {
     match output_mode {
         ContentSearchOutputMode::Content => {
-            convert_stdio_hits_to_file_search_results(search_results)
+            let hit_results = convert_stdio_hits_to_file_search_results(search_results);
+            if !hit_results.is_empty() {
+                return hit_results;
+            }
+
+            let count_results = convert_stdio_file_counts_to_search_results(search_results);
+            if !count_results.is_empty() {
+                return count_results;
+            }
+
+            let match_count_results =
+                convert_stdio_file_match_counts_to_search_results(search_results);
+            if !match_count_results.is_empty() {
+                return match_count_results;
+            }
+
+            convert_stdio_matched_paths_to_file_only_results(search_results)
         }
         ContentSearchOutputMode::Count => {
             convert_stdio_file_counts_to_search_results(search_results)
@@ -1323,6 +1424,30 @@ fn convert_stdio_file_counts_to_search_results(
             match_type: SearchMatchType::Content,
             line_number: None,
             matched_content: Some(count.matched_lines.to_string()),
+            preview_before: None,
+            preview_inside: None,
+            preview_after: None,
+        })
+        .collect()
+}
+
+fn convert_stdio_file_match_counts_to_search_results(
+    search_results: &SearchResults,
+) -> Vec<FileSearchResult> {
+    search_results
+        .file_match_counts
+        .iter()
+        .map(|count| FileSearchResult {
+            path: count.path.clone(),
+            name: Path::new(&count.path)
+                .file_name()
+                .and_then(|file_name| file_name.to_str())
+                .unwrap_or(&count.path)
+                .to_string(),
+            is_directory: false,
+            match_type: SearchMatchType::Content,
+            line_number: None,
+            matched_content: Some(count.matched_occurrences.to_string()),
             preview_before: None,
             preview_inside: None,
             preview_after: None,

--- a/src/crates/core/src/service/search/service.rs
+++ b/src/crates/core/src/service/search/service.rs
@@ -767,7 +767,24 @@ fn convert_search_results(
     output_mode: ContentSearchOutputMode,
 ) -> Vec<FileSearchResult> {
     match output_mode {
-        ContentSearchOutputMode::Content => convert_hits_to_file_search_results(search_results),
+        ContentSearchOutputMode::Content => {
+            let hit_results = convert_hits_to_file_search_results(search_results);
+            if !hit_results.is_empty() {
+                return hit_results;
+            }
+
+            let count_results = convert_file_counts_to_search_results(search_results);
+            if !count_results.is_empty() {
+                return count_results;
+            }
+
+            let match_count_results = convert_file_match_counts_to_search_results(search_results);
+            if !match_count_results.is_empty() {
+                return match_count_results;
+            }
+
+            convert_matched_paths_to_file_only_results(search_results)
+        }
         ContentSearchOutputMode::Count => convert_file_counts_to_search_results(search_results),
         ContentSearchOutputMode::FilesWithMatches => {
             convert_matched_paths_to_file_only_results(search_results)
@@ -790,6 +807,30 @@ fn convert_file_counts_to_search_results(search_results: &SearchResults) -> Vec<
             match_type: SearchMatchType::Content,
             line_number: None,
             matched_content: Some(count.matched_lines.to_string()),
+            preview_before: None,
+            preview_inside: None,
+            preview_after: None,
+        })
+        .collect()
+}
+
+fn convert_file_match_counts_to_search_results(
+    search_results: &SearchResults,
+) -> Vec<FileSearchResult> {
+    search_results
+        .file_match_counts
+        .iter()
+        .map(|count| FileSearchResult {
+            path: count.path.clone(),
+            name: Path::new(&count.path)
+                .file_name()
+                .and_then(|file_name| file_name.to_str())
+                .unwrap_or(&count.path)
+                .to_string(),
+            is_directory: false,
+            match_type: SearchMatchType::Content,
+            line_number: None,
+            matched_content: Some(count.matched_occurrences.to_string()),
             preview_before: None,
             preview_inside: None,
             preview_after: None,

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
@@ -60,8 +60,8 @@
   &__bubbles {
     position: relative;
     flex-shrink: 0;
-    width: max-content;
-    max-width: 252px;
+    width: 146px;
+    max-width: 146px;
     max-height: 100vh;
     display: flex;
     flex-direction: column;
@@ -72,6 +72,11 @@
     overscroll-behavior: contain;
     pointer-events: auto;
     scrollbar-width: thin;
+
+    &--single {
+      height: min(var(--bitfun-agent-companion-pet-height, 96px), 100vh);
+      overflow-y: hidden;
+    }
 
     &::-webkit-scrollbar {
       width: 5px;
@@ -87,9 +92,8 @@
     appearance: none;
     text-align: left;
     font: inherit;
-    width: max-content;
+    width: 146px;
     max-width: 100%;
-    min-width: 132px;
     box-sizing: border-box;
     padding: 7px 10px;
     border: 1px solid rgba(15, 23, 42, 0.1);
@@ -107,10 +111,17 @@
       outline: 2px solid rgba(59, 130, 246, 0.7);
       outline-offset: 2px;
     }
+
+    &--single {
+      height: min(var(--bitfun-agent-companion-pet-height, 96px), 100vh);
+      display: flex;
+      flex-direction: column;
+    }
   }
 
   &__bubble-title,
-  &__bubble-status {
+  &__bubble-status,
+  &__bubble-output {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -128,6 +139,29 @@
     font-size: 10px;
     line-height: 1.25;
     color: rgba(31, 41, 55, 0.7);
+  }
+
+  &__bubble-output {
+    margin-top: 6px;
+    min-height: 0;
+    flex: 1;
+    font-size: 10px;
+    line-height: 1.35;
+    color: rgba(31, 41, 55, 0.82);
+    white-space: normal;
+    text-overflow: clip;
+    word-break: break-word;
+
+    &--typing::after {
+      content: "";
+      display: inline-block;
+      width: 1px;
+      height: 1em;
+      margin-left: 2px;
+      vertical-align: -0.12em;
+      background: rgba(31, 41, 55, 0.55);
+      animation: bitfun-agent-companion-caret 920ms steps(2, start) infinite;
+    }
   }
 
   &__bubble--attention,
@@ -153,5 +187,17 @@
     --bitfun-petdex-margin-top: 0;
 
     pointer-events: none;
+  }
+}
+
+@keyframes bitfun-agent-companion-caret {
+  0%,
+  45% {
+    opacity: 1;
+  }
+
+  46%,
+  100% {
+    opacity: 0;
   }
 }

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
@@ -18,12 +18,59 @@ const WINDOW_MAX_HEIGHT = 240;
 const WINDOW_HORIZONTAL_GAP = 8;
 const MAX_VISIBLE_BUBBLES = 2;
 const BUBBLE_GAP = 6;
-const BUBBLE_MIN_WIDTH = 132;
-const BUBBLE_MAX_WIDTH = 252;
+const BUBBLE_WIDTH = 146;
+const BUBBLE_OUTPUT_VISIBLE_CHARS = 64;
+const BUBBLE_OUTPUT_TYPEWRITER_INTERVAL_MS = 28;
 const WINDOW_EDGE_BUFFER = 4;
 const POINTER_HOVER_POLL_INTERVAL_MS = 120;
 /** Clicks shorter/smaller than this use `show_main_window`; beyond it we start a native drag. */
 const PET_DRAG_THRESHOLD_PX = 8;
+
+interface TypewriterOutputState {
+  target: string;
+  visible: string;
+}
+
+function seedTypewriterOutput(target: string): string {
+  if (target.length <= 1) {
+    return '';
+  }
+
+  return target.slice(0, -1);
+}
+
+function commonSuffixPrefixLength(value: string, target: string): number {
+  const maxLength = Math.min(value.length, target.length);
+  for (let length = maxLength; length > 0; length -= 1) {
+    if (value.slice(-length) === target.slice(0, length)) {
+      return length;
+    }
+  }
+  return 0;
+}
+
+function advanceTypewriterOutput(visible: string, target: string): string {
+  if (visible === target) {
+    return visible;
+  }
+
+  if (target.startsWith(visible)) {
+    return target.slice(0, visible.length + 1);
+  }
+
+  const overlapLength = commonSuffixPrefixLength(visible, target);
+  return target.slice(0, Math.min(target.length, overlapLength + 1));
+}
+
+function formatBubbleOutput(output: string, target: string): string {
+  const visibleOutput = output.length > BUBBLE_OUTPUT_VISIBLE_CHARS
+    ? output.slice(-BUBBLE_OUTPUT_VISIBLE_CHARS)
+    : output;
+  const hasHiddenPrefix = target.length > BUBBLE_OUTPUT_VISIBLE_CHARS
+    || output.length > BUBBLE_OUTPUT_VISIBLE_CHARS;
+
+  return hasHiddenPrefix ? `...${visibleOutput}` : visibleOutput;
+}
 
 export const AgentCompanionDesktopPet: React.FC = () => {
   const { t } = useTranslation('flow-chat');
@@ -32,6 +79,7 @@ export const AgentCompanionDesktopPet: React.FC = () => {
   );
   const [mood, setMood] = useState<ChatInputPetMood>('rest');
   const [tasks, setTasks] = useState<AgentCompanionTaskStatus[]>([]);
+  const [typedOutputBySessionId, setTypedOutputBySessionId] = useState<Record<string, TypewriterOutputState>>({});
   const [isHoveringPet, setIsHoveringPet] = useState(false);
   const [isDraggingPet, setIsDraggingPet] = useState(false);
   const [petFrameSize, setPetFrameSize] = useState<{ width: number; height: number } | null>(null);
@@ -102,6 +150,55 @@ export const AgentCompanionDesktopPet: React.FC = () => {
     };
   }, []);
 
+  useEffect(() => {
+    setTypedOutputBySessionId(previous => {
+      const next: Record<string, TypewriterOutputState> = {};
+
+      tasks.forEach(task => {
+        if (!task.latestOutput) {
+          return;
+        }
+
+        const previousOutput = previous[task.sessionId];
+        next[task.sessionId] = previousOutput
+          ? { ...previousOutput, target: task.latestOutput }
+          : {
+            target: task.latestOutput,
+            visible: seedTypewriterOutput(task.latestOutput),
+          };
+      });
+
+      return next;
+    });
+  }, [tasks]);
+
+  useEffect(() => {
+    const hasTypingOutput = Object.values(typedOutputBySessionId)
+      .some(output => output.visible !== output.target);
+    if (!hasTypingOutput) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      setTypedOutputBySessionId(previous => {
+        let changed = false;
+        const next: Record<string, TypewriterOutputState> = {};
+
+        Object.entries(previous).forEach(([sessionId, output]) => {
+          const visible = advanceTypewriterOutput(output.visible, output.target);
+          if (visible !== output.visible) {
+            changed = true;
+          }
+          next[sessionId] = { ...output, visible };
+        });
+
+        return changed ? next : previous;
+      });
+    }, BUBBLE_OUTPUT_TYPEWRITER_INTERVAL_MS);
+
+    return () => window.clearInterval(intervalId);
+  }, [typedOutputBySessionId]);
+
   useLayoutEffect(() => {
     const bubbleCount = tasks.length;
     const bubbleElements = Array.from(bubblesRef.current?.children ?? [])
@@ -111,26 +208,15 @@ export const AgentCompanionDesktopPet: React.FC = () => {
       0,
     ) + Math.max(0, bubbleElements.length - 1) * BUBBLE_GAP;
     const measuredBubbleHeight = bubblesRef.current?.scrollHeight ?? 0;
-    const targetBubbleHeight = bubbleCount > MAX_VISIBLE_BUBBLES
-      ? visibleBubbleHeight
-      : measuredBubbleHeight;
+    const targetBubbleHeight = bubbleCount === 1
+      ? activePetSize.height
+      : bubbleCount > MAX_VISIBLE_BUBBLES
+        ? visibleBubbleHeight
+        : measuredBubbleHeight;
     const nextHeight = bubbleCount > 0
       ? Math.max(activePetSize.height, Math.min(WINDOW_MAX_HEIGHT, targetBubbleHeight))
       : activePetSize.height;
-    const measuredBubbleWidth = bubbleCount > 0
-      ? Math.min(
-        BUBBLE_MAX_WIDTH,
-        Math.max(
-          BUBBLE_MIN_WIDTH,
-          bubblesRef.current?.scrollWidth ?? 0,
-          bubblesRef.current?.getBoundingClientRect().width ?? 0,
-          ...Array.from(bubblesRef.current?.children ?? []).map(child => {
-            const element = child as HTMLElement;
-            return Math.max(element.scrollWidth, element.getBoundingClientRect().width);
-          }),
-        ),
-      )
-      : 0;
+    const measuredBubbleWidth = bubbleCount > 0 ? BUBBLE_WIDTH : 0;
     const measuredDockWidth = bubbleCount > 0
       ? measuredBubbleWidth + WINDOW_HORIZONTAL_GAP + activePetSize.width + WINDOW_EDGE_BUFFER
       : Math.max(
@@ -357,6 +443,7 @@ export const AgentCompanionDesktopPet: React.FC = () => {
     '--bitfun-agent-companion-pet-height': `${activePetSize.height}px`,
     '--bitfun-agent-companion-gap': `${WINDOW_HORIZONTAL_GAP}px`,
   } as React.CSSProperties;
+  const isSingleTask = tasks.length === 1;
 
   return (
     <main
@@ -370,7 +457,7 @@ export const AgentCompanionDesktopPet: React.FC = () => {
         {tasks.length > 0 && (
           <div
             ref={bubblesRef}
-            className="bitfun-agent-companion-window__bubbles"
+            className={`bitfun-agent-companion-window__bubbles${isSingleTask ? ' bitfun-agent-companion-window__bubbles--single' : ''}`}
             aria-live="polite"
             onDoubleClick={event => event.stopPropagation()}
           >
@@ -378,7 +465,7 @@ export const AgentCompanionDesktopPet: React.FC = () => {
               <button
                 type="button"
                 key={task.sessionId}
-                className={`bitfun-agent-companion-window__bubble bitfun-agent-companion-window__bubble--${task.state}`}
+                className={`bitfun-agent-companion-window__bubble bitfun-agent-companion-window__bubble--${task.state}${isSingleTask ? ' bitfun-agent-companion-window__bubble--single' : ''}`}
                 onClick={() => void openTaskSession(task)}
               >
                 <span className="bitfun-agent-companion-window__bubble-title">
@@ -387,6 +474,18 @@ export const AgentCompanionDesktopPet: React.FC = () => {
                 <span className="bitfun-agent-companion-window__bubble-status">
                   {t(task.labelKey, { defaultValue: task.defaultLabel })}
                 </span>
+                {isSingleTask && task.latestOutput && (() => {
+                  const typedOutput = typedOutputBySessionId[task.sessionId];
+                  const visibleOutput = typedOutput?.visible ?? seedTypewriterOutput(task.latestOutput);
+                  const targetOutput = typedOutput?.target ?? task.latestOutput;
+                  const isTyping = visibleOutput !== targetOutput;
+
+                  return (
+                    <span className={`bitfun-agent-companion-window__bubble-output${isTyping ? ' bitfun-agent-companion-window__bubble-output--typing' : ''}`}>
+                      {formatBubbleOutput(visibleOutput, targetOutput)}
+                    </span>
+                  );
+                })()}
               </button>
             ))}
           </div>

--- a/src/web-ui/src/flow_chat/services/EventBatcher.ts
+++ b/src/web-ui/src/flow_chat/services/EventBatcher.ts
@@ -352,9 +352,11 @@ export function generateToolEventKey(data: ToolEventData): { key: string; strate
     const { sessionId: parentSessionId, toolCallId: parentToolId } = subagentParentInfo;
 
     if (eventType === 'ParamsPartial') {
+      const toolName = (toolEvent as any).tool_name || '';
+      const isWriteLike = ['write', 'write_notebook', 'file_write', 'Write'].includes(toolName);
       return {
         key: `subagent:tool:params:${parentSessionId}:${parentToolId}:${toolUseId}`,
-        strategy: 'accumulate'
+        strategy: isWriteLike ? 'replace' : 'accumulate'
       };
     }
     if (eventType === 'Progress') {
@@ -365,9 +367,11 @@ export function generateToolEventKey(data: ToolEventData): { key: string; strate
     }
   } else {
     if (eventType === 'ParamsPartial') {
+      const toolName = (toolEvent as any).tool_name || '';
+      const isWriteLike = ['write', 'write_notebook', 'file_write', 'Write'].includes(toolName);
       return {
         key: `tool:params:${sessionId}:${toolUseId}`,
-        strategy: 'accumulate'
+        strategy: isWriteLike ? 'replace' : 'accumulate'
       };
     }
     if (eventType === 'Progress') {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
@@ -155,7 +155,11 @@ function isWriteLikeToolName(toolName: string): boolean {
   return ['write', 'write_notebook', 'file_write', 'Write'].includes(toolName);
 }
 
-function shouldIgnoreParamsPartial(status: FlowToolItem['status']): boolean {
+function shouldIgnoreParamsPartial(status: FlowToolItem['status'], toolName: string): boolean {
+  if (isWriteLikeToolName(toolName)) {
+    return ['completed', 'error', 'cancelled', 'pending_confirmation', 'confirmed'].includes(status);
+  }
+
   return ['running', 'completed', 'error', 'cancelled', 'pending_confirmation', 'confirmed'].includes(status);
 }
 
@@ -170,12 +174,12 @@ function applyParamsPartial(
   
   if (existingItem && existingItem.type === 'tool') {
     const existingToolItem = existingItem as FlowToolItem;
-    if (shouldIgnoreParamsPartial(existingToolItem.status)) {
+    const prevBuffer = existingToolItem._paramsBuffer || '';
+    const isWriteTool = isWriteLikeToolName(toolEvent.tool_name);
+    if (shouldIgnoreParamsPartial(existingToolItem.status, toolEvent.tool_name)) {
       return;
     }
 
-    const prevBuffer = existingToolItem._paramsBuffer || '';
-    const isWriteTool = isWriteLikeToolName(toolEvent.tool_name);
     const incomingParams = toolEvent.params || '';
     const isWriteFullParamsSnapshot = isWriteTool && incomingParams.trimStart().startsWith('{');
     const newBuffer = isWriteFullParamsSnapshot ? incomingParams : prevBuffer + incomingParams;
@@ -204,7 +208,7 @@ function applyParamsPartial(
       _paramsBuffer: newBuffer,
       status,
       isParamsStreaming: true,
-      _contentSize: hasContentField ? ((parsedParams.content || parsedParams.contents || '').length) : undefined
+      _contentSize: isWriteTool && hasContentField ? ((parsedParams.content || parsedParams.contents || '').length) : undefined
     }, silent);
     applyPendingTerminalSessionId(store, sessionId, turnId, toolEvent.tool_id, silent);
     applyPendingAcpPermissionForTool(store, toolEvent.tool_id);
@@ -233,7 +237,7 @@ export function processToolParamsPartialInternal(
   turnId: string,
   toolEvent: ParamsPartialToolEvent
 ): void {
-  applyParamsPartial(FlowChatStore.getInstance(), sessionId, turnId, toolEvent, true);
+  applyParamsPartial(FlowChatStore.getInstance(), sessionId, turnId, toolEvent, false);
 }
 
 export function processToolProgressInternal(

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
@@ -32,10 +32,14 @@ function makeTextItem(id: string, content: string): FlowTextItem {
 }
 
 function makeReadTool(id: string): FlowToolItem {
+  return makeTool(id, 'Read');
+}
+
+function makeTool(id: string, toolName: string): FlowToolItem {
   return {
     id,
     type: 'tool',
-    toolName: 'Read',
+    toolName,
     timestamp: 1001,
     status: 'completed',
     toolCall: {
@@ -167,6 +171,90 @@ describe('sessionToVirtualItems explore grouping', () => {
     const items = sessionToVirtualItems(session);
 
     expect(items.map(item => item.type)).toEqual(['user-message', 'explore-group']);
+  });
+
+  it('keeps trailing explore groups expanded while the turn is still processing', () => {
+    const session = makeSession({
+      dialogTurns: [{
+        id: 'turn-1',
+        sessionId: 'session-1',
+        userMessage: {
+          id: 'user-1',
+          content: 'Help',
+          timestamp: 900,
+        },
+        modelRounds: [makeRound({ id: 'round-1', isStreaming: false, isComplete: true })],
+        status: 'processing',
+        startTime: 900,
+      }],
+    });
+
+    const items = sessionToVirtualItems(session);
+
+    expect(items.map(item => item.type)).toEqual(['user-message', 'explore-group']);
+    expect(items[1]).toMatchObject({
+      type: 'explore-group',
+      data: {
+        wasCutByCritical: false,
+      },
+    });
+  });
+
+  it('auto-collapses completed trailing explore groups', () => {
+    const session = makeSession();
+
+    const items = sessionToVirtualItems(session);
+
+    expect(items[1]).toMatchObject({
+      type: 'explore-group',
+      data: {
+        wasCutByCritical: true,
+      },
+    });
+  });
+
+  it('auto-collapses non-trailing explore groups during an active turn', () => {
+    const session = makeSession({
+      dialogTurns: [{
+        id: 'turn-1',
+        sessionId: 'session-1',
+        userMessage: {
+          id: 'user-1',
+          content: 'Help',
+          timestamp: 900,
+        },
+        modelRounds: [
+          makeRound({ id: 'round-1' }),
+          makeRound({
+            id: 'round-2',
+            items: [makeTool('tool-2', 'TodoWrite')],
+          }),
+          makeRound({
+            id: 'round-3',
+            isStreaming: true,
+            isComplete: false,
+            status: 'streaming',
+          }),
+        ],
+        status: 'processing',
+        startTime: 900,
+      }],
+    });
+
+    const items = sessionToVirtualItems(session);
+    const exploreGroups = items.filter(item => item.type === 'explore-group');
+
+    expect(exploreGroups).toHaveLength(2);
+    expect(exploreGroups[0]).toMatchObject({
+      data: {
+        wasCutByCritical: true,
+      },
+    });
+    expect(exploreGroups[1]).toMatchObject({
+      data: {
+        wasCutByCritical: false,
+      },
+    });
   });
 
   it('renders user steering as a top-level user message item', () => {

--- a/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.scss
@@ -130,7 +130,8 @@
   right: 0;
   top: calc(100% + 4px);
   z-index: 10;
-  min-width: 160px;
+  width: max-content;
+  max-width: 150px;
   padding: 4px 0;
   border-radius: 6px;
   background: var(--color-bg-elevated);
@@ -150,6 +151,8 @@
   background: transparent;
   border: none;
   text-align: left;
+  white-space: normal;
+  overflow-wrap: anywhere;
 
   &:hover {
     background: var(--element-bg-soft);

--- a/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.tsx
@@ -67,6 +67,13 @@ export const ToolTimeoutIndicator: React.FC<ToolTimeoutIndicatorProps> = ({
   completedFailureReason,
 }) => {
   const { t } = useTranslation('flow-chat');
+  const { elapsedMs, remainingMs } = useLiveElapsedTime(
+    startTime,
+    isRunning,
+    timeoutMs,
+    false,
+  );
+
   const {
     isTimeoutDisabled,
     isToggling,
@@ -75,14 +82,7 @@ export const ToolTimeoutIndicator: React.FC<ToolTimeoutIndicatorProps> = ({
     extendTimeout,
     closePopover,
     remainingAtDisable,
-  } = useSubagentTimeoutControl(subagentSessionId, isRunning, timeoutMs, null);
-
-  const { elapsedMs, remainingMs } = useLiveElapsedTime(
-    startTime,
-    isRunning,
-    timeoutMs,
-    isTimeoutDisabled,
-  );
+  } = useSubagentTimeoutControl(subagentSessionId, isRunning, timeoutMs, remainingMs);
 
   const popoverRef = useRef<HTMLDivElement>(null);
 

--- a/src/web-ui/src/flow_chat/utils/agentCompanionActivity.test.ts
+++ b/src/web-ui/src/flow_chat/utils/agentCompanionActivity.test.ts
@@ -44,12 +44,73 @@ function createSession(turnStatus: DialogTurn['status']): Session {
   };
 }
 
+function createStreamingSessionWithText(content: string): Session {
+  const turn = createTurn('processing');
+  turn.modelRounds = [{
+    id: 'round-1',
+    index: 0,
+    items: [{
+      id: 'text-1',
+      type: 'text',
+      timestamp: 1500,
+      status: 'streaming',
+      content,
+      isStreaming: true,
+    }],
+    isStreaming: true,
+    isComplete: false,
+    status: 'streaming',
+    startTime: 1500,
+  }];
+
+  return {
+    ...createSession('processing'),
+    dialogTurns: [turn],
+  };
+}
+
+function createCompletedSessionWithText(content: string): Session {
+  const turn = createTurn('completed');
+  turn.modelRounds = [{
+    id: 'round-1',
+    index: 0,
+    items: [{
+      id: 'text-1',
+      type: 'text',
+      timestamp: 1500,
+      status: 'completed',
+      content,
+      isStreaming: false,
+    }],
+    isStreaming: false,
+    isComplete: true,
+    status: 'completed',
+    startTime: 1500,
+    endTime: 2000,
+  }];
+
+  return {
+    ...createSession('completed'),
+    dialogTurns: [turn],
+    hasUnreadCompletion: 'completed',
+    lastFinishedAt: 2100,
+  };
+}
+
 async function putStateMachineInFinishing(): Promise<void> {
   await stateMachineManager.transition('session-1', SessionExecutionEvent.START, {
     taskId: 'session-1',
     dialogTurnId: 'turn-1',
   });
   await stateMachineManager.transition('session-1', SessionExecutionEvent.BACKEND_STREAM_COMPLETED);
+}
+
+async function putStateMachineInStreaming(): Promise<void> {
+  await stateMachineManager.transition('session-1', SessionExecutionEvent.START, {
+    taskId: 'session-1',
+    dialogTurnId: 'turn-1',
+  });
+  await stateMachineManager.transition('session-1', SessionExecutionEvent.TEXT_CHUNK_RECEIVED);
 }
 
 describe('buildAgentCompanionActivity', () => {
@@ -87,6 +148,36 @@ describe('buildAgentCompanionActivity', () => {
     expect(buildAgentCompanionActivity()).toEqual({
       mood: 'rest',
       tasks: [],
+    });
+  });
+
+  it('keeps the latest output source anchored to the newest text', async () => {
+    const oldText = 'Older context that should not stay visible in the companion bubble. ';
+    const latestText = 'Newest streaming words should keep appearing normally at the end';
+    flowChatStore.setState(() => ({
+      sessions: new Map([['session-1', createStreamingSessionWithText(oldText.repeat(4) + latestText)]]),
+      activeSessionId: 'session-1',
+    }));
+    await putStateMachineInStreaming();
+
+    const activity = buildAgentCompanionActivity();
+
+    expect(activity.tasks[0].latestOutput).toContain(latestText);
+    expect(activity.tasks[0].latestOutput?.endsWith('...')).toBe(false);
+  });
+
+  it('keeps the final assistant output visible after completion', () => {
+    const finalText = 'Final analysis summary remains visible in the companion bubble.';
+    flowChatStore.setState(() => ({
+      sessions: new Map([['session-1', createCompletedSessionWithText(finalText)]]),
+      activeSessionId: 'session-1',
+    }));
+
+    const activity = buildAgentCompanionActivity();
+
+    expect(activity.tasks[0]).toMatchObject({
+      state: 'completed',
+      latestOutput: finalText,
     });
   });
 });

--- a/src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts
+++ b/src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts
@@ -2,7 +2,7 @@ import { FlowChatStore } from '../store/FlowChatStore';
 import { stateMachineManager } from '../state-machine/SessionStateMachineManager';
 import { ProcessingPhase, type SessionStateMachine } from '../state-machine/types';
 import { deriveChatInputPetMood, type ChatInputPetMood } from './chatInputPetMood';
-import type { DialogTurn, Session } from '../types/flow-chat';
+import type { DialogTurn, FlowTextItem, FlowThinkingItem, Session } from '../types/flow-chat';
 
 export type AgentCompanionTaskState =
   | 'running'
@@ -19,6 +19,7 @@ export interface AgentCompanionTaskStatus {
   state: AgentCompanionTaskState;
   labelKey: string;
   defaultLabel: string;
+  latestOutput?: string;
   startedAt: number;
   updatedAt: number;
 }
@@ -44,6 +45,7 @@ const TRANSIENT_TURN_STATUSES = new Set<DialogTurn['status']>([
   'finishing',
   'cancelling',
 ]);
+const LATEST_OUTPUT_MAX_CHARS = 512;
 
 function ensureTaskOrder(sessionId: string): number {
   const existingOrder = taskOrderBySessionId.get(sessionId);
@@ -68,6 +70,59 @@ function pruneTaskOrder(activeTasks: AgentCompanionTaskStatus[]): void {
 
 function sessionTitle(session: Session): string {
   return session.title?.trim() || 'Session';
+}
+
+function markdownToPlainText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, match => match.replace(/```[^\n]*\n?|```/g, ' '))
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+    .replace(/^\s{0,3}>\s?/gm, '')
+    .replace(/^\s*[-*+]\s+/gm, '')
+    .replace(/^\s*\d+\.\s+/gm, '')
+    .replace(/[*_~]{1,3}/g, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function truncateLatestOutput(text: string): string {
+  if (text.length <= LATEST_OUTPUT_MAX_CHARS) {
+    return text;
+  }
+
+  return text.slice(-LATEST_OUTPUT_MAX_CHARS);
+}
+
+function latestAssistantSnippet(turn: DialogTurn | undefined): string | undefined {
+  if (!turn) {
+    return undefined;
+  }
+
+  for (let roundIndex = turn.modelRounds.length - 1; roundIndex >= 0; roundIndex -= 1) {
+    const round = turn.modelRounds[roundIndex];
+    for (let itemIndex = round.items.length - 1; itemIndex >= 0; itemIndex -= 1) {
+      const item = round.items[itemIndex];
+      if (item.type === 'text' && item.runtimeStatus) {
+        continue;
+      }
+
+      const plainText = item.type === 'thinking'
+        ? markdownToPlainText((item as FlowThinkingItem).content)
+        : item.type === 'text'
+          ? (item as FlowTextItem).isMarkdown === false
+            ? (item as FlowTextItem).content.replace(/\s+/g, ' ').trim()
+            : markdownToPlainText((item as FlowTextItem).content)
+          : '';
+      if (plainText) {
+        return truncateLatestOutput(plainText);
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function trackedDialogTurn(
@@ -190,6 +245,7 @@ function completionTask(session: Session): AgentCompanionTaskStatus | null {
     sessionId: session.sessionId,
     title: sessionTitle(session),
     mood: 'rest' as ChatInputPetMood,
+    latestOutput: latestAssistantSnippet(session.dialogTurns[session.dialogTurns.length - 1]),
     startedAt: session.lastFinishedAt || session.updatedAt || session.lastActiveAt || session.createdAt,
     updatedAt: session.lastFinishedAt || session.updatedAt || session.lastActiveAt || session.createdAt,
   };
@@ -250,6 +306,7 @@ export function buildAgentCompanionActivity(): AgentCompanionActivityPayload {
 
     if (mood !== 'rest') {
       const label = runningLabel(snapshot);
+      const turn = trackedDialogTurn(session, snapshot);
       tasks.push({
         sessionId: session.sessionId,
         title: sessionTitle(session),
@@ -257,6 +314,7 @@ export function buildAgentCompanionActivity(): AgentCompanionActivityPayload {
         state: label.state,
         labelKey: label.labelKey,
         defaultLabel: label.defaultLabel,
+        latestOutput: latestAssistantSnippet(turn),
         startedAt: snapshot?.context.stats.startTime || session.lastActiveAt || session.updatedAt || session.createdAt,
         updatedAt: snapshot?.context.lastUpdateTime || session.updatedAt || session.lastActiveAt || session.createdAt,
       });


### PR DESCRIPTION
## Summary

This PR merges a batch of local fixes and small features developed on top of `bobleer/BitFun:main` (kept in sync with `GCWing/BitFun:main` through `c6103eaf`). All changes are organized into eight logical commits to keep review contained.

### Backend / Rust

- **fix(stream): dedupe finalized tool calls and align finish_reason placement** — `agent-stream` rejects the duplicate finalized tool call that some providers echo in the trailing chunk, and `ai-adapters` for both OpenAI and Gemini now attach `finish_reason` to the *last* unified response (creating a synthetic empty response if needed). Gemini also indexes parallel `functionCall` parts so same-name calls no longer collide on a generated id. Regression tests added in each crate.
- **fix(round-executor): accept stream partial recovery without retry** — Retrying after a partial-recovery stream forced the model to redo cached work, producing duplicate tool calls. Drop the retry path and accept the recovered partial result with a structured log.
- **fix(session): rollback also removes persisted dialog turn files** — `rollback_context_to_turn_start` only deleted snapshots, so reload re-materialized the rolled-back turns from `turn-N.json`. Add `PersistenceManager::delete_dialog_turns_from`, fix `turn_count` saturation, and call the new path before clearing snapshots. Integration test in `session_manager`.
- **feat(search): remote filename search and content fallback chain** — Desktop `search_filenames` (sync + streaming) now walks remote workspaces via `RemoteFileService` with regex matching, ignore lists, binary skipping, cancellation and progress sink. `core/service/search` adds a Content-mode fallback chain (`hits` → `file_counts` → `file_match_counts` → `matched_paths`) and a remote ScanFallback re-issue as `FilesWithMatches` so users do not see "no results" while the index is still building. `search_api.rs` reorders availability checks so remote registration / connectivity is validated before the local feature flag.

### Frontend / web-ui

- **feat(web-ui): typewriter latest output in single-task companion bubble** — Adds a third `__bubble-output` line that renders the latest assistant text (or thinking, markdown-stripped) for the active task using a small typewriter, only when exactly one task is active. Width is fixed to 146px with a `--single` modifier matching the pet height.
- **fix(web-ui): keep Write param updates flowing during execution and tighten timeout tooltip** — `Write` cards no longer ignore `ParamsPartial` events while the tool is running; `EventBatcher` switches to `replace` for write-like tools so a full-snapshot payload overwrites instead of concatenating. `ToolTimeoutIndicator` popover switches to `width: max-content; max-width: 150px` with soft wrapping, and now feeds the live `remainingMs` into `useSubagentTimeoutControl`.
- **chore: align explore-group tests with upstream and reformat touched modules** — Renames the local `shouldAutoCollapse` regression assertions to upstream's `wasCutByCritical` (same boolean semantics) so the tests run against the renderer landed in upstream PR #672. Also runs `cargo fmt` over `deep_review/manifest`, `code_review_tool`, and `tool_pipeline` so the workspace stays rustfmt-clean against the modules touched by the surrounding fixes.

### Docs

- **docs(agents): add remote compatibility and agent loop guidance** — Documents two recurring engineering principles: features must consider remote workspace / remote-control sync from the start (or gate cleanly), and looping behavior should not be patched with hard-coded limits before the root cause (tool, prompt, schema, state sync) is investigated.

## Test plan

- [x] `pnpm run lint:web` — clean
- [x] `pnpm run type-check:web` — clean
- [x] `pnpm --dir src/web-ui run test:run` — 96 files / 531 tests passed
- [x] `cargo check --workspace` — clean
- [x] `cargo check -p bitfun-desktop` — clean
- [x] `cargo test -p bitfun-agent-stream` — passed (incl. new dedup regression test)
- [x] `cargo test -p bitfun-ai-adapters --lib` — 120 tests passed (incl. new Gemini parallel + finish_reason placement tests)
- [x] `cargo test -p bitfun-core --lib` — 581 tests passed (incl. new `rollback_context_deletes_persisted_turns_from_target`)
- [x] `cargo test -p bitfun-desktop --lib` — 38 tests passed
- [x] `cargo clippy -p bitfun-ai-adapters --no-deps` — no new warnings introduced (only pre-existing main-branch warnings remain)
- [x] `rustfmt --check --edition 2021` on all touched files — clean