### PR TITLE
fix(web-ui): restore hidden subagent sessions for task projections

### DIFF
--- a/src/web-ui/src/flow_chat/components/TaskDetailPanel/TaskDetailPanel.tsx
+++ b/src/web-ui/src/flow_chat/components/TaskDetailPanel/TaskDetailPanel.tsx
@@ -565,7 +565,6 @@ export const TaskDetailPanel: React.FC<TaskDetailPanelProps> = ({ data }) => {
                 parentTaskToolId={toolItem.id}
                 subagentSessionId={subagentSessionId}
                 items={visibleSubagentItems}
-                isRunning={isRunning}
                 sessionId={subagentSessionId}
                 compactText={false}
               />

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
@@ -81,6 +81,8 @@ const TaskWithSubagentWrapper: React.FC<TaskWithSubagentWrapperProps> = React.me
   turnId,
 }) => {
   const isCollapsed = useTaskCollapsed(parentTaskToolId);
+  const isTaskRunning =
+    taskItem.status === 'preparing' || taskItem.status === 'streaming' || taskItem.status === 'running';
   const hasPrompt = Boolean(
     taskItem.type === 'tool' &&
     (taskItem as FlowToolItem).toolCall?.input?.prompt
@@ -103,8 +105,7 @@ const TaskWithSubagentWrapper: React.FC<TaskWithSubagentWrapperProps> = React.me
         parentSessionId={parentSessionId}
         directSubagentSessionId={directSubagentSessionId}
         parentToolIds={new Set<string>([parentTaskToolId, (taskItem as FlowToolItem).toolCall?.id].filter(Boolean) as string[])}
-        isRunning
-        ={taskItem.status === 'preparing' || taskItem.status === 'streaming' || taskItem.status === 'running'}
+        liveItemsMode={isTaskRunning ? 'full-turn' : 'last-round'}
         turnId={turnId}
       />
     </div>

--- a/src/web-ui/src/flow_chat/components/subagent/SubagentProjectionView.test.tsx
+++ b/src/web-ui/src/flow_chat/components/subagent/SubagentProjectionView.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SubagentProjectionView } from './SubagentProjectionView';
+import type { FlowChatState, Session } from '../../types/flow-chat';
+
+let flowChatState: FlowChatState;
+const ensureBtwSessionAvailableMock = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn(),
+  },
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string; shown?: number; total?: number }) =>
+      options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('../FlowTextBlock', () => ({
+  FlowTextBlock: () => <div data-testid="flow-text-block" />,
+}));
+
+vi.mock('../../tool-cards/ModelThinkingDisplay', () => ({
+  ModelThinkingDisplay: () => <div data-testid="thinking-display" />,
+}));
+
+vi.mock('../FlowToolCard', () => ({
+  FlowToolCard: () => <div data-testid="flow-tool-card" />,
+}));
+
+vi.mock('../modern/SmoothHeightCollapse', () => ({
+  SmoothHeightCollapse: ({
+    children,
+    isOpen,
+  }: {
+    children: React.ReactNode;
+    isOpen: boolean;
+  }) => (isOpen ? <>{children}</> : null),
+}));
+
+vi.mock('../../store/FlowChatStore', () => ({
+  FlowChatStore: {
+    getInstance: () => ({
+      getState: () => flowChatState,
+      subscribe: () => () => {},
+    }),
+  },
+}));
+
+vi.mock('../../services/openBtwSession', () => ({
+  ensureBtwSessionAvailable: (...args: unknown[]) => ensureBtwSessionAvailableMock(...args),
+}));
+
+function createSession(overrides: Partial<Session>): Session {
+  return {
+    sessionId: 'subagent-1',
+    title: 'Subagent',
+    dialogTurns: [],
+    status: 'idle',
+    config: {},
+    createdAt: 1,
+    lastActiveAt: 1,
+    error: null,
+    sessionKind: 'subagent',
+    ...overrides,
+  } as Session;
+}
+
+describe('SubagentProjectionView', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    ensureBtwSessionAvailableMock.mockReset();
+
+    flowChatState = {
+      sessions: new Map([
+        ['parent-1', createSession({
+          sessionId: 'parent-1',
+          sessionKind: 'normal',
+          workspacePath: 'D:/workspace/project',
+          remoteConnectionId: 'remote-1',
+          remoteSshHost: 'host-1',
+        })],
+      ]),
+      activeSessionId: 'parent-1',
+    };
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('hydrates a metadata-only historical subagent session for collapsed transcript projection', async () => {
+    flowChatState.sessions.set('subagent-1', createSession({
+      isHistorical: true,
+      historyState: 'metadata-only',
+      workspacePath: 'D:/workspace/project',
+      remoteConnectionId: 'remote-1',
+      remoteSshHost: 'host-1',
+    }));
+
+    await act(async () => {
+      root.render(
+        <SubagentProjectionView
+          parentTaskToolId="task-1"
+          parentSessionId="parent-1"
+          subagentSessionId="subagent-1"
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(ensureBtwSessionAvailableMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childSessionId: 'subagent-1',
+        parentSessionId: 'parent-1',
+        workspacePath: 'D:/workspace/project',
+        sessionKind: 'subagent',
+        remoteConnectionId: 'remote-1',
+        remoteSshHost: 'host-1',
+        includeInternal: true,
+      }),
+    );
+  });
+
+  it('does not hydrate when the caller already supplies projected items', async () => {
+    flowChatState.sessions.set('subagent-1', createSession({
+      isHistorical: true,
+      historyState: 'metadata-only',
+      workspacePath: 'D:/workspace/project',
+    }));
+
+    await act(async () => {
+      root.render(
+        <SubagentProjectionView
+          parentTaskToolId="task-1"
+          parentSessionId="parent-1"
+          subagentSessionId="subagent-1"
+          items={[]}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(ensureBtwSessionAvailableMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/flow_chat/components/subagent/SubagentProjectionView.tsx
+++ b/src/web-ui/src/flow_chat/components/subagent/SubagentProjectionView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { FlowChatState, FlowItem, FlowTextItem, FlowThinkingItem, FlowToolItem } from '../../types/flow-chat';
 import { FlowTextBlock } from '../FlowTextBlock';
@@ -8,6 +8,7 @@ import { taskCollapseStateManager } from '../../store/TaskCollapseStateManager';
 import { SmoothHeightCollapse } from '../modern/SmoothHeightCollapse';
 import { FlowChatStore } from '../../store/FlowChatStore';
 import { getSubagentProjectionState } from '../../utils/subagentProjection';
+import { ensureBtwSessionAvailable } from '../../services/openBtwSession';
 import './SubagentProjectionView.scss';
 
 interface SubagentProjectionViewProps {
@@ -17,11 +18,11 @@ interface SubagentProjectionViewProps {
   directSubagentSessionId?: string;
   subagentSessionId?: string;
   items?: FlowItem[];
-  isRunning?: boolean;
   turnId?: string;
   sessionId?: string;
   className?: string;
   compactText?: boolean;
+  liveItemsMode?: 'full-turn' | 'last-round';
 }
 
 const SUBAGENT_TEXT_TRUNCATE_LINES = 50;
@@ -127,24 +128,18 @@ export const SubagentProjectionView: React.FC<SubagentProjectionViewProps> = ({
   directSubagentSessionId,
   subagentSessionId,
   items: itemsProp,
-  isRunning: isRunningProp,
   turnId,
   sessionId,
   className = '',
   compactText = true,
+  liveItemsMode = 'last-round',
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
   const userScrolledUpRef = useRef(false);
   const lastScrollTopRef = useRef(0);
-  const previousRoundIdRef = useRef<string | null>(null);
-  const measuredHeightRef = useRef(0);
-  const retainedItemsRef = useRef<FlowItem[]>([]);
-  const floorOwnerRoundIdRef = useRef<string | null>(null);
   const [isCollapsed, setIsCollapsed] = useState(() =>
     taskCollapseStateManager.isCollapsed(parentTaskToolId)
   );
-  const [heightFloorPx, setHeightFloorPx] = useState(0);
   const [projectionState, setProjectionState] = useState(() => {
     if (!parentToolIds || parentToolIds.size === 0) {
       return null;
@@ -157,7 +152,7 @@ export const SubagentProjectionView: React.FC<SubagentProjectionViewProps> = ({
         parentToolIds,
         directSubagentSessionId,
       },
-      { itemsMode: 'last-round' },
+      { itemsMode: liveItemsMode },
     );
   });
 
@@ -189,7 +184,7 @@ export const SubagentProjectionView: React.FC<SubagentProjectionViewProps> = ({
           parentToolIds,
           directSubagentSessionId,
         },
-        { itemsMode: 'last-round' },
+        { itemsMode: liveItemsMode },
       );
     };
 
@@ -212,76 +207,54 @@ export const SubagentProjectionView: React.FC<SubagentProjectionViewProps> = ({
     });
 
     return unsubscribe;
-  }, [directSubagentSessionId, parentSessionId, parentToolIds]);
+  }, [directSubagentSessionId, liveItemsMode, parentSessionId, parentToolIds]);
 
   const liveItems = useMemo(
     () => itemsProp ?? projectionState?.items ?? [],
     [itemsProp, projectionState]
   );
-  const projectedRoundId = projectionState?.round?.id ?? null;
-  const isRunning = isRunningProp ?? projectionState?.isRunning ?? false;
   const resolvedSubagentSessionId = subagentSessionId
     ?? projectionState?.session?.sessionId
     ?? directSubagentSessionId;
-  const pendingRoundSwitchBridgePx = (() => {
-    const previousRoundId = previousRoundIdRef.current;
-    const measuredHeight = Math.ceil(measuredHeightRef.current);
+  const items = liveItems;
 
-    if (
-      !isRunning ||
-      liveItems.length > 0 ||
-      retainedItemsRef.current.length === 0 ||
-      !previousRoundId ||
-      !projectedRoundId ||
-      previousRoundId === projectedRoundId ||
-      measuredHeight <= 0
-    ) {
-      return 0;
+  useEffect(() => {
+    if (!resolvedSubagentSessionId || itemsProp !== undefined) {
+      return;
     }
 
-    return Math.max(heightFloorPx, measuredHeight);
-  })();
-  const effectiveHeightFloorPx = Math.max(heightFloorPx, pendingRoundSwitchBridgePx);
+    const flowChatStore = FlowChatStore.getInstance();
+    const state = flowChatStore.getState();
+    const session = state.sessions.get(resolvedSubagentSessionId);
+    const ownerSessionId = parentSessionId ?? sessionId;
 
-  useLayoutEffect(() => {
-    const currentRoundId = projectedRoundId;
-    const previousRoundId = previousRoundIdRef.current;
+    const shouldEnsureSession =
+      !session ||
+      (
+        session.isHistorical &&
+        (session.historyState === 'metadata-only' || session.historyState === 'failed')
+      );
 
-    if (
-      isRunning &&
-      previousRoundId &&
-      currentRoundId &&
-      previousRoundId !== currentRoundId &&
-      measuredHeightRef.current > 0
-    ) {
-      floorOwnerRoundIdRef.current = currentRoundId;
-      setHeightFloorPx(previous => Math.max(previous, Math.ceil(measuredHeightRef.current)));
+    if (!shouldEnsureSession) {
+      return;
     }
 
-    if (!isRunning) {
-      floorOwnerRoundIdRef.current = null;
-      setHeightFloorPx(0);
+    if (!ownerSessionId) {
+      return;
     }
 
-    previousRoundIdRef.current = currentRoundId;
-  }, [heightFloorPx, isRunning, liveItems.length, parentTaskToolId, projectedRoundId]);
+    ensureBtwSessionAvailable({
+      childSessionId: resolvedSubagentSessionId,
+      parentSessionId: ownerSessionId,
+      workspacePath: state.sessions.get(ownerSessionId)?.workspacePath,
+      sessionKind: 'subagent',
+      parentToolCallId: parentToolIds?.values().next().value,
+      remoteConnectionId: state.sessions.get(ownerSessionId)?.remoteConnectionId,
+      remoteSshHost: state.sessions.get(ownerSessionId)?.remoteSshHost,
+      includeInternal: true,
+    });
+  }, [items.length, itemsProp, parentSessionId, parentToolIds, resolvedSubagentSessionId, sessionId]);
 
-  const items = useMemo(() => {
-    if (liveItems.length > 0) {
-      retainedItemsRef.current = liveItems;
-      return liveItems;
-    }
-
-    if (isRunning && effectiveHeightFloorPx > 0 && retainedItemsRef.current.length > 0) {
-      return retainedItemsRef.current;
-    }
-
-    if (!isRunning) {
-      retainedItemsRef.current = [];
-    }
-
-    return liveItems;
-  }, [effectiveHeightFloorPx, isRunning, liveItems]);
   const lastActiveItemId = useMemo(() => {
     for (let index = items.length - 1; index >= 0; index -= 1) {
       const item = items[index];
@@ -298,45 +271,6 @@ export const SubagentProjectionView: React.FC<SubagentProjectionViewProps> = ({
 
     return items.length > 0 ? items[items.length - 1]?.id ?? null : null;
   }, [items]);
-
-  useEffect(() => {
-    const content = contentRef.current;
-    if (!content) {
-      return;
-    }
-
-    const updateMeasuredHeight = () => {
-      const nextHeight = Math.ceil(content.getBoundingClientRect().height);
-      measuredHeightRef.current = nextHeight;
-      const currentFloorOwnerRoundId = floorOwnerRoundIdRef.current;
-      const isShowingLiveItems = liveItems.length > 0;
-      const canReleaseHeightFloor =
-        heightFloorPx > 0 &&
-        isShowingLiveItems &&
-        currentFloorOwnerRoundId != null &&
-        projectedRoundId === currentFloorOwnerRoundId &&
-        nextHeight >= heightFloorPx - 12;
-
-      if (canReleaseHeightFloor) {
-        floorOwnerRoundIdRef.current = null;
-        setHeightFloorPx(0);
-      }
-    };
-
-    updateMeasuredHeight();
-
-    if (typeof ResizeObserver === 'undefined') {
-      const rafId = requestAnimationFrame(updateMeasuredHeight);
-      return () => cancelAnimationFrame(rafId);
-    }
-
-    const observer = new ResizeObserver(() => {
-      updateMeasuredHeight();
-    });
-    observer.observe(content);
-
-    return () => observer.disconnect();
-  }, [heightFloorPx, isRunning, items, liveItems.length, parentTaskToolId, projectedRoundId]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -390,7 +324,7 @@ export const SubagentProjectionView: React.FC<SubagentProjectionViewProps> = ({
 
   const shouldRenderProjection =
     Boolean(resolvedSubagentSessionId) &&
-    (items.length > 0 || (isRunning && effectiveHeightFloorPx > 0));
+    items.length > 0;
 
   if (!shouldRenderProjection) {
     return null;
@@ -406,9 +340,8 @@ export const SubagentProjectionView: React.FC<SubagentProjectionViewProps> = ({
           ref={containerRef}
           className={`subagent-projection-container ${isCollapsed ? 'subagent-projection-container--collapsed' : 'subagent-projection-container--expanded'}`}
           data-parent-tool-id={parentTaskToolId}
-          style={effectiveHeightFloorPx > 0 ? { minHeight: `${effectiveHeightFloorPx}px` } : undefined}
         >
-          <div ref={contentRef} className="subagent-projection-content">
+          <div className="subagent-projection-content">
             {items.map(item => renderProjectedItem(
               item,
               sessionId ?? resolvedSubagentSessionId,

--- a/src/web-ui/src/flow_chat/services/openBtwSession.test.ts
+++ b/src/web-ui/src/flow_chat/services/openBtwSession.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { openBtwSessionInAuxPane } from './openBtwSession';
+import { ensureBtwSessionAvailable, openBtwSessionInAuxPane } from './openBtwSession';
 
 const mocks = vi.hoisted(() => ({
   createTab: vi.fn(),
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 let animationFrameCallbacks: FrameRequestCallback[] = [];
+let sessions = new Map();
 
 const stubWindowForPanelExpansion = (rightPanelCollapsed: boolean) => {
   const dispatchEvent = vi.fn();
@@ -76,7 +77,7 @@ vi.mock('@/app/components/panels/content-canvas/stores', () => ({
 vi.mock('../store/FlowChatStore', () => ({
   flowChatStore: {
     getState: () => ({
-      sessions: new Map(),
+      sessions,
     }),
     addExternalSession: (...args: unknown[]) =>
       mocks.addExternalSession(...args),
@@ -112,6 +113,7 @@ describe('openBtwSessionInAuxPane', () => {
     mocks.addExternalSession.mockClear();
     mocks.loadSessionHistory.mockClear();
     mocks.updateSessionRelationship.mockClear();
+    sessions = new Map();
     vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
       animationFrameCallbacks.push(callback);
       return animationFrameCallbacks.length;
@@ -191,6 +193,91 @@ describe('openBtwSessionInAuxPane', () => {
     expect(mocks.createTab).not.toHaveBeenCalled();
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'expand-right-panel' }),
+    );
+  });
+
+  it('creates an on-demand subagent shell and hydrates it when the child session is missing', () => {
+    sessions.set('parent-session', {
+      sessionId: 'parent-session',
+      workspacePath: 'D:\\workspace\\repo',
+      mode: 'agentic',
+      remoteConnectionId: 'remote-1',
+      remoteSshHost: 'host-1',
+    });
+
+    ensureBtwSessionAvailable({
+      childSessionId: 'subagent-child',
+      parentSessionId: 'parent-session',
+      sessionKind: 'subagent',
+      parentToolCallId: 'call-1',
+      includeInternal: true,
+    });
+
+    expect(mocks.addExternalSession).toHaveBeenCalledWith(
+      'subagent-child',
+      expect.any(String),
+      'agentic',
+      'D:\\workspace\\repo',
+      expect.objectContaining({
+        parentSessionId: 'parent-session',
+        sessionKind: 'subagent',
+        parentToolCallId: 'call-1',
+      }),
+      'remote-1',
+      'host-1',
+    );
+    expect(mocks.loadSessionHistory).toHaveBeenCalledWith(
+      'subagent-child',
+      'D:\\workspace\\repo',
+      undefined,
+      'remote-1',
+      'host-1',
+      { includeInternal: true },
+    );
+  });
+
+  it('hydrates an existing metadata-only hidden child session without creating a duplicate shell', () => {
+    sessions.set('parent-session', {
+      sessionId: 'parent-session',
+      workspacePath: 'D:\\workspace\\repo',
+      mode: 'agentic',
+      remoteConnectionId: 'remote-1',
+      remoteSshHost: 'host-1',
+    });
+    sessions.set('subagent-child', {
+      sessionId: 'subagent-child',
+      sessionKind: 'subagent',
+      isHistorical: true,
+      historyState: 'metadata-only',
+      workspacePath: 'D:\\workspace\\repo',
+      remoteConnectionId: 'remote-1',
+      remoteSshHost: 'host-1',
+    });
+
+    ensureBtwSessionAvailable({
+      childSessionId: 'subagent-child',
+      parentSessionId: 'parent-session',
+      sessionKind: 'subagent',
+      parentToolCallId: 'call-1',
+      includeInternal: true,
+    });
+
+    expect(mocks.addExternalSession).not.toHaveBeenCalled();
+    expect(mocks.updateSessionRelationship).toHaveBeenCalledWith(
+      'subagent-child',
+      expect.objectContaining({
+        parentSessionId: 'parent-session',
+        sessionKind: 'subagent',
+        parentToolCallId: 'call-1',
+      }),
+    );
+    expect(mocks.loadSessionHistory).toHaveBeenCalledWith(
+      'subagent-child',
+      'D:\\workspace\\repo',
+      undefined,
+      'remote-1',
+      'host-1',
+      { includeInternal: true },
     );
   });
 });

--- a/src/web-ui/src/flow_chat/services/openBtwSession.ts
+++ b/src/web-ui/src/flow_chat/services/openBtwSession.ts
@@ -25,6 +25,20 @@ export interface BtwSessionPanelMetadata {
   contentRole: 'btw-session';
 }
 
+export interface EnsureBtwSessionAvailableParams {
+  childSessionId: string;
+  parentSessionId: string;
+  workspacePath?: string;
+  sessionKind?: 'btw' | 'review' | 'deep_review' | 'miniapp' | 'subagent';
+  sessionTitle?: string;
+  agentType?: string;
+  parentToolCallId?: string;
+  subagentType?: string;
+  remoteConnectionId?: string;
+  remoteSshHost?: string;
+  includeInternal?: boolean;
+}
+
 type AgentCanvasState = ReturnType<typeof useAgentCanvasStore.getState>;
 
 export const getBtwSessionDuplicateKey = (childSessionId: string) => `btw-session-${childSessionId}`;
@@ -122,6 +136,67 @@ export const selectActiveBtwSessionTab = (state: AgentCanvasState): CanvasTab | 
   return activeTab;
 };
 
+export function ensureBtwSessionAvailable(params: EnsureBtwSessionAvailableParams): void {
+  const existingSession = flowChatStore.getState().sessions.get(params.childSessionId);
+  const parentSession = flowChatStore.getState().sessions.get(params.parentSessionId);
+  const resolvedWorkspacePath = params.workspacePath || parentSession?.workspacePath;
+  const resolvedRemoteConnectionId =
+    params.remoteConnectionId || existingSession?.remoteConnectionId || parentSession?.remoteConnectionId;
+  const resolvedRemoteSshHost =
+    params.remoteSshHost || existingSession?.remoteSshHost || parentSession?.remoteSshHost;
+
+  if (
+    existingSession &&
+    (params.sessionKind === 'subagent' || existingSession.sessionKind === 'subagent')
+  ) {
+    flowChatStore.updateSessionRelationship(params.childSessionId, {
+      parentSessionId: params.parentSessionId,
+      sessionKind: params.sessionKind || existingSession.sessionKind,
+      parentToolCallId: params.parentToolCallId,
+      subagentType: params.subagentType,
+    });
+  }
+
+  if (!existingSession) {
+    flowChatStore.addExternalSession(
+      params.childSessionId,
+      params.sessionTitle || resolveBtwSessionTitle(params.childSessionId),
+      params.agentType || parentSession?.mode || 'agentic',
+      resolvedWorkspacePath,
+      {
+        parentSessionId: params.parentSessionId,
+        sessionKind: params.sessionKind || 'btw',
+        parentToolCallId: params.parentToolCallId,
+        subagentType: params.subagentType,
+      },
+      resolvedRemoteConnectionId,
+      resolvedRemoteSshHost,
+    );
+  }
+
+  const sessionToHydrate = flowChatStore.getState().sessions.get(params.childSessionId);
+  const shouldHydrate =
+    !existingSession ||
+    Boolean(
+      sessionToHydrate?.isHistorical &&
+      (sessionToHydrate.historyState === 'metadata-only' || sessionToHydrate.historyState === 'failed')
+    );
+
+  const workspacePath = resolvedWorkspacePath || sessionToHydrate?.workspacePath;
+  if (!shouldHydrate || !workspacePath) {
+    return;
+  }
+
+  void flowChatStore.loadSessionHistory(
+    params.childSessionId,
+    workspacePath,
+    undefined,
+    resolvedRemoteConnectionId,
+    resolvedRemoteSshHost,
+    { includeInternal: params.includeInternal },
+  );
+}
+
 export async function openMainSession(
   sessionId: string,
   options?: {
@@ -162,49 +237,7 @@ export function openBtwSessionInAuxPane(params: {
   remoteSshHost?: string;
   includeInternal?: boolean;
 }): void {
-  const existingSession = flowChatStore.getState().sessions.get(params.childSessionId);
-  const parentSession = flowChatStore.getState().sessions.get(params.parentSessionId);
-  const resolvedWorkspacePath = params.workspacePath || parentSession?.workspacePath;
-
-  if (
-    existingSession &&
-    (params.sessionKind === 'subagent' || existingSession.sessionKind === 'subagent')
-  ) {
-    flowChatStore.updateSessionRelationship(params.childSessionId, {
-      parentSessionId: params.parentSessionId,
-      sessionKind: params.sessionKind || existingSession.sessionKind,
-      parentToolCallId: params.parentToolCallId,
-      subagentType: params.subagentType,
-    });
-  }
-
-  if (!existingSession) {
-    const workspacePath = resolvedWorkspacePath;
-    flowChatStore.addExternalSession(
-      params.childSessionId,
-      params.sessionTitle || resolveBtwSessionTitle(params.childSessionId),
-      params.agentType || parentSession?.mode || 'agentic',
-      workspacePath,
-      {
-        parentSessionId: params.parentSessionId,
-        sessionKind: params.sessionKind || 'btw',
-        parentToolCallId: params.parentToolCallId,
-        subagentType: params.subagentType,
-      },
-      params.remoteConnectionId || parentSession?.remoteConnectionId,
-      params.remoteSshHost || parentSession?.remoteSshHost,
-    );
-    if (workspacePath) {
-      void flowChatStore.loadSessionHistory(
-        params.childSessionId,
-        workspacePath,
-        undefined,
-        params.remoteConnectionId || parentSession?.remoteConnectionId,
-        params.remoteSshHost || parentSession?.remoteSshHost,
-        { includeInternal: params.includeInternal },
-      );
-    }
-  }
+  ensureBtwSessionAvailable(params);
 
   const content = buildBtwSessionPanelContent(
     params.childSessionId,

--- a/src/web-ui/src/flow_chat/utils/subagentProjection.ts
+++ b/src/web-ui/src/flow_chat/utils/subagentProjection.ts
@@ -142,14 +142,15 @@ export function getSubagentProjectionState(
   const turn = pickProjectedTurn(session);
   const round = pickProjectedRound(turn);
   const itemsMode = options.itemsMode ?? 'full-turn';
+  const items = itemsMode === 'last-round'
+    ? flattenRoundItems(round)
+    : flattenTurnItems(turn);
 
   return {
     session,
     turn,
     round,
-    items: itemsMode === 'last-round'
-      ? flattenRoundItems(round)
-      : flattenTurnItems(turn),
+    items,
     isRunning: isActiveTurn(turn),
   };
 }


### PR DESCRIPTION
- show full subagent turn output while a task is running
- return completed task projections to last-round summaries
- ensure hidden subagent sessions are loaded on demand after app restart
- simplify subagent projection height handling and add regression tests
