### PR TITLE
feat: add desktop crash diagnostics

### DIFF
--- a/src/apps/desktop/src/api/config_api.rs
+++ b/src/apps/desktop/src/api/config_api.rs
@@ -38,6 +38,9 @@ pub struct ResetConfigRequest {
 #[derive(Debug, Deserialize, Default)]
 pub struct GetRuntimeLoggingInfoRequest {}
 
+#[derive(Debug, Deserialize, Default)]
+pub struct ExportDiagnosticsBundleRequest {}
+
 fn to_json_value<T: Serialize>(value: T, context: &str) -> Result<Value, String> {
     serde_json::to_value(value).map_err(|e| format!("Failed to serialize {}: {}", context, e))
 }
@@ -301,6 +304,15 @@ pub async fn get_runtime_logging_info(
 ) -> Result<Value, String> {
     let logging_info = crate::logging::get_runtime_logging_info();
     to_json_value(logging_info, "runtime logging info")
+}
+
+#[tauri::command]
+pub async fn export_diagnostics_bundle(
+    _state: State<'_, AppState>,
+    _request: ExportDiagnosticsBundleRequest,
+) -> Result<Value, String> {
+    let bundle_info = crate::crash_diagnostics::export_diagnostics_bundle()?;
+    to_json_value(bundle_info, "diagnostics bundle info")
 }
 
 #[tauri::command]

--- a/src/apps/desktop/src/api/system_api.rs
+++ b/src/apps/desktop/src/api/system_api.rs
@@ -377,6 +377,7 @@ fn read_main_window_fullscreen_response(
 #[tauri::command]
 pub async fn quit_app(app: tauri::AppHandle) -> Result<(), String> {
     log::info!("Quit requested via quit_app command");
+    crate::crash_diagnostics::mark_clean_shutdown("quit_app_command");
     crate::perform_process_exit_cleanup();
     app.exit(0);
     Ok(())

--- a/src/apps/desktop/src/crash_diagnostics.rs
+++ b/src/apps/desktop/src/crash_diagnostics.rs
@@ -1,0 +1,498 @@
+//! Crash diagnostics and local support bundle export.
+
+use chrono::{Local, Utc};
+use serde::{Deserialize, Serialize};
+use std::backtrace::Backtrace;
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use zip::write::FileOptions;
+
+const RUN_STATE_FILE: &str = "run-state.json";
+const CRASH_REPORT_FILE: &str = "crash-report.json";
+const DIAGNOSTIC_METADATA_FILE: &str = "diagnostic-metadata.json";
+const MAX_BUNDLED_LOG_SESSIONS: usize = 5;
+
+static CURRENT_RUN_CONTEXT: OnceLock<RunContext> = OnceLock::new();
+static PREVIOUS_UNEXPECTED_EXIT: OnceLock<Option<UnexpectedExitInfo>> = OnceLock::new();
+
+#[derive(Debug, Clone)]
+struct RunContext {
+    logs_root: PathBuf,
+    session_log_dir: PathBuf,
+    run_state_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnexpectedExitInfo {
+    pub detected: bool,
+    pub started_at: Option<String>,
+    pub session_log_dir: Option<String>,
+    pub crash_report_path: Option<String>,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RunState {
+    app_version: String,
+    pid: u32,
+    started_at: String,
+    updated_at: String,
+    session_log_dir: String,
+    clean_shutdown: bool,
+    shutdown_at: Option<String>,
+    exit_reason: Option<String>,
+    startup_trace_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CrashReport {
+    app_version: String,
+    pid: u32,
+    crashed_at: String,
+    session_log_dir: String,
+    thread_name: Option<String>,
+    thread_id: String,
+    location: String,
+    message: String,
+    backtrace: String,
+    os: String,
+    arch: String,
+    debug_assertions: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticsBundleInfo {
+    pub bundle_path: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticMetadata {
+    exported_at: String,
+    app_version: String,
+    os: String,
+    arch: String,
+    debug_assertions: bool,
+    current_pid: u32,
+    current_log_info: crate::logging::RuntimeLoggingInfo,
+    previous_unexpected_exit: Option<UnexpectedExitInfo>,
+    platform_crash_report_hints: Vec<String>,
+}
+
+pub fn initialize_run_state(session_log_dir: PathBuf, startup_trace_id: &str) {
+    let logs_root = session_log_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| session_log_dir.clone());
+    let run_state_path = logs_root.join(RUN_STATE_FILE);
+    let previous = detect_previous_unexpected_exit(&run_state_path);
+    let _ = PREVIOUS_UNEXPECTED_EXIT.set(previous);
+
+    let context = RunContext {
+        logs_root,
+        session_log_dir: session_log_dir.clone(),
+        run_state_path,
+    };
+
+    let state = RunState {
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        pid: std::process::id(),
+        started_at: Utc::now().to_rfc3339(),
+        updated_at: Utc::now().to_rfc3339(),
+        session_log_dir: session_log_dir.to_string_lossy().to_string(),
+        clean_shutdown: false,
+        shutdown_at: None,
+        exit_reason: None,
+        startup_trace_id: startup_trace_id.to_string(),
+    };
+
+    if let Err(error) = write_json_file(&context.run_state_path, &state) {
+        eprintln!("Warning: Failed to write run state: {}", error);
+    }
+
+    let _ = CURRENT_RUN_CONTEXT.set(context);
+}
+
+pub fn previous_unexpected_exit() -> Option<UnexpectedExitInfo> {
+    PREVIOUS_UNEXPECTED_EXIT.get().cloned().flatten()
+}
+
+pub fn log_previous_unexpected_exit_if_any() {
+    if let Some(info) = previous_unexpected_exit() {
+        log::warn!(
+            "Previous desktop session ended unexpectedly: session_log_dir={:?}, crash_report_path={:?}, reason={}",
+            info.session_log_dir,
+            info.crash_report_path,
+            info.reason
+        );
+    }
+}
+
+pub fn mark_clean_shutdown(reason: &str) {
+    let Some(context) = CURRENT_RUN_CONTEXT.get() else {
+        return;
+    };
+
+    let now = Utc::now().to_rfc3339();
+    let mut state =
+        read_json_file::<RunState>(&context.run_state_path).unwrap_or_else(|_| RunState {
+            app_version: env!("CARGO_PKG_VERSION").to_string(),
+            pid: std::process::id(),
+            started_at: now.clone(),
+            updated_at: now.clone(),
+            session_log_dir: context.session_log_dir.to_string_lossy().to_string(),
+            clean_shutdown: false,
+            shutdown_at: None,
+            exit_reason: None,
+            startup_trace_id: String::new(),
+        });
+    state.updated_at = now.clone();
+    state.clean_shutdown = true;
+    state.shutdown_at = Some(now);
+    state.exit_reason = Some(reason.to_string());
+
+    if let Err(error) = write_json_file(&context.run_state_path, &state) {
+        log::warn!("Failed to mark clean shutdown: {}", error);
+    }
+}
+
+pub fn write_panic_report(
+    location: String,
+    message: String,
+    thread_name: Option<String>,
+    thread_id: String,
+) {
+    let Some(context) = CURRENT_RUN_CONTEXT.get() else {
+        return;
+    };
+
+    let report = CrashReport {
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        pid: std::process::id(),
+        crashed_at: Utc::now().to_rfc3339(),
+        session_log_dir: context.session_log_dir.to_string_lossy().to_string(),
+        thread_name,
+        thread_id,
+        location,
+        message,
+        backtrace: Backtrace::force_capture().to_string(),
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        debug_assertions: cfg!(debug_assertions),
+    };
+
+    let crash_report_path = context.session_log_dir.join(CRASH_REPORT_FILE);
+    if let Err(error) = write_json_file(&crash_report_path, &report) {
+        eprintln!("Warning: Failed to write panic report: {}", error);
+    }
+}
+
+pub fn export_diagnostics_bundle() -> Result<DiagnosticsBundleInfo, String> {
+    let context = CURRENT_RUN_CONTEXT
+        .get()
+        .cloned()
+        .ok_or_else(|| "Crash diagnostics are not initialized".to_string())?;
+
+    let diagnostics_dir = context.logs_root.join("diagnostics");
+    fs::create_dir_all(&diagnostics_dir)
+        .map_err(|error| format!("Failed to create diagnostics directory: {}", error))?;
+
+    let filename = format!(
+        "bitfun-diagnostics-{}.zip",
+        Local::now().format("%Y%m%dT%H%M%S")
+    );
+    let bundle_path = diagnostics_dir.join(filename);
+    let file = File::create(&bundle_path)
+        .map_err(|error| format!("Failed to create diagnostics bundle: {}", error))?;
+    let mut zip = zip::ZipWriter::new(file);
+    let options = FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    let metadata = DiagnosticMetadata {
+        exported_at: Utc::now().to_rfc3339(),
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        debug_assertions: cfg!(debug_assertions),
+        current_pid: std::process::id(),
+        current_log_info: crate::logging::get_runtime_logging_info(),
+        previous_unexpected_exit: previous_unexpected_exit(),
+        platform_crash_report_hints: platform_crash_report_hints(),
+    };
+    add_json_entry(&mut zip, DIAGNOSTIC_METADATA_FILE, &metadata, options)?;
+
+    if context.run_state_path.exists() {
+        add_file_entry(&mut zip, &context.run_state_path, RUN_STATE_FILE, options)?;
+    }
+
+    for session_dir in recent_session_dirs(&context.logs_root, MAX_BUNDLED_LOG_SESSIONS)? {
+        let name = session_dir
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("unknown-session");
+        add_directory_entries(
+            &mut zip,
+            &session_dir,
+            &format!("sessions/{}", name),
+            options,
+        )?;
+    }
+
+    zip.finish()
+        .map_err(|error| format!("Failed to finish diagnostics bundle: {}", error))?;
+
+    Ok(DiagnosticsBundleInfo {
+        bundle_path: bundle_path.to_string_lossy().to_string(),
+    })
+}
+
+fn detect_previous_unexpected_exit(run_state_path: &Path) -> Option<UnexpectedExitInfo> {
+    let state = read_json_file::<RunState>(run_state_path).ok()?;
+    if state.clean_shutdown {
+        return None;
+    }
+
+    let session_log_dir = if state.session_log_dir.is_empty() {
+        None
+    } else {
+        Some(state.session_log_dir.clone())
+    };
+    let crash_report_path = session_log_dir
+        .as_ref()
+        .map(PathBuf::from)
+        .map(|path| path.join(CRASH_REPORT_FILE))
+        .filter(|path| path.exists())
+        .map(|path| path.to_string_lossy().to_string());
+
+    Some(UnexpectedExitInfo {
+        detected: true,
+        started_at: Some(state.started_at),
+        session_log_dir,
+        crash_report_path,
+        reason: "Previous run state was not marked as clean shutdown".to_string(),
+    })
+}
+
+fn recent_session_dirs(logs_root: &Path, limit: usize) -> Result<Vec<PathBuf>, String> {
+    let pattern = regex::Regex::new(r"^\d{8}T\d{6}$")
+        .map_err(|error| format!("Invalid log session pattern: {}", error))?;
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(logs_root)
+        .map_err(|error| format!("Failed to read logs directory: {}", error))?
+    {
+        let entry = entry.map_err(|error| format!("Failed to read logs entry: {}", error))?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if pattern.is_match(name) {
+            entries.push(path);
+        }
+    }
+
+    entries.sort();
+    entries.reverse();
+    entries.truncate(limit);
+    entries.reverse();
+    Ok(entries)
+}
+
+fn add_directory_entries(
+    zip: &mut zip::ZipWriter<File>,
+    dir: &Path,
+    archive_prefix: &str,
+    options: FileOptions,
+) -> Result<(), String> {
+    for entry in fs::read_dir(dir)
+        .map_err(|error| format!("Failed to read directory {}: {}", dir.display(), error))?
+    {
+        let entry = entry.map_err(|error| format!("Failed to read directory entry: {}", error))?;
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        let archive_path = format!("{}/{}", archive_prefix, name);
+
+        if path.is_dir() {
+            add_directory_entries(zip, &path, &archive_path, options)?;
+        } else if path.is_file() {
+            add_file_entry(zip, &path, &archive_path, options)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn add_json_entry<T: Serialize>(
+    zip: &mut zip::ZipWriter<File>,
+    archive_path: &str,
+    value: &T,
+    options: FileOptions,
+) -> Result<(), String> {
+    let content = serde_json::to_vec_pretty(value)
+        .map_err(|error| format!("Failed to serialize {}: {}", archive_path, error))?;
+    zip.start_file(normalize_archive_path(archive_path), options)
+        .map_err(|error| {
+            format!(
+                "Failed to add {} to diagnostics bundle: {}",
+                archive_path, error
+            )
+        })?;
+    zip.write_all(&content).map_err(|error| {
+        format!(
+            "Failed to write {} to diagnostics bundle: {}",
+            archive_path, error
+        )
+    })
+}
+
+fn add_file_entry(
+    zip: &mut zip::ZipWriter<File>,
+    source_path: &Path,
+    archive_path: &str,
+    options: FileOptions,
+) -> Result<(), String> {
+    let mut file = File::open(source_path)
+        .map_err(|error| format!("Failed to open {}: {}", source_path.display(), error))?;
+    zip.start_file(normalize_archive_path(archive_path), options)
+        .map_err(|error| {
+            format!(
+                "Failed to add {} to diagnostics bundle: {}",
+                archive_path, error
+            )
+        })?;
+    let mut buffer = [0_u8; 16 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| format!("Failed to read {}: {}", source_path.display(), error))?;
+        if read == 0 {
+            break;
+        }
+        zip.write_all(&buffer[..read]).map_err(|error| {
+            format!(
+                "Failed to write {} to diagnostics bundle: {}",
+                archive_path, error
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn normalize_archive_path(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("Failed to create {}: {}", parent.display(), error))?;
+    }
+    let content = serde_json::to_vec_pretty(value)
+        .map_err(|error| format!("Failed to serialize {}: {}", path.display(), error))?;
+    fs::write(path, content)
+        .map_err(|error| format!("Failed to write {}: {}", path.display(), error))
+}
+
+fn read_json_file<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, String> {
+    let content =
+        fs::read(path).map_err(|error| format!("Failed to read {}: {}", path.display(), error))?;
+    serde_json::from_slice(&content)
+        .map_err(|error| format!("Failed to parse {}: {}", path.display(), error))
+}
+
+fn platform_crash_report_hints() -> Vec<String> {
+    match std::env::consts::OS {
+        "macos" => vec![
+            "~/Library/Logs/DiagnosticReports".to_string(),
+            "Console.app Diagnostic Reports".to_string(),
+        ],
+        "windows" => vec![
+            "Windows Error Reporting".to_string(),
+            "Event Viewer > Windows Logs > Application".to_string(),
+        ],
+        "linux" => vec!["coredumpctl".to_string(), "systemd-coredump".to_string()],
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn detects_previous_unclean_run_state_with_crash_report() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "bitfun-crash-diagnostics-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time should be after unix epoch")
+                .as_nanos()
+        ));
+        let session_dir = temp_dir.join("20260528T120000");
+        fs::create_dir_all(&session_dir).expect("test session directory should be created");
+        fs::write(session_dir.join(CRASH_REPORT_FILE), "{}")
+            .expect("test crash report should be written");
+
+        let run_state = RunState {
+            app_version: "test".to_string(),
+            pid: 123,
+            started_at: "2026-05-28T12:00:00Z".to_string(),
+            updated_at: "2026-05-28T12:00:01Z".to_string(),
+            session_log_dir: session_dir.to_string_lossy().to_string(),
+            clean_shutdown: false,
+            shutdown_at: None,
+            exit_reason: None,
+            startup_trace_id: "test-trace".to_string(),
+        };
+        let run_state_path = temp_dir.join(RUN_STATE_FILE);
+        write_json_file(&run_state_path, &run_state).expect("test run state should be written");
+
+        let info = detect_previous_unexpected_exit(&run_state_path)
+            .expect("unclean run state should be detected");
+        assert!(info.detected);
+        assert_eq!(
+            info.session_log_dir.as_deref(),
+            Some(session_dir.to_string_lossy().as_ref())
+        );
+        assert!(info.crash_report_path.is_some());
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn ignores_previous_clean_run_state() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "bitfun-crash-diagnostics-clean-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time should be after unix epoch")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&temp_dir).expect("test directory should be created");
+        let run_state = RunState {
+            app_version: "test".to_string(),
+            pid: 123,
+            started_at: "2026-05-28T12:00:00Z".to_string(),
+            updated_at: "2026-05-28T12:00:01Z".to_string(),
+            session_log_dir: temp_dir.to_string_lossy().to_string(),
+            clean_shutdown: true,
+            shutdown_at: Some("2026-05-28T12:00:02Z".to_string()),
+            exit_reason: Some("test".to_string()),
+            startup_trace_id: "test-trace".to_string(),
+        };
+        let run_state_path = temp_dir.join(RUN_STATE_FILE);
+        write_json_file(&run_state_path, &run_state).expect("test run state should be written");
+
+        assert!(detect_previous_unexpected_exit(&run_state_path).is_none());
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+}

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod api;
 pub mod computer_use;
+pub mod crash_diagnostics;
 pub mod logging;
 pub mod macos_menubar;
 pub mod theme;
@@ -204,6 +205,8 @@ pub async fn run() {
     let log_config = logging::LogConfig::new(in_debug);
     let log_targets = logging::build_log_targets(&log_config);
     let session_log_dir = log_config.session_log_dir.clone();
+    crash_diagnostics::initialize_run_state(session_log_dir.clone(), &startup_trace_id);
+    setup_panic_hook();
 
     eprintln!("=== BitFun Desktop Starting ===");
 
@@ -285,8 +288,6 @@ pub async fn run() {
 
     let path_manager = get_path_manager_arc();
 
-    setup_panic_hook();
-
     let app = tauri::Builder::default()
         .plugin(logging::build_log_plugin(log_targets))
         .plugin(tauri_plugin_opener::init())
@@ -326,6 +327,7 @@ pub async fn run() {
             }
 
             logging::register_runtime_log_state(startup_log_level, session_log_dir.clone());
+            crash_diagnostics::log_previous_unexpected_exit_if_any();
             for step in startup_timings.steps() {
                 log::debug!(
                     "Desktop startup step completed: step={}, duration_ms={}",
@@ -687,6 +689,7 @@ pub async fn run() {
             sync_config_to_global,
             get_global_config_health,
             get_runtime_logging_info,
+            export_diagnostics_bundle,
             get_runtime_capabilities,
             get_mode_configs,
             get_mode_config,
@@ -1064,6 +1067,7 @@ pub async fn run() {
         Ok(app) => {
             app.run(|_app_handle, event| match event {
                 tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit => {
+                    crash_diagnostics::mark_clean_shutdown("tauri_run_exit");
                     perform_process_exit_cleanup();
                 }
                 #[cfg(target_os = "macos")]
@@ -1244,6 +1248,9 @@ fn init_acp_clients(app_handle: tauri::AppHandle) {
 
 fn setup_panic_hook() {
     std::panic::set_hook(Box::new(move |panic_info| {
+        let thread = std::thread::current();
+        let thread_name = thread.name().map(str::to_string);
+        let thread_id = format!("{:?}", thread.id());
         let location = panic_info
             .location()
             .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
@@ -1262,6 +1269,12 @@ fn setup_panic_hook() {
             .unwrap_or("unknown panic message");
 
         log::error!("Application panic at {}: {}", location, message);
+        crate::crash_diagnostics::write_panic_report(
+            location.clone(),
+            message.to_string(),
+            thread_name,
+            thread_id,
+        );
 
         // Known wry bug: WKWebView.URL() returns nil after navigating to an
         // invalid address, causing url_from_webview to panic on unwrap().

--- a/src/apps/desktop/src/logging.rs
+++ b/src/apps/desktop/src/logging.rs
@@ -160,6 +160,7 @@ pub struct RuntimeLoggingInfo {
     pub ai_log_path: String,
     pub flashgrep_log_path: String,
     pub webview_log_path: String,
+    pub previous_unexpected_exit: Option<crate::crash_diagnostics::UnexpectedExitInfo>,
 }
 
 pub fn get_runtime_logging_info() -> RuntimeLoggingInfo {
@@ -179,6 +180,7 @@ pub fn get_runtime_logging_info() -> RuntimeLoggingInfo {
             .join("webview.log")
             .to_string_lossy()
             .to_string(),
+        previous_unexpected_exit: crate::crash_diagnostics::previous_unexpected_exit(),
     }
 }
 

--- a/src/apps/desktop/src/tray.rs
+++ b/src/apps/desktop/src/tray.rs
@@ -194,6 +194,7 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 show_main_window(app);
             } else if id == "quit" {
                 log::info!("Quit requested from tray menu");
+                crate::crash_diagnostics::mark_clean_shutdown("tray_quit");
                 crate::perform_process_exit_cleanup();
                 app.exit(0);
             } else if id == "toggle_desktop_pet" {

--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -8,7 +8,7 @@ import { SSHRemoteProvider } from '../features/ssh-remote';
 import AppLayout from './layout/AppLayout';
 import { useCurrentModelConfig } from '../hooks/useModelConfigs';
 import { ContextMenuRenderer } from '../shared/context-menu-system/components/ContextMenuRenderer';
-import { NotificationContainer, NotificationCenter } from '../shared/notification-system';
+import { NotificationContainer, NotificationCenter, notificationService } from '../shared/notification-system';
 import { AnnouncementProvider } from '../shared/announcement-system';
 import { ConfirmDialogRenderer } from '../component-library';
 import { createLogger } from '@/shared/utils/logger';
@@ -23,6 +23,7 @@ import SplashScreen from './components/SplashScreen/SplashScreen';
 import { useGlobalSceneShortcuts } from './hooks/useGlobalSceneShortcuts';
 import { useDebugInspector } from '@/infrastructure/debug/useDebugInspector';
 import { openAgentCompanionSession } from './services/openAgentCompanionSession';
+import { useI18n } from '@/infrastructure/i18n';
 
 // Toolbar Mode
 import { ToolbarModeProvider } from '../flow_chat';
@@ -45,6 +46,7 @@ function App() {
   // AI initialization
   const { currentConfig } = useCurrentModelConfig();
   const { isInitialized: aiInitialized, isInitializing: aiInitializing, error: aiError } = useAIInitialization(currentConfig);
+  const { t } = useI18n('settings/basics');
 
   // Workspace loading state — drives splash exit timing
   const { loading: workspaceLoading } = useWorkspaceContext();
@@ -345,6 +347,70 @@ function App() {
 
   // Debug inspector shortcuts (desktop devtools only)
   useDebugInspector();
+
+  useEffect(() => {
+    if (!isTauriRuntime() || !interactiveShellReady) {
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { configAPI, workspaceAPI } = await import('@/infrastructure/api');
+        const runtimeInfo = await configAPI.getRuntimeLoggingInfo();
+        if (cancelled || !runtimeInfo.previousUnexpectedExit?.detected) {
+          return;
+        }
+        const recoveryKey = `bitfun:unexpected-exit-notice:${runtimeInfo.previousUnexpectedExit.sessionLogDir || 'unknown'}`;
+        if (sessionStorage.getItem(recoveryKey) === 'shown') {
+          return;
+        }
+        sessionStorage.setItem(recoveryKey, 'shown');
+
+        notificationService.warning(t('logging.startupRecovery.message'), {
+          title: t('logging.startupRecovery.title'),
+          duration: 0,
+          actions: [
+            {
+              label: t('logging.actions.exportDiagnostics'),
+              variant: 'primary',
+              onClick: () => {
+                void (async () => {
+                  try {
+                    const result = await configAPI.exportDiagnosticsBundle();
+                    notificationService.success(t('logging.messages.diagnosticsExported'), { duration: 3000 });
+                    await workspaceAPI.revealInExplorer(result.bundlePath);
+                  } catch (error) {
+                    log.error('Failed to export diagnostics bundle from startup notification', error);
+                    notificationService.error(t('logging.messages.diagnosticsExportFailed'), { duration: 5000 });
+                  }
+                })();
+              },
+            },
+            {
+              label: t('logging.actions.openLoggingSettings'),
+              onClick: () => {
+                void import('@/shared/services/ide-control').then(({ quickActions }) => {
+                  quickActions.openSettings('basics');
+                });
+              },
+            },
+          ],
+          metadata: {
+            source: 'startup-crash-diagnostics',
+            sessionLogDir: runtimeInfo.previousUnexpectedExit.sessionLogDir,
+            crashReportPath: runtimeInfo.previousUnexpectedExit.crashReportPath,
+          },
+        });
+      } catch (error) {
+        log.warn('Failed to check previous unexpected exit status', error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [interactiveShellReady, t]);
 
   // Unified layout via a single AppLayout
   return (

--- a/src/web-ui/src/infrastructure/api/service-api/ConfigAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ConfigAPI.ts
@@ -3,6 +3,7 @@
 import { api } from './ApiClient';
 import { createTauriCommandError } from '../errors/TauriCommandError';
 import type {
+  DiagnosticsBundleInfo,
   ModeSkillInfo,
   ModeConfigItem,
   RuntimeLoggingInfo,
@@ -180,6 +181,16 @@ export class ConfigAPI {
       });
     } catch (error) {
       throw createTauriCommandError('get_runtime_logging_info', error);
+    }
+  }
+
+  async exportDiagnosticsBundle(): Promise<DiagnosticsBundleInfo> {
+    try {
+      return await api.invoke('export_diagnostics_bundle', {
+        request: {},
+      });
+    } catch (error) {
+      throw createTauriCommandError('export_diagnostics_bundle', error);
     }
   }
 

--- a/src/web-ui/src/infrastructure/config/components/BasicsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/BasicsConfig.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FolderOpen } from 'lucide-react';
+import { Archive, FolderOpen } from 'lucide-react';
 import {
   Alert,
+  Button,
   Select,
   Switch,
   Tooltip,
@@ -230,6 +231,7 @@ function BasicsLoggingSection() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [openingFolder, setOpeningFolder] = useState(false);
+  const [exportingDiagnostics, setExportingDiagnostics] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error' | 'info'; text: string } | null>(null);
 
   const levelOptions = useMemo(
@@ -338,6 +340,20 @@ function BasicsLoggingSection() {
     }
   }, [runtimeInfo?.sessionLogDir, showMessage, t]);
 
+  const handleExportDiagnostics = useCallback(async () => {
+    try {
+      setExportingDiagnostics(true);
+      const result = await configAPI.exportDiagnosticsBundle();
+      showMessage('success', t('logging.messages.diagnosticsExported'));
+      await workspaceAPI.revealInExplorer(result.bundlePath);
+    } catch (error) {
+      log.error('Failed to export diagnostics bundle', { error });
+      showMessage('error', t('logging.messages.diagnosticsExportFailed'));
+    } finally {
+      setExportingDiagnostics(false);
+    }
+  }, [showMessage, t]);
+
   if (loading) {
     return <ConfigPageLoading text={t('logging.messages.loading')} />;
   }
@@ -351,6 +367,15 @@ function BasicsLoggingSection() {
           title={t('logging.sections.logging')}
           description={t('logging.sections.loggingHint')}
         >
+          {runtimeInfo?.previousUnexpectedExit?.detected && (
+            <Alert
+              type="warning"
+              message={t('logging.previousCrash.title')}
+              description={t('logging.previousCrash.description', {
+                path: runtimeInfo.previousUnexpectedExit.sessionLogDir || '-',
+              })}
+            />
+          )}
           <ConfigPageRow
             label={t('logging.sections.level')}
             description={t('logging.level.description')}
@@ -398,6 +423,25 @@ function BasicsLoggingSection() {
                 </button>
               </Tooltip>
             </div>
+          </ConfigPageRow>
+          <ConfigPageRow
+            label={t('logging.diagnostics.label')}
+            description={t('logging.diagnostics.description')}
+            align="center"
+          >
+            <Button
+              type="button"
+              variant="secondary"
+              size="small"
+              onClick={() => {
+                void handleExportDiagnostics();
+              }}
+              isLoading={exportingDiagnostics}
+              disabled={exportingDiagnostics}
+            >
+              <Archive size={14} />
+              {t('logging.actions.exportDiagnostics')}
+            </Button>
           </ConfigPageRow>
         </ConfigPageSection>
       </div>

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -560,6 +560,19 @@ export interface RuntimeLoggingInfo {
   aiLogPath: string;
   flashgrepLogPath: string;
   webviewLogPath: string;
+  previousUnexpectedExit?: UnexpectedExitInfo | null;
+}
+
+export interface UnexpectedExitInfo {
+  detected: boolean;
+  startedAt?: string;
+  sessionLogDir?: string;
+  crashReportPath?: string;
+  reason: string;
+}
+
+export interface DiagnosticsBundleInfo {
+  bundlePath: string;
 }
 
 export interface DefaultModels {

--- a/src/web-ui/src/locales/en-US/settings/basics.json
+++ b/src/web-ui/src/locales/en-US/settings/basics.json
@@ -117,6 +117,18 @@
     "path": {
       "description": "Directory where log files for this run are written."
     },
+    "diagnostics": {
+      "label": "Diagnostics Bundle",
+      "description": "Export recent local logs, crash reports, and runtime metadata as a zip file. BitFun does not upload it automatically."
+    },
+    "previousCrash": {
+      "title": "Previous session ended unexpectedly",
+      "description": "Last session logs are available at {{path}}."
+    },
+    "startupRecovery": {
+      "title": "Previous session did not close normally",
+      "message": "BitFun reopened after an unexpected quit. You can export diagnostics if you want to report the issue."
+    },
     "levels": {
       "trace": "Trace",
       "debug": "Debug",
@@ -128,7 +140,9 @@
     "actions": {
       "refreshTooltip": "Refresh runtime status",
       "openFolder": "Open Folder",
-      "openFolderTooltip": "Open log folder in file explorer"
+      "openFolderTooltip": "Open log folder in file explorer",
+      "exportDiagnostics": "Export Diagnostics",
+      "openLoggingSettings": "Open Logging Settings"
     },
     "messages": {
       "loading": "Loading...",
@@ -139,7 +153,9 @@
       "refreshed": "Runtime status refreshed",
       "openedFolder": "Log folder opened",
       "openFailed": "Failed to open log folder",
-      "pathUnavailable": "Log folder path is unavailable"
+      "pathUnavailable": "Log folder path is unavailable",
+      "diagnosticsExported": "Diagnostics bundle exported",
+      "diagnosticsExportFailed": "Failed to export diagnostics bundle"
     }
   },
   "terminal": {

--- a/src/web-ui/src/locales/zh-CN/settings/basics.json
+++ b/src/web-ui/src/locales/zh-CN/settings/basics.json
@@ -117,6 +117,18 @@
     "path": {
       "description": "本次启动写入日志文件所在的目录。"
     },
+    "diagnostics": {
+      "label": "诊断包",
+      "description": "将最近的本地日志、崩溃报告与运行时元数据导出为 zip 文件。BitFun 不会自动上传。"
+    },
+    "previousCrash": {
+      "title": "上次会话异常结束",
+      "description": "上次会话日志位于 {{path}}。"
+    },
+    "startupRecovery": {
+      "title": "上次没有正常关闭",
+      "message": "BitFun 已从一次异常退出后重新打开。如需反馈问题，可以导出诊断包。"
+    },
     "levels": {
       "trace": "Trace",
       "debug": "Debug",
@@ -128,7 +140,9 @@
     "actions": {
       "refreshTooltip": "刷新运行时状态",
       "openFolder": "打开文件夹",
-      "openFolderTooltip": "在文件管理器中打开日志文件夹"
+      "openFolderTooltip": "在文件管理器中打开日志文件夹",
+      "exportDiagnostics": "导出诊断包",
+      "openLoggingSettings": "打开日志设置"
     },
     "messages": {
       "loading": "加载中...",
@@ -139,7 +153,9 @@
       "refreshed": "运行时状态已刷新",
       "openedFolder": "日志文件夹已打开",
       "openFailed": "打开日志文件夹失败",
-      "pathUnavailable": "日志文件夹路径不可用"
+      "pathUnavailable": "日志文件夹路径不可用",
+      "diagnosticsExported": "诊断包已导出",
+      "diagnosticsExportFailed": "导出诊断包失败"
     }
   },
   "terminal": {

--- a/src/web-ui/src/locales/zh-TW/settings/basics.json
+++ b/src/web-ui/src/locales/zh-TW/settings/basics.json
@@ -103,6 +103,18 @@
     "path": {
       "description": "本次啟動寫入日誌文件所在的目錄。"
     },
+    "diagnostics": {
+      "label": "診斷包",
+      "description": "將最近的本機日誌、崩潰報告與運行時元資料匯出為 zip 文件。BitFun 不會自動上傳。"
+    },
+    "previousCrash": {
+      "title": "上次會話異常結束",
+      "description": "上次會話日誌位於 {{path}}。"
+    },
+    "startupRecovery": {
+      "title": "上次沒有正常關閉",
+      "message": "BitFun 已從一次異常退出後重新打開。如需回報問題，可以匯出診斷包。"
+    },
     "levels": {
       "trace": "Trace",
       "debug": "Debug",
@@ -114,7 +126,9 @@
     "actions": {
       "refreshTooltip": "刷新運行時狀態",
       "openFolder": "打開文件夾",
-      "openFolderTooltip": "在文件管理器中打開日誌文件夾"
+      "openFolderTooltip": "在文件管理器中打開日誌文件夾",
+      "exportDiagnostics": "匯出診斷包",
+      "openLoggingSettings": "打開日誌設置"
     },
     "messages": {
       "loading": "加載中...",
@@ -125,7 +139,9 @@
       "refreshed": "運行時狀態已刷新",
       "openedFolder": "日誌文件夾已打開",
       "openFailed": "打開日誌文件夾失敗",
-      "pathUnavailable": "日誌文件夾路徑不可用"
+      "pathUnavailable": "日誌文件夾路徑不可用",
+      "diagnosticsExported": "診斷包已匯出",
+      "diagnosticsExportFailed": "匯出診斷包失敗"
     }
   },
   "terminal": {


### PR DESCRIPTION
## Summary
- add desktop run-state tracking, panic crash reports, and local diagnostics bundle export
- surface previous unexpected exits in logging settings and startup notification
- add frontend API/types/locales for exporting diagnostics

## Verification
- cargo check -p bitfun-desktop
- cargo test -p bitfun-desktop crash_diagnostics -- --nocapture
- pnpm run type-check:web
- pnpm run lint:web

## Notes
- Diagnostics are local-only and are not uploaded automatically.
- Full web-ui test run still has pre-existing unrelated failures in TaskToolDisplay mocks / monaco-editor test resolution / localStorage setup.