### PR TITLE
feat(mobile-web): add connection health indicator

### DIFF
--- a/src/mobile-web/src/App.tsx
+++ b/src/mobile-web/src/App.tsx
@@ -8,6 +8,7 @@ import { I18nProvider, useI18n } from './i18n';
 import { RelayHttpClient } from './services/RelayHttpClient';
 import { RemoteSessionManager } from './services/RemoteSessionManager';
 import { ThemeProvider } from './theme';
+import { useConnectionHealth } from './hooks/useConnectionHealth';
 import { useMobileStore } from './services/store';
 import './styles/index.scss';
 
@@ -40,6 +41,8 @@ const AppContent: React.FC = () => {
   const clientRef = useRef<RelayHttpClient | null>(null);
   const sessionMgrRef = useRef<RemoteSessionManager | null>(null);
   const [sessionMgr, setSessionMgr] = useState<RemoteSessionManager | null>(null);
+
+  useConnectionHealth(sessionMgr);
 
   const [navDir, setNavDir] = useState<NavDirection>(null);
   const [prevPage, setPrevPage] = useState<Page | null>(null);

--- a/src/mobile-web/src/hooks/useConnectionHealth.ts
+++ b/src/mobile-web/src/hooks/useConnectionHealth.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import { RemoteSessionManager } from '../services/RemoteSessionManager';
+import { useMobileStore } from '../services/store';
+
+const PING_INTERVAL = 15000;
+const PING_TIMEOUT = 10000;
+
+function pingWithTimeout(mgr: RemoteSessionManager, ms: number): Promise<void> {
+  return Promise.race([
+    mgr.ping(),
+    new Promise<void>((_, reject) =>
+      setTimeout(() => reject(new Error('ping timeout')), ms),
+    ),
+  ]);
+}
+
+export function useConnectionHealth(sessionMgr: RemoteSessionManager | null) {
+  const setConnectionHealth = useMobileStore((s) => s.setConnectionHealth);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!sessionMgr) {
+      setConnectionHealth('unpaired');
+      return;
+    }
+
+    const loop = async () => {
+      try {
+        await pingWithTimeout(sessionMgr, PING_TIMEOUT);
+        if (!cancelled) setConnectionHealth('connected');
+      } catch {
+        if (!cancelled) setConnectionHealth('unreachable');
+      }
+
+      if (!cancelled) {
+        timerRef.current = setTimeout(loop, PING_INTERVAL);
+      }
+    };
+
+    loop();
+
+    return () => {
+      cancelled = true;
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [sessionMgr, setConnectionHealth]);
+}

--- a/src/mobile-web/src/i18n/messages.ts
+++ b/src/mobile-web/src/i18n/messages.ts
@@ -105,6 +105,10 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       disconnect: 'Disconnect',
       disconnectConfirm: 'Disconnect from current desktop? You can re-pair later.',
       reconnecting: 'Reconnecting...',
+      connectionUnpaired: 'Not connected',
+      connectionChecking: 'Checking connection...',
+      connectionConnected: 'Connected',
+      connectionUnreachable: 'Connection lost',
     },
     workspace: {
       title: 'Workspace',
@@ -282,6 +286,10 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       disconnect: '断开连接',
       disconnectConfirm: '断开当前桌面连接？之后可重新配对。',
       reconnecting: '正在重新连接...',
+      connectionUnpaired: '未连接',
+      connectionChecking: '检测连接中...',
+      connectionConnected: '已连接',
+      connectionUnreachable: '连接断开',
     },
     workspace: {
       title: '工作区',
@@ -459,6 +467,10 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       disconnect: '斷開連接',
       disconnectConfirm: '斷開當前桌面連接？之後可重新配對。',
       reconnecting: '正在重新連接...',
+      connectionUnpaired: '未連接',
+      connectionChecking: '檢測連接中...',
+      connectionConnected: '已連接',
+      connectionUnreachable: '連接斷開',
     },
     workspace: {
       title: '工作區',

--- a/src/mobile-web/src/pages/SessionListPage.tsx
+++ b/src/mobile-web/src/pages/SessionListPage.tsx
@@ -151,6 +151,7 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
     setCurrentAssistant,
     setPairedDisplayMode,
     authenticatedUserId,
+    connectionHealth,
   } = useMobileStore();
   const { isDark, toggleTheme } = useTheme();
   const [creating, setCreating] = useState(false);
