### PR TITLE
test(tools): guard runtime assembly boundaries

### DIFF
--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -1113,6 +1113,11 @@ pub fn create_tool_registry() -> ToolRegistry {
   `ToolRegistry` 只保留对 `bitfun-agent-tools` generic registry 的兼容容器和动态工具入口。
   该切片仍不迁移 `ToolUseContext`、runtime manifest assembly、`GetToolSpecTool` 执行、
   product collapsed-tool catalog 或 concrete tool implementation。
+- Tool-runtime H3 start（2026-05-19）：先补 tool runtime provider/assembly 等价保护，再评估 runtime
+  owner 外移。当前新增 custom decorator + provider assembly guard，并锁定 manifest /
+  `GetToolSpec` unlock surface 的现有顺序与 stub contract；不迁移 `ToolUseContext`、
+  runtime manifest assembly、`GetToolSpecTool` 执行、snapshot decorator port 或 concrete
+  tool implementation。
 
 **验证：**
 
@@ -1845,7 +1850,8 @@ git diff -- package.json scripts/dev.cjs scripts/desktop-tauri-build.mjs scripts
 18. 已完成：`product-domains` runtime port/facade closure。已迁入 MiniApp storage-backed runtime-state facade、built-in seed plan / marker wire helper 与 function-agent Git/AI port-backed runtime facade，并补充 focused contract tests；core 只对 MiniApp deps/restart/recompile/sync/rollback 的状态持久化委托 facade，仍保留 `PathManager` 注入、filesystem IO、worker process execution、host dispatch 执行、built-in asset seeding/source-hash lookup、prompt template、JSON extraction 和 error mapping adapter。Git commit-message 与 Startchat work-state 产品路径已通过 core-owned Git/AI adapter 接入 function-agent facade；extracted JSON string 可委托 product-domain parser，但 JSON 提取、日志与错误映射仍在 core。Startchat 接线已用 no-HEAD diff fallback、非 Git 目录空状态和 `analyze_git=false` time-info 保护旧行为，`analyzed_at` 仍由 core 在 AI 分析完成后赋值。
 19. 已合入：H1 tool runtime migration baseline。已把纯 helper 从 runtime owner 中剥离：`StaticToolProviderGroup`、registry snapshot 到 manifest policy input、generic collapsed exposure 查询、`GetToolSpec` collapsed-load 纯收集规则、prompt-visible manifest definition 组装规则和 `GetToolSpec` catalog description 组装规则可由 `bitfun-agent-tools` 拥有；完整 collapsed 工具清单、runtime context 传递和 portable facts 边界回归已作为迁移前基线。
 20. 本轮完成：H2 core-owned tool runtime assembly closure。先在 core 内部建立 `ProductToolRuntimeAssembly` 单一 owner，收敛 static provider 安装和 snapshot decorator，并保持 legacy `create_tool_registry()`、global registry、dynamic MCP tools、manifest resolver、`GetToolSpecTool` 执行、`ToolUseContext` 和 concrete tools 的行为边界不变。后续若继续外移，必须进入 port/provider 设计和等价性证明，不得把 runtime manifest assembly、product collapsed-tool catalog、snapshot decorator 或 concrete tools 混成隐式结构调整。
-21. 后续独立评估：`bitfun-core default = []`、per-product feature set、依赖版本收敛或构建收益优化；任何收益声明都需要记录 `cargo check -p bitfun-core`、workspace check 和目标 crate check 的前后数据。
+21. 当前阶段：tool-runtime H3 provider/assembly equivalence guard。先补 custom decorator、provider install、collapsed catalog、manifest / `GetToolSpec` unlock 等价保护，再决定是否迁移 `ToolUseContext`、runtime manifest assembly、snapshot decorator port 或 concrete tool implementation；本阶段不得把 concrete tool 迁移和行为语义调整混入同一提交。
+22. 后续独立评估：`bitfun-core default = []`、per-product feature set、依赖版本收敛或构建收益优化；任何收益声明都需要记录 `cargo check -p bitfun-core`、workspace check 和目标 crate check 的前后数据。
 
 冗余清理 PR 不进入上述主线序号。只有在满足 `0A.6` 的绝对等价要求时，才可以插入到相邻里程碑之间，并且不得与主线拆分 PR 混合。
 

--- a/src/crates/core/src/agentic/tools/manifest_resolver.rs
+++ b/src/crates/core/src/agentic/tools/manifest_resolver.rs
@@ -306,6 +306,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn manifest_guard_preserves_get_tool_spec_unlock_surface_before_owner_migration() {
+        let allowed_tools = vec![
+            "Read".to_string(),
+            "WebFetch".to_string(),
+            "GetFileDiff".to_string(),
+            "Git".to_string(),
+        ];
+
+        let manifest = resolve_tool_manifest(
+            &allowed_tools,
+            &AgentToolPolicyOverrides::default(),
+            &tool_context(),
+        )
+        .await;
+
+        assert_eq!(
+            manifest.allowed_tool_names,
+            vec![
+                "Read".to_string(),
+                "WebFetch".to_string(),
+                "GetFileDiff".to_string(),
+                "Git".to_string(),
+                GET_TOOL_SPEC_TOOL_NAME.to_string(),
+            ],
+            "GetToolSpec insertion must preserve the runtime allowed-list contract"
+        );
+        assert_eq!(
+            manifest.collapsed_tool_names,
+            vec![
+                "GetFileDiff".to_string(),
+                "WebFetch".to_string(),
+                "Git".to_string()
+            ],
+            "collapsed unlock list must follow product registry snapshot order"
+        );
+        assert_eq!(
+            manifest
+                .tool_definitions
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Read", "WebFetch", "GetToolSpec", "GetFileDiff", "Git"],
+            "prompt-visible definitions must keep the current discovery insertion and policy order stable"
+        );
+
+        for tool_name in ["GetFileDiff", "WebFetch", "Git"] {
+            let stub = manifest
+                .tool_definitions
+                .iter()
+                .find(|tool| tool.name == tool_name)
+                .unwrap_or_else(|| panic!("{tool_name} stub should exist"));
+            assert!(
+                stub.description.contains(&format!(
+                    "First call `GetToolSpec` with {{\"tool_name\":\"{tool_name}\"}}"
+                )),
+                "collapsed stub must point to the explicit GetToolSpec unlock flow"
+            );
+            assert_eq!(stub.parameters["type"], json!("object"));
+            assert_eq!(stub.parameters["additionalProperties"], json!(false));
+            assert_eq!(
+                stub.parameters["properties"]["tool_name"]["description"],
+                json!(format!(
+                    "Do not supply {tool_name} arguments here while the tool is collapsed. Use GetToolSpec with {{\"tool_name\":\"{tool_name}\"}} first."
+                ))
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn manifest_preserves_explicit_get_tool_spec_runtime_contract() {
         let allowed_tools = vec![GET_TOOL_SPEC_TOOL_NAME.to_string(), "WebFetch".to_string()];
 

--- a/src/crates/core/src/agentic/tools/registry.rs
+++ b/src/crates/core/src/agentic/tools/registry.rs
@@ -223,7 +223,7 @@ mod tests {
     use crate::agentic::tools::runtime_assembly::ProductToolRuntimeAssembly;
     use crate::agentic::tools::static_providers::builtin_static_tool_providers;
     use async_trait::async_trait;
-    use bitfun_agent_tools::{DynamicToolProvider, StaticToolProvider};
+    use bitfun_agent_tools::{DynamicToolProvider, StaticToolProvider, ToolDecorator};
     use serde_json::Value;
     use serde_json::json;
     use std::sync::Arc;
@@ -313,6 +313,60 @@ mod tests {
                 }),
             }),
         })
+    }
+
+    #[derive(Debug, Clone)]
+    struct MarkerToolDecorator;
+
+    impl ToolDecorator<ToolRef> for MarkerToolDecorator {
+        fn decorate(&self, tool: ToolRef) -> ToolRef {
+            Arc::new(DecoratedMarkerTool {
+                name: tool.name().to_string(),
+                exposure: tool.default_exposure(),
+                readonly: tool.is_readonly(),
+            })
+        }
+    }
+
+    struct DecoratedMarkerTool {
+        name: String,
+        exposure: crate::agentic::tools::framework::ToolExposure,
+        readonly: bool,
+    }
+
+    #[async_trait]
+    impl Tool for DecoratedMarkerTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        async fn description(&self) -> crate::util::errors::BitFunResult<String> {
+            Ok("decorated test tool".to_string())
+        }
+
+        fn short_description(&self) -> String {
+            "decorated test tool".to_string()
+        }
+
+        fn default_exposure(&self) -> crate::agentic::tools::framework::ToolExposure {
+            self.exposure
+        }
+
+        fn input_schema(&self) -> Value {
+            json!({ "type": "object" })
+        }
+
+        fn is_readonly(&self) -> bool {
+            self.readonly
+        }
+
+        async fn call_impl(
+            &self,
+            _input: &Value,
+            _context: &ToolUseContext,
+        ) -> crate::util::errors::BitFunResult<Vec<ToolResult>> {
+            Ok(Vec::new())
+        }
     }
 
     #[test]
