### PR TITLE
refactor(runtime): migrate scheduler owner decisions

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -57,7 +57,9 @@
 - `bitfun-agent-runtime` 已建立为可独立构建的 Agent Runtime SDK owner crate，当前承接 scheduler/background
   delivery 纯决策，thread goal runtime 的 turn accounting、goal mutation、continuation plan 和 tool response assembly，
   subagent query scope / visibility / availability 决策，以及 round-boundary yield / injection state 和
-  turn-outcome queue policy；prompt-loop 的 user-context policy、tool / skill / subagent listing reminder
+  turn-outcome queue policy、dialog turn queue、active-turn facts、background running-turn injection construction、
+  steering action、agent-session reply plan、cancelled-reply suppression state 和
+  goal-continuation abort flags；prompt-loop 的 user-context policy、tool / skill / subagent listing reminder
   ordering、prompt cache policy / identity / DTO / scope key / in-memory store、shared mode profile / context policy、
   mode / subagent source presentation facts 已归入该 crate；finish-reason label、session-state event label 和
   turn-outcome event fact 也已由 `bitfun-agent-runtime` 承接，core 只保留旧路径 re-export 或 concrete adapter。
@@ -70,7 +72,7 @@
 明确未完成：
 
 - `bitfun-agent-runtime` 不代表 session manager、session persistence / prompt-cache cold restore、concrete prompt assembly、
-  concrete agent definition loading、custom subagent file IO、scheduler 生命周期、event delivery、permission `Tool` handler
+  concrete agent definition loading、custom subagent file IO、scheduler concrete 生命周期、event delivery、permission `Tool` handler
   或 post-turn hook 已迁移；当前 event 迁移只覆盖无副作用的 wire label / fact 映射。
 - thread goal 的 metadata store、token subscriber、scheduler delivery adapter 和 goal `Tool` handler 仍在
   `bitfun-core`；runtime 决策已经归属 `bitfun-agent-runtime`，后续不应再把它误归入普通 concrete tool IO。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -125,12 +125,17 @@ PR-C 评估后不继续迁移的内容：MiniApp worker process / host dispatch 
 
 ### 5.2 Agent Registry / Scheduler Owner
 
-- 先迁移只读 facts、queue policy decision、runtime event facts，不先移动 concrete scheduler 生命周期。
-- 保留 mode-scoped visibility、hidden/custom/review grouping、background result delivery、running-turn injection、idle-session follow-up 和 persisted thread goal continuation 语义。
+- 已迁移只读 facts、queue policy decision、queue state、active-turn facts、background running-turn injection
+  construction、steering action、agent-session reply plan、cancelled-reply suppression state、goal-continuation abort flags 和 runtime event facts；
+  不移动 concrete scheduler 生命周期。
+- 保留 mode-scoped visibility、hidden/custom/review grouping、background delivery entrypoint、idle-session follow-up 和 persisted thread goal continuation 语义。
 - thread goal runtime、subagent visibility/availability、round-boundary yield/injection、turn-outcome queue
-  policy、finish-reason label、session-state event label 和 turn-outcome event fact 已归入
+  policy、dialog turn queue、active-turn state、background running-turn injection construction、steering action、
+  agent-session reply plan、cancel suppression、finish-reason label、session-state event label 和 turn-outcome event fact 已归入
   `bitfun-agent-runtime`；后续只允许 core 继续作为 metadata store、config/file IO adapter、concrete prompt
   assembly、concrete scheduler lifecycle、scheduler delivery、event delivery 和 `Tool` adapter。
+- 若继续迁移 scheduler lifecycle、event delivery、permission `Tool` handler 或 post-turn hook，必须先补端到端等价保护，
+  不能只用 owner contract test 证明。
 - 验证 subagent availability、queue/preempt/cancel suppression、DeepResearch citation / post-turn hook、goal verification events、`get_goal` / `create_goal` / `update_goal` tool response wire shape。
 
 ### 5.3 Product-Domain Runtime Owner

