### PR TITLE
fix(desktop): agent companion pet resize safety and Windows UX

### DIFF
--- a/src/apps/desktop/src/api/acp_client_api.rs
+++ b/src/apps/desktop/src/api/acp_client_api.rs
@@ -264,15 +264,15 @@ pub async fn start_acp_dialog_turn(
     tokio::spawn(async move {
         let mut current_round_id: Option<String> = None;
         let result = service
-        .prompt_agent_stream(
-            &request.client_id,
-            request.user_input,
-            request.workspace_path,
-            request.remote_connection_id,
-            request.session_id.clone(),
-            session_storage_path,
-            request.timeout_seconds,
-            |event| {
+            .prompt_agent_stream(
+                &request.client_id,
+                request.user_input,
+                request.workspace_path,
+                request.remote_connection_id,
+                request.session_id.clone(),
+                session_storage_path,
+                request.timeout_seconds,
+                |event| {
                     match event {
                         AcpClientStreamEvent::ModelRoundStarted {
                             round_id,

--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -522,6 +522,10 @@ fn resize_agent_companion_window(
     );
     let scale_factor = window.scale_factor().unwrap_or(1.0);
     let size = agent_companion_window_effective_size(window);
+    if (size.width - width).abs() < 0.5 && (size.height - height).abs() < 0.5 {
+        return;
+    }
+
     let old_position = window
         .outer_position()
         .ok()
@@ -620,7 +624,16 @@ pub async fn resize_agent_companion_desktop_pet(
 ) -> Result<(), String> {
     let _guard = agent_companion_window_ops().lock().await;
     if let Some(window) = app.get_webview_window(AGENT_COMPANION_WINDOW_LABEL) {
-        resize_agent_companion_window(&app, &window, width, height);
+        let app_for_resize = app.clone();
+        let window_for_resize = window.clone();
+        window
+            .run_on_main_thread(move || {
+                resize_agent_companion_window(&app_for_resize, &window_for_resize, width, height);
+            })
+            .map_err(|e| {
+                warn!("Failed to schedule Agent companion window resize: {}", e);
+                format!("Failed to schedule Agent companion window resize: {}", e)
+            })?;
     }
     Ok(())
 }

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
@@ -129,6 +129,9 @@
   }
 
   &__bubble-title {
+    box-sizing: border-box;
+    max-width: 100%;
+    padding-right: 8px;
     font-size: 11px;
     line-height: 1.25;
     font-weight: 650;
@@ -146,15 +149,15 @@
     display: block;
     margin-top: 6px;
     min-height: 0;
-    flex: 1;
+    flex: 0 0 calc(12px * 4);
+    height: calc(12px * 4);
     font-size: 10px;
-    line-height: 1.35;
+    line-height: 12px;
     color: rgba(31, 41, 55, 0.82);
     white-space: pre-wrap;
     word-break: break-word;
     overflow-wrap: anywhere;
-    overflow-x: hidden;
-    overflow-y: auto;
+    overflow: hidden;
     scrollbar-width: none;
     -ms-overflow-style: none;
 

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
@@ -24,6 +24,7 @@ const WINDOW_EDGE_BUFFER = 4;
 const POINTER_HOVER_POLL_INTERVAL_MS = 120;
 /** Clicks shorter/smaller than this use `show_main_window`; beyond it we start a native drag. */
 const PET_DRAG_THRESHOLD_PX = 8;
+const IS_WINDOWS_WEBVIEW = /\bWindows\b/i.test(window.navigator.userAgent);
 
 interface TypewriterOutputState {
   target: string;
@@ -235,6 +236,10 @@ export const AgentCompanionDesktopPet: React.FC = () => {
   }, [activePetSize.height, activePetSize.width, tasks]);
 
   useEffect(() => {
+    if (IS_WINDOWS_WEBVIEW) {
+      return;
+    }
+
     const tauriWindow = getCurrentWindow();
     let disposed = false;
     let windowPosition: { x: number; y: number } | null = null;


### PR DESCRIPTION
## Summary
- Run Agent Companion window resize on the main thread and skip redundant no-op resizes.
- Gate the macOS-style drag reposition polling so it does not run on Windows WebView.
- Adjust desktop pet bubble subtitle layout (fixed height, hidden overflow, title max width).
- Apply rustfmt to `prompt_agent_stream` indentation in `acp_client_api.rs`.

## Verification
- `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run`
- `cargo check -p bitfun-desktop`
