### PR TITLE
Refactor remote connect product surface contracts

### DIFF
--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -1687,7 +1687,7 @@ git diff -- package.json scripts/dev.cjs scripts/desktop-tauri-build.mjs scripts
 10. 进行中：PR 1 `services-integrations` runtime 收口，先处理 remote-SSH workspace registry / session mirror helper 和已迁移 file-watch 的 contract 复核；announcement 仅迁移无 config/content/remote fetch 依赖的 helper。
 11. 已完成：PR 2 MCP runtime 与 dynamic tools；已迁移 config service orchestration、server process / transport lifecycle、adapter、dynamic tool/resource/prompt provider，core 保留 ConfigService store adapter、OAuth data-dir 注入、BitFunError 映射、legacy facade 和 registry assembly。
 12. P2 后前置轨道：产品表面 contract-only 补强，可在 PR3 前或 PR3 第一组提交中处理；只允许 DTO/port、round-trip/no-op tests 和 boundary check，不实现 CLI/Desktop/Remote/ACP UI 或命令变更。
-13. 待执行：PR 3 remote-connect runtime。
+13. 已完成：PR 3 remote-connect runtime contract slice：产品表面 DTO 已以 contract-only 方式进入 `bitfun-core-types`；`bitfun-services-integrations` 新增 `remote-connect` feature，拥有 remote chat/image/tool/session wire DTO 与 relay/bot session/submission request builder；relay/bot 创建 session 已通过 `AgentSubmissionPort`。远程消息执行、image context、tracker event、cancel、terminal pre-warm 与 workspace/session restore 仍保留在 `bitfun-core` product runtime assembly，直到补齐 image/queue/event/cancellation port 后再迁移。
 14. 待执行：PR 4 agent tools + `tool-packs` owner 化。
 15. 待执行：PR 5 `product-domains` runtime + core facade finalization。
 16. 后续独立评估：`bitfun-core default = []` 或 per-product feature set。

