### PR TITLE
Reduce startup background contention

### DIFF
--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -251,6 +251,71 @@ describe('FlowChatStore historical session hydration state', () => {
     });
   });
 
+  it('loads model config once while processing multiple persisted sessions', async () => {
+    configManagerMock.getConfig.mockImplementation(async (path: string) => {
+      if (path === 'ai.models') return [{ id: 'primary-model', context_window: 256000 }];
+      if (path === 'ai.default_models') return { primary: 'primary-model' };
+      return undefined;
+    });
+    apiMocks.listSessions.mockResolvedValueOnce([
+      {
+        sessionId: 'history-1',
+        title: 'Saved session 1',
+        agentType: 'agentic',
+        createdAt: 10,
+        lastActiveAt: 20,
+      },
+      {
+        sessionId: 'history-2',
+        title: 'Saved session 2',
+        agentType: 'agentic',
+        createdAt: 11,
+        lastActiveAt: 21,
+      },
+    ]);
+
+    await flowChatStore.initializeFromDisk('D:/workspace/BitFun');
+
+    const configPaths = configManagerMock.getConfig.mock.calls.map(([path]) => path);
+    expect(configPaths.filter(path => path === 'ai.models')).toHaveLength(1);
+    expect(configPaths.filter(path => path === 'ai.default_models')).toHaveLength(1);
+    expect(flowChatStore.getState().sessions.get('history-1')?.maxContextTokens).toBe(256000);
+    expect(flowChatStore.getState().sessions.get('history-2')?.maxContextTokens).toBe(256000);
+  });
+
+  it('skips one bad metadata entry without dropping the rest of the session list', async () => {
+    apiMocks.listSessions.mockResolvedValueOnce([
+      {
+        sessionId: 'bad-1',
+        title: 'Bad session',
+        agentType: 'agentic',
+        createdAt: 10,
+        lastActiveAt: 20,
+      },
+      {
+        sessionId: 'good-1',
+        title: 'Good session',
+        agentType: 'agentic',
+        createdAt: 11,
+        lastActiveAt: 21,
+      },
+    ]);
+    stateMachineManagerMock.getOrCreate.mockImplementation((sessionId: string) => {
+      if (sessionId === 'bad-1') {
+        throw new Error('bad metadata');
+      }
+      return {};
+    });
+
+    await flowChatStore.initializeFromDisk('D:/workspace/BitFun');
+
+    expect(flowChatStore.getState().sessions.has('bad-1')).toBe(false);
+    expect(flowChatStore.getState().sessions.get('good-1')).toMatchObject({
+      sessionId: 'good-1',
+      historyState: 'metadata-only',
+    });
+  });
+
   it('marks historical sessions hydrating while turns are loading and ready after completion', async () => {
     const turns = createDeferred<any[]>();
     apiMocks.restoreSession.mockResolvedValueOnce(undefined);

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -1747,35 +1747,53 @@ export class FlowChatStore {
       startupTrace.markPhase('session_metadata_list_loaded', { remote, sessionCount });
 
       const { stateMachineManager } = await import('../state-machine');
-      sessions.forEach(metadata => {
-        stateMachineManager.getOrCreate(metadata.sessionId);
-      });
-      
+
+      let models: any[] = [];
+      let defaultModels: Record<string, string> = {};
+      try {
+        const { configManager } = await import('@/infrastructure/config/services/ConfigManager');
+        const [modelsResult, defaultModelsResult] = await Promise.allSettled([
+          configManager.getConfig<any[]>('ai.models'),
+          configManager.getConfig<Record<string, string>>('ai.default_models'),
+        ]);
+
+        if (modelsResult.status === 'fulfilled' && Array.isArray(modelsResult.value)) {
+          models = modelsResult.value;
+        }
+        if (
+          defaultModelsResult.status === 'fulfilled' &&
+          defaultModelsResult.value &&
+          typeof defaultModelsResult.value === 'object'
+        ) {
+          defaultModels = defaultModelsResult.value;
+        }
+      } catch (error) {
+        log.warn('Failed to load model config for session metadata, using defaults', { error });
+      }
+
       const processSession = async (metadata: any) => {
-        const existingSession = this.state.sessions.get(metadata.sessionId);
-        if (existingSession) {
-          return;
-        }
-        if (isLegacyPersistedBtwSession(metadata)) {
-          return;
-        }
-        
-        let maxContextTokens = 128128;
         try {
-          const { configManager } = await import('@/infrastructure/config/services/ConfigManager');
-          const models = await configManager.getConfig<any[]>('ai.models') || [];
-          
+          const existingSession = this.state.sessions.get(metadata.sessionId);
+          if (existingSession) {
+            return;
+          }
+          if (isLegacyPersistedBtwSession(metadata)) {
+            return;
+          }
+
+          stateMachineManager.getOrCreate(metadata.sessionId);
+
+          let maxContextTokens = 128128;
           if (metadata.modelName) {
             const model = models.find((m: any) => m.name === metadata.modelName || m.id === metadata.modelName);
             if (model?.context_window) {
               maxContextTokens = model.context_window;
             }
           }
-          
+
           if (maxContextTokens === 128128) {
-            const defaultModels = await configManager.getConfig<Record<string, string>>('ai.default_models');
             const primaryModelId = defaultModels?.primary;
-            
+
             if (primaryModelId) {
               const primaryModel = models.find((m: any) => m.id === primaryModelId);
               if (primaryModel?.context_window) {
@@ -1783,71 +1801,74 @@ export class FlowChatStore {
               }
             }
           }
-        } catch (error) {
-          log.warn('Failed to get model context window size, using default', { sessionId: metadata.sessionId, error });
-        }
-        
-        const relationship = deriveSessionRelationshipFromMetadata(metadata);
-        const lastFinishedAt = deriveLastFinishedAtFromMetadata(metadata);
-        const titleState = deriveSessionTitleStateFromMetadata(metadata);
-        const hasDynamicDefaultTitle = titleState.titleSource === 'i18n';
 
-        this.setState(prev => {
-          if (prev.sessions.has(metadata.sessionId)) {
-            return prev;
-          }
-          
-          const rawAgentType = metadata.agentType || 'agentic';
-          const validatedAgentType = isValidPersistedAgentType(rawAgentType) ? rawAgentType : 'agentic';
-          
-          if (rawAgentType !== validatedAgentType) {
-            log.warn('Invalid agentType, falling back to agentic', { sessionId: metadata.sessionId, rawAgentType, validatedAgentType });
-          }
-          
-          const session: Session = {
-            sessionId: metadata.sessionId,
-            title: titleState.title,
-            titleSource: titleState.titleSource,
-            titleI18nKey: titleState.titleI18nKey,
-            titleI18nParams: titleState.titleI18nParams,
-            titleStatus: hasDynamicDefaultTitle ? undefined : 'generated',
-            dialogTurns: [],
-            status: 'idle',
-            config: {
-              agentType: validatedAgentType,
-              modelName: metadata.modelName,
-            },
-            createdAt: metadata.createdAt,
-            lastActiveAt: metadata.lastActiveAt,
-            lastFinishedAt,
-            error: null,
-            isHistorical: true,
-            historyState: 'metadata-only',
-            todos: (metadata as any).todos || [],
-            maxContextTokens,
-            mode: validatedAgentType,
-            workspacePath: (metadata as any).workspacePath || workspacePath,
-            remoteConnectionId: metadata.remoteConnectionId || remoteConnectionId,
-            remoteSshHost:
-              metadata.remoteSshHost || metadata.workspaceHostname || remoteSshHost,
-            parentSessionId: relationship.parentSessionId,
-            sessionKind: relationship.sessionKind,
-            btwThreads: [],
-            btwOrigin: relationship.btwOrigin,
-            hasUnreadCompletion: metadata.unreadCompletion,
-            needsUserAttention: metadata.needsUserAttention,
-            deepReviewRunManifest: metadata.deepReviewRunManifest,
-            isTransient: false,
-          };
-          
-          const newSessions = new Map(prev.sessions);
-          newSessions.set(metadata.sessionId, session);
-          
-          return {
-            ...prev,
-            sessions: newSessions,
-          };
-        });
+          const relationship = deriveSessionRelationshipFromMetadata(metadata);
+          const lastFinishedAt = deriveLastFinishedAtFromMetadata(metadata);
+          const titleState = deriveSessionTitleStateFromMetadata(metadata);
+          const hasDynamicDefaultTitle = titleState.titleSource === 'i18n';
+
+          this.setState(prev => {
+            if (prev.sessions.has(metadata.sessionId)) {
+              return prev;
+            }
+
+            const rawAgentType = metadata.agentType || 'agentic';
+            const validatedAgentType = isValidPersistedAgentType(rawAgentType) ? rawAgentType : 'agentic';
+
+            if (rawAgentType !== validatedAgentType) {
+              log.warn('Invalid agentType, falling back to agentic', { sessionId: metadata.sessionId, rawAgentType, validatedAgentType });
+            }
+
+            const session: Session = {
+              sessionId: metadata.sessionId,
+              title: titleState.title,
+              titleSource: titleState.titleSource,
+              titleI18nKey: titleState.titleI18nKey,
+              titleI18nParams: titleState.titleI18nParams,
+              titleStatus: hasDynamicDefaultTitle ? undefined : 'generated',
+              dialogTurns: [],
+              status: 'idle',
+              config: {
+                agentType: validatedAgentType,
+                modelName: metadata.modelName,
+              },
+              createdAt: metadata.createdAt,
+              lastActiveAt: metadata.lastActiveAt,
+              lastFinishedAt,
+              error: null,
+              isHistorical: true,
+              historyState: 'metadata-only',
+              todos: (metadata as any).todos || [],
+              maxContextTokens,
+              mode: validatedAgentType,
+              workspacePath: (metadata as any).workspacePath || workspacePath,
+              remoteConnectionId: metadata.remoteConnectionId || remoteConnectionId,
+              remoteSshHost:
+                metadata.remoteSshHost || metadata.workspaceHostname || remoteSshHost,
+              parentSessionId: relationship.parentSessionId,
+              sessionKind: relationship.sessionKind,
+              btwThreads: [],
+              btwOrigin: relationship.btwOrigin,
+              hasUnreadCompletion: metadata.unreadCompletion,
+              needsUserAttention: metadata.needsUserAttention,
+              deepReviewRunManifest: metadata.deepReviewRunManifest,
+              isTransient: false,
+            };
+
+            const newSessions = new Map(prev.sessions);
+            newSessions.set(metadata.sessionId, session);
+
+            return {
+              ...prev,
+              sessions: newSessions,
+            };
+          });
+        } catch (error) {
+          log.warn('Failed to process persisted session metadata', {
+            sessionId: metadata?.sessionId,
+            error,
+          });
+        }
       };
       
       await Promise.all(sessions.map(processSession));

--- a/src/web-ui/src/main.tsx
+++ b/src/web-ui/src/main.tsx
@@ -265,11 +265,19 @@ async function initializeAfterRender(): Promise<void> {
   await fontPreferenceService.initialize();
   log.info('Font preference initialized at startup');
 
-  const { configManager } = await import('./infrastructure/config/services/ConfigManager');
-  await configManager.getConfig('editor');
-  log.info('Editor configuration preloaded');
-
   const initResults = await Promise.allSettled([
+    (async () => {
+      const { backgroundTaskScheduler } = await import('./shared/utils/backgroundTaskScheduler');
+      backgroundTaskScheduler.schedule(async () => {
+        const { configManager } = await import('./infrastructure/config/services/ConfigManager');
+        await configManager.getConfig('editor');
+        log.info('Editor configuration preloaded');
+      }, {
+        idle: true,
+        inFlightKey: 'startup:editor-config-preload',
+        priority: 'low',
+      });
+    })(),
     (async () => {
       const { installFrontendLogLevelConfigWatcher } = await import('./infrastructure/config/services/FrontendLogLevelSync');
       await installFrontendLogLevelConfigWatcher();
@@ -294,23 +302,20 @@ async function initializeAfterRender(): Promise<void> {
       registerNotificationContextMenu();
     })(),
     (async () => {
-      const { MonacoManager } = await import('./tools/editor');
-      await MonacoManager.initialize();
-
-      const { monacoThemeSync } = await import('./infrastructure/theme/integrations/MonacoThemeSync');
-      await monacoThemeSync.initialize();
-      log.info('Monaco theme sync initialized');
+      const { scheduleMonacoStartupWarmup } = await import('./tools/editor/services/MonacoStartupWarmup');
+      scheduleMonacoStartupWarmup();
     })(),
   ]);
 
   initResults.forEach((result, index) => {
     const names = [
+      'EditorConfigPreload',
       'LogLevelConfigWatcher',
       'DefaultContextTypes',
       'RecommendationProviders',
       'Tools',
       'ContextMenu',
-      'Editors',
+      'EditorWarmup',
     ];
     if (result.status === 'rejected') {
       log.warn('Initialization failed', { module: names[index], error: result.reason });

--- a/src/web-ui/src/shared/utils/backgroundTaskScheduler.test.ts
+++ b/src/web-ui/src/shared/utils/backgroundTaskScheduler.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import {
+  BackgroundTaskCancelledError,
+  BackgroundTaskScheduler,
+} from './backgroundTaskScheduler';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('BackgroundTaskScheduler', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as any).requestIdleCallback;
+    delete (globalThis as any).cancelIdleCallback;
+  });
+
+  it('respects concurrency limit and runs higher priority queued tasks first', async () => {
+    const scheduler = new BackgroundTaskScheduler({ concurrency: 1 });
+    const first = deferred<string>();
+    const order: string[] = [];
+
+    const firstTask = scheduler.schedule(async () => {
+      order.push('first:start');
+      await first.promise;
+      order.push('first:end');
+      return 'first';
+    }, { priority: 'low' });
+
+    const lowTask = scheduler.schedule(async () => {
+      order.push('low');
+      return 'low';
+    }, { priority: 'low' });
+
+    const highTask = scheduler.schedule(async () => {
+      order.push('high');
+      return 'high';
+    }, { priority: 'high' });
+
+    await Promise.resolve();
+    expect(order).toEqual(['first:start']);
+
+    first.resolve('first');
+    await expect(firstTask.promise).resolves.toBe('first');
+    await expect(highTask.promise).resolves.toBe('high');
+    await expect(lowTask.promise).resolves.toBe('low');
+    expect(order).toEqual(['first:start', 'first:end', 'high', 'low']);
+  });
+
+  it('deduplicates queued or running tasks with the same in-flight key', async () => {
+    const scheduler = new BackgroundTaskScheduler({ concurrency: 1 });
+    const task = vi.fn(async () => 'shared');
+
+    const first = scheduler.schedule(task, { inFlightKey: 'startup:monaco' });
+    const second = scheduler.schedule(task, { inFlightKey: 'startup:monaco' });
+
+    await expect(first.promise).resolves.toBe('shared');
+    await expect(second.promise).resolves.toBe('shared');
+    expect(first.promise).toBe(second.promise);
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels queued work without running it', async () => {
+    const scheduler = new BackgroundTaskScheduler({ concurrency: 1 });
+    const blocker = deferred<void>();
+    const queuedTask = vi.fn(async () => 'queued');
+
+    scheduler.schedule(async () => {
+      await blocker.promise;
+    });
+    const queued = scheduler.schedule(queuedTask);
+
+    queued.cancel();
+    blocker.resolve();
+
+    await expect(queued.promise).rejects.toBeInstanceOf(BackgroundTaskCancelledError);
+    expect(queuedTask).not.toHaveBeenCalled();
+  });
+
+  it('uses requestIdleCallback for idle tasks', async () => {
+    const scheduler = new BackgroundTaskScheduler({ concurrency: 1 });
+    const idleCallbacks: Array<() => void> = [];
+    const task = vi.fn(async () => 'idle');
+    (globalThis as any).requestIdleCallback = vi.fn((callback: () => void) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    });
+    (globalThis as any).cancelIdleCallback = vi.fn();
+
+    const scheduled = scheduler.schedule(task, { idle: true });
+    await Promise.resolve();
+
+    expect(task).not.toHaveBeenCalled();
+    expect((globalThis as any).requestIdleCallback).toHaveBeenCalledTimes(1);
+
+    idleCallbacks[0]();
+    await expect(scheduled.promise).resolves.toBe('idle');
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the concurrency slot when an idle task is cancelled', async () => {
+    const scheduler = new BackgroundTaskScheduler({ concurrency: 1 });
+    const task = vi.fn(async () => 'next');
+    (globalThis as any).requestIdleCallback = vi.fn(() => 1);
+    (globalThis as any).cancelIdleCallback = vi.fn();
+
+    const idle = scheduler.schedule(async () => 'idle', { idle: true });
+    idle.cancel();
+
+    const next = scheduler.schedule(task);
+
+    await expect(idle.promise).rejects.toBeInstanceOf(BackgroundTaskCancelledError);
+    await expect(next.promise).resolves.toBe('next');
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/shared/utils/backgroundTaskScheduler.ts
+++ b/src/web-ui/src/shared/utils/backgroundTaskScheduler.ts
@@ -1,0 +1,235 @@
+import { createLogger } from './logger';
+
+const log = createLogger('BackgroundTaskScheduler');
+
+export type BackgroundTaskPriority = 'high' | 'normal' | 'low';
+
+export interface BackgroundTaskOptions {
+  priority?: BackgroundTaskPriority;
+  idle?: boolean;
+  inFlightKey?: string;
+}
+
+export interface BackgroundTaskHandle<T> {
+  promise: Promise<T>;
+  cancel: () => void;
+}
+
+export interface BackgroundTaskSchedulerOptions {
+  concurrency?: number;
+}
+
+type TaskStatus = 'queued' | 'idle' | 'running' | 'settled' | 'cancelled';
+
+interface TaskEntry<T> {
+  id: number;
+  priority: BackgroundTaskPriority;
+  idle: boolean;
+  inFlightKey?: string;
+  status: TaskStatus;
+  task: (signal: AbortSignal) => Promise<T> | T;
+  controller: AbortController;
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+  idleHandle?: number;
+}
+
+export class BackgroundTaskCancelledError extends Error {
+  constructor() {
+    super('Background task cancelled');
+    this.name = 'BackgroundTaskCancelledError';
+  }
+}
+
+const PRIORITY_RANK: Record<BackgroundTaskPriority, number> = {
+  high: 0,
+  normal: 1,
+  low: 2,
+};
+
+function requestIdle(callback: () => void): number {
+  const requestIdleCallback = (globalThis as {
+    requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+  }).requestIdleCallback;
+
+  if (typeof requestIdleCallback === 'function') {
+    return requestIdleCallback(callback, { timeout: 2000 });
+  }
+
+  return globalThis.setTimeout(callback, 0) as unknown as number;
+}
+
+function cancelIdle(handle: number): void {
+  const cancelIdleCallback = (globalThis as {
+    cancelIdleCallback?: (handle: number) => void;
+  }).cancelIdleCallback;
+
+  if (typeof cancelIdleCallback === 'function') {
+    cancelIdleCallback(handle);
+    return;
+  }
+
+  globalThis.clearTimeout(handle);
+}
+
+export class BackgroundTaskScheduler {
+  private readonly concurrency: number;
+  private nextId = 1;
+  private runningCount = 0;
+  private queue: Array<TaskEntry<unknown>> = [];
+  private keyedTasks = new Map<string, TaskEntry<unknown>>();
+
+  constructor(options: BackgroundTaskSchedulerOptions = {}) {
+    this.concurrency = Math.max(1, options.concurrency ?? 2);
+  }
+
+  schedule<T>(
+    task: (signal: AbortSignal) => Promise<T> | T,
+    options: BackgroundTaskOptions = {}
+  ): BackgroundTaskHandle<T> {
+    const inFlightKey = options.inFlightKey;
+    if (inFlightKey) {
+      const existing = this.keyedTasks.get(inFlightKey) as TaskEntry<T> | undefined;
+      if (existing && existing.status !== 'cancelled' && existing.status !== 'settled') {
+        return this.toHandle(existing);
+      }
+    }
+
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    const entry: TaskEntry<T> = {
+      id: this.nextId++,
+      priority: options.priority ?? 'normal',
+      idle: options.idle ?? false,
+      inFlightKey,
+      status: 'queued',
+      task,
+      controller: new AbortController(),
+      promise,
+      resolve,
+      reject,
+    };
+
+    this.queue.push(entry as TaskEntry<unknown>);
+    if (inFlightKey) {
+      this.keyedTasks.set(inFlightKey, entry as TaskEntry<unknown>);
+    }
+    this.drain();
+
+    return this.toHandle(entry);
+  }
+
+  private toHandle<T>(entry: TaskEntry<T>): BackgroundTaskHandle<T> {
+    return {
+      promise: entry.promise,
+      cancel: () => this.cancel(entry),
+    };
+  }
+
+  private cancel<T>(entry: TaskEntry<T>): void {
+    if (entry.status === 'settled' || entry.status === 'cancelled') {
+      return;
+    }
+
+    if (entry.status === 'running') {
+      entry.controller.abort();
+      return;
+    }
+
+    const shouldReleaseSlot = entry.status === 'idle';
+    entry.status = 'cancelled';
+    entry.controller.abort();
+    if (entry.idleHandle !== undefined) {
+      cancelIdle(entry.idleHandle);
+      entry.idleHandle = undefined;
+    }
+    this.queue = this.queue.filter((item) => item !== entry);
+    this.deleteKeyIfCurrent(entry);
+    entry.reject(new BackgroundTaskCancelledError());
+    if (shouldReleaseSlot) {
+      this.runningCount -= 1;
+    }
+    this.drain();
+  }
+
+  private drain(): void {
+    while (this.runningCount < this.concurrency) {
+      const next = this.shiftNextRunnable();
+      if (!next) {
+        return;
+      }
+
+      this.runningCount += 1;
+      if (next.idle) {
+        next.status = 'idle';
+        next.idleHandle = requestIdle(() => {
+          next.idleHandle = undefined;
+          void this.run(next);
+        });
+      } else {
+        void this.run(next);
+      }
+    }
+  }
+
+  private shiftNextRunnable(): TaskEntry<unknown> | null {
+    this.queue = this.queue.filter((entry) => entry.status === 'queued');
+    if (this.queue.length === 0) {
+      return null;
+    }
+
+    this.queue.sort((a, b) => {
+      const priorityDiff = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
+      return priorityDiff !== 0 ? priorityDiff : a.id - b.id;
+    });
+
+    return this.queue.shift() ?? null;
+  }
+
+  private async run<T>(entry: TaskEntry<T>): Promise<void> {
+    if (entry.status === 'cancelled') {
+      this.runningCount -= 1;
+      this.drain();
+      return;
+    }
+
+    entry.status = 'running';
+    try {
+      if (entry.controller.signal.aborted) {
+        throw new BackgroundTaskCancelledError();
+      }
+      entry.resolve(await entry.task(entry.controller.signal));
+    } catch (error) {
+      if (entry.controller.signal.aborted && !(error instanceof BackgroundTaskCancelledError)) {
+        entry.reject(new BackgroundTaskCancelledError());
+      } else {
+        entry.reject(error);
+      }
+      if (!(error instanceof BackgroundTaskCancelledError)) {
+        log.warn('Background task failed', { inFlightKey: entry.inFlightKey, error });
+      }
+    } finally {
+      entry.status = 'settled';
+      this.deleteKeyIfCurrent(entry);
+      this.runningCount -= 1;
+      this.drain();
+    }
+  }
+
+  private deleteKeyIfCurrent<T>(entry: TaskEntry<T>): void {
+    if (!entry.inFlightKey) {
+      return;
+    }
+    if (this.keyedTasks.get(entry.inFlightKey) === entry) {
+      this.keyedTasks.delete(entry.inFlightKey);
+    }
+  }
+}
+
+export const backgroundTaskScheduler = new BackgroundTaskScheduler();

--- a/src/web-ui/src/tools/editor/services/MonacoStartupWarmup.test.ts
+++ b/src/web-ui/src/tools/editor/services/MonacoStartupWarmup.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { scheduleMonacoStartupWarmup } from './MonacoStartupWarmup';
+
+describe('scheduleMonacoStartupWarmup', () => {
+  it('schedules Monaco initialization as low-priority idle background work', async () => {
+    const initializeMonaco = vi.fn(async () => undefined);
+    const initializeThemeSync = vi.fn(async () => undefined);
+    const signal = { aborted: false } as AbortSignal;
+    const schedule = vi.fn((task: (signal: AbortSignal) => Promise<void>, options: unknown) => ({
+      promise: task(signal),
+      cancel: vi.fn(),
+      options,
+    }));
+
+    const handle = scheduleMonacoStartupWarmup({
+      scheduler: { schedule },
+      initializeMonaco,
+      initializeThemeSync,
+    });
+
+    expect(schedule).toHaveBeenCalledWith(expect.any(Function), {
+      idle: true,
+      inFlightKey: 'startup:monaco-warmup',
+      priority: 'low',
+    });
+    await expect(handle.promise).resolves.toBeUndefined();
+    expect(initializeMonaco).toHaveBeenCalledTimes(1);
+    expect(initializeThemeSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips theme sync when the warmup task is cancelled before Monaco resolves', async () => {
+    const initializeMonaco = vi.fn(async () => undefined);
+    const initializeThemeSync = vi.fn(async () => undefined);
+    const signal = { aborted: true } as AbortSignal;
+    const schedule = vi.fn((task: (signal: AbortSignal) => Promise<void>, options: unknown) => ({
+      promise: task(signal),
+      cancel: vi.fn(),
+      options,
+    }));
+
+    const handle = scheduleMonacoStartupWarmup({
+      scheduler: { schedule },
+      initializeMonaco,
+      initializeThemeSync,
+    });
+
+    await expect(handle.promise).resolves.toBeUndefined();
+    expect(initializeMonaco).toHaveBeenCalledTimes(1);
+    expect(initializeThemeSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/tools/editor/services/MonacoStartupWarmup.ts
+++ b/src/web-ui/src/tools/editor/services/MonacoStartupWarmup.ts
@@ -1,0 +1,63 @@
+import {
+  backgroundTaskScheduler,
+  type BackgroundTaskHandle,
+} from '@/shared/utils/backgroundTaskScheduler';
+import { createLogger } from '@/shared/utils/logger';
+
+const log = createLogger('MonacoStartupWarmup');
+
+interface SchedulerLike {
+  schedule<T>(
+    task: (signal: AbortSignal) => Promise<T> | T,
+    options: {
+      idle: boolean;
+      inFlightKey: string;
+      priority: 'low';
+    }
+  ): BackgroundTaskHandle<T>;
+}
+
+interface MonacoStartupWarmupOptions {
+  scheduler?: SchedulerLike;
+  initializeMonaco?: () => Promise<void>;
+  initializeThemeSync?: () => Promise<void>;
+}
+
+async function defaultInitializeMonaco(): Promise<void> {
+  const { MonacoManager } = await import('./MonacoInitManager');
+  await MonacoManager.initialize();
+}
+
+async function defaultInitializeThemeSync(): Promise<void> {
+  const { monacoThemeSync } = await import('@/infrastructure/theme/integrations/MonacoThemeSync');
+  await monacoThemeSync.initialize();
+}
+
+export function scheduleMonacoStartupWarmup(
+  options: MonacoStartupWarmupOptions = {}
+): BackgroundTaskHandle<void> {
+  const scheduler = options.scheduler ?? backgroundTaskScheduler;
+  const initializeMonaco = options.initializeMonaco ?? defaultInitializeMonaco;
+  const initializeThemeSync = options.initializeThemeSync ?? defaultInitializeThemeSync;
+
+  return scheduler.schedule(async (signal) => {
+    try {
+      await initializeMonaco();
+      if (signal.aborted) {
+        return;
+      }
+      await initializeThemeSync();
+      log.info('Monaco startup warmup completed');
+    } catch (error) {
+      if (signal.aborted) {
+        return;
+      }
+      log.warn('Monaco startup warmup failed', error);
+      throw error;
+    }
+  }, {
+    idle: true,
+    inFlightKey: 'startup:monaco-warmup',
+    priority: 'low',
+  });
+}

--- a/src/web-ui/src/tools/git/services/GitService.test.ts
+++ b/src/web-ui/src/tools/git/services/GitService.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { gitService } from './GitService';
+
+const gitApiMocks = vi.hoisted(() => ({
+  commit: vi.fn(),
+  push: vi.fn(),
+  resetFiles: vi.fn(),
+}));
+
+const gitStateManagerMock = vi.hoisted(() => ({
+  refresh: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/api', () => ({
+  gitAPI: gitApiMocks,
+}));
+
+vi.mock('@/infrastructure/i18n', () => ({
+  i18nService: {
+    t: (key: string) => key,
+  },
+}));
+
+vi.mock('../state/GitStateManager', () => ({
+  gitStateManager: gitStateManagerMock,
+}));
+
+const repositoryPath = 'D:/workspace/BitFun';
+
+describe('GitService dangerous operation refresh guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    gitStateManagerMock.refresh.mockResolvedValue(undefined);
+    gitApiMocks.commit.mockResolvedValue({ success: true });
+    gitApiMocks.push.mockResolvedValue({ success: true });
+    gitApiMocks.resetFiles.mockResolvedValue({ success: true });
+  });
+
+  it('forces a fresh basic/status refresh before committing', async () => {
+    const order: string[] = [];
+    gitStateManagerMock.refresh.mockImplementation(async () => {
+      order.push('refresh');
+    });
+    gitApiMocks.commit.mockImplementation(async () => {
+      order.push('commit');
+      return { success: true };
+    });
+
+    await gitService.commit(repositoryPath, { message: 'test' });
+
+    expect(order).toEqual(['refresh', 'commit']);
+    expect(gitStateManagerMock.refresh).toHaveBeenCalledWith(repositoryPath, {
+      force: true,
+      layers: ['basic', 'status'],
+      reason: 'operation',
+      silent: true,
+    });
+  });
+
+  it('forces a fresh basic/status refresh before push and reset operations', async () => {
+    await gitService.push(repositoryPath);
+    await gitService.resetFiles(repositoryPath, ['src/app.ts'], false);
+
+    expect(gitStateManagerMock.refresh).toHaveBeenCalledTimes(2);
+    expect(gitApiMocks.push).toHaveBeenCalledTimes(1);
+    expect(gitApiMocks.resetFiles).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/tools/git/services/GitService.ts
+++ b/src/web-ui/src/tools/git/services/GitService.ts
@@ -6,6 +6,7 @@ import { gitAPI } from '@/infrastructure/api';
 import { createLogger } from '@/shared/utils/logger';
 import { measureAsync } from '@/shared/utils/timing';
 import { i18nService } from '@/infrastructure/i18n';
+import { gitStateManager } from '../state/GitStateManager';
 
 const log = createLogger('GitService');
 export type { 
@@ -68,6 +69,15 @@ export class GitService {
     expiredPaths.forEach(path => {
       this.nonGitRepositoryCache.delete(path);
       this.cacheTimestamps.delete(path);
+    });
+  }
+
+  private async ensureFreshOperationState(repositoryPath: string): Promise<void> {
+    await gitStateManager.refresh(repositoryPath, {
+      force: true,
+      layers: ['basic', 'status'],
+      reason: 'operation',
+      silent: true,
     });
   }
 
@@ -275,6 +285,7 @@ export class GitService {
    */
   async commit(repositoryPath: string, params: GitCommitParams): Promise<GitOperationResult> {
     try {
+      await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.commit(repositoryPath, params);
       return result;
     } catch (error) {
@@ -291,6 +302,7 @@ export class GitService {
    */
   async push(repositoryPath: string, params: GitPushParams = {}): Promise<GitOperationResult> {
     try {
+      await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.push(repositoryPath, params);
       return result;
     } catch (error) {
@@ -307,6 +319,7 @@ export class GitService {
    */
   async pull(repositoryPath: string, params: GitPullParams = {}): Promise<GitOperationResult> {
     try {
+      await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.pull(repositoryPath, params);
       return result;
     } catch (error) {
@@ -323,6 +336,7 @@ export class GitService {
    */
   async checkoutBranch(repositoryPath: string, branchName: string): Promise<GitOperationResult> {
     try {
+      await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.checkoutBranch(repositoryPath, branchName);
       return result;
     } catch (error) {
@@ -339,6 +353,7 @@ export class GitService {
    */
   async createBranch(repositoryPath: string, branchName: string, startPoint?: string): Promise<GitOperationResult> {
     try {
+      await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.createBranch(repositoryPath, branchName, startPoint);
       return result;
     } catch (error) {
@@ -355,6 +370,7 @@ export class GitService {
    */
   async deleteBranch(repositoryPath: string, branchName: string, force: boolean = false): Promise<GitOperationResult> {
     try {
+      await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.deleteBranch(repositoryPath, branchName, force);
       return result;
     } catch (error) {
@@ -384,6 +400,7 @@ export class GitService {
    */
   async resetFiles(repositoryPath: string, files: string[], staged: boolean = false): Promise<GitOperationResult> {
     try {
+      await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.resetFiles(repositoryPath, files, staged);
       return result;
     } catch (error) {
@@ -400,6 +417,7 @@ export class GitService {
    */
   async resetToCommit(repositoryPath: string, commitHash: string, mode: 'soft' | 'mixed' | 'hard' = 'mixed'): Promise<GitOperationResult> {
     try {
+      await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.resetToCommit(repositoryPath, commitHash, mode);
       return result;
     } catch (error) {
@@ -443,6 +461,7 @@ export class GitService {
    */
   async cherryPick(repositoryPath: string, commitHash: string, noCommit: boolean = false): Promise<GitOperationResult> {
     try {
+      await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.cherryPick(repositoryPath, commitHash, noCommit);
       return result;
     } catch (error) {
@@ -459,6 +478,7 @@ export class GitService {
    */
   async cherryPickAbort(repositoryPath: string): Promise<GitOperationResult> {
     try {
+      await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.cherryPickAbort(repositoryPath);
       return result;
     } catch (error) {
@@ -475,6 +495,7 @@ export class GitService {
    */
   async cherryPickContinue(repositoryPath: string): Promise<GitOperationResult> {
     try {
+      await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.cherryPickContinue(repositoryPath);
       return result;
     } catch (error) {

--- a/src/web-ui/src/tools/git/services/WorkspaceGitInitializer.test.ts
+++ b/src/web-ui/src/tools/git/services/WorkspaceGitInitializer.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const workspaceManagerMock = vi.hoisted(() => ({
+  addEventListener: vi.fn(() => vi.fn()),
+  getState: vi.fn(() => ({
+    currentWorkspace: {
+      rootPath: 'D:/workspace/BitFun',
+    },
+  })),
+}));
+
+const gitStateManagerMock = vi.hoisted(() => ({
+  refresh: vi.fn(async () => undefined),
+  invalidateCache: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/services/business/workspaceManager', () => ({
+  workspaceManager: workspaceManagerMock,
+}));
+
+vi.mock('../state/GitStateManager', () => ({
+  gitStateManager: gitStateManagerMock,
+}));
+
+import { workspaceGitInitializer } from './WorkspaceGitInitializer';
+
+describe('WorkspaceGitInitializer startup refresh', () => {
+  it('refreshes only the basic Git layer for the current workspace on startup', async () => {
+    workspaceGitInitializer.start();
+    await Promise.resolve();
+
+    expect(gitStateManagerMock.refresh).toHaveBeenCalledWith('D:/workspace/BitFun', {
+      layers: ['basic'],
+      reason: 'mount',
+      force: true,
+    });
+  });
+});

--- a/src/web-ui/src/tools/git/services/WorkspaceGitInitializer.ts
+++ b/src/web-ui/src/tools/git/services/WorkspaceGitInitializer.ts
@@ -65,7 +65,7 @@ class WorkspaceGitInitializer {
     try {
       this.currentWorkspacePath = workspacePath;
       await gitStateManager.refresh(workspacePath, {
-        layers: ['basic', 'status'],
+        layers: ['basic'],
         reason: 'mount',
         force: true,
       });
@@ -92,7 +92,7 @@ class WorkspaceGitInitializer {
       }
       this.currentWorkspacePath = workspacePath;
       await gitStateManager.refresh(workspacePath, {
-        layers: ['basic', 'status'],
+        layers: ['basic'],
         reason: 'mount',
         force: true,
       });

--- a/src/web-ui/src/tools/git/state/GitStateManager.test.ts
+++ b/src/web-ui/src/tools/git/state/GitStateManager.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GitStateManager } from './GitStateManager';
+
+const gitApiMocks = vi.hoisted(() => ({
+  isGitRepository: vi.fn(),
+  getRepository: vi.fn(),
+  getStatus: vi.fn(),
+  getBranches: vi.fn(),
+  getCommits: vi.fn(),
+}));
+
+const gitEventServiceMock = vi.hoisted(() => ({
+  on: vi.fn(),
+  emit: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/api', () => ({
+  gitAPI: gitApiMocks,
+}));
+
+vi.mock('../services/GitEventService', () => ({
+  gitEventService: gitEventServiceMock,
+}));
+
+vi.mock('@/infrastructure/event-bus', () => ({
+  globalEventBus: {
+    emit: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/utils/debugProbe', () => ({
+  sendDebugProbe: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/i18n', () => ({
+  i18nService: {
+    t: (key: string) => key,
+  },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const repositoryPath = 'D:/workspace/BitFun';
+
+describe('GitStateManager refresh performance guards', () => {
+  let manager: GitStateManager;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    GitStateManager.resetInstance();
+    manager = GitStateManager.getInstance();
+    manager.setCacheConfig({ basic: 0, status: 0, detailed: 0 });
+
+    gitApiMocks.isGitRepository.mockResolvedValue(true);
+    gitApiMocks.getRepository.mockResolvedValue({
+      path: repositoryPath,
+      name: 'BitFun',
+      current_branch: 'main',
+      is_bare: false,
+      has_changes: true,
+      remotes: ['origin'],
+    });
+    gitApiMocks.getStatus.mockResolvedValue({
+      staged: [],
+      unstaged: [],
+      untracked: [],
+      conflicts: [],
+      current_branch: 'main',
+      ahead: 0,
+      behind: 0,
+    });
+  });
+
+  afterEach(() => {
+    manager.dispose();
+    GitStateManager.resetInstance();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('refreshes the basic layer without fetching full status', async () => {
+    const refresh = manager.refresh(repositoryPath, {
+      layers: ['basic'],
+      force: true,
+      reason: 'mount',
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await refresh;
+
+    expect(gitApiMocks.isGitRepository).toHaveBeenCalledTimes(1);
+    expect(gitApiMocks.getRepository).toHaveBeenCalledTimes(1);
+    expect(gitApiMocks.getStatus).not.toHaveBeenCalled();
+    expect(manager.getState(repositoryPath)).toMatchObject({
+      isRepository: true,
+      currentBranch: 'main',
+      hasChanges: true,
+    });
+  });
+
+  it('merges duplicate mount refreshes for the same repository and layer', async () => {
+    const first = manager.refresh(repositoryPath, {
+      layers: ['basic', 'status'],
+      reason: 'mount',
+    });
+    const second = manager.refresh(repositoryPath, {
+      layers: ['basic', 'status'],
+      reason: 'mount',
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await Promise.all([first, second]);
+
+    expect(gitApiMocks.getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run force refresh concurrently with an in-flight refresh', async () => {
+    const firstStatus = deferred<Awaited<ReturnType<typeof gitApiMocks.getStatus>>>();
+    gitApiMocks.getStatus
+      .mockReturnValueOnce(firstStatus.promise)
+      .mockResolvedValueOnce({
+        staged: [],
+        unstaged: [{ path: 'changed.ts', status: 'modified' }],
+        untracked: [],
+        conflicts: [],
+        current_branch: 'main',
+        ahead: 0,
+        behind: 0,
+      });
+
+    const first = manager.refresh(repositoryPath, {
+      layers: ['basic', 'status'],
+      force: true,
+      reason: 'mount',
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    await Promise.resolve();
+    expect(gitApiMocks.getStatus).toHaveBeenCalledTimes(1);
+
+    const forced = manager.refresh(repositoryPath, {
+      layers: ['basic', 'status'],
+      force: true,
+      reason: 'operation',
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    await Promise.resolve();
+
+    expect(gitApiMocks.getStatus).toHaveBeenCalledTimes(1);
+
+    firstStatus.resolve({
+      staged: [],
+      unstaged: [],
+      untracked: [],
+      conflicts: [],
+      current_branch: 'main',
+      ahead: 0,
+      behind: 0,
+    });
+
+    await first;
+    await forced;
+    expect(gitApiMocks.getStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates an in-flight refresh failure to non-force joiners', async () => {
+    const firstStatus = deferred<Awaited<ReturnType<typeof gitApiMocks.getStatus>>>();
+    const failure = new Error('status failed');
+    gitApiMocks.getStatus.mockReturnValueOnce(firstStatus.promise);
+
+    const first = manager.refresh(repositoryPath, {
+      layers: ['basic', 'status'],
+      force: true,
+      reason: 'mount',
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    await Promise.resolve();
+
+    const second = manager.refresh(repositoryPath, {
+      layers: ['basic', 'status'],
+      reason: 'mount',
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    await Promise.resolve();
+
+    firstStatus.reject(failure);
+
+    await expect(first).rejects.toThrow('status failed');
+    await expect(second).rejects.toThrow('status failed');
+    expect(gitApiMocks.getStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/tools/git/state/GitStateManager.ts
+++ b/src/web-ui/src/tools/git/state/GitStateManager.ts
@@ -329,9 +329,17 @@ export class GitStateManager {
     silent: boolean
   ): Promise<void> {
     const existingLock = this.refreshLocks.get(repositoryPath);
-    if (existingLock && !force) {
-      await existingLock;
-      return;
+    if (existingLock) {
+      if (!force) {
+        await existingLock;
+        return;
+      }
+      try {
+        await existingLock;
+      } catch {
+        // A force refresh after a failed in-flight refresh should still get a
+        // chance to rebuild fresh state.
+      }
     }
 
     const startedAt = nowMs();
@@ -377,7 +385,7 @@ export class GitStateManager {
 
 
         if (layersToRefresh.includes('basic') || layersToRefresh.includes('status')) {
-          await this.refreshBasicAndStatus(repositoryPath);
+          await this.refreshBasicAndStatus(repositoryPath, layersToRefresh);
         }
 
         if (layersToRefresh.includes('detailed')) {
@@ -446,7 +454,10 @@ export class GitStateManager {
   /**
    * Refresh basic + status layers.
    */
-  private async refreshBasicAndStatus(repositoryPath: string): Promise<void> {
+  private async refreshBasicAndStatus(
+    repositoryPath: string,
+    layersToRefresh: GitStateLayer[]
+  ): Promise<void> {
     try {
       const isRepo = await gitAPI.isGitRepository(repositoryPath);
 
@@ -461,6 +472,17 @@ export class GitStateManager {
           unstaged: [],
           untracked: [],
           conflicts: [],
+        });
+        return;
+      }
+
+      const shouldRefreshStatus = layersToRefresh.includes('status');
+      if (!shouldRefreshStatus) {
+        const repository = await gitAPI.getRepository(repositoryPath);
+        this.updateState(repositoryPath, {
+          isRepository: true,
+          currentBranch: repository.current_branch || repository.branch || null,
+          hasChanges: Boolean(repository.has_changes),
         });
         return;
       }


### PR DESCRIPTION
## Summary

This PR continues the startup/session performance work after the previous startup readiness PR was merged. It is intentionally scoped to the next milestone only and does not submit design documents or local baseline artifacts.

## Optimized Scenarios

- Early startup after-render work: editor config preload and Monaco warmup no longer block `initializeAfterRender` completion.
- Startup Git state: workspace mount now refreshes only the basic repository layer instead of full file status.
- Git safety operations: commit/push/pull/checkout/reset/cherry-pick paths force a fresh basic+status refresh before running, so startup status deferral does not execute dangerous operations from stale state.
- Historical session metadata load: persisted sessions read `ai.models` and `ai.default_models` once per initialization pass, and a single bad metadata item no longer drops the rest of the session list.

## Changes

- Add a bounded frontend background task scheduler with priority, concurrency limit, idle execution, cancellation, and in-flight key dedupe.
- Move editor config preload and Monaco startup warmup into low-priority idle background tasks.
- Split Git basic-only refresh from full status refresh and preserve non-force join semantics while allowing force refresh to run after an in-flight refresh settles.
- Add operation-time fresh Git state protection for dangerous Git actions.
- Batch model config reads during persisted session metadata processing and isolate per-session processing errors.
- Add focused regression tests for scheduler behavior, Monaco idle warmup, Git refresh semantics, dangerous-operation refresh, workspace Git startup refresh, and session metadata batching/isolation.

## Performance Results

Local release-like startup sampling, 3 runs each. M3 was re-sampled on top of latest `upstream/main` after the previous PR had already merged.

| Metric | M1 baseline | M2 previous PR | M3 current | Result |
|---|---:|---:|---:|---:|
| Start Application avg | 1249.3ms | 1038.5ms | 795.3ms | -36.3% vs M1, -23.4% vs M2 |
| After Render avg | 1165.1ms | 969.4ms | 756.9ms | -35.0% vs M1, -21.9% vs M2 |
| Main Window Shown avg | 2285.3ms | 2004.4ms | 2010.5ms | roughly flat vs M2, -12.0% vs M1 |
| Interactive Shell Ready avg | 2447.2ms | 2196.3ms | 2224.1ms | roughly flat vs M2, -9.1% vs M1 |
| Startup API count avg | 21.0 | 20.0 | 13.7 | -7.3 calls vs M1 |
| Startup request bytes avg | 1020.0 | 1006.0 | 659.3 | -35.4% vs M1 |
| Startup response bytes avg | 14561.0 | 13559.0 | 11411.3 | -21.6% vs M1 |
| Remote command count avg | 0.0 | 0.0 | 0.0 | no local increase |

The main gain is not native/WebView creation time; it is lower after-render contention and lower startup IPC/serialization pressure.

## Risks / Follow-ups

- Startup Git refresh is now basic-only. Full file status is intentionally delayed, and panes that need full status must request it; dangerous operations force-refresh before execution.
- Dangerous Git operations now pay one forced basic+status refresh. This is a safety tradeoff and can add latency, especially in remote workspaces.
- Monaco is warmed up through idle scheduling. First editor/diff open should still be manually smoke-tested; if it regresses, the fallback is to move warmup earlier or revert that slice.
- Real remote SSH workspace sampling was not available locally. Local counters show no remote command increase, but true remote RTT/payload behavior still needs verification with a real remote workspace.
- Existing Vite chunk-size / dynamic-import warnings remain. This PR does not hide them by changing thresholds.
- No Rust session API rewrite, turns pagination, Web Worker conversion, native splash, or remote aggregation protocol changes are included.

## Validation

- `pnpm --dir src/web-ui exec vitest run src/shared/utils/backgroundTaskScheduler.test.ts src/tools/editor/services/MonacoStartupWarmup.test.ts src/tools/git/state/GitStateManager.test.ts src/tools/git/services/WorkspaceGitInitializer.test.ts src/tools/git/services/GitService.test.ts src/flow_chat/store/FlowChatStore.test.ts` (6 files / 26 tests)
- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run` (129 files / 674 tests)
- `cargo check -p bitfun-desktop`
- `cargo test -p bitfun-desktop` (27 tests)
- `pnpm run desktop:build:release-fast` passed; existing Vite chunk-size / dynamic-import warnings are still present.
- `git diff --cached --check`
- `git diff --check`