### PR TITLE
feat(acp): add Oh My Pi (omp) as a built-in ACP agent

### DIFF
--- a/src/crates/acp/src/client/builtin_clients.rs
+++ b/src/crates/acp/src/client/builtin_clients.rs
@@ -7,7 +7,10 @@ pub(crate) struct BuiltinAcpClientPreset {
     pub(crate) command: &'static str,
     pub(crate) args: &'static [&'static str],
     pub(crate) tool_command: &'static str,
-    pub(crate) install_package: &'static str,
+    /// npm package BitFun can install on the user's behalf. `None` means the
+    /// agent is user-managed (BitFun only provides the integration, the user
+    /// installs the CLI themselves) — the UI then shows no one-click installer.
+    pub(crate) install_package: Option<&'static str>,
     pub(crate) adapter_package: Option<&'static str>,
     pub(crate) adapter_bin: Option<&'static str>,
 }
@@ -18,7 +21,22 @@ const BUILTIN_ACP_CLIENT_PRESETS: &[BuiltinAcpClientPreset] = &[
         command: "opencode",
         args: &["acp"],
         tool_command: "opencode",
-        install_package: "opencode-ai",
+        install_package: Some("opencode-ai"),
+        adapter_package: None,
+        adapter_bin: None,
+    },
+    // Oh My Pi (omp) — a terminal coding agent that speaks ACP natively via
+    // `omp acp` (no adapter needed, like opencode). User-managed: omp targets
+    // the bun runtime (installed via `bun install -g @oh-my-pi/pi-coding-agent`
+    // or `curl -fsSL https://omp.sh/install | sh`), which BitFun's npm-based
+    // installer cannot provide — so install_package is None and BitFun only
+    // detects `omp` on PATH and launches it. https://github.com/can1357/oh-my-pi
+    BuiltinAcpClientPreset {
+        id: "omp",
+        command: "omp",
+        args: &["acp"],
+        tool_command: "omp",
+        install_package: None,
         adapter_package: None,
         adapter_bin: None,
     },
@@ -27,7 +45,7 @@ const BUILTIN_ACP_CLIENT_PRESETS: &[BuiltinAcpClientPreset] = &[
         command: "npx",
         args: &["--yes", "@zed-industries/claude-code-acp@latest"],
         tool_command: "claude",
-        install_package: "@anthropic-ai/claude-code",
+        install_package: Some("@anthropic-ai/claude-code"),
         adapter_package: Some("@zed-industries/claude-code-acp"),
         adapter_bin: Some("claude-code-acp"),
     },
@@ -36,7 +54,7 @@ const BUILTIN_ACP_CLIENT_PRESETS: &[BuiltinAcpClientPreset] = &[
         command: "npx",
         args: &["--yes", "@zed-industries/codex-acp@latest"],
         tool_command: "codex",
-        install_package: "@openai/codex",
+        install_package: Some("@openai/codex"),
         adapter_package: Some("@zed-industries/codex-acp"),
         adapter_bin: Some("codex-acp"),
     },
@@ -84,5 +102,23 @@ mod tests {
             config.args,
             vec!["--yes", "@zed-industries/claude-code-acp@latest"]
         );
+    }
+
+    #[test]
+    fn omp_is_a_native_acp_preset() {
+        let preset = builtin_acp_client_preset("omp").expect("omp preset registered");
+        assert_eq!(preset.command, "omp");
+        assert_eq!(preset.args, &["acp"]);
+        assert_eq!(preset.tool_command, "omp");
+        // Native ACP — no adapter package/bin, like opencode.
+        assert!(preset.adapter_package.is_none());
+        assert!(preset.adapter_bin.is_none());
+        // User-managed: BitFun provides no installer for omp.
+        assert!(preset.install_package.is_none());
+
+        let config = default_config_for_builtin_client("omp").expect("omp config");
+        assert!(config.enabled);
+        assert_eq!(config.command, "omp");
+        assert_eq!(config.args, vec!["acp"]);
     }
 }

