### PR TITLE
fix(agentic): bind Task subagent guidance to available_agents listing

### DIFF
--- a/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -29,8 +29,7 @@ const SKILL_LISTING_GUIDANCE: &str =
     "The following skills are available for use with the Skill tool:";
 const AGENT_LISTING_TITLE: &str = "# Agent Listing";
 const AGENT_LISTING_GUIDANCE: &str = "Available subagent types for the Task tool:";
-const COLLAPSED_TOOL_LISTING_TITLE: &str =
-    "# Collapsed Tool Listing";
+const COLLAPSED_TOOL_LISTING_TITLE: &str = "# Collapsed Tool Listing";
 const COLLAPSED_TOOL_LISTING_GUIDANCE: &str = r#"The folling tools are intentionally collapsed. Their listed descriptions are short summaries rather than full usage instructions.
 Before calling a collapsed tool, call `GetToolSpec` with its exact tool name to read its full definition and input schema.
 After reading the returned spec, call the real tool directly by its own name.

--- a/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
@@ -69,10 +69,10 @@ The user will primarily request you perform software engineering tasks. This inc
   - Use 2-4 adjacent lines with stable surrounding context when that is enough to make `old_string` unique.
   - Use `replace_all` only when every occurrence should change.
   - If Edit fails because text was not found or matched multiple locations, Read the target lines again and retry with freshly copied text — do not adjust the failed string from memory.
-- Subagent delegation: use Explore, FileFinder, or other Task subagents when their specialized focus, separate context, or autonomy is likely to improve coverage. For simple known-path, single-symbol, or one-file questions, direct tools are usually enough.
+- Subagent delegation: use only Task subagents currently listed in `<available_agents>`, and choose one only when its description, separate context, or autonomy is likely to improve coverage. Never call a subagent that is absent from `<available_agents>`, even if examples or prior sessions mention it. For simple known-path, single-symbol, or one-file questions, direct tools are usually enough.
 <example>
 user: Give me a high-level map of how authentication flows through this monorepo
-assistant: [Uses Task with Explore because multiple services and layers must be traced]
+assistant: [Uses Task with a listed investigation subagent because multiple services and layers must be traced]
 </example>
 <example>
 user: Where is class ClientError defined?

--- a/src/crates/core/src/agentic/agents/prompts/multitask_mode_first_entry_reminder.md
+++ b/src/crates/core/src/agentic/agents/prompts/multitask_mode_first_entry_reminder.md
@@ -12,8 +12,9 @@ Before starting work, check whether the task contains two or more orthogonal bra
 
 ## Task Handoff Instructions
 
-- Use `Explore` when the subtask is read-only investigation, codebase understanding, or evidence gathering that should not modify files.
-- Use `GeneralPurpose` when the subtask is implementation work that is likely to modify files, such as editing code, wiring features, fixing tests, or updating configurations.
+- Use only Task subagents currently listed in `<available_agents>`.
+- Use a listed read-only investigation subagent when the subtask is codebase understanding or evidence gathering that should not modify files.
+- Use a listed implementation-capable subagent when the subtask is implementation work that is likely to modify files, such as editing code, wiring features, fixing tests, or updating configurations.
 - Give each subagent a clear scope, expected output, and ownership boundary so parallel branches do not overlap unnecessarily.
 - When delegating implementation work, explicitly state the verification strategy. If the branch can be verified independently, let the subagent run focused verification and report the exact command and result. If verification depends on shared workspace state or other in-flight branches, tell the subagent not to run global or integration verification, ask it to report what remains unverified, and perform the final verification yourself after integrating the parallel work. Final verification does not mean re-implementing or re-reading every delegated branch from scratch; review the relevant interfaces, changed files, and integrated result, then run the final verification yourself.
 

--- a/src/crates/core/src/agentic/agents/prompts/team_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/team_mode.md
@@ -40,10 +40,10 @@ Use Task to create real team behavior without changing BitFun's global agent ros
 
 - Always read the Task tool's available agent list before choosing `subagent_type`; only use listed enabled sub-agents.
 - Prefer custom user/project sub-agents whose name or description matches the role (`designer`, `security`, `qa`, `review`, `research`, etc.).
-- For broad codebase investigation, use `Explore` when it is available.
-- For file discovery, use `FileFinder` when it is available.
-- For browser or desktop QA, use `ComputerUse` when it is available and appropriate.
-- For deep code-review style checks, use the existing review sub-agents when available (`ReviewBusinessLogic`, `ReviewPerformance`, `ReviewSecurity`, `ReviewJudge`), especially in Review phases.
+- For broad codebase investigation, use a listed investigation sub-agent when one is available.
+- For file discovery, use a listed file-discovery sub-agent when one is available.
+- For browser or desktop QA, use a listed browser or desktop-control sub-agent when one is available and appropriate.
+- For deep code-review style checks, use listed review sub-agents whose descriptions match the role, especially in Review phases.
 - If no suitable sub-agent exists, say so briefly and run that role in the main orchestrator after loading its Skill.
 - Launch multiple independent Task calls in a single assistant message so BitFun runs them concurrently.
 - Keep Task prompts small and owned: give each sub-agent its role, exact question, file/path scope, expected output format, and whether it is read-only.
@@ -150,7 +150,7 @@ Think → Plan → Build → Review → Test → Ship → Reflect
    - `review` — production-bug hunt on the diff (always)
    - `cso` — OWASP / STRIDE pass (only if security-sensitive changes)
    - `design-review` — UI audit (only if UI changed)
