### PR TITLE
refactor(i18n): reduce fallback and format debt

### DIFF
--- a/scripts/i18n-literal-fallback-baseline.json
+++ b/scripts/i18n-literal-fallback-baseline.json
@@ -83,33 +83,6 @@
       }
     },
     {
-      "path": "src/web-ui/src/flow_chat/components/modern/ForkSessionButton.tsx",
-      "literalDefaultValues": {
-        "flow-chat:modelRound.forkDialog": 1,
-        "flow-chat:modelRound.forkFailed": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/flow_chat/components/modern/SessionFileModificationsBar.tsx",
-      "literalDefaultValues": {
-        "flow-chat:sessionFileModificationsBar.deepReviewSource": 1,
-        "flow-chat:sessionFileModificationsBar.reviewSource": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/flow_chat/components/ScrollToTurnHeaderButton.tsx",
-      "literalDefaultValues": {
-        "flow-chat:scroll.toCurrentTurn": 2
-      }
-    },
-    {
-      "path": "src/web-ui/src/flow_chat/components/StickyTaskIndicator.tsx",
-      "literalDefaultValues": {
-        "flow-chat:stickyTaskIndicator.tooltip": 1,
-        "flow-chat:toolCards.taskTool.defaultAgentKind": 1
-      }
-    },
-    {
       "path": "src/web-ui/src/flow_chat/components/TaskDetailPanel/TaskDetailPanel.tsx",
       "literalDefaultValues": {
         "flow-chat:toolCards.taskDetailPanel.stoppingSubagent": 1,
@@ -119,122 +92,10 @@
       }
     },
     {
-      "path": "src/web-ui/src/flow_chat/deep-review/action-bar/DecisionExecutionGate.tsx",
-      "literalDefaultValues": {
-        "flow-chat:deepReviewActionBar.decisionGate.cancel": 1,
-        "flow-chat:deepReviewActionBar.decisionGate.description": 1,
-        "flow-chat:deepReviewActionBar.decisionGate.missingSelection": 1,
-        "flow-chat:deepReviewActionBar.decisionGate.noOptionsHint": 1,
-        "flow-chat:deepReviewActionBar.decisionGate.supplementLabel": 1,
-        "flow-chat:deepReviewActionBar.decisionGate.supplementPlaceholder": 1,
-        "flow-chat:deepReviewActionBar.decisionGate.title": 1,
-        "flow-chat:toolCards.codeReview.remediationActions.recommended": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/flow_chat/deep-review/action-bar/PartialResultsPanel.tsx",
-      "literalDefaultValues": {
-        "flow-chat:deepReviewActionBar.hidePartialResults": 1,
-        "flow-chat:deepReviewActionBar.partialIssues": 1,
-        "flow-chat:deepReviewActionBar.partialRemediationItems": 1,
-        "flow-chat:deepReviewActionBar.partialResultsDescription": 1,
-        "flow-chat:deepReviewActionBar.partialReviewerSummaries": 1,
-        "flow-chat:deepReviewActionBar.viewPartialResults": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/flow_chat/deep-review/action-bar/RecoveryPlanPreview.tsx",
-      "literalDefaultValues": {
-        "flow-chat:deepReviewActionBar.recoveryPreserve": 1,
-        "flow-chat:deepReviewActionBar.recoveryRerun": 1,
-        "flow-chat:deepReviewActionBar.recoverySkip": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/flow_chat/deep-review/action-bar/RemediationSelectionPanel.tsx",
-      "literalDefaultValues": {
-        "flow-chat:deepReviewActionBar.remediationStatus.fixed": 1,
-        "flow-chat:deepReviewActionBar.remediationStatus.fixing": 1,
-        "flow-chat:reviewActionBar.needsDecisionTag": 1,
-        "flow-chat:toolCards.codeReview.remediationActions.collapseOptions": 1,
-        "flow-chat:toolCards.codeReview.remediationActions.expandOptions": 1,
-        "flow-chat:toolCards.codeReview.remediationActions.noSelectionHint": 1,
-        "flow-chat:toolCards.codeReview.remediationActions.recommended": 1,
-        "flow-chat:toolCards.codeReview.remediationActions.selectionCount": 1,
-        "flow-chat:toolCards.codeReview.remediationActions.ungrouped": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts",
-      "literalDefaultValues": {
-        "flow-chat:chatInput.goalAchieved": 1,
-        "flow-chat:chatInput.goalVerifyFailed": 1,
-        "flow-chat:chatInput.goalVerifying": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/flow_chat/services/openBtwSession.ts",
-      "literalDefaultValues": {
-        "flow-chat:btw.threadLabel": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/flow_chat/tool-cards/ContextCompressionDisplay.tsx",
-      "literalDefaultValues": {
-        "flow-chat:toolCards.contextCompression.noSummaryNotice": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/flow_chat/tool-cards/GetFileDiffDisplay.tsx",
-      "literalDefaultValues": {
-        "flow-chat:toolCards.getFileDiff.diffFile": 1,
-        "flow-chat:toolCards.getFileDiff.failed": 2,
-        "flow-chat:toolCards.getFileDiff.gettingDiff": 1,
-        "flow-chat:toolCards.getFileDiff.preparing": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx",
-      "literalDefaultValues": {
-        "flow-chat:toolCards.readFile.permissionRequest": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.tsx",
-      "literalDefaultValues": {
-        "flow-chat:toolCards.timeout.cancelledDurationTooltip": 1,
-        "flow-chat:toolCards.timeout.completedDurationTooltip": 1,
-        "flow-chat:toolCards.timeout.durationTooltip": 1,
-        "flow-chat:toolCards.timeout.failedDurationTooltip": 1,
-        "flow-chat:toolCards.timeout.failedDurationTooltipWithReason": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/infrastructure/config/components/AppearanceConfig.tsx",
-      "literalDefaultValues": {
-        "settings/basics:appearance.languageRowHint": 1,
-        "settings/basics:appearance.themeRowHint": 1
-      }
-    },
-    {
       "path": "src/web-ui/src/infrastructure/config/components/ReviewConfig.tsx",
       "literalDefaultValues": {
         "settings/default-model:selection.fast": 2,
         "settings/default-model:selection.primary": 2
-      }
-    },
-    {
-      "path": "src/web-ui/src/infrastructure/config/components/SkillsConfig.tsx",
-      "literalDefaultValues": {
-        "settings/skills:filters.project": 1,
-        "settings/skills:filters.user": 1
-      }
-    },
-    {
-      "path": "src/web-ui/src/tools/editor/components/MarkdownEditor.tsx",
-      "literalDefaultValues": {
-        "tools:editor.markdownEditor.copiedMarkdown": 4,
-        "tools:editor.markdownEditor.copyMarkdown": 4
       }
     }
   ]

--- a/scripts/i18n-locale-format-baseline.json
+++ b/scripts/i18n-locale-format-baseline.json
@@ -1,14 +1,5 @@
 {
   "version": 1,
   "description": "Temporary no-growth baseline for direct locale formatting calls outside the shared i18n formatting APIs. Lower this file when callers move to i18n-owned format helpers.",
-  "budgets": [
-    {
-      "path": "src/crates/core/src/miniapp/builtin/assets/coding-selfie/ui.js",
-      "maxLocaleFormatCalls": 1
-    },
-    {
-      "path": "src/crates/core/src/miniapp/builtin/assets/pr-review/ui.js",
-      "maxLocaleFormatCalls": 1
-    }
-  ]
+  "budgets": []
 }

--- a/src/crates/core/src/miniapp/builtin/assets/coding-selfie/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/coding-selfie/ui.js
@@ -373,6 +373,10 @@ function fmtDay(d) {
   const dt = new Date(d);
   return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`;
 }
+function fmtClock(d) {
+  const dt = new Date(d);
+  return `${String(dt.getHours()).padStart(2, '0')}:${String(dt.getMinutes()).padStart(2, '0')}:${String(dt.getSeconds()).padStart(2, '0')}`;
+}
 function relativeTime(iso) {
   const diff = Math.max(0, Date.now() - new Date(iso).getTime());
   const m = Math.floor(diff / 60000);
@@ -755,7 +759,7 @@ function renderHero(data, range, current) {
   const timeEl = $('meta-time');
   if (timeEl) {
     timeEl.textContent = `${String(snap.getHours()).padStart(2, '0')}:${String(snap.getMinutes()).padStart(2, '0')}`;
-    timeEl.parentElement.title = t('snapTimeTitle')(snap.toLocaleTimeString());
+    timeEl.parentElement.title = t('snapTimeTitle')(fmtClock(snap));
   }
 
   const isToday = range.kind === '1d';

--- a/src/crates/core/src/miniapp/builtin/assets/pr-review/ui.js
+++ b/src/crates/core/src/miniapp/builtin/assets/pr-review/ui.js
@@ -3800,12 +3800,12 @@ function formatDate(value) {
   if (!value) return '--';
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return new Intl.DateTimeFormat(state.locale, {
-    month: 'short',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(date);
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  const hh = String(date.getHours()).padStart(2, '0');
+  const min = String(date.getMinutes()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd} ${hh}:${min}`;
 }
 
 function textSnippet(value, limit = 120) {

--- a/src/web-ui/src/flow_chat/components/ScrollToTurnHeaderButton.tsx
+++ b/src/web-ui/src/flow_chat/components/ScrollToTurnHeaderButton.tsx
@@ -31,11 +31,11 @@ export const ScrollToTurnHeaderButton: React.FC<ScrollToTurnHeaderButtonProps> =
     >
       <div className="scroll-to-turn-header-trigger__gradient" />
       <div className="scroll-to-turn-header-trigger__content">
-        <Tooltip content={turnLabel || t('scroll.toCurrentTurn', { defaultValue: 'Jump to current turn' })}>
+        <Tooltip content={turnLabel || t('scroll.toCurrentTurn')}>
           <button
             className="scroll-to-turn-header-trigger__btn"
             onClick={onClick}
-            aria-label={turnLabel || t('scroll.toCurrentTurn', { defaultValue: 'Jump to current turn' })}
+            aria-label={turnLabel || t('scroll.toCurrentTurn')}
             tabIndex={visible ? 0 : -1}
           >
             <svg

--- a/src/web-ui/src/flow_chat/components/StickyTaskIndicator.tsx
+++ b/src/web-ui/src/flow_chat/components/StickyTaskIndicator.tsx
@@ -25,10 +25,8 @@ export const StickyTaskIndicator: React.FC<StickyTaskIndicatorProps> = ({
 }) => {
   const { t } = useTranslation('flow-chat');
 
-  const label = taskInfo?.label || t('toolCards.taskTool.defaultAgentKind', { defaultValue: 'Task' });
-  const tooltip = t('stickyTaskIndicator.tooltip', {
-    defaultValue: 'Jump to current task',
-  });
+  const label = taskInfo?.label || t('toolCards.taskTool.defaultAgentKind');
+  const tooltip = t('stickyTaskIndicator.tooltip');
 
   return (
     <div

--- a/src/web-ui/src/flow_chat/components/modern/ForkSessionButton.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ForkSessionButton.tsx
@@ -37,7 +37,7 @@ export const ForkSessionButton: React.FC<ForkSessionButtonProps> = ({
     } catch (error) {
       log.error('Failed to fork session', { sessionId, turnId, error });
       notificationService.error(
-        t('modelRound.forkFailed', { defaultValue: 'Failed to fork session' }),
+        t('modelRound.forkFailed'),
         { duration: 3500 }
       );
     } finally {
@@ -51,7 +51,7 @@ export const ForkSessionButton: React.FC<ForkSessionButtonProps> = ({
 
   return (
     <Tooltip
-      content={t('modelRound.forkDialog', { defaultValue: 'Fork session from here' })}
+      content={t('modelRound.forkDialog')}
       placement="top"
     >
       <button

--- a/src/web-ui/src/flow_chat/components/modern/SessionFileModificationsBar.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/SessionFileModificationsBar.tsx
@@ -389,8 +389,8 @@ export const SessionFileModificationsBar: React.FC<SessionFileModificationsBarPr
                 {stat.sourceKind !== 'parent' ? (
                   <span className="file-row__source">
                     {stat.sourceKind === 'deep_review'
-                      ? t('sessionFileModificationsBar.deepReviewSource', { defaultValue: 'Deep review' })
-                      : t('sessionFileModificationsBar.reviewSource', { defaultValue: 'Review' })}
+                      ? t('sessionFileModificationsBar.deepReviewSource')
+                      : t('sessionFileModificationsBar.reviewSource')}
                   </span>
                 ) : null}
 

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/DecisionExecutionGate.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/DecisionExecutionGate.tsx
@@ -35,14 +35,10 @@ export const DecisionExecutionGate: React.FC<DecisionExecutionGateProps> = ({
         <AlertTriangle size={16} className="deep-review-action-bar__decision-gate-icon" />
         <div>
           <div className="deep-review-action-bar__decision-gate-title">
-            {t('deepReviewActionBar.decisionGate.title', {
-              defaultValue: 'Confirm decision items before fixing',
-            })}
+            {t('deepReviewActionBar.decisionGate.title')}
           </div>
           <div className="deep-review-action-bar__decision-gate-desc">
-            {t('deepReviewActionBar.decisionGate.description', {
-              defaultValue: 'Choose how each selected decision should be handled before BitFun starts editing.',
-            })}
+            {t('deepReviewActionBar.decisionGate.description')}
           </div>
         </div>
       </div>
@@ -87,7 +83,7 @@ export const DecisionExecutionGate: React.FC<DecisionExecutionGateProps> = ({
                         </span>
                         <span className="deep-review-action-bar__decision-gate-option-text">
                           {option}
-                          {isRecommended ? ` (${t('toolCards.codeReview.remediationActions.recommended', { defaultValue: 'recommended' })})` : ''}
+                          {isRecommended ? ` (${t('toolCards.codeReview.remediationActions.recommended')})` : ''}
                         </span>
                       </button>
                     );
@@ -95,9 +91,7 @@ export const DecisionExecutionGate: React.FC<DecisionExecutionGateProps> = ({
                 </div>
               ) : (
                 <div className="deep-review-action-bar__decision-gate-note">
-                  {t('deepReviewActionBar.decisionGate.noOptionsHint', {
-                    defaultValue: 'This item has no structured options. Confirm only if you want the selected plan to be executed as written.',
-                  })}
+                  {t('deepReviewActionBar.decisionGate.noOptionsHint')}
                 </div>
               )}
             </section>
@@ -107,25 +101,19 @@ export const DecisionExecutionGate: React.FC<DecisionExecutionGateProps> = ({
 
       <label className="deep-review-action-bar__decision-gate-supplement">
         <span>
-          {t('deepReviewActionBar.decisionGate.supplementLabel', {
-            defaultValue: 'Additional requirements',
-          })}
+          {t('deepReviewActionBar.decisionGate.supplementLabel')}
         </span>
         <textarea
           value={customInstructions}
           onChange={(event) => onCustomInstructionsChange(event.target.value)}
-          placeholder={t('deepReviewActionBar.decisionGate.supplementPlaceholder', {
-            defaultValue: 'Optional: add constraints, scope limits, or implementation preferences before starting.',
-          })}
+          placeholder={t('deepReviewActionBar.decisionGate.supplementPlaceholder')}
           rows={2}
         />
       </label>
 
       {confirmDisabled && (
         <div className="deep-review-action-bar__decision-gate-warning" role="note">
-          {t('deepReviewActionBar.decisionGate.missingSelection', {
-            defaultValue: 'Choose an option for each selected decision item before starting.',
-          })}
+          {t('deepReviewActionBar.decisionGate.missingSelection')}
         </div>
       )}
 
@@ -138,18 +126,14 @@ export const DecisionExecutionGate: React.FC<DecisionExecutionGateProps> = ({
         >
           {t(rerunReview
             ? 'deepReviewActionBar.decisionGate.confirmFixAndReview'
-            : 'deepReviewActionBar.decisionGate.confirmFix', {
-            defaultValue: rerunReview ? 'Confirm and re-review' : 'Confirm and start',
-          })}
+            : 'deepReviewActionBar.decisionGate.confirmFix')}
         </Button>
         <Button
           variant="secondary"
           size="small"
           onClick={onCancel}
         >
-          {t('deepReviewActionBar.decisionGate.cancel', {
-            defaultValue: 'Back to selection',
-          })}
+          {t('deepReviewActionBar.decisionGate.cancel')}
         </Button>
       </div>
     </div>

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/PartialResultsPanel.test.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/PartialResultsPanel.test.tsx
@@ -3,12 +3,23 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 import { PartialResultsPanel } from './PartialResultsPanel';
 
+const messages: Record<string, string> = {
+  'deepReviewActionBar.hidePartialResults': 'Hide partial results',
+  'deepReviewActionBar.partialIssues': '{{count}} issues found',
+  'deepReviewActionBar.partialRemediationItems': '{{count}} remediation items',
+  'deepReviewActionBar.partialResultsDescription': '{{completed}}/{{total}} reviewers completed',
+  'deepReviewActionBar.partialReviewerSummaries': '{{count}} reviewer summaries',
+  'deepReviewActionBar.viewPartialResults': 'View partial results',
+};
+
+function t(key: string, options?: Record<string, unknown> & { defaultValue?: string }): string {
+  const template = messages[key] ?? options?.defaultValue ?? key;
+  return template.replace(/{{(\w+)}}/g, (_match, token: string) => String(options?.[token] ?? _match));
+}
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (_key: string, options?: Record<string, unknown> & { defaultValue?: string }) => {
-      const template = options?.defaultValue ?? _key;
-      return template.replace(/{{(\w+)}}/g, (_match, token: string) => String(options?.[token] ?? _match));
-    },
+    t,
   }),
 }));
 

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/PartialResultsPanel.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/PartialResultsPanel.tsx
@@ -31,7 +31,6 @@ export const PartialResultsPanel: React.FC<PartialResultsPanelProps> = ({
             {t('deepReviewActionBar.partialResultsDescription', {
               completed: progressSummary.completed,
               total: progressSummary.total,
-              defaultValue: '{{completed}}/{{total}} reviewers completed',
             })}
           </span>
           <button
@@ -41,8 +40,8 @@ export const PartialResultsPanel: React.FC<PartialResultsPanelProps> = ({
           >
             <Eye size={12} />
             {showPartialResults
-              ? t('deepReviewActionBar.hidePartialResults', { defaultValue: 'Hide partial results' })
-              : t('deepReviewActionBar.viewPartialResults', { defaultValue: 'View partial results' })}
+              ? t('deepReviewActionBar.hidePartialResults')
+              : t('deepReviewActionBar.viewPartialResults')}
           </button>
         </div>
       )}
@@ -54,7 +53,6 @@ export const PartialResultsPanel: React.FC<PartialResultsPanelProps> = ({
               <span className="deep-review-action-bar__partial-section-title">
                 {t('deepReviewActionBar.partialIssues', {
                   count: partialResults.completedIssues.length,
-                  defaultValue: '{{count}} issues found',
                 })}
               </span>
             </div>
@@ -64,7 +62,6 @@ export const PartialResultsPanel: React.FC<PartialResultsPanelProps> = ({
               <span className="deep-review-action-bar__partial-section-title">
                 {t('deepReviewActionBar.partialRemediationItems', {
                   count: partialResults.completedRemediationItems.length,
-                  defaultValue: '{{count}} remediation items',
                 })}
               </span>
             </div>
@@ -74,7 +71,6 @@ export const PartialResultsPanel: React.FC<PartialResultsPanelProps> = ({
               <span className="deep-review-action-bar__partial-section-title">
                 {t('deepReviewActionBar.partialReviewerSummaries', {
                   count: partialResults.completedReviewerSummaries.length,
-                  defaultValue: '{{count}} reviewer summaries',
                 })}
               </span>
               <ul className="deep-review-action-bar__partial-list">

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/RecoveryPlanPreview.test.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/RecoveryPlanPreview.test.tsx
@@ -3,12 +3,20 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 import { RecoveryPlanPreview } from './RecoveryPlanPreview';
 
+const messages: Record<string, string> = {
+  'deepReviewActionBar.recoveryPreserve': '{{count}} completed reviewers will be preserved',
+  'deepReviewActionBar.recoveryRerun': '{{count}} reviewers will be rerun',
+  'deepReviewActionBar.recoverySkip': '{{count}} reviewers will be skipped',
+};
+
+function t(key: string, options?: Record<string, unknown> & { defaultValue?: string }): string {
+  const template = messages[key] ?? options?.defaultValue ?? key;
+  return template.replace(/{{(\w+)}}/g, (_match, token: string) => String(options?.[token] ?? _match));
+}
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (_key: string, options?: Record<string, unknown> & { defaultValue?: string }) => {
-      const template = options?.defaultValue ?? _key;
-      return template.replace(/{{(\w+)}}/g, (_match, token: string) => String(options?.[token] ?? _match));
-    },
+    t,
   }),
 }));
 

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/RecoveryPlanPreview.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/RecoveryPlanPreview.tsx
@@ -25,7 +25,6 @@ export const RecoveryPlanPreview: React.FC<RecoveryPlanPreviewProps> = ({
             <span>
               {t('deepReviewActionBar.recoveryPreserve', {
                 count: recoveryPlan.willPreserve.length,
-                defaultValue: '{{count}} completed reviewers will be preserved',
               })}
             </span>
           </div>
@@ -36,7 +35,6 @@ export const RecoveryPlanPreview: React.FC<RecoveryPlanPreviewProps> = ({
             <span>
               {t('deepReviewActionBar.recoveryRerun', {
                 count: recoveryPlan.willRerun.length,
-                defaultValue: '{{count}} reviewers will be rerun',
               })}
             </span>
           </div>
@@ -47,7 +45,6 @@ export const RecoveryPlanPreview: React.FC<RecoveryPlanPreviewProps> = ({
             <span>
               {t('deepReviewActionBar.recoverySkip', {
                 count: recoveryPlan.willSkip.length,
-                defaultValue: '{{count}} reviewers will be skipped',
               })}
             </span>
           </div>

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/RemediationSelectionPanel.test.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/RemediationSelectionPanel.test.tsx
@@ -5,12 +5,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RemediationSelectionPanel } from './RemediationSelectionPanel';
 import type { ReviewRemediationItem } from '../../utils/codeReviewRemediation';
 
+const messages: Record<string, string> = {
+  'deepReviewActionBar.remediationStatus.fixed': 'Fixed',
+  'deepReviewActionBar.remediationStatus.fixing': 'Fixing',
+  'reviewActionBar.needsDecisionTag': 'Decision',
+  'toolCards.codeReview.remediationActions.collapseOptions': 'Hide options',
+  'toolCards.codeReview.remediationActions.expandOptions': 'Show options',
+  'toolCards.codeReview.remediationActions.noSelectionHint': 'Select at least one remediation item to start fixing.',
+  'toolCards.codeReview.remediationActions.recommended': 'recommended',
+  'toolCards.codeReview.remediationActions.selectionCount': '{{selected}}/{{total}} selected',
+  'toolCards.codeReview.remediationActions.ungrouped': 'Other',
+};
+
+function t(key: string, options?: Record<string, unknown> & { defaultValue?: string }): string {
+  const template = messages[key] ?? options?.defaultValue ?? key;
+  return template.replace(/{{(\w+)}}/g, (_match, token: string) => String(options?.[token] ?? _match));
+}
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (_key: string, options?: Record<string, unknown> & { defaultValue?: string }) => {
-      const template = options?.defaultValue ?? _key;
-      return template.replace(/{{(\w+)}}/g, (_match, token: string) => String(options?.[token] ?? _match));
-    },
+    t,
   }),
 }));
 

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/RemediationSelectionPanel.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/RemediationSelectionPanel.tsx
@@ -108,7 +108,6 @@ export const RemediationSelectionPanel: React.FC<RemediationSelectionPanelProps>
           {t('toolCards.codeReview.remediationActions.selectionCount', {
             selected: selectedCount,
             total: totalCount,
-            defaultValue: '{{selected}}/{{total}} selected',
           })}
         </span>
         {showRemediationList ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
@@ -128,7 +127,7 @@ export const RemediationSelectionPanel: React.FC<RemediationSelectionPanelProps>
             const groupAllSelected = groupTotalCount > 0 && groupSelectedCount === groupTotalCount;
             const groupPartial = groupSelectedCount > 0 && !groupAllSelected;
             const groupTitle = groupId === 'ungrouped'
-              ? t('toolCards.codeReview.remediationActions.ungrouped', { defaultValue: 'Other' })
+              ? t('toolCards.codeReview.remediationActions.ungrouped')
               : t(`toolCards.codeReview.groups.${groupId}`, { defaultValue: groupId });
             const groupMeta = groupId !== 'ungrouped' ? GROUP_PRIORITY_META[groupId as RemediationGroupId] : undefined;
 
@@ -195,13 +194,13 @@ export const RemediationSelectionPanel: React.FC<RemediationSelectionPanelProps>
                           {(isCompleted || isFixing) && (
                             <span className="deep-review-action-bar__remediation-status">
                               {isCompleted
-                                ? t('deepReviewActionBar.remediationStatus.fixed', { defaultValue: 'Fixed' })
-                                : t('deepReviewActionBar.remediationStatus.fixing', { defaultValue: 'Fixing' })}
+                                ? t('deepReviewActionBar.remediationStatus.fixed')
+                                : t('deepReviewActionBar.remediationStatus.fixing')}
                             </span>
                           )}
                           {item.requiresDecision && (
                             <span className="deep-review-action-bar__remediation-tag">
-                              {t('reviewActionBar.needsDecisionTag', { defaultValue: 'Decision' })}
+                              {t('reviewActionBar.needsDecisionTag')}
                             </span>
                           )}
                           {item.groupId === 'verification' ? (
@@ -243,8 +242,8 @@ export const RemediationSelectionPanel: React.FC<RemediationSelectionPanelProps>
                               }}
                             >
                               {expandedDecisionIds.has(item.id)
-                                ? t('toolCards.codeReview.remediationActions.collapseOptions', { defaultValue: 'Hide options' })
-                                : t('toolCards.codeReview.remediationActions.expandOptions', { defaultValue: 'Show options' })}
+                                ? t('toolCards.codeReview.remediationActions.collapseOptions')
+                                : t('toolCards.codeReview.remediationActions.expandOptions')}
                             </button>
                           )}
                           {expandedDecisionIds.has(item.id) && item.decisionContext?.options && (
@@ -267,7 +266,7 @@ export const RemediationSelectionPanel: React.FC<RemediationSelectionPanelProps>
                                       </span>
                                       <span className="deep-review-action-bar__decision-option-text">
                                         {opt}
-                                        {isRecommended ? ` (${t('toolCards.codeReview.remediationActions.recommended', { defaultValue: 'recommended' })})` : ''}
+                                        {isRecommended ? ` (${t('toolCards.codeReview.remediationActions.recommended')})` : ''}
                                       </span>
                                     </button>
                                   </li>
@@ -290,9 +289,7 @@ export const RemediationSelectionPanel: React.FC<RemediationSelectionPanelProps>
         <div className="deep-review-action-bar__empty-selection" role="note">
           <Info size={14} className="deep-review-action-bar__empty-selection-icon" />
           <span>
-            {t('toolCards.codeReview.remediationActions.noSelectionHint', {
-              defaultValue: 'Select at least one remediation item to start fixing.',
-            })}
+            {t('toolCards.codeReview.remediationActions.noSelectionHint')}
           </span>
         </div>
       )}

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -1980,9 +1980,7 @@ function handleGoalVerificationStartedEvent(event: any): void {
 
   handleGoalVerificationStarted(
     { sessionId: payload.sessionId, sourceTurnId: payload.sourceTurnId },
-    i18nService.t('flow-chat:chatInput.goalVerifying', {
-      defaultValue: 'Checking if the session goal is met...',
-    }),
+    i18nService.t('flow-chat:chatInput.goalVerifying'),
   );
 }
 
@@ -2000,12 +1998,8 @@ function handleGoalVerificationFinishedEvent(event: any): void {
       outcome: payload.outcome,
     },
     {
-      achievedTitle: i18nService.t('flow-chat:chatInput.goalAchieved', {
-        defaultValue: 'Session goal achieved',
-      }),
-      failedMessage: i18nService.t('flow-chat:chatInput.goalVerifyFailed', {
-        defaultValue: 'Goal verification failed. Check model configuration and try again.',
-      }),
+      achievedTitle: i18nService.t('flow-chat:chatInput.goalAchieved'),
+      failedMessage: i18nService.t('flow-chat:chatInput.goalVerifyFailed'),
     },
   );
 }

--- a/src/web-ui/src/flow_chat/services/openBtwSession.ts
+++ b/src/web-ui/src/flow_chat/services/openBtwSession.ts
@@ -35,7 +35,7 @@ const resolveBtwSessionTitle = (childSessionId: string): string => {
     ? resolveSessionTitle(session, (key, options) => i18nService.t(key, options))
     : undefined;
   if (title) return title;
-  return i18nService.t('flow-chat:btw.threadLabel', { defaultValue: 'Side thread' });
+  return i18nService.t('flow-chat:btw.threadLabel');
 };
 
 const scheduleFrame = (callback: FrameRequestCallback): void => {

--- a/src/web-ui/src/flow_chat/tool-cards/ContextCompressionDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ContextCompressionDisplay.tsx
@@ -158,9 +158,7 @@ export const ContextCompressionDisplay: React.FC<ContextCompressionDisplayProps>
 
     return (
       <div className="compression-detail-note">
-        {t('toolCards.contextCompression.noSummaryNotice', {
-          defaultValue: 'No additional summary was generated for this compaction pass.',
-        })}
+        {t('toolCards.contextCompression.noSummaryNotice')}
       </div>
     );
   };

--- a/src/web-ui/src/flow_chat/tool-cards/GetFileDiffDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GetFileDiffDisplay.tsx
@@ -129,15 +129,15 @@ export const GetFileDiffDisplay: React.FC<ToolCardProps> = React.memo(({
 
   const getActionText = () => {
     if (isFailed) {
-      return t('toolCards.getFileDiff.failed', { defaultValue: 'Diff failed' });
+      return t('toolCards.getFileDiff.failed');
     }
     if (status === 'running' || status === 'streaming') {
-      return t('toolCards.getFileDiff.gettingDiff', { defaultValue: 'Getting diff' });
+      return t('toolCards.getFileDiff.gettingDiff');
     }
     if (status === 'pending' || status === 'preparing') {
-      return t('toolCards.getFileDiff.preparing', { defaultValue: 'Preparing diff' });
+      return t('toolCards.getFileDiff.preparing');
     }
-    return t('toolCards.getFileDiff.diffFile', { defaultValue: 'Diff' });
+    return t('toolCards.getFileDiff.diffFile');
   };
 
   const renderHeader = () => (
@@ -222,7 +222,7 @@ export const GetFileDiffDisplay: React.FC<ToolCardProps> = React.memo(({
   const renderErrorContent = () => (
     <div className="error-content">
       <div className="error-message">
-        {t('toolCards.getFileDiff.failed', { defaultValue: 'Failed to get file diff' })}
+        {t('toolCards.getFileDiff.failed')}
       </div>
     </div>
   );

--- a/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.test.tsx
@@ -9,12 +9,16 @@ import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
+const messages: Record<string, string> = {
+  'toolCards.readFile.permissionRequest': 'Requesting read permission:',
+};
+
 vi.mock('react-i18next', async () => {
   const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next');
   return {
     ...actual,
     useTranslation: () => ({
-      t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+      t: (key: string, options?: { defaultValue?: string }) => messages[key] ?? options?.defaultValue ?? key,
     }),
   };
 });

--- a/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx
@@ -138,7 +138,7 @@ export const ReadFileDisplay: React.FC<ToolCardProps> = React.memo(({
     if (showConfirmationActions || status === 'pending_confirmation') {
       return (
         <>
-          {t('toolCards.readFile.permissionRequest', { defaultValue: 'Requesting read permission:' })} {permissionTargetPath}
+          {t('toolCards.readFile.permissionRequest')} {permissionTargetPath}
           {lineRange && <span className="read-file-meta"> {lineRange}</span>}
         </>
       );

--- a/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.tsx
@@ -126,27 +126,22 @@ export const ToolTimeoutIndicator: React.FC<ToolTimeoutIndicatorProps> = ({
       completedStatus === 'success'
         ? t('toolCards.timeout.completedDurationTooltip', {
           duration: durationLabel,
-          defaultValue: `Completed in ${durationLabel}`,
         })
         : completedStatus === 'error'
           ? completedFailureReason
             ? t('toolCards.timeout.failedDurationTooltipWithReason', {
               duration: durationLabel,
               reason: completedFailureReason,
-              defaultValue: `Failed after ${durationLabel}: ${completedFailureReason}`,
             })
             : t('toolCards.timeout.failedDurationTooltip', {
               duration: durationLabel,
-              defaultValue: `Failed after ${durationLabel}`,
             })
           : completedStatus === 'cancelled'
             ? t('toolCards.timeout.cancelledDurationTooltip', {
               duration: durationLabel,
-              defaultValue: `Cancelled after ${durationLabel}`,
             })
             : t('toolCards.timeout.durationTooltip', {
               duration: durationLabel,
-              defaultValue: `Duration ${durationLabel}`,
             })
     );
 

--- a/src/web-ui/src/infrastructure/config/components/AppearanceConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AppearanceConfig.tsx
@@ -65,9 +65,7 @@ function AppearanceThemeSection() {
         <ConfigPageSection title={t('appearance.title')} description={t('appearance.hint')}>
           <ConfigPageRow
             label={t('appearance.language')}
-            description={t('appearance.languageRowHint', {
-              defaultValue: 'Choose one language pack as the active UI language.',
-            })}
+            description={t('appearance.languageRowHint')}
             align="center"
           >
             <div className="theme-config__language-select">
@@ -87,9 +85,7 @@ function AppearanceThemeSection() {
           </ConfigPageRow>
           <ConfigPageRow
             label={t('appearance.themes')}
-            description={t('appearance.themeRowHint', {
-              defaultValue: 'Choose the interface color theme.',
-            })}
+            description={t('appearance.themeRowHint')}
             align="center"
           >
             <div className="theme-config__theme-picker">

--- a/src/web-ui/src/infrastructure/config/components/SkillsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SkillsConfig.tsx
@@ -598,7 +598,7 @@ const SkillsConfig: React.FC = () => {
         </ConfigPageSection>
 
         <ConfigPageSection
-          title={t('filters.user', { defaultValue: 'User Skills' })}
+          title={t('filters.user')}
           description={t('section.user.description')}
           extra={makeAddExtra('user')}
         >
@@ -614,7 +614,7 @@ const SkillsConfig: React.FC = () => {
         </ConfigPageSection>
 
         <ConfigPageSection
-          title={t('filters.project', { defaultValue: 'Project Skills' })}
+          title={t('filters.project')}
           description={t('section.project.description')}
           extra={makeAddExtra('project')}
         >

--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.test.tsx
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.test.tsx
@@ -50,9 +50,14 @@ vi.mock('../meditor/utils/tiptapMarkdown', () => ({
   }),
 }));
 
+const messages: Record<string, string> = {
+  'editor.markdownEditor.copiedMarkdown': 'Copied Markdown',
+  'editor.markdownEditor.copyMarkdown': 'Copy Markdown',
+};
+
 vi.mock('@/infrastructure/i18n', () => ({
   useI18n: () => ({
-    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+    t: (key: string, options?: { defaultValue?: string }) => messages[key] ?? options?.defaultValue ?? key,
   }),
 }));
 

--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.tsx
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.tsx
@@ -690,11 +690,11 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               className="bitfun-markdown-editor__toolbar-button bitfun-markdown-editor__copy-button"
               onClick={() => void handleCopyMarkdown()}
               aria-label={copied
-                ? t('editor.markdownEditor.copiedMarkdown', { defaultValue: 'Copied Markdown' })
-                : t('editor.markdownEditor.copyMarkdown', { defaultValue: 'Copy Markdown' })}
+                ? t('editor.markdownEditor.copiedMarkdown')
+                : t('editor.markdownEditor.copyMarkdown')}
               title={copied
-                ? t('editor.markdownEditor.copiedMarkdown', { defaultValue: 'Copied Markdown' })
-                : t('editor.markdownEditor.copyMarkdown', { defaultValue: 'Copy Markdown' })}
+                ? t('editor.markdownEditor.copiedMarkdown')
+                : t('editor.markdownEditor.copyMarkdown')}
             >
               {copied ? <Check size={13} /> : <Copy size={13} />}
             </Button>
@@ -798,11 +798,11 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
             className="bitfun-markdown-editor__toolbar-button bitfun-markdown-editor__copy-button"
             onClick={() => void handleCopyMarkdown()}
             aria-label={copied
-              ? t('editor.markdownEditor.copiedMarkdown', { defaultValue: 'Copied Markdown' })
-              : t('editor.markdownEditor.copyMarkdown', { defaultValue: 'Copy Markdown' })}
+              ? t('editor.markdownEditor.copiedMarkdown')
+              : t('editor.markdownEditor.copyMarkdown')}
             title={copied
-              ? t('editor.markdownEditor.copiedMarkdown', { defaultValue: 'Copied Markdown' })
-              : t('editor.markdownEditor.copyMarkdown', { defaultValue: 'Copy Markdown' })}
+              ? t('editor.markdownEditor.copiedMarkdown')
+              : t('editor.markdownEditor.copyMarkdown')}
           >
             {copied ? <Check size={13} /> : <Copy size={13} />}
           </Button>


### PR DESCRIPTION
﻿Related: #959

## Summary
- Removed low-risk literal `defaultValue` fallbacks from flow-chat tool cards, deep-review action controls, settings rows, and the Markdown editor so static copy resolves from locale resources.
- Replaced the remaining direct built-in miniapp locale formatting calls with stable numeric date/time formatting and lowered the locale-format baseline to zero.
- Lowered the literal fallback baseline to the remaining owned debt surface and updated affected tests with explicit translation dictionaries.

## Key metrics
| Metric | Before | After | Change |
|---|---:|---:|---:|
| Literal fallback candidates | 149 | 87 | -62 |
| Direct locale-format candidates | 2 | 0 | -2 |
| l10n quality candidates | 768 | 768 | 0 |
| Shared-term duplicate candidates | 201 | 201 | 0 |
| Dynamic key candidates | 193 | 193 | 0 |

## Risk / compatibility
- Static UI copy now depends on the checked-in locale resources instead of component-local literal fallbacks; `i18n:audit` validates the affected static keys.
- Built-in PR review miniapp timestamps now render as stable `YYYY-MM-DD HH:mm` instead of browser locale-specific month/day text. This removes unowned direct formatting calls, but richer locale-specific date styling should move through a shared miniapp formatting contract later.
- Remaining literal fallback debt is intentionally scoped to `ReviewTeamPage`, `FlowChatHeader`, `AgentsScene`, `TaskDetailPanel`, and `ReviewConfig`.

## Validation
- `pnpm run i18n:audit`
- `pnpm run i18n:contract:test:ci`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run`
- `pnpm run check:repo-hygiene`
- `git diff --check`
- `pnpm run lint:web` (passes with the existing `startupTrace.ts` unused eslint-disable warnings)
