### PR TITLE
ci: strengthen contribution governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: Report a reproducible bug or regression.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve BitFun. Please provide enough detail for maintainers to reproduce and route the issue.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+      placeholder: Briefly describe the bug.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Desktop app
+        - Web UI
+        - Mobile web
+        - Agent runtime / core
+        - AI provider / model adapter
+        - Remote workspace / relay
+        - Installer / packaging
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List exact steps from a clean state when possible.
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the version, commit, OS, browser, desktop/mobile device, model/provider, or deployment mode if relevant.
+      placeholder: |
+        BitFun version/commit:
+        OS:
+        Browser/device:
+        Model/provider:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or recordings
+      description: Paste relevant logs or attach images/recordings. Remove tokens, keys, user IDs, and private data.
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Regression?
+      options:
+        - "No"
+        - "Yes"
+        - "Not sure"
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else that may help triage the issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/GCWing/BitFun/security/advisories/new
+    about: Please report security issues privately instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,36 @@
+name: Documentation issue
+description: Report missing, outdated, confusing, or incorrect documentation.
+title: "[Docs]: "
+body:
+  - type: textarea
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link the page or file path if known.
+      placeholder: README.md, CONTRIBUTING.md, docs/..., website page, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is missing, outdated, confusing, or incorrect?
+    validations:
+      required: true
+  - type: textarea
+    id: suggested
+    attributes:
+      label: Suggested update
+      description: Optional. Describe the wording or structure you expected.
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Audience
+      options:
+        - New user
+        - Contributor
+        - Maintainer
+        - Developer integrating with BitFun
+        - Not sure
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+name: Feature or product proposal
+description: Suggest a user-facing feature, workflow improvement, or product direction.
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for product ideas, UX improvements, and new workflows. For small bugs, use the bug report form.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / opportunity
+      description: What user problem, workflow gap, or product opportunity should this address?
+      placeholder: Describe the current pain point and who experiences it.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should BitFun do differently?
+      placeholder: Describe the desired behavior or workflow.
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Product surface
+      options:
+        - Desktop app
+        - Web UI
+        - Mobile web
+        - Agent runtime / core
+        - AI provider / model adapter
+        - Remote workspace / relay
+        - Installer / packaging
+        - Documentation
+        - Cross-cutting
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What must be true for this to feel complete?
+      placeholder: |
+        - Users can ...
+        - The UI shows ...
+        - It works when ...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Mention other approaches or existing tools/workarounds.
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks or open questions
+      description: Optional. Include compatibility, privacy, performance, remote workspace, or UX concerns.
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution intent
+      options:
+        - label: I plan to open a PR for this.
+          required: false
+        - label: I can help test or provide feedback.
+          required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,71 @@
+## Summary
+
+<!-- Briefly describe what changed. -->
+
+## Motivation / Product Context
+
+<!-- What user or developer problem does this solve? Link issue/discussion if applicable. -->
+
+Fixes #
+
+## PR Type
+
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Regression fix
+- [ ] Refactor
+- [ ] UI / UX
+- [ ] Docs
+- [ ] Tests
+- [ ] Build / CI / release
+- [ ] Dependency update
+- [ ] AI-assisted prototype or iteration
+
+## Changed Areas
+
+- [ ] Rust core / agent runtime
+- [ ] Desktop / Tauri integration
+- [ ] Web UI
+- [ ] Mobile web
+- [ ] Server / relay / remote control
+- [ ] AI adapters / model providers
+- [ ] Installer / packaging
+- [ ] Docs only
+
+## User Impact
+
+<!-- Describe before/after behavior. For non-user-facing changes, write "No direct user-facing change". -->
+
+## Design / Architecture Notes
+
+<!-- Required for product behavior, cross-module changes, agent loop changes, remote workspace behavior, or shared abstractions. -->
+
+## Verification
+
+Verification scope:
+
+<!-- Select the relevant checks from CONTRIBUTING.md based on the changed areas. -->
+
+Commands run and results:
+
+<!-- List the exact commands and outcomes, for example: `pnpm run lint:web` -> pass. Write "N/A" for docs-only changes with no runnable check. -->
+
+Manual verification:
+
+<!-- Screenshots/recordings for UI changes; reproduction steps for bug fixes. -->
+
+Skipped checks:
+
+<!-- List any relevant checks not run and why. Write "N/A" if none. -->
+
+## Risk and Rollback
+
+<!-- Main risks, compatibility concerns, migration impact, and how to revert or disable if needed. -->
+
+## Checklist
+
+- [ ] This PR is focused and does not bundle unrelated changes.
+- [ ] No secrets, tokens, local absolute paths, temporary prompts, generated scratch files, or unrelated artifacts are committed.
+- [ ] User-facing strings are localized where applicable.
+- [ ] Docs are updated or intentionally not needed.
+- [ ] AI-assisted work is disclosed with testing level: untested / lightly tested / fully tested.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=6144
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -112,14 +114,29 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      - name: Check repository hygiene
+        run: pnpm run check:repo-hygiene
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Validate GitHub config
+        run: pnpm run check:github-config
 
       - name: Lint web UI
         run: pnpm run lint:web
 
