### PR TITLE
fix(acp): isolate provider slash commands

### DIFF
--- a/src/crates/acp/src/client/manager.rs
+++ b/src/crates/acp/src/client/manager.rs
@@ -65,6 +65,8 @@ const PERMISSION_TIMEOUT: Duration = Duration::from_secs(600);
 const SESSION_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
 const LOAD_REPLAY_DRAIN_QUIET_WINDOW: Duration = Duration::from_millis(250);
 const LOAD_REPLAY_DRAIN_MAX_DURATION: Duration = Duration::from_secs(2);
+const SESSION_METADATA_DRAIN_QUIET_WINDOW: Duration = Duration::from_millis(250);
+const SESSION_METADATA_DRAIN_MAX_DURATION: Duration = Duration::from_secs(2);
 const TURN_COMPLETION_DRAIN_QUIET_WINDOW: Duration = Duration::from_millis(250);
 const TURN_COMPLETION_DRAIN_MAX_DURATION: Duration = Duration::from_secs(2);
 
@@ -510,10 +512,13 @@ impl AcpClientService {
         workspace_path: Option<&str>,
         remote_connection_id: Option<&str>,
     ) -> BitFunResult<()> {
-        if let Some(existing) = self.clients.get(connection_id) {
+        if let Some(existing) = self.clients.get(connection_id).map(|entry| entry.clone()) {
             let status = *existing.status.read().await;
-            if matches!(status, AcpClientStatus::Running | AcpClientStatus::Starting) {
+            if matches!(status, AcpClientStatus::Running) {
                 return Ok(());
+            }
+            if matches!(status, AcpClientStatus::Starting) {
+                return wait_for_client_connection(existing, connection_id).await;
             }
         }
 
@@ -865,6 +870,7 @@ impl AcpClientService {
             &mut session,
         )
         .await?;
+        drain_pending_session_metadata_updates(&mut session).await?;
         Ok(session_options_from_state(
             session.models.as_ref(),
             &session.config_options,
@@ -899,6 +905,7 @@ impl AcpClientService {
             &mut session,
         )
         .await?;
+        drain_pending_session_metadata_updates(&mut session).await?;
         Ok(session.available_commands.clone())
     }
 
@@ -1811,6 +1818,32 @@ impl AcpClientConnection {
     }
 }
 
+async fn wait_for_client_connection(
+    client: Arc<AcpClientConnection>,
+    connection_id: &str,
+) -> BitFunResult<()> {
+    let started_at = Instant::now();
+    loop {
+        if client.connection.read().await.is_some() {
+            return Ok(());
+        }
+
+        let status = *client.status.read().await;
+        if matches!(status, AcpClientStatus::Failed | AcpClientStatus::Stopped) {
+            return Err(BitFunError::service(format!(
+                "ACP client '{}' is not running",
+                connection_id
+            )));
+        }
+
+        if started_at.elapsed() >= CLIENT_STARTUP_TIMEOUT {
+            return Err(startup_timeout_error(&client.client_id, "initialize"));
+        }
+
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
 fn parse_config_value(value: serde_json::Value) -> BitFunResult<AcpClientConfigFile> {
     if value.get("acpClients").is_some() {
         serde_json::from_value(value)
@@ -2177,6 +2210,50 @@ fn append_agent_text(output: &mut String, events: Vec<AcpClientStreamEvent>) {
             output.push_str(&text);
         }
     }
+}
+
+async fn drain_pending_session_metadata_updates(
+    session: &mut AcpRemoteSession,
+) -> BitFunResult<()> {
+    let started_at = Instant::now();
+    let mut drained_count = 0usize;
+    let mut tool_call_tracker = AcpToolCallTracker::new();
+
+    while started_at.elapsed() < SESSION_METADATA_DRAIN_MAX_DURATION {
+        let update = {
+            let Some(active) = session.active.as_mut() else {
+                return Ok(());
+            };
+            tokio::time::timeout(SESSION_METADATA_DRAIN_QUIET_WINDOW, active.read_update()).await
+        };
+
+        match update {
+            Ok(Ok(SessionMessage::SessionMessage(dispatch))) => {
+                let events =
+                    acp_dispatch_to_stream_events_with_tracker(dispatch, &mut tool_call_tracker)
+                        .await?;
+                update_session_from_events(session, &events);
+                drained_count += 1;
+            }
+            Ok(Ok(SessionMessage::StopReason(_))) => {
+                drained_count += 1;
+            }
+            Ok(Ok(_)) => {
+                drained_count += 1;
+            }
+            Ok(Err(error)) => return Err(protocol_error(error)),
+            Err(_) => break,
+        }
+    }
+
+    if drained_count > 0 {
+        debug!(
+            "Drained ACP session metadata updates: count={}",
+            drained_count
+        );
+    }
+
+    Ok(())
 }
 
 async fn discard_pending_session_updates_if_needed(session: &mut AcpRemoteSession) {

--- a/src/web-ui/src/flow_chat/components/ChatInput.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInput.scss
@@ -1220,11 +1220,12 @@
   
   &__slash-command-item {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: var(--flowchat-control-gap, 0.5rem);
     padding: var(--flowchat-inline-gap, 0.35rem) var(--flowchat-card-expanded-pad-x, 0.625rem);
     cursor: pointer;
     transition: all 0.15s ease;
+    min-width: 0;
     
     &:hover {
       background: var(--element-bg-soft);
@@ -1246,13 +1247,23 @@
     font-weight: 500;
     color: rgba(120, 160, 255, 0.9);
     font-family: var(--font-mono);
-    min-width: 100px;
+    flex: 0 0 112px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   
   &__slash-command-label {
     font-size: var(--flowchat-font-size-2xs);
     color: var(--color-text-secondary);
     flex: 1;
+    min-width: 0;
+    line-height: 1.35;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
   }
   
   &__slash-command-current {
@@ -1262,6 +1273,7 @@
     background: rgba(100, 140, 255, 0.15);
     color: rgba(140, 180, 255, 0.9);
     font-weight: 500;
+    flex: 0 0 auto;
   }
   
   &__slash-command-empty {

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -293,6 +293,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     [effectiveTargetSession],
   );
   const { commands: acpAgentCommands } = useAcpSlashCommands(acpSessionForInput);
+  const isAcpInputSession = Boolean(acpSessionForInput);
   const { entries: acpPlanEntries } = useAcpPlan(acpSessionForInput?.sessionId ?? null);
   const threadGoalController = useThreadGoalController(effectiveTargetSession, {
     isBtwSession,
@@ -849,6 +850,26 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     setChatPopupActive(slashCommandState.isActive || mentionState.isActive);
   }, [slashCommandState.isActive, mentionState.isActive]);
 
+  useEffect(() => {
+    if (!slashCommandState.isActive) {
+      return;
+    }
+
+    const frameId = requestAnimationFrame(() => {
+      const selectedItem = containerRef.current?.querySelector(
+        '.bitfun-chat-input__slash-command-list .bitfun-chat-input__slash-command-item--selected'
+      ) as HTMLElement | null;
+      selectedItem?.scrollIntoView({ block: 'nearest' });
+    });
+
+    return () => cancelAnimationFrame(frameId);
+  }, [
+    slashCommandState.isActive,
+    slashCommandState.kind,
+    slashCommandState.query,
+    slashCommandState.selectedIndex,
+  ]);
+
   const clearPendingLargePastes = useCallback(() => {
     pendingLargePastesRef.current = {};
   }, []);
@@ -1391,6 +1412,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   }, [effectiveTargetSessionId, workspacePath, derivedState?.isProcessing]);
 
   const getFilteredActions = useCallback(() => {
+    if (isAcpInputSession) {
+      return [];
+    }
+
     const items: SlashActionItem[] = [
       ...(isBtwSession
         ? []
@@ -1435,7 +1460,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
           ]
         : []),
     ];
-
     const q = (slashCommandState.query || '').trim().toLowerCase();
     if (!q) return items;
 
@@ -1443,9 +1467,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       const cmd = i.command.slice(1).toLowerCase();
       return cmd.includes(q) || i.label.toLowerCase().includes(q);
     });
-  }, [derivedState?.isProcessing, isBtwSession, slashCommandState.query, t]);
+  }, [derivedState?.isProcessing, isAcpInputSession, isBtwSession, slashCommandState.query, t]);
 
   const getFilteredMcpPromptCommands = useCallback((): SlashMcpPromptItem[] => {
+    if (isAcpInputSession) {
+      return [];
+    }
+
     const q = (slashCommandState.query || '').trim().toLowerCase();
     if (!q) {
       return mcpPromptCommands;
@@ -1459,7 +1487,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         item.label.toLowerCase().includes(q)
       );
     });
-  }, [mcpPromptCommands, slashCommandState.query]);
+  }, [isAcpInputSession, mcpPromptCommands, slashCommandState.query]);
 
   const getFilteredAcpCommands = useCallback((): SlashAcpCommandItem[] => {
     return filterSlashCommands(acpAgentCommands, slashCommandState.query).map(command => ({
@@ -1487,9 +1515,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   }, [mcpPromptCommands]);
 
   const getSlashPickerItems = useCallback((): SlashPickerItem[] => {
+    const acpCommands = getFilteredAcpCommands();
+    if (isAcpInputSession) {
+      return acpCommands;
+    }
+
     const actions = getFilteredActions();
     const mcpPrompts = getFilteredMcpPromptCommands();
-    const acpCommands = getFilteredAcpCommands();
     let modeList = incrementalCodeModes;
     if (canSwitchModes && slashCommandState.query) {
       const q = slashCommandState.query;
@@ -1505,7 +1537,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       name: mode.name,
     }));
     return [...acpCommands, ...actions, ...mcpPrompts, ...modes];
-  }, [canSwitchModes, getFilteredActions, getFilteredAcpCommands, getFilteredMcpPromptCommands, incrementalCodeModes, slashCommandState.query]);
+  }, [canSwitchModes, getFilteredActions, getFilteredAcpCommands, getFilteredMcpPromptCommands, incrementalCodeModes, isAcpInputSession, slashCommandState.query]);
   
   const handleInputChange = useCallback((text: string, activeContexts: import('../../shared/types/context').ContextItem[]) => {
     if (!inputState.isActive && text.length > 0) {
@@ -1527,12 +1559,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     dispatchInput({ type: 'SET_VALUE', payload: text });
     inputValueRef.current = text;
 
+    const localSlashCommandsEnabled = !isAcpInputSession;
     const trimmedLower = text.trim().toLowerCase();
-    const isBtwCommand = trimmedLower.startsWith('/btw');
-    const isCompactCommand = trimmedLower.startsWith('/compact');
-    const isGoalCommand = isGoalSlashCommand(text);
-    const isUsageCommand = trimmedLower.startsWith('/usage');
-    const isDeepReviewCommand = isDeepReviewSlashCommand(text);
+    const isBtwCommand = localSlashCommandsEnabled && trimmedLower.startsWith('/btw');
+    const isCompactCommand = localSlashCommandsEnabled && trimmedLower.startsWith('/compact');
+    const isGoalCommand = localSlashCommandsEnabled && isGoalSlashCommand(text);
+    const isUsageCommand = localSlashCommandsEnabled && trimmedLower.startsWith('/usage');
+    const isDeepReviewCommand = localSlashCommandsEnabled && isDeepReviewSlashCommand(text);
     const isProcessing = !!derivedState?.isProcessing;
 
     // Don't queue /btw or /goal while the main session is processing; they have dedicated flows.
@@ -1544,10 +1577,26 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       const afterSlash = text.slice(1);
       const hasWhitespace = /\s/.test(afterSlash);
       const query = afterSlash.trimStart().split(/\s+/, 1)[0]?.toLowerCase?.() ?? '';
-      const matchedMcpPrompt = resolveTypedMcpPromptCommand(text);
+      const matchedMcpPrompt = localSlashCommandsEnabled
+        ? resolveTypedMcpPromptCommand(text)
+        : null;
+
+      if (isAcpInputSession && hasWhitespace) {
+        if (slashCommandState.isActive) {
+          setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
+        }
+        return;
+      }
 
       // While the main session is running, expose a single quick action (/btw) via the same picker UX.
       if (isProcessing) {
+        if (!localSlashCommandsEnabled) {
+          if (slashCommandState.isActive) {
+            setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
+          }
+          return;
+        }
+
         // Only show the picker for "/..." patterns that are plausibly a command (/ or /b... /d...).
         // Once the user types a space (starts composing the real question), stop showing the picker
         // so Enter can submit "/btw ..." or "/DeepReview ..." instead of selecting from the picker.
@@ -1584,7 +1633,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         selectedIndex: 0,
       });
     }
-  }, [contexts, derivedState, inputState.isActive, prunePendingLargePastes, removeContext, resolveTypedMcpPromptCommand, setQueuedInput, slashCommandState.isActive, slashCommandState.kind]);
+  }, [contexts, derivedState, inputState.isActive, isAcpInputSession, prunePendingLargePastes, removeContext, resolveTypedMcpPromptCommand, setQueuedInput, slashCommandState.isActive, slashCommandState.kind]);
 
   const submitBtwFromInput = useCallback(async () => {
     if (!derivedState) return;
@@ -2123,65 +2172,66 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     const originalPendingLargePastes = { ...pendingLargePastesRef.current };
     const message = expandComposerSpecialTokens(originalMessage);
     const messageCharCount = getCharacterCount(message);
+    const localSlashCommandsEnabled = !isAcpInputSession;
 
-    if (message.toLowerCase().startsWith('/btw')) {
+    if (localSlashCommandsEnabled && message.toLowerCase().startsWith('/btw')) {
       // When idle, /btw can be sent via the normal send button.
       await submitBtwFromInput();
       return;
     }
 
-    if (isGoalSlashCommand(message)) {
+    if (localSlashCommandsEnabled && isGoalSlashCommand(message)) {
       await submitGoalFromInput();
       return;
     }
 
-    if (/^\/compact\s*$/i.test(message)) {
+    if (localSlashCommandsEnabled && /^\/compact\s*$/i.test(message)) {
       await submitCompactFromInput();
       return;
     }
 
-    if (/^\/usage\s*$/i.test(message)) {
+    if (localSlashCommandsEnabled && /^\/usage\s*$/i.test(message)) {
       await submitUsageFromInput();
       return;
     }
 
-    if (/^\/init\s*$/i.test(message)) {
+    if (localSlashCommandsEnabled && /^\/init\s*$/i.test(message)) {
       await submitInitFromInput();
       return;
     }
 
-    if (isDeepReviewSlashCommand(message)) {
+    if (localSlashCommandsEnabled && isDeepReviewSlashCommand(message)) {
       await submitDeepreviewFromInput();
       return;
     }
 
-    if (resolveTypedMcpPromptCommand(message)) {
+    if (localSlashCommandsEnabled && resolveTypedMcpPromptCommand(message)) {
       await submitMcpPromptFromInput();
       return;
     }
 
-    if (message.toLowerCase().startsWith('/compact')) {
+    if (localSlashCommandsEnabled && message.toLowerCase().startsWith('/compact')) {
       notificationService.warning(
         t('chatInput.compactUsage')
       );
       return;
     }
 
-    if (message.toLowerCase().startsWith('/usage')) {
+    if (localSlashCommandsEnabled && message.toLowerCase().startsWith('/usage')) {
       notificationService.warning(
         t('chatInput.usageCommandUsage')
       );
       return;
     }
 
-    if (message.toLowerCase().startsWith('/init')) {
+    if (localSlashCommandsEnabled && message.toLowerCase().startsWith('/init')) {
       notificationService.warning(
         t('chatInput.initUsage')
       );
       return;
     }
 
-    if (message.toLowerCase().startsWith('/goal') && !isGoalSlashCommand(message)) {
+    if (localSlashCommandsEnabled && message.toLowerCase().startsWith('/goal') && !isGoalSlashCommand(message)) {
       notificationService.warning(
         t('chatInput.goalUsage')
       );
@@ -2245,6 +2295,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     effectiveTargetSessionId,
     clearPendingLargePastes,
     expandComposerSpecialTokens,
+    isAcpInputSession,
     setQueuedInput,
     submitBtwFromInput,
     submitGoalFromInput,
@@ -3103,36 +3154,42 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                             {t('chatInput.loadingMcpPrompts')}
                           </div>
                         ) : items.length > 0 ? (
-                          items.map((item, index) => (
-                            <div
-                              key={`${item.kind}-${item.id}`}
-                              className={`bitfun-chat-input__slash-command-item ${index === slashCommandState.selectedIndex ? 'bitfun-chat-input__slash-command-item--selected' : ''} ${item.kind === 'mode' && item.id === modeState.current ? 'bitfun-chat-input__slash-command-item--active' : ''}`}
-                              onClick={() => {
-                                if (item.kind === 'mode') {
-                                  selectSlashCommandMode(item.id);
-                                } else if (item.kind === 'mcpPrompt') {
-                                  selectSlashPromptCommand(item);
-                                } else if (item.kind === 'acpCommand') {
-                                  selectSlashAcpCommand(item);
-                                } else {
-                                  selectSlashCommandAction(item.id);
-                                }
-                              }}
-                              onMouseEnter={() => setSlashCommandState(prev => ({ ...prev, selectedIndex: index }))}
-                            >
-                              <span className="bitfun-chat-input__slash-command-name">
-                                {item.kind === 'mode' ? `/${item.id}` : item.command}
-                              </span>
-                              <span className="bitfun-chat-input__slash-command-label">
-                                {item.kind === 'mode'
-                                  ? item.name
-                                  : item.kind === 'mcpPrompt'
-                                    ? `${item.serverName} · ${item.label}`
-                                    : item.label}
-                              </span>
-                              {item.kind === 'mode' && item.id === modeState.current && <span className="bitfun-chat-input__slash-command-current">{t('chatInput.current')}</span>}
-                            </div>
-                          ))
+                          items.map((item, index) => {
+                            const commandText = item.kind === 'mode' ? `/${item.id}` : item.command;
+                            const labelText = item.kind === 'mode'
+                              ? item.name
+                              : item.kind === 'mcpPrompt'
+                                ? `${item.serverName} · ${item.label}`
+                                : item.label;
+
+                            return (
+                              <div
+                                key={`${item.kind}-${item.id}`}
+                                className={`bitfun-chat-input__slash-command-item ${index === slashCommandState.selectedIndex ? 'bitfun-chat-input__slash-command-item--selected' : ''} ${item.kind === 'mode' && item.id === modeState.current ? 'bitfun-chat-input__slash-command-item--active' : ''}`}
+                                title={`${commandText}\n${labelText}`}
+                                onClick={() => {
+                                  if (item.kind === 'mode') {
+                                    selectSlashCommandMode(item.id);
+                                  } else if (item.kind === 'mcpPrompt') {
+                                    selectSlashPromptCommand(item);
+                                  } else if (item.kind === 'acpCommand') {
+                                    selectSlashAcpCommand(item);
+                                  } else {
+                                    selectSlashCommandAction(item.id);
+                                  }
+                                }}
+                                onMouseEnter={() => setSlashCommandState(prev => ({ ...prev, selectedIndex: index }))}
+                              >
+                                <span className="bitfun-chat-input__slash-command-name">
+                                  {commandText}
+                                </span>
+                                <span className="bitfun-chat-input__slash-command-label">
+                                  {labelText}
+                                </span>
+                                {item.kind === 'mode' && item.id === modeState.current && <span className="bitfun-chat-input__slash-command-current">{t('chatInput.current')}</span>}
+                              </div>
+                            );
+                          })
                         ) : (
                           <div className="bitfun-chat-input__slash-command-empty">
                             {t('chatInput.noMatchingCommand')}


### PR DESCRIPTION
## Summary
- drain pending ACP session metadata updates before returning session commands/options
- wait for in-flight ACP client startup instead of treating Starting as connected
- isolate ACP slash command picker from BitFun local commands, clamp long descriptions, and keep keyboard selection scrolled into view

## Testing
- pnpm run fmt:rs
- cargo check -p bitfun-acp
- cargo test -p bitfun-acp
- pnpm run type-check:web