### PR TITLE
fix(miniapp): stabilize assistant-created skeletons

### DIFF
--- a/src/crates/core/src/agentic/tools/implementations/miniapp_init_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/miniapp_init_tool.rs
@@ -1,6 +1,6 @@
 //! InitMiniApp tool — create a new MiniApp skeleton; AI then uses generic file tools to edit.
 
-use crate::agentic::tools::framework::{Tool, ToolExposure, ToolResult, ToolUseContext};
+use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
 use crate::infrastructure::events::{emit_global_event, BackendEvent};
 use crate::miniapp::try_get_global_miniapp_manager;
 use crate::miniapp::types::{
@@ -56,6 +56,18 @@ impl Default for InitMiniAppTool {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::InitMiniAppTool;
+    use crate::agentic::tools::framework::{Tool, ToolExposure};
+
+    #[test]
+    fn init_miniapp_stays_expanded_for_assistant_creation() {
+        let tool = InitMiniAppTool::new();
+        assert_eq!(tool.default_exposure(), ToolExposure::Expanded);
+    }
+}
+
 #[async_trait]
 impl Tool for InitMiniAppTool {
     fn name(&self) -> &str {
@@ -75,10 +87,6 @@ Returns app_id and the app root directory. Use the root directory and file names
 
     fn short_description(&self) -> String {
         "Create a new MiniApp skeleton in the Toolbox.".to_string()
-    }
-
-    fn default_exposure(&self) -> ToolExposure {
-        ToolExposure::Collapsed
     }
 
     fn input_schema(&self) -> Value {
@@ -196,6 +204,7 @@ Returns app_id and the app root directory. Use the root directory and file names
             "style": source_dir.join("style.css").to_string_lossy(),
             "html": source_dir.join("index.html").to_string_lossy(),
             "package": app_dir.join("package.json").to_string_lossy(),
+            "storage": app_dir.join("storage.json").to_string_lossy(),
         });
 
         let _ = emit_global_event(BackendEvent::Custom {

--- a/src/crates/core/src/agentic/tools/registry.rs
+++ b/src/crates/core/src/agentic/tools/registry.rs
@@ -528,6 +528,7 @@ mod tests {
         assert!(!registry.is_tool_collapsed("GetToolSpec"));
         assert!(registry.is_tool_collapsed("Git"));
         assert!(registry.is_tool_collapsed("ReviewPlatform"));
+        assert!(!registry.is_tool_collapsed("InitMiniApp"));
     }
 
     #[test]
@@ -553,7 +554,6 @@ mod tests {
                 "GenerativeUI",
                 "Git",
                 "ReviewPlatform",
-                "InitMiniApp",
                 "ControlHub",
                 "ComputerUse",
                 "Playbook",

--- a/src/crates/core/src/miniapp/storage.rs
+++ b/src/crates/core/src/miniapp/storage.rs
@@ -325,6 +325,13 @@ impl MiniAppStorage {
         self.write_package_json_to_dir(app_dir, &app.id, &app.source.npm_dependencies)
             .await?;
 
+        let storage_path = app_dir.join(STORAGE_JSON);
+        if !storage_path.exists() {
+            tokio::fs::write(&storage_path, "{}")
+                .await
+                .map_err(|e| BitFunError::io(format!("Failed to write storage.json: {}", e)))?;
+        }
+
         tokio::fs::write(app_dir.join(COMPILED_HTML), &app.compiled_html)
             .await
             .map_err(|e| BitFunError::io(format!("Failed to write compiled.html: {}", e)))?;
@@ -938,6 +945,11 @@ mod tests {
         let layout = MiniAppStorageLayout::new(path_manager.miniapps_dir(), "layout_app");
 
         storage.save(&app).await.unwrap();
+        assert!(layout.storage_path().is_file());
+        assert_eq!(
+            fs::read_to_string(layout.storage_path()).unwrap(),
+            "{}".to_string()
+        );
         storage
             .save_app_storage("layout_app", "answer", serde_json::json!(42))
             .await
@@ -947,7 +959,6 @@ mod tests {
         assert!(layout.app_dir().is_dir());
         assert!(layout.meta_path().is_file());
         assert!(layout.compiled_path().is_file());
-        assert!(layout.storage_path().is_file());
         assert!(layout.package_json_path().is_file());
         assert!(layout.source_file_path(INDEX_HTML).is_file());
         assert!(layout.source_file_path(STYLE_CSS).is_file());
@@ -955,6 +966,34 @@ mod tests {
         assert!(layout.source_file_path(WORKER_JS).is_file());
         assert!(layout.source_file_path(ESM_DEPS_JSON).is_file());
         assert!(layout.version_path(7).is_file());
+    }
+
+    #[tokio::test]
+    async fn saving_app_files_preserves_existing_storage_json() {
+        let root = std::env::temp_dir().join(format!(
+            "bitfun-miniapp-storage-preserve-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let path_manager =
+            Arc::new(crate::infrastructure::PathManager::with_user_root_for_tests(root));
+        let storage = MiniAppStorage::new(path_manager);
+        let app = sample_app("storage_app");
+
+        storage.save(&app).await.unwrap();
+        storage
+            .save_app_storage("storage_app", "answer", serde_json::json!(42))
+            .await
+            .unwrap();
+        storage.save(&app).await.unwrap();
+
+        assert_eq!(
+            storage
+                .load_app_storage("storage_app")
+                .await
+                .unwrap()
+                .get("answer"),
+            Some(&serde_json::json!(42))
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
﻿## Summary
- keep InitMiniApp visible to assistant creation flows instead of requiring tool-spec discovery first
- include storage.json in InitMiniApp result metadata and create it for active MiniApp saves
- preserve existing MiniApp storage data on later saves

## Root Cause
Assistant-created MiniApps rely on InitMiniApp to seed the Toolbox app directory, then use file tools to edit the generated source. Recent tool visibility changes made InitMiniApp collapsed, so assistant creation could skip the MiniApp runtime path and create files elsewhere. The active MiniApp save path also promised storage.json in the tool description but only draft/import/built-in paths initialized it.

## Validation
- cargo test -p bitfun-core init_miniapp_stays_expanded_for_assistant_creation -- --nocapture
- cargo test -p bitfun-core storage_adapter_uses_product_domain_layout_contract -- --nocapture
- cargo test -p bitfun-core saving_app_files_preserves_existing_storage_json -- --nocapture
- cargo check -p bitfun-core
- git diff --cached --check