### PR TITLE
[codex] Clarify Deep Review partial reviewer labels

### DIFF
--- a/src/web-ui/src/flow_chat/deep-review/report/reliabilityNotices.ts
+++ b/src/web-ui/src/flow_chat/deep-review/report/reliabilityNotices.ts
@@ -36,7 +36,7 @@ export const RELIABILITY_NOTICE_FALLBACK_LABELS: Record<ReviewReliabilityNoticeK
   cache_hit: 'Incremental cache reused reviewer output',
   cache_miss: 'Incremental cache missed or refreshed',
   concurrency_limited: 'Reviewer launch was concurrency-limited',
-  partial_reviewer: 'Reviewer timed out with partial result',
+  partial_reviewer: 'Reviewer returned partial result',
   reduced_scope: 'Reduced-depth coverage',
   retry_guidance: 'Retry guidance emitted',
   skipped_reviewers: 'Skipped reviewers',

--- a/src/web-ui/src/flow_chat/deep-review/report/reportSections.ts
+++ b/src/web-ui/src/flow_chat/deep-review/report/reportSections.ts
@@ -134,7 +134,7 @@ function buildPartialReviewerCoverageNotes(reviewers: CodeReviewReviewer[] = [])
       if (!partialOutput || !PARTIAL_TIMEOUT_REVIEWER_STATUSES.has(reviewer.status)) {
         return null;
       }
-      return `${reviewer.name} timed out after producing partial output: ${partialOutput}`;
+      return `${reviewer.name} stopped before completion after producing partial output: ${partialOutput}`;
     })
     .filter((note): note is string => Boolean(note));
 }

--- a/src/web-ui/src/flow_chat/tool-cards/CodeReviewReportExportActions.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CodeReviewReportExportActions.tsx
@@ -105,7 +105,7 @@ export const CodeReviewReportExportActions: React.FC<CodeReviewReportExportActio
         defaultValue: 'Reviewer launch was concurrency-limited',
       }),
       partial_reviewer: t('toolCards.codeReview.reliabilityStatus.partial_reviewer.label', {
-        defaultValue: 'Reviewer timed out with partial result',
+        defaultValue: 'Reviewer returned partial result',
       }),
       reduced_scope: t('toolCards.codeReview.reliabilityStatus.reduced_scope.label', {
         defaultValue: 'Reduced-depth coverage',

--- a/src/web-ui/src/flow_chat/tool-cards/CodeReviewToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CodeReviewToolCard.test.tsx
@@ -318,7 +318,7 @@ describe('CodeReviewToolCard', () => {
     expect(container.textContent).toContain('3 active');
   });
 
-  it('renders compact reliability status when a reviewer timed out with partial evidence', () => {
+  it('renders compact reliability status when a reviewer returned partial evidence', () => {
     const toolItem: FlowToolItem = {
       id: 'tool-1',
       type: 'tool',
@@ -375,7 +375,7 @@ describe('CodeReviewToolCard', () => {
     });
 
     expect(container.textContent).toContain('Review status');
-    expect(container.textContent).toContain('Reviewer timed out with partial result');
+    expect(container.textContent).toContain('Reviewer returned partial result');
     expect(container.textContent).toContain('1 reviewer result is partial; confidence is reduced.');
   });
 

--- a/src/web-ui/src/flow_chat/tool-cards/CodeReviewToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CodeReviewToolCard.tsx
@@ -144,7 +144,7 @@ function getReliabilityNoticeLabel(notice: ReviewReliabilityNotice, t: Translate
       cache_hit: 'Incremental cache reused reviewer output',
       cache_miss: 'Incremental cache missed or refreshed',
       concurrency_limited: 'Reviewer launch was concurrency-limited',
-      partial_reviewer: 'Reviewer timed out with partial result',
+      partial_reviewer: 'Reviewer returned partial result',
       reduced_scope: 'Reduced-depth coverage',
       retry_guidance: 'Retry guidance emitted',
       skipped_reviewers: 'Skipped reviewers',

--- a/src/web-ui/src/flow_chat/utils/codeReviewReport.test.ts
+++ b/src/web-ui/src/flow_chat/utils/codeReviewReport.test.ts
@@ -316,7 +316,7 @@ describe('codeReviewReport', () => {
 
     expect(sections.reviewerStats).toMatchObject({ total: 1, completed: 0, degraded: 1 });
     expect(sections.coverageNotes).toEqual([
-      'Security Reviewer timed out after producing partial output: Found likely token logging in src/auth.ts before timeout.',
+      'Security Reviewer stopped before completion after producing partial output: Found likely token logging in src/auth.ts before timeout.',
     ]);
   });
 
@@ -723,7 +723,7 @@ describe('codeReviewReport', () => {
     expect(markdown).toContain('Security Reviewer (security; Status: partial_timeout)');
     expect(markdown).toContain('Partial output: Found likely token logging in src/auth.ts before timeout.');
     expect(markdown).toContain(
-      'Security Reviewer timed out after producing partial output: Found likely token logging in src/auth.ts before timeout.',
+      'Security Reviewer stopped before completion after producing partial output: Found likely token logging in src/auth.ts before timeout.',
     );
   });
 

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1600,7 +1600,7 @@
           "detail": "{{count}} reviewer launch hit a concurrency cap."
         },
         "partial_reviewer": {
-          "label": "Reviewer timed out with partial result",
+          "label": "Reviewer returned partial result",
           "detail": "{{count}} reviewer result is partial; confidence is reduced."
         },
         "reduced_scope": {

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1600,7 +1600,7 @@
           "detail": "{{count}} 次审核员启动触发了并发上限。"
         },
         "partial_reviewer": {
-          "label": "审核者超时但有部分结果",
+          "label": "审核者返回了部分结果",
           "detail": "{{count}} 个审核者结果是部分结果，置信度已降低。"
         },
         "reduced_scope": {

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1600,7 +1600,7 @@
           "detail": "{{count}} 次審核員啟動觸發了並行上限。"
         },
         "partial_reviewer": {
-          "label": "審核者逾時但有部分結果",
+          "label": "審核者傳回了部分結果",
           "detail": "{{count}} 個審核者結果是部分結果，信心已降低。"
         },
         "reduced_scope": {


### PR DESCRIPTION
## Summary
- Rename partial reviewer reliability labels so they do not imply every partial reviewer result is strictly a timeout.
- Update Deep Review report coverage notes and export/tool-card fallbacks to use the broader partial-result wording.
- Keep the change limited to Code Review / Deep Review web UI presentation, tests, and locales.

## Scope Notes
- No core runtime, execution engine, transport, or API-layer changes remain in this PR.
- Removed the earlier tool-loop and reviewer execution-budget changes from the branch.

## Validation
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run -- src/flow_chat/tool-cards/CodeReviewToolCard.test.tsx src/flow_chat/utils/codeReviewReport.test.ts`
- `pnpm run lint:web`
- `pnpm --dir src/web-ui run test:run`