### PR TITLE
perf(flow-chat): render recent session history first

### DIFF
--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -224,6 +224,9 @@ pub struct RestoreSessionViewResponse {
     pub session: SessionResponse,
     pub turns: Vec<DialogTurnData>,
     pub context_restore_state: String,
+    pub is_partial: bool,
+    pub loaded_turn_count: usize,
+    pub total_turn_count: usize,
 }
 
 #[derive(Debug, Default)]
@@ -518,6 +521,8 @@ pub struct RestoreSessionRequest {
     pub include_internal: bool,
     #[serde(default)]
     pub trace_id: Option<String>,
+    #[serde(default)]
+    pub tail_turn_count: Option<usize>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1321,16 +1326,42 @@ pub async fn restore_session_view(
         path_started_at.elapsed().as_millis()
     );
 
-    let (session, mut turns) = if request.include_internal {
+    let tail_turn_count = request.tail_turn_count.filter(|count| *count > 0);
+    let (session, mut turns, total_turn_count) = if let Some(tail_turn_count) = tail_turn_count {
+        let tail_turn_count = tail_turn_count.min(16);
+        if request.include_internal {
+            coordinator
+                .restore_internal_session_view_tail(
+                    &effective_path,
+                    &request.session_id,
+                    tail_turn_count,
+                )
+                .await
+        } else {
+            coordinator
+                .restore_session_view_tail(&effective_path, &request.session_id, tail_turn_count)
+                .await
+        }
+    } else if request.include_internal {
         coordinator
             .restore_internal_session_view(&effective_path, &request.session_id)
             .await
+            .map(|(session, turns)| {
+                let total_turn_count = turns.len();
+                (session, turns, total_turn_count)
+            })
     } else {
         coordinator
             .restore_session_view(&effective_path, &request.session_id)
             .await
+            .map(|(session, turns)| {
+                let total_turn_count = turns.len();
+                (session, turns, total_turn_count)
+            })
     }
     .map_err(|e| format!("Failed to restore session view: {}", e))?;
+    let loaded_turn_count = turns.len();
+    let is_partial = loaded_turn_count < total_turn_count;
 
     if log::log_enabled!(log::Level::Debug) {
         let payload_stats = restore_turn_payload_stats(&turns);
@@ -1338,10 +1369,12 @@ pub async fn restore_session_view(
             || payload_stats.result_for_assistant_chars >= 1024 * 1024
         {
             debug!(
-                "restore_session_view payload diagnostics: trace_id={}, session_id={}, turn_count={}, tool_result_count={}, raw_result_string_chars={}, result_for_assistant_chars={}, largest_raw_result_chars={}, largest_raw_result_path={}, top_raw_results={}",
+                "restore_session_view payload diagnostics: trace_id={}, session_id={}, turn_count={}, total_turn_count={}, is_partial={}, tool_result_count={}, raw_result_string_chars={}, result_for_assistant_chars={}, largest_raw_result_chars={}, largest_raw_result_path={}, top_raw_results={}",
                 trace_id,
                 request.session_id,
                 turns.len(),
+                total_turn_count,
+                is_partial,
                 payload_stats.tool_result_count,
                 payload_stats.raw_result_string_chars,
                 payload_stats.result_for_assistant_chars,
@@ -1355,10 +1388,12 @@ pub async fn restore_session_view(
     compact_tool_results_for_session_view(&mut turns);
 
     debug!(
-        "restore_session_view completed: trace_id={}, session_id={}, turn_count={}, context_restore_state=pending, duration_ms={}",
+        "restore_session_view completed: trace_id={}, session_id={}, turn_count={}, total_turn_count={}, is_partial={}, context_restore_state=pending, duration_ms={}",
         trace_id,
         request.session_id,
         turns.len(),
+        total_turn_count,
+        is_partial,
         started_at.elapsed().as_millis()
     );
 
@@ -1366,6 +1401,9 @@ pub async fn restore_session_view(
         session: session_to_response(session),
         turns,
         context_restore_state: "pending".to_string(),
+        is_partial,
+        loaded_turn_count,
+        total_turn_count,
     })
 }
 

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -3240,6 +3240,17 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .await
     }
 
+    pub async fn restore_session_view_tail(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        tail_turn_count: usize,
+    ) -> BitFunResult<(Session, Vec<crate::service::session::DialogTurnData>, usize)> {
+        self.session_manager
+            .restore_session_view_tail(workspace_path, session_id, tail_turn_count)
+            .await
+    }
+
     pub async fn restore_internal_session_view(
         &self,
         workspace_path: &Path,
@@ -3247,6 +3258,17 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
     ) -> BitFunResult<(Session, Vec<crate::service::session::DialogTurnData>)> {
         self.session_manager
             .restore_internal_session_view(workspace_path, session_id)
+            .await
+    }
+
+    pub async fn restore_internal_session_view_tail(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        tail_turn_count: usize,
+    ) -> BitFunResult<(Session, Vec<crate::service::session::DialogTurnData>, usize)> {
+        self.session_manager
+            .restore_internal_session_view_tail(workspace_path, session_id, tail_turn_count)
             .await
     }
 

--- a/src/crates/core/src/agentic/persistence/manager.rs
+++ b/src/crates/core/src/agentic/persistence/manager.rs
@@ -2186,23 +2186,11 @@ impl PersistenceManager {
         Ok(session)
     }
 
-    /// Load session and return the persisted turns read while rebuilding the session header.
-    pub async fn load_session_with_turns(
-        &self,
-        workspace_path: &Path,
-        session_id: &str,
-    ) -> BitFunResult<(Session, Vec<DialogTurnData>)> {
-        let metadata = self
-            .load_session_metadata(workspace_path, session_id)
-            .await?
-            .ok_or_else(|| {
-                BitFunError::NotFound(format!("Session metadata not found: {}", session_id))
-            })?;
-        let stored_state = self
-            .load_stored_session_state(workspace_path, session_id)
-            .await?;
-        let turns = self.load_session_turns(workspace_path, session_id).await?;
-
+    fn build_session_from_persisted_parts(
+        metadata: SessionMetadata,
+        stored_state: Option<StoredSessionStateFile>,
+        turns: &[DialogTurnData],
+    ) -> Session {
         let mut config = stored_state
             .as_ref()
             .map(|value| value.config.clone())
@@ -2230,9 +2218,9 @@ impl PersistenceManager {
             .unwrap_or(SessionState::Idle);
         let created_at = Self::unix_ms_to_system_time(metadata.created_at);
         let last_activity_at = Self::unix_ms_to_system_time(metadata.last_active_at);
-
         let dialog_turn_ids = turns.iter().map(|turn| turn.turn_id.clone()).collect();
-        let session = Session {
+
+        Session {
             session_id: metadata.session_id.clone(),
             session_name: metadata.session_name.clone(),
             agent_type: metadata.agent_type.clone(),
@@ -2247,7 +2235,8 @@ impl PersistenceManager {
             created_by: metadata.created_by.clone(),
             kind: metadata.session_kind,
             snapshot_session_id: stored_state
-                .and_then(|value| value.snapshot_session_id)
+                .as_ref()
+                .and_then(|value| value.snapshot_session_id.clone())
                 .or(metadata.snapshot_session_id.clone()),
             dialog_turn_ids,
             state: runtime_state,
@@ -2256,9 +2245,55 @@ impl PersistenceManager {
             created_at,
             updated_at: last_activity_at,
             last_activity_at,
-        };
+        }
+    }
+
+    /// Load session and return the persisted turns read while rebuilding the session header.
+    pub async fn load_session_with_turns(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+    ) -> BitFunResult<(Session, Vec<DialogTurnData>)> {
+        let metadata = self
+            .load_session_metadata(workspace_path, session_id)
+            .await?
+            .ok_or_else(|| {
+                BitFunError::NotFound(format!("Session metadata not found: {}", session_id))
+            })?;
+        let stored_state = self
+            .load_stored_session_state(workspace_path, session_id)
+            .await?;
+        let turns = self.load_session_turns(workspace_path, session_id).await?;
+        let session = Self::build_session_from_persisted_parts(metadata, stored_state, &turns);
 
         Ok((session, turns))
+    }
+
+    pub async fn load_session_with_tail_turns(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        tail_turn_count: usize,
+    ) -> BitFunResult<(Session, Vec<DialogTurnData>, usize)> {
+        let metadata = self
+            .load_session_metadata(workspace_path, session_id)
+            .await?
+            .ok_or_else(|| {
+                BitFunError::NotFound(format!("Session metadata not found: {}", session_id))
+            })?;
+        let stored_state = self
+            .load_stored_session_state(workspace_path, session_id)
+            .await?;
+        let indexed_paths = self
+            .list_indexed_turn_paths(workspace_path, session_id)
+            .await?;
+        let total_turn_count = indexed_paths.len();
+        let start = indexed_paths.len().saturating_sub(tail_turn_count);
+        let selected_paths = indexed_paths.into_iter().skip(start).collect::<Vec<_>>();
+        let turns = self.read_turn_paths(selected_paths).await?;
+        let session = Self::build_session_from_persisted_parts(metadata, stored_state, &turns);
+
+        Ok((session, turns, total_turn_count))
     }
 
     /// Save session state
@@ -2527,18 +2562,16 @@ impl PersistenceManager {
             .map(|file| file.turn))
     }
 
-    pub async fn load_session_turns(
+    async fn list_indexed_turn_paths(
         &self,
         workspace_path: &Path,
         session_id: &str,
-    ) -> BitFunResult<Vec<DialogTurnData>> {
-        let started_at = Instant::now();
+    ) -> BitFunResult<Vec<(usize, PathBuf)>> {
         let turns_dir = self.turns_dir(workspace_path, session_id);
         if !turns_dir.exists() {
             return Ok(Vec::new());
         }
 
-        let scan_started_at = Instant::now();
         let mut indexed_paths = Vec::new();
         let mut entries = fs::read_dir(&turns_dir)
             .await
@@ -2566,11 +2599,14 @@ impl PersistenceManager {
         }
 
         indexed_paths.sort_by_key(|(index, _)| *index);
-        let scan_duration = scan_started_at.elapsed();
+        Ok(indexed_paths)
+    }
 
-        let read_started_at = Instant::now();
+    async fn read_turn_paths(
+        &self,
+        indexed_paths: Vec<(usize, PathBuf)>,
+    ) -> BitFunResult<Vec<DialogTurnData>> {
         let mut turns = Vec::with_capacity(indexed_paths.len());
-        let turn_file_count = indexed_paths.len();
         for (_, path) in indexed_paths {
             if let Some(file) = self
                 .read_json_optional::<StoredDialogTurnFile>(&path)
@@ -2579,6 +2615,24 @@ impl PersistenceManager {
                 turns.push(file.turn);
             }
         }
+        Ok(turns)
+    }
+
+    pub async fn load_session_turns(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+    ) -> BitFunResult<Vec<DialogTurnData>> {
+        let started_at = Instant::now();
+        let scan_started_at = Instant::now();
+        let indexed_paths = self
+            .list_indexed_turn_paths(workspace_path, session_id)
+            .await?;
+        let scan_duration = scan_started_at.elapsed();
+
+        let read_started_at = Instant::now();
+        let turn_file_count = indexed_paths.len();
+        let turns = self.read_turn_paths(indexed_paths).await?;
         let read_duration = read_started_at.elapsed();
         let total_duration = started_at.elapsed();
         if total_duration >= Duration::from_millis(80) || turn_file_count >= 50 {
@@ -2586,6 +2640,46 @@ impl PersistenceManager {
                 "Loaded session turns: session_id={} turn_count={} turn_file_count={} scan_duration_ms={} read_duration_ms={} total_duration_ms={}",
                 session_id,
                 turns.len(),
+                turn_file_count,
+                scan_duration.as_millis(),
+                read_duration.as_millis(),
+                total_duration.as_millis()
+            );
+        }
+
+        Ok(turns)
+    }
+
+    pub async fn load_session_tail_turns(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        count: usize,
+    ) -> BitFunResult<Vec<DialogTurnData>> {
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+
+        let started_at = Instant::now();
+        let scan_started_at = Instant::now();
+        let indexed_paths = self
+            .list_indexed_turn_paths(workspace_path, session_id)
+            .await?;
+        let scan_duration = scan_started_at.elapsed();
+        let turn_file_count = indexed_paths.len();
+        let start = indexed_paths.len().saturating_sub(count);
+        let selected_paths = indexed_paths.into_iter().skip(start).collect::<Vec<_>>();
+
+        let read_started_at = Instant::now();
+        let turns = self.read_turn_paths(selected_paths).await?;
+        let read_duration = read_started_at.elapsed();
+        let total_duration = started_at.elapsed();
+        if total_duration >= Duration::from_millis(40) || turn_file_count >= 50 {
+            debug!(
+                "Loaded session tail turns: session_id={} turn_count={} requested_count={} turn_file_count={} scan_duration_ms={} read_duration_ms={} total_duration_ms={}",
+                session_id,
+                turns.len(),
+                count,
                 turn_file_count,
                 scan_duration.as_millis(),
                 read_duration.as_millis(),
@@ -3086,6 +3180,58 @@ mod tests {
             .expect("transcript file should be readable");
         assert!(transcript.contains("## Turn 0"));
         assert!(transcript.contains("hello transcript"));
+    }
+
+    #[tokio::test]
+    async fn load_session_tail_turns_returns_latest_turns_in_chronological_order() {
+        let workspace = TestWorkspace::new();
+        let manager =
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager");
+        let session_id = Uuid::new_v4().to_string();
+        let metadata = SessionMetadata::new(
+            session_id.clone(),
+            "Tail turns test".to_string(),
+            "agent".to_string(),
+            "model".to_string(),
+        );
+        manager
+            .save_session_metadata(workspace.path(), &metadata)
+            .await
+            .expect("metadata should save");
+
+        for index in 0..5 {
+            let user_message = UserMessageData {
+                id: format!("user-{index}"),
+                content: format!("prompt {index}"),
+                timestamp: index as u64,
+                metadata: None,
+            };
+            let mut turn = DialogTurnData::new(
+                format!("turn-{index}"),
+                index,
+                session_id.clone(),
+                user_message,
+            );
+            turn.mark_completed();
+            manager
+                .save_dialog_turn(workspace.path(), &turn)
+                .await
+                .expect("turn should save");
+        }
+
+        let tail = manager
+            .load_session_tail_turns(workspace.path(), &session_id, 2)
+            .await
+            .expect("tail turns should load");
+
+        let turn_indices = tail.iter().map(|turn| turn.turn_index).collect::<Vec<_>>();
+        let prompts = tail
+            .iter()
+            .map(|turn| turn.user_message.content.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(turn_indices, vec![3, 4]);
+        assert_eq!(prompts, vec!["prompt 3", "prompt 4"]);
     }
 
     #[tokio::test]

--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -1843,8 +1843,9 @@ impl SessionManager {
         workspace_path: &Path,
         session_id: &str,
     ) -> BitFunResult<(Session, Vec<DialogTurnData>)> {
-        self.restore_session_view_internal(workspace_path, session_id, false)
+        self.restore_session_view_internal(workspace_path, session_id, false, None)
             .await
+            .map(|(session, turns, _)| (session, turns))
     }
 
     pub async fn restore_internal_session_view(
@@ -1852,7 +1853,28 @@ impl SessionManager {
         workspace_path: &Path,
         session_id: &str,
     ) -> BitFunResult<(Session, Vec<DialogTurnData>)> {
-        self.restore_session_view_internal(workspace_path, session_id, true)
+        self.restore_session_view_internal(workspace_path, session_id, true, None)
+            .await
+            .map(|(session, turns, _)| (session, turns))
+    }
+
+    pub async fn restore_session_view_tail(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        tail_turn_count: usize,
+    ) -> BitFunResult<(Session, Vec<DialogTurnData>, usize)> {
+        self.restore_session_view_internal(workspace_path, session_id, false, Some(tail_turn_count))
+            .await
+    }
+
+    pub async fn restore_internal_session_view_tail(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        tail_turn_count: usize,
+    ) -> BitFunResult<(Session, Vec<DialogTurnData>, usize)> {
+        self.restore_session_view_internal(workspace_path, session_id, true, Some(tail_turn_count))
             .await
     }
 
@@ -1861,7 +1883,8 @@ impl SessionManager {
         workspace_path: &Path,
         session_id: &str,
         include_internal: bool,
-    ) -> BitFunResult<(Session, Vec<DialogTurnData>)> {
+        tail_turn_count: Option<usize>,
+    ) -> BitFunResult<(Session, Vec<DialogTurnData>, usize)> {
         let restore_started_at = Instant::now();
         let storage_path_started_at = Instant::now();
         let session_storage_path = {
@@ -1899,14 +1922,26 @@ impl SessionManager {
         );
 
         let session_started_at = Instant::now();
-        let (mut session, persisted_turns) = self
-            .persistence_manager
-            .load_session_with_turns(&session_storage_path, session_id)
-            .await?;
+        let (mut session, persisted_turns, total_turn_count) = if let Some(tail_turn_count) =
+            tail_turn_count
+        {
+            self.persistence_manager
+                .load_session_with_tail_turns(&session_storage_path, session_id, tail_turn_count)
+                .await?
+        } else {
+            let (session, turns) = self
+                .persistence_manager
+                .load_session_with_turns(&session_storage_path, session_id)
+                .await?;
+            let total_turn_count = turns.len();
+            (session, turns, total_turn_count)
+        };
         debug!(
-            "Session view restore phase completed: session_id={}, phase=load_session_with_turns, turn_count={}, duration_ms={}",
+            "Session view restore phase completed: session_id={}, phase=load_session_with_turns, turn_count={}, total_turn_count={}, tail_turn_count={:?}, duration_ms={}",
             session_id,
             persisted_turns.len(),
+            total_turn_count,
+            tail_turn_count,
             elapsed_ms_u64(session_started_at)
         );
 
@@ -1941,7 +1976,7 @@ impl SessionManager {
             elapsed_ms_u64(restore_started_at)
         );
 
-        Ok((session, persisted_turns))
+        Ok((session, persisted_turns, total_turn_count))
     }
 
     /// Restore session and return the persisted turns read during restore.

--- a/src/web-ui/index.html
+++ b/src/web-ui/index.html
@@ -57,11 +57,50 @@
         width: 100%;
         height: 100%;
       }
+
+      .bitfun-preload {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: rgba(143, 143, 153, 0.92);
+        font-family: "Noto Sans SC", "Inter", "Segoe UI", system-ui, sans-serif;
+        font-size: 13px;
+      }
+
+      .bitfun-preload__content {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .bitfun-preload__spinner {
+        width: 14px;
+        height: 14px;
+        border: 2px solid rgba(143, 143, 153, 0.24);
+        border-top-color: rgba(143, 143, 153, 0.9);
+        border-radius: 50%;
+        animation: bitfun-preload-spin 0.8s linear infinite;
+      }
+
+      @keyframes bitfun-preload-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
     </style>
   </head>
 
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div class="bitfun-preload" aria-live="polite">
+        <div class="bitfun-preload__content">
+          <span class="bitfun-preload__spinner" aria-hidden="true"></span>
+          <span>Loading workspace...</span>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
@@ -26,6 +26,8 @@ import {
   getInitialModelRoundGroupRenderCount,
   getNextModelRoundGroupRenderCount,
   getSynchronizedModelRoundGroupRenderCount,
+  getVisibleModelRoundGroupEndIndex,
+  getVisibleModelRoundGroupStartIndex,
 } from './modelRoundProgressiveRender';
 import { Tooltip } from '@/component-library';
 import { createLogger } from '@/shared/utils/logger';
@@ -235,11 +237,22 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
       return () => window.clearTimeout(timeoutId);
     }, [groupedItems.length, renderedGroupCount, round.id, round.isStreaming]);
 
+    const visibleGroupStartIndex = getVisibleModelRoundGroupStartIndex({
+      renderedCount: renderedGroupCount,
+      groupCount: groupedItems.length,
+      isStreaming: round.isStreaming,
+    });
+    const visibleGroupEndIndex = getVisibleModelRoundGroupEndIndex({
+      renderedCount: renderedGroupCount,
+      groupCount: groupedItems.length,
+      startIndex: visibleGroupStartIndex,
+    });
     const visibleGroupedItems = useMemo(
-      () => groupedItems.slice(0, renderedGroupCount),
-      [groupedItems, renderedGroupCount],
+      () => groupedItems.slice(visibleGroupStartIndex, visibleGroupEndIndex),
+      [groupedItems, visibleGroupEndIndex, visibleGroupStartIndex],
     );
-    const hasDeferredGroups = renderedGroupCount < groupedItems.length;
+    const hasDeferredEarlierGroups = visibleGroupStartIndex > 0;
+    const hasDeferredLaterGroups = visibleGroupEndIndex < groupedItems.length;
 
     const extractDialogTurnContent = useCallback(() => {
       const flowChatStore = FlowChatStore.getInstance();
@@ -332,8 +345,14 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
       <div 
         className={`model-round-item model-round-item--${round.isStreaming ? 'streaming' : 'complete'}`}
       >
+        {hasDeferredEarlierGroups && (
+          <div className="model-round-item__history-loader">
+            {t('modelRound.loadingMoreHistory', { defaultValue: 'Loading more history...' })}
+          </div>
+        )}
+
         {visibleGroupedItems.map((group, groupIndex) => {
-          const isLastGroup = !hasDeferredGroups && groupIndex === groupedItems.length - 1;
+          const isLastGroup = visibleGroupStartIndex + groupIndex === groupedItems.length - 1;
           const isLast = isLastRound && isLastGroup;
           switch (group.type) {
             case 'explore':
@@ -377,12 +396,12 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
           }
         })}
 
-        {hasDeferredGroups && (
+        {hasDeferredLaterGroups && (
           <div className="model-round-item__history-loader">
             {t('modelRound.loadingMoreHistory', { defaultValue: 'Loading more history...' })}
           </div>
         )}
-        
+
         {isTurnComplete && isLastRound && hasContent && !round.isStreaming && (
           <div className="model-round-item__footer">
             <ForkSessionButton sessionId={sessionId} turnId={turnId} />

--- a/src/web-ui/src/flow_chat/components/modern/modelRoundProgressiveRender.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/modelRoundProgressiveRender.test.ts
@@ -6,6 +6,8 @@ import {
   getInitialModelRoundGroupRenderCount,
   getNextModelRoundGroupRenderCount,
   getSynchronizedModelRoundGroupRenderCount,
+  getVisibleModelRoundGroupEndIndex,
+  getVisibleModelRoundGroupStartIndex,
 } from './modelRoundProgressiveRender';
 
 describe('modelRoundProgressiveRender', () => {
@@ -42,5 +44,40 @@ describe('modelRoundProgressiveRender', () => {
       initialCount: MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT,
       isStreaming: false,
     })).toBe(MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT + 120);
+  });
+
+  it('starts completed partial rendering from the newest groups', () => {
+    expect(getVisibleModelRoundGroupStartIndex({
+      renderedCount: MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT,
+      groupCount: MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT + 25,
+      isStreaming: false,
+    })).toBe(25);
+  });
+
+  it('keeps streaming rendering anchored at the beginning', () => {
+    expect(getVisibleModelRoundGroupStartIndex({
+      renderedCount: MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT,
+      groupCount: MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT + 25,
+      isStreaming: true,
+    })).toBe(0);
+    expect(getVisibleModelRoundGroupEndIndex({
+      renderedCount: MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT,
+      groupCount: MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT + 25,
+      startIndex: 0,
+    })).toBe(MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT);
+  });
+
+  it('limits completed tail rendering to the requested visible count', () => {
+    const startIndex = getVisibleModelRoundGroupStartIndex({
+      renderedCount: MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT,
+      groupCount: MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT + 25,
+      isStreaming: false,
+    });
+
+    expect(getVisibleModelRoundGroupEndIndex({
+      renderedCount: MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT,
+      groupCount: MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT + 25,
+      startIndex,
+    })).toBe(MODEL_ROUND_INITIAL_GROUP_RENDER_LIMIT + 25);
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/modelRoundProgressiveRender.ts
+++ b/src/web-ui/src/flow_chat/components/modern/modelRoundProgressiveRender.ts
@@ -35,3 +35,25 @@ export function getSynchronizedModelRoundGroupRenderCount(params: {
 
   return Math.min(groupCount, Math.max(currentCount, initialCount));
 }
+
+export function getVisibleModelRoundGroupStartIndex(params: {
+  renderedCount: number;
+  groupCount: number;
+  isStreaming: boolean;
+}): number {
+  const { renderedCount, groupCount, isStreaming } = params;
+  if (isStreaming) {
+    return 0;
+  }
+
+  return Math.max(0, groupCount - Math.min(renderedCount, groupCount));
+}
+
+export function getVisibleModelRoundGroupEndIndex(params: {
+  renderedCount: number;
+  groupCount: number;
+  startIndex: number;
+}): number {
+  const { renderedCount, groupCount, startIndex } = params;
+  return Math.min(groupCount, startIndex + Math.min(renderedCount, groupCount));
+}

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -68,6 +68,15 @@ const resetStore = () => {
     }
   });
   metadataPageRequests?.clear();
+  const fullHistoryHydrationRequests = (flowChatStore as any).fullHistoryHydrationRequests as
+    | Map<string, { timer?: ReturnType<typeof setTimeout> }>
+    | undefined;
+  fullHistoryHydrationRequests?.forEach(request => {
+    if (request.timer) {
+      clearTimeout(request.timer);
+    }
+  });
+  fullHistoryHydrationRequests?.clear();
   ((flowChatStore as any).unsupportedRestoreCommands as Set<string> | undefined)?.clear();
   flowChatStore.setState((): FlowChatState => ({
     sessions: new Map(),
@@ -762,6 +771,112 @@ describe('FlowChatStore historical session hydration state', () => {
     expect(toolItem?.toolResult?.result?.stdout).toBe(visibleOutput);
     expect(toolItem?.toolResult?.result?.nested?.stderr).toBe('also visible');
     expect(toolItem?.toolResult?.resultForAssistant).toBeUndefined();
+  });
+
+  it('renders tail-restored turns before completing partial history in background', async () => {
+    vi.useFakeTimers();
+    const olderTurn = {
+      turnId: 'turn-1',
+      turnIndex: 0,
+      sessionId: 'history-1',
+      timestamp: 1,
+      userMessage: { id: 'user-1', content: 'older prompt', timestamp: 1 },
+      modelRounds: [],
+      startTime: 1,
+      status: 'completed',
+    };
+    const latestTurn = {
+      turnId: 'turn-2',
+      turnIndex: 1,
+      sessionId: 'history-1',
+      timestamp: 2,
+      userMessage: { id: 'user-2', content: 'latest prompt', timestamp: 2 },
+      modelRounds: [],
+      startTime: 2,
+      status: 'completed',
+    };
+    apiMocks.restoreSessionView
+      .mockResolvedValueOnce({
+        session: {
+          sessionId: 'history-1',
+          sessionName: 'History 1',
+          agentType: 'agentic',
+          state: 'Idle',
+          turnCount: 2,
+          createdAt: 1,
+        },
+        turns: [latestTurn],
+        contextRestoreState: 'pending',
+        isPartial: true,
+        loadedTurnCount: 1,
+        totalTurnCount: 2,
+      })
+      .mockResolvedValueOnce({
+        session: {
+          sessionId: 'history-1',
+          sessionName: 'History 1',
+          agentType: 'agentic',
+          state: 'Idle',
+          turnCount: 2,
+          createdAt: 1,
+        },
+        turns: [olderTurn, latestTurn],
+        contextRestoreState: 'pending',
+        isPartial: false,
+        loadedTurnCount: 2,
+        totalTurnCount: 2,
+      });
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    try {
+      await flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
+
+      expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(1);
+      expect(apiMocks.restoreSessionView).toHaveBeenNthCalledWith(
+        1,
+        'history-1',
+        'D:/workspace/BitFun',
+        undefined,
+        undefined,
+        expect.any(String),
+        undefined,
+        3,
+      );
+      expect(
+        flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.userMessage.content)
+      ).toEqual(['latest prompt']);
+      flowChatStore.setSessionContextRestoreState('history-1', 'ready');
+
+      await vi.runOnlyPendingTimersAsync();
+      await flushAsyncWork();
+
+      expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(2);
+      expect(apiMocks.restoreSessionView).toHaveBeenNthCalledWith(
+        2,
+        'history-1',
+        'D:/workspace/BitFun',
+        undefined,
+        undefined,
+        expect.stringContaining('full'),
+        undefined,
+        undefined,
+      );
+      expect(
+        flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.userMessage.content)
+      ).toEqual(['older prompt', 'latest prompt']);
+      expect(flowChatStore.getState().sessions.get('history-1')?.contextRestoreState).toBe('ready');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('falls back to restoreSessionWithTurns when view restore is unavailable', async () => {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -66,6 +66,8 @@ const VALID_AGENT_TYPES = new Set([
   'DeepResearch',
 ]);
 const METADATA_LIST_RECENT_DEDUPE_TTL_MS = 1000;
+const HISTORICAL_SESSION_INITIAL_TAIL_TURN_COUNT = 3;
+const HISTORICAL_SESSION_FULL_HISTORY_DELAY_MS = 150;
 
 interface MetadataListRequest {
   promise: Promise<void>;
@@ -77,6 +79,25 @@ interface MetadataPageRequest {
   promise: Promise<SessionMetadataPage>;
   completedAtMs?: number;
   cleanupTimer?: ReturnType<typeof setTimeout>;
+}
+
+interface FullHistoryHydrationRequest {
+  promise: Promise<void>;
+  timer?: ReturnType<typeof setTimeout>;
+}
+
+interface CompleteSessionHistoryLoadRequest {
+  sessionId: string;
+  workspacePath: string;
+  remoteConnectionId?: string;
+  remoteSshHost?: string;
+  includeInternal?: boolean;
+  initialSessionTraceId: string;
+  expectedDialogTurnIds: string[];
+}
+
+function areStringArraysEqual(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 function isUnsupportedTauriCommandError(error: unknown, command: string): boolean {
@@ -130,6 +151,7 @@ export class FlowChatStore {
   private silentMode = false;
   private metadataListRequests = new Map<string, MetadataListRequest>();
   private metadataPageRequests = new Map<string, MetadataPageRequest>();
+  private fullHistoryHydrationRequests = new Map<string, FullHistoryHydrationRequest>();
   private unsupportedRestoreCommands = new Set<string>();
   private onPersistUnreadCompletion?: (sessionId: string, value: 'completed' | 'error' | 'interrupted' | undefined) => void;
 
@@ -203,6 +225,142 @@ export class FlowChatStore {
       cursor || '',
       limit,
     ]);
+  }
+
+  private getFullHistoryHydrationKey(
+    sessionId: string,
+    workspacePath: string,
+    remoteConnectionId?: string,
+    remoteSshHost?: string,
+    includeInternal?: boolean,
+  ): string {
+    return JSON.stringify([
+      sessionId,
+      workspacePath,
+      remoteConnectionId || '',
+      remoteSshHost || '',
+      includeInternal === true,
+    ]);
+  }
+
+  private scheduleCompleteSessionHistoryLoad(request: CompleteSessionHistoryLoadRequest): void {
+    const requestKey = this.getFullHistoryHydrationKey(
+      request.sessionId,
+      request.workspacePath,
+      request.remoteConnectionId,
+      request.remoteSshHost,
+      request.includeInternal,
+    );
+    if (this.fullHistoryHydrationRequests.has(requestKey)) {
+      return;
+    }
+
+    const remote = isRemoteTraceContext(request.remoteConnectionId, request.remoteSshHost);
+    startupTrace.markPhase('historical_session_full_hydrate_scheduled', {
+      remote,
+      sessionTraceId: request.initialSessionTraceId,
+      loadedTurnCount: request.expectedDialogTurnIds.length,
+    });
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const promise = new Promise<void>(resolve => {
+      timer = setTimeout(() => {
+        void this.completeSessionHistoryLoad(request)
+          .catch(error => {
+            startupTrace.markPhase('historical_session_full_hydrate_failed', {
+              remote,
+              sessionTraceId: `${request.initialSessionTraceId}-full`,
+            });
+            log.warn('Failed to complete partial session history restore', {
+              sessionId: request.sessionId,
+              error,
+            });
+          })
+          .finally(resolve);
+      }, HISTORICAL_SESSION_FULL_HISTORY_DELAY_MS);
+    }).finally(() => {
+      const currentRequest = this.fullHistoryHydrationRequests.get(requestKey);
+      if (currentRequest?.promise === promise) {
+        this.fullHistoryHydrationRequests.delete(requestKey);
+      }
+    });
+
+    this.fullHistoryHydrationRequests.set(requestKey, { promise, timer });
+  }
+
+  private async completeSessionHistoryLoad(
+    request: CompleteSessionHistoryLoadRequest
+  ): Promise<void> {
+    const fullTraceId = `${request.initialSessionTraceId}-full`;
+    const startedAt = nowMs();
+    const remote = isRemoteTraceContext(request.remoteConnectionId, request.remoteSshHost);
+    startupTrace.markPhase('historical_session_full_hydrate_start', {
+      remote,
+      sessionTraceId: fullTraceId,
+    });
+
+    const { agentAPI } = await import('@/infrastructure/api');
+    const restored = await agentAPI.restoreSessionView(
+      request.sessionId,
+      request.workspacePath,
+      request.remoteConnectionId,
+      request.remoteSshHost,
+      fullTraceId,
+      request.includeInternal,
+      undefined,
+    );
+
+    const convertStartedAt = nowMs();
+    const dialogTurns = this.convertToDialogTurns(restored.turns);
+    const restoredLastUserDialogMode =
+      restored.session.lastUserDialogAgentType || this.deriveLastUserDialogMode(dialogTurns);
+    const contextRestoreState: SessionContextRestoreState =
+      restored.contextRestoreState === 'ready' ? 'ready' : 'pending';
+    startupTrace.markPhase('historical_session_full_hydrate_convert_end', {
+      remote,
+      sessionTraceId: fullTraceId,
+      turnCount: dialogTurns.length,
+      durationMs: elapsedMs(convertStartedAt),
+    });
+
+    let applied = false;
+    this.setState(prev => {
+      const session = prev.sessions.get(request.sessionId);
+      if (!session || session.historyState !== 'ready') {
+        return prev;
+      }
+
+      const currentDialogTurnIds = session.dialogTurns.map(turn => turn.id);
+      if (!areStringArraysEqual(currentDialogTurnIds, request.expectedDialogTurnIds)) {
+        return prev;
+      }
+
+      const newSessions = new Map(prev.sessions);
+      newSessions.set(request.sessionId, {
+        ...session,
+        dialogTurns,
+        contextRestoreState:
+          session.contextRestoreState === 'ready' ? 'ready' : contextRestoreState,
+        mode: restored.session.agentType || session.mode,
+        lastUserDialogMode: restoredLastUserDialogMode,
+        lastSubmittedMode:
+          restored.session.lastSubmittedAgentType ?? session.lastSubmittedMode,
+      });
+      applied = true;
+
+      return {
+        ...prev,
+        sessions: newSessions,
+      };
+    });
+
+    startupTrace.markPhase('historical_session_full_hydrate_end', {
+      remote,
+      sessionTraceId: fullTraceId,
+      turnCount: dialogTurns.length,
+      applied,
+      durationMs: elapsedMs(startedAt),
+    });
   }
 
   public setState(updater: (prevState: FlowChatState) => FlowChatState): void {
@@ -2670,6 +2828,9 @@ export class FlowChatStore {
       let turns: DialogTurnData[] | undefined;
       let restoredSessionInfo: AgentSessionInfo | undefined;
       let contextRestoreState: SessionContextRestoreState = 'ready';
+      let restoredHistoryPartial = false;
+      let restoredLoadedTurnCount: number | undefined;
+      let restoredTotalTurnCount: number | undefined;
       if (!isAcpSession) {
         const restoreStartedAt = nowMs();
         startupTrace.markPhase('historical_session_restore_start', { remote, sessionTraceId });
@@ -2741,11 +2902,15 @@ export class FlowChatStore {
                 remoteSshHost,
                 sessionTraceId,
                 options?.includeInternal,
+                HISTORICAL_SESSION_INITIAL_TAIL_TURN_COUNT,
               );
               restoredSessionInfo = restored.session;
               turns = restored.turns;
               contextRestoreState =
                 restored.contextRestoreState === 'ready' ? 'ready' : 'pending';
+              restoredHistoryPartial = restored.isPartial === true;
+              restoredLoadedTurnCount = restored.loadedTurnCount;
+              restoredTotalTurnCount = restored.totalTurnCount;
             } catch (error) {
               if (!isUnsupportedTauriCommandError(error, 'restore_session_view')) {
                 throw error;
@@ -2767,6 +2932,9 @@ export class FlowChatStore {
             remote,
             sessionTraceId,
             turnCount: Array.isArray(turns) ? turns.length : 0,
+            loadedTurnCount: restoredLoadedTurnCount,
+            totalTurnCount: restoredTotalTurnCount,
+            isPartial: restoredHistoryPartial,
             contextRestoreState,
             durationMs: elapsedMs(restoreStartedAt),
           });
@@ -2863,8 +3031,21 @@ export class FlowChatStore {
         remote,
         sessionTraceId,
         turnCount: dialogTurns.length,
+        totalTurnCount: restoredTotalTurnCount,
+        isPartial: restoredHistoryPartial,
         durationMs: elapsedMs(traceStartedAt),
       });
+      if (restoredHistoryPartial) {
+        this.scheduleCompleteSessionHistoryLoad({
+          sessionId,
+          workspacePath,
+          remoteConnectionId,
+          remoteSshHost,
+          includeInternal: options?.includeInternal,
+          initialSessionTraceId: sessionTraceId,
+          expectedDialogTurnIds: dialogTurns.map(turn => turn.id),
+        });
+      }
     } catch (error) {
       this.setState(prev => {
         const session = prev.sessions.get(sessionId);

--- a/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.tsx
@@ -19,6 +19,7 @@ import { Tooltip } from '@/component-library';
 import { createLogger } from '@/shared/utils/logger';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
 import { basenamePath, dirnameAbsolutePath } from '@/shared/utils/pathUtils';
+import { createTodoRenderItems } from './todoRenderItems';
 import './CreatePlanDisplay.scss';
 
 const log = createLogger('PlanDisplay');
@@ -103,6 +104,10 @@ export const PlanDisplay: React.FC<PlanDisplayProps> = ({
   }, [planFilePath, initialName, initialOverview, initialTodos]);
 
   const planData = refreshedData || initialPlanData;
+  const todoRenderItems = useMemo(
+    () => createTodoRenderItems(planData?.todos ?? []),
+    [planData?.todos],
+  );
 
   // Subscribe to shared build state service for cross-component sync.
   useEffect(() => {
@@ -351,9 +356,9 @@ ${JSON.stringify(simpleTodos, null, 2)}
       {planData.todos && planData.todos.length > 0 && isTodosExpanded && (
         <div className="create-plan-todos create-plan-todos--expanded">
           <div className="todos-list">
-            {planData.todos.map((todo, index) => (
+            {todoRenderItems.map(({ todo, key }) => (
               <div
-                key={todo.id || index}
+                key={key}
                 className={`todo-item status-${todo.status || 'pending'}`}
               >
                 {todo.status === 'completed' && (

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -107,6 +107,9 @@ export interface RestoreSessionViewResponse {
   session: SessionInfo;
   turns: DialogTurnData[];
   contextRestoreState: 'ready' | 'pending';
+  isPartial?: boolean;
+  loadedTurnCount?: number;
+  totalTurnCount?: number;
 }
 
 export interface EnsureAssistantBootstrapRequest {
@@ -499,6 +502,7 @@ export class AgentAPI {
     remoteSshHost?: string,
     traceId?: string,
     includeInternal?: boolean,
+    tailTurnCount?: number,
   ): Promise<RestoreSessionViewResponse> {
     try {
       return await api.invoke<RestoreSessionViewResponse>('restore_session_view', {
@@ -509,6 +513,7 @@ export class AgentAPI {
           remoteSshHost,
           traceId,
           includeInternal,
+          ...(tailTurnCount !== undefined ? { tailTurnCount } : {}),
         },
       });
     } catch (error) {


### PR DESCRIPTION
## Summary
- Restore historical sessions with the latest 3 turns first, then hydrate the full history after a short delay when the session state is still unchanged.
- Add backend tail-turn loading for `restore_session_view` so the first historical session open does not read and convert every older turn before showing the latest content.
- Keep large completed model rounds anchored on their newest groups while preserving head-anchored progressive rendering for streaming rounds.
- Add a static preload hint while the debug WebView/Vite module graph is still loading, and fix duplicate React keys in restored plan todo rendering.

Related issue: #949

## Performance Test Scope
This PR is evaluated from user-facing business scenarios, not only isolated helper speedups. The main target is first open of historical sessions, especially sessions with enough history that reading every turn delays the latest visible conversation. Startup is included because the PR adds a preload hint, but this PR does not claim startup latency improvement.

Test environment and method:
- Windows desktop debug preview on this branch after rebasing to latest `main`.
- Startup/session-list data comes from app and webview startup logs for PR commit `d3eec23d`.
- Historical-session restore data uses the same persistence restore path as the app. The baseline column is the no-tail/full restore behavior used before this PR; the PR column is `tailTurnCount=3`, followed by the existing full restore as delayed background hydration.
- Local restore benchmark was run after one warm-up, 7 measured repetitions per sample, on the 5 largest local sessions by turn count. Session identifiers are intentionally omitted from this PR body because they are not meaningful review data.

## Scenario Results
| Business scenario | Baseline / reference behavior | PR #958 result | Product impact |
| --- | ---: | ---: | --- |
| Debug startup to visible native window | Existing native show path | Main window `show` at 944 ms after main-window create start | No latency win claimed; unsafe delayed-window strategy was removed. |
| Debug startup to frontend script | Existing Vite/WebView cold module path | `first_script_eval` at 9799.4 ms | Still slow; preload hint only prevents blank white wait. |
| Debug startup to shell readiness | Existing readiness path | `interactive_shell_ready` at 10557 ms | Still a follow-up for #949; not solved by this PR. |
| Startup workspace/session navigation APIs | Existing paged metadata path | `get_opened_workspaces` 15.1 ms, `get_recent_workspaces` 13.9 ms, 7 `list_persisted_sessions_page` calls max 14.6 ms | Confirms workspace/history list remains visible and responsive after removing delayed-window logic. |
| First open of small/current session | Full restore is effectively unavoidable | 1/1 turn restored in 133.4 ms, convert 1.0 ms, state commit 0.5 ms | Neutral path; no tail-load benefit when the session has no older history. |
| First open of larger historical sessions | Full history read before first render | Tail-3 first restore reads only latest turns, then full history hydrates after 150 ms if state is unchanged | Improves time to latest visible conversation, but does not remove full-history cost. |
| Completed large model round rendering | Previously rendered from the oldest visible groups first | Completed rounds render newest visible groups first; streaming rounds remain anchored at the beginning | Improves perceived latest-content priority; covered by unit tests, no separate browser timing claimed. |
| Restored plan todo rendering | Duplicate IDs could trigger React key warnings | Stable duplicate-safe render keys | Correctness fix; no performance win claimed. |

## Historical Session Restore Measurements
The table below shows the tradeoff explicitly: the PR improves the first visible restore by loading tail turns, while the delayed full hydrate still pays the old full restore cost in the background.

| Local sample | Turns | Size | Baseline full restore avg | PR first restore avg (`tail=3`) | Deferred full hydrate cost still paid | Turn files avoided before first render |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| A | 26 | 3.02 MB | 75.5 ms | 4.2 ms | 75.5 ms | 23 |
| B | 23 | 4.29 MB | 99.5 ms | 5.8 ms | 99.5 ms | 20 |
| C | 17 | 1.33 MB | 35.1 ms | 2.4 ms | 35.1 ms | 14 |
| D | 14 | 2.95 MB | 59.3 ms | 2.9 ms | 59.3 ms | 11 |
| E | 11 | 3.80 MB | 79.7 ms | 10.0 ms | 79.7 ms | 8 |

Summary across these 5 samples:
- Baseline full restore avg range: 35.1-99.5 ms.
- PR first restore avg range: 2.4-10.0 ms.
- Average initial backend restore reduction across samples: 69.8 ms to 5.1 ms, about 92.7% lower before first render.
- Background full hydration still costs 35.1-99.5 ms after the 150 ms delay; this PR changes when the cost is paid, not whether full history eventually exists.

## Risks And Mitigations
- Full history hydration now starts 150 ms after the latest turns are committed. It only applies when the session still contains the same initial tail turn ids, so it should not overwrite a user action or newly appended live turn.
- Small sessions and already-short histories do not benefit materially; the implementation keeps behavior compatible by reporting `isPartial=false` and skipping background hydration when all turns are already loaded.
- The tail restore response includes `isPartial`, `loadedTurnCount`, and `totalTurnCount`; existing UI callers use those fields for hydration and do not rely on the response `session.turnCount` for metadata. Future callers should use `totalTurnCount` when requesting a partial view.
- The static preload hint is intentionally simple and runs before React/i18n initialization. It reduces blank-screen perception in debug preview but does not reduce the remaining `interactive_shell_ready` time.
- Remaining startup work, especially WebView/Vite module evaluation and deferred systems such as ACP requirement probing, still needs follow-up optimization in #949.

## Validation
- `pnpm run fmt:rs`
- `pnpm --dir src/web-ui run test:run -- TodoWriteDisplay.test.tsx FlowChatStore.test.ts modelRoundProgressiveRender.test.ts`
- `pnpm --dir src/web-ui run test:run -- FlowChatStore.test.ts modelRoundProgressiveRender.test.ts`
- `pnpm run type-check:web`
- `cargo test -p bitfun-core agentic::persistence::manager::tests::load_session_tail_turns_returns_latest_turns_in_chronological_order -- --nocapture`
- `cargo check -p bitfun-core`
- `cargo check -p bitfun-desktop` (passes with the existing `parse_clipboard_path_segments` dead_code warning)
- `git diff --check`
- Manual debug preview log check: workspace and session list APIs returned successfully; historical restore used `tailTurnCount: 3`.
- CI run `26673380390`: Frontend Build and Rust Build Check on macOS, Ubuntu, and Windows all passed.