### PR TITLE
Fix remote workspace compatibility guards

### DIFF
--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -1775,7 +1775,10 @@ pub async fn cleanup_invalid_workspaces(
     app: tauri::AppHandle,
 ) -> Result<usize, String> {
     match state.workspace_service.cleanup_invalid_workspaces().await {
-        Ok(removed_count) => {
+        Ok(local_removed_count) => {
+            let remote_removed_count = prune_unrecoverable_remote_workspaces(&state).await;
+            let removed_count = local_removed_count + remote_removed_count;
+
             if let Some(workspace_info) = state.workspace_service.get_current_workspace().await {
                 apply_active_workspace_context(&state, &app, &workspace_info).await;
             } else {
@@ -1804,6 +1807,80 @@ pub async fn cleanup_invalid_workspaces(
             Err(format!("Failed to cleanup invalid workspaces: {}", e))
         }
     }
+}
+
+async fn prune_unrecoverable_remote_workspaces(state: &State<'_, AppState>) -> usize {
+    let saved_connection_ids: std::collections::HashSet<String> = match state
+        .get_ssh_manager_async()
+        .await
+    {
+        Ok(manager) => manager
+            .get_saved_connections()
+            .await
+            .into_iter()
+            .map(|connection| connection.id)
+            .collect(),
+        Err(error) => {
+            warn!(
+                "Skipping remote workspace cleanup because SSH manager is unavailable: {}",
+                error
+            );
+            return 0;
+        }
+    };
+
+    let workspaces = state.workspace_service.list_workspace_infos().await;
+    let mut removed = 0usize;
+
+    for workspace in workspaces {
+        if workspace.workspace_kind != WorkspaceKind::Remote {
+            continue;
+        }
+
+        let connection_id = workspace
+            .metadata
+            .get("connectionId")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+
+        let should_remove = connection_id
+            .as_deref()
+            .map(|id| !saved_connection_ids.contains(id))
+            .unwrap_or(true);
+
+        if !should_remove {
+            continue;
+        }
+
+        if let Some(id) = connection_id.as_deref() {
+            state
+                .unregister_remote_workspace_entry(id, &workspace.root_path.to_string_lossy())
+                .await;
+        }
+
+        match state.workspace_service.remove_workspace(&workspace.id).await {
+            Ok(()) => {
+                removed += 1;
+                info!(
+                    "Removed unrecoverable remote workspace: workspace_id={}, connection_id={:?}, path={}",
+                    workspace.id,
+                    connection_id,
+                    workspace.root_path.display()
+                );
+            }
+            Err(error) => {
+                warn!(
+                    "Failed to remove unrecoverable remote workspace: workspace_id={}, error={}",
+                    workspace.id,
+                    error
+                );
+            }
+        }
+    }
+
+    removed
 }
 
 #[tauri::command]

--- a/src/crates/core/src/service/workspace/service.rs
+++ b/src/crates/core/src/service/workspace/service.rs
@@ -1234,11 +1234,13 @@ impl WorkspaceService {
             .map_err(|e| BitFunError::service(format!("Failed to load workspace data: {}", e)))?;
 
         let mut workspaces_to_restore = Vec::new();
+        let mut should_persist_cleaned_history = false;
 
         if let Some(data) = workspace_data {
             let mut manager = self.manager.write().await;
 
             let mut workspaces = data.workspaces;
+            let original_workspace_count = workspaces.len();
             // Filter out legacy remote workspaces that don't have the required metadata (sshHost and connectionId)
             workspaces.retain(|_id, ws| {
                 if ws.workspace_kind == WorkspaceKind::Remote {
@@ -1253,6 +1255,9 @@ impl WorkspaceService {
                 }
                 true
             });
+            if workspaces.len() != original_workspace_count {
+                should_persist_cleaned_history = true;
+            }
 
             *manager.get_workspaces_mut() = workspaces;
             // Also filter opened/recent lists to remove references to removed legacy workspaces
@@ -1262,6 +1267,9 @@ impl WorkspaceService {
                 .into_iter()
                 .filter(|id| manager.get_workspaces().contains_key(id))
                 .collect();
+            if filtered_opened_ids != data.opened_workspace_ids {
+                should_persist_cleaned_history = true;
+            }
             manager.set_opened_workspace_ids(filtered_opened_ids);
 
             let filtered_recent: Vec<String> = data
@@ -1270,6 +1278,9 @@ impl WorkspaceService {
                 .into_iter()
                 .filter(|id| manager.get_workspaces().contains_key(id))
                 .collect();
+            if filtered_recent != data.recent_workspaces {
+                should_persist_cleaned_history = true;
+            }
             manager.set_recent_workspaces(filtered_recent);
 
             let filtered_recent_assistant: Vec<String> = data
@@ -1278,9 +1289,15 @@ impl WorkspaceService {
                 .into_iter()
                 .filter(|id| manager.get_workspaces().contains_key(id))
                 .collect();
+            if filtered_recent_assistant != data.recent_assistant_workspaces {
+                should_persist_cleaned_history = true;
+            }
             manager.set_recent_assistant_workspaces(filtered_recent_assistant);
 
             let id_remap = manager.migrate_local_workspace_ids_to_stable_storage();
+            if !id_remap.is_empty() {
+                should_persist_cleaned_history = true;
+            }
 
             let raw_current = data
                 .current_workspace_id
@@ -1296,6 +1313,10 @@ impl WorkspaceService {
             }
 
             workspaces_to_restore = Self::collect_startup_restored_workspaces(&manager);
+        }
+
+        if should_persist_cleaned_history {
+            self.save_workspace_data().await?;
         }
 
         self.prepare_startup_restored_workspaces(workspaces_to_restore)

--- a/src/web-ui/src/app/components/NavPanel/MainNav.tsx
+++ b/src/web-ui/src/app/components/NavPanel/MainNav.tsx
@@ -695,8 +695,16 @@ const MainNav: React.FC<MainNavProps> = ({
           homePath={sshRemote.remoteFileBrowserInitialPath}
           onSelect={handleSelectRemoteWorkspace}
           onCancel={() => {
+            const hasActiveRemoteWorkspace =
+              Boolean(sshRemote.remoteWorkspace) ||
+              openedWorkspacesList.some(workspace =>
+                isRemoteWorkspace(workspace) &&
+                workspace.connectionId === sshRemote.connectionId
+              );
             sshRemote.setShowFileBrowser(false);
-            void sshRemote.disconnect();
+            if (!hasActiveRemoteWorkspace) {
+              void sshRemote.disconnect();
+            }
           }}
         />
       )}

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -125,7 +125,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
   // Remote connection status — optional: safe if not inside SSHRemoteProvider
   const sshContext = useContext(SSHContext);
   const remoteConnStatus = workspace.connectionId && sshContext
-    ? (sshContext.workspaceStatuses[workspace.connectionId] ?? 'connecting')
+    ? sshContext.workspaceStatuses[workspace.connectionId]
     : undefined;
 
   const searchIndexIndicator = useMemo(() => {
@@ -983,8 +983,8 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
             {isRemoteWorkspace(workspace) && (
               <span className="bitfun-nav-panel__workspace-item-subtitle">
                 <span
-                  className={`bitfun-nav-panel__workspace-item-status-dot is-${remoteConnStatus ?? 'connecting'}`}
-                  aria-label={remoteConnStatus ?? 'connecting'}
+                  className={`bitfun-nav-panel__workspace-item-status-dot is-${remoteConnStatus ?? 'unknown'}`}
+                  aria-label={remoteConnStatus ?? 'unknown'}
                 />
                 <span>{workspace.connectionName}</span>
               </span>

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
@@ -490,9 +490,14 @@
       background: var(--color-success, #22c55e);
     }
 
+    &.is-unknown,
     &.is-error,
     &.is-disconnected {
       background: var(--color-error, #ef4444);
+    }
+
+    &.is-unknown {
+      background: var(--color-text-tertiary, #94a3b8);
     }
 
     &.is-connecting {

--- a/src/web-ui/src/features/ssh-remote/SSHConnectionDialog.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHConnectionDialog.tsx
@@ -204,7 +204,7 @@ export const SSHConnectionDialog: React.FC<SSHConnectionDialogProps> = ({
     setIsConnecting(true);
     setLocalError(null);
     try {
-      await connect(config.id, config);
+      await connect(config.id, config, { browseAfterConnect: true });
       // Don't call onClose() here - connect() handles closing the dialog via context
     } catch (e) {
       setLocalError(e instanceof Error ? e.message : 'Connection failed');
@@ -220,14 +220,18 @@ export const SSHConnectionDialog: React.FC<SSHConnectionDialogProps> = ({
       setIsConnecting(true);
       setLocalError(null);
       try {
-        await connect(conn.id, {
-          id: conn.id,
-          name: conn.name,
-          host: conn.host,
-          port: conn.port,
-          username: conn.username,
-          auth: { type: 'Password', password: '' },
-        });
+        await connect(
+          conn.id,
+          {
+            id: conn.id,
+            name: conn.name,
+            host: conn.host,
+            port: conn.port,
+            username: conn.username,
+            auth: { type: 'Password', password: '' },
+          },
+          { browseAfterConnect: true }
+        );
       } catch {
         setCredentialsPrompt({ kind: 'saved', connection: conn });
       } finally {
@@ -241,14 +245,18 @@ export const SSHConnectionDialog: React.FC<SSHConnectionDialogProps> = ({
 
       setIsConnecting(true);
       try {
-        await connect(conn.id, {
-          id: conn.id,
-          name: conn.name,
-          host: conn.host,
-          port: conn.port,
-          username: conn.username,
-          auth,
-        });
+        await connect(
+          conn.id,
+          {
+            id: conn.id,
+            name: conn.name,
+            host: conn.host,
+            port: conn.port,
+            username: conn.username,
+            auth,
+          },
+          { browseAfterConnect: true }
+        );
       } catch (e) {
         setLocalError(e instanceof Error ? e.message : 'Connection failed');
       } finally {
@@ -292,7 +300,7 @@ export const SSHConnectionDialog: React.FC<SSHConnectionDialogProps> = ({
 
     setIsConnecting(true);
     try {
-      await connect(connectionId, authConfig);
+      await connect(connectionId, authConfig, { browseAfterConnect: true });
     } catch (e) {
       setLocalError(e instanceof Error ? e.message : 'Authentication failed');
     } finally {
@@ -331,7 +339,7 @@ export const SSHConnectionDialog: React.FC<SSHConnectionDialogProps> = ({
           username: resolvedUsername,
           auth,
         };
-        await connect(conn.id, full);
+        await connect(conn.id, full, { browseAfterConnect: true });
       } else {
         const { entry, connectHost, port } = credentialsPrompt;
         const connectionId = generateConnectionId(connectHost, port, resolvedUsername);
@@ -343,11 +351,10 @@ export const SSHConnectionDialog: React.FC<SSHConnectionDialogProps> = ({
           username: resolvedUsername,
           auth,
         };
-        await connect(connectionId, full);
+        await connect(connectionId, full, { browseAfterConnect: true });
         await loadSavedConnections();
       }
       setCredentialsPrompt(null);
-      onClose();
     } catch (e) {
       setLocalError(e instanceof Error ? e.message : 'Connection failed');
     } finally {

--- a/src/web-ui/src/features/ssh-remote/SSHRemoteContext.ts
+++ b/src/web-ui/src/features/ssh-remote/SSHRemoteContext.ts
@@ -16,7 +16,11 @@ export interface SSHContextValue {
   showFileBrowser: boolean;
   error: string | null;
   remoteFileBrowserInitialPath: string;
-  connect: (connectionId: string, config: SSHConnectionConfig) => Promise<void>;
+  connect: (
+    connectionId: string,
+    config: SSHConnectionConfig,
+    options?: { browseAfterConnect?: boolean }
+  ) => Promise<void>;
   disconnect: () => Promise<void>;
   openWorkspace: (path: string) => Promise<void>;
   closeWorkspace: () => Promise<void>;

--- a/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.tsx
@@ -10,6 +10,7 @@ import { sshApi } from './sshApi';
 import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
 import { ACPClientAPI } from '@/infrastructure/api/service-api/ACPClientAPI';
 import { normalizeRemoteWorkspacePath } from '@/shared/utils/pathUtils';
+import { notificationService } from '@/shared/notification-system';
 import {
   SSHContext,
   type ConnectionStatus,
@@ -18,6 +19,7 @@ import {
 
 const log = createLogger('SSHRemoteProvider');
 const pendingAcpCapabilityRefreshes = new Set<string>();
+const REMOTE_WORKSPACE_RECONNECT_TIMEOUT_MS = 60_000;
 
 function refreshRemoteAcpCapabilities(connectionId: string): void {
   const normalized = connectionId.trim();
@@ -133,14 +135,95 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
   // Per-workspace connection statuses (keyed by connectionId)
   const [workspaceStatuses, setWorkspaceStatuses] = useState<Record<string, ConnectionStatus>>({});
   const heartbeatInterval = useRef<number | null>(null);
+  const workspaceStatusTimeouts = useRef<Map<string, number>>(new Map());
+  const workspaceStatusesRef = useRef<Record<string, ConnectionStatus>>({});
+  const remoteWorkspaceRef = useRef<RemoteWorkspace | null>(null);
   const startHeartbeatRef = useRef<(connId: string) => void>(() => {});
   const checkRemoteWorkspaceRef = useRef<() => Promise<void>>(async () => {});
 
+  workspaceStatusesRef.current = workspaceStatuses;
+  remoteWorkspaceRef.current = remoteWorkspace;
+
   const setWorkspaceStatus = useCallback((connId: string, st: ConnectionStatus) => {
+    const existingTimeout = workspaceStatusTimeouts.current.get(connId);
+    if (existingTimeout !== undefined) {
+      window.clearTimeout(existingTimeout);
+      workspaceStatusTimeouts.current.delete(connId);
+    }
+
+    if (st === 'connecting') {
+      const timeoutId = window.setTimeout(() => {
+        workspaceStatusTimeouts.current.delete(connId);
+        if (workspaceStatusesRef.current[connId] !== 'connecting') {
+          return;
+        }
+
+        setWorkspaceStatuses(prev => {
+          if (prev[connId] !== 'connecting') {
+            return prev;
+          }
+          return { ...prev, [connId]: 'error' };
+        });
+
+        const openedRemoteWorkspaces: RemoteWorkspace[] = Array.from(workspaceManager.getState().openedWorkspaces.values())
+          .filter(workspace =>
+            workspace.workspaceKind === WorkspaceKind.Remote &&
+            (workspace.connectionId ?? '').trim() === connId
+          )
+          .map(workspace => ({
+            connectionId: connId,
+            connectionName: workspace.connectionName?.trim() || 'Remote',
+            remotePath: normalizeRemoteWorkspacePath(workspace.rootPath),
+            sshHost: workspace.sshHost?.trim() || undefined,
+          }));
+
+        const activeRemoteWorkspace = remoteWorkspaceRef.current;
+        if (
+          activeRemoteWorkspace &&
+          activeRemoteWorkspace.connectionId === connId &&
+          !openedRemoteWorkspaces.some(
+            workspace =>
+              normalizeRemoteWorkspacePath(workspace.remotePath) ===
+              normalizeRemoteWorkspacePath(activeRemoteWorkspace.remotePath)
+          )
+        ) {
+          openedRemoteWorkspaces.push(activeRemoteWorkspace);
+        }
+
+        const pathList = openedRemoteWorkspaces
+          .map(workspace => normalizeRemoteWorkspacePath(workspace.remotePath))
+          .filter(Boolean)
+          .join(', ');
+
+        notificationService.error(
+          pathList
+            ? `Remote workspace connection timed out after 60 seconds and was removed: ${pathList}`
+            : 'Remote workspace connection timed out after 60 seconds.',
+          { duration: 8000 }
+        );
+
+        void Promise.allSettled(
+          openedRemoteWorkspaces.map(workspace =>
+            Promise.allSettled([
+              workspaceManager.removeRemoteWorkspace(workspace.connectionId, workspace.remotePath),
+              sshApi.removeWorkspace(workspace.connectionId, workspace.remotePath),
+            ])
+          )
+        );
+      }, REMOTE_WORKSPACE_RECONNECT_TIMEOUT_MS);
+
+      workspaceStatusTimeouts.current.set(connId, timeoutId);
+    }
+
     setWorkspaceStatuses(prev => ({ ...prev, [connId]: st }));
   }, []);
 
   const clearWorkspaceStatus = useCallback((connId: string) => {
+    const existingTimeout = workspaceStatusTimeouts.current.get(connId);
+    if (existingTimeout !== undefined) {
+      window.clearTimeout(existingTimeout);
+      workspaceStatusTimeouts.current.delete(connId);
+    }
     setWorkspaceStatuses(prev => {
       if (!(connId in prev)) return prev;
       const next = { ...prev };
@@ -161,12 +244,25 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
     ]);
   }, [clearWorkspaceStatus]);
 
+  const reportRemoteWorkspaceReconnectFailure = useCallback((workspace: RemoteWorkspace) => {
+    const path = normalizeRemoteWorkspacePath(workspace.remotePath);
+    notificationService.error(
+      `Remote workspace could not reconnect within 60 seconds and was removed: ${path}`,
+      { duration: 8000 }
+    );
+  }, []);
+
   // Cleanup heartbeat on unmount
   useEffect(() => {
+    const statusTimeouts = workspaceStatusTimeouts.current;
     return () => {
       if (heartbeatInterval.current) {
         clearInterval(heartbeatInterval.current);
       }
+      for (const timeoutId of statusTimeouts.values()) {
+        window.clearTimeout(timeoutId);
+      }
+      statusTimeouts.clear();
     };
   }, []);
 
@@ -426,7 +522,11 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
             connectionId: workspace.connectionId,
             remotePath: workspace.remotePath,
           });
-          const result = await tryReconnectWithRetry(workspace, 1, 5000);
+          const result = await tryReconnectWithRetry(
+            workspace,
+            1,
+            REMOTE_WORKSPACE_RECONNECT_TIMEOUT_MS
+          );
 
           if (result !== false) {
             log.info('Reconnection successful', { newConnectionId: result.connectionId });
@@ -459,6 +559,7 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
             connectionId: workspace.connectionId,
             auth: savedConn?.authType.type,
           });
+          reportRemoteWorkspaceReconnectFailure(workspace);
           await forgetRemoteWorkspace(workspace);
           return { ok: false as const };
         })
@@ -478,7 +579,12 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
     } catch (e) {
       log.error('checkRemoteWorkspace failed', e);
     }
-  }, [forgetRemoteWorkspace, setWorkspaceStatus, tryReconnectWithRetry]);
+  }, [
+    forgetRemoteWorkspace,
+    reportRemoteWorkspaceReconnectFailure,
+    setWorkspaceStatus,
+    tryReconnectWithRetry,
+  ]);
   checkRemoteWorkspaceRef.current = checkRemoteWorkspace;
 
   // Wait for workspace manager to finish loading, then check remote workspaces
@@ -499,7 +605,28 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
     return unsubscribe;
   }, [checkRemoteWorkspace]);
 
-  const connect = useCallback(async (_connId: string, config: SSHConnectionConfig) => {
+  useEffect(() => {
+    return workspaceManager.addEventListener(event => {
+      const workspace =
+        'workspace' in event && event.workspace?.workspaceKind === WorkspaceKind.Remote
+          ? event.workspace
+          : null;
+      if (!workspace) {
+        return;
+      }
+      const connId = workspace.connectionId?.trim();
+      if (connId && !workspaceStatusesRef.current[connId]) {
+        setWorkspaceStatus(connId, 'connecting');
+      }
+      void checkRemoteWorkspaceRef.current();
+    });
+  }, [setWorkspaceStatus]);
+
+  const connect = useCallback(async (
+    _connId: string,
+    config: SSHConnectionConfig,
+    options?: { browseAfterConnect?: boolean }
+  ) => {
     log.debug('SSH connect called', { host: config.host });
     setStatus('connecting');
     setIsConnecting(true);
@@ -526,7 +653,16 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
         const homePath =
           home && home.length > 0 ? normalizeRemoteWorkspacePath(home) : '/tmp';
 
-        if (activeRemoteWorkspace) {
+        if (options?.browseAfterConnect) {
+          if (activeRemoteWorkspace) {
+            setRemoteWorkspace(activeRemoteWorkspace);
+            setWorkspaceStatus(result.connectionId, 'connected');
+          } else {
+            setRemoteWorkspace(null);
+          }
+          setRemoteFileBrowserInitialPath(homePath);
+          setShowFileBrowser(true);
+        } else if (activeRemoteWorkspace) {
           try {
             await sshApi.openWorkspace(result.connectionId, activeRemoteWorkspace.remotePath);
             setRemoteWorkspace(activeRemoteWorkspace);

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -729,6 +729,44 @@ export class FlowChatStore {
     return this.removeSessionsByIds(removedSessionIds);
   }
 
+  public async cancelRunningSessionsForWorkspace(
+    workspace: Pick<WorkspaceInfo, 'id' | 'rootPath' | 'connectionId' | 'sshHost'>
+  ): Promise<string[]> {
+    const runningSessionIds = Array.from(this.state.sessions.values())
+      .filter(session => sessionMatchesWorkspace(session, workspace))
+      .filter(session => {
+        const lastTurn = session.dialogTurns[session.dialogTurns.length - 1];
+        return Boolean(
+          lastTurn &&
+          !['completed', 'cancelled', 'error'].includes(lastTurn.status)
+        );
+      })
+      .map(session => session.sessionId);
+
+    if (runningSessionIds.length === 0) {
+      return [];
+    }
+
+    const { agentAPI } = await import('@/infrastructure/api');
+    await Promise.allSettled(
+      runningSessionIds.map(async sessionId => {
+        try {
+          await agentAPI.cancelSession(sessionId);
+        } catch (error) {
+          log.warn('Failed to cancel running session before closing workspace', {
+            sessionId,
+            workspaceId: workspace.id,
+            error,
+          });
+        } finally {
+          this.cancelSessionTask(sessionId);
+        }
+      })
+    );
+
+    return runningSessionIds;
+  }
+
   /** @deprecated Prefer `removeSessionsForWorkspace` with full `WorkspaceInfo`. */
   public removeSessionsByWorkspace(
     workspacePath: string,

--- a/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
+++ b/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
@@ -462,7 +462,14 @@ class WorkspaceManager {
         return;
       }
 
+      await this.cancelRunningSessionsForWorkspace(workspace);
       await globalStateAPI.closeWorkspace(workspace.id);
+      await globalStateAPI.removeWorkspaceFromRecent(workspace.id).catch(error => {
+        log.warn('Failed to remove remote workspace from recent list', {
+          workspaceId: workspace.id,
+          error,
+        });
+      });
 
       const [currentWorkspace, recentWorkspaces, openedWorkspaces] = await Promise.all([
         globalStateAPI.getCurrentWorkspace(),
@@ -550,6 +557,11 @@ class WorkspaceManager {
 
       log.info('Closing workspace', { workspaceId });
 
+      const closingWorkspace = this.state.openedWorkspaces.get(workspaceId);
+      if (closingWorkspace) {
+        await this.cancelRunningSessionsForWorkspace(closingWorkspace);
+      }
+
       await globalStateAPI.closeWorkspace(workspaceId);
 
       const [currentWorkspace, recentWorkspaces, openedWorkspaces] = await Promise.all([
@@ -573,6 +585,24 @@ class WorkspaceManager {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.updateState({ loading: false, error: errorMessage }, { type: 'workspace:error', error: errorMessage });
       throw error;
+    }
+  }
+
+  private async cancelRunningSessionsForWorkspace(workspace: WorkspaceInfo): Promise<void> {
+    try {
+      const { flowChatStore } = await import('@/flow_chat/store/FlowChatStore');
+      const cancelledSessionIds = await flowChatStore.cancelRunningSessionsForWorkspace(workspace);
+      if (cancelledSessionIds.length > 0) {
+        log.info('Cancelled running sessions before closing workspace', {
+          workspaceId: workspace.id,
+          count: cancelledSessionIds.length,
+        });
+      }
+    } catch (error) {
+      log.warn('Failed to cancel running sessions before closing workspace', {
+        workspaceId: workspace.id,
+        error,
+      });
     }
   }
 
@@ -892,5 +922,3 @@ class WorkspaceManager {
 export const workspaceManager = WorkspaceManager.getInstance();
 
 export { WorkspaceManager };
-
-


### PR DESCRIPTION
## Summary
- add 60s timeout/error handling for all pending remote workspace connection states and remove timed-out remote workspaces
- prune unrecoverable legacy remote workspace records from startup cleanup and workspace history
- allow connecting another folder on the same SSH connection via file browser without tearing down an active remote workspace
- cancel running sessions when a workspace is closed or removed

## Validation
- pnpm run lint:web
- pnpm run type-check:web
- pnpm --dir src/web-ui run test:run
- cargo check -p bitfun-desktop
- cargo test -p bitfun-desktop
- cargo check -p bitfun-core
- cargo test -p bitfun-core load_workspace_history_only -- --nocapture
