### PR TITLE
Improve startup and historical session readiness

### DIFF
--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -21,7 +21,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-use std::time::Instant;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tauri::Emitter;
 use tauri::Manager;
 
@@ -194,6 +194,10 @@ async fn webdriver_bridge_result(request: WebdriverBridgeResultRequest) -> Resul
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub async fn run() {
     let startup_started = Instant::now();
+    let startup_trace_id = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| format!("desktop-{}", duration.as_millis()))
+        .unwrap_or_else(|_| "desktop-unknown".to_string());
     let mut startup_timings = TimingCollector::default();
     let in_debug = cfg!(debug_assertions) || std::env::var("DEBUG").unwrap_or_default() == "1";
     let log_config = logging::LogConfig::new(in_debug);
@@ -303,6 +307,11 @@ pub async fn run() {
         .manage(terminal_state)
         .setup(move |app| {
             let setup_started = Instant::now();
+            log::debug!(
+                "Desktop startup trace event: trace_id={}, phase=tauri_setup_start, since_process_start_ms={}",
+                startup_trace_id,
+                elapsed_ms(startup_started)
+            );
             #[cfg(target_os = "macos")]
             {
                 app.on_menu_event(|app, event| {
@@ -414,16 +423,34 @@ pub async fn run() {
 
             let app_handle = app.handle().clone();
             let window_started = Instant::now();
-            theme::create_main_window(&app_handle);
+            log::debug!(
+                "Desktop startup trace event: trace_id={}, phase=main_window_create_start",
+                startup_trace_id
+            );
+            theme::create_main_window(&app_handle, &startup_trace_id);
+            let window_duration_ms = elapsed_ms(window_started);
             log::debug!(
                 "Desktop startup step completed: step=create_main_window, duration_ms={}",
-                elapsed_ms(window_started)
+                window_duration_ms
+            );
+            log::debug!(
+                "Desktop startup trace event: trace_id={}, phase=main_window_create_end, duration_ms={}",
+                startup_trace_id,
+                window_duration_ms
             );
             bitfun_webdriver::maybe_start(app_handle.clone());
+            let setup_duration_ms = elapsed_ms(setup_started);
+            let since_process_start_ms = elapsed_ms(startup_started);
             log::debug!(
                 "Desktop startup timing: phase=tauri_setup, duration_ms={}, since_process_start_ms={}",
-                elapsed_ms(setup_started),
-                elapsed_ms(startup_started)
+                setup_duration_ms,
+                since_process_start_ms
+            );
+            log::debug!(
+                "Desktop startup trace event: trace_id={}, phase=tauri_setup_end, duration_ms={}, since_process_start_ms={}",
+                startup_trace_id,
+                setup_duration_ms,
+                since_process_start_ms
             );
 
             #[cfg(target_os = "macos")]

--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -270,12 +270,15 @@ impl ThemeConfig {
         theme_id
     }
 
-    pub fn generate_init_script(&self) -> String {
+    pub fn generate_init_script(&self, startup_trace_id: &str) -> String {
         let theme_type = if self.is_light { "light" } else { "dark" };
+        let startup_trace_id_json = serde_json::to_string(startup_trace_id)
+            .unwrap_or_else(|_| "\"desktop-unknown\"".to_string());
 
         format!(
             r#"
             (function() {{
+                window.__BITFUN_STARTUP_TRACE_ID__ = {startup_trace_id_json};
                 function applyTheme() {{
                     var root = document.documentElement;
                     if (!root) return false;
@@ -318,6 +321,7 @@ impl ThemeConfig {
             bg_secondary = self.bg_secondary,
             bg_scene = self.bg_scene,
             text_primary = self.text_primary,
+            startup_trace_id_json = startup_trace_id_json,
         )
     }
 
@@ -330,10 +334,10 @@ impl ThemeConfig {
     }
 }
 
-pub fn create_main_window(app_handle: &tauri::AppHandle) {
+pub fn create_main_window(app_handle: &tauri::AppHandle, startup_trace_id: &str) {
     let theme = ThemeConfig::load_from_config();
     let bg_color = theme.to_tauri_color();
-    let init_script = theme.generate_init_script();
+    let init_script = theme.generate_init_script(startup_trace_id);
 
     let main_url = if cfg!(debug_assertions) {
         match "http://localhost:1422".parse() {

--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -10,6 +10,7 @@ import { NotificationContainer, NotificationCenter } from '../shared/notificatio
 import { AnnouncementProvider } from '../shared/announcement-system';
 import { ConfirmDialogRenderer } from '../component-library';
 import { createLogger } from '@/shared/utils/logger';
+import { startupTrace } from '@/shared/utils/startupTrace';
 import { aiExperienceConfigService } from '@/infrastructure/config/services/AIExperienceConfigService';
 import { syncAgentCompanionDesktopWindow } from '@/infrastructure/config/services/AgentCompanionWindowService';
 import { isTauriRuntime } from '@/infrastructure/runtime';
@@ -51,6 +52,7 @@ function App() {
   const [splashExiting, setSplashExiting] = useState(false);
   const mountTimeRef = useRef(Date.now());
   const mainWindowShownRef = useRef(false);
+  const interactiveShellReadyRef = useRef(false);
 
   // Once the workspace finishes loading, wait for the remaining min-display
   // time and then begin the exit animation.
@@ -76,6 +78,7 @@ function App() {
       const { invoke } = await import('@tauri-apps/api/core');
       await invoke('show_main_window');
       log.debug('Main window shown', { reason });
+      startupTrace.markPhase('main_window_shown', { reason });
     } catch (error: any) {
       log.error('Failed to show main window', error);
 
@@ -85,6 +88,7 @@ function App() {
         await mainWindow.show();
         await mainWindow.setFocus();
         log.debug('Main window shown via fallback', { reason });
+        startupTrace.markPhase('main_window_shown_fallback', { reason });
       } catch (fallbackError) {
         log.error('Fallback window show failed', fallbackError);
         mainWindowShownRef.current = false;
@@ -96,8 +100,17 @@ function App() {
   // The splash still covers the UI, so users see immediate feedback instead
   // of waiting on a hidden window while startup continues in the background.
   useEffect(() => {
+    startupTrace.markPhase('app_effect_mounted');
     void showMainWindow('startup-overlay');
   }, [showMainWindow]);
+
+  useEffect(() => {
+    if (workspaceLoading || interactiveShellReadyRef.current) {
+      return;
+    }
+    interactiveShellReadyRef.current = true;
+    startupTrace.markPhase('interactive_shell_ready');
+  }, [workspaceLoading]);
 
   // If the early reveal path fails, keep the old post-splash show as a retry.
   useEffect(() => {

--- a/src/web-ui/src/flow_chat/components/modern/HistorySessionPlaceholder.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/HistorySessionPlaceholder.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { AlertCircle, LoaderCircle, RefreshCw } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { SessionHistoryState } from '../../types/flow-chat';
+
+interface HistorySessionPlaceholderProps {
+  state: Extract<SessionHistoryState, 'metadata-only' | 'hydrating' | 'failed'>;
+  onRetry?: () => void;
+}
+
+export const HistorySessionPlaceholder: React.FC<HistorySessionPlaceholderProps> = ({
+  state,
+  onRetry,
+}) => {
+  const { t } = useTranslation('flow-chat');
+  const failed = state === 'failed';
+
+  return (
+    <div className="history-session-placeholder" role={failed ? 'alert' : 'status'}>
+      <div
+        className={`history-session-placeholder__icon${failed ? ' history-session-placeholder__icon--failed' : ''}`}
+        aria-hidden="true"
+      >
+        {failed ? <AlertCircle size={24} /> : <LoaderCircle size={24} />}
+      </div>
+      <div className="history-session-placeholder__text">
+        <h2 className="history-session-placeholder__title">
+          {failed ? t('historyState.failedTitle') : t('historyState.loadingTitle')}
+        </h2>
+        <p className="history-session-placeholder__description">
+          {failed ? t('historyState.failedDescription') : t('historyState.loadingDescription')}
+        </p>
+      </div>
+      {failed && (
+        <button
+          type="button"
+          className="history-session-placeholder__retry"
+          onClick={onRetry}
+        >
+          <RefreshCw size={14} aria-hidden="true" />
+          <span>{t('historyState.retry')}</span>
+        </button>
+      )}
+    </div>
+  );
+};
+
+HistorySessionPlaceholder.displayName = 'HistorySessionPlaceholder';

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { ModernFlowChatContainer } from './ModernFlowChatContainer';
+import type { Session } from '../../types/flow-chat';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const stateMocks = vi.hoisted(() => ({
+  activeSession: null as Session | null,
+  virtualItems: [] as unknown[],
+  visibleTurnInfo: null as unknown,
+}));
+
+const switchChatSessionMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const labels: Record<string, string> = {
+        'historyState.loadingTitle': 'Loading saved session',
+        'historyState.loadingDescription': 'Preparing the conversation history.',
+        'historyState.failedTitle': 'Session history did not load',
+        'historyState.failedDescription': 'Retry loading the saved conversation.',
+        'historyState.retry': 'Retry',
+      };
+      return labels[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('@/infrastructure/hooks/useShortcut', () => ({
+  useShortcut: vi.fn(),
+}));
+
+vi.mock('@/flow_chat/services/FlowChatManager', () => ({
+  FlowChatManager: {
+    getInstance: () => ({
+      cancelCurrentTask: vi.fn(),
+      createChatSession: vi.fn(),
+      switchChatSession: switchChatSessionMock,
+    }),
+  },
+}));
+
+vi.mock('@/app/stores/sessionModeStore', () => ({
+  useSessionModeStore: {
+    getState: () => ({
+      setMode: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('@/infrastructure/contexts/WorkspaceContext', () => ({
+  useWorkspaceContext: () => ({
+    workspacePath: 'D:/workspace/BitFun',
+  }),
+}));
+
+vi.mock('../../utils/acpSession', () => ({
+  isAcpFlowSession: () => false,
+}));
+
+vi.mock('../../store/modernFlowChatStore', () => ({
+  useVirtualItems: () => stateMocks.virtualItems,
+  useActiveSession: () => stateMocks.activeSession,
+  useVisibleTurnInfo: () => stateMocks.visibleTurnInfo,
+}));
+
+vi.mock('./VirtualMessageList', () => ({
+  VirtualMessageList: React.forwardRef(() => <div data-testid="virtual-list" />),
+}));
+
+vi.mock('./FlowChatHeader', () => ({
+  FlowChatHeader: () => <div data-testid="flowchat-header" />,
+}));
+
+vi.mock('../WelcomePanel', () => ({
+  WelcomePanel: () => <div data-testid="welcome-panel">Welcome panel</div>,
+}));
+
+vi.mock('./useExploreGroupState', () => ({
+  useExploreGroupState: () => ({
+    exploreGroupStates: {},
+    onExploreGroupToggle: vi.fn(),
+    onExpandGroup: vi.fn(),
+    onExpandAllInTurn: vi.fn(),
+    onCollapseGroup: vi.fn(),
+  }),
+}));
+
+vi.mock('./useFlowChatFileActions', () => ({
+  useFlowChatFileActions: () => ({
+    handleFileViewRequest: vi.fn(),
+  }),
+}));
+
+vi.mock('./useFlowChatNavigation', () => ({
+  useFlowChatNavigation: vi.fn(),
+}));
+
+vi.mock('./useFlowChatCopyDialog', () => ({
+  useFlowChatCopyDialog: vi.fn(),
+}));
+
+vi.mock('./useFlowChatSync', () => ({
+  useFlowChatSync: vi.fn(),
+}));
+
+vi.mock('./useFlowChatToolActions', () => ({
+  useFlowChatToolActions: () => ({
+    handleToolConfirm: vi.fn(),
+    handleToolReject: vi.fn(),
+  }),
+}));
+
+vi.mock('./useFlowChatSearch', () => ({
+  useFlowChatSearch: () => ({
+    searchQuery: '',
+    onSearchChange: vi.fn(),
+    matches: [],
+    matchIndices: [],
+    currentMatchIndex: -1,
+    currentMatchVirtualIndex: -1,
+    goToNext: vi.fn(),
+    goToPrev: vi.fn(),
+    clearSearch: vi.fn(),
+  }),
+}));
+
+function createSession(overrides: Partial<Session> = {}): Session {
+  return {
+    sessionId: 'session-1',
+    title: 'Saved session',
+    dialogTurns: [],
+    status: 'idle',
+    config: { agentType: 'agentic' },
+    createdAt: 1,
+    lastActiveAt: 1,
+    error: null,
+    isHistorical: true,
+    todos: [],
+    mode: 'agentic',
+    workspacePath: 'D:/workspace/BitFun',
+    sessionKind: 'normal',
+    ...overrides,
+  };
+}
+
+describe('ModernFlowChatContainer historical empty state', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    stateMocks.virtualItems = [];
+    stateMocks.visibleTurnInfo = null;
+    switchChatSessionMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root.unmount();
+      });
+    }
+    container?.remove();
+    stateMocks.activeSession = null;
+  });
+
+  it('shows a history loading shell for metadata-only sessions instead of the new-session welcome', () => {
+    stateMocks.activeSession = createSession({ historyState: 'metadata-only' } as Partial<Session>);
+
+    act(() => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(container.textContent).toContain('Loading saved session');
+    expect(container.querySelector('[data-testid="welcome-panel"]')).toBeNull();
+  });
+
+  it('keeps the loading shell while historical sessions are hydrating', () => {
+    stateMocks.activeSession = createSession({ historyState: 'hydrating' } as Partial<Session>);
+
+    act(() => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(container.textContent).toContain('Loading saved session');
+    expect(container.querySelector('[data-testid="welcome-panel"]')).toBeNull();
+  });
+
+  it('keeps the new-session welcome for genuinely new empty sessions', () => {
+    stateMocks.activeSession = createSession({
+      isHistorical: false,
+      historyState: 'new',
+    } as Partial<Session>);
+
+    act(() => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(container.querySelector('[data-testid="welcome-panel"]')).not.toBeNull();
+  });
+
+  it('shows retry for failed history loads', () => {
+    stateMocks.activeSession = createSession({ historyState: 'failed' } as Partial<Session>);
+
+    act(() => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    const retryButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('Retry'));
+    expect(container.textContent).toContain('Session history did not load');
+    expect(retryButton).toBeTruthy();
+
+    act(() => {
+      retryButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(switchChatSessionMock).toHaveBeenCalledWith('session-1');
+  });
+});

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.scss
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.scss
@@ -43,3 +43,84 @@
     border-top: 1px solid var(--color-border, #3a3a3a);
   }
 }
+
+.history-session-placeholder {
+  width: 100%;
+  height: 100%;
+  min-height: 240px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 32px;
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.history-session-placeholder__icon {
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-accent, #5b8def);
+
+  svg {
+    animation: history-placeholder-spin 1.1s linear infinite;
+  }
+}
+
+.history-session-placeholder__icon--failed {
+  color: var(--color-warning, #f59e0b);
+
+  svg {
+    animation: none;
+  }
+}
+
+.history-session-placeholder__text {
+  display: grid;
+  gap: 6px;
+  max-width: min(420px, 100%);
+}
+
+.history-session-placeholder__title {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.history-session-placeholder__description {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.history-session-placeholder__retry {
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 0 12px;
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.12));
+  border-radius: 6px;
+  color: var(--color-text-primary);
+  background: var(--color-surface-hover, rgba(255, 255, 255, 0.06));
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.history-session-placeholder__retry:hover {
+  background: var(--color-surface-active, rgba(255, 255, 255, 0.1));
+}
+
+@keyframes history-placeholder-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -11,6 +11,7 @@ import { useSessionModeStore } from '@/app/stores/sessionModeStore';
 import { VirtualMessageList, VirtualMessageListRef } from './VirtualMessageList';
 import { FlowChatHeader, type FlowChatHeaderTurnSummary } from './FlowChatHeader';
 import { WelcomePanel } from '../WelcomePanel';
+import { HistorySessionPlaceholder } from './HistorySessionPlaceholder';
 import { FlowChatContext, FlowChatContextValue } from './FlowChatContext';
 import { useExploreGroupState } from './useExploreGroupState';
 import { useFlowChatFileActions } from './useFlowChatFileActions';
@@ -56,6 +57,12 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const chatScopeRef = useRef<HTMLDivElement>(null);
   const { workspacePath } = useWorkspaceContext();
   const allowUserMessageRollback = !isAcpFlowSession(activeSession);
+  const historyState = activeSession?.historyState;
+  const showHistoryPlaceholder = virtualItems.length === 0 && (
+    historyState === 'metadata-only' ||
+    historyState === 'hydrating' ||
+    historyState === 'failed'
+  );
   const {
     exploreGroupStates,
     onExploreGroupToggle: handleExploreGroupToggle,
@@ -266,6 +273,12 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     handleJumpToTurn(nextTurn.turnId);
   }, [effectiveVisibleTurnInfo, handleJumpToTurn, turnSummaries]);
 
+  const handleRetryHistoryLoad = useCallback(() => {
+    const sessionId = activeSession?.sessionId;
+    if (!sessionId) return;
+    void FlowChatManager.getInstance().switchChatSession(sessionId);
+  }, [activeSession?.sessionId]);
+
   useShortcut(
     'chat.stopGeneration',
     { key: 'Escape', scope: 'chat', allowInInput: true },
@@ -343,7 +356,12 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
         />
 
         <div className="modern-flowchat-container__messages">
-          {virtualItems.length === 0 ? (
+          {showHistoryPlaceholder ? (
+            <HistorySessionPlaceholder
+              state={historyState}
+              onRetry={handleRetryHistoryLoad}
+            />
+          ) : virtualItems.length === 0 ? (
             <WelcomePanel
               key={activeSession?.sessionId ?? 'welcome'}
               sessionMode={activeSession?.mode}

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ensureBackendSession, switchChatSession } from './SessionModule';
+import type { Session } from '../../types/flow-chat';
+
+const agentApiMocks = vi.hoisted(() => ({
+  ensureCoordinatorSession: vi.fn(),
+  createSession: vi.fn(),
+}));
+
+const persistenceMocks = vi.hoisted(() => ({
+  touchSessionActivity: vi.fn(),
+  cleanupSaveState: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/api/service-api/AgentAPI', () => ({
+  agentAPI: agentApiMocks,
+}));
+
+vi.mock('@/infrastructure/api/service-api/SessionAPI', () => ({
+  sessionAPI: {},
+}));
+
+vi.mock('../../../shared/notification-system', () => ({
+  notificationService: {
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock('@/infrastructure/i18n', () => ({
+  i18nService: {
+    t: (key: string) => key,
+  },
+}));
+
+vi.mock('@/infrastructure/services/business/workspaceManager', () => ({
+  workspaceManager: {
+    getState: () => ({
+      currentWorkspace: null,
+      openedWorkspaces: new Map(),
+    }),
+  },
+}));
+
+vi.mock('./PersistenceModule', () => ({
+  touchSessionActivity: persistenceMocks.touchSessionActivity,
+  cleanupSaveState: persistenceMocks.cleanupSaveState,
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createSession(overrides: Partial<Session> = {}): Session {
+  return {
+    sessionId: 'history-1',
+    title: 'Saved session',
+    dialogTurns: [],
+    status: 'idle',
+    config: { agentType: 'agentic' },
+    createdAt: 1,
+    lastActiveAt: 1,
+    error: null,
+    isHistorical: true,
+    historyState: 'metadata-only',
+    todos: [],
+    mode: 'agentic',
+    workspacePath: 'D:/workspace/BitFun',
+    sessionKind: 'normal',
+    ...overrides,
+  };
+}
+
+function createContext(session: Session) {
+  let state = {
+    sessions: new Map([[session.sessionId, session]]),
+    activeSessionId: null as string | null,
+  };
+  const flowChatStore = {
+    getState: () => state,
+    switchSession: vi.fn((sessionId: string) => {
+      state = { ...state, activeSessionId: sessionId };
+    }),
+    loadSessionHistory: vi.fn(),
+    setState: vi.fn((updater: any) => {
+      state = updater(state);
+    }),
+  };
+
+  return {
+    context: {
+      flowChatStore,
+      pendingHistoryLoads: new Map<string, Promise<void>>(),
+    } as any,
+    flowChatStore,
+  };
+}
+
+describe('SessionModule historical session coordination', () => {
+  it('switches to a historical session immediately while hydrating in the background', async () => {
+    const load = createDeferred<void>();
+    const { context, flowChatStore } = createContext(createSession());
+    flowChatStore.loadSessionHistory.mockReturnValueOnce(load.promise);
+    persistenceMocks.touchSessionActivity.mockResolvedValueOnce(undefined);
+
+    await switchChatSession(context, 'history-1');
+
+    expect(flowChatStore.switchSession).toHaveBeenCalledWith('history-1');
+    expect(flowChatStore.loadSessionHistory).toHaveBeenCalledTimes(1);
+
+    load.resolve();
+    await load.promise;
+  });
+
+  it('reuses pending historical hydration before ensuring the backend session', async () => {
+    const pendingHydrate = createDeferred<void>();
+    const { context, flowChatStore } = createContext(createSession());
+    context.pendingHistoryLoads.set('history-1', pendingHydrate.promise);
+    agentApiMocks.ensureCoordinatorSession.mockResolvedValueOnce(undefined);
+
+    const ensure = ensureBackendSession(context, 'history-1');
+    await Promise.resolve();
+
+    expect(flowChatStore.loadSessionHistory).not.toHaveBeenCalled();
+    expect(agentApiMocks.ensureCoordinatorSession).not.toHaveBeenCalled();
+
+    pendingHydrate.resolve();
+    await ensure;
+
+    expect(agentApiMocks.ensureCoordinatorSession).toHaveBeenCalledTimes(1);
+    expect(agentApiMocks.createSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -7,6 +7,8 @@ import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
 import { sessionAPI } from '@/infrastructure/api/service-api/SessionAPI';
 import { notificationService } from '../../../shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
+import { isRemoteTraceContext, startupTrace } from '@/shared/utils/startupTrace';
+import { elapsedMs, nowMs } from '@/shared/utils/timing';
 import { i18nService } from '@/infrastructure/i18n';
 import { workspaceManager } from '@/infrastructure/services/business/workspaceManager';
 import { normalizeRemoteWorkspacePath } from '@/shared/utils/pathUtils';
@@ -105,9 +107,11 @@ async function hydrateHistoricalSession(
 ): Promise<void> {
   const existing = context.pendingHistoryLoads.get(sessionId);
   if (existing) {
+    startupTrace.markPhase('historical_session_hydrate_reused');
     await existing;
     return;
   }
+  const traceStartedAt = nowMs();
 
   const loadPromise = (async () => {
     const session = context.flowChatStore.getState().sessions.get(sessionId);
@@ -116,6 +120,8 @@ async function hydrateHistoricalSession(
     }
 
     const workspacePath = requireSessionWorkspacePath(session.workspacePath, sessionId);
+    const remote = isRemoteTraceContext(session.remoteConnectionId, session.remoteSshHost);
+    startupTrace.markPhase('historical_session_hydrate_request', { remote });
 
     // Prefer the current workspace's connection info over the session's
     // stored values.  When the user changes the SSH port the session's
@@ -145,7 +151,13 @@ async function hydrateHistoricalSession(
 
   try {
     await loadPromise;
+    startupTrace.markPhase('historical_session_hydrate_request_end', {
+      durationMs: elapsedMs(traceStartedAt),
+    });
   } catch (error) {
+    startupTrace.markPhase('historical_session_hydrate_request_failed', {
+      durationMs: elapsedMs(traceStartedAt),
+    });
     log.error('Failed to load session history', { sessionId, error });
     if (notifyOnError) {
       notificationService.warning('Failed to load session history, showing empty session', {
@@ -465,6 +477,10 @@ export async function switchChatSession(
 
     // Switch UI immediately so the user sees the new session without waiting for history load.
     context.flowChatStore.switchSession(sessionId);
+    startupTrace.markPhase('historical_session_switch', {
+      historical: Boolean(session?.isHistorical),
+      remote: isRemoteTraceContext(session?.remoteConnectionId, session?.remoteSshHost),
+    });
 
     touchSessionActivity(
       sessionId,
@@ -650,7 +666,7 @@ export async function ensureBackendSession(
       const newSessions = new Map(prev.sessions);
       const sess = newSessions.get(sessionId);
       if (sess) {
-        newSessions.set(sessionId, { ...sess, isHistorical: false });
+        newSessions.set(sessionId, { ...sess, isHistorical: false, historyState: 'ready' });
       }
       return { ...prev, sessions: newSessions };
     });

--- a/src/web-ui/src/flow_chat/services/storeSync.test.ts
+++ b/src/web-ui/src/flow_chat/services/storeSync.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '../types/flow-chat';
+
+const syncMocks = vi.hoisted(() => {
+  const flowState = {
+    sessions: new Map<string, Session>(),
+    activeSessionId: null as string | null,
+  };
+  const modernState = {
+    activeSession: null as Session | null,
+    setActiveSession: vi.fn((session: Session | null) => {
+      modernState.activeSession = session;
+    }),
+    clear: vi.fn(() => {
+      modernState.activeSession = null;
+    }),
+  };
+
+  return {
+    flowState,
+    modernState,
+  };
+});
+
+vi.mock('../store/FlowChatStore', () => ({
+  flowChatStore: {
+    getState: () => syncMocks.flowState,
+  },
+}));
+
+vi.mock('../store/modernFlowChatStore', () => ({
+  useModernFlowChatStore: {
+    getState: () => syncMocks.modernState,
+  },
+}));
+
+import { syncSessionToModernStore } from './storeSync';
+
+function createSession(overrides: Partial<Session> = {}): Session {
+  return {
+    sessionId: 'history-1',
+    title: 'Saved session',
+    dialogTurns: [],
+    status: 'idle',
+    config: { agentType: 'agentic' },
+    createdAt: 1,
+    lastActiveAt: 1,
+    error: null,
+    isHistorical: true,
+    historyState: 'metadata-only',
+    todos: [],
+    mode: 'agentic',
+    workspacePath: 'D:/workspace/BitFun',
+    sessionKind: 'normal',
+    ...overrides,
+  };
+}
+
+describe('storeSync history session state', () => {
+  afterEach(() => {
+    syncMocks.flowState.sessions = new Map();
+    syncMocks.flowState.activeSessionId = null;
+    syncMocks.modernState.activeSession = null;
+    syncMocks.modernState.setActiveSession.mockClear();
+    syncMocks.modernState.clear.mockClear();
+  });
+
+  it('preserves historyState when syncing historical sessions to the modern store', () => {
+    const session = createSession();
+    syncMocks.flowState.sessions = new Map([[session.sessionId, session]]);
+    syncMocks.flowState.activeSessionId = session.sessionId;
+
+    syncSessionToModernStore(session.sessionId);
+
+    expect(syncMocks.modernState.setActiveSession).toHaveBeenCalledWith(session);
+    expect(syncMocks.modernState.activeSession).toBe(session);
+    expect(syncMocks.modernState.activeSession?.historyState).toBe('metadata-only');
+  });
+});

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -2,6 +2,45 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { flowChatStore } from './FlowChatStore';
 import type { FlowChatState, Session } from '../types/flow-chat';
 
+const apiMocks = vi.hoisted(() => ({
+  listSessions: vi.fn(),
+  loadSessionTurns: vi.fn(),
+  saveSessionTurn: vi.fn(),
+  restoreSession: vi.fn(),
+}));
+
+const configManagerMock = vi.hoisted(() => ({
+  getConfig: vi.fn(async (path: string) => {
+    if (path === 'ai.models') return [];
+    if (path === 'ai.default_models') return {};
+    return undefined;
+  }),
+}));
+
+const stateMachineManagerMock = vi.hoisted(() => ({
+  getOrCreate: vi.fn(),
+  reset: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/api', () => ({
+  sessionAPI: {
+    listSessions: apiMocks.listSessions,
+    loadSessionTurns: apiMocks.loadSessionTurns,
+    saveSessionTurn: apiMocks.saveSessionTurn,
+  },
+  agentAPI: {
+    restoreSession: apiMocks.restoreSession,
+  },
+}));
+
+vi.mock('@/infrastructure/config/services/ConfigManager', () => ({
+  configManager: configManagerMock,
+}));
+
+vi.mock('../state-machine', () => ({
+  stateMachineManager: stateMachineManagerMock,
+}));
+
 const resetStore = () => {
   flowChatStore.setState((): FlowChatState => ({
     sessions: new Map(),
@@ -27,6 +66,22 @@ const createSession = (overrides: Partial<Session> = {}): Session => ({
   isTransient: false,
   ...overrides,
 });
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe('FlowChatStore metadata persistence callbacks', () => {
   afterEach(() => {
@@ -164,5 +219,137 @@ describe('FlowChatStore local usage reports', () => {
       'local-usage-usage-1',
       'local-usage-usage-2',
     ]);
+  });
+});
+
+describe('FlowChatStore historical session hydration state', () => {
+  afterEach(() => {
+    resetStore();
+    vi.clearAllMocks();
+  });
+
+  it('loads persisted metadata as metadata-only historical sessions', async () => {
+    apiMocks.listSessions.mockResolvedValueOnce([
+      {
+        sessionId: 'history-1',
+        title: 'Saved session',
+        agentType: 'agentic',
+        modelName: 'auto',
+        createdAt: 10,
+        lastActiveAt: 20,
+      },
+    ]);
+
+    await flowChatStore.initializeFromDisk('D:/workspace/BitFun');
+
+    const session = flowChatStore.getState().sessions.get('history-1');
+    expect(session).toMatchObject({
+      sessionId: 'history-1',
+      isHistorical: true,
+      historyState: 'metadata-only',
+      dialogTurns: [],
+    });
+  });
+
+  it('marks historical sessions hydrating while turns are loading and ready after completion', async () => {
+    const turns = createDeferred<any[]>();
+    apiMocks.restoreSession.mockResolvedValueOnce(undefined);
+    apiMocks.loadSessionTurns.mockReturnValueOnce(turns.promise);
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    const load = flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
+    await flushAsyncWork();
+
+    expect(flowChatStore.getState().sessions.get('history-1')?.historyState).toBe('hydrating');
+
+    turns.resolve([]);
+    await load;
+
+    expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
+      isHistorical: false,
+      historyState: 'ready',
+      dialogTurns: [],
+    });
+  });
+
+  it('marks historical sessions failed when hydrate fails', async () => {
+    apiMocks.restoreSession.mockResolvedValueOnce(undefined);
+    apiMocks.loadSessionTurns.mockRejectedValueOnce(new Error('turn load failed'));
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    await expect(
+      flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun')
+    ).rejects.toThrow('turn load failed');
+
+    expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
+      isHistorical: true,
+      historyState: 'failed',
+    });
+  });
+
+  it('does not change the active session when an older hydrate completes', async () => {
+    apiMocks.restoreSession.mockResolvedValueOnce(undefined);
+    apiMocks.loadSessionTurns.mockResolvedValueOnce([]);
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+        ['history-2', createSession({
+          sessionId: 'history-2',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-2',
+    }));
+
+    await flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
+
+    expect(flowChatStore.getState().activeSessionId).toBe('history-2');
+    expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
+      isHistorical: false,
+      historyState: 'ready',
+    });
+  });
+
+  it('does not restore ACP historical sessions through the normal backend path', async () => {
+    apiMocks.loadSessionTurns.mockResolvedValueOnce([]);
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['acp-1', createSession({
+          sessionId: 'acp-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+          mode: 'acp:test',
+          config: { agentType: 'acp:test' },
+        })],
+      ]),
+      activeSessionId: 'acp-1',
+    }));
+
+    await flowChatStore.loadSessionHistory('acp-1', 'D:/workspace/BitFun');
+
+    expect(apiMocks.restoreSession).not.toHaveBeenCalled();
   });
 });

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -14,8 +14,11 @@ import {
   ImageAnalysisResult,
   AnyFlowItem,
   SessionConfig,
+  SessionHistoryState,
 } from '../types/flow-chat';
 import { createLogger } from '@/shared/utils/logger';
+import { isRemoteTraceContext, startupTrace } from '@/shared/utils/startupTrace';
+import { elapsedMs, nowMs } from '@/shared/utils/timing';
 import { i18nService } from '@/infrastructure/i18n/core/I18nService';
 import type { LocalCommandMetadata, SessionKind } from '@/shared/types/session-history';
 import {
@@ -249,6 +252,7 @@ export class FlowChatStore {
         lastActiveAt: Date.now(),
         lastFinishedAt: undefined,
         error: null,
+        historyState: 'new',
         maxContextTokens: maxContextTokens || 128128,
         mode: mode || 'agentic',
         workspacePath,
@@ -320,6 +324,7 @@ export class FlowChatStore {
         maxContextTokens: 128128,
         mode: mode || 'agentic',
         isHistorical: false,
+        historyState: 'new',
         workspacePath,
         remoteConnectionId,
         remoteSshHost,
@@ -1731,9 +1736,15 @@ export class FlowChatStore {
     remoteConnectionId?: string,
     remoteSshHost?: string
   ): Promise<void> {
+    const traceStartedAt = nowMs();
+    const remote = isRemoteTraceContext(remoteConnectionId, remoteSshHost);
+    let sessionCount = 0;
+    startupTrace.markPhase('session_metadata_list_start', { remote });
     try {
       const { sessionAPI } = await import('@/infrastructure/api');
       const sessions = await sessionAPI.listSessions(workspacePath, remoteConnectionId, remoteSshHost);
+      sessionCount = sessions.length;
+      startupTrace.markPhase('session_metadata_list_loaded', { remote, sessionCount });
 
       const { stateMachineManager } = await import('../state-machine');
       sessions.forEach(metadata => {
@@ -1811,6 +1822,7 @@ export class FlowChatStore {
             lastFinishedAt,
             error: null,
             isHistorical: true,
+            historyState: 'metadata-only',
             todos: (metadata as any).todos || [],
             maxContextTokens,
             mode: validatedAgentType,
@@ -1839,9 +1851,39 @@ export class FlowChatStore {
       };
       
       await Promise.all(sessions.map(processSession));
+      startupTrace.markPhase('session_metadata_list_end', {
+        remote,
+        sessionCount,
+        durationMs: elapsedMs(traceStartedAt),
+      });
     } catch (error) {
+      startupTrace.markPhase('session_metadata_list_failed', {
+        remote,
+        sessionCount,
+        durationMs: elapsedMs(traceStartedAt),
+      });
       log.error('Failed to load persisted sessions', error);
     }
+  }
+
+  public setSessionHistoryState(sessionId: string, historyState: SessionHistoryState): void {
+    this.setState(prev => {
+      const session = prev.sessions.get(sessionId);
+      if (!session || session.historyState === historyState) {
+        return prev;
+      }
+
+      const newSessions = new Map(prev.sessions);
+      newSessions.set(sessionId, {
+        ...session,
+        historyState,
+      });
+
+      return {
+        ...prev,
+        sessions: newSessions,
+      };
+    });
   }
 
   /**
@@ -1854,6 +1896,10 @@ export class FlowChatStore {
     remoteConnectionId?: string,
     remoteSshHost?: string
   ): Promise<void> {
+    const traceStartedAt = nowMs();
+    const remote = isRemoteTraceContext(remoteConnectionId, remoteSshHost);
+    startupTrace.markPhase('historical_session_hydrate_start', { remote });
+    this.setSessionHistoryState(sessionId, 'hydrating');
     try {
       const { stateMachineManager } = await import('../state-machine');
       stateMachineManager.getOrCreate(sessionId);
@@ -1878,6 +1924,10 @@ export class FlowChatStore {
         remoteConnectionId,
         remoteSshHost
       );
+      startupTrace.markPhase('historical_session_turns_loaded', {
+        remote,
+        turnCount: Array.isArray(turns) ? turns.length : 0,
+      });
       
       const dialogTurns = this.convertToDialogTurns(turns);
       
@@ -1889,6 +1939,8 @@ export class FlowChatStore {
           ...session,
           dialogTurns,
           isHistorical: false,
+          historyState: 'ready' as const,
+          error: null,
         };
         
         const newSessions = new Map(prev.sessions);
@@ -1903,7 +1955,32 @@ export class FlowChatStore {
       // Reset state machine to IDLE after loading history
       // This handles the case where restoreSession triggered events that left the state machine in PROCESSING
       stateMachineManager.reset(sessionId);
+      startupTrace.markPhase('historical_session_hydrate_end', {
+        remote,
+        turnCount: dialogTurns.length,
+        durationMs: elapsedMs(traceStartedAt),
+      });
     } catch (error) {
+      this.setState(prev => {
+        const session = prev.sessions.get(sessionId);
+        if (!session) return prev;
+
+        const newSessions = new Map(prev.sessions);
+        newSessions.set(sessionId, {
+          ...session,
+          isHistorical: true,
+          historyState: 'failed',
+        });
+
+        return {
+          ...prev,
+          sessions: newSessions,
+        };
+      });
+      startupTrace.markPhase('historical_session_hydrate_failed', {
+        remote,
+        durationMs: elapsedMs(traceStartedAt),
+      });
       log.error('Failed to load session history', { sessionId, error });
       throw error;
     }

--- a/src/web-ui/src/flow_chat/types/flow-chat.ts
+++ b/src/web-ui/src/flow_chat/types/flow-chat.ts
@@ -232,6 +232,13 @@ export interface TodoItem {
   status: 'pending' | 'in_progress' | 'completed';
 }
 
+export type SessionHistoryState =
+  | 'new'
+  | 'metadata-only'
+  | 'hydrating'
+  | 'ready'
+  | 'failed';
+
 // Session state.
 export interface Session {
   sessionId: string;
@@ -263,6 +270,16 @@ export interface Session {
   
   // Historical sessions are persisted and require lazy loading.
   isHistorical?: boolean;
+
+  /**
+   * Lazy history lifecycle for persisted sessions:
+   * - 'new': an empty local session that should show the normal welcome state.
+   * - 'metadata-only': persisted metadata is visible, but turns have not hydrated yet.
+   * - 'hydrating': history is currently being restored / loaded.
+   * - 'ready': turns are available, or the session no longer needs lazy history.
+   * - 'failed': hydrate failed and the UI should offer retry instead of showing a new session.
+   */
+  historyState?: SessionHistoryState;
   
   todos?: TodoItem[];
   

--- a/src/web-ui/src/infrastructure/api/service-api/ApiClient.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ApiClient.ts
@@ -15,6 +15,7 @@ import {
 } from './types';
 import { createLogger } from '@/shared/utils/logger';
 import { elapsedMs, nowMs } from '@/shared/utils/timing';
+import { estimateJsonBytes, isRemoteTraceRequest, startupTrace } from '@/shared/utils/startupTrace';
 import { sanitizeErrorForLog, sanitizeLogValue, sanitizeTextForLog } from '../logSanitizer';
 
 const log = createLogger('ApiClient');
@@ -129,6 +130,19 @@ export class ApiClient implements IApiClient {
 
   private async executeRequest<T>(request: ApiRequest): Promise<T> {
     const startedAt = nowMs();
+    const tracePayloadStartedAt = nowMs();
+    const tracePayload = request.type === 'tauri'
+      ? (request.config as TauriCommandConfig).args
+      : {
+          params: (request.config as HttpRequestConfig).params,
+          data: (request.config as HttpRequestConfig).data,
+        };
+    const traceCommand = request.type === 'tauri'
+      ? (request.config as TauriCommandConfig).command
+      : `${(request.config as HttpRequestConfig).method} ${(request.config as HttpRequestConfig).url}`;
+    const requestBytes = estimateJsonBytes(tracePayload);
+    const remote = isRemoteTraceRequest(tracePayload);
+    const requestPayloadEstimateDurationMs = elapsedMs(tracePayloadStartedAt);
     
     this.updateStats({ totalRequests: this.stats.totalRequests + 1 });
 
@@ -157,6 +171,19 @@ export class ApiClient implements IApiClient {
 
         
         const durationMs = elapsedMs(startedAt);
+        const responseEstimateStartedAt = nowMs();
+        const responseBytes = estimateJsonBytes(response.data);
+        const responseEstimateDurationMs = elapsedMs(responseEstimateStartedAt);
+        startupTrace.recordApiCall({
+          type: request.type,
+          command: traceCommand,
+          durationMs,
+          outcome: 'success',
+          requestBytes,
+          responseBytes,
+          payloadEstimateDurationMs: requestPayloadEstimateDurationMs + responseEstimateDurationMs,
+          remote,
+        });
         this.recordResponseTime(durationMs);
         this.updateStats({ successfulRequests: this.stats.successfulRequests + 1 });
 
@@ -176,6 +203,15 @@ export class ApiClient implements IApiClient {
       }
     } catch (error) {
       this.updateStats({ failedRequests: this.stats.failedRequests + 1 });
+      startupTrace.recordApiCall({
+        type: request.type,
+        command: traceCommand,
+        durationMs: elapsedMs(startedAt),
+        outcome: 'failure',
+        requestBytes,
+        payloadEstimateDurationMs: requestPayloadEstimateDurationMs,
+        remote,
+      });
 
       
       if (request.retryCount < (request.config.retries || this.config.retries)) {

--- a/src/web-ui/src/infrastructure/config/services/ConfigManager.test.ts
+++ b/src/web-ui/src/infrastructure/config/services/ConfigManager.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { configManager } from './ConfigManager';
+
+const configApiMocks = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  setConfig: vi.fn(),
+  resetConfig: vi.fn(),
+  exportConfig: vi.fn(),
+  importConfig: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/api', () => ({
+  configAPI: configApiMocks,
+}));
+
+vi.mock('@/infrastructure/api/service-api/ConfigAPI', () => ({
+  configAPI: configApiMocks,
+}));
+
+vi.mock('@/infrastructure/i18n', () => ({
+  i18nService: {
+    t: (key: string) => key,
+  },
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('ConfigManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configManager.clearCache();
+  });
+
+  it('deduplicates concurrent reads for the same config path', async () => {
+    const deferred = createDeferred<string>();
+    configApiMocks.getConfig.mockReturnValueOnce(deferred.promise);
+
+    const first = configManager.getConfig<string>('app.logging.level');
+    const second = configManager.getConfig<string>('app.logging.level');
+
+    expect(configApiMocks.getConfig).toHaveBeenCalledTimes(1);
+    expect(configApiMocks.getConfig).toHaveBeenCalledWith('app.logging.level');
+
+    deferred.resolve('debug');
+
+    await expect(Promise.all([first, second])).resolves.toEqual(['debug', 'debug']);
+    expect(configApiMocks.getConfig).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/infrastructure/config/services/ConfigManager.ts
+++ b/src/web-ui/src/infrastructure/config/services/ConfigManager.ts
@@ -5,7 +5,7 @@ import {
   ConfigValidationResult,
   ConfigExport,
 } from '../types';
-import { configAPI } from '@/infrastructure/api';
+import { configAPI } from '@/infrastructure/api/service-api/ConfigAPI';
 import { i18nService } from '@/infrastructure/i18n';
 import { createLogger } from '@/shared/utils/logger';
 import { extractProviderSegmentFromBaseUrl, matchProviderCatalogItemByBaseUrl } from './providerCatalog';
@@ -15,6 +15,7 @@ const log = createLogger('ConfigManager');
 class ConfigManagerImpl implements IConfigManager {
   
   private configCache: Map<string, any> = new Map();
+  private inFlightReads: Map<string, Promise<unknown>> = new Map();
   private listeners: Set<(path: string, oldValue: any, newValue: any) => void> = new Set();
   private pathListeners: Map<string, Set<() => void>> = new Map();
 
@@ -67,6 +68,23 @@ class ConfigManagerImpl implements IConfigManager {
 
   
 
+  private getReadKey(path?: string): string {
+    return path ?? '<root>';
+  }
+
+  private async readConfig<T = any>(path?: string): Promise<T> {
+    const config = await configAPI.getConfig(path);
+    const resolvedConfig = path === 'ai.models'
+      ? await this.migrateLegacyAiModelsIfNeeded(config)
+      : config;
+
+    if (path) {
+      this.configCache.set(path, resolvedConfig);
+    }
+
+    return resolvedConfig as T;
+  }
+
   async getConfig<T = any>(path?: string): Promise<T> {
     try {
       
@@ -74,18 +92,21 @@ class ConfigManagerImpl implements IConfigManager {
         return this.configCache.get(path);
       }
 
-      
-      const config = await configAPI.getConfig(path);
-      const resolvedConfig = path === 'ai.models'
-        ? await this.migrateLegacyAiModelsIfNeeded(config)
-        : config;
-
-      
-      if (path) {
-        this.configCache.set(path, resolvedConfig);
+      const readKey = this.getReadKey(path);
+      const existingRead = this.inFlightReads.get(readKey);
+      if (existingRead) {
+        return (await existingRead) as T;
       }
-      
-      return resolvedConfig as T;
+
+      const readPromise = this.readConfig<T>(path);
+      this.inFlightReads.set(readKey, readPromise);
+      try {
+        return await readPromise;
+      } finally {
+        if (this.inFlightReads.get(readKey) === readPromise) {
+          this.inFlightReads.delete(readKey);
+        }
+      }
     } catch (error) {
       log.error('Failed to get config', { path, error });
       // Return defaults to avoid breaking the UI.
@@ -108,6 +129,7 @@ class ConfigManagerImpl implements IConfigManager {
   async setConfig<T = any>(path: string, value: T): Promise<void> {
     try {
       const oldValue = this.configCache.get(path);
+      this.inFlightReads.delete(this.getReadKey(path));
       
       
       await configAPI.setConfig(path, value);
@@ -130,8 +152,10 @@ class ConfigManagerImpl implements IConfigManager {
       
       if (path) {
         this.configCache.delete(path);
+        this.inFlightReads.delete(this.getReadKey(path));
       } else {
         this.configCache.clear();
+        this.inFlightReads.clear();
       }
     } catch (error) {
       log.error('Failed to reset config', { path, error });
@@ -189,6 +213,7 @@ class ConfigManagerImpl implements IConfigManager {
   async refreshCache(): Promise<void> {
     try {
       this.configCache.clear();
+      this.inFlightReads.clear();
     } catch (error) {
       log.error('Failed to refresh cache', error);
     }
@@ -196,6 +221,7 @@ class ConfigManagerImpl implements IConfigManager {
 
   clearCache(): void {
     this.configCache.clear();
+    this.inFlightReads.clear();
   }
 
   
@@ -259,6 +285,7 @@ class ConfigManagerImpl implements IConfigManager {
   async reload(): Promise<void> {
     try {
       this.configCache.clear();
+      this.inFlightReads.clear();
       
       await this.getConfig('ai.models');
       await this.getConfig('ai.agent_models');

--- a/src/web-ui/src/infrastructure/config/services/FrontendLogLevelSync.ts
+++ b/src/web-ui/src/infrastructure/config/services/FrontendLogLevelSync.ts
@@ -1,4 +1,4 @@
-import { configAPI } from '@/infrastructure/api';
+import { configAPI } from '@/infrastructure/api/service-api/ConfigAPI';
 import {
   LogLevel,
   createLogger,
@@ -6,13 +6,13 @@ import {
   setIncludeSensitiveDiagnostics,
 } from '@/shared/utils/logger';
 import type { BackendLogLevel } from '../types';
-import { configManager } from './ConfigManager';
 
 const log = createLogger('FrontendLogLevelSync');
 const LOGGING_LEVEL_PATH = 'app.logging.level';
 const LOGGING_INCLUDE_SENSITIVE_PATH = 'app.logging.include_sensitive_diagnostics';
 
-let initialized = false;
+let initialSettingsLoaded = false;
+let configWatcherInstalled = false;
 
 function toFrontendLogLevel(level: string | null | undefined): LogLevel | null {
   switch (level?.trim().toLowerCase()) {
@@ -74,7 +74,7 @@ function applyFrontendLogLevel(level: string | null | undefined, source: string)
 
 async function resolveInitialLogLevel(): Promise<string | undefined> {
   const [savedLevelResult, runtimeInfoResult] = await Promise.allSettled([
-    configManager.getConfig<BackendLogLevel>(LOGGING_LEVEL_PATH),
+    configAPI.getConfig(LOGGING_LEVEL_PATH) as Promise<BackendLogLevel>,
     configAPI.getRuntimeLoggingInfo(),
   ]);
 
@@ -93,27 +93,16 @@ async function resolveInitialLogLevel(): Promise<string | undefined> {
 }
 
 async function resolveInitialSensitiveDiagnosticsPreference(): Promise<boolean> {
-  const value = await configManager.getConfig<boolean>(LOGGING_INCLUDE_SENSITIVE_PATH);
+  const value = await configAPI.getConfig(LOGGING_INCLUDE_SENSITIVE_PATH) as boolean | undefined;
   return value ?? true;
 }
 
 export async function initializeFrontendLogLevelSync(): Promise<void> {
-  if (initialized) {
+  if (initialSettingsLoaded) {
     return;
   }
 
-  initialized = true;
-
-  configManager.onConfigChange((path, _oldValue, newValue) => {
-    if (path === LOGGING_LEVEL_PATH) {
-      applyFrontendLogLevel(typeof newValue === 'string' ? newValue : undefined, 'config_change');
-      return;
-    }
-
-    if (path === LOGGING_INCLUDE_SENSITIVE_PATH) {
-      setIncludeSensitiveDiagnostics(typeof newValue === 'boolean' ? newValue : true);
-    }
-  });
+  initialSettingsLoaded = true;
 
   try {
     const [initialLevel, includeSensitiveDiagnostics] = await Promise.all([
@@ -124,5 +113,30 @@ export async function initializeFrontendLogLevelSync(): Promise<void> {
     setIncludeSensitiveDiagnostics(includeSensitiveDiagnostics);
   } catch (error) {
     log.error('Failed to initialize frontend log level sync', error);
+  }
+}
+
+export async function installFrontendLogLevelConfigWatcher(): Promise<void> {
+  if (configWatcherInstalled) {
+    return;
+  }
+
+  configWatcherInstalled = true;
+
+  try {
+    const { configManager } = await import('./ConfigManager');
+    configManager.onConfigChange((path, _oldValue, newValue) => {
+      if (path === LOGGING_LEVEL_PATH) {
+        applyFrontendLogLevel(typeof newValue === 'string' ? newValue : undefined, 'config_change');
+        return;
+      }
+
+      if (path === LOGGING_INCLUDE_SENSITIVE_PATH) {
+        setIncludeSensitiveDiagnostics(typeof newValue === 'boolean' ? newValue : true);
+      }
+    });
+  } catch (error) {
+    configWatcherInstalled = false;
+    log.error('Failed to install frontend log level config watcher', error);
   }
 }

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -39,6 +39,13 @@
   "runtimeStatus": {
     "waitingForModelResponse": "Waiting for model response..."
   },
+  "historyState": {
+    "loadingTitle": "Loading saved session",
+    "loadingDescription": "Preparing the conversation history.",
+    "failedTitle": "Session history did not load",
+    "failedDescription": "Retry loading the saved conversation.",
+    "retry": "Retry"
+  },
   "usage": {
     "title": "Session Usage",
     "unavailable": "Unavailable",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -39,6 +39,13 @@
   "runtimeStatus": {
     "waitingForModelResponse": "等待模型响应..."
   },
+  "historyState": {
+    "loadingTitle": "正在加载历史会话",
+    "loadingDescription": "正在准备该会话的历史内容。",
+    "failedTitle": "历史会话加载失败",
+    "failedDescription": "可以重新加载已保存的会话内容。",
+    "retry": "重试"
+  },
   "usage": {
     "title": "会话用量",
     "unavailable": "不可用",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -39,6 +39,13 @@
   "runtimeStatus": {
     "waitingForModelResponse": "等待模型回應..."
   },
+  "historyState": {
+    "loadingTitle": "正在載入歷史會話",
+    "loadingDescription": "正在準備該會話的歷史內容。",
+    "failedTitle": "歷史會話載入失敗",
+    "failedDescription": "可以重新載入已儲存的會話內容。",
+    "retry": "重試"
+  },
   "usage": {
     "title": "工作階段用量",
     "unavailable": "不可用",

--- a/src/web-ui/src/main.tsx
+++ b/src/web-ui/src/main.tsx
@@ -18,6 +18,7 @@ import { loader } from '@monaco-editor/react';
 import { getMonacoPath, getMonacoWorkerPath, logMonacoResourceCheck } from './tools/editor/utils/monacoPathHelper';
 import { bootstrapLogger, createLogger, initLogger } from './shared/utils/logger';
 import { elapsedMs, logElapsed, measureAsyncAndLog, nowMs } from './shared/utils/timing';
+import { startupTrace } from './shared/utils/startupTrace';
 import {
   buildReactCrashLogPayload,
   isMinifiedReactErrorMessage,
@@ -27,6 +28,7 @@ import {
 bootstrapLogger();
 
 const log = createLogger('App');
+startupTrace.markPhase('first_script_eval');
 
 /** Dedupe only for white-screen heuristic (empty #root), not for Error Boundary logs. */
 const WHITE_SCREEN_LOGGED_FLAG = '__bitfun_white_screen_crash_logged__';
@@ -225,6 +227,7 @@ const DEFAULT_WORKER = 'base/worker/workerMain.js';
 /** Logger, theme, and minimal deps — must finish before first React paint (F5 / webview reload does not re-run Tauri init script). */
 async function initializeBeforeRender(): Promise<void> {
   const phaseStartedAt = nowMs();
+  startupTrace.markPhase('before_render_start');
   await measureAsyncAndLog(log, 'Startup step completed', () => initLogger(), {
     data: { step: 'initLogger' },
   });
@@ -240,20 +243,6 @@ async function initializeBeforeRender(): Promise<void> {
   log.info('Initializing BitFun');
 
   await measureAsyncAndLog(log, 'Startup step completed', async () => {
-    const { registerDefaultContextTypes } = await import('./shared/context-system/core/registerDefaultTypes');
-    registerDefaultContextTypes();
-  }, {
-    data: { step: 'registerDefaultContextTypes' },
-  });
-
-  await measureAsyncAndLog(log, 'Startup step completed', async () => {
-    const { initRecommendationProviders } = await import('./flow_chat/components/smart-recommendations');
-    initRecommendationProviders();
-  }, {
-    data: { step: 'initRecommendationProviders' },
-  });
-
-  await measureAsyncAndLog(log, 'Startup step completed', async () => {
     const { themeService } = await import('./infrastructure/theme');
     await themeService.initialize();
   }, {
@@ -263,20 +252,36 @@ async function initializeBeforeRender(): Promise<void> {
   logElapsed(log, 'Startup phase completed', phaseStartedAt, {
     data: { phase: 'initializeBeforeRender' },
   });
+  startupTrace.markPhase('before_render_end', {
+    durationMs: elapsedMs(phaseStartedAt),
+  });
 }
 
 /** Rest of startup runs after the shell is visible so refresh latency stays reasonable. */
 async function initializeAfterRender(): Promise<void> {
   const phaseStartedAt = nowMs();
+  startupTrace.markPhase('after_render_start');
   const { fontPreferenceService } = await import('./infrastructure/font-preference');
   await fontPreferenceService.initialize();
   log.info('Font preference initialized at startup');
 
-  const { configManager } = await import('./infrastructure/config');
+  const { configManager } = await import('./infrastructure/config/services/ConfigManager');
   await configManager.getConfig('editor');
   log.info('Editor configuration preloaded');
 
   const initResults = await Promise.allSettled([
+    (async () => {
+      const { installFrontendLogLevelConfigWatcher } = await import('./infrastructure/config/services/FrontendLogLevelSync');
+      await installFrontendLogLevelConfigWatcher();
+    })(),
+    (async () => {
+      const { registerDefaultContextTypes } = await import('./shared/context-system/core/registerDefaultTypes');
+      registerDefaultContextTypes();
+    })(),
+    (async () => {
+      const { initRecommendationProviders } = await import('./flow_chat/components/smart-recommendations');
+      initRecommendationProviders();
+    })(),
     initializeAllTools(),
     (async () => {
       initContextMenuSystem({
@@ -299,7 +304,14 @@ async function initializeAfterRender(): Promise<void> {
   ]);
 
   initResults.forEach((result, index) => {
-    const names = ['Tools', 'ContextMenu', 'Editors'];
+    const names = [
+      'LogLevelConfigWatcher',
+      'DefaultContextTypes',
+      'RecommendationProviders',
+      'Tools',
+      'ContextMenu',
+      'Editors',
+    ];
     if (result.status === 'rejected') {
       log.warn('Initialization failed', { module: names[index], error: result.reason });
     }
@@ -309,10 +321,14 @@ async function initializeAfterRender(): Promise<void> {
   logElapsed(log, 'Startup phase completed', phaseStartedAt, {
     data: { phase: 'initializeAfterRender' },
   });
+  startupTrace.markPhase('after_render_end', {
+    durationMs: elapsedMs(phaseStartedAt),
+  });
 }
 
 async function startApplication(): Promise<void> {
   const appStartedAt = nowMs();
+  startupTrace.markPhase('start_application_start');
   try {
     await initializeBeforeRender();
   } catch (error) {
@@ -345,6 +361,10 @@ async function startApplication(): Promise<void> {
         sinceStartupMs: elapsedMs(appStartedAt),
       },
     });
+    startupTrace.markPhase('agent_companion_render_scheduled', {
+      sinceStartupMs: elapsedMs(appStartedAt),
+    });
+    startupTrace.flushSummary('agent_companion_render_scheduled');
     return;
   }
 
@@ -363,6 +383,9 @@ async function startApplication(): Promise<void> {
       sinceStartupMs: elapsedMs(appStartedAt),
     },
   });
+  startupTrace.markPhase('react_render_scheduled', {
+    sinceStartupMs: elapsedMs(appStartedAt),
+  });
 
   try {
     await initializeAfterRender();
@@ -373,6 +396,10 @@ async function startApplication(): Promise<void> {
   logElapsed(log, 'Startup phase completed', appStartedAt, {
     data: { phase: 'startApplication' },
   });
+  startupTrace.markPhase('start_application_end', {
+    durationMs: elapsedMs(appStartedAt),
+  });
+  startupTrace.flushSummary('start_application_completed');
 }
 
 void startApplication();

--- a/src/web-ui/src/shared/utils/startupTrace.test.ts
+++ b/src/web-ui/src/shared/utils/startupTrace.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createStartupTrace,
+  estimateJsonBytes,
+  isRemoteTraceContext,
+  isRemoteTraceRequest,
+} from './startupTrace';
+import type { LoggerLike } from './timing';
+
+function createTestLogger(): LoggerLike & {
+  debug: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+} {
+  return {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe('startupTrace', () => {
+  it('records startup phases without exposing sensitive fields', () => {
+    const logger = createTestLogger();
+    const trace = createStartupTrace({
+      logger,
+      traceId: 'trace-test',
+      now: () => 100,
+    });
+
+    trace.markPhase('before_render_start', {
+      apiKey: 'secret',
+      command: 'get_config',
+      request: { nested: 'payload' },
+      remoteConnectionId: 'ssh-user@example.com',
+      sshHost: 'example.internal',
+      remote: true,
+    });
+
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    const [, payload] = logger.debug.mock.calls[0];
+    expect(payload).toMatchObject({
+      traceId: 'trace-test',
+      phase: 'before_render_start',
+      command: 'get_config',
+      remote: true,
+    });
+    expect(payload).not.toHaveProperty('apiKey');
+    expect(payload).not.toHaveProperty('request');
+    expect(payload).not.toHaveProperty('remoteConnectionId');
+    expect(payload).not.toHaveProperty('sshHost');
+  });
+
+  it('aggregates API calls by command and remote status', () => {
+    const logger = createTestLogger();
+    const trace = createStartupTrace({
+      logger,
+      traceId: 'trace-test',
+      now: () => 100,
+    });
+
+    trace.recordApiCall({
+      type: 'tauri',
+      command: 'list_persisted_sessions',
+      durationMs: 12.4,
+      requestBytes: 100,
+      responseBytes: 500,
+      remote: true,
+      cacheOutcome: 'miss',
+    });
+    trace.recordApiCall({
+      type: 'tauri',
+      command: 'list_persisted_sessions',
+      durationMs: 7.6,
+      requestBytes: 80,
+      responseBytes: 300,
+      remote: true,
+      cacheOutcome: 'hit',
+    });
+    trace.recordApiCall({
+      type: 'tauri',
+      command: 'get_config',
+      durationMs: 5,
+      requestBytes: 40,
+      responseBytes: 60,
+      remote: false,
+    });
+    trace.recordApiCall({
+      type: 'tauri',
+      command: 'git_get_status',
+      durationMs: 8,
+      requestBytes: 20,
+      remote: false,
+      outcome: 'failure',
+    });
+
+    trace.flushSummary('test');
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const [, payload] = logger.info.mock.calls[0];
+    expect(payload).toMatchObject({
+      traceId: 'trace-test',
+      reason: 'test',
+      phases: {
+        events: [],
+      },
+      api: {
+        totalCount: 4,
+        successCount: 3,
+        failureCount: 1,
+        cacheHitCount: 1,
+        cacheMissCount: 1,
+        cacheUnknownCount: 2,
+        remoteCount: 2,
+        requestBytes: 240,
+        responseBytes: 860,
+      },
+    });
+    expect(payload.api.byCommand).toEqual([
+      {
+        command: 'list_persisted_sessions',
+        count: 2,
+        successCount: 2,
+        failureCount: 0,
+        cacheHitCount: 1,
+        cacheMissCount: 1,
+        cacheUnknownCount: 0,
+        remoteCount: 2,
+        totalDurationMs: 20,
+        maxDurationMs: 12.4,
+        requestBytes: 180,
+        responseBytes: 800,
+      },
+      {
+        command: 'git_get_status',
+        count: 1,
+        successCount: 0,
+        failureCount: 1,
+        cacheHitCount: 0,
+        cacheMissCount: 0,
+        cacheUnknownCount: 1,
+        remoteCount: 0,
+        totalDurationMs: 8,
+        maxDurationMs: 8,
+        requestBytes: 20,
+        responseBytes: 0,
+      },
+      {
+        command: 'get_config',
+        count: 1,
+        successCount: 1,
+        failureCount: 0,
+        cacheHitCount: 0,
+        cacheMissCount: 0,
+        cacheUnknownCount: 1,
+        remoteCount: 0,
+        totalDurationMs: 5,
+        maxDurationMs: 5,
+        requestBytes: 40,
+        responseBytes: 60,
+      },
+    ]);
+  });
+
+  it('flushes bounded phase records so early events survive logger startup timing', () => {
+    const logger = createTestLogger();
+    let now = 10;
+    const trace = createStartupTrace({
+      logger,
+      traceId: 'trace-test',
+      now: () => now,
+      maxPhaseEvents: 2,
+    });
+
+    trace.markPhase('first_script_eval', { remote: false });
+    now = 20;
+    trace.markPhase('before_render_start');
+    now = 30;
+    trace.markPhase('ignored_after_limit');
+    trace.flushSummary('test');
+
+    const [, payload] = logger.info.mock.calls[0];
+    expect(payload.phases).toMatchObject({
+      count: 2,
+      events: [
+        {
+          traceId: 'trace-test',
+          phase: 'first_script_eval',
+          atMs: 10,
+          remote: false,
+        },
+        {
+          traceId: 'trace-test',
+          phase: 'before_render_start',
+          atMs: 20,
+        },
+      ],
+    });
+  });
+
+  it('does not log when disabled', () => {
+    const logger = createTestLogger();
+    const trace = createStartupTrace({
+      enabled: false,
+      logger,
+      traceId: 'trace-test',
+      now: () => 100,
+    });
+
+    trace.markPhase('first_script_eval');
+    trace.recordApiCall({
+      type: 'tauri',
+      command: 'get_config',
+      durationMs: 1,
+      remote: false,
+    });
+    trace.flushSummary('disabled');
+
+    expect(logger.debug).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('uses the desktop injected trace id when available', () => {
+    const previousTraceId = (globalThis as { __BITFUN_STARTUP_TRACE_ID__?: string })
+      .__BITFUN_STARTUP_TRACE_ID__;
+    (globalThis as { __BITFUN_STARTUP_TRACE_ID__?: string }).__BITFUN_STARTUP_TRACE_ID__ =
+      'desktop-123';
+
+    try {
+      const trace = createStartupTrace({
+        logger: createTestLogger(),
+        now: () => 100,
+      });
+
+      expect(trace.traceId).toBe('desktop-123');
+    } finally {
+      if (previousTraceId === undefined) {
+        delete (globalThis as { __BITFUN_STARTUP_TRACE_ID__?: string })
+          .__BITFUN_STARTUP_TRACE_ID__;
+      } else {
+        (globalThis as { __BITFUN_STARTUP_TRACE_ID__?: string }).__BITFUN_STARTUP_TRACE_ID__ =
+          previousTraceId;
+      }
+    }
+  });
+});
+
+describe('startupTrace payload helpers', () => {
+  it('estimates JSON payload size with a hard cap', () => {
+    const value = {
+      small: 'ok',
+      large: 'x'.repeat(10_000),
+    };
+
+    expect(estimateJsonBytes(value, 128)).toBe(128);
+  });
+
+  it('detects remote requests without needing full payload serialization', () => {
+    expect(isRemoteTraceRequest({
+      request: {
+        remoteConnectionId: 'ssh-user@example.com',
+      },
+    })).toBe(true);
+    expect(isRemoteTraceRequest({
+      request: {
+        workspacePath: 'D:/workspace/bitfun',
+      },
+    })).toBe(false);
+    expect(isRemoteTraceRequest({
+      request: {
+        sshHost: 'localhost',
+      },
+    })).toBe(false);
+    expect(isRemoteTraceRequest({
+      request: {
+        sshHost: 'example.internal',
+      },
+    })).toBe(true);
+    expect(isRemoteTraceRequest({
+      request: {
+        remoteSshHost: 'localhost',
+      },
+    })).toBe(false);
+    expect(isRemoteTraceRequest({
+      request: {
+        remoteSshHost: 'example.internal',
+      },
+    })).toBe(true);
+  });
+
+  it('keeps local ssh hosts out of remote session counters', () => {
+    expect(isRemoteTraceContext(undefined, 'localhost')).toBe(false);
+    expect(isRemoteTraceContext(undefined, '127.0.0.1')).toBe(false);
+    expect(isRemoteTraceContext('connection-1', 'localhost')).toBe(true);
+    expect(isRemoteTraceContext(undefined, 'example.internal')).toBe(true);
+  });
+});

--- a/src/web-ui/src/shared/utils/startupTrace.ts
+++ b/src/web-ui/src/shared/utils/startupTrace.ts
@@ -1,0 +1,370 @@
+import { createLogger } from './logger';
+import { roundDurationMs, type LoggerLike } from './timing';
+
+type NowFn = () => number;
+type TraceData = Record<string, unknown>;
+
+export type StartupTraceRequestType = 'tauri' | 'http';
+
+export interface StartupTraceApiCall {
+  type: StartupTraceRequestType;
+  command: string;
+  durationMs: number;
+  outcome?: 'success' | 'failure';
+  cacheOutcome?: 'hit' | 'miss' | 'unknown';
+  requestBytes?: number;
+  responseBytes?: number;
+  payloadEstimateDurationMs?: number;
+  remote: boolean;
+}
+
+export interface StartupTraceOptions {
+  enabled?: boolean;
+  logger?: LoggerLike;
+  traceId?: string;
+  now?: NowFn;
+  maxPhaseEvents?: number;
+}
+
+interface CommandAggregate {
+  command: string;
+  count: number;
+  successCount: number;
+  failureCount: number;
+  cacheHitCount: number;
+  cacheMissCount: number;
+  cacheUnknownCount: number;
+  remoteCount: number;
+  totalDurationMs: number;
+  maxDurationMs: number;
+  requestBytes: number;
+  responseBytes: number;
+}
+
+interface PhaseRecord {
+  traceId: string;
+  phase: string;
+  atMs: number;
+  [key: string]: unknown;
+}
+
+const DEFAULT_MAX_ESTIMATED_BYTES = 64 * 1024;
+const SENSITIVE_KEY_PATTERN =
+  /(api[-_]?key|authorization|bearer|token|secret|password|credential|payload|request|response|args|remoteconnectionid|remote[_-]?connection[_-]?id|remotesshhost|remote[_-]?ssh[_-]?host|sshhost|ssh[_-]?host|workspacepath|workspace[_-]?path)/i;
+
+function createTraceId(): string {
+  const injectedTraceId = (globalThis as { __BITFUN_STARTUP_TRACE_ID__?: unknown })
+    .__BITFUN_STARTUP_TRACE_ID__;
+  if (typeof injectedTraceId === 'string' && injectedTraceId.trim().length > 0) {
+    return injectedTraceId;
+  }
+
+  const cryptoLike = globalThis.crypto;
+  if (cryptoLike && typeof cryptoLike.randomUUID === 'function') {
+    return cryptoLike.randomUUID();
+  }
+  return `startup-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function isSafeScalar(value: unknown): value is string | number | boolean | null {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+}
+
+function sanitizeTraceData(data?: TraceData): TraceData | undefined {
+  if (!data) {
+    return undefined;
+  }
+
+  const sanitized: TraceData = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      continue;
+    }
+    if (isSafeScalar(value)) {
+      sanitized[key] = value;
+      continue;
+    }
+    if (Array.isArray(value) && value.every(isSafeScalar)) {
+      sanitized[key] = value;
+    }
+  }
+  return sanitized;
+}
+
+function isNonLocalRemoteHost(value: unknown): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return !(
+    normalized === 'localhost' ||
+    normalized.startsWith('localhost:') ||
+    normalized === '127.0.0.1' ||
+    normalized.startsWith('127.0.0.1:') ||
+    normalized === '::1' ||
+    normalized === '[::1]' ||
+    normalized.startsWith('[::1]:')
+  );
+}
+
+export function isRemoteTraceContext(
+  remoteConnectionId?: unknown,
+  remoteSshHost?: unknown
+): boolean {
+  if (typeof remoteConnectionId === 'string' && remoteConnectionId.trim().length > 0) {
+    return true;
+  }
+  return isNonLocalRemoteHost(remoteSshHost);
+}
+
+function hasRemoteKey(key: string, value: unknown): boolean {
+  const normalized = key.toLowerCase();
+  if (
+    normalized === 'remoteconnectionid' ||
+    normalized === 'remote_connection_id'
+  ) {
+    return typeof value === 'string' && value.trim().length > 0;
+  }
+  if (
+    normalized === 'remotesshhost' ||
+    normalized === 'remote_ssh_host' ||
+    normalized === 'sshhost' ||
+    normalized === 'ssh_host'
+  ) {
+    return isNonLocalRemoteHost(value);
+  }
+  if (normalized === 'workspacekind' || normalized === 'workspace_kind') {
+    return typeof value === 'string' && value.toLowerCase() === 'remote';
+  }
+  return false;
+}
+
+export function isRemoteTraceRequest(value: unknown, maxDepth = 4): boolean {
+  if (!value || typeof value !== 'object' || maxDepth < 0) {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(item => isRemoteTraceRequest(item, maxDepth - 1));
+  }
+
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    if (hasRemoteKey(key, nested)) {
+      return true;
+    }
+    if (nested && typeof nested === 'object' && isRemoteTraceRequest(nested, maxDepth - 1)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function estimateJsonBytes(value: unknown, maxBytes = DEFAULT_MAX_ESTIMATED_BYTES): number {
+  const seen = new WeakSet<object>();
+  let total = 0;
+
+  const add = (amount: number) => {
+    total = Math.min(maxBytes, total + amount);
+  };
+
+  const visit = (current: unknown, depth: number) => {
+    if (total >= maxBytes || depth < 0) {
+      return;
+    }
+
+    if (current === null || current === undefined) {
+      add(4);
+      return;
+    }
+
+    if (typeof current === 'string') {
+      add(current.length + 2);
+      return;
+    }
+
+    if (typeof current === 'number' || typeof current === 'boolean') {
+      add(String(current).length);
+      return;
+    }
+
+    if (typeof current !== 'object') {
+      add(String(current).length + 2);
+      return;
+    }
+
+    if (seen.has(current)) {
+      add(12);
+      return;
+    }
+    seen.add(current);
+
+    if (Array.isArray(current)) {
+      add(2);
+      for (const item of current) {
+        add(1);
+        visit(item, depth - 1);
+        if (total >= maxBytes) {
+          return;
+        }
+      }
+      return;
+    }
+
+    add(2);
+    for (const [key, nested] of Object.entries(current as Record<string, unknown>)) {
+      add(key.length + 3);
+      visit(nested, depth - 1);
+      if (total >= maxBytes) {
+        return;
+      }
+    }
+  };
+
+  visit(value, 8);
+  return total;
+}
+
+export class StartupTrace {
+  private readonly enabled: boolean;
+  private readonly logger: LoggerLike;
+  private readonly now: NowFn;
+  private readonly maxPhaseEvents: number;
+  readonly traceId: string;
+  private phaseEvents = 0;
+  private readonly phaseRecords: PhaseRecord[] = [];
+  private readonly commandAggregates = new Map<string, CommandAggregate>();
+  private totalApiCount = 0;
+  private successfulApiCount = 0;
+  private failedApiCount = 0;
+  private cacheHitCount = 0;
+  private cacheMissCount = 0;
+  private cacheUnknownCount = 0;
+  private remoteApiCount = 0;
+  private requestBytes = 0;
+  private responseBytes = 0;
+  private payloadEstimateDurationMs = 0;
+
+  constructor(options: StartupTraceOptions = {}) {
+    this.enabled = options.enabled ?? true;
+    this.logger = options.logger ?? createLogger('StartupTrace');
+    this.traceId = options.traceId ?? createTraceId();
+    this.now = options.now ?? (() => globalThis.performance?.now?.() ?? Date.now());
+    this.maxPhaseEvents = options.maxPhaseEvents ?? 80;
+  }
+
+  markPhase(phase: string, data?: TraceData): void {
+    if (!this.enabled || this.phaseEvents >= this.maxPhaseEvents) {
+      return;
+    }
+    this.phaseEvents += 1;
+    const phaseRecord = {
+      traceId: this.traceId,
+      phase,
+      atMs: roundDurationMs(this.now()),
+      ...(sanitizeTraceData(data) ?? {}),
+    };
+    this.phaseRecords.push(phaseRecord);
+    this.logger.debug('Startup trace event', phaseRecord);
+  }
+
+  recordApiCall(call: StartupTraceApiCall): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    const durationMs = roundDurationMs(call.durationMs);
+    const requestBytes = call.requestBytes ?? 0;
+    const responseBytes = call.responseBytes ?? 0;
+    const succeeded = call.outcome !== 'failure';
+    const cacheOutcome = call.cacheOutcome ?? 'unknown';
+    this.totalApiCount += 1;
+    this.successfulApiCount += succeeded ? 1 : 0;
+    this.failedApiCount += succeeded ? 0 : 1;
+    this.cacheHitCount += cacheOutcome === 'hit' ? 1 : 0;
+    this.cacheMissCount += cacheOutcome === 'miss' ? 1 : 0;
+    this.cacheUnknownCount += cacheOutcome === 'unknown' ? 1 : 0;
+    this.remoteApiCount += call.remote ? 1 : 0;
+    this.requestBytes += requestBytes;
+    this.responseBytes += responseBytes;
+    this.payloadEstimateDurationMs += call.payloadEstimateDurationMs ?? 0;
+
+    const existing = this.commandAggregates.get(call.command) ?? {
+      command: call.command,
+      count: 0,
+      successCount: 0,
+      failureCount: 0,
+      cacheHitCount: 0,
+      cacheMissCount: 0,
+      cacheUnknownCount: 0,
+      remoteCount: 0,
+      totalDurationMs: 0,
+      maxDurationMs: 0,
+      requestBytes: 0,
+      responseBytes: 0,
+    };
+
+    existing.count += 1;
+    existing.successCount += succeeded ? 1 : 0;
+    existing.failureCount += succeeded ? 0 : 1;
+    existing.cacheHitCount += cacheOutcome === 'hit' ? 1 : 0;
+    existing.cacheMissCount += cacheOutcome === 'miss' ? 1 : 0;
+    existing.cacheUnknownCount += cacheOutcome === 'unknown' ? 1 : 0;
+    existing.remoteCount += call.remote ? 1 : 0;
+    existing.totalDurationMs = roundDurationMs(existing.totalDurationMs + durationMs);
+    existing.maxDurationMs = Math.max(existing.maxDurationMs, durationMs);
+    existing.requestBytes += requestBytes;
+    existing.responseBytes += responseBytes;
+    this.commandAggregates.set(call.command, existing);
+  }
+
+  flushSummary(reason: string): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    const byCommand = Array.from(this.commandAggregates.values())
+      .sort((left, right) => right.totalDurationMs - left.totalDurationMs)
+      .map(item => ({
+        ...item,
+        totalDurationMs: roundDurationMs(item.totalDurationMs),
+        maxDurationMs: roundDurationMs(item.maxDurationMs),
+      }));
+
+    this.logger.info('Startup trace summary', {
+      traceId: this.traceId,
+      reason,
+      phases: {
+        count: this.phaseEvents,
+        events: this.phaseRecords,
+      },
+      api: {
+        totalCount: this.totalApiCount,
+        successCount: this.successfulApiCount,
+        failureCount: this.failedApiCount,
+        cacheHitCount: this.cacheHitCount,
+        cacheMissCount: this.cacheMissCount,
+        cacheUnknownCount: this.cacheUnknownCount,
+        remoteCount: this.remoteApiCount,
+        requestBytes: this.requestBytes,
+        responseBytes: this.responseBytes,
+        payloadEstimateDurationMs: roundDurationMs(this.payloadEstimateDurationMs),
+        byCommand,
+      },
+    });
+  }
+}
+
+export function createStartupTrace(options: StartupTraceOptions = {}): StartupTrace {
+  return new StartupTrace(options);
+}
+
+export const startupTrace = createStartupTrace();


### PR DESCRIPTION
## Summary

This PR improves startup observability and historical session readiness without changing `chunkSizeWarningLimit` and without submitting design or baseline documents.

## Changes

- Add lightweight startup trace aggregation for desktop/web startup phases and API payload/remote-call counters.
- Reduce pre-render startup blocking by moving non-critical context/recommendation/config watcher setup after the first render path.
- Dedupe concurrent `ConfigManager.getConfig()` reads for the same path to avoid repeated IPC during startup bursts.
- Track historical session hydrate state explicitly (`metadata-only`, `hydrating`, `ready`, `failed`) so opening a saved session shows a loading/retry state instead of briefly looking like a new empty session.
- Reuse pending historical hydrate before ensuring backend session setup, reducing duplicate session restore/create work.
- Add focused regression tests for startup tracing, config read dedupe, history hydrate transitions, failed/retry UI, pending hydrate reuse, ACP restore skip, and Modern store sync preservation.

## Performance Results

Local release-like startup sampling, 3 runs each:

| Metric | Before | After | Result |
|---|---:|---:|---:|
| First Render Scheduled avg | 82.8ms | 68.0ms | -17.9% |
| Start Application avg | 1249.3ms | 1038.5ms | -16.9% |
| After Render avg | 1165.1ms | 969.4ms | -16.8% |
| Main Window Shown avg | 2285.3ms | 2004.4ms | -12.3% |
| Interactive Shell Ready avg | 2447.2ms | 2196.3ms | -10.3% |
| Startup API count avg | 21.0 | 20.0 | -1 call |
| Startup response bytes avg | 14561 | 13559 | -1002 bytes |
| Remote command count avg | 0.0 | 0.0 | no local increase |

Historical-session UX improvement: saved sessions now enter a visible loading/retry lifecycle immediately, instead of falling through to the new-session empty state while turns are hydrating.

## Risks / Follow-ups

- Native window creation had one outlier in the after sample; this PR does not modify native window creation, so that metric is not claimed as a direct win and should continue to be sampled.
- Real remote SSH workspace sampling was not available locally. The trace counters show no local remote-call increase, but remote command count / payload / serialization data should be verified with a real remote workspace before making remote-specific claims.
- Deferring non-critical setup after render is intentionally conservative, but very early consumers of context/recommendation/config watcher state should be watched in manual smoke testing.
- Historical sessions still load full turns; this PR avoids high-risk paging/worker/protocol changes. Very large sessions may still need a later, separately reviewed optimization.
- Existing Vite chunk-size / dynamic-import warnings remain. This PR does not hide them by raising thresholds.

## Validation

- `git diff --cached --check`
- `rustfmt --edition 2021 --check --config skip_children=true src\apps\desktop\src\lib.rs src\apps\desktop\src\theme.rs`
- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run` (124 files / 650 tests)
- `cargo check -p bitfun-desktop`
- `cargo test -p bitfun-desktop` (27 tests)
- `pnpm run desktop:build:release-fast` passed during local milestone verification; existing Vite chunk warnings are still present.