### PR TITLE
fix(mcp): prevent handshake hang when local stdio server exits early

### DIFF
--- a/src/crates/services-core/src/process_manager.rs
+++ b/src/crates/services-core/src/process_manager.rs
@@ -103,16 +103,30 @@ pub fn create_command<S: AsRef<std::ffi::OsStr>>(program: S) -> Command {
 
 /// Create Tokio async Command (Windows automatically adds CREATE_NO_WINDOW)
 pub fn create_tokio_command<S: AsRef<std::ffi::OsStr>>(program: S) -> TokioCommand {
-    let cmd = TokioCommand::new(program.as_ref());
+    let mut cmd = TokioCommand::new(program.as_ref());
+
+    // macOS GUI apps inherit a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin)
+    // which is missing common tool locations like /opt/homebrew/bin and
+    // /usr/local/bin.  Resolve the shell PATH so that shebang-driven tools
+    // (npx, uvx, node, etc.) work out of the box.
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(shell_path) = std::process::Command::new("/bin/zsh")
+            .args(["-ilc", "echo -n $PATH"])
+            .output()
+        {
+            let path = String::from_utf8_lossy(&shell_path.stdout);
+            if !path.is_empty() {
+                cmd.env("PATH", path.as_ref());
+            }
+        }
+    }
 
     #[cfg(windows)]
     {
-        let mut cmd = cmd;
         cmd.creation_flags(CREATE_NO_WINDOW);
-        cmd
     }
 
-    #[cfg(not(windows))]
     cmd
 }
 

--- a/src/crates/services-integrations/src/mcp/server/connection.rs
+++ b/src/crates/services-integrations/src/mcp/server/connection.rs
@@ -69,7 +69,7 @@ impl MCPConnection {
         Self {
             transport: TransportType::Local(transport),
             pending_requests,
-            request_timeout: None,
+            request_timeout: Some(Duration::from_secs(30)),
             event_tx,
         }
     }
@@ -173,6 +173,21 @@ impl MCPConnection {
                     });
                 }
             }
+        }
+
+        // Drain all pending request waiters when the message channel closes,
+        // so that callers don't hang forever waiting for a response that will
+        // never arrive (e.g. server process exited).
+        {
+            let mut pending = pending_requests.write().await;
+            let count = pending.len();
+            if count > 0 {
+                warn!(
+                    "Message channel closed with {} pending request(s) — cancelling waiters",
+                    count
+                );
+            }
+            pending.clear();
         }
 
         let _ = event_tx.send(MCPConnectionEvent::Closed);

--- a/src/web-ui/src/infrastructure/config/components/McpToolsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/McpToolsConfig.tsx
@@ -195,10 +195,17 @@ const McpToolsConfig: React.FC = () => {
   };
 
   // ─── MCP effects & handlers ─────────────────────────────────────────────────
+  const LOAD_SERVERS_TIMEOUT_MS = 15_000;
+
   const loadServers = async () => {
     try {
       setMcpLoading(true);
-      const serverList = await MCPAPI.getServers();
+      const serverList = await Promise.race([
+        MCPAPI.getServers(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('MCP servers load timed out')), LOAD_SERVERS_TIMEOUT_MS)
+        ),
+      ]);
       setServers(serverList);
     } catch (error) {
       log.error('Failed to load MCP servers', error);


### PR DESCRIPTION
## Summary

Fixes #887 — three related issues that cause the MCP service list to hang on "加载中…" when a local stdio server fails to start.

## Changes

### 1. Add 30s request timeout to local connections (`connection.rs`)
`MCPConnection::new_local` previously set `request_timeout: None`, causing `send_request_and_wait` to block forever when the server process exited before completing the handshake. Now defaults to 30s.

### 2. Drain pending waiters on channel close (`connection.rs`)
When the message channel closes (server process exits), `handle_messages` now clears all pending `oneshot` waiters so callers receive a clean `MCPRuntimeError` instead of hanging indefinitely.

### 3. Inject shell PATH on macOS (`process_manager.rs`)
macOS GUI apps have a minimal default PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) with no Homebrew paths. `create_tokio_command` now resolves the user's shell PATH via `zsh -ilc` and injects it so shebang-driven tools (npx, uvx, node, etc.) work correctly.

### 4. Frontend timeout fallback (`McpToolsConfig.tsx`)
Added a 15s `Promise.race` timeout in `loadServers` as a defensive UI fallback — ensures `setMcpLoading(false)` always runs.