### PR TITLE
fix: improve AskUserQuestion resilience against stream truncation and duplicate cards

### DIFF
--- a/src/crates/ai-adapters/src/tool_call_accumulator.rs
+++ b/src/crates/ai-adapters/src/tool_call_accumulator.rs
@@ -97,6 +97,10 @@ pub fn is_write_like_tool_name(tool_name: &str) -> bool {
 
 fn is_truncation_safe_to_recover(tool_name: &str) -> bool {
     is_write_like_tool_name(tool_name)
+        || matches!(
+            tool_name,
+            "AskUserQuestion" | "TodoWrite"
+        )
 }
 
 /// Remove inline body fields that PlaintextFollowup Write must not carry in
@@ -1074,5 +1078,58 @@ mod tests {
             parsed["content"].as_str(),
             Some("she said \"hello\" and then")
         );
+    }
+
+    #[test]
+    fn ask_user_question_truncated_mid_chinese_string_is_recovered() {
+        let raw = r#"{"questions": [{"header": "重试场景", "multiSelect": true, "options": [{"description": "当消息发送后后端返回失败（消息气泡显示为红色失败状态，有 model rounds 但 status='error'），在失败气泡旁增加重试按钮，点击后重新发送该消息", "label": "失败消息气泡上加重试按钮"}]}]}"#;
+        // Truncate mid-Chinese-string, after a colon that opened the value
+        let truncated = &raw[..raw.find("消息气泡显示为红色失败状态").unwrap() + "消息气泡显示为红色失败状态".len()];
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("AskUserQuestion".to_string()));
+        pending.append_arguments(truncated);
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason, false)
+            .expect("finalized tool");
+
+        assert!(!finalized.is_error);
+        assert!(finalized.recovered_from_truncation);
+    }
+
+    #[test]
+    fn ask_user_question_truncated_mid_options_is_recovered() {
+        // Truncation right after a completed description value's closing quote + comma
+        let raw = r#"{"questions": [{"header": "场景", "multiSelect": true, "options": [{"description": "第一条描述", "label": "选项一"}, {"description": "第二条描"#;
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("AskUserQuestion".to_string()));
+        pending.append_arguments(raw);
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason, false)
+            .expect("finalized tool");
+
+        assert!(!finalized.is_error);
+        assert!(finalized.recovered_from_truncation);
+        let questions = finalized.arguments["questions"].as_array().unwrap();
+        assert_eq!(questions.len(), 1);
+        assert_eq!(questions[0]["options"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn todo_write_truncated_mid_content_is_recovered() {
+        let raw = r#"{"todos": [{"id": "1", "content": "完成重构并优化性能", "status": "in_progress"}, {"id": "2", "content": "编写单元测"#;
+        let mut pending = PendingToolCall::default();
+        pending.start_new("call_1".to_string(), Some("TodoWrite".to_string()));
+        pending.append_arguments(raw);
+
+        let finalized = pending
+            .finalize(ToolCallBoundary::FinishReason, false)
+            .expect("finalized tool");
+
+        assert!(!finalized.is_error);
+        assert!(finalized.recovered_from_truncation);
+        let todos = finalized.arguments["todos"].as_array().unwrap();
+        assert_eq!(todos.len(), 2);
     }
 }

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -55,6 +55,22 @@ struct RecentToolCall {
     arguments: serde_json::Value,
 }
 
+fn is_write_like_tool_name(tool_name: &str) -> bool {
+    matches!(tool_name, "Write" | "file_write" | "write_notebook")
+}
+
+fn build_truncation_recovery_notice(tool_name: &str) -> String {
+    if is_write_like_tool_name(tool_name) {
+        return format!(
+            "[Your previous {tool_name} call was truncated mid-stream by max_tokens and was auto-repaired before execution; the file was written with the partial content. The full truncated content — including the exact stopping point — is visible in the `input` of your previous tool_use message, so you do NOT need to read the file again. To finish it, issue ONE Edit call where `old_string` is the final unique substring of your truncated content and `new_string` is that same substring plus the continuation. If you do not have a concrete plan for the continuation, stop tool-calling and tell the user the output was truncated (suggest raising max_tokens). Do NOT call Read on this file and do NOT rewrite the whole file with Write.]\n\nOriginal tool result follows.\n\n"
+        );
+    }
+
+    format!(
+        "[Your previous {tool_name} call was truncated mid-stream by max_tokens and was auto-repaired before execution. The tool ran with the repaired, potentially incomplete arguments. Review the tool result and continue normally; if important information is missing, issue a fresh complete {tool_name} call rather than trying to continue a file write.]\n\nOriginal tool result follows.\n\n"
+    )
+}
+
 /// Convert framework::ToolResult to core::ToolResult
 ///
 /// Ensure always has result_for_assistant, avoid tool message content being empty
@@ -984,14 +1000,11 @@ impl ToolPipeline {
 
                 // The tool call succeeded with arguments that we patched
                 // because the model's output was truncated mid-stream. Tell
-                // the model so it can decide whether the partial write needs
+                // the model so it can decide whether the partial call needs
                 // to be continued or regenerated.
                 if recovered_from_truncation {
                     let original = tool_result.result_for_assistant.unwrap_or_default();
-                    let notice = format!(
-                        "[Your previous {} call was truncated mid-stream by max_tokens and was auto-repaired before execution; the file was written with the partial content. The full truncated content — including the exact stopping point — is visible in the `input` of your previous tool_use message, so you do NOT need to read the file again. To finish it, issue ONE Edit call where `old_string` is the final unique substring of your truncated content and `new_string` is that same substring plus the continuation. If you do not have a concrete plan for the continuation, stop tool-calling and tell the user the output was truncated (suggest raising max_tokens). Do NOT call Read on this file and do NOT rewrite the whole file with Write.]\n\nOriginal tool result follows.\n\n",
-                        tool_name
-                    );
+                    let notice = build_truncation_recovery_notice(&tool_name);
                     tool_result.result_for_assistant = Some(if original.is_empty() {
                         notice.trim_end().to_string()
                     } else {
@@ -1550,6 +1563,24 @@ mod tests {
         assert!(assistant_text.contains("\"exit_code\": 1"));
         assert!(assistant_text.contains("\"working_directory\": \"/private/tmp\""));
         assert!(!assistant_text.contains("completed with error"));
+    }
+
+    #[test]
+    fn truncation_notice_for_interactive_tools_does_not_claim_file_write() {
+        let notice = build_truncation_recovery_notice("AskUserQuestion");
+
+        assert!(notice.contains("AskUserQuestion call was truncated"));
+        assert!(notice.contains("fresh complete AskUserQuestion call"));
+        assert!(!notice.contains("file was written"));
+        assert!(!notice.contains("issue ONE Edit call"));
+    }
+
+    #[test]
+    fn truncation_notice_for_write_tools_keeps_write_continuation_guidance() {
+        let notice = build_truncation_recovery_notice("Write");
+
+        assert!(notice.contains("file was written with the partial content"));
+        assert!(notice.contains("issue ONE Edit call"));
     }
 
     #[test]

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.test.ts
@@ -55,6 +55,31 @@ function makeToolContext(): any {
   };
 }
 
+function makeAskUserQuestionTool(
+  id: string,
+  status: FlowToolItem['status'],
+  error?: string,
+): FlowToolItem {
+  return {
+    id,
+    type: 'tool',
+    toolName: 'AskUserQuestion',
+    timestamp: 1000,
+    status,
+    toolCall: {
+      id,
+      input: {},
+    },
+    toolResult: error
+      ? {
+          result: null,
+          success: false,
+          error,
+        }
+      : undefined,
+  };
+}
+
 describe('processToolParamsPartialInternal', () => {
   afterEach(() => {
     resetStore();
@@ -252,5 +277,98 @@ describe('processToolEvent late Started event behavior', () => {
 
     const updatedTurn = FlowChatStore.getInstance().getState().sessions.get('session-1')?.dialogTurns[0];
     expect(updatedTurn?.modelRounds[0]?.items.some(item => item.id === 'tool-late-1')).toBe(false);
+  });
+});
+
+describe('processToolEvent AskUserQuestion retry cleanup', () => {
+  afterEach(() => {
+    resetStore();
+  });
+
+  it('removes stale parse failure cards when a retry question is early detected', () => {
+    const staleTool = makeAskUserQuestionTool(
+      'ask-stale',
+      'error',
+      'Failed to parse input parameters: missing field `questions`',
+    );
+    const cancelledTool = makeAskUserQuestionTool(
+      'ask-cancelled',
+      'cancelled',
+      'User cancelled operation',
+    );
+    const ordinaryFailedTool = makeAskUserQuestionTool(
+      'ask-failed',
+      'error',
+      'User input channel closed',
+    );
+
+    const turn: DialogTurn = {
+      id: 'turn-1',
+      sessionId: 'session-1',
+      userMessage: {
+        id: 'user-1',
+        content: 'Ask me if needed',
+        timestamp: 800,
+      },
+      modelRounds: [
+        {
+          id: 'round-1',
+          index: 0,
+          items: [staleTool, cancelledTool, ordinaryFailedTool],
+          isStreaming: false,
+          isComplete: true,
+          status: 'completed',
+          startTime: 900,
+        },
+        {
+          id: 'round-2',
+          index: 1,
+          items: [],
+          isStreaming: true,
+          isComplete: false,
+          status: 'streaming',
+          startTime: 1200,
+        },
+      ],
+      status: 'processing',
+      startTime: 800,
+    };
+
+    const session: Session = {
+      sessionId: 'session-1',
+      title: 'Session 1',
+      dialogTurns: [turn],
+      status: 'active',
+      config: { agentType: 'agentic' },
+      createdAt: 700,
+      lastActiveAt: 1200,
+      error: null,
+      sessionKind: 'normal',
+    };
+
+    FlowChatStore.getInstance().setState(() => ({
+      sessions: new Map([['session-1', session]]),
+      activeSessionId: 'session-1',
+    }));
+
+    processToolEvent(
+      makeToolContext(),
+      'session-1',
+      'turn-1',
+      'round-2',
+      {
+        event_type: 'EarlyDetected',
+        tool_id: 'ask-retry',
+        tool_name: 'AskUserQuestion',
+      },
+    );
+
+    const updatedTurn = FlowChatStore.getInstance().getState().sessions.get('session-1')?.dialogTurns[0];
+    const allItemIds = updatedTurn?.modelRounds.flatMap(round => round.items.map(item => item.id)) || [];
+
+    expect(allItemIds).not.toContain('ask-stale');
+    expect(allItemIds).toContain('ask-cancelled');
+    expect(allItemIds).toContain('ask-failed');
+    expect(allItemIds).toContain('ask-retry');
   });
 });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
@@ -269,10 +269,10 @@ function handleEarlyDetected(
 ): void {
   flushPendingBatchedEvents(context);
 
-  // AskUserQuestion cards are rendered by the streaming engine before the tool
-  // is validated. When a stream retry regenerates the question after a parse
-  // failure, the previous card lingers. Remove any previously failed
-  // AskUserQuestion cards from all rounds so the retry replaces them cleanly.
+  // AskUserQuestion cards are rendered by the streaming engine before tool
+  // arguments are parsed and validated. When a stream retry regenerates the
+  // question after that specific failure class, remove the stale failed card
+  // while preserving real user-cancelled or otherwise failed questions.
   if (toolEvent.tool_name === 'AskUserQuestion') {
     store.updateDialogTurn(sessionId, turnId, (turn) => ({
       ...turn,
@@ -280,12 +280,7 @@ function handleEarlyDetected(
         ...round,
         items: round.items.filter(
           (item: FlowItem) =>
-            !(
-              item.type === 'tool' &&
-              (item as FlowToolItem).toolName === 'AskUserQuestion' &&
-              ((item as FlowToolItem).status === 'error' ||
-                (item as FlowToolItem).status === 'cancelled')
-            ),
+            !isStaleAskUserQuestionRetryCard(item),
         ),
       })),
     }));
@@ -320,6 +315,25 @@ function handleEarlyDetected(
 
   store.addModelRoundItem(sessionId, turnId, preparingToolItem, roundId);
   applyPendingAcpPermissionForTool(store, toolEvent.tool_id);
+}
+
+function isStaleAskUserQuestionRetryCard(item: FlowItem): boolean {
+  if (item.type !== 'tool') {
+    return false;
+  }
+
+  const toolItem = item as FlowToolItem;
+  if (toolItem.toolName !== 'AskUserQuestion' || toolItem.status !== 'error') {
+    return false;
+  }
+
+  const error = toolItem.toolResult?.error || '';
+  return (
+    error.includes('Arguments are invalid JSON') ||
+    error.includes('Tool arguments were truncated by the model') ||
+    error.includes('Failed to parse input parameters') ||
+    /^Question \d+ /.test(error)
+  );
 }
 
 /**

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
@@ -10,6 +10,7 @@ import type { FlowChatContext, FlowToolItem, ToolEventOptions, DialogTurn } from
 import { immediateSaveDialogTurn } from './PersistenceModule';
 import { applyPendingAcpPermissionForTool } from './AcpPermissionToolCardModule';
 import { normalizeParamsPartialFragment } from '../EventBatcher';
+import type { FlowItem } from '../../types/flow-chat';
 import type {
   CancelledToolEvent,
   CompletedToolEvent,
@@ -267,6 +268,28 @@ function handleEarlyDetected(
   options?: ToolEventOptions
 ): void {
   flushPendingBatchedEvents(context);
+
+  // AskUserQuestion cards are rendered by the streaming engine before the tool
+  // is validated. When a stream retry regenerates the question after a parse
+  // failure, the previous card lingers. Remove any previously failed
+  // AskUserQuestion cards from all rounds so the retry replaces them cleanly.
+  if (toolEvent.tool_name === 'AskUserQuestion') {
+    store.updateDialogTurn(sessionId, turnId, (turn) => ({
+      ...turn,
+      modelRounds: turn.modelRounds.map((round) => ({
+        ...round,
+        items: round.items.filter(
+          (item: FlowItem) =>
+            !(
+              item.type === 'tool' &&
+              (item as FlowToolItem).toolName === 'AskUserQuestion' &&
+              ((item as FlowToolItem).status === 'error' ||
+                (item as FlowToolItem).status === 'cancelled')
+            ),
+        ),
+      })),
+    }));
+  }
   
   const preparingToolItem: FlowToolItem = {
     id: toolEvent.tool_id,


### PR DESCRIPTION
## Summary

Two independent fixes to improve AskUserQuestion tool reliability. These are not tied to any specific agent mode.

### 1. Stream truncation recovery for safe read-only tools

`is_truncation_safe_to_recover` in `tool_call_accumulator.rs` previously only allowed Write-like tools. When AskUserQuestion or TodoWrite JSON arguments were truncated during streaming, the repaired JSON was discarded because the tool wasn't in the safe recovery whitelist. This fix adds them — both are read-only, idempotent, and partial execution is preferable to silent failure.

Follow-up hardening: the downstream truncation recovery notice is now tool-aware. Write-like tools still get the file/Edit continuation guidance, while AskUserQuestion and TodoWrite get a generic "fresh complete call if needed" notice instead of being incorrectly told that a file was written.

### 2. Duplicate AskUserQuestion cards from stream retries

When AskUserQuestion fails at parse/validation time, the card was already rendered by the streaming engine. The stream retry mechanism creates a new AskUserQuestion, resulting in two visible cards.

This now cleans up only stale AskUserQuestion cards that failed due to argument parse/validation errors. User-cancelled questions and ordinary failed AskUserQuestion history are preserved.

### Verification

```
cargo test -p bitfun-core truncation_notice -- --nocapture
cargo test -p bitfun-ai-adapters truncated_mid -- --nocapture
pnpm --dir src/web-ui run test:run ToolEventModule
pnpm run type-check:web
pnpm run lint:web
cargo check --workspace
git diff --check
```

Additional note: `pnpm --dir src/web-ui run test:run` still has unrelated existing failures in `TaskToolDisplay.test.tsx` (`flowChatStore.subscribe` missing from the test mock) and `EventHandlerModule.test.ts` (`monaco-editor` resolution in the test environment). The targeted ToolEventModule regression test passes.
