### PR TITLE
feat(cli): TUI slash-command autocomplete now matches substrings

### DIFF
--- a/src/apps/cli/src/commands.rs
+++ b/src/apps/cli/src/commands.rs
@@ -130,15 +130,98 @@ pub const STARTUP_COMMAND_SPECS: &[CommandSpec] = &[
     },
 ];
 
-pub fn match_prefix_in(
-    prefix: &str,
+pub fn match_substring_in(
+    query: &str,
     commands: &'static [CommandSpec],
 ) -> Vec<&'static CommandSpec> {
-    if prefix.is_empty() {
+    if query.is_empty() {
+        return Vec::new();
+    }
+    let q = query.strip_prefix('/').unwrap_or(query).to_lowercase();
+    if q.is_empty() {
         return Vec::new();
     }
     commands
         .iter()
-        .filter(|spec| spec.name.starts_with(prefix))
+        .filter(|spec| {
+            spec.name
+                .strip_prefix('/')
+                .unwrap_or(spec.name)
+                .to_lowercase()
+                .contains(&q)
+        })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_query_returns_empty() {
+        let result = match_substring_in("", COMMAND_SPECS);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_exact_match() {
+        let result = match_substring_in("/help", COMMAND_SPECS);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "/help");
+    }
+
+    #[test]
+    fn test_prefix_match() {
+        let result = match_substring_in("/he", COMMAND_SPECS);
+        assert_eq!(result.len(), 2);
+        let names: Vec<&str> = result.iter().map(|s| s.name).collect();
+        assert!(names.contains(&"/help"));
+        assert!(names.contains(&"/theme"));
+    }
+
+    #[test]
+    fn test_substring_match() {
+        let result = match_substring_in("/age", COMMAND_SPECS);
+        let names: Vec<&str> = result.iter().map(|s| s.name).collect();
+        assert!(names.contains(&"/usage"));
+    }
+
+    #[test]
+    fn test_mid_string_match() {
+        let result = match_substring_in("/usa", COMMAND_SPECS);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "/usage");
+    }
+
+    #[test]
+    fn test_multiple_substring_matches() {
+        let result = match_substring_in("/s", COMMAND_SPECS);
+        let names: Vec<&str> = result.iter().map(|s| s.name).collect();
+        assert!(names.contains(&"/sessions"));
+        assert!(names.contains(&"/skills"));
+        assert!(names.contains(&"/subagents"));
+        assert!(names.contains(&"/mcps"));
+        assert!(names.contains(&"/usage"));
+        assert!(names.contains(&"/models"));
+        assert!(names.contains(&"/history"));
+    }
+
+    #[test]
+    fn test_no_match() {
+        let result = match_substring_in("/zzz", COMMAND_SPECS);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_slash_only_returns_empty() {
+        let result = match_substring_in("/", COMMAND_SPECS);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        let result = match_substring_in("/HELP", COMMAND_SPECS);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "/help");
+    }
 }

--- a/src/apps/cli/src/ui/command_menu.rs
+++ b/src/apps/cli/src/ui/command_menu.rs
@@ -8,7 +8,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::commands::{match_prefix_in, CommandSpec, COMMAND_SPECS};
+use crate::commands::{match_substring_in, CommandSpec, COMMAND_SPECS};
 use crate::ui::theme::{StyleKind, Theme};
 
 pub struct CommandMenuState {
@@ -61,7 +61,7 @@ impl CommandMenuState {
         if query == "/" {
             self.items = commands.iter().collect();
         } else {
-            self.items = match_prefix_in(query, commands);
+            self.items = match_substring_in(query, commands);
         }
         self.items.sort_by_key(|spec| spec.name);
 


### PR DESCRIPTION
## Summary

- 将 TUI 斜杠命令菜单的匹配逻辑从**前缀匹配**改为**子串匹配**，与 Web UI 行为对齐
- 对标 Claude Code v2.1.157: "slash-command autocomplete in the dispatch input now matches substrings"

## Changes

| File | Change |
|---|---|
| `src/apps/cli/src/commands.rs` | `match_prefix_in` → `match_substring_in`，去掉 `/` 前缀后做 `contains` 子串匹配（大小写不敏感），新增 9 个单测 |
| `src/apps/cli/src/ui/command_menu.rs` | 更新 import 和调用点 |

## Behavior

- 输入 `/age` → 匹配 `/usage`（新能力，之前无结果）
- 输入 `/usa` → 匹配 `/usage`（新能力）
- 输入 `/s` → 匹配所有含 `s` 的命令（7个，之前仅前缀匹配出3个）
- 输入 `/HELP` → 匹配 `/help`（大小写不敏感）

## Test plan

- [x] 9 个单元测试全部通过（`cargo test -p bitfun-cli -- commands::tests`）
- [x] `cargo check -p bitfun-cli` 编译通过
- [x] 独立 Agent 代码审查通过（无 bug 发现）