### PR TITLE
feat(agentic): route PlaintextFollowup Write through post-write Read

### DIFF
--- a/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
@@ -66,10 +66,11 @@ The user will primarily request you perform software engineering tasks. This inc
 - For security-sensitive tasks, support defensive analysis and remediation only. Refuse malicious code, exploit workflows, credential harvesting, or instructions that would facilitate abuse.
 - Edit reliability discipline:
   - Read a file in this session before Edit. Partial range reads are allowed, but the Read range must include every line you will copy into `old_string`.
-  - Base `old_string` on the latest Read result for that file (or exact content from a successful prior Edit/Write on the same file).
+  - Base `old_string` on the latest Read result for that file; after Write, use the post-write Read result returned by the system.
   - Read output uses cat -n format: spaces, line number, tab, then file content. Copy only the text after the tab into `old_string` and `new_string`.
   - Do not reformat HTML/CSS/JS when constructing Edit strings; match indentation and blank lines exactly.
-  - Treat Read output as stale after a successful edit to the same file; re-read before the next Edit unless you are continuing from the updated content in the prior tool result.
+  - Treat Read output as stale after a successful edit to the same file; re-read before the next Edit unless you are continuing from the exact text returned by that Edit or by the post-write Read result.
+  - Use Write only to create a new file or intentionally replace a whole file in one step. After Write succeeds for a path, do not call Write again for that path to continue, refine, or patch it; use Edit against the latest Read content.
   - Use 2-4 adjacent lines with stable surrounding context when that is enough to make `old_string` unique.
   - Use `replace_all` only when every occurrence should change.
   - If Edit fails because text was not found or matched multiple locations, Read the target lines again and retry with freshly copied text — do not adjust the failed string from memory.

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -539,10 +539,6 @@ impl ExecutionEngine {
             .unwrap_or_else(|| "auto".to_string())
     }
 
