### PR TITLE
feat(cli): improve exec observability for evaluation runs

### DIFF
--- a/src/apps/cli/Cargo.toml
+++ b/src/apps/cli/Cargo.toml
@@ -67,5 +67,8 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+[dev-dependencies]
+tempfile = "3"
+
 [features]
 default = []

--- a/src/apps/cli/src/diagnostics.rs
+++ b/src/apps/cli/src/diagnostics.rs
@@ -1,0 +1,99 @@
+//! Exec-mode exit diagnostics for automated evaluation runners.
+
+use std::path::Path;
+
+pub const EXIT_LINE_PREFIX: &str = "BITFUN_EXIT: ";
+pub const DETAIL_MAX_LEN: usize = 500;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitKind {
+    SessionCreateFailed,
+    SendMessageFailed,
+    DialogTurnFailed,
+    SystemError,
+    ExecError,
+    PatchWriteFailed,
+}
+
+impl ExitKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SessionCreateFailed => "session_create_failed",
+            Self::SendMessageFailed => "send_message_failed",
+            Self::DialogTurnFailed => "dialog_turn_failed",
+            Self::SystemError => "system_error",
+            Self::ExecError => "exec_error",
+            Self::PatchWriteFailed => "patch_write_failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ExitContext<'a> {
+    pub session_id: Option<&'a str>,
+    pub turn_id: Option<&'a str>,
+    pub agent_type: Option<&'a str>,
+    pub workspace: Option<&'a Path>,
+}
+
+pub fn sanitize_exit_detail(detail: &str) -> String {
+    let collapsed = detail.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() <= DETAIL_MAX_LEN {
+        return collapsed;
+    }
+    let truncated: String = collapsed.chars().take(DETAIL_MAX_LEN).collect();
+    format!("{truncated}…")
+}
+
+pub fn format_exit_line(kind: ExitKind, detail: &str) -> String {
+    format!(
+        "{}{}: {}",
+        EXIT_LINE_PREFIX,
+        kind.as_str(),
+        sanitize_exit_detail(detail)
+    )
+}
+
+pub fn emit_exit_diagnostic(kind: ExitKind, detail: &str, ctx: &ExitContext<'_>) {
+    eprintln!("{}", format_exit_line(kind, detail));
+    tracing::error!(
+        kind = kind.as_str(),
+        session_id = ctx.session_id.unwrap_or("-"),
+        turn_id = ctx.turn_id.unwrap_or("-"),
+        agent_type = ctx.agent_type.unwrap_or("-"),
+        workspace = ?ctx.workspace,
+        detail = %detail,
+        "exec exit diagnostic"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_exit_line_uses_stable_prefix_and_kind() {
+        let line = format_exit_line(ExitKind::DialogTurnFailed, "429 Too Many Requests");
+        assert_eq!(
+            line,
+            "BITFUN_EXIT: dialog_turn_failed: 429 Too Many Requests"
+        );
+    }
+
+    #[test]
+    fn sanitize_exit_detail_collapses_whitespace_and_newlines() {
+        let detail = "line one\nline two\t\tline three";
+        assert_eq!(
+            sanitize_exit_detail(detail),
+            "line one line two line three"
+        );
+    }
+
+    #[test]
+    fn sanitize_exit_detail_truncates_long_messages() {
+        let detail = "x".repeat(DETAIL_MAX_LEN + 10);
+        let sanitized = sanitize_exit_detail(&detail);
+        assert!(sanitized.ends_with('…'));
+        assert!(sanitized.chars().count() <= DETAIL_MAX_LEN + 1);
+    }
+}

--- a/src/apps/cli/src/logging.rs
+++ b/src/apps/cli/src/logging.rs
@@ -1,0 +1,60 @@
+//! Shared file logging initialization for CLI modes.
+
+use std::fs::{self, OpenOptions};
+use std::path::{Path, PathBuf};
+
+use crate::config::CliConfig;
+
+pub fn resolve_log_dir() -> PathBuf {
+    CliConfig::config_dir()
+        .ok()
+        .map(|d| d.join("logs"))
+        .unwrap_or_else(|| std::env::temp_dir().join("bitfun-cli"))
+}
+
+pub fn resolve_log_file_path() -> PathBuf {
+    resolve_log_dir().join("bitfun-cli.log")
+}
+
+pub fn init_file_logging_at(log_dir: &Path, log_level: tracing::Level) -> PathBuf {
+    fs::create_dir_all(log_dir).ok();
+    let log_file = log_dir.join("bitfun-cli.log");
+
+    if let Ok(file) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_file)
+    {
+        tracing_subscriber::fmt()
+            .with_max_level(log_level)
+            .with_writer(move || file.try_clone().expect("log file clone"))
+            .with_ansi(false)
+            .with_target(false)
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_max_level(log_level)
+            .with_target(false)
+            .init();
+    }
+
+    log_file
+}
+
+pub fn init_file_logging(log_level: tracing::Level) -> PathBuf {
+    let log_dir = resolve_log_dir();
+    init_file_logging_at(&log_dir, log_level)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_file_logging_at_creates_log_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let log_file = init_file_logging_at(temp.path(), tracing::Level::INFO);
+        assert!(log_file.exists());
+        assert_eq!(log_file, temp.path().join("bitfun-cli.log"));
+    }
+}

