### PR TITLE
refactor(agent-runtime): close delivery contract owners

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -228,13 +228,35 @@
 - 非 custom agent definition loading、event delivery、permission `Tool` handler、concrete hook side-effect execution 和 concrete scheduler lifecycle 仍未迁移。
 - 继续迁移这些路径必须先补端到端等价保护，不能只依赖 owner contract test。
 
+### 1.13 最终 PR-C：Agent Runtime concrete delivery / permission closure
+
+- `bitfun-agent-runtime::thread_goal_tools` 承接 `get_goal` / `create_goal` / `update_goal` 的参数解析、status 解析、tool response
+  wire shape 和 assistant summary；core `Tool` adapter 只保留 coordinator 调用、session/workspace context 获取和 `BitFunError` 映射。
+- `bitfun-agent-runtime::user_questions` 承接 `AskUserQuestion` 的 input DTO、ACP 可用性判断、问题校验、answered/cancelled result
+  wire shape 和 assistant-facing result text；core 只保留 event emit、oneshot channel 和 user-input manager 适配。
+- thread goal 的 metadata patch、legacy `goal_mode` migration、event payload 序列化、token usage 过滤和 scheduler delivery plan 已归入
+  `bitfun-agent-runtime`；core 只保留 session metadata IO、全局 coordinator/runtime 调用、event emitter 和 scheduler submit / injection。
+- 非 custom builtin agent definition catalog 的顺序、分类、默认模型和 visibility policy 已归入
+  `bitfun-agent-runtime::agents`；core registry 只保留 legacy `Agent` factory 映射和注册适配。
+- DeepReview successful tool post-call hook 的 shared-context measurement 过滤、subagent/parent-turn 提取、local path 归一和 runtime URI
+  过滤已归入 `bitfun-agent-runtime::post_call_hooks`；core 只执行最终 diagnostics 记录副作用。
+- focused coverage 覆盖 goal tool wire shape、AskUserQuestion validation/result、builtin agent catalog、thread-goal metadata/event/token
+  delivery、scheduler resumed/objective-updated delivery plan 和 DeepReview hook measurement decision；core 聚焦测试覆盖 registry、goal mode、
+  scheduler、AskUserQuestion 和 DeepReview 旧路径兼容。
+
+明确未完成：
+
+- concrete scheduler lifecycle、session metadata / persistence IO、event emitter wiring、permission UI/channel wait、concrete prompt assembly、
+  product `Tool` execution adapter 和 DeepReview diagnostics store 仍是 core compatibility / product assembly 副作用，不属于 Agent Runtime SDK 纯 owner。
+- 这些剩余 concrete 副作用若继续外移，必须作为独立行为等价迁移评审，不得混入最终 PR-D 的 Product Runtime / Service / Tool closure。
+
 ## 2. 已建立保护
 
 - 新 owner crate 不得依赖回 `bitfun-core`。
 - `product-full` 是完整产品能力保护开关。
 - 构建脚本和 installer 相关脚本不作为 core 拆解的一部分修改。
 - boundary check 覆盖已外移 owner 的旧路径 facade-only / 禁止回流状态。
-- tool manifest、`GetToolSpec`、execution admission gate、MiniApp storage layout adapter、product-domain pure helper、remote workspace search fallback、MCP config / catalog / dynamic manifest、agent-runtime prompt cache、agent registry source/profile facts、custom subagent schema/default/markdown IO/discovery/loading、post-call hook routing/executor orchestration、tool confirmation plan/failure mapping、product capability pack、harness/tool provider assembly、session restore path/timing facts、本地 tool IO primitive、function-agent Git/AI concrete runtime 和 scheduled-job lifecycle state 等已有 focused baseline。
+- tool manifest、`GetToolSpec`、execution admission gate、MiniApp storage layout adapter、product-domain pure helper、remote workspace search fallback、MCP config / catalog / dynamic manifest、agent-runtime prompt cache、agent registry source/profile facts、builtin agent catalog、custom subagent schema/default/markdown IO/discovery/loading、thread-goal tool / metadata / event / token / scheduler delivery、AskUserQuestion validation/result、DeepReview hook measurement decision、post-call hook routing/executor orchestration、tool confirmation plan/failure mapping、product capability pack、harness/tool provider assembly、session restore path/timing facts、本地 tool IO primitive、function-agent Git/AI concrete runtime 和 scheduled-job lifecycle state 等已有 focused baseline。
 
 ## 3. 当前剩余结论
 
@@ -242,6 +264,6 @@
 - 早期 PR-C 已收敛 Harness / Product Capability / Build-Benefit closure；PR-1 已收敛 session restore hot-path
   request / timing / storage path facts 和 Runtime Services port；PR-2 已收敛本地 Write / Edit / Delete / Glob
   concrete IO primitive；PR-3 已收敛 function-agent Git/AI concrete runtime owner closure；PR-4 已收敛 scheduled-job lifecycle state owner closure；Agent Runtime Extension Boundary Closure 已收敛 custom subagent schema/default/markdown IO/discovery/loading、post-call hook routing/executor orchestration 和 tool confirmation 计划 / 失败映射。后续不应继续拆零散 helper PR；
-- 当前活跃迁移只剩 `core-decomposition-plan.md` 中的最终 PR-C / PR-D：最终 PR-C 关闭 Agent Runtime concrete delivery / permission / scheduler / event / hook / non-custom agent definition loading；最终 PR-D 关闭 Product Runtime、Runtime Services、Tool / Terminal / Search、Remote、MiniApp 和 function-agent 的剩余 concrete owner。最终 PR-C / PR-D 是收尾阶段编号，不再复用早期 PR-C 的范围。
+- 最终 PR-C 已收敛 Agent Runtime concrete delivery / permission 合同：goal/user-question tool handler 合同、thread-goal metadata / token / event / scheduler delivery plan、builtin agent catalog 和 DeepReview hook measurement decision。当前活跃迁移只剩 `core-decomposition-plan.md` 中的最终 PR-D：关闭 Product Runtime、Runtime Services、Tool / Terminal / Search、Remote、MiniApp 和 function-agent 的剩余 concrete owner。
 - PR-D 完成并通过总体验收后，本文档范围内的 core decomposition runtime owner 迁移应关闭；后续只允许独立缺陷修复、feature matrix、构建收益优化、目录整理或产品行为变更评审，不再作为迁移计划遗漏追加。
 - 缺陷修复、行为变更、冗余清理、三方库升级和构建脚本调整必须独立评估，不能伪装成 core decomposition 剩余里程碑。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -68,16 +68,15 @@ workspace build 证明没有行为或 feature 影响。
 
 ## 4. 后续迁移队列
 
-早期 PR-A / PR-B / PR-C、scheduler owner decision 扩展、PR-1 Session Store / Restore Runtime Services Owner、PR-2 Concrete Tool IO Runtime Owner、PR-3 Function-Agent Concrete Runtime Owner、PR-4 Scheduled Job Lifecycle State Owner 和 Agent Runtime Extension Boundary Closure 已进入完成归档。当前活跃队列只保留最终 PR-C / PR-D 两个大块迁移 PR；这里的最终 PR-C / PR-D 是收尾阶段编号，不再复用早期 PR-C 的范围。两者完成并通过验收后，本文档范围内的 core decomposition runtime owner 迁移应关闭，不再继续新增迁移 PR。后续如仍有缺陷修复、feature matrix、构建收益优化或产品行为变更，应作为独立工作评审，不能伪装成迁移收尾。
+早期 PR-A / PR-B / PR-C、scheduler owner decision 扩展、PR-1 Session Store / Restore Runtime Services Owner、PR-2 Concrete Tool IO Runtime Owner、PR-3 Function-Agent Concrete Runtime Owner、PR-4 Scheduled Job Lifecycle State Owner、Agent Runtime Extension Boundary Closure 和最终 PR-C 已进入完成归档。当前活跃队列只保留最终 PR-D。PR-D 完成并通过验收后，本文档范围内的 core decomposition runtime owner 迁移应关闭，不再继续新增迁移 PR。后续如仍有缺陷修复、feature matrix、构建收益优化或产品行为变更，应作为独立工作评审，不能伪装成迁移收尾。
 
 每个 PR 必须迁移真实 owner 逻辑，并同时包含旧路径兼容、focused tests、boundary check 和提交前对抗性审核。只新增抽象、只补 facade 或只增加 guard 不满足准出要求。
 
 | PR | 主题 | 完整范围 | 不允许混入 | 合入门禁 |
 |---|---|---|---|---|
-| PR-C | Agent Runtime Concrete Delivery / Permission Closure | 收敛 Agent Runtime 侧剩余 concrete delivery：event delivery、permission `Tool` handler、goal `Tool` handler、thread-goal metadata / token subscriber / scheduler delivery adapter、非 custom agent definition loading、concrete scheduler lifecycle、post-turn / hook side-effect execution，以及这些路径需要保留在 core 的最小 compatibility adapter | 用 owner contract test 替代端到端行为证明；改变 session lifecycle、event ordering、goal tool wire shape、DeepResearch citation/post-turn behavior、permission UI 语义或默认 agent / subagent 可见性 | queue/preempt/cancel/goal verification/event focused tests，DeepResearch citation/post-turn tests，permission tool handler tests，non-custom agent definition loading tests，`cargo check --workspace` |
 | PR-D | Product Runtime / Service / Tool Final Closure | 收敛剩余 concrete runtime owner：session persistence / cold restore / metadata IO、workspace-root / persistence / workspace service reads、remote FS / terminal / image context concrete impl、Bash / terminal lifecycle / indexed workspace search / remote shell execution、MiniApp worker / host / seed / marker IO、function-agent concrete service 外移，以及必要的 final boundary / directory organization cleanup | 改变产品能力集合、工具曝光、权限、checkpoint、remote fallback、MiniApp worker 生命周期、function-agent Git/AI 行为、release/installer 构建形态；把独立 feature matrix 或构建性能优化混入迁移 | session persistence / restore tests，remote workspace / file / terminal focused tests，terminal / shell / indexed-search focused tests，MiniApp import/sync/recompile/worker tests，function-agent Git/AI focused tests，`cargo check --workspace` |
 
-计划优先级：先完成 PR-C，再完成 PR-D。PR-D 合入后需要做一次总体验收：确认 plan / completed 文档没有剩余活跃迁移队列，`bitfun-core` 只保留兼容 facade 和产品组装，边界脚本覆盖已外移 owner，且所有产品形态仍保持既有能力集合。PR-1 到 PR-4 和 Agent Runtime Extension Boundary Closure 已进入完成归档；后续不应继续触碰 session restore 热路径、已迁移的本地 tool IO primitive、function-agent Git/AI concrete runtime、scheduled-job runtime state、custom subagent schema/default/markdown IO/discovery/loading、post-call hook routing/executor orchestration 或 tool confirmation 计划与失败映射，除非是修复等价测试发现的问题。
+计划优先级：完成最终 PR-D 后做一次总体验收：确认 plan / completed 文档没有剩余活跃迁移队列，`bitfun-core` 只保留兼容 facade 和产品组装，边界脚本覆盖已外移 owner，且所有产品形态仍保持既有能力集合。PR-1 到 PR-4、Agent Runtime Extension Boundary Closure 和最终 PR-C 已进入完成归档；后续不应继续触碰 session restore 热路径、已迁移的本地 tool IO primitive、function-agent Git/AI concrete runtime、scheduled-job runtime state、custom subagent schema/default/markdown IO/discovery/loading、post-call hook routing/executor orchestration、tool confirmation 计划与失败映射，或最终 PR-C 已收敛的 agent-runtime concrete delivery / permission 合同，除非是修复等价测试发现的问题。
 
 ## 5. 每类 PR 的保护重点
 
@@ -94,18 +93,20 @@ workspace build 证明没有行为或 feature 影响。
   construction、steering action、agent-session reply plan、cancelled-reply suppression state、goal-continuation abort flags 和 runtime event facts；
   不移动 concrete scheduler 生命周期。
 - 保留 mode-scoped visibility、hidden/custom/review grouping、background delivery entrypoint、idle-session follow-up 和 persisted thread goal continuation 语义。
-- thread goal runtime、subagent visibility/availability、round-boundary yield/injection、turn-outcome queue
+- thread goal runtime、metadata patch / legacy migration、token usage filter、event payload、scheduler delivery plan、goal
+  `Tool` wire contract、user-question `Tool` validation/result contract、builtin agent definition catalog、DeepReview
+  shared-context measurement decision、subagent visibility/availability、round-boundary yield/injection、turn-outcome queue
   policy、dialog turn queue、active-turn state、background running-turn injection construction、steering action、
   agent-session reply plan、cancel suppression、finish-reason label、session-state event label 和 turn-outcome event fact 已归入
