### PR TITLE
refactor(core): move GetToolSpec owner into product runtime

### DIFF
--- a/docs/architecture/core-decomposition.md
+++ b/docs/architecture/core-decomposition.md
@@ -258,7 +258,8 @@ scheduler lifecycle、session manager、prompt loop 和 subagent registry 仍未
 它只消费 `ToolExecutionServices` 这类窄 service 视图，不直接创建 filesystem、Git、terminal、MCP 等具体实现。
 当前相关 crate 包括 `tool-runtime`、`bitfun-agent-tools`、`bitfun-tool-packs` 以及 `bitfun-core`
 中的 tool materialization 代码。deterministic execution admission gate 已由 `bitfun-agent-tools` 承接；
-`bitfun-core` 的 pipeline 仍负责状态更新、registry lookup、input validation、confirmation、实际执行和 hook。
+`GetToolSpecTool` concrete adapter 已收敛到 `bitfun-core` 的 product runtime owner。`bitfun-core`
+的 pipeline 仍负责状态更新、registry lookup、input validation、confirmation、实际执行和 hook。
 
 ### 7.7 运行时服务层（Runtime Services）
 

--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -31,7 +31,7 @@
 明确未完成：
 
 - remote-SSH runtime、remote FS / terminal、workspace-root source、persistence / workspace service reads、`ImageContextData` concrete impl 仍未迁移。
-- `ToolUseContext`、runtime manifest / `GetToolSpecTool` execution、collapsed unlock state、concrete tools 仍未迁移。
+- `ToolUseContext`、runtime manifest、collapsed unlock state、concrete tools 仍未迁移。
 - MiniApp filesystem IO / worker / host dispatch / builtin asset runtime、function-agent Git / AI concrete service 仍未迁移。
 - agent registry / scheduler 仍未迁移。
 
@@ -75,11 +75,14 @@
   message、allowed-list gate、runtime restriction gate 和 collapsed-tool unlock gate。
 - `bitfun-core` 的 tool pipeline 已删除对应常量、历史结构、循环检测算法和三段准入分支，只保留状态更新、日志、错误映射、
   registry lookup、input validation、confirmation、实际执行和 hook。
+- `GetToolSpecTool` concrete adapter 已从 generic concrete-tool implementations 目录迁入 `product_runtime`
+  owner；generic implementations 只保留兼容 re-export，on-demand spec discovery 的 product runtime 边界、
+  错误映射和 context section renderer 由同一 owner 管理。
 
 明确未完成：
 
-- `ToolUseContext` concrete service handles、product registry materialization、manifest / `GetToolSpecTool`
-  concrete adapter、snapshot wrapper、collapsed unlock persistence、具体 IO tools 仍未迁移。
+- `ToolUseContext` concrete service handles、product registry materialization、manifest resolver、snapshot wrapper、
+  collapsed unlock persistence、具体 IO tools 仍未迁移。
 
 ## 2. 已建立保护
 

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -69,7 +69,7 @@
 | PR3 | Agent Runtime SDK Owner | 拆分 mode-scoped subagent visibility、agent registry facts、queue policy decision、scheduler submit/cancel facts 和 background delivery 边界；concrete scheduler 生命周期按保护程度逐步外移 | remote provider、tool IO、product-domain IO、默认 feature 调整 | subagent 可见性、queue/preempt/cancel、background reply、DeepResearch hook 等价 |
 | PR4 | Harness / Product Capability Boundary | 建立 Harness provider contract，让 Deep Review、DeepResearch、MiniApp 等 workflow 通过 provider 注册，不侵入 Agent Runtime SDK | concrete service IO、tool IO、surface 命令语义变更 | 至少两个 workflow 可通过 provider contract 表达，旧路径兼容 |
 | PR5 | Product-Domain Runtime Owner | MiniApp filesystem IO / worker / host / builtin seed 或 function-agent Git/AI 中完成一个完整 owner 主题，建立最小 port/provider 和 core adapter | tool runtime、service/agent runtime、surface 行为变更 | MiniApp/function-agent focused regression，PathManager/process/Git/AI 边界清晰 |
