### PR TITLE
fix(mcp): scope stdio handshake timeout

### DIFF
--- a/src/crates/services-core/src/process_manager.rs
+++ b/src/crates/services-core/src/process_manager.rs
@@ -3,6 +3,8 @@
 use std::io;
 use std::process::Command;
 use std::sync::LazyLock;
+#[cfg(target_os = "macos")]
+use std::sync::OnceLock;
 use tokio::process::{Child, Command as TokioCommand};
 #[cfg(unix)]
 use tokio::time::timeout;
@@ -105,22 +107,8 @@ pub fn create_command<S: AsRef<std::ffi::OsStr>>(program: S) -> Command {
 pub fn create_tokio_command<S: AsRef<std::ffi::OsStr>>(program: S) -> TokioCommand {
     let mut cmd = TokioCommand::new(program.as_ref());
 
-    // macOS GUI apps inherit a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin)
-    // which is missing common tool locations like /opt/homebrew/bin and
-    // /usr/local/bin.  Resolve the shell PATH so that shebang-driven tools
-    // (npx, uvx, node, etc.) work out of the box.
     #[cfg(target_os = "macos")]
-    {
-        if let Ok(shell_path) = std::process::Command::new("/bin/zsh")
-            .args(["-ilc", "echo -n $PATH"])
-            .output()
-        {
-            let path = String::from_utf8_lossy(&shell_path.stdout);
-            if !path.is_empty() {
-                cmd.env("PATH", path.as_ref());
-            }
-        }
-    }
+    apply_cached_macos_path(&mut cmd);
 
     #[cfg(windows)]
     {
@@ -128,6 +116,47 @@ pub fn create_tokio_command<S: AsRef<std::ffi::OsStr>>(program: S) -> TokioComma
     }
 
     cmd
+}
+
+#[cfg(target_os = "macos")]
+fn apply_cached_macos_path(cmd: &mut TokioCommand) {
+    if let Some(path) = cached_macos_path_env() {
+        cmd.env("PATH", path);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn cached_macos_path_env() -> Option<&'static std::ffi::OsString> {
+    static MACOS_PATH_ENV: OnceLock<Option<std::ffi::OsString>> = OnceLock::new();
+    MACOS_PATH_ENV.get_or_init(build_macos_path_env).as_ref()
+}
+
+#[cfg(target_os = "macos")]
+fn build_macos_path_env() -> Option<std::ffi::OsString> {
+    let existing_path = std::env::var_os("PATH");
+    let mut entries = Vec::new();
+    if let Some(path) = existing_path {
+        entries.extend(std::env::split_paths(&path));
+    }
+    entries.extend(crate::system::platform_path_entries());
+
+    if entries.is_empty() {
+        return None;
+    }
+
+    let mut merged = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for path in entries {
+        if path.as_os_str().is_empty() {
+            continue;
+        }
+        let key = path.to_string_lossy().to_string();
+        if seen.insert(key) {
+            merged.push(path);
+        }
+    }
+
+    std::env::join_paths(merged).ok()
 }
 
 #[cfg(unix)]

--- a/src/crates/services-integrations/src/mcp/server/connection.rs
+++ b/src/crates/services-integrations/src/mcp/server/connection.rs
@@ -49,9 +49,11 @@ pub enum MCPConnectionEvent {
 pub struct MCPConnection {
     transport: TransportType,
     pending_requests: Arc<RwLock<HashMap<u64, ResponseWaiter>>>,
-    request_timeout: Option<Duration>,
+    initialize_timeout: Option<Duration>,
     event_tx: broadcast::Sender<MCPConnectionEvent>,
 }
+
+const LOCAL_INITIALIZE_TIMEOUT: Duration = Duration::from_secs(30);
 
 impl MCPConnection {
     /// Creates a new local connection instance (stdin/stdout).
@@ -69,9 +71,15 @@ impl MCPConnection {
         Self {
             transport: TransportType::Local(transport),
             pending_requests,
-            request_timeout: Some(Duration::from_secs(30)),
+            initialize_timeout: Some(LOCAL_INITIALIZE_TIMEOUT),
             event_tx,
         }
+    }
+
+    #[cfg(test)]
+    fn with_initialize_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.initialize_timeout = timeout;
+        self
     }
 
     /// Creates a new remote connection instance (Streamable HTTP).
@@ -93,17 +101,9 @@ impl MCPConnection {
         headers: HashMap<String, String>,
         oauth_enabled: bool,
     ) -> MCPRuntimeResult<Self> {
-        let request_timeout = None;
+        let initialize_timeout = None;
         let transport = Arc::new(
-            RemoteMCPTransport::new(
-                data_dir,
-                server_id,
-                url,
-                headers,
-                request_timeout,
-                oauth_enabled,
-            )
-            .await?,
+            RemoteMCPTransport::new(data_dir, server_id, url, headers, None, oauth_enabled).await?,
         );
         let pending_requests = Arc::new(RwLock::new(HashMap::new()));
         let (event_tx, _) = broadcast::channel(64);
@@ -111,7 +111,7 @@ impl MCPConnection {
         Ok(Self {
             transport: TransportType::Remote(transport),
             pending_requests,
-            request_timeout,
+            initialize_timeout,
             event_tx,
         })
     }
@@ -199,6 +199,16 @@ impl MCPConnection {
         method: String,
         params: Option<Value>,
     ) -> MCPRuntimeResult<MCPResponse> {
+        self.send_request_and_wait_with_timeout(method, params, None)
+            .await
+    }
+
+    async fn send_request_and_wait_with_timeout(
+        &self,
+        method: String,
+        params: Option<Value>,
+        request_timeout: Option<Duration>,
+    ) -> MCPRuntimeResult<MCPResponse> {
         match &self.transport {
             TransportType::Local(transport) => {
                 let request_id = transport.next_request_id().await;
@@ -217,15 +227,18 @@ impl MCPConnection {
                     return Err(error);
                 }
 
-                let response = if let Some(request_timeout) = self.request_timeout {
-                    tokio::time::timeout(request_timeout, rx)
-                        .await
-                        .map_err(|_| {
-                            MCPRuntimeError::timeout(format!(
+                let response = if let Some(request_timeout) = request_timeout {
+                    match tokio::time::timeout(request_timeout, rx).await {
+                        Ok(response) => response,
+                        Err(_) => {
+                            let mut pending = self.pending_requests.write().await;
+                            pending.remove(&request_id);
+                            return Err(MCPRuntimeError::timeout(format!(
                                 "Request timeout for method: {}",
                                 method
-                            ))
-                        })?
+                            )));
+                        }
+                    }
                 } else {
                     rx.await
                 };
@@ -255,7 +268,11 @@ impl MCPConnection {
             TransportType::Local(_) => {
                 let request = create_initialize_request(0, client_name, client_version);
                 let response = self
-                    .send_request_and_wait(request.method.clone(), request.params)
+                    .send_request_and_wait_with_timeout(
+                        request.method.clone(),
+                        request.params,
+                        self.initialize_timeout,
+                    )
                     .await?;
                 let result = parse_response_result(&response)?;
 
@@ -408,6 +425,101 @@ impl MCPConnection {
                     .to_string(),
             )),
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::mcp::protocol::MCPToolResultContent;
+    use serde_json::json;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    #[tokio::test]
+    async fn local_tool_calls_do_not_inherit_initialize_timeout() {
+        let mut child = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg("cat")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn stdio echo child");
+
+        let stdin = child.stdin.take().expect("capture stdin");
+        let stdout = child.stdout.take().expect("capture stdout");
+        let (tx, rx) = mpsc::unbounded_channel();
+        let connection =
+            MCPConnection::new(stdin, rx).with_initialize_timeout(Some(Duration::from_millis(10)));
+
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout);
+            let mut line = String::new();
+            while reader
+                .read_line(&mut line)
+                .await
+                .expect("read request line")
+                > 0
+            {
+                let request: crate::mcp::protocol::MCPRequest =
+                    serde_json::from_str(line.trim()).expect("parse request");
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                tx.send(MCPMessage::Response(MCPResponse::success(
+                    request.id,
+                    json!({
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "done"
+                            }
+                        ]
+                    }),
+                )))
+                .expect("send response");
+                line.clear();
+            }
+        });
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            connection.call_tool("slow_tool", None),
+        )
+        .await
+        .expect("tool call should complete")
+        .expect("tool call should not use initialize timeout");
+
+        let content = result.content.expect("tool content");
+        assert!(matches!(
+            content.first(),
+            Some(MCPToolResultContent::Text { text }) if text == "done"
+        ));
+
+        let _ = child.kill().await;
+    }
+
+    #[tokio::test]
+    async fn local_initialize_uses_initialize_timeout() {
+        let mut child = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg("cat >/dev/null")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn silent stdio child");
+
+        let stdin = child.stdin.take().expect("capture stdin");
+        let stdout = child.stdout.take().expect("capture stdout");
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let connection =
+            MCPConnection::new(stdin, rx).with_initialize_timeout(Some(Duration::from_millis(10)));
+
+        let error = connection
+            .initialize("BitFunTest", "0.0.0")
+            .await
+            .expect_err("initialize should time out");
+        assert_eq!(error.kind(), crate::mcp::MCPRuntimeErrorKind::Timeout);
+
+        drop(stdout);
+        let _ = child.kill().await;
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #888.

- keep the 30s timeout for local stdio MCP initialize/handshake only
- leave regular local MCP requests, especially long-running tools/call, without the handshake timeout
- remove timed-out local requests from the pending map
- avoid spawning a login shell for every macOS child process by caching the merged PATH once and reusing existing platform PATH expansion

## Verification

- cargo test -p bitfun-services-core
- cargo test -p bitfun-services-integrations --features mcp connection::tests -- --nocapture
- cargo check -p bitfun-core --features product-full
- git diff --check