### PR TITLE
refactor(core): move tool manifest owner into product runtime

### DIFF
--- a/docs/architecture/core-decomposition.md
+++ b/docs/architecture/core-decomposition.md
@@ -258,8 +258,9 @@ scheduler lifecycle、session manager、prompt loop 和 subagent registry 仍未
 它只消费 `ToolExecutionServices` 这类窄 service 视图，不直接创建 filesystem、Git、terminal、MCP 等具体实现。
 当前相关 crate 包括 `tool-runtime`、`bitfun-agent-tools`、`bitfun-tool-packs` 以及 `bitfun-core`
 中的 tool materialization 代码。deterministic execution admission gate 已由 `bitfun-agent-tools` 承接；
-`GetToolSpecTool` concrete adapter 已收敛到 `bitfun-core` 的 product runtime owner。`bitfun-core`
-的 pipeline 仍负责状态更新、registry lookup、input validation、confirmation、实际执行和 hook。
+`GetToolSpecTool` concrete adapter、manifest/catalog facade 和 snapshot wrapper 已收敛到 `bitfun-core` 的
+product runtime owner。`bitfun-core` 的 pipeline 仍负责状态更新、registry lookup、input validation、
+confirmation、实际执行和 hook。
 
 ### 7.7 运行时服务层（Runtime Services）
 

--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -78,11 +78,15 @@
 - `GetToolSpecTool` concrete adapter 已从 generic concrete-tool implementations 目录迁入 `product_runtime`
   owner；generic implementations 只保留兼容 re-export，on-demand spec discovery 的 product runtime 边界、
   错误映射和 context section renderer 由同一 owner 管理。
+- manifest / visible tools / readonly catalog / GetToolSpec catalog path 已收敛到 `product_runtime/catalog.rs`；
+  `manifest_resolver.rs` 仅保留旧路径兼容 facade 和 parity regression。
+- snapshot wrapper 已收敛到 `product_runtime/snapshot.rs`，避免 registry assembly、catalog 和 snapshot adapter
+  继续堆在同一 owner 文件。
 
 明确未完成：
 
-- `ToolUseContext` concrete service handles、product registry materialization、manifest resolver、snapshot wrapper、
-  collapsed unlock persistence、具体 IO tools 仍未迁移。
+- `ToolUseContext` concrete service handles、product registry materialization、collapsed unlock persistence、
+  具体 IO tools 仍未迁移。
 
 ## 2. 已建立保护
 

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -69,7 +69,7 @@
 | PR3 | Agent Runtime SDK Owner | 拆分 mode-scoped subagent visibility、agent registry facts、queue policy decision、scheduler submit/cancel facts 和 background delivery 边界；concrete scheduler 生命周期按保护程度逐步外移 | remote provider、tool IO、product-domain IO、默认 feature 调整 | subagent 可见性、queue/preempt/cancel、background reply、DeepResearch hook 等价 |
 | PR4 | Harness / Product Capability Boundary | 建立 Harness provider contract，让 Deep Review、DeepResearch、MiniApp 等 workflow 通过 provider 注册，不侵入 Agent Runtime SDK | concrete service IO、tool IO、surface 命令语义变更 | 至少两个 workflow 可通过 provider contract 表达，旧路径兼容 |
 | PR5 | Product-Domain Runtime Owner | MiniApp filesystem IO / worker / host / builtin seed 或 function-agent Git/AI 中完成一个完整 owner 主题，建立最小 port/provider 和 core adapter | tool runtime、service/agent runtime、surface 行为变更 | MiniApp/function-agent focused regression，PathManager/process/Git/AI 边界清晰 |
-| PR6 | Tool Runtime Owner | 已完成 deterministic execution admission gate 和 `GetToolSpecTool` product runtime owner closure：core pipeline 删除旧准入算法和分支，generic implementations 不再拥有 GetToolSpec concrete adapter | service/agent runtime、product-domain runtime、feature matrix、产品行为变更 | tool pipeline focused tests、product runtime focused tests、`bitfun-agent-tools` contract tests、boundary check |
+| PR6 | Tool Runtime Owner | 已完成 deterministic execution admission gate、`GetToolSpecTool` product runtime owner closure、manifest/catalog/snapshot owner closure：core pipeline 删除旧准入算法和分支，generic implementations 不再拥有 GetToolSpec concrete adapter，`manifest_resolver` 仅保留兼容 facade | service/agent runtime、product-domain runtime、feature matrix、产品行为变更 | tool pipeline focused tests、product runtime focused tests、manifest facade parity tests、`bitfun-agent-tools` contract tests、boundary check |
 | PR7 | Feature / Build-Benefit Evaluation | 评估 feature matrix、dependency profile、no-default 编译面和构建收益数据，确认是否具备收敛默认 feature 的条件 | runtime owner 迁移、default feature 副作用、构建脚本变更 | cargo metadata / cargo tree 证据，产品入口完整能力不变 |
 
 ### 4.1 PR1 具体实施计划
@@ -176,7 +176,10 @@ PR4 不迁移 concrete service IO、tool IO、surface command 语义、session m
 - 已完成 deterministic execution admission gate 迁移；core 仅保留状态更新、registry lookup、input validation、confirmation、实际执行和 hook。
 - 已完成 `GetToolSpecTool` concrete adapter 的 product runtime owner closure；generic concrete-tool implementations
   只保留兼容 re-export，不再拥有 on-demand spec discovery Tool impl。
-- 后续不直接搬全部 concrete tools。只在 manifest/catalog snapshot、snapshot wrapper、collapsed unlock persistence
+- 已完成 manifest/catalog/snapshot owner closure；`manifest_resolver.rs` 只保留旧路径兼容 facade，product runtime
+  的 `catalog.rs` / `snapshot.rs` 管理 resolved manifest DTO、visible tools、readonly catalog、GetToolSpec catalog
+  path 和 snapshot wrapper。
+- 后续不直接搬全部 concrete tools。只在 collapsed unlock persistence、`ToolUseContext` concrete service handles
   或具体工具 IO 中选择能减少旧路径的完整 owner。
 - 保留 tool name、schema、prompt stub、readonly/enabled/filtering、unlock state 生命周期。
 - 验证 builtin tool list、provider order、expanded/collapsed exposure、dynamic provider metadata、Deep Review 修改类工具 checkpoint hook。

--- a/scripts/check-core-boundaries.mjs
+++ b/scripts/check-core-boundaries.mjs
@@ -1034,12 +1034,52 @@ const forbiddenContentRules = [
     ],
   },
   {
+    path: 'src/crates/core/src/agentic/tools/product_runtime/catalog.rs',
+    patterns: [
+      {
+        regex: /framework::(?:\{[^}]*\bToolUseContext\b[^}]*\}|\bToolUseContext\b)/,
+        message:
+          'product tool runtime catalog must import ToolUseContext from tool_context_runtime, not the framework re-export',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/core/src/agentic/tools/product_runtime/get_tool_spec_tool.rs',
+    patterns: [
+      {
+        regex: /framework::(?:\{[^}]*\bToolUseContext\b[^}]*\}|\bToolUseContext\b)/,
+        message:
+          'GetToolSpec adapter must import ToolUseContext from tool_context_runtime, not the framework re-export',
+      },
+    ],
+  },
+  {
     path: 'src/crates/core/src/agentic/tools/manifest_resolver.rs',
     patterns: [
       {
         regex: /framework::(?:\{[^}]*\bToolUseContext\b[^}]*\}|\bToolUseContext\b)/,
         message:
           'manifest resolver must import ToolUseContext from tool_context_runtime, not the framework re-export',
+      },
+      {
+        regex: /\bContextualToolManifest\b/,
+        message:
+          'manifest resolver must stay a compatibility facade; contextual manifest conversion belongs in product_runtime/catalog',
+      },
+      {
+        regex: /\bContextualVisibleTools\b/,
+        message:
+          'manifest resolver must stay a compatibility facade; contextual visible-tool conversion belongs in product_runtime/catalog',
+      },
+      {
+        regex: /\bToolManifestDefinition\b/,
+        message:
+          'manifest resolver must not own manifest DTO conversion; use product_runtime/catalog',
+      },
+      {
+        regex: /\bfn\s+to_core_tool_definition\b/,
+        message:
+          'manifest resolver must not own ToolDefinition conversion; use product_runtime/catalog',
       },
     ],
   },
