### PR TITLE
Fix ACP file path resolution for completed tool cards

### DIFF
--- a/src/crates/acp/src/client/manager.rs
+++ b/src/crates/acp/src/client/manager.rs
@@ -52,7 +52,10 @@ use super::requirements::{
 use super::session_options::{model_config_id, session_options_from_state, AcpSessionOptions};
 use super::session_persistence::AcpSessionPersistence;
 pub use super::session_persistence::CreateAcpFlowSessionRecordResponse;
-use super::stream::{acp_dispatch_to_stream_events, AcpClientStreamEvent, AcpStreamRoundTracker};
+use super::stream::{
+    acp_dispatch_to_stream_events_with_tracker, AcpClientStreamEvent, AcpStreamRoundTracker,
+    AcpToolCallTracker,
+};
 use super::tool::AcpAgentTool;
 
 const CONFIG_PATH: &str = "acp_clients";
@@ -1018,11 +1021,17 @@ impl AcpClientService {
                 .ok_or_else(|| BitFunError::service("ACP session was not initialized"))?;
             active.send_prompt(prompt).map_err(protocol_error)?;
             let mut round_tracker = AcpStreamRoundTracker::new();
+            let mut tool_call_tracker = AcpToolCallTracker::new();
 
             loop {
                 match active.read_update().await.map_err(protocol_error)? {
                     SessionMessage::SessionMessage(dispatch) => {
-                        for event in acp_dispatch_to_stream_events(dispatch).await? {
+                        for event in acp_dispatch_to_stream_events_with_tracker(
+                            dispatch,
+                            &mut tool_call_tracker,
+                        )
+                        .await?
+                        {
                             for event in round_tracker.apply(event) {
                                 on_event(event)?;
                             }

--- a/src/crates/acp/src/client/stream.rs
+++ b/src/crates/acp/src/client/stream.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use agent_client_protocol::schema::{
     ContentBlock, ContentChunk, SessionNotification, SessionUpdate, ToolCall, ToolCallContent,
     ToolCallStatus, ToolCallUpdate,
@@ -32,6 +34,19 @@ enum AcpStreamItemKind {
 pub(super) struct AcpStreamRoundTracker {
     next_round_index: usize,
     last_item_kind: Option<AcpStreamItemKind>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct AcpToolCallTracker {
+    calls: HashMap<String, AcpToolCallSnapshot>,
+}
+
+#[derive(Debug, Clone)]
+struct AcpToolCallSnapshot {
+    title: String,
+    tool_name: String,
+    raw_input: Option<serde_json::Value>,
+    kind: Option<agent_client_protocol::schema::ToolKind>,
 }
 
 impl AcpStreamRoundTracker {
@@ -82,8 +97,9 @@ impl AcpStreamRoundTracker {
     }
 }
 
-pub async fn acp_dispatch_to_stream_events(
+pub(super) async fn acp_dispatch_to_stream_events_with_tracker(
     dispatch: agent_client_protocol::Dispatch,
+    tracker: &mut AcpToolCallTracker,
 ) -> BitFunResult<Vec<AcpClientStreamEvent>> {
     let mut events = Vec::new();
     MatchDispatch::new(dispatch)
@@ -100,12 +116,10 @@ pub async fn acp_dispatch_to_stream_events(
                     }
                 }
                 SessionUpdate::ToolCall(tool_call) => {
-                    events.extend(acp_tool_call_events(tool_call));
+                    events.extend(acp_tool_call_events(tool_call, tracker));
                 }
                 SessionUpdate::ToolCallUpdate(tool_call_update) => {
-                    if let Some(event) = acp_tool_call_update_event(tool_call_update) {
-                        events.push(event);
-                    }
+                    events.extend(acp_tool_call_update_events(tool_call_update, tracker));
                 }
                 _ => {}
             }
@@ -124,16 +138,73 @@ fn content_chunk_text(chunk: ContentChunk) -> Option<String> {
     }
 }
 
-fn acp_tool_call_events(tool_call: ToolCall) -> Vec<AcpClientStreamEvent> {
+impl AcpToolCallTracker {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    fn upsert_from_call(
+        &mut self,
+        tool_id: String,
+        title: String,
+        raw_input: Option<serde_json::Value>,
+        kind: Option<agent_client_protocol::schema::ToolKind>,
+    ) -> AcpToolCallSnapshot {
+        let tool_name = acp_tool_name(&title, raw_input.as_ref(), kind.as_ref());
+        let snapshot = AcpToolCallSnapshot {
+            title,
+            tool_name,
+            raw_input,
+            kind,
+        };
+        self.calls.insert(tool_id, snapshot.clone());
+        snapshot
+    }
+
+    fn update_from_fields(
+        &mut self,
+        tool_id: &str,
+        title: Option<String>,
+        raw_input: Option<serde_json::Value>,
+        kind: Option<agent_client_protocol::schema::ToolKind>,
+    ) -> AcpToolCallSnapshot {
+        let previous = self.calls.get(tool_id).cloned();
+        let title = title
+            .or_else(|| previous.as_ref().map(|snapshot| snapshot.title.clone()))
+            .unwrap_or_else(|| tool_id.to_string());
+        let raw_input = raw_input.or_else(|| {
+            previous
+                .as_ref()
+                .and_then(|snapshot| snapshot.raw_input.clone())
+        });
+        let kind = kind.or_else(|| previous.as_ref().and_then(|snapshot| snapshot.kind.clone()));
+        let tool_name = acp_tool_name(&title, raw_input.as_ref(), kind.as_ref());
+        let snapshot = AcpToolCallSnapshot {
+            title,
+            tool_name,
+            raw_input,
+            kind,
+        };
+        self.calls.insert(tool_id.to_string(), snapshot.clone());
+        snapshot
+    }
+}
+
+fn acp_tool_call_events(
+    tool_call: ToolCall,
+    tracker: &mut AcpToolCallTracker,
+) -> Vec<AcpClientStreamEvent> {
     let tool_id = tool_call.tool_call_id.to_string();
-    let tool_name = acp_tool_name(
-        &tool_call.title,
-        tool_call.raw_input.as_ref(),
-        Some(&tool_call.kind),
+    let snapshot = tracker.upsert_from_call(
+        tool_id.clone(),
+        tool_call.title.clone(),
+        tool_call.raw_input.clone(),
+        Some(tool_call.kind.clone()),
     );
+    let tool_name = snapshot.tool_name;
     let params = normalize_tool_params(
         &tool_name,
-        tool_call.raw_input.clone().unwrap_or_else(|| {
+        snapshot.raw_input.clone().unwrap_or_else(|| {
             serde_json::json!({
                 "title": tool_call.title,
                 "kind": format!("{:?}", tool_call.kind),
@@ -185,18 +256,31 @@ fn acp_tool_call_events(tool_call: ToolCall) -> Vec<AcpClientStreamEvent> {
     events
 }
 
-fn acp_tool_call_update_event(update: ToolCallUpdate) -> Option<AcpClientStreamEvent> {
+fn acp_tool_call_update_events(
+    update: ToolCallUpdate,
+    tracker: &mut AcpToolCallTracker,
+) -> Vec<AcpClientStreamEvent> {
     let tool_id = update.tool_call_id.to_string();
-    let title = update.fields.title.unwrap_or_else(|| tool_id.clone());
-    let tool_name = acp_tool_name(
-        &title,
-        update.fields.raw_input.as_ref(),
-        update.fields.kind.as_ref(),
+    let snapshot = tracker.update_from_fields(
+        &tool_id,
+        update.fields.title.clone(),
+        update.fields.raw_input.clone(),
+        update.fields.kind.clone(),
     );
+    let tool_name = snapshot.tool_name.clone();
 
     match update.fields.status {
         Some(ToolCallStatus::Completed) => {
-            Some(AcpClientStreamEvent::ToolEvent(ToolEventData::Completed {
+            let mut events = Vec::new();
+            if let Some(raw_input) = snapshot.raw_input {
+                events.push(AcpClientStreamEvent::ToolEvent(ToolEventData::Started {
+                    tool_id: tool_id.clone(),
+                    tool_name: tool_name.clone(),
+                    params: normalize_tool_params(&tool_name, raw_input),
+                    timeout_seconds: None,
+                }));
+            }
+            events.push(AcpClientStreamEvent::ToolEvent(ToolEventData::Completed {
                 tool_id,
                 tool_name,
                 result: acp_tool_result_value(
@@ -210,10 +294,20 @@ fn acp_tool_call_update_event(update: ToolCallUpdate) -> Option<AcpClientStreamE
                 preflight_ms: None,
                 confirmation_wait_ms: None,
                 execution_ms: None,
-            }))
+            }));
+            events
         }
         Some(ToolCallStatus::Failed) => {
-            Some(AcpClientStreamEvent::ToolEvent(ToolEventData::Failed {
+            let mut events = Vec::new();
+            if let Some(raw_input) = snapshot.raw_input {
+                events.push(AcpClientStreamEvent::ToolEvent(ToolEventData::Started {
+                    tool_id: tool_id.clone(),
+                    tool_name: tool_name.clone(),
+                    params: normalize_tool_params(&tool_name, raw_input),
+                    timeout_seconds: None,
+                }));
+            }
+            events.push(AcpClientStreamEvent::ToolEvent(ToolEventData::Failed {
                 tool_id,
                 tool_name,
                 error: acp_tool_error_text(
@@ -225,33 +319,37 @@ fn acp_tool_call_update_event(update: ToolCallUpdate) -> Option<AcpClientStreamE
                 preflight_ms: None,
                 confirmation_wait_ms: None,
                 execution_ms: None,
-            }))
+            }));
+            events
         }
         Some(ToolCallStatus::InProgress) | Some(ToolCallStatus::Pending) | Some(_) => {
             let params = normalize_tool_params(
                 &tool_name,
-                update.fields.raw_input.unwrap_or_else(|| {
+                snapshot.raw_input.unwrap_or_else(|| {
                     serde_json::json!({
-                        "title": title,
+                        "title": snapshot.title,
                     })
                 }),
             );
-            Some(AcpClientStreamEvent::ToolEvent(ToolEventData::Started {
+            vec![AcpClientStreamEvent::ToolEvent(ToolEventData::Started {
                 tool_id,
                 tool_name,
                 params,
                 timeout_seconds: None,
-            }))
+            })]
         }
-        None => update.fields.raw_input.map(|params| {
-            let params = normalize_tool_params(&tool_name, params);
-            AcpClientStreamEvent::ToolEvent(ToolEventData::Started {
-                tool_id,
-                tool_name,
-                params,
-                timeout_seconds: None,
+        None => snapshot
+            .raw_input
+            .map(|params| {
+                let params = normalize_tool_params(&tool_name, params);
+                vec![AcpClientStreamEvent::ToolEvent(ToolEventData::Started {
+                    tool_id,
+                    tool_name,
+                    params,
+                    timeout_seconds: None,
+                })]
             })
-        }),
+            .unwrap_or_default(),
     }
 }
 
@@ -305,6 +403,7 @@ fn protocol_error(error: impl std::fmt::Display) -> BitFunError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agent_client_protocol::schema::{ToolCallUpdateFields, ToolKind};
     use serde_json::json;
 
     fn tool_event(id: &str) -> AcpClientStreamEvent {
@@ -374,5 +473,54 @@ mod tests {
         events.extend(tracker.apply(AcpClientStreamEvent::AgentText("b".to_string())));
 
         assert_eq!(event_kinds(&events), vec!["round", "text", "text"]);
+    }
+
+    #[test]
+    fn tool_call_tracker_replays_cached_input_before_completed_update() {
+        let mut tracker = AcpToolCallTracker::new();
+        let in_progress = ToolCallUpdate::new(
+            "tool-1",
+            ToolCallUpdateFields::new()
+                .title("Edit file")
+                .kind(ToolKind::Edit)
+                .status(ToolCallStatus::InProgress)
+                .raw_input(json!({
+                    "path": "src/lib.rs",
+                    "oldString": "before",
+                    "newString": "after"
+                })),
+        );
+        let completed = ToolCallUpdate::new(
+            "tool-1",
+            ToolCallUpdateFields::new()
+                .status(ToolCallStatus::Completed)
+                .raw_output(json!({ "success": true })),
+        );
+
+        let first = acp_tool_call_update_events(in_progress, &mut tracker);
+        assert!(matches!(
+            first.first(),
+            Some(AcpClientStreamEvent::ToolEvent(
+                ToolEventData::Started { .. }
+            ))
+        ));
+
+        let second = acp_tool_call_update_events(completed, &mut tracker);
+        assert_eq!(second.len(), 2);
+        match &second[0] {
+            AcpClientStreamEvent::ToolEvent(ToolEventData::Started {
+                tool_name, params, ..
+            }) => {
+                assert_eq!(tool_name, "Edit");
+                assert_eq!(params["file_path"], "src/lib.rs");
+                assert_eq!(params["old_string"], "before");
+                assert_eq!(params["new_string"], "after");
+            }
+            other => panic!("expected cached Started event, got {other:?}"),
+        }
+        assert!(matches!(
+            second[1],
+            AcpClientStreamEvent::ToolEvent(ToolEventData::Completed { .. })
+        ));
     }
 }

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.test.tsx
@@ -314,4 +314,54 @@ describe('FileOperationToolCard', () => {
       },
     );
   });
+
+  it('renders completed ACP file cards from result locations when input has no path', async () => {
+    const toolItem: FlowToolItem = {
+      id: 'tool-1',
+      type: 'tool',
+      toolName: 'Write',
+      status: 'completed',
+      toolCall: {
+        id: 'call-1',
+        name: 'Write',
+        input: {
+          title: 'Run Write',
+        },
+      },
+      toolResult: {
+        success: true,
+        result: {
+          content: [],
+          locations: [
+            {
+              path: 'src/from-acp-location.ts',
+            },
+          ],
+        },
+      },
+    } as FlowToolItem;
+
+    const config: ToolCardConfig = {
+      toolName: 'Write',
+      displayName: 'Write',
+      icon: 'WRITE',
+      requiresConfirmation: false,
+      resultDisplayType: 'detailed',
+      description: 'Write a file',
+      displayMode: 'standard',
+    };
+
+    await act(async () => {
+      root.render(
+        <FileOperationToolCard
+          toolItem={toolItem}
+          config={config}
+          sessionId="session-1"
+        />
+      );
+    });
+
+    expect(container.textContent).toContain('from-acp-location.ts');
+    expect(container.textContent).not.toContain('toolCards.file.parsingPath');
+  });
 });

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -72,6 +72,16 @@ function firstStringValue(source: Record<string, unknown> | null | undefined, ke
   return '';
 }
 
+function pathFromAcpLocations(locations: unknown): string {
+  if (!Array.isArray(locations)) return '';
+  for (const location of locations) {
+    const object = objectValue(location);
+    const filePath = firstStringValue(object, ['path', 'file_path', 'filePath', 'uri']);
+    if (filePath) return filePath;
+  }
+  return '';
+}
+
 function isWindowsAbsolutePath(filePath: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(filePath);
 }
@@ -142,6 +152,10 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
     const resultPath = stringPath(result?.file_path) || stringPath(result?.filePath);
     if (resultPath) {
       return resultPath;
+    }
+    const resultLocationPath = pathFromAcpLocations(result?.locations);
+    if (resultLocationPath) {
+      return resultLocationPath;
     }
 
     const params = objectValue(partialParams || toolCall?.input);


### PR DESCRIPTION
 ## Summary

  Fixes ACP-backed file operation cards getting stuck on “解析文件路径中...” when Codex ACP omits `raw_input` from
  completed tool updates.

  ## What Changed

  - Preserve the latest ACP tool call input across a turn by tracking tool calls by `tool_call_id`.
  - Replay cached tool input before completed/failed ACP tool events so the FlowChat tool card keeps the resolved file
  path.
  - Add a frontend fallback that reads file paths from ACP result `locations`.
  - Add regression coverage for cached ACP tool input and ACP result-location path fallback.

  ## Root Cause

  Codex ACP can send file path data in an in-progress update, then send the completed update without `raw_input`. The
  previous bridge treated the completed event as final without preserving earlier params, leaving the frontend file card
  without a path.