### PR TITLE
feat(core): persist oversized tool results

### DIFF
--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -4,10 +4,8 @@
 
 use super::stream_processor::{StreamProcessOptions, StreamProcessor, StreamResult};
 use super::types::{FinishReason, RoundContext, RoundResult};
-use crate::agentic::MessageContent;
 use crate::agentic::core::{Message, ToolCall};
 use crate::agentic::events::{AgenticEvent, EventPriority, EventQueue, ToolEventData};
-use crate::agentic::tools::ToolPathOperation;
 use crate::agentic::tools::computer_use_host::ComputerUseHostRef;
 use crate::agentic::tools::framework::{ToolPathResolution, ToolUseContext};
 use crate::agentic::tools::implementations::file_write_tool::{
@@ -16,9 +14,12 @@ use crate::agentic::tools::implementations::file_write_tool::{
 use crate::agentic::tools::pipeline::{ToolExecutionContext, ToolExecutionOptions, ToolPipeline};
 use crate::agentic::tools::registry::get_global_tool_registry;
 use crate::agentic::tools::tool_context_runtime;
+use crate::agentic::tools::tool_result_storage;
+use crate::agentic::tools::ToolPathOperation;
+use crate::agentic::MessageContent;
 use crate::infrastructure::ai::AIClient;
-use crate::service::config::GlobalConfigManager;
 use crate::service::config::types::WriteToolMode;
+use crate::service::config::GlobalConfigManager;
 use crate::util::elapsed_ms_u64;
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::types::Message as AIMessage;
@@ -669,6 +670,14 @@ impl RoundExecutor {
                 ..ToolExecutionOptions::default()
             };
 
+            let storage_context =
+                tool_context_runtime::build_tool_use_context_for_execution_context(
+                    &tool_context,
+                    Some(format!("round-budget-{}", round_id)),
+                    self.computer_use_host(),
+                    CancellationToken::new(),
+                );
+
             // Execute tools — convert pipeline-level Err into per-tool error results
             // so the model always receives a tool_result for every tool_call.
             let execution_results = match tool_pipeline
@@ -705,8 +714,10 @@ impl RoundExecutor {
                 }
             };
 
-            // Convert to ToolResult
-            execution_results.into_iter().map(|r| r.result).collect()
+            // Convert to ToolResult, then enforce the aggregate budget for this model round.
+            let tool_results = execution_results.into_iter().map(|r| r.result).collect();
+            tool_result_storage::apply_round_tool_result_budget(tool_results, &storage_context)
+                .await
         } else {
             vec![]
         };
@@ -1620,12 +1631,12 @@ fn detect_placeholder_patterns(content: &str) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use super::{RoundExecutor, StreamProcessor, extract_bitfun_contents};
-    use crate::agentic::WorkspaceBinding;
+    use super::{extract_bitfun_contents, RoundExecutor, StreamProcessor};
     use crate::agentic::core::ToolCall;
     use crate::agentic::events::{EventQueue, EventQueueConfig};
     use crate::agentic::execution::types::RoundContext;
     use crate::agentic::tools::ToolRuntimeRestrictions;
+    use crate::agentic::WorkspaceBinding;
     use dashmap::DashMap;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -1709,12 +1720,10 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&root);
 
-        assert!(
-            error
-                .as_deref()
-                .unwrap_or_default()
-                .contains("already exists")
-        );
+        assert!(error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("already exists"));
     }
 
     #[tokio::test]

--- a/src/crates/core/src/agentic/tools/implementations/bash_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/bash_tool.rs
@@ -26,6 +26,9 @@ use terminal_core::{
 use tokio::io::AsyncWriteExt;
 use tool_runtime::util::ansi_cleaner::strip_ansi;
 
+// Inline rendering budget for Bash's own result formatter. When the shared
+// oversized tool-result pipeline can persist the result, it stores the raw
+// `output` field instead of this rendered/truncated fallback.
 const MAX_OUTPUT_LENGTH: usize = 30000;
 const INTERRUPT_OUTPUT_DRAIN_MS: u64 = 500;
 
@@ -325,6 +328,87 @@ impl BashTool {
             "<terminal_session_id>{}</terminal_session_id>",
             terminal_session_id
         ));
