### PR TITLE
fix(core): avoid session auto-save lock contention

### DIFF
--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -97,6 +97,21 @@ pub struct SessionManager {
     config: SessionManagerConfig,
 }
 
+#[derive(Clone)]
+struct SessionAutoSaveSnapshot {
+    session_id: String,
+    updated_at: SystemTime,
+    last_activity_at: SystemTime,
+    session: Session,
+}
+
+#[derive(Clone)]
+struct SessionCleanupCandidate {
+    session_id: String,
+    updated_at: SystemTime,
+    last_activity_at: SystemTime,
+}
+
 impl SessionManager {
     async fn resolve_model_context_window(model_id: &str) -> Option<usize> {
         let trimmed = model_id.trim();
@@ -213,6 +228,99 @@ impl SessionManager {
 
     fn should_persist_session(session: &Session) -> bool {
         Self::should_persist_session_kind(session.kind)
+    }
+
+    fn same_session_version(
+        session: &Session,
+        updated_at: SystemTime,
+        last_activity_at: SystemTime,
+    ) -> bool {
+        session.updated_at == updated_at && session.last_activity_at == last_activity_at
+    }
+
+    fn collect_auto_save_snapshots(
+        sessions: &DashMap<String, Session>,
+    ) -> Vec<SessionAutoSaveSnapshot> {
+        sessions
+            .iter()
+            .filter_map(|entry| {
+                let session = entry.value();
+                if !Self::should_persist_session(session) {
+                    return None;
+                }
+                Some(SessionAutoSaveSnapshot {
+                    session_id: session.session_id.clone(),
+                    updated_at: session.updated_at,
+                    last_activity_at: session.last_activity_at,
+                    session: session.clone(),
+                })
+            })
+            .collect()
+    }
+
+    fn auto_save_snapshot_is_current(
+        sessions: &DashMap<String, Session>,
+        snapshot: &SessionAutoSaveSnapshot,
+    ) -> bool {
+        sessions
+            .get(&snapshot.session_id)
+            .map(|session| {
+                Self::same_session_version(&session, snapshot.updated_at, snapshot.last_activity_at)
+            })
+            .unwrap_or(false)
+    }
+
+    fn auto_save_interval(interval: Duration) -> time::Interval {
+        time::interval_at(time::Instant::now() + interval, interval)
+    }
+
+    fn is_session_expired(session: &Session, now: SystemTime, timeout: Duration) -> bool {
+        now.duration_since(session.last_activity_at)
+            .map(|idle_duration| idle_duration > timeout)
+            .unwrap_or(false)
+    }
+
+    fn collect_expired_session_candidates(
+        sessions: &DashMap<String, Session>,
+        now: SystemTime,
+        timeout: Duration,
+    ) -> Vec<SessionCleanupCandidate> {
+        sessions
+            .iter()
+            .filter_map(|entry| {
+                let session = entry.value();
+                if !Self::is_session_expired(session, now, timeout) {
+                    return None;
+                }
+                Some(SessionCleanupCandidate {
+                    session_id: session.session_id.clone(),
+                    updated_at: session.updated_at,
+                    last_activity_at: session.last_activity_at,
+                })
+            })
+            .collect()
+    }
+
+    fn cleanup_candidate_matches_session(
+        session: &Session,
+        candidate: &SessionCleanupCandidate,
+        now: SystemTime,
+        timeout: Duration,
+    ) -> bool {
+        Self::same_session_version(session, candidate.updated_at, candidate.last_activity_at)
+            && Self::is_session_expired(session, now, timeout)
+    }
+
+    fn cleanup_snapshot_for_candidate(
+        sessions: &DashMap<String, Session>,
+        candidate: &SessionCleanupCandidate,
+        now: SystemTime,
+        timeout: Duration,
+    ) -> Option<Session> {
+        sessions.get(&candidate.session_id).and_then(|session| {
+            Self::cleanup_candidate_matches_session(&session, candidate, now, timeout)
+                .then(|| session.clone())
+        })
     }
 
     pub fn should_persist_session_id(&self, session_id: &str) -> bool {
@@ -2784,23 +2892,28 @@ impl SessionManager {
         let interval = self.config.auto_save_interval;
 
         tokio::spawn(async move {
-            let mut ticker = time::interval(interval);
+            let mut ticker = Self::auto_save_interval(interval);
 
             loop {
                 ticker.tick().await;
 
-                for entry in sessions.iter() {
-                    let session = entry.value();
-                    if !Self::should_persist_session(session) {
+                for snapshot in Self::collect_auto_save_snapshots(&sessions) {
+                    if !Self::auto_save_snapshot_is_current(&sessions, &snapshot) {
                         continue;
                     }
                     if let Some(workspace_path) =
-                        Self::effective_workspace_path_from_config(&session.config).await
+                        Self::effective_workspace_path_from_config(&snapshot.session.config).await
                     {
-                        if let Err(e) = persistence.save_session(&workspace_path, session).await {
+                        if !Self::auto_save_snapshot_is_current(&sessions, &snapshot) {
+                            continue;
+                        }
+                        if let Err(e) = persistence
+                            .save_session(&workspace_path, &snapshot.session)
+                            .await
+                        {
                             error!(
                                 "Failed to auto-save session: session_id={}, error={}",
-                                session.session_id, e
+                                snapshot.session_id, e
                             );
                         }
                     }
@@ -2826,38 +2939,55 @@ impl SessionManager {
                 ticker.tick().await;
 
                 let now = SystemTime::now();
-                let mut expired_sessions = Vec::new();
+                let candidates = Self::collect_expired_session_candidates(&sessions, now, timeout);
 
-                for entry in sessions.iter() {
-                    let session = entry.value();
-                    if let Ok(idle_duration) = now.duration_since(session.last_activity_at) {
-                        if idle_duration > timeout {
-                            expired_sessions.push(session.session_id.clone());
-                        }
-                    }
-                }
+                for candidate in candidates {
+                    debug!(
+                        "Cleaning up expired session: session_id={}",
+                        candidate.session_id
+                    );
 
-                for session_id in expired_sessions {
-                    debug!("Cleaning up expired session: session_id={}", session_id);
+                    let cleanup_now = SystemTime::now();
+                    let Some(session) = Self::cleanup_snapshot_for_candidate(
+                        &sessions,
+                        &candidate,
+                        cleanup_now,
+                        timeout,
+                    ) else {
+                        continue;
+                    };
 
-                    // Save before deleting
-                    if enable_persistence {
-                        if let Some(session) = sessions.get(&session_id) {
-                            if !Self::should_persist_session(&session) {
-                                context_store.delete_session(&session_id);
-                                sessions.remove(&session_id);
-                                continue;
-                            }
-                            if let Some(workspace_path) =
-                                Self::effective_workspace_path_from_config(&session.config).await
+                    if enable_persistence && Self::should_persist_session(&session) {
+                        if let Some(workspace_path) =
+                            Self::effective_workspace_path_from_config(&session.config).await
+                        {
+                            if Self::cleanup_snapshot_for_candidate(
+                                &sessions,
+                                &candidate,
+                                SystemTime::now(),
+                                timeout,
+                            )
+                            .is_some()
                             {
                                 let _ = persistence.save_session(&workspace_path, &session).await;
                             }
                         }
                     }
 
-                    context_store.delete_session(&session_id);
-                    sessions.remove(&session_id);
+                    let removal_now = SystemTime::now();
+                    if sessions
+                        .remove_if(&candidate.session_id, |_, session| {
+                            Self::cleanup_candidate_matches_session(
+                                session,
+                                &candidate,
+                                removal_now,
+                                timeout,
+                            )
+                        })
+                        .is_some()
+                    {
+                        context_store.delete_session(&candidate.session_id);
+                    }
                 }
             }
         });
@@ -2877,6 +3007,7 @@ mod tests {
     use crate::service::session::{
         DialogTurnData, ModelRoundData, ToolCallData, ToolItemData, ToolResultData, UserMessageData,
     };
+    use dashmap::try_result::TryResult;
     use serde_json::json;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
@@ -2940,6 +3071,44 @@ mod tests {
                 enable_persistence: false,
             },
         )
+    }
+
+    #[tokio::test]
+    async fn auto_save_interval_waits_before_first_tick() {
+        let mut ticker = SessionManager::auto_save_interval(Duration::from_millis(40));
+        let started = tokio::time::Instant::now();
+
+        ticker.tick().await;
+
+        assert!(started.elapsed() >= Duration::from_millis(30));
+    }
+
+    #[tokio::test]
+    async fn auto_save_snapshot_collection_releases_session_map_guards() {
+        let workspace = TestWorkspace::new();
+        let manager = in_memory_test_manager();
+        let session = manager
+            .create_session(
+                "Auto-save snapshot".to_string(),
+                "agent".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+
+        let snapshots = SessionManager::collect_auto_save_snapshots(&manager.sessions);
+        assert!(snapshots
+            .iter()
+            .any(|snapshot| snapshot.session_id == session.session_id));
+
+        match manager.sessions.try_get_mut(&session.session_id) {
+            TryResult::Present(_) => {}
+            TryResult::Absent => panic!("session should remain present"),
+            TryResult::Locked => panic!("snapshot collection should not retain session map guards"),
+        };
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- avoid holding DashMap session guards across async auto-save and cleanup awaits
- snapshot sessions before persistence work, then re-check session timestamps before saving or removing
- delay the first auto-save tick by one interval so freshly-created sessions are not immediately re-saved in tests/runtime startup

## Validation
- `cargo test --locked -p bitfun-core auto_save_ -- --nocapture`
- `cargo test --locked -p bitfun-core rollback_to_empty_history_clears_last_user_dialog_agent_type -- --nocapture`
- `cargo test --locked -p bitfun-core`
- `cargo check --workspace`

## Notes
- `cargo test --workspace` was also tried locally, but it is blocked by unrelated pre-existing desktop test compile errors in `src/apps/desktop/src/api/agentic_api.rs` where test `DialogTurnData` initializers are missing `agent_type`.
