### PR TITLE
feat(prompt): require self-verification before declaring task done

### DIFF
--- a/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
+++ b/src/crates/core/src/agentic/agents/prompts/agentic_mode.md
@@ -56,6 +56,11 @@ The user will primarily request you perform software engineering tasks. This inc
   - List candidate sites in a TodoWrite item *before* writing the first edit. The list is the completion checklist: don't declare the fix done until each site is either changed or explicitly justified as not needing change.
 - Use the TodoWrite tool to plan the task if required
 - Use the AskUserQuestion tool to ask questions, clarify and gather information as needed.
+- After making code changes that should fix a bug or change behavior, verify the fix yourself before declaring done. A failed verification is signal, not failure:
+  - Start with cheap static checks: ensure imports succeed and syntax is valid (e.g., `python -c "import <package>"`, the project's linter/formatter when present).
+  - Find and run the tests the repository ships that exercise the changed code path. Use the project's own test runner (look at README/CI config rather than assuming a default). Scope the first run to the modified module before broadening.
+  - If the task description references specific tests, tracebacks, or reproduction scripts, run those — they were given to you as input.
+  - Treat any failure output as your next signal. Do not declare the task done until each failure is either fixed or explicitly justified as unrelated to the change.
 - Be careful not to introduce security vulnerabilities such as command injection, XSS, SQL injection, and other OWASP top 10 vulnerabilities. If you notice that you wrote insecure code, immediately fix it.
 - Avoid over-engineering. Only make changes that are directly requested or clearly necessary. Keep solutions simple and focused.
   - Don't add features, refactor code, or make "improvements" beyond what was asked. A bug fix doesn't need surrounding code cleaned up. A simple feature doesn't need extra configurability. Don't add docstrings, comments, or type annotations to code you didn't change. Only add comments where the logic isn't self-evident.


### PR DESCRIPTION
Continuing the SWE-bench Verified incomplete-fix work (P0a covered scope enumeration before edits; this covers verification after).

Add to shared agentic_mode "Doing tasks": after a behavior-changing edit, run static checks, repo-shipped tests scoped to the modified module, and any tests the task description quotes. Treat failures as the next signal, not as the end state. Avoids hidden-evaluator leakage by sourcing tests only from the repo and task input.

## Summary

<!-- Briefly describe what changed. -->

Fixes #

## Type and Areas

Type:

<!-- Feature / bug fix / regression fix / refactor / UI/UX / docs / test / CI / dependency / other. -->

Areas:

<!-- Rust core, desktop/Tauri, web UI, mobile web, server/relay, AI adapters, installer, docs, etc. -->

## Motivation / Impact

<!-- What problem does this solve, and what changes for users or developers? Write "No direct user-facing change" if applicable. -->

## Verification

<!-- List exact commands, manual checks, and outcomes. For docs-only or template-only changes, use the lightest relevant checks or explain why runtime checks were skipped. -->

## Reviewer Notes

<!-- Optional: screenshots, architecture notes, compatibility risks, migration notes, or rollback guidance. -->

## Checklist

- [ ] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [ ] Relevant verification is recorded above, or skipped checks are explained.
- [ ] User-facing strings, docs, and locales are updated where applicable.
