### PR TITLE
perf(startup): add release timing harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
     "e2e:test:l0:all": "cross-env BITFUN_E2E_APP_MODE=debug pnpm --dir tests/e2e run test:l0:all",
     "e2e:test:l1": "cross-env BITFUN_E2E_APP_MODE=debug pnpm --dir tests/e2e run test:l1",
     "e2e:test:smoke": "cross-env BITFUN_E2E_APP_MODE=debug pnpm --dir tests/e2e run test:smoke",
-    "e2e:test:chat": "cross-env BITFUN_E2E_APP_MODE=debug pnpm --dir tests/e2e run test:chat"
+    "e2e:test:chat": "cross-env BITFUN_E2E_APP_MODE=debug pnpm --dir tests/e2e run test:chat",
+    "e2e:test:perf:debug": "cross-env BITFUN_E2E_APP_MODE=debug pnpm --dir tests/e2e run test:perf",
+    "e2e:test:perf:release-fast": "cross-env BITFUN_E2E_APP_MODE=release-fast pnpm --dir tests/e2e run test:perf"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       '@wdio/devtools-service':
         specifier: ^10.1.0
         version: 10.2.1(@types/node@20.19.37)(@wdio/protocols@9.24.0)(devtools@8.42.0)(expect-webdriverio@5.6.4)(puppeteer-core@21.11.0)(rollup@4.57.1)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webdriverio@9.24.0(puppeteer-core@21.11.0))
+      '@wdio/globals':
+        specifier: ^9.0.0
+        version: 9.23.0(expect-webdriverio@5.6.4)(webdriverio@9.24.0(puppeteer-core@21.11.0))
       '@wdio/local-runner':
         specifier: ^9.0.0
         version: 9.24.0(@wdio/globals@9.23.0)(webdriverio@9.24.0(puppeteer-core@21.11.0))

--- a/src/apps/desktop/Cargo.toml
+++ b/src/apps/desktop/Cargo.toml
@@ -90,7 +90,7 @@ default = []
 # Enable webview devtools and element inspector for development builds.
 # Only active in debug builds or when explicitly requested via --features devtools.
 # Never enabled in release profile intended for end users.