+      - name: Run web UI tests
+        run: pnpm --dir src/web-ui run test:run
+
       - name: Build web UI
         run: pnpm run build:web
+
+      - name: Type-check mobile web
+        run: pnpm --dir src/mobile-web run type-check
+
+      - name: Build mobile web
+        run: pnpm run build:mobile-web
 
       - name: Upload frontend build artifacts
         uses: actions/upload-artifact@v4

--- a/AGENTS-CN.md
+++ b/AGENTS-CN.md
@@ -2,7 +2,7 @@
 
 # AGENTS-CN.md
 
-BitFun 是一个由 Rust workspace 与共享 React 前端组成的项目。
+BitFun 是一个由 Rust workspace 与 React 前端组成的项目。
 
 仓库核心原则：**先保持产品逻辑平台无关，再通过平台适配层对外暴露能力**。
 
@@ -19,7 +19,10 @@ BitFun 是一个由 Rust workspace 与共享 React 前端组成的项目。
 |---|---|---|
 | Core（产品逻辑） | `src/crates/core` | [AGENTS.md](src/crates/core/AGENTS.md) |
 | 已拆出的 core 支撑 crate | `src/crates/{core-types,agent-stream,runtime-ports,terminal,tool-runtime}` | （使用 core 指南） |
-| Core owner crate | `src/crates/{services-core,services-integrations,agent-tools,tool-packs}` | （使用 core 指南 + 拆解护栏） |
+| Service core owner crate | `src/crates/services-core` | [AGENTS.md](src/crates/services-core/AGENTS.md) |
+| Service integrations owner crate | `src/crates/services-integrations` | [AGENTS.md](src/crates/services-integrations/AGENTS.md) |
+| Agent tool contracts | `src/crates/agent-tools` | [AGENTS.md](src/crates/agent-tools/AGENTS.md) |
+| Tool pack provider plan | `src/crates/tool-packs` | [AGENTS.md](src/crates/tool-packs/AGENTS.md) |
 | 产品领域 crate | `src/crates/product-domains` | [AGENTS.md](src/crates/product-domains/AGENTS.md) |
 | Transport 适配层 | `src/crates/transport` | （使用 core 指南） |
 | API layer | `src/crates/api-layer` | （使用 core 指南） |
@@ -30,6 +33,7 @@ BitFun 是一个由 Rust workspace 与共享 React 前端组成的项目。
 | CLI | `src/apps/cli` | （使用 core 指南） |
 | 中继服务器 | `src/apps/relay-server` | （使用 core 指南） |
 | 共享前端 | `src/web-ui` | [AGENTS.md](src/web-ui/AGENTS.md) |
+| Mobile web | `src/mobile-web` | [AGENTS.md](src/mobile-web/AGENTS.md) |
 | 安装器 | `BitFun-Installer` | [AGENTS.md](BitFun-Installer/AGENTS.md) |
 | E2E 测试 | `tests/e2e` | [AGENTS.md](tests/e2e/AGENTS.md) |
 
@@ -49,6 +53,9 @@ pnpm run cli:dev                   # CLI 运行时
 pnpm run fmt:rs                     # 只格式化已改动 / 已暂存的 Rust 文件
 pnpm run lint:web
 pnpm run type-check:web
+pnpm --dir src/mobile-web run type-check
+pnpm run check:repo-hygiene
+pnpm run check:github-config
 cargo check --workspace
 
 # 测试
