### PR TITLE
refactor(core): move tool registry contracts into agent-tools

### DIFF
--- a/AGENTS-CN.md
+++ b/AGENTS-CN.md
@@ -115,6 +115,18 @@ await api.invoke('your_command', { request: { ... } });
 [`docs/architecture/core-decomposition.md`](docs/architecture/core-decomposition.md)。
 该文档定义产品行为不变量、crate 归属目标、禁止依赖方向、feature 安全规则和里程碑验证门禁。
 
+### Tool 归属护栏
+
+- `src/crates/agent-tools` 拥有轻量 tool contract，以及 generic registry / dynamic-provider container。
+- `src/crates/core/src/agentic/tools/registry.rs` 只负责产品工具组装、`dyn Tool` 适配和 snapshot decoration。
+- `ToolUseContext` 与具体工具实现继续留在 core，直到有已评审的 port/provider 设计和等价测试。
+
+### DeepReview 护栏
+
+Deep Review / 代码审核团队横跨 core runtime 与 Web UI。target resolution 与
+manifest construction 保持在前端；policy validation、queue/retry state 和
+report enrichment 保持在 shared core。
+
 ### 后端链路
 
 大多数功能建议按这个顺序追踪：

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,15 @@ before editing. The guardrail document defines product-behavior invariants,
 crate ownership targets, forbidden dependency directions, feature safety rules,
 and milestone verification gates.
 