--- a/src/crates/acp/src/client/requirements.rs
+++ b/src/crates/acp/src/client/requirements.rs
@@ -34,7 +34,7 @@ pub(crate) fn acp_requirement_spec<'a>(
     if let Some(preset) = builtin_acp_client_preset(client_id) {
         return AcpRequirementSpec {
             tool_command: preset.tool_command,
-            install_package: Some(preset.install_package),
+            install_package: preset.install_package,
             adapter: match (preset.adapter_package, preset.adapter_bin) {
                 (Some(package), Some(bin)) => Some(AcpAdapterSpec { package, bin }),
                 _ => None,

--- a/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.tsx
@@ -60,12 +60,28 @@ interface AcpClientPreset {
   args: string[];
 }
 
+// Presets that speak ACP natively and therefore need no separate adapter
+// package (their CLI binary is launched directly).
+const NATIVE_ACP_PRESET_IDS = new Set(['opencode', 'omp']);
+
+// Presets BitFun cannot install on the user's behalf — the agent must be
+// installed manually (e.g. omp targets bun and ships via its own installer).
+// The UI hides the one-click "Install CLI" action for these.
+const SELF_MANAGED_INSTALL_PRESET_IDS = new Set(['omp']);
+
 const PRESETS: AcpClientPreset[] = [
   {
     id: 'opencode',
     name: 'opencode',
     description: 'Native ACP coding agent.',
     command: 'opencode',
+    args: ['acp'],
+  },
+  {
+    id: 'omp',
+    name: 'Oh My Pi',
+    description: 'Native ACP coding agent (omp acp).',
+    command: 'omp',
     args: ['acp'],
   },
   {
@@ -388,7 +404,7 @@ const AcpAgentsConfig: React.FC = () => {
         enabled,
         toolInstalled: probe?.tool.installed,
         adapterInstalled: probe?.adapter?.installed,
-        requiresAdapter: Boolean(probe?.adapter || preset.id !== 'opencode'),
+        requiresAdapter: Boolean(probe?.adapter || !NATIVE_ACP_PRESET_IDS.has(preset.id)),
         probePending,
         probe,
       });
@@ -1031,7 +1047,9 @@ const AcpAgentsConfig: React.FC = () => {
                 const installing = installingClientIds.has(preset.id);
                 const configuring = installingClientIds.has(preset.id);
                 const showSelect = hasConfigEntry && (status === 'enabled' || status === 'ready');
-                const canInstallCli = status === 'not_installed' && issueKind !== 'connection_failed';
+                const canInstallCli = status === 'not_installed'
+                  && issueKind !== 'connection_failed'
+                  && !SELF_MANAGED_INSTALL_PRESET_IDS.has(preset.id);
                 const canConfigureAcp = !requiresAdapter
                   ? false
                   : issueKind === 'adapter_missing' || (status === 'partial' && issueKind === 'config_invalid');
@@ -1351,7 +1369,8 @@ const AcpAgentsConfig: React.FC = () => {
                             probe: row.requirementProbe,
                             requiresAdapter: row.requiresAdapter,
                           });
-                          const canInstallCli = row.preset && row.status === 'not_installed' && row.issueKind === 'cli_missing';
+                          const canInstallCli = row.preset && row.status === 'not_installed' && row.issueKind === 'cli_missing'
+                            && !SELF_MANAGED_INSTALL_PRESET_IDS.has(row.preset.id);
                           const canViewError = row.status === 'invalid' || row.status === 'partial'
                             || row.issueKind === 'connection_failed'
                             || row.issueKind === 'permission_denied'


### PR DESCRIPTION
## 概要

把 **Oh My Pi (omp)** 作为内置 ACP agent 接入 FlowChat —— 复用 BitFun 已有的 ACP client 子系统,而不是为它新造一套运行时。

OMP 原生支持 `omp acp`(Agent Client Protocol over JSON-RPC),因此可以直接走现有 ACP 通道,免费获得:子进程拉起、JSON-RPC、工具路由(`bash→terminal/create`、`read→fs/read_text_file`、edit→`session/request_permission` 走 BitFun 权限)、会话持久化、模型选择、PATH 探测等全部能力。

> 背景:这是 #931(multi-runtime support)的替代方案。#931 试图为 OMP/Claude 新写自定义子进程适配器,但 BitFun 早已有成熟的 ACP 集成(opencode / claude-code / codex),且 OMP/Claude 都会说 ACP——详见我在 #931 的分析。本 PR 用约 1/60 的改动量达成同样目标。

## 改动

- **`builtin_clients.rs`**:新增 preset `{ id:"omp", command:"omp", args:["acp"] }`。Native ACP、无 adapter(同 opencode)。per-workspace 的 ACP 会话菜单是动态从 `get_acp_clients` 读的,所以 OMP 会自动出现。
- **用户自管安装**:OMP 面向 `bun` 运行时、通过自身安装器分发(`bun install -g @oh-my-pi/pi-coding-agent` 或 `curl -fsSL https://omp.sh/install | sh`),BitFun 的 npm 安装器无法提供。因此把 `install_package` 改为 `Option` 并对 omp 设 `None`(其余 preset 保持 `Some(...)`);BitFun 只检测 PATH 上的 `omp` 并启动它。
- **`AcpAgentsConfig.tsx`**:设置目录新增 OMP;按 native ACP 处理(`NATIVE_ACP_PRESET_IDS`,无 adapter),并标为自管安装(`SELF_MANAGED_INSTALL_PRESET_IDS`),隐藏"一键安装 CLI"按钮——该行仅反映 PATH 检测到的安装状态。

## 前置条件

用户需自行安装 `omp`(`bun install -g @oh-my-pi/pi-coding-agent` 或 `curl -fsSL https://omp.sh/install | sh`),使其在 PATH 上可用。BitFun 只提供接入,不负责安装。

## 测试

- `cargo test -p bitfun-acp` —— 45 passed(含新增 `omp_is_a_native_acp_preset`,断言无 adapter、无 installer)。
- `vitest AcpAgentsConfig + workspaceAcpMenuClients` —— 10 passed。
- `tsc --noEmit` —— clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
