### PR TITLE
refactor: keep background result UI messages concise

### DIFF
--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -179,6 +179,21 @@ fn format_background_subagent_delivery_text(
     }
 }
 
+fn format_background_subagent_display_text(
+    outcome: Result<&SubagentResult, &BitFunError>,
+) -> String {
+    match outcome {
+        Ok(result) => {
+            if result.is_partial_timeout() {
+                "Background subagent completed with a partial timeout result.".to_string()
+            } else {
+                "Background subagent completed successfully.".to_string()
+            }
+        }
+        Err(_) => "Background subagent failed before producing a final result.".to_string(),
+    }
+}
+
 fn build_subagent_session_relationship(
     parent_info: Option<&SubagentParentInfo>,
     agent_type: &str,
@@ -5187,7 +5202,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .map(|token| token.child_token());
 
         tokio::spawn(async move {
-            let delivery_text = match coordinator
+            let (delivery_text, display_text) = match coordinator
                 .execute_hidden_subagent_internal(
                     request,
                     parent_cancel_token.as_ref(),
@@ -5195,15 +5210,21 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 )
                 .await
             {
-                Ok(result) => format_background_subagent_delivery_text(
-                    &background_task_id_for_delivery,
-                    &agent_type,
-                    Ok(&result),
+                Ok(result) => (
+                    format_background_subagent_delivery_text(
+                        &background_task_id_for_delivery,
+                        &agent_type,
+                        Ok(&result),
+                    ),
+                    format_background_subagent_display_text(Ok(&result)),
                 ),
-                Err(error) => format_background_subagent_delivery_text(
-                    &background_task_id_for_delivery,
-                    &agent_type,
-                    Err(&error),
+                Err(error) => (
+                    format_background_subagent_delivery_text(
+                        &background_task_id_for_delivery,
+                        &agent_type,
+                        Err(&error),
+                    ),
+                    format_background_subagent_display_text(Err(&error)),
                 ),
             };
 
@@ -5222,7 +5243,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                         parent_agent_type,
                         parent_workspace_path,
                         delivery_text,
-                        None,
+                        Some(display_text),
                         Some(metadata),
                     )
                     .await
@@ -5840,6 +5861,29 @@ mod tests {
             "Background subagent 'GeneralPurpose' (background_task_id='bg-subagent-789') failed before producing a final result."
         ));
         assert!(failed_text.contains("Error:"));
+    }
+
+    #[test]
+    fn background_subagent_display_text_is_concise() {
+        let completed = super::SubagentResult::completed("done".to_string());
+        assert_eq!(
+            super::format_background_subagent_display_text(Ok(&completed)),
+            "Background subagent completed successfully."
+        );
+
+        let partial =
+            super::SubagentResult::partial_timeout("partial".to_string(), "timeout".to_string());
+        assert_eq!(
+            super::format_background_subagent_display_text(Ok(&partial)),
+            "Background subagent completed with a partial timeout result."
+        );
+
+        assert_eq!(
+            super::format_background_subagent_display_text(Err(
+                &crate::util::errors::BitFunError::tool("boom".to_string())
+            )),
+            "Background subagent failed before producing a final result."
+        );
     }
 
     #[test]

--- a/src/crates/core/src/agentic/tools/implementations/bash_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/bash_tool.rs
@@ -497,6 +497,22 @@ impl BashTool {
         )
     }
 
+    fn format_background_command_display_text(
+        exit_code: Option<i32>,
+        timed_out: bool,
+        interrupted: bool,
+    ) -> String {
+        if timed_out {
+            "Background Bash command timed out.".to_string()
+        } else if interrupted {
+            "Background Bash command was interrupted.".to_string()
+        } else if exit_code == Some(0) {
+            "Background Bash command completed successfully.".to_string()
+        } else {
+            "Background Bash command completed with a non-zero exit code.".to_string()
+        }
+    }
+
     fn format_background_command_error_text(
         command: &str,
         terminal_session_id: &str,
@@ -523,6 +539,10 @@ impl BashTool {
         format!(
             "Background Bash command failed before producing a final completion result.\n<background_command status=\"error\" terminal_session_id=\"{terminal_session_id}\">\nCommand: {command}\nWorking directory: {working_directory}\n{persistence_line}\nError: {error}\n</background_command>"
         )
+    }
+
+    fn format_background_command_error_display_text() -> String {
+        "Background Bash command failed before producing a final completion result.".to_string()
     }
 }
 
@@ -1510,6 +1530,11 @@ impl BashTool {
                             &output_file_reference_for_task,
                             output_persist_error.as_deref(),
                         );
+                        let display_text = Self::format_background_command_display_text(
+                            exit_code,
+                            timed_out,
+                            interrupted,
+                        );
                         let metadata = json!({
                             "kind": "background_result",
                             "sourceKind": "bash_command",
@@ -1528,7 +1553,7 @@ impl BashTool {
                                     parent_agent_type.clone(),
                                     parent_workspace_path.clone(),
                                     delivery_text,
-                                    None,
+                                    Some(display_text),
                                     Some(metadata),
                                 )
                                 .await
@@ -1556,6 +1581,7 @@ impl BashTool {
                             &message,
                             output_persist_error.as_deref(),
                         );
+                        let display_text = Self::format_background_command_error_display_text();
                         let metadata = json!({
                             "kind": "background_result",
                             "sourceKind": "bash_command",
@@ -1575,7 +1601,7 @@ impl BashTool {
                                     parent_agent_type.clone(),
                                     parent_workspace_path.clone(),
                                     delivery_text,
-                                    None,
+                                    Some(display_text),
                                     Some(metadata),
                                 )
                                 .await
@@ -1606,6 +1632,7 @@ impl BashTool {
                     "Background Bash command stream ended without a completion event.",
                     output_persist_error.as_deref(),
                 );
+                let display_text = Self::format_background_command_error_display_text();
                 let metadata = json!({
                     "kind": "background_result",
                     "sourceKind": "bash_command",
@@ -1625,7 +1652,7 @@ impl BashTool {
                             parent_agent_type.clone(),
                             parent_workspace_path.clone(),
                             delivery_text,
-                            None,
+                            Some(display_text),
                             Some(metadata),
                         )
                         .await
@@ -1866,5 +1893,29 @@ mod tests {
         assert!(rendered.contains(
             "Full output was saved to: /runtime/sessions/session/tool-results/bash_123.txt"
         ));
+    }
+
+    #[test]
+    fn background_display_text_is_concise() {
+        assert_eq!(
+            BashTool::format_background_command_display_text(Some(0), false, false),
+            "Background Bash command completed successfully."
+        );
+        assert_eq!(
+            BashTool::format_background_command_display_text(Some(1), false, false),
+            "Background Bash command completed with a non-zero exit code."
+        );
+        assert_eq!(
+            BashTool::format_background_command_display_text(None, true, false),
+            "Background Bash command timed out."
+        );
+        assert_eq!(
+            BashTool::format_background_command_display_text(Some(130), false, true),
+            "Background Bash command was interrupted."
+        );
+        assert_eq!(
+            BashTool::format_background_command_error_display_text(),
+            "Background Bash command failed before producing a final completion result."
+        );
     }
 }


### PR DESCRIPTION
- add concise display text for background subagent result delivery
- add concise display text for background Bash result delivery
- preserve full background result content for agent consumption
- add focused tests for background result display text
