### PR TITLE
feat(mobile-web): add scroll-to-bottom button and dev mode

### DIFF
--- a/src/mobile-web/src/App.tsx
+++ b/src/mobile-web/src/App.tsx
@@ -6,8 +6,39 @@ import ChatPage from './pages/ChatPage';
 import { I18nProvider } from './i18n';
 import { RelayHttpClient } from './services/RelayHttpClient';
 import { RemoteSessionManager } from './services/RemoteSessionManager';
+import { useMobileStore } from './services/store';
+import type { ChatMessage } from './services/RemoteSessionManager';
 import { ThemeProvider } from './theme';
 import './styles/index.scss';
+
+// Dev mode: skip pairing when URL contains ?dev. Creates mock services and seeds
+// the store with sample data so UI features can be developed without a desktop instance.
+function isDevMode(): boolean {
+  return new URLSearchParams(window.location.search).has('dev');
+}
+
+function createMockMessages(): ChatMessage[] {
+  const msgs: ChatMessage[] = [];
+  for (let i = 1; i <= 20; i++) {
+    msgs.push({
+      id: `mock-user-${i}`,
+      role: 'user',
+      content: `这是第 ${i} 条用户消息。What does the git status command do?`,
+      timestamp: new Date(Date.now() - (20 - i) * 60000).toISOString(),
+    });
+    msgs.push({
+      id: `mock-assistant-${i}`,
+      role: 'assistant',
+      content: `## 回答 ${i}\n\n\`git status\` 显示工作目录和暂存区的状态。它告诉你哪些文件被修改了、哪些文件被暂存了、哪些文件没有被 Git 跟踪。\n\n### 常见用法\n\n\`\`\`bash\ngit status\n\`\`\`\n\n\`\`\`bash\ngit status -s  # 简短输出\n\`\`\`\n\n这是一个非常有用的命令，用来了解当前仓库的状态。`,
+      timestamp: new Date(Date.now() - (20 - i) * 60000 + 2000).toISOString(),
+      thinking: i % 3 === 0 ? '用户想了解 git status 命令。这是一个基础的 Git 问题，我应该给出清晰简洁的解释并附带示例。' : undefined,
+      items: i % 5 === 0 ? [
+        { type: 'tool' as const, tool: { id: 'tool-1', name: 'Bash', tool_input: { command: 'git status' }, status: 'completed' as const, input_preview: 'On branch main\nnothing to commit, working tree clean', duration_ms: 150 } },
+      ] : undefined,
+    });
+  }
+  return msgs;
+}
 
 type Page = 'pairing' | 'workspace' | 'sessions' | 'chat';
 type NavDirection = 'push' | 'pop' | null;
