### PR TITLE
feat(mobile-web): merge mobile stability PRs

### DIFF
--- a/src/mobile-web/src/App.tsx
+++ b/src/mobile-web/src/App.tsx
@@ -172,10 +172,16 @@ const AppContent: React.FC = () => {
     clientRef.current = null;
     sessionMgrRef.current = null;
     setActiveSessionId(null);
+    localStorage.removeItem('bitfun.mobile.user_id');
     const store = useMobileStore.getState();
     store.setConnectionStatus('idle');
     store.setSessions([]);
     store.setCurrentWorkspace(null);
+    store.setCurrentAssistant(null);
+    store.setPairedDisplayMode(null);
+    store.setAuthenticatedUserId(null);
+    store.setActiveTurn(null);
+    store.setError(null);
     pageStackRef.current = ['pairing'];
     setPage('pairing');
   }, []);

--- a/src/mobile-web/src/App.tsx
+++ b/src/mobile-web/src/App.tsx
@@ -3,7 +3,7 @@ import PairingPage from './pages/PairingPage';
 import WorkspacePage from './pages/WorkspacePage';
 import SessionListPage from './pages/SessionListPage';
 import ChatPage from './pages/ChatPage';
-import { I18nProvider } from './i18n';
+import { I18nProvider, useI18n } from './i18n';
 import { RelayHttpClient } from './services/RelayHttpClient';
 import { RemoteSessionManager } from './services/RemoteSessionManager';
 import { ThemeProvider } from './theme';
