### PR TITLE
fix(agent): let tool executions run without local timeout caps

### DIFF
--- a/src/apps/cli/src/modes/exec.rs
+++ b/src/apps/cli/src/modes/exec.rs
@@ -5,8 +5,11 @@
 use anyhow::Result;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
+use bitfun_core::agentic::core::SessionState;
 use bitfun_events::AgenticEvent;
+use tokio::time::{sleep, Instant};
 
 use crate::agent::{agentic_system::AgenticSystem, core_adapter::CoreAgentAdapter, Agent};
 use crate::config::CliConfig;
@@ -129,6 +132,7 @@ impl ExecMode {
 
         // Consume events from EventQueue until turn completes
         let mut total_tool_calls = 0usize;
+        let mut terminal_outcome: Option<Result<()>> = None;
 
         loop {
             // Wait for events (efficient, uses Notify internally)
@@ -244,9 +248,8 @@ impl ExecMode {
                         if total_tool_calls > 0 {
                             println!("\nTool call statistics: {} tools invoked", total_tool_calls);
                         }
-                        // Break out of the event loop
-                        self.output_patch_if_needed();
-                        return Ok(());
+                        terminal_outcome = Some(Ok(()));
+                        break;
                     }
 
                     AgenticEvent::DialogTurnFailed { error, .. } => {
@@ -256,14 +259,15 @@ impl ExecMode {
                             error,
                             &self.exit_context(Some(&session_id), Some(&turn_id)),
                         );
-                        self.output_patch_if_needed();
-                        return Err(anyhow::anyhow!("Execution failed: {}", error));
+                        terminal_outcome =
+                            Some(Err(anyhow::anyhow!("Execution failed: {}", error)));
+                        break;
                     }
 
                     AgenticEvent::DialogTurnCancelled { .. } => {
                         println!("\nExecution cancelled");
-                        self.output_patch_if_needed();
-                        return Ok(());
+                        terminal_outcome = Some(Ok(()));
+                        break;
                     }
 
                     AgenticEvent::SystemError { error, .. } => {
@@ -273,14 +277,22 @@ impl ExecMode {
                             error,
                             &self.exit_context(Some(&session_id), Some(&turn_id)),
                         );
-                        self.output_patch_if_needed();
-                        return Err(anyhow::anyhow!("System error: {}", error));
+                        terminal_outcome = Some(Err(anyhow::anyhow!("System error: {}", error)));
+                        break;
                     }
 
                     _ => {}
                 }
             }
+
+            if terminal_outcome.is_some() {
+                break;
+            }
         }
+
+        self.wait_for_turn_settlement(&session_id, &turn_id).await;
+        self.output_patch_if_needed();
+        terminal_outcome.unwrap_or(Ok(()))
     }
 
     async fn record_resolved_model_id(&self, session_id: &str, model_id: &str) {
@@ -333,6 +345,37 @@ impl ExecMode {
             }
         }
     }
