### PR TITLE
feat: show working directory hint in terminal list items

### DIFF
--- a/src/web-ui/src/app/scenes/shell/ShellNav.scss
+++ b/src/web-ui/src/app/scenes/shell/ShellNav.scss
@@ -327,12 +327,19 @@
     min-width: 0;
   }
 
-  &__terminal-item {
+  &__terminal-item-row {
     display: flex;
     align-items: center;
     gap: 6px;
     width: 100%;
-    height: 32px;
+  }
+
+  &__terminal-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    width: 100%;
+    min-height: 32px;
     padding: 0 $size-gap-2;
     border: none;
     border-radius: $size-radius-base;
@@ -343,9 +350,16 @@
     font-size: var(--font-size-sm);
     font-weight: 400;
     position: relative;
+    justify-content: center;
     transition:
       color $motion-fast $easing-standard,
       background $motion-fast $easing-standard;
+
+    &.has-cwd {
+      padding-top: 4px;
+      padding-bottom: 4px;
+      justify-content: center;
+    }
 
     &:hover {
       color: var(--color-text-primary);
@@ -445,6 +459,17 @@
       background: transparent;
       opacity: 0.8;
     }
+  }
+
+  &__terminal-cwd {
+    display: block;
+    padding-left: 20px;
+    font-size: var(--font-size-xxs);
+    line-height: 1.3;
+    color: var(--color-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &__cmd-indicator {

--- a/src/web-ui/src/app/scenes/shell/components/ShellNavEntryItem.tsx
+++ b/src/web-ui/src/app/scenes/shell/components/ShellNavEntryItem.tsx
@@ -26,6 +26,14 @@ interface ShellNavEntryItemProps {
   ) => void;
 }
 
+function getDisplayCwd(entry: ShellEntry): string | null {
+  const cwd = entry.workingDirectory ?? entry.cwd;
+  if (!cwd || cwd.trim().length === 0) {
+    return null;
+  }
+  return cwd;
+}
+
 const ShellNavEntryItem: React.FC<ShellNavEntryItemProps> = ({
   entry,
   isActive,
@@ -37,6 +45,8 @@ const ShellNavEntryItem: React.FC<ShellNavEntryItemProps> = ({
   onOpen,
   onOpenContextMenu,
 }) => {
+  const displayCwd = getDisplayCwd(entry);
+
   return (
     <div
       role="button"
@@ -44,6 +54,7 @@ const ShellNavEntryItem: React.FC<ShellNavEntryItemProps> = ({
       className={[
         'bitfun-shell-nav__terminal-item',
         isActive && 'is-active',
+        displayCwd && 'has-cwd',
       ].filter(Boolean).join(' ')}
       onClick={() => { void onOpen(entry); }}
       onKeyDown={(event) => {
@@ -60,40 +71,48 @@ const ShellNavEntryItem: React.FC<ShellNavEntryItemProps> = ({
         onOpenContextMenu(event, menuItems, { entry });
       }}
     >
-      <Tooltip content={entry.name} placement="right">
-        <span className="bitfun-shell-nav__terminal-item-main">
-          {showSavedBadge ? (
-            <Bookmark size={14} className="bitfun-shell-nav__terminal-icon bitfun-shell-nav__terminal-icon--saved" />
-          ) : (
-            <SquareTerminal size={14} className="bitfun-shell-nav__terminal-icon" />
-          )}
+      <div className="bitfun-shell-nav__terminal-item-row">
+        <Tooltip content={entry.name} placement="right">
+          <span className="bitfun-shell-nav__terminal-item-main">
+            {showSavedBadge ? (
+              <Bookmark size={14} className="bitfun-shell-nav__terminal-icon bitfun-shell-nav__terminal-icon--saved" />
+            ) : (
+              <SquareTerminal size={14} className="bitfun-shell-nav__terminal-icon" />
+            )}
 
-          <span className="bitfun-shell-nav__terminal-label">{entry.name}</span>
+            <span className="bitfun-shell-nav__terminal-label">{entry.name}</span>
 
-          {showSavedBadge ? (
-            <span className="bitfun-shell-nav__saved-indicator">{savedBadgeLabel}</span>
-          ) : null}
+            {showSavedBadge ? (
+              <span className="bitfun-shell-nav__saved-indicator">{savedBadgeLabel}</span>
+            ) : null}
 
-          {entry.startupCommand ? (
-            <span className="bitfun-shell-nav__cmd-indicator">{startupCommandBadgeLabel}</span>
-          ) : null}
+            {entry.startupCommand ? (
+              <span className="bitfun-shell-nav__cmd-indicator">{startupCommandBadgeLabel}</span>
+            ) : null}
 
-          <span className={`bitfun-shell-nav__terminal-dot${entry.isRunning ? ' is-running' : ' is-stopped'}`} />
+            <span className={`bitfun-shell-nav__terminal-dot${entry.isRunning ? ' is-running' : ' is-stopped'}`} />
+          </span>
+        </Tooltip>
+
+        <Tooltip content={quickAction.title} placement="right">
+          <button
+            type="button"
+            className="bitfun-shell-nav__terminal-close"
+            onClick={(event) => {
+              event.stopPropagation();
+              quickAction.onClick();
+            }}
+          >
+            {quickAction.icon}
+          </button>
+        </Tooltip>
+      </div>
+
+      {displayCwd ? (
+        <span className="bitfun-shell-nav__terminal-cwd" title={displayCwd}>
+          {displayCwd}
         </span>
-      </Tooltip>
-
-      <Tooltip content={quickAction.title} placement="right">
-        <button
-          type="button"
-          className="bitfun-shell-nav__terminal-close"
-          onClick={(event) => {
-            event.stopPropagation();
-            quickAction.onClick();
-          }}
-        >
-          {quickAction.icon}
-        </button>
-      </Tooltip>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
Display the working directory (workingDirectory/cwd) under each terminal entry in ShellNav, helping users distinguish terminals across different workspaces and avoid confusion when switching.

## Summary

<!-- Briefly describe what changed. -->

Fixes #

## Type and Areas

Type:

<!-- Feature / bug fix / regression fix / refactor / UI/UX / docs / test / CI / dependency / other. -->

Areas:

<!-- Rust core, desktop/Tauri, web UI, mobile web, server/relay, AI adapters, installer, docs, etc. -->

## Motivation / Impact

<!-- What problem does this solve, and what changes for users or developers? Write "No direct user-facing change" if applicable. -->

## Verification

<!-- List exact commands, manual checks, and outcomes. For docs-only or template-only changes, use the lightest relevant checks or explain why runtime checks were skipped. -->

## Reviewer Notes

<!-- Optional: screenshots, architecture notes, compatibility risks, migration notes, or rollback guidance. -->

## Checklist

- [ ] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [ ] Relevant verification is recorded above, or skipped checks are explained.
- [ ] User-facing strings, docs, and locales are updated where applicable.
