### PR TITLE
fix(flow-chat): reduce streaming code preview jank

### DIFF
--- a/src/web-ui/src/flow_chat/components/CodePreview.test.tsx
+++ b/src/web-ui/src/flow_chat/components/CodePreview.test.tsx
@@ -1,0 +1,110 @@
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+import { CodePreview } from './CodePreview';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@/infrastructure/theme', () => ({
+  useTheme: () => ({ isLight: false }),
+}));
+
+vi.mock('@/infrastructure/language-detection', () => ({
+  getPrismLanguage: () => 'typescript',
+}));
+
+vi.mock('@/shared/utils/syntaxHighlighterLoader', () => ({
+  getLoadedPrismSyntaxHighlighter: () => null,
+  loadPrismSyntaxHighlighter: async () => MockSyntaxHighlighter,
+}));
+
+function MockSyntaxHighlighter({
+  children,
+  startingLineNumber = 1,
+}: {
+  children: string;
+  startingLineNumber?: number;
+}) {
+  return (
+    <pre data-testid="syntax-highlighter" data-starting-line-number={startingLineNumber}>
+      {children}
+    </pre>
+  );
+}
+
+function makeLines(count: number): string {
+  return Array.from({ length: count }, (_, index) =>
+    `line ${String(index + 1).padStart(3, '0')}`
+  ).join('\n');
+}
+
+describe('CodePreview', () => {
+  let dom: JSDOM;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      pretendToBeVisual: true,
+    });
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it('renders only a viewport-sized tail while streaming long code', async () => {
+    await act(async () => {
+      root.render(
+        <CodePreview
+          content={makeLines(120)}
+          filePath="src/generated.ts"
+          isStreaming={true}
+          maxHeight={88}
+        />
+      );
+    });
+
+    const highlighter = container.querySelector('[data-testid="syntax-highlighter"]') as HTMLElement;
+    expect(highlighter).not.toBeNull();
+    expect(highlighter.textContent).toContain('line 120');
+    expect(highlighter.textContent).not.toContain('line 090');
+    expect(Number(highlighter.dataset.startingLineNumber)).toBeGreaterThan(100);
+  });
+
+  it('keeps enough streaming tail content to fill a taller preview', async () => {
+    await act(async () => {
+      root.render(
+        <CodePreview
+          content={makeLines(120)}
+          filePath="src/generated.ts"
+          isStreaming={true}
+          maxHeight={330}
+        />
+      );
+    });
+
+    const highlighter = container.querySelector('[data-testid="syntax-highlighter"]') as HTMLElement;
+    expect(highlighter).not.toBeNull();
+    expect(highlighter.textContent).toContain('line 120');
+    expect(highlighter.textContent).toContain('line 104');
+    expect(highlighter.textContent).not.toContain('line 090');
+    expect(Number(highlighter.dataset.startingLineNumber)).toBeLessThanOrEqual(104);
+  });
+});

--- a/src/web-ui/src/flow_chat/components/CodePreview.tsx
+++ b/src/web-ui/src/flow_chat/components/CodePreview.tsx
@@ -47,6 +47,66 @@ function detectLanguageFromPath(filePath: string): string {
   return getPrismLanguage(filePath);
 }
 
