### PR TITLE
fix(config): tolerate null mode config entries

### DIFF
--- a/src/crates/core/src/service/config/mode_config_canonicalizer.rs
+++ b/src/crates/core/src/service/config/mode_config_canonicalizer.rs
@@ -460,6 +460,7 @@ mod tests {
     use super::{
         canonicalize_mode_config, normalize_skill_override_lists, stored_mode_from_overrides,
     };
+    use serde_json::Value;
     use std::collections::HashSet;
 
     #[test]

--- a/src/crates/core/src/service/config/mode_config_canonicalizer.rs
+++ b/src/crates/core/src/service/config/mode_config_canonicalizer.rs
@@ -220,6 +220,9 @@ fn canonicalize_mode_config(
     let Some(raw_mode) = raw_mode else {
         return Ok(None);
     };
+    if raw_mode.is_null() {
+        return Ok(None);
+    }
 
     let mut stored: ModeConfig = serde_json::from_value(raw_mode.clone()).map_err(|error| {
         BitFunError::config(format!(
@@ -454,7 +457,9 @@ pub async fn canonicalize_mode_configs() -> BitFunResult<ModeConfigCanonicalizat
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_skill_override_lists, stored_mode_from_overrides};
+    use super::{
+        canonicalize_mode_config, normalize_skill_override_lists, stored_mode_from_overrides,
+    };
     use std::collections::HashSet;
 
     #[test]
@@ -495,5 +500,18 @@ mod tests {
             vec!["user::bitfun-system::pdf".to_string()]
         );
         assert!(stored.disabled_user_skills.is_empty());
+    }
+
+    #[test]
+    fn canonicalize_mode_config_treats_null_as_missing() {
+        let canonical = canonicalize_mode_config(
+            "Claw",
+            Some(&Value::Null),
+            &[],
+            &HashSet::new(),
+        )
+        .expect("null mode config should be ignored");
+
+        assert!(canonical.is_none());
     }
 }

--- a/src/crates/core/src/service/config/types.rs
+++ b/src/crates/core/src/service/config/types.rs
@@ -7,6 +7,18 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+fn deserialize_mode_configs<'de, D>(deserializer: D) -> Result<HashMap<String, ModeConfig>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = Option::<HashMap<String, Option<ModeConfig>>>::deserialize(deserializer)?;
+    Ok(raw
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(mode_id, config)| config.map(|config| (mode_id, config)))
+        .collect())
+}
+
 /// Web UI font preferences (settings → basics). Keys match `FontPreference` in the frontend (camelCase).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -516,7 +528,7 @@ pub struct AIConfig {
 
     /// Mode configuration.
     /// mode_id -> ModeConfig
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_mode_configs")]
     pub mode_configs: HashMap<String, ModeConfig>,
 
     /// SubAgent configuration (enable/disable state).
@@ -2006,6 +2018,39 @@ mod tests {
         .expect("config with subagent_max_concurrency should deserialize");
 
         assert_eq!(config.subagent_max_concurrency, 9);
+    }
+
+    #[test]
+    fn deserializes_mode_configs_with_null_entries() {
+        let config: AIConfig = serde_json::from_value(serde_json::json!({
+            "models": [],
+            "agent_models": {},
+            "func_agent_models": {},
+            "default_models": {},
+            "mode_configs": {
+                "Claw": null,
+                "Cowork": {
+                    "mode_id": "Cowork",
+                    "removed_tools": ["shell"]
+                }
+            },
+            "subagent_configs": {},
+            "proxy": {
+                "enabled": false,
+                "url": ""
+            }
+        }))
+        .expect("config with null mode config entries should deserialize");
+
+        assert!(!config.mode_configs.contains_key("Claw"));
+        assert_eq!(
+            config
+                .mode_configs
+                .get("Cowork")
+                .expect("non-null mode config should be retained")
+                .removed_tools,
+            vec!["shell".to_string()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- ignore `null` entries when deserializing `ai.mode_configs`
- treat `null` mode configs as missing during canonicalization
- add regression tests for both paths

## Problem
A persisted entry like `"Claw": null` in `mode_configs` can break config loading and startup.

## Testing
- not run (per request)