### PR TITLE
fix(agent): Edit tool hardening and flow chat code block UI

### DIFF
--- a/src/crates/core/src/agentic/tools/implementations/file_edit_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_edit_tool.rs
@@ -1,8 +1,8 @@
-use crate::agentic::tools::ToolPathOperation;
 use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext, ValidationResult};
+use crate::agentic::tools::ToolPathOperation;
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use tool_runtime::fs::edit_file::{apply_edit_to_content, edit_file};
 
 pub struct FileEditTool;
@@ -73,8 +73,9 @@ Usage:
                 },
                 "old_string": {
                     "type": "string",
+                    "minLength": 1,
                     "default": "",
-                    "description": "The exact current text to replace. It must match the current file contents exactly, including whitespace and indentation, and must be unique unless replace_all is true. Copy it from a fresh Read result, excluding the line-number prefix. If this file was edited earlier in the turn, read the target area again before building old_string. Include stable surrounding context when a short snippet may appear multiple times."
+                    "description": "The non-empty exact current text to replace. It must match the current file contents exactly, including whitespace and indentation, and must be unique unless replace_all is true. Copy it from a fresh Read result, excluding the line-number prefix. If this file was edited earlier in the turn, read the target area again before building old_string. Include stable surrounding context when a short snippet may appear multiple times."
                 },
                 "new_string": {
                     "type": "string",
@@ -169,6 +170,23 @@ Usage:
             .get("new_string")
             .and_then(|v| v.as_str())
             .unwrap_or("");
+        if old_string.is_empty() {
+            return ValidationResult {
+                result: false,
+                message: Some("old_string cannot be empty".to_string()),
+                error_code: Some(400),
+                meta: None,
+            };
+        }
+        if old_string == new_string {
+            return ValidationResult {
+                result: false,
+                message: Some("new_string must be different from old_string".to_string()),
+                error_code: Some(400),
+                meta: None,
+            };
+        }
+
         let largest_lines = old_string.lines().count().max(new_string.lines().count());
         let largest_bytes = old_string.len().max(new_string.len());
         if largest_lines > LARGE_EDIT_SOFT_LINE_LIMIT || largest_bytes > LARGE_EDIT_SOFT_BYTE_LIMIT
@@ -308,10 +326,12 @@ mod tests {
     fn edit_multiple_match_error_includes_unique_context_guidance() {
         let message = FileEditTool::enhance_edit_error(
             "src/lib.rs",
-            "`old_string` appears 2 times in file".to_string(),
+            "`old_string` appears 2 times in file\nMatched contexts:\n[match 1 starts at line 4]"
+                .to_string(),
         );
 
         assert!(message.contains("old_string"));
+        assert!(message.contains("[match 1 starts at line 4]"));
         assert!(message.contains("include more surrounding context"));
         assert!(message.contains("replace_all only when every occurrence should change"));
     }

--- a/src/crates/tool-runtime/src/fs/edit_file.rs
+++ b/src/crates/tool-runtime/src/fs/edit_file.rs
@@ -1,6 +1,10 @@
 use crate::util::string::normalize_string;
 use std::fs;
 
+const MAX_MATCH_CONTEXTS: usize = 5;
+const CONTEXT_LINES_BEFORE: usize = 2;
+const CONTEXT_LINES_AFTER: usize = 2;
+
 /// Edit result, contains line number range information
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EditResult {
@@ -30,6 +34,40 @@ fn count_newlines(s: &str) -> usize {
     s.matches('\n').count()
 }
 
+fn match_contexts(content: &str, old_string: &str, matches: &[(usize, &str)]) -> String {
+    let lines: Vec<&str> = content.split('\n').collect();
+    let old_line_count = count_newlines(old_string) + 1;
+    let mut contexts = Vec::new();
+
+    for (idx, (byte_pos, _)) in matches.iter().take(MAX_MATCH_CONTEXTS).enumerate() {
+        let start_line = count_lines_before(content, *byte_pos);
+        let old_end_line = start_line + old_line_count.saturating_sub(1);
+        let context_start_line = start_line.saturating_sub(CONTEXT_LINES_BEFORE).max(1);
+        let context_end_line = (old_end_line + CONTEXT_LINES_AFTER).min(lines.len().max(1));
+        let snippet = lines[(context_start_line - 1)..context_end_line].join("\n");
+
+        contexts.push(format!(
+            "[match {} starts at line {}]\n{}",
+            idx + 1,
+            start_line,
+            snippet
+        ));
+    }
+
+    let omitted = matches.len().saturating_sub(MAX_MATCH_CONTEXTS);
+    let omitted_note = if omitted > 0 {
+        format!("\n... {omitted} more matches omitted.")
+    } else {
+        String::new()
+    };
+
+    format!(
+        "Matched contexts (copy exact text from a snippet and add stable surrounding lines to make `old_string` unique):\n{}{}",
+        contexts.join("\n---\n"),
+        omitted_note
+    )
+}
+
 pub fn apply_edit_to_content(
     content: &str,
     old_string: &str,
@@ -40,6 +78,11 @@ pub fn apply_edit_to_content(
     let normalized_old = normalize_string(old_string);
     let normalized_new = normalize_string(new_string);
     let normalized_content = normalize_string(content);
+
+    if normalized_old.is_empty() {
+        return Err("old_string cannot be empty.".to_string());
+    }
+
     let matches: Vec<_> = normalized_content.match_indices(&normalized_old).collect();
 
     if matches.is_empty() {
@@ -48,8 +91,9 @@ pub fn apply_edit_to_content(
 
     if matches.len() > 1 && !replace_all {
         return Err(format!(
-            "`old_string` appears {} times in file, either provide a larger string with more surrounding context to make it unique or use `replace_all` to change every instance of `old_string`.",
-            matches.len()
+            "`old_string` appears {} times in file, either provide a larger string with more surrounding context to make it unique or use `replace_all` to change every instance of `old_string`.\n{}",
+            matches.len(),
+            match_contexts(&normalized_content, &normalized_old, &matches)
         ));
     }
 
@@ -140,6 +184,31 @@ mod tests {
         assert_eq!(result.match_count, 2);
         assert_eq!(result.new_content, "ONE\r\ntwo\r\nONE\r\n");
         assert_eq!(result.edit_result.start_line, 1);
+    }
+
+    #[test]
+    fn apply_edit_to_content_rejects_empty_old_string() {
+        let error = apply_edit_to_content("alpha\n", "", "beta", false)
+            .expect_err("empty old_string should fail");
+
+        assert_eq!(error, "old_string cannot be empty.");
+    }
+
+    #[test]
+    fn apply_edit_to_content_multiple_match_error_includes_contexts() {
+        let error = apply_edit_to_content(
+            "first block\n  same();\nend first\n\nsecond block\n  same();\nend second\n",
+            "  same();",
+            "  changed();",
+            false,
+        )
+        .expect_err("ambiguous edit should fail");
+
+        assert!(error.contains("`old_string` appears 2 times in file"));
+        assert!(error.contains("[match 1 starts at line 2]"));
+        assert!(error.contains("first block"));
+        assert!(error.contains("[match 2 starts at line 6]"));
+        assert!(error.contains("second block"));
     }
 
     #[test]

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
@@ -524,6 +524,71 @@ function formatCodeLanguageLabel(lang: string): string {
   return raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase();
 }
 
+interface StreamingCodeFallbackProps {
+  code: string;
+  language: string;
+  bodyStyle: React.CSSProperties;
+  codeTagStyle: React.CSSProperties;
+  gutterColor: string;
+}
+
+/**
+ * Lightweight, stable line-numbered code renderer used while the surrounding
+ * markdown is still streaming. Its layout deliberately matches the
+ * `react-syntax-highlighter` `showLineNumbers` output: a fixed-width inline
+ * line-number column followed by the line content, separated visually by the
+ * same padding. This keeps the code block from visibly jumping when streaming
+ * completes and the heavy Prism highlighter takes over.
+ */
+const StreamingCodeFallback: React.FC<StreamingCodeFallbackProps> = ({
+  code,
+  language,
+  bodyStyle,
+  codeTagStyle,
+  gutterColor,
+}) => {
+  const lineCount = code.length === 0 ? 1 : code.split('\n').length;
+  let gutterText = '';
+  for (let i = 1; i <= lineCount; i++) {
+    gutterText += i === lineCount ? `${i}` : `${i}\n`;
+  }
+
+  return (
+    <pre
+      className={`language-${language} code-block-fallback code-block-fallback--linenumbers`}
+      style={bodyStyle}
+    >
+      <code style={{ ...codeTagStyle, display: 'flex' }}>
+        <span
+          aria-hidden="true"
+          style={{
+            flex: 'none',
+            display: 'block',
+            minWidth: '3em',
+            paddingRight: '1em',
+            textAlign: 'right',
+            color: gutterColor,
+            userSelect: 'none',
+            whiteSpace: 'pre',
+          }}
+        >
+          {gutterText}
+        </span>
+        <span
+          style={{
+            flex: 1,
+            minWidth: 0,
+            display: 'block',
+            whiteSpace: 'pre',
+          }}
+        >
+          {code}
+        </span>
+      </code>
+    </pre>
+  );
+};
+
 const CopyButton: React.FC<{ code: string }> = ({ code }) => {
   const { t } = useI18n('components');
   const [copied, setCopied] = useState(false);
@@ -616,15 +681,31 @@ export const Markdown = React.memo<MarkdownProps>(({
   const { markdownContent, reproductionSteps } = useMemo(() => {
     const regex = /<reproduction_steps>([\s\S]*?)<\/reproduction[\s_]*steps\s*>?/g;
     const match = regex.exec(contentStr);
-    
+
+    let body = contentStr;
+    let steps: string | null = null;
     if (match) {
-      const steps = match[1].trim();
-      const cleanedContent = contentStr.replace(regex, '').trim();
-      return { markdownContent: cleanedContent, reproductionSteps: steps };
+      steps = match[1].trim();
+      body = contentStr.replace(regex, '').trim();
     }
-    
-    return { markdownContent: contentStr, reproductionSteps: null };
-  }, [contentStr]);
+
+    // While streaming, the model may emit an opening ```lang fence long before
+    // the closing ```. react-markdown then flips between parsing the tail as a
+    // paragraph (raw text) and as a fenced code block as more tokens arrive,
+    // which unmounts/remounts the code block and shifts its position every
+    // tick. Append a synthetic closing fence so the AST stays a stable code
+    // block from the moment the opening fence appears.
+    if (isStreaming) {
+      const fenceMatches = body.match(/^[ \t]{0,3}(`{3,}|~{3,})/gm);
+      if (fenceMatches && fenceMatches.length % 2 === 1) {
+        const lastFence = fenceMatches[fenceMatches.length - 1].trim();
+        const needsLeadingNewline = !body.endsWith('\n');
+        body = `${body}${needsLeadingNewline ? '\n' : ''}${lastFence}`;
+      }
+    }
+
+    return { markdownContent: body, reproductionSteps: steps };
+  }, [contentStr, isStreaming]);
   
   const linkMap = useMemo(() => {
     const map = new Map<string, string>();
@@ -847,7 +928,16 @@ export const Markdown = React.memo<MarkdownProps>(({
       }
       
       const normalizedLang = getPrismLanguageFromAlias(language);
-      
+      const codeBodyStyle: React.CSSProperties = {
+        margin: 0,
+        borderRadius: '0 0 8px 8px',
+        fontSize: '0.875rem',
+        lineHeight: '1.55',
+      };
+      const codeTagStyle: React.CSSProperties = {
+        fontFamily: 'var(--markdown-font-mono, "Fira Code", "JetBrains Mono", Consolas, "Courier New", monospace)',
+      };
+
       return (
         <div className={`code-block-wrapper${hasMultipleLines ? '' : ' code-block-wrapper--single-line'}`}>
           <div className="code-block-toolbar">
@@ -855,31 +945,40 @@ export const Markdown = React.memo<MarkdownProps>(({
             <CopyButton code={code} />
           </div>
           <div className="code-block-body">
-          <AsyncPrismSyntaxHighlighter
-            language={normalizedLang}
-            style={syntaxTheme}
-            showLineNumbers={true}
-            customStyle={{
-              margin: 0,
-              borderRadius: '0 0 8px 8px',
-              fontSize: '0.875rem',
-              lineHeight: '1.55'
-            }}
-            codeTagProps={{
-              style: {
-                fontFamily: 'var(--markdown-font-mono, "Fira Code", "JetBrains Mono", Consolas, "Courier New", monospace)'
-              }
-            }}
-            lineNumberStyle={{
-              color: isLight ? '#999' : '#666',
-              paddingRight: '1em',
-              textAlign: 'right',
-              userSelect: 'none',
-              minWidth: '3em'
-            }}
-          >
-            {code}
-          </AsyncPrismSyntaxHighlighter>
+          {isStreaming ? (
+            // While the text is still streaming, skip the heavy Prism
+            // tokenization on every tick (it re-highlights the entire
+            // code each frame, which is the main source of code-block
+            // jitter in the chat). Render a lightweight, line-numbered
+            // <pre> that matches Prism's `showLineNumbers` layout so the
+            // gutter width and line indentation stay visually stable
+            // across the eventual fallback -> Prism swap when streaming
+            // completes.
+            <StreamingCodeFallback
+              code={code}
+              language={normalizedLang}
+              bodyStyle={codeBodyStyle}
+              codeTagStyle={codeTagStyle}
+              gutterColor={isLight ? '#999' : '#666'}
+            />
+          ) : (
+            <AsyncPrismSyntaxHighlighter
+              language={normalizedLang}
+              style={syntaxTheme}
+              showLineNumbers={true}
+              customStyle={codeBodyStyle}
+              codeTagProps={{ style: codeTagStyle }}
+              lineNumberStyle={{
+                color: isLight ? '#999' : '#666',
+                paddingRight: '1em',
+                textAlign: 'right',
+                userSelect: 'none',
+                minWidth: '3em'
+              }}
+            >
+              {code}
+            </AsyncPrismSyntaxHighlighter>
+          )}
           </div>
         </div>
       );

--- a/src/web-ui/src/flow_chat/components/FlowTextBlock.tsx
+++ b/src/web-ui/src/flow_chat/components/FlowTextBlock.tsx
@@ -101,7 +101,14 @@ export const FlowTextBlock = React.memo<FlowTextBlockProps>(({
       {textItem.isMarkdown ? (
         <MarkdownRenderer
           content={displayContent}
-          isStreaming={isActivelyStreaming}
+          // Pass the raw streaming flag (not the idle-gated
+          // `isActivelyStreaming`) so the code-block render path inside
+          // Markdown stays stable across bursty AI output. Otherwise
+          // `isContentGrowing` toggles every >500ms idle and forces the
+          // fallback <pre> / Prism highlighter to swap back and forth,
+          // which makes line numbers and the code body visibly shake
+          // until the stream finally completes.
+          isStreaming={isStreaming}
           onFileViewRequest={onFileViewRequest}
           onTabOpen={onTabOpen}
           onOpenVisualization={(visualization) => {

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
@@ -697,11 +697,13 @@ const FlowItemRenderer: React.FC<FlowItemRendererProps> = ({ item, turnId, isLas
     case 'tool': {
       const toolItem = item as FlowToolItem;
       const isCompletedTool = toolItem.status === 'completed';
+      const isCollapsible = isCollapsibleTool(toolItem.toolName);
       const toolClassName = [
         'flowchat-flow-item',
-        'flowchat-flow-item--tool-transition',
-        isCompletedTool ? 'flowchat-flow-item--tool-completed' : 'flowchat-flow-item--tool-active',
-      ].join(' ');
+        isCollapsible && isCompletedTool ? 'flowchat-flow-item--tool-transition' : null,
+        isCollapsible && isCompletedTool ? 'flowchat-flow-item--tool-completed' : null,
+        isCollapsible && !isCompletedTool ? 'flowchat-flow-item--tool-active' : null,
+      ].filter(Boolean).join(' ');
 
       return wrapContent(
         <div className={toolClassName} data-flow-item-id={item.id} data-flow-item-type="tool">

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
@@ -104,7 +104,6 @@ function renderTerminalExpandedContent(params: {
           <TerminalOutputRenderer
             content={liveOutput}
             className="terminal-xterm-output"
-            minHeight={maxHeight}
             maxHeight={maxHeight}
           />
         </div>


### PR DESCRIPTION
## Summary

- Harden the file edit tool and `edit_file` runtime behavior for more reliable edits.
- Fix Edit tool status visibility in the flow chat model round UI when appropriate.
- Improve Markdown/code block rendering in the flow chat (including terminal tool card integration).

## Commits

1. `fix edit tool` — Rust: `file_edit_tool` + `edit_file` improvements
2. `fix edit tool hide status` — Web: `ModelRoundItem` edit-tool status display
3. `fix code block demonstration` — Web: Markdown / `FlowTextBlock` / `TerminalToolCard`

## Test plan

- [ ] `cargo check --workspace` (Rust paths touched)
- [ ] `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run` (web-ui paths touched)