@@ -58,6 +65,7 @@ cargo test --workspace
 # 构建
 cargo build -p bitfun-desktop
 pnpm run build:web
+pnpm run build:mobile-web
 
 # 快速构建（开发 / CI 提速）
 pnpm run desktop:build:fast           # debug 构建，不打包
@@ -164,6 +172,7 @@ SessionManager → Session → DialogTurn → ModelRound
 | 改动类型 | 最低验证要求 |
 |---|---|
 | 前端 UI、状态、适配层或多语言文案 | `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run` |
+| Mobile web UI、状态、配对、断开或重连行为 | `pnpm --dir src/mobile-web run type-check && pnpm run build:mobile-web`；行为变化还需要在 PR 中说明手动配对 / 重连验证 |
 | Deep Review / 代码审核团队行为 | 运行上面的前端验证，再运行 `cargo test -p bitfun-core deep_review -- --nocapture`；如果触及后端或 Tauri API，还需要运行下方 Rust / 桌面端验证 |
 | `core`、`transport`、`api-layer` 或共享服务中的 Rust 逻辑 | `cargo check --workspace && cargo test --workspace` |
 | 桌面端集成、Tauri API、browser/computer-use 或桌面专属行为 | `cargo check -p bitfun-desktop && cargo test -p bitfun-desktop` |
@@ -176,7 +185,8 @@ SessionManager → Session → DialogTurn → ModelRound
 | 功能 | 关键路径 |
 |---|---|
 | Agent mode | `src/crates/core/src/agentic/agents/`、`src/crates/core/src/agentic/agents/prompts/`、`src/web-ui/src/locales/*/scenes/agents.json` |
-| Deep Review / 代码审核团队 | `src/crates/core/src/agentic/deep_review_policy.rs`、`src/crates/core/src/agentic/agents/deep_review_agent.rs`、`src/crates/core/src/agentic/tools/implementations/{task_tool.rs,code_review_tool.rs}`、`src/web-ui/src/shared/services/reviewTeamService.ts`、`src/web-ui/src/flow_chat/services/DeepReviewService.ts`、`src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.tsx` |
+| Deep Review / 代码审核团队 | `src/crates/core/src/agentic/deep_review/`、`src/crates/core/src/agentic/deep_review_policy.rs`、`src/crates/core/src/agentic/agents/definitions/hidden/deep_review.rs`、`src/crates/core/src/agentic/tools/implementations/{task_tool.rs,code_review_tool.rs}`、`src/web-ui/src/shared/services/review-team/`、`src/web-ui/src/flow_chat/deep-review/`、`src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.tsx` |
+| Mobile web 配对 / 远程控制 | `src/mobile-web/src/pages/PairingPage.tsx`、`src/mobile-web/src/pages/SessionListPage.tsx`、`src/mobile-web/src/pages/ChatPage.tsx`、`src/mobile-web/src/services/RemoteSessionManager.ts`、`src/mobile-web/src/services/RelayHttpClient.ts`、`src/mobile-web/src/services/store.ts` |
 | 会话用量报告（`/usage`） | `src/crates/core/src/service/session_usage/`、`src/web-ui/src/flow_chat/components/usage/`、`src/web-ui/src/locales/*/flow-chat.json` |
 | Tool | `src/crates/core/src/agentic/tools/implementations/`、`src/crates/core/src/agentic/tools/registry.rs` |
 | MCP / LSP / remote | `src/crates/core/src/service/mcp/`、`src/crates/core/src/service/lsp/`、`src/crates/core/src/service/remote_connect/`、`src/crates/core/src/service/remote_ssh/` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 # AGENTS.md
 
-BitFun is a Rust workspace plus a shared React frontend.
+BitFun is a Rust workspace plus React frontends.
 
 Repository rule: **keep product logic platform-agnostic, then expose it through platform adapters**.
 
@@ -33,6 +33,7 @@ Repository rule: **keep product logic platform-agnostic, then expose it through 
 | CLI | `src/apps/cli` | (use core guide) |
 | Relay server | `src/apps/relay-server` | (use core guide) |
 | Shared frontend | `src/web-ui` | [AGENTS.md](src/web-ui/AGENTS.md) |
