### PR TITLE
Fix web UI serialization guards for streamed params and pet activity

### DIFF
--- a/src/web-ui/src/flow_chat/services/AgentCompanionActivityBridge.test.ts
+++ b/src/web-ui/src/flow_chat/services/AgentCompanionActivityBridge.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AgentCompanionActivityPayload } from '../utils/agentCompanionActivity';
+import { emitAgentCompanionActivity } from './AgentCompanionActivityBridge';
+
+const tauriEvent = vi.hoisted(() => ({
+  emit: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  emit: tauriEvent.emit,
+}));
+
+vi.mock('@/infrastructure/runtime', () => ({
+  isTauriRuntime: () => true,
+}));
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+describe('emitAgentCompanionActivity', () => {
+  afterEach(() => {
+    tauriEvent.emit.mockReset();
+  });
+
+  it('normalizes activity strings before crossing the desktop event boundary', async () => {
+    await emitAgentCompanionActivity({
+      mood: 'working',
+      tasks: [{
+        sessionId: 'session-\uD800',
+        title: 'Broken \uD800 title',
+        mood: 'working',
+        state: 'running',
+        labelKey: 'agentCompanion.activity.working',
+        defaultLabel: 'Working \uDC00',
+        latestOutput: 'Output \uD800',
+        startedAt: 1000,
+        updatedAt: 1200,
+      }],
+    });
+
+    const emittedActivity = tauriEvent.emit.mock.calls[0]?.[1] as AgentCompanionActivityPayload;
+
+    expect(tauriEvent.emit).toHaveBeenCalledWith('agent-companion://activity-updated', expect.any(Object));
+    expect(hasLoneSurrogate(emittedActivity.tasks[0].sessionId)).toBe(false);
+    expect(hasLoneSurrogate(emittedActivity.tasks[0].title)).toBe(false);
+    expect(hasLoneSurrogate(emittedActivity.tasks[0].defaultLabel)).toBe(false);
+    expect(hasLoneSurrogate(emittedActivity.tasks[0].latestOutput!)).toBe(false);
+  });
+});

--- a/src/web-ui/src/flow_chat/services/AgentCompanionActivityBridge.ts
+++ b/src/web-ui/src/flow_chat/services/AgentCompanionActivityBridge.ts
@@ -1,9 +1,28 @@
 import { isTauriRuntime } from '@/infrastructure/runtime';
 import { createLogger } from '@/shared/utils/logger';
-import type { AgentCompanionActivityPayload } from '../utils/agentCompanionActivity';
+import { toWellFormedText } from '@/shared/utils/wellFormedText';
+import type { AgentCompanionActivityPayload, AgentCompanionTaskStatus } from '../utils/agentCompanionActivity';
 
 const log = createLogger('AgentCompanionActivityBridge');
 let activitySequence = 0;
