### PR TITLE
refactor(agent-tools): move tool execution admission gate

### DIFF
--- a/docs/architecture/core-decomposition.md
+++ b/docs/architecture/core-decomposition.md
@@ -88,8 +88,8 @@ flowchart TB
 |---|---|---|
 | `bitfun-core` | 兼容 facade、agent runtime、tool runtime 组装、service 接线和完整产品能力集合 | 仍是事实上的 runtime owner，迁移必须先保护行为等价 |
 | `bitfun-runtime-ports` | 面向 runtime/service 边界的 DTO 和 trait | 只定义 contract，不拥有 runtime 实现 |
-| `bitfun-agent-tools` | provider-neutral tool DTO、manifest、path/result policy 和 catalog contract | 已适合承接更多 tool contract，但不应拥有具体 IO tool |
-| `tool-runtime` | 既有工具执行相关 crate | 目标是收敛 provider registry、permission gate 和 execution pipeline |
+| `bitfun-agent-tools` | provider-neutral tool DTO、manifest、path/result policy、catalog contract 和 deterministic execution admission gate | 已适合承接纯 tool runtime 策略，但不应拥有具体 IO tool |
+| `tool-runtime` | 既有工具执行相关 crate | 目标是继续收敛 provider registry、permission gate 和 execution pipeline |
 | `bitfun-services-core` | 基础 service helper、本地 filesystem facade、部分通用 service 逻辑 | 适合作为本地基础 service owner，但不能吸收产品 runtime 语义 |
 | `bitfun-services-integrations` | MCP、Git、remote-connect、remote-SSH 等 integration helper | 适合拥有外部协议和重依赖 adapter，不应反向感知产品 surface |
 | `bitfun-product-domains` | MiniApp、function-agent 等纯状态、策略、port 和部分决策逻辑 | 适合承接 pure domain，不应直接执行 filesystem/Git/AI concrete call |
@@ -257,7 +257,8 @@ scheduler lifecycle、session manager、prompt loop 和 subagent registry 仍未
 工具运行时（Tool Runtime）负责工具 manifest、catalog、permission gate、execution pipeline、tool hook 和结果归一化。
 它只消费 `ToolExecutionServices` 这类窄 service 视图，不直接创建 filesystem、Git、terminal、MCP 等具体实现。
 当前相关 crate 包括 `tool-runtime`、`bitfun-agent-tools`、`bitfun-tool-packs` 以及 `bitfun-core`
-中的 tool materialization 代码。
+中的 tool materialization 代码。deterministic execution admission gate 已由 `bitfun-agent-tools` 承接；
+`bitfun-core` 的 pipeline 仍负责状态更新、registry lookup、input validation、confirmation、实际执行和 hook。
 
 ### 7.7 运行时服务层（Runtime Services）
 

--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -69,16 +69,28 @@
 - Product command registry、capability pack、Harness 对 Tool Runtime / Runtime Services 的实际 orchestration
   仍是后续迁移项。
 
+### 1.5 Tool Runtime admission gate：执行准入 owner 迁移
+
+- `bitfun-agent-tools` 已承接 deterministic tool execution admission gate：tool-call loop history / block
+  message、allowed-list gate、runtime restriction gate 和 collapsed-tool unlock gate。
+- `bitfun-core` 的 tool pipeline 已删除对应常量、历史结构、循环检测算法和三段准入分支，只保留状态更新、日志、错误映射、
+  registry lookup、input validation、confirmation、实际执行和 hook。
+
+明确未完成：
+
+- `ToolUseContext` concrete service handles、product registry materialization、manifest / `GetToolSpecTool`
+  concrete adapter、snapshot wrapper、collapsed unlock persistence、具体 IO tools 仍未迁移。
+
 ## 2. 已建立保护
 
 - 新 owner crate 不得依赖回 `bitfun-core`。
 - `product-full` 是完整产品能力保护开关。
 - 构建脚本和 installer 相关脚本不作为 core 拆解的一部分修改。
 - boundary check 覆盖已外移 owner 的旧路径 facade-only / 禁止回流状态。
-- tool manifest、`GetToolSpec`、MiniApp storage layout adapter、product-domain pure helper、remote workspace search fallback、MCP config / catalog / dynamic manifest 等已有 focused baseline。
+- tool manifest、`GetToolSpec`、execution admission gate、MiniApp storage layout adapter、product-domain pure helper、remote workspace search fallback、MCP config / catalog / dynamic manifest 等已有 focused baseline。
 
 ## 3. 当前剩余结论
 
 - 低风险准备项已经完成，不再新增零散小 PR。
