### PR TITLE
feat(ssh): stable connection IDs and session hydration after port changes

### DIFF
--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -315,6 +315,11 @@ impl ConversationCoordinator {
     /// If the global remote workspace is active and matches the session path,
     /// returns a `WorkspaceBinding` with remote metadata and correct local
     /// session storage path.
+    ///
+    /// When the session's `remote_connection_id` does not match any active
+    /// SSH connection (e.g. the user changed the port and the old ID is now
+    /// stale), this method attempts to remap to the current workspace
+    /// registration so that historical sessions continue to work.
     async fn build_workspace_binding(config: &SessionConfig) -> Option<WorkspaceBinding> {
         let workspace_path = config.workspace_path.as_ref()?;
         let path_buf = PathBuf::from(workspace_path);
@@ -328,20 +333,61 @@ impl ConversationCoordinator {
             .await?;
 
         if let Some(rid) = identity.remote_connection_id.as_deref() {
-            let connection_name =
+            // Try to look up the connection by the session's stored ID first.
+            let lookup =
                 crate::service::remote_ssh::workspace_state::lookup_remote_connection_with_hint(
                     workspace_path,
                     Some(rid),
                 )
-                .await
+                .await;
+
+            // If the stored connection_id does not resolve to a registered
+            // workspace, attempt a path-only lookup.  This covers the case
+            // where the user changed the SSH port: the old connection_id is
+            // no longer registered, but the same remote path is now bound to
+            // a new connection with the updated port.
+            let (effective_rid, entry) = if lookup.is_some() {
+                (rid.to_string(), lookup)
+            } else {
+                let path_entry =
+                    crate::service::remote_ssh::workspace_state::lookup_remote_connection(
+                        workspace_path,
+                    )
+                    .await;
+                if let Some(ref pe) = path_entry {
+                    log::info!(
+                        "Session connection_id {} not registered for workspace {}; remapping to {}",
+                        rid,
+                        workspace_path,
+                        pe.connection_id
+                    );
+                    (pe.connection_id.clone(), path_entry)
+                } else {
+                    (rid.to_string(), lookup)
+                }
+            };
+
+            let connection_name = entry
                 .map(|e| e.connection_name)
-                .unwrap_or_else(|| rid.to_string());
+                .unwrap_or_else(|| effective_rid.clone());
+
+            // Re-resolve identity with the effective connection_id so the
+            // session storage path is correct.
+            let effective_identity =
+                crate::service::remote_ssh::workspace_state::resolve_workspace_session_identity(
+                    workspace_path,
+                    Some(&effective_rid),
+                    config.remote_ssh_host.as_deref(),
+                )
+                .await
+                .unwrap_or(identity);
+
             let binding = WorkspaceBinding::new_remote(
                 None,
                 path_buf,
-                rid.to_string(),
+                effective_rid,
                 connection_name,
-                identity,
+                effective_identity,
             );
 
             return Some(binding);

--- a/src/crates/core/src/service/remote_ssh/manager.rs
+++ b/src/crates/core/src/service/remote_ssh/manager.rs
@@ -13,8 +13,8 @@ use russh::client::{DisconnectReason, Handle, Handler, Msg};
 use russh::Sig;
 use russh_keys::key::PublicKey;
 use russh_keys::PublicKeyBase64;
-use russh_sftp::client::fs::ReadDir;
 use russh_sftp::client::SftpSession;
+use russh_sftp::client::fs::ReadDir;
 #[cfg(feature = "ssh_config")]
 use ssh_config::SSHConfig;
 use std::collections::HashMap;
@@ -771,7 +771,39 @@ impl SSHConnectionManager {
 
         let mut guard = self.saved_connections.write().await;
         *guard = saved;
-        drop(guard);
+
+        // Migrate old-format connection IDs that include the port
+        // (e.g. "ssh-root@host:22") to the new stable format ("ssh-root@host").
+        // This ensures historical sessions can still find the connection after
+        // the user changes the port.
+        let mut migrated_ids = Vec::new();
+        for conn in guard.iter_mut() {
+            if let Some(new_id) = Self::migrate_connection_id(&conn.id) {
+                let old_id = conn.id.clone();
+                log::info!("Migrating saved connection ID: {} -> {}", old_id, new_id);
+                conn.id = new_id.clone();
+                migrated_ids.push((old_id, new_id));
+            }
+        }
+        if !migrated_ids.is_empty() {
+            drop(guard);
+            for (old_id, new_id) in &migrated_ids {
+                if let Err(e) = self.password_vault.migrate_entry(old_id, new_id).await {
+                    log::warn!(
+                        "Failed to migrate SSH password vault entry from {} to {}: {}",
+                        old_id,
+                        new_id,
+                        e
+                    );
+                }
+            }
+            // Persist the migrated IDs to disk.
+            if let Err(e) = self.save_connections().await {
+                log::warn!("Failed to persist migrated connection IDs: {}", e);
+            }
+        } else {
+            drop(guard);
+        }
 
         let removed = self.prune_saved_connections_without_credentials().await?;
         if !removed.is_empty() {
@@ -784,6 +816,30 @@ impl SSHConnectionManager {
         let guard = self.saved_connections.read().await;
         log::info!("load_saved_connections: loaded {} connections", guard.len());
         Ok(())
+    }
+
+    /// If `id` follows the old format `ssh-{user}@{host}:{port}`, return the
+    /// new stable format `ssh-{user}@{host}`.  Otherwise return `None`.
+    fn migrate_connection_id(id: &str) -> Option<String> {
+        if !id.starts_with("ssh-") {
+            return None;
+        }
+        let rest = &id[4..]; // "{user}@{host}:{port}"
+        let at_pos = rest.find('@')?;
+        let colon_pos = rest.rfind(':')?;
+        if colon_pos <= at_pos {
+            return None;
+        }
+        // Verify the suffix after the last colon is a valid port number.
+        let port_str = &rest[colon_pos + 1..];
+        if port_str.parse::<u16>().is_ok() {
+            let stable = format!("ssh-{}", &rest[..colon_pos]);
+            // Only return if the ID actually changes (i.e. the port was present).
+            if stable != id {
+                return Some(stable);
+            }
+        }
+        None
     }
 
     /// Save connections to disk
@@ -906,12 +962,11 @@ impl SSHConnectionManager {
 
         let mut guard = self.saved_connections.write().await;
 
-        // Remove existing entry with same id OR same host+port+username (dedup)
+        // Remove existing entry with same id OR same host+username (dedup).
+        // Using host+username (without port) so that changing the port replaces
+        // the old entry instead of creating a duplicate.
         guard.retain(|c| {
-            c.id != config.id
-                && !(c.host == config.host
-                    && c.port == config.port
-                    && c.username == config.username)
+            c.id != config.id && !(c.host == config.host && c.username == config.username)
         });
 
         // Add new entry
@@ -1620,47 +1675,90 @@ impl SSHConnectionManager {
     /// server-side timeout), transparently reconnect using the saved config
     /// and (for password auth) the encrypted password vault.
     ///
+    /// Also detects config drift (e.g. the user changed the port after the
+    /// connection was established) and forces a reconnect with the updated
+    /// parameters so that historical sessions never use a stale port.
+    ///
     /// Uses a per-connection mutex to prevent reconnect stampedes when many
     /// concurrent SFTP/exec calls hit a dead session at the same time.
-    /// Idempotent: returns Ok(()) immediately when the session is already alive.
+    /// Idempotent: returns Ok(()) immediately when the session is already alive
+    /// **and** its config matches the latest saved profile.
     async fn ensure_alive_or_reconnect(&self, connection_id: &str) -> anyhow::Result<()> {
-        let missing_config = self
+        // Always read the latest saved config — this is the source of truth
+        // after the user edits a connection (e.g. changes the port).
+        let saved_config = self
             .load_connection_config_from_saved(connection_id)
             .await?;
 
-        let (alive_flag, reconnect_lock, mut config) = {
+        let (alive_flag, reconnect_lock, active_config) = {
             let guard = self.connections.read().await;
             if let Some(conn) = guard.get(connection_id) {
                 (
                     conn.alive.clone(),
                     conn.reconnect_lock.clone(),
-                    conn.config.clone(),
+                    Some(conn.config.clone()),
                 )
             } else {
-                let config = missing_config.ok_or_else(|| {
-                    anyhow!(
-                        "Connection {} not found and no saved SSH profile is available",
-                        connection_id
-                    )
-                })?;
                 (
                     Arc::new(AtomicBool::new(false)),
                     Arc::new(tokio::sync::Mutex::new(())),
-                    config,
+                    None,
                 )
             }
         };
 
+        // If the connection is alive, check for config drift before returning.
         if alive_flag.load(Ordering::SeqCst) {
-            return Ok(());
+            if let Some(ref saved) = saved_config {
+                if let Some(ref active) = active_config {
+                    if !saved.connection_params_equal(active) {
+                        log::warn!(
+                            "SSH config for {} has drifted (e.g. port {} -> {}), forcing reconnect",
+                            connection_id,
+                            active.port,
+                            saved.port
+                        );
+                        // Mark as dead so the reconnect path below is taken.
+                        alive_flag.store(false, Ordering::SeqCst);
+                    } else {
+                        return Ok(());
+                    }
+                } else {
+                    return Ok(());
+                }
+            } else {
+                return Ok(());
+            }
         }
 
         // Serialize concurrent reconnect attempts for the same connection.
         let _guard = reconnect_lock.lock().await;
         // Re-check under lock; another task may have already restored the session.
         if alive_flag.load(Ordering::SeqCst) {
-            return Ok(());
+            // Re-check config drift under lock as well.
+            if let Some(ref saved) = saved_config {
+                let guard = self.connections.read().await;
+                if let Some(conn) = guard.get(connection_id) {
+                    if saved.connection_params_equal(&conn.config) {
+                        return Ok(());
+                    }
+                }
+            } else {
+                return Ok(());
+            }
         }
+
+        // Prefer the latest saved config for reconnection; fall back to the
+        // active config only when no saved profile exists (should be rare).
+        let mut config = match saved_config {
+            Some(c) => c,
+            None => active_config.ok_or_else(|| {
+                anyhow!(
+                    "Connection {} not found and no saved SSH profile is available",
+                    connection_id
+                )
+            })?,
+        };
 
         let is_existing_connection = {
             let guard = self.connections.read().await;
@@ -1702,12 +1800,14 @@ impl SSHConnectionManager {
 
         let (handle, alive, server_info) = self.establish_session(&config, 30).await?;
 
-        // Replace the handle and clear the cached SFTP session so subsequent
-        // operations open a fresh channel on the new transport.
+        // Replace the handle, update the config to the latest saved version,
+        // and clear the cached SFTP session so subsequent operations open a
+        // fresh channel on the new transport.
         {
             let mut guard = self.connections.write().await;
             if let Some(conn) = guard.get_mut(connection_id) {
                 conn.handle = Arc::new(handle);
+                conn.config = config;
                 conn.alive = alive;
                 if let Some(si) = server_info.as_ref() {
                     conn.server_info = Some(si.clone());

--- a/src/crates/core/src/service/remote_ssh/password_vault.rs
+++ b/src/crates/core/src/service/remote_ssh/password_vault.rs
@@ -172,4 +172,72 @@ impl SSHPasswordVault {
         }
         Ok(())
     }
+
+    pub async fn migrate_entry(
+        &self,
+        old_connection_id: &str,
+        new_connection_id: &str,
+    ) -> Result<()> {
+        if old_connection_id == new_connection_id {
+            return Ok(());
+        }
+        let _g = self.lock.lock().await;
+        if !self.vault_path.exists() {
+            return Ok(());
+        }
+        let s = tokio::fs::read_to_string(&self.vault_path)
+            .await
+            .unwrap_or_default();
+        let mut file: VaultFile = serde_json::from_str(&s).unwrap_or_default();
+        let Some(entry) = file.entries.remove(old_connection_id) else {
+            return Ok(());
+        };
+        file.entries
+            .entry(new_connection_id.to_string())
+            .or_insert(entry);
+        tokio::fs::write(&self.vault_path, serde_json::to_string_pretty(&file)?).await?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ =
+                std::fs::set_permissions(&self.vault_path, std::fs::Permissions::from_mode(0o600));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SSHPasswordVault;
+
+    #[tokio::test]
+    async fn migrate_entry_moves_password_to_new_connection_id() {
+        let dir =
+            std::env::temp_dir().join(format!("bitfun-ssh-vault-test-{}", std::process::id()));
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        let vault = SSHPasswordVault::new(dir.clone());
+
+        vault
+            .store("ssh-root@example.com:22", "secret")
+            .await
+            .unwrap();
+        vault
+            .migrate_entry("ssh-root@example.com:22", "ssh-root@example.com")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            vault.load("ssh-root@example.com").await.unwrap().as_deref(),
+            Some("secret")
+        );
+        assert!(
+            vault
+                .load("ssh-root@example.com:22")
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
 }

--- a/src/crates/services-integrations/src/remote_ssh/types.rs
+++ b/src/crates/services-integrations/src/remote_ssh/types.rs
@@ -47,6 +47,19 @@ pub struct SSHConnectionConfig {
     pub default_workspace: Option<String>,
 }
 
+impl SSHConnectionConfig {
+    /// Compare the connection parameters that affect the underlying SSH session
+    /// (host, port, username, auth type). Used to detect config drift between
+    /// an active connection and the latest saved config so that a reconnect
+    /// can be triggered when the user changes the port or other params.
+    pub fn connection_params_equal(&self, other: &Self) -> bool {
+        self.host == other.host
+            && self.port == other.port
+            && self.username == other.username
+            && std::mem::discriminant(&self.auth) == std::mem::discriminant(&other.auth)
+    }
+}
+
 /// SSH authentication method
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]

--- a/src/web-ui/src/features/ssh-remote/SSHConnectionDialog.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHConnectionDialog.tsx
@@ -135,8 +135,12 @@ export const SSHConnectionDialog: React.FC<SSHConnectionDialogProps> = ({
     if (path) setFormData((prev) => ({ ...prev, keyPath: path }));
   }, [isConnecting, status, t]);
 
-  const generateConnectionId = (host: string, port: number, username: string) => {
-    return `ssh-${username}@${host}:${port}`;
+  // Port is intentionally excluded so that the ID stays stable when the user
+  // changes the SSH port.  Old-format IDs that include the port (e.g.
+  // "ssh-root@host:22") are migrated on the Rust side when saved connections
+  // are loaded from disk.
+  const generateConnectionId = (host: string, _port: number, username: string) => {
+    return `ssh-${username}@${host}`;
   };
 
   const buildAuthMethod = (): SSHAuthMethod => {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -23,6 +23,80 @@ import {
 const log = createLogger('SessionModule');
 const pendingSessionCreations = new Map<string, Promise<string>>();
 
+const normalizeOptional = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const hostFromSshConnectionId = (connectionId: string | undefined): string | undefined => {
+  const trimmed = connectionId?.trim();
+  if (!trimmed) return undefined;
+  const match = trimmed.match(/^ssh-[^@]+@(.+?)(?::\d+)?$/);
+  return match?.[1]?.trim().toLowerCase() || undefined;
+};
+
+const remotePathsMatch = (left: string | undefined, right: string | undefined): boolean => {
+  const leftNorm = normalizeOptional(left);
+  const rightNorm = normalizeOptional(right);
+  if (!leftNorm || !rightNorm) return false;
+  return normalizeRemoteWorkspacePath(leftNorm) === normalizeRemoteWorkspacePath(rightNorm);
+};
+
+const currentWorkspaceMatchesSessionScope = (
+  current: WorkspaceInfo | null | undefined,
+  storedConnectionId: string | undefined,
+  storedSshHost: string | undefined,
+  workspacePath: string
+): current is WorkspaceInfo => {
+  if (current?.workspaceKind !== WorkspaceKind.Remote || !current.connectionId) {
+    return false;
+  }
+  if (!remotePathsMatch(current.rootPath, workspacePath)) {
+    return false;
+  }
+
+  const currentHost = normalizeOptional(current.sshHost)?.toLowerCase()
+    || hostFromSshConnectionId(current.connectionId);
+  const storedHost = normalizeOptional(storedSshHost)?.toLowerCase()
+    || hostFromSshConnectionId(storedConnectionId);
+  if (currentHost && storedHost) {
+    return currentHost === storedHost;
+  }
+
+  const storedConnection = normalizeOptional(storedConnectionId);
+  return !storedConnection || storedConnection === current.connectionId;
+};
+
+/// Resolve the effective connection_id for a session, preferring the
+/// current workspace's connection when the stored ID may be stale
+/// (e.g. after the user changed the SSH port).
+const resolveEffectiveConnectionId = (
+  storedConnectionId: string | undefined,
+  storedSshHost: string | undefined,
+  workspacePath: string
+): string | undefined => {
+  const current = workspaceManager.getState().currentWorkspace;
+  if (currentWorkspaceMatchesSessionScope(current, storedConnectionId, storedSshHost, workspacePath)) {
+    return current.connectionId;
+  }
+  return storedConnectionId;
+};
+
+const resolveEffectiveSshHost = (
+  storedSshHost: string | undefined,
+  storedConnectionId: string | undefined,
+  workspacePath: string
+): string | undefined => {
+  const current = workspaceManager.getState().currentWorkspace;
+  if (
+    currentWorkspaceMatchesSessionScope(current, storedConnectionId, storedSshHost, workspacePath)
+    && current.sshHost?.trim()
+  ) {
+    return current.sshHost.trim() || undefined;
+  }
+  return storedSshHost;
+};
+
 async function hydrateHistoricalSession(
   context: FlowChatContext,
   sessionId: string,
@@ -42,12 +116,27 @@ async function hydrateHistoricalSession(
 
     const workspacePath = requireSessionWorkspacePath(session.workspacePath, sessionId);
 
+    // Prefer the current workspace's connection info over the session's
+    // stored values.  When the user changes the SSH port the session's
+    // remoteConnectionId becomes stale; the active workspace always
+    // carries the up-to-date connection_id.
+    const effectiveConnectionId = resolveEffectiveConnectionId(
+      session.remoteConnectionId,
+      session.remoteSshHost,
+      workspacePath
+    );
+    const effectiveSshHost = resolveEffectiveSshHost(
+      session.remoteSshHost,
+      session.remoteConnectionId,
+      workspacePath
+    );
+
     await context.flowChatStore.loadSessionHistory(
       sessionId,
       workspacePath,
       undefined,
-      session.remoteConnectionId,
-      session.remoteSshHost
+      effectiveConnectionId,
+      effectiveSshHost
     );
   })();
 
@@ -492,6 +581,20 @@ export async function ensureBackendSession(
   const latestSession = context.flowChatStore.getState().sessions.get(sessionId) ?? session;
   const workspacePath = requireSessionWorkspacePath(latestSession.workspacePath, sessionId);
 
+  // Resolve effective connection info: prefer the current workspace's
+  // connection_id over the session's stored value.  When the user changes
+  // the SSH port the session's remoteConnectionId becomes stale.
+  const effectiveConnectionId = resolveEffectiveConnectionId(
+    latestSession.remoteConnectionId,
+    latestSession.remoteSshHost,
+    workspacePath
+  );
+  const effectiveSshHost = resolveEffectiveSshHost(
+    latestSession.remoteSshHost,
+    latestSession.remoteConnectionId,
+    workspacePath
+  );
+
   const isHistoricalSession = latestSession.isHistorical === true;
   const isFirstTurn = latestSession.dialogTurns.length <= 1;
   const needsBackendSetup = isHistoricalSession || isFirstTurn;
@@ -515,8 +618,8 @@ export async function ensureBackendSession(
     await agentAPI.ensureCoordinatorSession({
       sessionId,
       workspacePath,
-      remoteConnectionId: latestSession.remoteConnectionId,
-      remoteSshHost: latestSession.remoteSshHost,
+      remoteConnectionId: effectiveConnectionId,
+      remoteSshHost: effectiveSshHost,
     });
     clearHistoricalFlag();
   } catch (e: any) {
@@ -537,14 +640,14 @@ export async function ensureBackendSession(
         `Session ${sessionId.slice(0, 8)}`,
       agentType: latestSession.mode || 'agentic',
       workspacePath,
-      remoteConnectionId: latestSession.remoteConnectionId,
-      remoteSshHost: latestSession.remoteSshHost,
+      remoteConnectionId: effectiveConnectionId,
+      remoteSshHost: effectiveSshHost,
       config: {
         modelName: latestSession.config.modelName || 'auto',
         enableTools: true,
         safeMode: true,
-        remoteConnectionId: latestSession.remoteConnectionId,
-        remoteSshHost: latestSession.remoteSshHost,
+        remoteConnectionId: effectiveConnectionId,
+        remoteSshHost: effectiveSshHost,
       }
     });
     clearHistoricalFlag();
@@ -586,4 +689,3 @@ export async function retryCreateBackendSession(
     }
   });
 }
-

--- a/src/web-ui/src/flow_chat/utils/sessionOrdering.test.ts
+++ b/src/web-ui/src/flow_chat/utils/sessionOrdering.test.ts
@@ -114,4 +114,21 @@ describe('sessionOrdering', () => {
       sessionBelongsToWorkspaceNavRow(sessionB, rowPath, conn, host)
     ).toBe(false);
   });
+
+  it('remote SSH: parses stable connection ids without ports when host metadata is absent', () => {
+    const session = {
+      workspacePath: '/home/u/project-a',
+      remoteConnectionId: 'ssh-user@myserver.example.com:22',
+      remoteSshHost: undefined,
+    };
+
+    expect(
+      sessionBelongsToWorkspaceNavRow(
+        session,
+        '/home/u/project-a',
+        'ssh-user@myserver.example.com',
+        undefined
+      )
+    ).toBe(true);
+  });
 });

--- a/src/web-ui/src/flow_chat/utils/sessionOrdering.ts
+++ b/src/web-ui/src/flow_chat/utils/sessionOrdering.ts
@@ -2,10 +2,10 @@ import type { Session } from '../types/flow-chat';
 import type { SessionMetadata } from '@/shared/types/session-history';
 import { isSamePath, normalizeRemoteWorkspacePath } from '@/shared/utils/pathUtils';
 
-/** Extract `host` from our saved form `ssh-{user}@{host}:{port}` (used when metadata omits `remoteSshHost`). */
+/** Extract `host` from SSH connection IDs, with or without the legacy port suffix. */
 function hostFromSshConnectionId(connectionId: string): string | null {
   const t = connectionId.trim();
-  const m = t.match(/^ssh-[^@]+@(.+):(\d+)$/);
+  const m = t.match(/^ssh-[^@]+@(.+?)(?::\d+)?$/);
   return m ? m[1].trim().toLowerCase() : null;
 }
 

--- a/src/web-ui/src/flow_chat/utils/sessionTitle.test.ts
+++ b/src/web-ui/src/flow_chat/utils/sessionTitle.test.ts
@@ -233,6 +233,26 @@ describe('sessionTitle', () => {
     ).toBe(2);
   });
 
+  it('keeps remote workspace counters stable across legacy and portless connection ids', () => {
+    const sessions = [
+      counterSession({
+        sessionId: 'legacy-remote-code-2',
+        workspacePath: '/repo',
+        remoteConnectionId: 'ssh-user@host-a:22',
+        remoteSshHost: undefined,
+        titleI18nParams: { count: 2 },
+      }),
+    ];
+
+    expect(
+      getNextDefaultSessionTitleCount(sessions, {
+        mode: 'code',
+        workspacePath: '/repo',
+        remoteConnectionId: 'ssh-user@host-a',
+      }),
+    ).toBe(3);
+  });
+
   it('ignores child sessions when choosing a main session title count', () => {
     const sessions = [
       counterSession({

--- a/src/web-ui/src/flow_chat/utils/sessionTitle.ts
+++ b/src/web-ui/src/flow_chat/utils/sessionTitle.ts
@@ -76,7 +76,7 @@ export function normalizeDefaultSessionTitleMode(mode?: string): DefaultSessionT
 }
 
 function remoteHostFromConnectionId(connectionId: string): string {
-  const match = connectionId.trim().match(/^ssh-[^@]+@(.+):(\d+)$/);
+  const match = connectionId.trim().match(/^ssh-[^@]+@(.+?)(?::\d+)?$/);
   return match ? match[1].trim().toLowerCase() : '';
 }
 


### PR DESCRIPTION
## Summary
- Migrate saved SSH connection IDs from `ssh-user@host:port` to stable `ssh-user@host` when loading persisted connections, and migrate matching password vault entries.
- When hydrating flow-chat sessions, prefer the current remote workspace `connectionId` / `sshHost` when the session scope (path + host) matches, so sessions stay valid after the user changes the SSH port.
- Coordinator, session ordering/title helpers, and SSH connection dialog aligned with host-aware matching.

## Verification
- `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run`
- `cargo check --workspace`
- `cargo test --workspace`