### PR TITLE
perf(startup): add tracing and reduce shell latency

### DIFF
--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -14,6 +14,7 @@ use crate::api::search_api::{
     should_use_workspace_search, SearchMetadataResponse,
 };
 use crate::api::workspace_activation::spawn_workspace_background_warmup;
+use crate::startup_trace::DesktopStartupTrace;
 use bitfun_core::infrastructure::{
     BatchedFileSearchProgressSink, FileSearchOutcome, FileSearchProgressSink, FileSearchResult,
     FileSearchResultGroup, FileTreeNode, SearchMatchType,
@@ -31,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, State};
 
 fn remote_workspace_from_info(info: &WorkspaceInfo) -> Option<crate::api::RemoteWorkspace> {
@@ -827,30 +828,67 @@ pub struct RevealInExplorerRequest {
     pub path: String,
 }
 
-async fn clear_active_workspace_context(state: &State<'_, AppState>, app: &AppHandle) {
+async fn clear_active_workspace_context(
+    state: &State<'_, AppState>,
+    app: &AppHandle,
+    startup_trace: Option<&DesktopStartupTrace>,
+) {
     #[cfg(not(target_os = "macos"))]
     let _ = app;
 
+    let step_started = Instant::now();
     let previous_workspace_path = state.workspace_path.read().await.clone();
     *state.workspace_path.write().await = None;
+    if let Some(trace) = startup_trace {
+        trace.record_elapsed_step(
+            "tauri_command",
+            "initialize_global_state.clear_active_workspace_path",
+            step_started,
+        );
+    }
 
     if let Some(previous_workspace_path) = previous_workspace_path {
+        let step_started = Instant::now();
         let root_str = previous_workspace_path.to_string_lossy().to_string();
         if !is_remote_path(root_str.trim()).await {
             state
                 .workspace_search_service
                 .schedule_repo_release(previous_workspace_path);
         }
+        if let Some(trace) = startup_trace {
+            trace.record_elapsed_step(
+                "tauri_command",
+                "initialize_global_state.release_previous_workspace_search",
+                step_started,
+            );
+        }
     }
 
     if let Some(ref pool) = state.js_worker_pool {
+        let step_started = Instant::now();
         pool.stop_all().await;
+        if let Some(trace) = startup_trace {
+            trace.record_elapsed_step(
+                "tauri_command",
+                "initialize_global_state.stop_js_worker_pool",
+                step_started,
+            );
+        }
     }
 
+    let step_started = Instant::now();
     state.agent_registry.clear_custom_subagents();
+    if let Some(trace) = startup_trace {
+        trace.record_elapsed_step(
+            "tauri_command",
+            "initialize_global_state.clear_custom_subagents",
+            step_started,
+        );
+    }
 
     #[cfg(target_os = "macos")]
     {
+        let step_started = Instant::now();
         let language = state
             .config_service
             .get_config::<String>(Some("app.language"))
@@ -863,6 +901,13 @@ async fn clear_active_workspace_context(state: &State<'_, AppState>, app: &AppHa
             crate::macos_menubar::MenubarMode::Startup,
             edit_mode,
         );
+        if let Some(trace) = startup_trace {
+            trace.record_elapsed_step(
+                "tauri_command",
+                "initialize_global_state.set_macos_startup_menubar",
+                step_started,
+            );
+        }
     }
 }
 
@@ -870,18 +915,44 @@ async fn apply_active_workspace_context(
     state: &State<'_, AppState>,
     app: &AppHandle,
     workspace_info: &bitfun_core::service::workspace::manager::WorkspaceInfo,
+    startup_trace: Option<&DesktopStartupTrace>,
 ) {
     #[cfg(not(target_os = "macos"))]
     let _ = app;
 
-    clear_active_workspace_context(state, app).await;
+    let step_started = Instant::now();
+    clear_active_workspace_context(state, app, startup_trace).await;
+    if let Some(trace) = startup_trace {
+        trace.record_elapsed_step(
+            "tauri_command",
+            "initialize_global_state.clear_active_workspace_context",
+            step_started,
+        );
+    }
 
+    let step_started = Instant::now();
     *state.workspace_path.write().await = Some(workspace_info.root_path.clone());
+    if let Some(trace) = startup_trace {
+        trace.record_elapsed_step(
+            "tauri_command",
+            "initialize_global_state.set_active_workspace_path",
+            step_started,
+        );
+    }
 
+    let step_started = Instant::now();
     spawn_workspace_background_warmup(&*state, workspace_info.clone());
+    if let Some(trace) = startup_trace {
+        trace.record_elapsed_step(
+            "tauri_command",
+            "initialize_global_state.spawn_workspace_background_warmup",
+            step_started,
+        );
+    }
 
     #[cfg(target_os = "macos")]
     {
+        let step_started = Instant::now();
         let language = state
             .config_service
             .get_config::<String>(Some("app.language"))
@@ -894,10 +965,18 @@ async fn apply_active_workspace_context(
             crate::macos_menubar::MenubarMode::Workspace,
             edit_mode,
         );
+        if let Some(trace) = startup_trace {
+            trace.record_elapsed_step(
+                "tauri_command",
+                "initialize_global_state.set_macos_workspace_menubar",
+                step_started,
+            );
+        }
     }
 
     // Keep global SSH registry + active connection hint aligned with the **foreground** workspace
     // so two servers opened at the same remote path (e.g. `/`) stay distinct.
+    let step_started = Instant::now();
     if workspace_info.workspace_kind == WorkspaceKind::Remote {
         if let Some(rw) = remote_workspace_from_info(workspace_info) {
             if let Err(e) = state.set_remote_workspace(rw).await {
@@ -913,15 +992,39 @@ async fn apply_active_workspace_context(
             m.set_active_connection_hint(None).await;
         }
     }
+    if let Some(trace) = startup_trace {
+        trace.record_elapsed_step(
+            "tauri_command",
+            "initialize_global_state.sync_remote_workspace_context",
+            step_started,
+        );
+    }
 }
 
 #[tauri::command]
 pub async fn initialize_global_state(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
+    startup_trace: State<'_, DesktopStartupTrace>,
 ) -> Result<String, String> {
-    if let Some(workspace_info) = state.workspace_service.get_current_workspace().await {
-        apply_active_workspace_context(&state, &app, &workspace_info).await;
+    let command_started = Instant::now();
+    let trace = startup_trace.inner();
+    let step_started = Instant::now();
+    let current_workspace = state.workspace_service.get_current_workspace().await;
+    trace.record_elapsed_step(
+        "tauri_command",
+        "initialize_global_state.get_current_workspace",
+        step_started,
+    );
+
+    if let Some(workspace_info) = current_workspace {
+        let step_started = Instant::now();
+        apply_active_workspace_context(&state, &app, &workspace_info, Some(trace)).await;
+        trace.record_elapsed_step(
+            "tauri_command",
+            "initialize_global_state.apply_active_workspace_context",
+            step_started,
+        );
 
         info!(
             "Global state initialized with active workspace: workspace_id={}, path={}",
@@ -929,9 +1032,22 @@ pub async fn initialize_global_state(
             workspace_info.root_path.display()
         );
     } else {
-        clear_active_workspace_context(&state, &app).await;
+        let step_started = Instant::now();
+        clear_active_workspace_context(&state, &app, Some(trace)).await;
+        trace.record_elapsed_step(
+            "tauri_command",
+            "initialize_global_state.clear_active_workspace_context",
+            step_started,
+        );
         info!("Global state initialized without active workspace");
     }
+
+    trace.record_elapsed_step(
+        "tauri_command",
+        "initialize_global_state.total",
+        command_started,
+    );
+    trace.record_tauri_command_elapsed("initialize_global_state", None, command_started);
 
     Ok("Global state initialized successfully".to_string())
 }
@@ -974,19 +1090,18 @@ pub async fn initialize_ai(state: State<'_, AppState>) -> Result<String, String>
         .primary
         .clone()
         .ok_or_else(|| {
-        "Primary model not configured, please configure it in settings".to_string()
-    })?;
+            "Primary model not configured, please configure it in settings".to_string()
+        })?;
     let model_config = global_config
         .ai
         .models
         .iter()
         .find(|m| m.id == primary_model_id)
         .ok_or_else(|| format!("Primary model '{}' does not exist", primary_model_id))?;
-    let stream_options =
-        bitfun_core::infrastructure::ai::build_stream_options_for_model(
-            &global_config.ai,
-            Some(model_config),
-        );
+    let stream_options = bitfun_core::infrastructure::ai::build_stream_options_for_model(
+        &global_config.ai,
+        Some(model_config),
+    );
 
     let ai_config = bitfun_core::util::types::AIConfig::try_from(model_config.clone())
         .map_err(|e| format!("Failed to convert AI configuration: {}", e))?;
@@ -1019,11 +1134,10 @@ async fn create_transient_ai_client_for_config(
         .get_config(None)
         .await
         .map_err(|e| format!("Failed to get configuration: {}", e))?;
-    let stream_options =
-        bitfun_core::infrastructure::ai::build_stream_options_for_model(
-            &global_config.ai,
-            Some(&model_config),
-        );
+    let stream_options = bitfun_core::infrastructure::ai::build_stream_options_for_model(
+        &global_config.ai,
+        Some(&model_config),
+    );
 
     let mut ai_config: bitfun_core::util::types::AIConfig = model_config
         .try_into()
@@ -1253,7 +1367,7 @@ pub async fn open_workspace(
         .await
     {
         Ok(workspace_info) => {
-            apply_active_workspace_context(&state, &app, &workspace_info).await;
+            apply_active_workspace_context(&state, &app, &workspace_info, None).await;
 
             if let Err(e) = state
                 .workspace_identity_watch_service
@@ -1394,7 +1508,7 @@ pub async fn open_remote_workspace(
                 warn!("Failed to set remote workspace state: {}", e);
             }
 
-            apply_active_workspace_context(&state, &app, &workspace_info).await;
+            apply_active_workspace_context(&state, &app, &workspace_info, None).await;
 
             info!(
                 "Remote workspace opened: name={}, remote_path={}, connection_id={}",
@@ -1423,7 +1537,7 @@ pub async fn create_assistant_workspace(
         .await
     {
         Ok(workspace_info) => {
-            apply_active_workspace_context(&state, &app, &workspace_info).await;
+            apply_active_workspace_context(&state, &app, &workspace_info, None).await;
 
             if let Err(e) = state
                 .workspace_identity_watch_service
@@ -1514,9 +1628,9 @@ pub async fn delete_assistant_workspace(
         .map_err(|e| format!("Failed to remove assistant workspace state: {}", e))?;
 
     if let Some(current_workspace) = state.workspace_service.get_current_workspace().await {
-        apply_active_workspace_context(&state, &app, &current_workspace).await;
+        apply_active_workspace_context(&state, &app, &current_workspace, None).await;
     } else {
-        clear_active_workspace_context(&state, &app).await;
+        clear_active_workspace_context(&state, &app, None).await;
     }
 
     if let Err(e) = state
@@ -1643,7 +1757,7 @@ pub async fn reset_assistant_workspace(
         .map(|workspace| workspace.id == request.workspace_id)
         .unwrap_or(false)
     {
-        apply_active_workspace_context(&state, &app, &updated_workspace).await;
+        apply_active_workspace_context(&state, &app, &updated_workspace, None).await;
     }
 
     info!(
@@ -1684,9 +1798,9 @@ pub async fn close_workspace(
             }
 
             if let Some(workspace_info) = state.workspace_service.get_current_workspace().await {
-                apply_active_workspace_context(&state, &app, &workspace_info).await;
+                apply_active_workspace_context(&state, &app, &workspace_info, None).await;
             } else {
-                clear_active_workspace_context(&state, &app).await;
+                clear_active_workspace_context(&state, &app, None).await;
             }
 
             info!("Workspace closed: workspace_id={}", request.workspace_id);
@@ -1717,7 +1831,7 @@ pub async fn set_active_workspace(
                 .await
                 .ok_or_else(|| "Active workspace not found after switching".to_string())?;
 
-            apply_active_workspace_context(&state, &app, &workspace_info).await;
+            apply_active_workspace_context(&state, &app, &workspace_info, None).await;
 
             info!(
                 "Active workspace changed: workspace_id={}, path={}",
@@ -1785,7 +1899,7 @@ pub async fn update_workspace_info(
                 .unwrap_or(false);
 
             if is_active_workspace {
-                apply_active_workspace_context(&state, &app, &workspace_info).await;
+                apply_active_workspace_context(&state, &app, &workspace_info, None).await;
             }
 
             info!(
@@ -1806,25 +1920,33 @@ pub async fn update_workspace_info(
 #[tauri::command]
 pub async fn get_current_workspace(
     state: State<'_, AppState>,
+    startup_trace: State<'_, DesktopStartupTrace>,
 ) -> Result<Option<WorkspaceInfoDto>, String> {
+    let trace_started = Instant::now();
     let workspace_service = &state.workspace_service;
-    Ok(workspace_service
+    let result = Ok(workspace_service
         .get_current_workspace()
         .await
-        .map(|info| WorkspaceInfoDto::from_workspace_info(&info)))
+        .map(|info| WorkspaceInfoDto::from_workspace_info(&info)));
+    startup_trace.record_tauri_command_elapsed("get_current_workspace", None, trace_started);
+    result
 }
 
 #[tauri::command]
 pub async fn get_recent_workspaces(
     state: State<'_, AppState>,
+    startup_trace: State<'_, DesktopStartupTrace>,
 ) -> Result<Vec<WorkspaceInfoDto>, String> {
+    let trace_started = Instant::now();
     let workspace_service = &state.workspace_service;
-    Ok(workspace_service
+    let result = Ok(workspace_service
         .get_recent_workspaces()
         .await
         .into_iter()
         .map(|info| WorkspaceInfoDto::from_workspace_info(&info))
-        .collect())
+        .collect());
+    startup_trace.record_tauri_command_elapsed("get_recent_workspaces", None, trace_started);
+    result
 }
 
 #[tauri::command]
@@ -1843,18 +1965,39 @@ pub async fn remove_recent_workspace(
 pub async fn cleanup_invalid_workspaces(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
+    startup_trace: State<'_, DesktopStartupTrace>,
 ) -> Result<usize, String> {
+    let trace_started = Instant::now();
+    let cleanup_started = Instant::now();
     match state.workspace_service.cleanup_invalid_workspaces().await {
         Ok(local_removed_count) => {
+            startup_trace.record_elapsed_step(
+                "tauri_command",
+                "cleanup_invalid_workspaces.local_workspace_cleanup",
+                cleanup_started,
+            );
+            let prune_remote_started = Instant::now();
             let remote_removed_count = prune_unrecoverable_remote_workspaces(&state).await;
+            startup_trace.record_elapsed_step(
+                "tauri_command",
+                "cleanup_invalid_workspaces.remote_workspace_prune",
+                prune_remote_started,
+            );
             let removed_count = local_removed_count + remote_removed_count;
 
+            let apply_context_started = Instant::now();
             if let Some(workspace_info) = state.workspace_service.get_current_workspace().await {
-                apply_active_workspace_context(&state, &app, &workspace_info).await;
+                apply_active_workspace_context(&state, &app, &workspace_info, None).await;
             } else {
-                clear_active_workspace_context(&state, &app).await;
+                clear_active_workspace_context(&state, &app, None).await;
             }
+            startup_trace.record_elapsed_step(
+                "tauri_command",
+                "cleanup_invalid_workspaces.apply_active_workspace_context",
+                apply_context_started,
+            );
 
+            let sync_watchers_started = Instant::now();
             if let Err(e) = state
                 .workspace_identity_watch_service
                 .sync_watched_workspaces()
@@ -1865,15 +2008,30 @@ pub async fn cleanup_invalid_workspaces(
                     e
                 );
             }
+            startup_trace.record_elapsed_step(
+                "tauri_command",
+                "cleanup_invalid_workspaces.sync_identity_watchers",
+                sync_watchers_started,
+            );
 
             info!(
                 "Invalid workspaces cleaned up: removed_count={}",
                 removed_count
             );
+            startup_trace.record_tauri_command_elapsed(
+                "cleanup_invalid_workspaces",
+                None,
+                trace_started,
+            );
             Ok(removed_count)
         }
         Err(e) => {
             error!("Failed to cleanup invalid workspaces: {}", e);
+            startup_trace.record_tauri_command_elapsed(
+                "cleanup_invalid_workspaces",
+                None,
+                trace_started,
+            );
             Err(format!("Failed to cleanup invalid workspaces: {}", e))
         }
     }
@@ -1957,14 +2115,18 @@ async fn prune_unrecoverable_remote_workspaces(state: &State<'_, AppState>) -> u
 #[tauri::command]
 pub async fn get_opened_workspaces(
     state: State<'_, AppState>,
+    startup_trace: State<'_, DesktopStartupTrace>,
 ) -> Result<Vec<WorkspaceInfoDto>, String> {
+    let trace_started = Instant::now();
     let workspace_service = &state.workspace_service;
-    Ok(workspace_service
+    let result = Ok(workspace_service
         .get_opened_workspaces()
         .await
         .into_iter()
         .map(|info| WorkspaceInfoDto::from_workspace_info(&info))
-        .collect())
+        .collect());
+    startup_trace.record_tauri_command_elapsed("get_opened_workspaces", None, trace_started);
+    result
 }
 
 #[tauri::command]

--- a/src/apps/desktop/src/api/config_api.rs
+++ b/src/apps/desktop/src/api/config_api.rs
@@ -1,11 +1,13 @@
 //! Configuration API
 
 use crate::api::app_state::AppState;
+use crate::startup_trace::DesktopStartupTrace;
 use bitfun_core::util::errors::BitFunError;
 use log::{error, info};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
+use std::time::Instant;
 use tauri::State;
 
 #[derive(Debug, Deserialize)]
@@ -57,11 +59,14 @@ fn is_expected_config_path_not_found(error: &BitFunError, path: Option<&str>) ->
 #[tauri::command]
 pub async fn get_config(
     state: State<'_, AppState>,
+    startup_trace: State<'_, DesktopStartupTrace>,
     request: GetConfigRequest,
 ) -> Result<Value, String> {
     let config_service = &state.config_service;
+    let trace_started = Instant::now();
+    let trace_target = request.path.clone();
 
-    match config_service
+    let result = match config_service
         .get_config::<Value>(request.path.as_deref())
         .await
     {
@@ -70,21 +75,31 @@ pub async fn get_config(
             if request.skip_retry_on_not_found
                 && is_expected_config_path_not_found(&e, request.path.as_deref())
             {
-                return Err(format!("Failed to get config: {}", e));
+                Err(format!("Failed to get config: {}", e))
+            } else {
+                error!("Failed to get config: path={:?}, error={}", request.path, e);
+                Err(format!("Failed to get config: {}", e))
             }
-            error!("Failed to get config: path={:?}, error={}", request.path, e);
-            Err(format!("Failed to get config: {}", e))
         }
-    }
+    };
+    startup_trace.record_tauri_command_elapsed(
+        "get_config",
+        trace_target.as_deref(),
+        trace_started,
+    );
+    result
 }
 
 #[tauri::command]
 pub async fn get_configs(
     state: State<'_, AppState>,
+    startup_trace: State<'_, DesktopStartupTrace>,
     request: GetConfigsRequest,
 ) -> Result<BTreeMap<String, Value>, String> {
     let config_service = &state.config_service;
     let mut configs = BTreeMap::new();
+    let trace_started = Instant::now();
+    let trace_target = request.paths.join(",");
 
     for path in request.paths {
         if configs.contains_key(&path) {
@@ -102,14 +117,25 @@ pub async fn get_configs(
                 if request.skip_retry_on_not_found
                     && is_expected_config_path_not_found(&e, Some(path.as_str()))
                 {
+                    startup_trace.record_tauri_command_elapsed(
+                        "get_configs",
+                        Some(&trace_target),
+                        trace_started,
+                    );
                     return Err(format!("Failed to get config: {}", e));
                 }
                 error!("Failed to get config: path={}, error={}", path, e);
+                startup_trace.record_tauri_command_elapsed(
+                    "get_configs",
+                    Some(&trace_target),
+                    trace_started,
+                );
                 return Err(format!("Failed to get config: {}", e));
             }
         }
     }
 
+    startup_trace.record_tauri_command_elapsed("get_configs", Some(&trace_target), trace_started);
     Ok(configs)
 }
 
@@ -142,11 +168,14 @@ mod tests {
 #[tauri::command]
 pub async fn set_config(
     state: State<'_, AppState>,
+    startup_trace: State<'_, DesktopStartupTrace>,
     request: SetConfigRequest,
 ) -> Result<String, String> {
     let config_service = &state.config_service;
+    let trace_started = Instant::now();
+    let trace_target = request.path.clone();
 
-    match config_service
+    let result = match config_service
         .set_config(&request.path, request.value)
         .await
     {
@@ -171,7 +200,13 @@ pub async fn set_config(
             error!("Failed to set config: path={}, error={}", request.path, e);
             Err(format!("Failed to set config: {}", e))
         }
-    }
+    };
+    startup_trace.record_tauri_command_elapsed(
+        "set_config",
+        Some(trace_target.as_str()),
+        trace_started,
+    );
+    result
 }
 
 #[tauri::command]
@@ -299,11 +334,15 @@ pub async fn get_global_config_health() -> Result<bool, String> {
 
 #[tauri::command]
 pub async fn get_runtime_logging_info(
+    startup_trace: State<'_, DesktopStartupTrace>,
     _state: State<'_, AppState>,
     _request: GetRuntimeLoggingInfoRequest,
 ) -> Result<Value, String> {
+    let trace_started = Instant::now();
     let logging_info = crate::logging::get_runtime_logging_info();
-    to_json_value(logging_info, "runtime logging info")
+    let result = to_json_value(logging_info, "runtime logging info");
+    startup_trace.record_tauri_command_elapsed("get_runtime_logging_info", None, trace_started);
+    result
 }
 
 #[tauri::command]

--- a/src/apps/desktop/src/api/ssh_api.rs
+++ b/src/apps/desktop/src/api/ssh_api.rs
@@ -2,9 +2,11 @@
 //!
 //! Tauri commands for SSH connection management and remote file operations.
 
+use std::time::Instant;
 use tauri::State;
 
 use crate::api::app_state::SSHServiceError;
+use crate::startup_trace::DesktopStartupTrace;
 use crate::AppState;
 use bitfun_core::service::remote_ssh::{
     RemoteTreeNode, SSHAuthMethod, SSHConfigEntry, SSHConfigLookupResult, SSHConnectionConfig,
@@ -473,8 +475,11 @@ pub async fn remote_remove_workspace(
 #[tauri::command]
 pub async fn remote_get_workspace_info(
     state: State<'_, AppState>,
+    startup_trace: State<'_, DesktopStartupTrace>,
 ) -> Result<Option<crate::api::RemoteWorkspace>, String> {
+    let trace_started = Instant::now();
     let workspace = state.get_remote_workspace_async().await;
     log::info!("remote_get_workspace_info: returning {:?}", workspace);
+    startup_trace.record_tauri_command_elapsed("remote_get_workspace_info", None, trace_started);
     Ok(workspace)
 }

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -6,6 +6,7 @@ pub mod computer_use;
 pub mod crash_diagnostics;
 pub mod logging;
 pub mod macos_menubar;
+pub mod startup_trace;
 pub mod theme;
 pub mod tray;
 
@@ -53,6 +54,7 @@ use api::storage_commands::*;
 use api::subagent_api::*;
 use api::system_api::*;
 use api::tool_api::*;
+use startup_trace::{DesktopStartupTrace, DesktopStartupTraceSnapshot};
 
 /// Agentic Coordinator state
 #[derive(Clone)]
@@ -192,6 +194,13 @@ async fn webdriver_bridge_result(request: WebdriverBridgeResultRequest) -> Resul
     bitfun_webdriver::handle_bridge_result(request.payload)
 }
 
+#[tauri::command]
+fn get_startup_native_trace(
+    state: tauri::State<'_, DesktopStartupTrace>,
+) -> DesktopStartupTraceSnapshot {
+    state.snapshot()
+}
+
 /// Tauri application entry point
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub async fn run() {
@@ -200,6 +209,8 @@ pub async fn run() {
         .duration_since(UNIX_EPOCH)
         .map(|duration| format!("desktop-{}", duration.as_millis()))
         .unwrap_or_else(|_| "desktop-unknown".to_string());
+    let startup_trace = DesktopStartupTrace::new(startup_trace_id.clone(), startup_started);
+    startup_trace.record_phase("native_process_start", "native");
     let mut startup_timings = TimingCollector::default();
     let in_debug = cfg!(debug_assertions) || std::env::var("DEBUG").unwrap_or_default() == "1";
     let log_config = logging::LogConfig::new(in_debug);
@@ -216,6 +227,7 @@ pub async fn run() {
         return;
     }
     startup_timings.record_elapsed("initialize_global_config", step_started);
+    startup_trace.record_elapsed_step("native_pre_tauri", "initialize_global_config", step_started);
 
     // Initialize global I18nService so bot/remote-connect language is always in sync.
     {
@@ -233,9 +245,20 @@ pub async fn run() {
             }
         }
         startup_timings.record_elapsed("initialize_global_i18n_service", step_started);
+        startup_trace.record_elapsed_step(
+            "native_pre_tauri",
+            "initialize_global_i18n_service",
+            step_started,
+        );
     }
 
+    let step_started = Instant::now();
     let startup_log_level = resolve_runtime_log_level(log_config.level).await;
+    startup_trace.record_elapsed_step(
+        "native_pre_tauri",
+        "resolve_runtime_log_level",
+        step_started,
+    );
 
     let step_started = Instant::now();
     if let Err(e) = AIClientFactory::initialize_global().await {
@@ -243,6 +266,11 @@ pub async fn run() {
         return;
     }
     startup_timings.record_elapsed("initialize_global_ai_client_factory", step_started);
+    startup_trace.record_elapsed_step(
+        "native_pre_tauri",
+        "initialize_global_ai_client_factory",
+        step_started,
+    );
 
     let step_started = Instant::now();
     let (coordinator, scheduler, event_queue, event_router, ai_client_factory, token_usage_service) =
@@ -254,6 +282,7 @@ pub async fn run() {
             }
         };
     startup_timings.record_elapsed("init_agentic_system", step_started);
+    startup_trace.record_elapsed_step("native_pre_tauri", "init_agentic_system", step_started);
 
     let step_started = Instant::now();
     if let Err(e) = init_function_agents(ai_client_factory.clone()).await {
@@ -261,10 +290,23 @@ pub async fn run() {
         return;
     }
     startup_timings.record_elapsed("init_function_agents", step_started);
+    startup_trace.record_elapsed_step("native_pre_tauri", "init_function_agents", step_started);
 
+    let step_started = Instant::now();
     let workspace_search_enabled =
         bitfun_core::service::search::workspace_search_feature_enabled().await;
+    startup_trace.record_elapsed_step(
+        "native_pre_tauri",
+        "workspace_search_feature_enabled",
+        step_started,
+    );
+    let step_started = Instant::now();
     let startup_flashgrep_path = configure_workspace_search_daemon_env();
+    startup_trace.record_elapsed_step(
+        "native_pre_tauri",
+        "configure_workspace_search_daemon_env",
+        step_started,
+    );
 
     let step_started = Instant::now();
     let app_state = match AppState::new_async(token_usage_service).await {
@@ -275,6 +317,7 @@ pub async fn run() {
         }
     };
     startup_timings.record_elapsed("initialize_app_state", step_started);
+    startup_trace.record_elapsed_step("native_pre_tauri", "initialize_app_state", step_started);
 
     let coordinator_state = CoordinatorState {
         coordinator: coordinator.clone(),
@@ -307,13 +350,10 @@ pub async fn run() {
         .manage(coordinator)
         .manage(scheduler)
         .manage(terminal_state)
+        .manage(startup_trace.clone())
         .setup(move |app| {
             let setup_started = Instant::now();
-            log::debug!(
-                "Desktop startup trace event: trace_id={}, phase=tauri_setup_start, since_process_start_ms={}",
-                startup_trace_id,
-                elapsed_ms(startup_started)
-            );
+            startup_trace.record_phase("tauri_setup_start", "native_setup");
             #[cfg(target_os = "macos")]
             {
                 app.on_menu_event(|app, event| {
@@ -326,8 +366,14 @@ pub async fn run() {
                 });
             }
 
+            let step_started = Instant::now();
             logging::register_runtime_log_state(startup_log_level, session_log_dir.clone());
             crash_diagnostics::log_previous_unexpected_exit_if_any();
+            startup_trace.record_elapsed_step(
+                "native_setup",
+                "register_runtime_log_state_and_crash_diagnostics",
+                step_started,
+            );
 
             // Ensure the Tauri NSIS registry install-location key points to the
             // actual install directory, so that auto-updates respect the custom
@@ -336,6 +382,7 @@ pub async fn run() {
             {
                 use std::os::windows::process::CommandExt;
                 const CREATE_NO_WINDOW: u32 = 0x08000000;
+                let step_started = Instant::now();
 
                 if let Ok(exe) = std::env::current_exe() {
                     if let Some(install_dir) = exe.parent() {
@@ -375,6 +422,11 @@ pub async fn run() {
                         }
                     }
                 }
+                startup_trace.record_elapsed_step(
+                    "native_setup",
+                    "sync_install_location_registry",
+                    step_started,
+                );
             }
             for step in startup_timings.steps() {
                 log::debug!(
@@ -385,6 +437,7 @@ pub async fn run() {
             }
 
             if workspace_search_enabled {
+                let step_started = Instant::now();
                 let flashgrep_path = startup_flashgrep_path.clone().or_else(|| {
                     let binary_names =
                         bitfun_core::service::search::workspace_search_daemon_binary_names();
@@ -428,6 +481,11 @@ pub async fn run() {
                         bitfun_core::service::search::workspace_search_daemon_missing_hint()
                     );
                 }
+                startup_trace.record_elapsed_step(
+                    "native_setup",
+                    "resolve_workspace_search_daemon",
+                    step_started,
+                );
             }
 
             // Register bundled mobile-web resource path for remote connect.
@@ -435,6 +493,7 @@ pub async fn run() {
             // so the primary candidate is "mobile-web/dist". Additional fallbacks
             // handle legacy or non-standard bundle layouts.
             {
+                let step_started = Instant::now();
                 let candidates = ["mobile-web/dist", "mobile-web", "dist"];
                 let mut found = false;
                 for candidate in &candidates {
@@ -470,37 +529,47 @@ pub async fn run() {
                         }
                     }
                 }
+                startup_trace.record_elapsed_step(
+                    "native_setup",
+                    "resolve_mobile_web_resource",
+                    step_started,
+                );
             }
 
             let app_handle = app.handle().clone();
             let window_started = Instant::now();
-            log::debug!(
-                "Desktop startup trace event: trace_id={}, phase=main_window_create_start",
-                startup_trace_id
-            );
-            theme::create_main_window(&app_handle, &startup_trace_id);
+            startup_trace.record_phase("main_window_create_start", "native_window");
+            theme::create_main_window(&app_handle, &startup_trace_id, &startup_trace);
             let window_duration_ms = elapsed_ms(window_started);
+            startup_trace.record_step(
+                "native_step_end",
+                "native_window",
+                "create_main_window",
+                window_duration_ms,
+            );
             log::debug!(
                 "Desktop startup step completed: step=create_main_window, duration_ms={}",
                 window_duration_ms
             );
-            log::debug!(
-                "Desktop startup trace event: trace_id={}, phase=main_window_create_end, duration_ms={}",
-                startup_trace_id,
-                window_duration_ms
-            );
+            let webdriver_started = Instant::now();
             bitfun_webdriver::maybe_start(app_handle.clone());
-            let setup_duration_ms = elapsed_ms(setup_started);
-            let since_process_start_ms = elapsed_ms(startup_started);
-            log::debug!(
-                "Desktop startup timing: phase=tauri_setup, duration_ms={}, since_process_start_ms={}",
-                setup_duration_ms,
-                since_process_start_ms
+            startup_trace.record_elapsed_step(
+                "native_setup",
+                "maybe_start_webdriver",
+                webdriver_started,
             );
+            let window_phase_duration_ms = elapsed_ms(setup_started);
+            let since_process_start_ms = elapsed_ms(startup_started);
+            startup_trace.record_step(
+                "native_step_end",
+                "native_setup",
+                "tauri_setup_until_main_window_created",
+                window_phase_duration_ms,
+            );
+            startup_trace.record_phase("tauri_setup_window_phase_end", "native_setup");
             log::debug!(
-                "Desktop startup trace event: trace_id={}, phase=tauri_setup_end, duration_ms={}, since_process_start_ms={}",
-                startup_trace_id,
-                setup_duration_ms,
+                "Desktop startup timing: phase=tauri_setup_until_main_window_created, duration_ms={}, since_process_start_ms={}",
+                window_phase_duration_ms,
                 since_process_start_ms
             );
 
@@ -537,13 +606,26 @@ pub async fn run() {
 
             let transport = Arc::new(TauriTransportAdapter::new(app_handle.clone()));
 
+            let step_started = Instant::now();
             start_event_loop_with_transport(event_queue, event_router, transport);
+            startup_trace.record_elapsed_step(
+                "native_setup",
+                "start_event_loop_with_transport",
+                step_started,
+            );
 
             // Eagerly initialize the remote connect service so previously
             // paired bots start listening immediately on app startup.
+            let step_started = Instant::now();
             api::remote_connect_api::init_on_startup();
+            startup_trace.record_elapsed_step(
+                "native_setup",
+                "remote_connect_init_on_startup",
+                step_started,
+            );
 
             {
+                let step_started = Instant::now();
                 let _terminal_state: tauri::State<'_, api::terminal_api::TerminalState> =
                     app.state();
                 let terminal_state_inner = api::terminal_api::TerminalState::new();
@@ -554,20 +636,49 @@ pub async fn run() {
                         app_handle_clone,
                     );
                 });
+                startup_trace.record_elapsed_step(
+                    "native_setup",
+                    "spawn_terminal_event_loop",
+                    step_started,
+                );
             }
 
+            let step_started = Instant::now();
             init_mcp_servers(app_handle.clone());
+            startup_trace.record_elapsed_step("native_setup", "init_mcp_servers", step_started);
+            let step_started = Instant::now();
             init_acp_clients(app_handle.clone());
+            startup_trace.record_elapsed_step("native_setup", "init_acp_clients", step_started);
 
+            let step_started = Instant::now();
             init_services(app_handle.clone(), startup_log_level);
+            startup_trace.record_elapsed_step("native_setup", "init_services", step_started);
 
+            let step_started = Instant::now();
             logging::spawn_log_cleanup_task();
+            startup_trace.record_elapsed_step("native_setup", "spawn_log_cleanup_task", step_started);
 
             // Set up system tray icon.
+            let step_started = Instant::now();
             if let Err(error) = crate::tray::setup_tray(app) {
                 log::warn!("Failed to set up system tray: {}", error);
             }
+            startup_trace.record_elapsed_step("native_setup", "setup_tray", step_started);
 
+            let setup_duration_ms = elapsed_ms(setup_started);
+            let since_process_start_ms = elapsed_ms(startup_started);
+            startup_trace.record_step(
+                "native_step_end",
+                "native_setup",
+                "tauri_setup",
+                setup_duration_ms,
+            );
+            startup_trace.record_phase("tauri_setup_end", "native_setup");
+            log::debug!(
+                "Desktop startup timing: phase=tauri_setup, duration_ms={}, since_process_start_ms={}",
+                setup_duration_ms,
+                since_process_start_ms
+            );
             log::info!("BitFun Desktop started successfully");
             Ok(())
         })
@@ -653,6 +764,7 @@ pub async fn run() {
             api::agentic_api::restore_session_view,
             api::agentic_api::restore_session_with_turns,
             webdriver_bridge_result,
+            get_startup_native_trace,
             api::agentic_api::list_sessions,
             api::agentic_api::confirm_tool_execution,
             api::agentic_api::reject_tool_execution,

--- a/src/apps/desktop/src/startup_trace.rs
+++ b/src/apps/desktop/src/startup_trace.rs
@@ -1,0 +1,175 @@
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use bitfun_core::util::elapsed_ms;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DesktopStartupTraceEvent {
+    pub trace_id: String,
+    pub phase: String,
+    pub at_ms: u64,
+    pub since_process_start_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub step: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DesktopStartupTraceSnapshot {
+    pub trace_id: String,
+    pub events: Vec<DesktopStartupTraceEvent>,
+}
+
+#[derive(Clone)]
+pub struct DesktopStartupTrace {
+    trace_id: String,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<DesktopStartupTraceEvent>>>,
+}
+
+impl DesktopStartupTrace {
+    pub fn new(trace_id: String, started_at: Instant) -> Self {
+        Self {
+            trace_id,
+            started_at,
+            events: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn trace_id(&self) -> &str {
+        &self.trace_id
+    }
+
+    pub fn record_phase(&self, phase: impl Into<String>, category: impl Into<String>) {
+        self.record_event(phase.into(), Some(category.into()), None, None, None, None);
+    }
+
+    pub fn record_step(
+        &self,
+        phase: impl Into<String>,
+        category: impl Into<String>,
+        step: impl Into<String>,
+        duration_ms: u128,
+    ) {
+        self.record_event(
+            phase.into(),
+            Some(category.into()),
+            Some(step.into()),
+            None,
+            None,
+            Some(duration_ms),
+        );
+    }
+
+    pub fn record_elapsed_step(
+        &self,
+        category: impl Into<String>,
+        step: impl Into<String>,
+        started_at: Instant,
+    ) -> u128 {
+        let duration_ms = elapsed_ms(started_at);
+        self.record_step("native_step_end", category, step, duration_ms);
+        duration_ms
+    }
+
+    pub fn record_tauri_command_elapsed(
+        &self,
+        command: impl Into<String>,
+        target: Option<&str>,
+        started_at: Instant,
+    ) -> u128 {
+        let duration_ms = elapsed_ms(started_at);
+        let command = command.into();
+        self.record_event(
+            "native_step_end".to_string(),
+            Some("tauri_command".to_string()),
+            Some(command.clone()),
+            Some(command),
+            target.map(ToOwned::to_owned),
+            Some(duration_ms),
+        );
+        duration_ms
+    }
+
+    pub fn snapshot(&self) -> DesktopStartupTraceSnapshot {
+        let events = self
+            .events
+            .lock()
+            .map(|events| events.clone())
+            .unwrap_or_default();
+        DesktopStartupTraceSnapshot {
+            trace_id: self.trace_id.clone(),
+            events,
+        }
+    }
+
+    fn record_event(
+        &self,
+        phase: String,
+        category: Option<String>,
+        step: Option<String>,
+        command: Option<String>,
+        target: Option<String>,
+        duration_ms: Option<u128>,
+    ) {
+        let since_process_start_ms = to_u64(elapsed_ms(self.started_at));
+        let duration_ms = duration_ms.map(to_u64);
+        let event = DesktopStartupTraceEvent {
+            trace_id: self.trace_id.clone(),
+            phase,
+            at_ms: since_process_start_ms,
+            since_process_start_ms,
+            category,
+            step,
+            command,
+            target,
+            duration_ms,
+        };
+
+        if let Ok(mut events) = self.events.lock() {
+            events.push(event);
+        }
+    }
+}
+
+fn to_u64(value: u128) -> u64 {
+    value.min(u64::MAX as u128) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn records_tauri_command_with_safe_target() {
+        let trace = DesktopStartupTrace::new(
+            "trace-test".to_string(),
+            Instant::now() - Duration::from_millis(20),
+        );
+
+        trace.record_tauri_command_elapsed(
+            "get_config",
+            Some("app.auto_update"),
+            Instant::now() - Duration::from_millis(7),
+        );
+
+        let snapshot = trace.snapshot();
+        let event = snapshot.events.last().expect("event should be recorded");
+
+        assert_eq!(event.category.as_deref(), Some("tauri_command"));
+        assert_eq!(event.command.as_deref(), Some("get_config"));
+        assert_eq!(event.target.as_deref(), Some("app.auto_update"));
+        assert!(event.duration_ms.unwrap_or_default() >= 7);
+    }
+}

--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -10,6 +10,8 @@ use log::{debug, error, warn};
 use tauri::webview::PageLoadEvent;
 use tauri::{Manager, WebviewUrl};
 
+use crate::startup_trace::DesktopStartupTrace;
+
 const AGENT_COMPANION_WINDOW_LABEL: &str = "agent-companion-pet";
 const AGENT_COMPANION_WINDOW_MIN_SIZE: f64 = 96.0;
 const AGENT_COMPANION_WINDOW_MAX_WIDTH: f64 = 360.0;
@@ -403,11 +405,21 @@ impl ThemeConfig {
     }
 }
 
-pub fn create_main_window(app_handle: &tauri::AppHandle, startup_trace_id: &str) {
+pub fn create_main_window(
+    app_handle: &tauri::AppHandle,
+    startup_trace_id: &str,
+    startup_trace: &DesktopStartupTrace,
+) {
     let total_started_at = Instant::now();
     let theme = ThemeConfig::load_from_config();
     let bg_color = theme.to_tauri_color();
     let init_script = theme.generate_init_script(startup_trace_id);
+    startup_trace.record_step(
+        "native_step_end",
+        "native_window",
+        "prepare_theme",
+        total_started_at.elapsed().as_millis(),
+    );
     debug!(
         "Main window creation step completed: step=prepare_theme duration_ms={}",
         total_started_at.elapsed().as_millis()
@@ -478,6 +490,7 @@ pub fn create_main_window(app_handle: &tauri::AppHandle, startup_trace_id: &str)
     let build_started_at = Instant::now();
     match builder.build() {
         Ok(window) => {
+            startup_trace.record_elapsed_step("native_window", "webview_build", build_started_at);
             debug!(
                 "Main window creation step completed: step=build url_kind={} duration_ms={} total_duration_ms={}",
                 main_url_kind,
@@ -494,7 +507,7 @@ pub fn create_main_window(app_handle: &tauri::AppHandle, startup_trace_id: &str)
                 }
             }
 
-            show_main_window_for_startup(&window, total_started_at);
+            show_main_window_for_startup(&window, total_started_at, startup_trace);
         }
         Err(e) => {
             error!(
@@ -506,20 +519,31 @@ pub fn create_main_window(app_handle: &tauri::AppHandle, startup_trace_id: &str)
     }
 }
 
-fn show_main_window_for_startup(window: &tauri::WebviewWindow, total_started_at: Instant) {
+fn show_main_window_for_startup(
+    window: &tauri::WebviewWindow,
+    total_started_at: Instant,
+    startup_trace: &DesktopStartupTrace,
+) {
     #[cfg(target_os = "windows")]
     {
         let step_started_at = Instant::now();
         if let Err(error) = window.maximize() {
             warn!("Failed to maximize main window during startup: {}", error);
         } else {
+            startup_trace.record_elapsed_step("native_window", "windows_maximize", step_started_at);
             debug!(
                 "Main window startup show step completed: step=maximize duration_ms={} since_create_start_ms={}",
                 step_started_at.elapsed().as_millis(),
                 total_started_at.elapsed().as_millis()
             );
         }
+        let show_delay_started_at = Instant::now();
         std::thread::sleep(std::time::Duration::from_millis(150));
+        startup_trace.record_elapsed_step(
+            "native_window",
+            "windows_show_after_maximize_wait",
+            show_delay_started_at,
+        );
     }
 
     let show_started_at = Instant::now();
@@ -527,6 +551,7 @@ fn show_main_window_for_startup(window: &tauri::WebviewWindow, total_started_at:
         warn!("Failed to show main window during startup: {}", error);
         return;
     }
+    startup_trace.record_elapsed_step("native_window", "show_window", show_started_at);
     debug!(
         "Main window startup show step completed: step=show duration_ms={} since_create_start_ms={}",
         show_started_at.elapsed().as_millis(),
@@ -538,6 +563,7 @@ fn show_main_window_for_startup(window: &tauri::WebviewWindow, total_started_at:
         warn!("Failed to focus main window during startup: {}", error);
         return;
     }
+    startup_trace.record_elapsed_step("native_window", "focus_window", focus_started_at);
     debug!(
         "Main window startup show step completed: step=focus duration_ms={} since_create_start_ms={}",
         focus_started_at.elapsed().as_millis(),

--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -1,27 +1,20 @@
-import { useEffect, useCallback, useState, useRef } from 'react';
+import { lazy, Suspense, useEffect, useCallback, useState, useRef } from 'react';
 import { useShortcut } from '@/infrastructure/hooks/useShortcut';
 import { useHasDismissibleLayer } from '@/infrastructure/hooks/useDismissibleLayer';
 import { dismissibleLayerManager } from '@/infrastructure/services/DismissibleLayerManager';
 import { ChatProvider } from '../infrastructure/contexts/ChatProvider';
 import { ViewModeProvider } from '../infrastructure/contexts/ViewModeProvider';
 import { SSHRemoteProvider } from '../features/ssh-remote';
-import AppLayout from './layout/AppLayout';
 import { ContextMenuRenderer } from '../shared/context-menu-system/components/ContextMenuRenderer';
 import { NotificationContainer, NotificationCenter, notificationService } from '../shared/notification-system';
 import { AnnouncementProvider } from '../shared/announcement-system';
 import { ConfirmDialogRenderer } from '../component-library';
 import { createLogger } from '@/shared/utils/logger';
 import { startupTrace } from '@/shared/utils/startupTrace';
-import { aiExperienceConfigService } from '@/infrastructure/config/services/AIExperienceConfigService';
-import { syncAgentCompanionDesktopWindow } from '@/infrastructure/config/services/AgentCompanionWindowService';
 import { isTauriRuntime } from '@/infrastructure/runtime';
-import { buildAgentCompanionActivity, subscribeAgentCompanionActivity } from '@/flow_chat/utils/agentCompanionActivity';
-import { emitAgentCompanionActivity } from '@/flow_chat/services/AgentCompanionActivityBridge';
-import { BackgroundTaskCancelledError } from '@/shared/utils/backgroundTaskScheduler';
 import { useWorkspaceContext } from '../infrastructure/contexts/WorkspaceContext';
 import { useGlobalSceneShortcuts } from './hooks/useGlobalSceneShortcuts';
 import { useDebugInspector } from '@/infrastructure/debug/useDebugInspector';
-import { openAgentCompanionSession } from './services/openAgentCompanionSession';
 import { useI18n } from '@/infrastructure/i18n';
 import { scheduleDeferredStartupSystems } from './startup/deferredStartupSystems';
 import {
@@ -29,11 +22,39 @@ import {
   hideStartupOverlay,
   isStartupOverlayPresent,
 } from './startup/startupOverlay';
-
-// Toolbar Mode
-import { ToolbarModeProvider } from '../flow_chat';
+import { ToolbarModeProvider } from '../flow_chat/components/toolbar-mode';
 
 const log = createLogger('App');
+
+function isBackgroundTaskCancelledError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'BackgroundTaskCancelledError';
+}
+
+interface AppLayoutStartupGateProps {
+  onReady: () => void;
+}
+
+const LazyAppLayout = lazy(async () => {
+  startupTrace.markPhase('app_layout_import_start');
+  try {
+    const module = await import('./layout/AppLayout');
+    startupTrace.markPhase('app_layout_import_end');
+    return {
+      default: function AppLayoutStartupGate({ onReady }: AppLayoutStartupGateProps) {
+        useEffect(() => {
+          startupTrace.markPhase('app_layout_ready');
+          onReady();
+        }, [onReady]);
+
+        return <module.default />;
+      },
+    };
+  } catch (error) {
+    startupTrace.markPhase('app_layout_import_failed');
+    throw error;
+  }
+});
+
 /**
  * BitFun main application component.
  *
@@ -58,11 +79,15 @@ function App() {
   const mainWindowShownRef = useRef(false);
   const interactiveShellReadyRef = useRef(false);
   const [interactiveShellReady, setInteractiveShellReady] = useState(false);
+  const [appLayoutReady, setAppLayoutReady] = useState(false);
+  const handleAppLayoutReady = useCallback(() => {
+    setAppLayoutReady(true);
+  }, []);
 
   // Once the workspace finishes loading, wait for the remaining min-display
   // time and then begin the exit animation.
   useEffect(() => {
-    if (workspaceLoading) return;
+    if (workspaceLoading || !appLayoutReady) return;
     const elapsed = getStartupOverlayElapsedMs();
     const remaining = Math.max(0, MIN_SPLASH_MS - elapsed);
     let cancelled = false;
@@ -77,7 +102,7 @@ function App() {
       cancelled = true;
       window.clearTimeout(timer);
     };
-  }, [workspaceLoading]);
+  }, [workspaceLoading, appLayoutReady]);
 
   const showMainWindow = useCallback(async (reason: string) => {
     if (mainWindowShownRef.current) {
@@ -146,16 +171,16 @@ function App() {
   }, [showMainWindow]);
 
   useEffect(() => {
-    if (workspaceLoading || interactiveShellReadyRef.current) {
+    if (workspaceLoading || !appLayoutReady || interactiveShellReadyRef.current) {
       return;
     }
     interactiveShellReadyRef.current = true;
     startupTrace.markPhase('interactive_shell_ready');
     window.dispatchEvent(new CustomEvent('bitfun:interactive-shell-ready', {
-      detail: { reason: 'workspace-ready' },
+      detail: { reason: 'workspace-and-layout-ready' },
     }));
     setInteractiveShellReady(true);
-  }, [workspaceLoading]);
+  }, [workspaceLoading, appLayoutReady]);
 
   // If the early reveal path fails, keep the old post-splash show as a retry.
   useEffect(() => {
@@ -188,7 +213,7 @@ function App() {
     log.info('Application interactive, scheduling deferred systems');
     const startupSystemsHandle = scheduleDeferredStartupSystems();
     startupSystemsHandle.promise.catch(error => {
-      if (!(error instanceof BackgroundTaskCancelledError)) {
+      if (!isBackgroundTaskCancelledError(error)) {
         log.warn('Deferred startup systems task failed', error);
       }
     });
@@ -211,7 +236,7 @@ function App() {
         }
         editorWarmupHandle = scheduleMonacoStartupWarmup();
         editorWarmupHandle.promise.catch(error => {
-          if (!disposed && !(error instanceof BackgroundTaskCancelledError)) {
+          if (!disposed && !isBackgroundTaskCancelledError(error)) {
             log.warn('Editor startup warmup task failed', error);
           }
         });
@@ -233,19 +258,35 @@ function App() {
 
     let disposed = false;
     let startupSyncHandle: { promise: Promise<void>; cancel: () => void } | null = null;
-    const emitCurrentAgentCompanionActivity = () => {
+    let removeSettingsListener: (() => void) | null = null;
+
+    void (async () => {
+      const [
+        { aiExperienceConfigService },
+        { syncAgentCompanionDesktopWindow },
+        { buildAgentCompanionActivity },
+        { emitAgentCompanionActivity },
+        { backgroundTaskScheduler },
+      ] = await Promise.all([
+        import('@/infrastructure/config/services/AIExperienceConfigService'),
+        import('@/infrastructure/config/services/AgentCompanionWindowService'),
+        import('@/flow_chat/utils/agentCompanionActivity'),
+        import('@/flow_chat/services/AgentCompanionActivityBridge'),
+        import('@/shared/utils/backgroundTaskScheduler'),
+      ]);
+
       if (disposed) {
         return;
       }
-      void emitAgentCompanionActivity(buildAgentCompanionActivity());
-    };
 
-    void aiExperienceConfigService.getSettingsAsync().then(async settings => {
-      if (disposed) {
-        return;
-      }
+      const emitCurrentAgentCompanionActivity = () => {
+        if (disposed) {
+          return;
+        }
+        void emitAgentCompanionActivity(buildAgentCompanionActivity());
+      };
 
-      const { backgroundTaskScheduler, BackgroundTaskCancelledError } = await import('@/shared/utils/backgroundTaskScheduler');
+      const settings = await aiExperienceConfigService.getSettingsAsync();
       if (disposed) {
         return;
       }
@@ -276,28 +317,57 @@ function App() {
       });
 
       startupSyncHandle.promise.catch(error => {
-        if (!disposed && !(error instanceof BackgroundTaskCancelledError)) {
+        if (!disposed && !isBackgroundTaskCancelledError(error)) {
           log.warn('Initial Agent companion sync task failed', error);
         }
       });
+
+      removeSettingsListener = aiExperienceConfigService.addChangeListener(settings => {
+        void syncAgentCompanionDesktopWindow(settings).then(() => {
+          emitCurrentAgentCompanionActivity();
+          window.setTimeout(emitCurrentAgentCompanionActivity, 250);
+        });
+      });
+    })().catch(error => {
+      if (!disposed) {
+        log.warn('Failed to initialize Agent companion startup sync', error);
+      }
     });
 
-    const removeSettingsListener = aiExperienceConfigService.addChangeListener(settings => {
-      void syncAgentCompanionDesktopWindow(settings).then(() => {
-        emitCurrentAgentCompanionActivity();
-        window.setTimeout(emitCurrentAgentCompanionActivity, 250);
-      });
-    });
     return () => {
       disposed = true;
       startupSyncHandle?.cancel();
-      removeSettingsListener();
+      removeSettingsListener?.();
     };
   }, [interactiveShellReady]);
 
-  useEffect(() => subscribeAgentCompanionActivity(activity => {
-    void emitAgentCompanionActivity(activity);
-  }), []);
+  useEffect(() => {
+    let disposed = false;
+    let unsubscribe: (() => void) | null = null;
+
+    void Promise.all([
+      import('@/flow_chat/utils/agentCompanionActivity'),
+      import('@/flow_chat/services/AgentCompanionActivityBridge'),
+    ])
+      .then(([{ subscribeAgentCompanionActivity }, { emitAgentCompanionActivity }]) => {
+        if (disposed) {
+          return;
+        }
+        unsubscribe = subscribeAgentCompanionActivity(activity => {
+          void emitAgentCompanionActivity(activity);
+        });
+      })
+      .catch(error => {
+        if (!disposed) {
+          log.warn('Failed to subscribe Agent companion activity bridge', error);
+        }
+      });
+
+    return () => {
+      disposed = true;
+      unsubscribe?.();
+    };
+  }, []);
 
   useEffect(() => {
     let unlisten: (() => void) | null = null;
@@ -308,6 +378,7 @@ function App() {
           const sessionId = event.payload?.sessionId;
           if (!sessionId) return;
 
+          const { openAgentCompanionSession } = await import('./services/openAgentCompanionSession');
           await openAgentCompanionSession(sessionId);
 
           try {
@@ -440,7 +511,9 @@ function App() {
         <SSHRemoteProvider>
           <ToolbarModeProvider>
             {/* Unified app layout with startup/workspace modes */}
-            <AppLayout />
+            <Suspense fallback={null}>
+              <LazyAppLayout onReady={handleAppLayoutReady} />
+            </Suspense>
 
             {/* Context menu renderer */}
             <ContextMenuRenderer />

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -36,6 +36,7 @@ import { computeFixedPopoverPosition } from '@/shared/utils/fixedPopoverViewport
 import WorkspaceRelatedPathsDialog from './WorkspaceRelatedPathsDialog';
 import { sessionAPI } from '@/infrastructure/api/service-api/SessionAPI';
 import { confirmWarning } from '@/component-library/components/ConfirmDialog/confirmService';
+import { scheduleAfterStartupSignal } from '@/shared/utils/startupTaskScheduling';
 
 
 interface WorkspaceItemProps {
@@ -122,10 +123,27 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
   });
 
   useEffect(() => {
-    setWorkspaceSearchEnabled(aiExperienceConfigService.getSettings().enable_workspace_search);
-    return aiExperienceConfigService.addChangeListener(settings => {
+    let cancelled = false;
+    let unsubscribeSettings: (() => void) | null = null;
+    const cancelStartupSchedule = scheduleAfterStartupSignal(async () => {
+      const settings = await aiExperienceConfigService.getSettingsAsync();
+      if (cancelled) {
+        return;
+      }
       setWorkspaceSearchEnabled(settings.enable_workspace_search);
+      unsubscribeSettings = aiExperienceConfigService.addChangeListener(nextSettings => {
+        setWorkspaceSearchEnabled(nextSettings.enable_workspace_search);
+      });
+    }, {
+      signalName: 'bitfun:interactive-shell-ready',
+      fallbackTimeoutMs: 10000,
+      frameCount: 1,
     });
+    return () => {
+      cancelled = true;
+      cancelStartupSchedule();
+      unsubscribeSettings?.();
+    };
   }, []);
 
   // Remote connection status — optional: safe if not inside SSHRemoteProvider

--- a/src/web-ui/src/app/layout/AppLayout.tsx
+++ b/src/web-ui/src/app/layout/AppLayout.tsx
@@ -18,12 +18,12 @@ import { useAssistantBootstrap } from '../hooks/useAssistantBootstrap';
 import { useApp } from '../hooks/useApp';
 import { useSceneStore } from '../stores/sceneStore';
 import { useShortcut } from '@/infrastructure/hooks/useShortcut';
-import { configManager } from '@/infrastructure/config';
+import { configManager } from '@/infrastructure/config/services/ConfigManager';
 
 type TransitionDirection = 'entering' | 'returning' | null;
 import { FlowChatManager } from '../../flow_chat/services/FlowChatManager';
 import WorkspaceBody from './WorkspaceBody';
-import { ToolbarMode, useToolbarModeContext } from '../../flow_chat';
+import { ToolbarMode, useToolbarModeContext } from '../../flow_chat/components/toolbar-mode';
 import { FloatingMiniChat } from './FloatingMiniChat';
 import { NewProjectDialog } from '../components/NewProjectDialog';
 import { AboutDialog } from '../components/AboutDialog';

--- a/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
+++ b/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
@@ -64,7 +64,17 @@ describe('startup performance contract', () => {
     expect(source).not.toMatch(/from\s+['"]\.\.\/infrastructure['"]/);
     expect(source).not.toMatch(/useAIInitialization/);
     expect(source).not.toMatch(/useCurrentModelConfig/);
+    expect(source).not.toMatch(/from\s+['"]@\/infrastructure\/config\/services\/AIExperienceConfigService['"]/);
     expect(source).toContain('bitfun:interactive-shell-ready');
+  });
+
+  it('keeps the heavy app layout out of the root startup module', () => {
+    const source = readSource('../App.tsx');
+
+    expect(source).not.toMatch(/import\s+AppLayout\s+from\s+['"]\.\/layout\/AppLayout['"]/);
+    expect(source).toContain("import('./layout/AppLayout')");
+    expect(source).toContain('app_layout_ready');
+    expect(source).toContain('!appLayoutReady');
   });
 
   it('loads Monaco styling and loader config only through editor initialization', () => {
@@ -135,6 +145,7 @@ describe('startup performance contract', () => {
 
   it('avoids the infrastructure barrel from startup-visible modules', () => {
     const sources = [
+      '../../app/layout/AppLayout.tsx',
       '../../flow_chat/components/ChatInput.tsx',
       '../../tools/git/services/GitEventService.ts',
     ].map(readSource);
@@ -143,5 +154,33 @@ describe('startup performance contract', () => {
       expect(source).not.toMatch(/from\s+['"]@\/infrastructure['"]/);
       expect(source).not.toMatch(/from\s+['"]\.\.\/\.\.\/\.\.\/infrastructure['"]/);
     }
+
+    expect(sources[0]).not.toMatch(/from\s+['"]@\/infrastructure\/config['"]/);
+    expect(sources[0]).toContain("from '@/infrastructure/config/services/ConfigManager'");
+  });
+
+  it('avoids the broad flow-chat barrel from startup-visible shell modules', () => {
+    const sources = [
+      '../App.tsx',
+      '../../app/layout/AppLayout.tsx',
+    ].map(readSource);
+
+    for (const source of sources) {
+      expect(source).not.toMatch(/from\s+['"]\.\.\/flow_chat['"]/);
+      expect(source).not.toMatch(/from\s+['"]\.\.\/\.\.\/flow_chat['"]/);
+      expect(source).not.toMatch(/from\s+['"]@\/flow_chat['"]/);
+    }
+  });
+
+  it('keeps Agent companion implementation modules out of the root startup bundle', () => {
+    const source = readSource('../App.tsx');
+
+    expect(source).not.toMatch(/from\s+['"]@\/flow_chat\/utils\/agentCompanionActivity['"]/);
+    expect(source).not.toMatch(/from\s+['"]@\/flow_chat\/services\/AgentCompanionActivityBridge['"]/);
+    expect(source).not.toMatch(/from\s+['"]\.\/services\/openAgentCompanionSession['"]/);
+    expect(source).not.toMatch(/from\s+['"]@\/infrastructure\/config\/services\/AgentCompanionWindowService['"]/);
+    expect(source).toContain("import('@/flow_chat/utils/agentCompanionActivity')");
+    expect(source).toContain("import('@/flow_chat/services/AgentCompanionActivityBridge')");
+    expect(source).toContain("import('./services/openAgentCompanionSession')");
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/SessionFilesBadge.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/SessionFilesBadge.tsx
@@ -50,6 +50,7 @@ import {
 } from '@/infrastructure/config/services/AIExperienceConfigService';
 import { resolveQuickActionText } from '@/infrastructure/config/services/quickActionLocalization';
 import { deriveDeepReviewSessionConcurrencyGuard } from '../../utils/deepReviewCapacityGuard';
+import { scheduleAfterStartupSignal } from '@/shared/utils/startupTaskScheduling';
 import './SessionFilesBadge.scss';
 
 const log = createLogger('SessionFilesBadge');
@@ -217,10 +218,29 @@ export const SessionFilesBadge: React.FC<SessionFilesBadgeProps> = ({
 
   // Sync quick actions when settings change.
   useEffect(() => {
-    return aiExperienceConfigService.addChangeListener((settings) => {
+    let cancelled = false;
+    let unsubscribeSettings: (() => void) | null = null;
+    const cancelStartupSchedule = scheduleAfterStartupSignal(async () => {
+      const settings = await aiExperienceConfigService.getSettingsAsync();
+      if (cancelled) {
+        return;
+      }
       const actions = settings.quick_actions;
       setQuickActions((actions && actions.length > 0) ? actions : DEFAULT_QUICK_ACTIONS);
+      unsubscribeSettings = aiExperienceConfigService.addChangeListener((nextSettings) => {
+        const nextActions = nextSettings.quick_actions;
+        setQuickActions((nextActions && nextActions.length > 0) ? nextActions : DEFAULT_QUICK_ACTIONS);
+      });
+    }, {
+      signalName: 'bitfun:interactive-shell-ready',
+      fallbackTimeoutMs: 10000,
+      frameCount: 1,
     });
+    return () => {
+      cancelled = true;
+      cancelStartupSchedule();
+      unsubscribeSettings?.();
+    };
   }, []);
 
   // Reset cached state when the session changes.

--- a/src/web-ui/src/infrastructure/api/service-api/ApiClient.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ApiClient.test.ts
@@ -54,6 +54,7 @@ describe('ApiClient startup trace classification', () => {
 
     expect(traceMocks.recordApiCall).toHaveBeenCalledWith(expect.objectContaining({
       command: 'get_config',
+      target: 'font',
       outcome: 'success',
     }));
     expect(client.getStats()).toMatchObject({

--- a/src/web-ui/src/infrastructure/api/service-api/ApiClient.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ApiClient.ts
@@ -57,6 +57,29 @@ function isOptionalConfigNotFound(request: ApiRequest, error: unknown): boolean 
   return isOptionalConfigNotFoundCommand(request.config as TauriCommandConfig, error);
 }
 
+function traceTargetForCommand(command: string, payload: unknown): string | undefined {
+  if (!payload || typeof payload !== 'object') {
+    return undefined;
+  }
+
+  const request = (payload as { request?: unknown }).request;
+  if (!request || typeof request !== 'object') {
+    return undefined;
+  }
+
+  const record = request as Record<string, unknown>;
+  if ((command === 'get_config' || command === 'set_config') && typeof record.path === 'string') {
+    return record.path;
+  }
+
+  if (command === 'get_configs' && Array.isArray(record.paths)) {
+    const paths = record.paths.filter((item): item is string => typeof item === 'string');
+    return paths.length > 0 ? paths.join(',') : undefined;
+  }
+
+  return undefined;
+}
+
 export class ApiClient implements IApiClient {
   private config: ApiConfig;
   private activeRequests = new Map<string, AbortController>();
@@ -178,6 +201,7 @@ export class ApiClient implements IApiClient {
       : `${(request.config as HttpRequestConfig).method} ${(request.config as HttpRequestConfig).url}`;
     const requestBytes = estimateJsonBytes(tracePayload);
     const remote = isRemoteTraceRequest(tracePayload);
+    const traceTarget = traceTargetForCommand(traceCommand, tracePayload);
     const requestPayloadEstimateDurationMs = elapsedMs(tracePayloadStartedAt);
     
     this.updateStats({ totalRequests: this.stats.totalRequests + 1 });
@@ -216,7 +240,10 @@ export class ApiClient implements IApiClient {
         startupTrace.recordApiCall({
           type: request.type,
           command: traceCommand,
+          target: traceTarget,
           durationMs,
+          startedAtMs: startedAt,
+          endedAtMs: startedAt + durationMs,
           outcome: 'success',
           requestBytes,
           responseBytes,
@@ -248,7 +275,10 @@ export class ApiClient implements IApiClient {
       startupTrace.recordApiCall({
         type: request.type,
         command: traceCommand,
+        target: traceTarget,
         durationMs: elapsedMs(startedAt),
+        startedAtMs: startedAt,
+        endedAtMs: nowMs(),
         outcome: optionalConfigNotFound ? 'success' : 'failure',
         requestBytes,
         payloadEstimateDurationMs: requestPayloadEstimateDurationMs,

--- a/src/web-ui/src/infrastructure/config/services/AIExperienceConfigService.test.ts
+++ b/src/web-ui/src/infrastructure/config/services/AIExperienceConfigService.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const configManagerMock = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  setConfig: vi.fn(),
+  watch: vi.fn(),
+}));
+
+vi.mock('./ConfigManager', () => ({
+  configManager: configManagerMock,
+}));
+
+vi.mock('./AgentCompanionPetService', () => ({
+  DEFAULT_AGENT_COMPANION_PET: {
+    id: 'default',
+    displayName: 'Default',
+    source: 'preset',
+    packagePath: '',
+    spritesheetPath: '',
+    spritesheetMimeType: 'image/png',
+  },
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+describe('AIExperienceConfigService startup behavior', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    configManagerMock.watch.mockReturnValue(() => undefined);
+  });
+
+  it('does not read app.ai_experience during module import', async () => {
+    await import('./AIExperienceConfigService');
+    await Promise.resolve();
+
+    expect(configManagerMock.getConfig).not.toHaveBeenCalled();
+  });
+
+  it('loads settings lazily when requested', async () => {
+    configManagerMock.getConfig.mockResolvedValueOnce({
+      enable_agent_companion: false,
+    });
+    const { aiExperienceConfigService } = await import('./AIExperienceConfigService');
+
+    await aiExperienceConfigService.getSettingsAsync();
+
+    expect(configManagerMock.watch).toHaveBeenCalledTimes(1);
+    expect(configManagerMock.watch).toHaveBeenCalledWith('app.ai_experience', expect.any(Function));
+    expect(configManagerMock.getConfig).toHaveBeenCalledTimes(1);
+    expect(configManagerMock.getConfig).toHaveBeenCalledWith('app.ai_experience');
+  });
+});

--- a/src/web-ui/src/infrastructure/config/services/AIExperienceConfigService.ts
+++ b/src/web-ui/src/infrastructure/config/services/AIExperienceConfigService.ts
@@ -84,14 +84,14 @@ export class AIExperienceConfigService {
   private listeners: Set<(settings: AIExperienceSettings) => void> = new Set();
   private unwatchConfig: (() => void) | null = null;
 
-  private constructor() {
-    // Defer configManager access to avoid circular dependency TDZ at module evaluation time.
-    // By the next microtask, all ESM modules have finished evaluating and configManager is available.
-    Promise.resolve().then(() => {
-      this.unwatchConfig = configManager.watch(CONFIG_PATH, () => {
-        this.reload();
-      });
-      this.loadSettings();
+  private constructor() {}
+
+  private ensureConfigWatcher(): void {
+    if (this.unwatchConfig) {
+      return;
+    }
+    this.unwatchConfig = configManager.watch(CONFIG_PATH, () => {
+      void this.reload();
     });
   }
 
@@ -105,6 +105,7 @@ export class AIExperienceConfigService {
 
    
   private async loadSettings(): Promise<void> {
+    this.ensureConfigWatcher();
     try {
       const settings = await configManager.getConfig<AIExperienceSettings>(CONFIG_PATH);
       const merged = normalizeSettings(settings);
@@ -130,6 +131,7 @@ export class AIExperienceConfigService {
 
    
   async getSettingsAsync(): Promise<AIExperienceSettings> {
+    this.ensureConfigWatcher();
     try {
       const settings = await configManager.getConfig<AIExperienceSettings>(CONFIG_PATH);
       this.cachedSettings = normalizeSettings(settings);
@@ -142,6 +144,7 @@ export class AIExperienceConfigService {
 
    
   async saveSettings(settings: AIExperienceSettings): Promise<void> {
+    this.ensureConfigWatcher();
     try {
       const normalized = normalizeSettings(settings);
       await configManager.setConfig(CONFIG_PATH, normalized);
@@ -159,6 +162,7 @@ export class AIExperienceConfigService {
   }
 
   addChangeListener(listener: (settings: AIExperienceSettings) => void): () => void {
+    this.ensureConfigWatcher();
     this.listeners.add(listener);
     
     

--- a/src/web-ui/src/infrastructure/config/services/modelConfigs.test.ts
+++ b/src/web-ui/src/infrastructure/config/services/modelConfigs.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const configManagerMock = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  setConfig: vi.fn(),
+}));
 
 vi.mock('./ConfigManager', () => ({
-  configManager: {},
+  configManager: configManagerMock,
 }));
 
 vi.mock('@/infrastructure/i18n', () => ({
@@ -10,10 +15,22 @@ vi.mock('@/infrastructure/i18n', () => ({
   },
 }));
 
-import { getProviderDisplayName } from './modelConfigs';
-
 describe('modelConfigs', () => {
-  it('preserves custom provider names even when the base URL matches a known provider', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('does not read ai.models when imported for display helpers', async () => {
+    await import('./modelConfigs');
+    await Promise.resolve();
+
+    expect(configManagerMock.getConfig).not.toHaveBeenCalled();
+  });
+
+  it('preserves custom provider names even when the base URL matches a known provider', async () => {
+    const { getProviderDisplayName } = await import('./modelConfigs');
+
     expect(getProviderDisplayName({
       name: 'My Zhipu Proxy',
       base_url: 'https://open.bigmodel.cn/api/paas/v4',
@@ -21,10 +38,40 @@ describe('modelConfigs', () => {
     })).toBe('My Zhipu Proxy');
   });
 
-  it('keeps legacy URL inference when a provider name is missing', () => {
+  it('keeps legacy URL inference when a provider name is missing', async () => {
+    const { getProviderDisplayName } = await import('./modelConfigs');
+
     expect(getProviderDisplayName({
       base_url: 'https://open.bigmodel.cn/api/paas/v4',
       model_name: 'glm-5',
     })).toBe('settings/ai-model:providers.zhipu.name');
+  });
+
+  it('loads ai.models only when the model manager is actually used', async () => {
+    configManagerMock.getConfig.mockResolvedValueOnce([
+      {
+        id: 'model-1',
+        name: 'Provider',
+        base_url: 'https://example.test',
+        api_key: '',
+        model_name: 'model',
+        provider: 'openai',
+      },
+    ]);
+    const { modelConfigManager } = await import('./modelConfigs');
+    const listener = vi.fn();
+
+    modelConfigManager.addListener(listener);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(configManagerMock.getConfig).toHaveBeenCalledTimes(1);
+    expect(configManagerMock.getConfig).toHaveBeenCalledWith('ai.models');
+    expect(listener).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'model-1',
+        modelName: 'model',
+      }),
+    ]);
   });
 });

--- a/src/web-ui/src/infrastructure/config/services/modelConfigs.ts
+++ b/src/web-ui/src/infrastructure/config/services/modelConfigs.ts
@@ -217,14 +217,13 @@ type ConfigChangeListener = (configs: ModelConfig[]) => void;
 class ModelConfigManager {
   private configs: ModelConfig[] = [];
   private listeners: Set<ConfigChangeListener> = new Set();
-
-  constructor() {
-    this.loadConfigs();
-  }
+  private loadPromise: Promise<void> | null = null;
+  private hasRequestedLoad = false;
 
   // Listener management
   addListener(listener: ConfigChangeListener): () => void {
     this.listeners.add(listener);
+    this.loadConfigs();
     return () => {
       this.listeners.delete(listener);
     };
@@ -245,15 +244,23 @@ class ModelConfigManager {
 
   // New architecture: load via the unified config manager.
   private loadConfigs(): void {
+    if (this.loadPromise || this.hasRequestedLoad) {
+      return;
+    }
+    this.hasRequestedLoad = true;
     // Start with an empty set, then sync async.
     this.configs = [];
-    
+
     // Async load the real config.
-    this.syncFromConfigManager().catch(error => {
-      log.error('Failed to load configs', error);
-      this.configs = [];
-      this.notifyListeners();
-    });
+    this.loadPromise = this.syncFromConfigManager()
+      .catch(error => {
+        log.error('Failed to load configs', error);
+        this.configs = [];
+        this.notifyListeners();
+      })
+      .finally(() => {
+        this.loadPromise = null;
+      });
   }
 
   // New architecture: sync from the unified config manager.
@@ -318,11 +325,13 @@ class ModelConfigManager {
 
   // Reload configuration (public).
   async reload(): Promise<void> {
+    this.hasRequestedLoad = true;
     await this.syncFromConfigManager();
   }
 
   // Read operations
   getAllConfigs(): ModelConfig[] {
+    this.loadConfigs();
     return [...this.configs];
   }
 

--- a/src/web-ui/src/infrastructure/contexts/WorkspaceProvider.tsx
+++ b/src/web-ui/src/infrastructure/contexts/WorkspaceProvider.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } f
 import { workspaceManager } from '../services/business/workspaceManager';
 import { WorkspaceInfo, WorkspaceKind } from '../../shared/types';
 import { createLogger } from '@/shared/utils/logger';
+import { startupTrace } from '@/shared/utils/startupTrace';
+import { elapsedMs, nowMs } from '@/shared/utils/timing';
 import {
   WorkspaceContext,
   type WorkspaceContextValue,
@@ -154,10 +156,16 @@ export const WorkspaceProvider: React.FC<WorkspaceProviderProps> = ({ children }
         return;
       }
 
+      const providerStartedAt = nowMs();
+      startupTrace.markPhase('workspace_provider_initialize_start');
+
       try {
         isInitializedRef.current = true;
         setState((prev) => ({ ...prev, loading: true }));
         await workspaceManager.initialize();
+        startupTrace.markPhase('workspace_provider_manager_initialize_end', {
+          durationMs: elapsedMs(providerStartedAt),
+        });
         const nextState = workspaceManager.getState();
         const activeWorkspace = nextState.currentWorkspace;
         const openedWorkspacesList = Array.from(nextState.openedWorkspaces.values());
@@ -177,7 +185,15 @@ export const WorkspaceProvider: React.FC<WorkspaceProviderProps> = ({ children }
           workspaceName: getWorkspaceDisplayName(activeWorkspace),
           workspacePath: activeWorkspace?.rootPath || '',
         }));
+        startupTrace.markPhase('workspace_provider_initialize_end', {
+          durationMs: elapsedMs(providerStartedAt),
+          openedCount: openedWorkspacesList.length,
+          hasActiveWorkspace: activeWorkspace !== null,
+        });
       } catch (error) {
+        startupTrace.markPhase('workspace_provider_initialize_failed', {
+          durationMs: elapsedMs(providerStartedAt),
+        });
         log.error('Failed to initialize workspace state', error);
         isInitializedRef.current = false;
         setState((prev) => ({ ...prev, loading: false, error: String(error) }));

--- a/src/web-ui/src/infrastructure/services/business/workspaceManager.test.ts
+++ b/src/web-ui/src/infrastructure/services/business/workspaceManager.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const globalStateMocks = vi.hoisted(() => ({
+  initializeGlobalState: vi.fn(),
+  cleanupInvalidWorkspaces: vi.fn(),
+  getRecentWorkspaces: vi.fn(),
+  getOpenedWorkspaces: vi.fn(),
+  getCurrentWorkspace: vi.fn(),
+}));
+
+const listenMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../shared/types', () => ({
+  WorkspaceKind: {
+    Normal: 'normal',
+    Assistant: 'assistant',
+    Remote: 'remote',
+  },
+  globalStateAPI: globalStateMocks,
+  isRemoteWorkspace: (workspace: { workspaceKind?: string } | null) =>
+    workspace?.workspaceKind === 'remote',
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: listenMock,
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('@/shared/utils/startupTrace', () => ({
+  startupTrace: {
+    markPhase: vi.fn(),
+  },
+}));
+
+function configureGlobalState(): void {
+  globalStateMocks.initializeGlobalState.mockResolvedValue('initialized');
+  globalStateMocks.cleanupInvalidWorkspaces.mockResolvedValue(0);
+  globalStateMocks.getRecentWorkspaces.mockResolvedValue([]);
+  globalStateMocks.getOpenedWorkspaces.mockResolvedValue([]);
+  globalStateMocks.getCurrentWorkspace.mockResolvedValue(null);
+}
+
+async function getFreshWorkspaceManager() {
+  vi.resetModules();
+  const { WorkspaceManager } = await import('./workspaceManager');
+  (WorkspaceManager as unknown as { instance: unknown }).instance = null;
+  return WorkspaceManager.getInstance();
+}
+
+describe('WorkspaceManager startup initialization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configureGlobalState();
+  });
+
+  it('overlaps global state initialization with identity listener registration but waits before publishing state', async () => {
+    let resolveListener: ((unlisten: () => void) => void) | null = null;
+    listenMock.mockReturnValue(new Promise(resolve => {
+      resolveListener = resolve;
+    }));
+    const manager = await getFreshWorkspaceManager();
+
+    const initializePromise = manager.initialize();
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    expect(listenMock).toHaveBeenCalledWith('workspace-identity-changed', expect.any(Function));
+    expect(globalStateMocks.initializeGlobalState).toHaveBeenCalledTimes(1);
+    expect(globalStateMocks.getCurrentWorkspace).not.toHaveBeenCalled();
+
+    resolveListener?.(() => undefined);
+    await initializePromise;
+
+    expect(globalStateMocks.getCurrentWorkspace).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
+++ b/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
@@ -8,9 +8,29 @@ import {
 } from '../../../shared/types';
 import { normalizeRemoteWorkspacePath } from '@/shared/utils/pathUtils';
 import { createLogger } from '@/shared/utils/logger';
+import { startupTrace } from '@/shared/utils/startupTrace';
+import { elapsedMs, nowMs } from '@/shared/utils/timing';
 import { listen } from '@tauri-apps/api/event';
 
 const log = createLogger('WorkspaceManager');
+
+function markWorkspaceStartupStepStart(step: string): number {
+  const startedAt = nowMs();
+  startupTrace.markPhase('workspace_startup_step_start', { step });
+  return startedAt;
+}
+
+function markWorkspaceStartupStepEnd(
+  step: string,
+  startedAt: number,
+  data?: Record<string, unknown>
+): void {
+  startupTrace.markPhase('workspace_startup_step_end', {
+    step,
+    durationMs: elapsedMs(startedAt),
+    ...(data ?? {}),
+  });
+}
 
 interface WorkspaceIdentityChangedEvent {
   workspaceId: string;
@@ -297,13 +317,20 @@ class WorkspaceManager {
     }
 
     this.identityEventListening = true;
+    const registrationStartedAt = nowMs();
 
     try {
       await listen<WorkspaceIdentityChangedEvent>('workspace-identity-changed', event => {
         this.applyIdentityUpdate(event.payload);
       });
+      startupTrace.markPhase('workspace_identity_listener_ready', {
+        durationMs: elapsedMs(registrationStartedAt),
+      });
     } catch (error) {
       this.identityEventListening = false;
+      startupTrace.markPhase('workspace_identity_listener_failed', {
+        durationMs: elapsedMs(registrationStartedAt),
+      });
       log.error('Failed to subscribe workspace identity updates', { error });
     }
   }
@@ -366,21 +393,47 @@ class WorkspaceManager {
       return;
     }
 
+    const initializeStartedAt = nowMs();
+    startupTrace.markPhase('workspace_initialize_start');
+
     try {
       this.isInitializing = true;
       log.info('Initializing workspace state');
-      await this.ensureIdentityChangeListener();
 
+      const identityListenerStartedAt = markWorkspaceStartupStepStart('ensure_identity_listener');
+      const identityListenerReady = this.ensureIdentityChangeListener()
+        .finally(() => {
+          markWorkspaceStartupStepEnd('ensure_identity_listener', identityListenerStartedAt, {
+            blocking: true,
+            overlappedWithGlobalState: true,
+          });
+        });
+
+      const globalStateStartedAt = markWorkspaceStartupStepStart('initialize_global_state');
       const initResult = await globalStateAPI.initializeGlobalState();
+      markWorkspaceStartupStepEnd('initialize_global_state', globalStateStartedAt);
       log.debug('Backend initialization completed', { result: initResult });
-      await globalStateAPI.cleanupInvalidWorkspaces();
+      await identityListenerReady;
 
+      const cleanupStartedAt = markWorkspaceStartupStepStart('cleanup_invalid_workspaces');
+      await globalStateAPI.cleanupInvalidWorkspaces();
+      markWorkspaceStartupStepEnd('cleanup_invalid_workspaces', cleanupStartedAt);
+
+      const fetchStateStartedAt = markWorkspaceStartupStepStart('fetch_workspace_state');
       const [recentWorkspaces, openedWorkspaces, currentWorkspace] = await Promise.all([
         globalStateAPI.getRecentWorkspaces(),
         globalStateAPI.getOpenedWorkspaces(),
         globalStateAPI.getCurrentWorkspace(),
       ]);
+      markWorkspaceStartupStepEnd('fetch_workspace_state', fetchStateStartedAt, {
+        recentCount: recentWorkspaces.length,
+        openedCount: openedWorkspaces.length,
+        hasCurrentWorkspace: currentWorkspace !== null,
+        currentWorkspaceKind: currentWorkspace?.workspaceKind ?? null,
+        currentWorkspaceRemote: currentWorkspace ? isRemoteWorkspace(currentWorkspace) : false,
+      });
 
+      const updateStateStartedAt = markWorkspaceStartupStepStart('update_workspace_state');
       this.updateWorkspaceState(
         currentWorkspace,
         recentWorkspaces,
@@ -391,14 +444,28 @@ class WorkspaceManager {
           ? { type: 'workspace:opened', workspace: currentWorkspace }
           : undefined
       );
+      markWorkspaceStartupStepEnd('update_workspace_state', updateStateStartedAt, {
+        recentCount: recentWorkspaces.length,
+        openedCount: openedWorkspaces.length,
+        hasCurrentWorkspace: currentWorkspace !== null,
+      });
 
       this.emit({ type: 'workspace:loading', loading: false });
       this.isInitialized = true;
+      startupTrace.markPhase('workspace_initialize_end', {
+        durationMs: elapsedMs(initializeStartedAt),
+        recentCount: recentWorkspaces.length,
+        openedCount: openedWorkspaces.length,
+        hasCurrentWorkspace: currentWorkspace !== null,
+      });
       log.info('Workspace state initialization completed', {
         activeWorkspaceId: currentWorkspace?.id ?? null,
         openedWorkspaceCount: openedWorkspaces.length,
       });
     } catch (error) {
+      startupTrace.markPhase('workspace_initialize_failed', {
+        durationMs: elapsedMs(initializeStartedAt),
+      });
       log.error('Failed to initialize workspace state', { error });
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.updateWorkspaceState(null, [], [], false, errorMessage);

--- a/src/web-ui/src/infrastructure/update/DailyAppUpdateGate.tsx
+++ b/src/web-ui/src/infrastructure/update/DailyAppUpdateGate.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type ReactElement } from 'rea
 import { systemAPI } from '@/infrastructure/api';
 import { configManager } from '@/infrastructure/config';
 import { createLogger } from '@/shared/utils/logger';
+import { scheduleAfterStartupSignal } from '@/shared/utils/startupTaskScheduling';
 import type { CheckForUpdatesResponse } from '@/infrastructure/api/service-api/SystemAPI';
 import { isTauriRuntime } from './tauriEnv';
 import {
@@ -35,7 +36,7 @@ export function DailyAppUpdateGate(): ReactElement | null {
       return;
     }
     let cancelled = false;
-    void (async () => {
+    const runDailyCheck = async () => {
       let autoUpdate = true;
       try {
         const v = await configManager.getConfig<boolean>('app.auto_update');
@@ -72,9 +73,20 @@ export function DailyAppUpdateGate(): ReactElement | null {
           }
         })();
       }, 900);
-    })();
+    };
+    const cancelStartupSchedule = scheduleAfterStartupSignal(() => {
+      void runDailyCheck();
+    }, {
+      signalName: 'bitfun:interactive-shell-ready',
+      fallbackTimeoutMs: 10000,
+      frameCount: 1,
+      onError: error => {
+        log.warn('Failed to schedule daily update check after startup', error);
+      },
+    });
     return () => {
       cancelled = true;
+      cancelStartupSchedule();
       if (dailyCheckTimerRef.current != null) {
         window.clearTimeout(dailyCheckTimerRef.current);
         dailyCheckTimerRef.current = null;

--- a/src/web-ui/src/main.tsx
+++ b/src/web-ui/src/main.tsx
@@ -26,6 +26,29 @@ startupTrace.markPhase('first_script_eval', {
   isDev: import.meta.env.DEV,
 });
 
+async function traceStartupStep<T>(
+  phase: string,
+  step: string,
+  run: () => Promise<T>
+): Promise<T> {
+  const startedAt = nowMs();
+  startupTrace.markPhase(`${phase}_start`, { step });
+  try {
+    const value = await run();
+    startupTrace.markPhase(`${phase}_end`, {
+      step,
+      durationMs: elapsedMs(startedAt),
+    });
+    return value;
+  } catch (error) {
+    startupTrace.markPhase(`${phase}_failed`, {
+      step,
+      durationMs: elapsedMs(startedAt),
+    });
+    throw error;
+  }
+}
+
 /** Dedupe only for white-screen heuristic (empty #root), not for Error Boundary logs. */
 const WHITE_SCREEN_LOGGED_FLAG = '__bitfun_white_screen_crash_logged__';
 function hasLoggedWhiteScreenCrash(): boolean {
@@ -177,24 +200,30 @@ document.addEventListener(
 async function initializeBeforeRender(): Promise<void> {
   const phaseStartedAt = nowMs();
   startupTrace.markPhase('before_render_start');
-  await measureAsyncAndLog(log, 'Startup step completed', () => initLogger(), {
-    data: { step: 'initLogger' },
+  await traceStartupStep('before_render_step', 'init_logger', async () => {
+    await measureAsyncAndLog(log, 'Startup step completed', () => initLogger(), {
+      data: { step: 'initLogger' },
+    });
   });
 
-  await measureAsyncAndLog(log, 'Startup step completed', async () => {
-    const { initializeFrontendLogLevelSync } = await import('./infrastructure/config/services/FrontendLogLevelSync');
-    await initializeFrontendLogLevelSync();
-  }, {
-    data: { step: 'initializeFrontendLogLevelSync' },
+  await traceStartupStep('before_render_step', 'initialize_frontend_log_level_sync', async () => {
+    await measureAsyncAndLog(log, 'Startup step completed', async () => {
+      const { initializeFrontendLogLevelSync } = await import('./infrastructure/config/services/FrontendLogLevelSync');
+      await initializeFrontendLogLevelSync();
+    }, {
+      data: { step: 'initializeFrontendLogLevelSync' },
+    });
   });
 
   log.info('Initializing BitFun');
 
-  await measureAsyncAndLog(log, 'Startup step completed', async () => {
-    const { themeService } = await import('./infrastructure/theme');
-    await themeService.initialize();
-  }, {
-    data: { step: 'themeService.initialize' },
+  await traceStartupStep('before_render_step', 'theme_service_initialize', async () => {
+    await measureAsyncAndLog(log, 'Startup step completed', async () => {
+      const { themeService } = await import('./infrastructure/theme');
+      await themeService.initialize();
+    }, {
+      data: { step: 'themeService.initialize' },
+    });
   });
   log.info('Theme system initialized');
   logElapsed(log, 'Startup phase completed', phaseStartedAt, {
@@ -288,11 +317,15 @@ async function startApplication(): Promise<void> {
   }
 
   // I18n Provider.
-  const i18nProviderImportResult = await measureAsyncAndLog(
-    log,
-    'Startup step completed',
-    () => import('./infrastructure/i18n'),
-    { data: { step: 'loadI18nProvider' } }
+  const i18nProviderImportResult = await traceStartupStep(
+    'startup_step',
+    'load_i18n_provider',
+    () => measureAsyncAndLog(
+      log,
+      'Startup step completed',
+      () => import('./infrastructure/i18n'),
+      { data: { step: 'loadI18nProvider' } }
+    )
   );
   const { I18nProvider } = i18nProviderImportResult.value;
   const isAgentCompanionWindow = new URLSearchParams(window.location.search)

--- a/src/web-ui/src/shared/announcement-system/components/AnnouncementProvider.tsx
+++ b/src/web-ui/src/shared/announcement-system/components/AnnouncementProvider.tsx
@@ -5,6 +5,7 @@ import AnnouncementToastStack from './AnnouncementToastStack';
 import FeatureModal from './FeatureModal';
 import { configAPI } from '@/infrastructure/api';
 import { createLogger } from '@/shared/utils/logger';
+import { scheduleAfterStartupSignal } from '@/shared/utils/startupTaskScheduling';
 
 const log = createLogger('AnnouncementProvider');
 
@@ -43,25 +44,52 @@ const AnnouncementProvider: React.FC = () => {
   // ── Normal load path ─────────────────────────────────────────────────────
   useEffect(() => {
     if (initialised) return;
+    let cancelled = false;
 
     const load = async () => {
       try {
         const cards = await announcementService.getPendingAnnouncements();
+        if (cancelled) {
+          return;
+        }
         const tipsEnabled = await configAPI.getConfig('app.notifications.enable_startup_tips') !== false;
+        if (cancelled) {
+          return;
+        }
         const visibleCards = tipsEnabled ? cards : cards.filter((card) => card.card_type !== 'tip');
         if (visibleCards.length > 0) {
           log.debug('Announcement cards loaded', { count: visibleCards.length });
           const maxDelay = Math.max(...visibleCards.map((c) => c.trigger.delay_ms ?? 0));
-          setTimeout(() => loadQueue(visibleCards), maxDelay);
+          setTimeout(() => {
+            if (!cancelled) {
+              loadQueue(visibleCards);
+            }
+          }, maxDelay);
         }
       } catch (e) {
         log.error('Failed to load announcement cards', e);
       } finally {
-        markInitialised();
+        if (!cancelled) {
+          markInitialised();
+        }
       }
     };
 
-    load();
+    const cancelStartupSchedule = scheduleAfterStartupSignal(() => {
+      void load();
+    }, {
+      signalName: 'bitfun:interactive-shell-ready',
+      fallbackTimeoutMs: 10000,
+      frameCount: 1,
+      onError: error => {
+        log.error('Failed to schedule announcement load after startup', error);
+      },
+    });
+
+    return () => {
+      cancelled = true;
+      cancelStartupSchedule();
+    };
   }, [initialised, loadQueue, markInitialised]);
 
   // ── Debug trigger ─────────────────────────────────────────────────────────

--- a/src/web-ui/src/shared/utils/startupTrace.test.ts
+++ b/src/web-ui/src/shared/utils/startupTrace.test.ts
@@ -23,7 +23,7 @@ function createTestLogger(): LoggerLike & {
 }
 
 describe('startupTrace', () => {
-  it('records startup phases without exposing sensitive fields', () => {
+  it('records startup phases without exposing sensitive fields or writing event logs by default', () => {
     const logger = createTestLogger();
     const trace = createStartupTrace({
       logger,
@@ -40,8 +40,8 @@ describe('startupTrace', () => {
       remote: true,
     });
 
-    expect(logger.debug).toHaveBeenCalledTimes(1);
-    const [, payload] = logger.debug.mock.calls[0];
+    expect(logger.debug).not.toHaveBeenCalled();
+    const payload = trace.getSnapshot().phases.events[0];
     expect(payload).toMatchObject({
       traceId: 'trace-test',
       phase: 'before_render_start',
@@ -52,6 +52,32 @@ describe('startupTrace', () => {
     expect(payload).not.toHaveProperty('request');
     expect(payload).not.toHaveProperty('remoteConnectionId');
     expect(payload).not.toHaveProperty('sshHost');
+  });
+
+  it('logs sanitized phase events only when explicitly enabled', () => {
+    const logger = createTestLogger();
+    const trace = createStartupTrace({
+      logger,
+      traceId: 'trace-test',
+      now: () => 100,
+      logEvents: true,
+    });
+
+    trace.markPhase('before_render_start', {
+      command: 'get_config',
+      request: { nested: 'payload' },
+      remote: true,
+    });
+
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    const [, payload] = logger.debug.mock.calls[0];
+    expect(payload).toMatchObject({
+      traceId: 'trace-test',
+      phase: 'before_render_start',
+      command: 'get_config',
+      remote: true,
+    });
+    expect(payload).not.toHaveProperty('request');
   });
 
   it('aggregates API calls by command and remote status', () => {
@@ -66,6 +92,8 @@ describe('startupTrace', () => {
       type: 'tauri',
       command: 'list_persisted_sessions',
       durationMs: 12.4,
+      startedAtMs: 100,
+      endedAtMs: 112.4,
       requestBytes: 100,
       responseBytes: 500,
       remote: true,
@@ -83,6 +111,7 @@ describe('startupTrace', () => {
     trace.recordApiCall({
       type: 'tauri',
       command: 'get_config',
+      target: 'font',
       durationMs: 5,
       requestBytes: 40,
       responseBytes: 60,
@@ -99,11 +128,10 @@ describe('startupTrace', () => {
 
     trace.flushSummary('test');
 
-    expect(logger.info).toHaveBeenCalledTimes(1);
-    const [, payload] = logger.info.mock.calls[0];
+    expect(logger.info).not.toHaveBeenCalled();
+    const payload = trace.getSnapshot();
     expect(payload).toMatchObject({
       traceId: 'trace-test',
-      reason: 'test',
       phases: {
         events: [],
       },
@@ -163,6 +191,23 @@ describe('startupTrace', () => {
         responseBytes: 60,
       },
     ]);
+    expect(payload.api.calls[0]).toMatchObject({
+      traceId: 'trace-test',
+      type: 'tauri',
+      command: 'list_persisted_sessions',
+      startedAtMs: 100,
+      endedAtMs: 112.4,
+      durationMs: 12.4,
+      outcome: 'success',
+      cacheOutcome: 'miss',
+      requestBytes: 100,
+      responseBytes: 500,
+      remote: true,
+    });
+    expect(payload.api.calls[2]).toMatchObject({
+      command: 'get_config',
+      target: 'font',
+    });
   });
 
   it('flushes bounded phase records so early events survive logger startup timing', () => {
@@ -182,7 +227,10 @@ describe('startupTrace', () => {
     trace.markPhase('ignored_after_limit');
     trace.flushSummary('test');
 
-    const [, payload] = logger.info.mock.calls[0];
+    trace.flushSummary('test');
+
+    expect(logger.info).not.toHaveBeenCalled();
+    const payload = trace.getSnapshot();
     expect(payload.phases).toMatchObject({
       count: 2,
       events: [
@@ -242,6 +290,13 @@ describe('startupTrace', () => {
       api: {
         totalCount: 1,
         successCount: 1,
+        calls: [
+          {
+            command: 'restore_session_view',
+            durationMs: 42.4,
+            outcome: 'success',
+          },
+        ],
         byCommand: [
           {
             command: 'restore_session_view',
@@ -317,8 +372,8 @@ describe('startupTrace', () => {
     now = 132;
     callbacks.shift()?.(now);
 
-    expect(logger.debug).toHaveBeenCalledTimes(1);
-    const [, payload] = logger.debug.mock.calls[0];
+    expect(logger.debug).not.toHaveBeenCalled();
+    const payload = trace.getSnapshot().phases.events[0];
     expect(payload).toMatchObject({
       traceId: 'trace-test',
       phase: 'historical_session_first_paint',

--- a/src/web-ui/src/shared/utils/startupTrace.ts
+++ b/src/web-ui/src/shared/utils/startupTrace.ts
@@ -9,7 +9,10 @@ export type StartupTraceRequestType = 'tauri' | 'http';
 export interface StartupTraceApiCall {
   type: StartupTraceRequestType;
   command: string;
+  target?: string;
   durationMs: number;
+  startedAtMs?: number;
+  endedAtMs?: number;
   outcome?: 'success' | 'failure';
   cacheOutcome?: 'hit' | 'miss' | 'unknown';
   requestBytes?: number;
@@ -24,6 +27,9 @@ export interface StartupTraceOptions {
   traceId?: string;
   now?: NowFn;
   maxPhaseEvents?: number;
+  maxApiCallRecords?: number;
+  logEvents?: boolean;
+  logSummary?: boolean;
 }
 
 export interface DeferredAnimationFrameTraceOptions {
@@ -66,6 +72,22 @@ export interface StartupTraceApiSummary {
   responseBytes: number;
   payloadEstimateDurationMs: number;
   byCommand: CommandAggregate[];
+  calls: StartupTraceApiCallRecord[];
+}
+
+export interface StartupTraceApiCallRecord {
+  traceId: string;
+  type: StartupTraceRequestType;
+  command: string;
+  target?: string;
+  startedAtMs?: number;
+  endedAtMs?: number;
+  durationMs: number;
+  outcome: 'success' | 'failure';
+  cacheOutcome: 'hit' | 'miss' | 'unknown';
+  requestBytes: number;
+  responseBytes: number;
+  remote: boolean;
 }
 
 export interface StartupTraceSnapshot {
@@ -279,9 +301,14 @@ export class StartupTrace {
   private readonly logger: LoggerLike;
   private readonly now: NowFn;
   private readonly maxPhaseEvents: number;
+  private readonly maxApiCallRecords: number;
+  private readonly logEvents: boolean;
+  private readonly logSummary: boolean;
   readonly traceId: string;
   private phaseEvents = 0;
   private readonly phaseRecords: PhaseRecord[] = [];
+  private apiCallEvents = 0;
+  private readonly apiCallRecords: StartupTraceApiCallRecord[] = [];
   private readonly commandAggregates = new Map<string, CommandAggregate>();
   private totalApiCount = 0;
   private successfulApiCount = 0;
@@ -299,7 +326,10 @@ export class StartupTrace {
     this.logger = options.logger ?? createLogger('StartupTrace');
     this.traceId = options.traceId ?? createTraceId();
     this.now = options.now ?? (() => globalThis.performance?.now?.() ?? Date.now());
-    this.maxPhaseEvents = options.maxPhaseEvents ?? 160;
+    this.maxPhaseEvents = options.maxPhaseEvents ?? 260;
+    this.maxApiCallRecords = options.maxApiCallRecords ?? 240;
+    this.logEvents = options.logEvents ?? false;
+    this.logSummary = options.logSummary ?? false;
   }
 
   markPhase(phase: string, data?: TraceData): void {
@@ -314,7 +344,9 @@ export class StartupTrace {
       ...(sanitizeTraceData(data) ?? {}),
     };
     this.phaseRecords.push(phaseRecord);
-    this.logger.debug('Startup trace event', phaseRecord);
+    if (this.logEvents) {
+      this.logger.debug('Startup trace event', phaseRecord);
+    }
   }
 
   recordApiCall(call: StartupTraceApiCall): void {
@@ -323,6 +355,12 @@ export class StartupTrace {
     }
 
     const durationMs = roundDurationMs(call.durationMs);
+    const startedAtMs = typeof call.startedAtMs === 'number'
+      ? roundDurationMs(call.startedAtMs)
+      : undefined;
+    const endedAtMs = typeof call.endedAtMs === 'number'
+      ? roundDurationMs(call.endedAtMs)
+      : (startedAtMs !== undefined ? roundDurationMs(startedAtMs + durationMs) : undefined);
     const requestBytes = call.requestBytes ?? 0;
     const responseBytes = call.responseBytes ?? 0;
     const succeeded = call.outcome !== 'failure';
@@ -337,6 +375,24 @@ export class StartupTrace {
     this.requestBytes += requestBytes;
     this.responseBytes += responseBytes;
     this.payloadEstimateDurationMs += call.payloadEstimateDurationMs ?? 0;
+
+    if (this.apiCallEvents < this.maxApiCallRecords) {
+      this.apiCallEvents += 1;
+      this.apiCallRecords.push({
+        traceId: this.traceId,
+        type: call.type,
+        command: call.command,
+        target: call.target,
+        startedAtMs,
+        endedAtMs,
+        durationMs,
+        outcome: succeeded ? 'success' : 'failure',
+        cacheOutcome,
+        requestBytes,
+        responseBytes,
+        remote: call.remote,
+      });
+    }
 
     const existing = this.commandAggregates.get(call.command) ?? {
       command: call.command,
@@ -388,6 +444,7 @@ export class StartupTrace {
       responseBytes: this.responseBytes,
       payloadEstimateDurationMs: roundDurationMs(this.payloadEstimateDurationMs),
       byCommand,
+      calls: this.apiCallRecords.map(record => ({ ...record })),
     };
   }
 
@@ -407,15 +464,17 @@ export class StartupTrace {
       return;
     }
 
-    const snapshot = this.getSnapshot();
-    this.logger.info('Startup trace summary', {
-      traceId: snapshot.traceId,
-      reason,
-      phases: snapshot.phases,
-      api: {
-        ...snapshot.api,
-      },
-    });
+    if (this.logSummary) {
+      const snapshot = this.getSnapshot();
+      this.logger.info('Startup trace summary', {
+        traceId: snapshot.traceId,
+        reason,
+        phases: snapshot.phases,
+        api: {
+          ...snapshot.api,
+        },
+      });
+    }
   }
 }
 

--- a/tests/e2e/helpers/performance-trace.ts
+++ b/tests/e2e/helpers/performance-trace.ts
@@ -5,6 +5,11 @@ declare global {
     __BITFUN_STARTUP_TRACE__?: {
       snapshot?: () => unknown;
     };
+    __TAURI__?: {
+      core?: {
+        invoke?: (command: string, args?: unknown) => Promise<unknown>;
+      };
+    };
   }
 }
 
@@ -30,6 +35,38 @@ export interface StartupTraceCommandAggregate {
   responseBytes: number;
 }
 
+export interface StartupTraceApiCallRecord {
+  traceId: string;
+  type: 'tauri' | 'http';
+  command: string;
+  target?: string;
+  startedAtMs?: number;
+  endedAtMs?: number;
+  durationMs: number;
+  outcome: 'success' | 'failure';
+  cacheOutcome: 'hit' | 'miss' | 'unknown';
+  requestBytes: number;
+  responseBytes: number;
+  remote: boolean;
+}
+
+export interface StartupTraceNativeEvent {
+  traceId: string;
+  phase: string;
+  atMs: number;
+  sinceProcessStartMs: number;
+  category?: string;
+  step?: string;
+  command?: string;
+  target?: string;
+  durationMs?: number;
+}
+
+export interface StartupTraceNativeSnapshot {
+  traceId: string;
+  events: StartupTraceNativeEvent[];
+}
+
 export interface StartupTraceSnapshot {
   traceId: string;
   phases: {
@@ -48,7 +85,9 @@ export interface StartupTraceSnapshot {
     responseBytes: number;
     payloadEstimateDurationMs: number;
     byCommand: StartupTraceCommandAggregate[];
+    calls: StartupTraceApiCallRecord[];
   };
+  native?: StartupTraceNativeSnapshot;
 }
 
 export type StartupPerfMilestones = {
@@ -62,7 +101,83 @@ export type StartupPerfMilestones = {
   nonCriticalInitDoneMs?: number;
 };
 
+export type StartupPerfBreakdown = {
+  native: {
+    preTauriLastStepEndMs?: number;
+    tauriSetupDurationMs?: number;
+    tauriSetupUntilMainWindowCreatedDurationMs?: number;
+    createMainWindowDurationMs?: number;
+    prepareThemeDurationMs?: number;
+    webviewBuildDurationMs?: number;
+    windowsMaximizeDurationMs?: number;
+    windowsShowAfterMaximizeWaitMs?: number;
+    showWindowDurationMs?: number;
+    focusWindowDurationMs?: number;
+  };
+  frontend: {
+    firstScriptToRenderScheduledMs?: number;
+    renderScheduledToAppEffectMs?: number;
+    mainWindowShownToInteractiveMs?: number;
+    interactiveToNonCriticalDoneMs?: number;
+    loadI18nProviderDurationMs?: number;
+    beforeRenderSteps: Record<string, number>;
+  };
+  workspace: {
+    initializeDurationMs?: number;
+    providerInitializeDurationMs?: number;
+    providerManagerInitializeDurationMs?: number;
+    steps: Record<string, number>;
+  };
+  tauriCommand: {
+    initializeGlobalState?: {
+      frontendDurationMs?: number;
+      backendDurationMs?: number;
+      estimatedQueueOrBridgeMs?: number;
+      steps: Record<string, number>;
+    };
+    beforeInteractive: {
+      matchedCount: number;
+      totalFrontendDurationMs: number;
+      totalBackendDurationMs: number;
+      totalEstimatedQueueOrBridgeMs: number;
+      byCommand: Array<{
+        command: string;
+        count: number;
+        frontendDurationMs: number;
+        backendDurationMs: number;
+        estimatedQueueOrBridgeMs: number;
+      }>;
+      slowCalls: Array<{
+        command: string;
+        target?: string;
+        frontendDurationMs: number;
+        backendDurationMs?: number;
+        estimatedQueueOrBridgeMs?: number;
+      }>;
+    };
+  };
+  apiBeforeInteractive: {
+    count: number;
+    totalDurationMs: number;
+    maxDurationMs?: number;
+    byCommand: StartupTraceCommandAggregate[];
+    slowCalls: Array<{
+      command: string;
+      target?: string;
+      startedAtMs?: number;
+      durationMs: number;
+      outcome: 'success' | 'failure';
+      remote: boolean;
+    }>;
+  };
+};
+
 export type SessionOpenPerfMilestones = {
+  clickToHydrateStartMs?: number;
+  clickToLatestFrameMs?: number;
+  clickToHydrateEndMs?: number;
+  clickToFullHydrateEndMs?: number;
+  clickToFullHydrateFrameMs?: number;
   hydrateStartMs?: number;
   restoreDurationMs?: number;
   convertDurationMs?: number;
@@ -84,6 +199,24 @@ function booleanField(value: unknown): boolean | undefined {
   return typeof value === 'boolean' ? value : undefined;
 }
 
+async function readNativeStartupTraceSnapshot(): Promise<StartupTraceNativeSnapshot | undefined> {
+  const snapshot = await browser.executeAsync((done: (value: unknown) => void) => {
+    const invoke = window.__TAURI__?.core?.invoke;
+    if (typeof invoke !== 'function') {
+      done(null);
+      return;
+    }
+    invoke('get_startup_native_trace')
+      .then(done)
+      .catch(() => done(null));
+  });
+
+  if (!snapshot || typeof snapshot !== 'object') {
+    return undefined;
+  }
+  return snapshot as StartupTraceNativeSnapshot;
+}
+
 export async function readStartupTraceSnapshot(): Promise<StartupTraceSnapshot> {
   const snapshot = await browser.execute(() => {
     const diagnostics = window.__BITFUN_STARTUP_TRACE__;
@@ -93,7 +226,11 @@ export async function readStartupTraceSnapshot(): Promise<StartupTraceSnapshot> 
   if (!snapshot) {
     throw new Error('Startup trace diagnostics are not available');
   }
-  return snapshot as StartupTraceSnapshot;
+  const native = await readNativeStartupTraceSnapshot();
+  return {
+    ...(snapshot as StartupTraceSnapshot),
+    ...(native ? { native } : {}),
+  };
 }
 
 export async function readPerformanceNow(): Promise<number> {
@@ -132,10 +269,277 @@ export function summarizeStartup(snapshot: StartupTraceSnapshot): StartupPerfMil
   };
 }
 
+function round(value: number | undefined): number | undefined {
+  return value === undefined ? undefined : Math.round(value * 10) / 10;
+}
+
+function aggregateApiCalls(calls: StartupTraceApiCallRecord[]): StartupTraceCommandAggregate[] {
+  const byCommand = new Map<string, StartupTraceCommandAggregate>();
+  for (const call of calls) {
+    const existing = byCommand.get(call.command) ?? {
+      command: call.command,
+      count: 0,
+      successCount: 0,
+      failureCount: 0,
+      cacheHitCount: 0,
+      cacheMissCount: 0,
+      cacheUnknownCount: 0,
+      remoteCount: 0,
+      totalDurationMs: 0,
+      maxDurationMs: 0,
+      requestBytes: 0,
+      responseBytes: 0,
+    };
+    existing.count += 1;
+    existing.successCount += call.outcome === 'success' ? 1 : 0;
+    existing.failureCount += call.outcome === 'failure' ? 1 : 0;
+    existing.cacheHitCount += call.cacheOutcome === 'hit' ? 1 : 0;
+    existing.cacheMissCount += call.cacheOutcome === 'miss' ? 1 : 0;
+    existing.cacheUnknownCount += call.cacheOutcome === 'unknown' ? 1 : 0;
+    existing.remoteCount += call.remote ? 1 : 0;
+    existing.totalDurationMs = round((existing.totalDurationMs ?? 0) + call.durationMs) ?? 0;
+    existing.maxDurationMs = Math.max(existing.maxDurationMs, call.durationMs);
+    existing.requestBytes += call.requestBytes;
+    existing.responseBytes += call.responseBytes;
+    byCommand.set(call.command, existing);
+  }
+
+  return Array.from(byCommand.values())
+    .sort((left, right) => right.totalDurationMs - left.totalDurationMs);
+}
+
+function summarizeBackendCommandOverlap(
+  frontendCalls: StartupTraceApiCallRecord[],
+  nativeEvents: StartupTraceNativeEvent[],
+) {
+  const backendEvents = nativeEvents
+    .filter(event =>
+      event.category === 'tauri_command' &&
+      typeof event.command === 'string' &&
+      typeof event.durationMs === 'number'
+    )
+    .map(event => ({ ...event, consumed: false }));
+  const matched = frontendCalls.map(call => {
+    const backend = backendEvents.find(event =>
+      !event.consumed &&
+      event.command === call.command &&
+      (event.target === call.target || event.target === undefined || call.target === undefined)
+    );
+    if (backend) {
+      backend.consumed = true;
+    }
+    const backendDurationMs = numberField(backend?.durationMs);
+    return {
+      command: call.command,
+      target: call.target,
+      frontendDurationMs: round(call.durationMs) ?? 0,
+      backendDurationMs: round(backendDurationMs),
+      estimatedQueueOrBridgeMs: round(
+        backendDurationMs === undefined ? undefined : call.durationMs - backendDurationMs
+      ),
+    };
+  });
+
+  const byCommand = new Map<string, {
+    command: string;
+    count: number;
+    frontendDurationMs: number;
+    backendDurationMs: number;
+    estimatedQueueOrBridgeMs: number;
+  }>();
+  for (const call of matched) {
+    const existing = byCommand.get(call.command) ?? {
+      command: call.command,
+      count: 0,
+      frontendDurationMs: 0,
+      backendDurationMs: 0,
+      estimatedQueueOrBridgeMs: 0,
+    };
+    existing.count += 1;
+    existing.frontendDurationMs = round((existing.frontendDurationMs ?? 0) + call.frontendDurationMs) ?? 0;
+    existing.backendDurationMs = round((existing.backendDurationMs ?? 0) + (call.backendDurationMs ?? 0)) ?? 0;
+    existing.estimatedQueueOrBridgeMs = round(
+      (existing.estimatedQueueOrBridgeMs ?? 0) + (call.estimatedQueueOrBridgeMs ?? 0)
+    ) ?? 0;
+    byCommand.set(call.command, existing);
+  }
+
+  return {
+    matchedCount: matched.filter(call => call.backendDurationMs !== undefined).length,
+    totalFrontendDurationMs: round(
+      matched.reduce((total, call) => total + call.frontendDurationMs, 0)
+    ) ?? 0,
+    totalBackendDurationMs: round(
+      matched.reduce((total, call) => total + (call.backendDurationMs ?? 0), 0)
+    ) ?? 0,
+    totalEstimatedQueueOrBridgeMs: round(
+      matched.reduce((total, call) => total + (call.estimatedQueueOrBridgeMs ?? 0), 0)
+    ) ?? 0,
+    byCommand: Array.from(byCommand.values())
+      .sort((left, right) => right.frontendDurationMs - left.frontendDurationMs),
+    slowCalls: [...matched]
+      .sort((left, right) => right.frontendDurationMs - left.frontendDurationMs)
+      .slice(0, 10),
+  };
+}
+
+export function summarizeStartupBreakdown(snapshot: StartupTraceSnapshot): StartupPerfBreakdown {
+  const first = (name: string) => snapshot.phases.events.find(event => event.phase === name);
+  const last = (name: string) => snapshot.phases.events.filter(event => event.phase === name).at(-1);
+  const nativeStep = (step: string) =>
+    snapshot.native?.events.find(event => event.phase === 'native_step_end' && event.step === step);
+  const nativeCommandStep = (step: string) =>
+    snapshot.native?.events.find(event => event.category === 'tauri_command' && event.step === step);
+  const frontendStepDuration = (phase: string, step: string) =>
+    snapshot.phases.events.find(event => event.phase === phase && event.step === step)?.durationMs;
+  const workspaceStepDuration = (step: string) =>
+    snapshot.phases.events.find(event =>
+      event.phase === 'workspace_startup_step_end' &&
+      event.step === step
+    )?.durationMs;
+  const numeric = (value: unknown): number | undefined =>
+    typeof value === 'number' ? value : undefined;
+
+  const firstScript = first('first_script_eval')?.atMs;
+  const renderScheduled = first('react_render_scheduled')?.atMs;
+  const appEffectMounted = first('app_effect_mounted')?.atMs;
+  const mainWindowShown = first('main_window_shown')?.atMs;
+  const interactive = first('interactive_shell_ready')?.atMs;
+  const nonCriticalDone = first('non_critical_init_done')?.atMs;
+  const apiCalls = snapshot.api.calls ?? [];
+  const initializeGlobalStateApiCall = apiCalls.find(call => call.command === 'initialize_global_state');
+  const initializeGlobalStateBackendDuration = nativeCommandStep('initialize_global_state.total')?.durationMs;
+  const initializeGlobalStateStepPrefix = 'initialize_global_state.';
+  const initializeGlobalStateBackendSteps = Object.fromEntries(
+    (snapshot.native?.events ?? [])
+      .filter(event =>
+        event.category === 'tauri_command' &&
+        typeof event.step === 'string' &&
+        event.step.startsWith(initializeGlobalStateStepPrefix) &&
+        event.step !== 'initialize_global_state.total' &&
+        typeof event.durationMs === 'number'
+      )
+      .map(event => [
+        event.step!.slice(initializeGlobalStateStepPrefix.length),
+        event.durationMs as number,
+      ])
+  );
+  const apiBeforeInteractive = apiCalls.filter(call =>
+    typeof call.startedAtMs === 'number' &&
+    (interactive === undefined || call.startedAtMs <= interactive)
+  );
+  const apiBeforeInteractiveByCommand = aggregateApiCalls(apiBeforeInteractive);
+  const backendBeforeInteractive = summarizeBackendCommandOverlap(
+    apiBeforeInteractive,
+    snapshot.native?.events ?? [],
+  );
+  const slowApiCalls = [...apiBeforeInteractive]
+    .sort((left, right) => right.durationMs - left.durationMs)
+    .slice(0, 10)
+    .map(call => ({
+      command: call.command,
+      target: call.target,
+      startedAtMs: round(call.startedAtMs),
+      durationMs: round(call.durationMs) ?? 0,
+      outcome: call.outcome,
+      remote: call.remote,
+    }));
+
+  return {
+    native: {
+      preTauriLastStepEndMs: snapshot.native?.events
+        .filter(event => event.category === 'native_pre_tauri')
+        .at(-1)?.atMs,
+      tauriSetupDurationMs: nativeStep('tauri_setup')?.durationMs,
+      tauriSetupUntilMainWindowCreatedDurationMs:
+        nativeStep('tauri_setup_until_main_window_created')?.durationMs,
+      createMainWindowDurationMs: nativeStep('create_main_window')?.durationMs,
+      prepareThemeDurationMs: nativeStep('prepare_theme')?.durationMs,
+      webviewBuildDurationMs: nativeStep('webview_build')?.durationMs,
+      windowsMaximizeDurationMs: nativeStep('windows_maximize')?.durationMs,
+      windowsShowAfterMaximizeWaitMs: nativeStep('windows_show_after_maximize_wait')?.durationMs,
+      showWindowDurationMs: nativeStep('show_window')?.durationMs,
+      focusWindowDurationMs: nativeStep('focus_window')?.durationMs,
+    },
+    frontend: {
+      firstScriptToRenderScheduledMs: round(
+        firstScript !== undefined && renderScheduled !== undefined
+          ? renderScheduled - firstScript
+          : undefined
+      ),
+      renderScheduledToAppEffectMs: round(
+        renderScheduled !== undefined && appEffectMounted !== undefined
+          ? appEffectMounted - renderScheduled
+          : undefined
+      ),
+      mainWindowShownToInteractiveMs: round(
+        mainWindowShown !== undefined && interactive !== undefined
+          ? interactive - mainWindowShown
+          : undefined
+      ),
+      interactiveToNonCriticalDoneMs: round(
+        interactive !== undefined && nonCriticalDone !== undefined
+          ? nonCriticalDone - interactive
+          : undefined
+      ),
+      loadI18nProviderDurationMs: numeric(frontendStepDuration('startup_step_end', 'load_i18n_provider')),
+      beforeRenderSteps: {
+        initLogger: numeric(frontendStepDuration('before_render_step_end', 'init_logger')) ?? 0,
+        initializeFrontendLogLevelSync:
+          numeric(frontendStepDuration('before_render_step_end', 'initialize_frontend_log_level_sync')) ?? 0,
+        themeServiceInitialize:
+          numeric(frontendStepDuration('before_render_step_end', 'theme_service_initialize')) ?? 0,
+      },
+    },
+    workspace: {
+      initializeDurationMs: numeric(last('workspace_initialize_end')?.durationMs),
+      providerInitializeDurationMs: numeric(last('workspace_provider_initialize_end')?.durationMs),
+      providerManagerInitializeDurationMs:
+        numeric(last('workspace_provider_manager_initialize_end')?.durationMs),
+      steps: {
+        ensureIdentityListener: numeric(workspaceStepDuration('ensure_identity_listener')) ?? 0,
+        initializeGlobalState: numeric(workspaceStepDuration('initialize_global_state')) ?? 0,
+        cleanupInvalidWorkspaces: numeric(workspaceStepDuration('cleanup_invalid_workspaces')) ?? 0,
+        fetchWorkspaceState: numeric(workspaceStepDuration('fetch_workspace_state')) ?? 0,
+        updateWorkspaceState: numeric(workspaceStepDuration('update_workspace_state')) ?? 0,
+      },
+    },
+    tauriCommand: {
+      initializeGlobalState: {
+        frontendDurationMs: round(initializeGlobalStateApiCall?.durationMs),
+        backendDurationMs: round(initializeGlobalStateBackendDuration),
+        estimatedQueueOrBridgeMs: round(
+          initializeGlobalStateApiCall?.durationMs !== undefined &&
+            initializeGlobalStateBackendDuration !== undefined
+            ? initializeGlobalStateApiCall.durationMs - initializeGlobalStateBackendDuration
+            : undefined
+        ),
+        steps: initializeGlobalStateBackendSteps,
+      },
+      beforeInteractive: backendBeforeInteractive,
+    },
+    apiBeforeInteractive: {
+      count: apiBeforeInteractive.length,
+      totalDurationMs: round(apiBeforeInteractive.reduce((total, call) => total + call.durationMs, 0)) ?? 0,
+      maxDurationMs: apiBeforeInteractive.length > 0
+        ? round(Math.max(...apiBeforeInteractive.map(call => call.durationMs)))
+        : undefined,
+      byCommand: apiBeforeInteractiveByCommand,
+      slowCalls: slowApiCalls,
+    },
+  };
+}
+
 export function summarizeSessionOpen(
   events: StartupTracePhase[],
+  clickedAtMs?: number,
 ): SessionOpenPerfMilestones {
   const last = (name: string) => events.filter(event => event.phase === name).at(-1);
+  const sinceClick = (event: StartupTracePhase | undefined): number | undefined =>
+    clickedAtMs !== undefined && typeof event?.atMs === 'number'
+      ? round(event.atMs - clickedAtMs)
+      : undefined;
+  const hydrateStart = last('historical_session_hydrate_start');
   const restoreEnd = last('historical_session_restore_end');
   const convertEnd = last('historical_session_convert_end');
   const stateCommitEnd = last('historical_session_state_commit_end');
@@ -145,7 +549,12 @@ export function summarizeSessionOpen(
   const fullHydrateFrame = last('historical_session_full_hydrate_after_state_commit_frame');
 
   return {
-    hydrateStartMs: numberField(last('historical_session_hydrate_start')?.atMs),
+    clickToHydrateStartMs: sinceClick(hydrateStart),
+    clickToLatestFrameMs: sinceClick(latestFrame),
+    clickToHydrateEndMs: sinceClick(hydrateEnd),
+    clickToFullHydrateEndMs: sinceClick(fullHydrateEnd),
+    clickToFullHydrateFrameMs: sinceClick(fullHydrateFrame),
+    hydrateStartMs: numberField(hydrateStart?.atMs),
     restoreDurationMs: numberField(restoreEnd?.durationMs),
     convertDurationMs: numberField(convertEnd?.durationMs),
     stateCommitDurationMs: numberField(stateCommitEnd?.durationMs),

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -6,6 +6,7 @@ import {
   readStartupTraceSnapshot,
   summarizeSessionOpen,
   summarizeStartup,
+  summarizeStartupBreakdown,
   waitForTracePhaseCount,
   type StartupTraceSnapshot,
 } from '../../helpers/performance-trace';
@@ -139,19 +140,24 @@ describe('Performance telemetry', () => {
   it('collects startup timing from the current build', async () => {
     const snapshot = await readStartupTraceSnapshot();
     const startup = summarizeStartup(snapshot);
+    const breakdown = summarizeStartupBreakdown(snapshot);
     const maxInteractiveMs = numericEnv('BITFUN_E2E_PERF_MAX_INTERACTIVE_MS');
 
     console.log('[Perf] startup', JSON.stringify({
       appMode: process.env.BITFUN_E2E_APP_MODE ?? 'auto',
       traceId: snapshot.traceId,
       startup,
+      breakdown,
       api: snapshot.api,
+      native: snapshot.native,
     }));
     await writeReport('startup', {
       appMode: process.env.BITFUN_E2E_APP_MODE ?? 'auto',
       traceId: snapshot.traceId,
       startup,
+      breakdown,
       api: snapshot.api,
+      native: snapshot.native,
       phases: snapshot.phases.events,
     });
 
@@ -182,6 +188,10 @@ describe('Performance telemetry', () => {
       beforeClickSnapshot,
       'historical_session_full_hydrate_end',
     );
+    const fullHydrateFrameCountBefore = countPhase(
+      beforeClickSnapshot,
+      'historical_session_full_hydrate_after_state_commit_frame',
+    );
     const clickedAtMs = await readPerformanceNow();
 
     await item.click();
@@ -196,15 +206,23 @@ describe('Performance telemetry', () => {
       fullHydrateCountBefore + 1,
       10000,
     );
-    const finalSnapshot =
-      afterFullSnapshot.phases.events.length >= afterFrameSnapshot.phases.events.length
-        ? afterFullSnapshot
-        : afterFrameSnapshot;
+    const afterFullFrameSnapshot = await waitForOptionalPhaseCount(
+      'historical_session_full_hydrate_after_state_commit_frame',
+      fullHydrateFrameCountBefore + 1,
+      10000,
+    );
+    const finalSnapshot = [
+      afterFrameSnapshot,
+      afterFullSnapshot,
+      afterFullFrameSnapshot,
+    ].reduce((latest, snapshot) =>
+      snapshot.phases.events.length >= latest.phases.events.length ? snapshot : latest
+    );
     const sessionEvents = finalSnapshot.phases.events.filter(event =>
-      event.atMs >= clickedAtMs - 50 &&
+      event.atMs >= clickedAtMs &&
       event.phase.startsWith('historical_session')
     );
-    const sessionOpen = summarizeSessionOpen(sessionEvents);
+    const sessionOpen = summarizeSessionOpen(sessionEvents, clickedAtMs);
     const maxLatestFrameMs = numericEnv('BITFUN_E2E_PERF_MAX_SESSION_FRAME_MS');
 
     console.log('[Perf] long-session-first-open', JSON.stringify({
@@ -223,6 +241,7 @@ describe('Performance telemetry', () => {
 
     expect(sessionOpen.hydrateDurationMs).toBeGreaterThan(0);
     expect(sessionOpen.latestFrameSinceHydrateMs).toBeGreaterThan(0);
+    expect(sessionOpen.clickToLatestFrameMs).toBeGreaterThan(0);
     if (maxLatestFrameMs !== undefined) {
       expect(sessionOpen.latestFrameSinceHydrateMs).toBeLessThanOrEqual(maxLatestFrameMs);
     }


### PR DESCRIPTION
﻿## Summary

- Add startup trace coverage for native window/WebView slices, frontend readiness, Tauri command queue/body timing, workspace initialization, and long-session first-open timing.
- Reduce startup work before `interactive_shell_ready` by lazy-loading the app layout shell, deferring non-critical config/announcement/update work until after shell readiness, lazy-initializing AI experience/model config services, and overlapping workspace initialization steps where ordering allows.
- Extend the release-fast performance E2E report so future PRs can distinguish backend command body time from frontend bridge/queue wait and user-visible session timing.

Refs #949

## Root Cause Confirmed By This PR

The main startup bottleneck is not backend command body time. In the new PR-only trace fields, pre-interactive Tauri command body time is about `3.0 ms` p50, while frontend bridge/queue wait is about `521.1 ms` p50. This means local backend micro-optimizations alone are unlikely to move end-to-end startup; the effective path is reducing the amount of startup-visible frontend module work and the number/timing of early bridge calls.

## Performance Data

Method: Windows desktop `release-fast`, 5 cold launches each, same performance E2E scenario. Baseline is `gcwing/main@2a016364`; PR head is `85225a72` after rebase onto that baseline.

### Cold Startup P50

| Metric | Main p50 | PR p50 | Delta |
| --- | ---: | ---: | ---: |
| `first_script_eval` | 632.4 ms | 545.6 ms | -86.8 ms (-13.7%) |
| `main_window_shown` | 740.0 ms | 593.4 ms | -146.6 ms (-19.8%) |
| `interactive_shell_ready` | 1138.7 ms | 778.4 ms | -360.3 ms (-31.6%) |
| `non_critical_init_done` | 1421.2 ms | 1296.3 ms | -124.9 ms (-8.8%) |

### Long Historical Session First Open P50

| Metric | Main p50 | PR p50 | Delta |
| --- | ---: | ---: | ---: |
| `restoreDuration` | 53.8 ms | 47.6 ms | -6.2 ms (-11.5%) |
| `hydrateDuration` | 123.6 ms | 109.8 ms | -13.8 ms (-11.2%) |
| `latestFrameSinceHydrate` | 43.2 ms | 42.5 ms | -0.7 ms (-1.6%) |
| `fullHydrateDuration` | 33.8 ms | 36.0 ms | +2.2 ms (+6.5%) |
| initially loaded turns | 3 / 80 | 3 / 80 | no change |

The small `fullHydrateDuration` regression is listed explicitly. It is below a material UX threshold in this run, but should remain tracked because this PR also adds click-to-frame fields that were unavailable on baseline main.

### New PR-Only Breakdown Fields

| Metric | PR p50 |
| --- | ---: |
| `webviewBuildDuration` | 500.0 ms |
| `mainWindowShownToInteractive` | 183.7 ms |
| `workspaceInit` | 73.6 ms |
| pre-interactive command count | 12 |
| pre-interactive command frontend total | 524.1 ms |
| pre-interactive command backend body total | 3.0 ms |
| pre-interactive estimated bridge/queue total | 521.1 ms |
| pre-interactive `get_config` count | 3 |
| pre-interactive `get_config` frontend total | 295.8 ms |
| long-session `clickToLatestFrame` | 166.1 ms |
| long-session `clickToFullHydrateFrame` | 360.8 ms |

## Risk And Functional Impact

- App layout is now a lazy chunk. The splash is only dismissed after workspace initialization and layout readiness, which avoids blank/flicker handoff risk, but a layout chunk load failure would keep the user on the startup overlay instead of showing a partially mounted shell.
- AI experience/model config service initialization is lazy. Existing UI state is preserved by syncing after shell readiness or on first concrete use, but settings/UI paths that require the values may pay first-use cost instead of startup cost.
- `app.keybindings` and remote workspace info are intentionally not deferred in this PR because they affect global shortcuts and remote-state correctness. Those need separate product decisions if optimized later.
- Post-interactive work remains significant. The new trace shows startup can be improved, but it also makes clear that session metadata, git/workspace status, and remaining static/dynamic import conflicts still need follow-up PRs.

## Validation

- `pnpm run fmt:rs`
- `git diff --check`
- `pnpm run check:repo-hygiene`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/infrastructure/config/services/modelConfigs.test.ts src/infrastructure/config/services/AIExperienceConfigService.test.ts src/infrastructure/services/business/workspaceManager.test.ts src/app/startup/startupPerformanceContract.test.ts src/shared/utils/startupTrace.test.ts src/infrastructure/api/service-api/ApiClient.test.ts`
- `cargo check -p bitfun-desktop`
- `pnpm run desktop:build:release-fast`
- 5x `pnpm run e2e:test:perf:release-fast` on `gcwing/main@2a016364`
- 5x `pnpm run e2e:test:perf:release-fast` on PR head `85225a72`

Known warnings preserved from the current tree/build: one existing Rust unused warning in clipboard file API, plus Vite static/dynamic import warnings. The Vite warnings are not new blockers for this PR, but they are part of the next optimization scope.
