### PR TITLE
feat(ai): add stream TTFT timeout and improve PlaintextFollowup Write reliability

### DIFF
--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -968,9 +968,12 @@ pub async fn initialize_ai(state: State<'_, AppState>) -> Result<String, String>
         .get_config(None)
         .await
         .map_err(|e| format!("Failed to get configuration: {}", e))?;
-    let stream_options = bitfun_core::infrastructure::ai::build_stream_options(&global_config.ai);
-
-    let primary_model_id = global_config.ai.default_models.primary.ok_or_else(|| {
+    let primary_model_id = global_config
+        .ai
+        .default_models
+        .primary
+        .clone()
+        .ok_or_else(|| {
         "Primary model not configured, please configure it in settings".to_string()
     })?;
     let model_config = global_config
@@ -979,6 +982,11 @@ pub async fn initialize_ai(state: State<'_, AppState>) -> Result<String, String>
         .iter()
         .find(|m| m.id == primary_model_id)
         .ok_or_else(|| format!("Primary model '{}' does not exist", primary_model_id))?;
+    let stream_options =
+        bitfun_core::infrastructure::ai::build_stream_options_for_model(
+            &global_config.ai,
+            Some(model_config),
+        );
 
     let ai_config = bitfun_core::util::types::AIConfig::try_from(model_config.clone())
         .map_err(|e| format!("Failed to convert AI configuration: {}", e))?;
@@ -1005,6 +1013,18 @@ async fn create_transient_ai_client_for_config(
     model_config: bitfun_core::service::config::types::AIModelConfig,
 ) -> Result<bitfun_core::infrastructure::ai::AIClient, String> {
     let auth = model_config.auth.clone();
+
+    let global_config: bitfun_core::service::config::GlobalConfig = state
+        .config_service
+        .get_config(None)
+        .await
+        .map_err(|e| format!("Failed to get configuration: {}", e))?;
+    let stream_options =
+        bitfun_core::infrastructure::ai::build_stream_options_for_model(
+            &global_config.ai,
+            Some(&model_config),
+        );
+
     let mut ai_config: bitfun_core::util::types::AIConfig = model_config
         .try_into()
         .map_err(|e| format!("Failed to convert configuration: {}", e))?;
@@ -1013,17 +1033,11 @@ async fn create_transient_ai_client_for_config(
         .await
         .map_err(|e| format!("Failed to resolve CLI credential: {}", e))?;
 
-    let global_config: bitfun_core::service::config::GlobalConfig = state
-        .config_service
-        .get_config(None)
-        .await
-        .map_err(|e| format!("Failed to get configuration: {}", e))?;
     let proxy_config = if global_config.ai.proxy.enabled {
         Some(global_config.ai.proxy.clone())
     } else {
         None
     };
-    let stream_options = bitfun_core::infrastructure::ai::build_stream_options(&global_config.ai);
 
     Ok(
         bitfun_core::infrastructure::ai::AIClient::new_with_runtime_options(

--- a/src/apps/desktop/src/api/config_api.rs
+++ b/src/apps/desktop/src/api/config_api.rs
@@ -152,6 +152,7 @@ pub async fn set_config(
                 || request.path.starts_with("ai.default_models")
                 || request.path.starts_with("ai.agent_models")
                 || request.path.starts_with("ai.stream_idle_timeout_secs")
+                || request.path.starts_with("ai.stream_ttft_timeout_secs")
                 || request.path.starts_with("ai.proxy")
             {
                 state.ai_client_factory.invalidate_cache();

--- a/src/crates/agent-stream/src/lib.rs
+++ b/src/crates/agent-stream/src/lib.rs
@@ -203,6 +203,10 @@ impl StreamProcessError {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct StreamProcessOptions {
     pub recover_partial_on_cancel: bool,
+    /// When true, Write tool-call JSON is sanitized to `file_path` only during
+    /// streaming and finalization. Inline `content` must never reach the UI or
+    /// downstream execution in PlaintextFollowup mode.
+    pub strip_write_inline_content: bool,
 }
 
 /// Stream processing context, encapsulates state during stream processing
@@ -241,6 +245,7 @@ impl StreamContext {
         session_id: String,
         dialog_turn_id: String,
         round_id: String,
+        options: StreamProcessOptions,
     ) -> Self {
         Self {
             session_id,
@@ -253,7 +258,7 @@ impl StreamContext {
             tool_calls: Vec::new(),
             usage: None,
             provider_metadata: None,
-            pending_tool_calls: PendingToolCalls::default(),
+            pending_tool_calls: PendingToolCalls::new(options.strip_write_inline_content),
             finalized_tool_call_ids: HashSet::new(),
             stream_started_at: Instant::now(),
             first_chunk_ms: None,
@@ -384,7 +389,7 @@ pub struct StreamProcessor {
 }
 
 impl StreamProcessor {
-    const WATCHDOG_GRACE_SECS: u64 = 5;
+    const WATCHDOG_GRACE_SECS: u64 = 2;
 
     pub fn new<E>(event_sink: Arc<E>) -> Self
     where
@@ -795,7 +800,7 @@ impl StreamProcessor {
         cancellation_token: &tokio_util::sync::CancellationToken,
         options: StreamProcessOptions,
     ) -> Result<StreamResult, StreamProcessError> {
-        let mut ctx = StreamContext::new(session_id, dialog_turn_id, round_id);
+        let mut ctx = StreamContext::new(session_id, dialog_turn_id, round_id, options);
         // Start SSE log collector (if raw_sse_rx is provided)
         let sse_collector = if let Some(mut rx) = raw_sse_rx {
             let collector = Arc::new(tokio::sync::Mutex::new(SseLogCollector::new(
@@ -1020,7 +1025,7 @@ mod tests {
         assert_eq!(StreamProcessor::derive_watchdog_timeout(None), None);
         assert_eq!(
             StreamProcessor::derive_watchdog_timeout(Some(Duration::from_secs(10))),
-            Some(Duration::from_secs(15))
+            Some(Duration::from_secs(12))
         );
     }
 
@@ -1063,6 +1068,7 @@ mod tests {
                 &cancellation_token,
                 StreamProcessOptions {
                     recover_partial_on_cancel: true,
+                    ..Default::default()
                 },
             )
             .await

--- a/src/crates/ai-adapters/src/client.rs
+++ b/src/crates/ai-adapters/src/client.rs
@@ -33,11 +33,23 @@ pub struct StreamResponse {
     pub raw_sse_rx: Option<mpsc::UnboundedReceiver<String>>,
 }
 
+/// Default time to wait for the first response headers / stream body to start.
+pub const DEFAULT_STREAM_TTFT_TIMEOUT_SECS: u64 = 30;
+
+/// Default idle time between streamed chunks once the stream has started.
+pub const DEFAULT_STREAM_IDLE_TIMEOUT_SECS: u64 = 45;
+
+/// Minimum TTFT for models with explicit reasoning enabled.
+pub const REASONING_STREAM_TTFT_TIMEOUT_SECS: u64 = 45;
+
 /// Runtime stream behavior shared across provider implementations.
 #[derive(Debug, Clone, Default)]
 pub struct StreamOptions {
     /// Maximum idle time between streamed chunks. `None` means wait indefinitely.
     pub idle_timeout: Option<Duration>,
+    /// Maximum time to wait for HTTP response headers when opening a stream.
+    /// `None` means wait indefinitely.
+    pub ttft_timeout: Option<Duration>,
 }
 
 #[derive(Debug, Clone)]
@@ -84,6 +96,36 @@ impl AIClient {
         self.stream_options.idle_timeout
     }
 
+    /// Returns the configured time-to-first-token timeout for opening a stream, if any.
+    pub fn stream_ttft_timeout(&self) -> Option<Duration> {
+        self.stream_options.ttft_timeout
+    }
+
+    /// Clone this client with a different reasoning mode while reusing the HTTP client.
+    pub fn with_reasoning_mode(&self, reasoning_mode: crate::types::ReasoningMode) -> Self {
+        let mut config = self.config.clone();
+        config.reasoning_mode = reasoning_mode;
+        Self {
+            client: self.client.clone(),
+            config,
+            stream_options: self.stream_options.clone(),
+        }
+    }
+
+    /// Provider-specific request overrides for PlaintextFollowup Write content generation.
+    ///
+    /// OpenAI-compatible APIs accept `tool_choice: "none"` to suppress tool calls when
+    /// history still contains prior tool turns. Anthropic/Gemini reject that field.
+    pub fn write_content_generation_extra_body(&self) -> Option<serde_json::Value> {
+        match ApiFormat::parse(&self.config.format) {
+            Ok(ApiFormat::OpenAIChat | ApiFormat::OpenAIResponses) => {
+                Some(serde_json::json!({ "tool_choice": "none" }))
+            }
+            Ok(ApiFormat::Anthropic | ApiFormat::Gemini | ApiFormat::GeminiCodeAssist) => None,
+            Err(_) => None,
+        }
+    }
+
     pub async fn send_message_stream(
         &self,
         messages: Vec<Message>,
@@ -100,7 +142,7 @@ impl AIClient {
         tools: Option<Vec<ToolDefinition>>,
         extra_body: Option<serde_json::Value>,
     ) -> Result<StreamResponse> {
-        let max_tries = 10;
+        let max_tries = SEND_MESSAGE_STREAM_ATTEMPTS;
         match ApiFormat::parse(&self.config.format)? {
             ApiFormat::OpenAIChat => {
                 openai::chat::send_stream(self, messages, tools, extra_body, max_tries).await
@@ -969,5 +1011,20 @@ mod tests {
                 "expected permanent stream error: {msg}"
             );
         }
+    }
+
+    #[test]
+    fn write_content_generation_extra_body_is_openai_only() {
+        let openai = make_test_client("openai", None);
+        assert_eq!(
+            openai.write_content_generation_extra_body(),
+            Some(json!({ "tool_choice": "none" }))
+        );
+
+        let anthropic = make_test_client("anthropic", None);
+        assert_eq!(anthropic.write_content_generation_extra_body(), None);
+
+        let gemini = make_test_client("gemini", None);
+        assert_eq!(gemini.write_content_generation_extra_body(), None);
     }
 }

--- a/src/crates/ai-adapters/src/client/sse.rs
+++ b/src/crates/ai-adapters/src/client/sse.rs
@@ -8,10 +8,52 @@ use reqwest::{
     header::{HeaderMap, RETRY_AFTER},
     StatusCode,
 };
+use std::time::Duration;
 use tokio::sync::mpsc;
 
 const BASE_RETRY_DELAY_MS: u64 = 500;
-const MAX_RETRY_AFTER_DELAY_MS: u64 = 30_000;
+const MAX_RETRY_AFTER_DELAY_MS: u64 = 10_000;
+
+enum StreamSendOutcome {
+    Response(reqwest::Response),
+    Transport(reqwest::Error),
+    TtftTimeout,
+}
+
+async fn send_stream_request<BuildRequest>(
+    build_request: BuildRequest,
+    request_body: &serde_json::Value,
+    ttft_timeout: Option<Duration>,
+) -> StreamSendOutcome
+where
+    BuildRequest: Fn() -> reqwest::RequestBuilder,
+{
+    match ttft_timeout {
+        Some(timeout) => match tokio::time::timeout(timeout, build_request().json(request_body).send())
+            .await
+        {
+            Ok(Ok(response)) => StreamSendOutcome::Response(response),
+            Ok(Err(error)) => StreamSendOutcome::Transport(error),
+            Err(_) => StreamSendOutcome::TtftTimeout,
+        },
+        None => match build_request().json(request_body).send().await {
+            Ok(response) => StreamSendOutcome::Response(response),
+            Err(error) => StreamSendOutcome::Transport(error),
+        },
+    }
+}
+
+fn format_ttft_timeout_error(label: &str, ttft_timeout: Option<Duration>) -> String {
+    let timeout_secs = ttft_timeout.map(|timeout| timeout.as_secs()).unwrap_or(0);
+    format!(
+        "{} TTFT timeout after {}s waiting for response headers",
+        label, timeout_secs
+    )
+}
+
+fn format_transport_error(label: &str, error: &reqwest::Error) -> String {
+    format!("{} connection failed: {}", label, error)
+}
 
 fn is_retryable_http_status(status: StatusCode) -> bool {
     status.is_server_error() || matches!(status.as_u16(), 408 | 409 | 425 | 429)
@@ -54,6 +96,7 @@ pub(crate) async fn execute_sse_request<BuildRequest, SpawnHandler>(
     _url: &str,
     request_body: &serde_json::Value,
     max_tries: usize,
+    ttft_timeout: Option<Duration>,
     build_request: BuildRequest,
     spawn_handler: SpawnHandler,
 ) -> Result<StreamResponse>
@@ -68,10 +111,10 @@ where
     let mut last_error = None;
     for attempt in 0..max_tries {
         let request_start_time = std::time::Instant::now();
-        let response_result = build_request().json(request_body).send().await;
+        let send_outcome = send_stream_request(&build_request, request_body, ttft_timeout).await;
 
-        let response = match response_result {
-            Ok(resp) => {
+        let response = match send_outcome {
+            StreamSendOutcome::Response(resp) => {
                 let connect_time = elapsed_ms_u64(request_start_time);
                 let status = resp.status();
                 let headers = resp.headers().clone();
@@ -125,16 +168,43 @@ where
                     continue;
                 }
             }
-            Err(e) => {
+            StreamSendOutcome::Transport(e) => {
                 let connect_time = request_start_time.elapsed().as_millis();
-                let error = anyhow!("{} connection failed: {}", label, e);
+                let error_msg = format_transport_error(label, &e);
+                let error = anyhow!("{}", error_msg);
                 warn!(
-                    "{} connection failed: {}ms, attempt {}/{}, error: {}",
+                    "{} request failed: {}ms, attempt {}/{}, error: {}",
                     label,
                     connect_time,
                     attempt + 1,
                     max_tries,
-                    e
+                    error_msg
+                );
+                last_error = Some(error);
+
+                if attempt < max_tries - 1 {
+                    let delay_ms = exponential_retry_delay_ms(attempt);
+                    debug!(
+                        "Retrying {} after {}ms (attempt {})",
+                        label,
+                        delay_ms,
+                        attempt + 2
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                }
+                continue;
+            }
+            StreamSendOutcome::TtftTimeout => {
+                let connect_time = request_start_time.elapsed().as_millis();
+                let error_msg = format_ttft_timeout_error(label, ttft_timeout);
+                let error = anyhow!("{}", error_msg);
+                warn!(
+                    "{} request failed: {}ms, attempt {}/{}, error: {}",
+                    label,
+                    connect_time,
+                    attempt + 1,
+                    max_tries,
+                    error_msg
                 );
                 last_error = Some(error);
 
@@ -176,6 +246,16 @@ where
 mod tests {
     use super::*;
     use reqwest::header::HeaderValue;
+
+    #[test]
+    fn format_ttft_timeout_error_includes_timeout_seconds() {
+        let message = format_ttft_timeout_error(
+            "Codex ChatGPT Responses API",
+            Some(std::time::Duration::from_secs(30)),
+        );
+
+        assert!(message.contains("TTFT timeout after 30s"));
+    }
 
     #[test]
     fn retryable_http_statuses_include_rate_limit_and_server_errors() {

--- a/src/crates/ai-adapters/src/lib.rs
+++ b/src/crates/ai-adapters/src/lib.rs
@@ -7,7 +7,10 @@ pub mod stream;
 pub mod tool_call_accumulator;
 pub mod types;
 
-pub use client::{AIClient, StreamOptions, StreamResponse};
+pub use client::{
+    AIClient, StreamOptions, StreamResponse, DEFAULT_STREAM_IDLE_TIMEOUT_SECS,
+    DEFAULT_STREAM_TTFT_TIMEOUT_SECS, REASONING_STREAM_TTFT_TIMEOUT_SECS,
+};
 pub use stream::{UnifiedResponse, UnifiedTokenUsage, UnifiedToolCall};
 pub use types::{
     resolve_request_url, AIConfig, ConnectionTestMessageCode, ConnectionTestResult, GeminiResponse,

--- a/src/crates/ai-adapters/src/providers/anthropic/request.rs
+++ b/src/crates/ai-adapters/src/providers/anthropic/request.rs
@@ -246,12 +246,14 @@ pub(crate) async fn send_stream(
     );
     let inline_think_in_text = client.config.inline_think_in_text;
     let idle_timeout = client.stream_options.idle_timeout;
+    let ttft_timeout = client.stream_options.ttft_timeout;
 
     execute_sse_request(
         "Anthropic Streaming API",
         &url,
         &request_body,
         max_tries,
+        ttft_timeout,
         || apply_headers(client, client.client.post(&url), &url),
         move |response, tx, tx_raw| {
             tokio::spawn(handle_anthropic_stream(

--- a/src/crates/ai-adapters/src/providers/gemini/code_assist.rs
+++ b/src/crates/ai-adapters/src/providers/gemini/code_assist.rs
@@ -171,11 +171,13 @@ pub(crate) async fn send_stream(
     );
 
     let idle_timeout = client.stream_options.idle_timeout;
+    let ttft_timeout = client.stream_options.ttft_timeout;
     execute_sse_request(
         "Gemini Code Assist Streaming API",
         &url,
         &request_body,
         max_tries,
+        ttft_timeout,
         || apply_headers(client, client.client.post(&url)),
         move |response, tx, tx_raw| {
             tokio::spawn(handle_gemini_stream(response, tx, tx_raw, idle_timeout));

--- a/src/crates/ai-adapters/src/providers/gemini/request.rs
+++ b/src/crates/ai-adapters/src/providers/gemini/request.rs
@@ -334,12 +334,14 @@ pub(crate) async fn send_stream(
         extra_body,
     );
     let idle_timeout = client.stream_options.idle_timeout;
+    let ttft_timeout = client.stream_options.ttft_timeout;
 
     execute_sse_request(
         "Gemini Streaming API",
         &url,
         &request_body,
         max_tries,
+        ttft_timeout,
         || apply_headers(client, client.client.post(&url)),
         move |response, tx, tx_raw| {
             tokio::spawn(handle_gemini_stream(response, tx, tx_raw, idle_timeout));

--- a/src/crates/ai-adapters/src/providers/openai/chat.rs
+++ b/src/crates/ai-adapters/src/providers/openai/chat.rs
@@ -88,12 +88,14 @@ pub(crate) async fn send_stream(
     let request_body = build_request_body(client, &url, openai_messages, openai_tools, extra_body);
     let inline_think_in_text = client.config.inline_think_in_text;
     let idle_timeout = client.stream_options.idle_timeout;
+    let ttft_timeout = client.stream_options.ttft_timeout;
 
     execute_sse_request(
         "OpenAI Streaming API",
         &url,
         &request_body,
         max_tries,
+        ttft_timeout,
         || common::apply_headers(client, client.client.post(&url)),
         move |response, tx, tx_raw| {
             tokio::spawn(handle_openai_stream(

--- a/src/crates/ai-adapters/src/providers/openai/codex_chatgpt.rs
+++ b/src/crates/ai-adapters/src/providers/openai/codex_chatgpt.rs
@@ -158,12 +158,14 @@ pub(crate) async fn send_stream(
     let request_body =
         build_request_body(client, instructions, response_input, tools_flat, extra_body);
     let idle_timeout = client.stream_options.idle_timeout;
+    let ttft_timeout = client.stream_options.ttft_timeout;
 
     execute_sse_request(
         "Codex ChatGPT Responses API",
         &url,
         &request_body,
         max_tries,
+        ttft_timeout,
         || common::apply_headers(client, client.client.post(&url)),
         move |response, tx, tx_raw| {
             tokio::spawn(handle_responses_stream(response, tx, tx_raw, idle_timeout));

--- a/src/crates/ai-adapters/src/providers/openai/responses.rs
+++ b/src/crates/ai-adapters/src/providers/openai/responses.rs
@@ -120,12 +120,14 @@ pub(crate) async fn send_stream(
         extra_body,
     );
     let idle_timeout = client.stream_options.idle_timeout;
+    let ttft_timeout = client.stream_options.ttft_timeout;
 
     execute_sse_request(
         "Responses API",
         &url,
         &request_body,
         max_tries,
+        ttft_timeout,
         || common::apply_headers(client, client.client.post(&url)),
         move |response, tx, tx_raw| {
             tokio::spawn(handle_responses_stream(response, tx, tx_raw, idle_timeout));

--- a/src/crates/ai-adapters/src/tool_call_accumulator.rs
+++ b/src/crates/ai-adapters/src/tool_call_accumulator.rs
@@ -83,6 +83,7 @@ pub struct ToolCallDeltaOutcome {
 #[derive(Debug, Clone, Default)]
 pub struct PendingToolCalls {
     pending: BTreeMap<ToolCallStreamKey, PendingToolCall>,
+    strip_write_inline_content: bool,
 }
 
 /// Tools where executing a truncated tool call is **safe and meaningful** —
@@ -90,8 +91,46 @@ pub struct PendingToolCalls {
 /// useful than a hard failure. For everything else (Bash, Edit, Task, ...) we
 /// surface the truncation as an error: a partial shell command or a partial
 /// `old_string`/`new_string` for Edit can change semantics destructively.
-fn is_truncation_safe_to_recover(tool_name: &str) -> bool {
+pub fn is_write_like_tool_name(tool_name: &str) -> bool {
     matches!(tool_name, "Write" | "file_write" | "write_notebook")
+}
+
+fn is_truncation_safe_to_recover(tool_name: &str) -> bool {
+    is_write_like_tool_name(tool_name)
+}
+
+/// Remove inline body fields that PlaintextFollowup Write must not carry in
+/// tool-call JSON. File content is generated in a separate follow-up request.
+pub fn strip_write_inline_content_fields(arguments: &mut Value) {
+    if let Some(object) = arguments.as_object_mut() {
+        object.remove("content");
+        object.remove("contents");
+    }
+}
+
+pub fn write_plaintext_followup_arguments_json(arguments: &Value) -> Option<String> {
+    let file_path = arguments.get("file_path")?;
+    serde_json::to_string(&json!({ "file_path": file_path })).ok()
+}
+
+fn write_plaintext_followup_params_snapshot(raw_arguments: &str) -> Option<String> {
+    let mut arguments = serde_json::from_str::<Value>(raw_arguments).ok()?;
+    strip_write_inline_content_fields(&mut arguments);
+    write_plaintext_followup_arguments_json(&arguments)
+}
+
+fn sanitize_write_plaintext_followup_finalized(
+    tool_name: &str,
+    strip_write_inline_content: bool,
+    raw_arguments: &str,
+    arguments: &mut Value,
+) -> String {
+    if !(strip_write_inline_content && is_write_like_tool_name(tool_name)) {
+        return raw_arguments.to_string();
+    }
+
+    strip_write_inline_content_fields(arguments);
+    write_plaintext_followup_arguments_json(arguments).unwrap_or_else(|| raw_arguments.to_string())
 }
 
 /// Attempt to repair a JSON document that was truncated mid-stream (typically
@@ -222,7 +261,11 @@ impl PendingToolCall {
         self.raw_arguments.push_str(arguments_snapshot);
     }
 
-    pub fn finalize(&mut self, boundary: ToolCallBoundary) -> Option<FinalizedToolCall> {
+    pub fn raw_arguments(&self) -> &str {
+        &self.raw_arguments
+    }
+
+    pub fn finalize(&mut self, boundary: ToolCallBoundary, strip_write_inline_content: bool) -> Option<FinalizedToolCall> {
         if !self.has_pending() {
             return None;
         }
@@ -241,7 +284,7 @@ impl PendingToolCall {
         self.early_detected_emitted = false;
         let parsed_arguments = Self::parse_arguments(&tool_name, &raw_arguments);
 
-        let (arguments, is_error, recovered_from_truncation) = match parsed_arguments {
+        let (mut arguments, is_error, recovered_from_truncation) = match parsed_arguments {
             Ok(value) => (value, false, false),
             Err(parse_err) => {
                 let repaired = repair_truncated_json(&raw_arguments)
@@ -285,6 +328,13 @@ impl PendingToolCall {
             }
         };
 
+        let raw_arguments = sanitize_write_plaintext_followup_finalized(
+            &tool_name,
+            strip_write_inline_content,
+            &raw_arguments,
+            &mut arguments,
+        );
+
         Some(FinalizedToolCall {
             tool_id,
             tool_name,
@@ -297,6 +347,13 @@ impl PendingToolCall {
 }
 
 impl PendingToolCalls {
+    pub fn new(strip_write_inline_content: bool) -> Self {
+        Self {
+            pending: BTreeMap::new(),
+            strip_write_inline_content,
+        }
+    }
+
     pub fn apply_delta(
         &mut self,
         key: ToolCallStreamKey,
@@ -323,7 +380,8 @@ impl PendingToolCalls {
         if let Some(tool_id) = tool_id.filter(|tool_id| !tool_id.is_empty()) {
             let is_new_tool = pending.tool_id() != tool_id;
             if is_new_tool {
-                outcome.finalized_previous = pending.finalize(ToolCallBoundary::NewTool);
+                outcome.finalized_previous =
+                    pending.finalize(ToolCallBoundary::NewTool, self.strip_write_inline_content);
                 pending.start_new(tool_id, tool_name.clone());
             } else {
                 pending.update_tool_name_if_missing(tool_name.clone());
@@ -353,11 +411,22 @@ impl PendingToolCalls {
                 } else {
                     pending.append_arguments(&arguments);
                 }
-                outcome.params_partial = Some(ToolCallParamsChunk {
-                    tool_id: pending.tool_id().to_string(),
-                    tool_name: pending.tool_name().to_string(),
-                    params_chunk: arguments,
-                });
+                let tool_name = pending.tool_name().to_string();
+                let params_chunk = if self.strip_write_inline_content
+                    && is_write_like_tool_name(&tool_name)
+                {
+                    write_plaintext_followup_params_snapshot(pending.raw_arguments())
+                        .unwrap_or_default()
+                } else {
+                    arguments
+                };
+                if !params_chunk.is_empty() {
+                    outcome.params_partial = Some(ToolCallParamsChunk {
+                        tool_id: pending.tool_id().to_string(),
+                        tool_name,
+                        params_chunk,
+                    });
+                }
             }
         }
 
@@ -370,7 +439,7 @@ impl PendingToolCalls {
         boundary: ToolCallBoundary,
     ) -> Option<FinalizedToolCall> {
         let mut pending = self.pending.remove(key)?;
-        pending.finalize(boundary)
+        pending.finalize(boundary, self.strip_write_inline_content)
     }
 
     pub fn finalize_all(&mut self, boundary: ToolCallBoundary) -> Vec<FinalizedToolCall> {
@@ -396,7 +465,7 @@ mod tests {
         pending.append_arguments("{\"a\":1}");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.tool_id, "call_1");
@@ -413,7 +482,7 @@ mod tests {
         pending.append_arguments("{\"a\":");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::StreamEnd)
+            .finalize(ToolCallBoundary::StreamEnd, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!({}));
@@ -427,7 +496,7 @@ mod tests {
         pending.append_arguments("git status");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.raw_arguments, "git status");
@@ -442,7 +511,7 @@ mod tests {
         pending.append_arguments("\"git diff --staged\"");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!("git diff --staged"));
@@ -456,7 +525,7 @@ mod tests {
         pending.append_arguments("{\"args\": \"--since=\\\"2026-05-02\\\" --oneline\"}");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(
@@ -473,7 +542,7 @@ mod tests {
         pending.append_arguments("{\"args\": \"log --oneline -10\"}");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!({"args": "log --oneline -10"}));
@@ -487,7 +556,7 @@ mod tests {
         pending.append_arguments("{\"args\": \"--stat\"}");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!({"args": "--stat"}));
@@ -516,7 +585,7 @@ mod tests {
             pending.append_arguments(raw_arguments);
 
             let finalized = pending
-                .finalize(ToolCallBoundary::FinishReason)
+                .finalize(ToolCallBoundary::FinishReason, false)
                 .expect("finalized tool");
 
             assert_eq!(finalized.arguments, json!({}), "tool={tool_name}");
@@ -533,7 +602,7 @@ mod tests {
         );
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!({}));
@@ -547,7 +616,7 @@ mod tests {
         pending.append_arguments("{\"command\": ");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!({}));
@@ -563,7 +632,7 @@ mod tests {
         );
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!({}));
@@ -577,7 +646,7 @@ mod tests {
         pending.append_arguments("{");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!({}));
@@ -591,7 +660,7 @@ mod tests {
         pending.append_arguments("{\"command\": \"git log --since=\\\"2026-05-02\\\" --on");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!({}));
@@ -605,7 +674,7 @@ mod tests {
         pending.append_arguments("\"git status\"");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!("git status"));
@@ -619,7 +688,7 @@ mod tests {
         pending.append_arguments("```bash\npnpm run lint:web\n```");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!({}));
@@ -633,7 +702,7 @@ mod tests {
         pending.append_arguments("src/main.rs");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!({}));
@@ -647,7 +716,7 @@ mod tests {
         pending.append_arguments("{\"a\":1}}");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.raw_arguments, "{\"a\":1}}");
@@ -662,7 +731,7 @@ mod tests {
         pending.append_arguments("{\"a\":1,\"b\":\"x\"}");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::EndOfAggregation)
+            .finalize(ToolCallBoundary::EndOfAggregation, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments["a"], json!(1));
@@ -677,7 +746,7 @@ mod tests {
         pending.replace_arguments("{\"city\":\"Beijing\"}");
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert_eq!(finalized.arguments, json!({"city": "Beijing"}));
@@ -836,6 +905,76 @@ mod tests {
     // ------------------------------------------------------------------
 
     #[test]
+    fn write_inline_content_is_stripped_when_strip_mode_enabled() {
+        let mut pending = PendingToolCalls::new(true);
+        pending.apply_delta(
+            ToolCallStreamKey::Indexed(0),
+            Some("call_1".to_string()),
+            Some("Write".to_string()),
+            Some(r#"{"file_path":"notes.md","content":"inline body"}"#.to_string()),
+            false,
+        );
+
+        let finalized = pending.finalize_all(ToolCallBoundary::FinishReason);
+        assert_eq!(finalized.len(), 1);
+        assert_eq!(finalized[0].arguments, json!({ "file_path": "notes.md" }));
+        assert_eq!(finalized[0].raw_arguments, r#"{"file_path":"notes.md"}"#);
+    }
+
+    #[test]
+    fn write_params_partial_emits_file_path_only_snapshot_when_strip_mode_enabled() {
+        let mut pending = PendingToolCalls::new(true);
+        pending.apply_delta(
+            ToolCallStreamKey::Indexed(0),
+            Some("call_1".to_string()),
+            Some("Write".to_string()),
+            None,
+            false,
+        );
+
+        let payload = pending.apply_delta(
+            ToolCallStreamKey::Indexed(0),
+            None,
+            None,
+            Some(r#"{"file_path":"notes.md","content":"inline body"}"#.to_string()),
+            false,
+        );
+
+        assert_eq!(
+            payload.params_partial,
+            Some(ToolCallParamsChunk {
+                tool_id: "call_1".to_string(),
+                tool_name: "Write".to_string(),
+                params_chunk: r#"{"file_path":"notes.md"}"#.to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn write_truncated_mid_content_string_is_recovered_without_inline_content_when_strip_enabled(
+    ) {
+        let raw = "{\"file_path\": \"/tmp/report.md\", \"content\": \"# Report\\n\\nA long body that was cut";
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("Write".to_string()));
+        pending.append_arguments(raw);
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason, true)
+            .expect("finalized tool");
+
+        assert!(!finalized.is_error, "Write recovery should succeed");
+        assert!(finalized.recovered_from_truncation);
+        assert_eq!(
+            finalized.arguments,
+            json!({ "file_path": "/tmp/report.md" })
+        );
+        assert_eq!(
+            finalized.raw_arguments,
+            serde_json::to_string(&json!({ "file_path": "/tmp/report.md" })).unwrap()
+        );
+    }
+
+    #[test]
     fn write_truncated_mid_content_string_is_recovered() {
         // Reproduces the deep-research dump: the model hit max_tokens while
         // streaming `content`, so the JSON ends inside the string literal
@@ -846,7 +985,7 @@ mod tests {
         pending.append_arguments(raw);
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert!(!finalized.is_error, "Write recovery should succeed");
@@ -868,7 +1007,7 @@ mod tests {
         pending.append_arguments(raw);
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         assert!(!finalized.is_error);
@@ -887,7 +1026,7 @@ mod tests {
         pending.append_arguments(raw);
 
         let finalized = pending
-            .finalize(ToolCallBoundary::FinishReason)
+            .finalize(ToolCallBoundary::FinishReason, false)
             .expect("finalized tool");
 
         // We never execute a partial shell command.

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -305,6 +305,16 @@ impl ExecutionEngine {
         )
     }
 
+    /// Whether a partial stream recovery should trigger a continuation round
+    /// instead of treating truncated assistant text as the final answer.
+    ///
+    /// User-initiated cancellation is excluded; all other partial recoveries
+    /// (idle timeout, watchdog timeout, mid-stream errors) may continue.
+    fn should_continue_after_partial_response(reason: &str) -> bool {
+        let lower = reason.to_ascii_lowercase();
+        !lower.contains("cancelled")
+    }
+
     /// Detect periodic tool-signature loops in the trailing window.
     ///
     /// Returns `true` when the last `2 * threshold` rounds contain at most
@@ -1713,6 +1723,7 @@ impl ExecutionEngine {
         let mut loop_detected = false;
         let mut loop_recovery_attempts: usize = 0;
         const MAX_LOOP_RECOVERY_ATTEMPTS: usize = 3;
+        const MAX_PARTIAL_CONTINUATION_ATTEMPTS: usize = 3;
         let mut full_compression_count = 0usize;
         let mut compression_failure_count = 0u32;
 
@@ -1722,6 +1733,7 @@ impl ExecutionEngine {
         // Track thinking-only rescue reminders for observability. This counter
         // is not a stop condition.
         let mut thinking_only_rescue_attempts: usize = 0;
+        let mut partial_continuation_attempts: usize = 0;
 
         // Add detailed logging showing the execution context messages.
         debug!(
@@ -2259,7 +2271,9 @@ impl ExecutionEngine {
             // Otherwise, if the round produced any tool_call, we already continue via
             // `has_more_rounds = true`. The interesting case is `has_more_rounds == false`:
             //
-            // - Model emitted user-visible text  -> final answer, end the turn.
+            // - Model emitted user-visible text  -> final answer, end the turn, unless
+            //   the stream was partially recovered (timeout / interruption) in which
+            //   case inject a continuation reminder and keep going.
             // - Model emitted thinking only      -> stalled mid-reasoning. Inject a
             //   system_reminder asking it to either act (call a tool) or finish
             //   (write the answer), and continue.
@@ -2269,11 +2283,58 @@ impl ExecutionEngine {
                 // fall through to next round so the model can respond to the steering
             } else if !round_result.has_more_rounds {
                 if round_result.had_assistant_text {
-                    debug!(
-                        "Model round {} ended with final answer, reason: {:?}",
-                        round_index, round_result.finish_reason
-                    );
-                    break;
+                    if let Some(ref reason) = round_result.partial_recovery_reason {
+                        if Self::should_continue_after_partial_response(reason) {
+                            partial_continuation_attempts += 1;
+                            if partial_continuation_attempts
+                                <= MAX_PARTIAL_CONTINUATION_ATTEMPTS
+                            {
+                                let reminder = format!(
+                                    "<system_reminder>Your previous assistant response was interrupted mid-stream ({reason}). Continue writing from exactly where you stopped. Do not repeat content that was already delivered; pick up seamlessly and complete the answer.</system_reminder>"
+                                );
+                                let user_msg = Message::user(reminder.clone());
+                                messages.push(user_msg.clone());
+                                if let Err(e) = self
+                                    .session_manager
+                                    .add_message(&context.session_id, user_msg)
+                                    .await
+                                {
+                                    warn!(
+                                        "Failed to persist partial continuation reminder: {}",
+                                        e
+                                    );
+                                }
+                                warn!(
+                                    "Partial stream recovery with assistant text; injecting continuation reminder #{}/{}: turn={}, round={}, reason={}",
+                                    partial_continuation_attempts,
+                                    MAX_PARTIAL_CONTINUATION_ATTEMPTS,
+                                    context.dialog_turn_id,
+                                    round_index,
+                                    reason
+                                );
+                                // Continue into the next round so the model can finish.
+                            } else {
+                                warn!(
+                                    "Partial stream continuation attempts exhausted; accepting truncated answer: turn={}, round={}, reason={}",
+                                    context.dialog_turn_id, round_index, reason
+                                );
+                                finalization_reason = Some("partial_truncated");
+                                break;
+                            }
+                        } else {
+                            debug!(
+                                "Model round {} ended with partial answer after cancellation, reason: {:?}",
+                                round_index, round_result.finish_reason
+                            );
+                            break;
+                        }
+                    } else {
+                        debug!(
+                            "Model round {} ended with final answer, reason: {:?}",
+                            round_index, round_result.finish_reason
+                        );
+                        break;
+                    }
                 } else if round_result.had_thinking_content {
                     thinking_only_rescue_attempts += 1;
                     let reminder = "<system_reminder>The previous round produced internal reasoning only — no tool call and no user-visible response. You MUST now either: (1) call the single tool that best advances the user's task, or (2) write your final answer to the user. Do not produce another round of reasoning without taking action.</system_reminder>".to_string();
@@ -2696,6 +2757,26 @@ mod tests {
         let summary = ExecutionEngine::tool_signature_args_summary(args);
 
         assert_eq!(summary, args);
+    }
+
+    #[test]
+    fn partial_continuation_allowed_for_stream_stall_reasons() {
+        assert!(ExecutionEngine::should_continue_after_partial_response(
+            "Stream processor watchdog timeout (no data received for 45 seconds)"
+        ));
+        assert!(ExecutionEngine::should_continue_after_partial_response(
+            "Stream processing error: SSE stream error"
+        ));
+    }
+
+    #[test]
+    fn partial_continuation_skipped_for_user_cancellation() {
+        assert!(!ExecutionEngine::should_continue_after_partial_response(
+            "Stream processing cancelled after partial output"
+        ));
+        assert!(!ExecutionEngine::should_continue_after_partial_response(
+            "Stream processing cancelled"
+        ));
     }
 
     #[test]

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -17,6 +17,7 @@ use crate::agentic::tools::tool_context_runtime;
 use crate::agentic::tools::tool_result_storage;
 use crate::agentic::MessageContent;
 use crate::infrastructure::ai::AIClient;
+use bitfun_ai_adapters::types::ReasoningMode;
 use crate::service::config::types::WriteToolMode;
 use crate::service::config::GlobalConfigManager;
 use crate::util::elapsed_ms_u64;
@@ -41,7 +42,7 @@ pub struct RoundExecutor {
 impl RoundExecutor {
     const MAX_STREAM_ATTEMPTS: usize = 10;
     const RETRY_BASE_DELAY_MS: u64 = 500;
-    const WRITE_CONTENT_STREAM_IDLE_TIMEOUT_SECS: u64 = 60;
+    const WRITE_CONTENT_STREAM_IDLE_TIMEOUT_SECS: u64 = 45;
 
     fn has_user_visible_assistant_text(text: &str) -> bool {
         !text.trim().is_empty()
@@ -160,10 +161,26 @@ impl RoundExecutor {
                 Err(e) => {
                     error!("AI request failed: {}", e);
                     let err_msg = e.to_string();
+                    if Self::is_transient_network_error(&err_msg) && attempt_index < max_attempts - 1
+                    {
+                        let delay_ms = Self::retry_delay_ms(attempt_index);
+                        warn!(
+                            "Retrying AI request after connection failure: session_id={}, round_id={}, attempt={}/{}, delay_ms={}, error={}",
+                            context.session_id,
+                            round_id,
+                            attempt_index + 1,
+                            max_attempts,
+                            delay_ms,
+                            err_msg
+                        );
+                        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                        attempt_index += 1;
+                        continue;
+                    }
                     if Self::is_transient_network_error(&err_msg) {
                         return Err(BitFunError::AIClient(format!(
-                            "AI stream connection retry budget exhausted: {}",
-                            err_msg
+                            "Stream retry budget exhausted after {} attempts: {}",
+                            max_attempts, err_msg
                         )));
                     }
                     return Err(BitFunError::AIClient(err_msg));
@@ -205,6 +222,10 @@ impl RoundExecutor {
                     &cancel_token,
                     StreamProcessOptions {
                         recover_partial_on_cancel: context.recover_partial_on_cancel,
+                        strip_write_inline_content: matches!(
+                            Self::write_tool_mode(&context),
+                            WriteToolMode::PlaintextFollowup
+                        ),
                     },
                 )
                 .await
@@ -566,7 +587,15 @@ impl RoundExecutor {
         // plain text wrapped in <bitfun_contents> tags. This avoids having the
         // model emit large file contents inside JSON tool-call arguments, which
         // is a major source of JSON parse failures.
-        let tool_calls = stream_result.tool_calls.clone();
+        let mut tool_calls = stream_result.tool_calls.clone();
+        if matches!(
+            Self::write_tool_mode(&context),
+            WriteToolMode::PlaintextFollowup
+        ) {
+            FileWriteTool::strip_plaintext_followup_inline_content_from_tool_calls(
+                &mut tool_calls,
+            );
+        }
         let tool_calls = if matches!(
             Self::write_tool_mode(&context),
             WriteToolMode::PlaintextFollowup
@@ -973,117 +1002,31 @@ impl RoundExecutor {
                  5. Do NOT output anything outside the <bitfun_contents> tags — no explanations, no commentary, \
                  no thinking blocks, no markdown fences (```), no extra XML wrapper tags.\n\
                  6. The text between the tags must be EXACTLY what gets written to disk — raw file content only.\n\
-                 7. Do NOT output any tool_call XML, JSON tool invocations, or agent framework syntax inside the tags. \
-                 You are not calling a tool here — you are outputting raw file content.\n\
-                 <bitfun_contents>\n",
+                 7. Do NOT call any tools in this turn. Do NOT output tool_call XML, JSON tool invocations, \
+                 function_call blocks, or agent framework syntax inside or outside the tags. \
+                 You are not calling a tool here — you are outputting raw file content only.\n\
+                 8. Do NOT repeat, summarize, or narrate prior tool calls (Read, Bash, Edit, etc.). Start writing the actual file body immediately.\n\
+                 9. Do NOT output `[called tools:` markers, tool parameter JSON, or `<bitfun_contents>` / `</bitfun_contents>` tags — the opening tag is already provided via prefill.",
                 file_path = file_path
             );
 
-            // Strip tool_calls and tool results from history to prevent weak models
-            // from imitating tool-call format inside the generated file content.
-            let mut content_messages: Vec<AIMessage> = ai_messages
-                .iter()
-                .filter_map(|m| {
-                    if m.role == "tool" {
-                        // Drop tool result messages entirely
-                        None
-                    } else if m.tool_calls.is_some() {
-                        // Replace assistant tool-call messages with a plain-text summary
-                        let names = m
-                            .tool_calls
-                            .as_ref()
-                            .unwrap()
-                            .iter()
-                            .map(|tc| tc.name.as_str())
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        Some(AIMessage::assistant(format!("[called tools: {names}]")))
-                    } else {
-                        Some(m.clone())
-                    }
-                })
-                .collect();
-            // Add an assistant prefill to prime the model to output content directly
-            // inside the tags, reducing the chance of preamble text.
-            content_messages.push(AIMessage::user(content_prompt));
-            content_messages.push(AIMessage::assistant("<bitfun_contents>\n".to_string()));
+            let content_messages =
+                Self::build_write_content_messages(ai_messages, &content_prompt);
+            let write_client = ai_client.with_reasoning_mode(ReasoningMode::Disabled);
 
-            // Send the content-generation request (no tools, pure text output)
-            let full_text = match ai_client.send_message_stream(content_messages, None).await {
-                Ok(response) => {
-                    let mut text = String::new();
-                    let mut stream = response.stream;
-                    let watchdog_timeout =
-                        StreamProcessor::derive_watchdog_timeout(ai_client.stream_idle_timeout())
-                            .unwrap_or_else(|| {
-                                Duration::from_secs(Self::WRITE_CONTENT_STREAM_IDLE_TIMEOUT_SECS)
-                            });
-                    use futures::StreamExt;
-                    loop {
-                        if cancel_token.is_cancelled() {
-                            return Err(BitFunError::Cancelled("Execution cancelled".to_string()));
-                        }
+            let full_text = self
+                .stream_write_tool_content(
+                    &write_client,
+                    content_messages,
+                    &file_path,
+                    &tool_id,
+                    context,
+                    round_id,
+                    cancel_token,
+                )
+                .await?;
 
-                        let chunk = match tokio::time::timeout(watchdog_timeout, stream.next())
-                            .await
-                        {
-                            Ok(Some(chunk)) => chunk,
-                            Ok(None) => break,
-                            Err(_) => {
-                                return Err(BitFunError::Timeout(format!(
-                                    "Write content generation timed out for {} after {} seconds without stream progress",
-                                    file_path,
-                                    watchdog_timeout.as_secs()
-                                )));
-                            }
-                        };
-
-                        match chunk {
-                            Ok(resp) => {
-                                let chunk_text = resp.text.unwrap_or_default();
-                                if !chunk_text.is_empty() {
-                                    text.push_str(&chunk_text);
-
-                                    // Emit streaming ParamsPartial so the UI
-                                    // shows a live content preview
-                                    let params = serde_json::json!({
-                                        "file_path": &file_path,
-                                        "content": &text,
-                                    });
-                                    self.emit_event(
-                                        AgenticEvent::ToolEvent {
-                                            session_id: context.session_id.clone(),
-                                            turn_id: context.dialog_turn_id.clone(),
-                                            round_id: round_id.to_string(),
-                                            tool_event: ToolEventData::ParamsPartial {
-                                                tool_id: tool_id.clone(),
-                                                tool_name: "Write".to_string(),
-                                                params: params.to_string(),
-                                            },
-                                        },
-                                        EventPriority::Normal,
-                                    )
-                                    .await;
-                                }
-                            }
-                            Err(e) => {
-                                error!("Error in Write content generation stream: {}", e);
-                                break;
-                            }
-                        }
-                    }
-                    text
-                }
-                Err(e) => {
-                    error!("Write content generation request failed: {}", e);
-                    return Err(BitFunError::AIClient(format!(
-                        "Write content generation failed for {}: {}",
-                        file_path, e
-                    )));
-                }
-            };
-
-            let content = extract_bitfun_contents(&full_text);
+            let content = extract_bitfun_contents_with_options(&full_text, true);
             if content.is_empty() {
                 warn!(
                     "Write content generation returned empty content for file_path={}",
@@ -1143,6 +1086,155 @@ impl RoundExecutor {
         }
 
         Ok(tool_calls)
+    }
+
+    /// Build the message list for Write content generation.
+    ///
+    /// Reuses the exact conversation prefix that was sent to the model for this
+    /// round so tool results, prior assistant tool-call turns, and other
+    /// context stay aligned (including provider-side prefix/KV reuse). Only
+    /// appends the write-content directive and an assistant prefill.
+    fn build_write_content_messages(
+        ai_messages: &[AIMessage],
+        content_prompt: &str,
+    ) -> Vec<AIMessage> {
+        let mut content_messages = ai_messages.to_vec();
+        content_messages.push(AIMessage::user(content_prompt.to_string()));
+        content_messages.push(AIMessage::assistant("<bitfun_contents>\n".to_string()));
+        content_messages
+    }
+
+    async fn stream_write_tool_content(
+        &self,
+        ai_client: &AIClient,
+        content_messages: Vec<AIMessage>,
+        file_path: &str,
+        tool_id: &str,
+        context: &RoundContext,
+        round_id: &str,
+        cancel_token: &CancellationToken,
+    ) -> BitFunResult<String> {
+        let mut attempt_index = 0usize;
+        loop {
+            if cancel_token.is_cancelled() {
+                return Err(BitFunError::Cancelled("Execution cancelled".to_string()));
+            }
+
+            let stream_response = match ai_client
+                .send_message_stream_with_extra_body(
+                    content_messages.clone(),
+                    None,
+                    ai_client.write_content_generation_extra_body(),
+                )
+                .await
+            {
+                Ok(response) => response,
+                Err(e) => {
+                    let err_msg = e.to_string();
+                    if Self::is_transient_network_error(&err_msg)
+                        && attempt_index < Self::MAX_STREAM_ATTEMPTS - 1
+                    {
+                        let delay_ms = Self::retry_delay_ms(attempt_index);
+                        warn!(
+                            "Retrying Write content generation after transient error: file_path={}, attempt={}/{}, delay_ms={}, error={}",
+                            file_path,
+                            attempt_index + 1,
+                            Self::MAX_STREAM_ATTEMPTS,
+                            delay_ms,
+                            err_msg
+                        );
+                        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                        attempt_index += 1;
+                        continue;
+                    }
+                    error!("Write content generation request failed: {}", err_msg);
+                    return Err(BitFunError::AIClient(format!(
+                        "Write content generation failed for {}: {}",
+                        file_path, err_msg
+                    )));
+                }
+            };
+
+            let mut text = String::new();
+            let mut stream = stream_response.stream;
+            let watchdog_timeout =
+                StreamProcessor::derive_watchdog_timeout(ai_client.stream_idle_timeout())
+                    .unwrap_or_else(|| {
+                        Duration::from_secs(Self::WRITE_CONTENT_STREAM_IDLE_TIMEOUT_SECS)
+                    });
+            use futures::StreamExt;
+            loop {
+                if cancel_token.is_cancelled() {
+                    return Err(BitFunError::Cancelled("Execution cancelled".to_string()));
+                }
+
+                let chunk = match tokio::time::timeout(watchdog_timeout, stream.next()).await {
+                    Ok(Some(chunk)) => chunk,
+                    Ok(None) => return Ok(text),
+                    Err(_) => {
+                        return Err(BitFunError::Timeout(format!(
+                            "Write content generation timed out for {} after {} seconds without stream progress",
+                            file_path,
+                            watchdog_timeout.as_secs()
+                        )));
+                    }
+                };
+
+                match chunk {
+                    Ok(resp) => {
+                        let chunk_text = resp.text.unwrap_or_default();
+                        if chunk_text.is_empty() {
+                            continue;
+                        }
+                        text.push_str(&chunk_text);
+
+                        let preview_content = extract_bitfun_contents_with_options(&text, true);
+                        let params = serde_json::json!({
+                            "file_path": file_path,
+                            "content": &preview_content,
+                        });
+                        self.emit_event(
+                            AgenticEvent::ToolEvent {
+                                session_id: context.session_id.clone(),
+                                turn_id: context.dialog_turn_id.clone(),
+                                round_id: round_id.to_string(),
+                                tool_event: ToolEventData::ParamsPartial {
+                                    tool_id: tool_id.to_string(),
+                                    tool_name: "Write".to_string(),
+                                    params: params.to_string(),
+                                },
+                            },
+                            EventPriority::Normal,
+                        )
+                        .await;
+                    }
+                    Err(e) => {
+                        error!("Error in Write content generation stream: {}", e);
+                        break;
+                    }
+                }
+            }
+
+            if !text.trim().is_empty() {
+                return Ok(text);
+            }
+
+            if attempt_index < Self::MAX_STREAM_ATTEMPTS - 1 {
+                let delay_ms = Self::retry_delay_ms(attempt_index);
+                warn!(
+                    "Retrying Write content generation after empty stream: file_path={}, attempt={}/{}, delay_ms={}",
+                    file_path,
+                    attempt_index + 1,
+                    Self::MAX_STREAM_ATTEMPTS,
+                    delay_ms
+                );
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                attempt_index += 1;
+                continue;
+            }
+
+            return Ok(text);
+        }
     }
 
     async fn write_content_preflight_error(
@@ -1349,24 +1441,31 @@ fn token_details_from_usage(
 
 /// Extract content from `<bitfun_contents>...</bitfun_contents>` tags.
 ///
-/// If the tags are present, returns the text between them (trimmed).
-/// If the tags are not present, returns the full text trimmed (fallback for
-/// models that ignore the tag instruction).
+/// When `prefill_open_tag` is true, the assistant prefill already opened the tag
+/// and streamed tokens are inner file content even if the opening tag is absent.
+#[cfg(test)]
 fn extract_bitfun_contents(text: &str) -> String {
+    extract_bitfun_contents_with_options(text, false)
+}
+
+fn extract_bitfun_contents_with_options(text: &str, prefill_open_tag: bool) -> String {
     const OPEN_TAG: &str = "<bitfun_contents>";
     const CLOSE_TAG: &str = "</bitfun_contents>";
 
-    let raw = if let Some(start) = text.find(OPEN_TAG) {
+    let raw = if let Some(start) = text.rfind(OPEN_TAG) {
         let content_start = start + OPEN_TAG.len();
         if let Some(end) = text[content_start..].find(CLOSE_TAG) {
             &text[content_start..content_start + end]
         } else {
-            // Opening tag found but no closing tag — take everything after the
-            // opening tag (the model may still be streaming or forgot to close).
             &text[content_start..]
         }
+    } else if prefill_open_tag {
+        if let Some(end) = text.find(CLOSE_TAG) {
+            &text[..end]
+        } else {
+            text
+        }
     } else {
-        // No tags at all — return the full text as a fallback
         text
     };
 
@@ -1378,6 +1477,9 @@ fn extract_bitfun_contents(text: &str) -> String {
 fn sanitize_write_content(content: &str) -> String {
     let mut s = content.to_string();
 
+    s = strip_called_tools_artifacts(&s);
+    s = strip_bitfun_content_tags(&s);
+
     // Strip multi-line thinking/reasoning XML blocks (e.g. <think ...>..</think >)
     // These are very common with reasoning models.
     s = strip_thinking_blocks(&s);
@@ -1386,8 +1488,41 @@ fn sanitize_write_content(content: &str) -> String {
     // that some models wrap around file content.
     s = strip_markdown_fences(&s);
 
-    // Trim leading/trailing whitespace left after stripping blocks
     s.trim().to_string()
+}
+
+fn strip_bitfun_content_tags(content: &str) -> String {
+    content
+        .replace("<bitfun_contents>", "")
+        .replace("</bitfun_contents>", "")
+}
+
+fn strip_called_tools_artifacts(content: &str) -> String {
+    let mut result = content.to_string();
+    while let Some(start) = result.find("[called tools:") {
+        let Some(end) = find_called_tools_block_end(&result[start..]) else {
+            break;
+        };
+        result = format!("{}{}", &result[..start], &result[start + end..]);
+    }
+    result
+}
+
+fn find_called_tools_block_end(block: &str) -> Option<usize> {
+    let mut depth = 0usize;
+    for (index, ch) in block.char_indices() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(index + ch.len_utf8());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Strip thinking-style XML blocks from content. Handles multi-line blocks
@@ -1559,7 +1694,10 @@ fn detect_placeholder_patterns(content: &str) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_bitfun_contents, RoundExecutor, StreamProcessor};
+    use super::{
+        extract_bitfun_contents, extract_bitfun_contents_with_options, RoundExecutor,
+        StreamProcessor,
+    };
     use crate::agentic::events::{EventQueue, EventQueueConfig};
     use crate::agentic::execution::types::RoundContext;
     use crate::agentic::tools::ToolRuntimeRestrictions;
@@ -1773,6 +1911,43 @@ mod tests {
     }
 
     #[test]
+    fn write_content_messages_preserve_full_conversation_prefix() {
+        use bitfun_ai_adapters::types::{Message as AIMessage, ToolCall};
+        use crate::util::types::Message as CoreAIMessage;
+
+        let ai_messages = vec![
+            CoreAIMessage::user("Create the benchmark doc".to_string()),
+            CoreAIMessage::assistant_with_tools(vec![ToolCall {
+                id: "write-1".to_string(),
+                name: "Write".to_string(),
+                arguments: serde_json::json!({ "file_path": "notes.md" }),
+                raw_arguments: None,
+            }]),
+            AIMessage {
+                role: "tool".to_string(),
+                content: Some("file body from Read".to_string()),
+                reasoning_content: None,
+                thinking_signature: None,
+                tool_calls: None,
+                tool_call_id: Some("read-1".to_string()),
+                name: Some("Read".to_string()),
+                is_error: None,
+                tool_image_attachments: None,
+            },
+        ];
+
+        let messages =
+            RoundExecutor::build_write_content_messages(&ai_messages, "Write the full file.");
+
+        assert_eq!(messages.len(), 5);
+        assert!(messages[1].tool_calls.is_some());
+        assert_eq!(messages[2].role, "tool");
+        assert_eq!(messages[3].role, "user");
+        assert_eq!(messages[4].role, "assistant");
+        assert_eq!(messages[4].content.as_deref(), Some("<bitfun_contents>\n"));
+    }
+
+    #[test]
     fn extract_bitfun_contents_with_tags() {
         let text =
             "Some preamble\n<bitfun_contents>\nfn main() {}\n</bitfun_contents>\nSome trailing";
@@ -1795,6 +1970,47 @@ mod tests {
     fn extract_bitfun_contents_empty() {
         let text = "<bitfun_contents></bitfun_contents>";
         assert_eq!(extract_bitfun_contents(text), "");
+    }
+
+    #[test]
+    fn extract_bitfun_contents_prefilled_stream_without_open_tag() {
+        let text = "# Title\n\nBody paragraph.\n";
+        assert_eq!(
+            extract_bitfun_contents_with_options(text, true),
+            "# Title\n\nBody paragraph."
+        );
+    }
+
+    #[test]
+    fn extract_bitfun_contents_prefilled_stream_strips_called_tools_preamble() {
+        let text = concat!(
+            "[called tools: Read with params: {\"file_path\":\"docs/plan.md\"}]",
+            "[called tools: Bash with params: {\"command\":\"cat docs/plan.md\"}]",
+            "<bitfun_contents>\n# Plan\n\n## Section\n"
+        );
+        assert_eq!(
+            extract_bitfun_contents_with_options(text, true),
+            "# Plan\n\n## Section"
+        );
+    }
+
+    #[test]
+    fn extract_bitfun_contents_prefilled_stream_uses_last_open_tag() {
+        let text = concat!(
+            "[called tools: Read with params: {\"file_path\":\"a.md\"}]",
+            "<bitfun_contents>\n# Wrong\n",
+            "<bitfun_contents>\n# Correct\n"
+        );
+        assert_eq!(
+            extract_bitfun_contents_with_options(text, true),
+            "# Correct"
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_called_tools_blocks_without_tags() {
+        let text = "[called tools: Write with params: {\"file_path\":\"a.md\"}]fn main() {}";
+        assert_eq!(extract_bitfun_contents(text), "fn main() {}");
     }
 
     // --- Sanitization tests ---

--- a/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -1,3 +1,4 @@
+use bitfun_ai_adapters::tool_call_accumulator::strip_write_inline_content_fields;
 use crate::agentic::tools::file_read_state_runtime::{
     assert_file_not_unexpectedly_modified, file_mutation_timestamp_ms,
     get_stored_file_read_state, local_file_modification_time_ms, read_current_file_content,
@@ -10,6 +11,7 @@ use crate::agentic::tools::file_tool_guidance::{
 use crate::agentic::tools::framework::{
     Tool, ToolPathResolution, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
+use crate::agentic::core::ToolCall;
 use crate::agentic::tools::ToolPathOperation;
 use crate::service::config::types::WriteToolMode;
 use crate::util::errors::{BitFunError, BitFunResult};
@@ -234,6 +236,30 @@ impl FileWriteTool {
         })
     }
 
+    fn model_input_schema(context: Option<&ToolUseContext>) -> Value {
+        match Self::write_tool_mode(context) {
+            WriteToolMode::InlineContent => Self::schema_with_content(),
+            WriteToolMode::PlaintextFollowup => Self::schema_without_content(),
+        }
+    }
+
+    /// PlaintextFollowup exposes only `file_path` to the model. Strip any inline
+    /// content the model hallucinates so the follow-up content generation path
+    /// remains the single source of file body text.
+    pub(crate) fn strip_plaintext_followup_inline_content(arguments: &mut Value) {
+        strip_write_inline_content_fields(arguments);
+    }
+
+    pub(crate) fn strip_plaintext_followup_inline_content_from_tool_calls(
+        tool_calls: &mut [ToolCall],
+    ) {
+        for tool_call in tool_calls.iter_mut() {
+            if tool_call.tool_name == "Write" {
+                Self::strip_plaintext_followup_inline_content(&mut tool_call.arguments);
+            }
+        }
+    }
+
     fn inline_description() -> String {
         r#"Writes a file to the local filesystem.
 
@@ -262,7 +288,7 @@ Usage:
 - Keep writes focused. For existing files, prefer Read + targeted Edit calls. Use Write only when you need to replace the entire file or create a new one.
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
 - Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.
-- Do NOT include the file content in the tool call arguments. Only provide file_path. The system will prompt you separately to output the file content as plain text."#
+- Only provide `file_path` in the tool call. The system generates file content in a separate step."#
             .to_string()
     }
 
@@ -338,6 +364,9 @@ Usage:
         input: &Value,
         context: &ToolUseContext,
     ) -> BitFunResult<Vec<ToolResult>> {
+        // PlaintextFollowup injects `content` in `generate_write_tool_contents` before
+        // pipeline execution. Inline model content is stripped earlier (stream +
+        // round_executor); do not strip again here or system-generated content is lost.
         let file_path = input
             .get("file_path")
             .and_then(|v| v.as_str())
@@ -437,6 +466,7 @@ Usage:
 #[cfg(test)]
 mod tests {
     use super::{FileWriteTool, WRITE_TOOL_MODE_CONTEXT_KEY};
+    use crate::agentic::core::ToolCall;
     use crate::agentic::tools::file_tool_guidance::FILE_TOOL_GUIDANCE_PREFIX;
     use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
     use crate::agentic::tools::ToolRuntimeRestrictions;
@@ -628,6 +658,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn input_schema_for_model_without_context_omits_content() {
+        let tool = FileWriteTool::new();
+
+        let schema = tool.input_schema_for_model().await;
+
+        assert_eq!(schema["required"], serde_json::json!(["file_path"]));
+        assert!(schema["properties"].get("content").is_none());
+    }
+
+    #[test]
+    fn strip_plaintext_followup_inline_content_removes_inline_body_fields() {
+        let mut arguments = json!({
+            "file_path": "notes.md",
+            "content": "inline body",
+            "contents": "legacy body"
+        });
+
+        FileWriteTool::strip_plaintext_followup_inline_content(&mut arguments);
+
+        assert_eq!(arguments, json!({ "file_path": "notes.md" }));
+    }
+
+    #[test]
+    fn strip_plaintext_followup_inline_content_from_tool_calls_keeps_non_write_calls() {
+        let mut tool_calls = vec![
+            ToolCall {
+                tool_id: "write-1".to_string(),
+                tool_name: "Write".to_string(),
+                arguments: json!({
+                    "file_path": "notes.md",
+                    "content": "inline body"
+                }),
+                raw_arguments: None,
+                is_error: false,
+                recovered_from_truncation: false,
+            },
+            ToolCall {
+                tool_id: "read-1".to_string(),
+                tool_name: "Read".to_string(),
+                arguments: json!({ "file_path": "notes.md" }),
+                raw_arguments: None,
+                is_error: false,
+                recovered_from_truncation: false,
+            },
+        ];
+
+        FileWriteTool::strip_plaintext_followup_inline_content_from_tool_calls(&mut tool_calls);
+
+        assert_eq!(
+            tool_calls[0].arguments,
+            json!({ "file_path": "notes.md" })
+        );
+        assert_eq!(
+            tool_calls[1].arguments,
+            json!({ "file_path": "notes.md" })
+        );
+    }
+
+    #[tokio::test]
     async fn inline_mode_schema_requires_content() {
         let tool = FileWriteTool::new();
         let mut custom_data = HashMap::new();
@@ -690,6 +779,27 @@ mod tests {
 
         assert_eq!(written, "new content");
     }
+
+    #[tokio::test]
+    async fn plaintext_followup_executes_system_injected_content() {
+        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create temp workspace");
+
+        let tool = FileWriteTool::new();
+        let body = "system generated body";
+        tool.call(
+            &json!({ "file_path": "generated.txt", "content": body }),
+            &local_context(root.clone()),
+        )
+        .await
+        .expect("plaintext followup should write system-injected content");
+
+        let written =
+            std::fs::read_to_string(root.join("generated.txt")).expect("read generated file");
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert_eq!(written, body);
+    }
 }
 
 #[async_trait]
@@ -720,11 +830,12 @@ impl Tool for FileWriteTool {
         Self::schema_without_content()
     }
 
+    async fn input_schema_for_model(&self) -> Value {
+        Self::model_input_schema(None)
+    }
+
     async fn input_schema_for_model_with_context(&self, context: Option<&ToolUseContext>) -> Value {
-        match Self::write_tool_mode(context) {
-            WriteToolMode::InlineContent => Self::schema_with_content(),
-            WriteToolMode::PlaintextFollowup => self.input_schema(),
-        }
+        Self::model_input_schema(context)
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/core/src/agentic/tools/manifest_resolver.rs
+++ b/src/crates/core/src/agentic/tools/manifest_resolver.rs
@@ -112,6 +112,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn manifest_write_schema_omits_content_in_plaintext_followup_mode() {
+        let mut context = tool_context();
+        context.custom_data.insert(
+            "write_tool_mode".to_string(),
+            json!("plaintext_followup"),
+        );
+
+        let manifest = resolve_tool_manifest(
+            &["Write".to_string()],
+            &AgentToolPolicyOverrides::default(),
+            &context,
+        )
+        .await;
+
+        let write = manifest
+            .tool_definitions
+            .iter()
+            .find(|tool| tool.name == "Write")
+            .expect("Write definition should exist");
+
+        assert_eq!(write.parameters["required"], json!(["file_path"]));
+        assert!(write.parameters["properties"].get("content").is_none());
+        assert!(!write.description.contains("Include the complete file content"));
+    }
+
+    #[tokio::test]
     async fn manifest_omits_get_tool_spec_without_collapsed_tools() {
         let allowed_tools = vec!["Read".to_string(), "Grep".to_string()];
 

--- a/src/crates/core/src/infrastructure/ai/client_factory.rs
+++ b/src/crates/core/src/infrastructure/ai/client_factory.rs
@@ -6,7 +6,7 @@
 //! 3. Invalidate cache when configuration changes
 //! 4. Provide global singleton access
 
-use crate::infrastructure::ai::{build_stream_options, AIClient};
+use crate::infrastructure::ai::{build_stream_options_for_model, AIClient};
 use crate::infrastructure::cli_credentials::{
     self, codex::CodexResolver, gemini::GeminiResolver, CredentialResolver,
 };
@@ -189,7 +189,7 @@ impl AIClientFactory {
             None
         };
 
-        let stream_options = build_stream_options(&global_config.ai);
+        let stream_options = build_stream_options_for_model(&global_config.ai, Some(model_config));
         let client = Arc::new(AIClient::new_with_runtime_options(
             ai_config,
             proxy_config,

--- a/src/crates/core/src/infrastructure/ai/mod.rs
+++ b/src/crates/core/src/infrastructure/ai/mod.rs
@@ -10,13 +10,70 @@ use std::time::Duration;
 pub use bitfun_ai_adapters::providers;
 pub use bitfun_ai_adapters::stream as ai_stream_handlers;
 
-pub use bitfun_ai_adapters::{AIClient, StreamOptions, StreamResponse};
+pub use bitfun_ai_adapters::{
+    AIClient, StreamOptions, StreamResponse, DEFAULT_STREAM_IDLE_TIMEOUT_SECS,
+    DEFAULT_STREAM_TTFT_TIMEOUT_SECS, REASONING_STREAM_TTFT_TIMEOUT_SECS,
+};
 pub use client_factory::{
     get_global_ai_client_factory, initialize_global_ai_client_factory, AIClientFactory,
 };
 
-pub fn build_stream_options(config: &crate::service::config::types::AIConfig) -> StreamOptions {
+use crate::service::config::types::{AIModelConfig, AIConfig, ReasoningMode};
+
+pub fn build_stream_options(config: &AIConfig) -> StreamOptions {
+    build_stream_options_for_model(config, None)
+}
+
+pub fn build_stream_options_for_model(
+    config: &AIConfig,
+    model_config: Option<&AIModelConfig>,
+) -> StreamOptions {
+    let idle_timeout = config
+        .stream_idle_timeout_secs
+        .map(Duration::from_secs);
+
+    let base_ttft_secs = config
+        .stream_ttft_timeout_secs
+        .or(Some(DEFAULT_STREAM_TTFT_TIMEOUT_SECS));
+
+    let ttft_secs = match (base_ttft_secs, model_config) {
+        (Some(secs), Some(model))
+            if matches!(
+                model.effective_reasoning_mode(),
+                ReasoningMode::Enabled | ReasoningMode::Adaptive
+            ) =>
+        {
+            Some(secs.max(REASONING_STREAM_TTFT_TIMEOUT_SECS))
+        }
+        (secs, _) => secs,
+    };
+
     StreamOptions {
-        idle_timeout: config.stream_idle_timeout_secs.map(Duration::from_secs),
+        idle_timeout,
+        ttft_timeout: ttft_secs.map(Duration::from_secs),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::config::types::AIModelConfig;
+
+    #[test]
+    fn reasoning_models_use_extended_ttft_timeout() {
+        let config = AIConfig::default();
+        let mut model = AIModelConfig::default();
+        model.reasoning_mode = Some(ReasoningMode::Enabled);
+
+        let options = build_stream_options_for_model(&config, Some(&model));
+
+        assert_eq!(
+            options.ttft_timeout,
+            Some(Duration::from_secs(REASONING_STREAM_TTFT_TIMEOUT_SECS))
+        );
+        assert_eq!(
+            options.idle_timeout,
+            Some(Duration::from_secs(DEFAULT_STREAM_IDLE_TIMEOUT_SECS))
+        );
     }
 }

--- a/src/crates/core/src/service/config/providers.rs
+++ b/src/crates/core/src/service/config/providers.rs
@@ -47,6 +47,14 @@ impl ConfigProvider for AIConfigProvider {
                 }
             }
 
+            if let Some(stream_ttft_timeout_secs) = ai_config.stream_ttft_timeout_secs {
+                if stream_ttft_timeout_secs == 0 {
+                    return Err(BitFunError::validation(
+                        "AI stream_ttft_timeout_secs must be greater than 0".to_string(),
+                    ));
+                }
+            }
+
             for (index, model) in ai_config.models.iter().enumerate() {
                 if model.name.trim().is_empty() {
                     return Err(BitFunError::validation(format!(

--- a/src/crates/core/src/service/config/types.rs
+++ b/src/crates/core/src/service/config/types.rs
@@ -606,6 +606,11 @@ pub struct AIConfig {
     #[serde(default = "default_stream_idle_timeout")]
     pub stream_idle_timeout_secs: Option<u64>,
 
+    /// Time-to-first-token timeout in seconds while opening a streaming request;
+    /// `None` means wait indefinitely.
+    #[serde(default = "default_stream_ttft_timeout")]
+    pub stream_ttft_timeout_secs: Option<u64>,
+
     /// Tool execution timeout in seconds; `None` means wait indefinitely.
     #[serde(default = "default_tool_execution_timeout")]
     pub tool_execution_timeout_secs: Option<u64>,
@@ -752,9 +757,14 @@ fn default_true() -> bool {
     true
 }
 
-/// Default is no timeout (wait forever).
+/// Default streaming idle timeout between chunks.
 fn default_stream_idle_timeout() -> Option<u64> {
-    None
+    Some(45)
+}
+
+/// Default time-to-first-token timeout while opening a stream.
+fn default_stream_ttft_timeout() -> Option<u64> {
+    Some(30)
 }
 
 /// Default is no timeout (wait forever).
@@ -1580,6 +1590,7 @@ impl Default for AIConfig {
             subagent_max_concurrency: default_subagent_max_concurrency(),
             proxy: ProxyConfig::default(),
             stream_idle_timeout_secs: default_stream_idle_timeout(),
+            stream_ttft_timeout_secs: default_stream_ttft_timeout(),
             tool_execution_timeout_secs: default_tool_execution_timeout(),
             tool_confirmation_timeout_secs: default_tool_confirmation_timeout(),
             skip_tool_confirmation: true,
@@ -2020,10 +2031,11 @@ mod tests {
     }
 
     #[test]
-    fn default_ai_config_uses_no_stream_idle_timeout() {
+    fn default_ai_config_uses_stream_timeouts() {
         let config = AIConfig::default();
 
-        assert_eq!(config.stream_idle_timeout_secs, None);
+        assert_eq!(config.stream_idle_timeout_secs, Some(45));
+        assert_eq!(config.stream_ttft_timeout_secs, Some(30));
         assert_eq!(config.subagent_max_concurrency, 5);
         let review_team = config
             .review_teams
@@ -2039,7 +2051,7 @@ mod tests {
     }
 
     #[test]
-    fn deserializes_missing_stream_idle_timeout_as_none() {
+    fn deserializes_missing_stream_idle_timeout_as_default() {
         let config: AIConfig = serde_json::from_value(serde_json::json!({
             "models": [],
             "agent_models": {},
@@ -2054,7 +2066,8 @@ mod tests {
         }))
         .expect("config without stream_idle_timeout_secs should deserialize");
 
-        assert_eq!(config.stream_idle_timeout_secs, None);
+        assert_eq!(config.stream_idle_timeout_secs, Some(45));
+        assert_eq!(config.stream_ttft_timeout_secs, Some(30));
         assert_eq!(config.subagent_max_concurrency, 5);
         assert!(config.review_teams.contains_key("default"));
     }

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -310,7 +310,8 @@ const AIModelConfig: React.FC = () => {
     password: ''
   });
   const [streamIdleTimeoutInput, setStreamIdleTimeoutInput] = useState('');
-  const [isStreamIdleTimeoutSaving, setIsStreamIdleTimeoutSaving] = useState(false);
+  const [streamTtftTimeoutInput, setStreamTtftTimeoutInput] = useState('');
+  const [isStreamTimeoutSaving, setIsStreamTimeoutSaving] = useState(false);
   const [isProxySaving, setIsProxySaving] = useState(false);
   const [remoteModelOptions, setRemoteModelOptions] = useState<RemoteModelOption[]>([]);
   const [isFetchingRemoteModels, setIsFetchingRemoteModels] = useState(false);
@@ -417,7 +418,13 @@ const AIModelConfig: React.FC = () => {
     () => parseOptionalPositiveIntegerInput(streamIdleTimeoutInput),
     [streamIdleTimeoutInput]
   );
+  const parsedStreamTtftTimeout = useMemo(
+    () => parseOptionalPositiveIntegerInput(streamTtftTimeoutInput),
+    [streamTtftTimeoutInput]
+  );
   const isStreamIdleTimeoutInvalid = parsedStreamIdleTimeout === undefined;
+  const isStreamTtftTimeoutInvalid = parsedStreamTtftTimeout === undefined;
+  const isStreamTimeoutInvalid = isStreamIdleTimeoutInvalid || isStreamTtftTimeoutInvalid;
 
   const getCustomRequestBodyTrimHint = useCallback((provider?: string): string => {
     switch (provider) {
@@ -442,10 +449,11 @@ const AIModelConfig: React.FC = () => {
   
   const loadConfig = useCallback(async () => {
     try {
-      const [models, proxy, streamIdleTimeoutSecs] = await Promise.all([
+      const [models, proxy, streamIdleTimeoutSecs, streamTtftTimeoutSecs] = await Promise.all([
         configManager.getConfig<AIModelConfigType[]>('ai.models'),
         configManager.getConfig<ProxyConfig>('ai.proxy'),
         configManager.getConfig<number | null>('ai.stream_idle_timeout_secs'),
+        configManager.getConfig<number | null>('ai.stream_ttft_timeout_secs'),
       ]);
       setAiModels(models);
       if (proxy) {
@@ -453,6 +461,9 @@ const AIModelConfig: React.FC = () => {
       }
       setStreamIdleTimeoutInput(
         streamIdleTimeoutSecs != null ? String(streamIdleTimeoutSecs) : ''
+      );
+      setStreamTtftTimeoutInput(
+        streamTtftTimeoutSecs != null ? String(streamTtftTimeoutSecs) : ''
       );
     } catch (error) {
       log.error('Failed to load AI config', error);
@@ -1272,27 +1283,36 @@ const AIModelConfig: React.FC = () => {
     }
   };
 
-  const handleSaveStreamIdleTimeout = async () => {
-    if (isStreamIdleTimeoutInvalid) {
+  const handleSaveStreamTimeouts = async () => {
+    if (isStreamTimeoutInvalid) {
       notification.warning(t('streamIdleTimeout.invalid'));
       return;
     }
 
-    setIsStreamIdleTimeoutSaving(true);
+    setIsStreamTimeoutSaving(true);
     try {
-      await configManager.setConfig(
-        'ai.stream_idle_timeout_secs',
-        parsedStreamIdleTimeout ?? null
-      );
+      await Promise.all([
+        configManager.setConfig(
+          'ai.stream_idle_timeout_secs',
+          parsedStreamIdleTimeout ?? null
+        ),
+        configManager.setConfig(
+          'ai.stream_ttft_timeout_secs',
+          parsedStreamTtftTimeout ?? null
+        ),
+      ]);
       setStreamIdleTimeoutInput(
         parsedStreamIdleTimeout != null ? String(parsedStreamIdleTimeout) : ''
       );
+      setStreamTtftTimeoutInput(
+        parsedStreamTtftTimeout != null ? String(parsedStreamTtftTimeout) : ''
+      );
       notification.success(t('streamIdleTimeout.saveSuccess'));
     } catch (error) {
-      log.error('Failed to save stream idle timeout', error);
+      log.error('Failed to save stream timeouts', error);
       notification.error(t('messages.saveFailed'));
     } finally {
-      setIsStreamIdleTimeoutSaving(false);
+      setIsStreamTimeoutSaving(false);
     }
   };
 
@@ -2504,15 +2524,15 @@ const AIModelConfig: React.FC = () => {
 
         <ConfigPageSection
           title={t('streamIdleTimeout.title')}
-          description={t('streamIdleTimeout.hint')}
+          description={`${t('streamTtftTimeout.hint')} ${t('streamIdleTimeout.hint')}`}
           extra={(
             <Button
               variant="primary"
               size="small"
-              onClick={handleSaveStreamIdleTimeout}
-              disabled={isStreamIdleTimeoutSaving || isStreamIdleTimeoutInvalid}
+              onClick={handleSaveStreamTimeouts}
+              disabled={isStreamTimeoutSaving || isStreamTimeoutInvalid}
             >
-              {isStreamIdleTimeoutSaving ? (
+              {isStreamTimeoutSaving ? (
                 <Loader size={16} className="spinning" />
               ) : (
                 t('streamIdleTimeout.save')
@@ -2520,6 +2540,17 @@ const AIModelConfig: React.FC = () => {
             </Button>
           )}
         >
+          <ConfigPageRow
+            label={t('streamTtftTimeout.label')}
+            align="center"
+          >
+            <Input
+              value={streamTtftTimeoutInput}
+              onChange={(e) => setStreamTtftTimeoutInput(e.target.value)}
+              placeholder={t('streamTtftTimeout.placeholder')}
+              inputSize="small"
+            />
+          </ConfigPageRow>
           <ConfigPageRow
             label={t('streamIdleTimeout.label')}
             align="center"

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -191,6 +191,7 @@ export interface AIConfig {
   auto_save_conversations: boolean;
   conversation_history_limit: number;
   stream_idle_timeout_secs?: number | null;
+  stream_ttft_timeout_secs?: number | null;
   tool_execution_timeout_secs?: number | null;
   tool_confirmation_timeout_secs?: number | null;
   skip_tool_confirmation?: boolean;

--- a/src/web-ui/src/locales/en-US/settings/ai-model.json
+++ b/src/web-ui/src/locales/en-US/settings/ai-model.json
@@ -220,11 +220,20 @@
   "streamIdleTimeout": {
     "title": "Streaming Timeout",
     "label": "Idle Timeout (seconds)",
-    "hint": "Global idle timeout between streamed chunks. Leave empty to wait indefinitely.",
+    "hint": "Global idle timeout between streamed chunks after the stream starts. Leave empty to wait indefinitely.",
     "placeholder": "Leave empty for no timeout",
     "invalid": "Enter a positive integer in seconds, or leave this field empty.",
     "save": "Save Streaming Timeout",
     "saveSuccess": "Streaming timeout saved"
+  },
+  "streamTtftTimeout": {
+    "title": "First Token Timeout",
+    "label": "TTFT Timeout (seconds)",
+    "hint": "Maximum wait time for the model to start streaming after a request is sent. Leave empty to wait indefinitely.",
+    "placeholder": "Leave empty for no timeout",
+    "invalid": "Enter a positive integer in seconds, or leave this field empty.",
+    "save": "Save First Token Timeout",
+    "saveSuccess": "First token timeout saved"
   },
   "capabilities": {
     "text_chat": "Chat",

--- a/src/web-ui/src/locales/zh-CN/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-CN/settings/ai-model.json
@@ -219,12 +219,21 @@
   },
   "streamIdleTimeout": {
     "title": "流式超时",
-    "label": "空闲超时（秒）",
-    "hint": "全局控制流式响应在两次 chunk 之间的最大等待时间。留空表示无限等待。",
+    "label": "Chunk 空闲超时（秒）",
+    "hint": "流式响应开始后，两次 chunk 之间的最大等待时间。留空表示无限等待。",
     "placeholder": "留空表示不设超时",
     "invalid": "请输入正整数秒数，或留空。",
     "save": "保存流式超时",
     "saveSuccess": "流式超时已保存"
+  },
+  "streamTtftTimeout": {
+    "title": "首 Token 超时",
+    "label": "TTFT 超时（秒）",
+    "hint": "请求发出后，等待模型开始流式输出的最长时间。留空表示无限等待。",
+    "placeholder": "留空表示不设超时",
+    "invalid": "请输入正整数秒数，或留空。",
+    "save": "保存首 Token 超时",
+    "saveSuccess": "首 Token 超时已保存"
   },
   "capabilities": {
     "text_chat": "对话",

--- a/src/web-ui/src/locales/zh-TW/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-TW/settings/ai-model.json
@@ -219,12 +219,21 @@
   },
   "streamIdleTimeout": {
     "title": "流式超時",
-    "label": "空閒超時（秒）",
-    "hint": "全局控制流式響應在兩次 chunk 之間的最大等待時間。留空表示無限等待。",
+    "label": "Chunk 空閒超時（秒）",
+    "hint": "流式響應開始後，兩次 chunk 之間的最大等待時間。留空表示無限等待。",
     "placeholder": "留空表示不設超時",
     "invalid": "請輸入正整數秒數，或留空。",
     "save": "保存流式超時",
     "saveSuccess": "流式超時已保存"
+  },
+  "streamTtftTimeout": {
+    "title": "首 Token 超時",
+    "label": "TTFT 超時（秒）",
+    "hint": "請求發出後，等待模型開始流式輸出的最長時間。留空表示無限等待。",
+    "placeholder": "留空表示不設超時",
+    "invalid": "請輸入正整數秒數，或留空。",
+    "save": "保存首 Token 超時",
+    "saveSuccess": "首 Token 超時已保存"
   },
   "capabilities": {
     "text_chat": "對話",


### PR DESCRIPTION
## Summary
- Add configurable stream TTFT (time-to-first-token) timeout with UI setting, per-model reasoning overrides, and provider-wide SSE request handling.
- Improve PlaintextFollowup Write reliability by stripping inline `content` during streaming, tightening tool schemas/manifests, and hardening follow-up content generation across OpenAI, Anthropic, and Gemini providers.
- Reduce stream watchdog grace and retry backoff caps to fail faster on stalled or rate-limited connections.

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo test -p bitfun-agent-stream -p bitfun-ai-adapters -p bitfun-core`
- [x] `pnpm run lint:web && pnpm run type-check:web`
- [ ] Manual: configure TTFT timeout in AI model settings and verify slow providers fail with a clear TTFT error
- [ ] Manual: run agent Write in PlaintextFollowup mode and confirm file content is generated in the follow-up step without inline tool-call body leakage