### PR TITLE
refactor(runtime): migrate session store and tool IO owners

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -142,18 +142,57 @@
 - PR-C 只证明 capability / harness / tool provider 组装边界和 no-default / dependency profile 未扩大；不迁移缺少等价保护的
   concrete IO、MiniApp worker/host、function-agent Git/AI 或 scheduler/event/permission lifecycle。
 
+### 1.8 Session Store / Restore Runtime Services Owner：restore 热路径边界
+
+- `bitfun-runtime-ports` 已承接 session store / restore view 的稳定 request、storage path resolution、
+  full/tail turn-load request、`SessionTurnLoadTiming` 和 `SessionViewRestoreTiming`。
+- `SessionStorePort` 已从空 capability marker 扩展为 typed storage path resolution port；`bitfun-runtime-services`
+  fake provider 和 contract test 覆盖该方法。
+- `bitfun-core` 新增 `CoreSessionStorePort` concrete adapter，承接 local / remote / unresolved remote
+  session storage path facts；`SessionManager` 保留旧方法签名，但 path resolution 委托 adapter。
+- `PersistenceManager` 的 full/tail load hot path 改为消费 `SessionTurnLoadRequest`，原有
+  `load_session_with_turns(_timed)` 和 `load_session_with_tail_turns(_timed)` API 保持兼容。
+- Desktop `restore_session_view` 复用 `SessionViewRestoreRequest` 的 tail 归一规则，保留既有 16-turn
+  UI view clamp、旧 response shape、tool-result preview compact 和 startup timing 记录。
+
+明确未完成：
+
+- `SessionManager` concrete 生命周期、auto-save / cleanup、event delivery、prompt assembly 和 runtime context restore
+  仍在 core。
+- session persistence 的具体文件 IO、metadata/index 写入、turn read/write、snapshot restore 和 cold restore 行为
+  仍在 core concrete path；后续迁移必须补充端到端等价和性能保护。
+
+### 1.9 Concrete Tool IO Runtime Owner：本地 tool IO 执行边界
+
+- `bitfun-tool-runtime` 已承接本地 Write / Edit / Delete / Glob 的具体 filesystem/search 执行 primitive：
+  文件写入的 created/overwritten/idempotent retry 结果、edit apply/write-back、delete target inspect/delete 和 glob
+  `rg` / fallback walk 执行与浅层优先限流。
+- `bitfun-core` 保留 agent-facing `Tool` adapter、tool name/schema/prompt stub、readonly/enabled exposure、
+  permission admission、checkpoint hook、file-read freshness、workspace-search 优先路径、remote shell fallback、
+  MCP/ACP catalog 和产品组装边界。
+- 新增 `tool-runtime` 契约测试覆盖本地 write/edit/delete/glob owner 行为；core focused tests 继续覆盖原有
+  FileWrite / FileEdit / Glob 兼容路径。
+
+明确未完成：
+
+- Bash / terminal lifecycle、indexed workspace search service、remote shell execution、permission `Tool` handler 和
+  checkpoint orchestration 仍不属于 `bitfun-tool-runtime` concrete owner。
+- 继续迁移 shell、terminal、remote 或 indexed search 时，必须先补 scheduler / terminal lifecycle / remote protocol
+  等价保护，不能复用本地 filesystem primitive 的低风险假设。
+
 ## 2. 已建立保护
 
 - 新 owner crate 不得依赖回 `bitfun-core`。
 - `product-full` 是完整产品能力保护开关。
 - 构建脚本和 installer 相关脚本不作为 core 拆解的一部分修改。
 - boundary check 覆盖已外移 owner 的旧路径 facade-only / 禁止回流状态。
-- tool manifest、`GetToolSpec`、execution admission gate、MiniApp storage layout adapter、product-domain pure helper、remote workspace search fallback、MCP config / catalog / dynamic manifest、agent-runtime prompt cache、agent registry source/profile facts、product capability pack 和 harness/tool provider assembly 等已有 focused baseline。
+- tool manifest、`GetToolSpec`、execution admission gate、MiniApp storage layout adapter、product-domain pure helper、remote workspace search fallback、MCP config / catalog / dynamic manifest、agent-runtime prompt cache、agent registry source/profile facts、product capability pack、harness/tool provider assembly、session restore path/timing facts 和本地 tool IO primitive 等已有 focused baseline。
 
 ## 3. 当前剩余结论
 
 - 低风险准备项已经完成，不再新增零散小 PR。
-- PR-C 已收敛 Harness / Product Capability / Build-Benefit closure。后续不应继续拆零散 helper PR；若继续迁移
-  MiniApp worker/host、function-agent Git/AI、具体 IO tools、Agent Runtime concrete scheduler/event/permission/post-turn
-  hook，必须先补端到端等价保护并作为新的完整 owner PR 评估。
+- PR-C 已收敛 Harness / Product Capability / Build-Benefit closure；PR-1 已收敛 session restore hot-path
+  request / timing / storage path facts 和 Runtime Services port；PR-2 已收敛本地 Write / Edit / Delete / Glob
+  concrete IO primitive。后续不应继续拆零散 helper PR；若继续迁移 MiniApp worker/host、function-agent Git/AI、
+  Bash/terminal/remote shell/indexed search、Agent Runtime concrete scheduler/event/permission/post-turn hook，必须先补端到端等价保护并作为新的完整 owner PR 评估。
 - 缺陷修复、行为变更、冗余清理、三方库升级和构建脚本调整必须独立评估，不能伪装成 core decomposition 剩余里程碑。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -68,51 +68,14 @@ workspace build 证明没有行为或 feature 影响。
 
 ## 4. 后续迁移队列
 
-后续迁移收敛为 PR-A / PR-B / PR-C 三个大型 PR。每个 PR 必须迁移真实 owner 逻辑，并同时包含旧路径兼容、focused tests、boundary check 和提交前对抗性审核。只新增抽象、只补 facade 或只增加 guard 不满足准出要求。
+PR-A / PR-B / PR-C、scheduler owner decision 扩展和 PR-1 Session Store / Restore Runtime Services Owner 已进入完成归档。后续不再沿用这些编号作为活跃队列；活跃计划只保留仍未完成、且需要端到端等价保护的高风险 owner 迁移。每个 PR 必须迁移真实 owner 逻辑，并同时包含旧路径兼容、focused tests、boundary check 和提交前对抗性审核。只新增抽象、只补 facade 或只增加 guard 不满足准出要求。
 
 | PR | 主题 | 完整范围 | 不允许混入 | 合入门禁 |
 |---|---|---|---|---|
-| PR-A | Agent Runtime SDK Owner Closure | 承接 prompt cache policy / identity / DTO / in-memory store、shared mode profile / context policy、mode / subagent source presentation facts，并保持 core agent registry 与 session manager 旧路径兼容 | concrete scheduler 生命周期、event emitter、post-turn hook、permission `Tool` handler、custom subagent file IO、产品命令或默认 feature 变更 | `bitfun-agent-runtime` 独立测试、core agents / prompt-cache focused tests、boundary check、repo hygiene、`cargo check -p bitfun-core --features product-full` |
-| PR-B | Product-Domain + Tool Runtime Owner Closure | 完成 MiniApp builtin bundle asset owner、ToolUseContext runtime handle bundle、product registry materialization、collapsed unlock lifecycle state，并保持旧路径与产品 tool exposure 兼容 | Agent Runtime scheduler / event 行为、Harness execution、feature matrix、UI 或产品语义变更、MiniApp worker / host dispatch、function-agent Git / AI concrete service、具体 IO tool 行为 | MiniApp builtin seed regressions、function-agent facade regressions、tool pipeline focused regressions，runtime/service port 边界清晰，产品 surface 不变 |
-| PR-C | Harness / Capability / Build-Benefit Closure | 推进 Harness execution / Product Capability pack / service-tool orchestration；评估 MiniApp worker/host、function-agent Git/AI、具体 IO tools 是否具备进一步外移保护；同时评估 feature matrix、dependency profile、no-default 编译面、构建收益和可选 crate 目录分组 | 默认 feature 副作用、未验证的构建脚本调整、未补等价保护的进程/权限/AI provider 迁移 | Harness workflow 等价、capability pack 注册可测、cargo metadata / cargo tree 证据，产品入口完整能力不变 |
+| PR-3 | Product-Domain Concrete Runtime Owner | 在端到端保护下评估并迁移 MiniApp worker/host/seed IO 或 function-agent Git/AI concrete service 的可移动部分；必须先拆清 process、permission、`PathManager`、provider acquisition 和 fallback 边界 | 同时迁移 MiniApp worker 与 function-agent Git/AI 全部主体；worker lifecycle、host primitive dispatch、seed marker、Git/no-HEAD fallback 或 AI provider error mapping 变更 | MiniApp import/sync/recompile/rollback/deps regression，function-agent Git/AI fallback regression，product surface checks，`cargo check -p bitfun-core --features product-full` |
+| PR-4 | Agent Runtime Lifecycle / Event / Permission Closure | 仅在 PR-1/PR-2 保护足够后，评估 scheduler lifecycle、event delivery、permission `Tool` handler、post-turn hook、agent definition loading 和 custom subagent file IO 的可迁移边界 | 用 owner contract test 替代端到端行为证明；session lifecycle、event ordering、goal tool wire shape、DeepResearch citation/post-turn behavior 变更 | queue/preempt/cancel/goal verification/event focused tests，DeepResearch citation/post-turn tests，permission tool handler tests，`cargo check --workspace` |
 
-### 4.1 PR-A 实施状态
-
-PR-A 只迁移无 IO、无副作用、可由 contract test 证明等价的 Agent Runtime SDK owner 事实。当前分支已经覆盖：
-
-1. `bitfun-agent-runtime::prompt_cache` 承接 prompt cache schema、policy、identity、DTO、scope key 和 in-memory store。
-2. `bitfun-agent-runtime::agents` 承接 shared coding mode profile、mode presentation rank、shared user-context policy、`SubAgentSource` DTO、source kind 与 presentation rank。
-3. `bitfun-core` 保留 `agentic::session::prompt_cache`、agent mode module 和 registry DTO 旧路径 re-export；session persistence、clone/cold restore、agent definition loading、custom subagent file IO、scheduler lifecycle 和 event delivery 仍在 core。
-4. `scripts/check-core-boundaries.mjs` 已增加 prompt cache、shared mode profile/context、mode/source presentation 和 `SubAgentSource` 的防回流规则。
-5. focused tests 覆盖 runtime contracts、core agent registry、prompt cache restore/clone/invalidation 和 boundary check。
-
-不继续纳入 PR-A 的内容：concrete scheduler 生命周期、event delivery / post-turn hook、permission coordination 的 `Tool` handler 和 custom subagent file IO。这些路径直接连接事件发送、调度执行或文件/配置 IO，若迁移必须在 PR-B/PR-C 前单独补可观测行为等价保护，不能作为“纯 owner 事实迁移”处理。
-
-### 4.2 PR-B 实施状态
-
-PR-B 收敛 Product-Domain 与 Tool Runtime 的真实 owner 逻辑，但不移动会改变进程、权限、Git/AI provider 或具体 IO 行为的实现。当前分支覆盖：
-
-1. `bitfun-product-domains::miniapp::builtin::BUILTIN_APPS` 承接内置 MiniApp bundle identity、版本和 embedded asset；`bitfun-core::miniapp::builtin` 保留旧路径 re-export、seed 写盘、marker IO、用户 storage 保留和 recompile。
-2. `bitfun-runtime-ports::ToolRuntimeHandles` 承接 tool execution context 的 workspace services 与 cancellation handle bundle；`ToolUseContext` 保留 core owner 类型、path/runtime lookup、portable facts 投影和具体 tool 调用上下文。
-3. `product_runtime/materialization.rs` 承接 product provider group plan 到 concrete tool 的 materialization，保持 provider order、tool name 和 registry exposure 不变。
-4. `product_runtime/unlock_state.rs` 承接 collapsed unlock 的 message-derived lifecycle state；`ExecutionEngine` 不再直接解析 `GetToolSpec` result。
-
-不继续纳入 PR-B 的内容：MiniApp worker process / host dispatch、builtin marker IO / seed 写盘、function-agent Git / AI concrete service、具体 IO tools。这些路径连接进程执行、权限检查、文件系统、shell、Git、AI provider 或用户可见工具行为，后续若迁移必须先补等价保护后再以完整 owner PR 评估。
-
-### 4.3 PR-C 实施状态
-
-PR-C 收敛 Harness / Product Capability / Build-Benefit closure，不把缺少等价保护的 concrete runtime 行为强行外移。当前分支覆盖：
-
-1. 新增 `bitfun-product-capabilities`，承接产品能力包 assembly facts：capability id、required runtime service capability、tool provider group id selection 和 harness provider selection。
-2. `bitfun-harness` 承接 provider-neutral harness descriptor 与 descriptor registry builder；`bitfun-core::agentic::harness` 改为消费 `bitfun-product-capabilities::default_product_harness_registry()`，core 不再硬编码 Deep Review / DeepResearch / MiniApp harness provider descriptor。
-3. `bitfun-tool-packs` 承接 tool provider group plan、按 id 选择 plan 和未知 provider group 校验；`ProductToolRuntime` 改为通过 Product Capability assembly 获取默认产品 tool provider group plan，tool group id 选择由 Product Capability pack 表达。
-4. `bitfun-agent-tools` 承接 provider-neutral static provider materialization 和 plan-to-registry assembly；core 不再拥有 provider plan 遍历、provider group 构建、未知工具项错误处理或 registry 安装主体算法，只保留具体 tool constructor factory、product plan adapter 和兼容 facade。
-5. Product Capability assembly 同时暴露 service requirement、tool provider group plan 和 harness provider selection；上层组装器可用外部 service availability 检查 capability 缺口，不需要依赖 concrete runtime service bundle。
-6. `scripts/check-core-boundaries.mjs` 增加 product-capabilities 防回流、harness descriptor owner、agent-tools generic materializer / registry assembly 和 core concrete factory adapter 检查，确保 owner 迁移不会回退成 core 内主体算法。
-7. tool-pack selector 对未知 tool provider group 显式报错，static provider materializer 对未知 concrete tool 显式报错，避免配置错误被静默过滤成工具能力缺失。
-8. cargo tree / metadata 证据显示 `bitfun-product-capabilities` 只依赖 `bitfun-harness`、`bitfun-runtime-ports`、`bitfun-tool-packs`；`bitfun-core --no-default-features` 不选入 product owner deps，相关 owner 依赖保持 optional。
-
-PR-C 评估后不继续迁移的内容：MiniApp worker process / host dispatch / builtin marker IO / seed 写盘、function-agent Git / AI concrete service、具体 IO tools、Agent Runtime concrete scheduler / event delivery / permission `Tool` handler / post-turn hook。这些路径仍缺少足够的端到端等价保护或会触及进程、权限、AI provider、filesystem/shell、checkpoint hook、session lifecycle 等用户可见行为，后续若迁移必须单独以完整 owner PR 处理。
+计划优先级：PR-3 先做。PR-1 和 PR-2 已进入完成归档；后续不应继续触碰 session restore 热路径或已迁移的本地 tool IO primitive，除非是修复等价测试发现的问题。
 
 ## 5. 每类 PR 的保护重点
 
