### PR TITLE
fix(cli): persist token usage by routing dequeued events internally

### DIFF
--- a/src/apps/cli/src/agent/core_adapter.rs
+++ b/src/apps/cli/src/agent/core_adapter.rs
@@ -1,7 +1,9 @@
 //! Core Agent adapter
 //!
 //! Adapts bitfun-core's Agentic system to CLI's Agent interface.
-//! Event consumption is NOT done here — it's done in the chat/exec mode main loops.
+//! Event consumption is done in the chat/exec mode main loops, which must also
+//! call [`Self::route_internal_events`] so internal subscribers (e.g. token usage)
+//! receive dequeued envelopes.
 
 use anyhow::Result;
 use std::path::PathBuf;
@@ -13,7 +15,7 @@ use bitfun_core::agentic::coordination::{
     ConversationCoordinator, DialogSubmissionPolicy, DialogTriggerSource,
 };
 use bitfun_core::agentic::core::SessionConfig;
-use bitfun_core::agentic::events::EventQueue;
+use bitfun_core::agentic::events::{EventEnvelope, EventQueue};
 
 /// Core-based Agent implementation.
 /// Stateless regarding agent_type — callers pass it per-call.
@@ -51,6 +53,15 @@ impl CoreAgentAdapter {
     #[allow(dead_code)]
     pub fn coordinator(&self) -> &Arc<ConversationCoordinator> {
         &self.coordinator
+    }
+
+    /// Forward dequeued envelopes to internal event subscribers.
+    pub async fn route_internal_events(&self, envelopes: &[EventEnvelope]) {
+        for envelope in envelopes {
+            if let Err(error) = self.coordinator.route_internal_event(envelope.clone()).await {
+                tracing::warn!("Internal event routing failed: {}", error);
+            }
+        }
     }
 
     pub fn workspace_path_buf(&self) -> PathBuf {

--- a/src/apps/cli/src/modes/chat.rs
+++ b/src/apps/cli/src/modes/chat.rs
@@ -545,6 +545,9 @@ impl ChatMode {
             // 2. Process core events (non-blocking)
             let events =
                 tokio::task::block_in_place(|| rt_handle.block_on(event_queue.dequeue_batch(20)));
+            tokio::task::block_in_place(|| {
+                rt_handle.block_on(self.agent.route_internal_events(&events))
+            });
             for envelope in events {
                 let event = &envelope.event;
 

--- a/src/apps/cli/src/modes/exec.rs
+++ b/src/apps/cli/src/modes/exec.rs
@@ -98,6 +98,7 @@ impl ExecMode {
             // Wait for events (efficient, uses Notify internally)
             event_queue.wait_for_events().await;
             let events = event_queue.dequeue_batch(20).await;
+            self.agent.route_internal_events(&events).await;
 
             for envelope in events {
                 let event = &envelope.event;

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -10,7 +10,8 @@ use crate::agentic::core::{
     SessionConfig, SessionKind, SessionState, SessionSummary, TurnStats,
 };
 use crate::agentic::events::{
-    AgenticEvent, DeepReviewQueueState, EventPriority, EventQueue, EventRouter, EventSubscriber,
+    AgenticEvent, DeepReviewQueueState, EventEnvelope, EventPriority, EventQueue, EventRouter,
+    EventSubscriber,
 };
 use crate::agentic::execution::{ContextCompactionOutcome, ExecutionContext, ExecutionEngine};
 use crate::agentic::fork_agent::{
@@ -2476,6 +2477,14 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
     /// Remove subscriber previously added via subscribe_internal
     pub fn unsubscribe_internal(&self, subscriber_id: &str) {
         self.event_router.unsubscribe_internal(subscriber_id);
+    }
+
+    /// Route a dequeued event to internal subscribers (token usage, cron, etc.).
+    ///
+    /// CLI hosts dequeue events for UI rendering and must call this so subscribers
+    /// registered via [`Self::subscribe_internal`] receive the same envelopes.
+    pub async fn route_internal_event(&self, envelope: EventEnvelope) -> BitFunResult<()> {
+        self.event_router.route(envelope).await
     }
 
     /// Confirm tool execution

--- a/src/crates/core/src/agentic/events/router.rs
+++ b/src/crates/core/src/agentic/events/router.rs
@@ -121,3 +121,56 @@ impl Default for EventRouter {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agentic::events::types::{EventEnvelope, EventPriority};
+    use bitfun_events::AgenticEvent;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingSubscriber {
+        count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl EventSubscriber for CountingSubscriber {
+        async fn on_event(&self, event: &AgenticEvent) -> BitFunResult<()> {
+            if matches!(event, AgenticEvent::TokenUsageUpdated { .. }) {
+                self.count.fetch_add(1, Ordering::SeqCst);
+            }
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn route_dispatches_to_internal_subscribers() {
+        let router = EventRouter::new();
+        let count = Arc::new(AtomicUsize::new(0));
+        router.subscribe_internal(
+            "test-token-usage".to_string(),
+            Arc::new(CountingSubscriber {
+                count: count.clone(),
+            }),
+        );
+
+        let envelope = EventEnvelope::new(
+            AgenticEvent::TokenUsageUpdated {
+                session_id: "session-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                model_id: "model-1".to_string(),
+                input_tokens: 10,
+                output_tokens: Some(5),
+                total_tokens: 15,
+                max_context_tokens: None,
+                is_subagent: false,
+                cached_tokens: None,
+                token_details: None,
+            },
+            EventPriority::Normal,
+        );
+
+        router.route(envelope).await.expect("route should succeed");
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+}


### PR DESCRIPTION
CLI chat and exec consumed EventQueue entries for UI only, so TokenUsageUpdated never reached TokenUsageSubscriber and nothing was written to ~/.config/bitfun/data/token_usage.