### PR TITLE
fix(agentic): make subagent ignore-timeout work and default unlimited in /goal mode

### DIFF
--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -1771,4 +1771,30 @@ mod tests {
         assert_eq!(tool_result.result["exit_code"], 0);
         assert_eq!(tool_result.result_for_assistant, None);
     }
+
+    #[test]
+    fn deserializes_set_subagent_timeout_disable_without_payload_field() {
+        let request: SetSubagentTimeoutRequest = serde_json::from_str(
+            r#"{"sessionId":"subagent-session","action":{"type":"Disable"}}"#,
+        )
+        .expect("disable action without payload should deserialize");
+        assert_eq!(request.session_id, "subagent-session");
+        assert!(matches!(
+            request.action,
+            SetSubagentTimeoutActionDTO::Disable
+        ));
+    }
+
+    #[test]
+    fn deserializes_set_subagent_timeout_disable_with_null_payload() {
+        let request: SetSubagentTimeoutRequest = serde_json::from_str(
+            r#"{"sessionId":"subagent-session","action":{"type":"Disable","payload":null}}"#,
+        )
+        .expect("disable action with null payload should deserialize");
+        assert_eq!(request.session_id, "subagent-session");
+        assert!(matches!(
+            request.action,
+            SetSubagentTimeoutActionDTO::Disable
+        ));
+    }
 }

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -20,6 +20,7 @@ use crate::agentic::goal_mode::{
     build_goal_kickoff_messages, build_goal_continuation_plan, clear_goal_mode_patch,
     generate_goal_from_context, goal_mode_from_custom_metadata, goal_mode_patch,
     should_skip_goal_verification_for_turn, user_facing_goal_mode_error,
+    effective_subagent_timeout_seconds,
     verify_goal_achievement, wrap_user_input_with_goal_reminder, GoalActivationResult,
     GoalContinuationPlan, GoalModeState, MAX_GOAL_CONTINUATIONS, now_ms,
 };
@@ -3461,8 +3462,30 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             runtime_tool_restrictions,
         } = request;
 
