### PR TITLE
fix(agentic): flush persisted tool result before returning

### DIFF
--- a/src/crates/core/src/agentic/tools/tool_result_storage.rs
+++ b/src/crates/core/src/agentic/tools/tool_result_storage.rs
@@ -221,6 +221,18 @@ async fn write_once(path: &Path, content: &str) -> BitFunResult<()> {
                     path.display(),
                     error
                 ))
+            })?;
+            // tokio::fs::File buffers writes and does NOT guarantee a flush on
+            // drop, so without an explicit flush a subsequent (possibly
+            // synchronous) read can observe an empty or partial file. This was
+            // an intermittent failure on macOS CI. flush() drains the buffer to
+            // the OS so the persisted output is visible to later readers.
+            file.flush().await.map_err(|error| {
+                BitFunError::io(format!(
+                    "Failed to flush tool result file {}: {}",
+                    path.display(),
+                    error
+                ))
             })
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),


### PR DESCRIPTION
## Summary

- `tool_result_storage::write_once` 在 tokio `write_all` 之后未 `flush()`。`tokio::fs::File` 缓冲写入且 drop 时不保证刷盘,导致后续同步 `std::fs::read_to_string` 可能读到空/不完整文件。
- 添加显式 `file.flush().await`,保证缓冲数据落到底层 std File(OS 页缓存)。

## 影响

- 在 macOS CI 上观察到的间歇性失败:`agentic::tools::tool_result_storage::tests::bash_full_output_persists_even_when_assistant_text_is_already_truncated`(`left: ""` vs `right: "xxxx..."`)。
- 生产路径同样可能受影响——任何在 `write_once` 返回后立即读取持久化文件的代码都可能拿到空内容。这里只是 macOS 时序更容易触发。

## Test plan

- [x] `cargo test -p bitfun-core bash_full_output_persists_even_when_assistant_text_is_already_truncated` 通过
- [x] `cargo test -p bitfun-core tool_result_storage`(模块全量,6 passed)通过
- [x] CI(ubuntu/windows/macos) 通过

## Notes

发现自 PR #846 的 macOS CI,根因与该 PR 无关,故拆出来单独提交。

🤖 Generated with [Claude Code](https://claude.com/claude-code)