### PR TITLE
fix(web-ui): unify startup overlay

### DIFF
--- a/src/apps/desktop/src/api/system_api.rs
+++ b/src/apps/desktop/src/api/system_api.rs
@@ -320,6 +320,20 @@ pub struct ToggleMainWindowFullscreenResponse {
     pub is_maximized: bool,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StartupWindowControlAction {
+    Minimize,
+    ToggleMaximize,
+    Close,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartupWindowControlRequest {
+    pub action: StartupWindowControlAction,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct MainWindowFullscreenTransition {
     next_fullscreen: bool,
@@ -391,6 +405,59 @@ pub async fn minimize_to_tray(app: tauri::AppHandle) -> Result<(), String> {
         window.hide().map_err(|e| e.to_string())?;
         log::info!("Main window minimized to tray via command");
     }
+    Ok(())
+}
+
+/// Minimal startup-window controls used by the static pre-React splash.
+#[tauri::command]
+pub async fn startup_window_control(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    request: StartupWindowControlRequest,
+) -> Result<(), String> {
+    let Some(window) = app.get_webview_window("main") else {
+        return Err("Main window not found".to_string());
+    };
+
+    match request.action {
+        StartupWindowControlAction::Minimize => {
+            window.minimize().map_err(|error| {
+                format!("Failed to minimize main window during startup: {}", error)
+            })?;
+        }
+        StartupWindowControlAction::ToggleMaximize => {
+            let is_maximized = window.is_maximized().unwrap_or(false);
+            if is_maximized {
+                window.unmaximize().map_err(|error| {
+                    format!("Failed to restore main window during startup: {}", error)
+                })?;
+            } else {
+                window.maximize().map_err(|error| {
+                    format!("Failed to maximize main window during startup: {}", error)
+                })?;
+            }
+        }
+        StartupWindowControlAction::Close => {
+            let behavior = state
+                .config_service
+                .get_config::<String>(Some("app.close_button_behavior"))
+                .await
+                .unwrap_or_else(|_| "minimize_to_tray".to_string());
+
+            if behavior == "quit" {
+                log::info!("Quit requested from startup window control");
+                crate::crash_diagnostics::mark_clean_shutdown("startup_window_control");
+                crate::perform_process_exit_cleanup();
+                app.exit(0);
+            } else {
+                window.hide().map_err(|error| {
+                    format!("Failed to hide main window during startup close: {}", error)
+                })?;
+                log::info!("Main window hidden from startup window control");
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -995,6 +995,7 @@ pub async fn run() {
             send_system_notification,
             api::system_api::quit_app,
             api::system_api::minimize_to_tray,
+            api::system_api::startup_window_control,
             api::system_api::toggle_main_window_fullscreen,
             check_command_exists,
             check_commands_exist,

--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -272,8 +272,64 @@ impl ThemeConfig {
         theme_id
     }
 
+    fn load_startup_locale_from_config() -> String {
+        let path_manager = match try_get_path_manager_arc() {
+            Ok(pm) => pm,
+            Err(_) => return "zh-CN".to_string(),
+        };
+        let config_file = path_manager.app_config_file();
+        let Ok(config_content) = std::fs::read_to_string(config_file) else {
+            return "zh-CN".to_string();
+        };
+        let Ok(config_value) = serde_json::from_str::<serde_json::Value>(&config_content) else {
+            return "zh-CN".to_string();
+        };
+        config_value
+            .pointer("/app/language")
+            .and_then(|value| value.as_str())
+            .or_else(|| {
+                config_value
+                    .pointer("/i18n/currentLanguage")
+                    .and_then(|value| value.as_str())
+            })
+            .unwrap_or("zh-CN")
+            .to_string()
+    }
+
+    fn startup_messages_json(locale: &str) -> String {
+        let messages = match locale {
+            "en-US" | "en" => serde_json::json!({
+                "loadingApp": "Starting BitFun...",
+                "minimize": "Minimize",
+                "maximize": "Maximize",
+                "close": "Close",
+                "petLoading": "Loading companion..."
+            }),
+            "zh-TW" | "zh-Hant-TW" => serde_json::json!({
+                "loadingApp": "正在啟動 BitFun...",
+                "minimize": "最小化",
+                "maximize": "最大化",
+                "close": "關閉",
+                "petLoading": "正在載入助手..."
+            }),
+            _ => serde_json::json!({
+                "loadingApp": "正在启动 BitFun...",
+                "minimize": "最小化",
+                "maximize": "最大化",
+                "close": "关闭",
+                "petLoading": "正在加载助手..."
+            }),
+        };
+        messages.to_string()
+    }
+
     pub fn generate_init_script(&self, startup_trace_id: &str) -> String {
         let theme_type = if self.is_light { "light" } else { "dark" };
+        let startup_locale = Self::load_startup_locale_from_config();
+        let startup_locale_json =
+            serde_json::to_string(&startup_locale).unwrap_or_else(|_| "\"zh-CN\"".to_string());
+        let startup_messages_json = Self::startup_messages_json(&startup_locale);
+        let show_startup_window_controls = !cfg!(target_os = "macos");
         let startup_trace_id_json = serde_json::to_string(startup_trace_id)
             .unwrap_or_else(|_| "\"desktop-unknown\"".to_string());
         let perf_trace_enabled = cfg!(debug_assertions)
@@ -285,6 +341,9 @@ impl ThemeConfig {
             (function() {{
                 window.__BITFUN_STARTUP_TRACE_ID__ = {startup_trace_id_json};
                 window.__BITFUN_PERF_TRACE_ENABLED__ = {perf_trace_enabled};
+                window.__BITFUN_BOOTSTRAP_LOCALE__ = {startup_locale_json};
+                window.__BITFUN_BOOTSTRAP_MESSAGES__ = {startup_messages_json};
+                window.__BITFUN_SHOW_STARTUP_WINDOW_CONTROLS__ = {show_startup_window_controls};
                 function applyTheme() {{
                     var root = document.documentElement;
                     if (!root) return false;
@@ -329,6 +388,9 @@ impl ThemeConfig {
             text_primary = self.text_primary,
             startup_trace_id_json = startup_trace_id_json,
             perf_trace_enabled = perf_trace_enabled,
+            startup_locale_json = startup_locale_json,
+            startup_messages_json = startup_messages_json,
+            show_startup_window_controls = show_startup_window_controls,
         )
     }
 

--- a/src/web-ui/index.html
+++ b/src/web-ui/index.html
@@ -13,6 +13,45 @@
         var light = '#f3f3f5';
         var m = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
         var root = document.documentElement;
+        var fallbackMessages = {
+          'en-US': {
+            loadingApp: 'Starting BitFun...',
+            minimize: 'Minimize',
+            maximize: 'Maximize',
+            close: 'Close',
+            petLoading: 'Loading companion...'
+          },
+          'zh-CN': {
+            loadingApp: '正在启动 BitFun...',
+            minimize: '最小化',
+            maximize: '最大化',
+            close: '关闭',
+            petLoading: '正在加载助手...'
+          },
+          'zh-TW': {
+            loadingApp: '正在啟動 BitFun...',
+            minimize: '最小化',
+            maximize: '最大化',
+            close: '關閉',
+            petLoading: '正在載入助手...'
+          }
+        };
+        function resolveLocale() {
+          var injected = window.__BITFUN_BOOTSTRAP_LOCALE__;
+          var lang = typeof injected === 'string' && injected ? injected : navigator.language;
+          if (/^zh-(tw|hk|mo|hant)/i.test(lang)) return 'zh-TW';
+          if (/^en/i.test(lang)) return 'en-US';
+          return 'zh-CN';
+        }
+        function resolveMessages() {
+          var locale = resolveLocale();
+          var injected = window.__BITFUN_BOOTSTRAP_MESSAGES__;
+          return Object.assign({}, fallbackMessages[locale], injected || {});
+        }
+        window.__BITFUN_RESOLVE_BOOTSTRAP_MESSAGES__ = resolveMessages;
+        window.__BITFUN_RESOLVE_BOOTSTRAP_LOCALE__ = resolveLocale;
+        window.__BITFUN_STARTUP_OVERLAY_STARTED_AT__ = performance.now();
+        root.setAttribute('lang', resolveLocale());
         var bg = root.style.backgroundColor || (m && m.matches ? dark : light);
         root.style.setProperty('--bitfun-startup-bg', bg);
         root.style.backgroundColor = bg;
@@ -54,44 +93,342 @@
         background-color: inherit;
       }
 
-      #root {
+      #root,
+      #bitfun-startup-overlay {
         width: 100%;
         height: 100%;
       }
 
-      .bitfun-preload {
+      #bitfun-startup-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+      }
+
+      .bitfun-sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      .splash-screen {
         width: 100%;
         height: 100%;
         display: flex;
         align-items: center;
         justify-content: center;
         background: var(--bitfun-startup-bg, inherit);
+        color: rgba(143, 143, 153, 0.56);
+        font-family: "Noto Sans SC", "Inter", "Segoe UI", system-ui, sans-serif;
+        font-size: 13px;
+        pointer-events: none;
       }
 
+      #bitfun-startup-overlay.bitfun-startup-overlay--exiting {
+        animation: bitfun-startup-overlay-exit 0.5s ease-in-out both;
+      }
+
+      .bitfun-startup-window-controls {
+        position: fixed;
+        top: 8px;
+        right: 10px;
+        z-index: 2;
+        display: flex;
+        align-items: center;
+        gap: 2px;
+        opacity: 0.72;
+        pointer-events: auto;
+      }
+
+      .bitfun-startup-window-controls[hidden] {
+        display: none;
+      }
+
+      .bitfun-startup-window-controls__btn {
+        width: 28px;
+        height: 28px;
+        display: grid;
+        place-items: center;
+        padding: 0;
+        border: 1px solid transparent;
+        border-radius: 6px;
+        background: transparent;
+        color: rgba(143, 143, 153, 0.9);
+        cursor: pointer;
+        transition: background 0.15s ease, color 0.15s ease;
+      }
+
+      .bitfun-startup-window-controls__btn:hover {
+        background: rgba(143, 143, 153, 0.12);
+        color: rgba(143, 143, 153, 1);
+      }
+
+      .bitfun-startup-window-controls__btn--close:hover {
+        color: #ef4444;
+      }
+
+      .bitfun-startup-window-controls__glyph {
+        position: relative;
+        width: 12px;
+        height: 12px;
+        display: block;
+      }
+
+      .bitfun-startup-window-controls__glyph--minimize::before {
+        content: "";
+        position: absolute;
+        left: 2px;
+        right: 2px;
+        top: 6px;
+        height: 1.5px;
+        border-radius: 999px;
+        background: currentColor;
+      }
+
+      .bitfun-startup-window-controls__glyph--maximize::before {
+        content: "";
+        position: absolute;
+        inset: 2px;
+        border: 1.5px solid currentColor;
+        border-radius: 2px;
+      }
+
+      .bitfun-startup-window-controls__glyph--close::before,
+      .bitfun-startup-window-controls__glyph--close::after {
+        content: "";
+        position: absolute;
+        left: 2px;
+        right: 2px;
+        top: 5px;
+        height: 1.5px;
+        border-radius: 999px;
+        background: currentColor;
+      }
+
+      .bitfun-startup-window-controls__glyph--close::before {
+        transform: rotate(45deg);
+      }
+
+      .bitfun-startup-window-controls__glyph--close::after {
+        transform: rotate(-45deg);
+      }
+
+      .splash-screen__center {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .splash-screen__logo-wrap {
+        animation: splash-logo-idle 3.2s ease-in-out infinite;
+        -webkit-animation: splash-logo-idle 3.2s ease-in-out infinite;
+        will-change: filter, opacity, transform;
+      }
+
+      .splash-screen__logo,
       .bitfun-preload__logo {
         display: block;
         width: 96px;
         height: 96px;
-        border-radius: 12px;
+        border-radius: 16px;
         user-select: none;
         -webkit-user-select: none;
+      }
+
+      .splash-screen__message {
+        position: absolute;
+        top: calc(100% + 16px);
+        left: 50%;
+        min-width: 220px;
+        max-width: min(360px, calc(100vw - 48px));
+        color: rgba(143, 143, 153, 0.72);
+        font-size: 12px;
+        line-height: 1.4;
+        text-align: center;
+        opacity: 0;
+        transform: translate(-50%, -2px);
+        transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+        pointer-events: none;
+      }
+
+      .splash-screen__message--visible {
+        opacity: 0.62;
+        transform: translate(-50%, 0);
+      }
+
+      @keyframes splash-logo-idle {
+        0%, 100% {
+          opacity: 0.42;
+          transform: scale(0.985);
+        }
+        50% {
+          opacity: 1;
+          transform: scale(1);
+        }
+      }
+
+      @keyframes bitfun-startup-overlay-exit {
+        from {
+          opacity: 1;
+        }
+        to {
+          opacity: 0;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .splash-screen__logo-wrap {
+          animation: none;
+        }
+
+        .splash-screen__logo {
+          filter: none;
+        }
+
+        .splash-screen__message {
+          transition: none;
+        }
+      }
+
+      .bitfun-pet-preload-body {
+        background: transparent !important;
+      }
+
+      .bitfun-pet-preload-body #root {
+        background: transparent;
+      }
+
+      .bitfun-pet-preload {
+        width: 100%;
+        height: 100%;
+        display: grid;
+        place-items: center;
+        background: transparent;
+        pointer-events: none;
+      }
+
+      .bitfun-pet-preload__sprite {
+        position: relative;
+        width: 48px;
+        height: 48px;
+        transform-origin: center bottom;
+        animation: bitfun-pet-preload-breathe 1.8s ease-in-out infinite;
+      }
+
+      @keyframes bitfun-pet-preload-breathe {
+        0%, 100% {
+          opacity: 0.58;
+          transform: scale(0.96);
+        }
+        50% {
+          opacity: 0.92;
+          transform: scale(1);
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .bitfun-pet-preload__sprite {
+          animation: none;
+        }
       }
     </style>
   </head>
 
   <body>
     <script type="module" src="/src/main.tsx"></script>
-    <div id="root">
-      <div class="bitfun-preload" aria-hidden="true">
-        <img
-          src="/Logo-ICON-128.png"
-          alt=""
-          class="bitfun-preload__logo"
-          draggable="false"
-          decoding="async"
-          fetchpriority="low"
-        />
+    <div id="root"></div>
+    <div id="bitfun-startup-overlay">
+      <div class="splash-screen" aria-hidden="true">
+        <div class="bitfun-startup-window-controls" data-startup-window-controls hidden>
+          <button class="bitfun-startup-window-controls__btn" type="button" data-startup-window-action="minimize">
+            <span class="bitfun-startup-window-controls__glyph bitfun-startup-window-controls__glyph--minimize" aria-hidden="true"></span>
+          </button>
+          <button class="bitfun-startup-window-controls__btn" type="button" data-startup-window-action="toggle_maximize">
+            <span class="bitfun-startup-window-controls__glyph bitfun-startup-window-controls__glyph--maximize" aria-hidden="true"></span>
+          </button>
+          <button class="bitfun-startup-window-controls__btn bitfun-startup-window-controls__btn--close" type="button" data-startup-window-action="close">
+            <span class="bitfun-startup-window-controls__glyph bitfun-startup-window-controls__glyph--close" aria-hidden="true"></span>
+          </button>
+        </div>
+        <div class="splash-screen__center">
+          <div class="splash-screen__logo-wrap">
+            <img
+              class="bitfun-preload__logo"
+              src="/Logo-ICON-128.png"
+              alt=""
+              draggable="false"
+              decoding="async"
+              fetchpriority="low"
+            />
+          </div>
+          <div class="splash-screen__message">Starting BitFun...</div>
+        </div>
       </div>
     </div>
+    <script>
+      (function () {
+        var params = new URLSearchParams(window.location.search);
+        var isPetWindow = params.get('bitfunWindow') === 'agent-companion';
+        var messages = window.__BITFUN_RESOLVE_BOOTSTRAP_MESSAGES__
+          ? window.__BITFUN_RESOLVE_BOOTSTRAP_MESSAGES__()
+          : { loadingApp: 'Starting BitFun...', minimize: 'Minimize', maximize: 'Maximize', close: 'Close', petLoading: 'Loading companion...' };
+        var locale = window.__BITFUN_RESOLVE_BOOTSTRAP_LOCALE__
+          ? window.__BITFUN_RESOLVE_BOOTSTRAP_LOCALE__()
+          : 'en-US';
+        document.documentElement.setAttribute('lang', locale);
+
+        if (isPetWindow) {
+          document.body.classList.add('bitfun-pet-preload-body');
+          var startupOverlay = document.getElementById('bitfun-startup-overlay');
+          if (startupOverlay) startupOverlay.remove();
+          var root = document.getElementById('root');
+          if (root) {
+            root.innerHTML = '<div class="bitfun-pet-preload"><div class="bitfun-pet-preload__sprite" aria-hidden="true"></div><span class="bitfun-sr-only"></span></div>';
+            var petStatus = root.querySelector('.bitfun-sr-only');
+            if (petStatus) petStatus.textContent = messages.petLoading;
+          }
+          return;
+        }
+
+        var hint = document.querySelector('.splash-screen__message');
+        if (hint) {
+          hint.textContent = messages.loadingApp;
+          window.setTimeout(function () {
+            hint.classList.add('splash-screen__message--visible');
+          }, 1200);
+        }
+
+        var controls = document.querySelector('[data-startup-window-controls]');
+        if (controls && window.__BITFUN_SHOW_STARTUP_WINDOW_CONTROLS__) {
+          controls.hidden = false;
+          var labels = {
+            minimize: messages.minimize,
+            toggle_maximize: messages.maximize,
+            close: messages.close
+          };
+          controls.querySelectorAll('[data-startup-window-action]').forEach(function (button) {
+            var action = button.getAttribute('data-startup-window-action');
+            var label = labels[action] || action;
+            button.setAttribute('aria-label', label);
+            button.setAttribute('title', label);
+            button.addEventListener('click', function (event) {
+              event.preventDefault();
+              event.stopPropagation();
+              var tauri = window.__TAURI_INTERNALS__;
+              if (!tauri || typeof tauri.invoke !== 'function') return;
+              tauri.invoke('startup_window_control', { request: { action: action } }).catch(function () {});
+            });
+          });
+        }
+      })();
+    </script>
   </body>
 </html>

--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -19,12 +19,16 @@ import { buildAgentCompanionActivity, subscribeAgentCompanionActivity } from '@/
 import { emitAgentCompanionActivity } from '@/flow_chat/services/AgentCompanionActivityBridge';
 import { BackgroundTaskCancelledError } from '@/shared/utils/backgroundTaskScheduler';
 import { useWorkspaceContext } from '../infrastructure/contexts/WorkspaceContext';
-import SplashScreen from './components/SplashScreen/SplashScreen';
 import { useGlobalSceneShortcuts } from './hooks/useGlobalSceneShortcuts';
 import { useDebugInspector } from '@/infrastructure/debug/useDebugInspector';
 import { openAgentCompanionSession } from './services/openAgentCompanionSession';
 import { useI18n } from '@/infrastructure/i18n';
 import { scheduleDeferredStartupSystems } from './startup/deferredStartupSystems';
+import {
+  getStartupOverlayElapsedMs,
+  hideStartupOverlay,
+  isStartupOverlayPresent,
+} from './startup/startupOverlay';
 
 // Toolbar Mode
 import { ToolbarModeProvider } from '../flow_chat';
@@ -45,16 +49,12 @@ const MIN_SPLASH_MS = 900;
 
 function App() {
   const { t } = useI18n('settings/basics');
-  const { t: tCommon } = useI18n('common');
 
   // Workspace loading state — drives splash exit timing
   const { loading: workspaceLoading } = useWorkspaceContext();
 
-  // Splash screen state
-  const [splashVisible, setSplashVisible] = useState(true);
-  const [splashExiting, setSplashExiting] = useState(false);
+  const [startupOverlayVisible, setStartupOverlayVisible] = useState(isStartupOverlayPresent);
   const hasAppDismissibleLayer = useHasDismissibleLayer('app');
-  const mountTimeRef = useRef(Date.now());
   const mainWindowShownRef = useRef(false);
   const interactiveShellReadyRef = useRef(false);
   const [interactiveShellReady, setInteractiveShellReady] = useState(false);
@@ -63,15 +63,21 @@ function App() {
   // time and then begin the exit animation.
   useEffect(() => {
     if (workspaceLoading) return;
-    const elapsed = Date.now() - mountTimeRef.current;
+    const elapsed = getStartupOverlayElapsedMs();
     const remaining = Math.max(0, MIN_SPLASH_MS - elapsed);
-    const timer = window.setTimeout(() => setSplashExiting(true), remaining);
-    return () => window.clearTimeout(timer);
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      void hideStartupOverlay().then(() => {
+        if (!cancelled) {
+          setStartupOverlayVisible(false);
+        }
+      });
+    }, remaining);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
   }, [workspaceLoading]);
-
-  const handleSplashExited = useCallback(() => {
-    setSplashVisible(false);
-  }, []);
 
   const showMainWindow = useCallback(async (reason: string) => {
     if (mainWindowShownRef.current) {
@@ -153,7 +159,7 @@ function App() {
 
   // If the early reveal path fails, keep the old post-splash show as a retry.
   useEffect(() => {
-    if (splashVisible) {
+    if (startupOverlayVisible) {
       return;
     }
 
@@ -162,7 +168,7 @@ function App() {
     }, 50);
 
     return () => window.clearTimeout(timer);
-  }, [splashVisible, verifyMainWindowVisible]);
+  }, [startupOverlayVisible, verifyMainWindowVisible]);
 
   // Safety net: if startup gets stuck, reveal the window so the user can see errors.
   useEffect(() => {
@@ -191,7 +197,7 @@ function App() {
   }, [interactiveShellReady]);
 
   useEffect(() => {
-    if (!interactiveShellReady || splashVisible) {
+    if (!interactiveShellReady || startupOverlayVisible) {
       return;
     }
 
@@ -220,7 +226,7 @@ function App() {
       disposed = true;
       editorWarmupHandle?.cancel();
     };
-  }, [interactiveShellReady, splashVisible]);
+  }, [interactiveShellReady, startupOverlayVisible]);
 
   useEffect(() => {
     if (!isTauriRuntime() || !interactiveShellReady) return;
@@ -449,14 +455,6 @@ function App() {
             {/* Announcement / feature-demo / tips system */}
             <AnnouncementProvider />
 
-            {/* Startup splash — sits above everything, exits once workspace is ready */}
-            {splashVisible && (
-              <SplashScreen
-                isExiting={splashExiting}
-                onExited={handleSplashExited}
-                delayedMessage={workspaceLoading ? tCommon('loading.workspace') : undefined}
-              />
-            )}
           </ToolbarModeProvider>
         </SSHRemoteProvider>
       </ViewModeProvider>

--- a/src/web-ui/src/app/components/SplashScreen/SplashScreen.scss
+++ b/src/web-ui/src/app/components/SplashScreen/SplashScreen.scss
@@ -65,8 +65,8 @@
   left: 50%;
   min-width: 220px;
   max-width: min(360px, calc(100vw - 48px));
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary, rgba(143, 143, 153, 0.72));
+  font-size: var(--font-size-xs);
   line-height: 1.4;
   text-align: center;
   opacity: 0;
@@ -78,7 +78,7 @@
 }
 
 .splash-screen__message--visible {
-  opacity: 1;
+  opacity: 0.62;
   transform: translate(-50%, 0);
 }
 
@@ -86,10 +86,12 @@
 
 // Idle logo: soft opacity pulse with a slight breathing scale
 @keyframes splash-logo-idle {
-  0%, 100% {
-    opacity: 0.85;
-    transform: scale(0.98);
+  0%,
+  100% {
+    opacity: 0.42;
+    transform: scale(0.985);
   }
+
   50% {
     opacity: 1;
     transform: scale(1);
@@ -107,6 +109,10 @@
 @media (prefers-reduced-motion: reduce) {
   .splash-screen__logo-wrap {
     animation: none;
+  }
+
+  .splash-screen__logo {
+    filter: none;
   }
 
   .splash-screen__message {

--- a/src/web-ui/src/app/components/SplashScreen/SplashScreen.test.tsx
+++ b/src/web-ui/src/app/components/SplashScreen/SplashScreen.test.tsx
@@ -29,13 +29,13 @@ describe('SplashScreen', () => {
     dom.window.close();
   });
 
-  it('reveals the workspace loading message only after the delay', () => {
+  it('reveals the subtle startup hint only after the delay', () => {
     act(() => {
       root.render(
         <SplashScreen
           isExiting={false}
           onExited={() => {}}
-          delayedMessage="Loading workspace..."
+          delayedMessage="Starting BitFun..."
           delayedMessageMs={1000}
         />
       );
@@ -52,17 +52,17 @@ describe('SplashScreen', () => {
       vi.advanceTimersByTime(1);
     });
     const message = container.querySelector('.splash-screen__message');
-    expect(message?.textContent).toBe('Loading workspace...');
+    expect(message?.textContent).toBe('Starting BitFun...');
     expect(message?.classList.contains('splash-screen__message--visible')).toBe(true);
   });
 
-  it('does not reveal the workspace loading message during the normal startup splash window by default', () => {
+  it('does not reveal the subtle startup hint during the normal startup splash window by default', () => {
     act(() => {
       root.render(
         <SplashScreen
           isExiting={false}
           onExited={() => {}}
-          delayedMessage="Loading workspace..."
+          delayedMessage="Starting BitFun..."
         />
       );
     });
@@ -87,7 +87,7 @@ describe('SplashScreen', () => {
         <SplashScreen
           isExiting={true}
           onExited={() => {}}
-          delayedMessage="Loading workspace..."
+          delayedMessage="Starting BitFun..."
           delayedMessageMs={1000}
         />
       );

--- a/src/web-ui/src/app/startup/startupOverlay.test.ts
+++ b/src/web-ui/src/app/startup/startupOverlay.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getStartupOverlayElapsedMs,
+  hideStartupOverlay,
+  isStartupOverlayPresent,
+} from './startupOverlay';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  delete window.__BITFUN_STARTUP_OVERLAY_STARTED_AT__;
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('startupOverlay', () => {
+  it('fades and removes the existing startup overlay', async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '<div id="bitfun-startup-overlay"></div>';
+
+    const hidden = hideStartupOverlay();
+
+    const overlay = document.getElementById('bitfun-startup-overlay');
+    expect(overlay?.classList.contains('bitfun-startup-overlay--exiting')).toBe(true);
+    expect(overlay?.getAttribute('aria-hidden')).toBe('true');
+
+    await vi.advanceTimersByTimeAsync(650);
+    await hidden;
+
+    expect(isStartupOverlayPresent()).toBe(false);
+  });
+
+  it('tracks elapsed time from the static overlay first paint', () => {
+    vi.spyOn(performance, 'now').mockReturnValue(1500);
+    window.__BITFUN_STARTUP_OVERLAY_STARTED_AT__ = 1200;
+
+    expect(getStartupOverlayElapsedMs()).toBe(300);
+  });
+});

--- a/src/web-ui/src/app/startup/startupOverlay.ts
+++ b/src/web-ui/src/app/startup/startupOverlay.ts
@@ -1,0 +1,47 @@
+const STARTUP_OVERLAY_ID = 'bitfun-startup-overlay';
+const EXIT_CLASS = 'bitfun-startup-overlay--exiting';
+const DEFAULT_EXIT_MS = 650;
+
+declare global {
+  interface Window {
+    __BITFUN_STARTUP_OVERLAY_STARTED_AT__?: number;
+  }
+}
+
+function getOverlay(): HTMLElement | null {
+  return document.getElementById(STARTUP_OVERLAY_ID);
+}
+
+export function getStartupOverlayElapsedMs(): number {
+  const startedAt = window.__BITFUN_STARTUP_OVERLAY_STARTED_AT__;
+  if (typeof startedAt !== 'number') {
+    return 0;
+  }
+  return Math.max(0, performance.now() - startedAt);
+}
+
+export function isStartupOverlayPresent(): boolean {
+  return getOverlay() !== null;
+}
+
+export function hideStartupOverlay(): Promise<void> {
+  const overlay = getOverlay();
+  if (!overlay) {
+    return Promise.resolve();
+  }
+
+  if (overlay.classList.contains(EXIT_CLASS)) {
+    return new Promise(resolve => {
+      window.setTimeout(resolve, DEFAULT_EXIT_MS);
+    });
+  }
+
+  overlay.classList.add(EXIT_CLASS);
+  overlay.setAttribute('aria-hidden', 'true');
+  return new Promise(resolve => {
+    window.setTimeout(() => {
+      overlay.remove();
+      resolve();
+    }, DEFAULT_EXIT_MS);
+  });
+}

--- a/src/web-ui/src/app/startup/startupPreload.test.ts
+++ b/src/web-ui/src/app/startup/startupPreload.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
+
+function readIndexHtml(): string {
+  return readFileSync(fileURLToPath(new URL('../../../index.html', import.meta.url)), 'utf8');
+}
+
+describe('startup preload shell', () => {
+  it('uses injected startup locale text and wires static window controls', () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    const dom = new JSDOM(readIndexHtml(), {
+      url: 'http://localhost:1422/',
+      runScripts: 'dangerously',
+      beforeParse(window) {
+        Object.assign(window, {
+          __BITFUN_BOOTSTRAP_LOCALE__: 'zh-CN',
+          __BITFUN_BOOTSTRAP_MESSAGES__: {
+            loadingApp: '正在启动 BitFun...',
+            minimize: '最小化',
+            maximize: '最大化',
+            close: '关闭',
+          },
+          __BITFUN_SHOW_STARTUP_WINDOW_CONTROLS__: true,
+          __TAURI_INTERNALS__: { invoke },
+        });
+      },
+    });
+
+    const hint = dom.window.document.querySelector('.splash-screen__message');
+    expect(dom.window.document.documentElement.lang).toBe('zh-CN');
+    expect(dom.window.document.getElementById('root')?.childElementCount).toBe(0);
+    expect(dom.window.document.getElementById('bitfun-startup-overlay')).not.toBeNull();
+    expect(hint?.textContent).toBe('正在启动 BitFun...');
+
+    const controls = dom.window.document.querySelector<HTMLElement>('[data-startup-window-controls]');
+    expect(controls?.hidden).toBe(false);
+
+    const closeButton = dom.window.document.querySelector<HTMLButtonElement>('[data-startup-window-action="close"]');
+    expect(closeButton?.getAttribute('aria-label')).toBe('关闭');
+    closeButton?.click();
+
+    expect(invoke).toHaveBeenCalledWith('startup_window_control', {
+      request: { action: 'close' },
+    });
+  });
+
+  it('shows the independent pet preload for the companion window', () => {
+    const html = readIndexHtml();
+    const dom = new JSDOM(html, {
+      url: 'http://localhost:1422/?bitfunWindow=agent-companion',
+      runScripts: 'dangerously',
+      beforeParse(window) {
+        Object.assign(window, {
+          __BITFUN_BOOTSTRAP_LOCALE__: 'en-US',
+          __BITFUN_BOOTSTRAP_MESSAGES__: {
+            petLoading: 'Loading companion...',
+          },
+        });
+      },
+    });
+
+    expect(dom.window.document.body.classList.contains('bitfun-pet-preload-body')).toBe(true);
+    expect(dom.window.document.getElementById('bitfun-startup-overlay')).toBeNull();
+    expect(dom.window.document.querySelector('.bitfun-pet-preload__sprite')).not.toBeNull();
+    expect(dom.window.document.querySelector('.splash-screen__logo')).toBeNull();
+    expect(dom.window.document.querySelector('.bitfun-sr-only')?.textContent).toBe('Loading companion...');
+    const spriteCss = html.match(/\.bitfun-pet-preload__sprite \{(?<css>[\s\S]*?)\n      \}/)?.groups?.css;
+    expect(spriteCss).toBeDefined();
+    expect(spriteCss).not.toContain('background:');
+    expect(spriteCss).not.toContain('border:');
+    expect(spriteCss).not.toContain('box-shadow:');
+  });
+});

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -904,6 +904,7 @@
     "panelView": "Panel View"
   },
   "loading": {
+    "app": "Starting BitFun...",
     "scenes": "Loading scene",
     "workspace": "Loading workspace..."
   },

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -904,6 +904,7 @@
     "panelView": "面板视图"
   },
   "loading": {
+    "app": "正在启动 BitFun...",
     "scenes": "正在加载场景",
     "workspace": "正在加载工作区..."
   },

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -904,6 +904,7 @@
     "panelView": "面板視圖"
   },
   "loading": {
+    "app": "正在啟動 BitFun...",
     "scenes": "正在載入場景",
     "workspace": "正在載入工作區..."
   },


### PR DESCRIPTION
## Summary
- replace the pre-React workspace spinner with a single startup overlay outside the React root
- let React fade out the existing overlay instead of remounting a second splash state
- add localized bootstrap copy, startup window controls, and transparent companion preload handling

## Verification
- pnpm --dir src/web-ui run test:run src/app/components/SplashScreen/SplashScreen.test.tsx src/app/startup/startupPreload.test.ts src/app/startup/startupOverlay.test.ts
- pnpm run type-check:web
- pnpm run i18n:audit
- cargo check -p bitfun-desktop
- git diff --check