### PR TITLE
perf(observability): add prefix-cache telemetry metrics

### DIFF
--- a/src/crates/agent-tools/src/framework.rs
+++ b/src/crates/agent-tools/src/framework.rs
@@ -682,10 +682,34 @@ where
         true
     }
 
+    /// Return the tool description that will be sent to the AI provider.
+    ///
+    /// # Prefix-cache stability contract
+    ///
+    /// The byte output of this method must be identical across every round of
+    /// the same session for the same logical tool configuration. Any variation
+    /// in the returned string invalidates the provider-side prefix cache for
+    /// all bytes that follow the tool-spec block, which can significantly
+    /// increase per-round cost.
+    ///
+    /// Acceptable variation:
+    /// - Remote vs local workspace, which changes at session start and then stays stable.
+    /// - Model capability flags such as vision support, which are stable per session.
+    /// - User-initiated config changes such as theme or write-tool mode.
+    ///
+    /// Forbidden variation:
+    /// - Timestamps, request IDs, UUIDs, or any non-deterministic data.
+    /// - Session-specific paths that change mid-session.
+    /// - Anything that varies between API calls within the same session.
     async fn description_with_context(&self, _context: &Context) -> Result<String, String> {
         self.description().await
     }
 
+    /// Return the JSON schema sent to the AI provider.
+    ///
+    /// Subject to the same prefix-cache stability contract as
+    /// [`Self::description_with_context`]: output must be byte-stable across
+    /// rounds of the same session for the same tool configuration.
     async fn input_schema_for_model_with_context(&self, _context: &Context) -> Value {
         self.input_schema_for_model().await
     }

