### PR TITLE
refactor: reuse shared i18n terms across surfaces

### DIFF
--- a/scripts/i18n-contract.test.mjs
+++ b/scripts/i18n-contract.test.mjs
@@ -384,6 +384,138 @@ test('i18n audit can emit a machine-readable governance report', { concurrency: 
   }
 });
 
+test('mobile-web uses shared terms for stable shared concept labels', { concurrency: false }, () => {
+  const reportPath = 'scripts/.tmp-i18n-mobile-shared-terms-report.json';
+  const absoluteReportPath = path.join(root, reportPath);
+  fs.rmSync(absoluteReportPath, { force: true });
+
+  try {
+    const result = runI18nAudit(['--report-json', reportPath]);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+    const report = readJson(reportPath);
+    const migratedSharedKeys = new Set([
+      'product.remote',
+      'features.workspace',
+      'agents.claw',
+      'agents.cowork',
+      'tools.edit',
+      'tools.explore',
+      'tools.read',
+      'tools.todo',
+      'tools.write',
+    ]);
+    const mobileDuplicates = report.sharedTermDuplicates
+      .filter((entry) => entry.surface === 'mobile-web' && migratedSharedKeys.has(entry.sharedKey))
+      .map((entry) => `${entry.sharedKey}:${entry.key}:${entry.locale}`)
+      .sort();
+    const legacyMobileKeys = [
+      'common.appName',
+      'sessions.workspace',
+      'sessions.coworkSession',
+      'sessions.agentClaw',
+      'workspace.title',
+      'tools.edit',
+      'tools.explore',
+      'tools.read',
+      'tools.todo',
+      'tools.write',
+    ];
+    const mobileSourceFiles = listFiles(path.join(root, 'src', 'mobile-web', 'src'), (file) => (
+      /\.(?:ts|tsx)$/.test(file) && !file.endsWith(`${path.sep}i18n${path.sep}messages.ts`)
+    ));
+    const legacyReferences = mobileSourceFiles.flatMap((file) => {
+      const source = fs.readFileSync(file, 'utf8');
+      return legacyMobileKeys
+        .filter((key) => source.includes(`'${key}'`) || source.includes(`"${key}"`))
+        .map((key) => `${path.relative(root, file)}:${key}`);
+    }).sort();
+
+    assert.deepEqual(
+      mobileDuplicates,
+      [],
+      'mobile-web should read migrated stable labels from shared terms instead of copying values',
+    );
+    assert.deepEqual(
+      legacyReferences,
+      [],
+      'mobile-web source should not call removed local keys for migrated shared terms',
+    );
+  } finally {
+    fs.rmSync(absoluteReportPath, { force: true });
+  }
+});
+
+test('web-ui uses shared terms for stable navigation and feature labels', { concurrency: false }, () => {
+  const reportPath = 'scripts/.tmp-i18n-web-ui-shared-terms-report.json';
+  const absoluteReportPath = path.join(root, reportPath);
+  fs.rmSync(absoluteReportPath, { force: true });
+
+  try {
+    const result = runI18nAudit(['--report-json', reportPath]);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+    const report = readJson(reportPath);
+    const migratedResourceKeys = new Set([
+      'common:app.name',
+      'common:header.remoteConnect',
+      'common:nav.sections.workspace',
+      'common:scenes.settings',
+      'common:tabs.settings',
+      'common:remoteConnect.title',
+      'flow-chat:layout.noPanels',
+      'flow-chat:toolbar.settings',
+      'flow-chat:toolCards.sessionControl.workspace',
+      'flow-chat:toolCards.sessionMessage.workspace',
+      'flow-chat:welcome.workspace',
+      'settings:title',
+      'settings:configCenter.title',
+      'settings:workspace.title',
+      'settings/lsp:tabs.settings',
+    ]);
+    const webUiDuplicates = report.sharedTermDuplicates
+      .filter((entry) => entry.surface === 'web-ui' && migratedResourceKeys.has(entry.resourceKey))
+      .map((entry) => `${entry.sharedKey}:${entry.resourceKey}:${entry.locale}`)
+      .sort();
+    const legacyWebUiKeys = [
+      'header.remoteConnect',
+      'remoteConnect.title',
+      'nav.sections.workspace',
+      'scenes.settings',
+      'tabs.settings',
+      'layout.noPanels',
+      'toolbar.settings',
+      'toolCards.sessionControl.workspace',
+      'toolCards.sessionMessage.workspace',
+      'welcome.workspace',
+      'configCenter.title',
+      'workspace.title',
+    ];
+    const webUiSourceFiles = listFiles(path.join(root, 'src', 'web-ui', 'src'), (file) => (
+      /\.(?:ts|tsx)$/.test(file)
+    ));
+    const legacyReferences = webUiSourceFiles.flatMap((file) => {
+      const source = fs.readFileSync(file, 'utf8');
+      return legacyWebUiKeys
+        .filter((key) => source.includes(`'${key}'`) || source.includes(`"${key}"`))
+        .map((key) => `${path.relative(root, file)}:${key}`);
+    }).sort();
+
+    assert.deepEqual(
+      webUiDuplicates,
+      [],
+      'web-ui should resolve migrated stable labels from shared terms instead of copied values',
+    );
+    assert.deepEqual(
+      legacyReferences,
+      [],
+      'web-ui source should not call removed local keys for migrated shared terms',
+    );
+  } finally {
+    fs.rmSync(absoluteReportPath, { force: true });
+  }
+});
+
 test('i18n audit enforces governance candidate baselines', { concurrency: false }, () => {
   const baselinePath = 'scripts/i18n-governance-baseline.json';
   const baseline = readJson(baselinePath);

--- a/scripts/i18n-governance-baseline.json
+++ b/scripts/i18n-governance-baseline.json
@@ -6,56 +6,52 @@
       "maxTotal": 0
     },
     "sharedTermDuplicates": {
-      "maxTotal": 281,
+      "maxTotal": 214,
       "bySurface": {
         "core": 18,
         "installer": 3,
-        "mobile-web": 38,
+        "mobile-web": 8,
         "relay-static-homepage": 2,
-        "web-ui": 220
+        "web-ui": 183
       },
       "bySharedKey": {
-        "agents.claw": 9,
+        "agents.claw": 6,
         "agents.code": 4,
-        "agents.cowork": 5,
+        "agents.cowork": 2,
         "agents.default": 3,
         "connectionMethods.bitfunServer": 1,
         "connectionMethods.lan": 2,
         "features.codeAgent": 1,
         "features.deepReview": 4,
-        "features.remoteControl": 6,
-        "features.settings": 13,
-        "features.workspace": 23,
+        "features.remoteControl": 2,
+        "features.settings": 1,
+        "features.workspace": 2,
         "modes.assistant": 2,
         "modes.expert": 3,
         "modes.review": 1,
-        "product.name": 12,
-        "product.remote": 3,
+        "product.name": 6,
         "statuses.cancelled": 29,
         "statuses.done": 26,
         "statuses.failed": 44,
         "statuses.loading": 5,
         "statuses.running": 13,
-        "tools.edit": 36,
-        "tools.explore": 5,
-        "tools.read": 3,
+        "tools.edit": 33,
+        "tools.explore": 2,
         "tools.search": 14,
-        "tools.shell": 8,
-        "tools.todo": 3,
-        "tools.write": 3
+        "tools.shell": 8
       }
     },
     "l10nQualityCandidates": {
-      "maxTotal": 1094,
+      "maxTotal": 1093,
       "bySurface": {
         "core": 36,
         "installer": 28,
-        "mobile-web": 22,
+        "mobile-web": 21,
         "relay-static-homepage": 1,
         "web-ui": 1007
       },
       "byNamespace": {
-        "<none>": 87,
+        "<none>": 86,
         "common": 158,
         "components": 87,
         "errors": 7,

--- a/scripts/i18n-literal-fallback-baseline.json
+++ b/scripts/i18n-literal-fallback-baseline.json
@@ -73,12 +73,6 @@
       }
     },
     {
-      "path": "src/web-ui/src/app/scenes/settings/SettingsNav.tsx",
-      "literalDefaultValues": {
-        "settings:title": 1
-      }
-    },
-    {
       "path": "src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx",
       "literalDefaultValues": {
         "flow-chat:childSession.stoppingReview": 2,

--- a/src/mobile-web/src/i18n/messages.ts
+++ b/src/mobile-web/src/i18n/messages.ts
@@ -10,7 +10,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
   'en-US': {
     shared: SHARED_TERMS_BY_LOCALE['en-US'],
     common: {
-      appName: 'BitFun Remote',
       back: 'Back',
       continue: 'Continue',
       cancel: 'Cancel',
@@ -49,7 +48,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       continue: 'Continue',
     },
     sessions: {
-      workspace: 'Workspace',
       switchWorkspace: 'Switch workspace',
       selectWorkspace: 'Select Workspace',
       noWorkspaces: 'No workspaces found',
@@ -64,7 +62,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       startRemoteFlow: 'Start a new remote flow',
       codeSession: 'Code Session',
       codeSessionDesc: 'For coding anywhere, anytime.',
-      coworkSession: 'Cowork Session',
       coworkSessionDesc: 'For assisting with everyday work.',
       clawSession: 'Claw Session',
       clawSessionDesc: 'Personal assistant for daily tasks.',
@@ -79,7 +76,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       remoteClawSession: 'Remote Claw Session',
       agentCode: 'Code',
       agentCowork: 'Cowork',
-      agentClaw: 'Claw',
       agentDefault: 'Default',
       searchSessions: 'Search sessions...',
       renameSession: 'Rename',
@@ -103,7 +99,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       connectionUnreachable: 'Connection lost',
     },
     workspace: {
-      title: 'Workspace',
       loadingInfo: 'Loading workspace info...',
       currentWorkspace: 'Current Workspace',
       unknownProject: 'Unknown Project',
@@ -161,9 +156,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       copyFailed: 'Copy failed',
     },
     tools: {
-      explore: 'Explore',
-      read: 'Read',
-      write: 'Write',
       ls: 'LS',
       shell: 'Shell',
       glob: 'Glob',
@@ -171,15 +163,12 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       delete: 'Delete',
       task: 'Task',
       search: 'Search',
-      edit: 'Edit',
       web: 'Web',
-      todo: 'Todo',
     },
   },
   'zh-CN': {
     shared: SHARED_TERMS_BY_LOCALE['zh-CN'],
     common: {
-      appName: 'BitFun Remote',
       back: '返回',
       continue: '继续',
       cancel: '取消',
@@ -218,7 +207,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       continue: '继续',
     },
     sessions: {
-      workspace: '工作区',
       switchWorkspace: '切换工作区',
       selectWorkspace: '选择工作区',
       noWorkspaces: '暂无工作区',
@@ -233,7 +221,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       startRemoteFlow: '开始一个新的远程流程',
       codeSession: '代码会话',
       codeSessionDesc: '随时随地进行编码。',
-      coworkSession: '协作会话',
       coworkSessionDesc: '处理日常协作与办公任务。',
       clawSession: '助理会话',
       clawSessionDesc: '处理日常任务的个人助手。',
@@ -248,7 +235,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       remoteClawSession: '远程助理会话',
       agentCode: 'Code',
       agentCowork: 'Cowork',
-      agentClaw: 'Claw',
       agentDefault: '默认',
       searchSessions: '搜索会话...',
       renameSession: '重命名',
@@ -272,7 +258,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       connectionUnreachable: '连接断开',
     },
     workspace: {
-      title: '工作区',
       loadingInfo: '正在加载工作区信息...',
       currentWorkspace: '当前工作区',
       unknownProject: '未知项目',
@@ -330,9 +315,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       copyFailed: '复制失败',
     },
     tools: {
-      explore: '探索',
-      read: '读取',
-      write: '写入',
       ls: '列表',
       shell: 'Shell',
       glob: 'Glob',
@@ -340,15 +322,12 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       delete: '删除',
       task: '任务',
       search: '搜索',
-      edit: '编辑',
       web: '网络',
-      todo: '待办',
     },
   },
   'zh-TW': {
     shared: SHARED_TERMS_BY_LOCALE['zh-TW'],
     common: {
-      appName: 'BitFun Remote',
       back: '返回',
       continue: '繼續',
       cancel: '取消',
@@ -387,7 +366,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       continue: '繼續',
     },
     sessions: {
-      workspace: '工作區',
       switchWorkspace: '切換工作區',
       selectWorkspace: '選擇工作區',
       noWorkspaces: '暫無工作區',
@@ -402,7 +380,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       startRemoteFlow: '開始一個新的遠程流程',
       codeSession: '代碼會話',
       codeSessionDesc: '隨時隨地進行編碼。',
-      coworkSession: '協作會話',
       coworkSessionDesc: '處理日常協作與辦公任務。',
       clawSession: '助理會話',
       clawSessionDesc: '處理日常任務的個人助手。',
@@ -417,7 +394,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       remoteClawSession: '遠程助理會話',
       agentCode: 'Code',
       agentCowork: 'Cowork',
-      agentClaw: 'Claw',
       agentDefault: '默認',
       searchSessions: '搜尋會話...',
       renameSession: '重新命名',
@@ -441,7 +417,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       connectionUnreachable: '連接斷開',
     },
     workspace: {
-      title: '工作區',
       loadingInfo: '正在加載工作區信息...',
       currentWorkspace: '當前工作區',
       unknownProject: '未知項目',
@@ -499,9 +474,6 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       copyFailed: '複製失敗',
     },
     tools: {
-      explore: '探索',
-      read: '讀取',
-      write: '寫入',
       ls: '列表',
       shell: 'Shell',
       glob: 'Glob',
@@ -509,9 +481,7 @@ export const messages: Record<MobileLanguage, MessageTree> = {
       delete: '刪除',
       task: '任務',
       search: '搜索',
-      edit: '編輯',
       web: '網絡',
-      todo: '待辦',
     },
   }
 };

--- a/src/mobile-web/src/pages/ChatPage.tsx
+++ b/src/mobile-web/src/pages/ChatPage.tsx
@@ -619,20 +619,20 @@ const ThinkingBlock: React.FC<{
 // ─── Tool Card ──────────────────────────────────────────────────────────────
 
 const TOOL_TYPE_MAP: Record<string, string> = {
-  explore: 'tools.explore',
-  read_file: 'tools.read',
-  write_file: 'tools.write',
+  explore: 'shared.tools.explore',
+  read_file: 'shared.tools.read',
+  write_file: 'shared.tools.write',
   list_directory: 'tools.ls',
   bash: 'tools.shell',
   glob: 'tools.glob',
   grep: 'tools.grep',
-  create_file: 'tools.write',
+  create_file: 'shared.tools.write',
   delete_file: 'tools.delete',
   Task: 'tools.task',
   search: 'tools.search',
-  edit_file: 'tools.edit',
+  edit_file: 'shared.tools.edit',
   web_search: 'tools.web',
-  TodoWrite: 'tools.todo',
+  TodoWrite: 'shared.tools.todo',
 };
 
 // ─── TodoWrite card ─────────────────────────────────────────────────────────

--- a/src/mobile-web/src/pages/PairingPage.tsx
+++ b/src/mobile-web/src/pages/PairingPage.tsx
@@ -277,7 +277,7 @@ const PairingPage: React.FC<PairingPageProps> = ({ onPaired }) => {
         <LanguageToggleButton />
       </div>
       <CubeLogo />
-      <div className="pairing-page__brand">{t('common.appName')}</div>
+      <div className="pairing-page__brand">{t('shared.product.remote')}</div>
 
       <div className="pairing-page__spinner-wrap">
         {showSpinner && <div className="spinner" />}

--- a/src/mobile-web/src/pages/SessionListPage.tsx
+++ b/src/mobile-web/src/pages/SessionListPage.tsx
@@ -43,7 +43,7 @@ function agentLabel(agentType: string, t: (key: string) => string): string {
       return t('sessions.agentCowork');
     case 'claw':
     case 'Claw':
-      return t('sessions.agentClaw');
+      return t('shared.agents.claw');
     default:
       return agentType || t('sessions.agentDefault');
   }
@@ -569,7 +569,7 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
         <div className="session-list__header-brand">
           <img src={logoIcon} alt="BitFun" className="session-list__logo" />
           <div className="session-list__header-copy">
-            <h1>{t('common.appName')}</h1>
+            <h1>{t('shared.product.remote')}</h1>
             {authenticatedUserId && (
               <span className="session-list__header-user-id">
                 <span className={`session-list__health-dot session-list__health-dot--${connectionHealth}`} title={(() => { switch (connectionHealth) { case 'connected': return t('sessions.connectionConnected'); case 'checking': return t('sessions.connectionChecking'); case 'unreachable': return t('sessions.connectionUnreachable'); default: return t('sessions.connectionUnpaired'); } })()} />
@@ -648,7 +648,7 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
                 <WorkspaceIcon />
               </span>
               <div className="session-list__workspace-copy">
-                <span className="session-list__workspace-label">{t('sessions.workspace')}</span>
+                <span className="session-list__workspace-label">{t('shared.features.workspace')}</span>
                 <span className="session-list__workspace-name" title={workspaceDisplayName}>{truncateMiddle(workspaceDisplayName, 24)}</span>
               </div>
               {currentWorkspace?.git_branch && (
@@ -792,7 +792,7 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
                         <SessionTypeIcon agentType="cowork" />
                       </div>
                       <div className="session-list__create-copy">
-                        <span className="session-list__create-title">{t('sessions.coworkSession')}</span>
+                        <span className="session-list__create-title">{t('shared.agents.cowork')}</span>
                         <span className="session-list__create-desc">{t('sessions.coworkSessionDesc')}</span>
                       </div>
                       <span className="session-list__create-arrow">

--- a/src/mobile-web/src/pages/WorkspacePage.tsx
+++ b/src/mobile-web/src/pages/WorkspacePage.tsx
@@ -83,7 +83,7 @@ const WorkspacePage: React.FC<WorkspacePageProps> = ({ sessionMgr, onReady }) =>
   return (
     <div className="workspace-page">
       <div className="workspace-page__header">
-        <h1>{t('workspace.title')}</h1>
+        <h1>{t('shared.features.workspace')}</h1>
         <LanguageToggleButton />
       </div>
 

--- a/src/web-ui/src/app/components/NavPanel/MainNav.tsx
+++ b/src/web-ui/src/app/components/NavPanel/MainNav.tsx
@@ -627,7 +627,7 @@ const MainNav: React.FC<MainNavProps> = ({
         {/* Workspace */}
         <div className="bitfun-nav-panel__section">
           <SectionHeader
-            label={t('nav.sections.workspace')}
+            label={t('shared:features.workspace')}
             collapsible
             isOpen={expandedSections.has('workspace')}
             onToggle={() => toggleSection('workspace')}

--- a/src/web-ui/src/app/components/NavPanel/components/PersistentFooterActions.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/PersistentFooterActions.tsx
@@ -191,7 +191,7 @@ const PersistentFooterActions: React.FC = () => {
                       onClick={handleRemoteConnect}
                     >
                       <Smartphone size={14} />
-                      <span>{t('header.remoteConnect')}</span>
+                      <span>{t('shared:features.remoteControl')}</span>
                     </button>
                   </Tooltip>
                   <div className="bitfun-nav-panel__footer-menu-divider" />
@@ -221,7 +221,7 @@ const PersistentFooterActions: React.FC = () => {
                     onClick={handleOpenSettings}
                   >
                     <Settings size={14} />
-                    <span>{t('tabs.settings')}</span>
+                    <span>{t('shared:features.settings')}</span>
                   </button>
                   <button
                     type="button"

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.tsx
@@ -917,7 +917,7 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
       <Modal
         isOpen={isOpen}
         onClose={onClose}
-        title={t('remoteConnect.title')}
+        title={t('shared:features.remoteControl')}
         titleExtra={(
           <span className="bitfun-remote-connect__title-extra">
             <button

--- a/src/web-ui/src/app/components/SceneBar/types.ts
+++ b/src/web-ui/src/app/components/SceneBar/types.ts
@@ -27,7 +27,7 @@ export type SceneTabId =
 export interface SceneTabDef {
   id: SceneTabId;
   label: string;
-  /** i18n key under common.scenes — when provided, SceneBar will translate instead of using label */
+  /** i18n key resolved through the common namespace, or an explicit namespace key such as shared:features.settings. */
   labelKey?: string;
   Icon?: LucideIcon;
   /** @deprecated Prefer fixed + closable. Pinned tabs cannot be closed and were protected from eviction. */

--- a/src/web-ui/src/app/scenes/registry.ts
+++ b/src/web-ui/src/app/scenes/registry.ts
@@ -66,6 +66,7 @@ export const SCENE_TAB_REGISTRY: SceneTabDef[] = [
   {
     id: 'settings' as SceneTabId,
     label: 'Settings',
+    labelKey: 'shared:features.settings',
     Icon: Settings,
     pinned: false,
     singleton: true,

--- a/src/web-ui/src/app/scenes/settings/SettingsNav.tsx
+++ b/src/web-ui/src/app/scenes/settings/SettingsNav.tsx
@@ -293,7 +293,7 @@ const SettingsNav: React.FC = () => {
     <div className="bitfun-settings-nav">
       <div className="bitfun-settings-nav__header">
         <span className="bitfun-settings-nav__title">
-          {t('configCenter.title', { defaultValue: t('title', { defaultValue: 'Settings' }) })}
+          {t('shared:features.settings')}
         </span>
       </div>
 

--- a/src/web-ui/src/flow_chat/components/WelcomePanel.tsx
+++ b/src/web-ui/src/flow_chat/components/WelcomePanel.tsx
@@ -228,7 +228,7 @@ export const WelcomePanel: React.FC<WelcomePanelProps> = ({
                         title={currentWorkspace?.rootPath}
                       >
                         <FolderOpen size={13} className="welcome-panel__inline-icon" />
-                        {currentWorkspace?.name || t('welcome.workspace')}
+                        {currentWorkspace?.name || t('shared:features.workspace')}
                         <ChevronDown
                           size={11}
                           className={`welcome-panel__inline-chevron${workspaceDropdownOpen ? ' welcome-panel__inline-chevron--open' : ''}`}

--- a/src/web-ui/src/flow_chat/tool-cards/SessionControlToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/SessionControlToolCard.tsx
@@ -156,7 +156,7 @@ export const SessionControlToolCard: React.FC<ToolCardProps> = React.memo(({
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
       {workspace && (
         <div className="detail-item">
-          <span className="detail-label">{t('toolCards.sessionControl.workspace')}:</span>
+          <span className="detail-label">{t('shared:features.workspace')}:</span>
           <span className="detail-value">{workspace}</span>
         </div>
       )}

--- a/src/web-ui/src/flow_chat/tool-cards/SessionMessageToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/SessionMessageToolCard.tsx
@@ -87,7 +87,7 @@ export const SessionMessageToolCard: React.FC<ToolCardProps> = React.memo(({
 
       {workspace && (
         <div className="detail-item">
-          <span className="detail-label">{t('toolCards.sessionMessage.workspace')}:</span>
+          <span className="detail-label">{t('shared:features.workspace')}:</span>
           <span className="detail-value">{workspace}</span>
         </div>
       )}

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "name": "BitFun",
     "version": "Version",
     "loading": "Loading...",
     "welcome": "Welcome to BitFun"
@@ -52,7 +51,6 @@
     "showChatPanel": "Show Chat Panel",
     "hideChatPanel": "Hide Chat Panel",
     "switchToToolbar": "Floating window mode",
-    "remoteConnect": "Remote Control",
     "modeSwitchAriaLabel": "View mode switch",
     "modeCowork": "Cowork",
     "modeCoder": "Coder",
@@ -95,7 +93,6 @@
       "addWorkspace": "Add workspace"
     },
     "sections": {
-      "workspace": "Workspace",
       "extensions": "Customize",
       "shell": "Shell",
       "assistantSessions": "Assistant Sessions"
@@ -174,7 +171,7 @@
       "delete": "Delete",
       "confirmEdit": "Confirm",
       "cancelEdit": "Cancel",
-      "loading": "Loading sessions...",
+      "loading": "Loading...",
       "showMore": "{{count}} more sessions",
       "showAll": "{{count}} more (show all)",
       "showLess": "Show less",
@@ -210,7 +207,6 @@
       "archivedSessions": "Archived Sessions",
       "noArchivedSessions": "No archived sessions",
       "archivedSessionsDescription": "View, restore, or permanently delete archived sessions.",
-      "loading": "Loading...",
       "untitled": "Untitled Session",
       "restore": "Restore",
       "archivedAll": "{{count}} sessions archived",
@@ -442,7 +438,6 @@
     "errorCreateFailed": "Failed to create project"
   },
   "remoteConnect": {
-    "title": "Remote Control",
     "tabLan": "LAN",
     "tabBitfunServer": "BitFun Server",
     "tabNgrok": "NAT Traversal",
@@ -864,7 +859,6 @@
     "fileBrowser": "File Browser",
     "editor": "Editor",
     "markdown": "Markdown",
-    "settings": "Settings",
     "settingsWithSection": "Settings - {{section}}"
   },
   "welcome": {
@@ -898,7 +892,6 @@
     "aiAgent": "Session",
     "terminal": "Terminal",
     "git": "Git",
-    "settings": "Settings",
     "fileViewer": "File Viewer",
     "projectContext": "Profile",
     "agents": "Agents",

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -16,7 +16,6 @@
     "releaseToAdd": "Release to add to this column"
   },
   "layout": {
-    "noPanels": "BitFun",
     "noPanelsHint": "Use the bottom bar to toggle panels or press <kbd>Ctrl+\\</kbd> <kbd>Ctrl+]</kbd> to expand panels",
     "chatHiddenTitle": "Chat is hidden",
     "chatHiddenDesc": "Use the Chat toggle in the top-right to show it again.",
@@ -443,7 +442,6 @@
   "toolbar": {
     "newSession": "New Session",
     "history": "History",
-    "settings": "Settings",
     "export": "Export Chat",
     "clear": "Clear Chat",
     "fullscreen": "Fullscreen",
@@ -1401,7 +1399,6 @@
       "listingSessions": "Listing sessions",
       "listedSessions": "Found {{count}} sessions",
       "actionFailed": "Session operation failed",
-      "workspace": "Workspace",
       "sessionId": "Session ID",
       "sessionName": "Session name",
       "agentType": "Agent type",
@@ -1423,7 +1420,6 @@
       "messageAccepted": "Message accepted for {{session}}",
       "sendFailed": "Failed to message {{session}}",
       "targetSession": "Target session",
-      "workspace": "Workspace",
       "agentType": "Agent type",
       "message": "Message"
     },
@@ -1782,7 +1778,6 @@
     "defaultAction2Command": "Continue previous work",
     "defaultAction3": "Start a new feature",
     "defaultAction3Command": "Start a new feature",
-    "workspace": "Workspace",
     "noWorkspace": "No workspace open",
     "openOtherProject": "Open other project...",
     "noWorkspaceHint": "No project selected yet",

--- a/src/web-ui/src/locales/en-US/settings.json
+++ b/src/web-ui/src/locales/en-US/settings.json
@@ -1,7 +1,5 @@
 {
-  "title": "Settings",
   "configCenter": {
-    "title": "Settings",
     "selectConfig": "Select Configuration",
     "searchPlaceholder": "Search settings…",
     "searchNoResults": "No matching settings",
@@ -145,7 +143,6 @@
     }
   },
   "workspace": {
-    "title": "Workspace",
     "files": {
       "title": "Files",
       "exclude": "Exclude Files",

--- a/src/web-ui/src/locales/en-US/settings/lsp.json
+++ b/src/web-ui/src/locales/en-US/settings/lsp.json
@@ -13,7 +13,6 @@
   },
   "tabs": {
     "plugins": "Plugin Management",
-    "settings": "Settings",
     "help": "Help"
   },
   "settings": {

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "name": "BitFun",
     "version": "版本",
     "loading": "加载中...",
     "welcome": "欢迎使用 BitFun"
@@ -52,7 +51,6 @@
     "showChatPanel": "显示聊天面板",
     "hideChatPanel": "隐藏聊天面板",
     "switchToToolbar": "悬浮窗模式",
-    "remoteConnect": "远程控制",
     "modeSwitchAriaLabel": "视图模式切换",
     "modeCowork": "Cowork",
     "modeCoder": "Coder",
@@ -95,7 +93,6 @@
       "addWorkspace": "添加工作区"
     },
     "sections": {
-      "workspace": "工作区",
       "extensions": "定制",
       "shell": "Shell",
       "assistantSessions": "助理会话"
@@ -174,7 +171,7 @@
       "delete": "删除",
       "confirmEdit": "确认",
       "cancelEdit": "取消",
-      "loading": "正在加载会话...",
+      "loading": "加载中...",
       "showMore": "还有 {{count}} 个会话",
       "showAll": "还有 {{count}} 个（展开全部）",
       "showLess": "收起",
@@ -210,7 +207,6 @@
       "archivedSessions": "已归档会话",
       "noArchivedSessions": "暂无已归档会话",
       "archivedSessionsDescription": "查看、恢复或永久删除已归档的会话。",
-      "loading": "加载中...",
       "untitled": "未命名会话",
       "restore": "恢复",
       "archivedAll": "已归档 {{count}} 个会话",
@@ -442,7 +438,6 @@
     "errorCreateFailed": "创建工作区失败"
   },
   "remoteConnect": {
-    "title": "远程控制",
     "tabLan": "局域网",
     "tabBitfunServer": "BitFun服务器",
     "tabNgrok": "内网穿透",
@@ -864,7 +859,6 @@
     "fileBrowser": "文件浏览器",
     "editor": "编辑器",
     "markdown": "Markdown",
-    "settings": "设置",
     "settingsWithSection": "设置 - {{section}}"
   },
   "welcome": {
@@ -898,7 +892,6 @@
     "aiAgent": "会话",
     "terminal": "终端",
     "git": "Git",
-    "settings": "设置",
     "fileViewer": "文件查看",
     "projectContext": "项目概况",
     "agents": "智能体",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -16,7 +16,6 @@
     "releaseToAdd": "释放以添加到此栏"
   },
   "layout": {
-    "noPanels": "BitFun",
     "noPanelsHint": "使用底部栏切换面板或按 <kbd>Ctrl+\\</kbd> <kbd>Ctrl+]</kbd> 展开面板",
     "chatHiddenTitle": "聊天已隐藏",
     "chatHiddenDesc": "你可以在右上角点击“聊天”重新打开。",
@@ -443,7 +442,6 @@
   "toolbar": {
     "newSession": "新建会话",
     "history": "历史记录",
-    "settings": "设置",
     "export": "导出对话",
     "clear": "清空对话",
     "fullscreen": "全屏",
@@ -1401,7 +1399,6 @@
       "listingSessions": "正在列出会话",
       "listedSessions": "共找到 {{count}} 个会话",
       "actionFailed": "会话操作失败",
-      "workspace": "工作区",
       "sessionId": "会话ID",
       "sessionName": "会话名称",
       "agentType": "Agent 类型",
@@ -1423,7 +1420,6 @@
       "messageAccepted": "消息已提交给 {{session}}",
       "sendFailed": "向 {{session}} 发送消息失败",
       "targetSession": "目标会话",
-      "workspace": "工作区",
       "agentType": "Agent 类型",
       "message": "消息内容"
     },
@@ -1782,7 +1778,6 @@
     "defaultAction2Command": "继续之前的工作",
     "defaultAction3": "开始新功能",
     "defaultAction3Command": "开始新功能",
-    "workspace": "工作区",
     "noWorkspace": "未打开工作区",
     "openOtherProject": "打开其他项目...",
     "noWorkspaceHint": "还没有选择项目",

--- a/src/web-ui/src/locales/zh-CN/settings.json
+++ b/src/web-ui/src/locales/zh-CN/settings.json
@@ -1,7 +1,5 @@
 {
-  "title": "设置",
   "configCenter": {
-    "title": "设置",
     "selectConfig": "选择配置项",
     "searchPlaceholder": "搜索配置…",
     "searchNoResults": "没有匹配的配置",
@@ -145,7 +143,6 @@
     }
   },
   "workspace": {
-    "title": "工作区",
     "files": {
       "title": "文件",
       "exclude": "排除文件",

--- a/src/web-ui/src/locales/zh-CN/settings/lsp.json
+++ b/src/web-ui/src/locales/zh-CN/settings/lsp.json
@@ -13,7 +13,6 @@
   },
   "tabs": {
     "plugins": "插件管理",
-    "settings": "设置",
     "help": "帮助"
   },
   "settings": {

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "name": "BitFun",
     "version": "版本",
     "loading": "加載中...",
     "welcome": "歡迎使用 BitFun"
@@ -52,7 +51,6 @@
     "showChatPanel": "顯示聊天面板",
     "hideChatPanel": "隱藏聊天面板",
     "switchToToolbar": "懸浮窗模式",
-    "remoteConnect": "遠程控制",
     "modeSwitchAriaLabel": "視圖模式切換",
     "modeCowork": "Cowork",
     "modeCoder": "Coder",
@@ -95,7 +93,6 @@
       "addWorkspace": "添加工作區"
     },
     "sections": {
-      "workspace": "工作區",
       "extensions": "定製",
       "shell": "Shell",
       "assistantSessions": "助理會話"
@@ -174,7 +171,7 @@
       "delete": "刪除",
       "confirmEdit": "確認",
       "cancelEdit": "取消",
-      "loading": "正在加載會話...",
+      "loading": "載入中...",
       "showMore": "還有 {{count}} 個會話",
       "showAll": "還有 {{count}} 個（展開全部）",
       "showLess": "收起",
@@ -210,7 +207,6 @@
       "archivedSessions": "已歸檔會話",
       "noArchivedSessions": "暫無已歸檔會話",
       "archivedSessionsDescription": "檢視、恢復或永久刪除已歸檔的會話。",
-      "loading": "載入中...",
       "untitled": "未命名會話",
       "restore": "恢復",
       "archivedAll": "已歸檔 {{count}} 個會話",
@@ -442,7 +438,6 @@
     "errorCreateFailed": "創建工作區失敗"
   },
   "remoteConnect": {
-    "title": "遠程控制",
     "tabLan": "局域網",
     "tabBitfunServer": "BitFun服務器",
     "tabNgrok": "內網穿透",
@@ -864,7 +859,6 @@
     "fileBrowser": "文件瀏覽器",
     "editor": "編輯器",
     "markdown": "Markdown",
-    "settings": "設置",
     "settingsWithSection": "設置 - {{section}}"
   },
   "welcome": {
@@ -898,7 +892,6 @@
     "aiAgent": "會話",
     "terminal": "終端",
     "git": "Git",
-    "settings": "設置",
     "fileViewer": "文件查看",
     "projectContext": "項目概況",
     "agents": "智能體",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -16,7 +16,6 @@
     "releaseToAdd": "釋放以添加到此欄"
   },
   "layout": {
-    "noPanels": "BitFun",
     "noPanelsHint": "使用底部欄切換面板或按 <kbd>Ctrl+\\</kbd> <kbd>Ctrl+]</kbd> 展開面板",
     "chatHiddenTitle": "聊天已隱藏",
     "chatHiddenDesc": "你可以在右上角點擊“聊天”重新打開。",
@@ -443,7 +442,6 @@
   "toolbar": {
     "newSession": "新建會話",
     "history": "歷史記錄",
-    "settings": "設置",
     "export": "導出對話",
     "clear": "清空對話",
     "fullscreen": "全屏",
@@ -1401,7 +1399,6 @@
       "listingSessions": "正在列出會話",
       "listedSessions": "共找到 {{count}} 個會話",
       "actionFailed": "會話操作失敗",
-      "workspace": "工作區",
       "sessionId": "會話ID",
       "sessionName": "會話名稱",
       "agentType": "Agent 類型",
@@ -1423,7 +1420,6 @@
       "messageAccepted": "消息已提交給 {{session}}",
       "sendFailed": "向 {{session}} 發送消息失敗",
       "targetSession": "目標會話",
-      "workspace": "工作區",
       "agentType": "Agent 類型",
       "message": "消息內容"
     },
@@ -1782,7 +1778,6 @@
     "defaultAction2Command": "繼續之前的工作",
     "defaultAction3": "開始新功能",
     "defaultAction3Command": "開始新功能",
-    "workspace": "工作區",
     "noWorkspace": "未打開工作區",
     "openOtherProject": "打開其他項目...",
     "noWorkspaceHint": "還沒有選擇項目",

--- a/src/web-ui/src/locales/zh-TW/settings.json
+++ b/src/web-ui/src/locales/zh-TW/settings.json
@@ -1,7 +1,5 @@
 {
-  "title": "設置",
   "configCenter": {
-    "title": "設置",
     "selectConfig": "選擇配置項",
     "searchPlaceholder": "搜索配置…",
     "searchNoResults": "沒有匹配的配置",
@@ -145,7 +143,6 @@
     }
   },
   "workspace": {
-    "title": "工作區",
     "files": {
       "title": "文件",
       "exclude": "排除文件",

--- a/src/web-ui/src/locales/zh-TW/settings/lsp.json
+++ b/src/web-ui/src/locales/zh-TW/settings/lsp.json
@@ -13,7 +13,6 @@
   },
   "tabs": {
     "plugins": "插件管理",
-    "settings": "設置",
     "help": "幫助"
   },
   "settings": {


### PR DESCRIPTION
## Summary

- Reuse generated shared i18n terms for stable mobile-web labels, including remote product naming, workspace labels, Cowork/Claw labels, and common tool names.
- Extend the same shared-term migration to Web UI stable labels: product-name resource copies, Remote Control, Workspace, and Settings labels in navigation, dialog titles, settings nav, welcome copy, and session tool cards.
- Remove the migrated local locale-key copies across `en-US`, `zh-CN`, and `zh-TW`, and lower the shared-term governance baseline.
- Add contract coverage that prevents mobile-web and Web UI from reintroducing the migrated local shared-term copies.

## Key Quantitative Changes

Baseline comparison is `gcwing/main` before this PR vs this PR branch.

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `sharedTermDuplicates.maxTotal` | 281 | 214 | -67 |
| `sharedTermDuplicates.bySurface.mobile-web` | 38 | 8 | -30 |
| `sharedTermDuplicates.bySurface.web-ui` | 220 | 183 | -37 |
| `features.workspace` duplicate candidates | 23 | 2 | -21 |
| `features.settings` duplicate candidates | 13 | 1 | -12 |
| `product.name` duplicate candidates | 12 | 6 | -6 |
| `features.remoteControl` duplicate candidates | 6 | 2 | -4 |

## Scope Boundaries

Remaining `features.workspace` candidates are Git `workingTree` labels, so they stay local because they are not the product Workspace concept. `common.header.configCenter`, relay homepage, core, and installer candidates are also left out because their wording or runtime contract differs from this Web/mobile cleanup slice.

`l10nQualityCandidates` remains at 1093. This PR removes structural shared-term duplication; it does not claim to resolve translation-quality debt.

## Risk And Behavior Notes

- Shared terms are referenced explicitly with `shared:` keys; this preserves the existing namespace priority model and does not make `shared` a fallback namespace.
- The PR removes local copies but does not widen startup namespaces or import another surface's locale catalog.
- While touching `common.json`, the existing duplicate `nav.sessions.loading` entries collapse to the effective `JSON.parse` value already used at runtime.

## Verification

- `pnpm run i18n:audit`
- `pnpm run i18n:contract:test` (27/27 tests)
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/infrastructure/i18n/core/I18nService.test.ts` (4/4 tests)
- `git diff --check HEAD`

Related tracking issue: #959.