### PR TITLE
feat(acp): surface dropped SessionUpdate variants + UI (slash commands, plan, config options)

### DIFF
--- a/src/apps/desktop/src/api/acp_client_api.rs
+++ b/src/apps/desktop/src/api/acp_client_api.rs
@@ -3,9 +3,9 @@
 use crate::api::app_state::AppState;
 use crate::api::session_storage_path::desktop_effective_session_storage_path;
 use bitfun_acp::client::{
-    AcpClientInfo, AcpClientPermissionResponse, AcpClientRequirementProbe, AcpClientStreamEvent,
-    AcpSessionOptions, CreateAcpFlowSessionRecordResponse, SetAcpSessionModelRequest,
-    SubmitAcpPermissionResponseRequest,
+    AcpAvailableCommand, AcpClientInfo, AcpClientPermissionResponse, AcpClientRequirementProbe,
+    AcpClientStreamEvent, AcpSessionOptions, CreateAcpFlowSessionRecordResponse,
+    SetAcpSessionModelRequest, SubmitAcpPermissionResponseRequest,
 };
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
@@ -377,6 +377,20 @@ pub async fn start_acp_dialog_turn(
                                     bitfun_core::util::errors::BitFunError::service(e.to_string())
                                 })?;
                         }
+                        AcpClientStreamEvent::AvailableCommandsUpdated(commands) => {
+                            app_handle
+                                .emit(
+                                    "agentic://acp-available-commands-updated",
+                                    serde_json::json!({
+                                        "sessionId": request.session_id,
+                                        "clientId": request.client_id,
+                                        "commands": commands,
+                                    }),
+                                )
+                                .map_err(|e| {
+                                    bitfun_core::util::errors::BitFunError::service(e.to_string())
+                                })?;
+                        }
                         AcpClientStreamEvent::Completed => {
                             app_handle
                                 .emit(
@@ -472,6 +486,39 @@ pub async fn get_acp_session_options(
     };
     service
         .get_session_options(
+            &request.client_id,
+            request.workspace_path,
+            request.remote_connection_id,
+            session_storage_path,
+            request.session_id,
+        )
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn get_acp_session_commands(
+    state: State<'_, AppState>,
+    request: GetAcpSessionOptionsRequest,
+) -> Result<Vec<AcpAvailableCommand>, String> {
+    let service = state
+        .acp_client_service
+        .as_ref()
+        .ok_or_else(|| "ACP client service not initialized".to_string())?;
+    let session_storage_path = match request.workspace_path.as_deref() {
+        Some(workspace_path) => Some(
+            desktop_effective_session_storage_path(
+                &state,
+                workspace_path,
+                request.remote_connection_id.as_deref(),
+                request.remote_ssh_host.as_deref(),
+            )
+            .await,
+        ),
+        None => None,
+    };
+    service
+        .get_session_commands(
             &request.client_id,
             request.workspace_path,
             request.remote_connection_id,

--- a/src/apps/desktop/src/api/acp_client_api.rs
+++ b/src/apps/desktop/src/api/acp_client_api.rs
@@ -391,6 +391,21 @@ pub async fn start_acp_dialog_turn(
                                     bitfun_core::util::errors::BitFunError::service(e.to_string())
                                 })?;
                         }
+                        AcpClientStreamEvent::PlanUpdated(entries) => {
+                            app_handle
+                                .emit(
+                                    "agentic://acp-plan-updated",
+                                    serde_json::json!({
+                                        "sessionId": request.session_id,
+                                        "turnId": request.turn_id,
+                                        "clientId": request.client_id,
+                                        "entries": entries,
+                                    }),
+                                )
+                                .map_err(|e| {
+                                    bitfun_core::util::errors::BitFunError::service(e.to_string())
+                                })?;
+                        }
                         AcpClientStreamEvent::Completed => {
                             app_handle
                                 .emit(

--- a/src/apps/desktop/src/api/acp_client_api.rs
+++ b/src/apps/desktop/src/api/acp_client_api.rs
@@ -406,6 +406,21 @@ pub async fn start_acp_dialog_turn(
                                     bitfun_core::util::errors::BitFunError::service(e.to_string())
                                 })?;
                         }
+                        AcpClientStreamEvent::ConfigOptionsUpdated(_) => {
+                            // The stored options were refreshed backend-side; tell
+                            // the frontend to refetch the combined session options.
+                            app_handle
+                                .emit(
+                                    "agentic://acp-session-options-changed",
+                                    serde_json::json!({
+                                        "sessionId": request.session_id,
+                                        "clientId": request.client_id,
+                                    }),
+                                )
+                                .map_err(|e| {
+                                    bitfun_core::util::errors::BitFunError::service(e.to_string())
+                                })?;
+                        }
                         AcpClientStreamEvent::Completed => {
                             app_handle
                                 .emit(

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -857,6 +857,7 @@ pub async fn run() {
             start_acp_dialog_turn,
             cancel_acp_dialog_turn,
             get_acp_session_options,
+            get_acp_session_commands,
             set_acp_session_model,
             lsp_initialize,
             lsp_start_server_for_file,

--- a/src/crates/acp/src/client/manager.rs
+++ b/src/crates/acp/src/client/manager.rs
@@ -47,7 +47,8 @@ use super::requirements::{
     probe_remote_executable, probe_remote_npx_adapter, resolve_configured_command,
 };
 use super::session_options::{
-    model_config_id, session_options_from_state, AcpSessionContextUsage, AcpSessionOptions,
+    model_config_id, session_options_from_state, AcpAvailableCommand, AcpSessionContextUsage,
+    AcpSessionOptions,
 };
 use super::session_persistence::AcpSessionPersistence;
 pub use super::session_persistence::CreateAcpFlowSessionRecordResponse;
@@ -132,6 +133,8 @@ struct AcpRemoteSession {
     models: Option<SessionModelState>,
     config_options: Vec<SessionConfigOption>,
     context_usage: Option<AcpSessionContextUsage>,
+    /// Latest slash commands advertised by the agent (AvailableCommandsUpdate).
+    available_commands: Vec<AcpAvailableCommand>,
     discard_pending_updates_before_next_prompt: bool,
 }
 
@@ -160,6 +163,7 @@ impl AcpRemoteSession {
             models: None,
             config_options: Vec::new(),
             context_usage: None,
+            available_commands: Vec::new(),
             discard_pending_updates_before_next_prompt: false,
         }
     }
@@ -869,6 +873,39 @@ impl AcpClientService {
         ))
     }
 
+    /// Slash commands the agent has advertised for this session
+    /// (via `AvailableCommandsUpdate`). Returns an empty list until the agent
+    /// sends them (typically during/after the first prompt).
+    pub async fn get_session_commands(
+        self: &Arc<Self>,
+        client_id: &str,
+        workspace_path: Option<String>,
+        remote_connection_id: Option<String>,
+        session_storage_path: Option<PathBuf>,
+        bitfun_session_id: String,
+    ) -> BitFunResult<Vec<AcpAvailableCommand>> {
+        let resolved = self
+            .resolve_or_create_client_session(
+                client_id,
+                workspace_path,
+                remote_connection_id.as_deref(),
+                &bitfun_session_id,
+            )
+            .await?;
+
+        let mut session = resolved.session.lock().await;
+        self.ensure_remote_session(
+            &resolved.client,
+            &resolved.session_key,
+            &resolved.cwd,
+            &bitfun_session_id,
+            session_storage_path.as_deref(),
+            &mut session,
+        )
+        .await?;
+        Ok(session.available_commands.clone())
+    }
+
     pub async fn set_session_model(
         self: &Arc<Self>,
         request: SetAcpSessionModelRequest,
@@ -1081,6 +1118,7 @@ impl AcpClientService {
                         )
                         .await?;
                         update_session_context_usage(&mut session, &events);
+                        update_session_available_commands(&mut session, &events);
                         for event in events {
                             for event in round_tracker.apply(event) {
                                 on_event(event)?;
@@ -2206,6 +2244,22 @@ fn update_session_context_usage(session: &mut AcpRemoteSession, events: &[AcpCli
     };
 
     session.context_usage = Some(usage);
+}
+
+fn update_session_available_commands(
+    session: &mut AcpRemoteSession,
+    events: &[AcpClientStreamEvent],
+) {
+    // The agent re-sends the full command list on each update, so the latest
+    // wins (replace rather than merge).
+    let Some(commands) = events.iter().rev().find_map(|event| match event {
+        AcpClientStreamEvent::AvailableCommandsUpdated(commands) => Some(commands.clone()),
+        _ => None,
+    }) else {
+        return;
+    };
+
+    session.available_commands = commands;
 }
 
 fn protocol_error(error: impl std::fmt::Display) -> BitFunError {

--- a/src/crates/acp/src/client/manager.rs
+++ b/src/crates/acp/src/client/manager.rs
@@ -1119,6 +1119,7 @@ impl AcpClientService {
                         .await?;
                         update_session_context_usage(&mut session, &events);
                         update_session_available_commands(&mut session, &events);
+                        update_session_config_options(&mut session, &events);
                         for event in events {
                             for event in round_tracker.apply(event) {
                                 on_event(event)?;
@@ -2260,6 +2261,21 @@ fn update_session_available_commands(
     };
 
     session.available_commands = commands;
+}
+
+fn update_session_config_options(
+    session: &mut AcpRemoteSession,
+    events: &[AcpClientStreamEvent],
+) {
+    // The agent sends the full set each time, so the latest update wins.
+    let Some(options) = events.iter().rev().find_map(|event| match event {
+        AcpClientStreamEvent::ConfigOptionsUpdated(options) => Some(options.clone()),
+        _ => None,
+    }) else {
+        return;
+    };
+
+    session.config_options = options;
 }
 
 fn protocol_error(error: impl std::fmt::Display) -> BitFunError {

--- a/src/crates/acp/src/client/mod.rs
+++ b/src/crates/acp/src/client/mod.rs
@@ -20,5 +20,7 @@ pub use manager::{
     AcpClientPermissionResponse, AcpClientService, CreateAcpFlowSessionRecordResponse,
     SetAcpSessionModelRequest, SubmitAcpPermissionResponseRequest,
 };
-pub use session_options::{AcpSessionContextUsage, AcpSessionModelOption, AcpSessionOptions};
+pub use session_options::{
+    AcpAvailableCommand, AcpSessionContextUsage, AcpSessionModelOption, AcpSessionOptions,
+};
 pub use stream::AcpClientStreamEvent;

--- a/src/crates/acp/src/client/session_options.rs
+++ b/src/crates/acp/src/client/session_options.rs
@@ -23,6 +23,41 @@ impl From<agent_client_protocol::schema::UsageUpdate> for AcpSessionContextUsage
     }
 }
 
+/// A slash command advertised by an ACP agent via `AvailableCommandsUpdate`.
+///
+/// Surfaced to the frontend so it can render a `/` command menu. Invocation is
+/// plain text: the client sends `session/prompt` with `/<name> <args>` — there
+/// is no dedicated command RPC in ACP.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpAvailableCommand {
+    /// Command name without the leading slash (e.g. `create_plan`).
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Hint for the unstructured input typed after the command name, if the
+    /// command takes input. `None` means the command takes no arguments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_hint: Option<String>,
+}
+
+impl From<agent_client_protocol::schema::AvailableCommand> for AcpAvailableCommand {
+    fn from(command: agent_client_protocol::schema::AvailableCommand) -> Self {
+        use agent_client_protocol::schema::AvailableCommandInput;
+        let input_hint = command.input.and_then(|input| match input {
+            AvailableCommandInput::Unstructured(unstructured) => Some(unstructured.hint),
+            // `AvailableCommandInput` is #[non_exhaustive]; unknown future input
+            // kinds carry no hint we can render.
+            _ => None,
+        });
+        Self {
+            name: command.name,
+            description: command.description,
+            input_hint,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AcpSessionOptions {
@@ -197,5 +232,26 @@ mod tests {
                 .map(|cost| cost.currency.as_str()),
             Some("USD")
         );
+    }
+
+    #[test]
+    fn converts_available_command_with_and_without_input() {
+        use agent_client_protocol::schema::{
+            AvailableCommand, AvailableCommandInput, UnstructuredCommandInput,
+        };
+
+        let with_input = AvailableCommand::new("create_plan", "Draft an execution plan")
+            .input(AvailableCommandInput::Unstructured(
+                UnstructuredCommandInput::new("what to plan"),
+            ));
+        let converted = AcpAvailableCommand::from(with_input);
+        assert_eq!(converted.name, "create_plan");
+        assert_eq!(converted.description, "Draft an execution plan");
+        assert_eq!(converted.input_hint.as_deref(), Some("what to plan"));
+
+        let no_input = AvailableCommand::new("compact", "Compact the context");
+        let converted = AcpAvailableCommand::from(no_input);
+        assert_eq!(converted.name, "compact");
+        assert!(converted.input_hint.is_none());
     }
 }

--- a/src/crates/acp/src/client/session_options.rs
+++ b/src/crates/acp/src/client/session_options.rs
@@ -58,6 +58,42 @@ impl From<agent_client_protocol::schema::AvailableCommand> for AcpAvailableComma
     }
 }
 
+/// One entry of an agent's execution plan (ACP `Plan` / agent-plan), surfaced to
+/// the frontend so it can render a live task checklist during a turn.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpPlanEntry {
+    /// Human-readable description of the task.
+    pub content: String,
+    /// `"high"` | `"medium"` | `"low"`.
+    pub priority: String,
+    /// `"pending"` | `"in_progress"` | `"completed"`.
+    pub status: String,
+}
+
+impl From<agent_client_protocol::schema::PlanEntry> for AcpPlanEntry {
+    fn from(entry: agent_client_protocol::schema::PlanEntry) -> Self {
+        use agent_client_protocol::schema::{PlanEntryPriority, PlanEntryStatus};
+        let priority = match entry.priority {
+            PlanEntryPriority::High => "high",
+            PlanEntryPriority::Medium => "medium",
+            PlanEntryPriority::Low => "low",
+            _ => "medium",
+        };
+        let status = match entry.status {
+            PlanEntryStatus::Pending => "pending",
+            PlanEntryStatus::InProgress => "in_progress",
+            PlanEntryStatus::Completed => "completed",
+            _ => "pending",
+        };
+        Self {
+            content: entry.content,
+            priority: priority.to_string(),
+            status: status.to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AcpSessionOptions {

--- a/src/crates/acp/src/client/stream.rs
+++ b/src/crates/acp/src/client/stream.rs
@@ -8,7 +8,7 @@ use agent_client_protocol::util::MatchDispatch;
 use bitfun_core::util::errors::{BitFunError, BitFunResult};
 use bitfun_events::ToolEventData;
 
-use super::session_options::AcpSessionContextUsage;
+use super::session_options::{AcpAvailableCommand, AcpSessionContextUsage};
 use super::tool_card_bridge::{acp_tool_name, normalize_tool_params};
 
 #[derive(Debug, Clone)]
@@ -22,6 +22,8 @@ pub enum AcpClientStreamEvent {
     AgentThought(String),
     ToolEvent(ToolEventData),
     ContextUsageUpdated(AcpSessionContextUsage),
+    /// The agent advertised (or updated) its slash commands.
+    AvailableCommandsUpdated(Vec<AcpAvailableCommand>),
     Completed,
     Cancelled,
 }
@@ -80,6 +82,7 @@ impl AcpStreamRoundTracker {
             }
             AcpClientStreamEvent::ModelRoundStarted { .. }
             | AcpClientStreamEvent::ContextUsageUpdated(_)
+            | AcpClientStreamEvent::AvailableCommandsUpdated(_)
             | AcpClientStreamEvent::Completed
             | AcpClientStreamEvent::Cancelled => vec![event],
         }
@@ -128,6 +131,14 @@ pub(super) async fn acp_dispatch_to_stream_events_with_tracker(
                     events.push(AcpClientStreamEvent::ContextUsageUpdated(
                         AcpSessionContextUsage::from(usage_update),
                     ));
+                }
+                SessionUpdate::AvailableCommandsUpdate(update) => {
+                    let commands = update
+                        .available_commands
+                        .into_iter()
+                        .map(AcpAvailableCommand::from)
+                        .collect();
+                    events.push(AcpClientStreamEvent::AvailableCommandsUpdated(commands));
                 }
                 _ => {}
             }
@@ -432,6 +443,7 @@ mod tests {
                 AcpClientStreamEvent::AgentThought(_) => "thought",
                 AcpClientStreamEvent::ToolEvent(_) => "tool",
                 AcpClientStreamEvent::ContextUsageUpdated(_) => "usage",
+                AcpClientStreamEvent::AvailableCommandsUpdated(_) => "commands",
                 AcpClientStreamEvent::Completed => "completed",
                 AcpClientStreamEvent::Cancelled => "cancelled",
             })
@@ -465,6 +477,41 @@ mod tests {
             events.as_slice(),
             [AcpClientStreamEvent::ContextUsageUpdated(usage)] if usage.used == 1_000 && usage.size == 4_000
         ));
+    }
+
+    #[test]
+    fn exposes_available_commands_updates() {
+        use agent_client_protocol::schema::{AvailableCommand, AvailableCommandsUpdate};
+        use agent_client_protocol::JsonRpcMessage;
+
+        let mut tracker = AcpToolCallTracker::new();
+        let notification = SessionNotification::new(
+            "session-1",
+            SessionUpdate::AvailableCommandsUpdate(AvailableCommandsUpdate::new(vec![
+                AvailableCommand::new("compact", "Compact the context"),
+                AvailableCommand::new("init", "Initialize the project"),
+            ])),
+        )
+        .to_untyped_message()
+        .expect("notification");
+        let dispatch = agent_client_protocol::Dispatch::Notification(notification);
+
+        let events = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(acp_dispatch_to_stream_events_with_tracker(
+                dispatch,
+                &mut tracker,
+            ))
+            .expect("dispatch");
+
+        match events.as_slice() {
+            [AcpClientStreamEvent::AvailableCommandsUpdated(commands)] => {
+                assert_eq!(commands.len(), 2);
+                assert_eq!(commands[0].name, "compact");
+                assert_eq!(commands[1].name, "init");
+            }
+            other => panic!("expected AvailableCommandsUpdated, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/crates/acp/src/client/stream.rs
+++ b/src/crates/acp/src/client/stream.rs
@@ -8,7 +8,7 @@ use agent_client_protocol::util::MatchDispatch;
 use bitfun_core::util::errors::{BitFunError, BitFunResult};
 use bitfun_events::ToolEventData;
 
-use super::session_options::{AcpAvailableCommand, AcpSessionContextUsage};
+use super::session_options::{AcpAvailableCommand, AcpPlanEntry, AcpSessionContextUsage};
 use super::tool_card_bridge::{acp_tool_name, normalize_tool_params};
 
 #[derive(Debug, Clone)]
@@ -24,6 +24,9 @@ pub enum AcpClientStreamEvent {
     ContextUsageUpdated(AcpSessionContextUsage),
     /// The agent advertised (or updated) its slash commands.
     AvailableCommandsUpdated(Vec<AcpAvailableCommand>),
+    /// The agent published (or revised) its execution plan. Replaces the prior
+    /// plan in full.
+    PlanUpdated(Vec<AcpPlanEntry>),
     Completed,
     Cancelled,
 }
@@ -83,6 +86,7 @@ impl AcpStreamRoundTracker {
             AcpClientStreamEvent::ModelRoundStarted { .. }
             | AcpClientStreamEvent::ContextUsageUpdated(_)
             | AcpClientStreamEvent::AvailableCommandsUpdated(_)
+            | AcpClientStreamEvent::PlanUpdated(_)
             | AcpClientStreamEvent::Completed
             | AcpClientStreamEvent::Cancelled => vec![event],
         }
@@ -139,6 +143,10 @@ pub(super) async fn acp_dispatch_to_stream_events_with_tracker(
                         .map(AcpAvailableCommand::from)
                         .collect();
                     events.push(AcpClientStreamEvent::AvailableCommandsUpdated(commands));
+                }
+                SessionUpdate::Plan(plan) => {
+                    let entries = plan.entries.into_iter().map(AcpPlanEntry::from).collect();
+                    events.push(AcpClientStreamEvent::PlanUpdated(entries));
                 }
                 _ => {}
             }
@@ -444,6 +452,7 @@ mod tests {
                 AcpClientStreamEvent::ToolEvent(_) => "tool",
                 AcpClientStreamEvent::ContextUsageUpdated(_) => "usage",
                 AcpClientStreamEvent::AvailableCommandsUpdated(_) => "commands",
+                AcpClientStreamEvent::PlanUpdated(_) => "plan",
                 AcpClientStreamEvent::Completed => "completed",
                 AcpClientStreamEvent::Cancelled => "cancelled",
             })
@@ -511,6 +520,45 @@ mod tests {
                 assert_eq!(commands[1].name, "init");
             }
             other => panic!("expected AvailableCommandsUpdated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exposes_plan_updates() {
+        use agent_client_protocol::schema::{
+            Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus,
+        };
+        use agent_client_protocol::JsonRpcMessage;
+
+        let mut tracker = AcpToolCallTracker::new();
+        let notification = SessionNotification::new(
+            "session-1",
+            SessionUpdate::Plan(Plan::new(vec![
+                PlanEntry::new("Explore", PlanEntryPriority::High, PlanEntryStatus::Completed),
+                PlanEntry::new("Implement", PlanEntryPriority::Medium, PlanEntryStatus::InProgress),
+            ])),
+        )
+        .to_untyped_message()
+        .expect("notification");
+        let dispatch = agent_client_protocol::Dispatch::Notification(notification);
+
+        let events = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(acp_dispatch_to_stream_events_with_tracker(
+                dispatch,
+                &mut tracker,
+            ))
+            .expect("dispatch");
+
+        match events.as_slice() {
+            [AcpClientStreamEvent::PlanUpdated(entries)] => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0].content, "Explore");
+                assert_eq!(entries[0].priority, "high");
+                assert_eq!(entries[0].status, "completed");
+                assert_eq!(entries[1].status, "in_progress");
+            }
+            other => panic!("expected PlanUpdated, got {other:?}"),
         }
     }
 

--- a/src/crates/acp/src/client/stream.rs
+++ b/src/crates/acp/src/client/stream.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use agent_client_protocol::schema::{
-    ContentBlock, ContentChunk, SessionNotification, SessionUpdate, ToolCall, ToolCallContent,
-    ToolCallStatus, ToolCallUpdate,
+    ContentBlock, ContentChunk, SessionConfigOption, SessionNotification, SessionUpdate, ToolCall,
+    ToolCallContent, ToolCallStatus, ToolCallUpdate,
 };
 use agent_client_protocol::util::MatchDispatch;
 use bitfun_core::util::errors::{BitFunError, BitFunResult};
@@ -27,6 +27,10 @@ pub enum AcpClientStreamEvent {
     /// The agent published (or revised) its execution plan. Replaces the prior
     /// plan in full.
     PlanUpdated(Vec<AcpPlanEntry>),
+    /// The agent updated its session configuration options (full set). Used to
+    /// keep the session's stored options fresh so model/options queries stay
+    /// accurate mid-session.
+    ConfigOptionsUpdated(Vec<SessionConfigOption>),
     Completed,
     Cancelled,
 }
@@ -87,6 +91,7 @@ impl AcpStreamRoundTracker {
             | AcpClientStreamEvent::ContextUsageUpdated(_)
             | AcpClientStreamEvent::AvailableCommandsUpdated(_)
             | AcpClientStreamEvent::PlanUpdated(_)
+            | AcpClientStreamEvent::ConfigOptionsUpdated(_)
             | AcpClientStreamEvent::Completed
             | AcpClientStreamEvent::Cancelled => vec![event],
         }
@@ -147,6 +152,11 @@ pub(super) async fn acp_dispatch_to_stream_events_with_tracker(
                 SessionUpdate::Plan(plan) => {
                     let entries = plan.entries.into_iter().map(AcpPlanEntry::from).collect();
                     events.push(AcpClientStreamEvent::PlanUpdated(entries));
+                }
+                SessionUpdate::ConfigOptionUpdate(update) => {
+                    events.push(AcpClientStreamEvent::ConfigOptionsUpdated(
+                        update.config_options,
+                    ));
                 }
                 _ => {}
             }
@@ -453,6 +463,7 @@ mod tests {
                 AcpClientStreamEvent::ContextUsageUpdated(_) => "usage",
                 AcpClientStreamEvent::AvailableCommandsUpdated(_) => "commands",
                 AcpClientStreamEvent::PlanUpdated(_) => "plan",
+                AcpClientStreamEvent::ConfigOptionsUpdated(_) => "config_options",
                 AcpClientStreamEvent::Completed => "completed",
                 AcpClientStreamEvent::Cancelled => "cancelled",
             })
@@ -559,6 +570,45 @@ mod tests {
                 assert_eq!(entries[1].status, "in_progress");
             }
             other => panic!("expected PlanUpdated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exposes_config_option_updates() {
+        use agent_client_protocol::schema::{ConfigOptionUpdate, SessionConfigOption};
+        use agent_client_protocol::JsonRpcMessage;
+
+        let mut tracker = AcpToolCallTracker::new();
+        let notification = SessionNotification::new(
+            "session-1",
+            SessionUpdate::ConfigOptionUpdate(ConfigOptionUpdate::new(vec![
+                SessionConfigOption::select(
+                    "model",
+                    "Model",
+                    "fast",
+                    vec![agent_client_protocol::schema::SessionConfigSelectOption::new(
+                        "fast", "Fast",
+                    )],
+                ),
+            ])),
+        )
+        .to_untyped_message()
+        .expect("notification");
+        let dispatch = agent_client_protocol::Dispatch::Notification(notification);
+
+        let events = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(acp_dispatch_to_stream_events_with_tracker(
+                dispatch,
+                &mut tracker,
+            ))
+            .expect("dispatch");
+
+        match events.as_slice() {
+            [AcpClientStreamEvent::ConfigOptionsUpdated(options)] => {
+                assert_eq!(options.len(), 1);
+            }
+            other => panic!("expected ConfigOptionsUpdated, got {other:?}"),
         }
     }
 

--- a/src/web-ui/src/flow_chat/components/AcpPlanPanel.scss
+++ b/src/web-ui/src/flow_chat/components/AcpPlanPanel.scss
@@ -1,0 +1,96 @@
+/**
+ * ACP execution-plan checklist, rendered above the chat input while an ACP
+ * agent streams a plan.
+ */
+
+.bitfun-acp-plan {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--element-bg-medium);
+  border: 1px solid var(--border-color-light);
+  font-size: var(--flowchat-font-size-xs);
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__title {
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    font-size: var(--flowchat-font-size-2xs);
+  }
+
+  &__progress {
+    color: var(--color-text-tertiary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__item {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 2px 0;
+    color: var(--color-text-primary);
+
+    &--completed {
+      color: var(--color-text-tertiary);
+
+      .bitfun-acp-plan__content {
+        text-decoration: line-through;
+      }
+    }
+
+    &--pending {
+      color: var(--color-text-secondary);
+    }
+  }
+
+  &__icon {
+    flex-shrink: 0;
+    margin-top: 2px;
+
+    &--done {
+      color: var(--color-success, #4caf50);
+    }
+
+    &--active {
+      color: var(--color-primary, #648cff);
+      animation: bitfun-acp-plan-spin 1.2s linear infinite;
+    }
+
+    &--pending {
+      opacity: 0.5;
+    }
+  }
+
+  &__content {
+    line-height: 1.4;
+    word-break: break-word;
+  }
+}
+
+@keyframes bitfun-acp-plan-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/web-ui/src/flow_chat/components/AcpPlanPanel.tsx
+++ b/src/web-ui/src/flow_chat/components/AcpPlanPanel.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Check, CircleDashed, LoaderCircle } from 'lucide-react';
+
+import type { AcpPlanEntry } from '@/infrastructure/api/service-api/ACPClientAPI';
+import './AcpPlanPanel.scss';
+
+export interface AcpPlanPanelProps {
+  entries: AcpPlanEntry[];
+}
+
+function statusIcon(status: string): React.ReactNode {
+  switch (status) {
+    case 'completed':
+      return <Check size={13} className="bitfun-acp-plan__icon bitfun-acp-plan__icon--done" />;
+    case 'in_progress':
+      return (
+        <LoaderCircle
+          size={13}
+          className="bitfun-acp-plan__icon bitfun-acp-plan__icon--active"
+        />
+      );
+    default:
+      return (
+        <CircleDashed size={13} className="bitfun-acp-plan__icon bitfun-acp-plan__icon--pending" />
+      );
+  }
+}
+
+/**
+ * Renders an ACP agent's execution plan as a live task checklist. Presentational
+ * only — fed by {@link useAcpPlan}. Renders nothing when there are no entries.
+ */
+export const AcpPlanPanel: React.FC<AcpPlanPanelProps> = ({ entries }) => {
+  if (entries.length === 0) return null;
+
+  const done = entries.filter((entry) => entry.status === 'completed').length;
+
+  return (
+    <div className="bitfun-acp-plan" data-testid="acp-plan-panel">
+      <div className="bitfun-acp-plan__header">
+        <span className="bitfun-acp-plan__title">Plan</span>
+        <span className="bitfun-acp-plan__progress">
+          {done}/{entries.length}
+        </span>
+      </div>
+      <ul className="bitfun-acp-plan__list">
+        {entries.map((entry, index) => (
+          <li
+            key={`${index}-${entry.content}`}
+            className={`bitfun-acp-plan__item bitfun-acp-plan__item--${entry.status}`}
+          >
+            {statusIcon(entry.status)}
+            <span className="bitfun-acp-plan__content">{entry.content}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+AcpPlanPanel.displayName = 'AcpPlanPanel';
+export default AcpPlanPanel;

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -2544,7 +2544,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       e.preventDefault();
       void handleCancelCurrentTask();
     }
-  }, [handleSendOrCancel, submitBtwFromInput, submitGoalFromInput, derivedState, handleCancelCurrentTask, slashCommandState, getFilteredIncrementalModes, getFilteredActions, getSlashPickerItems, selectSlashCommandMode, selectSlashCommandAction, selectSlashPromptCommand, canSwitchModes, historyIndex, inputHistory, savedDraft, inputState.value, currentSessionId, isBtwSession, showTargetSwitcher, setInputTarget, t]);
+  }, [handleSendOrCancel, submitBtwFromInput, submitGoalFromInput, derivedState, handleCancelCurrentTask, slashCommandState, getFilteredIncrementalModes, getFilteredActions, getSlashPickerItems, selectSlashCommandMode, selectSlashCommandAction, selectSlashAcpCommand, selectSlashPromptCommand, canSwitchModes, historyIndex, inputHistory, savedDraft, inputState.value, currentSessionId, isBtwSession, showTargetSwitcher, setInputTarget, t]);
 
   const handleImeCompositionStart = useCallback(() => {
     isImeComposingRef.current = true;

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -20,6 +20,10 @@ import {
 import { SessionExecutionEvent } from '../state-machine/types';
 import { ModelSelector } from './ModelSelector';
 import { FlowChatStore } from '../store/FlowChatStore';
+import { useAcpSlashCommands } from '../hooks/useAcpSlashCommands';
+import { useAcpPlan } from '../hooks/useAcpPlan';
+import { AcpPlanPanel } from './AcpPlanPanel';
+import { acpSessionRef, acpSlashCommandText } from '../utils/acpSession';
 import type { FlowChatState, Session } from '../types/flow-chat';
 import type { FileContext, DirectoryContext, ImageContext } from '@/types/context.ts';
 import { SmartRecommendations } from './smart-recommendations';
@@ -102,7 +106,14 @@ type SlashMcpPromptItem = {
   }>;
 };
 
-type SlashPickerItem = SlashActionItem | SlashModeItem | SlashMcpPromptItem;
+type SlashAcpCommandItem = {
+  kind: 'acpCommand';
+  id: string; // the agent command name (without leading slash)
+  command: string; // '/<name>'
+  label: string; // description
+};
+
+type SlashPickerItem = SlashActionItem | SlashModeItem | SlashMcpPromptItem | SlashAcpCommandItem;
 type ChatInputTarget = 'main' | 'btw';
 type PendingLargePasteMap = Record<string, string>;
 
@@ -269,6 +280,15 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     : undefined;
   const effectiveTargetRelationship = resolveSessionRelationship(effectiveTargetSession);
   const isBtwSession = effectiveTargetRelationship.displayAsChild;
+
+  // ACP agent slash commands (empty for non-ACP sessions). Surfaced in the
+  // existing slash picker alongside native actions / MCP prompts.
+  const acpSessionForCommands = useMemo(
+    () => acpSessionRef(effectiveTargetSession),
+    [effectiveTargetSession],
+  );
+  const { commands: acpAgentCommands } = useAcpSlashCommands(acpSessionForCommands);
+  const { entries: acpPlanEntries } = useAcpPlan(acpSessionForCommands?.sessionId ?? null);
   const currentSessionTitle = currentSession?.title?.trim() || t('session.untitled');
   const activeBtwSession = activeBtwSessionId
     ? flowChatState.sessions.get(activeBtwSessionId)
@@ -1258,6 +1278,21 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     });
   }, [mcpPromptCommands, slashCommandState.query]);
 
+  const getFilteredAcpCommands = useCallback((): SlashAcpCommandItem[] => {
+    const items: SlashAcpCommandItem[] = acpAgentCommands.map(command => ({
+      kind: 'acpCommand',
+      id: command.name,
+      command: `/${command.name}`,
+      label: command.description,
+    }));
+    const q = (slashCommandState.query || '').trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(item =>
+      item.command.slice(1).toLowerCase().includes(q) ||
+      item.label.toLowerCase().includes(q),
+    );
+  }, [acpAgentCommands, slashCommandState.query]);
+
   const resolveTypedMcpPromptCommand = useCallback((text: string): SlashMcpPromptItem | null => {
     const trimmed = text.trim();
     if (!trimmed.startsWith('/')) {
@@ -1277,6 +1312,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const getSlashPickerItems = useCallback((): SlashPickerItem[] => {
     const actions = getFilteredActions();
     const mcpPrompts = getFilteredMcpPromptCommands();
+    const acpCommands = getFilteredAcpCommands();
     let modeList = incrementalCodeModes;
     if (canSwitchModes && slashCommandState.query) {
       const q = slashCommandState.query;
@@ -1291,8 +1327,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       id: mode.id,
       name: mode.name,
     }));
-    return [...actions, ...mcpPrompts, ...modes];
-  }, [canSwitchModes, getFilteredActions, getFilteredMcpPromptCommands, incrementalCodeModes, slashCommandState.query]);
+    // ACP agent commands first — for an ACP session they are the primary
+    // commands the user wants.
+    return [...acpCommands, ...actions, ...mcpPrompts, ...modes];
+  }, [canSwitchModes, getFilteredAcpCommands, getFilteredActions, getFilteredMcpPromptCommands, incrementalCodeModes, slashCommandState.query]);
   
   const handleInputChange = useCallback((text: string, activeContexts: import('../../shared/types/context').ContextItem[]) => {
     if (!inputState.isActive && text.length > 0) {
@@ -2209,6 +2247,15 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     window.setTimeout(() => richTextInputRef.current?.focus(), 0);
   }, [setQueuedInput]);
 
+  const selectSlashAcpCommand = useCallback((item: SlashAcpCommandItem) => {
+    // Insert "/<name> " as prompt text — ACP has no command RPC; the command is
+    // sent as a normal prompt. The trailing space lets the user type arguments.
+    dispatchInput({ type: 'SET_VALUE', payload: acpSlashCommandText(item.id) });
+    setQueuedInput(null);
+    setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
+    window.setTimeout(() => richTextInputRef.current?.focus(), 0);
+  }, [setQueuedInput]);
+
   const handleBoostStartBtw = useCallback(
     (e: React.SyntheticEvent) => {
       e.stopPropagation();
@@ -2331,6 +2378,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 selectSlashCommandMode(item.id);
               } else if (item.kind === 'mcpPrompt') {
                 selectSlashPromptCommand(item);
+              } else if (item.kind === 'acpCommand') {
+                selectSlashAcpCommand(item);
               } else {
                 selectSlashCommandAction(item.id);
               }
@@ -2366,6 +2415,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 selectSlashCommandMode(item.id);
               } else if (item.kind === 'mcpPrompt') {
                 selectSlashPromptCommand(item);
+              } else if (item.kind === 'acpCommand') {
+                selectSlashAcpCommand(item);
               } else {
                 selectSlashCommandAction(item.id);
               }
@@ -2743,6 +2794,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         <PendingQueuePanel sessionId={effectiveTargetSessionId || undefined} />
 
         <div className="bitfun-chat-input__container">
+          <AcpPlanPanel entries={acpPlanEntries} />
           <div className={`bitfun-chat-input__box ${isMultiLine ? 'bitfun-chat-input__box--multi-line' : 'bitfun-chat-input__box--capsule'}`}>
             {showTargetSwitcher && (
               <div className="bitfun-chat-input__target-switcher" data-testid="chat-input-target-switcher">
@@ -2908,6 +2960,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                                   selectSlashCommandMode(item.id);
                                 } else if (item.kind === 'mcpPrompt') {
                                   selectSlashPromptCommand(item);
+                                } else if (item.kind === 'acpCommand') {
+                                  selectSlashAcpCommand(item);
                                 } else {
                                   selectSlashCommandAction(item.id);
                                 }

--- a/src/web-ui/src/flow_chat/hooks/useAcpPlan.ts
+++ b/src/web-ui/src/flow_chat/hooks/useAcpPlan.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+import type {
+  AcpPlanEntry,
+  AcpPlanUpdatedEvent,
+} from '@/infrastructure/api/service-api/ACPClientAPI';
+
+const PLAN_UPDATED_EVENT = 'agentic://acp-plan-updated';
+
+/**
+ * Track the execution plan an ACP agent publishes for the given session.
+ *
+ * The agent sends the full plan on each update (it replaces the prior one), so
+ * the latest event wins. Returns an empty list for non-ACP sessions or before
+ * the agent publishes a plan. Resets when the session changes.
+ */
+export function useAcpPlan(sessionId: string | null): { entries: AcpPlanEntry[] } {
+  const [entries, setEntries] = useState<AcpPlanEntry[]>([]);
+
+  useEffect(() => {
+    setEntries([]);
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    let active = true;
+    let unlisten: UnlistenFn | undefined;
+    listen<AcpPlanUpdatedEvent>(PLAN_UPDATED_EVENT, (event) => {
+      if (event.payload.sessionId === sessionId) {
+        setEntries(event.payload.entries);
+      }
+    }).then((fn) => {
+      if (active) unlisten = fn;
+      else fn();
+    });
+    return () => {
+      active = false;
+      unlisten?.();
+    };
+  }, [sessionId]);
+
+  return { entries };
+}

--- a/src/web-ui/src/flow_chat/hooks/useAcpSlashCommands.test.ts
+++ b/src/web-ui/src/flow_chat/hooks/useAcpSlashCommands.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AcpAvailableCommand } from '@/infrastructure/api/service-api/ACPClientAPI';
+import { filterSlashCommands } from './useAcpSlashCommands';
+import { acpSessionRef, acpSlashCommandText } from '../utils/acpSession';
+
+const commands: AcpAvailableCommand[] = [
+  { name: 'compact', description: 'Compact the conversation context' },
+  { name: 'init', description: 'Initialize the project' },
+  { name: 'create_plan', description: 'Draft an execution plan', inputHint: 'what to plan' },
+];
+
+describe('filterSlashCommands', () => {
+  it('returns all commands for an empty query', () => {
+    expect(filterSlashCommands(commands, '')).toHaveLength(3);
+    expect(filterSlashCommands(commands, '   ')).toHaveLength(3);
+  });
+
+  it('tolerates a leading slash', () => {
+    expect(filterSlashCommands(commands, '/comp').map((c) => c.name)).toEqual(['compact']);
+  });
+
+  it('matches on name (case-insensitive)', () => {
+    expect(filterSlashCommands(commands, 'INIT').map((c) => c.name)).toEqual(['init']);
+  });
+
+  it('matches on description', () => {
+    expect(filterSlashCommands(commands, 'plan').map((c) => c.name)).toEqual(['create_plan']);
+  });
+
+  it('returns empty when nothing matches', () => {
+    expect(filterSlashCommands(commands, 'zzz')).toEqual([]);
+  });
+});
+
+describe('acpSlashCommandText', () => {
+  it('formats a command name as invokable prompt text', () => {
+    expect(acpSlashCommandText('create_plan')).toBe('/create_plan ');
+  });
+});
+
+describe('acpSessionRef', () => {
+  it('returns null for a non-ACP session', () => {
+    expect(acpSessionRef({ sessionId: 's1', config: { agentType: 'agentic' }, mode: 'agentic' } as never)).toBeNull();
+  });
+
+  it('returns null when there is no session', () => {
+    expect(acpSessionRef(null)).toBeNull();
+    expect(acpSessionRef(undefined)).toBeNull();
+  });
+
+  it('derives the client id from an acp: agentType', () => {
+    const ref = acpSessionRef({
+      sessionId: 's1',
+      config: { agentType: 'acp:omp', workspacePath: '/ws' },
+      workspacePath: '/ws',
+      remoteConnectionId: 'conn-1',
+      remoteSshHost: 'host-1',
+    } as never);
+    expect(ref).toEqual({
+      sessionId: 's1',
+      clientId: 'omp',
+      workspacePath: '/ws',
+      remoteConnectionId: 'conn-1',
+      remoteSshHost: 'host-1',
+    });
+  });
+
+  it('falls back to mode when config.agentType is not acp', () => {
+    const ref = acpSessionRef({ sessionId: 's2', config: {}, mode: 'acp:claude-code' } as never);
+    expect(ref?.clientId).toBe('claude-code');
+    expect(ref?.sessionId).toBe('s2');
+  });
+});

--- a/src/web-ui/src/flow_chat/hooks/useAcpSlashCommands.ts
+++ b/src/web-ui/src/flow_chat/hooks/useAcpSlashCommands.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+import {
+  ACPClientAPI,
+  type AcpAvailableCommand,
+  type AcpAvailableCommandsUpdatedEvent,
+} from '@/infrastructure/api/service-api/ACPClientAPI';
+import type { AcpSessionRef } from '../utils/acpSession';
+
+const AVAILABLE_COMMANDS_EVENT = 'agentic://acp-available-commands-updated';
+
+/**
+ * Filter advertised slash commands by a query (the text the user has typed
+ * after `/`). A leading slash is tolerated. Matching is case-insensitive over
+ * both the command name and its description. An empty query returns all.
+ */
+export function filterSlashCommands(
+  commands: AcpAvailableCommand[],
+  query: string,
+): AcpAvailableCommand[] {
+  const q = query.trim().toLowerCase().replace(/^\//, '');
+  if (!q) return commands;
+  return commands.filter(
+    (command) =>
+      command.name.toLowerCase().includes(q) ||
+      command.description.toLowerCase().includes(q),
+  );
+}
+
+/**
+ * Track the slash commands an ACP agent advertises for the given session.
+ *
+ * Fetches the current list on mount / session change and then keeps it live by
+ * subscribing to `agentic://acp-available-commands-updated`. Returns an empty
+ * list for non-ACP sessions or before the agent has advertised any commands.
+ */
+export function useAcpSlashCommands(
+  acpSession: AcpSessionRef | null,
+): { commands: AcpAvailableCommand[] } {
+  const [commands, setCommands] = useState<AcpAvailableCommand[]>([]);
+
+  const sessionId = acpSession?.sessionId ?? null;
+  const clientId = acpSession?.clientId ?? null;
+  const workspacePath = acpSession?.workspacePath;
+  const remoteConnectionId = acpSession?.remoteConnectionId;
+  const remoteSshHost = acpSession?.remoteSshHost;
+
+  // Reset immediately when the session changes so a stale list never leaks
+  // across sessions.
+  useEffect(() => {
+    setCommands([]);
+  }, [sessionId]);
+
+  // Initial fetch of whatever the agent has already advertised.
+  useEffect(() => {
+    if (!sessionId || !clientId) return;
+    let cancelled = false;
+    ACPClientAPI.getSessionCommands({
+      sessionId,
+      clientId,
+      workspacePath,
+      remoteConnectionId,
+      remoteSshHost,
+    })
+      .then((list) => {
+        if (!cancelled) setCommands(list);
+      })
+      .catch(() => {
+        /* commands stay empty; the live event may still populate them */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, clientId, workspacePath, remoteConnectionId, remoteSshHost]);
+
+  // Live updates while a turn streams (the agent can change its command set).
+  useEffect(() => {
+    if (!sessionId) return;
+    let active = true;
+    let unlisten: UnlistenFn | undefined;
+    listen<AcpAvailableCommandsUpdatedEvent>(AVAILABLE_COMMANDS_EVENT, (event) => {
+      if (event.payload.sessionId === sessionId) {
+        setCommands(event.payload.commands);
+      }
+    }).then((fn) => {
+      if (active) unlisten = fn;
+      else fn();
+    });
+    return () => {
+      active = false;
+      unlisten?.();
+    };
+  }, [sessionId]);
+
+  return { commands };
+}

--- a/src/web-ui/src/flow_chat/utils/acpSession.ts
+++ b/src/web-ui/src/flow_chat/utils/acpSession.ts
@@ -22,3 +22,41 @@ export function isAcpFlowSession(
     isAcpAgentType(session?.mode),
   );
 }
+
+/** The identifying fields needed to query/observe an ACP session's backend state. */
+export interface AcpSessionRef {
+  sessionId: string;
+  clientId: string;
+  workspacePath?: string;
+  remoteConnectionId?: string;
+  remoteSshHost?: string;
+}
+
+/**
+ * Derive an {@link AcpSessionRef} from a flow-chat session, or `null` if the
+ * session is not ACP-backed. Mirrors the resolution used by ModelSelector.
+ */
+export function acpSessionRef(
+  session: Pick<Session, 'sessionId' | 'config' | 'mode' | 'workspacePath' | 'remoteConnectionId' | 'remoteSshHost'> | null | undefined,
+): AcpSessionRef | null {
+  if (!session?.sessionId) return null;
+  const clientId =
+    acpClientIdFromAgentType(session.config?.agentType) ??
+    acpClientIdFromAgentType(session.mode);
+  if (!clientId) return null;
+  return {
+    sessionId: session.sessionId,
+    clientId,
+    workspacePath: session.workspacePath ?? session.config?.workspacePath,
+    remoteConnectionId: session.remoteConnectionId ?? session.config?.remoteConnectionId,
+    remoteSshHost: session.remoteSshHost,
+  };
+}
+
+/**
+ * The text that invokes an ACP slash command. ACP has no dedicated command RPC:
+ * a command is sent as a normal prompt whose text begins with `/<name>`.
+ */
+export function acpSlashCommandText(name: string): string {
+  return `/${name} `;
+}

--- a/src/web-ui/src/infrastructure/api/service-api/ACPClientAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ACPClientAPI.ts
@@ -119,6 +119,24 @@ export interface SubmitAcpPermissionResponseRequest {
   optionId?: string;
 }
 
+/**
+ * A slash command advertised by an ACP agent (AvailableCommandsUpdate).
+ * Invoked by sending a normal prompt of the form `/<name> <args>`.
+ */
+export interface AcpAvailableCommand {
+  name: string;
+  description: string;
+  /** Hint for the text typed after the command name; absent if no input. */
+  inputHint?: string;
+}
+
+/** Live event payload emitted on `agentic://acp-available-commands-updated`. */
+export interface AcpAvailableCommandsUpdatedEvent {
+  sessionId: string;
+  clientId: string;
+  commands: AcpAvailableCommand[];
+}
+
 export interface AcpPermissionOption {
   optionId: string;
   name: string;
@@ -239,6 +257,17 @@ export class ACPClientAPI {
     request: GetAcpSessionOptionsRequest
   ): Promise<AcpSessionOptions> {
     return api.invoke('get_acp_session_options', { request });
+  }
+
+  /**
+   * Slash commands the agent has advertised for this session. Empty until the
+   * agent sends them (typically during/after the first prompt). Pair with the
+   * `agentic://acp-available-commands-updated` event for live updates.
+   */
+  static async getSessionCommands(
+    request: GetAcpSessionOptionsRequest
+  ): Promise<AcpAvailableCommand[]> {
+    return api.invoke('get_acp_session_commands', { request });
   }
 
   static async setSessionModel(

--- a/src/web-ui/src/infrastructure/api/service-api/ACPClientAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ACPClientAPI.ts
@@ -137,6 +137,23 @@ export interface AcpAvailableCommandsUpdatedEvent {
   commands: AcpAvailableCommand[];
 }
 
+/** One entry of an ACP agent's execution plan (agent-plan). */
+export interface AcpPlanEntry {
+  content: string;
+  /** 'high' | 'medium' | 'low' */
+  priority: string;
+  /** 'pending' | 'in_progress' | 'completed' */
+  status: string;
+}
+
+/** Live event payload emitted on `agentic://acp-plan-updated`. Replaces the plan in full. */
+export interface AcpPlanUpdatedEvent {
+  sessionId: string;
+  turnId: string;
+  clientId: string;
+  entries: AcpPlanEntry[];
+}
+
 export interface AcpPermissionOption {
   optionId: string;
   name: string;

--- a/src/web-ui/src/infrastructure/api/service-api/ACPClientAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ACPClientAPI.ts
@@ -154,6 +154,16 @@ export interface AcpPlanUpdatedEvent {
   entries: AcpPlanEntry[];
 }
 
+/**
+ * Live signal emitted on `agentic://acp-session-options-changed` when the agent
+ * updated its config options mid-session. Consumers should refetch via
+ * `getSessionOptions` to get the fresh combined view.
+ */
+export interface AcpSessionOptionsChangedEvent {
+  sessionId: string;
+  clientId: string;
+}
+
 export interface AcpPermissionOption {
   optionId: string;
   name: string;


### PR DESCRIPTION
## 概要

让 BitFun 的 ACP host 把此前**收到即丢弃**的几个 `session/update` 通知接进来,并补上前端视图层,benefits 所有 ACP agent(opencode / claude-code / codex / omp)。实现 #967 的 **P1 两项(完整三层)** + **P2 一项**。

之前 BitFun 的 ACP client 只处理 `AgentMessageChunk` / `AgentThoughtChunk` / `ToolCall` / `ToolCallUpdate` / `UsageUpdate`,其余 SessionUpdate 变体全部丢弃。

相关:#967(ACP host 完整度跟踪)。

## 改动

### 1. Slash 命令(`AvailableCommandsUpdate`)— 后端 + 逻辑 + UI 全套
ACP 里 slash 命令没有专门 RPC:**发现**靠 agent 的 `AvailableCommandsUpdate`,**调用**靠普通 `session/prompt` 发 `/<name> <args>` 文本。
- 后端:`AcpAvailableCommand` DTO、`stream.rs` 解析、`manager.rs` 按 session 存储 + `get_session_commands` 查询、desktop `get_acp_session_commands` 命令 + `agentic://acp-available-commands-updated` 实时事件。
- 前端逻辑:`ACPClientAPI.getSessionCommands()` + 类型;`useAcpSlashCommands` hook + `filterSlashCommands` / `acpSessionRef` / `acpSlashCommandText` 纯函数(已测)。
- **前端 UI**:接入 ChatInput **已有的 slash picker**(与原生 action / MCP prompt 同一套),新增 `SlashAcpCommandItem`,agent 命令置顶、可点击/键盘选中,选中后插入 `/<name> ` 文本。

### 2. 执行计划(`Plan`)— 后端 + UI
- 后端:`AcpPlanEntry` DTO + `From`(priority→high/medium/low,status→pending/in_progress/completed);`stream.rs` 解析;desktop `agentic://acp-plan-updated` 实时事件;前端类型。
- **前端 UI**:`useAcpPlan(sessionId)` 订阅事件;`AcpPlanPanel` 渲染实时任务清单(状态图标、done/total、完成项删除线),挂在输入框上方,空时不渲染。

### 3. 配置项保鲜(`ConfigOptionUpdate`)
- session 早就存 `config_options` 并被 model/options UI 消费,但 `ConfigOptionUpdate` 通知被忽略 → 中途更新会变陈旧。本 PR 接通,`manager.rs` 替换整套;desktop emit `agentic://acp-session-options-changed` 让前端 refetch。

## 测试
- `cargo test -p bitfun-acp` —— **48 passed**(新增 commands / plan / config-option 三个 dispatch 测试 + command 转换测试)。
- `vitest` —— **151 passed**(slash 命令消费逻辑、acpSession 工具等);ChatInput 布局测试通过。
- `cargo check -p bitfun-desktop`、`tsc --noEmit` —— clean。

## 说明 / 后续
- **In-app 验证**:slash 菜单和 plan 面板是严格照搬现有 slash picker(MCP prompt 路径)与事件订阅模式写的,类型/测试全过;但最终视觉与 contenteditable 交互建议在跑起来的 app 内确认。
- **#967 未含项**:`CurrentModeUpdate`(需配 available_modes + set_mode)、`SessionInfoUpdate`(标题)、以及 P0 的 fs/terminal 宿主能力 —— 更重或需产品决策,留作后续单独 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
