### PR TITLE
fix(nav-panel): clip collapsed assistant sessions to prevent overlap

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -1085,11 +1085,12 @@ $_section-header-height: 24px;
 
     &.is-collapsed {
       grid-template-rows: 0fr;
+      pointer-events: none;
     }
   }
 
   &__collapsible-inner {
-    overflow: visible;
+    overflow: hidden;
     min-height: 0;
     min-width: 0;
     max-width: 100%;

--- a/src/web-ui/src/app/components/NavPanel/NavPanelLayout.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/NavPanelLayout.test.ts
@@ -48,6 +48,15 @@ describe('NavPanel layout styles', () => {
     expect(sectionHeaderBlock).toContain('margin: 0 $size-gap-1;');
   });
 
+  it('clips collapsible section content when collapsed via grid 0fr', () => {
+    const stylesheet = readNavPanelStylesheet();
+    const collapsibleInnerBlock = extractBlock(stylesheet, '&__collapsible-inner');
+
+    expect(stylesheet).toContain('&.is-collapsed {\n      grid-template-rows: 0fr;');
+    expect(collapsibleInnerBlock).toContain('overflow: hidden;');
+    expect(collapsibleInnerBlock).toContain('min-height: 0;');
+  });
+
   it('uses one shared row-action size for root action buttons', () => {
     const stylesheet = readNavPanelStylesheet();
     const rootBlock = extractBlock(stylesheet, '.bitfun-nav-panel');


### PR DESCRIPTION
## Summary
- Fix assistant sessions section overlap after collapse by clipping the collapsible inner wrapper (`overflow: hidden`) required for the grid `0fr` collapse pattern
- Disable pointer events on collapsed sections so hidden session rows cannot be interacted with
- Add a layout regression test for the collapsible clip behavior

## Test plan
- [x] `pnpm --dir src/web-ui exec vitest run src/app/components/NavPanel/NavPanelLayout.test.ts`
- [x] Manually collapse "Assistant Sessions" in the nav panel and confirm session rows disappear without overlapping the workspace section below
- [x] Expand again and confirm sessions render normally