### PR TITLE
Improve Deep Review completion and companion routing

### DIFF
--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -15,11 +15,11 @@ import { syncAgentCompanionDesktopWindow } from '@/infrastructure/config/service
 import { isTauriRuntime } from '@/infrastructure/runtime';
 import { buildAgentCompanionActivity, subscribeAgentCompanionActivity } from '@/flow_chat/utils/agentCompanionActivity';
 import { emitAgentCompanionActivity } from '@/flow_chat/services/AgentCompanionActivityBridge';
-import { FlowChatStore } from '@/flow_chat/store/FlowChatStore';
 import { useWorkspaceContext } from '../infrastructure/contexts/WorkspaceContext';
 import SplashScreen from './components/SplashScreen/SplashScreen';
 import { useGlobalSceneShortcuts } from './hooks/useGlobalSceneShortcuts';
 import { useDebugInspector } from '@/infrastructure/debug/useDebugInspector';
+import { openAgentCompanionSession } from './services/openAgentCompanionSession';
 
 // Toolbar Mode
 import { ToolbarModeProvider } from '../flow_chat';
@@ -198,10 +198,7 @@ function App() {
           const sessionId = event.payload?.sessionId;
           if (!sessionId) return;
 
-          const flowChatStore = FlowChatStore.getInstance();
-          if (flowChatStore.getState().sessions.has(sessionId)) {
-            flowChatStore.switchSession(sessionId);
-          }
+          await openAgentCompanionSession(sessionId);
 
           try {
             const { invoke } = await import('@tauri-apps/api/core');

--- a/src/web-ui/src/app/services/openAgentCompanionSession.test.ts
+++ b/src/web-ui/src/app/services/openAgentCompanionSession.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { openAgentCompanionSession } from './openAgentCompanionSession';
+import type { Session } from '@/flow_chat/types/flow-chat';
+
+const mocks = vi.hoisted(() => ({
+  openBtwSessionInAuxPane: vi.fn(),
+  openMainSession: vi.fn(() => Promise.resolve()),
+  switchSession: vi.fn(),
+  sessions: new Map<string, Session>(),
+}));
+
+vi.mock('@/flow_chat/services/openBtwSession', () => ({
+  openBtwSessionInAuxPane: (...args: unknown[]) => mocks.openBtwSessionInAuxPane(...args),
+  openMainSession: (...args: unknown[]) => mocks.openMainSession(...args),
+}));
+
+vi.mock('@/flow_chat/store/FlowChatStore', () => ({
+  FlowChatStore: {
+    getInstance: () => ({
+      getState: () => ({
+        sessions: mocks.sessions,
+      }),
+      switchSession: (...args: unknown[]) => mocks.switchSession(...args),
+    }),
+  },
+}));
+
+function createSession(overrides: Partial<Session> = {}): Session {
+  return {
+    sessionId: 'session-1',
+    title: 'Session',
+    dialogTurns: [],
+    status: 'idle',
+    config: {},
+    createdAt: 1,
+    lastActiveAt: 1,
+    error: null,
+    ...overrides,
+  } as Session;
+}
+
+describe('openAgentCompanionSession', () => {
+  beforeEach(() => {
+    mocks.openBtwSessionInAuxPane.mockClear();
+    mocks.openMainSession.mockClear();
+    mocks.switchSession.mockClear();
+    mocks.sessions.clear();
+  });
+
+  it('opens deep review child sessions in the aux pane instead of switching to the child chat', async () => {
+    mocks.sessions.set('deep-review-child', createSession({
+      sessionId: 'deep-review-child',
+      sessionKind: 'deep_review',
+      parentSessionId: 'parent-session',
+      workspacePath: 'D:/workspace/project',
+    }));
+
+    const opened = await openAgentCompanionSession('deep-review-child');
+
+    expect(opened).toBe(true);
+    expect(mocks.openMainSession).toHaveBeenCalledWith('parent-session');
+    expect(mocks.openBtwSessionInAuxPane).toHaveBeenCalledWith({
+      childSessionId: 'deep-review-child',
+      parentSessionId: 'parent-session',
+      workspacePath: 'D:/workspace/project',
+    });
+    expect(mocks.switchSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps regular sessions on the main chat route', async () => {
+    mocks.sessions.set('session-1', createSession());
+
+    const opened = await openAgentCompanionSession('session-1');
+
+    expect(opened).toBe(true);
+    expect(mocks.switchSession).toHaveBeenCalledWith('session-1');
+    expect(mocks.openMainSession).not.toHaveBeenCalled();
+    expect(mocks.openBtwSessionInAuxPane).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/app/services/openAgentCompanionSession.ts
+++ b/src/web-ui/src/app/services/openAgentCompanionSession.ts
@@ -1,0 +1,27 @@
+import { FlowChatStore } from '@/flow_chat/store/FlowChatStore';
+import { openBtwSessionInAuxPane, openMainSession } from '@/flow_chat/services/openBtwSession';
+import { resolveSessionRelationship } from '@/flow_chat/utils/sessionMetadata';
+
+export async function openAgentCompanionSession(sessionId: string): Promise<boolean> {
+  const flowChatStore = FlowChatStore.getInstance();
+  const session = flowChatStore.getState().sessions.get(sessionId);
+  if (!session) {
+    return false;
+  }
+
+  const relationship = resolveSessionRelationship(session);
+  const parentSessionId = relationship.parentSessionId;
+
+  if (relationship.canOpenInAuxPane && parentSessionId) {
+    await openMainSession(parentSessionId);
+    openBtwSessionInAuxPane({
+      childSessionId: sessionId,
+      parentSessionId,
+      workspacePath: session.workspacePath,
+    });
+    return true;
+  }
+
+  flowChatStore.switchSession(sessionId);
+  return true;
+}

--- a/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.review-action.test.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.review-action.test.tsx
@@ -329,6 +329,27 @@ function createCancelledResumeDeepReview(): Session {
   } as Session;
 }
 
+function createCompletedResumeDeepReview(): Session {
+  const childSession = createReviewSession();
+  return {
+    ...childSession,
+    dialogTurns: [
+      createInterruptedDeepReviewWithoutResult().dialogTurns[0],
+      {
+        ...childSession.dialogTurns[0],
+        id: 'turn-2',
+        userMessage: {
+          id: 'user-2',
+          content: 'Continue interrupted Deep Review',
+          timestamp: 2,
+        },
+        startTime: 2,
+        timestamp: 2,
+      },
+    ],
+  } as Session;
+}
+
 function createCancelledFixDeepReview(): Session {
   const childSession = createReviewSession();
   return {
@@ -703,6 +724,51 @@ describe('BtwSessionPanel review action bar integration', () => {
       childSessionId: 'deep-review-child',
       phase: 'resume_running',
       minimized: true,
+    });
+  });
+
+  it('expands the action bar when a resumed Deep Review completes successfully', async () => {
+    flowChatState = {
+      ...flowChatState,
+      sessions: new Map([
+        ['deep-review-child', createCompletedResumeDeepReview()],
+        ['parent-session', flowChatState.sessions.get('parent-session')!],
+      ]),
+    } as FlowChatState;
+
+    const store = useReviewActionBarStore.getState();
+    store.showInterruptedActionBar({
+      childSessionId: 'deep-review-child',
+      parentSessionId: 'parent-session',
+      interruption: {
+        phase: 'review_interrupted',
+        childSessionId: 'deep-review-child',
+        parentSessionId: 'parent-session',
+        originalTarget: '/DeepReview review latest commit',
+        errorDetail: { category: 'unknown', rawMessage: 'previous execution failed' },
+        canResume: true,
+        recommendedActions: [],
+        reviewers: [],
+      },
+    });
+    store.setActiveAction('resume', { baselineTurnId: 'turn-1' });
+    store.updatePhase('resume_running');
+    store.minimize();
+
+    await act(async () => {
+      root.render(
+        <BtwSessionPanel
+          childSessionId="deep-review-child"
+          parentSessionId="parent-session"
+          workspacePath="D:/workspace/project"
+        />,
+      );
+    });
+
+    expect(useReviewActionBarStore.getState()).toMatchObject({
+      childSessionId: 'deep-review-child',
+      phase: 'review_completed',
+      minimized: false,
     });
   });
 

--- a/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx
@@ -580,7 +580,6 @@ export const BtwSessionPanel: React.FC<BtwSessionPanelProps> = ({
           phase: 'review_completed',
           completedRemediationIds: currentActionState.completedRemediationIds,
         });
-        store.minimize(childSessionId);
       } else if (isComplete && currentActionState.phase === 'review_running') {
         store.showActionBar({
           childSessionId,

--- a/src/web-ui/src/flow_chat/services/openBtwSession.test.ts
+++ b/src/web-ui/src/flow_chat/services/openBtwSession.test.ts
@@ -4,9 +4,33 @@ import { openBtwSessionInAuxPane } from './openBtwSession';
 const mocks = vi.hoisted(() => ({
   createTab: vi.fn(),
   clearSessionUnreadCompletion: vi.fn(),
+  findTabByMetadata: vi.fn(),
+  switchToTab: vi.fn(),
+  closeTab: vi.fn(),
 }));
 
 let animationFrameCallbacks: FrameRequestCallback[] = [];
+
+const stubWindowForPanelExpansion = (rightPanelCollapsed: boolean) => {
+  const dispatchEvent = vi.fn();
+  class TestCustomEvent {
+    readonly type: string;
+    readonly detail?: unknown;
+
+    constructor(type: string, init?: { detail?: unknown }) {
+      this.type = type;
+      this.detail = init?.detail;
+    }
+  }
+
+  vi.stubGlobal('window', {
+    CustomEvent: TestCustomEvent,
+    dispatchEvent,
+    __BITFUN_LAYOUT_STATE__: { rightPanelCollapsed },
+  });
+
+  return dispatchEvent;
+};
 
 vi.mock('@/infrastructure/i18n', () => ({
   i18nService: {
@@ -39,8 +63,9 @@ vi.mock('@/app/components/panels/content-canvas/stores', () => ({
       primaryGroup: { activeTabId: null, tabs: [] },
       secondaryGroup: { activeTabId: null, tabs: [] },
       tertiaryGroup: { activeTabId: null, tabs: [] },
-      findTabByMetadata: vi.fn(),
-      closeTab: vi.fn(),
+      findTabByMetadata: (...args: unknown[]) => mocks.findTabByMetadata(...args),
+      switchToTab: (...args: unknown[]) => mocks.switchToTab(...args),
+      closeTab: (...args: unknown[]) => mocks.closeTab(...args),
     }),
   },
 }));
@@ -72,6 +97,9 @@ describe('openBtwSessionInAuxPane', () => {
     animationFrameCallbacks = [];
     mocks.createTab.mockClear();
     mocks.clearSessionUnreadCompletion.mockClear();
+    mocks.findTabByMetadata.mockReset();
+    mocks.switchToTab.mockClear();
+    mocks.closeTab.mockClear();
     vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
       animationFrameCallbacks.push(callback);
       return animationFrameCallbacks.length;
@@ -109,5 +137,48 @@ describe('openBtwSessionInAuxPane', () => {
 
     animationFrameCallbacks.shift()?.(16);
     expect(mocks.clearSessionUnreadCompletion).toHaveBeenCalledWith('review-child');
+  });
+
+  it('switches to an existing aux pane tab without expanding the right panel again', () => {
+    const dispatchEvent = stubWindowForPanelExpansion(false);
+    mocks.findTabByMetadata.mockReturnValue({
+      tab: { id: 'existing-review-tab' },
+      groupId: 'secondary',
+    });
+
+    openBtwSessionInAuxPane({
+      childSessionId: 'review-child',
+      parentSessionId: 'parent-session',
+      workspacePath: 'D:\\workspace\\repo',
+    });
+
+    expect(mocks.findTabByMetadata).toHaveBeenCalledWith({
+      duplicateCheckKey: 'btw-session-review-child',
+    });
+    expect(mocks.switchToTab).toHaveBeenCalledWith('existing-review-tab', 'secondary');
+    expect(mocks.createTab).not.toHaveBeenCalled();
+    expect(dispatchEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'expand-right-panel' }),
+    );
+  });
+
+  it('expands the right panel before switching to an existing aux pane tab when collapsed', () => {
+    const dispatchEvent = stubWindowForPanelExpansion(true);
+    mocks.findTabByMetadata.mockReturnValue({
+      tab: { id: 'existing-review-tab' },
+      groupId: 'secondary',
+    });
+
+    openBtwSessionInAuxPane({
+      childSessionId: 'review-child',
+      parentSessionId: 'parent-session',
+      workspacePath: 'D:\\workspace\\repo',
+    });
+
+    expect(mocks.switchToTab).toHaveBeenCalledWith('existing-review-tab', 'secondary');
+    expect(mocks.createTab).not.toHaveBeenCalled();
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'expand-right-panel' }),
+    );
   });
 });

--- a/src/web-ui/src/flow_chat/services/openBtwSession.ts
+++ b/src/web-ui/src/flow_chat/services/openBtwSession.ts
@@ -57,6 +57,26 @@ const clearSessionUnreadCompletionAfterRender = (sessionId: string): void => {
 export const isBtwSessionPanelContent = (content: PanelContent | null | undefined): boolean =>
   content?.type === BTW_SESSION_PANEL_TYPE;
 
+const isRightPanelCollapsed = (): boolean => {
+  try {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    const layoutState = (window as unknown as {
+      __BITFUN_LAYOUT_STATE__?: { rightPanelCollapsed?: boolean };
+    }).__BITFUN_LAYOUT_STATE__;
+    return layoutState?.rightPanelCollapsed ?? false;
+  } catch {
+    return false;
+  }
+};
+
+const requestRightPanelExpansion = (): void => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new window.CustomEvent('expand-right-panel'));
+  }
+};
+
 export const buildBtwSessionPanelContent = (
   childSessionId: string,
   parentSessionId: string,
@@ -140,8 +160,22 @@ export function openBtwSessionInAuxPane(params: {
     params.workspacePath
   );
 
-  if (params.expand !== false && typeof window !== 'undefined') {
-    window.dispatchEvent(new window.CustomEvent('expand-right-panel'));
+  const duplicateCheckKey = content.metadata?.duplicateCheckKey;
+  const canvasStore = useAgentCanvasStore.getState();
+  if (duplicateCheckKey) {
+    const existing = canvasStore.findTabByMetadata({ duplicateCheckKey });
+    if (existing) {
+      if (params.expand !== false && isRightPanelCollapsed()) {
+        requestRightPanelExpansion();
+      }
+      canvasStore.switchToTab(existing.tab.id, existing.groupId);
+      clearSessionUnreadCompletionAfterRender(params.childSessionId);
+      return;
+    }
+  }
+
+  if (params.expand !== false) {
+    requestRightPanelExpansion();
   }
 
   createTab({
@@ -150,7 +184,7 @@ export function openBtwSessionInAuxPane(params: {
     data: content.data,
     metadata: content.metadata,
     checkDuplicate: true,
-    duplicateCheckKey: content.metadata?.duplicateCheckKey,
+    duplicateCheckKey,
     replaceExisting: false,
     mode: 'agent',
   });


### PR DESCRIPTION
## Summary
- Keep the Deep Review floating action bar expanded when a resumed review completes successfully.
- Route Agent Companion review-session notifications through the parent session and aux pane so Deep Review opens in the expected side panel.
- Reuse an existing Deep Review aux tab without forcing the right panel width back to the default.

## Verification
- `git diff --check gcwing/main..HEAD`
- `pnpm --dir src/web-ui exec vitest run src/flow_chat/services/openBtwSession.test.ts src/app/services/openAgentCompanionSession.test.ts src/flow_chat/components/btw/BtwSessionPanel.review-action.test.tsx`
- `pnpm run lint:web`
- `pnpm run type-check:web`