### PR TITLE
refactor(runtime): close product assembly service boundary

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -1,273 +1,91 @@
 # BitFun Core 拆解已完成内容归档
 
-本文只记录已完成事实和明确未完成边界。活跃执行计划见
-[`core-decomposition-plan.md`](core-decomposition-plan.md)。
+本文只记录已完成事实摘要，不作为后续执行计划。后续执行口径以
+[`core-decomposition-plan.md`](core-decomposition-plan.md) 为准；稳定架构目标以
+[`core-decomposition.md`](../architecture/core-decomposition.md) 和
+[`agent-runtime-services-design.md`](../architecture/agent-runtime-services-design.md) 为准。
 
-各阶段的“明确未完成”描述保留的是当时阶段的边界，不等同于新的活跃队列。当前仍需执行的迁移只以
-第 3 节和 `core-decomposition-plan.md` 的最终 PR-C / PR-D 为准。
+## 1. 已完成主线摘要
 
-## 1. 已完成主线
+### 1.1 基础边界与 owner crate 基线
 
-### 1.1 P0 / P1：安全边界与最小编译面验证
+- 已建立 `product-full` 作为完整产品能力保护开关，产品入口显式启用完整能力。
+- 已将原 nested `terminal-core`、`tool-runtime` 移到 workspace 顶层，保持旧 package / lib 语义。
+- 已抽出 `bitfun-core-types`、`bitfun-agent-stream`、`bitfun-runtime-ports` 等基础契约与轻量 owner。
+- 已建立 `bitfun-services-core`、`bitfun-services-integrations`、`bitfun-agent-tools`、`bitfun-tool-packs`、
+  `bitfun-product-domains`、`bitfun-runtime-services`、`bitfun-agent-runtime`、`bitfun-harness`、
+  `bitfun-product-capabilities` 等 owner crate 基线。
+- `bitfun-core` 已通过 facade / re-export 保持旧路径兼容，并逐步形成 `product_runtime`、
+  `product_domain_runtime`、`service_agent_runtime` 等迁移期组装入口。
 
-- 已建立 `product-full` 默认能力保护，产品 crate 显式启用完整能力。
-- 已把既有 nested `terminal-core` 和 `tool-runtime` 移到 workspace 顶层，保持旧 package / lib 语义。
-- 已抽出 `bitfun-core-types` 第一批纯类型、错误分类和轻量 helper。
-- 已抽出 `bitfun-agent-stream`，让 stream processor 和相关测试可绕开完整 `bitfun-core`。
-- 已引入 `bitfun-runtime-ports` 初始边界和旧路径 compatibility wrapper。
-- 已补 `AgentSubmissionRequest.source` / `turnId` 显式化，以及 dynamic tool provider metadata 基线。
+### 1.2 稳定契约与 Runtime Services 基线
 
-明确未完成：
+- `runtime-ports` 已承接 workspace、session store、remote workspace/projection、tool runtime handles、
+  thread goal DTO、scheduled-job state 等稳定接口或事实。
+- `runtime-services` 已建立 typed service bundle、builder、capability availability、provider 注册和 fake provider
+  测试基础。
+- remote workspace facts、remote session metadata、remote file projection DTO、remote workspace/projection host
+  trait 已归入稳定接口层，并保留旧路径 re-export。
+- session restore 的 storage path resolution、turn-load request、restore timing facts 已进入 Runtime Services /
+  Runtime Ports 边界；core 仍保留具体 persistence IO。
+- `bitfun-core::product_assembly::CoreRuntimeServicesProvider` 已把现有 core session store path resolution、
+  remote workspace/projection adapter，以及当前完整产品能力需要的 terminal / Git / Network / MCP catalog
+  capability marker 注册到 `RuntimeServicesBuilder` 组合中；该边界只表达当前能力可用性，不改变具体执行逻辑。
 
-- `BitFunError` / `BitFunResult` 仍继续 core-owned。
-- remote-connect / cron / MCP concrete call-site、generic attachment / image context 接入、产品逻辑或边界行为变更不属于 P1 完成范围。
+### 1.3 Tool Runtime 与 Product Capability 基线
 
-### 1.2 P2：中等粒度 owner crate 成型
+- `agent-tools` 已承接 provider-neutral tool DTO、manifest/catalog 策略、execution admission gate、
+  collapsed unlock gate、static provider materialization 和 plan-to-registry assembly。
+- `tool-runtime` 已承接本地 Write / Edit / Delete / Glob 的低风险 concrete IO primitive；core 保留 agent-facing
+  `Tool` adapter、权限、checkpoint、file-read freshness、remote fallback 和具体 tool context。
+- GetToolSpec concrete adapter、manifest resolver、visible tools、readonly catalog、snapshot wrapper、collapsed unlock
+  message-derived state 已收敛到 product/tool runtime owner 边界。
+- `tool-packs` 已承接 tool provider group plan、按 id 选择和 unknown provider group 校验。
+- `product-capabilities` 已承接 capability id、required service capability、tool provider group selection 和
+  harness provider selection 等 assembly facts。
+- Product Assembly 已承接 `DeliveryProfile`、`CapabilitySet`、完整 product-full provider plan 和 service availability
+  report；core tool runtime 与 harness registry 已改为消费显式 Product Assembly plan，并保持旧 facade 输出等价。
 
-- `bitfun-services-core`、`bitfun-services-integrations`、`bitfun-agent-tools`、`bitfun-tool-packs`、`bitfun-product-domains` 已加入 workspace。
-- `bitfun-core` 通过 facade / re-export 保持旧路径兼容。
-- 已迁移 Git feature group、remote-SSH identity / path helper、MCP runtime / dynamic provider、remote-connect wire / tracker / file / image / dialog helper。
-- 已迁移 generic tool registry / provider / catalog / `GetToolSpec` helper 和 product provider plan。
-- 已迁移 MiniApp / function-agent 的纯 domain helper、port / facade 和部分决策逻辑。
-- 已补 `core-types`、`runtime-ports`、`agent-tools`、`product-domains`、`services-integrations` 的 boundary check 和 feature graph 保护。
+### 1.4 Agent Runtime 与 Harness 契约基线
 
-明确未完成：
+- `agent-runtime` 已承接 scheduler/background delivery 的纯决策、thread goal runtime 的 accounting / mutation /
+  continuation plan、subagent visibility / availability、prompt cache facts、mode/source presentation facts、
+  scheduled-job lifecycle state、custom subagent schema/default/markdown IO/discovery/loading、post-call hook routing、
+  tool confirmation plan、goal/user-question tool wire contract、builtin agent catalog 和部分 event fact 映射。
+- core 仍保留 concrete session manager、metadata/persistence IO、scheduler lifecycle、event emitter、
+  permission UI/channel wait、concrete prompt assembly、product `Tool` adapter 和具体 hook side effect。
+- `harness` 已建立 workflow descriptor、legacy route plan、provider registry，并注册 Deep Review、DeepResearch、
+  MiniApp 的 legacy-facade provider。
+- Harness 当前只证明 route/descriptor 边界，不代表 concrete workflow execution 已迁移。
 
-- remote-SSH runtime、remote FS / terminal、workspace-root source、persistence / workspace service reads、`ImageContextData` concrete impl 仍未迁移。
-- concrete tools 仍未迁移。
-- MiniApp filesystem IO / worker / host dispatch / builtin marker IO / seed 写盘、function-agent AI provider acquisition 仍未迁移；function-agent Git concrete service 已在后续阶段外移。
-- agent definition loading / concrete scheduler lifecycle 仍未迁移。
+### 1.5 Product Domain 与 function-agent / MiniApp 边界
 
-### 1.3 H1-H5 基线收口
+- `product-domains` 已承接 MiniApp 的纯状态、runtime detection policy、worker capacity / idle / LRU policy、
+  host method / fs access / shell token / env 等纯决策，以及 function-agent prompt / parser / response policy / ports。
+- 内置 MiniApp bundle identity、版本和 embedded source assets 已归入 `product-domains`。
+- function-agent Git concrete snapshot、no-HEAD diff fallback、非 Git workspace fallback、ahead/behind/last-commit
+  fallback 和 project context lookup 已迁入 `services-integrations::function_agents`。
+- function-agent AI provider acquisition、AI transport error mapping、MiniApp worker process、host dispatch、
+  PathManager integration、marker IO 和 seed 写盘仍留在 core concrete path。
 
-- Tool runtime 已完成 provider-neutral contract、file guidance marker、file-read freshness facts、tool-result storage policy / preview / rendered replacement contract 和 execution presentation policy。
-- Product-domain 已完成 MiniApp 纯状态 owner、runtime detection policy、worker capacity / idle / LRU policy、host method / fs access / shell token / env 等纯决策，以及 function-agent prompt / response policy。
-- Service / agent 已完成 remote-connect presentation assembly、remote model policy、remote command orchestration、dialog scheduler outcome assembly、scheduler queue routing / cancel suppression 等 portable contract closure。
-- Core 内部已形成 `product_runtime.rs`、`product_domain_runtime.rs`、`service_agent_runtime.rs` 等 owner closure 入口，便于后续审查。
-- H5 当前只完成 feature / dependency baseline：`bitfun-core --no-default-features` 可编译面、`product-full` 显式 owner feature 聚合、optional dependency owner 映射和产品入口显式装配检查。
+## 2. 已建立的保护
 
-明确未完成：
+- owner crate 不得依赖回 `bitfun-core`。
+- `product-full` 继续保护完整产品能力集合。
+- boundary check 已覆盖多个 owner crate 的禁止依赖、旧路径 facade-only 和回流约束。
+- 已有 focused baseline 覆盖 tool manifest、GetToolSpec、execution admission、MiniApp storage / builtin asset、
+  remote workspace fallback、MCP config/catalog、agent-runtime prompt cache、custom subagent、thread-goal tools、
+  AskUserQuestion、DeepReview hook measurement、tool confirmation、product capability pack、session restore、
+  local tool IO、function-agent Git、scheduled-job state 等路径。
+- 构建脚本、installer 和发布形态不是 core decomposition 迁移的默认修改范围。
 
-- H5 不代表 per-product feature matrix、构建收益或 runtime owner 深迁移完成。
-- `bitfun-core default = []` 仍是独立评估项，不能混入 runtime owner 迁移。
-- 具体 IO、scheduler 生命周期、workspace-root、persistence、MiniApp worker / host / seed 写盘、function-agent AI provider acquisition 仍需后续完整 owner PR；function-agent Git concrete service 已在后续阶段外移。
+## 3. 明确未完成边界
 
