### PR TITLE
feat(core): restore inline Write via configurable write tool mode

### DIFF
--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -5,36 +5,36 @@
 use super::round_executor::RoundExecutor;
 use super::types::{ExecutionContext, ExecutionResult, RoundContext, RoundResult};
 use crate::agentic::agents::{
-    PromptBuilder, PromptBuilderContext, RemoteExecutionHints, get_agent_registry,
+    get_agent_registry, PromptBuilder, PromptBuilderContext, RemoteExecutionHints,
 };
 use crate::agentic::context_profile::{ContextProfilePolicy, ModelCapabilityProfile};
 use crate::agentic::core::{
-    Message, MessageContent, MessageHelper, MessageRole, MessageSemanticKind,
-    RequestReasoningTokenPolicy, Session, render_system_reminder,
+    render_system_reminder, Message, MessageContent, MessageHelper, MessageRole,
+    MessageSemanticKind, RequestReasoningTokenPolicy, Session,
 };
 use crate::agentic::events::{AgenticEvent, EventPriority, EventQueue};
 use crate::agentic::execution::types::FinishReason;
 use crate::agentic::image_analysis::{
-    ImageContextData, ImageLimits, build_multimodal_message_with_images,
-    process_image_contexts_for_provider,
+    build_multimodal_message_with_images, process_image_contexts_for_provider, ImageContextData,
+    ImageLimits,
 };
 use crate::agentic::round_preempt::RoundInjectionKind;
 use crate::agentic::session::{CompressionTailPolicy, ContextCompressor, SessionManager};
 use crate::agentic::tools::{
-    ResolvedToolManifest, SubagentParentInfo, ToolRuntimeRestrictions, resolve_tool_manifest,
+    resolve_tool_manifest, ResolvedToolManifest, SubagentParentInfo, ToolRuntimeRestrictions,
 };
 use crate::agentic::util::build_remote_workspace_layout_preview;
 use crate::agentic::{WorkspaceBackend, WorkspaceBinding};
 use crate::infrastructure::ai::get_global_ai_client_factory;
 use crate::service::config::get_global_config_service;
-use crate::service::config::types::{ModelCapability, ModelCategory};
+use crate::service::config::types::{ModelCapability, ModelCategory, WriteToolMode};
 use crate::service::remote_ssh::workspace_state::get_remote_workspace_manager;
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::token_counter::TokenCounter;
 use crate::util::types::Message as AIMessage;
 use crate::util::types::ToolDefinition;
 use crate::util::{elapsed_ms_u64, truncate_at_char_boundary};
-use bitfun_agent_tools::{GetToolSpecLoadObservation, collect_loaded_collapsed_tool_names};
+use bitfun_agent_tools::{collect_loaded_collapsed_tool_names, GetToolSpecLoadObservation};
 use log::{debug, error, info, trace, warn};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -1432,7 +1432,11 @@ impl ExecutionEngine {
             })?;
 
         // Primary model vision capability (tools + system prompt appendix; also used below for API message stripping).
-        let (resolved_primary_model_id, primary_supports_image_understanding) = {
+        let (
+            resolved_primary_model_id,
+            primary_supports_image_understanding,
+            configured_write_tool_mode,
+        ) = {
             let config_service = get_global_config_service().await.ok();
             if let Some(service) = config_service {
                 let ai_config: crate::service::config::types::AIConfig =
@@ -1465,12 +1469,12 @@ impl ExecutionEngine {
                         || matches!(m.category, ModelCategory::Multimodal)
                 });
 
-                (resolved_id, supports)
+                (resolved_id, supports, ai_config.write_tool_mode)
             } else {
                 warn!(
                     "Config service unavailable, assuming primary model is text-only for image input gating"
                 );
-                (model_id.clone(), false)
+                (model_id.clone(), false, WriteToolMode::default())
             }
         };
 