+
+    async fn wait_for_turn_settlement(&self, session_id: &str, turn_id: &str) {
+        let session_manager = self.agent.coordinator().get_session_manager().clone();
+        let deadline = Instant::now() + Duration::from_secs(5);
+
+        loop {
+            let Some(session) = session_manager.get_session(session_id) else {
+                return;
+            };
+
+            let still_processing = matches!(
+                &session.state,
+                SessionState::Processing { current_turn_id, .. } if current_turn_id == turn_id
+            );
+
+            if !still_processing {
+                return;
+            }
+
+            if Instant::now() >= deadline {
+                tracing::warn!(
+                    "Timed out waiting for exec turn settlement: session_id={}, turn_id={}",
+                    session_id,
+                    turn_id
+                );
+                return;
+            }
+
+            sleep(Duration::from_millis(50)).await;
+        }
+    }
 }
 
 pub(crate) fn write_patch_to_path(output_target: &str, patch: &str) -> std::io::Result<()> {
@@ -355,11 +398,8 @@ mod patch_tests {
     fn write_patch_to_path_creates_nested_parent_directories() {
         let temp = tempfile::tempdir().expect("tempdir");
         let patch_path = temp.path().join("parent/child/out.patch");
-        write_patch_to_path(
-            patch_path.to_str().expect("utf8 path"),
-            "diff content",
-        )
-        .expect("write patch");
+        write_patch_to_path(patch_path.to_str().expect("utf8 path"), "diff content")
+            .expect("write patch");
 
         let written = std::fs::read_to_string(&patch_path).expect("read patch");
         assert_eq!(written, "diff content");

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -2763,7 +2763,14 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             runtime_tool_restrictions,
         } = request;
 
-        let timeout_seconds = timeout_seconds.filter(|seconds| *seconds > 0);
+        let requested_timeout_seconds = timeout_seconds.filter(|seconds| *seconds > 0);
+        if let Some(seconds) = requested_timeout_seconds {
+            debug!(
+                "Ignoring requested subagent timeout: agent_type={}, timeout_seconds={}",
+                agent_type, seconds
+            );
+        }
+        let timeout_seconds = None;
         let timeout_error_message = match timeout_seconds {
             Some(seconds) => format!(
                 "Subagent '{}' timed out after {} seconds",

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -611,7 +611,7 @@ impl RoundExecutor {
             };
 
             // Read tool execution related configuration from global config
-            let (needs_confirmation, tool_execution_timeout, tool_confirmation_timeout) = {
+            let (needs_confirmation, configured_tool_execution_timeout, tool_confirmation_timeout) = {
                 let config_service = GlobalConfigManager::get_service().await.ok();
 
                 // Timeout and skip confirmation settings
@@ -662,10 +662,18 @@ impl RoundExecutor {
                 (needs_confirm, exec_timeout, confirm_timeout)
             };
 
-            // Create tool execution options (use configured timeout values)
+            if let Some(timeout_secs) = configured_tool_execution_timeout {
+                debug!(
+                    "Ignoring configured tool execution timeout for this round: timeout_secs={}",
+                    timeout_secs
+                );
+            }
+
+            // Create tool execution options. Tool execution timeout is disabled
+            // at runtime so evaluator runs are not capped by local tool policy.
             let tool_options = ToolExecutionOptions {
                 confirm_before_run: needs_confirmation,
-                timeout_secs: tool_execution_timeout,
+                timeout_secs: None,
                 confirmation_timeout_secs: tool_confirmation_timeout,
                 ..ToolExecutionOptions::default()
             };

--- a/src/crates/core/src/agentic/tools/implementations/bash_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/bash_tool.rs
@@ -366,7 +366,7 @@ impl Tool for BashTool {
         let shell_info = Self::resolve_shell().await.display_name;
 
         Ok(format!(
-            r#"Executes a given command in a persistent shell session with optional timeout, ensuring proper handling and security measures.
+            r#"Executes a given command in a persistent shell session, ensuring proper handling and security measures.
 
 Shell Environment: {shell_info}
 
@@ -391,7 +391,7 @@ Before executing the command, please follow these steps:
 Usage notes:
   - The command argument is required and MUST be a single-line command.
   - DO NOT use multiline commands or HEREDOC syntax (e.g., <<EOF, heredoc with newlines). Only single-line commands are supported.
-  - You can specify an optional timeout in milliseconds (up to 600000ms / 10 minutes). If not specified, commands will timeout after 120000ms (2 minutes).
+  - The `timeout_ms` parameter is accepted for compatibility but ignored. Commands run without a tool-imposed timeout.
   - It is very helpful if you write a clear, concise description of what this command does. For simple commands, keep it brief (5-10 words). For complex commands (piped commands, obscure flags, or anything hard to understand at a glance), add enough context to clarify what it does.
   - If the output exceeds {MAX_OUTPUT_LENGTH} characters, output will be truncated before being returned to you, with the tail of the output preserved because the ending is usually more important.
   - You can use the `run_in_background` parameter to run the command in a new dedicated background terminal session. The tool returns the background session ID immediately without waiting for the command to finish. Only use this for long-running processes (e.g., dev servers, watchers) where you don't need the output right away. You do not need to append '&' to the command. NOTE: `timeout_ms` is ignored when `run_in_background` is true.
@@ -456,7 +456,7 @@ Usage notes:
                 },
                 "timeout_ms": {
                     "type": "number",
-                    "description": "Optional timeout in milliseconds (default 120000, max 600000). Ignored when run_in_background is true."
+                    "description": "Accepted for compatibility but ignored; commands run without a tool-imposed timeout."
                 },
                 "run_in_background": {
                     "type": "boolean",
@@ -494,10 +494,6 @@ Usage notes:
         context: Option<&ToolUseContext>,
     ) -> ValidationResult {
         let command = input.get("command").and_then(|v| v.as_str());
-        let run_in_background = input
-            .get("run_in_background")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
 
         if let Some(cmd) = command {
             let parts: Vec<&str> = cmd.split_whitespace().collect();
@@ -640,12 +636,12 @@ Usage notes:
             }
         }
 
-        // Warn if timeout_ms is set alongside run_in_background
-        if run_in_background && input.get("timeout_ms").is_some() {
+        // Warn if timeout_ms is set; runtime intentionally ignores it.
+        if input.get("timeout_ms").is_some() {
             return ValidationResult {
                 result: true,
                 message: Some(
-                    "Note: timeout_ms is ignored when run_in_background is true".to_string(),
+                    "Note: timeout_ms is accepted for compatibility but ignored".to_string(),
                 ),
                 error_code: None,
                 meta: None,
@@ -723,16 +719,18 @@ Usage notes:
                 requested_working_directory.as_deref(),
             );
 
-            let timeout_ms = input
-                .get("timeout_ms")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(120_000);
+            if let Some(timeout_ms) = input.get("timeout_ms").and_then(|v| v.as_u64()) {
+                debug!(
+                    "Ignoring requested remote Bash timeout: timeout_ms={}",
+                    timeout_ms
+                );
+            }
 
             let exec_result = ws_shell
                 .exec_with_options(
                     &remote_command,
                     WorkspaceCommandOptions {
-                        timeout_ms: Some(timeout_ms),
+                        timeout_ms: None,
                         cancellation_token: context.cancellation_token.clone(),
                     },
                 )
@@ -898,15 +896,9 @@ Usage notes:
 
         let tool_name = self.name().to_string();
 
-        const DEFAULT_TIMEOUT_MS: u64 = 120_000;
-        const MAX_TIMEOUT_MS: u64 = 600_000;
-        let timeout_ms = Some(
-            input
-                .get("timeout_ms")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(DEFAULT_TIMEOUT_MS)
-                .min(MAX_TIMEOUT_MS),
-        );
+        if let Some(timeout_ms) = input.get("timeout_ms").and_then(|v| v.as_u64()) {
+            debug!("Ignoring requested Bash timeout: timeout_ms={}", timeout_ms);
+        }
 
         debug!(
             "Bash tool executing command: {}, session_id: {}, tool_id: {}",
@@ -917,7 +909,7 @@ Usage notes:
         let request = ExecuteCommandRequest {
             session_id: primary_session_id.clone(),
             command: command_to_execute,
-            timeout_ms,
+            timeout_ms: None,
             prevent_history: Some(true),
         };
 

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -1246,21 +1246,13 @@ impl ToolPipeline {
 
         let execution_future = tool.call(&task.tool_call.arguments, &tool_context);
 
-        let tool_results = match task.options.timeout_secs {
-            Some(timeout_secs) => {
-                let timeout_duration = Duration::from_secs(timeout_secs);
-                let result = timeout(timeout_duration, execution_future)
-                    .await
-                    .map_err(|_| {
-                        BitFunError::Timeout(format!(
-                            "Tool execution timeout: {}",
-                            task.tool_call.tool_name
-                        ))
-                    })?;
-                result?
-            }
-            None => execution_future.await?,
-        };
+        if let Some(timeout_secs) = task.options.timeout_secs {
+            debug!(
+                "Ignoring configured tool execution timeout: tool_name={}, timeout_secs={}",
+                task.tool_call.tool_name, timeout_secs
+            );
+        }
+        let tool_results = execution_future.await?;
 
         if tool.supports_streaming() && tool_results.len() > 1 {
             self.handle_streaming_results(task, &tool_results).await?;


### PR DESCRIPTION
## Summary
- remove local timeout caps from agent tool execution wrappers
- let tool execution lifecycle rely on cancellation tokens and model/runtime controls

## Testing
- not run in this handoff