-| PR6 | Tool Runtime Owner | 已完成 deterministic execution admission gate：tool-call loop、allowed-list、runtime restriction、collapsed unlock 的准入策略迁移到 `bitfun-agent-tools`，core pipeline 删除旧算法和分支 | service/agent runtime、product-domain runtime、feature matrix、产品行为变更 | tool pipeline focused tests、`bitfun-agent-tools` contract tests、boundary check |
+| PR6 | Tool Runtime Owner | 已完成 deterministic execution admission gate 和 `GetToolSpecTool` product runtime owner closure：core pipeline 删除旧准入算法和分支，generic implementations 不再拥有 GetToolSpec concrete adapter | service/agent runtime、product-domain runtime、feature matrix、产品行为变更 | tool pipeline focused tests、product runtime focused tests、`bitfun-agent-tools` contract tests、boundary check |
 | PR7 | Feature / Build-Benefit Evaluation | 评估 feature matrix、dependency profile、no-default 编译面和构建收益数据，确认是否具备收敛默认 feature 的条件 | runtime owner 迁移、default feature 副作用、构建脚本变更 | cargo metadata / cargo tree 证据，产品入口完整能力不变 |
 
 ### 4.1 PR1 具体实施计划
@@ -174,8 +174,10 @@ PR4 不迁移 concrete service IO、tool IO、surface command 语义、session m
 ### 5.4 Tool Runtime Owner
 
 - 已完成 deterministic execution admission gate 迁移；core 仅保留状态更新、registry lookup、input validation、confirmation、实际执行和 hook。
-- 后续不直接搬全部 concrete tools。只在 manifest/catalog snapshot、`GetToolSpec` concrete adapter、snapshot wrapper、
-  collapsed unlock persistence 或具体工具 IO 中选择能减少旧路径的完整 owner。
+- 已完成 `GetToolSpecTool` concrete adapter 的 product runtime owner closure；generic concrete-tool implementations
+  只保留兼容 re-export，不再拥有 on-demand spec discovery Tool impl。
+- 后续不直接搬全部 concrete tools。只在 manifest/catalog snapshot、snapshot wrapper、collapsed unlock persistence
+  或具体工具 IO 中选择能减少旧路径的完整 owner。
 - 保留 tool name、schema、prompt stub、readonly/enabled/filtering、unlock state 生命周期。
 - 验证 builtin tool list、provider order、expanded/collapsed exposure、dynamic provider metadata、Deep Review 修改类工具 checkpoint hook。
 

--- a/scripts/check-core-boundaries.mjs
+++ b/scripts/check-core-boundaries.mjs
@@ -2096,6 +2096,36 @@ const forbiddenContentUnderRules = [
       },
     ],
   },
