### PR TITLE
refactor(core): streamline request context prompt assembly

### DIFF
--- a/src/crates/core/src/agentic/agents/definitions/custom/subagent.rs
+++ b/src/crates/core/src/agentic/agents/definitions/custom/subagent.rs
@@ -1,5 +1,5 @@
 use crate::agentic::agents::Agent;
-use crate::agentic::agents::{PromptBuilder, PromptBuilderContext};
+use crate::agentic::agents::{PromptBuilder, PromptBuilderContext, RequestContextPolicy};
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::FrontMatterMarkdown;
 use async_trait::async_trait;
@@ -61,6 +61,13 @@ impl Agent for CustomSubagent {
 
     fn default_tools(&self) -> Vec<String> {
         self.tools.clone()
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_project_layout()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/agents/definitions/hidden/code_review.rs
+++ b/src/crates/core/src/agentic/agents/definitions/hidden/code_review.rs
@@ -3,7 +3,7 @@
 //! This agent can use Read/Grep/Glob/LS tools to gather context before
 //! submitting a code review, reducing false positives from missing context.
 
-use crate::agentic::agents::Agent;
+use crate::agentic::agents::{Agent, RequestContextPolicy};
 use async_trait::async_trait;
 
 pub struct CodeReviewAgent {
@@ -66,6 +66,13 @@ impl Agent for CodeReviewAgent {
 
     fn default_tools(&self) -> Vec<String> {
         self.default_tools.clone()
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_project_layout()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/agents/definitions/hidden/deep_review.rs
+++ b/src/crates/core/src/agentic/agents/definitions/hidden/deep_review.rs
@@ -1,4 +1,4 @@
-use crate::agentic::agents::Agent;
+use crate::agentic::agents::{Agent, RequestContextPolicy};
 use async_trait::async_trait;
 
 pub struct DeepReviewAgent {
@@ -57,6 +57,13 @@ impl Agent for DeepReviewAgent {
 
     fn default_tools(&self) -> Vec<String> {
         self.default_tools.clone()
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_project_layout()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/agents/definitions/hidden/generate_doc.rs
+++ b/src/crates/core/src/agentic/agents/definitions/hidden/generate_doc.rs
@@ -1,4 +1,4 @@
-use crate::agentic::agents::Agent;
+use crate::agentic::agents::{Agent, RequestContextPolicy};
 use async_trait::async_trait;
 
 pub struct GenerateDocAgent {
@@ -48,6 +48,13 @@ impl Agent for GenerateDocAgent {
 
     fn default_tools(&self) -> Vec<String> {
         self.default_tools.clone()
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_project_layout()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/agents/definitions/hidden/init.rs
+++ b/src/crates/core/src/agentic/agents/definitions/hidden/init.rs
@@ -1,4 +1,4 @@
-use crate::agentic::agents::Agent;
+use crate::agentic::agents::{Agent, RequestContextPolicy};
 use async_trait::async_trait;
 
 pub struct InitAgent {
@@ -52,6 +52,14 @@ impl Agent for InitAgent {
 
     fn default_tools(&self) -> Vec<String> {
         self.default_tools.clone()
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_workspace_memory_files()
+            .with_project_layout()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/agents/definitions/modes/agentic.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/agentic.rs
@@ -1,6 +1,8 @@
 //! Agentic Mode
 
-use crate::agentic::agents::{shared_coding_mode_tools, Agent, SHARED_CODING_MODE_PROMPT_TEMPLATE};
+use crate::agentic::agents::{
+    shared_coding_mode_tools, Agent, RequestContextPolicy, SHARED_CODING_MODE_PROMPT_TEMPLATE,
+};
 use async_trait::async_trait;
 pub struct AgenticMode {
     default_tools: Vec<String>,
@@ -44,6 +46,14 @@ impl Agent for AgenticMode {
 
     fn default_tools(&self) -> Vec<String> {
         self.default_tools.clone()
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_workspace_memory_files()
+            .with_project_layout()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/agents/definitions/modes/claw.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/claw.rs
@@ -68,7 +68,10 @@ impl Agent for ClawMode {
     }
 
     fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::full_without_layout()
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_workspace_memory_files()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/agents/definitions/modes/cowork.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/cowork.rs
@@ -2,7 +2,7 @@
 //!
 //! A collaborative mode that prioritizes early clarification and lightweight progress tracking.
 
-use crate::agentic::agents::Agent;
+use crate::agentic::agents::{Agent, RequestContextPolicy};
 use async_trait::async_trait;
 
 pub struct CoworkMode {
@@ -68,6 +68,13 @@ impl Agent for CoworkMode {
 
     fn default_tools(&self) -> Vec<String> {
         self.default_tools.clone()
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_project_layout()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/agents/definitions/modes/debug.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/debug.rs
@@ -1,6 +1,8 @@
 //! Debug Mode - Evidence-driven debugging mode
 
-use crate::agentic::agents::{get_embedded_prompt, Agent, PromptBuilder, PromptBuilderContext};
+use crate::agentic::agents::{
+    get_embedded_prompt, Agent, PromptBuilder, PromptBuilderContext, RequestContextPolicy,
+};
 use crate::service::config::global::GlobalConfigManager;
 use crate::service::config::types::{DebugModeConfig, LanguageDebugTemplate};
 use crate::service::lsp::project_detector::{ProjectDetector, ProjectInfo};
@@ -280,6 +282,14 @@ impl Agent for DebugMode {
 
     fn prompt_template_name(&self, _model_name: Option<&str>) -> &str {
         DEBUG_MODE_PROMPT_TEMPLATE
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_workspace_memory_files()
+            .with_project_layout()
     }
 
     async fn build_prompt(&self, context: &PromptBuilderContext) -> BitFunResult<String> {

--- a/src/crates/core/src/agentic/agents/definitions/modes/deep_research.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/deep_research.rs
@@ -1,4 +1,4 @@
-use crate::agentic::agents::{Agent, AgentToolPolicyOverrides};
+use crate::agentic::agents::{Agent, AgentToolPolicyOverrides, RequestContextPolicy};
 use crate::agentic::tools::framework::ToolExposure;
 use async_trait::async_trait;
 
@@ -68,6 +68,13 @@ impl Agent for DeepResearchMode {
 
     fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {
         &self.tool_exposure_overrides
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_project_layout()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/agents/definitions/modes/multitask.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/multitask.rs
@@ -1,7 +1,8 @@
 //! Multitask Mode
 
 use crate::agentic::agents::{
-    get_embedded_prompt, shared_coding_mode_tools, Agent, SHARED_CODING_MODE_PROMPT_TEMPLATE,
+    get_embedded_prompt, shared_coding_mode_tools, Agent, RequestContextPolicy,
+    SHARED_CODING_MODE_PROMPT_TEMPLATE,
 };
 use async_trait::async_trait;
 
@@ -9,8 +10,7 @@ pub struct MultitaskMode {
     default_tools: Vec<String>,
 }
 
-const MULTITASK_MODE_FIRST_ENTRY_REMINDER_TEMPLATE: &str =
-    "multitask_mode_first_entry_reminder";
+const MULTITASK_MODE_FIRST_ENTRY_REMINDER_TEMPLATE: &str = "multitask_mode_first_entry_reminder";
 const MULTITASK_MODE_ONGOING_REMINDER_TEMPLATE: &str = "multitask_mode_ongoing_reminder";
 
 impl Default for MultitaskMode {
@@ -61,6 +61,14 @@ impl Agent for MultitaskMode {
 
     fn prompt_template_name(&self, _model_name: Option<&str>) -> &str {
         SHARED_CODING_MODE_PROMPT_TEMPLATE
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_workspace_memory_files()
+            .with_project_layout()
     }
 
     async fn get_system_reminder(

--- a/src/crates/core/src/agentic/agents/definitions/modes/plan.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/plan.rs
@@ -61,7 +61,11 @@ impl Agent for PlanMode {
     }
 
     fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::instructions_and_layout()
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_workspace_memory_files()
+            .with_project_layout()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/agents/definitions/modes/team.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/team.rs
@@ -3,7 +3,7 @@
 //! Orchestrates a full software development sprint through specialized roles:
 //! Think → Plan → Build → Review → Test → Ship
 
-use crate::agentic::agents::Agent;
+use crate::agentic::agents::{Agent, RequestContextPolicy};
 use async_trait::async_trait;
 
 pub struct TeamMode {
@@ -66,6 +66,13 @@ impl Agent for TeamMode {
 
     fn default_tools(&self) -> Vec<String> {
         self.default_tools.clone()
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_project_layout()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/agents/definitions/review/review_fixer.rs
+++ b/src/crates/core/src/agentic/agents/definitions/review/review_fixer.rs
@@ -63,7 +63,7 @@ impl Agent for ReviewFixerAgent {
     }
 
     fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::instructions_only()
+        RequestContextPolicy::empty().with_workspace_instructions()
     }
 
     fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {
@@ -87,7 +87,7 @@ mod tests {
 
         assert_eq!(
             agent.request_context_policy(),
-            RequestContextPolicy::instructions_only()
+            RequestContextPolicy::empty().with_workspace_instructions()
         );
         assert!(tools.contains(&"Edit".to_string()));
         assert!(tools.contains(&"Write".to_string()));

--- a/src/crates/core/src/agentic/agents/definitions/review/review_specialists.rs
+++ b/src/crates/core/src/agentic/agents/definitions/review/review_specialists.rs
@@ -96,7 +96,7 @@ mod tests {
         for agent in agents {
             assert_eq!(
                 agent.request_context_policy(),
-                RequestContextPolicy::instructions_only()
+                RequestContextPolicy::empty().with_workspace_instructions()
             );
             assert!(agent.is_readonly());
             assert!(agent.default_tools().contains(&"GetFileDiff".to_string()));

--- a/src/crates/core/src/agentic/agents/definitions/shared/readonly.rs
+++ b/src/crates/core/src/agentic/agents/definitions/shared/readonly.rs
@@ -10,6 +10,7 @@ pub struct ReadonlySubagent {
     prompt_template: &'static str,
     default_tools: &'static [&'static str],
     tool_exposure_overrides: AgentToolPolicyOverrides,
+    request_context_policy: RequestContextPolicy,
 }
 
 impl ReadonlySubagent {
@@ -45,6 +46,26 @@ impl ReadonlySubagent {
             prompt_template,
             default_tools,
             tool_exposure_overrides,
+            request_context_policy: RequestContextPolicy::empty().with_workspace_instructions(),
+        }
+    }
+
+    pub fn with_policy(
+        id: &'static str,
+        name: &'static str,
+        description: &'static str,
+        prompt_template: &'static str,
+        default_tools: &'static [&'static str],
+        request_context_policy: RequestContextPolicy,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            description,
+            prompt_template,
+            default_tools,
+            tool_exposure_overrides: AgentToolPolicyOverrides::default(),
+            request_context_policy,
         }
     }
 }
@@ -76,7 +97,7 @@ impl Agent for ReadonlySubagent {
     }
 
     fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::instructions_only()
+        self.request_context_policy.clone()
     }
 
     fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {
@@ -86,6 +107,85 @@ impl Agent for ReadonlySubagent {
     fn is_readonly(&self) -> bool {
         true
     }
+}
+
+#[macro_export]
+macro_rules! define_readonly_subagent_with_context_policy {
+    (
+        $struct_name:ident,
+        $id:expr,
+        $name:literal,
+        $description:literal,
+        $prompt:literal,
+        $tools:expr,
+        $request_context_policy:expr
+    ) => {
+        pub struct $struct_name {
+            inner: $crate::agentic::agents::ReadonlySubagent,
+        }
+
+        impl Default for $struct_name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl $struct_name {
+            pub fn new() -> Self {
+                Self {
+                    inner: $crate::agentic::agents::ReadonlySubagent::with_policy(
+                        $id,
+                        $name,
+                        $description,
+                        $prompt,
+                        $tools,
+                        $request_context_policy,
+                    ),
+                }
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl $crate::agentic::agents::Agent for $struct_name {
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+
+            fn id(&self) -> &str {
+                self.inner.id()
+            }
+
+            fn name(&self) -> &str {
+                self.inner.name()
+            }
+
+            fn description(&self) -> &str {
+                self.inner.description()
+            }
+
+            fn prompt_template_name(&self, model_name: Option<&str>) -> &str {
+                self.inner.prompt_template_name(model_name)
+            }
+
+            fn default_tools(&self) -> Vec<String> {
+                self.inner.default_tools()
+            }
+
+            fn request_context_policy(&self) -> $crate::agentic::agents::RequestContextPolicy {
+                self.inner.request_context_policy()
+            }
+
+            fn tool_exposure_overrides(
+                &self,
+            ) -> &$crate::agentic::agents::AgentToolPolicyOverrides {
+                self.inner.tool_exposure_overrides()
+            }
+
+            fn is_readonly(&self) -> bool {
+                self.inner.is_readonly()
+            }
+        }
+    };
 }
 
 /// Define a read-only subagent struct and its `Agent` implementation

--- a/src/crates/core/src/agentic/agents/definitions/subagents/computer_use.rs
+++ b/src/crates/core/src/agentic/agents/definitions/subagents/computer_use.rs
@@ -2,7 +2,7 @@
 //!
 //! Dedicated agent for perceiving and operating the user's local computer.
 
-use crate::agentic::agents::{Agent, AgentToolPolicyOverrides};
+use crate::agentic::agents::{Agent, AgentToolPolicyOverrides, RequestContextPolicy};
 use crate::agentic::tools::framework::ToolExposure;
 use async_trait::async_trait;
 
@@ -61,6 +61,12 @@ impl Agent for ComputerUseMode {
 
     fn default_tools(&self) -> Vec<String> {
         self.default_tools.clone()
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
+            .with_workspace_instructions()
+            .with_project_layout()
     }
 
     fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {

--- a/src/crates/core/src/agentic/agents/definitions/subagents/general_purpose.rs
+++ b/src/crates/core/src/agentic/agents/definitions/subagents/general_purpose.rs
@@ -57,7 +57,10 @@ impl Agent for GeneralPurposeAgent {
     }
 
     fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::instructions_only()
+        RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_project_layout()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/agents/definitions/subagents/research_specialist.rs
+++ b/src/crates/core/src/agentic/agents/definitions/subagents/research_specialist.rs
@@ -1,12 +1,15 @@
-use crate::define_readonly_subagent;
+use crate::define_readonly_subagent_with_context_policy;
 
-define_readonly_subagent!(
+define_readonly_subagent_with_context_policy!(
     ResearchSpecialistAgent,
     "ResearchSpecialist",
     "Research Specialist",
     r#"Read-only subagent for **web research**. Has WebSearch (Exa) and WebFetch tools. Use to delegate one focused research role (primary sources, news/timeline, expert analysis, counter-evidence, or competitor profile) so multiple roles can run in parallel without polluting the parent context. The specialist runs 3–5 searches, fetches the most relevant pages, and returns a structured markdown report with claim / URL / direct-quote / authority for each finding. The parent agent is responsible for any file writes — specialists return findings via the Task tool result, they do not write to disk."#,
     "research_specialist_agent",
-    &["WebSearch", "WebFetch", "Read"]
+    &["WebSearch", "WebFetch", "Read"],
+    crate::agentic::agents::RequestContextPolicy::empty()
+        .with_workspace_context()
+        .with_workspace_instructions()
 );
 
 #[cfg(test)]

--- a/src/crates/core/src/agentic/agents/mod.rs
+++ b/src/crates/core/src/agentic/agents/mod.rs
@@ -31,7 +31,7 @@ pub use definitions::subagents::{
 use indexmap::IndexMap;
 pub use prompt_builder::{
     PromptBuilder, PromptBuilderContext, RemoteExecutionHints, RequestContextPolicy,
-    RequestContextSection,
+    RequestContextSection, RequestContextToolSections,
 };
 pub use registry::catalog::{builtin_agent_specs, BuiltinAgentSpec};
 pub use registry::types::{
@@ -99,9 +99,7 @@ pub trait Agent: Send + Sync + 'static {
         None // by default, no system reminder
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::default()
-    }
+    fn request_context_policy(&self) -> RequestContextPolicy;
 
     /// Build the system prompt for this agent
     async fn build_prompt(&self, context: &PromptBuilderContext) -> BitFunResult<String> {

--- a/src/crates/core/src/agentic/agents/prompt_builder/mod.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/mod.rs
@@ -1,5 +1,7 @@
 mod prompt_builder_impl;
 mod request_context;
 
-pub use prompt_builder_impl::{PromptBuilder, PromptBuilderContext, RemoteExecutionHints};
+pub use prompt_builder_impl::{
+    PromptBuilder, PromptBuilderContext, RemoteExecutionHints, RequestContextToolSections,
+};
 pub use request_context::{RequestContextPolicy, RequestContextSection};

--- a/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -110,6 +110,9 @@ impl PromptBuilder {
         let host_family = std::env::consts::FAMILY;
         let host_arch = std::env::consts::ARCH;
 
+        let now = chrono::Local::now();
+        let current_date = now.format("%Y-%m-%d").to_string();
+
         let computer_use_keys = match host_os {
             "macos" => "Computer use / `key_chord`: the **local BitFun desktop** is **macOS** — use `command`, `option`, `control`, `shift` (not Win/Linux modifier names). **ACTION PRIORITY:** 1) Terminal/CLI/system commands (use Bash tool for `osascript`, AppleScript, shell scripts) 2) Keyboard shortcuts: command+a/c/x/v (clipboard), command+space (Spotlight), command+tab (switch app) 3) UI control (AX/OCR/mouse) only when above fail.",
             "windows" => "Computer use / `key_chord`: the **local BitFun desktop** is **Windows** — use `meta`/`super` for Windows key, `alt`, `control`, `shift`. **ACTION PRIORITY:** 1) Terminal/CLI/system commands (use Bash tool for PowerShell, cmd, scripts) 2) Keyboard shortcuts: control+a/c/x/v (clipboard), meta (Start menu), Alt+Tab (switch) 3) UI control only when above fail.",
@@ -127,6 +130,7 @@ impl PromptBuilder {
 - **Paths and shell:** POSIX on the remote server — use forward slashes and Unix shell syntax (bash/sh). Do **not** use PowerShell, `cmd.exe`, or Windows-style paths for workspace operations.
 - Local BitFun client OS: {} ({}) — applies to Computer use / UI automation on this machine only, not to workspace file or terminal tools.
 - Local client architecture: {}
+- Current Date: {}
 - {}
 </environment_details>
 
@@ -138,6 +142,7 @@ impl PromptBuilder {
                 host_os,
                 host_family,
                 host_arch,
+                current_date,
                 computer_use_keys
             )
         } else {
@@ -147,11 +152,17 @@ impl PromptBuilder {
 - Current Working Directory: {}
 - Operating System: {} ({})
 - Architecture: {}
+- Current Date: {}
 - {}
 </environment_details>
 
 "#,
-                self.context.workspace_path, host_os, host_family, host_arch, computer_use_keys
+                self.context.workspace_path,
+                host_os,
+                host_family,
+                host_arch,
+                current_date,
+                computer_use_keys
             )
         }
     }
@@ -193,7 +204,6 @@ impl PromptBuilder {
         policy: &RequestContextPolicy,
     ) -> Option<String> {
         let mut sections = Vec::new();
-
         let mut instruction_sections = Vec::new();
         let mut override_sections = Vec::new();
         let mut trailing_sections = Vec::new();
@@ -242,15 +252,6 @@ impl PromptBuilder {
         } else {
             Some(sections.join("\n\n"))
         }
-    }
-
-    pub fn build_current_time_reminder(&self) -> String {
-        let now = chrono::Local::now();
-        format!(
-            "# Current Time\n<current_time>\n- Current Date: {}\n- Local Time: {}\n</current_time>",
-            now.format("%Y-%m-%d"),
-            now.format("%H:%M:%S")
-        )
     }
 
     /// Get visual mode instruction from user config

--- a/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -21,14 +21,73 @@ const PLACEHOLDER_AGENT_MEMORY: &str = "{AGENT_MEMORY}";
 const PLACEHOLDER_CLAW_WORKSPACE: &str = "{CLAW_WORKSPACE}";
 const PLACEHOLDER_VISUAL_MODE: &str = "{VISUAL_MODE}";
 const PLACEHOLDER_SESSION_ID: &str = "{SESSION_ID}";
-const ADDITIONAL_TOOLS_PROMPT: &str = r#"# Additional Tools
-
-Some tools in the tool list are intentionally collapsed.
+const ADDITIONAL_CONTEXT_PROMPT: &str =
+    "As you answer the user's questions, you can use the following context";
+const SKILL_TOOL_CONTEXT_TITLE: &str = "## Skills Available via Skill Tool";
+const TASK_TOOL_CONTEXT_TITLE: &str = "## Subagents Available via Task Tool";
+const GET_TOOL_SPEC_CONTEXT_TITLE: &str =
+    "## Collapsed Tools (load full definition via GetToolSpec tool)";
+const ADDITIONAL_TOOLS_PROMPT: &str = r#"Some tools in the tool list are intentionally collapsed.
 Their listed descriptions are short summaries rather than full usage instructions.
 Before calling a collapsed tool, call `GetToolSpec` with its exact tool name to read its full definition and input schema.
 After reading the returned spec, call the real tool directly by its own name.
-If a tool spec is already available in the current conversation, do not call `GetToolSpec` for it again.
-"#;
+If a tool spec is already available in the current conversation, do not call `GetToolSpec` for it again."#;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RequestContextToolSections {
+    pub available_skills: Option<String>,
+    pub available_agents: Option<String>,
+    pub collapsed_tools: Option<String>,
+}
+
+impl RequestContextToolSections {
+    pub fn is_empty(&self) -> bool {
+        self.available_skills.is_none()
+            && self.available_agents.is_none()
+            && self.collapsed_tools.is_none()
+    }
+
+    fn render(&self) -> Option<String> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let mut sections = Vec::new();
+        if let Some(available_skills) = self.available_skills.as_deref() {
+            sections.push(Self::render_section(
+                SKILL_TOOL_CONTEXT_TITLE,
+                available_skills,
+                None,
+            ));
+        }
+        if let Some(available_agents) = self.available_agents.as_deref() {
+            sections.push(Self::render_section(
+                TASK_TOOL_CONTEXT_TITLE,
+                available_agents,
+                None,
+            ));
+        }
+        if let Some(collapsed_tools) = self.collapsed_tools.as_deref() {
+            sections.push(Self::render_section(
+                GET_TOOL_SPEC_CONTEXT_TITLE,
+                collapsed_tools,
+                Some(ADDITIONAL_TOOLS_PROMPT),
+            ));
+        }
+
+        Some(format!(
+            "# Available Tool Context\n{}",
+            sections.join("\n\n")
+        ))
+    }
+
+    fn render_section(title: &str, body: &str, description: Option<&str>) -> String {
+        match description {
+            Some(description) => format!("{}\n{}\n\n{}", title, description, body.trim()),
+            None => format!("{}\n{}", title, body.trim()),
+        }
+    }
+}
 
 /// SSH remote host facts for system prompt (workspace tools run here, not on the local client).
 #[derive(Debug, Clone)]
@@ -49,8 +108,8 @@ pub struct PromptBuilderContext {
     pub remote_project_layout: Option<String>,
     /// When `Some(false)`, system prompt append Computer use text-only guidance (no screenshot tool output).
     pub supports_image_understanding: Option<bool>,
-    /// When true, append a static reminder that additional collapsed tools exist behind GetToolSpec.
-    pub has_additional_tools: bool,
+    /// Dynamic tool catalogs that are injected through request context instead of tool descriptions.
+    pub request_context_tools: RequestContextToolSections,
 }
 
 impl PromptBuilderContext {
@@ -66,7 +125,7 @@ impl PromptBuilderContext {
             remote_execution: None,
             remote_project_layout: None,
             supports_image_understanding: None,
-            has_additional_tools: false,
+            request_context_tools: RequestContextToolSections::default(),
         }
     }
 
@@ -75,8 +134,8 @@ impl PromptBuilderContext {
         self
     }
 
-    pub fn with_additional_tools_hint(mut self, has_additional_tools: bool) -> Self {
-        self.has_additional_tools = has_additional_tools;
+    pub fn with_request_context_tools(mut self, tools: RequestContextToolSections) -> Self {
+        self.request_context_tools = tools;
         self
     }
 
@@ -110,9 +169,6 @@ impl PromptBuilder {
         let host_family = std::env::consts::FAMILY;
         let host_arch = std::env::consts::ARCH;
 
-        let now = chrono::Local::now();
-        let current_date = now.format("%Y-%m-%d").to_string();
-
         let computer_use_keys = match host_os {
             "macos" => "Computer use / `key_chord`: the **local BitFun desktop** is **macOS** — use `command`, `option`, `control`, `shift` (not Win/Linux modifier names). **ACTION PRIORITY:** 1) Terminal/CLI/system commands (use Bash tool for `osascript`, AppleScript, shell scripts) 2) Keyboard shortcuts: command+a/c/x/v (clipboard), command+space (Spotlight), command+tab (switch app) 3) UI control (AX/OCR/mouse) only when above fail.",
             "windows" => "Computer use / `key_chord`: the **local BitFun desktop** is **Windows** — use `meta`/`super` for Windows key, `alt`, `control`, `shift`. **ACTION PRIORITY:** 1) Terminal/CLI/system commands (use Bash tool for PowerShell, cmd, scripts) 2) Keyboard shortcuts: control+a/c/x/v (clipboard), meta (Start menu), Alt+Tab (switch) 3) UI control only when above fail.",
@@ -120,49 +176,58 @@ impl PromptBuilder {
             _ => "Computer use / `key_chord`: match modifier names to the **local BitFun desktop** OS below. **ACTION PRIORITY:** 1) Terminal/CLI/system commands first 2) Keyboard shortcuts second 3) UI control (mouse/OCR) last resort.",
         };
 
-        if let Some(remote) = &self.context.remote_execution {
+        if self.context.remote_execution.is_some() {
             format!(
                 r#"# Environment Information
 <environment_details>
-- Workspace root (file tools, Glob, LS, Bash on workspace): {}
-- Execution environment: **Remote SSH** — connection "{}".
-- Remote host: {} (uname/kernel: {})
-- **Paths and shell:** POSIX on the remote server — use forward slashes and Unix shell syntax (bash/sh). Do **not** use PowerShell, `cmd.exe`, or Windows-style paths for workspace operations.
-- Local BitFun client OS: {} ({}) — applies to Computer use / UI automation on this machine only, not to workspace file or terminal tools.
+- Local BitFun client OS: {} ({}) — applies to Computer use / UI automation on this machine only.
 - Local client architecture: {}
-- Current Date: {}
 - {}
 </environment_details>
 
 "#,
-                self.context.workspace_path,
-                remote.connection_display_name.replace('"', "'"),
-                remote.hostname.replace('"', "'"),
-                remote.kernel_name.replace('"', "'"),
-                host_os,
-                host_family,
-                host_arch,
-                current_date,
-                computer_use_keys
+                host_os, host_family, host_arch, computer_use_keys
             )
         } else {
             format!(
                 r#"# Environment Information
 <environment_details>
-- Current Working Directory: {}
 - Operating System: {} ({})
 - Architecture: {}
-- Current Date: {}
 - {}
 </environment_details>
 
 "#,
+                host_os, host_family, host_arch, computer_use_keys
+            )
+        }
+    }
+
+    /// Get workspace context that is intentionally injected outside the system prompt cache.
+    pub fn get_workspace_context(&self) -> String {
+        if let Some(remote) = &self.context.remote_execution {
+            format!(
+                r#"## Workspace Context
+<workspace_context>
+- Workspace root (file tools, Glob, LS, Bash on workspace): {}
+- Execution environment: **Remote SSH** — connection "{}".
+- Remote host: {} (uname/kernel: {})
+- **Paths and shell:** POSIX on the remote server — use forward slashes and Unix shell syntax (bash/sh). Do **not** use PowerShell, `cmd.exe`, or Windows-style paths for workspace operations.
+</workspace_context>
+"#,
                 self.context.workspace_path,
-                host_os,
-                host_family,
-                host_arch,
-                current_date,
-                computer_use_keys
+                remote.connection_display_name.replace('"', "'"),
+                remote.hostname.replace('"', "'"),
+                remote.kernel_name.replace('"', "'")
+            )
+        } else {
+            format!(
+                r#"## Workspace Context
+<workspace_context>
+- Current Working Directory: {}
+</workspace_context>
+"#,
+                self.context.workspace_path
             )
         }
     }
@@ -170,7 +235,7 @@ impl PromptBuilder {
     /// Get workspace file list
     pub fn get_project_layout(&self) -> String {
         if let Some(remote_layout) = &self.context.remote_project_layout {
-            let mut project_layout = "# Workspace Layout\n<project_layout>\n".to_string();
+            let mut project_layout = "## Workspace Layout\n<project_layout>\n".to_string();
             project_layout.push_str(
                 "Below is a snapshot of the current workspace's file structure on the **remote** host.\n\n",
             );
@@ -187,7 +252,7 @@ impl PromptBuilder {
             reached_limit: false,
             text: format!("Error listing directory: {}", e),
         });
-        let mut project_layout = "# Workspace Layout\n<project_layout>\n".to_string();
+        let mut project_layout = "## Workspace Layout\n<project_layout>\n".to_string();
         if formatted_listing.reached_limit {
             project_layout.push_str(&format!("Below is a snapshot of the current workspace's file structure (showing up to {} entries).\n\n", self.file_tree_max_entries));
         } else {
@@ -204,15 +269,21 @@ impl PromptBuilder {
         policy: &RequestContextPolicy,
     ) -> Option<String> {
         let mut sections = Vec::new();
-        let mut instruction_sections = Vec::new();
-        let mut override_sections = Vec::new();
-        let mut trailing_sections = Vec::new();
+        let mut additional_sections = Vec::new();
+
+        if let Some(tool_context) = self.context.request_context_tools.render() {
+            sections.push(tool_context);
+        }
+
+        if policy.includes(RequestContextSection::WorkspaceContext) {
+            additional_sections.push(self.get_workspace_context());
+        }
 
         if self.context.remote_execution.is_none() {
             let workspace = Path::new(&self.context.workspace_path);
             if policy.includes(RequestContextSection::WorkspaceInstructions) {
                 match build_workspace_instruction_files_context(workspace).await {
-                    Ok(Some(prompt)) => instruction_sections.push(prompt),
+                    Ok(Some(prompt)) => additional_sections.push(prompt),
                     Ok(None) => {}
                     Err(e) => warn!(
                         "Failed to build workspace instruction context: path={} error={}",
@@ -223,7 +294,7 @@ impl PromptBuilder {
             }
             if policy.includes(RequestContextSection::WorkspaceMemoryFiles) {
                 match build_workspace_memory_files_context(workspace).await {
-                    Ok(Some(prompt)) => override_sections.push(prompt),
+                    Ok(Some(prompt)) => additional_sections.push(prompt),
                     Ok(None) => {}
                     Err(e) => warn!(
                         "Failed to build workspace memory context: path={} error={}",
@@ -235,17 +306,20 @@ impl PromptBuilder {
         }
 
         if policy.includes(RequestContextSection::ProjectLayout) {
-            trailing_sections.push(self.get_project_layout());
+            additional_sections.push(self.get_project_layout());
         }
 
-        sections.extend(instruction_sections);
-
-        if policy.has_override_sections() && !override_sections.is_empty() {
-            sections.push("Codebase and user instructions are shown below. Be sure to adhere to these instructions. IMPORTANT: These instructions OVERRIDE any default behavior and you MUST follow them exactly as written.".to_string());
-            sections.extend(override_sections);
+        if !additional_sections.is_empty() {
+            sections.push(format!(
+                "# Additional Context\n{}\n\n{}",
+                ADDITIONAL_CONTEXT_PROMPT,
+                additional_sections
+                    .into_iter()
+                    .map(|section| section.trim().to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n\n")
+            ));
         }
-
-        sections.extend(trailing_sections);
 
         if sections.is_empty() {
             None
@@ -304,14 +378,12 @@ Output Mermaid in fenced code blocks (```mermaid) so the UI can render them.
 
     /// Get Claw-specific workspace boundary instruction
     fn get_claw_workspace_instruction(&self) -> String {
-        format!(
-            "# Workspace
-Your dedicated operating space is `{}`.
+        "# Workspace
+Your dedicated operating space is the workspace root shown in the current request context.
 Prefer doing work inside this workspace and keep it well organized with clear structure, sensible filenames, and minimal clutter.
 Do not read from, modify, create, move, or delete files outside this workspace unless the user has explicitly granted permission for that external action.
-",
-            self.context.workspace_path
-        )
+"
+        .to_string()
     }
 
     /// Build prompt from template, automatically fill content based on placeholders
@@ -416,12 +488,6 @@ The configured **primary model does not accept image inputs**. When using **`Com
             );
         }
 
-        if self.context.has_additional_tools {
-            result.push_str("\n\n");
-            result.push_str(ADDITIONAL_TOOLS_PROMPT);
-            result.push('\n');
-        }
-
         Ok(result.trim().to_string())
     }
 }
@@ -430,29 +496,54 @@ The configured **primary model does not accept image inputs**. When using **`Com
 mod tests {
     use super::PromptBuilder;
     use super::PromptBuilderContext;
+    use super::RequestContextToolSections;
+    use super::{
+        ADDITIONAL_CONTEXT_PROMPT, GET_TOOL_SPEC_CONTEXT_TITLE, SKILL_TOOL_CONTEXT_TITLE,
+        TASK_TOOL_CONTEXT_TITLE,
+    };
+    use crate::agentic::agents::RequestContextPolicy;
 
     #[tokio::test]
-    async fn appends_additional_tools_section_when_hint_is_enabled() {
-        let context =
-            PromptBuilderContext::new("E:/workspace", None, None).with_additional_tools_hint(true);
+    async fn renders_available_tool_context_before_additional_context() {
+        let tool_sections = RequestContextToolSections {
+            available_skills: Some("<available_skills>\n- pdf\n</available_skills>".to_string()),
+            available_agents: Some(
+                "<available_agents>\n- Explore\n</available_agents>".to_string(),
+            ),
+            collapsed_tools: Some(
+                "<collapsed_tools>\n- WebFetch: Fetch readable web content.\n</collapsed_tools>"
+                    .to_string(),
+            ),
+        };
+        let context = PromptBuilderContext::new("E:/workspace", None, None)
+            .with_request_context_tools(tool_sections);
         let prompt = PromptBuilder::new(context)
-            .build_prompt_from_template("Base prompt")
+            .build_request_context_reminder(
+                &RequestContextPolicy::empty()
+                    .with_workspace_context()
+                    .with_workspace_instructions(),
+            )
             .await
-            .expect("prompt should build");
+            .expect("request context should build");
 
-        assert!(prompt.contains("# Additional Tools"));
-        assert!(prompt.contains("short summaries rather than full usage instructions"));
-        assert!(prompt.contains("call `GetToolSpec` with its exact tool name"));
+        assert!(prompt.contains("# Available Tool Context"));
+        assert!(prompt.contains(SKILL_TOOL_CONTEXT_TITLE));
+        assert!(prompt.contains(TASK_TOOL_CONTEXT_TITLE));
+        assert!(prompt.contains(GET_TOOL_SPEC_CONTEXT_TITLE));
+        assert!(prompt.contains("<collapsed_tools>"));
+        assert!(prompt.contains("# Additional Context"));
+        assert!(prompt.contains(ADDITIONAL_CONTEXT_PROMPT));
+        assert!(prompt.find("# Available Tool Context") < prompt.find("# Additional Context"));
+        assert!(prompt.contains("Current Working Directory: E:/workspace"));
     }
 
     #[tokio::test]
-    async fn omits_additional_tools_section_when_hint_is_disabled() {
+    async fn omits_request_context_when_policy_and_tool_sections_are_empty() {
         let context = PromptBuilderContext::new("E:/workspace", None, None);
         let prompt = PromptBuilder::new(context)
-            .build_prompt_from_template("Base prompt")
-            .await
-            .expect("prompt should build");
+            .build_request_context_reminder(&RequestContextPolicy::empty())
+            .await;
 
-        assert!(!prompt.contains("# Additional Tools"));
+        assert!(prompt.is_none());
     }
 }

--- a/src/crates/core/src/agentic/agents/prompt_builder/request_context.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/request_context.rs
@@ -1,5 +1,6 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RequestContextSection {
+    WorkspaceContext,
     WorkspaceInstructions,
     WorkspaceMemoryFiles,
     ProjectLayout,
@@ -11,47 +12,77 @@ pub struct RequestContextPolicy {
 }
 
 impl RequestContextPolicy {
-    pub fn new(sections: Vec<RequestContextSection>) -> Self {
-        Self { sections }
+    pub fn empty() -> Self {
+        Self {
+            sections: Vec::new(),
+        }
     }
 
-    pub fn full() -> Self {
-        Self::new(vec![
-            RequestContextSection::WorkspaceInstructions,
-            RequestContextSection::WorkspaceMemoryFiles,
-            RequestContextSection::ProjectLayout,
-        ])
+    pub fn with_section(mut self, section: RequestContextSection) -> Self {
+        if !self.includes(section) {
+            self.sections.push(section);
+        }
+        self
     }
 
-    pub fn full_without_layout() -> Self {
-        Self::new(vec![
-            RequestContextSection::WorkspaceInstructions,
-            RequestContextSection::WorkspaceMemoryFiles,
-        ])
+    pub fn without_section(mut self, section: RequestContextSection) -> Self {
+        self.sections.retain(|existing| *existing != section);
+        self
     }
 
-    pub fn instructions_only() -> Self {
-        Self::new(vec![RequestContextSection::WorkspaceInstructions])
+    pub fn with_workspace_context(self) -> Self {
+        self.with_section(RequestContextSection::WorkspaceContext)
     }
 
-    pub fn instructions_and_layout() -> Self {
-        Self::new(vec![
-            RequestContextSection::WorkspaceInstructions,
-            RequestContextSection::ProjectLayout,
-        ])
+    pub fn with_workspace_instructions(self) -> Self {
+        self.with_section(RequestContextSection::WorkspaceInstructions)
+    }
+
+    pub fn with_workspace_memory_files(self) -> Self {
+        self.with_section(RequestContextSection::WorkspaceMemoryFiles)
+    }
+
+    pub fn with_project_layout(self) -> Self {
+        self.with_section(RequestContextSection::ProjectLayout)
     }
 
     pub fn includes(&self, section: RequestContextSection) -> bool {
         self.sections.contains(&section)
     }
-
-    pub fn has_override_sections(&self) -> bool {
-        self.includes(RequestContextSection::WorkspaceMemoryFiles)
-    }
 }
 
 impl Default for RequestContextPolicy {
     fn default() -> Self {
-        Self::full()
+        Self::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RequestContextPolicy, RequestContextSection};
+
+    #[test]
+    fn chain_builder_preserves_order_and_dedupes_sections() {
+        let policy = RequestContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+            .with_workspace_context()
+            .with_project_layout()
+            .without_section(RequestContextSection::ProjectLayout)
+            .with_workspace_memory_files();
+
+        assert_eq!(
+            policy.sections,
+            vec![
+                RequestContextSection::WorkspaceContext,
+                RequestContextSection::WorkspaceInstructions,
+                RequestContextSection::WorkspaceMemoryFiles,
+            ]
+        );
+    }
+
+    #[test]
+    fn default_policy_is_empty() {
+        assert!(RequestContextPolicy::default().sections.is_empty());
     }
 }

--- a/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
@@ -78,12 +78,12 @@ Build these constants for the whole pipeline:
 
 ```
 SESSION_ID   = {SESSION_ID}
-TODAY        = today's date in YYYY-MM-DD from ENV_INFO
+TODAY        = current calendar date in YYYY-MM-DD when available from runtime/request context; ask before making date-sensitive claims if it is not available
 WORK_DIR     = <workspace_root>/.bitfun/sessions/{SESSION_ID}/research
 REPORT_PATH  = <WORK_DIR>/report.md
 ```
 
-`{SESSION_ID}` above is replaced at prompt build time with the current session's ID. `<workspace_root>` is the *Current Working Directory* shown in ENV_INFO — use it verbatim.
+`{SESSION_ID}` above is replaced at prompt build time with the current session's ID. `<workspace_root>` is the workspace root shown in additional context — use it verbatim.
 
 **File-layout convention.** Everything for this research session lives under `WORK_DIR`:
 

--- a/src/crates/core/src/agentic/agents/registry/tests.rs
+++ b/src/crates/core/src/agentic/agents/registry/tests.rs
@@ -9,7 +9,7 @@ use crate::agentic::agents::registry::types::{
 use crate::agentic::agents::registry::visibility::{
     BuiltinSubagentExposure, SubagentVisibilityPolicy,
 };
-use crate::agentic::agents::Agent;
+use crate::agentic::agents::{Agent, RequestContextPolicy};
 use crate::service::config::types::AgentSubagentOverrideState;
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -40,6 +40,10 @@ impl Agent for TestAgent {
 
     fn prompt_template_name(&self, _model_name: Option<&str>) -> &str {
         "test_agent"
+    }
+
+    fn request_context_policy(&self) -> RequestContextPolicy {
+        RequestContextPolicy::empty()
     }
 
     fn default_tools(&self) -> Vec<String> {

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -5,23 +5,23 @@
 use super::round_executor::RoundExecutor;
 use super::types::{ExecutionContext, ExecutionResult, RoundContext, RoundResult};
 use crate::agentic::agents::{
-    get_agent_registry, PromptBuilder, PromptBuilderContext, RemoteExecutionHints,
+    PromptBuilder, PromptBuilderContext, RemoteExecutionHints, get_agent_registry,
 };
 use crate::agentic::context_profile::{ContextProfilePolicy, ModelCapabilityProfile};
 use crate::agentic::core::{
-    render_system_reminder, Message, MessageContent, MessageHelper, MessageRole,
-    MessageSemanticKind, RequestReasoningTokenPolicy, Session,
+    Message, MessageContent, MessageHelper, MessageRole, MessageSemanticKind,
+    RequestReasoningTokenPolicy, Session, render_system_reminder,
 };
 use crate::agentic::events::{AgenticEvent, EventPriority, EventQueue};
 use crate::agentic::execution::types::FinishReason;
 use crate::agentic::image_analysis::{
-    build_multimodal_message_with_images, process_image_contexts_for_provider, ImageContextData,
-    ImageLimits,
+    ImageContextData, ImageLimits, build_multimodal_message_with_images,
+    process_image_contexts_for_provider,
 };
 use crate::agentic::round_preempt::RoundInjectionKind;
 use crate::agentic::session::{CompressionTailPolicy, ContextCompressor, SessionManager};
 use crate::agentic::tools::{
-    resolve_tool_manifest, tool_context_runtime, ResolvedToolManifest, SubagentParentInfo,
+    ResolvedToolManifest, SubagentParentInfo, resolve_tool_manifest, tool_context_runtime,
 };
 use crate::agentic::util::build_remote_workspace_layout_preview;
 use crate::agentic::{WorkspaceBackend, WorkspaceBinding};
@@ -34,7 +34,7 @@ use crate::util::token_counter::TokenCounter;
 use crate::util::types::Message as AIMessage;
 use crate::util::types::ToolDefinition;
 use crate::util::{elapsed_ms_u64, truncate_at_char_boundary};
-use bitfun_agent_tools::{collect_loaded_collapsed_tool_names, GetToolSpecLoadObservation};
+use bitfun_agent_tools::{GetToolSpecLoadObservation, collect_loaded_collapsed_tool_names};
 use log::{debug, error, info, trace, warn};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -753,7 +753,6 @@ impl ExecutionEngine {
         execution_context_vars: &HashMap<String, String>,
         primary_supports_image_understanding: bool,
         request_context_reminder: Option<&str>,
-        current_time_reminder: Option<&str>,
         messages: &[Message],
         reminder_text: &str,
         context_window: usize,
@@ -768,7 +767,6 @@ impl ExecutionEngine {
             &context.dialog_turn_id,
             primary_supports_image_understanding,
             request_context_reminder,
-            current_time_reminder,
         )
         .await?;
         final_ai_messages.push(AIMessage::user(reminder_text.to_string()));
@@ -813,7 +811,6 @@ impl ExecutionEngine {
         current_turn_id: &str,
         attach_images: bool,
         prepended_user_context: Option<&str>,
-        appended_user_context: Option<&str>,
     ) -> BitFunResult<Vec<AIMessage>> {
         /// Only the last this many **messages** that contain images keep their images for the API.
         const MAX_IMAGE_BEARING_MESSAGE_ROUNDS: usize = 2;
@@ -828,19 +825,8 @@ impl ExecutionEngine {
                 Some(trimmed)
             }
         });
-        let trimmed_appended_user_context = appended_user_context.and_then(|text| {
-            let trimmed = text.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed)
-            }
-        });
-        let mut result = Vec::with_capacity(
-            messages.len()
-                + usize::from(trimmed_user_context.is_some())
-                + usize::from(trimmed_appended_user_context.is_some()),
-        );
+        let mut result =
+            Vec::with_capacity(messages.len() + usize::from(trimmed_user_context.is_some()));
         let mut attached_image_count = 0usize;
         let first_non_system_index = messages
             .iter()
@@ -986,9 +972,6 @@ impl ExecutionEngine {
             if let Some(user_context) = trimmed_user_context {
                 result.push(AIMessage::user(render_system_reminder(user_context)));
             }
-        }
-        if let Some(user_context) = trimmed_appended_user_context {
-            result.push(AIMessage::user(render_system_reminder(user_context)));
         }
 
         Ok(result)
@@ -1638,9 +1621,6 @@ impl ExecutionEngine {
         } else {
             None
         };
-        let current_time_reminder = prompt_context.as_ref().map(|prompt_context| {
-            PromptBuilder::new(prompt_context.clone()).build_current_time_reminder()
-        });
         let system_prompt = current_agent
             .get_system_prompt(prompt_context.as_ref())
             .await?;
@@ -1950,7 +1930,6 @@ impl ExecutionEngine {
                 &context.dialog_turn_id,
                 primary_supports_image_understanding,
                 request_context_reminder.as_deref(),
-                current_time_reminder.as_deref(),
             )
             .await?;
 
@@ -2348,7 +2327,6 @@ impl ExecutionEngine {
                         &execution_context_vars,
                         primary_supports_image_understanding,
                         request_context_reminder.as_deref(),
-                        current_time_reminder.as_deref(),
                         &messages,
                         Self::FINALIZE_AFTER_TOOL_USE_REMINDER,
                         context_window,
@@ -2380,7 +2358,6 @@ impl ExecutionEngine {
                             &execution_context_vars,
                             primary_supports_image_understanding,
                             request_context_reminder.as_deref(),
-                            current_time_reminder.as_deref(),
                             &messages,
                             Self::FORCE_TEXT_ONLY_REMINDER,
                             context_window,

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -5,23 +5,25 @@
 use super::round_executor::RoundExecutor;
 use super::types::{ExecutionContext, ExecutionResult, RoundContext, RoundResult};
 use crate::agentic::agents::{
-    PromptBuilder, PromptBuilderContext, RemoteExecutionHints, get_agent_registry,
+    get_agent_registry, PromptBuilder, PromptBuilderContext, RemoteExecutionHints,
+    RequestContextToolSections,
 };
 use crate::agentic::context_profile::{ContextProfilePolicy, ModelCapabilityProfile};
 use crate::agentic::core::{
-    Message, MessageContent, MessageHelper, MessageRole, MessageSemanticKind,
-    RequestReasoningTokenPolicy, Session, render_system_reminder,
+    render_system_reminder, Message, MessageContent, MessageHelper, MessageRole,
+    MessageSemanticKind, RequestReasoningTokenPolicy, Session,
 };
 use crate::agentic::events::{AgenticEvent, EventPriority, EventQueue};
 use crate::agentic::execution::types::FinishReason;
 use crate::agentic::image_analysis::{
-    ImageContextData, ImageLimits, build_multimodal_message_with_images,
-    process_image_contexts_for_provider,
+    build_multimodal_message_with_images, process_image_contexts_for_provider, ImageContextData,
+    ImageLimits,
 };
 use crate::agentic::round_preempt::RoundInjectionKind;
 use crate::agentic::session::{CompressionTailPolicy, ContextCompressor, SessionManager};
+use crate::agentic::tools::implementations::{GetToolSpecTool, SkillTool, TaskTool};
 use crate::agentic::tools::{
-    ResolvedToolManifest, SubagentParentInfo, resolve_tool_manifest, tool_context_runtime,
+    resolve_tool_manifest, tool_context_runtime, ResolvedToolManifest, SubagentParentInfo,
 };
 use crate::agentic::util::build_remote_workspace_layout_preview;
 use crate::agentic::{WorkspaceBackend, WorkspaceBinding};
@@ -34,7 +36,7 @@ use crate::util::token_counter::TokenCounter;
 use crate::util::types::Message as AIMessage;
 use crate::util::types::ToolDefinition;
 use crate::util::{elapsed_ms_u64, truncate_at_char_boundary};
-use bitfun_agent_tools::{GetToolSpecLoadObservation, collect_loaded_collapsed_tool_names};
+use bitfun_agent_tools::{collect_loaded_collapsed_tool_names, GetToolSpecLoadObservation};
 use log::{debug, error, info, trace, warn};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -555,11 +557,43 @@ impl ExecutionEngine {
         )
     }
 
+    async fn build_request_context_tool_sections(
+        manifest: &ResolvedToolManifest,
+        tool_context: &crate::agentic::tools::framework::ToolUseContext,
+    ) -> RequestContextToolSections {
+        let has_tool_definition = |tool_name: &str| {
+            manifest
+                .tool_definitions
+                .iter()
+                .any(|definition| definition.name == tool_name)
+        };
+
+        RequestContextToolSections {
+            available_skills: if has_tool_definition("Skill") {
+                SkillTool::build_available_skills_context_section(Some(tool_context)).await
+            } else {
+                None
+            },
+            available_agents: if has_tool_definition("Task") {
+                TaskTool::build_available_agents_context_section(Some(tool_context)).await
+            } else {
+                None
+            },
+            collapsed_tools: if has_tool_definition("GetToolSpec") {
+                GetToolSpecTool::build_collapsed_tools_context_section(
+                    &manifest.collapsed_tool_summaries,
+                )
+            } else {
+                None
+            },
+        }
+    }
+
     async fn build_prompt_context(
         context: &ExecutionContext,
         model_name: &str,
         supports_image_understanding: bool,
-        has_additional_tools: bool,
+        request_context_tools: RequestContextToolSections,
     ) -> Option<PromptBuilderContext> {
         let workspace_path = context
             .workspace
@@ -572,7 +606,7 @@ impl ExecutionEngine {
             Some(model_name.to_string()),
         )
         .with_supports_image_understanding(supports_image_understanding)
-        .with_additional_tools_hint(has_additional_tools);
+        .with_request_context_tools(request_context_tools);
 
         let Some(workspace) = context.workspace.as_ref() else {
             return Some(base);
@@ -1569,6 +1603,14 @@ impl ExecutionEngine {
             write_tool_mode.as_str().to_string(),
         );
 
+        let tool_description_context = tool_context_runtime::build_tool_description_context(
+            &agent_type,
+            context.workspace.as_ref(),
+            context.workspace_services.as_ref(),
+            primary_supports_image_understanding,
+            &tool_manifest_context_vars,
+        );
+
         let tool_manifest = if enable_tools {
             debug!(
                 "Agent tools: agent={}, tool_count={}",
@@ -1576,14 +1618,10 @@ impl ExecutionEngine {
                 allowed_tools.len()
             );
             Some(
-                self.get_available_tools_and_definitions(
+                resolve_tool_manifest(
                     &allowed_tools,
                     &tool_policy.exposure_overrides,
-                    context.workspace.as_ref(),
-                    context.workspace_services.as_ref(),
-                    &agent_type,
-                    primary_supports_image_understanding,
-                    &tool_manifest_context_vars,
+                    &tool_description_context,
                 )
                 .await,
             )
@@ -1594,7 +1632,11 @@ impl ExecutionEngine {
             .as_ref()
             .map(|manifest| manifest.collapsed_tool_names.clone())
             .unwrap_or_default();
-        let has_additional_tools = !collapsed_tools.is_empty();
+        let request_context_tools = if let Some(manifest) = tool_manifest.as_ref() {
+            Self::build_request_context_tool_sections(manifest, &tool_description_context).await
+        } else {
+            RequestContextToolSections::default()
+        };
         let (available_tools, tool_definitions) = if let Some(manifest) = tool_manifest {
             (manifest.allowed_tool_names, Some(manifest.tool_definitions))
         } else {
@@ -1611,7 +1653,7 @@ impl ExecutionEngine {
             &context,
             &ai_client.config.model,
             primary_supports_image_understanding,
-            has_additional_tools,
+            request_context_tools,
         )
         .await;
         let request_context_reminder = if let Some(prompt_context) = prompt_context.as_ref() {
@@ -2533,27 +2575,6 @@ impl ExecutionEngine {
         self.round_executor
             .cleanup_dialog_turn(dialog_turn_id)
             .await
-    }
-
-    /// Get available tool names and definitions: 1. Tool itself is enabled 2. Explicitly allowed in mode config
-    async fn get_available_tools_and_definitions(
-        &self,
-        allowed_tools: &[String],
-        exposure_overrides: &crate::agentic::agents::AgentToolPolicyOverrides,
-        workspace: Option<&crate::agentic::WorkspaceBinding>,
-        workspace_services: Option<&crate::agentic::workspace::WorkspaceServices>,
-        agent_type: &str,
-        primary_supports_image_understanding: bool,
-        context_vars: &HashMap<String, String>,
-    ) -> ResolvedToolManifest {
-        let description_context = tool_context_runtime::build_tool_description_context(
-            agent_type,
-            workspace,
-            workspace_services,
-            primary_supports_image_understanding,
-            context_vars,
-        );
-        resolve_tool_manifest(allowed_tools, exposure_overrides, &description_context).await
     }
 
     /// Emit event

--- a/src/crates/core/src/agentic/session/compression/compressor.rs
+++ b/src/crates/core/src/agentic/session/compression/compressor.rs
@@ -14,7 +14,6 @@ use crate::infrastructure::ai::{get_global_ai_client_factory, AIClient};
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::types::Message as AIMessage;
 use anyhow;
-use futures::{stream, StreamExt, TryStreamExt};
 use log::{debug, trace, warn};
 use std::sync::Arc;
 
@@ -29,7 +28,6 @@ pub struct CompressionConfig {
     pub fallback_assistant_chars: usize,
     pub fallback_tool_arg_chars: usize,
     pub fallback_tool_command_chars: usize,
-    pub map_reduce_max_parallel_requests: usize,
 }
 
 impl Default for CompressionConfig {
@@ -43,7 +41,6 @@ impl Default for CompressionConfig {
             fallback_assistant_chars: 1000,
             fallback_tool_arg_chars: 100,
             fallback_tool_command_chars: 100,
-            map_reduce_max_parallel_requests: 4,
         }
     }
 }
@@ -476,168 +473,6 @@ impl ContextCompressor {
         Some(trimmed.to_string())
     }
 
-    fn gen_first_system_message() -> Message {
-        Message::system(
-            "You are a helpful AI assistant tasked with creating a detailed summary of the conversation so far."
-                .to_string(),
-        )
-    }
-
-    fn gen_reduce_system_message() -> Message {
-        Message::system(
-            r#"You are a conversation summarization manager performing a REDUCE and MERGE phase.
-Your task is to take multiple separate summaries of different segments of the same conversation, and merge them into a single, cohesive, chronological, and comprehensive final summary.
-
-## Your Task
-You will be given:
-- A list of individual summaries representing chronological segments of the conversation (inside `<segment_summary>` tags in a User message)
-
-Your job is to:
-1. Chronologically merge and unify these segment summaries.
-2. Remove any duplicate details or redundant explanations.
-3. Output a single, unified, comprehensive summary.
-
-## Important Guidelines
-- Preserve all important technical details, code patterns, and decisions from all segments.
-- Make the final summary cohesive and chronological.
-- Maintain the same summary structure/format as specified in the user instructions.
-- The final output should be ONE cohesive summary, not a list of separate summaries.
-
-Be thorough and precise."#.to_string()
-        )
-    }
-
-    fn build_reduce_prompt(segment_summaries: &[String]) -> String {
-        let mut reduce_prompt = "Below are the individual summaries of different chronological segments of the conversation. Please merge them into a single cohesive final summary:\n\n".to_string();
-        for (idx, segment_summary) in segment_summaries.iter().enumerate() {
-            reduce_prompt.push_str(&format!(
-                "<segment_summary index={}>\n{}\n</segment_summary>\n\n",
-                idx + 1,
-                segment_summary.trim()
-            ));
-        }
-        reduce_prompt
-    }
-
-    fn estimate_reduce_request_tokens(
-        &self,
-        segment_summaries: &[String],
-        contract: Option<&CompressionContract>,
-    ) -> usize {
-        let mut system_message = Self::gen_reduce_system_message();
-        let mut reduce_message = Message::user(Self::build_reduce_prompt(segment_summaries));
-        let mut compact_prompt = Message::user(self.get_compact_prompt(contract));
-        system_message.get_tokens() + reduce_message.get_tokens() + compact_prompt.get_tokens()
-    }
-
-    fn build_reduce_batches(
-        &self,
-        segment_summaries: Vec<String>,
-        token_limit: usize,
-    ) -> BitFunResult<Vec<Vec<String>>> {
-        let mut batches = Vec::new();
-        let mut current_batch: Vec<String> = Vec::new();
-
-        for summary in segment_summaries {
-            let mut candidate = current_batch.clone();
-            candidate.push(summary.clone());
-            if self.estimate_reduce_request_tokens(&candidate, None) <= token_limit {
-                current_batch = candidate;
-                continue;
-            }
-
-            if current_batch.is_empty() {
-                return Err(BitFunError::AIClient(
-                    "Reduce phase segment summary exceeds compression request token budget"
-                        .to_string(),
-                ));
-            }
-
-            batches.push(current_batch);
-            current_batch = vec![summary];
-        }
-
-        if !current_batch.is_empty() {
-            batches.push(current_batch);
-        }
-
-        Ok(batches)
-    }
-
-    async fn reduce_segment_summaries(
-        &self,
-        ai_client: Arc<AIClient>,
-        mut segment_summaries: Vec<String>,
-        token_limit: usize,
-        contract: Option<&CompressionContract>,
-    ) -> BitFunResult<String> {
-        let max_parallel = self
-            .config
-            .map_reduce_max_parallel_requests
-            .max(1)
-            .min(segment_summaries.len().max(1));
-
-        for pass in 1..=8 {
-            if self.estimate_reduce_request_tokens(&segment_summaries, contract) <= token_limit {
-                let reduce_messages =
-                    vec![Message::user(Self::build_reduce_prompt(&segment_summaries))];
-                return self
-                    .generate_summary(
-                        ai_client,
-                        Self::gen_reduce_system_message(),
-                        reduce_messages,
-                        contract,
-                    )
-                    .await;
-            }
-
-            let previous_count = segment_summaries.len();
-            let batches = self.build_reduce_batches(segment_summaries, token_limit)?;
-            if batches.len() >= previous_count {
-                return Err(BitFunError::AIClient(format!(
-                    "Reduce phase could not fit {} segment summaries into the compression request token budget",
-                    previous_count
-                )));
-            }
-
-            debug!(
-                "Reduce prompt exceeds budget; running pass {} across {} batch(es)",
-                pass,
-                batches.len()
-            );
-
-            let reduce_futures = batches.into_iter().enumerate().map(|(idx, batch)| {
-                let ai_client = ai_client.clone();
-                async move {
-                    let reduce_messages = vec![Message::user(Self::build_reduce_prompt(&batch))];
-                    self.generate_summary(
-                        ai_client,
-                        Self::gen_reduce_system_message(),
-                        reduce_messages,
-                        None,
-                    )
-                    .await
-                    .map_err(|e| {
-                        BitFunError::AIClient(format!(
-                            "Reduce phase failed for batch {}: {}",
-                            idx + 1,
-                            e
-                        ))
-                    })
-                }
-            });
-
-            segment_summaries = stream::iter(reduce_futures)
-                .buffered(max_parallel)
-                .try_collect::<Vec<_>>()
-                .await?;
-        }
-
-        Err(BitFunError::AIClient(
-            "Reduce phase exceeded maximum compression reduce passes".to_string(),
-        ))
-    }
-
     async fn execute_compression(
         &self,
         ai_client: Arc<AIClient>,
@@ -647,100 +482,127 @@ Be thorough and precise."#.to_string()
     ) -> BitFunResult<String> {
         debug!("Compressing {} turn(s)", turns_to_compress.len());
 
+        fn gen_system_message_for_summary(prev_summary: &str) -> Message {
+            if prev_summary.is_empty() {
+                Message::system(
+                    "You are a helpful AI assistant tasked with summarizing conversations."
+                        .to_string(),
+                )
+            } else {
+                Message::system(format!(
+                    r#"You are a conversation summarization assistant performing an INCREMENTAL summary update.
+
+## Previous Summary
+The conversation has already been partially summarized. Here is the existing summary:
+
+<previous_summary>
+{}
+</previous_summary>
+
+## Your Task
+You will be given the CONTINUATION of this conversation. Your job is to:
+1. Read and understand the new conversation segment
+2. MERGE the new information into the existing summary
+3. Output a single, unified summary that combines both the previous summary and the new conversation
+
+## Important Guidelines
+- Preserve all important information from the previous summary
+- Add new details from the current conversation segment
+- If new information contradicts or updates previous information, use the newer information
+- Maintain the same summary structure/format as specified in the user instructions
+- The final output should be ONE cohesive summary, not two separate summaries
+- Do not mention "previous summary" or "new conversation" in your output - write as if summarizing the entire conversation from the start
+
+Be thorough and precise. Do not lose important technical details from either the previous summary or the new conversation."#,
+                    prev_summary
+                ))
+            }
+        }
+
         let max_tokens_in_one_request =
             (context_window as f32 * self.config.single_request_max_tokens_ratio) as usize;
-
-        // Step 1: Slice turns into independent chunks based on token limits
-        let mut chunks = Vec::new();
-        let mut cur_chunk_messages = Vec::new();
         let mut current_tokens = 0;
-
-        for turn in turns_to_compress {
+        let mut cur_messages = Vec::new();
+        let mut summary = String::new();
+        let mut request_cnt = 0;
+        for (idx, turn) in turns_to_compress.into_iter().enumerate() {
             if current_tokens + turn.tokens <= max_tokens_in_one_request {
-                cur_chunk_messages.extend(turn.messages);
+                cur_messages.extend(turn.messages);
                 current_tokens += turn.tokens;
             } else {
-                if !cur_chunk_messages.is_empty() {
-                    chunks.push(cur_chunk_messages);
-                    cur_chunk_messages = Vec::new();
+                if !cur_messages.is_empty() {
+                    summary = self
+                        .generate_summary(
+                            ai_client.clone(),
+                            gen_system_message_for_summary(&summary),
+                            cur_messages,
+                            contract,
+                        )
+                        .await?;
+                    cur_messages = Vec::new();
                     current_tokens = 0;
+                    request_cnt += 1;
+                    trace!(
+                        "Compression request {} completed: turn_idx={}",
+                        request_cnt,
+                        idx
+                    );
                 }
 
                 if turn.tokens <= max_tokens_in_one_request {
-                    cur_chunk_messages = turn.messages;
+                    cur_messages.extend(turn.messages);
                     current_tokens = turn.tokens;
                 } else if let Some((messages_part1, messages_part2)) =
                     MessageHelper::split_messages_in_middle(turn.messages)
                 {
-                    chunks.push(messages_part1);
-                    chunks.push(messages_part2);
+                    summary = self
+                        .generate_summary(
+                            ai_client.clone(),
+                            gen_system_message_for_summary(&summary),
+                            messages_part1,
+                            contract,
+                        )
+                        .await?;
+                    request_cnt += 1;
+                    debug!(
+                        "[execute_compression] request_cnt={}, turn_idx={}, summary: \n{}",
+                        request_cnt, idx, summary
+                    );
+                    summary = self
+                        .generate_summary(
+                            ai_client.clone(),
+                            gen_system_message_for_summary(&summary),
+                            messages_part2,
+                            contract,
+                        )
+                        .await?;
+                    request_cnt += 1;
+                    debug!(
+                        "[execute_compression] request_cnt={}, turn_idx={}, summary: \n{}",
+                        request_cnt, idx, summary
+                    );
                 } else {
-                    return Err(BitFunError::Service(
-                        "Compression Failed, turn cannot be split in middle".to_string(),
-                    ));
+                    return Err(BitFunError::Service(format!(
+                        "Compression Failed, turn {} cannot be split in middle",
+                        idx
+                    )));
                 }
             }
         }
-        if !cur_chunk_messages.is_empty() {
-            chunks.push(cur_chunk_messages);
-        }
 
-        if chunks.is_empty() {
-            return Ok(String::new());
-        }
-
-        // Step 2: If there is only 1 chunk, perform a single direct summarization (O(1) latency)
-        if chunks.len() == 1 {
-            let single_chunk = chunks.into_iter().next().unwrap();
-            let summary = self
+        if !cur_messages.is_empty() {
+            summary = self
                 .generate_summary(
-                    ai_client,
-                    Self::gen_first_system_message(),
-                    single_chunk,
+                    ai_client.clone(),
+                    gen_system_message_for_summary(&summary),
+                    cur_messages,
                     contract,
                 )
                 .await?;
-            return Ok(summary);
+            request_cnt += 1;
+            trace!("Compression request {} completed", request_cnt);
         }
-
-        // Step 3: If there are multiple chunks, perform Parallel Map-Reduce (O(1) parallel latency)
-        debug!(
-            "Executing Parallel Map-Reduce compression across {} chunks",
-            chunks.len()
-        );
-
-        // 3.1. Map Phase (Parallel summarization of each chunk)
-        let max_parallel = self
-            .config
-            .map_reduce_max_parallel_requests
-            .max(1)
-            .min(chunks.len());
-        let map_futures = chunks.into_iter().enumerate().map(|(idx, chunk)| {
-            let ai_client = ai_client.clone();
-            let sys_msg = Self::gen_first_system_message();
-            async move {
-                self.generate_summary(
-                    ai_client, sys_msg, chunk,
-                    None, // Contract will be applied in the Reduce phase instead
-                )
-                .await
-                .map_err(|e| {
-                    BitFunError::AIClient(format!("Map phase failed for chunk {}: {}", idx + 1, e))
-                })
-            }
-        });
-
-        let map_results = stream::iter(map_futures)
-            .buffered(max_parallel)
-            .try_collect::<Vec<_>>()
-            .await?;
-
-        // 3.2. Reduce Phase (Chronologically merge and unify segment summaries into a single final summary)
-        let final_summary = self
-            .reduce_segment_summaries(ai_client, map_results, max_tokens_in_one_request, contract)
-            .await?;
-
-        Ok(final_summary)
+        Ok(summary)
     }
 
     async fn generate_summary(

--- a/src/crates/core/src/agentic/tools/implementations/get_tool_spec_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/get_tool_spec_tool.rs
@@ -1,16 +1,27 @@
 //! GetToolSpec tool implementation
 
-use crate::agentic::tools::product_runtime::{
-    build_product_get_tool_spec_catalog_description, product_get_tool_spec_runtime,
-    resolve_product_get_tool_spec_results, ProductGetToolSpecRuntime, ProductToolCatalogProvider,
-};
 use crate::agentic::tools::framework::{
     Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
+use crate::agentic::tools::product_runtime::{
+    product_get_tool_spec_runtime, resolve_product_get_tool_spec_results,
+    ProductGetToolSpecRuntime, ProductToolCatalogProvider,
+};
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
-use bitfun_agent_tools::{GetToolSpecExecutionError, GET_TOOL_SPEC_TOOL_NAME};
+use bitfun_agent_tools::{
+    build_get_tool_spec_collapsed_tool_entry, GetToolSpecCollapsedToolSummary,
+    GetToolSpecExecutionError, GET_TOOL_SPEC_TOOL_NAME,
+};
 use serde_json::Value;
+
+const GET_TOOL_SPEC_DESCRIPTION: &str = r#"Read usage instructions for additional tools.
+
+Some tools are collapsed: their names may appear in the tool list, but you must not call them directly until you have loaded their definition with GetToolSpec.
+
+When the current request context includes a <collapsed_tools> section, use the exact tool names from that section. Before using one of those tools, first call GetToolSpec with its exact tool name to read its full description and input schema. After reading the returned definition, call the real tool directly using its own name.
+
+Do not call GetToolSpec again for a tool whose definition is already loaded in the current conversation."#;
 
 pub struct GetToolSpecTool;
 
@@ -19,8 +30,25 @@ impl GetToolSpecTool {
         Self
     }
 
-    async fn build_collapsed_tools_description(&self, context: Option<&ToolUseContext>) -> String {
-        build_product_get_tool_spec_catalog_description(context).await
+    pub(crate) fn build_collapsed_tools_context_section(
+        collapsed_tools: &[GetToolSpecCollapsedToolSummary],
+    ) -> Option<String> {
+        if collapsed_tools.is_empty() {
+            return None;
+        }
+
+        let collapsed_tools_list = collapsed_tools
+            .iter()
+            .map(|tool| {
+                build_get_tool_spec_collapsed_tool_entry(&tool.name, &tool.short_description)
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Some(format!(
+            "<collapsed_tools>\n{}\n</collapsed_tools>",
+            collapsed_tools_list
+        ))
     }
 }
 
@@ -42,7 +70,7 @@ impl Tool for GetToolSpecTool {
     }
 
     async fn description(&self) -> BitFunResult<String> {
-        Ok(self.build_collapsed_tools_description(None).await)
+        Ok(GET_TOOL_SPEC_DESCRIPTION.to_string())
     }
 
     fn short_description(&self) -> String {
@@ -51,9 +79,9 @@ impl Tool for GetToolSpecTool {
 
     async fn description_with_context(
         &self,
-        context: Option<&ToolUseContext>,
+        _context: Option<&ToolUseContext>,
     ) -> BitFunResult<String> {
-        Ok(self.build_collapsed_tools_description(context).await)
+        Ok(GET_TOOL_SPEC_DESCRIPTION.to_string())
     }
 
     fn input_schema(&self) -> Value {
@@ -105,74 +133,21 @@ fn map_get_tool_spec_execution_error(error: GetToolSpecExecutionError) -> BitFun
 #[cfg(test)]
 mod tests {
     use super::GetToolSpecTool;
-    use crate::agentic::tools::framework::{
-        Tool, ToolExposure, ToolResult, ToolUseContext, ValidationResult,
-    };
-    use crate::agentic::tools::registry::get_global_tool_registry;
+    use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
     use crate::agentic::tools::ToolRuntimeRestrictions;
-    use crate::util::errors::BitFunResult;
-    use async_trait::async_trait;
-    use serde_json::{json, Value};
+    use serde_json::json;
     use std::collections::HashMap;
-    use std::sync::Arc;
 
-    struct CatalogDescriptionTestTool {
-        name: String,
-    }
-
-    #[async_trait]
-    impl Tool for CatalogDescriptionTestTool {
-        fn name(&self) -> &str {
-            &self.name
-        }
-
-        async fn description(&self) -> BitFunResult<String> {
-            Ok("Verbose description first line.\nSecond line.".to_string())
-        }
-
-        fn short_description(&self) -> String {
-            "Concise catalog entry.".to_string()
-        }
-
-        fn default_exposure(&self) -> ToolExposure {
-            ToolExposure::Collapsed
-        }
-
-        fn input_schema(&self) -> Value {
-            json!({ "type": "object" })
-        }
-
-        async fn validate_input(
-            &self,
-            _input: &Value,
-            _context: Option<&ToolUseContext>,
-        ) -> ValidationResult {
-            ValidationResult::default()
-        }
-
-        async fn call_impl(
-            &self,
-            _input: &Value,
-            _context: &ToolUseContext,
-        ) -> BitFunResult<Vec<ToolResult>> {
-            Ok(Vec::new())
-        }
-    }
-
-    #[tokio::test]
-    async fn get_tool_spec_uses_explicit_short_description() {
+    #[test]
+    fn collapsed_tools_context_uses_explicit_short_description() {
         let tool_name = format!("CatalogDescriptionTestTool_{}", uuid::Uuid::new_v4());
-        let registry = get_global_tool_registry();
-        {
-            let mut registry = registry.write().await;
-            registry.register_tool(Arc::new(CatalogDescriptionTestTool {
+        let description = GetToolSpecTool::build_collapsed_tools_context_section(&[
+            bitfun_agent_tools::GetToolSpecCollapsedToolSummary {
                 name: tool_name.clone(),
-            }));
-        }
-
-        let description = GetToolSpecTool::new()
-            .build_collapsed_tools_description(None)
-            .await;
+                short_description: "Concise catalog entry.".to_string(),
+            },
+        ])
+        .expect("collapsed tools section");
 
         assert!(description.contains(&format!("- {}: Concise catalog entry.", tool_name)));
         assert!(!description.contains(&format!("- {}: Verbose description first line.", tool_name)));

--- a/src/crates/core/src/agentic/tools/implementations/skill_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skill_tool.rs
@@ -22,18 +22,11 @@ impl SkillTool {
         Self
     }
 
-    fn render_description(&self, skills_list: String) -> String {
-        let skills_list = if skills_list.is_empty() {
-            "No skills available".to_string()
-        } else {
-            skills_list
-        };
-
-        format!(
-            r#"Execute a skill within the main conversation
+    fn render_description(&self) -> String {
+        r#"Execute a skill within the main conversation
 
 <skills_instructions>
-When users ask you to perform tasks, check if any of the available skills below can help complete the task more effectively. Skills provide specialized capabilities and domain knowledge.
+When users ask you to perform tasks, check whether any skills listed in the current request context can help complete the task more effectively. Skills provide specialized capabilities and domain knowledge.
 
 How to use skills:
 - Invoke skills using this tool with the skill name only (no arguments)
@@ -44,18 +37,15 @@ How to use skills:
   - `command: "ms-office-suite:pdf"` - invoke using fully qualified name
 
 Important:
-- Only use skills listed in <available_skills> below
+- Only use skills listed in the current request context's <available_skills> section
 - Do not invoke a skill that is already running
-</skills_instructions>
-
-<available_skills>
-{}
-</available_skills>"#,
-            skills_list
-        )
+</skills_instructions>"#
+            .to_string()
     }
 
-    async fn build_description_for_context(&self, context: Option<&ToolUseContext>) -> String {
+    pub(crate) async fn resolved_skills_xml_for_context(
+        context: Option<&ToolUseContext>,
+    ) -> String {
         let registry = get_skill_registry();
         let available_skills = match context {
             Some(ctx) if ctx.is_remote() => {
@@ -93,7 +83,27 @@ Important:
             }
         };
 
-        self.render_description(available_skills.join("\n"))
+        available_skills.join("\n")
+    }
+
+    pub(crate) async fn build_available_skills_context_section(
+        context: Option<&ToolUseContext>,
+    ) -> Option<String> {
+        let skills_list = Self::resolved_skills_xml_for_context(context).await;
+        let skills_list = skills_list.trim();
+        if skills_list.is_empty() {
+            return None;
+        }
+
+        let mut section = format!("<available_skills>\n{}\n</available_skills>", skills_list);
+        if context.map(|c| c.is_remote()).unwrap_or(false)
+            && context.and_then(|c| c.ws_fs()).is_none()
+        {
+            section.push_str(
+                "\n\nRemote workspace note: Project-level skills on the server could not be indexed because workspace I/O is unavailable. Only user-level skills are shown; BitFun will not fall back to scanning the remote path on the local filesystem.",
+            );
+        }
+        Some(section)
     }
 }
 
@@ -104,7 +114,7 @@ impl Tool for SkillTool {
     }
 
     async fn description(&self) -> BitFunResult<String> {
-        Ok(self.build_description_for_context(None).await)
+        Ok(self.render_description())
     }
 
     fn short_description(&self) -> String {
@@ -113,17 +123,9 @@ impl Tool for SkillTool {
 
     async fn description_with_context(
         &self,
-        context: Option<&ToolUseContext>,
+        _context: Option<&ToolUseContext>,
     ) -> BitFunResult<String> {
-        let mut s = self.build_description_for_context(context).await;
-        if context.map(|c| c.is_remote()).unwrap_or(false)
-            && context.and_then(|c| c.ws_fs()).is_none()
-        {
-            s.push_str(
-                "\n\n**Remote workspace:** Project-level skills on the server could not be indexed because workspace I/O is unavailable. Only user-level skills are shown; BitFun will not fall back to scanning the remote path on the local filesystem.",
-            );
-        }
-        Ok(s)
+        Ok(self.render_description())
     }
 
     fn input_schema(&self) -> Value {
@@ -389,10 +391,9 @@ Use the remote project skill.
             }),
         };
 
-        let description = SkillTool::new()
-            .description_with_context(Some(&context))
+        let description = SkillTool::build_available_skills_context_section(Some(&context))
             .await
-            .expect("description");
+            .expect("available skills section");
 
         assert!(description.contains("remote-only-skill-for-test"));
         assert!(

--- a/src/crates/core/src/agentic/tools/implementations/task_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/task_tool.rs
@@ -398,7 +398,7 @@ impl TaskTool {
         }
     }
 
-    fn format_agent_descriptions(&self, agents: &[AgentInfo]) -> String {
+    fn format_agent_descriptions(agents: &[AgentInfo]) -> String {
         if agents.is_empty() {
             return String::new();
         }
@@ -415,20 +415,12 @@ impl TaskTool {
         out
     }
 
-    fn render_description(&self, agent_descriptions: String) -> String {
-        let agent_descriptions = if agent_descriptions.is_empty() {
-            "<agents>No agents available</agents>".to_string()
-        } else {
-            agent_descriptions
-        };
-
-        format!(
-            r#"Launch a new agent to handle complex, multi-step tasks autonomously. 
+    fn render_description(&self) -> String {
+        r#"Launch a new agent to handle complex, multi-step tasks autonomously. 
 
 The Task tool launches specialized agents (subprocesses) that autonomously handle complex tasks. Each agent type has specific capabilities and tools available to it.
 
-Available agents and the tools they have access to:
-{}
+The current request context includes an <available_agents> section when subagents are available. Use the exact `type` attribute from that section as `subagent_type`.
 
 When using the Task tool, you must specify `subagent_type` as a top-level tool argument to select which agent type to use. Do not put `subagent_type`, `description`, `workspace_path`, `model_id`, or `timeout_seconds` inside the prompt string.
 
@@ -462,18 +454,23 @@ assistant: Uses the Task tool with subagent_type="Explore" because this is a bro
 <example>
 user: "Find the files that implement export formatting"
 assistant: Uses the Task tool with subagent_type="FileFinder" because the exact filenames are unknown and semantic file discovery is useful. The parent agent reads the returned files before proposing edits.
-</example>"#,
-            agent_descriptions
-        )
+</example>"#
+            .to_string()
     }
 
-    async fn build_description(&self, context: Option<&ToolUseContext>) -> String {
-        let agents = self.get_enabled_agents(context).await;
-        let agent_descriptions = self.format_agent_descriptions(&agents);
-        self.render_description(agent_descriptions)
+    pub(crate) async fn build_available_agents_context_section(
+        context: Option<&ToolUseContext>,
+    ) -> Option<String> {
+        let agents = Self::get_enabled_agents(context).await;
+        let agent_descriptions = Self::format_agent_descriptions(&agents);
+        if agent_descriptions.trim().is_empty() {
+            None
+        } else {
+            Some(agent_descriptions)
+        }
     }
 
-    async fn get_enabled_agents(&self, context: Option<&ToolUseContext>) -> Vec<AgentInfo> {
+    async fn get_enabled_agents(context: Option<&ToolUseContext>) -> Vec<AgentInfo> {
         let registry = get_agent_registry();
         let workspace_root = context.and_then(|ctx| ctx.workspace_root());
         if let Some(workspace_root) = workspace_root {
@@ -490,7 +487,7 @@ assistant: Uses the Task tool with subagent_type="FileFinder" because the exact 
     }
 
     async fn get_agents_types(&self, context: Option<&ToolUseContext>) -> Vec<String> {
-        self.get_enabled_agents(context)
+        Self::get_enabled_agents(context)
             .await
             .into_iter()
             .map(|agent| agent.id)
@@ -505,7 +502,7 @@ impl Tool for TaskTool {
     }
 
     async fn description(&self) -> BitFunResult<String> {
-        Ok(self.build_description(None).await)
+        Ok(self.render_description())
     }
 
     fn short_description(&self) -> String {
@@ -514,9 +511,9 @@ impl Tool for TaskTool {
 
     async fn description_with_context(
         &self,
-        context: Option<&ToolUseContext>,
+        _context: Option<&ToolUseContext>,
     ) -> BitFunResult<String> {
-        Ok(self.build_description(context).await)
+        Ok(self.render_description())
     }
 
     fn input_schema(&self) -> Value {
@@ -1551,7 +1548,9 @@ impl Tool for TaskTool {
 mod tests {
     use super::TaskTool;
     use crate::agentic::agents::CustomSubagentConfig;
-    use crate::agentic::agents::{get_agent_registry, Agent, AgentCategory, SubAgentSource};
+    use crate::agentic::agents::{
+        get_agent_registry, Agent, AgentCategory, RequestContextPolicy, SubAgentSource,
+    };
     use crate::agentic::deep_review::task_adapter as deep_review_task_adapter;
     use crate::agentic::deep_review_policy::{
         DeepReviewBudgetTracker, DeepReviewExecutionPolicy, DeepReviewSubagentRole,
@@ -1588,6 +1587,10 @@ mod tests {
 
         fn prompt_template_name(&self, _model_name: Option<&str>) -> &str {
             "test_prompt_order_agent"
+        }
+
+        fn request_context_policy(&self) -> RequestContextPolicy {
+            RequestContextPolicy::empty()
         }
 
         fn default_tools(&self) -> Vec<String> {
@@ -1693,10 +1696,7 @@ mod tests {
             TaskTool::resolve_subagent_timeout_seconds(Some(300), None),
             Some(300)
         );
-        assert_eq!(
-            TaskTool::resolve_subagent_timeout_seconds(None, None),
-            None
-        );
+        assert_eq!(TaskTool::resolve_subagent_timeout_seconds(None, None), None);
     }
 
     #[test]
@@ -1749,7 +1749,6 @@ mod tests {
 
     #[tokio::test]
     async fn description_with_context_filters_restricted_subagents_by_parent_agent() {
-        let tool = TaskTool::new();
         let agentic_context = ToolUseContext {
             tool_call_id: None,
             agent_type: Some("agentic".to_string()),
@@ -1768,25 +1767,24 @@ mod tests {
             ..agentic_context.clone()
         };
 
-        let agentic_description = tool
-            .description_with_context(Some(&agentic_context))
-            .await
-            .expect("agentic description should render");
+        let agentic_description =
+            TaskTool::build_available_agents_context_section(Some(&agentic_context))
+                .await
+                .expect("agentic available agents should render");
         assert!(agentic_description.contains("<agent type=\"Explore\">"));
         assert!(!agentic_description.contains("<agent type=\"ReviewSecurity\">"));
         assert!(!agentic_description.contains("<agent type=\"ResearchSpecialist\">"));
 
-        let deep_review_description = tool
-            .description_with_context(Some(&deep_review_context))
-            .await
-            .expect("deep review description should render");
+        let deep_review_description =
+            TaskTool::build_available_agents_context_section(Some(&deep_review_context))
+                .await
+                .expect("deep review available agents should render");
         assert!(deep_review_description.contains("<agent type=\"ReviewSecurity\">"));
         assert!(!deep_review_description.contains("<agent type=\"ResearchSpecialist\">"));
     }
 
     #[tokio::test]
     async fn prompt_stability_description_with_context_renders_available_agents_in_stable_order() {
-        let tool = TaskTool::new();
         let context = ToolUseContext {
             tool_call_id: None,
             agent_type: Some("agentic".to_string()),
@@ -1822,10 +1820,9 @@ mod tests {
             }),
         );
 
-        let description = tool
-            .description_with_context(Some(&context))
+        let description = TaskTool::build_available_agents_context_section(Some(&context))
             .await
-            .expect("description should render");
+            .expect("available agents should render");
 
         let builtin_a_index = find_agent_block_index(&description, builtin_a);
         let builtin_z_index = find_agent_block_index(&description, builtin_z);

--- a/src/crates/core/src/agentic/tools/manifest_resolver.rs
+++ b/src/crates/core/src/agentic/tools/manifest_resolver.rs
@@ -1,10 +1,13 @@
 use crate::agentic::agents::AgentToolPolicyOverrides;
+use crate::agentic::tools::framework::{Tool, ToolUseContext};
 use crate::agentic::tools::product_runtime::{
     resolve_product_tool_manifest, resolve_product_visible_tools,
 };
-use crate::agentic::tools::framework::{Tool, ToolUseContext};
 use crate::util::types::ToolDefinition;
-use bitfun_agent_tools::{ContextualToolManifest, ContextualVisibleTools, ToolManifestDefinition};
+use bitfun_agent_tools::{
+    ContextualToolManifest, ContextualVisibleTools, GetToolSpecCollapsedToolSummary,
+    ToolManifestDefinition,
+};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -12,6 +15,7 @@ pub struct ResolvedToolManifest {
     pub allowed_tool_names: Vec<String>,
     pub tool_definitions: Vec<ToolDefinition>,
     pub collapsed_tool_names: Vec<String>,
+    pub collapsed_tool_summaries: Vec<GetToolSpecCollapsedToolSummary>,
 }
 
 #[derive(Clone)]
@@ -39,6 +43,15 @@ impl From<ContextualVisibleTools<dyn Tool>> for ResolvedVisibleTools {
 
 impl From<ContextualToolManifest<dyn Tool>> for ResolvedToolManifest {
     fn from(value: ContextualToolManifest<dyn Tool>) -> Self {
+        let collapsed_tool_summaries = value
+            .collapsed_tools
+            .iter()
+            .map(|tool| GetToolSpecCollapsedToolSummary {
+                name: tool.name().to_string(),
+                short_description: tool.short_description(),
+            })
+            .collect();
+
         Self {
             allowed_tool_names: value.allowed_tool_names,
             tool_definitions: value
@@ -47,6 +60,7 @@ impl From<ContextualToolManifest<dyn Tool>> for ResolvedToolManifest {
                 .map(to_core_tool_definition)
                 .collect(),
             collapsed_tool_names: value.collapsed_tool_names,
+            collapsed_tool_summaries,
         }
     }
 }
@@ -57,8 +71,8 @@ pub async fn resolve_visible_tools(
     context: &ToolUseContext,
 ) -> ResolvedVisibleTools {
     resolve_product_visible_tools(allowed_tools, exposure_overrides, context)
-    .await
-    .into()
+        .await
+        .into()
 }
 
 pub async fn resolve_tool_manifest(
@@ -67,16 +81,16 @@ pub async fn resolve_tool_manifest(
     context: &ToolUseContext,
 ) -> ResolvedToolManifest {
     resolve_product_tool_manifest(allowed_tools, exposure_overrides, context)
-    .await
-    .into()
+        .await
+        .into()
 }
 
 #[cfg(test)]
 mod tests {
     use super::resolve_tool_manifest;
     use crate::agentic::agents::AgentToolPolicyOverrides;
-    use crate::agentic::tools::ToolRuntimeRestrictions;
     use crate::agentic::tools::framework::{ToolExposure, ToolUseContext};
+    use crate::agentic::tools::ToolRuntimeRestrictions;
     use bitfun_agent_tools::GET_TOOL_SPEC_TOOL_NAME;
     use serde_json::json;
     use std::collections::HashMap;
@@ -110,12 +124,10 @@ mod tests {
 
         assert!(manifest.collapsed_tool_names.is_empty());
         assert_eq!(manifest.allowed_tool_names, allowed_tools);
-        assert!(
-            !manifest
-                .tool_definitions
-                .iter()
-                .any(|tool| tool.name == GET_TOOL_SPEC_TOOL_NAME)
-        );
+        assert!(!manifest
+            .tool_definitions
+            .iter()
+            .any(|tool| tool.name == GET_TOOL_SPEC_TOOL_NAME));
     }
 
     #[tokio::test]
@@ -130,29 +142,26 @@ mod tests {
         .await;
 
         assert_eq!(manifest.collapsed_tool_names, vec!["WebFetch".to_string()]);
-        assert!(
-            manifest
-                .allowed_tool_names
-                .contains(&GET_TOOL_SPEC_TOOL_NAME.to_string())
-        );
-        assert!(
-            manifest
-                .tool_definitions
-                .iter()
-                .any(|tool| tool.name == "Read")
-        );
-        assert!(
-            manifest
-                .tool_definitions
-                .iter()
-                .any(|tool| tool.name == "WebFetch")
-        );
-        assert!(
-            manifest
-                .tool_definitions
-                .iter()
-                .any(|tool| tool.name == GET_TOOL_SPEC_TOOL_NAME)
-        );
+        assert_eq!(manifest.collapsed_tool_summaries.len(), 1);
+        assert_eq!(manifest.collapsed_tool_summaries[0].name, "WebFetch");
+        assert!(manifest.collapsed_tool_summaries[0]
+            .short_description
+            .contains("Fetch content from a URL"));
+        assert!(manifest
+            .allowed_tool_names
+            .contains(&GET_TOOL_SPEC_TOOL_NAME.to_string()));
+        assert!(manifest
+            .tool_definitions
+            .iter()
+            .any(|tool| tool.name == "Read"));
+        assert!(manifest
+            .tool_definitions
+            .iter()
+            .any(|tool| tool.name == "WebFetch"));
+        assert!(manifest
+            .tool_definitions
+            .iter()
+            .any(|tool| tool.name == GET_TOOL_SPEC_TOOL_NAME));
         let stub = manifest
             .tool_definitions
             .iter()
@@ -161,12 +170,10 @@ mod tests {
         assert!(stub.description.contains("First call `GetToolSpec`"));
         assert_eq!(stub.parameters["type"], json!("object"));
         assert_eq!(stub.parameters["additionalProperties"], json!(false));
-        assert!(
-            stub.parameters["properties"]["tool_name"]["description"]
-                .as_str()
-                .unwrap()
-                .contains("{\"tool_name\":\"WebFetch\"}")
-        );
+        assert!(stub.parameters["properties"]["tool_name"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("{\"tool_name\":\"WebFetch\"}"));
     }
 
     #[tokio::test]
@@ -216,11 +223,9 @@ mod tests {
             .iter()
             .find(|tool| tool.name == "WebFetch")
             .expect("collapsed WebFetch stub");
-        assert!(
-            web_fetch
-                .description
-                .contains("First call `GetToolSpec` with {\"tool_name\":\"WebFetch\"}")
-        );
+        assert!(web_fetch
+            .description
+            .contains("First call `GetToolSpec` with {\"tool_name\":\"WebFetch\"}"));
         assert_eq!(
             web_fetch.parameters,
             json!({
@@ -338,17 +343,13 @@ mod tests {
         let manifest = resolve_tool_manifest(&allowed_tools, &overrides, &tool_context()).await;
 
         assert!(manifest.collapsed_tool_names.is_empty());
-        assert!(
-            manifest
-                .tool_definitions
-                .iter()
-                .any(|tool| tool.name == "WebFetch")
-        );
-        assert!(
-            !manifest
-                .tool_definitions
-                .iter()
-                .any(|tool| tool.name == GET_TOOL_SPEC_TOOL_NAME)
-        );
+        assert!(manifest
+            .tool_definitions
+            .iter()
+            .any(|tool| tool.name == "WebFetch"));
+        assert!(!manifest
+            .tool_definitions
+            .iter()
+            .any(|tool| tool.name == GET_TOOL_SPEC_TOOL_NAME));
     }
 }

--- a/src/crates/core/src/agentic/tools/product_runtime.rs
+++ b/src/crates/core/src/agentic/tools/product_runtime.rs
@@ -242,15 +242,6 @@ pub(crate) async fn resolve_product_readonly_enabled_tools() -> Vec<Arc<dyn Tool
         .await
 }
 
-pub(crate) async fn build_product_get_tool_spec_catalog_description(
-    context: Option<&ToolUseContext>,
-) -> String {
-    let provider = ProductToolCatalogProvider;
-    product_get_tool_spec_runtime(&provider)
-        .catalog_description(context)
-        .await
-}
-
 pub(crate) async fn resolve_product_get_tool_spec_results(
     input: &Value,
     context: &ToolUseContext,

--- a/src/crates/core/src/service/agent_memory/auto_memory.rs
+++ b/src/crates/core/src/service/agent_memory/auto_memory.rs
@@ -303,14 +303,14 @@ async fn build_memory_space_files_section(memory_dir: &Path) -> BitFunResult<Str
     };
 
     Ok(format!(
-        r#"# memory_files
+        r#"## memory_files
 Persistent memory files currently available in `{memory_dir_display}`.
 
-## memory.md
+### memory.md
 High-level index for the durable workspace memory space.{index_description_suffix}
 {index_body}
 
-## topic_memory_files
+### topic_memory_files
 Topic-oriented durable memory files available in this workspace.{topic_description_suffix}
 {topic_files_content}"#
     ))

--- a/src/crates/core/src/service/agent_memory/instruction_context.rs
+++ b/src/crates/core/src/service/agent_memory/instruction_context.rs
@@ -50,7 +50,7 @@ fn render_workspace_instruction_files_section(
     }
 
     let mut rendered =
-        String::from("As you answer the user's questions, you can use the following context:\n\n");
+        String::from("## Codebase and user instructions\n\nBe sure to adhere to these instructions. IMPORTANT: These instructions OVERRIDE any default behavior and you MUST follow them exactly as written.\n");
 
     for file in files {
         rendered.push_str(&format!(


### PR DESCRIPTION
- move workspace context and dynamic tool catalogs out of env info and tool descriptions
- centralize request context section rendering in the prompt builder, including collapsed tool guidance
- simplify request context policy defaults and require agents to declare sections explicitly
- refactor request context construction toward chainable, easier-to-maintain composition
- update tool and prompt tests to cover the new request context layout