-### 1.4 Runtime owner PR1-PR4：组装、remote、agent runtime 与 harness 边界
-
-- `bitfun-runtime-services` 已建立 typed service bundle、builder、capability availability 和 fake provider 基础。
-- remote workspace facts、remote session metadata、remote file projection DTO 和 remote workspace/projection host trait
-  已归入 `bitfun-runtime-ports`，并由 `bitfun-services-integrations::remote_connect` 保留旧路径 re-export。
-- `bitfun-agent-runtime` 已建立为可独立构建的 Agent Runtime SDK owner crate，当前承接 scheduler/background
-  delivery 纯决策，thread goal runtime 的 turn accounting、goal mutation、continuation plan 和 tool response assembly，
-  subagent query scope / visibility / availability 决策，以及 round-boundary yield / injection state 和
-  turn-outcome queue policy、dialog turn queue、active-turn facts、background running-turn injection construction、
-  steering action、agent-session reply plan、cancelled-reply suppression state 和
-  goal-continuation abort flags；prompt-loop 的 user-context policy、tool / skill / subagent listing reminder
-  ordering、prompt cache policy / identity / DTO / scope key / in-memory store、shared mode profile / context policy、
-  mode / subagent source presentation facts 已归入该 crate；finish-reason label、session-state event label 和
-  turn-outcome event fact 也已由 `bitfun-agent-runtime` 承接，core 只保留旧路径 re-export 或 concrete adapter。
-- persisted thread goal 的 portable DTO、status、continuation plan 和 tool response contract 已归入
-  `bitfun-runtime-ports`；`get_goal` / `create_goal` / `update_goal` 已进入产品 tool registry。
-- `bitfun-harness` 已建立为可独立构建的 Harness contract crate，当前承接 workflow descriptor、legacy route
-  plan 和 provider registry；`bitfun-core::agentic::harness` 注册 Deep Review、DeepResearch、MiniApp 三个
-  legacy-facade provider。
-
-明确未完成：
-
-- `bitfun-agent-runtime` 不代表 session manager、session persistence / prompt-cache cold restore、concrete prompt assembly、
-  concrete non-custom agent definition loading、scheduler concrete 生命周期、event delivery、permission `Tool` handler
-  或 post-turn hook 已迁移；当前 event 迁移只覆盖无副作用的 wire label / fact 映射。
-- thread goal 的 metadata store、token subscriber、scheduler delivery adapter 和 goal `Tool` handler 仍在
-  `bitfun-core`；runtime 决策已经归属 `bitfun-agent-runtime`，后续不应再把它误归入普通 concrete tool IO。
-- `bitfun-harness` 不代表 Deep Review、DeepResearch、MiniApp 的 concrete workflow execution 已迁移；PR4 provider
-  只生成旧路径 route plan，实际执行仍在既有 core/product 路径。
-- Product command registry、capability pack、Harness 对 Tool Runtime / Runtime Services 的实际 orchestration
-  仍是后续迁移项。
-
-### 1.5 Tool Runtime admission gate：执行准入 owner 迁移
-
-- `bitfun-agent-tools` 已承接 deterministic tool execution admission gate：tool-call loop history / block
-  message、allowed-list gate、runtime restriction gate 和 collapsed-tool unlock gate。
-- `bitfun-core` 的 tool pipeline 已删除对应常量、历史结构、循环检测算法和三段准入分支，只保留状态更新、日志、错误映射、
-  registry lookup、input validation、confirmation channel / UI 副作用、实际执行和 concrete hook side effect。
-- `GetToolSpecTool` concrete adapter 已从 generic concrete-tool implementations 目录迁入 `product_runtime`
-  owner；generic implementations 只保留兼容 re-export，on-demand spec discovery 的 product runtime 边界、
-  错误映射和 context section renderer 由同一 owner 管理。
-- manifest / visible tools / readonly catalog / GetToolSpec catalog path 已收敛到 `product_runtime/catalog.rs`；
-  `manifest_resolver.rs` 仅保留旧路径兼容 facade 和 parity regression。
-- snapshot wrapper 已收敛到 `product_runtime/snapshot.rs`，避免 registry assembly、catalog 和 snapshot adapter
-  继续堆在同一 owner 文件。
-- `WorkspaceFileSystem`、`WorkspaceShell`、`WorkspaceServices`、workspace command / dir-entry contract 已归入
-  `bitfun-runtime-ports`；`bitfun-core::agentic::workspace` 只保留旧路径 re-export 和 local / remote concrete adapter。
-  为避免功能偏移，该 contract 暂时保留既有 `anyhow::Result` 和 `CancellationToken` 语义。
-- `ToolRuntimeHandles` 已归入 `bitfun-runtime-ports`，承接 `ToolUseContext` 的 workspace services /
-  cancellation handle bundle；core 继续拥有 `ToolUseContext` 类型、runtime lookup、portable facts 投影和具体 tool 调用上下文。
-- product provider group plan 到 concrete tool 的 materialization 已迁入 `product_runtime/materialization.rs`；
-  provider order、tool name 和 registry exposure 由 focused test 保护。
-- collapsed unlock 的 message-derived lifecycle state 与 `GetToolSpec` observation adapter 已迁入
-  `product_runtime/unlock_state.rs`；`ExecutionEngine` 不再直接解析 `GetToolSpec` tool result 或调用 generic collector。
-
-明确未完成：
-
-- 具体 IO tools 仍未迁移；继续迁移必须先保护权限、filesystem/shell 行为、checkpoint hook 和产品 tool exposure。
-
-### 1.6 Product-Domain builtin MiniApp bundle：asset owner 迁移
-
-- 内置 MiniApp 的 bundle identity、版本和 embedded source assets 已归入
-  `bitfun-product-domains::miniapp::builtin::BUILTIN_APPS`。
-- `bitfun-core::miniapp::builtin` 只保留旧路径 re-export、seed 写盘、marker IO、用户 `storage.json` 保留和 recompile。
-- 产品 seed 行为由既有 reseed/customization 回归和 product-domain bundle owner contract 保护。
-
-明确未完成：
-
-- MiniApp worker process、host dispatch、permission execution、PathManager integration、builtin marker IO /
-  seed 写盘仍在 core；后续迁移必须单独证明权限与进程行为等价。
-
-### 1.7 Product Capability pack：Harness / Tool / Service 组装闭环
-
-- 新增 `bitfun-product-capabilities`，承接产品能力包 assembly facts：capability id、required runtime service
-  capability、tool provider group id selection 和 harness provider selection。
-- `bitfun-harness` 承接 provider-neutral harness descriptor 与 descriptor registry builder；`bitfun-core::agentic::harness`
-  改为消费 product capability owner 提供的默认 harness registry，core 不再硬编码 Deep Review / DeepResearch / MiniApp provider descriptor。
-- `ProductToolRuntime` 改为通过 product capability owner 解析默认 tool provider group plan，默认产品 tool provider
-  order 保持不变。
-- `bitfun-tool-packs` 承接 tool provider group plan、按 id 选择 plan 和未知 provider group 校验；
-  product capability owner 不再拥有 provider plan 扫描和缺失 group 校验算法。
-- `bitfun-agent-tools` 承接 provider-neutral static provider materialization 和 plan-to-registry
-  assembly；core 只保留 concrete tool factory adapter、product plan adapter 和旧路径兼容入口，不再拥有 provider plan 遍历、provider group 构建、未知工具项错误处理或 registry 安装主体算法。
-- Product Capability assembly 同时收敛 service requirement、tool provider group plan 和 harness provider selection；
-  上层组装器可传入 service availability 来定位 capability 缺口，不需要让 capability owner 依赖 concrete service bundle。
-- tool-pack selector 对未知 tool provider group 显式报错，static provider materializer 对未知 concrete tool 显式报错，避免配置错误被静默过滤成工具能力缺失。
-- boundary check 覆盖 product-capabilities：禁止依赖 core、product-domain implementation、tool-runtime、concrete
-  service crate、Tauri 和重 IO / protocol dependency。
-- cargo tree / metadata 证据显示 product-capabilities 只依赖 harness、runtime-ports、tool-packs；core
-  no-default 不选入 product owner deps，相关 owner 依赖保持 optional。
-- 早期 PR-C 只证明 capability / harness / tool provider 组装边界和 no-default / dependency profile 未扩大；不迁移缺少等价保护的
-  concrete IO、MiniApp worker/host、function-agent AI provider acquisition 或 scheduler/event/permission lifecycle。
-
-### 1.8 Session Store / Restore Runtime Services Owner：restore 热路径边界
-
-- `bitfun-runtime-ports` 已承接 session store / restore view 的稳定 request、storage path resolution、
-  full/tail turn-load request、`SessionTurnLoadTiming` 和 `SessionViewRestoreTiming`。
-- `SessionStorePort` 已从空 capability marker 扩展为 typed storage path resolution port；`bitfun-runtime-services`
-  fake provider 和 contract test 覆盖该方法。
-- `bitfun-core` 新增 `CoreSessionStorePort` concrete adapter，承接 local / remote / unresolved remote
-  session storage path facts；`SessionManager` 保留旧方法签名，但 path resolution 委托 adapter。
-- `PersistenceManager` 的 full/tail load hot path 改为消费 `SessionTurnLoadRequest`，原有
-  `load_session_with_turns(_timed)` 和 `load_session_with_tail_turns(_timed)` API 保持兼容。
-- Desktop `restore_session_view` 复用 `SessionViewRestoreRequest` 的 tail 归一规则，保留既有 16-turn
-  UI view clamp、旧 response shape、tool-result preview compact 和 startup timing 记录。
-
-明确未完成：
-
-- `SessionManager` concrete 生命周期、auto-save / cleanup、event delivery、prompt assembly 和 runtime context restore
-  仍在 core。
-- session persistence 的具体文件 IO、metadata/index 写入、turn read/write、snapshot restore 和 cold restore 行为
-  仍在 core concrete path；后续迁移必须补充端到端等价和性能保护。
-
-### 1.9 Concrete Tool IO Runtime Owner：本地 tool IO 执行边界
-
-- `bitfun-tool-runtime` 已承接本地 Write / Edit / Delete / Glob 的具体 filesystem/search 执行 primitive：
-  文件写入的 created/overwritten/idempotent retry 结果、edit apply/write-back、delete target inspect/delete 和 glob
-  `rg` / fallback walk 执行与浅层优先限流。
-- `bitfun-core` 保留 agent-facing `Tool` adapter、tool name/schema/prompt stub、readonly/enabled exposure、
-  permission admission、checkpoint hook、file-read freshness、workspace-search 优先路径、remote shell fallback、
-  MCP/ACP catalog 和产品组装边界。
-- 新增 `tool-runtime` 契约测试覆盖本地 write/edit/delete/glob owner 行为；core focused tests 继续覆盖原有
-  FileWrite / FileEdit / Glob 兼容路径。
-
-明确未完成：
-
-- Bash / terminal lifecycle、indexed workspace search service、remote shell execution、permission `Tool` handler 和
-  checkpoint orchestration 仍不属于 `bitfun-tool-runtime` concrete owner。
-- 继续迁移 shell、terminal、remote 或 indexed search 时，必须先补 scheduler / terminal lifecycle / remote protocol
-  等价保护，不能复用本地 filesystem primitive 的低风险假设。
-
-### 1.10 Function-Agent Concrete Runtime Owner：Git 具体服务外移与 AI 边界
-
-- `bitfun-product-domains` 继续拥有 function-agent prompt、parser、response policy、port 和 facade orchestration。
-- `bitfun-core::product_domain_runtime::CoreProductDomainRuntime` 承接 function-agent 的 core runtime owner 入口，
-  public `GitFunctionAgent` / `StartchatFunctionAgent` 直接通过该入口组装 Git / AI adapter 与 product-domain facade。
-- `bitfun-services-integrations::function_agents::FunctionAgentGitService` 承接 concrete Git snapshot、startchat Git/time
-  snapshot、no-HEAD diff fallback、非 Git workspace fallback、unpushed/ahead-behind/last-commit fallback 和 project context
-  lookup；core Git adapter 只保留旧路径兼容和 port delegation。
-- `bitfun-core::function_agents::runtime_services` 继续承接 AI provider acquisition、AI transport error mapping、commit AI
-  analysis 和 work-state AI analysis，避免 integration crate 依赖回 core 的 AIClientFactory / Message。
-- 旧 `git_func_agent::AIAnalysisService`、`startchat_func_agent::AIWorkStateService`、`CommitGenerator` 和
-  `WorkStateAnalyzer` 只保留兼容 re-export / facade，不再拥有 concrete runtime 主体逻辑。
-- focused regression 覆盖 staged/unstaged diff 边界、no-HEAD fallback、非 Git workspace fallback、startchat snapshot
-  语义、time snapshot、AI parser policy 和 product-domain facade contract。
-
-明确未完成：
-
-- function-agent AI provider acquisition 仍保留在 core runtime owner 中。后续若外移，必须先抽稳定 AI runtime owner 或
-  AI provider port，不能通过 integration crate 依赖 core 或复制 AI client runtime。
-- MiniApp worker process、host dispatch、permission execution、PathManager integration、builtin marker IO / seed 写盘仍在 core；
-  后续迁移必须单独证明权限、进程生命周期、recompile 和用户 storage 保留行为等价。
-
-### 1.11 Scheduled Job Lifecycle State Owner：运行时状态机边界
-
-- `bitfun-agent-runtime::scheduled_job` 承接 scheduled-job runtime state、run status、默认 retry delay 和纯状态转移决策。
-- manual trigger、scheduled trigger coalescing、pending retry wakeup、enqueue success、enqueue failure、missing-session auto-disable、turn started / completed / failed / cancelled 和 restart recovery 的状态字段更新由 agent-runtime owner 管理。
-- `bitfun-core::service::cron::types` 保留 `CronJobState` / `CronJobRunStatus` 旧路径兼容 alias，保持 jobs.json state wire shape 不变。
-- `CronService` 继续拥有 concrete store、schedule parsing、loop wakeup、session creation、scheduler submit、API filtering 和 product runtime integration。
-- focused contract 覆盖 retry/coalescing/one-shot/missing-session/restart recovery 和 legacy cron state JSON shape；boundary check 覆盖 owner module、旧路径 alias 和 core service delegation。
-
-明确未完成：
-
-- concrete CronService loop、store、session creation、scheduler submit、event delivery、permission `Tool` handler、post-turn hook 和 agent definition loading 仍未迁移。
-- 继续迁移上述路径必须先补端到端等价保护，不能只依赖 scheduled-job owner contract。
-
-### 1.12 Agent Runtime Extension Boundary Closure：subagent、hook 与 confirmation
-
-- `bitfun-agent-runtime::custom_subagent` 承接 custom subagent 的 source kind、definition schema、required-field 校验、默认 tools / readonly / review / model、front-matter 省略决策、markdown front-matter IO、目录 discovery、非递归 `.md` loading、路径优先级去重和 load error report。
-- `bitfun-core::agentic::agents::definitions::custom::subagent` 保留旧路径兼容、路径持有和 `Agent` trait 适配；缺字段错误文本、默认值、保存省略规则和 markdown 读写委托 agent-runtime。
-- `bitfun-core::agentic::agents::registry::custom` 只供应 workspace / user / home root，记录 load error，保留工具 / 模型校验、registry 写入和 project/user source 语义。
-- `bitfun-agent-runtime::post_call_hooks` 承接 successful tool-call 后的 portable hook routing decision 和 executor orchestration；core 只实现 DeepReview shared-context measurement 的具体副作用。
-- `bitfun-agent-runtime::tool_confirmation` 承接 confirmation gate plan、无 timeout 时的一年 deadline 兼容和 rejected / channel closed / timeout 的 legacy reason / error mapping；core 继续拥有 channel wait、UI state update、task state update 和 concrete `BitFunError` 转换。
-- focused contract 覆盖 custom subagent 默认值、comma-format tools、默认字段省略、缺字段错误文本、markdown IO shape、discovery 优先级 / 去重 / 错误报告、successful tool-call hook routing/executor 和 confirmation plan/failure mapping；boundary check 覆盖 runtime owner、旧路径兼容、禁止旧 front-matter IO / discovery 回流和 core 委托。
-
-明确未完成：
-
-- 非 custom agent definition loading、event delivery、permission `Tool` handler、concrete hook side-effect execution 和 concrete scheduler lifecycle 仍未迁移。
-- 继续迁移这些路径必须先补端到端等价保护，不能只依赖 owner contract test。
-
-### 1.13 最终 PR-C：Agent Runtime concrete delivery / permission closure
-
-- `bitfun-agent-runtime::thread_goal_tools` 承接 `get_goal` / `create_goal` / `update_goal` 的参数解析、status 解析、tool response
-  wire shape 和 assistant summary；core `Tool` adapter 只保留 coordinator 调用、session/workspace context 获取和 `BitFunError` 映射。
-- `bitfun-agent-runtime::user_questions` 承接 `AskUserQuestion` 的 input DTO、ACP 可用性判断、问题校验、answered/cancelled result
-  wire shape 和 assistant-facing result text；core 只保留 event emit、oneshot channel 和 user-input manager 适配。
-- thread goal 的 metadata patch、legacy `goal_mode` migration、event payload 序列化、token usage 过滤和 scheduler delivery plan 已归入
-  `bitfun-agent-runtime`；core 只保留 session metadata IO、全局 coordinator/runtime 调用、event emitter 和 scheduler submit / injection。
-- 非 custom builtin agent definition catalog 的顺序、分类、默认模型和 visibility policy 已归入
-  `bitfun-agent-runtime::agents`；core registry 只保留 legacy `Agent` factory 映射和注册适配。
-- DeepReview successful tool post-call hook 的 shared-context measurement 过滤、subagent/parent-turn 提取、local path 归一和 runtime URI
-  过滤已归入 `bitfun-agent-runtime::post_call_hooks`；core 只执行最终 diagnostics 记录副作用。
-- focused coverage 覆盖 goal tool wire shape、AskUserQuestion validation/result、builtin agent catalog、thread-goal metadata/event/token
-  delivery、scheduler resumed/objective-updated delivery plan 和 DeepReview hook measurement decision；core 聚焦测试覆盖 registry、goal mode、
-  scheduler、AskUserQuestion 和 DeepReview 旧路径兼容。
-
-明确未完成：
-
-- concrete scheduler lifecycle、session metadata / persistence IO、event emitter wiring、permission UI/channel wait、concrete prompt assembly、
-  product `Tool` execution adapter 和 DeepReview diagnostics store 仍是 core compatibility / product assembly 副作用，不属于 Agent Runtime SDK 纯 owner。
-- 这些剩余 concrete 副作用若继续外移，必须作为独立行为等价迁移评审，不得混入最终 PR-D 的 Product Runtime / Service / Tool closure。
-
-## 2. 已建立保护
-
-- 新 owner crate 不得依赖回 `bitfun-core`。
-- `product-full` 是完整产品能力保护开关。
-- 构建脚本和 installer 相关脚本不作为 core 拆解的一部分修改。
-- boundary check 覆盖已外移 owner 的旧路径 facade-only / 禁止回流状态。
-- tool manifest、`GetToolSpec`、execution admission gate、MiniApp storage layout adapter、product-domain pure helper、remote workspace search fallback、MCP config / catalog / dynamic manifest、agent-runtime prompt cache、agent registry source/profile facts、builtin agent catalog、custom subagent schema/default/markdown IO/discovery/loading、thread-goal tool / metadata / event / token / scheduler delivery、AskUserQuestion validation/result、DeepReview hook measurement decision、post-call hook routing/executor orchestration、tool confirmation plan/failure mapping、product capability pack、harness/tool provider assembly、session restore path/timing facts、本地 tool IO primitive、function-agent Git concrete runtime / AI parser policy 和 scheduled-job lifecycle state 等已有 focused baseline。
-
-## 3. 当前剩余结论
-
-- 低风险准备项已经完成，不再新增零散小 PR。
-- 早期 PR-C 已收敛 Harness / Product Capability / Build-Benefit closure；PR-1 已收敛 session restore hot-path
-  request / timing / storage path facts 和 Runtime Services port；PR-2 已收敛本地 Write / Edit / Delete / Glob
-  concrete IO primitive；PR-3 已收敛 function-agent Git concrete runtime owner 与 AI 边界；PR-4 已收敛 scheduled-job lifecycle state owner closure；Agent Runtime Extension Boundary Closure 已收敛 custom subagent schema/default/markdown IO/discovery/loading、post-call hook routing/executor orchestration 和 tool confirmation 计划 / 失败映射。后续不应继续拆零散 helper PR；
-- 最终 PR-C 已收敛 Agent Runtime concrete delivery / permission 合同：goal/user-question tool handler 合同、thread-goal metadata / token / event / scheduler delivery plan、builtin agent catalog 和 DeepReview hook measurement decision。当前活跃迁移只剩 `core-decomposition-plan.md` 中的最终 PR-D：关闭 Product Runtime、Runtime Services、Tool / Terminal / Search、Remote、MiniApp 和 function-agent 的剩余 concrete owner。
-- PR-D 完成并通过总体验收后，本文档范围内的 core decomposition runtime owner 迁移应关闭；后续只允许独立缺陷修复、feature matrix、构建收益优化、目录整理或产品行为变更评审，不再作为迁移计划遗漏追加。
-- 缺陷修复、行为变更、冗余清理、三方库升级和构建脚本调整必须独立评估，不能伪装成 core decomposition 剩余里程碑。
+- `bitfun-core` 仍是完整产品 runtime 组装点，不能声明已经退化为纯 compatibility facade。
+- 产品入口仍主要通过 `bitfun-core` 的 `product-full` 获取完整能力；Product Assembly 已可表达当前完整能力集合，
+  但尚未完成按交付形态裁剪 feature / dependency。
+- concrete session manager、scheduler lifecycle、event delivery、permission UI/channel wait、prompt assembly、
+  session persistence IO、AI client factory / provider acquisition 仍在 core。
+- Bash / terminal lifecycle、indexed workspace search、remote shell execution、remote FS / terminal concrete impl、
+  MiniApp worker / host / seed / marker IO、Deep Review / DeepResearch / MiniApp concrete workflow execution 仍未完成 owner 迁移。
+- feature matrix、dependency trimming、build-benefit 仍未用 `cargo metadata` / `cargo tree` / build check 数据闭环。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -1,207 +1,191 @@
 # BitFun Core 拆解与运行时迁移执行计划
 