@@ -1524,6 +1528,22 @@ impl ExecutionEngine {
             .get("enable_tools")
             .and_then(|v| v.parse::<bool>().ok())
             .unwrap_or(true);
+        let write_tool_mode = if context
+            .context
+            .get("acp_transport")
+            .is_some_and(|value| value == "true")
+        {
+            WriteToolMode::InlineContent
+        } else {
+            configured_write_tool_mode
+        };
+
+        let mut tool_manifest_context_vars = context.context.clone();
+        tool_manifest_context_vars.insert(
+            "write_tool_mode".to_string(),
+            write_tool_mode.as_str().to_string(),
+        );
+
         let tool_manifest = if enable_tools {
             debug!(
                 "Agent tools: agent={}, tool_count={}",
@@ -1538,7 +1558,7 @@ impl ExecutionEngine {
                     context.workspace_services.as_ref(),
                     &agent_type,
                     primary_supports_image_understanding,
-                    &context.context,
+                    &tool_manifest_context_vars,
                 )
                 .await,
             )
@@ -1654,6 +1674,10 @@ impl ExecutionEngine {
         execution_context_vars.insert(
             "primary_model_supports_image_understanding".to_string(),
             primary_supports_image_understanding.to_string(),
+        );
+        execution_context_vars.insert(
+            "write_tool_mode".to_string(),
+            write_tool_mode.as_str().to_string(),
         );
         execution_context_vars.insert("turn_index".to_string(), context.turn_index.to_string());
 

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -8,12 +8,15 @@ use crate::agentic::core::{Message, ToolCall};
 use crate::agentic::events::{AgenticEvent, EventPriority, EventQueue, ToolEventData};
 use crate::agentic::tools::computer_use_host::ComputerUseHostRef;
 use crate::agentic::tools::framework::{ToolPathResolution, ToolUseContext};
-use crate::agentic::tools::implementations::file_write_tool::FileWriteTool;
+use crate::agentic::tools::implementations::file_write_tool::{
+    FileWriteTool, WRITE_TOOL_MODE_CONTEXT_KEY,
+};
 use crate::agentic::tools::pipeline::{ToolExecutionContext, ToolExecutionOptions, ToolPipeline};
 use crate::agentic::tools::registry::get_global_tool_registry;
 use crate::agentic::tools::ToolPathOperation;
 use crate::agentic::MessageContent;
 use crate::infrastructure::ai::AIClient;
+use crate::service::config::types::WriteToolMode;
 use crate::service::config::GlobalConfigManager;
 use crate::util::elapsed_ms_u64;
 use crate::util::errors::{BitFunError, BitFunResult};
@@ -42,6 +45,15 @@ impl RoundExecutor {
 
     fn has_user_visible_assistant_text(text: &str) -> bool {
         !text.trim().is_empty()
+    }
+
+    fn write_tool_mode(context: &RoundContext) -> WriteToolMode {
+        WriteToolMode::from_context_var(
+            context
+                .context_vars
+                .get(WRITE_TOOL_MODE_CONTEXT_KEY)
+                .map(String::as_str),
+        )
     }
 
     pub fn new(
@@ -555,8 +567,11 @@ impl RoundExecutor {
         // model emit large file contents inside JSON tool-call arguments, which
         // is a major source of JSON parse failures.
         let tool_calls = stream_result.tool_calls.clone();
-        let tool_calls = self
-            .generate_write_tool_contents(
+        let tool_calls = if matches!(
+            Self::write_tool_mode(&context),
+            WriteToolMode::PlaintextFollowup
+        ) {
+            self.generate_write_tool_contents(
                 ai_client.clone(),
                 &context,
                 &round_id,
@@ -564,7 +579,10 @@ impl RoundExecutor {
                 tool_calls,
                 &cancel_token,
             )
-            .await?;
+            .await?
+        } else {
+            tool_calls
+        };
 
         // Execute tool calls
         debug!(
@@ -1990,8 +2008,18 @@ mod tests {
             cache_creation_token_count: Some(20),
         };
         let details = super::token_details_from_usage(&usage).expect("details");
-        assert_eq!(details.get("cachedContentTokenCount").and_then(|v| v.as_u64()), Some(30));
-        assert_eq!(details.get("cacheCreationTokenCount").and_then(|v| v.as_u64()), Some(20));
+        assert_eq!(
+            details
+                .get("cachedContentTokenCount")
+                .and_then(|v| v.as_u64()),
+            Some(30)
+        );
+        assert_eq!(
+            details
+                .get("cacheCreationTokenCount")
+                .and_then(|v| v.as_u64()),
+            Some(20)
+        );
     }
 
     #[test]
@@ -2006,7 +2034,12 @@ mod tests {
             cache_creation_token_count: None,
         };
         let details = super::token_details_from_usage(&usage).expect("details");
-        assert_eq!(details.get("cachedContentTokenCount").and_then(|v| v.as_u64()), Some(30));
+        assert_eq!(
+            details
+                .get("cachedContentTokenCount")
+                .and_then(|v| v.as_u64()),
+            Some(30)
+        );
         assert!(details.get("cacheCreationTokenCount").is_none());
     }
 

--- a/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -2,6 +2,7 @@ use crate::agentic::tools::framework::{
     Tool, ToolPathResolution, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
 use crate::agentic::tools::ToolPathOperation;
+use crate::service::config::types::WriteToolMode;
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
 use serde_json::{json, Value};
@@ -9,6 +10,10 @@ use std::path::Path;
 use tokio::fs;
 
 pub struct FileWriteTool;
+
+const LARGE_WRITE_SOFT_LINE_LIMIT: usize = 200;
+const LARGE_WRITE_SOFT_BYTE_LIMIT: usize = 20 * 1024;
+pub(crate) const WRITE_TOOL_MODE_CONTEXT_KEY: &str = "write_tool_mode";
 
 impl Default for FileWriteTool {
     fn default() -> Self {
@@ -19,6 +24,18 @@ impl Default for FileWriteTool {
 impl FileWriteTool {
     pub fn new() -> Self {
         Self
+    }
+
+    pub(crate) fn write_tool_mode(context: Option<&ToolUseContext>) -> WriteToolMode {
+        if Self::is_acp_context(context) {
+            return WriteToolMode::InlineContent;
+        }
+
+        WriteToolMode::from_context_var(
+            context
+                .and_then(|ctx| ctx.custom_data.get(WRITE_TOOL_MODE_CONTEXT_KEY))
+                .and_then(|value| value.as_str()),
+        )
     }
 
     pub(crate) async fn existing_file_error(
@@ -109,11 +126,200 @@ impl FileWriteTool {
             "additionalProperties": false
         })
     }
+
+    fn schema_without_content() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "The file to write. Use a workspace-relative path, an absolute path inside the current workspace, or an exact bitfun://runtime URI returned by another tool."
+                }
+            },
+            "required": ["file_path"],
+            "additionalProperties": false
+        })
+    }
+
+    fn inline_description() -> String {
+        r#"Writes a file to the local filesystem.
+
+Usage:
+- This tool will overwrite the existing file if there is one at the provided path.
+- If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first.
+- The file_path parameter must be workspace-relative, an absolute path inside the current workspace, or an exact `bitfun://runtime/...` URI returned by another tool.
+- ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
+- Keep writes focused. The 200-line / 20KB guideline is a soft reliability threshold, not a hard cap. If a task genuinely needs more content, preserve correctness and use a staged plan instead of truncating.
+- For existing files, prefer Read + targeted Edit calls. For large new files or rewrites, write the stable scaffold first, then fill or revise sections with focused Edit calls. Do not replace an entire existing file just to change a few sections.
+- NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
+- Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.
+- Include the complete file content in the `content` argument."#
+            .to_string()
+    }
+
+    fn plaintext_followup_description() -> String {
+        r#"Writes a file to the local filesystem.
+
+Usage:
+- This tool is for creating NEW files only. Calling Write on a path that already exists will be REJECTED with an error.
+- To MODIFY an existing file, use the Edit tool — it is the correct choice in almost every case.
+- To FULLY REWRITE an existing file (e.g. regenerate a generated file, replace a template), first call the Delete tool on that path, then call Write to create the new version. Do not try to "overwrite" via Write directly.
+- After Write succeeds for a path, do not call Write for that path again in later rounds. Use Edit for any additional changes.
+- The file_path parameter must be workspace-relative, an absolute path inside the current workspace, or an exact `bitfun://runtime/...` URI returned by another tool.
+- ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
+- NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
+- Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.
+- Do NOT include the file content in the tool call arguments. Only provide file_path. The system will prompt you separately to output the file content as plain text."#
+            .to_string()
+    }
+
+    async fn call_inline_content_impl(
+        &self,
+        input: &Value,
+        context: &ToolUseContext,
+    ) -> BitFunResult<Vec<ToolResult>> {
+        let file_path = input
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| BitFunError::tool("file_path is required".to_string()))?;
+
+        let resolved = context.resolve_tool_path(file_path)?;
+        context.enforce_path_operation(ToolPathOperation::Write, &resolved)?;
+        context
+            .record_light_checkpoint(
+                "Write",
+                &resolved.logical_path,
+                vec![resolved.logical_path.clone()],
+            )
+            .await;
+
+        let content = input
+            .get("content")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| BitFunError::tool("content is required".to_string()))?;
+
+        if resolved.uses_remote_workspace_backend() {
+            let ws_fs = context.ws_fs().ok_or_else(|| {
+                BitFunError::tool("Remote workspace file system is unavailable".to_string())
+            })?;
+            ws_fs
+                .write_file(&resolved.resolved_path, content.as_bytes())
+                .await
+                .map_err(|e| BitFunError::tool(format!("Failed to write file: {}", e)))?;
+        } else {
+            if let Some(parent) = Path::new(&resolved.resolved_path).parent() {
+                fs::create_dir_all(parent)
+                    .await
+                    .map_err(|e| BitFunError::tool(format!("Failed to create directory: {}", e)))?;
+            }
+            fs::write(&resolved.resolved_path, content)
+                .await
+                .map_err(|e| {
+                    BitFunError::tool(format!(
+                        "Failed to write file {}: {}",
+                        resolved.logical_path, e
+                    ))
+                })?;
+        }
+
+        let result = ToolResult::Result {
+            data: json!({
+                "file_path": resolved.logical_path,
+                "bytes_written": content.len(),
+                "success": true
+            }),
+            result_for_assistant: Some(format!("Successfully wrote to {}", resolved.logical_path)),
+            image_attachments: None,
+        };
+
+        Ok(vec![result])
+    }
+
+    async fn call_plaintext_followup_impl(
+        &self,
+        input: &Value,
+        context: &ToolUseContext,
+    ) -> BitFunResult<Vec<ToolResult>> {
+        let file_path = input
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| BitFunError::tool("file_path is required".to_string()))?;
+
+        let resolved = context.resolve_tool_path(file_path)?;
+        context.enforce_path_operation(ToolPathOperation::Write, &resolved)?;
+        context
+            .record_light_checkpoint(
+                "Write",
+                &resolved.logical_path,
+                vec![resolved.logical_path.clone()],
+            )
+            .await;
+
+        let content = input
+            .get("content")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| BitFunError::tool("content is required".to_string()))?;
+
+        if let Some(error) = Self::existing_file_error(context, &resolved).await {
+            if Self::existing_file_matches_content(context, &resolved, content).await == Some(true)
+            {
+                let result = Self::write_success_result(
+                    &resolved.logical_path,
+                    0,
+                    "already_exists_same_content",
+                    format!(
+                        "Write skipped because {} already exists with identical content. Treat this file as successfully created and do not call Write for this path again. Use Edit for any further changes.",
+                        resolved.logical_path
+                    ),
+                );
+                return Ok(vec![result]);
+            }
+
+            return Err(BitFunError::tool(error));
+        }
+
+        if resolved.uses_remote_workspace_backend() {
+            let ws_fs = context.ws_fs().ok_or_else(|| {
+                BitFunError::tool("Remote workspace file system is unavailable".to_string())
+            })?;
+            ws_fs
+                .write_file(&resolved.resolved_path, content.as_bytes())
+                .await
+                .map_err(|e| BitFunError::tool(format!("Failed to write file: {}", e)))?;
+        } else {
+            if let Some(parent) = Path::new(&resolved.resolved_path).parent() {
+                fs::create_dir_all(parent)
+                    .await
+                    .map_err(|e| BitFunError::tool(format!("Failed to create directory: {}", e)))?;
+            }
+            fs::write(&resolved.resolved_path, content)
+                .await
+                .map_err(|e| {
+                    BitFunError::tool(format!(
+                        "Failed to write file {}: {}",
+                        resolved.logical_path, e
+                    ))
+                })?;
+        }
+
+        let result = Self::write_success_result(
+            &resolved.logical_path,
+            content.len(),
+            "created",
+            format!(
+                "Successfully created {} ({} bytes). The file now exists; do not call Write for this path again. Use Edit for any further changes.",
+                resolved.logical_path,
+                content.len()
+            ),
+        );
+
+        Ok(vec![result])
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::FileWriteTool;
+    use super::{FileWriteTool, WRITE_TOOL_MODE_CONTEXT_KEY};
     use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
     use crate::agentic::tools::ToolRuntimeRestrictions;
     use crate::agentic::WorkspaceBinding;
@@ -130,6 +336,25 @@ mod tests {
             workspace: Some(WorkspaceBinding::new(None, root)),
             unlocked_collapsed_tools: Vec::new(),
             custom_data: HashMap::new(),
+            computer_use_host: None,
+            cancellation_token: None,
+            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
+            workspace_services: None,
+        }
+    }
+
+    fn local_context_with_custom_data(
+        root: PathBuf,
+        custom_data: HashMap<String, serde_json::Value>,
+    ) -> ToolUseContext {
+        ToolUseContext {
+            tool_call_id: None,
+            agent_type: None,
+            session_id: None,
+            dialog_turn_id: None,
+            workspace: Some(WorkspaceBinding::new(None, root)),
+            unlocked_collapsed_tools: Vec::new(),
+            custom_data,
             computer_use_host: None,
             cancellation_token: None,
             runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
@@ -264,6 +489,70 @@ mod tests {
         assert_eq!(schema["required"], serde_json::json!(["file_path"]));
         assert!(schema["properties"].get("content").is_none());
     }
+
+    #[tokio::test]
+    async fn inline_mode_schema_requires_content() {
+        let tool = FileWriteTool::new();
+        let mut custom_data = HashMap::new();
+        custom_data.insert(
+            WRITE_TOOL_MODE_CONTEXT_KEY.to_string(),
+            serde_json::Value::String("inline_content".to_string()),
+        );
+        let context = context_with_custom_data(custom_data);
+
+        let schema = tool
+            .input_schema_for_model_with_context(Some(&context))
+            .await;
+
+        assert_eq!(
+            schema["required"],
+            serde_json::json!(["file_path", "content"])
+        );
+    }
+
+    #[tokio::test]
+    async fn inline_mode_requires_content_during_validation() {
+        let tool = FileWriteTool::new();
+        let mut custom_data = HashMap::new();
+        custom_data.insert(
+            WRITE_TOOL_MODE_CONTEXT_KEY.to_string(),
+            serde_json::Value::String("inline_content".to_string()),
+        );
+        let context = context_with_custom_data(custom_data);
+
+        let validation = tool
+            .validate_input(&json!({ "file_path": "new.txt" }), Some(&context))
+            .await;
+
+        assert!(!validation.result);
+        assert_eq!(validation.message.as_deref(), Some("content is required"));
+    }
+
+    #[tokio::test]
+    async fn inline_mode_overwrites_existing_file() {
+        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create temp workspace");
+        std::fs::write(root.join("existing.md"), "old content").expect("create existing file");
+
+        let mut custom_data = HashMap::new();
+        custom_data.insert(
+            WRITE_TOOL_MODE_CONTEXT_KEY.to_string(),
+            serde_json::Value::String("inline_content".to_string()),
+        );
+
+        let tool = FileWriteTool::new();
+        tool.call(
+            &json!({ "file_path": "existing.md", "content": "new content" }),
+            &local_context_with_custom_data(root.clone(), custom_data),
+        )
+        .await
+        .expect("inline mode should overwrite existing files");
+
+        let written = std::fs::read_to_string(root.join("existing.md")).expect("read file");
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert_eq!(written, "new content");
+    }
 }
 
 #[async_trait]
@@ -273,18 +562,7 @@ impl Tool for FileWriteTool {
     }
 
     async fn description(&self) -> BitFunResult<String> {
-        Ok(r#"Writes a file to the local filesystem.
-
-Usage:
-- This tool is for creating NEW files only. Calling Write on a path that already exists will be REJECTED with an error.
-- To MODIFY an existing file, use the Edit tool — it is the correct choice in almost every case.
-- To FULLY REWRITE an existing file (e.g. regenerate a generated file, replace a template), first call the Delete tool on that path, then call Write to create the new version. Do not try to "overwrite" via Write directly.
-- After Write succeeds for a path, do not call Write for that path again in later rounds. Use Edit for any additional changes.
-- The file_path parameter must be workspace-relative, an absolute path inside the current workspace, or an exact `bitfun://runtime/...` URI returned by another tool.
-- ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
-- NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
-- Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.
-- Do NOT include the file content in the tool call arguments. Only provide file_path. The system will prompt you separately to output the file content as plain text."#.to_string())
+        Ok(Self::plaintext_followup_description())
     }
 
     fn short_description(&self) -> String {
@@ -295,42 +573,20 @@ Usage:
         &self,
         context: Option<&ToolUseContext>,
     ) -> BitFunResult<String> {
-        if Self::is_acp_context(context) {
-            return Ok(r#"Writes a file to the local filesystem.
-
-Usage:
-- This tool is for creating NEW files only. Calling Write on a path that already exists will be REJECTED with an error unless the existing content is identical, in which case the retry is treated as already successful.
-- To MODIFY an existing file, use the Edit tool. To fully rewrite an existing file, first call the Delete tool on that path, then call Write to create the new version.
-- The file_path parameter must be workspace-relative, an absolute path inside the current workspace, or an exact `bitfun://runtime/...` URI returned by another tool.
-- ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
-- For new files, preserve correctness and provide the complete intended file content when this tool is appropriate.
-- NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
-- Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.
-- Include the complete file content in the `content` argument."#.to_string());
+        match Self::write_tool_mode(context) {
+            WriteToolMode::InlineContent => Ok(Self::inline_description()),
+            WriteToolMode::PlaintextFollowup => Ok(Self::plaintext_followup_description()),
         }
-
-        self.description().await
     }
 
     fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "file_path": {
-                    "type": "string",
-                    "description": "The file to write. Use a workspace-relative path, an absolute path inside the current workspace, or an exact bitfun://runtime URI returned by another tool."
-                }
-            },
-            "required": ["file_path"],
-            "additionalProperties": false
-        })
+        Self::schema_without_content()
     }
 
     async fn input_schema_for_model_with_context(&self, context: Option<&ToolUseContext>) -> Value {
-        if Self::is_acp_context(context) {
-            Self::schema_with_content()
-        } else {
-            self.input_schema()
+        match Self::write_tool_mode(context) {
+            WriteToolMode::InlineContent => Self::schema_with_content(),
+            WriteToolMode::PlaintextFollowup => self.input_schema(),
         }
     }
 
@@ -363,6 +619,35 @@ Usage:
             }
         };
 
+        let mode = Self::write_tool_mode(context);
+        if matches!(mode, WriteToolMode::InlineContent) && input.get("content").is_none() {
+            return ValidationResult {
+                result: false,
+                message: Some("content is required".to_string()),
+                error_code: Some(400),
+                meta: None,
+            };
+        }
+
+        let large_write_warning = if matches!(mode, WriteToolMode::InlineContent) {
+            input
+                .get("content")
+                .and_then(|v| v.as_str())
+                .and_then(|content| {
+                    let line_count = content.lines().count();
+                    let byte_count = content.len();
+                    if line_count > LARGE_WRITE_SOFT_LINE_LIMIT
+                        || byte_count > LARGE_WRITE_SOFT_BYTE_LIMIT
+                    {
+                        Some((line_count, byte_count))
+                    } else {
+                        None
+                    }
+                })
+        } else {
+            None
+        };
+
         if let Some(ctx) = context {
             let resolved = match ctx.resolve_tool_path(file_path) {
                 Ok(resolved) => resolved,
@@ -385,22 +670,42 @@ Usage:
                 };
             }
 
-            // If content is absent, RoundExecutor would otherwise launch a
-            // second model request to generate the full file. Reject existing
-            // targets here so we do not spend tokens producing content that
-            // Write must reject anyway. If a model already supplied content
-            // despite the public schema, defer to call_impl so identical
-            // retries can be treated as idempotent success.
-            if input.get("content").is_none() {
-                if let Some(error) = Self::existing_file_error(ctx, &resolved).await {
-                    return ValidationResult {
-                        result: false,
-                        message: Some(error),
-                        error_code: Some(400),
-                        meta: None,
-                    };
+            if matches!(mode, WriteToolMode::PlaintextFollowup) {
+                // If content is absent, RoundExecutor would otherwise launch a
+                // second model request to generate the full file. Reject existing
+                // targets here so we do not spend tokens producing content that
+                // Write must reject anyway. If a model already supplied content
+                // despite the public schema, defer to call_impl so identical
+                // retries can be treated as idempotent success.
+                if input.get("content").is_none() {
+                    if let Some(error) = Self::existing_file_error(ctx, &resolved).await {
+                        return ValidationResult {
+                            result: false,
+                            message: Some(error),
+                            error_code: Some(400),
+                            meta: None,
+                        };
+                    }
                 }
             }
+        }
+
+        if let Some((line_count, byte_count)) = large_write_warning {
+            return ValidationResult {
+                result: true,
+                message: Some(format!(
+                    "Large Write payload: {} lines, {} bytes. This is allowed when necessary, but prefer a staged approach: for existing files use Read + focused Edit calls; for large new files write a stable scaffold first, then add sections in follow-up edits unless a complete initial body is required.",
+                    line_count, byte_count
+                )),
+                error_code: None,
+                meta: Some(json!({
+                    "large_write": true,
+                    "line_count": line_count,
+                    "byte_count": byte_count,
+                    "soft_line_limit": LARGE_WRITE_SOFT_LINE_LIMIT,
+                    "soft_byte_limit": LARGE_WRITE_SOFT_BYTE_LIMIT
+                })),
+            };
         }
 
         ValidationResult::default()
@@ -428,79 +733,11 @@ Usage:
         input: &Value,
         context: &ToolUseContext,
     ) -> BitFunResult<Vec<ToolResult>> {
-        let file_path = input
-            .get("file_path")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| BitFunError::tool("file_path is required".to_string()))?;
-
-        let resolved = context.resolve_tool_path(file_path)?;
-        context.enforce_path_operation(ToolPathOperation::Write, &resolved)?;
-        context
-            .record_light_checkpoint(
-                "Write",
-                &resolved.logical_path,
-                vec![resolved.logical_path.clone()],
-            )
-            .await;
-
-        let content = input
-            .get("content")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| BitFunError::tool("content is required".to_string()))?;
-
-        if let Some(error) = Self::existing_file_error(context, &resolved).await {
-            if Self::existing_file_matches_content(context, &resolved, content).await == Some(true)
-            {
-                let result = Self::write_success_result(
-                    &resolved.logical_path,
-                    0,
-                    "already_exists_same_content",
-                    format!(
-                        "Write skipped because {} already exists with identical content. Treat this file as successfully created and do not call Write for this path again. Use Edit for any further changes.",
-                        resolved.logical_path
-                    ),
-                );
-                return Ok(vec![result]);
+        match Self::write_tool_mode(Some(context)) {
+            WriteToolMode::InlineContent => self.call_inline_content_impl(input, context).await,
+            WriteToolMode::PlaintextFollowup => {
+                self.call_plaintext_followup_impl(input, context).await
             }
-
-            return Err(BitFunError::tool(error));
         }
-
-        if resolved.uses_remote_workspace_backend() {
-            let ws_fs = context.ws_fs().ok_or_else(|| {
-                BitFunError::tool("Remote workspace file system is unavailable".to_string())
-            })?;
-            ws_fs
-                .write_file(&resolved.resolved_path, content.as_bytes())
-                .await
-                .map_err(|e| BitFunError::tool(format!("Failed to write file: {}", e)))?;
-        } else {
-            if let Some(parent) = Path::new(&resolved.resolved_path).parent() {
-                fs::create_dir_all(parent)
-                    .await
-                    .map_err(|e| BitFunError::tool(format!("Failed to create directory: {}", e)))?;
-            }
-            fs::write(&resolved.resolved_path, content)
-                .await
-                .map_err(|e| {
-                    BitFunError::tool(format!(
-                        "Failed to write file {}: {}",
-                        resolved.logical_path, e
-                    ))
-                })?;
-        }
-
-        let result = Self::write_success_result(
-            &resolved.logical_path,
-            content.len(),
-            "created",
-            format!(
-                "Successfully created {} ({} bytes). The file now exists; do not call Write for this path again. Use Edit for any further changes.",
-                resolved.logical_path,
-                content.len()
-            ),
-        );
-
-        Ok(vec![result])
     }
 }

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -19,8 +19,8 @@ use log::{debug, error, info, warn};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};
-use tokio::sync::{RwLock as TokioRwLock, oneshot};
-use tokio::time::{Duration, timeout};
+use tokio::sync::{oneshot, RwLock as TokioRwLock};
+use tokio::time::{timeout, Duration};
 use tokio_util::sync::CancellationToken;
 
 /// A batch of tool tasks to execute together.
