### PR TITLE
fix(core): prevent duplicate token usage records

### DIFF
--- a/src/apps/cli/src/agent/core_adapter.rs
+++ b/src/apps/cli/src/agent/core_adapter.rs
@@ -1,9 +1,8 @@
 //! Core Agent adapter
 //!
 //! Adapts bitfun-core's Agentic system to CLI's Agent interface.
-//! Event consumption is done in the chat/exec mode main loops, which must also
-//! call [`Self::route_internal_events`] so internal subscribers (e.g. token usage)
-//! receive dequeued envelopes.
+//! Event consumption is done in the chat/exec mode main loops. Internal
+//! subscribers receive the same envelopes from the core event broadcast.
 
 use anyhow::Result;
 use std::path::PathBuf;
@@ -15,7 +14,7 @@ use bitfun_core::agentic::coordination::{
     ConversationCoordinator, DialogSubmissionPolicy, DialogTriggerSource,
 };
 use bitfun_core::agentic::core::SessionConfig;
-use bitfun_core::agentic::events::{EventEnvelope, EventQueue};
+use bitfun_core::agentic::events::EventQueue;
 
 /// Core-based Agent implementation.
 /// Stateless regarding agent_type — callers pass it per-call.
@@ -53,15 +52,6 @@ impl CoreAgentAdapter {
     #[allow(dead_code)]
     pub fn coordinator(&self) -> &Arc<ConversationCoordinator> {
         &self.coordinator
-    }
-
-    /// Forward dequeued envelopes to internal event subscribers.
-    pub async fn route_internal_events(&self, envelopes: &[EventEnvelope]) {
-        for envelope in envelopes {
-            if let Err(error) = self.coordinator.route_internal_event(envelope.clone()).await {
-                tracing::warn!("Internal event routing failed: {}", error);
-            }
-        }
     }
 
     pub fn workspace_path_buf(&self) -> PathBuf {

--- a/src/apps/cli/src/main.rs
+++ b/src/apps/cli/src/main.rs
@@ -405,28 +405,6 @@ async fn initialize_core_services(
         .expect("Failed to initialize agentic system");
     tracing::info!("Agentic system initialized");
 
-    match bitfun_core::infrastructure::try_get_path_manager_arc() {
-        Ok(path_manager) => {
-            match bitfun_core::service::token_usage::TokenUsageService::new(path_manager).await {
-                Ok(token_usage_service) => {
-                    let subscriber = bitfun_core::service::token_usage::TokenUsageSubscriber::new(
-                        std::sync::Arc::new(token_usage_service),
-                    );
-                    agentic_system
-                        .coordinator
-                        .subscribe_internal("cli-token-usage".to_string(), subscriber);
-                    tracing::info!("CLI token usage subscriber initialized");
-                }
-                Err(error) => {
-                    tracing::warn!("Failed to initialize CLI token usage service: {}", error);
-                }
-            }
-        }
-        Err(error) => {
-            tracing::warn!("Failed to resolve path manager for token usage: {}", error);
-        }
-    }
-
     // Initialize MCP service in background (non-blocking)
     if let Some(ref cfg_svc) = config_service {
         match bitfun_core::service::mcp::MCPService::new(cfg_svc.clone()) {

--- a/src/apps/cli/src/modes/chat.rs
+++ b/src/apps/cli/src/modes/chat.rs
@@ -497,9 +497,6 @@ impl ChatMode {
             // 2. Process core events (non-blocking)
             let events =
                 tokio::task::block_in_place(|| rt_handle.block_on(event_queue.dequeue_batch(20)));
-            tokio::task::block_in_place(|| {
-                rt_handle.block_on(self.agent.route_internal_events(&events))
-            });
             for envelope in events {
                 let event = &envelope.event;
 

--- a/src/apps/cli/src/modes/exec.rs
+++ b/src/apps/cli/src/modes/exec.rs
@@ -232,7 +232,6 @@ impl ExecMode {
             }
 
             let events = event_queue.dequeue_batch(20).await;
-            self.agent.route_internal_events(&events).await;
 
             for envelope in events {
                 let event = &envelope.event;

--- a/src/crates/core/src/service/token_usage/service.rs
+++ b/src/crates/core/src/service/token_usage/service.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 const TOKEN_USAGE_DIR: &str = "token_usage";
 const MODEL_STATS_FILE: &str = "model_stats.json";
@@ -24,6 +24,7 @@ pub struct TokenUsageService {
     path_manager: Arc<PathManager>,
     model_stats: Arc<RwLock<HashMap<String, ModelTokenStats>>>,
     session_cache: Arc<RwLock<HashMap<String, SessionTokenStats>>>,
+    records_write_lock: Arc<Mutex<()>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -38,6 +39,7 @@ impl TokenUsageService {
             path_manager,
             model_stats: Arc::new(RwLock::new(HashMap::new())),
             session_cache: Arc::new(RwLock::new(HashMap::new())),
+            records_write_lock: Arc::new(Mutex::new(())),
         };
 
         // Initialize storage directories
@@ -271,6 +273,7 @@ impl TokenUsageService {
 
     /// Persist record to disk
     async fn persist_record(&self, record: &TokenUsageRecord) -> Result<()> {
+        let _guard = self.records_write_lock.lock().await;
         let path = self.get_records_path(record.timestamp);
 
         // Load existing records for the day
@@ -588,5 +591,80 @@ impl TokenUsageService {
 
         info!("Cleared all token usage statistics");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_path_manager() -> Arc<PathManager> {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir()
+            .join("bitfun-token-usage-tests")
+            .join(format!("{}-{}", std::process::id(), nanos));
+        Arc::new(PathManager::with_user_root_for_tests(root.join("config")))
+    }
+
+    #[tokio::test]
+    async fn concurrent_record_usage_persists_all_records() {
+        let path_manager = test_path_manager();
+        let cleanup_root = path_manager.user_data_dir();
+        let service = Arc::new(
+            TokenUsageService::new(path_manager)
+                .await
+                .expect("token usage service should initialize"),
+        );
+
+        let mut handles = Vec::new();
+        for index in 0..50u32 {
+            let service = service.clone();
+            handles.push(tokio::spawn(async move {
+                service
+                    .record_usage(
+                        "test-model".to_string(),
+                        format!("session-{}", index % 3),
+                        format!("turn-{}", index),
+                        100 + index,
+                        10,
+                        Some(5),
+                        Some(20),
+                        None,
+                        index % 2 == 0,
+                    )
+                    .await
+                    .expect("record usage should succeed");
+            }));
+        }
+
+        for handle in handles {
+            handle.await.expect("record task should join");
+        }
+
+        let records = service
+            .query_records(TokenUsageQuery {
+                model_id: Some("test-model".to_string()),
+                session_id: None,
+                time_range: TimeRange::Today,
+                limit: None,
+                offset: None,
+                include_subagent: true,
+            })
+            .await
+            .expect("records should query");
+        assert_eq!(records.len(), 50);
+
+        let stats = service
+            .get_model_stats("test-model")
+            .await
+            .expect("model stats should exist");
+        assert_eq!(stats.request_count, 50);
+        assert_eq!(stats.session_count, 3);
+
+        let _ = std::fs::remove_dir_all(cleanup_root);
     }
 }


### PR DESCRIPTION
## Summary
- serialize token usage record writes to avoid losing records during concurrent updates
- remove duplicate CLI token usage subscriber and duplicate internal event routing
- add a regression test covering concurrent token usage persistence

## Verification
- `CARGO_BUILD_JOBS=1 cargo test -p bitfun-core concurrent_record_usage_persists_all_records -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo check -p bitfun-cli`