-本文只记录活跃计划、执行节奏、剩余迁移队列和验收门禁。已完成事实移入
-[`core-decomposition-completed.md`](core-decomposition-completed.md)，避免主计划继续膨胀为历史流水账。
+本文是活跃执行计划。计划只从 Issue #970 原始目标、当前代码状态和两篇设计文档推导，不再沿用历史阶段标签
+作为事实口径。已完成事实只归档在
+[`core-decomposition-completed.md`](core-decomposition-completed.md)。
 
-架构基线见 [`core-decomposition.md`](../architecture/core-decomposition.md)，详细接口和 crate 内部设计见
-[`agent-runtime-services-design.md`](../architecture/agent-runtime-services-design.md)。
+稳定设计基线：
 
-## 1. 当前判断
+- [`core-decomposition.md`](../architecture/core-decomposition.md)：初始状态、目标状态、分层和风险。
+- [`agent-runtime-services-design.md`](../architecture/agent-runtime-services-design.md)：目标接口、crate 内部职责和质量保护。
 
-- P0/P1/P2 的低风险准备和 owner container 化已经完成，不再拆成 helper、guard、facade cleanup 小 PR。
-- 当前迁移已经进入高风险 runtime owner 阶段。后续 PR 必须按完整 owner 主题推进，不能把 PR 当作单个 commit 使用。
-- `bitfun-core` 迁移期继续作为兼容 facade 和完整产品 runtime 组装点；新 owner crate 不得依赖回 `bitfun-core`。
-- 目标不是立即让 `bitfun-core default = []`，而是先把接口、provider 注册、旧路径兼容和行为等价保护做实。
-- 产品能力、权限语义、工具曝光、事件语义、session 行为、release / fast build 脚本和各产品形态能力集合不得因迁移改变。
+## 1. 执行原则
 
-## 2. 迁移关键内容
+- 最终目标是让 `bitfun-core` 从 concrete runtime / product logic 中心收敛为 compatibility facade 与产品组装边界。
+- 依赖方向保持为：Product Surfaces -> Product Assembly / Capabilities -> Harness / Tool Runtime / Agent Runtime SDK
+  -> Runtime Services -> Stable Contracts / External Providers。
+- 新增抽象必须同时删除、迁移或显著简化既有 core 路径；纯 facade、纯 guard、纯文档或只新增空接口不算 owner 迁移完成。
+- 设计文档保持稳定，只在目标架构判断本身需要修正时修改；阶段状态和执行节奏只写入本计划和 completed 归档。
+- 任何可能改变产品行为、权限语义、工具曝光、事件语义、session 生命周期、remote 行为、MiniApp 行为或发布形态的变更必须暂停并单独评审。
 