+  {
+    path: 'src/crates/core/src/agentic/tools/implementations',
+    reason:
+      'GetToolSpec concrete adapter belongs in the product tool runtime owner, not the generic concrete-tool implementations module',
+    patterns: [
+      {
+        regex: /\bpub(?:\(crate\))? struct GetToolSpecTool\b/,
+        message: 'move GetToolSpecTool into core product_runtime owner',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/core/src/agentic/tools/pipeline',
+    reason:
+      'core pipeline must delegate deterministic tool execution admission policy to bitfun-agent-tools',
+    patterns: [
+      {
+        regex: /\bvalidate_tool_allowed_by_list\s*\(/,
+        message: 'allowed-list admission must stay behind validate_tool_execution_admission',
+      },
+      {
+        regex: /\bruntime_tool_restrictions\s*\.\s*ensure_tool_allowed\s*\(/,
+        message: 'runtime-restriction admission must stay behind validate_tool_execution_admission',
+      },
+      {
+        regex: /\bvalidate_collapsed_tool_usage\s*\(/,
+        message: 'collapsed-tool admission must stay behind validate_tool_execution_admission',
+      },
+    ],
+  },
 ];
 
 const requiredContentRules = [
@@ -4213,12 +4243,12 @@ const requiredContentRules = [
     ],
   },
   {
-    path: 'src/crates/core/src/agentic/tools/implementations/get_tool_spec_tool.rs',
+    path: 'src/crates/core/src/agentic/tools/product_runtime/get_tool_spec_tool.rs',
     reason:
-      'core must continue owning the GetToolSpec Tool adapter and product boundary while delegating generic runtime surface to agent-tools',
+      'product runtime must own the GetToolSpec Tool adapter while delegating generic runtime surface to agent-tools',
     patterns: [
       {
-        regex: /\bpub struct GetToolSpecTool\b/,
+        regex: /\bpub(?:\(crate\))? struct GetToolSpecTool\b/,
         message: 'missing GetToolSpec owner type',
       },
       {
@@ -7533,7 +7563,7 @@ function runManifestParserSelfTest() {
       ],
     },
     {
-      path: 'src/crates/core/src/agentic/tools/implementations/get_tool_spec_tool.rs',
+      path: 'src/crates/core/src/agentic/tools/product_runtime/get_tool_spec_tool.rs',
       contracts: [
         'GetToolSpecTool',
         'build_collapsed_tools_context_section',

--- a/src/crates/core/AGENTS.md
+++ b/src/crates/core/AGENTS.md
@@ -52,7 +52,10 @@ SessionManager → Session → DialogTurn → ModelRound
   provider-neutral contracts through `tool_adapter.rs`, and keep product
   registry snapshot access, product manifest / GetToolSpec facade wiring,
   product snapshot wrapper adapter injection, on-demand spec discovery Tool
-  impl, and unlock-state source in that product runtime owner for now.
+  impl, and unlock-state source in `product_runtime.rs` / `product_runtime/`
+  for now. Do not move `GetToolSpecTool` ownership back into generic
+  concrete-tool implementations; a legacy re-export is only a compatibility
+  alias.
   `bitfun-tool-packs` may expose planned
   feature-group scaffold metadata, but it must not own concrete tools yet.
 - Keep `ToolUseContext` and concrete tool implementations in core unless a

--- a/src/crates/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/core/src/agentic/execution/execution_engine.rs
@@ -22,7 +22,8 @@ use crate::agentic::image_analysis::{
 use crate::agentic::round_preempt::RoundInjectionKind;
 use crate::agentic::session::{CompressionMode, ContextCompressor, SessionManager};
 use crate::agentic::skill_agent_snapshot::build_skill_agent_tool_listing_sections_from_snapshot;
-use crate::agentic::tools::implementations::{GetToolSpecTool, SkillTool, TaskTool};
+use crate::agentic::tools::implementations::{SkillTool, TaskTool};
+use crate::agentic::tools::product_runtime::GetToolSpecTool;
 use crate::agentic::tools::{resolve_tool_manifest, tool_context_runtime, ResolvedToolManifest};
 use crate::agentic::WorkspaceBinding;
 use crate::infrastructure::ai::get_global_ai_client_factory;

--- a/src/crates/core/src/agentic/skill_agent_snapshot.rs
+++ b/src/crates/core/src/agentic/skill_agent_snapshot.rs
@@ -2,9 +2,9 @@ use crate::agentic::agents::{
     get_agent_registry, PromptBuilder, SubagentListScope, SubagentQueryContext,
     ToolListingSections, UserContextPolicy,
 };
-use crate::agentic::tools::implementations::get_tool_spec_tool::GetToolSpecTool;
 use crate::agentic::tools::implementations::skills::{get_skill_registry, SkillInfo};
 use crate::agentic::tools::manifest_resolver::{resolve_tool_manifest, ResolvedToolManifest};
+use crate::agentic::tools::product_runtime::GetToolSpecTool;
 use crate::agentic::tools::tool_context_runtime;
 use crate::agentic::workspace::WorkspaceServices;
 use crate::agentic::WorkspaceBinding;

--- a/src/crates/core/src/agentic/tools/implementations/mod.rs
+++ b/src/crates/core/src/agentic/tools/implementations/mod.rs
@@ -21,7 +21,6 @@ pub mod file_read_tool;
 pub mod file_write_tool;
 pub mod generative_ui_tool;
 pub mod get_file_diff_tool;
-pub mod get_tool_spec_tool;
 pub mod git_tool;
 pub mod glob_tool;
 pub mod grep_tool;
@@ -42,6 +41,8 @@ pub mod todo_write_tool;
 pub mod util;
 pub mod web_tools;
 
+#[deprecated(note = "GetToolSpecTool is owned by the product tool runtime boundary")]
+pub use crate::agentic::tools::product_runtime::GetToolSpecTool;
 pub use ask_user_question_tool::AskUserQuestionTool;
 pub use bash_tool::BashTool;
 pub use code_review_tool::CodeReviewTool;
@@ -58,7 +59,6 @@ pub use file_read_tool::FileReadTool;
 pub use file_write_tool::FileWriteTool;
 pub use generative_ui_tool::GenerativeUITool;
 pub use get_file_diff_tool::GetFileDiffTool;
-pub use get_tool_spec_tool::GetToolSpecTool;
 pub use git_tool::GitTool;
 pub use glob_tool::GlobTool;
 pub use grep_tool::GrepTool;

--- a/src/crates/core/src/agentic/tools/mod.rs
+++ b/src/crates/core/src/agentic/tools/mod.rs
@@ -13,7 +13,8 @@ pub mod implementations;
 pub mod manifest_resolver;
 pub mod pipeline;
 pub(crate) mod post_call_hooks;
-pub(crate) mod product_runtime;
+#[doc(hidden)]
+pub mod product_runtime;
 pub mod registry;
 pub mod restrictions;
 pub(crate) mod tool_adapter;

--- a/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -1371,6 +1371,7 @@ impl ToolPipeline {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agentic::core::ToolExecutionState;
     use crate::agentic::events::{EventQueue, EventQueueConfig};
     use crate::agentic::tools::framework::Tool;
     use crate::agentic::tools::implementations::task_tool::TaskTool;
@@ -1385,34 +1386,56 @@ mod tests {
         ToolPipeline::new(registry, state_manager, None)
     }
 
+    fn test_tool_call(tool_id: &str, tool_name: &str) -> ToolCall {
+        ToolCall {
+            tool_id: tool_id.to_string(),
+            tool_name: tool_name.to_string(),
+            arguments: json!({ "path": "src/main.rs" }),
+            raw_arguments: None,
+            is_error: false,
+            recovered_from_truncation: false,
+        }
+    }
+
+    fn test_tool_execution_context() -> ToolExecutionContext {
+        ToolExecutionContext {
+            session_id: "session_1".to_string(),
+            dialog_turn_id: "turn_1".to_string(),
+            round_id: "round_1".to_string(),
+            agent_type: "agent".to_string(),
+            workspace: None,
+            context_vars: HashMap::new(),
+            subagent_parent_info: None,
+            delegation_policy: bitfun_runtime_ports::DelegationPolicy::top_level(),
+            collapsed_tools: Vec::new(),
+            unlocked_collapsed_tools: Vec::new(),
+            allowed_tools: Vec::new(),
+            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
+            steering_interrupt: None,
+            workspace_services: None,
+        }
+    }
+
     fn test_tool_task(tool_id: &str, tool_name: &str) -> ToolTask {
         ToolTask::new(
-            ToolCall {
-                tool_id: tool_id.to_string(),
-                tool_name: tool_name.to_string(),
-                arguments: json!({ "path": "src/main.rs" }),
-                raw_arguments: None,
-                is_error: false,
-                recovered_from_truncation: false,
-            },
-            ToolExecutionContext {
-                session_id: "session_1".to_string(),
-                dialog_turn_id: "turn_1".to_string(),
-                round_id: "round_1".to_string(),
-                agent_type: "agent".to_string(),
-                workspace: None,
-                context_vars: HashMap::new(),
-                subagent_parent_info: None,
-                delegation_policy: bitfun_runtime_ports::DelegationPolicy::top_level(),
-                collapsed_tools: Vec::new(),
-                unlocked_collapsed_tools: Vec::new(),
-                allowed_tools: Vec::new(),
-                runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
-                steering_interrupt: None,
-                workspace_services: None,
-            },
+            test_tool_call(tool_id, tool_name),
+            test_tool_execution_context(),
             ToolExecutionOptions::default(),
         )
+    }
+
+    fn assert_failed_task_contains(pipeline: &ToolPipeline, tool_id: &str, expected: &str) {
+        let task = pipeline
+            .state_manager
+            .get_task(tool_id)
+            .unwrap_or_else(|| panic!("{tool_id} task should be retained"));
+        match task.state {
+            ToolExecutionState::Failed { error, .. } => assert!(
+                error.contains(expected),
+                "failed task error should contain '{expected}', got '{error}'"
+            ),
+            state => panic!("expected failed task state, got {state:?}"),
+        }
     }
 
     #[test]
@@ -1455,6 +1478,91 @@ mod tests {
             .as_deref()
             .unwrap_or_default()
             .contains("Provided arguments: {\"operation\":\"log\""));
+    }
+
+    #[tokio::test]
+    async fn pipeline_admission_allowed_list_rejection_updates_failed_state_before_registry_lookup()
+    {
+        let pipeline = test_tool_pipeline();
+        let mut context = test_tool_execution_context();
+        context.allowed_tools = vec!["Read".to_string()];
+
+        let results = pipeline
+            .execute_tools(
+                vec![test_tool_call("tool_1", "UnregisteredBlockedTool")],
+                context,
+                ToolExecutionOptions::default(),
+            )
+            .await
+            .expect("admission rejection should be returned as an error result");
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].result.is_error);
+        assert_failed_task_contains(
+            &pipeline,
+            "tool_1",
+            "Tool 'UnregisteredBlockedTool' is not in the allowed list",
+        );
+        assert!(
+            results[0]
+                .result
+                .result_for_assistant
+                .as_deref()
+                .unwrap_or_default()
+                .contains("UnregisteredBlockedTool"),
+            "error result should preserve rejected tool identity"
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_admission_runtime_restriction_rejection_updates_failed_state() {
+        let pipeline = test_tool_pipeline();
+        let mut context = test_tool_execution_context();
+        context
+            .runtime_tool_restrictions
+            .denied_tool_names
+            .insert("Read".to_string());
+
+        let results = pipeline
+            .execute_tools(
+                vec![test_tool_call("tool_1", "Read")],
+                context,
+                ToolExecutionOptions::default(),
+            )
+            .await
+            .expect("admission rejection should be returned as an error result");
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].result.is_error);
+        assert_failed_task_contains(
+            &pipeline,
+            "tool_1",
+            "Tool 'Read' is denied by runtime restrictions",
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_admission_collapsed_tool_rejection_updates_failed_state_before_validation() {
+        let pipeline = test_tool_pipeline();
+        let mut context = test_tool_execution_context();
+        context.collapsed_tools = vec!["WebFetch".to_string()];
+
+        let results = pipeline
+            .execute_tools(
+                vec![test_tool_call("tool_1", "WebFetch")],
+                context,
+                ToolExecutionOptions::default(),
+            )
+            .await
+            .expect("admission rejection should be returned as an error result");
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].result.is_error);
+        assert_failed_task_contains(
+            &pipeline,
+            "tool_1",
+            "Call GetToolSpec first with {\"tool_name\":\"WebFetch\"}",
+        );
     }
 
     #[test]

--- a/src/crates/core/src/agentic/tools/product_runtime.rs
+++ b/src/crates/core/src/agentic/tools/product_runtime.rs
@@ -5,6 +5,8 @@
 //! decoration. Concrete tools and `ToolUseContext` stay in core so this owner
 //! remains an equivalent structural boundary rather than a behavior migration.
 
+mod get_tool_spec_tool;
+
 use crate::agentic::agents::{get_agent_registry, AgentToolPolicyOverrides};
 use crate::agentic::tools::framework::{Tool, ToolExposure, ToolResult};
 use crate::agentic::tools::implementations::*;
@@ -24,6 +26,8 @@ use bitfun_agent_tools::{
 use bitfun_tool_packs::product_tool_provider_group_plan;
 use serde_json::Value;
 use std::sync::Arc;
+
+pub use get_tool_spec_tool::GetToolSpecTool;
 
 #[derive(Clone)]
 pub(crate) struct ProductToolRuntime {

--- a/src/crates/core/src/agentic/tools/product_runtime/get_tool_spec_tool.rs
+++ b/src/crates/core/src/agentic/tools/product_runtime/get_tool_spec_tool.rs
@@ -1,11 +1,11 @@
-//! GetToolSpec tool implementation
+//! Product Tool Runtime owned GetToolSpec concrete adapter.
 
-use crate::agentic::tools::framework::{
-    Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
-};
-use crate::agentic::tools::product_runtime::{
+use super::{
     product_get_tool_spec_runtime, resolve_product_get_tool_spec_results,
     ProductGetToolSpecRuntime, ProductToolCatalogProvider,
+};
+use crate::agentic::tools::framework::{
+    Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;


### PR DESCRIPTION
﻿## Summary

- Move the concrete `GetToolSpecTool` adapter from generic tool implementations into the core product tool runtime owner.
- Keep the old `implementations::GetToolSpecTool` path as a deprecated compatibility re-export while preventing the implementation from moving back.
- Add pipeline-level regression coverage for deterministic admission rejection state updates.
- Update core decomposition docs and core agent guidance to reflect the completed owner closure and remaining Tool Runtime work.

## Behavior and Compatibility

- Tool name, schema, readonly/concurrency/permission behavior, collapsed unlock semantics, and result shape are unchanged.
- The old public import path remains available through a deprecated alias; ownership now lives under the product runtime boundary.
- `product_runtime` is exposed as a hidden module only to preserve the compatibility re-export path, while its other owner internals remain crate-scoped.

## Review Notes

- Adversarial review caught one compatibility issue: removing the old public re-export would have made existing `implementations::GetToolSpecTool` imports fail. This PR keeps that path as a deprecated alias.
- The completed-work archive previously still listed `GetToolSpecTool execution` as unfinished; this PR removes that stale item.
- The added boundary checks prevent the core pipeline from reintroducing direct allowed-list, runtime-restriction, or collapsed-tool admission branches.

## Verification

- `cargo check -p bitfun-core --features product-full`
- `cargo check -p bitfun-core --no-default-features`
- `cargo test -p bitfun-core --features product-full agentic::tools::pipeline::tool_pipeline::tests -- --nocapture`
- `cargo test -p bitfun-core --features product-full agentic::tools::product_runtime -- --nocapture`
- `cargo test -p bitfun-agent-tools`
- `node scripts/check-core-boundaries.mjs`
- `pnpm run check:repo-hygiene`
- `git diff --check gcwing/main`
