### PR TITLE
[codex] Dedupe Rust dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ regex = "1"
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp"] }
 md5 = "0.7"
-dashmap = "5"
+dashmap = "6"
 indexmap = "2"
 include_dir = "0.7"
 

--- a/src/apps/cli/Cargo.toml
+++ b/src/apps/cli/Cargo.toml
@@ -44,7 +44,7 @@ dunce = { workspace = true }
 pulldown-cmark = "0.11"
 
 # Diff computation for tool card rendering
-similar = "2"
+similar = { workspace = true }
 
 # Syntax highlighting for code blocks and tool cards
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-fancy"] }

--- a/src/apps/relay-server/Cargo.toml
+++ b/src/apps/relay-server/Cargo.toml
@@ -36,7 +36,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Utilities
 uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde", "clock"] }
-dashmap = "5.5"
+dashmap = { workspace = true }
 rand = "0.8"
 base64 = "0.21"
 sha2 = "0.10"


### PR DESCRIPTION
## Summary

- Move the workspace `dashmap` requirement to 6.x so direct BitFun crates align with the `russh-sftp` graph.
- Use the workspace `similar` requirement from the CLI crate instead of a separate broad requirement.
- Move relay-server's direct `dashmap` requirement onto the workspace dependency.

## Impact

This removes `dashmap v5.5.3` from the Rust dependency graph and keeps the remaining direct `similar` requirements aligned at the workspace level.

## Validation

- Confirmed `dashmap@5.5.3` is no longer present in `cargo tree --workspace --target all`.
- Ran `cargo check --workspace` successfully. The only warning observed was the existing desktop dead-code warning for `parse_clipboard_path_segments`.