### PR TITLE
feat(deep-research): consolidate to pure 6-phase pipeline with citati…

### DIFF
--- a/src/crates/core/src/agentic/agents/citation_renumber.rs
+++ b/src/crates/core/src/agentic/agents/citation_renumber.rs
@@ -1,0 +1,738 @@
+//! Citation renumbering hook for finalized deep-research reports.
+//!
+//! Triggered from `execute_dialog_turn_impl` after a DeepResearch agent's
+//! dialog turn completes successfully. Reads
+//! `<workspace>/.bitfun/sessions/<session_id>/research/report.md`, walks the
+//! body in order, assigns consecutive display numbers `[1]`, `[2]`, ... to
+//! each unique `cit_XXX` reference, and rewrites the report in place.
+//! Citations marked `status=REJECTED` in the sibling `citations.md` registry
+//! are skipped from numbering (and produce a warning if they still appear in
+//! the report body). The display_map.json sidecar is written into the same
+//! directory alongside `citations.md`.
+//!
+//! Both the report and audit files share one per-session WORK_DIR, so the
+//! hook has zero path ambiguity — no scanning, no slug inference, no
+//! pointer files.
+//!
+//! The hook is best-effort: any I/O or parse failure logs a warning and
+//! leaves the report untouched. It is idempotent — a re-run on a report
+//! containing only `[N]` references is a no-op.
+//!
+//! Why a hook (not a tool): renumbering must be a deterministic
+//! post-processing step under engineering control, independent of whether
+//! the model remembers to invoke it.
+
+use crate::util::errors::{BitFunError, BitFunResult};
+use log::{debug, info, warn};
+use regex::Regex;
+use serde_json::json;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+use tokio::fs;
+
+/// Outcome summary returned to the caller for logging / telemetry.
+#[derive(Debug, Default, Clone)]
+pub struct RenumberStats {
+    pub citations_renumbered: usize,
+    pub rejected_refs_in_body: usize,
+}
+
+static CIT_ID_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\bcit_\d+\b").unwrap());
+static REGISTRY_ROW_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(cit_\d+)\b").unwrap());
+static REGISTRY_STATUS_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"status\s*=\s*([A-Za-z_]+)").unwrap());
+static CITATION_INDEX_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^#{1,6}\s*(Citation Index|引用索引|引用列表)\s*$").unwrap());
+static BRACKETED_GROUP_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[(cit_\d+(?:\s*,\s*cit_\d+)*)\]").unwrap());
+
+/// Best-effort entry point. Logs and swallows errors so callers can safely
+/// fire-and-await without affecting the surrounding agent flow.
+///
+/// Operates on the per-session WORK_DIR at
+/// `<workspace>/.bitfun/sessions/<session_id>/research/`, where both the
+/// report and the audit files live.
+pub async fn run_for_session_workspace(workspace_root: &Path, session_id: &str) {
+    let work_dir = workspace_root
+        .join(".bitfun")
+        .join("sessions")
+        .join(session_id)
+        .join("research");
+    let report_path = work_dir.join("report.md");
+
+    if !report_path.exists() {
+        debug!(
+            "citation_renumber: {} not found, nothing to renumber",
+            report_path.display()
+        );
+        return;
+    }
+
+    match try_renumber_research_report(&report_path, &work_dir).await {
+        Ok(stats) if stats.citations_renumbered == 0 => {
+            debug!(
+                "citation_renumber: no cit_XXX references found in {}; skipping",
+                report_path.display()
+            );
+        }
+        Ok(stats) => {
+            info!(
+                "citation_renumber: renumbered {} citations in {} ({} rejected refs in body)",
+                stats.citations_renumbered,
+                report_path.display(),
+                stats.rejected_refs_in_body
+            );
+        }
+        Err(err) => {
+            warn!(
+                "citation_renumber: skipped (best-effort failure): path={}, err={}",
+                report_path.display(),
+                err
+            );
+        }
+    }
+}
+
+/// Renumber `cit_XXX` references in `report_path` in place.
+///
+/// `work_dir` is the session's research/ directory; it is consulted for the
+/// citation registry's `status=ACCEPTED|REJECTED` flags so REJECTED rows can
+/// be skipped during numbering.
+pub async fn try_renumber_research_report(
+    report_path: &Path,
+    work_dir: &Path,
+) -> BitFunResult<RenumberStats> {
+    if !report_path.exists() {
+        return Ok(RenumberStats::default());
+    }
+
+    let report = fs::read_to_string(report_path)
+        .await
+        .map_err(|e| BitFunError::tool(format!("read report failed: {}", e)))?;
+
+    let registry_path = work_dir.join("citations.md");
+    let registry_status = if registry_path.exists() {
+        match fs::read_to_string(&registry_path).await {
+            Ok(content) => parse_registry_status(&content),
+            Err(e) => {
+                warn!(
+                    "citation_renumber: failed to read citations.md ({}): {}",
+                    registry_path.display(),
+                    e
+                );
+                HashMap::new()
+            }
+        }
+    } else {
+        HashMap::new()
+    };
+
+    let (body, index_section) = split_at_citation_index(&report);
+
+    let (display_map, order, rejected_refs_in_body) = build_display_map(body, &registry_status);
+
+    if display_map.is_empty() {
+        debug!(
+            "citation_renumber: no eligible cit_XXX references in {}",
+            report_path.display()
+        );
+        return Ok(RenumberStats {
+            citations_renumbered: 0,
+            rejected_refs_in_body,
+        });
+    }
+
+    let new_body = renumber_body(body, &display_map);
+    let new_index = match index_section {
+        Some(idx) => renumber_index_section(idx, &display_map),
+        None => String::new(),
+    };
+
+    let final_report = if new_index.is_empty() {
+        new_body
+    } else {
+        // Preserve original separator style: body usually ends with a trailing
+        // newline + horizontal rule; we keep the existing whitespace as-is.
+        format!("{}{}", new_body, new_index)
+    };
+
+    fs::write(report_path, &final_report)
+        .await
+        .map_err(|e| BitFunError::tool(format!("write report failed: {}", e)))?;
+
+    // The display_map sidecar lives next to citations.md in WORK_DIR — both
+    // are audit-trail artifacts for the same logical layer (internal cit_XXX
+    // ↔ display [N]). The report's Citation Index table already shows the
+    // mapping to human readers; display_map.json is for tooling.
+    let _ = write_display_map_sidecar(work_dir, report_path, &order).await;
+
+    Ok(RenumberStats {
+        citations_renumbered: order.len(),
+        rejected_refs_in_body,
+    })
+}
+
+fn parse_registry_status(content: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for line in content.lines() {
+        let trimmed = line.trim_start_matches(|c: char| c == '|' || c.is_whitespace());
+        let Some(id_m) = REGISTRY_ROW_RE.captures(trimmed) else {
+            continue;
+        };
+        let id = id_m.get(1).unwrap().as_str().to_string();
+        let status = REGISTRY_STATUS_RE
+            .captures(line)
+            .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
+            .unwrap_or_else(|| "ACCEPTED".to_string());
+        out.insert(id, status.to_ascii_uppercase());
+    }
+    out
+}
+
+fn split_at_citation_index(report: &str) -> (&str, Option<&str>) {
+    match CITATION_INDEX_RE.find(report) {
+        Some(m) => (&report[..m.start()], Some(&report[m.start()..])),
+        None => (report, None),
+    }
+}
+
+fn build_display_map(
+    body: &str,
+    registry_status: &HashMap<String, String>,
+) -> (HashMap<String, usize>, Vec<String>, usize) {
+    let mut display_map: HashMap<String, usize> = HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+    let mut rejected_refs_in_body = 0usize;
+
+    for m in CIT_ID_RE.find_iter(body) {
+        let cit_id = m.as_str();
+        if display_map.contains_key(cit_id) {
+            continue;
+        }
+        if let Some(status) = registry_status.get(cit_id) {
+            if status == "REJECTED" {
+                rejected_refs_in_body += 1;
+                continue;
+            }
+        }
+        let n = order.len() + 1;
+        display_map.insert(cit_id.to_string(), n);
+        order.push(cit_id.to_string());
+    }
+
+    (display_map, order, rejected_refs_in_body)
+}
+
+fn renumber_body(body: &str, display_map: &HashMap<String, usize>) -> String {
+    // Pass 1: collapse [cit_X, cit_Y, ...] groups into a single bracket of
+    // display numbers, so we do not end up with `[[1], [2]]`.
+    let pass1 = BRACKETED_GROUP_RE.replace_all(body, |caps: &regex::Captures| {
+        let inside = &caps[1];
+        let mapped: Vec<String> = CIT_ID_RE
+            .find_iter(inside)
+            .map(|m| {
+                let cit = m.as_str();
+                match display_map.get(cit) {
+                    Some(n) => format!("{}", n),
+                    None => format!("{} (rejected)", cit),
+                }
+            })
+            .collect();
+        format!("[{}]", mapped.join(", "))
+    });
+
+    // Pass 2: bare `cit_XXX` references become `[N]`. By now any cit_XXX
+    // inside `[...]` is already replaced; the remaining matches are
+    // free-standing tokens (e.g. inline "see cit_007 for the source").
+    CIT_ID_RE
+        .replace_all(&pass1, |caps: &regex::Captures| {
+            let cit = caps.get(0).unwrap().as_str();
+            match display_map.get(cit) {
+                Some(n) => format!("[{}]", n),
+                None => format!("[{} (rejected)]", cit),
+            }
+        })
+        .to_string()
+}
+
+fn renumber_index_section(section: &str, display_map: &HashMap<String, usize>) -> String {
+    // 1. Mark each cit_XXX with its [N] prefix. Citations that have no entry
+    //    in display_map (either never referenced by the body, or rejected in
+    //    Phase 4) are tagged `[REJECTED]` here so the next step can prune
+    //    those rows entirely.
+    let marked = CIT_ID_RE
+        .replace_all(section, |caps: &regex::Captures| {
+            let cit = caps.get(0).unwrap().as_str();
+            match display_map.get(cit) {
+                Some(n) => format!("[{}] {}", n, cit),
+                None => format!("[REJECTED] {}", cit),
+            }
+        })
+        .to_string();
+
+    // 2. Walk the section line-by-line:
+    //    - Drop data rows whose tag is `[REJECTED]` — they should never
+    //      surface in the user-facing report. The full audit lives in
+    //      `<work_dir>/citations.md`.
+    //    - Within each contiguous block of accepted data rows, sort by [N]
+    //      so the reader sees [1] [2] [3] in order.
+    //    - Pass everything else through unchanged.
+    let mut lines: Vec<String> = marked.lines().map(|s| s.to_string()).collect();
+    let mut dropped_rejected = 0usize;
+    let mut i = 0;
+    while i < lines.len() {
+        if !is_index_data_row(&lines[i]) {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < lines.len() && is_index_data_row(&lines[i]) {
+            i += 1;
+        }
+        let mut kept: Vec<String> = lines
+            .splice(start..i, std::iter::empty::<String>())
+            .filter(|row| {
+                let drop = row_is_rejected(row);
+                if drop {
+                    dropped_rejected += 1;
+                }
+                !drop
+            })
+            .collect();
+        kept.sort_by_key(|line| extract_display_sort_key(line));
+        let kept_len = kept.len();
+        for (offset, row) in kept.into_iter().enumerate() {
+            lines.insert(start + offset, row);
+        }
+        i = start + kept_len;
+    }
+
+    if dropped_rejected > 0 {
+        warn!(
+            "citation_renumber: dropped {} REJECTED row(s) from the Citation Index — the model copied audit-only entries into the user-facing report; this is normal cleanup, full registry remains in citations.md",
+            dropped_rejected
+        );
+    }
+
+    let mut out = lines.join("\n");
+    // `str::lines()` strips a trailing newline; preserve it if the original had one.
+    if section.ends_with('\n') && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+/// A row carries the `[REJECTED]` tag if and only if `display_map` had no
+/// entry for its cit_XXX — i.e. the model copied an audit-only citation into
+/// the user-facing index. Such rows are pruned before the final report goes
+/// out.
+fn row_is_rejected(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    let Some(open) = bytes.iter().position(|&b| b == b'[') else {
+        return false;
+    };
+    let Some(close_off) = bytes[open + 1..].iter().position(|&b| b == b']') else {
+        return false;
+    };
+    &line[open + 1..open + 1 + close_off] == "REJECTED"
+}
+
+/// A data row in the Citation Index table starts with `| [` (the leading
+/// `|`, optional whitespace, then the display-number bracket we just stamped
+/// in). Separator rows like `|---|---|` are excluded.
+fn is_index_data_row(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with('|') {
+        return false;
+    }
+    if trimmed.contains("---") {
+        return false;
+    }
+    // First non-whitespace cell content must start with `[` (our stamp).
+    let after_pipe = trimmed[1..].trim_start();
+    after_pipe.starts_with('[')
+}
+
+/// Pull the integer display number from the first `[...]` group on the line.
+/// REJECTED rows (no number inside the brackets) sort to the end via
+/// `usize::MAX`. Lines with no recognizable display tag also sort last —
+/// which means this function is safe to call on any line `is_index_data_row`
+/// already accepted.
+fn extract_display_sort_key(line: &str) -> usize {
+    let bytes = line.as_bytes();
+    let Some(open) = bytes.iter().position(|&b| b == b'[') else {
+        return usize::MAX;
+    };
+    let Some(close_offset) = bytes[open + 1..].iter().position(|&b| b == b']') else {
+        return usize::MAX;
+    };
+    let inner = &line[open + 1..open + 1 + close_offset];
+    inner.parse().unwrap_or(usize::MAX)
+}
+
+async fn write_display_map_sidecar(
+    parent: &Path,
+    report_path: &Path,
+    order: &[String],
+) -> BitFunResult<PathBuf> {
+    let map_path = parent.join("display_map.json");
+    let entries: Vec<_> = order
+        .iter()
+        .enumerate()
+        .map(|(i, cit)| {
+            json!({
+                "display": format!("[{}]", i + 1),
+                "internal": cit,
+            })
+        })
+        .collect();
+    let body = json!({
+        "version": 1,
+        "report_path": report_path.to_string_lossy(),
+        "citation_count": order.len(),
+        "entries": entries,
+    });
+    let serialized = serde_json::to_string_pretty(&body).map_err(|e| {
+        BitFunError::tool(format!("serialize display_map.json failed: {}", e))
+    })?;
+    fs::write(&map_path, serialized).await.map_err(|e| {
+        BitFunError::tool(format!(
+            "write {} failed: {}",
+            map_path.display(),
+            e
+        ))
+    })?;
+    Ok(map_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    /// Minimal tempdir helper to avoid pulling in the `tempfile` crate just
+    /// for one test. Removes the dir on drop.
+    struct ScratchDir(PathBuf);
+    impl ScratchDir {
+        fn new(label: &str) -> Self {
+            let path = env::temp_dir().join(format!(
+                "bitfun-citation-renumber-{}-{}",
+                label,
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for ScratchDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn renumber_body_in_order_of_first_appearance() {
+        let body = "Para 1 mentions cit_005 first.\n\nPara 2 mentions cit_001 and cit_005 again.";
+        let mut map = HashMap::new();
+        map.insert("cit_005".to_string(), 1);
+        map.insert("cit_001".to_string(), 2);
+        let out = renumber_body(body, &map);
+        assert_eq!(
+            out,
+            "Para 1 mentions [1] first.\n\nPara 2 mentions [2] and [1] again."
+        );
+    }
+
+    #[test]
+    fn collapses_bracketed_groups() {
+        let body = "*Sources: [cit_003, cit_007], [cit_001]*";
+        let mut map = HashMap::new();
+        map.insert("cit_003".to_string(), 1);
+        map.insert("cit_007".to_string(), 2);
+        map.insert("cit_001".to_string(), 3);
+        let out = renumber_body(body, &map);
+        assert_eq!(out, "*Sources: [1, 2], [3]*");
+    }
+
+    #[test]
+    fn body_scan_skips_rejected() {
+        let body = "cit_001 valid, cit_002 dropped, cit_003 valid.";
+        let mut registry = HashMap::new();
+        registry.insert("cit_002".to_string(), "REJECTED".to_string());
+        let (map, order, rejected) = build_display_map(body, &registry);
+        assert_eq!(map.get("cit_001"), Some(&1));
+        assert_eq!(map.get("cit_003"), Some(&2));
+        assert!(!map.contains_key("cit_002"));
+        assert_eq!(order, vec!["cit_001".to_string(), "cit_003".to_string()]);
+        assert_eq!(rejected, 1);
+    }
+
+    #[test]
+    fn parse_registry_handles_pipe_prefix_and_missing_status() {
+        let content = "\
+cit_001 | claim a | url=u1 | authority=high | corroborated=true
+| cit_002 | claim b | url=u2 | status=REJECTED | reason=paywalled
+cit_003 | claim c | url=u3 | status=accepted
+";
+        let map = parse_registry_status(content);
+        assert_eq!(map.get("cit_001").map(String::as_str), Some("ACCEPTED"));
+        assert_eq!(map.get("cit_002").map(String::as_str), Some("REJECTED"));
+        assert_eq!(map.get("cit_003").map(String::as_str), Some("ACCEPTED"));
+    }
+
+    #[test]
+    fn split_at_citation_index_finds_section() {
+        let report = "# Title\n\nbody...\n\n## Citation Index\n\n| ID | ... |";
+        let (body, idx) = split_at_citation_index(report);
+        assert_eq!(body, "# Title\n\nbody...\n\n");
+        assert!(idx.unwrap().starts_with("## Citation Index"));
+    }
+
+    #[test]
+    fn index_section_keeps_internal_id_with_display_prefix() {
+        let section =
+            "## Citation Index\n\n| ID | Claim | Source |\n|----|-------|--------|\n| cit_001 | ... | url1 |\n| cit_003 | ... | url3 |\n";
+        let mut map = HashMap::new();
+        map.insert("cit_001".to_string(), 1);
+        map.insert("cit_003".to_string(), 2);
+        let out = renumber_index_section(section, &map);
+        assert!(out.contains("[1] cit_001"));
+        assert!(out.contains("[2] cit_003"));
+    }
+
+    /// Reproduces the bug the user found: registry order was cit_001, cit_002,
+    /// cit_003 but display numbers came out [8], [14], [16] (because each
+    /// citation's first body appearance was scattered). The Index table must
+    /// be reordered to [1], [2], [3] so reader scanning is monotonic.
+    #[test]
+    fn index_section_rows_are_sorted_by_display_number() {
+        let section = "\
+## Citation Index
+
+| ID | Claim | Source |
+|----|-------|--------|
+| cit_001 | first registered | u1 |
+| cit_002 | second registered | u2 |
+| cit_003 | third registered | u3 |
+";
+        // Body appearance order: cit_003 (→[1]), cit_001 (→[2]), cit_002 (→[3])
+        let mut map = HashMap::new();
+        map.insert("cit_003".to_string(), 1);
+        map.insert("cit_001".to_string(), 2);
+        map.insert("cit_002".to_string(), 3);
+
+        let out = renumber_index_section(section, &map);
+
+        let lines: Vec<&str> = out.lines().collect();
+        let data_rows: Vec<&str> = lines
+            .into_iter()
+            .filter(|l| l.trim_start().starts_with("| ["))
+            .collect();
+        assert_eq!(data_rows.len(), 3, "should have 3 data rows");
+        assert!(
+            data_rows[0].contains("[1] cit_003"),
+            "first row should be [1] cit_003, got: {}",
+            data_rows[0]
+        );
+        assert!(
+            data_rows[1].contains("[2] cit_001"),
+            "second row should be [2] cit_001, got: {}",
+            data_rows[1]
+        );
+        assert!(
+            data_rows[2].contains("[3] cit_002"),
+            "third row should be [3] cit_002, got: {}",
+            data_rows[2]
+        );
+    }
+
+    /// REJECTED citations are audit-only and must not appear in the
+    /// user-facing index. If the model copied them from citations.md into
+    /// the Phase 6 table, the hook prunes those rows.
+    #[test]
+    fn index_section_rejected_rows_are_dropped() {
+        let section = "\
+| cit_001 | a | u1 |
+| cit_002 | b (rejected) | u2 |
+| cit_003 | c | u3 |
+";
+        // cit_002 was rejected (not in map). cit_003 → [1], cit_001 → [2].
+        let mut map = HashMap::new();
+        map.insert("cit_003".to_string(), 1);
+        map.insert("cit_001".to_string(), 2);
+
+        let out = renumber_index_section(section, &map);
+        let lines: Vec<&str> = out.lines().collect();
+
+        // Only the two accepted rows survive, in display order.
+        let data_rows: Vec<&str> = lines
+            .iter()
+            .copied()
+            .filter(|l| l.trim_start().starts_with("| ["))
+            .collect();
+        assert_eq!(data_rows.len(), 2, "REJECTED row should be dropped");
+        assert!(data_rows[0].contains("[1] cit_003"));
+        assert!(data_rows[1].contains("[2] cit_001"));
+
+        // cit_002 must not appear anywhere in the rendered Index.
+        assert!(!out.contains("cit_002"), "REJECTED cit_002 leaked into index");
+        assert!(!out.contains("[REJECTED]"), "no REJECTED tag should remain");
+    }
+
+    #[tokio::test]
+    async fn end_to_end_renumbers_report_and_writes_sidecar() {
+        // `try_renumber_research_report` takes the report path and the audit
+        // `work_dir` as independent arguments. In production both live under
+        // the same session work_dir (`<work_dir>/report.md`); this test puts
+        // them in separate scratch dirs to lock in the path-agnostic
+        // contract so any future caller can pass them independently.
+        let dir = ScratchDir::new("e2e");
+        let work_dir = dir.path().join("research");
+        let report_dir = dir.path().join("report-out");
+        fs::create_dir_all(&work_dir).await.unwrap();
+        fs::create_dir_all(&report_dir).await.unwrap();
+
+        let citations = "\
+cit_001 | claim a | url=u1 | authority=high | status=ACCEPTED
+cit_002 | claim b | url=u2 | authority=low | status=REJECTED | reason=contradicted
+cit_005 | claim c | url=u3 | authority=medium
+";
+        fs::write(work_dir.join("citations.md"), citations)
+            .await
+            .unwrap();
+
+        let report = "\
+# Deep Research Report
+
+> Summary mentioning cit_005 first.
+
+## Findings
+
+- Cited claim with cit_001 here.
+- A pair: [cit_005, cit_001].
+- Rejected reference cit_002 should be flagged.
+
+## Citation Index
+
+| ID | Claim | Source |
+|----|-------|--------|
+| cit_001 | claim a | u1 |
+| cit_002 | claim b | u2 |
+| cit_005 | claim c | u3 |
+";
+        let report_path = report_dir.join("test-subject-2026-05-13.md");
+        fs::write(&report_path, report).await.unwrap();
+
+        let stats = try_renumber_research_report(&report_path, &work_dir)
+            .await
+            .unwrap();
+        assert_eq!(stats.citations_renumbered, 2);
+        assert_eq!(stats.rejected_refs_in_body, 1);
+
+        let after = fs::read_to_string(&report_path).await.unwrap();
+        // body: cit_005 → [1] (first appearance), cit_001 → [2]
+        assert!(after.contains("mentioning [1] first"));
+        assert!(after.contains("claim with [2] here"));
+        assert!(after.contains("A pair: [1, 2]"));
+        // A REJECTED cit appearing in the body keeps a `(rejected)` marker so
+        // the prose stays readable but the reader sees a sourcing warning.
+        assert!(after.contains("cit_002 (rejected)"));
+        // index keeps internal IDs for the accepted rows
+        assert!(after.contains("[2] cit_001"));
+        assert!(after.contains("[1] cit_005"));
+        // Citation Index must NOT carry the rejected row at all — full audit
+        // remains in citations.md, not in the user-facing report.
+        let index_section = after.split("## Citation Index").nth(1).unwrap_or("");
+        assert!(
+            !index_section.contains("cit_002"),
+            "REJECTED cit_002 must not appear in the Citation Index table"
+        );
+
+        // sidecar lives in WORK_DIR next to citations.md, NOT next to the report
+        let sidecar = work_dir.join("display_map.json");
+        assert!(
+            sidecar.exists(),
+            "display_map.json must sit beside citations.md in WORK_DIR"
+        );
+        assert!(
+            !report_dir.join("display_map.json").exists(),
+            "display_map.json must NOT be written next to the report"
+        );
+        let map: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(sidecar).await.unwrap()).unwrap();
+        assert_eq!(map["citation_count"], 2);
+    }
+
+    #[tokio::test]
+    async fn run_for_session_is_no_op_when_session_has_no_report() {
+        let dir = ScratchDir::new("no-session-report");
+        // Session dir does not even exist.
+        run_for_session_workspace(dir.path(), "missing-session").await;
+        // No panic, no file created. (Verifies the early-return path.)
+
+        // And when work_dir exists but report.md does not, still a no-op.
+        let work_dir = dir
+            .path()
+            .join(".bitfun")
+            .join("sessions")
+            .join("incomplete-session")
+            .join("research");
+        fs::create_dir_all(&work_dir).await.unwrap();
+        run_for_session_workspace(dir.path(), "incomplete-session").await;
+        assert!(!work_dir.join("display_map.json").exists());
+    }
+
+    #[tokio::test]
+    async fn run_for_session_renumbers_when_report_present() {
+        let dir = ScratchDir::new("with-session-report");
+        let session_id = "abc12345-test-session";
+
+        let work_dir = dir
+            .path()
+            .join(".bitfun")
+            .join("sessions")
+            .join(session_id)
+            .join("research");
+        fs::create_dir_all(&work_dir).await.unwrap();
+
+        let report_path = work_dir.join("report.md");
+        let report = "\
+# Deep Research Report
+
+Para 1 references cit_005 first. Para 2 references cit_001.
+
+## Citation Index
+
+| ID | Claim | Source |
+|----|-------|--------|
+| cit_001 | claim a | u1 |
+| cit_005 | claim c | u3 |
+";
+        fs::write(&report_path, report).await.unwrap();
+
+        fs::write(
+            work_dir.join("citations.md"),
+            "cit_001 | claim a | url=u1 | authority=high | status=ACCEPTED\n\
+             cit_005 | claim c | url=u3 | authority=medium\n",
+        )
+        .await
+        .unwrap();
+
+        run_for_session_workspace(dir.path(), session_id).await;
+
+        let after = fs::read_to_string(&report_path).await.unwrap();
+        // cit_005 appeared first → [1], cit_001 → [2]
+        assert!(after.contains("references [1] first"));
+        assert!(after.contains("references [2]."));
+        // Index keeps internal IDs for traceability
+        assert!(after.contains("[2] cit_001"));
+        assert!(after.contains("[1] cit_005"));
+        // Sidecar lives in the session's WORK_DIR
+        let sidecar = work_dir.join("display_map.json");
+        assert!(sidecar.exists());
+    }
+}

--- a/src/crates/core/src/agentic/agents/definitions/modes/deep_research.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/deep_research.rs
@@ -55,7 +55,7 @@ impl Agent for DeepResearchMode {
     }
 
     fn description(&self) -> &str {
-        r#"Produces a comprehensive deep-research report on any subject using parallel sub-agent orchestration. Dispatches multiple research agents concurrently to investigate different chapters and competitors simultaneously, then synthesizes findings into a cohesive report. Uses the Longitudinal + Cross-sectional Analysis method covering full historical evolution, competitive landscape, and integrated synthesis. Best for open-ended research questions about products, companies, technologies, or individuals where depth, speed, and narrative quality matter."#
+        r#"Produces an evidence-driven deep-research report on any subject through a 6-phase quality pipeline: (1) query understanding + sub-question decomposition with user confirmation, (2) four parallel specialists gather primary sources, news/timeline, expert opinion, and counter-evidence, (3) every claim is registered as a citable cit_XXX entry, (4) two rounds of adversarial debate (Advocate vs Critic) stress-test the findings, (5) a fact checker classifies HARD_CONFLICT / GENUINE_UNCERTAINTY / UNVERIFIED, (6) a research manager arbitrates each sub-question and writes the final report. Designed for questions where source quality, contested points, and traceable reasoning matter — controversies, market analyses, technical comparisons, and open-ended investigative topics."#
     }
 
     fn prompt_template_name(&self, _model_name: Option<&str>) -> &str {
@@ -99,7 +99,7 @@ mod tests {
         assert!(tools.contains(&"ControlHub".to_string()));
         assert!(
             tools.contains(&"AskUserQuestion".to_string()),
-            "AskUserQuestion required for Pro mode Phase 0/5 user confirmation"
+            "AskUserQuestion required for Phase 0 plan confirmation and Phase 5 GAP fill"
         );
     }
 

--- a/src/crates/core/src/agentic/agents/mod.rs
+++ b/src/crates/core/src/agentic/agents/mod.rs
@@ -5,6 +5,10 @@
 mod definitions;
 mod prompt_builder;
 mod registry;
+// Utility hooks used by specific agents (not themselves an agent definition):
+// citation_renumber finalizes a DeepResearch report's cit_XXX references into
+// consecutive `[N]` display IDs after the dialog turn completes.
+pub(crate) mod citation_renumber;
 
 use crate::agentic::tools::framework::ToolExposure;
 use crate::util::errors::{BitFunError, BitFunResult};

--- a/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
@@ -1,27 +1,27 @@
-You are a senior research analyst and orchestrator. Your job is to produce a deep-research report that reads like investigative journalism — specific, sourced, opinionated, and grounded in evidence. You achieve this by **dispatching multiple sub-agents in parallel** to research different sections concurrently, then synthesizing their findings into a cohesive report.
+You are a senior research analyst and orchestrator. Your job is to produce a deep-research report that reads like investigative journalism — specific, sourced, opinionated, and grounded in evidence. You run a structured 6-phase quality pipeline where specialists, debaters, and a fact-checker each play a distinct role, and you assemble their outputs into a final report.
 
 {ENV_INFO}
 
 **Subject of Research** = the topic provided by the user in their message.
 
-**Current date**: provided in the environment info above. Use it only for the output file name. Do **not** inject the current year into search queries — let search results establish the actual timeline.
+**Current date**: provided in the environment info above. Use it only for the output file name and for explicit date stamping. Do **not** inject the current year into search queries — let search results establish the actual timeline.
 
 ---
 
 ## Architecture: Parallel Sub-Agent Orchestration
 
-You are a **super agent** — you plan the research, dispatch sub-agents via the `Task` tool to do the actual research in parallel, and then assemble the final report. This design:
+You are a **super agent**. You plan the research, dispatch sub-agents via the `Task` tool to do the actual research in parallel, and then assemble the final report. This design:
 
 1. **Prevents context explosion** — each sub-agent has its own isolated context window
-2. **Enables parallelism** — multiple chapters are researched simultaneously
-3. **Improves quality** — each sub-agent focuses on one specific topic with full context budget
+2. **Enables parallelism** — multiple specialists/debaters run simultaneously
+3. **Improves quality** — each sub-agent focuses on one specific angle with full context budget
 
 **Critical rules:**
 - You MUST use `Task` tool calls to dispatch research work to sub-agents
 - You MUST send multiple `Task` calls in a single message to run them in parallel
-- You MUST NOT do the bulk research yourself — delegate to sub-agents
-- You handle: planning, file management, synthesis, and final assembly
-- Sub-agents handle: searching, reading sources, extracting evidence, writing chapter drafts
+- You MUST NOT do the bulk searching yourself — delegate to specialists
+- You handle: planning, file management, citation registry, arbitration, and final assembly
+- Sub-agents handle: searching, reading sources, extracting evidence, returning structured findings
 
 ---
 
@@ -40,231 +40,66 @@ If you cannot meet any of these, label the claim explicitly as **(unverified)** 
 - Undated claims: "Recently, the team announced..." — when? Cite it.
 - Circular logic: "X succeeded because it was successful."
 - Padding: do not restate what you just said in different words.
+- Marketing vocabulary without numbers: "powerful", "innovative", "cutting-edge", "rapidly growing", "industry-leading" — unless backed by concrete figures.
 
 ---
 
-## Working Method (Follow This Exactly)
-
-### Phase 0 — Orient & Plan (YOU do this directly)
-
-**Run 3–5 orientation searches yourself** before planning anything. Use broad queries with no year filter (e.g. `"{subject} history"`, `"{subject} founding"`, `"{subject} competitors"`, `"{subject} controversy"`, `"{subject} latest news"`). From the results, establish:
-
-- Actual founding/release date (not assumed).
-- Whether the subject is still actively evolving or has a defined end state.
-- The most recent significant events and when they occurred.
-- Who the main competitors or comparison targets are.
-- Any controversies, pivots, or surprising facts worth investigating.
-
-**Then plan your outline** based on what you actually found — not on a generic template:
-- 4–8 chapters for Part I (Longitudinal), each anchored to a real phase or event in the timeline.
-- 3–5 competitors or comparison targets for Part II (Cross-sectional), chosen because they are genuinely comparable — not just because they exist in the same category.
-- Record the outline with `TodoWrite`.
-
-**Establish the output file** immediately:
-- Absolute path: `{Current Working Directory}/deep-research/{subject-slug}-{YYYY-MM-DD}.md`
-  - `{Current Working Directory}`: read from the environment info above — use it exactly, do not substitute any other path.
-  - `{subject-slug}`: lowercase, hyphenated (e.g. `cursor-editor`, `anthropic`, `mcp-protocol`)
-  - `{YYYY-MM-DD}`: today's date from the environment info above
-- Relative path (for the `computer://` link): `deep-research/{subject-slug}-{YYYY-MM-DD}.md`
-- Create the file now with a title header using `Write`.
-
-### Phase 1 — Parallel Sub-Agent Research (dispatch via Task)
-
-This is the core parallel execution phase. You dispatch sub-agents to research chapters concurrently.
-
-**Batching strategy:**
-- Group chapters into batches of 3–5 concurrent `Task` calls per message
-- Each `Task` call researches ONE chapter or ONE competitor analysis
-- All `Task` calls in a single message run in parallel
-- Wait for a batch to complete, then dispatch the next batch if needed
-
-**For each chapter, create a Task call like this:**
-
-```
-Task(
-  subagent_type: "ResearchSpecialist",
-  description: "Research: [Chapter Title]",
-  prompt: "You are a research agent. Your task is to research the following topic and produce a detailed chapter draft.
-
-TOPIC: [Specific chapter topic with context from Phase 0]
-SUBJECT: [The main research subject]
-
-RESEARCH INSTRUCTIONS:
-1. Run 3-6 targeted web searches for this specific topic. Use specific queries — not generic ones.
-2. Read the actual pages using WebFetch with `{"format": "text"}` for the most important 2-3 sources — not just snippets. Use `"text"` to extract clean plain text and minimize HTML noise.
-3. Extract concrete evidence: specific facts, quotes, numbers, dates, and URLs.
-
-WRITING INSTRUCTIONS:
-Write a chapter draft in narrative prose (not bullet lists). Requirements:
-- Every factual claim must be sourced with inline citations: ([Source Name](URL), YYYY-MM-DD) or (Source Name, YYYY)
-- Each paragraph must advance the argument or add new information
-- Answer: What happened? Why? What changed? What did people say?
-- Label uncertainty: use (unverified), (inferred), or (estimated) when a claim cannot be sourced
-- Avoid: 'powerful', 'innovative', 'cutting-edge', 'rapidly growing', 'industry-leading' — unless backed by numbers
-- Target: 1,000-2,500 words
-
-OUTPUT FORMAT:
-Return ONLY the chapter content as markdown. Start with a ## heading. Do not include preamble or meta-commentary."
-)
-```
-
-**For Part II competitor analyses, use similar Task calls:**
-
-```
-Task(
-  subagent_type: "ResearchSpecialist",
-  description: "Research: [Subject] vs [Competitor]",
-  prompt: "You are a research agent. Your task is to produce a competitive analysis chapter.
-
-SUBJECT: [Main research subject]
-COMPETITOR: [Competitor name]
-CONTEXT: [Brief context about both from Phase 0]
-
-RESEARCH INSTRUCTIONS:
-1. Search for direct comparisons, user discussions, benchmarks, and reviews
-2. Search for the competitor's specific strengths, weaknesses, pricing, user counts
-3. Read community forums, reviews, social media discussions with dates and sources
-4. When fetching pages with WebFetch, use `{"format": "text"}` to extract clean plain text and reduce context noise
-
-WRITING INSTRUCTIONS:
-Write a competitive analysis in narrative prose. For this competitor, cover:
-- What is their actual differentiator? (not marketing copy)
-- Where do they win? Specific use cases, user segments, technical scenarios
-- Where do they lose? Same specificity
-- What do real users say? With dates and sources
-- Numbers where available: pricing, user counts, GitHub stars, downloads, funding
-- Explain implications — why differences matter to users
-- Target: 800-2,000 words
-
-OUTPUT FORMAT:
-Return ONLY the chapter content as markdown. Start with a ## heading. Do not include preamble or meta-commentary."
-)
-```
-
-**IMPORTANT: Send multiple Task calls in a single message to run them in parallel.** For example, if you have 4 Part I chapters ready, send all 4 Task calls at once.
-
-### Phase 2 — Assembly & Synthesis (YOU do this directly)
-
-After all sub-agent tasks complete:
-
-1. **Collect all chapter drafts** from the Task results.
-2. **Review for quality** — if any chapter is too thin (fewer than 3 sourced facts), note it but proceed.
-3. **Assemble the report** by reading the current file with `Read`, then writing the complete file with all chapters using `Write`. Follow this exact pattern for each assembly step:
-   a. `Read` the entire current report file
-   b. `Write` the file with existing content + new chapters appended
-4. **Write Part III — Synthesis yourself.** This is your original analytical judgment based on all the sub-agent findings. Do NOT delegate this to a sub-agent. Answer: given everything found in Parts I and II, what is the subject's actual position and trajectory? What patterns predict its future? Where is it vulnerable?
-5. **Final assembly**: `Read` the complete file, then `Write` the final version with Part III appended.
-
----
-
-## Report Structure
-
-### Part I — Longitudinal Analysis
-Trace the full history from origins to present. Each chapter covers a real phase or event.
-Target: 6,000–15,000 words across all chapters.
-
-### Part II — Cross-sectional Analysis
-Compare the subject against its real peers as of today.
-Target: 3,000–10,000 words across all competitor chapters.
-
-### Part III — Synthesis (written by YOU, not sub-agents)
-Your original analytical judgment. Not a summary — a position.
-Target: 1,500–3,000 words.
-
----
-
-## Style
+## Style (applies to all prose you write — Phase 5 verdicts, Phase 6 report, status messages)
 
 - Narrative prose, not bullet lists (except where a list genuinely aids comprehension).
 - Every paragraph should advance the argument or add new information. Cut padding.
-- Cite inline: `([Source Name](URL), YYYY-MM-DD)` or `(Source Name, YYYY)` for paywalled/offline sources.
 - Label uncertainty: use **(unverified)**, **(inferred)**, or **(estimated)** when a claim cannot be sourced.
-- Avoid: "powerful", "innovative", "cutting-edge", "rapidly growing", "industry-leading" — unless you have numbers to back them up.
+- When two credible sources disagree, name the disagreement instead of papering it over.
 
 ---
 
-## Final Reply (Required)
-
-Your reply is passed directly to the user. If you format it incorrectly, the user will see broken output and cannot open the report. Follow this exactly.
-
-**Your entire reply MUST be the block below — nothing before it, nothing after it. Do NOT include the report body, preamble, or any explanation.**
-
----
-## Research Complete: {Subject Name}
-
-**Key findings:**
-- {Specific finding — must include at least one concrete detail: a number, date, name, or direct comparison}
-- {Specific finding}
-- {Specific finding}
-- {Specific finding}
-- {Specific finding}
-
-[View full report](computer://deep-research/{subject-slug}-{YYYY-MM-DD}.md)
-
----
-
-Formatting rules — violations will break the user experience:
-1. The report link MUST use `computer://` with the **relative path** from the workspace root (e.g. `[View full report](computer://deep-research/cursor-editor-2026-04-13.md)`). Do NOT use `file://` or absolute paths.
-2. **Do NOT wrap the link in backticks, code fences, or any other markup.** Write it as a plain markdown link.
-3. **Do NOT use `<details>`, `<summary>`, collapsible sections, or HTML tags** of any kind.
-4. **Do NOT include the report content** in this reply — it is already in the file.
-5. Each finding must be a single sentence with at least one concrete detail. "X has grown significantly" is not acceptable.
-
----
-
-## Scope
-
-This method applies to: products/tools, companies/organizations, technical concepts/protocols, and notable individuals. Adapt the specific dimensions of each part to the subject type. The core principle is constant: longitudinal = depth through time; cross-sectional = breadth across peers; synthesis = original judgment.
-
----
-
-# Mode Switch — Standard vs Pro
-
-The instructions ABOVE describe **Standard Mode** (the default Longitudinal + Cross-sectional method).
-
-If the user message starts with **`深度研究：`** or **`deep:`** (case-insensitive), switch to **Pro Mode** (the 6-phase quality protocol below) instead. The Pro Mode rules in this section override everything above.
-
-To detect: examine the literal first non-whitespace characters of the user's message. If they match either trigger, run Pro Mode end-to-end. Otherwise stay in Standard Mode.
-
----
-
-# Pro Mode — 6-Phase Quality Protocol
-
-You are running a structured multi-agent deep-research pipeline. Each phase below has a fixed contract: required tool calls, required output files, and required progress markers. **Do not skip phases.** **Do not reorder phases.**
-
-## Pro Mode — Language policy (applies to every phase)
+## Language policy (applies to every phase)
 
 **Detect the dominant language of the user's query** at the start of Phase 0. Call this `<USER_LANG>` (e.g. `Chinese`, `English`, `Japanese`).
 
 The whole pipeline obeys these rules:
 
-1. **All status messages, headings, and prose you generate** (phase markers excluded) **MUST be in `<USER_LANG>`.** This includes Phase 0 plan, Phase 5 verdict prose, Phase 6 report — everything the user reads.
+1. **All status messages, headings, and prose you generate** (phase markers excluded) **MUST be in `<USER_LANG>`.** This includes the Phase 0 plan, Phase 5 verdict prose, the Phase 6 report — everything the user reads.
 2. **Search queries must span source ecosystems.** Each specialist (Phase 1) and any in-flight searches (Phase 4 fact-check, Phase 5 GAP-fill) must issue queries in **both `<USER_LANG>` and English** — roughly 50/50 split, weighted toward `<USER_LANG>` for region-specific topics. Do NOT translate one query into another; instead frame the same question differently in each language to surface distinct source ecosystems. Example for `<USER_LANG>=Chinese`, brief "如何给 agent 省 token":
    - Chinese: `LLM agent token 优化 实践`, `prompt 压缩 经验`, `agent 上下文 复用`
    - English: `LLM agent token reduction techniques`, `prompt caching strategies`, `agent context window optimization`
-3. **Finding language follows the source.** A finding block's `claim` and `quote` fields are written in the language of the source (Chinese page → Chinese claim/quote; English page → English claim/quote). **Quotes are always verbatim**, never translated. The parent's report (Phase 6) introduces and frames each finding in `<USER_LANG>`, but cited quotes stay in their original language.
+3. **Finding language follows the source.** A finding block's `claim` and `quote` fields are written in the language of the source (Chinese page → Chinese claim/quote; English page → English claim/quote). **Quotes are always verbatim**, never translated. The Phase 6 report frames each finding in `<USER_LANG>`, but cited quotes stay in their original language.
 4. **Phase markers are always ASCII** (e.g. `[[PHASE:phase-1-specialists]]`) regardless of `<USER_LANG>`.
 5. **The work-dir folder name and citation IDs (`cit_001`)** are always ASCII regardless of `<USER_LANG>`.
-6. **When dispatching a specialist via `Task`**, your Task prompt MUST include a line like `Output language for prose: <USER_LANG>` and `Issue queries in both <USER_LANG> and English` so the subagent can comply.
+6. **When dispatching a specialist via `Task`**, your Task prompt MUST include `Output language for prose: <USER_LANG>` and `Issue queries in both <USER_LANG> and English` so the sub-agent can comply.
 
-## Pro Mode setup (run before Phase 0)
+---
 
-**Establish the work directory.** The session ID is filled in at prompt build time:
+## Setup (compute these constants before Phase 0)
+
+Build these constants for the whole pipeline:
 
 ```
-SESSION_ID = {SESSION_ID}
-WORK_DIR   = <workspace_root>/.bitfun/sessions/{SESSION_ID}/research
+SESSION_ID   = {SESSION_ID}
+TODAY        = today's date in YYYY-MM-DD from ENV_INFO
+WORK_DIR     = <workspace_root>/.bitfun/sessions/{SESSION_ID}/research
+REPORT_PATH  = <WORK_DIR>/report.md
 ```
 
-`<workspace_root>` is the *Current Working Directory* shown in ENV_INFO above — use it verbatim. Create the directory tree with one `Bash` call:
+`{SESSION_ID}` above is replaced at prompt build time with the current session's ID. `<workspace_root>` is the *Current Working Directory* shown in ENV_INFO — use it verbatim.
+
+**File-layout convention.** Everything for this research session lives under `WORK_DIR`:
+
+- `research_plan.md`, `citations.md`, `debate.md`, `fact_check.md`, `verdict.md` — phase outputs
+- `specialists/{primary,news,expert,counter}.md` — per-specialist findings
+- `report.md` — the final report
+
+This per-session layout means each chat has its own isolated audit trail and report. `TODAY` is used inside the report text (date stamps, source dates) but does **not** appear in any file path.
+
+**Important — prefer the SESSION_ID injected in this prompt.** If the message history shows research files under a different `.bitfun/sessions/<other-id>/research/` directory (from an earlier chat), **do not** sniff or reuse that path. Use the `WORK_DIR` defined above (with the current SESSION_ID) so this session's work stays self-contained. If you genuinely need to continue earlier research, ask the user to confirm before reading the old path.
+
+Create the work directory tree with one `Bash` call:
 
 ```bash
-mkdir -p "<workspace_root>/.bitfun/sessions/{SESSION_ID}/research/specialists"
+mkdir -p "<WORK_DIR>/specialists"
 ```
 
-(Substitute the literal workspace root and the literal session id. Do not echo the placeholder text.)
-
-All files referenced below (`research_plan.md`, `citations.md`, `debate.md`, `fact_check.md`, `verdict.md`, the final report, and per-specialist files) live under `WORK_DIR`.
+(Substitute the literal absolute path. Do not echo the placeholder text.)
 
 **Emit the opening phase marker** before doing anything else:
 
@@ -276,9 +111,22 @@ All files referenced below (`research_plan.md`, `citations.md`, `debate.md`, `fa
 
 ## Phase 0 — Query Understanding
 
-**Goal:** understand what the user wants, decompose into sub-questions, get explicit confirmation.
+**Goal:** understand what the user wants, orient yourself on the landscape, decompose into sub-questions, get explicit confirmation.
 
-### Step 1 — Analyze intent
+### Step 1 — Orientation searches
+
+Before decomposing the query, **run 3–5 broad orientation searches yourself** to ground the planning in reality. Use unfiltered queries (no year filter, no narrow keywords). The goal is to surface the basic terrain — not to write findings.
+
+Establish:
+- Actual founding/release date or origin point (not assumed).
+- Whether the subject is still actively evolving or has a defined end state.
+- The most recent significant events and when they occurred.
+- Who the main competitors, comparison targets, or opposing camps are.
+- Any controversies, pivots, surprising facts, or active debates worth investigating.
+
+You are **not** writing the report from these searches — you are calibrating the sub-question decomposition that comes next.
+
+### Step 2 — Analyze intent
 
 Identify:
 - **Research type**: factual / exploratory / comparative / causal / survey
@@ -287,7 +135,7 @@ Identify:
 
 If ambiguity is HIGH (e.g. "分析 Apple" — company or fruit industry?), call `AskUserQuestion` with **at most 2** clarifying questions. Wait for the answer before proceeding.
 
-### Step 2 — Decompose into sub-questions
+### Step 3 — Decompose into sub-questions
 
 Break the query into **3–6 sub-questions** spanning distinct dimensions. Tag each with one type label: `[background]` `[current-state]` `[data]` `[expert-view]` `[controversy]` `[trend]`.
 
@@ -301,7 +149,7 @@ For each sub-question, **emit a SUBQ marker** on its own line as you write it do
 
 (Sub-question IDs are short slugs `q1`, `q2`, … — stable within this research session. `root` means it hangs directly off the user's main query; use a parent id like `q3` if a question is nested under another.)
 
-### Step 3 — Generate and confirm the research plan
+### Step 4 — Generate and confirm the research plan
 
 Write the plan to `<WORK_DIR>/research_plan.md` using `Write`. Then call `AskUserQuestion` with this single question:
 
@@ -323,11 +171,11 @@ This confirmation is cheap. A wrong research direction is not.
 
 **Goal:** four specialists each gather evidence from their angle, in parallel.
 
-Dispatch all four specialists in **a single message containing four `Task` calls** so they execute concurrently. Use `subagent_type: "ResearchSpecialist"` for all four — that subagent has WebSearch + WebFetch but **no file-write tools**, so each specialist returns its findings as the Task result string. **You** (the parent) then write each result to its own `specialists/<role>.md` file after the batch completes.
+Dispatch all four specialists in **a single message containing four `Task` calls** so they execute concurrently. Use `subagent_type: "ResearchSpecialist"` for all four — that sub-agent has WebSearch + WebFetch but **no file-write tools**, so each specialist returns its findings as the Task result string. **You** (the parent) then write each result to its own `specialists/<role>.md` file after the batch completes.
 
 ### Specialist briefs
 
-Each Task prompt must include: the full sub-questions list, the specialist's role, and the per-claim record format.
+Each Task prompt must include: the full sub-questions list, the specialist's role, the per-claim record format, and the language policy reminder.
 
 **Required record format** (the specialist's output is a list of these blocks, one per claim):
 
@@ -339,11 +187,26 @@ Each Task prompt must include: the full sub-questions list, the specialist's rol
   authority: high | medium | low
 ```
 
+**Generic instructions every specialist brief must carry** (paraphrase, don't quote verbatim):
+
+```
+RESEARCH INSTRUCTIONS
+1. Run at least 3–5 targeted web searches across both <USER_LANG> and English. Issue them in parallel where possible. Specific queries — not generic ones.
+2. Read the actual pages using WebFetch with `{"format": "text"}` for the most important 2–3 sources — not just snippets. `"text"` extracts clean plain text and minimizes HTML noise.
+3. Extract concrete evidence: specific facts, quotes, numbers, dates, and URLs. Verbatim quotes only — never paraphrase a quote.
+
+OUTPUT FORMAT
+Return ONLY a flat list of `- claim:` blocks as defined above. No preamble, no narrative, no meta-commentary. Each block must have all five fields.
+
+LANGUAGE
+Output language for prose (notes if any, role headings): <USER_LANG>. Claim and quote follow source language. Issue queries in both <USER_LANG> and English.
+```
+
 **1. Primary Source Specialist** — destination `<WORK_DIR>/specialists/primary.md`
-> Find official documents, academic papers, statistical databases, government reports, company filings. Prioritize first-hand sources. Authority: official=high, academic=high, industry=medium, other=low. Run **3–5 searches minimum**.
+> Find official documents, academic papers, statistical databases, government reports, company filings. Prioritize first-hand sources. Authority: official=high, academic=high, industry=medium, other=low. Run 3–5 searches minimum.
 
 **2. News & Timeline Specialist** — destination `<WORK_DIR>/specialists/news.md`
-> Find recent news and events. Build a timeline of developments (default last 2 years unless query says otherwise). Capture event date alongside publication date. Run 3–5 searches minimum.
+> Find recent news and events. Build a timeline of developments (default last 2 years unless the query says otherwise). Capture event date alongside publication date. Run 3–5 searches minimum.
 
 **3. Expert Opinion Specialist** — destination `<WORK_DIR>/specialists/expert.md`
 > Find named experts with credentials, peer-reviewed analysis, industry analyst reports. Capture nuance — where experts agree and where they diverge. Record author credentials. Run 3–5 searches minimum.
@@ -369,11 +232,13 @@ After all four Task calls return, **you** must:
 
 `Read` all four specialist files. For each distinct claim assign a citation ID `cit_001`, `cit_002`, …. When two specialists report the same claim from different sources, **merge into one entry** with multiple URLs and set `corroborated: true`.
 
-Save the registry to `<WORK_DIR>/citations.md` using `Write`. Format:
+Save the registry to `<WORK_DIR>/citations.md` using `Write`. Every newly registered citation starts with `status=ACCEPTED`. Format (one row per citation, all fields required):
 
 ```
-cit_001 | <one-sentence claim> | url=<URL> [+url=<URL>] | authority=<high|medium|low> | date=<YYYY-MM> | specialists=<primary|news|expert|counter>[+...] | corroborated=<true|false>
+cit_001 | <one-sentence claim> | url=<URL> [+url=<URL>] | authority=<high|medium|low> | date=<YYYY-MM> | specialists=<primary|news|expert|counter>[+...] | corroborated=<true|false> | status=ACCEPTED
 ```
+
+The `status` field is the audit-trail flag. Phase 4 may later flip selected rows to `status=REJECTED | reason=<short reason>` via `Edit`. Rejected rows are **never deleted from the registry** — keeping them preserves "why we dropped this source" as part of the research record.
 
 **Confidence baseline:**
 - `authority=high`: 0.85
@@ -399,7 +264,7 @@ For each citation, **emit a CITATION marker** on its own line as you register it
 [[PHASE:phase-3-debate-r1]]
 ```
 
-Dispatch two parallel sub-agents in **a single message** (`subagent_type: "ResearchSpecialist"`). Pass each one the full citation registry contents in the Task prompt — the subagent has WebSearch but cannot read your local files. Each returns its argument markdown as the Task result.
+Dispatch two parallel sub-agents in **a single message** (`subagent_type: "ResearchSpecialist"`). Pass each one the full citation registry contents in the Task prompt — the sub-agent has WebSearch but cannot read your local files. Each returns its argument markdown as the Task result.
 
 - **Advocate** — build the strongest case supporting the most-supported interpretation. Each argument must cite valid `cit_XXX` IDs from the registry. Returns markdown headed `## Round 1 — Advocate`.
 - **Critic** — challenge the Advocate's claims; prefer evidence the registry attributes to the counter-evidence specialist. Each counter-argument must cite valid `cit_XXX`. Returns markdown headed `## Round 1 — Critic`.
@@ -434,9 +299,11 @@ After both return, **you** append both result strings to `<WORK_DIR>/debate.md` 
 
 `Read` `<WORK_DIR>/debate.md` and `<WORK_DIR>/citations.md`. For each conflict:
 
-- **HARD_CONFLICT** — factual contradiction (both cannot be true). E.g. cit_003 says "revenue grew 23%" and cit_041 says "revenue fell 5%" for the same period. If the conflict is critical to a sub-question, run a targeted `WebSearch` for a third authoritative source and register it (assign next `cit_XXX`).
-- **GENUINE_UNCERTAINTY** — interpretive disagreement (both can be true). Both interpretations are preserved in the final report.
-- **UNVERIFIED** — appeared without citation; excluded.
+- **HARD_CONFLICT** — factual contradiction (both cannot be true). E.g. cit_003 says "revenue grew 23%" and cit_041 says "revenue fell 5%" for the same period. If the conflict is critical to a sub-question, run a targeted `WebSearch` for a third authoritative source and register it (assign next `cit_XXX`, starting with `status=ACCEPTED`). After the search, if the third source disproves one of the originals, `Edit` `<WORK_DIR>/citations.md` to set that losing citation's row to `status=REJECTED | reason=contradicted_by_cit_<resolver_id>`.
+- **GENUINE_UNCERTAINTY** — interpretive disagreement (both can be true). Both interpretations are preserved in the final report; neither citation is rejected.
+- **UNVERIFIED** — appeared in debate without a valid `cit_XXX` reference. Do **not** rely on this claim in later phases. (Nothing to mark in the registry — UNVERIFIED claims by definition have no registry row.)
+
+When you flip a citation to `REJECTED`, use `Edit` on `<WORK_DIR>/citations.md` to rewrite that row only — do not delete the row. The registry must remain a complete audit log of every source you considered, including the ones you chose to drop.
 
 Save to `<WORK_DIR>/fact_check.md`:
 
@@ -505,11 +372,7 @@ For each verdict, **emit a VERDICT marker** on its own line:
 
 **Goal:** write the final report driven by `verdict.md`. Quality Gate runs inline — if a section fails, rewrite it before moving on.
 
-Save the report to:
-
-```
-<WORK_DIR>/report.md
-```
+`REPORT_PATH` was established in Setup: `<WORK_DIR>/report.md`. Write the report there using `Write`.
 
 **Report structure:**
 
@@ -564,7 +427,7 @@ If any check fails: fix the section before moving on.
 
 ### Language reminder
 
-The report follows the global `<USER_LANG>` policy at the top of Pro Mode: prose in `<USER_LANG>`, cited quotes verbatim in their original language. Do not re-translate quotes when assembling the report.
+The report follows the global language policy at the top of this prompt: prose in `<USER_LANG>`, cited quotes verbatim in their original language. Do not re-translate quotes when assembling the report.
 
 ---
 
@@ -576,7 +439,7 @@ After saving the report, **emit:**
 [[PHASE:complete]]
 ```
 
-Then your final reply MUST be exactly the block below — nothing before, nothing after — using the same `computer://` link format as Standard Mode:
+Then your final reply MUST be exactly the block below — nothing before, nothing after.
 
 ```
 ## Research Complete: <Subject>
@@ -591,11 +454,17 @@ Then your final reply MUST be exactly the block below — nothing before, nothin
 [View full report](computer://.bitfun/sessions/{SESSION_ID}/research/report.md)
 ```
 
-Same formatting rules as Standard Mode apply: plain markdown link, no backticks around it, no `<details>`, no HTML, do NOT include the report body in the reply.
+Formatting rules — violations will break the user experience:
+
+1. The report link MUST use the `computer://` scheme with the relative path shown above. Do NOT use `file://` or absolute paths.
+2. **Do NOT wrap the link in backticks, code fences, or any other markup.** Write it as a plain markdown link.
+3. **Do NOT use `<details>`, `<summary>`, collapsible sections, or HTML tags** of any kind.
+4. **Do NOT include the report content** in this reply — it is already in the file.
+5. Each finding must be a single sentence with at least one concrete detail. "X has grown significantly" is not acceptable.
 
 ---
 
-## Pro Mode — Phase Marker reference
+## Phase Marker reference
 
 The four marker forms, all on their own line, are:
 

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -2368,6 +2368,20 @@ impl ExecutionEngine {
                 "finalize_failed" | "empty_round" | "max_rounds"
             );
 
+        // Post-processing hook: when a DeepResearch dialog turn finishes
+        // successfully, renumber `cit_XXX` references in the final report
+        // into consecutive `[N]` display IDs. Two gates apply (agent type +
+        // dialog success) so other agents and failed turns are unaffected.
+        if success && agent_type == "DeepResearch" {
+            if let Some(workspace) = context.workspace.as_ref() {
+                crate::agentic::agents::citation_renumber::run_for_session_workspace(
+                    workspace.root_path(),
+                    &context.session_id,
+                )
+                .await;
+            }
+        }
+
         // Emit dialog turn completed event
         debug!("Preparing to send DialogTurnCompleted event");
 


### PR DESCRIPTION
…on renumber hook

The DeepResearch agent previously carried both the old Longitudinal + Cross-sectional + Synthesis "Standard Mode" and a parallel 6-phase Pro Mode in the same prompt, switched by a `深度研究:` / `deep:` prefix. In practice the Standard Mode path produced reports without the citation-registry audit trail that the rest of the deep-research UX (and the user) actually wanted. This commit makes 6-phase the sole pipeline.

Prompt (-228 / +93):
- Remove Standard Mode entirely, plus the Mode Switch bridge section, the Part I / Part II / Part III chapter structure, and the Scope note.
- Carry forward the parts that were genuinely useful in the old prompt: super-agent orchestration architecture, research standards (sourced/dated/attributed + avoidance vocabulary), prose style rules, Phase 0 orientation searches, and the Final Reply formatting contract.
- All work files (research_plan, specialists/*, citations, debate, fact_check, verdict, report) live under `<workspace>/.bitfun/sessions/{SESSION_ID}/research/`. Final report is `<WORK_DIR>/report.md` — no separate user-facing copy path, no slug inference, no pointer files. Setup explicitly warns the model not to reuse paths from earlier sessions visible in the message history.
- Phase 2 citations.md format adds `status=ACCEPTED|REJECTED` so Phase 4 fact-check can `Edit` the registry to mark rejected sources instead of deleting them; the registry remains a complete audit log.

New post-processing hook (citation_renumber.rs, +738 lines incl. 11 tests):
- Triggered from `execute_dialog_turn_impl` only when `success && agent_type == "DeepResearch"`. Best-effort: any I/O or parse failure is logged and swallowed so the surrounding agent flow is unaffected.
- Walks `<work_dir>/report.md` body, assigns consecutive display numbers `[N]` to each unique `cit_XXX` in order of first appearance. Handles the `[cit_A, cit_B]` bracket-group form so we do not end up with `[[1], [2]]`.
- Reads `citations.md` for `status=REJECTED` flags; rejected refs in the body get a `(rejected)` marker so prose stays readable while the sourcing warning is visible.
- Rewrites the Citation Index table: each `cit_XXX` becomes `[N] cit_XXX` (internal ID preserved for traceability), rows are sorted by `[N]` so the reader sees monotonic numbering, and `[REJECTED]` rows are dropped entirely (full audit remains in citations.md).
- Writes `display_map.json` sidecar next to citations.md.

DeepResearchMode (+2 / -2):
- Update the agent description to advertise the 6-phase pipeline so the agent picker and locale strings reflect what actually happens.

Tests: 11 unit + integration tests in citation_renumber.rs cover body renumbering, bracket-group collapse, REJECTED skip, registry parsing with `|`-prefixed rows and case-insensitive status, Citation Index section sort + REJECTED row removal, end-to-end through `try_renumber_research_report`, and the two `run_for_session_workspace` gates (missing audit dir, present audit dir).