### PR TITLE
feat(bash tool): auto-deliver background task results and bash completions

### DIFF
--- a/src/crates/core/src/agentic/agents/prompts/multitask_mode_first_entry_reminder.md
+++ b/src/crates/core/src/agentic/agents/prompts/multitask_mode_first_entry_reminder.md
@@ -5,6 +5,7 @@ Treat the task as a parallel work orchestration problem whenever it is beneficia
 # Subagent Delegation Guide
 
 - Prefer background subagents whenever the branch is independent and does not block your immediate next step. Use `run_in_background: true` on the Task call to launch it in the background.
+- Background subagent results are delivered back to you automatically when they finish. Do not poll or repeatedly check on background work just for status updates. If your current path is blocked on a background result and there is no other productive local work to do, it is fine to end the current turn instead of waiting idly.
 - Keep yourself on the critical path. Handle decomposition, dependency management, interface alignment, integration, and final verification yourself.
 - Use `FileFinder` when the subtask is primarily about locating relevant files, entry points, symbols, or ownership boundaries.
 - Use `Explore` when the subtask is read-only investigation, codebase understanding, or evidence gathering that should not modify files.

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -26,8 +26,8 @@ use crate::agentic::WorkspaceBinding;
 use crate::service::bootstrap::{
     ensure_workspace_persona_files_for_prompt, is_workspace_bootstrap_pending,
 };
-use crate::service::session::{SessionRelationship, SessionRelationshipKind};
 use crate::service::config::global::GlobalConfigManager;
+use crate::service::session::{SessionRelationship, SessionRelationshipKind};
 use crate::service::workspace::{
     get_global_workspace_service, WorkspaceCreateOptions, WorkspaceKind,
 };
@@ -1623,8 +1623,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         };
         let effective_agent_type = Self::normalize_agent_type(&provisional_agent_type);
 
-        Self::track_session_workspace_activity_best_effort(&session.config, "dialog_started")
-            .await;
+        Self::track_session_workspace_activity_best_effort(&session.config, "dialog_started").await;
 
         debug!(
             "Resolved dialog turn agent type: session_id={}, turn_id={}, requested_agent_type={}, session_agent_type={}, effective_agent_type={}, trigger_source={:?}, queue_priority={:?}, skip_tool_confirmation={}",
@@ -2663,7 +2662,10 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         self.session_manager.list_sessions(workspace_path).await
     }
 
