### PR TITLE
fix(flow-chat): keep historical sessions responsive

### DIFF
--- a/src/web-ui/src/flow_chat/services/storeSync.test.ts
+++ b/src/web-ui/src/flow_chat/services/storeSync.test.ts
@@ -6,8 +6,10 @@ const syncMocks = vi.hoisted(() => {
     sessions: new Map<string, Session>(),
     activeSessionId: null as string | null,
   };
+  const listeners = new Set<(state: typeof flowState) => void>();
   const modernState = {
     activeSession: null as Session | null,
+    virtualItems: [] as unknown[],
     setActiveSession: vi.fn((session: Session | null) => {
       modernState.activeSession = session;
     }),
@@ -18,6 +20,7 @@ const syncMocks = vi.hoisted(() => {
 
   return {
     flowState,
+    listeners,
     modernState,
   };
 });
@@ -25,6 +28,12 @@ const syncMocks = vi.hoisted(() => {
 vi.mock('../store/FlowChatStore', () => ({
   flowChatStore: {
     getState: () => syncMocks.flowState,
+    subscribe: vi.fn((listener: (state: typeof syncMocks.flowState) => void) => {
+      syncMocks.listeners.add(listener);
+      return () => {
+        syncMocks.listeners.delete(listener);
+      };
+    }),
   },
 }));
 
@@ -34,7 +43,7 @@ vi.mock('../store/modernFlowChatStore', () => ({
   },
 }));
 
-import { syncSessionToModernStore } from './storeSync';
+import { startAutoSync, syncSessionToModernStore } from './storeSync';
 
 function createSession(overrides: Partial<Session> = {}): Session {
   return {
@@ -60,7 +69,9 @@ describe('storeSync history session state', () => {
   afterEach(() => {
     syncMocks.flowState.sessions = new Map();
     syncMocks.flowState.activeSessionId = null;
+    syncMocks.listeners.clear();
     syncMocks.modernState.activeSession = null;
+    syncMocks.modernState.virtualItems = [];
     syncMocks.modernState.setActiveSession.mockClear();
     syncMocks.modernState.clear.mockClear();
   });
@@ -75,5 +86,60 @@ describe('storeSync history session state', () => {
     expect(syncMocks.modernState.setActiveSession).toHaveBeenCalledWith(session);
     expect(syncMocks.modernState.activeSession).toBe(session);
     expect(syncMocks.modernState.activeSession?.historyState).toBe('metadata-only');
+  });
+
+  it('repairs a ready active session when the modern item projection is empty', () => {
+    const session = createSession({
+      isHistorical: false,
+      historyState: 'ready',
+      dialogTurns: [{
+        id: 'turn-1',
+        sessionId: 'history-1',
+        userMessage: {
+          id: 'user-1',
+          content: 'Loaded history',
+          timestamp: 1,
+        },
+        modelRounds: [],
+        status: 'completed',
+        startTime: 1,
+      }],
+    });
+    syncMocks.flowState.sessions = new Map([[session.sessionId, session]]);
+    syncMocks.flowState.activeSessionId = session.sessionId;
+    syncMocks.modernState.activeSession = session;
+    syncMocks.modernState.virtualItems = [];
+
+    syncSessionToModernStore(session.sessionId);
+
+    expect(syncMocks.modernState.setActiveSession).toHaveBeenCalledWith(session);
+  });
+
+  it('repairs an empty projection when auto sync starts on a ready active session', () => {
+    const session = createSession({
+      isHistorical: false,
+      historyState: 'ready',
+      dialogTurns: [{
+        id: 'turn-1',
+        sessionId: 'history-1',
+        userMessage: {
+          id: 'user-1',
+          content: 'Loaded history',
+          timestamp: 1,
+        },
+        modelRounds: [],
+        status: 'completed',
+        startTime: 1,
+      }],
+    });
+    syncMocks.flowState.sessions = new Map([[session.sessionId, session]]);
+    syncMocks.flowState.activeSessionId = session.sessionId;
+    syncMocks.modernState.activeSession = session;
+    syncMocks.modernState.virtualItems = [];
+
+    const unsubscribe = startAutoSync();
+    unsubscribe();
+
+    expect(syncMocks.modernState.setActiveSession).toHaveBeenCalledWith(session);
   });
 });

--- a/src/web-ui/src/flow_chat/services/storeSync.ts
+++ b/src/web-ui/src/flow_chat/services/storeSync.ts
@@ -6,18 +6,35 @@
 
 import { flowChatStore } from '../store/FlowChatStore';
 import { useModernFlowChatStore } from '../store/modernFlowChatStore';
+import type { Session } from '../types/flow-chat';
 import { createLogger } from '@/shared/utils/logger';
 
 const log = createLogger('StoreSync');
 
 function isSessionAlreadySynced(
   sessionId: string,
-  session: object,
+  session: Session,
   modernStore: ReturnType<typeof useModernFlowChatStore.getState>
 ): boolean {
-  return (
-    modernStore.activeSession?.sessionId === sessionId &&
-    modernStore.activeSession === session
+  if (
+    modernStore.activeSession?.sessionId !== sessionId ||
+    modernStore.activeSession !== session
+  ) {
+    return false;
+  }
+
+  if (session.historyState === 'ready' && hasRenderableContent(session) && modernStore.virtualItems.length === 0) {
+    return false;
+  }
+
+  return true;
+}
+
+function hasRenderableContent(session: Session): boolean {
+  return session.dialogTurns.some(turn =>
+    Boolean(turn.userMessage) ||
+    (turn.status === 'image_analyzing' && turn.modelRounds.length === 0) ||
+    turn.modelRounds.some(round => round.items.length > 0)
   );
 }
 
@@ -56,7 +73,14 @@ export function startAutoSync(): () => void {
 
     if (state.activeSessionId) {
       const session = state.sessions.get(state.activeSessionId);
-      if (session && (session !== lastSyncedSession || state.activeSessionId !== lastSyncedSessionId)) {
+      if (
+        session &&
+        (
+          session !== lastSyncedSession ||
+          state.activeSessionId !== lastSyncedSessionId ||
+          !isSessionAlreadySynced(state.activeSessionId, session, modernStore)
+        )
+      ) {
         lastSyncedSessionId = state.activeSessionId;
         lastSyncedSession = session;
         modernStore.setActiveSession(session);

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
@@ -509,4 +509,73 @@ describe('sessionToVirtualItems explore grouping', () => {
       steeringStatus: 'pending',
     });
   });
+
+  it('reuses the projection for completed turns when a later active turn changes', () => {
+    const completedTurn = {
+      id: 'completed-turn',
+      sessionId: 'stable-turn-session',
+      userMessage: {
+        id: 'user-completed',
+        content: 'Loaded prompt',
+        timestamp: 900,
+      },
+      modelRounds: [makeRound({ id: 'completed-round' })],
+      status: 'completed' as const,
+      startTime: 900,
+    };
+    const activeTurnBase = {
+      id: 'active-turn',
+      sessionId: 'stable-turn-session',
+      userMessage: {
+        id: 'user-active',
+        content: 'Continue',
+        timestamp: 1000,
+      },
+      status: 'processing' as const,
+      startTime: 1000,
+    };
+    const firstSession = makeSession({
+      sessionId: 'stable-turn-session',
+      dialogTurns: [
+        completedTurn,
+        {
+          ...activeTurnBase,
+          modelRounds: [
+            makeRound({
+              id: 'active-round-1',
+              isStreaming: true,
+              isComplete: false,
+              status: 'streaming',
+              items: [makeTool('active-tool-1', 'TodoWrite', 'running')],
+            }),
+          ],
+        },
+      ],
+    });
+    const secondSession = makeSession({
+      sessionId: 'stable-turn-session',
+      dialogTurns: [
+        completedTurn,
+        {
+          ...activeTurnBase,
+          modelRounds: [
+            makeRound({
+              id: 'active-round-2',
+              isStreaming: true,
+              isComplete: false,
+              status: 'streaming',
+              items: [makeTool('active-tool-2', 'TodoWrite', 'running')],
+            }),
+          ],
+        },
+      ],
+    });
+
+    const firstItems = sessionToVirtualItems(firstSession);
+    const secondItems = sessionToVirtualItems(secondSession);
+
+    expect(secondItems[0]).toBe(firstItems[0]);
+    expect(secondItems[1]).toBe(firstItems[1]);
+    expect(secondItems[2]).not.toBe(firstItems[2]);
+  });
 });

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
@@ -7,13 +7,10 @@
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 import { immer } from 'zustand/middleware/immer';
-import type { Session, DialogTurn, ModelRound, FlowItem, FlowToolItem, FlowUserSteeringItem } from '../types/flow-chat';
+import type { Session, DialogTurn, ModelRound, FlowItem, FlowToolItem, FlowUserSteeringItem, AnyFlowItem } from '../types/flow-chat';
 import { isCollapsibleTool, READ_TOOL_NAMES, SEARCH_TOOL_NAMES, COMMAND_TOOL_NAMES } from '../tool-cards';
 import { COMPLETED_TOOL_TRANSIENT_MS } from '../components/modern/modelRoundItemGrouping';
 import { flowChatStore } from './FlowChatStore';
-import { createLogger } from '@/shared/utils/logger';
-
-const log = createLogger('ModernFlowChatStore');
 
 /**
  * Explore group statistics (merged computed stats)
@@ -180,9 +177,55 @@ function steeringItemToUserMessage(item: FlowUserSteeringItem): NonNullable<Dial
   };
 }
 
+function isTerminalTurnStatus(status: DialogTurn['status']): boolean {
+  return status === 'completed' || status === 'cancelled' || status === 'error';
+}
+
+function isTerminalRoundStatus(status: ModelRound['status']): boolean {
+  return status === 'completed' || status === 'cancelled' || status === 'error';
+}
+
+function isActiveFlowItem(item: AnyFlowItem): boolean {
+  if (
+    item.status === 'pending' ||
+    item.status === 'preparing' ||
+    item.status === 'running' ||
+    item.status === 'streaming' ||
+    item.status === 'receiving' ||
+    item.status === 'analyzing' ||
+    item.status === 'pending_confirmation'
+  ) {
+    return true;
+  }
+
+  if (item.type === 'text' || item.type === 'thinking') {
+    return item.isStreaming;
+  }
+
+  if (item.type === 'tool') {
+    return item.isParamsStreaming === true;
+  }
+
+  return false;
+}
+
+function isStableTurnProjection(turn: DialogTurn): boolean {
+  if (!isTerminalTurnStatus(turn.status)) {
+    return false;
+  }
+
+  return turn.modelRounds.every(round =>
+    isTerminalRoundStatus(round.status) &&
+    !round.isStreaming &&
+    round.isComplete !== false &&
+    round.items.every(item => !isActiveFlowItem(item))
+  );
+}
+
 let cachedSession: Session | null = null;
 let cachedDialogTurnsRef: DialogTurn[] | null = null;
 let cachedVirtualItems: VirtualItem[] = [];
+let cachedTurnItems = new WeakMap<DialogTurn, VirtualItem[]>();
 
 /**
  * Convert Session to virtualized render items
@@ -199,6 +242,7 @@ export function sessionToVirtualItems(session: Session | null): VirtualItem[] {
       cachedSession = null;
       cachedDialogTurnsRef = null;
       cachedVirtualItems = [];
+      cachedTurnItems = new WeakMap();
     }
     return cachedVirtualItems;
   }
@@ -217,6 +261,13 @@ export function sessionToVirtualItems(session: Session | null): VirtualItem[] {
   const nowMs = Date.now();
 
   session.dialogTurns.forEach(turn => {
+    const cachedItems = cachedTurnItems.get(turn);
+    if (cachedItems && isStableTurnProjection(turn)) {
+      items.push(...cachedItems);
+      return;
+    }
+    const turnItemStart = items.length;
+
     if (turn.userMessage) {
       items.push({
         type: 'user-message',
@@ -338,16 +389,6 @@ export function sessionToVirtualItems(session: Session | null): VirtualItem[] {
 
           const groupId = group.rounds[0]?.id ?? `explore-group-${turn.id}-${group.startIndex}`;
 
-          if (wasCutByCritical) {
-            log.debug('explore-group marked wasCutByCritical', {
-              groupId,
-              endIndex: group.endIndex,
-              totalRounds: rounds.length,
-              isTurnComplete,
-              isGroupStreaming,
-            });
-          }
-
           items.push({
             type: 'explore-group',
             turnId: turn.id,
@@ -404,6 +445,9 @@ export function sessionToVirtualItems(session: Session | null): VirtualItem[] {
 
     flushRoundEntries(pendingRounds, { collapseTrailingExploreGroup: true });
 
+    if (isStableTurnProjection(turn)) {
+      cachedTurnItems.set(turn, items.slice(turnItemStart));
+    }
   });
 
   cachedVirtualItems = items;
@@ -457,6 +501,7 @@ export const useModernFlowChatStore = create<ModernFlowChatState>()(
       cachedSession = null;
       cachedDialogTurnsRef = null;
       cachedVirtualItems = [];
+      cachedTurnItems = new WeakMap();
 
       set((state) => {
         state.activeSession = null;

--- a/src/web-ui/src/flow_chat/tool-cards/DefaultToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/DefaultToolCard.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+import { DefaultToolCard } from './DefaultToolCard';
+import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-i18next', async () => {
+  const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next');
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+    }),
+  };
+});
+
+vi.mock('../../component-library', () => ({
+  ToolProcessingDots: () => <span data-testid="tool-processing-dots" />,
+}));
+
+const config: ToolCardConfig = {
+  toolName: 'WebFetch',
+  displayName: 'WebFetch',
+  icon: 'W',
+  requiresConfirmation: false,
+  resultDisplayType: 'summary',
+  description: 'Fetch web content',
+  displayMode: 'compact',
+};
+
+function completedWebFetchItem(result: unknown): FlowToolItem {
+  return {
+    id: 'tool-webfetch-1',
+    type: 'tool',
+    toolName: 'WebFetch',
+    status: 'completed',
+    timestamp: Date.now(),
+    toolCall: {
+      id: 'call-webfetch-1',
+      input: {
+        url: 'https://example.com/large',
+      },
+    },
+    toolResult: {
+      success: true,
+      result,
+    },
+  };
+}
+
+describe('DefaultToolCard', () => {
+  let dom: JSDOM;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      pretendToBeVisual: true,
+    });
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('CustomEvent', dom.window.CustomEvent);
+    vi.stubGlobal('ResizeObserver', class {
+      observe = vi.fn();
+      disconnect = vi.fn();
+    });
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it('does not stringify detailed result payloads while collapsed', () => {
+    const result = {
+      content: 'large fetched page content',
+    };
+    const toJSON = vi.fn(() => result);
+    Object.defineProperty(result, 'toJSON', {
+      enumerable: false,
+      value: toJSON,
+    });
+
+    act(() => {
+      root.render(
+        <DefaultToolCard
+          toolItem={completedWebFetchItem(result)}
+          config={config}
+        />
+      );
+    });
+
+    expect(container.textContent).toContain('toolCards.default.completed');
+    expect(toJSON).not.toHaveBeenCalled();
+  });
+
+  it('stringifies detailed result payloads after the card is expanded', () => {
+    const result = {
+      content: 'large fetched page content',
+    };
+    const toJSON = vi.fn(() => result);
+    Object.defineProperty(result, 'toJSON', {
+      enumerable: false,
+      value: toJSON,
+    });
+
+    act(() => {
+      root.render(
+        <DefaultToolCard
+          toolItem={completedWebFetchItem(result)}
+          config={config}
+        />
+      );
+    });
+
+    const card = container.querySelector('.compact-tool-card');
+    expect(card).not.toBeNull();
+
+    act(() => {
+      card?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(toJSON).toHaveBeenCalled();
+    expect(container.textContent).toContain('large fetched page content');
+  });
+});

--- a/src/web-ui/src/flow_chat/tool-cards/DefaultToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/DefaultToolCard.tsx
@@ -19,6 +19,8 @@ import {
 import './DefaultToolCard.scss';
 
 const MAX_PREVIEW_CHARS = 4000;
+const INLINE_PREVIEW_CHARS = 72;
+const INLINE_PREVIEW_SCAN_CHARS = 512;
 
 function sanitizeToolInput(input: any): any {
   if (input === null || input === undefined) return input;
@@ -62,10 +64,15 @@ function getInlinePreview(value: any): string | null {
   if (value === null || value === undefined) return null;
 
   if (typeof value === 'string') {
-    const normalized = value.replace(/\s+/g, ' ').trim();
+    const scanned = value.length > INLINE_PREVIEW_SCAN_CHARS
+      ? value.slice(0, INLINE_PREVIEW_SCAN_CHARS)
+      : value;
+    const normalized = scanned.replace(/\s+/g, ' ').trim();
     if (!normalized) return null;
     if (isOnlySessionViewPreviewText(normalized)) return null;
-    return normalized.length > 72 ? `${normalized.slice(0, 72)}...` : normalized;
+    return normalized.length > INLINE_PREVIEW_CHARS || scanned.length < value.length
+      ? `${normalized.slice(0, INLINE_PREVIEW_CHARS)}...`
+      : normalized;
   }
 
   if (typeof value === 'number' || typeof value === 'boolean') {
@@ -116,14 +123,14 @@ export const DefaultToolCard: React.FC<ToolCardProps> = ({
   const canExpand = hasInput || hasResult || hasError || showConfirmationActions;
 
   const inputPreview = useMemo(() => {
-    if (!hasInput) return null;
+    if (!isExpanded || !hasInput) return null;
     return truncatePreview(stringifyValue(filteredInput));
-  }, [filteredInput, hasInput]);
+  }, [filteredInput, hasInput, isExpanded]);
 
   const resultPreview = useMemo(() => {
-    if (!hasResult) return null;
+    if (!isExpanded || !hasResult) return null;
     return truncatePreview(stringifyValue(toolResult?.result));
-  }, [hasResult, toolResult?.result]);
+  }, [hasResult, isExpanded, toolResult?.result]);
 
   const handleConfirm = () => {
     onConfirm?.(toolCall?.input);
@@ -221,7 +228,7 @@ export const DefaultToolCard: React.FC<ToolCardProps> = ({
         onClick={handleToggleExpand}
         className={`default-tool-card ${showConfirmationHighlight ? 'requires-confirmation' : ''}`}
         clickable={canExpand}
-          header={
+        header={
           <CompactToolCardHeader
             icon={<ToolCardStatusSlot status={status} toolIcon={config.icon ?? undefined} />}
             action={config.displayName}
@@ -238,57 +245,57 @@ export const DefaultToolCard: React.FC<ToolCardProps> = ({
               )}
             </div>
 
-          {hasInput && (
-            <div className="default-tool-card__section">
-              <div className="default-tool-card__section-label">{t('toolCards.common.inputParams')}</div>
-              <pre className="default-tool-card__code-block">{inputPreview}</pre>
-            </div>
-          )}
+            {hasInput && (
+              <div className="default-tool-card__section">
+                <div className="default-tool-card__section-label">{t('toolCards.common.inputParams')}</div>
+                <pre className="default-tool-card__code-block">{inputPreview}</pre>
+              </div>
+            )}
 
-          {showConfirmationActions && (
-            <div className="default-tool-card__actions">
-              {hasAcpPermissionOptions(toolItem) ? (
-                <AcpPermissionActions
-                  toolItem={toolItem}
-                  input={toolCall?.input}
-                  presentation="text"
-                  disabled={status === 'streaming'}
-                  onConfirm={onConfirm}
-                  onReject={onReject}
-                />
-              ) : (
-                <>
-                  <button
-                    type="button"
-                    className="default-tool-card__button default-tool-card__button--confirm"
-                    onClick={handleConfirm}
+            {showConfirmationActions && (
+              <div className="default-tool-card__actions">
+                {hasAcpPermissionOptions(toolItem) ? (
+                  <AcpPermissionActions
+                    toolItem={toolItem}
+                    input={toolCall?.input}
+                    presentation="text"
                     disabled={status === 'streaming'}
-                  >
-                    {t('toolCards.mcp.confirmExecute')}
-                  </button>
-                  <button
-                    type="button"
-                    className="default-tool-card__button default-tool-card__button--reject"
-                    onClick={handleReject}
-                    disabled={status === 'streaming'}
-                  >
-                    {t('toolCards.mcp.cancel')}
-                  </button>
-                </>
-              )}
-            </div>
-          )}
+                    onConfirm={onConfirm}
+                    onReject={onReject}
+                  />
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      className="default-tool-card__button default-tool-card__button--confirm"
+                      onClick={handleConfirm}
+                      disabled={status === 'streaming'}
+                    >
+                      {t('toolCards.mcp.confirmExecute')}
+                    </button>
+                    <button
+                      type="button"
+                      className="default-tool-card__button default-tool-card__button--reject"
+                      onClick={handleReject}
+                      disabled={status === 'streaming'}
+                    >
+                      {t('toolCards.mcp.cancel')}
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
 
-          {hasResult && (
-            <div className="default-tool-card__section">
-              <div className="default-tool-card__section-label">{t('toolCards.common.executionResult')}</div>
-              {toolResult?.success === false ? (
-                <div className="default-tool-card__error-message">{errorMessage}</div>
-              ) : (
-                <pre className="default-tool-card__code-block">{resultPreview}</pre>
-              )}
-            </div>
-          )}
+            {hasResult && (
+              <div className="default-tool-card__section">
+                <div className="default-tool-card__section-label">{t('toolCards.common.executionResult')}</div>
+                {toolResult?.success === false ? (
+                  <div className="default-tool-card__error-message">{errorMessage}</div>
+                ) : (
+                  <pre className="default-tool-card__code-block">{resultPreview}</pre>
+                )}
+              </div>
+            )}
           </div>
         ) : undefined}
       />


### PR DESCRIPTION
## Summary
- Keep ready restored sessions from being skipped by the legacy-to-modern store sync when the modern projection is unexpectedly empty.
- Cache virtual items for stable completed turns so active-turn updates do not repeatedly rebuild old history turns.
- Defer large collapsed default tool-card previews from the earlier fix.
- Remove the hot-path per explore-group debug log that produced thousands of repeated webview log entries during the latest repro.

## Root cause
The first logs showed historical hydration completing, but rendering was expensive because collapsed default tool cards still eagerly built detailed previews from large persisted tool results.

The latest repro looks different: the webview logs do not contain `historical_session_*` / `restore_session_view` markers or repeated large default `WebFetch` cards, but they do show thousands of repeated `ModernFlowChatStore` explore-group projection logs. That points to the UI/store projection path rather than backend history loading. If the active restored session is already `ready` while `ModernFlowChatStore.virtualItems` remains empty, the existing sync short-circuit can leave the loading placeholder visible until a session switch forces another sync.

## Impact
- Restored history sessions with renderable content now re-sync if the modern projection is empty instead of staying on the loading shell.
- Completed historical turns are reused while later active turns change, reducing repeated projection work on large sessions.
- Collapsed default tool cards still show bounded summaries; expanded details still render on demand.

## Validation
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/flow_chat/services/storeSync.test.ts src/flow_chat/store/modernFlowChatStore.test.ts src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx src/flow_chat/tool-cards/DefaultToolCard.test.tsx`
- `pnpm run check:repo-hygiene`
- `git diff --check`