@@ -459,6 +513,36 @@ mod tests {
             assert!(
                 assistant_text.contains("snapshot system"),
                 "runtime assembly must preserve snapshot wrapping for {tool_name}"
+            );
+        }
+    }
+
+    #[test]
+    fn product_tool_runtime_assembly_keeps_custom_decorator_provider_contract() {
+        let registry =
+            ProductToolRuntimeAssembly::with_tool_decorator(Arc::new(MarkerToolDecorator))
+                .create_registry();
+        let compatibility_registry = create_tool_registry();
+
+        assert_eq!(
+            registry.get_tool_names(),
+            compatibility_registry.get_tool_names(),
+            "custom decorator assembly must keep provider tool order stable"
+        );
+        assert_eq!(
+            registry.get_collapsed_tool_names(),
+            compatibility_registry.get_collapsed_tool_names(),
+            "custom decorator assembly must keep collapsed exposure stable"
+        );
+
+        for tool_name in ["Write", "GetToolSpec", "WebFetch"] {
+            let tool = registry
+                .get_tool(tool_name)
+                .unwrap_or_else(|| panic!("{tool_name} tool should be registered"));
+            assert_eq!(
+                tool.short_description(),
+                "decorated test tool",
+                "custom decorator must be applied while preserving provider installation"
             );
         }
     }


