### PR TITLE
refactor(web-ui): capsule/multi-line chat input auto layout

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInput.scss
@@ -49,272 +49,149 @@
   flex-direction: column;
   transform: translateY(0);
   transition:
-    max-width 0.32s cubic-bezier(0.4, 0, 0.2, 1),
-    transform 0.32s cubic-bezier(0.4, 0, 0.2, 1);
-  
-  &--collapsed {
-    cursor: text;
-    max-width: min(380px, 80%);
-    margin: 0 auto;
-    transform: translateY(3px);
+    max-width 0.28s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
 
-    .bitfun-chat-input__box {
-      position: relative;
-      overflow: hidden;
-      min-height: 48px;
-      max-height: 48px;
-      padding: 0 18px;
-      border-radius: 24px;
-      cursor: text;
-      background: rgba(18, 18, 28, 0.22);
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      backdrop-filter: blur(8px);
-      -webkit-backdrop-filter: blur(8px);
-      box-shadow: 
-        0 8px 24px rgba(0, 0, 0, 0.18),
-        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  // ─── Single-line capsule mode ─────────────────────────────────────────────
+  &--capsule {
+    .bitfun-chat-input__box--capsule {
       flex-direction: row;
       align-items: center;
-      gap: var(--flowchat-control-gap, 0.5rem);
-      
-      &:hover {
-        background: rgba(25, 25, 40, 0.38);
-        border: 1px solid rgba(255, 255, 255, 0.16);
-        backdrop-filter: blur(12px);
-        -webkit-backdrop-filter: blur(12px);
-        box-shadow: 
-          0 12px 30px rgba(0, 0, 0, 0.24),
-          inset 0 1px 0 rgba(255, 255, 255, 0.08);
-      }
-    }
-    
-    // Light theme overrides for the collapsed capsule
-    :root[data-theme="light"] &,
-    :root[data-theme-type="light"] &,
-    .light & {
-      .bitfun-chat-input__box {
-        background: rgba(255, 255, 255, 0.28);
-        border: 1px solid rgba(0, 0, 0, 0.08);
-        backdrop-filter: blur(8px);
-        -webkit-backdrop-filter: blur(8px);
-        box-shadow:
-          0 2px 8px rgba(0, 0, 0, 0.06),
-          inset 0 1px 0 rgba(255, 255, 255, 0.8);
-        
-        &:hover {
-          background: rgba(255, 255, 255, 0.45);
-          border: 1px solid rgba(0, 0, 0, 0.14);
-          backdrop-filter: blur(12px);
-          -webkit-backdrop-filter: blur(12px);
-          box-shadow:
-            0 12px 24px rgba(0, 0, 0, 0.1),
-            inset 0 1px 0 rgba(255, 255, 255, 0.9);
-        }
-      }
-    }
-    
-    .bitfun-chat-input__expand-button,
-    .bitfun-chat-input__cowork-examples,
-    .bitfun-chat-input__recommendations,
-    .bitfun-chat-input__target-switcher,
-    .bitfun-chat-input__actions-left,
-    .bitfun-chat-input__agent-boost,
-    .bitfun-chat-input__actions-right {
-      display: none !important;
-    }
-    
-    .bitfun-chat-input__input-area {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      width: calc(100% - 36px);
-      min-height: 28px;
-      max-height: 28px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      transform: translate(-50%, -50%);
-      pointer-events: none;
+      min-height: 44px;
+      max-height: 44px;
+      padding: 0 6px 0 2px;
+      border-radius: 22px;
+      overflow: visible;
 
-      .rich-text-input {
-        min-height: 28px !important;
-        max-height: 28px !important;
-        max-width: 100%;
-        font-size: var(--flowchat-font-size-base);
-        line-height: var(--flowchat-support-line-height, 1.45);
-        overflow: hidden;
-        padding: 0 !important;
-        margin: 0 auto;
-        text-align: center;
-        width: 100%;
-
-        &:empty::before {
-          display: block;
-          color: color-mix(in srgb, var(--color-text-muted) 52%, transparent);
-          font-size: var(--flowchat-font-size-base);
-          line-height: var(--flowchat-support-line-height, 1.45);
-          text-align: center;
-          width: 100%;
-        }
-      }
-
-      .bitfun-chat-input__space-hint {
-        display: inline-flex;
-        position: absolute;
-        inset: 0;
-        align-items: center;
-        justify-content: center;
-        gap: var(--flowchat-inline-gap, 0.35rem);
-        width: 100%;
-        font-size: var(--flowchat-font-size-sm);
-        line-height: var(--flowchat-support-line-height, 1.45);
-        color: color-mix(in srgb, var(--color-text-muted) 48%, transparent);
-        white-space: nowrap;
-        pointer-events: none;
-        letter-spacing: 0.01em;
-        animation: bitfun-space-hint-pop 0.28s cubic-bezier(0.4, 0, 0.2, 1) 0.22s both;
-      }
-    }
-    
-    .bitfun-chat-input__actions {
-      flex-shrink: 0;
-      height: auto;
-      padding: 0;
-      margin: 0;
-    }
-
-    &.bitfun-chat-input--processing {
-      .bitfun-chat-input__input-area {
-        left: 18px;
-        right: 118px;
-        width: auto;
-        transform: translateY(-50%);
-        justify-content: flex-start;
-      }
-
-      .rich-text-input {
-        display: none;
-      }
-
+      // Dissolve the actions wrapper so its children become direct flex items
       .bitfun-chat-input__actions {
-        position: absolute;
-        top: 0;
-        right: 14px;
-        bottom: 0;
+        display: contents;
+      }
+
+      .bitfun-chat-input__actions-left {
+        order: 1;
+        flex-shrink: 0;
         display: flex;
         align-items: center;
-        z-index: 2;
+        padding: 0 2px 0 4px;
+        animation: none;
+
+        // In capsule, hide the mode capsule badge (not enough space)
+        .bitfun-chat-input__agent-capsule {
+          display: none !important;
+        }
+
+        // Enlarge the Plus button to match the capsule height
+        .bitfun-chat-input__agent-boost-add {
+          width: 28px !important;
+          height: 28px !important;
+          min-width: 28px !important;
+          border-radius: 50% !important;
+          display: flex !important;
+          align-items: center !important;
+          justify-content: center !important;
+        }
+      }
+
+      .bitfun-chat-input__input-area {
+        order: 2;
+        flex: 1;
+        min-width: 0;
+        min-height: 0;
+        padding-bottom: 0;
+        display: flex;
+        align-items: center;
+
+        .rich-text-input {
+          min-height: 22px !important;
+          max-height: 22px !important;
+          overflow: hidden;
+          line-height: var(--flowchat-support-line-height, 1.45);
+          font-size: var(--flowchat-font-size-base);
+          padding: 0 !important;
+          width: 100%;
+          // Allow clicks to reach the contenteditable in capsule mode
+          pointer-events: auto;
+
+        }
       }
 
       .bitfun-chat-input__actions-right {
-        display: flex !important;
+        order: 3;
+        flex-shrink: 0;
+        display: flex;
         align-items: center;
-        gap: var(--flowchat-control-gap, 0.5rem);
+        gap: $size-gap-1;
+        padding: 0 4px 0 2px;
+        animation: none;
+
+        // Enlarge send/stop button to match the capsule height
+        .bitfun-chat-input__send-button {
+          width: 28px !important;
+          height: 28px !important;
+          border-radius: 50% !important;
+          display: inline-flex !important;
+          align-items: center !important;
+          justify-content: center !important;
+
+          &--breathing {
+            width: auto !important;
+            height: auto !important;
+          }
+        }
+
+        .bitfun-chat-input__breathing-circle {
+          width: 28px !important;
+          height: 28px !important;
+        }
+
+        .bitfun-chat-input__model-usage-group {
+          display: flex;
+          align-items: center;
+        }
       }
 
-      .bitfun-chat-input__space-hint {
-        justify-content: flex-start;
-        width: 100%;
-      }
-
-      .bitfun-chat-input__action-button {
+      // Hide things that belong to multi-line only
+      .bitfun-chat-input__cowork-examples,
+      .bitfun-chat-input__recommendations,
+      .bitfun-chat-input__target-switcher,
+      .bitfun-chat-input__image-strip {
         display: none !important;
       }
     }
+  }
 
-    &:hover .bitfun-chat-input__space-hint {
-      color: color-mix(in srgb, var(--color-text-muted) 62%, transparent);
-    }
+  &__placeholder {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    pointer-events: none;
+    color: color-mix(in srgb, var(--color-text-muted) 52%, transparent);
+    font-size: var(--flowchat-font-size-base);
+    line-height: var(--flowchat-support-line-height, 1.45);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    user-select: none;
+  }
 
-    &.bitfun-chat-input--pet-visible {
-      .bitfun-chat-input__input-area {
-        z-index: 1;
-      }
+  // In multi-line card mode: align to top of text area
+  &__box--multi-line &__placeholder {
+    padding-top: 1px;
+  }
 
-      .bitfun-chat-input__actions {
-        z-index: 2;
-      }
+  // In capsule: vertically centre inside the 22px line height
+  &__box--capsule &__placeholder {
+    top: 50%;
+    transform: translateY(-50%);
+  }
 
-      .bitfun-chat-input__space-hint {
-        opacity: 0;
-        transition: opacity 0.36s cubic-bezier(0.4, 0, 0.2, 1);
-      }
-
-      &:hover .bitfun-chat-input__space-hint {
-        opacity: 1;
-        color: color-mix(in srgb, var(--color-text-muted) 58%, transparent);
-      }
-
-      &.bitfun-chat-input--pet-split-send.bitfun-chat-input--processing {
-        .bitfun-chat-input__actions {
-          z-index: 5;
-        }
-      }
-    }
-
-    &.bitfun-chat-input--pet-replaces-stop.bitfun-chat-input--processing {
-      .bitfun-chat-input__input-area {
-        right: 52px;
-      }
-
-      &.bitfun-chat-input--pet-split-send .bitfun-chat-input__input-area {
-        right: 112px;
-      }
-    }
-
-    .bitfun-chat-input__pet-wrap {
-      position: absolute;
-      inset: 0;
-      z-index: 3;
-      pointer-events: none;
-    }
-
-    /* Full width so flex alignment is relative to the capsule (not the ~40px pet). */
-    .bitfun-chat-input__pet-inner {
-      box-sizing: border-box;
-      width: 100%;
-      height: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding-left: 0;
-      padding-right: 0;
-      transition:
-        justify-content 0.45s cubic-bezier(0.34, 1.15, 0.64, 1),
-        padding 0.45s cubic-bezier(0.34, 1.15, 0.64, 1);
-    }
-
-    /* Align with former stop control (~same inset as .bitfun-chat-input__actions { right: 14px }). */
-    .bitfun-chat-input__pet-wrap--shift .bitfun-chat-input__pet-inner {
-      justify-content: flex-end;
-      padding-right: 8px;
-    }
-
-    .bitfun-chat-input__pet-wrap--shift.bitfun-chat-input__pet-wrap--split .bitfun-chat-input__pet-inner {
-      padding-right: 42px;
-    }
-
-    .bitfun-chat-input__pet-stop-btn {
-      pointer-events: auto;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0;
-      margin: 0;
-      border: none;
-      background: transparent;
-      cursor: pointer;
-      border-radius: 10px;
-      line-height: 0;
-
-      &:hover {
-        filter: brightness(1.08);
-      }
-
-      &:focus-visible {
-        outline: 2px solid var(--color-accent-primary);
-        outline-offset: 2px;
-      }
+  :root[data-theme="light"] &,
+  :root[data-theme-type="light"] &,
+  .light & {
+    &__placeholder {
+      color: color-mix(in srgb, var(--color-text-secondary) 48%, transparent);
     }
   }
 
@@ -475,17 +352,67 @@
     &::before {
       content: none;
     }
+
+    // Capsule (single-line) mode appearance
+    &--capsule {
+      border-radius: 22px;
+      min-height: 44px;
+      max-height: 44px;
+      padding: 0 6px 0 2px;
+      background: rgba(18, 18, 28, 0.22);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      box-shadow:
+        0 8px 24px rgba(0, 0, 0, 0.18),
+        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+
+      &:hover {
+        background: rgba(25, 25, 40, 0.38);
+        border-color: rgba(255, 255, 255, 0.16);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        box-shadow:
+          0 12px 30px rgba(0, 0, 0, 0.24),
+          inset 0 1px 0 rgba(255, 255, 255, 0.08);
+      }
+
+      &:focus-within {
+        background: rgba(25, 25, 40, 0.42);
+        border-color: rgba(255, 255, 255, 0.2);
+        box-shadow:
+          0 12px 30px rgba(0, 0, 0, 0.28),
+          inset 0 1px 0 rgba(255, 255, 255, 0.1);
+      }
+    }
+
+    :root[data-theme="light"] &--capsule,
+    :root[data-theme-type="light"] &--capsule,
+    .light &--capsule {
+      background: rgba(255, 255, 255, 0.28);
+      border: 1px solid rgba(0, 0, 0, 0.08);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      box-shadow:
+        0 2px 8px rgba(0, 0, 0, 0.06),
+        inset 0 1px 0 rgba(255, 255, 255, 0.8);
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.45);
+        border-color: rgba(0, 0, 0, 0.14);
+        box-shadow:
+          0 12px 24px rgba(0, 0, 0, 0.1),
+          inset 0 1px 0 rgba(255, 255, 255, 0.9);
+      }
+    }
     
-    &--expanded {
-      max-height: calc(100vh - 178px);
-      
+    &--multi-line {
+      // Max ~5 lines: 5 × (14px × 1.45) ≈ 101px + padding + action bar ≈ 160px
       .bitfun-chat-input__input-area {
-        min-height: calc(100vh - 240px);
-        max-height: calc(100vh - 240px);
-        
+        min-height: 56px;
+
         .rich-text-input {
-          min-height: calc(100vh - 280px);
-          max-height: calc(100vh - 280px);
+          max-height: 102px; // ~5 lines of text
         }
       }
     }
@@ -567,61 +494,6 @@
     }
   }
   
-  &__expand-button.icon-btn {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    width: 22px;
-    height: 22px;
-    border: none;
-    border-radius: 50%;
-    background: transparent;
-    color: var(--color-text-secondary);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    opacity: 1;
-    transform: scale(1);
-    transform-origin: center;
-    transition:
-      transform 0.22s cubic-bezier(0.34, 1.2, 0.64, 1),
-      background 0.2s ease,
-      color 0.2s ease,
-      box-shadow 0.2s ease;
-    animation: bitfun-stacked-reveal 0.22s cubic-bezier(0.4, 0, 0.2, 1) 0.24s both;
-    box-shadow: none;
-
-    svg {
-      opacity: 0.5;
-      transition:
-        opacity 0.2s ease,
-        transform 0.22s cubic-bezier(0.34, 1.2, 0.64, 1);
-    }
-
-    &:hover:not(:disabled) {
-      transform: scale(1.14);
-      color: var(--color-accent-400);
-      background: var(--color-accent-100);
-      box-shadow:
-        inset 0 0 0 1px color-mix(in srgb, var(--color-accent-400) 22%, transparent),
-        0 2px 10px color-mix(in srgb, var(--color-accent-400) 12%, transparent);
-
-      svg {
-        opacity: 1;
-        transform: scale(1.12);
-      }
-    }
-
-    &:active:not(:disabled) {
-      transform: scale(1.02);
-      transition-duration: 0.1s;
-
-      svg {
-        transform: scale(1);
-      }
-    }
-  }
   
   &__input-area {
     position: relative;

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -5,8 +5,8 @@
 
 import React, { useRef, useCallback, useEffect, useReducer, useState, useMemo } from 'react';
 import path from 'path-browserify';
-import { Trans, useTranslation } from 'react-i18next';
-import { ArrowUp, Image, Maximize2, Minimize2, RotateCcw, Plus, X, Sparkles, Loader2, ChevronRight, Files, MessageSquarePlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { ArrowUp, Image, RotateCcw, Plus, X, Sparkles, Loader2, ChevronRight, Files, MessageSquarePlus } from 'lucide-react';
 import { ContextDropZone, useContextStore } from '../../shared/context-system';
 import { useActiveSessionState } from '@/flow_chat/hooks';
 import { RichTextInput, type MentionState } from './RichTextInput';
@@ -56,14 +56,10 @@ import { useSceneStore } from '@/app/stores/sceneStore';
 import type { SceneTabId } from '@/app/components/SceneBar/types';
 import { configAPI } from '@/infrastructure/api';
 import type { ModeSkillInfo } from '@/infrastructure/config/types';
-import { aiExperienceConfigService } from '@/infrastructure/config/services/AIExperienceConfigService';
 import MCPAPI, { type MCPPrompt, type MCPPromptMessage, type MCPServerInfo } from '@/infrastructure/api/service-api/MCPAPI';
-import { deriveChatInputPetMood } from '../utils/chatInputPetMood';
-import { ChatInputPixelPet } from './ChatInputPixelPet';
 import { ChatInputWorkspaceStrip } from './ChatInputWorkspaceStrip';
 import { expandWidgetPromptReferenceTokens } from '@/tools/generative-widget/widgetPromptReference';
 import { useDeepReviewConsent } from './DeepReviewConsentDialog';
-import { useAgentCompanionActivity } from '../hooks/useAgentCompanionActivity';
 import { useSessionReviewActivity } from '../hooks/useSessionReviewActivity';
 import { shouldBlockDeepReviewCommand } from '../utils/deepReviewCommandGuard';
 import { deriveDeepReviewSessionConcurrencyGuard } from '../utils/deepReviewCapacityGuard';
@@ -229,6 +225,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const [modeState, dispatchMode] = useReducer(modeReducer, initialModeState);
   
   const richTextInputRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const agentBoostRef = useRef<HTMLDivElement>(null);
   const isImeComposingRef = useRef(false);
   // Ref so the queuedInput sync effect can read the latest value without it being a dep
@@ -300,39 +297,90 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     inputState.value.trim()
   );
   const currentReviewActivity = useSessionReviewActivity(currentSessionId);
-  const sessionMachineSnapshot = useSessionStateMachine(effectiveTargetSessionId);
-  const companionActivity = useAgentCompanionActivity();
+  useSessionStateMachine(effectiveTargetSessionId);
   const { confirmDeepReviewLaunch, deepReviewConsentDialog } = useDeepReviewConsent();
-  const targetPetMood = useMemo(
-    () => deriveChatInputPetMood(sessionMachineSnapshot),
-    [sessionMachineSnapshot],
-  );
-  const petMood = targetPetMood === 'rest' ? companionActivity.mood : targetPetMood;
-  const [agentCompanionEnabled, setAgentCompanionEnabled] = useState(
-    () => aiExperienceConfigService.getSettings().enable_agent_companion,
-  );
-  const [agentCompanionDisplayMode, setAgentCompanionDisplayMode] = useState(
-    () => aiExperienceConfigService.getSettings().agent_companion_display_mode,
-  );
-  const [agentCompanionPet, setAgentCompanionPet] = useState(
-    () => aiExperienceConfigService.getSettings().agent_companion_pet ?? null,
-  );
-  useEffect(() => {
-    void aiExperienceConfigService.getSettingsAsync().then(initialSettings => {
-      setAgentCompanionEnabled(initialSettings.enable_agent_companion);
-      setAgentCompanionDisplayMode(initialSettings.agent_companion_display_mode);
-      setAgentCompanionPet(initialSettings.agent_companion_pet ?? null);
-    });
-    return aiExperienceConfigService.addChangeListener(settings => {
-      setAgentCompanionEnabled(settings.enable_agent_companion);
-      setAgentCompanionDisplayMode(settings.agent_companion_display_mode);
-      setAgentCompanionPet(settings.agent_companion_pet ?? null);
-    });
+  // isMultiLine: true when content overflows a single line (scrollHeight > threshold or has newlines)
+  const [isMultiLine, setIsMultiLine] = useState(false);
+  // showPlaceholder is true when the editor DOM is truly empty (value empty AND no residual <br>)
+  const [showPlaceholder, setShowPlaceholder] = useState(true);
+
+  const checkDomEmpty = useCallback(() => {
+    const el = richTextInputRef.current;
+    if (!el) { setShowPlaceholder(true); return; }
+    const hasOnlyBr =
+      el.childNodes.length === 1 &&
+      (el.childNodes[0] as Element).nodeName === 'BR';
+    const isEmpty = (el.textContent ?? '').trim() === '' &&
+      (el.childNodes.length === 0 || hasOnlyBr);
+    setShowPlaceholder(isEmpty);
   }, []);
-  const agentCompanionInInput =
-    agentCompanionEnabled && agentCompanionDisplayMode === 'input';
-  const showCollapsedPet =
-    agentCompanionInInput && !inputState.isActive && !inputState.value.trim();
+
+  // Shared measurement: temporarily unconstrain the editor and use the capsule input
+  // width so the result is consistent between capsule ↔ multi-line transitions.
+  const measureIsMultiLine = useCallback(() => {
+    const hasNewline = inputState.value.includes('\n');
+    const hasImages = imageContexts.length > 0;
+    if (hasNewline || hasImages) {
+      setIsMultiLine(true);
+      return;
+    }
+    const el = richTextInputRef.current;
+    if (!el) {
+      setIsMultiLine(false);
+      return;
+    }
+    // Capsule input width ≈ box width minus Plus-area (~36px) and right-actions (~140px)
+    const boxEl = el.closest('.bitfun-chat-input__box') as HTMLElement | null;
+    const boxWidth = boxEl?.offsetWidth ?? containerRef.current?.offsetWidth ?? 400;
+    const capsuleInputWidth = Math.max(80, boxWidth - 176);
+
+    // Temporarily remove flex stretching + set capsule width to get the true content height.
+    const prevFlex = el.style.flex;
+    const prevMinH = el.style.minHeight;
+    const prevWidth = el.style.width;
+    el.style.flex = 'none';
+    el.style.minHeight = '0';
+    el.style.width = `${capsuleInputWidth}px`;
+    const naturalHeight = el.scrollHeight;
+    el.style.flex = prevFlex;
+    el.style.minHeight = prevMinH;
+    el.style.width = prevWidth;
+    // ~1.45 × 14px ≈ 20px per line; threshold of 32px means "needs > 1 line"
+    setIsMultiLine(naturalHeight > 32);
+  }, [inputState.value, imageContexts.length]);
+
+  // Re-measure when value or image count changes (handles typing / deleting)
+  useEffect(() => {
+    // Defer one frame so RichTextInput has synced the new value to the contenteditable DOM.
+    const rafId = requestAnimationFrame(() => {
+      measureIsMultiLine();
+      checkDomEmpty();
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [measureIsMultiLine, checkDomEmpty]);
+
+  // Also watch DOM mutations on the editor so that Shift+Enter in an empty input
+  // (which adds a <br> without changing the React value) triggers expansion,
+  // and so that residual <br> after deletion is detected for placeholder visibility.
+  useEffect(() => {
+    const el = richTextInputRef.current;
+    if (!el) return;
+    let rafId: number;
+    const observer = new MutationObserver(() => {
+      rafId = requestAnimationFrame(() => {
+        measureIsMultiLine();
+        checkDomEmpty();
+      });
+    });
+    observer.observe(el, { childList: true, subtree: true });
+    return () => {
+      observer.disconnect();
+      cancelAnimationFrame(rafId);
+    };
+  // measureIsMultiLine / checkDomEmpty capture latest closure values
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const { transition, setQueuedInput } = useSessionStateMachineActions(effectiveTargetSessionId);
 
   const { workspace, workspacePath, workspaceName } = useCurrentWorkspace();
@@ -2436,15 +2484,30 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     input.click();
   }, [addContext, currentImageCount, t]);
   
-  const toggleExpand = useCallback(() => {
-    dispatchInput({ type: 'TOGGLE_EXPAND' });
-  }, []);
 
   const focusRichTextInputSoon = useCallback(() => {
     window.requestAnimationFrame(() => {
       richTextInputRef.current?.focus();
     });
   }, []);
+
+  // Space-to-focus: when no editable element is focused, Space key focuses the input.
+  useEffect(() => {
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== ' ') return;
+      const target = e.target as HTMLElement;
+      const isEditable =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable ||
+        target.closest('[contenteditable="true"]') !== null;
+      if (isEditable) return;
+      e.preventDefault();
+      focusRichTextInputSoon();
+    };
+    document.addEventListener('keydown', handleGlobalKeyDown, true);
+    return () => document.removeEventListener('keydown', handleGlobalKeyDown, true);
+  }, [focusRichTextInputSoon]);
 
   const insertSkillIntoInput = useCallback(
     (skillName: string) => {
@@ -2494,83 +2557,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     },
     [clearSkillsTimer, openScene]
   );
-  
-  const handleActivate = useCallback((e?: React.MouseEvent) => {
-    if (e?.target instanceof HTMLButtonElement || 
-        (e?.target instanceof Element && e.target.closest('button'))) {
-      if (!inputState.isActive) {
-        dispatchInput({ type: 'ACTIVATE' });
-      }
-      return;
-    }
-    
-    if (!inputState.isActive) {
-      dispatchInput({ type: 'ACTIVATE' });
-      focusRichTextInputSoon();
-    }
-  }, [focusRichTextInputSoon, inputState.isActive]);
-
-  // Global space-to-activate: when collapsed and no editable element is focused
-  useEffect(() => {
-    if (inputState.isActive) return;
-
-    const handleGlobalKeyDown = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement;
-      const isEditable =
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.isContentEditable ||
-        target.closest('[contenteditable="true"]') !== null;
-
-      const isImeOwnedKey = e.key === 'Escape' && (e.isComposing || e.keyCode === 229);
-      if (isImeOwnedKey) return;
-
-      if (e.key === 'Escape' && derivedState?.canCancel) {
-        if (isEditable) return;
-        e.preventDefault();
-        void handleCancelCurrentTask();
-        return;
-      }
-
-      if (e.key !== ' ') return;
-      if (isEditable) return;
-
-      e.preventDefault();
-      dispatchInput({ type: 'ACTIVATE' });
-      focusRichTextInputSoon();
-    };
-
-    // Capture phase so activation runs before nested handlers; Space must dispatch ACTIVATE, not only focus().
-    document.addEventListener('keydown', handleGlobalKeyDown, true);
-    return () => document.removeEventListener('keydown', handleGlobalKeyDown, true);
-  }, [derivedState?.canCancel, focusRichTextInputSoon, handleCancelCurrentTask, inputState.isActive]);
-  
-  const containerRef = useRef<HTMLDivElement>(null);
-  
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
-      // Do not collapse when clicking the scroll-to-latest bar.
-      if ((target as Element)?.closest?.('.scroll-to-latest-bar')) return;
-      if (
-        inputState.isActive &&
-        containerRef.current &&
-        !containerRef.current.contains(target)
-      ) {
-        // While IME is composing, React value can still be empty (RichTextInput skips onChange),
-        // but the editor DOM holds preedit text — collapsing would show space-hint on top of it.
-        if (inputState.value.trim() === '' && !isImeComposingRef.current) {
-          dispatchInput({ type: 'DEACTIVATE' });
-        }
-      }
-    };
-    
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [inputState.isActive, inputState.value]);
-
   useEffect(() => {
     const dropZone = containerRef.current?.closest('.bitfun-chat-input-drop-zone') as HTMLElement | null;
     const el = dropZone ?? containerRef.current;
@@ -2584,35 +2570,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const isCollapsedProcessing = !inputState.isActive && !!derivedState?.isProcessing;
-  const petReplacesStopChrome = agentCompanionInInput && isCollapsedProcessing;
-  const petStopClickable = petReplacesStopChrome && derivedState?.canCancel;
-  const collapsedPetSplitSend =
-    petReplacesStopChrome && derivedState?.sendButtonMode === 'split';
 
   const renderActionButton = () => {
     if (!derivedState) return <IconButton className="bitfun-chat-input__send-button" disabled size="small"><ArrowUp size={11} /></IconButton>;
-
-    if (petReplacesStopChrome) {
-      const { sendButtonMode } = derivedState;
-      if (sendButtonMode === 'cancel') {
-        return null;
-      }
-      if (sendButtonMode === 'split') {
-        return (
-          <IconButton
-            className="bitfun-chat-input__send-button"
-            onClick={handleSendOrCancel}
-            disabled={!inputState.value.trim()}
-            data-testid="chat-input-send-btn"
-            tooltip={t('input.sendShortcut')}
-            size="small"
-          >
-            <ArrowUp size={11} />
-          </IconButton>
-        );
-      }
-    }
 
     const { sendButtonMode, hasQueuedInput } = derivedState;
     
@@ -2713,8 +2673,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       >
         <div 
           ref={containerRef}
-          className={`bitfun-chat-input ${inputState.isActive ? 'bitfun-chat-input--active' : 'bitfun-chat-input--collapsed'} ${inputState.isExpanded ? 'bitfun-chat-input--expanded' : ''} ${derivedState?.isProcessing ? 'bitfun-chat-input--processing' : ''} ${showCollapsedPet ? 'bitfun-chat-input--pet-visible' : ''} ${petReplacesStopChrome ? 'bitfun-chat-input--pet-replaces-stop' : ''} ${collapsedPetSplitSend ? 'bitfun-chat-input--pet-split-send' : ''} ${className}`}
-          onClick={!inputState.isActive ? handleActivate : undefined}
+          className={`bitfun-chat-input ${isMultiLine ? 'bitfun-chat-input--multi-line' : 'bitfun-chat-input--capsule'} ${derivedState?.isProcessing ? 'bitfun-chat-input--processing' : ''} ${className}`}
           data-testid="chat-input-container"
         >
         {recommendationContext && (
@@ -2727,44 +2686,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         <PendingQueuePanel sessionId={effectiveTargetSessionId || undefined} />
 
         <div className="bitfun-chat-input__container">
-          <div className={`bitfun-chat-input__box ${inputState.isExpanded ? 'bitfun-chat-input__box--expanded' : ''}`}>
-            {showCollapsedPet && (
-              <div
-                className={[
-                  'bitfun-chat-input__pet-wrap',
-                  petReplacesStopChrome ? 'bitfun-chat-input__pet-wrap--shift' : '',
-                  collapsedPetSplitSend ? 'bitfun-chat-input__pet-wrap--split' : '',
-                ]
-                  .filter(Boolean)
-                  .join(' ')}
-              >
-                <div className="bitfun-chat-input__pet-inner">
-                  {petStopClickable ? (
-                    <button
-                      type="button"
-                      className="bitfun-chat-input__pet-stop-btn"
-                      onClick={e => {
-                        e.stopPropagation();
-                        void handleCancelCurrentTask();
-                      }}
-                      aria-label={t('input.stopGeneration')}
-                    >
-                      <ChatInputPixelPet
-                        mood={petMood}
-                        layout={petReplacesStopChrome ? 'stopRight' : 'center'}
-                        pet={agentCompanionPet}
-                      />
-                    </button>
-                  ) : (
-                    <ChatInputPixelPet
-                      mood={petMood}
-                      layout={petReplacesStopChrome ? 'stopRight' : 'center'}
-                      pet={agentCompanionPet}
-                    />
-                  )}
-                </div>
-              </div>
-            )}
+          <div className={`bitfun-chat-input__box ${isMultiLine ? 'bitfun-chat-input__box--multi-line' : 'bitfun-chat-input__box--capsule'}`}>
             {showTargetSwitcher && (
               <div className="bitfun-chat-input__target-switcher" data-testid="chat-input-target-switcher">
                 <span className="bitfun-chat-input__target-switcher-label">{t('chatInput.conversationTarget')}</span>
@@ -2833,6 +2755,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                   })}
                 </div>
               )}
+              {showPlaceholder && (
+                <span className="bitfun-chat-input__placeholder" aria-hidden>
+                  {t('input.placeholder')}
+                </span>
+              )}
               <RichTextInput
                 ref={richTextInputRef}
                 value={inputState.value}
@@ -2841,7 +2768,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 onKeyDown={handleKeyDown}
                 onCompositionStart={handleImeCompositionStart}
                 onCompositionEnd={handleImeCompositionEnd}
-                placeholder={inputState.isActive ? t('input.placeholder') : ''}
+                placeholder=""
                 disabled={false}
                 contexts={contexts}
                 onRemoveContext={removeContext}
@@ -2849,19 +2776,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 data-testid="chat-input-textarea"
               />
 
-              {!inputState.isActive &&
-                !inputState.value.trim() &&
-                !agentCompanionInInput && (
-                <span className="bitfun-chat-input__space-hint">
-                  <Trans
-                    i18nKey="input.spaceToActivate"
-                    t={t}
-                    components={{
-                      space: <span className="bitfun-chat-input__space-key" />,
-                    }}
-                  />
-                </span>
-              )}
               
               <FileMentionPicker
                 isOpen={mentionState.isActive}
@@ -3000,16 +2914,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
               })()}
             </div>
             
-            <IconButton
-              className="bitfun-chat-input__expand-button"
-              variant="ghost"
-              size="xs"
-              shape="circle"
-              onClick={toggleExpand}
-              tooltip={inputState.isExpanded ? t('input.collapseInput') : t('input.expandInput')}
-            >
-              {inputState.isExpanded ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
-            </IconButton>
             <div className="bitfun-chat-input__actions">
               <div className="bitfun-chat-input__actions-left">
                 <div className="bitfun-chat-input__agent-boost" ref={agentBoostRef}>
@@ -3208,7 +3112,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                     </div>
                   )}
                 </div>