@@ -163,7 +126,8 @@ PR-C 评估后不继续迁移的内容：MiniApp worker process / host dispatch 
   只保留 product plan、decorator 与旧路径兼容入口。
 - workspace service contract 暂时保留既有 `anyhow::Result` 和 `CancellationToken` 语义，避免在 owner 迁移 PR 中同时改变
   错误分类、取消语义或调用方边界；后续若要收敛为 portable `PortResult`，必须单独补错误映射等价测试。
-- 后续不直接搬全部 concrete tools；具体 IO tools 只有在权限、filesystem/shell 行为和 checkpoint hook 均有等价保护时才允许进入 PR-C。
+- 本地 Write / Edit / Delete / Glob 的具体 filesystem/search 执行 primitive 已迁入 `bitfun-tool-runtime`；core 保留 `Tool` adapter、权限、checkpoint、file-read freshness、workspace-search 和 remote fallback。
+- 后续若继续迁移 Bash、terminal、indexed workspace search 或 remote shell execution，必须先证明 scheduler、terminal lifecycle、remote protocol 和 checkpoint 行为等价，不能把它们当作普通本地 IO helper 直接搬移。
 - 保留 tool name、schema、prompt stub、readonly/enabled/filtering、unlock state 生命周期。
 - 验证 builtin tool list、provider order、expanded/collapsed exposure、dynamic provider metadata、Deep Review 修改类工具 checkpoint hook。
 

--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -22,7 +22,7 @@ use bitfun_core::agentic::deep_review_policy::{
 };
 use bitfun_core::agentic::goal_mode::{ThreadGoal, ThreadGoalStatus};
 use bitfun_core::agentic::image_analysis::ImageContextData;
-use bitfun_core::agentic::session::SessionViewRestoreTiming;
+use bitfun_core::agentic::session::{SessionViewRestoreRequest, SessionViewRestoreTiming};
 use bitfun_core::agentic::tools::image_context::get_image_context;
 use bitfun_core::service::session::{DialogTurnData, SessionRelationship};
 
@@ -1571,30 +1571,41 @@ pub async fn restore_session_view(
             path_started_at.elapsed().as_millis()
         );
 