@@ -1319,6 +1319,19 @@ impl ToolPipeline {
                         );
                     }
                 }
+                if let Some(write_tool_mode) = task.context.context_vars.get("write_tool_mode") {
+                    if !write_tool_mode.is_empty() {
+                        map.insert(
+                            "write_tool_mode".to_string(),
+                            serde_json::json!(write_tool_mode),
+                        );
+                    }
+                }
+                if let Some(acp_transport) = task.context.context_vars.get("acp_transport") {
+                    if let Ok(flag) = acp_transport.parse::<bool>() {
+                        map.insert("acp_transport".to_string(), serde_json::json!(flag));
+                    }
+                }
                 let deep_review_parent_context =
                     task.context
                         .subagent_parent_info
@@ -1652,14 +1665,12 @@ mod tests {
             result.result.result["provided_arguments"],
             serde_json::Value::String("{\"operation\":\"log\"".to_string())
         );
-        assert!(
-            result
-                .result
-                .result_for_assistant
-                .as_deref()
-                .unwrap_or_default()
-                .contains("Provided arguments: {\"operation\":\"log\"")
-        );
+        assert!(result
+            .result
+            .result_for_assistant
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Provided arguments: {\"operation\":\"log\""));
     }
 
     #[test]
@@ -1700,6 +1711,12 @@ mod tests {
             "primary_model_supports_image_understanding".to_string(),
             "true".to_string(),
         );