-- 后续只按高风险 owner 主题推进：Product-Domain Runtime、Tool Runtime、Feature / Build-Benefit Evaluation，以及经过单独保护的 Harness execution / Product Capability pack 迁移。
+- 后续只按高风险 owner 主题推进：Product-Domain Runtime、Tool Runtime 剩余主体、Feature / Build-Benefit Evaluation，以及经过单独保护的 Harness execution / Product Capability pack 迁移。
 - 缺陷修复、行为变更、冗余清理、三方库升级和构建脚本调整必须独立评估，不能伪装成 core decomposition 剩余里程碑。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -69,7 +69,7 @@
 | PR3 | Agent Runtime SDK Owner | 拆分 mode-scoped subagent visibility、agent registry facts、queue policy decision、scheduler submit/cancel facts 和 background delivery 边界；concrete scheduler 生命周期按保护程度逐步外移 | remote provider、tool IO、product-domain IO、默认 feature 调整 | subagent 可见性、queue/preempt/cancel、background reply、DeepResearch hook 等价 |
 | PR4 | Harness / Product Capability Boundary | 建立 Harness provider contract，让 Deep Review、DeepResearch、MiniApp 等 workflow 通过 provider 注册，不侵入 Agent Runtime SDK | concrete service IO、tool IO、surface 命令语义变更 | 至少两个 workflow 可通过 provider contract 表达，旧路径兼容 |
 | PR5 | Product-Domain Runtime Owner | MiniApp filesystem IO / worker / host / builtin seed 或 function-agent Git/AI 中完成一个完整 owner 主题，建立最小 port/provider 和 core adapter | tool runtime、service/agent runtime、surface 行为变更 | MiniApp/function-agent focused regression，PathManager/process/Git/AI 边界清晰 |
-| PR6 | Tool Runtime Owner | 在 `ToolUseContext` projection、manifest execution、`GetToolSpecTool` execution、snapshot wrapper、collapsed unlock state 或具体工具 IO 中完成一个收益明确的完整 owner 主题 | service/agent runtime、product-domain runtime、feature matrix、产品行为变更 | tool visibility、manifest、`GetToolSpec`、snapshot、Deep Review tool flow 等价 |
+| PR6 | Tool Runtime Owner | 已完成 deterministic execution admission gate：tool-call loop、allowed-list、runtime restriction、collapsed unlock 的准入策略迁移到 `bitfun-agent-tools`，core pipeline 删除旧算法和分支 | service/agent runtime、product-domain runtime、feature matrix、产品行为变更 | tool pipeline focused tests、`bitfun-agent-tools` contract tests、boundary check |
 | PR7 | Feature / Build-Benefit Evaluation | 评估 feature matrix、dependency profile、no-default 编译面和构建收益数据，确认是否具备收敛默认 feature 的条件 | runtime owner 迁移、default feature 副作用、构建脚本变更 | cargo metadata / cargo tree 证据，产品入口完整能力不变 |
 
 ### 4.1 PR1 具体实施计划
@@ -173,7 +173,9 @@ PR4 不迁移 concrete service IO、tool IO、surface command 语义、session m
 
 ### 5.4 Tool Runtime Owner
 
-- 不直接搬全部 concrete tools。先拆 portable facts projection、manifest/catalog snapshot、`GetToolSpec`、snapshot wrapper 或 collapsed unlock 中一个 owner。
+- 已完成 deterministic execution admission gate 迁移；core 仅保留状态更新、registry lookup、input validation、confirmation、实际执行和 hook。
+- 后续不直接搬全部 concrete tools。只在 manifest/catalog snapshot、`GetToolSpec` concrete adapter、snapshot wrapper、
+  collapsed unlock persistence 或具体工具 IO 中选择能减少旧路径的完整 owner。
 - 保留 tool name、schema、prompt stub、readonly/enabled/filtering、unlock state 生命周期。
 - 验证 builtin tool list、provider order、expanded/collapsed exposure、dynamic provider metadata、Deep Review 修改类工具 checkpoint hook。
 

