### PR TITLE
feat: refine i18n loading guardrails

### DIFF
--- a/AGENTS-CN.md
+++ b/AGENTS-CN.md
@@ -37,7 +37,10 @@ BitFun 是一个由 Rust workspace 与 React 前端组成的项目。
 | 安装器 | `BitFun-Installer` | [AGENTS.md](BitFun-Installer/AGENTS.md) |
 | E2E 测试 | `tests/e2e` | [AGENTS.md](tests/e2e/AGENTS.md) |
 
-## 最常用命令
+## 常用命令
+
+这些是命令参考，不是 PR 前置检查清单。预检请按下方“验证”表选择最小本地检查；
+大范围测试和构建主要用于复现 CI 或验证构建相关改动。
 
 ```bash
 # 安装
@@ -54,29 +57,42 @@ pnpm run fmt:rs                     # 只格式化已改动 / 已暂存的 Rust 
 pnpm run lint:web
 pnpm run type-check:web
 pnpm --dir src/mobile-web run type-check
+pnpm run i18n:contract:test          # 仅 i18n contract / resources
+pnpm run i18n:audit                  # 仅 i18n contract / resources
 pnpm run check:repo-hygiene
 pnpm run check:github-config
 cargo check --workspace
 
-# 测试
-pnpm --dir src/web-ui run test:run
-cargo test --workspace
+# 测试（本地优先用精确测试路径；大范围测试由 CI 兜底）
+pnpm --dir src/web-ui run test:run      # 大范围测试；本地优先用精确测试路径
+cargo test --workspace                  # 大范围测试；CI 兜底
 
-# 构建
-cargo build -p bitfun-desktop
-pnpm run build:web
-pnpm run build:mobile-web
+# 构建（仅构建相关改动或复现 CI 时运行）
+cargo build -p bitfun-desktop           # 构建相关改动 / 复现 CI
+pnpm run build:web                      # 构建相关改动 / 复现 CI
+pnpm run build:mobile-web               # 构建相关改动 / 复现 CI
 
-# 快速构建（开发 / CI 提速）
+# 快速构建（手动构建 / 调试流程）
 pnpm run desktop:build:fast           # debug 构建，不打包
 pnpm run desktop:build:release-fast   # release 但降低 LTO
 pnpm run desktop:build:nsis:fast      # Windows 安装器，release-fast profile
-pnpm run installer:build:fast         # 安装器应用，快速模式
 ```
 
 完整脚本列表见 [`package.json`](package.json)。
 
 ## 全局规则
+
+### 国际化
+
+- Locale id、alias、fallback 和各形态默认语言统一由
+  `src/shared/i18n/contract/locales.json` 管理；修改后运行
+  `pnpm run i18n:generate`。
+- 跨形态稳定标签放在
+  `src/shared/i18n/resources/shared/<locale>/terms.json`；流程文案留在所属
+  产品形态资源中。
+- 不要把 Web UI locale 资源导入 `src/mobile-web`、`BitFun-Installer` 等较小形态。
+- Web UI 只急切加载 bootstrap namespace；路由或功能文案使用
+  `useI18n(namespace)`，直接 `i18nService.t(...)` 只用于 bootstrap namespace。
 
 ### 日志
 
@@ -169,16 +185,24 @@ SessionManager → Session → DialogTurn → ModelRound
 
 ## 验证
 
+按触及文件选择最小本地预检。完整构建和大范围测试默认由 CI 保护；只有改动直接影响构建、
+打包，或 CI 无法覆盖对应路径时，才在本地运行更重的命令。
+
 | 改动类型 | 最低验证要求 |
 |---|---|
-| 前端 UI、状态、适配层或多语言文案 | `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run` |
-| Mobile web UI、状态、配对、断开或重连行为 | `pnpm --dir src/mobile-web run type-check && pnpm run build:mobile-web`；行为变化还需要在 PR 中说明手动配对 / 重连验证 |
-| Deep Review / 代码审核团队行为 | 运行上面的前端验证，再运行 `cargo test -p bitfun-core deep_review -- --nocapture`；如果触及后端或 Tauri API，还需要运行下方 Rust / 桌面端验证 |
-| `core`、`transport`、`api-layer` 或共享服务中的 Rust 逻辑 | `cargo check --workspace && cargo test --workspace` |
-| 桌面端集成、Tauri API、browser/computer-use 或桌面专属行为 | `cargo check -p bitfun-desktop && cargo test -p bitfun-desktop` |
-| 被桌面端 smoke/functional 流覆盖的行为 | `cargo build -p bitfun-desktop` 后运行最接近的 E2E spec，或 `pnpm run e2e:test:l0` |
-| `src/crates/ai-adapters` | 运行上面相关 Rust 检查，**并且**运行 `cargo test -p bitfun-agent-stream` 验证 stream contract |
-| 安装器应用 | `pnpm run installer:build` |
+| 不涉及 i18n 资源/契约的前端 UI、状态或适配层 | `pnpm run type-check:web`；行为变化时再加最近的 focused test |
+| 仅 locale 资源改动 | `pnpm run i18n:audit` |
+| Locale contract 或 shared terms | `pnpm run i18n:generate && pnpm run i18n:contract:test && pnpm run i18n:audit` |
+| Web UI i18n runtime、namespace loading 或直接 `i18nService.t(...)` 调用 | `pnpm run i18n:contract:test && pnpm run type-check:web && pnpm --dir src/web-ui run test:run src/infrastructure/i18n/core/I18nService.test.ts` |
+| Mobile web UI、状态、配对、断开或重连行为 | `pnpm --dir src/mobile-web run type-check`；行为变化还需要在 PR 中说明手动配对 / 重连验证 |
+| Deep Review / 代码审核团队行为 | 运行最近的 Web UI 检查，再运行 `cargo test -p bitfun-core deep_review -- --nocapture`；如果触及后端或 Tauri API，还需要运行对应 Rust / 桌面端检查 |
+| `core`、`transport`、`api-layer` 或共享服务中的 Rust 逻辑 | `cargo check --workspace`；行为变化时再加最近的 focused `cargo test` |
+| 桌面端集成、Tauri API、browser/computer-use 或桌面专属行为 | `cargo check -p bitfun-desktop`；行为变化时再加 focused desktop tests |
+| 被桌面端 smoke/functional 流覆盖的行为 | 优先运行最近的 focused E2E/smoke check；除非改动影响构建，否则 broad build/test 交给 CI |
+| `src/crates/ai-adapters` | 运行上面相关 Rust 检查；只有 stream contract 改动时再加 `cargo test -p bitfun-agent-stream` |
+| 不涉及打包的安装器前端或 i18n runtime | `pnpm --dir BitFun-Installer run type-check` |
+| 安装器 Tauri/Rust 改动 | `cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml` |
+| 安装器打包、payload、安装/卸载流程或 native bundling | `pnpm run installer:build` |
 
 ## 先看哪里
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,11 @@ Repository rule: **keep product logic platform-agnostic, then expose it through 
 | Installer | `BitFun-Installer` | [AGENTS.md](BitFun-Installer/AGENTS.md) |
 | E2E tests | `tests/e2e` | [AGENTS.md](tests/e2e/AGENTS.md) |
 
-## Most-used commands
+## Common commands
+
+These are command references, not a pre-PR checklist. Use the Verification table
+to choose the smallest local precheck; broad suites and builds are mainly for CI
+reproduction or build-impacting changes.
 
 ```bash
 # Install
@@ -54,24 +58,25 @@ pnpm run fmt:rs                     # format only changed / staged Rust files
 pnpm run lint:web
 pnpm run type-check:web
 pnpm --dir src/mobile-web run type-check
+pnpm run i18n:contract:test          # i18n contract / resources only
+pnpm run i18n:audit                  # i18n contract / resources only
 pnpm run check:repo-hygiene
 pnpm run check:github-config
 cargo check --workspace
 
-# Test
-pnpm --dir src/web-ui run test:run
-cargo test --workspace
+# Test (prefer focused paths locally; broad suites are CI-backed)
+pnpm --dir src/web-ui run test:run      # broad suite; prefer focused paths locally
+cargo test --workspace                  # broad suite; CI-backed
 
-# Build
-cargo build -p bitfun-desktop
-pnpm run build:web
-pnpm run build:mobile-web
+# Build (only for build-impacting changes or CI reproduction)
+cargo build -p bitfun-desktop           # build-impacting changes / CI reproduction
+pnpm run build:web                      # build-impacting changes / CI reproduction
+pnpm run build:mobile-web               # build-impacting changes / CI reproduction
 
-# Fast builds (for development / CI speed)
+# Fast builds (manual build/debug flows)
 pnpm run desktop:build:fast           # debug build, no bundling
 pnpm run desktop:build:release-fast   # release with reduced LTO
 pnpm run desktop:build:nsis:fast      # Windows installer, release-fast profile
-pnpm run installer:build:fast         # installer app, fast mode
 ```
 
 For the full script list, see [`package.json`](package.json).
