### PR TITLE
fix: render mermaid in markdown editor preview

### DIFF
--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.test.tsx
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.test.tsx
@@ -27,13 +27,13 @@ vi.mock('@/component-library', () => ({
 }));
 
 vi.mock('../meditor', () => ({
-  MEditor: forwardRef((_props: { value?: string }, ref) => {
+  MEditor: forwardRef((props: { value?: string; mode?: string }, ref) => {
     useImperativeHandle(ref, () => ({
       destroy: vi.fn(),
       markSaved: vi.fn(),
       setInitialContent: vi.fn(),
     }));
-    return <div data-testid="markdown-body" />;
+    return <div data-testid="markdown-body" data-mode={props.mode} />;
   }),
 }));
 
@@ -91,5 +91,13 @@ describe('MarkdownEditor', () => {
     expect(html).toContain('aria-label="Copy Markdown"');
     expect(html).toContain('data-icon="copy"');
     expect(html).toContain('bitfun-markdown-editor__toolbar-button');
+  });
+
+  it('uses preview mode for markdown rendering', () => {
+    const html = renderToStaticMarkup(
+      <MarkdownEditor initialContent="```mermaid\ngraph TD\n  A-->B\n```" />,
+    );
+
+    expect(html).toContain('data-mode="preview"');
   });
 });

--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.tsx
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.tsx
@@ -814,7 +814,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         onChange={handleContentChange}
         onSave={handleSave}
         onDirtyChange={handleDirtyChange}
-        mode={viewMode === 'preview' ? 'ir' : 'edit'}
+        mode={viewMode === 'preview' ? 'preview' : 'edit'}
         theme={isLight ? 'light' : 'dark'}
         height="100%"
         width="100%"


### PR DESCRIPTION
## Summary
- switch MarkdownEditor preview mode to the shared MarkdownRenderer path so fenced Mermaid blocks render correctly
- add a regression test covering preview mode

## Verification
- pnpm run lint:web
- pnpm run type-check:web
- pnpm --dir src/web-ui run test:run src/tools/editor/components/MarkdownEditor.test.tsx