### PR TITLE
fix(agentic): reject tool-invocation syntax in Write content generation

### DIFF
--- a/src/crates/core/src/agentic/execution/mod.rs
+++ b/src/crates/core/src/agentic/execution/mod.rs
@@ -6,6 +6,7 @@ pub mod execution_engine;
 pub mod round_executor;
 pub mod stream_processor;
 pub mod types;
+pub mod write_content_sanitizer;
 
 pub use execution_engine::*;
 pub use round_executor::*;

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -4,6 +4,9 @@
 
 use super::stream_processor::{StreamProcessOptions, StreamProcessor, StreamResult};
 use super::types::{FinishReason, RoundContext, RoundResult};
+use super::write_content_sanitizer::{
+    contains_tool_invocation_artifacts, strip_tool_invocation_artifacts,
+};
 use crate::agentic::core::{Message, ToolCall};
 use crate::agentic::events::{AgenticEvent, EventPriority, EventQueue, ToolEventData};
 use crate::agentic::tools::computer_use_host::ComputerUseHostRef;
@@ -41,6 +44,7 @@ pub struct RoundExecutor {
 
 impl RoundExecutor {
     const MAX_STREAM_ATTEMPTS: usize = 10;
+    const MAX_WRITE_CONTENT_QUALITY_ATTEMPTS: usize = 2;
     const RETRY_BASE_DELAY_MS: u64 = 500;
     const WRITE_CONTENT_STREAM_IDLE_TIMEOUT_SECS: u64 = 45;
 
@@ -1000,7 +1004,8 @@ impl RoundExecutor {
                  5. Do NOT output anything outside the <bitfun_contents> tags — no explanations, no commentary, \
                  no thinking blocks, no markdown fences (```), no extra XML wrapper tags.\n\
                  6. The text between the tags must be EXACTLY what gets written to disk — raw file content only.\n\
-                 7. Do NOT call any tools in this turn. Do NOT output tool_call XML, JSON tool invocations, \
+                 7. Do NOT call any tools in this turn. Do NOT output tool_call XML, DSML syntax \
+                 (including `<｜｜DSML｜｜tool_calls>` / `<invoke>` markers), JSON tool invocations, \
                  function_call blocks, or agent framework syntax inside or outside the tags. \
                  You are not calling a tool here — you are outputting raw file content only.\n\
                  8. Do NOT repeat, summarize, or narrate prior tool calls (Read, Bash, Edit, etc.). Start writing the actual file body immediately.\n\
@@ -1011,24 +1016,73 @@ impl RoundExecutor {
             let content_messages = Self::build_write_content_messages(ai_messages, &content_prompt);
             let write_client = ai_client.with_reasoning_mode(ReasoningMode::Disabled);
 
-            let full_text = self
-                .stream_write_tool_content(
-                    &write_client,
-                    content_messages,
-                    &file_path,
-                    &tool_id,
-                    context,
-                    round_id,
-                    cancel_token,
-                )
-                .await?;
+            let content = {
+                let mut content_attempt = 0usize;
+                loop {
+                    let full_text = self
+                        .stream_write_tool_content(
+                            &write_client,
+                            content_messages.clone(),
+                            &file_path,
+                            &tool_id,
+                            context,
+                            round_id,
+                            cancel_token,
+                        )
+                        .await?;
 
-            let content = extract_bitfun_contents_with_options(&full_text, true);
+                    let extracted = extract_bitfun_contents_with_options(&full_text, true);
+                    if extracted.is_empty() {
+                        warn!(
+                            "Write content generation returned empty content for file_path={}",
+                            file_path
+                        );
+                    } else if contains_tool_invocation_artifacts(&extracted) {
+                        if content_attempt + 1 >= Self::MAX_WRITE_CONTENT_QUALITY_ATTEMPTS {
+                            let error = format!(
+                                "Write content generation returned tool-invocation syntax instead of file content for {}. \
+                                 Retry Write after reviewing the target file requirements.",
+                                file_path
+                            );
+                            warn!("{}", error);
+                            self.emit_event(
+                                AgenticEvent::ToolEvent {
+                                    session_id: context.session_id.clone(),
+                                    turn_id: context.dialog_turn_id.clone(),
+                                    round_id: round_id.to_string(),
+                                    tool_event: ToolEventData::Failed {
+                                        tool_id: tool_id.clone(),
+                                        tool_name: "Write".to_string(),
+                                        error,
+                                        duration_ms: None,
+                                        queue_wait_ms: None,
+                                        preflight_ms: None,
+                                        confirmation_wait_ms: None,
+                                        execution_ms: None,
+                                    },
+                                },
+                                EventPriority::High,
+                            )
+                            .await;
+                            break String::new();
+                        }
+
+                        warn!(
+                            "Write content generation returned tool-invocation syntax for file_path={}, retrying ({}/{})",
+                            file_path,
+                            content_attempt + 1,
+                            Self::MAX_WRITE_CONTENT_QUALITY_ATTEMPTS
+                        );
+                        content_attempt += 1;
+                        continue;
+                    }
+
+                    break extracted;
+                }
+            };
+
             if content.is_empty() {
-                warn!(
-                    "Write content generation returned empty content for file_path={}",
-                    file_path
-                );
+                continue;
             }
 
             // Detect strong "omission marker" phrases that indicate the model
@@ -1475,6 +1529,7 @@ fn sanitize_write_content(content: &str) -> String {
     let mut s = content.to_string();
 
     s = strip_called_tools_artifacts(&s);
+    s = strip_tool_invocation_artifacts(&s);
     s = strip_bitfun_content_tags(&s);
 
     // Strip multi-line thinking/reasoning XML blocks (e.g. <think ...>..</think >)
@@ -2053,6 +2108,18 @@ mod tests {
     fn sanitization_strips_reasoning_block() {
         let text = "<bitfun_contents>\n<reasoning>\nAnalyzing code...\n</reasoning>\nfn main() {}\n</bitfun_contents>";
         assert_eq!(extract_bitfun_contents(text), "fn main() {}");
+    }
+
+    #[test]
+    fn sanitization_strips_dsml_tool_invocation_blocks() {
+        let text = concat!(
+            "<｜｜DSML｜｜tool_calls>\n",
+            "<｜｜DSML｜｜invoke name=\"Write\">\n",
+            "<｜｜DSML｜｜parameter name=\"file_path\" string=\"true\">a.ts</｜｜DSML｜｜parameter>\n",
+            "</｜｜DSML｜｜invoke>\n",
+            "</｜｜DSML｜｜tool_calls>"
+        );
+        assert_eq!(extract_bitfun_contents(text), "");
     }
 
     #[test]

--- a/src/crates/core/src/agentic/execution/write_content_sanitizer.rs
+++ b/src/crates/core/src/agentic/execution/write_content_sanitizer.rs
@@ -1,0 +1,126 @@
+//! Sanitization and validation for Write tool file-body generation.
+
+/// Returns true when the model output looks like a tool invocation instead of
+/// raw file content (DSML blocks, nested tool_call XML, function_call JSON, etc.).
+pub fn contains_tool_invocation_artifacts(content: &str) -> bool {
+    if content.trim().is_empty() {
+        return false;
+    }
+
+    let lower = content.to_ascii_lowercase();
+
+    if content.contains("DSML")
+        && (content.contains("tool_calls")
+            || content.contains("invoke name")
+            || content.contains("<invoke"))
+    {
+        return true;
+    }
+
+    const MARKERS: &[&str] = &[
+        "<tool_calls",
+        "</tool_calls",
+        "<invoke",
+        "</invoke",
+        "function_call",
+        "[tooluse:",
+        "<function=",
+        "\"type\":\"tool_use\"",
+        "\"type\": \"tool_use\"",
+        "toolu_",
+    ];
+
+    MARKERS.iter().any(|marker| lower.contains(marker))
+}
+
+/// Best-effort removal of tool-invocation wrappers that sometimes appear before
+/// the real file body. When the entire payload is tool syntax, this returns an
+/// empty string and callers should treat that as a generation failure.
+pub fn strip_tool_invocation_artifacts(content: &str) -> String {
+    let mut result = content.to_string();
+
+    for (open, close) in [
+        ("<tool_calls", "</tool_calls>"),
+        ("<｜｜DSML｜｜tool_calls>", "</｜｜DSML｜｜tool_calls>"),
+        ("<invoke", "</invoke>"),
+        ("<function_call", "</function_call>"),
+    ] {
+        result = strip_delimited_block(&result, open, close);
+    }
+
+    // Some models emit one DSML invoke block without an outer tool_calls wrapper.
+    while let Some(start) = result.find("<｜｜DSML｜｜invoke") {
+        let Some(end) = result[start..].find("</｜｜DSML｜｜invoke>") else {
+            result = result[..start].to_string();
+            break;
+        };
+        let end = start + end + "</｜｜DSML｜｜invoke>".len();
+        result = format!("{}{}", &result[..start], &result[end..]);
+    }
+
+    result.trim().to_string()
+}
+
+fn strip_delimited_block(content: &str, open_prefix: &str, close_tag: &str) -> String {
+    let mut result = content.to_string();
+    loop {
+        let Some(start) = result.find(open_prefix) else {
+            break;
+        };
+        let Some(relative_end) = result[start..].find(close_tag) else {
+            result = result[..start].to_string();
+            break;
+        };
+        let end = start + relative_end + close_tag.len();
+        result = format!("{}{}", &result[..start], &result[end..]);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{contains_tool_invocation_artifacts, strip_tool_invocation_artifacts};
+
+    #[test]
+    fn detects_dsml_nested_write() {
+        let content = concat!(
+            "<｜｜DSML｜｜tool_calls>\n",
+            "<｜｜DSML｜｜invoke name=\"Write\">\n",
+            "<｜｜DSML｜｜parameter name=\"file_path\" string=\"true\">a.ts</｜｜DSML｜｜parameter>\n",
+            "</｜｜DSML｜｜invoke>\n",
+            "</｜｜DSML｜｜tool_calls>"
+        );
+        assert!(contains_tool_invocation_artifacts(content));
+        assert!(strip_tool_invocation_artifacts(content).is_empty());
+    }
+
+    #[test]
+    fn detects_standard_tool_calls_block() {
+        let content = "<tool_calls><invoke name=\"Write\">...</invoke></tool_calls>";
+        assert!(contains_tool_invocation_artifacts(content));
+        assert!(strip_tool_invocation_artifacts(content).is_empty());
+    }
+
+    #[test]
+    fn preserves_normal_source_code() {
+        let content = "import React from 'react';\n\nexport default function App() {}\n";
+        assert!(!contains_tool_invocation_artifacts(content));
+        assert_eq!(
+            strip_tool_invocation_artifacts(content),
+            "import React from 'react';\n\nexport default function App() {}"
+        );
+    }
+
+    #[test]
+    fn strips_tool_block_before_real_content() {
+        let content = concat!(
+            "<tool_calls><invoke name=\"Write\"></invoke></tool_calls>",
+            "export const value = 1;\n"
+        );
+        assert!(contains_tool_invocation_artifacts(content));
+        assert_eq!(
+            strip_tool_invocation_artifacts(content),
+            "export const value = 1;"
+        );
+    }
+}

--- a/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -8,6 +8,9 @@ use crate::agentic::tools::file_read_state_runtime::{
 use crate::agentic::tools::file_tool_guidance::{
     file_tool_guidance_message, is_file_tool_guidance_message,
 };
+use crate::agentic::execution::write_content_sanitizer::{
+    contains_tool_invocation_artifacts, strip_tool_invocation_artifacts,
+};
 use crate::agentic::tools::framework::{
     Tool, ToolPathResolution, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
@@ -323,6 +326,19 @@ Usage:
             .get("content")
             .and_then(|v| v.as_str())
             .ok_or_else(|| BitFunError::tool("content is required".to_string()))?;
+        let content = strip_tool_invocation_artifacts(content);
+        if content.is_empty() {
+            return Err(BitFunError::tool(Self::write_guidance_message(
+                "Write content is empty after removing tool-invocation syntax. \
+                 Provide the raw file body in the `content` field.",
+            )));
+        }
+        if contains_tool_invocation_artifacts(&content) {
+            return Err(BitFunError::tool(Self::write_guidance_message(
+                "Write content still contains tool-invocation syntax after sanitization. \
+                 Provide raw file content only.",
+            )));
+        }
 
         Self::assert_atomic_write_freshness_if_exists(context, &resolved).await?;
 
@@ -340,7 +356,7 @@ Usage:
                     .await
                     .map_err(|e| BitFunError::tool(format!("Failed to create directory: {}", e)))?;
             }
-            fs::write(&resolved.resolved_path, content)
+            fs::write(&resolved.resolved_path, &content)
                 .await
                 .map_err(|e| {
                     BitFunError::tool(format!(
@@ -351,7 +367,7 @@ Usage:
         }
 
         let timestamp_ms = file_mutation_timestamp_ms(context, &resolved).await;
-        update_file_read_state_after_mutation(context, &resolved, content, timestamp_ms);
+        update_file_read_state_after_mutation(context, &resolved, &content, timestamp_ms);
 
         let result = ToolResult::Result {
             data: json!({
@@ -746,6 +762,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn inline_mode_rejects_tool_invocation_content() {
+        let tool = FileWriteTool::new();
+        let mut custom_data = HashMap::new();
+        custom_data.insert(
+            WRITE_TOOL_MODE_CONTEXT_KEY.to_string(),
+            serde_json::Value::String("inline_content".to_string()),
+        );
+        let context = context_with_custom_data(custom_data);
+
+        let validation = tool
+            .validate_input(
+                &json!({
+                    "file_path": "notes.md",
+                    "content": "<tool_calls><invoke name=\"Write\"></invoke></tool_calls>"
+                }),
+                Some(&context),
+            )
+            .await;
+
+        assert!(!validation.result);
+        assert!(validation
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("tool-invocation syntax")));
+    }
+
+    #[tokio::test]
     async fn inline_mode_requires_content_during_validation() {
         let tool = FileWriteTool::new();
         let mut custom_data = HashMap::new();
@@ -898,6 +941,22 @@ impl Tool for FileWriteTool {
                 error_code: Some(400),
                 meta: None,
             };
+        }
+
+        if matches!(mode, WriteToolMode::InlineContent) {
+            if let Some(content) = input.get("content").and_then(|v| v.as_str()) {
+                if contains_tool_invocation_artifacts(content) {
+                    return ValidationResult {
+                        result: false,
+                        message: Some(Self::write_guidance_message(
+                            "Write content looks like tool-invocation syntax instead of raw file content. \
+                             Output the file body directly in the `content` field without nested tool calls.",
+                        )),
+                        error_code: Some(400),
+                        meta: Some(json!({ "failure_kind": "guidance" })),
+                    };
+                }
+            }
         }
 
         let large_write_warning = if matches!(mode, WriteToolMode::InlineContent) {


### PR DESCRIPTION
## Summary

- Add `write_content_sanitizer` to detect and strip DSML / nested tool-call artifacts from Write file-body generation.
- Retry streamed Write content generation once when the model returns tool-invocation syntax instead of raw file content; fail with guidance after the retry budget is exhausted.
- Validate and sanitize inline `Write` tool `content` before persisting to disk.

## Context

Models sometimes emit DSML blocks (`<｜｜DSML｜｜tool_calls>`, `<invoke>`, etc.) or nested tool-call XML inside Write content streams. This PR prevents that syntax from being written to disk and gives the agent a clear retry/failure path.

## Test plan

- [x] `cargo test -p bitfun-core write_content_sanitizer`
- [x] `cargo test -p bitfun-core sanitization_strips_dsml`
- [x] `cargo check -p bitfun-core`