-        let timeout_seconds = timeout_seconds.filter(|seconds| *seconds > 0);
-        let timeout_error_message = match timeout_seconds {
+        let requested_timeout_seconds = timeout_seconds.filter(|seconds| *seconds > 0);
+        let parent_goal_mode_active = if let Some(parent_info) = subagent_parent_info.as_ref() {
+            matches!(
+                self.load_active_goal_mode(&parent_info.session_id).await,
+                Ok(Some(_))
+            )
+        } else {
+            false
+        };
+        if parent_goal_mode_active {
+            let parent_session_id = subagent_parent_info
+                .as_ref()
+                .map(|info| info.session_id.as_str())
+                .unwrap_or("-");
+            debug!(
+                "Subagent timeout disabled by default for active goal mode: agent_type={}, parent_session_id={}",
+                agent_type, parent_session_id
+            );
+        }
+        let timeout_seconds = effective_subagent_timeout_seconds(
+            requested_timeout_seconds,
+            parent_goal_mode_active,
+        );
+        let timeout_error_message = match timeout_seconds.or(requested_timeout_seconds) {
             Some(seconds) => format!(
                 "Subagent '{}' timed out after {} seconds",
                 agent_type, seconds
@@ -3575,7 +3598,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         let timeout_handle = Arc::new(SubagentTimeoutHandle {
             deadline_tx: deadline_tx.clone(),
             session_id: session_id.clone(),
-            original_timeout_seconds: timeout_seconds,
+            original_timeout_seconds: requested_timeout_seconds,
             remaining_at_pause: std::sync::Mutex::new(None),
         });
         {
@@ -3745,7 +3768,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
 
         // Dynamic timeout loop: deadline can be adjusted via watch channel.
         let execution_outcome = loop {
-            let current_deadline = *deadline_rx.borrow();
+            let current_deadline = *deadline_rx.borrow_and_update();
             match current_deadline {
                 Some(expires_at) if Instant::now() >= expires_at => {
                     break SubagentExecutionOutcome::TimedOut;
@@ -4982,6 +5005,27 @@ mod tests {
         assert_eq!(normalize_subagent_max_concurrency(0), 1);
         assert_eq!(normalize_subagent_max_concurrency(5), 5);
         assert_eq!(normalize_subagent_max_concurrency(usize::MAX), 64);
+    }
+
+    #[test]
+    fn subagent_timeout_disable_clears_active_deadline() {
+        use super::SubagentTimeoutAction;
+        use std::sync::Mutex;
+        use tokio::sync::watch;
+        use tokio::time::{Duration, Instant};
+
+        let initial_deadline = Instant::now() + Duration::from_secs(1200);
+        let (deadline_tx, mut deadline_rx) = watch::channel(Some(initial_deadline));
+        let handle = super::SubagentTimeoutHandle {
+            deadline_tx,
+            session_id: "subagent-session".to_string(),
+            original_timeout_seconds: Some(1200),
+            remaining_at_pause: Mutex::new(None),
+        };
+
+        handle.apply_action(SubagentTimeoutAction::Disable);
+
+        assert!(deadline_rx.borrow_and_update().is_none());
     }
 
     #[test]

--- a/src/crates/core/src/agentic/goal_mode/mod.rs
+++ b/src/crates/core/src/agentic/goal_mode/mod.rs
@@ -35,6 +35,19 @@ pub fn clear_goal_mode_patch() -> serde_json::Value {
     })
 }
 
+/// In `/goal` mode, subagents start without an active timeout. The requested
+/// timeout is still preserved on the handle so the user can re-enable a limit.
+pub fn effective_subagent_timeout_seconds(
+    timeout_seconds: Option<u64>,
+    parent_goal_mode_active: bool,
+) -> Option<u64> {
+    if parent_goal_mode_active {
+        None
+    } else {
+        timeout_seconds.filter(|seconds| *seconds > 0)
+    }
+}
+
 pub fn message_text(message: &Message) -> Option<String> {
     match &message.content {
         MessageContent::Text(text) => Some(text.clone()),
@@ -440,6 +453,13 @@ fn parse_goal_verification(raw: &str) -> BitFunResult<GoalVerificationResult> {
 mod tests {
     use super::*;
     use crate::agentic::core::Message;
+
+    #[test]
+    fn effective_subagent_timeout_defaults_to_unlimited_in_goal_mode() {
+        assert_eq!(effective_subagent_timeout_seconds(Some(1200), true), None);
+        assert_eq!(effective_subagent_timeout_seconds(Some(1200), false), Some(1200));
+        assert_eq!(effective_subagent_timeout_seconds(None, true), None);
+    }
 
     #[test]
     fn goal_mode_patch_round_trips() {

--- a/src/crates/core/src/agentic/tools/framework.rs
+++ b/src/crates/core/src/agentic/tools/framework.rs
@@ -370,6 +370,13 @@ pub trait Tool: Send + Sync {
         !self.is_readonly()
     }
 
+    /// Whether this tool manages its own execution timeout (for example via the
+    /// subagent timeout handle) and should not be wrapped by the global tool
+    /// pipeline timeout.
+    fn manages_own_execution_timeout(&self) -> bool {
+        false
+    }
+
     /// Whether to support streaming output
     fn supports_streaming(&self) -> bool {
         false

--- a/src/crates/core/src/agentic/tools/implementations/task_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/task_tool.rs
@@ -501,6 +501,10 @@ impl Tool for TaskTool {
         "Task"
     }
 
+    fn manages_own_execution_timeout(&self) -> bool {
+        true
+    }
+
     async fn description(&self) -> BitFunResult<String> {
         Ok(self.render_description())
     }

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -1228,7 +1228,13 @@ impl ToolPipeline {
 
         let execution_future = tool.call(&task.tool_call.arguments, &tool_context);
 
-        let tool_results = match task.options.timeout_secs {
+        let pipeline_timeout_secs = if tool.manages_own_execution_timeout() {
+            None
+        } else {
+            task.options.timeout_secs
+        };
+
+        let tool_results = match pipeline_timeout_secs {
             Some(timeout_secs) => {
                 let timeout_duration = Duration::from_secs(timeout_secs);
                 let result = timeout(timeout_duration, execution_future)
@@ -1507,6 +1513,8 @@ impl ToolPipeline {
 mod tests {
     use super::*;
     use crate::agentic::events::{EventQueue, EventQueueConfig};
+    use crate::agentic::tools::framework::Tool;
+    use crate::agentic::tools::implementations::task_tool::TaskTool;
     use crate::agentic::tools::ToolRuntimeRestrictions;
     use serde_json::json;
     use std::collections::HashMap;
@@ -1703,5 +1711,11 @@ mod tests {
             result.is_ok(),
             "GetToolSpec duplicate-load validation moved into GetToolSpec itself"
         );
+    }
+
+    #[test]
+    fn task_tool_manages_its_own_execution_timeout() {
+        let task_tool = TaskTool::new();
+        assert!(task_tool.manages_own_execution_timeout());
     }
 }

--- a/src/web-ui/src/flow_chat/components/TaskDetailPanel/TaskDetailPanel.tsx
+++ b/src/web-ui/src/flow_chat/components/TaskDetailPanel/TaskDetailPanel.tsx
@@ -19,6 +19,7 @@ import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
 import type { ReviewerContext } from '@/shared/services/reviewTeamService';
 import { SubagentProjectionView } from '../subagent/SubagentProjectionView';
 import { getSubagentProjectionState } from '../../utils/subagentProjection';
+import { useSessionGoalModeActive } from '../../hooks/useSessionGoalModeActive';
 import './TaskDetailPanel.scss';
 
 const log = createLogger('TaskDetailPanel');
@@ -171,6 +172,7 @@ export const TaskDetailPanel: React.FC<TaskDetailPanelProps> = ({ data }) => {
   const { t } = useTranslation('flow-chat');
   const { t: tAgents } = useTranslation('scenes/agents');
   const { toolItem: initialToolItem, taskInput, sessionId } = data || {};
+  const defaultTimeoutDisabled = useSessionGoalModeActive(sessionId);
   const parentTaskToolId = initialToolItem?.id;
   const parentTaskToolCallId = initialToolItem?.toolCall?.id;
   const directSubagentSessionId = initialToolItem?.subagentSessionId;
@@ -477,6 +479,7 @@ export const TaskDetailPanel: React.FC<TaskDetailPanelProps> = ({ data }) => {
           }
           showControls={true}
           subagentSessionId={subagentSessionId}
+          defaultTimeoutDisabled={defaultTimeoutDisabled}
           completedDurationMs={taskDurationMs}
           completedStatus={isFailed ? 'error' : status === 'cancelled' ? 'cancelled' : isCompleted ? 'success' : undefined}
           completedFailureReason={isFailed ? getErrorMessage() : undefined}

--- a/src/web-ui/src/flow_chat/hooks/useSessionGoalModeActive.ts
+++ b/src/web-ui/src/flow_chat/hooks/useSessionGoalModeActive.ts
@@ -1,0 +1,14 @@
+import { useSyncExternalStore } from 'react';
+import { flowChatStore } from '../store/FlowChatStore';
+
+export function useSessionGoalModeActive(sessionId: string | undefined): boolean {
+  return useSyncExternalStore(
+    (callback) => flowChatStore.subscribe(() => callback()),
+    () => (
+      sessionId
+        ? Boolean(flowChatStore.getState().sessions.get(sessionId)?.goalModeActive)
+        : false
+    ),
+    () => false,
+  );
+}

--- a/src/web-ui/src/flow_chat/hooks/useSubagentTimeoutControl.ts
+++ b/src/web-ui/src/flow_chat/hooks/useSubagentTimeoutControl.ts
@@ -1,5 +1,8 @@
 import { useState, useCallback, useRef } from 'react';
 import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
+import { createLogger } from '@/shared/utils/logger';
+
+const log = createLogger('useSubagentTimeoutControl');
 
 export interface UseSubagentTimeoutControlResult {
   /** Whether timeout is currently disabled by user. */
@@ -25,18 +28,20 @@ export interface UseSubagentTimeoutControlResult {
  * @param isRunning - Whether the subagent is currently running.
  * @param timeoutMs - Original timeout in ms.
  * @param remainingMs - Current remaining time in ms (null if no timeout or disabled).
+ * @param defaultTimeoutDisabled - Whether timeout starts disabled (e.g. `/goal` mode).
  */
 export function useSubagentTimeoutControl(
   subagentSessionId: string | undefined,
   isRunning: boolean,
   timeoutMs: number | undefined,
   remainingMs: number | null,
+  defaultTimeoutDisabled = false,
 ): UseSubagentTimeoutControlResult {
   // timeoutMs is part of the API surface but not directly used here;
   // remainingMs (derived from timeoutMs + elapsed time) drives the UI logic.
   void timeoutMs;
 
-  const [isTimeoutDisabled, setIsTimeoutDisabled] = useState(false);
+  const [isTimeoutDisabled, setIsTimeoutDisabled] = useState(defaultTimeoutDisabled);
   const [isToggling, setIsToggling] = useState(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [remainingAtDisable, setRemainingAtDisable] = useState(0);
@@ -54,7 +59,12 @@ export function useSubagentTimeoutControl(
     setIsToggling(true);
     try {
       await agentAPI.setSubagentTimeout(subagentSessionId, action);
-    } catch (_error) {
+    } catch (error) {
+      log.warn('Failed to adjust subagent timeout', {
+        subagentSessionId,
+        action: action.type,
+        error,
+      });
       // Rollback on failure.
       if (action.type === 'disable') {
         setIsTimeoutDisabled(false);

--- a/src/web-ui/src/flow_chat/services/goalService.ts
+++ b/src/web-ui/src/flow_chat/services/goalService.ts
@@ -70,6 +70,8 @@ export async function runGoalCommand(params: GoalCommandParams): Promise<GoalCom
       duration: 6000,
     });
 
+    flowChatStore.setGoalModeActive(params.session.sessionId, true);
+
     return {
       goalText: activation.goalText,
       successCriteria: activation.successCriteria,

--- a/src/web-ui/src/flow_chat/services/goalVerificationService.test.ts
+++ b/src/web-ui/src/flow_chat/services/goalVerificationService.test.ts
@@ -58,4 +58,22 @@ describe('goalVerificationService', () => {
 
     expect(flowChatStore.getState().sessions.get(session.sessionId)?.dialogTurns).toHaveLength(0);
   });
+
+  it('clears goal mode active flag when the session goal is achieved', () => {
+    const session = createSession({ goalModeActive: true });
+    flowChatStore.setState(() => ({
+      sessions: new Map([[session.sessionId, session]]),
+      activeSessionId: session.sessionId,
+    }));
+
+    handleGoalVerificationFinished(
+      { sessionId: session.sessionId, sourceTurnId: 'turn-1', outcome: 'achieved' },
+      {
+        achievedTitle: 'Session goal achieved',
+        failedMessage: 'Goal verification failed',
+      },
+    );
+
+    expect(flowChatStore.getState().sessions.get(session.sessionId)?.goalModeActive).toBe(false);
+  });
 });

--- a/src/web-ui/src/flow_chat/services/goalVerificationService.ts
+++ b/src/web-ui/src/flow_chat/services/goalVerificationService.ts
@@ -35,6 +35,10 @@ export function handleGoalVerificationFinished(
 
   flowChatStore.removeLocalGoalVerifyingTurn(payload.sessionId);
 
+  if (payload.outcome === 'achieved' || payload.outcome === 'limit_reached') {
+    flowChatStore.setGoalModeActive(payload.sessionId, false);
+  }
+
   switch (payload.outcome) {
     case 'achieved':
       if (messages.achievedMessage) {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -486,6 +486,29 @@ export class FlowChatStore {
     });
   }
 
+  public setGoalModeActive(sessionId: string, active: boolean): void {
+    this.setState(prev => {
+      const session = prev.sessions.get(sessionId);
+      if (!session) return prev;
+
+      if (Boolean(session.goalModeActive) === active) return prev;
+
+      const updatedSession = {
+        ...session,
+        goalModeActive: active,
+        lastActiveAt: Date.now(),
+      };
+
+      const newSessions = new Map(prev.sessions);
+      newSessions.set(sessionId, updatedSession);
+
+      return {
+        ...prev,
+        sessions: newSessions,
+      };
+    });
+  }
+
   public updateSessionModelName(sessionId: string, modelName: string): void {
     this.setState(prev => {
       const session = prev.sessions.get(sessionId);

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.tsx
@@ -25,6 +25,7 @@ import { hasAcpPermissionOptions } from './AcpPermissionActions.utils';
 import { AcpPermissionActions } from './AcpPermissionActions';
 import { openBtwSessionInAuxPane } from '../services/openBtwSession';
 import { flowChatStore } from '../store/FlowChatStore';
+import { useSessionGoalModeActive } from '../hooks/useSessionGoalModeActive';
 import './TaskToolDisplay.scss';
 import './ModelThinkingDisplay.scss';
 
@@ -100,6 +101,7 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
   sessionId
 }) => {
   const { t } = useTranslation('flow-chat');
+  const defaultTimeoutDisabled = useSessionGoalModeActive(sessionId);
   const { t: tAgents } = useTranslation('scenes/agents');
   const { toolCall, toolResult, status, requiresConfirmation, userConfirmed } = toolItem;
   const toolId = toolItem.id ?? toolCall?.id;
@@ -401,6 +403,7 @@ export const TaskToolDisplay: React.FC<ToolCardProps> = ({
                   }
                   showControls={true}
                   subagentSessionId={toolItem.subagentSessionId}
+                  defaultTimeoutDisabled={defaultTimeoutDisabled}
                   completedDurationMs={taskDurationMs}
                   completedStatus={completedDurationStatus}
                   completedFailureReason={isFailed ? taskErrorMessage ?? undefined : undefined}

--- a/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.tsx
@@ -43,6 +43,7 @@ export interface ToolTimeoutIndicatorProps {
   completedStatus?: 'success' | 'error' | 'cancelled';
   completedTooltip?: string;
   completedFailureReason?: string;
+  defaultTimeoutDisabled?: boolean;
 }
 
 function renderCompletedDurationIcon(status: ToolTimeoutIndicatorProps['completedStatus']) {
@@ -65,14 +66,10 @@ export const ToolTimeoutIndicator: React.FC<ToolTimeoutIndicatorProps> = ({
   completedStatus,
   completedTooltip,
   completedFailureReason,
+  defaultTimeoutDisabled = false,
 }) => {
   const { t } = useTranslation('flow-chat');
-  const { elapsedMs, remainingMs } = useLiveElapsedTime(
-    startTime,
-    isRunning,
-    timeoutMs,
-    false,
-  );
+  const remainingMsRef = useRef<number | null>(null);
 
   const {
     isTimeoutDisabled,
@@ -82,7 +79,21 @@ export const ToolTimeoutIndicator: React.FC<ToolTimeoutIndicatorProps> = ({
     extendTimeout,
     closePopover,
     remainingAtDisable,
-  } = useSubagentTimeoutControl(subagentSessionId, isRunning, timeoutMs, remainingMs);
+  } = useSubagentTimeoutControl(
+    subagentSessionId,
+    isRunning,
+    timeoutMs,
+    remainingMsRef.current,
+    defaultTimeoutDisabled,
+  );
+
+  const { elapsedMs, remainingMs } = useLiveElapsedTime(
+    startTime,
+    isRunning,
+    timeoutMs,
+    isTimeoutDisabled,
+  );
+  remainingMsRef.current = remainingMs;
 
   const popoverRef = useRef<HTMLDivElement>(null);
 

--- a/src/web-ui/src/flow_chat/types/flow-chat.ts
+++ b/src/web-ui/src/flow_chat/types/flow-chat.ts
@@ -344,6 +344,9 @@ export interface Session {
   /** Logical subagent id / type used to launch this hidden subagent session. */
   subagentType?: string;
 
+  /** Whether `/goal` mode is active for this session. */
+  goalModeActive?: boolean;
+
   /**
    * Lightweight markers for /btw threads created from this session.
    * Stored only on the parent session for quick navigation.

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.test.ts
@@ -22,7 +22,7 @@ describe('AgentAPI', () => {
     expect(invokeMock).toHaveBeenCalledWith('set_subagent_timeout', {
       request: {
         sessionId: 'subagent-session',
-        action: { type: 'Disable' },
+        action: { type: 'Disable', payload: null },
       },
     });
   });

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -749,9 +749,9 @@ export class AgentAPI {
     action: { type: 'disable' } | { type: 'restore' } | { type: 'extend'; seconds: number },
   ): Promise<void> {
     const actionPayload = action.type === 'disable'
-      ? { type: 'Disable' }
+      ? { type: 'Disable', payload: null }
       : action.type === 'restore'
-        ? { type: 'Restore' }
+        ? { type: 'Restore', payload: null }
         : { type: 'Extend', payload: { seconds: action.seconds } };
     try {
       await api.invoke<void>('set_subagent_timeout', {


### PR DESCRIPTION
## Summary
- Fix the subagent "Ignore limit" control by skipping the global tool pipeline timeout for Task tools, which previously still killed subagents at the configured deadline.
- Restore the `set_subagent_timeout` request payload shape and make the coordinator deadline watch loop reliably observe runtime disable/restore actions.
- In `/goal` mode, subagents now start with no active timeout by default while preserving the requested limit so users can re-enable it from the UI.

## Test plan
- [x] `cargo test -p bitfun-core --features product-full --lib effective_subagent_timeout_defaults subagent_timeout_disable_clears task_tool_manages`
- [x] `cargo test -p bitfun-desktop deserializes_set_subagent_timeout`
- [x] `npx vitest run src/flow_chat/services/goalVerificationService.test.ts src/flow_chat/tool-cards/ToolTimeoutIndicator.test.tsx src/infrastructure/api/service-api/AgentAPI.test.ts`
- [ ] Manual: start a subagent with a 1200s limit, click Ignore limit, confirm it continues past 20m
- [ ] Manual: in `/goal` mode, confirm subagent cards show unlimited timeout by default and can still restore a limit