### PR TITLE
refactor(core): split tool prompt reminders and rename request context to user context

### DIFF
--- a/src/crates/core/src/agentic/agents/definitions/custom/subagent.rs
+++ b/src/crates/core/src/agentic/agents/definitions/custom/subagent.rs
@@ -1,5 +1,5 @@
 use crate::agentic::agents::Agent;
-use crate::agentic::agents::{PromptBuilder, PromptBuilderContext, RequestContextPolicy};
+use crate::agentic::agents::{PromptBuilder, PromptBuilderContext, UserContextPolicy};
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::FrontMatterMarkdown;
 use async_trait::async_trait;
@@ -63,8 +63,8 @@ impl Agent for CustomSubagent {
         self.tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_project_layout()

--- a/src/crates/core/src/agentic/agents/definitions/hidden/code_review.rs
+++ b/src/crates/core/src/agentic/agents/definitions/hidden/code_review.rs
@@ -3,7 +3,7 @@
 //! This agent can use Read/Grep/Glob/LS tools to gather context before
 //! submitting a code review, reducing false positives from missing context.
 
-use crate::agentic::agents::{Agent, RequestContextPolicy};
+use crate::agentic::agents::{Agent, UserContextPolicy};
 use async_trait::async_trait;
 
 pub struct CodeReviewAgent {
@@ -68,8 +68,8 @@ impl Agent for CodeReviewAgent {
         self.default_tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_project_layout()

--- a/src/crates/core/src/agentic/agents/definitions/hidden/deep_review.rs
+++ b/src/crates/core/src/agentic/agents/definitions/hidden/deep_review.rs
@@ -1,4 +1,4 @@
-use crate::agentic::agents::{Agent, RequestContextPolicy};
+use crate::agentic::agents::{Agent, UserContextPolicy};
 use async_trait::async_trait;
 
 pub struct DeepReviewAgent {
@@ -59,8 +59,8 @@ impl Agent for DeepReviewAgent {
         self.default_tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_project_layout()

--- a/src/crates/core/src/agentic/agents/definitions/hidden/generate_doc.rs
+++ b/src/crates/core/src/agentic/agents/definitions/hidden/generate_doc.rs
@@ -1,4 +1,4 @@
-use crate::agentic::agents::{Agent, RequestContextPolicy};
+use crate::agentic::agents::{Agent, UserContextPolicy};
 use async_trait::async_trait;
 
 pub struct GenerateDocAgent {
@@ -50,8 +50,8 @@ impl Agent for GenerateDocAgent {
         self.default_tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_project_layout()

--- a/src/crates/core/src/agentic/agents/definitions/hidden/init.rs
+++ b/src/crates/core/src/agentic/agents/definitions/hidden/init.rs
@@ -1,4 +1,4 @@
-use crate::agentic::agents::{Agent, RequestContextPolicy};
+use crate::agentic::agents::{Agent, UserContextPolicy};
 use async_trait::async_trait;
 
 pub struct InitAgent {
@@ -54,8 +54,8 @@ impl Agent for InitAgent {
         self.default_tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_workspace_memory_files()

--- a/src/crates/core/src/agentic/agents/definitions/modes/agentic.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/agentic.rs
@@ -1,7 +1,7 @@
 //! Agentic Mode
 
 use crate::agentic::agents::{
-    shared_coding_mode_tools, Agent, RequestContextPolicy, SHARED_CODING_MODE_PROMPT_TEMPLATE,
+    shared_coding_mode_tools, Agent, UserContextPolicy, SHARED_CODING_MODE_PROMPT_TEMPLATE,
 };
 use async_trait::async_trait;
 pub struct AgenticMode {
@@ -48,8 +48,8 @@ impl Agent for AgenticMode {
         self.default_tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_workspace_memory_files()

--- a/src/crates/core/src/agentic/agents/definitions/modes/claw.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/claw.rs
@@ -1,6 +1,6 @@
 //! Claw Mode
 
-use crate::agentic::agents::{Agent, RequestContextPolicy};
+use crate::agentic::agents::{Agent, UserContextPolicy};
 use async_trait::async_trait;
 pub struct ClawMode {
     default_tools: Vec<String>,
@@ -67,8 +67,8 @@ impl Agent for ClawMode {
         self.default_tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_workspace_memory_files()

--- a/src/crates/core/src/agentic/agents/definitions/modes/cowork.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/cowork.rs
@@ -2,7 +2,7 @@
 //!
 //! A collaborative mode that prioritizes early clarification and lightweight progress tracking.
 
-use crate::agentic::agents::{Agent, RequestContextPolicy};
+use crate::agentic::agents::{Agent, UserContextPolicy};
 use async_trait::async_trait;
 
 pub struct CoworkMode {
@@ -70,8 +70,8 @@ impl Agent for CoworkMode {
         self.default_tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_project_layout()

--- a/src/crates/core/src/agentic/agents/definitions/modes/debug.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/debug.rs
@@ -1,7 +1,7 @@
 //! Debug Mode - Evidence-driven debugging mode
 
 use crate::agentic::agents::{
-    get_embedded_prompt, Agent, PromptBuilder, PromptBuilderContext, RequestContextPolicy,
+    get_embedded_prompt, Agent, PromptBuilder, PromptBuilderContext, UserContextPolicy,
 };
 use crate::service::config::global::GlobalConfigManager;
 use crate::service::config::types::{DebugModeConfig, LanguageDebugTemplate};
@@ -284,8 +284,8 @@ impl Agent for DebugMode {
         DEBUG_MODE_PROMPT_TEMPLATE
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_workspace_memory_files()

--- a/src/crates/core/src/agentic/agents/definitions/modes/deep_research.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/deep_research.rs
@@ -1,4 +1,4 @@
-use crate::agentic::agents::{Agent, AgentToolPolicyOverrides, RequestContextPolicy};
+use crate::agentic::agents::{Agent, AgentToolPolicyOverrides, UserContextPolicy};
 use crate::agentic::tools::framework::ToolExposure;
 use async_trait::async_trait;
 
@@ -70,8 +70,8 @@ impl Agent for DeepResearchMode {
         &self.tool_exposure_overrides
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_project_layout()

--- a/src/crates/core/src/agentic/agents/definitions/modes/multitask.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/multitask.rs
@@ -1,7 +1,7 @@
 //! Multitask Mode
 
 use crate::agentic::agents::{
-    get_embedded_prompt, shared_coding_mode_tools, Agent, RequestContextPolicy,
+    get_embedded_prompt, shared_coding_mode_tools, Agent, UserContextPolicy,
     SHARED_CODING_MODE_PROMPT_TEMPLATE,
 };
 use async_trait::async_trait;
@@ -63,8 +63,8 @@ impl Agent for MultitaskMode {
         SHARED_CODING_MODE_PROMPT_TEMPLATE
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_workspace_memory_files()

--- a/src/crates/core/src/agentic/agents/definitions/modes/plan.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/plan.rs
@@ -1,6 +1,6 @@
 //! Plan Mode
 
-use crate::agentic::agents::{Agent, RequestContextPolicy};
+use crate::agentic::agents::{Agent, UserContextPolicy};
 use async_trait::async_trait;
 
 const PLAN_MODE_PROMPT_TEMPLATE: &str = "plan_mode";
@@ -60,8 +60,8 @@ impl Agent for PlanMode {
         self.default_tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_workspace_memory_files()

--- a/src/crates/core/src/agentic/agents/definitions/modes/team.rs
+++ b/src/crates/core/src/agentic/agents/definitions/modes/team.rs
@@ -3,7 +3,7 @@
 //! Orchestrates a full software development sprint through specialized roles:
 //! Think → Plan → Build → Review → Test → Ship
 
-use crate::agentic::agents::{Agent, RequestContextPolicy};
+use crate::agentic::agents::{Agent, UserContextPolicy};
 use async_trait::async_trait;
 
 pub struct TeamMode {
@@ -68,8 +68,8 @@ impl Agent for TeamMode {
         self.default_tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_project_layout()

--- a/src/crates/core/src/agentic/agents/definitions/review/review_fixer.rs
+++ b/src/crates/core/src/agentic/agents/definitions/review/review_fixer.rs
@@ -1,4 +1,4 @@
-use crate::agentic::agents::{Agent, AgentToolPolicyOverrides, RequestContextPolicy};
+use crate::agentic::agents::{Agent, AgentToolPolicyOverrides, UserContextPolicy};
 use crate::agentic::tools::framework::ToolExposure;
 use async_trait::async_trait;
 
@@ -62,8 +62,8 @@ impl Agent for ReviewFixerAgent {
         self.default_tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty().with_workspace_instructions()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty().with_workspace_instructions()
     }
 
     fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {
@@ -78,7 +78,7 @@ impl Agent for ReviewFixerAgent {
 #[cfg(test)]
 mod tests {
     use super::{Agent, ReviewFixerAgent};
-    use crate::agentic::agents::RequestContextPolicy;
+    use crate::agentic::agents::UserContextPolicy;
 
     #[test]
     fn review_fixer_agent_has_edit_and_verify_tools() {
@@ -86,8 +86,8 @@ mod tests {
         let tools = agent.default_tools();
 
         assert_eq!(
-            agent.request_context_policy(),
-            RequestContextPolicy::empty().with_workspace_instructions()
+            agent.user_context_policy(),
+            UserContextPolicy::empty().with_workspace_instructions()
         );
         assert!(tools.contains(&"Edit".to_string()));
         assert!(tools.contains(&"Write".to_string()));

--- a/src/crates/core/src/agentic/agents/definitions/review/review_specialists.rs
+++ b/src/crates/core/src/agentic/agents/definitions/review/review_specialists.rs
@@ -80,7 +80,7 @@ mod tests {
         ArchitectureReviewerAgent, BusinessLogicReviewerAgent, FrontendReviewerAgent,
         PerformanceReviewerAgent, ReviewJudgeAgent, SecurityReviewerAgent,
     };
-    use crate::agentic::agents::{Agent, RequestContextPolicy};
+    use crate::agentic::agents::{Agent, UserContextPolicy};
 
     #[test]
     fn specialist_reviewers_use_isolated_instruction_context() {
@@ -95,8 +95,8 @@ mod tests {
 
         for agent in agents {
             assert_eq!(
-                agent.request_context_policy(),
-                RequestContextPolicy::empty().with_workspace_instructions()
+                agent.user_context_policy(),
+                UserContextPolicy::empty().with_workspace_instructions()
             );
             assert!(agent.is_readonly());
             assert!(agent.default_tools().contains(&"GetFileDiff".to_string()));

--- a/src/crates/core/src/agentic/agents/definitions/shared/readonly.rs
+++ b/src/crates/core/src/agentic/agents/definitions/shared/readonly.rs
@@ -1,4 +1,4 @@
-use crate::agentic::agents::{Agent, AgentToolPolicyOverrides, RequestContextPolicy};
+use crate::agentic::agents::{Agent, AgentToolPolicyOverrides, UserContextPolicy};
 use async_trait::async_trait;
 
 /// Internal helper that holds the common metadata and behaviour for
@@ -10,7 +10,7 @@ pub struct ReadonlySubagent {
     prompt_template: &'static str,
     default_tools: &'static [&'static str],
     tool_exposure_overrides: AgentToolPolicyOverrides,
-    request_context_policy: RequestContextPolicy,
+    user_context_policy: UserContextPolicy,
 }
 
 impl ReadonlySubagent {
@@ -46,7 +46,7 @@ impl ReadonlySubagent {
             prompt_template,
             default_tools,
             tool_exposure_overrides,
-            request_context_policy: RequestContextPolicy::empty().with_workspace_instructions(),
+            user_context_policy: UserContextPolicy::empty().with_workspace_instructions(),
         }
     }
 
@@ -56,7 +56,7 @@ impl ReadonlySubagent {
         description: &'static str,
         prompt_template: &'static str,
         default_tools: &'static [&'static str],
-        request_context_policy: RequestContextPolicy,
+        user_context_policy: UserContextPolicy,
     ) -> Self {
         Self {
             id,
@@ -65,7 +65,7 @@ impl ReadonlySubagent {
             prompt_template,
             default_tools,
             tool_exposure_overrides: AgentToolPolicyOverrides::default(),
-            request_context_policy,
+            user_context_policy,
         }
     }
 }
@@ -96,8 +96,8 @@ impl Agent for ReadonlySubagent {
         self.default_tools.iter().map(|s| s.to_string()).collect()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        self.request_context_policy.clone()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        self.user_context_policy.clone()
     }
 
     fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {
@@ -118,7 +118,7 @@ macro_rules! define_readonly_subagent_with_context_policy {
         $description:literal,
         $prompt:literal,
         $tools:expr,
-        $request_context_policy:expr
+        $user_context_policy:expr
     ) => {
         pub struct $struct_name {
             inner: $crate::agentic::agents::ReadonlySubagent,
@@ -139,7 +139,7 @@ macro_rules! define_readonly_subagent_with_context_policy {
                         $description,
                         $prompt,
                         $tools,
-                        $request_context_policy,
+                        $user_context_policy,
                     ),
                 }
             }
@@ -171,8 +171,8 @@ macro_rules! define_readonly_subagent_with_context_policy {
                 self.inner.default_tools()
             }
 
-            fn request_context_policy(&self) -> $crate::agentic::agents::RequestContextPolicy {
-                self.inner.request_context_policy()
+            fn user_context_policy(&self) -> $crate::agentic::agents::UserContextPolicy {
+                self.inner.user_context_policy()
             }
 
             fn tool_exposure_overrides(
@@ -250,8 +250,8 @@ macro_rules! define_readonly_subagent {
                 self.inner.default_tools()
             }
 
-            fn request_context_policy(&self) -> $crate::agentic::agents::RequestContextPolicy {
-                self.inner.request_context_policy()
+            fn user_context_policy(&self) -> $crate::agentic::agents::UserContextPolicy {
+                self.inner.user_context_policy()
             }
 
             fn tool_exposure_overrides(
@@ -329,8 +329,8 @@ macro_rules! define_readonly_subagent_with_overrides {
                 self.inner.default_tools()
             }
 
-            fn request_context_policy(&self) -> $crate::agentic::agents::RequestContextPolicy {
-                self.inner.request_context_policy()
+            fn user_context_policy(&self) -> $crate::agentic::agents::UserContextPolicy {
+                self.inner.user_context_policy()
             }
 
             fn tool_exposure_overrides(

--- a/src/crates/core/src/agentic/agents/definitions/subagents/computer_use.rs
+++ b/src/crates/core/src/agentic/agents/definitions/subagents/computer_use.rs
@@ -2,7 +2,7 @@
 //!
 //! Dedicated agent for perceiving and operating the user's local computer.
 
-use crate::agentic::agents::{Agent, AgentToolPolicyOverrides, RequestContextPolicy};
+use crate::agentic::agents::{Agent, AgentToolPolicyOverrides, UserContextPolicy};
 use crate::agentic::tools::framework::ToolExposure;
 use async_trait::async_trait;
 
@@ -63,8 +63,8 @@ impl Agent for ComputerUseMode {
         self.default_tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_instructions()
             .with_project_layout()
     }

--- a/src/crates/core/src/agentic/agents/definitions/subagents/general_purpose.rs
+++ b/src/crates/core/src/agentic/agents/definitions/subagents/general_purpose.rs
@@ -1,4 +1,4 @@
-use crate::agentic::agents::{Agent, RequestContextPolicy};
+use crate::agentic::agents::{Agent, UserContextPolicy};
 use async_trait::async_trait;
 
 pub struct GeneralPurposeAgent {
@@ -56,8 +56,8 @@ impl Agent for GeneralPurposeAgent {
         self.default_tools.clone()
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_project_layout()

--- a/src/crates/core/src/agentic/agents/definitions/subagents/research_specialist.rs
+++ b/src/crates/core/src/agentic/agents/definitions/subagents/research_specialist.rs
@@ -7,7 +7,7 @@ define_readonly_subagent_with_context_policy!(
     r#"Read-only subagent for **web research**. Has WebSearch (Exa) and WebFetch tools. Use to delegate one focused research role (primary sources, news/timeline, expert analysis, counter-evidence, or competitor profile) so multiple roles can run in parallel without polluting the parent context. The specialist runs 3–5 searches, fetches the most relevant pages, and returns a structured markdown report with claim / URL / direct-quote / authority for each finding. The parent agent is responsible for any file writes — specialists return findings via the Task tool result, they do not write to disk."#,
     "research_specialist_agent",
     &["WebSearch", "WebFetch", "Read"],
-    crate::agentic::agents::RequestContextPolicy::empty()
+    crate::agentic::agents::UserContextPolicy::empty()
         .with_workspace_context()
         .with_workspace_instructions()
 );

--- a/src/crates/core/src/agentic/agents/mod.rs
+++ b/src/crates/core/src/agentic/agents/mod.rs
@@ -30,8 +30,8 @@ pub use definitions::subagents::{
 };
 use indexmap::IndexMap;
 pub use prompt_builder::{
-    PromptBuilder, PromptBuilderContext, RemoteExecutionHints, RequestContextPolicy,
-    RequestContextSection, RequestContextToolSections,
+    PrependedPromptReminders, PromptBuilder, PromptBuilderContext, RemoteExecutionHints,
+    ToolListingSections, UserContextPolicy, UserContextSection,
 };
 pub use registry::catalog::{builtin_agent_specs, BuiltinAgentSpec};
 pub use registry::types::{
@@ -99,7 +99,7 @@ pub trait Agent: Send + Sync + 'static {
         None // by default, no system reminder
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy;
+    fn user_context_policy(&self) -> UserContextPolicy;
 
     /// Build the system prompt for this agent
     async fn build_prompt(&self, context: &PromptBuilderContext) -> BitFunResult<String> {

--- a/src/crates/core/src/agentic/agents/prompt_builder/mod.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/mod.rs
@@ -1,7 +1,8 @@
 mod prompt_builder_impl;
-mod request_context;
+mod user_context;
 
 pub use prompt_builder_impl::{
-    PromptBuilder, PromptBuilderContext, RemoteExecutionHints, RequestContextToolSections,
+    PrependedPromptReminders, PromptBuilder, PromptBuilderContext, RemoteExecutionHints,
+    ToolListingSections,
 };
-pub use request_context::{RequestContextPolicy, RequestContextSection};
+pub use user_context::{UserContextPolicy, UserContextSection};

--- a/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -1,5 +1,5 @@
 //! System prompts module providing main dialogue and agent dialogue prompts
-use super::request_context::{RequestContextPolicy, RequestContextSection};
+use super::user_context::{UserContextPolicy, UserContextSection};
 use crate::service::agent_memory::{
     build_workspace_agent_memory_prompt, build_workspace_instruction_files_context,
     build_workspace_memory_files_context,
@@ -22,64 +22,64 @@ const PLACEHOLDER_AGENT_MEMORY: &str = "{AGENT_MEMORY}";
 const PLACEHOLDER_CLAW_WORKSPACE: &str = "{CLAW_WORKSPACE}";
 const PLACEHOLDER_VISUAL_MODE: &str = "{VISUAL_MODE}";
 const PLACEHOLDER_SESSION_ID: &str = "{SESSION_ID}";
-const ADDITIONAL_CONTEXT_PROMPT: &str =
+const USER_CONTEXT_PROMPT: &str =
     "As you answer the user's questions, you can use the following context";
-const SKILL_TOOL_CONTEXT_TITLE: &str = "## Skills available for use with the Skill tool";
-const TASK_TOOL_CONTEXT_TITLE: &str = "## Available agent types for the Task Tool";
-const GET_TOOL_SPEC_CONTEXT_TITLE: &str =
-    "## Collapsed Tools (load full definition via GetToolSpec tool)";
-const ADDITIONAL_TOOLS_PROMPT: &str = r#"Some tools in the tool list are intentionally collapsed.
-Their listed descriptions are short summaries rather than full usage instructions.
+const SKILL_LISTING_TITLE: &str = "# Skill Listing";
+const SKILL_LISTING_GUIDANCE: &str =
+    "The following skills are available for use with the Skill tool:";
+const AGENT_LISTING_TITLE: &str = "# Agent Listing";
+const AGENT_LISTING_GUIDANCE: &str = "Available subagent types for the Task tool:";
+const COLLAPSED_TOOL_LISTING_TITLE: &str =
+    "# Collapsed Tool Listing";
+const COLLAPSED_TOOL_LISTING_GUIDANCE: &str = r#"The folling tools are intentionally collapsed. Their listed descriptions are short summaries rather than full usage instructions.
 Before calling a collapsed tool, call `GetToolSpec` with its exact tool name to read its full definition and input schema.
 After reading the returned spec, call the real tool directly by its own name.
 If a tool spec is already available in the current conversation, do not call `GetToolSpec` for it again."#;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct RequestContextToolSections {
-    pub available_skills: Option<String>,
-    pub available_agents: Option<String>,
-    pub collapsed_tools: Option<String>,
+pub struct ToolListingSections {
+    pub skill_listing: Option<String>,
+    pub agent_listing: Option<String>,
+    pub collapsed_tool_listing: Option<String>,
 }
 
-impl RequestContextToolSections {
+impl ToolListingSections {
     pub fn is_empty(&self) -> bool {
-        self.available_skills.is_none()
-            && self.available_agents.is_none()
-            && self.collapsed_tools.is_none()
+        self.skill_listing.is_none()
+            && self.agent_listing.is_none()
+            && self.collapsed_tool_listing.is_none()
     }
 
-    fn render(&self) -> Option<String> {
-        if self.is_empty() {
-            return None;
-        }
+    fn render_skill_listing_reminder(&self) -> Option<String> {
+        self.skill_listing.as_deref().map(|skill_listing| {
+            Self::render_section(
+                SKILL_LISTING_TITLE,
+                skill_listing,
+                Some(SKILL_LISTING_GUIDANCE),
+            )
+        })
+    }
 
-        let mut sections = Vec::new();
-        if let Some(available_skills) = self.available_skills.as_deref() {
-            sections.push(Self::render_section(
-                SKILL_TOOL_CONTEXT_TITLE,
-                available_skills,
-                None,
-            ));
-        }
-        if let Some(available_agents) = self.available_agents.as_deref() {
-            sections.push(Self::render_section(
-                TASK_TOOL_CONTEXT_TITLE,
-                available_agents,
-                None,
-            ));
-        }
-        if let Some(collapsed_tools) = self.collapsed_tools.as_deref() {
-            sections.push(Self::render_section(
-                GET_TOOL_SPEC_CONTEXT_TITLE,
-                collapsed_tools,
-                Some(ADDITIONAL_TOOLS_PROMPT),
-            ));
-        }
+    fn render_agent_listing_reminder(&self) -> Option<String> {
+        self.agent_listing.as_deref().map(|agent_listing| {
+            Self::render_section(
+                AGENT_LISTING_TITLE,
+                agent_listing,
+                Some(AGENT_LISTING_GUIDANCE),
+            )
+        })
+    }
 
-        Some(format!(
-            "# Available Tool Context\n{}",
-            sections.join("\n\n")
-        ))
+    fn render_collapsed_tool_listing_reminder(&self) -> Option<String> {
+        self.collapsed_tool_listing
+            .as_deref()
+            .map(|collapsed_tool_listing| {
+                Self::render_section(
+                    COLLAPSED_TOOL_LISTING_TITLE,
+                    collapsed_tool_listing,
+                    Some(COLLAPSED_TOOL_LISTING_GUIDANCE),
+                )
+            })
     }
 
     fn render_section(title: &str, body: &str, description: Option<&str>) -> String {
@@ -87,6 +87,33 @@ impl RequestContextToolSections {
             Some(description) => format!("{}\n{}\n\n{}", title, description, body.trim()),
             None => format!("{}\n{}", title, body.trim()),
         }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PrependedPromptReminders {
+    pub skill_listing: Option<String>,
+    pub agent_listing: Option<String>,
+    pub collapsed_tool_listing: Option<String>,
+    pub user_context: Option<String>,
+}
+
+impl PrependedPromptReminders {
+    pub fn ordered_reminders(&self) -> Vec<&str> {
+        let mut reminders = Vec::new();
+        if let Some(skill_listing) = self.skill_listing.as_deref() {
+            reminders.push(skill_listing);
+        }
+        if let Some(agent_listing) = self.agent_listing.as_deref() {
+            reminders.push(agent_listing);
+        }
+        if let Some(collapsed_tool_listing) = self.collapsed_tool_listing.as_deref() {
+            reminders.push(collapsed_tool_listing);
+        }
+        if let Some(user_context) = self.user_context.as_deref() {
+            reminders.push(user_context);
+        }
+        reminders
     }
 }
 
@@ -110,8 +137,8 @@ pub struct PromptBuilderContext {
     pub remote_project_layout: Option<String>,
     /// When `Some(false)`, system prompt append Computer use text-only guidance (no screenshot tool output).
     pub supports_image_understanding: Option<bool>,
-    /// Dynamic tool catalogs that are injected through request context instead of tool descriptions.
-    pub request_context_tools: RequestContextToolSections,
+    /// Dynamic tool listings injected outside tool descriptions for cache stability.
+    pub tool_listing_sections: ToolListingSections,
 }
 
 impl PromptBuilderContext {
@@ -128,7 +155,7 @@ impl PromptBuilderContext {
             remote_execution: None,
             remote_project_layout: None,
             supports_image_understanding: None,
-            request_context_tools: RequestContextToolSections::default(),
+            tool_listing_sections: ToolListingSections::default(),
         }
     }
 
@@ -137,8 +164,8 @@ impl PromptBuilderContext {
         self
     }
 
-    pub fn with_request_context_tools(mut self, tools: RequestContextToolSections) -> Self {
-        self.request_context_tools = tools;
+    pub fn with_tool_listing_sections(mut self, sections: ToolListingSections) -> Self {
+        self.tool_listing_sections = sections;
         self
     }
 
@@ -308,24 +335,34 @@ impl PromptBuilder {
         project_layout
     }
 
-    pub async fn build_request_context_reminder(
-        &self,
-        policy: &RequestContextPolicy,
-    ) -> Option<String> {
-        let mut sections = Vec::new();
+    pub fn build_skill_listing_reminder(&self) -> Option<String> {
+        self.context
+            .tool_listing_sections
+            .render_skill_listing_reminder()
+    }
+
+    pub fn build_agent_listing_reminder(&self) -> Option<String> {
+        self.context
+            .tool_listing_sections
+            .render_agent_listing_reminder()
+    }
+
+    pub fn build_collapsed_tool_listing_reminder(&self) -> Option<String> {
+        self.context
+            .tool_listing_sections
+            .render_collapsed_tool_listing_reminder()
+    }
+
+    pub async fn build_user_context_reminder(&self, policy: &UserContextPolicy) -> Option<String> {
         let mut additional_sections = Vec::new();
 
-        if let Some(tool_context) = self.context.request_context_tools.render() {
-            sections.push(tool_context);
-        }
-
-        if policy.includes(RequestContextSection::WorkspaceContext) {
+        if policy.includes(UserContextSection::WorkspaceContext) {
             additional_sections.push(self.get_workspace_context());
         }
 
         if self.context.remote_execution.is_none() {
             let workspace = Path::new(&self.context.workspace_path);
-            if policy.includes(RequestContextSection::WorkspaceInstructions) {
+            if policy.includes(UserContextSection::WorkspaceInstructions) {
                 match build_workspace_instruction_files_context(workspace).await {
                     Ok(Some(prompt)) => additional_sections.push(prompt),
                     Ok(None) => {}
@@ -336,7 +373,7 @@ impl PromptBuilder {
                     ),
                 }
             }
-            if policy.includes(RequestContextSection::WorkspaceMemoryFiles) {
+            if policy.includes(UserContextSection::WorkspaceMemoryFiles) {
                 match build_workspace_memory_files_context(workspace).await {
                     Ok(Some(prompt)) => additional_sections.push(prompt),
                     Ok(None) => {}
@@ -349,26 +386,34 @@ impl PromptBuilder {
             }
         }
 
-        if policy.includes(RequestContextSection::ProjectLayout) {
+        if policy.includes(UserContextSection::ProjectLayout) {
             additional_sections.push(self.get_project_layout());
         }
 
-        if !additional_sections.is_empty() {
-            sections.push(format!(
-                "# Additional Context\n{}\n\n{}",
-                ADDITIONAL_CONTEXT_PROMPT,
+        if additional_sections.is_empty() {
+            None
+        } else {
+            Some(format!(
+                "# User Context\n{}\n\n{}",
+                USER_CONTEXT_PROMPT,
                 additional_sections
                     .into_iter()
                     .map(|section| section.trim().to_string())
                     .collect::<Vec<_>>()
                     .join("\n\n")
-            ));
+            ))
         }
+    }
 
-        if sections.is_empty() {
-            None
-        } else {
-            Some(sections.join("\n\n"))
+    pub async fn build_prepended_reminders(
+        &self,
+        user_context_policy: &UserContextPolicy,
+    ) -> PrependedPromptReminders {
+        PrependedPromptReminders {
+            skill_listing: self.build_skill_listing_reminder(),
+            agent_listing: self.build_agent_listing_reminder(),
+            collapsed_tool_listing: self.build_collapsed_tool_listing_reminder(),
+            user_context: self.build_user_context_reminder(user_context_policy).await,
         }
     }
 
@@ -423,7 +468,7 @@ Output Mermaid in fenced code blocks (```mermaid) so the UI can render them.
     /// Get Claw-specific workspace boundary instruction
     fn get_claw_workspace_instruction(&self) -> String {
         "# Workspace
-Your dedicated operating space is the workspace root shown in the current request context.
+Your dedicated operating space is the workspace root shown in the current user context.
 Prefer doing work inside this workspace and keep it well organized with clear structure, sensible filenames, and minimal clutter.
 Do not read from, modify, create, move, or delete files outside this workspace unless the user has explicitly granted permission for that external action.
 "
@@ -538,58 +583,79 @@ The configured **primary model does not accept image inputs**. When using **`Com
 
 #[cfg(test)]
 mod tests {
+    use super::PrependedPromptReminders;
     use super::PromptBuilder;
     use super::PromptBuilderContext;
-    use super::RequestContextToolSections;
+    use super::ToolListingSections;
     use super::{
-        ADDITIONAL_CONTEXT_PROMPT, GET_TOOL_SPEC_CONTEXT_TITLE, SKILL_TOOL_CONTEXT_TITLE,
-        TASK_TOOL_CONTEXT_TITLE,
+        AGENT_LISTING_TITLE, COLLAPSED_TOOL_LISTING_TITLE, SKILL_LISTING_TITLE, USER_CONTEXT_PROMPT,
     };
-    use crate::agentic::agents::RequestContextPolicy;
+    use crate::agentic::agents::UserContextPolicy;
     use crate::service::workspace::RelatedPath;
 
     #[tokio::test]
-    async fn renders_available_tool_context_before_additional_context() {
-        let tool_sections = RequestContextToolSections {
-            available_skills: Some("<available_skills>\n- pdf\n</available_skills>".to_string()),
-            available_agents: Some(
-                "<available_agents>\n- Explore\n</available_agents>".to_string(),
-            ),
-            collapsed_tools: Some(
+    async fn builds_ordered_prepended_reminders_from_tool_listings_and_user_context() {
+        let tool_sections = ToolListingSections {
+            skill_listing: Some("<available_skills>\n- pdf\n</available_skills>".to_string()),
+            agent_listing: Some("<available_agents>\n- Explore\n</available_agents>".to_string()),
+            collapsed_tool_listing: Some(
                 "<collapsed_tools>\n- WebFetch: Fetch readable web content.\n</collapsed_tools>"
                     .to_string(),
             ),
         };
         let context = PromptBuilderContext::new("E:/workspace", None, None)
-            .with_request_context_tools(tool_sections);
-        let prompt = PromptBuilder::new(context)
-            .build_request_context_reminder(
-                &RequestContextPolicy::empty()
+            .with_tool_listing_sections(tool_sections);
+        let reminders = PromptBuilder::new(context)
+            .build_prepended_reminders(
+                &UserContextPolicy::empty()
                     .with_workspace_context()
                     .with_workspace_instructions(),
             )
-            .await
-            .expect("request context should build");
+            .await;
+        let reminders_for_order = reminders.clone();
+        let ordered_reminders = reminders_for_order.ordered_reminders();
 
-        assert!(prompt.contains("# Available Tool Context"));
-        assert!(prompt.contains(SKILL_TOOL_CONTEXT_TITLE));
-        assert!(prompt.contains(TASK_TOOL_CONTEXT_TITLE));
-        assert!(prompt.contains(GET_TOOL_SPEC_CONTEXT_TITLE));
-        assert!(prompt.contains("<collapsed_tools>"));
-        assert!(prompt.contains("# Additional Context"));
-        assert!(prompt.contains(ADDITIONAL_CONTEXT_PROMPT));
-        assert!(prompt.find("# Available Tool Context") < prompt.find("# Additional Context"));
-        assert!(prompt.contains("Current Working Directory: E:/workspace"));
+        let skill_listing = reminders
+            .skill_listing
+            .expect("skill listing reminder should build");
+        let agent_listing = reminders
+            .agent_listing
+            .expect("agent listing reminder should build");
+        let collapsed_tool_listing = reminders
+            .collapsed_tool_listing
+            .expect("collapsed tool listing reminder should build");
+        let user_context = reminders.user_context.expect("user context should build");
+
+        assert!(skill_listing.contains(SKILL_LISTING_TITLE));
+        assert!(skill_listing.contains("<available_skills>"));
+        assert!(!skill_listing.contains(AGENT_LISTING_TITLE));
+        assert!(agent_listing.contains(AGENT_LISTING_TITLE));
+        assert!(agent_listing.contains("<available_agents>"));
+        assert!(!agent_listing.contains(COLLAPSED_TOOL_LISTING_TITLE));
+        assert!(collapsed_tool_listing.contains(COLLAPSED_TOOL_LISTING_TITLE));
+        assert!(collapsed_tool_listing.contains("<collapsed_tools>"));
+        assert!(user_context.contains("# User Context"));
+        assert!(user_context.contains(USER_CONTEXT_PROMPT));
+        assert!(user_context.contains("Current Working Directory: E:/workspace"));
+        assert_eq!(
+            ordered_reminders,
+            vec![
+                skill_listing.as_str(),
+                agent_listing.as_str(),
+                collapsed_tool_listing.as_str(),
+                user_context.as_str(),
+            ]
+        );
     }
 
     #[tokio::test]
-    async fn omits_request_context_when_policy_and_tool_sections_are_empty() {
+    async fn omits_prepended_reminders_when_policy_and_sections_are_empty() {
         let context = PromptBuilderContext::new("E:/workspace", None, None);
-        let prompt = PromptBuilder::new(context)
-            .build_request_context_reminder(&RequestContextPolicy::empty())
+        let reminders = PromptBuilder::new(context)
+            .build_prepended_reminders(&UserContextPolicy::empty())
             .await;
 
-        assert!(prompt.is_none());
+        assert_eq!(reminders, PrependedPromptReminders::default());
     }
 
     #[test]

--- a/src/crates/core/src/agentic/agents/prompt_builder/user_context.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/user_context.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RequestContextSection {
+pub enum UserContextSection {
     WorkspaceContext,
     WorkspaceInstructions,
     WorkspaceMemoryFiles,
@@ -7,51 +7,51 @@ pub enum RequestContextSection {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RequestContextPolicy {
-    pub sections: Vec<RequestContextSection>,
+pub struct UserContextPolicy {
+    pub sections: Vec<UserContextSection>,
 }
 
-impl RequestContextPolicy {
+impl UserContextPolicy {
     pub fn empty() -> Self {
         Self {
             sections: Vec::new(),
         }
     }
 
-    pub fn with_section(mut self, section: RequestContextSection) -> Self {
+    pub fn with_section(mut self, section: UserContextSection) -> Self {
         if !self.includes(section) {
             self.sections.push(section);
         }
         self
     }
 
-    pub fn without_section(mut self, section: RequestContextSection) -> Self {
+    pub fn without_section(mut self, section: UserContextSection) -> Self {
         self.sections.retain(|existing| *existing != section);
         self
     }
 
     pub fn with_workspace_context(self) -> Self {
-        self.with_section(RequestContextSection::WorkspaceContext)
+        self.with_section(UserContextSection::WorkspaceContext)
     }
 
     pub fn with_workspace_instructions(self) -> Self {
-        self.with_section(RequestContextSection::WorkspaceInstructions)
+        self.with_section(UserContextSection::WorkspaceInstructions)
     }
 
     pub fn with_workspace_memory_files(self) -> Self {
-        self.with_section(RequestContextSection::WorkspaceMemoryFiles)
+        self.with_section(UserContextSection::WorkspaceMemoryFiles)
     }
 
     pub fn with_project_layout(self) -> Self {
-        self.with_section(RequestContextSection::ProjectLayout)
+        self.with_section(UserContextSection::ProjectLayout)
     }
 
-    pub fn includes(&self, section: RequestContextSection) -> bool {
+    pub fn includes(&self, section: UserContextSection) -> bool {
         self.sections.contains(&section)
     }
 }
 
-impl Default for RequestContextPolicy {
+impl Default for UserContextPolicy {
     fn default() -> Self {
         Self::empty()
     }
@@ -59,30 +59,30 @@ impl Default for RequestContextPolicy {
 
 #[cfg(test)]
 mod tests {
-    use super::{RequestContextPolicy, RequestContextSection};
+    use super::{UserContextPolicy, UserContextSection};
 
     #[test]
     fn chain_builder_preserves_order_and_dedupes_sections() {
-        let policy = RequestContextPolicy::empty()
+        let policy = UserContextPolicy::empty()
             .with_workspace_context()
             .with_workspace_instructions()
             .with_workspace_context()
             .with_project_layout()
-            .without_section(RequestContextSection::ProjectLayout)
+            .without_section(UserContextSection::ProjectLayout)
             .with_workspace_memory_files();
 
         assert_eq!(
             policy.sections,
             vec![
-                RequestContextSection::WorkspaceContext,
-                RequestContextSection::WorkspaceInstructions,
-                RequestContextSection::WorkspaceMemoryFiles,
+                UserContextSection::WorkspaceContext,
+                UserContextSection::WorkspaceInstructions,
+                UserContextSection::WorkspaceMemoryFiles,
             ]
         );
     }
 
     #[test]
     fn default_policy_is_empty() {
-        assert!(RequestContextPolicy::default().sections.is_empty());
+        assert!(UserContextPolicy::default().sections.is_empty());
     }
 }

--- a/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
+++ b/src/crates/core/src/agentic/agents/prompts/deep_research_agent.md
@@ -83,7 +83,7 @@ WORK_DIR     = <workspace_root>/.bitfun/sessions/{SESSION_ID}/research
 REPORT_PATH  = <WORK_DIR>/report.md
 ```
 
-`{SESSION_ID}` above is replaced at prompt build time with the current session's ID. `<workspace_root>` is the workspace root shown in additional context — use it verbatim.
+`{SESSION_ID}` above is replaced at prompt build time with the current session's ID. `<workspace_root>` is the workspace root shown in user context — use it verbatim.
 
 **File-layout convention.** Everything for this research session lives under `WORK_DIR`:
 

--- a/src/crates/core/src/agentic/agents/registry/tests.rs
+++ b/src/crates/core/src/agentic/agents/registry/tests.rs
@@ -9,7 +9,7 @@ use crate::agentic::agents::registry::types::{
 use crate::agentic::agents::registry::visibility::{
     BuiltinSubagentExposure, SubagentVisibilityPolicy,
 };
-use crate::agentic::agents::{Agent, RequestContextPolicy};
+use crate::agentic::agents::{Agent, UserContextPolicy};
 use crate::service::config::types::AgentSubagentOverrideState;
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -42,8 +42,8 @@ impl Agent for TestAgent {
         "test_agent"
     }
 
-    fn request_context_policy(&self) -> RequestContextPolicy {
-        RequestContextPolicy::empty()
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
     }
 
     fn default_tools(&self) -> Vec<String> {

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -5,8 +5,8 @@
 use super::round_executor::RoundExecutor;
 use super::types::{ExecutionContext, ExecutionResult, RoundContext, RoundResult};
 use crate::agentic::agents::{
-    get_agent_registry, PromptBuilder, PromptBuilderContext, RemoteExecutionHints,
-    RequestContextToolSections,
+    get_agent_registry, PrependedPromptReminders, PromptBuilder, PromptBuilderContext,
+    RemoteExecutionHints, ToolListingSections,
 };
 use crate::agentic::context_profile::{ContextProfilePolicy, ModelCapabilityProfile};
 use crate::agentic::core::{
@@ -568,10 +568,10 @@ impl ExecutionEngine {
         )
     }
 
-    async fn build_request_context_tool_sections(
+    async fn build_tool_listing_sections(
         manifest: &ResolvedToolManifest,
         tool_context: &crate::agentic::tools::framework::ToolUseContext,
-    ) -> RequestContextToolSections {
+    ) -> ToolListingSections {
         let has_tool_definition = |tool_name: &str| {
             manifest
                 .tool_definitions
@@ -579,18 +579,18 @@ impl ExecutionEngine {
                 .any(|definition| definition.name == tool_name)
         };
 
-        RequestContextToolSections {
-            available_skills: if has_tool_definition("Skill") {
+        ToolListingSections {
+            skill_listing: if has_tool_definition("Skill") {
                 SkillTool::build_available_skills_context_section(Some(tool_context)).await
             } else {
                 None
             },
-            available_agents: if has_tool_definition("Task") {
+            agent_listing: if has_tool_definition("Task") {
                 TaskTool::build_available_agents_context_section(Some(tool_context)).await
             } else {
                 None
             },
-            collapsed_tools: if has_tool_definition("GetToolSpec") {
+            collapsed_tool_listing: if has_tool_definition("GetToolSpec") {
                 GetToolSpecTool::build_collapsed_tools_context_section(
                     &manifest.collapsed_tool_summaries,
                 )
@@ -604,7 +604,7 @@ impl ExecutionEngine {
         context: &ExecutionContext,
         model_name: &str,
         supports_image_understanding: bool,
-        request_context_tools: RequestContextToolSections,
+        tool_listing_sections: ToolListingSections,
     ) -> Option<PromptBuilderContext> {
         let workspace_path = context
             .workspace
@@ -636,7 +636,7 @@ impl ExecutionEngine {
         )
         .with_related_paths(related_paths)
         .with_supports_image_understanding(supports_image_understanding)
-        .with_request_context_tools(request_context_tools);
+        .with_tool_listing_sections(tool_listing_sections);
 
         let Some(workspace) = context.workspace.as_ref() else {
             return Some(base);
@@ -816,7 +816,7 @@ impl ExecutionEngine {
         round_number: usize,
         execution_context_vars: &HashMap<String, String>,
         primary_supports_image_understanding: bool,
-        request_context_reminder: Option<&str>,
+        prepended_reminders: &[&str],
         messages: &[Message],
         reminder_text: &str,
         context_window: usize,
@@ -830,7 +830,7 @@ impl ExecutionEngine {
                 .map(|workspace| workspace.root_path()),
             &context.dialog_turn_id,
             primary_supports_image_understanding,
-            request_context_reminder,
+            prepended_reminders,
         )
         .await?;
         final_ai_messages.push(AIMessage::user(reminder_text.to_string()));
@@ -874,23 +874,19 @@ impl ExecutionEngine {
         workspace_path: Option<&Path>,
         current_turn_id: &str,
         attach_images: bool,
-        prepended_user_context: Option<&str>,
+        prepended_reminders: &[&str],
     ) -> BitFunResult<Vec<AIMessage>> {
         /// Only the last this many **messages** that contain images keep their images for the API.
         const MAX_IMAGE_BEARING_MESSAGE_ROUNDS: usize = 2;
 
         let limits = ImageLimits::for_provider(provider);
 
-        let trimmed_user_context = prepended_user_context.and_then(|text| {
-            let trimmed = text.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed)
-            }
-        });
-        let mut result =
-            Vec::with_capacity(messages.len() + usize::from(trimmed_user_context.is_some()));
+        let trimmed_reminders = prepended_reminders
+            .iter()
+            .map(|text| text.trim())
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>();
+        let mut result = Vec::with_capacity(messages.len() + trimmed_reminders.len());
         let mut attached_image_count = 0usize;
         let first_non_system_index = messages
             .iter()
@@ -906,8 +902,8 @@ impl ExecutionEngine {
 
         for (msg_idx, msg) in messages.iter().enumerate() {
             if !user_context_injected && msg_idx == first_non_system_index {
-                if let Some(user_context) = trimmed_user_context {
-                    result.push(AIMessage::user(render_system_reminder(user_context)));
+                for reminder in &trimmed_reminders {
+                    result.push(AIMessage::user(render_system_reminder(reminder)));
                 }
                 user_context_injected = true;
             }
@@ -1033,8 +1029,8 @@ impl ExecutionEngine {
         }
 
         if !user_context_injected {
-            if let Some(user_context) = trimmed_user_context {
-                result.push(AIMessage::user(render_system_reminder(user_context)));
+            for reminder in trimmed_reminders {
+                result.push(AIMessage::user(render_system_reminder(reminder)));
             }
         }
 
@@ -1662,10 +1658,10 @@ impl ExecutionEngine {
             .as_ref()
             .map(|manifest| manifest.collapsed_tool_names.clone())
             .unwrap_or_default();
-        let request_context_tools = if let Some(manifest) = tool_manifest.as_ref() {
-            Self::build_request_context_tool_sections(manifest, &tool_description_context).await
+        let tool_listing_sections = if let Some(manifest) = tool_manifest.as_ref() {
+            Self::build_tool_listing_sections(manifest, &tool_description_context).await
         } else {
-            RequestContextToolSections::default()
+            ToolListingSections::default()
         };
         let (available_tools, tool_definitions) = if let Some(manifest) = tool_manifest {
             (manifest.allowed_tool_names, Some(manifest.tool_definitions))
@@ -1683,23 +1679,40 @@ impl ExecutionEngine {
             &context,
             &ai_client.config.model,
             primary_supports_image_understanding,
-            request_context_tools,
+            tool_listing_sections,
         )
         .await;
-        let request_context_reminder = if let Some(prompt_context) = prompt_context.as_ref() {
+        let prepended_prompt_reminders = if let Some(prompt_context) = prompt_context.as_ref() {
             PromptBuilder::new(prompt_context.clone())
-                .build_request_context_reminder(&current_agent.request_context_policy())
+                .build_prepended_reminders(&current_agent.user_context_policy())
                 .await
         } else {
-            None
+            PrependedPromptReminders::default()
         };
+        let prepended_reminders = prepended_prompt_reminders.ordered_reminders();
         let system_prompt = current_agent
             .get_system_prompt(prompt_context.as_ref())
             .await?;
         debug!("System prompt built, length: {} bytes", system_prompt.len());
         debug!(
-            "Request context reminder built, length: {} bytes",
-            request_context_reminder
+            "Prepended reminders built: skill_listing_len={} agent_listing_len={} collapsed_tool_listing_len={} user_context_len={}",
+            prepended_prompt_reminders
+                .skill_listing
+                .as_ref()
+                .map(|text| text.len())
+                .unwrap_or(0),
+            prepended_prompt_reminders
+                .agent_listing
+                .as_ref()
+                .map(|text| text.len())
+                .unwrap_or(0),
+            prepended_prompt_reminders
+                .collapsed_tool_listing
+                .as_ref()
+                .map(|text| text.len())
+                .unwrap_or(0),
+            prepended_prompt_reminders
+                .user_context
                 .as_ref()
                 .map(|text| text.len())
                 .unwrap_or(0)
@@ -2003,7 +2016,7 @@ impl ExecutionEngine {
                     .map(|workspace| workspace.root_path()),
                 &context.dialog_turn_id,
                 primary_supports_image_understanding,
-                request_context_reminder.as_deref(),
+                &prepended_reminders,
             )
             .await?;
 
@@ -2286,9 +2299,7 @@ impl ExecutionEngine {
                     if let Some(ref reason) = round_result.partial_recovery_reason {
                         if Self::should_continue_after_partial_response(reason) {
                             partial_continuation_attempts += 1;
-                            if partial_continuation_attempts
-                                <= MAX_PARTIAL_CONTINUATION_ATTEMPTS
-                            {
+                            if partial_continuation_attempts <= MAX_PARTIAL_CONTINUATION_ATTEMPTS {
                                 let reminder = format!(
                                     "<system_reminder>Your previous assistant response was interrupted mid-stream ({reason}). Continue writing from exactly where you stopped. Do not repeat content that was already delivered; pick up seamlessly and complete the answer.</system_reminder>"
                                 );
@@ -2299,10 +2310,7 @@ impl ExecutionEngine {
                                     .add_message(&context.session_id, user_msg)
                                     .await
                                 {
-                                    warn!(
-                                        "Failed to persist partial continuation reminder: {}",
-                                        e
-                                    );
+                                    warn!("Failed to persist partial continuation reminder: {}", e);
                                 }
                                 warn!(
                                     "Partial stream recovery with assistant text; injecting continuation reminder #{}/{}: turn={}, round={}, reason={}",
@@ -2449,7 +2457,7 @@ impl ExecutionEngine {
                         completed_rounds,
                         &execution_context_vars,
                         primary_supports_image_understanding,
-                        request_context_reminder.as_deref(),
+                        &prepended_reminders,
                         &messages,
                         Self::FINALIZE_AFTER_TOOL_USE_REMINDER,
                         context_window,
@@ -2480,7 +2488,7 @@ impl ExecutionEngine {
                             completed_rounds,
                             &execution_context_vars,
                             primary_supports_image_understanding,
-                            request_context_reminder.as_deref(),
+                            &prepended_reminders,
                             &messages,
                             Self::FORCE_TEXT_ONLY_REMINDER,
                             context_window,

--- a/src/crates/core/src/agentic/tools/implementations/get_tool_spec_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/get_tool_spec_tool.rs
@@ -19,7 +19,7 @@ const GET_TOOL_SPEC_DESCRIPTION: &str = r#"Read usage instructions for additiona
 
 Some tools are collapsed: their names may appear in the tool list, but you must not call them directly until you have loaded their definition with GetToolSpec.
 
-When the current request context includes a <collapsed_tools> section, use the exact tool names from that section. Before using one of those tools, first call GetToolSpec with its exact tool name to read its full description and input schema. After reading the returned definition, call the real tool directly using its own name.
+When the current collapsed tool listing includes a <collapsed_tools> section, use the exact tool names from that section. Before using one of those tools, first call GetToolSpec with its exact tool name to read its full description and input schema. After reading the returned definition, call the real tool directly using its own name.
 
 Do not call GetToolSpec again for a tool whose definition is already loaded in the current conversation."#;
 

--- a/src/crates/core/src/agentic/tools/implementations/skill_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/skill_tool.rs
@@ -26,7 +26,7 @@ impl SkillTool {
         r#"Execute a skill within the main conversation
 
 <skills_instructions>
-When users ask you to perform tasks, check whether any skills listed in the current request context can help complete the task more effectively. Skills provide specialized capabilities and domain knowledge.
+When users ask you to perform tasks, check whether any skills listed in the current skill listing can help complete the task more effectively. Skills provide specialized capabilities and domain knowledge.
 
 How to use skills:
 - Invoke skills using this tool with the skill name only (no arguments)
@@ -37,7 +37,7 @@ How to use skills:
   - `command: "ms-office-suite:pdf"` - invoke using fully qualified name
 
 Important:
-- Only use skills listed in the current request context's <available_skills> section
+- Only use skills listed in the current skill listing's <available_skills> section
 - Do not invoke a skill that is already running
 </skills_instructions>"#
             .to_string()

--- a/src/crates/core/src/agentic/tools/implementations/task_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/task_tool.rs
@@ -420,7 +420,7 @@ impl TaskTool {
 
 The Task tool launches specialized agents (subprocesses) that autonomously handle complex tasks. Each agent type has specific capabilities and tools available to it.
 
-The current request context includes an <available_agents> section when subagents are available. Use the exact `type` attribute from that section as `subagent_type`.
+The current agent listing includes an <available_agents> section when subagents are available. Use the exact `type` attribute from that section as `subagent_type`.
 
 When using the Task tool, you must specify `subagent_type` as a top-level tool argument to select which agent type to use. Do not put `subagent_type`, `description`, `workspace_path`, `model_id`, or `timeout_seconds` inside the prompt string.
 
@@ -1553,7 +1553,7 @@ mod tests {
     use super::TaskTool;
     use crate::agentic::agents::CustomSubagentConfig;
     use crate::agentic::agents::{
-        get_agent_registry, Agent, AgentCategory, RequestContextPolicy, SubAgentSource,
+        get_agent_registry, Agent, AgentCategory, SubAgentSource, UserContextPolicy,
     };
     use crate::agentic::deep_review::task_adapter as deep_review_task_adapter;
     use crate::agentic::deep_review_policy::{
@@ -1593,8 +1593,8 @@ mod tests {
             "test_prompt_order_agent"
         }
 
-        fn request_context_policy(&self) -> RequestContextPolicy {
-            RequestContextPolicy::empty()
+        fn user_context_policy(&self) -> UserContextPolicy {
+            UserContextPolicy::empty()
         }
 
         fn default_tools(&self) -> Vec<String> {


### PR DESCRIPTION
- rename request-context types and prompt-builder APIs to user-context for clearer semantics
- split prepended tool reminders into skill listing, agent listing, and collapsed tool listing
- update execution prompt injection to preserve ordered multi-reminder delivery
- align tool guidance, agent policies, tests, and prompt wording with the new naming model
