### PR TITLE
feat(agentic): stabilize prompt cache reuse across skill and subagent updates

### DIFF
--- a/docs/architecture/model-request-cache-reuse.md
+++ b/docs/architecture/model-request-cache-reuse.md
@@ -1,0 +1,471 @@
+# Model Request Cache Reuse In BitFun
+
+This note summarizes the mechanisms BitFun uses to improve model-side prompt
+cache reuse and to avoid unnecessary cache invalidation across long-running
+agent sessions.
+
+The implementation is mostly in the shared Rust runtime under
+`src/crates/core/src/agentic/`.
+
+## The Core Idea
+
+BitFun tries to keep the model-visible request prefix as stable as possible.
+It does that in four complementary ways:
+
+1. Cache stable prompt fragments at the session level.
+2. Reuse or clone existing conversation prefixes when creating derived
+   sessions.
+3. Keep compatible coding modes on the same prompt-cache identity.
+4. Move frequently changing surfaces, such as skill and subagent listings, out
+   of the cached base prompt and update them incrementally.
+
+There is also explicit observability for provider-reported cache reads versus
+cache writes so BitFun can measure whether these strategies are actually
+working.
+
+## 1. System Prompt And User Context Are Cached Separately
+
+BitFun does not treat the whole request prefix as one opaque string.
+Instead, it separates two relatively stable layers:
+
+- the system prompt
+- the user-context reminder
+
+The cache model lives in
+`src/crates/core/src/agentic/session/prompt_cache.rs`.
+
+Key details:
+
+- `SystemPromptCacheIdentity` keys the cached system prompt.
+- `UserContextCacheIdentity` keys the cached user-context reminder.
+- `SessionPromptCache` stores both entries independently.
+- `PromptCachePolicy` supports both in-memory TTL and persistence TTL.
+- the default persistence TTL is one day
+  (`DEFAULT_PROMPT_CACHE_PERSISTENCE_TTL`)
+
+Session-level loading, saving, invalidation, and cloning live in
+`src/crates/core/src/agentic/session/session_manager.rs`.
+
+The test coverage in that file also explicitly exercises:
+
+- persistence across session restore
+- persisted invalidation cleanup
+- prompt-cache cloning between sessions
+
+Persistence details:
+
+- prompt cache is persisted as `prompt_cache.json`
+- the file is stored under the session directory in `.bitfun/sessions/...`
+- restore-time TTL cleanup happens before the cache is accepted back into
+  memory
+
+Request assembly uses the cache in
+`src/crates/core/src/agentic/execution/execution_engine.rs`:
+
+- `resolve_cached_system_prompt(...)` reuses a cached system prompt when the
+  scope key still matches
+- `build_cached_prepended_prompt_reminders(...)` reuses the cached
+  user-context reminder when the user-context scope key still matches
+
+One important design choice is documented directly in
+`prompt_builder_impl.rs`: workspace context is intentionally injected outside
+the system prompt cache. That lets BitFun keep the global instruction template
+stable while still handling workspace-dependent context separately.
+
+## 2. Derived Sessions Reuse Existing Prefixes Instead Of Starting Cold
+
+### Session branching
+
+Persisted session branching is implemented in
+`src/crates/core/src/agentic/persistence/session_branch.rs`.
+
+When BitFun branches a session from an existing turn, it copies more than turn
+text:
+
+- the branched turns up to the selected turn
+- persisted turn context snapshots
+- persisted skill/subagent listing snapshots
+- the source session's prompt cache
+- compression state and lineage metadata
+
+This means a branch can continue from a pre-built prefix instead of paying to
+reconstruct everything from scratch.
+
+### `/btw` side questions
+
+`/btw` is implemented as a hidden child session, not as an ad hoc detached
+request.
+
+Relevant code:
+
+- desktop adapter:
+  `src/apps/desktop/src/api/btw_api.rs`
+- child-session creation:
+  `ConversationCoordinator::ensure_hidden_btw_session(...)` in
+  `src/crates/core/src/agentic/coordination/coordinator.rs`
+- side-question prompt wrapper:
+  `src/crates/core/src/agentic/side_question.rs`
+
+The parent context snapshot is not limited to a hot in-memory session. When
+needed, `load_session_context_messages(...)` restores the parent session from
+persistence first and then captures the context snapshot.
+
+The child session is initialized from a captured parent context snapshot:
+
+- same parent agent type
+- same workspace and model config
+- inherited message context
+- cloned session-level prompt cache
+
+That gives the side thread an already-built conversational prefix.
+
+In other words, `/btw` now reuses both:
+
+- the parent message context snapshot
+- the parent session's prompt cache via `SessionManager::clone_prompt_cache(...)`
+
+### `fork_context` subagents
+
+Forked subagents reuse even more.
+
+Relevant code:
+
+- snapshot model:
+  `src/crates/core/src/agentic/fork_agent/mod.rs`
+- request validation and tool contract:
+  `src/crates/core/src/agentic/tools/implementations/task_tool.rs`
+- execution and prompt-cache cloning:
+  `src/crates/core/src/agentic/coordination/coordinator.rs`
+
+When `Task` is called with `fork_context=true`, BitFun:
+
+- captures the parent session's model-visible message context
+- creates an isolated child session with the parent session's agent type,
+  workspace, remote metadata, and model selection
+- clones the parent session's prompt cache into the child session via
+  `SessionManager::clone_prompt_cache(...)`
+
+The `Task` tool also forbids fields that would make the fork drift away from
+the inherited prefix, including `subagent_type`, `workspace_path`, `model_id`,
+and DeepReview retry fields.
+
+That restriction is not just validation polish; it protects cache reuse by
+keeping the forked child aligned with the parent session shape.
+
+## 3. The Shared Coding Modes Intentionally Reuse The Same Cache Identity
+
+BitFun's four shared coding modes are:
+
+- `agentic`
+- `Plan`
+- `debug`
+- `Multitask`
+
+They are intentionally configured to share the same stable prompt base.
+
+Relevant code:
+
+- shared constants and tests:
+  `src/crates/core/src/agentic/agents/mod.rs`
+- mode definitions:
+  `src/crates/core/src/agentic/agents/definitions/modes/{agentic,plan,debug,multitask}.rs`
+
+Why they reuse cache:
+
+- all four modes use the same prompt template:
+  `SHARED_CODING_MODE_PROMPT_TEMPLATE = "agentic_mode"`
+- all four modes use the same user-context policy:
+  `shared_coding_mode_user_context_policy()`
+- `Agent::system_prompt_cache_identity(...)` is derived from
+  `prompt_template_name(...)`
+- `Agent::user_context_cache_identity(...)` is derived from the user-context
+  policy scope key
+
+The test `shared_template_modes_share_system_prompt_cache_identity()` asserts
+that these shared modes intentionally produce the same system-prompt and
+user-context cache identities.
+
+Mode-specific behavior is added through `system_reminder` text, not by swapping
+the cached base template:
+
+- `Plan`, `Debug`, and `Multitask` provide first-entry and ongoing reminder
+  templates
+- reminders are injected immediately before the current user message in
+  `ExecutionEngine::build_ai_messages_for_send(...)`
+
+This is the key reason mode switches between these four coding modes do not
+force a base prompt cache reset.
+
+The frontend also knows about this compatibility:
+
+- `AgentInfo.prompt_cache_scope_key` is produced in
+  `src/crates/core/src/agentic/agents/registry/types.rs`
+- `ChatInput.tsx` only shows a prompt-cache warning when the next mode's scope
+  key differs from the last submitted mode's scope key
+
+In other words, BitFun aligns backend prompt identities and frontend mode-switch
+UX around the same cache-compatibility contract.
+
+## 4. Skill And Subagent Listings Are Hot-Updated Without Rebuilding The Base Prompt
+
+A major source of cache churn in agent systems is dynamic capability listing.
+BitFun explicitly avoids baking that surface into one permanently rebuilt prompt.
+
+Relevant code:
+
+- snapshot and diff model:
+  `src/crates/core/src/agentic/skill_agent_snapshot.rs`
+- sparse snapshot store:
+  `src/crates/core/src/agentic/session/turn_skill_agent_snapshot_store.rs`
+- turn-time diff injection:
+  `ConversationCoordinator::wrap_user_input(...)`
+- baseline reminder reuse:
+  `ExecutionEngine::build_cached_prepended_prompt_reminders(...)`
+
+The strategy is:
+
+1. On the first turn, BitFun saves a full skill/subagent snapshot.
+2. On later turns, it resolves the current snapshot again.
+3. It diffs the latest prior snapshot against the new one.
+4. Only the diff is injected as a reminder when something changed.
+
+This keeps the base cached prefix stable while still letting the model see
+fresh capability changes.
+
+What gets updated dynamically:
+
+- skills
+- visible subagents / agents
+- collapsed tool listing sections
+
+Why this is effectively "hot update":
+
+- local custom subagents are reloaded during request wrapping via
+  `load_custom_subagents(...)`
+- skills are rescanned for the current workspace via
+  `get_resolved_skills_for_workspace(...)`
+- the desktop app also exposes an explicit `reload_subagents` command in
+  `src/apps/desktop/src/api/subagent_api.rs`
+
+So capability changes can reach the next request without restarting the session
+and without rebuilding the main prompt template.
+
+### Current gap: per-agent tool changes still churn request-prefix cache
+
+This is not fully solved yet.
+
+BitFun does allow tool customization at the agent/profile level:
+
+- built-in modes resolve their effective tools from default tools plus user
+  `added_tools` / `removed_tools`
+- custom subagents can define their own tool lists directly
+
+Relevant code:
+
+- mode/profile tool overrides:
+  `src/crates/core/src/service/config/types.rs`
+  and `src/crates/core/src/service/config/mode_config_canonicalizer.rs`
+- runtime resolution of effective agent tool policy:
+  `src/crates/core/src/agentic/agents/registry/query.rs`
+
+However, tool manifests are still recomputed per turn/request, not diff-patched
+like skill and subagent listings.
+
+More precisely:
+
+- `ExecutionEngine` resolves `get_agent_tool_policy(...)` at turn start
+- it then resolves `resolve_tool_manifest(...)`
+- the resulting `tool_definitions` are attached to the model request for that
+  turn
+- all model rounds inside the same turn reuse that resolved tool surface
+
+Relevant code:
+
+- request-time tool manifest resolution:
+  `src/crates/core/src/agentic/execution/execution_engine.rs`
+- tool definitions included in token estimation:
+  `src/crates/core/src/util/token_counter.rs`
+- provider request-body tool attachment:
+  `src/crates/ai-adapters/src/providers/openai/responses.rs`
+  and `src/crates/ai-adapters/src/providers/openai/codex_chatgpt.rs`
+
+This is why tool changes cannot currently be handled the same way as
+skill/subagent listing updates.
+
+Skill and subagent listings are prompt-visible descriptive surfaces, so BitFun
+can:
+
+- keep a baseline
+- send only a diff reminder when they change
+
+But tool availability is different. For many tool-calling providers, the model
+is only allowed to call tools that are present in the current request's tool
+definitions/schema payload.
+
+That creates an asymmetry:
+
+- removing a tool or changing its description can be partially explained with a
+  reminder
+- adding a new callable tool cannot be expressed by reminder alone
+- the new tool must exist in the turn's actual `tool_definitions`
+
+So as long as the callable tool set is request-attached in this provider style,
+new tool additions will necessarily mutate the request prefix surface and
+typically break prompt-cache reuse for that turn.
+
+One plausible future direction would be to expose only a single stable
+"tool-dispatch" entry in the provider request and let that entry accept:
+
+- the real tool name
+- the real tool arguments
+
+In that design, the provider-visible tool schema could stay nearly constant
+even when the product's actual tool catalog changes underneath it.
+
+However, BitFun does not currently plan to implement this.
+
+Reasons:
+
+- it would be a fairly large architectural change across tool schema exposure,
+  execution, validation, safety checks, and provider adapters
+- the cache misses caused by tool-set changes are relatively low-frequency in
+  practice
+- those misses are usually user-driven, because changing an agent's tool set is
+  an explicit configuration action rather than a high-churn runtime event
+
+So while the direction is technically viable, it is not currently attractive
+enough relative to its implementation cost.
+
+## 5. Compression Rebuilds A Smaller Stable Prefix
+
+Compression is not a pure cache-preserving operation, but it is still part of
+BitFun's cache-hit strategy.
+
+Relevant code:
+
+- compression flow:
+  `src/crates/core/src/agentic/execution/execution_engine.rs`
+- compressor:
+  `src/crates/core/src/agentic/session/compression/`
+
+There are two different cache-reuse stories around compression:
+
+1. the compression request itself reuses the current session prefix
+2. the completed compression result intentionally invalidates and rebuilds the
+   session prompt cache
+
+### Compression request path: reuses the existing prefix
+
+BitFun does not send compression as a detached, prompt-from-scratch request.
+
+Instead:
+
+- `build_compression_request_messages(...)` calls
+  `build_ai_messages_for_send(...)`
+- that means the compression request is assembled through the same message-send
+  path used for ordinary model rounds
+- prepended reminders are preserved
+- the current conversation messages are preserved
+
+For automatic compression, the `runtime_messages` passed into
+`build_compression_request_messages(...)` come from the active `messages`
+buffer, which already includes the current system prompt at the front of the
+request.
+
+For manual compaction, the code explicitly rebuilds `runtime_messages` as:
+
+- `system_prompt_message`
+- followed by the current session messages
+
+Only after that shared prefix is rebuilt does BitFun append the final
+compression-specific instruction from
+`context_compressor.build_compact_prompt(...)`.
+
+So the compression model call itself is prefix-reusing by design: it keeps the
+same stable prefix and adds one extra user message that asks the model to
+compact the conversation.
+
+There is even an explicit runtime comment documenting why an older pre-pass was
+removed: the removed "microcompact" rewrite mutated already-sent prefixes and
+"kill[ed] provider KV-cache hits on every round". The current compression path
+keeps that concern front and center.
+
+### Compression completion path: invalidate, then rebuild against a shorter prefix
+
+When compression is applied, BitFun does three important things:
+
+1. Replaces the live context messages with the compressed result.
+2. Rebuilds the skill/subagent listing baseline to the latest snapshot.
+3. Invalidates the session prompt cache because the mutable prefix changed.
+
+That invalidation happens on purpose. After compression, the old cached prompt
+fragments no longer match the new conversation prefix.
+
+However, the next request can rebuild cache entries against a much shorter and
+more stable post-compression prefix. In practice, compression is a "reset once,
+reuse many times after" mechanism, not a permanent loss.
+
+## 6. Cache Observability Is First-Class
+
+BitFun also normalizes provider-specific cache telemetry so cache reuse can be
+measured instead of guessed.
+
+Relevant code:
+
+- unified usage types:
+  `src/crates/ai-adapters/src/stream/types/unified.rs`
+- Anthropic mapping:
+  `src/crates/ai-adapters/src/stream/types/anthropic.rs`
+- OpenAI / DeepSeek mapping:
+  `src/crates/ai-adapters/src/stream/types/openai.rs`
+- runtime event emission:
+  `src/crates/core/src/agentic/execution/round_executor.rs`
+
+Two fields matter:
+
+- `cached_content_token_count`: cache reads / hits
+- `cache_creation_token_count`: cache writes / creation
+
+BitFun keeps them separate on purpose. That avoids overstating hit rate and
+makes it possible to answer both of these questions correctly:
+
+- "How many input tokens were served from cache?"
+- "How many input tokens were spent creating new cache entries?"
+
+## Summary
+
+BitFun improves request cache hit rate by combining prompt splitting, session
+reuse, compatible mode identities, incremental capability-list updates, and
+post-compression prefix rebuilding.
+
+The most important implementation choices are:
+
+- stable prompt pieces are cached separately and persisted per session
+- derived sessions reuse parent prefixes instead of starting from zero
+- shared coding modes keep the same cache identity and express differences as
+  reminders
+- dynamic capability surfaces are updated incrementally outside the base cached
+  prompt
+- provider cache-read and cache-write telemetry is tracked separately
+
+## Implementation Map
+
+- Prompt cache model:
+  `src/crates/core/src/agentic/session/prompt_cache.rs`
+- Prompt cache lifecycle:
+  `src/crates/core/src/agentic/session/session_manager.rs`
+- Request assembly and cache hits:
+  `src/crates/core/src/agentic/execution/execution_engine.rs`
+- Fork snapshot model:
+  `src/crates/core/src/agentic/fork_agent/mod.rs`
+- Session branching:
+  `src/crates/core/src/agentic/persistence/session_branch.rs`
+- Side-question child sessions:
+  `src/crates/core/src/agentic/coordination/coordinator.rs`
+  and `src/apps/desktop/src/api/btw_api.rs`
+- Shared coding-mode identities:
+  `src/crates/core/src/agentic/agents/mod.rs`
+- Dynamic skill/agent listing snapshots:
+  `src/crates/core/src/agentic/skill_agent_snapshot.rs`
+- Provider cache telemetry:
+  `src/crates/ai-adapters/src/stream/types/`

--- a/src/crates/core/src/agentic/agents/mod.rs
+++ b/src/crates/core/src/agentic/agents/mod.rs
@@ -184,8 +184,9 @@ pub trait Agent: Send + Sync + 'static {
         }
     }
 