+
+function sanitizeTaskForEmit(task: AgentCompanionTaskStatus): AgentCompanionTaskStatus {
+  return {
+    ...task,
+    sessionId: toWellFormedText(task.sessionId),
+    title: toWellFormedText(task.title),
+    labelKey: toWellFormedText(task.labelKey),
+    defaultLabel: toWellFormedText(task.defaultLabel),
+    latestOutput: task.latestOutput === undefined ? undefined : toWellFormedText(task.latestOutput),
+  };
+}
+
+function sanitizeActivityForEmit(activity: AgentCompanionActivityPayload): AgentCompanionActivityPayload {
+  return {
+    ...activity,
+    tasks: activity.tasks.map(sanitizeTaskForEmit),
+  };
+}
 
 export async function emitAgentCompanionActivity(
   activity: AgentCompanionActivityPayload,
@@ -11,7 +30,7 @@ export async function emitAgentCompanionActivity(
   if (!isTauriRuntime()) return;
 
   const sequencedActivity: AgentCompanionActivityPayload = {
-    ...activity,
+    ...sanitizeActivityForEmit(activity),
     sequence: activitySequence += 1,
     emittedAt: Date.now(),
   };

--- a/src/web-ui/src/flow_chat/services/EventBatcher.ts
+++ b/src/web-ui/src/flow_chat/services/EventBatcher.ts
@@ -214,6 +214,10 @@ export interface ParamsPartialToolEvent extends BaseToolEvent<'ParamsPartial'> {
   params: string;
 }
 
+export function normalizeParamsPartialFragment(params: unknown): string {
+  return typeof params === 'string' ? params : '';
+}
+
 export interface QueuedToolEvent extends BaseToolEvent<'Queued'> {
   position: number;
 }

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -10,6 +10,7 @@ import { agenticEventListener, type AgenticEventCallbacks } from '../AgenticEven
 import { 
   generateTextChunkKey, 
   generateToolEventKey,
+  normalizeParamsPartialFragment,
   parseEventKey,
   type FlowToolEvent,
   type SubagentParentInfo,
@@ -1573,8 +1574,8 @@ function handleToolEvent(
           toolEvent: {
             ...(existing.toolEvent as ParamsPartialToolEvent),
             params:
-              (existing.toolEvent as ParamsPartialToolEvent).params +
-              (incoming.toolEvent as ParamsPartialToolEvent).params
+              normalizeParamsPartialFragment((existing.toolEvent as ParamsPartialToolEvent).params) +
+              normalizeParamsPartialFragment((incoming.toolEvent as ParamsPartialToolEvent).params)
           }
         })
       );

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { FlowChatStore } from '../../store/FlowChatStore';
+import type { DialogTurn, FlowToolItem, ModelRound, Session } from '../../types/flow-chat';
+import { processToolParamsPartialInternal } from './ToolEventModule';
+
+function resetStore(): void {
+  FlowChatStore.getInstance().setState(() => ({
+    sessions: new Map(),
+    activeSessionId: null,
+  }));
+}
+
+function createSessionWithTool(tool: FlowToolItem): Session {
+  const round: ModelRound = {
+    id: 'round-1',
+    index: 0,
+    items: [tool],
+    isStreaming: true,
+    isComplete: false,
+    status: 'streaming',
+    startTime: 1000,
+  };
+  const turn: DialogTurn = {
+    id: 'turn-1',
+    sessionId: 'session-1',
+    userMessage: {
+      id: 'user-1',
+      content: 'Inspect this file',
+      timestamp: 900,
+    },
+    modelRounds: [round],
+    status: 'processing',
+    startTime: 900,
+  };
+
+  return {
+    sessionId: 'session-1',
+    title: 'Session 1',
+    dialogTurns: [turn],
+    status: 'active',
+    config: { agentType: 'agentic' },
+    createdAt: 800,
+    lastActiveAt: 1000,
+    error: null,
+    sessionKind: 'normal',
+  };
+}
+
+describe('processToolParamsPartialInternal', () => {
+  afterEach(() => {
+    resetStore();
+  });
+
+  it('drops malformed non-string params fragments without replacing existing preview state', () => {
+    const existingParams = { file_path: 'src/main.rs' };
+    const tool: FlowToolItem = {
+      id: 'tool-1',
+      type: 'tool',
+      toolName: 'Read',
+      timestamp: 1001,
+      status: 'streaming',
+      toolCall: {
+        id: 'tool-1',
+        input: existingParams,
+      },
+      isParamsStreaming: true,
+      partialParams: existingParams,
+      _paramsBuffer: '{"file_path":"src/main.rs"}',
+    };
+
+    FlowChatStore.getInstance().setState(() => ({
+      sessions: new Map([['session-1', createSessionWithTool(tool)]]),
+      activeSessionId: 'session-1',
+    }));
+
+    expect(() => {
+      processToolParamsPartialInternal('session-1', 'turn-1', {
+        event_type: 'ParamsPartial',
+        tool_id: 'tool-1',
+        tool_name: 'Read',
+        params: { file_path: 'src/lib.rs' } as any,
+      });
+    }).not.toThrow();
+
+    const updatedTool = FlowChatStore.getInstance()
+      .findToolItem('session-1', 'turn-1', 'tool-1') as FlowToolItem;
+
+    expect(updatedTool._paramsBuffer).toBe('{"file_path":"src/main.rs"}');
+    expect(updatedTool.partialParams).toEqual(existingParams);
+    expect(updatedTool.toolCall.input).toEqual(existingParams);
+  });
+});

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
@@ -9,6 +9,7 @@ import { createLogger } from '@/shared/utils/logger';
 import type { FlowChatContext, FlowToolItem, ToolEventOptions, DialogTurn } from './types';
 import { immediateSaveDialogTurn } from './PersistenceModule';
 import { applyPendingAcpPermissionForTool } from './AcpPermissionToolCardModule';
+import { normalizeParamsPartialFragment } from '../EventBatcher';
 import type {
   CancelledToolEvent,
   CompletedToolEvent,
@@ -180,7 +181,10 @@ function applyParamsPartial(
       return;
     }
 
-    const incomingParams = toolEvent.params || '';
+    const incomingParams = normalizeParamsPartialFragment(toolEvent.params);
+    if (!incomingParams) {
+      return;
+    }
     const isWriteFullParamsSnapshot = isWriteTool && incomingParams.trimStart().startsWith('{');
     const newBuffer = isWriteFullParamsSnapshot ? incomingParams : prevBuffer + incomingParams;
     

--- a/src/web-ui/src/flow_chat/utils/agentCompanionActivity.test.ts
+++ b/src/web-ui/src/flow_chat/utils/agentCompanionActivity.test.ts
@@ -5,6 +5,25 @@ import { ProcessingPhase, SessionExecutionEvent, SessionExecutionState } from '.
 import type { DialogTurn, Session } from '../types/flow-chat';
 import { buildAgentCompanionActivity } from './agentCompanionActivity';
 
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function resetState(): void {
   flowChatStore.setState(() => ({
     sessions: new Map(),
@@ -164,6 +183,20 @@ describe('buildAgentCompanionActivity', () => {
 
     expect(activity.tasks[0].latestOutput).toContain(latestText);
     expect(activity.tasks[0].latestOutput?.endsWith('...')).toBe(false);
+  });
+
+  it('keeps truncated latest output well-formed for desktop pet events', async () => {
+    const content = '\uD83D\uDE00' + 'a'.repeat(511);
+    flowChatStore.setState(() => ({
+      sessions: new Map([['session-1', createStreamingSessionWithText(content)]]),
+      activeSessionId: 'session-1',
+    }));
+    await putStateMachineInStreaming();
+
+    const latestOutput = buildAgentCompanionActivity().tasks[0].latestOutput;
+
+    expect(latestOutput).toBeDefined();
+    expect(hasLoneSurrogate(latestOutput!)).toBe(false);
   });
 
   it('keeps the final assistant output visible after completion', () => {

--- a/src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts
+++ b/src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts
@@ -3,6 +3,7 @@ import { stateMachineManager } from '../state-machine/SessionStateMachineManager
 import { ProcessingPhase, type SessionStateMachine } from '../state-machine/types';
 import { deriveChatInputPetMood, type ChatInputPetMood } from './chatInputPetMood';
 import type { DialogTurn, FlowTextItem, FlowThinkingItem, Session } from '../types/flow-chat';
+import { toWellFormedText } from '@/shared/utils/wellFormedText';
 
 export type AgentCompanionTaskState =
   | 'running'
@@ -69,7 +70,7 @@ function pruneTaskOrder(activeTasks: AgentCompanionTaskStatus[]): void {
 }
 
 function sessionTitle(session: Session): string {
-  return session.title?.trim() || 'Session';
+  return toWellFormedText(session.title?.trim() || 'Session');
 }
 
 function markdownToPlainText(markdown: string): string {
@@ -89,11 +90,12 @@ function markdownToPlainText(markdown: string): string {
 }
 
 function truncateLatestOutput(text: string): string {
-  if (text.length <= LATEST_OUTPUT_MAX_CHARS) {
-    return text;
+  const wellFormedText = toWellFormedText(text);
+  if (wellFormedText.length <= LATEST_OUTPUT_MAX_CHARS) {
+    return wellFormedText;
   }
 
-  return text.slice(-LATEST_OUTPUT_MAX_CHARS);
+  return toWellFormedText(wellFormedText.slice(-LATEST_OUTPUT_MAX_CHARS));
 }
 
 function latestAssistantSnippet(turn: DialogTurn | undefined): string | undefined {

--- a/src/web-ui/src/shared/utils/partialJsonParser.test.ts
+++ b/src/web-ui/src/shared/utils/partialJsonParser.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getFirstAvailableField,
+  isFieldComplete,
+  parsePartialJson,
+} from './partialJsonParser';
+
+describe('partialJsonParser', () => {
+  it('treats non-object partial fragments as empty params', () => {
+    const partialString = '"from';
+
+    expect(parsePartialJson(partialString)).toEqual({});
+    expect(isFieldComplete(partialString, 'content')).toBe(false);
+    expect(getFirstAvailableField(partialString, ['content', 'contents'])).toBeUndefined();
+  });
+
+  it('treats valid non-object JSON values as empty params', () => {
+    expect(parsePartialJson('["content"]')).toEqual({});
+    expect(parsePartialJson('true')).toEqual({});
+    expect(parsePartialJson('42')).toEqual({});
+  });
+
+  it('treats non-string parser input as empty params', () => {
+    expect(parsePartialJson({ content: 'not a JSON string' } as any)).toEqual({});
+  });
+});

--- a/src/web-ui/src/shared/utils/partialJsonParser.ts
+++ b/src/web-ui/src/shared/utils/partialJsonParser.ts
@@ -5,21 +5,23 @@ import { createLogger } from '@/shared/utils/logger';
 
 const log = createLogger('PartialJsonParser');
 
- 
-export function parsePartialJson(jsonStr: string): Record<string, any> {
-  if (!jsonStr || jsonStr.trim() === '') {
+function objectParams(value: unknown): Record<string, any> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, any>
+    : {};
+}
+
+export function parsePartialJson(jsonStr: unknown): Record<string, any> {
+  if (typeof jsonStr !== 'string' || jsonStr.trim() === '') {
     return {};
   }
 
   try {
-    
-    return JSON.parse(jsonStr);
+    return objectParams(JSON.parse(jsonStr));
   } catch {
     try {
-      
-      
       const result = parse(jsonStr, Allow.ALL);
-      return result || {};
+      return objectParams(result);
     } catch (error) {
       log.warn('Failed to parse partial JSON', error);
       return {};
@@ -27,36 +29,32 @@ export function parsePartialJson(jsonStr: string): Record<string, any> {
   }
 }
 
- 
 export function isFieldComplete(jsonStr: string, fieldName: string): boolean {
   const parsed = parsePartialJson(jsonStr);
   return fieldName in parsed && parsed[fieldName] !== null && parsed[fieldName] !== undefined;
 }
 
- 
 export function getFieldValue<T = any>(
-  jsonStr: string, 
-  fieldName: string, 
-  defaultValue?: T
+  jsonStr: string,
+  fieldName: string,
+  defaultValue?: T,
 ): T | undefined {
   const parsed = parsePartialJson(jsonStr);
   return parsed[fieldName] !== undefined ? parsed[fieldName] : defaultValue;
 }
 
- 
 export function getFirstAvailableField<T = any>(
   jsonStr: string,
   fieldNames: string[],
-  defaultValue?: T
+  defaultValue?: T,
 ): T | undefined {
   const parsed = parsePartialJson(jsonStr);
-  
+
   for (const fieldName of fieldNames) {
     if (fieldName in parsed && parsed[fieldName] !== null && parsed[fieldName] !== undefined) {
       return parsed[fieldName];
     }
   }
-  
+
   return defaultValue;
 }
-

--- a/src/web-ui/src/shared/utils/wellFormedText.ts
+++ b/src/web-ui/src/shared/utils/wellFormedText.ts
@@ -1,0 +1,27 @@
+export function toWellFormedText(text: string): string {
+  let result = '';
+
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = text.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        result += text[index] + text[index + 1];
+        index += 1;
+      } else {
+        result += '\uFFFD';
+      }
+      continue;
+    }
+
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      result += '\uFFFD';
+      continue;
+    }
+
+    result += text[index];
+  }
+
+  return result;
+}


### PR DESCRIPTION
﻿## Summary

- Harden streamed tool parameter parsing so partial JSON only updates UI state when it resolves to an object.
- Drop malformed non-string `ParamsPartial` fragments instead of corrupting the existing tool preview buffer.
- Normalize Agent companion activity strings before sending desktop pet events so invalid surrogate pairs cannot break Tauri event serialization.

## Root Cause

The web UI treated partial JSON parser output as an object even though `partial-json` can return primitive values for incomplete fragments. A malformed fragment could reach object-field checks and crash the page. Separately, companion activity text could be truncated in the middle of a UTF-16 surrogate pair, producing a payload that the desktop event bridge could not serialize.

## Validation

- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run`
