### PR TITLE
Add desktop system fullscreen mode

### DIFF
--- a/docs/plans/desktop-window-fullscreen-plan.md
+++ b/docs/plans/desktop-window-fullscreen-plan.md
@@ -1,0 +1,94 @@
+# Desktop Window Fullscreen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add OS-level fullscreen support for the BitFun Desktop main window without changing maximize, panel fullscreen, CLI/TUI rendering, or product runtime logic.
+
+**Architecture:** Keep fullscreen as a Desktop shell capability owned by the Tauri/Web UI adapter layer. Extend the existing `useWindowControls` hook so maximize and fullscreen share focus restoration and state-sync helpers while keeping separate state, handlers, permissions, and comments.
+
+**Tech Stack:** Tauri v2 window APIs, React hooks, BitFun `ShortcutManager` where appropriate, Vitest for pure shortcut helper coverage, existing locale JSON files.
+
+---
+
+## Product Scope
+
+This feature means OS window fullscreen:
+
+- Windows/Linux: pressing `F11` asks the operating system to put the whole BitFun Desktop window into fullscreen.
+- macOS: pressing `Control+Command+F` uses the platform fullscreen convention.
+- The BitFun internal layout remains the same: NavBar, SceneBar, panels, chat, editor, terminal, browser, and diff surfaces continue to render.
+
+This feature is not:
+
+- `maximize()` / `unmaximize()`.
+- Internal panel fullscreen, editor Zen Mode, or diff preview fullscreen.
+- CLI/TUI alternate-screen rendering.
+- A persisted workspace/session state.
+
+## Competitor Notes
+
+- Claude Code Desktop treats desktop as a workbench with panes, terminal, file editor, preview, and computer use. This supports adding OS window fullscreen as shell chrome behavior, not as model/runtime logic.
+- Claude Code CLI fullscreen rendering is an alternate terminal renderer using the terminal's drawing surface; its docs explicitly say it is unrelated to maximizing the terminal window.
+- Codex CLI launches into a full-screen terminal UI, while the Codex app handles app/window workflows separately.
+- OpenCode TUI uses TUI keybinds, mouse capture, and terminal-aware layout settings. That reinforces keeping CLI fullscreen separate from Desktop OS fullscreen.
+
+## State Model
+
+| State | Meaning | Owner |
+|---|---|---|
+| Normal | Ordinary Desktop window | OS/Tauri |
+| Maximized | Desktop window fills available work area but remains a normal window | existing maximize logic |
+| Fullscreen | OS-level fullscreen window state | new fullscreen logic |
+| Minimized | Hidden/minimized app window | existing minimize logic |
+
+`isMaximized` and `isFullscreen` must remain independent. Callers must not use maximize as a proxy for fullscreen.
+
+## Remote Compatibility
+
+OS window fullscreen is a local Desktop shell capability. It must not be modeled as a remote workspace, SSH session, agent runtime, or transport command.
+
+- Remote SSH workspaces continue to render inside the same local Desktop window; toggling fullscreen changes only that local shell window.
+- The shortcut path is gated by native window-control support and does not add remote network, SSH, file-tree, terminal, or agent-loop round trips.
+- If a future remote-control product surface needs to control a client window's fullscreen state, it should be exposed as an explicit client shell capability with capability negotiation, not by reusing workspace/session APIs.
+
+## Milestone 1: Desktop Shell Fullscreen
+
+Risk: Medium. The code path is narrow, but platform fullscreen behavior differs across Windows, Linux window managers, and macOS Spaces.
+
+- [x] Add Tauri permission for frontend `is_fullscreen` state sync. `set_fullscreen` stays in the desktop host command and does not need a frontend window permission. Risk: Low.
+- [x] Extend `useWindowControls` with `isFullscreen` and `handleToggleFullscreen`. Risk: Medium.
+- [x] Keep fullscreen comments explicit: OS fullscreen is not maximize and not panel fullscreen. Risk: Low.
+- [x] Reuse shared focus restoration and state-sync helpers instead of copying maximize logic. Risk: Medium.
+- [x] Register a Desktop-only fullscreen shortcut. Risk: Medium.
+  - Windows/Linux: `F11`.
+  - macOS: `Control+Command+F`.
+- [x] Add locale error copy for fullscreen failure. Risk: Low.
+- [x] Add pure tests for shortcut detection. Risk: Low.
+- [x] Verify. Risk: Low.
+  - `pnpm run lint:web`
+  - `pnpm run type-check:web`
+  - `pnpm --dir src/web-ui run test:run`
+  - `cargo check -p bitfun-desktop`
+  - `cargo test -p bitfun-desktop`
+
+M1 implementation notes:
+
+- `useWindowControls` now owns both `isMaximized` and `isFullscreen`, but the states remain independent.
+- Maximize and fullscreen share focus restoration, titlebar restoration, and window-state refresh helpers.
+- Fullscreen uses desktop-host `set_fullscreen(...)` through `toggle_main_window_fullscreen`; ordinary maximize continues to use the existing frontend `maximize()` / `unmaximize()` path.
+- Entering fullscreen from a maximized window must not call `unmaximize()`, `hide()`, or `show()` as part of the enter path; those create visible restore/focus artifacts on Windows. The desktop command instead records whether the window was maximized. On Windows, where direct fullscreen from an undecorated maximized window can remain stuck at work-area size, it enters fullscreen while preserving maximize state and then applies the current monitor's full bounds as a post-fullscreen geometry correction.
+- The native fullscreen transition now lives behind the desktop command `toggle_main_window_fullscreen`. The web UI calls a single `systemAPI.toggleMainWindowFullscreen()` method instead of stitching together multiple frontend window calls.
+- The Desktop shortcut listener is raw `keydown` handling by design because the macOS fullscreen chord is exact `Control+Command+F`, not the app-level `mod+F` shortcut abstraction.
+- Successful fullscreen toggles show a short top-center mode hint so accidental `F11` presses explain both the current mode and the platform exit shortcut.
+- Browser mode and toolbar mode do not register the OS fullscreen shortcut.
+
+## Milestone 2: Product Polish And Cross-Platform Hardening
+
+Risk: Medium to Low. The main work is QA and discoverability, not new behavior.
+
+- [ ] Add a menu/command entry such as `View > Toggle Full Screen`. Risk: Low.
+- [ ] Show the platform shortcut in a read-only shortcuts/settings surface. Risk: Low.
+- [ ] Confirm terminal/editor focus behavior and document whether focused terminal receives or yields `F11`. Risk: Medium.
+- [ ] Manually verify Windows, macOS, Linux, browser mode, multiple monitors, and 125%/150% DPI. Risk: Medium.
+- [ ] Confirm fullscreen does not persist into workspace/session state. Risk: Low.
+- [ ] Confirm existing maximize button, double-click titlebar maximize, diff fullscreen, and editor/image fullscreen still behave independently. Risk: Medium.

--- a/src/apps/desktop/capabilities/default.json
+++ b/src/apps/desktop/capabilities/default.json
@@ -33,6 +33,7 @@
     "core:window:allow-current-monitor",
     "core:window:allow-outer-position",
     "core:window:allow-outer-size",
+    "core:window:allow-is-fullscreen",
     "core:window:allow-is-maximized",
     "core:window:allow-center",
     "core:window:allow-close",

--- a/src/apps/desktop/src/api/system_api.rs
+++ b/src/apps/desktop/src/api/system_api.rs
@@ -1,11 +1,11 @@
 //! System API
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::api::app_state::AppState;
 use bitfun_core::service::system;
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter, Manager, State};
+use tauri::{AppHandle, Emitter, Manager, Position, Size, State};
 use tauri_plugin_updater::UpdaterExt;
 
 /// Emitted during `install_update` download; matches `installUpdateWithProgress` / frontend listener.
