### PR TITLE
Add backend diagnostic log redactor

### DIFF
--- a/src/apps/desktop/src/logging.rs
+++ b/src/apps/desktop/src/logging.rs
@@ -5,12 +5,12 @@ use chrono::Local;
 use serde::Serialize;
 use std::path::PathBuf;
 use std::sync::{
-    atomic::{AtomicU8, Ordering},
     OnceLock,
+    atomic::{AtomicU8, Ordering},
 };
 use std::thread;
-use tauri::{plugin::TauriPlugin, Runtime};
-use tauri_plugin_log::{fern, RotationStrategy, Target, TargetKind, TimezoneStrategy};
+use tauri::{Runtime, plugin::TauriPlugin};
+use tauri_plugin_log::{RotationStrategy, Target, TargetKind, TimezoneStrategy, fern};
 
 const SESSION_DIR_PATTERN: &str = r"^\d{8}T\d{6}$";
 const MAX_LOG_SESSIONS: usize = 10;
@@ -309,6 +309,17 @@ pub fn build_log_plugin<R: Runtime>(log_targets: Vec<Target>) -> TauriPlugin<R> 
         .level_for("opentelemetry_sdk", log::LevelFilter::Off)
         .level_for("opentelemetry-otlp", log::LevelFilter::Off)
         .level_for("notify", log::LevelFilter::Off)
+        // These targets can emit hot-path trace diagnostics during event
+        // routing. Keep debug diagnostics, warnings, and errors, but avoid
+        // drowning useful app traces in mechanical noise.
+        .level_for(
+            "bitfun_core::agentic::events::queue",
+            log::LevelFilter::Debug,
+        )
+        .level_for(
+            "bitfun_core::agentic::events::router",
+            log::LevelFilter::Debug,
+        )
         .level_for("hyper_util", log::LevelFilter::Info)
         .level_for("h2", log::LevelFilter::Info)
         .level_for("portable_pty", log::LevelFilter::Info)

--- a/src/crates/ai-adapters/src/diagnostics.rs
+++ b/src/crates/ai-adapters/src/diagnostics.rs
@@ -1,0 +1,27 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static INCLUDE_SENSITIVE_DIAGNOSTICS: AtomicBool = AtomicBool::new(true);
+
+pub fn set_include_sensitive_diagnostics(enabled: bool) {
+    INCLUDE_SENSITIVE_DIAGNOSTICS.store(enabled, Ordering::Relaxed);
+}
+
+pub fn include_sensitive_diagnostics() -> bool {
+    INCLUDE_SENSITIVE_DIAGNOSTICS.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{include_sensitive_diagnostics, set_include_sensitive_diagnostics};
+
+    #[test]
+    fn sensitive_diagnostics_can_be_toggled() {
+        set_include_sensitive_diagnostics(true);
+        assert!(include_sensitive_diagnostics());
+
+        set_include_sensitive_diagnostics(false);
+        assert!(!include_sensitive_diagnostics());
+
+        set_include_sensitive_diagnostics(true);
+    }
+}

--- a/src/crates/ai-adapters/src/lib.rs
+++ b/src/crates/ai-adapters/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 pub mod client;
+pub mod diagnostics;
 pub mod providers;
 pub mod stream;
 pub mod tool_call_accumulator;
@@ -9,7 +10,7 @@ pub mod types;
 pub use client::{AIClient, StreamOptions, StreamResponse};
 pub use stream::{UnifiedResponse, UnifiedTokenUsage, UnifiedToolCall};
 pub use types::{
-    resolve_request_url, AIConfig, ConnectionTestMessageCode, ConnectionTestResult, GeminiResponse,
-    GeminiUsage, Message, ProxyConfig, ReasoningMode, RemoteModelInfo, ToolCall, ToolDefinition,
-    ToolImageAttachment,
+    AIConfig, ConnectionTestMessageCode, ConnectionTestResult, GeminiResponse, GeminiUsage,
+    Message, ProxyConfig, ReasoningMode, RemoteModelInfo, ToolCall, ToolDefinition,
+    ToolImageAttachment, resolve_request_url,
 };

--- a/src/crates/ai-adapters/src/providers/shared.rs
+++ b/src/crates/ai-adapters/src/providers/shared.rs
@@ -1,7 +1,7 @@
+use crate::client::AIClient;
 use crate::client::utils::{
     build_request_body_subset, is_trim_custom_request_body_mode, merge_json_value,
 };
-use crate::client::AIClient;
 use reqwest::RequestBuilder;
 
 pub(crate) fn apply_header_policy<F>(
@@ -104,12 +104,175 @@ pub(crate) fn log_extra_body_keys(
     );
 }
 