-### 2.1 接口与实现分离
+## 2. 当前代码基线判断
 
-- 稳定接口属于 Stable Contracts、Runtime Services、Tool Runtime 或 Harness contract。
-- 具体实现按 Tool、OS、Remote、Protocol provider 分类，保留在 app 或 integration owner 中。
-- Product Assembly 是唯一注册点，负责把具体 provider 注入 typed builder / registry。
-- Runtime、Tool、Harness 只消费接口或 registry，不直接创建 filesystem、terminal、MCP、ACP、remote host 等 concrete manager。
+最新 `main` 已包含 function-agent Git concrete service owner 迁移，且当前分支已开始把 Product Assembly 与
+Runtime Services provider 组合显式化。但当前代码仍未达到设计文档的目标状态：
 
-### 2.2 Runtime owner 拆分
+- 产品入口仍通过 `bitfun-core` 的 `product-full` 获得完整能力；Product Assembly 已可表达当前完整能力集合，
+  但尚未支撑按交付形态裁剪 feature / dependency。
+- `runtime-services` 已有 typed builder、capability availability 和 core product assembly provider 组合，
+  但许多 concrete provider 仍在 core 创建或持有。
+- core 仍持有 `SessionManager`、`ExecutionEngine`、`PersistenceManager`、`CronService`、`MiniAppManager`、
+  `RemoteFileService`、`RemoteTerminalManager`、`WorkspaceSearchService`、AI client factory 和大量 concrete tool adapter。
+- `tool-runtime` 已迁移部分低风险本地 IO primitive，但 Bash、terminal lifecycle、indexed search、remote shell、
+  permission UI/channel wait、checkpoint orchestration 和完整 execution pipeline 仍不是独立 Tool Runtime owner。
+- `harness` 当前主要承接 descriptor / route plan / registry contract，Deep Review、DeepResearch、MiniApp 的 concrete workflow execution
+  仍留在 core 或产品路径。
+- feature / dependency trimming 还没有数据证明，不能声称不同交付形态已经可以按最小依赖组合。
 
-- Agent Runtime SDK：session、turn、scheduler、prompt loop、subagent、background task、permission coordination、runtime events。
-- Runtime Services：filesystem、workspace、session store、Git、terminal、network、MCP catalog、remote connection / projection 等 port 和 capability availability。
-- Tool Runtime：manifest、catalog、permission gate、execution pipeline、tool hook、结果归一化。
-- Harness Layer：SDD、Deep Review、DeepResearch、MiniApp 等多步骤工作流和策略编排。
-- Product Capabilities：Code Agent、MiniApp、function-agent、Remote Control、MCP App、Computer Use 等能力包。
+## 3. PR 准出门禁
 
-### 2.3 Remote 拆分原则
+每个迁移 PR 必须同时满足：
 
-- Remote 不是 Agent Runtime SDK 的内部能力，也不只按 Desktop / CLI 入口区分。
-- 稳定接口应拆为 remote connection、remote workspace、remote filesystem / terminal projection、remote capability facts。
-- SSH、relay、本地隧道、远端 OS 差异、认证方式属于具体 Remote provider。
-- remote workspace、terminal pre-warm、scheduler submit、session restore、file chunk / image fallback 等行为必须用等价测试保护。
+- 有完整 owner 主题，且范围足够迁移真实逻辑主体。
+- 保留旧路径兼容，删除或明显简化对应 core 主体路径。
+- 有 focused regression、snapshot、contract test 或产品入口验证证明行为等价。
+- boundary check 覆盖新 owner 和旧路径 facade，禁止反向依赖、Tauri 下沉、无类型 service locator 和全局 mutable registry 膨胀。
+- PR 描述只说明本次 diff 的变更、风险、验证和剩余边界，不写过程信息。
 
-### 2.4 目标 crate 创建或扩展准入
+不满足上述门禁时，不允许把变更作为独立 PR 提交。
 
-- 新目标 crate 不能为了“架构完整”提前创建。必须同时满足 owner 边界清晰、旧路径兼容可保留、focused tests 可落地、依赖收益可解释、boundary check 可防回流。
-- `bitfun-runtime-services` 已按该准入建立基础壳层；继续扩展时仍必须保持 `RuntimeServicesBuilder` skeleton、Remote ports 和 fake provider 测试同时成立。
-- `bitfun-agent-runtime` 只能在 session / turn / scheduler / prompt loop 中至少一个 owner 可脱离 `bitfun-core` 构建时创建。
-- `bitfun-harness` 已按 Deep Review、DeepResearch、MiniApp 三个 legacy-facade provider 建立 descriptor / registry contract；继续扩展时不能把 concrete workflow execution 描述为已完成。
-- 若某项迁移只能承接单个 helper，或测试仍必须依赖完整 `bitfun-core`，继续留在迁移期 facade。
+## 4. 后续里程碑
 
-### 2.5 Workspace crate 目录组织
+### 4.1 M1（当前变更已闭环）：Product Assembly 与 Runtime Services concrete provider 组合
 
-`src/crates` 当前按 crate 名平铺，随着 owner crate 增多，可读性会下降。目录重组属于后置非功能性整理，
-不应混入 runtime owner 迁移 PR。待 Agent Runtime、Tool Runtime、Runtime Services、Harness 和
-Product Domains 的 owner 边界稳定后，再评估是否按 `contracts/`、`runtime/`、`services/`、
-`integrations/`、`product/` 等目录分组，并用 Cargo path 更新、module index、boundary check 和
-workspace build 证明没有行为或 feature 影响。
+目标：让产品能力选择、service provider 注册和 capability availability 从 core 隐式聚合转为显式组装边界。
 
-## 3. 执行节奏
+完成口径：
 
-每个高风险 PR 按同一节奏执行：
+- Product Assembly 已建立 `DeliveryProfile`、`CapabilitySet`、tool provider plan、harness provider plan 和
+  service availability report；当前 Desktop / CLI / Server / Remote / ACP / Web 均保持完整 product-full 能力集合，
+  先证明“不减少能力”。
+- core 的 tool runtime 与 harness registry 已改为消费显式 Product Assembly plan，旧 facade 输出保持等价。
+- core product assembly provider 已把现有 session store path resolution、remote workspace/projection adapter，以及当前
+  product-full 需要的 terminal / Git / Network / MCP catalog capability marker 注册进 `RuntimeServicesBuilder` 组合。
+- 基础必选端口、search concrete、AI provider acquisition 和按交付形态裁剪不在 M1 中完成，继续留给后续 owner 迁移和
+  feature/dependency 收尾阶段。
 
-1. **同步主干。** 变基到远端 `main`，检查最新主干是否引入新的 tool、remote、session、scheduler、CLI、mobile-web 或 product-surface 行为。
-2. **确认组装门禁。** 高风险迁移前必须先有最小 Product Assembly / Runtime Services skeleton，能把 provider 注册到 typed builder / registry。
-3. **确定 owner 主题。** 每个 PR 只迁移一个完整 owner 主题；预保护、迁移、旧路径兼容、文档更新和对抗性审核属于同一个 PR。
-4. **先补保护。** 在移动 owner 前补 owner 设计、输入输出盘点、旧路径兼容方案、等价测试或 snapshot。
-5. **再移动实现。** 只移动已被 port/provider 保护的逻辑；发现需要改变产品行为时暂停并单独评审。
-6. **回看边界。** 检查是否新增反向依赖、万能 context、无类型 service locator、全局 mutable registry 或重复 runtime materialization。
-7. **提交前审核。** 从第三方角度审查功能偏移、性能劣化、产品形态遗漏和文档一致性；不满足时不提交 PR。
+**不混入：** default feature 调整、构建收益声明、大规模目录移动、UI 行为变更。
 
-## 4. 后续迁移队列
+**门禁：**
+- `cargo check -p bitfun-core --features product-full`
+- `cargo test -p bitfun-runtime-services`
+- 涉及 remote / terminal / search / Git / AI 时补对应 focused tests。
 
-早期 PR-A / PR-B / PR-C、scheduler owner decision 扩展、PR-1 Session Store / Restore Runtime Services Owner、PR-2 Concrete Tool IO Runtime Owner、PR-3 Function-Agent Concrete Runtime Owner、PR-4 Scheduled Job Lifecycle State Owner、Agent Runtime Extension Boundary Closure 和最终 PR-C 已进入完成归档。当前活跃队列只保留最终 PR-D。PR-D 完成并通过验收后，本文档范围内的 core decomposition runtime owner 迁移应关闭，不再继续新增迁移 PR。后续如仍有缺陷修复、feature matrix、构建收益优化或产品行为变更，应作为独立工作评审，不能伪装成迁移收尾。
+### 4.2 M2：Tool Runtime concrete execution 闭环
 
-每个 PR 必须迁移真实 owner 逻辑，并同时包含旧路径兼容、focused tests、boundary check 和提交前对抗性审核。只新增抽象、只补 facade 或只增加 guard 不满足准出要求。
+目标：让 Tool Runtime 不再只承接 manifest / admission，而是接管可证明等价的工具执行管线主体。
 
-| PR | 主题 | 完整范围 | 不允许混入 | 合入门禁 |
-|---|---|---|---|---|
-| PR-D | Product Runtime / Service / Tool Final Closure | 收敛剩余 concrete runtime owner：session persistence / cold restore / metadata IO、workspace-root / persistence / workspace service reads、remote FS / terminal / image context concrete impl、Bash / terminal lifecycle / indexed workspace search / remote shell execution、MiniApp worker / host / seed / marker IO、function-agent Git concrete service 外移，以及必要的 final boundary / directory organization cleanup。function-agent AI provider acquisition 暂留 core，后续必须先抽稳定 AI runtime owner，不能让 integration crate 依赖回 core | 改变产品能力集合、工具曝光、权限、checkpoint、remote fallback、MiniApp worker 生命周期、function-agent Git/AI 行为、release/installer 构建形态；把独立 feature matrix 或构建性能优化混入迁移 | session persistence / restore tests，remote workspace / file / terminal focused tests，terminal / shell / indexed-search focused tests，MiniApp import/sync/recompile/worker tests，function-agent Git/AI focused tests，`cargo check --workspace` |
+- 迁移 Bash、terminal lifecycle、indexed workspace search、remote shell execution 中可被 port/provider 保护的执行主体。
+- 将 permission gate、tool execution services、result/artifact policy、tool hook 顺序和 cancellation 语义收敛到 Tool Runtime 边界。
+- core 保留 agent-facing `Tool` adapter、旧 import path、UI/channel 副作用和必要 checkpoint adapter。
+- 继续保护 prompt-visible manifest、GetToolSpec、readonly/enabled filtering、expanded/collapsed exposure、MCP/ACP catalog。
 
-计划优先级：完成最终 PR-D 后做一次总体验收：确认 plan / completed 文档没有剩余活跃迁移队列，`bitfun-core` 只保留兼容 facade 和产品组装，边界脚本覆盖已外移 owner，且所有产品形态仍保持既有能力集合。PR-1 到 PR-4、Agent Runtime Extension Boundary Closure 和最终 PR-C 已进入完成归档；后续不应继续触碰 session restore 热路径、已迁移的本地 tool IO primitive、function-agent Git concrete runtime、scheduled-job runtime state、custom subagent schema/default/markdown IO/discovery/loading、post-call hook routing/executor orchestration、tool confirmation 计划与失败映射，或最终 PR-C 已收敛的 agent-runtime concrete delivery / permission 合同，除非是修复等价测试发现的问题。
+**不混入：** 改变工具 schema、权限默认值、checkpoint 语义、remote fallback、shell 工作目录或 terminal prewarm 行为。
 