+### Tool ownership guardrails
+
+- `src/crates/agent-tools` owns lightweight tool contracts and the generic
+  registry / dynamic-provider container.
+- `src/crates/core/src/agentic/tools/registry.rs` owns product tool assembly,
+  `dyn Tool` adaptation, and snapshot decoration only.
+- Keep `ToolUseContext` and concrete tool implementations in core until a
+  reviewed port/provider design and equivalence tests exist.
+
 ### DeepReview guardrails
 
 Deep Review / Code Review Team work spans the core runtime and web UI. Keep

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -971,14 +971,15 @@ product-full = ["git", "mcp", "remote-ssh", "remote-connect", "announcement", "f
 - [x] 迁移 `mcp` 的 PR2 runtime 与 dynamic provider：config service orchestration、server process / transport lifecycle、resource/prompt adapter、catalog cache、list-changed/reconnect policy、dynamic descriptor / provider / result rendering 均归属 `bitfun-services-integrations`。
 - [x] `bitfun-core` 保留 core `ConfigService` store adapter、OAuth data-dir 注入、`BitFunError` 映射、旧路径 facade 和全局 tool registry 组装；tool registry owner 化不混入本 PR。
 - [x] 先迁移 `announcement` 的纯 types contract，scheduler / state store / content loader / remote fetch 仍保留在 core。
-- [ ] 最后迁移 `remote-connect`，通过 `AgentSubmissionPort`、`SessionTranscriptReader`、`EventSink` 解耦 agent runtime。
+- [x] 先完成 `remote-connect` contract slice：remote chat/image/tool/session wire DTO 与 relay/bot session/submission request builder 由 `bitfun-services-integrations` 拥有，relay/bot session 创建通过 `AgentSubmissionPort`。
+- [ ] 后续完整迁移 `remote-connect` runtime 时，再通过 `SessionTranscriptReader`、`EventSink`、`RemoteControlStatePort` 与 image/queue/event/cancellation port 解耦 agent runtime。
 - [x] 已迁移的集成能力保持 core 旧路径 re-export。
 - [x] 产品完整 runtime 通过 `services-integrations/product-full` 启用已迁移集成能力。
 
 **当前安全迁移状态（2026-05-13）：**
 
 - 已迁移到 `bitfun-services-integrations`：`service::file_watch`，通过 `file-watch` / `product-full` feature 启用，并保持 `core::service::file_watch` 旧路径。
-- `git` 已完成 DTO/params/graph/raw command output/text parser/arg builder、`GitError`、`GitService` runtime implementation 与 git utils 迁移；`bitfun-core::service::git::*` 仅保留 legacy facade re-export。`remote-ssh` 已迁移纯 contract/type、workspace path/identity helper 与 unresolved-session-key helper；SSH runtime manager / fs / terminal、password vault 与 PathManager-backed session mirror assembly 仍保留在 core。`mcp` 已迁移 tool-name / tool-info / protocol types / config location / server type-status、server config、cursor-format、JSON-RPC request builder、JSON config format/validation helper、config merge / remote authorization helper、OAuth credential vault / authorization bootstrap contract、remote auth error classifier、legacy remote header fallback helper、transport Authorization 归一化 helper、remote client capability helper、rmcp 到 BitFun protocol 的纯映射 helper、resource/prompt adapter、catalog cache、list-changed/reconnect policy、config service save-load orchestration、server process / local-remote transport lifecycle、dynamic tool descriptor / provider / result rendering helper，并用 owner crate contract test 锁定 wire shape、transport default、validation message、Cursor 兼容格式、config precedence / dedup 语义、OAuth vault 存储路径注入、NeedsAuth 分类、旧 env Authorization fallback、remote client capabilities、remote result metadata / structured content 映射、config load/save/delete contract、unsupported remote transport contract、context resource selection 和 dynamic manifest；`bitfun-core` 继续负责 core `ConfigService` store adapter、OAuth data-dir 注入、`BitFunError` 映射、legacy facade 和全局 tool registry 组装。`announcement` 仅迁移了纯 types contract，scheduler / state store / content loader / remote fetch 仍保留在 core；`remote-connect` 尚未迁移。它们涉及 SSH runtime、remote agent submission、tool registry owner 化与 announcement config/path 边界，继续前需要单独确认端口方案与等价性测试。
+- `git` 已完成 DTO/params/graph/raw command output/text parser/arg builder、`GitError`、`GitService` runtime implementation 与 git utils 迁移；`bitfun-core::service::git::*` 仅保留 legacy facade re-export。`remote-ssh` 已迁移纯 contract/type、workspace path/identity helper 与 unresolved-session-key helper；SSH runtime manager / fs / terminal、password vault 与 PathManager-backed session mirror assembly 仍保留在 core。`mcp` 已迁移 tool-name / tool-info / protocol types / config location / server type-status、server config、cursor-format、JSON-RPC request builder、JSON config format/validation helper、config merge / remote authorization helper、OAuth credential vault / authorization bootstrap contract、remote auth error classifier、legacy remote header fallback helper、transport Authorization 归一化 helper、remote client capability helper、rmcp 到 BitFun protocol 的纯映射 helper、resource/prompt adapter、catalog cache、list-changed/reconnect policy、config service save-load orchestration、server process / local-remote transport lifecycle、dynamic tool descriptor / provider / result rendering helper，并用 owner crate contract test 锁定 wire shape、transport default、validation message、Cursor 兼容格式、config precedence / dedup 语义、OAuth vault 存储路径注入、NeedsAuth 分类、旧 env Authorization fallback、remote client capabilities、remote result metadata / structured content 映射、config load/save/delete contract、unsupported remote transport contract、context resource selection 和 dynamic manifest；`bitfun-core` 继续负责 core `ConfigService` store adapter、OAuth data-dir 注入、`BitFunError` 映射、legacy facade 和全局 tool registry 组装。`announcement` 仅迁移了纯 types contract，scheduler / state store / content loader / remote fetch 仍保留在 core；`remote-connect` 已完成 contract/request-builder slice，远程消息执行、image context、tracker event、cancel、terminal pre-warm 与 workspace/session restore 仍保留在 core。它们涉及 SSH runtime、remote agent submission runtime、tool registry owner 化与 announcement config/path 边界，继续前需要单独确认端口方案与等价性测试。
 - 最新主干的 Deep Review capacity / cost / queue、context profile、evidence ledger、session manifest、stream dedupe、search remote/fallback 与 session rollback persistence 仍属于 core runtime 或对应产品 runtime，不在本轮 `services-integrations` 迁移范围内；如果后续迁移 remote-connect / MCP / search / session，需要先定义运行状态 port 合约和等价测试。
 
 **验证：**
@@ -1040,11 +1041,11 @@ pub fn create_tool_registry() -> ToolRegistry {
 
 - [ ] 增加 registry 等价性测试：完整产品 registry 中的工具集合与拆分前一致。
 
-**当前安全迁移状态（2026-05-11）：**
+**当前安全迁移状态（2026-05-13）：**
 
-- 已迁移到 `bitfun-agent-tools`：`ToolResult`、`ValidationResult`、`InputValidator`，core 旧路径继续 re-export。
+- 已迁移到 `bitfun-agent-tools`：`ToolResult`、`ValidationResult`、`InputValidator`、dynamic tool metadata、tool render options、runtime restriction DTO 和 path resolution DTO；dynamic tool provider / decorator contract 已通过 `agent-tools` 提供兼容 re-export，原 `runtime-ports` 路径保持可用；core 旧路径继续 re-export，并只保留 `BitFunError` 映射与路径 containment helper。
 - 已新增 `bitfun-tool-packs` feature scaffold，默认 feature 为空，`product-full` 只聚合 feature，不注册或迁移任何工具实现。
-- `Tool` trait、`ToolUseContext`、registry 和具体工具实现仍在 core；它们直接连接 workspace service、snapshot wrapper、computer-use host、runtime restrictions 与 cancellation token，继续迁移前必须先确认可移植 tool context / provider port 方案，并补工具清单等价性测试。
+- `Tool` trait、`ToolUseContext`、registry 和具体工具实现仍在 core；它们直接连接 workspace service、snapshot wrapper、computer-use host、cancellation token 与 Deep Review checkpoint hook，继续迁移前必须先确认可移植 tool context / provider port 方案，并补工具清单等价性测试。
 - 最新主干新增的 Deep Review shared-context / evidence-ledger checkpoint hook 仍保留在 core 的 `ToolUseContext` 中；在设计独立 tool context / event port 前，不应把 `ToolUseContext` 或 registry 继续外移。
 
 **验证：**
@@ -1530,7 +1531,7 @@ cargo check --workspace
 - 已扩展 `scripts/check-core-boundaries.mjs`，增加 dependency profile / feature graph 静态保护：`core-types` default profile 禁止非 DTO 依赖，`runtime-ports` default profile 禁止 service implementation 依赖，`agent-tools` contract profile 禁止依赖 `bitfun-ai-adapters`，`product-domains` default profile 禁止无条件拉入 `dirs`，`services-integrations` default profile 禁止无条件拉入 feature-gated integration 依赖。
 - 已将 `ToolImageAttachment` 提升到 `bitfun-core-types`，并由 `bitfun-ai-adapters`、`bitfun-agent-tools` 和 `bitfun-core::util::types` 保留旧路径兼容；`bitfun-agent-tools` 不再依赖 `bitfun-ai-adapters`。
 - 已将 `product-domains` 的 `dirs` 依赖限制到 `miniapp` feature，默认 profile 保持轻量。
-- 已补充 `ToolResult` image attachment 序列化 round-trip 测试，以及 tool registry readonly 工具清单快照测试；后续迁移 `ToolUseContext`、registry/provider 或 concrete tool implementation 前必须保持这些基线。
+- 已补充 `ToolResult` image attachment、dynamic provider metadata、dynamic descriptor wire shape、runtime restrictions 与 path resolution contract 测试，以及 tool registry readonly / descriptor / stale metadata 工具清单快照测试；后续迁移 `ToolUseContext`、registry/provider 或 concrete tool implementation 前必须保持这些基线。
 - PR 1 已开始执行：remote-SSH workspace registry / ambiguous root resolution / legacy state snapshot 已迁入 `bitfun-services-integrations::remote_ssh::RemoteWorkspaceRegistry`，core 仅保留 local assistant path guard 与 SSH manager / file service / terminal manager 组装；announcement state persistence 已迁入 `bitfun-services-integrations::announcement::AnnouncementStateStore`，core 旧 `PathManager` 构造 API 继续委托并映射原错误类型。
 - 本批 dependency profile 基线已验证：
   - `cargo tree -p bitfun-core-types --depth 1 --edges features` 运行时依赖仅显示 `serde`，测试依赖显示 `serde_json`。
@@ -1588,9 +1589,9 @@ P2 后产品表面契约轨道（contract-only）：
    - 保留边界：`bitfun-core` 只保留 core `ConfigService` store adapter、OAuth data-dir 注入、`BitFunError` 映射、legacy facade 和与全局 tool registry 的组装调用；配置写入、OAuth、SSE/session 与 registry 行为不得在本 PR 中改变。
    - 后续切片：tool registry/provider owner 化需要放入 PR4，并先保留 dynamic provider metadata、工具清单顺序和 snapshot wrapper 等价测试。
    - 文档校正：P2 后补充文档中的 MCP runtime step 已由本 PR2 闭环；后续 MCP 相关工作只保留 tool registry/provider owner 化和 concrete tool implementation 迁移，不再重复迁移 config/process/transport lifecycle。
-3. remote-connect runtime：通过 `AgentSubmissionPort`、`SessionTranscriptReader`、`EventSink` 等 port 合约迁移 remote-connect / relay-facing runtime。验收重点是 message contract、session submission、remote control 同步与无真实网络依赖的 integration test。
-   - 进入前先复核产品表面契约轨道：如果 remote-connect 需要表达 source surface、thread environment、approval source 或 artifact ref，先补 contract-only DTO/port 和 round-trip/no-op tests，不改变现有 remote behavior。
-4. agent tools + `tool-packs` owner 化：`ToolUseContext` port 化、tool registry/provider 化、concrete tool implementation 按 feature group 迁移；必须保持 builtin/readonly/dynamic manifest、snapshot wrapping、runtime restrictions、cancellation 与 Deep Review tool flow 等价。
+3. 已完成：remote-connect contract slice：产品表面 DTO、remote chat/image/tool/session wire DTO 与 relay/bot session/submission request builder 已迁入 owner crate；完整 remote runtime 仍保留在 core，直到 `SessionTranscriptReader`、`EventSink`、`RemoteControlStatePort` 和 image/queue/event/cancellation port 补齐。
+   - 后续切片：完整 remote-connect runtime 迁移必须单独执行，不得混入 PR4 的 tool/provider owner 化。
+4. 进行中：agent tools + `tool-packs` owner 化：已先迁移纯 tool contract/provider metadata、runtime restriction DTO、path resolution DTO，并为 dynamic provider contract 提供 `agent-tools` 兼容 re-export；`ToolUseContext`、tool registry/provider 化、concrete tool implementation 按 feature group 迁移必须保持 builtin/readonly/dynamic manifest、snapshot wrapping、runtime restrictions、cancellation 与 Deep Review tool flow 等价。
 5. `product-domains` runtime + core facade finalization：迁移 miniapp runtime/compiler/builtin 与 function-agent 运行逻辑，最后把 `bitfun-core` 收敛为 facade + product runtime assembly；不在本 PR 中修改 `bitfun-core default = []` 或 per-product feature matrix。
 
 `bitfun-core default = []`、per-product feature set、构建矩阵和 release 能力调整仍作为重构完成后的独立评估，不计入上述 5 个 PR。
@@ -1637,7 +1638,7 @@ P2 后产品表面契约轨道（contract-only）：
 - 质量边界：本阶段证明已拆 owner crate 不依赖回 `bitfun-core`，并证明已迁移的 Git / remote-ssh helper 与 MCP config/process/transport/dynamic provider 旧路径或调用点仍通过当前 Rust workspace 检查；不声明 remote connect、tool registry/snapshot wrapping、miniapp/function-agent runtime 的外移完成。
 - boundary check 已扩展到 `core-types`、`runtime-ports` 和 `agent-tools` 的轻量边界，并覆盖 Cargo inline 依赖和 dependency table 依赖声明，后续不能绕过脚本把重 runtime、concrete service、platform adapter 或 CLI/TUI presentation 依赖带入这些 contract crate。
 - boundary check 也已锁定 `bitfun-core::service::git`、`bitfun-core::service::remote_ssh::types`、remote-ssh workspace path/identity/unresolved-key helper、`bitfun-core::service::mcp::{tool_info,tool_name}`、`bitfun-core::service::mcp::protocol::{types,jsonrpc}`、`bitfun-core::service::mcp::config::{location,cursor_format,json_config,service_helpers}`、`bitfun-core::service::mcp::server::config`、`bitfun-core::service::mcp::auth` 和 `bitfun-core::service::announcement::types` 的旧路径 facade-only / 禁止回流状态，并禁止在 `MCPServerProcess` runtime 文件重新定义已外移的 server type/status contract、auth error classifier 和 legacy remote header fallback helper，也禁止在 remote transport 重新实现 Authorization 归一化、client capability 构造和 rmcp result mapping。
-- 后续迁移必须拆成可独立审核的提交：先补 port/provider 设计和等价测试，再按 `remote-ssh` runtime、`remote-connect`、tool registry/provider 的顺序一次迁移一个 owner 主题。
+- 后续迁移必须拆成可独立审核的提交：先补 port/provider 设计和等价测试；`remote-connect` 完整 runtime、tool registry/provider、product-domain runtime 必须一次迁移一个 owner 主题。
 - tool registry / concrete tool implementation 外移必须先有工具清单等价测试，并保留 dynamic provider metadata；不能把注册名解析、snapshot wrapper 或 runtime restriction 行为改成隐式约定。
 - 已新增并扩展内置工具清单基线测试，后续 registry/provider 外移必须先保持该清单、注册顺序、runtime collection 顺序、dynamic provider metadata 顺序和修改类工具 snapshot wrapper 等价，再评估 owner crate 边界。
 - miniapp 与 function-agent runtime 外移必须先明确 Git/AI service、PathManager、process execution 和 permission policy 边界；如果需要行为合约变化，必须作为后续单独 PR 并先确认。
@@ -1688,7 +1689,7 @@ git diff -- package.json scripts/dev.cjs scripts/desktop-tauri-build.mjs scripts
 11. 已完成：PR 2 MCP runtime 与 dynamic tools；已迁移 config service orchestration、server process / transport lifecycle、adapter、dynamic tool/resource/prompt provider，core 保留 ConfigService store adapter、OAuth data-dir 注入、BitFunError 映射、legacy facade 和 registry assembly。
 12. P2 后前置轨道：产品表面 contract-only 补强，可在 PR3 前或 PR3 第一组提交中处理；只允许 DTO/port、round-trip/no-op tests 和 boundary check，不实现 CLI/Desktop/Remote/ACP UI 或命令变更。
 13. 已完成：PR 3 remote-connect runtime contract slice：产品表面 DTO 已以 contract-only 方式进入 `bitfun-core-types`；`bitfun-services-integrations` 新增 `remote-connect` feature，拥有 remote chat/image/tool/session wire DTO 与 relay/bot session/submission request builder；relay/bot 创建 session 已通过 `AgentSubmissionPort`。远程消息执行、image context、tracker event、cancel、terminal pre-warm 与 workspace/session restore 仍保留在 `bitfun-core` product runtime assembly，直到补齐 image/queue/event/cancellation port 后再迁移。
-14. 待执行：PR 4 agent tools + `tool-packs` owner 化。
+14. 进行中：PR 4 agent tools + `tool-packs` owner 化，当前仅处理低风险 contract / DTO 外移、provider contract 兼容 re-export 和边界防护。
 15. 待执行：PR 5 `product-domains` runtime + core facade finalization。
 16. 后续独立评估：`bitfun-core default = []` 或 per-product feature set。
 

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -1012,7 +1012,8 @@ cargo check -p bitfun-cli
 
 **任务：**
 
-- [ ] 抽出 tool trait、tool context、tool result、registry 到 `agent-tools`。
+- [x] 抽出 tool result、validation、dynamic metadata、runtime restriction、path resolution DTO，以及 generic registry / dynamic provider container 到 `agent-tools`。
+- [ ] 抽出 `Tool` trait 与 `ToolUseContext` 前，先补可移植 tool context / service port 设计；当前不做无端口支撑的行为迁移。
 - [x] `agent-tools` 不依赖任何 concrete service。
 - [ ] 将工具实现迁移到 `tool-packs` crate，并按 feature group 分模块：
   - basic file/search/terminal
@@ -1043,10 +1044,11 @@ pub fn create_tool_registry() -> ToolRegistry {
 
 **当前安全迁移状态（2026-05-13）：**
 
-- 已迁移到 `bitfun-agent-tools`：`ToolResult`、`ValidationResult`、`InputValidator`、dynamic tool metadata、tool render options、runtime restriction DTO 和 path resolution DTO；dynamic tool provider / decorator contract 已通过 `agent-tools` 提供兼容 re-export，原 `runtime-ports` 路径保持可用；core 旧路径继续 re-export，并只保留 `BitFunError` 映射与路径 containment helper。
+- 已迁移到 `bitfun-agent-tools`：`ToolResult`、`ValidationResult`、`InputValidator`、dynamic tool metadata、tool render options、runtime restriction DTO、path resolution DTO，以及不依赖 core service 的 `ToolRegistry<T>` / `ToolRegistryItem` generic registry container。dynamic tool provider / decorator contract 已通过 `agent-tools` 提供兼容 re-export，原 `runtime-ports` 路径保持可用；core 旧路径继续 re-export，并只保留 `BitFunError` 映射与路径 containment helper。
+- `bitfun-core::agentic::tools::registry` 现在只保留产品完整工具列表、snapshot decorator 组装、旧构造函数和 `dyn Tool` 到 generic registry 的适配；dynamic metadata map、tool map、dynamic descriptor assembly 由 `bitfun-agent-tools` 拥有。
 - 已新增 `bitfun-tool-packs` feature scaffold，默认 feature 为空，`product-full` 只聚合 feature，不注册或迁移任何工具实现。
-- `Tool` trait、`ToolUseContext`、registry 和具体工具实现仍在 core；它们直接连接 workspace service、snapshot wrapper、computer-use host、cancellation token 与 Deep Review checkpoint hook，继续迁移前必须先确认可移植 tool context / provider port 方案，并补工具清单等价性测试。
-- 最新主干新增的 Deep Review shared-context / evidence-ledger checkpoint hook 仍保留在 core 的 `ToolUseContext` 中；在设计独立 tool context / event port 前，不应把 `ToolUseContext` 或 registry 继续外移。
+- `Tool` trait、`ToolUseContext` 和具体工具实现仍在 core；它们直接连接 workspace service、snapshot wrapper、computer-use host、cancellation token 与 Deep Review checkpoint hook，继续迁移前必须先确认可移植 tool context / provider port 方案，并补工具清单等价性测试。
+- 最新主干新增的 Deep Review shared-context / evidence-ledger checkpoint hook 仍保留在 core 的 `ToolUseContext` 中；在设计独立 tool context / event port 前，不应把 `ToolUseContext` 或 concrete tool implementation 继续外移。
 
 **验证：**
 
@@ -1055,7 +1057,8 @@ cargo test -p bitfun-agent-tools
 cargo test -p bitfun-tool-packs --features basic
 cargo check -p bitfun-tool-packs --features product-full
 cargo check -p bitfun-core --features product-full
-cargo test -p bitfun-core registry_includes
+cargo test -p bitfun-core registry_ --lib
+cargo test -p bitfun-core dynamic_tool_provider_ --lib
 cargo check -p bitfun-desktop
 ```
 
@@ -1149,7 +1152,7 @@ default = []
 
 **当前收敛状态（2026-05-13）：**
 
-- 本轮不把 `remote-ssh` runtime、`remote-connect`、announcement runtime、concrete tool implementations、tool registry、miniapp runtime/compiler/builtin、function-agent 运行逻辑声明为已迁移；它们继续作为 `bitfun-core` 的 product runtime assembly 或后续 owner PR 拥有路径。`git` feature group 已外移；`remote-ssh` 目前只外移 contract/type、workspace path/identity helper 与 unresolved-session-key helper；MCP PR2 已外移 config service orchestration、server process / transport lifecycle、adapter 和 dynamic tool/resource/prompt provider，core 只保留 ConfigService store adapter、OAuth data-dir 注入、BitFunError 映射、legacy facade 与 registry assembly；`announcement` 目前只外移 types contract。
+- 本轮不把 `remote-ssh` runtime、`remote-connect`、announcement runtime、concrete tool implementations、`ToolUseContext`、product registry assembly、miniapp runtime/compiler/builtin、function-agent 运行逻辑声明为已迁移；它们继续作为 `bitfun-core` 的 product runtime assembly 或后续 owner PR 拥有路径。`git` feature group 已外移；`remote-ssh` 目前只外移 contract/type、workspace path/identity helper 与 unresolved-session-key helper；MCP PR2 已外移 config service orchestration、server process / transport lifecycle、adapter 和 dynamic tool/resource/prompt provider；generic tool registry / dynamic descriptor assembly 已由 `bitfun-agent-tools` 拥有，core 只保留 ConfigService store adapter、OAuth data-dir 注入、BitFunError 映射、legacy facade、产品工具列表与 snapshot decorator assembly；`announcement` 目前只外移 types contract。
 - 新增 `scripts/check-core-boundaries.mjs`，用于阻止已拆出的 owner crate 反向依赖 `bitfun-core`。该脚本只证明 crate graph 方向，不替代产品等价性测试。
 - `default = []` 仍保持为后续独立评估项，本轮不调整默认 feature、构建脚本或 release 脚本。
 
@@ -1505,14 +1508,14 @@ cargo check --workspace
 - 新增 crate 数量仍保持中等粒度。
 - heavy dependency 所属 crate 清晰。
 
-**当前 P2 执行状态（2026-05-12）：**
+**当前 P2 执行状态（2026-05-13）：**
 
 - 已完成中等粒度 owner crate 成型的安全部分：`bitfun-services-core`、`bitfun-services-integrations`、`bitfun-agent-tools`、`bitfun-tool-packs`、`bitfun-product-domains` 均已加入 workspace。
 - 已迁移的模块均由 core facade re-export，未改变产品默认 feature、构建脚本或 release 脚本。
-- Git feature group 已闭环迁移到 `bitfun-services-integrations` 的 `git` feature：DTO/params/graph/raw command output/text parser/arg builder、`GitError`、`GitService` runtime implementation 与 git utils 均由 integrations owner crate 拥有，并通过 `bitfun-core::service::git::*` 保留旧路径兼容。`GitService` 所需的 Windows `libgit2` system-link 边界挂在该 crate 的 `git` feature 上；`bitfun-core` 仍因未迁移的 remote-connect runtime 保留其它 `git2` 使用。remote-ssh 本轮进一步外移 workspace path/identity 与 unresolved-session-key helper，并用 owner crate contract test 锁定 normalized path、mirror subpath、hostname sanitization、stable id 和 unresolved key 输出；PathManager-backed mirror root、global workspace registry、SSH manager/fs/terminal/runtime 仍留在 core。MCP PR2 已进一步外移 config service orchestration、server process / local-remote transport lifecycle、dynamic tool provider 与 context resource selection helper，core 旧路径继续做兼容 facade、core config store adapter、OAuth 数据目录注入、`BitFunError` 映射和全局 registry 组装。
-- 未声明完成的 P2/后续剩余部分：remote-ssh runtime、remote-connect 等重 service 迁移、concrete tool implementation 迁移、tool registry/provider 化、miniapp/function-agent 运行逻辑迁移。这些会触碰 `PathManager`、`ToolUseContext`、workspace service、snapshot wrapper、`AgentSubmissionPort` 或 AI service 边界，需要在继续前显式确认。
+- Git feature group 已闭环迁移到 `bitfun-services-integrations` 的 `git` feature：DTO/params/graph/raw command output/text parser/arg builder、`GitError`、`GitService` runtime implementation 与 git utils 均由 integrations owner crate 拥有，并通过 `bitfun-core::service::git::*` 保留旧路径兼容。`GitService` 所需的 Windows `libgit2` system-link 边界挂在该 crate 的 `git` feature 上；`bitfun-core` 仍因未迁移的 remote-connect runtime 保留其它 `git2` 使用。remote-ssh 本轮进一步外移 workspace path/identity 与 unresolved-session-key helper，并用 owner crate contract test 锁定 normalized path、mirror subpath、hostname sanitization、stable id 和 unresolved key 输出；PathManager-backed mirror root、global workspace registry、SSH manager/fs/terminal/runtime 仍留在 core。MCP PR2 已进一步外移 config service orchestration、server process / local-remote transport lifecycle、dynamic tool provider 与 context resource selection helper，core 旧路径继续做兼容 facade、core config store adapter、OAuth 数据目录注入与 `BitFunError` 映射。PR4 已将 generic tool registry / dynamic descriptor assembly 迁入 `bitfun-agent-tools`；core 继续负责产品工具列表、snapshot decorator 和 `dyn Tool` 适配。
+- 未声明完成的 P2/后续剩余部分：remote-ssh runtime、remote-connect 等重 service 迁移、`ToolUseContext` 外移、concrete tool implementation 迁移、product registry/provider assembly、miniapp/function-agent 运行逻辑迁移。这些会触碰 `PathManager`、`ToolUseContext`、workspace service、snapshot wrapper、`AgentSubmissionPort` 或 AI service 边界，需要在继续前显式确认。
 - 本次 rebase 后重新核对最新主干 Deep Review capacity/cost/queue、context profile、evidence ledger 与 session manifest 变更：当前 PR 已完成 Git feature group 的 owner crate 归属迁移，但未改动这些 Deep Review 行为路径；后续迁移必须补端口设计和等价测试后再推进。
-- 本次 P2 后续复核结论：上述高耦合剩余项不是纯文件搬迁；若继续迁移会改变依赖方向或需要新增 port/provider 行为合约。因此当前 PR 将它们显式保留为 core-owned runtime，并通过 P3 boundary check 防止已拆 owner crate 回流依赖 core。
+- 本次 P2 后续复核结论：上述高耦合剩余项不是纯文件搬迁；若继续迁移会改变依赖方向或需要新增 port/provider 行为合约。因此当前 PR 将它们显式保留为 core-owned runtime，只完成低风险 owner container 化，并通过 boundary check 防止已拆 owner crate 回流依赖 core。
 
 **后续风险重排（2026-05-13）：**
 
@@ -1531,12 +1534,13 @@ cargo check --workspace
 - 已扩展 `scripts/check-core-boundaries.mjs`，增加 dependency profile / feature graph 静态保护：`core-types` default profile 禁止非 DTO 依赖，`runtime-ports` default profile 禁止 service implementation 依赖，`agent-tools` contract profile 禁止依赖 `bitfun-ai-adapters`，`product-domains` default profile 禁止无条件拉入 `dirs`，`services-integrations` default profile 禁止无条件拉入 feature-gated integration 依赖。
 - 已将 `ToolImageAttachment` 提升到 `bitfun-core-types`，并由 `bitfun-ai-adapters`、`bitfun-agent-tools` 和 `bitfun-core::util::types` 保留旧路径兼容；`bitfun-agent-tools` 不再依赖 `bitfun-ai-adapters`。
 - 已将 `product-domains` 的 `dirs` 依赖限制到 `miniapp` feature，默认 profile 保持轻量。
-- 已补充 `ToolResult` image attachment、dynamic provider metadata、dynamic descriptor wire shape、runtime restrictions 与 path resolution contract 测试，以及 tool registry readonly / descriptor / stale metadata 工具清单快照测试；后续迁移 `ToolUseContext`、registry/provider 或 concrete tool implementation 前必须保持这些基线。
+- 已补充 `ToolResult` image attachment、dynamic provider metadata、dynamic descriptor wire shape、runtime restrictions、path resolution contract、generic tool registry descriptor/stale metadata 测试，以及 core 内置 tool registry 清单快照测试；后续迁移 `ToolUseContext`、product registry assembly 或 concrete tool implementation 前必须保持这些基线。
+- 已将 generic tool registry / dynamic provider descriptor assembly 迁入 `bitfun-agent-tools`；core registry 只保留产品完整工具列表、snapshot decorator 和 `dyn Tool` 适配，并通过 boundary check 禁止重新拥有 `IndexMap` 工具容器或 dynamic metadata map。
 - PR 1 已开始执行：remote-SSH workspace registry / ambiguous root resolution / legacy state snapshot 已迁入 `bitfun-services-integrations::remote_ssh::RemoteWorkspaceRegistry`，core 仅保留 local assistant path guard 与 SSH manager / file service / terminal manager 组装；announcement state persistence 已迁入 `bitfun-services-integrations::announcement::AnnouncementStateStore`，core 旧 `PathManager` 构造 API 继续委托并映射原错误类型。
 - 本批 dependency profile 基线已验证：
   - `cargo tree -p bitfun-core-types --depth 1 --edges features` 运行时依赖仅显示 `serde`，测试依赖显示 `serde_json`。
   - `cargo tree -p bitfun-runtime-ports --depth 1 --edges features` 仅显示 `async-trait`、`serde`、`serde_json`。
-  - `cargo tree -p bitfun-agent-tools --depth 1 --edges features` 仅显示 `bitfun-core-types`、`serde`、`serde_json`。
+  - `cargo tree -p bitfun-agent-tools --depth 1 --edges features` 仅显示 `async-trait`、`bitfun-core-types`、`bitfun-runtime-ports`、`indexmap`、`serde`、`serde_json`；dev-dependencies 仅显示 `tokio`。
   - `cargo tree -p bitfun-product-domains --no-default-features --depth 1 --edges features` 仅显示 `serde`、`serde_json`，不会拉入 `dirs`。
   - `cargo tree -p bitfun-services-integrations --no-default-features --depth 1 --edges features` 仅显示 `bitfun-events`、`serde`、`serde_json`、`log`、`tokio`。
 
@@ -1560,8 +1564,8 @@ P2 后产品表面契约轨道（contract-only）：
 
 需要单独审视的高风险项：
 
-- `ToolUseContext`、tool registry/provider、concrete tool implementation 外移。
-- MCP tool registry owner 化与 concrete tool implementation 外移。
+- `ToolUseContext`、product tool provider assembly、concrete tool implementation 外移。
+- MCP concrete tool implementation / product registry assembly 外移。
 - remote-connect、remote-SSH runtime、announcement runtime 外移。
 - miniapp runtime/compiler/builtin 与 function-agent 运行逻辑外移。
 - agent registry / subagent visibility 外移，特别是 hidden/custom/review 分组、mode-scoped visibility 和 desktop API contract。
@@ -1579,7 +1583,7 @@ P2 后产品表面契约轨道（contract-only）：
 
 - 某个迁移必须让产品 crate 减少 feature 才能通过。
 - `services-integrations` 的 feature group 互相强耦合，无法单独 check。
-- tool registry 迁移后工具清单无法证明等价。
+- product registry assembly 或 concrete tool implementation 迁移后工具清单无法证明等价。
 - 新 owner crate 反向依赖 core。
 
 **剩余工作压缩为 5 个 PR（2026-05-13）：**
@@ -1587,11 +1591,11 @@ P2 后产品表面契约轨道（contract-only）：
 1. `services-integrations` runtime 收口：迁移 remote-SSH 中不直接持有 SSH channel / SFTP / terminal handle 的 workspace registry、session mirror 与轻量 runtime helper；继续保留 SSH manager / remote FS / remote terminal 的 core-owned assembly，直到 port/provider 合约明确。`file-watch` 已由 `services-integrations` 拥有，只做 contract 复核；announcement 只迁移不依赖 config service / embedded content / remote fetch 的 state 或 eligibility helper。验收重点是 owner crate contract test、旧路径 facade、boundary check、workspace check/test。
 2. 已完成：MCP runtime 与 dynamic tools：MCP config service orchestration、server process / transport lifecycle、adapter、dynamic tool/resource/prompt provider 已归属 `bitfun-services-integrations`；未混入 remote-connect 或 tool registry owner 化。验收重点是 MCP wire shape、auth/config merge、dynamic manifest 快照和 core registry 集成等价。
    - 保留边界：`bitfun-core` 只保留 core `ConfigService` store adapter、OAuth data-dir 注入、`BitFunError` 映射、legacy facade 和与全局 tool registry 的组装调用；配置写入、OAuth、SSE/session 与 registry 行为不得在本 PR 中改变。
-   - 后续切片：tool registry/provider owner 化需要放入 PR4，并先保留 dynamic provider metadata、工具清单顺序和 snapshot wrapper 等价测试。
-   - 文档校正：P2 后补充文档中的 MCP runtime step 已由本 PR2 闭环；后续 MCP 相关工作只保留 tool registry/provider owner 化和 concrete tool implementation 迁移，不再重复迁移 config/process/transport lifecycle。
+   - 后续切片：MCP concrete tool integration / product registry assembly 继续保留 dynamic provider metadata、工具清单顺序和 snapshot wrapper 等价测试。
+   - 文档校正：P2 后补充文档中的 MCP runtime step 已由本 PR2 闭环；后续 MCP 相关工作只保留 concrete tool implementation 迁移或 product registry assembly，不再重复迁移 config/process/transport lifecycle。
 3. 已完成：remote-connect contract slice：产品表面 DTO、remote chat/image/tool/session wire DTO 与 relay/bot session/submission request builder 已迁入 owner crate；完整 remote runtime 仍保留在 core，直到 `SessionTranscriptReader`、`EventSink`、`RemoteControlStatePort` 和 image/queue/event/cancellation port 补齐。
    - 后续切片：完整 remote-connect runtime 迁移必须单独执行，不得混入 PR4 的 tool/provider owner 化。
-4. 进行中：agent tools + `tool-packs` owner 化：已先迁移纯 tool contract/provider metadata、runtime restriction DTO、path resolution DTO，并为 dynamic provider contract 提供 `agent-tools` 兼容 re-export；`ToolUseContext`、tool registry/provider 化、concrete tool implementation 按 feature group 迁移必须保持 builtin/readonly/dynamic manifest、snapshot wrapping、runtime restrictions、cancellation 与 Deep Review tool flow 等价。
+4. 已完成本轮可提交闭环：agent tools + `tool-packs` owner 化低风险部分。纯 tool contract/provider metadata、runtime restriction DTO、path resolution DTO、generic tool registry / dynamic provider container 已迁入 `bitfun-agent-tools`，并为 dynamic provider contract 提供 `agent-tools` 兼容 re-export；core registry 只保留产品完整工具列表、snapshot decorator 和 `dyn Tool` 适配。`ToolUseContext` 与 concrete tool implementation 按 feature group 外移需要新的 port/provider 设计，必须保持 builtin/readonly/dynamic manifest、snapshot wrapping、runtime restrictions、cancellation 与 Deep Review tool flow 等价，作为后续高风险迁移单独审视。
 5. `product-domains` runtime + core facade finalization：迁移 miniapp runtime/compiler/builtin 与 function-agent 运行逻辑，最后把 `bitfun-core` 收敛为 facade + product runtime assembly；不在本 PR 中修改 `bitfun-core default = []` 或 per-product feature matrix。
 
 `bitfun-core default = []`、per-product feature set、构建矩阵和 release 能力调整仍作为重构完成后的独立评估，不计入上述 5 个 PR。
@@ -1622,25 +1626,25 @@ P2 后产品表面契约轨道（contract-only）：
 
 **P3 进入条件与最新主干补充（2026-05-12）：**
 
-- P3 只能在 P2 剩余迁移闭环后启动：重 service 迁移、concrete tool implementation 迁移、tool registry/provider 化、miniapp/function-agent 运行逻辑迁移都必须先完成或显式保留为 core-owned runtime。
+- P3 只能在 P2 剩余迁移闭环后启动：重 service 迁移、`ToolUseContext` / concrete tool implementation 迁移、product registry/provider assembly、miniapp/function-agent 运行逻辑迁移都必须先完成或显式保留为 core-owned runtime；generic registry/provider container 已在 PR4 中完成低风险外移。
 - 最近 `origin/main` 的 Deep Review 变更增加了 context profile、evidence ledger、capacity/cost/queue 控制、`deep_review_run_manifest` / `deep_review_cache`、以及 review-team UI orchestration；最新主干还补充了 agent-stream tool-call dedupe、search remote/fallback、session rollback persistence 和 companion typewriter。P3 facade 收敛前必须确认这些行为要么仍由 core product runtime assembly 拥有，要么已有对应 owner crate + port/provider 合约和等价测试。
 - 最新主干的 mode-scoped subagent visibility 将 `agentic::agents` 重组为 definitions / registry / visibility 边界，并扩展了 desktop subagent API 与 Review Team 可见性测试；后续若迁移 agent registry，不能只做路径 re-export，必须保留 mode 可见性过滤、hidden/custom/review 分组语义和前后端 API contract。
 - 最新主干的 CLI 重构主要新增 TUI/theme/selector/dialog/chat-state 等 app-layer 代码，后续又收敛预置 theme 并补充 desktop companion pet resize / Windows UX；这些当前没有改变 `services-integrations` 的迁移归属。后续若调整 shared crate 边界，必须继续把 `bitfun-cli`、`ratatui`、`crossterm`、`arboard`、`syntect-tui` 等 CLI-only 依赖限制在 app adapter / presentation layer，desktop / web-ui presentation 修复也不应被误判为 core service 迁移前置条件。
 - P2 后产品表面策略要求“surface divergence, capability convergence”：CLI `/diff`、Desktop 快捷键/面板、Remote card、ACP method 可以映射到同一 capability contract，但不能为了复用把 surface command 或 UI rendering 下沉到 contract crate。
 - `ToolUseContext` 的 shared-context / evidence checkpoint hook、`TaskTool` / `CodeReviewTool` 的 Deep Review capacity flow、session manifest/cache persistence、rollback persisted-turn cleanup、search fallback chain 与 stream finish/tool-call contract 不能在 P3 中只通过 re-export 消失；如果外移，需要先补 boundary contract、旧路径兼容和对应 regression。
 - P3 的闭环检查应同时覆盖 Rust crate graph 与产品 runtime 行为：边界脚本只证明依赖方向，不能替代 Deep Review、MCP dynamic tools、remote connect、snapshot wrapping、miniapp/function-agent 的产品等价性验证。
-- 当前 PR 的 P3 范围按“显式保留 core-owned runtime + 强制 owner crate 边界”闭环；后续如果要继续外移这些 runtime 路径，需要作为新的迁移批次先补 port 设计、等价测试和用户确认。
+- 后续 P3 范围按“显式保留 core-owned runtime + 强制 owner crate 边界”闭环；如果要继续外移这些 runtime 路径，需要作为新的迁移批次先补 port 设计、等价测试和用户确认。
 
-**阶段复核与后续拆分（2026-05-13 PR2 完成后）：**
+**阶段复核与后续拆分（2026-05-13 PR4 完成后）：**
 
-- 当前分支保持单一主题：只包含 boundary check、阶段文档，以及 Git / remote-ssh 已迁移边界上的 MCP PR2 runtime / dynamic provider 归属迁移；不继续混入 remote-connect、tool registry owner 化、miniapp 或 function-agent runtime 迁移。
-- 本次 rebase 到最新 `upstream/main` 后，PR #680 的三颗等价提交已进入主干；新增 CLI 收敛、版本 bump 和 desktop companion pet UX 修复没有改变本轮 `services-integrations` / service facade 迁移内容，但会把后续 CLI 产品检查、agent registry/provider 与 session/tool runtime 外移的等价性门槛抬高。
-- 质量边界：本阶段证明已拆 owner crate 不依赖回 `bitfun-core`，并证明已迁移的 Git / remote-ssh helper 与 MCP config/process/transport/dynamic provider 旧路径或调用点仍通过当前 Rust workspace 检查；不声明 remote connect、tool registry/snapshot wrapping、miniapp/function-agent runtime 的外移完成。
+- 当前分支保持单一主题：只包含 agent tools / tool registry 低风险 owner 化、boundary check 和阶段文档；不继续混入 remote-connect、miniapp 或 function-agent runtime 迁移。
+- 本次 rebase 到最新 `upstream/main` 后，PR #680 的三颗等价提交已进入主干；新增 CLI 收敛、版本 bump 和 desktop companion pet UX 修复没有改变本轮 `agent-tools` / registry container 迁移内容，但会把后续 CLI 产品检查、agent registry/provider 与 session/tool runtime 外移的等价性门槛抬高。
+- 质量边界：本阶段证明已拆 owner crate 不依赖回 `bitfun-core`，并证明已迁移的 tool contract、generic registry / dynamic provider container 旧路径或调用点仍通过当前 Rust workspace 检查；不声明 remote connect、`ToolUseContext`、concrete tool implementation、miniapp/function-agent runtime 的外移完成。
 - boundary check 已扩展到 `core-types`、`runtime-ports` 和 `agent-tools` 的轻量边界，并覆盖 Cargo inline 依赖和 dependency table 依赖声明，后续不能绕过脚本把重 runtime、concrete service、platform adapter 或 CLI/TUI presentation 依赖带入这些 contract crate。
-- boundary check 也已锁定 `bitfun-core::service::git`、`bitfun-core::service::remote_ssh::types`、remote-ssh workspace path/identity/unresolved-key helper、`bitfun-core::service::mcp::{tool_info,tool_name}`、`bitfun-core::service::mcp::protocol::{types,jsonrpc}`、`bitfun-core::service::mcp::config::{location,cursor_format,json_config,service_helpers}`、`bitfun-core::service::mcp::server::config`、`bitfun-core::service::mcp::auth` 和 `bitfun-core::service::announcement::types` 的旧路径 facade-only / 禁止回流状态，并禁止在 `MCPServerProcess` runtime 文件重新定义已外移的 server type/status contract、auth error classifier 和 legacy remote header fallback helper，也禁止在 remote transport 重新实现 Authorization 归一化、client capability 构造和 rmcp result mapping。
-- 后续迁移必须拆成可独立审核的提交：先补 port/provider 设计和等价测试；`remote-connect` 完整 runtime、tool registry/provider、product-domain runtime 必须一次迁移一个 owner 主题。
-- tool registry / concrete tool implementation 外移必须先有工具清单等价测试，并保留 dynamic provider metadata；不能把注册名解析、snapshot wrapper 或 runtime restriction 行为改成隐式约定。
-- 已新增并扩展内置工具清单基线测试，后续 registry/provider 外移必须先保持该清单、注册顺序、runtime collection 顺序、dynamic provider metadata 顺序和修改类工具 snapshot wrapper 等价，再评估 owner crate 边界。
+- boundary check 也已锁定 `bitfun-core::service::git`、`bitfun-core::service::remote_ssh::types`、remote-ssh workspace path/identity/unresolved-key helper、`bitfun-core::service::mcp::{tool_info,tool_name}`、`bitfun-core::service::mcp::protocol::{types,jsonrpc}`、`bitfun-core::service::mcp::config::{location,cursor_format,json_config,service_helpers}`、`bitfun-core::service::mcp::server::config`、`bitfun-core::service::mcp::auth` 和 `bitfun-core::service::announcement::types` 的旧路径 facade-only / 禁止回流状态，并禁止在 `MCPServerProcess` runtime 文件重新定义已外移的 server type/status contract、auth error classifier 和 legacy remote header fallback helper，也禁止在 remote transport 重新实现 Authorization 归一化、client capability 构造和 rmcp result mapping；本轮新增禁止 core registry 重新拥有 `IndexMap` 工具容器或 dynamic metadata map。
+- 后续迁移必须拆成可独立审核的提交：先补 port/provider 设计和等价测试；`remote-connect` 完整 runtime、`ToolUseContext` / concrete tool implementation、product-domain runtime 必须一次迁移一个 owner 主题。
+- concrete tool implementation 或 product registry assembly 外移必须先有工具清单等价测试，并保留 dynamic provider metadata；不能把注册名解析、snapshot wrapper 或 runtime restriction 行为改成隐式约定。
+- 已新增并扩展内置工具清单基线测试，后续迁移 `ToolUseContext`、concrete tool implementation 或 product registry assembly 必须先保持该清单、注册顺序、runtime collection 顺序、dynamic provider metadata 顺序和修改类工具 snapshot wrapper 等价，再评估 owner crate 边界。
 - miniapp 与 function-agent runtime 外移必须先明确 Git/AI service、PathManager、process execution 和 permission policy 边界；如果需要行为合约变化，必须作为后续单独 PR 并先确认。
 - 产品表面 contract 补强必须保持 observational：只记录 surface/thread/environment/permission/artifact facts，不改变 CLI、Desktop、Remote、ACP 的现有交互和运行时语义。
 - `bitfun-core default = []` 和依赖版本收敛仍是后续独立评估项，不与 runtime 外移或构建脚本调整混在同一批提交。
@@ -1686,10 +1690,10 @@ git diff -- package.json scripts/dev.cjs scripts/desktop-tauri-build.mjs scripts
 8. 已完成：抽取 `bitfun-services-integrations` 的低风险 feature group 和纯 helper，闭环 `git`、remote-SSH contract/helper、MCP 纯 protocol/config/auth helper；MCP runtime / dynamic provider 已在 PR2 补齐，未把 remote-connect 或 tool registry owner 化顺带迁入。
 9. 已完成：前移低风险保护项：dependency profile / feature graph 基线、轻量 contract crate 依赖瘦身、feature group 说明、boundary check 扩展、迁移前快照测试。
 10. 进行中：PR 1 `services-integrations` runtime 收口，先处理 remote-SSH workspace registry / session mirror helper 和已迁移 file-watch 的 contract 复核；announcement 仅迁移无 config/content/remote fetch 依赖的 helper。
-11. 已完成：PR 2 MCP runtime 与 dynamic tools；已迁移 config service orchestration、server process / transport lifecycle、adapter、dynamic tool/resource/prompt provider，core 保留 ConfigService store adapter、OAuth data-dir 注入、BitFunError 映射、legacy facade 和 registry assembly。
+11. 已完成：PR 2 MCP runtime 与 dynamic tools；已迁移 config service orchestration、server process / transport lifecycle、adapter、dynamic tool/resource/prompt provider，core 保留 ConfigService store adapter、OAuth data-dir 注入、BitFunError 映射、legacy facade 和 product registry assembly。
 12. P2 后前置轨道：产品表面 contract-only 补强，可在 PR3 前或 PR3 第一组提交中处理；只允许 DTO/port、round-trip/no-op tests 和 boundary check，不实现 CLI/Desktop/Remote/ACP UI 或命令变更。
 13. 已完成：PR 3 remote-connect runtime contract slice：产品表面 DTO 已以 contract-only 方式进入 `bitfun-core-types`；`bitfun-services-integrations` 新增 `remote-connect` feature，拥有 remote chat/image/tool/session wire DTO 与 relay/bot session/submission request builder；relay/bot 创建 session 已通过 `AgentSubmissionPort`。远程消息执行、image context、tracker event、cancel、terminal pre-warm 与 workspace/session restore 仍保留在 `bitfun-core` product runtime assembly，直到补齐 image/queue/event/cancellation port 后再迁移。
-14. 进行中：PR 4 agent tools + `tool-packs` owner 化，当前仅处理低风险 contract / DTO 外移、provider contract 兼容 re-export 和边界防护。
+14. 已完成：PR 4 agent tools + `tool-packs` owner 化低风险闭环；tool contract / DTO、runtime restriction、path resolution、generic registry / dynamic provider container 已归属 `bitfun-agent-tools`，core 保留产品工具列表、snapshot decorator、`ToolUseContext` 和 concrete tool implementation，后续外移需单独 port/provider 设计。
 15. 待执行：PR 5 `product-domains` runtime + core facade finalization。
 16. 后续独立评估：`bitfun-core default = []` 或 per-product feature set。
 

--- a/scripts/check-core-boundaries.mjs
+++ b/scripts/check-core-boundaries.mjs
@@ -318,6 +318,49 @@ const facadeOnlyFiles = [
 
 const forbiddenContentRules = [
   {
+    path: 'src/crates/core/src/agentic/tools/framework.rs',
+    patterns: [
+      {
+        regex: /\bpub struct DynamicMcpToolInfo\b/,
+        message: 'core tool framework must not redefine DynamicMcpToolInfo; use bitfun-agent-tools',
+      },
+      {
+        regex: /\bpub struct DynamicToolInfo\b/,
+        message: 'core tool framework must not redefine DynamicToolInfo; use bitfun-agent-tools',
+      },
+      {
+        regex: /\bpub struct ToolRenderOptions\b/,
+        message: 'core tool framework must not redefine ToolRenderOptions; use bitfun-agent-tools',
+      },
+      {
+        regex: /\bpub enum ToolPathBackend\b/,
+        message: 'core tool framework must not redefine ToolPathBackend; use bitfun-agent-tools',
+      },
+      {
+        regex: /\bpub struct ToolPathResolution\b/,
+        message: 'core tool framework must not redefine ToolPathResolution; use bitfun-agent-tools',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/core/src/agentic/tools/restrictions.rs',
+    patterns: [
+      {
+        regex: /\bpub enum ToolPathOperation\b/,
+        message: 'core tool restrictions must not redefine ToolPathOperation; use bitfun-agent-tools',
+      },
+      {
+        regex: /\bpub struct ToolPathPolicy\b/,
+        message: 'core tool restrictions must not redefine ToolPathPolicy; use bitfun-agent-tools',
+      },
+      {
+        regex: /\bpub struct ToolRuntimeRestrictions\b/,
+        message:
+          'core tool restrictions must not redefine ToolRuntimeRestrictions; use bitfun-agent-tools',
+      },
+    ],
+  },
+  {
     path: 'src/crates/core/src/service/mcp/server/process.rs',
     patterns: [
       {
@@ -998,6 +1041,46 @@ function runManifestParserSelfTest() {
   const agentToolsRule = lightweightBoundaryRules.find((rule) => rule.crateName === 'agent-tools');
   if (!agentToolsRule?.forbiddenDeps.includes('bitfun-ai-adapters')) {
     throw new Error('agent-tools lightweight boundary must forbid bitfun-ai-adapters');
+  }
+  const coreToolFrameworkRule = forbiddenContentRules.find(
+    (rule) => rule.path === 'src/crates/core/src/agentic/tools/framework.rs',
+  );
+  if (!coreToolFrameworkRule) {
+    throw new Error('missing core tool framework boundary rule');
+  }
+  const coreToolFrameworkContracts = [
+    'DynamicMcpToolInfo',
+    'DynamicToolInfo',
+    'ToolRenderOptions',
+    'ToolPathBackend',
+    'ToolPathResolution',
+  ];
+  const coreToolFrameworkRuleText = coreToolFrameworkRule.patterns
+    .map((pattern) => pattern.regex.source)
+    .join('\n');
+  for (const contract of coreToolFrameworkContracts) {
+    if (!coreToolFrameworkRuleText.includes(contract)) {
+      throw new Error(`core tool framework boundary rule must forbid contract: ${contract}`);
+    }
+  }
+  const coreToolRestrictionRule = forbiddenContentRules.find(
+    (rule) => rule.path === 'src/crates/core/src/agentic/tools/restrictions.rs',
+  );
+  if (!coreToolRestrictionRule) {
+    throw new Error('missing core tool restrictions boundary rule');
+  }
+  const coreToolRestrictionContracts = [
+    'ToolPathOperation',
+    'ToolPathPolicy',
+    'ToolRuntimeRestrictions',
+  ];
+  const coreToolRestrictionRuleText = coreToolRestrictionRule.patterns
+    .map((pattern) => pattern.regex.source)
+    .join('\n');
+  for (const contract of coreToolRestrictionContracts) {
+    if (!coreToolRestrictionRuleText.includes(contract)) {
+      throw new Error(`core tool restrictions boundary rule must forbid contract: ${contract}`);
+    }
   }
 
   const productDomainProfile = dependencyProfileRules.find(

--- a/scripts/check-core-boundaries.mjs
+++ b/scripts/check-core-boundaries.mjs
@@ -361,6 +361,26 @@ const forbiddenContentRules = [
     ],
   },
   {
+    path: 'src/crates/core/src/agentic/tools/registry.rs',
+    patterns: [
+      {
+        regex: /\bstruct DynamicToolMetadata\b/,
+        message:
+          'core tool registry must not own dynamic tool metadata storage; use bitfun-agent-tools ToolRegistry',
+      },
+      {
+        regex: /\btools\s*:\s*IndexMap\b/,
+        message:
+          'core tool registry must not own the generic tool map; use bitfun-agent-tools ToolRegistry',
+      },
+      {
+        regex: /\bdynamic_tools\s*:\s*IndexMap\b/,
+        message:
+          'core tool registry must not own the dynamic tool map; use bitfun-agent-tools ToolRegistry',
+      },
+    ],
+  },
+  {
     path: 'src/crates/core/src/service/mcp/server/process.rs',
     patterns: [
       {
@@ -1080,6 +1100,25 @@ function runManifestParserSelfTest() {
   for (const contract of coreToolRestrictionContracts) {
     if (!coreToolRestrictionRuleText.includes(contract)) {
       throw new Error(`core tool restrictions boundary rule must forbid contract: ${contract}`);
+    }
+  }
+  const coreToolRegistryRule = forbiddenContentRules.find(
+    (rule) => rule.path === 'src/crates/core/src/agentic/tools/registry.rs',
+  );
+  if (!coreToolRegistryRule) {
+    throw new Error('missing core tool registry boundary rule');
+  }
+  const coreToolRegistryRuleText = coreToolRegistryRule.patterns
+    .map((pattern) => pattern.regex.source)
+    .join('\n');
+  const coreToolRegistryContracts = [
+    'DynamicToolMetadata',
+    'tools\\s*:\\s*IndexMap',
+    'dynamic_tools\\s*:\\s*IndexMap',
+  ];
+  for (const contract of coreToolRegistryContracts) {
+    if (!coreToolRegistryRuleText.includes(contract)) {
+      throw new Error(`core tool registry boundary rule must forbid contract: ${contract}`);
     }
   }
 

--- a/src/apps/desktop/src/api/tool_api.rs
+++ b/src/apps/desktop/src/api/tool_api.rs
@@ -186,7 +186,9 @@ async fn build_tool_context(workspace_path: Option<&str>) -> ToolUseContext {
     }
 }
 
-fn to_dynamic_mcp_tool_info(info: bitfun_core::service::mcp::McpToolInfo) -> DynamicMcpToolInfo {
+fn to_dynamic_mcp_tool_info(
+    info: bitfun_core::agentic::tools::framework::DynamicMcpToolInfo,
+) -> DynamicMcpToolInfo {
     DynamicMcpToolInfo {
         server_id: info.server_id,
         server_name: info.server_name,

--- a/src/crates/agent-tools/Cargo.toml
+++ b/src/crates/agent-tools/Cargo.toml
@@ -13,3 +13,7 @@ crate-type = ["rlib"]
 serde = { workspace = true }
 serde_json = { workspace = true }
 bitfun-core-types = { path = "../core-types" }
+bitfun-runtime-ports = { path = "../runtime-ports" }
+
+[dev-dependencies]
+async-trait = { workspace = true }

--- a/src/crates/agent-tools/Cargo.toml
+++ b/src/crates/agent-tools/Cargo.toml
@@ -14,6 +14,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 bitfun-core-types = { path = "../core-types" }
 bitfun-runtime-ports = { path = "../runtime-ports" }
+async-trait = { workspace = true }
+indexmap = { workspace = true }
 
 [dev-dependencies]
-async-trait = { workspace = true }
+tokio = { workspace = true }

--- a/src/crates/agent-tools/src/framework.rs
+++ b/src/crates/agent-tools/src/framework.rs
@@ -1,6 +1,204 @@
 use bitfun_core_types::ToolImageAttachment;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// Dynamic MCP tool subtype metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamicMcpToolInfo {
+    pub server_id: String,
+    pub server_name: String,
+    pub tool_name: String,
+}
+
+/// Dynamic tool provider metadata used by registry and boundary adapters.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamicToolInfo {
+    pub provider_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp: Option<DynamicMcpToolInfo>,
+}
+
+/// Tool result rendering options.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolRenderOptions {
+    pub verbose: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolPathBackend {
+    Local,
+    RemoteWorkspace,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolPathResolution {
+    pub requested_path: String,
+    pub logical_path: String,
+    pub resolved_path: String,
+    pub backend: ToolPathBackend,
+    pub runtime_scope: Option<String>,
+    pub runtime_root: Option<PathBuf>,
+}
+
+impl ToolPathResolution {
+    pub fn uses_remote_workspace_backend(&self) -> bool {
+        matches!(self.backend, ToolPathBackend::RemoteWorkspace)
+    }
+
+    pub fn is_runtime_artifact(&self) -> bool {
+        self.runtime_scope.is_some()
+    }
+
+    pub fn logical_child_path(&self, absolute_child_path: &Path) -> Option<String> {
+        let scope = self.runtime_scope.as_deref()?;
+        let root = self.runtime_root.as_ref()?;
+        let relative = absolute_child_path.strip_prefix(root).ok()?;
+        let relative_str = relative.to_string_lossy().replace('\\', "/");
+        build_bitfun_runtime_uri(scope, &relative_str)
+    }
+}
+
+fn build_bitfun_runtime_uri(workspace_scope: &str, relative_path: &str) -> Option<String> {
+    let scope = workspace_scope.trim();
+    if scope.is_empty() {
+        return None;
+    }
+
+    Some(format!(
+        "bitfun://runtime/{}/{}",
+        scope,
+        normalize_runtime_relative_path(relative_path)?
+    ))
+}
+
+fn normalize_runtime_relative_path(path: &str) -> Option<String> {
+    let normalized = path.trim().replace('\\', "/");
+    let trimmed = normalized.trim_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut segments = Vec::new();
+    for part in trimmed.split('/') {
+        match part {
+            "" | "." => continue,
+            ".." => return None,
+            value => segments.push(value.to_string()),
+        }
+    }
+
+    if segments.is_empty() {
+        return None;
+    }
+
+    Some(segments.join("/"))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ToolPathOperation {
+    Write,
+    Edit,
+    Delete,
+}
+
+impl ToolPathOperation {
+    pub fn verb(self) -> &'static str {
+        match self {
+            Self::Write => "write",
+            Self::Edit => "edit",
+            Self::Delete => "delete",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolPathPolicy {
+    #[serde(default)]
+    pub write_roots: Vec<String>,
+    #[serde(default)]
+    pub edit_roots: Vec<String>,
+    #[serde(default)]
+    pub delete_roots: Vec<String>,
+}
+
+impl ToolPathPolicy {
+    pub fn roots_for(&self, operation: ToolPathOperation) -> &[String] {
+        match operation {
+            ToolPathOperation::Write => &self.write_roots,
+            ToolPathOperation::Edit => &self.edit_roots,
+            ToolPathOperation::Delete => &self.delete_roots,
+        }
+    }
+
+    pub fn is_restricted(&self, operation: ToolPathOperation) -> bool {
+        !self.roots_for(operation).is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolRuntimeRestrictions {
+    #[serde(default)]
+    pub allowed_tool_names: BTreeSet<String>,
+    #[serde(default)]
+    pub denied_tool_names: BTreeSet<String>,
+    #[serde(default)]
+    pub path_policy: ToolPathPolicy,
+}
+
+impl ToolRuntimeRestrictions {
+    pub fn is_tool_allowed(&self, tool_name: &str) -> bool {
+        (self.allowed_tool_names.is_empty() || self.allowed_tool_names.contains(tool_name))
+            && !self.denied_tool_names.contains(tool_name)
+    }
+
+    pub fn ensure_tool_allowed(&self, tool_name: &str) -> Result<(), ToolRestrictionError> {
+        if self.denied_tool_names.contains(tool_name) {
+            return Err(ToolRestrictionError::Denied {
+                tool_name: tool_name.to_string(),
+            });
+        }
+
+        if !self.allowed_tool_names.is_empty() && !self.allowed_tool_names.contains(tool_name) {
+            return Err(ToolRestrictionError::NotAllowed {
+                tool_name: tool_name.to_string(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolRestrictionError {
+    Denied { tool_name: String },
+    NotAllowed { tool_name: String },
+}
+
+impl fmt::Display for ToolRestrictionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Denied { tool_name } => write!(
+                formatter,
+                "Tool '{}' is denied by runtime restrictions",
+                tool_name
+            ),
+            Self::NotAllowed { tool_name } => write!(
+                formatter,
+                "Tool '{}' is not allowed by runtime restrictions",
+                tool_name
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ToolRestrictionError {}
 
 /// Validation result
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/crates/agent-tools/src/framework.rs
+++ b/src/crates/agent-tools/src/framework.rs
@@ -1,9 +1,15 @@
+use crate::{
+    DynamicToolDescriptor, DynamicToolProvider, PortError, PortErrorKind, PortResult, ToolDecorator,
+};
+use async_trait::async_trait;
 use bitfun_core_types::ToolImageAttachment;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeSet;
 use std::fmt;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Dynamic MCP tool subtype metadata.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -23,6 +29,181 @@ pub struct DynamicToolInfo {
     pub provider_kind: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp: Option<DynamicMcpToolInfo>,
+}
+
+#[async_trait]
+pub trait ToolRegistryItem: Send + Sync {
+    fn name(&self) -> &str;
+
+    async fn description(&self) -> Result<String, String>;
+
+    fn input_schema(&self) -> Value;
+
+    async fn input_schema_for_model(&self) -> Value {
+        self.input_schema()
+    }
+
+    fn dynamic_provider_id(&self) -> Option<&str> {
+        None
+    }
+
+    fn dynamic_tool_info(&self) -> Option<DynamicToolInfo> {
+        self.dynamic_provider_id()
+            .map(|provider_id| DynamicToolInfo {
+                provider_id: provider_id.to_string(),
+                provider_kind: None,
+                mcp: None,
+            })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DynamicToolMetadata {
+    provider_id: String,
+    info: DynamicToolInfo,
+}
+
+struct IdentityToolDecorator;
+
+impl<Tool> ToolDecorator<Tool> for IdentityToolDecorator {
+    fn decorate(&self, tool: Tool) -> Tool {
+        tool
+    }
+}
+
+pub type ToolRef<Tool> = Arc<Tool>;
+pub type ToolDecoratorRef<Tool> = Arc<dyn ToolDecorator<ToolRef<Tool>>>;
+
+pub struct ToolRegistry<Tool: ToolRegistryItem + ?Sized> {
+    tools: IndexMap<String, ToolRef<Tool>>,
+    dynamic_tools: IndexMap<String, DynamicToolMetadata>,
+    tool_decorator: ToolDecoratorRef<Tool>,
+}
+
+impl<Tool: ToolRegistryItem + ?Sized> Default for ToolRegistry<Tool> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Tool: ToolRegistryItem + ?Sized> ToolRegistry<Tool> {
+    pub fn new() -> Self {
+        Self::with_tool_decorator(Arc::new(IdentityToolDecorator))
+    }
+
+    pub fn with_tool_decorator(tool_decorator: ToolDecoratorRef<Tool>) -> Self {
+        Self {
+            tools: IndexMap::new(),
+            dynamic_tools: IndexMap::new(),
+            tool_decorator,
+        }
+    }
+
+    pub fn register_tool(&mut self, tool: ToolRef<Tool>) {
+        let tool = self.tool_decorator.decorate(tool);
+        let name = tool.name().to_string();
+        let dynamic_info = tool.dynamic_tool_info().and_then(|info| {
+            if info.provider_id.trim().is_empty() {
+                None
+            } else {
+                Some(info)
+            }
+        });
+
+        if let Some(info) = dynamic_info {
+            self.dynamic_tools.insert(
+                name.clone(),
+                DynamicToolMetadata {
+                    provider_id: info.provider_id.clone(),
+                    info,
+                },
+            );
+        } else {
+            self.dynamic_tools.shift_remove(&name);
+        }
+        self.tools.insert(name, tool);
+    }
+
+    pub fn unregister_mcp_server_tools(&mut self, server_id: &str) {
+        let to_remove = self
+            .dynamic_tools
+            .iter()
+            .filter(|(_, metadata)| {
+                metadata
+                    .info
+                    .mcp
+                    .as_ref()
+                    .is_some_and(|info| info.server_id == server_id)
+            })
+            .map(|(tool_name, _)| tool_name.clone())
+            .collect::<Vec<_>>();
+
+        for key in to_remove {
+            self.tools.shift_remove(&key);
+            self.dynamic_tools.shift_remove(&key);
+        }
+    }
+
+    pub fn unregister_tools_by_prefix(&mut self, prefix: &str) -> usize {
+        let to_remove = self
+            .tools
+            .keys()
+            .filter(|key| key.starts_with(prefix))
+            .cloned()
+            .collect::<Vec<_>>();
+        let count = to_remove.len();
+
+        for key in to_remove {
+            self.tools.shift_remove(&key);
+            self.dynamic_tools.shift_remove(&key);
+        }
+
+        count
+    }
+
+    pub fn get_tool(&self, name: &str) -> Option<ToolRef<Tool>> {
+        self.tools.get(name).cloned()
+    }
+
+    pub fn get_dynamic_tool_info(&self, name: &str) -> Option<DynamicToolInfo> {
+        self.dynamic_tools
+            .get(name)
+            .map(|metadata| metadata.info.clone())
+    }
+
+    pub fn get_tool_names(&self) -> Vec<String> {
+        self.tools.keys().cloned().collect()
+    }
+
+    pub fn get_all_tools(&self) -> Vec<ToolRef<Tool>> {
+        self.tools.values().cloned().collect()
+    }
+}
+
+#[async_trait]
+impl<Tool: ToolRegistryItem + ?Sized> DynamicToolProvider for ToolRegistry<Tool> {
+    async fn list_dynamic_tools(&self) -> PortResult<Vec<DynamicToolDescriptor>> {
+        let mut descriptors = Vec::new();
+
+        for (name, tool) in self.tools.iter() {
+            let Some(metadata) = self.dynamic_tools.get(name) else {
+                continue;
+            };
+            let description = tool
+                .description()
+                .await
+                .map_err(|error| PortError::new(PortErrorKind::Backend, error))?;
+
+            descriptors.push(DynamicToolDescriptor {
+                name: tool.name().to_string(),
+                description,
+                input_schema: tool.input_schema_for_model().await,
+                provider_id: Some(metadata.provider_id.clone()),
+            });
+        }
+
+        Ok(descriptors)
+    }
 }
 
 /// Tool result rendering options.

--- a/src/crates/agent-tools/src/lib.rs
+++ b/src/crates/agent-tools/src/lib.rs
@@ -7,5 +7,12 @@ pub mod framework;
 pub mod input_validator;
 
 pub use bitfun_core_types::ToolImageAttachment;
-pub use framework::{ToolResult, ValidationResult};
+pub use bitfun_runtime_ports::{
+    DynamicToolDescriptor, DynamicToolProvider, PortError, PortErrorKind, PortResult, ToolDecorator,
+};
+pub use framework::{
+    DynamicMcpToolInfo, DynamicToolInfo, ToolPathBackend, ToolPathOperation, ToolPathPolicy,
+    ToolPathResolution, ToolRenderOptions, ToolRestrictionError, ToolResult,
+    ToolRuntimeRestrictions, ValidationResult,
+};
 pub use input_validator::InputValidator;

--- a/src/crates/agent-tools/src/lib.rs
+++ b/src/crates/agent-tools/src/lib.rs
@@ -12,7 +12,7 @@ pub use bitfun_runtime_ports::{
 };
 pub use framework::{
     DynamicMcpToolInfo, DynamicToolInfo, ToolPathBackend, ToolPathOperation, ToolPathPolicy,
-    ToolPathResolution, ToolRenderOptions, ToolRestrictionError, ToolResult,
-    ToolRuntimeRestrictions, ValidationResult,
+    ToolPathResolution, ToolRef, ToolRegistry, ToolRegistryItem, ToolRenderOptions,
+    ToolRestrictionError, ToolResult, ToolRuntimeRestrictions, ValidationResult,
 };
 pub use input_validator::InputValidator;

--- a/src/crates/agent-tools/tests/tool_contracts.rs
+++ b/src/crates/agent-tools/tests/tool_contracts.rs
@@ -1,5 +1,10 @@
-use bitfun_agent_tools::{InputValidator, ToolImageAttachment, ToolResult, ValidationResult};
+use bitfun_agent_tools::{
+    DynamicMcpToolInfo, DynamicToolInfo, InputValidator, ToolImageAttachment, ToolPathBackend,
+    ToolPathResolution, ToolRenderOptions, ToolResult, ToolRuntimeRestrictions, ValidationResult,
+};
+use bitfun_agent_tools::{DynamicToolDescriptor, DynamicToolProvider, PortResult, ToolDecorator};
 use serde_json::json;
+use std::path::PathBuf;
 
 #[test]
 fn validation_result_default_preserves_success_contract() {
@@ -57,4 +62,160 @@ fn tool_image_attachment_keeps_wire_shape_without_ai_adapter_dependency() {
         }
         other => panic!("expected image result, got {other:?}"),
     }
+}
+
+#[test]
+fn dynamic_tool_info_keeps_provider_and_mcp_metadata_without_core_dependency() {
+    let info = DynamicToolInfo {
+        provider_id: "github-server-id".to_string(),
+        provider_kind: Some("mcp".to_string()),
+        mcp: Some(DynamicMcpToolInfo {
+            server_id: "github-server-id".to_string(),
+            server_name: "GitHub".to_string(),
+            tool_name: "search_repos".to_string(),
+        }),
+    };
+
+    let value = serde_json::to_value(&info).expect("serialize dynamic info");
+
+    assert_eq!(value["providerId"], "github-server-id");
+    assert_eq!(value["providerKind"], "mcp");
+    assert_eq!(value["mcp"]["serverId"], "github-server-id");
+    assert_eq!(value["mcp"]["serverName"], "GitHub");
+    assert_eq!(value["mcp"]["toolName"], "search_repos");
+
+    let round_trip: DynamicToolInfo =
+        serde_json::from_value(value).expect("deserialize dynamic info");
+    assert_eq!(round_trip.provider_id, "github-server-id");
+    assert_eq!(round_trip.provider_kind.as_deref(), Some("mcp"));
+    assert_eq!(
+        round_trip.mcp.as_ref().map(|mcp| mcp.tool_name.as_str()),
+        Some("search_repos")
+    );
+}
+
+#[test]
+fn tool_render_options_stays_a_lightweight_contract() {
+    let options = ToolRenderOptions { verbose: true };
+
+    assert!(options.verbose);
+}
+
+#[test]
+fn runtime_restrictions_keep_allow_deny_semantics_without_core_dependency() {
+    let restrictions = ToolRuntimeRestrictions {
+        allowed_tool_names: ["Read", "Write"].into_iter().map(str::to_string).collect(),
+        denied_tool_names: ["Write"].into_iter().map(str::to_string).collect(),
+        path_policy: Default::default(),
+    };
+
+    assert!(restrictions.is_tool_allowed("Read"));
+    assert!(!restrictions.is_tool_allowed("Write"));
+    assert!(!restrictions.is_tool_allowed("Bash"));
+
+    let denied = restrictions
+        .ensure_tool_allowed("Write")
+        .expect_err("deny list must override allow list");
+    assert_eq!(
+        denied.to_string(),
+        "Tool 'Write' is denied by runtime restrictions"
+    );
+
+    let not_allowed = restrictions
+        .ensure_tool_allowed("Bash")
+        .expect_err("non-empty allow list must reject missing tools");
+    assert_eq!(
+        not_allowed.to_string(),
+        "Tool 'Bash' is not allowed by runtime restrictions"
+    );
+}
+
+#[test]
+fn runtime_restrictions_keep_current_snake_case_wire_shape() {
+    let value = json!({
+        "allowed_tool_names": ["Read"],
+        "denied_tool_names": ["Write"],
+        "path_policy": {
+            "write_roots": ["src"],
+            "edit_roots": ["docs"],
+            "delete_roots": ["target/generated"]
+        }
+    });
+
+    let restrictions: ToolRuntimeRestrictions =
+        serde_json::from_value(value.clone()).expect("deserialize restrictions");
+    assert!(restrictions.is_tool_allowed("Read"));
+    assert!(!restrictions.is_tool_allowed("Write"));
+    assert_eq!(restrictions.path_policy.write_roots, vec!["src"]);
+    assert_eq!(restrictions.path_policy.edit_roots, vec!["docs"]);
+    assert_eq!(
+        restrictions.path_policy.delete_roots,
+        vec!["target/generated"]
+    );
+
+    let round_trip = serde_json::to_value(&restrictions).expect("serialize restrictions");
+    assert_eq!(round_trip, value);
+}
+
+#[test]
+fn path_resolution_contract_keeps_backend_and_runtime_helpers() {
+    let remote = ToolPathResolution {
+        requested_path: "src/lib.rs".to_string(),
+        logical_path: "/workspace/src/lib.rs".to_string(),
+        resolved_path: "/workspace/src/lib.rs".to_string(),
+        backend: ToolPathBackend::RemoteWorkspace,
+        runtime_scope: None,
+        runtime_root: None,
+    };
+    assert!(remote.uses_remote_workspace_backend());
+    assert!(!remote.is_runtime_artifact());
+
+    let runtime_root = PathBuf::from("/runtime/workspace");
+    let runtime = ToolPathResolution {
+        requested_path: "bitfun://runtime/workspace-1/logs/tool.txt".to_string(),
+        logical_path: "bitfun://runtime/workspace-1/logs/tool.txt".to_string(),
+        resolved_path: runtime_root
+            .join("logs")
+            .join("tool.txt")
+            .display()
+            .to_string(),
+        backend: ToolPathBackend::Local,
+        runtime_scope: Some("workspace-1".to_string()),
+        runtime_root: Some(runtime_root.clone()),
+    };
+
+    assert!(!runtime.uses_remote_workspace_backend());
+    assert!(runtime.is_runtime_artifact());
+    assert_eq!(
+        runtime.logical_child_path(&runtime_root.join("logs").join("tool.txt")),
+        Some("bitfun://runtime/workspace-1/logs/tool.txt".to_string())
+    );
+    assert_eq!(
+        runtime.logical_child_path(&PathBuf::from("/outside/tool.txt")),
+        None
+    );
+}
+
+#[test]
+fn dynamic_tool_provider_contract_is_available_from_agent_tools_boundary() {
+    fn assert_provider_contract<T: DynamicToolProvider>() {}
+    fn assert_decorator_contract<T: ToolDecorator<String>>() {}
+
+    struct MarkerProvider;
+    #[async_trait::async_trait]
+    impl DynamicToolProvider for MarkerProvider {
+        async fn list_dynamic_tools(&self) -> PortResult<Vec<DynamicToolDescriptor>> {
+            Ok(Vec::new())
+        }
+    }
+
+    struct MarkerDecorator;
+    impl ToolDecorator<String> for MarkerDecorator {
+        fn decorate(&self, tool: String) -> String {
+            tool
+        }
+    }
+
+    assert_provider_contract::<MarkerProvider>();
+    assert_decorator_contract::<MarkerDecorator>();
 }

--- a/src/crates/agent-tools/tests/tool_contracts.rs
+++ b/src/crates/agent-tools/tests/tool_contracts.rs
@@ -2,9 +2,13 @@ use bitfun_agent_tools::{
     DynamicMcpToolInfo, DynamicToolInfo, InputValidator, ToolImageAttachment, ToolPathBackend,
     ToolPathResolution, ToolRenderOptions, ToolResult, ToolRuntimeRestrictions, ValidationResult,
 };
-use bitfun_agent_tools::{DynamicToolDescriptor, DynamicToolProvider, PortResult, ToolDecorator};
+use bitfun_agent_tools::{
+    DynamicToolDescriptor, DynamicToolProvider, PortResult, ToolDecorator, ToolRegistry,
+    ToolRegistryItem,
+};
 use serde_json::json;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 #[test]
 fn validation_result_default_preserves_success_contract() {
@@ -218,4 +222,97 @@ fn dynamic_tool_provider_contract_is_available_from_agent_tools_boundary() {
 
     assert_provider_contract::<MarkerProvider>();
     assert_decorator_contract::<MarkerDecorator>();
+}
+
+struct RegistryMarkerTool {
+    name: String,
+    provider_id: Option<String>,
+}
+
+#[async_trait::async_trait]
+impl ToolRegistryItem for RegistryMarkerTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn description(&self) -> Result<String, String> {
+        Ok("marker tool".to_string())
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        json!({ "type": "object" })
+    }
+
+    async fn input_schema_for_model(&self) -> serde_json::Value {
+        self.input_schema()
+    }
+
+    fn dynamic_tool_info(&self) -> Option<DynamicToolInfo> {
+        self.provider_id
+            .as_ref()
+            .map(|provider_id| DynamicToolInfo {
+                provider_id: provider_id.clone(),
+                provider_kind: None,
+                mcp: None,
+            })
+    }
+}
+
+fn registry_marker_tool(name: &str, provider_id: Option<&str>) -> Arc<RegistryMarkerTool> {
+    Arc::new(RegistryMarkerTool {
+        name: name.to_string(),
+        provider_id: provider_id.map(str::to_string),
+    })
+}
+
+#[tokio::test]
+async fn generic_tool_registry_preserves_dynamic_descriptor_contract() {
+    let mut registry = ToolRegistry::new();
+    registry.register_tool(registry_marker_tool("external_search", Some("provider-a")));
+    registry.register_tool(registry_marker_tool("local_docs", Some("provider-b")));
+    registry.register_tool(registry_marker_tool("static_tool", None));
+
+    assert_eq!(
+        registry.get_tool_names(),
+        vec!["external_search", "local_docs", "static_tool"]
+    );
+    assert_eq!(
+        registry
+            .get_dynamic_tool_info("external_search")
+            .expect("dynamic metadata")
+            .provider_id,
+        "provider-a"
+    );
+
+    let descriptors = registry
+        .list_dynamic_tools()
+        .await
+        .expect("list dynamic tools");
+    assert_eq!(
+        descriptors
+            .iter()
+            .map(|descriptor| (descriptor.name.as_str(), descriptor.provider_id.as_deref()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("external_search", Some("provider-a")),
+            ("local_docs", Some("provider-b")),
+        ]
+    );
+    assert_eq!(descriptors[0].description, "marker tool");
+    assert_eq!(descriptors[0].input_schema, json!({ "type": "object" }));
+}
+
+#[tokio::test]
+async fn generic_tool_registry_clears_stale_dynamic_metadata_on_overwrite() {
+    let mut registry = ToolRegistry::new();
+    registry.register_tool(registry_marker_tool("external_search", Some("provider-a")));
+
+    registry.register_tool(registry_marker_tool("external_search", None));
+
+    assert!(registry.get_dynamic_tool_info("external_search").is_none());
+    let descriptors = registry
+        .list_dynamic_tools()
+        .await
+        .expect("list dynamic tools");
+    assert!(descriptors.is_empty());
 }

--- a/src/crates/core/AGENTS-CN.md
+++ b/src/crates/core/AGENTS-CN.md
@@ -28,11 +28,17 @@ SessionManager → Session → DialogTurn → ModelRound
 - 避免引入 `tauri::AppHandle` 等宿主 API
 - 使用 `bitfun_events::EventEmitter` 等共享抽象
 - 桌面端专属集成应放在 `src/apps/desktop`，再通过 transport / API layer 连接回来
+- core 拆解期间，`bitfun-core` 是兼容 facade 与完整产品 runtime assembly 点；新模块优先放到 `docs/architecture/core-decomposition.md` 指定的 owner crate。
+- Tool 相关轻量 contract 与 generic registry/provider container 归属 `bitfun-agent-tools`；core registry 只负责产品工具组装、`dyn Tool` 适配和 snapshot decoration。
+- `ToolUseContext` 与具体工具实现继续留在 core，除非已有评审过的 port/provider 方案和等价测试。
+- 不要在没有小型 port/interface 边界的情况下新增 `service` 到 `agentic` 的跨层引用。
+- 不要在 core 拆解中把平台专属逻辑、构建脚本行为或产品能力选择下沉到 shared core。
 
 这里已经有更细粒度规则：
 
 - `src/crates/ai-adapters/AGENTS.md`
 - `src/agentic/execution/AGENTS.md`
+- `src/agentic/deep_review/AGENTS.md`
 
 ## 命令
 

--- a/src/crates/core/AGENTS.md
+++ b/src/crates/core/AGENTS.md
@@ -31,6 +31,11 @@ SessionManager → Session → DialogTurn → ModelRound
 - During core decomposition, `bitfun-core` is a compatibility facade and full
   product runtime assembly point. New modules should prefer the extracted owner
   crate listed in `docs/architecture/core-decomposition.md`.
+- For tools, keep lightweight contracts and generic registry/provider container
+  logic in `bitfun-agent-tools`. Core registry should only assemble product
+  tools, adapt `dyn Tool`, and apply snapshot decoration.
+- Keep `ToolUseContext` and concrete tool implementations in core unless a
+  reviewed port/provider plan and equivalence tests exist.
 - Do not add new cross-layer references from `service` to `agentic` without a
   small port/interface boundary.
 - Do not move platform-specific logic, build-script behavior, or product

--- a/src/crates/core/src/agentic/tools/framework.rs
+++ b/src/crates/core/src/agentic/tools/framework.rs
@@ -14,59 +14,20 @@ use crate::agentic::workspace::WorkspaceServices;
 use crate::agentic::WorkspaceBinding;
 use crate::infrastructure::get_path_manager_arc;
 use crate::service::git::{GitDiffParams, GitService};
-use crate::service::mcp::McpToolInfo;
 use crate::service::remote_ssh::workspace_state::remote_workspace_runtime_root;
 use crate::service::{get_workspace_runtime_service_arc, WorkspaceRuntimeContext};
 use crate::util::errors::BitFunResult;
 use async_trait::async_trait;
-pub use bitfun_agent_tools::{ToolResult, ValidationResult};
+pub use bitfun_agent_tools::{
+    DynamicMcpToolInfo, DynamicToolInfo, ToolPathBackend, ToolPathResolution, ToolRenderOptions,
+    ToolResult, ValidationResult,
+};
 use log::warn;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ToolPathBackend {
-    Local,
-    RemoteWorkspace,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DynamicToolInfo {
-    pub provider_id: String,
-    pub provider_kind: Option<String>,
-    pub mcp: Option<McpToolInfo>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ToolPathResolution {
-    pub requested_path: String,
-    pub logical_path: String,
-    pub resolved_path: String,
-    pub backend: ToolPathBackend,
-    pub runtime_scope: Option<String>,
-    pub runtime_root: Option<PathBuf>,
-}
-
-impl ToolPathResolution {
-    pub fn uses_remote_workspace_backend(&self) -> bool {
-        matches!(self.backend, ToolPathBackend::RemoteWorkspace)
-    }
-
-    pub fn is_runtime_artifact(&self) -> bool {
-        self.runtime_scope.is_some()
-    }
-
-    pub fn logical_child_path(&self, absolute_child_path: &Path) -> Option<String> {
-        let scope = self.runtime_scope.as_deref()?;
-        let root = self.runtime_root.as_ref()?;
-        let relative = absolute_child_path.strip_prefix(root).ok()?;
-        let relative_str = relative.to_string_lossy().replace('\\', "/");
-        build_bitfun_runtime_uri(scope, &relative_str).ok()
-    }
-}
 
 /// Tool use context
 #[derive(Debug, Clone)]
@@ -212,6 +173,7 @@ impl ToolUseContext {
     pub fn enforce_tool_runtime_restrictions(&self, tool_name: &str) -> BitFunResult<()> {
         self.runtime_tool_restrictions
             .ensure_tool_allowed(tool_name)
+            .map_err(Into::into)
     }
 
     pub fn enforce_path_operation(
@@ -725,12 +687,6 @@ pub trait Tool: Send + Sync {
         }
         result
     }
-}
-
-/// Tool render options
-#[derive(Debug, Clone)]
-pub struct ToolRenderOptions {
-    pub verbose: bool,
 }
 
 #[cfg(test)]

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -778,7 +778,7 @@ impl ToolPipeline {
                 )
                 .await;
 
-            return Err(err);
+            return Err(err.into());
         }
 
         let tool = {

--- a/src/crates/core/src/agentic/tools/registry.rs
+++ b/src/crates/core/src/agentic/tools/registry.rs
@@ -3,7 +3,9 @@
 use crate::agentic::tools::framework::{DynamicToolInfo, Tool};
 use crate::agentic::tools::implementations::*;
 use crate::util::errors::BitFunResult;
-use bitfun_runtime_ports::{DynamicToolDescriptor, DynamicToolProvider, ToolDecorator};
+use bitfun_agent_tools::{
+    DynamicToolDescriptor, DynamicToolProvider, PortError, PortErrorKind, PortResult, ToolDecorator,
+};
 use indexmap::IndexMap;
 use log::{debug, info, trace, warn};
 use std::sync::Arc;
@@ -265,21 +267,17 @@ impl ToolRegistry {
 
 #[async_trait::async_trait]
 impl DynamicToolProvider for ToolRegistry {
-    async fn list_dynamic_tools(
-        &self,
-    ) -> bitfun_runtime_ports::PortResult<Vec<DynamicToolDescriptor>> {
+    async fn list_dynamic_tools(&self) -> PortResult<Vec<DynamicToolDescriptor>> {
         let mut descriptors = Vec::new();
 
         for (name, tool) in self.tools.iter() {
             let Some(metadata) = self.dynamic_tools.get(name) else {
                 continue;
             };
-            let description = tool.description().await.map_err(|error| {
-                bitfun_runtime_ports::PortError::new(
-                    bitfun_runtime_ports::PortErrorKind::Backend,
-                    error.to_string(),
-                )
-            })?;
+            let description = tool
+                .description()
+                .await
+                .map_err(|error| PortError::new(PortErrorKind::Backend, error.to_string()))?;
 
             descriptors.push(DynamicToolDescriptor {
                 name: tool.name().to_string(),
@@ -299,10 +297,10 @@ mod tests {
     use super::ToolRef;
     use super::ToolRegistry;
     use crate::agentic::tools::framework::{
-        DynamicToolInfo, Tool, ToolResult, ToolUseContext, ValidationResult,
+        DynamicMcpToolInfo, DynamicToolInfo, Tool, ToolResult, ToolUseContext, ValidationResult,
     };
     use async_trait::async_trait;
-    use bitfun_runtime_ports::DynamicToolProvider;
+    use bitfun_agent_tools::DynamicToolProvider;
     use serde_json::json;
     use serde_json::Value;
     use std::sync::Arc;
@@ -381,7 +379,7 @@ mod tests {
             dynamic_info: Some(DynamicToolInfo {
                 provider_id: server_id.to_string(),
                 provider_kind: Some("mcp".to_string()),
-                mcp: Some(crate::service::mcp::McpToolInfo {
+                mcp: Some(DynamicMcpToolInfo {
                     server_id: server_id.to_string(),
                     server_name: server_name.to_string(),
                     tool_name: tool_name.to_string(),
@@ -525,6 +523,76 @@ mod tests {
         assert_eq!(
             descriptors[0].provider_id.as_deref(),
             Some("github__enterprise/prod")
+        );
+    }
+
+    #[tokio::test]
+    async fn dynamic_tool_provider_preserves_descriptor_shape_and_order() {
+        let mut registry = ToolRegistry::new();
+        registry.register_tool(dynamic_tool("external_search", Some("provider-a")));
+        registry.register_tool(dynamic_tool("local_docs", Some("provider-b")));
+
+        let descriptors = registry
+            .list_dynamic_tools()
+            .await
+            .expect("list dynamic tools");
+
+        let dynamic_descriptors = descriptors
+            .iter()
+            .map(|descriptor| {
+                (
+                    descriptor.name.as_str(),
+                    descriptor.description.as_str(),
+                    descriptor.input_schema.clone(),
+                    descriptor.provider_id.as_deref(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            dynamic_descriptors,
+            vec![
+                (
+                    "external_search",
+                    "dynamic test tool",
+                    json!({ "type": "object" }),
+                    Some("provider-a"),
+                ),
+                (
+                    "local_docs",
+                    "dynamic test tool",
+                    json!({ "type": "object" }),
+                    Some("provider-b"),
+                ),
+            ],
+            "dynamic descriptor shape and registration order must remain stable before provider owner migration"
+        );
+    }
+
+    #[tokio::test]
+    async fn registering_static_tool_clears_stale_dynamic_metadata_for_same_name() {
+        let mut registry = ToolRegistry::new();
+        registry.register_tool(dynamic_tool("external_search", Some("provider-a")));
+        assert!(
+            registry.get_dynamic_tool_info("external_search").is_some(),
+            "dynamic metadata should be registered before overwrite"
+        );
+
+        registry.register_tool(dynamic_tool("external_search", None));
+
+        assert!(
+            registry.get_dynamic_tool_info("external_search").is_none(),
+            "stale dynamic metadata must be removed when a static tool overwrites a dynamic tool"
+        );
+        let descriptors = registry
+            .list_dynamic_tools()
+            .await
+            .expect("list dynamic tools");
+        assert!(
+            descriptors
+                .iter()
+                .all(|descriptor| descriptor.name != "external_search"),
+            "stale dynamic descriptor must not leak after static overwrite"
         );
     }
 

--- a/src/crates/core/src/agentic/tools/registry.rs
+++ b/src/crates/core/src/agentic/tools/registry.rs
@@ -4,20 +4,15 @@ use crate::agentic::tools::framework::{DynamicToolInfo, Tool};
 use crate::agentic::tools::implementations::*;
 use crate::util::errors::BitFunResult;
 use bitfun_agent_tools::{
-    DynamicToolDescriptor, DynamicToolProvider, PortError, PortErrorKind, PortResult, ToolDecorator,
+    DynamicToolDescriptor, DynamicToolProvider, PortResult, ToolDecorator,
+    ToolRegistry as AgentToolRegistry, ToolRegistryItem,
 };
-use indexmap::IndexMap;
 use log::{debug, info, trace, warn};
+use serde_json::Value;
 use std::sync::Arc;
 
 type ToolRef = Arc<dyn Tool>;
 type ToolDecoratorRef = Arc<dyn ToolDecorator<ToolRef>>;
-
-#[derive(Debug, Clone)]
-struct DynamicToolMetadata {
-    provider_id: String,
-    info: DynamicToolInfo,
-}
 
 struct SnapshotToolDecorator;
 
@@ -29,9 +24,7 @@ impl ToolDecorator<ToolRef> for SnapshotToolDecorator {
 
 /// Tool registry - manages all available tools (using IndexMap to maintain registration order)
 pub struct ToolRegistry {
-    tools: IndexMap<String, ToolRef>,
-    dynamic_tools: IndexMap<String, DynamicToolMetadata>,
-    tool_decorator: ToolDecoratorRef,
+    inner: AgentToolRegistry<dyn Tool>,
 }
 
 impl Default for ToolRegistry {
@@ -53,9 +46,7 @@ impl ToolRegistry {
     /// through the `bitfun-runtime-ports` interface.
     pub fn with_tool_decorator(tool_decorator: ToolDecoratorRef) -> Self {
         let mut registry = Self {
-            tools: IndexMap::new(),
-            dynamic_tools: IndexMap::new(),
-            tool_decorator,
+            inner: AgentToolRegistry::with_tool_decorator(tool_decorator),
         };
 
         // Register all tools
@@ -68,7 +59,7 @@ impl ToolRegistry {
         let tool_count = tools.len();
         info!("Registering MCP tools: count={}", tool_count);
 
-        let before_count = self.tools.len();
+        let before_count = self.get_tool_names().len();
         debug!("Tool count before registration: {}", before_count);
 
         for (index, tool) in tools.into_iter().enumerate() {
@@ -81,7 +72,7 @@ impl ToolRegistry {
             );
 
             // Check if a tool with the same name already exists
-            if self.tools.contains_key(&name) {
+            if self.get_tool(&name).is_some() {
                 warn!(
                     "Tool already exists, will be overwritten: tool_name={}",
                     name
@@ -92,7 +83,7 @@ impl ToolRegistry {
             debug!("MCP tool registered: tool_name={}", name);
         }
 
-        let after_count = self.tools.len();
+        let after_count = self.get_tool_names().len();
         let added_count = after_count - before_count;
 
         info!(
@@ -103,41 +94,36 @@ impl ToolRegistry {
 
     /// Remove all tools from the MCP server
     pub fn unregister_mcp_server_tools(&mut self, server_id: &str) {
-        let to_remove: Vec<String> = self
-            .dynamic_tools
-            .iter()
-            .filter(|(_, metadata)| {
-                metadata
-                    .info
-                    .mcp
-                    .as_ref()
-                    .is_some_and(|info| info.server_id == server_id)
+        let removed_tool_names = self
+            .get_tool_names()
+            .into_iter()
+            .filter(|name| {
+                self.get_dynamic_tool_info(name)
+                    .and_then(|info| info.mcp)
+                    .is_some_and(|mcp| mcp.server_id == server_id)
             })
-            .map(|(tool_name, _)| tool_name.clone())
-            .collect();
+            .collect::<Vec<_>>();
 
-        for key in to_remove {
+        self.inner.unregister_mcp_server_tools(server_id);
+
+        for key in removed_tool_names {
             info!("Unregistering dynamic tool: tool_name={}", key);
-            self.tools.shift_remove(&key);
-            self.dynamic_tools.shift_remove(&key);
         }
     }
 
     /// Remove all tools whose registry name starts with the given prefix.
     pub fn unregister_tools_by_prefix(&mut self, prefix: &str) -> usize {
-        let to_remove: Vec<String> = self
-            .tools
-            .keys()
-            .filter(|k| k.starts_with(prefix))
-            .cloned()
-            .collect();
-        let count = to_remove.len();
+        let removed_tool_names = self
+            .get_tool_names()
+            .into_iter()
+            .filter(|name| name.starts_with(prefix))
+            .collect::<Vec<_>>();
+        let count = self.inner.unregister_tools_by_prefix(prefix);
 
-        for key in to_remove {
+        for key in removed_tool_names {
             info!("Unregistering dynamic tool: tool_name={}", key);
-            self.tools.shift_remove(&key);
-            self.dynamic_tools.shift_remove(&key);
         }
+
         count
     }
 
@@ -213,81 +199,66 @@ impl ToolRegistry {
 
     /// Register a single tool
     pub fn register_tool(&mut self, tool: ToolRef) {
-        // Snapshot-aware wrapping happens once at registration time so every
-        // subsequent lookup returns the same runtime implementation.
-        let tool = self.tool_decorator.decorate(tool);
-        let name = tool.name().to_string();
-        let dynamic_info = tool.dynamic_tool_info().and_then(|info| {
-            if info.provider_id.trim().is_empty() {
-                None
-            } else {
-                Some(info)
-            }
-        });
-
-        if let Some(info) = dynamic_info {
-            self.dynamic_tools.insert(
-                name.clone(),
-                DynamicToolMetadata {
-                    provider_id: info.provider_id.clone(),
-                    info,
-                },
-            );
-        } else {
-            self.dynamic_tools.shift_remove(&name);
-        }
-        self.tools.insert(name, tool);
+        self.inner.register_tool(tool);
     }
 
     /// Get tool
     pub fn get_tool(&self, name: &str) -> Option<Arc<dyn Tool>> {
-        self.tools.get(name).cloned()
+        self.inner.get_tool(name)
     }
 
     pub fn get_dynamic_tool_info(&self, name: &str) -> Option<DynamicToolInfo> {
-        self.dynamic_tools
-            .get(name)
-            .map(|metadata| metadata.info.clone())
+        self.inner.get_dynamic_tool_info(name)
     }
 
     /// Get all tool names
     pub fn get_tool_names(&self) -> Vec<String> {
-        self.tools.keys().cloned().collect()
+        self.inner.get_tool_names()
     }
 
     /// Get all tools
     pub fn get_all_tools(&self) -> Vec<Arc<dyn Tool>> {
         trace!(
             "ToolRegistry::get_all_tools() called: total={}",
-            self.tools.len()
+            self.get_tool_names().len()
         );
-        self.tools.values().cloned().collect()
+        self.inner.get_all_tools()
     }
 }
 
 #[async_trait::async_trait]
 impl DynamicToolProvider for ToolRegistry {
     async fn list_dynamic_tools(&self) -> PortResult<Vec<DynamicToolDescriptor>> {
-        let mut descriptors = Vec::new();
+        self.inner.list_dynamic_tools().await
+    }
+}
 
-        for (name, tool) in self.tools.iter() {
-            let Some(metadata) = self.dynamic_tools.get(name) else {
-                continue;
-            };
-            let description = tool
-                .description()
-                .await
-                .map_err(|error| PortError::new(PortErrorKind::Backend, error.to_string()))?;
+#[async_trait::async_trait]
+impl ToolRegistryItem for dyn Tool {
+    fn name(&self) -> &str {
+        Tool::name(self)
+    }
 
-            descriptors.push(DynamicToolDescriptor {
-                name: tool.name().to_string(),
-                description,
-                input_schema: tool.input_schema_for_model().await,
-                provider_id: Some(metadata.provider_id.clone()),
-            });
-        }
+    async fn description(&self) -> Result<String, String> {
+        Tool::description(self)
+            .await
+            .map_err(|error| error.to_string())
+    }
 
-        Ok(descriptors)
+    fn input_schema(&self) -> Value {
+        Tool::input_schema(self)
+    }
+
+    async fn input_schema_for_model(&self) -> Value {
+        Tool::input_schema_for_model(self).await
+    }
+
+    fn dynamic_provider_id(&self) -> Option<&str> {
+        Tool::dynamic_provider_id(self)
+    }
+
+    fn dynamic_tool_info(&self) -> Option<DynamicToolInfo> {
+        Tool::dynamic_tool_info(self)
     }
 }
 

--- a/src/crates/core/src/agentic/tools/restrictions.rs
+++ b/src/crates/core/src/agentic/tools/restrictions.rs
@@ -1,81 +1,12 @@
 use crate::util::errors::{BitFunError, BitFunResult};
-use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+pub use bitfun_agent_tools::{
+    ToolPathOperation, ToolPathPolicy, ToolRestrictionError, ToolRuntimeRestrictions,
+};
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum ToolPathOperation {
-    Write,
-    Edit,
-    Delete,
-}
-
-impl ToolPathOperation {
-    pub fn verb(self) -> &'static str {
-        match self {
-            Self::Write => "write",
-            Self::Edit => "edit",
-            Self::Delete => "delete",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ToolPathPolicy {
-    #[serde(default)]
-    pub write_roots: Vec<String>,
-    #[serde(default)]
-    pub edit_roots: Vec<String>,
-    #[serde(default)]
-    pub delete_roots: Vec<String>,
-}
-
-impl ToolPathPolicy {
-    pub fn roots_for(&self, operation: ToolPathOperation) -> &[String] {
-        match operation {
-            ToolPathOperation::Write => &self.write_roots,
-            ToolPathOperation::Edit => &self.edit_roots,
-            ToolPathOperation::Delete => &self.delete_roots,
-        }
-    }
-
-    pub fn is_restricted(&self, operation: ToolPathOperation) -> bool {
-        !self.roots_for(operation).is_empty()
-    }
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ToolRuntimeRestrictions {
-    #[serde(default)]
-    pub allowed_tool_names: BTreeSet<String>,
-    #[serde(default)]
-    pub denied_tool_names: BTreeSet<String>,
-    #[serde(default)]
-    pub path_policy: ToolPathPolicy,
-}
-
-impl ToolRuntimeRestrictions {
-    pub fn is_tool_allowed(&self, tool_name: &str) -> bool {
-        (self.allowed_tool_names.is_empty() || self.allowed_tool_names.contains(tool_name))
-            && !self.denied_tool_names.contains(tool_name)
-    }
-
-    pub fn ensure_tool_allowed(&self, tool_name: &str) -> BitFunResult<()> {
-        if self.denied_tool_names.contains(tool_name) {
-            return Err(BitFunError::validation(format!(
-                "Tool '{}' is denied by runtime restrictions",
-                tool_name
-            )));
-        }
-
-        if !self.allowed_tool_names.is_empty() && !self.allowed_tool_names.contains(tool_name) {
-            return Err(BitFunError::validation(format!(
-                "Tool '{}' is not allowed by runtime restrictions",
-                tool_name
-            )));
-        }
-
-        Ok(())
+impl From<ToolRestrictionError> for BitFunError {
+    fn from(error: ToolRestrictionError) -> Self {
+        BitFunError::validation(error.to_string())
     }
 }
 

--- a/src/crates/core/src/service/mcp/adapter/tool.rs
+++ b/src/crates/core/src/service/mcp/adapter/tool.rs
@@ -3,7 +3,8 @@
 //! Wraps MCP tools as implementations of BitFun's `Tool` trait.
 
 use crate::agentic::tools::framework::{
-    DynamicToolInfo, Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
+    DynamicMcpToolInfo, DynamicToolInfo, Tool, ToolRenderOptions, ToolResult, ToolUseContext,
+    ValidationResult,
 };
 use crate::service::mcp::protocol::{MCPTool, MCPToolResult};
 use crate::service::mcp::server::MCPConnection;
@@ -91,7 +92,11 @@ impl Tool for MCPToolWrapper {
         Some(DynamicToolInfo {
             provider_id: self.descriptor.provider_id.clone(),
             provider_kind: Some(self.descriptor.provider_kind.clone()),
-            mcp: Some(self.descriptor.tool_info.clone()),
+            mcp: Some(DynamicMcpToolInfo {
+                server_id: self.descriptor.tool_info.server_id.clone(),
+                server_name: self.descriptor.tool_info.server_name.clone(),
+                tool_name: self.descriptor.tool_info.tool_name.clone(),
+            }),
         })
     }
 

--- a/src/crates/runtime-ports/src/lib.rs
+++ b/src/crates/runtime-ports/src/lib.rs
@@ -264,4 +264,36 @@ mod tests {
         assert_eq!(json["turnId"], "turn_1");
         assert!(json.get("fromTurnId").is_none());
     }
+
+    #[test]
+    fn dynamic_tool_descriptor_serializes_current_wire_shape() {
+        let descriptor = DynamicToolDescriptor {
+            name: "external_search".to_string(),
+            description: "Search external docs".to_string(),
+            input_schema: serde_json::json!({ "type": "object" }),
+            provider_id: Some("provider-a".to_string()),
+        };
+
+        let json = serde_json::to_value(descriptor).expect("serialize descriptor");
+
+        assert_eq!(json["name"], "external_search");
+        assert_eq!(json["description"], "Search external docs");
+        assert_eq!(json["inputSchema"]["type"], "object");
+        assert_eq!(json["providerId"], "provider-a");
+        assert!(json.get("provider_id").is_none());
+    }
+
+    #[test]
+    fn dynamic_tool_descriptor_omits_missing_provider_id() {
+        let descriptor = DynamicToolDescriptor {
+            name: "local_tool".to_string(),
+            description: "Local tool".to_string(),
+            input_schema: serde_json::json!({ "type": "object" }),
+            provider_id: None,
+        };
+
+        let json = serde_json::to_value(descriptor).expect("serialize descriptor");
+
+        assert!(json.get("providerId").is_none());
+    }
 }


### PR DESCRIPTION
﻿## Summary

- Move lightweight tool contracts plus the generic tool registry / dynamic-provider container into `bitfun-agent-tools`.
- Keep `bitfun-core` registry as product runtime assembly: builtin tool list, `dyn Tool` adapter, snapshot decoration, and legacy compatibility paths.
- Add boundary checks and concise docs/AGENTS guidance so `ToolUseContext` and concrete tool implementations stay core-owned until a reviewed port/provider design and equivalence tests exist.

## Guardrails

- No concrete tool implementation or `ToolUseContext` migration in this PR.
- No product feature matrix, default feature, build script, or release script changes.
- Dynamic tool metadata, descriptor shape/order, readonly/builtin tool lists, and snapshot wrapping remain covered by tests.

## Validation

- `node scripts/check-core-boundaries.mjs`
- `rustfmt --edition 2021 --check src\crates\agent-tools\src\framework.rs src\crates\agent-tools\src\lib.rs src\crates\agent-tools\tests\tool_contracts.rs src\crates\core\src\agentic\tools\framework.rs src\crates\core\src\agentic\tools\registry.rs src\crates\core\src\agentic\tools\restrictions.rs src\crates\core\src\agentic\tools\pipeline\tool_pipeline.rs src\crates\runtime-ports\src\lib.rs`
- `git diff --check gcwing/main..HEAD`
- `cargo test -p bitfun-agent-tools`
- `cargo test -p bitfun-runtime-ports`
- `cargo test -p bitfun-core registry_ --lib`
- `cargo test -p bitfun-core dynamic_tool_provider_ --lib`
- `cargo check --workspace` (passes with existing `bitfun-cli` unused `Read` warning)
- `cargo test --workspace` (passes with existing `bitfun-cli` unused `Read` warning)