+| Mobile web | `src/mobile-web` | [AGENTS.md](src/mobile-web/AGENTS.md) |
 | Installer | `BitFun-Installer` | [AGENTS.md](BitFun-Installer/AGENTS.md) |
 | E2E tests | `tests/e2e` | [AGENTS.md](tests/e2e/AGENTS.md) |
 
@@ -52,6 +53,9 @@ pnpm run cli:dev                   # CLI runtime
 pnpm run fmt:rs                     # format only changed / staged Rust files
 pnpm run lint:web
 pnpm run type-check:web
+pnpm --dir src/mobile-web run type-check
+pnpm run check:repo-hygiene
+pnpm run check:github-config
 cargo check --workspace
 
 # Test
@@ -61,6 +65,7 @@ cargo test --workspace
 # Build
 cargo build -p bitfun-desktop
 pnpm run build:web
+pnpm run build:mobile-web
 
 # Fast builds (for development / CI speed)
 pnpm run desktop:build:fast           # debug build, no bundling
@@ -171,6 +176,7 @@ Session data is stored under `.bitfun/sessions/{session_id}/`.
 | Change type | Minimum verification |
 |---|---|
 | Frontend UI, state, adapters, or locales | `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run` |
+| Mobile web UI, state, pairing, disconnect, or reconnect behavior | `pnpm --dir src/mobile-web run type-check && pnpm run build:mobile-web`; include manual pairing / reconnect verification when behavior changes |
 | Deep Review / Code Review Team behavior | Web UI verification above, plus `cargo test -p bitfun-core deep_review -- --nocapture`; also run the Rust / desktop rows below when backend or Tauri APIs are touched |
 | Shared Rust logic in `core`, `transport`, `api-layer`, or services | `cargo check --workspace && cargo test --workspace` |
 | Desktop integration, Tauri APIs, browser/computer-use, or desktop-only behavior | `cargo check -p bitfun-desktop && cargo test -p bitfun-desktop` |
@@ -183,7 +189,8 @@ Session data is stored under `.bitfun/sessions/{session_id}/`.
 | Feature | Key paths |
 |---|---|
 | Agent modes | `src/crates/core/src/agentic/agents/`, `src/crates/core/src/agentic/agents/prompts/`, `src/web-ui/src/locales/*/scenes/agents.json` |
-| Deep Review / Code Review Team | `src/crates/core/src/agentic/deep_review/`, `src/crates/core/src/agentic/deep_review_policy.rs`, `src/crates/core/src/agentic/agents/deep_review_agent.rs`, `src/crates/core/src/agentic/tools/implementations/{task_tool.rs,code_review_tool.rs}`, `src/web-ui/src/shared/services/review-team/`, `src/web-ui/src/flow_chat/deep-review/`, `src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.tsx` |
+| Deep Review / Code Review Team | `src/crates/core/src/agentic/deep_review/`, `src/crates/core/src/agentic/deep_review_policy.rs`, `src/crates/core/src/agentic/agents/definitions/hidden/deep_review.rs`, `src/crates/core/src/agentic/tools/implementations/{task_tool.rs,code_review_tool.rs}`, `src/web-ui/src/shared/services/review-team/`, `src/web-ui/src/flow_chat/deep-review/`, `src/web-ui/src/app/scenes/agents/components/ReviewTeamPage.tsx` |
+| Mobile web pairing / remote control | `src/mobile-web/src/pages/PairingPage.tsx`, `src/mobile-web/src/pages/SessionListPage.tsx`, `src/mobile-web/src/pages/ChatPage.tsx`, `src/mobile-web/src/services/RemoteSessionManager.ts`, `src/mobile-web/src/services/RelayHttpClient.ts`, `src/mobile-web/src/services/store.ts` |
 | Session usage report (`/usage`) | `src/crates/core/src/service/session_usage/`, `src/web-ui/src/flow_chat/components/usage/`, `src/web-ui/src/locales/*/flow-chat.json` |
 | Tools | `src/crates/core/src/agentic/tools/implementations/`, `src/crates/core/src/agentic/tools/registry.rs` |
 | MCP / LSP / remote | `src/crates/core/src/service/mcp/`, `src/crates/core/src/service/lsp/`, `src/crates/core/src/service/remote_connect/`, `src/crates/core/src/service/remote_ssh/` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,7 @@ We welcome contributions beyond standard feature or bug-fix PRs. Examples includ
 
 - Open an issue to describe the problem or proposal, especially for larger changes, to avoid duplication and design conflicts
 - For new features or UI changes, discuss the design direction early to ensure it fits the product experience