-devtools = ["tauri/devtools"]
+devtools = ["tauri/devtools", "bitfun-webdriver/embedded"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 atspi = { workspace = true }

--- a/src/apps/desktop/src/logging.rs
+++ b/src/apps/desktop/src/logging.rs
@@ -37,7 +37,8 @@ pub struct LogConfig {
 }
 
 fn is_embedded_webdriver_mode() -> bool {
-    cfg!(debug_assertions) && std::env::var_os("BITFUN_WEBDRIVER_PORT").is_some()
+    (cfg!(debug_assertions) || cfg!(feature = "devtools"))
+        && std::env::var_os("BITFUN_WEBDRIVER_PORT").is_some()
 }
 
 fn resolve_logs_root() -> PathBuf {

--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -276,11 +276,15 @@ impl ThemeConfig {
         let theme_type = if self.is_light { "light" } else { "dark" };
         let startup_trace_id_json = serde_json::to_string(startup_trace_id)
             .unwrap_or_else(|_| "\"desktop-unknown\"".to_string());
+        let perf_trace_enabled = cfg!(debug_assertions)
+            || ((cfg!(feature = "devtools") || std::env::var_os("BITFUN_PERF_TRACE").is_some())
+                && std::env::var_os("BITFUN_WEBDRIVER_PORT").is_some());
 
         format!(
             r#"
             (function() {{
                 window.__BITFUN_STARTUP_TRACE_ID__ = {startup_trace_id_json};
+                window.__BITFUN_PERF_TRACE_ENABLED__ = {perf_trace_enabled};
                 function applyTheme() {{
                     var root = document.documentElement;
                     if (!root) return false;
@@ -295,6 +299,7 @@ impl ThemeConfig {
                     root.style.setProperty('--color-bg-flowchat', '{bg_scene}');
                     root.style.setProperty('--color-bg-scene', '{bg_scene}');
                     root.style.setProperty('--color-text-primary', '{text_primary}');
+                    root.style.setProperty('--bitfun-startup-bg', '{bg_primary}');
                     
                     root.style.backgroundColor = '{bg_primary}';
                     
@@ -323,6 +328,7 @@ impl ThemeConfig {
             bg_scene = self.bg_scene,
             text_primary = self.text_primary,
             startup_trace_id_json = startup_trace_id_json,
+            perf_trace_enabled = perf_trace_enabled,
         )
     }
 

--- a/src/crates/webdriver/Cargo.toml
+++ b/src/crates/webdriver/Cargo.toml
@@ -5,6 +5,10 @@ authors.workspace = true
 edition.workspace = true
 description = "Embedded WebDriver server for BitFun desktop"
 
+[features]
+default = []
+embedded = []
+
 [dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true }

--- a/src/crates/webdriver/src/lib.rs
+++ b/src/crates/webdriver/src/lib.rs
@@ -17,7 +17,7 @@ const DEFAULT_WEBDRIVER_LABEL: &str = "main";
 static SERVER_STARTED: AtomicBool = AtomicBool::new(false);
 
 pub fn maybe_start(app: AppHandle) {
-    if !cfg!(debug_assertions) {
+    if !(cfg!(debug_assertions) || cfg!(feature = "embedded")) {
         return;
     }
 

--- a/src/crates/webdriver/src/server/router.rs
+++ b/src/crates/webdriver/src/server/router.rs
@@ -13,208 +13,208 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/status", get(handlers::status))
         .route("/session", post(handlers::session::create))
-        .route("/session/:session_id", delete(handlers::session::delete))
+        .route("/session/{session_id}", delete(handlers::session::delete))
         .route(
-            "/session/:session_id/timeouts",
+            "/session/{session_id}/timeouts",
             get(handlers::timeouts::get).post(handlers::timeouts::set),
         )
         .route(
-            "/session/:session_id/url",
+            "/session/{session_id}/url",
             get(handlers::navigation::get_url).post(handlers::navigation::navigate),
         )
         .route(
-            "/session/:session_id/back",
+            "/session/{session_id}/back",
             post(handlers::navigation::back),
         )
         .route(
-            "/session/:session_id/forward",
+            "/session/{session_id}/forward",
             post(handlers::navigation::forward),
         )
         .route(
-            "/session/:session_id/refresh",
+            "/session/{session_id}/refresh",
             post(handlers::navigation::refresh),
         )
         .route(
-            "/session/:session_id/title",
+            "/session/{session_id}/title",
             get(handlers::navigation::get_title),
         )
         .route(
-            "/session/:session_id/source",
+            "/session/{session_id}/source",
             get(handlers::navigation::get_source),
         )
         .route(
-            "/session/:session_id/window",
+            "/session/{session_id}/window",
             get(handlers::window::get_window_handle)
                 .post(handlers::window::switch_to_window)
                 .delete(handlers::window::close_window),
         )
         .route(
-            "/session/:session_id/window/new",
+            "/session/{session_id}/window/new",
             post(handlers::window::new_window),
         )
         .route(
-            "/session/:session_id/window/handles",
+            "/session/{session_id}/window/handles",
             get(handlers::window::get_window_handles),
         )
         .route(
-            "/session/:session_id/window/rect",
+            "/session/{session_id}/window/rect",
             get(handlers::window::get_window_rect).post(handlers::window::set_window_rect),
         )
         .route(
-            "/session/:session_id/window/maximize",
+            "/session/{session_id}/window/maximize",
             post(handlers::window::maximize),
         )
         .route(
-            "/session/:session_id/window/minimize",
+            "/session/{session_id}/window/minimize",
             post(handlers::window::minimize),
         )
         .route(
-            "/session/:session_id/window/fullscreen",
+            "/session/{session_id}/window/fullscreen",
             post(handlers::window::fullscreen),
         )
         .route(
-            "/session/:session_id/frame",
+            "/session/{session_id}/frame",
             post(handlers::frame::switch_to_frame),
         )
         .route(
-            "/session/:session_id/frame/parent",
+            "/session/{session_id}/frame/parent",
             post(handlers::frame::switch_to_parent_frame),
         )
         .route(
-            "/session/:session_id/alert/dismiss",
+            "/session/{session_id}/alert/dismiss",
             post(handlers::alert::dismiss),
         )
         .route(
-            "/session/:session_id/alert/accept",
+            "/session/{session_id}/alert/accept",
             post(handlers::alert::accept),
         )
         .route(
-            "/session/:session_id/alert/text",
+            "/session/{session_id}/alert/text",
             get(handlers::alert::get_text).post(handlers::alert::send_text),
         )
         .route(
-            "/session/:session_id/element",
+            "/session/{session_id}/element",
             post(handlers::element::find),
         )
         .route(
-            "/session/:session_id/elements",
+            "/session/{session_id}/elements",
             post(handlers::element::find_all),
         )
         .route(
-            "/session/:session_id/element/active",
+            "/session/{session_id}/element/active",
             get(handlers::element::get_active),
         )
         .route(
-            "/session/:session_id/element/:element_id/element",
+            "/session/{session_id}/element/{element_id}/element",
             post(handlers::element::find_from_element),
         )
         .route(
-            "/session/:session_id/element/:element_id/elements",
+            "/session/{session_id}/element/{element_id}/elements",
             post(handlers::element::find_all_from_element),
         )
         .route(
-            "/session/:session_id/element/:element_id/selected",
+            "/session/{session_id}/element/{element_id}/selected",
             get(handlers::element::is_selected),
         )
         .route(
-            "/session/:session_id/element/:element_id/displayed",
+            "/session/{session_id}/element/{element_id}/displayed",
             get(handlers::element::is_displayed),
         )
         .route(
-            "/session/:session_id/element/:element_id/attribute/:name",
+            "/session/{session_id}/element/{element_id}/attribute/{name}",
             get(handlers::element::get_attribute),
         )
         .route(
-            "/session/:session_id/element/:element_id/property/:name",
+            "/session/{session_id}/element/{element_id}/property/{name}",
             get(handlers::element::get_property),
         )
         .route(
-            "/session/:session_id/element/:element_id/css/:property_name",
+            "/session/{session_id}/element/{element_id}/css/{property_name}",
             get(handlers::element::get_css_value),
         )
         .route(
-            "/session/:session_id/element/:element_id/text",
+            "/session/{session_id}/element/{element_id}/text",
             get(handlers::element::get_text),
         )
         .route(
-            "/session/:session_id/element/:element_id/name",
+            "/session/{session_id}/element/{element_id}/name",
             get(handlers::element::get_name),
         )
         .route(
-            "/session/:session_id/element/:element_id/rect",
+            "/session/{session_id}/element/{element_id}/rect",
             get(handlers::element::get_rect),
         )
         .route(
-            "/session/:session_id/element/:element_id/enabled",
+            "/session/{session_id}/element/{element_id}/enabled",
             get(handlers::element::is_enabled),
         )
         .route(
-            "/session/:session_id/element/:element_id/computedrole",
+            "/session/{session_id}/element/{element_id}/computedrole",
             get(handlers::element::get_computed_role),
         )
         .route(
-            "/session/:session_id/element/:element_id/computedlabel",
+            "/session/{session_id}/element/{element_id}/computedlabel",
             get(handlers::element::get_computed_label),
         )
         .route(
-            "/session/:session_id/element/:element_id/click",
+            "/session/{session_id}/element/{element_id}/click",
             post(handlers::element::click),
         )
         .route(
-            "/session/:session_id/element/:element_id/clear",
+            "/session/{session_id}/element/{element_id}/clear",
             post(handlers::element::clear),
         )
         .route(
-            "/session/:session_id/element/:element_id/value",
+            "/session/{session_id}/element/{element_id}/value",
             post(handlers::element::send_keys),
         )
         .route(
-            "/session/:session_id/execute/sync",
+            "/session/{session_id}/execute/sync",
             post(handlers::script::execute_sync),
         )
         .route(
-            "/session/:session_id/execute/async",
+            "/session/{session_id}/execute/async",
             post(handlers::script::execute_async),
         )
-        .route("/session/:session_id/print", post(handlers::print::print))
+        .route("/session/{session_id}/print", post(handlers::print::print))
         .route(
-            "/session/:session_id/actions",
+            "/session/{session_id}/actions",
             post(handlers::actions::perform).delete(handlers::actions::release),
         )
         .route(
-            "/session/:session_id/screenshot",
+            "/session/{session_id}/screenshot",
             get(handlers::screenshot::take),
         )
         .route(
-            "/session/:session_id/element/:element_id/screenshot",
+            "/session/{session_id}/element/{element_id}/screenshot",
             get(handlers::screenshot::take_element),
         )
         .route(
-            "/session/:session_id/element/:element_id/shadow",
+            "/session/{session_id}/element/{element_id}/shadow",
             get(handlers::shadow::get_shadow_root),
         )
         .route(
-            "/session/:session_id/shadow/:shadow_id/element",
+            "/session/{session_id}/shadow/{shadow_id}/element",
             post(handlers::shadow::find_element_in_shadow),
         )
         .route(
-            "/session/:session_id/shadow/:shadow_id/elements",
+            "/session/{session_id}/shadow/{shadow_id}/elements",
             post(handlers::shadow::find_elements_in_shadow),
         )
         .route(
-            "/session/:session_id/se/log/types",
+            "/session/{session_id}/se/log/types",
             get(handlers::logs::get_types),
         )
         .route(
-            "/session/:session_id/cookie",
+            "/session/{session_id}/cookie",
             get(handlers::cookie::get_all)
                 .post(handlers::cookie::add)
                 .delete(handlers::cookie::delete_all),
         )
         .route(
-            "/session/:session_id/cookie/:name",
+            "/session/{session_id}/cookie/{name}",
             get(handlers::cookie::get).delete(handlers::cookie::delete),
         )
-        .route("/session/:session_id/se/log", post(handlers::logs::get))
+        .route("/session/{session_id}/se/log", post(handlers::logs::get))
         .with_state(state)
 }

--- a/src/web-ui/index.html
+++ b/src/web-ui/index.html
@@ -14,6 +14,7 @@
         var m = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
         var root = document.documentElement;
         var bg = root.style.backgroundColor || (m && m.matches ? dark : light);
+        root.style.setProperty('--bitfun-startup-bg', bg);
         root.style.backgroundColor = bg;
         function paintBody() {
           if (document.body) document.body.style.backgroundColor = bg;
@@ -64,6 +65,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
+        background: var(--bitfun-startup-bg, inherit);
         color: rgba(143, 143, 153, 0.92);
         font-family: "Noto Sans SC", "Inter", "Segoe UI", system-ui, sans-serif;
         font-size: 13px;

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -703,6 +703,9 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
               ]
                 .filter(Boolean)
                 .join(' ')}
+              data-testid="session-nav-item"
+              data-session-id={session.sessionId}
+              data-session-title={sessionTitle}
               onClick={() => handleSwitch(session.sessionId)}
             >
               {showSessionModeIcon ? (
@@ -869,6 +872,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
         <button
           type="button"
           className={`bitfun-nav-panel__inline-toggle${metadataPageState.isLoading ? ' is-loading' : ''}`}
+          data-testid="session-nav-show-more"
           disabled={metadataPageState.isLoading}
           onClick={() => { void handleExpandToggle(); }}
         >

--- a/src/web-ui/src/app/components/SplashScreen/SplashScreen.scss
+++ b/src/web-ui/src/app/components/SplashScreen/SplashScreen.scss
@@ -16,9 +16,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  // Explicit dark background as fallback for Linux WebKitGTK
-  // where CSS variable might not load synchronously
-  background: var(--color-bg-primary, #121214);
+  background: var(--bitfun-startup-bg, var(--color-bg-primary, #f3f3f5));
   pointer-events: none;
 
   // ── Exit state ─────────────────────────────────────────────────────────────

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -297,6 +297,7 @@ export class FlowChatStore {
     startupTrace.markPhase('historical_session_full_hydrate_start', {
       remote,
       sessionTraceId: fullTraceId,
+      loadedTurnCount: request.expectedDialogTurnIds.length,
     });
 
     const { agentAPI } = await import('@/infrastructure/api');
@@ -361,6 +362,16 @@ export class FlowChatStore {
       applied,
       durationMs: elapsedMs(startedAt),
     });
+    if (applied) {
+      markPhaseAfterAnimationFrames(startupTrace, 'historical_session_full_hydrate_after_state_commit_frame', {
+        remote,
+        sessionTraceId: fullTraceId,
+        turnCount: dialogTurns.length,
+        durationMs: elapsedMs(startedAt),
+      }, {
+        frameCount: 2,
+      });
+    }
   }
 
   public setState(updater: (prevState: FlowChatState) => FlowChatState): void {
@@ -3014,12 +3025,17 @@ export class FlowChatStore {
         remote,
         sessionTraceId,
         turnCount: dialogTurns.length,
+        totalTurnCount: restoredTotalTurnCount,
+        isPartial: restoredHistoryPartial,
         durationMs: elapsedMs(stateCommitStartedAt),
       });
       markPhaseAfterAnimationFrames(startupTrace, 'historical_session_after_state_commit_frame', {
         remote,
         sessionTraceId,
         turnCount: dialogTurns.length,
+        totalTurnCount: restoredTotalTurnCount,
+        isPartial: restoredHistoryPartial,
+        durationMs: elapsedMs(traceStartedAt),
       }, {
         frameCount: 2,
       });

--- a/src/web-ui/src/infrastructure/theme/core/ThemeService.ts
+++ b/src/web-ui/src/infrastructure/theme/core/ThemeService.ts
@@ -750,6 +750,7 @@ export class ThemeService {
     root.setAttribute('data-theme-type', theme.type);
 
     const bgPrimary = colors.background.primary;
+    root.style.setProperty('--bitfun-startup-bg', bgPrimary);
     root.style.backgroundColor = bgPrimary;
     if (document.body) {
       document.body.style.backgroundColor = bgPrimary;

--- a/src/web-ui/src/main.tsx
+++ b/src/web-ui/src/main.tsx
@@ -29,7 +29,10 @@ import {
 bootstrapLogger();
 
 const log = createLogger('App');
-startupTrace.markPhase('first_script_eval');
+startupTrace.markPhase('first_script_eval', {
+  viteMode: import.meta.env.MODE,
+  isDev: import.meta.env.DEV,
+});
 
 /** Dedupe only for white-screen heuristic (empty #root), not for Error Boundary logs. */
 const WHITE_SCREEN_LOGGED_FLAG = '__bitfun_white_screen_crash_logged__';

--- a/src/web-ui/src/shared/utils/startupTrace.test.ts
+++ b/src/web-ui/src/shared/utils/startupTrace.test.ts
@@ -201,6 +201,67 @@ describe('startupTrace', () => {
     });
   });
 
+  it('returns a sanitized immutable snapshot for performance E2E collection', () => {
+    const logger = createTestLogger();
+    let now = 100;
+    const trace = createStartupTrace({
+      logger,
+      traceId: 'trace-test',
+      now: () => now,
+    });
+
+    trace.markPhase('historical_session_hydrate_start', {
+      sessionTraceId: 'session-1',
+      workspacePath: '/workspace/BitFun',
+      remote: false,
+    });
+    trace.recordApiCall({
+      type: 'tauri',
+      command: 'restore_session_view',
+      durationMs: 42.4,
+      responseBytes: 2048,
+      remote: false,
+      cacheOutcome: 'unknown',
+    });
+
+    const snapshot = trace.getSnapshot();
+    expect(snapshot).toMatchObject({
+      traceId: 'trace-test',
+      phases: {
+        count: 1,
+        events: [
+          {
+            traceId: 'trace-test',
+            phase: 'historical_session_hydrate_start',
+            sessionTraceId: 'session-1',
+            atMs: 100,
+            remote: false,
+          },
+        ],
+      },
+      api: {
+        totalCount: 1,
+        successCount: 1,
+        byCommand: [
+          {
+            command: 'restore_session_view',
+            count: 1,
+            totalDurationMs: 42.4,
+            responseBytes: 2048,
+          },
+        ],
+      },
+    });
+    expect(snapshot.phases.events[0]).not.toHaveProperty('workspacePath');
+
+    snapshot.phases.events.push({
+      traceId: 'mutated',
+      phase: 'mutated',
+      atMs: 0,
+    });
+    expect(trace.getSnapshot().phases.events).toHaveLength(1);
+  });
+
   it('does not log when disabled', () => {
     const logger = createTestLogger();
     const trace = createStartupTrace({

--- a/src/web-ui/src/shared/utils/startupTrace.ts
+++ b/src/web-ui/src/shared/utils/startupTrace.ts
@@ -54,6 +54,43 @@ interface PhaseRecord {
   [key: string]: unknown;
 }
 
+export interface StartupTraceApiSummary {
+  totalCount: number;
+  successCount: number;
+  failureCount: number;
+  cacheHitCount: number;
+  cacheMissCount: number;
+  cacheUnknownCount: number;
+  remoteCount: number;
+  requestBytes: number;
+  responseBytes: number;
+  payloadEstimateDurationMs: number;
+  byCommand: CommandAggregate[];
+}
+
+export interface StartupTraceSnapshot {
+  traceId: string;
+  phases: {
+    count: number;
+    events: PhaseRecord[];
+  };
+  api: StartupTraceApiSummary;
+}
+
+export interface StartupTraceDiagnostics {
+  snapshot: () => StartupTraceSnapshot;
+  flushSummary: (reason: string) => void;
+}
+
+declare global {
+  // E2E and manual performance collection read this sanitized diagnostic surface.
+  // It intentionally exposes no raw request payloads or workspace paths.
+  // eslint-disable-next-line no-var
+  var __BITFUN_STARTUP_TRACE__: StartupTraceDiagnostics | undefined;
+  // eslint-disable-next-line no-var
+  var __BITFUN_PERF_TRACE_ENABLED__: boolean | undefined;
+}
+
 const DEFAULT_MAX_ESTIMATED_BYTES = 64 * 1024;
 const SENSITIVE_KEY_PATTERN =
   /(api[-_]?key|authorization|bearer|token|secret|password|credential|payload|request|response|args|remoteconnectionid|remote[_-]?connection[_-]?id|remotesshhost|remote[_-]?ssh[_-]?host|sshhost|ssh[_-]?host|workspacepath|workspace[_-]?path)/i;
@@ -264,7 +301,7 @@ export class StartupTrace {
     this.logger = options.logger ?? createLogger('StartupTrace');
     this.traceId = options.traceId ?? createTraceId();
     this.now = options.now ?? (() => globalThis.performance?.now?.() ?? Date.now());
-    this.maxPhaseEvents = options.maxPhaseEvents ?? 80;
+    this.maxPhaseEvents = options.maxPhaseEvents ?? 160;
   }
 
   markPhase(phase: string, data?: TraceData): void {
@@ -332,11 +369,7 @@ export class StartupTrace {
     this.commandAggregates.set(call.command, existing);
   }
 
-  flushSummary(reason: string): void {
-    if (!this.enabled) {
-      return;
-    }
-
+  private buildApiSummary(): StartupTraceApiSummary {
     const byCommand = Array.from(this.commandAggregates.values())
       .sort((left, right) => right.totalDurationMs - left.totalDurationMs)
       .map(item => ({
@@ -345,25 +378,44 @@ export class StartupTrace {
         maxDurationMs: roundDurationMs(item.maxDurationMs),
       }));
 
-    this.logger.info('Startup trace summary', {
+    return {
+      totalCount: this.totalApiCount,
+      successCount: this.successfulApiCount,
+      failureCount: this.failedApiCount,
+      cacheHitCount: this.cacheHitCount,
+      cacheMissCount: this.cacheMissCount,
+      cacheUnknownCount: this.cacheUnknownCount,
+      remoteCount: this.remoteApiCount,
+      requestBytes: this.requestBytes,
+      responseBytes: this.responseBytes,
+      payloadEstimateDurationMs: roundDurationMs(this.payloadEstimateDurationMs),
+      byCommand,
+    };
+  }
+
+  getSnapshot(): StartupTraceSnapshot {
+    return {
       traceId: this.traceId,
-      reason,
       phases: {
         count: this.phaseEvents,
-        events: this.phaseRecords,
+        events: this.phaseRecords.map(record => ({ ...record })),
       },
+      api: this.buildApiSummary(),
+    };
+  }
+
+  flushSummary(reason: string): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    const snapshot = this.getSnapshot();
+    this.logger.info('Startup trace summary', {
+      traceId: snapshot.traceId,
+      reason,
+      phases: snapshot.phases,
       api: {
-        totalCount: this.totalApiCount,
-        successCount: this.successfulApiCount,
-        failureCount: this.failedApiCount,
-        cacheHitCount: this.cacheHitCount,
-        cacheMissCount: this.cacheMissCount,
-        cacheUnknownCount: this.cacheUnknownCount,
-        remoteCount: this.remoteApiCount,
-        requestBytes: this.requestBytes,
-        responseBytes: this.responseBytes,
-        payloadEstimateDurationMs: roundDurationMs(this.payloadEstimateDurationMs),
-        byCommand,
+        ...snapshot.api,
       },
     });
   }
@@ -374,6 +426,13 @@ export function createStartupTrace(options: StartupTraceOptions = {}): StartupTr
 }
 
 export const startupTrace = createStartupTrace();
+
+if (import.meta.env.DEV || globalThis.__BITFUN_PERF_TRACE_ENABLED__ === true) {
+  globalThis.__BITFUN_STARTUP_TRACE__ = {
+    snapshot: () => startupTrace.getSnapshot(),
+    flushSummary: (reason: string) => startupTrace.flushSummary(reason),
+  };
+}
 
 export function markPhaseAfterAnimationFrames(
   trace: StartupTrace,

--- a/tests/e2e/E2E-TESTING-GUIDE.md
+++ b/tests/e2e/E2E-TESTING-GUIDE.md
@@ -148,12 +148,19 @@ pnpm test -- --spec ./specs/l0-smoke.spec.ts
 
 ### 4. Test Running Mode (Release vs Dev)
 
-The test framework runs in debug/dev mode:
+The default test framework runs in debug/dev mode. Performance runs can use
+`release-fast` so startup/session timings are closer to a production bundle
+while still enabling the embedded WebDriver through the `devtools` feature.
 
 #### Debug Mode (Default)
 - **Application Path**: `target/debug/bitfun-desktop.exe`
 - **Characteristics**: Includes debug symbols, requires dev server (port 1422)
 - **Use Case**: Local development, rapid iteration
+
+#### Release-Fast Performance Mode
+- **Application Path**: `target/release-fast/bitfun-desktop.exe`
+- **Characteristics**: Production web bundle, release-like Rust profile, embedded WebDriver enabled by `--features devtools`
+- **Use Case**: Startup and historical-session performance measurements
 
 **How to Identify Current Mode**:
 
@@ -165,7 +172,37 @@ application: <PROJECT_ROOT>\target\debug\bitfun-desktop.exe
 Debug build detected, checking dev server...
 ```
 
-**Core Principle**: E2E uses `target/debug/bitfun-desktop.exe` only. If the debug binary is missing, the run should fail instead of falling back to `release`.
+**Core Principle**: Functional E2E still defaults to `target/debug/bitfun-desktop.exe`.
+Performance E2E should explicitly set `BITFUN_E2E_APP_MODE=release-fast` after
+building `pnpm run desktop:build:release-fast`.
+
+### 5. Startup and Long-Session Performance E2E
+
+Generate a long-session fixture in the workspace you want to measure:
+
+```bash
+pnpm --dir tests/e2e run fixture:long-session -- --workspace <workspace-path> --session-count 80 --long-turns 80
+```
+
+Build and run the release-like performance spec:
+
+```bash
+pnpm run desktop:build:release-fast
+cross-env E2E_TEST_WORKSPACE=<workspace-path> BITFUN_E2E_PERF_SESSION_ID=perf-long-session-000 pnpm run e2e:test:perf:release-fast
+```
+
+For debug-only comparison, build the debug binary and run:
+
+```bash
+cargo build -p bitfun-desktop
+cross-env E2E_TEST_WORKSPACE=<workspace-path> BITFUN_E2E_PERF_SESSION_ID=perf-long-session-000 pnpm run e2e:test:perf:debug
+```
+
+The spec writes JSON reports under `tests/e2e/reports/performance/`. It records
+startup milestones, Tauri API aggregates, first-open session hydration timings,
+and background full-hydrate timings when they occur. Optional threshold gates can
+be enabled with `BITFUN_E2E_PERF_MAX_INTERACTIVE_MS` and
+`BITFUN_E2E_PERF_MAX_SESSION_FRAME_MS`.
 
 ## Test Structure
 

--- a/tests/e2e/E2E-TESTING-GUIDE.zh-CN.md
+++ b/tests/e2e/E2E-TESTING-GUIDE.zh-CN.md
@@ -165,7 +165,33 @@ application: <PROJECT_ROOT>\target\debug\bitfun-desktop.exe
 Debug build detected, checking dev server...
 ```
 
-**核心原理**: E2E 只使用 `target/debug/bitfun-desktop.exe`。如果 debug 二进制不存在，应直接失败，而不是回退到 `release`。
+**核心原理**: 功能 E2E 默认使用 `target/debug/bitfun-desktop.exe`。性能 E2E 需要显式设置 `BITFUN_E2E_APP_MODE=release-fast`，并先执行 `pnpm run desktop:build:release-fast`。
+
+### 5. 启动和长 Session 性能 E2E
+
+性能测试优先使用 `release-fast`，这样可以使用生产 Web bundle 和类 release Rust profile，同时通过 `devtools` feature 保留嵌入式 WebDriver。
+
+先为目标工作区生成长 session 和长列表 fixture：
+
+```bash
+pnpm --dir tests/e2e run fixture:long-session -- --workspace <workspace-path> --session-count 80 --long-turns 80
+```
+
+运行类 release 性能测试：
+
+```bash
+pnpm run desktop:build:release-fast
+cross-env E2E_TEST_WORKSPACE=<workspace-path> BITFUN_E2E_PERF_SESSION_ID=perf-long-session-000 pnpm run e2e:test:perf:release-fast
+```
+
+运行 debug 对照测试：
+
+```bash
+cargo build -p bitfun-desktop
+cross-env E2E_TEST_WORKSPACE=<workspace-path> BITFUN_E2E_PERF_SESSION_ID=perf-long-session-000 pnpm run e2e:test:perf:debug
+```
+
+测试报告会写入 `tests/e2e/reports/performance/`，包含启动阶段、Tauri API 聚合、首次打开长 session、后台 full hydrate 等时间片。可选阈值环境变量：`BITFUN_E2E_PERF_MAX_INTERACTIVE_MS`、`BITFUN_E2E_PERF_MAX_SESSION_FRAME_MS`。
 
 ## 测试结构
 

--- a/tests/e2e/config/embedded-driver.ts
+++ b/tests/e2e/config/embedded-driver.ts
@@ -28,7 +28,9 @@ type BrowserLogEntry = {
   timestamp: number;
 };
 
-function executableCandidates(buildType: 'debug' | 'release'): string[] {
+type E2eBuildType = 'debug' | 'release' | 'release-fast';
+
+function executableCandidates(buildType: E2eBuildType): string[] {
   const root = projectRoot();
   const suffix = process.platform === 'win32' ? '.exe' : '';
   const binaryName = `bitfun-desktop${suffix}`;
@@ -55,8 +57,12 @@ export function getApplicationPath(): string {
     return executableCandidates('debug')[0];
   }
 
+  if (forcedMode === 'release-fast') {
+    return executableCandidates('release-fast')[0];
+  }
+
   if (forcedMode === 'release') {
-    throw new Error('Release mode is disabled for E2E. Use the debug desktop build instead.');
+    return executableCandidates('release')[0];
   }
 
   const debugMatch = executableCandidates('debug').find(candidate => fs.existsSync(candidate));
@@ -363,8 +369,9 @@ async function startBitFunApp(): Promise<void> {
 
   if (!fs.existsSync(appPath)) {
     console.error(`Application not found at: ${appPath}`);
-    console.error('Please build the debug application first with:');
+    console.error('Please build the selected application first. Common commands:');
     console.error('cargo build -p bitfun-desktop');
+    console.error('pnpm run desktop:build:release-fast');
     throw new Error('Application not built');
   }
 
@@ -475,8 +482,9 @@ export function createEmbeddedConfig(specs: string[], label: string): Options.Te
 
       if (!fs.existsSync(appPath)) {
         console.error(`Application not found at: ${appPath}`);
-        console.error('Please build the debug application first with:');
+        console.error('Please build the selected application first. Common commands:');
         console.error('cargo build -p bitfun-desktop');
+        console.error('pnpm run desktop:build:release-fast');
         throw new Error('Application not built');
       }
 

--- a/tests/e2e/helpers/performance-trace.ts
+++ b/tests/e2e/helpers/performance-trace.ts
@@ -1,0 +1,160 @@
+import { browser } from '@wdio/globals';
+
+declare global {
+  interface Window {
+    __BITFUN_STARTUP_TRACE__?: {
+      snapshot?: () => unknown;
+    };
+  }
+}
+
+export interface StartupTracePhase {
+  traceId: string;
+  phase: string;
+  atMs: number;
+  [key: string]: unknown;
+}
+
+export interface StartupTraceCommandAggregate {
+  command: string;
+  count: number;
+  successCount: number;
+  failureCount: number;
+  cacheHitCount: number;
+  cacheMissCount: number;
+  cacheUnknownCount: number;
+  remoteCount: number;
+  totalDurationMs: number;
+  maxDurationMs: number;
+  requestBytes: number;
+  responseBytes: number;
+}
+
+export interface StartupTraceSnapshot {
+  traceId: string;
+  phases: {
+    count: number;
+    events: StartupTracePhase[];
+  };
+  api: {
+    totalCount: number;
+    successCount: number;
+    failureCount: number;
+    cacheHitCount: number;
+    cacheMissCount: number;
+    cacheUnknownCount: number;
+    remoteCount: number;
+    requestBytes: number;
+    responseBytes: number;
+    payloadEstimateDurationMs: number;
+    byCommand: StartupTraceCommandAggregate[];
+  };
+}
+
+export type StartupPerfMilestones = {
+  firstScriptEvalMs?: number;
+  startApplicationStartMs?: number;
+  beforeRenderDurationMs?: number;
+  reactRenderScheduledMs?: number;
+  appEffectMountedMs?: number;
+  mainWindowShownMs?: number;
+  interactiveShellReadyMs?: number;
+  nonCriticalInitDoneMs?: number;
+};
+
+export type SessionOpenPerfMilestones = {
+  hydrateStartMs?: number;
+  restoreDurationMs?: number;
+  convertDurationMs?: number;
+  stateCommitDurationMs?: number;
+  latestFrameSinceHydrateMs?: number;
+  hydrateDurationMs?: number;
+  fullHydrateDurationMs?: number;
+  fullHydrateFrameSinceStartMs?: number;
+  loadedTurnCount?: number;
+  totalTurnCount?: number;
+  isPartial?: boolean;
+};
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function booleanField(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+export async function readStartupTraceSnapshot(): Promise<StartupTraceSnapshot> {
+  const snapshot = await browser.execute(() => {
+    const diagnostics = window.__BITFUN_STARTUP_TRACE__;
+    return diagnostics?.snapshot?.() ?? null;
+  });
+
+  if (!snapshot) {
+    throw new Error('Startup trace diagnostics are not available');
+  }
+  return snapshot as StartupTraceSnapshot;
+}
+
+export async function readPerformanceNow(): Promise<number> {
+  return browser.execute(() => performance.now());
+}
+
+export async function waitForTracePhaseCount(
+  phase: string,
+  minCount: number,
+  timeoutMs = 15000,
+): Promise<StartupTraceSnapshot> {
+  let latest = await readStartupTraceSnapshot();
+  await browser.waitUntil(async () => {
+    latest = await readStartupTraceSnapshot();
+    return latest.phases.events.filter(event => event.phase === phase).length >= minCount;
+  }, {
+    timeout: timeoutMs,
+    interval: 100,
+    timeoutMsg: `Timed out waiting for startup trace phase '${phase}' count ${minCount}`,
+  });
+  return latest;
+}
+
+export function summarizeStartup(snapshot: StartupTraceSnapshot): StartupPerfMilestones {
+  const phase = (name: string) => snapshot.phases.events.find(event => event.phase === name);
+  const beforeRenderEnd = phase('before_render_end');
+  return {
+    firstScriptEvalMs: numberField(phase('first_script_eval')?.atMs),
+    startApplicationStartMs: numberField(phase('start_application_start')?.atMs),
+    beforeRenderDurationMs: numberField(beforeRenderEnd?.durationMs),
+    reactRenderScheduledMs: numberField(phase('react_render_scheduled')?.atMs),
+    appEffectMountedMs: numberField(phase('app_effect_mounted')?.atMs),
+    mainWindowShownMs: numberField(phase('main_window_shown')?.atMs),
+    interactiveShellReadyMs: numberField(phase('interactive_shell_ready')?.atMs),
+    nonCriticalInitDoneMs: numberField(phase('non_critical_init_done')?.atMs),
+  };
+}
+
+export function summarizeSessionOpen(
+  events: StartupTracePhase[],
+): SessionOpenPerfMilestones {
+  const last = (name: string) => events.filter(event => event.phase === name).at(-1);
+  const restoreEnd = last('historical_session_restore_end');
+  const convertEnd = last('historical_session_convert_end');
+  const stateCommitEnd = last('historical_session_state_commit_end');
+  const latestFrame = last('historical_session_after_state_commit_frame');
+  const hydrateEnd = last('historical_session_hydrate_end');
+  const fullHydrateEnd = last('historical_session_full_hydrate_end');
+  const fullHydrateFrame = last('historical_session_full_hydrate_after_state_commit_frame');
+
+  return {
+    hydrateStartMs: numberField(last('historical_session_hydrate_start')?.atMs),
+    restoreDurationMs: numberField(restoreEnd?.durationMs),
+    convertDurationMs: numberField(convertEnd?.durationMs),
+    stateCommitDurationMs: numberField(stateCommitEnd?.durationMs),
+    latestFrameSinceHydrateMs: numberField(latestFrame?.durationMs),
+    hydrateDurationMs: numberField(hydrateEnd?.durationMs),
+    fullHydrateDurationMs: numberField(fullHydrateEnd?.durationMs),
+    fullHydrateFrameSinceStartMs: numberField(fullHydrateFrame?.durationMs),
+    loadedTurnCount: numberField(restoreEnd?.loadedTurnCount),
+    totalTurnCount: numberField(restoreEnd?.totalTurnCount ?? hydrateEnd?.totalTurnCount),
+    isPartial: booleanField(restoreEnd?.isPartial ?? hydrateEnd?.isPartial),
+  };
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -29,6 +29,8 @@
     "test:l1:session": "wdio run ./config/wdio.conf.ts --spec \"./specs/l1-session.spec.ts\"",
     "test:l1:dialog": "wdio run ./config/wdio.conf.ts --spec \"./specs/l1-dialog.spec.ts\"",
     "test:l1:chat-flow": "wdio run ./config/wdio.conf.ts --spec \"./specs/l1-chat.spec.ts\"",
+    "test:perf": "wdio run ./config/wdio.conf.ts --spec \"./specs/performance/startup-session-perf.spec.ts\"",
+    "fixture:long-session": "node ./scripts/generate-long-session-fixture.mjs",
     "test:smoke": "wdio run ./config/wdio.conf.ts --spec \"./specs/startup/*.spec.ts\"",
     "test:chat": "wdio run ./config/wdio.conf.ts --spec \"./specs/chat/*.spec.ts\"",
     "clean": "rimraf ./reports"
@@ -37,6 +39,7 @@
     "@types/node": "^20.0.0",
     "@wdio/cli": "^9.0.0",
     "@wdio/devtools-service": "^10.1.0",
+    "@wdio/globals": "^9.0.0",
     "@wdio/local-runner": "^9.0.0",
     "@wdio/mocha-framework": "^9.0.0",
     "@wdio/spec-reporter": "^9.0.0",

--- a/tests/e2e/scripts/generate-long-session-fixture.mjs
+++ b/tests/e2e/scripts/generate-long-session-fixture.mjs
@@ -1,0 +1,420 @@
+import crypto from 'crypto';
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import os from 'os';
+import path from 'path';
+
+const SESSION_STORAGE_SCHEMA_VERSION = 2;
+const MAX_PROJECT_SLUG_LEN = 120;
+
+function parseArgs(argv) {
+  const options = {
+    workspace: undefined,
+    bitfunHome: process.env.BITFUN_HOME || path.join(os.homedir(), '.bitfun'),
+    sessionPrefix: 'perf-long-session',
+    sessionCount: 80,
+    longTurns: 80,
+    shortTurns: 1,
+    assistantChars: 2_000,
+    toolResultChars: 12_000,
+    toolItems: 2,
+    cleanup: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => {
+      index += 1;
+      if (index >= argv.length) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      return argv[index];
+    };
+
+    switch (arg) {
+      case '--workspace':
+        options.workspace = next();
+        break;
+      case '--bitfun-home':
+        options.bitfunHome = next();
+        break;
+      case '--session-prefix':
+        options.sessionPrefix = next();
+        break;
+      case '--session-count':
+        options.sessionCount = Number(next());
+        break;
+      case '--long-turns':
+        options.longTurns = Number(next());
+        break;
+      case '--short-turns':
+        options.shortTurns = Number(next());
+        break;
+      case '--assistant-chars':
+        options.assistantChars = Number(next());
+        break;
+      case '--tool-result-chars':
+        options.toolResultChars = Number(next());
+        break;
+      case '--tool-items':
+        options.toolItems = Number(next());
+        break;
+      case '--cleanup':
+        options.cleanup = true;
+        break;
+      case '--help':
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.workspace) {
+    throw new Error('Missing --workspace');
+  }
+  for (const key of ['sessionCount', 'longTurns', 'shortTurns', 'assistantChars', 'toolResultChars', 'toolItems']) {
+    if (!Number.isFinite(options[key]) || options[key] < 0) {
+      throw new Error(`Invalid numeric value for ${key}`);
+    }
+  }
+  if (options.sessionCount < 1) {
+    throw new Error('--session-count must be at least 1');
+  }
+  if (!options.sessionPrefix.trim()) {
+    throw new Error('--session-prefix cannot be empty');
+  }
+  return options;
+}
+
+function printHelp() {
+  console.log(`Generate BitFun long-session performance fixtures.
+
+Usage:
+  node tests/e2e/scripts/generate-long-session-fixture.mjs --workspace <path> [options]
+
+Options:
+  --session-count <n>       Number of metadata rows to create. Default: 80
+  --long-turns <n>          Turn count for the latest session. Default: 80
+  --short-turns <n>         Turn count for other sessions. Default: 1
+  --assistant-chars <n>     Assistant text chars per turn. Default: 2000
+  --tool-result-chars <n>   Raw tool result chars per tool item. Default: 12000
+  --tool-items <n>          Tool item count per turn. Default: 2
+  --session-prefix <text>   Session id prefix. Default: perf-long-session
+  --bitfun-home <path>      BitFun home root. Default: BITFUN_HOME or ~/.bitfun
+  --cleanup                 Remove generated sessions for the prefix.
+`);
+}
+
+function projectRuntimeSlug(workspacePath) {
+  const canonical = fsSync.realpathSync(workspacePath);
+  const slug = canonical
+    .split('')
+    .map(ch => /[a-zA-Z0-9]/.test(ch) ? ch.toLowerCase() : '-')
+    .join('')
+    .replace(/^-+|-+$/g, '') || 'workspace';
+
+  if (slug.length <= MAX_PROJECT_SLUG_LEN) {
+    return slug;
+  }
+
+  const suffix = crypto.createHash('sha256').update(canonical).digest('hex').slice(0, 12);
+  const maxPrefixLen = MAX_PROJECT_SLUG_LEN - suffix.length - 1;
+  return `${slug.slice(0, maxPrefixLen).replace(/-+$/g, '')}-${suffix}`;
+}
+
+function repeatedText(chars, label) {
+  if (chars <= label.length + 1) {
+    return label.slice(0, chars);
+  }
+  return `${label} ${'x'.repeat(chars - label.length - 1)}`;
+}
+
+function makeMetadata({ sessionId, sessionName, workspacePath, createdAt, lastActiveAt, turnCount, toolItems }) {
+  return {
+    sessionId,
+    sessionName,
+    agentType: 'agentic',
+    lastUserDialogAgentType: 'agentic',
+    lastSubmittedAgentType: 'agentic',
+    createdBy: null,
+    sessionKind: 'standard',
+    modelName: 'perf-fixture-model',
+    createdAt,
+    lastActiveAt,
+    turnCount,
+    messageCount: turnCount * 2,
+    toolCallCount: turnCount * toolItems,
+    status: 'active',
+    terminalSessionId: null,
+    snapshotSessionId: null,
+    tags: ['performance-fixture'],
+    customMetadata: {
+      generatedBy: 'tests/e2e/scripts/generate-long-session-fixture.mjs',
+      fixtureVersion: 1,
+    },
+    relationship: null,
+    todos: null,
+    deepReviewRunManifest: null,
+    deepReviewCache: null,
+    workspacePath,
+    workspaceHostname: 'localhost',
+    unreadCompletion: null,
+    needsUserAttention: null,
+  };
+}
+
+function makeState(workspacePath) {
+  return {
+    schema_version: SESSION_STORAGE_SCHEMA_VERSION,
+    config: {
+      max_context_tokens: 128128,
+      auto_compact: true,
+      enable_tools: true,
+      safe_mode: true,
+      max_turns: 200,
+      enable_context_compression: true,
+      compression_threshold: 0.8,
+      workspace_path: workspacePath,
+      workspace_id: null,
+      remote_connection_id: null,
+      remote_ssh_host: null,
+      model_id: 'perf-fixture-model',
+    },
+    snapshot_session_id: null,
+    last_user_dialog_agent_type: 'agentic',
+    last_submitted_agent_type: 'agentic',
+    compression_state: {
+      last_compression_at: null,
+      compression_count: 0,
+    },
+    runtime_state: 'Idle',
+  };
+}
+
+function makeTurn({ sessionId, turnIndex, timestamp, assistantChars, toolResultChars, toolItems }) {
+  const turnId = `${sessionId}-turn-${String(turnIndex).padStart(4, '0')}`;
+  const textItemId = `${turnId}-text-0`;
+  const toolItemsData = Array.from({ length: toolItems }, (_, toolIndex) => {
+    const toolId = `${turnId}-tool-${toolIndex}`;
+    return {
+      id: toolId,
+      toolName: 'Read',
+      toolCall: {
+        id: toolId,
+        input: {
+          filePath: `/workspace/perf-fixture-${turnIndex}-${toolIndex}.txt`,
+        },
+      },
+      toolResult: {
+        result: {
+          output: repeatedText(toolResultChars, `raw result ${turnIndex}.${toolIndex}`),
+          fixture: true,
+        },
+        success: true,
+        resultForAssistant: repeatedText(
+          Math.min(512, toolResultChars),
+          `assistant result ${turnIndex}.${toolIndex}`,
+        ),
+        durationMs: 5,
+      },
+      aiIntent: 'Synthetic performance fixture tool result',
+      startTime: timestamp + 10,
+      endTime: timestamp + 15,
+      durationMs: 5,
+      queueWaitMs: 0,
+      preflightMs: 0,
+      confirmationWaitMs: 0,
+      executionMs: 5,
+      orderIndex: toolIndex,
+      status: 'completed',
+    };
+  });
+
+  return {
+    schema_version: SESSION_STORAGE_SCHEMA_VERSION,
+    turnId,
+    turnIndex,
+    sessionId,
+    timestamp,
+    kind: 'user_dialog',
+    agentType: 'agentic',
+    userMessage: {
+      id: `${turnId}-user`,
+      content: `Synthetic user turn ${turnIndex}`,
+      timestamp,
+      metadata: {
+        generatedBy: 'performance-fixture',
+      },
+    },
+    modelRounds: [
+      {
+        id: `${turnId}-round-0`,
+        turnId,
+        roundIndex: 0,
+        timestamp: timestamp + 1,
+        textItems: [
+          {
+            id: textItemId,
+            content: repeatedText(assistantChars, `Synthetic assistant response ${turnIndex}`),
+            isStreaming: false,
+            timestamp: timestamp + 20,
+            isMarkdown: true,
+            orderIndex: toolItems,
+            status: 'completed',
+          },
+        ],
+        toolItems: toolItemsData,
+        thinkingItems: [],
+        startTime: timestamp + 1,
+        endTime: timestamp + 30,
+        durationMs: 29,
+        providerId: 'perf-fixture',
+        modelId: 'perf-fixture-model',
+        modelAlias: 'Perf Fixture',
+        status: 'completed',
+      },
+    ],
+    startTime: timestamp,
+    endTime: timestamp + 30,
+    durationMs: 30,
+    status: 'completed',
+  };
+}
+
+async function readIndex(indexPath) {
+  try {
+    return JSON.parse(await fs.readFile(indexPath, 'utf8'));
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeJson(filePath, value) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+async function removeGeneratedSessions(sessionsRoot, sessionPrefix) {
+  try {
+    const entries = await fs.readdir(sessionsRoot, { withFileTypes: true });
+    await Promise.all(entries
+      .filter(entry => entry.isDirectory() && entry.name.startsWith(sessionPrefix))
+      .map(entry => fs.rm(path.join(sessionsRoot, entry.name), { recursive: true, force: true })));
+  } catch (error) {
+    if (error && error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+async function writeIndex(sessionsRoot, generatedMetadata, sessionPrefix) {
+  const indexPath = path.join(sessionsRoot, 'index.json');
+  const existing = await readIndex(indexPath);
+  const existingSessions = Array.isArray(existing?.sessions) ? existing.sessions : [];
+  const retained = existingSessions.filter(session =>
+    typeof session?.sessionId === 'string' && !session.sessionId.startsWith(sessionPrefix)
+  );
+  const sessions = [...generatedMetadata, ...retained]
+    .sort((left, right) => (right.lastActiveAt ?? 0) - (left.lastActiveAt ?? 0));
+
+  await writeJson(indexPath, {
+    schema_version: SESSION_STORAGE_SCHEMA_VERSION,
+    updated_at: Date.now(),
+    metadata_file_count: sessions.length,
+    sessions,
+  });
+}
+
+async function generate(options) {
+  const workspacePath = fsSync.realpathSync(options.workspace);
+  const slug = projectRuntimeSlug(workspacePath);
+  const sessionsRoot = path.join(options.bitfunHome, 'projects', slug, 'sessions');
+
+  await fs.mkdir(sessionsRoot, { recursive: true });
+  await removeGeneratedSessions(sessionsRoot, options.sessionPrefix);
+
+  if (options.cleanup) {
+    await writeIndex(sessionsRoot, [], options.sessionPrefix);
+    return {
+      action: 'cleanup',
+      workspacePath,
+      sessionsRoot,
+      sessionPrefix: options.sessionPrefix,
+    };
+  }
+
+  const now = Date.now();
+  const generatedMetadata = [];
+  for (let sessionIndex = 0; sessionIndex < options.sessionCount; sessionIndex += 1) {
+    const sessionId = `${options.sessionPrefix}-${String(sessionIndex).padStart(3, '0')}`;
+    const turnCount = sessionIndex === 0 ? options.longTurns : options.shortTurns;
+    const createdAt = now - (options.sessionCount - sessionIndex) * 60_000;
+    const lastActiveAt = now - sessionIndex * 1_000;
+    const sessionDir = path.join(sessionsRoot, sessionId);
+    const turnsDir = path.join(sessionDir, 'turns');
+    const metadata = makeMetadata({
+      sessionId,
+      sessionName: sessionIndex === 0
+        ? `Perf Fixture Long Session (${turnCount} turns)`
+        : `Perf Fixture Session ${sessionIndex}`,
+      workspacePath,
+      createdAt,
+      lastActiveAt,
+      turnCount,
+      toolItems: options.toolItems,
+    });
+
+    await fs.mkdir(turnsDir, { recursive: true });
+    await writeJson(path.join(sessionDir, 'metadata.json'), {
+      schema_version: SESSION_STORAGE_SCHEMA_VERSION,
+      ...metadata,
+    });
+    await writeJson(path.join(sessionDir, 'state.json'), makeState(workspacePath));
+
+    for (let turnIndex = 0; turnIndex < turnCount; turnIndex += 1) {
+      await writeJson(
+        path.join(turnsDir, `turn-${String(turnIndex).padStart(4, '0')}.json`),
+        makeTurn({
+          sessionId,
+          turnIndex,
+          timestamp: createdAt + turnIndex * 1_000,
+          assistantChars: options.assistantChars,
+          toolResultChars: options.toolResultChars,
+          toolItems: options.toolItems,
+        }),
+      );
+    }
+
+    generatedMetadata.push(metadata);
+  }
+
+  await writeIndex(sessionsRoot, generatedMetadata, options.sessionPrefix);
+  return {
+    action: 'generate',
+    workspacePath,
+    bitfunHome: options.bitfunHome,
+    sessionsRoot,
+    sessionPrefix: options.sessionPrefix,
+    sessionCount: options.sessionCount,
+    longSessionId: `${options.sessionPrefix}-000`,
+    longTurns: options.longTurns,
+    assistantChars: options.assistantChars,
+    toolResultChars: options.toolResultChars,
+    toolItems: options.toolItems,
+  };
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const result = await generate(options);
+  console.log(JSON.stringify(result, null, 2));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error('Run with --help for usage.');
+  process.exit(1);
+}

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -1,0 +1,230 @@
+import { $, browser, expect } from '@wdio/globals';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import {
+  readPerformanceNow,
+  readStartupTraceSnapshot,
+  summarizeSessionOpen,
+  summarizeStartup,
+  waitForTracePhaseCount,
+  type StartupTraceSnapshot,
+} from '../../helpers/performance-trace';
+import { StartupPage } from '../../page-objects/StartupPage';
+import { ensureWorkspaceOpen } from '../../helpers/workspace-utils';
+import { ensureCodeSessionOpen, openWorkspace } from '../../helpers/workspace-helper';
+
+const DEFAULT_PERF_SESSION_ID = 'perf-long-session-000';
+
+function reportDir(): string {
+  return path.resolve(process.cwd(), 'reports', 'performance');
+}
+
+async function writeReport(name: string, data: unknown): Promise<void> {
+  await fs.mkdir(reportDir(), { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  await fs.writeFile(
+    path.join(reportDir(), `${name}-${timestamp}.json`),
+    `${JSON.stringify(data, null, 2)}\n`,
+    'utf8',
+  );
+}
+
+function countPhase(snapshot: StartupTraceSnapshot, phase: string): number {
+  return snapshot.phases.events.filter(event => event.phase === phase).length;
+}
+
+function numericEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (!raw) {
+    return undefined;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+async function waitForOptionalPhaseCount(
+  phase: string,
+  minCount: number,
+  timeoutMs: number,
+): Promise<StartupTraceSnapshot> {
+  try {
+    return await waitForTracePhaseCount(phase, minCount, timeoutMs);
+  } catch {
+    return readStartupTraceSnapshot();
+  }
+}
+
+async function findSessionItem(sessionId: string) {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const item = await $(`[data-testid="session-nav-item"][data-session-id="${sessionId}"]`);
+    if (await item.isExisting()) {
+      return item;
+    }
+
+    const showMore = await $('[data-testid="session-nav-show-more"]');
+    if (!(await showMore.isExisting()) || !(await showMore.isEnabled())) {
+      break;
+    }
+    await showMore.click();
+    await browser.pause(500);
+  }
+  return null;
+}
+
+async function ensurePerformanceWorkspace(startupPage: StartupPage): Promise<boolean> {
+  const targetWorkspace = process.env.E2E_TEST_WORKSPACE;
+  if (!targetWorkspace) {
+    return ensureWorkspaceOpen(startupPage);
+  }
+
+  const isBundledApp = await browser.execute(() => window.location.hostname === 'tauri.localhost');
+  if (isBundledApp) {
+    return true;
+  }
+
+  const opened = await openWorkspace(targetWorkspace);
+  if (!opened) {
+    return ensureWorkspaceOpen(startupPage);
+  }
+  await ensureCodeSessionOpen();
+  return true;
+}
+
+async function isSessionItemActive(item: WebdriverIO.Element): Promise<boolean> {
+  const className = await item.getAttribute('class');
+  return className.split(/\s+/).includes('is-active');
+}
+
+function siblingSessionId(sessionId: string): string | null {
+  const match = /^(.*-)(\d{3,})$/.exec(sessionId);
+  if (!match) {
+    return null;
+  }
+  return `${match[1]}${match[2] === '001' ? '000' : '001'}`;
+}
+
+async function switchAwayIfSessionIsActive(sessionId: string): Promise<void> {
+  const item = await findSessionItem(sessionId);
+  if (!item || !(await isSessionItemActive(item))) {
+    return;
+  }
+
+  const alternateId = siblingSessionId(sessionId);
+  const alternate = alternateId ? await findSessionItem(alternateId) : null;
+  if (!alternate) {
+    return;
+  }
+
+  const beforeSnapshot = await readStartupTraceSnapshot();
+  const frameCountBefore = countPhase(
+    beforeSnapshot,
+    'historical_session_after_state_commit_frame',
+  );
+  await alternate.click();
+  await waitForOptionalPhaseCount(
+    'historical_session_after_state_commit_frame',
+    frameCountBefore + 1,
+    10000,
+  );
+}
+
+describe('Performance telemetry', () => {
+  const startupPage = new StartupPage();
+
+  before(async () => {
+    await waitForTracePhaseCount('interactive_shell_ready', 1, 30000);
+    await ensurePerformanceWorkspace(startupPage);
+  });
+
+  it('collects startup timing from the current build', async () => {
+    const snapshot = await readStartupTraceSnapshot();
+    const startup = summarizeStartup(snapshot);
+    const maxInteractiveMs = numericEnv('BITFUN_E2E_PERF_MAX_INTERACTIVE_MS');
+
+    console.log('[Perf] startup', JSON.stringify({
+      appMode: process.env.BITFUN_E2E_APP_MODE ?? 'auto',
+      traceId: snapshot.traceId,
+      startup,
+      api: snapshot.api,
+    }));
+    await writeReport('startup', {
+      appMode: process.env.BITFUN_E2E_APP_MODE ?? 'auto',
+      traceId: snapshot.traceId,
+      startup,
+      api: snapshot.api,
+      phases: snapshot.phases.events,
+    });
+
+    expect(startup.firstScriptEvalMs).toBeGreaterThan(0);
+    expect(startup.interactiveShellReadyMs).toBeGreaterThan(0);
+    if (maxInteractiveMs !== undefined) {
+      expect(startup.interactiveShellReadyMs).toBeLessThanOrEqual(maxInteractiveMs);
+    }
+  });
+
+  it('collects first-open timing for a generated long session', async function () {
+    const sessionId = process.env.BITFUN_E2E_PERF_SESSION_ID || DEFAULT_PERF_SESSION_ID;
+    await switchAwayIfSessionIsActive(sessionId);
+
+    const item = await findSessionItem(sessionId);
+    if (!item) {
+      console.log(`[Perf] Session ${sessionId} not found; generate it before running this spec.`);
+      this.skip();
+      return;
+    }
+
+    const beforeClickSnapshot = await readStartupTraceSnapshot();
+    const frameCountBefore = countPhase(
+      beforeClickSnapshot,
+      'historical_session_after_state_commit_frame',
+    );
+    const fullHydrateCountBefore = countPhase(
+      beforeClickSnapshot,
+      'historical_session_full_hydrate_end',
+    );
+    const clickedAtMs = await readPerformanceNow();
+
+    await item.click();
+
+    const afterFrameSnapshot = await waitForTracePhaseCount(
+      'historical_session_after_state_commit_frame',
+      frameCountBefore + 1,
+      20000,
+    );
+    const afterFullSnapshot = await waitForOptionalPhaseCount(
+      'historical_session_full_hydrate_end',
+      fullHydrateCountBefore + 1,
+      10000,
+    );
+    const finalSnapshot =
+      afterFullSnapshot.phases.events.length >= afterFrameSnapshot.phases.events.length
+        ? afterFullSnapshot
+        : afterFrameSnapshot;
+    const sessionEvents = finalSnapshot.phases.events.filter(event =>
+      event.atMs >= clickedAtMs - 50 &&
+      event.phase.startsWith('historical_session')
+    );
+    const sessionOpen = summarizeSessionOpen(sessionEvents);
+    const maxLatestFrameMs = numericEnv('BITFUN_E2E_PERF_MAX_SESSION_FRAME_MS');
+
+    console.log('[Perf] long-session-first-open', JSON.stringify({
+      appMode: process.env.BITFUN_E2E_APP_MODE ?? 'auto',
+      sessionId,
+      sessionOpen,
+    }));
+    await writeReport('long-session-first-open', {
+      appMode: process.env.BITFUN_E2E_APP_MODE ?? 'auto',
+      sessionId,
+      clickedAtMs,
+      sessionOpen,
+      events: sessionEvents,
+      api: finalSnapshot.api,
+    });
+
+    expect(sessionOpen.hydrateDurationMs).toBeGreaterThan(0);
+    expect(sessionOpen.latestFrameSinceHydrateMs).toBeGreaterThan(0);
+    if (maxLatestFrameMs !== undefined) {
+      expect(sessionOpen.latestFrameSinceHydrateMs).toBeLessThanOrEqual(maxLatestFrameMs);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add a sanitized startup/session performance trace snapshot for debug and explicit perf E2E runs.
- Add a release-fast performance E2E path, a long-session fixture generator, and a startup/session timing spec.
- Enable embedded WebDriver for release-fast E2E through the existing `devtools` feature and update WebDriver routes to Axum 0.8 path syntax.
- Stabilize the startup splash background with a shared `--bitfun-startup-bg` variable so light-theme startup no longer flashes from a dark splash fallback to a white splash.

Refs #949

## Performance Data

Scenario: Windows local release-fast build with production web bundle, release-fast Rust profile, embedded WebDriver, 80 generated session metadata rows, and one 80-turn long session with 160 synthetic tool results.

Latest post-rebase sample from this PR:

| Scenario | Metric | Result |
| --- | --- | ---: |
| Startup | `first_script_eval` | 1358.4 ms |
| Startup | `before_render` duration | 32.7 ms |
| Startup | `app_effect_mounted` | 1484.0 ms |
| Startup | `main_window_shown` | 1484.6 ms |
| Startup | `non_critical_init_done` | 1886.8 ms |
| Startup | `interactive_shell_ready` | 1943.5 ms |
| Long session first open | initially loaded turns | 3 / 80 |
| Long session first open | restore latest turns | 39.4 ms |
| Long session first open | state commit | 2.5 ms |
| Long session first open | latest-turn first frame | 48.9 ms |
| Long session background hydrate | full hydrate | 56.5 ms |

Startup API aggregate in the same sample:

| Command | Count | Total | Max |
| --- | ---: | ---: | ---: |
| `get_config` | 10 | 1438.7 ms | 357.5 ms |
| `initialize_ai` | 1 | 335.9 ms | 335.9 ms |
| `git_is_repository` | 4 | 73.3 ms | 28.7 ms |
| `remote_get_workspace_info` | 1 | 69.5 ms | 69.5 ms |
| `git_get_repository_basic` | 3 | 51.8 ms | 17.8 ms |

Earlier repeat samples on the same release-fast branch before the final upstream rebase showed startup variance rather than a stable startup reduction:

| Scenario | Metric | Min | P50 | Max |
| --- | --- | ---: | ---: | ---: |
| Startup, 3 runs | `interactive_shell_ready` | 1438.1 ms | 1554.0 ms | 1597.2 ms |
| Startup, 3 runs | `main_window_shown` | 1066.2 ms | 1098.9 ms | 1188.7 ms |
| Long session, 3 runs | latest-turn first frame | 36.0 ms | 49.5 ms | 64.5 ms |

One earlier cold-ish long-session background hydrate outlier hit about 1535.9 ms; backend logs attributed it to reading 80 turn files with about 1.9 MB raw tool-result text. The perceived first frame still stayed near the 50 ms range because only the latest 3 turns are restored initially.

This PR should be evaluated as measurement infrastructure plus startup visual consistency. It does not claim an end-to-end startup reduction; the data points to follow-up optimization work around startup API duplication and early initialization.

## Risks / Notes

- The diagnostic `window.__BITFUN_STARTUP_TRACE__` surface exposes only sanitized phase/API aggregates, not raw request payloads or workspace paths, and is limited to dev or explicit perf WebDriver runs.
- `devtools` now enables embedded WebDriver for release-fast E2E. End-user release builds are unaffected unless that feature is explicitly enabled.
- Session nav `data-testid` attributes are test-only selectors; `data-session-title` mirrors already visible UI text.
- The long-session fixture writes synthetic local test data and requires an explicit workspace path when run.
- Startup splash background is now tied to the earliest known theme background; if a platform shows a native pre-document blank window before web content, that remains a separate native show-timing problem.

## Verification

- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/shared/utils/startupTrace.test.ts src/infrastructure/theme/core/ThemeService.test.ts`
- `pnpm run check:repo-hygiene`
- `cargo check -p bitfun-desktop --features devtools` *(passes with existing `parse_clipboard_path_segments` unused warning)*
- `pnpm run desktop:build:release-fast` *(passes with existing Vite chunk warnings and the same Rust warning)*
- `E2E_TEST_WORKSPACE=<workspace> BITFUN_E2E_PERF_SESSION_ID=perf-long-session-000 pnpm run e2e:test:perf:release-fast`
- `git diff --check gcwing/main...HEAD`