### PR TITLE
fix(web-ui): keep toolbar window within desktop bounds

### DIFF
--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarModeProvider.tsx
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarModeProvider.tsx
@@ -12,6 +12,7 @@ import {
   type ToolbarModeContextType,
   type ToolbarModeState,
 } from './ToolbarModeContext';
+import { resolveToolbarWindowGeometry } from './toolbarWindowGeometry';
 
 const log = createLogger('ToolbarModeContext');
 
@@ -80,23 +81,21 @@ export const ToolbarModeProvider: React.FC<ToolbarModeProviderProps> = ({ childr
         await win.unmaximize();
       }
 
-      let x = 100;
-      let y = 100;
-
       const monitor = await currentMonitor();
-      if (monitor) {
-        const scaleFactor = await win.scaleFactor();
-        const margin = Math.round(20 * scaleFactor);
-        const taskbarHeight = Math.round(50 * scaleFactor);
-
-        x = monitor.size.width - TOOLBAR_EXPANDED_SIZE.width - margin;
-        y = monitor.size.height - TOOLBAR_EXPANDED_SIZE.height - margin - taskbarHeight;
-      }
+      const geometry = resolveToolbarWindowGeometry({
+        monitor,
+        targetSize: TOOLBAR_EXPANDED_SIZE,
+        minSize: TOOLBAR_EXPANDED_MIN,
+      });
+      const toolbarMinSize = {
+        width: Math.min(TOOLBAR_EXPANDED_MIN.width, geometry.width),
+        height: Math.min(TOOLBAR_EXPANDED_MIN.height, geometry.height),
+      };
 
       const toolbarWindowOps: Array<Promise<unknown>> = [
         win.setAlwaysOnTop(true),
-        win.setSize(new PhysicalSize(TOOLBAR_EXPANDED_SIZE.width, TOOLBAR_EXPANDED_SIZE.height)),
-        win.setPosition(new PhysicalPosition(x, y)),
+        win.setSize(new PhysicalSize(geometry.width, geometry.height)),
+        win.setPosition(new PhysicalPosition(geometry.x, geometry.y)),
         win.setResizable(true),
         win.setSkipTaskbar(true),
       ];
@@ -110,7 +109,7 @@ export const ToolbarModeProvider: React.FC<ToolbarModeProviderProps> = ({ childr
       }
       await Promise.all(toolbarWindowOps);
 
-      await win.setMinSize(new PhysicalSize(TOOLBAR_EXPANDED_MIN.width, TOOLBAR_EXPANDED_MIN.height));
+      await win.setMinSize(new PhysicalSize(toolbarMinSize.width, toolbarMinSize.height));
     } catch (error) {
       log.error('Failed to enable toolbar mode', error);
       setIsToolbarMode(false);
@@ -201,14 +200,32 @@ export const ToolbarModeProvider: React.FC<ToolbarModeProviderProps> = ({ childr
       const minSize = newIsExpanded ? TOOLBAR_EXPANDED_MIN : TOOLBAR_COMPACT_MIN;
       const currentPosition = await win.outerPosition();
       const currentSize = await win.outerSize();
-      const heightDiff = targetSize.height - currentSize.height;
-      const newY = currentPosition.y - heightDiff;
+      const monitor = await currentMonitor();
+      const geometry = resolveToolbarWindowGeometry({
+        monitor,
+        targetSize,
+        minSize,
+        anchor: {
+          x: currentPosition.x,
+          y: currentPosition.y,
+          width: currentSize.width,
+          height: currentSize.height,
+        },
+        fallbackPosition: {
+          x: currentPosition.x,
+          y: Math.max(0, currentPosition.y + currentSize.height - targetSize.height),
+        },
+      });
+      const toolbarMinSize = {
+        width: Math.min(minSize.width, geometry.width),
+        height: Math.min(minSize.height, geometry.height),
+      };
 
       setIsExpanded(newIsExpanded);
 
-      await win.setMinSize(new PhysicalSize(minSize.width, minSize.height));
-      await win.setSize(new PhysicalSize(targetSize.width, targetSize.height));
-      await win.setPosition(new PhysicalPosition(currentPosition.x, Math.max(0, newY)));
+      await win.setMinSize(new PhysicalSize(toolbarMinSize.width, toolbarMinSize.height));
+      await win.setSize(new PhysicalSize(geometry.width, geometry.height));
+      await win.setPosition(new PhysicalPosition(geometry.x, geometry.y));
     } catch (error) {
       log.error('Failed to toggle expanded state', { newIsExpanded, error });
     }

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/toolbarWindowGeometry.test.ts
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/toolbarWindowGeometry.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TOOLBAR_EXPANDED_MIN,
+  TOOLBAR_EXPANDED_SIZE,
+} from './ToolbarModeContext';
+import { resolveToolbarWindowGeometry } from './toolbarWindowGeometry';
+
+describe('resolveToolbarWindowGeometry', () => {
+  it('fits expanded toolbar mode inside a short desktop work area', () => {
+    const geometry = resolveToolbarWindowGeometry({
+      monitor: {
+        position: { x: 0, y: 0 },
+        size: { width: 1365, height: 768 },
+        workArea: {
+          position: { x: 0, y: 0 },
+          size: { width: 1365, height: 728 },
+        },
+        scaleFactor: 1,
+      },
+      targetSize: TOOLBAR_EXPANDED_SIZE,
+      minSize: TOOLBAR_EXPANDED_MIN,
+    });
+
+    expect(geometry.y).toBeGreaterThanOrEqual(0);
+    expect(geometry.y + geometry.height).toBeLessThanOrEqual(728);
+    expect(geometry.height).toBe(688);
+  });
+
+  it('keeps the toolbar within a secondary monitor work area', () => {
+    const geometry = resolveToolbarWindowGeometry({
+      monitor: {
+        position: { x: -1280, y: 0 },
+        size: { width: 1280, height: 1024 },
+        workArea: {
+          position: { x: -1280, y: 24 },
+          size: { width: 1280, height: 960 },
+        },
+        scaleFactor: 1,
+      },
+      targetSize: TOOLBAR_EXPANDED_SIZE,
+      minSize: TOOLBAR_EXPANDED_MIN,
+    });
+
+    expect(geometry.x).toBeGreaterThanOrEqual(-1280);
+    expect(geometry.x + geometry.width).toBeLessThanOrEqual(0);
+    expect(geometry.y).toBeGreaterThanOrEqual(24);
+    expect(geometry.y + geometry.height).toBeLessThanOrEqual(984);
+  });
+
+  it('preserves the bottom edge margin when expanding from compact mode', () => {
+    const geometry = resolveToolbarWindowGeometry({
+      monitor: {
+        position: { x: 0, y: 0 },
+        size: { width: 1920, height: 1080 },
+        workArea: {
+          position: { x: 0, y: 0 },
+          size: { width: 1920, height: 1040 },
+        },
+        scaleFactor: 1,
+      },
+      targetSize: TOOLBAR_EXPANDED_SIZE,
+      minSize: TOOLBAR_EXPANDED_MIN,
+      anchor: {
+        x: 1200,
+        y: 900,
+        width: 700,
+        height: 140,
+      },
+    });
+
+    expect(geometry.y + geometry.height).toBe(1020);
+  });
+});

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/toolbarWindowGeometry.ts
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/toolbarWindowGeometry.ts
@@ -1,0 +1,93 @@
+export interface ToolbarWindowSize {
+  width: number;
+  height: number;
+}
+
+export interface ToolbarWindowRect extends ToolbarWindowSize {
+  x: number;
+  y: number;
+}
+
+interface PhysicalArea {
+  position: {
+    x: number;
+    y: number;
+  };
+  size: ToolbarWindowSize;
+}
+
+export interface ToolbarMonitorGeometry extends PhysicalArea {
+  scaleFactor?: number;
+  workArea?: PhysicalArea;
+}
+
+interface ResolveToolbarWindowGeometryOptions {
+  monitor: ToolbarMonitorGeometry | null | undefined;
+  targetSize: ToolbarWindowSize;
+  minSize: ToolbarWindowSize;
+  anchor?: ToolbarWindowRect | null;
+  fallbackPosition?: {
+    x: number;
+    y: number;
+  };
+}
+
+const TOOLBAR_WINDOW_EDGE_MARGIN = 20;
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+};
+
+const resolveDimension = (target: number, min: number, available: number): number => {
+  const usable = Math.max(1, available);
+  const lowerBound = Math.min(Math.max(1, min), usable);
+  return clamp(target, lowerBound, usable);
+};
+
+export const resolveToolbarWindowGeometry = ({
+  monitor,
+  targetSize,
+  minSize,
+  anchor,
+  fallbackPosition = { x: 100, y: 100 },
+}: ResolveToolbarWindowGeometryOptions): ToolbarWindowRect => {
+  if (!monitor) {
+    return {
+      ...fallbackPosition,
+      ...targetSize,
+    };
+  }
+
+  const workArea = monitor.workArea ?? {
+    position: monitor.position,
+    size: monitor.size,
+  };
+  const margin = Math.max(
+    0,
+    Math.round(TOOLBAR_WINDOW_EDGE_MARGIN * (monitor.scaleFactor ?? 1))
+  );
+  const availableWidth = workArea.size.width - margin * 2;
+  const availableHeight = workArea.size.height - margin * 2;
+  const width = resolveDimension(targetSize.width, minSize.width, availableWidth);
+  const height = resolveDimension(targetSize.height, minSize.height, availableHeight);
+
+  const desiredX = anchor
+    ? anchor.x + anchor.width - width
+    : workArea.position.x + workArea.size.width - width - margin;
+  const desiredY = anchor
+    ? anchor.y + anchor.height - height
+    : workArea.position.y + workArea.size.height - height - margin;
+
+  const minX = workArea.position.x + margin;
+  const minY = workArea.position.y + margin;
+  const maxX = workArea.position.x + workArea.size.width - width - margin;
+  const maxY = workArea.position.y + workArea.size.height - height - margin;
+
+  return {
+    x: maxX >= minX ? clamp(desiredX, minX, maxX) : workArea.position.x,
+    y: maxY >= minY ? clamp(desiredY, minY, maxY) : workArea.position.y,
+    width,
+    height,
+  };
+};


### PR DESCRIPTION
## Summary
- Clamp toolbar-mode window geometry to the current monitor work area
- Shrink expanded toolbar height on short desktops instead of allowing negative Y positions
- Reuse the same geometry calculation for expanded/compact transitions

## Verification
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/toolbar-mode/toolbarWindowGeometry.test.ts`
- `pnpm run type-check:web`
- `git diff --check -- src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarModeProvider.tsx src/web-ui/src/flow_chat/components/toolbar-mode/toolbarWindowGeometry.ts src/web-ui/src/flow_chat/components/toolbar-mode/toolbarWindowGeometry.test.ts`

fix https://github.com/GCWing/BitFun/issues/1017