-    fn should_use_fast_auto_model(turn_index: usize, original_user_input: &str) -> bool {
-        turn_index == 0 && original_user_input.chars().count() <= 10
-    }
-
     fn collect_unlocked_collapsed_tools(
         messages: &[Message],
         collapsed_tools: &[String],
@@ -822,9 +818,11 @@ impl ExecutionEngine {
         let resolved_configured_model_id =
             Self::resolve_configured_model_id(&ai_config, &configured_model_id);
 
-        let model_id = if configured_model_id == "auto" || resolved_configured_model_id == "auto" {
-            let use_fast_model = Self::should_use_fast_auto_model(turn_index, original_user_input);
-            let fallback_model = if use_fast_model { "fast" } else { "primary" };
+        let model_id = if configured_model_id == "auto"
+            || configured_model_id == "default"
+            || resolved_configured_model_id == "auto"
+        {
+            let fallback_model = "primary";
             let resolved_model_id = ai_config.resolve_model_selection(fallback_model);
 
             if let Some(resolved_model_id) = resolved_model_id {
@@ -3167,25 +3165,6 @@ mod tests {
             enabled: true,
             ..Default::default()
         }
-    }
-
-    #[test]
-    fn auto_model_uses_fast_for_short_first_message() {
-        assert!(ExecutionEngine::should_use_fast_auto_model(0, "你好"));
-        assert!(ExecutionEngine::should_use_fast_auto_model(0, "1234567890"));
-    }
-
-    #[test]
-    fn auto_model_uses_primary_for_long_first_message() {
-        assert!(!ExecutionEngine::should_use_fast_auto_model(
-            0,
-            "12345678901"
-        ));
-    }
-
-    #[test]
-    fn auto_model_uses_primary_after_first_turn() {
-        assert!(!ExecutionEngine::should_use_fast_auto_model(1, "短消息"));
     }
 
     #[test]

--- a/src/crates/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/core/src/agentic/execution/round_executor.rs
@@ -29,6 +29,7 @@ use crate::util::types::ToolDefinition;
 use bitfun_ai_adapters::types::ReasoningMode;
 use dashmap::DashMap;
 use log::{debug, error, info, warn};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
@@ -47,6 +48,7 @@ impl RoundExecutor {
     const MAX_WRITE_CONTENT_QUALITY_ATTEMPTS: usize = 2;
     const RETRY_BASE_DELAY_MS: u64 = 500;
     const WRITE_CONTENT_STREAM_IDLE_TIMEOUT_SECS: u64 = 45;
+    const AUTO_READ_AFTER_WRITE_MARKER: &'static str = "__read_after_write";
 
     fn has_user_visible_assistant_text(text: &str) -> bool {
         !text.trim().is_empty()
@@ -615,6 +617,14 @@ impl RoundExecutor {
         } else {
             tool_calls
         };
+        let assistant_tool_calls = if matches!(
+            Self::write_tool_mode(&context),
+            WriteToolMode::PlaintextFollowup
+        ) {
+            Self::strip_plaintext_followup_write_content_for_history(tool_calls.clone())
+        } else {
+            tool_calls.clone()
+        };
 
         // Execute tool calls
         debug!(
@@ -625,6 +635,8 @@ impl RoundExecutor {
         let tool_phase_started_at = Instant::now();
         let tool_results = if let Some(tool_pipeline) = &self.tool_pipeline {
             // Create tool execution context
+            let allowed_tools =
+                Self::allowed_tools_for_execution(&context.available_tools, &tool_calls);
             let tool_context = ToolExecutionContext {
                 session_id: context.session_id.clone(),
                 dialog_turn_id: context.dialog_turn_id.clone(),
@@ -636,7 +648,7 @@ impl RoundExecutor {
                 delegation_policy: context.delegation_policy,
                 collapsed_tools: context.collapsed_tools.clone(),
                 unlocked_collapsed_tools: context.unlocked_collapsed_tools.clone(),
-                allowed_tools: context.available_tools.clone(),
+                allowed_tools,
                 runtime_tool_restrictions: context.runtime_tool_restrictions.clone(),
                 steering_interrupt: context.steering_interrupt.clone(),
                 workspace_services: context.workspace_services.clone(),
@@ -768,7 +780,7 @@ impl RoundExecutor {
         let assistant_message = Message::assistant_with_reasoning(
             reasoning,
             stream_result.full_text.clone(),
-            tool_calls.clone(),
+            assistant_tool_calls.clone(),
         )
         .with_turn_id(context.dialog_turn_id.clone())
         .with_round_id(round_id.clone())
@@ -824,7 +836,7 @@ impl RoundExecutor {
 
         Ok(RoundResult {
             assistant_message,
-            tool_calls: tool_calls.clone(),
+            tool_calls: assistant_tool_calls,
             tool_result_messages,
             has_more_rounds,
             finish_reason: if has_more_rounds {
@@ -897,7 +909,9 @@ impl RoundExecutor {
     /// separate AI request with the full session history and a directive to
     /// output the file content as plain text inside `<bitfun_contents>` tags.
     /// The extracted content is then injected into the tool call arguments so
-    /// the downstream Write tool execution proceeds as normal.
+    /// the downstream Write tool execution proceeds as normal. A synthetic Read
+    /// call is added after each generated Write so the next model round sees
+    /// the written file through the normal file-reading contract.
     async fn generate_write_tool_contents(
         &self,
         ai_client: Arc<AIClient>,
@@ -927,10 +941,16 @@ impl RoundExecutor {
             return Ok(tool_calls);
         }
 
+        // PlaintextFollowup injects a synthetic Read after each generated Write.
+        // Fail fast before the slow content-generation requests if Read cannot run.
+        Self::ensure_auto_read_after_write_executable(context).await?;
+
         info!(
             "Generating content for {} Write tool call(s) via separate AI request",
             write_indices.len()
         );
+
+        let mut generated_write_reads: Vec<(String, String)> = Vec::new();
 
         for idx in &write_indices {
             if cancel_token.is_cancelled() {
@@ -1168,6 +1188,7 @@ impl RoundExecutor {
                 .as_object_mut()
                 .expect("Write tool arguments must be a JSON object")
                 .insert("content".to_string(), serde_json::Value::String(content));
+            generated_write_reads.push((tool_id.clone(), file_path.clone()));
 
             debug!(
                 "Write content generated: file_path={}, content_len={}",
@@ -1181,7 +1202,146 @@ impl RoundExecutor {
             );
         }
 
+        if !generated_write_reads.is_empty() {
+            tool_calls = Self::insert_auto_read_calls_after_generated_writes(
+                tool_calls,
+                &generated_write_reads,
+            );
+        }
+
         Ok(tool_calls)
+    }
+
+    async fn ensure_auto_read_after_write_executable(context: &RoundContext) -> BitFunResult<()> {
+        context
+            .runtime_tool_restrictions
+            .ensure_tool_allowed("Read")
+            .map_err(BitFunError::from)?;
+
+        let registry = get_global_tool_registry();
+        let tool_registry = registry.read().await;
+        if tool_registry.get_tool("Read").is_none() {
+            return Err(BitFunError::tool(
+                "PlaintextFollowup Write requires the Read tool to be registered so the system can inspect the file after writing.".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn allowed_tools_for_execution(
+        available_tools: &[String],
+        tool_calls: &[ToolCall],
+    ) -> Vec<String> {
+        let mut allowed_tools = available_tools.to_vec();
+        if allowed_tools.is_empty()
+            || !Self::contains_auto_read_after_write(tool_calls)
+            || allowed_tools.iter().any(|tool| tool == "Read")
+        {
+            return allowed_tools;
+        }
+
+        // The post-Write Read is injected by the runtime, not selected by the
+        // model from the visible manifest. Permit that synthetic Read through
+        // the execution allow-list while keeping runtime restrictions enforced.
+        allowed_tools.push("Read".to_string());
+        allowed_tools
+    }
+
+    fn contains_auto_read_after_write(tool_calls: &[ToolCall]) -> bool {
+        tool_calls.iter().any(|tool_call| {
+            tool_call.tool_name == "Read"
+                && tool_call
+                    .tool_id
+                    .contains(Self::AUTO_READ_AFTER_WRITE_MARKER)
+        })
+    }
+
+    fn insert_auto_read_calls_after_generated_writes(
+        tool_calls: Vec<ToolCall>,
+        generated_write_reads: &[(String, String)],
+    ) -> Vec<ToolCall> {
+        if generated_write_reads.is_empty() {
+            return tool_calls;
+        }
+
+        let generated_by_tool_id: HashMap<String, String> =
+            generated_write_reads.iter().cloned().collect();
+        let mut existing_ids: HashSet<String> = tool_calls
+            .iter()
+            .map(|tool_call| tool_call.tool_id.clone())
+            .collect();
+        let original_tool_calls = tool_calls.clone();
+        let mut expanded =
+            Vec::with_capacity(tool_calls.len().saturating_add(generated_write_reads.len()));
+
+        for tool_call in tool_calls {
+            let write_tool_id = tool_call.tool_id.clone();
+            let read_file_path = generated_by_tool_id.get(&write_tool_id).cloned();
+            expanded.push(tool_call);
+
+            let Some(file_path) = read_file_path else {
+                continue;
+            };
+
+            if Self::has_later_read_for_file(&original_tool_calls, &write_tool_id, &file_path) {
+                continue;
+            }
+
+            let read_tool_id = Self::unique_auto_read_tool_id(&write_tool_id, &mut existing_ids);
+            expanded.push(ToolCall {
+                tool_id: read_tool_id,
+                tool_name: "Read".to_string(),
+                arguments: serde_json::json!({ "file_path": file_path }),
+                raw_arguments: None,
+                is_error: false,
+                recovered_from_truncation: false,
+            });
+        }
+
+        expanded
+    }
+
+    fn has_later_read_for_file(
+        tool_calls: &[ToolCall],
+        write_tool_id: &str,
+        file_path: &str,
+    ) -> bool {
+        let mut after_write = false;
+        for tool_call in tool_calls {
+            if after_write
+                && tool_call.tool_name == "Read"
+                && tool_call
+                    .arguments
+                    .get("file_path")
+                    .and_then(|value| value.as_str())
+                    == Some(file_path)
+            {
+                return true;
+            }
+            if tool_call.tool_id == write_tool_id {
+                after_write = true;
+            }
+        }
+        false
+    }
+
+    fn unique_auto_read_tool_id(write_tool_id: &str, existing_ids: &mut HashSet<String>) -> String {
+        let base = format!("{write_tool_id}{}", Self::AUTO_READ_AFTER_WRITE_MARKER);
+        let mut candidate = base.clone();
+        let mut suffix = 2usize;
+        while !existing_ids.insert(candidate.clone()) {
+            candidate = format!("{base}_{suffix}");
+            suffix += 1;
+        }
+        candidate
+    }
+
+    fn strip_plaintext_followup_write_content_for_history(
+        mut tool_calls: Vec<ToolCall>,
+    ) -> Vec<ToolCall> {
+        FileWriteTool::strip_plaintext_followup_inline_content_from_tool_calls(&mut tool_calls);
+        tool_calls
     }
 
     /// Build the message list for Write content generation.
@@ -2067,11 +2227,168 @@ mod tests {
         assert_eq!(messages[3].role, "user");
         assert_eq!(messages[4].role, "assistant");
         assert_eq!(messages[4].content.as_deref(), Some("<bitfun_contents>"));
-        assert!(
-            messages[4]
-                .content
-                .as_deref()
-                .is_some_and(|content| !content.ends_with(char::is_whitespace))
+        assert!(messages[4]
+            .content
+            .as_deref()
+            .is_some_and(|content| !content.ends_with(char::is_whitespace)));
+    }
+
+    #[test]
+    fn generated_write_gets_followup_read_call() {
+        let tool_calls = vec![
+            crate::agentic::core::ToolCall {
+                tool_id: "write-1".to_string(),
+                tool_name: "Write".to_string(),
+                arguments: serde_json::json!({
+                    "file_path": "notes.md",
+                    "content": "hello"
+                }),
+                raw_arguments: None,
+                is_error: false,
+                recovered_from_truncation: false,
+            },
+            crate::agentic::core::ToolCall {
+                tool_id: "bash-1".to_string(),
+                tool_name: "Bash".to_string(),
+                arguments: serde_json::json!({ "command": "pwd" }),
+                raw_arguments: None,
+                is_error: false,
+                recovered_from_truncation: false,
+            },
+        ];
+
+        let expanded = RoundExecutor::insert_auto_read_calls_after_generated_writes(
+            tool_calls,
+            &[("write-1".to_string(), "notes.md".to_string())],
+        );
+
+        assert_eq!(
+            expanded
+                .iter()
+                .map(|tool_call| tool_call.tool_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Write", "Read", "Bash"]
+        );
+        assert_eq!(expanded[1].tool_id, "write-1__read_after_write".to_string());
+        assert_eq!(
+            expanded[1].arguments,
+            serde_json::json!({ "file_path": "notes.md" })
+        );
+    }
+
+    #[test]
+    fn generated_write_does_not_duplicate_existing_later_read() {
+        let tool_calls = vec![
+            crate::agentic::core::ToolCall {
+                tool_id: "write-1".to_string(),
+                tool_name: "Write".to_string(),
+                arguments: serde_json::json!({
+                    "file_path": "notes.md",
+                    "content": "hello"
+                }),
+                raw_arguments: None,
+                is_error: false,
+                recovered_from_truncation: false,
+            },
+            crate::agentic::core::ToolCall {
+                tool_id: "read-1".to_string(),
+                tool_name: "Read".to_string(),
+                arguments: serde_json::json!({ "file_path": "notes.md" }),
+                raw_arguments: None,
+                is_error: false,
+                recovered_from_truncation: false,
+            },
+        ];
+
+        let expanded = RoundExecutor::insert_auto_read_calls_after_generated_writes(
+            tool_calls,
+            &[("write-1".to_string(), "notes.md".to_string())],
+        );
+
+        assert_eq!(expanded.len(), 2);
+        assert_eq!(expanded[1].tool_id, "read-1");
+    }
+
+    #[test]
+    fn synthetic_post_write_read_is_allowed_for_execution_when_hidden_from_model() {
+        let tool_calls = vec![
+            crate::agentic::core::ToolCall {
+                tool_id: "write-1".to_string(),
+                tool_name: "Write".to_string(),
+                arguments: serde_json::json!({
+                    "file_path": "notes.md",
+                    "content": "hello"
+                }),
+                raw_arguments: None,
+                is_error: false,
+                recovered_from_truncation: false,
+            },
+            crate::agentic::core::ToolCall {
+                tool_id: "write-1__read_after_write".to_string(),
+                tool_name: "Read".to_string(),
+                arguments: serde_json::json!({ "file_path": "notes.md" }),
+                raw_arguments: None,
+                is_error: false,
+                recovered_from_truncation: false,
+            },
+        ];
+
+        let allowed =
+            RoundExecutor::allowed_tools_for_execution(&["Write".to_string()], &tool_calls);
+
+        assert_eq!(allowed, vec!["Write".to_string(), "Read".to_string()]);
+    }
+
+    #[test]
+    fn regular_read_is_not_added_to_execution_allow_list() {
+        let tool_calls = vec![crate::agentic::core::ToolCall {
+            tool_id: "read-1".to_string(),
+            tool_name: "Read".to_string(),
+            arguments: serde_json::json!({ "file_path": "notes.md" }),
+            raw_arguments: None,
+            is_error: false,
+            recovered_from_truncation: false,
+        }];
+
+        let allowed =
+            RoundExecutor::allowed_tools_for_execution(&["Write".to_string()], &tool_calls);
+
+        assert_eq!(allowed, vec!["Write".to_string()]);
+    }
+
+    #[test]
+    fn plaintext_followup_history_strips_generated_write_content() {
+        let tool_calls = vec![
+            crate::agentic::core::ToolCall {
+                tool_id: "write-1".to_string(),
+                tool_name: "Write".to_string(),
+                arguments: serde_json::json!({
+                    "file_path": "notes.md",
+                    "content": "system generated body"
+                }),
+                raw_arguments: None,
+                is_error: false,
+                recovered_from_truncation: false,
+            },
+            crate::agentic::core::ToolCall {
+                tool_id: "write-1__read_after_write".to_string(),
+                tool_name: "Read".to_string(),
+                arguments: serde_json::json!({ "file_path": "notes.md" }),
+                raw_arguments: None,
+                is_error: false,
+                recovered_from_truncation: false,
+            },
+        ];
+
+        let history = RoundExecutor::strip_plaintext_followup_write_content_for_history(tool_calls);
+
+        assert_eq!(
+            history[0].arguments,
+            serde_json::json!({ "file_path": "notes.md" })
+        );
+        assert_eq!(
+            history[1].arguments,
+            serde_json::json!({ "file_path": "notes.md" })
         );
     }
 

--- a/src/crates/core/src/agentic/insights/collector.rs
+++ b/src/crates/core/src/agentic/insights/collector.rs
@@ -643,7 +643,8 @@ fn compute_days_covered(range: &DateRange) -> u32 {
 /// and `new_end_line - start_line + 1` as lines added, falling back to counting
 /// newlines in `old_string`/`new_string`.
 ///
-/// For Write tool: counts newlines in the written content as lines added.
+/// For Write tool: uses `lines_written`, falling back to counting newlines in
+/// the tool input for older persisted sessions.
 ///
 /// Per session, each distinct file path touched by Edit/Write contributes once to `languages_by_files`
 /// according to [`language_name_for_path`].
@@ -701,8 +702,13 @@ fn accumulate_code_stats_from_turns(base_stats: &mut BaseStats, turns: &[DialogT
                             modified_files.insert(fp.to_string());
                         }
 
-                        let input = &ti.tool_call.input;
-                        if let Some(content) = input.get("content").and_then(|v| v.as_str()) {
+                        if let Some(lines_written) =
+                            result.get("lines_written").and_then(|v| v.as_u64())
+                        {
+                            base_stats.total_lines_added += lines_written as usize;
+                        } else if let Some(content) =
+                            ti.tool_call.input.get("content").and_then(|v| v.as_str())
+                        {
                             base_stats.total_lines_added += content.lines().count().max(1);
                         }
                     }

--- a/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -1,4 +1,7 @@
 use crate::agentic::core::ToolCall;
+use crate::agentic::execution::write_content_sanitizer::{
+    contains_tool_invocation_artifacts, strip_tool_invocation_artifacts,
+};
 use crate::agentic::tools::file_read_state_runtime::{
     assert_file_not_unexpectedly_modified, file_mutation_timestamp_ms, get_stored_file_read_state,
     local_file_modification_time_ms, read_current_file_content, read_state_tracking_enabled,
@@ -7,9 +10,6 @@ use crate::agentic::tools::file_read_state_runtime::{
 };
 use crate::agentic::tools::file_tool_guidance::{
     file_tool_guidance_message, is_file_tool_guidance_message,
-};
-use crate::agentic::execution::write_content_sanitizer::{
-    contains_tool_invocation_artifacts, strip_tool_invocation_artifacts,
 };
 use crate::agentic::tools::framework::{
     Tool, ToolPathResolution, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
@@ -186,25 +186,29 @@ impl FileWriteTool {
     fn write_success_result(
         logical_path: &str,
         bytes_written: usize,
+        lines_written: usize,
         status: &str,
         assistant_message: String,
-        content: &str,
     ) -> ToolResult {
-        let result_for_assistant = format!(
-            "{assistant_message}\n\nWritten content:\n<bitfun_contents>\n{content}</bitfun_contents>"
-        );
-
         ToolResult::Result {
             data: json!({
                 "file_path": logical_path,
                 "bytes_written": bytes_written,
+                "lines_written": lines_written,
                 "success": true,
                 "status": status,
                 "message": assistant_message,
-                "content": content,
             }),
-            result_for_assistant: Some(result_for_assistant),
+            result_for_assistant: Some(assistant_message),
             image_attachments: None,
+        }
+    }
+
+    fn count_written_lines(content: &str) -> usize {
+        if content.is_empty() {
+            0
+        } else {
+            content.lines().count().max(1)
         }
     }
 
@@ -280,6 +284,7 @@ Usage:
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - Keep writes focused. The 200-line / 20KB guideline is a soft reliability threshold, not a hard cap. If a task genuinely needs more content, preserve correctness and use a staged plan instead of truncating.
 - For existing files, prefer Read + targeted Edit calls. For large new files or rewrites, write the stable scaffold first, then fill or revise sections with focused Edit calls. Do not replace an entire existing file just to change a few sections.
+- After a successful Write, do not call Write again for the same path to continue, refine, or patch the file. Use Read + Edit instead.
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
 - Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.
 - Include the complete file content in the `content` argument."#
@@ -296,6 +301,7 @@ Usage:
 - The file_path parameter must be workspace-relative, an absolute path inside the current workspace, or an exact `bitfun://runtime/...` URI returned by another tool.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - Keep writes focused. For existing files, prefer Read + targeted Edit calls. Use Write only when you need to replace the entire file or create a new one.
+- After a successful Write, the system reads the file back. Use that post-write Read result for any follow-up Edit. Do not call Write again for the same path to continue, refine, or patch the file.
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
 - Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.
 - IMPORTANT — two-step protocol: This tool's schema accepts ONLY `file_path`. Do NOT include a `content` field; any inline content will be discarded. After your tool call, the system automatically issues a separate follow-up request that asks you to output the complete file body inside `<bitfun_contents>` tags, and that text is then written to disk.
@@ -427,12 +433,12 @@ Usage:
             let result = Self::write_success_result(
                 &resolved.logical_path,
                 0,
+                0,
                 "already_exists_same_content",
                 format!(
                     "Write skipped because {} already exists with identical content.",
                     resolved.logical_path
                 ),
-                content,
             );
             return Ok(vec![result]);
         }
@@ -489,9 +495,9 @@ Usage:
         let result = Self::write_success_result(
             &resolved.logical_path,
             content.len(),
+            Self::count_written_lines(content),
             status,
             assistant_message,
-            content,
         );
 
         Ok(vec![result])
@@ -625,16 +631,17 @@ mod tests {
         };
         assert_eq!(data["success"], true);
         assert_eq!(data["bytes_written"], 0);
+        assert_eq!(data["lines_written"], 0);
         assert_eq!(data["status"], "already_exists_same_content");
-        assert_eq!(data["content"], "same content");
         assert!(result_for_assistant
             .as_deref()
             .unwrap_or_default()
             .contains("identical content"));
-        assert!(result_for_assistant
+        assert!(!data.as_object().unwrap().contains_key("content"));
+        assert!(!result_for_assistant
             .as_deref()
             .unwrap_or_default()
-            .contains("<bitfun_contents>\nsame content</bitfun_contents>"));
+            .contains("<bitfun_contents>"));
     }
 
     #[tokio::test]
@@ -661,7 +668,9 @@ mod tests {
             panic!("expected result");
         };
         assert_eq!(data["status"], "overwritten");
-        assert_eq!(data["content"], "new content");
+        assert_eq!(data["bytes_written"], "new content".len());
+        assert_eq!(data["lines_written"], 1);
+        assert!(!data.as_object().unwrap().contains_key("content"));
     }
 
     #[tokio::test]
@@ -903,11 +912,13 @@ mod tests {
         else {
             panic!("expected result");
         };
-        assert_eq!(data["content"], body);
-        assert!(result_for_assistant
+        assert_eq!(data["bytes_written"], body.len());
+        assert_eq!(data["lines_written"], 1);
+        assert!(!data.as_object().unwrap().contains_key("content"));
+        assert!(!result_for_assistant
             .as_deref()
             .unwrap_or_default()
-            .contains("<bitfun_contents>\nsystem generated body</bitfun_contents>"));
+            .contains("<bitfun_contents>"));
     }
 }
 

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -62,7 +62,7 @@ fn is_write_like_tool_name(tool_name: &str) -> bool {
 fn build_truncation_recovery_notice(tool_name: &str) -> String {
     if is_write_like_tool_name(tool_name) {
         return format!(
-            "[Your previous {tool_name} call was truncated mid-stream by max_tokens and was auto-repaired before execution; the file was written with the partial content. The full truncated content — including the exact stopping point — is visible in the `input` of your previous tool_use message, so you do NOT need to read the file again. To finish it, issue ONE Edit call where `old_string` is the final unique substring of your truncated content and `new_string` is that same substring plus the continuation. If you do not have a concrete plan for the continuation, stop tool-calling and tell the user the output was truncated (suggest raising max_tokens). Do NOT call Read on this file and do NOT rewrite the whole file with Write.]\n\nOriginal tool result follows.\n\n"
+            "[Your previous {tool_name} call was truncated mid-stream by max_tokens and was auto-repaired before execution; the file may have been written with partial content. Use the latest Read result for that file (or call Read once if no current Read result is available) to inspect what is on disk. To finish it, issue ONE Edit call where `old_string` is a final unique substring from the current file and `new_string` is that same substring plus the continuation. If you do not have a concrete plan for the continuation, stop tool-calling and tell the user the output was truncated (suggest raising max_tokens). Do NOT rewrite the whole file with Write.]\n\nOriginal tool result follows.\n\n"
         );
     }
 
@@ -658,7 +658,7 @@ impl ToolPipeline {
         // identical call within the per-session sliding window.
         if self.check_and_record_tool_call(&task.context.session_id, &tool_name, &tool_args) {
             let error_msg = format!(
-                "Tool-call loop blocked: '{}' was already called {} times in a row in this session with identical arguments. Refusing to execute this {}th identical call. Issue a different tool call, or stop tool-calling and respond to the user. If you wrote a file recently and want to continue it, its full content is already visible in your earlier tool_use message — use Edit with `old_string` taken from the end of that content; do not Read the file again.",
+                "Tool-call loop blocked: '{}' was already called {} times in a row in this session with identical arguments. Refusing to execute this {}th identical call. Issue a different tool call, or stop tool-calling and respond to the user. If you wrote a file recently and want to continue or modify it, do not call Write again for the same path; use the latest Read result for that file, or call Read once if no current Read result is available, then use Edit with `old_string` taken from the current file content.",
                 tool_name,
                 TOOL_CALL_LOOP_THRESHOLD,
                 TOOL_CALL_LOOP_THRESHOLD + 1
@@ -1580,7 +1580,8 @@ mod tests {
     fn truncation_notice_for_write_tools_keeps_write_continuation_guidance() {
         let notice = build_truncation_recovery_notice("Write");
 
-        assert!(notice.contains("file was written with the partial content"));
+        assert!(notice.contains("file may have been written with partial content"));
+        assert!(notice.contains("latest Read result"));
         assert!(notice.contains("issue ONE Edit call"));
     }
 

--- a/src/crates/core/src/infrastructure/ai/client_factory.rs
+++ b/src/crates/core/src/infrastructure/ai/client_factory.rs
@@ -25,6 +25,15 @@ pub struct AIClientFactory {
 }
 
 impl AIClientFactory {
+    fn normalize_model_selector(model_id: &str) -> &str {
+        let trimmed = model_id.trim();
+        if trimmed.is_empty() || trimmed == "auto" || trimmed == "default" {
+            "primary"
+        } else {
+            trimmed
+        }
+    }
+
     fn resolve_model_reference_in_config(
         global_config: &crate::service::config::GlobalConfig,
         model_ref: &str,
@@ -83,6 +92,7 @@ impl AIClientFactory {
     pub async fn get_client_resolved(&self, model_id: &str) -> Result<Arc<AIClient>> {
         let global_config: crate::service::config::GlobalConfig =
             self.config_service.get_config(None).await?;
+        let model_id = Self::normalize_model_selector(model_id);
 
         let resolved_model_id = match model_id {
             "primary" => Self::resolve_model_selection_in_config(&global_config, "primary")
@@ -137,6 +147,7 @@ impl AIClientFactory {
     async fn get_or_create_client(&self, model_id: &str) -> Result<Arc<AIClient>> {
         let global_config: crate::service::config::GlobalConfig =
             self.config_service.get_config(None).await?;
+        let model_id = Self::normalize_model_selector(model_id);
         let normalized_model_id = match model_id {
             "primary" | "fast" => Self::resolve_model_selection_in_config(&global_config, model_id)
                 .unwrap_or_else(|| model_id.to_string()),
@@ -369,6 +380,20 @@ mod tests {
         assert_eq!(
             AIClientFactory::resolve_model_reference_in_config(&config, "claude-sonnet-4.5"),
             Some("model-123".to_string())
+        );
+    }
+
+    #[test]
+    fn auto_model_selectors_normalize_to_primary_for_client_lookup() {
+        assert_eq!(AIClientFactory::normalize_model_selector("auto"), "primary");
+        assert_eq!(
+            AIClientFactory::normalize_model_selector(" default "),
+            "primary"
+        );
+        assert_eq!(AIClientFactory::normalize_model_selector(""), "primary");
+        assert_eq!(
+            AIClientFactory::normalize_model_selector("model-primary"),
+            "model-primary"
         );
     }
 


### PR DESCRIPTION
## Summary
- PlaintextFollowup Write no longer echoes generated file bodies in tool results or persisted assistant tool calls; the runtime injects a synthetic Read after each generated Write so the next model round continues from normal Read output.
- Fail fast before slow Write content generation when Read is unavailable or unregistered, and align agent prompts plus tool-loop/truncation guidance to prefer Read + Edit over repeated Write on the same path.
- Resolve `auto`/`default` model selectors to primary (remove short first-turn fast-model shortcut) and track Write stats via `lines_written`.

## Test plan
- [x] `cargo test -p bitfun-core round_executor -- --nocapture`
- [ ] Manual PlaintextFollowup flow: Write(file_path) → content generation → Write execution → auto Read → Edit from Read result
- [ ] Confirm ACP/InlineContent Write path is unchanged (inline content still in tool call args)
- [ ] Confirm auto/default model selection resolves to primary model