### PR TITLE
fix(bot): avoid duplicate IM menu items

### DIFF
--- a/src/crates/core/src/service/remote_connect/bot/command_router.rs
+++ b/src/crates/core/src/service/remote_connect/bot/command_router.rs
@@ -931,6 +931,7 @@ fn workspace_selection_view(
         .with_body(body.trim_end().to_string())
         .with_items(items)
         .with_footer(s.footer_reply_workspace)
+        .without_plain_text_items()
 }
 
 fn assistant_selection_view(
@@ -954,6 +955,7 @@ fn assistant_selection_view(
         .with_body(body.trim_end().to_string())
         .with_items(items)
         .with_footer(s.footer_reply_assistant)
+        .without_plain_text_items()
 }
 
 fn session_selection_view(
@@ -987,6 +989,7 @@ fn session_selection_view(
         .with_body(body.trim_end().to_string())
         .with_items(items)
         .with_footer(footer)
+        .without_plain_text_items()
 }
 
 async fn select_workspace(

--- a/src/crates/core/src/service/remote_connect/bot/menu.rs
+++ b/src/crates/core/src/service/remote_connect/bot/menu.rs
@@ -72,6 +72,11 @@ pub struct MenuView {
     /// Optional footer hint shown below items (telegram/feishu silently
     /// drop this; weixin shows it as the last text line).
     pub footer_hint: Option<String>,
+    /// Whether text-only renderers should append `items` as numbered lines.
+    /// Some selection prompts include richer numbered lines in `body` while
+    /// still keeping `items` for native buttons; appending both duplicates the
+    /// option list on plain-text platforms.
+    pub render_items_in_plain_text: bool,
 }
 
 impl MenuView {
@@ -81,6 +86,7 @@ impl MenuView {
             body: None,
             items: Vec::new(),
             footer_hint: None,
+            render_items_in_plain_text: true,
         }
     }
 
@@ -96,6 +102,11 @@ impl MenuView {
 
     pub fn with_footer(mut self, hint: impl Into<String>) -> Self {
         self.footer_hint = Some(hint.into());
+        self
+    }
+
+    pub fn without_plain_text_items(mut self) -> Self {
+        self.render_items_in_plain_text = false;
         self
     }
 
@@ -124,7 +135,7 @@ impl MenuView {
                 out.push_str(body);
             }
         }
-        if !self.items.is_empty() {
+        if self.render_items_in_plain_text && !self.items.is_empty() {
             if !out.is_empty() {
                 out.push_str("\n\n");
             }


### PR DESCRIPTION
## Summary
- add a MenuView flag to skip appending button items in plain-text renders
- disable duplicate plain-text item rendering for workspace, assistant, and session selection prompts

## Verification
- cargo test -p bitfun-core service::remote_connect::bot:: -- --nocapture