-
+              </div>
+              <div className="bitfun-chat-input__actions-right">
                 <div className="bitfun-chat-input__model-usage-group">
                   <ModelSelector
                     currentMode={modeState.current}
@@ -3217,17 +3122,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                     maxTokens={tokenUsage.max}
                   />
                 </div>
-              </div>
-              <div className="bitfun-chat-input__actions-right">
-                {isCollapsedProcessing && !petReplacesStopChrome && (
-                  <>
-                    <span className="bitfun-chat-input__capsule-divider" />
-                    <span className="bitfun-chat-input__cancel-shortcut">
-                      <span className="bitfun-chat-input__space-key">Esc</span>
-                      <span>{t('input.cancelShortcut')}</span>
-                    </span>
-                  </>
-                )}
 
                 {renderActionButton()}
               </div>

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.scss
@@ -36,22 +36,13 @@
   user-select: text;
   pointer-events: auto;
 
-  /* Default (collapsed / idle capsule): same width as `.bitfun-chat-input--collapsed`, centered */
-  left: 50%;
-  right: auto;
-  transform: translateX(-50%);
-  width: min(380px, 80%);
-  max-width: calc(100% - #{$size-gap-2 * 2});
-
-  /* Expanded: indent past the rounded card edge — align with `.bitfun-chat-input__box` inner padding (8px) on top of drop-zone horizontal padding */
-  .bitfun-chat-input-drop-zone:has(.bitfun-chat-input--active) & {
-    left: 0;
-    right: 0;
-    transform: none;
-    width: 100%;
-    max-width: none;
-    padding: 3px calc(#{$size-gap-2} + 8px) 4px;
-  }
+  /* Always full-width — capsule is no longer narrowed in the new two-mode design */
+  left: 0;
+  right: 0;
+  transform: none;
+  width: 100%;
+  max-width: none;
+  padding: 3px calc(#{$size-gap-2} + 8px) 4px;
 
   &__main {
     display: flex;
@@ -79,12 +70,13 @@
     width: 16px;
     height: 16px;
     min-width: 16px;
-    border-radius: 4px;
+    border-radius: 50%;
     opacity: 0.86;
     color: color-mix(in srgb, var(--color-accent-500) 62%, var(--color-text-secondary));
 
     &:hover:not(:disabled) {
       transform: none;
+      border-radius: 50%;
       background: color-mix(in srgb, var(--color-accent-500) 10%, var(--element-bg-medium));
       color: color-mix(in srgb, var(--color-accent-500) 86%, var(--color-text-primary));
       opacity: 1;

--- a/src/web-ui/src/flow_chat/components/RichTextInput.scss
+++ b/src/web-ui/src/flow_chat/components/RichTextInput.scss
@@ -24,23 +24,14 @@
   word-break: break-word;
   cursor: text;
   box-shadow: none !important;
-  
+
+  // Fallback placeholder via CSS :empty (may not work after browser inserts a <br>)
   &:empty::before {
     content: attr(data-placeholder);
     color: color-mix(in srgb, var(--color-text-muted) 52%, transparent);
     pointer-events: none;
-    animation: rich-text-placeholder-fade-in 0.25s ease-out;
   }
-  
-  @keyframes rich-text-placeholder-fade-in {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
-  
+
   &:focus {
     outline: none !important;
     border: none !important;
@@ -51,7 +42,6 @@
     opacity: 0.6;
     cursor: default;
   }
-  
 }
 
 // Light theme: placeholder slightly softer than body text.

--- a/src/web-ui/src/flow_chat/components/richTextInputSync.ts
+++ b/src/web-ui/src/flow_chat/components/richTextInputSync.ts
@@ -9,7 +9,9 @@ export function getRichTextExternalSyncAction(
   }
 
   if (!value) {
-    return currentContent ? 'clear' : 'noop';
+    // Always clear when value is empty so residual <br> nodes left by the browser
+    // after deleting the last character are removed, allowing :empty::before to show.
+    return 'clear';
   }
 
   return 'replace';

--- a/src/web-ui/src/flow_chat/reducers/inputReducer.ts
+++ b/src/web-ui/src/flow_chat/reducers/inputReducer.ts
@@ -4,9 +4,9 @@
 
 export interface InputState {
   value: string;
-  /** Expanded to full height */
+  /** Kept for compatibility; not actively used in the new two-mode layout */
   isExpanded: boolean;
-  /** Active state when expanding from collapsed */
+  /** Always true in the new two-mode layout (capsule ↔ multi-line) */
   isActive: boolean;
 }
 
@@ -42,10 +42,7 @@ export function inputReducer(state: InputState, action: InputAction): InputState
       return { ...state, isActive: true };
       
     case 'DEACTIVATE':
-      // Only allow deactivation when input is empty
-      if (state.value.trim() === '') {
-        return { ...state, isActive: false, isExpanded: false };
-      }
+      // No-op: the input is always active in the new two-mode design.
       return state;
       
     default:


### PR DESCRIPTION
## Summary

- Replace the collapsed/activate/expand chat input model with automatic **capsule** (single-line) and **multi-line** modes based on content height, newlines, and attached images.
- Restructure the capsule layout so Plus, editor, and send/model controls share one horizontal row; remove the expand button, space-to-activate hint, and agent companion pet chrome from the input.
- Add an overlay placeholder with DOM-empty detection, clear residual <br> nodes on empty sync, and keep Space-to-focus when no editable element is focused.

## Test plan

- [x] pnpm run lint:web
- [x] pnpm run type-check:web
- [x] pnpm --dir src/web-ui exec vitest run src/flow_chat/components/richTextInputSync.test.ts src/flow_chat/components/RichTextInput.test.tsx
- [ ] Manually verify capsule stays single-line for short text and expands to multi-line card on Shift+Enter or overflow
- [ ] Manually verify placeholder shows/hides correctly when typing and deleting all content
- [ ] Manually verify Space focuses the input when focus is elsewhere
- [ ] Manually verify send/stop and model selector remain usable in both capsule and multi-line modes