@@ -29,10 +29,12 @@ function getNavClass(
 }
 
 const AppContent: React.FC = () => {
+  const { t } = useI18n();
   const [page, setPage] = useState<Page>('pairing');
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [activeSessionName, setActiveSessionName] = useState<string>('Session');
   const [chatAutoFocus, setChatAutoFocus] = useState(false);
+  const [isReconnecting, setIsReconnecting] = useState(false);
   const clientRef = useRef<RelayHttpClient | null>(null);
   const sessionMgrRef = useRef<RemoteSessionManager | null>(null);
 
@@ -109,6 +111,28 @@ const AppContent: React.FC = () => {
     [],
   );
 
+  // Periodic connection health check
+  useEffect(() => {
+    const mgr = sessionMgrRef.current;
+    if (!mgr) {
+      setIsReconnecting(false);
+      return;
+    }
+
+    let timer: ReturnType<typeof setInterval>;
+    const check = async () => {
+      try {
+        await mgr.ping();
+        setIsReconnecting(false);
+      } catch {
+        setIsReconnecting(true);
+      }
+    };
+    check();
+    timer = setInterval(check, 15000);
+    return () => clearInterval(timer);
+  }, [page === 'sessions' || page === 'chat' ? sessionMgrRef.current : null]);
+
   // Pop navigation handlers that can be called from both UI buttons and popstate
   const doPopFromChat = useCallback(() => {
     navigateTo('sessions', 'pop');
@@ -174,6 +198,12 @@ const AppContent: React.FC = () => {
 
   return (
     <div className="mobile-app">
+      {isReconnecting && (
+        <div className="mobile-reconnect-banner">
+          <span className="mobile-reconnect-spinner" />
+          {t('sessions.reconnecting')}
+        </div>
+      )}
       {page === 'pairing' && <PairingPage onPaired={handlePaired} />}
       {shouldShow('workspace') && sessionMgrRef.current && (
         <div className={`nav-page ${getNavClass('workspace', currentPage, navDir, isAnimating)}`}>

--- a/src/mobile-web/src/App.tsx
+++ b/src/mobile-web/src/App.tsx
@@ -8,6 +8,7 @@ import { I18nProvider } from './i18n';
 import { RelayHttpClient } from './services/RelayHttpClient';
 import { RemoteSessionManager } from './services/RemoteSessionManager';
 import { ThemeProvider } from './theme';
+import { useMobileStore } from './services/store';
 import './styles/index.scss';
 
 type Page = 'pairing' | 'workspace' | 'sessions' | 'chat';
@@ -168,6 +169,21 @@ const AppContent: React.FC = () => {
     setTimeout(() => setActiveSessionId(null), NAV_DURATION);
   }, [navigateTo]);
 
+  const handleDisconnect = useCallback(() => {
+    clientRef.current = null;
+    sessionMgrRef.current = null;
+    setActiveSessionId(null);
+    setActiveSessionName('Session');
+    setChatAutoFocus(false);
+    setPrevPage(null);
+    setNavDir(null);
+    clearTimeout(timerRef.current);
+    localStorage.removeItem('bitfun.mobile.user_id');
+    useMobileStore.getState().resetConnectionState();
+    pageStackRef.current = ['pairing'];
+    setPage('pairing');
+  }, []);
+
   const isAnimating = navDir !== null;
   const currentPage: Page = page;
 
@@ -190,6 +206,7 @@ const AppContent: React.FC = () => {
             sessionMgr={sessionMgrRef.current}
             onSelectSession={handleSelectSession}
             onOpenWorkspace={handleOpenWorkspace}
+            onDisconnect={handleDisconnect}
           />
         </div>
       )}
@@ -210,11 +227,11 @@ const AppContent: React.FC = () => {
 
 const App: React.FC = () => (
   <ThemeProvider>
-    <I18nProvider>
-      <ErrorBoundary>
+    <ErrorBoundary>
+      <I18nProvider>
         <AppContent />
-      </ErrorBoundary>
-    </I18nProvider>
+      </I18nProvider>
+    </ErrorBoundary>
   </ThemeProvider>
 );
 

--- a/src/mobile-web/src/App.tsx
+++ b/src/mobile-web/src/App.tsx
@@ -3,6 +3,7 @@ import PairingPage from './pages/PairingPage';
 import WorkspacePage from './pages/WorkspacePage';
 import SessionListPage from './pages/SessionListPage';
 import ChatPage from './pages/ChatPage';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { I18nProvider } from './i18n';
 import { RelayHttpClient } from './services/RelayHttpClient';
 import { RemoteSessionManager } from './services/RemoteSessionManager';
@@ -210,7 +211,9 @@ const AppContent: React.FC = () => {
 const App: React.FC = () => (
   <ThemeProvider>
     <I18nProvider>
-      <AppContent />
+      <ErrorBoundary>
+        <AppContent />
+      </ErrorBoundary>
     </I18nProvider>
   </ThemeProvider>
 );

--- a/src/mobile-web/src/App.tsx
+++ b/src/mobile-web/src/App.tsx
@@ -4,7 +4,7 @@ import WorkspacePage from './pages/WorkspacePage';
 import SessionListPage from './pages/SessionListPage';
 import ChatPage from './pages/ChatPage';
 import { ErrorBoundary } from './components/ErrorBoundary';
-import { I18nProvider } from './i18n';
+import { I18nProvider, useI18n } from './i18n';
 import { RelayHttpClient } from './services/RelayHttpClient';
 import { RemoteSessionManager } from './services/RemoteSessionManager';
 import { ThemeProvider } from './theme';
@@ -31,12 +31,15 @@ function getNavClass(
 }
 
 const AppContent: React.FC = () => {
+  const { t } = useI18n();
   const [page, setPage] = useState<Page>('pairing');
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [activeSessionName, setActiveSessionName] = useState<string>('Session');
   const [chatAutoFocus, setChatAutoFocus] = useState(false);
+  const [isReconnecting, setIsReconnecting] = useState(false);
   const clientRef = useRef<RelayHttpClient | null>(null);
   const sessionMgrRef = useRef<RemoteSessionManager | null>(null);
+  const [sessionMgr, setSessionMgr] = useState<RemoteSessionManager | null>(null);
 
   const [navDir, setNavDir] = useState<NavDirection>(null);
   const [prevPage, setPrevPage] = useState<Page | null>(null);
@@ -104,12 +107,57 @@ const AppContent: React.FC = () => {
     (client: RelayHttpClient, sessionMgr: RemoteSessionManager) => {
       clientRef.current = client;
       sessionMgrRef.current = sessionMgr;
+      setSessionMgr(sessionMgr);
       pageStackRef.current = ['pairing', 'sessions'];
       history.pushState({ page: 'sessions' }, '');
       setPage('sessions');
     },
     [],
   );
+
+  // Periodic connection health check
+  useEffect(() => {
+    const shouldMonitor = page === 'sessions' || page === 'chat';
+    if (!shouldMonitor || !sessionMgr) {
+      setIsReconnecting(false);
+      return;
+    }
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const pingWithTimeout = (ms: number): Promise<void> => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      return Promise.race([
+        sessionMgr.ping(),
+        new Promise<void>((_, reject) => {
+          timeoutId = setTimeout(() => reject(new Error('ping timeout')), ms);
+        }),
+      ]).finally(() => {
+        if (timeoutId) clearTimeout(timeoutId);
+      });
+    };
+
+    const loop = async () => {
+      try {
+        await pingWithTimeout(10000);
+        if (!cancelled) setIsReconnecting(false);
+      } catch {
+        if (!cancelled) setIsReconnecting(true);
+      }
+
+      if (!cancelled) {
+        timer = setTimeout(loop, 15000);
+      }
+    };
+
+    loop();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [sessionMgr, page]);
 
   // Pop navigation handlers that can be called from both UI buttons and popstate
   const doPopFromChat = useCallback(() => {
@@ -172,6 +220,8 @@ const AppContent: React.FC = () => {
   const handleDisconnect = useCallback(() => {
     clientRef.current = null;
     sessionMgrRef.current = null;
+    setSessionMgr(null);
+    setIsReconnecting(false);
     setActiveSessionId(null);
     setActiveSessionName('Session');
     setChatAutoFocus(false);
@@ -191,6 +241,12 @@ const AppContent: React.FC = () => {
 
   return (
     <div className="mobile-app">
+      {isReconnecting && (
+        <div className="mobile-reconnect-banner">
+          <span className="mobile-reconnect-spinner" />
+          {t('sessions.reconnecting')}
+        </div>
+      )}
       {page === 'pairing' && <PairingPage onPaired={handlePaired} />}
       {shouldShow('workspace') && sessionMgrRef.current && (
         <div className={`nav-page ${getNavClass('workspace', currentPage, navDir, isAnimating)}`}>

--- a/src/mobile-web/src/App.tsx
+++ b/src/mobile-web/src/App.tsx
@@ -7,6 +7,7 @@ import { I18nProvider } from './i18n';
 import { RelayHttpClient } from './services/RelayHttpClient';
 import { RemoteSessionManager } from './services/RemoteSessionManager';
 import { ThemeProvider } from './theme';
+import { useMobileStore } from './services/store';
 import './styles/index.scss';
 
 type Page = 'pairing' | 'workspace' | 'sessions' | 'chat';
@@ -167,6 +168,18 @@ const AppContent: React.FC = () => {
     setTimeout(() => setActiveSessionId(null), NAV_DURATION);
   }, [navigateTo]);
 
+  const handleDisconnect = useCallback(() => {
+    clientRef.current = null;
+    sessionMgrRef.current = null;
+    setActiveSessionId(null);
+    const store = useMobileStore.getState();
+    store.setConnectionStatus('idle');
+    store.setSessions([]);
+    store.setCurrentWorkspace(null);
+    pageStackRef.current = ['pairing'];
+    setPage('pairing');
+  }, []);
+
   const isAnimating = navDir !== null;
   const currentPage: Page = page;
 
@@ -189,6 +202,7 @@ const AppContent: React.FC = () => {
             sessionMgr={sessionMgrRef.current}
             onSelectSession={handleSelectSession}
             onOpenWorkspace={handleOpenWorkspace}
+            onDisconnect={handleDisconnect}
           />
         </div>
       )}

--- a/src/mobile-web/src/App.tsx
+++ b/src/mobile-web/src/App.tsx
@@ -37,6 +37,7 @@ const AppContent: React.FC = () => {
   const [isReconnecting, setIsReconnecting] = useState(false);
   const clientRef = useRef<RelayHttpClient | null>(null);
   const sessionMgrRef = useRef<RemoteSessionManager | null>(null);
+  const [sessionMgr, setSessionMgr] = useState<RemoteSessionManager | null>(null);
 
   const [navDir, setNavDir] = useState<NavDirection>(null);
   const [prevPage, setPrevPage] = useState<Page | null>(null);
@@ -104,6 +105,7 @@ const AppContent: React.FC = () => {
     (client: RelayHttpClient, sessionMgr: RemoteSessionManager) => {
       clientRef.current = client;
       sessionMgrRef.current = sessionMgr;
+      setSessionMgr(sessionMgr);
       pageStackRef.current = ['pairing', 'sessions'];
       history.pushState({ page: 'sessions' }, '');
       setPage('sessions');
@@ -113,25 +115,43 @@ const AppContent: React.FC = () => {
 
   // Periodic connection health check
   useEffect(() => {
-    const mgr = sessionMgrRef.current;
-    if (!mgr) {
+    const shouldMonitor = page === 'sessions' || page === 'chat';
+    if (!shouldMonitor || !sessionMgr) {
       setIsReconnecting(false);
       return;
     }
 
-    let timer: ReturnType<typeof setInterval>;
-    const check = async () => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const pingWithTimeout = (ms: number): Promise<void> =>
+      Promise.race([
+        sessionMgr.ping(),
+        new Promise<void>((_, reject) =>
+          setTimeout(() => reject(new Error('ping timeout')), ms),
+        ),
+      ]);
+
+    const loop = async () => {
       try {
-        await mgr.ping();
-        setIsReconnecting(false);
+        await pingWithTimeout(10000);
+        if (!cancelled) setIsReconnecting(false);
       } catch {
-        setIsReconnecting(true);
+        if (!cancelled) setIsReconnecting(true);
+      }
+
+      if (!cancelled) {
+        timer = setTimeout(loop, 15000);
       }
     };
-    check();
-    timer = setInterval(check, 15000);
-    return () => clearInterval(timer);
-  }, [page === 'sessions' || page === 'chat' ? sessionMgrRef.current : null]);
+
+    loop();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [sessionMgr, page]);
 
   // Pop navigation handlers that can be called from both UI buttons and popstate
   const doPopFromChat = useCallback(() => {

--- a/src/mobile-web/src/components/ErrorBoundary.tsx
+++ b/src/mobile-web/src/components/ErrorBoundary.tsx
@@ -19,6 +19,10 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
     return { hasError: true, error };
   }
 
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('[ErrorBoundary]', error.message, errorInfo.componentStack);
+  }
+
   handleRetry = () => {
     this.setState({ hasError: false, error: null });
   };

--- a/src/mobile-web/src/components/ErrorBoundary.tsx
+++ b/src/mobile-web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('[ErrorBoundary]', error.message, errorInfo.componentStack);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: '100%',
+            padding: '32px',
+            textAlign: 'center',
+            background: 'var(--color-bg-primary)',
+            color: 'var(--color-text-primary)',
+            fontFamily: 'system-ui, sans-serif',
+          }}
+        >
+          <div style={{ fontSize: '48px', marginBottom: '16px' }}>⚠</div>
+          <h2 style={{ fontSize: '18px', fontWeight: 600, margin: '0 0 8px' }}>
+            Something went wrong
+          </h2>
+          <p style={{ fontSize: '13px', color: 'var(--color-text-muted)', margin: '0 0 24px', maxWidth: '280px' }}>
+            {this.state.error?.message || 'An unexpected error occurred.'}
+          </p>
+          <button
+            onClick={this.handleRetry}
+            style={{
+              padding: '12px 32px',
+              border: 'none',
+              borderRadius: '14px',
+              background: 'var(--color-accent-500)',
+              color: '#fff',
+              fontSize: '15px',
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/mobile-web/src/components/ErrorBoundary.tsx
+++ b/src/mobile-web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: '100%',
+            padding: '32px',
+            textAlign: 'center',
+            background: 'var(--color-bg-primary)',
+            color: 'var(--color-text-primary)',
+            fontFamily: 'system-ui, sans-serif',
+          }}
+        >
+          <div style={{ fontSize: '48px', marginBottom: '16px' }}>⚠</div>
+          <h2 style={{ fontSize: '18px', fontWeight: 600, margin: '0 0 8px' }}>
+            Something went wrong
+          </h2>
+          <p style={{ fontSize: '13px', color: 'var(--color-text-muted)', margin: '0 0 24px', maxWidth: '280px' }}>
+            {this.state.error?.message || 'An unexpected error occurred.'}
+          </p>
+          <button
+            onClick={this.handleRetry}
+            style={{
+              padding: '12px 32px',
+              border: 'none',
+              borderRadius: '14px',
+              background: 'var(--color-accent-500)',
+              color: '#fff',
+              fontSize: '15px',
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/mobile-web/src/i18n/messages.ts
+++ b/src/mobile-web/src/i18n/messages.ts
@@ -102,6 +102,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       deleted: 'Session deleted',
       deleteFailed: 'Delete failed',
       renameFailed: 'Rename failed',
+      reconnecting: 'Reconnecting...',
     },
     workspace: {
       title: 'Workspace',
@@ -276,6 +277,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       deleted: '会话已删除',
       deleteFailed: '删除失败',
       renameFailed: '重命名失败',
+      reconnecting: '正在重新连接...',
     },
     workspace: {
       title: '工作区',
@@ -450,6 +452,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       deleted: '會話已刪除',
       deleteFailed: '刪除失敗',
       renameFailed: '重新命名失敗',
+      reconnecting: '正在重新連接...',
     },
     workspace: {
       title: '工作區',

--- a/src/mobile-web/src/i18n/messages.ts
+++ b/src/mobile-web/src/i18n/messages.ts
@@ -102,6 +102,8 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       deleted: 'Session deleted',
       deleteFailed: 'Delete failed',
       renameFailed: 'Rename failed',
+      disconnect: 'Disconnect',
+      disconnectConfirm: 'Disconnect from current desktop? You can re-pair later.',
     },
     workspace: {
       title: 'Workspace',
@@ -276,6 +278,8 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       deleted: '会话已删除',
       deleteFailed: '删除失败',
       renameFailed: '重命名失败',
+      disconnect: '断开连接',
+      disconnectConfirm: '断开当前桌面连接？之后可重新配对。',
     },
     workspace: {
       title: '工作区',
@@ -450,6 +454,8 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       deleted: '會話已刪除',
       deleteFailed: '刪除失敗',
       renameFailed: '重新命名失敗',
+      disconnect: '斷開連接',
+      disconnectConfirm: '斷開當前桌面連接？之後可重新配對。',
     },
     workspace: {
       title: '工作區',

--- a/src/mobile-web/src/i18n/messages.ts
+++ b/src/mobile-web/src/i18n/messages.ts
@@ -104,6 +104,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       renameFailed: 'Rename failed',
       disconnect: 'Disconnect',
       disconnectConfirm: 'Disconnect from current desktop? You can re-pair later.',
+      reconnecting: 'Reconnecting...',
     },
     workspace: {
       title: 'Workspace',
@@ -280,6 +281,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       renameFailed: '重命名失败',
       disconnect: '断开连接',
       disconnectConfirm: '断开当前桌面连接？之后可重新配对。',
+      reconnecting: '正在重新连接...',
     },
     workspace: {
       title: '工作区',
@@ -456,6 +458,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       renameFailed: '重新命名失敗',
       disconnect: '斷開連接',
       disconnectConfirm: '斷開當前桌面連接？之後可重新配對。',
+      reconnecting: '正在重新連接...',
     },
     workspace: {
       title: '工作區',
@@ -535,4 +538,3 @@ export const messages: Record<MobileLanguage, MessageTree> = {
     },
   }
 };
-

--- a/src/mobile-web/src/pages/SessionListPage.tsx
+++ b/src/mobile-web/src/pages/SessionListPage.tsx
@@ -1015,7 +1015,16 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
 
       {/* Disconnect Confirmation */}
       {showDisconnectConfirm && (
-        <div className="session-list__picker-overlay" onClick={() => setShowDisconnectConfirm(false)}>
+        <div
+          className="session-list__picker-overlay"
+          role="alertdialog"
+          aria-modal="true"
+          onClick={() => setShowDisconnectConfirm(false)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') setShowDisconnectConfirm(false);
+            if (e.key === 'Enter') { setShowDisconnectConfirm(false); onDisconnect(); }
+          }}
+        >
           <div className="session-list__confirm-modal" onClick={(e) => e.stopPropagation()}>
             <div className="session-list__confirm-icon">
               <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
@@ -1030,6 +1039,7 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
               <button
                 className="session-list__confirm-btn session-list__confirm-btn--cancel"
                 onClick={() => setShowDisconnectConfirm(false)}
+                autoFocus
               >
                 {t('common.cancel')}
               </button>

--- a/src/mobile-web/src/pages/SessionListPage.tsx
+++ b/src/mobile-web/src/pages/SessionListPage.tsx
@@ -14,6 +14,7 @@ interface SessionListPageProps {
   sessionMgr: RemoteSessionManager;
   onSelectSession: (sessionId: string, sessionName?: string, isNew?: boolean) => void;
   onOpenWorkspace: () => void;
+  onDisconnect: () => void;
 }
 
 function formatTime(unixStr: string, language: string, t: (key: string, params?: Record<string, string | number>) => string): string {
@@ -137,7 +138,7 @@ const ThemeToggleIcon: React.FC<{ isDark: boolean }> = ({ isDark }) => (
   </svg>
 );
 
-const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectSession, onOpenWorkspace }) => {
+const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectSession, onOpenWorkspace, onDisconnect }) => {
   const { t, language } = useI18n();
   const {
     sessions,
@@ -176,6 +177,8 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
   const [deleting, setDeleting] = useState(false);
   const [renaming, setRenaming] = useState(false);
   const [actionToast, setActionToast] = useState<string | null>(null);
+
+  const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
 
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const longPressPosRef = useRef({ x: 0, y: 0 });
@@ -575,6 +578,13 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
           <LanguageToggleButton />
           <button className="session-list__theme-btn" onClick={toggleTheme} aria-label={t('common.toggleTheme')}>
             <ThemeToggleIcon isDark={isDark} />
+          </button>
+          <button className="session-list__disconnect-btn" onClick={() => setShowDisconnectConfirm(true)} aria-label={t('sessions.disconnect')} title={t('sessions.disconnect')}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+              <polyline points="16 17 21 12 16 7" />
+              <line x1="21" y1="12" x2="9" y2="12" />
+            </svg>
           </button>
         </div>
       </div>
@@ -997,6 +1007,48 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
                 disabled={deleting}
               >
                 {deleting ? '...' : t('sessions.deleteSession')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Disconnect Confirmation */}
+      {showDisconnectConfirm && (
+        <div
+          className="session-list__picker-overlay"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="disconnect-confirm-title"
+          aria-describedby="disconnect-confirm-desc"
+          onClick={() => setShowDisconnectConfirm(false)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') setShowDisconnectConfirm(false);
+          }}
+        >
+          <div className="session-list__confirm-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="session-list__confirm-icon">
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                <polyline points="16 17 21 12 16 7" />
+                <line x1="21" y1="12" x2="9" y2="12" />
+              </svg>
+            </div>
+            <h3 id="disconnect-confirm-title" className="session-list__confirm-title">{t('sessions.disconnect')}</h3>
+            <p id="disconnect-confirm-desc" className="session-list__confirm-desc">{t('sessions.disconnectConfirm')}</p>
+            <div className="session-list__confirm-actions">
+              <button
+                className="session-list__confirm-btn session-list__confirm-btn--cancel"
+                onClick={() => setShowDisconnectConfirm(false)}
+                autoFocus
+              >
+                {t('common.cancel')}
+              </button>
+              <button
+                className="session-list__confirm-btn session-list__confirm-btn--danger"
+                onClick={() => { setShowDisconnectConfirm(false); onDisconnect(); }}
+              >
+                {t('sessions.disconnect')}
               </button>
             </div>
           </div>

--- a/src/mobile-web/src/pages/SessionListPage.tsx
+++ b/src/mobile-web/src/pages/SessionListPage.tsx
@@ -14,6 +14,7 @@ interface SessionListPageProps {
   sessionMgr: RemoteSessionManager;
   onSelectSession: (sessionId: string, sessionName?: string, isNew?: boolean) => void;
   onOpenWorkspace: () => void;
+  onDisconnect: () => void;
 }
 
 function formatTime(unixStr: string, language: string, t: (key: string, params?: Record<string, string | number>) => string): string {
@@ -137,7 +138,7 @@ const ThemeToggleIcon: React.FC<{ isDark: boolean }> = ({ isDark }) => (
   </svg>
 );
 
-const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectSession, onOpenWorkspace }) => {
+const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectSession, onOpenWorkspace, onDisconnect }) => {
   const { t, language } = useI18n();
   const {
     sessions,
@@ -176,6 +177,8 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
   const [deleting, setDeleting] = useState(false);
   const [renaming, setRenaming] = useState(false);
   const [actionToast, setActionToast] = useState<string | null>(null);
+
+  const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
 
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const longPressPosRef = useRef({ x: 0, y: 0 });
@@ -575,6 +578,13 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
           <LanguageToggleButton />
           <button className="session-list__theme-btn" onClick={toggleTheme} aria-label={t('common.toggleTheme')}>
             <ThemeToggleIcon isDark={isDark} />
+          </button>
+          <button className="session-list__disconnect-btn" onClick={() => setShowDisconnectConfirm(true)} aria-label={t('sessions.disconnect')} title={t('sessions.disconnect')}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+              <polyline points="16 17 21 12 16 7" />
+              <line x1="21" y1="12" x2="9" y2="12" />
+            </svg>
           </button>
         </div>
       </div>
@@ -997,6 +1007,37 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
                 disabled={deleting}
               >
                 {deleting ? '...' : t('sessions.deleteSession')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Disconnect Confirmation */}
+      {showDisconnectConfirm && (
+        <div className="session-list__picker-overlay" onClick={() => setShowDisconnectConfirm(false)}>
+          <div className="session-list__confirm-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="session-list__confirm-icon">
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                <polyline points="16 17 21 12 16 7" />
+                <line x1="21" y1="12" x2="9" y2="12" />
+              </svg>
+            </div>
+            <h3 className="session-list__confirm-title">{t('sessions.disconnect')}</h3>
+            <p className="session-list__confirm-desc">{t('sessions.disconnectConfirm')}</p>
+            <div className="session-list__confirm-actions">
+              <button
+                className="session-list__confirm-btn session-list__confirm-btn--cancel"
+                onClick={() => setShowDisconnectConfirm(false)}
+              >
+                {t('common.cancel')}
+              </button>
+              <button
+                className="session-list__confirm-btn session-list__confirm-btn--danger"
+                onClick={() => { setShowDisconnectConfirm(false); onDisconnect(); }}
+              >
+                {t('sessions.disconnect')}
               </button>
             </div>
           </div>

--- a/src/mobile-web/src/services/store.ts
+++ b/src/mobile-web/src/services/store.ts
@@ -47,6 +47,8 @@ interface MobileStore {
 
   error: string | null;
   setError: (e: string | null) => void;
+
+  resetConnectionState: () => void;
 }
 
 export const useMobileStore = create<MobileStore>((set, get) => ({
@@ -133,4 +135,19 @@ export const useMobileStore = create<MobileStore>((set, get) => ({
 
   error: null,
   setError: (error) => set({ error }),
+
+  resetConnectionState: () =>
+    set({
+      connectionStatus: 'idle',
+      currentWorkspace: null,
+      currentAssistant: null,
+      pairedDisplayMode: null,
+      authenticatedUserId: null,
+      sessions: [],
+      activeSessionId: null,
+      messagesBySession: {},
+      deletedMessageIds: {},
+      activeTurn: null,
+      error: null,
+    }),
 }));

--- a/src/mobile-web/src/styles/components/sessions.scss
+++ b/src/mobile-web/src/styles/components/sessions.scss
@@ -100,6 +100,15 @@
   }
 }
 
+.session-list__disconnect-btn {
+  @extend .session-list__theme-btn;
+
+  &:active {
+    color: var(--color-error);
+    background: var(--color-error-bg);
+  }
+}
+
 .session-list__workspace-bar {
   position: relative;
   z-index: 1;

--- a/src/mobile-web/src/styles/global.scss
+++ b/src/mobile-web/src/styles/global.scss
@@ -174,3 +174,31 @@ html.theme-switching {
                 background 0.28s ease !important;
   }
 }
+
+// Reconnect banner
+.mobile-reconnect-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: var(--color-warning);
+  color: #fff;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  animation: slideDown var(--motion-fast) var(--easing-standard);
+}
+
+.mobile-reconnect-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}

--- a/src/mobile-web/src/styles/global.scss
+++ b/src/mobile-web/src/styles/global.scss
@@ -174,3 +174,36 @@ html.theme-switching {
                 background 0.28s ease !important;
   }
 }
+
+// Reconnect banner
+.mobile-reconnect-banner {
+  position: fixed;
+  top: env(safe-area-inset-top, 0);
+  left: 0;
+  right: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: var(--color-warning);
+  color: #fff;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  animation: slideDown var(--motion-fast) var(--easing-standard);
+}
+
+.mobile-reconnect-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: reconnect-spin 0.8s linear infinite;
+}
+
+@keyframes reconnect-spin {
+  to { transform: rotate(360deg); }
+}

--- a/src/mobile-web/src/styles/global.scss
+++ b/src/mobile-web/src/styles/global.scss
@@ -178,10 +178,10 @@ html.theme-switching {
 // Reconnect banner
 .mobile-reconnect-banner {
   position: fixed;
-  top: 0;
+  top: env(safe-area-inset-top, 0);
   left: 0;
   right: 0;
-  z-index: 9999;
+  z-index: 100;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -195,10 +195,15 @@ html.theme-switching {
 }
 
 .mobile-reconnect-spinner {
+  display: inline-block;
   width: 14px;
   height: 14px;
   border: 2px solid rgba(255, 255, 255, 0.3);
   border-top-color: #fff;
   border-radius: 50%;
-  animation: spin 0.8s linear infinite;
+  animation: reconnect-spin 0.8s linear infinite;
+}
+
+@keyframes reconnect-spin {
+  to { transform: rotate(360deg); }
 }


### PR DESCRIPTION
## Summary

Integrates the mobile-web stability PRs:

- #921 adds a React error boundary for crash fallback UI
- #923 adds a disconnect flow for switching desktops
- #926 adds a reconnecting banner for relay health checks

Additional maintainer fixes included while resolving the combined merge:

- Move the error boundary outside `I18nProvider` while keeping it inside `ThemeProvider`, so i18n initialization failures can still show the fallback UI.
- Reset all mobile connection/session state on disconnect, including cached messages and deleted-message markers.
- Keep disconnect confirmation Enter behavior scoped to the focused button; Escape still closes the dialog.
- Stop reconnect monitoring state when disconnecting and clear ping timeout timers after each race settles.
- Resolve combined `App.tsx` and i18n key conflicts across #921/#923/#926.

## Verification

- `pnpm --dir src/mobile-web exec tsc --noEmit`
- `pnpm --dir src/mobile-web build`