-  `bitfun-agent-runtime`；后续只允许 core 继续作为 metadata store、config/file IO adapter、concrete prompt
-  assembly、concrete scheduler lifecycle、scheduler delivery、event delivery 和 `Tool` adapter。
+  `bitfun-agent-runtime`；后续只允许 core 继续作为 session metadata IO、config/file IO adapter、concrete prompt
+  assembly、concrete scheduler lifecycle、event emitter、channel wait、UI 副作用和 product `Tool` execution adapter。
 - scheduled-job runtime state、run status、retry / coalescing / one-shot / missing-session disable / restart recovery
   transition 已归入 `bitfun-agent-runtime::scheduled_job`；core cron 继续拥有 store、schedule parsing、loop wakeup、session
   creation、scheduler submit 和 API wire compatibility。
 - custom subagent definition schema、required-field 校验、默认值、front-matter 省略决策、markdown front-matter IO、目录 discovery / `.md` loading、successful tool post-call hook routing / executor orchestration
   和 tool confirmation 计划 / 失败映射已归入 `bitfun-agent-runtime`；core 继续供应 concrete root path、持有旧 `Agent` 适配、记录加载错误、执行工具 / 模型校验、写入 registry，并保留 DeepReview shared-context measurement 的具体副作用、confirmation channel wait / 状态更新 / UI 副作用和 `BitFunError` 映射。
-- 若继续迁移 scheduler lifecycle、event delivery、permission `Tool` handler、非 custom agent definition loading 或 concrete hook side-effect execution，必须先补端到端等价保护，
-  不能只用 owner contract test 证明。
+- 若继续迁移 scheduler lifecycle、session metadata IO、event emitter、permission UI/channel wait 或 concrete hook side-effect execution，必须先补端到端等价保护，
+  不能只用 owner contract test 证明；不得把这些剩余 concrete 副作用伪装成 Agent Runtime SDK 纯合同迁移。
 - 验证 subagent availability、queue/preempt/cancel suppression、DeepResearch citation / post-turn hook、goal verification events、`get_goal` / `create_goal` / `update_goal` tool response wire shape。
 
 ### 5.3 Product-Domain Runtime Owner