--- a/scripts/check-core-boundaries.mjs
+++ b/scripts/check-core-boundaries.mjs
@@ -219,6 +219,7 @@ const dependencyProfileRules = [
       'anyhow',
       'async-trait',
       'base64',
+      'bitfun-runtime-ports',
       'bitfun-services-core',
       'chrono',
       'futures',
@@ -711,6 +712,39 @@ const forbiddenContentRules = [
       {
         regex: /\bregistration_matches_path\b/,
         message: 'core remote SSH workspace runtime must not own path-to-registration matching; use the integrations registry',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/core/src/service/remote_connect/remote_server.rs',
+    patterns: [
+      {
+        regex: /\bpub struct ImageAttachment\b/,
+        message: 'core remote-connect server must not redefine image attachment wire DTOs; use the integrations contract',
+      },
+      {
+        regex: /\bpub struct ChatImageAttachment\b/,
+        message: 'core remote-connect server must not redefine chat image wire DTOs; use the integrations contract',
+      },
+      {
+        regex: /\bpub struct ChatMessage\b/,
+        message: 'core remote-connect server must not redefine chat message wire DTOs; use the integrations contract',
+      },
+      {
+        regex: /\bpub struct ChatMessageItem\b/,
+        message: 'core remote-connect server must not redefine chat message item DTOs; use the integrations contract',
+      },
+      {
+        regex: /\bpub struct RemoteToolStatus\b/,
+        message: 'core remote-connect server must not redefine remote tool status DTOs; use the integrations contract',
+      },
+      {
+        regex: /\bpub struct ActiveTurnSnapshot\b/,
+        message: 'core remote-connect server must not redefine active turn snapshot DTOs; use the integrations contract',
+      },
+      {
+        regex: /\bpub struct SessionInfo\b/,
+        message: 'core remote-connect server must not redefine session info DTOs; use the integrations contract',
       },
     ],
   },
@@ -1286,6 +1320,30 @@ function runManifestParserSelfTest() {
   for (const dep of ['futures', 'reqwest', 'sse-stream']) {
     if (!servicesIntegrationsProfile?.forbiddenNonOptionalDeps.includes(dep)) {
       throw new Error(`services-integrations default profile must forbid non-optional ${dep}`);
+    }
+  }
+
+  const remoteConnectRule = forbiddenContentRules.find(
+    (rule) => rule.path === 'src/crates/core/src/service/remote_connect/remote_server.rs',
+  );
+  if (!remoteConnectRule) {
+    throw new Error('missing remote-connect remote_server boundary rule');
+  }
+  const remoteConnectContracts = [
+    'ImageAttachment',
+    'ChatImageAttachment',
+    'ChatMessage',
+    'ChatMessageItem',
+    'RemoteToolStatus',
+    'ActiveTurnSnapshot',
+    'SessionInfo',
+  ];
+  const remoteConnectRuleText = remoteConnectRule.patterns
+    .map((pattern) => pattern.regex.source)
+    .join('\n');
+  for (const contract of remoteConnectContracts) {
+    if (!remoteConnectRuleText.includes(contract)) {
+      throw new Error(`remote-connect boundary rule must forbid contract: ${contract}`);
     }
   }
 

--- a/src/crates/core-types/src/lib.rs
+++ b/src/crates/core-types/src/lib.rs
@@ -5,8 +5,13 @@
 
 pub mod errors;
 pub mod session;
+pub mod surface;
 pub mod tool_image_attachment;
 
 pub use errors::{AiErrorDetail, ErrorCategory};
 pub use session::SessionKind;
+pub use surface::{
+    ApprovalSource, CapabilityRequest, CapabilityRequestKind, PermissionDecision, PermissionScope,
+    RuntimeArtifactKind, RuntimeArtifactRef, SurfaceKind, ThreadEnvironment, ThreadEnvironmentKind,
+};
 pub use tool_image_attachment::ToolImageAttachment;

--- a/src/crates/core-types/src/surface.rs
+++ b/src/crates/core-types/src/surface.rs
@@ -1,0 +1,140 @@
+//! Product-surface capability contract DTOs.
+//!
+//! These types are observational facts shared by product surfaces. They must
+//! not encode CLI, desktop, remote, ACP, or server presentation behavior.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub type SurfaceMetadata = BTreeMap<String, String>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SurfaceKind {
+    Desktop,
+    Cli,
+    Remote,
+    Acp,
+    Server,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThreadEnvironmentKind {
+    Local,
+    Worktree,
+    RemoteSsh,
+    RemoteConnect,
+    CloudLike,
+    Acp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadEnvironment {
+    pub kind: ThreadEnvironmentKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_connection_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: SurfaceMetadata,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeArtifactKind {
+    Diff,
+    TerminalSnapshot,
+    Preview,
+    Usage,
+    ReviewReport,
+    MiniApp,
+    McpManifest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeArtifactRef {
+    pub id: String,
+    pub kind: RuntimeArtifactKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub producer_surface: Option<SurfaceKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_artifact_id: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: SurfaceMetadata,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionDecision {
+    ApproveOnce,
+    ApproveSession,
+    Always,
+    Deny,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionScope {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_prefix: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path_pattern: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub surface: Option<SurfaceKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApprovalSource {
+    pub surface: SurfaceKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subagent_thread_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityRequestKind {
+    Diff,
+    Review,
+    Status,
+    TerminalSnapshot,
+    EnvironmentOpen,
+    PermissionDecision,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CapabilityRequest {
+    pub request_id: String,
+    pub kind: CapabilityRequestKind,
+    pub source: ApprovalSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<RuntimeArtifactRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permission: Option<PermissionScope>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision: Option<PermissionDecision>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: SurfaceMetadata,
+}

--- a/src/crates/core-types/tests/surface_contracts.rs
+++ b/src/crates/core-types/tests/surface_contracts.rs
@@ -1,0 +1,77 @@
+use bitfun_core_types::surface::{
+    ApprovalSource, CapabilityRequest, CapabilityRequestKind, PermissionDecision, PermissionScope,
+    RuntimeArtifactKind, RuntimeArtifactRef, SurfaceKind, ThreadEnvironment, ThreadEnvironmentKind,
+};
+use std::collections::BTreeMap;
+
+#[test]
+fn surface_contract_serializes_observational_runtime_facts() {
+    let artifact = RuntimeArtifactRef {
+        id: "artifact-1".to_string(),
+        kind: RuntimeArtifactKind::TerminalSnapshot,
+        session_id: Some("session-1".to_string()),
+        thread_id: Some("thread-1".to_string()),
+        turn_id: Some("turn-1".to_string()),
+        producer_surface: Some(SurfaceKind::Cli),
+        parent_artifact_id: None,
+        metadata: BTreeMap::new(),
+    };
+
+    let json = serde_json::to_value(&artifact).expect("serialize artifact");
+
+    assert_eq!(json["kind"], "terminal_snapshot");
+    assert_eq!(json["sessionId"], "session-1");
+    assert_eq!(json["producerSurface"], "cli");
+    assert!(json.get("parentArtifactId").is_none());
+}
+
+#[test]
+fn permission_and_capability_contracts_keep_source_identity() {
+    let request = CapabilityRequest {
+        request_id: "cap-1".to_string(),
+        kind: CapabilityRequestKind::PermissionDecision,
+        source: ApprovalSource {
+            surface: SurfaceKind::Remote,
+            thread_id: Some("thread-remote".to_string()),
+            turn_id: Some("turn-remote".to_string()),
+            subagent_thread_id: Some("child-1".to_string()),
+        },
+        artifact: None,
+        permission: Some(PermissionScope {
+            tool_id: Some("bash".to_string()),
+            command_prefix: Some("git status".to_string()),
+            path_pattern: Some("src/**".to_string()),
+            agent_role: Some("reviewer".to_string()),
+            surface: Some(SurfaceKind::Remote),
+            thread_id: Some("thread-remote".to_string()),
+        }),
+        decision: Some(PermissionDecision::ApproveSession),
+        metadata: BTreeMap::new(),
+    };
+
+    let json = serde_json::to_value(&request).expect("serialize request");
+
+    assert_eq!(json["kind"], "permission_decision");
+    assert_eq!(json["source"]["surface"], "remote");
+    assert_eq!(json["source"]["subagentThreadId"], "child-1");
+    assert_eq!(json["permission"]["commandPrefix"], "git status");
+    assert_eq!(json["decision"], "approve_session");
+}
+
+#[test]
+fn thread_environment_contract_does_not_require_surface_specific_fields() {
+    let env = ThreadEnvironment {
+        kind: ThreadEnvironmentKind::RemoteConnect,
+        workspace_path: None,
+        remote_connection_id: Some("paired-phone".to_string()),
+        label: None,
+        metadata: BTreeMap::new(),
+    };
+
+    let json = serde_json::to_value(&env).expect("serialize environment");
+
+    assert_eq!(json["kind"], "remote_connect");
+    assert_eq!(json["remoteConnectionId"], "paired-phone");
+    assert!(json.get("workspacePath").is_none());
+    assert!(json.get("label").is_none());
+}

--- a/src/crates/core/src/service/remote_connect/bot/command_router.rs
+++ b/src/crates/core/src/service/remote_connect/bot/command_router.rs
@@ -1379,8 +1379,11 @@ async fn guarded_new(
 
 async fn create_session(state: &mut BotChatState, agent_type: &str) -> HandleResult {
     use crate::agentic::coordination::get_global_coordinator;
-    use crate::agentic::core::SessionConfig;
     use crate::service::workspace::get_global_workspace_service;
+    use bitfun_runtime_ports::AgentSubmissionPort;
+    use bitfun_services_integrations::remote_connect::{
+        build_remote_session_create_request, RemoteConnectSubmissionSource,
+    };
 
     let language = current_bot_language().await;
     let s = strings_for(language);
@@ -1477,19 +1480,14 @@ async fn create_session(state: &mut BotChatState, agent_type: &str) -> HandleRes
         return result_from_menu(state, view);
     };
 
-    match coordinator
-        .create_session_with_workspace(
-            None,
-            session_name.to_string(),
-            agent_type.to_string(),
-            SessionConfig {
-                workspace_path: Some(workspace_path.clone()),
-                ..Default::default()
-            },
-            workspace_path.clone(),
-        )
-        .await
-    {
+    let request = build_remote_session_create_request(
+        session_name,
+        agent_type,
+        Some(workspace_path.clone()),
+        RemoteConnectSubmissionSource::Bot,
+    );
+    let submission_port: &dyn AgentSubmissionPort = coordinator.as_ref();
+    match submission_port.create_session(request).await {
         Ok(session) => {
             state.current_session_id = Some(session.session_id.clone());
             let body = format!(
@@ -1505,7 +1503,7 @@ async fn create_session(state: &mut BotChatState, agent_type: &str) -> HandleRes
         }
         Err(e) => result_from_menu(
             state,
-            MenuView::plain(format!("{}{e}", s.session_create_failed_prefix)),
+            MenuView::plain(format!("{}{}", s.session_create_failed_prefix, e.message)),
         ),
     }
 }
@@ -1979,12 +1977,15 @@ async fn submit_question_answers(
 /// to the safe default ("agentic"), so chat keeps working.
 async fn resolve_session_agent_type(session_id: &str) -> Option<String> {
     use crate::agentic::coordination::get_global_coordinator;
+    use bitfun_runtime_ports::AgentSubmissionPort;
 
     let coordinator = get_global_coordinator()?;
-    coordinator
-        .get_session_manager()
-        .get_session(session_id)
-        .map(|s| s.agent_type.clone())
+    let submission_port: &dyn AgentSubmissionPort = coordinator.as_ref();
+    submission_port
+        .resolve_session_agent_type(session_id)
+        .await
+        .ok()
+        .flatten()
 }
 
 async fn handle_chat(

--- a/src/crates/core/src/service/remote_connect/remote_server.rs
+++ b/src/crates/core/src/service/remote_connect/remote_server.rs
@@ -17,6 +17,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
 
 use super::encryption;
+pub use bitfun_services_integrations::remote_connect::{
+    ActiveTurnSnapshot, AssistantEntry, ChatImageAttachment, ChatMessage, ChatMessageItem,
+    ImageAttachment, RecentWorkspaceEntry, RemoteToolStatus, SessionInfo,
+};
 
 fn current_workspace_path() -> Option<std::path::PathBuf> {
     crate::service::workspace::get_global_workspace_service()
@@ -246,13 +250,6 @@ async fn load_remote_model_catalog(
         default_models: ai_config.default_models,
         session_model_id,
     })
-}
-
-/// Image sent from mobile as a base64 data-URL.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ImageAttachment {
-    pub name: String,
-    pub data_url: String,
 }
 
 /// Commands that the mobile client can send to the desktop.
@@ -485,101 +482,6 @@ pub enum RemoteResponse {
     Error {
         message: String,
     },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SessionInfo {
-    pub session_id: String,
-    pub name: String,
-    pub agent_type: String,
-    pub created_at: String,
-    pub updated_at: String,
-    pub message_count: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub workspace_path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub workspace_name: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ChatImageAttachment {
-    pub name: String,
-    pub data_url: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ChatMessage {
-    pub id: String,
-    pub role: String,
-    pub content: String,
-    pub timestamp: String,
-    pub metadata: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tools: Option<Vec<RemoteToolStatus>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub thinking: Option<String>,
-    /// Ordered items preserving the interleaved display order from the desktop.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<Vec<ChatMessageItem>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub images: Option<Vec<ChatImageAttachment>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ChatMessageItem {
-    #[serde(rename = "type")]
-    pub item_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tool: Option<RemoteToolStatus>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub is_subagent: Option<bool>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RecentWorkspaceEntry {
-    pub path: String,
-    pub name: String,
-    pub last_opened: String,
-    /// `"normal"` | `"assistant"` | `"remote"`
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub workspace_kind: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AssistantEntry {
-    pub path: String,
-    pub name: String,
-    pub assistant_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ActiveTurnSnapshot {
-    pub turn_id: String,
-    pub status: String,
-    pub text: String,
-    pub thinking: String,
-    pub tools: Vec<RemoteToolStatus>,
-    pub round_index: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<Vec<ChatMessageItem>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RemoteToolStatus {
-    pub id: String,
-    pub name: String,
-    pub status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration_ms: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_ms: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub input_preview: Option<String>,
-    /// Full tool input for interactive tools (e.g. AskUserQuestion).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tool_input: Option<serde_json::Value>,
 }
 
 pub type EncryptedPayload = (String, String);
@@ -2485,7 +2387,11 @@ impl RemoteServer {
     // ── Session commands ────────────────────────────────────────────
 
     async fn handle_session_command(&self, cmd: &RemoteCommand) -> RemoteResponse {
-        use crate::agentic::{coordination::get_global_coordinator, core::SessionConfig};
+        use crate::agentic::coordination::get_global_coordinator;
+        use bitfun_runtime_ports::AgentSubmissionPort;
+        use bitfun_services_integrations::remote_connect::{
+            build_remote_session_create_request, RemoteConnectSubmissionSource,
+        };
 
         let coordinator = match get_global_coordinator() {
             Some(c) => c,
@@ -2640,26 +2546,18 @@ impl RemoteServer {
                     };
                 };
 
-                match coordinator
-                    .create_session_with_workspace(
-                        None,
-                        session_name.to_string(),
-                        agent.to_string(),
-                        SessionConfig {
-                            workspace_path: Some(binding_ws_str.clone()),
-                            ..Default::default()
-                        },
-                        binding_ws_str,
-                    )
-                    .await
-                {
-                    Ok(session) => {
-                        let session_id = session.session_id.clone();
-                        RemoteResponse::SessionCreated { session_id }
-                    }
-                    Err(e) => RemoteResponse::Error {
-                        message: e.to_string(),
+                let request = build_remote_session_create_request(
+                    session_name,
+                    agent,
+                    Some(binding_ws_str),
+                    RemoteConnectSubmissionSource::Relay,
+                );
+                let submission_port: &dyn AgentSubmissionPort = coordinator.as_ref();
+                match submission_port.create_session(request).await {
+                    Ok(session) => RemoteResponse::SessionCreated {
+                        session_id: session.session_id,
                     },
+                    Err(e) => RemoteResponse::Error { message: e.message },
                 }
             }
             RemoteCommand::GetModelCatalog { session_id } => {

--- a/src/crates/services-integrations/Cargo.toml
+++ b/src/crates/services-integrations/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 log = { workspace = true }
 bitfun-events = { path = "../events" }
+bitfun-runtime-ports = { path = "../runtime-ports", optional = true }
 aes-gcm = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
@@ -60,5 +61,13 @@ mcp = [
     "rmcp/transport-streamable-http-client-reqwest",
     "sse-stream",
 ]
+remote-connect = ["bitfun-runtime-ports"]
 remote-ssh = ["sha2", "tokio-util"]
-product-full = ["announcement", "file-watch", "git", "mcp", "remote-ssh"]
+product-full = [
+    "announcement",
+    "file-watch",
+    "git",
+    "mcp",
+    "remote-connect",
+    "remote-ssh",
+]

--- a/src/crates/services-integrations/src/lib.rs
+++ b/src/crates/services-integrations/src/lib.rs
@@ -15,6 +15,9 @@ pub mod git;
 #[cfg(feature = "mcp")]
 pub mod mcp;
 
+#[cfg(feature = "remote-connect")]
+pub mod remote_connect;
+
 #[cfg(feature = "remote-ssh")]
 pub mod remote_ssh;
 

--- a/src/crates/services-integrations/src/remote_connect.rs
+++ b/src/crates/services-integrations/src/remote_connect.rs
@@ -1,0 +1,168 @@
+//! Remote-connect integration contracts.
+//!
+//! This module owns stable remote-facing DTOs and runtime-port request
+//! construction. Network lifecycle, tracker state, and product assembly stay in
+//! `bitfun-core` until their ports are explicit.
+
+use bitfun_runtime_ports::{
+    AgentSessionCreateRequest, AgentSubmissionRequest, AgentSubmissionSource,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteConnectSubmissionSource {
+    Relay,
+    Bot,
+}
+
+impl RemoteConnectSubmissionSource {
+    pub const fn agent_submission_source(self) -> AgentSubmissionSource {
+        match self {
+            RemoteConnectSubmissionSource::Relay => AgentSubmissionSource::RemoteRelay,
+            RemoteConnectSubmissionSource::Bot => AgentSubmissionSource::Bot,
+        }
+    }
+
+    pub const fn metadata_source(self) -> &'static str {
+        match self {
+            RemoteConnectSubmissionSource::Relay => "remote_relay",
+            RemoteConnectSubmissionSource::Bot => "bot",
+        }
+    }
+}
+
+pub fn build_remote_session_create_request(
+    session_name: impl Into<String>,
+    agent_type: impl Into<String>,
+    workspace_path: Option<impl Into<String>>,
+    source: RemoteConnectSubmissionSource,
+) -> AgentSessionCreateRequest {
+    let mut metadata = serde_json::Map::new();
+    metadata.insert(
+        "source".to_string(),
+        serde_json::Value::String(source.metadata_source().to_string()),
+    );
+
+    AgentSessionCreateRequest {
+        session_name: session_name.into(),
+        agent_type: agent_type.into(),
+        workspace_path: workspace_path.map(Into::into),
+        metadata,
+    }
+}
+
+pub fn build_remote_submission_request(
+    session_id: impl Into<String>,
+    message: impl Into<String>,
+    turn_id: Option<String>,
+    source: RemoteConnectSubmissionSource,
+) -> AgentSubmissionRequest {
+    AgentSubmissionRequest {
+        session_id: session_id.into(),
+        message: message.into(),
+        turn_id,
+        source: Some(source.agent_submission_source()),
+        attachments: Vec::new(),
+        metadata: serde_json::Map::new(),
+    }
+}
+
+/// Image sent from a remote client as a base64 data URL.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImageAttachment {
+    pub name: String,
+    pub data_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionInfo {
+    pub session_id: String,
+    pub name: String,
+    pub agent_type: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub message_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChatImageAttachment {
+    pub name: String,
+    pub data_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub id: String,
+    pub role: String,
+    pub content: String,
+    pub timestamp: String,
+    pub metadata: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<RemoteToolStatus>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub items: Option<Vec<ChatMessageItem>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub images: Option<Vec<ChatImageAttachment>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChatMessageItem {
+    #[serde(rename = "type")]
+    pub item_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool: Option<RemoteToolStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_subagent: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecentWorkspaceEntry {
+    pub path: String,
+    pub name: String,
+    pub last_opened: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_kind: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssistantEntry {
+    pub path: String,
+    pub name: String,
+    pub assistant_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActiveTurnSnapshot {
+    pub turn_id: String,
+    pub status: String,
+    pub text: String,
+    pub thinking: String,
+    pub tools: Vec<RemoteToolStatus>,
+    pub round_index: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub items: Option<Vec<ChatMessageItem>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RemoteToolStatus {
+    pub id: String,
+    pub name: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_preview: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_input: Option<serde_json::Value>,
+}

--- a/src/crates/services-integrations/tests/remote_connect_contracts.rs
+++ b/src/crates/services-integrations/tests/remote_connect_contracts.rs
@@ -1,0 +1,96 @@
+#![cfg(feature = "remote-connect")]
+
+use bitfun_runtime_ports::AgentSubmissionSource;
+use bitfun_services_integrations::remote_connect::{
+    build_remote_session_create_request, build_remote_submission_request, ChatImageAttachment,
+    ChatMessage, ChatMessageItem, ImageAttachment, RemoteConnectSubmissionSource, RemoteToolStatus,
+};
+
+#[test]
+fn remote_connect_submission_contract_preserves_relay_source_and_turn_id() {
+    let request = build_remote_submission_request(
+        "session-1",
+        "hello from phone",
+        Some("turn-1".to_string()),
+        RemoteConnectSubmissionSource::Relay,
+    );
+
+    assert_eq!(request.session_id, "session-1");
+    assert_eq!(request.message, "hello from phone");
+    assert_eq!(request.turn_id.as_deref(), Some("turn-1"));
+    assert_eq!(request.source, Some(AgentSubmissionSource::RemoteRelay));
+    assert!(request.attachments.is_empty());
+}
+
+#[test]
+fn remote_connect_submission_contract_preserves_bot_source() {
+    let request = build_remote_submission_request(
+        "session-2",
+        "hello from bot",
+        None,
+        RemoteConnectSubmissionSource::Bot,
+    );
+
+    assert_eq!(request.source, Some(AgentSubmissionSource::Bot));
+    assert!(request.turn_id.is_none());
+}
+
+#[test]
+fn remote_connect_session_create_contract_preserves_workspace_binding() {
+    let request = build_remote_session_create_request(
+        "Remote Session",
+        "agentic",
+        Some("D:/workspace/project"),
+        RemoteConnectSubmissionSource::Relay,
+    );
+
+    assert_eq!(request.session_name, "Remote Session");
+    assert_eq!(request.agent_type, "agentic");
+    assert_eq!(
+        request.workspace_path.as_deref(),
+        Some("D:/workspace/project")
+    );
+    assert_eq!(request.metadata["source"], "remote_relay");
+}
+
+#[test]
+fn remote_connect_message_dtos_keep_current_wire_shape() {
+    let image = ImageAttachment {
+        name: "clip.png".to_string(),
+        data_url: "data:image/png;base64,abc".to_string(),
+    };
+    let chat = ChatMessage {
+        id: "msg-1".to_string(),
+        role: "assistant".to_string(),
+        content: "done".to_string(),
+        timestamp: "1".to_string(),
+        metadata: None,
+        tools: Some(vec![RemoteToolStatus {
+            id: "tool-1".to_string(),
+            name: "bash".to_string(),
+            status: "running".to_string(),
+            duration_ms: None,
+            start_ms: Some(42),
+            input_preview: Some("{\"cmd\":\"git status\"}".to_string()),
+            tool_input: None,
+        }]),
+        thinking: None,
+        items: Some(vec![ChatMessageItem {
+            item_type: "tool".to_string(),
+            content: None,
+            tool: None,
+            is_subagent: Some(false),
+        }]),
+        images: Some(vec![ChatImageAttachment {
+            name: image.name.clone(),
+            data_url: image.data_url.clone(),
+        }]),
+    };
+
+    let json = serde_json::to_value(chat).expect("serialize chat message");
+
+    assert_eq!(json["id"], "msg-1");
+    assert_eq!(json["tools"][0]["start_ms"], 42);
+    assert_eq!(json["items"][0]["type"], "tool");
+    assert_eq!(json["images"][0]["data_url"], "data:image/png;base64,abc");
+}


### PR DESCRIPTION
## Summary
- Add shared product surface DTOs in `bitfun-core-types` for surface identity, environment, permissions, and capability observations.
- Move remote-connect submission/session DTO contract ownership into `bitfun-services-integrations` behind the `remote-connect` feature while keeping existing `bitfun-core` public re-export paths intact.
- Route remote relay and bot session creation through `AgentSubmissionPort` request builders instead of assembling those request shapes directly in core.
- Extend the core boundary check and update the decomposition plan so this PR documents the current PR3 boundary and the remaining runtime-assembly work.

## Behavior and Boundary Guardrails
- Intended as structural refactor only: remote message execution, image context handling, tracker/cancel state, terminal prewarm, workspace restore, and bot/relay runtime assembly remain in `bitfun-core`.
- No new surface-specific behavior is enabled; the product surface DTOs are observational contracts for later adapter ownership work.
- Existing core import paths for remote-connect DTOs are preserved via re-exports to avoid downstream API drift.

## Verification
- `node scripts/check-core-boundaries.mjs`
- `cargo test -p bitfun-core-types --test surface_contracts`
- `cargo test -p bitfun-services-integrations --features product-full --test remote_connect_contracts`
- `cargo check --workspace` (passes with existing `bitfun-cli` unused `Read` warning)
- `cargo test -p bitfun-core remote_connect -- --nocapture`