### PR TITLE
perf(startup): defer editor and AI initialization

### DIFF
--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -2,11 +2,10 @@ import { useEffect, useCallback, useState, useRef } from 'react';
 import { useShortcut } from '@/infrastructure/hooks/useShortcut';
 import { useHasDismissibleLayer } from '@/infrastructure/hooks/useDismissibleLayer';
 import { dismissibleLayerManager } from '@/infrastructure/services/DismissibleLayerManager';
-import { ChatProvider, useAIInitialization } from '../infrastructure';
+import { ChatProvider } from '../infrastructure/contexts/ChatProvider';
 import { ViewModeProvider } from '../infrastructure/contexts/ViewModeProvider';
 import { SSHRemoteProvider } from '../features/ssh-remote';
 import AppLayout from './layout/AppLayout';
-import { useCurrentModelConfig } from '../hooks/useModelConfigs';
 import { ContextMenuRenderer } from '../shared/context-menu-system/components/ContextMenuRenderer';
 import { NotificationContainer, NotificationCenter, notificationService } from '../shared/notification-system';
 import { AnnouncementProvider } from '../shared/announcement-system';
@@ -45,9 +44,6 @@ const log = createLogger('App');
 const MIN_SPLASH_MS = 900;
 
 function App() {
-  // AI initialization
-  const { currentConfig } = useCurrentModelConfig();
-  const { isInitialized: aiInitialized, isInitializing: aiInitializing, error: aiError } = useAIInitialization(currentConfig);
   const { t } = useI18n('settings/basics');
 
   // Workspace loading state — drives splash exit timing
@@ -148,6 +144,9 @@ function App() {
     }
     interactiveShellReadyRef.current = true;
     startupTrace.markPhase('interactive_shell_ready');
+    window.dispatchEvent(new CustomEvent('bitfun:interactive-shell-ready', {
+      detail: { reason: 'workspace-ready' },
+    }));
     setInteractiveShellReady(true);
   }, [workspaceLoading]);
 
@@ -294,23 +293,6 @@ function App() {
       unlisten?.();
     };
   }, []);
-
-  // Observe AI initialization state
-  useEffect(() => {
-    if (aiError) {
-      log.error('AI initialization failed', aiError);
-    } else if (aiInitialized) {
-      log.debug('AI client initialized successfully');
-    } else if (!aiInitializing && !currentConfig) {
-      log.warn('AI not initialized: waiting for model config');
-    } else if (!aiInitializing && currentConfig && !currentConfig.apiKey) {
-      log.warn('AI not initialized: missing API key');
-    } else if (!aiInitializing && currentConfig && !currentConfig.modelName) {
-      log.warn('AI not initialized: missing model name');
-    } else if (!aiInitializing && currentConfig && !currentConfig.baseUrl) {
-      log.warn('AI not initialized: missing base URL');
-    }
-  }, [aiInitialized, aiInitializing, aiError, currentConfig]);
 
   // Block browser-native Ctrl+F (find bar) and Ctrl+R (hard reload).
   // On macOS the equivalent modifiers are Cmd+F / Cmd+R.

--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -45,6 +45,7 @@ const MIN_SPLASH_MS = 900;
 
 function App() {
   const { t } = useI18n('settings/basics');
+  const { t: tCommon } = useI18n('common');
 
   // Workspace loading state — drives splash exit timing
   const { loading: workspaceLoading } = useWorkspaceContext();
@@ -188,6 +189,38 @@ function App() {
 
     return () => startupSystemsHandle.cancel();
   }, [interactiveShellReady]);
