### PR TITLE
feat(acp): follow up session update UI work

### DIFF
--- a/src/apps/desktop/src/api/acp_client_api.rs
+++ b/src/apps/desktop/src/api/acp_client_api.rs
@@ -3,9 +3,9 @@
 use crate::api::app_state::AppState;
 use crate::api::session_storage_path::desktop_effective_session_storage_path;
 use bitfun_acp::client::{
-    AcpClientInfo, AcpClientPermissionResponse, AcpClientRequirementProbe, AcpClientStreamEvent,
-    AcpSessionOptions, CreateAcpFlowSessionRecordResponse, SetAcpSessionModelRequest,
-    SubmitAcpPermissionResponseRequest,
+    AcpAvailableCommand, AcpClientInfo, AcpClientPermissionResponse, AcpClientRequirementProbe,
+    AcpClientStreamEvent, AcpSessionOptions, CreateAcpFlowSessionRecordResponse,
+    SetAcpSessionModelRequest, SubmitAcpPermissionResponseRequest,
 };
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
@@ -377,6 +377,48 @@ pub async fn start_acp_dialog_turn(
                                     bitfun_core::util::errors::BitFunError::service(e.to_string())
                                 })?;
                         }
+                        AcpClientStreamEvent::AvailableCommandsUpdated(commands) => {
+                            app_handle
+                                .emit(
+                                    "agentic://acp-available-commands-updated",
+                                    serde_json::json!({
+                                        "sessionId": request.session_id,
+                                        "clientId": request.client_id,
+                                        "commands": commands,
+                                    }),
+                                )
+                                .map_err(|e| {
+                                    bitfun_core::util::errors::BitFunError::service(e.to_string())
+                                })?;
+                        }
+                        AcpClientStreamEvent::PlanUpdated(entries) => {
+                            app_handle
+                                .emit(
+                                    "agentic://acp-plan-updated",
+                                    serde_json::json!({
+                                        "sessionId": request.session_id,
+                                        "turnId": request.turn_id,
+                                        "clientId": request.client_id,
+                                        "entries": entries,
+                                    }),
+                                )
+                                .map_err(|e| {
+                                    bitfun_core::util::errors::BitFunError::service(e.to_string())
+                                })?;
+                        }
+                        AcpClientStreamEvent::ConfigOptionsUpdated(_) => {
+                            app_handle
+                                .emit(
+                                    "agentic://acp-session-options-changed",
+                                    serde_json::json!({
+                                        "sessionId": request.session_id,
+                                        "clientId": request.client_id,
+                                    }),
+                                )
+                                .map_err(|e| {
+                                    bitfun_core::util::errors::BitFunError::service(e.to_string())
+                                })?;
+                        }
                         AcpClientStreamEvent::Completed => {
                             app_handle
                                 .emit(
@@ -472,6 +514,39 @@ pub async fn get_acp_session_options(
     };
     service
         .get_session_options(
+            &request.client_id,
+            request.workspace_path,
+            request.remote_connection_id,
+            session_storage_path,
+            request.session_id,
+        )
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn get_acp_session_commands(
+    state: State<'_, AppState>,
+    request: GetAcpSessionOptionsRequest,
+) -> Result<Vec<AcpAvailableCommand>, String> {
+    let service = state
+        .acp_client_service
+        .as_ref()
+        .ok_or_else(|| "ACP client service not initialized".to_string())?;
+    let session_storage_path = match request.workspace_path.as_deref() {
+        Some(workspace_path) => Some(
+            desktop_effective_session_storage_path(
+                &state,
+                workspace_path,
+                request.remote_connection_id.as_deref(),
+                request.remote_ssh_host.as_deref(),
+            )
+            .await,
+        ),
+        None => None,
+    };
+    service
+        .get_session_commands(
             &request.client_id,
             request.workspace_path,
             request.remote_connection_id,

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1022,6 +1022,7 @@ pub async fn run() {
             start_acp_dialog_turn,
             cancel_acp_dialog_turn,
             get_acp_session_options,
+            get_acp_session_commands,
             set_acp_session_model,
             lsp_initialize,
             lsp_start_server_for_file,

--- a/src/crates/acp/src/client/manager.rs
+++ b/src/crates/acp/src/client/manager.rs
@@ -47,7 +47,8 @@ use super::requirements::{
     probe_remote_executable, probe_remote_npx_adapter, resolve_configured_command,
 };
 use super::session_options::{
-    model_config_id, session_options_from_state, AcpSessionContextUsage, AcpSessionOptions,
+    model_config_id, session_options_from_state, AcpAvailableCommand, AcpSessionContextUsage,
+    AcpSessionOptions,
 };
 use super::session_persistence::AcpSessionPersistence;
 pub use super::session_persistence::CreateAcpFlowSessionRecordResponse;
@@ -132,6 +133,7 @@ struct AcpRemoteSession {
     models: Option<SessionModelState>,
     config_options: Vec<SessionConfigOption>,
     context_usage: Option<AcpSessionContextUsage>,
+    available_commands: Vec<AcpAvailableCommand>,
     discard_pending_updates_before_next_prompt: bool,
 }
 
@@ -160,6 +162,7 @@ impl AcpRemoteSession {
             models: None,
             config_options: Vec::new(),
             context_usage: None,
+            available_commands: Vec::new(),
             discard_pending_updates_before_next_prompt: false,
         }
     }
@@ -869,6 +872,36 @@ impl AcpClientService {
         ))
     }
 
+    pub async fn get_session_commands(
+        self: &Arc<Self>,
+        client_id: &str,
+        workspace_path: Option<String>,
+        remote_connection_id: Option<String>,
+        session_storage_path: Option<PathBuf>,
+        bitfun_session_id: String,
+    ) -> BitFunResult<Vec<AcpAvailableCommand>> {
+        let resolved = self
+            .resolve_or_create_client_session(
+                client_id,
+                workspace_path,
+                remote_connection_id.as_deref(),
+                &bitfun_session_id,
+            )
+            .await?;
+
+        let mut session = resolved.session.lock().await;
+        self.ensure_remote_session(
+            &resolved.client,
+            &resolved.session_key,
+            &resolved.cwd,
+            &bitfun_session_id,
+            session_storage_path.as_deref(),
+            &mut session,
+        )
+        .await?;
+        Ok(session.available_commands.clone())
+    }
+
     pub async fn set_session_model(
         self: &Arc<Self>,
         request: SetAcpSessionModelRequest,
@@ -1080,7 +1113,7 @@ impl AcpClientService {
                             &mut tool_call_tracker,
                         )
                         .await?;
-                        update_session_context_usage(&mut session, &events);
+                        update_session_from_events(&mut session, &events);
                         for event in events {
                             for event in round_tracker.apply(event) {
                                 on_event(event)?;
@@ -2035,7 +2068,7 @@ where
             Ok(Ok(SessionMessage::SessionMessage(dispatch))) => {
                 let events =
                     acp_dispatch_to_stream_events_with_tracker(dispatch, tool_call_tracker).await?;
-                update_session_context_usage(session, &events);
+                update_session_from_events(session, &events);
                 for event in events {
                     for event in round_tracker.apply(event) {
                         on_event(event)?;
@@ -2081,7 +2114,7 @@ async fn read_turn_to_string(session: &mut AcpRemoteSession) -> BitFunResult<Str
                 let events =
                     acp_dispatch_to_stream_events_with_tracker(dispatch, &mut tool_call_tracker)
                         .await?;
-                update_session_context_usage(session, &events);
+                update_session_from_events(session, &events);
                 append_agent_text(&mut output, events);
             }
             SessionMessage::StopReason(_) => {
@@ -2113,7 +2146,7 @@ async fn drain_pending_turn_text(
             Ok(Ok(SessionMessage::SessionMessage(dispatch))) => {
                 let events =
                     acp_dispatch_to_stream_events_with_tracker(dispatch, tool_call_tracker).await?;
-                update_session_context_usage(session, &events);
+                update_session_from_events(session, &events);
                 append_agent_text(output, events);
                 drained_count += 1;
             }
@@ -2168,7 +2201,7 @@ async fn discard_pending_session_updates_if_needed(session: &mut AcpRemoteSessio
                 if let Ok(events) =
                     acp_dispatch_to_stream_events_with_tracker(dispatch, &mut tracker).await
                 {
-                    update_session_context_usage(session, &events);
+                    update_session_from_events(session, &events);
                 }
                 discarded_count += 1;
             }
@@ -2197,6 +2230,12 @@ async fn discard_pending_session_updates_if_needed(session: &mut AcpRemoteSessio
     }
 }
 
+fn update_session_from_events(session: &mut AcpRemoteSession, events: &[AcpClientStreamEvent]) {
+    update_session_context_usage(session, events);
+    update_session_available_commands(session, events);
+    update_session_config_options(session, events);
+}
+
 fn update_session_context_usage(session: &mut AcpRemoteSession, events: &[AcpClientStreamEvent]) {
     let Some(usage) = events.iter().rev().find_map(|event| match event {
         AcpClientStreamEvent::ContextUsageUpdated(usage) => Some(usage.clone()),
@@ -2206,6 +2245,31 @@ fn update_session_context_usage(session: &mut AcpRemoteSession, events: &[AcpCli
     };
 
     session.context_usage = Some(usage);
+}
+
+fn update_session_available_commands(
+    session: &mut AcpRemoteSession,
+    events: &[AcpClientStreamEvent],
+) {
+    let Some(commands) = events.iter().rev().find_map(|event| match event {
+        AcpClientStreamEvent::AvailableCommandsUpdated(commands) => Some(commands.clone()),
+        _ => None,
+    }) else {
+        return;
+    };
+
+    session.available_commands = commands;
+}
+
+fn update_session_config_options(session: &mut AcpRemoteSession, events: &[AcpClientStreamEvent]) {
+    let Some(options) = events.iter().rev().find_map(|event| match event {
+        AcpClientStreamEvent::ConfigOptionsUpdated(options) => Some(options.clone()),
+        _ => None,
+    }) else {
+        return;
+    };
+
+    session.config_options = options;
 }
 
 fn protocol_error(error: impl std::fmt::Display) -> BitFunError {

--- a/src/crates/acp/src/client/mod.rs
+++ b/src/crates/acp/src/client/mod.rs
@@ -20,5 +20,8 @@ pub use manager::{
     AcpClientPermissionResponse, AcpClientService, CreateAcpFlowSessionRecordResponse,
     SetAcpSessionModelRequest, SubmitAcpPermissionResponseRequest,
 };
-pub use session_options::{AcpSessionContextUsage, AcpSessionModelOption, AcpSessionOptions};
+pub use session_options::{
+    AcpAvailableCommand, AcpPlanEntry, AcpSessionContextUsage, AcpSessionModelOption,
+    AcpSessionOptions,
+};
 pub use stream::AcpClientStreamEvent;

--- a/src/crates/acp/src/client/session_options.rs
+++ b/src/crates/acp/src/client/session_options.rs
@@ -23,6 +23,69 @@ impl From<agent_client_protocol::schema::UsageUpdate> for AcpSessionContextUsage
     }
 }
 
+/// A slash command advertised by an ACP agent via `AvailableCommandsUpdate`.
+///
+/// Invocation is plain prompt text: `/<name> <args>`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpAvailableCommand {
+    pub name: String,
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_hint: Option<String>,
+}
+
+impl From<agent_client_protocol::schema::AvailableCommand> for AcpAvailableCommand {
+    fn from(command: agent_client_protocol::schema::AvailableCommand) -> Self {
+        use agent_client_protocol::schema::AvailableCommandInput;
+
+        let input_hint = command.input.and_then(|input| match input {
+            AvailableCommandInput::Unstructured(unstructured) => Some(unstructured.hint),
+            _ => None,
+        });
+
+        Self {
+            name: command.name,
+            description: command.description,
+            input_hint,
+        }
+    }
+}
+
+/// One entry of an ACP agent execution plan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpPlanEntry {
+    pub content: String,
+    pub priority: String,
+    pub status: String,
+}
+
+impl From<agent_client_protocol::schema::PlanEntry> for AcpPlanEntry {
+    fn from(entry: agent_client_protocol::schema::PlanEntry) -> Self {
+        use agent_client_protocol::schema::{PlanEntryPriority, PlanEntryStatus};
+
+        let priority = match entry.priority {
+            PlanEntryPriority::High => "high",
+            PlanEntryPriority::Medium => "medium",
+            PlanEntryPriority::Low => "low",
+            _ => "medium",
+        };
+        let status = match entry.status {
+            PlanEntryStatus::Pending => "pending",
+            PlanEntryStatus::InProgress => "in_progress",
+            PlanEntryStatus::Completed => "completed",
+            _ => "pending",
+        };
+
+        Self {
+            content: entry.content,
+            priority: priority.to_string(),
+            status: status.to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AcpSessionOptions {
@@ -197,5 +260,25 @@ mod tests {
                 .map(|cost| cost.currency.as_str()),
             Some("USD")
         );
+    }
+
+    #[test]
+    fn converts_available_command_with_and_without_input() {
+        use agent_client_protocol::schema::{
+            AvailableCommand, AvailableCommandInput, UnstructuredCommandInput,
+        };
+
+        let with_input = AvailableCommand::new("create_plan", "Draft an execution plan").input(
+            AvailableCommandInput::Unstructured(UnstructuredCommandInput::new("what to plan")),
+        );
+        let converted = AcpAvailableCommand::from(with_input);
+        assert_eq!(converted.name, "create_plan");
+        assert_eq!(converted.description, "Draft an execution plan");
+        assert_eq!(converted.input_hint.as_deref(), Some("what to plan"));
+
+        let converted =
+            AcpAvailableCommand::from(AvailableCommand::new("compact", "Compact the context"));
+        assert_eq!(converted.name, "compact");
+        assert!(converted.input_hint.is_none());
     }
 }

--- a/src/crates/acp/src/client/stream.rs
+++ b/src/crates/acp/src/client/stream.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 
 use agent_client_protocol::schema::{
-    ContentBlock, ContentChunk, SessionNotification, SessionUpdate, ToolCall, ToolCallContent,
-    ToolCallStatus, ToolCallUpdate,
+    ContentBlock, ContentChunk, SessionConfigOption, SessionNotification, SessionUpdate, ToolCall,
+    ToolCallContent, ToolCallStatus, ToolCallUpdate,
 };
 use agent_client_protocol::util::MatchDispatch;
 use bitfun_core::util::errors::{BitFunError, BitFunResult};
 use bitfun_events::ToolEventData;
 
-use super::session_options::AcpSessionContextUsage;
+use super::session_options::{AcpAvailableCommand, AcpPlanEntry, AcpSessionContextUsage};
 use super::tool_card_bridge::{acp_tool_name, normalize_tool_params};
 
 #[derive(Debug, Clone)]
@@ -22,6 +22,9 @@ pub enum AcpClientStreamEvent {
     AgentThought(String),
     ToolEvent(ToolEventData),
     ContextUsageUpdated(AcpSessionContextUsage),
+    AvailableCommandsUpdated(Vec<AcpAvailableCommand>),
+    PlanUpdated(Vec<AcpPlanEntry>),
+    ConfigOptionsUpdated(Vec<SessionConfigOption>),
     Completed,
     Cancelled,
 }
@@ -80,6 +83,9 @@ impl AcpStreamRoundTracker {
             }
             AcpClientStreamEvent::ModelRoundStarted { .. }
             | AcpClientStreamEvent::ContextUsageUpdated(_)
+            | AcpClientStreamEvent::AvailableCommandsUpdated(_)
+            | AcpClientStreamEvent::PlanUpdated(_)
+            | AcpClientStreamEvent::ConfigOptionsUpdated(_)
             | AcpClientStreamEvent::Completed
             | AcpClientStreamEvent::Cancelled => vec![event],
         }
@@ -127,6 +133,25 @@ pub(super) async fn acp_dispatch_to_stream_events_with_tracker(
                 SessionUpdate::UsageUpdate(usage_update) => {
                     events.push(AcpClientStreamEvent::ContextUsageUpdated(
                         AcpSessionContextUsage::from(usage_update),
+                    ));
+                }
+                SessionUpdate::AvailableCommandsUpdate(update) => {
+                    events.push(AcpClientStreamEvent::AvailableCommandsUpdated(
+                        update
+                            .available_commands
+                            .into_iter()
+                            .map(AcpAvailableCommand::from)
+                            .collect(),
+                    ));
+                }
+                SessionUpdate::Plan(plan) => {
+                    events.push(AcpClientStreamEvent::PlanUpdated(
+                        plan.entries.into_iter().map(AcpPlanEntry::from).collect(),
+                    ));
+                }
+                SessionUpdate::ConfigOptionUpdate(update) => {
+                    events.push(AcpClientStreamEvent::ConfigOptionsUpdated(
+                        update.config_options,
                     ));
                 }
                 _ => {}
@@ -432,6 +457,9 @@ mod tests {
                 AcpClientStreamEvent::AgentThought(_) => "thought",
                 AcpClientStreamEvent::ToolEvent(_) => "tool",
                 AcpClientStreamEvent::ContextUsageUpdated(_) => "usage",
+                AcpClientStreamEvent::AvailableCommandsUpdated(_) => "commands",
+                AcpClientStreamEvent::PlanUpdated(_) => "plan",
+                AcpClientStreamEvent::ConfigOptionsUpdated(_) => "config_options",
                 AcpClientStreamEvent::Completed => "completed",
                 AcpClientStreamEvent::Cancelled => "cancelled",
             })
@@ -464,6 +492,125 @@ mod tests {
         assert!(matches!(
             events.as_slice(),
             [AcpClientStreamEvent::ContextUsageUpdated(usage)] if usage.used == 1_000 && usage.size == 4_000
+        ));
+    }
+
+    #[test]
+    fn exposes_available_commands_updates() {
+        use agent_client_protocol::schema::{AvailableCommand, AvailableCommandsUpdate};
+        use agent_client_protocol::JsonRpcMessage;
+
+        let mut tracker = AcpToolCallTracker::new();
+        let notification = SessionNotification::new(
+            "session-1",
+            SessionUpdate::AvailableCommandsUpdate(AvailableCommandsUpdate::new(vec![
+                AvailableCommand::new("compact", "Compact the context"),
+                AvailableCommand::new("init", "Initialize the project"),
+            ])),
+        )
+        .to_untyped_message()
+        .expect("notification");
+        let dispatch = agent_client_protocol::Dispatch::Notification(notification);
+
+        let events = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(acp_dispatch_to_stream_events_with_tracker(
+                dispatch,
+                &mut tracker,
+            ))
+            .expect("dispatch");
+
+        match events.as_slice() {
+            [AcpClientStreamEvent::AvailableCommandsUpdated(commands)] => {
+                assert_eq!(commands.len(), 2);
+                assert_eq!(commands[0].name, "compact");
+                assert_eq!(commands[1].name, "init");
+            }
+            other => panic!("expected AvailableCommandsUpdated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exposes_plan_updates() {
+        use agent_client_protocol::schema::{Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus};
+        use agent_client_protocol::JsonRpcMessage;
+
+        let mut tracker = AcpToolCallTracker::new();
+        let notification = SessionNotification::new(
+            "session-1",
+            SessionUpdate::Plan(Plan::new(vec![
+                PlanEntry::new(
+                    "Explore",
+                    PlanEntryPriority::High,
+                    PlanEntryStatus::Completed,
+                ),
+                PlanEntry::new(
+                    "Implement",
+                    PlanEntryPriority::Medium,
+                    PlanEntryStatus::InProgress,
+                ),
+            ])),
+        )
+        .to_untyped_message()
+        .expect("notification");
+        let dispatch = agent_client_protocol::Dispatch::Notification(notification);
+
+        let events = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(acp_dispatch_to_stream_events_with_tracker(
+                dispatch,
+                &mut tracker,
+            ))
+            .expect("dispatch");
+
+        match events.as_slice() {
+            [AcpClientStreamEvent::PlanUpdated(entries)] => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0].content, "Explore");
+                assert_eq!(entries[0].priority, "high");
+                assert_eq!(entries[0].status, "completed");
+                assert_eq!(entries[1].status, "in_progress");
+            }
+            other => panic!("expected PlanUpdated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exposes_config_option_updates() {
+        use agent_client_protocol::schema::{ConfigOptionUpdate, SessionConfigOption};
+        use agent_client_protocol::JsonRpcMessage;
+
+        let mut tracker = AcpToolCallTracker::new();
+        let notification = SessionNotification::new(
+            "session-1",
+            SessionUpdate::ConfigOptionUpdate(ConfigOptionUpdate::new(vec![
+                SessionConfigOption::select(
+                    "model",
+                    "Model",
+                    "fast",
+                    vec![
+                        agent_client_protocol::schema::SessionConfigSelectOption::new(
+                            "fast", "Fast",
+                        ),
+                    ],
+                ),
+            ])),
+        )
+        .to_untyped_message()
+        .expect("notification");
+        let dispatch = agent_client_protocol::Dispatch::Notification(notification);
+
+        let events = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(acp_dispatch_to_stream_events_with_tracker(
+                dispatch,
+                &mut tracker,
+            ))
+            .expect("dispatch");
+
+        assert!(matches!(
+            events.as_slice(),
+            [AcpClientStreamEvent::ConfigOptionsUpdated(options)] if options.len() == 1
         ));
     }
 

--- a/src/web-ui/src/flow_chat/components/AcpPlanPanel.scss
+++ b/src/web-ui/src/flow_chat/components/AcpPlanPanel.scss
@@ -1,0 +1,92 @@
+.bitfun-acp-plan {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color-light);
+  border-radius: 8px;
+  background: var(--element-bg-medium);
+  font-size: var(--flowchat-font-size-xs);
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__title {
+    color: var(--color-text-secondary);
+    font-size: var(--flowchat-font-size-2xs);
+    font-weight: 600;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+  }
+
+  &__progress {
+    color: var(--color-text-tertiary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__item {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 2px 0;
+    color: var(--color-text-primary);
+
+    &--completed {
+      color: var(--color-text-tertiary);
+
+      .bitfun-acp-plan__content {
+        text-decoration: line-through;
+      }
+    }
+
+    &--pending {
+      color: var(--color-text-secondary);
+    }
+  }
+
+  &__icon {
+    flex-shrink: 0;
+    margin-top: 2px;
+
+    &--done {
+      color: var(--color-success, #4caf50);
+    }
+
+    &--active {
+      color: var(--color-primary, #648cff);
+      animation: bitfun-acp-plan-spin 1.2s linear infinite;
+    }
+
+    &--pending {
+      opacity: 0.5;
+    }
+  }
+
+  &__content {
+    line-height: 1.4;
+    word-break: break-word;
+  }
+}
+
+@keyframes bitfun-acp-plan-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/web-ui/src/flow_chat/components/AcpPlanPanel.tsx
+++ b/src/web-ui/src/flow_chat/components/AcpPlanPanel.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Check, CircleDashed, LoaderCircle } from 'lucide-react';
+
+import type { AcpPlanEntry } from '@/infrastructure/api/service-api/ACPClientAPI';
+import './AcpPlanPanel.scss';
+
+export interface AcpPlanPanelProps {
+  entries: AcpPlanEntry[];
+}
+
+function statusIcon(status: string): React.ReactNode {
+  switch (status) {
+    case 'completed':
+      return <Check size={13} className="bitfun-acp-plan__icon bitfun-acp-plan__icon--done" />;
+    case 'in_progress':
+      return (
+        <LoaderCircle
+          size={13}
+          className="bitfun-acp-plan__icon bitfun-acp-plan__icon--active"
+        />
+      );
+    default:
+      return (
+        <CircleDashed size={13} className="bitfun-acp-plan__icon bitfun-acp-plan__icon--pending" />
+      );
+  }
+}
+
+export const AcpPlanPanel: React.FC<AcpPlanPanelProps> = ({ entries }) => {
+  const { t } = useTranslation('flow-chat');
+  if (entries.length === 0) return null;
+
+  const done = entries.filter((entry) => entry.status === 'completed').length;
+
+  return (
+    <div className="bitfun-acp-plan" data-testid="acp-plan-panel">
+      <div className="bitfun-acp-plan__header">
+        <span className="bitfun-acp-plan__title">{t('chatInput.acpPlan.title')}</span>
+        <span className="bitfun-acp-plan__progress">
+          {done}/{entries.length}
+        </span>
+      </div>
+      <ul className="bitfun-acp-plan__list">
+        {entries.map((entry, index) => (
+          <li
+            key={`${index}-${entry.content}`}
+            className={`bitfun-acp-plan__item bitfun-acp-plan__item--${entry.status}`}
+          >
+            {statusIcon(entry.status)}
+            <span className="bitfun-acp-plan__content">{entry.content}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+AcpPlanPanel.displayName = 'AcpPlanPanel';

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -20,6 +20,10 @@ import {
 import { SessionExecutionEvent } from '../state-machine/types';
 import { ModelSelector } from './ModelSelector';
 import { FlowChatStore } from '../store/FlowChatStore';
+import { useAcpPlan } from '../hooks/useAcpPlan';
+import { filterSlashCommands, useAcpSlashCommands } from '../hooks/useAcpSlashCommands';
+import { acpSessionRef, acpSlashCommandText } from '../utils/acpSession';
+import { AcpPlanPanel } from './AcpPlanPanel';
 import type { FlowChatState, Session } from '../types/flow-chat';
 import type { FileContext, DirectoryContext, ImageContext } from '@/types/context.ts';
 import { SmartRecommendations } from './smart-recommendations';
@@ -106,7 +110,14 @@ type SlashMcpPromptItem = {
   }>;
 };
 
-type SlashPickerItem = SlashActionItem | SlashModeItem | SlashMcpPromptItem;
+type SlashAcpCommandItem = {
+  kind: 'acpCommand';
+  id: string;
+  command: string;
+  label: string;
+};
+
+type SlashPickerItem = SlashActionItem | SlashModeItem | SlashMcpPromptItem | SlashAcpCommandItem;
 type ChatInputTarget = 'main' | 'btw';
 type PendingLargePasteMap = Record<string, string>;
 
@@ -277,6 +288,12 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     : undefined;
   const effectiveTargetRelationship = resolveSessionRelationship(effectiveTargetSession);
   const isBtwSession = effectiveTargetRelationship.displayAsChild;
+  const acpSessionForInput = useMemo(
+    () => acpSessionRef(effectiveTargetSession),
+    [effectiveTargetSession],
+  );
+  const { commands: acpAgentCommands } = useAcpSlashCommands(acpSessionForInput);
+  const { entries: acpPlanEntries } = useAcpPlan(acpSessionForInput?.sessionId ?? null);
   const threadGoalController = useThreadGoalController(effectiveTargetSession, {
     isBtwSession,
   });
@@ -1444,6 +1461,15 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     });
   }, [mcpPromptCommands, slashCommandState.query]);
 
+  const getFilteredAcpCommands = useCallback((): SlashAcpCommandItem[] => {
+    return filterSlashCommands(acpAgentCommands, slashCommandState.query).map(command => ({
+      kind: 'acpCommand',
+      id: command.name,
+      command: `/${command.name}`,
+      label: command.description,
+    }));
+  }, [acpAgentCommands, slashCommandState.query]);
+
   const resolveTypedMcpPromptCommand = useCallback((text: string): SlashMcpPromptItem | null => {
     const trimmed = text.trim();
     if (!trimmed.startsWith('/')) {
@@ -1463,6 +1489,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const getSlashPickerItems = useCallback((): SlashPickerItem[] => {
     const actions = getFilteredActions();
     const mcpPrompts = getFilteredMcpPromptCommands();
+    const acpCommands = getFilteredAcpCommands();
     let modeList = incrementalCodeModes;
     if (canSwitchModes && slashCommandState.query) {
       const q = slashCommandState.query;
@@ -1477,8 +1504,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       id: mode.id,
       name: mode.name,
     }));
-    return [...actions, ...mcpPrompts, ...modes];
-  }, [canSwitchModes, getFilteredActions, getFilteredMcpPromptCommands, incrementalCodeModes, slashCommandState.query]);
+    return [...acpCommands, ...actions, ...mcpPrompts, ...modes];
+  }, [canSwitchModes, getFilteredActions, getFilteredAcpCommands, getFilteredMcpPromptCommands, incrementalCodeModes, slashCommandState.query]);
   
   const handleInputChange = useCallback((text: string, activeContexts: import('../../shared/types/context').ContextItem[]) => {
     if (!inputState.isActive && text.length > 0) {
@@ -2359,6 +2386,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     window.setTimeout(() => richTextInputRef.current?.focus(), 0);
   }, [setQueuedInput]);
 
+  const selectSlashAcpCommand = useCallback((item: SlashAcpCommandItem) => {
+    dispatchInput({ type: 'SET_VALUE', payload: acpSlashCommandText(item.id) });
+    setQueuedInput(null);
+    setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
+    window.setTimeout(() => richTextInputRef.current?.focus(), 0);
+  }, [setQueuedInput]);
+
   const handleBoostStartBtw = useCallback(
     (e: React.SyntheticEvent) => {
       e.stopPropagation();
@@ -2496,6 +2530,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 selectSlashCommandMode(item.id);
               } else if (item.kind === 'mcpPrompt') {
                 selectSlashPromptCommand(item);
+              } else if (item.kind === 'acpCommand') {
+                selectSlashAcpCommand(item);
               } else {
                 selectSlashCommandAction(item.id);
               }
@@ -2531,6 +2567,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 selectSlashCommandMode(item.id);
               } else if (item.kind === 'mcpPrompt') {
                 selectSlashPromptCommand(item);
+              } else if (item.kind === 'acpCommand') {
+                selectSlashAcpCommand(item);
               } else {
                 selectSlashCommandAction(item.id);
               }
@@ -2658,7 +2696,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       e.preventDefault();
       void handleCancelCurrentTask();
     }
-  }, [handleSendOrCancel, submitBtwFromInput, submitGoalFromInput, derivedState, handleCancelCurrentTask, slashCommandState, getFilteredIncrementalModes, getFilteredActions, getSlashPickerItems, selectSlashCommandMode, selectSlashCommandAction, selectSlashPromptCommand, canSwitchModes, historyIndex, inputHistory, savedDraft, inputState.value, currentSessionId, isBtwSession, showTargetSwitcher, setInputTarget, removeContext, t]);
+  }, [handleSendOrCancel, submitBtwFromInput, submitGoalFromInput, derivedState, handleCancelCurrentTask, slashCommandState, getFilteredIncrementalModes, getFilteredActions, getSlashPickerItems, selectSlashCommandMode, selectSlashCommandAction, selectSlashPromptCommand, selectSlashAcpCommand, canSwitchModes, historyIndex, inputHistory, savedDraft, inputState.value, currentSessionId, isBtwSession, showTargetSwitcher, setInputTarget, removeContext, t]);
 
   const handleImeCompositionStart = useCallback(() => {
     isImeComposingRef.current = true;
@@ -2908,6 +2946,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         <PendingQueuePanel sessionId={effectiveTargetSessionId || undefined} />
 
         <div className="bitfun-chat-input__container">
+          <AcpPlanPanel entries={acpPlanEntries} />
           <div className={`bitfun-chat-input__box ${isMultiLine ? 'bitfun-chat-input__box--multi-line' : 'bitfun-chat-input__box--capsule'}`}>
             {showTargetSwitcher && (
               <div className="bitfun-chat-input__target-switcher" data-testid="chat-input-target-switcher">
@@ -3073,6 +3112,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                                   selectSlashCommandMode(item.id);
                                 } else if (item.kind === 'mcpPrompt') {
                                   selectSlashPromptCommand(item);
+                                } else if (item.kind === 'acpCommand') {
+                                  selectSlashAcpCommand(item);
                                 } else {
                                   selectSlashCommandAction(item.id);
                                 }

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -21,6 +21,7 @@ import { Tooltip } from '@/component-library';
 import { FlowChatStore } from '../store/FlowChatStore';
 import { getModelMaxTokens } from '../services/flow-chat-manager/SessionModule';
 import { createLogger } from '@/shared/utils/logger';
+import { acpClientIdFromAgentType } from '../utils/acpSession';
 import './ModelSelector.scss';
 
 const log = createLogger('ModelSelector');
@@ -147,9 +148,9 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
 
   const dropdownRef = useRef<HTMLDivElement>(null);
   const activeSession = sessionId ? FlowChatStore.getInstance().getState().sessions.get(sessionId) : undefined;
-  const acpClientId = activeSession?.config.agentType?.startsWith('acp:')
-    ? activeSession.config.agentType.slice('acp:'.length)
-    : null;
+  const acpClientId =
+    acpClientIdFromAgentType(activeSession?.config.agentType) ??
+    acpClientIdFromAgentType(activeSession?.mode);
   const isAcpSession = Boolean(acpClientId && sessionId);
 
   // Load configuration data.
@@ -253,6 +254,16 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   useEffect(() => {
     loadAcpOptions();
   }, [loadAcpOptions]);
+
+  useEffect(() => {
+    if (!isAcpSession || !sessionId || !acpClientId) return;
+
+    return ACPClientAPI.onSessionOptionsChanged((event) => {
+      if (event.sessionId === sessionId && event.clientId === acpClientId) {
+        loadAcpOptions();
+      }
+    });
+  }, [acpClientId, isAcpSession, loadAcpOptions, sessionId]);
   
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/src/web-ui/src/flow_chat/hooks/useAcpPlan.ts
+++ b/src/web-ui/src/flow_chat/hooks/useAcpPlan.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { AcpPlanEntry } from '@/infrastructure/api/service-api/ACPClientAPI';
+import { ACPClientAPI } from '@/infrastructure/api/service-api/ACPClientAPI';
+import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
+
+export function useAcpPlan(sessionId: string | null): { entries: AcpPlanEntry[] } {
+  const [entries, setEntries] = useState<AcpPlanEntry[]>([]);
+  const latestTurnIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    latestTurnIdRef.current = null;
+    setEntries([]);
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) return;
+
+    return ACPClientAPI.onPlanUpdated((event) => {
+      if (event.sessionId !== sessionId) return;
+      latestTurnIdRef.current = event.turnId;
+      setEntries(event.entries);
+    });
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const maybeClear = (event: { sessionId?: string; turnId?: string }) => {
+      if (event.sessionId !== sessionId) return;
+      const latestTurnId = latestTurnIdRef.current;
+      if (!latestTurnId || event.turnId === latestTurnId) {
+        latestTurnIdRef.current = null;
+        setEntries([]);
+      }
+    };
+
+    const unlistenCompleted = agentAPI.onDialogTurnCompleted(maybeClear);
+    const unlistenCancelled = agentAPI.onDialogTurnCancelled(maybeClear);
+    const unlistenFailed = agentAPI.onDialogTurnFailed(maybeClear);
+
+    return () => {
+      unlistenCompleted();
+      unlistenCancelled();
+      unlistenFailed();
+    };
+  }, [sessionId]);
+
+  return { entries };
+}

--- a/src/web-ui/src/flow_chat/hooks/useAcpSlashCommands.test.ts
+++ b/src/web-ui/src/flow_chat/hooks/useAcpSlashCommands.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AcpAvailableCommand } from '@/infrastructure/api/service-api/ACPClientAPI';
+import { acpSessionRef, acpSlashCommandText } from '../utils/acpSession';
+import { filterSlashCommands } from './useAcpSlashCommands';
+
+const commands: AcpAvailableCommand[] = [
+  { name: 'compact', description: 'Compact the conversation context' },
+  { name: 'init', description: 'Initialize the project' },
+  { name: 'create_plan', description: 'Draft an execution plan', inputHint: 'what to plan' },
+];
+
+describe('filterSlashCommands', () => {
+  it('returns all commands for an empty query', () => {
+    expect(filterSlashCommands(commands, '')).toHaveLength(3);
+    expect(filterSlashCommands(commands, '   ')).toHaveLength(3);
+  });
+
+  it('tolerates a leading slash', () => {
+    expect(filterSlashCommands(commands, '/comp').map((command) => command.name)).toEqual([
+      'compact',
+    ]);
+  });
+
+  it('matches command names case-insensitively', () => {
+    expect(filterSlashCommands(commands, 'INIT').map((command) => command.name)).toEqual([
+      'init',
+    ]);
+  });
+
+  it('matches descriptions', () => {
+    expect(filterSlashCommands(commands, 'plan').map((command) => command.name)).toEqual([
+      'create_plan',
+    ]);
+  });
+
+  it('returns empty when nothing matches', () => {
+    expect(filterSlashCommands(commands, 'zzz')).toEqual([]);
+  });
+});
+
+describe('acpSlashCommandText', () => {
+  it('formats command names as invokable prompt text', () => {
+    expect(acpSlashCommandText('create_plan')).toBe('/create_plan ');
+  });
+});
+
+describe('acpSessionRef', () => {
+  it('returns null for a non-ACP session', () => {
+    expect(
+      acpSessionRef({
+        sessionId: 's1',
+        config: { agentType: 'agentic' },
+        mode: 'agentic',
+      } as never),
+    ).toBeNull();
+  });
+
+  it('returns null when there is no session', () => {
+    expect(acpSessionRef(null)).toBeNull();
+    expect(acpSessionRef(undefined)).toBeNull();
+  });
+
+  it('derives the client id from an acp agent type', () => {
+    const ref = acpSessionRef({
+      sessionId: 's1',
+      config: { agentType: 'acp:omp', workspacePath: '/ws' },
+      workspacePath: '/ws',
+      remoteConnectionId: 'conn-1',
+      remoteSshHost: 'host-1',
+    } as never);
+
+    expect(ref).toEqual({
+      sessionId: 's1',
+      clientId: 'omp',
+      workspacePath: '/ws',
+      remoteConnectionId: 'conn-1',
+      remoteSshHost: 'host-1',
+    });
+  });
+
+  it('falls back to mode when config.agentType is not acp', () => {
+    const ref = acpSessionRef({
+      sessionId: 's2',
+      config: {},
+      mode: 'acp:claude-code',
+    } as never);
+
+    expect(ref?.clientId).toBe('claude-code');
+    expect(ref?.sessionId).toBe('s2');
+  });
+});

--- a/src/web-ui/src/flow_chat/hooks/useAcpSlashCommands.ts
+++ b/src/web-ui/src/flow_chat/hooks/useAcpSlashCommands.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+
+import {
+  ACPClientAPI,
+  type AcpAvailableCommand,
+} from '@/infrastructure/api/service-api/ACPClientAPI';
+import type { AcpSessionRef } from '../utils/acpSession';
+
+export function filterSlashCommands(
+  commands: AcpAvailableCommand[],
+  query: string,
+): AcpAvailableCommand[] {
+  const q = query.trim().toLowerCase().replace(/^\//, '');
+  if (!q) return commands;
+
+  return commands.filter(
+    (command) =>
+      command.name.toLowerCase().includes(q) ||
+      command.description.toLowerCase().includes(q),
+  );
+}
+
+export function useAcpSlashCommands(
+  acpSession: AcpSessionRef | null,
+): { commands: AcpAvailableCommand[] } {
+  const [commands, setCommands] = useState<AcpAvailableCommand[]>([]);
+
+  const sessionId = acpSession?.sessionId ?? null;
+  const clientId = acpSession?.clientId ?? null;
+  const workspacePath = acpSession?.workspacePath;
+  const remoteConnectionId = acpSession?.remoteConnectionId;
+  const remoteSshHost = acpSession?.remoteSshHost;
+
+  useEffect(() => {
+    setCommands([]);
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId || !clientId) return;
+
+    let cancelled = false;
+    ACPClientAPI.getSessionCommands({
+      sessionId,
+      clientId,
+      workspacePath,
+      remoteConnectionId,
+      remoteSshHost,
+    })
+      .then((list) => {
+        if (!cancelled) setCommands(list);
+      })
+      .catch(() => {
+        if (!cancelled) setCommands([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, clientId, workspacePath, remoteConnectionId, remoteSshHost]);
+
+  useEffect(() => {
+    if (!sessionId || !clientId) return;
+
+    return ACPClientAPI.onAvailableCommandsUpdated((event) => {
+      if (event.sessionId === sessionId && event.clientId === clientId) {
+        setCommands(event.commands);
+      }
+    });
+  }, [sessionId, clientId]);
+
+  return { commands };
+}

--- a/src/web-ui/src/flow_chat/utils/acpSession.ts
+++ b/src/web-ui/src/flow_chat/utils/acpSession.ts
@@ -22,3 +22,40 @@ export function isAcpFlowSession(
     isAcpAgentType(session?.mode),
   );
 }
+
+export interface AcpSessionRef {
+  sessionId: string;
+  clientId: string;
+  workspacePath?: string;
+  remoteConnectionId?: string;
+  remoteSshHost?: string;
+}
+
+export function acpSessionRef(
+  session:
+    | Pick<
+        Session,
+        'sessionId' | 'config' | 'mode' | 'workspacePath' | 'remoteConnectionId' | 'remoteSshHost'
+      >
+    | null
+    | undefined,
+): AcpSessionRef | null {
+  if (!session?.sessionId) return null;
+
+  const clientId =
+    acpClientIdFromAgentType(session.config?.agentType) ??
+    acpClientIdFromAgentType(session.mode);
+  if (!clientId) return null;
+
+  return {
+    sessionId: session.sessionId,
+    clientId,
+    workspacePath: session.workspacePath ?? session.config?.workspacePath,
+    remoteConnectionId: session.remoteConnectionId ?? session.config?.remoteConnectionId,
+    remoteSshHost: session.remoteSshHost,
+  };
+}
+
+export function acpSlashCommandText(name: string): string {
+  return `/${name} `;
+}

--- a/src/web-ui/src/infrastructure/api/service-api/ACPClientAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ACPClientAPI.ts
@@ -113,6 +113,36 @@ export interface AcpSessionOptions {
   contextUsage?: AcpContextUsage;
 }
 
+export interface AcpAvailableCommand {
+  name: string;
+  description: string;
+  inputHint?: string;
+}
+
+export interface AcpAvailableCommandsUpdatedEvent {
+  sessionId: string;
+  clientId: string;
+  commands: AcpAvailableCommand[];
+}
+
+export interface AcpPlanEntry {
+  content: string;
+  priority: 'high' | 'medium' | 'low' | string;
+  status: 'pending' | 'in_progress' | 'completed' | string;
+}
+
+export interface AcpPlanUpdatedEvent {
+  sessionId: string;
+  turnId: string;
+  clientId: string;
+  entries: AcpPlanEntry[];
+}
+
+export interface AcpSessionOptionsChangedEvent {
+  sessionId: string;
+  clientId: string;
+}
+
 export interface SubmitAcpPermissionResponseRequest {
   permissionId: string;
   approve: boolean;
@@ -281,10 +311,38 @@ export class ACPClientAPI {
     return api.invoke('get_acp_session_options', { request });
   }
 
+  static async getSessionCommands(
+    request: GetAcpSessionOptionsRequest
+  ): Promise<AcpAvailableCommand[]> {
+    return api.invoke('get_acp_session_commands', { request });
+  }
+
   static async setSessionModel(
     request: SetAcpSessionModelRequest
   ): Promise<AcpSessionOptions> {
     return api.invoke('set_acp_session_model', { request });
+  }
+
+  static onAvailableCommandsUpdated(
+    callback: (event: AcpAvailableCommandsUpdatedEvent) => void
+  ): () => void {
+    return api.listen<AcpAvailableCommandsUpdatedEvent>(
+      'agentic://acp-available-commands-updated',
+      callback
+    );
+  }
+
+  static onPlanUpdated(callback: (event: AcpPlanUpdatedEvent) => void): () => void {
+    return api.listen<AcpPlanUpdatedEvent>('agentic://acp-plan-updated', callback);
+  }
+
+  static onSessionOptionsChanged(
+    callback: (event: AcpSessionOptionsChangedEvent) => void
+  ): () => void {
+    return api.listen<AcpSessionOptionsChangedEvent>(
+      'agentic://acp-session-options-changed',
+      callback
+    );
   }
 }
 

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -556,6 +556,9 @@
     "promptCacheGuardCancel": "Stay here",
     "quickAction": "Quick action",
     "commands": "Commands",
+    "acpPlan": {
+      "title": "Plan"
+    },
     "compactAction": "Compact session",
     "compactNoSession": "No active session for /compact",
     "compactBusy": "Wait until the session is idle before using /compact.",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -556,6 +556,9 @@
     "promptCacheGuardCancel": "先不发送",
     "quickAction": "快捷操作",
     "commands": "命令",
+    "acpPlan": {
+      "title": "计划"
+    },
     "compactAction": "压缩会话",
     "compactNoSession": "当前没有可用于 /compact 的会话",
     "compactBusy": "请等待当前会话空闲后再使用 /compact。",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -556,6 +556,9 @@
     "promptCacheGuardCancel": "先不發送",
     "quickAction": "快捷操作",
     "commands": "指令",
+    "acpPlan": {
+      "title": "計畫"
+    },
     "compactAction": "壓縮會話",
     "compactNoSession": "目前沒有可用於 /compact 的會話",
     "compactBusy": "請等待目前會話空閒後再使用 /compact。",


### PR DESCRIPTION
## Summary
- Follows up the work from PR #979 on current main after that branch hit merge conflicts.
- Re-applies the ACP SessionUpdate plumbing for AvailableCommandsUpdate, Plan, and ConfigOptionUpdate.
- Adds ACP slash command picker integration and a live plan panel in ChatInput.
- Completes the follow-up fixes from review: plan state is scoped to the active turn lifecycle, ModelSelector refreshes on config option updates, frontend events route through the shared API adapter, and the plan panel title uses i18n.

## Verification
- pnpm run fmt:rs
- cargo test -p bitfun-acp
- cargo check -p bitfun-desktop
- pnpm --dir src/web-ui run test:run src/flow_chat/hooks/useAcpSlashCommands.test.ts
- pnpm run type-check:web
- pnpm run i18n:audit