### PR TITLE
ci: make PR rust cache restore-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
         with:
           shared-key: "ci-check-v2-${{ runner.os }}-no-cargo-bin-v1"
           cache-bin: false
+          # PR caches are scoped to merge refs; main pushes own shared cache refreshes.
+          save-if: ${{ github.event_name != 'pull_request' }}
 
       - name: Check compilation
         run: cargo check --workspace --exclude bitfun-cli


### PR DESCRIPTION
﻿## Summary
- Keep Rust cache restore enabled for all CI platforms.
- Make all `pull_request` CI runs restore-only for Rust cache saves.
- Keep `push` runs, including `main`, responsible for refreshing shared Rust caches.

## Context
Recent CI samples show Linux/macOS usually hit exact cache keys and finish rust-cache post-run in ~0-1s, while Windows repeatedly restores an older key and spends several minutes saving a large cache. PR-created caches are scoped to the PR merge ref, so those uploads are not reusable by the base branch or sibling PRs. Treating PR runs as restore-only avoids low-value cache uploads without adding platform-specific policy.

| Recent successful CI samples | macOS | Ubuntu | Windows |
|---|---:|---:|---:|
| `swatinem/rust-cache` post-run range | 0-1s | 0-1s | 207-324s |
| Cache behavior in logs | exact hit, up-to-date | exact hit, up-to-date | restore-key hit, save upload |

## Risk
- PR runs no longer create new Rust cache entries on any platform.
- After Rust dependency, lockfile, or toolchain changes, PRs may compile more until a `push` run refreshes the shared cache.
- Build correctness is unchanged because this only changes cache save behavior, not restore, compile, or test steps.

## Verification
- `pnpm run check:github-config`
- `pnpm run check:repo-hygiene`
- `git diff --check`
