### PR TITLE
feat(web-ui): add write tool mode setting

### DIFF
--- a/src/web-ui/src/app/scenes/settings/settingsConfig.ts
+++ b/src/web-ui/src/app/scenes/settings/settingsConfig.ts
@@ -148,6 +148,10 @@ export const SETTINGS_CATEGORIES: ConfigCategoryDef[] = [
         keywords: [
           'session',
           'tool',
+          'write',
+          'file write',
+          'inline content',
+          'plaintext followup',
           'timeout',
           'confirmation',
           'computer use',

--- a/src/web-ui/src/app/scenes/settings/settingsTabSearchContent.ts
+++ b/src/web-ui/src/app/scenes/settings/settingsTabSearchContent.ts
@@ -83,6 +83,8 @@ export const SETTINGS_TAB_SEARCH_CONTENT: Record<ConfigTab, readonly SettingsTab
     { ns: 'settings/agentic-tools', key: 'config.confirmTimeoutDesc' },
     { ns: 'settings/agentic-tools', key: 'config.executionTimeout' },
     { ns: 'settings/agentic-tools', key: 'config.executionTimeoutDesc' },
+    { ns: 'settings/agentic-tools', key: 'config.writeToolMode' },
+    { ns: 'settings/agentic-tools', key: 'config.writeToolModeDesc' },
     { ns: 'settings/debug', key: 'sections.combined' },
     { ns: 'settings/debug', key: 'sections.combinedDescription' },
     { ns: 'settings/debug', key: 'settings.logPath.label' },

--- a/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
@@ -28,7 +28,7 @@ import {
 import { configManager } from '../services/ConfigManager';
 import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
 import { useNotification, notificationService } from '@/shared/notification-system';
-import type { AIModelConfig, DebugModeConfig, LanguageDebugTemplate } from '../types';
+import type { AIModelConfig, DebugModeConfig, LanguageDebugTemplate, WriteToolMode } from '../types';
 import {
   LANGUAGE_TEMPLATE_LABELS,
   DEFAULT_DEBUG_MODE_CONFIG,
@@ -94,6 +94,7 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
   const [models, setModels] = useState<AIModelConfig[]>([]);
   const [funcAgentModels, setFuncAgentModels] = useState<Record<string, string>>({});
   const [skipToolConfirmation, setSkipToolConfirmation] = useState(true);
+  const [writeToolMode, setWriteToolMode] = useState<WriteToolMode>('plaintext_followup');
   const [executionTimeout, setExecutionTimeout] = useState('');
   const [confirmationTimeout, setConfirmationTimeout] = useState('');
   const [toolExecConfigLoading, setToolExecConfigLoading] = useState(false);
@@ -193,6 +194,7 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
         allModels,
         funcAgentModelsData,
         skipConfirm,
+        writeToolModeConfig,
         execTimeout,
         confirmTimeout,
         debugConfigData,
@@ -204,6 +206,7 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
         configManager.getConfig<AIModelConfig[]>('ai.models') || [],
         configManager.getConfig<Record<string, string>>('ai.func_agent_models') || {},
         configManager.getConfig<boolean>('ai.skip_tool_confirmation'),
+        configManager.getConfig<WriteToolMode>('ai.write_tool_mode'),
         configManager.getConfig<number | null>('ai.tool_execution_timeout_secs'),
         configManager.getConfig<number | null>('ai.tool_confirmation_timeout_secs'),
         configManager.getConfig<DebugModeConfig>('ai.debug_mode_config'),
@@ -217,6 +220,7 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
       setModels(allModels as AIModelConfig[]);
       setFuncAgentModels(funcAgentModelsData as Record<string, string>);
       setSkipToolConfirmation(skipConfirm ?? true);
+      setWriteToolMode(writeToolModeConfig === 'inline_content' ? 'inline_content' : 'plaintext_followup');
       setExecutionTimeout(execTimeout != null ? String(execTimeout) : '');
       setConfirmationTimeout(confirmTimeout != null ? String(confirmTimeout) : '');
       if (debugConfigData) setDebugConfig(debugConfigData);
@@ -440,6 +444,30 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
       setComputerUseEnabled(!checked);
     } finally {
       setComputerUseBusy(false);
+    }
+  };
+
+  const handleWriteToolModeChange = async (value: string | number | (string | number)[]) => {
+    const nextValue = String(Array.isArray(value) ? value[0] : value);
+    const normalizedValue: WriteToolMode =
+      nextValue === 'inline_content' ? 'inline_content' : 'plaintext_followup';
+    const previousValue = writeToolMode;
+
+    setWriteToolMode(normalizedValue);
+    setToolExecConfigLoading(true);
+    try {
+      await configManager.setConfig('ai.write_tool_mode', normalizedValue);
+      const { globalEventBus } = await import('@/infrastructure/event-bus');
+      globalEventBus.emit('mode:config:updated');
+      notificationService.success(t('messages.saveSuccess'), { duration: 2000 });
+    } catch (error) {
+      log.error('Failed to save write_tool_mode', error);
+      notificationService.error(
+        `${tTools('messages.saveFailed')}: ` + (error instanceof Error ? error.message : String(error))
+      );
+      setWriteToolMode(previousValue);
+    } finally {
+      setToolExecConfigLoading(false);
     }
   };
 
@@ -706,6 +734,18 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
     label: option.installed ? option.label : `${option.label} (${t('browserControl.notInstalled')})`,
     disabled: !option.installed,
   }));