@@ -29,12 +60,63 @@ function getNavClass(
 }
 
 const AppContent: React.FC = () => {
-  const [page, setPage] = useState<Page>('pairing');
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
-  const [activeSessionName, setActiveSessionName] = useState<string>('Session');
+  const devMode = isDevMode();
+  const [page, setPage] = useState<Page>(devMode ? 'chat' : 'pairing');
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(devMode ? 'mock-session-1' : null);
+  const [activeSessionName, setActiveSessionName] = useState<string>('Dev Session');
   const [chatAutoFocus, setChatAutoFocus] = useState(false);
   const clientRef = useRef<RelayHttpClient | null>(null);
   const sessionMgrRef = useRef<RemoteSessionManager | null>(null);
+  const [devReady, setDevReady] = useState(false);
+
+  // Dev mode: seed mock data on mount
+  useEffect(() => {
+    if (!devMode) return;
+    const store = useMobileStore.getState();
+    store.setSessions([
+      { session_id: 'mock-session-1', name: 'Dev 会话 1', agent_type: 'code', created_at: new Date().toISOString(), updated_at: new Date().toISOString(), message_count: 40 },
+      { session_id: 'mock-session-2', name: 'Dev 会话 2', agent_type: 'code', created_at: new Date(Date.now() - 3600000).toISOString(), updated_at: new Date(Date.now() - 3600000).toISOString(), message_count: 5 },
+      { session_id: 'mock-session-3', name: 'Dev Cowork', agent_type: 'cowork', created_at: new Date(Date.now() - 7200000).toISOString(), updated_at: new Date(Date.now() - 7200000).toISOString(), message_count: 12 },
+    ]);
+    store.setMessages('mock-session-1', createMockMessages());
+    store.setCurrentWorkspace({
+      has_workspace: true,
+      path: '/home/dev/sample-project',
+      project_name: 'sample-project',
+      git_branch: 'feat/dev-branch',
+      workspace_kind: 'normal',
+    });
+    store.setPairedDisplayMode('pro');
+
+    // Minimal mock client & session manager for UI interaction
+    const mockCatalog: any = {
+      models: [
+        { id: 'auto', name: 'Auto', provider: 'auto', base_url: '', model_name: 'auto', enabled: true, capabilities: [] },
+        { id: 'primary', name: 'Primary Model', provider: 'openai', base_url: '', model_name: 'gpt-4o', enabled: true, capabilities: ['thinking'] },
+        { id: 'fast', name: 'Fast Model', provider: 'openai', base_url: '', model_name: 'gpt-4o-mini', enabled: true, capabilities: [] },
+      ],
+      default_models: { auto: 'auto', primary: 'primary', fast: 'fast' },
+      session_model_id: 'auto',
+    };
+    const mockClient = {
+      pair: async () => ({}),
+      sendCommand: async (cmd: any) => {
+        if (cmd.cmd === 'get_model_catalog') return { catalog: mockCatalog };
+        if (cmd.cmd === 'set_session_model') return { model_id: cmd.model_id || 'auto' };
+        if (cmd.cmd === 'get_session_messages') {
+          const existing = useMobileStore.getState().getMessages(cmd.session_id);
+          return { messages: existing, has_more: false };
+        }
+        return {};
+      },
+      get baseUrl() { return ''; },
+      get room() { return 'dev'; },
+    } as unknown as RelayHttpClient;
+    const mockSessionMgr = new RemoteSessionManager(mockClient);
+    clientRef.current = mockClient;
+    sessionMgrRef.current = mockSessionMgr;
+    setDevReady(true);
+  }, [devMode]);
 
   const [navDir, setNavDir] = useState<NavDirection>(null);
   const [prevPage, setPrevPage] = useState<Page | null>(null);
@@ -43,7 +125,7 @@ const AppContent: React.FC = () => {
   // Track the page stack for browser history integration.
   // When user triggers browser back (phone back button / edge swipe),
   // we intercept popstate and perform in-app navigation instead.
-  const pageStackRef = useRef<Page[]>(['pairing']);
+  const pageStackRef = useRef<Page[]>(devMode ? ['chat'] : ['pairing']);
   const isPopstateNavRef = useRef(false);
 
   const navigateTo = useCallback((target: Page, direction: NavDirection) => {
@@ -171,11 +253,12 @@ const AppContent: React.FC = () => {
   const currentPage: Page = page;
 
   const shouldShow = (p: Page) => currentPage === p || (isAnimating && prevPage === p);
+  const hasSessionMgr = devMode ? devReady : !!sessionMgrRef.current;
 
   return (
     <div className="mobile-app">
-      {page === 'pairing' && <PairingPage onPaired={handlePaired} />}
-      {shouldShow('workspace') && sessionMgrRef.current && (
+      {page === 'pairing' && !devMode && <PairingPage onPaired={handlePaired} />}
+      {shouldShow('workspace') && hasSessionMgr && sessionMgrRef.current && (
         <div className={`nav-page ${getNavClass('workspace', currentPage, navDir, isAnimating)}`}>
           <WorkspacePage
             sessionMgr={sessionMgrRef.current}
@@ -183,7 +266,7 @@ const AppContent: React.FC = () => {
           />
         </div>
       )}
-      {shouldShow('sessions') && sessionMgrRef.current && (
+      {shouldShow('sessions') && hasSessionMgr && sessionMgrRef.current && (
         <div className={`nav-page ${getNavClass('sessions', currentPage, navDir, isAnimating)}`}>
           <SessionListPage
             sessionMgr={sessionMgrRef.current}
@@ -192,7 +275,7 @@ const AppContent: React.FC = () => {
           />
         </div>
       )}
-      {shouldShow('chat') && sessionMgrRef.current && activeSessionId && (
+      {shouldShow('chat') && hasSessionMgr && sessionMgrRef.current && activeSessionId && (
         <div className={`nav-page ${getNavClass('chat', currentPage, navDir, isAnimating)}`}>
           <ChatPage
             sessionMgr={sessionMgrRef.current}

--- a/src/mobile-web/src/i18n/messages.ts
+++ b/src/mobile-web/src/i18n/messages.ts
@@ -143,6 +143,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       fileDownloading: 'Downloading...',
       fileDownloaded: 'Downloaded',
       clickToDownload: 'Click to download',
+      scrollToBottom: 'Scroll to bottom',
     },
     tools: {
       explore: 'Explore',
@@ -297,6 +298,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       fileDownloading: '下载中...',
       fileDownloaded: '已下载',
       clickToDownload: '点击下载',
+      scrollToBottom: '滚动到底部',
     },
     tools: {
       explore: '探索',
@@ -451,6 +453,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       fileDownloading: '下載中...',
       fileDownloaded: '已下載',
       clickToDownload: '點擊下載',
+      scrollToBottom: '捲動到底部',
     },
     tools: {
       explore: '探索',

--- a/src/mobile-web/src/pages/ChatPage.tsx
+++ b/src/mobile-web/src/pages/ChatPage.tsx
@@ -2001,6 +2001,7 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const [expandedMsgIds, setExpandedMsgIds] = useState<Set<string>>(new Set());
   const [infoToast, setInfoToast] = useState<string | null>(null);
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
 
   const isStreaming = activeTurn != null && activeTurn.status === 'active';
 
@@ -2137,6 +2138,8 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
   }, [sessionMgr, sessionId, setMessages, setError, getMessages]);
 
   const isNearBottomRef = useRef(true);
+  const programmaticScrollRef = useRef(false);
+  const lastShowScrollToBottomRef = useRef(false);
   const BOTTOM_THRESHOLD = 80;
 
   const handleScroll = useCallback(() => {
@@ -2144,13 +2147,32 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
     if (!container) return;
 
     const gap = container.scrollHeight - container.scrollTop - container.clientHeight;
-    isNearBottomRef.current = gap < BOTTOM_THRESHOLD;
+    const nearBottom = gap < BOTTOM_THRESHOLD;
+    isNearBottomRef.current = nearBottom;
+    if (nearBottom) {
+      programmaticScrollRef.current = false;
+    }
+    if (!programmaticScrollRef.current) {
+      const show = !nearBottom;
+      if (show !== lastShowScrollToBottomRef.current) {
+        lastShowScrollToBottomRef.current = show;
+        setShowScrollToBottom(show);
+      }
+    }
 
     if (container.scrollTop < 100 && hasMore && !isLoadingMore) {
       const msgs = getMessages(sessionId);
       if (msgs.length > 0) loadMessages(msgs[0].id);
     }
   }, [hasMore, isLoadingMore, getMessages, sessionId, loadMessages]);
+
+  const scrollToBottom = useCallback(() => {
+    programmaticScrollRef.current = true;
+    isNearBottomRef.current = true;
+    setShowScrollToBottom(false);
+    lastShowScrollToBottomRef.current = false;
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, []);
 
   // Initial load + start poller
   const initialScrollDone = useRef(false);
@@ -2231,6 +2253,7 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
       const isNewAppend = messages.length > prevMsgCountRef.current;
       prevMsgCountRef.current = messages.length;
       if (isNewAppend && !isLoadingMore && isNearBottomRef.current) {
+        programmaticScrollRef.current = true;
         messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
       }
     }
@@ -2239,11 +2262,13 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
   useEffect(() => {
     if (!initialScrollDone.current || !isStreaming) return;
     if (!isNearBottomRef.current) return;
+    programmaticScrollRef.current = true;
     messagesEndRef.current?.scrollIntoView({ behavior: 'auto' });
   }, [activeTurn, isStreaming]);
 
   useEffect(() => {
     if (optimisticMsg) {
+      programmaticScrollRef.current = true;
       isNearBottomRef.current = true;
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
@@ -2257,6 +2282,7 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
       if (!isNearBottomRef.current) return;
       const gap = container.scrollHeight - container.scrollTop - container.clientHeight;
       if (gap > 10 && gap < 400) {
+        programmaticScrollRef.current = true;
         container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
       }
     }, 300);
@@ -2399,10 +2425,6 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
       e.preventDefault();
       handleSend();
     }
-    if (e.key === 'Tab' && e.shiftKey) {
-      e.preventDefault();
-      cycleAgentMode();
-    }
   };
 
   const handleCancel = async () => {
@@ -2419,9 +2441,9 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Tab' && e.shiftKey) {
-        // Skip when the textarea is focused — its own React handler already fired.
-        const tag = (e.target as HTMLElement)?.tagName;
-        if (tag === 'TEXTAREA') return;
+        const target = e.target as HTMLElement;
+        const tag = target?.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target?.isContentEditable) return;
         e.preventDefault();
         cycleAgentModeRef.current();
       }
@@ -2692,7 +2714,21 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
         )}
 
         <div ref={messagesEndRef} />
+
       </div>
+
+      {showScrollToBottom && (
+        <button
+          type="button"
+          className="chat-page__scroll-to-bottom"
+          onClick={scrollToBottom}
+          aria-label={t('chat.scrollToBottom')}
+        >
+          <svg aria-hidden="true" focusable="false" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+      )}
 
       {/* Floating Input Bar — two-stage (matches desktop ChatInput) */}
       <input

--- a/src/mobile-web/src/styles/components/chat.scss
+++ b/src/mobile-web/src/styles/components/chat.scss
@@ -133,6 +133,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--size-gap-4);
+  position: relative;
 }
 
 .chat-page__load-more-indicator {
@@ -140,6 +141,51 @@
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
   padding: var(--size-gap-2) 0;
+}
+
+.chat-page__scroll-to-bottom {
+  position: fixed;
+  bottom: 110px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid var(--border-subtle);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-md);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 15;
+  animation: scrollBtnIn 200ms var(--easing-standard);
+
+  &:active {
+    transform: translateX(-50%) scale(0.92);
+    box-shadow: var(--shadow-sm);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent-500);
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+
+  @media (forced-colors: active) {
+    border: 2px solid ButtonText;
+    background: ButtonFace;
+    color: ButtonText;
+  }
+}
+
+@keyframes scrollBtnIn {
+  from { opacity: 0; transform: translateX(-50%) scale(0.7); }
+  to   { opacity: 1; transform: translateX(-50%) scale(1); }
 }
 
 // Message items — FlowChat style (no bubbles)

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -2056,7 +2056,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       e.preventDefault();
       e.stopPropagation();
 
-      // Dismiss slash command if open
       if (slashCommandState.isActive) {
         setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
         dispatchInput({ type: 'CLEAR_VALUE' });


### PR DESCRIPTION
## Summary

- **Scroll-to-bottom button**: A floating button appears when the user scrolls up from the message list on mobile. Tapping it smoothly scrolls back to the latest messages. Suppresses flicker during auto-scroll via `programmaticScrollRef` guard.
- **Dev mode**: Adding `?dev` to the URL seeds mock data and bypasses pairing, enabling offline UI development without a desktop instance.
- **Shift+Tab fixes**: Exclude all text-editing elements (INPUT, TEXTAREA, SELECT, contentEditable) from the document-level mode cycling listener on mobile. Remove unnecessary comment on desktop.

## Test plan

- [x] Scroll up in a chat page on mobile → scroll-to-bottom button appears
- [x] Tap button → smooth scroll to bottom, button disappears
- [x] Auto-scroll (new messages, streaming) does not show button flicker
- [x] `?dev` URL parameter bypasses pairing and shows mock data with 20 messages
- [x] Shift+Tab mode cycling does not trigger when typing in INPUT/TEXTAREA/SELECT/contentEditable
- [x] Accessibility: focus-visible outline, prefers-reduced-motion, forced-colors