-3. If existing review sub-agents are available, prefer `ReviewBusinessLogic`, `ReviewPerformance`, and `ReviewSecurity` for independent read-only review tracks, then use `ReviewJudge` as a quality gate when warranted.
+3. If listed review sub-agents are available, prefer the ones whose descriptions match the needed independent read-only review tracks, then use a listed quality-gate or judge sub-agent when warranted.
 4. After all reviewers return, write a **Review Synthesis** block. Tag every finding with its source role and whether it came from a Task sub-agent or main-session role work.
 5. Fix all AUTO-FIX issues immediately. Present ASK items to the user and wait for decisions.
 

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -17,12 +17,12 @@ use crate::agentic::fork_agent::{
     ForkAgentContextSnapshot, ForkAgentExecutionRequest, ForkAgentExecutionResult,
 };
 use crate::agentic::goal_mode::{
-    build_goal_kickoff_messages, build_goal_continuation_plan, clear_goal_mode_patch,
-    generate_goal_from_context, goal_mode_from_custom_metadata, goal_mode_patch,
-    should_skip_goal_verification_for_turn, user_facing_goal_mode_error,
+    build_goal_continuation_plan, build_goal_kickoff_messages, clear_goal_mode_patch,
     effective_subagent_timeout_seconds, ensure_final_response_in_goal_context,
-    verify_goal_achievement, wrap_user_input_with_goal_reminder, GoalActivationResult,
-    GoalContinuationPlan, GoalModeState, MAX_GOAL_CONTINUATIONS, now_ms,
+    generate_goal_from_context, goal_mode_from_custom_metadata, goal_mode_patch, now_ms,
+    should_skip_goal_verification_for_turn, user_facing_goal_mode_error, verify_goal_achievement,
+    wrap_user_input_with_goal_reminder, GoalActivationResult, GoalContinuationPlan, GoalModeState,
+    MAX_GOAL_CONTINUATIONS,
 };
 use crate::agentic::image_analysis::ImageContextData;
 use crate::agentic::round_preempt::{DialogRoundInjectionSource, DialogRoundPreemptSource};
@@ -303,10 +303,8 @@ impl Drop for SubagentExecutionScope {
                 );
             }
 
-            session_manager.reset_session_state_if_processing(
-                &subagent_session_id,
-                &subagent_dialog_turn_id,
-            );
+            session_manager
+                .reset_session_state_if_processing(&subagent_session_id, &subagent_dialog_turn_id);
         });
     }
 }
@@ -1570,18 +1568,18 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .get_session(session_id)
             .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {session_id}")))?;
         let workspace_path = session.config.workspace_path.as_deref().ok_or_else(|| {
-            BitFunError::Validation(format!(
-                "Session workspace_path is missing: {session_id}"
-            ))
+            BitFunError::Validation(format!("Session workspace_path is missing: {session_id}"))
         })?;
         let metadata = self
             .session_manager
             .load_session_metadata(Path::new(workspace_path), session_id)
             .await?;
-        Ok(
-            goal_mode_from_custom_metadata(metadata.as_ref().and_then(|value| value.custom_metadata.as_ref()))
-                .filter(GoalModeState::is_active),
+        Ok(goal_mode_from_custom_metadata(
+            metadata
+                .as_ref()
+                .and_then(|value| value.custom_metadata.as_ref()),
         )
+        .filter(GoalModeState::is_active))
     }
 
     /// Activate `/goal` mode for a session by synthesizing a goal from context.
@@ -1595,7 +1593,10 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .get_session(&session_id)
             .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {session_id}")))?;
 