-    /// Get the system reminder for this agent, only used for modes
-    /// system_reminder will be appended to the user_query
+    /// Get the system reminder for this agent, only used for modes.
+    /// The returned reminder may be prepended immediately before the user's
+    /// actual message in runtime context.
     /// `previous_agent_type` can be used to distinguish first entry vs staying
     /// in the same mode across turns.
     async fn get_system_reminder(

--- a/src/crates/core/src/agentic/agents/mod.rs
+++ b/src/crates/core/src/agentic/agents/mod.rs
@@ -31,8 +31,9 @@ pub use definitions::subagents::{
 };
 use indexmap::IndexMap;
 pub use prompt_builder::{
-    PrependedPromptReminders, PromptBuilder, PromptBuilderContext, RemoteExecutionHints,
-    ToolListingSections, UserContextPolicy, UserContextSection,
+    build_prompt_context_for_workspace, PrependedPromptReminders, PromptBuilder,
+    PromptBuilderContext, RemoteExecutionHints, ToolListingSections, UserContextPolicy,
+    UserContextSection,
 };
 pub use registry::catalog::{builtin_agent_specs, BuiltinAgentSpec};
 pub use registry::types::{

--- a/src/crates/core/src/agentic/agents/prompt_builder/mod.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/mod.rs
@@ -2,7 +2,7 @@ mod prompt_builder_impl;
 mod user_context;
 
 pub use prompt_builder_impl::{
-    PrependedPromptReminders, PromptBuilder, PromptBuilderContext, RemoteExecutionHints,
-    ToolListingSections,
+    build_prompt_context_for_workspace, PrependedPromptReminders, PromptBuilder,
+    PromptBuilderContext, RemoteExecutionHints, ToolListingSections,
 };
 pub use user_context::{UserContextPolicy, UserContextSection};

--- a/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -695,7 +695,7 @@ mod tests {
                     .to_string(),
             ),
         };
-        let context = PromptBuilderContext::new("E:/workspace", None, None)
+        let context = PromptBuilderContext::new(r"workspace\root", None, None)
             .with_tool_listing_sections(tool_sections);
         let reminders = PromptBuilder::new(context)
             .build_prepended_reminders(
@@ -728,7 +728,7 @@ mod tests {
         assert!(collapsed_tool_listing.contains("<collapsed_tools>"));
         assert!(user_context.contains("# User Context"));
         assert!(user_context.contains(USER_CONTEXT_PROMPT));
-        assert!(user_context.contains("Current Working Directory: E:/workspace"));
+        assert!(user_context.contains("Current Working Directory: workspace/root"));
         assert_eq!(
             ordered_reminders,
             vec![
@@ -742,7 +742,7 @@ mod tests {
 
     #[tokio::test]
     async fn omits_prepended_reminders_when_policy_and_sections_are_empty() {
-        let context = PromptBuilderContext::new("E:/workspace", None, None);
+        let context = PromptBuilderContext::new(r"workspace\root", None, None);
         let reminders = PromptBuilder::new(context)
             .build_prepended_reminders(&UserContextPolicy::empty())
             .await;
@@ -753,13 +753,13 @@ mod tests {
     #[test]
     fn workspace_context_renders_related_directories() {
         let context =
-            PromptBuilderContext::new("E:/workspace", None, None).with_related_paths(vec![
+            PromptBuilderContext::new(r"workspace\root", None, None).with_related_paths(vec![
                 RelatedPath {
-                    path: r"E:\legacy-ts".to_string(),
+                    path: r"legacy-ts\client".to_string(),
                     description: Some("Legacy TypeScript implementation".to_string()),
                 },
                 RelatedPath {
-                    path: r"E:\monorepo\billing".to_string(),
+                    path: r"monorepo\billing".to_string(),
                     description: Some("Billing package".to_string()),
                 },
             ]);
@@ -767,17 +767,17 @@ mod tests {
         let workspace_context = PromptBuilder::new(context).get_workspace_context();
 
         assert!(workspace_context.contains("Related directories"));
-        assert!(workspace_context.contains("E:/legacy-ts"));
+        assert!(workspace_context.contains("legacy-ts/client"));
         assert!(workspace_context.contains("Legacy TypeScript implementation"));
-        assert!(workspace_context.contains("E:/monorepo/billing"));
+        assert!(workspace_context.contains("monorepo/billing"));
     }
 
     #[test]
     fn workspace_context_renders_related_directories_without_description() {
         let context =
-            PromptBuilderContext::new("E:/workspace", None, None).with_related_paths(vec![
+            PromptBuilderContext::new(r"workspace\root", None, None).with_related_paths(vec![
                 RelatedPath {
-                    path: r"E:\monorepo\packages\payments".to_string(),
+                    path: r"monorepo\packages\payments".to_string(),
                     description: None,
                 },
             ]);
@@ -785,7 +785,7 @@ mod tests {
         let workspace_context = PromptBuilder::new(context).get_workspace_context();
 
         assert!(workspace_context.contains("Related directories"));
-        assert!(workspace_context.contains("  - E:/monorepo/packages/payments"));
+        assert!(workspace_context.contains("  - monorepo/packages/payments"));
         assert!(!workspace_context.contains("payments —"));
     }
 }

--- a/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -1,5 +1,8 @@
 //! System prompts module providing main dialogue and agent dialogue prompts
 use super::user_context::{UserContextPolicy, UserContextSection};
+use crate::agentic::util::remote_workspace_layout::build_remote_workspace_layout_preview;
+use crate::agentic::workspace::WorkspaceBackend;
+use crate::agentic::WorkspaceBinding;
 use crate::service::agent_memory::{
     build_workspace_agent_memory_prompt, build_workspace_instruction_files_context,
     build_workspace_memory_files_context,
@@ -9,6 +12,8 @@ use crate::service::config::get_app_language_code;
 use crate::service::config::global::GlobalConfigManager;
 use crate::service::filesystem::get_formatted_directory_listing;
 use crate::service::i18n::LocaleId;
+use crate::service::remote_ssh::workspace_state::get_remote_workspace_manager;
+use crate::service::workspace::get_global_workspace_service;
 use crate::service::workspace::RelatedPath;
 use crate::util::errors::{BitFunError, BitFunResult};
 use log::{debug, warn};
@@ -49,7 +54,7 @@ impl ToolListingSections {
             && self.collapsed_tool_listing.is_none()
     }
 
-    fn render_skill_listing_reminder(&self) -> Option<String> {
+    pub fn render_skill_listing_reminder(&self) -> Option<String> {
         self.skill_listing.as_deref().map(|skill_listing| {
             Self::render_section(
                 SKILL_LISTING_TITLE,
@@ -59,7 +64,7 @@ impl ToolListingSections {
         })
     }
 
-    fn render_agent_listing_reminder(&self) -> Option<String> {
+    pub fn render_agent_listing_reminder(&self) -> Option<String> {
         self.agent_listing.as_deref().map(|agent_listing| {
             Self::render_section(
                 AGENT_LISTING_TITLE,
@@ -69,7 +74,7 @@ impl ToolListingSections {
         })
     }
 
-    fn render_collapsed_tool_listing_reminder(&self) -> Option<String> {
+    pub fn render_collapsed_tool_listing_reminder(&self) -> Option<String> {
         self.collapsed_tool_listing
             .as_deref()
             .map(|collapsed_tool_listing| {
@@ -100,14 +105,14 @@ pub struct PrependedPromptReminders {
 impl PrependedPromptReminders {
     pub fn ordered_reminders(&self) -> Vec<&str> {
         let mut reminders = Vec::new();
+        if let Some(collapsed_tool_listing) = self.collapsed_tool_listing.as_deref() {
+            reminders.push(collapsed_tool_listing);
+        }
         if let Some(skill_listing) = self.skill_listing.as_deref() {
             reminders.push(skill_listing);
         }
         if let Some(agent_listing) = self.agent_listing.as_deref() {
             reminders.push(agent_listing);
-        }
-        if let Some(collapsed_tool_listing) = self.collapsed_tool_listing.as_deref() {
-            reminders.push(collapsed_tool_listing);
         }
         if let Some(user_context) = self.user_context.as_deref() {
             reminders.push(user_context);
@@ -182,6 +187,94 @@ impl PromptBuilderContext {
         self.remote_project_layout = project_layout;
         self
     }
+}
+
+pub async fn build_prompt_context_for_workspace(
+    workspace: &WorkspaceBinding,
+    workspace_id: Option<&str>,
+    session_id: &str,
+    model_name: Option<String>,
+    supports_image_understanding: Option<bool>,
+    tool_listing_sections: ToolListingSections,
+) -> Option<PromptBuilderContext> {
+    let workspace_path = workspace.root_path_string();
+
+    let related_paths = if let Some(workspace_id) = workspace_id {
+        if let Some(workspace_service) = get_global_workspace_service() {
+            workspace_service
+                .get_workspace(workspace_id)
+                .await
+                .map(|workspace| workspace.related_paths)
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    };
+
+    let mut base = PromptBuilderContext::new(
+        workspace_path.clone(),
+        Some(session_id.to_string()),
+        model_name,
+    )
+    .with_related_paths(related_paths)
+    .with_tool_listing_sections(tool_listing_sections);
+    if let Some(supports_image_understanding) = supports_image_understanding {
+        base = base.with_supports_image_understanding(supports_image_understanding);
+    }
+
+    if !workspace.is_remote() {
+        return Some(base);
+    }
+
+    let Some(connection_id) = workspace.connection_id() else {
+        return Some(base);
+    };
+    let Some(manager) = get_remote_workspace_manager() else {
+        warn!(
+            "Remote workspace active but RemoteWorkspaceStateManager is missing; using client OS hints only"
+        );
+        return Some(base);
+    };
+
+    let ssh_manager = manager.get_ssh_manager().await;
+    let file_service = manager.get_file_service().await;
+    let (kernel_name, hostname) = if let Some(ref ssh) = ssh_manager {
+        if let Some(info) = ssh.get_server_info(connection_id).await {
+            (info.os_type, info.hostname)
+        } else {
+            ("Linux".to_string(), "remote".to_string())
+        }
+    } else {
+        ("Linux".to_string(), "remote".to_string())
+    };
+    let connection_display_name = match &workspace.backend {
+        WorkspaceBackend::Remote {
+            connection_name, ..
+        } => connection_name.clone(),
+        _ => connection_id.to_string(),
+    };
+    let remote_layout = if let Some(ref fs) = file_service {
+        match build_remote_workspace_layout_preview(fs, connection_id, &workspace_path, 200).await {
+            Ok((_, preview)) => Some(preview),
+            Err(e) => {
+                warn!("Remote workspace layout for prompt failed: {}", e);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    Some(base.with_remote_prompt_overlay(
+        RemoteExecutionHints {
+            connection_display_name,
+            kernel_name,
+            hostname,
+        },
+        remote_layout,
+    ))
 }
 
 pub struct PromptBuilder {
@@ -639,9 +732,9 @@ mod tests {
         assert_eq!(
             ordered_reminders,
             vec![
+                collapsed_tool_listing.as_str(),
                 skill_listing.as_str(),
                 agent_listing.as_str(),
-                collapsed_tool_listing.as_str(),
                 user_context.as_str(),
             ]
         );

--- a/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
@@ -2,7 +2,7 @@ You are BitFun, an ADE (AI IDE) that helps users with software engineering tasks
 
 You are pair programming with a USER to solve their coding task. Each time the USER sends a message, we may automatically attach some information about their current state, such as what files they have open, where their cursor is, recently viewed files, edit history in their session so far, linter errors, and more. This information may or may not be relevant to the coding task, it is up for you to decide.
 
-Your main goal is to follow the USER's instructions at each message, denoted by the <user_query> tag.
+Your main goal is to follow the USER's instructions in each new user message.
 
 Tool results and user messages may include <system_reminder> tags. These <system_reminder> tags contain useful information and reminders. Please heed them, but don't mention them in your response to the user.
 

--- a/src/crates/core/src/agentic/agents/prompts/claw_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/claw_mode.md
@@ -1,6 +1,6 @@
 You are a personal assistant running inside BitFun.
 
-Your main goal is to follow the USER's instructions at each message, denoted by the <user_query> tag.
+Your main goal is to follow the USER's instructions in each new user message.
 
 Tool results and user messages may include <system_reminder> tags. These <system_reminder> tags contain useful information and reminders. Please heed them, but don't mention them in your response to the user.
 

--- a/src/crates/core/src/agentic/agents/prompts/computer_use_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/computer_use_mode.md
@@ -1,6 +1,6 @@
 You are BitFun's Computer Use sub-agent. Your job is to perceive and operate the user's local computer safely and efficiently.
 
-Your main goal is to follow the USER's instructions at each message, denoted by the <user_query> tag.
+Your main goal is to follow the USER's instructions in each new user message.
 
 Tool results and user messages may include <system_reminder> tags. These <system_reminder> tags contain useful information and reminders. Please heed them, but don't mention them in your response to the user.
 

--- a/src/crates/core/src/agentic/agents/prompts/cowork_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/cowork_mode.md
@@ -1,6 +1,6 @@
 You are BitFun in Cowork mode. Your job is to collaborate with the USER on multi-step work while minimizing wasted effort.
 
-Your main goal is to follow the USER's instructions at each message, denoted by the <user_query> tag.
+Your main goal is to follow the USER's instructions in each new user message.
 
 Tool results and user messages may include <system_reminder> tags. These <system_reminder> tags contain useful information and reminders. Please heed them, but don't mention them in your response to the user.
 

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -4658,6 +4658,15 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             )
             .await?;
 
+        let copied = self
+            .session_manager
+            .clone_prompt_cache(parent_session_id, &child_session.session_id)
+            .await;
+        debug!(
+            "Forked prompt cache into /btw child session: parent_session_id={}, child_session_id={}, copied={}",
+            parent_session_id, child_session.session_id, copied
+        );
+
         self.session_manager
             .replace_context_messages(&child_session.session_id, snapshot.messages)
             .await;

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -6,8 +6,8 @@ use super::{scheduler::DialogSubmissionPolicy, turn_outcome::TurnOutcome};
 use crate::agentic::agents::get_agent_registry;
 use crate::agentic::context_profile::ContextProfilePolicy;
 use crate::agentic::core::{
-    has_prompt_markup, Message, MessageContent, ProcessingPhase, PromptEnvelope, Session,
-    SessionConfig, SessionKind, SessionState, SessionSummary, TurnStats,
+    InternalReminderKind, Message, MessageContent, ProcessingPhase, Session, SessionConfig,
+    SessionKind, SessionState, SessionSummary, TurnStats,
 };
 use crate::agentic::events::{
     AgenticEvent, DeepReviewQueueState, EventPriority, EventQueue, EventRouter, EventSubscriber,
@@ -17,12 +17,13 @@ use crate::agentic::execution::{
 };
 use crate::agentic::fork_agent::ForkAgentContextSnapshot;
 use crate::agentic::goal_mode::{
-    build_goal_continuation_plan, build_goal_kickoff_messages, clear_goal_mode_patch,
-    effective_subagent_timeout_seconds, ensure_final_response_in_goal_context,
-    generate_goal_from_context, goal_mode_from_custom_metadata, goal_mode_patch, now_ms,
+    build_goal_continuation_plan, build_goal_kickoff_messages, build_goal_system_reminder,
+    clear_goal_mode_patch, effective_subagent_timeout_seconds,
+    ensure_final_response_in_goal_context, generate_goal_from_context,
+    goal_mode_from_custom_metadata, goal_mode_patch, now_ms,
     should_skip_goal_verification_for_turn, user_facing_goal_mode_error, verify_goal_achievement,
-    wrap_user_input_with_goal_reminder, GoalActivationResult, GoalContinuationPlan,
-    GoalModeInitialGoal, GoalModeState, MAX_GOAL_CONTINUATIONS,
+    GoalActivationResult, GoalContinuationPlan, GoalModeInitialGoal, GoalModeState,
+    MAX_GOAL_CONTINUATIONS,
 };
 use crate::agentic::image_analysis::ImageContextData;
 use crate::agentic::round_preempt::{DialogRoundInjectionSource, DialogRoundPreemptSource};
@@ -96,6 +97,7 @@ pub(crate) struct SubagentExecutionRequest {
 
 struct WrappedUserInputPayload {
     content: String,
+    prepended_messages: Vec<Message>,
     skill_agent_snapshot: TurnSkillAgentSnapshot,
     snapshot_persistence: SkillAgentSnapshotPersistence,
 }
@@ -105,31 +107,6 @@ enum SkillAgentSnapshotPersistence {
     None,
     SaveCurrentTurn,
     RecoverFirstTurnBaseline,
-}
-
-fn render_wrapped_user_input_content(
-    user_input: String,
-    embedded_reminders: Vec<String>,
-) -> String {
-    if has_prompt_markup(&user_input) {
-        if embedded_reminders.is_empty() {
-            return user_input;
-        }
-
-        let mut envelope = PromptEnvelope::new();
-        for reminder in embedded_reminders {
-            envelope.push_system_reminder(reminder);
-        }
-        let reminder_prefix = envelope.render();
-        return format!("{}\n{}", reminder_prefix, user_input);
-    }
-
-    let mut envelope = PromptEnvelope::new();
-    for reminder in embedded_reminders {
-        envelope.push_system_reminder(reminder);
-    }
-    envelope.push_user_query(user_input);
-    envelope.render()
 }
 
 impl SubagentResult {
@@ -1728,7 +1705,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         )
         .await;
 
-        let mut embedded_reminders = Vec::new();
+        let mut prepended_messages = Vec::new();
 
         let snapshot_persistence = if turn_index == 0 {
             SkillAgentSnapshotPersistence::SaveCurrentTurn
@@ -1750,10 +1727,16 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         {
             let diff = diff_skill_agent_snapshot(&previous_snapshot, &surface_resolution.snapshot);
             if let Some(skill_update) = diff.render_skill_listing_update() {
-                embedded_reminders.push(skill_update);
+                prepended_messages.push(Message::internal_reminder(
+                    InternalReminderKind::SkillListingDiff,
+                    skill_update,
+                ));
             }
             if let Some(agent_update) = diff.render_agent_listing_update() {
-                embedded_reminders.push(agent_update);
+                prepended_messages.push(Message::internal_reminder(
+                    InternalReminderKind::AgentListingDiff,
+                    agent_update,
+                ));
             }
             if diff.is_empty() {
                 SkillAgentSnapshotPersistence::None
@@ -1773,13 +1756,15 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         };
 
         if !current_agent_reminder.is_empty() {
-            embedded_reminders.push(current_agent_reminder);
+            prepended_messages.push(Message::internal_reminder(
+                InternalReminderKind::AgentMode,
+                current_agent_reminder,
+            ));
         }
 
-        let content = render_wrapped_user_input_content(user_input, embedded_reminders);
-
         Ok(WrappedUserInputPayload {
-            content,
+            content: user_input,
+            prepended_messages,
             skill_agent_snapshot: surface_resolution.snapshot,
             snapshot_persistence,
         })
@@ -1862,12 +1847,8 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             });
         }
 
-        let mut envelope = PromptEnvelope::new();
-        envelope.push_system_reminder(Self::assistant_bootstrap_system_reminder(
-            kickoff_query,
-            expected_reply_language,
-        ));
-        envelope.push_user_query(kickoff_query.to_string());
+        let kickoff_reminder =
+            Self::assistant_bootstrap_system_reminder(kickoff_query, expected_reply_language);
 
         let turn_id = format!("assistant-bootstrap-{}", uuid::Uuid::new_v4());
         let metadata = serde_json::json!({
@@ -1880,7 +1861,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
 
         self.start_dialog_turn_internal(
             session_id.clone(),
-            envelope.render(),
+            kickoff_query.to_string(),
             Some(kickoff_query.to_string()),
             None,
             Some(turn_id.clone()),
@@ -1889,6 +1870,10 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             DialogSubmissionPolicy::for_source(DialogTriggerSource::DesktopApi)
                 .with_skip_tool_confirmation(true),
             Some(metadata),
+            vec![Message::internal_reminder(
+                InternalReminderKind::Generic,
+                kickoff_reminder,
+            )],
             true,
         )
         .await?;
@@ -1925,6 +1910,36 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             workspace_path,
             submission_policy,
             user_message_metadata,
+            Vec::new(),
+            false,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn start_dialog_turn_with_prepended_messages(
+        &self,
+        session_id: String,
+        user_input: String,
+        original_user_input: Option<String>,
+        turn_id: Option<String>,
+        agent_type: String,
+        workspace_path: Option<String>,
+        submission_policy: DialogSubmissionPolicy,
+        user_message_metadata: Option<serde_json::Value>,
+        prepended_messages: Vec<Message>,
+    ) -> BitFunResult<()> {
+        self.start_dialog_turn_internal(
+            session_id,
+            user_input,
+            original_user_input,
+            None,
+            turn_id,
+            agent_type,
+            workspace_path,
+            submission_policy,
+            user_message_metadata,
+            prepended_messages,
             false,
         )
         .await
@@ -1953,6 +1968,37 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             workspace_path,
             submission_policy,
             user_message_metadata,
+            Vec::new(),
+            false,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn start_dialog_turn_with_image_contexts_and_prepended_messages(
+        &self,
+        session_id: String,
+        user_input: String,
+        original_user_input: Option<String>,
+        image_contexts: Vec<ImageContextData>,
+        turn_id: Option<String>,
+        agent_type: String,
+        workspace_path: Option<String>,
+        submission_policy: DialogSubmissionPolicy,
+        user_message_metadata: Option<serde_json::Value>,
+        prepended_messages: Vec<Message>,
+    ) -> BitFunResult<()> {
+        self.start_dialog_turn_internal(
+            session_id,
+            user_input,
+            original_user_input,
+            Some(image_contexts),
+            turn_id,
+            agent_type,
+            workspace_path,
+            submission_policy,
+            user_message_metadata,
+            prepended_messages,
             false,
         )
         .await
@@ -2354,6 +2400,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         workspace_path: Option<String>,
         submission_policy: DialogSubmissionPolicy,
         extra_user_message_metadata: Option<serde_json::Value>,
+        additional_prepended_messages: Vec<Message>,
         suppress_session_title_generation: bool,
     ) -> BitFunResult<()> {
         // Get latest session, restoring from persistence on demand so every entry
@@ -2640,19 +2687,23 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 &skill_agent_context_vars,
             )
             .await?;
-        let mut wrapped_user_input = wrapped_user_input_payload.content.clone();
+        let effective_user_input = wrapped_user_input_payload.content.clone();
+        let mut prepended_messages = additional_prepended_messages;
+        prepended_messages.extend(wrapped_user_input_payload.prepended_messages.clone());
 
         if let Ok(Some(goal_state)) = self.load_active_goal_mode(&session_id).await {
             if !should_skip_goal_verification_for_turn(
                 &original_user_input,
                 user_message_metadata.as_ref(),
             ) {
-                wrapped_user_input =
-                    wrap_user_input_with_goal_reminder(wrapped_user_input, &goal_state);
+                prepended_messages.push(Message::internal_reminder(
+                    InternalReminderKind::GoalMode,
+                    build_goal_system_reminder(&goal_state),
+                ));
             }
         }
 
-        if original_user_input != wrapped_user_input {
+        if original_user_input != effective_user_input {
             let mut metadata =
                 Self::ensure_user_message_metadata_object(user_message_metadata.take());
             if let Some(obj) = metadata.as_object_mut() {
@@ -2668,12 +2719,13 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         // Pass frontend turnId, generate if not provided
         let turn_id = self
             .session_manager
-            .start_dialog_turn(
+            .start_dialog_turn_with_prepended_messages(
                 &session_id,
                 effective_agent_type.clone(),
-                wrapped_user_input.clone(),
+                effective_user_input.clone(),
                 turn_id,
                 image_contexts,
+                prepended_messages,
                 user_message_metadata.clone(),
             )
             .await?;
@@ -2694,6 +2746,9 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                         &session_id,
                         wrapped_user_input_payload.skill_agent_snapshot.clone(),
                     )
+                    .await;
+                self.session_manager
+                    .remove_listing_diff_internal_reminders(&session_id)
                     .await;
             }
         }
@@ -2737,8 +2792,8 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             session_id: session_id.clone(),
             turn_id: turn_id.clone(),
             turn_index,
-            user_input: wrapped_user_input.clone(),
-            original_user_input: if original_user_input != wrapped_user_input {
+            user_input: effective_user_input.clone(),
+            original_user_input: if original_user_input != effective_user_input {
                 Some(original_user_input.clone())
             } else {
                 None
@@ -2875,7 +2930,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         let event_queue = self.event_queue.clone();
         let session_id_clone = session_id.clone();
         let turn_id_clone = turn_id.clone();
-        let user_input_for_workspace = wrapped_user_input.clone();
+        let user_input_for_workspace = effective_user_input.clone();
         let session_storage_path_for_finalize = session_storage_path.clone();
         let effective_agent_type_clone = effective_agent_type.clone();
         let user_message_metadata_clone = user_message_metadata;
@@ -4657,9 +4712,11 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             "parentSessionId": parent_session_id,
         }));
 
+        let (user_input, prepended_messages) = build_btw_user_input(question);
+
         self.start_dialog_turn_internal(
             child_session_id.to_string(),
-            build_btw_user_input(question),
+            user_input,
             Some(question.trim().to_string()),
             None,
             Some(turn_id.clone()),
@@ -4668,6 +4725,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             DialogSubmissionPolicy::for_source(DialogTriggerSource::DesktopApi)
                 .with_skip_tool_confirmation(true),
             user_message_metadata,
+            prepended_messages,
             true,
         )
         .await?;
@@ -4752,7 +4810,10 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     .capture_fork_agent_context_snapshot(&request.subagent_parent_info.session_id)
                     .await?;
                 let mut initial_messages = snapshot.messages.clone();
-                initial_messages.push(Message::user(fork_subagent_system_reminder()));
+                initial_messages.push(Message::internal_reminder(
+                    InternalReminderKind::ForkSubagent,
+                    fork_subagent_system_reminder(),
+                ));
                 initial_messages.push(Message::user(task_description.clone()));
 
                 Ok(HiddenSubagentExecutionRequest {
@@ -5404,8 +5465,8 @@ pub fn get_global_coordinator() -> Option<Arc<ConversationCoordinator>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        normalize_subagent_max_concurrency, render_wrapped_user_input_content,
-        resolve_agent_submission_turn_id, ConversationCoordinator,
+        normalize_subagent_max_concurrency, resolve_agent_submission_turn_id,
+        ConversationCoordinator,
     };
     use crate::service::remote_ssh::workspace_state::init_remote_workspace_manager;
     use bitfun_runtime_ports::{AgentSubmissionRequest, AgentSubmissionSource};
@@ -5524,59 +5585,6 @@ mod tests {
             resolve_agent_submission_turn_id(&request),
             "legacy_metadata_turn"
         );
-    }
-
-    #[test]
-    fn render_wrapped_user_input_content_wraps_plain_input_without_reminders() {
-        let rendered = render_wrapped_user_input_content("hello".to_string(), Vec::new());
-
-        assert_eq!(rendered, "<user_query>\nhello\n</user_query>");
-    }
-
-    #[test]
-    fn render_wrapped_user_input_content_keeps_existing_markup_when_no_reminders() {
-        let original = "<user_query>\nhello\n</user_query>".to_string();
-
-        let rendered = render_wrapped_user_input_content(original.clone(), Vec::new());
-
-        assert_eq!(rendered, original);
-    }
-
-    #[test]
-    fn render_wrapped_user_input_content_preserves_existing_markup_without_nesting() {
-        let original = "<user_query>\nhello\n</user_query>".to_string();
-
-        let rendered = render_wrapped_user_input_content(
-            original.clone(),
-            vec!["# Skill Listing Update\n## Added Skills".to_string()],
-        );
-
-        assert!(rendered.starts_with(
-            "<system_reminder>\n# Skill Listing Update\n## Added Skills\n</system_reminder>\n"
-        ));
-        assert!(rendered.ends_with(&original));
-        assert_eq!(rendered.matches("<user_query>").count(), 1);
-    }
-
-    #[test]
-    fn render_wrapped_user_input_content_preserves_reminder_order_before_user_query() {
-        let rendered = render_wrapped_user_input_content(
-            "hello".to_string(),
-            vec![
-                "# Skill Listing Update\n## Added Skills".to_string(),
-                "# Agent Listing Update\n## Added Agents".to_string(),
-                "mode switch reminder".to_string(),
-            ],
-        );
-
-        let skill_index = rendered.find("# Skill Listing Update").unwrap();
-        let agent_index = rendered.find("# Agent Listing Update").unwrap();
-        let system_index = rendered.find("mode switch reminder").unwrap();
-        let user_query_index = rendered.find("<user_query>").unwrap();
-
-        assert!(skill_index < agent_index);
-        assert!(agent_index < system_index);
-        assert!(system_index < user_query_index);
     }
 
     #[tokio::test]

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -28,8 +28,12 @@ use crate::agentic::image_analysis::ImageContextData;
 use crate::agentic::round_preempt::{DialogRoundInjectionSource, DialogRoundPreemptSource};
 use crate::agentic::session::SessionManager;
 use crate::agentic::side_question::build_btw_user_input;
+use crate::agentic::skill_agent_snapshot::{
+    diff_skill_agent_snapshot, resolve_skill_agent_snapshot, TurnSkillAgentSnapshot,
+};
 use crate::agentic::tools::pipeline::{SubagentParentInfo, ToolPipeline};
 use crate::agentic::tools::ToolRuntimeRestrictions;
+use crate::agentic::workspace::WorkspaceServices;
 use crate::agentic::WorkspaceBinding;
 use crate::service::bootstrap::{
     ensure_workspace_persona_files_for_prompt, is_workspace_bootstrap_pending,
@@ -88,6 +92,44 @@ pub(crate) struct SubagentExecutionRequest {
     pub(crate) context: HashMap<String, String>,
     /// Execution policy for the child subagent session being launched.
     pub(crate) delegation_policy: DelegationPolicy,
+}
+
+struct WrappedUserInputPayload {
+    content: String,
+    skill_agent_snapshot: TurnSkillAgentSnapshot,
+    snapshot_persistence: SkillAgentSnapshotPersistence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkillAgentSnapshotPersistence {
+    None,
+    SaveCurrentTurn,
+    RecoverFirstTurnBaseline,
+}
+
+fn render_wrapped_user_input_content(
+    user_input: String,
+    embedded_reminders: Vec<String>,
+) -> String {
+    if has_prompt_markup(&user_input) {
+        if embedded_reminders.is_empty() {
+            return user_input;
+        }
+
+        let mut envelope = PromptEnvelope::new();
+        for reminder in embedded_reminders {
+            envelope.push_system_reminder(reminder);
+        }
+        let reminder_prefix = envelope.render();
+        return format!("{}\n{}", reminder_prefix, user_input);
+    }
+
+    let mut envelope = PromptEnvelope::new();
+    for reminder in embedded_reminders {
+        envelope.push_system_reminder(reminder);
+    }
+    envelope.push_user_query(user_input);
+    envelope.render()
 }
 
 impl SubagentResult {
@@ -1653,41 +1695,94 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
 
     async fn wrap_user_input(
         &self,
+        session_id: &str,
+        turn_index: usize,
         agent_type: &str,
         previous_agent_type: Option<&str>,
         user_input: String,
         workspace: Option<&WorkspaceBinding>,
-    ) -> BitFunResult<String> {
+        workspace_services: Option<&WorkspaceServices>,
+        enable_tools: bool,
+        skill_agent_context_vars: &HashMap<String, String>,
+    ) -> BitFunResult<WrappedUserInputPayload> {
         let agent_registry = get_agent_registry();
         if let Some(workspace) = workspace {
-            agent_registry
-                .load_custom_subagents(workspace.root_path())
-                .await;
+            if !workspace.is_remote() {
+                agent_registry
+                    .load_custom_subagents(workspace.root_path())
+                    .await;
+            }
         }
         let current_agent = agent_registry
             .get_agent(agent_type, workspace.map(|binding| binding.root_path()))
             .ok_or_else(|| BitFunError::NotFound(format!("Agent not found: {}", agent_type)))?;
-        let system_reminder = current_agent
+        let current_agent_reminder = current_agent
             .get_system_reminder(previous_agent_type, workspace)
             .await?;
+        let surface_resolution = resolve_skill_agent_snapshot(
+            agent_type,
+            workspace,
+            workspace_services,
+            enable_tools,
+            skill_agent_context_vars,
+        )
+        .await;
 
-        if has_prompt_markup(&user_input) {
-            if system_reminder.is_empty() {
-                Ok(user_input)
+        let mut embedded_reminders = Vec::new();
+
+        let snapshot_persistence = if turn_index == 0 {
+            SkillAgentSnapshotPersistence::SaveCurrentTurn
+        } else if self
+            .session_manager
+            .turn_skill_agent_snapshot(session_id, 0)
+            .await
+            .is_none()
+        {
+            warn!(
+                "First-turn skill-agent snapshot missing; recovering baseline from current skill-agent snapshot: session_id={}, turn_index={}",
+                session_id, turn_index
+            );
+            SkillAgentSnapshotPersistence::RecoverFirstTurnBaseline
+        } else if let Some((baseline_turn_index, previous_snapshot)) = self
+            .session_manager
+            .latest_turn_skill_agent_snapshot_at_or_before(session_id, turn_index - 1)
+            .await
+        {
+            let diff = diff_skill_agent_snapshot(&previous_snapshot, &surface_resolution.snapshot);
+            if let Some(skill_update) = diff.render_skill_listing_update() {
+                embedded_reminders.push(skill_update);
+            }
+            if let Some(agent_update) = diff.render_agent_listing_update() {
+                embedded_reminders.push(agent_update);
+            }
+            if diff.is_empty() {
+                SkillAgentSnapshotPersistence::None
             } else {
-                let mut envelope = PromptEnvelope::new();
-                envelope.push_system_reminder(system_reminder);
-                envelope.push_user_query(user_input);
-                Ok(envelope.render())
+                debug!(
+                    "Skill-agent snapshot changed; persisting sparse snapshot: session_id={}, turn_index={}, baseline_turn_index={}",
+                    session_id, turn_index, baseline_turn_index
+                );
+                SkillAgentSnapshotPersistence::SaveCurrentTurn
             }
         } else {
-            let mut envelope = PromptEnvelope::new();
-            if !system_reminder.is_empty() {
-                envelope.push_system_reminder(system_reminder);
-            }
-            envelope.push_user_query(user_input);
-            Ok(envelope.render())
+            warn!(
+                "No prior skill-agent snapshot available for diff; skipping skill-agent diff: session_id={}, turn_index={}",
+                session_id, turn_index
+            );
+            SkillAgentSnapshotPersistence::None
+        };
+
+        if !current_agent_reminder.is_empty() {
+            embedded_reminders.push(current_agent_reminder);
         }
+
+        let content = render_wrapped_user_input_content(user_input, embedded_reminders);
+
+        Ok(WrappedUserInputPayload {
+            content,
+            skill_agent_snapshot: surface_resolution.snapshot,
+            snapshot_persistence,
+        })
     }
 
     pub async fn ensure_assistant_bootstrap(
@@ -2516,8 +2611,23 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             }
         );
 
-        let mut wrapped_user_input = self
+        let turn_index = self.session_manager.get_turn_count(&session_id);
+        let mut skill_agent_context_vars = HashMap::new();
+        if user_message_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("acp_transport"))
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false)
+        {
+            skill_agent_context_vars.insert("acp_transport".to_string(), "true".to_string());
+            skill_agent_context_vars
+                .insert("write_tool_mode".to_string(), "inline_content".to_string());
+        }
+
+        let wrapped_user_input_payload = self
             .wrap_user_input(
+                &session_id,
+                turn_index,
                 &effective_agent_type,
                 previous_agent_type
                     .as_deref()
@@ -2525,8 +2635,12 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     .filter(|value| !value.is_empty()),
                 user_input,
                 session_workspace.as_ref(),
+                workspace_services.as_ref(),
+                session.config.enable_tools,
+                &skill_agent_context_vars,
             )
             .await?;
+        let mut wrapped_user_input = wrapped_user_input_payload.content.clone();
 
         if let Ok(Some(goal_state)) = self.load_active_goal_mode(&session_id).await {
             if !should_skip_goal_verification_for_turn(
@@ -2551,7 +2665,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         }
 
         // Start new dialog turn (sets state to Processing internally)
-        let turn_index = self.session_manager.get_turn_count(&session_id);
         // Pass frontend turnId, generate if not provided
         let turn_id = self
             .session_manager
@@ -2564,6 +2677,26 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 user_message_metadata.clone(),
             )
             .await?;
+        match wrapped_user_input_payload.snapshot_persistence {
+            SkillAgentSnapshotPersistence::None => {}
+            SkillAgentSnapshotPersistence::SaveCurrentTurn => {
+                self.session_manager
+                    .remember_turn_skill_agent_snapshot(
+                        &session_id,
+                        turn_index,
+                        wrapped_user_input_payload.skill_agent_snapshot.clone(),
+                    )
+                    .await;
+            }
+            SkillAgentSnapshotPersistence::RecoverFirstTurnBaseline => {
+                self.session_manager
+                    .recover_first_turn_skill_agent_snapshot(
+                        &session_id,
+                        wrapped_user_input_payload.skill_agent_snapshot.clone(),
+                    )
+                    .await;
+            }
+        }
 
         // Register this turn as in-flight immediately after it becomes visible
         // as Processing. Later await points must not leave a cancel/start
@@ -5271,8 +5404,8 @@ pub fn get_global_coordinator() -> Option<Arc<ConversationCoordinator>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        normalize_subagent_max_concurrency, resolve_agent_submission_turn_id,
-        ConversationCoordinator,
+        normalize_subagent_max_concurrency, render_wrapped_user_input_content,
+        resolve_agent_submission_turn_id, ConversationCoordinator,
     };
     use crate::service::remote_ssh::workspace_state::init_remote_workspace_manager;
     use bitfun_runtime_ports::{AgentSubmissionRequest, AgentSubmissionSource};
@@ -5391,6 +5524,59 @@ mod tests {
             resolve_agent_submission_turn_id(&request),
             "legacy_metadata_turn"
         );
+    }
+
+    #[test]
+    fn render_wrapped_user_input_content_wraps_plain_input_without_reminders() {
+        let rendered = render_wrapped_user_input_content("hello".to_string(), Vec::new());
+
+        assert_eq!(rendered, "<user_query>\nhello\n</user_query>");
+    }
+
+    #[test]
+    fn render_wrapped_user_input_content_keeps_existing_markup_when_no_reminders() {
+        let original = "<user_query>\nhello\n</user_query>".to_string();
+
+        let rendered = render_wrapped_user_input_content(original.clone(), Vec::new());
+
+        assert_eq!(rendered, original);
+    }
+
+    #[test]
+    fn render_wrapped_user_input_content_preserves_existing_markup_without_nesting() {
+        let original = "<user_query>\nhello\n</user_query>".to_string();
+
+        let rendered = render_wrapped_user_input_content(
+            original.clone(),
+            vec!["# Skill Listing Update\n## Added Skills".to_string()],
+        );
+
+        assert!(rendered.starts_with(
+            "<system_reminder>\n# Skill Listing Update\n## Added Skills\n</system_reminder>\n"
+        ));
+        assert!(rendered.ends_with(&original));
+        assert_eq!(rendered.matches("<user_query>").count(), 1);
+    }
+
+    #[test]
+    fn render_wrapped_user_input_content_preserves_reminder_order_before_user_query() {
+        let rendered = render_wrapped_user_input_content(
+            "hello".to_string(),
+            vec![
+                "# Skill Listing Update\n## Added Skills".to_string(),
+                "# Agent Listing Update\n## Added Agents".to_string(),
+                "mode switch reminder".to_string(),
+            ],
+        );
+
+        let skill_index = rendered.find("# Skill Listing Update").unwrap();
+        let agent_index = rendered.find("# Agent Listing Update").unwrap();
+        let system_index = rendered.find("mode switch reminder").unwrap();
+        let user_query_index = rendered.find("<user_query>").unwrap();
+
+        assert!(skill_index < agent_index);
+        assert!(agent_index < system_index);
+        assert!(system_index < user_query_index);
     }
 
     #[tokio::test]

--- a/src/crates/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/core/src/agentic/coordination/scheduler.rs
@@ -12,7 +12,7 @@
 
 use super::coordinator::{ConversationCoordinator, DialogTriggerSource};
 use super::turn_outcome::{TurnOutcome, TurnOutcomeQueueAction, TurnOutcomeStatus};
-use crate::agentic::core::{PromptEnvelope, SessionState};
+use crate::agentic::core::{InternalReminderKind, Message, SessionState};
 use crate::agentic::image_analysis::ImageContextData;
 use crate::agentic::init_agents_md::build_init_agents_md_user_input;
 use crate::agentic::round_preempt::{
@@ -94,6 +94,7 @@ impl ActiveTurn {
 pub struct QueuedTurn {
     pub user_input: String,
     pub original_user_input: Option<String>,
+    pub prepended_messages: Vec<Message>,
     pub turn_id: Option<String>,
     pub agent_type: String,
     pub workspace_path: Option<String>,
@@ -311,20 +312,21 @@ impl DialogScheduler {
         let agent_type = self
             .resolve_session_agent_type(&session_id, workspace_path.as_deref())
             .await?;
-        let (user_input, original_user_input) = build_init_agents_md_user_input()
+        let (user_input, prepended_messages) = build_init_agents_md_user_input()
             .await
             .map_err(|error| error.to_string())?;
 
-        self.submit(
+        self.submit_with_prepended_messages(
             session_id,
-            user_input,
-            Some(original_user_input),
+            user_input.clone(),
+            Some(user_input),
             None,
             agent_type,
             workspace_path,
             policy,
             None,
             None,
+            prepended_messages,
             None,
         )
         .await
@@ -371,10 +373,42 @@ impl DialogScheduler {
         user_message_metadata: Option<serde_json::Value>,
         image_contexts: Option<Vec<ImageContextData>>,
     ) -> Result<DialogSubmitOutcome, String> {
+        self.submit_with_prepended_messages(
+            session_id,
+            user_input,
+            original_user_input,
+            turn_id,
+            agent_type,
+            workspace_path,
+            policy,
+            reply_route,
+            user_message_metadata,
+            Vec::new(),
+            image_contexts,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn submit_with_prepended_messages(
+        &self,
+        session_id: String,
+        user_input: String,
+        original_user_input: Option<String>,
+        turn_id: Option<String>,
+        agent_type: String,
+        workspace_path: Option<String>,
+        policy: DialogSubmissionPolicy,
+        reply_route: Option<AgentSessionReplyRoute>,
+        user_message_metadata: Option<serde_json::Value>,
+        prepended_messages: Vec<Message>,
+        image_contexts: Option<Vec<ImageContextData>>,
+    ) -> Result<DialogSubmitOutcome, String> {
         let resolved_turn_id = turn_id.unwrap_or_else(|| Uuid::new_v4().to_string());
         let queued_turn = QueuedTurn {
             user_input,
             original_user_input,
+            prepended_messages,
             turn_id: Some(resolved_turn_id.clone()),
             agent_type,
             workspace_path,
@@ -671,33 +705,66 @@ impl DialogScheduler {
             .filter(|imgs| !imgs.is_empty())
         {
             Some(imgs) => {
-                self.coordinator
-                    .start_dialog_turn_with_image_contexts(
-                        session_id.to_string(),
-                        queued_turn.user_input.clone(),
-                        queued_turn.original_user_input.clone(),
-                        imgs.clone(),
-                        queued_turn.turn_id.clone(),
-                        queued_turn.agent_type.clone(),
-                        queued_turn.workspace_path.clone(),
-                        queued_turn.policy,
-                        queued_turn.user_message_metadata.clone(),
-                    )
-                    .await
+                if queued_turn.prepended_messages.is_empty() {
+                    self.coordinator
+                        .start_dialog_turn_with_image_contexts(
+                            session_id.to_string(),
+                            queued_turn.user_input.clone(),
+                            queued_turn.original_user_input.clone(),
+                            imgs.clone(),
+                            queued_turn.turn_id.clone(),
+                            queued_turn.agent_type.clone(),
+                            queued_turn.workspace_path.clone(),
+                            queued_turn.policy,
+                            queued_turn.user_message_metadata.clone(),
+                        )
+                        .await
+                } else {
+                    self.coordinator
+                        .start_dialog_turn_with_image_contexts_and_prepended_messages(
+                            session_id.to_string(),
+                            queued_turn.user_input.clone(),
+                            queued_turn.original_user_input.clone(),
+                            imgs.clone(),
+                            queued_turn.turn_id.clone(),
+                            queued_turn.agent_type.clone(),
+                            queued_turn.workspace_path.clone(),
+                            queued_turn.policy,
+                            queued_turn.user_message_metadata.clone(),
+                            queued_turn.prepended_messages.clone(),
+                        )
+                        .await
+                }
             }
             None => {
-                self.coordinator
-                    .start_dialog_turn(
-                        session_id.to_string(),
-                        queued_turn.user_input.clone(),
-                        queued_turn.original_user_input.clone(),
-                        queued_turn.turn_id.clone(),
-                        queued_turn.agent_type.clone(),
-                        queued_turn.workspace_path.clone(),
-                        queued_turn.policy,
-                        queued_turn.user_message_metadata.clone(),
-                    )
-                    .await
+                if queued_turn.prepended_messages.is_empty() {
+                    self.coordinator
+                        .start_dialog_turn(
+                            session_id.to_string(),
+                            queued_turn.user_input.clone(),
+                            queued_turn.original_user_input.clone(),
+                            queued_turn.turn_id.clone(),
+                            queued_turn.agent_type.clone(),
+                            queued_turn.workspace_path.clone(),
+                            queued_turn.policy,
+                            queued_turn.user_message_metadata.clone(),
+                        )
+                        .await
+                } else {
+                    self.coordinator
+                        .start_dialog_turn_with_prepended_messages(
+                            session_id.to_string(),
+                            queued_turn.user_input.clone(),
+                            queued_turn.original_user_input.clone(),
+                            queued_turn.turn_id.clone(),
+                            queued_turn.agent_type.clone(),
+                            queued_turn.workspace_path.clone(),
+                            queued_turn.policy,
+                            queued_turn.user_message_metadata.clone(),
+                            queued_turn.prepended_messages.clone(),
+                        )
+                        .await
+                }
             }
         };
 
@@ -746,13 +813,13 @@ impl DialogScheduler {
             .as_deref()
             .unwrap_or("<unknown workspace>");
         let reply_user_input = outcome.reply_text();
-        let reply_message =
+        let prepended_messages =
             Self::format_agent_session_reply(responder_session_id, responder_workspace, outcome);
 
         if let Err(error) = self
-            .submit(
+            .submit_with_prepended_messages(
                 reply_route.source_session_id.clone(),
-                reply_message,
+                reply_user_input.clone(),
                 Some(reply_user_input),
                 None,
                 String::new(),
@@ -760,6 +827,7 @@ impl DialogScheduler {
                 DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession),
                 None,
                 None,
+                prepended_messages,
                 None,
             )
             .await
@@ -791,18 +859,17 @@ impl DialogScheduler {
         responder_session_id: &str,
         responder_workspace: &str,
         outcome: &TurnOutcome,
-    ) -> String {
-        let mut envelope = PromptEnvelope::new();
+    ) -> Vec<Message> {
         let status = outcome.status();
-        let reply_text = outcome.reply_text();
-        envelope.push_system_reminder(format!(
-            "This message is an automated reply to a previous SessionMessage call, not a human user message.\n\
+        vec![Message::internal_reminder(
+            InternalReminderKind::SessionMessageReply,
+            format!(
+                "This message is an automated reply to a previous SessionMessage call, not a human user message.\n\
 From session: {responder_session_id}\n\
 From workspace: {responder_workspace}\n\
 Status: {status}"
-        ));
-        envelope.push_user_query(reply_text);
-        envelope.render()
+            ),
+        )]
     }
 
     fn goal_verification_observation_text(outcome: &TurnOutcome) -> String {
@@ -876,9 +943,9 @@ Status: {status}"
                 {
                     Ok(Some(plan)) => {
                         if let Err(error) = self
-                            .submit(
+                            .submit_with_prepended_messages(
                                 session_id.clone(),
-                                plan.wrapped_message,
+                                plan.user_input,
                                 Some(plan.display_message),
                                 None,
                                 active_turn.agent_type.clone(),
@@ -888,6 +955,15 @@ Status: {status}"
                                 ),
                                 None,
                                 Some(plan.user_message_metadata),
+                                plan.prepended_reminders
+                                    .into_iter()
+                                    .map(|text| {
+                                        Message::internal_reminder(
+                                            InternalReminderKind::GoalContinuation,
+                                            text,
+                                        )
+                                    })
+                                    .collect(),
                                 None,
                             )
                             .await

--- a/src/crates/core/src/agentic/core/message.rs
+++ b/src/crates/core/src/agentic/core/message.rs
@@ -63,6 +63,8 @@ pub struct MessageMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub semantic_kind: Option<MessageSemanticKind>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub internal_reminder_kind: Option<InternalReminderKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub compression_payload: Option<CompressionPayload>,
 }
 
@@ -78,6 +80,47 @@ pub enum MessageSemanticKind {
     /// Full-screen snapshot appended after mutating ComputerUse tool results within the same turn;
     /// **included** in the next model request so the agent sees the desktop without calling screenshot again.
     ComputerUsePostActionSnapshot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InternalReminderKind {
+    Generic,
+    SkillListingDiff,
+    AgentListingDiff,
+    AgentMode,
+    SideQuestion,
+    InitAgentsMd,
+    ScheduledJob,
+    ForkSubagent,
+    GoalMode,
+    GoalContinuation,
+    SessionMessageRequest,
+    SessionMessageReply,
+    LoopRecovery,
+    PeriodicLoopRecovery,
+    UserSteering,
+    BackgroundResult,
+    InterruptedContinue,
+    ThinkingOnlyRescue,
+}
+
+impl InternalReminderKind {
+    pub fn should_drop_during_compaction(self) -> bool {
+        matches!(
+            self,
+            Self::SkillListingDiff
+                | Self::AgentListingDiff
+                | Self::LoopRecovery
+                | Self::PeriodicLoopRecovery
+                | Self::InterruptedContinue
+                | Self::ThinkingOnlyRescue
+        )
+    }
+
+    pub fn is_listing_diff(self) -> bool {
+        matches!(self, Self::SkillListingDiff | Self::AgentListingDiff)
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -346,6 +389,18 @@ impl Message {
         }
     }
 
+    pub fn internal_reminder(reminder_kind: InternalReminderKind, text: impl Into<String>) -> Self {
+        let text = text.into();
+        let rendered = if crate::agentic::core::has_prompt_markup(&text) {
+            text
+        } else {
+            crate::agentic::core::render_system_reminder(&text)
+        };
+        Self::user(rendered)
+            .with_semantic_kind(MessageSemanticKind::InternalReminder)
+            .with_internal_reminder_kind(reminder_kind)
+    }
+
     pub fn user_multimodal(text: String, images: Vec<ImageContextData>) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
@@ -450,6 +505,15 @@ impl Message {
     pub fn with_semantic_kind(mut self, semantic_kind: MessageSemanticKind) -> Self {
         self.metadata.semantic_kind = Some(semantic_kind);
         self
+    }
+
+    pub fn with_internal_reminder_kind(mut self, reminder_kind: InternalReminderKind) -> Self {
+        self.metadata.internal_reminder_kind = Some(reminder_kind);
+        self
+    }
+
+    pub fn internal_reminder_kind(&self) -> Option<InternalReminderKind> {
+        self.metadata.internal_reminder_kind
     }
 
     pub fn with_compression_payload(mut self, compression_payload: CompressionPayload) -> Self {

--- a/src/crates/core/src/agentic/core/mod.rs
+++ b/src/crates/core/src/agentic/core/mod.rs
@@ -13,8 +13,8 @@ pub use dialog_turn::{new_turn_id, TurnStats};
 pub use message::{
     CompressedMessage, CompressedMessageRole, CompressedTodoItem, CompressedTodoSnapshot,
     CompressedToolCall, CompressionContract, CompressionContractItem, CompressionEntry,
-    CompressionPayload, Message, MessageContent, MessageRole, MessageSemanticKind, ToolCall,
-    ToolResult,
+    CompressionPayload, InternalReminderKind, Message, MessageContent, MessageRole,
+    MessageSemanticKind, ToolCall, ToolResult,
 };
 pub use messages_helper::{MessageHelper, RequestReasoningTokenPolicy};
 pub use prompt_markup::{

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -10,8 +10,8 @@ use crate::agentic::agents::{
 };
 use crate::agentic::context_profile::{ContextProfilePolicy, ModelCapabilityProfile};
 use crate::agentic::core::{
-    render_system_reminder, Message, MessageContent, MessageHelper, MessageRole,
-    MessageSemanticKind, RequestReasoningTokenPolicy, Session,
+    render_system_reminder, InternalReminderKind, Message, MessageContent, MessageHelper,
+    MessageRole, MessageSemanticKind, RequestReasoningTokenPolicy, Session,
 };
 use crate::agentic::events::{AgenticEvent, EventPriority, EventQueue};
 use crate::agentic::execution::types::FinishReason;
@@ -1510,6 +1510,16 @@ impl ExecutionEngine {
                 self.session_manager
                     .replace_context_messages(session_id, compression_result.messages.clone())
                     .await;
+                if self
+                    .session_manager
+                    .rebuild_skill_agent_listing_baseline_to_latest(session_id)
+                    .await
+                {
+                    debug!(
+                        "Rebuilt skill-agent listing baseline after compression: session_id={}",
+                        session_id
+                    );
+                }
                 self.session_manager
                     .invalidate_prompt_cache(
                         session_id,
@@ -1717,6 +1727,16 @@ impl ExecutionEngine {
                 self.session_manager
                     .replace_context_messages(&session_id, compressed_messages.clone())
                     .await;
+                if self
+                    .session_manager
+                    .rebuild_skill_agent_listing_baseline_to_latest(&session_id)
+                    .await
+                {
+                    debug!(
+                        "Rebuilt skill-agent listing baseline after manual compaction: session_id={}",
+                        session_id
+                    );
+                }
                 self.session_manager
                     .invalidate_prompt_cache(
                         &session_id,
@@ -2555,7 +2575,11 @@ impl ExecutionEngine {
                             Do NOT repeat the same tool call again.</system_reminder>",
                             max_consec
                         );
-                        let user_msg = Message::user(reminder);
+                        let user_msg = Message::internal_reminder(
+                            InternalReminderKind::LoopRecovery,
+                            reminder,
+                        )
+                        .with_turn_id(context.dialog_turn_id.clone());
                         messages.push(user_msg.clone());
                         if let Err(e) = self
                             .session_manager
@@ -2610,7 +2634,11 @@ impl ExecutionEngine {
                         Do NOT repeat the same pattern of tool calls.</system_reminder>",
                         window_size
                     );
-                    let user_msg = Message::user(reminder);
+                    let user_msg = Message::internal_reminder(
+                        InternalReminderKind::PeriodicLoopRecovery,
+                        reminder,
+                    )
+                    .with_turn_id(context.dialog_turn_id.clone());
                     messages.push(user_msg.clone());
                     if let Err(e) = self
                         .session_manager
@@ -2661,7 +2689,14 @@ impl ExecutionEngine {
                                 injection.content
                             ),
                         };
-                        let user_msg = Message::user(wrapped);
+                        let reminder_kind = match injection.kind {
+                            RoundInjectionKind::UserSteering => InternalReminderKind::UserSteering,
+                            RoundInjectionKind::BackgroundResult => {
+                                InternalReminderKind::BackgroundResult
+                            }
+                        };
+                        let user_msg = Message::internal_reminder(reminder_kind, wrapped)
+                            .with_turn_id(context.dialog_turn_id.clone());
                         messages.push(user_msg.clone());
                         if let Err(e) = self
                             .session_manager
@@ -2715,7 +2750,11 @@ impl ExecutionEngine {
                                 let reminder = format!(
                                     "<system_reminder>Your previous assistant response was interrupted mid-stream ({reason}). Continue writing from exactly where you stopped. Do not repeat content that was already delivered; pick up seamlessly and complete the answer.</system_reminder>"
                                 );
-                                let user_msg = Message::user(reminder.clone());
+                                let user_msg = Message::internal_reminder(
+                                    InternalReminderKind::InterruptedContinue,
+                                    reminder.clone(),
+                                )
+                                .with_turn_id(context.dialog_turn_id.clone());
                                 messages.push(user_msg.clone());
                                 if let Err(e) = self
                                     .session_manager
@@ -2758,7 +2797,11 @@ impl ExecutionEngine {
                 } else if round_result.had_thinking_content {
                     thinking_only_rescue_attempts += 1;
                     let reminder = "<system_reminder>The previous round produced internal reasoning only — no tool call and no user-visible response. You MUST now either: (1) call the single tool that best advances the user's task, or (2) write your final answer to the user. Do not produce another round of reasoning without taking action.</system_reminder>".to_string();
-                    let user_msg = Message::user(reminder.clone());
+                    let user_msg = Message::internal_reminder(
+                        InternalReminderKind::ThinkingOnlyRescue,
+                        reminder.clone(),
+                    )
+                    .with_turn_id(context.dialog_turn_id.clone());
                     messages.push(user_msg.clone());
                     if let Err(e) = self
                         .session_manager

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -5,8 +5,8 @@
 use super::round_executor::RoundExecutor;
 use super::types::{ExecutionContext, ExecutionResult, RoundContext, RoundResult};
 use crate::agentic::agents::{
-    get_agent_registry, PrependedPromptReminders, PromptBuilder, PromptBuilderContext,
-    RemoteExecutionHints, ToolListingSections,
+    build_prompt_context_for_workspace, get_agent_registry, PrependedPromptReminders,
+    PromptBuilder, PromptBuilderContext, ToolListingSections,
 };
 use crate::agentic::context_profile::{ContextProfilePolicy, ModelCapabilityProfile};
 use crate::agentic::core::{
@@ -21,15 +21,13 @@ use crate::agentic::image_analysis::{
 };
 use crate::agentic::round_preempt::RoundInjectionKind;
 use crate::agentic::session::{CompressionMode, ContextCompressor, SessionManager};
+use crate::agentic::skill_agent_snapshot::build_skill_agent_tool_listing_sections_from_snapshot;
 use crate::agentic::tools::implementations::{GetToolSpecTool, SkillTool, TaskTool};
 use crate::agentic::tools::{resolve_tool_manifest, tool_context_runtime, ResolvedToolManifest};
-use crate::agentic::util::build_remote_workspace_layout_preview;
-use crate::agentic::{WorkspaceBackend, WorkspaceBinding};
+use crate::agentic::WorkspaceBinding;
 use crate::infrastructure::ai::get_global_ai_client_factory;
 use crate::service::config::get_global_config_service;
 use crate::service::config::types::{ModelCapability, ModelCategory, WriteToolMode};
-use crate::service::remote_ssh::workspace_state::get_remote_workspace_manager;
-use crate::service::workspace::get_global_workspace_service;
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::token_counter::TokenCounter;
 use crate::util::types::Message as AIMessage;
@@ -609,94 +607,16 @@ impl ExecutionEngine {
         supports_image_understanding: bool,
         tool_listing_sections: ToolListingSections,
     ) -> Option<PromptBuilderContext> {
-        let workspace_path = context
-            .workspace
-            .as_ref()
-            .map(|workspace| workspace.root_path_string())?;
-
-        let related_paths = if let Some(workspace_id) = context
-            .workspace
-            .as_ref()
-            .and_then(|workspace| workspace.workspace_id.as_deref())
-        {
-            if let Some(workspace_service) = get_global_workspace_service() {
-                workspace_service
-                    .get_workspace(workspace_id)
-                    .await
-                    .map(|workspace| workspace.related_paths)
-                    .unwrap_or_default()
-            } else {
-                Vec::new()
-            }
-        } else {
-            Vec::new()
-        };
-
-        let base = PromptBuilderContext::new(
-            workspace_path.clone(),
-            Some(context.session_id.clone()),
+        let workspace = context.workspace.as_ref()?;
+        build_prompt_context_for_workspace(
+            workspace,
+            workspace.workspace_id.as_deref(),
+            &context.session_id,
             Some(model_name.to_string()),
+            Some(supports_image_understanding),
+            tool_listing_sections,
         )
-        .with_related_paths(related_paths)
-        .with_supports_image_understanding(supports_image_understanding)
-        .with_tool_listing_sections(tool_listing_sections);
-
-        let Some(workspace) = context.workspace.as_ref() else {
-            return Some(base);
-        };
-        if !workspace.is_remote() {
-            return Some(base);
-        }
-
-        let Some(connection_id) = workspace.connection_id() else {
-            return Some(base);
-        };
-        let Some(manager) = get_remote_workspace_manager() else {
-            warn!(
-                "Remote workspace active but RemoteWorkspaceStateManager is missing; using client OS hints only"
-            );
-            return Some(base);
-        };
-
-        let ssh_manager = manager.get_ssh_manager().await;
-        let file_service = manager.get_file_service().await;
-        let (kernel_name, hostname) = if let Some(ref ssh) = ssh_manager {
-            if let Some(info) = ssh.get_server_info(connection_id).await {
-                (info.os_type, info.hostname)
-            } else {
-                ("Linux".to_string(), "remote".to_string())
-            }
-        } else {
-            ("Linux".to_string(), "remote".to_string())
-        };
-        let connection_display_name = match &workspace.backend {
-            WorkspaceBackend::Remote {
-                connection_name, ..
-            } => connection_name.clone(),
-            _ => connection_id.to_string(),
-        };
-        let remote_layout = if let Some(ref fs) = file_service {
-            match build_remote_workspace_layout_preview(fs, connection_id, &workspace_path, 200)
-                .await
-            {
-                Ok((_, preview)) => Some(preview),
-                Err(e) => {
-                    warn!("Remote workspace layout for prompt failed: {}", e);
-                    None
-                }
-            }
-        } else {
-            None
-        };
-
-        Some(base.with_remote_prompt_overlay(
-            RemoteExecutionHints {
-                connection_display_name,
-                kernel_name,
-                hostname,
-            },
-            remote_layout,
-        ))
+        .await
     }
 
     async fn build_cached_prepended_prompt_reminders(
@@ -704,12 +624,24 @@ impl ExecutionEngine {
         session_id: &str,
         current_agent: &dyn crate::agentic::agents::Agent,
         prompt_context: Option<&PromptBuilderContext>,
+        _context_vars: &HashMap<String, String>,
     ) -> PrependedPromptReminders {
         let Some(prompt_context) = prompt_context.cloned() else {
             return PrependedPromptReminders::default();
         };
 
         let prompt_builder = PromptBuilder::new(prompt_context);
+        let baseline_tool_sections = self
+            .session_manager
+            .turn_skill_agent_snapshot(session_id, 0)
+            .await
+            .map(|snapshot| build_skill_agent_tool_listing_sections_from_snapshot(&snapshot));
+        if baseline_tool_sections.is_none() {
+            warn!(
+                "First-turn skill-agent snapshot unavailable while building prepended reminders: session_id={}",
+                session_id
+            );
+        }
         let user_context_identity = current_agent.user_context_cache_identity();
         let user_context = if let Some(cached_user_context) = self
             .session_manager
@@ -742,8 +674,12 @@ impl ExecutionEngine {
         };
 
         PrependedPromptReminders {
-            skill_listing: prompt_builder.build_skill_listing_reminder(),
-            agent_listing: prompt_builder.build_agent_listing_reminder(),
+            skill_listing: baseline_tool_sections
+                .as_ref()
+                .and_then(|sections| sections.render_skill_listing_reminder()),
+            agent_listing: baseline_tool_sections
+                .as_ref()
+                .and_then(|sections| sections.render_agent_listing_reminder()),
             collapsed_tool_listing: prompt_builder.build_collapsed_tool_listing_reminder(),
             user_context,
         }
@@ -1464,6 +1400,7 @@ impl ExecutionEngine {
                 &context.session_id,
                 current_agent.as_ref(),
                 prompt_context.as_ref(),
+                &context.context,
             )
             .await;
         let system_prompt = self
@@ -2151,6 +2088,7 @@ impl ExecutionEngine {
                 &context.session_id,
                 current_agent.as_ref(),
                 prompt_context.as_ref(),
+                &context.context,
             )
             .await;
         let prepended_reminders = prepended_prompt_reminders.ordered_reminders();

--- a/src/crates/core/src/agentic/goal_mode/mod.rs
+++ b/src/crates/core/src/agentic/goal_mode/mod.rs
@@ -5,9 +5,7 @@ mod types;
 
 pub use types::*;
 
-use crate::agentic::core::{
-    Message, MessageContent, MessageRole, MessageSemanticKind, PromptEnvelope,
-};
+use crate::agentic::core::{Message, MessageContent, MessageRole, MessageSemanticKind};
 use crate::service::config::{get_app_language_code, short_model_user_language_instruction};
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::extract_json_from_ai_response;
@@ -167,20 +165,6 @@ Keep working toward the initial session goal. Do not declare the task finished u
     )
 }
 
-pub fn wrap_user_input_with_goal_reminder(user_input: String, state: &GoalModeState) -> String {
-    if has_prompt_markup(&user_input) {
-        return user_input;
-    }
-    let mut envelope = PromptEnvelope::new();
-    envelope.push_system_reminder(build_goal_system_reminder(state));
-    envelope.push_user_query(user_input);
-    envelope.render()
-}
-
-fn has_prompt_markup(text: &str) -> bool {
-    crate::agentic::core::has_prompt_markup(text)
-}
-
 pub fn build_goal_kickoff_messages(
     generation: &GoalGenerationResult,
     user_hint: Option<&str>,
@@ -245,26 +229,23 @@ pub fn build_goal_continuation_plan(
 
     let display_message = format!("Goal not yet achieved — continuing work on: {guidance}");
 
-    let wrapped_message = {
-        let mut envelope = PromptEnvelope::new();
-        envelope.push_system_reminder(format!(
-            "Goal verification found the initial session goal is NOT yet achieved.\n\
+    let continuation_reminder = format!(
+        "Goal verification found the initial session goal is NOT yet achieved.\n\
 Initial session goal: {}\n\
 {current_goal_note}\
 Remaining gaps:\n{gaps}\n\
 Next steps:\n{guidance}\n\
 Continue working until the initial session goal is fully satisfied. Do not stop early.",
-            initial_goal_text
-        ));
-        envelope.push_user_query(format!(
-            "Continue working toward the initial session goal. Address the remaining gaps and complete the goal before stopping.\n\nInitial session goal: {}",
-            initial_goal_text
-        ));
-        envelope.render()
-    };
+        initial_goal_text
+    );
+    let user_input = format!(
+        "Continue working toward the initial session goal. Address the remaining gaps and complete the goal before stopping.\n\nInitial session goal: {}",
+        initial_goal_text
+    );
 
     GoalContinuationPlan {
-        wrapped_message,
+        user_input,
+        prepended_reminders: vec![continuation_reminder],
         display_message,
         user_message_metadata: serde_json::json!({
             "goalModeContinuation": true,
@@ -845,7 +826,8 @@ mod tests {
             guidance: "Add tests".to_string(),
         };
         let plan = build_goal_continuation_plan(&state, &verification);
-        assert!(plan.wrapped_message.contains("Ship feature"));
+        assert!(plan.user_input.contains("Ship feature"));
+        assert!(plan.prepended_reminders[0].contains("Ship feature"));
         assert!(plan.display_message.contains("Add tests"));
         assert!(!plan.display_message.contains("Ship feature"));
     }
@@ -874,11 +856,9 @@ mod tests {
         };
 
         let plan = build_goal_continuation_plan(&state, &verification);
-        assert!(plan
-            .wrapped_message
+        assert!(plan.prepended_reminders[0]
             .contains("Initial session goal: Ship the importer fix with tests"));
-        assert!(plan
-            .wrapped_message
+        assert!(plan.prepended_reminders[0]
             .contains("Current continuation target: Summarize current progress"));
         assert_eq!(
             plan.user_message_metadata["initialGoal"]["goalText"],

--- a/src/crates/core/src/agentic/init_agents_md.rs
+++ b/src/crates/core/src/agentic/init_agents_md.rs
@@ -1,5 +1,5 @@
 use crate::agentic::agents::get_embedded_prompt;
-use crate::agentic::core::PromptEnvelope;
+use crate::agentic::core::{InternalReminderKind, Message};
 use crate::service::config::get_app_language_code;
 use crate::util::errors::{BitFunError, BitFunResult};
 
@@ -13,7 +13,7 @@ fn init_agents_md_user_query(is_chinese: bool) -> &'static str {
     }
 }
 
-pub(crate) async fn build_init_agents_md_user_input() -> BitFunResult<(String, String)> {
+pub(crate) async fn build_init_agents_md_user_input() -> BitFunResult<(String, Vec<Message>)> {
     let prompt = get_embedded_prompt(INIT_AGENTS_MD_PROMPT_NAME).ok_or_else(|| {
         BitFunError::Agent(format!(
             "{} not found in embedded files",
@@ -22,10 +22,13 @@ pub(crate) async fn build_init_agents_md_user_input() -> BitFunResult<(String, S
     })?;
     let is_chinese = get_app_language_code().await.starts_with("zh");
     let user_query = init_agents_md_user_query(is_chinese).to_string();
-    let mut envelope = PromptEnvelope::new();
-    envelope.push_system_reminder(prompt.to_string());
-    envelope.push_user_query(user_query.clone());
-    Ok((envelope.render(), user_query))
+    Ok((
+        user_query,
+        vec![Message::internal_reminder(
+            InternalReminderKind::InitAgentsMd,
+            prompt.to_string(),
+        )],
+    ))
 }
 
 #[cfg(test)]
@@ -39,14 +42,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn init_agents_md_user_input_wraps_reminder_before_query() {
-        let (user_input, original_user_input) = build_init_agents_md_user_input()
+    async fn init_agents_md_user_input_returns_query_and_reminder_message() {
+        let (user_input, prepended_messages) = build_init_agents_md_user_input()
             .await
             .expect("init agents md prompt should build");
 
-        assert!(user_input.contains("<system_reminder>"));
-        assert!(user_input.contains("<user_query>"));
-        assert!(user_input.find("<system_reminder>") < user_input.find("<user_query>"));
-        assert!(!original_user_input.trim().is_empty());
+        assert!(!user_input.trim().is_empty());
+        assert_eq!(prepended_messages.len(), 1);
+        assert_eq!(
+            prepended_messages[0].internal_reminder_kind(),
+            Some(crate::agentic::core::InternalReminderKind::InitAgentsMd)
+        );
     }
 }

--- a/src/crates/core/src/agentic/mod.rs
+++ b/src/crates/core/src/agentic/mod.rs
@@ -7,6 +7,7 @@
 pub mod core;
 pub mod events;
 pub mod persistence;
+pub mod skill_agent_snapshot;
 
 // Session management module
 pub mod session;
@@ -67,5 +68,6 @@ pub use round_preempt::{
 };
 pub use session::*;
 pub use side_question::*;
+pub use skill_agent_snapshot::*;
 pub use system::{init_agentic_system, AgenticSystem};
 pub use workspace::{WorkspaceBackend, WorkspaceBinding};

--- a/src/crates/core/src/agentic/persistence/manager.rs
+++ b/src/crates/core/src/agentic/persistence/manager.rs
@@ -7,6 +7,7 @@ use crate::agentic::core::{
     SessionKind, SessionState, SessionSummary,
 };
 use crate::agentic::session::{SessionPromptCache, PROMPT_CACHE_SCHEMA_VERSION};
+use crate::agentic::skill_agent_snapshot::TurnSkillAgentSnapshot;
 use crate::infrastructure::PathManager;
 use crate::service::remote_ssh::workspace_state::{
     resolve_workspace_session_identity, LOCAL_WORKSPACE_SSH_HOST,
@@ -95,6 +96,14 @@ pub struct SessionMetadataPage {
 struct SessionMetadataPageCursor {
     last_active_at: u64,
     session_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredTurnSkillAgentSnapshotFile {
+    schema_version: u32,
+    session_id: String,
+    turn_index: usize,
+    snapshot: TurnSkillAgentSnapshot,
 }
 
 #[derive(Debug, Default)]
@@ -448,6 +457,16 @@ impl PersistenceManager {
     ) -> PathBuf {
         self.snapshots_dir(workspace_path, session_id)
             .join(format!("context-{:04}.json", turn_index))
+    }
+
+    fn skill_agent_snapshot_path(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        turn_index: usize,
+    ) -> PathBuf {
+        self.snapshots_dir(workspace_path, session_id)
+            .join(format!("skill-agent-{:04}.json", turn_index))
     }
 
     fn transcript_path(&self, workspace_path: &Path, session_id: &str) -> PathBuf {
@@ -2104,6 +2123,83 @@ impl PersistenceManager {
         Ok(Some((turn_index, messages)))
     }
 
+    pub async fn save_turn_skill_agent_snapshot(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        turn_index: usize,
+        snapshot: &TurnSkillAgentSnapshot,
+    ) -> BitFunResult<()> {
+        self.ensure_runtime_for_write(workspace_path).await?;
+        self.ensure_snapshots_dir(workspace_path, session_id)
+            .await?;
+
+        self.write_json_atomic(
+            &self.skill_agent_snapshot_path(workspace_path, session_id, turn_index),
+            &StoredTurnSkillAgentSnapshotFile {
+                schema_version: SESSION_STORAGE_SCHEMA_VERSION,
+                session_id: session_id.to_string(),
+                turn_index,
+                snapshot: snapshot.clone(),
+            },
+        )
+        .await
+    }
+
+    pub async fn load_turn_skill_agent_snapshot(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        turn_index: usize,
+    ) -> BitFunResult<Option<TurnSkillAgentSnapshot>> {
+        let stored = self
+            .read_json_optional::<StoredTurnSkillAgentSnapshotFile>(
+                &self.skill_agent_snapshot_path(workspace_path, session_id, turn_index),
+            )
+            .await?;
+        Ok(stored.map(|value| value.snapshot))
+    }
+
+    pub async fn delete_turn_skill_agent_snapshots_from(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        turn_index: usize,
+    ) -> BitFunResult<()> {
+        let dir = self.snapshots_dir(workspace_path, session_id);
+        if !dir.exists() {
+            return Ok(());
+        }
+
+        let mut rd = fs::read_dir(&dir)
+            .await
+            .map_err(|e| BitFunError::io(format!("Failed to read snapshots directory: {}", e)))?;
+        while let Some(entry) = rd
+            .next_entry()
+            .await
+            .map_err(|e| BitFunError::io(format!("Failed to iterate snapshots directory: {}", e)))?
+        {
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            let Some(index_str) = stem.strip_prefix("skill-agent-") else {
+                continue;
+            };
+            let Ok(index) = index_str.parse::<usize>() else {
+                continue;
+            };
+            if index >= turn_index {
+                let _ = fs::remove_file(&path).await;
+            }
+        }
+
+        Ok(())
+    }
+
     pub async fn delete_turn_context_snapshots_from(
         &self,
         workspace_path: &Path,
@@ -2130,7 +2226,11 @@ impl PersistenceManager {
             let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
                 continue;
             };
-            let Some(index_str) = stem.strip_prefix("context-") else {
+            let index_str = if let Some(index) = stem.strip_prefix("context-") {
+                index
+            } else if let Some(index) = stem.strip_prefix("skill-agent-") {
+                index
+            } else {
                 continue;
             };
             let Ok(index) = index_str.parse::<usize>() else {
@@ -3053,6 +3153,9 @@ impl PersistenceManager {
 mod tests {
     use super::{context_snapshot_payload_stats, PersistenceManager};
     use crate::agentic::core::{Message, Session, SessionConfig, SessionKind, ToolResult};
+    use crate::agentic::skill_agent_snapshot::{
+        AgentSnapshotEntry, SkillSnapshotEntry, TurnSkillAgentSnapshot,
+    };
     use crate::infrastructure::PathManager;
     use crate::service::session::{
         DialogTurnData, ModelRoundData, SessionMetadata, SessionRelationship,
@@ -3833,5 +3936,62 @@ mod tests {
         assert!(runtime.snapshot_operations_dir.exists());
         assert!(runtime.plans_dir.exists());
         assert!(runtime.layout_state_file.exists());
+    }
+
+    #[tokio::test]
+    async fn skill_agent_snapshots_persist_and_truncate_with_context_snapshots() {
+        let workspace = TestWorkspace::new();
+        let manager = PersistenceManager::new(Arc::new(PathManager::new().expect("path manager")))
+            .expect("persistence manager");
+        let session_id = Uuid::new_v4().to_string();
+        let snapshot = TurnSkillAgentSnapshot {
+            skills: vec![SkillSnapshotEntry {
+                name: "skill-a".to_string(),
+                description: "desc-a".to_string(),
+                location: "/skills/a".to_string(),
+            }],
+            subagents: vec![AgentSnapshotEntry {
+                id: "agent-a".to_string(),
+                description: "desc-a".to_string(),
+                default_tools: vec!["Read".to_string()],
+            }],
+        };
+
+        manager
+            .save_turn_context_snapshot(
+                workspace.path(),
+                &session_id,
+                0,
+                &[Message::user("hi".to_string())],
+            )
+            .await
+            .expect("context snapshot should save");
+        manager
+            .save_turn_skill_agent_snapshot(workspace.path(), &session_id, 0, &snapshot)
+            .await
+            .expect("skill-agent snapshot should save");
+
+        let loaded = manager
+            .load_turn_skill_agent_snapshot(workspace.path(), &session_id, 0)
+            .await
+            .expect("skill-agent snapshot should load")
+            .expect("skill-agent snapshot should exist");
+        assert_eq!(loaded, snapshot);
+
+        manager
+            .delete_turn_context_snapshots_from(workspace.path(), &session_id, 0)
+            .await
+            .expect("snapshot deletion should succeed");
+
+        assert!(manager
+            .load_turn_skill_agent_snapshot(workspace.path(), &session_id, 0)
+            .await
+            .expect("skill-agent snapshot reload should succeed")
+            .is_none());
+        assert!(manager
+            .load_turn_context_snapshot(workspace.path(), &session_id, 0)
+            .await
+            .expect("context snapshot reload should succeed")
+            .is_none());
     }
 }

--- a/src/crates/core/src/agentic/persistence/session_branch.rs
+++ b/src/crates/core/src/agentic/persistence/session_branch.rs
@@ -160,6 +160,22 @@ impl PersistenceManager {
                     )
                     .await?;
                 }
+                if let Some(snapshot) = self
+                    .load_turn_skill_agent_snapshot(
+                        workspace_path,
+                        &request.source_session_id,
+                        source_turn.turn_index,
+                    )
+                    .await?
+                {
+                    self.save_turn_skill_agent_snapshot(
+                        workspace_path,
+                        &target_session_id,
+                        new_index,
+                        &snapshot,
+                    )
+                    .await?;
+                }
             }
 
             for turn in &branched_turns {

--- a/src/crates/core/src/agentic/session/compression/fallback/builder.rs
+++ b/src/crates/core/src/agentic/session/compression/fallback/builder.rs
@@ -162,6 +162,13 @@ fn extract_nested_compression_entries(message: &Message) -> Option<Vec<Compressi
         return None;
     }
 
+    if message
+        .internal_reminder_kind()
+        .is_some_and(|kind| kind.should_drop_during_compaction())
+    {
+        return Some(Vec::new());
+    }
+
     let raw_text = match &message.content {
         MessageContent::Text(text) => text.clone(),
         MessageContent::Multimodal { text, .. } => text.clone(),

--- a/src/crates/core/src/agentic/session/compression/fallback/tests.rs
+++ b/src/crates/core/src/agentic/session/compression/fallback/tests.rs
@@ -4,8 +4,8 @@ use super::{
 };
 use crate::agentic::core::{
     render_system_reminder, render_user_query, CompressedMessageRole, CompressionContract,
-    CompressionContractItem, CompressionEntry, CompressionPayload, Message, MessageSemanticKind,
-    ToolCall, ToolResult,
+    CompressionContractItem, CompressionEntry, CompressionPayload, InternalReminderKind, Message,
+    MessageSemanticKind, ToolCall, ToolResult,
 };
 use serde_json::json;
 
@@ -122,6 +122,23 @@ fn drops_system_reminder_only_user_messages_from_fallback_summary() {
         vec![vec![Message::user(render_system_reminder(
             "Summarized context boundary marker",
         ))]],
+        &default_options(),
+    );
+
+    assert!(summary_artifact.payload.entries.is_empty());
+    assert_eq!(
+        summary_artifact.summary_text,
+        "No detailed historical entries fit within the remaining context budget."
+    );
+}
+
+#[test]
+fn drops_listing_diff_internal_reminders_from_fallback_summary() {
+    let summary_artifact = build_structured_compression_summary(
+        vec![vec![Message::internal_reminder(
+            InternalReminderKind::SkillListingDiff,
+            "# Skill Listing Update\n\nChanged",
+        )]],
         &default_options(),
     );
 

--- a/src/crates/core/src/agentic/session/mod.rs
+++ b/src/crates/core/src/agentic/session/mod.rs
@@ -8,6 +8,7 @@ pub mod evidence_ledger;
 pub mod file_read_state;
 pub mod prompt_cache;
 pub mod session_manager;
+pub mod turn_skill_agent_snapshot_store;
 
 pub use compression::*;
 pub use context_store::*;
@@ -15,3 +16,4 @@ pub use evidence_ledger::*;
 pub use file_read_state::*;
 pub use prompt_cache::*;
 pub use session_manager::*;
+pub use turn_skill_agent_snapshot_store::*;

--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -13,8 +13,9 @@ use crate::agentic::session::{
     EvidenceLedgerEventStatus, EvidenceLedgerSummary, EvidenceLedgerTargetKind, FileReadState,
     FileReadStateStore, PromptCacheLookup, PromptCachePolicy, PromptCacheScope,
     SessionContextStore, SessionEvidenceLedger, SessionPromptCache, SessionPromptCacheStore,
-    SystemPromptCacheIdentity, UserContextCacheIdentity,
+    SystemPromptCacheIdentity, TurnSkillAgentSnapshotStore, UserContextCacheIdentity,
 };
+use crate::agentic::skill_agent_snapshot::TurnSkillAgentSnapshot;
 use crate::infrastructure::ai::get_global_ai_client_factory;
 use crate::service::config::{
     get_app_language_code, get_global_config_service, short_model_user_language_instruction,
@@ -96,6 +97,7 @@ pub struct SessionManager {
     /// Sub-components
     context_store: Arc<SessionContextStore>,
     prompt_cache_store: Arc<SessionPromptCacheStore>,
+    turn_skill_agent_snapshot_store: Arc<TurnSkillAgentSnapshotStore>,
     file_read_state_store: Arc<FileReadStateStore>,
     evidence_ledger: Arc<SessionEvidenceLedger>,
     persistence_manager: Arc<PersistenceManager>,
@@ -715,6 +717,17 @@ impl SessionManager {
         self.prompt_cache_store.replace_cache(session_id, cache);
     }
 
+    async fn load_turn_skill_agent_snapshot_from_persistence(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        turn_index: usize,
+    ) -> BitFunResult<Option<TurnSkillAgentSnapshot>> {
+        self.persistence_manager
+            .load_turn_skill_agent_snapshot(workspace_path, session_id, turn_index)
+            .await
+    }
+
     async fn load_prompt_cache_from_persistence(
         &self,
         workspace_path: &Path,
@@ -800,6 +813,7 @@ impl SessionManager {
             session_workspace_index: Arc::new(DashMap::new()),
             context_store,
             prompt_cache_store: Arc::new(SessionPromptCacheStore::new()),
+            turn_skill_agent_snapshot_store: Arc::new(TurnSkillAgentSnapshotStore::new()),
             file_read_state_store: Arc::new(FileReadStateStore::new()),
             evidence_ledger: Arc::new(SessionEvidenceLedger::new()),
             persistence_manager,
@@ -987,6 +1001,7 @@ impl SessionManager {
         let session_workspace_index = self.session_workspace_index.clone();
         let context_store = self.context_store.clone();
         let prompt_cache_store = self.prompt_cache_store.clone();
+        let turn_skill_agent_snapshot_store = self.turn_skill_agent_snapshot_store.clone();
         let file_read_state_store = self.file_read_state_store.clone();
         let evidence_ledger = self.evidence_ledger.clone();
         let persistence_manager = self.persistence_manager.clone();
@@ -1008,6 +1023,7 @@ impl SessionManager {
                 session_workspace_index,
                 context_store,
                 prompt_cache_store,
+                turn_skill_agent_snapshot_store,
                 file_read_state_store,
                 evidence_ledger,
                 persistence_manager,
@@ -1147,6 +1163,8 @@ impl SessionManager {
 
         // 2. Initialize the in-memory context cache.
         self.context_store.create_session(&session_id);
+        self.turn_skill_agent_snapshot_store
+            .create_session(&session_id);
         self.file_read_state_store.create_session(&session_id);
 
         // 3. Persist to local path (handles remote workspaces correctly)
@@ -1260,6 +1278,190 @@ impl SessionManager {
         self.persist_prompt_cache_best_effort(target_session_id, "prompt_cache_cloned")
             .await;
         true
+    }
+
+    pub async fn turn_skill_agent_snapshot(
+        &self,
+        session_id: &str,
+        turn_index: usize,
+    ) -> Option<TurnSkillAgentSnapshot> {
+        if let Some(snapshot) = self
+            .turn_skill_agent_snapshot_store
+            .get_snapshot(session_id, turn_index)
+        {
+            return Some(snapshot);
+        }
+
+        if !self.should_persist_session_id(session_id) {
+            return None;
+        }
+
+        let workspace_path = self.effective_session_workspace_path(session_id).await?;
+        match self
+            .load_turn_skill_agent_snapshot_from_persistence(
+                &workspace_path,
+                session_id,
+                turn_index,
+            )
+            .await
+        {
+            Ok(Some(snapshot)) => {
+                self.turn_skill_agent_snapshot_store.set_snapshot(
+                    session_id,
+                    turn_index,
+                    snapshot.clone(),
+                );
+                Some(snapshot)
+            }
+            Ok(None) => None,
+            Err(error) => {
+                warn!(
+                    "Failed to load turn skill-agent snapshot: session_id={}, turn_index={}, workspace_path={}, error={}",
+                    session_id,
+                    turn_index,
+                    workspace_path.display(),
+                    error
+                );
+                None
+            }
+        }
+    }
+
+    pub async fn latest_turn_skill_agent_snapshot_at_or_before(
+        &self,
+        session_id: &str,
+        turn_index: usize,
+    ) -> Option<(usize, TurnSkillAgentSnapshot)> {
+        let cached_snapshot = self
+            .turn_skill_agent_snapshot_store
+            .latest_snapshot_at_or_before(session_id, turn_index);
+        if let Some(snapshot) = cached_snapshot.as_ref() {
+            if snapshot.0 == turn_index || !self.should_persist_session_id(session_id) {
+                return cached_snapshot;
+            }
+        }
+
+        if !self.should_persist_session_id(session_id) {
+            return cached_snapshot;
+        }
+
+        let workspace_path = self.effective_session_workspace_path(session_id).await?;
+        let scan_floor_exclusive = cached_snapshot.as_ref().map(|snapshot| snapshot.0);
+        for index in (0..=turn_index).rev() {
+            if scan_floor_exclusive.is_some_and(|floor| index <= floor) {
+                break;
+            }
+            match self
+                .load_turn_skill_agent_snapshot_from_persistence(&workspace_path, session_id, index)
+                .await
+            {
+                Ok(Some(snapshot)) => {
+                    self.turn_skill_agent_snapshot_store.set_snapshot(
+                        session_id,
+                        index,
+                        snapshot.clone(),
+                    );
+                    return Some((index, snapshot));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    warn!(
+                        "Failed to load turn skill-agent snapshot while scanning backwards: session_id={}, turn_index={}, workspace_path={}, error={}",
+                        session_id,
+                        index,
+                        workspace_path.display(),
+                        error
+                    );
+                }
+            }
+        }
+
+        cached_snapshot
+    }
+
+    pub async fn remember_turn_skill_agent_snapshot(
+        &self,
+        session_id: &str,
+        turn_index: usize,
+        snapshot: TurnSkillAgentSnapshot,
+    ) {
+        self.turn_skill_agent_snapshot_store
+            .set_snapshot(session_id, turn_index, snapshot.clone());
+
+        if !self.should_persist_session_id(session_id) {
+            return;
+        }
+
+        let Some(workspace_path) = self.effective_session_workspace_path(session_id).await else {
+            debug!(
+                "Skipping turn skill-agent snapshot persistence because workspace path is unavailable: session_id={}, turn_index={}",
+                session_id, turn_index
+            );
+            return;
+        };
+
+        if let Err(error) = self
+            .persistence_manager
+            .save_turn_skill_agent_snapshot(&workspace_path, session_id, turn_index, &snapshot)
+            .await
+        {
+            warn!(
+                "Failed to persist turn skill-agent snapshot: session_id={}, turn_index={}, workspace_path={}, error={}",
+                session_id,
+                turn_index,
+                workspace_path.display(),
+                error
+            );
+        }
+    }
+
+    pub async fn recover_first_turn_skill_agent_snapshot(
+        &self,
+        session_id: &str,
+        snapshot: TurnSkillAgentSnapshot,
+    ) {
+        self.turn_skill_agent_snapshot_store
+            .remove_from(session_id, 1);
+        self.turn_skill_agent_snapshot_store
+            .set_snapshot(session_id, 0, snapshot.clone());
+
+        if !self.should_persist_session_id(session_id) {
+            return;
+        }
+
+        let Some(workspace_path) = self.effective_session_workspace_path(session_id).await else {
+            debug!(
+                "Skipping first-turn skill-agent baseline recovery persistence because workspace path is unavailable: session_id={}",
+                session_id
+            );
+            return;
+        };
+
+        if let Err(error) = self
+            .persistence_manager
+            .delete_turn_skill_agent_snapshots_from(&workspace_path, session_id, 1)
+            .await
+        {
+            warn!(
+                "Failed to prune turn skill-agent snapshots during baseline recovery: session_id={}, workspace_path={}, error={}",
+                session_id,
+                workspace_path.display(),
+                error
+            );
+        }
+
+        if let Err(error) = self
+            .persistence_manager
+            .save_turn_skill_agent_snapshot(&workspace_path, session_id, 0, &snapshot)
+            .await
+        {
+            warn!(
+                "Failed to persist recovered first-turn skill-agent snapshot: session_id={}, workspace_path={}, error={}",
+                session_id,
+                workspace_path.display(),
+                error
+            );
+        }
     }
 
     pub async fn invalidate_prompt_cache(
@@ -1701,6 +1903,8 @@ impl SessionManager {
         );
         self.context_store.delete_session(session_id);
         self.prompt_cache_store.delete_session(session_id);
+        self.turn_skill_agent_snapshot_store
+            .delete_session(session_id);
         self.file_read_state_store.delete_session(session_id);
         debug!(
             "Session deletion stage completed: session_id={}, stage=context_store_delete, duration_ms={}",
@@ -2184,6 +2388,8 @@ impl SessionManager {
         if session_already_in_memory {
             self.context_store.delete_session(session_id);
             self.prompt_cache_store.delete_session(session_id);
+            self.turn_skill_agent_snapshot_store
+                .delete_session(session_id);
             self.file_read_state_store.delete_session(session_id);
         }
 
@@ -2361,6 +2567,8 @@ impl SessionManager {
                 .delete_turn_context_snapshots_from(workspace_path, session_id, target_turn)
                 .await?;
         }
+        self.turn_skill_agent_snapshot_store
+            .remove_from(session_id, target_turn);
 
         Ok(())
     }
@@ -3841,6 +4049,7 @@ impl SessionManager {
         let enable_persistence = self.config.enable_persistence;
         let context_store = self.context_store.clone();
         let prompt_cache_store = self.prompt_cache_store.clone();
+        let turn_skill_agent_snapshot_store = self.turn_skill_agent_snapshot_store.clone();
         let file_read_state_store = self.file_read_state_store.clone();
 
         tokio::spawn(async move {
@@ -3899,6 +4108,7 @@ impl SessionManager {
                     {
                         context_store.delete_session(&candidate.session_id);
                         prompt_cache_store.delete_session(&candidate.session_id);
+                        turn_skill_agent_snapshot_store.delete_session(&candidate.session_id);
                         file_read_state_store.delete_session(&candidate.session_id);
                     }
                 }
@@ -4993,6 +5203,98 @@ mod tests {
             .expect("metadata should load")
             .expect("metadata should exist");
         assert_eq!(metadata.turn_count, 1);
+    }
+
+    #[tokio::test]
+    async fn latest_skill_agent_snapshot_scans_persistence_beyond_stale_cache_hit() {
+        use crate::agentic::skill_agent_snapshot::{
+            AgentSnapshotEntry, SkillSnapshotEntry, TurnSkillAgentSnapshot,
+        };
+
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager);
+        let session = manager
+            .create_session(
+                "Skill agent snapshot".to_string(),
+                "agent".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+
+        manager
+            .remember_turn_skill_agent_snapshot(
+                &session.session_id,
+                0,
+                TurnSkillAgentSnapshot {
+                    skills: vec![SkillSnapshotEntry {
+                        name: "skill-a".to_string(),
+                        description: "desc-a".to_string(),
+                        location: "/a".to_string(),
+                    }],
+                    subagents: vec![AgentSnapshotEntry {
+                        id: "agent-a".to_string(),
+                        description: "desc-a".to_string(),
+                        default_tools: vec!["Read".to_string()],
+                    }],
+                },
+            )
+            .await;
+        manager
+            .remember_turn_skill_agent_snapshot(
+                &session.session_id,
+                1,
+                TurnSkillAgentSnapshot {
+                    skills: vec![SkillSnapshotEntry {
+                        name: "skill-a".to_string(),
+                        description: "desc-a".to_string(),
+                        location: "/a".to_string(),
+                    }],
+                    subagents: vec![AgentSnapshotEntry {
+                        id: "agent-b".to_string(),
+                        description: "desc-b".to_string(),
+                        default_tools: vec!["Read".to_string(), "Grep".to_string()],
+                    }],
+                },
+            )
+            .await;
+
+        manager
+            .turn_skill_agent_snapshot_store
+            .delete_session(&session.session_id);
+        manager
+            .turn_skill_agent_snapshot_store
+            .create_session(&session.session_id);
+        manager.turn_skill_agent_snapshot_store.set_snapshot(
+            &session.session_id,
+            0,
+            TurnSkillAgentSnapshot {
+                skills: vec![SkillSnapshotEntry {
+                    name: "skill-a".to_string(),
+                    description: "desc-a".to_string(),
+                    location: "/a".to_string(),
+                }],
+                subagents: vec![AgentSnapshotEntry {
+                    id: "agent-a".to_string(),
+                    description: "desc-a".to_string(),
+                    default_tools: vec!["Read".to_string()],
+                }],
+            },
+        );
+
+        let latest = manager
+            .latest_turn_skill_agent_snapshot_at_or_before(&session.session_id, 1)
+            .await
+            .expect("latest snapshot should exist");
+
+        assert_eq!(latest.0, 1);
+        assert_eq!(latest.1.subagents[0].id, "agent-b");
     }
 
     #[tokio::test]

--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -3,8 +3,9 @@
 //! Responsible for session CRUD, lifecycle management, and resource association
 
 use crate::agentic::core::{
-    new_turn_id, CompressionContract, CompressionState, Message, MessageSemanticKind,
-    ProcessingPhase, Session, SessionConfig, SessionKind, SessionState, SessionSummary, TurnStats,
+    new_turn_id, CompressionContract, CompressionState, InternalReminderKind, Message,
+    MessageSemanticKind, ProcessingPhase, Session, SessionConfig, SessionKind, SessionState,
+    SessionSummary, TurnStats,
 };
 use crate::agentic::image_analysis::ImageContextData;
 use crate::agentic::persistence::PersistenceManager;
@@ -82,6 +83,13 @@ pub struct ResolvedSessionTitle {
     pub title: String,
     pub method: SessionTitleMethod,
 }
+
+// When a full skill/agent listing baseline is rebuilt at turn R, snapshots whose
+// turn_index < R still contain now-redundant listing diff reminders. We do not
+// eagerly rewrite all historical snapshots; instead restore/rollback sanitize those
+// older snapshots lazily based on this persisted cutoff.
+const LISTING_BASELINE_REBUILD_TURN_INDEX_METADATA_KEY: &str = "listingBaselineRebuildTurnIndex";
+
 /// Session manager
 pub struct SessionManager {
     /// Active sessions in memory
@@ -1464,6 +1472,204 @@ impl SessionManager {
         }
     }
 
+    pub async fn rebuild_skill_agent_listing_baseline_to_latest(&self, session_id: &str) -> bool {
+        let Some(turn_index) = self
+            .sessions
+            .get(session_id)
+            .and_then(|session| session.dialog_turn_ids.len().checked_sub(1))
+        else {
+            return false;
+        };
+
+        let Some((_, latest_snapshot)) = self
+            .latest_turn_skill_agent_snapshot_at_or_before(session_id, turn_index)
+            .await
+        else {
+            return false;
+        };
+
+        self.recover_first_turn_skill_agent_snapshot(session_id, latest_snapshot)
+            .await;
+        self.persist_listing_baseline_rebuild_turn_index_best_effort(session_id, turn_index)
+            .await;
+
+        let _ = self
+            .remove_listing_diff_internal_reminders(session_id)
+            .await;
+        true
+    }
+
+    pub async fn remove_listing_diff_internal_reminders(&self, session_id: &str) -> bool {
+        let context_messages = self.context_store.get_context_messages(session_id);
+        if context_messages.is_empty() {
+            return false;
+        }
+
+        let (filtered_messages, changed) =
+            Self::strip_listing_diff_internal_reminders(context_messages);
+        if !changed {
+            return false;
+        }
+
+        self.context_store
+            .replace_context(session_id, filtered_messages);
+        self.persist_current_turn_context_snapshot_best_effort(
+            session_id,
+            "listing_diff_internal_reminders_removed",
+        )
+        .await;
+        true
+    }
+
+    fn strip_listing_diff_internal_reminders(messages: Vec<Message>) -> (Vec<Message>, bool) {
+        let original_len = messages.len();
+        let filtered_messages = messages
+            .into_iter()
+            .filter(|message| {
+                !message
+                    .internal_reminder_kind()
+                    .is_some_and(InternalReminderKind::is_listing_diff)
+            })
+            .collect::<Vec<_>>();
+
+        let changed = filtered_messages.len() != original_len;
+        (filtered_messages, changed)
+    }
+
+    fn listing_baseline_rebuild_turn_index_from_custom_metadata(
+        custom_metadata: Option<&serde_json::Value>,
+    ) -> Option<usize> {
+        custom_metadata?
+            .get(LISTING_BASELINE_REBUILD_TURN_INDEX_METADATA_KEY)?
+            .as_u64()?
+            .try_into()
+            .ok()
+    }
+
+    fn listing_baseline_rebuild_turn_index_from_metadata(
+        metadata: Option<&SessionMetadata>,
+    ) -> Option<usize> {
+        Self::listing_baseline_rebuild_turn_index_from_custom_metadata(
+            metadata.and_then(|metadata| metadata.custom_metadata.as_ref()),
+        )
+    }
+
+    async fn persist_context_snapshot_messages_best_effort(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        turn_index: usize,
+        messages: &[Message],
+        reason: &str,
+    ) {
+        if !self.should_persist_session_id(session_id) {
+            return;
+        }
+
+        if let Err(err) = self
+            .persistence_manager
+            .save_turn_context_snapshot(workspace_path, session_id, turn_index, messages)
+            .await
+        {
+            warn!(
+                "failed to persist explicit context snapshot: session_id={}, turn_index={}, reason={}, err={}",
+                session_id, turn_index, reason, err
+            );
+        }
+    }
+
+    async fn sanitize_listing_diff_context_snapshot_if_needed(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        turn_index: usize,
+        messages: Vec<Message>,
+        cutoff_turn_index: Option<usize>,
+        reason: &str,
+    ) -> Vec<Message> {
+        let Some(cutoff_turn_index) = cutoff_turn_index else {
+            return messages;
+        };
+        // The rebuild performed at turn R already persisted snapshots on and after R against
+        // the new baseline. Only snapshots strictly before that rebuilt turn need diff-reminder
+        // cleanup, so the predicate is `< cutoff`, not `<= cutoff`.
+        if turn_index >= cutoff_turn_index {
+            return messages;
+        }
+
+        let (sanitized_messages, changed) = Self::strip_listing_diff_internal_reminders(messages);
+        if !changed {
+            return sanitized_messages;
+        }
+
+        debug!(
+            "Sanitized listing diff reminders from pre-rebuild context snapshot: session_id={}, turn_index={}, cutoff_turn_index={}, reason={}",
+            session_id, turn_index, cutoff_turn_index, reason
+        );
+        self.persist_context_snapshot_messages_best_effort(
+            workspace_path,
+            session_id,
+            turn_index,
+            &sanitized_messages,
+            reason,
+        )
+        .await;
+        sanitized_messages
+    }
+
+    async fn persist_listing_baseline_rebuild_turn_index_best_effort(
+        &self,
+        session_id: &str,
+        turn_index: usize,
+    ) {
+        if let Err(err) = self
+            .merge_session_custom_metadata(
+                session_id,
+                json!({
+                    LISTING_BASELINE_REBUILD_TURN_INDEX_METADATA_KEY: turn_index,
+                }),
+            )
+            .await
+        {
+            warn!(
+                "failed to persist listing baseline rebuild turn index: session_id={}, turn_index={}, err={}",
+                session_id, turn_index, err
+            );
+        }
+    }
+
+    async fn truncate_listing_baseline_rebuild_turn_index_after_rollback(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        target_turn: usize,
+    ) -> BitFunResult<()> {
+        let metadata = self
+            .persistence_manager
+            .load_session_metadata(workspace_path, session_id)
+            .await?;
+        let Some(existing_cutoff) =
+            Self::listing_baseline_rebuild_turn_index_from_metadata(metadata.as_ref())
+        else {
+            return Ok(());
+        };
+
+        if existing_cutoff <= target_turn {
+            return Ok(());
+        }
+
+        // After rollback, the session branches again from `target_turn`. Keeping a cutoff newer
+        // than that branch point would cause future snapshots on the new branch to be mistaken
+        // for "pre-rebuild" history during the next restore, so clamp the cutoff down.
+        self.merge_session_custom_metadata(
+            session_id,
+            json!({
+                LISTING_BASELINE_REBUILD_TURN_INDEX_METADATA_KEY: target_turn,
+            }),
+        )
+        .await
+    }
+
     pub async fn invalidate_prompt_cache(
         &self,
         session_id: &str,
@@ -2230,10 +2436,12 @@ impl SessionManager {
         );
 
         let metadata_started_at = Instant::now();
-        if self
+        let session_metadata = self
             .persistence_manager
             .load_session_metadata(&session_storage_path, session_id)
-            .await?
+            .await?;
+        if session_metadata
+            .as_ref()
             .is_some_and(|metadata| !include_internal && metadata.should_hide_from_user_lists())
         {
             return Err(BitFunError::NotFound(format!(
@@ -2241,6 +2449,8 @@ impl SessionManager {
                 session_id
             )));
         }
+        let listing_baseline_rebuild_turn_index =
+            Self::listing_baseline_rebuild_turn_index_from_metadata(session_metadata.as_ref());
         debug!(
             "Session restore phase completed: session_id={}, phase=load_metadata, duration_ms={}",
             session_id,
@@ -2349,7 +2559,15 @@ impl SessionManager {
         {
             Some((turn_index, msgs)) => {
                 latest_turn_index = Some(turn_index);
-                msgs
+                self.sanitize_listing_diff_context_snapshot_if_needed(
+                    &session_storage_path,
+                    session_id,
+                    turn_index,
+                    msgs,
+                    listing_baseline_rebuild_turn_index,
+                    "restore_pre_listing_baseline_rebuild_snapshot",
+                )
+                .await
             }
             None => Self::build_messages_from_turns(&persisted_turns),
         };
@@ -2487,11 +2705,25 @@ impl SessionManager {
             let _ = self.restore_session(workspace_path, session_id).await;
         }
 
+        // Rollback may load a historical snapshot from before the latest rebuilt baseline. In
+        // that case we must strip all listing diff reminders before the snapshot re-enters
+        // runtime context, otherwise old diffs reappear after rollback/reopen.
+        let listing_baseline_rebuild_turn_index = if self.config.enable_persistence {
+            let metadata = self
+                .persistence_manager
+                .load_session_metadata(workspace_path, session_id)
+                .await?;
+            Self::listing_baseline_rebuild_turn_index_from_metadata(metadata.as_ref())
+        } else {
+            None
+        };
+
         // 1) Load target context (target_turn == 0 => empty context)
         let messages = if target_turn == 0 {
             Vec::new()
         } else {
-            self.persistence_manager
+            let messages = self
+                .persistence_manager
                 .load_turn_context_snapshot(workspace_path, session_id, target_turn - 1)
                 .await?
                 .ok_or_else(|| {
@@ -2500,7 +2732,16 @@ impl SessionManager {
                         session_id,
                         target_turn - 1
                     ))
-                })?
+                })?;
+            self.sanitize_listing_diff_context_snapshot_if_needed(
+                workspace_path,
+                session_id,
+                target_turn - 1,
+                messages,
+                listing_baseline_rebuild_turn_index,
+                "rollback_restore_pre_listing_baseline_rebuild_snapshot",
+            )
+            .await
         };
 
         // 2) Restore the in-memory context cache.
@@ -2566,6 +2807,12 @@ impl SessionManager {
             self.persistence_manager
                 .delete_turn_context_snapshots_from(workspace_path, session_id, target_turn)
                 .await?;
+            self.truncate_listing_baseline_rebuild_turn_index_after_rollback(
+                workspace_path,
+                session_id,
+                target_turn,
+            )
+            .await?;
         }
         self.turn_skill_agent_snapshot_store
             .remove_from(session_id, target_turn);
@@ -2953,7 +3200,7 @@ impl SessionManager {
         agent_type: Option<String>,
         user_input: String,
         turn_id: Option<String>,
-        context_message: Option<Message>,
+        context_messages: Vec<Message>,
         processing_phase: ProcessingPhase,
         user_message_metadata: Option<serde_json::Value>,
     ) -> BitFunResult<String> {
@@ -2985,7 +3232,7 @@ impl SessionManager {
             session.last_activity_at = SystemTime::now();
         }
 
-        if let Some(message) = context_message {
+        for message in context_messages {
             self.context_store
                 .add_message(session_id, message.with_turn_id(turn_id.clone()));
         }
@@ -3059,13 +3306,56 @@ impl SessionManager {
                 Some(agent_type),
                 user_input,
                 turn_id,
-                Some(user_message),
+                vec![user_message],
                 ProcessingPhase::Starting,
                 user_message_metadata,
             )
             .await?;
 
         debug!("Starting dialog turn: turn_id={}", turn_id);
+
+        Ok(turn_id)
+    }
+
+    pub async fn start_dialog_turn_with_prepended_messages(
+        &self,
+        session_id: &str,
+        agent_type: String,
+        user_input: String,
+        turn_id: Option<String>,
+        image_contexts: Option<Vec<ImageContextData>>,
+        prepended_messages: Vec<Message>,
+        user_message_metadata: Option<serde_json::Value>,
+    ) -> BitFunResult<String> {
+        let user_message =
+            if let Some(images) = image_contexts.as_ref().filter(|v| !v.is_empty()).cloned() {
+                Message::user_multimodal(user_input.clone(), images)
+                    .with_semantic_kind(MessageSemanticKind::ActualUserInput)
+            } else {
+                Message::user(user_input.clone())
+                    .with_semantic_kind(MessageSemanticKind::ActualUserInput)
+            };
+
+        let mut context_messages = prepended_messages;
+        context_messages.push(user_message);
+
+        let turn_id = self
+            .start_persisted_turn(
+                session_id,
+                DialogTurnKind::UserDialog,
+                Some(agent_type),
+                user_input,
+                turn_id,
+                context_messages,
+                ProcessingPhase::Starting,
+                user_message_metadata,
+            )
+            .await?;
+
+        debug!(
+            "Starting dialog turn with prepended messages: turn_id={}",
+            turn_id
+        );
 
         Ok(turn_id)
     }
@@ -3093,7 +3383,7 @@ impl SessionManager {
                 Some(agent_type),
                 user_input,
                 turn_id,
-                None,
+                Vec::new(),
                 ProcessingPhase::Starting,
                 user_message_metadata,
             )
@@ -3122,7 +3412,7 @@ impl SessionManager {
                 None,
                 display_message,
                 turn_id,
-                None,
+                Vec::new(),
                 ProcessingPhase::Compacting,
                 user_message_metadata,
             )
@@ -5215,7 +5505,7 @@ mod tests {
         let persistence_manager = Arc::new(
             PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
         );
-        let manager = test_manager(persistence_manager);
+        let manager = test_manager(persistence_manager.clone());
         let session = manager
             .create_session(
                 "Skill agent snapshot".to_string(),
@@ -5295,6 +5585,352 @@ mod tests {
 
         assert_eq!(latest.0, 1);
         assert_eq!(latest.1.subagents[0].id, "agent-b");
+    }
+
+    #[tokio::test]
+    async fn rebuild_skill_agent_listing_baseline_to_latest_removes_listing_diff_reminders() {
+        use crate::agentic::core::{InternalReminderKind, Message, MessageSemanticKind};
+        use crate::agentic::skill_agent_snapshot::{SkillSnapshotEntry, TurnSkillAgentSnapshot};
+
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Listing baseline rebuild".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+
+        {
+            let mut active = manager
+                .sessions
+                .get_mut(&session.session_id)
+                .expect("session should be active");
+            active.dialog_turn_ids = vec!["turn-0".to_string(), "turn-1".to_string()];
+        }
+
+        manager.context_store.replace_context(
+            &session.session_id,
+            vec![
+                Message::internal_reminder(
+                    InternalReminderKind::SkillListingDiff,
+                    "# Skill Listing Update\n\nChanged",
+                )
+                .with_turn_id("turn-1".to_string()),
+                Message::internal_reminder(
+                    InternalReminderKind::AgentListingDiff,
+                    "# Agent Listing Update\n\nChanged",
+                )
+                .with_turn_id("turn-1".to_string()),
+                Message::user("real question".to_string())
+                    .with_turn_id("turn-1".to_string())
+                    .with_semantic_kind(MessageSemanticKind::ActualUserInput),
+            ],
+        );
+
+        manager
+            .remember_turn_skill_agent_snapshot(
+                &session.session_id,
+                0,
+                TurnSkillAgentSnapshot {
+                    skills: vec![SkillSnapshotEntry {
+                        name: "old-skill".to_string(),
+                        description: "old".to_string(),
+                        location: "/old".to_string(),
+                    }],
+                    ..Default::default()
+                },
+            )
+            .await;
+        manager
+            .remember_turn_skill_agent_snapshot(
+                &session.session_id,
+                1,
+                TurnSkillAgentSnapshot {
+                    skills: vec![SkillSnapshotEntry {
+                        name: "new-skill".to_string(),
+                        description: "new".to_string(),
+                        location: "/new".to_string(),
+                    }],
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        assert!(
+            manager
+                .rebuild_skill_agent_listing_baseline_to_latest(&session.session_id)
+                .await
+        );
+
+        let context_messages = manager
+            .context_store
+            .get_context_messages(&session.session_id);
+        assert_eq!(context_messages.len(), 1);
+        assert_eq!(
+            context_messages[0].metadata.semantic_kind,
+            Some(MessageSemanticKind::ActualUserInput)
+        );
+
+        let baseline = manager
+            .turn_skill_agent_snapshot(&session.session_id, 0)
+            .await
+            .expect("baseline snapshot should exist");
+        assert_eq!(baseline.skills[0].name, "new-skill");
+        assert!(manager
+            .turn_skill_agent_snapshot(&session.session_id, 1)
+            .await
+            .is_none());
+
+        let metadata = persistence_manager
+            .load_session_metadata(workspace.path(), &session.session_id)
+            .await
+            .expect("metadata lookup should succeed")
+            .expect("metadata should exist");
+        assert_eq!(
+            SessionManager::listing_baseline_rebuild_turn_index_from_metadata(Some(&metadata)),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_session_sanitizes_pre_cutoff_listing_diff_snapshot() {
+        use crate::agentic::core::{InternalReminderKind, Message, MessageSemanticKind};
+
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session_id = Uuid::new_v4().to_string();
+        let mut session = Session::new_with_id(
+            session_id.clone(),
+            "Restore sanitize".to_string(),
+            "agentic".to_string(),
+            SessionConfig {
+                workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                ..Default::default()
+            },
+        );
+        session.dialog_turn_ids = vec!["turn-0".to_string(), "turn-1".to_string()];
+
+        persistence_manager
+            .save_session(workspace.path(), &session)
+            .await
+            .expect("session should save");
+
+        let mut metadata = persistence_manager
+            .load_session_metadata(workspace.path(), &session_id)
+            .await
+            .expect("metadata load should succeed")
+            .expect("metadata should exist");
+        metadata.custom_metadata = Some(json!({
+            super::LISTING_BASELINE_REBUILD_TURN_INDEX_METADATA_KEY: 2,
+        }));
+        persistence_manager
+            .save_session_metadata(workspace.path(), &metadata)
+            .await
+            .expect("metadata should save");
+
+        for index in 0..=1 {
+            let turn = DialogTurnData::new(
+                format!("turn-{index}"),
+                index,
+                session_id.clone(),
+                UserMessageData {
+                    id: format!("turn-{index}-user"),
+                    content: format!("prompt {index}"),
+                    timestamp: index as u64,
+                    metadata: None,
+                },
+            );
+            persistence_manager
+                .save_dialog_turn(workspace.path(), &turn)
+                .await
+                .expect("turn should save");
+        }
+
+        persistence_manager
+            .save_turn_context_snapshot(
+                workspace.path(),
+                &session_id,
+                1,
+                &[
+                    Message::internal_reminder(
+                        InternalReminderKind::SkillListingDiff,
+                        "# Skill Listing Update\n\nChanged",
+                    )
+                    .with_turn_id("turn-1".to_string()),
+                    Message::user("prompt 1".to_string())
+                        .with_turn_id("turn-1".to_string())
+                        .with_semantic_kind(MessageSemanticKind::ActualUserInput),
+                ],
+            )
+            .await
+            .expect("snapshot should save");
+
+        let restored = manager
+            .restore_session(workspace.path(), &session_id)
+            .await
+            .expect("session should restore");
+
+        assert_eq!(
+            restored.dialog_turn_ids,
+            vec!["turn-0".to_string(), "turn-1".to_string()]
+        );
+        let context_messages = manager.context_store.get_context_messages(&session_id);
+        assert_eq!(context_messages.len(), 1);
+        assert_eq!(
+            context_messages[0].metadata.semantic_kind,
+            Some(MessageSemanticKind::ActualUserInput)
+        );
+
+        let sanitized_snapshot = persistence_manager
+            .load_turn_context_snapshot(workspace.path(), &session_id, 1)
+            .await
+            .expect("snapshot load should succeed")
+            .expect("snapshot should still exist");
+        assert_eq!(sanitized_snapshot.len(), 1);
+        assert_eq!(
+            sanitized_snapshot[0].metadata.semantic_kind,
+            Some(MessageSemanticKind::ActualUserInput)
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_sanitizes_pre_cutoff_snapshot_and_truncates_cutoff() {
+        use crate::agentic::core::{InternalReminderKind, Message, MessageSemanticKind};
+
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Rollback sanitize".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+
+        for index in 0..=2 {
+            let turn = DialogTurnData::new(
+                format!("turn-{index}"),
+                index,
+                session.session_id.clone(),
+                UserMessageData {
+                    id: format!("turn-{index}-user"),
+                    content: format!("prompt {index}"),
+                    timestamp: index as u64,
+                    metadata: None,
+                },
+            );
+            persistence_manager
+                .save_dialog_turn(workspace.path(), &turn)
+                .await
+                .expect("turn should save");
+        }
+
+        {
+            let mut active = manager
+                .sessions
+                .get_mut(&session.session_id)
+                .expect("session should be active");
+            active.dialog_turn_ids = vec![
+                "turn-0".to_string(),
+                "turn-1".to_string(),
+                "turn-2".to_string(),
+            ];
+        }
+
+        manager
+            .merge_session_custom_metadata(
+                &session.session_id,
+                json!({
+                    super::LISTING_BASELINE_REBUILD_TURN_INDEX_METADATA_KEY: 2,
+                }),
+            )
+            .await
+            .expect("cutoff metadata should save");
+
+        persistence_manager
+            .save_turn_context_snapshot(
+                workspace.path(),
+                &session.session_id,
+                0,
+                &[
+                    Message::internal_reminder(
+                        InternalReminderKind::AgentListingDiff,
+                        "# Agent Listing Update\n\nChanged",
+                    )
+                    .with_turn_id("turn-0".to_string()),
+                    Message::user("prompt 0".to_string())
+                        .with_turn_id("turn-0".to_string())
+                        .with_semantic_kind(MessageSemanticKind::ActualUserInput),
+                ],
+            )
+            .await
+            .expect("snapshot 0 should save");
+        persistence_manager
+            .save_turn_context_snapshot(
+                workspace.path(),
+                &session.session_id,
+                1,
+                &[
+                    Message::user("prompt 0".to_string()),
+                    Message::user("prompt 1".to_string()),
+                ],
+            )
+            .await
+            .expect("snapshot 1 should save");
+
+        manager
+            .rollback_context_to_turn_start(workspace.path(), &session.session_id, 1)
+            .await
+            .expect("rollback should succeed");
+
+        let context_messages = manager
+            .context_store
+            .get_context_messages(&session.session_id);
+        assert_eq!(context_messages.len(), 1);
+        assert_eq!(
+            context_messages[0].metadata.semantic_kind,
+            Some(MessageSemanticKind::ActualUserInput)
+        );
+
+        let sanitized_snapshot = persistence_manager
+            .load_turn_context_snapshot(workspace.path(), &session.session_id, 0)
+            .await
+            .expect("snapshot 0 load should succeed")
+            .expect("snapshot 0 should still exist");
+        assert_eq!(sanitized_snapshot.len(), 1);
+        assert_eq!(
+            sanitized_snapshot[0].metadata.semantic_kind,
+            Some(MessageSemanticKind::ActualUserInput)
+        );
+
+        let metadata = persistence_manager
+            .load_session_metadata(workspace.path(), &session.session_id)
+            .await
+            .expect("metadata load should succeed")
+            .expect("metadata should exist");
+        assert_eq!(
+            SessionManager::listing_baseline_rebuild_turn_index_from_metadata(Some(&metadata)),
+            Some(1)
+        );
     }
 
     #[tokio::test]

--- a/src/crates/core/src/agentic/session/turn_skill_agent_snapshot_store.rs
+++ b/src/crates/core/src/agentic/session/turn_skill_agent_snapshot_store.rs
@@ -1,0 +1,120 @@
+use crate::agentic::skill_agent_snapshot::TurnSkillAgentSnapshot;
+use dashmap::DashMap;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+#[derive(Default)]
+pub struct TurnSkillAgentSnapshotStore {
+    session_snapshots: Arc<DashMap<String, BTreeMap<usize, TurnSkillAgentSnapshot>>>,
+}
+
+impl TurnSkillAgentSnapshotStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn create_session(&self, session_id: &str) {
+        self.session_snapshots
+            .entry(session_id.to_string())
+            .or_default();
+    }
+
+    pub fn get_snapshot(
+        &self,
+        session_id: &str,
+        turn_index: usize,
+    ) -> Option<TurnSkillAgentSnapshot> {
+        self.session_snapshots
+            .get(session_id)
+            .and_then(|snapshots| snapshots.get(&turn_index).cloned())
+    }
+
+    pub fn set_snapshot(
+        &self,
+        session_id: &str,
+        turn_index: usize,
+        snapshot: TurnSkillAgentSnapshot,
+    ) {
+        if let Some(mut snapshots) = self.session_snapshots.get_mut(session_id) {
+            snapshots.insert(turn_index, snapshot);
+        } else {
+            let mut snapshots = BTreeMap::new();
+            snapshots.insert(turn_index, snapshot);
+            self.session_snapshots
+                .insert(session_id.to_string(), snapshots);
+        }
+    }
+
+    pub fn latest_snapshot_at_or_before(
+        &self,
+        session_id: &str,
+        turn_index: usize,
+    ) -> Option<(usize, TurnSkillAgentSnapshot)> {
+        self.session_snapshots
+            .get(session_id)
+            .and_then(|snapshots| {
+                snapshots
+                    .range(..=turn_index)
+                    .next_back()
+                    .map(|(index, snapshot)| (*index, snapshot.clone()))
+            })
+    }
+
+    pub fn delete_session(&self, session_id: &str) {
+        self.session_snapshots.remove(session_id);
+    }
+
+    pub fn remove_from(&self, session_id: &str, turn_index: usize) {
+        if let Some(mut snapshots) = self.session_snapshots.get_mut(session_id) {
+            snapshots.retain(|index, _| *index < turn_index);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TurnSkillAgentSnapshotStore;
+    use crate::agentic::skill_agent_snapshot::{SkillSnapshotEntry, TurnSkillAgentSnapshot};
+
+    #[test]
+    fn latest_snapshot_at_or_before_returns_nearest_sparse_snapshot() {
+        let store = TurnSkillAgentSnapshotStore::new();
+        store.create_session("session");
+        store.set_snapshot(
+            "session",
+            0,
+            TurnSkillAgentSnapshot {
+                skills: vec![SkillSnapshotEntry {
+                    name: "skill-a".to_string(),
+                    description: "desc-a".to_string(),
+                    location: "/a".to_string(),
+                }],
+                ..Default::default()
+            },
+        );
+        store.set_snapshot(
+            "session",
+            3,
+            TurnSkillAgentSnapshot {
+                skills: vec![SkillSnapshotEntry {
+                    name: "skill-b".to_string(),
+                    description: "desc-b".to_string(),
+                    location: "/b".to_string(),
+                }],
+                ..Default::default()
+            },
+        );
+
+        let nearest = store
+            .latest_snapshot_at_or_before("session", 2)
+            .expect("nearest snapshot should exist");
+        let latest = store
+            .latest_snapshot_at_or_before("session", 4)
+            .expect("latest snapshot should exist");
+
+        assert_eq!(nearest.0, 0);
+        assert_eq!(nearest.1.skills[0].name, "skill-a");
+        assert_eq!(latest.0, 3);
+        assert_eq!(latest.1.skills[0].name, "skill-b");
+    }
+}

--- a/src/crates/core/src/agentic/side_question.rs
+++ b/src/crates/core/src/agentic/side_question.rs
@@ -1,6 +1,6 @@
 //! Shared `/btw` helpers and runtime-only request tracking.
 
-use crate::agentic::core::PromptEnvelope;
+use crate::agentic::core::{InternalReminderKind, Message};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -101,9 +101,12 @@ CRITICAL CONSTRAINTS:
 Simply answer the question with the information you have, and use tools only when needed."#
 }
 
-pub fn build_btw_user_input(question: &str) -> String {
-    let mut envelope = PromptEnvelope::new();
-    envelope.push_system_reminder(btw_system_reminder());
-    envelope.push_user_query(question.trim());
-    envelope.render()
+pub fn build_btw_user_input(question: &str) -> (String, Vec<Message>) {
+    (
+        question.trim().to_string(),
+        vec![Message::internal_reminder(
+            InternalReminderKind::SideQuestion,
+            btw_system_reminder(),
+        )],
+    )
 }

--- a/src/crates/core/src/agentic/skill_agent_snapshot.rs
+++ b/src/crates/core/src/agentic/skill_agent_snapshot.rs
@@ -1,0 +1,565 @@
+use crate::agentic::agents::{
+    get_agent_registry, PromptBuilder, SubagentListScope, SubagentQueryContext,
+    ToolListingSections, UserContextPolicy,
+};
+use crate::agentic::tools::implementations::get_tool_spec_tool::GetToolSpecTool;
+use crate::agentic::tools::implementations::skills::{get_skill_registry, SkillInfo};
+use crate::agentic::tools::manifest_resolver::{resolve_tool_manifest, ResolvedToolManifest};
+use crate::agentic::tools::tool_context_runtime;
+use crate::agentic::workspace::WorkspaceServices;
+use crate::agentic::WorkspaceBinding;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillSnapshotEntry {
+    pub name: String,
+    pub description: String,
+    pub location: String,
+}
+
+impl SkillSnapshotEntry {
+    fn from_skill_info(skill: SkillInfo) -> Self {
+        Self {
+            name: skill.name,
+            description: skill.description,
+            location: skill.path,
+        }
+    }
+
+    fn to_xml_desc(&self) -> String {
+        format!(
+            r#"<skill>
+<name>
+{}
+</name>
+<description>
+{}
+</description>
+<location>
+{}
+</location>
+</skill>"#,
+            self.name, self.description, self.location
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentSnapshotEntry {
+    pub id: String,
+    pub description: String,
+    pub default_tools: Vec<String>,
+}
+
+impl AgentSnapshotEntry {
+    fn to_xml_desc(&self) -> String {
+        format!(
+            "<agent type=\"{}\">\n<description>\n{}\n</description>\n<tools>{}</tools>\n</agent>",
+            self.id,
+            self.description,
+            self.default_tools.join(", ")
+        )
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnSkillAgentSnapshot {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<SkillSnapshotEntry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub subagents: Vec<AgentSnapshotEntry>,
+}
+
+impl TurnSkillAgentSnapshot {
+    pub fn is_empty(&self) -> bool {
+        self.skills.is_empty() && self.subagents.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SkillAgentDiff {
+    pub added_skills: Vec<SkillSnapshotEntry>,
+    pub changed_skills: Vec<SkillSnapshotEntry>,
+    pub removed_skills: Vec<String>,
+    pub added_subagents: Vec<AgentSnapshotEntry>,
+    pub changed_subagents: Vec<AgentSnapshotEntry>,
+    pub removed_subagents: Vec<String>,
+}
+
+impl SkillAgentDiff {
+    pub fn is_empty(&self) -> bool {
+        self.added_skills.is_empty()
+            && self.changed_skills.is_empty()
+            && self.removed_skills.is_empty()
+            && self.added_subagents.is_empty()
+            && self.changed_subagents.is_empty()
+            && self.removed_subagents.is_empty()
+    }
+
+    pub fn render_skill_listing_update(&self) -> Option<String> {
+        if self.added_skills.is_empty()
+            && self.changed_skills.is_empty()
+            && self.removed_skills.is_empty()
+        {
+            return None;
+        }
+
+        let mut sections = Vec::new();
+        if !self.added_skills.is_empty() {
+            sections.push(render_titled_skill_entries(
+                "Added Skills",
+                &self.added_skills,
+            ));
+        }
+        if !self.changed_skills.is_empty() {
+            sections.push(render_titled_skill_entries(
+                "Changed Skills",
+                &self.changed_skills,
+            ));
+        }
+        if !self.removed_skills.is_empty() {
+            sections.push(render_removed_name_entries(
+                "Removed Skills",
+                &self.removed_skills,
+            ));
+        }
+
+        Some(format!(
+            "# Skill Listing Update\n\n{}",
+            sections.join("\n\n")
+        ))
+    }
+
+    pub fn render_agent_listing_update(&self) -> Option<String> {
+        if self.added_subagents.is_empty()
+            && self.changed_subagents.is_empty()
+            && self.removed_subagents.is_empty()
+        {
+            return None;
+        }
+
+        let mut sections = Vec::new();
+        if !self.added_subagents.is_empty() {
+            sections.push(render_titled_subagent_entries(
+                "Added Agents",
+                &self.added_subagents,
+            ));
+        }
+        if !self.changed_subagents.is_empty() {
+            sections.push(render_titled_subagent_entries(
+                "Changed Agents",
+                &self.changed_subagents,
+            ));
+        }
+        if !self.removed_subagents.is_empty() {
+            sections.push(render_removed_name_entries(
+                "Removed Agents",
+                &self.removed_subagents,
+            ));
+        }
+
+        Some(format!(
+            "# Agent Listing Update\n\n{}",
+            sections.join("\n\n")
+        ))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillAgentSnapshotResolution {
+    pub snapshot: TurnSkillAgentSnapshot,
+    pub tool_listing_sections: ToolListingSections,
+}
+
+pub async fn resolve_skill_agent_snapshot(
+    agent_type: &str,
+    workspace: Option<&WorkspaceBinding>,
+    workspace_services: Option<&WorkspaceServices>,
+    enable_tools: bool,
+    context_vars: &std::collections::HashMap<String, String>,
+) -> SkillAgentSnapshotResolution {
+    if !enable_tools {
+        return SkillAgentSnapshotResolution {
+            snapshot: TurnSkillAgentSnapshot::default(),
+            tool_listing_sections: ToolListingSections::default(),
+        };
+    }
+
+    let agent_registry = get_agent_registry();
+    if let Some(workspace) = workspace {
+        if !workspace.is_remote() {
+            agent_registry
+                .load_custom_subagents(workspace.root_path())
+                .await;
+        }
+    }
+
+    let tool_policy = agent_registry
+        .get_agent_tool_policy(agent_type, workspace.map(|binding| binding.root_path()))
+        .await;
+
+    let tool_description_context = tool_context_runtime::build_tool_description_context(
+        agent_type,
+        workspace,
+        workspace_services,
+        true,
+        context_vars,
+    );
+    let manifest = resolve_tool_manifest(
+        &tool_policy.allowed_tools,
+        &tool_policy.exposure_overrides,
+        &tool_description_context,
+    )
+    .await;
+
+    let snapshot =
+        build_skill_agent_snapshot(workspace, workspace_services, agent_type, &manifest).await;
+    let tool_listing_sections = build_tool_listing_sections(&manifest, &snapshot);
+
+    SkillAgentSnapshotResolution {
+        snapshot,
+        tool_listing_sections,
+    }
+}
+
+async fn build_skill_agent_snapshot(
+    workspace: Option<&WorkspaceBinding>,
+    workspace_services: Option<&WorkspaceServices>,
+    agent_type: &str,
+    manifest: &ResolvedToolManifest,
+) -> TurnSkillAgentSnapshot {
+    let has_tool = |tool_name: &str| {
+        manifest
+            .tool_definitions
+            .iter()
+            .any(|definition| definition.name == tool_name)
+    };
+
+    let mut snapshot = TurnSkillAgentSnapshot::default();
+
+    if has_tool("Skill") {
+        snapshot.skills = load_skill_entries(workspace, workspace_services, Some(agent_type)).await;
+    }
+
+    if has_tool("Task") {
+        snapshot.subagents = load_subagent_entries(workspace, Some(agent_type)).await;
+    }
+
+    snapshot
+}
+
+fn build_tool_listing_sections(
+    manifest: &ResolvedToolManifest,
+    snapshot: &TurnSkillAgentSnapshot,
+) -> ToolListingSections {
+    let has_tool = |tool_name: &str| {
+        manifest
+            .tool_definitions
+            .iter()
+            .any(|definition| definition.name == tool_name)
+    };
+
+    ToolListingSections {
+        skill_listing: has_tool("Skill")
+            .then(|| render_full_skill_listing_body(&snapshot.skills))
+            .filter(|body| !body.is_empty()),
+        agent_listing: has_tool("Task")
+            .then(|| render_full_agent_listing_body(&snapshot.subagents))
+            .filter(|body| !body.is_empty()),
+        collapsed_tool_listing: if has_tool("GetToolSpec") {
+            GetToolSpecTool::build_collapsed_tools_context_section(
+                &manifest.collapsed_tool_summaries,
+            )
+        } else {
+            None
+        },
+    }
+}
+
+async fn load_skill_entries(
+    workspace: Option<&WorkspaceBinding>,
+    workspace_services: Option<&WorkspaceServices>,
+    agent_type: Option<&str>,
+) -> Vec<SkillSnapshotEntry> {
+    let registry = get_skill_registry();
+    let skills = match workspace {
+        Some(workspace) if workspace.is_remote() => {
+            if let Some(services) = workspace_services {
+                registry
+                    .get_resolved_skills_for_remote_workspace(
+                        services.fs.as_ref(),
+                        &workspace.root_path_string(),
+                        agent_type,
+                    )
+                    .await
+            } else {
+                Vec::new()
+            }
+        }
+        Some(workspace) => {
+            registry
+                .get_resolved_skills_for_workspace(Some(workspace.root_path()), agent_type)
+                .await
+        }
+        None => {
+            registry
+                .get_resolved_skills_for_workspace(None, agent_type)
+                .await
+        }
+    };
+
+    skills
+        .into_iter()
+        .map(SkillSnapshotEntry::from_skill_info)
+        .collect()
+}
+
+async fn load_subagent_entries(
+    workspace: Option<&WorkspaceBinding>,
+    agent_type: Option<&str>,
+) -> Vec<AgentSnapshotEntry> {
+    let registry = get_agent_registry();
+    let workspace_root = workspace
+        .filter(|workspace| !workspace.is_remote())
+        .map(|workspace| workspace.root_path());
+    let agents = registry
+        .get_subagents_for_query(&SubagentQueryContext {
+            parent_agent_type: agent_type,
+            workspace_root,
+            list_scope: SubagentListScope::TaskVisible,
+            include_disabled: false,
+        })
+        .await;
+
+    agents
+        .into_iter()
+        .map(|agent| AgentSnapshotEntry {
+            id: agent.id,
+            description: agent.description,
+            default_tools: agent.default_tools,
+        })
+        .collect()
+}
+
+pub fn diff_skill_agent_snapshot(
+    previous: &TurnSkillAgentSnapshot,
+    current: &TurnSkillAgentSnapshot,
+) -> SkillAgentDiff {
+    let previous_skills = previous
+        .skills
+        .iter()
+        .cloned()
+        .map(|entry| (entry.name.clone(), entry))
+        .collect::<BTreeMap<_, _>>();
+    let current_skills = current
+        .skills
+        .iter()
+        .cloned()
+        .map(|entry| (entry.name.clone(), entry))
+        .collect::<BTreeMap<_, _>>();
+    let previous_subagents = previous
+        .subagents
+        .iter()
+        .cloned()
+        .map(|entry| (entry.id.clone(), entry))
+        .collect::<BTreeMap<_, _>>();
+    let current_subagents = current
+        .subagents
+        .iter()
+        .cloned()
+        .map(|entry| (entry.id.clone(), entry))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut diff = SkillAgentDiff::default();
+
+    for (name, entry) in &current_skills {
+        match previous_skills.get(name) {
+            None => diff.added_skills.push(entry.clone()),
+            Some(previous) if previous != entry => diff.changed_skills.push(entry.clone()),
+            Some(_) => {}
+        }
+    }
+    for name in previous_skills.keys() {
+        if !current_skills.contains_key(name) {
+            diff.removed_skills.push(name.clone());
+        }
+    }
+
+    for (id, entry) in &current_subagents {
+        match previous_subagents.get(id) {
+            None => diff.added_subagents.push(entry.clone()),
+            Some(previous) if previous != entry => diff.changed_subagents.push(entry.clone()),
+            Some(_) => {}
+        }
+    }
+    for id in previous_subagents.keys() {
+        if !current_subagents.contains_key(id) {
+            diff.removed_subagents.push(id.clone());
+        }
+    }
+
+    diff
+}
+
+pub async fn build_embedded_user_context_reminder(
+    workspace: Option<&WorkspaceBinding>,
+    workspace_id: Option<&str>,
+    session_id: &str,
+    user_context_policy: &UserContextPolicy,
+) -> Option<String> {
+    let workspace = workspace?;
+    let context = crate::agentic::agents::build_prompt_context_for_workspace(
+        workspace,
+        workspace_id,
+        session_id,
+        None,
+        None,
+        ToolListingSections::default(),
+    )
+    .await?;
+    PromptBuilder::new(context)
+        .build_user_context_reminder(user_context_policy)
+        .await
+}
+
+pub fn render_full_skill_listing_body(skills: &[SkillSnapshotEntry]) -> String {
+    if skills.is_empty() {
+        return String::new();
+    }
+    format!(
+        "<available_skills>\n{}\n</available_skills>",
+        skills
+            .iter()
+            .map(SkillSnapshotEntry::to_xml_desc)
+            .collect::<Vec<_>>()
+            .join("\n")
+    )
+}
+
+pub fn render_full_agent_listing_body(subagents: &[AgentSnapshotEntry]) -> String {
+    if subagents.is_empty() {
+        return String::new();
+    }
+    format!(
+        "<available_agents>\n{}\n</available_agents>",
+        subagents
+            .iter()
+            .map(AgentSnapshotEntry::to_xml_desc)
+            .collect::<Vec<_>>()
+            .join("\n")
+    )
+}
+
+pub fn build_skill_agent_tool_listing_sections_from_snapshot(
+    snapshot: &TurnSkillAgentSnapshot,
+) -> ToolListingSections {
+    ToolListingSections {
+        skill_listing: (!snapshot.skills.is_empty())
+            .then(|| render_full_skill_listing_body(&snapshot.skills))
+            .filter(|body| !body.is_empty()),
+        agent_listing: (!snapshot.subagents.is_empty())
+            .then(|| render_full_agent_listing_body(&snapshot.subagents))
+            .filter(|body| !body.is_empty()),
+        collapsed_tool_listing: None,
+    }
+}
+
+fn render_titled_skill_entries(title: &str, entries: &[SkillSnapshotEntry]) -> String {
+    format!(
+        "## {}\n\n{}",
+        title,
+        entries
+            .iter()
+            .map(SkillSnapshotEntry::to_xml_desc)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+}
+
+fn render_titled_subagent_entries(title: &str, entries: &[AgentSnapshotEntry]) -> String {
+    format!(
+        "## {}\n\n{}",
+        title,
+        entries
+            .iter()
+            .map(AgentSnapshotEntry::to_xml_desc)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+}
+
+fn render_removed_name_entries(title: &str, names: &[String]) -> String {
+    let entries = names
+        .iter()
+        .map(|name| format!("- {}", name))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("## {}\n\n{}", title, entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        diff_skill_agent_snapshot, AgentSnapshotEntry, SkillSnapshotEntry, TurnSkillAgentSnapshot,
+    };
+
+    #[test]
+    fn skill_agent_diff_renders_changed_added_and_removed_entries() {
+        let previous = TurnSkillAgentSnapshot {
+            skills: vec![
+                SkillSnapshotEntry {
+                    name: "skill-a".to_string(),
+                    description: "desc-a".to_string(),
+                    location: "/a".to_string(),
+                },
+                SkillSnapshotEntry {
+                    name: "skill-b".to_string(),
+                    description: "desc-b".to_string(),
+                    location: "/b".to_string(),
+                },
+            ],
+            subagents: vec![AgentSnapshotEntry {
+                id: "agent-a".to_string(),
+                description: "desc-a".to_string(),
+                default_tools: vec!["Read".to_string()],
+            }],
+        };
+        let current = TurnSkillAgentSnapshot {
+            skills: vec![
+                SkillSnapshotEntry {
+                    name: "skill-a".to_string(),
+                    description: "desc-a2".to_string(),
+                    location: "/a".to_string(),
+                },
+                SkillSnapshotEntry {
+                    name: "skill-c".to_string(),
+                    description: "desc-c".to_string(),
+                    location: "/c".to_string(),
+                },
+            ],
+            subagents: vec![AgentSnapshotEntry {
+                id: "agent-a".to_string(),
+                description: "desc-a".to_string(),
+                default_tools: vec!["Read".to_string(), "Grep".to_string()],
+            }],
+        };
+
+        let diff = diff_skill_agent_snapshot(&previous, &current);
+        let skill_update = diff
+            .render_skill_listing_update()
+            .expect("skill update should render");
+        let agent_update = diff
+            .render_agent_listing_update()
+            .expect("agent update should render");
+
+        assert!(skill_update.contains("## Changed Skills"));
+        assert!(skill_update.contains("## Added Skills"));
+        assert!(skill_update.contains("## Removed Skills"));
+        assert!(skill_update.contains("skill-a"));
+        assert!(skill_update.contains("skill-c"));
+        assert!(skill_update.contains("- skill-b"));
+        assert!(agent_update.contains("## Changed Agents"));
+        assert!(agent_update.contains("Grep"));
+    }
+}

--- a/src/crates/core/src/agentic/skill_agent_snapshot.rs
+++ b/src/crates/core/src/agentic/skill_agent_snapshot.rs
@@ -389,7 +389,9 @@ pub fn diff_skill_agent_snapshot(
     for (id, entry) in &current_subagents {
         match previous_subagents.get(id) {
             None => diff.added_subagents.push(entry.clone()),
-            Some(previous) if previous != entry => diff.changed_subagents.push(entry.clone()),
+            Some(previous) if !agent_snapshot_entries_match_for_diff(previous, entry) => {
+                diff.changed_subagents.push(entry.clone())
+            }
             Some(_) => {}
         }
     }
@@ -400,6 +402,21 @@ pub fn diff_skill_agent_snapshot(
     }
 
     diff
+}
+
+fn agent_snapshot_entries_match_for_diff(
+    previous: &AgentSnapshotEntry,
+    current: &AgentSnapshotEntry,
+) -> bool {
+    previous.id == current.id
+        && previous.description == current.description
+        && sorted_tool_names(&previous.default_tools) == sorted_tool_names(&current.default_tools)
+}
+
+fn sorted_tool_names(tool_names: &[String]) -> Vec<&str> {
+    let mut normalized = tool_names.iter().map(String::as_str).collect::<Vec<_>>();
+    normalized.sort_unstable();
+    normalized
 }
 
 pub async fn build_embedded_user_context_reminder(
@@ -561,5 +578,30 @@ mod tests {
         assert!(skill_update.contains("- skill-b"));
         assert!(agent_update.contains("## Changed Agents"));
         assert!(agent_update.contains("Grep"));
+    }
+
+    #[test]
+    fn skill_agent_diff_ignores_default_tool_reordering_for_agents() {
+        let previous = TurnSkillAgentSnapshot {
+            subagents: vec![AgentSnapshotEntry {
+                id: "agent-a".to_string(),
+                description: "desc-a".to_string(),
+                default_tools: vec!["Read".to_string(), "Grep".to_string()],
+            }],
+            ..Default::default()
+        };
+        let current = TurnSkillAgentSnapshot {
+            subagents: vec![AgentSnapshotEntry {
+                id: "agent-a".to_string(),
+                description: "desc-a".to_string(),
+                default_tools: vec!["Grep".to_string(), "Read".to_string()],
+            }],
+            ..Default::default()
+        };
+
+        let diff = diff_skill_agent_snapshot(&previous, &current);
+
+        assert!(diff.changed_subagents.is_empty());
+        assert!(diff.is_empty());
     }
 }

--- a/src/crates/core/src/agentic/tools/implementations/session_message_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/session_message_tool.rs
@@ -3,7 +3,7 @@ use crate::agentic::coordination::{
     get_global_coordinator, get_global_scheduler, AgentSessionReplyRoute, DialogSubmissionPolicy,
     DialogTriggerSource,
 };
-use crate::agentic::core::{PromptEnvelope, SessionConfig};
+use crate::agentic::core::{InternalReminderKind, Message, SessionConfig};
 use crate::agentic::tools::framework::{
     Tool, ToolExposure, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
@@ -158,14 +158,15 @@ impl SessionMessageTool {
         Ok(format!("session-{}", creator_session_id))
     }
 
-    fn format_forwarded_message(&self, message: &str) -> String {
-        let mut envelope = PromptEnvelope::new();
-        envelope.push_system_reminder(
-            "This request was sent by another agent, not human user. Do not use interactive tools for this request. In particular, do not call AskUserQuestion."
-                .to_string(),
-        );
-        envelope.push_user_query(message.to_string());
-        envelope.render()
+    fn format_forwarded_message(&self, message: &str) -> (String, Vec<Message>) {
+        (
+            message.to_string(),
+            vec![Message::internal_reminder(
+                InternalReminderKind::SessionMessageRequest,
+                "This request was sent by another agent, not human user. Do not use interactive tools for this request. In particular, do not call AskUserQuestion."
+                    .to_string(),
+            )],
+        )
     }
 }
 
@@ -537,10 +538,11 @@ Allowed agent types when creating a session:
                 )
             };
 
-        let forwarded_message = self.format_forwarded_message(&params.message);
+        let (forwarded_message, prepended_messages) =
+            self.format_forwarded_message(&params.message);
 
         scheduler
-            .submit(
+            .submit_with_prepended_messages(
                 target_session_id.clone(),
                 forwarded_message,
                 Some(params.message.clone()),
@@ -553,6 +555,7 @@ Allowed agent types when creating a session:
                     source_workspace_path: source_workspace,
                 }),
                 None,
+                prepended_messages,
                 None,
             )
             .await

--- a/src/crates/core/src/agentic/util/mod.rs
+++ b/src/crates/core/src/agentic/util/mod.rs
@@ -1,3 +1,1 @@
 pub mod remote_workspace_layout;
-
-pub use remote_workspace_layout::build_remote_workspace_layout_preview;

--- a/src/crates/core/src/service/cron/service.rs
+++ b/src/crates/core/src/service/cron/service.rs
@@ -11,7 +11,7 @@ use super::types::{
 use crate::agentic::coordination::{
     DialogQueuePriority, DialogScheduler, DialogSubmissionPolicy, DialogTriggerSource,
 };
-use crate::agentic::core::PromptEnvelope;
+use crate::agentic::core::{InternalReminderKind, Message};
 use crate::infrastructure::PathManager;
 use crate::util::errors::{BitFunError, BitFunResult};
 use chrono::{Local, SecondsFormat, TimeZone, Utc};
@@ -476,11 +476,14 @@ impl CronService {
 
                 let turn_id = format!("cronjob_{}_{}", job.id, pending_trigger_at_ms);
                 scheduled_at_ms = Some(pending_trigger_at_ms);
+                let (user_input, prepended_messages) =
+                    format_scheduled_job_user_input(&job.payload.text, current_ms);
                 enqueue_input = Some(EnqueueInput {
                     turn_id,
                     session_id: job.session_id.clone(),
                     workspace_path: job.workspace_path.clone(),
-                    user_input: format_scheduled_job_user_input(&job.payload.text, current_ms),
+                    user_input,
+                    prepended_messages,
                 });
                 should_attempt_enqueue = true;
             }
@@ -509,16 +512,17 @@ impl CronService {
 
         let submit_result = self
             .scheduler
-            .submit(
+            .submit_with_prepended_messages(
                 enqueue_input.session_id.clone(),
-                enqueue_input.user_input,
-                None,
+                enqueue_input.user_input.clone(),
+                Some(enqueue_input.user_input),
                 Some(enqueue_input.turn_id.clone()),
                 String::new(),
                 Some(enqueue_input.workspace_path),
                 scheduled_job_policy(),
                 None,
                 None,
+                enqueue_input.prepended_messages,
                 None,
             )
             .await;
@@ -718,20 +722,23 @@ fn next_wakeup_for_job(job: &CronJob) -> Option<i64> {
     }
 }
 
-fn format_scheduled_job_user_input(payload: &str, current_ms: i64) -> String {
+fn format_scheduled_job_user_input(payload: &str, current_ms: i64) -> (String, Vec<Message>) {
     let current_time = Local
         .timestamp_millis_opt(current_ms)
         .single()
         .map(|datetime| datetime.to_rfc3339_opts(SecondsFormat::Secs, false))
         .unwrap_or_else(|| current_ms.to_string());
 
-    let mut envelope = PromptEnvelope::new();
-    envelope.push_system_reminder(format!(
-        "This message was triggered by a scheduled job.\nCurrent time: {}",
-        current_time
-    ));
-    envelope.push_user_query(payload.to_string());
-    envelope.render()
+    (
+        payload.to_string(),
+        vec![Message::internal_reminder(
+            InternalReminderKind::ScheduledJob,
+            format!(
+                "This message was triggered by a scheduled job.\nCurrent time: {}",
+                current_time
+            ),
+        )],
+    )
 }
 
 fn scheduled_job_policy() -> DialogSubmissionPolicy {
@@ -751,6 +758,7 @@ struct EnqueueInput {
     session_id: String,
     workspace_path: String,
     user_input: String,
+    prepended_messages: Vec<Message>,
 }
 
 /// Permanent failure: coordinator cannot load session metadata (session deleted from disk).

--- a/src/crates/runtime-ports/src/lib.rs
+++ b/src/crates/runtime-ports/src/lib.rs
@@ -658,7 +658,8 @@ pub struct GoalActivationResult {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GoalContinuationPlan {
-    pub wrapped_message: String,
+    pub user_input: String,
+    pub prepended_reminders: Vec<String>,
     pub display_message: String,
     pub user_message_metadata: serde_json::Value,
 }


### PR DESCRIPTION
## Summary

This PR improves agentic prompt-cache stability when skills, subagents, reminders, and session flows change at runtime.

## What changed

- preserve first-turn prompt cache baselines by snapshotting turn-level skill and subagent listings
- inject incremental skill/agent listing updates into user input instead of rebuilding cached prompt prefixes
- switch reminders from envelope-style prompt wrapping to typed internal messages for more reliable persistence and filtering
- persist and recover reminder and skill/agent snapshot state across restore, rollback, branching, and compression flows
- make hidden `/btw` child sessions inherit the parent prompt cache on creation
- ignore agent snapshot diffs caused only by default-tool reordering
- remove prompt assumptions that user input is always wrapped in `<user_query>` tags
- add architecture documentation for session-level model request cache reuse and current cache-miss gaps

## Why

Previously, dynamic skill/subagent changes or reminder rebuilding could invalidate cached prompt prefixes or create noisy diff/update behavior. This PR makes runtime updates more incremental and keeps prompt-cache state consistent across branching, `/btw`, mode switching, restore/rollback, and compression paths.