+pub(crate) fn summarize_request_body_for_log(
+    request_body: &serde_json::Value,
+) -> serde_json::Value {
+    let mut summary = serde_json::Map::new();
+
+    if let Some(model) = request_body
+        .get("model")
+        .and_then(serde_json::Value::as_str)
+    {
+        summary.insert(
+            "model".to_string(),
+            serde_json::Value::String(model.to_string()),
+        );
+    }
+    if let Some(stream) = request_body
+        .get("stream")
+        .and_then(serde_json::Value::as_bool)
+    {
+        summary.insert("stream".to_string(), serde_json::Value::Bool(stream));
+    }
+    if let Some(max_tokens) = request_body
+        .get("max_tokens")
+        .and_then(|value| value.as_u64())
+    {
+        summary.insert(
+            "max_tokens".to_string(),
+            serde_json::Value::Number(max_tokens.into()),
+        );
+    }
+    if let Some(tool_stream) = request_body
+        .get("tool_stream")
+        .and_then(serde_json::Value::as_bool)
+    {
+        summary.insert(
+            "tool_stream".to_string(),
+            serde_json::Value::Bool(tool_stream),
+        );
+    }
+    if let Some(system) = request_body
+        .get("system")
+        .and_then(serde_json::Value::as_str)
+    {
+        summary.insert(
+            "system_chars".to_string(),
+            serde_json::Value::Number((system.chars().count() as u64).into()),
+        );
+    }
+    if let Some(messages) = request_body
+        .get("messages")
+        .and_then(serde_json::Value::as_array)
+    {
+        summary.insert(
+            "message_count".to_string(),
+            serde_json::Value::Number((messages.len() as u64).into()),
+        );
+        summary.insert(
+            "messages".to_string(),
+            serde_json::Value::Array(messages.iter().map(summarize_message_for_log).collect()),
+        );
+    }
+    if let Some(tools) = request_body
+        .get("tools")
+        .and_then(serde_json::Value::as_array)
+    {
+        summary.insert(
+            "tool_count".to_string(),
+            serde_json::Value::Number((tools.len() as u64).into()),
+        );
+    }
+    if let Some(object) = request_body.as_object() {
+        let mut top_level_keys = object.keys().cloned().collect::<Vec<_>>();
+        top_level_keys.sort();
+        summary.insert(
+            "top_level_keys".to_string(),
+            serde_json::Value::Array(
+                top_level_keys
+                    .into_iter()
+                    .map(serde_json::Value::String)
+                    .collect(),
+            ),
+        );
+    }
+
+    serde_json::Value::Object(summary)
+}
+
+fn summarize_message_for_log(message: &serde_json::Value) -> serde_json::Value {
+    let mut summary = serde_json::Map::new();
+    let content = message.get("content");
+
+    if let Some(role) = message.get("role").and_then(serde_json::Value::as_str) {
+        summary.insert(
+            "role".to_string(),
+            serde_json::Value::String(role.to_string()),
+        );
+    }
+    if let Some(content) = content {
+        summary.insert(
+            "content_chars".to_string(),
+            serde_json::Value::Number((content_text_chars(content) as u64).into()),
+        );
+        if let Some(items) = content.as_array() {
+            summary.insert(
+                "content_items".to_string(),
+                serde_json::Value::Number((items.len() as u64).into()),
+            );
+            let mut content_types = items
+                .iter()
+                .filter_map(|item| item.get("type").and_then(serde_json::Value::as_str))
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            content_types.sort();
+            content_types.dedup();
+            if !content_types.is_empty() {
+                summary.insert(
+                    "content_types".to_string(),
+                    serde_json::Value::Array(
+                        content_types
+                            .into_iter()
+                            .map(serde_json::Value::String)
+                            .collect(),
+                    ),
+                );
+            }
+        }
+    }
+
+    serde_json::Value::Object(summary)
+}
+
+fn content_text_chars(content: &serde_json::Value) -> usize {
+    if let Some(text) = content.as_str() {
+        return text.chars().count();
+    }
+
+    content
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.get("text").and_then(serde_json::Value::as_str))
+                .map(|text| text.chars().count())
+                .sum()
+        })
+        .unwrap_or(0)
+}
+
+fn should_log_full_request_body(include_sensitive_diagnostics: bool) -> bool {
+    include_sensitive_diagnostics
+}
+
 pub(crate) fn log_request_body(target: &str, label: &str, request_body: &serde_json::Value) {
+    if should_log_full_request_body(crate::diagnostics::include_sensitive_diagnostics()) {
+        log::debug!(
+            target: target,
+            "{}\n{}",
+            label,
+            serde_json::to_string_pretty(request_body)
+                .unwrap_or_else(|_| "serialization failed".to_string())
+        );
+        return;
+    }
+
+    let summary_label = label.trim_end_matches(':');
     log::debug!(
         target: target,
-        "{}\n{}",
-        label,
-        serde_json::to_string_pretty(request_body)
+        "{} summary:\n{}",
+        summary_label,
+        serde_json::to_string_pretty(&summarize_request_body_for_log(request_body))
             .unwrap_or_else(|_| "serialization failed".to_string())
     );
 }
@@ -144,5 +307,52 @@ pub(crate) fn collect_function_declaration_names_or_object_keys(
             .into_iter()
             .flat_map(|map| map.keys().cloned())
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_log_full_request_body;
+    use super::summarize_request_body_for_log;
+
+    #[test]
+    fn request_body_log_summary_keeps_shape_without_message_contents() {
+        let request_body = serde_json::json!({
+            "model": "kimi-k2.6",
+            "stream": true,
+            "max_tokens": 32000,
+            "system": "secret system context",
+            "messages": [
+                { "role": "user", "content": "secret user message" },
+                {
+                    "role": "assistant",
+                    "content": [
+                        { "type": "text", "text": "secret assistant message" },
+                        { "type": "tool_use", "id": "tool-1", "name": "Read" }
+                    ]
+                }
+            ]
+        });
+
+        let summary = summarize_request_body_for_log(&request_body);
+        let summary_text = serde_json::to_string(&summary).unwrap();
+
+        assert!(!summary_text.contains("secret system context"));
+        assert!(!summary_text.contains("secret user message"));
+        assert!(!summary_text.contains("secret assistant message"));
+        assert_eq!(summary["model"], "kimi-k2.6");
+        assert_eq!(summary["stream"], true);
+        assert_eq!(summary["max_tokens"], 32000);
+        assert_eq!(summary["system_chars"], 21);
+        assert_eq!(summary["message_count"], 2);
+        assert_eq!(summary["messages"][0]["role"], "user");
+        assert_eq!(summary["messages"][0]["content_chars"], 19);
+        assert_eq!(summary["messages"][1]["content_items"], 2);
+    }
+
+    #[test]
+    fn request_body_logging_keeps_full_payload_when_sensitive_diagnostics_are_enabled() {
+        assert!(should_log_full_request_body(true));
+        assert!(!should_log_full_request_body(false));
     }
 }