+        task.context
+            .context_vars
+            .insert("write_tool_mode".to_string(), "inline_content".to_string());
+        task.context
+            .context_vars
+            .insert("acp_transport".to_string(), "true".to_string());
         task.context.collapsed_tools = vec!["WebFetch".to_string()];
         task.context.unlocked_collapsed_tools = vec!["WebFetch".to_string()];
         task.context.runtime_tool_restrictions = ToolRuntimeRestrictions {
@@ -1716,11 +1733,9 @@ mod tests {
         assert_eq!(context.dialog_turn_id.as_deref(), Some("turn_1"));
         assert_eq!(context.unlocked_collapsed_tools, vec!["WebFetch"]);
         assert!(context.cancellation_token.is_some());
-        assert!(
-            context
-                .runtime_tool_restrictions
-                .is_tool_allowed("WebFetch")
-        );
+        assert!(context
+            .runtime_tool_restrictions
+            .is_tool_allowed("WebFetch"));
         assert!(!context.runtime_tool_restrictions.is_tool_allowed("Bash"));
         assert_eq!(context.custom_data["turn_index"], json!(7));
         assert_eq!(
@@ -1731,6 +1746,11 @@ mod tests {
             context.custom_data["primary_model_supports_image_understanding"],
             json!(true)
         );
+        assert_eq!(
+            context.custom_data["write_tool_mode"],
+            json!("inline_content")
+        );
+        assert_eq!(context.custom_data["acp_transport"], json!(true));
 
         let facts = context.to_tool_context_facts();
         let value = serde_json::to_value(&facts).expect("serialize context facts");
@@ -1750,10 +1770,9 @@ mod tests {
         let err = ToolPipeline::validate_collapsed_tool_usage(&task)
             .expect_err("collapsed tool should require GetToolSpec unlock");
 
-        assert!(
-            err.to_string()
-                .contains("Call GetToolSpec first with {\"tool_name\":\"WebFetch\"}")
-        );
+        assert!(err
+            .to_string()
+            .contains("Call GetToolSpec first with {\"tool_name\":\"WebFetch\"}"));
     }
 
     #[test]

--- a/src/crates/core/src/service/config/types.rs
+++ b/src/crates/core/src/service/config/types.rs
@@ -462,6 +462,31 @@ pub enum ModelCategory {
 
 pub use bitfun_ai_adapters::types::ReasoningMode;
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum WriteToolMode {
+    InlineContent,
+    #[default]
+    PlaintextFollowup,
+}
+
+impl WriteToolMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::InlineContent => "inline_content",
+            Self::PlaintextFollowup => "plaintext_followup",
+        }
+    }
+
+    pub fn from_context_var(value: Option<&str>) -> Self {
+        match value.map(str::trim) {
+            Some("inline_content") => Self::InlineContent,
+            Some("plaintext_followup") => Self::PlaintextFollowup,
+            _ => Self::default(),
+        }
+    }
+}
+
 /// Default model configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -592,6 +617,10 @@ pub struct AIConfig {
     /// Skip tool execution confirmation (global, applies to all modes).
     #[serde(default = "default_skip_tool_confirmation")]
     pub skip_tool_confirmation: bool,
+
+    /// Selects how the Write tool obtains file content.
+    #[serde(default)]
+    pub write_tool_mode: WriteToolMode,
 
     /// Debug-mode configuration (log path, language templates, etc.).
     #[serde(default)]
@@ -1554,6 +1583,7 @@ impl Default for AIConfig {
             tool_execution_timeout_secs: default_tool_execution_timeout(),
             tool_confirmation_timeout_secs: default_tool_confirmation_timeout(),
             skip_tool_confirmation: true,
+            write_tool_mode: WriteToolMode::default(),
             debug_mode_config: DebugModeConfig::default(),
             computer_use_enabled: false,
             browser_control_preferred_browser: String::new(),


### PR DESCRIPTION
- add AIConfig.write_tool_mode with plaintext_followup default
- support inline_content and plaintext_followup under the same Write tool name
- switch Write schema, validation, and execution by context mode
- gate round-executor plaintext follow-up generation by write tool mode
- propagate write tool mode through execution and tool pipeline contexts
- preserve ACP compatibility by forcing inline content mode