-## 5. 每类 PR 的保护重点
+**门禁：**
+- `cargo test -p bitfun-agent-tools`
+- `cargo test -p bitfun-tool-runtime`
+- tool manifest / GetToolSpec / Bash / terminal / search / remote shell focused tests
+- `node scripts/check-core-boundaries.mjs`
 
-### 5.1 Service / Agent Remote Runtime Owner
+### 4.3 M3：Agent Runtime concrete lifecycle 闭环
 
-- 先定义 remote connection、workspace、projection、capability facts port。
-- 保留 core adapter 读取 workspace-root、persistence、session restore、scheduler submit，直到有端到端 remote regression。
-- SSH、relay、tunnel、远端 OS、认证差异留在 Remote provider。
-- 验证 remote command/response wire、restore -> terminal pre-warm -> scheduler submit 顺序、file full/chunk/info、image context fallback、remote workspace startup guard。
+目标：让 Agent Runtime SDK 接管 session / turn / scheduler / event / permission 中可迁移的 runtime kernel 主体。
 
-### 5.2 Agent Registry / Scheduler Owner
+- 迁移 session lifecycle、turn submission、scheduler queue/lifecycle、cancellation、event fact delivery、permission coordination、
+  prompt-loop 可移植策略和 subagent/background task concrete coordination 中可证明等价的部分。
+- 将 session metadata / persistence IO、event emitter wiring、permission UI/channel wait 和 concrete prompt assembly 明确划入
+  core compatibility / Product Assembly adapter，或在有端到端保护后迁移。
+- 禁止 Agent Runtime SDK 直接依赖 Tauri、ACP protocol、CLI TUI、desktop app state、concrete filesystem/Git/terminal/MCP client。
 
-- 已迁移只读 facts、queue policy decision、queue state、active-turn facts、background running-turn injection
-  construction、steering action、agent-session reply plan、cancelled-reply suppression state、goal-continuation abort flags 和 runtime event facts；
-  不移动 concrete scheduler 生命周期。
-- 保留 mode-scoped visibility、hidden/custom/review grouping、background delivery entrypoint、idle-session follow-up 和 persisted thread goal continuation 语义。
-- thread goal runtime、metadata patch / legacy migration、token usage filter、event payload、scheduler delivery plan、goal
-  `Tool` wire contract、user-question `Tool` validation/result contract、builtin agent definition catalog、DeepReview
-  shared-context measurement decision、subagent visibility/availability、round-boundary yield/injection、turn-outcome queue
-  policy、dialog turn queue、active-turn state、background running-turn injection construction、steering action、
-  agent-session reply plan、cancel suppression、finish-reason label、session-state event label 和 turn-outcome event fact 已归入
-  `bitfun-agent-runtime`；后续只允许 core 继续作为 session metadata IO、config/file IO adapter、concrete prompt
-  assembly、concrete scheduler lifecycle、event emitter、channel wait、UI 副作用和 product `Tool` execution adapter。
-- scheduled-job runtime state、run status、retry / coalescing / one-shot / missing-session disable / restart recovery
-  transition 已归入 `bitfun-agent-runtime::scheduled_job`；core cron 继续拥有 store、schedule parsing、loop wakeup、session
-  creation、scheduler submit 和 API wire compatibility。
-- custom subagent definition schema、required-field 校验、默认值、front-matter 省略决策、markdown front-matter IO、目录 discovery / `.md` loading、successful tool post-call hook routing / executor orchestration
-  和 tool confirmation 计划 / 失败映射已归入 `bitfun-agent-runtime`；core 继续供应 concrete root path、持有旧 `Agent` 适配、记录加载错误、执行工具 / 模型校验、写入 registry，并保留 DeepReview shared-context measurement 的具体副作用、confirmation channel wait / 状态更新 / UI 副作用和 `BitFunError` 映射。
-- 若继续迁移 scheduler lifecycle、session metadata IO、event emitter、permission UI/channel wait 或 concrete hook side-effect execution，必须先补端到端等价保护，
-  不能只用 owner contract test 证明；不得把这些剩余 concrete 副作用伪装成 Agent Runtime SDK 纯合同迁移。
-- 验证 subagent availability、queue/preempt/cancel suppression、DeepResearch citation / post-turn hook、goal verification events、`get_goal` / `create_goal` / `update_goal` tool response wire shape。
+**不混入：** 改变 `/goal`、AskUserQuestion、Task、subagent、post-turn hook、DeepReview measurement、token usage 或 continuation wire shape。
 
-### 5.3 Product-Domain Runtime Owner
+**门禁：**
+- `cargo test -p bitfun-agent-runtime`
+- `cargo test -p bitfun-core --features product-full` 中 session / scheduler / goal / subagent focused tests
+- `cargo check -p bitfun-core --features product-full`
+- boundary check 证明 agent-runtime 不依赖 core 或平台实现。
 
-- MiniApp 已将 builtin bundle identity、版本和 embedded asset 放入 `bitfun-product-domains`；core 继续负责 seed 写盘、marker IO、用户 storage 保留、recompile、PathManager、worker process 和 host dispatch。
-- 后续若继续迁移 MiniApp worker / host，必须先拆清 process runtime、permission policy、host primitive dispatch、draft worker 与 active worker 的等价边界，不能把 PathManager 或 worker process 下沉到 domain crate。
-- function-agent 的 prompt、parser 和 facade policy 已归属 `bitfun-product-domains`；Git snapshot / no-HEAD diff fallback / 非 Git workspace fallback 已归属 `bitfun-services-integrations::function_agents`。core 通过 `CoreProductDomainRuntime` 保留旧入口和 AI provider acquisition / error mapping / `analyzed_at` 时序，后续 AI 外移必须先完成独立 AI runtime owner 设计。
-- 验证 MiniApp import/sync/recompile/rollback/deps state、builtin seed marker、customized update metadata、function-agent prompt/response policy。
+### 4.4 M4：Harness 与 Product Domain concrete workflow 闭环
 
-### 5.4 Tool Runtime Owner
+目标：让 Harness / Product Domains 不再停留在 descriptor 或 pure policy 层，而是接管符合设计边界的工作流和 domain owner。
 
-- 已完成 deterministic execution admission gate 迁移；core 仅保留状态更新、registry lookup、input validation、confirmation channel / UI 副作用、实际执行和 concrete hook side effect。
-- 已完成 `GetToolSpecTool` concrete adapter 的 product runtime owner closure；generic concrete-tool implementations
-  只保留兼容 re-export，不再拥有 on-demand spec discovery Tool impl。
-- 已完成 manifest/catalog/snapshot owner closure；`manifest_resolver.rs` 只保留旧路径兼容 facade，product runtime
-  的 `catalog.rs` / `snapshot.rs` 管理 resolved manifest DTO、visible tools、readonly catalog、GetToolSpec catalog
-  path 和 snapshot wrapper。
-- 已完成 `WorkspaceFileSystem`、`WorkspaceShell`、`WorkspaceServices` 等 workspace service
-  contract 归入 `bitfun-runtime-ports`，core `workspace.rs` 只保留旧路径 re-export 和 local/remote concrete adapter；
-  `ToolRuntimeHandles` 归入 `bitfun-runtime-ports`，承接 ToolUseContext 的 workspace services / cancellation handle bundle。
-- collapsed unlock 的 message-derived state 与 GetToolSpec observation adapter 已归入 `product_runtime/unlock_state.rs`，
-  `ExecutionEngine` 不再拥有 GetToolSpec 结果解析细节。
-- product provider group plan 到最终 registry 的 generic assembly 已归入 `bitfun-agent-tools`；
-  `product_runtime/materialization.rs` 只保留 concrete factory / product plan adapter，`product_runtime.rs`
-  只保留 product plan、decorator 与旧路径兼容入口。
-- workspace service contract 暂时保留既有 `anyhow::Result` 和 `CancellationToken` 语义，避免在 owner 迁移 PR 中同时改变
-  错误分类、取消语义或调用方边界；后续若要收敛为 portable `PortResult`，必须单独补错误映射等价测试。
-- 本地 Write / Edit / Delete / Glob 的具体 filesystem/search 执行 primitive 已迁入 `bitfun-tool-runtime`；core 保留 `Tool` adapter、权限、checkpoint、file-read freshness、workspace-search 和 remote fallback。
-- 后续若继续迁移 Bash、terminal、indexed workspace search 或 remote shell execution，必须先证明 scheduler、terminal lifecycle、remote protocol 和 checkpoint 行为等价，不能把它们当作普通本地 IO helper 直接搬移。
-- 保留 tool name、schema、prompt stub、readonly/enabled/filtering、unlock state 生命周期。
-- 验证 builtin tool list、provider order、expanded/collapsed exposure、dynamic provider metadata、Deep Review 修改类工具 checkpoint hook。
+- 为 Deep Review、DeepResearch、MiniApp、function-agent 明确哪些属于 Harness workflow、哪些属于 Product Domain policy、
+  哪些属于 Concrete Integration provider。
+- 迁移 MiniApp worker/host/seed/marker IO 中可被 Runtime Services / provider port 保护的主体。
+- 为 function-agent AI provider acquisition 抽稳定 AI runtime/provider port，避免 integration crate 依赖回 core 或复制 AI client runtime。
+- Harness provider 从 legacy route plan 逐步转向可执行 workflow owner；无法迁移的 concrete 副作用必须明确保留在 Product Assembly adapter。
 
-### 5.5 Core / Tauri 脱离保护
+**不混入：** 改变 MiniApp storage layout、worker 生命周期、host primitive 权限、Deep Review report 语义、function-agent prompt/response policy。
 
-- `bitfun-core`、Agent Runtime SDK、Tool Runtime、Harness、Runtime Services contract 不应直接依赖
-  Tauri handle、window、command macro、desktop API state 或 Tauri-specific path/event 类型。
-- Desktop 形态中的 Tauri 逻辑只能停留在 `src/apps/desktop`、transport/API adapter 或 Product Assembly 的
-  concrete provider 注册侧；下层只消费 typed port、DTO、event fact 或 capability availability。
-- 迁移现有 Tauri-adjacent 调用时，先抽稳定 port / provider，再让 desktop provider 实现该 port；不得在同一 PR
-  同时改变 command wire shape、权限语义、事件语义或构建脚本。
-- 后续 PR 若触碰 desktop/Tauri 边界，必须显式列出哪些能力仍是 Desktop-only，哪些能力已经通过 port
-  可被 CLI/Server/Remote/ACP 复用，并补 `cargo check -p bitfun-desktop` 及对应 focused regression。
+**门禁：**
+- `cargo test -p bitfun-harness`
+- `cargo test -p bitfun-product-domains`
+- MiniApp import/sync/recompile/worker focused tests
+- function-agent Git/AI focused tests
+- 涉及 desktop / API 时补 `cargo check -p bitfun-desktop`
 
-## 6. 不可变更边界
+### 4.5 M5：feature matrix、依赖收益与目录组织收尾
 
-- 不改变产品行为、默认能力集合、权限语义、工具曝光、事件语义或 session 生命周期。
-- 不修改 `package.json`、`scripts/dev.cjs`、`scripts/desktop-tauri-build.mjs`、`scripts/ensure-openssl-windows.mjs`、`scripts/ci/setup-openssl-windows.ps1`、`BitFun-Installer/**`，除非单独作为产品构建变更评审。
-- 不让新 crate 依赖回 `bitfun-core`。
-- 不把 `bitfun-core` 重新包装成新的 `common`、`platform`、`app context` 或 service locator。
-- 不让 runtime owner 或 contract crate 吸收 Tauri / desktop app state；Tauri 只能作为具体 Desktop provider
-  或 transport/API adapter 的实现细节。
-- 不在同一 PR 中同时做 runtime owner 迁移、default feature 调整、三方库大版本升级和构建脚本变更。
-- 不为了减少代码行数抽象语义并不等价的跨产品或跨平台流程。
+目标：在 owner 边界稳定后，用数据证明不同产品形态可以最小依赖组合，并整理 workspace crate 可读性。
 