+- Use the issue and PR templates. If a field does not apply, write "N/A" instead of deleting the section.
 
 ### PR title and description
 
@@ -155,6 +156,8 @@ UI changes should include before/after screenshots or a short recording for fast
 
 If your work is AI-assisted, please note it in the PR and indicate testing level (untested/lightly tested/fully tested) to help reviewers assess risk.
 
+Do not commit transient AI prompts, local absolute paths, generated scratch files, pairing secrets, tokens, certificates, or unrelated artifacts. Keep the PR focused on the intended product or maintenance change.
+
 ### Branch management
 
 **The `main` branch is the default collaboration branch and accepts feature PRs.** Since this repo encourages product managers and developers to use AI-generated code for rapid validation or idea submission, **please open all PRs targeting the `main` branch**.
@@ -169,13 +172,16 @@ Run relevant tests for your change:
 
 For `/usage` UI copy changes, keep `en-US`, `zh-CN`, and `zh-TW` locale strings in sync.
 
-```bash
-# Rust
-cargo test --workspace
+| Change type | Recommended verification |
+| --- | --- |
+| Repository metadata, PR/issue templates, or GitHub workflows | `pnpm run check:repo-hygiene && pnpm run check:github-config && git diff --check` |
+| Web UI, state, adapters, or locale changes | `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run` |
+| Mobile web UI, pairing, reconnect, disconnect, or chat-flow changes | `pnpm --dir src/mobile-web run type-check && pnpm run build:mobile-web` |
+| Rust core, transport, API layer, services, or shared runtime logic | `cargo check --workspace && cargo test --workspace` |
+| Desktop integration, Tauri APIs, or desktop-only behavior | `cargo check -p bitfun-desktop && cargo test -p bitfun-desktop` |
+| E2E-covered behavior | Build the nearest app target, then run the closest E2E spec or `pnpm run e2e:test:l0` |
 
-# E2E
-pnpm run e2e:test
-```
+For mobile-web pairing, reconnect, disconnect, or chat-flow changes, include manual verification steps and screenshots or a short recording when the UI changes.
 
 If you cannot run tests, explain why in the PR and provide manual verification steps.
 

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -133,6 +133,7 @@ await api.invoke("your_command", { request: { /* ... */ } });
 
 - 先开 Issue 说明问题或方案，尤其是较大改动，以避免重复与设计冲突
 - 新功能或 UI 变更建议先讨论设计方向，确保符合产品体验
+- 使用 Issue 和 PR 模板；如果某个字段不适用，请写 `N/A`，不要直接删除该部分。
 
 ### PR 标题与描述
 
@@ -149,6 +150,8 @@ UI 改动请附前后对比截图或短录屏，方便快速评审。
 
 如为 AI 辅助产出，请在 PR 中注明并说明测试程度（未测/轻测/已测），便于评审风险。
 
+不要提交临时 AI prompt、本地绝对路径、生成的草稿文件、配对密钥、token、证书或无关产物。PR 应聚焦于本次产品或维护改动。
+
 ### 分支管理
 
 **`main` 分支为默认协作分支，并接受特性 PR。** 本仓库欢迎产品经理、开发者使用 AI 生成代码进行快速验证或提交想法，因此 **所有 PR 请直接提交到 `main` 分支**。
@@ -163,13 +166,16 @@ UI 改动请附前后对比截图或短录屏，方便快速评审。
 
 修改 `/usage` UI 文案时，请同步 `en-US`、`zh-CN`、`zh-TW` 多语言文本。
 