-        if matches!(session.kind, SessionKind::Subagent | SessionKind::EphemeralChild) {
+        if matches!(
+            session.kind,
+            SessionKind::Subagent | SessionKind::EphemeralChild
+        ) {
             return Err(BitFunError::Validation(
                 "Goal mode is only available for main sessions".to_string(),
             ));
@@ -1653,7 +1654,10 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .session_manager
             .get_session(session_id)
             .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {session_id}")))?;
-        if matches!(session.kind, SessionKind::Subagent | SessionKind::EphemeralChild) {
+        if matches!(
+            session.kind,
+            SessionKind::Subagent | SessionKind::EphemeralChild
+        ) {
             return Ok(None);
         }
 
@@ -2790,11 +2794,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         }
     }
 
-    async fn stop_active_subagent_execution(
-        &self,
-        active: &ActiveSubagentExecution,
-        reason: &str,
-    ) {
+    async fn stop_active_subagent_execution(&self, active: &ActiveSubagentExecution, reason: &str) {
         debug!(
             "Stopping active subagent execution: subagent_session_id={}, subagent_dialog_turn_id={}, parent_session_id={}, parent_dialog_turn_id={}, reason={}",
             active.subagent_session_id,
@@ -2870,10 +2870,11 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             }
         }
 
-        if let Err(error) = self.session_manager.cancel_dialog_turn(
-            &active.subagent_session_id,
-            &active.subagent_dialog_turn_id,
-        ).await {
+        if let Err(error) = self
+            .session_manager
+            .cancel_dialog_turn(&active.subagent_session_id, &active.subagent_dialog_turn_id)
+            .await
+        {
             warn!(
                 "Failed to persist subagent turn cancellation: subagent_session_id={}, subagent_dialog_turn_id={}, error={}",
                 active.subagent_session_id, active.subagent_dialog_turn_id, error
@@ -3483,10 +3484,8 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 agent_type, parent_session_id
             );
         }
-        let timeout_seconds = effective_subagent_timeout_seconds(
-            requested_timeout_seconds,
-            parent_goal_mode_active,
-        );
+        let timeout_seconds =
+            effective_subagent_timeout_seconds(requested_timeout_seconds, parent_goal_mode_active);
         let timeout_error_message = match timeout_seconds.or(requested_timeout_seconds) {
             Some(seconds) => format!(
                 "Subagent '{}' timed out after {} seconds",

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -17,13 +17,13 @@ use crate::agentic::tools::tool_context_runtime;
 use crate::agentic::tools::tool_result_storage;
 use crate::agentic::MessageContent;
 use crate::infrastructure::ai::AIClient;
-use bitfun_ai_adapters::types::ReasoningMode;
 use crate::service::config::types::WriteToolMode;
 use crate::service::config::GlobalConfigManager;
 use crate::util::elapsed_ms_u64;
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::types::Message as AIMessage;
 use crate::util::types::ToolDefinition;
+use bitfun_ai_adapters::types::ReasoningMode;
 use dashmap::DashMap;
 use log::{debug, error, info, warn};
 use std::sync::Arc;
@@ -161,7 +161,8 @@ impl RoundExecutor {
                 Err(e) => {
                     error!("AI request failed: {}", e);
                     let err_msg = e.to_string();
-                    if Self::is_transient_network_error(&err_msg) && attempt_index < max_attempts - 1
+                    if Self::is_transient_network_error(&err_msg)
+                        && attempt_index < max_attempts - 1
                     {
                         let delay_ms = Self::retry_delay_ms(attempt_index);
                         warn!(
@@ -592,9 +593,7 @@ impl RoundExecutor {
             Self::write_tool_mode(&context),
             WriteToolMode::PlaintextFollowup
         ) {
-            FileWriteTool::strip_plaintext_followup_inline_content_from_tool_calls(
-                &mut tool_calls,
-            );
+            FileWriteTool::strip_plaintext_followup_inline_content_from_tool_calls(&mut tool_calls);
         }
         let tool_calls = if matches!(
             Self::write_tool_mode(&context),
@@ -942,8 +941,7 @@ impl RoundExecutor {
                 .to_string();
             let tool_id = tc.tool_id.clone();
 
-            if let Some(error) = Self::write_content_preflight_error(context, &file_path).await
-            {
+            if let Some(error) = Self::write_content_preflight_error(context, &file_path).await {
                 debug!(
                     "Skipping Write content generation after preflight failure: file_path={}, error={}",
                     file_path, error
@@ -1010,8 +1008,7 @@ impl RoundExecutor {
                 file_path = file_path
             );
 
-            let content_messages =
-                Self::build_write_content_messages(ai_messages, &content_prompt);
+            let content_messages = Self::build_write_content_messages(ai_messages, &content_prompt);
             let write_client = ai_client.with_reasoning_mode(ReasoningMode::Disabled);
 
             let full_text = self
@@ -1912,8 +1909,8 @@ mod tests {
 
     #[test]
     fn write_content_messages_preserve_full_conversation_prefix() {
-        use bitfun_ai_adapters::types::{Message as AIMessage, ToolCall};
         use crate::util::types::Message as CoreAIMessage;
+        use bitfun_ai_adapters::types::{Message as AIMessage, ToolCall};
 
         let ai_messages = vec![
             CoreAIMessage::user("Create the benchmark doc".to_string()),

--- a/src/crates/core/src/agentic/persistence/session_branch.rs
+++ b/src/crates/core/src/agentic/persistence/session_branch.rs
@@ -346,14 +346,16 @@ mod tests {
             "parentSessionId": "legacy-parent",
             "preservedKey": "preserved-value"
         }));
-        source_metadata.relationship = Some(serde_json::from_value(serde_json::json!({
-            "kind": "deep_review",
-            "parentSessionId": "structured-parent",
-            "parentRequestId": "structured-request",
-            "parentDialogTurnId": "structured-turn",
-            "parentTurnIndex": 4
-        }))
-        .expect("relationship should deserialize"));
+        source_metadata.relationship = Some(
+            serde_json::from_value(serde_json::json!({
+                "kind": "deep_review",
+                "parentSessionId": "structured-parent",
+                "parentRequestId": "structured-request",
+                "parentDialogTurnId": "structured-turn",
+                "parentTurnIndex": 4
+            }))
+            .expect("relationship should deserialize"),
+        );
         source_metadata.deep_review_run_manifest = Some(serde_json::json!({
             "reviewMode": "deep",
             "coreReviewers": [{ "subagentId": "ReviewBusinessLogic" }]

--- a/src/crates/core/src/agentic/tools/file_tool_guidance.rs
+++ b/src/crates/core/src/agentic/tools/file_tool_guidance.rs
@@ -1,5 +1,5 @@
 //! Compatibility re-exports for file Write/Edit guardrail guidance markers.
 
 pub use bitfun_agent_tools::{
-    FILE_TOOL_GUIDANCE_PREFIX, file_tool_guidance_message, is_file_tool_guidance_message,
+    file_tool_guidance_message, is_file_tool_guidance_message, FILE_TOOL_GUIDANCE_PREFIX,
 };

--- a/src/crates/core/src/agentic/tools/implementations/file_edit_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_edit_tool.rs
@@ -1,8 +1,8 @@
 use crate::agentic::tools::file_read_state_runtime::{
-    assert_file_not_unexpectedly_modified, file_mutation_timestamp_ms,
-    get_stored_file_read_state, local_file_modification_time_ms,
-    read_current_file_content, read_state_tracking_enabled, update_file_read_state_after_mutation,
-    validate_edit_against_read_state, validate_edit_has_prior_read, FILE_UNEXPECTEDLY_MODIFIED_ERROR,
+    assert_file_not_unexpectedly_modified, file_mutation_timestamp_ms, get_stored_file_read_state,
+    local_file_modification_time_ms, read_current_file_content, read_state_tracking_enabled,
+    update_file_read_state_after_mutation, validate_edit_against_read_state,
+    validate_edit_has_prior_read, FILE_UNEXPECTEDLY_MODIFIED_ERROR,
 };
 use crate::agentic::tools::file_tool_guidance::file_tool_guidance_message;
 use crate::agentic::tools::framework::{
@@ -64,8 +64,7 @@ impl FileEditTool {
     }
 
     fn is_edit_content_guardrail_error(error: &str) -> bool {
-        error.contains("old_string not found in file")
-            || error.contains("`old_string` appears")
+        error.contains("old_string not found in file") || error.contains("`old_string` appears")
     }
 
     async fn edit_read_state_guardrail_error(
@@ -92,15 +91,14 @@ impl FileEditTool {
         let current_mtime_ms = if resolved.uses_remote_workspace_backend() {
             None
         } else {
-            Some(local_file_modification_time_ms(Path::new(&resolved.resolved_path)))
+            Some(local_file_modification_time_ms(Path::new(
+                &resolved.resolved_path,
+            )))
         };
 
-        if let Some(error) = assert_file_not_unexpectedly_modified(
-            read_state.as_ref(),
-            content,
-            current_mtime_ms,
-        )
-        .err()
+        if let Some(error) =
+            assert_file_not_unexpectedly_modified(read_state.as_ref(), content, current_mtime_ms)
+                .err()
         {
             return Err(BitFunError::tool(file_tool_guidance_message(
                 Self::format_edit_freshness_guidance(&resolved.logical_path, error),
@@ -437,7 +435,10 @@ mod tests {
 
     #[tokio::test]
     async fn edit_tool_prompt_matches_claude_style() {
-        let description = FileEditTool::new().description().await.expect("description");
+        let description = FileEditTool::new()
+            .description()
+            .await
+            .expect("description");
 
         assert_eq!(description, EDIT_TOOL_PROMPT);
         assert!(description.contains("You must use your `Read` tool"));
@@ -462,22 +463,18 @@ mod tests {
                 .and_then(Value::as_str),
             Some("The path to the file to modify")
         );
-        assert!(
-            properties
-                .get("old_string")
-                .and_then(|value| value.get("description"))
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .contains("latest Read")
-        );
-        assert!(
-            properties
-                .get("new_string")
-                .and_then(|value| value.get("description"))
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .contains("indentation")
-        );
+        assert!(properties
+            .get("old_string")
+            .and_then(|value| value.get("description"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .contains("latest Read"));
+        assert!(properties
+            .get("new_string")
+            .and_then(|value| value.get("description"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .contains("indentation"));
         assert_eq!(
             properties
                 .get("replace_all")
@@ -507,6 +504,8 @@ mod tests {
         assert!(FileEditTool::is_edit_content_guardrail_error(
             "`old_string` appears 2 times in file, either provide a larger string with more surrounding context to make it unique or use `replace_all` to change every instance of `old_string`.\n"
         ));
-        assert!(!FileEditTool::is_edit_content_guardrail_error("Permission denied"));
+        assert!(!FileEditTool::is_edit_content_guardrail_error(
+            "Permission denied"
+        ));
     }
 }

--- a/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -1,9 +1,9 @@
-use bitfun_ai_adapters::tool_call_accumulator::strip_write_inline_content_fields;
+use crate::agentic::core::ToolCall;
 use crate::agentic::tools::file_read_state_runtime::{
-    assert_file_not_unexpectedly_modified, file_mutation_timestamp_ms,
-    get_stored_file_read_state, local_file_modification_time_ms, read_current_file_content,
-    read_state_tracking_enabled, update_file_read_state_after_mutation,
-    validate_existing_file_read_before_write, FILE_UNEXPECTEDLY_MODIFIED_ERROR,
+    assert_file_not_unexpectedly_modified, file_mutation_timestamp_ms, get_stored_file_read_state,
+    local_file_modification_time_ms, read_current_file_content, read_state_tracking_enabled,
+    update_file_read_state_after_mutation, validate_existing_file_read_before_write,
+    FILE_UNEXPECTEDLY_MODIFIED_ERROR,
 };
 use crate::agentic::tools::file_tool_guidance::{
     file_tool_guidance_message, is_file_tool_guidance_message,
@@ -11,11 +11,11 @@ use crate::agentic::tools::file_tool_guidance::{
 use crate::agentic::tools::framework::{
     Tool, ToolPathResolution, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
-use crate::agentic::core::ToolCall;
 use crate::agentic::tools::ToolPathOperation;
 use crate::service::config::types::WriteToolMode;
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
+use bitfun_ai_adapters::tool_call_accumulator::strip_write_inline_content_fields;
 use serde_json::{json, Value};
 use std::path::Path;
 use tokio::fs;
@@ -122,7 +122,9 @@ impl FileWriteTool {
         let current_mtime_ms = if resolved.uses_remote_workspace_backend() {
             None
         } else {
-            Some(local_file_modification_time_ms(Path::new(&resolved.resolved_path)))
+            Some(local_file_modification_time_ms(Path::new(
+                &resolved.resolved_path,
+            )))
         };
 
         assert_file_not_unexpectedly_modified(
@@ -153,8 +155,7 @@ impl FileWriteTool {
             return None;
         }
 
-        if let Some(message) = validate_existing_file_read_before_write(context, resolved).await
-        {
+        if let Some(message) = validate_existing_file_read_before_write(context, resolved).await {
             return Some(Self::write_guidance_message(message));
         }
 
@@ -549,8 +550,8 @@ mod tests {
         let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&root).expect("create temp workspace");
 
-        let error = FileWriteTool::preflight_write_error(&local_context(root.clone()), "new.txt")
-            .await;
+        let error =
+            FileWriteTool::preflight_write_error(&local_context(root.clone()), "new.txt").await;
 
         let _ = std::fs::remove_dir_all(&root);
 
@@ -600,18 +601,14 @@ mod tests {
         assert_eq!(data["bytes_written"], 0);
         assert_eq!(data["status"], "already_exists_same_content");
         assert_eq!(data["content"], "same content");
-        assert!(
-            result_for_assistant
-                .as_deref()
-                .unwrap_or_default()
-                .contains("identical content")
-        );
-        assert!(
-            result_for_assistant
-                .as_deref()
-                .unwrap_or_default()
-                .contains("<bitfun_contents>\nsame content</bitfun_contents>")
-        );
+        assert!(result_for_assistant
+            .as_deref()
+            .unwrap_or_default()
+            .contains("identical content"));
+        assert!(result_for_assistant
+            .as_deref()
+            .unwrap_or_default()
+            .contains("<bitfun_contents>\nsame content</bitfun_contents>"));
     }
 
     #[tokio::test]
@@ -724,14 +721,8 @@ mod tests {
 
         FileWriteTool::strip_plaintext_followup_inline_content_from_tool_calls(&mut tool_calls);
 
-        assert_eq!(
-            tool_calls[0].arguments,
-            json!({ "file_path": "notes.md" })
-        );
-        assert_eq!(
-            tool_calls[1].arguments,
-            json!({ "file_path": "notes.md" })
-        );
+        assert_eq!(tool_calls[0].arguments, json!({ "file_path": "notes.md" }));
+        assert_eq!(tool_calls[1].arguments, json!({ "file_path": "notes.md" }));
     }
 
     #[tokio::test]
@@ -827,12 +818,10 @@ mod tests {
             panic!("expected result");
         };
         assert_eq!(data["content"], body);
-        assert!(
-            result_for_assistant
-                .as_deref()
-                .unwrap_or_default()
-                .contains("<bitfun_contents>\nsystem generated body</bitfun_contents>")
-        );
+        assert!(result_for_assistant
+            .as_deref()
+            .unwrap_or_default()
+            .contains("<bitfun_contents>\nsystem generated body</bitfun_contents>"));
     }
 }
 

--- a/src/crates/core/src/agentic/tools/implementations/task_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/task_tool.rs
@@ -420,20 +420,20 @@ impl TaskTool {
 
 The Task tool launches specialized agents (subprocesses) that autonomously handle complex tasks. Each agent type has specific capabilities and tools available to it.
 
-The current agent listing includes an <available_agents> section when subagents are available. Use the exact `type` attribute from that section as `subagent_type`.
+The current agent listing includes an <available_agents> section when subagents are available. Use only the exact `type` attributes from that section as `subagent_type`. If a subagent is not listed there, it is unavailable for this session even if you remember seeing that subagent in other sessions or examples.
 
 When using the Task tool, you must specify `subagent_type` as a top-level tool argument to select which agent type to use. Do not put `subagent_type`, `description`, `workspace_path`, `model_id`, or `timeout_seconds` inside the prompt string.
 
 When to use the Task tool:
 - Delegate when a specialized subagent or separate context is likely to improve coverage, independence, or parallelism.
 - Use direct tools instead for focused lookups, known paths, single symbols, or code that can be inspected in a few reads/searches.
-- For Explore, prefer it for broad or multi-area exploration where many search/read rounds would otherwise be needed.
+- Prefer the listed subagent whose description best matches the task. If no listed subagent fits, continue with direct tools in the parent session.
 
 Usage notes:
 - Include a short description summarizing what the agent will do.
 - Provide a clear prompt so the agent can work autonomously and return the information you need.
 - If 'workspace_path' is omitted, the task inherits the current workspace by default.
-- Provide 'workspace_path' when the selected agent requires an explicit workspace, such as Explore or FileFinder.
+- Provide 'workspace_path' when the selected agent description or tool error requires an explicit workspace.
 - Use 'model_id' when a caller needs a specific model or model slot for the subagent. Omit it to use the agent default.
 - Use 'timeout_seconds' when you need a hard deadline for the subagent. When omitted, the session execution timeout from settings is used. When provided, the effective timeout is the larger of the requested value and the session execution timeout. Set it to 0 with no configured session execution timeout to disable the timeout.
 - For DeepReview only, set 'retry' to true when re-dispatching a reviewer after that same reviewer returned partial_timeout or an explicit transient capacity failure in the current turn. Retry calls must include retry_coverage with source_packet_id, source_status, covered_files, and a smaller retry_scope_files list. Do not set 'auto_retry' unless this is a backend-owned automatic retry admitted by Review Team settings; model-issued retry decisions should omit it or set it to false. Example retry_coverage: {{ "source_packet_id": "reviewer-123", "source_status": "partial_timeout", "covered_files": ["src/main.rs"], "retry_scope_files": ["src/parser.rs"] }}.
@@ -448,12 +448,12 @@ Example usage:
 
 <example>
 user: "Map how authentication flows through this monorepo"
-assistant: Uses the Task tool with subagent_type="Explore" because this is a broad, multi-area architecture investigation. The prompt asks for a read-only survey, key files, and a concise call-flow summary.
+assistant: Uses the Task tool with a listed read-only investigation subagent because this is a broad, multi-area architecture investigation. The prompt asks for a read-only survey, key files, and a concise call-flow summary.
 </example>
 
 <example>
 user: "Find the files that implement export formatting"
-assistant: Uses the Task tool with subagent_type="FileFinder" because the exact filenames are unknown and semantic file discovery is useful. The parent agent reads the returned files before proposing edits.
+assistant: Uses the Task tool with a listed file-discovery subagent when one is available because the exact filenames are unknown and semantic file discovery is useful. The parent agent reads the returned files before proposing edits.
 </example>"#
             .to_string()
     }
@@ -534,11 +534,11 @@ impl Tool for TaskTool {
                 },
                 "subagent_type": {
                     "type": "string",
-                    "description": "Required top-level agent type id. Use the exact case-sensitive id from the available_agents type attribute, for example Explore, FileFinder, CodeReview, or another listed agent."
+                    "description": "Required top-level agent type id. Use only an exact case-sensitive id from the current available_agents type attributes. Do not use remembered or example agent ids that are absent from available_agents."
                 },
                 "workspace_path": {
                     "type": "string",
-                    "description": "The absolute path of the workspace for this task. If omitted, inherits the current workspace. Explore/FileFinder must provide it explicitly."
+                    "description": "The absolute path of the workspace for this task. If omitted, inherits the current workspace. Provide it when the selected listed subagent requires an explicit workspace."
                 },
                 "model_id": {
                     "type": "string",
@@ -1619,6 +1619,24 @@ mod tests {
         description
             .find(&format!("<agent type=\"{}\">", agent_id))
             .unwrap_or_else(|| panic!("expected agent block for {}", agent_id))
+    }
+
+    #[test]
+    fn task_prompt_guidance_avoids_static_subagent_recommendations() {
+        let description = TaskTool::new().render_description();
+        assert!(description.contains("Use only the exact `type` attributes"));
+        assert!(!description.contains("subagent_type=\"Explore\""));
+        assert!(!description.contains("subagent_type=\"FileFinder\""));
+        assert!(!description.contains("For Explore"));
+        assert!(!description.contains("Explore/FileFinder"));
+
+        let schema = TaskTool::new().input_schema();
+        let subagent_description = schema["properties"]["subagent_type"]["description"]
+            .as_str()
+            .expect("subagent_type description should be a string");
+        assert!(subagent_description.contains("Use only an exact case-sensitive id"));
+        assert!(!subagent_description.contains("Explore"));
+        assert!(!subagent_description.contains("FileFinder"));
     }
 
     #[test]

--- a/src/crates/core/src/agentic/tools/mod.rs
+++ b/src/crates/core/src/agentic/tools/mod.rs
@@ -1,12 +1,12 @@
 //! Tool system - includes Tool interface, tool registry and tool executor
 
-pub mod file_read_state_runtime;
-pub mod file_tool_guidance;
 pub mod browser_control;
 pub mod computer_use_capability;
 pub mod computer_use_host;
 pub mod computer_use_optimizer;
 pub mod computer_use_verification;
+pub mod file_read_state_runtime;
+pub mod file_tool_guidance;
 pub mod framework;
 pub mod image_context;
 pub mod implementations;

--- a/src/crates/core/src/agentic/tools/restrictions.rs
+++ b/src/crates/core/src/agentic/tools/restrictions.rs
@@ -1,7 +1,7 @@
 use crate::util::errors::{BitFunError, BitFunResult};
 pub use bitfun_agent_tools::{
-    ToolPathOperation, ToolPathPolicy, ToolRestrictionError, ToolRuntimeRestrictions,
-    is_remote_posix_path_within_root,
+    is_remote_posix_path_within_root, ToolPathOperation, ToolPathPolicy, ToolRestrictionError,
+    ToolRuntimeRestrictions,
 };
 use std::path::{Path, PathBuf};
 

--- a/src/crates/core/src/agentic/tools/workspace_paths.rs
+++ b/src/crates/core/src/agentic/tools/workspace_paths.rs
@@ -6,7 +6,7 @@
 
 use crate::util::errors::{BitFunError, BitFunResult};
 pub use bitfun_agent_tools::{
-    BITFUN_RUNTIME_URI_PREFIX, ParsedBitFunRuntimeUri, is_bitfun_runtime_uri,
+    is_bitfun_runtime_uri, ParsedBitFunRuntimeUri, BITFUN_RUNTIME_URI_PREFIX,
 };
 use std::path::Path;
 

--- a/src/crates/core/src/infrastructure/ai/mod.rs
+++ b/src/crates/core/src/infrastructure/ai/mod.rs
@@ -18,7 +18,7 @@ pub use client_factory::{
     get_global_ai_client_factory, initialize_global_ai_client_factory, AIClientFactory,
 };
 
-use crate::service::config::types::{AIModelConfig, AIConfig, ReasoningMode};
+use crate::service::config::types::{AIConfig, AIModelConfig, ReasoningMode};
 
 pub fn build_stream_options(config: &AIConfig) -> StreamOptions {
     build_stream_options_for_model(config, None)
@@ -28,9 +28,7 @@ pub fn build_stream_options_for_model(
     config: &AIConfig,
     model_config: Option<&AIModelConfig>,
 ) -> StreamOptions {
-    let idle_timeout = config
-        .stream_idle_timeout_secs
-        .map(Duration::from_secs);
+    let idle_timeout = config.stream_idle_timeout_secs.map(Duration::from_secs);
 
     let base_ttft_secs = config
         .stream_ttft_timeout_secs

--- a/src/crates/core/src/miniapp/exporter.rs
+++ b/src/crates/core/src/miniapp/exporter.rs
@@ -1,7 +1,7 @@
 //! MiniApp export engine — export to Electron or Tauri standalone app (skeleton).
 
 pub use bitfun_product_domains::miniapp::exporter::{
-    ExportCheckResult, ExportOptions, ExportResult, ExportTarget, build_export_check_result,
+    build_export_check_result, ExportCheckResult, ExportOptions, ExportResult, ExportTarget,
 };
 
 use crate::util::errors::{BitFunError, BitFunResult};

--- a/src/crates/core/src/miniapp/host_dispatch.rs
+++ b/src/crates/core/src/miniapp/host_dispatch.rs
@@ -25,15 +25,15 @@
 use crate::miniapp::permission_policy::resolve_policy;
 use crate::miniapp::types::MiniAppPermissions;
 use crate::util::errors::{BitFunError, BitFunResult};
-use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 pub use bitfun_product_domains::miniapp::host_routing::is_host_primitive;
 use bitfun_product_domains::miniapp::host_routing::{
-    FsAccessMode, command_basename_allowed, command_basename_for_allowlist, fs_method_access_mode,
+    command_basename_allowed, command_basename_for_allowlist, fs_method_access_mode,
     fs_policy_scopes, fs_resolved_path_allowed, host_allowed_by_allowlist, shell_exec_cwd,
     shell_exec_default_env, shell_exec_first_token, shell_exec_input_is_empty,
-    shell_exec_timeout_ms, split_host_method,
+    shell_exec_timeout_ms, split_host_method, FsAccessMode,
 };
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 

--- a/src/crates/core/src/miniapp/js_worker_pool.rs
+++ b/src/crates/core/src/miniapp/js_worker_pool.rs
@@ -1,7 +1,7 @@
 //! JS Worker pool — LRU pool, get_or_spawn, call, stop_all, install_deps.
 
 use crate::miniapp::js_worker::JsWorker;
-use crate::miniapp::runtime_detect::{DetectedRuntime, detect_runtime};
+use crate::miniapp::runtime_detect::{detect_runtime, DetectedRuntime};
 use crate::miniapp::types::{NodePermissions, NpmDep};
 use crate::util::errors::{BitFunError, BitFunResult};
 use bitfun_product_domains::miniapp::ports::{
@@ -10,7 +10,7 @@ use bitfun_product_domains::miniapp::ports::{
 };
 pub use bitfun_product_domains::miniapp::worker::InstallResult;
 use bitfun_product_domains::miniapp::worker::{
-    InstallDepsPlan, plan_install_deps, select_lru_worker, worker_is_idle, worker_pool_at_capacity,
+    plan_install_deps, select_lru_worker, worker_is_idle, worker_pool_at_capacity, InstallDepsPlan,
 };
 use serde_json::Value;
 use std::path::PathBuf;

--- a/src/crates/core/src/miniapp/manager.rs
+++ b/src/crates/core/src/miniapp/manager.rs
@@ -9,26 +9,27 @@ use crate::miniapp::types::{
 use crate::product_domain_runtime::CoreProductDomainRuntime;
 use crate::util::errors::{BitFunError, BitFunResult};
 use bitfun_product_domains::miniapp::customization::{
-    MiniAppCustomizationBaseline, MiniAppCustomizationLocalSnapshot, MiniAppCustomizationMetadata,
-    MiniAppPermissionDiff, apply_draft_customization_metadata, decline_builtin_update_metadata,
+    apply_draft_customization_metadata, decline_builtin_update_metadata,
     declined_builtin_update_needs_local_snapshot, diff_permissions,
     is_current_declined_builtin_update, mark_builtin_update_available_metadata,
+    MiniAppCustomizationBaseline, MiniAppCustomizationLocalSnapshot, MiniAppCustomizationMetadata,
+    MiniAppPermissionDiff,
 };
 use bitfun_product_domains::miniapp::draft::{
-    MiniAppDraft, MiniAppDraftManifest, build_draft_manifest, build_draft_response,
+    build_draft_manifest, build_draft_response, MiniAppDraft, MiniAppDraftManifest,
 };
 use bitfun_product_domains::miniapp::lifecycle::{
-    MiniAppCreateInput, MiniAppUpdatePatch, apply_draft_permission_update_result,
-    apply_draft_source_sync_result, apply_draft_to_active, apply_update_patch, build_created_app,
-    build_worker_revision, ensure_runtime_state, prepare_draft_app, prepare_imported_meta,
-    workspace_dir_string,
+    apply_draft_permission_update_result, apply_draft_source_sync_result, apply_draft_to_active,
+    apply_update_patch, build_created_app, build_worker_revision, ensure_runtime_state,
+    prepare_draft_app, prepare_imported_meta, workspace_dir_string, MiniAppCreateInput,
+    MiniAppUpdatePatch,
 };
 use bitfun_product_domains::miniapp::ports::{
     MiniAppPortError, MiniAppPortErrorKind, MiniAppRuntimeFacade,
 };
 use bitfun_product_domains::miniapp::storage::{
-    COMPILED_HTML, ESM_DEPS_JSON, META_JSON, MiniAppImportLayout, PACKAGE_JSON,
-    REQUIRED_SOURCE_FILES, SOURCE_DIR, STORAGE_JSON, build_import_fallbacks,
+    build_import_fallbacks, MiniAppImportLayout, COMPILED_HTML, ESM_DEPS_JSON, META_JSON,
+    PACKAGE_JSON, REQUIRED_SOURCE_FILES, SOURCE_DIR, STORAGE_JSON,
 };
 use chrono::Utc;
 use std::collections::HashMap;
@@ -1055,12 +1056,10 @@ mod tests {
         .unwrap();
         assert_eq!(package_json["name"], format!("miniapp-{}", imported.id));
         assert_eq!(package_json["dependencies"], serde_json::json!({}));
-        assert!(
-            tokio::fs::read_to_string(app_dir.join(COMPILED_HTML))
-                .await
-                .unwrap()
-                .contains("textContent = 'imported'")
-        );
+        assert!(tokio::fs::read_to_string(app_dir.join(COMPILED_HTML))
+            .await
+            .unwrap()
+            .contains("textContent = 'imported'"));
 
         let _ = tokio::fs::remove_dir_all(import_root).await;
     }

--- a/src/crates/core/src/miniapp/mod.rs
+++ b/src/crates/core/src/miniapp/mod.rs
@@ -16,12 +16,12 @@ pub use bitfun_product_domains::miniapp::customization::{
 pub use bitfun_product_domains::miniapp::draft::{MiniAppDraft, MiniAppDraftManifest};
 pub use bitfun_product_domains::miniapp::{bridge_builder, permission_policy, types};
 
-pub use builtin::{BUILTIN_APPS, BuiltinApp, seed_builtin_miniapps};
+pub use builtin::{seed_builtin_miniapps, BuiltinApp, BUILTIN_APPS};
 pub use exporter::{ExportCheckResult, ExportOptions, ExportResult, ExportTarget, MiniAppExporter};
 pub use host_dispatch::{dispatch_host, is_host_primitive};
 pub use js_worker_pool::{InstallResult, JsWorkerPool};
 pub use manager::{
-    MiniAppManager, initialize_global_miniapp_manager, try_get_global_miniapp_manager,
+    initialize_global_miniapp_manager, try_get_global_miniapp_manager, MiniAppManager,
 };
 pub use permission_policy::resolve_policy;
 pub use runtime_detect::{DetectedRuntime, RuntimeKind};

--- a/src/crates/core/src/miniapp/runtime_detect.rs
+++ b/src/crates/core/src/miniapp/runtime_detect.rs
@@ -1,3 +1,3 @@
 //! Compatibility facade for MiniApp runtime detection.
 
-pub use bitfun_product_domains::miniapp::runtime::{DetectedRuntime, RuntimeKind, detect_runtime};
+pub use bitfun_product_domains::miniapp::runtime::{detect_runtime, DetectedRuntime, RuntimeKind};

--- a/src/crates/core/src/miniapp/storage.rs
+++ b/src/crates/core/src/miniapp/storage.rs
@@ -7,9 +7,9 @@ use bitfun_product_domains::miniapp::ports::{
     MiniAppPortError, MiniAppPortErrorKind, MiniAppPortFuture, MiniAppStoragePort,
 };
 use bitfun_product_domains::miniapp::storage::{
-    COMPILED_HTML, DRAFT_JSON, DRAFTS_CLEANUP_MARKER, DRAFTS_CLEANUP_PREFIX, DRAFTS_DIR,
-    ESM_DEPS_JSON, INDEX_HTML, META_JSON, MiniAppStorageLayout, PACKAGE_JSON, STORAGE_JSON,
-    STYLE_CSS, UI_JS, WORKER_JS, build_package_json, parse_npm_dependencies,
+    build_package_json, parse_npm_dependencies, MiniAppStorageLayout, COMPILED_HTML,
+    DRAFTS_CLEANUP_MARKER, DRAFTS_CLEANUP_PREFIX, DRAFTS_DIR, DRAFT_JSON, ESM_DEPS_JSON,
+    INDEX_HTML, META_JSON, PACKAGE_JSON, STORAGE_JSON, STYLE_CSS, UI_JS, WORKER_JS,
 };
 use serde_json;
 use std::path::{Path, PathBuf};

--- a/src/crates/core/src/service/review_platform/mod.rs
+++ b/src/crates/core/src/service/review_platform/mod.rs
@@ -3151,7 +3151,10 @@ fn capabilities_for_remote(_remote: &ReviewPlatformRemote) -> ReviewPlatformCapa
             platform,
             ReviewPlatformKind::Github | ReviewPlatformKind::Gitlab | ReviewPlatformKind::Gitcode
         ),
-        can_reply_to_thread: matches!(platform, ReviewPlatformKind::Github | ReviewPlatformKind::Gitlab),
+        can_reply_to_thread: matches!(
+            platform,
+            ReviewPlatformKind::Github | ReviewPlatformKind::Gitlab
+        ),
         can_resolve_thread: matches!(platform, ReviewPlatformKind::Gitlab),
         can_approve: matches!(
             platform,

--- a/src/crates/core/src/service/search/remote.rs
+++ b/src/crates/core/src/service/search/remote.rs
@@ -1008,10 +1008,8 @@ impl RemoteWorkspaceSearchService {
                 local_bundle.sha256,
                 remote_sha256.as_deref().unwrap_or("missing")
             );
-            let temp_remote_binary_path = format!(
-                "{}.upload-{}.tmp",
-                remote_binary_path, local_bundle.sha256
-            );
+            let temp_remote_binary_path =
+                format!("{}.upload-{}.tmp", remote_binary_path, local_bundle.sha256);
             self.remote_file_service
                 .write_file(connection_id, &temp_remote_binary_path, &local_bundle.bytes)
                 .await
@@ -1629,9 +1627,8 @@ fn shell_escape(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        looks_like_linux_workspace_root, parse_remote_architecture_output,
-        parse_remote_os_output, remote_flashgrep_install_dir,
-        should_retry_remote_scan_fallback_as_files_with_matches,
+        looks_like_linux_workspace_root, parse_remote_architecture_output, parse_remote_os_output,
+        remote_flashgrep_install_dir, should_retry_remote_scan_fallback_as_files_with_matches,
     };
     use crate::service::search::flashgrep::{
         drain_content_length_messages, FileCount, SearchBackend, SearchHit, SearchModeConfig,

--- a/src/web-ui/src/flow_chat/components/subagent/SubagentProjectionView.scss
+++ b/src/web-ui/src/flow_chat/components/subagent/SubagentProjectionView.scss
@@ -8,11 +8,12 @@
   gap: 8px;
   overflow-y: auto;
   overscroll-behavior: contain;
+  box-sizing: border-box;
 }
 
 .subagent-projection-container--expanded {
   max-height: min(48vh, 640px);
-  padding: 2px 0 4px;
+  padding: 8px 0 10px;
 }
 
 .subagent-projection-container--collapsed {
@@ -23,6 +24,15 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.subagent-projection-content {
+  min-width: 0;
+
+  .flow-thinking-item .thinking-content {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 .subagent-projection-text__hint {

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.scss
@@ -529,7 +529,8 @@
 
     // Strip the subagent container's own border/background/shadow so it
     // merges into the wrapper; the wrapper provides the unified card chrome.
-    .subagent-items-container {
+    .subagent-items-container,
+    .subagent-projection-container {
       border: none;
       background: transparent;
       backdrop-filter: none;
@@ -539,8 +540,21 @@
       animation: none;
     }
 
-    &.task-with-subagent-wrapper--has-prompt .subagent-items-container {
+    &.task-with-subagent-wrapper--has-prompt .subagent-items-container,
+    &.task-with-subagent-wrapper--has-prompt .subagent-projection-container--expanded {
       border-top: 1px solid var(--border-base);
+    }
+
+    // Match `.task-expanded-content .task-prompt-content` horizontal inset.
+    .subagent-projection-container--expanded {
+      --task-prompt-inline-pad: calc(
+        var(--flowchat-card-expanded-pad-x, 0.625rem) + var(--flowchat-card-pad-x, 0.75rem)
+      );
+      padding:
+        8px
+        var(--task-prompt-inline-pad)
+        10px
+        var(--task-prompt-inline-pad);
     }
 
     // Hide the header top accent line — the wrapper border already frames


### PR DESCRIPTION
## Summary
- Update agentic, multitask, team mode, and Task tool prompts to delegate only to subagents currently listed in `<available_agents>`, removing hardcoded Explore/FileFinder examples that can cause invalid Task calls.
- Tighten Task tool schema guidance and add a regression test to prevent static subagent recommendations from returning.
- Align subagent projection styling with Task card padding in the web UI.

## Test plan
- [x] `cargo check -p bitfun-core`
- [x] `cargo test -p bitfun-core task_prompt_guidance_avoids_static_subagent_recommendations -- --nocapture`
- [ ] Verify Task tool cards render subagent projection with consistent horizontal padding in expanded state