### PR TITLE
feat(flow-chat): add Shift+Tab shortcut for agent mode cycling

### DIFF
--- a/src/mobile-web/src/pages/ChatPage.tsx
+++ b/src/mobile-web/src/pages/ChatPage.tsx
@@ -1943,6 +1943,7 @@ const ModelSelectorPill: React.FC<{
 // ─── Agent Mode ─────────────────────────────────────────────────────────────
 
 type AgentMode = 'agentic' | 'Plan' | 'debug';
+const AGENT_MODE_ORDER: AgentMode[] = ['agentic', 'Plan', 'debug'];
 
 // ─── ChatPage ───────────────────────────────────────────────────────────────
 
@@ -1969,6 +1970,13 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
   const messages = getMessages(sessionId);
   const [input, setInput] = useState('');
   const [agentMode, setAgentMode] = useState<AgentMode>('agentic');
+
+  const cycleAgentMode = useCallback(() => {
+    setAgentMode(prev => {
+      const idx = AGENT_MODE_ORDER.indexOf(prev);
+      return AGENT_MODE_ORDER[(idx + 1) % AGENT_MODE_ORDER.length];
+    });
+  }, []);
   const [liveTitle, setLiveTitle] = useState(sessionName);
   const [modelCatalog, setModelCatalog] = useState<RemoteModelCatalog | null>(null);
   const [selectedModelId, setSelectedModelId] = useState<string>('auto');
@@ -2391,6 +2399,10 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
       e.preventDefault();
       handleSend();
     }
+    if (e.key === 'Tab' && e.shiftKey) {
+      e.preventDefault();
+      cycleAgentMode();
+    }
   };
 
   const handleCancel = async () => {
@@ -2400,6 +2412,23 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
       // best effort
     }
   };
+
+  // Listen at document level so the shortcut works even when the input is collapsed.
+  const cycleAgentModeRef = useRef(cycleAgentMode);
+  cycleAgentModeRef.current = cycleAgentMode;
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Tab' && e.shiftKey) {
+        // Skip when the textarea is focused — its own React handler already fired.
+        const tag = (e.target as HTMLElement)?.tagName;
+        if (tag === 'TEXTAREA') return;
+        e.preventDefault();
+        cycleAgentModeRef.current();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
 
   const workspaceName = currentWorkspace?.project_name || currentWorkspace?.path?.split('/').pop() || '';
   const gitBranch = currentWorkspace?.git_branch;
@@ -2735,11 +2764,7 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
                 <>
                   <button
                     className={`chat-page__mode-pill${agentMode !== 'agentic' ? ` chat-page__mode-pill--${agentMode}` : ''}`}
-                    onClick={() => {
-                      const modes: AgentMode[] = ['agentic', 'Plan', 'debug'];
-                      const idx = modes.indexOf(agentMode);
-                      setAgentMode(modes[(idx + 1) % modes.length]);
-                    }}
+                    onClick={cycleAgentMode}
                     disabled={imageAnalyzing}
                   >
                     {modeOptions.find(m => m.id === agentMode)?.label}

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -349,6 +349,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     [isAssistantWorkspace, modeState.available]
   );
 
+  // Stable refs for Shift+Tab mode cycling (avoids adding deps to handleKeyDown)
+  const switchableModesRef = useRef(switchableModes);
+  switchableModesRef.current = switchableModes;
+  const currentModeRef = useRef(currentMode);
+  currentModeRef.current = currentMode;
+  const applyModeChangeRef = useRef<((modeId: string) => void) | null>(null);
+
   /** Code session: modes switchable on top of default agentic */
   const incrementalCodeModes = useMemo(
     () =>
@@ -1897,6 +1904,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     }
   }, [effectiveTargetSessionId]);
 
+  applyModeChangeRef.current = applyModeChange;
+
   const requestModeChange = useCallback((modeId: string) => {
     if (!canSwitchModes) {
       dispatchMode({ type: 'CLOSE_DROPDOWN' });
@@ -2035,6 +2044,31 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       || nativeEvt.keyCode === 229;
 
     if (e.key === 'Escape' && isComposing) {
+      return;
+    }
+
+    if (e.key === 'Tab' && e.shiftKey) {
+      const modes = switchableModesRef.current;
+      const modeNow = currentModeRef.current;
+      const apply = applyModeChangeRef.current;
+      if (!(canSwitchModes && apply && modes.length > 1)) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Dismiss slash command if open
+      if (slashCommandState.isActive) {
+        setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
+        dispatchInput({ type: 'CLEAR_VALUE' });
+      }
+
+      const currentIdx = modes.findIndex(m => m.id === modeNow);
+      if (currentIdx === -1) {
+        apply(modes[0].id);
+        return;
+      }
+      const nextIdx = (currentIdx + 1) % modes.length;
+      apply(modes[nextIdx].id);
       return;
     }
 


### PR DESCRIPTION
## Summary

Mirror Claude Code's Tab-based agent mode cycling: pressing **Shift+Tab** now cycles the agent mode forward. Works across both desktop (web-ui) and mobile-web.

## Changes

### Desktop (`ChatInput.tsx`)
- Shift+Tab cycles forward through all **switchable modes** (dynamic list from backend; excludes Cowork, and Claw outside assistant workspaces)
- Uses stable refs to keep the `handleKeyDown` dependency array lean
- Dismisses any open slash-command picker before cycling
- Handles edge case: if current mode is not in the switchable list, falls back explicitly to the first switchable mode

### Mobile (`ChatPage.tsx`)
- Shift+Tab cycles through **agentic → Plan → debug → agentic**
- Works in both states:
  - **Expanded textarea**: via React `onKeyDown`
  - **Collapsed placeholder**: via `document.addEventListener('keydown', ...)` with deduplication
- Extracted shared `cycleAgentMode` callback (used by both the mode-pill button and keyboard handler)
- Extracted `AGENT_MODE_ORDER` module-level constant to eliminate string array duplication

## Behavior
| Context | Before | After |
|---|---|---|
| Desktop chat input | Mode switching only via `/` slash command picker or mode button | **+ Shift+Tab** cycles modes instantly |
| Mobile chat | Mode switching only via mode-pill button tap | **+ Shift+Tab** cycles modes (physical/BT keyboard) |

## Test plan
- [x] TypeScript type-check passes for both mobile-web and web-ui
- [ ] Manual test: Desktop — press Shift+Tab with ChatInput focused, verify mode cycles
- [ ] Manual test: Mobile — pair with desktop over relay, press Shift+Tab (BT keyboard), verify mode pill updates
- [ ] Manual test: Verify Shift+Tab does NOT fire when slash-command picker is closed (only mode cycles)