+
+        result_string
+    }
+
+    fn render_output_block_with_limit(
+        tag: &str,
+        output_text: &str,
+        max_chars: usize,
+    ) -> Option<String> {
+        if output_text.is_empty() {
+            return None;
+        }
+
+        let cleaned_output = strip_ansi(output_text);
+        let output_len = cleaned_output.chars().count();
+        if max_chars == 0 {
+            Some(format!(
+                "<{tag} truncated=\"true\">... [truncated, no budget remaining] ...</{tag}>"
+            ))
+        } else if output_len > max_chars {
+            let truncated = truncate_output_preserving_tail(&cleaned_output, max_chars);
+            Some(format!("<{tag} truncated=\"true\">{}</{tag}>", truncated))
+        } else {
+            Some(format!("<{tag}>{}</{tag}>", cleaned_output))
+        }
+    }
+
+    fn remote_stream_budgets(stdout: &str, stderr: &str) -> (usize, usize) {
+        let stdout_len = strip_ansi(stdout).chars().count();
+        let stderr_len = strip_ansi(stderr).chars().count();
+
+        if stderr_len >= MAX_OUTPUT_LENGTH {
+            return (0, MAX_OUTPUT_LENGTH);
+        }
+
+        let stderr_budget = stderr_len;
+        let stdout_budget = MAX_OUTPUT_LENGTH.saturating_sub(stderr_budget);
+        (stdout_budget.min(stdout_len), stderr_budget)
+    }
+
+    fn render_remote_result(
+        &self,
+        working_directory: &str,
+        stdout: &str,
+        stderr: &str,
+        interrupted: bool,
+        timed_out: bool,
+        exit_code: i32,
+    ) -> String {
+        let mut result_string = String::new();
+        result_string.push_str("<remote_ssh>true</remote_ssh>");
+        result_string.push_str(&format!("<exit_code>{}</exit_code>", exit_code));
+        if !working_directory.is_empty() {
+            result_string.push_str(&format!(
+                "<working_directory>{}</working_directory>",
+                working_directory
+            ));
+        }
+
+        let (stdout_budget, stderr_budget) = Self::remote_stream_budgets(stdout, stderr);
+
+        if let Some(stdout_block) =
+            Self::render_output_block_with_limit("stdout", stdout, stdout_budget)
+        {
+            result_string.push_str(&stdout_block);
+        }
+        if let Some(stderr_block) =
+            Self::render_output_block_with_limit("stderr", stderr, stderr_budget)
+        {
+            result_string.push_str(&stderr_block);
+        }
+
+        if timed_out {
+            result_string.push_str(
+                "<status type=\"timeout\">Command timed out before completion. Partial stdout/stderr, if any, is included above.</status>",
+            );
+        } else if interrupted {
+            result_string.push_str(
+                "<status type=\"interrupted\">Command was canceled before completion. ASK THE USER what they would like to do next.</status>",
+            );
+        }
 
         result_string
     }
@@ -829,6 +913,14 @@ Usage notes:
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or_default();
             let working_directory = requested_working_directory.unwrap_or(working_directory);
+            let result_for_assistant = self.render_remote_result(
+                &working_directory,
+                &exec_result.stdout,
+                &exec_result.stderr,
+                exec_result.interrupted,
+                exec_result.timed_out,
+                exec_result.exit_code,
+            );
 
             let result = ToolResult::Result {
                 data: json!({
@@ -845,22 +937,7 @@ Usage notes:
                     "duration_ms": execution_time_ms,
                     "is_remote": true
                 }),
-                result_for_assistant: Some(if exec_result.timed_out {
-                    format!(
-                        "[Remote SSH] Command timed out on remote server in {}:\n{}\n\nExit code: {}",
-                        working_directory, output, exec_result.exit_code
-                    )
-                } else if exec_result.interrupted {
-                    format!(
-                        "[Remote SSH] Command was cancelled on remote server in {}:\n{}\n\nExit code: {}",
-                        working_directory, output, exec_result.exit_code
-                    )
-                } else {
-                    format!(
-                        "[Remote SSH] Command executed on remote server in {}:\n{}\n\nExit code: {}",
-                        working_directory, output, exec_result.exit_code
-                    )
-                }),
+                result_for_assistant: Some(result_for_assistant),
                 image_attachments: None,
             };
             return Ok(vec![result]);
@@ -1677,6 +1754,53 @@ mod tests {
         assert!(rendered.contains("tail preserved"));
         assert!(rendered.contains("final-error"));
         assert!(rendered.contains("<exit_code>1</exit_code>"));
+    }
+
+    #[test]
+    fn render_remote_result_keeps_stdout_and_stderr_separate() {
+        let tool = BashTool::new();
+
+        let rendered =
+            tool.render_remote_result("/repo", "stdout text", "stderr text", false, false, 2);
+
+        assert!(rendered.contains("<remote_ssh>true</remote_ssh>"));
+        assert!(rendered.contains("<exit_code>2</exit_code>"));
+        assert!(rendered.contains("<stdout>stdout text</stdout>"));
+        assert!(rendered.contains("<stderr>stderr text</stderr>"));
+        assert!(!rendered.contains("<terminal_session_id>"));
+    }
+
+    #[test]
+    fn render_remote_result_uses_shared_budget_with_stderr_priority() {
+        let tool = BashTool::new();
+        let long_stdout =
+            "prefix\n".to_string() + &"x".repeat(MAX_OUTPUT_LENGTH + 100) + "\nstdout-tail";
+        let long_stderr =
+            "prefix\n".to_string() + &"z".repeat(MAX_OUTPUT_LENGTH / 2) + "\nstderr-tail";
+
+        let rendered =
+            tool.render_remote_result("/repo", &long_stdout, &long_stderr, false, false, 1);
+
+        assert!(rendered.contains("<stdout truncated=\"true\">"));
+        assert!(rendered.contains("stdout-tail"));
+        assert!(!rendered.contains("<stderr truncated=\"true\">"));
+        assert!(rendered.contains("stderr-tail"));
+    }
+
+    #[test]
+    fn render_remote_result_gives_all_budget_to_oversized_stderr() {
+        let tool = BashTool::new();
+        let long_stderr =
+            "prefix\n".to_string() + &"z".repeat(MAX_OUTPUT_LENGTH + 100) + "\nremote-final-error";
+
+        let rendered =
+            tool.render_remote_result("/repo", "stdout text", &long_stderr, false, false, 1);
+
+        assert!(rendered.contains("<stdout truncated=\"true\">"));
+        assert!(rendered.contains("no budget remaining"));
+        assert!(rendered.contains("<stderr truncated=\"true\">"));
+        assert!(rendered.contains("tail preserved"));
+        assert!(rendered.contains("remote-final-error"));
     }
 
     #[test]