+const CODE_PREVIEW_STREAMING_LINE_HEIGHT_PX = 22;
+const STREAMING_TAIL_MIN_LINES = 4;
+const STREAMING_TAIL_MAX_LINES = 24;
+const STREAMING_TAIL_OVERSCAN_LINES = 2;
+const STREAMING_TAIL_MAX_CHARS = 6000;
+
+function countNewlines(value: string, endExclusive = value.length): number {
+  let count = 0;
+  const end = Math.min(endExclusive, value.length);
+  for (let index = 0; index < end; index += 1) {
+    if (value.charCodeAt(index) === 10) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function getStreamingTailLineLimit(maxHeight: number): number {
+  const visibleLines = Math.ceil(maxHeight / CODE_PREVIEW_STREAMING_LINE_HEIGHT_PX);
+  return Math.min(
+    STREAMING_TAIL_MAX_LINES,
+    Math.max(STREAMING_TAIL_MIN_LINES, visibleLines + STREAMING_TAIL_OVERSCAN_LINES),
+  );
+}
+
+function getStreamingTailDisplayContent(content: string, maxHeight: number): {
+  content: string;
+  startingLineNumber: number;
+} {
+  const tailLineLimit = getStreamingTailLineLimit(maxHeight);
+  const totalLineCount = countNewlines(content) + 1;
+
+  if (totalLineCount <= tailLineLimit && content.length <= STREAMING_TAIL_MAX_CHARS) {
+    return { content, startingLineNumber: 1 };
+  }
+
+  let sliceStart = 0;
+  let remainingLineBreaks = tailLineLimit;
+  for (let index = content.length - 1; index >= 0; index -= 1) {
+    if (content.charCodeAt(index) !== 10) {
+      continue;
+    }
+
+    remainingLineBreaks -= 1;
+    if (remainingLineBreaks === 0) {
+      sliceStart = index + 1;
+      break;
+    }
+  }
+
+  if (content.length - sliceStart > STREAMING_TAIL_MAX_CHARS) {
+    sliceStart = Math.max(sliceStart, content.length - STREAMING_TAIL_MAX_CHARS);
+  }
+
+  return {
+    content: content.slice(sliceStart),
+    startingLineNumber: countNewlines(content, sliceStart) + 1,
+  };
+}
+
 /**
  * CodePreview component with streaming-friendly syntax highlighting.
  */
@@ -74,28 +134,16 @@ export const CodePreview: React.FC<CodePreviewProps> = memo(({
   // tokenization runs during browser idle time.
   const deferredContent = useDeferredValue(content);
 
-  // Prism tokenizes the *entire* string synchronously. For large streaming files
-  // (e.g. 500-line SCSS) this blocks the main thread for 50-150 ms per 100 ms
-  // batch flush. Since the streaming preview shows at most 4 visible lines
-  // (maxHeight ≈ 88 px), we only need to tokenize the tail of the buffer.
-  // After streaming ends, the full content is restored for the completed view.
-  const STREAMING_TAIL_LINES = 60; // generous tail – more than enough for any maxHeight
+  // Prism and line-number DOM are synchronous work. While params are streaming,
+  // keep this preview near the visible viewport instead of tokenizing a large
+  // hidden tail on every batch. The completed view still receives full content.
   const displayContentInfo = useMemo(() => {
     if (!isStreaming) {
       return { content: deferredContent, startingLineNumber: 1 };
     }
 
-    const lines = deferredContent.split('\n');
-    if (lines.length <= STREAMING_TAIL_LINES) {
-      return { content: deferredContent, startingLineNumber: 1 };
-    }
-
-    const startingLineNumber = lines.length - STREAMING_TAIL_LINES + 1;
-    return {
-      content: lines.slice(-STREAMING_TAIL_LINES).join('\n'),
-      startingLineNumber,
-    };
-  }, [isStreaming, deferredContent]);
+    return getStreamingTailDisplayContent(deferredContent, maxHeight);
+  }, [isStreaming, deferredContent, maxHeight]);
 
   const displayContent = displayContentInfo.content;
 

--- a/src/web-ui/src/flow_chat/components/codePreviewPerfHarness.tsx
+++ b/src/web-ui/src/flow_chat/components/codePreviewPerfHarness.tsx
@@ -1,0 +1,141 @@
+import { createRoot } from 'react-dom/client';
+
+import { CodePreview } from './CodePreview';
+
+export interface CodePreviewStreamingProbeOptions {
+  totalLines?: number;
+  updateCount?: number;
+  maxHeight?: number;
+  autoScrollToBottom?: boolean;
+  charsPerLine?: number;
+}
+
+export interface CodePreviewStreamingProbeResult {
+  renderedLineCount: number;
+  startingLineNumber: number;
+  containsLine090: boolean;
+  containsFinalLine: boolean;
+  scrollWrites: number;
+  durationMs: number;
+  maxFrameMs: number;
+  longFrameCount: number;
+}
+
+function makeLine(lineNumber: number, charsPerLine: number): string {
+  const prefix = `line ${String(lineNumber).padStart(3, '0')} `;
+  return prefix + 'x'.repeat(Math.max(0, charsPerLine - prefix.length));
+}
+
+function makeContent(lineCount: number, charsPerLine: number): string {
+  return Array.from({ length: lineCount }, (_, index) => makeLine(index + 1, charsPerLine)).join('\n');
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
+
+function getScrollTopDescriptor(): PropertyDescriptor | undefined {
+  let prototype: object | null = HTMLElement.prototype;
+  while (prototype) {
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, 'scrollTop');
+    if (descriptor) {
+      return descriptor;
+    }
+    prototype = Object.getPrototypeOf(prototype);
+  }
+  return undefined;
+}
+
+export async function runCodePreviewStreamingPerfProbe({
+  totalLines = 160,
+  updateCount = 30,
+  maxHeight = 88,
+  autoScrollToBottom = false,
+  charsPerLine = 80,
+}: CodePreviewStreamingProbeOptions = {}): Promise<CodePreviewStreamingProbeResult> {
+  document.getElementById('bitfun-code-preview-perf-probe')?.remove();
+
+  const host = document.createElement('div');
+  host.id = 'bitfun-code-preview-perf-probe';
+  host.style.cssText = [
+    'position: fixed',
+    'left: 0',
+    'top: 0',
+    'width: 820px',
+    'height: 180px',
+    'z-index: -1',
+    'opacity: 0',
+    'pointer-events: none',
+  ].join(';');
+  document.body.appendChild(host);
+
+  const originalDescriptor = getScrollTopDescriptor();
+  let scrollWrites = 0;
+
+  Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+    configurable: true,
+    get() {
+      return originalDescriptor?.get ? originalDescriptor.get.call(this) : 0;
+    },
+    set(value: number) {
+      if (this instanceof HTMLElement && this.classList.contains('code-preview__content')) {
+        scrollWrites += 1;
+      }
+      originalDescriptor?.set?.call(this, value);
+    },
+  });
+
+  const root = createRoot(host);
+  const frameDurations: number[] = [];
+  let lastFrameAt = performance.now();
+  const startAt = lastFrameAt;
+
+  try {
+    for (let updateIndex = 1; updateIndex <= updateCount; updateIndex += 1) {
+      const currentLineCount = Math.max(1, Math.floor((totalLines * updateIndex) / updateCount));
+      root.render(
+        <CodePreview
+          content={makeContent(currentLineCount, charsPerLine)}
+          filePath="src/generated.ts"
+          isStreaming={true}
+          maxHeight={maxHeight}
+          autoScrollToBottom={autoScrollToBottom}
+        />,
+      );
+
+      await nextFrame();
+      const now = performance.now();
+      frameDurations.push(now - lastFrameAt);
+      lastFrameAt = now;
+    }
+
+    await nextFrame();
+    await nextFrame();
+
+    const text = host.textContent ?? '';
+    const renderedLines = text.match(/line \d{3}/g) ?? [];
+    const finalLine = `line ${String(totalLines).padStart(3, '0')}`;
+    const firstRenderedLine = renderedLines[0]?.match(/\d{3}/)?.[0];
+
+    return {
+      renderedLineCount: renderedLines.length,
+      startingLineNumber: firstRenderedLine ? Number(firstRenderedLine) : 0,
+      containsLine090: text.includes('line 090'),
+      containsFinalLine: text.includes(finalLine),
+      scrollWrites,
+      durationMs: performance.now() - startAt,
+      maxFrameMs: Math.max(0, ...frameDurations),
+      longFrameCount: frameDurations.filter((duration) => duration > 50).length,
+    };
+  } finally {
+    root.unmount();
+    host.remove();
+    if (originalDescriptor) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollTop', originalDescriptor);
+    } else {
+      delete (HTMLElement.prototype as { scrollTop?: number }).scrollTop;
+    }
+  }
+}

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   currentWorkspace: undefined as undefined | { rootPath: string },
   createDiffEditorTab: vi.fn(),
   openFile: vi.fn(),