+
+  useEffect(() => {
+    if (!interactiveShellReady || splashVisible) {
+      return;
+    }
+
+    let disposed = false;
+    let editorWarmupHandle: { promise: Promise<void>; cancel: () => void } | null = null;
+
+    void import('@/tools/editor/services/MonacoStartupWarmup')
+      .then(({ scheduleMonacoStartupWarmup }) => {
+        if (disposed) {
+          return;
+        }
+        editorWarmupHandle = scheduleMonacoStartupWarmup();
+        editorWarmupHandle.promise.catch(error => {
+          if (!disposed && !(error instanceof BackgroundTaskCancelledError)) {
+            log.warn('Editor startup warmup task failed', error);
+          }
+        });
+      })
+      .catch(error => {
+        if (!disposed) {
+          log.warn('Failed to schedule editor startup warmup', error);
+        }
+      });
+
+    return () => {
+      disposed = true;
+      editorWarmupHandle?.cancel();
+    };
+  }, [interactiveShellReady, splashVisible]);
 
   useEffect(() => {
     if (!isTauriRuntime() || !interactiveShellReady) return;
@@ -418,7 +451,11 @@ function App() {
 
             {/* Startup splash — sits above everything, exits once workspace is ready */}
             {splashVisible && (
-              <SplashScreen isExiting={splashExiting} onExited={handleSplashExited} />
+              <SplashScreen
+                isExiting={splashExiting}
+                onExited={handleSplashExited}
+                delayedMessage={workspaceLoading ? tCommon('loading.workspace') : undefined}
+              />
             )}
           </ToolbarModeProvider>
         </SSHRemoteProvider>

--- a/src/web-ui/src/app/components/SplashScreen/SplashScreen.scss
+++ b/src/web-ui/src/app/components/SplashScreen/SplashScreen.scss
@@ -37,8 +37,8 @@
   position: relative;
   z-index: 1;
   display: flex;
-  flex-direction: column;
   align-items: center;
+  justify-content: center;
 }
 
 // ── Logo ──────────────────────────────────────────────────────────────────────
@@ -57,6 +57,29 @@
   user-select: none;
   // Ensure proper rendering on Linux
   -webkit-user-select: none;
+}
+
+.splash-screen__message {
+  position: absolute;
+  top: calc(100% + #{$size-gap-4});
+  left: 50%;
+  min-width: 220px;
+  max-width: min(360px, calc(100vw - 48px));
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+  text-align: center;
+  opacity: 0;
+  transform: translate(-50%, -2px);
+  transition:
+    opacity $motion-base $easing-decelerate,
+    transform $motion-base $easing-decelerate;
+  pointer-events: none;
+}
+
+.splash-screen__message--visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 // ── Keyframes ─────────────────────────────────────────────────────────────────
@@ -84,6 +107,10 @@
 @media (prefers-reduced-motion: reduce) {
   .splash-screen__logo-wrap {
     animation: none;
+  }
+
+  .splash-screen__message {
+    transition: none;
   }
 
   .splash-screen--exiting {

--- a/src/web-ui/src/app/components/SplashScreen/SplashScreen.test.tsx
+++ b/src/web-ui/src/app/components/SplashScreen/SplashScreen.test.tsx
@@ -1,0 +1,103 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SplashScreen from './SplashScreen';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('SplashScreen', () => {
+  let dom: JSDOM;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    globalThis.window = dom.window as unknown as Window & typeof globalThis;
+    globalThis.document = dom.window.document;
+    container = document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    vi.useRealTimers();
+    dom.window.close();
+  });
+
+  it('reveals the workspace loading message only after the delay', () => {
+    act(() => {
+      root.render(
+        <SplashScreen
+          isExiting={false}
+          onExited={() => {}}
+          delayedMessage="Loading workspace..."
+          delayedMessageMs={1000}
+        />
+      );
+    });
+
+    const message = container.querySelector('.splash-screen__message');
+    expect(message?.textContent).toBe('Loading workspace...');
+    expect(message?.classList.contains('splash-screen__message--visible')).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(message?.classList.contains('splash-screen__message--visible')).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(message?.classList.contains('splash-screen__message--visible')).toBe(true);
+  });
+
+  it('does not reveal the workspace loading message during the normal startup splash window by default', () => {
+    act(() => {
+      root.render(
+        <SplashScreen
+          isExiting={false}
+          onExited={() => {}}
+          delayedMessage="Loading workspace..."
+        />
+      );
+    });
+
+    const message = container.querySelector('.splash-screen__message');
+    expect(message?.classList.contains('splash-screen__message--visible')).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1799);
+    });
+    expect(message?.classList.contains('splash-screen__message--visible')).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(message?.classList.contains('splash-screen__message--visible')).toBe(true);
+  });
+
+  it('does not show the delayed message while exiting', () => {
+    act(() => {
+      root.render(
+        <SplashScreen
+          isExiting={true}
+          onExited={() => {}}
+          delayedMessage="Loading workspace..."
+          delayedMessageMs={1000}
+        />
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    const message = container.querySelector('.splash-screen__message');
+    expect(message?.classList.contains('splash-screen__message--visible')).toBe(false);
+  });
+});

--- a/src/web-ui/src/app/components/SplashScreen/SplashScreen.tsx
+++ b/src/web-ui/src/app/components/SplashScreen/SplashScreen.tsx
@@ -5,18 +5,41 @@
  * Exiting: logo scales up and fades; backdrop dissolves.
  */
 
-import React, { useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 import './SplashScreen.scss';
+
+const DEFAULT_LOADING_MESSAGE_DELAY_MS = 1800;
 
 interface SplashScreenProps {
   isExiting: boolean;
   onExited: () => void;
+  delayedMessage?: string;
+  delayedMessageMs?: number;
 }
 
-const SplashScreen: React.FC<SplashScreenProps> = ({ isExiting, onExited }) => {
+const SplashScreen: React.FC<SplashScreenProps> = ({
+  isExiting,
+  onExited,
+  delayedMessage,
+  delayedMessageMs = DEFAULT_LOADING_MESSAGE_DELAY_MS,
+}) => {
+  const [showDelayedMessage, setShowDelayedMessage] = useState(false);
   const handleExited = useCallback(() => {
     onExited();
   }, [onExited]);
+
+  useEffect(() => {
+    setShowDelayedMessage(false);
+
+    if (!delayedMessage || isExiting) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setShowDelayedMessage(true);
+    }, delayedMessageMs);
+    return () => window.clearTimeout(timer);
+  }, [delayedMessage, delayedMessageMs, isExiting]);
 
   // Remove from DOM after exit animation completes (~650 ms).
   useEffect(() => {
@@ -28,7 +51,7 @@ const SplashScreen: React.FC<SplashScreenProps> = ({ isExiting, onExited }) => {
   return (
     <div
       className={`splash-screen${isExiting ? ' splash-screen--exiting' : ''}`}
-      aria-hidden="true"
+      aria-hidden={!showDelayedMessage}
     >
       <div className="splash-screen__center">
         <div className="splash-screen__logo-wrap">
@@ -39,6 +62,15 @@ const SplashScreen: React.FC<SplashScreenProps> = ({ isExiting, onExited }) => {
             draggable={false}
           />
         </div>
+        {delayedMessage && (
+          <div
+            className={`splash-screen__message${showDelayedMessage ? ' splash-screen__message--visible' : ''}`}
+            role="status"
+            aria-live="polite"
+          >
+            {delayedMessage}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/web-ui/src/app/components/panels/base/FlexiblePanel.tsx
+++ b/src/web-ui/src/app/components/panels/base/FlexiblePanel.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, memo } from 'react';
 import { Download, Copy, X, AlertCircle } from 'lucide-react';
 import { MarkdownRenderer, IconButton } from '@/component-library';
-import { CodeEditor, MarkdownEditor, ImageViewer, DiffEditor } from '@/tools/editor';
 import { useI18n } from '@/infrastructure/i18n';
 import { createLogger } from '@/shared/utils/logger';
 import { globalEventBus } from '@/infrastructure/event-bus';
@@ -46,8 +45,35 @@ const GitSettingsView = React.lazy(() =>
   import('@/tools/git/components/GitSettingsView/GitSettingsView')
 );
 
-// Directly imported (not lazy-loaded) to avoid loading delay in frequently used Git panel
-import { GitDiffEditor } from '@/tools/git/components/GitDiffEditor/GitDiffEditor';
+const CodeEditor = React.lazy(() =>
+  import('@/tools/editor/components/CodeEditor').then(module => ({
+    default: module.default,
+  }))
+);
+
+const MarkdownEditor = React.lazy(() =>
+  import('@/tools/editor/components/MarkdownEditor').then(module => ({
+    default: module.default,
+  }))
+);
+
+const ImageViewer = React.lazy(() =>
+  import('@/tools/editor/components/ImageViewer').then(module => ({
+    default: module.default,
+  }))
+);
+
+const DiffEditor = React.lazy(() =>
+  import('@/tools/editor/components/DiffEditor').then(module => ({
+    default: module.default,
+  }))
+);
+
+const GitDiffEditor = React.lazy(() =>
+  import('@/tools/git/components/GitDiffEditor/GitDiffEditor').then(module => ({
+    default: module.default,
+  }))
+);
 
 const GitGraphView = React.lazy(() => 
   import('@/tools/git/components/GitGraphView/GitGraphView').then(module => ({ 
@@ -216,6 +242,18 @@ const FlexiblePanel: React.FC<ExtendedFlexiblePanelProps> = memo(({
     URL.revokeObjectURL(url);
   }, [content]);
 
+  const renderEditorLoading = () => (
+    <div className="bitfun-flexible-panel__loading">
+      {t('select.loading')}
+    </div>
+  );
+
+  const renderLazyEditor = (node: React.ReactNode) => (
+    <React.Suspense fallback={renderEditorLoading()}>
+      {node}
+    </React.Suspense>
+  );
+
   const renderContent = () => {
     if (!content || content.type === 'empty') {
       return (
@@ -260,27 +298,29 @@ const FlexiblePanel: React.FC<ExtendedFlexiblePanelProps> = memo(({
         return (
           <div className="bitfun-flexible-panel__markdown-editor">
             {markdownFilePath || markdownInitialContent !== undefined ? (
-              <MarkdownEditor
-                filePath={markdownFilePath}
-                initialContent={markdownInitialContent}
-                fileName={markdownFileName}
-                workspacePath={markdownWorkspacePath}
-                readOnly={markdownEditorData.readOnly || false}
-                jumpToLine={markdownJumpToLine}
-                jumpToColumn={markdownJumpToColumn}
-                isActiveTab={isActive}
-                onFileMissingFromDiskChange={onFileMissingFromDiskChange}
-                onContentChange={(_newContent, hasChanges) => {
-                  if (onDirtyStateChange) {
-                    onDirtyStateChange(hasChanges);
-                  }
-                }}
-                onSave={(_savedContent) => {
-                  if (onDirtyStateChange) {
-                    onDirtyStateChange(false);
-                  }
-                }}
-              />
+              renderLazyEditor(
+                <MarkdownEditor
+                  filePath={markdownFilePath}
+                  initialContent={markdownInitialContent}
+                  fileName={markdownFileName}
+                  workspacePath={markdownWorkspacePath}
+                  readOnly={markdownEditorData.readOnly || false}
+                  jumpToLine={markdownJumpToLine}
+                  jumpToColumn={markdownJumpToColumn}
+                  isActiveTab={isActive}
+                  onFileMissingFromDiskChange={onFileMissingFromDiskChange}
+                  onContentChange={(_newContent, hasChanges) => {
+                    if (onDirtyStateChange) {
+                      onDirtyStateChange(hasChanges);
+                    }
+                  }}
+                  onSave={(_savedContent) => {
+                    if (onDirtyStateChange) {
+                      onDirtyStateChange(false);
+                    }
+                  }}
+                />
+              )
             ) : (
               <div className="bitfun-flexible-panel__error-message">
                 <AlertCircle size={20} />
@@ -306,17 +346,19 @@ const FlexiblePanel: React.FC<ExtendedFlexiblePanelProps> = memo(({
         
         return (
           <div className="bitfun-flexible-panel__code-viewer-container">
-            <CodeEditor
-              filePath={fileViewerData.filePath || ''}
-              fileName={content.title}
-              readOnly={true}
-              showLineNumbers={true}
-              showMinimap={true}
-              theme="vs-dark"
-              className={fileViewerClass}
-              isActiveTab={isActive}
-              onFileMissingFromDiskChange={onFileMissingFromDiskChange}
-            />
+            {renderLazyEditor(
+              <CodeEditor
+                filePath={fileViewerData.filePath || ''}
+                fileName={content.title}
+                readOnly={true}
+                showLineNumbers={true}
+                showMinimap={true}
+                theme="vs-dark"
+                className={fileViewerClass}
+                isActiveTab={isActive}
+                onFileMissingFromDiskChange={onFileMissingFromDiskChange}
+              />
+            )}
           </div>
         );
       }
@@ -326,12 +368,14 @@ const FlexiblePanel: React.FC<ExtendedFlexiblePanelProps> = memo(({
         
         return (
           <div className="bitfun-flexible-panel__image-viewer-container">
-            <ImageViewer
-              filePath={imageViewerData.filePath || ''}
-              fileName={content.title}
-              workspacePath={workspacePath}
-              className="bitfun-flexible-panel__image-viewer"
-            />
+            {renderLazyEditor(
+              <ImageViewer
+                filePath={imageViewerData.filePath || ''}
+                fileName={content.title}
+                workspacePath={workspacePath}
+                className="bitfun-flexible-panel__image-viewer"
+              />
+            )}
           </div>
         );
       }
@@ -344,18 +388,20 @@ const FlexiblePanel: React.FC<ExtendedFlexiblePanelProps> = memo(({
         return (
           <div className="bitfun-flexible-panel__code-viewer-container">
             <div className={`bitfun-flexible-panel__code-content ${needsFix ? 'needs-fix' : ''}`}>
-              <CodeEditor
-                filePath={codeData.filePath || ''}
-                fileName={codeData.fileName}
-                language={codeData.language || 'typescript'}
-                readOnly={codeData.readOnly !== false}
-                showLineNumbers={true}
-                showMinimap={true}
-                theme="vs-dark"
-                onContentChange={codeData.onContentChange}
-                isActiveTab={isActive}
-                onFileMissingFromDiskChange={onFileMissingFromDiskChange}
-              />
+              {renderLazyEditor(
+                <CodeEditor
+                  filePath={codeData.filePath || ''}
+                  fileName={codeData.fileName}
+                  language={codeData.language || 'typescript'}
+                  readOnly={codeData.readOnly !== false}
+                  showLineNumbers={true}
+                  showMinimap={true}
+                  theme="vs-dark"
+                  onContentChange={codeData.onContentChange}
+                  isActiveTab={isActive}
+                  onFileMissingFromDiskChange={onFileMissingFromDiskChange}
+                />
+              )}
             </div>
           </div>
         );
@@ -430,7 +476,7 @@ const FlexiblePanel: React.FC<ExtendedFlexiblePanelProps> = memo(({
           }
         };
 
-        return (
+        return renderLazyEditor(
           <CodeEditor
             filePath={filePath}
             workspacePath={editorWorkspacePath}
@@ -449,34 +495,34 @@ const FlexiblePanel: React.FC<ExtendedFlexiblePanelProps> = memo(({
             isActiveTab={isActive}
             onFileMissingFromDiskChange={onFileMissingFromDiskChange}
             onContentChange={(newContent, hasChanges) => {
-                if (onContentChange) {
-                  onContentChange({
-                    ...content,
-                    data: {
-                      ...editorData,
-                      content: newContent,
-                      hasChanges
-                    }
-                  });
-                }
-                
-                if (onDirtyStateChange) {
-                  onDirtyStateChange(hasChanges);
-                }
+              if (onContentChange) {
+                onContentChange({
+                  ...content,
+                  data: {
+                    ...editorData,
+                    content: newContent,
+                    hasChanges
+                  }
+                });
+              }
 
-                void syncGenerativeWidgetToolResult(newContent, false);
-              }}
-              onSave={(content) => {
-                if (onInteraction) {
-                  onInteraction('save', JSON.stringify({ filePath, content }));
-                }
-                
-                if (onDirtyStateChange) {
-                  onDirtyStateChange(false);
-                }
+              if (onDirtyStateChange) {
+                onDirtyStateChange(hasChanges);
+              }
 
-                void syncGenerativeWidgetToolResult(content, true);
-              }}
+              void syncGenerativeWidgetToolResult(newContent, false);
+            }}
+            onSave={(content) => {
+              if (onInteraction) {
+                onInteraction('save', JSON.stringify({ filePath, content }));
+              }
+
+              if (onDirtyStateChange) {
+                onDirtyStateChange(false);
+              }
+
+              void syncGenerativeWidgetToolResult(content, true);
+            }}
           />
         );
       }
@@ -492,7 +538,7 @@ const FlexiblePanel: React.FC<ExtendedFlexiblePanelProps> = memo(({
         const diffViewerKey = `diff-${diffFilePath || 'unknown'}-${originalCode.length}-${modifiedCode.length}`;
         
         if (diffRepositoryPath && diffFilePath) {
-          return (
+          return renderLazyEditor(
             <GitDiffEditor
               key={diffViewerKey}
               originalContent={originalCode}
@@ -526,7 +572,7 @@ const FlexiblePanel: React.FC<ExtendedFlexiblePanelProps> = memo(({
           );
         }
         
-        return (
+        return renderLazyEditor(
           <DiffEditor
             key={diffViewerKey}
             originalContent={originalCode}

--- a/src/web-ui/src/app/scenes/shell/ShellNav.tsx
+++ b/src/web-ui/src/app/scenes/shell/ShellNav.tsx
@@ -12,7 +12,7 @@ import { useI18n } from '@/infrastructure/i18n';
 import { configManager } from '@/infrastructure/config/services/ConfigManager';
 import type { TerminalConfig } from '@/infrastructure/config/types';
 import TerminalEditModal from '@/app/components/panels/TerminalEditModal';
-import { useContextMenuStore } from '@/shared/context-menu-system';
+import { useContextMenuStore } from '@/shared/context-menu-system/store/ContextMenuStore';
 import { ContextType } from '@/shared/context-menu-system/types/context.types';
 import type { MenuItem } from '@/shared/context-menu-system/types/menu.types';
 import { useSceneStore } from '@/app/stores/sceneStore';

--- a/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
+++ b/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+function readSource(relativePath: string): string {
+  return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+}
+
+describe('startup performance contract', () => {
+  it('keeps editor and tool infrastructure out of the first startup module', () => {
+    const source = readSource('../../main.tsx');
+
+    expect(source).not.toMatch(/import\s+['"]monaco-editor\/min\/vs\/editor\/editor\.main\.css['"]/);
+    expect(source).not.toMatch(/from\s+['"]@monaco-editor\/react['"]/);
+    expect(source).not.toMatch(/from\s+['"]\.\/tools\/initializeTools['"]/);
+    expect(source).not.toMatch(/from\s+['"]\.\/shared\/context-menu-system['"]/);
+
+    expect(source).toContain("import('./tools/initializeTools')");
+    expect(source).toContain("import('./shared/context-menu-system')");
+  });
+
+  it('starts non-critical work after the shell is interactive', () => {
+    const source = readSource('../../main.tsx');
+
+    expect(source).toContain("signalName: 'bitfun:interactive-shell-ready'");
+    expect(source).not.toContain("signalName: 'bitfun:main-window-shown'");
+    expect(source).toContain('fallbackTimeoutMs: 10000');
+  });
+
+  it('does not initialize AI from the root app component', () => {
+    const source = readSource('../App.tsx');
+
+    expect(source).not.toMatch(/from\s+['"]\.\.\/infrastructure['"]/);
+    expect(source).not.toMatch(/useAIInitialization/);
+    expect(source).not.toMatch(/useCurrentModelConfig/);
+    expect(source).toContain('bitfun:interactive-shell-ready');
+  });
+
+  it('loads Monaco styling and loader config only through editor initialization', () => {
+    const source = readSource('../../tools/editor/services/MonacoInitManager.ts');
+
+    expect(source).toContain("import('monaco-editor/min/vs/editor/editor.main.css')");
+    expect(source).toContain('loader.config');
+    expect(source).toContain('MonacoEnvironment');
+  });
+
+  it('keeps editor panel implementations lazy from the session shell', () => {
+    const source = readSource('../components/panels/base/FlexiblePanel.tsx');
+    const componentLibraryBarrel = readSource('../../component-library/components/index.ts');
+
+    expect(source).not.toMatch(/from\s+['"]@\/tools\/editor['"]/);
+    expect(source).not.toMatch(/from\s+['"]@\/tools\/git\/components\/GitDiffEditor\/GitDiffEditor['"]/);
+    expect(source).toContain("import('@/tools/editor/components/CodeEditor')");
+    expect(source).toContain("import('@/tools/editor/components/DiffEditor')");
+    expect(source).toContain("import('@/tools/git/components/GitDiffEditor/GitDiffEditor')");
+    expect(source).toContain('renderLazyEditor(');
+    expect(componentLibraryBarrel).not.toMatch(/CodeEditor/);
+  });
+
+  it('keeps theme startup from importing the Monaco runtime', () => {
+    const source = readSource('../../infrastructure/theme/integrations/MonacoThemeSync.ts');
+
+    expect(source).not.toMatch(/import\s+\*\s+as\s+monaco\s+from\s+['"]monaco-editor['"]/);
+    expect(source).toMatch(/import\s+type\s+\*\s+as\s+Monaco\s+from\s+['"]monaco-editor['"]/);
+    expect(source).toContain('attachMonaco');
+  });
+
+  it('does not import Monaco runtime from shared edit-target services', () => {
+    const source = readSource('../../tools/editor/services/ActiveEditTargetService.ts');
+
+    expect(source).not.toMatch(/import\s+\*\s+as\s+monaco\s+from\s+['"]monaco-editor['"]/);
+    expect(source).toMatch(/import\s+type\s+\*\s+as\s+monaco\s+from\s+['"]monaco-editor['"]/);
+  });
+
+  it('uses narrow context-menu imports from startup-visible modules', () => {
+    const sources = [
+      '../../app/scenes/shell/ShellNav.tsx',
+      '../../component-library/components/Markdown/Markdown.tsx',
+      '../../flow_chat/tool-cards/GenerativeWidgetToolCard.tsx',
+      '../../tools/file-system/components/FileSearchResults.tsx',
+      '../../tools/generative-widget/useGenerativeWidgetPromptMenu.ts',
+      '../../shared/notification-system/providers/NotificationContextMenuProvider.ts',
+    ].map(readSource);
+
+    for (const source of sources) {
+      expect(source).not.toMatch(/from\s+['"]@\/shared\/context-menu-system['"]/);
+    }
+  });
+
+  it('avoids the infrastructure barrel from startup-visible modules', () => {
+    const sources = [
+      '../../flow_chat/components/ChatInput.tsx',
+      '../../tools/git/services/GitEventService.ts',
+    ].map(readSource);
+
+    for (const source of sources) {
+      expect(source).not.toMatch(/from\s+['"]@\/infrastructure['"]/);
+      expect(source).not.toMatch(/from\s+['"]\.\.\/\.\.\/\.\.\/infrastructure['"]/);
+    }
+  });
+});

--- a/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
+++ b/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
@@ -72,6 +72,21 @@ describe('startup performance contract', () => {
     expect(source).toMatch(/import\s+type\s+\*\s+as\s+monaco\s+from\s+['"]monaco-editor['"]/);
   });
 
+  it('prewarms editor runtime only after the shell is interactive', () => {
+    const source = readSource('../App.tsx');
+
+    expect(source).toContain('interactiveShellReady');
+    expect(source).toContain("import('@/tools/editor/services/MonacoStartupWarmup')");
+    expect(source).toContain('scheduleMonacoStartupWarmup()');
+  });
+
+  it('keeps Git diff editor from importing the broad editor barrel', () => {
+    const source = readSource('../../tools/git/components/GitDiffEditor/GitDiffEditor.tsx');
+
+    expect(source).not.toMatch(/from\s+['"]@\/tools\/editor['"]/);
+    expect(source).toContain("from '@/tools/editor/components/DiffEditor'");
+  });
+
   it('uses narrow context-menu imports from startup-visible modules', () => {
     const sources = [
       '../../app/scenes/shell/ShellNav.tsx',

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
@@ -20,7 +20,7 @@ import { Tooltip } from '../Tooltip';
 import { globalAPI, systemAPI, workspaceAPI } from '../../../infrastructure/api';
 import { getPrismLanguageFromAlias } from '@/infrastructure/language-detection';
 import { useTheme } from '@/infrastructure/theme';
-import { contextMenuController } from '@/shared/context-menu-system';
+import { contextMenuController } from '@/shared/context-menu-system/core/ContextMenuController';
 import { ContextType, type CustomContext, type MenuItem } from '@/shared/context-menu-system/types';
 import { createLogger } from '@/shared/utils/logger';
 import path from 'path-browserify';
@@ -239,7 +239,7 @@ function normalizeFileLikeHref(rawHref: string): string {
     }
   }
 
-  // Normalize paths like /C:/Users/... from URI forms to Windows absolute paths.
+  // Normalize URI-style Windows drive paths to native absolute paths.
   if (/^\/[A-Za-z]:[\\/]/.test(filePath)) {
     filePath = filePath.slice(1);
   }

--- a/src/web-ui/src/component-library/components/index.ts
+++ b/src/web-ui/src/component-library/components/index.ts
@@ -34,8 +34,6 @@ export * from './Card';
 export * from './FilterPill';
 export * from './ConfigPage';
 
-export * from './CodeEditor';
-
 export * from './StreamText';
 export * from './TextStrokeEffect';
 export * from './CubeLogo';

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -11,7 +11,7 @@ import { ContextDropZone, useContextStore } from '../../shared/context-system';
 import { useActiveSessionState } from '@/flow_chat/hooks';
 import { RichTextInput, type MentionState } from './RichTextInput';
 import { FileMentionPicker } from './FileMentionPicker';
-import { globalEventBus } from '@/infrastructure';
+import { globalEventBus } from '@/infrastructure/event-bus';
 import {
   useSessionDerivedState,
   useSessionStateMachine,

--- a/src/web-ui/src/flow_chat/tool-cards/GenerativeWidgetToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GenerativeWidgetToolCard.tsx
@@ -11,7 +11,7 @@ import GenerativeWidgetFrame, {
 import GenerativeWidgetStaticRenderer from '@/tools/generative-widget/GenerativeWidgetStaticRenderer';
 import { handleWidgetBridgeEvent } from '@/tools/generative-widget/widgetInteraction';
 import { useGenerativeWidgetPromptMenu } from '@/tools/generative-widget/useGenerativeWidgetPromptMenu';
-import { useContextMenuStore } from '@/shared/context-menu-system';
+import { useContextMenuStore } from '@/shared/context-menu-system/store/ContextMenuStore';
 import { captureElementToDownloadsPng } from '../utils/captureElementToDownloadsPng';
 import { createLogger } from '@/shared/utils/logger';
 import { notificationService } from '@/shared/notification-system';

--- a/src/web-ui/src/infrastructure/theme/integrations/MonacoThemeSync.test.ts
+++ b/src/web-ui/src/infrastructure/theme/integrations/MonacoThemeSync.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { bitfunDarkTheme } from '../presets/dark-theme';
+import { MonacoThemeSync } from './MonacoThemeSync';
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function createMonacoStub() {
+  const defineTheme = vi.fn();
+  const setTheme = vi.fn();
+  const getEditors = vi.fn(() => []);
+
+  return {
+    monaco: {
+      editor: {
+        defineTheme,
+        setTheme,
+        getEditors,
+      },
+    },
+    defineTheme,
+    setTheme,
+  };
+}
+
+describe('MonacoThemeSync deferred runtime behavior', () => {
+  it('keeps custom theme registrations until Monaco runtime is attached', () => {
+    const sync = new MonacoThemeSync();
+    const queuedTheme = {
+      ...bitfunDarkTheme,
+      id: 'queued-theme',
+      name: 'Queued theme',
+    };
+    const { monaco, defineTheme } = createMonacoStub();
+
+    sync.registerTheme(queuedTheme.id, queuedTheme);
+    expect(defineTheme).not.toHaveBeenCalled();
+
+    sync.attachMonaco(monaco as never);
+
+    expect(defineTheme).toHaveBeenCalledWith(
+      queuedTheme.id,
+      expect.objectContaining({
+        base: queuedTheme.monaco?.base,
+        inherit: queuedTheme.monaco?.inherit,
+      }),
+    );
+  });
+});

--- a/src/web-ui/src/infrastructure/theme/integrations/MonacoThemeSync.ts
+++ b/src/web-ui/src/infrastructure/theme/integrations/MonacoThemeSync.ts
@@ -1,6 +1,6 @@
  
 
-import * as monaco from 'monaco-editor';
+import type * as Monaco from 'monaco-editor';
 import { ThemeConfig } from '../types';
 import { BitFunDarkTheme } from '@/tools/editor/themes/bitfun-dark.theme';
 import { createLogger } from '@/shared/utils/logger';
@@ -10,7 +10,7 @@ const log = createLogger('MonacoThemeSync');
 
 const SEMANTIC_HIGHLIGHTING_RULES = BitFunDarkTheme.rules;
 
-function getBitfunLightMonacoTheme(): monaco.editor.IStandaloneThemeData {
+function getBitfunLightMonacoTheme(): Monaco.editor.IStandaloneThemeData {
   return {
     base: 'vs',
     inherit: true,
@@ -73,56 +73,92 @@ function convertColorsToHex(colors: Record<string, string>): Record<string, stri
 export class MonacoThemeSync {
   private initialized = false;
   private currentThemeId: string | null = null;
+  private monacoInstance: typeof Monaco | null = null;
+  private pendingTheme: ThemeConfig | null = null;
+  private pendingRegisteredThemes = new Map<string, ThemeConfig>();
   
-   
   async initialize(): Promise<void> {
     if (this.initialized) {
       return;
     }
-    
-    
-    try {
-      monaco.editor.defineTheme('bitfun-dark', BitFunDarkTheme);
-      log.debug('BitFun Dark theme registered');
-      this.initialized = true;
-    } catch (error) {
-      log.warn('Monaco Editor not loaded yet, will retry later', error);
+
+    this.initialized = true;
+    if (this.monacoInstance) {
+      this.ensureBuiltinThemes(this.monacoInstance);
     }
   }
   
-   
-  syncTheme(theme: ThemeConfig): void {
+  syncTheme(theme: ThemeConfig): string {
+    this.pendingTheme = theme;
+    const targetThemeId = this.getTargetMonacoThemeId(theme);
+
+    if (!this.monacoInstance) {
+      log.debug('Monaco runtime not loaded; theme sync deferred', { themeId: targetThemeId });
+      return targetThemeId;
+    }
+
+    this.applyTheme(this.monacoInstance, theme, targetThemeId);
+    return targetThemeId;
+  }
+
+  attachMonaco(monacoInstance: typeof Monaco, theme?: ThemeConfig): string {
+    this.monacoInstance = monacoInstance;
+    this.initialized = true;
+    this.ensureBuiltinThemes(monacoInstance);
+    this.flushPendingRegisteredThemes(monacoInstance);
+
+    const activeTheme = theme ?? this.pendingTheme;
+    if (!activeTheme) {
+      return this.currentThemeId ?? 'bitfun-dark';
+    }
+
+    const targetThemeId = this.getTargetMonacoThemeId(activeTheme);
+    this.applyTheme(monacoInstance, activeTheme, targetThemeId);
+    return targetThemeId;
+  }
+
+  private ensureBuiltinThemes(monacoInstance: typeof Monaco): void {
     try {
-      let targetThemeId: string;
+      monacoInstance.editor.defineTheme('bitfun-dark', BitFunDarkTheme);
+      monacoInstance.editor.defineTheme('bitfun-light', getBitfunLightMonacoTheme());
+      log.debug('BitFun Monaco themes registered');
+    } catch (error) {
+      log.warn('Failed to register BitFun Monaco themes', error);
+    }
+  }
 
-      if (theme.monaco) {
-        targetThemeId = theme.id;
-      } else {
-        if (theme.type === 'dark') {
-          targetThemeId = 'bitfun-dark';
-        } else {
-          targetThemeId = 'bitfun-light';
-        }
-      }
+  private flushPendingRegisteredThemes(monacoInstance: typeof Monaco): void {
+    if (this.pendingRegisteredThemes.size === 0) {
+      return;
+    }
 
+    for (const [themeId, theme] of this.pendingRegisteredThemes) {
+      this.defineTheme(monacoInstance, themeId, theme);
+    }
+    this.pendingRegisteredThemes.clear();
+  }
+
+  private applyTheme(
+    monacoInstance: typeof Monaco,
+    theme: ThemeConfig,
+    targetThemeId: string,
+  ): void {
+    try {
       if (this.currentThemeId === targetThemeId) {
         return;
       }
 
       if (theme.monaco) {
         const monacoTheme = this.convertToMonacoTheme(theme);
-        monaco.editor.defineTheme(theme.id, monacoTheme);
+        monacoInstance.editor.defineTheme(theme.id, monacoTheme);
         log.debug('Custom theme registered', { themeId: theme.id, themeName: theme.name });
       } else {
-        if (theme.type === 'light') {
-          monaco.editor.defineTheme('bitfun-light', getBitfunLightMonacoTheme());
-        }
         log.debug('Using builtin theme', { themeId: targetThemeId });
       }
 
-      monaco.editor.setTheme(targetThemeId);
+      monacoInstance.editor.setTheme(targetThemeId);
 
-      const editors = monaco.editor.getEditors();
+      const editors = monacoInstance.editor.getEditors();
       if (editors && editors.length > 0) {
         log.debug('Refreshing editor instances', { count: editors.length });
         editors.forEach((editor, index) => {
@@ -137,9 +173,11 @@ export class MonacoThemeSync {
       this.currentThemeId = targetThemeId;
       log.info('Theme switched successfully', { themeName: theme.name, themeId: targetThemeId });
 
-      window.dispatchEvent(new CustomEvent('monaco-theme-changed', {
-        detail: { themeId: targetThemeId, theme }
-      }));
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('monaco-theme-changed', {
+          detail: { themeId: targetThemeId, theme }
+        }));
+      }
     } catch (error) {
       log.error('Failed to sync theme', error);
     }
@@ -166,16 +204,9 @@ export class MonacoThemeSync {
    * Use from the Monaco React wrapper `beforeMount` hook so themes exist on the loader's Monaco
    * before the editor is created (avoids falling back to the default light theme).
    */
-  registerThemesForEditorInstance(monacoInstance: typeof monaco, theme: ThemeConfig): string {
+  registerThemesForEditorInstance(monacoInstance: typeof Monaco, theme: ThemeConfig): string {
     try {
-      monacoInstance.editor.defineTheme('bitfun-dark', BitFunDarkTheme);
-      monacoInstance.editor.defineTheme('bitfun-light', getBitfunLightMonacoTheme());
-
-      if (theme.monaco) {
-        monacoInstance.editor.defineTheme(theme.id, this.convertToMonacoTheme(theme));
-        return theme.id;
-      }
-      return this.getTargetMonacoThemeId(theme);
+      return this.attachMonaco(monacoInstance, theme);
     } catch (error) {
       log.error('registerThemesForEditorInstance failed', error);
       return 'bitfun-dark';
@@ -183,7 +214,7 @@ export class MonacoThemeSync {
   }
   
    
-  private convertToMonacoTheme(theme: ThemeConfig): monaco.editor.IStandaloneThemeData {
+  private convertToMonacoTheme(theme: ThemeConfig): Monaco.editor.IStandaloneThemeData {
     const { monaco: monacoConfig, colors } = theme;
     if (!monacoConfig) {
       
@@ -214,7 +245,7 @@ export class MonacoThemeSync {
       : SEMANTIC_HIGHLIGHTING_RULES;
     
     
-    const themeData: monaco.editor.IStandaloneThemeData = {
+    const themeData: Monaco.editor.IStandaloneThemeData = {
       base: monacoConfig.base,
       inherit: monacoConfig.inherit,
       rules: themeRules,
@@ -333,12 +364,21 @@ export class MonacoThemeSync {
    
   registerTheme(themeId: string, theme: ThemeConfig): void {
     try {
-      const monacoTheme = this.convertToMonacoTheme(theme);
-      monaco.editor.defineTheme(themeId, monacoTheme);
-      log.debug('Theme registered', { themeId });
+      if (!this.monacoInstance) {
+        this.pendingRegisteredThemes.set(themeId, theme);
+        log.debug('Monaco runtime not loaded; custom theme registration deferred', { themeId });
+        return;
+      }
+      this.defineTheme(this.monacoInstance, themeId, theme);
     } catch (error) {
       log.error('Failed to register theme', { themeId, error });
     }
+  }
+
+  private defineTheme(monacoInstance: typeof Monaco, themeId: string, theme: ThemeConfig): void {
+    const monacoTheme = this.convertToMonacoTheme(theme);
+    monacoInstance.editor.defineTheme(themeId, monacoTheme);
+    log.debug('Theme registered', { themeId });
   }
 }
 

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -904,7 +904,8 @@
     "panelView": "Panel View"
   },
   "loading": {
-    "scenes": "Loading scene"
+    "scenes": "Loading scene",
+    "workspace": "Loading workspace..."
   },
   "welcomeScene": {
     "tabLabel": "Welcome",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -904,7 +904,8 @@
     "panelView": "面板视图"
   },
   "loading": {
-    "scenes": "正在加载场景"
+    "scenes": "正在加载场景",
+    "workspace": "正在加载工作区..."
   },
   "welcomeScene": {
     "tabLabel": "欢迎使用",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -904,7 +904,8 @@
     "panelView": "面板視圖"
   },
   "loading": {
-    "scenes": "正在加載場景"
+    "scenes": "正在加載場景",
+    "workspace": "正在加載工作區..."
   },
   "welcomeScene": {
     "tabLabel": "歡迎使用",

--- a/src/web-ui/src/main.tsx
+++ b/src/web-ui/src/main.tsx
@@ -5,17 +5,9 @@ import AppErrorBoundary from "./app/components/AppErrorBoundary";
 import { WorkspaceProvider } from "./infrastructure/contexts/WorkspaceProvider";
 import "./app/styles/index.scss";
 
-// Manually import Monaco Editor CSS.
-// This ensures the CSS loads correctly in Tauri production.
-import 'monaco-editor/min/vs/editor/editor.main.css';
-
 // Font: Noto Sans SC is loaded via a <link> tag in index.html.
 // File path: public/fonts/fonts.css, served as /fonts/fonts.css.
 
-import { initializeAllTools } from "./tools/initializeTools";
-import { initContextMenuSystem } from "./shared/context-menu-system";
-import { loader } from '@monaco-editor/react';
-import { getMonacoPath, getMonacoWorkerPath, logMonacoResourceCheck } from './tools/editor/utils/monacoPathHelper';
 import { bootstrapLogger, createLogger, initLogger } from './shared/utils/logger';
 import { elapsedMs, logElapsed, measureAsyncAndLog, nowMs } from './shared/utils/timing';
 import { startupTrace } from './shared/utils/startupTrace';
@@ -181,53 +173,6 @@ document.addEventListener(
   true
 );
 
-// Configure Monaco Editor loader - use local files (offline-ready).
-const isDev = import.meta.env.DEV;
-const monacoPath = getMonacoPath();
-
-loader.config({
-  paths: {
-    vs: monacoPath
-  }
-});
-
-// Debug: check resource availability in production.
-if (!isDev) {
-  // Delay checks to avoid blocking startup.
-  setTimeout(() => {
-    logMonacoResourceCheck().catch(err => {
-      log.error('Monaco resource check failed', err);
-    });
-  }, 2000);
-}
-
-// Optimization: Monaco Editor worker mapping.
-const MONACO_WORKER_MAP: Record<string, string> = {
-  json: 'language/json/jsonWorker.js',
-  css: 'language/css/cssWorker.js',
-  scss: 'language/css/cssWorker.js',
-  less: 'language/css/cssWorker.js',
-  html: 'language/html/htmlWorker.js',
-  handlebars: 'language/html/htmlWorker.js',
-  razor: 'language/html/htmlWorker.js',
-  typescript: 'language/typescript/tsWorker.js',
-  javascript: 'language/typescript/tsWorker.js',
-};
-
-const DEFAULT_WORKER = 'base/worker/workerMain.js';
-
-(window as any).MonacoEnvironment = {
-  getWorker(_workerId: string, label: string) {
-    const workerFile = MONACO_WORKER_MAP[label] || DEFAULT_WORKER;
-    const workerPath = getMonacoWorkerPath(workerFile);
-    
-    return new Worker(workerPath, {
-      type: 'classic',
-      name: `monaco-${label}-worker`
-    });
-  }
-};
-
 /** Logger, theme, and minimal deps — must finish before first React paint (F5 / webview reload does not re-run Tauri init script). */
 async function initializeBeforeRender(): Promise<void> {
   const phaseStartedAt = nowMs();
@@ -243,7 +188,6 @@ async function initializeBeforeRender(): Promise<void> {
     data: { step: 'initializeFrontendLogLevelSync' },
   });
 
-  log.debug('Monaco loader configured', { vs: monacoPath, isDev });
   log.info('Initializing BitFun');
 
   await measureAsyncAndLog(log, 'Startup step completed', async () => {
@@ -261,7 +205,7 @@ async function initializeBeforeRender(): Promise<void> {
   });
 }
 
-/** Rest of startup runs after the shell is visible so refresh latency stays reasonable. */
+/** Rest of startup runs after the shell is interactive so first-screen latency stays reasonable. */
 async function initializeAfterRender(): Promise<void> {
   const phaseStartedAt = nowMs();
   startupTrace.markPhase('after_render_start');
@@ -294,8 +238,12 @@ async function initializeAfterRender(): Promise<void> {
       const { initRecommendationProviders } = await import('./flow_chat/components/smart-recommendations');
       initRecommendationProviders();
     })(),
-    initializeAllTools(),
     (async () => {
+      const { initializeAllTools } = await import('./tools/initializeTools');
+      await initializeAllTools();
+    })(),
+    (async () => {
+      const { initContextMenuSystem } = await import('./shared/context-menu-system');
       initContextMenuSystem({
         registerBuiltinCommands: true,
         registerBuiltinProviders: true,
@@ -392,8 +340,8 @@ async function startApplication(): Promise<void> {
   });
 
   startupTrace.markPhase('non_critical_init_scheduled', {
-    signalName: 'bitfun:main-window-shown',
-    fallbackTimeoutMs: 2000,
+    signalName: 'bitfun:interactive-shell-ready',
+    fallbackTimeoutMs: 10000,
     frameCount: 1,
   });
   scheduleAfterStartupSignal(async () => {
@@ -411,8 +359,8 @@ async function startApplication(): Promise<void> {
       });
     }
   }, {
-    signalName: 'bitfun:main-window-shown',
-    fallbackTimeoutMs: 2000,
+    signalName: 'bitfun:interactive-shell-ready',
+    fallbackTimeoutMs: 10000,
     frameCount: 1,
     onError: error => {
       log.error('Failed to schedule post-render initialization', error);

--- a/src/web-ui/src/shared/notification-system/providers/NotificationContextMenuProvider.ts
+++ b/src/web-ui/src/shared/notification-system/providers/NotificationContextMenuProvider.ts
@@ -1,6 +1,6 @@
  
 
-import { contextMenuRegistry } from '@/shared/context-menu-system';
+import { contextMenuRegistry } from '@/shared/context-menu-system/core/ContextMenuRegistry';
 import type { MenuContext, MenuItem } from '@/shared/context-menu-system/types';
 import { i18nService } from '@/infrastructure/i18n';
 import { createLogger } from '@/shared/utils/logger';

--- a/src/web-ui/src/tools/editor/services/ActiveEditTargetService.ts
+++ b/src/web-ui/src/tools/editor/services/ActiveEditTargetService.ts
@@ -1,4 +1,4 @@
-import * as monaco from 'monaco-editor';
+import type * as monaco from 'monaco-editor';
 import { createLogger } from '@/shared/utils/logger';
 import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
 

--- a/src/web-ui/src/tools/editor/services/MonacoInitManager.ts
+++ b/src/web-ui/src/tools/editor/services/MonacoInitManager.ts
@@ -12,10 +12,25 @@ import { loader } from '@monaco-editor/react';
 import type * as Monaco from 'monaco-editor';
 import { registerMermaidLanguage } from '../languages/mermaid.language';
 import { registerTomlLanguage } from '../languages/toml.language';
+import { getMonacoPath, getMonacoWorkerPath, logMonacoResourceCheck } from '../utils/monacoPathHelper';
 import { themeManager } from './ThemeManager';
 import { createLogger } from '@/shared/utils/logger';
 
 const log = createLogger('MonacoInitManager');
+
+const MONACO_WORKER_MAP: Record<string, string> = {
+  json: 'language/json/jsonWorker.js',
+  css: 'language/css/cssWorker.js',
+  scss: 'language/css/cssWorker.js',
+  less: 'language/css/cssWorker.js',
+  html: 'language/html/htmlWorker.js',
+  handlebars: 'language/html/htmlWorker.js',
+  razor: 'language/html/htmlWorker.js',
+  typescript: 'language/typescript/tsWorker.js',
+  javascript: 'language/typescript/tsWorker.js',
+};
+
+const DEFAULT_WORKER = 'base/worker/workerMain.js';
 
 class MonacoInitManager {
   private static instance: MonacoInitManager;
@@ -23,6 +38,8 @@ class MonacoInitManager {
   private initPromise: Promise<typeof Monaco> | null = null;
   private monaco: typeof Monaco | null = null;
   private editorOpenerRegistered = false;
+  private loaderConfigured = false;
+  private resourceCheckScheduled = false;
   
   private constructor() {}
   
@@ -51,7 +68,9 @@ class MonacoInitManager {
   private async doInitialize(): Promise<typeof Monaco> {
     try {
       log.info('Initializing Monaco Editor');
-      
+
+      this.configureLoader();
+      await import('monaco-editor/min/vs/editor/editor.main.css');
       const monaco = await loader.init();
       
       this.configureTypeScriptLanguage(monaco);
@@ -70,6 +89,51 @@ class MonacoInitManager {
       this.initPromise = null; // Allow retry
       throw error;
     }
+  }
+
+  private configureLoader(): void {
+    if (this.loaderConfigured) {
+      return;
+    }
+
+    const monacoPath = getMonacoPath();
+    loader.config({
+      paths: {
+        vs: monacoPath,
+      },
+    });
+
+    (window as any).MonacoEnvironment = {
+      getWorker(_workerId: string, label: string) {
+        const workerFile = MONACO_WORKER_MAP[label] || DEFAULT_WORKER;
+        const workerPath = getMonacoWorkerPath(workerFile);
+
+        return new Worker(workerPath, {
+          type: 'classic',
+          name: `monaco-${label}-worker`,
+        });
+      },
+    };
+
+    this.loaderConfigured = true;
+    log.debug('Monaco loader configured', {
+      vs: monacoPath,
+      isDev: import.meta.env.DEV,
+    });
+    this.scheduleResourceCheck();
+  }
+
+  private scheduleResourceCheck(): void {
+    if (import.meta.env.DEV || this.resourceCheckScheduled) {
+      return;
+    }
+
+    this.resourceCheckScheduled = true;
+    window.setTimeout(() => {
+      logMonacoResourceCheck().catch(err => {
+        log.error('Monaco resource check failed', err);
+      });
+    }, 2000);
   }
   
   private configureTypeScriptLanguage(monaco: typeof Monaco): void {
@@ -302,6 +366,8 @@ class MonacoInitManager {
     this.initPromise = null;
     this.monaco = null;
     this.editorOpenerRegistered = false;
+    this.loaderConfigured = false;
+    this.resourceCheckScheduled = false;
   }
 }
 

--- a/src/web-ui/src/tools/editor/services/MonacoStartupWarmup.test.ts
+++ b/src/web-ui/src/tools/editor/services/MonacoStartupWarmup.test.ts
@@ -2,9 +2,23 @@ import { describe, expect, it, vi } from 'vitest';
 import { scheduleMonacoStartupWarmup } from './MonacoStartupWarmup';
 
 describe('scheduleMonacoStartupWarmup', () => {
-  it('schedules Monaco initialization as low-priority idle background work', async () => {
-    const initializeMonaco = vi.fn(async () => undefined);
-    const initializeThemeSync = vi.fn(async () => undefined);
+  it('schedules editor runtime warmup as low-priority idle background work', async () => {
+    const order: string[] = [];
+    const initializeMonaco = vi.fn(async () => {
+      order.push('monaco');
+    });
+    const initializeThemeSync = vi.fn(async () => {
+      order.push('theme');
+    });
+    const preloadEditorSurfaceStages = [
+      { name: 'code_editor', run: vi.fn(async () => { order.push('code'); }) },
+      { name: 'diff_editor', run: vi.fn(async () => { order.push('diff'); }) },
+      { name: 'git_diff_editor', run: vi.fn(async () => { order.push('git'); }) },
+    ];
+    const waitForIdle = vi.fn(async () => {
+      order.push('idle');
+    });
+    const trace = { markPhase: vi.fn() };
     const signal = { aborted: false } as AbortSignal;
     const schedule = vi.fn((task: (signal: AbortSignal) => Promise<void>, options: unknown) => ({
       promise: task(signal),
@@ -16,21 +30,48 @@ describe('scheduleMonacoStartupWarmup', () => {
       scheduler: { schedule },
       initializeMonaco,
       initializeThemeSync,
+      preloadEditorSurfaceStages,
+      waitForIdle,
+      trace,
     });
 
+    expect(trace.markPhase).toHaveBeenCalledWith('editor_startup_warmup_scheduled', {
+      idle: true,
+      priority: 'low',
+    });
     expect(schedule).toHaveBeenCalledWith(expect.any(Function), {
       idle: true,
       inFlightKey: 'startup:monaco-warmup',
       priority: 'low',
     });
     await expect(handle.promise).resolves.toBeUndefined();
+    expect(preloadEditorSurfaceStages[0].run).toHaveBeenCalledTimes(1);
+    expect(preloadEditorSurfaceStages[1].run).toHaveBeenCalledTimes(1);
+    expect(preloadEditorSurfaceStages[2].run).toHaveBeenCalledTimes(1);
+    expect(waitForIdle).toHaveBeenCalledTimes(4);
     expect(initializeMonaco).toHaveBeenCalledTimes(1);
     expect(initializeThemeSync).toHaveBeenCalledTimes(1);
+    expect(order).toEqual([
+      'code',
+      'idle',
+      'diff',
+      'idle',
+      'git',
+      'idle',
+      'monaco',
+      'idle',
+      'theme',
+    ]);
+    expect(trace.markPhase).toHaveBeenCalledWith('editor_startup_warmup_end');
   });
 
-  it('skips theme sync when the warmup task is cancelled before Monaco resolves', async () => {
+  it('skips editor warmup work when cancelled before execution', async () => {
     const initializeMonaco = vi.fn(async () => undefined);
     const initializeThemeSync = vi.fn(async () => undefined);
+    const preloadEditorSurfaceStages = [
+      { name: 'code_editor', run: vi.fn(async () => undefined) },
+    ];
+    const waitForIdle = vi.fn(async () => undefined);
     const signal = { aborted: true } as AbortSignal;
     const schedule = vi.fn((task: (signal: AbortSignal) => Promise<void>, options: unknown) => ({
       promise: task(signal),
@@ -42,10 +83,15 @@ describe('scheduleMonacoStartupWarmup', () => {
       scheduler: { schedule },
       initializeMonaco,
       initializeThemeSync,
+      preloadEditorSurfaceStages,
+      waitForIdle,
+      trace: { markPhase: vi.fn() },
     });
 
     await expect(handle.promise).resolves.toBeUndefined();
-    expect(initializeMonaco).toHaveBeenCalledTimes(1);
+    expect(preloadEditorSurfaceStages[0].run).not.toHaveBeenCalled();
+    expect(waitForIdle).not.toHaveBeenCalled();
+    expect(initializeMonaco).not.toHaveBeenCalled();
     expect(initializeThemeSync).not.toHaveBeenCalled();
   });
 });

--- a/src/web-ui/src/tools/editor/services/MonacoStartupWarmup.ts
+++ b/src/web-ui/src/tools/editor/services/MonacoStartupWarmup.ts
@@ -3,6 +3,7 @@ import {
   type BackgroundTaskHandle,
 } from '@/shared/utils/backgroundTaskScheduler';
 import { createLogger } from '@/shared/utils/logger';
+import { startupTrace } from '@/shared/utils/startupTrace';
 
 const log = createLogger('MonacoStartupWarmup');
 
@@ -21,6 +22,16 @@ interface MonacoStartupWarmupOptions {
   scheduler?: SchedulerLike;
   initializeMonaco?: () => Promise<void>;
   initializeThemeSync?: () => Promise<void>;
+  preloadEditorSurfaceStages?: EditorWarmupStage[];
+  waitForIdle?: (signal: AbortSignal) => Promise<void>;
+  trace?: {
+    markPhase: (phase: string, data?: Record<string, unknown>) => void;
+  };
+}
+
+interface EditorWarmupStage {
+  name: string;
+  run: () => Promise<void>;
 }
 
 async function defaultInitializeMonaco(): Promise<void> {
@@ -33,25 +44,125 @@ async function defaultInitializeThemeSync(): Promise<void> {
   await monacoThemeSync.initialize();
 }
 
+const defaultEditorSurfaceStages: EditorWarmupStage[] = [
+  {
+    name: 'code_editor',
+    run: async () => {
+      await import('@/tools/editor/components/CodeEditor');
+    },
+  },
+  {
+    name: 'diff_editor',
+    run: async () => {
+      await import('@/tools/editor/components/DiffEditor');
+    },
+  },
+  {
+    name: 'git_diff_editor',
+    run: async () => {
+      await import('@/tools/git/components/GitDiffEditor/GitDiffEditor');
+    },
+  },
+];
+
+function defaultWaitForIdle(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.resolve();
+  }
+
+  return new Promise(resolve => {
+    let settled = false;
+    let cancelScheduled: (() => void) | null = null;
+
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      signal.removeEventListener('abort', finish);
+      cancelScheduled?.();
+      resolve();
+    };
+
+    signal.addEventListener('abort', finish, { once: true });
+
+    const requestIdleCallback = (globalThis as {
+      requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+    }).requestIdleCallback;
+    const cancelIdleCallback = (globalThis as {
+      cancelIdleCallback?: (handle: number) => void;
+    }).cancelIdleCallback;
+
+    if (typeof requestIdleCallback === 'function') {
+      const idleHandle = requestIdleCallback(finish, { timeout: 1500 });
+      cancelScheduled = () => cancelIdleCallback?.(idleHandle);
+      return;
+    }
+
+    const timer = globalThis.setTimeout(finish, 16) as unknown as number;
+    cancelScheduled = () => globalThis.clearTimeout(timer);
+  });
+}
+
 export function scheduleMonacoStartupWarmup(
   options: MonacoStartupWarmupOptions = {}
 ): BackgroundTaskHandle<void> {
   const scheduler = options.scheduler ?? backgroundTaskScheduler;
   const initializeMonaco = options.initializeMonaco ?? defaultInitializeMonaco;
   const initializeThemeSync = options.initializeThemeSync ?? defaultInitializeThemeSync;
+  const preloadEditorSurfaceStages = options.preloadEditorSurfaceStages ?? defaultEditorSurfaceStages;
+  const waitForIdle = options.waitForIdle ?? defaultWaitForIdle;
+  const trace = options.trace ?? startupTrace;
+
+  trace.markPhase('editor_startup_warmup_scheduled', {
+    idle: true,
+    priority: 'low',
+  });
 
   return scheduler.schedule(async (signal) => {
     try {
+      if (signal.aborted) {
+        return;
+      }
+      trace.markPhase('editor_startup_warmup_start');
+      for (const stage of preloadEditorSurfaceStages) {
+        trace.markPhase('editor_startup_warmup_stage_start', { stage: stage.name });
+        await stage.run();
+        if (signal.aborted) {
+          return;
+        }
+        trace.markPhase('editor_startup_warmup_stage_end', { stage: stage.name });
+        await waitForIdle(signal);
+        if (signal.aborted) {
+          return;
+        }
+      }
+      if (signal.aborted) {
+        return;
+      }
+      trace.markPhase('editor_startup_warmup_surfaces_loaded');
       await initializeMonaco();
       if (signal.aborted) {
         return;
       }
+      trace.markPhase('editor_startup_warmup_monaco_ready');
+      await waitForIdle(signal);
+      if (signal.aborted) {
+        return;
+      }
       await initializeThemeSync();
+      if (signal.aborted) {
+        return;
+      }
+      trace.markPhase('editor_startup_warmup_end');
       log.info('Monaco startup warmup completed');
     } catch (error) {
       if (signal.aborted) {
         return;
       }
+      trace.markPhase('editor_startup_warmup_failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
       log.warn('Monaco startup warmup failed', error);
       throw error;
     }

--- a/src/web-ui/src/tools/editor/services/ThemeManager.ts
+++ b/src/web-ui/src/tools/editor/services/ThemeManager.ts
@@ -135,25 +135,32 @@ class ThemeManager {
   private async syncWithThemeService(): Promise<void> {
     try {
       const { themeService } = await import('@/infrastructure/theme');
+      const { monacoThemeSync } = await import('@/infrastructure/theme/integrations/MonacoThemeSync');
       const currentTheme = themeService.getCurrentTheme();
       
       if (currentTheme) {
-        const themeId = currentTheme.monaco 
-          ? currentTheme.id 
-          : (currentTheme.type === 'dark' ? this.getDefaultThemeId() : 'vs');
-        
-        this.currentThemeId = themeId;
-        const { monacoThemeSync } = await import('@/infrastructure/theme/integrations/MonacoThemeSync');
-        monacoThemeSync.syncTheme(currentTheme);
+        this.currentThemeId = monacoThemeSync.attachMonaco(monaco, currentTheme);
+        this.registeredThemes.add('bitfun-dark');
+        this.registeredThemes.add('bitfun-light');
+        if (currentTheme.monaco) {
+          this.registeredThemes.add(currentTheme.id);
+        }
       }
       
       themeService.on('theme:after-change', (event) => {
         if (event.theme) {
-          const newThemeId = event.theme.monaco 
-            ? event.theme.id 
-            : (event.theme.type === 'dark' ? this.getDefaultThemeId() : 'vs');
-          
-          this.setTheme(newThemeId);
+          const previousThemeId = this.currentThemeId;
+          const newThemeId = monacoThemeSync.syncTheme(event.theme);
+          if (event.theme.monaco) {
+            this.registeredThemes.add(event.theme.id);
+          }
+          if (newThemeId !== previousThemeId) {
+            this.currentThemeId = newThemeId;
+            this.notifyListeners({
+              previousThemeId,
+              currentThemeId: newThemeId,
+            });
+          }
         }
       });
       

--- a/src/web-ui/src/tools/file-system/components/FileSearchResults.tsx
+++ b/src/web-ui/src/tools/file-system/components/FileSearchResults.tsx
@@ -7,7 +7,7 @@ import type {
 import { useI18n } from '@/infrastructure/i18n';
 import { i18nService } from '@/infrastructure/i18n';
 import { notificationService } from '@/shared/notification-system';
-import { useContextMenuStore } from '@/shared/context-menu-system';
+import { useContextMenuStore } from '@/shared/context-menu-system/store/ContextMenuStore';
 import { ContextType } from '@/shared/context-menu-system/types/context.types';
 import type { MenuItem } from '@/shared/context-menu-system/types/menu.types';
 import { addFileMentionToChat, type FileMentionTarget } from '@/shared/utils/chatContext';

--- a/src/web-ui/src/tools/generative-widget/useGenerativeWidgetPromptMenu.ts
+++ b/src/web-ui/src/tools/generative-widget/useGenerativeWidgetPromptMenu.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { globalEventBus } from '@/infrastructure/event-bus';
-import { useContextMenuStore } from '@/shared/context-menu-system';
+import { useContextMenuStore } from '@/shared/context-menu-system/store/ContextMenuStore';
 import { ContextType } from '@/shared/context-menu-system/types/context.types';
 import type { MenuItem } from '@/shared/context-menu-system/types/menu.types';
 import { notificationService } from '@/shared/notification-system';

--- a/src/web-ui/src/tools/git/components/GitDiffEditor/GitDiffEditor.tsx
+++ b/src/web-ui/src/tools/git/components/GitDiffEditor/GitDiffEditor.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { DiffEditor } from '@/tools/editor';
+import { DiffEditor } from '@/tools/editor/components/DiffEditor';
 import { X } from 'lucide-react';
 import { createLogger } from '@/shared/utils/logger';
 import { globalEventBus } from '@/infrastructure/event-bus';

--- a/src/web-ui/src/tools/git/services/GitEventService.ts
+++ b/src/web-ui/src/tools/git/services/GitEventService.ts
@@ -2,7 +2,7 @@
  * Git event service - manages Git event pub/sub
  */
 
-import { globalEventBus } from '../../../infrastructure';
+import { globalEventBus } from '../../../infrastructure/event-bus';
 import { 
   GitEvent, 
   GitEventType, 

--- a/tests/e2e/specs/performance/editor-first-open-perf.spec.ts
+++ b/tests/e2e/specs/performance/editor-first-open-perf.spec.ts
@@ -1,0 +1,253 @@
+import { $, browser, expect } from '@wdio/globals';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import {
+  readPerformanceNow,
+  readStartupTraceSnapshot,
+  waitForTracePhaseCount,
+} from '../../helpers/performance-trace';
+
+type EditorScenario = 'code-editor' | 'git-diff';
+
+interface EditorOpenReport {
+  appMode: string;
+  scenario: EditorScenario;
+  traceId: string;
+  filePath: string;
+  waitedForEditorWarmup: boolean;
+  editorWarmupStartAtMs?: number;
+  editorWarmupEndAtMs?: number;
+  editorWarmupDurationMs?: number;
+  editorWarmupCompletedBeforeTrigger: boolean;
+  triggerAtMs: number;
+  editorReadyAtMs: number;
+  triggerToEditorReadyMs: number;
+  matchingEditorCount: number;
+}
+
+function reportDir(): string {
+  return path.resolve(process.cwd(), 'reports', 'performance');
+}
+
+async function writeReport(name: string, data: unknown): Promise<void> {
+  await fs.mkdir(reportDir(), { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  await fs.writeFile(
+    path.join(reportDir(), `${name}-${timestamp}.json`),
+    `${JSON.stringify(data, null, 2)}\n`,
+    'utf8',
+  );
+}
+
+function getScenario(): EditorScenario {
+  const raw = process.env.BITFUN_E2E_EDITOR_SCENARIO;
+  return raw === 'git-diff' ? 'git-diff' : 'code-editor';
+}
+
+function getWorkspacePath(): string {
+  return process.env.E2E_TEST_WORKSPACE || path.resolve(process.cwd(), '..', '..');
+}
+
+function getEditorFilePath(workspacePath: string): string {
+  return process.env.BITFUN_E2E_EDITOR_FILE_PATH
+    || path.join(workspacePath, 'src', 'web-ui', 'src', 'main.tsx');
+}
+
+function shouldWaitForEditorWarmup(): boolean {
+  return process.env.BITFUN_E2E_WAIT_FOR_EDITOR_WARMUP === '1';
+}
+
+function fileNameOf(filePath: string): string {
+  return filePath.replace(/\\/g, '/').split('/').pop() || 'main.tsx';
+}
+
+function lastPhaseAt(snapshot: Awaited<ReturnType<typeof readStartupTraceSnapshot>>, phase: string): number | undefined {
+  return snapshot.phases.events
+    .filter(event => event.phase === phase)
+    .at(-1)?.atMs;
+}
+
+async function openSessionScene(): Promise<void> {
+  await browser.execute(() => {
+    window.dispatchEvent(new CustomEvent('scene:open', { detail: { sceneId: 'session' } }));
+    window.dispatchEvent(new CustomEvent('expand-right-panel'));
+  });
+  await $('[data-testid="app-main-content"]').waitForExist({ timeout: 10000 });
+}
+
+async function openGitScene(): Promise<void> {
+  await browser.execute(() => {
+    window.dispatchEvent(new CustomEvent('scene:open', { detail: { sceneId: 'git' } }));
+  });
+  await $('.bitfun-git-scene-working-copy__diff-area').waitForExist({ timeout: 15000 });
+}
+
+async function triggerCodeEditor(filePath: string, fileName: string): Promise<number> {
+  return browser.execute((args) => {
+    const triggerAt = performance.now();
+    const duplicateKey = `perf-code-editor:${args.filePath}:${triggerAt}`;
+    window.dispatchEvent(new CustomEvent('scene:open', { detail: { sceneId: 'session' } }));
+    window.dispatchEvent(new CustomEvent('expand-right-panel'));
+    window.dispatchEvent(new CustomEvent('agent-create-tab', {
+      detail: {
+        type: 'code-editor',
+        title: args.fileName,
+        data: {
+          filePath: args.filePath,
+          fileName: args.fileName,
+          language: 'typescript',
+          readOnly: true,
+          showLineNumbers: true,
+          showMinimap: false,
+          theme: 'vs-dark',
+        },
+        metadata: {
+          filePath: args.filePath,
+          fileName: args.fileName,
+          duplicateCheckKey: duplicateKey,
+        },
+        checkDuplicate: false,
+        duplicateCheckKey: duplicateKey,
+        replaceExisting: false,
+      },
+    }));
+    return triggerAt;
+  }, { filePath, fileName });
+}
+
+async function triggerGitDiff(
+  workspacePath: string,
+  filePath: string,
+  fileName: string,
+): Promise<number> {
+  const content = await fs.readFile(filePath, 'utf8');
+  const relativePath = path.relative(workspacePath, filePath).replace(/\\/g, '/');
+  const modifiedContent = `${content}\n// perf measurement synthetic diff\n`;
+
+  return browser.execute((args) => {
+    const triggerAt = performance.now();
+    const duplicateKey = `perf-git-diff:${args.relativePath}:${triggerAt}`;
+    window.dispatchEvent(new CustomEvent('git-create-tab', {
+      detail: {
+        type: 'diff-code-editor',
+        title: `${args.fileName} - Git Diff`,
+        data: {
+          fileName: args.fileName,
+          filePath: args.relativePath,
+          language: 'typescript',
+          originalCode: args.originalContent,
+          modifiedCode: args.modifiedContent,
+          readOnly: true,
+          repositoryPath: args.workspacePath,
+        },
+        metadata: {
+          filePath: args.relativePath,
+          repositoryPath: args.workspacePath,
+          duplicateCheckKey: duplicateKey,
+        },
+        checkDuplicate: false,
+        duplicateCheckKey: duplicateKey,
+        replaceExisting: false,
+      },
+    }));
+    return triggerAt;
+  }, {
+    workspacePath,
+    relativePath,
+    fileName,
+    originalContent: content,
+    modifiedContent,
+  });
+}
+
+async function waitForEditorReady(scenario: EditorScenario): Promise<{ atMs: number; count: number }> {
+  const selector = editorSelector(scenario);
+
+  await browser.waitUntil(async () => {
+    const count = await countMatchingEditors(scenario);
+    return count > 0;
+  }, {
+    timeout: 30000,
+    interval: 50,
+    timeoutMsg: `Timed out waiting for ${scenario} Monaco editor`,
+  });
+
+  const result = await browser.execute((query) => ({
+    atMs: performance.now(),
+    count: document.querySelectorAll(query).length,
+  }), selector);
+  return result as { atMs: number; count: number };
+}
+
+function editorSelector(scenario: EditorScenario): string {
+  return scenario === 'git-diff'
+    ? '.monaco-diff-editor, .monaco-editor'
+    : '.monaco-editor';
+}
+
+async function countMatchingEditors(scenario: EditorScenario): Promise<number> {
+  const selector = editorSelector(scenario);
+  return browser.execute((query) => document.querySelectorAll(query).length, selector);
+}
+
+describe('Editor first-open performance telemetry', () => {
+  before(async () => {
+    await waitForTracePhaseCount('interactive_shell_ready', 1, 30000);
+    if (shouldWaitForEditorWarmup()) {
+      await waitForTracePhaseCount('editor_startup_warmup_end', 1, 30000);
+    }
+  });
+
+  it('collects first-open timing for editor-heavy surfaces', async () => {
+    const scenario = getScenario();
+    const workspacePath = getWorkspacePath();
+    const filePath = getEditorFilePath(workspacePath);
+    const fileName = fileNameOf(filePath);
+
+    if (scenario === 'git-diff') {
+      await openGitScene();
+    } else {
+      await openSessionScene();
+    }
+    const existingEditorCount = await countMatchingEditors(scenario);
+    if (existingEditorCount > 0) {
+      throw new Error(`Expected no existing ${scenario} editor before first-open measurement; found ${existingEditorCount}`);
+    }
+
+    const snapshotBefore = await readStartupTraceSnapshot();
+    const editorWarmupStartAtMs = lastPhaseAt(snapshotBefore, 'editor_startup_warmup_start');
+    const editorWarmupEndAtMs = lastPhaseAt(snapshotBefore, 'editor_startup_warmup_end');
+    const triggerAtMs = scenario === 'git-diff'
+      ? await triggerGitDiff(workspacePath, filePath, fileName)
+      : await triggerCodeEditor(filePath, fileName);
+    const ready = await waitForEditorReady(scenario);
+    const trace = await readStartupTraceSnapshot();
+
+    const report: EditorOpenReport = {
+      appMode: process.env.BITFUN_E2E_APP_MODE ?? 'auto',
+      scenario,
+      traceId: trace.traceId || snapshotBefore.traceId,
+      filePath,
+      waitedForEditorWarmup: shouldWaitForEditorWarmup(),
+      editorWarmupStartAtMs,
+      editorWarmupEndAtMs,
+      editorWarmupDurationMs:
+        typeof editorWarmupStartAtMs === 'number' && typeof editorWarmupEndAtMs === 'number'
+          ? editorWarmupEndAtMs - editorWarmupStartAtMs
+          : undefined,
+      editorWarmupCompletedBeforeTrigger:
+        typeof editorWarmupEndAtMs === 'number' && editorWarmupEndAtMs <= triggerAtMs,
+      triggerAtMs,
+      editorReadyAtMs: ready.atMs,
+      triggerToEditorReadyMs: ready.atMs - triggerAtMs,
+      matchingEditorCount: ready.count,
+    };
+
+    console.log('[Perf] editor-first-open', JSON.stringify(report));
+    await writeReport(`editor-first-open-${scenario}`, report);
+
+    expect(report.triggerToEditorReadyMs).toBeGreaterThan(0);
+    expect(report.matchingEditorCount).toBeGreaterThan(0);
+    expect(await readPerformanceNow()).toBeGreaterThan(report.triggerAtMs);
+  });
+});


### PR DESCRIPTION
﻿## Decision Status

This PR remains **draft** under #949, but the editor first-open regression called out in the previous PR description has now been mitigated with measured release-fast data.

Current data is positive for the target startup path and for the measured editor-heavy first-open paths. Remaining merge risk is mostly measurement rigor: the branch was rebased onto latest `gcwing/main@18aa2df4`, but the comparison baseline below is the existing #949 baseline (`gcwing/main@978e079f`) rather than a freshly rerun latest-main strict A/B baseline.

Refs #949

## Summary

- Move Monaco loader config, worker mapping, CSS loading, and resource checks from `main.tsx` into `MonacoInitManager`, so editor runtime work starts only when the editor is initialized.
- Lazy-load editor-heavy surfaces (`CodeEditor`, `DiffEditor`, `MarkdownEditor`, `ImageViewer`, `GitDiffEditor`) from `FlexiblePanel` with a lightweight fallback.
- After the shell is interactive and the startup splash has exited, schedule a low-priority idle editor warmup that preloads editor surfaces in slices, initializes Monaco, and syncs Monaco themes.
- Start non-critical tool/context-menu initialization after `bitfun:interactive-shell-ready` instead of the earlier main-window signal, with a 10s watchdog fallback.
- Remove root `App` AI auto-initialization and model-config subscription; AI initialization remains on explicit/on-demand service paths.
- Keep the startup splash logo-only by default; show `Loading workspace...` below the logo only after 1800ms if workspace loading is still active, avoiding the short loading-text flash during normal startup.
- Add performance contract coverage for startup bundle boundaries, deferred Monaco/theme behavior, editor first-open timing, warmup telemetry, and delayed splash loading feedback.

## Measurement Method

- Platform/build: Windows desktop `release-fast`.
- Current PR head: `20d6a235`, rebased on `gcwing/main@18aa2df4`.
- Continuity baseline: `gcwing/main@978e079f` from #949's existing measurement set.
- Runs: 5 repeated app launches per startup, long-session, code-editor, and Git-diff no-wait scenario; 5 code-editor explicit-warmup runs; 10 Git-diff explicit-warmup runs after one small outlier in the first 5-sample set.
- Startup and long-session timing: `tests/e2e/specs/performance/startup-session-perf.spec.ts`.
- Editor first-open timing: `tests/e2e/specs/performance/editor-first-open-perf.spec.ts`.
- Long-session fixture: 80 sessions, latest long session has 80 turns; first render measures latest visible content, then full hydrate.
- Editor first-open measures event trigger to Monaco DOM ready. It intentionally isolates deferred editor/rendering cost, not file-tree click latency or Git status refresh.

## Runtime Results

### Cold Startup, p50

| Metric | Baseline | This PR | Delta |
| --- | ---: | ---: | ---: |
| `first_script_eval` | 1179.0 ms | 601.1 ms | -577.9 ms (-49.0%) |
| `main_window_shown` | 1309.5 ms | 711.3 ms | -598.2 ms (-45.7%) |
| `interactive_shell_ready` | 1720.4 ms | 1059.8 ms | -660.6 ms (-38.4%) |
| `non_critical_init_done` | 1667.2 ms | 1315.9 ms | -351.3 ms (-21.1%) |

Startup target result: **positive** on the measured release-fast head data.

### First Open Of Long Historical Session, p50

| Metric | Baseline | This PR | Delta |
| --- | ---: | ---: | ---: |
| Backend restore | 45.6 ms | 41.5 ms | -4.1 ms (-9.0%) |
| Latest frame after hydrate | 45.7 ms | 46.5 ms | +0.8 ms (+1.8%) |
| Initial hydrate | 105.9 ms | 102.9 ms | -3.0 ms (-2.8%) |
| Full hydrate | 51.5 ms | 52.7 ms | +1.2 ms (+2.3%) |

Long-session result: **neutral to slightly positive**, with the remaining regressions under 2 ms p50 in this run.

### First Editor-Heavy Interaction, p50

| Scenario | Baseline | Previous PR before warmup | This PR no explicit wait | This PR after warmup wait |
| --- | ---: | ---: | ---: | ---: |
| First code editor open | 384.1 ms | 503.7 ms | 207.4 ms | 203.4 ms |
| First Git diff editor open | 398.6 ms | 526.9 ms | 283.7 ms | 271.2 ms |

Editor result: **the previous first-use regression is mitigated**. Compared with the previous PR measurement, code-editor p50 drops by 296.3 ms and Git-diff p50 drops by 243.2 ms. Compared with the continuity baseline, code-editor p50 improves by 176.7 ms (-46.0%) and Git-diff p50 improves by 127.4 ms (-32.0%) in the explicit-warmup path.

### Background Editor Warmup Cost

| Scenario | Samples | Warmup completed before trigger | Warmup duration p50 |
| --- | ---: | ---: | ---: |
| Code editor, no explicit wait | 5 | 5/5 | 235.6 ms |
| Code editor, explicit wait | 5 | 5/5 | 237.0 ms |
| Git diff, no explicit wait | 5 | 5/5 | 226.7 ms |
| Git diff, explicit wait | 10 | 10/10 | 230.4 ms |

This work is deliberately scheduled after splash exit and split across idle slices. It still consumes post-startup idle time and is not free.

## Bundle / Parse-Pressure Evidence

Measured earlier with `pnpm --dir src/web-ui run build` on this PR line.

| Scenario | Entry JS | Monaco runtime markers | Root AI hook marker |
| --- | ---: | --- | --- |
| `gcwing/main@978e079f` | 8,298,942 bytes | present (`Click to toggle color options`, `editor.action.showHover`) | present (`useAIInitialization`) |
| This PR line | 4,294,694 bytes | removed | removed |

Net entry JS reduction: **4,004,248 bytes / 48.25%**.

## Risks / Functional Impact

- Latest-main strict A/B was not rerun after the rebase. The current head data is real repeated release-fast data, but final merge should not pretend it is a strict latest-main A/B comparison.
- Users who open an editor before the idle warmup finishes can still pay partial cold cost. The current measured no-wait runs completed warmup before trigger, so this edge remains a residual risk rather than proven neutral.
- Background editor warmup costs about 230 ms total in idle slices. It improves likely first editor open, but it can still contend with user activity if the browser grants idle time aggressively.
- Root AI initialization is no longer automatic at app mount. Focused tests pass, but manual AI-entry validation is still useful before marking ready.
- Delaying non-critical initialization behind `bitfun:interactive-shell-ready` reduces startup pressure but can delay tool/context-menu availability if the readiness event is late or missed; the watchdog caps this at 10s.
- Startup workspace loading text is intentionally delayed to 1800ms; slower startups still show a loading hint below the logo, while normal startup paths stay logo-only.

## Current Decision

Do not merge solely on bundle-size or architecture arguments. With the current release-fast data, this PR now has a measured user-facing performance result:

- Startup p50 improves by 351-661 ms across the measured marks.
- Long-session first-open stays neutral in p50.
- First editor-heavy interactions improve relative to both the previous PR measurement and the continuity baseline after the background warmup mitigation.

The remaining blocker is whether we require a fresh latest-main strict A/B run before marking the draft ready.

## Verification

- `pnpm --dir src/web-ui run test:run src/tools/editor/services/MonacoStartupWarmup.test.ts src/app/startup/startupPerformanceContract.test.ts src/app/components/SplashScreen/SplashScreen.test.tsx src/infrastructure/theme/integrations/MonacoThemeSync.test.ts src/shared/utils/startupTaskScheduling.test.ts src/infrastructure/services/api/aiService.test.ts`
- `pnpm run type-check:web`
- `pnpm run i18n:audit`
- `pnpm run check:repo-hygiene`
- `pnpm run desktop:build:release-fast`
- `git diff --check gcwing/main...HEAD`
- `BITFUN_E2E_APP_MODE=release-fast pnpm --dir tests/e2e run test:perf` repeated 5 times
- `BITFUN_E2E_EDITOR_SCENARIO=code-editor pnpm --dir tests/e2e exec wdio run ./config/wdio.conf.ts --spec ./specs/performance/editor-first-open-perf.spec.ts` repeated 5 times without explicit warmup wait and 5 times with explicit warmup wait
- `BITFUN_E2E_EDITOR_SCENARIO=git-diff pnpm --dir tests/e2e exec wdio run ./config/wdio.conf.ts --spec ./specs/performance/editor-first-open-perf.spec.ts` repeated 5 times without explicit warmup wait and 10 times with explicit warmup wait