--- a/scripts/check-core-boundaries.mjs
+++ b/scripts/check-core-boundaries.mjs
@@ -5815,19 +5815,38 @@ const requiredContentRules = [
   {
     path: 'src/crates/core/src/agentic/agents/registry/builtin.rs',
     reason:
-      'core builtin registry must continue registering latest-main mode and subagent defaults until agent registry ownership migrates with API equivalence tests',
+      'core builtin registry must delegate builtin default model facts to agent-runtime while preserving latest-main compatibility',
     patterns: [
       {
         regex: /\bbuiltin_agent_specs\(\)/,
         message: 'missing builtin agent spec registration source',
       },
       {
-        regex: /"Multitask"\s*=>\s*"auto"/,
-        message: 'missing Multitask default model mapping',
+        regex: /\bruntime_agents::default_model_id_for_builtin_agent\(agent_type\)/,
+        message: 'missing default model delegation to agent-runtime',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/agent-runtime/src/agents.rs',
+    reason:
+      'agent-runtime builtin agent catalog must own latest-main mode/subagent categories, visibility, and default model facts',
+    patterns: [
+      {
+        regex: /\bbuiltin_agent_definition_specs\(\)/,
+        message: 'missing builtin agent definition catalog owner',
       },
       {
-        regex: /"GeneralPurpose"\s*=>\s*"fast"/,
-        message: 'missing GeneralPurpose default model mapping',
+        regex: /builtin_agent_spec\(\s*"Multitask",\s*Mode,\s*"auto"/,
+        message: 'missing Multitask runtime default model mapping',
+      },
+      {
+        regex: /builtin_agent_spec\(\s*"GeneralPurpose",\s*SubAgent,\s*"fast"/,
+        message: 'missing GeneralPurpose runtime default model mapping',
+      },
+      {
+        regex: /SubagentVisibilityPolicy::restricted\(\["Claw",\s*"Team"\]\)/,
+        message: 'missing ComputerUse restricted visibility mapping',
       },
     ],
   },

--- a/src/crates/agent-runtime/AGENTS.md
+++ b/src/crates/agent-runtime/AGENTS.md
@@ -9,15 +9,20 @@ and tested without `bitfun-core`.
 
 - Do not depend on `bitfun-core`, app crates, Tauri, ACP protocol, web UI,
   concrete service crates, or product-domain implementations.
-- Keep concrete scheduler/session lifecycle execution, session metadata IO, and
-  product `Tool` adapters in `bitfun-core` until a reviewed owner migration
-  proves behavior equivalence.
+- Keep concrete scheduler/session lifecycle execution, session metadata IO,
+  event emitter wiring, permission UI / channel waits, and product `Tool`
+  adapter execution in `bitfun-core` until a reviewed owner migration proves
+  behavior equivalence.
 - Prefer pure facts and decisions first: queue policy, background delivery,
   dialog-turn queue state, active-turn facts, cancellation routing and
   suppression state, background running-turn injection construction, steering action
   planning, agent-session reply planning, thread-goal accounting/mutation/continuation decisions,
   scheduled-job lifecycle state transitions, runtime event facts,
   registry visibility/availability, custom subagent schema/default decisions,
+  builtin agent definition catalog, thread-goal metadata / event payload /
+  token usage / scheduler delivery plans, thread-goal tool wire contracts,
+  user-question validation/result contracts, DeepReview shared-context
+  measurement decisions,
   custom subagent markdown front-matter IO, custom subagent discovery/loading,
   post-call hook routing/executor orchestration,
   tool confirmation planning/failure mapping, round-boundary yield/injection state, turn-outcome
@@ -25,10 +30,9 @@ and tested without `bitfun-core`.
   policy, prompt listing reminder ordering, prompt-cache policy/identity/store,
   finish-reason labels, session-state event labels, and turn-outcome event facts.
 - Keep concrete prompt assembly, workspace context IO, prompt-cache persistence
-  wiring, dynamic environment collection, concrete non-custom agent definition
-  loading, concrete hook side effects, permission UI/tool side effects, and
-  channel/state mutation outside this crate until a reviewed migration proves
-  behavior equivalence.
+  wiring, dynamic environment collection, concrete hook side effects, concrete
+  product tool execution, and channel/state mutation outside this crate until a
+  reviewed migration proves behavior equivalence.
 - Add focused tests before moving any runtime decision into this crate.
 
 ## Verification

--- a/src/crates/agent-runtime/src/agents.rs
+++ b/src/crates/agent-runtime/src/agents.rs
@@ -56,6 +56,169 @@ pub fn shared_coding_mode_user_context_policy() -> UserContextPolicy {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuiltinAgentCategory {
+    Mode,
+    SubAgent,
+    Hidden,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuiltinAgentDefinitionSpec {
+    pub id: &'static str,
+    pub category: BuiltinAgentCategory,
+    pub visibility_policy: SubagentVisibilityPolicy,
+    pub default_model_id: &'static str,
+}
+
+pub fn builtin_agent_definition_specs() -> Vec<BuiltinAgentDefinitionSpec> {
+    use BuiltinAgentCategory::{Hidden, Mode, SubAgent};
+
+    vec![
+        builtin_agent_spec("agentic", Mode, "auto", SubagentVisibilityPolicy::default()),
+        builtin_agent_spec("Cowork", Mode, "auto", SubagentVisibilityPolicy::default()),
+        builtin_agent_spec("debug", Mode, "auto", SubagentVisibilityPolicy::default()),
+        builtin_agent_spec(
+            "Multitask",
+            Mode,
+            "auto",
+            SubagentVisibilityPolicy::default(),
+        ),
+        builtin_agent_spec("Plan", Mode, "auto", SubagentVisibilityPolicy::default()),
+        builtin_agent_spec("Claw", Mode, "auto", SubagentVisibilityPolicy::default()),
+        builtin_agent_spec(
+            "DeepResearch",
+            Mode,
+            "auto",
+            SubagentVisibilityPolicy::default(),
+        ),
+        builtin_agent_spec("Team", Mode, "auto", SubagentVisibilityPolicy::default()),
+        builtin_agent_spec(
+            "ComputerUse",
+            SubAgent,
+            "auto",
+            SubagentVisibilityPolicy::restricted(["Claw", "Team"]),
+        ),
+        builtin_agent_spec(
+            "Explore",
+            SubAgent,
+            "primary",
+            SubagentVisibilityPolicy::public(),
+        ),
+        builtin_agent_spec(
+            "GeneralPurpose",
+            SubAgent,
+            "fast",
+            SubagentVisibilityPolicy::public(),
+        ),
+        builtin_agent_spec(
+            "ResearchSpecialist",
+            SubAgent,
+            "fast",
+            SubagentVisibilityPolicy::restricted(["DeepResearch"]),
+        ),
+        builtin_agent_spec(
+            "FileFinder",
+            SubAgent,
+            "primary",
+            SubagentVisibilityPolicy::public(),
+        ),
+        builtin_agent_spec(
+            "ReviewBusinessLogic",
+            SubAgent,
+            "fast",
+            SubagentVisibilityPolicy::restricted(["DeepReview"]),
+        ),
+        builtin_agent_spec(
+            "ReviewPerformance",
+            SubAgent,
+            "fast",
+            SubagentVisibilityPolicy::restricted(["DeepReview"]),
+        ),
+        builtin_agent_spec(
+            "ReviewSecurity",
+            SubAgent,
+            "fast",
+            SubagentVisibilityPolicy::restricted(["DeepReview"]),
+        ),
+        builtin_agent_spec(
+            "ReviewArchitecture",
+            SubAgent,
+            "fast",
+            SubagentVisibilityPolicy::restricted(["DeepReview"]),
+        ),
+        builtin_agent_spec(
+            "ReviewFrontend",
+            SubAgent,
+            "fast",
+            SubagentVisibilityPolicy::restricted(["DeepReview"]),
+        ),
+        builtin_agent_spec(
+            "ReviewJudge",
+            SubAgent,
+            "fast",
+            SubagentVisibilityPolicy::restricted(["DeepReview"]),
+        ),
+        builtin_agent_spec(
+            "ReviewFixer",
+            SubAgent,
+            "fast",
+            SubagentVisibilityPolicy::restricted(["DeepReview"]),
+        ),
+        builtin_agent_spec(
+            "CodeReview",
+            Hidden,
+            "primary",
+            SubagentVisibilityPolicy::default(),
+        ),
+        builtin_agent_spec(
+            "DeepReview",
+            Hidden,
+            "fast",
+            SubagentVisibilityPolicy::default(),
+        ),
+        builtin_agent_spec(
+            "GenerateDoc",
+            Hidden,
+            "primary",
+            SubagentVisibilityPolicy::default(),
+        ),
+    ]
+}
+
+pub fn default_model_id_for_builtin_agent(agent_type: &str) -> &'static str {
+    match agent_type {
+        "agentic" | "Cowork" | "ComputerUse" | "Plan" | "debug" | "Claw" | "DeepResearch"
+        | "Team" | "Multitask" => "auto",
+        "Explore" | "FileFinder" | "CodeReview" | "GenerateDoc" => "primary",
+        "GeneralPurpose"
+        | "ResearchSpecialist"
+        | "DeepReview"
+        | "ReviewBusinessLogic"
+        | "ReviewPerformance"
+        | "ReviewSecurity"
+        | "ReviewArchitecture"
+        | "ReviewFrontend"
+        | "ReviewJudge"
+        | "ReviewFixer" => "fast",
+        _ => "fast",
+    }
+}
+
+fn builtin_agent_spec(
+    id: &'static str,
+    category: BuiltinAgentCategory,
+    default_model_id: &'static str,
+    visibility_policy: SubagentVisibilityPolicy,
+) -> BuiltinAgentDefinitionSpec {
+    BuiltinAgentDefinitionSpec {
+        id,
+        category,
+        visibility_policy,
+        default_model_id,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubagentListScope {
     TaskVisible,
     RegistryManagement,

--- a/src/crates/agent-runtime/src/lib.rs
+++ b/src/crates/agent-runtime/src/lib.rs
@@ -12,4 +12,6 @@ pub mod prompt_cache;
 pub mod scheduled_job;
 pub mod scheduler;
 pub mod thread_goal;
+pub mod thread_goal_tools;
 pub mod tool_confirmation;
+pub mod user_questions;

--- a/src/crates/agent-runtime/src/post_call_hooks.rs
+++ b/src/crates/agent-runtime/src/post_call_hooks.rs
@@ -1,6 +1,8 @@
 //! Portable post-call hook routing decisions.
 
 use serde_json::Value;
+use std::collections::HashMap;
+use std::path::Path;
 
 /// Hook categories that concrete runtime integrations may execute after a
 /// successful tool call.
@@ -37,4 +39,89 @@ pub fn run_successful_tool_post_call_hooks<C, E>(
             }
         }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DeepReviewSharedContextToolUseFacts<'a> {
+    pub tool_name: &'a str,
+    pub input: &'a Value,
+    pub custom_data: &'a HashMap<String, Value>,
+    pub workspace_root: Option<&'a Path>,
+    pub is_remote: bool,
+    pub agent_type: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeepReviewSharedContextToolUseRecord {
+    pub parent_turn_id: String,
+    pub subagent_type: String,
+    pub tool_name: String,
+    pub measured_path: String,
+}
+
+pub fn resolve_deep_review_shared_context_tool_use(
+    facts: DeepReviewSharedContextToolUseFacts<'_>,
+) -> Option<DeepReviewSharedContextToolUseRecord> {
+    if !facts.tool_name.eq_ignore_ascii_case("Read")
+        && !facts.tool_name.eq_ignore_ascii_case("GetFileDiff")
+    {
+        return None;
+    }
+    if !custom_data_str(facts.custom_data, "deep_review_subagent_role")
+        .is_some_and(|role| role.eq_ignore_ascii_case("reviewer"))
+    {
+        return None;
+    }
+    let parent_turn_id = custom_data_str(facts.custom_data, "deep_review_parent_dialog_turn_id")?;
+    let file_path = facts
+        .input
+        .get("file_path")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    if is_bitfun_runtime_uri(file_path) {
+        return None;
+    }
+
+    let measured_path = if facts.is_remote {
+        None
+    } else {
+        facts
+            .workspace_root
+            .and_then(|workspace_root| git_relative_path(workspace_root, file_path))
+    }
+    .unwrap_or_else(|| file_path.to_string());
+    let subagent_type = custom_data_str(facts.custom_data, "deep_review_subagent_type")
+        .or(facts.agent_type)
+        .unwrap_or("unknown");
+
+    Some(DeepReviewSharedContextToolUseRecord {
+        parent_turn_id: parent_turn_id.to_string(),
+        subagent_type: subagent_type.to_string(),
+        tool_name: facts.tool_name.to_string(),
+        measured_path,
+    })
+}
+
+fn custom_data_str<'a>(custom_data: &'a HashMap<String, Value>, key: &str) -> Option<&'a str> {
+    custom_data
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn git_relative_path(workspace_root: &Path, path: &str) -> Option<String> {
+    let path = Path::new(path);
+    let relative = if path.is_absolute() {
+        path.strip_prefix(workspace_root).ok()?
+    } else {
+        path.strip_prefix(workspace_root).unwrap_or(path)
+    };
+
+    Some(relative.to_string_lossy().replace('\\', "/"))
+}
+
+fn is_bitfun_runtime_uri(path: &str) -> bool {
+    path.trim().starts_with("bitfun://runtime/")
 }

--- a/src/crates/agent-runtime/src/scheduler.rs
+++ b/src/crates/agent-runtime/src/scheduler.rs
@@ -1,11 +1,12 @@
 //! Scheduler owner decisions.
 
 use crate::events::turn_outcome_kind;
+use crate::thread_goal::{build_objective_updated_plan, build_thread_goal_continuation_plan};
 use bitfun_runtime_ports::{
     should_skip_agent_session_reply, should_suppress_agent_session_cancelled_reply,
     AgentSessionReplyRoute, DialogQueuePriority, DialogRoundInjectionSource,
     DialogRoundPreemptSource, DialogSessionStateFact, DialogSteerOutcome, DialogSubmissionPolicy,
-    DialogTriggerSource, RoundInjection, RoundInjectionKind, RoundInjectionTarget,
+    DialogTriggerSource, RoundInjection, RoundInjectionKind, RoundInjectionTarget, ThreadGoal,
 };
 use std::collections::VecDeque;
 use std::fmt;
@@ -329,6 +330,29 @@ pub enum BackgroundInjectionKind {
     BackgroundResult,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThreadGoalDeliveryReminderKind {
+    GoalContinuation,
+    GoalObjectiveUpdated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadGoalDeliveryReminder {
+    pub kind: ThreadGoalDeliveryReminderKind,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadGoalDeliveryPlan {
+    pub injection_prompt: String,
+    pub injection_display: String,
+    pub display_message: String,
+    pub follow_up_user_input: String,
+    pub follow_up_original_user_input: Option<String>,
+    pub user_message_metadata: serde_json::Value,
+    pub prepended_reminders: Vec<ThreadGoalDeliveryReminder>,
+}
+
 impl BackgroundDeliveryAction {
     pub const fn follow_up_submission_policy(self) -> Option<DialogSubmissionPolicy> {
         match self {
@@ -342,6 +366,60 @@ impl BackgroundDeliveryAction {
                 skip_tool_confirmation,
             )),
         }
+    }
+}
+
+pub fn build_thread_goal_resumed_delivery_plan(goal: &ThreadGoal) -> ThreadGoalDeliveryPlan {
+    let plan = build_thread_goal_continuation_plan(goal);
+    let injection_prompt = plan
+        .prepended_reminders
+        .first()
+        .cloned()
+        .unwrap_or_default();
+    let display_message = plan.display_message;
+    ThreadGoalDeliveryPlan {
+        injection_prompt,
+        injection_display: display_message.clone(),
+        display_message: display_message.clone(),
+        follow_up_user_input: "Resume working toward the active thread goal.".to_string(),
+        follow_up_original_user_input: Some(display_message),
+        user_message_metadata: plan.user_message_metadata,
+        prepended_reminders: plan
+            .prepended_reminders
+            .into_iter()
+            .map(|content| ThreadGoalDeliveryReminder {
+                kind: ThreadGoalDeliveryReminderKind::GoalContinuation,
+                content,
+            })
+            .collect(),
+    }
+}
+
+pub fn build_thread_goal_objective_updated_delivery_plan(
+    goal: &ThreadGoal,
+) -> ThreadGoalDeliveryPlan {
+    let plan = build_objective_updated_plan(goal);
+    let injection_prompt = plan
+        .prepended_reminders
+        .first()
+        .cloned()
+        .unwrap_or_default();
+    let display_message = plan.display_message;
+    ThreadGoalDeliveryPlan {
+        injection_prompt,
+        injection_display: display_message.clone(),
+        display_message: display_message.clone(),
+        follow_up_user_input: "Adjust work to match the updated thread goal.".to_string(),
+        follow_up_original_user_input: Some(display_message),
+        user_message_metadata: plan.user_message_metadata,
+        prepended_reminders: plan
+            .prepended_reminders
+            .into_iter()
+            .map(|content| ThreadGoalDeliveryReminder {
+                kind: ThreadGoalDeliveryReminderKind::GoalObjectiveUpdated,
+                content,
+            })
+            .collect(),
     }
 }
 

--- a/src/crates/agent-runtime/src/thread_goal.rs
+++ b/src/crates/agent-runtime/src/thread_goal.rs
@@ -2,7 +2,8 @@
 
 use bitfun_runtime_ports::{
     validate_thread_goal_objective, SetThreadGoalResult, ThreadGoal, ThreadGoalContinuationPlan,
-    ThreadGoalStatus, ThreadGoalToolResponse, MAX_THREAD_GOAL_AUTO_CONTINUATIONS,
+    ThreadGoalStatus, ThreadGoalToolResponse, GOAL_MODE_METADATA_KEY,
+    MAX_THREAD_GOAL_AUTO_CONTINUATIONS, THREAD_GOAL_METADATA_KEY,
 };
 use std::fmt;
 use std::sync::{Mutex, MutexGuard};
@@ -167,6 +168,27 @@ pub fn billable_tokens_from_counts(
     input_tokens.saturating_sub(cached_tokens) + output_tokens
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ThreadGoalTokenUsageFacts {
+    pub input_tokens: usize,
+    pub output_tokens: Option<usize>,
+    pub cached_tokens: Option<usize>,
+    pub is_subagent: bool,
+}
+
+pub fn should_record_thread_goal_token_usage(facts: ThreadGoalTokenUsageFacts) -> Option<usize> {
+    if facts.is_subagent {
+        return None;
+    }
+
+    let billable = billable_tokens_from_counts(
+        facts.input_tokens,
+        facts.cached_tokens.unwrap_or(0),
+        facts.output_tokens.unwrap_or(0),
+    );
+    (billable > 0).then_some(billable)
+}
+
 pub fn is_usage_limit_message(message: &str) -> bool {
     let message = message.to_ascii_lowercase();
     [
@@ -223,6 +245,76 @@ pub fn goal_tool_response(
         remaining_tokens,
         completion_budget_report,
     }
+}
+
+pub fn thread_goal_patch(goal: &ThreadGoal) -> serde_json::Value {
+    serde_json::json!({
+        THREAD_GOAL_METADATA_KEY: goal,
+    })
+}
+
+pub fn clear_thread_goal_patch() -> serde_json::Value {
+    serde_json::json!({
+        THREAD_GOAL_METADATA_KEY: serde_json::Value::Null,
+    })
+}
+
+pub fn thread_goal_event_payload(goal: Option<ThreadGoal>) -> Option<serde_json::Value> {
+    goal.and_then(|goal| serde_json::to_value(goal).ok())
+}
+
+pub fn thread_goal_from_custom_metadata(
+    custom_metadata: Option<&serde_json::Value>,
+    legacy_goal_id: String,
+    legacy_created_at: i64,
+) -> Option<ThreadGoal> {
+    if let Some(goal) = custom_metadata
+        .and_then(|value| value.get(THREAD_GOAL_METADATA_KEY))
+        .and_then(|value| serde_json::from_value::<ThreadGoal>(value.clone()).ok())
+    {
+        return Some(goal);
+    }
+    migrate_legacy_goal_mode(custom_metadata, legacy_goal_id, legacy_created_at)
+}
+
+fn migrate_legacy_goal_mode(
+    custom_metadata: Option<&serde_json::Value>,
+    legacy_goal_id: String,
+    legacy_created_at: i64,
+) -> Option<ThreadGoal> {
+    let legacy = custom_metadata?.get(GOAL_MODE_METADATA_KEY)?;
+    let active = legacy.get("active")?.as_bool().unwrap_or(false);
+    if !active {
+        return None;
+    }
+    let objective = legacy
+        .get("initialGoal")
+        .and_then(|value| value.get("goalText"))
+        .and_then(|value| value.as_str())
+        .or_else(|| legacy.get("goalText").and_then(|value| value.as_str()))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let session_id = legacy
+        .get("sessionId")
+        .and_then(|value| value.as_str())
+        .unwrap_or("unknown");
+    let created_at = legacy
+        .get("activatedAtMs")
+        .and_then(|value| value.as_u64())
+        .map(|value| value as i64)
+        .unwrap_or(legacy_created_at);
+    Some(ThreadGoal {
+        goal_id: legacy_goal_id,
+        session_id: session_id.to_string(),
+        objective: objective.to_string(),
+        status: ThreadGoalStatus::Active,
+        token_budget: None,
+        tokens_used: 0,
+        time_used_seconds: 0,
+        created_at,
+        updated_at: created_at,
+        auto_continuation_count: 0,
+    })
 }
 
 /// Statuses where the user may explicitly resume auto-continuation toward the goal.

--- a/src/crates/agent-runtime/src/thread_goal_tools.rs
+++ b/src/crates/agent-runtime/src/thread_goal_tools.rs
@@ -1,0 +1,89 @@
+//! Portable contracts for persisted thread-goal tool handlers.
+
+use crate::thread_goal::goal_tool_response;
+use bitfun_runtime_ports::{ThreadGoal, ThreadGoalStatus};
+use serde::Deserialize;
+use serde_json::Value;
+use std::fmt;
+
+pub const GET_GOAL_TOOL_NAME: &str = "get_goal";
+pub const CREATE_GOAL_TOOL_NAME: &str = "create_goal";
+pub const UPDATE_GOAL_TOOL_NAME: &str = "update_goal";
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct CreateGoalArgs {
+    pub objective: String,
+    pub token_budget: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct UpdateGoalArgs {
+    pub status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GoalToolResult {
+    pub data: Value,
+    pub result_for_assistant: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadGoalToolError(String);
+
+impl ThreadGoalToolError {
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl fmt::Display for ThreadGoalToolError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ThreadGoalToolError {}
+
+pub fn parse_create_goal_args(input: Value) -> Result<CreateGoalArgs, ThreadGoalToolError> {
+    serde_json::from_value(input).map_err(|error| {
+        ThreadGoalToolError::validation(format!("invalid create_goal args: {error}"))
+    })
+}
+
+pub fn parse_update_goal_args(input: Value) -> Result<UpdateGoalArgs, ThreadGoalToolError> {
+    serde_json::from_value(input).map_err(|error| {
+        ThreadGoalToolError::validation(format!("invalid update_goal args: {error}"))
+    })
+}
+
+pub fn parse_update_goal_status(raw: &str) -> Result<ThreadGoalStatus, ThreadGoalToolError> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "complete" => Ok(ThreadGoalStatus::Complete),
+        "blocked" => Ok(ThreadGoalStatus::Blocked),
+        other => Err(ThreadGoalToolError::validation(format!(
+            "update_goal status must be complete or blocked, got {other}"
+        ))),
+    }
+}
+
+pub fn build_goal_tool_result(
+    goal: Option<ThreadGoal>,
+    include_completion_report: bool,
+) -> Result<GoalToolResult, ThreadGoalToolError> {
+    let response = goal_tool_response(goal, include_completion_report);
+    let data = serde_json::to_value(response).map_err(|error| {
+        ThreadGoalToolError::validation(format!("failed to serialize goal tool result: {error}"))
+    })?;
+    let result_for_assistant = data
+        .get("goal")
+        .and_then(|goal| goal.get("status"))
+        .and_then(|status| status.as_str())
+        .map(|status| format!("Thread goal status: {status}"))
+        .unwrap_or_else(|| "No thread goal is set.".to_string());
+    Ok(GoalToolResult {
+        data,
+        result_for_assistant,
+    })
+}

--- a/src/crates/agent-runtime/src/user_questions.rs
+++ b/src/crates/agent-runtime/src/user_questions.rs
@@ -1,0 +1,160 @@
+//! Portable contracts for user-question tool handlers.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct QuestionOption {
+    pub label: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Question {
+    pub question: String,
+    pub header: String,
+    pub options: Vec<QuestionOption>,
+    #[serde(rename = "multiSelect")]
+    pub multi_select: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AskUserQuestionInput {
+    pub questions: Vec<Question>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserQuestionToolResult {
+    pub data: Value,
+    pub result_for_assistant: String,
+}
+
+pub fn ask_user_question_available_for_acp_transport(acp_transport: Option<&Value>) -> bool {
+    !acp_transport.is_some_and(|value| value == "true" || value == &json!(true))
+}
+
+pub fn validate_ask_user_question_input(input: &AskUserQuestionInput) -> Result<(), String> {
+    if input.questions.is_empty() {
+        return Err("At least one question is required".to_string());
+    }
+    if input.questions.len() > 4 {
+        return Err("Maximum 4 questions allowed".to_string());
+    }
+
+    for (q_idx, question) in input.questions.iter().enumerate() {
+        let q_num = q_idx + 1;
+
+        if question.question.trim().is_empty() {
+            return Err(format!("Question {} text is required", q_num));
+        }
+
+        if question.header.trim().is_empty() {
+            return Err(format!("Question {} header is required", q_num));
+        }
+        if question.header.chars().count() > 20 {
+            return Err(format!(
+                "Question {} header must be less than 20 characters",
+                q_num
+            ));
+        }
+
+        if question.options.len() < 2 || question.options.len() > 10 {
+            return Err(format!("Question {} must have 2-10 options", q_num));
+        }
+
+        for (opt_idx, opt) in question.options.iter().enumerate() {
+            if opt.label.trim().is_empty() {
+                return Err(format!(
+                    "Question {} option {} label is required",
+                    q_num,
+                    opt_idx + 1
+                ));
+            }
+            if opt.description.trim().is_empty() {
+                return Err(format!(
+                    "Question {} option {} description is required",
+                    q_num,
+                    opt_idx + 1
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn build_answered_user_question_result(
+    input: &AskUserQuestionInput,
+    answers: Value,
+) -> UserQuestionToolResult {
+    let result_for_assistant = format_result_for_assistant(&input.questions, &answers);
+    let questions_summary: Vec<Value> = input
+        .questions
+        .iter()
+        .map(|question| {
+            json!({
+                "question": question.question,
+                "header": question.header
+            })
+        })
+        .collect();
+
+    UserQuestionToolResult {
+        data: json!({
+            "questions": questions_summary,
+            "answers": answers,
+            "status": "answered"
+        }),
+        result_for_assistant,
+    }
+}
+
+pub fn build_cancelled_user_question_result(
+    input: &AskUserQuestionInput,
+) -> UserQuestionToolResult {
+    UserQuestionToolResult {
+        data: json!({
+            "questions_count": input.questions.len(),
+            "status": "cancelled"
+        }),
+        result_for_assistant: "User input request was cancelled.".to_string(),
+    }
+}
+
+fn format_result_for_assistant(questions: &[Question], answers: &Value) -> String {
+    let answers_obj = answers
+        .as_object()
+        .or_else(|| answers.get("answers").and_then(|v| v.as_object()));
+
+    if let Some(answers_map) = answers_obj {
+        let mut result_lines = vec!["User has answered your questions:".to_string()];
+
+        for (idx, question) in questions.iter().enumerate() {
+            let idx_str = idx.to_string();
+            let answer_text = if let Some(answer_value) = answers_map.get(&idx_str) {
+                if let Some(arr) = answer_value.as_array() {
+                    arr.iter()
+                        .filter_map(|v| v.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                } else if let Some(s) = answer_value.as_str() {
+                    s.to_string()
+                } else {
+                    "N/A".to_string()
+                }
+            } else {
+                "N/A".to_string()
+            };
+
+            result_lines.push(format!(
+                "- {} ({}): \"{}\"",
+                question.question, question.header, answer_text
+            ));
+        }
+
+        result_lines.push("\nYou can now continue with the user's answers in mind.".to_string());
+        result_lines.join("\n")
+    } else {
+        "User has answered your questions (no valid answers received).".to_string()
+    }
+}

--- a/src/crates/agent-runtime/tests/agent_registry_contracts.rs
+++ b/src/crates/agent-runtime/tests/agent_registry_contracts.rs
@@ -1,10 +1,11 @@
 use bitfun_agent_runtime::agents::{
-    mode_config_profile_label, mode_config_profile_member_mode_ids, mode_presentation_rank,
-    resolve_mode_config_profile_id, resolve_subagent_availability,
-    resolve_subagent_default_enabled, shared_coding_mode_user_context_policy, subagent_source_kind,
-    subagent_source_presentation_rank, BuiltinSubagentExposure, SubAgentSource,
-    SubagentOverrideLayers, SubagentOverrideState, SubagentSourceKind, SubagentStateReason,
-    SubagentVisibilityPolicy, SHARED_CODING_MODE_CONFIG_PROFILE_ID,
+    builtin_agent_definition_specs, default_model_id_for_builtin_agent, mode_config_profile_label,
+    mode_config_profile_member_mode_ids, mode_presentation_rank, resolve_mode_config_profile_id,
+    resolve_subagent_availability, resolve_subagent_default_enabled,
+    shared_coding_mode_user_context_policy, subagent_source_kind,
+    subagent_source_presentation_rank, BuiltinAgentCategory, BuiltinSubagentExposure,
+    SubAgentSource, SubagentOverrideLayers, SubagentOverrideState, SubagentSourceKind,
+    SubagentStateReason, SubagentVisibilityPolicy, SHARED_CODING_MODE_CONFIG_PROFILE_ID,
     SHARED_CODING_MODE_CONFIG_PROFILE_LABEL, SHARED_CODING_MODE_IDS,
 };
 
@@ -163,4 +164,77 @@ fn mode_presentation_and_shared_context_policy_match_existing_mode_contract() {
         shared_coding_mode_user_context_policy().cache_scope_key(),
         "workspace_context|workspace_instructions|workspace_memory_files|project_layout"
     );
+}
+
+#[test]
+fn builtin_agent_definition_catalog_preserves_order_categories_models_and_visibility() {
+    let specs = builtin_agent_definition_specs();
+    let ids: Vec<_> = specs.iter().map(|spec| spec.id).collect();
+    assert_eq!(
+        ids,
+        vec![
+            "agentic",
+            "Cowork",
+            "debug",
+            "Multitask",
+            "Plan",
+            "Claw",
+            "DeepResearch",
+            "Team",
+            "ComputerUse",
+            "Explore",
+            "GeneralPurpose",
+            "ResearchSpecialist",
+            "FileFinder",
+            "ReviewBusinessLogic",
+            "ReviewPerformance",
+            "ReviewSecurity",
+            "ReviewArchitecture",
+            "ReviewFrontend",
+            "ReviewJudge",
+            "ReviewFixer",
+            "CodeReview",
+            "DeepReview",
+            "GenerateDoc",
+        ]
+    );
+
+    assert_eq!(specs[0].category, BuiltinAgentCategory::Mode);
+    assert_eq!(specs[8].category, BuiltinAgentCategory::SubAgent);
+    assert_eq!(specs[20].category, BuiltinAgentCategory::Hidden);
+    assert_eq!(default_model_id_for_builtin_agent("agentic"), "auto");
+    assert_eq!(default_model_id_for_builtin_agent("Explore"), "primary");
+    assert_eq!(default_model_id_for_builtin_agent("GeneralPurpose"), "fast");
+    assert_eq!(
+        default_model_id_for_builtin_agent("ResearchSpecialist"),
+        "fast"
+    );
+    assert_eq!(
+        default_model_id_for_builtin_agent("ReviewArchitecture"),
+        "fast"
+    );
+
+    let computer_use = specs
+        .iter()
+        .find(|spec| spec.id == "ComputerUse")
+        .expect("ComputerUse spec should exist");
+    assert_eq!(
+        computer_use.visibility_policy.summary().exposure,
+        BuiltinSubagentExposure::Restricted
+    );
+    assert!(computer_use
+        .visibility_policy
+        .can_access_from_parent(Some("Claw")));
+    assert!(computer_use
+        .visibility_policy
+        .can_access_from_parent(Some("Team")));
+    assert!(!computer_use
+        .visibility_policy
+        .can_access_from_parent(Some("agentic")));
+
+    let research_specialist = specs
+        .iter()
+        .find(|spec| spec.id == "ResearchSpecialist")
+        .expect("ResearchSpecialist spec should exist");
+    assert_eq!(research_specialist.default_model_id, "fast");
 }

--- a/src/crates/agent-runtime/tests/post_call_hook_execution_contracts.rs
+++ b/src/crates/agent-runtime/tests/post_call_hook_execution_contracts.rs
@@ -1,7 +1,10 @@
 use bitfun_agent_runtime::post_call_hooks::{
-    run_successful_tool_post_call_hooks, SuccessfulToolPostCallHookExecutor,
+    resolve_deep_review_shared_context_tool_use, run_successful_tool_post_call_hooks,
+    DeepReviewSharedContextToolUseFacts, SuccessfulToolPostCallHookExecutor,
 };
 use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::path::Path;
 
 #[derive(Default)]
 struct RecordingExecutor {
@@ -37,5 +40,85 @@ fn successful_tool_post_call_executor_runs_deep_review_measurement_route() {
             json!({ "file_path": "src/lib.rs" }),
             "review-context".to_string()
         )]
+    );
+}
+
+fn reviewer_custom_data() -> HashMap<String, Value> {
+    HashMap::from([
+        (
+            "deep_review_subagent_role".to_string(),
+            Value::String("reviewer".to_string()),
+        ),
+        (
+            "deep_review_parent_dialog_turn_id".to_string(),
+            Value::String("turn-parent".to_string()),
+        ),
+        (
+            "deep_review_subagent_type".to_string(),
+            Value::String("ReviewSecurity".to_string()),
+        ),
+    ])
+}
+
+#[test]
+fn deep_review_measurement_decision_normalizes_local_paths_and_filters_non_reviewers() {
+    let custom_data = reviewer_custom_data();
+    let record = resolve_deep_review_shared_context_tool_use(DeepReviewSharedContextToolUseFacts {
+        tool_name: "Read",
+        input: &json!({ "file_path": "C:/repo/src/lib.rs" }),
+        custom_data: &custom_data,
+        workspace_root: Some(Path::new("C:/repo")),
+        is_remote: false,
+        agent_type: Some("fallback"),
+    })
+    .expect("reviewer Read should record");
+
+    assert_eq!(record.parent_turn_id, "turn-parent");
+    assert_eq!(record.subagent_type, "ReviewSecurity");
+    assert_eq!(record.tool_name, "Read");
+    assert_eq!(record.measured_path, "src/lib.rs");
+
+    let mut non_reviewer = custom_data.clone();
+    non_reviewer.insert(
+        "deep_review_subagent_role".to_string(),
+        Value::String("planner".to_string()),
+    );
+    assert!(
+        resolve_deep_review_shared_context_tool_use(DeepReviewSharedContextToolUseFacts {
+            tool_name: "Read",
+            input: &json!({ "file_path": "C:/repo/src/lib.rs" }),
+            custom_data: &non_reviewer,
+            workspace_root: Some(Path::new("C:/repo")),
+            is_remote: false,
+            agent_type: Some("fallback"),
+        },)
+        .is_none()
+    );
+}
+
+#[test]
+fn deep_review_measurement_decision_preserves_remote_paths_and_ignores_runtime_uri() {
+    let custom_data = reviewer_custom_data();
+    let remote = resolve_deep_review_shared_context_tool_use(DeepReviewSharedContextToolUseFacts {
+        tool_name: "GetFileDiff",
+        input: &json!({ "file_path": "/workspace/src/lib.rs" }),
+        custom_data: &custom_data,
+        workspace_root: Some(Path::new("/workspace")),
+        is_remote: true,
+        agent_type: Some("fallback"),
+    })
+    .expect("remote path should record without local relativization");
+    assert_eq!(remote.measured_path, "/workspace/src/lib.rs");
+
+    assert!(
+        resolve_deep_review_shared_context_tool_use(DeepReviewSharedContextToolUseFacts {
+            tool_name: "Read",
+            input: &json!({ "file_path": "bitfun://runtime/session/output.txt" }),
+            custom_data: &custom_data,
+            workspace_root: Some(Path::new("/workspace")),
+            is_remote: false,
+            agent_type: Some("fallback"),
+        },)
+        .is_none()
     );
 }

--- a/src/crates/agent-runtime/tests/scheduler_contracts.rs
+++ b/src/crates/agent-runtime/tests/scheduler_contracts.rs
@@ -1,17 +1,18 @@
 use bitfun_agent_runtime::scheduler::{
+    build_thread_goal_objective_updated_delivery_plan, build_thread_goal_resumed_delivery_plan,
     resolve_agent_session_reply_action, resolve_background_delivery_action,
     resolve_background_delivery_injection, resolve_dialog_steering_action, ActiveDialogTurn,
     ActiveDialogTurnStore, AgentSessionReplyAction, BackgroundDeliveryAction,
     BackgroundDeliveryFacts, BackgroundInjectionKind, DialogReplySuppressionSet,
     DialogRoundInjectionInterrupt, DialogSteeringAction, DialogTurnQueue, DialogTurnQueueError,
     NoopDialogRoundPreemptSource, SessionAbortFlags, SessionRoundInjectionBuffer,
-    SessionRoundYieldFlags, TurnOutcome, TurnOutcomeQueueAction, TurnOutcomeStatus,
-    DEFAULT_MAX_DIALOG_QUEUE_DEPTH,
+    SessionRoundYieldFlags, ThreadGoalDeliveryReminderKind, TurnOutcome, TurnOutcomeQueueAction,
+    TurnOutcomeStatus, DEFAULT_MAX_DIALOG_QUEUE_DEPTH,
 };
 use bitfun_runtime_ports::{
     AgentSessionReplyRoute, DialogQueuePriority, DialogRoundPreemptSource, DialogSessionStateFact,
     DialogSteerOutcome, DialogSubmissionPolicy, DialogTriggerSource, RoundInjection,
-    RoundInjectionKind, RoundInjectionTarget,
+    RoundInjectionKind, RoundInjectionTarget, ThreadGoal, ThreadGoalStatus,
 };
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -109,6 +110,72 @@ fn background_delivery_injection_builds_background_result_with_display_fallback(
     assert_eq!(injection.content, "result content");
     assert_eq!(injection.display_content, "result content");
     assert_eq!(injection.created_at, created_at);
+}
+
+fn thread_goal() -> ThreadGoal {
+    ThreadGoal {
+        goal_id: "goal-1".to_string(),
+        session_id: "session-1".to_string(),
+        objective: "finish PR-C".to_string(),
+        status: ThreadGoalStatus::Active,
+        token_budget: None,
+        tokens_used: 0,
+        time_used_seconds: 0,
+        created_at: 1,
+        updated_at: 2,
+        auto_continuation_count: 2,
+    }
+}
+
+#[test]
+fn thread_goal_resumed_delivery_plan_preserves_follow_up_and_metadata() {
+    let plan = build_thread_goal_resumed_delivery_plan(&thread_goal());
+
+    assert_eq!(
+        plan.follow_up_user_input,
+        "Resume working toward the active thread goal."
+    );
+    assert_eq!(
+        plan.follow_up_original_user_input,
+        Some(plan.display_message.clone())
+    );
+    assert!(plan
+        .injection_prompt
+        .contains("Continue working toward the active thread goal."));
+    assert_eq!(plan.injection_display, plan.display_message);
+    assert_eq!(
+        plan.prepended_reminders[0].kind,
+        ThreadGoalDeliveryReminderKind::GoalContinuation
+    );
+    assert_eq!(plan.user_message_metadata["threadGoalContinuation"], true);
+    assert_eq!(plan.user_message_metadata["autoContinuationAttempt"], 2);
+}
+
+#[test]
+fn thread_goal_objective_updated_delivery_plan_preserves_follow_up_and_metadata() {
+    let plan = build_thread_goal_objective_updated_delivery_plan(&thread_goal());
+
+    assert_eq!(
+        plan.follow_up_user_input,
+        "Adjust work to match the updated thread goal."
+    );
+    assert_eq!(plan.injection_display, "Thread goal updated: finish PR-C");
+    assert_eq!(
+        plan.follow_up_original_user_input,
+        Some(plan.injection_display.clone())
+    );
+    assert!(plan
+        .injection_prompt
+        .contains("The active thread goal objective was edited by the user."));
+    assert_eq!(
+        plan.prepended_reminders[0].kind,
+        ThreadGoalDeliveryReminderKind::GoalObjectiveUpdated
+    );
+    assert_eq!(
+        plan.user_message_metadata["threadGoalObjectiveUpdated"],
+        true
+    );
+    assert_eq!(plan.user_message_metadata["goalId"], "goal-1");
 }
 
 #[test]

--- a/src/crates/agent-runtime/tests/thread_goal_contracts.rs
+++ b/src/crates/agent-runtime/tests/thread_goal_contracts.rs
@@ -1,12 +1,15 @@
 use bitfun_agent_runtime::thread_goal::{
     billable_tokens_from_counts, build_objective_updated_plan, build_set_thread_goal_result,
-    build_thread_goal_continuation_plan, goal_continuation_submit_retry_delay_ms,
-    goal_tool_response, is_usage_limit_message, should_skip_goal_continuation_after_turn,
-    should_skip_goal_for_turn, thread_goal_status_is_resumable, SetThreadGoalRequest,
-    ThreadGoalContinuationFacts, ThreadGoalRuntime,
+    build_thread_goal_continuation_plan, clear_thread_goal_patch,
+    goal_continuation_submit_retry_delay_ms, goal_tool_response, is_usage_limit_message,
+    should_record_thread_goal_token_usage, should_skip_goal_continuation_after_turn,
+    should_skip_goal_for_turn, thread_goal_event_payload, thread_goal_from_custom_metadata,
+    thread_goal_patch, thread_goal_status_is_resumable, SetThreadGoalRequest,
+    ThreadGoalContinuationFacts, ThreadGoalRuntime, ThreadGoalTokenUsageFacts,
 };
 use bitfun_runtime_ports::{
     ThreadGoal, ThreadGoalStatus, MAX_GOAL_CONTINUATIONS, MAX_THREAD_GOAL_AUTO_CONTINUATIONS,
+    THREAD_GOAL_METADATA_KEY,
 };
 
 fn goal(status: ThreadGoalStatus) -> ThreadGoal {
@@ -251,6 +254,77 @@ fn prompt_and_tool_response_contracts_match_thread_goal_wire_shape() {
 
     let plan = build_thread_goal_continuation_plan(&goal(ThreadGoalStatus::Active));
     assert_eq!(plan.user_message_metadata["autoContinuationMax"], 100);
+}
+
+#[test]
+fn thread_goal_metadata_patch_and_legacy_goal_mode_migration_keep_wire_shape() {
+    let active = goal(ThreadGoalStatus::Active);
+    let patch = thread_goal_patch(&active);
+    assert_eq!(patch[THREAD_GOAL_METADATA_KEY]["goalId"], "g1");
+    assert_eq!(patch[THREAD_GOAL_METADATA_KEY]["status"], "active");
+    assert_eq!(
+        clear_thread_goal_patch()[THREAD_GOAL_METADATA_KEY],
+        serde_json::Value::Null
+    );
+
+    let restored = thread_goal_from_custom_metadata(Some(&patch), "legacy-id".to_string(), 99)
+        .expect("thread_goal metadata should restore");
+    assert_eq!(restored, active);
+
+    let legacy = serde_json::json!({
+        "goal_mode": {
+            "active": true,
+            "sessionId": "session-legacy",
+            "goalText": "  migrate metadata  ",
+            "activatedAtMs": 1234
+        }
+    });
+    let migrated = thread_goal_from_custom_metadata(Some(&legacy), "legacy-id".to_string(), 99)
+        .expect("legacy goal mode should migrate");
+    assert_eq!(migrated.goal_id, "legacy-id");
+    assert_eq!(migrated.session_id, "session-legacy");
+    assert_eq!(migrated.objective, "migrate metadata");
+    assert_eq!(migrated.status, ThreadGoalStatus::Active);
+    assert_eq!(migrated.created_at, 1234);
+    assert_eq!(migrated.updated_at, 1234);
+}
+
+#[test]
+fn thread_goal_event_payload_and_token_usage_filter_preserve_core_delivery_contract() {
+    let active = goal(ThreadGoalStatus::Active);
+    let payload = thread_goal_event_payload(Some(active.clone()))
+        .expect("active goal should serialize for event");
+    assert_eq!(payload["goalId"], active.goal_id);
+    assert_eq!(payload["status"], "active");
+    assert_eq!(thread_goal_event_payload(None), None);
+
+    assert_eq!(
+        should_record_thread_goal_token_usage(ThreadGoalTokenUsageFacts {
+            input_tokens: 100,
+            output_tokens: Some(30),
+            cached_tokens: Some(40),
+            is_subagent: false,
+        }),
+        Some(90)
+    );
+    assert_eq!(
+        should_record_thread_goal_token_usage(ThreadGoalTokenUsageFacts {
+            input_tokens: 100,
+            output_tokens: Some(30),
+            cached_tokens: Some(40),
+            is_subagent: true,
+        }),
+        None
+    );
+    assert_eq!(
+        should_record_thread_goal_token_usage(ThreadGoalTokenUsageFacts {
+            input_tokens: 0,
+            output_tokens: None,
+            cached_tokens: None,
+            is_subagent: false,
+        }),
+        None
+    );
 }
 
 #[test]

--- a/src/crates/agent-runtime/tests/thread_goal_tool_handler_contracts.rs
+++ b/src/crates/agent-runtime/tests/thread_goal_tool_handler_contracts.rs
@@ -1,0 +1,77 @@
+use bitfun_agent_runtime::thread_goal_tools::{
+    build_goal_tool_result, parse_create_goal_args, parse_update_goal_status,
+};
+use bitfun_runtime_ports::{ThreadGoal, ThreadGoalStatus};
+
+fn goal(status: ThreadGoalStatus) -> ThreadGoal {
+    ThreadGoal {
+        goal_id: "goal-1".to_string(),
+        session_id: "session-1".to_string(),
+        objective: "finish migration".to_string(),
+        status,
+        token_budget: Some(100),
+        tokens_used: 80,
+        time_used_seconds: 3,
+        created_at: 1,
+        updated_at: 2,
+        auto_continuation_count: 0,
+    }
+}
+
+#[test]
+fn update_goal_status_parser_preserves_legacy_values_and_errors() {
+    assert_eq!(
+        parse_update_goal_status(" complete ").expect("complete should parse"),
+        ThreadGoalStatus::Complete
+    );
+    assert_eq!(
+        parse_update_goal_status("BLOCKED").expect("blocked should parse"),
+        ThreadGoalStatus::Blocked
+    );
+
+    assert_eq!(
+        parse_update_goal_status("paused")
+            .expect_err("unsupported status should fail")
+            .to_string(),
+        "update_goal status must be complete or blocked, got paused"
+    );
+}
+
+#[test]
+fn create_goal_args_parser_preserves_snake_case_wire_contract() {
+    let args = parse_create_goal_args(serde_json::json!({
+        "objective": "ship PR-C",
+        "token_budget": 4096
+    }))
+    .expect("valid create_goal args should parse");
+
+    assert_eq!(args.objective, "ship PR-C");
+    assert_eq!(args.token_budget, Some(4096));
+
+    assert!(
+        parse_create_goal_args(serde_json::json!({ "token_budget": 4096 }))
+            .expect_err("missing objective should fail")
+            .to_string()
+            .starts_with("invalid create_goal args: missing field `objective`")
+    );
+}
+
+#[test]
+fn goal_tool_result_preserves_empty_and_complete_wire_shape() {
+    let empty = build_goal_tool_result(None, false).expect("empty goal should serialize");
+    assert_eq!(empty.data, serde_json::json!({}));
+    assert_eq!(empty.result_for_assistant, "No thread goal is set.");
+
+    let complete =
+        build_goal_tool_result(Some(goal(ThreadGoalStatus::Complete)), true).expect("serializes");
+    assert_eq!(complete.data["goal"]["status"], "complete");
+    assert_eq!(complete.data["remainingTokens"], 20);
+    assert!(complete.data["completionBudgetReport"]
+        .as_str()
+        .expect("completion report should be string")
+        .contains("Goal achieved"));
+    assert_eq!(
+        complete.result_for_assistant,
+        "Thread goal status: complete"
+    );
+}

--- a/src/crates/agent-runtime/tests/user_question_tool_contracts.rs
+++ b/src/crates/agent-runtime/tests/user_question_tool_contracts.rs
@@ -1,0 +1,100 @@
+use bitfun_agent_runtime::user_questions::{
+    ask_user_question_available_for_acp_transport, build_answered_user_question_result,
+    build_cancelled_user_question_result, validate_ask_user_question_input, AskUserQuestionInput,
+    Question, QuestionOption,
+};
+
+fn question() -> Question {
+    Question {
+        question: "Which path should be used?".to_string(),
+        header: "Path".to_string(),
+        options: vec![
+            QuestionOption {
+                label: "A".to_string(),
+                description: "Use A".to_string(),
+            },
+            QuestionOption {
+                label: "B".to_string(),
+                description: "Use B".to_string(),
+            },
+        ],
+        multi_select: false,
+    }
+}
+
+#[test]
+fn ask_user_question_validation_preserves_legacy_limits() {
+    assert_eq!(
+        validate_ask_user_question_input(&AskUserQuestionInput { questions: vec![] })
+            .expect_err("empty questions should fail"),
+        "At least one question is required"
+    );
+
+    let mut too_many = vec![question(), question(), question(), question(), question()];
+    assert_eq!(
+        validate_ask_user_question_input(&AskUserQuestionInput {
+            questions: std::mem::take(&mut too_many),
+        })
+        .expect_err("too many questions should fail"),
+        "Maximum 4 questions allowed"
+    );
+
+    let mut missing_header = question();
+    missing_header.header.clear();
+    assert_eq!(
+        validate_ask_user_question_input(&AskUserQuestionInput {
+            questions: vec![missing_header],
+        })
+        .expect_err("missing header should fail"),
+        "Question 1 header is required"
+    );
+}
+
+#[test]
+fn ask_user_question_available_flag_matches_acp_transport_contract() {
+    assert!(!ask_user_question_available_for_acp_transport(Some(
+        &serde_json::json!(true)
+    )));
+    assert!(!ask_user_question_available_for_acp_transport(Some(
+        &serde_json::json!("true")
+    )));
+    assert!(ask_user_question_available_for_acp_transport(Some(
+        &serde_json::json!(false)
+    )));
+    assert!(ask_user_question_available_for_acp_transport(None));
+}
+
+#[test]
+fn ask_user_question_answered_and_cancelled_results_keep_wire_shape() {
+    let input = AskUserQuestionInput {
+        questions: vec![question()],
+    };
+    let answered = build_answered_user_question_result(
+        &input,
+        serde_json::json!({
+            "0": "A"
+        }),
+    );
+
+    assert_eq!(answered.data["status"], "answered");
+    assert_eq!(
+        answered.data["questions"][0]["question"],
+        input.questions[0].question
+    );
+    assert_eq!(
+        answered.data["questions"][0]["header"],
+        input.questions[0].header
+    );
+    assert_eq!(answered.data["answers"]["0"], "A");
+    assert!(answered
+        .result_for_assistant
+        .contains("- Which path should be used? (Path): \"A\""));
+
+    let cancelled = build_cancelled_user_question_result(&input);
+    assert_eq!(cancelled.data["status"], "cancelled");
+    assert_eq!(cancelled.data["questions_count"], 1);
+    assert_eq!(
+        cancelled.result_for_assistant,
+        "User input request was cancelled."
+    );
+}

--- a/src/crates/core/src/agentic/agents/registry/builtin.rs
+++ b/src/crates/core/src/agentic/agents/registry/builtin.rs
@@ -3,26 +3,13 @@ use super::visibility::SubagentVisibilityPolicy;
 use super::AgentRegistry;
 use crate::agentic::agents::registry::catalog::builtin_agent_specs;
 use crate::agentic::agents::{Agent, AgentCategory, SubAgentSource};
+use bitfun_agent_runtime::agents as runtime_agents;
 use log::error;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 pub(crate) fn default_model_id_for_builtin_agent(agent_type: &str) -> &'static str {
-    match agent_type {
-        "agentic" | "Cowork" | "ComputerUse" | "Plan" | "debug" | "Claw" | "DeepResearch"
-        | "Team" | "Multitask" => "auto",
-        "DeepReview"
-        | "ReviewBusinessLogic"
-        | "ReviewPerformance"
-        | "ReviewSecurity"
-        | "ReviewArchitecture"
-        | "ReviewFrontend"
-        | "ReviewJudge"
-        | "ReviewFixer" => "fast",
-        "Explore" | "FileFinder" | "CodeReview" | "GenerateDoc" => "primary",
-        "GeneralPurpose" => "fast",
-        _ => "fast",
-    }
+    runtime_agents::default_model_id_for_builtin_agent(agent_type)
 }
 
 impl AgentRegistry {

--- a/src/crates/core/src/agentic/agents/registry/catalog.rs
+++ b/src/crates/core/src/agentic/agents/registry/catalog.rs
@@ -7,6 +7,7 @@ use crate::agentic::agents::{
     MultitaskMode, PerformanceReviewerAgent, PlanMode, ResearchSpecialistAgent, ReviewFixerAgent,
     ReviewJudgeAgent, SecurityReviewerAgent, TeamMode,
 };
+use bitfun_agent_runtime::agents as runtime_agents;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -17,121 +18,49 @@ pub struct BuiltinAgentSpec {
 }
 
 pub fn builtin_agent_specs() -> Vec<BuiltinAgentSpec> {
-    vec![
-        BuiltinAgentSpec {
-            factory: || Arc::new(AgenticMode::new()),
-            category: AgentCategory::Mode,
-            visibility_policy: SubagentVisibilityPolicy::default(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(CoworkMode::new()),
-            category: AgentCategory::Mode,
-            visibility_policy: SubagentVisibilityPolicy::default(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(DebugMode::new()),
-            category: AgentCategory::Mode,
-            visibility_policy: SubagentVisibilityPolicy::default(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(MultitaskMode::new()),
-            category: AgentCategory::Mode,
-            visibility_policy: SubagentVisibilityPolicy::default(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(PlanMode::new()),
-            category: AgentCategory::Mode,
-            visibility_policy: SubagentVisibilityPolicy::default(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(ClawMode::new()),
-            category: AgentCategory::Mode,
-            visibility_policy: SubagentVisibilityPolicy::default(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(DeepResearchMode::new()),
-            category: AgentCategory::Mode,
-            visibility_policy: SubagentVisibilityPolicy::default(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(TeamMode::new()),
-            category: AgentCategory::Mode,
-            visibility_policy: SubagentVisibilityPolicy::default(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(ComputerUseMode::new()),
-            category: AgentCategory::SubAgent,
-            visibility_policy: SubagentVisibilityPolicy::restricted(["Claw", "Team"]),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(ExploreAgent::new()),
-            category: AgentCategory::SubAgent,
-            visibility_policy: SubagentVisibilityPolicy::public(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(GeneralPurposeAgent::new()),
-            category: AgentCategory::SubAgent,
-            visibility_policy: SubagentVisibilityPolicy::public(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(ResearchSpecialistAgent::new()),
-            category: AgentCategory::SubAgent,
-            visibility_policy: SubagentVisibilityPolicy::restricted(["DeepResearch"]),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(FileFinderAgent::new()),
-            category: AgentCategory::SubAgent,
-            visibility_policy: SubagentVisibilityPolicy::public(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(BusinessLogicReviewerAgent::new()),
-            category: AgentCategory::SubAgent,
-            visibility_policy: SubagentVisibilityPolicy::restricted(["DeepReview"]),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(PerformanceReviewerAgent::new()),
-            category: AgentCategory::SubAgent,
-            visibility_policy: SubagentVisibilityPolicy::restricted(["DeepReview"]),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(SecurityReviewerAgent::new()),
-            category: AgentCategory::SubAgent,
-            visibility_policy: SubagentVisibilityPolicy::restricted(["DeepReview"]),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(ArchitectureReviewerAgent::new()),
-            category: AgentCategory::SubAgent,
-            visibility_policy: SubagentVisibilityPolicy::restricted(["DeepReview"]),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(FrontendReviewerAgent::new()),
-            category: AgentCategory::SubAgent,
-            visibility_policy: SubagentVisibilityPolicy::restricted(["DeepReview"]),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(ReviewJudgeAgent::new()),
-            category: AgentCategory::SubAgent,
-            visibility_policy: SubagentVisibilityPolicy::restricted(["DeepReview"]),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(ReviewFixerAgent::new()),
-            category: AgentCategory::SubAgent,
-            visibility_policy: SubagentVisibilityPolicy::restricted(["DeepReview"]),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(CodeReviewAgent::new()),
-            category: AgentCategory::Hidden,
-            visibility_policy: SubagentVisibilityPolicy::default(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(DeepReviewAgent::new()),
-            category: AgentCategory::Hidden,
-            visibility_policy: SubagentVisibilityPolicy::default(),
-        },
-        BuiltinAgentSpec {
-            factory: || Arc::new(GenerateDocAgent::new()),
-            category: AgentCategory::Hidden,
-            visibility_policy: SubagentVisibilityPolicy::default(),
-        },
-    ]
+    runtime_agents::builtin_agent_definition_specs()
+        .into_iter()
+        .map(|spec| BuiltinAgentSpec {
+            factory: builtin_agent_factory(spec.id),
+            category: map_builtin_agent_category(spec.category),
+            visibility_policy: spec.visibility_policy,
+        })
+        .collect()
+}
+
+fn map_builtin_agent_category(category: runtime_agents::BuiltinAgentCategory) -> AgentCategory {
+    match category {
+        runtime_agents::BuiltinAgentCategory::Mode => AgentCategory::Mode,
+        runtime_agents::BuiltinAgentCategory::SubAgent => AgentCategory::SubAgent,
+        runtime_agents::BuiltinAgentCategory::Hidden => AgentCategory::Hidden,
+    }
+}
+
+fn builtin_agent_factory(id: &str) -> fn() -> Arc<dyn Agent> {
+    match id {
+        "agentic" => || Arc::new(AgenticMode::new()),
+        "Cowork" => || Arc::new(CoworkMode::new()),
+        "debug" => || Arc::new(DebugMode::new()),
+        "Multitask" => || Arc::new(MultitaskMode::new()),
+        "Plan" => || Arc::new(PlanMode::new()),
+        "Claw" => || Arc::new(ClawMode::new()),
+        "DeepResearch" => || Arc::new(DeepResearchMode::new()),
+        "Team" => || Arc::new(TeamMode::new()),
+        "ComputerUse" => || Arc::new(ComputerUseMode::new()),
+        "Explore" => || Arc::new(ExploreAgent::new()),
+        "GeneralPurpose" => || Arc::new(GeneralPurposeAgent::new()),
+        "ResearchSpecialist" => || Arc::new(ResearchSpecialistAgent::new()),
+        "FileFinder" => || Arc::new(FileFinderAgent::new()),
+        "ReviewBusinessLogic" => || Arc::new(BusinessLogicReviewerAgent::new()),
+        "ReviewPerformance" => || Arc::new(PerformanceReviewerAgent::new()),
+        "ReviewSecurity" => || Arc::new(SecurityReviewerAgent::new()),
+        "ReviewArchitecture" => || Arc::new(ArchitectureReviewerAgent::new()),
+        "ReviewFrontend" => || Arc::new(FrontendReviewerAgent::new()),
+        "ReviewJudge" => || Arc::new(ReviewJudgeAgent::new()),
+        "ReviewFixer" => || Arc::new(ReviewFixerAgent::new()),
+        "CodeReview" => || Arc::new(CodeReviewAgent::new()),
+        "DeepReview" => || Arc::new(DeepReviewAgent::new()),
+        "GenerateDoc" => || Arc::new(GenerateDocAgent::new()),
+        _ => panic!("missing legacy Agent factory for builtin agent {id}"),
+    }
 }

--- a/src/crates/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/core/src/agentic/coordination/coordinator.rs
@@ -2400,7 +2400,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
     }
 
     pub async fn emit_thread_goal_updated(&self, session_id: &str, goal: Option<ThreadGoal>) {
-        let goal = goal.and_then(|goal| serde_json::to_value(goal).ok());
+        let goal = bitfun_agent_runtime::thread_goal::thread_goal_event_payload(goal);
         self.emit_event(AgenticEvent::ThreadGoalUpdated {
             session_id: session_id.to_string(),
             goal,

--- a/src/crates/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/core/src/agentic/coordination/scheduler.rs
@@ -14,9 +14,8 @@ use super::coordinator::{ConversationCoordinator, DialogTriggerSource};
 use super::turn_outcome::{TurnOutcome, TurnOutcomeQueueAction, TurnOutcomeStatus};
 use crate::agentic::core::{InternalReminderKind, Message, SessionState};
 use crate::agentic::goal_mode::{
-    build_objective_updated_plan, build_thread_goal_continuation_plan,
     goal_continuation_submit_retry_delay_ms, goal_internal_context_message,
-    goal_objective_updated_message, objective_updated_prompt,
+    goal_objective_updated_message,
 };
 use crate::agentic::image_analysis::ImageContextData;
 use crate::agentic::init_agents_md::build_init_agents_md_user_input;
@@ -36,11 +35,13 @@ use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use bitfun_agent_runtime::scheduler::{
+    build_thread_goal_objective_updated_delivery_plan, build_thread_goal_resumed_delivery_plan,
     resolve_agent_session_reply_action, resolve_background_delivery_action,
     resolve_background_delivery_injection, resolve_dialog_steering_action, ActiveDialogTurn,
     ActiveDialogTurnStore, AgentSessionReplyAction, AgentSessionReplyPlan,
     BackgroundDeliveryAction, BackgroundDeliveryFacts, BackgroundInjectionKind,
     DialogReplySuppressionSet, DialogSteeringAction, DialogTurnQueue, SessionAbortFlags,
+    ThreadGoalDeliveryReminder, ThreadGoalDeliveryReminderKind,
 };
 use bitfun_runtime_ports::{
     resolve_dialog_submit_queue_action, DialogSessionStateFact, DialogSubmitQueueAction,
@@ -208,7 +209,7 @@ impl DialogScheduler {
         workspace_path: Option<String>,
         goal: ThreadGoal,
     ) -> Result<(), String> {
-        let plan = build_thread_goal_continuation_plan(&goal);
+        let plan = build_thread_goal_resumed_delivery_plan(&goal);
         let state = self
             .session_manager
             .get_session(&session_id)
@@ -218,18 +219,13 @@ impl DialogScheduler {
             session_state: Self::session_state_fact(state.as_ref()),
         }) {
             BackgroundDeliveryAction::InjectIntoRunningTurn => {
-                let prompt = plan
-                    .prepended_reminders
-                    .into_iter()
-                    .next()
-                    .unwrap_or_default();
                 self.round_injection_buffer.push(
                     &session_id,
                     resolve_background_delivery_injection(
                         BackgroundInjectionKind::ThreadGoalObjectiveUpdated,
                         Uuid::new_v4().to_string(),
-                        prompt,
-                        Some(plan.display_message.clone()),
+                        plan.injection_prompt,
+                        Some(plan.injection_display),
                         SystemTime::now(),
                     ),
                 );
@@ -239,15 +235,11 @@ impl DialogScheduler {
                 queue_priority,
                 skip_tool_confirmation,
             } => {
-                let prepended: Vec<Message> = plan
-                    .prepended_reminders
-                    .into_iter()
-                    .map(goal_internal_context_message)
-                    .collect();
+                let prepended = thread_goal_delivery_messages(plan.prepended_reminders);
                 self.submit_with_prepended_messages(
                     session_id,
-                    "Resume working toward the active thread goal.".to_string(),
-                    Some(plan.display_message),
+                    plan.follow_up_user_input,
+                    plan.follow_up_original_user_input,
                     None,
                     agent_type,
                     workspace_path,
@@ -275,8 +267,7 @@ impl DialogScheduler {
         workspace_path: Option<String>,
         goal: ThreadGoal,
     ) -> Result<(), String> {
-        let prompt = objective_updated_prompt(&goal);
-        let display = format!("Thread goal updated: {}", goal.objective.trim());
+        let plan = build_thread_goal_objective_updated_delivery_plan(&goal);
         let state = self
             .session_manager
             .get_session(&session_id)
@@ -291,8 +282,8 @@ impl DialogScheduler {
                     resolve_background_delivery_injection(
                         BackgroundInjectionKind::ThreadGoalObjectiveUpdated,
                         Uuid::new_v4().to_string(),
-                        prompt,
-                        Some(display),
+                        plan.injection_prompt,
+                        Some(plan.injection_display),
                         SystemTime::now(),
                     ),
                 );
@@ -302,16 +293,11 @@ impl DialogScheduler {
                 queue_priority,
                 skip_tool_confirmation,
             } => {
-                let plan = build_objective_updated_plan(&goal);
-                let prepended = plan
-                    .prepended_reminders
-                    .into_iter()
-                    .map(goal_objective_updated_message)
-                    .collect();
+                let prepended = thread_goal_delivery_messages(plan.prepended_reminders);
                 self.submit_with_prepended_messages(
                     session_id,
-                    "Adjust work to match the updated thread goal.".to_string(),
-                    Some(display),
+                    plan.follow_up_user_input,
+                    plan.follow_up_original_user_input,
                     None,
                     agent_type,
                     workspace_path,
@@ -1076,6 +1062,20 @@ impl DialogScheduler {
             }
         }
     }
+}
+
+fn thread_goal_delivery_messages(reminders: Vec<ThreadGoalDeliveryReminder>) -> Vec<Message> {
+    reminders
+        .into_iter()
+        .map(|reminder| match reminder.kind {
+            ThreadGoalDeliveryReminderKind::GoalContinuation => {
+                goal_internal_context_message(reminder.content)
+            }
+            ThreadGoalDeliveryReminderKind::GoalObjectiveUpdated => {
+                goal_objective_updated_message(reminder.content)
+            }
+        })
+        .collect()
 }
 
 // ── Global instance ──────────────────────────────────────────────────────────

--- a/src/crates/core/src/agentic/deep_review/tool_measurement.rs
+++ b/src/crates/core/src/agentic/deep_review/tool_measurement.rs
@@ -6,74 +6,33 @@
 
 use crate::agentic::deep_review_policy::record_deep_review_shared_context_tool_use;
 use crate::agentic::tools::framework::ToolUseContext;
-use crate::agentic::tools::workspace_paths::is_bitfun_runtime_uri;
+use bitfun_agent_runtime::post_call_hooks::{
+    resolve_deep_review_shared_context_tool_use, DeepReviewSharedContextToolUseFacts,
+};
 use serde_json::Value;
-use std::path::Path;
-
-fn git_relative_path(workspace_root: &Path, path: &str) -> Option<String> {
-    if is_bitfun_runtime_uri(path) {
-        return None;
-    }
-
-    let path = Path::new(path);
-    let relative = if path.is_absolute() {
-        path.strip_prefix(workspace_root).ok()?
-    } else {
-        path
-    };
-
-    Some(relative.to_string_lossy().replace('\\', "/"))
-}
-
-fn custom_data_str<'a>(context: &'a ToolUseContext, key: &str) -> Option<&'a str> {
-    context
-        .custom_data
-        .get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-}
 
 pub(crate) fn maybe_record_shared_context_tool_use(
     tool_name: &str,
     input: &Value,
     context: &ToolUseContext,
 ) {
-    if !tool_name.eq_ignore_ascii_case("Read") && !tool_name.eq_ignore_ascii_case("GetFileDiff") {
-        return;
-    }
-    if !custom_data_str(context, "deep_review_subagent_role")
-        .is_some_and(|role| role.eq_ignore_ascii_case("reviewer"))
-    {
-        return;
-    }
-    let Some(parent_turn_id) = custom_data_str(context, "deep_review_parent_dialog_turn_id") else {
-        return;
-    };
-    let Some(file_path) = input
-        .get("file_path")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
+    let Some(record) =
+        resolve_deep_review_shared_context_tool_use(DeepReviewSharedContextToolUseFacts {
+            tool_name,
+            input,
+            custom_data: &context.custom_data,
+            workspace_root: context.workspace_root(),
+            is_remote: context.is_remote(),
+            agent_type: context.agent_type.as_deref(),
+        })
     else {
         return;
     };
-    let measured_path = if context.is_remote() {
-        None
-    } else {
-        context
-            .workspace_root()
-            .and_then(|workspace_root| git_relative_path(workspace_root, file_path))
-    }
-    .unwrap_or_else(|| file_path.to_string());
-    let subagent_type = custom_data_str(context, "deep_review_subagent_type")
-        .or(context.agent_type.as_deref())
-        .unwrap_or("unknown");
 
     record_deep_review_shared_context_tool_use(
-        parent_turn_id,
-        subagent_type,
-        tool_name,
-        &measured_path,
+        &record.parent_turn_id,
+        &record.subagent_type,
+        &record.tool_name,
+        &record.measured_path,
     );
 }

--- a/src/crates/core/src/agentic/goal_mode/mod.rs
+++ b/src/crates/core/src/agentic/goal_mode/mod.rs
@@ -13,11 +13,12 @@ use crate::agentic::session::SessionManager;
 use crate::util::errors::{BitFunError, BitFunResult};
 pub use bitfun_agent_runtime::thread_goal::{
     billable_tokens_from_counts, build_objective_updated_plan, build_thread_goal_continuation_plan,
-    completion_budget_report, continuation_prompt, effective_subagent_timeout_seconds,
-    goal_continuation_submit_retry_delay_ms, goal_tool_response, objective_updated_prompt,
-    should_skip_goal_continuation_after_turn, should_skip_goal_for_turn,
-    thread_goal_status_is_resumable, ThreadGoalContinuationFacts, ThreadGoalRuntime,
-    GOAL_CONTINUATION_SUBMIT_RETRY_BASE_DELAY_MS, GOAL_CONTINUATION_SUBMIT_RETRY_MAX_DELAY_MS,
+    clear_thread_goal_patch, completion_budget_report, continuation_prompt,
+    effective_subagent_timeout_seconds, goal_continuation_submit_retry_delay_ms,
+    goal_tool_response, objective_updated_prompt, should_skip_goal_continuation_after_turn,
+    should_skip_goal_for_turn, thread_goal_patch, thread_goal_status_is_resumable,
+    ThreadGoalContinuationFacts, ThreadGoalRuntime, GOAL_CONTINUATION_SUBMIT_RETRY_BASE_DELAY_MS,
+    GOAL_CONTINUATION_SUBMIT_RETRY_MAX_DELAY_MS,
 };
 use bitfun_agent_runtime::thread_goal::{
     build_set_thread_goal_result, is_usage_limit_message, SetThreadGoalRequest,
@@ -47,64 +48,14 @@ pub fn now_epoch_seconds() -> i64 {
         .unwrap_or(0)
 }
 
-pub fn thread_goal_patch(goal: &ThreadGoal) -> serde_json::Value {
-    serde_json::json!({
-        THREAD_GOAL_METADATA_KEY: goal,
-    })
-}
-
-pub fn clear_thread_goal_patch() -> serde_json::Value {
-    serde_json::json!({
-        THREAD_GOAL_METADATA_KEY: serde_json::Value::Null,
-    })
-}
-
 pub fn thread_goal_from_custom_metadata(
     custom_metadata: Option<&serde_json::Value>,
 ) -> Option<ThreadGoal> {
-    if let Some(goal) = custom_metadata
-        .and_then(|value| value.get(THREAD_GOAL_METADATA_KEY))
-        .and_then(|value| serde_json::from_value::<ThreadGoal>(value.clone()).ok())
-    {
-        return Some(goal);
-    }
-    migrate_legacy_goal_mode(custom_metadata)
-}
-
-fn migrate_legacy_goal_mode(custom_metadata: Option<&serde_json::Value>) -> Option<ThreadGoal> {
-    let legacy = custom_metadata?.get(GOAL_MODE_METADATA_KEY)?;
-    let active = legacy.get("active")?.as_bool().unwrap_or(false);
-    if !active {
-        return None;
-    }
-    let objective = legacy
-        .get("initialGoal")
-        .and_then(|value| value.get("goalText"))
-        .and_then(|value| value.as_str())
-        .or_else(|| legacy.get("goalText").and_then(|value| value.as_str()))
-        .map(str::trim)
-        .filter(|value| !value.is_empty())?;
-    let session_id = legacy
-        .get("sessionId")
-        .and_then(|value| value.as_str())
-        .unwrap_or("unknown");
-    let created_at = legacy
-        .get("activatedAtMs")
-        .and_then(|value| value.as_u64())
-        .map(|value| value as i64)
-        .unwrap_or_else(now_epoch_seconds);
-    Some(ThreadGoal {
-        goal_id: Uuid::new_v4().to_string(),
-        session_id: session_id.to_string(),
-        objective: objective.to_string(),
-        status: ThreadGoalStatus::Active,
-        token_budget: None,
-        tokens_used: 0,
-        time_used_seconds: 0,
-        created_at,
-        updated_at: created_at,
-        auto_continuation_count: 0,
-    })
+    bitfun_agent_runtime::thread_goal::thread_goal_from_custom_metadata(
+        custom_metadata,
+        Uuid::new_v4().to_string(),
+        now_epoch_seconds(),
+    )
 }
 
 pub fn is_usage_limit_error(error: &BitFunError) -> bool {

--- a/src/crates/core/src/agentic/goal_mode/token_subscriber.rs
+++ b/src/crates/core/src/agentic/goal_mode/token_subscriber.rs
@@ -2,8 +2,10 @@
 
 use crate::agentic::coordination::get_global_coordinator;
 use crate::agentic::events::{AgenticEvent, EventSubscriber};
-use crate::agentic::goal_mode::billable_tokens_from_counts;
 use crate::util::errors::BitFunResult;
+use bitfun_agent_runtime::thread_goal::{
+    should_record_thread_goal_token_usage, ThreadGoalTokenUsageFacts,
+};
 use log::debug;
 
 pub struct ThreadGoalTokenSubscriber;
@@ -24,16 +26,14 @@ impl EventSubscriber for ThreadGoalTokenSubscriber {
             return Ok(());
         };
 
-        if *is_subagent {
+        let Some(billable) = should_record_thread_goal_token_usage(ThreadGoalTokenUsageFacts {
+            input_tokens: *input_tokens,
+            output_tokens: *output_tokens,
+            cached_tokens: *cached_tokens,
+            is_subagent: *is_subagent,
+        }) else {
             return Ok(());
-        }
-
-        let output_tokens = output_tokens.unwrap_or(0);
-        let cached_tokens = cached_tokens.unwrap_or(0);
-        let billable = billable_tokens_from_counts(*input_tokens, cached_tokens, output_tokens);
-        if billable == 0 {
-            return Ok(());
-        }
+        };
 
         let Some(coordinator) = get_global_coordinator() else {
             return Ok(());

--- a/src/crates/core/src/agentic/tools/implementations/ask_user_question_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/ask_user_question_tool.rs
@@ -3,8 +3,11 @@
 //! Allows AI to ask questions to users during execution and wait for answers
 
 use async_trait::async_trait;
+use bitfun_agent_runtime::user_questions::{
+    ask_user_question_available_for_acp_transport, build_answered_user_question_result,
+    build_cancelled_user_question_result, validate_ask_user_question_input, AskUserQuestionInput,
+};
 use log::{debug, warn};
-use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
@@ -12,29 +15,6 @@ use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
 use crate::agentic::tools::user_input_manager::get_user_input_manager;
 use crate::infrastructure::events::event_system::{get_global_event_system, BackendEvent};
 use crate::util::errors::BitFunResult;
-
-/// Question option
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct QuestionOption {
-    pub label: String,
-    pub description: String,
-}
-
-/// Question definition
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Question {
-    pub question: String,
-    pub header: String,
-    pub options: Vec<QuestionOption>,
-    #[serde(rename = "multiSelect")]
-    pub multi_select: bool,
-}
-
-/// Tool input parameters - supports multiple questions
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AskUserQuestionInput {
-    pub questions: Vec<Question>,
-}
 
 /// AskUserQuestion tool
 pub struct AskUserQuestionTool;
@@ -50,110 +30,10 @@ impl AskUserQuestionTool {
         Self
     }
 
-    fn is_acp_context(context: Option<&ToolUseContext>) -> bool {
-        context
-            .and_then(|ctx| ctx.custom_data.get("acp_transport"))
-            .is_some_and(|value| value == "true" || value == &json!(true))
-    }
-
-    /// Validate question format (supports multiple questions)
-    fn validate_input(input: &AskUserQuestionInput) -> Result<(), String> {
-        // Validate question count
-        if input.questions.is_empty() {
-            return Err("At least one question is required".to_string());
-        }
-        if input.questions.len() > 4 {
-            return Err("Maximum 4 questions allowed".to_string());
-        }
-
-        // Validate each question
-        for (q_idx, question) in input.questions.iter().enumerate() {
-            let q_num = q_idx + 1;
-
-            // Validate question text
-            if question.question.trim().is_empty() {
-                return Err(format!("Question {} text is required", q_num));
-            }
-
-            // Validate header
-            if question.header.trim().is_empty() {
-                return Err(format!("Question {} header is required", q_num));
-            }
-            if question.header.chars().count() > 20 {
-                return Err(format!(
-                    "Question {} header must be less than 20 characters",
-                    q_num
-                ));
-            }
-
-            // Validate options
-            if question.options.len() < 2 || question.options.len() > 10 {
-                return Err(format!("Question {} must have 2-10 options", q_num));
-            }
-
-            for (opt_idx, opt) in question.options.iter().enumerate() {
-                if opt.label.trim().is_empty() {
-                    return Err(format!(
-                        "Question {} option {} label is required",
-                        q_num,
-                        opt_idx + 1
-                    ));
-                }
-                if opt.description.trim().is_empty() {
-                    return Err(format!(
-                        "Question {} option {} description is required",
-                        q_num,
-                        opt_idx + 1
-                    ));
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Format result for AI (supports multiple questions)
-    fn format_result_for_assistant(questions: &[Question], answers: &Value) -> String {
-        // Try flat structure first (frontend sends {"0": "...", "1": [...]}),
-        // then fall back to nested {"answers": {...}} for backward compatibility
-        let answers_obj = answers
-            .as_object()
-            .or_else(|| answers.get("answers").and_then(|v| v.as_object()));
-
-        if let Some(answers_map) = answers_obj {
-            let mut result_lines = vec!["User has answered your questions:".to_string()];
-
-            for (idx, question) in questions.iter().enumerate() {
-                let idx_str = idx.to_string();
-                let answer_text = if let Some(answer_value) = answers_map.get(&idx_str) {
-                    if let Some(arr) = answer_value.as_array() {
-                        // Multi-select: join answers
-                        arr.iter()
-                            .filter_map(|v| v.as_str())
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    } else if let Some(s) = answer_value.as_str() {
-                        // Single-select
-                        s.to_string()
-                    } else {
-                        "N/A".to_string()
-                    }
-                } else {
-                    "N/A".to_string()
-                };
-
-                result_lines.push(format!(
-                    "- {} ({}): \"{}\"",
-                    question.question, question.header, answer_text
-                ));
-            }
-
-            result_lines
-                .push("\nYou can now continue with the user's answers in mind.".to_string());
-            result_lines.join("\n")
-        } else {
-            "User has answered your questions (no valid answers received).".to_string()
-        }
+    fn is_available_for_tool_context(context: Option<&ToolUseContext>) -> bool {
+        ask_user_question_available_for_acp_transport(
+            context.and_then(|ctx| ctx.custom_data.get("acp_transport")),
+        )
     }
 
     /// Generate tool ID
@@ -287,7 +167,7 @@ Usage notes:
     }
 
     async fn is_available_in_context(&self, context: Option<&ToolUseContext>) -> bool {
-        !Self::is_acp_context(context)
+        Self::is_available_for_tool_context(context)
     }
 
     async fn call_impl(
@@ -305,7 +185,7 @@ Usage notes:
             })?;
 
         // 2. Validate question format
-        if let Err(error) = Self::validate_input(&tool_input) {
+        if let Err(error) = validate_ask_user_question_input(&tool_input) {
             return Err(crate::util::errors::BitFunError::Validation(error));
         }
 
@@ -352,39 +232,20 @@ Usage notes:
                     "AskUserQuestion tool received user response, tool_id: {}",
                     tool_id
                 );
-                let result_text =
-                    Self::format_result_for_assistant(&tool_input.questions, &response.answers);
-
-                // Build question summary for return data
-                let questions_summary: Vec<Value> = tool_input
-                    .questions
-                    .iter()
-                    .map(|q| {
-                        json!({
-                            "question": q.question,
-                            "header": q.header
-                        })
-                    })
-                    .collect();
+                let result = build_answered_user_question_result(&tool_input, response.answers);
 
                 Ok(vec![ToolResult::Result {
-                    data: json!({
-                        "questions": questions_summary,
-                        "answers": response.answers,
-                        "status": "answered"
-                    }),
-                    result_for_assistant: Some(result_text),
+                    data: result.data,
+                    result_for_assistant: Some(result.result_for_assistant),
                     image_attachments: None,
                 }])
             }
             Err(_) => {
                 warn!("AskUserQuestion tool channel closed, tool_id: {}", tool_id);
+                let result = build_cancelled_user_question_result(&tool_input);
                 Ok(vec![ToolResult::Result {
-                    data: json!({
-                        "questions_count": tool_input.questions.len(),
-                        "status": "cancelled"
-                    }),
-                    result_for_assistant: Some("User input request was cancelled.".to_string()),
+                    data: result.data,
+                    result_for_assistant: Some(result.result_for_assistant),
                     image_attachments: None,
                 }])
             }

--- a/src/crates/core/src/agentic/tools/implementations/thread_goal_tools.rs
+++ b/src/crates/core/src/agentic/tools/implementations/thread_goal_tools.rs
@@ -1,32 +1,16 @@
 //! Built-in model tool handlers for persisted session thread goals.
 
 use crate::agentic::coordination::get_global_coordinator;
-use crate::agentic::goal_mode::{
-    completion_budget_report, goal_tool_response, user_facing_thread_goal_error,
-};
+use crate::agentic::goal_mode::user_facing_thread_goal_error;
 use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
+use bitfun_agent_runtime::thread_goal_tools::{
+    build_goal_tool_result, parse_create_goal_args, parse_update_goal_args,
+    parse_update_goal_status, CREATE_GOAL_TOOL_NAME, GET_GOAL_TOOL_NAME, UPDATE_GOAL_TOOL_NAME,
+};
 use bitfun_runtime_ports::ThreadGoalStatus;
-use serde::Deserialize;
 use serde_json::{json, Value};
-
-pub const GET_GOAL_TOOL_NAME: &str = "get_goal";
-pub const CREATE_GOAL_TOOL_NAME: &str = "create_goal";
-pub const UPDATE_GOAL_TOOL_NAME: &str = "update_goal";
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "snake_case")]
-struct CreateGoalArgs {
-    objective: String,
-    token_budget: Option<i64>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "snake_case")]
-struct UpdateGoalArgs {
-    status: String,
-}
 
 fn require_coordinator(
 ) -> BitFunResult<std::sync::Arc<crate::agentic::coordination::ConversationCoordinator>> {
@@ -44,33 +28,6 @@ fn require_session_context(context: &ToolUseContext) -> BitFunResult<(String, st
         .ok_or_else(|| BitFunError::Validation("workspace_path is unavailable".to_string()))?
         .to_path_buf();
     Ok((session_id, workspace_path))
-}
-
-fn parse_update_goal_status(raw: &str) -> BitFunResult<ThreadGoalStatus> {
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "complete" => Ok(ThreadGoalStatus::Complete),
-        "blocked" => Ok(ThreadGoalStatus::Blocked),
-        other => Err(BitFunError::Validation(format!(
-            "update_goal status must be complete or blocked, got {other}"
-        ))),
-    }
-}
-
-fn serialize_goal_response(
-    goal: Option<bitfun_runtime_ports::ThreadGoal>,
-    include_completion_report: bool,
-) -> BitFunResult<(Value, String)> {
-    let response = goal_tool_response(goal, include_completion_report);
-    let payload = serde_json::to_value(response).map_err(|error| {
-        BitFunError::Validation(format!("failed to serialize goal tool result: {error}"))
-    })?;
-    let summary = payload
-        .get("goal")
-        .and_then(|goal| goal.get("status"))
-        .and_then(|status| status.as_str())
-        .map(|status| format!("Thread goal status: {status}"))
-        .unwrap_or_else(|| "No thread goal is set.".to_string());
-    Ok((payload, summary))
 }
 
 pub struct GetGoalTool;
@@ -124,10 +81,11 @@ impl Tool for GetGoalTool {
             .get_thread_goal(&session_id, workspace_path.as_path())
             .await
             .map_err(user_facing_thread_goal_error)?;
-        let (data, summary) = serialize_goal_response(goal, false)?;
+        let result = build_goal_tool_result(goal, false)
+            .map_err(|error| BitFunError::Validation(error.to_string()))?;
         Ok(vec![ToolResult::Result {
-            data,
-            result_for_assistant: Some(summary),
+            data: result.data,
+            result_for_assistant: Some(result.result_for_assistant),
             image_attachments: None,
         }])
     }
@@ -187,9 +145,8 @@ Set token_budget only when an explicit token budget is requested. Fails if a goa
         input: &Value,
         context: &ToolUseContext,
     ) -> BitFunResult<Vec<ToolResult>> {
-        let parsed: CreateGoalArgs = serde_json::from_value(input.clone()).map_err(|error| {
-            BitFunError::Validation(format!("invalid create_goal args: {error}"))
-        })?;
+        let parsed = parse_create_goal_args(input.clone())
+            .map_err(|error| BitFunError::Validation(error.to_string()))?;
         let coordinator = require_coordinator()?;
         let (session_id, workspace_path) = require_session_context(context)?;
         let goal = coordinator
@@ -201,10 +158,11 @@ Set token_budget only when an explicit token budget is requested. Fails if a goa
             )
             .await
             .map_err(user_facing_thread_goal_error)?;
-        let (data, summary) = serialize_goal_response(Some(goal), false)?;
+        let result = build_goal_tool_result(Some(goal), false)
+            .map_err(|error| BitFunError::Validation(error.to_string()))?;
         Ok(vec![ToolResult::Result {
-            data,
-            result_for_assistant: Some(summary),
+            data: result.data,
+            result_for_assistant: Some(result.result_for_assistant),
             image_attachments: None,
         }])
     }
@@ -264,10 +222,10 @@ You cannot use this tool to pause, resume, budget-limit, or usage-limit a goal."
         input: &Value,
         context: &ToolUseContext,
     ) -> BitFunResult<Vec<ToolResult>> {
-        let parsed: UpdateGoalArgs = serde_json::from_value(input.clone()).map_err(|error| {
-            BitFunError::Validation(format!("invalid update_goal args: {error}"))
-        })?;
-        let status = parse_update_goal_status(&parsed.status)?;
+        let parsed = parse_update_goal_args(input.clone())
+            .map_err(|error| BitFunError::Validation(error.to_string()))?;
+        let status = parse_update_goal_status(&parsed.status)
+            .map_err(|error| BitFunError::Validation(error.to_string()))?;
         let coordinator = require_coordinator()?;
         let (session_id, workspace_path) = require_session_context(context)?;
         let goal = coordinator
@@ -280,11 +238,11 @@ You cannot use this tool to pause, resume, budget-limit, or usage-limit a goal."
             .await
             .map_err(user_facing_thread_goal_error)?;
         let include_report = status == ThreadGoalStatus::Complete;
-        let _ = completion_budget_report(&goal);
-        let (data, summary) = serialize_goal_response(Some(goal), include_report)?;
+        let result = build_goal_tool_result(Some(goal), include_report)
+            .map_err(|error| BitFunError::Validation(error.to_string()))?;
         Ok(vec![ToolResult::Result {
-            data,
-            result_for_assistant: Some(summary),
+            data: result.data,
+            result_for_assistant: Some(result.result_for_assistant),
             image_attachments: None,
         }])
     }


### PR DESCRIPTION
﻿## Summary

- Move PR-C Agent Runtime delivery contracts into `bitfun-agent-runtime`: builtin agent catalog/default model/visibility facts, thread-goal tool contracts, thread-goal metadata/event/token/scheduler delivery plans, AskUserQuestion validation/results, and DeepReview shared-context measurement decisions.
- Reduce `bitfun-core` to compatibility adapters for coordinator/session context, metadata IO, event emission, channel waits, diagnostics writes, and product tool side effects.
- Update focused contract coverage, the core boundary script, and decomposition plan/completed docs so the remaining active queue is limited to PR-D.

## Risk and behavior boundary

- No intended product behavior, feature exposure, tool wire shape, permission, scheduler lifecycle, or default agent model changes.
- Concrete scheduler lifecycle, session metadata/persistence IO, event emitter wiring, permission UI/channel waits, product `Tool` execution, and DeepReview diagnostics storage remain in core compatibility/product assembly paths.
- PR-D remains the separate closure for Product Runtime / Runtime Services / Tool / Terminal / Search / Remote / MiniApp / function-agent concrete owners.

## Verification

- `cargo test -p bitfun-agent-runtime`
- `cargo test -p bitfun-core agentic::agents::registry -- --nocapture`
- `cargo test -p bitfun-core ask_user_question -- --nocapture`
- `cargo test -p bitfun-core goal_mode -- --nocapture`
- `cargo test -p bitfun-core coordination::scheduler -- --nocapture`
- `cargo test -p bitfun-core deep_review -- --nocapture`
- `pnpm run check:repo-hygiene`
- `cargo check --workspace`
- `node scripts/check-core-boundaries.mjs`
- `git diff --check`
