### PR TITLE
perf(startup): reduce desktop first-screen work

### DIFF
--- a/src/apps/desktop/src/api/session_api.rs
+++ b/src/apps/desktop/src/api/session_api.rs
@@ -3,7 +3,7 @@
 use crate::api::app_state::AppState;
 use crate::api::session_storage_path::desktop_effective_session_storage_path;
 use bitfun_core::agentic::persistence::{
-    PersistenceManager, SessionBranchRequest, SessionBranchResult,
+    PersistenceManager, SessionBranchRequest, SessionBranchResult, SessionMetadataPage,
 };
 use bitfun_core::infrastructure::PathManager;
 use bitfun_core::service::session::{
@@ -20,6 +20,18 @@ use tauri::State;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListPersistedSessionsRequest {
     pub workspace_path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_connection_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_ssh_host: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListPersistedSessionsPageRequest {
+    pub workspace_path: String,
+    pub limit: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_connection_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -191,6 +203,28 @@ pub async fn list_persisted_sessions(
         .list_session_metadata(&workspace_path)
         .await
         .map_err(|e| format!("Failed to list persisted sessions: {}", e))
+}
+
+#[tauri::command]
+pub async fn list_persisted_sessions_page(
+    request: ListPersistedSessionsPageRequest,
+    app_state: State<'_, AppState>,
+    path_manager: State<'_, Arc<PathManager>>,
+) -> Result<SessionMetadataPage, String> {
+    let workspace_path = desktop_effective_session_storage_path(
+        &app_state,
+        &request.workspace_path,
+        request.remote_connection_id.as_deref(),
+        request.remote_ssh_host.as_deref(),
+    )
+    .await;
+    let manager = PersistenceManager::new(path_manager.inner().clone())
+        .map_err(|e| format!("Failed to create persistence manager: {}", e))?;
+
+    manager
+        .list_session_metadata_page(&workspace_path, request.cursor.as_deref(), request.limit)
+        .await
+        .map_err(|e| format!("Failed to list persisted session page: {}", e))
 }
 
 #[tauri::command]

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -793,6 +793,7 @@ pub async fn run() {
             initialize_project_storage,
             // Session persistence API
             list_persisted_sessions,
+            list_persisted_sessions_page,
             load_session_turns,
             get_session_usage_report,
             save_session_turn,

--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -426,8 +426,7 @@ pub fn create_main_window(app_handle: &tauri::AppHandle, startup_trace_id: &str)
                 }
             }
 
-            #[cfg(not(any(debug_assertions, feature = "devtools")))]
-            let _ = window;
+            show_main_window_for_startup(&window, total_started_at);
         }
         Err(e) => {
             error!(
@@ -437,6 +436,45 @@ pub fn create_main_window(app_handle: &tauri::AppHandle, startup_trace_id: &str)
             );
         }
     }