--- a/scripts/check-core-boundaries.mjs
+++ b/scripts/check-core-boundaries.mjs
@@ -976,6 +976,61 @@ const forbiddenContentRules = [
     path: 'src/crates/core/src/agentic/coordination/scheduler.rs',
     patterns: [
       {
+        regex: /\bconst\s+MAX_QUEUE_DEPTH\b/,
+        message:
+          'core scheduler must not own dialog queue capacity; use bitfun-agent-runtime scheduler',
+      },
+      {
+        regex: /\bstd::collections::VecDeque\b/,
+        message:
+          'core scheduler must not own dialog queue storage; use bitfun-agent-runtime scheduler',
+      },
+      {
+        regex: /\bdashmap::DashMap\b/,
+        message:
+          'core scheduler must not own scheduler state maps; use bitfun-agent-runtime scheduler stores',
+      },
+      {
+        regex: /\bstruct\s+ActiveTurn\b/,
+        message:
+          'core scheduler must not own active-turn facts; use bitfun-agent-runtime scheduler',
+      },
+      {
+        regex: /\bfn\s+format_agent_session_reply\b/,
+        message:
+          'core scheduler must not own agent-session reply text assembly; use bitfun-agent-runtime scheduler',
+      },
+      {
+        regex: /automated reply to a previous SessionMessage call/,
+        message:
+          'core scheduler must not own agent-session reply reminder text; use bitfun-agent-runtime scheduler',
+      },
+      {
+        regex: /RoundInjectionKind::UserSteering/,
+        message:
+          'core scheduler must not own steering injection construction; use bitfun-agent-runtime scheduler',
+      },
+      {
+        regex: /RoundInjectionTarget::ExactTurn/,
+        message:
+          'core scheduler must not own steering exact-turn targeting; use bitfun-agent-runtime scheduler',
+      },
+      {
+        regex: /RoundInjectionKind::ThreadGoalObjectiveUpdated/,
+        message:
+          'core scheduler must not own thread-goal background injection construction; use bitfun-agent-runtime scheduler',
+      },
+      {
+        regex: /RoundInjectionKind::BackgroundResult/,
+        message:
+          'core scheduler must not own background result injection construction; use bitfun-agent-runtime scheduler',
+      },
+      {
+        regex: /RoundInjectionTarget::CurrentRunningTurn/,
+        message:
+          'core scheduler must not own current-turn background injection targeting; use bitfun-agent-runtime scheduler',
+      },
+      {
         regex: /\bfn\s+turn_outcome_kind\s*\(/,
         message:
           'core scheduler must not own turn-outcome event facts; use bitfun-agent-runtime events',
@@ -3781,17 +3836,13 @@ const requiredContentRules = [
       },
       {
         regex:
-          /use bitfun_runtime_ports::\{(?=[\s\S]*DialogSessionStateFact)(?=[\s\S]*DialogSubmitQueueAction)(?=[\s\S]*DialogSubmitQueueFacts)(?=[\s\S]*resolve_dialog_submit_queue_action)(?=[\s\S]*should_skip_agent_session_reply_contract)(?=[\s\S]*should_suppress_agent_session_cancelled_reply_contract)[\s\S]*\};/,
+          /use bitfun_runtime_ports::\{(?=[\s\S]*DialogSessionStateFact)(?=[\s\S]*DialogSubmitQueueAction)(?=[\s\S]*DialogSubmitQueueFacts)(?=[\s\S]*resolve_dialog_submit_queue_action)[\s\S]*\};/,
         message: 'missing dialog scheduler decision contract import',
       },
       {
-        regex: /use bitfun_agent_runtime::events::turn_outcome_kind;/,
-        message: 'missing agent-runtime turn-outcome event fact import',
-      },
-      {
         regex:
-          /use bitfun_agent_runtime::scheduler::\{(?=[\s\S]*BackgroundDeliveryAction)(?=[\s\S]*BackgroundDeliveryFacts)(?=[\s\S]*resolve_background_delivery_action)[\s\S]*\};/,
-        message: 'missing agent-runtime background delivery decision import',
+          /use bitfun_agent_runtime::scheduler::\{(?=[\s\S]*ActiveDialogTurn)(?=[\s\S]*ActiveDialogTurnStore)(?=[\s\S]*AgentSessionReplyAction)(?=[\s\S]*AgentSessionReplyPlan)(?=[\s\S]*BackgroundDeliveryAction)(?=[\s\S]*BackgroundDeliveryFacts)(?=[\s\S]*BackgroundInjectionKind)(?=[\s\S]*DialogReplySuppressionSet)(?=[\s\S]*DialogSteeringAction)(?=[\s\S]*DialogTurnQueue)(?=[\s\S]*SessionAbortFlags)(?=[\s\S]*resolve_agent_session_reply_action)(?=[\s\S]*resolve_background_delivery_action)(?=[\s\S]*resolve_background_delivery_injection)(?=[\s\S]*resolve_dialog_steering_action)[\s\S]*\};/,
+        message: 'missing agent-runtime scheduler owner imports',
       },
     ],
   },
@@ -5357,19 +5408,15 @@ const requiredContentRules = [
   {
     path: 'src/crates/core/src/agentic/coordination/scheduler.rs',
     reason:
-      'core scheduler must continue owning background subagent result delivery until running-turn and idle-session routing equivalence tests exist',
+      'core scheduler keeps concrete background delivery entry points while bitfun-agent-runtime owns running-turn injection construction',
     patterns: [
       {
         regex: /\bdeliver_background_result\b/,
         message: 'missing background subagent delivery entry point',
       },
       {
-        regex: /RoundInjectionKind::BackgroundResult/,
-        message: 'missing running-turn background result injection',
-      },
-      {
-        regex: /RoundInjectionTarget::CurrentRunningTurn/,
-        message: 'missing current-turn injection target',
+        regex: /\bresolve_background_delivery_injection\b/,
+        message: 'missing runtime-owned background injection construction',
       },
       {
         regex: /DialogTriggerSource::AgentSession/,
@@ -7856,9 +7903,22 @@ function runManifestParserSelfTest() {
     {
       path: 'src/crates/agent-runtime/src/scheduler.rs',
       contracts: [
+        'DEFAULT_MAX_DIALOG_QUEUE_DEPTH',
+        'ActiveDialogTurn',
+        'ActiveDialogTurnStore',
+        'AgentSessionReplyAction',
+        'AgentSessionReplyPlan',
         'BackgroundDeliveryFacts',
         'BackgroundDeliveryAction',
+        'BackgroundInjectionKind',
+        'DialogReplySuppressionSet',
+        'DialogSteeringAction',
+        'DialogTurnQueue',
+        'SessionAbortFlags',
+        'resolve_agent_session_reply_action',
         'resolve_background_delivery_action',
+        'resolve_background_delivery_injection',
+        'resolve_dialog_steering_action',
         'follow_up_submission_policy',
         'SubmitAgentSessionFollowUp',
         'InjectIntoRunningTurn',
@@ -7875,6 +7935,20 @@ function runManifestParserSelfTest() {
         'background_delivery_starts_agent_session_follow_up_when_session_is_not_processing',
         'background_delivery_follow_up_uses_agent_session_source_semantics',
         'background_delivery_injection_does_not_expose_follow_up_policy',
+        'background_delivery_injection_builds_thread_goal_current_turn_message',
+        'background_delivery_injection_builds_background_result_with_display_fallback',
+        'dialog_turn_queue_preserves_priority_order_and_fifo_within_priority',
+        'dialog_turn_queue_rejects_overflow_and_preserves_current_error_shape',
+        'dialog_turn_queue_requeued_turn_keeps_original_priority_for_later_ordering',
+        'active_dialog_turn_owns_agent_session_reply_suppression_facts',
+        'active_dialog_turn_store_owns_suppression_key_resolution_and_removal',
+        'reply_suppression_set_marks_takes_and_clears_turn_keys',
+        'session_abort_flags_are_session_scoped',
+        'agent_session_reply_action_forwards_completed_outcome_with_legacy_reminder_text',
+        'agent_session_reply_action_suppresses_cancelled_auto_reply_when_requested',
+        'agent_session_reply_action_ignores_non_agent_session_turns',
+        'dialog_steering_action_buffers_exact_running_turn_with_display_fallback',
+        'dialog_steering_action_rejects_when_target_turn_is_not_running',
         'round_yield_flags_are_session_scoped_and_clearable',
         'round_injection_buffer_drains_only_messages_for_the_active_turn',
         'turn_outcome_status_reply_and_queue_policy_are_portable',
@@ -8134,11 +8208,19 @@ function runManifestParserSelfTest() {
         'DialogSubmitOutcome',
         'DialogSubmitQueueAction',
         'DialogSubmitQueueFacts',
-        'bitfun_agent_runtime::events::turn_outcome_kind',
+        'ActiveDialogTurnStore',
+        'AgentSessionReplyAction',
+        'AgentSessionReplyPlan',
+        'BackgroundInjectionKind',
+        'DialogReplySuppressionSet',
+        'DialogSteeringAction',
+        'DialogTurnQueue',
+        'SessionAbortFlags',
         'dialog_policy_may_preempt',
+        'resolve_agent_session_reply_action',
+        'resolve_background_delivery_injection',
         'resolve_dialog_submit_queue_action',
-        'should_skip_agent_session_reply_contract',
-        'should_suppress_agent_session_cancelled_reply_contract',
+        'resolve_dialog_steering_action',
       ],
     },
     {

--- a/src/crates/agent-runtime/AGENTS.md
+++ b/src/crates/agent-runtime/AGENTS.md
@@ -13,7 +13,9 @@ and tested without `bitfun-core`.
   product `Tool` adapters in `bitfun-core` until a reviewed owner migration
   proves behavior equivalence.
 - Prefer pure facts and decisions first: queue policy, background delivery,
-  thread-goal accounting/mutation/continuation decisions, cancellation routing,
+  dialog-turn queue state, active-turn facts, cancellation routing and
+  suppression state, background running-turn injection construction, steering action
+  planning, agent-session reply planning, thread-goal accounting/mutation/continuation decisions,
   runtime event facts, registry visibility/availability, round-boundary
   yield/injection state, turn-outcome queue decisions, registry source/profile
   facts, prompt-loop user-context policy, prompt listing reminder ordering,

--- a/src/crates/agent-runtime/src/scheduler.rs
+++ b/src/crates/agent-runtime/src/scheduler.rs
@@ -1,13 +1,313 @@
 //! Scheduler owner decisions.
 
+use crate::events::turn_outcome_kind;
 use bitfun_runtime_ports::{
-    DialogQueuePriority, DialogRoundInjectionSource, DialogRoundPreemptSource,
-    DialogSessionStateFact, DialogSubmissionPolicy, DialogTriggerSource, RoundInjection,
-    RoundInjectionTarget,
+    should_skip_agent_session_reply, should_suppress_agent_session_cancelled_reply,
+    AgentSessionReplyRoute, DialogQueuePriority, DialogRoundInjectionSource,
+    DialogRoundPreemptSource, DialogSessionStateFact, DialogSteerOutcome, DialogSubmissionPolicy,
+    DialogTriggerSource, RoundInjection, RoundInjectionKind, RoundInjectionTarget,
 };
+use std::collections::VecDeque;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::SystemTime;
+
+pub const DEFAULT_MAX_DIALOG_QUEUE_DEPTH: usize = 20;
+
+#[derive(Debug, Clone)]
+pub struct ActiveDialogTurn {
+    turn_id: String,
+    workspace_path: Option<String>,
+    agent_type: String,
+    user_input: String,
+    user_message_metadata: Option<serde_json::Value>,
+    policy: DialogSubmissionPolicy,
+    reply_route: Option<AgentSessionReplyRoute>,
+}
+
+impl ActiveDialogTurn {
+    pub fn new(
+        turn_id: String,
+        workspace_path: Option<String>,
+        agent_type: String,
+        user_input: String,
+        user_message_metadata: Option<serde_json::Value>,
+        policy: DialogSubmissionPolicy,
+        reply_route: Option<AgentSessionReplyRoute>,
+    ) -> Self {
+        Self {
+            turn_id,
+            workspace_path,
+            agent_type,
+            user_input,
+            user_message_metadata,
+            policy,
+            reply_route,
+        }
+    }
+
+    pub fn turn_id(&self) -> &str {
+        &self.turn_id
+    }
+
+    pub fn workspace_path(&self) -> Option<&str> {
+        self.workspace_path.as_deref()
+    }
+
+    pub fn workspace_path_owned(&self) -> Option<String> {
+        self.workspace_path.clone()
+    }
+
+    pub fn agent_type(&self) -> &str {
+        &self.agent_type
+    }
+
+    pub fn agent_type_owned(&self) -> String {
+        self.agent_type.clone()
+    }
+
+    pub fn user_input(&self) -> &str {
+        &self.user_input
+    }
+
+    pub fn user_message_metadata(&self) -> Option<&serde_json::Value> {
+        self.user_message_metadata.as_ref()
+    }
+
+    pub fn reply_route(&self) -> Option<&AgentSessionReplyRoute> {
+        self.reply_route.as_ref()
+    }
+
+    pub fn is_agent_session_request(&self) -> bool {
+        self.policy.trigger_source == DialogTriggerSource::AgentSession
+            && self.reply_route.is_some()
+    }
+
+    pub fn should_suppress_cancelled_reply_for_requester(
+        &self,
+        requester_session_id: &str,
+    ) -> bool {
+        should_suppress_agent_session_cancelled_reply(
+            &self.policy,
+            self.reply_route
+                .as_ref()
+                .map(|reply_route| reply_route.source_session_id.as_str()),
+            requester_session_id,
+        )
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ActiveDialogTurnStore {
+    inner: dashmap::DashMap<String, ActiveDialogTurn>,
+}
+
+impl ActiveDialogTurnStore {
+    pub fn insert(&self, session_id: &str, turn: ActiveDialogTurn) {
+        self.inner.insert(session_id.to_string(), turn);
+    }
+
+    pub fn remove(&self, session_id: &str) -> Option<ActiveDialogTurn> {
+        self.inner.remove(session_id).map(|(_, turn)| turn)
+    }
+
+    pub fn suppression_key_for_requester(
+        &self,
+        target_session_id: &str,
+        requester_session_id: &str,
+    ) -> Option<(String, String)> {
+        self.inner.get(target_session_id).and_then(|active_turn| {
+            active_turn
+                .should_suppress_cancelled_reply_for_requester(requester_session_id)
+                .then(|| {
+                    (
+                        target_session_id.to_string(),
+                        active_turn.turn_id().to_string(),
+                    )
+                })
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DialogReplySuppressionSet {
+    inner: dashmap::DashMap<(String, String), ()>,
+}
+
+impl DialogReplySuppressionSet {
+    pub fn mark(&self, session_id: &str, turn_id: &str) {
+        self.inner
+            .insert((session_id.to_string(), turn_id.to_string()), ());
+    }
+
+    pub fn clear(&self, session_id: &str, turn_id: &str) {
+        self.inner
+            .remove(&(session_id.to_string(), turn_id.to_string()));
+    }
+
+    pub fn take(&self, session_id: &str, turn_id: &str) -> bool {
+        self.inner
+            .remove(&(session_id.to_string(), turn_id.to_string()))
+            .is_some()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SessionAbortFlags {
+    inner: dashmap::DashMap<String, ()>,
+}
+
+impl SessionAbortFlags {
+    pub fn mark(&self, session_id: &str) {
+        self.inner.insert(session_id.to_string(), ());
+    }
+
+    pub fn clear(&self, session_id: &str) {
+        self.inner.remove(session_id);
+    }
+
+    pub fn contains(&self, session_id: &str) -> bool {
+        self.inner.contains_key(session_id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DialogTurnQueueError {
+    Full {
+        session_id: String,
+        max_depth: usize,
+    },
+}
+
+impl fmt::Display for DialogTurnQueueError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Full {
+                session_id,
+                max_depth,
+            } => write!(
+                f,
+                "Message queue full for session {session_id} (max {max_depth} messages)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DialogTurnQueueError {}
+
+#[derive(Debug, Clone)]
+struct QueuedDialogTurn<T> {
+    priority: DialogQueuePriority,
+    turn: T,
+}
+
+/// Per-session dialog-turn queue with product scheduler priority semantics.
+#[derive(Debug)]
+pub struct DialogTurnQueue<T> {
+    max_depth: usize,
+    inner: dashmap::DashMap<String, VecDeque<QueuedDialogTurn<T>>>,
+}
+
+impl<T> Default for DialogTurnQueue<T> {
+    fn default() -> Self {
+        Self::with_max_depth(DEFAULT_MAX_DIALOG_QUEUE_DEPTH)
+    }
+}
+
+impl<T> DialogTurnQueue<T> {
+    pub fn with_max_depth(max_depth: usize) -> Self {
+        Self {
+            max_depth,
+            inner: dashmap::DashMap::new(),
+        }
+    }
+
+    pub const fn max_depth(&self) -> usize {
+        self.max_depth
+    }
+
+    pub fn depth(&self, session_id: &str) -> usize {
+        self.inner.get(session_id).map(|q| q.len()).unwrap_or(0)
+    }
+
+    pub fn has_items(&self, session_id: &str) -> bool {
+        self.depth(session_id) > 0
+    }
+
+    pub fn enqueue(
+        &self,
+        session_id: &str,
+        turn: T,
+        priority: DialogQueuePriority,
+    ) -> Result<usize, DialogTurnQueueError> {
+        let mut queue = self.inner.entry(session_id.to_string()).or_default();
+        if queue.len() >= self.max_depth {
+            return Err(DialogTurnQueueError::Full {
+                session_id: session_id.to_string(),
+                max_depth: self.max_depth,
+            });
+        }
+
+        let queued = QueuedDialogTurn { priority, turn };
+        let insert_at = queue
+            .iter()
+            .position(|existing| existing.priority < queued.priority);
+        if let Some(index) = insert_at {
+            queue.insert(index, queued);
+        } else {
+            queue.push_back(queued);
+        }
+
+        Ok(queue.len())
+    }
+
+    pub fn clear(&self, session_id: &str) -> usize {
+        self.inner
+            .remove(session_id)
+            .map(|(_, queue)| queue.len())
+            .unwrap_or(0)
+    }
+
+    pub fn dequeue_next(&self, session_id: &str) -> Option<T> {
+        self.inner
+            .get_mut(session_id)
+            .and_then(|mut q| q.pop_front().map(|item| item.turn))
+    }
+
+    pub fn requeue_front(&self, session_id: &str, turn: T, priority: DialogQueuePriority) {
+        self.inner
+            .entry(session_id.to_string())
+            .or_default()
+            .push_front(QueuedDialogTurn { priority, turn });
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentSessionReplyPlan {
+    pub target_session_id: String,
+    pub target_workspace_path: String,
+    pub user_input: String,
+    pub reminder_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentSessionReplyAction {
+    NoReply,
+    SkipSuppressedCancelledReply,
+    Forward(AgentSessionReplyPlan),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DialogSteeringAction {
+    Reject {
+        error: String,
+    },
+    Buffer {
+        injection: RoundInjection,
+        outcome: DialogSteerOutcome,
+    },
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BackgroundDeliveryFacts {
@@ -21,6 +321,12 @@ pub enum BackgroundDeliveryAction {
         queue_priority: DialogQueuePriority,
         skip_tool_confirmation: bool,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackgroundInjectionKind {
+    ThreadGoalObjectiveUpdated,
+    BackgroundResult,
 }
 
 impl BackgroundDeliveryAction {
@@ -218,6 +524,29 @@ pub const fn resolve_background_delivery_action(
     }
 }
 
+pub fn resolve_background_delivery_injection(
+    kind: BackgroundInjectionKind,
+    injection_id: String,
+    content: String,
+    display_content: Option<String>,
+    created_at: SystemTime,
+) -> RoundInjection {
+    let display_content = display_content.unwrap_or_else(|| content.clone());
+    RoundInjection {
+        id: injection_id,
+        kind: match kind {
+            BackgroundInjectionKind::ThreadGoalObjectiveUpdated => {
+                RoundInjectionKind::ThreadGoalObjectiveUpdated
+            }
+            BackgroundInjectionKind::BackgroundResult => RoundInjectionKind::BackgroundResult,
+        },
+        target: RoundInjectionTarget::CurrentRunningTurn,
+        content,
+        display_content,
+        created_at,
+    }
+}
+
 /// Outcome of a completed dialog turn, used to notify the concrete scheduler.
 #[derive(Debug, Clone)]
 pub enum TurnOutcome {
@@ -306,5 +635,75 @@ impl TurnOutcome {
             Self::Completed { .. } | Self::Cancelled { .. } => TurnOutcomeQueueAction::DispatchNext,
             Self::Failed { .. } => TurnOutcomeQueueAction::ClearQueue,
         }
+    }
+}
+
+pub fn resolve_agent_session_reply_action(
+    responder_session_id: &str,
+    active_turn: &ActiveDialogTurn,
+    outcome: &TurnOutcome,
+    suppressed_cancelled_reply: bool,
+) -> AgentSessionReplyAction {
+    if !active_turn.is_agent_session_request() {
+        return AgentSessionReplyAction::NoReply;
+    }
+
+    if should_skip_agent_session_reply(turn_outcome_kind(outcome), suppressed_cancelled_reply) {
+        return AgentSessionReplyAction::SkipSuppressedCancelledReply;
+    }
+
+    let Some(reply_route) = active_turn.reply_route() else {
+        return AgentSessionReplyAction::NoReply;
+    };
+
+    let responder_workspace = active_turn
+        .workspace_path()
+        .unwrap_or("<unknown workspace>");
+    let status = outcome.status();
+    AgentSessionReplyAction::Forward(AgentSessionReplyPlan {
+        target_session_id: reply_route.source_session_id.clone(),
+        target_workspace_path: reply_route.source_workspace_path.clone(),
+        user_input: outcome.reply_text(),
+        reminder_text: format!(
+            "This message is an automated reply to a previous SessionMessage call, not a human user message.\n\
+From session: {responder_session_id}\n\
+From workspace: {responder_workspace}\n\
+Status: {status}"
+        ),
+    })
+}
+
+pub fn resolve_dialog_steering_action(
+    active_turn_id: Option<&str>,
+    session_id: &str,
+    turn_id: &str,
+    content: String,
+    display_content: Option<String>,
+    steering_id: String,
+    created_at: SystemTime,
+) -> DialogSteeringAction {
+    if active_turn_id != Some(turn_id) {
+        return DialogSteeringAction::Reject {
+            error: format!(
+                "Dialog turn is no longer running and cannot be steered: session_id={session_id}, turn_id={turn_id}"
+            ),
+        };
+    }
+
+    let display = display_content.unwrap_or_else(|| content.clone());
+    DialogSteeringAction::Buffer {
+        injection: RoundInjection {
+            id: steering_id.clone(),
+            kind: RoundInjectionKind::UserSteering,
+            target: RoundInjectionTarget::ExactTurn(turn_id.to_string()),
+            content,
+            display_content: display,
+            created_at,
+        },
+        outcome: DialogSteerOutcome::Buffered {
+            session_id: session_id.to_string(),
+            turn_id: turn_id.to_string(),
+            steering_id,
+        },
     }
 }

--- a/src/crates/agent-runtime/tests/scheduler_contracts.rs
+++ b/src/crates/agent-runtime/tests/scheduler_contracts.rs
@@ -1,11 +1,17 @@
 use bitfun_agent_runtime::scheduler::{
-    resolve_background_delivery_action, BackgroundDeliveryAction, BackgroundDeliveryFacts,
-    DialogRoundInjectionInterrupt, NoopDialogRoundPreemptSource, SessionRoundInjectionBuffer,
+    resolve_agent_session_reply_action, resolve_background_delivery_action,
+    resolve_background_delivery_injection, resolve_dialog_steering_action, ActiveDialogTurn,
+    ActiveDialogTurnStore, AgentSessionReplyAction, BackgroundDeliveryAction,
+    BackgroundDeliveryFacts, BackgroundInjectionKind, DialogReplySuppressionSet,
+    DialogRoundInjectionInterrupt, DialogSteeringAction, DialogTurnQueue, DialogTurnQueueError,
+    NoopDialogRoundPreemptSource, SessionAbortFlags, SessionRoundInjectionBuffer,
     SessionRoundYieldFlags, TurnOutcome, TurnOutcomeQueueAction, TurnOutcomeStatus,
+    DEFAULT_MAX_DIALOG_QUEUE_DEPTH,
 };
 use bitfun_runtime_ports::{
-    DialogQueuePriority, DialogRoundPreemptSource, DialogSessionStateFact, DialogTriggerSource,
-    RoundInjection, RoundInjectionKind, RoundInjectionTarget,
+    AgentSessionReplyRoute, DialogQueuePriority, DialogRoundPreemptSource, DialogSessionStateFact,
+    DialogSteerOutcome, DialogSubmissionPolicy, DialogTriggerSource, RoundInjection,
+    RoundInjectionKind, RoundInjectionTarget,
 };
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -60,6 +66,332 @@ fn background_delivery_injection_does_not_expose_follow_up_policy() {
     });
 
     assert_eq!(action.follow_up_submission_policy(), None);
+}
+
+#[test]
+fn background_delivery_injection_builds_thread_goal_current_turn_message() {
+    let created_at = SystemTime::UNIX_EPOCH;
+
+    let injection = resolve_background_delivery_injection(
+        BackgroundInjectionKind::ThreadGoalObjectiveUpdated,
+        "injection-id".to_string(),
+        "prompt".to_string(),
+        Some("display".to_string()),
+        created_at,
+    );
+
+    assert_eq!(injection.id, "injection-id");
+    assert_eq!(
+        injection.kind,
+        RoundInjectionKind::ThreadGoalObjectiveUpdated
+    );
+    assert_eq!(injection.target, RoundInjectionTarget::CurrentRunningTurn);
+    assert_eq!(injection.content, "prompt");
+    assert_eq!(injection.display_content, "display");
+    assert_eq!(injection.created_at, created_at);
+}
+
+#[test]
+fn background_delivery_injection_builds_background_result_with_display_fallback() {
+    let created_at = SystemTime::UNIX_EPOCH;
+
+    let injection = resolve_background_delivery_injection(
+        BackgroundInjectionKind::BackgroundResult,
+        "injection-id".to_string(),
+        "result content".to_string(),
+        None,
+        created_at,
+    );
+
+    assert_eq!(injection.id, "injection-id");
+    assert_eq!(injection.kind, RoundInjectionKind::BackgroundResult);
+    assert_eq!(injection.target, RoundInjectionTarget::CurrentRunningTurn);
+    assert_eq!(injection.content, "result content");
+    assert_eq!(injection.display_content, "result content");
+    assert_eq!(injection.created_at, created_at);
+}
+
+#[test]
+fn dialog_turn_queue_preserves_priority_order_and_fifo_within_priority() {
+    let queue = DialogTurnQueue::with_max_depth(4);
+
+    queue
+        .enqueue("s1", "normal-1", DialogQueuePriority::Normal)
+        .expect("normal turn should enqueue");
+    queue
+        .enqueue("s1", "high", DialogQueuePriority::High)
+        .expect("high-priority turn should enqueue");
+    queue
+        .enqueue("s1", "normal-2", DialogQueuePriority::Normal)
+        .expect("second normal turn should enqueue");
+
+    assert_eq!(queue.depth("s1"), 3);
+    assert!(queue.has_items("s1"));
+    assert_eq!(queue.dequeue_next("s1"), Some("high"));
+    assert_eq!(queue.dequeue_next("s1"), Some("normal-1"));
+    assert_eq!(queue.dequeue_next("s1"), Some("normal-2"));
+    assert_eq!(queue.dequeue_next("s1"), None);
+}
+
+#[test]
+fn dialog_turn_queue_rejects_overflow_and_preserves_current_error_shape() {
+    let queue = DialogTurnQueue::with_max_depth(1);
+
+    queue
+        .enqueue("s1", "first", DialogQueuePriority::Normal)
+        .expect("first turn should fit");
+    let error = queue
+        .enqueue("s1", "overflow", DialogQueuePriority::Normal)
+        .expect_err("overflow must reject instead of dropping queued work");
+
+    assert_eq!(
+        error,
+        DialogTurnQueueError::Full {
+            session_id: "s1".to_string(),
+            max_depth: 1,
+        }
+    );
+    assert_eq!(
+        error.to_string(),
+        "Message queue full for session s1 (max 1 messages)"
+    );
+    assert_eq!(queue.dequeue_next("s1"), Some("first"));
+}
+
+#[test]
+fn dialog_turn_queue_clear_and_requeue_front_preserve_scheduler_recovery_contract() {
+    let queue = DialogTurnQueue::default();
+
+    assert_eq!(queue.max_depth(), DEFAULT_MAX_DIALOG_QUEUE_DEPTH);
+    queue
+        .enqueue("s1", "queued", DialogQueuePriority::Low)
+        .expect("turn should enqueue");
+    queue.requeue_front("s1", "retry", DialogQueuePriority::Low);
+
+    assert_eq!(queue.dequeue_next("s1"), Some("retry"));
+    assert_eq!(queue.clear("s1"), 1);
+    assert!(!queue.has_items("s1"));
+    assert_eq!(queue.depth("s1"), 0);
+}
+
+#[test]
+fn dialog_turn_queue_requeued_turn_keeps_original_priority_for_later_ordering() {
+    let queue = DialogTurnQueue::default();
+
+    queue.requeue_front("s1", "retry-low", DialogQueuePriority::Low);
+    queue
+        .enqueue("s1", "new-high", DialogQueuePriority::High)
+        .expect("new high-priority turn should enqueue before requeued low-priority turn");
+
+    assert_eq!(queue.dequeue_next("s1"), Some("new-high"));
+    assert_eq!(queue.dequeue_next("s1"), Some("retry-low"));
+}
+
+#[test]
+fn active_dialog_turn_owns_agent_session_reply_suppression_facts() {
+    let route = AgentSessionReplyRoute {
+        source_session_id: "source-session".to_string(),
+        source_workspace_path: "workspace".to_string(),
+    };
+    let turn = ActiveDialogTurn::new(
+        "turn-1".to_string(),
+        Some("workspace".to_string()),
+        "agentic".to_string(),
+        "run task".to_string(),
+        Some(serde_json::json!({"kind": "session_message"})),
+        DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession),
+        Some(route),
+    );
+
+    assert!(turn.is_agent_session_request());
+    assert_eq!(turn.turn_id(), "turn-1");
+    assert_eq!(turn.workspace_path(), Some("workspace"));
+    assert_eq!(turn.agent_type(), "agentic");
+    assert_eq!(turn.user_input(), "run task");
+    assert!(turn.user_message_metadata().is_some());
+    assert!(turn.reply_route().is_some());
+    assert!(turn.should_suppress_cancelled_reply_for_requester("source-session"));
+    assert!(!turn.should_suppress_cancelled_reply_for_requester("other-session"));
+}
+
+#[test]
+fn active_dialog_turn_does_not_suppress_non_agent_session_turns() {
+    let turn = ActiveDialogTurn::new(
+        "turn-1".to_string(),
+        None,
+        "agentic".to_string(),
+        "user task".to_string(),
+        None,
+        DialogSubmissionPolicy::for_source(DialogTriggerSource::DesktopUi),
+        None,
+    );
+
+    assert!(!turn.is_agent_session_request());
+    assert!(!turn.should_suppress_cancelled_reply_for_requester("source-session"));
+}
+
+#[test]
+fn active_dialog_turn_store_owns_suppression_key_resolution_and_removal() {
+    let store = ActiveDialogTurnStore::default();
+    let turn = agent_session_turn("source-session");
+    store.insert("target-session", turn);
+
+    assert_eq!(
+        store.suppression_key_for_requester("target-session", "source-session"),
+        Some(("target-session".to_string(), "turn-1".to_string()))
+    );
+    assert_eq!(
+        store.suppression_key_for_requester("target-session", "other-session"),
+        None
+    );
+
+    let removed = store
+        .remove("target-session")
+        .expect("active turn should remove");
+    assert_eq!(removed.turn_id(), "turn-1");
+    assert!(store.remove("target-session").is_none());
+}
+
+#[test]
+fn reply_suppression_set_marks_takes_and_clears_turn_keys() {
+    let set = DialogReplySuppressionSet::default();
+
+    set.mark("session-a", "turn-1");
+    assert!(set.take("session-a", "turn-1"));
+    assert!(!set.take("session-a", "turn-1"));
+
+    set.mark("session-a", "turn-2");
+    set.clear("session-a", "turn-2");
+    assert!(!set.take("session-a", "turn-2"));
+}
+
+#[test]
+fn session_abort_flags_are_session_scoped() {
+    let flags = SessionAbortFlags::default();
+
+    flags.mark("s1");
+    assert!(flags.contains("s1"));
+    assert!(!flags.contains("s2"));
+
+    flags.clear("s1");
+    assert!(!flags.contains("s1"));
+}
+
+#[test]
+fn agent_session_reply_action_forwards_completed_outcome_with_legacy_reminder_text() {
+    let turn = agent_session_turn("source-session");
+    let outcome = TurnOutcome::Completed {
+        turn_id: "turn-1".to_string(),
+        final_response: "done".to_string(),
+    };
+
+    let action = resolve_agent_session_reply_action("target-session", &turn, &outcome, false);
+
+    let AgentSessionReplyAction::Forward(plan) = action else {
+        panic!("agent-session completion should forward a reply");
+    };
+    assert_eq!(plan.target_session_id, "source-session");
+    assert_eq!(plan.target_workspace_path, "workspace");
+    assert_eq!(plan.user_input, "done");
+    assert_eq!(
+        plan.reminder_text,
+        "This message is an automated reply to a previous SessionMessage call, not a human user message.\n\
+From session: target-session\n\
+From workspace: workspace\n\
+Status: completed"
+    );
+}
+
+#[test]
+fn agent_session_reply_action_suppresses_cancelled_auto_reply_when_requested() {
+    let turn = agent_session_turn("source-session");
+    let outcome = TurnOutcome::Cancelled {
+        turn_id: "turn-1".to_string(),
+    };
+
+    let action = resolve_agent_session_reply_action("target-session", &turn, &outcome, true);
+
+    assert_eq!(
+        action,
+        AgentSessionReplyAction::SkipSuppressedCancelledReply
+    );
+}
+
+#[test]
+fn agent_session_reply_action_ignores_non_agent_session_turns() {
+    let turn = ActiveDialogTurn::new(
+        "turn-1".to_string(),
+        Some("workspace".to_string()),
+        "agentic".to_string(),
+        "user task".to_string(),
+        None,
+        DialogSubmissionPolicy::for_source(DialogTriggerSource::DesktopUi),
+        None,
+    );
+    let outcome = TurnOutcome::Completed {
+        turn_id: "turn-1".to_string(),
+        final_response: "done".to_string(),
+    };
+
+    let action = resolve_agent_session_reply_action("target-session", &turn, &outcome, false);
+
+    assert_eq!(action, AgentSessionReplyAction::NoReply);
+}
+
+#[test]
+fn dialog_steering_action_buffers_exact_running_turn_with_display_fallback() {
+    let created_at = SystemTime::UNIX_EPOCH;
+
+    let action = resolve_dialog_steering_action(
+        Some("turn-1"),
+        "session-1",
+        "turn-1",
+        "steer content".to_string(),
+        None,
+        "steer-id".to_string(),
+        created_at,
+    );
+
+    let DialogSteeringAction::Buffer { injection, outcome } = action else {
+        panic!("matching running turn should buffer steering");
+    };
+    assert_eq!(injection.id, "steer-id");
+    assert_eq!(injection.kind, RoundInjectionKind::UserSteering);
+    assert_eq!(
+        injection.target,
+        RoundInjectionTarget::ExactTurn("turn-1".to_string())
+    );
+    assert_eq!(injection.content, "steer content");
+    assert_eq!(injection.display_content, "steer content");
+    assert_eq!(injection.created_at, created_at);
+    assert_eq!(
+        outcome,
+        DialogSteerOutcome::Buffered {
+            session_id: "session-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            steering_id: "steer-id".to_string(),
+        }
+    );
+}
+
+#[test]
+fn dialog_steering_action_rejects_when_target_turn_is_not_running() {
+    let action = resolve_dialog_steering_action(
+        Some("other-turn"),
+        "session-1",
+        "turn-1",
+        "steer content".to_string(),
+        Some("display".to_string()),
+        "steer-id".to_string(),
+        SystemTime::UNIX_EPOCH,
+    );
+
+    assert_eq!(
+        action,
+        DialogSteeringAction::Reject {
+            error: "Dialog turn is no longer running and cannot be steered: session_id=session-1, turn_id=turn-1".to_string(),
+        }
+    );
 }
 
 #[test]
@@ -160,4 +492,19 @@ fn current_turn_msg(content: &str) -> RoundInjection {
         display_content: content.to_string(),
         created_at: SystemTime::now(),
     }
+}
+
+fn agent_session_turn(source_session_id: &str) -> ActiveDialogTurn {
+    ActiveDialogTurn::new(
+        "turn-1".to_string(),
+        Some("workspace".to_string()),
+        "agentic".to_string(),
+        "run task".to_string(),
+        Some(serde_json::json!({"kind": "session_message"})),
+        DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession),
+        Some(AgentSessionReplyRoute {
+            source_session_id: source_session_id.to_string(),
+            source_workspace_path: "workspace".to_string(),
+        }),
+    )
 }

--- a/src/crates/core/AGENTS.md
+++ b/src/crates/core/AGENTS.md
@@ -57,6 +57,11 @@ SessionManager -> Session -> DialogTurn -> ModelRound
 - Remote/service changes must keep external protocol lifecycle, workspace
   projection, scheduler/session restore, terminal pre-warm, and product
   execution boundaries explicit.
+- Scheduler changes should keep queue state, active-turn facts, background
+  running-turn injection construction, cancelled-reply suppression state, steering action planning,
+  agent-session reply planning, and goal-continuation abort flags in
+  `bitfun-agent-runtime`; core keeps coordinator, session-manager wiring,
+  delivery, and concrete lifecycle until an equivalence-protected migration.
 - Feature work must keep `product-full` as the compatibility product assembly
   boundary unless a separate product matrix review changes default capability
   selection.

--- a/src/crates/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/core/src/agentic/coordination/scheduler.rs
@@ -21,15 +21,13 @@ use crate::agentic::goal_mode::{
 use crate::agentic::image_analysis::ImageContextData;
 use crate::agentic::init_agents_md::build_init_agents_md_user_input;
 use crate::agentic::round_preempt::{
-    DialogRoundInjectionSource, DialogRoundPreemptSource, RoundInjection, RoundInjectionKind,
-    RoundInjectionTarget, SessionRoundInjectionBuffer, SessionRoundYieldFlags,
+    DialogRoundInjectionSource, DialogRoundPreemptSource, SessionRoundInjectionBuffer,
+    SessionRoundYieldFlags,
 };
 use crate::agentic::session::SessionManager;
 use bitfun_runtime_ports::ThreadGoal;
 use bitfun_runtime_ports::MAX_THREAD_GOAL_AUTO_CONTINUATIONS;
-use dashmap::DashMap;
 use log::{debug, info, warn};
-use std::collections::VecDeque;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -37,65 +35,21 @@ use std::time::{Duration, SystemTime};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-const MAX_QUEUE_DEPTH: usize = 20;
-
-use bitfun_agent_runtime::events::turn_outcome_kind;
 use bitfun_agent_runtime::scheduler::{
-    resolve_background_delivery_action, BackgroundDeliveryAction, BackgroundDeliveryFacts,
+    resolve_agent_session_reply_action, resolve_background_delivery_action,
+    resolve_background_delivery_injection, resolve_dialog_steering_action, ActiveDialogTurn,
+    ActiveDialogTurnStore, AgentSessionReplyAction, AgentSessionReplyPlan,
+    BackgroundDeliveryAction, BackgroundDeliveryFacts, BackgroundInjectionKind,
+    DialogReplySuppressionSet, DialogSteeringAction, DialogTurnQueue, SessionAbortFlags,
 };
 use bitfun_runtime_ports::{
-    resolve_dialog_submit_queue_action,
-    should_skip_agent_session_reply as should_skip_agent_session_reply_contract,
-    should_suppress_agent_session_cancelled_reply as should_suppress_agent_session_cancelled_reply_contract,
-    DialogSessionStateFact, DialogSubmitQueueAction, DialogSubmitQueueFacts,
+    resolve_dialog_submit_queue_action, DialogSessionStateFact, DialogSubmitQueueAction,
+    DialogSubmitQueueFacts,
 };
 pub use bitfun_runtime_ports::{
     AgentSessionReplyRoute, DialogQueuePriority, DialogSteerOutcome, DialogSubmissionPolicy,
     DialogSubmitOutcome,
 };
-
-#[derive(Debug, Clone)]
-struct ActiveTurn {
-    turn_id: String,
-    workspace_path: Option<String>,
-    agent_type: String,
-    user_input: String,
-    user_message_metadata: Option<serde_json::Value>,
-    policy: DialogSubmissionPolicy,
-    reply_route: Option<AgentSessionReplyRoute>,
-}
-
-impl ActiveTurn {
-    fn from_queued_turn(turn: &QueuedTurn, turn_id: String) -> Self {
-        Self {
-            turn_id,
-            workspace_path: turn.workspace_path.clone(),
-            agent_type: turn.agent_type.clone(),
-            user_input: turn
-                .original_user_input
-                .clone()
-                .unwrap_or_else(|| turn.user_input.clone()),
-            user_message_metadata: turn.user_message_metadata.clone(),
-            policy: turn.policy,
-            reply_route: turn.reply_route.clone(),
-        }
-    }
-
-    fn is_agent_session_request(&self) -> bool {
-        self.policy.trigger_source == DialogTriggerSource::AgentSession
-            && self.reply_route.is_some()
-    }
-
-    fn should_suppress_cancelled_reply_for_requester(&self, requester_session_id: &str) -> bool {
-        should_suppress_agent_session_cancelled_reply_contract(
-            &self.policy,
-            self.reply_route
-                .as_ref()
-                .map(|reply_route| reply_route.source_session_id.as_str()),
-            requester_session_id,
-        )
-    }
-}
 
 /// A message waiting to be dispatched to the coordinator
 #[derive(Debug, Clone)]
@@ -122,15 +76,15 @@ pub struct QueuedTurn {
 pub struct DialogScheduler {
     coordinator: Arc<ConversationCoordinator>,
     session_manager: Arc<SessionManager>,
-    /// Per-session priority message queues
-    queues: Arc<DashMap<String, VecDeque<QueuedTurn>>>,
+    /// Per-session priority message queues.
+    queues: Arc<DialogTurnQueue<QueuedTurn>>,
     /// Currently active turn metadata keyed by target session ID
-    active_turns: Arc<DashMap<String, ActiveTurn>>,
+    active_turns: Arc<ActiveDialogTurnStore>,
     /// Turns whose cancelled auto-reply should be suppressed because the source
     /// agent explicitly cancelled its own outstanding SessionMessage request.
-    suppressed_cancelled_replies: Arc<DashMap<(String, String), ()>>,
+    suppressed_cancelled_replies: Arc<DialogReplySuppressionSet>,
     /// Set when the user cancels an in-flight turn; aborts goal-continuation submit retries.
-    goal_continuation_abort: Arc<DashMap<String, ()>>,
+    goal_continuation_abort: Arc<SessionAbortFlags>,
     /// Cloneable sender given to ConversationCoordinator for turn outcome notifications
     outcome_tx: mpsc::Sender<(String, TurnOutcome)>,
     /// When a user submits while `Processing`, engine yields after the current model round.
@@ -155,10 +109,10 @@ impl DialogScheduler {
         let scheduler = Arc::new(Self {
             coordinator,
             session_manager,
-            queues: Arc::new(DashMap::new()),
-            active_turns: Arc::new(DashMap::new()),
-            suppressed_cancelled_replies: Arc::new(DashMap::new()),
-            goal_continuation_abort: Arc::new(DashMap::new()),
+            queues: Arc::new(DialogTurnQueue::default()),
+            active_turns: Arc::new(ActiveDialogTurnStore::default()),
+            suppressed_cancelled_replies: Arc::new(DialogReplySuppressionSet::default()),
+            goal_continuation_abort: Arc::new(SessionAbortFlags::default()),
             outcome_tx,
             round_yield_flags: Arc::new(SessionRoundYieldFlags::default()),
             round_injection_buffer: Arc::new(SessionRoundInjectionBuffer::default()),
@@ -202,53 +156,48 @@ impl DialogScheduler {
         content: String,
         display_content: Option<String>,
     ) -> Result<DialogSteerOutcome, String> {
-        let active_matches_turn = match self
+        let active_turn_id = match self
             .session_manager
             .get_session(&session_id)
             .map(|s| s.state.clone())
         {
             Some(SessionState::Processing {
                 current_turn_id, ..
-            }) => current_turn_id == turn_id,
-            _ => false,
+            }) => Some(current_turn_id),
+            _ => None,
         };
-
-        if !active_matches_turn {
-            warn!(
-                "submit_steering rejected: target turn is not running: session_id={}, turn_id={}",
-                session_id, turn_id
-            );
-            return Err(format!(
-                "Dialog turn is no longer running and cannot be steered: session_id={}, turn_id={}",
-                session_id, turn_id
-            ));
-        }
 
         let steering_id = Uuid::new_v4().to_string();
-        let display = display_content.unwrap_or_else(|| content.clone());
-        let message = RoundInjection {
-            id: steering_id.clone(),
-            kind: RoundInjectionKind::UserSteering,
-            target: RoundInjectionTarget::ExactTurn(turn_id.clone()),
+        match resolve_dialog_steering_action(
+            active_turn_id.as_deref(),
+            &session_id,
+            &turn_id,
             content,
-            display_content: display,
-            created_at: SystemTime::now(),
-        };
-
-        self.round_injection_buffer.push(&session_id, message);
-        info!(
-            "Steering message buffered: session_id={}, turn_id={}, steering_id={}, pending={}",
-            session_id,
-            turn_id,
+            display_content,
             steering_id,
-            self.round_injection_buffer.pending_count(&session_id)
-        );
+            SystemTime::now(),
+        ) {
+            DialogSteeringAction::Reject { error } => {
+                warn!(
+                    "submit_steering rejected: target turn is not running: session_id={}, turn_id={}",
+                    session_id, turn_id
+                );
+                Err(error)
+            }
+            DialogSteeringAction::Buffer { injection, outcome } => {
+                self.round_injection_buffer.push(&session_id, injection);
+                let DialogSteerOutcome::Buffered { steering_id, .. } = &outcome;
+                info!(
+                    "Steering message buffered: session_id={}, turn_id={}, steering_id={}, pending={}",
+                    session_id,
+                    turn_id,
+                    steering_id,
+                    self.round_injection_buffer.pending_count(&session_id)
+                );
 
-        Ok(DialogSteerOutcome::Buffered {
-            session_id,
-            turn_id,
-            steering_id,
-        })
+                Ok(outcome)
+            }
+        }
     }
 
     /// Resume auto-continuation toward an active thread goal (after pause / blocked / usage limit).
@@ -276,14 +225,13 @@ impl DialogScheduler {
                     .unwrap_or_default();
                 self.round_injection_buffer.push(
                     &session_id,
-                    RoundInjection {
-                        id: Uuid::new_v4().to_string(),
-                        kind: RoundInjectionKind::ThreadGoalObjectiveUpdated,
-                        target: RoundInjectionTarget::CurrentRunningTurn,
-                        content: prompt,
-                        display_content: plan.display_message.clone(),
-                        created_at: SystemTime::now(),
-                    },
+                    resolve_background_delivery_injection(
+                        BackgroundInjectionKind::ThreadGoalObjectiveUpdated,
+                        Uuid::new_v4().to_string(),
+                        prompt,
+                        Some(plan.display_message.clone()),
+                        SystemTime::now(),
+                    ),
                 );
                 Ok(())
             }
@@ -340,14 +288,13 @@ impl DialogScheduler {
             BackgroundDeliveryAction::InjectIntoRunningTurn => {
                 self.round_injection_buffer.push(
                     &session_id,
-                    RoundInjection {
-                        id: Uuid::new_v4().to_string(),
-                        kind: RoundInjectionKind::ThreadGoalObjectiveUpdated,
-                        target: RoundInjectionTarget::CurrentRunningTurn,
-                        content: prompt,
-                        display_content: display,
-                        created_at: SystemTime::now(),
-                    },
+                    resolve_background_delivery_injection(
+                        BackgroundInjectionKind::ThreadGoalObjectiveUpdated,
+                        Uuid::new_v4().to_string(),
+                        prompt,
+                        Some(display),
+                        SystemTime::now(),
+                    ),
                 );
                 Ok(())
             }
@@ -408,17 +355,15 @@ impl DialogScheduler {
             session_state: Self::session_state_fact(state.as_ref()),
         }) {
             BackgroundDeliveryAction::InjectIntoRunningTurn => {
-                let injection_id = Uuid::new_v4().to_string();
                 self.round_injection_buffer.push(
                     &session_id,
-                    RoundInjection {
-                        id: injection_id,
-                        kind: RoundInjectionKind::BackgroundResult,
-                        target: RoundInjectionTarget::CurrentRunningTurn,
+                    resolve_background_delivery_injection(
+                        BackgroundInjectionKind::BackgroundResult,
+                        Uuid::new_v4().to_string(),
                         content,
-                        display_content: display,
-                        created_at: SystemTime::now(),
-                    },
+                        Some(display),
+                        SystemTime::now(),
+                    ),
                 );
                 Ok(())
             }
@@ -489,7 +434,7 @@ impl DialogScheduler {
     ///
     /// - Session idle, queue empty → dispatched immediately.
     /// - Session idle, queue non-empty → enqueued then highest-priority queued message dispatched.
-    /// - Session processing → queued (up to MAX_QUEUE_DEPTH). For interactive sources
+    /// - Session processing → queued up to the runtime-owned queue limit. For interactive sources
     ///   (desktop, CLI, bot, …), also requests a yield after the current model round so
     ///   the queued message can start sooner than a full multi-round turn.
     /// - Session error → queue cleared, dispatched immediately.
@@ -597,11 +542,7 @@ impl DialogScheduler {
             .get_session(&session_id)
             .map(|s| s.state.clone());
 
-        let queue_has_items = self
-            .queues
-            .get(&session_id)
-            .map(|q| !q.is_empty())
-            .unwrap_or(false);
+        let queue_has_items = self.queues.has_items(&session_id);
         let action = resolve_dialog_submit_queue_action(DialogSubmitQueueFacts {
             session_state: Self::session_state_fact(state.as_ref()),
             queue_has_items,
@@ -679,7 +620,7 @@ impl DialogScheduler {
 
     /// Number of messages currently queued for a session.
     pub fn queue_depth(&self, session_id: &str) -> usize {
-        self.queues.get(session_id).map(|q| q.len()).unwrap_or(0)
+        self.queues.depth(session_id)
     }
 
     /// Cancel the target session's active turn on behalf of a requester session.
@@ -695,20 +636,14 @@ impl DialogScheduler {
     ) -> crate::util::errors::BitFunResult<Option<String>> {
         let suppression_key = self
             .active_turns
-            .get(target_session_id)
-            .and_then(|active_turn| {
-                active_turn
-                    .should_suppress_cancelled_reply_for_requester(requester_session_id)
-                    .then(|| (target_session_id.to_string(), active_turn.turn_id.clone()))
-            });
+            .suppression_key_for_requester(target_session_id, requester_session_id);
 
         if let Some((session_id, turn_id)) = suppression_key.as_ref() {
             debug!(
                 "Suppressing cancelled auto-reply for agent-session turn: target_session_id={}, turn_id={}, requester_session_id={}",
                 session_id, turn_id, requester_session_id
             );
-            self.suppressed_cancelled_replies
-                .insert((session_id.clone(), turn_id.clone()), ());
+            self.suppressed_cancelled_replies.mark(session_id, turn_id);
         }
 
         abort_thread_goal_continuation_for_session(target_session_id);
@@ -722,7 +657,7 @@ impl DialogScheduler {
                 if cancelled_turn_id.is_none() {
                     if let Some((session_id, turn_id)) = suppression_key {
                         self.suppressed_cancelled_replies
-                            .remove(&(session_id, turn_id));
+                            .clear(&session_id, &turn_id);
                     }
                 }
                 Ok(cancelled_turn_id)
@@ -730,7 +665,7 @@ impl DialogScheduler {
             Err(error) => {
                 if let Some((session_id, turn_id)) = suppression_key {
                     self.suppressed_cancelled_replies
-                        .remove(&(session_id, turn_id));
+                        .clear(&session_id, &turn_id);
                 }
                 Err(error)
             }
@@ -740,68 +675,43 @@ impl DialogScheduler {
     // ── Private helpers ──────────────────────────────────────────────────────
 
     fn enqueue(&self, session_id: &str, queued_turn: QueuedTurn) -> Result<(), String> {
-        let queue_len = self.queues.get(session_id).map(|q| q.len()).unwrap_or(0);
-
-        if queue_len >= MAX_QUEUE_DEPTH {
-            warn!(
-                "Queue full, rejecting message: session_id={}, max={}",
-                session_id, MAX_QUEUE_DEPTH
-            );
-            return Err(format!(
-                "Message queue full for session {} (max {} messages)",
-                session_id, MAX_QUEUE_DEPTH
-            ));
-        }
-
-        self.queues
-            .entry(session_id.to_string())
-            .or_default()
-            .push_back(queued_turn.clone());
-        if let Some(mut queue) = self.queues.get_mut(session_id) {
-            if let Some(reordered_turn) = queue.pop_back() {
-                let insert_at = queue.iter().position(|existing| {
-                    existing.policy.queue_priority < reordered_turn.policy.queue_priority
-                });
-                if let Some(index) = insert_at {
-                    queue.insert(index, reordered_turn);
-                } else {
-                    queue.push_back(reordered_turn);
-                }
+        let priority = queued_turn.policy.queue_priority;
+        let new_len = match self.queues.enqueue(session_id, queued_turn, priority) {
+            Ok(new_len) => new_len,
+            Err(error) => {
+                let max_depth = self.queues.max_depth();
+                warn!(
+                    "Queue full, rejecting message: session_id={}, max={}",
+                    session_id, max_depth
+                );
+                return Err(error.to_string());
             }
-        }
+        };
 
-        let new_len = self.queues.get(session_id).map(|q| q.len()).unwrap_or(0);
         debug!(
             "Message queued: session_id={}, queue_depth={}, priority={:?}",
-            session_id, new_len, queued_turn.policy.queue_priority
+            session_id, new_len, priority
         );
         Ok(())
     }
 
     fn clear_queue(&self, session_id: &str) {
-        if let Some(mut queue) = self.queues.get_mut(session_id) {
-            let count = queue.len();
-            queue.clear();
-            if count > 0 {
-                info!(
-                    "Cleared {} queued messages: session_id={}",
-                    count, session_id
-                );
-            }
+        let count = self.queues.clear(session_id);
+        if count > 0 {
+            info!(
+                "Cleared {} queued messages: session_id={}",
+                count, session_id
+            );
         }
     }
 
     fn dequeue_next(&self, session_id: &str) -> Option<QueuedTurn> {
-        self.queues
-            .get_mut(session_id)
-            .and_then(|mut q| q.pop_front())
+        self.queues.dequeue_next(session_id)
     }
 
     fn requeue_front(&self, session_id: &str, turn: QueuedTurn) {
-        self.queues
-            .entry(session_id.to_string())
-            .or_default()
-            .push_front(turn);
+        let priority = turn.policy.queue_priority;
+        self.queues.requeue_front(session_id, turn, priority);
     }
 
     async fn try_start_next_queued(&self, session_id: &str) -> Result<Option<String>, String> {
@@ -817,7 +727,7 @@ impl DialogScheduler {
             return Ok(None);
         };
 
-        let remaining = self.queues.get(session_id).map(|q| q.len()).unwrap_or(0);
+        let remaining = self.queues.depth(session_id);
         info!(
             "Dispatching queued message: session_id={}, priority={:?}, remaining_queue_depth={}",
             session_id, next_turn.policy.queue_priority, remaining
@@ -925,8 +835,19 @@ impl DialogScheduler {
             })?;
 
         self.active_turns.insert(
-            session_id.to_string(),
-            ActiveTurn::from_queued_turn(queued_turn, resolved.clone()),
+            session_id,
+            ActiveDialogTurn::new(
+                resolved.clone(),
+                queued_turn.workspace_path.clone(),
+                queued_turn.agent_type.clone(),
+                queued_turn
+                    .original_user_input
+                    .clone()
+                    .unwrap_or_else(|| queued_turn.user_input.clone()),
+                queued_turn.user_message_metadata.clone(),
+                queued_turn.policy,
+                queued_turn.reply_route.clone(),
+            ),
         );
 
         Ok(resolved)
@@ -935,33 +856,24 @@ impl DialogScheduler {
     async fn forward_agent_session_reply(
         &self,
         responder_session_id: &str,
-        active_turn: &ActiveTurn,
-        outcome: &TurnOutcome,
+        plan: AgentSessionReplyPlan,
     ) {
-        if !active_turn.is_agent_session_request() {
-            return;
-        }
-
-        let Some(reply_route) = active_turn.reply_route.as_ref() else {
-            return;
-        };
-
-        let responder_workspace = active_turn
-            .workspace_path
-            .as_deref()
-            .unwrap_or("<unknown workspace>");
-        let reply_user_input = outcome.reply_text();
-        let prepended_messages =
-            Self::format_agent_session_reply(responder_session_id, responder_workspace, outcome);
+        let reply_user_input = plan.user_input;
+        let target_session_id = plan.target_session_id;
+        let target_workspace_path = plan.target_workspace_path;
+        let prepended_messages = vec![Message::internal_reminder(
+            InternalReminderKind::SessionMessageReply,
+            plan.reminder_text,
+        )];
 
         if let Err(error) = self
             .submit_with_prepended_messages(
-                reply_route.source_session_id.clone(),
+                target_session_id.clone(),
                 reply_user_input.clone(),
                 Some(reply_user_input),
                 None,
                 String::new(),
-                Some(reply_route.source_workspace_path.clone()),
+                Some(target_workspace_path),
                 DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession),
                 None,
                 None,
@@ -972,42 +884,13 @@ impl DialogScheduler {
         {
             warn!(
                 "Failed to forward agent-session reply: responder_session_id={}, source_session_id={}, error={}",
-                responder_session_id, reply_route.source_session_id, error
+                responder_session_id, target_session_id, error
             );
         }
     }
 
     fn take_suppressed_cancelled_reply(&self, session_id: &str, turn_id: &str) -> bool {
-        self.suppressed_cancelled_replies
-            .remove(&(session_id.to_string(), turn_id.to_string()))
-            .is_some()
-    }
-
-    fn should_skip_agent_session_reply(
-        outcome: &TurnOutcome,
-        suppressed_cancelled_reply: bool,
-    ) -> bool {
-        should_skip_agent_session_reply_contract(
-            turn_outcome_kind(outcome),
-            suppressed_cancelled_reply,
-        )
-    }
-
-    fn format_agent_session_reply(
-        responder_session_id: &str,
-        responder_workspace: &str,
-        outcome: &TurnOutcome,
-    ) -> Vec<Message> {
-        let status = outcome.status();
-        vec![Message::internal_reminder(
-            InternalReminderKind::SessionMessageReply,
-            format!(
-                "This message is an automated reply to a previous SessionMessage call, not a human user message.\n\
-From session: {responder_session_id}\n\
-From workspace: {responder_workspace}\n\
-Status: {status}"
-            ),
-        )]
+        self.suppressed_cancelled_replies.take(session_id, turn_id)
     }
 
     async fn dispatch_next_if_idle(&self, session_id: &str) -> Result<(), String> {
@@ -1031,17 +914,25 @@ Status: {status}"
             let suppressed_cancelled_reply =
                 self.take_suppressed_cancelled_reply(&session_id, outcome.turn_id());
 
-            let active_turn = self.active_turns.remove(&session_id).map(|(_, turn)| turn);
+            let active_turn = self.active_turns.remove(&session_id);
             if let Some(active_turn) = active_turn.as_ref() {
-                if Self::should_skip_agent_session_reply(&outcome, suppressed_cancelled_reply) {
-                    debug!(
-                        "Skipping cancelled auto-reply because the source session explicitly cancelled its own SessionMessage request: session_id={}, turn_id={}",
-                        session_id,
-                        outcome.turn_id()
-                    );
-                } else {
-                    self.forward_agent_session_reply(&session_id, active_turn, &outcome)
-                        .await;
+                match resolve_agent_session_reply_action(
+                    &session_id,
+                    active_turn,
+                    &outcome,
+                    suppressed_cancelled_reply,
+                ) {
+                    AgentSessionReplyAction::NoReply => {}
+                    AgentSessionReplyAction::SkipSuppressedCancelledReply => {
+                        debug!(
+                            "Skipping cancelled auto-reply because the source session explicitly cancelled its own SessionMessage request: session_id={}, turn_id={}",
+                            session_id,
+                            outcome.turn_id()
+                        );
+                    }
+                    AgentSessionReplyAction::Forward(plan) => {
+                        self.forward_agent_session_reply(&session_id, plan).await;
+                    }
                 }
             }
 
@@ -1054,7 +945,7 @@ Status: {status}"
 
             if let Some(active_turn) = active_turn.as_ref() {
                 if matches!(outcome, TurnOutcome::Cancelled { .. }) {
-                    self.goal_continuation_abort.insert(session_id.clone(), ());
+                    self.goal_continuation_abort.mark(&session_id);
                     debug!(
                         "Skipping thread goal continuation after user-cancelled turn: session_id={}, turn_id={}",
                         session_id,
@@ -1062,14 +953,14 @@ Status: {status}"
                     );
                 } else {
                     let turn_completed = matches!(outcome, TurnOutcome::Completed { .. });
-                    self.goal_continuation_abort.remove(&session_id);
+                    self.goal_continuation_abort.clear(&session_id);
                     match self
                         .coordinator
                         .prepare_goal_continuation_after_turn(
                             &session_id,
                             &outcome.turn_id(),
-                            &active_turn.user_input,
-                            active_turn.user_message_metadata.as_ref(),
+                            active_turn.user_input(),
+                            active_turn.user_message_metadata(),
                             turn_completed,
                         )
                         .await
@@ -1087,7 +978,7 @@ Status: {status}"
                                 .collect();
                             let mut last_error = None;
                             for attempt in 1..=MAX_THREAD_GOAL_AUTO_CONTINUATIONS {
-                                if self.goal_continuation_abort.contains_key(&session_id) {
+                                if self.goal_continuation_abort.contains(&session_id) {
                                     debug!(
                                         "Aborting goal continuation submit retries after user cancellation: session_id={}",
                                         session_id
@@ -1101,8 +992,8 @@ Status: {status}"
                                             .to_string(),
                                         Some(plan.display_message.clone()),
                                         None,
-                                        active_turn.agent_type.clone(),
-                                        active_turn.workspace_path.clone(),
+                                        active_turn.agent_type_owned(),
+                                        active_turn.workspace_path_owned(),
                                         DialogSubmissionPolicy::for_source(
                                             DialogTriggerSource::AgentSession,
                                         ),
@@ -1119,7 +1010,7 @@ Status: {status}"
                                     }
                                     Err(error) => {
                                         last_error = Some(error);
-                                        if self.goal_continuation_abort.contains_key(&session_id) {
+                                        if self.goal_continuation_abort.contains(&session_id) {
                                             debug!(
                                                 "Aborting goal continuation submit retries after user cancellation: session_id={}",
                                                 session_id
@@ -1146,7 +1037,7 @@ Status: {status}"
                                 }
                             }
                             if let Some(error) = last_error {
-                                if !self.goal_continuation_abort.contains_key(&session_id) {
+                                if !self.goal_continuation_abort.contains(&session_id) {
                                     warn!(
                                         "Failed to submit goal continuation turn after retries: session_id={}, error={}",
                                         session_id, error
@@ -1202,16 +1093,14 @@ pub fn set_global_scheduler(scheduler: Arc<DialogScheduler>) {
 /// Stop in-flight thread-goal continuation submit retries when the user cancels a turn.
 pub fn abort_thread_goal_continuation_for_session(session_id: &str) {
     if let Some(scheduler) = get_global_scheduler() {
-        scheduler
-            .goal_continuation_abort
-            .insert(session_id.to_string(), ());
+        scheduler.goal_continuation_abort.mark(session_id);
     }
 }
 
 /// Allow goal auto-continuation again after the user explicitly resumes a paused goal.
 pub fn clear_thread_goal_continuation_abort(session_id: &str) {
     if let Some(scheduler) = get_global_scheduler() {
-        scheduler.goal_continuation_abort.remove(session_id);
+        scheduler.goal_continuation_abort.clear(session_id);
     }
 }
 
@@ -1219,19 +1108,19 @@ pub fn clear_thread_goal_continuation_abort(session_id: &str) {
 mod tests {
     use super::*;
 
-    fn agent_session_active_turn(source_session_id: &str) -> ActiveTurn {
-        ActiveTurn {
-            turn_id: "turn_1".to_string(),
-            workspace_path: Some("/workspace".to_string()),
-            agent_type: "agentic".to_string(),
-            user_input: "hello".to_string(),
-            user_message_metadata: None,
-            policy: DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession),
-            reply_route: Some(AgentSessionReplyRoute {
+    fn agent_session_active_turn(source_session_id: &str) -> ActiveDialogTurn {
+        ActiveDialogTurn::new(
+            "turn_1".to_string(),
+            Some("/workspace".to_string()),
+            "agentic".to_string(),
+            "hello".to_string(),
+            None,
+            DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession),
+            Some(AgentSessionReplyRoute {
                 source_session_id: source_session_id.to_string(),
                 source_workspace_path: "/source".to_string(),
             }),
-        }
+        )
     }
 
     #[test]
@@ -1243,6 +1132,7 @@ mod tests {
 
     #[test]
     fn cancelled_reply_is_skipped_only_when_suppressed() {
+        let active_turn = agent_session_active_turn("session_a");
         let cancelled = TurnOutcome::Cancelled {
             turn_id: "turn_1".to_string(),
         };
@@ -1251,14 +1141,17 @@ mod tests {
             final_response: "done".to_string(),
         };
 
-        assert!(DialogScheduler::should_skip_agent_session_reply(
-            &cancelled, true
+        assert_eq!(
+            resolve_agent_session_reply_action("session_b", &active_turn, &cancelled, true),
+            AgentSessionReplyAction::SkipSuppressedCancelledReply
+        );
+        assert!(matches!(
+            resolve_agent_session_reply_action("session_b", &active_turn, &cancelled, false),
+            AgentSessionReplyAction::Forward(_)
         ));
-        assert!(!DialogScheduler::should_skip_agent_session_reply(
-            &cancelled, false
-        ));
-        assert!(!DialogScheduler::should_skip_agent_session_reply(
-            &completed, true
+        assert!(matches!(
+            resolve_agent_session_reply_action("session_b", &active_turn, &completed, true),
+            AgentSessionReplyAction::Forward(_)
         ));
     }
 


### PR DESCRIPTION
﻿## 摘要
- 将 per-session dialog queue owner 迁入 `bitfun-agent-runtime`，承接 max depth、priority ordering、FIFO、overflow error、clear/dequeue/requeue/depth。
- 将 active dialog turn facts、cancelled-reply suppression set、goal-continuation abort flags、SessionMessage reply plan、steering action plan 和 background running-turn injection construction 迁入 `bitfun-agent-runtime`。
- `bitfun-core::agentic::coordination::scheduler` 保留 concrete submit/start-turn/coordinator/session-manager wiring、background delivery entrypoint 和 idle follow-up submission，不再直接持有 queue storage、active-turn fact map、suppression set、abort flag map、reply formatter、steering injection 或 background injection construction。
- 更新 boundary check、scheduler owner contracts、`AGENTS.md` 和 core decomposition plan/completed docs，防止 owner 回流。

## 功能边界
- 不改变 queue max depth、priority ordering、same-priority FIFO、overflow error text、cancelled reply suppression、goal continuation abort/retry semantics。
- `requeue_front` 保留旧 priority 语义：重试项先回到队首，但后续新 High priority 仍可按旧排序规则插入到 Low retry 前。
- 不改变 SessionMessage auto-reply reminder text、cancelled auto-reply suppression、steering rejection error text、steering display fallback、`DialogSteerOutcome::Buffered` shape、background result display fallback 或 `RoundInjection` kind/target。
- 不迁移 concrete scheduler lifecycle、event delivery、permission `Tool` handler、post-turn hook、SessionManager persistence、coordinator start/cancel behavior 或 persisted thread-goal metadata store。
- 不修改 UI、Tauri/API wire shape、tool exposure、permission 策略、默认产品能力或 feature matrix。

## 验证
- `cargo test -p bitfun-agent-runtime --test scheduler_contracts -- --nocapture`
- `cargo test -p bitfun-core scheduler -- --nocapture`
- `node scripts/check-core-boundaries.mjs`
- `cargo check -p bitfun-core --features product-full`
- `cargo check -p bitfun-core --no-default-features`
- `pnpm run check:repo-hygiene`
- `git diff --check`
- `cargo tree -p bitfun-agent-runtime --edges normal`

Refs #970