--- a/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
+++ b/src/crates/ai-adapters/src/stream/stream_handler/anthropic.rs
@@ -1,12 +1,12 @@
 use super::inline_think::InlineThinkParser;
 use super::stream_stats::StreamStats;
-use super::{next_stream_item, TimedStreamItem};
+use super::{TimedStreamItem, next_stream_item};
 use crate::stream::types::anthropic::{
     AnthropicSSEError, ContentBlock, ContentBlockDelta, ContentBlockStart, MessageDelta,
     MessageStart, Usage,
 };
 use crate::stream::types::unified::UnifiedResponse;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use eventsource_stream::Eventsource;
 use log::{error, trace};
 use reqwest::Response;
@@ -40,11 +40,7 @@ pub async fn handle_anthropic_stream(
             TimedStreamItem::End => {
                 if received_finish_reason {
                     for unified_response in inline_think_parser.flush() {
-                        trace!(
-                            target: AI_STREAM_RESPONSE_TARGET,
-                            "Anthropic unified response: {:?}",
-                            unified_response
-                        );
+                        trace_unified_response_if_useful(&unified_response);
                         stats.record_unified_response(&unified_response);
                         let _ = tx_event.send(Ok(unified_response));
                     }
@@ -77,9 +73,14 @@ pub async fn handle_anthropic_stream(
             }
         };
 
-        trace!(target: AI_STREAM_RESPONSE_TARGET, "Anthropic SSE: {:?}", sse);
+        let include_sensitive_diagnostics = crate::diagnostics::include_sensitive_diagnostics();
+        if include_sensitive_diagnostics {
+            trace!(target: AI_STREAM_RESPONSE_TARGET, "Anthropic SSE: {:?}", sse);
+        }
+
         let event_type = sse.event;
         let data = sse.data;
+        trace_anthropic_sse_event_if_useful(&event_type, &data);
         stats.record_sse_event(&event_type);
 
         if let Some(ref tx) = tx_raw_sse {
@@ -211,11 +212,7 @@ pub async fn handle_anthropic_stream(
             }
             "message_stop" => {
                 for unified_response in inline_think_parser.flush() {
-                    trace!(
-                        target: AI_STREAM_RESPONSE_TARGET,
-                        "Anthropic unified response: {:?}",
-                        unified_response
-                    );
+                    trace_unified_response_if_useful(&unified_response);
                     stats.record_unified_response(&unified_response);
                     let _ = tx_event.send(Ok(unified_response));
                 }
@@ -259,6 +256,92 @@ fn format_provider_error_from_sse_message(event_type: &str, data: &str) -> Optio
     Some(formatted)
 }
 
+fn should_trace_anthropic_sse_event(event_type: &str, _data: &str) -> bool {
+    event_type != "content_block_delta"
+}
+
+fn trace_anthropic_sse_event_if_useful(event_type: &str, data: &str) {
+    if should_log_full_stream_events(crate::diagnostics::include_sensitive_diagnostics()) {
+        return;
+    }
+
+    if !should_trace_anthropic_sse_event(event_type, data) {
+        return;
+    }
+
+    trace!(
+        target: AI_STREAM_RESPONSE_TARGET,
+        "Anthropic SSE event: event_type={}, data_bytes={}",
+        event_type,
+        data.len()
+    );
+}
+
+fn should_log_full_stream_events(include_sensitive_diagnostics: bool) -> bool {
+    include_sensitive_diagnostics
+}
+
+fn should_trace_unified_response(response: &UnifiedResponse) -> bool {
+    response.finish_reason.is_some()
+        || response.usage.is_some()
+        || response.provider_metadata.is_some()
+        || response.thinking_signature.is_some()
+        || response
+            .tool_call
+            .as_ref()
+            .is_some_and(|tool_call| tool_call.id.is_some() || tool_call.name.is_some())
+}
+
+fn trace_unified_response_if_useful(response: &UnifiedResponse) {
+    if should_log_full_stream_events(crate::diagnostics::include_sensitive_diagnostics()) {
+        trace!(
+            target: AI_STREAM_RESPONSE_TARGET,
+            "Anthropic unified response full: {:?}",
+            response
+        );
+        return;
+    }
+
+    if !should_trace_unified_response(response) {
+        return;
+    }
+
+    let tool_call_summary = response.tool_call.as_ref().map(|tool_call| {
+        format!(
+            "index={:?}, has_id={}, name={:?}, arguments_bytes={}, snapshot={}",
+            tool_call.tool_call_index,
+            tool_call.id.is_some(),
+            tool_call.name.as_deref(),
+            tool_call
+                .arguments
+                .as_ref()
+                .map(|value| value.len())
+                .unwrap_or(0),
+            tool_call.arguments_is_snapshot
+        )
+    });
+
+    trace!(
+        target: AI_STREAM_RESPONSE_TARGET,
+        "Anthropic unified response summary: text_chars={}, reasoning_chars={}, has_signature={}, tool_call={:?}, has_usage={}, finish_reason={:?}, has_provider_metadata={}",
+        response
+            .text
+            .as_ref()
+            .map(|value| value.chars().count())
+            .unwrap_or(0),
+        response
+            .reasoning_content
+            .as_ref()
+            .map(|value| value.chars().count())
+            .unwrap_or(0),
+        response.thinking_signature.is_some(),
+        tool_call_summary,
+        response.usage.is_some(),
+        response.finish_reason.as_deref(),
+        response.provider_metadata.is_some()
+    );
+}
+
 fn emit_normalized_response(
     inline_think_parser: &mut InlineThinkParser,
     tx_event: &mpsc::UnboundedSender<Result<UnifiedResponse>>,
@@ -266,11 +349,7 @@ fn emit_normalized_response(
     unified_response: UnifiedResponse,
 ) {
     for normalized_response in inline_think_parser.normalize_response(unified_response) {
-        trace!(
-            target: AI_STREAM_RESPONSE_TARGET,
-            "Anthropic unified response: {:?}",
-            normalized_response
-        );
+        trace_unified_response_if_useful(&normalized_response);
         stats.record_unified_response(&normalized_response);
         let _ = tx_event.send(Ok(normalized_response));
     }
@@ -278,7 +357,11 @@ fn emit_normalized_response(
 
 #[cfg(test)]
 mod tests {
-    use super::format_provider_error_from_sse_message;
+    use super::{
+        format_provider_error_from_sse_message, should_log_full_stream_events,
+        should_trace_anthropic_sse_event, should_trace_unified_response,
+    };
+    use crate::stream::types::unified::{UnifiedResponse, UnifiedToolCall};
 
     #[test]
     fn extracts_glm_business_error_from_message_event() {
@@ -297,5 +380,62 @@ mod tests {
         let raw = r#"{"type":"message_delta","delta":{"stop_reason":null}}"#;
 
         assert!(format_provider_error_from_sse_message("message_delta", raw).is_none());
+    }
+
+    #[test]
+    fn suppresses_noisy_anthropic_delta_trace_but_keeps_errors() {
+        assert!(!should_trace_anthropic_sse_event(
+            "content_block_delta",
+            r#"{"delta":{"type":"text_delta","text":"hello"}}"#
+        ));
+        assert!(should_trace_anthropic_sse_event(
+            "error",
+            r#"{"error":{"message":"bad request"}}"#
+        ));
+        assert!(should_trace_anthropic_sse_event(
+            "message_start",
+            r#"{"message":{"model":"kimi-k2.6"}}"#
+        ));
+    }
+
+    #[test]
+    fn suppresses_chunk_unified_trace_but_keeps_boundaries_and_usage() {
+        assert!(!should_trace_unified_response(&UnifiedResponse {
+            text: Some("hello".to_string()),
+            ..UnifiedResponse::default()
+        }));
+
+        assert!(!should_trace_unified_response(&UnifiedResponse {
+            tool_call: Some(UnifiedToolCall {
+                tool_call_index: None,
+                id: None,
+                name: None,
+                arguments: Some("{\"path\"".to_string()),
+                arguments_is_snapshot: false,
+            }),
+            ..UnifiedResponse::default()
+        }));
+
+        assert!(should_trace_unified_response(&UnifiedResponse {
+            tool_call: Some(UnifiedToolCall {
+                tool_call_index: None,
+                id: Some("tool-1".to_string()),
+                name: Some("Read".to_string()),
+                arguments: None,
+                arguments_is_snapshot: false,
+            }),
+            ..UnifiedResponse::default()
+        }));
+
+        assert!(should_trace_unified_response(&UnifiedResponse {
+            finish_reason: Some("tool_use".to_string()),
+            ..UnifiedResponse::default()
+        }));
+    }
+
+    #[test]
+    fn full_anthropic_stream_trace_follows_sensitive_diagnostics_preference() {
+        assert!(should_log_full_stream_events(true));
+        assert!(!should_log_full_stream_events(false));
     }
 }

--- a/src/crates/core/src/service/config/global.rs
+++ b/src/crates/core/src/service/config/global.rs
@@ -53,6 +53,11 @@ pub enum ConfigUpdateEvent {
         /// New runtime log level.
         new_level: String,
     },
+    /// Runtime sensitive diagnostics preference updated.
+    LoggingSensitiveDiagnosticsUpdated {
+        /// Whether logs may include prompts, payloads, and other sensitive diagnostics.
+        include_sensitive_diagnostics: bool,
+    },
     /// AI models / default-model slots / agent-model mappings were reconciled
     /// after a model became unavailable (disabled, deleted, or otherwise
     /// invalid). Emitted whenever the config layer had to silently rewrite

--- a/src/crates/core/src/service/config/manager.rs
+++ b/src/crates/core/src/service/config/manager.rs
@@ -4,7 +4,7 @@
 
 use super::providers::ConfigProviderRegistry;
 use super::types::*;
-use crate::infrastructure::{try_get_path_manager_arc, PathManager};
+use crate::infrastructure::{PathManager, try_get_path_manager_arc};
 use crate::util::errors::*;
 use log::{debug, info, warn};
 
@@ -68,6 +68,9 @@ impl ConfigManager {
         };
 
         manager.load_or_create_config().await?;
+        bitfun_ai_adapters::diagnostics::set_include_sensitive_diagnostics(
+            manager.config.app.logging.include_sensitive_diagnostics,
+        );
 
         debug!("ConfigManager initialized at {:?}", manager.config_file);
         Ok(manager)
@@ -509,6 +512,8 @@ impl ConfigManager {
         self.check_and_broadcast_app_change(path).await;
         self.check_and_broadcast_debug_mode_change(old_config).await;
         self.check_and_broadcast_log_level_change(old_config).await;
+        self.check_and_broadcast_sensitive_diagnostics_change(old_config)
+            .await;
 
         self.providers
             .notify_config_changed(path, old_config, &self.config)
@@ -562,6 +567,29 @@ impl ConfigManager {
             use super::global::{ConfigUpdateEvent, GlobalConfigManager};
             GlobalConfigManager::broadcast_update(ConfigUpdateEvent::LogLevelUpdated { new_level })
                 .await;
+        }
+    }
+
+    /// Detects and broadcasts runtime sensitive diagnostics changes.
+    async fn check_and_broadcast_sensitive_diagnostics_change(&self, old_config: &GlobalConfig) {
+        let old_include = old_config.app.logging.include_sensitive_diagnostics;
+        let new_include = self.config.app.logging.include_sensitive_diagnostics;
+
+        if old_include != new_include {
+            debug!(
+                "App logging sensitive diagnostics preference changed: {} -> {}",
+                old_include, new_include
+            );
+
+            bitfun_ai_adapters::diagnostics::set_include_sensitive_diagnostics(new_include);
+
+            use super::global::{ConfigUpdateEvent, GlobalConfigManager};
+            GlobalConfigManager::broadcast_update(
+                ConfigUpdateEvent::LoggingSensitiveDiagnosticsUpdated {
+                    include_sensitive_diagnostics: new_include,
+                },
+            )
+            .await;
         }
     }
 }

--- a/src/crates/core/src/service/config/types.rs
+++ b/src/crates/core/src/service/config/types.rs
@@ -117,6 +117,9 @@ pub struct AppLoggingConfig {
     /// Runtime backend log level.
     /// Allowed values: trace, debug, info, warn, error, off.
     pub level: String,
+    /// Whether diagnostic logs may include sensitive troubleshooting payloads.
+    #[serde(default = "default_true")]
+    pub include_sensitive_diagnostics: bool,
 }
 
 /// Session-related UI preferences.
@@ -1294,6 +1297,7 @@ impl Default for AppLoggingConfig {
         Self {
             // Set to Debug in early development for easier diagnostics
             level: "debug".to_string(),
+            include_sensitive_diagnostics: true,
         }
     }
 }
@@ -1727,7 +1731,9 @@ impl AIModelConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{AIConfig, AIExperienceConfig, AIModelConfig, GlobalConfig, ReasoningMode};
+    use super::{
+        AIConfig, AIExperienceConfig, AIModelConfig, AppLoggingConfig, GlobalConfig, ReasoningMode,
+    };
 
     #[test]
     fn deserializes_compatibility_thinking_flag_into_reasoning_mode() {
@@ -1970,6 +1976,16 @@ mod tests {
         assert_eq!(config.stream_idle_timeout_secs, None);
         assert_eq!(config.subagent_max_concurrency, 5);
         assert!(config.review_teams.contains_key("default"));
+    }
+
+    #[test]
+    fn app_logging_defaults_to_sensitive_diagnostics_enabled() {
+        let config: AppLoggingConfig = serde_json::from_value(serde_json::json!({
+            "level": "trace"
+        }))
+        .expect("logging config without sensitive preference should deserialize");
+
+        assert!(config.include_sensitive_diagnostics);
     }
 
     #[test]

--- a/src/web-ui/src/flow_chat/services/EventBatcher.test.ts
+++ b/src/web-ui/src/flow_chat/services/EventBatcher.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { setIncludeSensitiveDiagnostics } from '@/shared/utils/logger';
+import { getBatchedEventsLogPayload, summarizeBatchedEventsForLog, type BatchedEvent } from './EventBatcher';
+
+describe('summarizeBatchedEventsForLog', () => {
+  afterEach(() => {
+    setIncludeSensitiveDiagnostics(true);
+  });
+
+  it('keeps full payloads when sensitive diagnostics are enabled', () => {
+    setIncludeSensitiveDiagnostics(true);
+    const events: BatchedEvent[] = [
+      {
+        key: 'subagent:tool:params:session:call:tool',
+        payload: {
+          toolEvent: {
+            event_type: 'ParamsPartial',
+            params: '{"file_path":"src/secret.ts","content":"very sensitive content"}',
+          },
+        },
+        strategy: 'accumulate',
+        sourceCount: 12,
+        timestamp: 1000,
+      },
+    ];
+
+    const payloadText = JSON.stringify(getBatchedEventsLogPayload(events));
+
+    expect(payloadText).toContain('very sensitive content');
+    expect(payloadText).toContain('src/secret.ts');
+  });
+
+  it('keeps batch diagnostics without logging full event payloads', () => {
+    setIncludeSensitiveDiagnostics(false);
+    const events: BatchedEvent[] = [
+      {
+        key: 'subagent:tool:params:session:call:tool',
+        payload: {
+          toolEvent: {
+            event_type: 'ParamsPartial',
+            params: '{"file_path":"src/secret.ts","content":"very sensitive content"}',
+          },
+        },
+        strategy: 'accumulate',
+        sourceCount: 12,
+        timestamp: 1000,
+      },
+    ];
+
+    const summary = summarizeBatchedEventsForLog(events);
+    const summaryText = JSON.stringify(summary);
+
+    expect(summary.rawEventCount).toBe(12);
+    expect(summary.mergedEventCount).toBe(1);
+    expect(summary.events[0]).toEqual({
+      key: 'subagent:tool:params:session:call:tool',
+      strategy: 'accumulate',
+      sourceCount: 12,
+      timestamp: 1000,
+      eventType: 'ParamsPartial',
+      toolName: undefined,
+      paramsLength: 64,
+    });
+    expect(summaryText).not.toContain('very sensitive content');
+    expect(summaryText).not.toContain('src/secret.ts');
+  });
+});

--- a/src/web-ui/src/flow_chat/services/EventBatcher.ts
+++ b/src/web-ui/src/flow_chat/services/EventBatcher.ts
@@ -9,7 +9,7 @@
  * - Supports different key generation strategies for normal and subagent events
  */
 
-import { createLogger } from '@/shared/utils/logger';
+import { areSensitiveDiagnosticsEnabled, createLogger } from '@/shared/utils/logger';
 import { elapsedMs, nowMs } from '@/shared/utils/timing';
 
 const log = createLogger('EventBatcher');
@@ -27,6 +27,70 @@ export interface BatchedEvent<T = any> {
 
 export interface EventBatcherOptions {
   onFlush: (events: Array<{ key: string; payload: any }>) => void;
+}
+
+export interface BatchedEventLogSummary {
+  rawEventCount: number;
+  mergedEventCount: number;
+  events: Array<{
+    key: string;
+    strategy: MergeStrategy;
+    sourceCount: number;
+    timestamp: number;
+    eventType?: string;
+    toolName?: string;
+    paramsLength?: number;
+  }>;
+}
+
+export interface SensitiveBatchedEventLogPayload {
+  rawEventCount: number;
+  mergedEventCount: number;
+  mergedEvents: BatchedEvent[];
+}
+
+export function summarizeBatchedEventsForLog(bufferedEvents: BatchedEvent[]): BatchedEventLogSummary {
+  return {
+    rawEventCount: bufferedEvents.reduce((count, event) => count + event.sourceCount, 0),
+    mergedEventCount: bufferedEvents.length,
+    events: bufferedEvents.map(({ key, payload, strategy, sourceCount, timestamp }) => {
+      const toolEvent = payload?.toolEvent;
+      const params = toolEvent?.params;
+
+      return {
+        key,
+        strategy,
+        sourceCount,
+        timestamp,
+        eventType: toolEvent?.event_type,
+        toolName: toolEvent?.tool_name,
+        paramsLength: typeof params === 'string' ? params.length : undefined,
+      };
+    }),
+  };
+}
+
+export function getBatchedEventsLogPayload(
+  bufferedEvents: BatchedEvent[]
+): BatchedEventLogSummary | SensitiveBatchedEventLogPayload {
+  const rawEventCount = bufferedEvents.reduce((count, event) => count + event.sourceCount, 0);
+  const mergedEventCount = bufferedEvents.length;
+
+  if (!areSensitiveDiagnosticsEnabled()) {
+    return summarizeBatchedEventsForLog(bufferedEvents);
+  }
+
+  return {
+    rawEventCount,
+    mergedEventCount,
+    mergedEvents: bufferedEvents.map(({ key, payload, strategy, sourceCount, timestamp }) => ({
+      key,
+      payload,
+      strategy,
+      sourceCount,
+      timestamp,
+    })),
+  };
 }
 
 export class EventBatcher {
@@ -61,8 +125,6 @@ export class EventBatcher {
         existing.timestamp = Date.now();
       }
       existing.sourceCount += 1;
-
-      log.trace('Merged event', { key, strategy });
     } else {
       this.buffer.set(key, {
         key,
@@ -72,8 +134,6 @@ export class EventBatcher {
         sourceCount: 1,
         timestamp: Date.now()
       });
-
-      log.trace('Added new event', { key, strategy });
     }
 
     this.scheduleFlush();
@@ -112,25 +172,15 @@ export class EventBatcher {
 
     const startTime = nowMs();
     const bufferedEvents = Array.from(this.buffer.values());
-    const mergedEventCount = bufferedEvents.length;
-    const rawEventCount = bufferedEvents.reduce((count, event) => count + event.sourceCount, 0);
+    const logPayload = getBatchedEventsLogPayload(bufferedEvents);
+    const { rawEventCount, mergedEventCount } = logPayload;
 
     const events = bufferedEvents.map(({ key, payload }) => ({
       key,
       payload
     }));
 
-    log.trace('Flushing batched events', {
-      rawEventCount,
-      mergedEventCount,
-      mergedEvents: bufferedEvents.map(({ key, payload, strategy, sourceCount, timestamp }) => ({
-        key,
-        strategy,
-        sourceCount,
-        timestamp,
-        payload
-      }))
-    });
+    log.trace('Flushing batched events', logPayload);
 
     this.buffer = new Map();
     this.onFlush(events);

--- a/src/web-ui/src/infrastructure/config/components/BasicsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/BasicsConfig.tsx
@@ -225,6 +225,7 @@ function BasicsAutoUpdateSection() {
 function BasicsLoggingSection() {
   const { t } = useTranslation('settings/basics');
   const [configLevel, setConfigLevel] = useState<BackendLogLevel>('info');
+  const [includeSensitiveDiagnostics, setIncludeSensitiveDiagnostics] = useState(true);
   const [runtimeInfo, setRuntimeInfo] = useState<RuntimeLoggingInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -252,12 +253,14 @@ function BasicsLoggingSection() {
     try {
       setLoading(true);
 
-      const [savedLevel, info] = await Promise.all([
+      const [savedLevel, savedIncludeSensitiveDiagnostics, info] = await Promise.all([
         configManager.getConfig<BackendLogLevel>('app.logging.level'),
+        configManager.getConfig<boolean>('app.logging.include_sensitive_diagnostics'),
         configAPI.getRuntimeLoggingInfo(),
       ]);
 
       setConfigLevel(savedLevel || info.effectiveLevel || 'info');
+      setIncludeSensitiveDiagnostics(savedIncludeSensitiveDiagnostics ?? true);
       setRuntimeInfo(info);
     } catch (error) {
       log.error('Failed to load logging config', error);
@@ -294,6 +297,27 @@ function BasicsLoggingSection() {
       }
     },
     [configLevel, showMessage, t]
+  );
+
+  const handleSensitiveDiagnosticsChange = useCallback(
+    async (checked: boolean) => {
+      const previousValue = includeSensitiveDiagnostics;
+      setIncludeSensitiveDiagnostics(checked);
+      setSaving(true);
+
+      try {
+        await configManager.setConfig('app.logging.include_sensitive_diagnostics', checked);
+        configManager.clearCache();
+        showMessage('success', t('logging.messages.sensitiveDiagnosticsUpdated'));
+      } catch (error) {
+        setIncludeSensitiveDiagnostics(previousValue);
+        log.error('Failed to update sensitive diagnostics logging preference', { checked, error });
+        showMessage('error', t('logging.messages.saveFailed'));
+      } finally {
+        setSaving(false);
+      }
+    },
+    [includeSensitiveDiagnostics, showMessage, t]
   );
 
   const handleOpenFolder = useCallback(async () => {
@@ -340,6 +364,19 @@ function BasicsLoggingSection() {
                 disabled={saving}
               />
             </div>
+          </ConfigPageRow>
+          <ConfigPageRow
+            label={t('logging.sensitiveDiagnostics.label')}
+            description={t('logging.sensitiveDiagnostics.description')}
+            align="center"
+          >
+            <Switch
+              checked={includeSensitiveDiagnostics}
+              onChange={(e) => {
+                void handleSensitiveDiagnosticsChange(e.target.checked);
+              }}
+              disabled={saving}
+            />
           </ConfigPageRow>
           <ConfigPageRow
             label={t('logging.sections.path')}

--- a/src/web-ui/src/infrastructure/config/services/FrontendLogLevelSync.ts
+++ b/src/web-ui/src/infrastructure/config/services/FrontendLogLevelSync.ts
@@ -1,10 +1,16 @@
 import { configAPI } from '@/infrastructure/api';
-import { LogLevel, createLogger, logger } from '@/shared/utils/logger';
+import {
+  LogLevel,
+  createLogger,
+  logger,
+  setIncludeSensitiveDiagnostics,
+} from '@/shared/utils/logger';
 import type { BackendLogLevel } from '../types';
 import { configManager } from './ConfigManager';
 
 const log = createLogger('FrontendLogLevelSync');
 const LOGGING_LEVEL_PATH = 'app.logging.level';
+const LOGGING_INCLUDE_SENSITIVE_PATH = 'app.logging.include_sensitive_diagnostics';
 
 let initialized = false;
 
@@ -86,6 +92,11 @@ async function resolveInitialLogLevel(): Promise<string | undefined> {
   return undefined;
 }
 
+async function resolveInitialSensitiveDiagnosticsPreference(): Promise<boolean> {
+  const value = await configManager.getConfig<boolean>(LOGGING_INCLUDE_SENSITIVE_PATH);
+  return value ?? true;
+}
+
 export async function initializeFrontendLogLevelSync(): Promise<void> {
   if (initialized) {
     return;
@@ -94,16 +105,23 @@ export async function initializeFrontendLogLevelSync(): Promise<void> {
   initialized = true;
 
   configManager.onConfigChange((path, _oldValue, newValue) => {
-    if (path !== LOGGING_LEVEL_PATH) {
+    if (path === LOGGING_LEVEL_PATH) {
+      applyFrontendLogLevel(typeof newValue === 'string' ? newValue : undefined, 'config_change');
       return;
     }
 
-    applyFrontendLogLevel(typeof newValue === 'string' ? newValue : undefined, 'config_change');
+    if (path === LOGGING_INCLUDE_SENSITIVE_PATH) {
+      setIncludeSensitiveDiagnostics(typeof newValue === 'boolean' ? newValue : true);
+    }
   });
 
   try {
-    const initialLevel = await resolveInitialLogLevel();
+    const [initialLevel, includeSensitiveDiagnostics] = await Promise.all([
+      resolveInitialLogLevel(),
+      resolveInitialSensitiveDiagnosticsPreference(),
+    ]);
     applyFrontendLogLevel(initialLevel, 'startup');
+    setIncludeSensitiveDiagnostics(includeSensitiveDiagnostics);
   } catch (error) {
     log.error('Failed to initialize frontend log level sync', error);
   }

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -31,6 +31,7 @@ export type BackendLogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'o
 
 export interface AppLoggingConfig {
   level: BackendLogLevel;
+  include_sensitive_diagnostics: boolean;
 }
 
 // Reserved; legacy `default_mode` in saved JSON is ignored by the app.

--- a/src/web-ui/src/locales/en-US/settings/basics.json
+++ b/src/web-ui/src/locales/en-US/settings/basics.json
@@ -110,6 +110,10 @@
     "level": {
       "description": "Controls log verbosity in real time. Changes apply immediately."
     },
+    "sensitiveDiagnostics": {
+      "label": "Include sensitive diagnostic data",
+      "description": "When enabled, local logs may include prompts, model request and response payloads, tool arguments, file paths, and webview event payloads for troubleshooting. BitFun does not upload these log files automatically."
+    },
     "path": {
       "description": "Directory where log files for this run are written."
     },
@@ -131,6 +135,7 @@
       "loadFailed": "Failed to load logging configuration",
       "saveFailed": "Failed to save logging level",
       "levelUpdated": "Logging level updated",
+      "sensitiveDiagnosticsUpdated": "Sensitive diagnostic logging preference updated",
       "refreshed": "Runtime status refreshed",
       "openedFolder": "Log folder opened",
       "openFailed": "Failed to open log folder",

--- a/src/web-ui/src/locales/zh-CN/settings/basics.json
+++ b/src/web-ui/src/locales/zh-CN/settings/basics.json
@@ -110,6 +110,10 @@
     "level": {
       "description": "实时控制日志输出级别，修改后立即生效。"
     },
+    "sensitiveDiagnostics": {
+      "label": "包含敏感调试信息",
+      "description": "开启后，本地日志可能包含用户 Prompt、模型请求和响应 payload、工具参数、文件路径以及 Webview 事件 payload，用于问题排查。BitFun 不会自动上传这些日志文件。"
+    },
     "path": {
       "description": "本次启动写入日志文件所在的目录。"
     },
@@ -131,6 +135,7 @@
       "loadFailed": "加载日志配置失败",
       "saveFailed": "保存日志级别失败",
       "levelUpdated": "日志级别已更新",
+      "sensitiveDiagnosticsUpdated": "敏感调试信息日志偏好已更新",
       "refreshed": "运行时状态已刷新",
       "openedFolder": "日志文件夹已打开",
       "openFailed": "打开日志文件夹失败",

--- a/src/web-ui/src/locales/zh-TW/settings/basics.json
+++ b/src/web-ui/src/locales/zh-TW/settings/basics.json
@@ -96,6 +96,10 @@
     "level": {
       "description": "實時控制日誌輸出級別，修改後立即生效。"
     },
+    "sensitiveDiagnostics": {
+      "label": "包含敏感除錯資訊",
+      "description": "開啟後，本機日誌可能包含使用者 Prompt、模型請求與回應 payload、工具參數、檔案路徑以及 Webview 事件 payload，用於問題排查。BitFun 不會自動上傳這些日誌檔案。"
+    },
     "path": {
       "description": "本次啟動寫入日誌文件所在的目錄。"
     },
@@ -117,6 +121,7 @@
       "loadFailed": "加載日誌配置失敗",
       "saveFailed": "保存日誌級別失敗",
       "levelUpdated": "日誌級別已更新",
+      "sensitiveDiagnosticsUpdated": "敏感除錯資訊日誌偏好已更新",
       "refreshed": "運行時狀態已刷新",
       "openedFolder": "日誌文件夾已打開",
       "openFailed": "打開日誌文件夾失敗",

--- a/src/web-ui/src/shared/utils/logger.ts
+++ b/src/web-ui/src/shared/utils/logger.ts
@@ -34,6 +34,15 @@ const isTauri = typeof window !== 'undefined' && '__TAURI__' in window;
 const isDev = import.meta.env?.DEV ?? process.env.NODE_ENV === 'development';
 
 const CONSOLE_FORWARD_INSTALLED = '__bitfun_console_forward_installed__';
+let includeSensitiveDiagnostics = true;
+
+export function setIncludeSensitiveDiagnostics(enabled: boolean): void {
+  includeSensitiveDiagnostics = enabled;
+}
+
+export function areSensitiveDiagnosticsEnabled(): boolean {
+  return includeSensitiveDiagnostics;
+}
 
 function formatConsoleArg(value: unknown): string {
   if (value === undefined) return 'undefined';


### PR DESCRIPTION
## Summary
- Add a shared backend diagnostics redaction module in `bitfun-services-core` with `redact_diagnostic_log_text` and `redact_diagnostic_log_text_with_report`.
- Redact sensitive prompt, payload, token, and path-like values line by line while preserving routing metadata, event/tool shape, line count, and a replacement count for large log text.
- Re-export the diagnostics facade through `bitfun_core::service` so backend callers can use one project-wide redaction implementation without adding a desktop API.

## Validation
- `cargo test -p bitfun-services-core`
- `cargo check --workspace`
- `cargo test --workspace`
