### PR TITLE
feat(core): add session-scoped prompt cache with lazy restore

### DIFF
--- a/src/crates/core/src/agentic/agents/definitions/custom/subagent.rs
+++ b/src/crates/core/src/agentic/agents/definitions/custom/subagent.rs
@@ -1,9 +1,11 @@
 use crate::agentic::agents::Agent;
 use crate::agentic::agents::{PromptBuilder, PromptBuilderContext, UserContextPolicy};
+use crate::agentic::session::SystemPromptCacheIdentity;
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::FrontMatterMarkdown;
 use async_trait::async_trait;
 use serde_yaml::Value;
+use sha2::{Digest, Sha256};
 
 /// Subagent type: project-level or user-level
 #[derive(Debug, Clone, Copy)]
@@ -47,6 +49,11 @@ impl Agent for CustomSubagent {
 
     fn prompt_template_name(&self, _model_name: Option<&str>) -> &str {
         ""
+    }
+
+    fn system_prompt_cache_identity(&self, _model_name: Option<&str>) -> SystemPromptCacheIdentity {
+        let prompt_hash = hex::encode(Sha256::digest(self.prompt.as_bytes()));
+        SystemPromptCacheIdentity::new(self.id(), format!("custom_prompt_sha256:{prompt_hash}"))
     }
 
     async fn build_prompt(&self, context: &PromptBuilderContext) -> BitFunResult<String> {

--- a/src/crates/core/src/agentic/agents/mod.rs
+++ b/src/crates/core/src/agentic/agents/mod.rs
@@ -10,6 +10,7 @@ mod registry;
 // consecutive `[N]` display IDs after the dialog turn completes.
 pub(crate) mod citation_renumber;
 
+use crate::agentic::session::SystemPromptCacheIdentity;
 use crate::agentic::tools::framework::ToolExposure;
 use crate::agentic::WorkspaceBinding;
 use crate::util::errors::{BitFunError, BitFunResult};
@@ -94,6 +95,17 @@ pub trait Agent: Send + Sync + 'static {
 
     /// Prompt template name for the agent.
     fn prompt_template_name(&self, model_name: Option<&str>) -> &str;
+
+    fn system_prompt_cache_identity(&self, model_name: Option<&str>) -> SystemPromptCacheIdentity {
+        let template_name = self.prompt_template_name(model_name).trim();
+        let prompt_identity = if template_name.is_empty() {
+            format!("agent:{}", self.id())
+        } else {
+            format!("template:{}", template_name)
+        };
+
+        SystemPromptCacheIdentity::new(self.id(), prompt_identity)
+    }
 
     fn system_reminder_template_name(&self) -> Option<&str> {
         None // by default, no system reminder

--- a/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -23,7 +23,7 @@ const PLACEHOLDER_CLAW_WORKSPACE: &str = "{CLAW_WORKSPACE}";
 const PLACEHOLDER_VISUAL_MODE: &str = "{VISUAL_MODE}";
 const PLACEHOLDER_SESSION_ID: &str = "{SESSION_ID}";
 const USER_CONTEXT_PROMPT: &str =
-    "As you answer the user's questions, you can use the following context";
+    "As you answer the user's questions, you can use the following context.\nNote: this is a snapshot captured at the start of the conversation and may not reflect real-time changes made afterward.";
 const SKILL_LISTING_TITLE: &str = "# Skill Listing";
 const SKILL_LISTING_GUIDANCE: &str =
     "The following skills are available for use with the Skill tool:";

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -696,6 +696,78 @@ impl ExecutionEngine {
         ))
     }
 
+    async fn build_cached_prepended_prompt_reminders(
+        &self,
+        session_id: &str,
+        current_agent: &dyn crate::agentic::agents::Agent,
+        prompt_context: Option<&PromptBuilderContext>,
+    ) -> PrependedPromptReminders {
+        let Some(prompt_context) = prompt_context.cloned() else {
+            return PrependedPromptReminders::default();
+        };
+
+        let prompt_builder = PromptBuilder::new(prompt_context);
+        let user_context = if let Some(cached_user_context) =
+            self.session_manager.cached_user_context(session_id).await
+        {
+            debug!("User context cache hit: session_id={}", session_id);
+            Some(cached_user_context)
+        } else {
+            debug!("User context cache miss: session_id={}", session_id);
+            let built_user_context = prompt_builder
+                .build_user_context_reminder(&current_agent.user_context_policy())
+                .await;
+            if let Some(ref user_context) = built_user_context {
+                self.session_manager
+                    .remember_user_context(session_id, user_context.clone())
+                    .await;
+            }
+            built_user_context
+        };
+
+        PrependedPromptReminders {
+            skill_listing: prompt_builder.build_skill_listing_reminder(),
+            agent_listing: prompt_builder.build_agent_listing_reminder(),
+            collapsed_tool_listing: prompt_builder.build_collapsed_tool_listing_reminder(),
+            user_context,
+        }
+    }
+
+    async fn resolve_cached_system_prompt(
+        &self,
+        session_id: &str,
+        current_agent: &dyn crate::agentic::agents::Agent,
+        prompt_context: Option<&PromptBuilderContext>,
+    ) -> BitFunResult<String> {
+        let identity = prompt_context
+            .map(|context| {
+                current_agent.system_prompt_cache_identity(context.model_name.as_deref())
+            })
+            .unwrap_or_else(|| current_agent.system_prompt_cache_identity(None));
+
+        if let Some(cached_system_prompt) = self
+            .session_manager
+            .cached_system_prompt(session_id, &identity)
+            .await
+        {
+            debug!(
+                "System prompt cache hit: session_id={}, agent_id={}, prompt_identity={}",
+                session_id, identity.agent_id, identity.prompt_identity
+            );
+            return Ok(cached_system_prompt);
+        }
+
+        debug!(
+            "System prompt cache miss: session_id={}, agent_id={}, prompt_identity={}",
+            session_id, identity.agent_id, identity.prompt_identity
+        );
+        let system_prompt = current_agent.get_system_prompt(prompt_context).await?;
+        self.session_manager
+            .remember_system_prompt(session_id, identity, system_prompt.clone())
+            .await;
+        Ok(system_prompt)
+    }
+
     pub(crate) async fn resolve_model_id_for_turn(
         &self,
         session: &Session,
@@ -1139,6 +1211,13 @@ impl ExecutionEngine {
                 self.session_manager
                     .replace_context_messages(session_id, compression_result.messages.clone())
                     .await;
+                self.session_manager
+                    .invalidate_prompt_cache(
+                        session_id,
+                        crate::agentic::session::PromptCacheScope::All,
+                        "context_compression_applied",
+                    )
+                    .await;
                 let mut new_messages = vec![system_prompt_message];
                 new_messages.extend(compression_result.messages);
                 // Update session compression state
@@ -1322,6 +1401,13 @@ impl ExecutionEngine {
                 let mut compressed_messages = compression_result.messages;
                 self.session_manager
                     .replace_context_messages(session_id, compressed_messages.clone())
+                    .await;
+                self.session_manager
+                    .invalidate_prompt_cache(
+                        session_id,
+                        crate::agentic::session::PromptCacheScope::All,
+                        "manual_context_compaction_applied",
+                    )
                     .await;
 
                 session.compression_state.increment_compression_count();
@@ -1682,16 +1768,20 @@ impl ExecutionEngine {
             tool_listing_sections,
         )
         .await;
-        let prepended_prompt_reminders = if let Some(prompt_context) = prompt_context.as_ref() {
-            PromptBuilder::new(prompt_context.clone())
-                .build_prepended_reminders(&current_agent.user_context_policy())
-                .await
-        } else {
-            PrependedPromptReminders::default()
-        };
+        let prepended_prompt_reminders = self
+            .build_cached_prepended_prompt_reminders(
+                &context.session_id,
+                current_agent.as_ref(),
+                prompt_context.as_ref(),
+            )
+            .await;
         let prepended_reminders = prepended_prompt_reminders.ordered_reminders();
-        let system_prompt = current_agent
-            .get_system_prompt(prompt_context.as_ref())
+        let system_prompt = self
+            .resolve_cached_system_prompt(
+                &context.session_id,
+                current_agent.as_ref(),
+                prompt_context.as_ref(),
+            )
             .await?;
         debug!("System prompt built, length: {} bytes", system_prompt.len());
         debug!(

--- a/src/crates/core/src/agentic/persistence/manager.rs
+++ b/src/crates/core/src/agentic/persistence/manager.rs
@@ -6,14 +6,16 @@ use crate::agentic::core::{
     strip_prompt_markup, CompressionState, Message, MessageContent, Session, SessionConfig,
     SessionKind, SessionState, SessionSummary,
 };
+use crate::agentic::session::{SessionPromptCache, PROMPT_CACHE_SCHEMA_VERSION};
 use crate::infrastructure::PathManager;
 use crate::service::remote_ssh::workspace_state::{
     resolve_workspace_session_identity, LOCAL_WORKSPACE_SSH_HOST,
 };
 use crate::service::session::{
-    DialogTurnData, SessionMetadata, SessionRelationship, SessionRelationshipKind, SessionStatus, SessionTranscriptExport,
-    SessionTranscriptExportOptions, SessionTranscriptIndexEntry, StoredSessionIndexFile,
-    StoredSessionMetadataFile, ToolItemData, TranscriptLineRange, SESSION_STORAGE_SCHEMA_VERSION,
+    DialogTurnData, SessionMetadata, SessionRelationship, SessionRelationshipKind, SessionStatus,
+    SessionTranscriptExport, SessionTranscriptExportOptions, SessionTranscriptIndexEntry,
+    StoredSessionIndexFile, StoredSessionMetadataFile, ToolItemData, TranscriptLineRange,
+    SESSION_STORAGE_SCHEMA_VERSION,
 };
 use crate::service::workspace_runtime::WorkspaceRuntimeService;
 use crate::util::errors::{BitFunError, BitFunResult};
@@ -56,6 +58,13 @@ struct StoredSessionStateFile {
     last_user_dialog_agent_type: Option<String>,
     compression_state: CompressionState,
     runtime_state: SessionState,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredSessionPromptCacheFile {
+    schema_version: u32,
+    #[serde(flatten)]
+    cache: SessionPromptCache,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -383,6 +392,11 @@ impl PersistenceManager {
     fn state_path(&self, workspace_path: &Path, session_id: &str) -> PathBuf {
         self.session_dir(workspace_path, session_id)
             .join("state.json")
+    }
+
+    fn prompt_cache_path(&self, workspace_path: &Path, session_id: &str) -> PathBuf {
+        self.session_dir(workspace_path, session_id)
+            .join("prompt_cache.json")
     }
 
     fn turns_dir(&self, workspace_path: &Path, session_id: &str) -> PathBuf {
@@ -1690,6 +1704,53 @@ impl PersistenceManager {
     ) -> BitFunResult<()> {
         self.write_json_atomic(&self.state_path(workspace_path, session_id), state)
             .await
+    }
+
+    pub async fn load_prompt_cache(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+    ) -> BitFunResult<Option<SessionPromptCache>> {
+        Ok(self
+            .read_json_optional::<StoredSessionPromptCacheFile>(
+                &self.prompt_cache_path(workspace_path, session_id),
+            )
+            .await?
+            .map(|file| file.cache))
+    }
+
+    pub async fn save_prompt_cache(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        cache: &SessionPromptCache,
+    ) -> BitFunResult<()> {
+        self.ensure_runtime_for_write(workspace_path).await?;
+        self.ensure_session_dir(workspace_path, session_id).await?;
+
+        self.write_json_atomic(
+            &self.prompt_cache_path(workspace_path, session_id),
+            &StoredSessionPromptCacheFile {
+                schema_version: PROMPT_CACHE_SCHEMA_VERSION,
+                cache: cache.clone(),
+            },
+        )
+        .await
+    }
+
+    pub async fn delete_prompt_cache(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+    ) -> BitFunResult<()> {
+        match fs::remove_file(self.prompt_cache_path(workspace_path, session_id)).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(BitFunError::io(format!(
+                "Failed to delete prompt cache for session {}: {}",
+                session_id, error
+            ))),
+        }
     }
 
     // ============ Turn context snapshot (sent to model)============

--- a/src/crates/core/src/agentic/session/mod.rs
+++ b/src/crates/core/src/agentic/session/mod.rs
@@ -3,13 +3,15 @@
 //! Provides session lifecycle management and context management.
 
 pub mod compression;
-pub mod file_read_state;
 pub mod context_store;
 pub mod evidence_ledger;
+pub mod file_read_state;
+pub mod prompt_cache;
 pub mod session_manager;
 
 pub use compression::*;
-pub use file_read_state::*;
 pub use context_store::*;
 pub use evidence_ledger::*;
+pub use file_read_state::*;
+pub use prompt_cache::*;
 pub use session_manager::*;

--- a/src/crates/core/src/agentic/session/prompt_cache.rs
+++ b/src/crates/core/src/agentic/session/prompt_cache.rs
@@ -1,0 +1,361 @@
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+pub const PROMPT_CACHE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptCachePolicy {
+    pub cache_ttl: Option<Duration>,
+    pub persistence_ttl: Option<Duration>,
+}
+
+impl Default for PromptCachePolicy {
+    fn default() -> Self {
+        Self {
+            cache_ttl: None,
+            persistence_ttl: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SystemPromptCacheIdentity {
+    pub agent_id: String,
+    pub prompt_identity: String,
+}
+
+impl SystemPromptCacheIdentity {
+    pub fn new(agent_id: impl Into<String>, prompt_identity: impl Into<String>) -> Self {
+        Self {
+            agent_id: agent_id.into(),
+            prompt_identity: prompt_identity.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CachedPromptText {
+    pub content: String,
+    pub created_at_ms: u64,
+}
+
+impl CachedPromptText {
+    pub fn new(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            created_at_ms: current_time_ms(),
+        }
+    }
+
+    pub fn is_expired(&self, ttl: Option<Duration>, now_ms: u64) -> bool {
+        ttl.is_some_and(|ttl| {
+            let ttl_ms = ttl.as_millis().try_into().unwrap_or(u64::MAX);
+            now_ms.saturating_sub(self.created_at_ms) >= ttl_ms
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CachedSystemPrompt {
+    #[serde(flatten)]
+    pub text: CachedPromptText,
+    pub identity: SystemPromptCacheIdentity,
+}
+
+impl CachedSystemPrompt {
+    pub fn new(identity: SystemPromptCacheIdentity, content: impl Into<String>) -> Self {
+        Self {
+            text: CachedPromptText::new(content),
+            identity,
+        }
+    }
+
+    pub fn is_usable(
+        &self,
+        identity: &SystemPromptCacheIdentity,
+        ttl: Option<Duration>,
+        now_ms: u64,
+    ) -> bool {
+        self.identity == *identity && !self.text.is_expired(ttl, now_ms)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionPromptCache {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_prompt: Option<CachedSystemPrompt>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_context: Option<CachedPromptText>,
+}
+
+impl SessionPromptCache {
+    pub fn apply_persistence_ttl(&mut self, ttl: Option<Duration>) -> bool {
+        let now_ms = current_time_ms();
+        let mut changed = false;
+
+        if self
+            .system_prompt
+            .as_ref()
+            .is_some_and(|entry| entry.text.is_expired(ttl, now_ms))
+        {
+            self.system_prompt = None;
+            changed = true;
+        }
+
+        if self
+            .user_context
+            .as_ref()
+            .is_some_and(|entry| entry.is_expired(ttl, now_ms))
+        {
+            self.user_context = None;
+            changed = true;
+        }
+
+        changed
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.system_prompt.is_none() && self.user_context.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptCacheScope {
+    SystemPrompt,
+    UserContext,
+    All,
+}
+
+impl PromptCacheScope {
+    fn clears_system_prompt(self) -> bool {
+        matches!(self, Self::SystemPrompt | Self::All)
+    }
+
+    fn clears_user_context(self) -> bool {
+        matches!(self, Self::UserContext | Self::All)
+    }
+}
+
+pub struct SessionPromptCacheStore {
+    session_caches: Arc<DashMap<String, SessionPromptCache>>,
+}
+
+pub enum PromptCacheLookup {
+    Hit(String),
+    Miss,
+    Expired,
+}
+
+impl Default for SessionPromptCacheStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionPromptCacheStore {
+    pub fn new() -> Self {
+        Self {
+            session_caches: Arc::new(DashMap::new()),
+        }
+    }
+
+    pub fn create_session(&self, session_id: &str) {
+        self.session_caches
+            .entry(session_id.to_string())
+            .or_default();
+    }
+
+    pub fn has_session(&self, session_id: &str) -> bool {
+        self.session_caches.contains_key(session_id)
+    }
+
+    pub fn replace_cache(&self, session_id: &str, cache: SessionPromptCache) {
+        self.session_caches.insert(session_id.to_string(), cache);
+    }
+
+    pub fn get_cache(&self, session_id: &str) -> Option<SessionPromptCache> {
+        self.session_caches
+            .get(session_id)
+            .map(|cache| cache.clone())
+    }
+
+    pub fn lookup_system_prompt(
+        &self,
+        session_id: &str,
+        identity: &SystemPromptCacheIdentity,
+        ttl: Option<Duration>,
+    ) -> PromptCacheLookup {
+        let now_ms = current_time_ms();
+        let cached_entry = self
+            .session_caches
+            .get(session_id)
+            .and_then(|cache| cache.system_prompt.clone());
+
+        match cached_entry {
+            Some(entry) if entry.is_usable(identity, ttl, now_ms) => {
+                PromptCacheLookup::Hit(entry.text.content)
+            }
+            Some(entry) if entry.text.is_expired(ttl, now_ms) => {
+                self.invalidate(session_id, PromptCacheScope::SystemPrompt);
+                PromptCacheLookup::Expired
+            }
+            _ => PromptCacheLookup::Miss,
+        }
+    }
+
+    pub fn lookup_user_context(
+        &self,
+        session_id: &str,
+        ttl: Option<Duration>,
+    ) -> PromptCacheLookup {
+        let now_ms = current_time_ms();
+        let cached_entry = self
+            .session_caches
+            .get(session_id)
+            .and_then(|cache| cache.user_context.clone());
+
+        match cached_entry {
+            Some(entry) if !entry.is_expired(ttl, now_ms) => PromptCacheLookup::Hit(entry.content),
+            Some(_) => {
+                self.invalidate(session_id, PromptCacheScope::UserContext);
+                PromptCacheLookup::Expired
+            }
+            None => PromptCacheLookup::Miss,
+        }
+    }
+
+    pub fn set_system_prompt(&self, session_id: &str, entry: CachedSystemPrompt) {
+        if let Some(mut cache) = self.session_caches.get_mut(session_id) {
+            cache.system_prompt = Some(entry);
+        } else {
+            self.session_caches.insert(
+                session_id.to_string(),
+                SessionPromptCache {
+                    system_prompt: Some(entry),
+                    user_context: None,
+                },
+            );
+        }
+    }
+
+    pub fn set_user_context(&self, session_id: &str, entry: CachedPromptText) {
+        if let Some(mut cache) = self.session_caches.get_mut(session_id) {
+            cache.user_context = Some(entry);
+        } else {
+            self.session_caches.insert(
+                session_id.to_string(),
+                SessionPromptCache {
+                    system_prompt: None,
+                    user_context: Some(entry),
+                },
+            );
+        }
+    }
+
+    pub fn invalidate(&self, session_id: &str, scope: PromptCacheScope) -> bool {
+        let Some(mut cache) = self.session_caches.get_mut(session_id) else {
+            return false;
+        };
+
+        let mut changed = false;
+        if scope.clears_system_prompt() && cache.system_prompt.take().is_some() {
+            changed = true;
+        }
+        if scope.clears_user_context() && cache.user_context.take().is_some() {
+            changed = true;
+        }
+        changed
+    }
+
+    pub fn delete_session(&self, session_id: &str) {
+        self.session_caches.remove(session_id);
+    }
+}
+
+fn current_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CachedPromptText, CachedSystemPrompt, PromptCacheLookup, PromptCacheScope,
+        SessionPromptCacheStore, SystemPromptCacheIdentity,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn system_prompt_cache_requires_matching_identity() {
+        let store = SessionPromptCacheStore::new();
+        store.create_session("session-1");
+        store.set_system_prompt(
+            "session-1",
+            CachedSystemPrompt::new(
+                SystemPromptCacheIdentity::new("agentic", "template:agentic_mode"),
+                "prompt-a",
+            ),
+        );
+
+        assert_eq!(
+            match store.lookup_system_prompt(
+                "session-1",
+                &SystemPromptCacheIdentity::new("agentic", "template:agentic_mode"),
+                None,
+            ) {
+                PromptCacheLookup::Hit(value) => Some(value),
+                _ => None,
+            },
+            Some("prompt-a".to_string())
+        );
+        assert!(matches!(
+            store.lookup_system_prompt(
+                "session-1",
+                &SystemPromptCacheIdentity::new("debug", "template:debug_mode"),
+                None,
+            ),
+            PromptCacheLookup::Miss
+        ));
+    }
+
+    #[test]
+    fn expired_user_context_is_evicted_on_read() {
+        let store = SessionPromptCacheStore::new();
+        store.create_session("session-1");
+        store.set_user_context("session-1", CachedPromptText::new("stale context"));
+
+        assert!(matches!(
+            store.lookup_user_context("session-1", Some(Duration::from_millis(0))),
+            PromptCacheLookup::Expired
+        ));
+        assert!(store
+            .get_cache("session-1")
+            .expect("session cache")
+            .user_context
+            .is_none());
+    }
+
+    #[test]
+    fn invalidate_scope_can_clear_all_cached_prompt_parts() {
+        let store = SessionPromptCacheStore::new();
+        store.create_session("session-1");
+        store.set_system_prompt(
+            "session-1",
+            CachedSystemPrompt::new(
+                SystemPromptCacheIdentity::new("agentic", "template:agentic_mode"),
+                "prompt-a",
+            ),
+        );
+        store.set_user_context("session-1", CachedPromptText::new("context"));
+
+        assert!(store.invalidate("session-1", PromptCacheScope::All));
+
+        let cache = store.get_cache("session-1").expect("session cache");
+        assert!(cache.system_prompt.is_none());
+        assert!(cache.user_context.is_none());
+    }
+}

--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -9,9 +9,11 @@ use crate::agentic::core::{
 use crate::agentic::image_analysis::ImageContextData;
 use crate::agentic::persistence::PersistenceManager;
 use crate::agentic::session::{
-    EvidenceLedgerCheckpoint, EvidenceLedgerEvent, EvidenceLedgerEventStatus,
-    EvidenceLedgerSummary, EvidenceLedgerTargetKind, FileReadState, FileReadStateStore,
-    SessionContextStore, SessionEvidenceLedger,
+    CachedPromptText, CachedSystemPrompt, EvidenceLedgerCheckpoint, EvidenceLedgerEvent,
+    EvidenceLedgerEventStatus, EvidenceLedgerSummary, EvidenceLedgerTargetKind, FileReadState,
+    FileReadStateStore, PromptCacheLookup, PromptCachePolicy, PromptCacheScope,
+    SessionContextStore, SessionEvidenceLedger, SessionPromptCache, SessionPromptCacheStore,
+    SystemPromptCacheIdentity,
 };
 use crate::infrastructure::ai::get_global_ai_client_factory;
 use crate::service::config::{
@@ -44,6 +46,7 @@ pub struct SessionManagerConfig {
     pub session_idle_timeout: Duration,
     pub auto_save_interval: Duration,
     pub enable_persistence: bool,
+    pub prompt_cache_policy: PromptCachePolicy,
 }
 
 impl Default for SessionManagerConfig {
@@ -53,6 +56,7 @@ impl Default for SessionManagerConfig {
             session_idle_timeout: Duration::from_secs(3600), // 1 hour
             auto_save_interval: Duration::from_secs(300),    // 5 minutes
             enable_persistence: true,
+            prompt_cache_policy: PromptCachePolicy::default(),
         }
     }
 }
@@ -91,6 +95,7 @@ pub struct SessionManager {
 
     /// Sub-components
     context_store: Arc<SessionContextStore>,
+    prompt_cache_store: Arc<SessionPromptCacheStore>,
     file_read_state_store: Arc<FileReadStateStore>,
     evidence_ledger: Arc<SessionEvidenceLedger>,
     persistence_manager: Arc<PersistenceManager>,
@@ -115,8 +120,7 @@ struct SessionCleanupCandidate {
 }
 
 impl SessionManager {
-    async fn load_ai_config_for_model_resolution()
-        -> Option<crate::service::config::types::AIConfig>
+    async fn load_ai_config_for_model_resolution() -> Option<crate::service::config::types::AIConfig>
     {
         let config_service = get_global_config_service().await.ok()?;
         config_service.get_config(Some("ai")).await.ok()
@@ -677,6 +681,113 @@ impl SessionManager {
             .await;
     }
 
+    async fn ensure_prompt_cache_loaded(&self, session_id: &str) {
+        if self.prompt_cache_store.has_session(session_id) {
+            return;
+        }
+
+        let cache = if self.should_persist_session_id(session_id) {
+            match self.effective_session_workspace_path(session_id).await {
+                Some(workspace_path) => {
+                    match self
+                        .load_prompt_cache_from_persistence(&workspace_path, session_id)
+                        .await
+                    {
+                        Ok(Some(cache)) => cache,
+                        Ok(None) => SessionPromptCache::default(),
+                        Err(error) => {
+                            warn!(
+                                "Failed to load prompt cache: session_id={}, workspace_path={}, error={}",
+                                session_id,
+                                workspace_path.display(),
+                                error
+                            );
+                            SessionPromptCache::default()
+                        }
+                    }
+                }
+                None => SessionPromptCache::default(),
+            }
+        } else {
+            SessionPromptCache::default()
+        };
+
+        self.prompt_cache_store.replace_cache(session_id, cache);
+    }
+
+    async fn load_prompt_cache_from_persistence(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+    ) -> BitFunResult<Option<SessionPromptCache>> {
+        let mut cache = match self
+            .persistence_manager
+            .load_prompt_cache(workspace_path, session_id)
+            .await?
+        {
+            Some(cache) => cache,
+            None => return Ok(None),
+        };
+
+        let expired_entries_removed =
+            cache.apply_persistence_ttl(self.config.prompt_cache_policy.persistence_ttl);
+
+        if !expired_entries_removed {
+            return Ok(Some(cache));
+        }
+
+        if cache.is_empty() {
+            self.persistence_manager
+                .delete_prompt_cache(workspace_path, session_id)
+                .await?;
+            Ok(None)
+        } else {
+            self.persistence_manager
+                .save_prompt_cache(workspace_path, session_id, &cache)
+                .await?;
+            Ok(Some(cache))
+        }
+    }
+
+    async fn persist_prompt_cache_best_effort(&self, session_id: &str, reason: &str) {
+        if !self.should_persist_session_id(session_id) {
+            return;
+        }
+
+        let Some(workspace_path) = self.effective_session_workspace_path(session_id).await else {
+            debug!(
+                "Skipping prompt cache persistence because workspace path is unavailable: session_id={}, reason={}",
+                session_id, reason
+            );
+            return;
+        };
+
+        let cache = self
+            .prompt_cache_store
+            .get_cache(session_id)
+            .unwrap_or_default();
+
+        let persist_result = if cache.system_prompt.is_none() && cache.user_context.is_none() {
+            self.persistence_manager
+                .delete_prompt_cache(&workspace_path, session_id)
+                .await
+        } else {
+            self.persistence_manager
+                .save_prompt_cache(&workspace_path, session_id, &cache)
+                .await
+        };
+
+        if let Err(error) = persist_result {
+            warn!(
+                "Failed to persist prompt cache: session_id={}, workspace_path={}, reason={}, error={}",
+                session_id,
+                workspace_path.display(),
+                reason,
+                error
+            );
+        }
+    }
+
     pub fn new(
         context_store: Arc<SessionContextStore>,
         persistence_manager: Arc<PersistenceManager>,
@@ -688,6 +799,7 @@ impl SessionManager {
             sessions: Arc::new(DashMap::new()),
             session_workspace_index: Arc::new(DashMap::new()),
             context_store,
+            prompt_cache_store: Arc::new(SessionPromptCacheStore::new()),
             file_read_state_store: Arc::new(FileReadStateStore::new()),
             evidence_ledger: Arc::new(SessionEvidenceLedger::new()),
             persistence_manager,
@@ -874,6 +986,7 @@ impl SessionManager {
         let sessions = self.sessions.clone();
         let session_workspace_index = self.session_workspace_index.clone();
         let context_store = self.context_store.clone();
+        let prompt_cache_store = self.prompt_cache_store.clone();
         let file_read_state_store = self.file_read_state_store.clone();
         let evidence_ledger = self.evidence_ledger.clone();
         let persistence_manager = self.persistence_manager.clone();
@@ -894,6 +1007,7 @@ impl SessionManager {
                 sessions,
                 session_workspace_index,
                 context_store,
+                prompt_cache_store,
                 file_read_state_store,
                 evidence_ledger,
                 persistence_manager,
@@ -1052,6 +1166,89 @@ impl SessionManager {
     /// Get session
     pub fn get_session(&self, session_id: &str) -> Option<Session> {
         self.sessions.get(session_id).map(|s| s.clone())
+    }
+
+    pub async fn cached_system_prompt(
+        &self,
+        session_id: &str,
+        identity: &SystemPromptCacheIdentity,
+    ) -> Option<String> {
+        self.ensure_prompt_cache_loaded(session_id).await;
+        match self.prompt_cache_store.lookup_system_prompt(
+            session_id,
+            identity,
+            self.config.prompt_cache_policy.cache_ttl,
+        ) {
+            PromptCacheLookup::Hit(prompt) => Some(prompt),
+            PromptCacheLookup::Miss => None,
+            PromptCacheLookup::Expired => {
+                self.persist_prompt_cache_best_effort(
+                    session_id,
+                    "system_prompt_cache_expired_cleanup",
+                )
+                .await;
+                None
+            }
+        }
+    }
+
+    pub async fn remember_system_prompt(
+        &self,
+        session_id: &str,
+        identity: SystemPromptCacheIdentity,
+        prompt: String,
+    ) {
+        self.ensure_prompt_cache_loaded(session_id).await;
+        self.prompt_cache_store
+            .set_system_prompt(session_id, CachedSystemPrompt::new(identity, prompt));
+        self.persist_prompt_cache_best_effort(session_id, "system_prompt_cached")
+            .await;
+    }
+
+    pub async fn cached_user_context(&self, session_id: &str) -> Option<String> {
+        self.ensure_prompt_cache_loaded(session_id).await;
+        match self
+            .prompt_cache_store
+            .lookup_user_context(session_id, self.config.prompt_cache_policy.cache_ttl)
+        {
+            PromptCacheLookup::Hit(user_context) => Some(user_context),
+            PromptCacheLookup::Miss => None,
+            PromptCacheLookup::Expired => {
+                self.persist_prompt_cache_best_effort(
+                    session_id,
+                    "user_context_cache_expired_cleanup",
+                )
+                .await;
+                None
+            }
+        }
+    }
+
+    pub async fn remember_user_context(&self, session_id: &str, user_context: String) {
+        self.ensure_prompt_cache_loaded(session_id).await;
+        self.prompt_cache_store
+            .set_user_context(session_id, CachedPromptText::new(user_context));
+        self.persist_prompt_cache_best_effort(session_id, "user_context_cached")
+            .await;
+    }
+
+    pub async fn invalidate_prompt_cache(
+        &self,
+        session_id: &str,
+        scope: PromptCacheScope,
+        reason: &str,
+    ) {
+        self.ensure_prompt_cache_loaded(session_id).await;
+        let changed = self.prompt_cache_store.invalidate(session_id, scope);
+
+        if changed {
+            debug!(
+                "Invalidated session prompt cache: session_id={}, scope={:?}, reason={}",
+                session_id, scope, reason
+            );
+            self.persist_prompt_cache_best_effort(session_id, reason)
+                .await;
+        }
     }
 
     /// Synchronously reset session state to Idle if it is currently Processing
@@ -1434,6 +1631,7 @@ impl SessionManager {
             session_id
         );
         self.context_store.delete_session(session_id);
+        self.prompt_cache_store.delete_session(session_id);
         self.file_read_state_store.delete_session(session_id);
         debug!(
             "Session deletion stage completed: session_id={}, stage=context_store_delete, duration_ms={}",
@@ -1881,6 +2079,7 @@ impl SessionManager {
         // If session already exists, delete old one first then create (ensure clean state)
         if session_already_in_memory {
             self.context_store.delete_session(session_id);
+            self.prompt_cache_store.delete_session(session_id);
             self.file_read_state_store.delete_session(session_id);
         }
 
@@ -2145,19 +2344,26 @@ impl SessionManager {
                     .sessions
                     .get(session_id)
                     .map(|value| value.clone())
-                    .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {}", session_id)))?;
+                    .ok_or_else(|| {
+                        BitFunError::NotFound(format!("Session not found: {}", session_id))
+                    })?;
                 self.persistence_manager
                     .save_session(&workspace_path, &session)
                     .await?;
                 self.persistence_manager
                     .load_session_metadata(&workspace_path, session_id)
                     .await?
-                    .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {}", session_id)))?
+                    .ok_or_else(|| {
+                        BitFunError::NotFound(format!("Session not found: {}", session_id))
+                    })?
             }
         };
 
         metadata.custom_metadata = Some(match (metadata.custom_metadata.take(), patch) {
-            (Some(serde_json::Value::Object(mut existing)), serde_json::Value::Object(patch_obj)) => {
+            (
+                Some(serde_json::Value::Object(mut existing)),
+                serde_json::Value::Object(patch_obj),
+            ) => {
                 for (key, value) in patch_obj {
                     existing.insert(key, value);
                 }
@@ -2201,14 +2407,18 @@ impl SessionManager {
                     .sessions
                     .get(session_id)
                     .map(|value| value.clone())
-                    .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {}", session_id)))?;
+                    .ok_or_else(|| {
+                        BitFunError::NotFound(format!("Session not found: {}", session_id))
+                    })?;
                 self.persistence_manager
                     .save_session(&workspace_path, &session)
                     .await?;
                 self.persistence_manager
                     .load_session_metadata(&workspace_path, session_id)
                     .await?
-                    .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {}", session_id)))?
+                    .ok_or_else(|| {
+                        BitFunError::NotFound(format!("Session not found: {}", session_id))
+                    })?
             }
         };
 
@@ -2248,20 +2458,26 @@ impl SessionManager {
                     .sessions
                     .get(session_id)
                     .map(|value| value.clone())
-                    .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {}", session_id)))?;
+                    .ok_or_else(|| {
+                        BitFunError::NotFound(format!("Session not found: {}", session_id))
+                    })?;
                 self.persistence_manager
                     .save_session(&workspace_path, &session)
                     .await?;
                 self.persistence_manager
                     .load_session_metadata(&workspace_path, session_id)
                     .await?
-                    .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {}", session_id)))?
+                    .ok_or_else(|| {
+                        BitFunError::NotFound(format!("Session not found: {}", session_id))
+                    })?
             }
         };
 
         metadata.relationship = Some(relationship);
 
-        if let Some(serde_json::Value::Object(mut custom_metadata)) = metadata.custom_metadata.take() {
+        if let Some(serde_json::Value::Object(mut custom_metadata)) =
+            metadata.custom_metadata.take()
+        {
             for key in [
                 "kind",
                 "parentSessionId",
@@ -2273,8 +2489,8 @@ impl SessionManager {
             ] {
                 custom_metadata.remove(key);
             }
-            metadata.custom_metadata = (!custom_metadata.is_empty())
-                .then_some(serde_json::Value::Object(custom_metadata));
+            metadata.custom_metadata =
+                (!custom_metadata.is_empty()).then_some(serde_json::Value::Object(custom_metadata));
         }
 
         self.persistence_manager
@@ -2392,14 +2608,18 @@ impl SessionManager {
                     .sessions
                     .get(session_id)
                     .map(|value| value.clone())
-                    .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {}", session_id)))?;
+                    .ok_or_else(|| {
+                        BitFunError::NotFound(format!("Session not found: {}", session_id))
+                    })?;
                 self.persistence_manager
                     .save_session(&workspace_path, &session)
                     .await?;
                 self.persistence_manager
                     .load_session_metadata(&workspace_path, session_id)
                     .await?
-                    .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {}", session_id)))?
+                    .ok_or_else(|| {
+                        BitFunError::NotFound(format!("Session not found: {}", session_id))
+                    })?
             }
         };
 
@@ -3229,12 +3449,7 @@ impl SessionManager {
             .await;
     }
 
-    pub fn set_file_read_state(
-        &self,
-        session_id: &str,
-        logical_path: &str,
-        state: FileReadState,
-    ) {
+    pub fn set_file_read_state(&self, session_id: &str, logical_path: &str, state: FileReadState) {
         self.file_read_state_store
             .set(session_id, logical_path, state);
     }
@@ -3482,6 +3697,7 @@ impl SessionManager {
         let persistence = self.persistence_manager.clone();
         let enable_persistence = self.config.enable_persistence;
         let context_store = self.context_store.clone();
+        let prompt_cache_store = self.prompt_cache_store.clone();
         let file_read_state_store = self.file_read_state_store.clone();
 
         tokio::spawn(async move {
@@ -3539,6 +3755,7 @@ impl SessionManager {
                         .is_some()
                     {
                         context_store.delete_session(&candidate.session_id);
+                        prompt_cache_store.delete_session(&candidate.session_id);
                         file_read_state_store.delete_session(&candidate.session_id);
                     }
                 }
@@ -3593,7 +3810,9 @@ mod tests {
     use super::{SessionManager, SessionManagerConfig};
     use crate::agentic::core::{Message, ProcessingPhase, Session, SessionConfig, SessionState};
     use crate::agentic::persistence::PersistenceManager;
-    use crate::agentic::session::SessionContextStore;
+    use crate::agentic::session::{
+        PromptCachePolicy, PromptCacheScope, SessionContextStore, SystemPromptCacheIdentity,
+    };
     use crate::infrastructure::PathManager;
     use crate::service::config::types::{
         AIConfig as ServiceAIConfig, AIModelConfig as ServiceAIModelConfig,
@@ -3650,7 +3869,19 @@ mod tests {
                 session_idle_timeout: Duration::from_secs(3600),
                 auto_save_interval: Duration::from_secs(300),
                 enable_persistence: true,
+                prompt_cache_policy: PromptCachePolicy::default(),
             },
+        )
+    }
+
+    fn test_manager_with_config(
+        persistence_manager: Arc<PersistenceManager>,
+        config: SessionManagerConfig,
+    ) -> SessionManager {
+        SessionManager::new(
+            Arc::new(SessionContextStore::new()),
+            persistence_manager,
+            config,
         )
     }
 
@@ -3667,6 +3898,7 @@ mod tests {
                 session_idle_timeout: Duration::from_secs(3600),
                 auto_save_interval: Duration::from_secs(300),
                 enable_persistence: false,
+                prompt_cache_policy: PromptCachePolicy::default(),
             },
         )
     }
@@ -4036,7 +4268,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn persist_session_lineage_updates_structured_relationship_and_clears_legacy_projection() {
+    async fn persist_session_lineage_updates_structured_relationship_and_clears_legacy_projection()
+    {
         let workspace = TestWorkspace::new();
         let persistence_manager = Arc::new(
             PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
@@ -4733,5 +4966,204 @@ mod tests {
         let summary = manager.evidence_summary_for_session("session-a", 10);
         assert_eq!(summary.partial_subagent_results.len(), 1);
         assert_eq!(summary.partial_subagent_results[0].event_id, event.event_id);
+    }
+
+    #[tokio::test]
+    async fn prompt_cache_persists_across_session_restore() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager =
+            Arc::new(PersistenceManager::new(workspace.path_manager()).expect("persistence"));
+        let manager = test_manager(persistence_manager.clone());
+        let workspace_path = workspace.path().to_string_lossy().to_string();
+        let session = manager
+            .create_session(
+                "Prompt cache".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace_path),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should be created");
+        let identity = SystemPromptCacheIdentity::new("agentic", "template:agentic_mode");
+
+        manager
+            .remember_system_prompt(
+                &session.session_id,
+                identity.clone(),
+                "cached system prompt".to_string(),
+            )
+            .await;
+        manager
+            .remember_user_context(&session.session_id, "cached user context".to_string())
+            .await;
+
+        let restored_manager = test_manager(persistence_manager);
+        restored_manager
+            .restore_session(workspace.path(), &session.session_id)
+            .await
+            .expect("session should restore");
+
+        assert_eq!(
+            restored_manager
+                .cached_system_prompt(&session.session_id, &identity)
+                .await,
+            Some("cached system prompt".to_string())
+        );
+        assert_eq!(
+            restored_manager
+                .cached_user_context(&session.session_id)
+                .await,
+            Some("cached user context".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn prompt_cache_invalidation_removes_persisted_entries() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager =
+            Arc::new(PersistenceManager::new(workspace.path_manager()).expect("persistence"));
+        let manager = test_manager(persistence_manager.clone());
+        let workspace_path = workspace.path().to_string_lossy().to_string();
+        let session = manager
+            .create_session(
+                "Prompt cache".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace_path),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should be created");
+        let identity = SystemPromptCacheIdentity::new("agentic", "template:agentic_mode");
+
+        manager
+            .remember_system_prompt(
+                &session.session_id,
+                identity.clone(),
+                "cached system prompt".to_string(),
+            )
+            .await;
+        manager
+            .remember_user_context(&session.session_id, "cached user context".to_string())
+            .await;
+
+        manager
+            .invalidate_prompt_cache(&session.session_id, PromptCacheScope::All, "test")
+            .await;
+
+        let restored_manager = test_manager(persistence_manager.clone());
+        restored_manager
+            .restore_session(workspace.path(), &session.session_id)
+            .await
+            .expect("session should restore");
+
+        assert_eq!(
+            restored_manager
+                .cached_system_prompt(&session.session_id, &identity)
+                .await,
+            None
+        );
+        assert_eq!(
+            restored_manager
+                .cached_user_context(&session.session_id)
+                .await,
+            None
+        );
+        assert_eq!(
+            persistence_manager
+                .load_prompt_cache(workspace.path(), &session.session_id)
+                .await
+                .expect("prompt cache load should succeed"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn prompt_cache_persistence_ttl_only_affects_cold_start_restore() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager =
+            Arc::new(PersistenceManager::new(workspace.path_manager()).expect("persistence"));
+        let manager = test_manager_with_config(
+            persistence_manager.clone(),
+            SessionManagerConfig {
+                max_active_sessions: 100,
+                session_idle_timeout: Duration::from_secs(3600),
+                auto_save_interval: Duration::from_secs(300),
+                enable_persistence: true,
+                prompt_cache_policy: PromptCachePolicy {
+                    cache_ttl: None,
+                    persistence_ttl: Some(Duration::from_millis(0)),
+                },
+            },
+        );
+        let workspace_path = workspace.path().to_string_lossy().to_string();
+        let session = manager
+            .create_session(
+                "Prompt cache".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace_path),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should be created");
+        let identity = SystemPromptCacheIdentity::new("agentic", "template:agentic_mode");
+
+        manager
+            .remember_system_prompt(
+                &session.session_id,
+                identity.clone(),
+                "cached system prompt".to_string(),
+            )
+            .await;
+        manager
+            .remember_user_context(&session.session_id, "cached user context".to_string())
+            .await;
+
+        assert_eq!(
+            manager
+                .cached_system_prompt(&session.session_id, &identity)
+                .await,
+            Some("cached system prompt".to_string())
+        );
+        assert_eq!(
+            manager.cached_user_context(&session.session_id).await,
+            Some("cached user context".to_string())
+        );
+
+        let restored_manager = test_manager_with_config(
+            persistence_manager.clone(),
+            SessionManagerConfig {
+                max_active_sessions: 100,
+                session_idle_timeout: Duration::from_secs(3600),
+                auto_save_interval: Duration::from_secs(300),
+                enable_persistence: true,
+                prompt_cache_policy: PromptCachePolicy {
+                    cache_ttl: None,
+                    persistence_ttl: Some(Duration::from_millis(0)),
+                },
+            },
+        );
+        restored_manager
+            .restore_session(workspace.path(), &session.session_id)
+            .await
+            .expect("session should restore");
+
+        assert_eq!(
+            restored_manager
+                .cached_system_prompt(&session.session_id, &identity)
+                .await,
+            None
+        );
+        assert_eq!(
+            restored_manager
+                .cached_user_context(&session.session_id)
+                .await,
+            None
+        );
     }
 }


### PR DESCRIPTION
- add session-level prompt cache models, runtime store, and prompt_cache.json persistence
- use cache-first system prompt and user context resolution with lazy restore on first lookup
- separate cache TTL from persistence TTL and keep persistence for cold-start recovery only
- add explicit prompt cache invalidation hooks and clear cache after context compression
- keep minimal system prompt identity checks and document user context as a start-of-conversation snapshot