+  const writeToolModeOptions: SelectOption[] = [
+    {
+      value: 'plaintext_followup',
+      label: tTools('config.writeToolModeOptions.plaintextFollowup'),
+      description: tTools('config.writeToolModeOptions.plaintextFollowupDesc'),
+    },
+    {
+      value: 'inline_content',
+      label: tTools('config.writeToolModeOptions.inlineContent'),
+      description: tTools('config.writeToolModeOptions.inlineContentDesc'),
+    },
+  ];
 
   const pageTitle = variant === 'personalization'
     ? t('personalizationPage.title')
@@ -1015,6 +1055,19 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
                 unit={tTools('config.seconds')}
                 size="small"
                 variant="compact"
+              />
+            </div>
+          </ConfigPageRow>
+          <ConfigPageRow label={tTools('config.writeToolMode')} description={tTools('config.writeToolModeDesc')} align="center">
+            <div className="bitfun-func-agent-config__row-control">
+              <Select
+                size="small"
+                options={writeToolModeOptions}
+                value={writeToolMode}
+                disabled={toolExecConfigLoading}
+                onChange={(value) => {
+                  void handleWriteToolModeChange(value);
+                }}
               />
             </div>
           </ConfigPageRow>

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -174,6 +174,8 @@ export interface DefaultModelsConfig {
   fast?: string | null;
 }
 
+export type WriteToolMode = 'inline_content' | 'plaintext_followup';
+
 export interface AIConfig {
   models: AIModelConfig[];
   default_models: DefaultModelsConfig;
@@ -194,6 +196,7 @@ export interface AIConfig {
   tool_execution_timeout_secs?: number | null;
   tool_confirmation_timeout_secs?: number | null;
   skip_tool_confirmation?: boolean;
+  write_tool_mode?: WriteToolMode;
   computer_use_enabled?: boolean;
   browser_control_preferred_browser?: string;
 }

--- a/src/web-ui/src/locales/en-US/settings/agentic-tools.json
+++ b/src/web-ui/src/locales/en-US/settings/agentic-tools.json
@@ -18,6 +18,14 @@
     "confirmTimeoutDesc": "Maximum time (seconds) to wait for user confirmation of tool calls.",
     "executionTimeout": "Execution Timeout",
     "executionTimeoutDesc": "Maximum time (seconds) for tool execution, including Task subagent runs.",
+    "writeToolMode": "Write Tool Mode",
+    "writeToolModeDesc": "Choose whether the Write tool sends file content inline or generates it in a separate follow-up step. ACP sessions always use inline content.",
+    "writeToolModeOptions": {
+      "plaintextFollowup": "Plaintext follow-up",
+      "plaintextFollowupDesc": "Expose only file_path to the model, then generate the full file body in a second step.",
+      "inlineContent": "Inline content",
+      "inlineContentDesc": "Expose both file_path and content so the model sends the full file body in one tool call."
+    },
     "seconds": "sec"
   },
   "filters": {

--- a/src/web-ui/src/locales/zh-CN/settings/agentic-tools.json
+++ b/src/web-ui/src/locales/zh-CN/settings/agentic-tools.json
@@ -18,6 +18,14 @@
     "confirmTimeoutDesc": "等待用户确认工具调用的最长时间（秒）。",
     "executionTimeout": "执行超时",
     "executionTimeoutDesc": "工具执行的最长时间（秒），包含 Task 子智能体运行时长。",
+    "writeToolMode": "Write 工具模式",
+    "writeToolModeDesc": "选择 Write 工具以内联方式直接携带文件内容，还是通过单独的后续步骤生成完整文件内容。ACP 会话始终使用内联内容。",
+    "writeToolModeOptions": {
+      "plaintextFollowup": "纯文本后续生成",
+      "plaintextFollowupDesc": "只向模型暴露 file_path，再通过第二步生成完整文件内容。",
+      "inlineContent": "内联内容",
+      "inlineContentDesc": "向模型同时暴露 file_path 和 content，在一次工具调用中直接提交完整文件内容。"
+    },
     "seconds": "秒"
   },
   "filters": {

--- a/src/web-ui/src/locales/zh-TW/settings/agentic-tools.json
+++ b/src/web-ui/src/locales/zh-TW/settings/agentic-tools.json
@@ -18,6 +18,14 @@
     "confirmTimeoutDesc": "等待用戶確認工具調用的最長時間（秒）。",
     "executionTimeout": "執行超時",
     "executionTimeoutDesc": "工具執行的最長時間（秒），包含 Task 子智能體執行時長。",
+    "writeToolMode": "Write 工具模式",
+    "writeToolModeDesc": "選擇 Write 工具以內聯方式直接攜帶檔案內容，還是透過單獨的後續步驟生成完整檔案內容。ACP 會話始終使用內聯內容。",
+    "writeToolModeOptions": {
+      "plaintextFollowup": "純文字後續生成",
+      "plaintextFollowupDesc": "只向模型暴露 file_path，再透過第二步生成完整檔案內容。",
+      "inlineContent": "內聯內容",
+      "inlineContentDesc": "向模型同時暴露 file_path 和 content，在一次工具調用中直接提交完整檔案內容。"
+    },
     "seconds": "秒"
   },
   "filters": {


### PR DESCRIPTION
Add a Write Tool Mode selector under Settings -> Session Permissions -> Tool execution.
Persist ai.write_tool_mode from the frontend config layer, refresh mode-dependent UI
after updates, and add search keywords plus localized copy for the new setting.
