### PR TITLE
fix(debug-log): prevent ingest route startup panic

### DIFF
--- a/src/crates/core/src/infrastructure/debug_log/http_server.rs
+++ b/src/crates/core/src/infrastructure/debug_log/http_server.rs
@@ -100,7 +100,7 @@ impl IngestServerManager {
 
         let app = Router::new()
             .route("/health", get(health_handler))
-            .route("/ingest/:session_id", post(ingest_handler))
+            .route("/ingest/{session_id}", post(ingest_handler))
             .layer(cors)
             .with_state(state.clone());
 
@@ -225,5 +225,26 @@ async fn ingest_handler(
                 }),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn starts_with_session_id_ingest_route() {
+        let manager = IngestServerManager::new();
+        let config = IngestServerConfig {
+            port: 0,
+            ..IngestServerConfig::default()
+        };
+
+        manager
+            .start(Some(config))
+            .await
+            .expect("ingest server should start with session id route");
+
+        manager.stop().await;
     }
 }


### PR DESCRIPTION
## Summary
- update the debug log ingest route to axum's `{session_id}` path parameter syntax
- add a regression test that starts the ingest server and catches router-construction panics

## Root cause
Axum rejects route segments starting with `:`. The debug ingest server still registered `/ingest/:session_id`, so debug-mode startup could panic while building the router before the app finished opening.

## Validation
- `pnpm run fmt:rs`
- `cargo test -p bitfun-core infrastructure::debug_log::http_server::tests::starts_with_session_id_ingest_route -- --nocapture`
- `cargo check -p bitfun-core`
- `git diff --staged --check`