### PR TITLE
test(agent-stream): add timeouts to stream fixture harness

### DIFF
--- a/src/crates/agent-stream/tests/common/stream_test_harness.rs
+++ b/src/crates/agent-stream/tests/common/stream_test_harness.rs
@@ -8,6 +8,7 @@ use bitfun_ai_adapters::stream::{
 use bitfun_events::{AgenticEvent, AgenticEventPriority as EventPriority};
 use futures::StreamExt;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{mpsc, Mutex};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
@@ -39,6 +40,7 @@ pub enum StreamFixtureProvider {
     Responses,
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct StreamFixtureRunOutput {
     pub result: Result<StreamResult, StreamProcessError>,
@@ -48,6 +50,8 @@ pub struct StreamFixtureRunOutput {
 #[derive(Debug, Clone, Copy)]
 pub struct StreamFixtureRunOptions {
     pub server_options: FixtureSseServerOptions,
+    pub request_timeout: Duration,
+    pub process_timeout: Duration,
     pub openai_inline_think_in_text: bool,
     pub anthropic_inline_think_in_text: bool,
     pub log_raw_sse: bool,
@@ -57,6 +61,8 @@ impl Default for StreamFixtureRunOptions {
     fn default() -> Self {
         Self {
             server_options: FixtureSseServerOptions::default(),
+            request_timeout: Duration::from_secs(5),
+            process_timeout: Duration::from_secs(5),
             openai_inline_think_in_text: false,
             anthropic_inline_think_in_text: false,
             log_raw_sse: false,
@@ -89,13 +95,20 @@ pub async fn run_stream_fixture_with_options(
     let fixture_bytes = load_fixture_bytes(fixture_relative_path);
     let fixture_server = FixtureSseServer::spawn(fixture_bytes, options.server_options).await;
 
-    let response = reqwest::Client::new()
-        .get(fixture_server.url())
-        .send()
-        .await
-        .expect("fixture SSE request should succeed")
-        .error_for_status()
-        .expect("fixture SSE response should be 2xx");
+    let response = tokio::time::timeout(
+        options.request_timeout,
+        reqwest::Client::new().get(fixture_server.url()).send(),
+    )
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "fixture SSE request timed out after {:?} for provider {:?} fixture {}",
+            options.request_timeout, provider, fixture_relative_path
+        )
+    })
+    .expect("fixture SSE request should succeed")
+    .error_for_status()
+    .expect("fixture SSE response should be 2xx");
 
     let (tx_event, rx_event) = mpsc::unbounded_channel::<Result<UnifiedResponse, anyhow::Error>>();
     let (tx_raw_sse, rx_raw_sse) = mpsc::unbounded_channel::<String>();
@@ -159,8 +172,9 @@ pub async fn run_stream_fixture_with_options(
     let unified_stream = UnboundedReceiverStream::new(rx_event).boxed();
     let cancellation_token = CancellationToken::new();
 
-    let result = processor
-        .process_stream(
+    let result = tokio::time::timeout(
+        options.process_timeout,
+        processor.process_stream(
             unified_stream,
             None,
             raw_sse_rx_for_processor,
@@ -168,8 +182,15 @@ pub async fn run_stream_fixture_with_options(
             "turn_fixture".to_string(),
             "round_fixture".to_string(),
             &cancellation_token,
+        ),
+    )
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "stream fixture processing timed out after {:?} for provider {:?} fixture {}",
+            options.process_timeout, provider, fixture_relative_path
         )
-        .await;
+    });
 
     let events = event_sink.drain_all().await;
 

--- a/src/crates/agent-stream/tests/stream_test_harness.rs
+++ b/src/crates/agent-stream/tests/stream_test_harness.rs
@@ -1,0 +1,25 @@
+mod common;
+
+use common::sse_fixture_server::FixtureSseServerOptions;
+use common::stream_test_harness::{
+    run_stream_fixture_with_options, StreamFixtureProvider, StreamFixtureRunOptions,
+};
+use std::time::Duration;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[should_panic(expected = "stream fixture processing timed out")]
+async fn stream_test_harness_fails_fast_when_fixture_processing_stalls() {
+    run_stream_fixture_with_options(
+        StreamFixtureProvider::OpenAi,
+        "stream/openai/tool_args_split_with_usage.sse",
+        StreamFixtureRunOptions {
+            server_options: FixtureSseServerOptions {
+                chunk_size: 1,
+                chunk_delay: Duration::from_millis(50),
+            },
+            process_timeout: Duration::from_millis(20),
+            ..Default::default()
+        },
+    )
+    .await;
+}


### PR DESCRIPTION
## Summary
- add request and processing timeouts to the shared stream fixture harness
- fail fast with provider and fixture context when a stream fixture stalls
- add a regression test that proves stalled fixture processing times out instead of hanging

## Verification
- cargo test -p bitfun-agent-stream --test stream_test_harness -- --nocapture
- cargo test -p bitfun-agent-stream --test stream_processor_openai -- --nocapture
- cargo test -p bitfun-agent-stream --test stream_processor_anthropic -- --nocapture