### PR TITLE
fix(mcp): complete stdio initialization handshake

### DIFF
--- a/src/crates/services-integrations/src/mcp/protocol/transport.rs
+++ b/src/crates/services-integrations/src/mcp/protocol/transport.rs
@@ -23,7 +23,7 @@ impl MCPTransport {
         }
     }
 
-    async fn next_request_id(&self) -> u64 {
+    pub async fn next_request_id(&self) -> u64 {
         let mut id = self.request_id.lock().await;
         *id += 1;
         *id
@@ -38,6 +38,16 @@ impl MCPTransport {
         let request = MCPRequest::new(Value::Number(id.into()), method, params);
         self.send_message(MCPMessage::Request(request)).await?;
         Ok(id)
+    }
+
+    pub async fn send_request_with_id(
+        &self,
+        id: u64,
+        method: String,
+        params: Option<Value>,
+    ) -> MCPRuntimeResult<()> {
+        let request = MCPRequest::new(Value::Number(id.into()), method, params);
+        self.send_message(MCPMessage::Request(request)).await
     }
 
     pub async fn send_notification(

--- a/src/crates/services-integrations/src/mcp/server/connection.rs
+++ b/src/crates/services-integrations/src/mcp/server/connection.rs
@@ -186,12 +186,20 @@ impl MCPConnection {
     ) -> MCPRuntimeResult<MCPResponse> {
         match &self.transport {
             TransportType::Local(transport) => {
-                let request_id = transport.send_request(method.clone(), params).await?;
-
+                let request_id = transport.next_request_id().await;
                 let (tx, rx) = oneshot::channel();
                 {
                     let mut pending = self.pending_requests.write().await;
                     pending.insert(request_id, tx);
+                }
+
+                if let Err(error) = transport
+                    .send_request_with_id(request_id, method.clone(), params)
+                    .await
+                {
+                    let mut pending = self.pending_requests.write().await;
+                    pending.remove(&request_id);
+                    return Err(error);
                 }
 
                 let response = if let Some(request_timeout) = self.request_timeout {
@@ -234,7 +242,15 @@ impl MCPConnection {
                 let response = self
                     .send_request_and_wait(request.method.clone(), request.params)
                     .await?;
-                parse_response_result(&response)
+                let result = parse_response_result(&response)?;
+
+                if let TransportType::Local(transport) = &self.transport {
+                    transport
+                        .send_notification("notifications/initialized".to_string(), None)
+                        .await?;
+                }
+
+                Ok(result)
             }
             TransportType::Remote(transport) => {
                 transport.initialize(client_name, client_version).await


### PR DESCRIPTION
 - Send `notifications/initialized` after successful stdio MCP initialization.
  - Register pending stdio requests before writing JSON-RPC requests to avoid dropping fast responses.

  ## Root cause

  Some MCP servers strictly require the initialized notification before handling `tools/list`. And they
  also responds quickly enough to expose a client-side race where responses could arrive before the pending request
  channel was registered