@@ -88,6 +93,9 @@ For the full script list, see [`package.json`](package.json).
   in the owning product surface.
 - Do not import Web UI locale resources into smaller product surfaces such as
   `src/mobile-web` or `BitFun-Installer`. See `docs/architecture/i18n.md`.
+- Web UI loads only bootstrap namespaces eagerly; use `useI18n(namespace)` for
+  route or feature copy and keep direct `i18nService.t(...)` calls in bootstrap
+  namespaces.
 
 ### Logging
 
@@ -184,16 +192,24 @@ Session data is stored under `.bitfun/sessions/{session_id}/`.
 
 ## Verification
 
+Run the smallest local precheck that matches the touched files. CI is expected to
+cover full builds and broad test suites; run heavier local commands only when the
+change directly affects build, packaging, or CI cannot protect the path.
+
 | Change type | Minimum verification |
 |---|---|
-| Frontend UI, state, adapters, or locales | `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run` |
-| Mobile web UI, state, pairing, disconnect, or reconnect behavior | `pnpm --dir src/mobile-web run type-check && pnpm run build:mobile-web`; include manual pairing / reconnect verification when behavior changes |
-| Deep Review / Code Review Team behavior | Web UI verification above, plus `cargo test -p bitfun-core deep_review -- --nocapture`; also run the Rust / desktop rows below when backend or Tauri APIs are touched |
-| Shared Rust logic in `core`, `transport`, `api-layer`, or services | `cargo check --workspace && cargo test --workspace` |
-| Desktop integration, Tauri APIs, browser/computer-use, or desktop-only behavior | `cargo check -p bitfun-desktop && cargo test -p bitfun-desktop` |
-| Behavior covered by desktop smoke/functional flows | `cargo build -p bitfun-desktop` then the nearest E2E spec or `pnpm run e2e:test:l0` |
-| `src/crates/ai-adapters` | Relevant Rust checks above **and** `cargo test -p bitfun-agent-stream` for stream contracts |
-| Installer frontend, i18n, or locale contract | `pnpm --dir BitFun-Installer run type-check && cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml && pnpm --dir BitFun-Installer run build` |
+| Frontend UI, state, or adapters without i18n resource/contract changes | `pnpm run type-check:web`, plus the nearest focused test when behavior changed |
+| Locale resource-only changes | `pnpm run i18n:audit` |
+| Locale contract or shared terms | `pnpm run i18n:generate && pnpm run i18n:contract:test && pnpm run i18n:audit` |
+| Web UI i18n runtime, namespace loading, or direct `i18nService.t(...)` usage | `pnpm run i18n:contract:test && pnpm run type-check:web && pnpm --dir src/web-ui run test:run src/infrastructure/i18n/core/I18nService.test.ts` |
+| Mobile web UI, state, pairing, disconnect, or reconnect behavior | `pnpm --dir src/mobile-web run type-check`; include manual pairing / reconnect notes when behavior changes |
+| Deep Review / Code Review Team behavior | Nearest Web UI check above, plus `cargo test -p bitfun-core deep_review -- --nocapture`; also run Rust / desktop checks when backend or Tauri APIs are touched |
+| Shared Rust logic in `core`, `transport`, `api-layer`, or services | `cargo check --workspace`, plus the nearest focused `cargo test` when behavior changed |
+| Desktop integration, Tauri APIs, browser/computer-use, or desktop-only behavior | `cargo check -p bitfun-desktop`, plus focused desktop tests when behavior changed |
+| Behavior covered by desktop smoke/functional flows | Prefer the nearest focused E2E/smoke check; rely on CI for broad build/test coverage unless build behavior changed |
+| `src/crates/ai-adapters` | Relevant Rust checks above; add `cargo test -p bitfun-agent-stream` only when stream contracts changed |
+| Installer frontend or i18n runtime without packaging changes | `pnpm --dir BitFun-Installer run type-check` |
+| Installer Tauri/Rust changes | `cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml` |
 | Installer packaging, payload, install/uninstall flow, or native bundling | `pnpm run installer:build` |
 
 ## Where to look first

--- a/BitFun-Installer/AGENTS-CN.md
+++ b/BitFun-Installer/AGENTS-CN.md
@@ -17,6 +17,8 @@
 - `src-tauri/src/installer/shortcut.rs`：快捷方式创建
 - `src-tauri/src/installer/extract.rs`：压缩包解压
 - `src/hooks/useInstaller.ts`：前端安装流程状态
+- `src/i18n/`：安装器专属文案；locale 元数据由
+  `src/shared/i18n/contract/locales.json` 生成
 
 安装流程：
 
@@ -26,15 +28,28 @@ Language Select → Options → Progress → Model Setup → Theme Setup
 
 ## 命令
 
+这些是命令参考，不是默认预检清单。PR 范围请以下方 Verification 为准。
+
 ```bash
 pnpm --dir BitFun-Installer run installer:dev
 pnpm --dir BitFun-Installer run tauri:dev
 pnpm --dir BitFun-Installer run type-check
-pnpm --dir BitFun-Installer run build
-pnpm --dir BitFun-Installer run installer:build
+pnpm --dir BitFun-Installer run build            # React build / 复现 CI
+pnpm --dir BitFun-Installer run installer:build  # 仅打包场景
 ```
 
 ## 验证
+
+按触及范围选择最小检查：
+
+```bash
+pnpm run i18n:audit                                                   # 仅资源类 i18n
+pnpm run i18n:generate && pnpm run i18n:contract:test && pnpm run i18n:audit
+pnpm --dir BitFun-Installer run type-check                            # 前端 i18n/runtime
+cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml      # Tauri/Rust 改动
+```
+
+只有修改打包、payload、native bundling、安装/卸载流程、注册表、快捷方式或解压逻辑时，才运行完整安装器构建：
 
 ```bash
 pnpm --dir BitFun-Installer run type-check && pnpm --dir BitFun-Installer run installer:build

--- a/BitFun-Installer/AGENTS.md
+++ b/BitFun-Installer/AGENTS.md
@@ -28,23 +28,26 @@ Language Select → Options → Progress → Model Setup → Theme Setup
 
 ## Commands
 
+These are command references, not the default precheck list. Use Verification
+below for PR scope.
+
 ```bash
 pnpm --dir BitFun-Installer run installer:dev
 pnpm --dir BitFun-Installer run tauri:dev
 pnpm --dir BitFun-Installer run type-check
-pnpm --dir BitFun-Installer run build
-pnpm --dir BitFun-Installer run installer:build
+pnpm --dir BitFun-Installer run build            # React build / CI reproduction
+pnpm --dir BitFun-Installer run installer:build  # packaging only
 ```
 
 ## Verification
 
-For frontend, i18n, language-contract, or non-packaging installer changes, prefer
-the lighter focused checks:
+Use the smallest matching check:
 
 ```bash
