### PR TITLE
feat(workspace): add related directories support

### DIFF
--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -34,6 +34,8 @@ pub struct CreateSessionRequest {
     pub agent_type: String,
     pub workspace_path: String,
     #[serde(default)]
+    pub workspace_id: Option<String>,
+    #[serde(default)]
     pub session_kind: Option<SessionKind>,
     #[serde(default)]
     pub remote_connection_id: Option<String>,
@@ -568,12 +570,14 @@ pub async fn create_session(
             enable_context_compression: c.enable_context_compression.unwrap_or(true),
             compression_threshold: c.compression_threshold.unwrap_or(0.8),
             workspace_path: Some(request.workspace_path.clone()),
+            workspace_id: request.workspace_id.clone(),
             remote_connection_id: remote_conn.clone(),
             remote_ssh_host: remote_ssh_host.clone(),
             model_id: c.model_name,
         })
         .unwrap_or(SessionConfig {
             workspace_path: Some(request.workspace_path.clone()),
+            workspace_id: request.workspace_id.clone(),
             remote_connection_id: remote_conn.clone(),
             remote_ssh_host: remote_ssh_host.clone(),
             ..Default::default()

--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -405,6 +405,17 @@ pub struct ReorderOpenedWorkspacesRequest {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateWorkspaceInfoRequest {
+    pub workspace_id: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub tags: Option<Vec<String>>,
+    #[serde(default)]
+    pub related_paths: Option<Vec<bitfun_core::service::workspace::RelatedPath>>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct TestAIConfigConnectionRequest {
     pub config: bitfun_core::service::config::types::AIModelConfig,
 }
@@ -1729,6 +1740,51 @@ pub async fn reorder_opened_workspaces(
         Err(e) => {
             error!("Failed to reorder opened workspaces: {}", e);
             Err(format!("Failed to reorder opened workspaces: {}", e))
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn update_workspace_info(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    request: UpdateWorkspaceInfoRequest,
+) -> Result<WorkspaceInfoDto, String> {
+    let updates = bitfun_core::service::workspace::WorkspaceInfoUpdates {
+        name: request.name,
+        description: request.description,
+        tags: request.tags,
+        related_paths: request.related_paths,
+    };
+
+    match state
+        .workspace_service
+        .update_workspace_info(&request.workspace_id, updates)
+        .await
+    {
+        Ok(workspace_info) => {
+            let is_active_workspace = state
+                .workspace_service
+                .get_current_workspace()
+                .await
+                .map(|workspace| workspace.id == workspace_info.id)
+                .unwrap_or(false);
+
+            if is_active_workspace {
+                apply_active_workspace_context(&state, &app, &workspace_info).await;
+            }
+
+            info!(
+                "Workspace info updated: workspace_id={}, path={}",
+                workspace_info.id,
+                workspace_info.root_path.display()
+            );
+
+            Ok(WorkspaceInfoDto::from_workspace_info(&workspace_info))
+        }
+        Err(error) => {
+            error!("Failed to update workspace info: {}", error);
+            Err(format!("Failed to update workspace info: {}", error))
         }
     }
 }

--- a/src/apps/desktop/src/api/dto.rs
+++ b/src/apps/desktop/src/api/dto.rs
@@ -53,6 +53,14 @@ pub struct WorkspaceWorktreeInfoDto {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct RelatedPathDto {
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct WorkspaceInfoDto {
     pub id: String,
     pub name: String,
@@ -69,6 +77,8 @@ pub struct WorkspaceInfoDto {
     pub identity: Option<WorkspaceIdentityDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub worktree: Option<WorkspaceWorktreeInfoDto>,
+    #[serde(default)]
+    pub related_paths: Vec<RelatedPathDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -134,6 +144,11 @@ impl WorkspaceInfoDto {
                 .worktree
                 .as_ref()
                 .map(WorkspaceWorktreeInfoDto::from_workspace_worktree_info),
+            related_paths: info
+                .related_paths
+                .iter()
+                .map(RelatedPathDto::from_related_path)
+                .collect(),
             connection_id,
             connection_name,
             ssh_host,
@@ -163,6 +178,15 @@ impl WorkspaceWorktreeInfoDto {
             branch: info.branch.clone(),
             main_repo_path: info.main_repo_path.clone(),
             is_main: info.is_main,
+        }
+    }
+}
+
+impl RelatedPathDto {
+    pub fn from_related_path(path: &bitfun_core::service::workspace::RelatedPath) -> Self {
+        Self {
+            path: path.path.clone(),
+            description: path.description.clone(),
         }
     }
 }

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -632,6 +632,7 @@ pub async fn run() {
             refresh_model_client,
             get_app_state,
             update_app_status,
+            update_workspace_info,
             theme::show_agent_companion_desktop_pet,
             theme::hide_agent_companion_desktop_pet,
             theme::resize_agent_companion_desktop_pet,

--- a/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -9,6 +9,7 @@ use crate::service::config::get_app_language_code;
 use crate::service::config::global::GlobalConfigManager;
 use crate::service::filesystem::get_formatted_directory_listing;
 use crate::service::i18n::LocaleId;
+use crate::service::workspace::RelatedPath;
 use crate::util::errors::{BitFunError, BitFunResult};
 use log::{debug, warn};
 use std::path::Path;
@@ -100,6 +101,7 @@ pub struct RemoteExecutionHints {
 #[derive(Debug, Clone)]
 pub struct PromptBuilderContext {
     pub workspace_path: String,
+    pub related_paths: Vec<RelatedPath>,
     pub session_id: Option<String>,
     pub model_name: Option<String>,
     /// When set, file/shell tools target this remote environment; OS and path instructions follow it.
@@ -120,6 +122,7 @@ impl PromptBuilderContext {
     ) -> Self {
         Self {
             workspace_path: workspace_path.into().replace("\\", "/"),
+            related_paths: Vec::new(),
             session_id,
             model_name,
             remote_execution: None,
@@ -136,6 +139,11 @@ impl PromptBuilderContext {
 
     pub fn with_request_context_tools(mut self, tools: RequestContextToolSections) -> Self {
         self.request_context_tools = tools;
+        self
+    }
+
+    pub fn with_related_paths(mut self, related_paths: Vec<RelatedPath>) -> Self {
+        self.related_paths = related_paths;
         self
     }
 
@@ -205,29 +213,65 @@ impl PromptBuilder {
 
     /// Get workspace context that is intentionally injected outside the system prompt cache.
     pub fn get_workspace_context(&self) -> String {
+        let related_paths_section = if self.context.related_paths.is_empty() {
+            String::new()
+        } else {
+            let items = self
+                .context
+                .related_paths
+                .iter()
+                .map(|related_path| {
+                    let path = related_path.path.replace("\\", "/");
+                    match related_path.description.as_deref().map(str::trim) {
+                        Some(description) if !description.is_empty() => {
+                            format!("  - {} — {}", path, description)
+                        }
+                        _ => format!("  - {}", path),
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!(
+                "- Related directories (user-specified directories related to this workspace):\n{}",
+                items
+            )
+        };
+
         if let Some(remote) = &self.context.remote_execution {
             format!(
                 r#"## Workspace Context
 <workspace_context>
 - Workspace root (file tools, Glob, LS, Bash on workspace): {}
+{}
 - Execution environment: **Remote SSH** — connection "{}".
 - Remote host: {} (uname/kernel: {})
 - **Paths and shell:** POSIX on the remote server — use forward slashes and Unix shell syntax (bash/sh). Do **not** use PowerShell, `cmd.exe`, or Windows-style paths for workspace operations.
 </workspace_context>
 "#,
                 self.context.workspace_path,
+                if related_paths_section.is_empty() {
+                    String::new()
+                } else {
+                    format!("{}\n", related_paths_section)
+                },
                 remote.connection_display_name.replace('"', "'"),
                 remote.hostname.replace('"', "'"),
-                remote.kernel_name.replace('"', "'")
+                remote.kernel_name.replace('"', "'"),
             )
         } else {
             format!(
                 r#"## Workspace Context
 <workspace_context>
 - Current Working Directory: {}
+{}
 </workspace_context>
 "#,
-                self.context.workspace_path
+                self.context.workspace_path,
+                if related_paths_section.is_empty() {
+                    String::new()
+                } else {
+                    format!("\n{}", related_paths_section)
+                }
             )
         }
     }
@@ -502,6 +546,7 @@ mod tests {
         TASK_TOOL_CONTEXT_TITLE,
     };
     use crate::agentic::agents::RequestContextPolicy;
+    use crate::service::workspace::RelatedPath;
 
     #[tokio::test]
     async fn renders_available_tool_context_before_additional_context() {
@@ -545,5 +590,44 @@ mod tests {
             .await;
 
         assert!(prompt.is_none());
+    }
+
+    #[test]
+    fn workspace_context_renders_related_directories() {
+        let context =
+            PromptBuilderContext::new("E:/workspace", None, None).with_related_paths(vec![
+                RelatedPath {
+                    path: r"E:\legacy-ts".to_string(),
+                    description: Some("Legacy TypeScript implementation".to_string()),
+                },
+                RelatedPath {
+                    path: r"E:\monorepo\billing".to_string(),
+                    description: Some("Billing package".to_string()),
+                },
+            ]);
+
+        let workspace_context = PromptBuilder::new(context).get_workspace_context();
+
+        assert!(workspace_context.contains("Related directories"));
+        assert!(workspace_context.contains("E:/legacy-ts"));
+        assert!(workspace_context.contains("Legacy TypeScript implementation"));
+        assert!(workspace_context.contains("E:/monorepo/billing"));
+    }
+
+    #[test]
+    fn workspace_context_renders_related_directories_without_description() {
+        let context =
+            PromptBuilderContext::new("E:/workspace", None, None).with_related_paths(vec![
+                RelatedPath {
+                    path: r"E:\monorepo\packages\payments".to_string(),
+                    description: None,
+                },
+            ]);
+
+        let workspace_context = PromptBuilder::new(context).get_workspace_context();
+
+        assert!(workspace_context.contains("Related directories"));
+        assert!(workspace_context.contains("  - E:/monorepo/packages/payments"));
+        assert!(!workspace_context.contains("payments —"));
     }
 }

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -34,6 +34,7 @@ use crate::service::bootstrap::{
     ensure_workspace_persona_files_for_prompt, is_workspace_bootstrap_pending,
 };
 use crate::service::config::global::GlobalConfigManager;
+use crate::service::remote_ssh::normalize_remote_workspace_path;
 use crate::service::session::{SessionRelationship, SessionRelationshipKind};
 use crate::service::workspace::{
     get_global_workspace_service, WorkspaceCreateOptions, WorkspaceKind,
@@ -454,6 +455,73 @@ pub struct ConversationCoordinator {
 }
 
 impl ConversationCoordinator {
+    async fn resolve_workspace_id_for_config(config: &SessionConfig) -> Option<String> {
+        let explicit = config
+            .workspace_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        if explicit.is_some() {
+            return explicit;
+        }
+
+        let workspace_path = config.workspace_path.as_deref()?;
+        let workspace_service = get_global_workspace_service()?;
+
+        if config.remote_connection_id.is_some() || config.remote_ssh_host.is_some() {
+            let normalized_path = normalize_remote_workspace_path(workspace_path);
+            let desired_connection_id = config
+                .remote_connection_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            let desired_ssh_host = config
+                .remote_ssh_host
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+
+            return workspace_service
+                .list_workspace_infos()
+                .await
+                .into_iter()
+                .find(|workspace| {
+                    if workspace.workspace_kind != WorkspaceKind::Remote {
+                        return false;
+                    }
+                    if normalize_remote_workspace_path(&workspace.root_path.to_string_lossy())
+                        != normalized_path
+                    {
+                        return false;
+                    }
+                    if let Some(connection_id) = desired_connection_id {
+                        if workspace.remote_ssh_connection_id() != Some(connection_id) {
+                            return false;
+                        }
+                    }
+                    if let Some(ssh_host) = desired_ssh_host {
+                        let workspace_ssh_host = workspace
+                            .metadata
+                            .get("sshHost")
+                            .and_then(|value| value.as_str())
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty());
+                        if workspace_ssh_host != Some(ssh_host) {
+                            return false;
+                        }
+                    }
+                    true
+                })
+                .map(|workspace| workspace.id);
+        }
+
+        workspace_service
+            .get_workspace_by_path(Path::new(workspace_path))
+            .await
+            .map(|workspace| workspace.id)
+    }
+
     async fn track_session_workspace_activity_best_effort(config: &SessionConfig, reason: &str) {
         let Some(workspace_path) = config.workspace_path.as_ref() else {
             return;
@@ -498,6 +566,7 @@ impl ConversationCoordinator {
     async fn build_workspace_binding(config: &SessionConfig) -> Option<WorkspaceBinding> {
         let workspace_path = config.workspace_path.as_ref()?;
         let path_buf = PathBuf::from(workspace_path);
+        let workspace_id = Self::resolve_workspace_id_for_config(config).await;
 
         let identity =
             crate::service::remote_ssh::workspace_state::resolve_workspace_session_identity(
@@ -558,7 +627,7 @@ impl ConversationCoordinator {
                 .unwrap_or(identity);
 
             let binding = WorkspaceBinding::new_remote(
-                None,
+                workspace_id.clone(),
                 path_buf,
                 effective_rid,
                 connection_name,
@@ -568,7 +637,7 @@ impl ConversationCoordinator {
             return Some(binding);
         }
 
-        let binding = WorkspaceBinding::new(None, path_buf);
+        let binding = WorkspaceBinding::new(workspace_id, path_buf);
 
         Some(binding)
     }
@@ -1042,6 +1111,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         // Persist the workspace binding inside the session config so execution can
         // consistently restore the correct workspace regardless of the entry point.
         config.workspace_path = Some(workspace_path.clone());
+        config.workspace_id = Self::resolve_workspace_id_for_config(&config).await;
         let agent_type = Self::normalize_agent_type(&agent_type);
         let session = self
             .session_manager
@@ -1085,6 +1155,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         created_by: Option<String>,
     ) -> BitFunResult<Session> {
         config.workspace_path = Some(workspace_path);
+        config.workspace_id = Self::resolve_workspace_id_for_config(&config).await;
         let agent_type = Self::normalize_agent_type(&agent_type);
         self.create_hidden_subagent_session(
             session_id,

--- a/src/crates/core/src/agentic/core/session.rs
+++ b/src/crates/core/src/agentic/core/session.rs
@@ -134,6 +134,9 @@ pub struct SessionConfig {
     /// without changing the desktop's foreground workspace.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_path: Option<String>,
+    /// Stable workspace id for resolving workspace-scoped metadata such as related directories.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
     /// SSH workspace: required for remote tool I/O (file/shell). When set, `workspace_path` is
     /// interpreted as the path on that host; when unset, the workspace is always local regardless
     /// of string shape (avoids inferring remote from path alone). Also disambiguates the same
@@ -159,6 +162,7 @@ impl Default for SessionConfig {
             enable_context_compression: true,
             compression_threshold: 0.8, // 80%
             workspace_path: None,
+            workspace_id: None,
             remote_connection_id: None,
             remote_ssh_host: None,
             model_id: None,

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -31,6 +31,7 @@ use crate::infrastructure::ai::get_global_ai_client_factory;
 use crate::service::config::get_global_config_service;
 use crate::service::config::types::{ModelCapability, ModelCategory, WriteToolMode};
 use crate::service::remote_ssh::workspace_state::get_remote_workspace_manager;
+use crate::service::workspace::get_global_workspace_service;
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::token_counter::TokenCounter;
 use crate::util::types::Message as AIMessage;
@@ -600,11 +601,30 @@ impl ExecutionEngine {
             .as_ref()
             .map(|workspace| workspace.root_path_string())?;
 
+        let related_paths = if let Some(workspace_id) = context
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.workspace_id.as_deref())
+        {
+            if let Some(workspace_service) = get_global_workspace_service() {
+                workspace_service
+                    .get_workspace(workspace_id)
+                    .await
+                    .map(|workspace| workspace.related_paths)
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            }
+        } else {
+            Vec::new()
+        };
+
         let base = PromptBuilderContext::new(
             workspace_path.clone(),
             Some(context.session_id.clone()),
             Some(model_name.to_string()),
         )
+        .with_related_paths(related_paths)
         .with_supports_image_understanding(supports_image_understanding)
         .with_request_context_tools(request_context_tools);
 

--- a/src/crates/core/src/service/workspace/manager.rs
+++ b/src/crates/core/src/service/workspace/manager.rs
@@ -75,6 +75,15 @@ pub struct WorkspaceWorktreeInfo {
     pub is_main: bool,
 }
 
+/// User-managed related directory reference for the current workspace context.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RelatedPath {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 struct WorkspaceIdentityFrontmatter {
@@ -201,6 +210,8 @@ pub struct WorkspaceInfo {
     pub identity: Option<WorkspaceIdentity>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree: Option<WorkspaceWorktreeInfo>,
+    #[serde(rename = "relatedPaths", default)]
+    pub related_paths: Vec<RelatedPath>,
     pub metadata: HashMap<String, serde_json::Value>,
 }
 
@@ -345,6 +356,7 @@ impl WorkspaceInfo {
             statistics: None,
             identity: None,
             worktree: None,
+            related_paths: Vec::new(),
             metadata: HashMap::new(),
         };
 

--- a/src/crates/core/src/service/workspace/mod.rs
+++ b/src/crates/core/src/service/workspace/mod.rs
@@ -12,9 +12,9 @@ pub mod service;
 pub use factory::WorkspaceFactory;
 pub use identity_watch::WorkspaceIdentityWatchService;
 pub use manager::{
-    GitInfo, ScanOptions, WorkspaceIdentity, WorkspaceInfo, WorkspaceKind, WorkspaceManager,
-    WorkspaceManagerConfig, WorkspaceManagerStatistics, WorkspaceOpenOptions, WorkspaceStatistics,
-    WorkspaceStatus, WorkspaceSummary, WorkspaceType,
+    GitInfo, RelatedPath, ScanOptions, WorkspaceIdentity, WorkspaceInfo, WorkspaceKind,
+    WorkspaceManager, WorkspaceManagerConfig, WorkspaceManagerStatistics, WorkspaceOpenOptions,
+    WorkspaceStatistics, WorkspaceStatus, WorkspaceSummary, WorkspaceType,
 };
 pub use provider::{WorkspaceCleanupResult, WorkspaceProvider, WorkspaceSystemSummary};
 pub use service::{

--- a/src/crates/core/src/service/workspace/service.rs
+++ b/src/crates/core/src/service/workspace/service.rs
@@ -3,7 +3,7 @@
 //! Provides comprehensive workspace management functionality.
 
 use super::manager::{
-    ScanOptions, WorkspaceIdentity, WorkspaceInfo, WorkspaceKind, WorkspaceManager,
+    RelatedPath, ScanOptions, WorkspaceIdentity, WorkspaceInfo, WorkspaceKind, WorkspaceManager,
     WorkspaceManagerConfig, WorkspaceManagerStatistics, WorkspaceOpenOptions, WorkspaceStatus,
     WorkspaceSummary, WorkspaceType,
 };
@@ -13,7 +13,8 @@ use crate::service::bootstrap::{
     ensure_workspace_gitignore_ignores_bitfun, initialize_workspace_persona_files,
 };
 use crate::service::remote_ssh::workspace_state::{
-    local_workspace_roots_equal, normalize_remote_workspace_path, remote_workspace_stable_id,
+    canonicalize_local_workspace_root, get_remote_workspace_manager, local_workspace_roots_equal,
+    normalize_remote_workspace_path, remote_workspace_stable_id,
 };
 use crate::service::workspace_runtime::{
     try_get_workspace_runtime_service_arc, WorkspaceRuntimeService,
@@ -882,31 +883,204 @@ impl WorkspaceService {
         &self,
         workspace_id: &str,
         updates: WorkspaceInfoUpdates,
-    ) -> BitFunResult<()> {
-        let mut manager = self.manager.write().await;
+    ) -> BitFunResult<WorkspaceInfo> {
+        let WorkspaceInfoUpdates {
+            name,
+            description,
+            tags,
+            related_paths,
+        } = updates;
 
-        if let Some(workspace) = manager.get_workspaces_mut().get_mut(workspace_id) {
-            if let Some(name) = updates.name {
+        let existing_workspace = {
+            let manager = self.manager.read().await;
+            manager
+                .get_workspaces()
+                .get(workspace_id)
+                .cloned()
+                .ok_or_else(|| {
+                    BitFunError::service(format!("Workspace not found: {}", workspace_id))
+                })?
+        };
+
+        let normalized_related_paths = match related_paths {
+            Some(related_paths) => Some(
+                self.normalize_related_paths_for_workspace(&existing_workspace, related_paths)
+                    .await?,
+            ),
+            None => None,
+        };
+
+        let updated_workspace = {
+            let mut manager = self.manager.write().await;
+            let workspace = manager
+                .get_workspaces_mut()
+                .get_mut(workspace_id)
+                .ok_or_else(|| {
+                    BitFunError::service(format!("Workspace not found: {}", workspace_id))
+                })?;
+
+            if let Some(name) = name {
                 workspace.name = name;
             }
 
-            if let Some(description) = updates.description {
+            if let Some(description) = description {
                 workspace.description = Some(description);
             }
 
-            if let Some(tags) = updates.tags {
+            if let Some(tags) = tags {
                 workspace.tags = tags;
             }
 
-            workspace.last_accessed = chrono::Utc::now();
+            if let Some(related_paths) = normalized_related_paths {
+                workspace.related_paths = related_paths;
+            }
 
-            Ok(())
-        } else {
-            Err(BitFunError::service(format!(
-                "Workspace not found: {}",
-                workspace_id
-            )))
+            workspace.last_accessed = chrono::Utc::now();
+            workspace.clone()
+        };
+
+        self.save_workspace_data().await?;
+
+        Ok(updated_workspace)
+    }
+
+    async fn normalize_related_paths_for_workspace(
+        &self,
+        workspace: &WorkspaceInfo,
+        related_paths: Vec<RelatedPath>,
+    ) -> BitFunResult<Vec<RelatedPath>> {
+        let mut normalized = Vec::with_capacity(related_paths.len());
+        let mut seen_paths = HashSet::new();
+
+        match workspace.workspace_kind {
+            WorkspaceKind::Remote => {
+                let connection_id = workspace
+                    .remote_ssh_connection_id()
+                    .ok_or_else(|| {
+                        BitFunError::service(format!(
+                            "Remote workspace is missing connectionId metadata: {}",
+                            workspace.id
+                        ))
+                    })?
+                    .to_string();
+                let remote_manager = get_remote_workspace_manager().ok_or_else(|| {
+                    BitFunError::service(
+                        "Remote workspace manager is unavailable for related path validation"
+                            .to_string(),
+                    )
+                })?;
+                let file_service = remote_manager.get_file_service().await.ok_or_else(|| {
+                    BitFunError::service(
+                        "Remote file service is unavailable for related path validation"
+                            .to_string(),
+                    )
+                })?;
+
+                for related_path in related_paths {
+                    let description =
+                        Self::normalize_related_path_description(related_path.description);
+                    let path = normalize_remote_workspace_path(related_path.path.trim());
+                    if path.is_empty() {
+                        return Err(BitFunError::service(
+                            "Related directory path cannot be empty".to_string(),
+                        ));
+                    }
+                    if !seen_paths.insert(path.clone()) {
+                        continue;
+                    }
+
+                    if !file_service
+                        .exists(&connection_id, &path)
+                        .await
+                        .map_err(|error| {
+                            BitFunError::service(format!(
+                                "Failed to validate remote related directory '{}': {}",
+                                path, error
+                            ))
+                        })?
+                    {
+                        return Err(BitFunError::service(format!(
+                            "Remote related directory does not exist: {}",
+                            path
+                        )));
+                    }
+
+                    if !file_service
+                        .is_dir(&connection_id, &path)
+                        .await
+                        .map_err(|error| {
+                            BitFunError::service(format!(
+                                "Failed to inspect remote related directory '{}': {}",
+                                path, error
+                            ))
+                        })?
+                    {
+                        return Err(BitFunError::service(format!(
+                            "Remote related path is not a directory: {}",
+                            path
+                        )));
+                    }
+
+                    normalized.push(RelatedPath { path, description });
+                }
+            }
+            _ => {
+                for related_path in related_paths {
+                    let description =
+                        Self::normalize_related_path_description(related_path.description);
+                    let raw_path = related_path.path.trim();
+                    if raw_path.is_empty() {
+                        return Err(BitFunError::service(
+                            "Related directory path cannot be empty".to_string(),
+                        ));
+                    }
+
+                    let path_buf = PathBuf::from(raw_path);
+                    let (canonical_path, normalized_key) =
+                        canonicalize_local_workspace_root(&path_buf)
+                            .map_err(BitFunError::service)?;
+
+                    let metadata = tokio::fs::metadata(&canonical_path)
+                        .await
+                        .map_err(|error| {
+                            BitFunError::service(format!(
+                                "Failed to inspect related directory '{}': {}",
+                                canonical_path.display(),
+                                error
+                            ))
+                        })?;
+
+                    if !metadata.is_dir() {
+                        return Err(BitFunError::service(format!(
+                            "Related path is not a directory: {}",
+                            canonical_path.display()
+                        )));
+                    }
+
+                    if !seen_paths.insert(normalized_key) {
+                        continue;
+                    }
+
+                    normalized.push(RelatedPath {
+                        path: canonical_path.to_string_lossy().to_string(),
+                        description,
+                    });
+                }
+            }
         }
+
+        Ok(normalized)
+    }
+
+    fn normalize_related_path_description(description: Option<String>) -> Option<String> {
+        description.and_then(|value| {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
     }
 
     /// Imports workspaces in batch.
@@ -1775,6 +1949,7 @@ pub struct WorkspaceInfoUpdates {
     pub name: Option<String>,
     pub description: Option<String>,
     pub tags: Option<Vec<String>>,
+    pub related_paths: Option<Vec<RelatedPath>>,
 }
 
 /// Batch remove result.
@@ -2130,5 +2305,27 @@ mod tests {
         );
         assert_eq!(tracked.root_path, remote_workspace_root);
         assert!(service.get_opened_workspaces().await.is_empty());
+    }
+
+    #[test]
+    fn normalize_related_path_description_treats_blank_as_none() {
+        assert_eq!(
+            WorkspaceService::normalize_related_path_description(None),
+            None
+        );
+        assert_eq!(
+            WorkspaceService::normalize_related_path_description(Some("".to_string())),
+            None
+        );
+        assert_eq!(
+            WorkspaceService::normalize_related_path_description(Some("   ".to_string())),
+            None
+        );
+        assert_eq!(
+            WorkspaceService::normalize_related_path_description(Some(
+                " Legacy TypeScript implementation ".to_string()
+            )),
+            Some("Legacy TypeScript implementation".to_string())
+        );
     }
 }

--- a/src/web-ui/src/app/components/NavPanel/MainNav.tsx
+++ b/src/web-ui/src/app/components/NavPanel/MainNav.tsx
@@ -699,6 +699,7 @@ const MainNav: React.FC<MainNavProps> = ({
           connectionId={sshRemote.connectionId}
           initialPath={sshRemote.remoteFileBrowserInitialPath}
           homePath={sshRemote.remoteFileBrowserInitialPath}
+          selectDirectoriesOnly
           onSelect={handleSelectRemoteWorkspace}
           onCancel={() => {
             const hasActiveRemoteWorkspace =

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Folder, FolderOpen, MoreHorizontal, FolderSearch, Plus, ChevronDown, Trash2, RotateCcw, Copy, FileText, GitBranch, Bot } from 'lucide-react';
+import { Folder, FolderOpen, MoreHorizontal, FolderSearch, Plus, ChevronDown, Trash2, RotateCcw, Copy, FileText, GitBranch, Bot, Link2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { DotMatrixArrowRightIcon } from './DotMatrixArrowRightIcon';
 import { Button, ConfirmDialog, Modal, Tooltip } from '@/component-library';
@@ -33,6 +33,7 @@ import {
 import { SSHContext } from '@/features/ssh-remote/SSHRemoteContext';
 import { useWorkspaceSearchIndex } from '@/tools/file-explorer';
 import { computeFixedPopoverPosition } from '@/shared/utils/fixedPopoverViewport';
+import WorkspaceRelatedPathsDialog from './WorkspaceRelatedPathsDialog';
 
 
 interface WorkspaceItemProps {
@@ -78,6 +79,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteWorktreeDialogOpen, setDeleteWorktreeDialogOpen] = useState(false);
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
+  const [relatedPathsDialogOpen, setRelatedPathsDialogOpen] = useState(false);
   const [isDeletingAssistant, setIsDeletingAssistant] = useState(false);
   const [isDeletingWorktree, setIsDeletingWorktree] = useState(false);
   const [isResettingWorkspace, setIsResettingWorkspace] = useState(false);
@@ -103,6 +105,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
       ? workspace.identity?.name?.trim() || workspace.name
       : workspace.name;
   const isLinkedWorktree = isLinkedWorktreeWorkspace(workspace);
+  const relatedPathCount = workspace.relatedPaths?.length ?? 0;
   const canShowSearchIndex =
     isActive
     && workspaceSearchEnabled
@@ -864,6 +867,11 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
                 >
                   <span className="bitfun-nav-panel__workspace-item-name-line">
                     <span className="bitfun-nav-panel__workspace-item-label">{workspaceDisplayName}</span>
+                    {relatedPathCount > 0 ? (
+                      <span className="bitfun-nav-panel__workspace-item-badge">
+                        {t('nav.workspaces.relatedPaths.badge', { count: relatedPathCount })}
+                      </span>
+                    ) : null}
                   </span>
                 </button>
               </Tooltip>
@@ -1048,6 +1056,19 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
                   <FileText size={13} />
                   <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.initAgents')}</span>
                 </button>
+                <button
+                  type="button"
+                  className="bitfun-nav-panel__workspace-item-menu-item"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    setRelatedPathsDialogOpen(true);
+                  }}
+                >
+                  <Link2 size={13} />
+                  <span className="bitfun-nav-panel__workspace-item-menu-label">
+                    {t('nav.workspaces.actions.manageRelatedPaths')}
+                  </span>
+                </button>
                 <div className="bitfun-nav-panel__workspace-item-menu-divider" />
                 {isLinkedWorktree ? (
                   <button
@@ -1132,6 +1153,11 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
         cancelText={t('actions.cancel')}
         confirmDanger
         preview={`${t('nav.workspaces.deleteWorktreeDialog.pathLabel')}\n${workspace.rootPath}`}
+      />
+      <WorkspaceRelatedPathsDialog
+        workspace={workspace}
+        isOpen={relatedPathsDialogOpen}
+        onClose={() => setRelatedPathsDialogOpen(false)}
       />
     </div>
   );

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceRelatedPathsDialog.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceRelatedPathsDialog.scss
@@ -1,0 +1,161 @@
+.workspace-related-paths-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+  color: var(--color-text-primary);
+
+  &__modal {
+    overflow-x: hidden;
+  }
+
+  &__intro {
+    display: flex;
+    gap: 12px;
+    padding: 4px 0 2px;
+  }
+
+  &__intro-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--color-accent-500) 14%, transparent);
+    color: var(--color-accent-500);
+  }
+
+  &__intro-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  &__intro-title {
+    font-size: var(--font-size-sm);
+    font-weight: 700;
+    line-height: 1.3;
+  }
+
+  &__intro-text,
+  &__scope {
+    font-size: var(--font-size-xs);
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+  }
+
+  &__scope {
+    color: var(--color-text-muted);
+  }
+
+  &__empty {
+    padding: 18px 16px;
+    border-radius: 14px;
+    border: 1px dashed color-mix(in srgb, var(--border-subtle) 78%, transparent);
+    background: color-mix(in srgb, var(--element-bg-subtle) 80%, transparent);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-xs);
+    text-align: center;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+    border-radius: 14px;
+    border: 1px solid color-mix(in srgb, var(--border-subtle) 82%, transparent);
+    background: color-mix(in srgb, var(--element-bg-medium) 52%, transparent);
+  }
+
+  &__card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  &__card-index {
+    font-size: var(--font-size-xxs);
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+  }
+
+  &__remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: none;
+    border-radius: 10px;
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+
+    &:hover {
+      background: color-mix(in srgb, var(--color-error, #e05d5d) 10%, transparent);
+      color: var(--color-error, #e05d5d);
+    }
+  }
+
+  &__path-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: start;
+  }
+
+  &__error {
+    padding: 10px 12px;
+    border-radius: 12px;
+    border: 1px solid color-mix(in srgb, var(--color-error, #e05d5d) 22%, transparent);
+    background: color-mix(in srgb, var(--color-error, #e05d5d) 9%, transparent);
+    color: color-mix(in srgb, var(--color-error, #e05d5d) 88%, var(--color-text-primary));
+    font-size: var(--font-size-xs);
+    line-height: 1.45;
+  }
+
+  &__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding-top: 4px;
+  }
+
+  &__footer-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+}
+
+@media (max-width: 720px) {
+  .workspace-related-paths-dialog {
+    &__path-row {
+      grid-template-columns: 1fr;
+    }
+
+    &__footer {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    &__footer-actions {
+      width: 100%;
+      justify-content: flex-end;
+    }
+  }
+}

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceRelatedPathsDialog.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceRelatedPathsDialog.tsx
@@ -1,0 +1,315 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { open as openDirectoryDialog } from '@tauri-apps/plugin-dialog';
+import { Button, Input, Modal, Textarea } from '@/component-library';
+import { useI18n } from '@/infrastructure/i18n';
+import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
+import { sshApi } from '@/features/ssh-remote/sshApi';
+import RemoteFileBrowser from '@/features/ssh-remote/RemoteFileBrowser';
+import { createLogger } from '@/shared/utils/logger';
+import { isRemoteWorkspace, type RelatedPath, type WorkspaceInfo } from '@/shared/types';
+import { FolderOpen, Link2, Plus, Trash2 } from 'lucide-react';
+import './WorkspaceRelatedPathsDialog.scss';
+
+const log = createLogger('WorkspaceRelatedPathsDialog');
+
+interface WorkspaceRelatedPathsDialogProps {
+  workspace: WorkspaceInfo;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface DraftRelatedPath {
+  id: string;
+  path: string;
+  description: string;
+}
+
+function createDraft(path?: Partial<RelatedPath>): DraftRelatedPath {
+  return {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    path: path?.path ?? '',
+    description: path?.description ?? '',
+  };
+}
+
+function normalizeDrafts(drafts: DraftRelatedPath[]): RelatedPath[] {
+  return drafts.map(draft => ({
+    path: draft.path.trim(),
+    ...(draft.description.trim()
+      ? { description: draft.description.trim() }
+      : {}),
+  }));
+}
+
+export const WorkspaceRelatedPathsDialog: React.FC<WorkspaceRelatedPathsDialogProps> = ({
+  workspace,
+  isOpen,
+  onClose,
+}) => {
+  const { t } = useI18n('common');
+  const { updateWorkspaceRelatedPaths } = useWorkspaceContext();
+  const [drafts, setDrafts] = useState<DraftRelatedPath[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [browsingIndex, setBrowsingIndex] = useState<number | null>(null);
+  const [remoteHomePath, setRemoteHomePath] = useState<string | undefined>(undefined);
+
+  const remoteWorkspace = isRemoteWorkspace(workspace);
+  const connectionId = workspace.connectionId?.trim() || undefined;
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setDrafts((workspace.relatedPaths ?? []).map(path => createDraft(path)));
+    setSaving(false);
+    setError(null);
+  }, [isOpen, workspace.relatedPaths]);
+
+  useEffect(() => {
+    if (!isOpen || !remoteWorkspace || !connectionId) {
+      setRemoteHomePath(undefined);
+      return;
+    }
+
+    let cancelled = false;
+    void sshApi
+      .getServerInfo(connectionId)
+      .then(info => {
+        if (!cancelled) {
+          setRemoteHomePath(info?.homeDir?.trim() || undefined);
+        }
+      })
+      .catch(fetchError => {
+        log.warn('Failed to load remote server info for related directories', {
+          workspaceId: workspace.id,
+          error: fetchError,
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [connectionId, isOpen, remoteWorkspace, workspace.id]);
+
+  const normalizedDrafts = useMemo(() => normalizeDrafts(drafts), [drafts]);
+  const hasInvalidDraft = normalizedDrafts.some(draft => !draft.path);
+  const isUnchanged = JSON.stringify(normalizedDrafts) === JSON.stringify(workspace.relatedPaths ?? []);
+
+  const setDraftValue = (
+    draftId: string,
+    field: 'path' | 'description',
+    value: string
+  ) => {
+    setDrafts(current =>
+      current.map(draft => (draft.id === draftId ? { ...draft, [field]: value } : draft))
+    );
+    setError(null);
+  };
+
+  const handleAddDraft = () => {
+    setDrafts(current => [...current, createDraft()]);
+    setError(null);
+  };
+
+  const handleRemoveDraft = (draftId: string) => {
+    setDrafts(current => current.filter(draft => draft.id !== draftId));
+    setError(null);
+  };
+
+  const handleSelectLocalDirectory = async (index: number) => {
+    try {
+      const selected = await openDirectoryDialog({
+        directory: true,
+        multiple: false,
+        title: t('nav.workspaces.relatedPaths.dialog.selectDirectoryTitle'),
+        defaultPath: drafts[index]?.path || workspace.rootPath,
+      });
+
+      if (typeof selected === 'string' && selected.trim()) {
+        setDraftValue(drafts[index].id, 'path', selected);
+      }
+    } catch (selectionError) {
+      log.error('Failed to select related directory', { workspaceId: workspace.id, error: selectionError });
+      setError(t('nav.workspaces.relatedPaths.messages.selectFailed'));
+    }
+  };
+
+  const handleSave = async () => {
+    if (hasInvalidDraft) {
+      setError(t('nav.workspaces.relatedPaths.validation.pathRequired'));
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await updateWorkspaceRelatedPaths(workspace.id, normalizedDrafts);
+      onClose();
+    } catch (saveError) {
+      log.error('Failed to save related directories', { workspaceId: workspace.id, error: saveError });
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : t('nav.workspaces.relatedPaths.messages.saveFailed')
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <Modal
+        isOpen={isOpen}
+        onClose={() => {
+          if (!saving) {
+            onClose();
+          }
+        }}
+        title={t('nav.workspaces.relatedPaths.dialog.title')}
+        size="large"
+        contentInset
+        contentClassName="workspace-related-paths-dialog__modal"
+      >
+        <div className="workspace-related-paths-dialog">
+          <div className="workspace-related-paths-dialog__intro">
+            <div className="workspace-related-paths-dialog__intro-icon">
+              <Link2 size={18} />
+            </div>
+            <div className="workspace-related-paths-dialog__intro-copy">
+              <div className="workspace-related-paths-dialog__intro-title">
+                {t('nav.workspaces.relatedPaths.dialog.heading')}
+              </div>
+              <div className="workspace-related-paths-dialog__intro-text">
+                {t('nav.workspaces.relatedPaths.dialog.description')}
+              </div>
+              <div className="workspace-related-paths-dialog__scope">
+                {remoteWorkspace
+                  ? t('nav.workspaces.relatedPaths.dialog.remoteScope', {
+                      connectionName: workspace.connectionName || workspace.name,
+                    })
+                  : t('nav.workspaces.relatedPaths.dialog.localScope')}
+              </div>
+            </div>
+          </div>
+
+          {drafts.length === 0 ? (
+            <div className="workspace-related-paths-dialog__empty">
+              {t('nav.workspaces.relatedPaths.dialog.empty')}
+            </div>
+          ) : (
+            <div className="workspace-related-paths-dialog__list">
+              {drafts.map((draft, index) => (
+                <div key={draft.id} className="workspace-related-paths-dialog__card">
+                  <div className="workspace-related-paths-dialog__card-header">
+                    <span className="workspace-related-paths-dialog__card-index">
+                      {t('nav.workspaces.relatedPaths.dialog.itemLabel', { index: index + 1 })}
+                    </span>
+                    <button
+                      type="button"
+                      className="workspace-related-paths-dialog__remove"
+                      onClick={() => handleRemoveDraft(draft.id)}
+                      aria-label={t('actions.remove')}
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+
+                  <div className="workspace-related-paths-dialog__path-row">
+                    <Input
+                      value={draft.path}
+                      onChange={event => setDraftValue(draft.id, 'path', event.target.value)}
+                      placeholder={t('nav.workspaces.relatedPaths.dialog.pathPlaceholder')}
+                      disabled={saving}
+                    />
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="small"
+                      onClick={() =>
+                        remoteWorkspace
+                          ? setBrowsingIndex(index)
+                          : void handleSelectLocalDirectory(index)
+                      }
+                      disabled={saving || (remoteWorkspace && !connectionId)}
+                    >
+                      <FolderOpen size={14} />
+                      <span>{t('actions.select')}</span>
+                    </Button>
+                  </div>
+
+                  <Textarea
+                    value={draft.description}
+                    onChange={event => setDraftValue(draft.id, 'description', event.target.value)}
+                    placeholder={t('nav.workspaces.relatedPaths.dialog.descriptionPlaceholder')}
+                    disabled={saving}
+                    autoResize
+                    rows={2}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+
+          {error ? (
+            <div className="workspace-related-paths-dialog__error" role="alert">
+              {error}
+            </div>
+          ) : null}
+
+          <div className="workspace-related-paths-dialog__footer">
+            <Button
+              type="button"
+              variant="secondary"
+              size="small"
+              onClick={handleAddDraft}
+              disabled={saving}
+            >
+              <Plus size={14} />
+              <span>{t('nav.workspaces.relatedPaths.dialog.add')}</span>
+            </Button>
+
+            <div className="workspace-related-paths-dialog__footer-actions">
+              <Button
+                type="button"
+                variant="secondary"
+                size="small"
+                onClick={onClose}
+                disabled={saving}
+              >
+                {t('actions.cancel')}
+              </Button>
+              <Button
+                type="button"
+                variant="primary"
+                size="small"
+                onClick={() => void handleSave()}
+                disabled={saving || hasInvalidDraft || isUnchanged}
+              >
+                {saving ? t('status.saving') : t('actions.save')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </Modal>
+
+      {remoteWorkspace && connectionId && browsingIndex !== null ? (
+        <RemoteFileBrowser
+          connectionId={connectionId}
+          initialPath={drafts[browsingIndex]?.path || workspace.rootPath}
+          homePath={remoteHomePath}
+          selectDirectoriesOnly
+          onSelect={(path: string) => {
+            setDraftValue(drafts[browsingIndex].id, 'path', path);
+            setBrowsingIndex(null);
+          }}
+          onCancel={() => setBrowsingIndex(null)}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default WorkspaceRelatedPathsDialog;

--- a/src/web-ui/src/features/ssh-remote/RemoteFileBrowser.tsx
+++ b/src/web-ui/src/features/ssh-remote/RemoteFileBrowser.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { useI18n } from '@/infrastructure/i18n';
 import { Button } from '@/component-library';
 import { ConfirmDialog } from './ConfirmDialog';
@@ -30,6 +31,8 @@ interface RemoteFileBrowserProps {
   initialPath?: string;
   /** Used by the Home button; defaults to `initialPath`. */
   homePath?: string;
+  /** When true, only directories can be chosen and files are not selectable. */
+  selectDirectoriesOnly?: boolean;
   onSelect: (path: string) => void;
   onCancel: () => void;
 }
@@ -84,6 +87,7 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
   connectionId,
   initialPath = '/tmp',
   homePath,
+  selectDirectoriesOnly = false,
   onSelect,
   onCancel,
 }) => {
@@ -194,7 +198,7 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
   const handleEntryClick = (entry: RemoteFileEntry) => {
     if (entry.isDir) {
       navigateTo(entry.path);
-    } else {
+    } else if (!selectDirectoriesOnly) {
       setSelectedPath(entry.path);
     }
     setContextMenu({ show: false, x: 0, y: 0, entry: null });
@@ -254,7 +258,7 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
         case 'open':
           if (entry.isDir) {
             navigateTo(entry.path);
-          } else {
+          } else if (!selectDirectoriesOnly) {
             onSelect(entry.path);
           }
           break;
@@ -340,7 +344,7 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
   };
 
   const openSelectedWorkspace = () => {
-    onSelect(selectedPath || currentPath);
+    onSelect(selectDirectoriesOnly ? currentPath : (selectedPath || currentPath));
   };
 
   const formatFileSize = (bytes?: number): string => {
@@ -384,7 +388,7 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
     return `/${pathParts.slice(0, index + 1).join('/')}`;
   };
 
-  return (
+  const browser = (
     <div className="remote-file-browser-overlay">
       <div className="remote-file-browser">
         {/* Header */}
@@ -669,13 +673,15 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
         {/* Footer */}
         <div className="remote-file-browser__footer">
           <div className="remote-file-browser__footer-info">
-            {selectedPath ? (
+            {!selectDirectoriesOnly && selectedPath ? (
               <>
                 <span className="remote-file-browser__footer-label">{t('ssh.remote.selected')}: </span>
                 <span className="remote-file-browser__footer-path">{selectedPath}</span>
               </>
             ) : (
-              <span className="remote-file-browser__footer-hint">{t('ssh.remote.clickToSelect')}</span>
+              <span className="remote-file-browser__footer-hint">
+                {selectDirectoriesOnly ? currentPath : t('ssh.remote.clickToSelect')}
+              </span>
             )}
           </div>
           <div className="remote-file-browser__footer-actions">
@@ -695,6 +701,8 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
       </div>
     </div>
   );
+
+  return createPortal(browser, document.body);
 };
 
 export default RemoteFileBrowser;

--- a/src/web-ui/src/flow_chat/hooks/useFlowChat.ts
+++ b/src/web-ui/src/flow_chat/hooks/useFlowChat.ts
@@ -99,6 +99,7 @@ export const useFlowChat = () => {
         sessionName,
         agentType: agentTypeForSession,
         workspacePath,
+        workspaceId: workspace?.id ?? config?.workspaceId,
         remoteConnectionId,
         remoteSshHost,
         config: {

--- a/src/web-ui/src/flow_chat/services/BtwThreadService.ts
+++ b/src/web-ui/src/flow_chat/services/BtwThreadService.ts
@@ -113,6 +113,7 @@ export async function createBtwChildSession(params: {
           sessionName: childSessionName,
           agentType,
           workspacePath,
+          workspaceId: parentSession?.workspaceId,
           remoteConnectionId,
           remoteSshHost,
           relationship,

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -418,6 +418,7 @@ export async function createChatSession(
         sessionName,
         agentType,
         workspacePath,
+        workspaceId: mergedConfig.workspaceId,
         remoteConnectionId,
         remoteSshHost,
         config: {
@@ -759,6 +760,7 @@ export async function ensureBackendSession(
         `Session ${sessionId.slice(0, 8)}`,
       agentType: latestSession.mode || 'agentic',
       workspacePath,
+      workspaceId: latestSession.workspaceId,
       remoteConnectionId: effectiveConnectionId,
       remoteSshHost: effectiveSshHost,
       relationship: buildCreateSessionRelationship(latestSession),
@@ -799,6 +801,7 @@ export async function retryCreateBackendSession(
       `Session ${sessionId.slice(0, 8)}`,
     agentType: session.mode || 'agentic',
     workspacePath,
+    workspaceId: session.workspaceId,
     remoteConnectionId: session.remoteConnectionId,
     remoteSshHost: session.remoteSshHost,
     relationship: buildCreateSessionRelationship(session),

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -42,6 +42,7 @@ export interface CreateSessionRequest {
   sessionName: string;
   agentType: string;
   workspacePath: string;
+  workspaceId?: string;
   remoteConnectionId?: string;
   remoteSshHost?: string;
   sessionKind?: 'standard' | 'subagent';

--- a/src/web-ui/src/infrastructure/api/service-api/GlobalAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/GlobalAPI.ts
@@ -39,6 +39,11 @@ export interface WorkspaceWorktreeInfo {
   isMain: boolean;
 }
 
+export interface RelatedPath {
+  path: string;
+  description?: string | null;
+}
+
 export interface WorkspaceInfo {
   id: string;
   name: string;
@@ -54,6 +59,7 @@ export interface WorkspaceInfo {
   statistics?: ProjectStatistics | null;
   identity?: WorkspaceIdentity | null;
   worktree?: WorkspaceWorktreeInfo | null;
+  relatedPaths?: RelatedPath[];
   connectionId?: string;
   connectionName?: string;
   /** With `rootPath`, forms logical key `{sshHost}:{rootPath}`; local uses `localhost`. */
@@ -88,6 +94,14 @@ export interface SetActiveWorkspaceRequest {
 
 export interface ReorderOpenedWorkspacesRequest {
   workspaceIds: string[];
+}
+
+export interface UpdateWorkspaceInfoRequest {
+  workspaceId: string;
+  name?: string;
+  description?: string | null;
+  tags?: string[];
+  relatedPaths?: RelatedPath[];
 }
 
 export interface DeleteAssistantWorkspaceRequest {
@@ -211,6 +225,16 @@ export class GlobalAPI {
       });
     } catch (error) {
       throw createTauriCommandError('reorder_opened_workspaces', error, { workspaceIds });
+    }
+  }
+
+  async updateWorkspaceInfo(request: UpdateWorkspaceInfoRequest): Promise<WorkspaceInfo> {
+    try {
+      return await api.invoke('update_workspace_info', {
+        request,
+      });
+    } catch (error) {
+      throw createTauriCommandError('update_workspace_info', error, { request });
     }
   }
 

--- a/src/web-ui/src/infrastructure/api/service-api/tauri-commands.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/tauri-commands.ts
@@ -32,6 +32,10 @@ export interface WorkspaceInfo {
     vibe?: string | null;
     emoji?: string | null;
   } | null;
+  relatedPaths?: Array<{
+    path: string;
+    description?: string | null;
+  }>;
   connectionId?: string;
   connectionName?: string;
 }

--- a/src/web-ui/src/infrastructure/contexts/WorkspaceContext.ts
+++ b/src/web-ui/src/infrastructure/contexts/WorkspaceContext.ts
@@ -34,6 +34,10 @@ export interface WorkspaceContextValue extends WorkspaceState {
     targetWorkspaceId: string,
     position: 'before' | 'after'
   ) => Promise<void>;
+  updateWorkspaceRelatedPaths: (
+    workspaceId: string,
+    relatedPaths: WorkspaceInfo['relatedPaths']
+  ) => Promise<WorkspaceInfo>;
   scanWorkspaceInfo: () => Promise<WorkspaceInfo | null>;
   refreshRecentWorkspaces: () => Promise<void>;
   removeWorkspaceFromRecent: (workspaceId: string) => Promise<void>;

--- a/src/web-ui/src/infrastructure/contexts/WorkspaceProvider.tsx
+++ b/src/web-ui/src/infrastructure/contexts/WorkspaceProvider.tsx
@@ -53,6 +53,10 @@ export const WorkspaceProvider: React.FC<WorkspaceProviderProps> = ({ children }
             targetWorkspaceId,
             position
           ),
+        updateWorkspaceRelatedPaths: async (
+          workspaceId: string,
+          relatedPaths: WorkspaceInfo['relatedPaths']
+        ) => workspaceManager.updateWorkspaceRelatedPaths(workspaceId, relatedPaths),
         scanWorkspaceInfo: async () => workspaceManager.scanWorkspaceInfo(),
         refreshRecentWorkspaces: async () => workspaceManager.refreshRecentWorkspaces(),
         removeWorkspaceFromRecent: async (workspaceId: string) =>
@@ -97,6 +101,10 @@ export const WorkspaceProvider: React.FC<WorkspaceProviderProps> = ({ children }
             targetWorkspaceId,
             position
           ),
+        updateWorkspaceRelatedPaths: async (
+          workspaceId: string,
+          relatedPaths: WorkspaceInfo['relatedPaths']
+        ) => workspaceManager.updateWorkspaceRelatedPaths(workspaceId, relatedPaths),
         scanWorkspaceInfo: async () => workspaceManager.scanWorkspaceInfo(),
         refreshRecentWorkspaces: async () => workspaceManager.refreshRecentWorkspaces(),
         removeWorkspaceFromRecent: async (workspaceId: string) =>
@@ -229,6 +237,13 @@ export const WorkspaceProvider: React.FC<WorkspaceProviderProps> = ({ children }
     return await workspaceManager.scanWorkspaceInfo();
   }, []);
 
+  const updateWorkspaceRelatedPaths = useCallback(async (
+    workspaceId: string,
+    relatedPaths: WorkspaceInfo['relatedPaths']
+  ): Promise<WorkspaceInfo> => {
+    return await workspaceManager.updateWorkspaceRelatedPaths(workspaceId, relatedPaths);
+  }, []);
+
   const refreshRecentWorkspaces = useCallback(async (): Promise<void> => {
     return await workspaceManager.refreshRecentWorkspaces();
   }, []);
@@ -260,6 +275,7 @@ export const WorkspaceProvider: React.FC<WorkspaceProviderProps> = ({ children }
       switchWorkspace,
       setActiveWorkspace,
       reorderOpenedWorkspacesInSection,
+      updateWorkspaceRelatedPaths,
       scanWorkspaceInfo,
       refreshRecentWorkspaces,
       removeWorkspaceFromRecent,
@@ -278,6 +294,7 @@ export const WorkspaceProvider: React.FC<WorkspaceProviderProps> = ({ children }
     switchWorkspace,
     setActiveWorkspace,
     reorderOpenedWorkspacesInSection,
+    updateWorkspaceRelatedPaths,
     scanWorkspaceInfo,
     refreshRecentWorkspaces,
     removeWorkspaceFromRecent,

--- a/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
+++ b/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
@@ -263,6 +263,34 @@ class WorkspaceManager {
     );
   }
 
+  private applyWorkspaceRecordUpdate(updatedWorkspace: WorkspaceInfo): void {
+    const currentWorkspace = this.state.currentWorkspace?.id === updatedWorkspace.id
+      ? updatedWorkspace
+      : this.state.currentWorkspace;
+    const openedWorkspaces = new Map(this.state.openedWorkspaces);
+    if (openedWorkspaces.has(updatedWorkspace.id)) {
+      openedWorkspaces.set(updatedWorkspace.id, updatedWorkspace);
+    }
+    const recentWorkspaces = this.state.recentWorkspaces.map(workspace =>
+      workspace.id === updatedWorkspace.id ? updatedWorkspace : workspace
+    );
+
+    this.updateState(
+      {
+        currentWorkspace,
+        openedWorkspaces,
+        recentWorkspaces,
+        activeWorkspaceId: currentWorkspace?.id ?? this.state.activeWorkspaceId,
+        lastUsedWorkspaceId: this.resolveLastUsedWorkspaceId(
+          currentWorkspace,
+          recentWorkspaces,
+          openedWorkspaces
+        ),
+      },
+      { type: 'workspace:updated', workspace: updatedWorkspace }
+    );
+  }
+
   private async ensureIdentityChangeListener(): Promise<void> {
     if (this.identityEventListening) {
       return;
@@ -873,6 +901,27 @@ class WorkspaceManager {
   public async removeWorkspaceFromRecent(workspaceId: string): Promise<void> {
     await globalStateAPI.removeWorkspaceFromRecent(workspaceId);
     await this.refreshRecentWorkspaces();
+  }
+
+  public async updateWorkspaceRelatedPaths(
+    workspaceId: string,
+    relatedPaths: WorkspaceInfo['relatedPaths']
+  ): Promise<WorkspaceInfo> {
+    try {
+      this.setError(null);
+
+      const updatedWorkspace = await globalStateAPI.updateWorkspaceInfo(workspaceId, {
+        relatedPaths,
+      });
+
+      this.applyWorkspaceRecordUpdate(updatedWorkspace);
+      return updatedWorkspace;
+    } catch (error) {
+      log.error('Failed to update workspace related paths', { workspaceId, error });
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.updateState({ error: errorMessage }, { type: 'workspace:error', error: errorMessage });
+      throw error;
+    }
   }
 
   public async cleanupInvalidWorkspaces(): Promise<number> {

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -318,11 +318,35 @@
         "deleteAssistant": "Delete personal assistant",
         "resetWorkspace": "Reset workspace",
         "initAgents": "Initialize AGENTS.md",
+        "manageRelatedPaths": "Related directories",
         "newWorktree": "New worktree",
         "deleteWorktree": "Delete worktree",
         "copyPath": "Copy path",
         "reveal": "Reveal in explorer",
         "close": "Close workspace"
+      },
+      "relatedPaths": {
+        "badge": "{{count}} linked",
+        "dialog": {
+          "title": "Related directories",
+          "heading": "Add supporting directories to this workspace",
+          "description": "These directories and descriptions are injected into workspace context, which is useful for cross-project migrations and focused monorepo slices.",
+          "localScope": "This workspace runs locally, so only local directories can be linked here.",
+          "remoteScope": "This workspace runs remotely, so only directories under connection \"{{connectionName}}\" can be linked here.",
+          "empty": "No related directories yet. Once added, the AI will see these directories and descriptions in workspace context.",
+          "itemLabel": "Directory {{index}}",
+          "add": "Add directory",
+          "selectDirectoryTitle": "Select related directory",
+          "pathPlaceholder": "Enter a directory path, or use the picker on the right",
+          "descriptionPlaceholder": "Optional: briefly explain why this directory matters, for example: legacy TypeScript implementation / billing package inside the monorepo"
+        },
+        "messages": {
+          "saveFailed": "Failed to save related directories",
+          "selectFailed": "Failed to select directory"
+        },
+        "validation": {
+          "pathRequired": "Please fill in a path for every related directory"
+        }
       },
       "deleteAssistantDialog": {
         "title": "Delete {{name}}?",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -318,11 +318,35 @@
         "deleteAssistant": "删除个人助理",
         "resetWorkspace": "重置工作区",
         "initAgents": "初始化 AGENTS.md",
+        "manageRelatedPaths": "关联目录",
         "newWorktree": "新建 worktree",
         "deleteWorktree": "删除 worktree",
         "copyPath": "复制路径",
         "reveal": "在资源管理器中打开",
         "close": "关闭工作区"
+      },
+      "relatedPaths": {
+        "badge": "{{count}} 关联",
+        "dialog": {
+          "title": "关联目录",
+          "heading": "为当前工作区补充相关目录",
+          "description": "这些目录会连同说明一起进入工作区上下文，适合跨项目迁移、monorepo 子目录协作等场景。",
+          "localScope": "当前工作区是本地环境，因此这里只能关联本地目录。",
+          "remoteScope": "当前工作区是远程环境，因此这里只能关联连接“{{connectionName}}”下的目录。",
+          "empty": "还没有关联目录。添加后，AI 会在工作区上下文中看到这些目录和说明。",
+          "itemLabel": "目录 {{index}}",
+          "add": "添加目录",
+          "selectDirectoryTitle": "选择关联目录",
+          "pathPlaceholder": "输入目录路径，或使用右侧选择器",
+          "descriptionPlaceholder": "选填：简短说明这个目录为什么重要，例如：旧版 TypeScript 实现 / monorepo 中的 billing 子目录"
+        },
+        "messages": {
+          "saveFailed": "保存关联目录失败",
+          "selectFailed": "选择目录失败"
+        },
+        "validation": {
+          "pathRequired": "请为每个关联目录填写路径"
+        }
       },
       "deleteAssistantDialog": {
         "title": "删除 {{name}}？",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -318,11 +318,35 @@
         "deleteAssistant": "刪除個人助理",
         "resetWorkspace": "重置工作區",
         "initAgents": "初始化 AGENTS.md",
+        "manageRelatedPaths": "關聯目錄",
         "newWorktree": "新建 worktree",
         "deleteWorktree": "刪除 worktree",
         "copyPath": "複製路徑",
         "reveal": "在資源管理器中打開",
         "close": "關閉工作區"
+      },
+      "relatedPaths": {
+        "badge": "{{count}} 關聯",
+        "dialog": {
+          "title": "關聯目錄",
+          "heading": "為當前工作區補充相關目錄",
+          "description": "這些目錄會連同說明一起進入工作區上下文，適合跨項目遷移、monorepo 子目錄協作等場景。",
+          "localScope": "當前工作區是本地環境，因此這裡只能關聯本地目錄。",
+          "remoteScope": "當前工作區是遠程環境，因此這裡只能關聯連接「{{connectionName}}」下的目錄。",
+          "empty": "還沒有關聯目錄。添加後，AI 會在工作區上下文中看到這些目錄和說明。",
+          "itemLabel": "目錄 {{index}}",
+          "add": "添加目錄",
+          "selectDirectoryTitle": "選擇關聯目錄",
+          "pathPlaceholder": "輸入目錄路徑，或使用右側選擇器",
+          "descriptionPlaceholder": "選填：簡短說明這個目錄為什麼重要，例如：舊版 TypeScript 實現 / monorepo 中的 billing 子目錄"
+        },
+        "messages": {
+          "saveFailed": "保存關聯目錄失敗",
+          "selectFailed": "選擇目錄失敗"
+        },
+        "validation": {
+          "pathRequired": "請為每個關聯目錄填寫路徑"
+        }
       },
       "deleteAssistantDialog": {
         "title": "刪除 {{name}}？",

--- a/src/web-ui/src/shared/types/global-state.ts
+++ b/src/web-ui/src/shared/types/global-state.ts
@@ -81,6 +81,11 @@ export interface WorkspaceWorktreeInfo {
   isMain: boolean;
 }
 
+export interface RelatedPath {
+  path: string;
+  description?: string;
+}
+
 
 export interface WorkspaceInfo {
   id: string;
@@ -97,6 +102,7 @@ export interface WorkspaceInfo {
   statistics?: ProjectStatistics;
   identity?: WorkspaceIdentity | null;
   worktree?: WorkspaceWorktreeInfo | null;
+  relatedPaths?: RelatedPath[];
   connectionId?: string;
   connectionName?: string;
   /**
@@ -181,6 +187,15 @@ export interface GlobalStateAPI {
   closeWorkspace(workspaceId: string): Promise<void>;
   setActiveWorkspace(workspaceId: string): Promise<WorkspaceInfo>;
   reorderOpenedWorkspaces(workspaceIds: string[]): Promise<void>;
+  updateWorkspaceInfo(
+    workspaceId: string,
+    updates: {
+      name?: string;
+      description?: string | null;
+      tags?: string[];
+      relatedPaths?: RelatedPath[];
+    }
+  ): Promise<WorkspaceInfo>;
   getCurrentWorkspace(): Promise<WorkspaceInfo | null>;
   getOpenedWorkspaces(): Promise<WorkspaceInfo[]>;
   getRecentWorkspaces(): Promise<WorkspaceInfo[]>;
@@ -301,6 +316,10 @@ function mapWorkspaceInfo(workspace: APIWorkspaceInfo): WorkspaceInfo {
       : undefined,
     identity: mapWorkspaceIdentity(workspace.identity),
     worktree: mapWorkspaceWorktree(workspace.worktree),
+    relatedPaths: (workspace.relatedPaths ?? []).map(path => ({
+      path: path.path,
+      description: path.description ?? undefined,
+    })),
     connectionId: workspace.connectionId,
     connectionName: workspace.connectionName,
     sshHost:
@@ -387,6 +406,23 @@ export function createGlobalStateAPI(): GlobalStateAPI {
 
     async reorderOpenedWorkspaces(workspaceIds: string[]): Promise<void> {
       return await globalAPI.reorderOpenedWorkspaces(workspaceIds);
+    },
+
+    async updateWorkspaceInfo(
+      workspaceId: string,
+      updates: {
+        name?: string;
+        description?: string | null;
+        tags?: string[];
+        relatedPaths?: RelatedPath[];
+      }
+    ): Promise<WorkspaceInfo> {
+      return mapWorkspaceInfo(
+        await globalAPI.updateWorkspaceInfo({
+          workspaceId,
+          ...updates,
+        })
+      );
     },
 
     async getCurrentWorkspace(): Promise<WorkspaceInfo | null> {

--- a/src/web-ui/src/tools/workspace/components/WorkspaceManager.css
+++ b/src/web-ui/src/tools/workspace/components/WorkspaceManager.css
@@ -205,6 +205,55 @@
   color: var(--color-accent-500);
 }
 
+.workspace-related-paths {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.workspace-related-paths__label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.workspace-related-paths__list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.workspace-related-paths__item,
+.workspace-related-paths__more {
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(96, 165, 250, 0.06);
+  border: 1px solid rgba(96, 165, 250, 0.12);
+}
+
+.workspace-related-paths__path {
+  display: block;
+  font-size: 12px;
+  font-family: 'Fira Code', 'Monaco', 'Consolas', monospace;
+  color: var(--color-accent-500);
+  word-break: break-all;
+}
+
+.workspace-related-paths__desc {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.45;
+}
+
+.workspace-related-paths__more {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.62);
+}
+
 .workspace-type {
   font-size: 12px;
   padding: 2px 8px;

--- a/src/web-ui/src/tools/workspace/components/WorkspaceManager.tsx
+++ b/src/web-ui/src/tools/workspace/components/WorkspaceManager.tsx
@@ -3,7 +3,7 @@ import { FolderOpen, Clock, FileText, Code, Folder, Bot } from 'lucide-react';
 import { useWorkspaceContext } from '../../../infrastructure/contexts/WorkspaceContext';
 import { WorkspaceInfo, WorkspaceKind, WorkspaceType } from '../../../shared/types';
 import { Modal } from '@/component-library';
-import { i18nService } from '@/infrastructure/i18n';
+import { i18nService, useI18n } from '@/infrastructure/i18n';
 import { createLogger } from '@/shared/utils/logger';
 import { getRecentWorkspaceLineParts } from '@/shared/utils/recentWorkspaceDisplay';
 import './WorkspaceManager.css';
@@ -25,6 +25,7 @@ const WorkspaceManager: React.FC<WorkspaceManagerProps> = ({
   onClose,
   onWorkspaceSelect
 }) => {
+  const { t } = useI18n('common');
   const {
     currentWorkspace,
     recentWorkspaces,
@@ -61,6 +62,36 @@ const WorkspaceManager: React.FC<WorkspaceManagerProps> = ({
             <span className="workspace-identity__value">{entry.value}</span>
           </span>
         ))}
+      </div>
+    );
+  };
+
+  const renderRelatedPaths = (workspace: WorkspaceInfo) => {
+    const relatedPaths = workspace.relatedPaths ?? [];
+    if (relatedPaths.length === 0) {
+      return null;
+    }
+
+    return (
+      <div className="workspace-related-paths">
+        <span className="workspace-related-paths__label">
+          {t('nav.workspaces.relatedPaths.dialog.title')}
+        </span>
+        <div className="workspace-related-paths__list">
+          {relatedPaths.slice(0, 3).map(path => (
+            <div key={path.path} className="workspace-related-paths__item">
+              <span className="workspace-related-paths__path">{path.path}</span>
+              {path.description?.trim() ? (
+                <span className="workspace-related-paths__desc">{path.description}</span>
+              ) : null}
+            </div>
+          ))}
+          {relatedPaths.length > 3 ? (
+            <div className="workspace-related-paths__more">
+              +{relatedPaths.length - 3}
+            </div>
+          ) : null}
+        </div>
       </div>
     );
   };
@@ -165,6 +196,7 @@ const WorkspaceManager: React.FC<WorkspaceManagerProps> = ({
                     )}
                   </div>
                   {renderIdentityDetails(currentWorkspace)}
+                  {renderRelatedPaths(currentWorkspace)}
                 </div>
               </div>
               
@@ -249,6 +281,7 @@ const WorkspaceManager: React.FC<WorkspaceManagerProps> = ({
                         )}
                       </div>
                       {renderIdentityDetails(workspace)}
+                      {renderRelatedPaths(workspace)}
                     </div>
                   </div>
                 </div>
@@ -288,6 +321,7 @@ const WorkspaceManager: React.FC<WorkspaceManagerProps> = ({
                         )}
                       </div>
                       {renderIdentityDetails(workspace)}
+                      {renderRelatedPaths(workspace)}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
- persist user-managed related directories for local and remote workspaces
- add workspace UI for creating, editing, removing, and displaying related directories
- inject related directories into agent request context and prompt workspace context
- propagate workspace id through agentic session creation to resolve related context reliably
- support optional related directory descriptions and improve remote picker stacking behavior