@@ -570,7 +571,10 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
           <div className="session-list__header-copy">
             <h1>{t('common.appName')}</h1>
             {authenticatedUserId && (
-              <span className="session-list__header-user-id">{authenticatedUserId}</span>
+              <span className="session-list__header-user-id">
+                <span className={`session-list__health-dot session-list__health-dot--${connectionHealth}`} title={(() => { switch (connectionHealth) { case 'connected': return t('sessions.connectionConnected'); case 'checking': return t('sessions.connectionChecking'); case 'unreachable': return t('sessions.connectionUnreachable'); default: return t('sessions.connectionUnpaired'); } })()} />
+                {authenticatedUserId}
+              </span>
             )}
           </div>
         </div>

--- a/src/mobile-web/src/services/store.ts
+++ b/src/mobile-web/src/services/store.ts
@@ -8,10 +8,13 @@ import type {
 } from './RemoteSessionManager';
 
 export type ConnectionStatus = 'idle' | 'pairing' | 'paired' | 'error';
+export type ConnectionHealth = 'unpaired' | 'checking' | 'connected' | 'unreachable';
 
 interface MobileStore {
   connectionStatus: ConnectionStatus;
   setConnectionStatus: (s: ConnectionStatus) => void;
+  connectionHealth: ConnectionHealth;
+  setConnectionHealth: (h: ConnectionHealth) => void;
 
   currentWorkspace: WorkspaceInfo | null;
   setCurrentWorkspace: (w: WorkspaceInfo | null) => void;
@@ -54,6 +57,8 @@ interface MobileStore {
 export const useMobileStore = create<MobileStore>((set, get) => ({
   connectionStatus: 'idle',
   setConnectionStatus: (connectionStatus) => set({ connectionStatus }),
+  connectionHealth: 'unpaired',
+  setConnectionHealth: (connectionHealth) => set({ connectionHealth }),
 
   currentWorkspace: null,
   setCurrentWorkspace: (currentWorkspace) => set({ currentWorkspace }),

--- a/src/mobile-web/src/styles/components/sessions.scss
+++ b/src/mobile-web/src/styles/components/sessions.scss
@@ -57,6 +57,31 @@
   letter-spacing: 0.02em;
 }
 
+.session-list__health-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-right: 5px;
+  vertical-align: middle;
+
+  &--connected {
+    background: var(--color-success);
+  }
+
+  &--checking {
+    background: var(--color-warning);
+  }
+
+  &--unpaired {
+    background: var(--color-text-muted);
+  }
+
+  &--unreachable {
+    background: var(--color-error);
+  }
+}
+
 .session-list__header-kicker {
   font-size: 10px;
   font-weight: var(--font-weight-semibold);


### PR DESCRIPTION
## Summary
Shows a colored status dot in the session list header: grey=unpaired, yellow=checking, green=connected, red=unreachable.

## Changes
- New `useConnectionHealth` hook with `setTimeout`-based non-overlapping polling
- 10s ping timeout, `cancelled` flag prevents stale state updates
- Reactive `sessionMgr` state ensures hook re-runs on connect/disconnect
- Four ConnectionHealth states: `unpaired` | `checking` | `connected` | `unreachable`
- Store initializes to `unpaired` (grey dot) — not misleading
- All tooltip text fully i18n'd (en-US/zh-CN/zh-TW)
- CSS: `--color-success` / `--color-warning` / `--color-error` / `--color-text-muted` tokens

## Review Fixes
1. Removed `_codex_review_prompt.txt` and `docs/mobile-gap-analysis.md`
2. Status dot is the single shared health source; the reconnect banner (separate PR) consumes the same `connectionHealth` store field
3. `useConnectionHealth` is the one canonical health-check loop — no duplicate polling
4. Added `unpaired` state to distinguish "not yet paired" from "connection lost"
5. All tooltip text now uses i18n keys (`sessions.connectionConnected/Checking/Unreachable/Unpaired`)