-构建脚本保护命令：
+- 建立 Desktop / CLI / Server / Remote / ACP / Web 的 capability matrix 与 feature group 显式映射。
+- 用 `cargo metadata`、`cargo tree`、`cargo check` 数据证明 no-default、product-full 和关键交付形态的依赖边界。
+- 评估 `src/crates` 是否按 `contracts/`、`runtime/`、`services/`、`integrations/`、`product/` 等目录分组。
+- 目录移动只允许在 owner 边界稳定后执行，并必须同步 Cargo path、AGENTS module index、boundary check 和 workspace build。
 
-```powershell
-git diff -- package.json scripts/dev.cjs scripts/desktop-tauri-build.mjs scripts/ensure-openssl-windows.mjs scripts/ci/setup-openssl-windows.ps1 BitFun-Installer
-```
+**不混入：** 运行时 owner 深迁移、三方库大版本升级、构建脚本行为变更、installer 发布流程变更。
 
-期望结果：没有 diff。
+**门禁：**
+- `cargo metadata`
+- `cargo tree` 对比
+- `cargo check --workspace`
+- `pnpm run check:repo-hygiene`
+- `node scripts/check-core-boundaries.mjs`
 
-## 7. 验证矩阵
+## 5. 执行节奏
 
-按触碰范围选择最小但足够的验证：
+后续按 M2 -> M3 -> M4 -> M5 推进。每个里程碑原则上对应一个大 PR；如果发现风险超过单 PR 可控范围，只允许按 owner 边界拆分，
+不允许拆成 facade / guard / helper 小 PR。
+
+每个里程碑固定流程：
+
+1. 同步最新 `main`，检查主干新增的 tool、remote、session、scheduler、CLI、mobile-web、ACP 或 product surface 变更。
+2. 对照 Issue #970 和设计文档确认本次 owner 边界，不从旧 plan 标签继承完成判断。
+3. 先补等价保护，再迁移实现主体。
+4. 删除、迁移或显著简化 core 中对应旧路径。
+5. 运行最小但足够的 focused verification 和 boundary check。
+6. 从独立第三方角度审查功能漂移、性能劣化、依赖回流、产品形态遗漏和文档一致性。
+7. 合入后只更新 completed 摘要和 issue 状态；设计文档默认不修改。
+
+## 6. 验证矩阵
 
 | 触碰范围 | 最小验证 |
 |---|---|
-| contract / DTO / boundary 文档 | `pnpm run check:repo-hygiene`，必要时补 `node scripts/check-core-boundaries.mjs` |
-| Runtime ports / service boundary | `cargo test -p bitfun-runtime-ports`，`cargo check -p bitfun-core --features product-full` |
-| Service integrations / Remote | owner crate focused tests，remote-connect / remote-SSH focused tests，`cargo check -p bitfun-core --features product-full` |
-| Remote product surfaces | 触碰 remote connection / workspace / projection 时，按范围补 Desktop remote connect、relay / mobile session、ACP remote config reuse、CLI subagent / remote-adjacent path 验证 |
-| Harness contract / registry | `cargo test -p bitfun-harness`，`cargo test -p bitfun-core --features product-full product_harness`，`node scripts/check-core-boundaries.mjs` |
-| Tool runtime | `cargo test -p bitfun-agent-tools`，tool manifest / `GetToolSpec` / snapshot focused tests，`node scripts/check-core-boundaries.mjs` |
-| Product domains | `cargo test -p bitfun-product-domains`，MiniApp / function-agent focused tests |
-| Product surface 或 Tauri/API 触碰 | `cargo check -p bitfun-desktop`，检查 Tauri 依赖未下沉到 runtime owner，必要时补 Web UI 或 mobile-web 验证 |
-| 大范围 owner 迁移 | `cargo check --workspace`；若行为面广，再补 `cargo test --workspace` |
+| docs / boundary script | `pnpm run check:repo-hygiene`，必要时 `node scripts/check-core-boundaries.mjs` |
+| Runtime Services / ports | `cargo test -p bitfun-runtime-services`，`cargo check -p bitfun-core --features product-full` |
+| Tool Runtime | `cargo test -p bitfun-agent-tools`，`cargo test -p bitfun-tool-runtime`，tool focused tests |
+| Agent Runtime | `cargo test -p bitfun-agent-runtime`，core session / scheduler / goal / subagent focused tests |
+| Harness | `cargo test -p bitfun-harness`，core harness focused tests |
+| Product Domains | `cargo test -p bitfun-product-domains`，MiniApp / function-agent focused tests |
+| Desktop / Tauri/API | `cargo check -p bitfun-desktop`，并确认 Tauri 未下沉到 runtime owner |
+| 大范围 owner 迁移 | `cargo check --workspace`，必要时补 `cargo test --workspace` |
+| feature / dependency 收益 | `cargo metadata`，`cargo tree`，对应 build/check 对比 |
 
-任何声明构建收益的 PR 必须记录迁移前后 cargo metadata / cargo tree / check 数据；不声明收益时，也不得造成明显编译或运行时退化。
+## 7. 暂停条件
 
-## 8. 暂停条件
-
-- 必须改变用户可见行为、权限策略、产品命令、默认能力或 release 构建形态才能继续。
-- 新 owner crate 必须依赖回 `bitfun-core` 才能编译。
-- contract crate 开始吸收 Tauri、CLI/TUI、network client、process execution、`git2`、`rmcp`、`image`、`tokio-tungstenite` 等 concrete runtime 依赖。
-- Remote / Tool / MiniApp / function-agent / scheduler 迁移无法给出迁移前后等价测试或可复核 snapshot。
+- 迁移必须改变用户可见行为、权限策略、工具 schema、默认能力集合或 release 构建形态才能继续。
+- 新 owner crate 必须依赖回 `bitfun-core` 才能编译或测试。
+- Runtime / contract crate 开始吸收 Tauri、CLI/TUI、process execution、network client、Git provider、AI provider、MCP client 等 concrete dependency。
 - Product Assembly 变成无类型 service locator 或全局 mutable app state。
-- 某个产品 crate 需要减少 feature 才能通过编译。
+- 无法为 remote、tool、MiniApp、function-agent、scheduler、session lifecycle 迁移提供等价测试或可复核 snapshot。
+- PR 只新增抽象而没有迁移、删除或显著简化旧 core 主体路径。
 
-## 9. 完成标准
+## 8. 完成标准
 
-- `bitfun-core` 只保留兼容 facade 和产品组装，不再承载新 runtime owner 实现。
-- Agent Runtime SDK、Runtime Services、Tool Runtime、Harness、Product Capabilities 与 Concrete Integrations 的依赖方向可由边界检查证明。
-- 至少有一组低层 contract / owner crate 可以绕开完整 `bitfun-core` 和对应 heavy dependency。
-- 产品 crate 仍拥有拆解前的完整能力集合，且旧公开 import 路径保持兼容。
-- Remote、Tool、MiniApp/function-agent、scheduler/registry 等高风险路径都有等价测试、旧路径兼容和回滚边界。
-- 新增 crate 数量保持中等粒度；继续拆小必须有 owner、依赖或实测收益依据。
-- 已完成事实只记录在归档文档中，主计划持续聚焦当前方向和待完成事项。
+- `bitfun-core` 只保留 compatibility facade 与 product-full / Product Assembly 兼容边界。
+- Agent Runtime SDK、Runtime Services、Tool Runtime、Harness、Product Capabilities、Product Domains 和 Concrete Integrations
+  的职责边界可被代码结构、依赖检查和测试证明。
+- 产品入口通过 Product Assembly / capability matrix 显式选择能力和 provider，不再被完整 core 隐式牵引。
+- 高风险路径具备旧路径兼容、等价保护、明确回滚边界和产品形态验证。
+- feature / dependency trimming 有数据证明，且不以功能缺失、权限漂移或性能劣化换取构建收益。