+  codePreviewProps: [] as Array<Record<string, unknown>>,
   getOperationDiff: vi.fn(async () => ({
     originalContent: '',
     modifiedContent: '',
@@ -34,6 +35,11 @@ vi.mock('../../component-library', () => ({
 }));
 
 vi.mock('@/component-library', () => ({
+  CubeLoading: () => <span data-testid="cube-loading" />,
+  IconButton: ({ children, onClick }: { children: React.ReactNode; onClick?: React.MouseEventHandler }) => (
+    <button type="button" onClick={onClick}>{children}</button>
+  ),
+  ToolProcessingDots: () => <span data-testid="tool-processing-dots" />,
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
@@ -57,7 +63,10 @@ vi.mock('../../tools/snapshot_system/core/SnapshotEventBus', () => ({
 }));
 
 vi.mock('../components/CodePreview', () => ({
-  CodePreview: ({ content }: { content: string }) => <pre>{content}</pre>,
+  CodePreview: (props: Record<string, unknown>) => {
+    mocks.codePreviewProps.push(props);
+    return <pre>{String(props.content ?? '')}</pre>;
+  },
 }));
 
 vi.mock('../components/InlineDiffPreview', () => ({
@@ -111,6 +120,11 @@ describe('FileOperationToolCard', () => {
     vi.stubGlobal('document', dom.window.document);
     vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
     vi.stubGlobal('CustomEvent', dom.window.CustomEvent);
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    });
 
     container = dom.window.document.getElementById('root') as HTMLDivElement;
     root = createRoot(container);
@@ -118,6 +132,7 @@ describe('FileOperationToolCard', () => {
     mocks.currentWorkspace = undefined;
     mocks.createDiffEditorTab.mockReset();
     mocks.openFile.mockReset();
+    mocks.codePreviewProps = [];
     mocks.getOperationDiff.mockReset();
     mocks.getOperationDiff.mockResolvedValue({
       originalContent: '',
@@ -461,5 +476,53 @@ describe('FileOperationToolCard', () => {
       'Use Read to load the current contents of src/main.rs before calling Edit on it.',
     );
     expect(container.querySelector('.file-operation-card--guidance')).not.toBeNull();
+  });
+
+  it('disables nested code-preview autoscroll while write content is streaming', async () => {
+    const toolItem: FlowToolItem = {
+      id: 'tool-1',
+      type: 'tool',
+      toolName: 'Write',
+      status: 'streaming',
+      isParamsStreaming: true,
+      toolCall: {
+        id: 'call-1',
+        name: 'Write',
+        input: {
+          file_path: 'src/generated.ts',
+          content: 'const value = 1;\nconst value2 = 2;',
+        },
+      },
+      partialParams: {
+        file_path: 'src/generated.ts',
+        content: 'const value = 1;\nconst value2 = 2;',
+      },
+    } as FlowToolItem;
+
+    const config: ToolCardConfig = {
+      toolName: 'Write',
+      displayName: 'Write',
+      icon: 'WRITE',
+      requiresConfirmation: false,
+      resultDisplayType: 'detailed',
+      description: 'Write a file',
+      displayMode: 'standard',
+    };
+
+    await act(async () => {
+      root.render(
+        <FileOperationToolCard
+          toolItem={toolItem}
+          config={config}
+          sessionId="session-1"
+        />
+      );
+    });
+
+    expect(mocks.codePreviewProps).toHaveLength(1);
+    expect(mocks.codePreviewProps[0]).toMatchObject({
+      isStreaming: true,
+      autoScrollToBottom: false,
+    });
   });
 });

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -816,7 +816,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
                 isStreaming={isParamsStreaming}
                 showLineNumbers={isContentExpanded}
                 maxHeight={previewMaxHeight}
-                autoScrollToBottom={isParamsStreaming}
+                autoScrollToBottom={false}
                 onLineClick={handleCodeLineClick}
               />
             </div>
@@ -855,7 +855,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
                 isStreaming={isParamsStreaming}
                 showLineNumbers={isContentExpanded}
                 maxHeight={previewMaxHeight}
-                autoScrollToBottom={isParamsStreaming}
+                autoScrollToBottom={false}
                 onLineClick={handleCodeLineClick}
               />
             </div>

--- a/src/web-ui/src/flow_chat/tool-cards/README.md
+++ b/src/web-ui/src/flow_chat/tool-cards/README.md
@@ -37,8 +37,11 @@ Current examples:
 
 ## Auto-Scroll Behavior For Previews
 
-When the preview uses a scrolling code viewer, only auto-scroll while content is
-actively streaming. Do not keep forcing auto-scroll after streaming has stopped.
+When the preview uses a nested scrolling code viewer, avoid forcing that nested
+viewer to auto-scroll while params are streaming. Streaming code previews already
+render the latest viewport-sized tail, and the outer conversation list owns the
+high-level follow behavior. Writing `scrollTop` on every preview batch can force
+layout work inside the WebView and make long code output less responsive.
 
 Preferred pattern:
 
@@ -46,7 +49,7 @@ Preferred pattern:
 <CodePreview
   content={previewContent}
   isStreaming={isParamsStreaming}
-  autoScrollToBottom={isParamsStreaming}
+  autoScrollToBottom={false}
 />
 ```
 

--- a/tests/e2e/specs/l1-code-preview-performance.spec.ts
+++ b/tests/e2e/specs/l1-code-preview-performance.spec.ts
@@ -1,0 +1,44 @@
+import { browser, expect } from '@wdio/globals';
+
+interface CodePreviewStreamingProbeResult {
+  renderedLineCount: number;
+  startingLineNumber: number;
+  containsLine090: boolean;
+  containsFinalLine: boolean;
+  scrollWrites: number;
+  durationMs: number;
+  maxFrameMs: number;
+  longFrameCount: number;
+}
+
+describe('L1 Code preview streaming performance', () => {
+  it('bounds streamed preview work and avoids nested auto-scroll writes', async () => {
+    await browser.waitUntil(
+      async () => browser.execute(() => document.readyState === 'complete'),
+      {
+        timeout: 30000,
+        timeoutMsg: 'Webview document did not finish loading',
+      },
+    );
+
+    const result = await browser.execute(async () => {
+      const module = await import('/src/flow_chat/components/codePreviewPerfHarness.tsx');
+      return module.runCodePreviewStreamingPerfProbe({
+        totalLines: 160,
+        updateCount: 30,
+        maxHeight: 88,
+        autoScrollToBottom: false,
+        charsPerLine: 96,
+      });
+    }) as CodePreviewStreamingProbeResult;
+
+    console.log('[CodePreviewPerf] Probe result:', JSON.stringify(result));
+
+    expect(result.containsFinalLine).toBe(true);
+    expect(result.containsLine090).toBe(false);
+    expect(result.startingLineNumber).toBeGreaterThan(140);
+    expect(result.renderedLineCount).toBeLessThanOrEqual(12);
+    expect(result.scrollWrites).toBe(0);
+    expect(result.maxFrameMs).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
﻿## Summary

- 将流式 `CodePreview` 的高亮输入限制为按预览高度计算的尾部内容，完成后仍恢复完整内容。
- 在 `FileOperationToolCard` 的 Write/Edit 流式代码预览中禁用嵌套 code preview 的强制 auto-scroll，避免每批输出写 `scrollTop` 触发布局同步。
- 增加 CodePreview / FileOperationToolCard 单测，以及桌面 E2E 长代码流式性能探针。
- 同步更新 tool card 预览滚动约定文档。

## Root Cause

issue #980 中确认的主要触发点是长代码流式输出时，代码预览组件在高频批次中同时做 Prism/行号 DOM 渲染和同步滚动追随。旧实现会持续保留 60 行流式尾部并在每次内容增长时写入嵌套滚动容器的 `scrollTop`，这会在 Windows WebView 核显环境下放大主线程布局/绘制压力，表现为系统鼠标输入明显卡顿。

## Verification

- `pnpm --dir src/web-ui run test:run -- src/flow_chat/components/CodePreview.test.tsx src/flow_chat/tool-cards/FileOperationToolCard.test.tsx`：2 个文件、8 条测试通过
- `pnpm run lint:web`：退出码 0；仍有 `startupTrace.ts` 既有 2 个 warning，和本次改动无关
- `pnpm run type-check:web`：通过
- `pnpm run check:repo-hygiene`：通过
- `pnpm --dir src/web-ui run test:run`：161 个文件、821 条测试通过
- `pnpm run build:web`：通过；仍有项目既有 Vite chunk/dynamic import warning
- `pnpm --dir tests/e2e exec wdio run ./config/wdio.conf.ts --spec "./specs/l1-code-preview-performance.spec.ts"`：通过；构造 160 行长代码、30 次流式更新，探针结果 `renderedLineCount=6`、`startingLineNumber=155`、`containsLine090=false`、`scrollWrites=0`、`maxFrameMs≈37.2ms`

Fixes #980
