### PR TITLE
fix: @ file mention picker cannot be closed by clicking outside

### DIFF
--- a/src/web-ui/src/flow_chat/components/FileMentionPicker.tsx
+++ b/src/web-ui/src/flow_chat/components/FileMentionPicker.tsx
@@ -389,6 +389,23 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
     }
   }, [isOpen, handleKeyDown]);
 
+  // Close picker when clicking outside
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    // Use mousedown to capture clicks before they trigger other effects (e.g. blur on editor)
+    document.addEventListener('mousedown', handleClickOutside, true);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside, true);
+    };
+  }, [isOpen, onClose]);
+
   useEffect(() => {
     if (containerRef.current && displayItems.length > 0) {
       const container = containerRef.current;


### PR DESCRIPTION
## Summary

The `@` file mention picker (FileMentionPicker) could not be dismissed by clicking outside the popup. Users could only close it via Escape, selecting an item, or editor blur.

## Fix

Added a document-level `mousedown` listener (capture phase) that closes the picker when the user clicks anywhere outside the container. Uses `containerRef.current.contains()` to avoid closing on clicks inside the picker.

## Verification

- `pnpm run lint:web` — passed
- `pnpm run type-check:web` — passed