--- a/scripts/check-core-boundaries.mjs
+++ b/scripts/check-core-boundaries.mjs
@@ -4395,8 +4395,8 @@ const requiredContentRules = [
       'core must continue carrying collapsed-tool unlock state while delegating provider-neutral execution gate policy to agent-tools',
     patterns: [
       {
-        regex: /\bfn validate_collapsed_tool_usage\b/,
-        message: 'missing collapsed-tool execution gate compatibility wrapper',
+        regex: /\bvalidate_tool_execution_admission\b/,
+        message: 'missing provider-neutral tool execution admission gate delegation',
       },
       {
         regex: /\bunlocked_collapsed_tools\b/,

--- a/src/crates/agent-tools/AGENTS.md
+++ b/src/crates/agent-tools/AGENTS.md
@@ -14,8 +14,9 @@ the product tool runtime.
   remote POSIX path pure contracts, provider-neutral path resolution /
   absolute-path checks, runtime artifact reference assembly, file guidance
   markers, file-read freshness comparison policy, oversized tool-result
-  preview/rendering policy, tool execution result/error/invalid-call presentation policy, allowed-list /
-  collapsed-tool execution gate policy, generic/static/dynamic provider contracts, pure
+  preview/rendering policy, tool execution result/error/invalid-call presentation policy, deterministic
+  tool execution admission policy including loop detection, allowed-list,
+  runtime-restriction and collapsed-tool gates, generic/static/dynamic provider contracts, pure
   manifest/exposure helpers, generic contextual prompt-manifest resolver
   contracts, generic catalog snapshot provider contracts, generic GetToolSpec
   catalog provider/detail/summary helpers, provider-backed GetToolSpec runtime
@@ -25,7 +26,7 @@ the product tool runtime.
   registration stay outside this crate until H1 explicitly moves an owner.
 - Do not move `ToolUseContext`, concrete tools, workspace services, cancellation
   tokens, session file-read state storage, tool-result filesystem writes,
-  snapshot decoration, collapsed unlock state, product registry
+  state update side effects, snapshot decoration, collapsed unlock state, product registry
   snapshot access, or concrete `GetToolSpecTool` execution here without H1
   approval and equivalence tests.
 - Provider-specific wire serialization belongs in AI adapters, not in these

--- a/src/crates/agent-tools/src/execution_gate.rs
+++ b/src/crates/agent-tools/src/execution_gate.rs
@@ -1,0 +1,139 @@
+use crate::{
+    validate_collapsed_tool_usage, validate_tool_allowed_by_list, CollapsedToolUsageError,
+    ToolExecutionAccessError, ToolRestrictionError, ToolRuntimeRestrictions,
+};
+use serde_json::Value;
+use std::collections::VecDeque;
+use std::fmt;
+
+/// Number of consecutive identical tool calls tolerated before blocking.
+pub const TOOL_CALL_LOOP_THRESHOLD: usize = 3;
+
+/// Bounded per-session history window for loop detection.
+pub const TOOL_CALL_HISTORY_WINDOW: usize = 10;
+
+#[derive(Debug, Clone)]
+struct RecentToolCall {
+    tool_name: String,
+    arguments: Value,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ToolCallLoopHistory {
+    entries: VecDeque<RecentToolCall>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCallLoopBlock {
+    pub tool_name: String,
+    pub threshold: usize,
+    pub attempt: usize,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolCallLoopDecision {
+    Allowed,
+    Blocked(ToolCallLoopBlock),
+}
+
+impl ToolCallLoopDecision {
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, Self::Allowed)
+    }
+
+    pub fn into_blocked(self) -> Option<ToolCallLoopBlock> {
+        match self {
+            Self::Allowed => None,
+            Self::Blocked(block) => Some(block),
+        }
+    }
+}
+
+impl ToolCallLoopHistory {
+    pub fn check_and_record(&mut self, tool_name: &str, arguments: &Value) -> ToolCallLoopDecision {
+        let identical_priors = self
+            .entries
+            .iter()
+            .rev()
+            .take(TOOL_CALL_LOOP_THRESHOLD)
+            .take_while(|past| past.tool_name == tool_name && &past.arguments == arguments)
+            .count();
+        let is_loop = identical_priors >= TOOL_CALL_LOOP_THRESHOLD;
+
+        self.entries.push_back(RecentToolCall {
+            tool_name: tool_name.to_string(),
+            arguments: arguments.clone(),
+        });
+        while self.entries.len() > TOOL_CALL_HISTORY_WINDOW {
+            self.entries.pop_front();
+        }
+
+        if is_loop {
+            ToolCallLoopDecision::Blocked(ToolCallLoopBlock {
+                tool_name: tool_name.to_string(),
+                threshold: TOOL_CALL_LOOP_THRESHOLD,
+                attempt: TOOL_CALL_LOOP_THRESHOLD + 1,
+                message: build_tool_call_loop_block_message(tool_name),
+            })
+        } else {
+            ToolCallLoopDecision::Allowed
+        }
+    }
+}
+
+pub fn build_tool_call_loop_block_message(tool_name: &str) -> String {
+    format!(
+        "Tool-call loop blocked: '{}' was already called {} times in a row in this session with identical arguments. Refusing to execute this {}th identical call. Issue a different tool call, or stop tool-calling and respond to the user. If you wrote a file recently and want to continue or modify it, do not call Write again for the same path; use the latest Read result for that file, or call Read once if no current Read result is available, then use Edit with `old_string` taken from the current file content.",
+        tool_name,
+        TOOL_CALL_LOOP_THRESHOLD,
+        TOOL_CALL_LOOP_THRESHOLD + 1
+    )
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ToolExecutionAdmissionRequest<'a> {
+    pub tool_name: &'a str,
+    pub allowed_tools: &'a [String],
+    pub runtime_tool_restrictions: &'a ToolRuntimeRestrictions,
+    pub collapsed_tools: &'a [String],
+    pub loaded_collapsed_tools: &'a [String],
+    pub get_tool_spec_tool_name: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolExecutionAdmissionRejection {
+    AllowedList(ToolExecutionAccessError),
+    RuntimeRestriction(ToolRestrictionError),
+    Collapsed(CollapsedToolUsageError),
+}
+
+impl fmt::Display for ToolExecutionAdmissionRejection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AllowedList(error) => write!(formatter, "{error}"),
+            Self::RuntimeRestriction(error) => write!(formatter, "{error}"),
+            Self::Collapsed(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for ToolExecutionAdmissionRejection {}
+
+pub fn validate_tool_execution_admission(
+    request: ToolExecutionAdmissionRequest<'_>,
+) -> Result<(), ToolExecutionAdmissionRejection> {
+    validate_tool_allowed_by_list(request.tool_name, request.allowed_tools)
+        .map_err(ToolExecutionAdmissionRejection::AllowedList)?;
+    request
+        .runtime_tool_restrictions
+        .ensure_tool_allowed(request.tool_name)
+        .map_err(ToolExecutionAdmissionRejection::RuntimeRestriction)?;
+    validate_collapsed_tool_usage(
+        request.tool_name,
+        request.collapsed_tools,
+        request.loaded_collapsed_tools,
+        request.get_tool_spec_tool_name,
+    )
+    .map_err(ToolExecutionAdmissionRejection::Collapsed)
+}

--- a/src/crates/agent-tools/src/lib.rs
+++ b/src/crates/agent-tools/src/lib.rs
@@ -3,6 +3,7 @@
 //! Pure tool DTOs and helpers live here before the concrete tool framework and
 //! tool packs are moved out of the core facade.
 
+pub mod execution_gate;
 pub mod file_guidance;
 pub mod file_read_freshness;
 pub mod framework;
@@ -13,6 +14,11 @@ pub mod tool_result_storage;
 pub use bitfun_core_types::ToolImageAttachment;
 pub use bitfun_runtime_ports::{
     DynamicToolDescriptor, DynamicToolProvider, PortError, PortErrorKind, PortResult, ToolDecorator,
+};
+pub use execution_gate::{
+    build_tool_call_loop_block_message, validate_tool_execution_admission, ToolCallLoopBlock,
+    ToolCallLoopDecision, ToolCallLoopHistory, ToolExecutionAdmissionRejection,
+    ToolExecutionAdmissionRequest, TOOL_CALL_HISTORY_WINDOW, TOOL_CALL_LOOP_THRESHOLD,
 };
 pub use file_guidance::{
     file_tool_guidance_message, is_file_tool_guidance_message, FILE_TOOL_GUIDANCE_PREFIX,

--- a/src/crates/agent-tools/tests/tool_contracts.rs
+++ b/src/crates/agent-tools/tests/tool_contracts.rs
@@ -19,12 +19,14 @@ use bitfun_agent_tools::{
     resolve_workspace_tool_path, sort_tool_manifest_definitions,
     summarize_get_tool_spec_collapsed_tools, tool_path_is_effectively_absolute,
     validate_collapsed_tool_usage, validate_get_tool_spec_input, validate_tool_allowed_by_list,
-    DynamicMcpToolInfo, DynamicToolInfo, GetToolSpecCollapsedToolSummary,
-    GetToolSpecExecutionError, GetToolSpecExecutionPlan, GetToolSpecLoadObservation,
-    GetToolSpecRuntime, InputValidator, PromptVisibleToolManifestItem, ToolContextFacts,
-    ToolExposure, ToolImageAttachment, ToolManifestDefinition, ToolManifestPolicyTool,
-    ToolPathBackend, ToolPathOperation, ToolPathResolution, ToolRenderOptions, ToolResult,
-    ToolRuntimeRestrictions, ToolWorkspaceKind, ValidationResult, GET_TOOL_SPEC_TOOL_NAME,
+    validate_tool_execution_admission, DynamicMcpToolInfo, DynamicToolInfo,
+    GetToolSpecCollapsedToolSummary, GetToolSpecExecutionError, GetToolSpecExecutionPlan,
+    GetToolSpecLoadObservation, GetToolSpecRuntime, InputValidator, PromptVisibleToolManifestItem,
+    ToolCallLoopHistory, ToolContextFacts, ToolExecutionAdmissionRejection,
+    ToolExecutionAdmissionRequest, ToolExposure, ToolImageAttachment, ToolManifestDefinition,
+    ToolManifestPolicyTool, ToolPathBackend, ToolPathOperation, ToolPathResolution,
+    ToolRenderOptions, ToolResult, ToolRuntimeRestrictions, ToolWorkspaceKind, ValidationResult,
+    GET_TOOL_SPEC_TOOL_NAME,
 };
 use bitfun_agent_tools::{
     build_invalid_tool_call_error_message, build_tool_execution_error_presentation,
@@ -856,6 +858,100 @@ fn tool_allowed_list_gate_preserves_pipeline_rejection_contract() {
         err.to_string(),
         "Tool 'Bash' is not in the allowed list: [\"Read\", \"GetToolSpec\"]"
     );
+}
+
+#[test]
+fn tool_call_loop_history_blocks_fourth_identical_call_and_keeps_recovery_message() {
+    let mut history = ToolCallLoopHistory::default();
+    let args = json!({ "file_path": "src/lib.rs" });
+
+    for _ in 0..3 {
+        assert!(history.check_and_record("Write", &args).is_allowed());
+    }
+
+    let blocked = history
+        .check_and_record("Write", &args)
+        .into_blocked()
+        .expect("fourth identical call should be blocked");
+
+    assert_eq!(blocked.threshold, 3);
+    assert_eq!(blocked.attempt, 4);
+    assert!(blocked.message.contains("Tool-call loop blocked: 'Write'"));
+    assert!(blocked.message.contains("use the latest Read result"));
+
+    assert!(
+        history
+            .check_and_record("Edit", &json!({ "file_path": "src/lib.rs" }))
+            .is_allowed(),
+        "different tool call should reset the consecutive loop window"
+    );
+}
+
+#[test]
+fn tool_execution_admission_gate_preserves_pipeline_rejection_order() {
+    let mut restrictions = ToolRuntimeRestrictions::default();
+    restrictions
+        .denied_tool_names
+        .insert("WebFetch".to_string());
+
+    let request = ToolExecutionAdmissionRequest {
+        tool_name: "WebFetch",
+        allowed_tools: &["Read".to_string()],
+        runtime_tool_restrictions: &restrictions,
+        collapsed_tools: &["WebFetch".to_string()],
+        loaded_collapsed_tools: &[],
+        get_tool_spec_tool_name: GET_TOOL_SPEC_TOOL_NAME,
+    };
+
+    let err = validate_tool_execution_admission(request)
+        .expect_err("allowed-list should be evaluated before runtime restrictions");
+
+    assert!(matches!(
+        err,
+        ToolExecutionAdmissionRejection::AllowedList(_)
+    ));
+    assert_eq!(
+        err.to_string(),
+        "Tool 'WebFetch' is not in the allowed list: [\"Read\"]"
+    );
+
+    let request = ToolExecutionAdmissionRequest {
+        tool_name: "WebFetch",
+        allowed_tools: &["WebFetch".to_string()],
+        runtime_tool_restrictions: &restrictions,
+        collapsed_tools: &["WebFetch".to_string()],
+        loaded_collapsed_tools: &[],
+        get_tool_spec_tool_name: GET_TOOL_SPEC_TOOL_NAME,
+    };
+
+    let err = validate_tool_execution_admission(request)
+        .expect_err("runtime restrictions should run before collapsed unlock");
+
+    assert!(matches!(
+        err,
+        ToolExecutionAdmissionRejection::RuntimeRestriction(_)
+    ));
+    assert_eq!(
+        err.to_string(),
+        "Tool 'WebFetch' is denied by runtime restrictions"
+    );
+
+    let request = ToolExecutionAdmissionRequest {
+        tool_name: "WebFetch",
+        allowed_tools: &["WebFetch".to_string()],
+        runtime_tool_restrictions: &ToolRuntimeRestrictions::default(),
+        collapsed_tools: &["WebFetch".to_string()],
+        loaded_collapsed_tools: &[],
+        get_tool_spec_tool_name: GET_TOOL_SPEC_TOOL_NAME,
+    };
+
+    let err = validate_tool_execution_admission(request)
+        .expect_err("collapsed tool should require GetToolSpec after access gates pass");
+
+    assert!(matches!(err, ToolExecutionAdmissionRejection::Collapsed(_)));
+    assert!(err
+        .to_string()
+        .contains("Call GetToolSpec first with {\"tool_name\":\"WebFetch\"}"));
 }
 
 #[test]

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -19,13 +19,13 @@ use bitfun_agent_tools::{
     build_invalid_tool_call_error_message, build_tool_execution_error_presentation,
     build_user_steering_interrupted_presentation, render_tool_result_for_assistant,
     truncate_raw_tool_arguments_preview, truncate_tool_arguments_preview,
-    validate_collapsed_tool_usage, validate_tool_allowed_by_list, GET_TOOL_SPEC_TOOL_NAME,
+    validate_tool_execution_admission, ToolCallLoopDecision, ToolCallLoopHistory,
+    ToolExecutionAdmissionRejection, ToolExecutionAdmissionRequest, GET_TOOL_SPEC_TOOL_NAME,
     USER_STEERING_INTERRUPTED_MESSAGE,
 };
 use dashmap::DashMap;
 use futures::future::join_all;
 use log::{debug, error, info, warn};
-use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};
 use tokio::sync::{oneshot, RwLock as TokioRwLock};
@@ -36,23 +36,6 @@ use tokio_util::sync::CancellationToken;
 struct ToolBatch {
     task_ids: Vec<String>,
     is_concurrent: bool,
-}
-
-/// Number of *consecutive* identical tool calls (same name + deep-equal
-/// arguments) tolerated before the pipeline blocks further attempts as a
-/// detected loop. The (N+1)-th identical call is the one that gets blocked.
-const TOOL_CALL_LOOP_THRESHOLD: usize = 3;
-
-/// Cap on per-session recent tool call history. Bounded so a long-lived
-/// session does not accumulate unbounded memory; only the tail of the window
-/// participates in loop detection anyway.
-const TOOL_CALL_HISTORY_WINDOW: usize = 10;
-
-/// Snapshot of a recently attempted tool call, used to detect agent loops.
-#[derive(Debug, Clone)]
-struct RecentToolCall {
-    tool_name: String,
-    arguments: serde_json::Value,
 }
 
 fn is_write_like_tool_name(tool_name: &str) -> bool {
@@ -252,6 +235,18 @@ fn should_retry_tool_error(error: &BitFunError) -> bool {
     )
 }
 
+fn map_tool_execution_admission_rejection(error: ToolExecutionAdmissionRejection) -> BitFunError {
+    match error {
+        ToolExecutionAdmissionRejection::RuntimeRestriction(error) => error.into(),
+        ToolExecutionAdmissionRejection::AllowedList(error) => {
+            BitFunError::Validation(error.to_string())
+        }
+        ToolExecutionAdmissionRejection::Collapsed(error) => {
+            BitFunError::Validation(error.to_string())
+        }
+    }
+}
+
 /// Confirmation response type
 #[derive(Debug, Clone)]
 pub enum ConfirmationResponse {
@@ -270,21 +265,11 @@ pub struct ToolPipeline {
     /// Per-session ring buffer of recent tool calls for loop detection.
     /// Keyed by session_id; entries store (tool_name, arguments) so that
     /// "same tool with deep-equal arguments" can be recognized across rounds.
-    recent_tool_calls: Arc<DashMap<String, VecDeque<RecentToolCall>>>,
+    recent_tool_calls: Arc<DashMap<String, ToolCallLoopHistory>>,
     computer_use_host: Option<ComputerUseHostRef>,
 }
 
 impl ToolPipeline {
-    fn validate_collapsed_tool_usage(task: &ToolTask) -> BitFunResult<()> {
-        validate_collapsed_tool_usage(
-            task.tool_call.tool_name.as_str(),
-            &task.context.collapsed_tools,
-            &task.context.unlocked_collapsed_tools,
-            GET_TOOL_SPEC_TOOL_NAME,
-        )
-        .map_err(|error| BitFunError::Validation(error.to_string()))
-    }
-
     pub fn new(
         tool_registry: Arc<TokioRwLock<ToolRegistry>>,
         state_manager: Arc<ToolStateManager>,
@@ -300,42 +285,17 @@ impl ToolPipeline {
         }
     }
 
-    /// Check whether this tool call forms a loop (the last
-    /// `TOOL_CALL_LOOP_THRESHOLD` consecutive calls in this session all had
-    /// the same name AND deep-equal arguments). Always records the call into
-    /// the per-session history so that persistent loops continue to register.
-    /// Returns `true` if this call should be blocked.
     fn check_and_record_tool_call(
         &self,
         session_id: &str,
         tool_name: &str,
         arguments: &serde_json::Value,
-    ) -> bool {
+    ) -> ToolCallLoopDecision {
         let mut entry = self
             .recent_tool_calls
             .entry(session_id.to_string())
             .or_default();
-        let history = entry.value_mut();
-
-        // Count *consecutive* matches from the tail. A non-matching call
-        // anywhere in the window resets the streak.
-        let identical_priors = history
-            .iter()
-            .rev()
-            .take(TOOL_CALL_LOOP_THRESHOLD)
-            .take_while(|past| past.tool_name == tool_name && &past.arguments == arguments)
-            .count();
-        let is_loop = identical_priors >= TOOL_CALL_LOOP_THRESHOLD;
-
-        history.push_back(RecentToolCall {
-            tool_name: tool_name.to_string(),
-            arguments: arguments.clone(),
-        });
-        while history.len() > TOOL_CALL_HISTORY_WINDOW {
-            history.pop_front();
-        }
-
-        is_loop
+        entry.value_mut().check_and_record(tool_name, arguments)
     }
 
     /// Drop the loop-detection history for a session that is ending. Bounded
@@ -656,16 +616,13 @@ impl ToolPipeline {
         // Loop detection: refuse to execute the same tool call repeatedly with
         // identical arguments. Triggered on the (THRESHOLD + 1)-th consecutive
         // identical call within the per-session sliding window.
-        if self.check_and_record_tool_call(&task.context.session_id, &tool_name, &tool_args) {
-            let error_msg = format!(
-                "Tool-call loop blocked: '{}' was already called {} times in a row in this session with identical arguments. Refusing to execute this {}th identical call. Issue a different tool call, or stop tool-calling and respond to the user. If you wrote a file recently and want to continue or modify it, do not call Write again for the same path; use the latest Read result for that file, or call Read once if no current Read result is available, then use Edit with `old_string` taken from the current file content.",
-                tool_name,
-                TOOL_CALL_LOOP_THRESHOLD,
-                TOOL_CALL_LOOP_THRESHOLD + 1
-            );
+        if let ToolCallLoopDecision::Blocked(block) =
+            self.check_and_record_tool_call(&task.context.session_id, &tool_name, &tool_args)
+        {
+            let error_msg = block.message;
             warn!(
                 "Tool-call loop blocked: tool_name={}, tool_id={}, session_id={}, threshold={}",
-                tool_name, tool_id, task.context.session_id, TOOL_CALL_LOOP_THRESHOLD
+                tool_name, tool_id, task.context.session_id, block.threshold
             );
 
             self.state_manager
@@ -686,36 +643,16 @@ impl ToolPipeline {
             return Err(BitFunError::Validation(error_msg));
         }
 
-        if let Err(err) = validate_tool_allowed_by_list(&tool_name, &task.context.allowed_tools) {
+        if let Err(err) = validate_tool_execution_admission(ToolExecutionAdmissionRequest {
+            tool_name: &tool_name,
+            allowed_tools: &task.context.allowed_tools,
+            runtime_tool_restrictions: &task.context.runtime_tool_restrictions,
+            collapsed_tools: &task.context.collapsed_tools,
+            loaded_collapsed_tools: &task.context.unlocked_collapsed_tools,
+            get_tool_spec_tool_name: GET_TOOL_SPEC_TOOL_NAME,
+        }) {
             let error_msg = err.to_string();
-            warn!("Tool not allowed: {}", error_msg);
-
-            // Update state to failed
-            self.state_manager
-                .update_state(
-                    &tool_id,
-                    ToolExecutionState::Failed {
-                        error: error_msg.clone(),
-                        is_retryable: false,
-                        duration_ms: None,
-                        queue_wait_ms: None,
-                        preflight_ms: None,
-                        confirmation_wait_ms: None,
-                        execution_ms: None,
-                    },
-                )
-                .await;
-
-            return Err(BitFunError::Validation(error_msg));
-        }
-
-        if let Err(err) = task
-            .context
-            .runtime_tool_restrictions
-            .ensure_tool_allowed(&tool_name)
-        {
-            let error_msg = err.to_string();
-            warn!("Tool rejected by runtime restrictions: {}", error_msg);
+            warn!("Tool execution admission rejected: {}", error_msg);
 
             self.state_manager
                 .update_state(
@@ -732,29 +669,7 @@ impl ToolPipeline {
                 )
                 .await;
 
-            return Err(err.into());
-        }
-
-        if let Err(err) = Self::validate_collapsed_tool_usage(&task) {
-            let error_msg = err.to_string();
-            warn!("Collapsed tool usage validation failed: {}", error_msg);
-
-            self.state_manager
-                .update_state(
-                    &tool_id,
-                    ToolExecutionState::Failed {
-                        error: error_msg,
-                        is_retryable: false,
-                        duration_ms: None,
-                        queue_wait_ms: None,
-                        preflight_ms: None,
-                        confirmation_wait_ms: None,
-                        execution_ms: None,
-                    },
-                )
-                .await;
-
-            return Err(err);
+            return Err(map_tool_execution_admission_rejection(err));
         }
 
         let tool = {
@@ -1656,8 +1571,15 @@ mod tests {
         let mut task = test_tool_task("tool_1", "WebFetch");
         task.context.collapsed_tools = vec!["WebFetch".to_string()];
 
-        let err = ToolPipeline::validate_collapsed_tool_usage(&task)
-            .expect_err("collapsed tool should require GetToolSpec unlock");
+        let err = validate_tool_execution_admission(ToolExecutionAdmissionRequest {
+            tool_name: &task.tool_call.tool_name,
+            allowed_tools: &task.context.allowed_tools,
+            runtime_tool_restrictions: &task.context.runtime_tool_restrictions,
+            collapsed_tools: &task.context.collapsed_tools,
+            loaded_collapsed_tools: &task.context.unlocked_collapsed_tools,
+            get_tool_spec_tool_name: GET_TOOL_SPEC_TOOL_NAME,
+        })
+        .expect_err("collapsed tool should require GetToolSpec unlock");
 
         assert!(err
             .to_string()
@@ -1670,7 +1592,14 @@ mod tests {
         task.tool_call.arguments = json!({ "tool_name": "WebFetch" });
         task.context.unlocked_collapsed_tools = vec!["WebFetch".to_string()];
 
-        let result = ToolPipeline::validate_collapsed_tool_usage(&task);
+        let result = validate_tool_execution_admission(ToolExecutionAdmissionRequest {
+            tool_name: &task.tool_call.tool_name,
+            allowed_tools: &task.context.allowed_tools,
+            runtime_tool_restrictions: &task.context.runtime_tool_restrictions,
+            collapsed_tools: &task.context.collapsed_tools,
+            loaded_collapsed_tools: &task.context.unlocked_collapsed_tools,
+            get_tool_spec_tool_name: GET_TOOL_SPEC_TOOL_NAME,
+        });
 
         assert!(
             result.is_ok(),


### PR DESCRIPTION
## Summary

- Replaces the previous narrow Product-Domain MiniApp facade scope with a real Tool Runtime owner migration.
- Moves deterministic tool execution admission policy into `bitfun-agent-tools`: tool-call loop history / block message, allowed-list gate, runtime restriction gate, and collapsed-tool admission gate.
- Removes the corresponding constants, history structure, loop-detection algorithm, and three separate admission branches from the core tool pipeline.
- Keeps `bitfun-core` responsible for runtime state updates, logging, error mapping, registry lookup, input validation, confirmation, concrete execution, and hooks.
- Updates architecture / plan docs and boundary checks so this owner boundary is tracked explicitly.

## Scope and non-goals

- Does not move concrete IO tools, `ToolUseContext` service handles, product registry materialization, `GetToolSpecTool` concrete adapter, snapshot wrapper, or collapsed unlock persistence.
- Does not change product commands, UI, default features, build scripts, or tool execution behavior intentionally.
- Admission ordering is preserved: allowed-list, runtime restrictions, then collapsed-tool unlock gate.

## Verification

- `cargo test -p bitfun-core --features product-full agentic::tools::pipeline::tool_pipeline::tests -- --nocapture`
- `cargo check -p bitfun-core --features product-full`
- `cargo test -p bitfun-agent-tools`
- `node scripts/check-core-boundaries.mjs`
- `pnpm run check:repo-hygiene`
- `git diff --check gcwing/main..HEAD`

Rebased onto `gcwing/main` at `95025981` before push.