--- a/scripts/core-boundaries/rules/source/required-rules.mjs
+++ b/scripts/core-boundaries/rules/source/required-rules.mjs
@@ -3130,8 +3130,8 @@ export const requiredContentRules = [
         message: 'missing product registry assembly adapter delegation',
       },
       {
-        regex: /\bdefault_product_capability_assembly\b/,
-        message: 'missing product capability assembly provider group plan delegation',
+        regex: /\bproduct_assembly_plan_for_profile\b/,
+        message: 'missing product assembly plan provider group plan delegation',
       },
       {
         regex: /\bproduct_tool_runtime_owner_preserves_registry_contract\b/,

--- a/scripts/core-boundaries/self-test.mjs
+++ b/scripts/core-boundaries/self-test.mjs
@@ -1440,7 +1440,7 @@ export function runManifestParserSelfTest({
         'ProductToolRuntime',
         'SnapshotToolDecorator',
         'create_product_tool_registry_from_plan',
-        'default_product_capability_assembly',
+        'product_assembly_plan_for_profile',
         'product_tool_runtime_owner_preserves_registry_contract',
         'product_tool_runtime_registry_preserves_provider_plan_order',
       ],

--- a/src/crates/core/Cargo.toml
+++ b/src/crates/core/Cargo.toml
@@ -143,6 +143,7 @@ bitfun-relay-server = { path = "../../apps/relay-server", optional = true }
 bitfun-core-types = { path = "../core-types" }
 bitfun-events = { path = "../events" }
 bitfun-runtime-ports = { path = "../runtime-ports" }
+bitfun-runtime-services = { path = "../runtime-services", optional = true }
 
 # Transport layer dependency
 bitfun-transport = { path = "../transport" }
@@ -182,11 +183,13 @@ product-full = [
     "ssh-remote",
     "product-capabilities",
     "product-domains",
+    "runtime-services",
     "service-integrations",
     "tool-packs",
 ]
 product-capabilities = ["dep:bitfun-product-capabilities"]
 product-domains = ["dep:bitfun-product-domains", "bitfun-product-domains/product-full"]
+runtime-services = ["dep:bitfun-runtime-services"]
 service-integrations = [
     "dep:aes",
     "dep:aes-gcm",

--- a/src/crates/core/src/agentic/harness.rs
+++ b/src/crates/core/src/agentic/harness.rs
@@ -1,17 +1,25 @@
 use bitfun_harness::{HarnessRegistry, HarnessRegistryBuildError};
+use bitfun_product_capabilities::{product_assembly_plan_for_profile, DeliveryProfile};
 pub use bitfun_product_capabilities::{
     CORE_DEEP_RESEARCH_HARNESS_PROVIDER_ID, CORE_DEEP_REVIEW_HARNESS_PROVIDER_ID,
     CORE_MINIAPP_HARNESS_PROVIDER_ID,
 };
 
 pub fn product_harness_registry() -> Result<HarnessRegistry, HarnessRegistryBuildError> {
-    bitfun_product_capabilities::default_product_harness_registry()
+    product_harness_registry_for_profile(DeliveryProfile::ProductFull)
+}
+
+pub fn product_harness_registry_for_profile(
+    profile: DeliveryProfile,
+) -> Result<HarnessRegistry, HarnessRegistryBuildError> {
+    product_assembly_plan_for_profile(profile).build_harness_registry()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use bitfun_harness::{HarnessInput, HarnessStepKind, HarnessWorkflow};
+    use bitfun_product_capabilities::DeliveryProfile;
 
     #[test]
     fn product_harness_registry_registers_existing_workflow_facades() {
@@ -56,6 +64,17 @@ mod tests {
         assert!(
             provider.execute(Default::default(), plan).await.is_err(),
             "PR4 must not move concrete workflow execution out of legacy paths"
+        );
+    }
+
+    #[test]
+    fn product_harness_registry_can_be_built_from_explicit_delivery_profile() {
+        let registry = product_harness_registry_for_profile(DeliveryProfile::Cli)
+            .expect("profile-scoped product harness registry should build");
+
+        assert_eq!(
+            registry.provider_ids(),
+            vec!["core.deep_review", "core.deep_research", "core.miniapp"]
         );
     }
 }

--- a/src/crates/core/src/agentic/tools/product_runtime.rs
+++ b/src/crates/core/src/agentic/tools/product_runtime.rs
@@ -13,6 +13,9 @@ mod unlock_state;
 
 use crate::agentic::tools::registry::{ProductToolDecoratorRef, ToolRegistry};
 use bitfun_agent_tools::SnapshotToolDecorator;
+use bitfun_product_capabilities::{
+    product_assembly_plan_for_profile, DeliveryProfile, ProductAssemblyPlan,
+};
 use materialization::create_product_tool_registry_from_plan;
 use snapshot::ProductSnapshotToolWrapper;
 use std::sync::Arc;
@@ -29,6 +32,7 @@ pub(crate) use unlock_state::collect_product_unlocked_collapsed_tools;
 #[derive(Clone)]
 pub(crate) struct ProductToolRuntime {
     tool_decorator: ProductToolDecoratorRef,
+    assembly_plan: ProductAssemblyPlan,
 }
 
 impl Default for ProductToolRuntime {
@@ -39,19 +43,40 @@ impl Default for ProductToolRuntime {
 
 impl ProductToolRuntime {
     pub(crate) fn new() -> Self {
-        Self::with_tool_decorator(Arc::new(SnapshotToolDecorator::new(Arc::new(
-            ProductSnapshotToolWrapper,
-        ))))
+        Self::for_profile(DeliveryProfile::ProductFull)
+    }
+
+    pub(crate) fn for_profile(profile: DeliveryProfile) -> Self {
+        Self::with_tool_decorator_and_assembly_plan(
+            Arc::new(SnapshotToolDecorator::new(Arc::new(
+                ProductSnapshotToolWrapper,
+            ))),
+            product_assembly_plan_for_profile(profile),
+        )
     }
 
     pub(crate) fn with_tool_decorator(tool_decorator: ProductToolDecoratorRef) -> Self {
-        Self { tool_decorator }
+        Self::with_tool_decorator_and_assembly_plan(
+            tool_decorator,
+            product_assembly_plan_for_profile(DeliveryProfile::ProductFull),
+        )
+    }
+
+    pub(crate) fn with_tool_decorator_and_assembly_plan(
+        tool_decorator: ProductToolDecoratorRef,
+        assembly_plan: ProductAssemblyPlan,
+    ) -> Self {
+        Self {
+            tool_decorator,
+            assembly_plan,
+        }
     }
 
     pub(crate) fn create_registry(&self) -> ToolRegistry {
-        let assembly = bitfun_product_capabilities::default_product_capability_assembly();
         let inner = create_product_tool_registry_from_plan(
-            assembly.tool_provider_group_plan(),
+            self.assembly_plan
+                .capability_assembly()
+                .tool_provider_group_plan(),
             self.tool_decorator.clone(),
         );
         ToolRegistry::from_inner(inner)
@@ -62,7 +87,7 @@ impl ProductToolRuntime {
 mod tests {
     use super::ProductToolRuntime;
     use crate::agentic::tools::registry::create_tool_registry;
-    use bitfun_product_capabilities::default_product_capability_assembly;
+    use bitfun_product_capabilities::{product_assembly_plan_for_profile, DeliveryProfile};
 
     #[test]
     fn product_tool_runtime_owner_preserves_registry_contract() {
@@ -84,7 +109,9 @@ mod tests {
 
     #[test]
     fn product_tool_runtime_registry_preserves_provider_plan_order() {
-        let assembly = default_product_capability_assembly();
+        let assembly = product_assembly_plan_for_profile(DeliveryProfile::ProductFull)
+            .capability_assembly()
+            .clone();
         let planned_names = assembly
             .tool_provider_group_plan()
             .iter()
@@ -93,5 +120,21 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(planned_names, create_tool_registry().get_tool_names());
+    }
+
+    #[test]
+    fn product_tool_runtime_can_consume_explicit_product_assembly_plan() {
+        let runtime = ProductToolRuntime::for_profile(DeliveryProfile::Cli);
+        let owner_registry = runtime.create_registry();
+        let compatibility_registry = create_tool_registry();
+
+        assert_eq!(
+            owner_registry.get_tool_names(),
+            compatibility_registry.get_tool_names()
+        );
+        assert_eq!(
+            owner_registry.get_collapsed_tool_names(),
+            compatibility_registry.get_collapsed_tool_names()
+        );
     }
 }

--- a/src/crates/core/src/lib.rs
+++ b/src/crates/core/src/lib.rs
@@ -12,6 +12,8 @@ pub mod function_agents; // Function-based agents
 pub mod infrastructure; // AI clients, storage, logging, events
 #[cfg(feature = "product-domains")]
 pub mod miniapp; // AI-generated instant apps (Zero-Dialect Runtime)
+#[cfg(feature = "product-full")]
+pub mod product_assembly;
 #[cfg(feature = "product-domains")]
 pub(crate) mod product_domain_runtime;
 pub mod service; // Workspace, Config, FileSystem, Terminal, Git

--- a/src/crates/core/src/product_assembly.rs
+++ b/src/crates/core/src/product_assembly.rs
@@ -1,0 +1,91 @@
+//! Product assembly compatibility boundary for the full core runtime.
+//!
+//! This module registers existing core concrete adapters into typed runtime
+//! service builders. It does not create new runtime behavior.
+
+use std::sync::Arc;
+
+use bitfun_runtime_ports::{
+    GitPort, McpCatalogPort, NetworkPort, RemoteProjectionPort, RemoteWorkspacePort,
+    RuntimeServiceCapability, RuntimeServicePort, SessionStorePort, TerminalPort,
+};
+use bitfun_runtime_services::{RuntimeServicesBuilder, RuntimeServicesProvider};
+
+use crate::agentic::session::CoreSessionStorePort;
+
+#[cfg(feature = "service-integrations")]
+use crate::service_agent_runtime::{
+    CoreRemoteWorkspaceFileRuntimeHost, CoreRemoteWorkspaceRuntimeHost,
+};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CoreRuntimeServicesProvider;
+
+impl CoreRuntimeServicesProvider {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl RuntimeServicesProvider for CoreRuntimeServicesProvider {
+    fn register(&self, builder: RuntimeServicesBuilder) -> RuntimeServicesBuilder {
+        let session_store: Arc<dyn SessionStorePort> = Arc::new(CoreSessionStorePort);
+        let terminal: Arc<dyn TerminalPort> = Arc::new(CoreRuntimeServiceMarkerPort::new(
+            RuntimeServiceCapability::Terminal,
+        ));
+        let network: Arc<dyn NetworkPort> = Arc::new(CoreRuntimeServiceMarkerPort::new(
+            RuntimeServiceCapability::Network,
+        ));
+        let git: Arc<dyn GitPort> = Arc::new(CoreRuntimeServiceMarkerPort::new(
+            RuntimeServiceCapability::Git,
+        ));
+        let mcp_catalog: Arc<dyn McpCatalogPort> = Arc::new(CoreRuntimeServiceMarkerPort::new(
+            RuntimeServiceCapability::McpCatalog,
+        ));
+        let builder = builder
+            .with_session_store(session_store)
+            .with_optional_terminal(Some(terminal))
+            .with_optional_network(Some(network))
+            .with_optional_git(Some(git))
+            .with_optional_mcp_catalog(Some(mcp_catalog));
+
+        #[cfg(feature = "service-integrations")]
+        {
+            let remote_workspace: Arc<dyn RemoteWorkspacePort> =
+                Arc::new(CoreRemoteWorkspaceRuntimeHost::new());
+            let remote_projection: Arc<dyn RemoteProjectionPort> =
+                Arc::new(CoreRemoteWorkspaceFileRuntimeHost::new());
+
+            builder
+                .with_optional_remote_workspace(Some(remote_workspace))
+                .with_optional_remote_projection(Some(remote_projection))
+        }
+
+        #[cfg(not(feature = "service-integrations"))]
+        {
+            builder
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CoreRuntimeServiceMarkerPort {
+    capability: RuntimeServiceCapability,
+}
+
+impl CoreRuntimeServiceMarkerPort {
+    const fn new(capability: RuntimeServiceCapability) -> Self {
+        Self { capability }
+    }
+}
+
+impl RuntimeServicePort for CoreRuntimeServiceMarkerPort {
+    fn capability(&self) -> RuntimeServiceCapability {
+        self.capability
+    }
+}
+
+impl TerminalPort for CoreRuntimeServiceMarkerPort {}
+impl NetworkPort for CoreRuntimeServiceMarkerPort {}
+impl GitPort for CoreRuntimeServiceMarkerPort {}
+impl McpCatalogPort for CoreRuntimeServiceMarkerPort {}

--- a/src/crates/core/tests/product_assembly.rs
+++ b/src/crates/core/tests/product_assembly.rs
@@ -1,0 +1,51 @@
+use bitfun_core::product_assembly::CoreRuntimeServicesProvider;
+use bitfun_product_capabilities::{
+    product_assembly_plan_for_profile, DeliveryProfile, ProductServiceCapabilityStatus,
+};
+use bitfun_runtime_ports::RuntimeServiceCapability;
+use bitfun_runtime_services::test_support::FakeRuntimeServicesProvider;
+use bitfun_runtime_services::{RuntimeServicesBuilder, RuntimeServicesRegistry};
+
+#[test]
+fn core_runtime_services_provider_registers_existing_adapters_and_capability_markers() {
+    let registry = RuntimeServicesRegistry::new()
+        .with_provider(FakeRuntimeServicesProvider::with_all_required())
+        .with_provider(CoreRuntimeServicesProvider::new());
+
+    let services = registry
+        .build(RuntimeServicesBuilder::new())
+        .expect("core product assembly provider should register concrete adapters");
+
+    assert_eq!(
+        services.session_store.capability(),
+        RuntimeServiceCapability::SessionStore
+    );
+    assert!(services.has_capability(RuntimeServiceCapability::Terminal));
+    assert!(services.has_capability(RuntimeServiceCapability::Network));
+    assert!(services.has_capability(RuntimeServiceCapability::Git));
+    assert!(services.has_capability(RuntimeServiceCapability::McpCatalog));
+    assert!(services.has_capability(RuntimeServiceCapability::RemoteWorkspace));
+    assert!(services.has_capability(RuntimeServiceCapability::RemoteProjection));
+}
+
+#[test]
+fn core_provider_closes_current_product_full_service_capability_requirements() {
+    let registry = RuntimeServicesRegistry::new()
+        .with_provider(FakeRuntimeServicesProvider::with_all_required())
+        .with_provider(CoreRuntimeServicesProvider::new());
+    let services = registry
+        .build(RuntimeServicesBuilder::new())
+        .expect("core product assembly provider should build with required services");
+    let plan = product_assembly_plan_for_profile(DeliveryProfile::ProductFull);
+
+    let unavailable = plan
+        .service_availability_report(|capability| services.has_capability(capability))
+        .into_iter()
+        .filter(|entry| entry.status() == ProductServiceCapabilityStatus::Unavailable)
+        .collect::<Vec<_>>();
+
+    assert!(
+        unavailable.is_empty(),
+        "product-full service requirements must be explicitly satisfied: {unavailable:?}"
+    );
+}

--- a/src/crates/product-capabilities/src/lib.rs
+++ b/src/crates/product-capabilities/src/lib.rs
@@ -79,10 +79,112 @@ impl ProductCapabilityPack {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum DeliveryProfile {
+    ProductFull,
+    Desktop,
+    Cli,
+    Server,
+    Remote,
+    Acp,
+    Web,
+}
+
+impl DeliveryProfile {
+    pub const fn id(self) -> &'static str {
+        match self {
+            Self::ProductFull => "product-full",
+            Self::Desktop => "desktop",
+            Self::Cli => "cli",
+            Self::Server => "server",
+            Self::Remote => "remote",
+            Self::Acp => "acp",
+            Self::Web => "web",
+        }
+    }
+
+    pub const fn all_current_product_profiles() -> &'static [DeliveryProfile] {
+        &[
+            Self::ProductFull,
+            Self::Desktop,
+            Self::Cli,
+            Self::Server,
+            Self::Remote,
+            Self::Acp,
+            Self::Web,
+        ]
+    }
+}
+
+impl fmt::Display for DeliveryProfile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.id())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ProductServiceCapabilityRequirement {
     capability_id: ProductCapabilityId,
     service_capability: RuntimeServiceCapability,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ProductServiceCapabilityStatus {
+    Available,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProductServiceCapabilityAvailability {
+    requirement: ProductServiceCapabilityRequirement,
+    status: ProductServiceCapabilityStatus,
+}
+
+impl ProductServiceCapabilityAvailability {
+    pub const fn new(
+        requirement: ProductServiceCapabilityRequirement,
+        status: ProductServiceCapabilityStatus,
+    ) -> Self {
+        Self {
+            requirement,
+            status,
+        }
+    }
+
+    pub const fn requirement(self) -> ProductServiceCapabilityRequirement {
+        self.requirement
+    }
+
+    pub const fn status(self) -> ProductServiceCapabilityStatus {
+        self.status
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProductCapabilitySet {
+    ids: Vec<ProductCapabilityId>,
+}
+
+impl ProductCapabilitySet {
+    pub fn new(ids: Vec<ProductCapabilityId>) -> Self {
+        let mut deduped = Vec::new();
+        for id in ids {
+            if !deduped.contains(&id) {
+                deduped.push(id);
+            }
+        }
+        Self { ids: deduped }
+    }
+
+    pub fn ids(&self) -> &[ProductCapabilityId] {
+        &self.ids
+    }
+
+    pub fn contains(&self, id: ProductCapabilityId) -> bool {
+        self.ids.contains(&id)
+    }
 }
 
 impl ProductServiceCapabilityRequirement {
@@ -111,6 +213,65 @@ pub struct ProductCapabilityAssembly {
     service_requirements: Vec<ProductServiceCapabilityRequirement>,
     tool_provider_group_plan: Vec<ToolProviderGroupPlan>,
     harness_provider_descriptors: Vec<HarnessProviderDescriptor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProductAssemblyPlan {
+    profile: DeliveryProfile,
+    capability_set: ProductCapabilitySet,
+    capability_assembly: ProductCapabilityAssembly,
+}
+
+impl ProductAssemblyPlan {
+    pub fn new(
+        profile: DeliveryProfile,
+        capability_set: ProductCapabilitySet,
+        capability_assembly: ProductCapabilityAssembly,
+    ) -> Self {
+        Self {
+            profile,
+            capability_set,
+            capability_assembly,
+        }
+    }
+
+    pub const fn profile(&self) -> DeliveryProfile {
+        self.profile
+    }
+
+    pub fn capability_set(&self) -> &ProductCapabilitySet {
+        &self.capability_set
+    }
+
+    pub fn capability_assembly(&self) -> &ProductCapabilityAssembly {
+        &self.capability_assembly
+    }
+
+    pub fn service_availability_report<F>(
+        &self,
+        mut is_available: F,
+    ) -> Vec<ProductServiceCapabilityAvailability>
+    where
+        F: FnMut(RuntimeServiceCapability) -> bool,
+    {
+        self.capability_assembly
+            .service_requirements()
+            .iter()
+            .copied()
+            .map(|requirement| {
+                let status = if is_available(requirement.service_capability()) {
+                    ProductServiceCapabilityStatus::Available
+                } else {
+                    ProductServiceCapabilityStatus::Unavailable
+                };
+                ProductServiceCapabilityAvailability::new(requirement, status)
+            })
+            .collect()
+    }
+
+    pub fn build_harness_registry(&self) -> Result<HarnessRegistry, HarnessRegistryBuildError> {
+        self.capability_assembly.build_harness_registry()
+    }
 }
 
 impl ProductCapabilityAssembly {
@@ -277,6 +438,16 @@ impl ProductCapabilityRegistry {
         self.try_build_assembly()
             .expect("product capability packs must build a valid assembly")
     }
+
+    pub fn capability_set(self) -> ProductCapabilitySet {
+        ProductCapabilitySet::new(self.capability_ids())
+    }
+
+    pub fn build_assembly_plan(self, profile: DeliveryProfile) -> ProductAssemblyPlan {
+        let capability_set = self.capability_set();
+        let capability_assembly = self.build_assembly();
+        ProductAssemblyPlan::new(profile, capability_set, capability_assembly)
+    }
 }
 
 const CODE_AGENT_SERVICES: &[RuntimeServiceCapability] = &[
@@ -286,6 +457,7 @@ const CODE_AGENT_SERVICES: &[RuntimeServiceCapability] = &[
     RuntimeServiceCapability::Permission,
     RuntimeServiceCapability::Events,
     RuntimeServiceCapability::Clock,
+    RuntimeServiceCapability::Terminal,
 ];
 const DEEP_REVIEW_SERVICES: &[RuntimeServiceCapability] = &[
     RuntimeServiceCapability::Workspace,
@@ -384,6 +556,14 @@ pub fn default_product_capability_registry() -> ProductCapabilityRegistry {
 
 pub fn default_product_capability_assembly() -> ProductCapabilityAssembly {
     default_product_capability_registry().build_assembly()
+}
+
+pub fn product_assembly_plan_for_profile(profile: DeliveryProfile) -> ProductAssemblyPlan {
+    default_product_capability_registry().build_assembly_plan(profile)
+}
+
+pub fn default_product_assembly_plan() -> ProductAssemblyPlan {
+    product_assembly_plan_for_profile(DeliveryProfile::ProductFull)
 }
 
 pub fn default_product_harness_registry() -> Result<HarnessRegistry, HarnessRegistryBuildError> {

--- a/src/crates/product-capabilities/tests/product_capabilities.rs
+++ b/src/crates/product-capabilities/tests/product_capabilities.rs
@@ -1,8 +1,10 @@
 use bitfun_harness::{HarnessCapability, HarnessWorkflow};
 use bitfun_product_capabilities::{
-    default_product_capability_assembly, default_product_capability_registry,
-    default_product_harness_registry, ProductCapabilityBuildError, ProductCapabilityId,
-    ProductCapabilityPack, ProductCapabilityRegistry, ProductServiceCapabilityRequirement,
+    default_product_assembly_plan, default_product_capability_assembly,
+    default_product_capability_registry, default_product_harness_registry,
+    product_assembly_plan_for_profile, DeliveryProfile, ProductCapabilityBuildError,
+    ProductCapabilityId, ProductCapabilityPack, ProductCapabilityRegistry,
+    ProductServiceCapabilityRequirement, ProductServiceCapabilityStatus,
 };
 use bitfun_runtime_ports::RuntimeServiceCapability;
 
@@ -103,6 +105,76 @@ fn capability_packs_describe_service_tool_and_harness_requirements() {
 }
 
 #[test]
+fn product_assembly_plan_makes_delivery_profile_explicit_without_reducing_capabilities() {
+    let expected_capabilities = vec!["code-agent", "deep-review", "deep-research", "miniapp"];
+    let expected_tool_groups = vec![
+        "core.basic",
+        "core.agent",
+        "core.session",
+        "core.integration",
+    ];
+
+    for profile in DeliveryProfile::all_current_product_profiles()
+        .iter()
+        .copied()
+    {
+        let plan = product_assembly_plan_for_profile(profile);
+
+        assert_eq!(plan.profile(), profile);
+        assert_eq!(
+            plan.capability_set()
+                .ids()
+                .iter()
+                .map(|capability_id| capability_id.id())
+                .collect::<Vec<_>>(),
+            expected_capabilities,
+            "{profile} must preserve the current product-full capability set until explicit trimming is proven"
+        );
+        assert_eq!(
+            plan.capability_assembly()
+                .tool_provider_group_plan()
+                .iter()
+                .map(|group| group.provider_id())
+                .collect::<Vec<_>>(),
+            expected_tool_groups,
+            "{profile} must preserve current tool provider groups"
+        );
+    }
+}
+
+#[test]
+fn product_assembly_plan_reports_service_availability_by_capability() {
+    let plan = default_product_assembly_plan();
+
+    let unavailable = plan
+        .service_availability_report(|capability| {
+            !matches!(
+                capability,
+                RuntimeServiceCapability::Git | RuntimeServiceCapability::Network
+            )
+        })
+        .into_iter()
+        .filter(|entry| entry.status() == ProductServiceCapabilityStatus::Unavailable)
+        .collect::<Vec<_>>();
+
+    assert_eq!(unavailable.len(), 2);
+    assert_eq!(
+        unavailable[0].requirement(),
+        ProductServiceCapabilityRequirement::new(
+            ProductCapabilityId::DeepReview,
+            RuntimeServiceCapability::Git,
+        )
+    );
+    assert_eq!(
+        unavailable[1].requirement(),
+        ProductServiceCapabilityRequirement::new(
+            ProductCapabilityId::DeepResearch,
+            RuntimeServiceCapability::Network,
+        )
+    );
+}
+
+#[test]
 fn default_capability_assembly_keeps_service_tool_and_harness_facts_together() {
     let assembly = default_product_capability_assembly();
 
@@ -126,6 +198,7 @@ fn default_capability_assembly_keeps_service_tool_and_harness_facts_together() {
             RuntimeServiceCapability::Permission,
             RuntimeServiceCapability::Events,
             RuntimeServiceCapability::Clock,
+            RuntimeServiceCapability::Terminal,
             RuntimeServiceCapability::Git,
             RuntimeServiceCapability::Network,
         ]


### PR DESCRIPTION
﻿## Summary

- Add Product Assembly plan support with `DeliveryProfile`, `CapabilitySet`, tool/harness provider plans, and service availability reporting.
- Route core product tool runtime and harness registry through the explicit Product Assembly plan while preserving existing `product-full` output.
- Add a core Product Assembly runtime services provider for existing session-store and remote workspace/projection adapters plus current product capability markers; update boundary checks and active/completed plan docs.

## Risk / behavior

- No product behavior, tool schema, permission, UI, release feature, or execution semantics change is intended.
- Terminal/Git/Network/MCP entries are availability markers unless the existing port already owns concrete methods; execution remains in existing core paths.
- Per-delivery feature trimming, search concrete, AI provider acquisition, and deeper Tool/Agent Runtime owner migration remain out of scope.

## Verification

- `cargo test -p bitfun-product-capabilities`
- `cargo test -p bitfun-runtime-services`
- `cargo test -p bitfun-core --test product_assembly --features product-full -- --nocapture`
- `cargo test -p bitfun-core product_tool_runtime --features product-full -- --nocapture`
- `cargo test -p bitfun-core product_harness_registry --features product-full -- --nocapture`
- `cargo check -p bitfun-core --features product-full`
- `cargo check -p bitfun-core --no-default-features`
- `node scripts/check-core-boundaries.mjs`
- `pnpm run check:repo-hygiene`
- `git diff --check`
- `cargo check --workspace`

Refs #970
