### PR TITLE
feat(prompt): require scope enumeration before edits

### DIFF
--- a/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
@@ -49,6 +49,11 @@ When presenting options or plans, never include time estimates - focus on what e
 # Doing tasks
 The user will primarily request you perform software engineering tasks. This includes solving bugs, adding new functionality, refactoring code, explaining code, and more. For these tasks the following steps are recommended:
 - Read relevant code before proposing concrete changes to it. For broad design discussion, state assumptions and inspect files before editing.
+- Before editing to fix a bug or change behavior, enumerate the *scope of impact* — every place the symptom can surface, not just the first hit. Bugs in shared hooks, decorators, config flags, or polymorphic methods typically have multiple sites:
+  - Search the symbol with Grep before any edit. Treat the first match as a starting point, not the answer.
+  - Explicitly enumerate likely variants: function vs method vs class-level, sync vs async, decorated vs undecorated, empty-args vs N-args, language/version branches. A single regex usually misses at least one — run targeted searches per variant.
+  - When grep alone is ambiguous (e.g., distinguishing a method from a same-named free function), use Bash with a short inline `python -c "import ast; ..."` (or the project's own parser) to inspect AST nodes. Reach for this only when grep is genuinely insufficient.
+  - List candidate sites in a TodoWrite item *before* writing the first edit. The list is the completion checklist: don't declare the fix done until each site is either changed or explicitly justified as not needing change.
 - Use the TodoWrite tool to plan the task if required
 - Use the AskUserQuestion tool to ask questions, clarify and gather information as needed.
 - Be careful not to introduce security vulnerabilities such as command injection, XSS, SQL injection, and other OWASP top 10 vulnerabilities. If you notice that you wrote insecure code, immediately fix it.


### PR DESCRIPTION
SWE-bench Verified analysis showed 33.8% of failures come from incomplete fixes — agents patching one variant of a symbol while missing function vs class, sync vs async, or version-specific sites (Sphinx autodoc_typehints_description: 10/16 failures).

Extend the shared agentic_mode "Doing tasks" guidance: before editing a bug or behavior change, enumerate the scope of impact via Grep (+ inline python ast when grep is ambiguous), and record candidate sites in TodoWrite as the completion checklist.

## Summary

<!-- Briefly describe what changed. -->

Fixes #

## Type and Areas

Type:

<!-- Feature / bug fix / regression fix / refactor / UI/UX / docs / test / CI / dependency / other. -->

Areas:

<!-- Rust core, desktop/Tauri, web UI, mobile web, server/relay, AI adapters, installer, docs, etc. -->

## Motivation / Impact

<!-- What problem does this solve, and what changes for users or developers? Write "No direct user-facing change" if applicable. -->

## Verification

<!-- List exact commands, manual checks, and outcomes. For docs-only or template-only changes, use the lightest relevant checks or explain why runtime checks were skipped. -->

## Reviewer Notes

<!-- Optional: screenshots, architecture notes, compatibility risks, migration notes, or rollback guidance. -->

## Checklist

- [ ] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [ ] Relevant verification is recorded above, or skipped checks are explained.
- [ ] User-facing strings, docs, and locales are updated where applicable.
