### PR TITLE
Fix ACP tool diff fallback and search result rendering

### DIFF
--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -538,6 +538,25 @@ pub struct SessionManager {
 }
 
 impl SessionManager {
+    async fn resolve_model_context_window(model_id: &str) -> Option<usize> {
+        let trimmed = model_id.trim();
+        if trimmed.is_empty() || trimmed == "auto" || trimmed == "default" {
+            return None;
+        }
+
+        let config_service = get_global_config_service().await.ok()?;
+        let ai_config: crate::service::config::types::AIConfig =
+            config_service.get_config(Some("ai")).await.ok()?;
+        let resolved_model_id = ai_config.resolve_model_selection(trimmed)?;
+
+        ai_config
+            .models
+            .iter()
+            .find(|model| model.id == resolved_model_id)
+            .and_then(|model| model.context_window)
+            .map(|tokens| tokens as usize)
+    }
+
     fn normalize_session_title_input(title: &str) -> BitFunResult<String> {
         let trimmed = title.trim();
         if trimmed.is_empty() {
@@ -1472,6 +1491,8 @@ impl SessionManager {
         session_id: &str,
         model_id: &str,
     ) -> BitFunResult<()> {
+        let resolved_context_window = Self::resolve_model_context_window(model_id).await;
+
         // If the session was evicted from memory (idle > 1h), try to restore it
         // using the workspace path recorded when it was first created/restored.
         if !self.sessions.contains_key(session_id) && self.config.enable_persistence {
@@ -1490,6 +1511,9 @@ impl SessionManager {
 
         if let Some(mut session) = self.sessions.get_mut(session_id) {
             session.config.model_id = Some(model_id.to_string());
+            if let Some(context_window) = resolved_context_window {
+                session.config.max_context_tokens = context_window;
+            }
             session.updated_at = SystemTime::now();
             session.last_activity_at = SystemTime::now();
         } else {
@@ -1511,8 +1535,8 @@ impl SessionManager {
         }
 
         debug!(
-            "Session model id updated: session_id={}, model_id={}",
-            session_id, model_id
+            "Session model id updated: session_id={}, model_id={}, max_context_tokens={:?}",
+            session_id, model_id, resolved_context_window
         );
 
         Ok(())

--- a/src/crates/core/src/agentic/tools/implementations/grep_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/grep_tool.rs
@@ -1,19 +1,19 @@
 use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
 use crate::service::search::{
+    ContentSearchOutputMode, ContentSearchRequest, WorkspaceSearchHit, WorkspaceSearchLine,
     get_global_workspace_search_service, remote_workspace_search_service_for_path,
-    workspace_search_feature_enabled, workspace_search_runtime_available, ContentSearchOutputMode,
-    ContentSearchRequest, WorkspaceSearchHit, WorkspaceSearchLine,
+    workspace_search_feature_enabled, workspace_search_runtime_available,
 };
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
 use tool_runtime::search::grep_search::{
-    grep_search, GrepOptions, GrepSearchResult, OutputMode, ProgressCallback,
+    GrepOptions, GrepSearchResult, OutputMode, ProgressCallback, grep_search,
 };
 
 const DEFAULT_HEAD_LIMIT: usize = 250;
@@ -425,14 +425,30 @@ impl GrepTool {
             "content" => {
                 let mut lines =
                     render_workspace_search_content_lines(&result.hits, show_line_numbers);
+                if lines.is_empty() {
+                    lines = render_workspace_search_result_lines(
+                        &result.outcome.results,
+                        show_line_numbers,
+                    );
+                }
                 apply_offset_and_limit(&mut lines, offset, head_limit);
                 let rendered = Self::relativize_result_text(&lines.join("\n"), display_base);
-                let file_count = result
-                    .hits
-                    .iter()
-                    .map(|hit| hit.path.as_str())
-                    .collect::<HashSet<_>>()
-                    .len();
+                let file_count = if result.hits.is_empty() {
+                    result
+                        .outcome
+                        .results
+                        .iter()
+                        .map(|item| item.path.as_str())
+                        .collect::<HashSet<_>>()
+                        .len()
+                } else {
+                    result
+                        .hits
+                        .iter()
+                        .map(|hit| hit.path.as_str())
+                        .collect::<HashSet<_>>()
+                        .len()
+                };
                 (rendered, file_count, result.matched_occurrences)
             }
             "count" => {
@@ -463,6 +479,26 @@ impl GrepTool {
             }
         }
     }
+}
+
+fn render_workspace_search_result_lines(
+    results: &[crate::infrastructure::FileSearchResult],
+    show_line_numbers: bool,
+) -> Vec<String> {
+    results
+        .iter()
+        .filter_map(|result| {
+            let content = result.matched_content.as_deref()?.trim_end();
+            if show_line_numbers {
+                result
+                    .line_number
+                    .map(|line| format!("{}:{}:{}", result.path, line, content))
+                    .or_else(|| Some(format!("{}:{}", result.path, content)))
+            } else {
+                Some(format!("{}:{}", result.path, content))
+            }
+        })
+        .collect()
 }
 
 fn render_workspace_search_content_lines(
@@ -514,8 +550,11 @@ fn apply_offset_and_limit(items: &mut Vec<String>, offset: usize, head_limit: Op
 
 #[cfg(test)]
 mod tests {
-    use super::{render_workspace_search_content_lines, GrepTool, DEFAULT_HEAD_LIMIT};
-    use crate::infrastructure::FileSearchOutcome;
+    use super::{
+        DEFAULT_HEAD_LIMIT, GrepTool, render_workspace_search_content_lines,
+        render_workspace_search_result_lines,
+    };
+    use crate::infrastructure::{FileSearchOutcome, FileSearchResult, SearchMatchType};
     use crate::service::search::{
         ContentSearchResult, WorkspaceSearchBackend, WorkspaceSearchHit, WorkspaceSearchLine,
         WorkspaceSearchMatch, WorkspaceSearchMatchLocation, WorkspaceSearchRepoPhase,
@@ -709,6 +748,99 @@ mod tests {
         );
         assert_eq!(file_count, 1);
         assert_eq!(total_matches, 1);
+    }
+
+    #[test]
+    fn content_workspace_output_falls_back_to_converted_line_results() {
+        let tool = GrepTool::new();
+        let result = ContentSearchResult {
+            outcome: FileSearchOutcome {
+                results: vec![
+                    FileSearchResult {
+                        path: "/repo/src/main.rs".to_string(),
+                        name: "main.rs".to_string(),
+                        is_directory: false,
+                        match_type: SearchMatchType::Content,
+                        line_number: Some(12),
+                        matched_content: Some("panic!(\"x\")".to_string()),
+                        preview_before: None,
+                        preview_inside: Some("panic!(\"x\")".to_string()),
+                        preview_after: None,
+                    },
+                    FileSearchResult {
+                        path: "/repo/src/lib.rs".to_string(),
+                        name: "lib.rs".to_string(),
+                        is_directory: false,
+                        match_type: SearchMatchType::Content,
+                        line_number: Some(3),
+                        matched_content: Some("pub fn lib() {}".to_string()),
+                        preview_before: None,
+                        preview_inside: Some("pub fn lib() {}".to_string()),
+                        preview_after: None,
+                    },
+                ],
+                truncated: false,
+            },
+            file_counts: Vec::new(),
+            hits: Vec::new(),
+            backend: WorkspaceSearchBackend::Indexed,
+            repo_status: WorkspaceSearchRepoStatus {
+                repo_id: "repo".to_string(),
+                repo_path: "/repo".to_string(),
+                storage_root: "/repo/.bitfun/search/flashgrep-index".to_string(),
+                base_snapshot_root: "/repo/.bitfun/search/flashgrep-index/base-snapshot"
+                    .to_string(),
+                workspace_overlay_root: "/repo/.bitfun/search/flashgrep-index/workspace-overlay"
+                    .to_string(),
+                phase: WorkspaceSearchRepoPhase::Ready,
+                snapshot_key: None,
+                last_probe_unix_secs: None,
+                last_rebuild_unix_secs: None,
+                dirty_files: crate::service::search::WorkspaceSearchDirtyFiles {
+                    modified: 0,
+                    deleted: 0,
+                    new: 0,
+                },
+                rebuild_recommended: false,
+                active_task_id: None,
+                probe_healthy: true,
+                last_error: None,
+                overlay: None,
+            },
+            candidate_docs: 2,
+            matched_lines: 2,
+            matched_occurrences: 2,
+        };
+
+        let (rendered, file_count, total_matches) =
+            tool.format_workspace_search_output("content", true, 0, None, &result, Some("/repo"));
+
+        assert_eq!(
+            rendered,
+            "src/main.rs:12:panic!(\"x\")\nsrc/lib.rs:3:pub fn lib() {}"
+        );
+        assert_eq!(file_count, 2);
+        assert_eq!(total_matches, 2);
+    }
+
+    #[test]
+    fn renders_workspace_search_result_lines_without_line_numbers() {
+        let lines = render_workspace_search_result_lines(
+            &[FileSearchResult {
+                path: "/repo/src/main.rs".to_string(),
+                name: "main.rs".to_string(),
+                is_directory: false,
+                match_type: SearchMatchType::Content,
+                line_number: Some(12),
+                matched_content: Some("panic!(\"x\")".to_string()),
+                preview_before: None,
+                preview_inside: Some("panic!(\"x\")".to_string()),
+                preview_after: None,
+            }],
+            false,
+        );
+
+        assert_eq!(lines, vec!["/repo/src/main.rs:panic!(\"x\")"]);
     }
 }
 

--- a/src/crates/core/src/service/search/flashgrep/mod.rs
+++ b/src/crates/core/src/service/search/flashgrep/mod.rs
@@ -49,7 +49,7 @@ pub(crate) use protocol::{
     RepoRef, Request, Response, SearchHit, SearchLine, SearchParams, TaskRef,
 };
 pub(crate) use repo_session::FlashgrepRepoSession;
-pub(crate) use rpc_client::{drain_content_length_messages, ProtocolClient};
+pub(crate) use rpc_client::{ProtocolClient, drain_content_length_messages};
 pub(crate) use types::{
     ConsistencyMode, DirtyFileStats, FileCount, GlobOutcome, GlobRequest, OpenRepoParams,
     PathScope, QuerySpec, RefreshPolicyConfig, RepoConfig, RepoPhase, RepoStatus, SearchBackend,

--- a/src/crates/core/src/service/search/flashgrep/protocol.rs
+++ b/src/crates/core/src/service/search/flashgrep/protocol.rs
@@ -238,7 +238,7 @@ pub(crate) enum CorpusModeConfig {
     NoIgnore,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum SearchModeConfig {
     CountOnly,
@@ -496,6 +496,8 @@ pub(crate) struct SearchResults {
     #[serde(default)]
     pub file_match_counts: Vec<FileMatchCount>,
     #[serde(default)]
+    pub line_matches: Vec<LineMatch>,
+    #[serde(default)]
     pub hits: Vec<SearchHit>,
 }
 
@@ -509,6 +511,13 @@ pub(crate) struct FileCount {
 pub(crate) struct FileMatchCount {
     pub path: String,
     pub matched_occurrences: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct LineMatch {
+    pub path: String,
+    pub line_number: usize,
+    pub line_text: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/crates/core/src/service/search/remote.rs
+++ b/src/crates/core/src/service/search/remote.rs
@@ -1,21 +1,20 @@
 use crate::infrastructure::{FileSearchOutcome, FileSearchResult, SearchMatchType};
-use crate::service::config::{get_global_config_service, types::WorkspaceConfig, ConfigService};
+use crate::service::config::{ConfigService, get_global_config_service, types::WorkspaceConfig};
 use crate::service::remote_ssh::workspace_state::{
-    get_remote_workspace_manager, lookup_remote_connection, lookup_remote_connection_with_hint,
-    RemoteWorkspaceEntry,
+    RemoteWorkspaceEntry, get_remote_workspace_manager, lookup_remote_connection,
+    lookup_remote_connection_with_hint,
 };
 use crate::service::remote_ssh::{
-    normalize_remote_workspace_path, RemoteFileService, SSHConnectionManager,
+    RemoteFileService, SSHConnectionManager, normalize_remote_workspace_path,
 };
 use crate::service::search::flashgrep::{
-    drain_content_length_messages, ClientCapabilities, ClientInfo, ConsistencyMode, GlobOutcome,
-    GlobParams, GlobRequest, InitializeParams, OpenRepoParams, PathScope, ProtocolClient,
-    QuerySpec, RefreshPolicyConfig, RepoConfig, RepoRef, RepoStatus, Request, Response,
-    SearchBackend, SearchModeConfig, SearchOutcome, SearchParams, SearchRequest, SearchResults,
-    TaskRef, TaskStatus,
-    FLASHGREP_LOG_TARGET, log_flashgrep_stderr_line_with_context,
+    ClientCapabilities, ClientInfo, ConsistencyMode, FLASHGREP_LOG_TARGET, GlobOutcome, GlobParams,
+    GlobRequest, InitializeParams, OpenRepoParams, PathScope, ProtocolClient, QuerySpec,
+    RefreshPolicyConfig, RepoConfig, RepoRef, RepoStatus, Request, Response, SearchBackend,
+    SearchModeConfig, SearchOutcome, SearchParams, SearchRequest, SearchResults, TaskRef,
+    TaskStatus, drain_content_length_messages, log_flashgrep_stderr_line_with_context,
 };
-use crate::service::search::flashgrep::{error::AppError, FlashgrepRepoSession};
+use crate::service::search::flashgrep::{FlashgrepRepoSession, error::AppError};
 use crate::service::search::{
     ContentSearchOutputMode, ContentSearchRequest, ContentSearchResult, GlobSearchRequest,
     GlobSearchResult, IndexTaskHandle, WorkspaceIndexStatus, WorkspaceSearchFileCount,
@@ -27,12 +26,12 @@ use std::collections::{BTreeMap, HashMap};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
     Arc, LazyLock,
+    atomic::{AtomicU64, Ordering},
 };
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
-use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio::time::{sleep, timeout};
 
 const REMOTE_FLASHGREP_INSTALL_DIR: &str = ".bitfun/bin";
@@ -1388,6 +1387,11 @@ fn convert_stdio_search_results(
                 return hit_results;
             }
 
+            let line_results = convert_stdio_line_matches_to_file_search_results(search_results);
+            if !line_results.is_empty() {
+                return line_results;
+            }
+
             let count_results = convert_stdio_file_counts_to_search_results(search_results);
             if !count_results.is_empty() {
                 return count_results;
@@ -1416,6 +1420,30 @@ fn remote_stdio_search_mode(output_mode: ContentSearchOutputMode) -> SearchModeC
         ContentSearchOutputMode::Count => SearchModeConfig::CountOnly,
         ContentSearchOutputMode::FilesWithMatches => SearchModeConfig::FilesWithMatches,
     }
+}
+
+fn convert_stdio_line_matches_to_file_search_results(
+    search_results: &SearchResults,
+) -> Vec<FileSearchResult> {
+    search_results
+        .line_matches
+        .iter()
+        .map(|matched| FileSearchResult {
+            path: matched.path.clone(),
+            name: Path::new(&matched.path)
+                .file_name()
+                .and_then(|file_name| file_name.to_str())
+                .unwrap_or(&matched.path)
+                .to_string(),
+            is_directory: false,
+            match_type: SearchMatchType::Content,
+            line_number: Some(matched.line_number),
+            matched_content: Some(matched.line_text.clone()),
+            preview_before: None,
+            preview_inside: Some(matched.line_text.clone()),
+            preview_after: None,
+        })
+        .collect()
 }
 
 fn convert_stdio_file_counts_to_search_results(

--- a/src/crates/core/src/service/search/service.rs
+++ b/src/crates/core/src/service/search/service.rs
@@ -2,17 +2,17 @@ use crate::infrastructure::{FileSearchOutcome, FileSearchResult, SearchMatchType
 use crate::service::bootstrap::ensure_workspace_gitignore_ignores_bitfun;
 use crate::service::config::{get_global_config_service, types::WorkspaceConfig};
 use crate::service::search::flashgrep::{
-    ConsistencyMode, FlashgrepRepoSession, GlobRequest, ManagedClient, OpenRepoParams, PathScope,
-    QuerySpec, RefreshPolicyConfig, RepoConfig, RepoSession, SearchRequest, SearchResults,
-    FLASHGREP_LOG_TARGET,
+    ConsistencyMode, FLASHGREP_LOG_TARGET, FlashgrepRepoSession, GlobRequest, ManagedClient,
+    OpenRepoParams, PathScope, QuerySpec, RefreshPolicyConfig, RepoConfig, RepoSession,
+    SearchRequest, SearchResults,
 };
 use crate::util::errors::{BitFunError, BitFunResult};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
     Arc, LazyLock, Mutex as StdMutex, Weak,
+    atomic::{AtomicU64, Ordering},
 };
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, RwLock};
@@ -826,6 +826,11 @@ fn convert_search_results(
                 return hit_results;
             }
 
+            let line_results = convert_line_matches_to_file_search_results(search_results);
+            if !line_results.is_empty() {
+                return line_results;
+            }
+
             let count_results = convert_file_counts_to_search_results(search_results);
             if !count_results.is_empty() {
                 return count_results;
@@ -843,6 +848,30 @@ fn convert_search_results(
             convert_matched_paths_to_file_only_results(search_results)
         }
     }
+}
+
+fn convert_line_matches_to_file_search_results(
+    search_results: &SearchResults,
+) -> Vec<FileSearchResult> {
+    search_results
+        .line_matches
+        .iter()
+        .map(|matched| FileSearchResult {
+            path: matched.path.clone(),
+            name: Path::new(&matched.path)
+                .file_name()
+                .and_then(|file_name| file_name.to_str())
+                .unwrap_or(&matched.path)
+                .to_string(),
+            is_directory: false,
+            match_type: SearchMatchType::Content,
+            line_number: Some(matched.line_number),
+            matched_content: Some(matched.line_text.clone()),
+            preview_before: None,
+            preview_inside: Some(matched.line_text.clone()),
+            preview_after: None,
+        })
+        .collect()
 }
 
 fn convert_file_counts_to_search_results(search_results: &SearchResults) -> Vec<FileSearchResult> {
@@ -985,5 +1014,51 @@ fn map_flashgrep_error(
             _ => error.to_string(),
         };
         BitFunError::service(format!("{prefix}: {detail}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_search_results() -> SearchResults {
+        serde_json::from_value(serde_json::json!({
+            "candidate_docs": 0,
+            "searches_with_match": 0,
+            "bytes_searched": 0,
+            "matched_lines": 0,
+            "matched_occurrences": 0
+        }))
+        .expect("empty search results should decode with defaulted collections")
+    }
+
+    #[test]
+    fn content_search_uses_flashgrep_line_matches_protocol() {
+        assert_eq!(
+            ContentSearchOutputMode::Content.search_mode(),
+            crate::service::search::flashgrep::SearchModeConfig::LineMatches
+        );
+    }
+
+    #[test]
+    fn content_search_converts_legacy_line_matches() {
+        let mut search_results = empty_search_results();
+        search_results.line_matches = serde_json::from_value(serde_json::json!([{
+            "path": "src/search.rs",
+            "line_number": 42,
+            "line_text": "pub enum SearchMode"
+        }]))
+        .expect("legacy line_matches should decode");
+
+        let results = convert_search_results(&search_results, ContentSearchOutputMode::Content);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, "src/search.rs");
+        assert_eq!(results[0].name, "search.rs");
+        assert_eq!(results[0].line_number, Some(42));
+        assert_eq!(
+            results[0].matched_content.as_deref(),
+            Some("pub enum SearchMode")
+        );
     }
 }

--- a/src/crates/core/src/service/search/types.rs
+++ b/src/crates/core/src/service/search/types.rs
@@ -21,7 +21,7 @@ pub enum ContentSearchOutputMode {
 impl ContentSearchOutputMode {
     pub(crate) fn search_mode(self) -> SearchModeConfig {
         match self {
-            Self::Content => SearchModeConfig::MaterializeMatches,
+            Self::Content => SearchModeConfig::LineMatches,
             Self::Count => SearchModeConfig::CountOnly,
             Self::FilesWithMatches => SearchModeConfig::FilesWithMatches,
         }

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -19,6 +19,7 @@ import { globalEventBus } from '@/infrastructure/event-bus';
 import type { AIModelConfig } from '@/infrastructure/config/types';
 import { Tooltip } from '@/component-library';
 import { FlowChatStore } from '../store/FlowChatStore';
+import { getModelMaxTokens } from '../services/flow-chat-manager/SessionModule';
 import { createLogger } from '@/shared/utils/logger';
 import './ModelSelector.scss';
 
@@ -386,6 +387,8 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       if (sessionId) {
         const store = FlowChatStore.getInstance();
         store.updateSessionModelName(sessionId, modelId);
+        const maxContextTokens = await getModelMaxTokens(modelId, currentMode);
+        store.updateSessionMaxContextTokens(sessionId, maxContextTokens);
         const session = store.getState().sessions.get(sessionId);
         if (!session?.isTransient) {
           await agentAPI.updateSessionModel({

--- a/src/web-ui/src/flow_chat/hooks/useFlowChat.ts
+++ b/src/web-ui/src/flow_chat/hooks/useFlowChat.ts
@@ -15,12 +15,12 @@ import {
 import { flowChatStore } from '../store/FlowChatStore';
 import { flowChatManager } from '../services/FlowChatManager';
 import type { UnlistenFn } from '@tauri-apps/api/event';
-import { configManager } from '@/infrastructure/config/services/ConfigManager';
 import { i18nService } from '@/infrastructure/i18n';
 import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
 import { WorkspaceKind } from '@/shared/types';
 import { generateTempTitle } from '../utils/titleUtils';
 import { createLogger } from '@/shared/utils/logger';
+import { getModelMaxTokens } from '../services/flow-chat-manager/SessionModule';
 import {
   createI18nSessionTitleDescriptor,
   getNextDefaultSessionTitleCount,
@@ -28,40 +28,6 @@ import {
 } from '../utils/sessionTitle';
 
 const log = createLogger('useFlowChat');
-
-/**
- * Resolve the model context window size.
- */
-async function getModelContextWindow(modelName?: string): Promise<number> {
-  try {
-    const models = await configManager.getConfig<any[]>('ai.models') || [];
-    
-    // Prefer the specified model if provided.
-    if (modelName) {
-      const model = models.find(m => m.name === modelName || m.id === modelName);
-      if (model?.context_window) {
-        return model.context_window;
-      }
-    }
-    
-    // Fallback to the primary default model.
-    const defaultModels = await configManager.getConfig<any>('ai.default_models');
-    const primaryModelId = defaultModels?.primary;
-
-    if (primaryModelId) {
-      const primaryModel = models.find(m => m.id === primaryModelId);
-      if (primaryModel?.context_window) {
-        return primaryModel.context_window;
-      }
-    }
-    
-    // Final fallback.
-    return 128128;
-  } catch (error) {
-    log.error('Failed to get model context window size', { error });
-    return 128128;
-  }
-}
 
 export const useFlowChat = () => {
   const { workspacePath, workspace } = useCurrentWorkspace();
@@ -102,13 +68,12 @@ export const useFlowChat = () => {
         throw new Error('Workspace path is required to create a session');
       }
       
-      const maxContextTokens = await getModelContextWindow(config?.modelName);
-      
       const isRemote = workspace?.workspaceKind === WorkspaceKind.Remote;
       const remoteConnectionId = isRemote ? workspace?.connectionId : undefined;
       const remoteSshHost = isRemote ? workspace?.sshHost : undefined;
 
       const agentTypeForSession = (config?.agentType || 'agentic').trim() || 'agentic';
+      const maxContextTokens = await getModelMaxTokens(config?.modelName, agentTypeForSession);
       const sessionTitleMode =
         workspace?.workspaceKind === WorkspaceKind.Assistant
           ? 'claw'

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -13,7 +13,7 @@ import { SessionExecutionEvent, SessionExecutionState } from '../../state-machin
 import { generateTempTitle } from '../../utils/titleUtils';
 import { createLogger } from '@/shared/utils/logger';
 import type { FlowChatContext, DialogTurn } from './types';
-import { ensureBackendSession, retryCreateBackendSession } from './SessionModule';
+import { ensureBackendSession, getModelMaxTokens, retryCreateBackendSession } from './SessionModule';
 import { cleanupSessionBuffers } from './TextChunkModule';
 import type { ImageContextData as ImageInputContextData } from '@/infrastructure/api/service-api/ImageContextTypes';
 import { globalEventBus } from '@/infrastructure/event-bus';
@@ -68,21 +68,30 @@ async function syncSessionModelSelection(
     throw new Error(`Session does not exist: ${sessionId}`);
   }
 
-  const [agentModels, allModels, defaultModels] = await Promise.all([
-    configManager.getConfig<Record<string, string>>('ai.agent_models') || {},
-    configManager.getConfig<AIModelConfig[]>('ai.models') || [],
-    configManager.getConfig<DefaultModelsConfig>('ai.default_models') || {},
+  const [agentModelsConfig, allModelsConfig, defaultModelsConfig] = await Promise.all([
+    configManager.getConfig<Record<string, string>>('ai.agent_models'),
+    configManager.getConfig<AIModelConfig[]>('ai.models'),
+    configManager.getConfig<DefaultModelsConfig>('ai.default_models'),
   ]);
+  const agentModels = agentModelsConfig || {};
+  const allModels = allModelsConfig || [];
+  const defaultModels = defaultModelsConfig || {};
 
   const desiredModelId = normalizeModelSelection(agentModels[agentType], allModels, defaultModels);
   const currentModelId = (session.config.modelName || 'auto').trim() || 'auto';
   const shouldForceAutoSync = desiredModelId === 'auto';
-  if (!shouldForceAutoSync && desiredModelId === currentModelId) {
+  const desiredMaxContextTokens = await getModelMaxTokens(desiredModelId, agentType);
+  const shouldSyncContextWindow = session.maxContextTokens !== desiredMaxContextTokens;
+
+  if (!shouldForceAutoSync && desiredModelId === currentModelId && !shouldSyncContextWindow) {
     return;
   }
 
   if (currentModelId !== desiredModelId) {
     context.flowChatStore.updateSessionModelName(sessionId, desiredModelId);
+  }
+  if (shouldSyncContextWindow) {
+    context.flowChatStore.updateSessionMaxContextTokens(sessionId, desiredMaxContextTokens);
   }
   await agentAPI.updateSessionModel({
     sessionId,

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -11,6 +11,7 @@ import { i18nService } from '@/infrastructure/i18n';
 import { workspaceManager } from '@/infrastructure/services/business/workspaceManager';
 import { normalizeRemoteWorkspacePath } from '@/shared/utils/pathUtils';
 import { WorkspaceKind, type WorkspaceInfo } from '@/shared/types';
+import type { AIModelConfig, DefaultModelsConfig } from '@/infrastructure/config/types';
 import type { FlowChatContext, SessionConfig } from './types';
 import { touchSessionActivity, cleanupSaveState } from './PersistenceModule';
 import {
@@ -269,32 +270,73 @@ function requireSessionWorkspacePath(
 /**
  * Get model's maximum token count
  */
-export async function getModelMaxTokens(modelName?: string): Promise<number> {
+function findEnabledModel(models: AIModelConfig[], modelRef: string | null | undefined): AIModelConfig | null {
+  const value = modelRef?.trim();
+  if (!value) return null;
+  return models.find(model =>
+    model.enabled !== false
+    && (model.id === value || model.name === value || model.model_name === value)
+  ) ?? null;
+}
+
+function resolveModelForContextWindow(
+  modelRef: string | null | undefined,
+  models: AIModelConfig[],
+  defaultModels: DefaultModelsConfig,
+): AIModelConfig | null {
+  const value = modelRef?.trim();
+  if (!value) return null;
+
+  if (value === 'primary') {
+    return findEnabledModel(models, defaultModels.primary);
+  }
+
+  if (value === 'fast') {
+    return findEnabledModel(models, defaultModels.fast) ?? findEnabledModel(models, defaultModels.primary);
+  }
+
+  if (value === 'auto' || value === 'default') {
+    return null;
+  }
+
+  return findEnabledModel(models, value);
+}
+
+export async function getModelMaxTokens(modelName?: string, agentType?: string): Promise<number> {
   try {
     const configManager = await import('@/infrastructure/config/services/ConfigManager').then(m => m.configManager);
-    const models = await configManager.getConfig<any[]>('ai.models') || [];
+    const [modelsConfig, defaultModelsConfig, agentModelsConfig] = await Promise.all([
+      configManager.getConfig<AIModelConfig[]>('ai.models'),
+      configManager.getConfig<DefaultModelsConfig>('ai.default_models'),
+      configManager.getConfig<Record<string, string>>('ai.agent_models'),
+    ]);
+    const models = modelsConfig || [];
+    const defaultModels = defaultModelsConfig || {};
+    const agentModels = agentModelsConfig || {};
     
-    if (modelName) {
-      const model = models.find(m => m.name === modelName || m.id === modelName);
-      if (model?.context_window) {
-        return model.context_window;
-      }
+    const explicitModel = resolveModelForContextWindow(modelName, models, defaultModels);
+    if (explicitModel?.context_window) {
+      return explicitModel.context_window;
+    }
+
+    const agentModel = resolveModelForContextWindow(
+      agentType ? agentModels[agentType] : undefined,
+      models,
+      defaultModels,
+    );
+    if (agentModel?.context_window) {
+      return agentModel.context_window;
+    }
+
+    const primaryModel = resolveModelForContextWindow('primary', models, defaultModels);
+    if (primaryModel?.context_window) {
+      return primaryModel.context_window;
     }
     
-    const defaultModels = await configManager.getConfig<Record<string, string>>('ai.default_models');
-    const primaryModelId = defaultModels?.primary;
-    
-    if (primaryModelId) {
-      const primaryModel = models.find(m => m.id === primaryModelId);
-      if (primaryModel?.context_window) {
-        return primaryModel.context_window;
-      }
-    }
-    
-    log.debug('Model context_window config not found, using default', { modelName });
+    log.debug('Model context_window config not found, using default', { modelName, agentType });
     return 128128;
   } catch (error) {
-    log.warn('Failed to get model max tokens', { modelName, error });
+    log.warn('Failed to get model max tokens', { modelName, agentType, error });
     return 128128;
   }
 }
@@ -351,7 +393,7 @@ export async function createChatSession(
     );
     const sessionName = titleDescriptor.text;
     
-    const maxContextTokens = await getModelMaxTokens(config.modelName);
+    const maxContextTokens = await getModelMaxTokens(config.modelName, agentType);
 
     const mergedConfig: SessionConfig = {
       ...config,

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.test.tsx
@@ -10,6 +10,7 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const mocks = vi.hoisted(() => ({
   currentWorkspace: undefined as undefined | { rootPath: string },
+  createDiffEditorTab: vi.fn(),
   openFile: vi.fn(),
   getOperationDiff: vi.fn(async () => ({
     originalContent: '',
@@ -64,7 +65,7 @@ vi.mock('../components/InlineDiffPreview', () => ({
 }));
 
 vi.mock('../../shared/utils/tabUtils', () => ({
-  createDiffEditorTab: vi.fn(),
+  createDiffEditorTab: mocks.createDiffEditorTab,
 }));
 
 vi.mock('../../shared/services/FileTabManager', () => ({
@@ -115,6 +116,7 @@ describe('FileOperationToolCard', () => {
     root = createRoot(container);
 
     mocks.currentWorkspace = undefined;
+    mocks.createDiffEditorTab.mockReset();
     mocks.openFile.mockReset();
     mocks.getOperationDiff.mockReset();
     mocks.getOperationDiff.mockResolvedValue({
@@ -240,5 +242,76 @@ describe('FileOperationToolCard', () => {
       fileName: 'newFile.ts',
       mode: 'agent',
     }));
+  });
+
+  it('opens a local diff for completed write cards without snapshot context', async () => {
+    const toolItem: FlowToolItem = {
+      id: 'tool-1',
+      type: 'tool',
+      toolName: 'Write',
+      status: 'completed',
+      toolCall: {
+        id: 'call-1',
+        name: 'Write',
+        input: {
+          filepath: 'src/newFile.ts',
+          content: 'export const value = 1;\n',
+        },
+      },
+      toolResult: {
+        success: true,
+        result: {
+          success: true,
+        },
+      },
+    } as FlowToolItem;
+
+    const config: ToolCardConfig = {
+      toolName: 'Write',
+      displayName: 'Write',
+      icon: 'WRITE',
+      requiresConfirmation: false,
+      resultDisplayType: 'detailed',
+      description: 'Write a file',
+      displayMode: 'standard',
+    };
+
+    await act(async () => {
+      root.render(
+        <FileOperationToolCard
+          toolItem={toolItem}
+          config={config}
+        />
+      );
+    });
+
+    const diffButton = container.querySelector('.file-op-diff-pill') as HTMLButtonElement | null;
+    expect(diffButton).not.toBeNull();
+
+    await act(async () => {
+      diffButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    await act(async () => {
+      dom.window.dispatchEvent(new dom.window.Event('tick'));
+      await new Promise(resolve => dom.window.setTimeout(resolve, 260));
+    });
+
+    expect(mocks.getOperationDiff).not.toHaveBeenCalled();
+    expect(mocks.createDiffEditorTab).toHaveBeenCalledWith(
+      'src/newFile.ts',
+      'newFile.ts',
+      '',
+      'export const value = 1;\n',
+      false,
+      'agent',
+      undefined,
+      undefined,
+      false,
+      {
+        titleKind: 'diff',
+        duplicateKeyPrefix: 'diff',
+      },
+    );
   });
 });

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -59,6 +59,19 @@ function stringPath(value: unknown): string {
   return typeof value === 'string' && value.trim().length > 0 ? value : '';
 }
 
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? value as Record<string, unknown> : null;
+}
+
+function firstStringValue(source: Record<string, unknown> | null | undefined, keys: string[]): string {
+  if (!source) return '';
+  for (const key of keys) {
+    const value = stringPath(source[key]);
+    if (value) return value;
+  }
+  return '';
+}
+
 function isWindowsAbsolutePath(filePath: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(filePath);
 }
@@ -131,12 +144,20 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
       return resultPath;
     }
 
-    const params = partialParams || toolCall?.input;
+    const params = objectValue(partialParams || toolCall?.input);
     if (!params) return '';
     
     if (Object.keys(params).length === 0) return '';
     
-    return params.file_path || params.target_file || params.path || params.filename || '';
+    return firstStringValue(params, [
+      'file_path',
+      'filePath',
+      'filepath',
+      'target_file',
+      'targetFile',
+      'path',
+      'filename',
+    ]);
   }, [toolCall, partialParams, toolResult]);
 
   const currentFilePath = getFilePath();
@@ -310,6 +331,24 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   const currentFileDiffStats = useMemo(() => {
     return operationDiffStats ?? localDiffStats ?? { additions: 0, deletions: 0 };
   }, [operationDiffStats, localDiffStats]);
+
+  const localDiffContent = useMemo(() => {
+    if (toolItem.toolName === 'Edit' && (oldStringContent || newStringContent)) {
+      return {
+        originalContent: oldStringContent,
+        modifiedContent: newStringContent,
+      };
+    }
+
+    if (toolItem.toolName === 'Write' && contentPreview) {
+      return {
+        originalContent: '',
+        modifiedContent: contentPreview,
+      };
+    }
+
+    return null;
+  }, [contentPreview, newStringContent, oldStringContent, toolItem.toolName]);
 
   useEffect(() => {
     if (!sessionId || !toolCall?.id || status !== 'completed' || isFailed) return;
@@ -560,7 +599,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   ]);
 
   const handleOpenBaselineDiff = useCallback(async () => {
-    if (!currentFilePath || !currentWorkspace || !sessionId) {
+    if (!currentFilePath) {
       log.warn('Cannot open diff: missing required info', {
         hasFilePath: !!currentFilePath,
         hasWorkspace: !!currentWorkspace,
@@ -571,6 +610,50 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
 
     const diffFilePath = currentFile?.filePath || currentFilePath;
     const fileName = diffFilePath.split(/[/\\]/).pop() || diffFilePath;
+
+    const openLocalDiff = () => {
+      if (!localDiffContent) return false;
+
+      if (localDiffContent.originalContent === localDiffContent.modifiedContent) {
+        notificationService.info(
+          `No changes to display for ${fileName}: original and modified content are identical.`
+        );
+        return true;
+      }
+
+      window.dispatchEvent(new CustomEvent('expand-right-panel'));
+
+      setTimeout(() => {
+        createDiffEditorTab(
+          diffFilePath,
+          fileName,
+          localDiffContent.originalContent,
+          localDiffContent.modifiedContent,
+          false,
+          'agent',
+          currentWorkspace?.rootPath,
+          undefined,
+          false,
+          {
+            titleKind: 'diff',
+            duplicateKeyPrefix: 'diff'
+          }
+        );
+      }, 250);
+
+      return true;
+    };
+
+    if (!currentWorkspace || !sessionId) {
+      if (openLocalDiff()) return;
+
+      log.warn('Cannot open diff: no snapshot context and no local diff content', {
+        filePath: currentFilePath,
+        hasWorkspace: !!currentWorkspace,
+        hasSessionId: !!sessionId,
+      });
+      return;
+    }
 
     try {
       const { snapshotAPI } = await import('../../infrastructure/api');
@@ -586,6 +669,14 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
       const modifiedContent = diffData.modifiedContent || '';
 
       if (originalContent === modifiedContent) {
+        if (
+          localDiffContent &&
+          localDiffContent.originalContent !== localDiffContent.modifiedContent
+        ) {
+          openLocalDiff();
+          return;
+        }
+
         log.info('Baseline diff has no changes, skipping diff editor', {
           filePath: diffFilePath,
           originalLength: originalContent.length,
@@ -619,9 +710,17 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
         );
       }, 250);
     } catch (error) {
+      if (openLocalDiff()) {
+        log.warn('Snapshot diff unavailable, opened local tool diff instead', {
+          filePath: currentFilePath,
+          error,
+        });
+        return;
+      }
+
       log.error('Failed to open Baseline Diff', { filePath: currentFilePath, error });
     }
-  }, [currentFile, currentFilePath, currentWorkspace, sessionId, toolCall?.id]);
+  }, [currentFile, currentFilePath, currentWorkspace, localDiffContent, sessionId, toolCall?.id]);
 
   const getToolIconInfo = () => {
     const iconMap: Record<string, { icon: React.ReactNode; className: string }> = {
@@ -799,7 +898,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   const renderHeader = () => {
     const { className: iconClassName } = getToolIconInfo();
     const gitDiffDisabled =
-      !currentFilePath || !currentWorkspace || !sessionId;
+      !currentFilePath || (!localDiffContent && (!currentWorkspace || !sessionId));
     const hasDiffStats =
       currentFileDiffStats.additions > 0 || currentFileDiffStats.deletions > 0;
 


### PR DESCRIPTION
## Summary

- Fixes ACP tool diff fallback behavior.
- Updates session context handling so model context limits follow the selected model configuration.
- Aligns BitFun workspace search with the current flashgrep protocol by using `line_matches` for content search results.
- Fixes Grep tool rendering so converted line-level search results are shown to the model instead of reporting zero files when matches exist.

## Root Cause

BitFun still rendered content-mode workspace search output from the older `hits` shape. After flashgrep returned line-level matches through the newer protocol, the search backend reported matches, but the Grep tool could render an empty result and a zero file count. That misled the model into thinking the search matched zero files.

## Validation

- `cargo check -p bitfun-core`
- `cargo test -p bitfun-core service::search::service::tests -- --nocapture`
- `cargo check --workspace`
- `cargo test -p bitfun-core agentic::tools::implementations::grep_tool::tests -- --nocapture`
- `rustfmt --edition 2024 src/crates/core/src/agentic/tools/implementations/grep_tool.rs --check`

Full `cargo test --workspace` was not run because the local session was interrupted before completion.