--- a/src/crates/core/src/service/session_usage/service.rs
+++ b/src/crates/core/src/service/session_usage/service.rs
@@ -1946,6 +1946,7 @@ mod tests {
             output_tokens,
             cached_tokens,
             cached_tokens_available: false,
+            cache_write_tokens: 0,
             total_tokens: input_tokens + output_tokens,
             token_details: None,
             is_subagent: false,

--- a/src/crates/core/src/service/token_usage/service.rs
+++ b/src/crates/core/src/service/token_usage/service.rs
@@ -155,6 +155,12 @@ impl TokenUsageService {
         let total_tokens = input_tokens + output_tokens;
         let cached_tokens_available = cached_tokens.is_some();
         let cached_tokens = cached_tokens.unwrap_or(0);
+        let cache_write_tokens: u32 = token_details
+            .as_ref()
+            .and_then(|details| details.get("cacheCreationTokenCount"))
+            .and_then(|value| value.as_u64())
+            .map(|value| value as u32)
+            .unwrap_or(0);
 
         let record = TokenUsageRecord {
             model_id: model_id.clone(),
@@ -165,6 +171,7 @@ impl TokenUsageService {
             output_tokens,
             cached_tokens,
             cached_tokens_available,
+            cache_write_tokens,
             total_tokens,
             token_details,
             is_subagent,
@@ -201,6 +208,7 @@ impl TokenUsageService {
         stats.total_input += record.input_tokens as u64;
         stats.total_output += record.output_tokens as u64;
         stats.total_cached += record.cached_tokens as u64;
+        stats.total_cache_write += record.cache_write_tokens as u64;
         stats.total_tokens += record.total_tokens as u64;
         stats.request_count += 1;
 
@@ -234,6 +242,7 @@ impl TokenUsageService {
                 total_input: 0,
                 total_output: 0,
                 total_cached: 0,
+                total_cache_write: 0,
                 total_tokens: 0,
                 request_count: 0,
                 created_at: record.timestamp,
@@ -243,6 +252,7 @@ impl TokenUsageService {
         stats.total_input += record.input_tokens;
         stats.total_output += record.output_tokens;
         stats.total_cached += record.cached_tokens;
+        stats.total_cache_write += record.cache_write_tokens;
         stats.total_tokens += record.total_tokens;
         stats.request_count += 1;
         stats.last_updated = record.timestamp;
@@ -435,6 +445,7 @@ impl TokenUsageService {
         let mut total_input = 0u64;
         let mut total_output = 0u64;
         let mut total_cached = 0u64;
+        let mut total_cache_write = 0u64;
         let mut total_tokens = 0u64;
 
         let mut by_model: HashMap<String, ModelTokenStats> = HashMap::new();
@@ -444,6 +455,7 @@ impl TokenUsageService {
             total_input += record.input_tokens as u64;
             total_output += record.output_tokens as u64;
             total_cached += record.cached_tokens as u64;
+            total_cache_write += record.cache_write_tokens as u64;
             total_tokens += record.total_tokens as u64;
 
             // Aggregate by model
@@ -458,6 +470,7 @@ impl TokenUsageService {
             model_stats.total_input += record.input_tokens as u64;
             model_stats.total_output += record.output_tokens as u64;
             model_stats.total_cached += record.cached_tokens as u64;
+            model_stats.total_cache_write += record.cache_write_tokens as u64;
             model_stats.total_tokens += record.total_tokens as u64;
             model_stats.request_count += 1;
             model_stats.session_ids.insert(record.session_id.clone());
@@ -478,6 +491,7 @@ impl TokenUsageService {
                     total_input: 0,
                     total_output: 0,
                     total_cached: 0,
+                    total_cache_write: 0,
                     total_tokens: 0,
                     request_count: 0,
                     created_at: record.timestamp,
@@ -487,6 +501,7 @@ impl TokenUsageService {
             session_stats.total_input += record.input_tokens;
             session_stats.total_output += record.output_tokens;
             session_stats.total_cached += record.cached_tokens;
+            session_stats.total_cache_write += record.cache_write_tokens;
             session_stats.total_tokens += record.total_tokens;
             session_stats.request_count += 1;
 
@@ -507,6 +522,7 @@ impl TokenUsageService {
             total_input,
             total_output,
             total_cached,
+            total_cache_write,
             total_tokens,
             by_model,
             by_session,

--- a/src/crates/core/src/service/token_usage/service.rs
+++ b/src/crates/core/src/service/token_usage/service.rs
@@ -209,6 +209,9 @@ impl TokenUsageService {
         stats.total_output += record.output_tokens as u64;
         stats.total_cached += record.cached_tokens as u64;
         stats.total_cache_write += record.cache_write_tokens as u64;
+        if record.cached_tokens_available {
+            stats.cache_reported_input_tokens += record.input_tokens as u64;
+        }
         stats.total_tokens += record.total_tokens as u64;
         stats.request_count += 1;
 
@@ -243,6 +246,7 @@ impl TokenUsageService {
                 total_output: 0,
                 total_cached: 0,
                 total_cache_write: 0,
+                cache_reported_input_tokens: 0,
                 total_tokens: 0,
                 request_count: 0,
                 created_at: record.timestamp,
@@ -253,6 +257,9 @@ impl TokenUsageService {
         stats.total_output += record.output_tokens;
         stats.total_cached += record.cached_tokens;
         stats.total_cache_write += record.cache_write_tokens;
+        if record.cached_tokens_available {
+            stats.cache_reported_input_tokens += record.input_tokens;
+        }
         stats.total_tokens += record.total_tokens;
         stats.request_count += 1;
         stats.last_updated = record.timestamp;
@@ -322,6 +329,10 @@ impl TokenUsageService {
             stats.total_input += record.input_tokens as u64;
             stats.total_output += record.output_tokens as u64;
             stats.total_cached += record.cached_tokens as u64;
+            stats.total_cache_write += record.cache_write_tokens as u64;
+            if record.cached_tokens_available {
+                stats.cache_reported_input_tokens += record.input_tokens as u64;
+            }
             stats.total_tokens += record.total_tokens as u64;
             stats.request_count += 1;
             stats.session_ids.insert(record.session_id.clone());
@@ -446,6 +457,7 @@ impl TokenUsageService {
         let mut total_output = 0u64;
         let mut total_cached = 0u64;
         let mut total_cache_write = 0u64;
+        let mut cache_reported_input_tokens = 0u64;
         let mut total_tokens = 0u64;
 
         let mut by_model: HashMap<String, ModelTokenStats> = HashMap::new();
@@ -456,6 +468,9 @@ impl TokenUsageService {
             total_output += record.output_tokens as u64;
             total_cached += record.cached_tokens as u64;
             total_cache_write += record.cache_write_tokens as u64;
+            if record.cached_tokens_available {
+                cache_reported_input_tokens += record.input_tokens as u64;
+            }
             total_tokens += record.total_tokens as u64;
 
             // Aggregate by model
@@ -471,6 +486,9 @@ impl TokenUsageService {
             model_stats.total_output += record.output_tokens as u64;
             model_stats.total_cached += record.cached_tokens as u64;
             model_stats.total_cache_write += record.cache_write_tokens as u64;
+            if record.cached_tokens_available {
+                model_stats.cache_reported_input_tokens += record.input_tokens as u64;
+            }
             model_stats.total_tokens += record.total_tokens as u64;
             model_stats.request_count += 1;
             model_stats.session_ids.insert(record.session_id.clone());
@@ -492,6 +510,7 @@ impl TokenUsageService {
                     total_output: 0,
                     total_cached: 0,
                     total_cache_write: 0,
+                    cache_reported_input_tokens: 0,
                     total_tokens: 0,
                     request_count: 0,
                     created_at: record.timestamp,
@@ -502,6 +521,9 @@ impl TokenUsageService {
             session_stats.total_output += record.output_tokens;
             session_stats.total_cached += record.cached_tokens;
             session_stats.total_cache_write += record.cache_write_tokens;
+            if record.cached_tokens_available {
+                session_stats.cache_reported_input_tokens += record.input_tokens;
+            }
             session_stats.total_tokens += record.total_tokens;
             session_stats.request_count += 1;
 
@@ -523,6 +545,7 @@ impl TokenUsageService {
             total_output,
             total_cached,
             total_cache_write,
+            cache_reported_input_tokens,
             total_tokens,
             by_model,
             by_session,

--- a/src/crates/services-core/src/token_usage/types.rs
+++ b/src/crates/services-core/src/token_usage/types.rs
@@ -17,6 +17,11 @@ pub struct TokenUsageRecord {
     /// Whether cached token count was explicitly reported by the provider/event.
     #[serde(default)]
     pub cached_tokens_available: bool,
+    /// Cache WRITE tokens (Anthropic only: `cache_creation_input_tokens`).
+    /// These are tokens written into the cache this call (billed at write price).
+    /// Extracted from `token_details.cacheCreationTokenCount` when present.
+    #[serde(default)]
+    pub cache_write_tokens: u32,
     pub total_tokens: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_details: Option<serde_json::Value>,
@@ -31,7 +36,11 @@ pub struct ModelTokenStats {
     pub model_id: String,
     pub total_input: u64,
     pub total_output: u64,
+    /// Cumulative cache HIT tokens (served from cache, charged at cache-read price).
     pub total_cached: u64,
+    /// Cumulative cache WRITE tokens (Anthropic only; charged at cache-write price).
+    #[serde(default)]
+    pub total_cache_write: u64,
     pub total_tokens: u64,
     /// Number of distinct sessions that used this model
     pub session_count: u32,
@@ -44,6 +53,27 @@ pub struct ModelTokenStats {
     pub last_used: Option<DateTime<Utc>>,
 }
 
+impl ModelTokenStats {
+    /// Fraction of prompt tokens served from cache (0.0–1.0).
+    /// Returns `None` when no prompt tokens have been recorded or when the
+    /// provider never reported cache token counts.
+    pub fn cache_hit_ratio(&self) -> Option<f64> {
+        if self.total_input == 0 {
+            return None;
+        }
+        Some(self.total_cached as f64 / self.total_input as f64)
+    }
+
+    /// Estimated cost-savings ratio attributed to prefix-cache hits.
+    ///
+    /// Uses DeepSeek / Anthropic cache pricing where a cache-read costs about 10%
+    /// of a full prompt token. The returned value represents the fraction of prompt
+    /// spend that was avoided. Returns `None` when `cache_hit_ratio` is `None`.
+    pub fn estimated_cache_savings_ratio(&self) -> Option<f64> {
+        self.cache_hit_ratio().map(|r| r * 0.90)
+    }
+}
+
 /// Token statistics for a specific session
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionTokenStats {
@@ -51,11 +81,31 @@ pub struct SessionTokenStats {
     pub model_id: String,
     pub total_input: u32,
     pub total_output: u32,
+    /// Cumulative cache HIT tokens for this session.
     pub total_cached: u32,
+    /// Cumulative cache WRITE tokens for this session (Anthropic only).
+    #[serde(default)]
+    pub total_cache_write: u32,
     pub total_tokens: u32,
     pub request_count: u32,
     pub created_at: DateTime<Utc>,
     pub last_updated: DateTime<Utc>,
+}
+
+impl SessionTokenStats {
+    /// Fraction of prompt tokens served from cache (0.0–1.0).
+    /// Returns `None` when no prompt tokens recorded or provider never reported cache counts.
+    pub fn cache_hit_ratio(&self) -> Option<f64> {
+        if self.total_input == 0 {
+            return None;
+        }
+        Some(self.total_cached as f64 / self.total_input as f64)
+    }
+
+    /// Estimated cost-savings ratio from prefix-cache hits (cache read about 10% of full price).
+    pub fn estimated_cache_savings_ratio(&self) -> Option<f64> {
+        self.cache_hit_ratio().map(|r| r * 0.90)
+    }
 }
 
 /// Time range for querying statistics
@@ -89,7 +139,11 @@ pub struct TokenUsageQuery {
 pub struct TokenUsageSummary {
     pub total_input: u64,
     pub total_output: u64,
+    /// Aggregate cache HIT tokens across all records in the query.
     pub total_cached: u64,
+    /// Aggregate cache WRITE tokens across all records in the query (Anthropic only).
+    #[serde(default)]
+    pub total_cache_write: u64,
     pub total_tokens: u64,
     pub by_model: HashMap<String, ModelTokenStats>,
     pub by_session: HashMap<String, SessionTokenStats>,

--- a/src/crates/services-core/src/token_usage/types.rs
+++ b/src/crates/services-core/src/token_usage/types.rs
@@ -41,6 +41,10 @@ pub struct ModelTokenStats {
     /// Cumulative cache WRITE tokens (Anthropic only; charged at cache-write price).
     #[serde(default)]
     pub total_cache_write: u64,
+    /// Prompt input tokens from requests where the provider explicitly reported
+    /// cache hit telemetry. Used as the cache hit ratio denominator.
+    #[serde(default)]
+    pub cache_reported_input_tokens: u64,
     pub total_tokens: u64,
     /// Number of distinct sessions that used this model
     pub session_count: u32,
@@ -58,10 +62,10 @@ impl ModelTokenStats {
     /// Returns `None` when no prompt tokens have been recorded or when the
     /// provider never reported cache token counts.
     pub fn cache_hit_ratio(&self) -> Option<f64> {
-        if self.total_input == 0 {
+        if self.cache_reported_input_tokens == 0 {
             return None;
         }
-        Some(self.total_cached as f64 / self.total_input as f64)
+        Some(self.total_cached as f64 / self.cache_reported_input_tokens as f64)
     }
 
     /// Estimated cost-savings ratio attributed to prefix-cache hits.
@@ -86,6 +90,10 @@ pub struct SessionTokenStats {
     /// Cumulative cache WRITE tokens for this session (Anthropic only).
     #[serde(default)]
     pub total_cache_write: u32,
+    /// Prompt input tokens from requests where the provider explicitly reported
+    /// cache hit telemetry. Used as the cache hit ratio denominator.
+    #[serde(default)]
+    pub cache_reported_input_tokens: u32,
     pub total_tokens: u32,
     pub request_count: u32,
     pub created_at: DateTime<Utc>,
@@ -96,10 +104,10 @@ impl SessionTokenStats {
     /// Fraction of prompt tokens served from cache (0.0–1.0).
     /// Returns `None` when no prompt tokens recorded or provider never reported cache counts.
     pub fn cache_hit_ratio(&self) -> Option<f64> {
-        if self.total_input == 0 {
+        if self.cache_reported_input_tokens == 0 {
             return None;
         }
-        Some(self.total_cached as f64 / self.total_input as f64)
+        Some(self.total_cached as f64 / self.cache_reported_input_tokens as f64)
     }
 
     /// Estimated cost-savings ratio from prefix-cache hits (cache read about 10% of full price).
@@ -144,6 +152,9 @@ pub struct TokenUsageSummary {
     /// Aggregate cache WRITE tokens across all records in the query (Anthropic only).
     #[serde(default)]
     pub total_cache_write: u64,
+    /// Aggregate prompt input tokens from requests where cache hit telemetry was reported.
+    #[serde(default)]
+    pub cache_reported_input_tokens: u64,
     pub total_tokens: u64,
     pub by_model: HashMap<String, ModelTokenStats>,
     pub by_session: HashMap<String, SessionTokenStats>,

--- a/src/crates/services-core/tests/token_usage_contracts.rs
+++ b/src/crates/services-core/tests/token_usage_contracts.rs
@@ -1,4 +1,6 @@
-use bitfun_services_core::token_usage::{TimeRange, TokenUsageQuery, TokenUsageRecord};
+use bitfun_services_core::token_usage::{
+    ModelTokenStats, SessionTokenStats, TimeRange, TokenUsageQuery, TokenUsageRecord,
+};
 use chrono::Utc;
 
 #[test]
@@ -34,4 +36,43 @@ fn token_usage_query_preserves_include_subagent_default() {
             .expect("query should deserialize");
 
     assert!(!restored.include_subagent);
+}
+
+#[test]
+fn model_cache_hit_ratio_requires_reported_cache_telemetry() {
+    let no_telemetry = ModelTokenStats {
+        model_id: "model-a".to_string(),
+        total_input: 100,
+        total_cached: 0,
+        ..Default::default()
+    };
+    assert_eq!(no_telemetry.cache_hit_ratio(), None);
+
+    let reported = ModelTokenStats {
+        model_id: "model-a".to_string(),
+        total_input: 300,
+        total_cached: 50,
+        cache_reported_input_tokens: 100,
+        ..Default::default()
+    };
+    assert_eq!(reported.cache_hit_ratio(), Some(0.5));
+}
+
+#[test]
+fn session_cache_hit_ratio_uses_reported_input_denominator() {
+    let stats = SessionTokenStats {
+        session_id: "session-1".to_string(),
+        model_id: "model-a".to_string(),
+        total_input: 300,
+        total_output: 20,
+        total_cached: 50,
+        total_cache_write: 0,
+        cache_reported_input_tokens: 100,
+        total_tokens: 320,
+        request_count: 2,
+        created_at: Utc::now(),
+        last_updated: Utc::now(),
+    };
+
+    assert_eq!(stats.cache_hit_ratio(), Some(0.5));
 }


### PR DESCRIPTION
Supersedes #907.

Credit to @harryfan1985 for the original work in #907. This replacement PR keeps and adapts the parts of that work that remain valid on top of current `main`, while leaving context compression aligned with `5e5738f`, which already implemented prompt-cache-aware context compression on `main` via the full-prefix compression path.

What changed:
- add cache write token tracking for prefix-cache observability
- refine cache hit ratio accounting to use only input tokens from requests where cache telemetry was explicitly reported
- document the prefix-cache stability contract for contextual tool manifests

What is intentionally not included:
- `dc992d6`, which is already on `main`
- the context compression implementation from `3a5033c` / `3acb3fb`, because `5e5738f` already implemented prompt-cache-aware compression on the current main branch and this PR's compression path takes a different approach

Commits:
- `3a312eeb` `perf(observability): add cache write token metrics`
- `70378754` `fix(token-usage): refine cache hit ratio denominator`
- `2165bfa7` `docs(agent-tools): document prefix-cache stability contract`