### PR TITLE
refactor: add i18n governance report

### DIFF
--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -185,6 +185,16 @@ explicit allowlist or a code-level mapping comment before cleanup. Localization
 quality candidates are translation work, not structural cleanup, and should not
 be treated as unused keys.
 
+`pnpm run i18n:audit -- --report-json <path>` emits the machine-readable
+governance snapshot for these categories. The report is a review input: it does
+not automatically delete keys or force shared-term migrations.
+
+Dynamic key contracts are tracked in
+`scripts/i18n-dynamic-key-allowlist.json`. Each entry must name the owning code
+path, surface, and exact keys or prefixes. Stale entries fail `i18n:audit`, so
+metadata-driven keys, backend error-code mappings, fallback-key arrays, and
+template factories stay visible before cleanup work deletes resource keys.
+
 Do not add checked-in execution plans for these governance improvements. Keep
 durable architecture and development rules in this document and
 `docs/development/i18n.md`; keep one-off rollout plans outside version control.

--- a/docs/development/i18n.md
+++ b/docs/development/i18n.md
@@ -163,6 +163,16 @@ growth, and CJK source candidates outside approved resource owners. Keep
 user-facing copy in locale/resource files rather than raising hardcoded-copy or
 literal-fallback baselines.
 
+Use `pnpm run i18n:audit -- --report-json <path>` when reviewing cleanup or
+shared-term work. The JSON report separates confirmed unused keys, dynamic-key
+candidates, shared-term duplicate candidates, and l10n quality candidates.
+Delete only confirmed unused keys.
+
+When code reaches keys through metadata or factories, add or update
+`scripts/i18n-dynamic-key-allowlist.json`. Keep each entry scoped to an owner
+path and exact keys or prefixes. Stale allowlist entries fail `i18n:audit`, so
+do not keep broad prefixes after the owning code or resource group is removed.
+
 ## Loading Size
 
 Unifying the language contract must not unify all translation bundles. Each

--- a/scripts/i18n-audit.mjs
+++ b/scripts/i18n-audit.mjs
@@ -8,6 +8,7 @@ const root = process.cwd();
 const contractPath = path.join(root, 'src', 'shared', 'i18n', 'contract', 'locales.json');
 const hardcodedBaselinePath = path.join(root, 'scripts', 'i18n-hardcoded-baseline.json');
 const literalFallbackBaselinePath = path.join(root, 'scripts', 'i18n-literal-fallback-baseline.json');
