### PR TITLE
Fix web UI test failures

### DIFF
--- a/src/web-ui/src/flow_chat/services/goalVerificationService.ts
+++ b/src/web-ui/src/flow_chat/services/goalVerificationService.ts
@@ -1,4 +1,4 @@
-import { notificationService } from '@/shared/notification-system';
+import { notificationService } from '@/shared/notification-system/services/NotificationService';
 import { flowChatStore } from '../store/FlowChatStore';
 
 export type GoalVerificationOutcome = 'achieved' | 'continuing' | 'failed' | 'limit_reached';

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.test.tsx
@@ -49,6 +49,7 @@ vi.mock('../services/openBtwSession', () => ({
 
 vi.mock('../store/FlowChatStore', () => ({
   flowChatStore: {
+    subscribe: () => () => {},
     getState: () => ({
       sessions: new Map([
         ['parent-session', {


### PR DESCRIPTION
## Summary
- Add the missing FlowChatStore subscribe mock in TaskToolDisplay tests
- Import NotificationService directly from goalVerificationService to avoid pulling UI/theme/Monaco into logic tests

## Verification
- pnpm --dir src/web-ui run test:run