-pnpm --dir BitFun-Installer run type-check
-cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml
-pnpm --dir BitFun-Installer run build
+pnpm run i18n:audit                                                   # resource-only i18n
+pnpm run i18n:generate && pnpm run i18n:contract:test && pnpm run i18n:audit
+pnpm --dir BitFun-Installer run type-check                            # frontend i18n/runtime
+cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml      # Tauri/Rust changes
 ```
 
 Run the full installer build only for packaging, payload, native bundling,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,15 @@ Captured data is logged as structured JSON under the `bitfun::devtools` target.
 - Frontend: `createLogger('ModuleName')`
 - Backend: `log::{info, debug, warn, error}` macros
 
+### Internationalization
+
+- Locale metadata lives in `src/shared/i18n/contract/locales.json`; run
+  `pnpm run i18n:generate` after editing it.
+- Put stable cross-surface labels in `src/shared/i18n/resources/shared`; keep
+  workflow copy in the owning surface.
+- Web UI route or feature copy should use `useI18n(namespace)`. Do not import
+  Web UI locale catalogs into mobile-web, installer, backend, or static pages.
+
 ### Platform-agnostic core
 
 Do not use platform-specific dependencies in `core`:
@@ -170,16 +179,23 @@ Keep PRs small and focused. Avoid bundling unrelated changes.
 
 Run relevant tests for your change. You do not need to run every row below; choose the smallest set that matches the files and behavior you touched:
 
+CI covers full builds and broad test suites. Local prechecks should stay focused
+unless the change directly touches build, packaging, or a path not covered by CI.
+
 For `/usage` UI copy changes, keep `en-US`, `zh-CN`, and `zh-TW` locale strings in sync.
 
 | Change type | Recommended verification |
 | --- | --- |
 | Repository metadata, PR/issue templates, or GitHub workflows | `pnpm run check:repo-hygiene && pnpm run check:github-config && git diff --check` |
-| Web UI, state, adapters, or locale changes | `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run` |
-| Mobile web UI, pairing, reconnect, disconnect, or chat-flow changes | `pnpm --dir src/mobile-web run type-check && pnpm run build:mobile-web` |
-| Rust core, transport, API layer, services, or shared runtime logic | `cargo check --workspace && cargo test --workspace` |
-| Desktop integration, Tauri APIs, or desktop-only behavior | `cargo check -p bitfun-desktop && cargo test -p bitfun-desktop` |
-| E2E-covered behavior | Build the nearest app target, then run the closest E2E spec or `pnpm run e2e:test:l0` |
+| Locale resource-only changes | `pnpm run i18n:audit` |
+| Locale contract or shared terms | `pnpm run i18n:generate && pnpm run i18n:contract:test && pnpm run i18n:audit` |
+| Web UI state, adapters, or runtime code | `pnpm run type-check:web`, plus the nearest focused test when behavior changed |
+| Web UI i18n runtime or namespace-loading changes | `pnpm run i18n:contract:test && pnpm run type-check:web && pnpm --dir src/web-ui run test:run src/infrastructure/i18n/core/I18nService.test.ts` |
+| Mobile web UI, pairing, reconnect, disconnect, or chat-flow changes | `pnpm --dir src/mobile-web run type-check` |
+| Installer frontend or i18n runtime without packaging changes | `pnpm --dir BitFun-Installer run type-check` |
+| Rust core, transport, API layer, services, or shared runtime logic | `cargo check --workspace`, plus the nearest focused `cargo test` when behavior changed |
+| Desktop integration, Tauri APIs, or desktop-only behavior | `cargo check -p bitfun-desktop`, plus focused desktop tests when behavior changed |
+| E2E-covered behavior | Run the closest focused E2E/smoke check; rely on CI for broad build/test coverage unless build behavior changed |
 
 For mobile-web pairing, reconnect, disconnect, or chat-flow changes, include manual verification steps and screenshots or a short recording when the UI changes.
 

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -78,6 +78,13 @@ pnpm run e2e:test
 - 前端：`createLogger('ModuleName')`
 - 后端：`log::{info, debug, warn, error}` 宏
 
+### 国际化
+
+- Locale 元数据统一维护在 `src/shared/i18n/contract/locales.json`；修改后运行
+  `pnpm run i18n:generate`。
+- 跨形态稳定标签放在 `src/shared/i18n/resources/shared`；流程文案留在所属形态资源中。
+- Web UI 路由或功能文案使用 `useI18n(namespace)`。不要把 Web UI locale 资源导入 mobile-web、installer、backend 或静态页面。
+
 ### 平台无关核心
 
 `core` 中禁止引入平台相关依赖：
@@ -164,16 +171,23 @@ UI 改动请附前后对比截图或短录屏，方便快速评审。
 
 按改动范围运行相关测试；不需要跑完下方所有命令，只选择与本次改动文件和行为匹配的最小集合：
 
+完整构建和大范围测试由 CI 保护。本地预检应保持聚焦；只有改动直接触及构建、打包，
+或 CI 不覆盖对应路径时才运行更重命令。
+
 修改 `/usage` UI 文案时，请同步 `en-US`、`zh-CN`、`zh-TW` 多语言文本。
 
 | 改动类型 | 推荐验证 |
 | --- | --- |
 | 仓库元信息、PR/Issue 模板或 GitHub workflow | `pnpm run check:repo-hygiene && pnpm run check:github-config && git diff --check` |
-| Web UI、状态、适配层或多语言文案 | `pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run` |
-| Mobile web UI、配对、重连、断开或聊天流程 | `pnpm --dir src/mobile-web run type-check && pnpm run build:mobile-web` |
-| Rust core、transport、API layer、services 或共享运行时逻辑 | `cargo check --workspace && cargo test --workspace` |
-| 桌面端集成、Tauri API 或桌面端专属行为 | `cargo check -p bitfun-desktop && cargo test -p bitfun-desktop` |
-| E2E 覆盖的行为 | 先构建最近的 app target，再运行最接近的 E2E spec 或 `pnpm run e2e:test:l0` |
+| 仅 locale 资源改动 | `pnpm run i18n:audit` |
+| Locale contract 或 shared terms | `pnpm run i18n:generate && pnpm run i18n:contract:test && pnpm run i18n:audit` |
+| Web UI 状态、适配层或运行时代码 | `pnpm run type-check:web`；行为变化时再加最近的 focused test |
+| Web UI i18n runtime 或 namespace loading 改动 | `pnpm run i18n:contract:test && pnpm run type-check:web && pnpm --dir src/web-ui run test:run src/infrastructure/i18n/core/I18nService.test.ts` |
+| Mobile web UI、配对、重连、断开或聊天流程 | `pnpm --dir src/mobile-web run type-check` |
+| 不涉及打包的安装器前端或 i18n runtime | `pnpm --dir BitFun-Installer run type-check` |
+| Rust core、transport、API layer、services 或共享运行时逻辑 | `cargo check --workspace`；行为变化时再加最近的 focused `cargo test` |
+| 桌面端集成、Tauri API 或桌面端专属行为 | `cargo check -p bitfun-desktop`；行为变化时再加 focused desktop tests |
+| E2E 覆盖的行为 | 运行最近的 focused E2E/smoke check；除非影响构建，否则 broad build/test 交给 CI |
 
 Mobile web 配对、重连、断开或聊天流程改动，需要在 PR 中补充手动验证步骤；涉及 UI 变化时，请附截图或短录屏。
 

--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -54,6 +54,7 @@ Surface resources stay in their existing owners:
 - Mobile Web: `src/mobile-web/src/i18n/messages.ts`
 - Installer: `BitFun-Installer/src/i18n/locales/*.json`
 - Backend: `src/crates/core/locales/*.ftl`
+- Relay static homepage: `src/apps/relay-server/static/homepage`
 
 Shared contract does not mean shared bundle. Importing Web UI locales from
 `mobile-web`, installer, backend, or another app is not allowed.
@@ -62,18 +63,25 @@ Shared contract does not mean shared bundle. Importing Web UI locales from
 
 The locale contract is shared; translation resources are not. Each surface must
 load only its own resource owner. Smaller surfaces should keep runtime loading
-to their current locale data, while Web UI keeps its current eager behavior
-until the later namespace-splitting work lands.
+to their current locale data.
 
-- Web UI owns Web UI namespaces. The current PR preserves the existing eager
-  namespace loading; later runtime work should split route or feature namespaces
-  into independently loadable chunks.
+- Web UI owns Web UI namespaces. It eagerly bootstraps only
+  `WEB_UI_BOOTSTRAP_NAMESPACES`, the small namespace set needed by synchronous
+  `i18nService.t(...)` call sites during module initialization. Other Web UI
+  namespaces load lazily through the i18next backend when a component requests
+  them with `useI18n(namespace)` or `i18nService.loadNamespace(namespace)`.
 - Mobile Web owns mobile-only resources and must not import Web UI locale
   catalogs.
 - Installer owns installer-only resources and must not depend on app runtime
   locale catalogs.
 - Backend owns backend Fluent resources and uses generated contract helpers for
   locale parsing, canonicalization, fallback order, and shared terms.
+- Relay static homepage is a self-contained static surface. It is tracked in the
+  contract and audit baseline, but it does not import runtime locale catalogs.
+
+Direct Web UI `i18nService.t('namespace:key')` calls are allowed only for
+bootstrap namespaces. Route, scene, and feature UI should use `useI18n(namespace)`
+so the namespace can be loaded on demand.
 
 ## Backend And Frontend Language Contract
 
@@ -95,3 +103,5 @@ store canonical ids.
 4. Run `pnpm run i18n:generate`.
 5. Run `pnpm run i18n:audit`.
 6. Run the focused type checks/builds for the touched surfaces.
+7. If a surface intentionally stays self-contained or does not support the new
+   locale, document that surface decision in the contract and PR.

--- a/docs/development/i18n.md
+++ b/docs/development/i18n.md
@@ -14,6 +14,9 @@
 - Do not import `src/web-ui/src/locales` from `src/mobile-web`,
   `BitFun-Installer`, Rust crates, or server apps.
 - Persist and send canonical app locale ids, not aliases.
+- In Web UI, request route or feature namespaces through `useI18n(namespace)`.
+  Add a namespace to `WEB_UI_BOOTSTRAP_NAMESPACES` only when a synchronous
+  `i18nService.t('namespace:key')` call must run during module initialization.
 
 ## Commands
 
@@ -23,14 +26,17 @@ pnpm run i18n:contract:test
 pnpm run i18n:audit
 ```
 
-Run the nearest surface checks after changing resources:
+Run only the touched surface checks. CI covers broad builds and full suites;
+resource-only JSON changes usually stop after `i18n:audit`, and contract/shared
+term changes stop after the three commands above unless runtime code changed:
 
 ```bash
-pnpm run type-check:web
-pnpm --dir src/mobile-web run type-check
-pnpm --dir BitFun-Installer run type-check
-cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml
-cargo test -p bitfun-core i18n -- --nocapture
+pnpm run type-check:web                                               # Web UI i18n runtime/hooks
+pnpm --dir src/web-ui run test:run src/infrastructure/i18n/core/I18nService.test.ts
+pnpm --dir src/mobile-web run type-check                              # mobile-web messages.ts/runtime
+pnpm --dir BitFun-Installer run type-check                            # installer frontend i18n runtime
+cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml      # installer Tauri/Rust changes
+cargo test -p bitfun-core i18n -- --nocapture                         # backend i18n runtime changes
 ```
 
 ## Where To Put Strings
@@ -97,12 +103,20 @@ Do not rely on literal fallback strings in component code. Add the missing key
 to the relevant locale file instead. Literal fallback strings make audits and
 translation completeness harder to enforce.
 
+`pnpm run i18n:audit` fails on missing or extra keys in Web UI, mobile-web, and
+installer locale resources. It also fails if the checked-in CJK source candidate
+budgets grow. Existing budget warnings are grandfathered; new user-facing copy
+should be extracted instead of increasing the baseline.
+
 ## Loading Size
 
 Unifying the language contract must not unify all translation bundles. Each
 surface should ship only the resource set needed for that surface and the current
-locale path. Web UI still uses its existing eager namespace loading in PR1; do
-not use that as a precedent for smaller surfaces.
+locale path.
+
+Web UI eagerly loads only bootstrap namespaces and lazy-loads all other
+namespaces. Mobile Web, Installer, Backend, and static relay pages must not
+import Web UI locale catalogs to reuse copy.
 
 For bundle-sensitive changes, compare generated asset sizes before and after the
 change and include the result in the PR.
@@ -127,3 +141,4 @@ Every i18n PR should state:
 - Whether generated files were updated.
 - Which i18n verification commands passed.
 - Whether any surface intentionally does not support a new locale.
+- Whether a hardcoded-copy budget changed, and why that increase is acceptable.

--- a/scripts/i18n-audit.mjs
+++ b/scripts/i18n-audit.mjs
@@ -1,9 +1,12 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 
+const require = createRequire(import.meta.url);
 const root = process.cwd();
 const contractPath = path.join(root, 'src', 'shared', 'i18n', 'contract', 'locales.json');
+const hardcodedBaselinePath = path.join(root, 'scripts', 'i18n-hardcoded-baseline.json');
 const sharedTermsDir = path.join(root, 'src', 'shared', 'i18n', 'resources', 'shared');
 const webLocalesDir = path.join(root, 'src', 'web-ui', 'src', 'locales');
 const namespaceRegistryPath = path.join(
@@ -18,6 +21,10 @@ const namespaceRegistryPath = path.join(
 );
 const webSourceDir = path.join(root, 'src', 'web-ui', 'src');
 const mobileWebSourceDir = path.join(root, 'src', 'mobile-web', 'src');
+const mobileWebMessagesPath = path.join(mobileWebSourceDir, 'i18n', 'messages.ts');
+const installerSourceDir = path.join(root, 'BitFun-Installer', 'src');
+const installerLocalesDir = path.join(installerSourceDir, 'i18n', 'locales');
+const relayHomepageDir = path.join(root, 'src', 'apps', 'relay-server', 'static', 'homepage');
 const supportedLocales = fs
   .readdirSync(webLocalesDir, { withFileTypes: true })
   .filter((entry) => entry.isDirectory())
@@ -118,6 +125,99 @@ function readJsonKeys(locale, namespace) {
     reportError(`Failed to parse ${toPosixPath(path.relative(root, file))}: ${error.message}`);
     return [];
   }
+}
+
+function readInstallerJsonKeys(uiLocale) {
+  const file = path.join(installerLocalesDir, `${uiLocale}.json`);
+  try {
+    return flattenKeys(readJsonFile(file));
+  } catch (error) {
+    reportError(`Failed to parse ${toPosixPath(path.relative(root, file))}: ${error.message}`);
+    return [];
+  }
+}
+
+function propertyNameToString(ts, name) {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  return null;
+}
+
+function unwrapTsExpression(ts, expression) {
+  let current = expression;
+  while (current && (ts.isAsExpression(current) || ts.isSatisfiesExpression(current))) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function flattenTsObjectKeys(ts, objectLiteral, prefix = '') {
+  const keys = [];
+  for (const property of objectLiteral.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+
+    const key = propertyNameToString(ts, property.name);
+    if (!key) continue;
+    if (!prefix && key === 'shared') continue;
+
+    const nextPrefix = prefix ? `${prefix}.${key}` : key;
+    const initializer = unwrapTsExpression(ts, property.initializer);
+
+    if (ts.isObjectLiteralExpression(initializer)) {
+      keys.push(...flattenTsObjectKeys(ts, initializer, nextPrefix));
+    } else {
+      keys.push(nextPrefix);
+    }
+  }
+  return keys.sort();
+}
+
+function readMobileMessageKeysByLocale() {
+  let ts;
+  try {
+    ts = require('typescript');
+  } catch (error) {
+    reportError(`Failed to load TypeScript for mobile-web i18n audit: ${error.message}`);
+    return new Map();
+  }
+
+  const source = fs.readFileSync(mobileWebMessagesPath, 'utf8');
+  const sourceFile = ts.createSourceFile(mobileWebMessagesPath, source, ts.ScriptTarget.Latest, true);
+  const output = new Map();
+
+  function visit(node) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === 'messages'
+    ) {
+      const initializer = unwrapTsExpression(ts, node.initializer);
+      if (!initializer || !ts.isObjectLiteralExpression(initializer)) {
+        reportError('mobile-web messages export is not an object literal');
+        return;
+      }
+
+      for (const property of initializer.properties) {
+        if (!ts.isPropertyAssignment(property)) continue;
+
+        const locale = propertyNameToString(ts, property.name);
+        if (!locale) continue;
+
+        const value = unwrapTsExpression(ts, property.initializer);
+        if (!ts.isObjectLiteralExpression(value)) {
+          reportError(`mobile-web messages.${locale} is not an object literal`);
+          continue;
+        }
+
+        output.set(locale, flattenTsObjectKeys(ts, value));
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return output;
 }
 
 function diffSets(left, right) {
@@ -286,6 +386,44 @@ function auditKeyParity(namespaces) {
   }
 }
 
+function auditMobileWebMessageParity() {
+  const messagesByLocale = readMobileMessageKeysByLocale();
+  const baselineKeys = messagesByLocale.get('en-US');
+  if (!baselineKeys) {
+    reportError('mobile-web messages are missing the en-US baseline locale');
+    return;
+  }
+
+  for (const [locale, keys] of messagesByLocale.entries()) {
+    if (locale === 'en-US') continue;
+
+    const missing = diffSets(baselineKeys, keys);
+    const extra = diffSets(keys, baselineKeys);
+    if (missing.length > 0) {
+      reportError(`mobile-web ${locale} messages are missing ${missing.length} key(s): ${missing.slice(0, 8).join(', ')}`);
+    }
+    if (extra.length > 0) {
+      reportError(`mobile-web ${locale} messages have ${extra.length} extra key(s): ${extra.slice(0, 8).join(', ')}`);
+    }
+  }
+}
+
+function auditInstallerKeyParity() {
+  const baselineKeys = readInstallerJsonKeys('en');
+  for (const uiLocale of ['zh', 'zh-TW']) {
+    const keys = readInstallerJsonKeys(uiLocale);
+    const missing = diffSets(baselineKeys, keys);
+    const extra = diffSets(keys, baselineKeys);
+
+    if (missing.length > 0) {
+      reportError(`installer ${uiLocale}.json is missing ${missing.length} key(s): ${missing.slice(0, 8).join(', ')}`);
+    }
+    if (extra.length > 0) {
+      reportError(`installer ${uiLocale}.json has ${extra.length} extra key(s): ${extra.slice(0, 8).join(', ')}`);
+    }
+  }
+}
+
 function shouldSkipSourceScan(file) {
   const normalized = toPosixPath(path.relative(root, file));
   return (
@@ -299,6 +437,30 @@ function shouldSkipSourceScan(file) {
   );
 }
 
+function shouldSkipMobileWebSourceScan(file) {
+  const normalized = toPosixPath(path.relative(root, file));
+  return (
+    normalized.endsWith('/i18n/messages.ts') ||
+    normalized.endsWith('/i18n/generatedLocaleContract.ts') ||
+    normalized.endsWith('.test.ts') ||
+    normalized.endsWith('.test.tsx') ||
+    normalized.endsWith('.spec.ts') ||
+    normalized.endsWith('.spec.tsx')
+  );
+}
+
+function shouldSkipInstallerSourceScan(file) {
+  const normalized = toPosixPath(path.relative(root, file));
+  return (
+    normalized.includes('/i18n/locales/') ||
+    normalized.endsWith('/i18n/generatedLocaleContract.ts') ||
+    normalized.endsWith('.test.ts') ||
+    normalized.endsWith('.test.tsx') ||
+    normalized.endsWith('.spec.ts') ||
+    normalized.endsWith('.spec.tsx')
+  );
+}
+
 function auditSourceText() {
   const sourceFiles = listFiles(
     webSourceDir,
@@ -306,9 +468,7 @@ function auditSourceText() {
   );
 
   const fallbackFindings = [];
-  const cjkFindings = [];
   const fallbackPattern = /\bt\s*\(\s*(['"`])(?:\\.|(?!\1).)+\1\s*,\s*(['"`])/g;
-  const cjkPattern = /\p{Script=Han}/u;
 
   for (const file of sourceFiles) {
     const text = fs.readFileSync(file, 'utf8');
@@ -318,18 +478,73 @@ function auditSourceText() {
         fallbackFindings.push(`${toPosixPath(path.relative(root, file))}:${index + 1}`);
       }
       fallbackPattern.lastIndex = 0;
-
-      if (cjkPattern.test(line)) {
-        cjkFindings.push(`${toPosixPath(path.relative(root, file))}:${index + 1}`);
-      }
     });
   }
 
   if (fallbackFindings.length > 0) {
     reportWarning(`Found ${fallbackFindings.length} t(key, "literal fallback") candidate(s). First entries: ${fallbackFindings.slice(0, 12).join(', ')}`);
   }
-  if (cjkFindings.length > 0) {
-    reportWarning(`Found ${cjkFindings.length} CJK source line candidate(s) outside locale/test/generated files; review user-facing literals for extraction. First entries: ${cjkFindings.slice(0, 12).join(', ')}`);
+}
+
+function countCjkSourceLines(scanRoot, predicate) {
+  const cjkPattern = /\p{Script=Han}/u;
+  const findings = [];
+  const sourceFiles = listFiles(scanRoot, predicate);
+
+  for (const file of sourceFiles) {
+    const text = fs.readFileSync(file, 'utf8');
+    const lines = text.split(/\r?\n/);
+    lines.forEach((line, index) => {
+      if (cjkPattern.test(line)) {
+        findings.push(`${toPosixPath(path.relative(root, file))}:${index + 1}`);
+      }
+    });
+  }
+
+  return findings;
+}
+
+function auditHardcodedSourceBudgets() {
+  const baseline = readJsonFile(hardcodedBaselinePath);
+  const budgetById = new Map((baseline.budgets ?? []).map((budget) => [budget.id, budget.maxCjkLines]));
+  // Baselines are a no-new-hardcoded-copy gate. Lower them as strings move to
+  // owned locale resources; do not raise them for new user-facing text.
+  const specs = [
+    {
+      id: 'web-ui-source',
+      root: webSourceDir,
+      predicate: (file) => (file.endsWith('.ts') || file.endsWith('.tsx')) && !shouldSkipSourceScan(file),
+    },
+    {
+      id: 'mobile-web-source',
+      root: mobileWebSourceDir,
+      predicate: (file) => (file.endsWith('.ts') || file.endsWith('.tsx')) && !shouldSkipMobileWebSourceScan(file),
+    },
+    {
+      id: 'installer-source',
+      root: installerSourceDir,
+      predicate: (file) => (file.endsWith('.ts') || file.endsWith('.tsx')) && !shouldSkipInstallerSourceScan(file),
+    },
+    {
+      id: 'relay-static-homepage',
+      root: relayHomepageDir,
+      predicate: (file) => file.endsWith('.html') || file.endsWith('.js') || file.endsWith('.css'),
+    },
+  ];
+
+  for (const spec of specs) {
+    const maxCjkLines = budgetById.get(spec.id);
+    if (typeof maxCjkLines !== 'number') {
+      reportError(`Missing hardcoded CJK budget for ${spec.id}`);
+      continue;
+    }
+
+    const findings = countCjkSourceLines(spec.root, spec.predicate);
+    if (findings.length > maxCjkLines) {
+      reportError(`${spec.id} has ${findings.length} CJK source candidate line(s), budget is ${maxCjkLines}. First entries: ${findings.slice(0, 12).join(', ')}`);
+    } else if (findings.length > 0) {
+      reportWarning(`${spec.id} has ${findings.length} grandfathered CJK source candidate line(s). First entries: ${findings.slice(0, 12).join(', ')}`);
+    }
   }
 }
 
@@ -340,7 +555,10 @@ auditMobileWebBoundary();
 
 const namespaces = auditNamespaceCoverage();
 auditKeyParity(namespaces);
+auditMobileWebMessageParity();
+auditInstallerKeyParity();
 auditSourceText();
+auditHardcodedSourceBudgets();
 
 if (errorCount > 0) {
   console.error(`[i18n:audit] Failed with ${errorCount} error(s) and ${warningCount} warning(s).`);

--- a/scripts/i18n-contract.test.mjs
+++ b/scripts/i18n-contract.test.mjs
@@ -33,6 +33,28 @@ function flattenKeys(value, prefix = '') {
     .sort();
 }
 
+function listFiles(dir, predicate) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const absolutePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return listFiles(absolutePath, predicate);
+    }
+
+    return predicate(absolutePath) ? [absolutePath] : [];
+  });
+}
+
+function extractStringArrayConstant(source, exportName) {
+  const marker = `export const ${exportName} = [`;
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `missing ${exportName} constant`);
+  const body = source.slice(start + marker.length);
+  const end = body.indexOf('] as const');
+  assert.notEqual(end, -1, `${exportName} must be an as const string array`);
+  return [...body.slice(0, end).matchAll(/'([^']+)'/g)].map((entry) => entry[1]);
+}
+
 test('i18n contract generated files are in sync with the canonical contract', () => {
   assert.ok(fs.existsSync(contractPath), 'missing shared i18n locale contract');
 
@@ -129,12 +151,78 @@ test('frontend runtimes use generated locale defaults and fallback chains', () =
   assert.match(installerI18nSource, /getInstallerUiFallbackChain/, 'installer i18next should use the generated locale fallback chain');
 });
 
+test('web-ui runtime keeps locale namespaces lazy outside its bootstrap set', () => {
+  const webI18nSource = readText('src/web-ui/src/infrastructure/i18n/core/I18nService.ts');
+
+  assert.match(webI18nSource, /WEB_UI_BOOTSTRAP_NAMESPACES/, 'Web UI should declare the small eager namespace set');
+  assert.match(webI18nSource, /import\.meta\.glob\('\.\.\/\.\.\/\.\.\/locales\/\*\*\/\*\.json'/, 'Web UI should keep a lazy namespace glob for non-bootstrap resources');
+  const lazyGlobBlock = webI18nSource.match(/const lazyLocaleModules = import\.meta\.glob\([\s\S]*?\) as/)?.[0] ?? '';
+  assert.doesNotMatch(
+    lazyGlobBlock,
+    /eager:\s*true/,
+    'Web UI must not eagerly import every locale namespace',
+  );
+});
+
+test('web-ui synchronous i18nService.t namespaces stay in the bootstrap set', () => {
+  const registrySource = readText('src/web-ui/src/infrastructure/i18n/presets/namespaceRegistry.ts');
+  const bootstrapNamespaces = new Set(extractStringArrayConstant(registrySource, 'WEB_UI_BOOTSTRAP_NAMESPACES'));
+  const sourceRoot = path.join(root, 'src', 'web-ui', 'src');
+  const missing = new Set();
+
+  const sourceFiles = listFiles(sourceRoot, (file) => {
+    const normalized = file.replace(/\\/g, '/');
+    return (
+      /\.(ts|tsx)$/.test(file) &&
+      !normalized.includes('/locales/') &&
+      !normalized.endsWith('.test.ts') &&
+      !normalized.endsWith('.test.tsx') &&
+      !normalized.endsWith('.spec.ts') &&
+      !normalized.endsWith('.spec.tsx')
+    );
+  });
+
+  for (const file of sourceFiles) {
+    const text = fs.readFileSync(file, 'utf8');
+    const patterns = [/i18nService\.t\(\s*(['"`])([^'"`:]+):/g];
+    if (text.includes('i18nService.getT()')) {
+      patterns.push(/\bt\(\s*(['"`])([^'"`:]+):/g);
+    }
+
+    for (const pattern of patterns) {
+      for (const match of text.matchAll(pattern)) {
+        const namespace = match[2];
+        if (!bootstrapNamespaces.has(namespace)) {
+          missing.add(`${namespace} (${path.relative(root, file).replace(/\\/g, '/')})`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(
+    [...missing].sort(),
+    [],
+    'synchronous i18nService.t(...) call sites require eager bootstrap namespaces',
+  );
+});
+
+test('i18n audit enforces the checked-in hardcoded source candidate budget', () => {
+  const baselineSource = readText('scripts/i18n-hardcoded-baseline.json');
+  const auditSource = readText('scripts/i18n-audit.mjs');
+
+  assert.doesNotThrow(() => JSON.parse(baselineSource));
+  assert.match(auditSource, /i18n-hardcoded-baseline\.json/, 'i18n:audit should read the hardcoded copy baseline');
+  assert.match(auditSource, /auditHardcodedSourceBudgets/, 'i18n:audit should fail when hardcoded candidate budgets grow');
+});
+
 test('i18n audit treats locale key parity as an error', () => {
   const auditSource = readText('scripts/i18n-audit.mjs');
   const parityFunction = auditSource.match(/function auditKeyParity\(namespaces\) \{[\s\S]*?\n\}/)?.[0] ?? '';
 
   assert.match(parityFunction, /reportError\(`\$\{locale\}\/\$\{namespace\}\.json is missing/, 'missing locale keys should fail i18n:audit');
   assert.match(parityFunction, /reportError\(`\$\{locale\}\/\$\{namespace\}\.json has/, 'extra locale keys should fail i18n:audit');
+  assert.match(auditSource, /auditMobileWebMessageParity/, 'mobile-web message keys should be covered by i18n:audit');
+  assert.match(auditSource, /auditInstallerKeyParity/, 'installer locale keys should be covered by i18n:audit');
 });
 
 test('installer Rust locale contract is generated from the installer surface order', () => {

--- a/scripts/i18n-hardcoded-baseline.json
+++ b/scripts/i18n-hardcoded-baseline.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "budgets": [
+    {
+      "id": "web-ui-source",
+      "maxCjkLines": 198
+    },
+    {
+      "id": "mobile-web-source",
+      "maxCjkLines": 8
+    },
+    {
+      "id": "installer-source",
+      "maxCjkLines": 0
+    },
+    {
+      "id": "relay-static-homepage",
+      "maxCjkLines": 17
+    }
+  ]
+}

--- a/src/mobile-web/src/i18n/messages.ts
+++ b/src/mobile-web/src/i18n/messages.ts
@@ -69,6 +69,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       defaultAssistant: 'Default Assistant',
       switchAssistant: 'Switch assistant',
       selectAssistant: 'Select Assistant',
+      launch: 'Launch',
       startRemoteFlow: 'Start a new remote flow',
       codeSession: 'Code Session',
       codeSessionDesc: 'For coding anywhere, anytime.',

--- a/src/shared/i18n/contract/locales.json
+++ b/src/shared/i18n/contract/locales.json
@@ -50,6 +50,10 @@
     "core": {
       "resourceRoot": "src/crates/core/locales",
       "loading": "backend-service"
+    },
+    "relay-static-homepage": {
+      "resourceRoot": "src/apps/relay-server/static/homepage",
+      "loading": "self-contained-static"
     }
   },
   "locales": [

--- a/src/web-ui/AGENTS.md
+++ b/src/web-ui/AGENTS.md
@@ -29,20 +29,38 @@ Most changes start in:
 - Keep locale metadata in the generated i18n contract files. Edit
   `src/shared/i18n/contract/locales.json`, run `pnpm run i18n:generate`, and
   keep Web UI strings under `src/web-ui/src/locales`.
+- Use `useI18n(namespace)` for route or feature copy so non-bootstrap
+  namespaces stay lazy. Direct `i18nService.t(...)` calls require bootstrap
+  namespace coverage.
 - Follow `src/web-ui/LOGGING.md`: English only, no emojis, structured logs
 
 ## Commands
+
+These are command references, not the default precheck list. Use Verification
+below for PR scope.
 
 ```bash
 pnpm --dir src/web-ui dev
 pnpm --dir src/web-ui run lint
 pnpm --dir src/web-ui run type-check
-pnpm --dir src/web-ui run test:run
-pnpm run build:web
+pnpm --dir src/web-ui run test:run     # broad suite; prefer focused paths locally
+pnpm run i18n:contract:test
+pnpm run i18n:audit
+pnpm run build:web                     # build-impacting changes / CI reproduction
 ```
 
 ## Verification
 
+Choose the smallest matching check:
+
 ```bash
-pnpm run lint:web && pnpm run type-check:web && pnpm --dir src/web-ui run test:run
+pnpm run i18n:audit
+pnpm run i18n:generate && pnpm run i18n:contract:test && pnpm run i18n:audit
+pnpm run type-check:web && pnpm --dir src/web-ui run test:run src/infrastructure/i18n/core/I18nService.test.ts
+pnpm run type-check:web
 ```
+
+Use the first line for resource-only locale changes, the second for
+contract/shared-term changes, the third for i18n runtime/namespace-loading
+changes, and the fourth for ordinary Web UI code. Rely on CI for full lint,
+build, and broad test coverage unless the local change specifically needs it.

--- a/src/web-ui/src/infrastructure/i18n/core/I18nService.test.ts
+++ b/src/web-ui/src/infrastructure/i18n/core/I18nService.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import { I18nService } from './I18nService';
+import { DEFAULT_LOCALE, WEB_UI_BOOTSTRAP_NAMESPACES } from '../presets';
 
 describe('I18nService shared namespace contract', () => {
+  it('keeps bootstrap translations available synchronously after construction', () => {
+    const service = new I18nService();
+
+    expect(service.t('common:actions.copy')).not.toBe('common:actions.copy');
+  });
+
   it('keeps shared terms explicit so surface namespaces retain priority', () => {
     const service = new I18nService();
     const i18n = service.getI18nInstance();
@@ -27,5 +34,19 @@ describe('I18nService shared namespace contract', () => {
     await i18n.changeLanguage('zh-TW');
 
     expect(service.t('fallbackProbe')).toBe('simplified fallback');
+  });
+
+  it('keeps non-bootstrap web-ui namespaces out of the startup resource bundle', async () => {
+    const service = new I18nService();
+    const i18n = service.getI18nInstance();
+
+    for (const namespace of WEB_UI_BOOTSTRAP_NAMESPACES) {
+      expect(i18n.hasResourceBundle(DEFAULT_LOCALE, namespace)).toBe(true);
+    }
+    expect(i18n.hasResourceBundle(DEFAULT_LOCALE, 'settings/basics')).toBe(false);
+
+    await service.loadNamespace('settings/basics');
+
+    expect(i18n.hasResourceBundle(DEFAULT_LOCALE, 'settings/basics')).toBe(true);
   });
 });

--- a/src/web-ui/src/infrastructure/i18n/core/I18nService.ts
+++ b/src/web-ui/src/infrastructure/i18n/core/I18nService.ts
@@ -1,6 +1,11 @@
  
 
-import i18next, { i18n as I18nInstance, Resource, TFunction } from 'i18next';
+import i18next, {
+  i18n as I18nInstance,
+  Resource,
+  TFunction,
+  type BackendModule,
+} from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
 import type {
@@ -17,7 +22,7 @@ import {
   DEFAULT_LOCALE,
   DEFAULT_FALLBACK_LOCALE,
   DEFAULT_NAMESPACE,
-  ALL_NAMESPACES,
+  WEB_UI_BOOTSTRAP_NAMESPACES,
   getLocaleFallbackChain,
   isLocaleSupported,
   SHARED_TERMS_BY_LOCALE,
@@ -30,43 +35,95 @@ import { logDuration, measureSync, nowMs, elapsedMs } from '@/shared/utils/timin
 
 const log = createLogger('I18nService');
 
-// Eager glob preserves the previous startup behavior while removing the
-// per-locale manual import list. Adding locales now only needs registry and
-// JSON files; the build discovers matching resources automatically.
-const localeModules = import.meta.glob('../../../locales/**/*.json', {
+const lazyLocaleModules = import.meta.glob('../../../locales/**/*.json', {
+  import: 'default',
+}) as Record<string, () => Promise<Record<string, unknown>>>;
+
+// Keep the bootstrap set explicit because these namespaces are used by
+// synchronous i18nService.t(...) call sites during module initialization.
+const bootstrapLocaleModules = import.meta.glob([
+  '../../../locales/*/common.json',
+  '../../../locales/*/components.json',
+  '../../../locales/*/errors.json',
+  '../../../locales/*/flow-chat.json',
+  '../../../locales/*/panels/files.json',
+  '../../../locales/*/panels/git.json',
+  '../../../locales/*/settings/ai-model.json',
+  '../../../locales/*/settings/lsp.json',
+  '../../../locales/*/tools.json',
+], {
   eager: true,
   import: 'default',
 }) as Record<string, Record<string, unknown>>;
 