### PR DESCRIPTION
﻿## Summary
- Add a runtime assembly guard proving injected tool decorators still preserve core provider installation order and the product collapsed-tool catalog.
- Add a manifest guard for the current `GetToolSpec` unlock surface: allowed-list insertion, collapsed-tool order, prompt-visible definition order, and collapsed stub schema.
- Update the decomposition plan to record this as the tool-runtime H3 provider/assembly equivalence guard before any runtime owner migration.

## Functional boundary
- Test/docs only; no production runtime code changes.
- Does not migrate `ToolUseContext`, runtime manifest assembly, `GetToolSpecTool` execution, snapshot decorator ports, or concrete tool implementations.
- Does not change Cargo dependencies, feature flags, tool registration order, prompt manifest behavior, or unlock behavior.

## Adversarial review
- Rebased onto latest `gcwing/main`; the merged H2 commit was skipped, leaving this branch as one H3 commit.
- Checked the diff for accidental production logic changes, dependency drift, feature drift, and H3 naming ambiguity against the broader high-risk milestone table.
- Renamed the doc status to `tool-runtime H3` to avoid conflating this guard slice with the global high-risk H3 service/runtime queue.

## Verification
- `rustfmt --edition 2024 --check src/crates/core/src/agentic/tools/registry.rs src/crates/core/src/agentic/tools/manifest_resolver.rs`
- `node scripts/check-core-boundaries.mjs`
- `git diff --check gcwing/main..HEAD`
- `cargo test -p bitfun-core product_tool_runtime_assembly --lib`
- `cargo test -p bitfun-core manifest_guard_preserves_get_tool_spec_unlock_surface_before_owner_migration --lib`
- `cargo test -p bitfun-core registry_ --lib`
- `cargo test -p bitfun-core manifest_ --lib`
- `cargo test -p bitfun-core get_tool_spec --lib`
- `cargo check -p bitfun-core --features product-full`
- `cargo check --workspace`
- `cargo test --workspace`