+const dynamicKeyAllowlistPath = path.join(root, 'scripts', 'i18n-dynamic-key-allowlist.json');
 const sharedTermsDir = path.join(root, 'src', 'shared', 'i18n', 'resources', 'shared');
 const webLocalesDir = path.join(root, 'src', 'web-ui', 'src', 'locales');
 const namespaceRegistryPath = path.join(
@@ -39,6 +40,22 @@ const localeContract = readJsonFile(contractPath);
 let errorCount = 0;
 let warningCount = 0;
 let auditTypeScript = null;
+let cliOptions = { reportJsonPath: null };
+const reportCategories = [
+  'confirmedUnusedKeys',
+  'dynamicKeyCandidates',
+  'sharedTermDuplicates',
+  'l10nQualityCandidates',
+];
+const governanceReport = {
+  version: 1,
+  generatedBy: 'scripts/i18n-audit.mjs',
+  summary: { counts: {} },
+  confirmedUnusedKeys: [],
+  dynamicKeyCandidates: [],
+  sharedTermDuplicates: [],
+  l10nQualityCandidates: [],
+};
 
 function reportError(message) {
   errorCount += 1;
@@ -49,6 +66,40 @@ function reportWarning(message) {
   warningCount += 1;
   console.warn(`[i18n:audit] WARN ${message}`);
 }
+
+function parseCliOptions(args) {
+  const options = { reportJsonPath: null };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--report-json') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) {
+        reportError('--report-json requires an output path');
+      } else {
+        options.reportJsonPath = value;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (arg.startsWith('--report-json=')) {
+      const value = arg.slice('--report-json='.length);
+      if (!value) {
+        reportError('--report-json requires an output path');
+      } else {
+        options.reportJsonPath = value;
+      }
+      continue;
+    }
+
+    reportError(`Unknown i18n audit option "${arg}"`);
+  }
+
+  return options;
+}
+
+cliOptions = parseCliOptions(process.argv.slice(2));
 
 function loadTypeScriptForAudit() {
   try {
@@ -173,6 +224,36 @@ function extractFluentPlaceholders(value) {
 function sameSet(left, right) {
   if (left.length !== right.length) return false;
   return left.every((item, index) => item === right[index]);
+}
+
+function hasHanText(value) {
+  return /\p{Script=Han}/u.test(String(value));
+}
+
+function sortByReportIdentity(left, right) {
+  return JSON.stringify(left).localeCompare(JSON.stringify(right));
+}
+
+function finalizeGovernanceReport() {
+  for (const category of reportCategories) {
+    governanceReport[category].sort(sortByReportIdentity);
+    governanceReport.summary.counts[category] = governanceReport[category].length;
+  }
+}
+
+function writeGovernanceReport() {
+  finalizeGovernanceReport();
+  if (!cliOptions.reportJsonPath) return;
+
+  const outputPath = path.isAbsolute(cliOptions.reportJsonPath)
+    ? cliOptions.reportJsonPath
+    : path.join(root, cliOptions.reportJsonPath);
+  try {
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(governanceReport, null, 2)}\n`, 'utf8');
+  } catch (error) {
+    reportError(`Failed to write i18n governance report to ${toPosixPath(path.relative(root, outputPath))}: ${error.message}`);
+  }
 }
 
 function reportPlaceholderParity(surface, locale, key, expected, actual) {
@@ -745,6 +826,332 @@ function auditRelayStaticHomepageResources() {
   }
 }
 
+function maybeNamespaceResourceKey(namespace, key) {
+  return namespace ? `${namespace}:${key}` : key;
+}
+
+function pushResourceEntry(entries, { surface, locale, namespace = null, key, value, file }) {
+  entries.push({
+    surface,
+    locale,
+    namespace,
+    key,
+    resourceKey: maybeNamespaceResourceKey(namespace, key),
+    value: String(value ?? ''),
+    file,
+  });
+}
+
+function collectI18nResourceEntries(namespaces) {
+  const entries = [];
+  const localeById = new Map(localeContract.locales.map((locale) => [locale.id, locale]));
+
+  for (const locale of supportedLocales) {
+    for (const namespace of namespaces) {
+      const surface = namespace === 'shared' ? 'shared' : 'web-ui';
+      const file = namespace === 'shared'
+        ? `src/shared/i18n/resources/shared/${locale}/terms.json`
+        : `src/web-ui/src/locales/${locale}/${namespace}.json`;
+      for (const [key, value] of readJsonEntries(locale, namespace)) {
+        pushResourceEntry(entries, {
+          surface,
+          locale,
+          namespace: namespace === 'shared' ? 'shared' : namespace,
+          key,
+          value,
+          file,
+        });
+      }
+    }
+  }
+
+  if (auditTypeScript) {
+    for (const [locale, messageEntries] of readMobileMessagesByLocale().entries()) {
+      for (const [key, value] of messageEntries.entries()) {
+        pushResourceEntry(entries, {
+          surface: 'mobile-web',
+          locale,
+          key,
+          value,
+          file: 'src/mobile-web/src/i18n/messages.ts',
+        });
+      }
+    }
+  }
+
+  for (const localeId of localeContract.surfaceOrders?.installer ?? []) {
+    const uiLocale = localeById.get(localeId)?.installer?.uiCode;
+    if (!uiLocale) continue;
+    for (const [key, value] of readInstallerJsonEntries(uiLocale).entries()) {
+      pushResourceEntry(entries, {
+        surface: 'installer',
+        locale: localeId,
+        key,
+        value,
+        file: `BitFun-Installer/src/i18n/locales/${uiLocale}.json`,
+      });
+    }
+  }
+
+  for (const locale of localeContract.surfaceOrders?.core ?? []) {
+    for (const [key, value] of readFluentMessages(locale).entries()) {
+      pushResourceEntry(entries, {
+        surface: 'core',
+        locale,
+        key,
+        value,
+        file: `src/crates/core/locales/${locale}.ftl`,
+      });
+    }
+  }
+
+  const relayMessages = readRelayHomepageMessages();
+  for (const [locale, relayEntries] of relayMessages.entriesByLocale.entries()) {
+    for (const [key, value] of relayEntries.entries()) {
+      pushResourceEntry(entries, {
+        surface: 'relay-static-homepage',
+        locale,
+        key,
+        value,
+        file: 'src/apps/relay-server/static/homepage/i18n.json',
+      });
+    }
+  }
+
+  return entries;
+}
+
+function resourceGroupId(entry) {
+  return [entry.surface, entry.namespace ?? '', entry.key].join('\u0000');
+}
+
+function buildResourceGroups(entries) {
+  const groups = new Map();
+
+  for (const entry of entries) {
+    const id = resourceGroupId(entry);
+    const group = groups.get(id) ?? {
+      id,
+      surface: entry.surface,
+      namespace: entry.namespace,
+      key: entry.key,
+      resourceKey: entry.resourceKey,
+      locales: [],
+      files: [],
+      valueByLocale: new Map(),
+    };
+    group.locales.push(entry.locale);
+    group.files.push(entry.file);
+    group.valueByLocale.set(entry.locale, entry.value);
+    groups.set(id, group);
+  }
+
+  return Array.from(groups.values()).map((group) => ({
+    ...group,
+    locales: sortedUnique(group.locales),
+    files: sortedUnique(group.files),
+  }));
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function readDynamicKeyAllowlist() {
+  if (!fs.existsSync(dynamicKeyAllowlistPath)) {
+    reportError('Missing scripts/i18n-dynamic-key-allowlist.json');
+    return { entries: [] };
+  }
+
+  let allowlist;
+  try {
+    allowlist = readJsonFile(dynamicKeyAllowlistPath);
+  } catch (error) {
+    reportError(`Failed to parse scripts/i18n-dynamic-key-allowlist.json: ${error.message}`);
+    return { entries: [] };
+  }
+
+  if (allowlist.version !== 1) {
+    reportError('scripts/i18n-dynamic-key-allowlist.json must use version 1');
+  }
+  if (!Array.isArray(allowlist.entries)) {
+    reportError('scripts/i18n-dynamic-key-allowlist.json must define an entries array');
+    return { entries: [] };
+  }
+
+  const seenIds = new Set();
+  for (const entry of allowlist.entries) {
+    if (!isNonEmptyString(entry.id)) {
+      reportError('Dynamic key allowlist entries require a non-empty id');
+      continue;
+    }
+    if (seenIds.has(entry.id)) {
+      reportError(`Dynamic key allowlist id "${entry.id}" is duplicated`);
+    }
+    seenIds.add(entry.id);
+
+    for (const field of ['surface', 'owner', 'description']) {
+      if (!isNonEmptyString(entry[field])) {
+        reportError(`Dynamic key allowlist "${entry.id}" requires a non-empty ${field}`);
+      }
+    }
+
+    const keys = Array.isArray(entry.keys) ? entry.keys : [];
+    const prefixes = Array.isArray(entry.keyPrefixes) ? entry.keyPrefixes : [];
+    if (keys.length === 0 && prefixes.length === 0) {
+      reportError(`Dynamic key allowlist "${entry.id}" must define keys or keyPrefixes`);
+    }
+    for (const key of keys) {
+      if (!isNonEmptyString(key)) {
+        reportError(`Dynamic key allowlist "${entry.id}" has an invalid key entry`);
+      }
+    }
+    for (const prefix of prefixes) {
+      if (!isNonEmptyString(prefix)) {
+        reportError(`Dynamic key allowlist "${entry.id}" has an invalid keyPrefixes entry`);
+      }
+    }
+  }
+
+  return allowlist;
+}
+
+function allowlistTargetForGroup(entry, group) {
+  if (entry.surface !== group.surface) return null;
+  if (entry.namespace && entry.namespace !== group.namespace) return null;
+  if (entry.locale && !group.locales.includes(entry.locale)) return null;
+  return entry.namespace ? group.key : group.resourceKey;
+}
+
+function collectDynamicKeyCandidates(resourceGroups) {
+  const allowlist = readDynamicKeyAllowlist();
+  const seen = new Set();
+
+  function addCandidate(entry, group) {
+    const id = [entry.id, group.id].join('\u0000');
+    if (seen.has(id)) return;
+    seen.add(id);
+
+    governanceReport.dynamicKeyCandidates.push({
+      allowlistId: entry.id,
+      surface: group.surface,
+      namespace: group.namespace,
+      key: entry.namespace ? group.key : group.resourceKey,
+      resourceKey: group.resourceKey,
+      owner: entry.owner,
+      reason: entry.description,
+      locales: group.locales,
+      files: group.files,
+    });
+  }
+
+  for (const entry of allowlist.entries ?? []) {
+    const eligibleGroups = resourceGroups.filter((group) => allowlistTargetForGroup(entry, group) != null);
+
+    for (const key of entry.keys ?? []) {
+      const matches = eligibleGroups.filter((group) => allowlistTargetForGroup(entry, group) === key);
+      if (matches.length === 0) {
+        reportError(`Dynamic key allowlist "${entry.id}" references "${key}" but no ${entry.surface} resource matches`);
+      }
+      for (const group of matches) {
+        addCandidate(entry, group);
+      }
+    }
+
+    for (const prefix of entry.keyPrefixes ?? []) {
+      const matches = eligibleGroups.filter((group) => allowlistTargetForGroup(entry, group).startsWith(prefix));
+      if (matches.length === 0) {
+        reportError(`Dynamic key allowlist "${entry.id}" references prefix "${prefix}" but no ${entry.surface} resource matches`);
+      }
+      for (const group of matches) {
+        addCandidate(entry, group);
+      }
+    }
+  }
+}
+
+function collectSharedTermDuplicates(resourceEntries) {
+  const sharedByLocaleAndValue = new Map();
+
+  for (const entry of resourceEntries.filter((item) => item.surface === 'shared')) {
+    if (!entry.value) continue;
+    const localeMap = sharedByLocaleAndValue.get(entry.locale) ?? new Map();
+    localeMap.set(entry.value, [...(localeMap.get(entry.value) ?? []), entry]);
+    sharedByLocaleAndValue.set(entry.locale, localeMap);
+  }
+
+  for (const entry of resourceEntries.filter((item) => item.surface !== 'shared')) {
+    if (!entry.value) continue;
+    const matches = sharedByLocaleAndValue.get(entry.locale)?.get(entry.value) ?? [];
+    for (const shared of matches) {
+      governanceReport.sharedTermDuplicates.push({
+        surface: entry.surface,
+        locale: entry.locale,
+        namespace: entry.namespace,
+        key: entry.key,
+        resourceKey: entry.resourceKey,
+        sharedKey: shared.key,
+        sharedResourceKey: shared.resourceKey,
+        value: entry.value,
+        file: entry.file,
+        reason: 'matches-shared-term-value',
+      });
+    }
+  }
+}
+
+function collectL10nQualityCandidates(resourceGroups) {
+  for (const group of resourceGroups) {
+    const simplified = group.valueByLocale.get('zh-CN');
+    const traditional = group.valueByLocale.get('zh-TW');
+    if (!simplified || !traditional || simplified !== traditional || !hasHanText(traditional)) {
+      continue;
+    }
+
+    governanceReport.l10nQualityCandidates.push({
+      surface: group.surface,
+      namespace: group.namespace,
+      key: group.key,
+      resourceKey: group.resourceKey,
+      locale: 'zh-TW',
+      comparisonLocale: 'zh-CN',
+      value: traditional,
+      files: group.files,
+      reason: 'matches-comparison-locale',
+    });
+  }
+}
+
+function collectConfirmedUnusedKeys() {
+  const expectedLocaleIds = (localeContract.locales ?? []).map((locale) => locale.id).sort();
+  const baselineLocaleId = expectedLocaleIds.includes('en-US') ? 'en-US' : expectedLocaleIds[0];
+  const { entriesByLocale } = readRelayHomepageMessages();
+  const baselineEntries = entriesByLocale.get(baselineLocaleId) ?? new Map();
+  const dataKeys = collectRelayHomepageDataKeys();
+
+  for (const key of diffSets(Array.from(baselineEntries.keys()).sort(), dataKeys)) {
+    governanceReport.confirmedUnusedKeys.push({
+      surface: 'relay-static-homepage',
+      key,
+      resourceKey: key,
+      file: 'src/apps/relay-server/static/homepage/i18n.json',
+      reason: 'not-referenced-by-static-data-i18n-attribute',
+    });
+  }
+}
+
+function auditI18nGovernanceReport(namespaces) {
+  const resourceEntries = collectI18nResourceEntries(namespaces);
+  const resourceGroups = buildResourceGroups(resourceEntries);
+
+  collectDynamicKeyCandidates(resourceGroups);
+  if (cliOptions.reportJsonPath) {
+    collectConfirmedUnusedKeys();
+    collectSharedTermDuplicates(resourceEntries);
+    collectL10nQualityCandidates(resourceGroups);
+  }
+}
+
 function shouldSkipSourceScan(file) {
   const normalized = toPosixPath(path.relative(root, file));
   return (
@@ -1216,6 +1623,8 @@ auditCoreFluentParity();
 auditRelayStaticHomepageResources();
 auditSourceText();
 auditHardcodedSourceBudgets();
+auditI18nGovernanceReport(namespaces);
+writeGovernanceReport();
 
 if (errorCount > 0) {
   console.error(`[i18n:audit] Failed with ${errorCount} error(s) and ${warningCount} warning(s).`);

--- a/scripts/i18n-contract.test.mjs
+++ b/scripts/i18n-contract.test.mjs
@@ -28,8 +28,8 @@ function writeText(relativePath, content) {
   fs.writeFileSync(path.join(root, relativePath), content, 'utf8');
 }
 
-function runI18nAudit() {
-  return spawnSync(process.execPath, ['scripts/i18n-audit.mjs'], {
+function runI18nAudit(args = []) {
+  return spawnSync(process.execPath, ['scripts/i18n-audit.mjs', ...args], {
     cwd: root,
     encoding: 'utf8',
   });
@@ -304,6 +304,92 @@ test('i18n audit gates object-form literal fallbacks with an explicit budget', (
   assert.match(auditSource, /i18n-literal-fallback-baseline\.json/, 'audit should read the literal fallback baseline');
   assert.match(auditSource, /auditWebUiLiteralFallbackBudget/, 'object-form defaultValue fallbacks should have a no-growth gate');
   assert.match(auditSource, /defaultValue/, 'audit should inspect i18next defaultValue options');
+});
+
+test('i18n audit can emit a machine-readable governance report', { concurrency: false }, () => {
+  const reportPath = 'scripts/.tmp-i18n-governance-report.json';
+  const absoluteReportPath = path.join(root, reportPath);
+  fs.rmSync(absoluteReportPath, { force: true });
+
+  try {
+    const result = runI18nAudit(['--report-json', reportPath]);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.ok(fs.existsSync(absoluteReportPath), 'audit should write the requested report file');
+
+    const report = readJson(reportPath);
+    assert.equal(report.version, 1);
+    assert.equal(report.generatedBy, 'scripts/i18n-audit.mjs');
+    assert.ok(Array.isArray(report.confirmedUnusedKeys), 'report should include confirmed unused keys');
+    assert.ok(Array.isArray(report.dynamicKeyCandidates), 'report should include dynamic key candidates');
+    assert.ok(Array.isArray(report.sharedTermDuplicates), 'report should include shared-term duplicate candidates');
+    assert.ok(Array.isArray(report.l10nQualityCandidates), 'report should include l10n quality candidates');
+    assert.deepEqual(
+      report.summary.counts,
+      {
+        confirmedUnusedKeys: report.confirmedUnusedKeys.length,
+        dynamicKeyCandidates: report.dynamicKeyCandidates.length,
+        sharedTermDuplicates: report.sharedTermDuplicates.length,
+        l10nQualityCandidates: report.l10nQualityCandidates.length,
+      },
+      'report counts should match finding arrays',
+    );
+    assert.ok(
+      report.dynamicKeyCandidates.some((entry) => (
+        entry.allowlistId === 'installer-install-path-errors' &&
+        entry.surface === 'installer' &&
+        entry.key === 'errors.installPath.notAbsolute'
+      )),
+      'installer backend error-code mapping should be reported as a dynamic key contract',
+    );
+    assert.ok(
+      report.sharedTermDuplicates.some((entry) => (
+        entry.sharedKey === 'product.name' &&
+        entry.value === 'BitFun' &&
+        entry.resourceKey !== 'shared:product.name'
+      )),
+      'stable product name duplicates should be reported as shared-term candidates',
+    );
+    assert.ok(
+      report.l10nQualityCandidates.some((entry) => (
+        entry.locale === 'zh-TW' &&
+        entry.comparisonLocale === 'zh-CN' &&
+        entry.reason === 'matches-comparison-locale'
+      )),
+      'unchanged zh-TW copy should be reported as a localization quality candidate',
+    );
+  } finally {
+    fs.rmSync(absoluteReportPath, { force: true });
+  }
+});
+
+test('i18n audit fails stale dynamic key allowlist entries', { concurrency: false }, () => {
+  const allowlistPath = 'scripts/i18n-dynamic-key-allowlist.json';
+  const reportPath = 'scripts/.tmp-i18n-stale-dynamic-key-report.json';
+  const absoluteReportPath = path.join(root, reportPath);
+  const allowlist = readJson(allowlistPath);
+
+  allowlist.entries.push({
+    id: 'stale-test-dynamic-key',
+    surface: 'installer',
+    owner: 'scripts/i18n-contract.test.mjs',
+    description: 'Test fixture for stale dynamic key governance.',
+    keys: ['errors.installPath.__missingGovernanceKey__'],
+  });
+
+  fs.rmSync(absoluteReportPath, { force: true });
+  withTemporaryTextFile(allowlistPath, `${JSON.stringify(allowlist, null, 2)}\n`, () => {
+    try {
+      const result = runI18nAudit(['--report-json', reportPath]);
+      assert.notEqual(result.status, 0, 'stale allowlist keys must fail i18n audit');
+      assert.match(
+        `${result.stdout}\n${result.stderr}`,
+        /stale-test-dynamic-key.*errors\.installPath\.__missingGovernanceKey__/,
+        'audit output should identify the stale allowlist key',
+      );
+    } finally {
+      fs.rmSync(absoluteReportPath, { force: true });
+    }
+  });
 });
 
 test('i18n audit validates static hook translation keys with namespace context', () => {

--- a/scripts/i18n-dynamic-key-allowlist.json
+++ b/scripts/i18n-dynamic-key-allowlist.json
@@ -1,0 +1,141 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "id": "installer-install-path-errors",
+      "surface": "installer",
+      "owner": "BitFun-Installer/src/utils/installPathErrors.ts",
+      "description": "Installer backend returns INSTALL_PATH::snake_case codes that the frontend maps to errors.installPath.camelCase.",
+      "keys": [
+        "errors.installPath.notAbsolute",
+        "errors.installPath.filesystemRoot",
+        "errors.installPath.pathNotDirectory",
+        "errors.installPath.directoryMustBeEmptyOrBitfun",
+        "errors.installPath.inspectDirectoryFailed",
+        "errors.installPath.directoryNotWritable",
+        "errors.installPath.parentNotWritable"
+      ]
+    },
+    {
+      "id": "installer-model-provider-metadata",
+      "surface": "installer",
+      "owner": "BitFun-Installer/src/data/modelProviders.ts",
+      "description": "Installer model-provider templates resolve nameKey, descriptionKey, and noteKey metadata at render time.",
+      "keyPrefixes": [
+        "model.providers."
+      ]
+    },
+    {
+      "id": "web-settings-navigation-metadata",
+      "surface": "web-ui",
+      "namespace": "settings",
+      "owner": "src/web-ui/src/app/scenes/settings/settingsConfig.ts",
+      "description": "Settings categories and tabs store nameKey, labelKey, and descriptionKey metadata resolved with the settings namespace.",
+      "keyPrefixes": [
+        "configCenter.categories.",
+        "configCenter.tabs.",
+        "configCenter.tabDescriptions."
+      ]
+    },
+    {
+      "id": "web-settings-keyboard-shortcut-metadata",
+      "surface": "web-ui",
+      "namespace": "settings",
+      "owner": "src/web-ui/src/shared/constants/shortcuts.ts",
+      "description": "Keyboard shortcut descriptors store descriptionKey metadata resolved with the settings namespace.",
+      "keyPrefixes": [
+        "keyboard.shortcuts."
+      ]
+    },
+    {
+      "id": "web-editor-option-metadata",
+      "surface": "web-ui",
+      "namespace": "settings/editor",
+      "owner": "src/web-ui/src/infrastructure/config/components/EditorConfig.tsx",
+      "description": "Editor option descriptors store labelKey metadata resolved with the settings/editor namespace.",
+      "keys": [
+        "display.minimapPositionLeft",
+        "display.minimapPositionRight",
+        "display.minimapSizeAuto",
+        "display.minimapSizeFill",
+        "display.minimapSizeFit"
+      ],
+      "keyPrefixes": [
+        "appearance.cursorStyles.",
+        "appearance.cursorBlinkings.",
+        "behavior.wordWrapOptions.",
+        "behavior.lineNumberOptions.",
+        "display.whitespaceOptions.",
+        "display.lineHighlightOptions."
+      ]
+    },
+    {
+      "id": "web-quick-action-default-metadata",
+      "surface": "web-ui",
+      "namespace": "settings/quick-actions",
+      "owner": "src/web-ui/src/infrastructure/config/services/quickActionLocalization.ts",
+      "description": "Built-in quick action defaults resolve labelKey metadata with the settings/quick-actions namespace.",
+      "keyPrefixes": [
+        "quickActions.defaults."
+      ]
+    },
+    {
+      "id": "web-flow-chat-agent-companion-activity-metadata",
+      "surface": "web-ui",
+      "namespace": "flow-chat",
+      "owner": "src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts",
+      "description": "Agent companion activity descriptors store labelKey metadata resolved with the flow-chat namespace.",
+      "keyPrefixes": [
+        "agentCompanion.activity."
+      ]
+    },
+    {
+      "id": "web-flow-chat-deep-review-action-metadata",
+      "surface": "web-ui",
+      "namespace": "flow-chat",
+      "owner": "src/web-ui/src/flow_chat/utils/deepReviewExperience.ts",
+      "description": "Deep Review degradation descriptors store labelKey and descriptionKey metadata resolved with the flow-chat namespace.",
+      "keys": [
+        "deepReviewActionBar.degradation.reduceReviewers",
+        "deepReviewActionBar.degradation.reduceReviewersDesc",
+        "deepReviewActionBar.degradation.compressContext",
+        "deepReviewActionBar.degradation.compressContextDesc",
+        "deepReviewActionBar.degradation.viewPartial",
+        "deepReviewActionBar.degradation.viewPartialDesc"
+      ]
+    },
+    {
+      "id": "web-ai-error-action-metadata",
+      "surface": "web-ui",
+      "namespace": "errors",
+      "owner": "src/web-ui/src/shared/ai-errors/aiErrorPresenter.ts",
+      "description": "AI error presenters map action codes to errors:ai.actions.* label keys.",
+      "keyPrefixes": [
+        "ai.actions."
+      ]
+    },
+    {
+      "id": "web-profile-persona-doc-template",
+      "surface": "web-ui",
+      "namespace": "scenes/profile",
+      "owner": "src/web-ui/src/app/scenes/profile/views/AssistantConfigPage.tsx",
+      "description": "Assistant persona document labels are generated from Markdown filenames into nursery.assistant.personaDocs.* keys.",
+      "keyPrefixes": [
+        "nursery.assistant.personaDocs."
+      ]
+    },
+    {
+      "id": "web-skills-filter-and-suite-metadata",
+      "surface": "web-ui",
+      "namespace": "scenes/skills",
+      "owner": "src/web-ui/src/app/scenes/skills",
+      "description": "Skills filters and suite modes store labelKey and descKey metadata resolved with the scenes/skills namespace.",
+      "keyPrefixes": [
+        "filters.",
+        "categories.",
+        "suite.modes.",
+        "suite.modeDescriptions."
+      ]
+    }
+  ]
+}

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
@@ -347,7 +347,7 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
       >
         {hasDeferredEarlierGroups && (
           <div className="model-round-item__history-loader">
-            {t('modelRound.loadingMoreHistory', { defaultValue: 'Loading more history...' })}
+            {t('modelRound.loadingMoreHistory')}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Add `i18n:audit -- --report-json <path>` support for a machine-readable governance snapshot covering confirmed unused keys, dynamic-key candidates, shared-term duplicates, and l10n quality candidates.
- Add `scripts/i18n-dynamic-key-allowlist.json` for documented dynamic key contracts such as installer error-code mapping, metadata `labelKey`/`descriptionKey` usage, and template-generated keys.
- Document the report and allowlist workflow in the durable i18n architecture/development docs.
- Remove a literal `defaultValue` fallback from `ModelRoundItem` where `flow-chat:modelRound.loadingMoreHistory` already exists in all locale resources.

## Quality protection
- `pnpm run i18n:audit`
- `pnpm run i18n:contract:test`
- `pnpm run type-check:web`
- `git diff --check`
- Pre-submit adversarial review performed after implementation; the initially broad Deep Review allowlist prefix was narrowed to exact dynamic keys, and report write failures now surface as audit errors.

## Risks and behavior notes
- Normal `i18n:audit` remains a no-build check. It validates dynamic allowlist staleness, while shared-term and l10n candidate collection runs only when `--report-json` is requested.
- The report is advisory and must not be used for automatic deletion. Confirmed-unused detection is intentionally conservative in this PR.
- Dynamic-key allowlist entries must stay scoped to real owner paths and exact keys or narrow prefixes; stale entries now fail the audit.

Related #959