@@ -3971,7 +4011,7 @@ const requiredContentRules = [
   {
     path: 'src/crates/core/src/agentic/tools/product_runtime.rs',
     reason:
-      'core product tool runtime owner keeps registry assembly, static tool materialization, catalog manifests, and GetToolSpec facades explicit until concrete tools migrate',
+      'core product tool runtime owner keeps registry assembly and static tool materialization explicit until concrete tools migrate',
     patterns: [
       {
         regex: /\bProductToolRuntime\b/,
@@ -3980,10 +4020,6 @@ const requiredContentRules = [
       {
         regex: /\bSnapshotToolDecorator\b/,
         message: 'missing generic snapshot decorator injection',
-      },
-      {
-        regex: /\bProductSnapshotToolWrapper\b/,
-        message: 'missing core product snapshot wrapper adapter',
       },
       {
         regex: /\bbuiltin_static_tool_providers\b/,
@@ -4014,9 +4050,35 @@ const requiredContentRules = [
         message: 'missing generic static provider assembly delegation',
       },
       {
+        regex: /\bproduct_tool_runtime_owner_preserves_registry_contract\b/,
+        message: 'missing product runtime owner registry equivalence regression',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/core/src/agentic/tools/product_runtime/snapshot.rs',
+    reason:
+      'product runtime snapshot wrapper must stay isolated from registry and catalog ownership',
+    patterns: [
+      {
+        regex: /\bProductSnapshotToolWrapper\b/,
+        message: 'missing core product snapshot wrapper adapter',
+      },
+      {
+        regex: /\bimpl SnapshotToolWrapper<dyn Tool> for ProductSnapshotToolWrapper\b/,
+        message: 'missing generic snapshot wrapper implementation',
+      },
+      {
         regex: /\bwrap_tool_for_snapshot_tracking\b/,
         message: 'missing snapshot wrapper boundary',
       },
+    ],
+  },
+  {
+    path: 'src/crates/core/src/agentic/tools/product_runtime/catalog.rs',
+    reason:
+      'product runtime catalog owner keeps manifest, snapshot, readonly, and GetToolSpec product facades explicit',
+    patterns: [
       {
         regex: /\bProductToolCatalogProvider\b/,
         message: 'missing core product tool catalog provider owner',
@@ -4058,6 +4120,14 @@ const requiredContentRules = [
         message: 'missing product manifest facade',
       },
       {
+        regex: /\bresolve_product_resolved_tool_manifest\b/,
+        message: 'missing product resolved manifest compatibility facade',
+      },
+      {
+        regex: /\bresolve_product_resolved_visible_tools\b/,
+        message: 'missing product resolved visible-tools compatibility facade',
+      },
+      {
         regex: /\bresolve_product_readonly_enabled_tools\b/,
         message: 'missing product readonly enabled tools facade',
       },
@@ -4074,8 +4144,8 @@ const requiredContentRules = [
         message: 'missing product catalog provider collapsed catalog regression',
       },
       {
-        regex: /\bproduct_tool_runtime_owner_preserves_registry_contract\b/,
-        message: 'missing product runtime owner registry equivalence regression',
+        regex: /\bproduct_resolved_manifest_owner_matches_legacy_shape\b/,
+        message: 'missing product resolved manifest compatibility regression',
       },
       {
         regex: /\bGetToolSpec requires agent type context\b/,
@@ -4225,11 +4295,11 @@ const requiredContentRules = [
         message: 'missing GetToolSpec manifest insertion anchor',
       },
       {
-        regex: /\bresolve_product_visible_tools\b/,
+        regex: /\bresolve_product_resolved_visible_tools\b/,
         message: 'missing core product visible-tools facade delegation',
       },
       {
-        regex: /\bresolve_product_tool_manifest\b/,
+        regex: /\bresolve_product_resolved_tool_manifest\b/,
         message: 'missing core product manifest facade delegation',
       },
       {
@@ -4237,8 +4307,8 @@ const requiredContentRules = [
         message: 'missing collapsed-tool name tracking',
       },
       {
-        regex: /\bmanifest_preserves_explicit_get_tool_spec_runtime_contract\b/,
-        message: 'missing core GetToolSpec manifest insertion regression',
+        regex: /\bmanifest_resolver_facade_preserves_product_owner_output\b/,
+        message: 'missing manifest resolver facade parity regression',
       },
     ],
   },

--- a/src/crates/core/AGENTS.md
+++ b/src/crates/core/AGENTS.md
@@ -53,7 +53,9 @@ SessionManager → Session → DialogTurn → ModelRound
   registry snapshot access, product manifest / GetToolSpec facade wiring,
   product snapshot wrapper adapter injection, on-demand spec discovery Tool
   impl, and unlock-state source in `product_runtime.rs` / `product_runtime/`
-  for now. Do not move `GetToolSpecTool` ownership back into generic
+  for now. Keep manifest/catalog ownership in `product_runtime/catalog.rs`
+  and snapshot decoration in `product_runtime/snapshot.rs`; `manifest_resolver.rs`
+  should stay a compatibility facade. Do not move `GetToolSpecTool` ownership back into generic
   concrete-tool implementations; a legacy re-export is only a compatibility
   alias.
   `bitfun-tool-packs` may expose planned

--- a/src/crates/core/src/agentic/tools/manifest_resolver.rs
+++ b/src/crates/core/src/agentic/tools/manifest_resolver.rs
@@ -1,79 +1,19 @@
+//! Compatibility facade for product tool manifest resolution.
+
 use crate::agentic::agents::AgentToolPolicyOverrides;
-use crate::agentic::tools::framework::Tool;
 use crate::agentic::tools::product_runtime::{
-    resolve_product_tool_manifest, resolve_product_visible_tools,
+    resolve_product_resolved_tool_manifest, resolve_product_resolved_visible_tools,
 };
 use crate::agentic::tools::tool_context_runtime::ToolUseContext;
-use crate::util::types::ToolDefinition;
-use bitfun_agent_tools::{
-    ContextualToolManifest, ContextualVisibleTools, GetToolSpecCollapsedToolSummary,
-    ToolManifestDefinition,
-};
-use std::sync::Arc;
 
-#[derive(Debug, Clone)]
-pub struct ResolvedToolManifest {
-    pub allowed_tool_names: Vec<String>,
-    pub tool_definitions: Vec<ToolDefinition>,
-    pub collapsed_tool_names: Vec<String>,
-    pub collapsed_tool_summaries: Vec<GetToolSpecCollapsedToolSummary>,
-}
-
-#[derive(Clone)]
-pub struct ResolvedVisibleTools {
-    pub expanded_tools: Vec<Arc<dyn Tool>>,
-    pub collapsed_tools: Vec<Arc<dyn Tool>>,
-}
-
-fn to_core_tool_definition(definition: ToolManifestDefinition) -> ToolDefinition {
-    ToolDefinition {
-        name: definition.name,
-        description: definition.description,
-        parameters: definition.parameters,
-    }
-}
-
-impl From<ContextualVisibleTools<dyn Tool>> for ResolvedVisibleTools {
-    fn from(value: ContextualVisibleTools<dyn Tool>) -> Self {
-        Self {
-            expanded_tools: value.expanded_tools,
-            collapsed_tools: value.collapsed_tools,
-        }
-    }
-}
-
-impl From<ContextualToolManifest<dyn Tool>> for ResolvedToolManifest {
-    fn from(value: ContextualToolManifest<dyn Tool>) -> Self {
-        let collapsed_tool_summaries = value
-            .collapsed_tools
-            .iter()
-            .map(|tool| GetToolSpecCollapsedToolSummary {
-                name: tool.name().to_string(),
-                short_description: tool.short_description(),
-            })
-            .collect();
-
-        Self {
-            allowed_tool_names: value.allowed_tool_names,
-            tool_definitions: value
-                .tool_definitions
-                .into_iter()
-                .map(to_core_tool_definition)
-                .collect(),
-            collapsed_tool_names: value.collapsed_tool_names,
-            collapsed_tool_summaries,
-        }
-    }
-}
+pub use crate::agentic::tools::product_runtime::{ResolvedToolManifest, ResolvedVisibleTools};
 
 pub async fn resolve_visible_tools(
     allowed_tools: &[String],
     exposure_overrides: &AgentToolPolicyOverrides,
     context: &ToolUseContext,
 ) -> ResolvedVisibleTools {
-    resolve_product_visible_tools(allowed_tools, exposure_overrides, context)
-        .await
-        .into()
+    resolve_product_resolved_visible_tools(allowed_tools, exposure_overrides, context).await
 }
 
 pub async fn resolve_tool_manifest(
@@ -81,20 +21,19 @@ pub async fn resolve_tool_manifest(
     exposure_overrides: &AgentToolPolicyOverrides,
     context: &ToolUseContext,
 ) -> ResolvedToolManifest {
-    resolve_product_tool_manifest(allowed_tools, exposure_overrides, context)
-        .await
-        .into()
+    resolve_product_resolved_tool_manifest(allowed_tools, exposure_overrides, context).await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_tool_manifest;
+    use super::{resolve_tool_manifest, resolve_visible_tools};
     use crate::agentic::agents::AgentToolPolicyOverrides;
-    use crate::agentic::tools::framework::ToolExposure;
+    use crate::agentic::tools::product_runtime::{
+        resolve_product_resolved_tool_manifest, resolve_product_resolved_visible_tools,
+    };
     use crate::agentic::tools::tool_context_runtime::ToolUseContext;
     use crate::agentic::tools::ToolRuntimeRestrictions;
     use bitfun_agent_tools::GET_TOOL_SPEC_TOOL_NAME;
-    use serde_json::json;
     use std::collections::HashMap;
 
     fn tool_context() -> ToolUseContext {
@@ -114,271 +53,83 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn manifest_write_schema_omits_content_in_plaintext_followup_mode() {
-        let mut context = tool_context();
-        context
-            .custom_data
-            .insert("write_tool_mode".to_string(), json!("plaintext_followup"));
+    async fn manifest_resolver_facade_preserves_product_owner_output() {
+        let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
+        let context = tool_context();
 
-        let manifest = resolve_tool_manifest(
-            &["Write".to_string()],
+        let facade = resolve_tool_manifest(
+            &allowed_tools,
+            &AgentToolPolicyOverrides::default(),
+            &context,
+        )
+        .await;
+        let owner = resolve_product_resolved_tool_manifest(
+            &allowed_tools,
             &AgentToolPolicyOverrides::default(),
             &context,
         )
         .await;
 
-        let write = manifest
-            .tool_definitions
-            .iter()
-            .find(|tool| tool.name == "Write")
-            .expect("Write definition should exist");
-
-        assert_eq!(write.parameters["required"], json!(["file_path"]));
-        assert!(write.parameters["properties"].get("content").is_none());
-        assert!(!write
-            .description
-            .contains("Include the complete file content"));
-    }
-
-    #[tokio::test]
-    async fn manifest_omits_get_tool_spec_without_collapsed_tools() {
-        let allowed_tools = vec!["Read".to_string(), "Grep".to_string()];
-
-        let manifest = resolve_tool_manifest(
-            &allowed_tools,
-            &AgentToolPolicyOverrides::default(),
-            &tool_context(),
-        )
-        .await;
-
-        assert!(manifest.collapsed_tool_names.is_empty());
-        assert_eq!(manifest.allowed_tool_names, allowed_tools);
-        assert!(!manifest
-            .tool_definitions
-            .iter()
-            .any(|tool| tool.name == GET_TOOL_SPEC_TOOL_NAME));
-    }
-
-    #[tokio::test]
-    async fn manifest_adds_get_tool_spec_when_collapsed_tools_are_allowed() {
-        let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
-
-        let manifest = resolve_tool_manifest(
-            &allowed_tools,
-            &AgentToolPolicyOverrides::default(),
-            &tool_context(),
-        )
-        .await;
-
-        assert_eq!(manifest.collapsed_tool_names, vec!["WebFetch".to_string()]);
-        assert_eq!(manifest.collapsed_tool_summaries.len(), 1);
-        assert_eq!(manifest.collapsed_tool_summaries[0].name, "WebFetch");
-        assert!(manifest.collapsed_tool_summaries[0]
-            .short_description
-            .contains("Fetch content from a URL"));
-        assert!(manifest
+        assert_eq!(facade.allowed_tool_names, owner.allowed_tool_names);
+        assert_eq!(facade.collapsed_tool_names, owner.collapsed_tool_names);
+        assert_eq!(
+            facade
+                .tool_definitions
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            owner
+                .tool_definitions
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert!(facade
             .allowed_tool_names
             .contains(&GET_TOOL_SPEC_TOOL_NAME.to_string()));
-        assert!(manifest
-            .tool_definitions
-            .iter()
-            .any(|tool| tool.name == "Read"));
-        assert!(manifest
-            .tool_definitions
-            .iter()
-            .any(|tool| tool.name == "WebFetch"));
-        assert!(manifest
-            .tool_definitions
-            .iter()
-            .any(|tool| tool.name == GET_TOOL_SPEC_TOOL_NAME));
-        let stub = manifest
-            .tool_definitions
-            .iter()
-            .find(|tool| tool.name == "WebFetch")
-            .expect("WebFetch stub should exist");
-        assert!(stub.description.contains("First call `GetToolSpec`"));
-        assert_eq!(stub.parameters["type"], json!("object"));
-        assert_eq!(stub.parameters["additionalProperties"], json!(false));
-        assert!(stub.parameters["properties"]["tool_name"]["description"]
-            .as_str()
-            .unwrap()
-            .contains("{\"tool_name\":\"WebFetch\"}"));
     }
 
     #[tokio::test]
-    async fn manifest_snapshot_preserves_collapsed_tool_discovery_contract() {
-        let allowed_tools = vec![
-            "TodoWrite".to_string(),
-            "WebFetch".to_string(),
-            "Read".to_string(),
-            "WebSearch".to_string(),
-        ];
-
-        let manifest = resolve_tool_manifest(
-            &allowed_tools,
-            &AgentToolPolicyOverrides::default(),
-            &tool_context(),
-        )
-        .await;
-
-        assert_eq!(
-            manifest.allowed_tool_names,
-            vec![
-                "TodoWrite".to_string(),
-                "WebFetch".to_string(),
-                "Read".to_string(),
-                "WebSearch".to_string(),
-                GET_TOOL_SPEC_TOOL_NAME.to_string(),
-            ],
-            "GetToolSpec should be appended without reordering the allowed-list contract"
-        );
-        assert_eq!(
-            manifest.collapsed_tool_names,
-            vec!["WebSearch".to_string(), "WebFetch".to_string()],
-            "collapsed tools should follow registry snapshot order"
-        );
-        assert_eq!(
-            manifest
-                .tool_definitions
-                .iter()
-                .map(|tool| tool.name.as_str())
-                .collect::<Vec<_>>(),
-            vec!["Read", "WebFetch", "WebSearch", "TodoWrite", "GetToolSpec"],
-            "prompt-visible manifest order must stay stable before owner migration"
-        );
-
-        let web_fetch = manifest
-            .tool_definitions
-            .iter()
-            .find(|tool| tool.name == "WebFetch")
-            .expect("collapsed WebFetch stub");
-        assert!(web_fetch
-            .description
-            .contains("First call `GetToolSpec` with {\"tool_name\":\"WebFetch\"}"));
-        assert_eq!(
-            web_fetch.parameters,
-            json!({
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "tool_name": {
-                        "type": "string",
-                        "description": "Do not supply WebFetch arguments here while the tool is collapsed. Use GetToolSpec with {\"tool_name\":\"WebFetch\"} first."
-                    }
-                }
-            })
-        );
-    }
-
-    #[tokio::test]
-    async fn manifest_guard_preserves_get_tool_spec_unlock_surface_before_owner_migration() {
-        let allowed_tools = vec![
-            "Read".to_string(),
-            "WebFetch".to_string(),
-            "GetFileDiff".to_string(),
-            "Git".to_string(),
-        ];
-
-        let manifest = resolve_tool_manifest(
-            &allowed_tools,
-            &AgentToolPolicyOverrides::default(),
-            &tool_context(),
-        )
-        .await;
-
-        assert_eq!(
-            manifest.allowed_tool_names,
-            vec![
-                "Read".to_string(),
-                "WebFetch".to_string(),
-                "GetFileDiff".to_string(),
-                "Git".to_string(),
-                GET_TOOL_SPEC_TOOL_NAME.to_string(),
-            ],
-            "GetToolSpec insertion must preserve the runtime allowed-list contract"
-        );
-        assert_eq!(
-            manifest.collapsed_tool_names,
-            vec![
-                "GetFileDiff".to_string(),
-                "WebFetch".to_string(),
-                "Git".to_string()
-            ],
-            "collapsed unlock list must follow product registry snapshot order"
-        );
-        assert_eq!(
-            manifest
-                .tool_definitions
-                .iter()
-                .map(|tool| tool.name.as_str())
-                .collect::<Vec<_>>(),
-            vec!["Read", "WebFetch", "GetToolSpec", "GetFileDiff", "Git"],
-            "prompt-visible definitions must keep the current discovery insertion and policy order stable"
-        );
-
-        for tool_name in ["GetFileDiff", "WebFetch", "Git"] {
-            let stub = manifest
-                .tool_definitions
-                .iter()
-                .find(|tool| tool.name == tool_name)
-                .unwrap_or_else(|| panic!("{tool_name} stub should exist"));
-            assert!(
-                stub.description.contains(&format!(
-                    "First call `GetToolSpec` with {{\"tool_name\":\"{tool_name}\"}}"
-                )),
-                "collapsed stub must point to the explicit GetToolSpec unlock flow"
-            );
-            assert_eq!(stub.parameters["type"], json!("object"));
-            assert_eq!(stub.parameters["additionalProperties"], json!(false));
-            assert_eq!(
-                stub.parameters["properties"]["tool_name"]["description"],
-                json!(format!(
-                    "Do not supply {tool_name} arguments here while the tool is collapsed. Use GetToolSpec with {{\"tool_name\":\"{tool_name}\"}} first."
-                ))
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn manifest_preserves_explicit_get_tool_spec_runtime_contract() {
-        let allowed_tools = vec![GET_TOOL_SPEC_TOOL_NAME.to_string(), "WebFetch".to_string()];
-
-        let manifest = resolve_tool_manifest(
-            &allowed_tools,
-            &AgentToolPolicyOverrides::default(),
-            &tool_context(),
-        )
-        .await;
-
-        assert_eq!(manifest.allowed_tool_names, allowed_tools);
-        assert_eq!(manifest.collapsed_tool_names, vec!["WebFetch".to_string()]);
-        assert_eq!(
-            manifest
-                .tool_definitions
-                .iter()
-                .map(|tool| tool.name.as_str())
-                .collect::<Vec<_>>(),
-            vec!["WebFetch", "GetToolSpec", "GetToolSpec"],
-            "core runtime currently mirrors the pure policy contract when GetToolSpec is already allowed"
-        );
-    }
-
-    #[tokio::test]
-    async fn manifest_expands_tool_when_agent_override_requests_it() {
+    async fn visible_tools_facade_preserves_product_owner_output() {
         let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
-        let mut overrides = AgentToolPolicyOverrides::default();
-        overrides.insert("WebFetch".to_string(), ToolExposure::Expanded);
+        let context = tool_context();
 
-        let manifest = resolve_tool_manifest(&allowed_tools, &overrides, &tool_context()).await;
+        let facade = resolve_visible_tools(
+            &allowed_tools,
+            &AgentToolPolicyOverrides::default(),
+            &context,
+        )
+        .await;
+        let owner = resolve_product_resolved_visible_tools(
+            &allowed_tools,
+            &AgentToolPolicyOverrides::default(),
+            &context,
+        )
+        .await;
 
-        assert!(manifest.collapsed_tool_names.is_empty());
-        assert!(manifest
-            .tool_definitions
-            .iter()
-            .any(|tool| tool.name == "WebFetch"));
-        assert!(!manifest
-            .tool_definitions
-            .iter()
-            .any(|tool| tool.name == GET_TOOL_SPEC_TOOL_NAME));
+        assert_eq!(
+            facade
+                .expanded_tools
+                .iter()
+                .map(|tool| tool.name().to_string())
+                .collect::<Vec<_>>(),
+            owner
+                .expanded_tools
+                .iter()
+                .map(|tool| tool.name().to_string())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            facade
+                .collapsed_tools
+                .iter()
+                .map(|tool| tool.name().to_string())
+                .collect::<Vec<_>>(),
+            owner
+                .collapsed_tools
+                .iter()
+                .map(|tool| tool.name().to_string())
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/src/crates/core/src/agentic/tools/product_runtime.rs
+++ b/src/crates/core/src/agentic/tools/product_runtime.rs
@@ -5,28 +5,26 @@
 //! decoration. Concrete tools and `ToolUseContext` stay in core so this owner
 //! remains an equivalent structural boundary rather than a behavior migration.
 
+mod catalog;
 mod get_tool_spec_tool;
+mod snapshot;
 
-use crate::agentic::agents::{get_agent_registry, AgentToolPolicyOverrides};
-use crate::agentic::tools::framework::{Tool, ToolExposure, ToolResult};
+use crate::agentic::tools::framework::Tool;
 use crate::agentic::tools::implementations::*;
-use crate::agentic::tools::registry::{
-    get_global_tool_registry, ProductToolDecoratorRef, ToolRef, ToolRegistry,
-};
-use crate::agentic::tools::tool_context_runtime::ToolUseContext;
-use crate::util::errors::{BitFunError, BitFunResult};
+use crate::agentic::tools::registry::{ProductToolDecoratorRef, ToolRegistry};
 #[cfg(test)]
 use bitfun_agent_tools::StaticToolProvider;
-use bitfun_agent_tools::{
-    ContextualToolManifest, ContextualVisibleTools, GetToolSpecCatalogProvider,
-    GetToolSpecExecutionError, GetToolSpecRuntime, SnapshotToolDecorator, SnapshotToolWrapper,
-    StaticToolProviderGroup, ToolCatalogRuntime, ToolCatalogSnapshotProvider, ToolRuntimeAssembly,
-    GET_TOOL_SPEC_TOOL_NAME,
-};
+use bitfun_agent_tools::{SnapshotToolDecorator, StaticToolProviderGroup, ToolRuntimeAssembly};
 use bitfun_tool_packs::product_tool_provider_group_plan;
-use serde_json::Value;
+use snapshot::ProductSnapshotToolWrapper;
 use std::sync::Arc;
 
+pub(crate) use catalog::{
+    product_get_tool_spec_runtime, resolve_product_get_tool_spec_results,
+    resolve_product_readonly_enabled_tools, resolve_product_resolved_tool_manifest,
+    resolve_product_resolved_visible_tools, ProductGetToolSpecRuntime, ProductToolCatalogProvider,
+};
+pub use catalog::{ResolvedToolManifest, ResolvedVisibleTools};
 pub use get_tool_spec_tool::GetToolSpecTool;
 
 #[derive(Clone)]
@@ -73,15 +71,6 @@ impl ProductToolRuntime {
         let inner = ToolRuntimeAssembly::with_tool_decorator(self.tool_decorator.clone())
             .create_registry_from_static_providers(&providers);
         ToolRegistry::from_inner(inner)
-    }
-}
-
-#[derive(Debug, Clone)]
-struct ProductSnapshotToolWrapper;
-
-impl SnapshotToolWrapper<dyn Tool> for ProductSnapshotToolWrapper {
-    fn wrap_for_snapshot_tracking(&self, tool: ToolRef) -> ToolRef {
-        crate::service::snapshot::wrap_tool_for_snapshot_tracking(tool)
     }
 }
 
@@ -142,155 +131,10 @@ fn materialize_tool(tool_name: &str) -> Arc<dyn Tool> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct ProductToolCatalogProvider;
-
-pub(crate) type ProductGetToolSpecRuntime<'a> =
-    GetToolSpecRuntime<'a, dyn Tool, ToolUseContext, ProductToolCatalogProvider>;
-
-pub(crate) type ProductToolCatalogRuntime<'a> =
-    ToolCatalogRuntime<'a, dyn Tool, ToolUseContext, ProductToolCatalogProvider>;
-
-#[async_trait::async_trait]
-impl ToolCatalogSnapshotProvider<dyn Tool> for ProductToolCatalogProvider {
-    async fn tool_snapshot(&self) -> Vec<Arc<dyn Tool>> {
-        let registry = get_global_tool_registry();
-        let registry = registry.read().await;
-        registry.get_all_tools()
-    }
-}
-
-#[async_trait::async_trait]
-impl GetToolSpecCatalogProvider<dyn Tool, ToolUseContext> for ProductToolCatalogProvider {
-    async fn collapsed_tools_for_get_tool_spec(
-        &self,
-        context: Option<&ToolUseContext>,
-    ) -> Result<Vec<Arc<dyn Tool>>, String> {
-        match context {
-            Some(context) => self
-                .contextual_collapsed_tools(context)
-                .await
-                .map_err(|error| error.to_string()),
-            None => Ok(self.default_collapsed_tools().await),
-        }
-    }
-}
-
-impl ProductToolCatalogProvider {
-    async fn default_collapsed_tools(&self) -> Vec<Arc<dyn Tool>> {
-        let registry = get_global_tool_registry();
-        let registry = registry.read().await;
-        registry
-            .get_all_tools()
-            .into_iter()
-            .filter(|tool| tool.default_exposure() == ToolExposure::Collapsed)
-            .collect()
-    }
-
-    async fn contextual_collapsed_tools(
-        &self,
-        context: &ToolUseContext,
-    ) -> BitFunResult<Vec<Arc<dyn Tool>>> {
-        let agent_type = context.agent_type.as_deref().ok_or_else(|| {
-            BitFunError::Validation("GetToolSpec requires agent type context".to_string())
-        })?;
-        let workspace_root = context.workspace_root();
-        let agent_registry = get_agent_registry();
-        let policy = agent_registry
-            .get_agent_tool_policy(agent_type, workspace_root)
-            .await;
-        let visible_tools = product_tool_catalog_runtime(self)
-            .visible_tools(&policy.allowed_tools, &policy.exposure_overrides, context)
-            .await;
-        Ok(visible_tools.collapsed_tools)
-    }
-}
-
-pub(crate) fn product_get_tool_spec_runtime(
-    provider: &ProductToolCatalogProvider,
-) -> ProductGetToolSpecRuntime<'_> {
-    GetToolSpecRuntime::new(provider, GET_TOOL_SPEC_TOOL_NAME)
-}
-
-pub(crate) fn product_tool_catalog_runtime(
-    provider: &ProductToolCatalogProvider,
-) -> ProductToolCatalogRuntime<'_> {
-    ToolCatalogRuntime::new(provider, GET_TOOL_SPEC_TOOL_NAME)
-}
-
-pub(crate) async fn resolve_product_visible_tools(
-    allowed_tools: &[String],
-    exposure_overrides: &AgentToolPolicyOverrides,
-    context: &ToolUseContext,
-) -> ContextualVisibleTools<dyn Tool> {
-    let provider = ProductToolCatalogProvider;
-    product_tool_catalog_runtime(&provider)
-        .visible_tools(allowed_tools, exposure_overrides, context)
-        .await
-}
-
-pub(crate) async fn resolve_product_tool_manifest(
-    allowed_tools: &[String],
-    exposure_overrides: &AgentToolPolicyOverrides,
-    context: &ToolUseContext,
-) -> ContextualToolManifest<dyn Tool> {
-    let provider = ProductToolCatalogProvider;
-    product_tool_catalog_runtime(&provider)
-        .tool_manifest(allowed_tools, exposure_overrides, context)
-        .await
-}
-
-pub(crate) async fn resolve_product_readonly_enabled_tools() -> Vec<Arc<dyn Tool>> {
-    let provider = ProductToolCatalogProvider;
-    product_tool_catalog_runtime(&provider)
-        .readonly_enabled_tools()
-        .await
-}
-
-pub(crate) async fn resolve_product_get_tool_spec_results(
-    input: &Value,
-    context: &ToolUseContext,
-    get_tool_spec_tool_name: &str,
-) -> Result<Vec<ToolResult>, GetToolSpecExecutionError> {
-    let provider = ProductToolCatalogProvider;
-    GetToolSpecRuntime::new(&provider, get_tool_spec_tool_name)
-        .call_results(input, &context.unlocked_collapsed_tools, context)
-        .await
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        resolve_product_get_tool_spec_results, resolve_product_readonly_enabled_tools,
-        resolve_product_tool_manifest, ProductToolCatalogProvider, ProductToolRuntime,
-    };
-    use crate::agentic::agents::AgentToolPolicyOverrides;
+    use super::ProductToolRuntime;
     use crate::agentic::tools::registry::create_tool_registry;
-    use crate::agentic::tools::tool_context_runtime::ToolUseContext;
-    use crate::agentic::tools::ToolRuntimeRestrictions;
-    use bitfun_agent_tools::{GetToolSpecCatalogProvider, ToolCatalogSnapshotProvider, ToolResult};
-    use serde_json::json;
-    use std::collections::HashMap;
-
-    fn tool_context(agent_type: Option<&str>) -> ToolUseContext {
-        ToolUseContext {
-            tool_call_id: None,
-            agent_type: agent_type.map(str::to_string),
-            session_id: None,
-            dialog_turn_id: None,
-            workspace: None,
-            unlocked_collapsed_tools: Vec::new(),
-            custom_data: HashMap::new(),
-            computer_use_host: None,
-            cancellation_token: None,
-            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
-            workspace_services: None,
-        }
-    }
-
-    fn context_without_agent_type() -> ToolUseContext {
-        tool_context(None)
-    }
 
     #[test]
     fn product_tool_runtime_owner_preserves_registry_contract() {
@@ -307,125 +151,6 @@ mod tests {
             owner_registry.get_collapsed_tool_names(),
             compatibility_registry.get_collapsed_tool_names(),
             "product tool runtime owner must preserve collapsed-tool exposure"
-        );
-    }
-
-    #[tokio::test]
-    async fn product_catalog_provider_reads_global_registry_snapshot() {
-        let provider = ProductToolCatalogProvider;
-
-        let snapshot_names = provider
-            .tool_snapshot()
-            .await
-            .into_iter()
-            .map(|tool| tool.name().to_string())
-            .collect::<Vec<_>>();
-
-        let expected_builtin_names = create_tool_registry().get_tool_names();
-        assert!(
-            snapshot_names.starts_with(&expected_builtin_names),
-            "product catalog provider must preserve global registry snapshot order"
-        );
-    }
-
-    #[tokio::test]
-    async fn product_catalog_provider_default_get_tool_spec_catalog_matches_registry() {
-        let provider = ProductToolCatalogProvider;
-
-        let collapsed_names = provider
-            .collapsed_tools_for_get_tool_spec(None)
-            .await
-            .expect("default collapsed catalog")
-            .into_iter()
-            .map(|tool| tool.name().to_string())
-            .collect::<Vec<_>>();
-
-        let expected_builtin_collapsed_names = create_tool_registry().get_collapsed_tool_names();
-        assert!(
-            collapsed_names.starts_with(&expected_builtin_collapsed_names),
-            "GetToolSpec default catalog must preserve collapsed registry order"
-        );
-    }
-
-    #[tokio::test]
-    async fn product_catalog_provider_context_requires_agent_type() {
-        let provider = ProductToolCatalogProvider;
-
-        let result = provider
-            .collapsed_tools_for_get_tool_spec(Some(&context_without_agent_type()))
-            .await;
-        let error = match result {
-            Ok(_) => {
-                panic!("contextual catalog without agent_type should keep existing validation")
-            }
-            Err(error) => error,
-        };
-
-        assert!(
-            error.contains("GetToolSpec requires agent type context"),
-            "unexpected validation error: {error}"
-        );
-    }
-
-    #[tokio::test]
-    async fn product_catalog_facade_resolves_manifest_from_same_provider_owner() {
-        let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
-
-        let manifest = resolve_product_tool_manifest(
-            &allowed_tools,
-            &AgentToolPolicyOverrides::default(),
-            &tool_context(Some("agentic")),
-        )
-        .await;
-
-        assert_eq!(manifest.collapsed_tool_names, vec!["WebFetch".to_string()]);
-        assert_eq!(
-            manifest
-                .tool_definitions
-                .iter()
-                .map(|tool| tool.name.as_str())
-                .collect::<Vec<_>>(),
-            vec!["Read", "WebFetch", "GetToolSpec"],
-            "product manifest facade must preserve prompt-visible definition order"
-        );
-    }
-
-    #[tokio::test]
-    async fn product_catalog_facade_resolves_get_tool_spec_results_from_same_provider_owner() {
-        let results = resolve_product_get_tool_spec_results(
-            &json!({ "tool_name": "WebFetch" }),
-            &tool_context(Some("agentic")),
-            "GetToolSpec",
-        )
-        .await
-        .expect("WebFetch should resolve through product GetToolSpec runtime facade");
-
-        assert_eq!(results.len(), 1);
-        let ToolResult::Result { data, .. } = &results[0] else {
-            panic!("expected normal tool result");
-        };
-
-        assert_eq!(data["tool_name"], "WebFetch");
-        assert_eq!(data["input_schema"]["type"], "object");
-    }
-
-    #[tokio::test]
-    async fn product_catalog_facade_resolves_readonly_enabled_tools_from_same_provider_owner() {
-        let readonly_names = resolve_product_readonly_enabled_tools()
-            .await
-            .into_iter()
-            .map(|tool| tool.name().to_string())
-            .collect::<Vec<_>>();
-        let mut expected_readonly_names = Vec::new();
-        for tool in create_tool_registry().get_all_tools() {
-            if tool.is_readonly() && tool.is_enabled().await {
-                expected_readonly_names.push(tool.name().to_string());
-            }
-        }
-
-        assert_eq!(
-            readonly_names, expected_readonly_names,
-            "product readonly catalog facade must preserve registry snapshot order"
         );
     }
 }

--- a/src/crates/core/src/agentic/tools/product_runtime/catalog.rs
+++ b/src/crates/core/src/agentic/tools/product_runtime/catalog.rs
@@ -1,0 +1,630 @@
+//! Product tool catalog, manifest, and GetToolSpec runtime owner.
+
+use crate::agentic::agents::{get_agent_registry, AgentToolPolicyOverrides};
+use crate::agentic::tools::framework::{Tool, ToolExposure, ToolResult};
+use crate::agentic::tools::registry::{get_global_tool_registry, ToolRef};
+use crate::agentic::tools::tool_context_runtime::ToolUseContext;
+use crate::util::errors::{BitFunError, BitFunResult};
+use crate::util::types::ToolDefinition;
+use bitfun_agent_tools::{
+    ContextualToolManifest, ContextualVisibleTools, GetToolSpecCatalogProvider,
+    GetToolSpecCollapsedToolSummary, GetToolSpecExecutionError, GetToolSpecRuntime,
+    ToolCatalogRuntime, ToolCatalogSnapshotProvider, ToolManifestDefinition,
+    GET_TOOL_SPEC_TOOL_NAME,
+};
+use serde_json::Value;
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct ResolvedToolManifest {
+    pub allowed_tool_names: Vec<String>,
+    pub tool_definitions: Vec<ToolDefinition>,
+    pub collapsed_tool_names: Vec<String>,
+    pub collapsed_tool_summaries: Vec<GetToolSpecCollapsedToolSummary>,
+}
+
+#[derive(Clone)]
+pub struct ResolvedVisibleTools {
+    pub expanded_tools: Vec<Arc<dyn Tool>>,
+    pub collapsed_tools: Vec<Arc<dyn Tool>>,
+}
+
+fn to_core_tool_definition(definition: ToolManifestDefinition) -> ToolDefinition {
+    ToolDefinition {
+        name: definition.name,
+        description: definition.description,
+        parameters: definition.parameters,
+    }
+}
+
+impl From<ContextualVisibleTools<dyn Tool>> for ResolvedVisibleTools {
+    fn from(value: ContextualVisibleTools<dyn Tool>) -> Self {
+        Self {
+            expanded_tools: value.expanded_tools,
+            collapsed_tools: value.collapsed_tools,
+        }
+    }
+}
+
+impl From<ContextualToolManifest<dyn Tool>> for ResolvedToolManifest {
+    fn from(value: ContextualToolManifest<dyn Tool>) -> Self {
+        let collapsed_tool_summaries = value
+            .collapsed_tools
+            .iter()
+            .map(|tool| GetToolSpecCollapsedToolSummary {
+                name: tool.name().to_string(),
+                short_description: tool.short_description(),
+            })
+            .collect();
+
+        Self {
+            allowed_tool_names: value.allowed_tool_names,
+            tool_definitions: value
+                .tool_definitions
+                .into_iter()
+                .map(to_core_tool_definition)
+                .collect(),
+            collapsed_tool_names: value.collapsed_tool_names,
+            collapsed_tool_summaries,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ProductToolCatalogProvider;
+
+pub(crate) type ProductGetToolSpecRuntime<'a> =
+    GetToolSpecRuntime<'a, dyn Tool, ToolUseContext, ProductToolCatalogProvider>;
+
+pub(crate) type ProductToolCatalogRuntime<'a> =
+    ToolCatalogRuntime<'a, dyn Tool, ToolUseContext, ProductToolCatalogProvider>;
+
+#[async_trait::async_trait]
+impl ToolCatalogSnapshotProvider<dyn Tool> for ProductToolCatalogProvider {
+    async fn tool_snapshot(&self) -> Vec<ToolRef> {
+        let registry = get_global_tool_registry();
+        let registry = registry.read().await;
+        registry.get_all_tools()
+    }
+}
+
+#[async_trait::async_trait]
+impl GetToolSpecCatalogProvider<dyn Tool, ToolUseContext> for ProductToolCatalogProvider {
+    async fn collapsed_tools_for_get_tool_spec(
+        &self,
+        context: Option<&ToolUseContext>,
+    ) -> Result<Vec<ToolRef>, String> {
+        match context {
+            Some(context) => self
+                .contextual_collapsed_tools(context)
+                .await
+                .map_err(|error| error.to_string()),
+            None => Ok(self.default_collapsed_tools().await),
+        }
+    }
+}
+
+impl ProductToolCatalogProvider {
+    async fn default_collapsed_tools(&self) -> Vec<ToolRef> {
+        let registry = get_global_tool_registry();
+        let registry = registry.read().await;
+        registry
+            .get_all_tools()
+            .into_iter()
+            .filter(|tool| tool.default_exposure() == ToolExposure::Collapsed)
+            .collect()
+    }
+
+    async fn contextual_collapsed_tools(
+        &self,
+        context: &ToolUseContext,
+    ) -> BitFunResult<Vec<ToolRef>> {
+        let agent_type = context.agent_type.as_deref().ok_or_else(|| {
+            BitFunError::Validation("GetToolSpec requires agent type context".to_string())
+        })?;
+        let workspace_root = context.workspace_root();
+        let agent_registry = get_agent_registry();
+        let policy = agent_registry
+            .get_agent_tool_policy(agent_type, workspace_root)
+            .await;
+        let visible_tools = product_tool_catalog_runtime(self)
+            .visible_tools(&policy.allowed_tools, &policy.exposure_overrides, context)
+            .await;
+        Ok(visible_tools.collapsed_tools)
+    }
+}
+
+pub(crate) fn product_get_tool_spec_runtime(
+    provider: &ProductToolCatalogProvider,
+) -> ProductGetToolSpecRuntime<'_> {
+    GetToolSpecRuntime::new(provider, GET_TOOL_SPEC_TOOL_NAME)
+}
+
+pub(crate) fn product_tool_catalog_runtime(
+    provider: &ProductToolCatalogProvider,
+) -> ProductToolCatalogRuntime<'_> {
+    ToolCatalogRuntime::new(provider, GET_TOOL_SPEC_TOOL_NAME)
+}
+
+pub(crate) async fn resolve_product_visible_tools(
+    allowed_tools: &[String],
+    exposure_overrides: &AgentToolPolicyOverrides,
+    context: &ToolUseContext,
+) -> ContextualVisibleTools<dyn Tool> {
+    let provider = ProductToolCatalogProvider;
+    product_tool_catalog_runtime(&provider)
+        .visible_tools(allowed_tools, exposure_overrides, context)
+        .await
+}
+
+pub(crate) async fn resolve_product_tool_manifest(
+    allowed_tools: &[String],
+    exposure_overrides: &AgentToolPolicyOverrides,
+    context: &ToolUseContext,
+) -> ContextualToolManifest<dyn Tool> {
+    let provider = ProductToolCatalogProvider;
+    product_tool_catalog_runtime(&provider)
+        .tool_manifest(allowed_tools, exposure_overrides, context)
+        .await
+}
+
+pub(crate) async fn resolve_product_resolved_visible_tools(
+    allowed_tools: &[String],
+    exposure_overrides: &AgentToolPolicyOverrides,
+    context: &ToolUseContext,
+) -> ResolvedVisibleTools {
+    resolve_product_visible_tools(allowed_tools, exposure_overrides, context)
+        .await
+        .into()
+}
+
+pub(crate) async fn resolve_product_resolved_tool_manifest(
+    allowed_tools: &[String],
+    exposure_overrides: &AgentToolPolicyOverrides,
+    context: &ToolUseContext,
+) -> ResolvedToolManifest {
+    resolve_product_tool_manifest(allowed_tools, exposure_overrides, context)
+        .await
+        .into()
+}
+
+pub(crate) async fn resolve_product_readonly_enabled_tools() -> Vec<ToolRef> {
+    let provider = ProductToolCatalogProvider;
+    product_tool_catalog_runtime(&provider)
+        .readonly_enabled_tools()
+        .await
+}
+
+pub(crate) async fn resolve_product_get_tool_spec_results(
+    input: &Value,
+    context: &ToolUseContext,
+    get_tool_spec_tool_name: &str,
+) -> Result<Vec<ToolResult>, GetToolSpecExecutionError> {
+    let provider = ProductToolCatalogProvider;
+    GetToolSpecRuntime::new(&provider, get_tool_spec_tool_name)
+        .call_results(input, &context.unlocked_collapsed_tools, context)
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        resolve_product_get_tool_spec_results, resolve_product_readonly_enabled_tools,
+        resolve_product_resolved_tool_manifest, resolve_product_resolved_visible_tools,
+        resolve_product_tool_manifest, ProductToolCatalogProvider,
+    };
+    use crate::agentic::agents::AgentToolPolicyOverrides;
+    use crate::agentic::tools::framework::{ToolExposure, ToolResult};
+    use crate::agentic::tools::registry::create_tool_registry;
+    use crate::agentic::tools::tool_context_runtime::ToolUseContext;
+    use crate::agentic::tools::ToolRuntimeRestrictions;
+    use bitfun_agent_tools::{
+        GetToolSpecCatalogProvider, ToolCatalogSnapshotProvider, GET_TOOL_SPEC_TOOL_NAME,
+    };
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    fn tool_context(agent_type: Option<&str>) -> ToolUseContext {
+        ToolUseContext {
+            tool_call_id: None,
+            agent_type: agent_type.map(str::to_string),
+            session_id: None,
+            dialog_turn_id: None,
+            workspace: None,
+            unlocked_collapsed_tools: Vec::new(),
+            custom_data: HashMap::new(),
+            computer_use_host: None,
+            cancellation_token: None,
+            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
+            workspace_services: None,
+        }
+    }
+
+    fn context_without_agent_type() -> ToolUseContext {
+        tool_context(None)
+    }
+
+    #[tokio::test]
+    async fn product_catalog_provider_reads_global_registry_snapshot() {
+        let provider = ProductToolCatalogProvider;
+
+        let snapshot_names = provider
+            .tool_snapshot()
+            .await
+            .into_iter()
+            .map(|tool| tool.name().to_string())
+            .collect::<Vec<_>>();
+
+        let expected_builtin_names = create_tool_registry().get_tool_names();
+        assert!(
+            snapshot_names.starts_with(&expected_builtin_names),
+            "product catalog provider must preserve global registry snapshot order"
+        );
+    }
+
+    #[tokio::test]
+    async fn product_catalog_provider_default_get_tool_spec_catalog_matches_registry() {
+        let provider = ProductToolCatalogProvider;
+
+        let collapsed_names = provider
+            .collapsed_tools_for_get_tool_spec(None)
+            .await
+            .expect("default collapsed catalog")
+            .into_iter()
+            .map(|tool| tool.name().to_string())
+            .collect::<Vec<_>>();
+
+        let expected_builtin_collapsed_names = create_tool_registry().get_collapsed_tool_names();
+        assert!(
+            collapsed_names.starts_with(&expected_builtin_collapsed_names),
+            "GetToolSpec default catalog must preserve collapsed registry order"
+        );
+    }
+
+    #[tokio::test]
+    async fn product_catalog_provider_context_requires_agent_type() {
+        let provider = ProductToolCatalogProvider;
+
+        let result = provider
+            .collapsed_tools_for_get_tool_spec(Some(&context_without_agent_type()))
+            .await;
+        let error = match result {
+            Ok(_) => {
+                panic!("contextual catalog without agent_type should keep existing validation")
+            }
+            Err(error) => error,
+        };
+
+        assert!(
+            error.contains("GetToolSpec requires agent type context"),
+            "unexpected validation error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn product_catalog_facade_resolves_manifest_from_same_provider_owner() {
+        let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
+
+        let manifest = resolve_product_tool_manifest(
+            &allowed_tools,
+            &AgentToolPolicyOverrides::default(),
+            &tool_context(Some("agentic")),
+        )
+        .await;
+
+        assert_eq!(manifest.collapsed_tool_names, vec!["WebFetch".to_string()]);
+        assert_eq!(
+            manifest
+                .tool_definitions
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Read", "WebFetch", "GetToolSpec"],
+            "product manifest facade must preserve prompt-visible definition order"
+        );
+    }
+
+    #[tokio::test]
+    async fn product_resolved_manifest_owner_matches_legacy_shape() {
+        let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
+
+        let manifest = resolve_product_resolved_tool_manifest(
+            &allowed_tools,
+            &AgentToolPolicyOverrides::default(),
+            &tool_context(Some("agentic")),
+        )
+        .await;
+
+        assert_eq!(
+            manifest.allowed_tool_names,
+            vec![
+                "Read".to_string(),
+                "WebFetch".to_string(),
+                GET_TOOL_SPEC_TOOL_NAME.to_string()
+            ]
+        );
+        assert_eq!(manifest.collapsed_tool_names, vec!["WebFetch".to_string()]);
+        assert_eq!(manifest.collapsed_tool_summaries.len(), 1);
+        assert_eq!(manifest.collapsed_tool_summaries[0].name, "WebFetch");
+        assert_eq!(
+            manifest
+                .tool_definitions
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Read", "WebFetch", "GetToolSpec"]
+        );
+    }
+
+    #[tokio::test]
+    async fn product_resolved_visible_tools_owner_matches_registry_visibility() {
+        let visible = resolve_product_resolved_visible_tools(
+            &["Read".to_string(), "WebFetch".to_string()],
+            &AgentToolPolicyOverrides::default(),
+            &tool_context(Some("agentic")),
+        )
+        .await;
+
+        assert_eq!(
+            visible
+                .expanded_tools
+                .iter()
+                .map(|tool| tool.name().to_string())
+                .collect::<Vec<_>>(),
+            vec!["Read".to_string(), GET_TOOL_SPEC_TOOL_NAME.to_string()]
+        );
+        assert_eq!(
+            visible
+                .collapsed_tools
+                .iter()
+                .map(|tool| tool.name().to_string())
+                .collect::<Vec<_>>(),
+            vec!["WebFetch".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn product_catalog_facade_resolves_get_tool_spec_results_from_same_provider_owner() {
+        let results = resolve_product_get_tool_spec_results(
+            &json!({ "tool_name": "WebFetch" }),
+            &tool_context(Some("agentic")),
+            "GetToolSpec",
+        )
+        .await
+        .expect("WebFetch should resolve through product GetToolSpec runtime facade");
+
+        assert_eq!(results.len(), 1);
+        let ToolResult::Result { data, .. } = &results[0] else {
+            panic!("expected normal tool result");
+        };
+
+        assert_eq!(data["tool_name"], "WebFetch");
+        assert_eq!(data["input_schema"]["type"], "object");
+    }
+
+    #[tokio::test]
+    async fn product_catalog_facade_resolves_readonly_enabled_tools_from_same_provider_owner() {
+        let readonly_names = resolve_product_readonly_enabled_tools()
+            .await
+            .into_iter()
+            .map(|tool| tool.name().to_string())
+            .collect::<Vec<_>>();
+        let mut expected_readonly_names = Vec::new();
+        for tool in create_tool_registry().get_all_tools() {
+            if tool.is_readonly() && tool.is_enabled().await {
+                expected_readonly_names.push(tool.name().to_string());
+            }
+        }
+
+        assert_eq!(
+            readonly_names, expected_readonly_names,
+            "product readonly catalog facade must preserve registry snapshot order"
+        );
+    }
+
+    #[tokio::test]
+    async fn product_manifest_write_schema_omits_content_in_plaintext_followup_mode() {
+        let mut context = tool_context(Some("test-agent"));
+        context
+            .custom_data
+            .insert("write_tool_mode".to_string(), json!("plaintext_followup"));
+
+        let manifest = resolve_product_resolved_tool_manifest(
+            &["Write".to_string()],
+            &AgentToolPolicyOverrides::default(),
+            &context,
+        )
+        .await;
+
+        let write = manifest
+            .tool_definitions
+            .iter()
+            .find(|tool| tool.name == "Write")
+            .expect("Write definition should exist");
+
+        assert_eq!(write.parameters["required"], json!(["file_path"]));
+        assert!(write.parameters["properties"].get("content").is_none());
+        assert!(!write
+            .description
+            .contains("Include the complete file content"));
+    }
+
+    #[tokio::test]
+    async fn product_manifest_omits_get_tool_spec_without_collapsed_tools() {
+        let allowed_tools = vec!["Read".to_string(), "Grep".to_string()];
+
+        let manifest = resolve_product_resolved_tool_manifest(
+            &allowed_tools,
+            &AgentToolPolicyOverrides::default(),
+            &tool_context(Some("test-agent")),
+        )
+        .await;
+
+        assert!(manifest.collapsed_tool_names.is_empty());
+        assert_eq!(manifest.allowed_tool_names, allowed_tools);
+        assert!(!manifest
+            .tool_definitions
+            .iter()
+            .any(|tool| tool.name == GET_TOOL_SPEC_TOOL_NAME));
+    }
+
+    #[tokio::test]
+    async fn product_manifest_snapshot_preserves_collapsed_tool_discovery_contract() {
+        let allowed_tools = vec![
+            "TodoWrite".to_string(),
+            "WebFetch".to_string(),
+            "Read".to_string(),
+            "WebSearch".to_string(),
+        ];
+
+        let manifest = resolve_product_resolved_tool_manifest(
+            &allowed_tools,
+            &AgentToolPolicyOverrides::default(),
+            &tool_context(Some("test-agent")),
+        )
+        .await;
+
+        assert_eq!(
+            manifest.allowed_tool_names,
+            vec![
+                "TodoWrite".to_string(),
+                "WebFetch".to_string(),
+                "Read".to_string(),
+                "WebSearch".to_string(),
+                GET_TOOL_SPEC_TOOL_NAME.to_string(),
+            ],
+            "GetToolSpec should be appended without reordering the allowed-list contract"
+        );
+        assert_eq!(
+            manifest.collapsed_tool_names,
+            vec!["WebSearch".to_string(), "WebFetch".to_string()],
+            "collapsed tools should follow registry snapshot order"
+        );
+        assert_eq!(
+            manifest
+                .tool_definitions
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Read", "WebFetch", "WebSearch", "TodoWrite", "GetToolSpec"],
+            "prompt-visible manifest order must stay stable before owner migration"
+        );
+    }
+
+    #[tokio::test]
+    async fn product_manifest_guard_preserves_get_tool_spec_unlock_surface() {
+        let allowed_tools = vec![
+            "Read".to_string(),
+            "WebFetch".to_string(),
+            "GetFileDiff".to_string(),
+            "Git".to_string(),
+        ];
+
+        let manifest = resolve_product_resolved_tool_manifest(
+            &allowed_tools,
+            &AgentToolPolicyOverrides::default(),
+            &tool_context(Some("test-agent")),
+        )
+        .await;
+
+        assert_eq!(
+            manifest.allowed_tool_names,
+            vec![
+                "Read".to_string(),
+                "WebFetch".to_string(),
+                "GetFileDiff".to_string(),
+                "Git".to_string(),
+                GET_TOOL_SPEC_TOOL_NAME.to_string(),
+            ],
+            "GetToolSpec insertion must preserve the runtime allowed-list contract"
+        );
+        assert_eq!(
+            manifest.collapsed_tool_names,
+            vec![
+                "GetFileDiff".to_string(),
+                "WebFetch".to_string(),
+                "Git".to_string()
+            ],
+            "collapsed unlock list must follow product registry snapshot order"
+        );
+        assert_eq!(
+            manifest
+                .tool_definitions
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Read", "WebFetch", "GetToolSpec", "GetFileDiff", "Git"],
+            "prompt-visible definitions must keep the current discovery insertion and policy order stable"
+        );
+
+        for tool_name in ["GetFileDiff", "WebFetch", "Git"] {
+            let stub = manifest
+                .tool_definitions
+                .iter()
+                .find(|tool| tool.name == tool_name)
+                .unwrap_or_else(|| panic!("{tool_name} stub should exist"));
+            assert!(
+                stub.description.contains(&format!(
+                    "First call `GetToolSpec` with {{\"tool_name\":\"{tool_name}\"}}"
+                )),
+                "collapsed stub must point to the explicit GetToolSpec unlock flow"
+            );
+            assert_eq!(stub.parameters["type"], json!("object"));
+            assert_eq!(stub.parameters["additionalProperties"], json!(false));
+            assert_eq!(
+                stub.parameters["properties"]["tool_name"]["description"],
+                json!(format!(
+                    "Do not supply {tool_name} arguments here while the tool is collapsed. Use GetToolSpec with {{\"tool_name\":\"{tool_name}\"}} first."
+                ))
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn product_manifest_preserves_explicit_get_tool_spec_runtime_contract() {
+        let allowed_tools = vec![GET_TOOL_SPEC_TOOL_NAME.to_string(), "WebFetch".to_string()];
+
+        let manifest = resolve_product_resolved_tool_manifest(
+            &allowed_tools,
+            &AgentToolPolicyOverrides::default(),
+            &tool_context(Some("test-agent")),
+        )
+        .await;
+
+        assert_eq!(manifest.allowed_tool_names, allowed_tools);
+        assert_eq!(manifest.collapsed_tool_names, vec!["WebFetch".to_string()]);
+        assert_eq!(
+            manifest
+                .tool_definitions
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["WebFetch", "GetToolSpec", "GetToolSpec"],
+            "core runtime currently mirrors the pure policy contract when GetToolSpec is already allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn product_manifest_expands_tool_when_agent_override_requests_it() {
+        let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
+        let mut overrides = AgentToolPolicyOverrides::default();
+        overrides.insert("WebFetch".to_string(), ToolExposure::Expanded);
+
+        let manifest = resolve_product_resolved_tool_manifest(
+            &allowed_tools,
+            &overrides,
+            &tool_context(Some("test-agent")),
+        )
+        .await;
+
+        assert!(manifest.collapsed_tool_names.is_empty());
+        assert!(manifest
+            .tool_definitions
+            .iter()
+            .any(|tool| tool.name == "WebFetch"));
+        assert!(!manifest
+            .tool_definitions
+            .iter()
+            .any(|tool| tool.name == GET_TOOL_SPEC_TOOL_NAME));
+    }
+}

--- a/src/crates/core/src/agentic/tools/product_runtime/get_tool_spec_tool.rs
+++ b/src/crates/core/src/agentic/tools/product_runtime/get_tool_spec_tool.rs
@@ -4,9 +4,8 @@ use super::{
     product_get_tool_spec_runtime, resolve_product_get_tool_spec_results,
     ProductGetToolSpecRuntime, ProductToolCatalogProvider,
 };
-use crate::agentic::tools::framework::{
-    Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
-};
+use crate::agentic::tools::framework::{Tool, ToolRenderOptions, ToolResult, ValidationResult};
+use crate::agentic::tools::tool_context_runtime::ToolUseContext;
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
 use bitfun_agent_tools::{
@@ -133,7 +132,8 @@ fn map_get_tool_spec_execution_error(error: GetToolSpecExecutionError) -> BitFun
 #[cfg(test)]
 mod tests {
     use super::GetToolSpecTool;
-    use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
+    use crate::agentic::tools::framework::{Tool, ToolResult};
+    use crate::agentic::tools::tool_context_runtime::ToolUseContext;
     use crate::agentic::tools::ToolRuntimeRestrictions;
     use serde_json::json;
     use std::collections::HashMap;

--- a/src/crates/core/src/agentic/tools/product_runtime/snapshot.rs
+++ b/src/crates/core/src/agentic/tools/product_runtime/snapshot.rs
@@ -1,0 +1,14 @@
+//! Product tool snapshot decoration boundary.
+
+use crate::agentic::tools::framework::Tool;
+use crate::agentic::tools::registry::ToolRef;
+use bitfun_agent_tools::SnapshotToolWrapper;
+
+#[derive(Debug, Clone)]
+pub(super) struct ProductSnapshotToolWrapper;
+
+impl SnapshotToolWrapper<dyn Tool> for ProductSnapshotToolWrapper {
+    fn wrap_for_snapshot_tracking(&self, tool: ToolRef) -> ToolRef {
+        crate::service::snapshot::wrap_tool_for_snapshot_tracking(tool)
+    }
+}


### PR DESCRIPTION
﻿## Summary

- Move tool manifest / visible tools / readonly catalog / GetToolSpec catalog ownership from `manifest_resolver.rs` and the flat product runtime file into `product_runtime/catalog.rs`.
- Keep `manifest_resolver.rs` as a compatibility facade only, with parity regressions against the product runtime owner.
- Move product snapshot wrapping into `product_runtime/snapshot.rs` and add boundary checks to prevent ownership from drifting back.
- Update core decomposition docs and core agent guidance to reflect the completed manifest/catalog/snapshot owner closure and the remaining Tool Runtime work.

## Behavior / risk review

- Product behavior is intended to remain unchanged: tool names, manifest order, collapsed/expanded exposure, GetToolSpec insertion, readonly filtering, and snapshot wrapping are covered by focused regressions.
- No product surface, build script, installer, or packaging path was changed.
- This is not an API-only PR: the old manifest resolver logic is removed from the legacy path and re-owned by the product runtime catalog boundary.

## Verification

- `node scripts/check-core-boundaries.mjs`
- `cargo check -p bitfun-core --features product-full`
- `cargo check -p bitfun-core --no-default-features`
- `cargo test -p bitfun-core --features product-full agentic::tools::manifest_resolver -- --nocapture`
- `cargo test -p bitfun-core --features product-full agentic::tools::product_runtime -- --nocapture`
- `cargo test -p bitfun-agent-tools`
- `pnpm run check:repo-hygiene`
- `git diff --check gcwing/main`