-```bash
-# Rust
-cargo test --workspace
+| 改动类型 | 推荐验证 |
+| --- | --- |
+| 仓库元信息、PR/Issue 模板或 GitHub workflow | `pnpm run check:repo-hygiene && pnpm run check:github-config && git diff --check` |
+| Web UI、状态、适配层或多语言文案 | `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run` |
+| Mobile web UI、配对、重连、断开或聊天流程 | `pnpm --dir src/mobile-web run type-check && pnpm run build:mobile-web` |
+| Rust core、transport、API layer、services 或共享运行时逻辑 | `cargo check --workspace && cargo test --workspace` |
+| 桌面端集成、Tauri API 或桌面端专属行为 | `cargo check -p bitfun-desktop && cargo test -p bitfun-desktop` |
+| E2E 覆盖的行为 | 先构建最近的 app target，再运行最接近的 E2E spec 或 `pnpm run e2e:test:l0` |
 
-# E2E
-pnpm run e2e:test
-```
+Mobile web 配对、重连、断开或聊天流程改动，需要在 PR 中补充手动验证步骤；涉及 UI 变化时，请附截图或短录屏。
 
 如暂时无法运行测试，请在 PR 描述中说明原因，并提供手动验证步骤。
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "lint:web": "pnpm --dir src/web-ui run lint",
     "lint:web:fix": "pnpm --dir src/web-ui run lint:fix",
     "i18n:audit": "node scripts/i18n-audit.mjs",
+    "check:repo-hygiene": "node scripts/check-repo-hygiene.mjs",
+    "check:github-config": "pnpm --dir src/web-ui exec node ../../scripts/check-github-config.mjs",
     "fmt:rs": "node scripts/format-changed-rust.mjs",
     "prebuild": "pnpm run prebuild:web",
     "prebuild:web": "pnpm run copy-assets --silent && pnpm run generate-all --silent",