-function buildResources(): Resource {
-  const resources = Object.entries(localeModules).reduce<Resource>((acc, [modulePath, messages]) => {
-    const match = modulePath.match(/locales\/([^/]+)\/(.+)\.json$/);
-    if (!match) return acc;
+function parseLocaleModulePath(modulePath: string): { locale: string; namespace: string } | null {
+  const match = modulePath.match(/locales\/([^/]+)\/(.+)\.json$/);
+  if (!match) return null;
 
-    const [, locale, namespace] = match;
-    acc[locale] = {
-      ...(acc[locale] ?? {}),
-      [namespace]: messages,
-    };
+  const [, locale, namespace] = match;
+  return { locale, namespace };
+}
+
+function addNamespaceResource(
+  resources: Resource,
+  locale: string,
+  namespace: string,
+  messages: Record<string, unknown>,
+): void {
+  resources[locale] = {
+    ...(resources[locale] ?? {}),
+    [namespace]: messages,
+  };
+}
+
+function buildResources(): Resource {
+  const resources = Object.entries(bootstrapLocaleModules).reduce<Resource>((acc, [modulePath, messages]) => {
+    const parsed = parseLocaleModulePath(modulePath);
+    if (!parsed) return acc;
+
+    addNamespaceResource(acc, parsed.locale, parsed.namespace, messages);
     return acc;
   }, {});
 
   for (const [locale, sharedTerms] of Object.entries(SHARED_TERMS_BY_LOCALE)) {
-    resources[locale] = {
-      ...(resources[locale] ?? {}),
-      shared: sharedTerms,
-    };
+    addNamespaceResource(resources, locale, 'shared', sharedTerms);
   }
 
   return resources;
 }
 
+async function loadLocaleNamespace(locale: string, namespace: string): Promise<Record<string, unknown>> {
+  if (namespace === 'shared') {
+    return SHARED_TERMS_BY_LOCALE[locale as LocaleId] ?? {};
+  }
+
+  const resourceModule = lazyLocaleModules[`../../../locales/${locale}/${namespace}.json`];
+  if (!resourceModule) {
+    return {};
+  }
+
+  return resourceModule();
+}
+
+const lazyNamespaceBackend: BackendModule = {
+  type: 'backend',
+  init() {
+    // Required by the i18next backend interface; this backend has no setup state.
+  },
+  read(language, namespace, callback) {
+    loadLocaleNamespace(language, namespace)
+      .then((messages) => callback(null, messages))
+      .catch((error) => callback(error, false));
+  },
+};
+
 const resourcesResult = measureSync(() => buildResources());
 const resources = resourcesResult.value;
 logDuration(log, 'I18n resources prepared', resourcesResult.durationMs, {
   data: {
-  localeCount: Object.keys(resources).length,
-  moduleCount: Object.keys(localeModules).length,
+    localeCount: Object.keys(resources).length,
+    bootstrapModuleCount: Object.keys(bootstrapLocaleModules).length,
+    lazyModuleCount: Object.keys(lazyLocaleModules).length,
   },
 });
 
@@ -82,19 +139,23 @@ export class I18nService {
 
   constructor() {
     this.i18nInstance = i18next.createInstance();
-    
-    
+
     this.i18nInstance
+      .use(lazyNamespaceBackend)
       .use(initReactI18next)
       .init({
         resources,
+        partialBundledLanguages: true,
         lng: DEFAULT_LOCALE,
         fallbackLng: (code) => getLocaleFallbackChain(code ?? DEFAULT_FALLBACK_LOCALE),
         defaultNS: DEFAULT_NAMESPACE,
         // Shared terms are an explicit namespace, not a global fallback. Product
         // surfaces should opt in with local-first fallback keys when needed.
         fallbackNS: false,
-        ns: [...ALL_NAMESPACES],
+        ns: [...WEB_UI_BOOTSTRAP_NAMESPACES],
+        // Bootstrap namespaces must remain available to module-level
+        // i18nService.t(...) calls immediately after service construction.
+        initImmediate: false,
         interpolation: {
           escapeValue: false,
         },
@@ -123,12 +184,14 @@ export class I18nService {
       }
 
       if (localeToUse !== this.currentLocaleId) {
+        await this.loadNamespacesForLocale(WEB_UI_BOOTSTRAP_NAMESPACES, localeToUse);
         await this.i18nInstance.changeLanguage(localeToUse);
         this.currentLocaleId = localeToUse;
       }
       
       
       const store = useI18nStore.getState();
+      WEB_UI_BOOTSTRAP_NAMESPACES.forEach((namespace) => store.addLoadedNamespace(namespace));
       store.setCurrentLanguage(this.currentLocaleId);
       store.setInitialized(true);
       
@@ -274,7 +337,12 @@ export class I18nService {
       }
       this.emitEvent('i18n:before-change', locale, oldLocale);
 
-      
+      const loadedNamespaces = new Set<I18nNamespace>([
+        ...WEB_UI_BOOTSTRAP_NAMESPACES,
+        ...store.loadedNamespaces,
+      ]);
+      await this.loadNamespacesForLocale([...loadedNamespaces], locale);
+
       await this.i18nInstance.changeLanguage(locale);
       this.currentLocaleId = locale;
 
@@ -321,13 +389,14 @@ export class I18nService {
    
   async loadNamespace(namespace: I18nNamespace): Promise<void> {
     const store = useI18nStore.getState();
-    
-    if (store.loadedNamespaces.includes(namespace)) {
+
+    if (this.hasNamespaceResources(namespace, this.currentLocaleId)) {
+      store.addLoadedNamespace(namespace);
       return;
     }
 
     try {
-      await this.i18nInstance.loadNamespaces(namespace);
+      await this.loadNamespacesForLocale([namespace], this.currentLocaleId);
       store.addLoadedNamespace(namespace);
       this.emitEvent('i18n:namespace-loaded', this.currentLocaleId, undefined, namespace);
     } catch (error) {
@@ -339,7 +408,33 @@ export class I18nService {
    
   isNamespaceLoaded(namespace: I18nNamespace): boolean {
     const store = useI18nStore.getState();
-    return store.loadedNamespaces.includes(namespace);
+    return store.loadedNamespaces.includes(namespace) && this.hasNamespaceResources(namespace, this.currentLocaleId);
+  }
+
+  private hasNamespaceResources(namespace: I18nNamespace, locale: LocaleId): boolean {
+    return getLocaleFallbackChain(locale, true)
+      .every((localeId) => this.i18nInstance.hasResourceBundle(localeId, namespace));
+  }
+
+  private async loadNamespacesForLocale(
+    namespaces: readonly I18nNamespace[],
+    locale: LocaleId,
+  ): Promise<void> {
+    const localeChain = getLocaleFallbackChain(locale, true);
+    await Promise.all(
+      localeChain.flatMap((localeId) =>
+        namespaces.map(async (namespace) => {
+          if (this.i18nInstance.hasResourceBundle(localeId, namespace)) {
+            return;
+          }
+
+          const messages = await loadLocaleNamespace(localeId, namespace);
+          if (Object.keys(messages).length > 0) {
+            this.i18nInstance.addResourceBundle(localeId, namespace, messages, true, true);
+          }
+        }),
+      ),
+    );
   }
 
   

--- a/src/web-ui/src/infrastructure/i18n/hooks/useI18n.ts
+++ b/src/web-ui/src/infrastructure/i18n/hooks/useI18n.ts
@@ -1,10 +1,10 @@
  
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation, UseTranslationOptions } from 'react-i18next';
 import { useI18nStore } from '../store/i18nStore';
 import { i18nService } from '../core/I18nService';
-import { builtinLocales, resolveLocaleId } from '../presets';
+import { builtinLocales, DEFAULT_NAMESPACE, resolveLocaleId } from '../presets';
 import type { LocaleId, I18nNamespace, LocaleMetadata } from '../types';
 
  
@@ -43,12 +43,25 @@ export function useI18n(
   options?: UseTranslationOptions<I18nNamespace>
 ): UseI18nReturn {
   const { t: rawT, i18n, ready } = useTranslation(ns, options);
+  const namespaceKey = Array.isArray(ns) ? ns.join('|') : ns ?? DEFAULT_NAMESPACE;
+  const requestedNamespaces = useMemo(
+    () => namespaceKey.split('|') as I18nNamespace[],
+    [namespaceKey],
+  );
   
   const {
     currentLanguage,
     isInitialized,
     isChanging,
   } = useI18nStore();
+
+  useEffect(() => {
+    requestedNamespaces.forEach((namespace) => {
+      void i18nService.loadNamespace(namespace).catch(() => {
+        // loadNamespace logs failures; keep React render paths non-throwing.
+      });
+    });
+  }, [requestedNamespaces]);
 
   const changeLanguage = useCallback(async (locale: LocaleId) => {
     await i18nService.changeLanguage(locale);

--- a/src/web-ui/src/infrastructure/i18n/presets/index.ts
+++ b/src/web-ui/src/infrastructure/i18n/presets/index.ts
@@ -12,7 +12,7 @@ import {
   resolveLocaleId,
   SHARED_TERMS_BY_LOCALE,
 } from './localeRegistry';
-export { ALL_NAMESPACES } from './namespaceRegistry';
+export { ALL_NAMESPACES, WEB_UI_BOOTSTRAP_NAMESPACES } from './namespaceRegistry';
 export {
   DEFAULT_FALLBACK_LOCALE,
   DEFAULT_LOCALE,

--- a/src/web-ui/src/infrastructure/i18n/presets/namespaceRegistry.ts
+++ b/src/web-ui/src/infrastructure/i18n/presets/namespaceRegistry.ts
@@ -39,3 +39,16 @@ export const ALL_NAMESPACES = [
   'shared',
   'tools',
 ] as const;
+
+export const WEB_UI_BOOTSTRAP_NAMESPACES = [
+  'common',
+  'components',
+  'errors',
+  'flow-chat',
+  'panels/files',
+  'panels/git',
+  'settings/ai-model',
+  'settings/lsp',
+  'shared',
+  'tools',
+] as const satisfies readonly (typeof ALL_NAMESPACES)[number][];


### PR DESCRIPTION
## Summary
- Split Web UI i18n loading into a small eager bootstrap set plus lazy namespace loading for all other Web UI locale JSON files.
- Added guardrails for Web UI bootstrap coverage, mobile-web/installer key parity, hardcoded CJK copy budgets, and the self-contained relay static homepage surface.
- Updated the i18n architecture/development docs plus concise AGENTS/CONTRIBUTING guidance; no process or execution-plan docs are included.
- Scoped AGENTS/CONTRIBUTING verification guidance to the smallest local prechecks, relying on CI for broad builds/full suites unless build or packaging behavior is touched.
- Fixed the existing mobile-web parity gap by adding `en-US.sessions.launch`.

## Behavior and Contract Changes
- Web UI now eagerly bundles only `WEB_UI_BOOTSTRAP_NAMESPACES`; route and feature namespaces should be requested through `useI18n(namespace)` or `i18nService.loadNamespace(namespace)`.
- Direct synchronous `i18nService.t('namespace:key')` and `i18nService.getT()` namespace usage must stay within bootstrap namespaces; `pnpm run i18n:contract:test` enforces this.
- `pnpm run i18n:audit` now treats Web UI, mobile-web, and installer key mismatches as errors, and fails if hardcoded CJK source candidate budgets increase.
- The relay static homepage is explicitly tracked as a self-contained static i18n surface; it is audited for hardcoded-copy budget growth but does not import runtime locale catalogs.
- Verification docs now distinguish resource-only locale changes, contract/shared-term changes, i18n runtime changes, mobile/installer frontend changes, Rust/desktop changes, and packaging changes.

## Risk Notes
- Main runtime risk is missing namespace requests after Web UI lazy loading. This is mitigated by preserving bootstrap coverage for synchronous call sites and adding runtime tests for bootstrap and lazy namespace loading.
- Existing CJK hardcoded-copy warnings remain as grandfathered debt. New CJK source lines should be extracted instead of raising the baseline.
- Existing Vite chunk-size/dynamic-import warnings still appear in Web UI and mobile-web builds; this PR does not attempt unrelated bundle splitting.
- The docs intentionally reduce local prechecks for many changes; this shifts broad build/style regressions to CI, while keeping focused local checks for the touched runtime or resource layer.

## Adversarial Review
- Rechecked startup translation availability after introducing the i18next backend; added `initImmediate: false` and a synchronous bootstrap translation test.
- Rechecked bootstrap ordering/coverage; added a contract test that scans synchronous `i18nService.t(...)` and `getT()` namespace usage against `WEB_UI_BOOTSTRAP_NAMESPACES`.
- Rechecked cross-surface key parity; audit exposed `sessions.launch` missing from mobile-web `en-US`, which is fixed in this PR.
- Rechecked generated/build side effects; Tauri schema and installer sync outputs were not committed.
- Rechecked verification guidance after follow-up feedback; removed web/mobile/installer builds from default local precheck rows and marked remaining broad build/test commands as references for CI reproduction or build-impacting changes only.

## Verification
Runtime and cross-surface validation run earlier in this PR:
- `pnpm run i18n:contract:test`
- `pnpm run i18n:audit` (passes with 3 grandfathered CJK budget warnings)
- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run` (146 files, 772 tests)
- `pnpm run build:web`
- `pnpm --dir src/mobile-web run type-check`
- `pnpm run build:mobile-web`
- `pnpm --dir BitFun-Installer run type-check`
- `pnpm --dir BitFun-Installer run build`
- `cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml`
- `cargo test -p bitfun-core i18n -- --nocapture` (8 passed)

Latest docs-only follow-up validation:
- `pnpm run check:repo-hygiene`
- `git diff --check`
- `git diff --cached --check`
- Legacy heavy-precheck grep returned no matches for the old combined local verification commands.