+}
+
+fn show_main_window_for_startup(window: &tauri::WebviewWindow, total_started_at: Instant) {
+    #[cfg(target_os = "windows")]
+    {
+        let step_started_at = Instant::now();
+        if let Err(error) = window.maximize() {
+            warn!("Failed to maximize main window during startup: {}", error);
+        } else {
+            debug!(
+                "Main window startup show step completed: step=maximize duration_ms={} since_create_start_ms={}",
+                step_started_at.elapsed().as_millis(),
+                total_started_at.elapsed().as_millis()
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(150));
+    }
+
+    let show_started_at = Instant::now();
+    if let Err(error) = window.show() {
+        warn!("Failed to show main window during startup: {}", error);
+        return;
+    }
+    debug!(
+        "Main window startup show step completed: step=show duration_ms={} since_create_start_ms={}",
+        show_started_at.elapsed().as_millis(),
+        total_started_at.elapsed().as_millis()
+    );
+
+    let focus_started_at = Instant::now();
+    if let Err(error) = window.set_focus() {
+        warn!("Failed to focus main window during startup: {}", error);
+        return;
+    }
+    debug!(
+        "Main window startup show step completed: step=focus duration_ms={} since_create_start_ms={}",
+        focus_started_at.elapsed().as_millis(),
+        total_started_at.elapsed().as_millis()
+    );
 }
 
 fn app_url(path: &str) -> WebviewUrl {

--- a/src/crates/core/src/agentic/persistence/manager.rs
+++ b/src/crates/core/src/agentic/persistence/manager.rs
@@ -22,7 +22,7 @@ use crate::util::errors::{BitFunError, BitFunResult};
 use log::{debug, info, warn};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
@@ -78,6 +78,23 @@ struct StoredTurnContextSnapshotFile {
     session_id: String,
     turn_index: usize,
     messages: Vec<Message>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMetadataPage {
+    pub sessions: Vec<SessionMetadata>,
+    pub total_top_level_count: usize,
+    pub loaded_top_level_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SessionMetadataPageCursor {
+    last_active_at: u64,
+    session_id: String,
 }
 
 #[derive(Debug, Default)]
@@ -1502,14 +1519,16 @@ impl PersistenceManager {
         workspace_path: &Path,
     ) -> BitFunResult<Vec<SessionMetadata>> {
         let metadata_list = self.scan_session_metadata_dirs(workspace_path).await?;
+        let metadata_file_count = metadata_list.len();
         let visible_sessions = metadata_list
             .into_iter()
             .filter(|metadata| !metadata.should_hide_from_user_lists())
             .collect::<Vec<_>>();
 
-        let index = StoredSessionIndexFile::new(
+        let index = StoredSessionIndexFile::with_metadata_file_count(
             Self::system_time_to_unix_ms(SystemTime::now()),
             visible_sessions.clone(),
+            metadata_file_count,
         );
         self.write_json_atomic(&self.index_path(workspace_path), &index)
             .await?;
@@ -1521,16 +1540,22 @@ impl PersistenceManager {
         &self,
         workspace_path: &Path,
         metadata: &SessionMetadata,
+        metadata_file_created: bool,
     ) -> BitFunResult<()> {
         let index_path = self.index_path(workspace_path);
-        let mut index = self
+        let existing_index = self
             .read_json_optional::<StoredSessionIndexFile>(&index_path)
-            .await?
-            .unwrap_or(StoredSessionIndexFile {
+            .await?;
+        let had_index = existing_index.is_some();
+        let mut index = match existing_index {
+            Some(index) => index,
+            None => StoredSessionIndexFile {
                 schema_version: SESSION_STORAGE_SCHEMA_VERSION,
                 updated_at: 0,
+                metadata_file_count: self.count_session_metadata_dirs(workspace_path).await?,
                 sessions: Vec::new(),
-            });
+            },
+        };
 
         if let Some(existing) = index
             .sessions
@@ -1545,6 +1570,9 @@ impl PersistenceManager {
         index
             .sessions
             .sort_by(|a, b| b.last_active_at.cmp(&a.last_active_at));
+        if had_index && metadata_file_created {
+            index.metadata_file_count = index.metadata_file_count.saturating_add(1);
+        }
         index.updated_at = Self::system_time_to_unix_ms(SystemTime::now());
         index.schema_version = SESSION_STORAGE_SCHEMA_VERSION;
         self.write_json_atomic(&index_path, &index).await
@@ -1554,6 +1582,7 @@ impl PersistenceManager {
         &self,
         workspace_path: &Path,
         session_id: &str,
+        metadata_file_count_delta: isize,
     ) -> BitFunResult<()> {
         let index_path = self.index_path(workspace_path);
         let Some(mut index) = self
@@ -1566,30 +1595,17 @@ impl PersistenceManager {
         index
             .sessions
             .retain(|value| value.session_id != session_id);
+        if metadata_file_count_delta > 0 {
+            index.metadata_file_count = index
+                .metadata_file_count
+                .saturating_add(metadata_file_count_delta as usize);
+        } else if metadata_file_count_delta < 0 {
+            index.metadata_file_count = index
+                .metadata_file_count
+                .saturating_sub(metadata_file_count_delta.unsigned_abs());
+        }
         index.updated_at = Self::system_time_to_unix_ms(SystemTime::now());
         self.write_json_atomic(&index_path, &index).await
-    }
-
-    async fn upsert_index_entry(
-        &self,
-        workspace_path: &Path,
-        metadata: &SessionMetadata,
-    ) -> BitFunResult<()> {
-        let lock = self.get_session_index_lock(workspace_path).await;
-        let _guard = lock.lock().await;
-        self.upsert_index_entry_locked(workspace_path, metadata)
-            .await
-    }
-
-    async fn remove_index_entry(
-        &self,
-        workspace_path: &Path,
-        session_id: &str,
-    ) -> BitFunResult<()> {
-        let lock = self.get_session_index_lock(workspace_path).await;
-        let _guard = lock.lock().await;
-        self.remove_index_entry_locked(workspace_path, session_id)
-            .await
     }
 
     pub async fn list_session_metadata(
@@ -1625,10 +1641,10 @@ impl PersistenceManager {
             }
 
             let disk_count = self.count_session_metadata_dirs(workspace_path).await?;
-            if index.sessions.len() != disk_count {
+            if index.metadata_file_count != disk_count {
                 warn!(
                     "Session index incomplete (index: {}, disk: {}), rebuilding: {}",
-                    index.sessions.len(),
+                    index.metadata_file_count,
                     disk_count,
                     index_path.display()
                 );
@@ -1639,6 +1655,211 @@ impl PersistenceManager {
         }
 
         self.rebuild_index_locked(workspace_path).await
+    }
+
+    fn session_parent_id(metadata: &SessionMetadata) -> Option<String> {
+        if let Some(parent_id) = metadata
+            .relationship
+            .as_ref()
+            .and_then(|relationship| relationship.parent_session_id.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Some(parent_id.to_string());
+        }
+
+        metadata
+            .custom_metadata
+            .as_ref()
+            .and_then(|custom| {
+                custom
+                    .get("parentSessionId")
+                    .or_else(|| custom.get("parent_session_id"))
+            })
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    }
+
+    fn session_metadata_page_offset(
+        cursor: Option<&str>,
+        top_level_sessions: &[SessionMetadata],
+    ) -> usize {
+        let Some(cursor) = cursor else {
+            return 0;
+        };
+
+        if let Ok(parsed) = serde_json::from_str::<SessionMetadataPageCursor>(cursor) {
+            if let Some(index) = top_level_sessions.iter().position(|metadata| {
+                metadata.session_id == parsed.session_id
+                    && metadata.last_active_at == parsed.last_active_at
+            }) {
+                return index + 1;
+            }
+
+            if let Some(index) = top_level_sessions
+                .iter()
+                .position(|metadata| metadata.session_id == parsed.session_id)
+            {
+                return index + 1;
+            }
+        }
+
+        cursor.parse::<usize>().unwrap_or(0)
+    }
+
+    fn session_metadata_page_cursor(metadata: &SessionMetadata) -> String {
+        serde_json::to_string(&SessionMetadataPageCursor {
+            last_active_at: metadata.last_active_at,
+            session_id: metadata.session_id.clone(),
+        })
+        .unwrap_or_else(|_| metadata.session_id.clone())
+    }
+
+    fn build_session_metadata_page(
+        indexed_sessions: Vec<SessionMetadata>,
+        cursor: Option<&str>,
+        limit: usize,
+    ) -> SessionMetadataPage {
+        let visible_sessions = indexed_sessions
+            .into_iter()
+            .filter(|metadata| {
+                !metadata.should_hide_from_user_lists()
+                    && metadata.status != SessionStatus::Archived
+            })
+            .collect::<Vec<_>>();
+        let visible_ids = visible_sessions
+            .iter()
+            .map(|metadata| metadata.session_id.clone())
+            .collect::<HashSet<_>>();
+
+        let mut top_level_sessions = Vec::new();
+        let mut children_by_parent: HashMap<String, Vec<SessionMetadata>> = HashMap::new();
+        for metadata in visible_sessions {
+            if let Some(parent_id) = Self::session_parent_id(&metadata) {
+                if visible_ids.contains(&parent_id) {
+                    children_by_parent
+                        .entry(parent_id)
+                        .or_default()
+                        .push(metadata);
+                    continue;
+                }
+            }
+
+            top_level_sessions.push(metadata);
+        }
+
+        let total_top_level_count = top_level_sessions.len();
+        let offset = Self::session_metadata_page_offset(cursor, &top_level_sessions);
+        let offset = offset.min(total_top_level_count);
+        let next_offset = offset.saturating_add(limit).min(total_top_level_count);
+        let selected_top_level = top_level_sessions
+            .iter()
+            .skip(offset)
+            .take(limit)
+            .cloned()
+            .collect::<Vec<_>>();
+        let loaded_top_level_count = selected_top_level.len();
+        let has_more = next_offset < total_top_level_count;
+        let next_cursor = has_more
+            .then(|| {
+                selected_top_level
+                    .last()
+                    .map(Self::session_metadata_page_cursor)
+            })
+            .flatten();
+
+        let mut sessions = Vec::new();
+        for metadata in selected_top_level {
+            let session_id = metadata.session_id.clone();
+            sessions.push(metadata);
+
+            if let Some(mut children) = children_by_parent.remove(&session_id) {
+                children.sort_by(|a, b| b.last_active_at.cmp(&a.last_active_at));
+                sessions.extend(children);
+            }
+        }
+
+        SessionMetadataPage {
+            sessions,
+            total_top_level_count,
+            loaded_top_level_count,
+            next_cursor,
+            has_more,
+        }
+    }
+
+    pub async fn list_session_metadata_page(
+        &self,
+        workspace_path: &Path,
+        cursor: Option<&str>,
+        limit: usize,
+    ) -> BitFunResult<SessionMetadataPage> {
+        if !workspace_path.exists() {
+            return Ok(SessionMetadataPage {
+                sessions: Vec::new(),
+                total_top_level_count: 0,
+                loaded_top_level_count: 0,
+                next_cursor: None,
+                has_more: false,
+            });
+        }
+
+        if self.existing_project_sessions_dir(workspace_path).is_none() {
+            return Ok(SessionMetadataPage {
+                sessions: Vec::new(),
+                total_top_level_count: 0,
+                loaded_top_level_count: 0,
+                next_cursor: None,
+                has_more: false,
+            });
+        }
+
+        let limit = limit.max(1);
+
+        let lock = self.get_session_index_lock(workspace_path).await;
+        let _guard = lock.lock().await;
+        let index_path = self.index_path(workspace_path);
+        let indexed_sessions = if let Some(index) = self
+            .read_json_optional::<StoredSessionIndexFile>(&index_path)
+            .await?
+        {
+            if index.metadata_file_count < index.sessions.len() {
+                warn!(
+                    "Session index has invalid metadata count before page read (index: {}, sessions: {}), rebuilding: {}",
+                    index.metadata_file_count,
+                    index.sessions.len(),
+                    index_path.display()
+                );
+                self.rebuild_index_locked(workspace_path).await?
+            } else {
+                index.sessions
+            }
+        } else {
+            self.rebuild_index_locked(workspace_path).await?
+        };
+
+        let page = Self::build_session_metadata_page(indexed_sessions, cursor, limit);
+        let has_stale_page_entry = page.sessions.iter().any(|metadata| {
+            !self
+                .metadata_path(workspace_path, &metadata.session_id)
+                .exists()
+        });
+        if !has_stale_page_entry {
+            return Ok(page);
+        }
+
+        warn!(
+            "Session index page contains stale entries, rebuilding before page read: {}",
+            index_path.display()
+        );
+        let rebuilt_sessions = self.rebuild_index_locked(workspace_path).await?;
+        Ok(Self::build_session_metadata_page(
+            rebuilt_sessions,
+            cursor,
+            limit,
+        ))
     }
 
     pub async fn list_session_metadata_including_internal(
@@ -1664,19 +1885,23 @@ impl PersistenceManager {
         self.ensure_runtime_for_write(workspace_path).await?;
         self.ensure_session_dir(workspace_path, &metadata.session_id)
             .await?;
-
+        let metadata_path = self.metadata_path(workspace_path, &metadata.session_id);
         let file = StoredSessionMetadataFile::new(metadata.clone());
 
-        self.write_json_atomic(
-            &self.metadata_path(workspace_path, &metadata.session_id),
-            &file,
-        )
-        .await?;
+        let lock = self.get_session_index_lock(workspace_path).await;
+        let _guard = lock.lock().await;
+        let metadata_file_created = !metadata_path.exists();
+        self.write_json_atomic(&metadata_path, &file).await?;
         if !metadata.should_hide_from_user_lists() {
-            self.upsert_index_entry(workspace_path, metadata).await
-        } else {
-            self.remove_index_entry(workspace_path, &metadata.session_id)
+            self.upsert_index_entry_locked(workspace_path, metadata, metadata_file_created)
                 .await
+        } else {
+            self.remove_index_entry_locked(
+                workspace_path,
+                &metadata.session_id,
+                if metadata_file_created { 1 } else { 0 },
+            )
+            .await
         }
     }
 
@@ -2071,14 +2296,22 @@ impl PersistenceManager {
         workspace_path: &Path,
         session_id: &str,
     ) -> BitFunResult<()> {
+        let lock = self.get_session_index_lock(workspace_path).await;
+        let _guard = lock.lock().await;
         let dir = self.session_dir(workspace_path, session_id);
+        let metadata_file_removed = self.metadata_path(workspace_path, session_id).exists();
         if dir.exists() {
             fs::remove_dir_all(&dir).await.map_err(|e| {
                 BitFunError::io(format!("Failed to delete session directory: {}", e))
             })?;
         }
 
-        self.remove_index_entry(workspace_path, session_id).await?;
+        self.remove_index_entry_locked(
+            workspace_path,
+            session_id,
+            if metadata_file_removed { -1 } else { 0 },
+        )
+        .await?;
         info!("Session deleted: session_id={}", session_id);
         Ok(())
     }
@@ -2728,11 +2961,13 @@ mod tests {
     use crate::agentic::core::{Message, Session, SessionConfig, SessionKind, ToolResult};
     use crate::infrastructure::PathManager;
     use crate::service::session::{
-        DialogTurnData, ModelRoundData, SessionMetadata, SessionTranscriptExportOptions,
+        DialogTurnData, ModelRoundData, SessionMetadata, SessionRelationship,
+        SessionRelationshipKind, SessionTranscriptExportOptions, StoredSessionIndexFile,
         TextItemData, UserMessageData,
     };
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
+    use std::time::Instant;
     use uuid::Uuid;
 
     struct TestWorkspace {
@@ -3216,6 +3451,211 @@ mod tests {
         assert!(
             !manager.project_sessions_dir(workspace.path()).exists(),
             "listing sessions should not create the runtime sessions directory"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_session_metadata_page_returns_visible_top_level_page_with_children() {
+        let workspace = TestWorkspace::new();
+        let manager =
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager");
+
+        for index in 0..12 {
+            let mut metadata = SessionMetadata::new(
+                format!("parent-{index}"),
+                format!("Parent {index}"),
+                "agent".to_string(),
+                "model".to_string(),
+            );
+            metadata.last_active_at = 1_000 + index;
+            manager
+                .save_session_metadata(workspace.path(), &metadata)
+                .await
+                .expect("parent metadata should save");
+        }
+
+        let mut child = SessionMetadata::new(
+            "child-latest".to_string(),
+            "Child latest".to_string(),
+            "agent".to_string(),
+            "model".to_string(),
+        );
+        child.last_active_at = 2_000;
+        child.relationship = Some(SessionRelationship {
+            kind: Some(SessionRelationshipKind::Btw),
+            parent_session_id: Some("parent-11".to_string()),
+            ..Default::default()
+        });
+        manager
+            .save_session_metadata(workspace.path(), &child)
+            .await
+            .expect("child metadata should save");
+
+        let page = manager
+            .list_session_metadata_page(workspace.path(), None, 5)
+            .await
+            .expect("session metadata page should load");
+        let session_ids = page
+            .sessions
+            .iter()
+            .map(|metadata| metadata.session_id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(page.total_top_level_count, 12);
+        assert_eq!(page.loaded_top_level_count, 5);
+        assert!(page.next_cursor.is_some());
+        assert!(page.has_more);
+        assert_eq!(
+            session_ids,
+            vec![
+                "parent-11",
+                "child-latest",
+                "parent-10",
+                "parent-9",
+                "parent-8",
+                "parent-7",
+            ]
+        );
+
+        let second_page = manager
+            .list_session_metadata_page(workspace.path(), page.next_cursor.as_deref(), 5)
+            .await
+            .expect("second session metadata page should load");
+        let second_page_session_ids = second_page
+            .sessions
+            .iter()
+            .map(|metadata| metadata.session_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(second_page.loaded_top_level_count, 5);
+        assert_eq!(
+            second_page_session_ids,
+            vec!["parent-6", "parent-5", "parent-4", "parent-3", "parent-2"]
+        );
+    }
+
+    #[tokio::test]
+    async fn list_session_metadata_page_rebuilds_stale_visible_page_entry() {
+        let workspace = TestWorkspace::new();
+        let manager =
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager");
+
+        let mut older = SessionMetadata::new(
+            "older-session".to_string(),
+            "Older session".to_string(),
+            "agent".to_string(),
+            "model".to_string(),
+        );
+        older.last_active_at = 1_000;
+        let mut newer = SessionMetadata::new(
+            "newer-session".to_string(),
+            "Newer session".to_string(),
+            "agent".to_string(),
+            "model".to_string(),
+        );
+        newer.last_active_at = 2_000;
+
+        manager
+            .save_session_metadata(workspace.path(), &older)
+            .await
+            .expect("older metadata should save");
+        manager
+            .save_session_metadata(workspace.path(), &newer)
+            .await
+            .expect("newer metadata should save");
+
+        let mut missing = SessionMetadata::new(
+            "missing-session".to_string(),
+            "Missing session".to_string(),
+            "agent".to_string(),
+            "model".to_string(),
+        );
+        missing.last_active_at = 3_000;
+
+        let stale_index = StoredSessionIndexFile::new(0, vec![missing, older]);
+        manager
+            .write_json_atomic(&manager.index_path(workspace.path()), &stale_index)
+            .await
+            .expect("stale index should be written");
+
+        let page = manager
+            .list_session_metadata_page(workspace.path(), None, 5)
+            .await
+            .expect("session metadata page should rebuild stale index");
+        let session_ids = page
+            .sessions
+            .iter()
+            .map(|metadata| metadata.session_id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(page.total_top_level_count, 2);
+        assert_eq!(session_ids, vec!["newer-session", "older-session"]);
+    }
+
+    #[tokio::test]
+    #[ignore = "local performance benchmark; prints timing data only"]
+    async fn bench_session_metadata_page_vs_full_list() {
+        const SESSION_COUNT: usize = 1_000;
+        const ITERATIONS: usize = 10;
+
+        let workspace = TestWorkspace::new();
+        let manager =
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager");
+
+        for index in 0..SESSION_COUNT {
+            let mut metadata = SessionMetadata::new(
+                format!("bench-parent-{index}"),
+                format!("Bench parent {index}"),
+                "agent".to_string(),
+                "model".to_string(),
+            );
+            metadata.last_active_at = 1_000_000 + index as u64;
+            manager
+                .save_session_metadata(workspace.path(), &metadata)
+                .await
+                .expect("benchmark metadata should save");
+        }
+
+        manager
+            .list_session_metadata(workspace.path())
+            .await
+            .expect("warm full list should load");
+        manager
+            .list_session_metadata_page(workspace.path(), None, 5)
+            .await
+            .expect("warm page should load");
+
+        let mut full_list_total_ms = 0.0;
+        for _ in 0..ITERATIONS {
+            let started = Instant::now();
+            let full = manager
+                .list_session_metadata(workspace.path())
+                .await
+                .expect("full list should load");
+            assert_eq!(full.len(), SESSION_COUNT);
+            full_list_total_ms += started.elapsed().as_secs_f64() * 1000.0;
+        }
+
+        let mut page_total_ms = 0.0;
+        for _ in 0..ITERATIONS {
+            let started = Instant::now();
+            let page = manager
+                .list_session_metadata_page(workspace.path(), None, 5)
+                .await
+                .expect("page should load");
+            assert_eq!(page.loaded_top_level_count, 5);
+            assert_eq!(page.total_top_level_count, SESSION_COUNT);
+            page_total_ms += started.elapsed().as_secs_f64() * 1000.0;
+        }
+
+        let full_avg_ms = full_list_total_ms / ITERATIONS as f64;
+        let page_avg_ms = page_total_ms / ITERATIONS as f64;
+        println!(
+            "session_metadata_bench sessions={} iterations={} full_list_avg_ms={:.3} page5_avg_ms={:.3} speedup={:.1}x",
+            SESSION_COUNT,
+            ITERATIONS,
+            full_avg_ms,
+            page_avg_ms,
+            full_avg_ms / page_avg_ms.max(0.001)
         );
     }
 

--- a/src/crates/core/src/agentic/persistence/mod.rs
+++ b/src/crates/core/src/agentic/persistence/mod.rs
@@ -5,5 +5,5 @@
 pub mod manager;
 pub mod session_branch;
 
-pub use manager::PersistenceManager;
+pub use manager::{PersistenceManager, SessionMetadataPage};
 pub use session_branch::{SessionBranchRequest, SessionBranchResult};

--- a/src/crates/services-core/src/session/types.rs
+++ b/src/crates/services-core/src/session/types.rs
@@ -259,14 +259,26 @@ impl StoredSessionMetadataFile {
 pub struct StoredSessionIndexFile {
     pub schema_version: u32,
     pub updated_at: u64,
+    #[serde(default)]
+    pub metadata_file_count: usize,
     pub sessions: Vec<SessionMetadata>,
 }
 
 impl StoredSessionIndexFile {
     pub fn new(updated_at: u64, sessions: Vec<SessionMetadata>) -> Self {
+        let metadata_file_count = sessions.len();
+        Self::with_metadata_file_count(updated_at, sessions, metadata_file_count)
+    }
+
+    pub fn with_metadata_file_count(
+        updated_at: u64,
+        sessions: Vec<SessionMetadata>,
+        metadata_file_count: usize,
+    ) -> Self {
         Self {
             schema_version: SESSION_STORAGE_SCHEMA_VERSION,
             updated_at,
+            metadata_file_count,
             sessions,
         }
     }

--- a/src/web-ui/index.html
+++ b/src/web-ui/index.html
@@ -12,8 +12,8 @@
         /* Keep in sync with presets/light-theme.ts colors.background.primary */
         var light = '#f3f3f5';
         var m = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
-        var bg = m && m.matches ? dark : light;
         var root = document.documentElement;
+        var bg = root.style.backgroundColor || (m && m.matches ? dark : light);
         root.style.backgroundColor = bg;
         function paintBody() {
           if (document.body) document.body.style.backgroundColor = bg;
@@ -51,6 +51,11 @@
       
       body {
         background-color: inherit;
+      }
+
+      #root {
+        width: 100%;
+        height: 100%;
       }
     </style>
   </head>

--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -18,12 +18,14 @@ import { syncAgentCompanionDesktopWindow } from '@/infrastructure/config/service
 import { isTauriRuntime } from '@/infrastructure/runtime';
 import { buildAgentCompanionActivity, subscribeAgentCompanionActivity } from '@/flow_chat/utils/agentCompanionActivity';
 import { emitAgentCompanionActivity } from '@/flow_chat/services/AgentCompanionActivityBridge';
+import { BackgroundTaskCancelledError } from '@/shared/utils/backgroundTaskScheduler';
 import { useWorkspaceContext } from '../infrastructure/contexts/WorkspaceContext';
 import SplashScreen from './components/SplashScreen/SplashScreen';
 import { useGlobalSceneShortcuts } from './hooks/useGlobalSceneShortcuts';
 import { useDebugInspector } from '@/infrastructure/debug/useDebugInspector';
 import { openAgentCompanionSession } from './services/openAgentCompanionSession';
 import { useI18n } from '@/infrastructure/i18n';
+import { scheduleDeferredStartupSystems } from './startup/deferredStartupSystems';
 
 // Toolbar Mode
 import { ToolbarModeProvider } from '../flow_chat';
@@ -85,6 +87,7 @@ function App() {
       await invoke('show_main_window');
       log.debug('Main window shown', { reason });
       startupTrace.markPhase('main_window_shown', { reason });
+      window.dispatchEvent(new CustomEvent('bitfun:main-window-shown', { detail: { reason } }));
     } catch (error: any) {
       log.error('Failed to show main window', error);
 
@@ -95,6 +98,7 @@ function App() {
         await mainWindow.setFocus();
         log.debug('Main window shown via fallback', { reason });
         startupTrace.markPhase('main_window_shown_fallback', { reason });
+        window.dispatchEvent(new CustomEvent('bitfun:main-window-shown', { detail: { reason } }));
       } catch (fallbackError) {
         log.error('Fallback window show failed', fallbackError);
         mainWindowShownRef.current = false;
@@ -102,11 +106,39 @@ function App() {
     }
   }, []);
 
-  // Reveal the native window as soon as React has painted a frame.
-  // The splash still covers the UI, so users see immediate feedback instead
-  // of waiting on a hidden window while startup continues in the background.
+  const verifyMainWindowVisible = useCallback(async (reason: string) => {
+    if (!isTauriRuntime()) {
+      void showMainWindow(reason);
+      return;
+    }
+
+    try {
+      const { getCurrentWindow } = await import('@tauri-apps/api/window');
+      const mainWindow = getCurrentWindow();
+      if (await mainWindow.isVisible()) {
+        return;
+      }
+
+      log.warn('Main window is not visible after native startup show, retrying', { reason });
+      mainWindowShownRef.current = false;
+      await showMainWindow(reason);
+    } catch (error) {
+      log.warn('Failed to verify main window visibility after native startup show', { reason, error });
+    }
+  }, [showMainWindow]);
+
+  // Desktop shows the startup splash from the native window creation path.
+  // Mark it here so deferred work can wait until the first visible shell exists.
   useEffect(() => {
     startupTrace.markPhase('app_effect_mounted');
+    if (isTauriRuntime()) {
+      mainWindowShownRef.current = true;
+      startupTrace.markPhase('main_window_shown', { reason: 'startup-native' });
+      window.dispatchEvent(new CustomEvent('bitfun:main-window-shown', {
+        detail: { reason: 'startup-native' },
+      }));
+      return;
+    }
     void showMainWindow('startup-overlay');
   }, [showMainWindow]);
 
@@ -126,69 +158,37 @@ function App() {
     }
 
     const timer = window.setTimeout(() => {
-      void showMainWindow('startup-complete');
+      void verifyMainWindowVisible('startup-complete');
     }, 50);
 
     return () => window.clearTimeout(timer);
-  }, [showMainWindow, splashVisible]);
+  }, [splashVisible, verifyMainWindowVisible]);
 
   // Safety net: if startup gets stuck, reveal the window so the user can see errors.
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      void showMainWindow('startup-watchdog');
+      void verifyMainWindowVisible('startup-watchdog');
     }, 10000);
 
     return () => window.clearTimeout(timer);
-  }, [showMainWindow]);
+  }, [verifyMainWindowVisible]);
 
-  // Startup logs and initialization
+  // Non-critical systems are delayed until the shell is interactive.
   useEffect(() => {
-    log.info('Application started, initializing systems');
-    
-    // Initialize IDE control system
-    const initIdeControl = async () => {
-      try {
-        const { initializeIdeControl } = await import('../shared/services/ide-control');
-        await initializeIdeControl();
-        log.debug('IDE control system initialized');
-      } catch (error) {
-        log.error('Failed to initialize IDE control system', error);
-      }
-    };
-    
-    // Initialize MCP servers
-    const initMCPServers = async () => {
-      try {
-        const { MCPAPI } = await import('../infrastructure/api/service-api/MCPAPI');
-        await MCPAPI.initializeServers();
-        log.debug('MCP servers initialized');
-      } catch (error) {
-        log.error('Failed to initialize MCP servers', error);
-      }
-    };
+    if (!interactiveShellReady) {
+      return;
+    }
 
-    const initACPClients = async () => {
-      try {
-        const { ACPClientAPI } = await import('../infrastructure/api/service-api/ACPClientAPI');
-        await ACPClientAPI.initializeClients();
-        log.debug('ACP clients initialized');
-        void ACPClientAPI.probeClientRequirements()
-          .then(() => {
-            log.debug('ACP client requirements probed');
-          })
-          .catch((error) => {
-            log.warn('Failed to probe ACP client requirements during startup', error);
-          });
-      } catch (error) {
-        log.error('Failed to initialize ACP clients', error);
+    log.info('Application interactive, scheduling deferred systems');
+    const startupSystemsHandle = scheduleDeferredStartupSystems();
+    startupSystemsHandle.promise.catch(error => {
+      if (!(error instanceof BackgroundTaskCancelledError)) {
+        log.warn('Deferred startup systems task failed', error);
       }
-    };
+    });
 
-    initIdeControl();
-    initMCPServers();
-    initACPClients();
-    
-  }, []);
+    return () => startupSystemsHandle.cancel();
+  }, [interactiveShellReady]);
 
   useEffect(() => {
     if (!isTauriRuntime() || !interactiveShellReady) return;

--- a/src/web-ui/src/app/components/NavPanel/MainNav.tsx
+++ b/src/web-ui/src/app/components/NavPanel/MainNav.tsx
@@ -26,7 +26,6 @@ import SessionsSection from './sections/sessions/SessionsSection';
 import { useSceneStore } from '../../stores/sceneStore';
 import { useMyAgentStore } from '../../scenes/my-agent/myAgentStore';
 import { useMiniAppCatalogSync } from '../../scenes/miniapps/hooks/useMiniAppCatalogSync';
-import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
 import { flowChatManager } from '@/flow_chat/services/FlowChatManager';
 import { workspaceManager } from '@/infrastructure/services/business/workspaceManager';
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
@@ -61,8 +60,6 @@ const MainNav: React.FC<MainNavProps> = ({
   isDeparting: _isDeparting = false,
   anchorNavSceneId: _anchorNavSceneId = null,
 }) => {
-  useMiniAppCatalogSync();
-
   const sshRemote = useSSHRemoteContext();
   const [isSSHConnectionDialogOpen, setIsSSHConnectionDialogOpen] = useState(false);
 
@@ -79,6 +76,7 @@ const MainNav: React.FC<MainNavProps> = ({
   const { t } = useI18n('common');
   const {
     currentWorkspace,
+    loading: workspaceLoading,
     recentWorkspaces,
     openedWorkspacesList,
     assistantWorkspacesList,
@@ -86,6 +84,11 @@ const MainNav: React.FC<MainNavProps> = ({
     switchWorkspace,
     setActiveWorkspace,
   } = useWorkspaceContext();
+
+  useMiniAppCatalogSync({
+    enabled: !workspaceLoading,
+    initialLoad: 'idle',
+  });
 
   const activeMiniAppId = useMemo(
     () => (typeof activeTabId === 'string' && activeTabId.startsWith('miniapp:') ? activeTabId.slice('miniapp:'.length) : null),
@@ -170,26 +173,6 @@ const MainNav: React.FC<MainNavProps> = ({
     () => assistantWorkspacesList.find(w => !w.assistantId) ?? assistantWorkspacesList[0] ?? null,
     [assistantWorkspacesList]
   );
-
-  useEffect(() => {
-    openedWorkspacesList.forEach(workspace => {
-      if (workspace.workspaceKind === WorkspaceKind.Remote) {
-        void flowChatStore.initializeFromDisk(
-          workspace.rootPath,
-          workspace.connectionId ?? undefined,
-          workspace.sshHost ?? undefined,
-          'main_nav_opened_remote_workspace'
-        );
-      } else {
-        void flowChatStore.initializeFromDisk(
-          workspace.rootPath,
-          undefined,
-          undefined,
-          'main_nav_opened_local_workspace'
-        );
-      }
-    });
-  }, [openedWorkspacesList]);
 
   const toggleNavSearch = useCallback(() => {
     setSearchOpen((v) => !v);
@@ -632,6 +615,7 @@ const MainNav: React.FC<MainNavProps> = ({
                       remoteConnectionId={isRemoteWorkspace(workspace) ? workspace.connectionId : null}
                       isActiveWorkspace={workspace.id === currentWorkspace?.id}
                       assistantLabel={assistantDisplayName}
+                      isVisible={expandedSections.has('assistant-sessions')}
                     />
                   );
                 })}

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
@@ -57,6 +57,29 @@
     font-style: italic;
   }
 
+  &__inline-loading {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    min-width: 0;
+    height: 24px;
+    padding: 0 $size-gap-1;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-2xs);
+
+    svg {
+      flex: 0 0 auto;
+      animation: bitfun-nav-session-spin 1s linear infinite;
+    }
+
+    span {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
   &__inline-item {
     display: flex;
     align-items: center;
@@ -505,6 +528,20 @@
       color: var(--color-text-primary);
       background: var(--element-bg-soft);
     }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.72;
+    }
+
+    &.is-loading {
+      color: var(--color-text-secondary);
+    }
+  }
+
+  &__inline-toggle-spinner {
+    flex: 0 0 auto;
+    animation: bitfun-nav-session-spin 1s linear infinite;
   }
 
   &__inline-toggle-dots {

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -101,6 +101,8 @@ interface SessionsSectionProps {
   assistantLabel?: string;
   /** When false, hide the leading mode / running icon on each row (e.g. assistant detail page). */
   showSessionModeIcon?: boolean;
+  /** Prevents startup metadata fetching while the surrounding section is collapsed. */
+  isVisible?: boolean;
 }
 
 const SessionsSection: React.FC<SessionsSectionProps> = ({
@@ -111,6 +113,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   isActiveWorkspace: _isActiveWorkspace = true,
   assistantLabel,
   showSessionModeIcon = true,
+  isVisible = true,
 }) => {
   const { t } = useI18n('common');
   const { setActiveWorkspace, currentWorkspace } = useWorkspaceContext();
@@ -125,12 +128,24 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
   const [expandLevel, setExpandLevel] = useState<0 | 1 | 2>(0);
+  const [metadataPageState, setMetadataPageState] = useState<{
+    totalTopLevelCount: number | null;
+    nextCursor?: string;
+    hasMore: boolean;
+    isLoading: boolean;
+  }>({
+    totalTopLevelCount: null,
+    nextCursor: undefined,
+    hasMore: false,
+    isLoading: false,
+  });
   const [openMenuSessionId, setOpenMenuSessionId] = useState<string | null>(null);
   const [sessionMenuPosition, setSessionMenuPosition] = useState<{ top: number; left: number } | null>(null);
   const [runningSessionIds, setRunningSessionIds] = useState<Set<string>>(new Set());
   const editInputRef = useRef<HTMLInputElement>(null);
   const sessionMenuPopoverRef = useRef<HTMLDivElement>(null);
   const sessionMenuAnchorRef = useRef<HTMLButtonElement>(null);
+  const metadataLoadRequestIdRef = useRef(0);
 
   // Subscribe to state machine changes for running status
   useEffect(() => {
@@ -169,8 +184,62 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   }, [editingSessionId]);
 
   useEffect(() => {
+    metadataLoadRequestIdRef.current += 1;
     setExpandLevel(0);
+    setMetadataPageState({
+      totalTopLevelCount: null,
+      nextCursor: undefined,
+      hasMore: false,
+      isLoading: false,
+    });
   }, [workspaceId, workspacePath, remoteConnectionId, remoteSshHost]);
+
+  const loadMetadataPage = useCallback(
+    async (limit: number, cursor: string | undefined, source: string) => {
+      if (!workspacePath || limit <= 0) {
+        return null;
+      }
+
+      const requestId = metadataLoadRequestIdRef.current + 1;
+      metadataLoadRequestIdRef.current = requestId;
+      setMetadataPageState(prev => ({ ...prev, isLoading: true }));
+
+      try {
+        const page = await flowChatStore.loadSessionMetadataPage(
+          workspacePath,
+          limit,
+          cursor,
+          remoteConnectionId || undefined,
+          remoteSshHost || undefined,
+          source
+        );
+        if (metadataLoadRequestIdRef.current === requestId) {
+          setMetadataPageState({
+            totalTopLevelCount: page.totalTopLevelCount,
+            nextCursor: page.nextCursor,
+            hasMore: page.hasMore,
+            isLoading: false,
+          });
+        }
+        return page;
+      } catch (error) {
+        if (metadataLoadRequestIdRef.current === requestId) {
+          setMetadataPageState(prev => ({ ...prev, isLoading: false }));
+        }
+        log.warn('Failed to load visible session metadata page', { error, workspacePath, cursor, limit });
+        return null;
+      }
+    },
+    [workspacePath, remoteConnectionId, remoteSshHost]
+  );
+
+  useEffect(() => {
+    if (!isVisible || !workspacePath) {
+      return;
+    }
+
+    void loadMetadataPage(SESSIONS_LEVEL_0, undefined, 'sessions_nav_initial');
+  }, [isVisible, workspacePath, remoteConnectionId, remoteSshHost, loadMetadataPage]);
 
   useEffect(() => {
     if (!openMenuSessionId) return;
@@ -288,6 +357,10 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
     if (expandLevel === 1) return Math.min(total, SESSIONS_LEVEL_1);
     return SESSIONS_LEVEL_0;
   }, [topLevelSessions.length, expandLevel]);
+
+  const totalTopLevelSessionCount = metadataPageState.totalTopLevelCount ?? topLevelSessions.length;
+  const hasMoreUnloadedSessions =
+    metadataPageState.hasMore || topLevelSessions.length < totalTopLevelSessionCount;
 
   const visibleItems = useMemo(() => {
     const visibleParents = topLevelSessions.slice(0, sessionDisplayLimit);
@@ -476,7 +549,69 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
     [handleConfirmEdit, handleCancelEdit]
   );
 
+  const handleExpandToggle = useCallback(async () => {
+    if (metadataPageState.isLoading) {
+      return;
+    }
+
+    const loadedTopLevelCount = topLevelSessions.length;
+    const total = totalTopLevelSessionCount;
+
+    if (expandLevel === 0) {
+      const targetCount = Math.min(total, SESSIONS_LEVEL_1);
+      if (
+        loadedTopLevelCount < targetCount &&
+        hasMoreUnloadedSessions &&
+        metadataPageState.nextCursor
+      ) {
+        await loadMetadataPage(
+          targetCount - loadedTopLevelCount,
+          metadataPageState.nextCursor,
+          'sessions_nav_expand_level_1'
+        );
+      }
+      setExpandLevel(1);
+      return;
+    }
+
+    if (expandLevel === 1 && total > SESSIONS_LEVEL_1) {
+      if (
+        loadedTopLevelCount < total &&
+        hasMoreUnloadedSessions &&
+        metadataPageState.nextCursor
+      ) {
+        await loadMetadataPage(
+          total - loadedTopLevelCount,
+          metadataPageState.nextCursor,
+          'sessions_nav_expand_all'
+        );
+      }
+      setExpandLevel(2);
+      return;
+    }
+
+    setExpandLevel(0);
+  }, [
+    expandLevel,
+    hasMoreUnloadedSessions,
+    loadMetadataPage,
+    metadataPageState.isLoading,
+    metadataPageState.nextCursor,
+    topLevelSessions.length,
+    totalTopLevelSessionCount,
+  ]);
+
   if (topLevelSessions.length === 0) {
+    if (metadataPageState.isLoading) {
+      return (
+        <div className="bitfun-nav-panel__inline-list">
+          <div className="bitfun-nav-panel__inline-loading">
+            <Loader2 size={12} />
+            <span>{t('nav.sessions.loading', { defaultValue: 'Loading sessions...' })}</span>
+          </div>
+        </div>
+      );
+    }
     return null;
   }
 
@@ -730,38 +865,36 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
           );
         })}
 
-      {topLevelSessions.length > SESSIONS_LEVEL_0 && (
+      {(totalTopLevelSessionCount > SESSIONS_LEVEL_0 || hasMoreUnloadedSessions) && (
         <button
           type="button"
-          className="bitfun-nav-panel__inline-toggle"
-          onClick={() => {
-            const total = topLevelSessions.length;
-            if (expandLevel === 0) {
-              setExpandLevel(1);
-              return;
-            }
-            if (expandLevel === 1 && total > SESSIONS_LEVEL_1) {
-              setExpandLevel(2);
-              return;
-            }
-            setExpandLevel(0);
-          }}
+          className={`bitfun-nav-panel__inline-toggle${metadataPageState.isLoading ? ' is-loading' : ''}`}
+          disabled={metadataPageState.isLoading}
+          onClick={() => { void handleExpandToggle(); }}
         >
           {expandLevel === 0 ? (
             <>
-              <span className="bitfun-nav-panel__inline-toggle-dots">···</span>
+              {metadataPageState.isLoading ? (
+                <Loader2 size={12} className="bitfun-nav-panel__inline-toggle-spinner" />
+              ) : (
+                <span className="bitfun-nav-panel__inline-toggle-dots">···</span>
+              )}
               <span>
                 {t('nav.sessions.showMore', {
-                  count: topLevelSessions.length - SESSIONS_LEVEL_0,
+                  count: Math.max(totalTopLevelSessionCount - SESSIONS_LEVEL_0, 0),
                 })}
               </span>
             </>
-          ) : expandLevel === 1 && topLevelSessions.length > SESSIONS_LEVEL_1 ? (
+          ) : expandLevel === 1 && totalTopLevelSessionCount > SESSIONS_LEVEL_1 ? (
             <>
-              <span className="bitfun-nav-panel__inline-toggle-dots">···</span>
+              {metadataPageState.isLoading ? (
+                <Loader2 size={12} className="bitfun-nav-panel__inline-toggle-spinner" />
+              ) : (
+                <span className="bitfun-nav-panel__inline-toggle-dots">···</span>
+              )}
               <span>
                 {t('nav.sessions.showAll', {
-                  count: topLevelSessions.length - SESSIONS_LEVEL_1,
+                  count: Math.max(totalTopLevelSessionCount - SESSIONS_LEVEL_1, 0),
                 })}
               </span>
             </>

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Folder, FolderOpen, MoreHorizontal, FolderSearch, Plus, ChevronDown, Trash2, RotateCcw, Copy, FileText, GitBranch, Bot, Link2, Archive } from 'lucide-react';
+import { Folder, FolderOpen, MoreHorizontal, FolderSearch, Plus, ChevronDown, Trash2, RotateCcw, Copy, FileText, GitBranch, Bot, Link2, Archive, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { DotMatrixArrowRightIcon } from './DotMatrixArrowRightIcon';
 import { Button, ConfirmDialog, Modal, Tooltip } from '@/component-library';
@@ -91,6 +91,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
     () => aiExperienceConfigService.getSettings().enable_workspace_search,
   );
   const [acpClients, setAcpClients] = useState<AcpClientInfo[]>([]);
+  const [acpClientsLoading, setAcpClientsLoading] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuAnchorRef = useRef<HTMLDivElement>(null);
   const menuPopoverRef = useRef<HTMLDivElement>(null);
@@ -316,10 +317,16 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
   }, [menuOpen, updateMenuPosition]);
 
   useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+
     let cancelled = false;
     const remoteWorkspace = isRemoteWorkspace(workspace);
 
     const loadAcpClients = async () => {
+      setAcpClients([]);
+      setAcpClientsLoading(true);
       try {
         const clients = await loadWorkspaceAcpMenuClients({
           remoteWorkspace,
@@ -329,7 +336,13 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
           setAcpClients(clients);
         }
       } catch (_error) {
-        setAcpClients([]);
+        if (!cancelled) {
+          setAcpClients([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setAcpClientsLoading(false);
+        }
       }
     };
 
@@ -341,7 +354,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
       window.removeEventListener('bitfun:acp-clients-changed', loadAcpClients);
       window.removeEventListener('bitfun:acp-requirements-changed', loadAcpClients);
     };
-  }, [workspace]);
+  }, [menuOpen, workspace]);
 
   const handleActivate = useCallback(async () => {
     if (!isActive) {
@@ -825,6 +838,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
             remoteSshHost={isRemoteWorkspace(workspace) ? workspace.sshHost : null}
             isActiveWorkspace={isActive}
             assistantLabel={workspaceDisplayName}
+            isVisible={!sessionsCollapsed}
           />
         </div>
 
@@ -1091,6 +1105,16 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
                     </button>
                   );
                 })}
+                {acpClientsLoading ? (
+                  <button
+                    type="button"
+                    className="bitfun-nav-panel__workspace-item-menu-item"
+                    disabled
+                  >
+                    <Loader2 size={13} />
+                    <span className="bitfun-nav-panel__workspace-item-menu-label">{t('app.loading')}</span>
+                  </button>
+                ) : null}
                 <button type="button" className="bitfun-nav-panel__workspace-item-menu-item" onClick={() => { void handleCreateInitSession(); }}>
                   <FileText size={13} />
                   <span className="bitfun-nav-panel__workspace-item-menu-label">{t('nav.workspaces.actions.initAgents')}</span>
@@ -1178,6 +1202,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
           remoteConnectionId={isRemoteWorkspace(workspace) ? workspace.connectionId : null}
           remoteSshHost={isRemoteWorkspace(workspace) ? workspace.sshHost : null}
           isActiveWorkspace={isActive}
+          isVisible={!sessionsCollapsed}
         />
       </div>
 

--- a/src/web-ui/src/app/scenes/miniapps/hooks/miniAppCatalogStartupRefresh.test.ts
+++ b/src/web-ui/src/app/scenes/miniapps/hooks/miniAppCatalogStartupRefresh.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { scheduleMiniAppCatalogStartupRefresh } from './miniAppCatalogStartupRefresh';
+
+describe('scheduleMiniAppCatalogStartupRefresh', () => {
+  it('defers the initial Mini App catalog refresh to idle work', async () => {
+    let scheduledTask: ((signal: AbortSignal) => Promise<void>) | null = null;
+    const schedule = vi.fn((task: (signal: AbortSignal) => Promise<void>, options) => {
+      scheduledTask = task;
+      return {
+        promise: Promise.resolve(),
+        cancel: vi.fn(),
+      };
+    });
+    const refreshApps = vi.fn(async () => undefined);
+    const refreshRunningWorkers = vi.fn(async () => undefined);
+
+    scheduleMiniAppCatalogStartupRefresh({
+      scheduler: { schedule },
+      refreshApps,
+      refreshRunningWorkers,
+    });
+
+    expect(schedule).toHaveBeenCalledTimes(1);
+    expect(schedule.mock.calls[0][1]).toMatchObject({
+      idle: true,
+      priority: 'low',
+      inFlightKey: 'miniapp:startup-catalog-refresh',
+    });
+    expect(refreshApps).not.toHaveBeenCalled();
+    expect(refreshRunningWorkers).not.toHaveBeenCalled();
+
+    await scheduledTask?.(new AbortController().signal);
+
+    expect(refreshApps).toHaveBeenCalledTimes(1);
+    expect(refreshRunningWorkers).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/app/scenes/miniapps/hooks/miniAppCatalogStartupRefresh.ts
+++ b/src/web-ui/src/app/scenes/miniapps/hooks/miniAppCatalogStartupRefresh.ts
@@ -1,0 +1,32 @@
+import {
+  backgroundTaskScheduler,
+  type BackgroundTaskHandle,
+  type BackgroundTaskScheduler,
+} from '@/shared/utils/backgroundTaskScheduler';
+
+export interface MiniAppCatalogStartupRefreshDependencies {
+  scheduler?: Pick<BackgroundTaskScheduler, 'schedule'>;
+  refreshApps: () => Promise<void>;
+  refreshRunningWorkers: () => Promise<void>;
+}
+
+export function scheduleMiniAppCatalogStartupRefresh(
+  dependencies: MiniAppCatalogStartupRefreshDependencies
+): BackgroundTaskHandle<void> {
+  const scheduler = dependencies.scheduler ?? backgroundTaskScheduler;
+
+  return scheduler.schedule(async signal => {
+    if (signal.aborted) {
+      return;
+    }
+    await dependencies.refreshApps();
+    if (signal.aborted) {
+      return;
+    }
+    await dependencies.refreshRunningWorkers();
+  }, {
+    idle: true,
+    priority: 'low',
+    inFlightKey: 'miniapp:startup-catalog-refresh',
+  });
+}

--- a/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppCatalogSync.ts
+++ b/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppCatalogSync.ts
@@ -4,12 +4,20 @@
 import { useCallback, useEffect } from 'react';
 import { api } from '@/infrastructure/api/service-api/ApiClient';
 import { miniAppAPI } from '@/infrastructure/api/service-api/MiniAppAPI';
+import { BackgroundTaskCancelledError } from '@/shared/utils/backgroundTaskScheduler';
 import { createLogger } from '@/shared/utils/logger';
 import { useMiniAppStore } from '../miniAppStore';
+import { scheduleMiniAppCatalogStartupRefresh } from './miniAppCatalogStartupRefresh';
 
 const log = createLogger('useMiniAppCatalogSync');
 
-export function useMiniAppCatalogSync() {
+export interface UseMiniAppCatalogSyncOptions {
+  enabled?: boolean;
+  initialLoad?: 'immediate' | 'idle' | 'manual';
+}
+
+export function useMiniAppCatalogSync(options: UseMiniAppCatalogSyncOptions = {}) {
+  const { enabled = true, initialLoad = 'immediate' } = options;
   const setApps = useMiniAppStore((state) => state.setApps);
   const setLoading = useMiniAppStore((state) => state.setLoading);
   const setRunningWorkerIds = useMiniAppStore((state) => state.setRunningWorkerIds);
@@ -38,8 +46,27 @@ export function useMiniAppCatalogSync() {
   }, [setRunningWorkerIds]);
 
   useEffect(() => {
-    void refreshApps();
-    void refreshRunningWorkers();
+    if (!enabled) {
+      return;
+    }
+
+    const startupRefreshHandle = initialLoad === 'idle'
+      ? scheduleMiniAppCatalogStartupRefresh({
+          refreshApps,
+          refreshRunningWorkers,
+        })
+      : null;
+
+    if (initialLoad === 'immediate') {
+      void refreshApps();
+      void refreshRunningWorkers();
+    }
+
+    startupRefreshHandle?.promise.catch(error => {
+      if (!(error instanceof BackgroundTaskCancelledError)) {
+        log.warn('Initial miniapp catalog refresh task failed', error);
+      }
+    });
 
     const unlistenCreated = api.listen('miniapp-created', () => {
       void refreshApps();
@@ -65,13 +92,14 @@ export function useMiniAppCatalogSync() {
     });
 
     return () => {
+      startupRefreshHandle?.cancel();
       unlistenCreated();
       unlistenUpdated();
       unlistenDeleted();
       unlistenRestarted();
       unlistenStopped();
     };
-  }, [markWorkerRunning, markWorkerStopped, refreshApps, refreshRunningWorkers]);
+  }, [enabled, initialLoad, markWorkerRunning, markWorkerStopped, refreshApps, refreshRunningWorkers]);
 
   return {
     refreshApps,

--- a/src/web-ui/src/app/startup/deferredStartupSystems.test.ts
+++ b/src/web-ui/src/app/startup/deferredStartupSystems.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { scheduleDeferredStartupSystems } from './deferredStartupSystems';
+
+describe('scheduleDeferredStartupSystems', () => {
+  it('schedules MCP, ACP, and IDE startup as deferred idle work', async () => {
+    let scheduledTask: ((signal: AbortSignal) => Promise<void>) | null = null;
+    const schedule = vi.fn((task: (signal: AbortSignal) => Promise<void>, options) => {
+      scheduledTask = task;
+      return {
+        promise: Promise.resolve(),
+        cancel: vi.fn(),
+      };
+    });
+    const order: string[] = [];
+
+    scheduleDeferredStartupSystems({
+      scheduler: { schedule },
+      log: {
+        debug: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      trace: {
+        markPhase: vi.fn(),
+      },
+      initializeIdeControl: async () => {
+        order.push('ide');
+      },
+      initializeMcpServers: async () => {
+        order.push('mcp');
+      },
+      initializeAcpClients: async () => {
+        order.push('acp');
+      },
+      probeAcpClientRequirements: async () => {
+        order.push('acp-probe');
+      },
+    });
+
+    expect(schedule).toHaveBeenCalledTimes(1);
+    expect(schedule.mock.calls[0][1]).toMatchObject({
+      idle: true,
+      priority: 'low',
+      inFlightKey: 'startup:deferred-systems',
+    });
+    expect(order).toEqual([]);
+
+    await scheduledTask?.(new AbortController().signal);
+
+    expect(order).toEqual(['ide', 'mcp', 'acp', 'acp-probe']);
+  });
+
+  it('skips deferred startup systems when cancelled before execution', async () => {
+    let scheduledTask: ((signal: AbortSignal) => Promise<void>) | null = null;
+    const schedule = vi.fn((task: (signal: AbortSignal) => Promise<void>) => {
+      scheduledTask = task;
+      return {
+        promise: Promise.resolve(),
+        cancel: vi.fn(),
+      };
+    });
+    const initializeIdeControl = vi.fn();
+    const controller = new AbortController();
+
+    scheduleDeferredStartupSystems({
+      scheduler: { schedule },
+      log: {
+        debug: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      trace: {
+        markPhase: vi.fn(),
+      },
+      initializeIdeControl,
+      initializeMcpServers: vi.fn(),
+      initializeAcpClients: vi.fn(),
+      probeAcpClientRequirements: vi.fn(),
+    });
+
+    controller.abort();
+    await scheduledTask?.(controller.signal);
+
+    expect(initializeIdeControl).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/app/startup/deferredStartupSystems.ts
+++ b/src/web-ui/src/app/startup/deferredStartupSystems.ts
@@ -1,0 +1,95 @@
+import {
+  backgroundTaskScheduler,
+  type BackgroundTaskHandle,
+  type BackgroundTaskScheduler,
+} from '@/shared/utils/backgroundTaskScheduler';
+import { createLogger } from '@/shared/utils/logger';
+import { startupTrace } from '@/shared/utils/startupTrace';
+
+const log = createLogger('DeferredStartupSystems');
+
+interface DeferredStartupLog {
+  debug: (message: string, data?: unknown) => void;
+  warn: (message: string, data?: unknown) => void;
+  error: (message: string, data?: unknown) => void;
+}
+
+interface DeferredStartupTrace {
+  markPhase: (phase: string, data?: Record<string, unknown>) => void;
+}
+
+export interface DeferredStartupSystemsDependencies {
+  scheduler?: Pick<BackgroundTaskScheduler, 'schedule'>;
+  log?: DeferredStartupLog;
+  trace?: DeferredStartupTrace;
+  initializeIdeControl?: () => Promise<void>;
+  initializeMcpServers?: () => Promise<void>;
+  initializeAcpClients?: () => Promise<void>;
+  probeAcpClientRequirements?: () => Promise<void>;
+}
+
+async function initializeIdeControlDefault(): Promise<void> {
+  const { initializeIdeControl } = await import('@/shared/services/ide-control');
+  await initializeIdeControl();
+}
+
+async function initializeMcpServersDefault(): Promise<void> {
+  const { MCPAPI } = await import('@/infrastructure/api/service-api/MCPAPI');
+  await MCPAPI.initializeServers();
+}
+
+async function initializeAcpClientsDefault(): Promise<void> {
+  const { ACPClientAPI } = await import('@/infrastructure/api/service-api/ACPClientAPI');
+  await ACPClientAPI.initializeClients();
+}
+
+async function probeAcpClientRequirementsDefault(): Promise<void> {
+  const { ACPClientAPI } = await import('@/infrastructure/api/service-api/ACPClientAPI');
+  await ACPClientAPI.probeClientRequirements();
+}
+
+export function scheduleDeferredStartupSystems(
+  dependencies: DeferredStartupSystemsDependencies = {}
+): BackgroundTaskHandle<void> {
+  const scheduler = dependencies.scheduler ?? backgroundTaskScheduler;
+  const logger = dependencies.log ?? log;
+  const trace = dependencies.trace ?? startupTrace;
+  const initializeIdeControl = dependencies.initializeIdeControl ?? initializeIdeControlDefault;
+  const initializeMcpServers = dependencies.initializeMcpServers ?? initializeMcpServersDefault;
+  const initializeAcpClients = dependencies.initializeAcpClients ?? initializeAcpClientsDefault;
+  const probeAcpClientRequirements =
+    dependencies.probeAcpClientRequirements ?? probeAcpClientRequirementsDefault;
+
+  return scheduler.schedule(async signal => {
+    if (signal.aborted) {
+      return;
+    }
+
+    trace.markPhase('deferred_startup_systems_start');
+
+    const runStep = async (name: string, step: () => Promise<void>) => {
+      if (signal.aborted) {
+        return;
+      }
+      try {
+        await step();
+        logger.debug('Deferred startup system initialized', { system: name });
+      } catch (error) {
+        logger.error('Deferred startup system failed', { system: name, error });
+      }
+    };
+
+    await runStep('ide_control', initializeIdeControl);
+    await runStep('mcp_servers', initializeMcpServers);
+    await runStep('acp_clients', initializeAcpClients);
+    await runStep('acp_client_requirements', probeAcpClientRequirements);
+
+    if (!signal.aborted) {
+      trace.markPhase('deferred_startup_systems_end');
+    }
+  }, {
+    idle: true,
+    priority: 'low',
+    inFlightKey: 'startup:deferred-systems',
+  });
+}

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -110,8 +110,10 @@ export class FlowChatManager {
         }
       );
 
-      await this.context.flowChatStore.initializeFromDisk(
+      const initialMetadataPage = await this.context.flowChatStore.loadSessionMetadataPage(
         workspacePath,
+        5,
+        undefined,
         remoteConnectionId,
         remoteSshHost,
         'flow_chat_manager'
@@ -135,9 +137,35 @@ export class FlowChatManager {
         );
       };
 
-      const state = this.context.flowChatStore.getState();
-      const workspaceSessions = Array.from(state.sessions.values()).filter(sessionMatchesWorkspace);
-      const hasHistoricalSessions = workspaceSessions.length > 0;
+      let state = this.context.flowChatStore.getState();
+      let workspaceSessions = Array.from(state.sessions.values()).filter(sessionMatchesWorkspace);
+      if (
+        preferredMode &&
+        initialMetadataPage.hasMore &&
+        !workspaceSessions.some(session => session.mode === preferredMode)
+      ) {
+        let nextCursor = initialMetadataPage.nextCursor;
+        while (nextCursor) {
+          const nextPage = await this.context.flowChatStore.loadSessionMetadataPage(
+            workspacePath,
+            5,
+            nextCursor,
+            remoteConnectionId,
+            remoteSshHost,
+            'flow_chat_manager_preferred_mode'
+          );
+          state = this.context.flowChatStore.getState();
+          workspaceSessions = Array.from(state.sessions.values()).filter(sessionMatchesWorkspace);
+          if (workspaceSessions.some(session => session.mode === preferredMode) || !nextPage.hasMore) {
+            break;
+          }
+          nextCursor = nextPage.nextCursor;
+        }
+      }
+      const hasHistoricalSessions =
+        workspaceSessions.length > 0 ||
+        initialMetadataPage.totalTopLevelCount > 0 ||
+        initialMetadataPage.sessions.length > 0;
       const activeSession = state.activeSessionId
         ? state.sessions.get(state.activeSessionId) ?? null
         : null;

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -4,6 +4,7 @@ import type { FlowChatState, Session } from '../types/flow-chat';
 
 const apiMocks = vi.hoisted(() => ({
   listSessions: vi.fn(),
+  listSessionsPage: vi.fn(),
   loadSessionTurns: vi.fn(),
   saveSessionTurn: vi.fn(),
   restoreSession: vi.fn(),
@@ -27,6 +28,7 @@ const stateMachineManagerMock = vi.hoisted(() => ({
 vi.mock('@/infrastructure/api', () => ({
   sessionAPI: {
     listSessions: apiMocks.listSessions,
+    listSessionsPage: apiMocks.listSessionsPage,
     loadSessionTurns: apiMocks.loadSessionTurns,
     saveSessionTurn: apiMocks.saveSessionTurn,
   },
@@ -57,6 +59,15 @@ const resetStore = () => {
     }
   });
   metadataListRequests?.clear();
+  const metadataPageRequests = (flowChatStore as any).metadataPageRequests as
+    | Map<string, { cleanupTimer?: ReturnType<typeof setTimeout> }>
+    | undefined;
+  metadataPageRequests?.forEach(request => {
+    if (request.cleanupTimer) {
+      clearTimeout(request.cleanupTimer);
+    }
+  });
+  metadataPageRequests?.clear();
   ((flowChatStore as any).unsupportedRestoreCommands as Set<string> | undefined)?.clear();
   flowChatStore.setState((): FlowChatState => ({
     sessions: new Map(),
@@ -489,6 +500,52 @@ describe('FlowChatStore historical session hydration state', () => {
     await flowChatStore.initializeFromDisk('D:/workspace/BitFun', undefined, undefined, 'second-source');
 
     expect(apiMocks.listSessions).toHaveBeenCalledTimes(1);
+    expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
+      sessionId: 'history-1',
+      historyState: 'metadata-only',
+    });
+  });
+
+  it('loads a paged metadata slice without requesting the full session list', async () => {
+    apiMocks.listSessionsPage.mockResolvedValueOnce({
+      sessions: [
+        {
+          sessionId: 'history-1',
+          title: 'Saved session',
+          agentType: 'agentic',
+          modelName: 'auto',
+          createdAt: 10,
+          lastActiveAt: 20,
+        },
+      ],
+      totalTopLevelCount: 12,
+      loadedTopLevelCount: 5,
+      nextCursor: '5',
+      hasMore: true,
+    });
+
+    const page = await flowChatStore.loadSessionMetadataPage(
+      'D:/workspace/BitFun',
+      5,
+      undefined,
+      undefined,
+      undefined,
+      'nav_initial'
+    );
+
+    expect(apiMocks.listSessions).not.toHaveBeenCalled();
+    expect(apiMocks.listSessionsPage).toHaveBeenCalledWith({
+      workspacePath: 'D:/workspace/BitFun',
+      limit: 5,
+      cursor: undefined,
+      remoteConnectionId: undefined,
+      remoteSshHost: undefined,
+    });
+    expect(page).toMatchObject({
+      totalTopLevelCount: 12,
+      nextCursor: '5',
+      hasMore: true,
+    });
     expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
       sessionId: 'history-1',
       historyState: 'metadata-only',

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -28,6 +28,7 @@ import { elapsedMs, nowMs } from '@/shared/utils/timing';
 import { i18nService } from '@/infrastructure/i18n/core/I18nService';
 import type { DialogTurnData, LocalCommandMetadata, SessionKind } from '@/shared/types/session-history';
 import type { SessionInfo as AgentSessionInfo } from '@/infrastructure/api/service-api/AgentAPI';
+import type { SessionMetadataPage } from '@/infrastructure/api/service-api/SessionAPI';
 import {
   deriveLastFinishedAtFromMetadata,
   deriveSessionRelationshipFromMetadata,
@@ -68,6 +69,12 @@ const METADATA_LIST_RECENT_DEDUPE_TTL_MS = 1000;
 
 interface MetadataListRequest {
   promise: Promise<void>;
+  completedAtMs?: number;
+  cleanupTimer?: ReturnType<typeof setTimeout>;
+}
+
+interface MetadataPageRequest {
+  promise: Promise<SessionMetadataPage>;
   completedAtMs?: number;
   cleanupTimer?: ReturnType<typeof setTimeout>;
 }
@@ -122,6 +129,7 @@ export class FlowChatStore {
   private listeners: Set<(state: FlowChatState) => void> = new Set();
   private silentMode = false;
   private metadataListRequests = new Map<string, MetadataListRequest>();
+  private metadataPageRequests = new Map<string, MetadataPageRequest>();
   private unsupportedRestoreCommands = new Set<string>();
   private onPersistUnreadCompletion?: (sessionId: string, value: 'completed' | 'error' | 'interrupted' | undefined) => void;
 
@@ -178,6 +186,22 @@ export class FlowChatStore {
       workspacePath,
       remoteConnectionId || '',
       remoteSshHost || '',
+    ]);
+  }
+
+  private getMetadataPageRequestKey(
+    workspacePath: string,
+    limit: number,
+    cursor?: string,
+    remoteConnectionId?: string,
+    remoteSshHost?: string,
+  ): string {
+    return JSON.stringify([
+      workspacePath,
+      remoteConnectionId || '',
+      remoteSshHost || '',
+      cursor || '',
+      limit,
     ]);
   }
 
@@ -2092,6 +2116,305 @@ export class FlowChatStore {
     });
 
     return loadPromise;
+  }
+
+  private async loadSessionMetadataModelConfig(): Promise<{
+    models: any[];
+    defaultModels: Record<string, string>;
+  }> {
+    let models: any[] = [];
+    let defaultModels: Record<string, string> = {};
+    try {
+      const { configManager } = await import('@/infrastructure/config/services/ConfigManager');
+      const [modelsResult, defaultModelsResult] = await Promise.allSettled([
+        configManager.getConfig<any[]>('ai.models'),
+        configManager.getConfig<Record<string, string>>('ai.default_models'),
+      ]);
+
+      if (modelsResult.status === 'fulfilled' && Array.isArray(modelsResult.value)) {
+        models = modelsResult.value;
+      }
+      if (
+        defaultModelsResult.status === 'fulfilled' &&
+        defaultModelsResult.value &&
+        typeof defaultModelsResult.value === 'object'
+      ) {
+        defaultModels = defaultModelsResult.value;
+      }
+    } catch (error) {
+      log.warn('Failed to load model config for session metadata, using defaults', { error });
+    }
+
+    return { models, defaultModels };
+  }
+
+  private async processPersistedSessionMetadataList(
+    sessions: any[],
+    workspacePath: string,
+    remoteConnectionId?: string,
+    remoteSshHost?: string,
+  ): Promise<void> {
+    const { stateMachineManager } = await import('../state-machine');
+    const { models, defaultModels } = await this.loadSessionMetadataModelConfig();
+
+    const processSession = async (metadata: any) => {
+      try {
+        const existingSession = this.state.sessions.get(metadata.sessionId);
+        if (existingSession) {
+          return;
+        }
+        if (isLegacyPersistedBtwSession(metadata)) {
+          return;
+        }
+        // Skip archived sessions - they are managed in the settings page.
+        if (metadata.status === 'archived') {
+          return;
+        }
+
+        stateMachineManager.getOrCreate(metadata.sessionId);
+
+        let maxContextTokens = 128128;
+        if (metadata.modelName) {
+          const model = models.find((m: any) => m.name === metadata.modelName || m.id === metadata.modelName);
+          if (model?.context_window) {
+            maxContextTokens = model.context_window;
+          }
+        }
+
+        if (maxContextTokens === 128128) {
+          const primaryModelId = defaultModels?.primary;
+
+          if (primaryModelId) {
+            const primaryModel = models.find((m: any) => m.id === primaryModelId);
+            if (primaryModel?.context_window) {
+              maxContextTokens = primaryModel.context_window;
+            }
+          }
+        }
+
+        const relationship = deriveSessionRelationshipFromMetadata(metadata);
+        const lastFinishedAt = deriveLastFinishedAtFromMetadata(metadata);
+        const titleState = deriveSessionTitleStateFromMetadata(metadata);
+        const hasDynamicDefaultTitle = titleState.titleSource === 'i18n';
+
+        this.setState(prev => {
+          if (prev.sessions.has(metadata.sessionId)) {
+            return prev;
+          }
+
+          const rawAgentType = metadata.agentType || 'agentic';
+          const validatedAgentType = isValidPersistedAgentType(rawAgentType) ? rawAgentType : 'agentic';
+
+          if (rawAgentType !== validatedAgentType) {
+            log.warn('Invalid agentType, falling back to agentic', { sessionId: metadata.sessionId, rawAgentType, validatedAgentType });
+          }
+
+          const session: Session = {
+            sessionId: metadata.sessionId,
+            title: titleState.title,
+            titleSource: titleState.titleSource,
+            titleI18nKey: titleState.titleI18nKey,
+            titleI18nParams: titleState.titleI18nParams,
+            titleStatus: hasDynamicDefaultTitle ? undefined : 'generated',
+            dialogTurns: [],
+            status: 'idle',
+            config: {
+              agentType: validatedAgentType,
+              modelName: metadata.modelName,
+            },
+            createdAt: metadata.createdAt,
+            lastActiveAt: metadata.lastActiveAt,
+            lastFinishedAt,
+            error: null,
+            isHistorical: true,
+            historyState: 'metadata-only',
+            todos: (metadata as any).todos || [],
+            maxContextTokens,
+            mode: validatedAgentType,
+            lastUserDialogMode: metadata.lastUserDialogAgentType,
+            lastSubmittedMode: metadata.lastSubmittedAgentType,
+            workspacePath: (metadata as any).workspacePath || workspacePath,
+            remoteConnectionId: metadata.remoteConnectionId || remoteConnectionId,
+            remoteSshHost:
+              metadata.remoteSshHost || metadata.workspaceHostname || remoteSshHost,
+            parentSessionId: relationship.parentSessionId,
+            sessionKind: relationship.sessionKind,
+            parentToolCallId: relationship.parentToolCallId,
+            subagentType: relationship.subagentType,
+            btwThreads: [],
+            btwOrigin: relationship.btwOrigin,
+            hasUnreadCompletion: metadata.unreadCompletion,
+            needsUserAttention: metadata.needsUserAttention,
+            deepReviewRunManifest: metadata.deepReviewRunManifest,
+            isTransient: false,
+          };
+
+          const newSessions = new Map(prev.sessions);
+          newSessions.set(metadata.sessionId, session);
+
+          return {
+            ...prev,
+            sessions: newSessions,
+          };
+        });
+      } catch (error) {
+        log.warn('Failed to process persisted session metadata', {
+          sessionId: metadata?.sessionId,
+          error,
+        });
+      }
+    };
+
+    await Promise.all(sessions.map(processSession));
+  }
+
+  public async loadSessionMetadataPage(
+    workspacePath: string,
+    limit: number,
+    cursor?: string,
+    remoteConnectionId?: string,
+    remoteSshHost?: string,
+    traceSource = 'unknown'
+  ): Promise<SessionMetadataPage> {
+    const requestKey = this.getMetadataPageRequestKey(
+      workspacePath,
+      limit,
+      cursor,
+      remoteConnectionId,
+      remoteSshHost,
+    );
+    const existingRequest = this.metadataPageRequests.get(requestKey);
+    const remote = isRemoteTraceContext(remoteConnectionId, remoteSshHost);
+    if (existingRequest) {
+      const completedAtMs = existingRequest.completedAtMs;
+      const isRecentCompletedRequest =
+        completedAtMs !== undefined &&
+        elapsedMs(completedAtMs) <= METADATA_LIST_RECENT_DEDUPE_TTL_MS;
+
+      if (completedAtMs === undefined || isRecentCompletedRequest) {
+        startupTrace.markPhase('session_metadata_page_deduped', {
+          remote,
+          source: traceSource,
+          cursor: cursor || null,
+          limit,
+          dedupeState: completedAtMs === undefined ? 'in-flight' : 'recent',
+        });
+        return existingRequest.promise;
+      }
+
+      if (existingRequest.cleanupTimer) {
+        clearTimeout(existingRequest.cleanupTimer);
+      }
+      this.metadataPageRequests.delete(requestKey);
+    }
+
+    const loadPromise = this.loadSessionMetadataPageUncached(
+      workspacePath,
+      limit,
+      cursor,
+      remoteConnectionId,
+      remoteSshHost,
+      traceSource,
+    );
+
+    const request: MetadataPageRequest = { promise: loadPromise };
+    this.metadataPageRequests.set(requestKey, request);
+
+    loadPromise
+      .then(() => {
+        const currentRequest = this.metadataPageRequests.get(requestKey);
+        if (currentRequest !== request) {
+          return;
+        }
+
+        request.completedAtMs = nowMs();
+        request.cleanupTimer = setTimeout(() => {
+          if (this.metadataPageRequests.get(requestKey) === request) {
+            this.metadataPageRequests.delete(requestKey);
+          }
+        }, METADATA_LIST_RECENT_DEDUPE_TTL_MS);
+      })
+      .catch(() => {
+        if (this.metadataPageRequests.get(requestKey) === request) {
+          this.metadataPageRequests.delete(requestKey);
+        }
+      });
+
+    return loadPromise;
+  }
+
+  private async loadSessionMetadataPageUncached(
+    workspacePath: string,
+    limit: number,
+    cursor?: string,
+    remoteConnectionId?: string,
+    remoteSshHost?: string,
+    traceSource = 'unknown'
+  ): Promise<SessionMetadataPage> {
+    const traceStartedAt = nowMs();
+    const remote = isRemoteTraceContext(remoteConnectionId, remoteSshHost);
+    const metadataListTraceId = `metadata-page-${Math.random().toString(36).slice(2, 8)}`;
+    startupTrace.markPhase('session_metadata_page_start', {
+      remote,
+      source: traceSource,
+      metadataListTraceId,
+      cursor: cursor || null,
+      limit,
+    });
+
+    try {
+      const { sessionAPI } = await import('@/infrastructure/api');
+      let page: SessionMetadataPage;
+      try {
+        page = await sessionAPI.listSessionsPage({
+          workspacePath,
+          limit,
+          cursor,
+          remoteConnectionId,
+          remoteSshHost,
+        });
+      } catch (error) {
+        if (!isUnsupportedTauriCommandError(error, 'list_persisted_sessions_page')) {
+          throw error;
+        }
+
+        const sessions = await sessionAPI.listSessions(workspacePath, remoteConnectionId, remoteSshHost);
+        page = {
+          sessions,
+          totalTopLevelCount: sessions.length,
+          loadedTopLevelCount: sessions.length,
+          nextCursor: undefined,
+          hasMore: false,
+        };
+      }
+
+      await this.processPersistedSessionMetadataList(
+        page.sessions,
+        workspacePath,
+        remoteConnectionId,
+        remoteSshHost,
+      );
+      startupTrace.markPhase('session_metadata_page_end', {
+        remote,
+        source: traceSource,
+        metadataListTraceId,
+        sessionCount: page.sessions.length,
+        totalTopLevelCount: page.totalTopLevelCount,
+        loadedTopLevelCount: page.loadedTopLevelCount,
+        hasMore: page.hasMore,
+        durationMs: elapsedMs(traceStartedAt),
+      });
+      return page;
+    } catch (error) {
+      startupTrace.markPhase('session_metadata_page_failed', {
+        remote,
+        source: traceSource,
+        metadataListTraceId,
+        durationMs: elapsedMs(traceStartedAt),
+      });
+      log.error('Failed to load persisted session metadata page', error);
+      throw error;
+    }
   }
 
   private async initializeFromDiskUncached(

--- a/src/web-ui/src/infrastructure/api/service-api/ACPClientAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ACPClientAPI.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./ApiClient', () => ({
+  api: {
+    invoke: invokeMock,
+  },
+}));
+
+async function importApi() {
+  vi.resetModules();
+  return (await import('./ACPClientAPI')).default;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('ACPClientAPI client list startup cache', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    vi.useRealTimers();
+    vi.stubGlobal('window', { dispatchEvent: vi.fn() });
+  });
+
+  it('deduplicates concurrent client list requests', async () => {
+    const ACPClientAPI = await importApi();
+    const clients = [
+      {
+        id: 'claude',
+        name: 'Claude',
+        command: 'claude',
+        args: [],
+        enabled: true,
+        readonly: false,
+        permissionMode: 'ask',
+        status: 'configured',
+        toolName: 'claude',
+        sessionCount: 0,
+      },
+    ];
+    const deferred = createDeferred<typeof clients>();
+    invokeMock.mockReturnValueOnce(deferred.promise);
+
+    const first = ACPClientAPI.getClients();
+    const second = ACPClientAPI.getClients();
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith('get_acp_clients');
+
+    deferred.resolve(clients);
+    await expect(Promise.all([first, second])).resolves.toEqual([clients, clients]);
+  });
+
+  it('serves a recently resolved client list from memory until clients change', async () => {
+    const ACPClientAPI = await importApi();
+    invokeMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([
+        {
+          id: 'codex',
+          name: 'Codex',
+          command: 'codex',
+          args: [],
+          enabled: true,
+          readonly: false,
+          permissionMode: 'ask',
+          status: 'configured',
+          toolName: 'codex',
+          sessionCount: 0,
+        },
+      ]);
+
+    await expect(ACPClientAPI.getClients()).resolves.toEqual([]);
+    await expect(ACPClientAPI.getClients()).resolves.toEqual([]);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    await ACPClientAPI.initializeClients();
+    await ACPClientAPI.getClients();
+    expect(invokeMock).toHaveBeenCalledTimes(3);
+    expect(invokeMock).toHaveBeenNthCalledWith(2, 'initialize_acp_clients');
+    expect(invokeMock).toHaveBeenNthCalledWith(3, 'get_acp_clients');
+  });
+});

--- a/src/web-ui/src/infrastructure/api/service-api/ACPClientAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ACPClientAPI.ts
@@ -138,10 +138,23 @@ export interface AcpPermissionRequestEvent {
 }
 
 const LOCAL_REQUIREMENT_CACHE_KEY = '__local__';
+const CLIENT_LIST_CACHE_TTL_MS = 1000;
 const requirementProbeCache = new Map<string, AcpClientRequirementProbe[]>();
 const requirementProbeInFlight = new Map<string, Promise<AcpClientRequirementProbe[]>>();
 
 export class ACPClientAPI {
+  private static clientListCache: {
+    clients: AcpClientInfo[];
+    expiresAt: number;
+  } | null = null;
+
+  private static clientListInFlight: Promise<AcpClientInfo[]> | null = null;
+
+  private static invalidateClientListCache(): void {
+    ACPClientAPI.clientListCache = null;
+    ACPClientAPI.clientListInFlight = null;
+  }
+
   private static invalidateRequirementProbeCache(): void {
     requirementProbeCache.clear();
     requirementProbeInFlight.clear();
@@ -149,12 +162,34 @@ export class ACPClientAPI {
 
   static async initializeClients(): Promise<void> {
     await api.invoke('initialize_acp_clients');
+    ACPClientAPI.invalidateClientListCache();
     ACPClientAPI.invalidateRequirementProbeCache();
     window.dispatchEvent(new Event('bitfun:acp-clients-changed'));
   }
 
   static async getClients(): Promise<AcpClientInfo[]> {
-    return api.invoke('get_acp_clients');
+    const now = Date.now();
+    if (ACPClientAPI.clientListCache && ACPClientAPI.clientListCache.expiresAt > now) {
+      return ACPClientAPI.clientListCache.clients;
+    }
+    if (ACPClientAPI.clientListInFlight) {
+      return ACPClientAPI.clientListInFlight;
+    }
+
+    const inFlight = api.invoke<AcpClientInfo[]>('get_acp_clients')
+      .then((clients) => {
+        ACPClientAPI.clientListCache = {
+          clients,
+          expiresAt: Date.now() + CLIENT_LIST_CACHE_TTL_MS,
+        };
+        return clients;
+      })
+      .finally(() => {
+        ACPClientAPI.clientListInFlight = null;
+      });
+
+    ACPClientAPI.clientListInFlight = inFlight;
+    return inFlight;
   }
 
   static async probeClientRequirements(
@@ -188,18 +223,21 @@ export class ACPClientAPI {
 
   static async predownloadClientAdapter(request: AcpClientIdRequest): Promise<void> {
     await api.invoke('predownload_acp_client_adapter', { request });
+    ACPClientAPI.invalidateClientListCache();
     ACPClientAPI.invalidateRequirementProbeCache();
     window.dispatchEvent(new Event('bitfun:acp-requirements-changed'));
   }
 
   static async installClientCli(request: AcpClientIdRequest): Promise<void> {
     await api.invoke('install_acp_client_cli', { request });
+    ACPClientAPI.invalidateClientListCache();
     ACPClientAPI.invalidateRequirementProbeCache();
     window.dispatchEvent(new Event('bitfun:acp-requirements-changed'));
   }
 
   static async stopClient(request: AcpClientIdRequest): Promise<void> {
     await api.invoke('stop_acp_client', { request });
+    ACPClientAPI.invalidateClientListCache();
     window.dispatchEvent(new Event('bitfun:acp-clients-changed'));
   }
 
@@ -209,6 +247,7 @@ export class ACPClientAPI {
 
   static async saveJsonConfig(jsonConfig: string): Promise<void> {
     await api.invoke('save_acp_json_config', { jsonConfig });
+    ACPClientAPI.invalidateClientListCache();
     ACPClientAPI.invalidateRequirementProbeCache();
     window.dispatchEvent(new Event('bitfun:acp-clients-changed'));
   }
@@ -223,6 +262,7 @@ export class ACPClientAPI {
     request: CreateAcpFlowSessionRequest
   ): Promise<CreateAcpFlowSessionResponse> {
     const response = await api.invoke<CreateAcpFlowSessionResponse>('create_acp_flow_session', { request });
+    ACPClientAPI.invalidateClientListCache();
     window.dispatchEvent(new Event('bitfun:acp-clients-changed'));
     return response;
   }

--- a/src/web-ui/src/infrastructure/api/service-api/GitAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/GitAPI.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GitAPI } from './GitAPI';
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./ApiClient', () => ({
+  api: {
+    invoke: invokeMock,
+  },
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('GitAPI repository probe cache', () => {
+  let gitAPI: GitAPI;
+
+  beforeEach(() => {
+    gitAPI = new GitAPI();
+    invokeMock.mockReset();
+  });
+
+  it('deduplicates concurrent repository probes for the same path', async () => {
+    const deferred = createDeferred<boolean>();
+    invokeMock.mockReturnValueOnce(deferred.promise);
+
+    const first = gitAPI.isGitRepository('D:/workspace/BitFun');
+    const second = gitAPI.isGitRepository('D:/workspace/BitFun');
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith('git_is_repository', {
+      request: { repositoryPath: 'D:/workspace/BitFun' },
+    });
+
+    deferred.resolve(true);
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+  });
+
+  it('reuses a recent repository probe result for the same path', async () => {
+    invokeMock.mockResolvedValueOnce(true);
+
+    await expect(gitAPI.isGitRepository('D:/workspace/BitFun')).resolves.toBe(true);
+    await expect(gitAPI.isGitRepository('D:/workspace/BitFun')).resolves.toBe(true);
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/infrastructure/api/service-api/GitAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/GitAPI.ts
@@ -5,6 +5,7 @@ import { createTauriCommandError } from '../errors/TauriCommandError';
 import { createLogger } from '@/shared/utils/logger';
 
 const log = createLogger('GitAPI');
+const REPOSITORY_PROBE_CACHE_TTL_MS = 1000;
 
 export interface GitRepository {
   path: string;
@@ -178,15 +179,43 @@ export interface GitWorktreeInfo {
 }
 
 export class GitAPI {
+  private repositoryProbeCache = new Map<string, {
+    value: boolean;
+    expiresAt: number;
+  }>();
+  private repositoryProbeInFlight = new Map<string, Promise<boolean>>();
+
    
   async isGitRepository(repositoryPath: string): Promise<boolean> {
-    try {
-      return await api.invoke('git_is_repository', { 
-        request: { repositoryPath } 
-      });
-    } catch (error) {
-      throw createTauriCommandError('git_is_repository', error, { repositoryPath });
+    const now = Date.now();
+    const cached = this.repositoryProbeCache.get(repositoryPath);
+    if (cached && cached.expiresAt > now) {
+      return cached.value;
     }
+
+    const inFlight = this.repositoryProbeInFlight.get(repositoryPath);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const request = { repositoryPath };
+    const probe = api.invoke<boolean>('git_is_repository', { request })
+      .then((value) => {
+        this.repositoryProbeCache.set(repositoryPath, {
+          value,
+          expiresAt: Date.now() + REPOSITORY_PROBE_CACHE_TTL_MS,
+        });
+        return value;
+      })
+      .catch((error) => {
+        throw createTauriCommandError('git_is_repository', error, { repositoryPath });
+      })
+      .finally(() => {
+        this.repositoryProbeInFlight.delete(repositoryPath);
+      });
+
+    this.repositoryProbeInFlight.set(repositoryPath, probe);
+    return probe;
   }
 
    

--- a/src/web-ui/src/infrastructure/api/service-api/SessionAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SessionAPI.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionAPI } from './SessionAPI';
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./ApiClient', () => ({
+  api: {
+    invoke: invokeMock,
+  },
+}));
+
+describe('SessionAPI paged metadata reads', () => {
+  let sessionAPI: SessionAPI;
+
+  beforeEach(() => {
+    sessionAPI = new SessionAPI();
+    invokeMock.mockReset();
+  });
+
+  it('requests a top-level session metadata page with cursor and remote identity', async () => {
+    const page = {
+      sessions: [],
+      totalTopLevelCount: 12,
+      loadedTopLevelCount: 5,
+      nextCursor: '5',
+      hasMore: true,
+    };
+    invokeMock.mockResolvedValueOnce(page);
+
+    await expect(
+      sessionAPI.listSessionsPage({
+        workspacePath: '/repo',
+        limit: 5,
+        cursor: '0',
+        remoteConnectionId: 'remote-1',
+        remoteSshHost: 'host',
+      })
+    ).resolves.toBe(page);
+
+    expect(invokeMock).toHaveBeenCalledWith('list_persisted_sessions_page', {
+      request: {
+        workspace_path: '/repo',
+        limit: 5,
+        cursor: '0',
+        remote_connection_id: 'remote-1',
+        remote_ssh_host: 'host',
+      },
+    });
+  });
+});

--- a/src/web-ui/src/infrastructure/api/service-api/SessionAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SessionAPI.ts
@@ -3,6 +3,22 @@ import { api } from './ApiClient';
 import { createTauriCommandError } from '../errors/TauriCommandError';
 import type { SessionMetadata, DialogTurnData } from '@/shared/types/session-history';
 
+export interface SessionMetadataPageRequest {
+  workspacePath: string;
+  limit: number;
+  cursor?: string;
+  remoteConnectionId?: string;
+  remoteSshHost?: string;
+}
+
+export interface SessionMetadataPage {
+  sessions: SessionMetadata[];
+  totalTopLevelCount: number;
+  loadedTopLevelCount: number;
+  nextCursor?: string;
+  hasMore: boolean;
+}
+
 export interface SessionUsageReportRequest {
   sessionId: string;
   workspacePath: string;
@@ -195,6 +211,27 @@ export class SessionAPI {
       });
     } catch (error) {
       throw createTauriCommandError('list_persisted_sessions', error, { workspacePath });
+    }
+  }
+
+  async listSessionsPage(
+    request: SessionMetadataPageRequest
+  ): Promise<SessionMetadataPage> {
+    try {
+      return await api.invoke('list_persisted_sessions_page', {
+        request: {
+          workspace_path: request.workspacePath,
+          limit: request.limit,
+          ...(request.cursor ? { cursor: request.cursor } : {}),
+          ...remoteSessionFields(request.remoteConnectionId, request.remoteSshHost),
+        }
+      });
+    } catch (error) {
+      throw createTauriCommandError('list_persisted_sessions_page', error, {
+        workspacePath: request.workspacePath,
+        limit: request.limit,
+        cursor: request.cursor,
+      });
     }
   }
 

--- a/src/web-ui/src/infrastructure/config/services/FrontendLogLevelSync.test.ts
+++ b/src/web-ui/src/infrastructure/config/services/FrontendLogLevelSync.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const configApiMocks = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  getConfigs: vi.fn(),
+  getRuntimeLoggingInfo: vi.fn(),
+}));
+
+const loggerMocks = vi.hoisted(() => ({
+  getLevel: vi.fn(),
+  setLevel: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  setIncludeSensitiveDiagnostics: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/api/service-api/ConfigAPI', () => ({
+  configAPI: configApiMocks,
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  LogLevel: {
+    TRACE: 0,
+    DEBUG: 1,
+    INFO: 2,
+    WARN: 3,
+    ERROR: 4,
+    NONE: 5,
+  },
+  logger: {
+    getLevel: loggerMocks.getLevel,
+    setLevel: loggerMocks.setLevel,
+  },
+  createLogger: () => ({
+    info: loggerMocks.info,
+    warn: loggerMocks.warn,
+    error: loggerMocks.error,
+  }),
+  setIncludeSensitiveDiagnostics: loggerMocks.setIncludeSensitiveDiagnostics,
+}));
+
+const LOGGING_LEVEL_PATH = 'app.logging.level';
+const LOGGING_INCLUDE_SENSITIVE_PATH = 'app.logging.include_sensitive_diagnostics';
+
+async function importSyncModule() {
+  vi.resetModules();
+  return import('./FrontendLogLevelSync');
+}
+
+describe('FrontendLogLevelSync startup reads', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loggerMocks.getLevel.mockReturnValue(3);
+    configApiMocks.getRuntimeLoggingInfo.mockResolvedValue({ effectiveLevel: 'warn' });
+  });
+
+  it('loads initial frontend logging settings through one batch config read', async () => {
+    configApiMocks.getConfigs.mockResolvedValueOnce({
+      [LOGGING_LEVEL_PATH]: 'debug',
+      [LOGGING_INCLUDE_SENSITIVE_PATH]: false,
+    });
+
+    const { initializeFrontendLogLevelSync } = await importSyncModule();
+    await initializeFrontendLogLevelSync();
+
+    expect(configApiMocks.getConfigs).toHaveBeenCalledTimes(1);
+    expect(configApiMocks.getConfigs).toHaveBeenCalledWith([
+      LOGGING_LEVEL_PATH,
+      LOGGING_INCLUDE_SENSITIVE_PATH,
+    ]);
+    expect(configApiMocks.getConfig).not.toHaveBeenCalled();
+    expect(configApiMocks.getRuntimeLoggingInfo).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.setLevel).toHaveBeenCalledWith(1);
+    expect(loggerMocks.setIncludeSensitiveDiagnostics).toHaveBeenCalledWith(false);
+  });
+
+  it('falls back to the runtime log level when the saved frontend level is invalid', async () => {
+    configApiMocks.getConfigs.mockResolvedValueOnce({
+      [LOGGING_LEVEL_PATH]: 'verbose',
+      [LOGGING_INCLUDE_SENSITIVE_PATH]: true,
+    });
+    configApiMocks.getRuntimeLoggingInfo.mockResolvedValueOnce({ effectiveLevel: 'error' });
+
+    const { initializeFrontendLogLevelSync } = await importSyncModule();
+    await initializeFrontendLogLevelSync();
+
+    expect(loggerMocks.setLevel).toHaveBeenCalledWith(4);
+    expect(loggerMocks.setIncludeSensitiveDiagnostics).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/web-ui/src/infrastructure/config/services/FrontendLogLevelSync.ts
+++ b/src/web-ui/src/infrastructure/config/services/FrontendLogLevelSync.ts
@@ -14,6 +14,11 @@ const LOGGING_INCLUDE_SENSITIVE_PATH = 'app.logging.include_sensitive_diagnostic
 let initialSettingsLoaded = false;
 let configWatcherInstalled = false;
 
+interface InitialLoggingSettings {
+  level?: string;
+  includeSensitiveDiagnostics: boolean;
+}
+
 function toFrontendLogLevel(level: string | null | undefined): LogLevel | null {
   switch (level?.trim().toLowerCase()) {
     case 'trace':
@@ -72,29 +77,50 @@ function applyFrontendLogLevel(level: string | null | undefined, source: string)
   });
 }
 
-async function resolveInitialLogLevel(): Promise<string | undefined> {
-  const [savedLevelResult, runtimeInfoResult] = await Promise.allSettled([
-    configAPI.getConfig(LOGGING_LEVEL_PATH) as Promise<BackendLogLevel>,
+async function resolveInitialLoggingSettings(): Promise<InitialLoggingSettings> {
+  const [configResult, runtimeInfoResult] = await Promise.allSettled([
+    configAPI.getConfigs([
+      LOGGING_LEVEL_PATH,
+      LOGGING_INCLUDE_SENSITIVE_PATH,
+    ]),
     configAPI.getRuntimeLoggingInfo(),
   ]);
 
-  if (savedLevelResult.status === 'fulfilled' && toFrontendLogLevel(savedLevelResult.value) !== null) {
-    return savedLevelResult.value;
+  const configs = configResult.status === 'fulfilled' ? configResult.value : {};
+  if (configResult.status === 'rejected') {
+    log.warn('Failed to load frontend logging configs in batch', configResult.reason);
+  }
+
+  const savedLevel = configs[LOGGING_LEVEL_PATH];
+  if (typeof savedLevel === 'string' && toFrontendLogLevel(savedLevel) !== null) {
+    return {
+      level: savedLevel,
+      includeSensitiveDiagnostics:
+        typeof configs[LOGGING_INCLUDE_SENSITIVE_PATH] === 'boolean'
+          ? configs[LOGGING_INCLUDE_SENSITIVE_PATH]
+          : true,
+    };
   }
 
   if (runtimeInfoResult.status === 'fulfilled') {
     const runtimeLevel = runtimeInfoResult.value?.effectiveLevel;
     if (toFrontendLogLevel(runtimeLevel) !== null) {
-      return runtimeLevel;
+      return {
+        level: runtimeLevel,
+        includeSensitiveDiagnostics:
+          typeof configs[LOGGING_INCLUDE_SENSITIVE_PATH] === 'boolean'
+            ? configs[LOGGING_INCLUDE_SENSITIVE_PATH]
+            : true,
+      };
     }
   }
 
-  return undefined;
-}
-
-async function resolveInitialSensitiveDiagnosticsPreference(): Promise<boolean> {
-  const value = await configAPI.getConfig(LOGGING_INCLUDE_SENSITIVE_PATH) as boolean | undefined;
-  return value ?? true;
+  return {
+    includeSensitiveDiagnostics:
+      typeof configs[LOGGING_INCLUDE_SENSITIVE_PATH] === 'boolean'
+        ? configs[LOGGING_INCLUDE_SENSITIVE_PATH]
+        : true,
+  };
 }
 
 export async function initializeFrontendLogLevelSync(): Promise<void> {
@@ -105,12 +131,9 @@ export async function initializeFrontendLogLevelSync(): Promise<void> {
   initialSettingsLoaded = true;
 
   try {
-    const [initialLevel, includeSensitiveDiagnostics] = await Promise.all([
-      resolveInitialLogLevel(),
-      resolveInitialSensitiveDiagnosticsPreference(),
-    ]);
-    applyFrontendLogLevel(initialLevel, 'startup');
-    setIncludeSensitiveDiagnostics(includeSensitiveDiagnostics);
+    const initialSettings = await resolveInitialLoggingSettings();
+    applyFrontendLogLevel(initialSettings.level, 'startup');
+    setIncludeSensitiveDiagnostics(initialSettings.includeSensitiveDiagnostics);
   } catch (error) {
     log.error('Failed to initialize frontend log level sync', error);
   }

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -173,6 +173,7 @@
       "delete": "Delete",
       "confirmEdit": "Confirm",
       "cancelEdit": "Cancel",
+      "loading": "Loading sessions...",
       "showMore": "{{count}} more sessions",
       "showAll": "{{count}} more (show all)",
       "showLess": "Show less",

--- a/src/web-ui/src/locales/en-US/tools.json
+++ b/src/web-ui/src/locales/en-US/tools.json
@@ -43,6 +43,7 @@
       "delete": "Delete"
     },
     "codeEditor": {
+      "preparingEditor": "Preparing editor...",
       "loadingFile": "Loading file...",
       "saving": "Saving...",
       "initFailedWithMessage": "Failed to initialize editor: {{message}}",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -173,6 +173,7 @@
       "delete": "删除",
       "confirmEdit": "确认",
       "cancelEdit": "取消",
+      "loading": "正在加载会话...",
       "showMore": "还有 {{count}} 个会话",
       "showAll": "还有 {{count}} 个（展开全部）",
       "showLess": "收起",

--- a/src/web-ui/src/locales/zh-CN/tools.json
+++ b/src/web-ui/src/locales/zh-CN/tools.json
@@ -43,6 +43,7 @@
       "delete": "删除"
     },
     "codeEditor": {
+      "preparingEditor": "正在准备编辑器...",
       "loadingFile": "正在加载文件...",
       "saving": "正在保存...",
       "initFailedWithMessage": "编辑器初始化失败: {{message}}",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -173,6 +173,7 @@
       "delete": "刪除",
       "confirmEdit": "確認",
       "cancelEdit": "取消",
+      "loading": "正在加載會話...",
       "showMore": "還有 {{count}} 個會話",
       "showAll": "還有 {{count}} 個（展開全部）",
       "showLess": "收起",

--- a/src/web-ui/src/locales/zh-TW/tools.json
+++ b/src/web-ui/src/locales/zh-TW/tools.json
@@ -43,6 +43,7 @@
       "delete": "刪除"
     },
     "codeEditor": {
+      "preparingEditor": "正在準備編輯器...",
       "loadingFile": "正在加載文件...",
       "saving": "正在保存...",
       "initFailedWithMessage": "編輯器初始化失敗: {{message}}",

--- a/src/web-ui/src/main.tsx
+++ b/src/web-ui/src/main.tsx
@@ -19,6 +19,7 @@ import { getMonacoPath, getMonacoWorkerPath, logMonacoResourceCheck } from './to
 import { bootstrapLogger, createLogger, initLogger } from './shared/utils/logger';
 import { elapsedMs, logElapsed, measureAsyncAndLog, nowMs } from './shared/utils/timing';
 import { startupTrace } from './shared/utils/startupTrace';
+import { scheduleAfterStartupSignal } from './shared/utils/startupTaskScheduling';
 import {
   buildReactCrashLogPayload,
   isMinifiedReactErrorMessage,
@@ -301,10 +302,6 @@ async function initializeAfterRender(): Promise<void> {
       const { registerNotificationContextMenu } = await import('./shared/notification-system');
       registerNotificationContextMenu();
     })(),
-    (async () => {
-      const { scheduleMonacoStartupWarmup } = await import('./tools/editor/services/MonacoStartupWarmup');
-      scheduleMonacoStartupWarmup();
-    })(),
   ]);
 
   initResults.forEach((result, index) => {
@@ -315,7 +312,6 @@ async function initializeAfterRender(): Promise<void> {
       'RecommendationProviders',
       'Tools',
       'ContextMenu',
-      'EditorWarmup',
     ];
     if (result.status === 'rejected') {
       log.warn('Initialization failed', { module: names[index], error: result.reason });
@@ -392,11 +388,33 @@ async function startApplication(): Promise<void> {
     sinceStartupMs: elapsedMs(appStartedAt),
   });
 
-  try {
-    await initializeAfterRender();
-  } catch (error) {
-    log.error('Failed to complete post-render initialization', error);
-  }
+  startupTrace.markPhase('non_critical_init_scheduled', {
+    signalName: 'bitfun:main-window-shown',
+    fallbackTimeoutMs: 2000,
+    frameCount: 1,
+  });
+  scheduleAfterStartupSignal(async () => {
+    const nonCriticalStartedAt = nowMs();
+    try {
+      await initializeAfterRender();
+      startupTrace.markPhase('non_critical_init_done', {
+        durationMs: elapsedMs(nonCriticalStartedAt),
+      });
+      startupTrace.flushSummary('non_critical_init_completed');
+    } catch (error) {
+      log.error('Failed to complete post-render initialization', error);
+      startupTrace.markPhase('non_critical_init_failed', {
+        durationMs: elapsedMs(nonCriticalStartedAt),
+      });
+    }
+  }, {
+    signalName: 'bitfun:main-window-shown',
+    fallbackTimeoutMs: 2000,
+    frameCount: 1,
+    onError: error => {
+      log.error('Failed to schedule post-render initialization', error);
+    },
+  });
 
   logElapsed(log, 'Startup phase completed', appStartedAt, {
     data: { phase: 'startApplication' },

--- a/src/web-ui/src/shared/utils/startupTaskScheduling.test.ts
+++ b/src/web-ui/src/shared/utils/startupTaskScheduling.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  scheduleAfterStartupPaint,
+  scheduleAfterStartupSignal,
+} from './startupTaskScheduling';
+
+describe('scheduleAfterStartupPaint', () => {
+  it('runs work only after the requested animation frames', () => {
+    const callbacks: Array<(time: number) => void> = [];
+    const task = vi.fn();
+
+    scheduleAfterStartupPaint(task, {
+      frameCount: 2,
+      requestAnimationFrame: callback => {
+        callbacks.push(callback);
+        return callbacks.length;
+      },
+      cancelAnimationFrame: vi.fn(),
+      setTimeout: vi.fn(),
+      clearTimeout: vi.fn(),
+    });
+
+    expect(task).not.toHaveBeenCalled();
+    expect(callbacks).toHaveLength(1);
+
+    callbacks.shift()?.(16);
+    expect(task).not.toHaveBeenCalled();
+    expect(callbacks).toHaveLength(1);
+
+    callbacks.shift()?.(32);
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels queued animation-frame work', () => {
+    const callbacks: Array<(time: number) => void> = [];
+    const cancelAnimationFrame = vi.fn();
+    const task = vi.fn();
+
+    const cancel = scheduleAfterStartupPaint(task, {
+      frameCount: 2,
+      requestAnimationFrame: callback => {
+        callbacks.push(callback);
+        return callbacks.length;
+      },
+      cancelAnimationFrame,
+      setTimeout: vi.fn(),
+      clearTimeout: vi.fn(),
+    });
+
+    cancel();
+    callbacks.shift()?.(16);
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(1);
+    expect(task).not.toHaveBeenCalled();
+  });
+
+  it('waits for the startup signal before scheduling paint-delayed work', () => {
+    const callbacks: Array<(time: number) => void> = [];
+    let signalHandler: (() => void) | null = null;
+    const addEventListener = vi.fn((_name: string, handler: EventListenerOrEventListenerObject) => {
+      signalHandler = handler as () => void;
+    });
+    const removeEventListener = vi.fn();
+    const setTimeout = vi.fn();
+    const task = vi.fn();
+
+    scheduleAfterStartupSignal(task, {
+      frameCount: 1,
+      signalName: 'bitfun:main-window-shown',
+      signalTarget: { addEventListener, removeEventListener },
+      fallbackTimeoutMs: 2000,
+      requestAnimationFrame: callback => {
+        callbacks.push(callback);
+        return callbacks.length;
+      },
+      cancelAnimationFrame: vi.fn(),
+      setTimeout,
+      clearTimeout: vi.fn(),
+    });
+
+    expect(addEventListener).toHaveBeenCalledWith('bitfun:main-window-shown', expect.any(Function));
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 2000);
+    expect(task).not.toHaveBeenCalled();
+
+    signalHandler?.();
+    expect(task).not.toHaveBeenCalled();
+    callbacks.shift()?.(16);
+
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(removeEventListener).toHaveBeenCalledWith('bitfun:main-window-shown', expect.any(Function));
+  });
+
+  it('falls back when the startup signal is not observed', () => {
+    const callbacks: Array<(time: number) => void> = [];
+    let fallback: (() => void) | null = null;
+    const task = vi.fn();
+
+    scheduleAfterStartupSignal(task, {
+      frameCount: 1,
+      signalTarget: {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+      fallbackTimeoutMs: 2000,
+      requestAnimationFrame: callback => {
+        callbacks.push(callback);
+        return callbacks.length;
+      },
+      cancelAnimationFrame: vi.fn(),
+      setTimeout: callback => {
+        fallback = callback;
+        return 1;
+      },
+      clearTimeout: vi.fn(),
+    });
+
+    fallback?.();
+    callbacks.shift()?.(16);
+
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/shared/utils/startupTaskScheduling.ts
+++ b/src/web-ui/src/shared/utils/startupTaskScheduling.ts
@@ -1,0 +1,138 @@
+export interface StartupPaintSchedulingOptions {
+  frameCount?: number;
+  requestAnimationFrame?: (callback: FrameRequestCallback) => number;
+  cancelAnimationFrame?: (handle: number) => void;
+  setTimeout?: (callback: () => void, timeout: number) => number;
+  clearTimeout?: (handle: number) => void;
+  onError?: (error: unknown) => void;
+}
+
+export interface StartupSignalSchedulingOptions extends StartupPaintSchedulingOptions {
+  signalName?: string;
+  signalTarget?: Pick<EventTarget, 'addEventListener' | 'removeEventListener'>;
+  fallbackTimeoutMs?: number;
+}
+
+export function scheduleAfterStartupPaint(
+  task: () => void | Promise<void>,
+  options: StartupPaintSchedulingOptions = {}
+): () => void {
+  const frameCount = Math.max(1, Math.floor(options.frameCount ?? 2));
+  const requestFrame =
+    options.requestAnimationFrame ?? globalThis.requestAnimationFrame?.bind(globalThis);
+  const cancelFrame =
+    options.cancelAnimationFrame ?? globalThis.cancelAnimationFrame?.bind(globalThis);
+  const setTimer =
+    options.setTimeout ?? ((callback, timeout) => globalThis.setTimeout(callback, timeout) as unknown as number);
+  const clearTimer =
+    options.clearTimeout ?? ((handle) => globalThis.clearTimeout(handle));
+
+  let cancelled = false;
+  let activeFrameHandle: number | null = null;
+  let activeTimerHandle: number | null = null;
+
+  const runTask = () => {
+    if (cancelled) {
+      return;
+    }
+    activeFrameHandle = null;
+    activeTimerHandle = null;
+    try {
+      void Promise.resolve(task()).catch(error => {
+        options.onError?.(error);
+      });
+    } catch (error) {
+      options.onError?.(error);
+    }
+  };
+
+  if (!requestFrame) {
+    activeTimerHandle = setTimer(runTask, 0);
+    return () => {
+      cancelled = true;
+      if (activeTimerHandle !== null) {
+        clearTimer(activeTimerHandle);
+        activeTimerHandle = null;
+      }
+    };
+  }
+
+  let remainingFrames = frameCount;
+  const scheduleNextFrame = () => {
+    if (cancelled) {
+      return;
+    }
+    activeFrameHandle = requestFrame(() => {
+      remainingFrames -= 1;
+      if (remainingFrames <= 0) {
+        runTask();
+        return;
+      }
+      scheduleNextFrame();
+    });
+  };
+
+  scheduleNextFrame();
+
+  return () => {
+    cancelled = true;
+    if (activeFrameHandle !== null && cancelFrame) {
+      cancelFrame(activeFrameHandle);
+      activeFrameHandle = null;
+    }
+  };
+}
+
+export function scheduleAfterStartupSignal(
+  task: () => void | Promise<void>,
+  options: StartupSignalSchedulingOptions = {}
+): () => void {
+  const signalName = options.signalName ?? 'bitfun:main-window-shown';
+  const signalTarget =
+    options.signalTarget ?? (typeof window !== 'undefined' ? window : undefined);
+  const fallbackTimeoutMs = Math.max(0, options.fallbackTimeoutMs ?? 2000);
+  const setTimer =
+    options.setTimeout ?? ((callback, timeout) => globalThis.setTimeout(callback, timeout) as unknown as number);
+  const clearTimer =
+    options.clearTimeout ?? ((handle) => globalThis.clearTimeout(handle));
+
+  let cancelled = false;
+  let started = false;
+  let fallbackTimer: number | null = null;
+  let cancelPaintTask: (() => void) | null = null;
+
+  const cleanupSignal = () => {
+    signalTarget?.removeEventListener(signalName, startAfterSignal);
+  };
+
+  const clearFallback = () => {
+    if (fallbackTimer !== null) {
+      clearTimer(fallbackTimer);
+      fallbackTimer = null;
+    }
+  };
+
+  function startAfterSignal() {
+    if (cancelled || started) {
+      return;
+    }
+    started = true;
+    cleanupSignal();
+    clearFallback();
+    cancelPaintTask = scheduleAfterStartupPaint(task, options);
+  }
+
+  if (signalTarget) {
+    signalTarget.addEventListener(signalName, startAfterSignal);
+    fallbackTimer = setTimer(startAfterSignal, fallbackTimeoutMs);
+  } else {
+    fallbackTimer = setTimer(startAfterSignal, 0);
+  }
+
+  return () => {
+    cancelled = true;
+    cleanupSignal();
+    clearFallback();
+    cancelPaintTask?.();
+  };
+}

--- a/src/web-ui/src/tools/editor/components/CodeEditor.tsx
+++ b/src/web-ui/src/tools/editor/components/CodeEditor.tsx
@@ -159,7 +159,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
   autoSave = false,
   autoSaveDelayMs = 800,
 }) => {
-  // Decode URL-encoded paths (e.g. d%3A/path -> d:/path)
+  // Decode URL-encoded paths before handing them to the editor.
   const filePath = useMemo(() => {
     try {
       if (rawFilePath.includes('%')) {
@@ -1015,10 +1015,38 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
   }, [monacoReady, applyExternalContentToModel]);
 
   useEffect(() => {
-    if (content && !lspReady) {
-      setLspReady(true);
+    if (!content || lspReady) {
+      return;
     }
-  }, [content, lspReady]);
+
+    let cancelled = false;
+    void (async () => {
+      if (!enableLsp || largeFileMode) {
+        if (!cancelled) {
+          setLspReady(true);
+        }
+        return;
+      }
+
+      try {
+        const { ensureWorkspaceLspInitialized, initializeLsp } = await import('@/tools/lsp/initializeLsp');
+        await initializeLsp();
+        if (lspExtensionRegistry.isFileSupported(filePath)) {
+          await ensureWorkspaceLspInitialized(workspacePath);
+        }
+      } catch (error) {
+        log.warn('Failed to initialize LSP on editor open', { filePath, workspacePath, error });
+      }
+
+      if (!cancelled) {
+        setLspReady(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [content, enableLsp, filePath, largeFileMode, lspReady, workspacePath]);
 
   useEffect(() => {
     if (modelRef.current && monacoReady) {
@@ -2094,6 +2122,10 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
     };
   }, [monacoReady]);
 
+  const loadingOverlayText = monacoReady
+    ? t('editor.codeEditor.loadingFile')
+    : t('editor.codeEditor.preparingEditor');
+
   return (
     <div 
       className={`code-editor-tool ${className} ${loading && showLoadingOverlay ? 'is-loading' : ''} ${error ? 'is-error' : ''} ${largeFileMode ? 'is-large-file-mode' : ''}`}
@@ -2123,7 +2155,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
 
       {loading && showLoadingOverlay && (
         <div className="code-editor-tool__loading-overlay">
-          <CubeLoading size="medium" text={t('editor.codeEditor.loadingFile')} />
+          <CubeLoading size="medium" text={loadingOverlayText} />
         </div>
       )}
 

--- a/src/web-ui/src/tools/lsp/initializeLsp.test.ts
+++ b/src/web-ui/src/tools/lsp/initializeLsp.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const registryMock = vi.hoisted(() => ({
+  initialize: vi.fn(),
+}));
+
+const workspaceInitializerMock = vi.hoisted(() => ({
+  start: vi.fn(),
+  initializeWorkspace: vi.fn(),
+}));
+
+vi.mock('./services/LspDiagnostics', () => ({}));
+vi.mock('./services/LspExtensionRegistry', () => ({
+  lspExtensionRegistry: registryMock,
+}));
+vi.mock('./services/WorkspaceLspInitializer', () => ({
+  workspaceLspInitializer: workspaceInitializerMock,
+}));
+
+describe('initializeLsp', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    registryMock.initialize.mockResolvedValue(undefined);
+    workspaceInitializerMock.initializeWorkspace.mockResolvedValue(undefined);
+  });
+
+  it('initializes only lightweight LSP configuration by default', async () => {
+    const { initializeLsp } = await import('./initializeLsp');
+
+    await initializeLsp();
+
+    expect(registryMock.initialize).toHaveBeenCalledTimes(1);
+    expect(workspaceInitializerMock.start).not.toHaveBeenCalled();
+    expect(workspaceInitializerMock.initializeWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('initializes a workspace only when LSP is needed', async () => {
+    const { ensureWorkspaceLspInitialized } = await import('./initializeLsp');
+
+    await ensureWorkspaceLspInitialized('D:/workspace/BitFun');
+
+    expect(registryMock.initialize).toHaveBeenCalledTimes(1);
+    expect(workspaceInitializerMock.start).not.toHaveBeenCalled();
+    expect(workspaceInitializerMock.initializeWorkspace).toHaveBeenCalledWith(
+      'D:/workspace/BitFun',
+      { prestartServers: false }
+    );
+  });
+});

--- a/src/web-ui/src/tools/lsp/initializeLsp.ts
+++ b/src/web-ui/src/tools/lsp/initializeLsp.ts
@@ -9,18 +9,39 @@ import { createLogger } from '@/shared/utils/logger';
 
 import './services/LspDiagnostics';
 import { lspExtensionRegistry } from './services/LspExtensionRegistry';
-import { workspaceLspInitializer } from './services/WorkspaceLspInitializer';
 
 const log = createLogger('LSP');
+let lspInitializationPromise: Promise<void> | null = null;
 
 export async function initializeLsp(): Promise<void> {
+  if (lspInitializationPromise) {
+    return lspInitializationPromise;
+  }
+
+  lspInitializationPromise = initializeLspOnce();
+  return lspInitializationPromise;
+}
+
+async function initializeLspOnce(): Promise<void> {
   try {
     await lspExtensionRegistry.initialize();
-    workspaceLspInitializer.start();
     installLspDiagnosticTools();
   } catch (error) {
+    lspInitializationPromise = null;
     log.error('Failed to initialize LSP module', { error });
   }
+}
+
+export async function ensureWorkspaceLspInitialized(workspacePath?: string): Promise<void> {
+  await initializeLsp();
+  if (!workspacePath) {
+    return;
+  }
+
+  const { workspaceLspInitializer } = await import('./services/WorkspaceLspInitializer');
+  await workspaceLspInitializer.initializeWorkspace(workspacePath, {
+    prestartServers: false,
+  });
 }
 
 /**
@@ -187,7 +208,9 @@ function installLspDiagnosticTools() {
     },
   };
 
-  (window as any).LspDiag = lspDiag;
+  if (typeof window !== 'undefined') {
+    (window as any).LspDiag = lspDiag;
+  }
 }
 
 function loadMonacoLspDiagnostics() {

--- a/src/web-ui/src/tools/lsp/services/WorkspaceLspInitializer.ts
+++ b/src/web-ui/src/tools/lsp/services/WorkspaceLspInitializer.ts
@@ -21,6 +21,10 @@ interface ProjectInfo {
   totalFiles: number;
 }
 
+interface InitializeWorkspaceOptions {
+  prestartServers?: boolean;
+}
+
 class WorkspaceLspInitializer {
   private static instance: WorkspaceLspInitializer | null = null;
   private removeListener: (() => void) | null = null;
@@ -67,6 +71,13 @@ class WorkspaceLspInitializer {
   }
   
   private async handleWorkspaceOpened(workspacePath: string): Promise<void> {
+    await this.initializeWorkspace(workspacePath, { prestartServers: true });
+  }
+
+  async initializeWorkspace(
+    workspacePath: string,
+    options: InitializeWorkspaceOptions = {}
+  ): Promise<void> {
     try {
       const manager = WorkspaceLspManager.getOrCreate(workspacePath);
       
@@ -74,7 +85,7 @@ class WorkspaceLspInitializer {
       
       log.info('LSP initialized for workspace', { workspacePath });
 
-      if (!lspConfigService.isAutoStartEnabled()) {
+      if (!options.prestartServers || !lspConfigService.isAutoStartEnabled()) {
         return;
       }
 


### PR DESCRIPTION
## Summary
Tracking issue: #949

- Show the desktop main window from the native startup path, while keeping the frontend show path as a fallback and visibility checkpoint.
- Move non-critical startup work behind the first visible shell / idle boundary, including IDE, MCP, ACP startup probes and MiniApp catalog refresh.
- Page session metadata loading so startup fetches only initially visible rows; explicit expand / show-more actions load the next page with loading feedback.
- Keep workspace and session sections visually expanded by default, so this does not hide existing navigation content to obtain the startup win.
- Remove the pre-React static logo layer and preserve the Tauri-injected theme background to avoid the black-logo-to-white-logo startup flash.
- Keep editor/LSP startup lazy and show a first-open loading prompt for the longer editor initialization path.
- Keep paged session reads on the maintained session index fast path; the page API validates stale entries only for the returned page, while full-list/rebuild paths keep the broader index integrity check.
- Maintain the session metadata index count incrementally on writes/deletes so the startup fast path does not reintroduce an O(number of sessions) directory scan during normal metadata saves.

## Performance Data
Benchmark method: Windows desktop `release-fast` cold launches, 10 runs per build. The comparison uses the same packaged WebView path (`tauri.localhost`) for baseline and stage 1. Baseline snapshot: `main@9fa991f6`; PR head: `bf1163d0`. The branch is rebased onto `gcwing/main@8a93ed70`; the newer base commits are i18n contract guardrails and remote-connect owner migration changes, not frontend startup changes.

| P50 metric | Baseline | Stage 1 | Delta |
| --- | ---: | ---: | ---: |
| Native window show since process start | n/a | 888.5 ms | n/a |
| `main_window_shown` | 1504.7 ms | 1101.8 ms | -402.9 ms (-26.8%) |
| `start_application_end` | 1455.7 ms | 1035.6 ms | -420.1 ms (-28.9%) |
| `startApplicationDurationMs` | 614.7 ms | 27.7 ms | -586.9 ms (-95.5%) |
| `afterRenderDurationMs` | 584.1 ms | 461.4 ms | -122.7 ms (-21.0%) |
| Primary startup API count | 15.5 | 7.0 | -8.5 (-54.8%) |
| Primary startup response bytes | 12,891 | 7,699 | -5,192 (-40.3%) |
| Session metadata loaded | 187 | 27 | -160 (-85.6%) |
| Max session metadata duration | 175.1 ms | 53.3 ms | -121.8 ms (-69.6%) |
| `interactive_shell_ready` | 1538.9 ms | 1628.4 ms | +89.4 ms (+5.8%) |

Additional notes:
- `mainWindowShownReason` was `startup-native` in all 10 stage-1 runs, with zero frontend fallback shows.
- The Windows maximize wait is preserved from the existing startup path. A previous no-wait run was excluded from the table because it was not an apples-to-apples packaged WebView run.
- A focused local metadata benchmark after the final audit fix reports `page5_avg_ms=11.550` versus `full_list_avg_ms=88.142` for 1000 sessions, or about 7.6x faster for the paged backend path.

## Risks and Tradeoffs
- First visible window time improves by about 403 ms p50, but `interactive_shell_ready` p50 is still about 89 ms slower. Follow-up work should target React mount/effect cost and shell readiness directly.
- Deferred ACP / IDE / MCP startup means the first on-demand operation may pay the deferred fetch or startup cost. ACP menu client loading now has an explicit loading state.
- Session sections remain expanded by default. Only explicit user collapse suppresses metadata fetching, and clicking show more loads the next visible page.
- Paged session metadata now trusts the maintained index for startup performance and validates stale entries on the returned page. Out-of-band metadata writes outside the current page may require the full-list/rebuild path before they appear.
- Native startup now reveals a theme-colored shell before React renders. The extra pre-React logo was removed because it caused a double-logo flash.

## Verification
- `pnpm run fmt:rs`
- `pnpm run check:repo-hygiene`
- `pnpm run check:github-config`
- `pnpm run i18n:generate`
- `pnpm run i18n:audit`
- `pnpm run i18n:contract:test`
- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run`
- `cargo test -p bitfun-core list_session_metadata_page -- --nocapture`
- `cargo test -p bitfun-core bench_session_metadata_page_vs_full_list -- --ignored --nocapture`
- `cargo test -p bitfun-core`
- `cargo check --workspace`
- `git diff --check`
- `git diff --cached --check`
