### PR TITLE
fix(desktop): default close button to minimize to system tray

### DIFF
--- a/src/crates/core/src/service/config/types.rs
+++ b/src/crates/core/src/service/config/types.rs
@@ -92,7 +92,7 @@ impl ProjectConfig {
 
 /// App configuration.
 fn default_close_button_behavior() -> String {
-    "quit".to_string()
+    "minimize_to_tray".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/web-ui/src/app/layout/AppLayout.tsx
+++ b/src/web-ui/src/app/layout/AppLayout.tsx
@@ -421,11 +421,11 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
           }
 
           // Windows / Linux: read the user's close-button preference.
-          let behavior: CloseBehavior = 'quit';
+          let behavior: CloseBehavior = 'minimize_to_tray';
           try {
-            behavior = (await configManager.getConfig<CloseBehavior>('app.close_button_behavior')) ?? 'quit';
+            behavior = (await configManager.getConfig<CloseBehavior>('app.close_button_behavior')) ?? 'minimize_to_tray';
           } catch {
-            // Fall back to quit if config cannot be read.
+            // Fall back to minimize_to_tray if config cannot be read.
           }
 
           try {

--- a/src/web-ui/src/infrastructure/config/components/BasicsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/BasicsConfig.tsx
@@ -597,10 +597,10 @@ function BasicsWindowBehaviorSection() {
       try {
         setLoading(true);
         const v = await configManager.getConfig<CloseBehavior>('app.close_button_behavior');
-        if (!cancelled) setBehavior(v ?? 'quit');
+        if (!cancelled) setBehavior(v ?? 'minimize_to_tray');
       } catch {
         // Key absent on first launch — fall back to default silently.
-        if (!cancelled) setBehavior('quit');
+        if (!cancelled) setBehavior('minimize_to_tray');
       } finally {
         if (!cancelled) setLoading(false);
       }


### PR DESCRIPTION
## Summary
- Change the default `app.close_button_behavior` from `quit` to `minimize_to_tray` in core config defaults.
- Align Windows/Linux close-handler and settings UI fallbacks with the new default when the config key is missing or unreadable.

## Test plan
- [ ] Fresh install (or delete `app.close_button_behavior` from config): click window close on Windows/Linux → main window hides to tray, app keeps running.
- [ ] Settings → Basics → Close button action shows **Minimize to System Tray** by default.
- [ ] Set behavior to **Quit** and save → close button exits the app.
- [ ] macOS: close button still hides to Dock (unchanged).