-    pub async fn resolve_session_workspace_path(&self, session_id: &str) -> Option<std::path::PathBuf> {
+    pub async fn resolve_session_workspace_path(
+        &self,
+        session_id: &str,
+    ) -> Option<std::path::PathBuf> {
         self.session_manager
             .resolve_session_workspace_path(session_id)
             .await
@@ -3075,10 +3077,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         self.session_manager
             .persist_session_lineage(
                 &session_id,
-                build_subagent_session_relationship(
-                    subagent_parent_info.as_ref(),
-                    &agent_type,
-                ),
+                build_subagent_session_relationship(subagent_parent_info.as_ref(), &agent_type),
             )
             .await?;
 
@@ -3861,9 +3860,8 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             context: context.unwrap_or_default(),
             runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
         };
-        let coordinator = get_global_coordinator().ok_or_else(|| {
-            BitFunError::service("Coordinator not initialized".to_string())
-        })?;
+        let coordinator = get_global_coordinator()
+            .ok_or_else(|| BitFunError::service("Coordinator not initialized".to_string()))?;
 
         tokio::spawn(async move {
             let delivery_text = match coordinator
@@ -3883,7 +3881,8 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             };
 
             let metadata = serde_json::json!({
-                "kind": "background_subagent_result",
+                "kind": "background_result",
+                "sourceKind": "subagent",
                 "backgroundTaskId": background_task_id_for_delivery,
                 "subagentType": agent_type,
                 "taskDescription": task_description,
@@ -3891,7 +3890,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
 
             if let Some(scheduler) = super::scheduler::get_global_scheduler() {
                 if let Err(error) = scheduler
-                    .deliver_background_subagent_result(
+                    .deliver_background_result(
                         subagent_parent_info.session_id.clone(),
                         parent_agent_type,
                         parent_workspace_path,
@@ -4479,10 +4478,8 @@ mod tests {
         assert!(completed_text.contains("<result>\n"));
         assert!(!completed_text.contains("background_task_id=\"bg-subagent-123\""));
 
-        let partial = super::SubagentResult::partial_timeout(
-            "partial".to_string(),
-            "timeout".to_string(),
-        );
+        let partial =
+            super::SubagentResult::partial_timeout("partial".to_string(), "timeout".to_string());
         let partial_text = super::format_background_subagent_delivery_text(
             "bg-subagent-456",
             "GeneralPurpose",

--- a/src/crates/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/core/src/agentic/coordination/scheduler.rs
@@ -15,9 +15,8 @@ use super::turn_outcome::{TurnOutcome, TurnOutcomeQueueAction, TurnOutcomeStatus
 use crate::agentic::core::{PromptEnvelope, SessionState};
 use crate::agentic::image_analysis::ImageContextData;
 use crate::agentic::round_preempt::{
-    DialogRoundInjectionSource, DialogRoundPreemptSource, RoundInjection,
-    RoundInjectionKind, RoundInjectionTarget, SessionRoundInjectionBuffer,
-    SessionRoundYieldFlags,
+    DialogRoundInjectionSource, DialogRoundPreemptSource, RoundInjection, RoundInjectionKind,
+    RoundInjectionTarget, SessionRoundInjectionBuffer, SessionRoundYieldFlags,
 };
 use crate::agentic::session::SessionManager;
 use dashmap::DashMap;
@@ -291,12 +290,12 @@ impl DialogScheduler {
         })
     }
 
-    /// Deliver a completed background subagent result back to the parent
-    /// session. If the session is currently processing, inject the result into
-    /// the running turn at the next model-round boundary. Otherwise, start a
-    /// new turn immediately so the result is handled without waiting for an
+    /// Deliver a completed background result back to the parent session.
+    /// If the session is currently processing, inject the result into the
+    /// running turn at the next model-round boundary. Otherwise, start a new
+    /// turn immediately so the result is handled without waiting for an
     /// unrelated future message.
-    pub async fn deliver_background_subagent_result(
+    pub async fn deliver_background_result(
         &self,
         session_id: String,
         agent_type: String,
@@ -318,7 +317,7 @@ impl DialogScheduler {
                     &session_id,
                     RoundInjection {
                         id: injection_id,
-                        kind: RoundInjectionKind::BackgroundSubagentResult,
+                        kind: RoundInjectionKind::BackgroundResult,
                         target: RoundInjectionTarget::CurrentRunningTurn,
                         content,
                         display_content: display,
@@ -327,8 +326,8 @@ impl DialogScheduler {
                 );
                 Ok(())
             }
-            _ => {
-                self.submit(
+            _ => self
+                .submit(
                     session_id,
                     content,
                     Some(display),
@@ -341,8 +340,7 @@ impl DialogScheduler {
                     None,
                 )
                 .await
-                .map(|_| ())
-            }
+                .map(|_| ()),
         }
     }
 

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -2127,8 +2127,8 @@ impl ExecutionEngine {
                                 "<system_reminder>\nThe user sent a new message while this turn was running. You have just finished the previous atomic action; handle this new user message now as the current direction, while preserving the existing conversation and task context. Do not ignore it or wait for a separate future turn.\n\nNew user message:\n{}\n</system_reminder>",
                                 injection.content
                             ),
-                            RoundInjectionKind::BackgroundSubagentResult => format!(
-                                "<system_reminder>\nA background subagent has finished and returned new information while this turn was running. Incorporate it into your current work immediately when relevant. Do not wait for a separate future turn.\n\nBackground subagent result:\n{}\n</system_reminder>",
+                            RoundInjectionKind::BackgroundResult => format!(
+                                "<system_reminder>\nA background task has finished and returned new information while this turn was running. Incorporate it into your current work immediately when relevant. Do not wait for a separate future turn.\n\nBackground result:\n{}\n</system_reminder>",
                                 injection.content
                             ),
                         };

--- a/src/crates/core/src/agentic/round_preempt.rs
+++ b/src/crates/core/src/agentic/round_preempt.rs
@@ -70,7 +70,7 @@ impl DialogRoundPreemptSource for SessionRoundYieldFlags {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RoundInjectionKind {
     UserSteering,
-    BackgroundSubagentResult,
+    BackgroundResult,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -245,7 +245,7 @@ mod steering_tests {
     fn current_turn_msg(content: &str) -> RoundInjection {
         RoundInjection {
             id: uuid::Uuid::new_v4().to_string(),
-            kind: RoundInjectionKind::BackgroundSubagentResult,
+            kind: RoundInjectionKind::BackgroundResult,
             target: RoundInjectionTarget::CurrentRunningTurn,
             content: content.to_string(),
             display_content: content.to_string(),

--- a/src/crates/core/src/agentic/tools/implementations/bash_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/bash_tool.rs
@@ -1,3 +1,4 @@
+use crate::agentic::coordination::scheduler::get_global_scheduler;
 use crate::agentic::tools::framework::{
     Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
@@ -19,8 +20,8 @@ use std::time::{Duration, Instant};
 use terminal_core::session::SessionSource;
 use terminal_core::shell::{ShellDetector, ShellType};
 use terminal_core::{
-    CommandCompletionReason, CommandStreamEvent, ExecuteCommandRequest, SendCommandRequest,
-    SignalRequest, TerminalApi, TerminalBindingOptions, TerminalSessionBinding,
+    CommandCompletionReason, CommandStreamEvent, ExecuteCommandRequest, SignalRequest, TerminalApi,
+    TerminalBindingOptions, TerminalSessionBinding,
 };
 use tokio::io::AsyncWriteExt;
 use tool_runtime::util::ansi_cleaner::strip_ansi;
@@ -354,6 +355,91 @@ impl BashTool {
     fn cancellation_error(stage: &str) -> BitFunError {
         BitFunError::cancelled(format!("Bash tool execution cancelled {}", stage))
     }
+
+    fn background_output_file_reference(
+        context: &ToolUseContext,
+        chat_session_id: &str,
+        tool_use_id: &str,
+        output_file_path: &Path,
+    ) -> String {
+        context
+            .build_session_runtime_artifact_reference(
+                chat_session_id,
+                &format!("tool-results/{}.txt", tool_use_id),
+            )
+            .unwrap_or_else(|_| output_file_path.display().to_string())
+    }
+
+    fn format_background_command_delivery_text(
+        command: &str,
+        terminal_session_id: &str,
+        working_directory: &str,
+        exit_code: Option<i32>,
+        timed_out: bool,
+        interrupted: bool,
+        output_file_reference: &str,
+        output_persist_error: Option<&str>,
+    ) -> String {
+        let (status, summary) = if timed_out {
+            ("timeout", "Background Bash command timed out.")
+        } else if interrupted {
+            ("interrupted", "Background Bash command was interrupted.")
+        } else if exit_code == Some(0) {
+            (
+                "completed",
+                "Background Bash command completed successfully.",
+            )
+        } else {
+            (
+                "failed",
+                "Background Bash command completed with a non-zero exit code.",
+            )
+        };
+        let exit_code_attr = exit_code
+            .map(|code| format!(" exit_code=\"{}\"", code))
+            .unwrap_or_default();
+        let persistence_line = output_persist_error.map_or_else(
+            || format!("Full output was saved to: {}", output_file_reference),
+            |error| {
+                format!(
+                    "Output persistence encountered an error while writing {}: {}",
+                    output_file_reference, error
+                )
+            },
+        );
+
+        format!(
+            "{summary}\n<background_command status=\"{status}\" terminal_session_id=\"{terminal_session_id}\"{exit_code_attr}>\nCommand: {command}\nWorking directory: {working_directory}\n{persistence_line}\n</background_command>"
+        )
+    }
+
+    fn format_background_command_error_text(
+        command: &str,
+        terminal_session_id: &str,
+        working_directory: &str,
+        output_file_reference: &str,
+        error: &str,
+        output_persist_error: Option<&str>,
+    ) -> String {
+        let persistence_line = output_persist_error.map_or_else(
+            || {
+                format!(
+                    "Any captured output was saved to: {}",
+                    output_file_reference
+                )
+            },
+            |persist_error| {
+                format!(
+                    "Output persistence encountered an error while writing {}: {}",
+                    output_file_reference, persist_error
+                )
+            },
+        );
+
+        format!(
+            "Background Bash command failed before producing a final completion result.\n<background_command status=\"error\" terminal_session_id=\"{terminal_session_id}\">\nCommand: {command}\nWorking directory: {working_directory}\n{persistence_line}\nError: {error}\n</background_command>"
+        )
+    }
 }
 
 #[async_trait]
@@ -394,7 +480,7 @@ Usage notes:
   - You can specify an optional timeout in milliseconds (up to 600000ms / 10 minutes). If not specified, commands will timeout after 120000ms (2 minutes).
   - It is very helpful if you write a clear, concise description of what this command does. For simple commands, keep it brief (5-10 words). For complex commands (piped commands, obscure flags, or anything hard to understand at a glance), add enough context to clarify what it does.
   - If the output exceeds {MAX_OUTPUT_LENGTH} characters, output will be truncated before being returned to you, with the tail of the output preserved because the ending is usually more important.
-  - You can use the `run_in_background` parameter to run the command in a new dedicated background terminal session. The tool returns the background session ID immediately without waiting for the command to finish. Only use this for long-running processes (e.g., dev servers, watchers) where you don't need the output right away. You do not need to append '&' to the command. NOTE: `timeout_ms` is ignored when `run_in_background` is true.
+  - You can use the `run_in_background` parameter to run the command in a new dedicated background terminal session. The tool returns immediately without waiting for the command to finish. The final completion result will be delivered back to you automatically when it is done, and the full output will be saved to a session runtime file instead of being pasted back into chat. Only use this for long-running processes (e.g., dev servers, watchers) where you do not need the output right away. You do not need to append '&' to the command. NOTE: `timeout_ms` is ignored when `run_in_background` is true.
   - Each result includes a `<terminal_session_id>` tag identifying the terminal session. The persistent shell session ID remains constant throughout the entire conversation; background sessions each have their own unique ID.
   - The output may include the command echo and/or the shell prompt (e.g., `PS C:\path>`). Do not treat these as part of the command's actual result.
   - Avoid interactive commands that may block waiting for user input or open a pager/editor. Prefer non-interactive variants and explicit flags. For example, use `git --no-pager diff` instead of `git diff`, and avoid commands that prompt for confirmation unless the User explicitly asks for them.
@@ -454,7 +540,7 @@ Usage notes:
                 },
                 "run_in_background": {
                     "type": "boolean",
-                    "description": "If true, runs the command in a new dedicated background terminal session and returns the session ID immediately without waiting for completion. Useful for long-running processes like dev servers or file watchers. timeout_ms is ignored when this is true."
+                    "description": "If true, runs the command in a new dedicated background terminal session and returns immediately. The final completion result is delivered back automatically when the command finishes, and the full output is saved to a session runtime file instead of being injected into chat. Useful for long-running processes like dev servers or file watchers. timeout_ms is ignored when this is true."
                 },
                 "working_directory": {
                     "type": "string",
@@ -842,7 +928,6 @@ Usage notes:
                     &initial_cwd,
                     context,
                     shell_type,
-                    &terminal_api,
                     &binding,
                     start_time,
                 )
@@ -1147,7 +1232,6 @@ impl BashTool {
         initial_cwd: &str,
         context: &ToolUseContext,
         shell_type: Option<ShellType>,
-        terminal_api: &TerminalApi,
         binding: &TerminalSessionBinding,
         start_time: Instant,
     ) -> BitFunResult<Vec<ToolResult>> {
@@ -1190,10 +1274,9 @@ impl BashTool {
             .unwrap_or_else(|| format!("bash_{}", uuid::Uuid::new_v4()));
         Self::emit_terminal_ready_event(&tool_use_id, &bg_session_id);
 
-        // Subscribe to session output before sending the command so no data is missed
-        let mut output_rx = terminal_api.subscribe_session_output(&bg_session_id);
-
         if Self::cancellation_requested(context) {
+            let terminal_api = TerminalApi::from_singleton()
+                .map_err(|e| BitFunError::tool(format!("Terminal not initialized: {}", e)))?;
             let _ = terminal_api
                 .close_session(terminal_core::CloseSessionRequest {
                     session_id: bg_session_id.clone(),
@@ -1205,98 +1288,287 @@ impl BashTool {
             ));
         }
 
-        // Fire-and-forget: write the command to the PTY without waiting for completion
-        terminal_api
-            .send_command(SendCommandRequest {
-                session_id: bg_session_id.clone(),
-                command: command_str.to_string(),
-            })
+        // Store background output under the session-scoped runtime tool-results tree:
+        // local:  ~/.bitfun/projects/<project-slug>/sessions/<chat-session-id>/tool-results/<tool-use-id>.txt
+        // remote: ~/.bitfun/remote_ssh/<host>/<remote-path>/sessions/<chat-session-id>/tool-results/<tool-use-id>.txt
+        let output_file_path =
+            Self::background_output_file_path(context, chat_session_id, &tool_use_id).ok_or_else(
+                || {
+                    BitFunError::tool(
+                        "Failed to prepare a background output file for Bash tool".to_string(),
+                    )
+                },
+            )?;
+        if let Some(parent) = output_file_path.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                BitFunError::tool(format!(
+                    "Failed to create background output directory: {}",
+                    e
+                ))
+            })?;
+        }
+        let output_file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&output_file_path)
             .await
-            .map_err(|e| BitFunError::tool(format!("Failed to send background command: {}", e)))?;
+            .map_err(|e| {
+                BitFunError::tool(format!("Failed to open background output file: {}", e))
+            })?;
+        let output_file_reference = Self::background_output_file_reference(
+            context,
+            chat_session_id,
+            &tool_use_id,
+            &output_file_path,
+        );
 
         debug!(
             "Background command started, session_id: {}, owner: {}",
             bg_session_id, chat_session_id
         );
 
-        // Store background output under the session-scoped runtime tool-results tree:
-        // local:  ~/.bitfun/projects/<project-slug>/sessions/<chat-session-id>/tool-results/<tool-use-id>.txt
-        // remote: ~/.bitfun/remote_ssh/<host>/<remote-path>/sessions/<chat-session-id>/tool-results/<tool-use-id>.txt
-        let output_file_path =
-            Self::background_output_file_path(context, chat_session_id, &tool_use_id);
+        let parent_session_id = chat_session_id.to_string();
+        let parent_agent_type = context
+            .agent_type
+            .clone()
+            .unwrap_or_else(|| "Agentic".to_string());
+        let parent_workspace_path = context
+            .workspace_root()
+            .map(|path| path.to_string_lossy().to_string());
+        let command = command_str.to_string();
+        let working_directory = initial_cwd.to_string();
+        let terminal_session_id = bg_session_id.clone();
+        let output_file_reference_for_task = output_file_reference.clone();
+        let tool_use_id_for_task = tool_use_id.clone();
 
-        // Spawn task: write PTY output to file, delete when session ends
-        if let Some(file_path) = output_file_path.clone() {
-            let bg_id_for_log = bg_session_id.clone();
-            tokio::spawn(async move {
-                if let Some(parent) = file_path.parent() {
-                    if let Err(e) = tokio::fs::create_dir_all(parent).await {
-                        error!(
-                            "Failed to create tool-results output dir for bg session {}: {}",
-                            bg_id_for_log, e
-                        );
-                        return;
-                    }
+        tokio::spawn(async move {
+            let mut writer = tokio::io::BufWriter::new(output_file);
+            let mut output_persist_error: Option<String> = None;
+            let mut saw_output_event = false;
+            let mut saw_completion = false;
+            let mut delivery_sent = false;
+
+            let terminal_api = match TerminalApi::from_singleton() {
+                Ok(api) => api,
+                Err(error) => {
+                    error!(
+                        "Background Bash command could not access terminal singleton: session_id={}, error={}",
+                        terminal_session_id, error
+                    );
+                    return;
                 }
+            };
 
-                let file = match tokio::fs::OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .truncate(true)
-                    .open(&file_path)
-                    .await
-                {
-                    Ok(f) => f,
-                    Err(e) => {
-                        error!(
-                            "Failed to open output file for bg session {}: {}",
-                            bg_id_for_log, e
+            let mut stream = terminal_api.execute_command_stream(ExecuteCommandRequest {
+                session_id: terminal_session_id.clone(),
+                command: command.clone(),
+                timeout_ms: None,
+                prevent_history: Some(true),
+            });
+
+            while let Some(event) = stream.next().await {
+                match event {
+                    CommandStreamEvent::Started { command_id } => {
+                        debug!(
+                            "Background Bash command started execution, session_id={}, command_id={}",
+                            terminal_session_id, command_id
                         );
-                        return;
                     }
-                };
+                    CommandStreamEvent::Output { data } => {
+                        saw_output_event = true;
+                        if output_persist_error.is_none() {
+                            if let Err(error) = writer.write_all(data.as_bytes()).await {
+                                output_persist_error = Some(error.to_string());
+                                error!(
+                                    "Failed to write background Bash output: session_id={}, error={}",
+                                    terminal_session_id, error
+                                );
+                            } else if let Err(error) = writer.flush().await {
+                                output_persist_error = Some(error.to_string());
+                                error!(
+                                    "Failed to flush background Bash output: session_id={}, error={}",
+                                    terminal_session_id, error
+                                );
+                            }
+                        }
+                    }
+                    CommandStreamEvent::Completed {
+                        exit_code,
+                        total_output,
+                        completion_reason,
+                        shell_state: _,
+                    } => {
+                        saw_completion = true;
 
-                let mut writer = tokio::io::BufWriter::new(file);
+                        if !saw_output_event
+                            && !total_output.is_empty()
+                            && output_persist_error.is_none()
+                        {
+                            if let Err(error) = writer.write_all(total_output.as_bytes()).await {
+                                output_persist_error = Some(error.to_string());
+                                error!(
+                                    "Failed to persist background Bash completion output: session_id={}, error={}",
+                                    terminal_session_id, error
+                                );
+                            } else if let Err(error) = writer.flush().await {
+                                output_persist_error = Some(error.to_string());
+                                error!(
+                                    "Failed to flush background Bash completion output: session_id={}, error={}",
+                                    terminal_session_id, error
+                                );
+                            }
+                        }
 
-                while let Some(data) = output_rx.recv().await {
-                    if let Err(e) = writer.write_all(data.as_bytes()).await {
-                        error!(
-                            "Failed to write output for bg session {}: {}",
-                            bg_id_for_log, e
+                        let timed_out = completion_reason == CommandCompletionReason::TimedOut;
+                        let interrupted =
+                            !timed_out && matches!(exit_code, Some(130) | Some(-1073741510));
+                        let delivery_text = Self::format_background_command_delivery_text(
+                            &command,
+                            &terminal_session_id,
+                            &working_directory,
+                            exit_code,
+                            timed_out,
+                            interrupted,
+                            &output_file_reference_for_task,
+                            output_persist_error.as_deref(),
                         );
+                        let metadata = json!({
+                            "kind": "background_result",
+                            "sourceKind": "bash_command",
+                            "toolName": "Bash",
+                            "toolCallId": tool_use_id_for_task.clone(),
+                            "terminalSessionId": terminal_session_id.clone(),
+                            "command": command.clone(),
+                            "workingDirectory": working_directory.clone(),
+                            "outputFile": output_file_reference_for_task.clone(),
+                        });
+
+                        if let Some(scheduler) = get_global_scheduler() {
+                            if let Err(error) = scheduler
+                                .deliver_background_result(
+                                    parent_session_id.clone(),
+                                    parent_agent_type.clone(),
+                                    parent_workspace_path.clone(),
+                                    delivery_text,
+                                    None,
+                                    Some(metadata),
+                                )
+                                .await
+                            {
+                                error!(
+                                    "Failed to deliver background Bash result: session_id={}, terminal_session_id={}, error={}",
+                                    parent_session_id, terminal_session_id, error
+                                );
+                            }
+                        } else {
+                            error!(
+                                "Scheduler not initialized; background Bash result dropped: session_id={}, terminal_session_id={}",
+                                parent_session_id, terminal_session_id
+                            );
+                        }
+                        delivery_sent = true;
                         break;
                     }
-                    let _ = writer.flush().await;
-                }
+                    CommandStreamEvent::Error { message } => {
+                        let delivery_text = Self::format_background_command_error_text(
+                            &command,
+                            &terminal_session_id,
+                            &working_directory,
+                            &output_file_reference_for_task,
+                            &message,
+                            output_persist_error.as_deref(),
+                        );
+                        let metadata = json!({
+                            "kind": "background_result",
+                            "sourceKind": "bash_command",
+                            "toolName": "Bash",
+                            "toolCallId": tool_use_id_for_task.clone(),
+                            "terminalSessionId": terminal_session_id.clone(),
+                            "command": command.clone(),
+                            "workingDirectory": working_directory.clone(),
+                            "outputFile": output_file_reference_for_task.clone(),
+                            "error": message.clone(),
+                        });
 
-                // Channel closed means session was destroyed - delete the log file
-                drop(writer);
-                if let Err(e) = tokio::fs::remove_file(&file_path).await {
-                    debug!(
-                        "Could not remove output file for bg session {} (may already be gone): {}",
-                        bg_id_for_log, e
-                    );
-                } else {
-                    debug!("Removed output file for bg session {}", bg_id_for_log);
+                        if let Some(scheduler) = get_global_scheduler() {
+                            if let Err(error) = scheduler
+                                .deliver_background_result(
+                                    parent_session_id.clone(),
+                                    parent_agent_type.clone(),
+                                    parent_workspace_path.clone(),
+                                    delivery_text,
+                                    None,
+                                    Some(metadata),
+                                )
+                                .await
+                            {
+                                error!(
+                                    "Failed to deliver background Bash error result: session_id={}, terminal_session_id={}, error={}",
+                                    parent_session_id, terminal_session_id, error
+                                );
+                            }
+                        } else {
+                            error!(
+                                "Scheduler not initialized; background Bash error result dropped: session_id={}, terminal_session_id={}",
+                                parent_session_id, terminal_session_id
+                            );
+                        }
+                        delivery_sent = true;
+                        break;
+                    }
                 }
-            });
-        }
+            }
+
+            if !saw_completion && !delivery_sent {
+                let delivery_text = Self::format_background_command_error_text(
+                    &command,
+                    &terminal_session_id,
+                    &working_directory,
+                    &output_file_reference_for_task,
+                    "Background Bash command stream ended without a completion event.",
+                    output_persist_error.as_deref(),
+                );
+                let metadata = json!({
+                    "kind": "background_result",
+                    "sourceKind": "bash_command",
+                    "toolName": "Bash",
+                    "toolCallId": tool_use_id_for_task,
+                    "terminalSessionId": terminal_session_id.clone(),
+                    "command": command.clone(),
+                    "workingDirectory": working_directory.clone(),
+                    "outputFile": output_file_reference_for_task.clone(),
+                    "error": "stream_ended_without_completion",
+                });
+
+                if let Some(scheduler) = get_global_scheduler() {
+                    if let Err(error) = scheduler
+                        .deliver_background_result(
+                            parent_session_id.clone(),
+                            parent_agent_type.clone(),
+                            parent_workspace_path.clone(),
+                            delivery_text,
+                            None,
+                            Some(metadata),
+                        )
+                        .await
+                    {
+                        error!(
+                            "Failed to deliver background Bash terminal stream-end result: session_id={}, terminal_session_id={}, error={}",
+                            parent_session_id, terminal_session_id, error
+                        );
+                    }
+                } else {
+                    error!(
+                        "Scheduler not initialized; background Bash stream-end result dropped: session_id={}, terminal_session_id={}",
+                        parent_session_id, terminal_session_id
+                    );
+                }
+            }
+        });
 
         let execution_time_ms = elapsed_ms_u64(start_time);
-
-        let output_file_str = output_file_path.as_deref().map(|p| p.display().to_string());
-        let output_file_reference = context
-            .build_session_runtime_artifact_reference(
-                chat_session_id,
-                &format!("tool-results/{}.txt", tool_use_id),
-            )
-            .ok()
-            .or_else(|| output_file_str.clone());
-
-        let output_file_note = output_file_reference
-            .as_deref()
-            .map(|s| format!("\nOutput is being written to: {}", s))
-            .unwrap_or_default();
+        let output_file_note = format!("\nFull output will be saved to: {}", output_file_reference);
 
         let result_data = json!({
             "success": true,
@@ -1308,10 +1580,11 @@ impl BashTool {
             "execution_time_ms": execution_time_ms,
             "terminal_session_id": bg_session_id,
             "output_file": output_file_reference,
+            "run_in_background": true,
         });
 
         let result_for_assistant = format!(
-            "Command started in background terminal session (id: {}). Working directory: {}.{}",
+            "Command started in background terminal session (id: {}). Working directory: {}.{} Its final result will be delivered back automatically when it finishes. Do not poll for status updates. If your current path is blocked on this result and there is no other useful local work to do, it is fine to end the current turn.",
             bg_session_id, initial_cwd, output_file_note
         );
 
@@ -1448,5 +1721,26 @@ mod tests {
         assert!(rendered.contains("<exit_code>1</exit_code>"));
         assert!(rendered.contains("<working_directory>/private/tmp</working_directory>"));
         assert!(rendered.contains("ERR_PNPM_NO_PKG_MANIFEST"));
+    }
+
+    #[test]
+    fn background_delivery_text_points_to_saved_output_file() {
+        let rendered = BashTool::format_background_command_delivery_text(
+            "pnpm test",
+            "bg-session-1",
+            "/repo",
+            Some(0),
+            false,
+            false,
+            "/runtime/sessions/session/tool-results/bash_123.txt",
+            None,
+        );
+
+        assert!(rendered.contains("Background Bash command completed successfully."));
+        assert!(rendered.contains("status=\"completed\""));
+        assert!(rendered.contains("terminal_session_id=\"bg-session-1\""));
+        assert!(rendered.contains(
+            "Full output was saved to: /runtime/sessions/session/tool-results/bash_123.txt"
+        ));
     }
 }

--- a/src/crates/core/src/agentic/tools/implementations/task_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/task_tool.rs
@@ -1139,7 +1139,7 @@ impl Tool for TaskTool {
                     "background_task_id": background_result.background_task_id,
                 }),
                 result_for_assistant: Some(format!(
-                    "Background subagent '{}' started successfully.\n<background_task status=\"started\" id=\"{}\">Its final result will be delivered back automatically to you when it is finished.</background_task>",
+                    "Background subagent '{}' started successfully.\n<background_task status=\"started\" id=\"{}\">Its final result will be delivered back automatically to you when it is finished. Do not poll for status updates. If your current path is blocked on this result and there is no other useful local work to do, it is fine to end the current turn.</background_task>",
                     subagent_type, background_result.background_task_id
                 )),
                 image_attachments: None,


### PR DESCRIPTION
- generalize background result delivery beyond subagents
- auto-inject completed background bash command results via steering
- persist full background bash output to runtime files instead of chat
- clarify no-poll guidance for background subagents and commands
