### PR TITLE
Record LLM TPS metrics in token usage

### DIFF
--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -85,20 +85,30 @@ struct TurnTokenUsageTotals {
     prompt_tokens: u64,
     completion_tokens: u64,
     total_tokens: u64,
+    llm_duration_ms: u64,
     cached_tokens: u64,
     cached_tokens_reported_count: usize,
 }
 
 impl TurnTokenUsageTotals {
-    fn add_usage(&mut self, usage: &crate::util::types::ai::GeminiUsage) {
+    fn add_usage(&mut self, usage: &crate::util::types::ai::GeminiUsage, llm_latency_ms: u64) {
         self.usage_count += 1;
         self.prompt_tokens += usage.prompt_token_count as u64;
         self.completion_tokens += usage.candidates_token_count as u64;
         self.total_tokens += usage.total_token_count as u64;
+        self.llm_duration_ms = self.llm_duration_ms.saturating_add(llm_latency_ms);
         if let Some(cached_tokens) = usage.cached_content_token_count {
             self.cached_tokens += cached_tokens as u64;
             self.cached_tokens_reported_count += 1;
         }
+    }
+
+    fn llm_tps(&self) -> Option<f64> {
+        if self.usage_count == 0 || self.llm_duration_ms == 0 {
+            return None;
+        }
+
+        Some(self.completion_tokens as f64 * 1000.0 / self.llm_duration_ms as f64)
     }
 
     fn cache_coverage(&self) -> &'static str {
@@ -1952,7 +1962,7 @@ impl ExecutionEngine {
             completed_rounds += 1;
 
             if let Some(ref usage) = round_result.usage {
-                token_usage_totals.add_usage(usage);
+                token_usage_totals.add_usage(usage, round_result.llm_latency_ms);
             }
 
             // Add assistant message to history
@@ -2335,7 +2345,7 @@ impl ExecutionEngine {
                     !Self::assistant_has_tool_calls(&final_round_result.assistant_message);
                 let mut chosen_assistant_message: Option<Message> = None;
                 if let Some(ref usage) = final_round_result.usage {
-                    token_usage_totals.add_usage(usage);
+                    token_usage_totals.add_usage(usage, final_round_result.llm_latency_ms);
                 }
 
                 if accepted {
@@ -2363,7 +2373,7 @@ impl ExecutionEngine {
                         )
                         .await?;
                     if let Some(ref usage) = retry_result.usage {
-                        token_usage_totals.add_usage(usage);
+                        token_usage_totals.add_usage(usage, retry_result.llm_latency_ms);
                     }
                     finalize_fallback_text_used = true;
                     if Self::assistant_has_tool_calls(&retry_result.assistant_message) {
@@ -2440,14 +2450,20 @@ impl ExecutionEngine {
         // the reported subtotal and mark coverage as partial so downstream
         // consumers do not treat it as a complete total.
         if token_usage_totals.usage_count > 0 {
+            let llm_tps = token_usage_totals
+                .llm_tps()
+                .map(|value| format!("{:.1}", value))
+                .unwrap_or_else(|| "unavailable".to_string());
             if token_usage_totals.has_reported_cache_tokens() {
                 info!(
-                    "Dialog turn completed - Token stats: turn_id={}, rounds={}, model_calls={}, tools={}, duration={}ms, prompt_tokens={}, completion_tokens={}, total_tokens={}, cached_tokens={}, cached_tokens_available={}",
+                    "Dialog turn completed - Token stats: turn_id={}, rounds={}, model_calls={}, tools={}, duration={}ms, llm_duration={}ms, llm_tps={} tokens/s, prompt_tokens={}, completion_tokens={}, total_tokens={}, cached_tokens={}, cached_tokens_available={}",
                     context.dialog_turn_id,
                     completed_rounds,
                     token_usage_totals.usage_count,
                     total_tools,
                     duration_ms,
+                    token_usage_totals.llm_duration_ms,
+                    llm_tps,
                     token_usage_totals.prompt_tokens,
                     token_usage_totals.completion_tokens,
                     token_usage_totals.total_tokens,
@@ -2456,12 +2472,14 @@ impl ExecutionEngine {
                 );
             } else {
                 info!(
-                    "Dialog turn completed - Token stats: turn_id={}, rounds={}, model_calls={}, tools={}, duration={}ms, prompt_tokens={}, completion_tokens={}, total_tokens={}, cached_tokens_available={}",
+                    "Dialog turn completed - Token stats: turn_id={}, rounds={}, model_calls={}, tools={}, duration={}ms, llm_duration={}ms, llm_tps={} tokens/s, prompt_tokens={}, completion_tokens={}, total_tokens={}, cached_tokens_available={}",
                     context.dialog_turn_id,
                     completed_rounds,
                     token_usage_totals.usage_count,
                     total_tools,
                     duration_ms,
+                    token_usage_totals.llm_duration_ms,
+                    llm_tps,
                     token_usage_totals.prompt_tokens,
                     token_usage_totals.completion_tokens,
                     token_usage_totals.total_tokens,
@@ -2608,13 +2626,15 @@ mod tests {
     fn turn_token_usage_totals_accumulates_model_calls() {
         let mut totals = TurnTokenUsageTotals::default();
 
-        totals.add_usage(&usage(10, 2, Some(3)));
-        totals.add_usage(&usage(20, 4, Some(5)));
+        totals.add_usage(&usage(10, 2, Some(3)), 100);
+        totals.add_usage(&usage(20, 4, Some(5)), 200);
 
         assert_eq!(totals.usage_count, 2);
         assert_eq!(totals.prompt_tokens, 30);
         assert_eq!(totals.completion_tokens, 6);
         assert_eq!(totals.total_tokens, 36);
+        assert_eq!(totals.llm_duration_ms, 300);
+        assert_eq!(totals.llm_tps(), Some(20.0));
         assert_eq!(totals.cached_tokens, 8);
         assert!(totals.has_complete_cache_tokens());
         assert_eq!(totals.cache_coverage(), "true");
@@ -2623,8 +2643,8 @@ mod tests {
     #[test]
     fn turn_token_usage_totals_marks_partial_or_missing_cache() {
         let mut partial = TurnTokenUsageTotals::default();
-        partial.add_usage(&usage(10, 2, Some(3)));
-        partial.add_usage(&usage(20, 4, None));
+        partial.add_usage(&usage(10, 2, Some(3)), 100);
+        partial.add_usage(&usage(20, 4, None), 200);
 
         assert_eq!(partial.cached_tokens, 3);
         assert!(partial.has_reported_cache_tokens());
@@ -2632,7 +2652,7 @@ mod tests {
         assert_eq!(partial.cache_coverage(), "partial");
 
         let mut unavailable = TurnTokenUsageTotals::default();
-        unavailable.add_usage(&usage(10, 2, None));
+        unavailable.add_usage(&usage(10, 2, None), 100);
 
         assert_eq!(unavailable.cached_tokens, 0);
         assert!(!unavailable.has_reported_cache_tokens());

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -417,6 +417,7 @@ impl RoundExecutor {
             stream_result.first_chunk_ms,
             stream_result.first_visible_output_ms
         );
+        let llm_latency_ms = send_to_stream_ms.saturating_add(stream_processing_ms);
 
         // Check cancellation token again after stream processing completes
         if cancel_token.is_cancelled() {
@@ -464,6 +465,7 @@ impl RoundExecutor {
                     total_tokens: usage.total_token_count as usize,
                     max_context_tokens: context_window,
                     is_subagent,
+                    llm_latency_ms: Some(llm_latency_ms),
                     cached_tokens: usage.cached_content_token_count.map(|v| v as usize),
                     token_details: token_details_from_usage(usage),
                 },
@@ -552,6 +554,7 @@ impl RoundExecutor {
                 has_more_rounds: false,
                 finish_reason: FinishReason::Complete,
                 usage: stream_result.usage.clone(),
+                llm_latency_ms,
                 provider_metadata: stream_result.provider_metadata.clone(),
                 partial_recovery_reason: stream_result.partial_recovery_reason.clone(),
                 had_assistant_text: Self::has_user_visible_assistant_text(&stream_result.full_text),
@@ -799,6 +802,7 @@ impl RoundExecutor {
                 FinishReason::Complete
             },
             usage: stream_result.usage.clone(),
+            llm_latency_ms,
             provider_metadata: stream_result.provider_metadata.clone(),
             partial_recovery_reason: stream_result.partial_recovery_reason.clone(),
             had_assistant_text: Self::has_user_visible_assistant_text(&stream_result.full_text),

--- a/src/crates/core/src/agentic/execution/types.rs
+++ b/src/crates/core/src/agentic/execution/types.rs
@@ -72,6 +72,8 @@ pub struct RoundResult {
     pub finish_reason: FinishReason,
     /// Token usage statistics (from model response)
     pub usage: Option<crate::util::types::ai::GeminiUsage>,
+    /// LLM call latency for this round, excluding tool execution time.
+    pub llm_latency_ms: u64,
     /// Provider-specific metadata returned by the model.
     pub provider_metadata: Option<Value>,
     /// When set, this round's stream was partially recovered (aborted mid-way

--- a/src/crates/core/src/service/session_usage/service.rs
+++ b/src/crates/core/src/service/session_usage/service.rs
@@ -1895,6 +1895,7 @@ mod tests {
             cached_tokens,
             cached_tokens_available: false,
             total_tokens: input_tokens + output_tokens,
+            llm_latency_ms: None,
             token_details: None,
             is_subagent: false,
         }

--- a/src/crates/core/src/service/token_usage/service.rs
+++ b/src/crates/core/src/service/token_usage/service.rs
@@ -148,6 +148,7 @@ impl TokenUsageService {
         input_tokens: u32,
         output_tokens: u32,
         cached_tokens: Option<u32>,
+        llm_latency_ms: Option<u64>,
         token_details: Option<serde_json::Value>,
         is_subagent: bool,
     ) -> Result<()> {
@@ -166,6 +167,7 @@ impl TokenUsageService {
             cached_tokens,
             cached_tokens_available,
             total_tokens,
+            llm_latency_ms,
             token_details,
             is_subagent,
         };

--- a/src/crates/core/src/service/token_usage/subscriber.rs
+++ b/src/crates/core/src/service/token_usage/subscriber.rs
@@ -32,6 +32,7 @@ impl EventSubscriber for TokenUsageSubscriber {
             output_tokens,
             total_tokens,
             is_subagent,
+            llm_latency_ms,
             cached_tokens,
             token_details,
             ..
@@ -60,6 +61,7 @@ impl EventSubscriber for TokenUsageSubscriber {
                     *input_tokens as u32,
                     output as u32,
                     cached_tokens.map(|value| value as u32),
+                    *llm_latency_ms,
                     token_details.clone(),
                     *is_subagent,
                 )

--- a/src/crates/events/src/agentic.rs
+++ b/src/crates/events/src/agentic.rs
@@ -163,6 +163,8 @@ pub enum AgenticEvent {
         max_context_tokens: Option<usize>,
         is_subagent: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        llm_latency_ms: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         cached_tokens: Option<usize>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         token_details: Option<serde_json::Value>,
@@ -492,6 +494,7 @@ mod tests {
             total_tokens: 15,
             max_context_tokens: Some(100),
             is_subagent: false,
+            llm_latency_ms: Some(2500),
             cached_tokens: Some(3),
             token_details: Some(serde_json::json!({ "cachedSource": "provider" })),
         };
@@ -499,6 +502,7 @@ mod tests {
         let json = serde_json::to_value(&event).expect("serialize event");
 
         assert_eq!(json["cached_tokens"], 3);
+        assert_eq!(json["llm_latency_ms"], 2500);
         assert_eq!(json["token_details"]["cachedSource"], "provider");
     }
 

--- a/src/crates/services-core/src/token_usage/types.rs
+++ b/src/crates/services-core/src/token_usage/types.rs
@@ -18,6 +18,9 @@ pub struct TokenUsageRecord {
     #[serde(default)]
     pub cached_tokens_available: bool,
     pub total_tokens: u32,
+    /// LLM call latency in milliseconds, excluding tool execution time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub llm_latency_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_details: Option<serde_json::Value>,
     /// Whether this record is from a subagent call

--- a/src/crates/services-core/tests/token_usage_contracts.rs
+++ b/src/crates/services-core/tests/token_usage_contracts.rs
@@ -16,6 +16,27 @@ fn token_usage_record_preserves_cached_availability_default() {
     .expect("legacy token usage record should deserialize");
 
     assert!(!record.cached_tokens_available);
+    assert_eq!(record.llm_latency_ms, None);
+}
+
+#[test]
+fn token_usage_record_serializes_llm_latency() {
+    let record: TokenUsageRecord = serde_json::from_value(serde_json::json!({
+        "model_id": "model-a",
+        "session_id": "session-1",
+        "turn_id": "turn-1",
+        "timestamp": Utc::now(),
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "cached_tokens": 0,
+        "cached_tokens_available": false,
+        "total_tokens": 15,
+        "llm_latency_ms": 2500
+    }))
+    .expect("token usage record should deserialize");
+
+    let json = serde_json::to_value(record).expect("record should serialize");
+    assert_eq!(json["llm_latency_ms"], 2500);
 }
 
 #[test]

--- a/src/crates/transport/src/adapters/tauri.rs
+++ b/src/crates/transport/src/adapters/tauri.rs
@@ -271,6 +271,7 @@ impl TransportAdapter for TauriTransportAdapter {
                 total_tokens,
                 max_context_tokens,
                 is_subagent,
+                llm_latency_ms,
                 cached_tokens,
                 token_details,
             } => {
@@ -285,6 +286,7 @@ impl TransportAdapter for TauriTransportAdapter {
                         "totalTokens": total_tokens,
                         "maxContextTokens": max_context_tokens,
                         "isSubagent": is_subagent,
+                        "llmLatencyMs": llm_latency_ms,
                         "cachedTokens": cached_tokens,
                         "tokenDetails": token_details,
                     }),

--- a/src/crates/transport/src/adapters/websocket.rs
+++ b/src/crates/transport/src/adapters/websocket.rs
@@ -171,6 +171,7 @@ impl TransportAdapter for WebSocketTransportAdapter {
                 total_tokens,
                 max_context_tokens,
                 is_subagent,
+                llm_latency_ms,
                 cached_tokens,
                 token_details,
             } => {
@@ -184,6 +185,7 @@ impl TransportAdapter for WebSocketTransportAdapter {
                     "totalTokens": total_tokens,
                     "maxContextTokens": max_context_tokens,
                     "isSubagent": is_subagent,
+                    "llmLatencyMs": llm_latency_ms,
                     "cachedTokens": cached_tokens,
                     "tokenDetails": token_details,
                 })


### PR DESCRIPTION
## Summary
- track per-round LLM latency excluding tool execution time
- include LLM TPS in dialog-turn token stats logs
- persist llm_latency_ms in token_usage records and forward it through token usage events/transports

## Verification
- cargo test -p bitfun-core turn_token_usage_totals -- --nocapture
- cargo test -p bitfun-events token_usage_updated_serializes_optional_cache_and_detail_fields -- --nocapture
- cargo test -p bitfun-services-core token_usage -- --nocapture
- cargo check -p bitfun-core