### PR TITLE
feat(mobile-web): show reconnect banner when relay is unreachable

### DIFF
--- a/src/mobile-web/src/App.tsx
+++ b/src/mobile-web/src/App.tsx
@@ -3,7 +3,7 @@ import PairingPage from './pages/PairingPage';
 import WorkspacePage from './pages/WorkspacePage';
 import SessionListPage from './pages/SessionListPage';
 import ChatPage from './pages/ChatPage';
-import { I18nProvider } from './i18n';
+import { I18nProvider, useI18n } from './i18n';
 import { RelayHttpClient } from './services/RelayHttpClient';
 import { RemoteSessionManager } from './services/RemoteSessionManager';
 import { ThemeProvider } from './theme';
@@ -29,12 +29,15 @@ function getNavClass(
 }
 
 const AppContent: React.FC = () => {
+  const { t } = useI18n();
   const [page, setPage] = useState<Page>('pairing');
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [activeSessionName, setActiveSessionName] = useState<string>('Session');
   const [chatAutoFocus, setChatAutoFocus] = useState(false);
+  const [isReconnecting, setIsReconnecting] = useState(false);
   const clientRef = useRef<RelayHttpClient | null>(null);
   const sessionMgrRef = useRef<RemoteSessionManager | null>(null);
+  const [sessionMgr, setSessionMgr] = useState<RemoteSessionManager | null>(null);
 
   const [navDir, setNavDir] = useState<NavDirection>(null);
   const [prevPage, setPrevPage] = useState<Page | null>(null);
@@ -102,12 +105,53 @@ const AppContent: React.FC = () => {
     (client: RelayHttpClient, sessionMgr: RemoteSessionManager) => {
       clientRef.current = client;
       sessionMgrRef.current = sessionMgr;
+      setSessionMgr(sessionMgr);
       pageStackRef.current = ['pairing', 'sessions'];
       history.pushState({ page: 'sessions' }, '');
       setPage('sessions');
     },
     [],
   );
+
+  // Periodic connection health check
+  useEffect(() => {
+    const shouldMonitor = page === 'sessions' || page === 'chat';
+    if (!shouldMonitor || !sessionMgr) {
+      setIsReconnecting(false);
+      return;
+    }
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const pingWithTimeout = (ms: number): Promise<void> =>
+      Promise.race([
+        sessionMgr.ping(),
+        new Promise<void>((_, reject) =>
+          setTimeout(() => reject(new Error('ping timeout')), ms),
+        ),
+      ]);
+
+    const loop = async () => {
+      try {
+        await pingWithTimeout(10000);
+        if (!cancelled) setIsReconnecting(false);
+      } catch {
+        if (!cancelled) setIsReconnecting(true);
+      }
+
+      if (!cancelled) {
+        timer = setTimeout(loop, 15000);
+      }
+    };
+
+    loop();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [sessionMgr, page]);
 
   // Pop navigation handlers that can be called from both UI buttons and popstate
   const doPopFromChat = useCallback(() => {
@@ -174,6 +218,12 @@ const AppContent: React.FC = () => {
 
   return (
     <div className="mobile-app">
+      {isReconnecting && (
+        <div className="mobile-reconnect-banner">
+          <span className="mobile-reconnect-spinner" />
+          {t('sessions.reconnecting')}
+        </div>
+      )}
       {page === 'pairing' && <PairingPage onPaired={handlePaired} />}
       {shouldShow('workspace') && sessionMgrRef.current && (
         <div className={`nav-page ${getNavClass('workspace', currentPage, navDir, isAnimating)}`}>

--- a/src/mobile-web/src/i18n/messages.ts
+++ b/src/mobile-web/src/i18n/messages.ts
@@ -102,6 +102,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       deleted: 'Session deleted',
       deleteFailed: 'Delete failed',
       renameFailed: 'Rename failed',
+      reconnecting: 'Reconnecting...',
     },
     workspace: {
       title: 'Workspace',
@@ -276,6 +277,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       deleted: '会话已删除',
       deleteFailed: '删除失败',
       renameFailed: '重命名失败',
+      reconnecting: '正在重新连接...',
     },
     workspace: {
       title: '工作区',
@@ -450,6 +452,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       deleted: '會話已刪除',
       deleteFailed: '刪除失敗',
       renameFailed: '重新命名失敗',
+      reconnecting: '正在重新連接...',
     },
     workspace: {
       title: '工作區',

--- a/src/mobile-web/src/styles/global.scss
+++ b/src/mobile-web/src/styles/global.scss
@@ -174,3 +174,36 @@ html.theme-switching {
                 background 0.28s ease !important;
   }
 }
+
+// Reconnect banner
+.mobile-reconnect-banner {
+  position: fixed;
+  top: env(safe-area-inset-top, 0);
+  left: 0;
+  right: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: var(--color-warning);
+  color: #fff;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  animation: slideDown var(--motion-fast) var(--easing-standard);
+}
+
+.mobile-reconnect-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: reconnect-spin 0.8s linear infinite;
+}
+
+@keyframes reconnect-spin {
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
Shows a yellow "Reconnecting..." banner with spinner when relay is unreachable.

## Changes
- Reactive `sessionMgr` + `page` state as effect dependencies
- `setTimeout`-based non-overlapping polling with 10s ping timeout
- Cancellation guard prevents stale state updates
- `env(safe-area-inset-top, 0)` for notch support
- Scoped `reconnect-spin` keyframe, `display:inline-block` on spinner
- i18n: `sessions.reconnecting` key in en-US/zh-CN/zh-TW

## Verified
- TS: zero errors
- Build: success
- Demo: banner appears/dismisses correctly