### PR TITLE
fix(ai-adapters): align DeepSeek Anthropic thinking semantics

### DIFF
--- a/src/crates/ai-adapters/src/client.rs
+++ b/src/crates/ai-adapters/src/client.rs
@@ -956,7 +956,7 @@ mod tests {
         );
 
         assert_eq!(request_body["thinking"]["type"], "enabled");
-        assert_eq!(request_body["thinking"]["budget_tokens"], 6144);
+        assert!(request_body["thinking"].get("budget_tokens").is_none());
         assert_eq!(request_body["output_config"]["effort"], "max");
     }
 
@@ -995,6 +995,118 @@ mod tests {
 
         assert_eq!(request_body["thinking"]["type"], "enabled");
         assert_eq!(request_body["thinking"]["budget_tokens"], 3000);
+    }
+
+    #[test]
+    fn build_anthropic_request_body_default_deepseek_reasoning_omits_thinking_fields() {
+        let client = AIClient::new(AIConfig {
+            name: "deepseek".to_string(),
+            base_url: "https://api.deepseek.com/anthropic".to_string(),
+            request_url: "https://api.deepseek.com/anthropic/v1/messages".to_string(),
+            api_key: "test-key".to_string(),
+            model: "deepseek-v4-flash".to_string(),
+            format: "anthropic".to_string(),
+            context_window: 200000,
+            max_tokens: Some(8192),
+            temperature: None,
+            top_p: None,
+            reasoning_mode: ReasoningMode::Default,
+            inline_think_in_text: false,
+            custom_headers: None,
+            custom_headers_mode: None,
+            skip_ssl_verify: false,
+            reasoning_effort: Some("high".to_string()),
+            thinking_budget_tokens: None,
+            custom_request_body: None,
+            custom_request_body_mode: None,
+        });
+
+        let request_body = anthropic::request::build_request_body(
+            &client,
+            &client.config.request_url,
+            None,
+            vec![json!({ "role": "user", "content": [{ "type": "text", "text": "hello" }] })],
+            None,
+            None,
+        );
+
+        assert!(request_body.get("thinking").is_none());
+        assert!(request_body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn build_anthropic_request_body_disabled_deepseek_reasoning_omits_effort() {
+        let client = AIClient::new(AIConfig {
+            name: "deepseek".to_string(),
+            base_url: "https://api.deepseek.com/anthropic".to_string(),
+            request_url: "https://api.deepseek.com/anthropic/v1/messages".to_string(),
+            api_key: "test-key".to_string(),
+            model: "deepseek-v4-flash".to_string(),
+            format: "anthropic".to_string(),
+            context_window: 200000,
+            max_tokens: Some(8192),
+            temperature: None,
+            top_p: None,
+            reasoning_mode: ReasoningMode::Disabled,
+            inline_think_in_text: false,
+            custom_headers: None,
+            custom_headers_mode: None,
+            skip_ssl_verify: false,
+            reasoning_effort: Some("high".to_string()),
+            thinking_budget_tokens: None,
+            custom_request_body: None,
+            custom_request_body_mode: None,
+        });
+
+        let request_body = anthropic::request::build_request_body(
+            &client,
+            &client.config.request_url,
+            None,
+            vec![json!({ "role": "user", "content": [{ "type": "text", "text": "hello" }] })],
+            None,
+            None,
+        );
+
+        assert_eq!(request_body["thinking"]["type"], "disabled");
+        assert!(request_body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn build_anthropic_request_body_adaptive_deepseek_reasoning_falls_back_to_enabled() {
+        let client = AIClient::new(AIConfig {
+            name: "deepseek".to_string(),
+            base_url: "https://api.deepseek.com/anthropic".to_string(),
+            request_url: "https://api.deepseek.com/anthropic/v1/messages".to_string(),
+            api_key: "test-key".to_string(),
+            model: "deepseek-v4-flash".to_string(),
+            format: "anthropic".to_string(),
+            context_window: 200000,
+            max_tokens: Some(8192),
+            temperature: None,
+            top_p: None,
+            reasoning_mode: ReasoningMode::Adaptive,
+            inline_think_in_text: false,
+            custom_headers: None,
+            custom_headers_mode: None,
+            skip_ssl_verify: false,
+            reasoning_effort: Some("high".to_string()),
+            thinking_budget_tokens: Some(4096),
+            custom_request_body: None,
+            custom_request_body_mode: None,
+        });
+
+        let request_body = anthropic::request::build_request_body(
+            &client,
+            &client.config.request_url,
+            None,
+            vec![json!({ "role": "user", "content": [{ "type": "text", "text": "hello" }] })],
+            None,
+            None,
+        );
+
+        assert_eq!(request_body["thinking"]["type"], "enabled");
+        assert!(request_body["thinking"].get("budget_tokens").is_none());
+        assert_eq!(request_body["output_config"]["effort"], "high");
     }
 
     #[test]

--- a/src/crates/ai-adapters/src/providers/anthropic/request.rs
+++ b/src/crates/ai-adapters/src/providers/anthropic/request.rs
@@ -107,6 +107,48 @@ fn apply_anthropic_adaptive_reasoning(
     });
 }
 
+fn apply_deepseek_anthropic_reasoning(
+    request_body: &mut serde_json::Value,
+    mode: ReasoningMode,
+    model_name: &str,
+    reasoning_effort: Option<&str>,
+) {
+    match mode {
+        ReasoningMode::Default => {}
+        ReasoningMode::Disabled => {
+            request_body["thinking"] = serde_json::json!({ "type": "disabled" });
+            if reasoning_effort.is_some_and(|value| !value.trim().is_empty()) {
+                warn!(
+                    target: "ai::anthropic_stream_request",
+                    "Omitting output_config.effort for DeepSeek Anthropic model {} because thinking is disabled",
+                    model_name
+                );
+            }
+        }
+        ReasoningMode::Enabled => {
+            request_body["thinking"] = serde_json::json!({ "type": "enabled" });
+            if let Some(effort) = reasoning_effort.and_then(normalize_deepseek_reasoning_effort) {
+                request_body["output_config"] = serde_json::json!({
+                    "effort": effort
+                });
+            }
+        }
+        ReasoningMode::Adaptive => {
+            warn!(
+                target: "ai::anthropic_stream_request",
+                "DeepSeek Anthropic model {} does not support adaptive reasoning; falling back to thinking.type=enabled",
+                model_name
+            );
+            apply_deepseek_anthropic_reasoning(
+                request_body,
+                ReasoningMode::Enabled,
+                model_name,
+                reasoning_effort,
+            );
+        }
+    }
+}
+
 fn apply_reasoning_fields(
     request_body: &mut serde_json::Value,
     mode: ReasoningMode,
@@ -118,19 +160,16 @@ fn apply_reasoning_fields(
 ) {
     let is_deepseek_reasoning_target =
         is_deepseek_url(url) || is_deepseek_reasoning_effort_model(model_name);
+
+    if is_deepseek_reasoning_target {
+        apply_deepseek_anthropic_reasoning(request_body, mode, model_name, reasoning_effort);
+        return;
+    }
+
     let capability = anthropic_thinking_capability(model_name);
 
     match mode {
-        ReasoningMode::Default => {
-            if is_deepseek_reasoning_target {
-                if let Some(effort) = reasoning_effort.and_then(normalize_deepseek_reasoning_effort)
-                {
-                    request_body["output_config"] = serde_json::json!({
-                        "effort": effort
-                    });
-                }
-            }
-        }
+        ReasoningMode::Default => {}
         ReasoningMode::Disabled => {
             if capability == AnthropicThinkingCapability::AdaptiveDefaultNoDisabled {
                 warn!(
@@ -155,14 +194,6 @@ fn apply_reasoning_fields(
                 thinking["budget_tokens"] = serde_json::json!(budget_tokens);
             }
             request_body["thinking"] = thinking;
-            if is_deepseek_reasoning_target {
-                if let Some(effort) = reasoning_effort.and_then(normalize_deepseek_reasoning_effort)
-                {
-                    request_body["output_config"] = serde_json::json!({
-                        "effort": effort
-                    });
-                }
-            }
         }
         ReasoningMode::Adaptive => {
             if anthropic_supports_adaptive_reasoning(capability) {


### PR DESCRIPTION
- split DeepSeek Anthropic reasoning handling from native Claude adaptive logic
- omit thinking and output_config in default mode
- send output_config.effort only when DeepSeek thinking is enabled
- drop budget_tokens for DeepSeek Anthropic requests
- fallback adaptive mode to enabled for DeepSeek Anthropic models
- add focused tests for default, disabled, enabled, and adaptive DeepSeek paths