--- a/src/crates/core/src/agentic/tools/mod.rs
+++ b/src/crates/core/src/agentic/tools/mod.rs
@@ -16,6 +16,7 @@ pub mod registry;
 pub mod restrictions;
 pub(crate) mod tool_adapter;
 pub(crate) mod tool_context_runtime;
+pub(crate) mod tool_result_storage;
 pub mod user_input_manager;
 pub mod workspace_paths;
 pub use bitfun_agent_tools::input_validator;
@@ -27,7 +28,7 @@ pub use framework::{
 pub use image_context::{ImageContextData, ImageContextProvider, ImageContextProviderRef};
 pub use input_validator::InputValidator;
 pub use manifest_resolver::{
-    ResolvedToolManifest, ResolvedVisibleTools, resolve_tool_manifest, resolve_visible_tools,
+    resolve_tool_manifest, resolve_visible_tools, ResolvedToolManifest, ResolvedVisibleTools,
 };
 pub use pipeline::*;
 pub use registry::{

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -11,10 +11,11 @@ use crate::agentic::tools::computer_use_host::ComputerUseHostRef;
 use crate::agentic::tools::framework::{ToolResult as FrameworkToolResult, ToolUseContext};
 use crate::agentic::tools::registry::ToolRegistry;
 use crate::agentic::tools::tool_context_runtime;
+use crate::agentic::tools::tool_result_storage;
 use crate::util::elapsed_ms_u64;
 use crate::util::errors::{BitFunError, BitFunResult};
 use bitfun_agent_tools::{
-    GET_TOOL_SPEC_TOOL_NAME, validate_collapsed_tool_usage, validate_tool_allowed_by_list,
+    validate_collapsed_tool_usage, validate_tool_allowed_by_list, GET_TOOL_SPEC_TOOL_NAME,
 };
 use dashmap::DashMap;
 use futures::future::join_all;
@@ -22,8 +23,8 @@ use log::{debug, error, info, warn};
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};
-use tokio::sync::{RwLock as TokioRwLock, oneshot};
-use tokio::time::{Duration, timeout};
+use tokio::sync::{oneshot, RwLock as TokioRwLock};
+use tokio::time::{timeout, Duration};
 use tokio_util::sync::CancellationToken;
 
 /// A batch of tool tasks to execute together.
@@ -1032,6 +1033,7 @@ impl ToolPipeline {
         }
 
         let execution_started_at = Instant::now();
+        let tool_context = self.build_tool_use_context(&task, cancellation_token.clone());
         let result = self
             .execute_with_retry(&task, cancellation_token.clone(), tool)
             .await;
@@ -1042,7 +1044,11 @@ impl ToolPipeline {
         match result {
             Ok(tool_result) => {
                 let duration_ms = elapsed_ms_u64(start_time);
-                let mut tool_result = tool_result;
+                let mut tool_result = tool_result_storage::maybe_persist_large_tool_result(
+                    tool_result,
+                    &tool_context,
+                )
+                .await;
                 tool_result.duration_ms = Some(duration_ms);
 
                 // The tool call succeeded with arguments that we patched
@@ -1575,14 +1581,12 @@ mod tests {
             result.result.result["provided_arguments"],
             serde_json::Value::String("{\"operation\":\"log\"".to_string())
         );
-        assert!(
-            result
-                .result
-                .result_for_assistant
-                .as_deref()
-                .unwrap_or_default()
-                .contains("Provided arguments: {\"operation\":\"log\"")
-        );
+        assert!(result
+            .result
+            .result_for_assistant
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Provided arguments: {\"operation\":\"log\""));
     }
 
     #[test]
@@ -1645,11 +1649,9 @@ mod tests {
         assert_eq!(context.dialog_turn_id.as_deref(), Some("turn_1"));
         assert_eq!(context.unlocked_collapsed_tools, vec!["WebFetch"]);
         assert!(context.cancellation_token.is_some());
-        assert!(
-            context
-                .runtime_tool_restrictions
-                .is_tool_allowed("WebFetch")
-        );
+        assert!(context
+            .runtime_tool_restrictions
+            .is_tool_allowed("WebFetch"));
         assert!(!context.runtime_tool_restrictions.is_tool_allowed("Bash"));
         assert_eq!(context.custom_data["turn_index"], json!(7));
         assert_eq!(
@@ -1684,10 +1686,9 @@ mod tests {
         let err = ToolPipeline::validate_collapsed_tool_usage(&task)
             .expect_err("collapsed tool should require GetToolSpec unlock");
 
-        assert!(
-            err.to_string()
-                .contains("Call GetToolSpec first with {\"tool_name\":\"WebFetch\"}")
-        );
+        assert!(err
+            .to_string()
+            .contains("Call GetToolSpec first with {\"tool_name\":\"WebFetch\"}"));
     }
 
     #[test]

--- a/src/crates/core/src/agentic/tools/tool_context_runtime.rs
+++ b/src/crates/core/src/agentic/tools/tool_context_runtime.rs
@@ -5,11 +5,9 @@
 //! core. The portable facts projection stays in `framework.rs` and
 //! `bitfun-agent-tools`.
 
-use crate::agentic::WorkspaceBinding;
 use crate::agentic::coordination::get_global_coordinator;
 use crate::agentic::deep_review::tool_context;
 use crate::agentic::session::EvidenceLedgerCheckpoint;
-use crate::agentic::tools::ToolRuntimeRestrictions;
 use crate::agentic::tools::computer_use_host::ComputerUseHostRef;
 use crate::agentic::tools::framework::{
     ToolPathBackend, ToolPathResolution, ToolResult, ToolUseContext,
@@ -17,17 +15,19 @@ use crate::agentic::tools::framework::{
 use crate::agentic::tools::pipeline::{ToolExecutionContext, ToolTask};
 use crate::agentic::tools::post_call_hooks;
 use crate::agentic::tools::restrictions::{
-    ToolPathOperation, is_local_path_within_root, is_remote_posix_path_within_root,
+    is_local_path_within_root, is_remote_posix_path_within_root, ToolPathOperation,
 };
 use crate::agentic::tools::workspace_paths::{
     build_bitfun_runtime_uri, is_bitfun_runtime_uri, normalize_runtime_relative_path,
     parse_bitfun_runtime_uri,
 };
+use crate::agentic::tools::ToolRuntimeRestrictions;
 use crate::agentic::workspace::WorkspaceServices;
+use crate::agentic::WorkspaceBinding;
 use crate::infrastructure::get_path_manager_arc;
 use crate::service::git::{GitDiffParams, GitService};
 use crate::service::remote_ssh::workspace_state::remote_workspace_runtime_root;
-use crate::service::{WorkspaceRuntimeContext, get_workspace_runtime_service_arc};
+use crate::service::{get_workspace_runtime_service_arc, WorkspaceRuntimeContext};
 use crate::util::errors::{BitFunError, BitFunResult};
 use log::warn;
 use serde_json::Value;
@@ -69,18 +69,32 @@ pub(crate) fn build_tool_use_context_for_task(
     computer_use_host: Option<ComputerUseHostRef>,
     cancellation_token: CancellationToken,
 ) -> ToolUseContext {
+    build_tool_use_context_for_execution_context(
+        &task.context,
+        Some(task.tool_call.tool_id.clone()),
+        computer_use_host,
+        cancellation_token,
+    )
+}
+
+pub(crate) fn build_tool_use_context_for_execution_context(
+    context: &ToolExecutionContext,
+    tool_call_id: Option<String>,
+    computer_use_host: Option<ComputerUseHostRef>,
+    cancellation_token: CancellationToken,
+) -> ToolUseContext {
     ToolUseContext {
-        tool_call_id: Some(task.tool_call.tool_id.clone()),
-        agent_type: Some(task.context.agent_type.clone()),
-        session_id: Some(task.context.session_id.clone()),
-        dialog_turn_id: Some(task.context.dialog_turn_id.clone()),
-        workspace: task.context.workspace.clone(),
-        unlocked_collapsed_tools: task.context.unlocked_collapsed_tools.clone(),
-        custom_data: build_tool_context_custom_data(&task.context),
+        tool_call_id,
+        agent_type: Some(context.agent_type.clone()),
+        session_id: Some(context.session_id.clone()),
+        dialog_turn_id: Some(context.dialog_turn_id.clone()),
+        workspace: context.workspace.clone(),
+        unlocked_collapsed_tools: context.unlocked_collapsed_tools.clone(),
+        custom_data: build_tool_context_custom_data(context),
         computer_use_host,
         cancellation_token: Some(cancellation_token),
-        runtime_tool_restrictions: task.context.runtime_tool_restrictions.clone(),
-        workspace_services: task.context.workspace_services.clone(),
+        runtime_tool_restrictions: context.runtime_tool_restrictions.clone(),
+        workspace_services: context.workspace_services.clone(),
     }
 }
 
@@ -573,9 +587,9 @@ fn git_relative_path(workspace_root: &Path, path: &str) -> Option<String> {
 
 #[cfg(test)]
 mod path_resolution_tests {
-    use crate::agentic::WorkspaceBinding;
     use crate::agentic::tools::framework::ToolUseContext;
     use crate::agentic::tools::{ToolPathOperation, ToolPathPolicy, ToolRuntimeRestrictions};
+    use crate::agentic::WorkspaceBinding;
     use crate::service::remote_ssh::workspace_state::workspace_session_identity;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -715,10 +729,9 @@ mod path_resolution_tests {
             .resolve_tool_path("bitfun://runtime/workspace-456/plans/demo.plan.md")
             .expect_err("runtime artifact scopes must match the active workspace");
 
-        assert!(
-            err.to_string()
-                .contains("does not match the current workspace")
-        );
+        assert!(err
+            .to_string()
+            .contains("does not match the current workspace"));
     }
 
     #[test]
@@ -773,12 +786,12 @@ mod path_resolution_tests {
 #[cfg(test)]
 mod call_runtime_tests {
     use super::call_with_tool_runtime_hooks;
-    use crate::agentic::tools::ToolRuntimeRestrictions;
     use crate::agentic::tools::framework::{ToolResult, ToolUseContext};
+    use crate::agentic::tools::ToolRuntimeRestrictions;
     use crate::util::errors::{BitFunError, BitFunResult};
     use serde_json::json;
     use std::collections::HashMap;
-    use tokio::time::{Duration, sleep};
+    use tokio::time::{sleep, Duration};
     use tokio_util::sync::CancellationToken;
 
     fn context_with_cancellation(cancellation_token: CancellationToken) -> ToolUseContext {
@@ -917,10 +930,10 @@ mod context_builder_tests {
 mod task_context_tests {
     use super::build_tool_use_context_for_task;
     use crate::agentic::core::ToolCall;
-    use crate::agentic::tools::ToolRuntimeRestrictions;
     use crate::agentic::tools::pipeline::{
         SubagentParentInfo, ToolExecutionContext, ToolExecutionOptions, ToolTask,
     };
+    use crate::agentic::tools::ToolRuntimeRestrictions;
     use serde_json::json;
     use std::collections::{BTreeSet, HashMap};
     use tokio_util::sync::CancellationToken;
@@ -996,11 +1009,9 @@ mod task_context_tests {
         assert_eq!(context.dialog_turn_id.as_deref(), Some("turn_1"));
         assert_eq!(context.unlocked_collapsed_tools, vec!["WebFetch"]);
         assert!(context.cancellation_token.is_some());
-        assert!(
-            context
-                .runtime_tool_restrictions
-                .is_tool_allowed("WebFetch")
-        );
+        assert!(context
+            .runtime_tool_restrictions
+            .is_tool_allowed("WebFetch"));
         assert!(!context.runtime_tool_restrictions.is_tool_allowed("Bash"));
         assert_eq!(context.custom_data["turn_index"], json!(7));
         assert_eq!(

--- a/src/crates/core/src/agentic/tools/tool_result_storage.rs
+++ b/src/crates/core/src/agentic/tools/tool_result_storage.rs
@@ -1,0 +1,638 @@
+//! Shared handling for oversized tool results.
+//!
+//! The model should not receive unbounded tool output. Large outputs are stored
+//! under the session runtime directory and replaced, for the assistant only, by
+//! a small preview plus a stable reference to the full content.
+
+use crate::agentic::core::ToolResult;
+use crate::agentic::tools::framework::ToolUseContext;
+use crate::util::errors::{BitFunError, BitFunResult};
+use bitfun_agent_tools::GET_TOOL_SPEC_TOOL_NAME;
+use log::{debug, warn};
+use std::collections::HashSet;
+use std::path::Path;
+
+pub(crate) const DEFAULT_MAX_TOOL_RESULT_CHARS: usize = 50_000;
+pub(crate) const MAX_TOOL_RESULTS_PER_ROUND_CHARS: usize = 200_000;
+pub(crate) const TOOL_RESULT_PREVIEW_CHARS: usize = 2_000;
+pub(crate) const PERSISTED_OUTPUT_TAG: &str = "<persisted-output>";
+pub(crate) const PERSISTED_OUTPUT_CLOSING_TAG: &str = "</persisted-output>";
+
+const READ_TOOL_NAME: &str = "Read";
+const BASH_TOOL_NAME: &str = "Bash";
+const SHELL_MAX_TOOL_RESULT_CHARS: usize = 30_000;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ToolResultStoragePolicy {
+    pub per_tool_limit_chars: usize,
+    pub per_round_limit_chars: usize,
+    pub preview_chars: usize,
+}
+
+impl Default for ToolResultStoragePolicy {
+    fn default() -> Self {
+        Self {
+            per_tool_limit_chars: DEFAULT_MAX_TOOL_RESULT_CHARS,
+            per_round_limit_chars: MAX_TOOL_RESULTS_PER_ROUND_CHARS,
+            preview_chars: TOOL_RESULT_PREVIEW_CHARS,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PersistedToolResult {
+    reference: String,
+    original_chars: usize,
+    line_count: usize,
+    preview: String,
+    has_more: bool,
+    metadata: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone)]
+struct ToolResultCandidate {
+    index: usize,
+    visible_chars: usize,
+}
+
+pub(crate) async fn maybe_persist_large_tool_result(
+    mut result: ToolResult,
+    context: &ToolUseContext,
+) -> ToolResult {
+    let policy = ToolResultStoragePolicy::default();
+    if should_skip_tool_result(&result) || visible_content_is_compacted(&result) {
+        return result;
+    }
+
+    let per_tool_limit = effective_per_tool_limit(&result.tool_name, policy);
+    let visible_chars = result_visible_content(&result).chars().count();
+    let content_override = content_override_if_oversized(&result, per_tool_limit);
+    if visible_chars <= per_tool_limit
+        && content_override.is_none()
+        && !json_result_is_oversized(&result, per_tool_limit)
+    {
+        return result;
+    }
+
+    match persist_and_render_replacement(&result, context, policy, content_override).await {
+        Ok(replacement) => {
+            result.result_for_assistant = Some(replacement);
+            result
+        }
+        Err(error) => {
+            warn!(
+                "Failed to persist oversized tool result: tool_name={}, tool_id={}, error={}",
+                result.tool_name, result.tool_id, error
+            );
+            result
+        }
+    }
+}
+
+pub(crate) async fn apply_round_tool_result_budget(
+    mut results: Vec<ToolResult>,
+    context: &ToolUseContext,
+) -> Vec<ToolResult> {
+    let policy = ToolResultStoragePolicy::default();
+    let candidates = collect_round_budget_candidates(&results);
+    let total_visible_chars = candidates
+        .iter()
+        .map(|candidate| candidate.visible_chars)
+        .sum::<usize>();
+
+    if total_visible_chars <= policy.per_round_limit_chars {
+        return results;
+    }
+
+    let selected = select_candidates_to_persist(
+        &candidates,
+        total_visible_chars,
+        policy.per_round_limit_chars,
+    );
+    if selected.is_empty() {
+        return results;
+    }
+
+    let selected_indices = selected.into_iter().collect::<HashSet<_>>();
+    let mut replaced_count = 0usize;
+    for (index, result) in results.iter_mut().enumerate() {
+        if !selected_indices.contains(&index) {
+            continue;
+        }
+
+        match persist_and_render_replacement(result, context, policy, None).await {
+            Ok(replacement) => {
+                result.result_for_assistant = Some(replacement);
+                replaced_count += 1;
+            }
+            Err(error) => {
+                warn!(
+                    "Failed to persist round-budget tool result: tool_name={}, tool_id={}, error={}",
+                    result.tool_name, result.tool_id, error
+                );
+            }
+        }
+    }
+
+    if replaced_count > 0 {
+        debug!(
+            "Round tool result budget enforced: replaced={}, total_visible_chars={}, limit={}",
+            replaced_count, total_visible_chars, policy.per_round_limit_chars
+        );
+    }
+
+    results
+}
+
+fn should_skip_tool_result(result: &ToolResult) -> bool {
+    result.tool_name == READ_TOOL_NAME
+        || result.tool_name == GET_TOOL_SPEC_TOOL_NAME
+        || result
+            .image_attachments
+            .as_ref()
+            .is_some_and(|v| !v.is_empty())
+}
+
+fn collect_round_budget_candidates(results: &[ToolResult]) -> Vec<ToolResultCandidate> {
+    results
+        .iter()
+        .enumerate()
+        .filter(|(_, result)| !should_skip_tool_result(result))
+        .filter(|(_, result)| !visible_content_is_compacted(result))
+        .map(|(index, result)| ToolResultCandidate {
+            index,
+            visible_chars: result_visible_content(result).chars().count(),
+        })
+        .collect()
+}
+
+fn select_candidates_to_persist(
+    candidates: &[ToolResultCandidate],
+    total_visible_chars: usize,
+    limit: usize,
+) -> Vec<usize> {
+    let mut sorted = candidates.to_vec();
+    sorted.sort_by(|a, b| b.visible_chars.cmp(&a.visible_chars));
+
+    let mut selected = Vec::new();
+    let mut remaining = total_visible_chars;
+    for candidate in sorted {
+        if remaining <= limit {
+            break;
+        }
+        selected.push(candidate.index);
+        remaining = remaining.saturating_sub(candidate.visible_chars);
+    }
+    selected
+}
+
+async fn persist_and_render_replacement(
+    result: &ToolResult,
+    context: &ToolUseContext,
+    policy: ToolResultStoragePolicy,
+    content_override: Option<String>,
+) -> BitFunResult<String> {
+    let persisted =
+        persist_tool_result(result, context, policy.preview_chars, content_override).await?;
+    Ok(build_persisted_output_message(
+        &persisted,
+        policy.preview_chars,
+    ))
+}
+
+async fn persist_tool_result(
+    result: &ToolResult,
+    context: &ToolUseContext,
+    preview_chars: usize,
+    content_override: Option<String>,
+) -> BitFunResult<PersistedToolResult> {
+    let session_id = context.session_id.as_deref().ok_or_else(|| {
+        BitFunError::tool("A session id is required to persist tool results".to_string())
+    })?;
+
+    let (serialized, is_json) = if let Some(content) = content_override {
+        (content, false)
+    } else {
+        serialize_tool_result_content(result)?
+    };
+    let file_name = tool_result_file_name(&result.tool_id, is_json);
+    let path = context.current_workspace_session_tool_result_path(session_id, &file_name)?;
+
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|error| {
+            BitFunError::io(format!(
+                "Failed to create tool result directory {}: {}",
+                parent.display(),
+                error
+            ))
+        })?;
+    }
+
+    write_once(&path, &serialized).await?;
+
+    let reference = context
+        .build_session_runtime_artifact_reference(
+            session_id,
+            &format!("tool-results/{}", file_name),
+        )
+        .unwrap_or_else(|_| path.display().to_string());
+    let (preview, has_more) = generate_preview(&serialized, preview_chars);
+
+    debug!(
+        "Persisted oversized tool result: tool_name={}, tool_id={}, chars={}, path={}",
+        result.tool_name,
+        result.tool_id,
+        serialized.chars().count(),
+        path.display()
+    );
+
+    Ok(PersistedToolResult {
+        reference,
+        original_chars: serialized.chars().count(),
+        line_count: count_text_lines(&serialized),
+        preview,
+        has_more,
+        metadata: tool_result_metadata(result),
+    })
+}
+
+async fn write_once(path: &Path, content: &str) -> BitFunResult<()> {
+    match tokio::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+        .await
+    {
+        Ok(mut file) => {
+            use tokio::io::AsyncWriteExt;
+            file.write_all(content.as_bytes()).await.map_err(|error| {
+                BitFunError::io(format!(
+                    "Failed to write tool result file {}: {}",
+                    path.display(),
+                    error
+                ))
+            })
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => Err(BitFunError::io(format!(
+            "Failed to create tool result file {}: {}",
+            path.display(),
+            error
+        ))),
+    }
+}
+
+fn serialize_tool_result_content(result: &ToolResult) -> BitFunResult<(String, bool)> {
+    if let Some(text) = result.result_for_assistant.as_ref() {
+        return Ok((text.clone(), false));
+    }
+
+    serde_json::to_string_pretty(&result.result)
+        .or_else(|_| serde_json::to_string(&result.result))
+        .map(|text| (text, true))
+        .map_err(|error| {
+            BitFunError::serialization(format!("Failed to serialize tool result: {}", error))
+        })
+}
+
+fn effective_per_tool_limit(tool_name: &str, policy: ToolResultStoragePolicy) -> usize {
+    match tool_name {
+        BASH_TOOL_NAME => SHELL_MAX_TOOL_RESULT_CHARS,
+        _ => policy.per_tool_limit_chars,
+    }
+}
+
+fn content_override_if_oversized(result: &ToolResult, limit: usize) -> Option<String> {
+    if result.tool_name != BASH_TOOL_NAME {
+        return None;
+    }
+
+    let output = result
+        .result
+        .get("output")
+        .and_then(|value| value.as_str())?;
+    (output.chars().count() > limit).then(|| output.to_string())
+}
+
+fn json_result_is_oversized(result: &ToolResult, limit: usize) -> bool {
+    if result.result_for_assistant.is_some() {
+        return false;
+    }
+
+    serde_json::to_string_pretty(&result.result)
+        .or_else(|_| serde_json::to_string(&result.result))
+        .map(|text| text.chars().count() > limit)
+        .unwrap_or(false)
+}
+
+fn result_visible_content(result: &ToolResult) -> String {
+    if let Some(text) = result
+        .result_for_assistant
+        .as_ref()
+        .filter(|text| !text.is_empty())
+    {
+        return text.clone();
+    }
+
+    serde_json::to_string_pretty(&result.result)
+        .or_else(|_| serde_json::to_string(&result.result))
+        .unwrap_or_else(|_| format!("Tool {} execution completed", result.tool_name))
+}
+
+fn visible_content_is_compacted(result: &ToolResult) -> bool {
+    result
+        .result_for_assistant
+        .as_deref()
+        .is_some_and(|text| text.starts_with(PERSISTED_OUTPUT_TAG))
+}
+
+fn tool_result_file_name(tool_id: &str, is_json: bool) -> String {
+    let safe_id = sanitize_file_component(tool_id);
+    let ext = if is_json { "json" } else { "txt" };
+    format!("{}.{}", safe_id, ext)
+}
+
+fn sanitize_file_component(value: &str) -> String {
+    let mut sanitized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+
+    if sanitized.is_empty() {
+        sanitized = uuid::Uuid::new_v4().to_string();
+    }
+    sanitized
+}
+
+fn generate_preview(content: &str, max_chars: usize) -> (String, bool) {
+    if content.chars().count() <= max_chars {
+        return (content.to_string(), false);
+    }
+
+    let prefix = content.chars().take(max_chars).collect::<String>();
+    let cut_point = prefix
+        .char_indices()
+        .filter_map(|(idx, ch)| (ch == '\n').then_some(idx))
+        .last()
+        .filter(|idx| *idx > prefix.len() / 2)
+        .unwrap_or(prefix.len());
+
+    (prefix[..cut_point].to_string(), true)
+}
+
+fn count_text_lines(content: &str) -> usize {
+    if content.is_empty() {
+        0
+    } else {
+        content.lines().count()
+    }
+}
+
+fn build_persisted_output_message(result: &PersistedToolResult, preview_chars: usize) -> String {
+    let mut message = format!(
+        "{PERSISTED_OUTPUT_TAG}\nOutput too large ({} chars). Full output saved to: {}\nLine count: {}\n\nPreview (first {} chars):\n{}",
+        result.original_chars, result.reference, result.line_count, preview_chars, result.preview
+    );
+    if result.has_more {
+        message.push_str("\n...\n");
+    } else {
+        message.push('\n');
+    }
+    if !result.metadata.is_empty() {
+        message.push_str("\nMetadata:\n");
+        for (key, value) in &result.metadata {
+            message.push_str(&format!("- {}: {}\n", key, value));
+        }
+    }
+    message.push_str(PERSISTED_OUTPUT_CLOSING_TAG);
+    message
+}
+
+fn tool_result_metadata(result: &ToolResult) -> Vec<(String, String)> {
+    let Some(object) = result.result.as_object() else {
+        return Vec::new();
+    };
+
+    [
+        "success",
+        "exit_code",
+        "timed_out",
+        "working_directory",
+        "terminal_session_id",
+    ]
+    .into_iter()
+    .filter_map(|key| {
+        let value = object.get(key)?;
+        let rendered = value
+            .as_str()
+            .map(str::to_string)
+            .unwrap_or_else(|| value.to_string());
+        Some((key.to_string(), rendered))
+    })
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agentic::tools::ToolRuntimeRestrictions;
+    use crate::agentic::WorkspaceBinding;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn test_context(root: PathBuf) -> ToolUseContext {
+        ToolUseContext {
+            tool_call_id: Some("call_1".to_string()),
+            agent_type: Some("agent".to_string()),
+            session_id: Some("session_1".to_string()),
+            dialog_turn_id: Some("turn_1".to_string()),
+            workspace: Some(WorkspaceBinding::new(None, root)),
+            unlocked_collapsed_tools: Vec::new(),
+            custom_data: HashMap::new(),
+            computer_use_host: None,
+            cancellation_token: None,
+            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
+            workspace_services: None,
+        }
+    }
+
+    fn temp_workspace(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "bitfun-tool-result-storage-{}-{}",
+            name,
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    fn tool_result(tool_id: &str, tool_name: &str, text: String) -> ToolResult {
+        ToolResult {
+            tool_id: tool_id.to_string(),
+            tool_name: tool_name.to_string(),
+            result: json!({ "content": text }),
+            result_for_assistant: Some(text),
+            is_error: false,
+            duration_ms: None,
+            image_attachments: None,
+        }
+    }
+
+    fn bash_result(tool_id: &str, output: String, result_for_assistant: String) -> ToolResult {
+        ToolResult {
+            tool_id: tool_id.to_string(),
+            tool_name: "Bash".to_string(),
+            result: json!({
+                "success": false,
+                "output": output,
+                "exit_code": 1,
+                "timed_out": false,
+                "working_directory": "/repo",
+                "terminal_session_id": "term_1"
+            }),
+            result_for_assistant: Some(result_for_assistant),
+            is_error: false,
+            duration_ms: None,
+            image_attachments: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn single_large_result_persists_and_replaces_assistant_text() {
+        let root = temp_workspace("single");
+        let context = test_context(root.clone());
+        let result = tool_result(
+            "tool/one",
+            "Bash",
+            "x".repeat(DEFAULT_MAX_TOOL_RESULT_CHARS + 1),
+        );
+
+        let processed = maybe_persist_large_tool_result(result, &context).await;
+        let assistant = processed.result_for_assistant.unwrap_or_default();
+
+        assert!(assistant.starts_with(PERSISTED_OUTPUT_TAG));
+        assert!(assistant.contains("Full output saved to:"));
+        assert!(assistant.contains("Preview"));
+        assert!(assistant.len() < DEFAULT_MAX_TOOL_RESULT_CHARS);
+
+        let session_dir = context
+            .current_workspace_session_tool_results_dir("session_1")
+            .expect("session tool-results dir");
+        assert!(session_dir.join("tool_one.txt").exists());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn read_result_is_not_persisted_even_when_large() {
+        let root = temp_workspace("read");
+        let context = test_context(root.clone());
+        let text = "x".repeat(DEFAULT_MAX_TOOL_RESULT_CHARS + 1);
+        let result = tool_result("read_1", "Read", text.clone());
+
+        let processed = maybe_persist_large_tool_result(result, &context).await;
+
+        assert_eq!(
+            processed.result_for_assistant.as_deref(),
+            Some(text.as_str())
+        );
+        let session_dir = context
+            .current_workspace_session_tool_results_dir("session_1")
+            .expect("session tool-results dir");
+        assert!(!session_dir.join("read_1.txt").exists());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn get_tool_spec_result_is_not_persisted_even_when_large() {
+        let root = temp_workspace("get-tool-spec");
+        let context = test_context(root.clone());
+        let text = "x".repeat(DEFAULT_MAX_TOOL_RESULT_CHARS + 1);
+        let result = tool_result("get_tool_spec_1", GET_TOOL_SPEC_TOOL_NAME, text.clone());
+
+        let processed = maybe_persist_large_tool_result(result, &context).await;
+
+        assert_eq!(
+            processed.result_for_assistant.as_deref(),
+            Some(text.as_str())
+        );
+        let session_dir = context
+            .current_workspace_session_tool_results_dir("session_1")
+            .expect("session tool-results dir");
+        assert!(!session_dir.join("get_tool_spec_1.txt").exists());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn bash_full_output_persists_even_when_assistant_text_is_already_truncated() {
+        let root = temp_workspace("bash");
+        let context = test_context(root.clone());
+        let full_output = format!(
+            "{}\nfinal-error",
+            "x".repeat(SHELL_MAX_TOOL_RESULT_CHARS + 1)
+        );
+        let result = bash_result(
+            "bash_1",
+            full_output.clone(),
+            "<output truncated=\"true\">tail only</output>".to_string(),
+        );
+
+        let processed = maybe_persist_large_tool_result(result, &context).await;
+        let assistant = processed.result_for_assistant.unwrap_or_default();
+
+        assert!(assistant.starts_with(PERSISTED_OUTPUT_TAG));
+        assert!(assistant.contains("exit_code: 1"));
+        assert!(assistant.contains("working_directory: /repo"));
+        assert!(assistant.contains("Line count: 2"));
+        let output_path = context
+            .current_workspace_session_tool_result_path("session_1", "bash_1.txt")
+            .expect("tool result path");
+        let saved = std::fs::read_to_string(output_path).expect("saved output");
+        assert_eq!(saved, full_output);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn round_budget_persists_largest_non_read_results() {
+        let root = temp_workspace("round");
+        let context = test_context(root.clone());
+        let largest = tool_result("large_1", "Bash", "a".repeat(170_000));
+        let medium = tool_result("medium_1", "WebFetch", "b".repeat(60_000));
+        let read = tool_result("read_1", "Read", "c".repeat(170_000));
+
+        let processed = apply_round_tool_result_budget(vec![largest, medium, read], &context).await;
+
+        assert!(processed[0]
+            .result_for_assistant
+            .as_deref()
+            .unwrap_or_default()
+            .starts_with(PERSISTED_OUTPUT_TAG));
+        assert!(!processed[1]
+            .result_for_assistant
+            .as_deref()
+            .unwrap_or_default()
+            .starts_with(PERSISTED_OUTPUT_TAG));
+        assert!(!processed[2]
+            .result_for_assistant
+            .as_deref()
+            .unwrap_or_default()
+            .starts_with(PERSISTED_OUTPUT_TAG));
+
+        let session_dir = context
+            .current_workspace_session_tool_results_dir("session_1")
+            .expect("session tool-results dir");
+        assert!(session_dir.join("large_1.txt").exists());
+        assert!(!session_dir.join("medium_1.txt").exists());
+        assert!(!session_dir.join("read_1.txt").exists());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+}


### PR DESCRIPTION
- Add shared persistence for oversized tool results.
- Exempt Read and image outputs from persistence.
- Enforce per-tool and per-round result budgets.
- Persist raw Bash output and add remote stdout/stderr budgeting.
- Include line counts in persisted-output previews.