--- a/src/apps/cli/src/main.rs
+++ b/src/apps/cli/src/main.rs
@@ -9,6 +9,8 @@ mod commands;
 /// - Single command execution
 /// - Batch task processing
 mod config;
+mod diagnostics;
+mod logging;
 mod modes;
 mod prompts;
 mod ui;
@@ -378,31 +380,11 @@ async fn main() -> Result<()> {
 
     let is_tui_mode = matches!(cli.command, None | Some(Commands::Chat { .. }));
     let is_acp_mode = matches!(cli.command, Some(Commands::Acp { .. }));
+    let is_exec_mode = matches!(cli.command, Some(Commands::Exec { .. }));
+    let uses_file_log = is_tui_mode || is_exec_mode;
 
-    if is_tui_mode {
-        use std::fs::OpenOptions;
-
-        let log_dir = CliConfig::config_dir()
-            .ok()
-            .map(|d| d.join("logs"))
-            .unwrap_or_else(|| std::env::temp_dir().join("bitfun-cli"));
-
-        std::fs::create_dir_all(&log_dir).ok();
-        let log_file = log_dir.join("bitfun-cli.log");
-
-        if let Ok(file) = OpenOptions::new().create(true).append(true).open(log_file) {
-            tracing_subscriber::fmt()
-                .with_max_level(log_level)
-                .with_writer(move || file.try_clone().unwrap())
-                .with_ansi(false)
-                .with_target(false)
-                .init();
-        } else {
-            tracing_subscriber::fmt()
-                .with_max_level(log_level)
-                .with_target(false)
-                .init();
-        }
+    if uses_file_log {
+        logging::init_file_logging(log_level);
     } else if is_acp_mode {
         tracing_subscriber::fmt()
             .with_max_level(log_level)
@@ -437,6 +419,7 @@ async fn main() -> Result<()> {
             output_patch,
             confirm,
         }) => {
+            let agent_type = agent.clone();
             let workspace_path_resolved = std::env::current_dir().ok();
 
             if let Some(ref ws_path) = workspace_path_resolved {
@@ -445,7 +428,20 @@ async fn main() -> Result<()> {
 
             let skip_confirmation = !confirm;
             let (agentic_system, original_skip_confirmation) =
-                initialize_core_services(skip_confirmation).await?;
+                initialize_core_services(skip_confirmation)
+                    .await
+                    .map_err(|e| {
+                        crate::diagnostics::emit_exit_diagnostic(
+                            crate::diagnostics::ExitKind::ExecError,
+                            &e.to_string(),
+                            &crate::diagnostics::ExitContext {
+                                agent_type: Some(agent_type.as_str()),
+                                workspace: workspace_path_resolved.as_deref(),
+                                ..Default::default()
+                            },
+                        );
+                        e
+                    })?;
 
             let mut exec_mode = ExecMode::new(
                 config,

--- a/src/apps/cli/src/modes/exec.rs
+++ b/src/apps/cli/src/modes/exec.rs
@@ -10,6 +10,7 @@ use bitfun_events::AgenticEvent;
 
 use crate::agent::{agentic_system::AgenticSystem, core_adapter::CoreAgentAdapter, Agent};
 use crate::config::CliConfig;
+use crate::diagnostics::{emit_exit_diagnostic, ExitContext, ExitKind};
 
 pub struct ExecMode {
     #[allow(dead_code)]
@@ -47,6 +48,19 @@ impl ExecMode {
         }
     }
 
+    fn exit_context<'a>(
+        &'a self,
+        session_id: Option<&'a str>,
+        turn_id: Option<&'a str>,
+    ) -> ExitContext<'a> {
+        ExitContext {
+            session_id,
+            turn_id,
+            agent_type: Some(self.agent_type.as_str()),
+            workspace: self.workspace_path.as_deref(),
+        }
+    }
+
     fn get_git_diff(&self) -> Option<String> {
         let workspace = self.workspace_path.as_ref()?;
 
@@ -72,24 +86,46 @@ impl ExecMode {
 
     pub async fn run(&mut self) -> Result<()> {
         tracing::info!(
-            "Executing command, Agent: {}, Message: {}",
-            self.agent_type,
-            self.message
+            agent_type = %self.agent_type,
+            message_len = self.message.len(),
+            workspace = ?self.workspace_path,
+            "Executing command"
         );
 
         println!("Executing: {}", self.message);
         println!();
 
         // Ensure session and send message
-        let session_id = self.agent.ensure_session(&self.agent_type).await?;
+        let session_id = self
+            .agent
+            .ensure_session(&self.agent_type)
+            .await
+            .map_err(|e| {
+                emit_exit_diagnostic(
+                    ExitKind::SessionCreateFailed,
+                    &e.to_string(),
+                    &self.exit_context(None, None),
+                );
+                e
+            })?;
+        tracing::info!(session_id = %session_id, "Session ready");
         let event_queue = self.agent.event_queue().clone();
 
         println!("Thinking...");
 
-        let _turn_id = self
+        let turn_id = self
             .agent
             .send_message(self.message.clone(), &self.agent_type)
-            .await?;
+            .await
+            .map_err(|e| {
+                emit_exit_diagnostic(
+                    ExitKind::SendMessageFailed,
+                    &e.to_string(),
+                    &self.exit_context(Some(&session_id), None),
+                );
+                e
+            })?;
+        tracing::info!(session_id = %session_id, turn_id = %turn_id, "Message sent");
 
         // Consume events from EventQueue until turn completes
         let mut total_tool_calls = 0usize;
@@ -215,6 +251,11 @@ impl ExecMode {
 
                     AgenticEvent::DialogTurnFailed { error, .. } => {
                         eprintln!("\nExecution failed: {}", error);
+                        emit_exit_diagnostic(
+                            ExitKind::DialogTurnFailed,
+                            error,
+                            &self.exit_context(Some(&session_id), Some(&turn_id)),
+                        );
                         self.output_patch_if_needed();
                         return Err(anyhow::anyhow!("Execution failed: {}", error));
                     }
@@ -227,6 +268,11 @@ impl ExecMode {
 
                     AgenticEvent::SystemError { error, .. } => {
                         eprintln!("\nSystem error: {}", error);
+                        emit_exit_diagnostic(
+                            ExitKind::SystemError,
+                            error,
+                            &self.exit_context(Some(&session_id), Some(&turn_id)),
+                        );
                         self.output_patch_if_needed();
                         return Err(anyhow::anyhow!("System error: {}", error));
                     }
@@ -269,7 +315,7 @@ impl ExecMode {
                     println!("{}", patch);
                     println!("---PATCH_END---");
                 } else {
-                    match std::fs::write(output_target, &patch) {
+                    match write_patch_to_path(output_target, &patch) {
                         Ok(_) => {
                             println!("Patch saved to: {}", output_target);
                             println!("({} bytes)", patch.len());
@@ -286,5 +332,36 @@ impl ExecMode {
                 println!("(Unable to generate patch)");
             }
         }
+    }
+}
+
+pub(crate) fn write_patch_to_path(output_target: &str, patch: &str) -> std::io::Result<()> {
+    use std::path::Path;
+
+    let path = Path::new(output_target);
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    std::fs::write(path, patch)
+}
+
+#[cfg(test)]
+mod patch_tests {
+    use super::write_patch_to_path;
+
+    #[test]
+    fn write_patch_to_path_creates_nested_parent_directories() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let patch_path = temp.path().join("parent/child/out.patch");
+        write_patch_to_path(
+            patch_path.to_str().expect("utf8 path"),
+            "diff content",
+        )
+        .expect("write patch");
+
+        let written = std::fs::read_to_string(&patch_path).expect("read patch");
+        assert_eq!(written, "diff content");
     }
 }


### PR DESCRIPTION
Persist file logs in exec mode, emit stable BITFUN_EXIT stderr lines on failure, and create patch output parent directories so automated runners can classify errors and debug full traces.