### PR TITLE
feat(mobile-web): add error boundary to prevent white-screen crashes

### DIFF
--- a/src/mobile-web/src/App.tsx
+++ b/src/mobile-web/src/App.tsx
@@ -3,6 +3,7 @@ import PairingPage from './pages/PairingPage';
 import WorkspacePage from './pages/WorkspacePage';
 import SessionListPage from './pages/SessionListPage';
 import ChatPage from './pages/ChatPage';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { I18nProvider } from './i18n';
 import { RelayHttpClient } from './services/RelayHttpClient';
 import { RemoteSessionManager } from './services/RemoteSessionManager';
@@ -210,7 +211,9 @@ const AppContent: React.FC = () => {
 const App: React.FC = () => (
   <ThemeProvider>
     <I18nProvider>
-      <AppContent />
+      <ErrorBoundary>
+        <AppContent />
+      </ErrorBoundary>
     </I18nProvider>
   </ThemeProvider>
 );

--- a/src/mobile-web/src/components/ErrorBoundary.tsx
+++ b/src/mobile-web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('[ErrorBoundary]', error.message, errorInfo.componentStack);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '32px',
+            textAlign: 'center',
+            background: 'var(--color-bg-primary)',
+            color: 'var(--color-text-primary)',
+            fontFamily: 'system-ui, sans-serif',
+          }}
+        >
+          <div style={{ fontSize: '48px', marginBottom: '16px' }}>⚠</div>
+          <h2 style={{ fontSize: '18px', fontWeight: 600, margin: '0 0 8px' }}>
+            Something went wrong
+          </h2>
+          <p style={{ fontSize: '13px', color: 'var(--color-text-muted)', margin: '0 0 24px', maxWidth: '280px' }}>
+            {this.state.error?.message || 'An unexpected error occurred.'}
+          </p>
+          <button
+            onClick={this.handleRetry}
+            style={{
+              padding: '12px 32px',
+              border: 'none',
+              borderRadius: '14px',
+              background: 'var(--color-accent-500)',
+              color: '#fff',
+              fontSize: '15px',
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
Wraps the app content in a React error boundary that catches uncaught errors and shows a friendly fallback UI with a retry button.

## Changes
- New `ErrorBoundary` class component with `getDerivedStateFromError` + `componentDidCatch`
- Fallback uses `position:absolute; inset:0` to guarantee full viewport coverage
- Wraps `<AppContent />` inside `<ThemeProvider>` and `<I18nProvider>`
- Retry button resets boundary state

## Verified
- TS: zero errors
- Build: success
- Demo: crash trigger shows fallback UI correctly