@@ -309,6 +309,67 @@ pub struct SendNotificationRequest {
     pub body: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ToggleMainWindowFullscreenRequest {}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToggleMainWindowFullscreenResponse {
+    pub is_fullscreen: bool,
+    pub is_maximized: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MainWindowFullscreenTransition {
+    next_fullscreen: bool,
+    should_apply_monitor_bounds_after_enter: bool,
+    should_restore_maximized_after_exit: bool,
+    next_restore_maximized_after_fullscreen: bool,
+}
+
+fn plan_main_window_fullscreen_transition(
+    current_fullscreen: bool,
+    current_maximized: bool,
+    restore_maximized_after_fullscreen: bool,
+    apply_maximized_fullscreen_monitor_bounds: bool,
+) -> MainWindowFullscreenTransition {
+    let next_fullscreen = !current_fullscreen;
+
+    if next_fullscreen {
+        MainWindowFullscreenTransition {
+            next_fullscreen,
+            should_apply_monitor_bounds_after_enter: current_maximized
+                && apply_maximized_fullscreen_monitor_bounds,
+            should_restore_maximized_after_exit: false,
+            next_restore_maximized_after_fullscreen: current_maximized,
+        }
+    } else {
+        MainWindowFullscreenTransition {
+            next_fullscreen,
+            should_apply_monitor_bounds_after_enter: false,
+            should_restore_maximized_after_exit: restore_maximized_after_fullscreen,
+            next_restore_maximized_after_fullscreen: false,
+        }
+    }
+}
+
+fn main_window_fullscreen_restore_maximized() -> &'static Mutex<bool> {
+    static RESTORE_MAXIMIZED: OnceLock<Mutex<bool>> = OnceLock::new();
+    RESTORE_MAXIMIZED.get_or_init(|| Mutex::new(false))
+}
+
+fn read_main_window_fullscreen_response(
+    window: &tauri::WebviewWindow,
+    fallback_fullscreen: bool,
+    fallback_maximized: bool,
+) -> ToggleMainWindowFullscreenResponse {
+    ToggleMainWindowFullscreenResponse {
+        is_fullscreen: window.is_fullscreen().unwrap_or(fallback_fullscreen),
+        is_maximized: window.is_maximized().unwrap_or(fallback_maximized),
+    }
+}
+
 // ─── Window / Tray behavior commands ─────────────────────────────────────────
 
 /// Immediately exit the application (used by the "ask" dialog when the user
@@ -332,6 +393,136 @@ pub async fn minimize_to_tray(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Toggle OS-level fullscreen for the Desktop main window.
+///
+/// This is intentionally not the same as maximize: maximize fills the normal
+/// work area, while fullscreen asks the OS to own the whole monitor surface.
+/// This is also intentionally a Desktop shell adapter command, not a remote
+/// workspace/session/runtime command; remote workspaces still run inside the
+/// same local Desktop window, so fullscreen must not enter transport or core
+/// product logic.
+/// Keeping the transition in the desktop host avoids frontend code stitching
+/// together `set_fullscreen` / `maximize` with visible JS turns.
+///
+/// Important: do not unmaximize before entering fullscreen. On Windows this
+/// briefly restores the normal window bounds, which makes the window origin and
+/// size visibly jump before the OS fullscreen transition starts. Fullscreen and
+/// maximize are tracked separately so we can remember whether to restore the
+/// maximized state after fullscreen exits without touching window geometry on
+/// entry.
+///
+/// Windows note: Tauri/wry fullscreen does not always expand an undecorated
+/// maximized window beyond the work area if we call `set_fullscreen(true)`
+/// directly. The Windows path therefore keeps the window maximized, enters
+/// fullscreen, then applies the current monitor's full bounds as a geometry
+/// correction. Never reintroduce `unmaximize`, `hide`, or `show` in this enter
+/// path: those expose a restore transition and make repeated F11 toggles feel
+/// broken.
+#[tauri::command]
+pub async fn toggle_main_window_fullscreen(
+    app: tauri::AppHandle,
+    request: ToggleMainWindowFullscreenRequest,
+) -> Result<ToggleMainWindowFullscreenResponse, String> {
+    let _ = request;
+    let Some(window) = app.get_webview_window("main") else {
+        return Err("Main window not found".to_string());
+    };
+
+    let current_fullscreen = window.is_fullscreen().map_err(|error| {
+        format!("Failed to read main window fullscreen state: {}", error)
+    })?;
+    let current_maximized = window.is_maximized().map_err(|error| {
+        format!("Failed to read main window maximize state: {}", error)
+    })?;
+    let restore_maximized_after_fullscreen = *main_window_fullscreen_restore_maximized()
+        .lock()
+        .map_err(|_| "Main window fullscreen restore state is unavailable".to_string())?;
+
+    let transition = plan_main_window_fullscreen_transition(
+        current_fullscreen,
+        current_maximized,
+        restore_maximized_after_fullscreen,
+        should_apply_maximized_fullscreen_monitor_bounds(),
+    );
+
+    if transition.next_fullscreen {
+        if let Err(error) = window.set_fullscreen(true) {
+            return Err(format!("Failed to enter main window fullscreen: {}", error));
+        }
+
+        if transition.should_apply_monitor_bounds_after_enter {
+            apply_main_window_fullscreen_monitor_bounds(&app, &window)?;
+        }
+
+        *main_window_fullscreen_restore_maximized()
+            .lock()
+            .map_err(|_| "Main window fullscreen restore state is unavailable".to_string())? =
+            transition.next_restore_maximized_after_fullscreen;
+
+        return Ok(read_main_window_fullscreen_response(
+            &window,
+            true,
+            false,
+        ));
+    }
+
+    window
+        .set_fullscreen(false)
+        .map_err(|error| format!("Failed to exit main window fullscreen: {}", error))?;
+
+    let mut restored_maximized = false;
+    if transition.should_restore_maximized_after_exit {
+        let is_already_maximized = window.is_maximized().unwrap_or(false);
+        if !is_already_maximized {
+            window.maximize().map_err(|error| {
+                format!("Failed to restore maximize after fullscreen: {}", error)
+            })?;
+        }
+        restored_maximized = true;
+    }
+
+    *main_window_fullscreen_restore_maximized()
+        .lock()
+        .map_err(|_| "Main window fullscreen restore state is unavailable".to_string())? =
+        transition.next_restore_maximized_after_fullscreen;
+
+    Ok(read_main_window_fullscreen_response(
+        &window,
+        false,
+        restored_maximized,
+    ))
+}
+
+fn apply_main_window_fullscreen_monitor_bounds(
+    app: &tauri::AppHandle,
+    window: &tauri::WebviewWindow,
+) -> Result<(), String> {
+    let monitor = window
+        .current_monitor()
+        .map_err(|error| format!("Failed to read current monitor for fullscreen: {}", error))?
+        .or_else(|| app.primary_monitor().ok().flatten())
+        .ok_or_else(|| "Failed to resolve monitor for fullscreen".to_string())?;
+
+    window
+        .set_position(Position::Physical(*monitor.position()))
+        .map_err(|error| format!("Failed to align fullscreen window position: {}", error))?;
+    window
+        .set_size(Size::Physical(*monitor.size()))
+        .map_err(|error| format!("Failed to align fullscreen window size: {}", error))?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn should_apply_maximized_fullscreen_monitor_bounds() -> bool {
+    true
+}
+
+#[cfg(not(target_os = "windows"))]
+fn should_apply_maximized_fullscreen_monitor_bounds() -> bool {
+    false
+}
+
 /// Send an OS-level desktop notification (Windows toast / macOS notification center).
 #[tauri::command]
 pub async fn send_system_notification(
@@ -345,4 +536,38 @@ pub async fn send_system_notification(
         builder = builder.body(body);
     }
     builder.show().map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn main_window_fullscreen_transition_enters_from_maximized_without_reusing_maximize_state() {
+        let transition = plan_main_window_fullscreen_transition(false, true, false, true);
+
+        assert!(transition.next_fullscreen);
+        assert!(transition.should_apply_monitor_bounds_after_enter);
+        assert!(transition.next_restore_maximized_after_fullscreen);
+        assert!(!transition.should_restore_maximized_after_exit);
+    }
+
+    #[test]
+    fn main_window_fullscreen_transition_exits_and_restores_previous_maximize_state() {
+        let transition = plan_main_window_fullscreen_transition(true, false, true, true);
+
+        assert!(!transition.next_fullscreen);
+        assert!(!transition.should_apply_monitor_bounds_after_enter);
+        assert!(!transition.next_restore_maximized_after_fullscreen);
+        assert!(transition.should_restore_maximized_after_exit);
+    }
+
+    #[test]
+    fn main_window_fullscreen_transition_can_enter_without_masking_geometry() {
+        let transition = plan_main_window_fullscreen_transition(false, true, false, false);
+
+        assert!(transition.next_fullscreen);
+        assert!(!transition.should_apply_monitor_bounds_after_enter);
+        assert!(transition.next_restore_maximized_after_fullscreen);
+    }
 }

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -898,6 +898,7 @@ pub async fn run() {
             send_system_notification,
             api::system_api::quit_app,
             api::system_api::minimize_to_tray,
+            api::system_api::toggle_main_window_fullscreen,
             check_command_exists,
             check_commands_exist,
             run_system_command,

--- a/src/crates/core/src/service/lsp/workspace_manager.rs
+++ b/src/crates/core/src/service/lsp/workspace_manager.rs
@@ -9,7 +9,7 @@
 //! - Push real-time events to the frontend
 
 use anyhow::{anyhow, Result};
-use log::{debug, error, info, warn};
+use log::{debug, error, info, trace, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -310,7 +310,7 @@ impl WorkspaceLspManager {
         let server_language = match self.get_running_server_for_language(&language).await {
             Some(lang) => lang,
             None => {
-                debug!(
+                trace!(
                     "LSP server not running for language: {}, skipping didOpen",
                     language
                 );

--- a/src/web-ui/src/app/hooks/useWindowControls.ts
+++ b/src/web-ui/src/app/hooks/useWindowControls.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState, useEffect } from 'react';
 import { getCurrentWindow } from '@tauri-apps/api/window';
+import { getCurrentWebview } from '@tauri-apps/api/webview';
 import { useWorkspaceContext } from '../../infrastructure/contexts/WorkspaceContext';
 import { notificationService } from '@/shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
@@ -7,15 +8,39 @@ import { sendDebugProbe } from '@/shared/utils/debugProbe';
 import { nowMs } from '@/shared/utils/timing';
 import { useI18n } from '@/infrastructure/i18n';
 import { isMacOSDesktopRuntime, supportsNativeWindowControls } from '@/infrastructure/runtime';
+import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
+import {
+  captureFocusedEditable,
+  restoreWindowKeyboardFocus,
+  type WindowKeyboardFocusTarget,
+} from './windowKeyboardFocus';
 
 const log = createLogger('useWindowControls');
 
 const formatErrorMessage = (error: unknown) =>
   error instanceof Error ? error.message : String(error);
 
+const createWindowKeyboardFocusTarget = (
+  appWindow: ReturnType<typeof getCurrentWindow> | null
+): WindowKeyboardFocusTarget => {
+  if (!appWindow) return null;
+
+  return {
+    setFocus: () => appWindow.setFocus(),
+    setWebviewFocus: () => getCurrentWebview().setFocus(),
+  };
+};
+
 /**
  * Window controls hook.
- * Manages minimize, maximize, close, and related actions.
+ * Manages minimize, maximize, OS fullscreen, close, and related actions.
+ *
+ * Important: OS fullscreen is not maximize. Fullscreen asks the operating
+ * system to put the entire Desktop window into fullscreen (`F11` on
+ * Windows/Linux, `Control+Command+F` on macOS). Maximize keeps the app as a
+ * normal window that fills the available work area. Keep their state and
+ * handlers separate so callers do not accidentally wire panel/fullscreen
+ * behavior to maximize/restore UI.
  */
 export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
   const { t } = useI18n('errors');
@@ -23,14 +48,52 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
   const canUseNativeWindowControls = supportsNativeWindowControls();
   const { hasWorkspace, closeWorkspace } = useWorkspaceContext();
   
-  // Maximized state
+  // Maximized state: ordinary OS window maximize/restore, not fullscreen.
   const [isMaximized, setIsMaximized] = useState(false);
+  // OS fullscreen state: entire Desktop window fullscreen, not panel fullscreen.
+  const [isFullscreen, setIsFullscreen] = useState(false);
   
   // Debounce guard to prevent rapid toggles
   const isMaximizeInProgress = useRef(false);
+  const isFullscreenInProgress = useRef(false);
   
   // Skip state updates during manual operations
   const shouldSkipStateUpdate = useRef(false);
+
+  const restoreMacOSOverlayTitlebar = useCallback(async (appWindow: any) => {
+    if (!isMacOSDesktopRuntime() || isToolbarMode) return;
+    try {
+      if (typeof appWindow.setTitleBarStyle === 'function') {
+        await appWindow.setTitleBarStyle('overlay');
+      }
+    } catch {
+      // Ignore failures during window animation/state changes.
+    }
+  }, [isToolbarMode]);
+
+  const updateWindowState = useCallback(async (appWindow: any, skipVisibilityCheck = false) => {
+    if (shouldSkipStateUpdate.current) {
+      return;
+    }
+
+    try {
+      if (!skipVisibilityCheck) {
+        const isVisible = await appWindow.isVisible();
+        if (!isVisible) {
+          return;
+        }
+      }
+
+      const [maximized, fullscreen] = await Promise.all([
+        appWindow.isMaximized(),
+        appWindow.isFullscreen(),
+      ]);
+      setIsMaximized(maximized);
+      setIsFullscreen(fullscreen);
+    } catch (_error) {
+      // Ignore errors to avoid noise when the window is minimized or transitioning.
+    }
+  }, []);
 
   // Listen for window state changes
   useEffect(() => {
@@ -41,51 +104,10 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
     // Debounce timer
     let resizeTimer: NodeJS.Timeout | null = null;
 
-    const isMacOSDesktop = isMacOSDesktopRuntime();
-
-    const restoreMacOSOverlayTitlebar = async (appWindow: any) => {
-      if (!isMacOSDesktop || isToolbarMode) return;
-      try {
-        if (typeof appWindow.setTitleBarStyle === 'function') {
-          await appWindow.setTitleBarStyle('overlay');
-        }
-      } catch {
-        // Ignore failures during window animation/state changes
-      }
-    };
-    
-    // Helper to update window state (minimize API calls)
-    const updateWindowState = async (appWindow: any, skipVisibilityCheck = false) => {
-      // Skip auto updates while maximizing to avoid duplicates
-      if (shouldSkipStateUpdate.current) {
-        return;
-      }
-      
-      try {
-        // Skip visibility check when not required
-        if (skipVisibilityCheck) {
-          const maximized = await appWindow.isMaximized();
-          setIsMaximized(maximized);
-          return;
-        }
-        
-        // Skip if window is not visible (minimized)
-        const isVisible = await appWindow.isVisible();
-        if (!isVisible) {
-          return;
-        }
-        
-        const maximized = await appWindow.isMaximized();
-        setIsMaximized(maximized);
-      } catch (_error) {
-        // Ignore errors to avoid noise when minimized
-      }
-    };
-    
     // Update state when window regains focus.
     // Note: Tauri may not expose onFocus; use page visibility as a fallback.
     const handleVisibilityChange = async () => {
-      // Skip visibility handling while maximizing
+      // Skip visibility handling while a window state transition is in flight.
       if (shouldSkipStateUpdate.current) {
         return;
       }
@@ -149,7 +171,7 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
         
         // Listen for resize (with debounce and visibility checks)
         unlistenResized = await appWindow.onResized(async () => {
-          // Skip resize handling while maximizing
+          // Skip resize handling while a window state transition is in flight.
           if (shouldSkipStateUpdate.current) {
             return;
           }
@@ -159,7 +181,7 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
             clearTimeout(resizeTimer);
           }
           
-          // Debounce: delay to avoid frequent calls (300ms covers maximize/restore)
+          // Debounce: delay to avoid frequent calls (300ms covers maximize/restore/fullscreen)
           resizeTimer = setTimeout(async () => {
             await updateWindowState(appWindow);
             await restoreMacOSOverlayTitlebar(appWindow);
@@ -185,19 +207,14 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
       // Remove page visibility listener
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [canUseNativeWindowControls, isToolbarMode]);
+  }, [canUseNativeWindowControls, isToolbarMode, restoreMacOSOverlayTitlebar, updateWindowState]);
 
   // Window control handlers
   const handleMinimize = useCallback(async () => {
     if (!canUseNativeWindowControls) return;
 
     // Save active element to restore focus after window restore
-    const activeElement = document.activeElement as HTMLElement;
-    const wasInputFocused = activeElement && (
-      activeElement.classList.contains('rich-text-input') ||
-      activeElement.closest('.rich-text-input') !== null ||
-      activeElement.isContentEditable
-    );
+    const focusSnapshot = captureFocusedEditable();
     
     try {
       const appWindow = getCurrentWindow();
@@ -206,28 +223,11 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
       // Ensure input is usable after restore
       // Listen for restore
       const handleWindowRestore = async () => {
-        setTimeout(() => {
-          // Ensure contentEditable is set correctly
-          const chatInputs = document.querySelectorAll('.rich-text-input[contenteditable]');
-          chatInputs.forEach((input) => {
-            const element = input as HTMLElement;
-            if (element.getAttribute('contenteditable') !== 'true') {
-              element.setAttribute('contenteditable', 'true');
-            }
-          });
-          
-          // Restore focus if input was focused
-          if (wasInputFocused && activeElement && activeElement.isConnected) {
-            try {
-              const rect = activeElement.getBoundingClientRect();
-              if (rect.width > 0 && rect.height > 0) {
-                activeElement.focus();
-              }
-            } catch (_error) {
-              // Ignore focus restore failures
-            }
-          }
-        }, 100);
+        restoreWindowKeyboardFocus(
+          createWindowKeyboardFocusTarget(getCurrentWindow()),
+          focusSnapshot,
+          100
+        );
         
         // Run once
         window.removeEventListener('focus', handleWindowRestore);
@@ -250,19 +250,15 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
     }
     
     // Save active element to restore focus after window change
-    const activeElement = document.activeElement as HTMLElement;
-    const wasInputFocused = activeElement && (
-      activeElement.classList.contains('rich-text-input') ||
-      activeElement.closest('.rich-text-input') !== null ||
-      activeElement.isContentEditable
-    );
+    const focusSnapshot = captureFocusedEditable();
+    let appWindow: ReturnType<typeof getCurrentWindow> | null = null;
     
     try {
       isMaximizeInProgress.current = true;
       // Skip auto updates to avoid duplicate state changes
       shouldSkipStateUpdate.current = true;
       
-      const appWindow = getCurrentWindow();
+      appWindow = getCurrentWindow();
       
       // Optimization: skip isVisible check; query maximized directly.
       // If minimized, user restores via taskbar instead of double-clicking header.
@@ -292,30 +288,11 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
       
       // Delay DOM work to avoid blocking UI rendering
       requestAnimationFrame(() => {
-        setTimeout(() => {
-          // Ensure contentEditable is set correctly
-          const chatInputs = document.querySelectorAll('.rich-text-input[contenteditable]');
-          chatInputs.forEach((input) => {
-            const element = input as HTMLElement;
-            // Ensure contentEditable is set correctly
-            if (element.getAttribute('contenteditable') !== 'true') {
-              element.setAttribute('contenteditable', 'true');
-            }
-          });
-          
-          // Restore focus if input was focused (best-effort)
-          if (wasInputFocused && activeElement && activeElement.isConnected) {
-            try {
-              // Restore only if element is still present and visible
-              const rect = activeElement.getBoundingClientRect();
-              if (rect.width > 0 && rect.height > 0) {
-                activeElement.focus();
-              }
-            } catch (_error) {
-              // Ignore focus restore failures
-            }
-          }
-        }, 50); // Reduced delay from 100ms to 50ms
+        restoreWindowKeyboardFocus(
+          createWindowKeyboardFocusTarget(appWindow),
+          focusSnapshot,
+          50
+        );
       });
     } catch (error) {
       log.error('Failed to toggle maximize window', error);
@@ -325,9 +302,61 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
       setTimeout(() => {
         isMaximizeInProgress.current = false;
         shouldSkipStateUpdate.current = false;
+        if (appWindow) {
+          void updateWindowState(appWindow, true);
+          void restoreMacOSOverlayTitlebar(appWindow);
+        }
       }, 200);
     }
-  }, [canUseNativeWindowControls, t]);
+  }, [canUseNativeWindowControls, restoreMacOSOverlayTitlebar, t, updateWindowState]);
+
+  const handleToggleFullscreen = useCallback(async () => {
+    if (!canUseNativeWindowControls) return;
+
+    if (isFullscreenInProgress.current) {
+      return;
+    }
+
+    const focusSnapshot = captureFocusedEditable();
+    let appWindow: ReturnType<typeof getCurrentWindow> | null = null;
+
+    try {
+      isFullscreenInProgress.current = true;
+      shouldSkipStateUpdate.current = true;
+
+      appWindow = getCurrentWindow();
+
+      // OS fullscreen is intentionally separate from maximize/restore.
+      // The desktop host owns the native maximize/fullscreen transition so the
+      // web UI does not expose visible intermediate OS window states.
+      const nextState = await systemAPI.toggleMainWindowFullscreen();
+
+      requestAnimationFrame(() => {
+        setIsFullscreen(nextState.isFullscreen);
+        setIsMaximized(nextState.isMaximized);
+        restoreWindowKeyboardFocus(
+          createWindowKeyboardFocusTarget(appWindow),
+          focusSnapshot,
+          80
+        );
+      });
+
+      return nextState.isFullscreen;
+    } catch (error) {
+      log.error('Failed to toggle fullscreen window', error);
+      notificationService.error(t('window.fullscreenFailed', { error: formatErrorMessage(error) }));
+      return undefined;
+    } finally {
+      setTimeout(() => {
+        isFullscreenInProgress.current = false;
+        shouldSkipStateUpdate.current = false;
+        if (appWindow) {
+          void updateWindowState(appWindow, true);
+          void restoreMacOSOverlayTitlebar(appWindow);
+        }
+      }, 300);
+    }
+  }, [canUseNativeWindowControls, restoreMacOSOverlayTitlebar, t, updateWindowState]);
 
   const handleClose = useCallback(async () => {
     if (!canUseNativeWindowControls) return;
@@ -359,9 +388,11 @@ export const useWindowControls = (options?: { isToolbarMode?: boolean }) => {
   return {
     handleMinimize,
     handleMaximize,
+    handleToggleFullscreen,
     handleClose,
     handleHomeClick,
     isMaximized,
+    isFullscreen,
     canUseNativeWindowControls
   };
 };

--- a/src/web-ui/src/app/hooks/windowFullscreenShortcut.test.ts
+++ b/src/web-ui/src/app/hooks/windowFullscreenShortcut.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { isWindowFullscreenShortcut } from './windowFullscreenShortcut';
+
+const event = (
+  key: string,
+  overrides: Partial<Pick<KeyboardEvent, 'ctrlKey' | 'metaKey' | 'altKey' | 'shiftKey'>> = {}
+) => ({
+  key,
+  ctrlKey: false,
+  metaKey: false,
+  altKey: false,
+  shiftKey: false,
+  ...overrides,
+} as KeyboardEvent);
+
+describe('isWindowFullscreenShortcut', () => {
+  it('uses F11 for Windows and Linux OS-window fullscreen', () => {
+    expect(isWindowFullscreenShortcut(event('F11'), 'Win32')).toBe(true);
+    expect(isWindowFullscreenShortcut(event('F11'), 'Linux x86_64')).toBe(true);
+  });
+
+  it('does not treat modified F11 as the Desktop fullscreen shortcut', () => {
+    expect(isWindowFullscreenShortcut(event('F11', { ctrlKey: true }), 'Win32')).toBe(false);
+    expect(isWindowFullscreenShortcut(event('F11', { shiftKey: true }), 'Linux x86_64')).toBe(false);
+  });
+
+  it('uses Control+Command+F on macOS', () => {
+    expect(isWindowFullscreenShortcut(event('f', { ctrlKey: true, metaKey: true }), 'MacIntel')).toBe(true);
+    expect(isWindowFullscreenShortcut(event('F', { ctrlKey: true, metaKey: true }), 'MacIntel')).toBe(true);
+  });
+
+  it('does not confuse macOS Command+F with OS-window fullscreen', () => {
+    expect(isWindowFullscreenShortcut(event('f', { metaKey: true }), 'MacIntel')).toBe(false);
+    expect(isWindowFullscreenShortcut(event('f', { ctrlKey: true }), 'MacIntel')).toBe(false);
+  });
+});

--- a/src/web-ui/src/app/hooks/windowFullscreenShortcut.ts
+++ b/src/web-ui/src/app/hooks/windowFullscreenShortcut.ts
@@ -1,0 +1,41 @@
+type FullscreenShortcutEvent = Pick<
+  KeyboardEvent,
+  'key' | 'ctrlKey' | 'metaKey' | 'altKey' | 'shiftKey'
+>;
+
+const isMacPlatform = (platform: string): boolean =>
+  platform.toUpperCase().includes('MAC');
+
+/**
+ * OS-window fullscreen shortcut detection.
+ *
+ * This intentionally does not use the generic "mod" shortcut mapping:
+ * fullscreen follows OS conventions (`F11` on Windows/Linux and
+ * `Control+Command+F` on macOS), while app shortcuts fold Ctrl into Cmd on
+ * macOS. Keeping this separate prevents callers from confusing fullscreen
+ * with maximize or an internal panel fullscreen action.
+ */
+export const isWindowFullscreenShortcut = (
+  event: FullscreenShortcutEvent,
+  platform = typeof navigator !== 'undefined' ? navigator.platform : ''
+): boolean => {
+  const key = event.key.toLowerCase();
+
+  if (isMacPlatform(platform)) {
+    return (
+      key === 'f' &&
+      event.ctrlKey &&
+      event.metaKey &&
+      !event.altKey &&
+      !event.shiftKey
+    );
+  }
+
+  return (
+    key === 'f11' &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.shiftKey
+  );
+};

--- a/src/web-ui/src/app/hooks/windowKeyboardFocus.test.ts
+++ b/src/web-ui/src/app/hooks/windowKeyboardFocus.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  restoreWindowKeyboardFocus,
+  type FocusSnapshot,
+  type WindowKeyboardFocusTarget,
+} from './windowKeyboardFocus';
+
+describe('restoreWindowKeyboardFocus', () => {
+  it('restores native window focus and webview focus after a hidden fullscreen relayout', async () => {
+    vi.useFakeTimers();
+
+    const setWindowFocus = vi.fn().mockResolvedValue(undefined);
+    const setWebviewFocus = vi.fn().mockResolvedValue(undefined);
+    const windowFocus = vi.spyOn(window, 'focus').mockImplementation(() => {});
+    const appRoot = document.createElement('div');
+    appRoot.className = 'bitfun-app-layout';
+    document.body.appendChild(appRoot);
+
+    const focusTarget: WindowKeyboardFocusTarget = {
+      setFocus: setWindowFocus,
+      setWebviewFocus,
+    };
+    const focusSnapshot: FocusSnapshot = {
+      activeElement: null,
+      wasInputFocused: false,
+    };
+
+    restoreWindowKeyboardFocus(focusTarget, focusSnapshot, 80);
+
+    await vi.advanceTimersByTimeAsync(80);
+    await vi.waitFor(() => {
+      expect(setWindowFocus).toHaveBeenCalledTimes(1);
+      expect(setWebviewFocus).toHaveBeenCalledTimes(1);
+    });
+
+    expect(document.activeElement).toBe(appRoot);
+
+    document.body.removeChild(appRoot);
+    windowFocus.mockRestore();
+    vi.useRealTimers();
+  });
+});

--- a/src/web-ui/src/app/hooks/windowKeyboardFocus.ts
+++ b/src/web-ui/src/app/hooks/windowKeyboardFocus.ts
@@ -1,0 +1,93 @@
+export type FocusSnapshot = {
+  activeElement: HTMLElement | null;
+  wasInputFocused: boolean;
+};
+
+export type WindowKeyboardFocusTarget = {
+  setFocus?: () => Promise<void> | void;
+  setWebviewFocus?: () => Promise<void> | void;
+} | null;
+
+export const captureFocusedEditable = (): FocusSnapshot => {
+  const activeElement =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const wasInputFocused = !!activeElement && (
+    activeElement.classList.contains('rich-text-input') ||
+    activeElement.closest('.rich-text-input') !== null ||
+    activeElement.isContentEditable
+  );
+
+  return { activeElement, wasInputFocused };
+};
+
+const restoreFocusedEditable = (snapshot: FocusSnapshot) => {
+  const chatInputs = document.querySelectorAll('.rich-text-input[contenteditable]');
+  chatInputs.forEach((input) => {
+    const element = input as HTMLElement;
+    if (element.getAttribute('contenteditable') !== 'true') {
+      element.setAttribute('contenteditable', 'true');
+    }
+  });
+
+  if (snapshot.wasInputFocused && snapshot.activeElement?.isConnected) {
+    try {
+      const rect = snapshot.activeElement.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        snapshot.activeElement.focus();
+      }
+    } catch (_error) {
+      // Ignore focus restore failures.
+    }
+  }
+};
+
+const focusAppRootForKeyboardShortcuts = () => {
+  const appRoot = document.querySelector('.bitfun-app-layout');
+  if (!(appRoot instanceof HTMLElement)) {
+    window.focus();
+    return;
+  }
+
+  const previousTabIndex = appRoot.getAttribute('tabindex');
+  appRoot.setAttribute('tabindex', '-1');
+  appRoot.focus({ preventScroll: true });
+
+  if (previousTabIndex === null) {
+    appRoot.removeAttribute('tabindex');
+  } else {
+    appRoot.setAttribute('tabindex', previousTabIndex);
+  }
+};
+
+export const restoreWindowKeyboardFocus = (
+  focusTarget: WindowKeyboardFocusTarget,
+  snapshot: FocusSnapshot,
+  delayMs: number
+) => {
+  setTimeout(() => {
+    void (async () => {
+      try {
+        await focusTarget?.setFocus?.();
+      } catch {
+        // Ignore focus failures during native window transitions.
+      }
+
+      try {
+        // Hidden fullscreen relayouts show the native window before the WebView
+        // reliably owns keyboard focus. The DOM F11 listener only receives the
+        // next keydown after the WebView, not just the native window, is focused.
+        await focusTarget?.setWebviewFocus?.();
+      } catch {
+        // Ignore focus failures during native webview transitions.
+      }
+
+      window.focus();
+
+      if (snapshot.wasInputFocused) {
+        restoreFocusedEditable(snapshot);
+      } else {
+        focusAppRootForKeyboardShortcuts();
+      }
+    })();
+  }, delayMs);
+};

--- a/src/web-ui/src/app/layout/AppLayout.scss
+++ b/src/web-ui/src/app/layout/AppLayout.scss
@@ -53,6 +53,10 @@ html, body {
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
 
+  &:focus {
+    outline: none;
+  }
+
   // All children
   * {
     box-sizing: border-box;
@@ -154,10 +158,62 @@ html, body {
   }
 }
 
+.bitfun-window-mode-hint {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + #{$size-gap-3});
+  left: 50%;
+  z-index: $z-notification;
+  display: inline-flex;
+  align-items: center;
+  gap: $size-gap-2;
+  max-width: min(560px, calc(100vw - 32px));
+  min-height: 34px;
+  padding: $size-gap-1 $size-gap-3;
+  border: 1px solid var(--border-subtle);
+  border-radius: $size-radius-base;
+  background: color-mix(in srgb, var(--color-bg-elevated) 90%, transparent);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.30);
+  color: var(--color-text-primary);
+  pointer-events: none;
+  transform: translateX(-50%);
+  animation: bitfun-window-mode-hint-in $motion-base $easing-decelerate both;
+  backdrop-filter: blur(12px);
+
+  &__title {
+    flex: 0 0 auto;
+    min-width: 0;
+    font-size: var(--font-size-sm);
+    font-weight: $font-weight-semibold;
+    line-height: 1.35;
+    white-space: nowrap;
+  }
+
+  &__detail {
+    min-width: 0;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 1.35;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
 @keyframes bitfun-acp-session-loading-in {
   from {
     opacity: 0;
     transform: translateX(-50%) translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+@keyframes bitfun-window-mode-hint-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-8px);
   }
   to {
     opacity: 1;
@@ -185,6 +241,19 @@ html, body {
   .bitfun-app-layout {
     --header-height: 32px;
   }
+
+  .bitfun-window-mode-hint {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 1px;
+    width: calc(100vw - 24px);
+    max-width: none;
+
+    &__title,
+    &__detail {
+      white-space: normal;
+    }
+  }
 }
 
 // ==================== Dark theme tweaks ====================
@@ -205,6 +274,10 @@ html, body {
 @media (prefers-reduced-motion: reduce) {
   .bitfun-app-layout * {
     transition: none;
+    animation: none;
+  }
+
+  .bitfun-window-mode-hint {
     animation: none;
   }
 }

--- a/src/web-ui/src/app/layout/AppLayout.tsx
+++ b/src/web-ui/src/app/layout/AppLayout.tsx
@@ -13,6 +13,7 @@ import { open } from '@tauri-apps/plugin-dialog';
 import { LoaderCircle } from 'lucide-react';
 import { useWorkspaceContext } from '../../infrastructure/contexts/WorkspaceContext';
 import { useWindowControls } from '../hooks/useWindowControls';
+import { isWindowFullscreenShortcut } from '../hooks/windowFullscreenShortcut';
 import { useAssistantBootstrap } from '../hooks/useAssistantBootstrap';
 import { useApp } from '../hooks/useApp';
 import { useSceneStore } from '../stores/sceneStore';
@@ -54,6 +55,12 @@ interface AcpSessionCreationEventDetail {
   action?: 'create' | 'restore';
 }
 
+interface WindowModeHint {
+  id: number;
+  title: string;
+  detail: string;
+}
+
 const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
   const { t } = useI18n('components');
   const { t: tCommon } = useI18n('common');
@@ -74,11 +81,54 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
 
   const { isToolbarMode } = useToolbarModeContext();
   const { ensureForWorkspace: ensureAssistantBootstrapForWorkspace } = useAssistantBootstrap();
+  const isMacOS = useMemo(() => {
+    return isMacOSDesktopRuntime();
+  }, []);
 
-  const { handleMinimize, handleMaximize, handleClose, isMaximized, canUseNativeWindowControls } =
+  const {
+    handleMinimize,
+    handleMaximize,
+    handleToggleFullscreen,
+    handleClose,
+    isMaximized,
+    isFullscreen,
+    canUseNativeWindowControls,
+  } =
     useWindowControls({ isToolbarMode });
 
   const { state, switchLeftPanelTab, toggleLeftPanel, toggleRightPanel } = useApp();
+  const [windowModeHint, setWindowModeHint] = useState<WindowModeHint | null>(null);
+  const windowModeHintTimerRef = useRef<number | null>(null);
+
+  const showWindowFullscreenHint = useCallback((enteredFullscreen: boolean) => {
+    if (windowModeHintTimerRef.current) {
+      window.clearTimeout(windowModeHintTimerRef.current);
+    }
+
+    const shortcut = isMacOS ? 'Control+Command+F' : 'F11';
+    setWindowModeHint({
+      id: Date.now(),
+      title: t(enteredFullscreen
+        ? 'appLayout.windowFullscreenEntered'
+        : 'appLayout.windowFullscreenExited'),
+      detail: t(enteredFullscreen
+        ? 'appLayout.windowFullscreenExitHint'
+        : 'appLayout.windowFullscreenEnterHint', { shortcut }),
+    });
+
+    windowModeHintTimerRef.current = window.setTimeout(() => {
+      setWindowModeHint(null);
+      windowModeHintTimerRef.current = null;
+    }, 2200);
+  }, [isMacOS, t]);
+
+  useEffect(() => {
+    return () => {
+      if (windowModeHintTimerRef.current) {
+        window.clearTimeout(windowModeHintTimerRef.current);
+      }
+    };
+  }, []);
 
   // ── Load user keybinding overrides from config on startup ────────────────
   useEffect(() => {
@@ -102,6 +152,32 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
 
     return () => unsubscribe();
   }, []);
+
+  useEffect(() => {
+    if (!canUseNativeWindowControls || isToolbarMode) return;
+
+    const handleSystemFullscreenShortcut = (event: KeyboardEvent) => {
+      if (!isWindowFullscreenShortcut(event)) return;
+
+      // OS fullscreen is a platform window command, not the app's maximize
+      // shortcut and not an internal panel fullscreen action. Use a raw
+      // listener because ShortcutManager intentionally maps Ctrl to Cmd on
+      // macOS for "mod" shortcuts, while system fullscreen requires the exact
+      // Control+Command+F chord.
+      event.preventDefault();
+      event.stopPropagation();
+      void handleToggleFullscreen().then((enteredFullscreen) => {
+        if (typeof enteredFullscreen === 'boolean') {
+          showWindowFullscreenHint(enteredFullscreen);
+        }
+      });
+    };
+
+    window.addEventListener('keydown', handleSystemFullscreenShortcut, { capture: true });
+    return () => {
+      window.removeEventListener('keydown', handleSystemFullscreenShortcut, { capture: true });
+    };
+  }, [canUseNativeWindowControls, handleToggleFullscreen, isToolbarMode, showWindowFullscreenHint]);
   const activeSceneId = useSceneStore(s => s.activeTabId);
   const isAgentScene = activeSceneId === 'session';
   const isWelcomeScene = activeSceneId === 'welcome';
@@ -174,10 +250,6 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
   }, [handleNewProject, handleOpenProject]);
 
   // macOS native menubar events (previously in TitleBar)
-  const isMacOS = useMemo(() => {
-    return isMacOSDesktopRuntime();
-  }, []);
-
   useEffect(() => {
     if (!isMacOS) return;
     let unlistenFns: Array<() => void> = [];
@@ -554,6 +626,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
     'bitfun-app-layout',
     isMacOS ? 'bitfun-app-layout--macos' : '',
     className,
+    isFullscreen ? 'bitfun-app-layout--window-fullscreen' : '',
     isTransitioning ? 'bitfun-app-layout--transitioning' : '',
   ].filter(Boolean).join(' ');
 
@@ -570,6 +643,18 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
     <>
       <DailyAppUpdateGate />
       <div className={containerClassName} data-testid="app-layout">
+        {windowModeHint && (
+          <div
+            key={windowModeHint.id}
+            className="bitfun-window-mode-hint"
+            role="status"
+            aria-live="polite"
+          >
+            <span className="bitfun-window-mode-hint__title">{windowModeHint.title}</span>
+            <span className="bitfun-window-mode-hint__detail">{windowModeHint.detail}</span>
+          </div>
+        )}
+
         {/* Main content — always render WorkspaceBody; WelcomeScene in viewport handles no-workspace state */}
         <main className="bitfun-app-main-workspace" data-testid="app-main-content">
           <WorkspaceBody

--- a/src/web-ui/src/infrastructure/api/service-api/SystemAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SystemAPI.ts
@@ -18,6 +18,12 @@ export interface CheckForUpdatesResponse {
   releaseDate: string | null;
 }
 
+/** Matches `toggle_main_window_fullscreen` / desktop `ToggleMainWindowFullscreenResponse`. */
+export interface ToggleMainWindowFullscreenResponse {
+  isFullscreen: boolean;
+  isMaximized: boolean;
+}
+
 /** Close-button behavior values (matches `app.close_button_behavior` config key). */
 export type CloseBehavior = 'quit' | 'minimize_to_tray' | 'ask';
 
@@ -220,6 +226,21 @@ export class SystemAPI {
       await api.invoke('minimize_to_tray', { request: {} });
     } catch (error) {
       throw createTauriCommandError('minimize_to_tray', error);
+    }
+  }
+
+  /**
+   * Desktop only: toggle OS-window fullscreen for the main window.
+   *
+   * This is intentionally not maximize and not app panel fullscreen. The
+   * desktop host owns the native fullscreen/maximize transition so the web UI
+   * does not stitch together multiple window-state calls.
+   */
+  async toggleMainWindowFullscreen(): Promise<ToggleMainWindowFullscreenResponse> {
+    try {
+      return await api.invoke('toggle_main_window_fullscreen', { request: {} });
+    } catch (error) {
+      throw createTauriCommandError('toggle_main_window_fullscreen', error);
     }
   }
 }

--- a/src/web-ui/src/locales/en-US/components.json
+++ b/src/web-ui/src/locales/en-US/components.json
@@ -531,7 +531,11 @@
     "projectRequestMessage": "I want to create a new project:\n\n{{description}}\n\nPlease design the project structure and start implementing it.",
     "projectRequestSent": "Project requirements sent to Xiaofang. Collaboration started.",
     "projectRequestSendFailed": "Failed to send project description. Please enter it manually.",
-    "flowChatInitFailed": "Initialization failed. Please refresh the page."
+    "flowChatInitFailed": "Initialization failed. Please refresh the page.",
+    "windowFullscreenEntered": "Entered window fullscreen",
+    "windowFullscreenExited": "Exited window fullscreen",
+    "windowFullscreenExitHint": "Press {{shortcut}} to exit.",
+    "windowFullscreenEnterHint": "Press {{shortcut}} to enter again."
   },
   "bottomBar": {
     "sessions": "Workbench",

--- a/src/web-ui/src/locales/en-US/errors.json
+++ b/src/web-ui/src/locales/en-US/errors.json
@@ -112,6 +112,7 @@
   },
   "window": {
     "maximizeFailed": "Failed to maximize window: {{error}}",
+    "fullscreenFailed": "Failed to toggle fullscreen: {{error}}",
     "closeFailed": "Failed to close window: {{error}}"
   },
   "editor": {

--- a/src/web-ui/src/locales/zh-CN/components.json
+++ b/src/web-ui/src/locales/zh-CN/components.json
@@ -531,7 +531,11 @@
     "projectRequestMessage": "我想创建一个新项目：\n\n{{description}}\n\n请帮我设计项目结构并开始实现。",
     "projectRequestSent": "已将项目需求发送给小方，开始协作创建！",
     "projectRequestSendFailed": "发送项目描述失败，请手动输入",
-    "flowChatInitFailed": "初始化失败，请刷新页面重试"
+    "flowChatInitFailed": "初始化失败，请刷新页面重试",
+    "windowFullscreenEntered": "已进入窗口全屏",
+    "windowFullscreenExited": "已退出窗口全屏",
+    "windowFullscreenExitHint": "按 {{shortcut}} 退出。",
+    "windowFullscreenEnterHint": "按 {{shortcut}} 再次进入。"
   },
   "bottomBar": {
     "sessions": "Agent 工作台",

--- a/src/web-ui/src/locales/zh-CN/errors.json
+++ b/src/web-ui/src/locales/zh-CN/errors.json
@@ -112,6 +112,7 @@
   },
   "window": {
     "maximizeFailed": "最大化窗口失败：{{error}}",
+    "fullscreenFailed": "切换全屏失败：{{error}}",
     "closeFailed": "关闭窗口失败：{{error}}"
   },
   "editor": {

--- a/src/web-ui/src/locales/zh-TW/components.json
+++ b/src/web-ui/src/locales/zh-TW/components.json
@@ -531,7 +531,11 @@
     "projectRequestMessage": "我想創建一個新項目：\n\n{{description}}\n\n請幫我設計項目結構並開始實現。",
     "projectRequestSent": "已將項目需求發送給小方，開始協作創建！",
     "projectRequestSendFailed": "發送項目描述失敗，請手動輸入",
-    "flowChatInitFailed": "初始化失敗，請刷新頁面重試"
+    "flowChatInitFailed": "初始化失敗，請刷新頁面重試",
+    "windowFullscreenEntered": "已進入視窗全螢幕",
+    "windowFullscreenExited": "已退出視窗全螢幕",
+    "windowFullscreenExitHint": "按 {{shortcut}} 退出。",
+    "windowFullscreenEnterHint": "按 {{shortcut}} 再次進入。"
   },
   "bottomBar": {
     "sessions": "Agent 工作臺",

--- a/src/web-ui/src/locales/zh-TW/errors.json
+++ b/src/web-ui/src/locales/zh-TW/errors.json
@@ -112,6 +112,7 @@
   },
   "window": {
     "maximizeFailed": "最大化窗口失敗：{{error}}",
+    "fullscreenFailed": "切換全屏失敗：{{error}}",
     "closeFailed": "關閉窗口失敗：{{error}}"
   },
   "editor": {

--- a/src/web-ui/src/tools/lsp/services/LspDocumentService.ts
+++ b/src/web-ui/src/tools/lsp/services/LspDocumentService.ts
@@ -117,11 +117,15 @@ class LspDocumentService {
     const manager = WorkspaceLspManager.getOrCreate(workspacePath);
     
     try {
-      await manager.openDocument(
+      const openResult = await manager.openDocument(
         event.uri,
         state.language,
         event.content
       );
+
+      if (!openResult.opened) {
+        return;
+      }
       
       state.isOpen = true;
       state.lastSyncedContent = event.content;

--- a/src/web-ui/src/tools/lsp/services/WorkspaceLspManager.test.ts
+++ b/src/web-ui/src/tools/lsp/services/WorkspaceLspManager.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const invokeMock = vi.hoisted(() => vi.fn());
+const listenMock = vi.hoisted(() => vi.fn(async () => () => {}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: listenMock
+}));
+
+vi.mock('@/shared/notification-system', () => ({
+  notificationService: {
+    progress: vi.fn(),
+    error: vi.fn(),
+    loading: vi.fn(() => ({
+      updateMessage: vi.fn(),
+      complete: vi.fn()
+    }))
+  }
+}));
+
+vi.mock('@/infrastructure/i18n', () => ({
+  i18nService: {
+    t: vi.fn((key: string) => key)
+  }
+}));
+
+import { WorkspaceLspManager } from './WorkspaceLspManager';
+
+function serverState(status: 'stopped' | 'starting' | 'running' | 'failed' | 'restarting') {
+  return {
+    status,
+    language: 'rust',
+    startedAt: null,
+    lastError: null,
+    restartCount: 0,
+    documentCount: 0
+  };
+}
+
+describe('WorkspaceLspManager', () => {
+  afterEach(() => {
+    invokeMock.mockReset();
+    listenMock.mockReset();
+    listenMock.mockResolvedValue(() => {});
+    (WorkspaceLspManager as unknown as {
+      instances: Map<string, WorkspaceLspManager>;
+    }).instances.clear();
+  });
+
+  it('skips didOpen when the language server is stopped', async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'lsp_open_workspace') {
+        return undefined;
+      }
+      if (command === 'lsp_get_server_state') {
+        return serverState('stopped');
+      }
+      if (command === 'lsp_open_document') {
+        throw new Error('didOpen should not be sent for a stopped server');
+      }
+      return undefined;
+    });
+
+    const manager = WorkspaceLspManager.getOrCreate('D:\\workspace\\BitFun');
+
+    const result = await manager.openDocument(
+      'file:///D:/workspace/BitFun/src/main.rs',
+      'rust',
+      'fn main() {}'
+    );
+
+    expect(result).toEqual({
+      language: 'rust',
+      opened: false,
+      skippedReason: 'server-not-running',
+      serverStatus: 'stopped'
+    });
+    expect(invokeMock).not.toHaveBeenCalledWith('lsp_open_document', expect.anything());
+  });
+
+  it('sends didOpen when the language server is running', async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'lsp_open_workspace') {
+        return undefined;
+      }
+      if (command === 'lsp_get_server_state') {
+        return serverState('running');
+      }
+      if (command === 'lsp_open_document') {
+        return undefined;
+      }
+      return undefined;
+    });
+
+    const manager = WorkspaceLspManager.getOrCreate('D:\\workspace\\BitFun');
+
+    const result = await manager.openDocument(
+      'file:///D:/workspace/BitFun/src/main.rs',
+      'rust',
+      'fn main() {}'
+    );
+
+    expect(result).toEqual({ language: 'rust', opened: true });
+    expect(invokeMock).toHaveBeenCalledWith('lsp_open_document', {
+      request: {
+        workspacePath: 'D:\\workspace\\BitFun',
+        uri: 'file:///D:/workspace/BitFun/src/main.rs',
+        language: 'rust',
+        content: 'fn main() {}'
+      }
+    });
+  });
+
+  it('caches stopped server state to avoid repeated state queries during UI remounts', async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'lsp_open_workspace') {
+        return undefined;
+      }
+      if (command === 'lsp_get_server_state') {
+        return serverState('stopped');
+      }
+      if (command === 'lsp_open_document') {
+        throw new Error('didOpen should not be sent for a stopped server');
+      }
+      return undefined;
+    });
+
+    const manager = WorkspaceLspManager.getOrCreate('D:\\workspace\\BitFun');
+
+    await manager.openDocument('file:///D:/workspace/BitFun/src/main.rs', 'rust', 'fn main() {}');
+    await manager.openDocument('file:///D:/workspace/BitFun/src/lib.rs', 'rust', 'pub fn lib() {}');
+
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+    expect(invokeMock).toHaveBeenCalledWith('lsp_open_workspace', {
+      request: { workspacePath: 'D:\\workspace\\BitFun' }
+    });
+    expect(invokeMock).toHaveBeenCalledWith('lsp_get_server_state', {
+      request: {
+        workspacePath: 'D:\\workspace\\BitFun',
+        language: 'rust'
+      }
+    });
+    expect(invokeMock).not.toHaveBeenCalledWith('lsp_open_document', expect.anything());
+  });
+});

--- a/src/web-ui/src/tools/lsp/services/WorkspaceLspManager.ts
+++ b/src/web-ui/src/tools/lsp/services/WorkspaceLspManager.ts
@@ -38,16 +38,29 @@ interface ServerState {
   documentCount: number;
 }
 
+type OpenDocumentSkippedReason = 'server-not-running';
+
+export interface OpenDocumentResult {
+  language: string;
+  opened: boolean;
+  skippedReason?: OpenDocumentSkippedReason;
+  serverStatus?: ServerState['status'];
+}
+
+interface CachedServerStatus {
+  status: ServerState['status'];
+  updatedAt: number;
+}
+
 export class WorkspaceLspManager {
   private static instances = new Map<string, WorkspaceLspManager>();
   
   private workspacePath: string;
   private eventUnlisten?: UnlistenFn;
   private isInitialized = false;
-  
-
-  private startingLanguages = new Set<string>();
-  private languageReadyPromises = new Map<string, Promise<void>>();
+  private serverStatusByLanguage = new Map<string, CachedServerStatus>();
+  private skippedOpenNoticeLanguages = new Set<string>();
+  private readonly SERVER_STATUS_CACHE_TTL_MS = 30000;
   
 
   private diagnosticsCallbacks = new Map<string, Array<(diagnostics: any[]) => void>>();
@@ -155,7 +168,81 @@ export class WorkspaceLspManager {
     return uri.toLowerCase();
   }
 
-  
+
+  private normalizeLanguage(language: string): string {
+    return language.trim().toLowerCase();
+  }
+
+
+  private isServerStatus(status?: string): status is ServerState['status'] {
+    return status === 'stopped'
+      || status === 'starting'
+      || status === 'running'
+      || status === 'failed'
+      || status === 'restarting';
+  }
+
+
+  private rememberServerStatus(language: string, status: ServerState['status']): void {
+    const key = this.normalizeLanguage(language);
+    this.serverStatusByLanguage.set(key, {
+      status,
+      updatedAt: Date.now()
+    });
+
+    if (status === 'running') {
+      this.skippedOpenNoticeLanguages.delete(key);
+    }
+  }
+
+
+  private getFreshCachedServerStatus(language: string): ServerState['status'] | undefined {
+    const cached = this.serverStatusByLanguage.get(this.normalizeLanguage(language));
+    if (!cached) {
+      return undefined;
+    }
+
+    if (Date.now() - cached.updatedAt > this.SERVER_STATUS_CACHE_TTL_MS) {
+      return undefined;
+    }
+
+    return cached.status;
+  }
+
+
+  private async getDocumentOpenAvailability(language: string): Promise<{
+    canOpen: boolean;
+    status?: ServerState['status'];
+    skippedReason?: OpenDocumentSkippedReason;
+  }> {
+    const cachedStatus = this.getFreshCachedServerStatus(language);
+    if (cachedStatus) {
+      return cachedStatus === 'running'
+        ? { canOpen: true, status: cachedStatus }
+        : {
+            canOpen: false,
+            status: cachedStatus,
+            skippedReason: 'server-not-running'
+          };
+    }
+
+    const state = await this.getServerState(language);
+    if (!state) {
+      return { canOpen: true };
+    }
+
+    this.rememberServerStatus(language, state.status);
+
+    return state.status === 'running'
+      ? { canOpen: true, status: state.status }
+      : {
+          canOpen: false,
+          status: state.status,
+          skippedReason: 'server-not-running'
+        };
+  }
+
+
   private onDiagnosticsReceived(data: LspEvent['data']) {
     const { uri, diagnostics } = data;
     
@@ -186,6 +273,9 @@ export class WorkspaceLspManager {
     
     if (!language) return;
 
+    if (this.isServerStatus(status)) {
+      this.rememberServerStatus(language, status);
+    }
 
     switch (status) {
       case 'starting':
@@ -282,21 +372,10 @@ export class WorkspaceLspManager {
       progressNotif.complete();
       this.indexingProgressNotifications.delete(language);
     }
-    
-
-    this.startingLanguages.delete(language);
   }
   
   
-  async openDocument(uri: string, language: string, content: string): Promise<string> {
-
-    if (this.startingLanguages.has(language)) {
-      const readyPromise = this.languageReadyPromises.get(language);
-      if (readyPromise) {
-        await readyPromise;
-      }
-    }
-    
+  async openDocument(uri: string, language: string, content: string): Promise<OpenDocumentResult> {
     if (!this.isInitialized) {
       try {
         await this.initialize();
@@ -305,21 +384,28 @@ export class WorkspaceLspManager {
         throw initError;
       }
     }
-    
 
-    if (!this.startingLanguages.has(language)) {
-      this.startingLanguages.add(language);
-      
+    // didOpen is only meaningful when a language server is actually running.
+    // Checking the state here prevents layout/remount churn (for example window
+    // fullscreen transitions) from generating batches of backend no-op logs.
+    const availability = await this.getDocumentOpenAvailability(language);
+    if (!availability.canOpen) {
+      const key = this.normalizeLanguage(language);
+      if (!this.skippedOpenNoticeLanguages.has(key)) {
+        log.debug('Skipped LSP didOpen because language server is not running', {
+          workspacePath: this.workspacePath,
+          language,
+          status: availability.status
+        });
+        this.skippedOpenNoticeLanguages.add(key);
+      }
 
-      const readyPromise = new Promise<void>((resolve) => {
-
-        setTimeout(() => {
-          this.startingLanguages.delete(language);
-          this.languageReadyPromises.delete(language);
-          resolve();
-        }, 5000);
-      });
-      this.languageReadyPromises.set(language, readyPromise);
+      return {
+        language,
+        opened: false,
+        skippedReason: availability.skippedReason,
+        serverStatus: availability.status
+      };
     }
     
     try {
@@ -341,7 +427,7 @@ export class WorkspaceLspManager {
       
 
 
-      return language;
+      return { language, opened: true };
     } catch (error) {
       log.error('Failed to open document', { workspacePath: this.workspacePath, uri, language, error });
       throw error;


### PR DESCRIPTION
﻿## Summary

- add a desktop system fullscreen command and F11 shortcut flow that is explicitly separate from window maximize
- show a short fullscreen status hint with localized exit guidance and preserve keyboard focus across toggles
- document the OS-window fullscreen product/implementation plan and add regression coverage for fullscreen shortcut and focus handling
- suppress noisy LSP didOpen attempts when a language server is stopped, with a backend trace-level fallback

## Product Behavior

This implements OS-level window fullscreen for the desktop shell, not panel fullscreen and not maximize. The flow preserves previous maximize state on exit, handles Windows monitor bounds for maximized-to-fullscreen transitions, and keeps F11 usable when no chat is open.

## Guardrails

- fullscreen and maximize paths are intentionally named and commented separately in the desktop API
- the frontend goes through the system API adapter instead of calling native window APIs directly from components
- stopped LSP servers are checked before didOpen so window/layout remounts do not flood backend debug logs

## Validation

- `git diff --check refs/remotes/upstream/main..HEAD`
- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run`
- `cargo check -p bitfun-core`
- `cargo check -p bitfun-desktop`
- `cargo test -p bitfun-desktop`
