### PR TITLE
fix(desktop): suppress context menu on agent companion pet, reorder AI model config form fields

### DIFF
--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
@@ -343,6 +343,10 @@ export const AgentCompanionDesktopPet: React.FC = () => {
     }
   }, []);
 
+  const onContextMenu = useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
+  }, []);
+
   const clearPetPointerSession = (target: HTMLDivElement, pointerId: number) => {
     const session = petPointerSessionRef.current;
     if (!session || session.pointerId !== pointerId) {
@@ -451,6 +455,7 @@ export const AgentCompanionDesktopPet: React.FC = () => {
   return (
     <main
       className="bitfun-agent-companion-window"
+      onContextMenu={onContextMenu}
     >
       <div
         ref={dockRef}

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -1922,6 +1922,8 @@ const AIModelConfig: React.FC = () => {
                     <ConfigPageRow label={`${t('form.configName')} *`} align="center" wide>
                       <Input value={editingConfig.name || ''} onChange={(e) => setEditingConfig(prev => ({ ...prev, name: e.target.value }))} placeholder={t('form.configNamePlaceholder')} inputSize="small" />
                     </ConfigPageRow>
+                    {renderAuthRow()}
+                    {!authIsCli && renderApiKeyRow(`${t('form.apiKey')} *`)}
                     <ConfigPageRow label={`${t('form.baseUrl')} *`} align="center" wide>
                       <div className="bitfun-ai-model-config__control-stack">
                         <Input
@@ -1952,8 +1954,6 @@ const AIModelConfig: React.FC = () => {
                         )}
                       </div>
                     </ConfigPageRow>
-                    {renderAuthRow()}
-                    {!authIsCli && renderApiKeyRow(`${t('form.apiKey')} *`)}
                     <ConfigPageRow label={t('form.provider')} align="center" wide>
                       <Select value={editingConfig.provider || 'openai'} onChange={(value) => {
                         const provider = value as string;


### PR DESCRIPTION
- Add onContextMenu preventDefault to AgentCompanionDesktopPet to block native right-click menu
- Move auth and API key fields before base URL in AIModelConfig form for better UX