-        let tail_turn_count = request.tail_turn_count.filter(|count| *count > 0);
+        let view_request = SessionViewRestoreRequest {
+            workspace_path: effective_path,
+            session_id: request.session_id.clone(),
+            include_internal: request.include_internal,
+            tail_turn_count: request.tail_turn_count,
+        };
+        let tail_turn_count = view_request
+            .tail_turn_count
+            .filter(|count| *count > 0)
+            .map(|count| count.min(16));
         let (session, mut turns, total_turn_count, timings) =
             if let Some(tail_turn_count) = tail_turn_count {
-                let tail_turn_count = tail_turn_count.min(16);
-                if request.include_internal {
+                if view_request.include_internal {
                     coordinator
                         .restore_internal_session_view_tail_timed(
-                            &effective_path,
-                            &request.session_id,
+                            &view_request.workspace_path,
+                            &view_request.session_id,
                             tail_turn_count,
                         )
                         .await
                 } else {
                     coordinator
                         .restore_session_view_tail_timed(
-                            &effective_path,
-                            &request.session_id,
+                            &view_request.workspace_path,
+                            &view_request.session_id,
                             tail_turn_count,
                         )
                         .await
                 }
-            } else if request.include_internal {
+            } else if view_request.include_internal {
                 coordinator
-                    .restore_internal_session_view_timed(&effective_path, &request.session_id)
+                    .restore_internal_session_view_timed(
+                        &view_request.workspace_path,
+                        &view_request.session_id,
+                    )
                     .await
                     .map(|(session, turns, timings)| {
                         let total_turn_count = turns.len();
@@ -1602,7 +1613,7 @@ pub async fn restore_session_view(
                     })
             } else {
                 coordinator
-                    .restore_session_view_timed(&effective_path, &request.session_id)
+                    .restore_session_view_timed(&view_request.workspace_path, &view_request.session_id)
                     .await
                     .map(|(session, turns, timings)| {
                         let total_turn_count = turns.len();

--- a/src/crates/core/AGENTS-CN.md
+++ b/src/crates/core/AGENTS-CN.md
@@ -40,6 +40,7 @@ SessionManager -> Session -> DialogTurn -> ModelRound
   port/provider 设计与行为等价测试前继续留在 core。
 - Tool 改动必须保持 expanded/collapsed exposure、prompt-visible manifest、`GetToolSpec`、权限行为、
   `ToolUseContext` 语义，以及 desktop/MCP/ACP catalog 行为等价。
+- Runtime owner 迁移在目标 owner 具备评审过的 port/provider 设计和行为等价测试前，不应移动 concrete lifecycle、IO、event delivery、permission orchestration 或 remote/platform provider。
 - Product-domain 改动不得在没有明确 owner 设计和 focused regression 覆盖前，把 filesystem writes、worker/host execution、
   Git/AI concrete calls、marker IO 或 path-manager integration 移出 core。
 - Remote/service 改动必须保持 external protocol lifecycle、workspace projection、scheduler/session restore、

--- a/src/crates/core/AGENTS.md
+++ b/src/crates/core/AGENTS.md
@@ -51,17 +51,16 @@ SessionManager -> Session -> DialogTurn -> ModelRound
 - Tool changes must preserve expanded/collapsed exposure, prompt-visible
   manifests, `GetToolSpec`, permission behavior, `ToolUseContext` semantics, and
   desktop/MCP/ACP catalog behavior.
+- Runtime-owner migrations must keep concrete lifecycle, IO, event delivery,
+  permission orchestration, and remote/platform providers in core until the
+  target owner has a reviewed port/provider design plus behavior-equivalence
+  tests.
 - Product-domain changes must not move filesystem writes, worker/host execution,
   Git/AI concrete calls, marker IO, or path-manager integration out of core
   without an explicit owner design and focused regression coverage.
 - Remote/service changes must keep external protocol lifecycle, workspace
   projection, scheduler/session restore, terminal pre-warm, and product
   execution boundaries explicit.
-- Scheduler changes should keep queue state, active-turn facts, background
-  running-turn injection construction, cancelled-reply suppression state, steering action planning,
-  agent-session reply planning, and goal-continuation abort flags in
-  `bitfun-agent-runtime`; core keeps coordinator, session-manager wiring,
-  delivery, and concrete lifecycle until an equivalence-protected migration.
 - Feature work must keep `product-full` as the compatibility product assembly
   boundary unless a separate product matrix review changes default capability
   selection.

--- a/src/crates/core/Cargo.toml
+++ b/src/crates/core/Cargo.toml
@@ -46,7 +46,6 @@ axum = { workspace = true }
 tower-http = { workspace = true }
 
 glob = { workspace = true, optional = true }
-ignore = { workspace = true }
 notify = { workspace = true }
 dirs = { workspace = true }
 dunce = { workspace = true }
@@ -63,8 +62,6 @@ which = { workspace = true }
 similar = { workspace = true, optional = true }
 urlencoding = { workspace = true }
 
-grep-searcher = { workspace = true }
-grep-regex = { workspace = true }
 globset = { workspace = true, optional = true }
 
 eventsource-stream = { workspace = true, optional = true }

--- a/src/crates/core/src/agentic/persistence/manager.rs
+++ b/src/crates/core/src/agentic/persistence/manager.rs
@@ -21,6 +21,7 @@ use crate::service::session::{
 use crate::service::workspace_runtime::WorkspaceRuntimeService;
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::timing::elapsed_ms_u64;
+use bitfun_runtime_ports::{SessionTurnLoadRequest, SessionTurnLoadTiming};
 use futures::{stream, StreamExt};
 use log::{debug, info, warn};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -49,24 +50,6 @@ struct StoredDialogTurnFile {
     schema_version: u32,
     #[serde(flatten)]
     turn: DialogTurnData,
-}
-
-#[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SessionTurnLoadTiming {
-    pub requested_tail_turn_count: Option<usize>,
-    pub loaded_turn_count: usize,
-    pub total_turn_count: usize,
-    pub turn_file_count: usize,
-    pub missing_turn_file_count: usize,
-    pub fast_path: bool,
-    pub metadata_duration_ms: u64,
-    pub state_duration_ms: u64,
-    pub scan_duration_ms: u64,
-    pub read_duration_ms: u64,
-    pub max_turn_read_duration_ms: u64,
-    pub build_session_duration_ms: u64,
-    pub total_duration_ms: u64,
 }
 
 struct ReadTurnPathsResult {
@@ -2445,25 +2428,33 @@ impl PersistenceManager {
         workspace_path: &Path,
         session_id: &str,
     ) -> BitFunResult<(Session, Vec<DialogTurnData>, SessionTurnLoadTiming)> {
+        let request = SessionTurnLoadRequest {
+            workspace_path: workspace_path.to_path_buf(),
+            session_id: session_id.to_string(),
+            tail_turn_count: None,
+        };
         let started_at = Instant::now();
         let metadata_started_at = Instant::now();
         let metadata = self
-            .load_session_metadata(workspace_path, session_id)
+            .load_session_metadata(&request.workspace_path, &request.session_id)
             .await?
             .ok_or_else(|| {
-                BitFunError::NotFound(format!("Session metadata not found: {}", session_id))
+                BitFunError::NotFound(format!(
+                    "Session metadata not found: {}",
+                    request.session_id
+                ))
             })?;
         let metadata_duration_ms = elapsed_ms_u64(metadata_started_at);
 
         let state_started_at = Instant::now();
         let stored_state = self
-            .load_stored_session_state(workspace_path, session_id)
+            .load_stored_session_state(&request.workspace_path, &request.session_id)
             .await?;
         let state_duration_ms = elapsed_ms_u64(state_started_at);
 
         let scan_started_at = Instant::now();
         let indexed_paths = self
-            .list_indexed_turn_paths(workspace_path, session_id)
+            .list_indexed_turn_paths(&request.workspace_path, &request.session_id)
             .await?;
         let scan_duration_ms = elapsed_ms_u64(scan_started_at);
 
@@ -2483,7 +2474,7 @@ impl PersistenceManager {
         if total_duration_ms >= 80 || turn_file_count >= 50 {
             debug!(
                 "Loaded session turns: session_id={} turn_count={} turn_file_count={} missing_turn_file_count={} metadata_duration_ms={} state_duration_ms={} scan_duration_ms={} read_duration_ms={} max_turn_read_duration_ms={} build_session_duration_ms={} total_duration_ms={}",
-                session_id,
+                request.session_id,
                 turns.len(),
                 turn_file_count,
                 missing_turn_file_count,
@@ -2533,27 +2524,35 @@ impl PersistenceManager {
         session_id: &str,
         tail_turn_count: usize,
     ) -> BitFunResult<(Session, Vec<DialogTurnData>, usize, SessionTurnLoadTiming)> {
+        let request = SessionTurnLoadRequest {
+            workspace_path: workspace_path.to_path_buf(),
+            session_id: session_id.to_string(),
+            tail_turn_count: Some(tail_turn_count),
+        };
         let started_at = Instant::now();
         let metadata_started_at = Instant::now();
         let metadata = self
-            .load_session_metadata(workspace_path, session_id)
+            .load_session_metadata(&request.workspace_path, &request.session_id)
             .await?
             .ok_or_else(|| {
-                BitFunError::NotFound(format!("Session metadata not found: {}", session_id))
+                BitFunError::NotFound(format!(
+                    "Session metadata not found: {}",
+                    request.session_id
+                ))
             })?;
         let metadata_duration = metadata_started_at.elapsed();
 
         let state_started_at = Instant::now();
         let stored_state = self
-            .load_stored_session_state(workspace_path, session_id)
+            .load_stored_session_state(&request.workspace_path, &request.session_id)
             .await?;
         let state_duration = state_started_at.elapsed();
 
         let fast_path_started_at = Instant::now();
         let fast_path_turns = self
             .read_metadata_tail_turns(
-                workspace_path,
-                session_id,
+                &request.workspace_path,
+                &request.session_id,
                 metadata.turn_count,
                 tail_turn_count,
             )
@@ -2581,7 +2580,7 @@ impl PersistenceManager {
         } else {
             let scan_started_at = Instant::now();
             let indexed_paths = self
-                .list_indexed_turn_paths(workspace_path, session_id)
+                .list_indexed_turn_paths(&request.workspace_path, &request.session_id)
                 .await?;
             let scan_duration = scan_started_at.elapsed();
             let total_turn_count = indexed_paths.len();
@@ -2610,9 +2609,9 @@ impl PersistenceManager {
         if total_duration >= Duration::from_millis(40) || total_turn_count >= 50 {
             debug!(
                 "Loaded session tail view: session_id={} turn_count={} requested_count={} total_turn_count={} missing_turn_file_count={} fast_path={} metadata_duration_ms={} state_duration_ms={} scan_duration_ms={} read_duration_ms={} max_turn_read_duration_ms={} build_session_duration_ms={} total_duration_ms={}",
-                session_id,
+                request.session_id,
                 turns.len(),
-                tail_turn_count,
+                request.tail_turn_count.unwrap_or(tail_turn_count),
                 total_turn_count,
                 missing_turn_file_count,
                 fast_path,
@@ -2627,7 +2626,7 @@ impl PersistenceManager {
         }
 
         let timing = SessionTurnLoadTiming {
-            requested_tail_turn_count: Some(tail_turn_count),
+            requested_tail_turn_count: request.tail_turn_count,
             loaded_turn_count: turns.len(),
             total_turn_count,
             turn_file_count: total_turn_count,

--- a/src/crates/core/src/agentic/persistence/mod.rs
+++ b/src/crates/core/src/agentic/persistence/mod.rs
@@ -5,5 +5,6 @@
 pub mod manager;
 pub mod session_branch;
 
-pub use manager::{PersistenceManager, SessionMetadataPage, SessionTurnLoadTiming};
+pub use bitfun_runtime_ports::SessionTurnLoadTiming;
+pub use manager::{PersistenceManager, SessionMetadataPage};
 pub use session_branch::{SessionBranchRequest, SessionBranchResult};

--- a/src/crates/core/src/agentic/session/mod.rs
+++ b/src/crates/core/src/agentic/session/mod.rs
@@ -8,6 +8,7 @@ pub mod evidence_ledger;
 pub mod file_read_state;
 pub mod prompt_cache;
 pub mod session_manager;
+pub mod session_store_port;
 pub mod turn_skill_agent_snapshot_store;
 
 pub use compression::*;
@@ -16,4 +17,10 @@ pub use evidence_ledger::*;
 pub use file_read_state::*;
 pub use prompt_cache::*;
 pub use session_manager::*;
+pub use session_store_port::*;
 pub use turn_skill_agent_snapshot_store::*;
+
+pub use bitfun_runtime_ports::{
+    SessionStorageKind, SessionStoragePathRequest, SessionStoragePathResolution,
+    SessionTurnLoadTiming, SessionViewRestoreRequest, SessionViewRestoreTiming,
+};

--- a/src/crates/core/src/agentic/session/session_manager.rs
+++ b/src/crates/core/src/agentic/session/session_manager.rs
@@ -8,7 +8,8 @@ use crate::agentic::core::{
     SessionSummary, TurnStats,
 };
 use crate::agentic::image_analysis::ImageContextData;
-use crate::agentic::persistence::{PersistenceManager, SessionTurnLoadTiming};
+use crate::agentic::persistence::PersistenceManager;
+use crate::agentic::session::session_store_port::CoreSessionStorePort;
 use crate::agentic::session::{
     CachedSystemPrompt, CachedUserContext, EvidenceLedgerCheckpoint, EvidenceLedgerEvent,
     EvidenceLedgerEventStatus, EvidenceLedgerSummary, EvidenceLedgerTargetKind, FileReadState,
@@ -31,9 +32,12 @@ use crate::service::workspace::get_global_workspace_service;
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::sanitize_plain_model_output;
 use crate::util::timing::elapsed_ms_u64;
+pub use bitfun_runtime_ports::SessionViewRestoreTiming;
+use bitfun_runtime_ports::{
+    SessionStoragePathRequest, SessionStorePort, SessionViewRestoreRequest,
+};
 use dashmap::DashMap;
 use log::{debug, error, info, warn};
-use serde::Serialize;
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -50,17 +54,6 @@ pub struct SessionManagerConfig {
     pub auto_save_interval: Duration,
     pub enable_persistence: bool,
     pub prompt_cache_policy: PromptCachePolicy,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SessionViewRestoreTiming {
-    pub resolve_storage_path_duration_ms: u64,
-    pub visibility_metadata_duration_ms: u64,
-    pub load_session_with_turns_duration_ms: u64,
-    pub normalize_turn_ids_duration_ms: u64,
-    pub total_duration_ms: u64,
-    pub turn_load: SessionTurnLoadTiming,
 }
 
 impl Default for SessionManagerConfig {
@@ -414,29 +407,9 @@ impl SessionManager {
 
     /// Resolve the effective storage path for a session's workspace.
     async fn effective_workspace_path_from_config(config: &SessionConfig) -> Option<PathBuf> {
-        let workspace_path = config.workspace_path.as_ref()?;
-        let identity =
-            crate::service::remote_ssh::workspace_state::resolve_workspace_session_identity(
-                workspace_path,
-                config.remote_connection_id.as_deref(),
-                config.remote_ssh_host.as_deref(),
-            )
-            .await?;
-
-        if identity.hostname
-            == crate::service::remote_ssh::workspace_state::LOCAL_WORKSPACE_SSH_HOST
-        {
-            Some(PathBuf::from(identity.logical_workspace_path()))
-        } else if identity.hostname == "_unresolved" {
-            Some(
-                crate::service::remote_ssh::workspace_state::unresolved_remote_session_storage_dir(
-                    identity.remote_connection_id.as_deref().unwrap_or_default(),
-                    identity.logical_workspace_path(),
-                ),
-            )
-        } else {
-            Some(identity.session_storage_path())
-        }
+        CoreSessionStorePort::resolve_storage_path_for_config(config)
+            .await
+            .map(|resolution| resolution.effective_storage_path)
     }
 
     #[allow(dead_code)]
@@ -2490,22 +2463,27 @@ impl SessionManager {
         usize,
         SessionViewRestoreTiming,
     )> {
+        let restore_request = SessionViewRestoreRequest {
+            workspace_path: workspace_path.to_path_buf(),
+            session_id: session_id.to_string(),
+            include_internal,
+            tail_turn_count,
+        };
         let restore_started_at = Instant::now();
         let storage_path_started_at = Instant::now();
-        let session_storage_path = {
-            let ws = workspace_path.to_string_lossy().to_string();
-            let tmp_config = SessionConfig {
-                workspace_path: Some(ws),
-                ..Default::default()
-            };
-            Self::effective_workspace_path_from_config(&tmp_config)
-                .await
-                .unwrap_or_else(|| workspace_path.to_path_buf())
-        };
+        let session_storage_path = CoreSessionStorePort
+            .resolve_session_storage_path(SessionStoragePathRequest {
+                workspace_path: restore_request.workspace_path.clone(),
+                remote_connection_id: None,
+                remote_ssh_host: None,
+            })
+            .await
+            .map(|resolution| resolution.effective_storage_path)
+            .unwrap_or_else(|_| restore_request.workspace_path.clone());
         let resolve_storage_path_duration_ms = elapsed_ms_u64(storage_path_started_at);
         debug!(
             "Session view restore phase completed: session_id={}, phase=resolve_storage_path, duration_ms={}",
-            session_id,
+            restore_request.session_id,
             resolve_storage_path_duration_ms
         );
 
@@ -2514,34 +2492,39 @@ impl SessionManager {
             .persistence_manager
             .load_session_metadata(&session_storage_path, session_id)
             .await?
-            .is_some_and(|metadata| !include_internal && metadata.should_hide_from_user_lists())
+            .is_some_and(|metadata| {
+                !restore_request.include_internal && metadata.should_hide_from_user_lists()
+            })
         {
             return Err(BitFunError::NotFound(format!(
                 "Session not found: {}",
-                session_id
+                restore_request.session_id
             )));
         }
         let visibility_metadata_duration_ms = elapsed_ms_u64(metadata_started_at);
         debug!(
             "Session view restore phase completed: session_id={}, phase=load_metadata, duration_ms={}",
-            session_id,
+            restore_request.session_id,
             visibility_metadata_duration_ms
         );
 
         let session_started_at = Instant::now();
         let (mut session, persisted_turns, total_turn_count, turn_load) =
-            if let Some(tail_turn_count) = tail_turn_count {
+            if let Some(tail_turn_count) = restore_request.tail_turn_count {
                 self.persistence_manager
                     .load_session_with_tail_turns_timed(
                         &session_storage_path,
-                        session_id,
+                        &restore_request.session_id,
                         tail_turn_count,
                     )
                     .await?
             } else {
                 let (session, turns, timing) = self
                     .persistence_manager
-                    .load_session_with_turns_timed(&session_storage_path, session_id)
+                    .load_session_with_turns_timed(
+                        &session_storage_path,
+                        &restore_request.session_id,
+                    )
                     .await?;
                 let total_turn_count = turns.len();
                 (session, turns, total_turn_count, timing)
@@ -2552,7 +2535,7 @@ impl SessionManager {
             session_id,
             persisted_turns.len(),
             total_turn_count,
-            tail_turn_count,
+            restore_request.tail_turn_count,
             load_session_with_turns_duration_ms
         );
 
@@ -4667,7 +4650,7 @@ fn extract_subagent_relationship(
 
 #[cfg(test)]
 mod tests {
-    use super::{SessionManager, SessionManagerConfig};
+    use super::{CoreSessionStorePort, SessionManager, SessionManagerConfig};
     use crate::agentic::core::{
         Message, MessageContent, MessageRole, ProcessingPhase, Session, SessionConfig, SessionState,
     };
@@ -5324,6 +5307,34 @@ mod tests {
         assert_eq!(
             cascade,
             vec!["grandchild".to_string(), "child-root".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn core_session_store_port_resolves_unresolved_remote_storage_path() {
+        use bitfun_runtime_ports::{
+            SessionStorageKind, SessionStoragePathRequest, SessionStorePort,
+        };
+
+        let port = CoreSessionStorePort;
+        let resolution = port
+            .resolve_session_storage_path(SessionStoragePathRequest {
+                workspace_path: PathBuf::from("/remote/project"),
+                remote_connection_id: Some("conn-1".to_string()),
+                remote_ssh_host: None,
+            })
+            .await
+            .expect("storage path should resolve");
+
+        assert_eq!(
+            resolution.storage_kind,
+            SessionStorageKind::UnresolvedRemote
+        );
+        assert!(resolution.is_remote_storage());
+        assert_eq!(resolution.remote_connection_id.as_deref(), Some("conn-1"));
+        assert_ne!(
+            resolution.effective_storage_path,
+            PathBuf::from("/remote/project")
         );
     }
 

--- a/src/crates/core/src/agentic/session/session_store_port.rs
+++ b/src/crates/core/src/agentic/session/session_store_port.rs
@@ -1,0 +1,93 @@
+use std::path::PathBuf;
+
+use bitfun_runtime_ports::{
+    PortError, PortErrorKind, PortResult, RuntimeServiceCapability, RuntimeServicePort,
+    SessionStorageKind, SessionStoragePathRequest, SessionStoragePathResolution, SessionStorePort,
+};
+
+use crate::agentic::core::SessionConfig;
+use crate::service::remote_ssh::workspace_state::{
+    resolve_workspace_session_identity, unresolved_remote_session_storage_dir,
+    LOCAL_WORKSPACE_SSH_HOST,
+};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CoreSessionStorePort;
+
+impl CoreSessionStorePort {
+    pub async fn resolve_storage_path_for_config(
+        config: &SessionConfig,
+    ) -> Option<SessionStoragePathResolution> {
+        let workspace_path = config.workspace_path.as_ref()?;
+        let request = SessionStoragePathRequest {
+            workspace_path: PathBuf::from(workspace_path),
+            remote_connection_id: config.remote_connection_id.clone(),
+            remote_ssh_host: config.remote_ssh_host.clone(),
+        };
+        Self::default()
+            .resolve_session_storage_path(request)
+            .await
+            .ok()
+    }
+}
+
+impl RuntimeServicePort for CoreSessionStorePort {
+    fn capability(&self) -> RuntimeServiceCapability {
+        RuntimeServiceCapability::SessionStore
+    }
+}
+
+#[async_trait::async_trait]
+impl SessionStorePort for CoreSessionStorePort {
+    async fn resolve_session_storage_path(
+        &self,
+        request: SessionStoragePathRequest,
+    ) -> PortResult<SessionStoragePathResolution> {
+        let workspace_path = request.workspace_path.to_string_lossy().to_string();
+        let identity = resolve_workspace_session_identity(
+            &workspace_path,
+            request.remote_connection_id.as_deref(),
+            request.remote_ssh_host.as_deref(),
+        )
+        .await
+        .ok_or_else(|| {
+            PortError::new(
+                PortErrorKind::InvalidRequest,
+                "Session workspace_path is required",
+            )
+        })?;
+
+        let requested_workspace_path = request.workspace_path;
+        let (effective_storage_path, storage_kind, remote_ssh_host) =
+            if identity.hostname == LOCAL_WORKSPACE_SSH_HOST {
+                (
+                    PathBuf::from(identity.logical_workspace_path()),
+                    SessionStorageKind::Local,
+                    None,
+                )
+            } else if identity.hostname == "_unresolved" {
+                (
+                    unresolved_remote_session_storage_dir(
+                        identity.remote_connection_id.as_deref().unwrap_or_default(),
+                        identity.logical_workspace_path(),
+                    ),
+                    SessionStorageKind::UnresolvedRemote,
+                    None,
+                )
+            } else {
+                (
+                    identity.session_storage_path(),
+                    SessionStorageKind::Remote,
+                    Some(identity.hostname.clone()),
+                )
+            };
+
+        Ok(SessionStoragePathResolution::new(
+            requested_workspace_path,
+            effective_storage_path,
+            storage_kind,
+            identity.remote_connection_id,
+            remote_ssh_host,
+        ))
+    }
+}

--- a/src/crates/core/src/agentic/tools/implementations/delete_file_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/delete_file_tool.rs
@@ -5,10 +5,9 @@ use crate::agentic::tools::workspace_paths::is_bitfun_runtime_uri;
 use crate::agentic::tools::ToolPathOperation;
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
-use log::debug;
 use serde_json::{json, Value};
 use std::path::Path;
-use tokio::fs;
+use tool_runtime::fs::{delete_local_path, inspect_local_delete_target, DeleteLocalPathRequest};
 
 /// File deletion tool - provides safe file/directory deletion functionality
 ///
@@ -205,7 +204,7 @@ Important notes:
         }
 
         if !resolved.uses_remote_workspace_backend() {
-            let local_path = Path::new(&resolved.resolved_path);
+            let local_path = Path::new(&resolved.resolved_path).to_path_buf();
             if !local_path.exists() {
                 return ValidationResult {
                     result: false,
@@ -221,10 +220,13 @@ Important notes:
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
 
-                let is_empty = match fs::read_dir(local_path).await {
-                    Ok(mut entries) => entries.next_entry().await.ok().flatten().is_none(),
-                    Err(_) => false,
-                };
+                let is_empty =
+                    tokio::task::spawn_blocking(move || inspect_local_delete_target(&local_path))
+                        .await
+                        .ok()
+                        .and_then(Result::ok)
+                        .map(|target| target.is_empty)
+                        .unwrap_or(false);
 
                 if !is_empty && !recursive {
                     return ValidationResult {
@@ -345,36 +347,21 @@ Important notes:
             }]);
         }
 
-        let path = Path::new(&resolved.resolved_path);
-        let is_directory = path.is_dir();
-
-        debug!(
-            "DeleteFile tool deleting {}: {}",
-            if is_directory { "directory" } else { "file" },
-            resolved.logical_path
-        );
-
-        if is_directory {
-            if recursive {
-                fs::remove_dir_all(path)
-                    .await
-                    .map_err(|e| BitFunError::tool(format!("Failed to delete directory: {}", e)))?;
-            } else {
-                fs::remove_dir(path)
-                    .await
-                    .map_err(|e| BitFunError::tool(format!("Failed to delete directory: {}", e)))?;
-            }
-        } else {
-            fs::remove_file(path)
-                .await
-                .map_err(|e| BitFunError::tool(format!("Failed to delete file: {}", e)))?;
-        }
+        let delete_request = DeleteLocalPathRequest {
+            logical_path: resolved.logical_path.clone(),
+            resolved_path: Path::new(&resolved.resolved_path).to_path_buf(),
+            recursive,
+        };
+        let outcome = tokio::task::spawn_blocking(move || delete_local_path(delete_request))
+            .await
+            .map_err(|error| BitFunError::tool(format!("Delete task failed: {}", error)))?
+            .map_err(BitFunError::tool)?;
 
         let result_data = json!({
             "success": true,
-            "path": resolved.logical_path,
-            "is_directory": is_directory,
-            "recursive": recursive
+            "path": outcome.logical_path,
+            "is_directory": outcome.is_directory,
+            "recursive": outcome.recursive
         });
 
         let result_text = self.render_result_for_assistant(&result_data);

--- a/src/crates/core/src/agentic/tools/implementations/file_edit_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_edit_tool.rs
@@ -13,7 +13,9 @@ use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use std::path::Path;
-use tool_runtime::fs::edit_file::apply_edit_to_content;
+use tool_runtime::fs::edit_file::{
+    apply_edit_to_content, edit_local_file_with_content, EditLocalFileWithContentRequest,
+};
 
 pub struct FileEditTool;
 
@@ -374,7 +376,7 @@ impl Tool for FileEditTool {
             return Ok(vec![result]);
         }
 
-        // Local: read → edit in memory → write back so failures can include current file context.
+        // Local: core keeps freshness/checkpoint, tool-runtime owns edit application and write-back.
         let content = std::fs::read_to_string(&resolved.resolved_path).map_err(|e| {
             BitFunError::tool(format!(
                 "Failed to read file {}: {}",
@@ -382,23 +384,21 @@ impl Tool for FileEditTool {
             ))
         })?;
         Self::assert_atomic_edit_freshness(context, &resolved, &content)?;
-        let edit_result = apply_edit_to_content(&content, old_string, new_string, replace_all)
-            .map_err(|error| {
-                if Self::is_edit_content_guardrail_error(&error) {
-                    BitFunError::tool(file_tool_guidance_message(error))
-                } else {
-                    BitFunError::tool(error)
-                }
-            })?;
-
-        std::fs::write(&resolved.resolved_path, edit_result.new_content.as_bytes()).map_err(
-            |e| {
-                BitFunError::tool(format!(
-                    "Failed to write file {}: {}",
-                    resolved.logical_path, e
-                ))
-            },
-        )?;
+        let edit_result = edit_local_file_with_content(EditLocalFileWithContentRequest {
+            logical_path: resolved.logical_path.clone(),
+            resolved_path: Path::new(&resolved.resolved_path).to_path_buf(),
+            current_content: content,
+            old_string: old_string.to_string(),
+            new_string: new_string.to_string(),
+            replace_all,
+        })
+        .map_err(|error| {
+            if Self::is_edit_content_guardrail_error(&error) {
+                BitFunError::tool(file_tool_guidance_message(error))
+            } else {
+                BitFunError::tool(error)
+            }
+        })?;
 
         let timestamp_ms = file_mutation_timestamp_ms(context, &resolved).await;
         update_file_read_state_after_mutation(

--- a/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -19,6 +19,7 @@ use async_trait::async_trait;
 use serde_json::{json, Value};
 use std::path::Path;
 use tokio::fs;
+use tool_runtime::fs::{write_local_file, WriteLocalFileRequest};
 
 pub struct FileWriteTool;
 
@@ -186,14 +187,6 @@ impl FileWriteTool {
             }),
             result_for_assistant: Some(assistant_message),
             image_attachments: None,
-        }
-    }
-
-    fn count_written_lines(content: &str) -> usize {
-        if content.is_empty() {
-            0
-        } else {
-            content.lines().count().max(1)
         }
     }
 
@@ -619,51 +612,62 @@ impl Tool for FileWriteTool {
                 .write_file(&resolved.resolved_path, content.as_bytes())
                 .await
                 .map_err(|e| BitFunError::tool(format!("Failed to write file: {}", e)))?;
-        } else {
-            if let Some(parent) = Path::new(&resolved.resolved_path).parent() {
-                fs::create_dir_all(parent)
-                    .await
-                    .map_err(|e| BitFunError::tool(format!("Failed to create directory: {}", e)))?;
-            }
-            fs::write(&resolved.resolved_path, &content)
-                .await
-                .map_err(|e| {
-                    BitFunError::tool(format!(
-                        "Failed to write file {}: {}",
-                        resolved.logical_path, e
-                    ))
-                })?;
+            let timestamp_ms = file_mutation_timestamp_ms(context, &resolved).await;
+            update_file_read_state_after_mutation(context, &resolved, &content, timestamp_ms);
+
+            let (status, assistant_message) = if file_already_exists {
+                (
+                    "overwritten",
+                    format!(
+                        "Successfully overwrote {} ({} bytes).",
+                        resolved.logical_path,
+                        content.len()
+                    ),
+                )
+            } else {
+                (
+                    "created",
+                    format!(
+                        "Successfully created {} ({} bytes).",
+                        resolved.logical_path,
+                        content.len()
+                    ),
+                )
+            };
+
+            let result = Self::write_success_result(
+                &resolved.logical_path,
+                content.len(),
+                if content.is_empty() {
+                    0
+                } else {
+                    content.lines().count().max(1)
+                },
+                status,
+                assistant_message,
+            );
+            return Ok(vec![result]);
         }
+
+        let write_request = WriteLocalFileRequest {
+            logical_path: resolved.logical_path.clone(),
+            resolved_path: Path::new(&resolved.resolved_path).to_path_buf(),
+            content: content.clone(),
+        };
+        let outcome = tokio::task::spawn_blocking(move || write_local_file(write_request))
+            .await
+            .map_err(|error| BitFunError::tool(format!("Write task failed: {}", error)))?
+            .map_err(BitFunError::tool)?;
 
         let timestamp_ms = file_mutation_timestamp_ms(context, &resolved).await;
         update_file_read_state_after_mutation(context, &resolved, &content, timestamp_ms);
 
-        let (status, assistant_message) = if file_already_exists {
-            (
-                "overwritten",
-                format!(
-                    "Successfully overwrote {} ({} bytes).",
-                    resolved.logical_path,
-                    content.len()
-                ),
-            )
-        } else {
-            (
-                "created",
-                format!(
-                    "Successfully created {} ({} bytes).",
-                    resolved.logical_path,
-                    content.len()
-                ),
-            )
-        };
-
         let result = Self::write_success_result(
             &resolved.logical_path,
-            content.len(),
-            Self::count_written_lines(&content),
-            status,
-            assistant_message,
+            outcome.bytes_written,
+            outcome.lines_written,
+            outcome.status.as_str(),
+            outcome.assistant_message,
         );
 
         Ok(vec![result])

--- a/src/crates/core/src/agentic/tools/implementations/glob_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/glob_tool.rs
@@ -4,393 +4,14 @@ use crate::service::search::{
     workspace_search_feature_enabled, workspace_search_runtime_available, GlobSearchRequest,
 };
 use crate::util::errors::{BitFunError, BitFunResult};
-use crate::util::process_manager;
 use async_trait::async_trait;
-use globset::{GlobBuilder, GlobMatcher};
-use ignore::WalkBuilder;
 use log::{info, warn};
 use serde_json::{json, Value};
-use std::cmp::Ordering;
-use std::collections::BinaryHeap;
-use std::path::{Component, Path, PathBuf};
-
-fn extract_glob_base_directory(pattern: &str) -> (String, String) {
-    let glob_start = pattern.find(['*', '?', '[', '{']);
-
-    match glob_start {
-        Some(index) => {
-            let static_prefix = &pattern[..index];
-            let last_separator = static_prefix
-                .char_indices()
-                .rev()
-                .find(|(_, ch)| *ch == '/' || *ch == '\\')
-                .map(|(idx, _)| idx);
-
-            if let Some(separator_index) = last_separator {
-                (
-                    static_prefix[..separator_index].to_string(),
-                    pattern[separator_index + 1..].to_string(),
-                )
-            } else {
-                (String::new(), pattern.to_string())
-            }
-        }
-        None => {
-            let trimmed = pattern.trim_end_matches(['/', '\\']);
-            let literal_path = Path::new(trimmed);
-            let base_dir = literal_path
-                .parent()
-                .filter(|parent| !parent.as_os_str().is_empty() && *parent != Path::new("."))
-                .map(|parent| parent.to_string_lossy().to_string())
-                .unwrap_or_default();
-            let file_name = literal_path
-                .file_name()
-                .map(|name| name.to_string_lossy().to_string())
-                .unwrap_or_else(|| trimmed.to_string());
-
-            let relative_pattern = if pattern.ends_with('/') || pattern.ends_with('\\') {
-                format!("{}/", file_name)
-            } else {
-                file_name
-            };
-
-            (base_dir, relative_pattern)
-        }
-    }
-}
-
-fn normalize_path(path: &Path) -> String {
-    dunce::simplified(path).to_string_lossy().replace('\\', "/")
-}
-
-fn shell_escape(value: &str) -> String {
-    value.replace('\'', "'\\''")
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-struct GlobCandidate {
-    depth: usize,
-    path: String,
-}
-
-impl Ord for GlobCandidate {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.depth
-            .cmp(&other.depth)
-            .then_with(|| self.path.cmp(&other.path))
-    }
-}
-
-impl PartialOrd for GlobCandidate {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-fn is_safe_relative_subpath(path: &Path) -> bool {
-    !path.is_absolute()
-        && path
-            .components()
-            .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
-}
-
-fn derive_walk_root(search_path_abs: &Path, pattern: &str) -> (PathBuf, String) {
-    let (base_dir, relative_pattern) = extract_glob_base_directory(pattern);
-    let base_path = Path::new(&base_dir);
-
-    if base_dir.is_empty() || !is_safe_relative_subpath(base_path) {
-        return (search_path_abs.to_path_buf(), pattern.to_string());
-    }
-
-    let walk_root = search_path_abs.join(base_path);
-    if walk_root.starts_with(search_path_abs) {
-        (walk_root, relative_pattern)
-    } else {
-        (search_path_abs.to_path_buf(), pattern.to_string())
-    }
-}
-
-fn resolve_glob_config(pattern: &str) -> (bool, bool) {
-    let is_whitelisted = pattern.starts_with(".bitfun")
-        || pattern.contains("/.bitfun")
-        || pattern.contains("\\.bitfun");
-
-    let apply_gitignore = !is_whitelisted;
-    let ignore_hidden_files = !is_whitelisted;
-    (apply_gitignore, ignore_hidden_files)
-}
-
-fn build_rg_args(
-    relative_pattern: &str,
-    apply_gitignore: bool,
-    ignore_hidden_files: bool,
-) -> Vec<String> {
-    let mut args = vec![
-        "--files".to_string(),
-        "--glob".to_string(),
-        relative_pattern.to_string(),
-        "--sort".to_string(),
-        "path".to_string(),
-    ];
-
-    if !apply_gitignore {
-        args.push("--no-ignore".to_string());
-    }
-
-    if !ignore_hidden_files {
-        args.push("--hidden".to_string());
-    }
-
-    args
-}
-
-fn build_fallback_matcher(relative_pattern: &str) -> Result<GlobMatcher, String> {
-    GlobBuilder::new(relative_pattern)
-        .literal_separator(true)
-        .build()
-        .map_err(|err| err.to_string())
-        .map(|glob| glob.compile_matcher())
-}
-
-fn match_relative_path(matcher: &GlobMatcher, relative_path: &str, is_dir: bool) -> bool {
-    if is_dir {
-        matcher.is_match(relative_path) || matcher.is_match(format!("{}/", relative_path))
-    } else {
-        matcher.is_match(relative_path)
-    }
-}
-
-fn collect_with_walk_fallback(
-    walk_root: &Path,
-    relative_pattern: &str,
-    apply_gitignore: bool,
-    ignore_hidden_files: bool,
-    limit: usize,
-) -> Result<Vec<String>, String> {
-    let matcher = build_fallback_matcher(relative_pattern)?;
-    let walker = WalkBuilder::new(walk_root)
-        .ignore(apply_gitignore)
-        .git_ignore(apply_gitignore)
-        .git_global(apply_gitignore)
-        .git_exclude(apply_gitignore)
-        .hidden(ignore_hidden_files)
-        .build();
-
-    let mut best_matches = BinaryHeap::with_capacity(limit.saturating_add(1));
-    for entry in walker {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(err) => {
-                warn!("Glob walker fallback entry error (skipped): {}", err);
-                continue;
-            }
-        };
-
-        let path = entry.path().to_path_buf();
-        let relative_path = match path.strip_prefix(walk_root) {
-            Ok(relative) => relative,
-            Err(_) => continue,
-        };
-        let relative_path = normalize_path(relative_path);
-
-        if match_relative_path(
-            &matcher,
-            &relative_path,
-            entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false),
-        ) {
-            let normalized_path = normalize_path(&path);
-            let candidate = GlobCandidate {
-                depth: normalized_path.split('/').count(),
-                path: normalized_path,
-            };
-
-            if best_matches.len() < limit {
-                best_matches.push(candidate);
-            } else if let Some(worst_match) = best_matches.peek() {
-                if candidate < *worst_match {
-                    best_matches.pop();
-                    best_matches.push(candidate);
-                }
-            }
-        }
-    }
-
-    let mut results = best_matches
-        .into_sorted_vec()
-        .into_iter()
-        .map(|candidate| candidate.path)
-        .collect::<Vec<_>>();
-    results.sort();
-    Ok(results)
-}
-
-fn call_rg(search_path: &str, pattern: &str, limit: usize) -> Result<Vec<String>, String> {
-    let path = std::path::Path::new(search_path);
-    if !path.exists() {
-        return Err(format!("Search path '{}' does not exist", search_path));
-    }
-    if !path.is_dir() {
-        return Err(format!("Search path '{}' is not a directory", search_path));
-    }
-
-    let search_path_abs =
-        dunce::canonicalize(Path::new(search_path)).map_err(|err| err.to_string())?;
-    let (walk_root, relative_pattern) = derive_walk_root(&search_path_abs, pattern);
-    let (apply_gitignore, ignore_hidden_files) = resolve_glob_config(pattern);
-
-    if !walk_root.exists() || !walk_root.is_dir() || limit == 0 {
-        return Ok(Vec::new());
-    }
-
-    let args = build_rg_args(&relative_pattern, apply_gitignore, ignore_hidden_files);
-    let output = process_manager::create_command("rg")
-        .current_dir(&walk_root)
-        .args(&args)
-        .arg(".")
-        .output()
-        .map_err(|err| {
-            if err.kind() == std::io::ErrorKind::NotFound {
-                "ripgrep (rg) is required for Glob tool execution but was not found".to_string()
-            } else {
-                format!("Failed to execute rg for Glob tool: {}", err)
-            }
-        });
-
-    let output = match output {
-        Ok(output) => {
-            info!(
-                "Glob backend selected: backend=rg, search_root={}, pattern={}",
-                walk_root.display(),
-                relative_pattern
-            );
-            output
-        }
-        Err(err) if err.contains("ripgrep (rg) is required") => {
-            info!(
-                "Glob backend selected: backend=fallback_walk, reason=rg_not_found, search_root={}, pattern={}",
-                walk_root.display(),
-                relative_pattern
-            );
-            return collect_with_walk_fallback(
-                &walk_root,
-                &relative_pattern,
-                apply_gitignore,
-                ignore_hidden_files,
-                limit,
-            );
-        }
-        Err(err) => return Err(err),
-    };
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let message = if stderr.is_empty() {
-            format!("rg --files failed with status {}", output.status)
-        } else {
-            format!("rg --files failed: {}", stderr)
-        };
-        if stderr.contains("No such file or directory") || stderr.contains("not found") {
-            info!(
-                "Glob backend selected: backend=fallback_walk, reason=rg_execution_failed, search_root={}, pattern={}",
-                walk_root.display(),
-                relative_pattern
-            );
-            return collect_with_walk_fallback(
-                &walk_root,
-                &relative_pattern,
-                apply_gitignore,
-                ignore_hidden_files,
-                limit,
-            );
-        }
-        return Err(message);
-    }
-
-    let all_paths = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter(|line| !line.is_empty())
-        .map(|line| {
-            let relative_path = line.strip_prefix("./").unwrap_or(line);
-            let full_path = walk_root.join(relative_path);
-            normalize_path(&full_path)
-        })
-        .collect::<Vec<_>>();
-    Ok(limit_paths(&all_paths, limit))
-}
-
-fn limit_paths(paths: &[String], limit: usize) -> Vec<String> {
-    let mut depth_and_paths = paths
-        .iter()
-        .map(|path| {
-            let normalized_path = path.replace('\\', "/");
-            let depth = normalized_path.split('/').count();
-            (depth, normalized_path)
-        })
-        .collect::<Vec<_>>();
-    depth_and_paths.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
-
-    let mut result = depth_and_paths
-        .into_iter()
-        .take(limit)
-        .map(|(_, path)| path)
-        .collect::<Vec<_>>();
-    result.sort();
-    result
-}
-
-fn build_remote_rg_command(search_dir: &str, pattern: &str) -> String {
-    let search_dir_path = Path::new(search_dir);
-    let (remote_walk_root, remote_pattern) = derive_walk_root(search_dir_path, pattern);
-    let (apply_gitignore, ignore_hidden_files) = resolve_glob_config(pattern);
-
-    let mut parts = vec![
-        "cd".to_string(),
-        format!(
-            "'{}'",
-            shell_escape(remote_walk_root.to_string_lossy().as_ref())
-        ),
-        "&&".to_string(),
-        "rg".to_string(),
-        "--files".to_string(),
-        "--glob".to_string(),
-        format!("'{}'", shell_escape(&remote_pattern)),
-        "--sort".to_string(),
-        "path".to_string(),
-    ];
-
-    if !apply_gitignore {
-        parts.push("--no-ignore".to_string());
-    }
-
-    if !ignore_hidden_files {
-        parts.push("--hidden".to_string());
-    }
-
-    parts.push(".".to_string());
-    parts.push("2>/dev/null".to_string());
-    parts.join(" ")
-}
-
-fn build_remote_find_command(search_dir: &str, pattern: &str, limit: usize) -> String {
-    let search_dir_path = Path::new(search_dir);
-    let (remote_walk_root, remote_pattern) = derive_walk_root(search_dir_path, pattern);
-
-    let name_pattern = if remote_pattern.contains("**/") {
-        remote_pattern.replacen("**/", "", 1)
-    } else if remote_pattern.contains('/') || remote_pattern.contains('\\') {
-        "*".to_string()
-    } else {
-        remote_pattern
-    };
-
-    let escaped_dir = remote_walk_root.to_string_lossy().replace('\'', "'\\''");
-    let escaped_pattern = name_pattern.replace('\'', "'\\''");
-
-    format!(
-        "find '{}' -maxdepth 10 -name '{}' -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null | head -n {}",
-        escaped_dir, escaped_pattern, limit
-    )
-}
+use std::path::{Path, PathBuf};
+use tool_runtime::search::glob_search::{
+    build_remote_find_command, build_remote_rg_command, execute_local_glob, limit_paths,
+    normalize_path, LocalGlobRequest,
+};
 
 pub struct GlobTool;
 
@@ -606,20 +227,20 @@ impl Tool for GlobTool {
                     BitFunError::tool(format!("Failed to glob on remote with rg: {}", e))
                 })?;
 
-            let matches: Vec<String> = stdout
+            let matches = stdout
                 .lines()
                 .filter(|l| !l.is_empty())
                 .map(|line| {
                     let relative_path = line.strip_prefix("./").unwrap_or(line);
-                    normalize_path(&Path::new(&search_dir).join(relative_path))
+                    Path::new(&search_dir).join(relative_path)
                 })
-                .collect();
+                .collect::<Vec<_>>();
             let limited = limit_paths(&matches, limit)
                 .into_iter()
                 .map(|path| {
                     resolved
-                        .logical_child_path(Path::new(&path))
-                        .unwrap_or(path)
+                        .logical_child_path(&path)
+                        .unwrap_or_else(|| normalize_path(&path))
                 })
                 .collect::<Vec<_>>();
             let result_text = if limited.is_empty() {
@@ -685,19 +306,24 @@ impl Tool for GlobTool {
         }
         let resolved_str_for_rg = resolved_str.clone();
         let pattern_for_rg = pattern.to_string();
-        let matches = tokio::task::spawn_blocking(move || {
-            call_rg(&resolved_str_for_rg, &pattern_for_rg, limit)
+        let glob_result = tokio::task::spawn_blocking(move || {
+            execute_local_glob(LocalGlobRequest {
+                search_path: PathBuf::from(resolved_str_for_rg),
+                pattern: pattern_for_rg,
+                limit,
+            })
         })
         .await
         .map_err(|err| BitFunError::tool(format!("Glob tool task failed: {}", err)))?
         .map_err(BitFunError::tool)?;
 
-        let matches = matches
+        let matches = glob_result
+            .matches
             .into_iter()
             .map(|path| {
                 resolved
-                    .logical_child_path(Path::new(&path))
-                    .unwrap_or(path)
+                    .logical_child_path(&path)
+                    .unwrap_or_else(|| normalize_path(&path))
             })
             .collect::<Vec<_>>();
 
@@ -724,11 +350,13 @@ impl Tool for GlobTool {
 
 #[cfg(test)]
 mod tests {
-    use super::{call_rg, derive_walk_root, extract_glob_base_directory};
-    use crate::util::process_manager;
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
+    use tool_runtime::search::glob_search::{
+        derive_walk_root, execute_local_glob, extract_glob_base_directory, normalize_path,
+        LocalGlobRequest,
+    };
 
     fn make_temp_dir(name: &str) -> PathBuf {
         let unique = SystemTime::now()
@@ -767,14 +395,6 @@ mod tests {
 
     #[test]
     fn keeps_shallowest_matches_from_rg_results() {
-        if process_manager::create_command("rg")
-            .arg("--version")
-            .output()
-            .is_err()
-        {
-            return;
-        }
-
         let root = make_temp_dir("limit");
         fs::create_dir_all(root.join("src/deep")).unwrap();
         fs::create_dir_all(root.join("tests")).unwrap();
@@ -783,7 +403,16 @@ mod tests {
         fs::write(root.join("src/deep/mod.rs"), "").unwrap();
         fs::write(root.join("tests/mod.rs"), "").unwrap();
 
-        let matches = call_rg(root.to_string_lossy().as_ref(), "**/*.rs", 2).unwrap();
+        let matches = execute_local_glob(LocalGlobRequest {
+            search_path: root.clone(),
+            pattern: "**/*.rs".to_string(),
+            limit: 2,
+        })
+        .unwrap()
+        .matches
+        .into_iter()
+        .map(|path| normalize_path(&path))
+        .collect::<Vec<_>>();
 
         assert_eq!(matches.len(), 2);
         assert!(matches.iter().any(|path| path.ends_with("/src/lib.rs")));
@@ -797,19 +426,20 @@ mod tests {
 
     #[test]
     fn wildcard_search_now_returns_files_only() {
-        if process_manager::create_command("rg")
-            .arg("--version")
-            .output()
-            .is_err()
-        {
-            return;
-        }
-
         let root = make_temp_dir("files-only");
         fs::create_dir_all(root.join("src/nested")).unwrap();
         fs::write(root.join("src/nested/lib.rs"), "").unwrap();
 
-        let matches = call_rg(root.to_string_lossy().as_ref(), "*", 10).unwrap();
+        let matches = execute_local_glob(LocalGlobRequest {
+            search_path: root.clone(),
+            pattern: "*".to_string(),
+            limit: 10,
+        })
+        .unwrap()
+        .matches
+        .into_iter()
+        .map(|path| normalize_path(&path))
+        .collect::<Vec<_>>();
 
         assert!(matches.iter().all(|path| !path.ends_with("/src")));
         assert!(!matches.is_empty());

--- a/src/crates/runtime-ports/AGENTS.md
+++ b/src/crates/runtime-ports/AGENTS.md
@@ -13,6 +13,9 @@ facts. It is an interface crate, not a runtime implementation crate.
   or catch-all context structs.
 - This crate may define portable request/response DTOs, runtime handles,
   capability facts, cancellation surfaces, and service traits.
+- `SessionStorePort` owns typed session storage-path resolution plus restore /
+  load request and timing facts only. Concrete session persistence, file IO,
+  session lifecycle, context restore, and prompt assembly do not belong here.
 - Do not put filesystem writes, process execution, network clients, Git/AI/MCP
   concrete behavior, product policy, or UI command logic here.
 - Preserve serialization compatibility for persisted or cross-process DTOs.

--- a/src/crates/runtime-ports/Cargo.toml
+++ b/src/crates/runtime-ports/Cargo.toml
@@ -15,3 +15,6 @@ async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio-util = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/src/crates/runtime-ports/src/lib.rs
+++ b/src/crates/runtime-ports/src/lib.rs
@@ -101,7 +101,110 @@ pub trait FileSystemPort: RuntimeServicePort {}
 
 pub trait WorkspacePort: RuntimeServicePort {}
 
-pub trait SessionStorePort: RuntimeServicePort {}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionStoragePathRequest {
+    pub workspace_path: PathBuf,
+    pub remote_connection_id: Option<String>,
+    pub remote_ssh_host: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStorageKind {
+    Local,
+    Remote,
+    UnresolvedRemote,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionStoragePathResolution {
+    pub requested_workspace_path: PathBuf,
+    pub effective_storage_path: PathBuf,
+    pub storage_kind: SessionStorageKind,
+    pub remote_connection_id: Option<String>,
+    pub remote_ssh_host: Option<String>,
+}
+
+impl SessionStoragePathResolution {
+    pub fn new(
+        requested_workspace_path: PathBuf,
+        effective_storage_path: PathBuf,
+        storage_kind: SessionStorageKind,
+        remote_connection_id: Option<String>,
+        remote_ssh_host: Option<String>,
+    ) -> Self {
+        Self {
+            requested_workspace_path,
+            effective_storage_path,
+            storage_kind,
+            remote_connection_id,
+            remote_ssh_host,
+        }
+    }
+
+    pub fn is_remote_storage(&self) -> bool {
+        matches!(
+            self.storage_kind,
+            SessionStorageKind::Remote | SessionStorageKind::UnresolvedRemote
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionViewRestoreRequest {
+    pub workspace_path: PathBuf,
+    pub session_id: String,
+    pub include_internal: bool,
+    pub tail_turn_count: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionTurnLoadRequest {
+    pub workspace_path: PathBuf,
+    pub session_id: String,
+    pub tail_turn_count: Option<usize>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionTurnLoadTiming {
+    pub requested_tail_turn_count: Option<usize>,
+    pub loaded_turn_count: usize,
+    pub total_turn_count: usize,
+    pub turn_file_count: usize,
+    pub missing_turn_file_count: usize,
+    pub fast_path: bool,
+    pub metadata_duration_ms: u64,
+    pub state_duration_ms: u64,
+    pub scan_duration_ms: u64,
+    pub read_duration_ms: u64,
+    pub max_turn_read_duration_ms: u64,
+    pub build_session_duration_ms: u64,
+    pub total_duration_ms: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionViewRestoreTiming {
+    pub resolve_storage_path_duration_ms: u64,
+    pub visibility_metadata_duration_ms: u64,
+    pub load_session_with_turns_duration_ms: u64,
+    pub normalize_turn_ids_duration_ms: u64,
+    pub total_duration_ms: u64,
+    pub turn_load: SessionTurnLoadTiming,
+}
+
+#[async_trait::async_trait]
+pub trait SessionStorePort: RuntimeServicePort {
+    async fn resolve_session_storage_path(
+        &self,
+        request: SessionStoragePathRequest,
+    ) -> PortResult<SessionStoragePathResolution>;
+}
 
 /// One row from [`WorkspaceFileSystem::read_dir`] (POSIX paths when the backend is remote SSH).
 #[derive(Debug, Clone)]

--- a/src/crates/runtime-ports/tests/session_store_contracts.rs
+++ b/src/crates/runtime-ports/tests/session_store_contracts.rs
@@ -1,0 +1,109 @@
+use std::path::PathBuf;
+
+use bitfun_runtime_ports::{
+    RuntimeServiceCapability, RuntimeServicePort, SessionStorageKind, SessionStoragePathRequest,
+    SessionStoragePathResolution, SessionStorePort, SessionTurnLoadTiming,
+    SessionViewRestoreTiming,
+};
+
+#[test]
+fn session_storage_path_resolution_carries_local_and_remote_facts() {
+    let local = SessionStoragePathResolution::new(
+        PathBuf::from("/repo"),
+        PathBuf::from("/repo"),
+        SessionStorageKind::Local,
+        None,
+        None,
+    );
+    assert_eq!(local.storage_kind, SessionStorageKind::Local);
+    assert!(!local.is_remote_storage());
+
+    let remote = SessionStoragePathResolution::new(
+        PathBuf::from("/repo"),
+        PathBuf::from("/state/sessions/remote"),
+        SessionStorageKind::Remote,
+        Some("conn-1".to_string()),
+        Some("devbox".to_string()),
+    );
+    assert_eq!(remote.storage_kind, SessionStorageKind::Remote);
+    assert!(remote.is_remote_storage());
+
+    let encoded = serde_json::to_string(&remote).expect("resolution should serialize");
+    assert!(encoded.contains("effectiveStoragePath"));
+    assert!(encoded.contains("remoteConnectionId"));
+}
+
+#[test]
+fn session_restore_timing_serializes_camel_case_fields() {
+    let timing = SessionViewRestoreTiming {
+        resolve_storage_path_duration_ms: 1,
+        visibility_metadata_duration_ms: 2,
+        load_session_with_turns_duration_ms: 3,
+        normalize_turn_ids_duration_ms: 4,
+        total_duration_ms: 5,
+        turn_load: SessionTurnLoadTiming {
+            requested_tail_turn_count: Some(8),
+            loaded_turn_count: 8,
+            total_turn_count: 10,
+            turn_file_count: 10,
+            missing_turn_file_count: 0,
+            fast_path: true,
+            metadata_duration_ms: 1,
+            state_duration_ms: 1,
+            scan_duration_ms: 0,
+            read_duration_ms: 2,
+            max_turn_read_duration_ms: 1,
+            build_session_duration_ms: 1,
+            total_duration_ms: 5,
+        },
+    };
+
+    let encoded = serde_json::to_value(&timing).expect("timing should serialize");
+    assert_eq!(encoded["resolveStoragePathDurationMs"], 1);
+    assert_eq!(encoded["turnLoad"]["requestedTailTurnCount"], 8);
+    assert_eq!(encoded["turnLoad"]["fastPath"], true);
+}
+
+struct ContractSessionStorePort;
+
+impl RuntimeServicePort for ContractSessionStorePort {
+    fn capability(&self) -> RuntimeServiceCapability {
+        RuntimeServiceCapability::SessionStore
+    }
+}
+
+#[async_trait::async_trait]
+impl SessionStorePort for ContractSessionStorePort {
+    async fn resolve_session_storage_path(
+        &self,
+        request: SessionStoragePathRequest,
+    ) -> bitfun_runtime_ports::PortResult<SessionStoragePathResolution> {
+        Ok(SessionStoragePathResolution::new(
+            request.workspace_path.clone(),
+            request.workspace_path,
+            SessionStorageKind::Local,
+            request.remote_connection_id,
+            request.remote_ssh_host,
+        ))
+    }
+}
+
+#[tokio::test]
+async fn session_store_port_exposes_typed_storage_path_resolution() {
+    let port = ContractSessionStorePort;
+    assert_eq!(port.capability(), RuntimeServiceCapability::SessionStore);
+
+    let resolution = port
+        .resolve_session_storage_path(SessionStoragePathRequest {
+            workspace_path: PathBuf::from("/workspace"),
+            remote_connection_id: None,
+            remote_ssh_host: None,
+        })
+        .await
+        .expect("path should resolve");
+
+    assert_eq!(
+        resolution.effective_storage_path,
+        PathBuf::from("/workspace")
+    );
+}

--- a/src/crates/runtime-services/src/test_support.rs
+++ b/src/crates/runtime-services/src/test_support.rs
@@ -6,7 +6,8 @@ use bitfun_runtime_ports::{
     RemoteCapabilityPort, RemoteConnectionPort, RemoteProjectionPort, RemoteRecentWorkspaceFacts,
     RemoteWorkspaceFacts, RemoteWorkspaceFileRuntimeHost, RemoteWorkspaceKind, RemoteWorkspacePort,
     RemoteWorkspaceRuntimeHost, RemoteWorkspaceUpdate, RuntimeEventEnvelope, RuntimeEventSink,
-    RuntimeServiceCapability, RuntimeServicePort, SessionStorePort, TerminalPort, WorkspacePort,
+    RuntimeServiceCapability, RuntimeServicePort, SessionStorageKind, SessionStoragePathRequest,
+    SessionStoragePathResolution, SessionStorePort, TerminalPort, WorkspacePort,
 };
 
 use crate::{
@@ -32,7 +33,21 @@ impl RuntimeServicePort for FakeRuntimePort {
 
 impl FileSystemPort for FakeRuntimePort {}
 impl WorkspacePort for FakeRuntimePort {}
-impl SessionStorePort for FakeRuntimePort {}
+#[async_trait::async_trait]
+impl SessionStorePort for FakeRuntimePort {
+    async fn resolve_session_storage_path(
+        &self,
+        request: SessionStoragePathRequest,
+    ) -> PortResult<SessionStoragePathResolution> {
+        Ok(SessionStoragePathResolution::new(
+            request.workspace_path.clone(),
+            request.workspace_path,
+            SessionStorageKind::Local,
+            request.remote_connection_id,
+            request.remote_ssh_host,
+        ))
+    }
+}
 impl TerminalPort for FakeRuntimePort {}
 impl NetworkPort for FakeRuntimePort {}
 impl GitPort for FakeRuntimePort {}

--- a/src/crates/runtime-services/tests/runtime_services_contracts.rs
+++ b/src/crates/runtime-services/tests/runtime_services_contracts.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use bitfun_runtime_ports::FileSystemPort;
-use bitfun_runtime_ports::{RemoteWorkspaceKind, RuntimeServiceCapability};
+use bitfun_runtime_ports::{
+    RemoteWorkspaceKind, RuntimeServiceCapability, SessionStorageKind, SessionStoragePathRequest,
+};
 use bitfun_runtime_services::test_support::{FakeRuntimePort, FakeRuntimeServicesProvider};
 use bitfun_runtime_services::{
     CapabilityAvailability, RuntimeServicesBuilder, RuntimeServicesError, RuntimeServicesProvider,
@@ -124,4 +126,27 @@ async fn registered_remote_ports_expose_owner_contract_methods() {
     assert_eq!(workspace.kind, RemoteWorkspaceKind::Remote);
     assert_eq!(workspace.path, "/remote/project");
     assert_eq!(projection_root.to_string_lossy(), "/remote/project");
+}
+
+#[tokio::test]
+async fn registered_session_store_port_exposes_storage_path_resolution() {
+    let services = FakeRuntimeServicesProvider::with_all_required()
+        .build_services()
+        .expect("required fake services should build");
+
+    let resolution = services
+        .session_store
+        .resolve_session_storage_path(SessionStoragePathRequest {
+            workspace_path: "/workspace".into(),
+            remote_connection_id: None,
+            remote_ssh_host: None,
+        })
+        .await
+        .expect("fake session store should resolve local path");
+
+    assert_eq!(resolution.storage_kind, SessionStorageKind::Local);
+    assert_eq!(
+        resolution.effective_storage_path.to_string_lossy(),
+        "/workspace"
+    );
 }

--- a/src/crates/tool-runtime/Cargo.toml
+++ b/src/crates/tool-runtime/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 globset = { workspace = true }
+dunce = { workspace = true }
 grep-regex = { workspace = true }
 grep-searcher = { workspace = true }
 ignore = { workspace = true }

--- a/src/crates/tool-runtime/src/fs/delete_path.rs
+++ b/src/crates/tool-runtime/src/fs/delete_path.rs
@@ -1,0 +1,77 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalDeleteTarget {
+    pub exists: bool,
+    pub is_directory: bool,
+    pub is_empty: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeleteLocalPathRequest {
+    pub logical_path: String,
+    pub resolved_path: PathBuf,
+    pub recursive: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeleteLocalPathOutcome {
+    pub logical_path: String,
+    pub is_directory: bool,
+    pub recursive: bool,
+}
+
+pub fn inspect_local_delete_target(path: &Path) -> Result<LocalDeleteTarget, String> {
+    if !path.exists() {
+        return Ok(LocalDeleteTarget {
+            exists: false,
+            is_directory: false,
+            is_empty: false,
+        });
+    }
+
+    let is_directory = path.is_dir();
+    let is_empty = if is_directory {
+        fs::read_dir(path)
+            .map_err(|error| format!("Failed to read directory: {}", error))?
+            .next()
+            .is_none()
+    } else {
+        false
+    };
+
+    Ok(LocalDeleteTarget {
+        exists: true,
+        is_directory,
+        is_empty,
+    })
+}
+
+pub fn delete_local_path(
+    request: DeleteLocalPathRequest,
+) -> Result<DeleteLocalPathOutcome, String> {
+    let target = inspect_local_delete_target(&request.resolved_path)?;
+    if !target.exists {
+        return Err(format!("Path does not exist: {}", request.logical_path));
+    }
+
+    if target.is_directory {
+        if request.recursive {
+            fs::remove_dir_all(&request.resolved_path)
+                .map_err(|error| format!("Failed to delete directory: {}", error))?;
+        } else {
+            fs::remove_dir(&request.resolved_path)
+                .map_err(|error| format!("Failed to delete directory: {}", error))?;
+        }
+    } else {
+        fs::remove_file(&request.resolved_path)
+            .map_err(|error| format!("Failed to delete file: {}", error))?;
+    }
+
+    Ok(DeleteLocalPathOutcome {
+        logical_path: request.logical_path,
+        is_directory: target.is_directory,
+        recursive: request.recursive,
+    })
+}

--- a/src/crates/tool-runtime/src/fs/edit_file.rs
+++ b/src/crates/tool-runtime/src/fs/edit_file.rs
@@ -3,6 +3,7 @@ use crate::util::read_line_prefix::{
 };
 use crate::util::string::normalize_string;
 use std::fs;
+use std::path::PathBuf;
 
 const MAX_MATCH_CONTEXTS: usize = 5;
 const CONTEXT_LINES_BEFORE: usize = 2;
@@ -24,6 +25,32 @@ pub struct EditResult {
 /// Result of applying an edit to in-memory content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApplyEditResult {
+    pub new_content: String,
+    pub match_count: usize,
+    pub edit_result: EditResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditLocalFileRequest {
+    pub logical_path: String,
+    pub resolved_path: PathBuf,
+    pub old_string: String,
+    pub new_string: String,
+    pub replace_all: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditLocalFileWithContentRequest {
+    pub logical_path: String,
+    pub resolved_path: PathBuf,
+    pub current_content: String,
+    pub old_string: String,
+    pub new_string: String,
+    pub replace_all: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditLocalFileOutcome {
     pub new_content: String,
     pub match_count: usize,
     pub edit_result: EditResult,
@@ -111,19 +138,28 @@ fn find_actual_string(file_content: &str, search_string: &str) -> Option<String>
             .map(normalize_quote_char)
             .eq(normalized_search.iter().copied());
         if window_matches {
-            return Some(file_chars[start..start + search_chars.len()].iter().collect());
+            return Some(
+                file_chars[start..start + search_chars.len()]
+                    .iter()
+                    .collect(),
+            );
         }
     }
 
     None
 }
 
-fn edit_string_candidates(content: &str, old_string: &str, new_string: &str) -> Vec<(String, String)> {
+fn edit_string_candidates(
+    content: &str,
+    old_string: &str,
+    new_string: &str,
+) -> Vec<(String, String)> {
     let mut candidates = Vec::new();
     let mut push_candidate = |old: String, new: String| {
-        if !candidates.iter().any(|(existing_old, existing_new)| {
-            existing_old == &old && existing_new == &new
-        }) {
+        if !candidates
+            .iter()
+            .any(|(existing_old, existing_new)| existing_old == &old && existing_new == &new)
+        {
             candidates.push((old, new));
         }
     };
@@ -131,8 +167,8 @@ fn edit_string_candidates(content: &str, old_string: &str, new_string: &str) -> 
     push_candidate(old_string.to_string(), new_string.to_string());
 
     if let Some(sanitized_old) = sanitize_read_tool_copied_text(old_string) {
-        let sanitized_new = sanitize_read_tool_copied_text(new_string)
-            .unwrap_or_else(|| new_string.to_string());
+        let sanitized_new =
+            sanitize_read_tool_copied_text(new_string).unwrap_or_else(|| new_string.to_string());
         push_candidate(sanitized_old, sanitized_new);
     }
 
@@ -348,11 +384,42 @@ pub fn edit_file(
     Ok(result.edit_result)
 }
 
+pub fn edit_local_file(request: EditLocalFileRequest) -> Result<EditLocalFileOutcome, String> {
+    let content = fs::read_to_string(&request.resolved_path)
+        .map_err(|error| format!("Failed to read file {}: {}", request.logical_path, error))?;
+    edit_local_file_with_content(EditLocalFileWithContentRequest {
+        logical_path: request.logical_path,
+        resolved_path: request.resolved_path,
+        current_content: content,
+        old_string: request.old_string,
+        new_string: request.new_string,
+        replace_all: request.replace_all,
+    })
+}
+
+pub fn edit_local_file_with_content(
+    request: EditLocalFileWithContentRequest,
+) -> Result<EditLocalFileOutcome, String> {
+    let result = apply_edit_to_content(
+        &request.current_content,
+        &request.old_string,
+        &request.new_string,
+        request.replace_all,
+    )?;
+
+    fs::write(&request.resolved_path, result.new_content.as_bytes())
+        .map_err(|error| format!("Failed to write file {}: {}", request.logical_path, error))?;
+
+    Ok(EditLocalFileOutcome {
+        new_content: result.new_content,
+        match_count: result.match_count,
+        edit_result: result.edit_result,
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{
-        apply_edit_to_content, edit_file, sanitize_read_tool_copied_text, EditResult,
-    };
+    use super::{apply_edit_to_content, edit_file, sanitize_read_tool_copied_text, EditResult};
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -413,8 +480,9 @@ mod tests {
     #[test]
     fn apply_edit_to_content_accepts_read_tool_line_prefixes() {
         let content = "alpha\nbeta\n";
-        let result = apply_edit_to_content(content, "     1\talpha\n     2\tbeta", "alpha\nBETA", false)
-            .expect("edit should succeed with read prefixes");
+        let result =
+            apply_edit_to_content(content, "     1\talpha\n     2\tbeta", "alpha\nBETA", false)
+                .expect("edit should succeed with read prefixes");
 
         assert_eq!(result.new_content, "alpha\nBETA\n");
     }

--- a/src/crates/tool-runtime/src/fs/mod.rs
+++ b/src/crates/tool-runtime/src/fs/mod.rs
@@ -1,5 +1,18 @@
 pub mod backend;
+pub mod delete_path;
 pub mod edit_file;
 pub mod read_file;
+pub mod write_file;
 
 pub use backend::{FileSystem, LocalFileSystem};
+pub use delete_path::{
+    delete_local_path, inspect_local_delete_target, DeleteLocalPathOutcome, DeleteLocalPathRequest,
+    LocalDeleteTarget,
+};
+pub use edit_file::{
+    edit_local_file, edit_local_file_with_content, EditLocalFileOutcome, EditLocalFileRequest,
+    EditLocalFileWithContentRequest,
+};
+pub use write_file::{
+    write_local_file, WriteLocalFileOutcome, WriteLocalFileRequest, WriteLocalFileStatus,
+};

--- a/src/crates/tool-runtime/src/fs/write_file.rs
+++ b/src/crates/tool-runtime/src/fs/write_file.rs
@@ -1,0 +1,96 @@
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WriteLocalFileStatus {
+    Created,
+    Overwritten,
+    AlreadyExistsSameContent,
+}
+
+impl WriteLocalFileStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Overwritten => "overwritten",
+            Self::AlreadyExistsSameContent => "already_exists_same_content",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteLocalFileRequest {
+    pub logical_path: String,
+    pub resolved_path: PathBuf,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteLocalFileOutcome {
+    pub status: WriteLocalFileStatus,
+    pub bytes_written: usize,
+    pub lines_written: usize,
+    pub assistant_message: String,
+}
+
+fn count_written_lines(content: &str) -> usize {
+    if content.is_empty() {
+        0
+    } else {
+        content.lines().count().max(1)
+    }
+}
+
+pub fn write_local_file(request: WriteLocalFileRequest) -> Result<WriteLocalFileOutcome, String> {
+    let file_already_exists = request.resolved_path.exists();
+    if file_already_exists {
+        let existing = fs::read(&request.resolved_path).map_err(|error| {
+            format!(
+                "Failed to read existing file {}: {}",
+                request.logical_path, error
+            )
+        })?;
+        if existing == request.content.as_bytes() {
+            return Ok(WriteLocalFileOutcome {
+                status: WriteLocalFileStatus::AlreadyExistsSameContent,
+                bytes_written: 0,
+                lines_written: 0,
+                assistant_message: format!(
+                    "Write skipped because {} already exists with identical content.",
+                    request.logical_path
+                ),
+            });
+        }
+    }
+
+    if let Some(parent) = request.resolved_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("Failed to create directory: {}", error))?;
+    }
+
+    fs::write(&request.resolved_path, &request.content)
+        .map_err(|error| format!("Failed to write file {}: {}", request.logical_path, error))?;
+
+    let status = if file_already_exists {
+        WriteLocalFileStatus::Overwritten
+    } else {
+        WriteLocalFileStatus::Created
+    };
+    let verb = match status {
+        WriteLocalFileStatus::Created => "created",
+        WriteLocalFileStatus::Overwritten => "overwrote",
+        WriteLocalFileStatus::AlreadyExistsSameContent => unreachable!(),
+    };
+
+    Ok(WriteLocalFileOutcome {
+        status,
+        bytes_written: request.content.len(),
+        lines_written: count_written_lines(&request.content),
+        assistant_message: format!(
+            "Successfully {} {} ({} bytes).",
+            verb,
+            request.logical_path,
+            request.content.len()
+        ),
+    })
+}

--- a/src/crates/tool-runtime/src/search/glob_search.rs
+++ b/src/crates/tool-runtime/src/search/glob_search.rs
@@ -1,0 +1,509 @@
+use globset::{GlobBuilder, GlobMatcher};
+use ignore::WalkBuilder;
+use log::{info, warn};
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalGlobRequest {
+    pub search_path: PathBuf,
+    pub pattern: String,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalGlobResult {
+    pub matches: Vec<PathBuf>,
+}
+
+pub fn extract_glob_base_directory(pattern: &str) -> (String, String) {
+    let glob_start = pattern.find(['*', '?', '[', '{']);
+
+    match glob_start {
+        Some(index) => {
+            let static_prefix = &pattern[..index];
+            let last_separator = static_prefix
+                .char_indices()
+                .rev()
+                .find(|(_, ch)| *ch == '/' || *ch == '\\')
+                .map(|(idx, _)| idx);
+
+            if let Some(separator_index) = last_separator {
+                (
+                    static_prefix[..separator_index].to_string(),
+                    pattern[separator_index + 1..].to_string(),
+                )
+            } else {
+                (String::new(), pattern.to_string())
+            }
+        }
+        None => {
+            let trimmed = pattern.trim_end_matches(['/', '\\']);
+            let literal_path = Path::new(trimmed);
+            let base_dir = literal_path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty() && *parent != Path::new("."))
+                .map(|parent| parent.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let file_name = literal_path
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| trimmed.to_string());
+
+            let relative_pattern = if pattern.ends_with('/') || pattern.ends_with('\\') {
+                format!("{}/", file_name)
+            } else {
+                file_name
+            };
+
+            (base_dir, relative_pattern)
+        }
+    }
+}
+
+pub fn normalize_path(path: &Path) -> String {
+    dunce::simplified(path).to_string_lossy().replace('\\', "/")
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct GlobCandidate {
+    depth: usize,
+    path: String,
+}
+
+impl Ord for GlobCandidate {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.depth
+            .cmp(&other.depth)
+            .then_with(|| self.path.cmp(&other.path))
+    }
+}
+
+impl PartialOrd for GlobCandidate {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn is_safe_relative_subpath(path: &Path) -> bool {
+    !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
+}
+
+pub fn derive_walk_root(search_path_abs: &Path, pattern: &str) -> (PathBuf, String) {
+    let (base_dir, relative_pattern) = extract_glob_base_directory(pattern);
+    let base_path = Path::new(&base_dir);
+
+    if base_dir.is_empty() || !is_safe_relative_subpath(base_path) {
+        return (search_path_abs.to_path_buf(), pattern.to_string());
+    }
+
+    let walk_root = search_path_abs.join(base_path);
+    if walk_root.starts_with(search_path_abs) {
+        (walk_root, relative_pattern)
+    } else {
+        (search_path_abs.to_path_buf(), pattern.to_string())
+    }
+}
+
+pub fn resolve_glob_config(pattern: &str) -> (bool, bool) {
+    let is_whitelisted = pattern.starts_with(".bitfun")
+        || pattern.contains("/.bitfun")
+        || pattern.contains("\\.bitfun");
+
+    let apply_gitignore = !is_whitelisted;
+    let ignore_hidden_files = !is_whitelisted;
+    (apply_gitignore, ignore_hidden_files)
+}
+
+fn build_rg_args(
+    relative_pattern: &str,
+    apply_gitignore: bool,
+    ignore_hidden_files: bool,
+) -> Vec<String> {
+    let mut args = vec![
+        "--files".to_string(),
+        "--glob".to_string(),
+        relative_pattern.to_string(),
+        "--sort".to_string(),
+        "path".to_string(),
+    ];
+
+    if !apply_gitignore {
+        args.push("--no-ignore".to_string());
+    }
+
+    if !ignore_hidden_files {
+        args.push("--hidden".to_string());
+    }
+
+    args
+}
+
+#[cfg(windows)]
+fn create_command(program: &str) -> Command {
+    let mut command = Command::new(program);
+    command.creation_flags(CREATE_NO_WINDOW);
+    command
+}
+
+#[cfg(not(windows))]
+fn create_command(program: &str) -> Command {
+    let command = Command::new(program);
+    command
+}
+
+fn build_fallback_matcher(relative_pattern: &str) -> Result<GlobMatcher, String> {
+    GlobBuilder::new(relative_pattern)
+        .literal_separator(true)
+        .build()
+        .map_err(|error| error.to_string())
+        .map(|glob| glob.compile_matcher())
+}
+
+fn pattern_has_path_separator(pattern: &str) -> bool {
+    pattern.contains('/') || pattern.contains('\\')
+}
+
+fn match_relative_path(matcher: &GlobMatcher, relative_pattern: &str, relative_path: &str) -> bool {
+    if !pattern_has_path_separator(relative_pattern)
+        && Path::new(relative_path)
+            .file_name()
+            .is_some_and(|file_name| matcher.is_match(file_name))
+    {
+        return true;
+    }
+
+    matcher.is_match(relative_path)
+}
+
+fn collect_with_walk_fallback(
+    walk_root: &Path,
+    relative_pattern: &str,
+    apply_gitignore: bool,
+    ignore_hidden_files: bool,
+    limit: usize,
+) -> Result<Vec<PathBuf>, String> {
+    let matcher = build_fallback_matcher(relative_pattern)?;
+    let walker = WalkBuilder::new(walk_root)
+        .ignore(apply_gitignore)
+        .git_ignore(apply_gitignore)
+        .git_global(apply_gitignore)
+        .git_exclude(apply_gitignore)
+        .hidden(ignore_hidden_files)
+        .build();
+
+    let mut best_matches = BinaryHeap::with_capacity(limit.saturating_add(1));
+    for entry in walker {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                warn!("Glob walker fallback entry error (skipped): {}", error);
+                continue;
+            }
+        };
+
+        if entry
+            .file_type()
+            .map(|file_type| file_type.is_dir())
+            .unwrap_or(false)
+        {
+            continue;
+        }
+
+        let path = entry.path().to_path_buf();
+        let relative_path = match path.strip_prefix(walk_root) {
+            Ok(relative) => relative,
+            Err(_) => continue,
+        };
+        let relative_path = normalize_path(relative_path);
+
+        if match_relative_path(&matcher, relative_pattern, &relative_path) {
+            let normalized_path = normalize_path(&path);
+            let candidate = GlobCandidate {
+                depth: normalized_path.split('/').count(),
+                path: normalized_path,
+            };
+
+            if best_matches.len() < limit {
+                best_matches.push(candidate);
+            } else if let Some(worst_match) = best_matches.peek() {
+                if candidate < *worst_match {
+                    best_matches.pop();
+                    best_matches.push(candidate);
+                }
+            }
+        }
+    }
+
+    Ok(best_matches
+        .into_sorted_vec()
+        .into_iter()
+        .map(|candidate| PathBuf::from(candidate.path))
+        .collect())
+}
+
+pub fn limit_paths(paths: &[PathBuf], limit: usize) -> Vec<PathBuf> {
+    let mut depth_and_paths = paths
+        .iter()
+        .map(|path| {
+            let normalized_path = normalize_path(path);
+            let depth = normalized_path.split('/').count();
+            (depth, normalized_path)
+        })
+        .collect::<Vec<_>>();
+    depth_and_paths.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+
+    let mut result = depth_and_paths
+        .into_iter()
+        .take(limit)
+        .map(|(_, path)| PathBuf::from(path))
+        .collect::<Vec<_>>();
+    result.sort();
+    result
+}
+
+pub fn execute_local_glob(request: LocalGlobRequest) -> Result<LocalGlobResult, String> {
+    if !request.search_path.exists() {
+        return Err(format!(
+            "Search path '{}' does not exist",
+            request.search_path.display()
+        ));
+    }
+    if !request.search_path.is_dir() {
+        return Err(format!(
+            "Search path '{}' is not a directory",
+            request.search_path.display()
+        ));
+    }
+
+    let search_path_abs =
+        dunce::canonicalize(&request.search_path).map_err(|error| error.to_string())?;
+    let (walk_root, relative_pattern) = derive_walk_root(&search_path_abs, &request.pattern);
+    let (apply_gitignore, ignore_hidden_files) = resolve_glob_config(&request.pattern);
+
+    if !walk_root.exists() || !walk_root.is_dir() || request.limit == 0 {
+        return Ok(LocalGlobResult {
+            matches: Vec::new(),
+        });
+    }
+
+    let args = build_rg_args(&relative_pattern, apply_gitignore, ignore_hidden_files);
+    let output = create_command("rg")
+        .current_dir(&walk_root)
+        .args(&args)
+        .arg(".")
+        .output()
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                "ripgrep (rg) is required for Glob tool execution but was not found".to_string()
+            } else {
+                format!("Failed to execute rg for Glob tool: {}", error)
+            }
+        });
+
+    let output = match output {
+        Ok(output) => {
+            info!(
+                "Glob backend selected: backend=rg, search_root={}, pattern={}",
+                walk_root.display(),
+                relative_pattern
+            );
+            output
+        }
+        Err(error) if error.contains("ripgrep (rg) is required") => {
+            info!(
+                "Glob backend selected: backend=fallback_walk, reason=rg_not_found, search_root={}, pattern={}",
+                walk_root.display(),
+                relative_pattern
+            );
+            return collect_with_walk_fallback(
+                &walk_root,
+                &relative_pattern,
+                apply_gitignore,
+                ignore_hidden_files,
+                request.limit,
+            )
+            .map(|matches| LocalGlobResult { matches });
+        }
+        Err(error) => return Err(error),
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let message = if stderr.is_empty() {
+            format!("rg --files failed with status {}", output.status)
+        } else {
+            format!("rg --files failed: {}", stderr)
+        };
+        if stderr.contains("No such file or directory") || stderr.contains("not found") {
+            info!(
+                "Glob backend selected: backend=fallback_walk, reason=rg_execution_failed, search_root={}, pattern={}",
+                walk_root.display(),
+                relative_pattern
+            );
+            return collect_with_walk_fallback(
+                &walk_root,
+                &relative_pattern,
+                apply_gitignore,
+                ignore_hidden_files,
+                request.limit,
+            )
+            .map(|matches| LocalGlobResult { matches });
+        }
+        return Err(message);
+    }
+
+    let all_paths = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            let relative_path = line.strip_prefix("./").unwrap_or(line);
+            walk_root.join(relative_path)
+        })
+        .collect::<Vec<_>>();
+
+    Ok(LocalGlobResult {
+        matches: limit_paths(&all_paths, request.limit),
+    })
+}
+
+pub fn shell_escape(value: &str) -> String {
+    value.replace('\'', "'\\''")
+}
+
+pub fn build_remote_rg_command(search_dir: &str, pattern: &str) -> String {
+    let search_dir_path = Path::new(search_dir);
+    let (remote_walk_root, remote_pattern) = derive_walk_root(search_dir_path, pattern);
+    let (apply_gitignore, ignore_hidden_files) = resolve_glob_config(pattern);
+
+    let mut parts = vec![
+        "cd".to_string(),
+        format!(
+            "'{}'",
+            shell_escape(remote_walk_root.to_string_lossy().as_ref())
+        ),
+        "&&".to_string(),
+        "rg".to_string(),
+        "--files".to_string(),
+        "--glob".to_string(),
+        format!("'{}'", shell_escape(&remote_pattern)),
+        "--sort".to_string(),
+        "path".to_string(),
+    ];
+
+    if !apply_gitignore {
+        parts.push("--no-ignore".to_string());
+    }
+
+    if !ignore_hidden_files {
+        parts.push("--hidden".to_string());
+    }
+
+    parts.push(".".to_string());
+    parts.push("2>/dev/null".to_string());
+    parts.join(" ")
+}
+
+pub fn build_remote_find_command(search_dir: &str, pattern: &str, limit: usize) -> String {
+    let search_dir_path = Path::new(search_dir);
+    let (remote_walk_root, remote_pattern) = derive_walk_root(search_dir_path, pattern);
+
+    let name_pattern = if remote_pattern.contains("**/") {
+        remote_pattern.replacen("**/", "", 1)
+    } else if remote_pattern.contains('/') || remote_pattern.contains('\\') {
+        "*".to_string()
+    } else {
+        remote_pattern
+    };
+
+    let escaped_dir = remote_walk_root.to_string_lossy().replace('\'', "'\\''");
+    let escaped_pattern = name_pattern.replace('\'', "'\\''");
+
+    format!(
+        "find '{}' -maxdepth 10 -name '{}' -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null | head -n {}",
+        escaped_dir, escaped_pattern, limit
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{collect_with_walk_fallback, normalize_path};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TempTree {
+        root: PathBuf,
+    }
+
+    impl TempTree {
+        fn path(&self) -> &Path {
+            &self.root
+        }
+    }
+
+    impl Drop for TempTree {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn make_temp_dir(name: &str) -> TempTree {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("bitfun-glob-search-{name}-{unique}"));
+        fs::create_dir_all(&dir).expect("temp dir should be created");
+        TempTree { root: dir }
+    }
+
+    fn normalized(path: &Path) -> String {
+        normalize_path(path)
+    }
+
+    #[test]
+    fn walk_fallback_returns_files_only_and_matches_rg_basename_globs() {
+        let temp = make_temp_dir("files-only");
+        let root = temp.path();
+        fs::create_dir_all(root.join("src").join("nested")).expect("dirs should be created");
+        fs::write(root.join("src").join("nested").join("lib.rs"), "")
+            .expect("file should be written");
+
+        let wildcard_matches = collect_with_walk_fallback(root, "*", false, false, 10)
+            .expect("fallback glob should succeed")
+            .into_iter()
+            .map(|path| normalized(&path))
+            .collect::<Vec<_>>();
+
+        assert!(wildcard_matches
+            .iter()
+            .all(|path| !path.ends_with("/src") && !path.ends_with("/src/nested")));
+        assert!(wildcard_matches
+            .iter()
+            .any(|path| path.ends_with("/src/nested/lib.rs")));
+
+        let rust_matches = collect_with_walk_fallback(root, "*.rs", false, false, 10)
+            .expect("fallback rust glob should succeed")
+            .into_iter()
+            .map(|path| normalized(&path))
+            .collect::<Vec<_>>();
+        assert_eq!(rust_matches.len(), 1);
+        assert!(rust_matches[0].ends_with("/src/nested/lib.rs"));
+
+        let directory_name_matches = collect_with_walk_fallback(root, "src", false, false, 10)
+            .expect("fallback directory-name glob should succeed");
+        assert!(directory_name_matches.is_empty());
+    }
+}

--- a/src/crates/tool-runtime/src/search/mod.rs
+++ b/src/crates/tool-runtime/src/search/mod.rs
@@ -1,3 +1,8 @@
+pub mod glob_search;
 pub mod grep_search;
 
+pub use glob_search::{
+    build_remote_find_command, build_remote_rg_command, derive_walk_root, execute_local_glob,
+    extract_glob_base_directory, limit_paths, normalize_path, LocalGlobRequest, LocalGlobResult,
+};
 pub use grep_search::{grep_search, GrepOptions, OutputMode, ProgressCallback};

--- a/src/crates/tool-runtime/tests/tool_io_contracts.rs
+++ b/src/crates/tool-runtime/tests/tool_io_contracts.rs
@@ -1,0 +1,162 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tool_runtime::fs::{
+    delete_local_path, edit_local_file, inspect_local_delete_target, write_local_file,
+    DeleteLocalPathRequest, EditLocalFileRequest, LocalDeleteTarget, WriteLocalFileRequest,
+    WriteLocalFileStatus,
+};
+use tool_runtime::search::glob_search::{execute_local_glob, LocalGlobRequest};
+
+fn make_temp_dir(name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("bitfun-tool-io-{name}-{unique}"));
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    dir
+}
+
+fn normalized(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[test]
+fn write_local_file_reports_created_overwritten_and_identical_retry() {
+    let root = make_temp_dir("write");
+    let target = root.join("nested").join("file.txt");
+
+    let created = write_local_file(WriteLocalFileRequest {
+        logical_path: "nested/file.txt".to_string(),
+        resolved_path: target.clone(),
+        content: "hello\nworld\n".to_string(),
+    })
+    .expect("write should create file");
+
+    assert_eq!(created.status, WriteLocalFileStatus::Created);
+    assert_eq!(created.bytes_written, "hello\nworld\n".len());
+    assert_eq!(created.lines_written, 2);
+    assert_eq!(
+        fs::read_to_string(&target).expect("file should exist"),
+        "hello\nworld\n"
+    );
+
+    let identical = write_local_file(WriteLocalFileRequest {
+        logical_path: "nested/file.txt".to_string(),
+        resolved_path: target.clone(),
+        content: "hello\nworld\n".to_string(),
+    })
+    .expect("identical retry should be successful and idempotent");
+
+    assert_eq!(
+        identical.status,
+        WriteLocalFileStatus::AlreadyExistsSameContent
+    );
+    assert_eq!(identical.bytes_written, 0);
+    assert_eq!(identical.lines_written, 0);
+
+    let overwritten = write_local_file(WriteLocalFileRequest {
+        logical_path: "nested/file.txt".to_string(),
+        resolved_path: target.clone(),
+        content: "replacement".to_string(),
+    })
+    .expect("write should overwrite file");
+
+    assert_eq!(overwritten.status, WriteLocalFileStatus::Overwritten);
+    assert_eq!(
+        fs::read_to_string(&target).expect("file should exist"),
+        "replacement"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn edit_local_file_writes_apply_edit_result() {
+    let root = make_temp_dir("edit");
+    let target = root.join("file.txt");
+    fs::write(&target, "alpha\nbeta\n").expect("file should be written");
+
+    let outcome = edit_local_file(EditLocalFileRequest {
+        logical_path: "file.txt".to_string(),
+        resolved_path: target.clone(),
+        old_string: "beta".to_string(),
+        new_string: "BETA".to_string(),
+        replace_all: false,
+    })
+    .expect("edit should succeed");
+
+    assert_eq!(outcome.match_count, 1);
+    assert_eq!(outcome.edit_result.start_line, 2);
+    assert_eq!(
+        fs::read_to_string(&target).expect("file should exist"),
+        "alpha\nBETA\n"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn delete_local_path_inspection_and_execution_preserve_recursive_guard_facts() {
+    let root = make_temp_dir("delete");
+    let dir = root.join("dir");
+    fs::create_dir_all(&dir).expect("dir should be created");
+    fs::write(dir.join("child.txt"), "child").expect("child should be written");
+
+    let target = inspect_local_delete_target(&dir).expect("target should inspect");
+    assert_eq!(
+        target,
+        LocalDeleteTarget {
+            exists: true,
+            is_directory: true,
+            is_empty: false,
+        }
+    );
+
+    let deleted = delete_local_path(DeleteLocalPathRequest {
+        logical_path: "dir".to_string(),
+        resolved_path: dir.clone(),
+        recursive: true,
+    })
+    .expect("recursive delete should succeed");
+
+    assert!(deleted.is_directory);
+    assert!(deleted.recursive);
+    assert!(!dir.exists());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn execute_local_glob_keeps_shallowest_matches() {
+    let root = make_temp_dir("glob");
+    fs::create_dir_all(root.join("src").join("deep")).expect("dirs should be created");
+    fs::create_dir_all(root.join("tests")).expect("dirs should be created");
+    fs::write(root.join("Cargo.toml"), "").expect("file should be written");
+    fs::write(root.join("src").join("lib.rs"), "").expect("file should be written");
+    fs::write(root.join("src").join("deep").join("mod.rs"), "").expect("file should be written");
+    fs::write(root.join("tests").join("mod.rs"), "").expect("file should be written");
+
+    let result = execute_local_glob(LocalGlobRequest {
+        search_path: root.clone(),
+        pattern: "**/*.rs".to_string(),
+        limit: 2,
+    })
+    .expect("glob should succeed");
+
+    let matches = result
+        .matches
+        .iter()
+        .map(|path| normalized(path))
+        .collect::<Vec<_>>();
+    assert_eq!(matches.len(), 2);
+    assert!(matches.iter().any(|path| path.ends_with("/src/lib.rs")));
+    assert!(matches.iter().any(|path| path.ends_with("/tests/mod.rs")));
+    assert!(!matches
+        .iter()
+        .any(|path| path.ends_with("/src/deep/mod.rs")));
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Summary
- Move session restore/load request, timing, and storage-path facts into runtime ports/services while keeping the core session-store adapter as the concrete bridge.
- Move local Write/Edit/Delete/Glob filesystem and search execution primitives into `tool-runtime`; core keeps the agent-facing `Tool` adapters, freshness checks, permission admission, checkpoint hooks, and product assembly boundaries.
- Keep the runtime-ports API minimal by avoiding delivery-shape policy helpers in the shared contracts; desktop keeps its own 16-turn restore-view clamp.
- Update the core decomposition plan/completed docs to mark PR-2 as complete without changing the target architecture design.

## Behavior / Risk
- Preserves desktop restore response shape, session-view tail clamp behavior, tool-result preview compacting, and startup timing recording.
- Preserves tool names, schemas, prompt-visible exposure, file-read freshness, workspace-search preference, remote shell fallback, and MCP/ACP catalog behavior.
- Local blocking filesystem/search primitives run behind blocking tasks when entered from async tool paths.
- Glob local fallback now matches `rg --files --glob` files-only behavior for wildcard basename patterns, covering CI environments that take the fallback path.
- Does not move Bash/terminal lifecycle, indexed workspace search service, remote shell execution, permission `Tool` handler, checkpoint orchestration, session manager lifecycle, or persistence file IO.

## Verification
- `cargo test -p tool-runtime`
- `cargo test -p bitfun-runtime-ports`
- `cargo test -p bitfun-runtime-services`
- `cargo test -p bitfun-agent-tools`
- `cargo test --locked -p bitfun-core`
- `node scripts/check-core-boundaries.mjs`
- `cargo check -p bitfun-core --no-default-features`
- `cargo check -p bitfun-core --features product-full`
- `cargo check -p bitfun-desktop`
- `git diff --check`