--- a/scripts/check-github-config.mjs
+++ b/scripts/check-github-config.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const requireFromWebUi = createRequire(path.join(rootDir, 'src/web-ui/package.json'));
+const yaml = requireFromWebUi('yaml');
+
+const yamlFiles = [];
+
+function addYamlFiles(dir) {
+  const absoluteDir = path.join(rootDir, dir);
+  if (!existsSync(absoluteDir)) {
+    return;
+  }
+
+  for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+    const relativePath = path.posix.join(dir.replace(/\\/g, '/'), entry.name);
+    const absolutePath = path.join(absoluteDir, entry.name);
+
+    if (entry.isDirectory()) {
+      addYamlFiles(relativePath);
+    } else if (/\.(ya?ml)$/i.test(entry.name)) {
+      yamlFiles.push({ relativePath, absolutePath });
+    }
+  }
+}
+
+addYamlFiles('.github/workflows');
+addYamlFiles('.github/ISSUE_TEMPLATE');
+
+const errors = [];
+
+for (const { relativePath, absolutePath } of yamlFiles) {
+  const document = yaml.parseDocument(readFileSync(absolutePath, 'utf8'), {
+    prettyErrors: true,
+  });
+
+  if (document.errors.length > 0) {
+    for (const error of document.errors) {
+      errors.push(`${relativePath}: ${error.message}`);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error('GitHub YAML config check failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`GitHub YAML config check passed (${yamlFiles.length} files parsed).`);

--- a/scripts/check-repo-hygiene.mjs
+++ b/scripts/check-repo-hygiene.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function runGit(args) {
+  try {
+    return execFileSync('git', args, { encoding: 'utf8' }).split(/\r?\n/).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function uniqueFiles(files) {
+  return [...new Set(files.filter(Boolean))];
+}
+
+function hasCommit(ref) {
+  try {
+    execFileSync('git', ['rev-parse', '--verify', `${ref}^{commit}`], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const trackedFiles = runGit(['ls-files']);
+const untrackedFiles = runGit(['ls-files', '--others', '--exclude-standard']);
+const repositoryFiles = uniqueFiles([...trackedFiles, ...untrackedFiles]);
+const localChangedFiles = uniqueFiles([
+  ...runGit(['diff', '--name-only', '--diff-filter=ACMRT', 'HEAD']),
+  ...untrackedFiles,
+]);
+const committedChangedFiles = hasCommit('HEAD^1')
+  ? runGit(['diff', '--name-only', '--diff-filter=ACMRT', 'HEAD^1', 'HEAD'])
+  : [];
+const contentScanFiles = uniqueFiles(
+  localChangedFiles.length > 0
+    ? localChangedFiles
+    : committedChangedFiles.length > 0
+      ? committedChangedFiles
+      : trackedFiles,
+);
+const contentScanFileSet = new Set(contentScanFiles.map(normalizePath));
+
+const textExtensions = new Set([
+  '.cjs',
+  '.css',
+  '.html',
+  '.js',
+  '.json',
+  '.jsx',
+  '.md',
+  '.mjs',
+  '.rs',
+  '.scss',
+  '.toml',
+  '.ts',
+  '.tsx',
+  '.txt',
+  '.yaml',
+  '.yml',
+]);
+
+const ignoredContentPaths = [
+  /(^|\/)node_modules\//,
+  /(^|\/)dist\//,
+  /(^|\/)target\//,
+  /(^|\/)src\/web-ui\/public\/monaco-editor\//,
+  /(^|\/)src\/mobile-web\/dist\//,
+  /(^|\/).*package-lock\.json$/,
+  /(^|\/)pnpm-lock\.yaml$/,
+  /(^|\/)Cargo\.lock$/,
+];
+
+const testFilePattern = /(^|\/)(tests?|__tests__)\/|[._-](test|spec)\.[cm]?[jt]sx?$|_tests?\.rs$|\/tests\.rs$/;
+const temporaryPromptNames = new Set([
+  '_codex_review_prompt.txt',
+  'codex_review_prompt.txt',
+  'review_prompt.txt',
+]);
+const sensitiveFilenamePattern =
+  /(^|[._-])(id_rsa|id_dsa|id_ecdsa|id_ed25519)([._-]|$)|\.(pem|p12|pfx|mobileprovision)$/i;
+const localAbsolutePathPattern =
+  /(^|[^A-Za-z])((?:[A-Za-z]:[\\/][^\s'"`)<\]]+)|(?:file:\/\/\/[A-Za-z]:\/[^\s'"`)<\]]+))/g;
+const tokenPattern =
+  /\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{20,})\b/g;
+const privateKeyPattern = /-----BEGIN (?:RSA |DSA |EC |OPENSSH |)?PRIVATE KEY-----/;
+
+const violations = [];
+
+function normalizePath(file) {
+  return file.replace(/\\/g, '/');
+}
+
+function shouldScanText(file) {
+  const normalized = normalizePath(file);
+  const ext = path.extname(normalized).toLowerCase();
+  return textExtensions.has(ext) && !ignoredContentPaths.some((pattern) => pattern.test(normalized));
+}
+
+function addViolation(file, line, message) {
+  violations.push(line ? `${file}:${line} ${message}` : `${file} ${message}`);
+}
+
+for (const file of repositoryFiles) {
+  const normalized = normalizePath(file);
+  const basename = path.posix.basename(normalized).toLowerCase();
+
+  if (
+    temporaryPromptNames.has(basename) ||
+    /(^|[-_])review[-_]?prompt\.(txt|md)$/i.test(basename)
+  ) {
+    addViolation(file, null, 'looks like a transient review prompt file.');
+  }
+
+  if (sensitiveFilenamePattern.test(basename)) {
+    addViolation(file, null, 'looks like a private key, certificate, or provisioning file.');
+  }
+
+  if (!contentScanFileSet.has(normalized) || !shouldScanText(file)) {
+    continue;
+  }
+
+  let content;
+  try {
+    content = readFileSync(file, 'utf8');
+  } catch {
+    continue;
+  }
+
+  const isTestFile = testFilePattern.test(normalized);
+  const scanLocalPaths = !isTestFile;
+  const scanTokenLikeSecrets = !isTestFile;
+  const lines = content.split(/\r?\n/);
+
+  for (const [index, line] of lines.entries()) {
+    const lineNumber = index + 1;
+
+    if (privateKeyPattern.test(line)) {
+      addViolation(file, lineNumber, 'contains a private key marker.');
+    }
+
+    if (scanTokenLikeSecrets && tokenPattern.test(line)) {
+      addViolation(file, lineNumber, 'contains a token-like secret.');
+    }
+
+    if (scanLocalPaths && localAbsolutePathPattern.test(line)) {
+      addViolation(file, lineNumber, 'contains a local absolute path.');
+    }
+
+    localAbsolutePathPattern.lastIndex = 0;
+    tokenPattern.lastIndex = 0;
+  }
+}
+
+if (violations.length > 0) {
+  console.error('Repository hygiene check failed:');
+  for (const violation of violations) {
+    console.error(`- ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Repository hygiene check passed (${contentScanFiles.length} content files scanned, ${repositoryFiles.length} filenames checked).`,
+);

--- a/src/mobile-web/AGENTS.md
+++ b/src/mobile-web/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+Mobile web is the browser-based remote control client for BitFun desktop sessions.
+
+## Boundaries
+
+- Keep mobile-web logic inside `src/mobile-web`; do not import from `src/web-ui`.
+- Treat pairing, reconnect, disconnect, session list, and chat state as one connected product flow.
+- Keep connection state semantics consistent across persistent indicators, banners, dialogs, and disabled states.
+- User-facing strings should use the mobile-web i18n message system when one is already present for the surface being changed.
+- Do not commit local pairing URLs, user IDs, logs, screenshots with sensitive data, or temporary AI prompts.
+
+## Where to look first
+
+| Area | Paths |
+|---|---|
+| Pairing | `src/pages/PairingPage.tsx`, `src/services/RelayHttpClient.ts` |
+| Session list | `src/pages/SessionListPage.tsx`, `src/services/store.ts` |
+| Chat | `src/pages/ChatPage.tsx`, `src/services/RemoteSessionManager.ts` |
+| Connection health / reconnect | `src/App.tsx`, `src/services/RemoteSessionManager.ts`, `src/services/store.ts` |
+| Styles | `src/styles/`, `src/theme/` |
+| Messages | `src/i18n/messages.ts` |
+
+## Verification
+
+Run the focused mobile-web checks after changes:
+
+```bash
+pnpm --dir src/mobile-web run type-check
+pnpm run build:mobile-web
+```
+
+For pairing, reconnect, disconnect, or chat behavior changes, also describe manual verification in the PR, including the browser/device used and the observed state transitions.

--- a/src/mobile-web/package.json
+++ b/src/mobile-web/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "type-check": "tsc --noEmit",
     "build": "vite build",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Summary

Add lightweight contribution governance for BitFun:

- Default PR template with verification evidence fields instead of duplicated command lists.
- Short issue forms for bugs, product proposals, and documentation issues.
- Repository hygiene and GitHub YAML validation scripts.
- CI coverage for web UI tests and mobile-web type-check/build.
- Updated AGENTS/CONTRIBUTING guidance for mobile-web and focused verification.

## Motivation / Product Context

As BitFun accepts broader open-source contributions across desktop, web UI, mobile web, relay, and agent runtime surfaces, maintainers need enough context to triage and review without making contribution templates feel like long forms.

Fixes #N/A

## Type and Areas

Type: Docs / CI / repository governance

Areas: GitHub templates, CI, AGENTS, CONTRIBUTING, mobile web guidance

## User Impact

No direct runtime user-facing behavior changes. Contributors get clearer and lighter issue/PR intake, while maintainers get stronger automated checks for template/config validity and frontend coverage.

## Design / Architecture Notes

The command selection matrix lives in CONTRIBUTING.md as the source of truth. The PR template records verification evidence instead of duplicating command lists. Issue templates keep only the minimum fields needed for triage.

## Verification

Verification scope:

Repository metadata, GitHub templates, GitHub workflow, and docs guidance.

Commands run and results:

- `pnpm run check:repo-hygiene` -> pass
- `pnpm run check:github-config` -> pass
- `git diff --check` -> pass
- `git diff --cached --check` -> pass
- `pnpm --dir src/web-ui run test:run` -> pass, 145 files / 768 tests
- `pnpm run lint:web` -> pass
- `pnpm run build:web` -> pass
- `pnpm --dir src/mobile-web run type-check` -> pass
- `pnpm run build:mobile-web` -> pass

Manual verification:

N/A. This PR changes repository governance, CI, and contribution documentation only.

Skipped checks:

Rust and desktop runtime checks were not rerun for the latest template-only refinement because no Rust, Tauri, desktop runtime, or product behavior code changed.

## Risk and Rollback

Main risk is modest CI duration increase from web UI tests and mobile-web checks. Current GitHub Actions measurement showed `Frontend Build` increasing from about 1m51s to about 2m36s, while the full workflow remains dominated by the Rust Windows job. Rollback is straightforward by reverting this PR.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and AI-assisted work disclosure are handled where applicable.