### PR TITLE
refactor(tool-runtime): move remote tool execution helpers

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -38,6 +38,8 @@
   collapsed unlock gate、static provider materialization 和 plan-to-registry assembly。
 - `tool-runtime` 已承接本地 Write / Edit / Delete / Glob 的低风险 concrete IO primitive；core 保留 agent-facing
   `Tool` adapter、权限、checkpoint、file-read freshness、remote fallback 和具体 tool context。
+- `tool-runtime` 已承接远程 Delete / Read / LS / Glob / Grep 的命令规划、stdout/stderr 规整、marker 解析、
+  path display 和 offset/limit windowing 等低层 execution helper；core 仍负责 workspace shell 执行和 ToolResult 包装。
 - GetToolSpec concrete adapter、manifest resolver、visible tools、readonly catalog、snapshot wrapper、collapsed unlock
   message-derived state 已收敛到 product/tool runtime owner 边界。
 - `tool-packs` 已承接 tool provider group plan、按 id 选择和 unknown provider group 校验。
@@ -76,7 +78,7 @@
 - 已有 focused baseline 覆盖 tool manifest、GetToolSpec、execution admission、MiniApp storage / builtin asset、
   remote workspace fallback、MCP config/catalog、agent-runtime prompt cache、custom subagent、thread-goal tools、
   AskUserQuestion、DeepReview hook measurement、tool confirmation、product capability pack、session restore、
-  local tool IO、function-agent Git、scheduled-job state 等路径。
+  local/remote tool IO helper、function-agent Git、scheduled-job state 等路径。
 - 构建脚本、installer 和发布形态不是 core decomposition 迁移的默认修改范围。
 
 ## 3. 明确未完成边界
@@ -86,6 +88,7 @@
   但尚未完成按交付形态裁剪 feature / dependency。
 - concrete session manager、scheduler lifecycle、event delivery、permission UI/channel wait、prompt assembly、
   session persistence IO、AI client factory / provider acquisition 仍在 core。
-- Bash / terminal lifecycle、indexed workspace search、remote shell execution、remote FS / terminal concrete impl、
-  MiniApp worker / host / seed / marker IO、Deep Review / DeepResearch / MiniApp concrete workflow execution 仍未完成 owner 迁移。
+- Bash tool orchestration、terminal lifecycle / PTY、indexed workspace search service owner、remote shell executor abstraction、
+  remote terminal concrete impl、MiniApp worker / host / seed / marker IO、Deep Review / DeepResearch / MiniApp concrete workflow execution
+  仍未完成 owner 迁移。
 - feature matrix、dependency trimming、build-benefit 仍未用 `cargo metadata` / `cargo tree` / build check 数据闭环。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -71,21 +71,27 @@ Runtime Services provider 组合显式化。但当前代码仍未达到设计文
 - `cargo test -p bitfun-runtime-services`
 - 涉及 remote / terminal / search / Git / AI 时补对应 focused tests。
 
-### 4.2 M2：Tool Runtime concrete execution 闭环
+### 4.2 M2（当前变更已闭环）：Tool Runtime concrete IO/search execution helper
 
-目标：让 Tool Runtime 不再只承接 manifest / admission，而是接管可证明等价的工具执行管线主体。
+目标：在不改变产品工具语义的前提下，让 `tool-runtime` 接管低层 filesystem / search 工具中可证明等价的执行 helper，
+减少 core 对 remote shell 命令形态、stdout/stderr marker 和结果窗口裁剪的直接理解。
 
-- 迁移 Bash、terminal lifecycle、indexed workspace search、remote shell execution 中可被 port/provider 保护的执行主体。
-- 将 permission gate、tool execution services、result/artifact policy、tool hook 顺序和 cancellation 语义收敛到 Tool Runtime 边界。
-- core 保留 agent-facing `Tool` adapter、旧 import path、UI/channel 副作用和必要 checkpoint adapter。
-- 继续保护 prompt-visible manifest、GetToolSpec、readonly/enabled filtering、expanded/collapsed exposure、MCP/ACP catalog。
+完成口径：
+- `tool-runtime` 承接远程 Delete 命令规划、Read awk 命令规划与 marker 解析、LS 命令规划与 stdout entry 规整。
+- `tool-runtime` 承接远程 Glob stdout 规整，以及远程 Grep 命令规划、result text 规整、match count 和 offset/limit windowing。
+- core 删除对应重复拼接/解析逻辑，只保留 agent-facing `Tool` adapter、`ToolUseContext` path resolution、workspace shell 执行、
+  checkpoint、UI/channel 副作用和 `ToolResult` 包装。
+- `agent-tools` 继续拥有 manifest / admission / GetToolSpec 等 provider-neutral contract；`terminal-core` 继续拥有 PTY 与 terminal lifecycle。
 
-**不混入：** 改变工具 schema、权限默认值、checkpoint 语义、remote fallback、shell 工作目录或 terminal prewarm 行为。
+**不混入：** 改变工具 schema、权限默认值、checkpoint 语义、remote fallback、shell 工作目录、terminal prewarm / PTY lifecycle、
+prompt-visible manifest、GetToolSpec、readonly/enabled filtering、expanded/collapsed exposure、MCP/ACP catalog。
 
 **门禁：**
+- `cargo test -p tool-runtime`
 - `cargo test -p bitfun-agent-tools`
-- `cargo test -p bitfun-tool-runtime`
-- tool manifest / GetToolSpec / Bash / terminal / search / remote shell focused tests
+- core Grep / remote filesystem focused tests
+- `cargo check --workspace`
+- `pnpm run check:repo-hygiene`
 - `node scripts/check-core-boundaries.mjs`
 
 ### 4.3 M3：Agent Runtime concrete lifecycle 闭环

--- a/src/crates/core/src/agentic/tools/implementations/delete_file_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/delete_file_tool.rs
@@ -7,7 +7,10 @@ use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use std::path::Path;
-use tool_runtime::fs::{delete_local_path, inspect_local_delete_target, DeleteLocalPathRequest};
+use tool_runtime::fs::{
+    build_remote_delete_command, delete_local_path, inspect_local_delete_target,
+    DeleteLocalPathRequest,
+};
 
 /// File deletion tool - provides safe file/directory deletion functionality
 ///
@@ -314,11 +317,7 @@ Important notes:
                 BitFunError::tool("Workspace shell not available for remote Delete".to_string())
             })?;
 
-            let rm_cmd = if recursive {
-                format!("rm -rf '{}'", resolved.resolved_path.replace('\'', "'\\''"))
-            } else {
-                format!("rm -f '{}'", resolved.resolved_path.replace('\'', "'\\''"))
-            };
+            let rm_cmd = build_remote_delete_command(&resolved.resolved_path, recursive);
 
             let (_stdout, stderr, exit_code) = ws_shell
                 .exec(&rm_cmd, Some(15_000))

--- a/src/crates/core/src/agentic/tools/implementations/file_read_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/file_read_tool.rs
@@ -12,7 +12,7 @@ use log::{debug, warn};
 use serde_json::{json, Value};
 use std::path::Path;
 use std::time::Instant;
-use tool_runtime::fs::read_file::read_file;
+use tool_runtime::fs::read_file::{build_remote_read_command, parse_remote_read_output, read_file};
 
 pub struct FileReadTool {
     default_max_lines_to_read: usize,
@@ -57,28 +57,18 @@ impl FileReadTool {
         limit: usize,
         context: &ToolUseContext,
     ) -> BitFunResult<tool_runtime::fs::read_file::ReadFileResult> {
-        const TOTAL_LINES_MARKER: &str = "__BITFUN_TOTAL_LINES__=";
-        const HIT_TOTAL_CHAR_LIMIT_MARKER: &str = "__BITFUN_HIT_TOTAL_CHAR_LIMIT__=";
-
-        let end_line = start_line
-            .checked_add(limit.saturating_sub(1))
-            .ok_or_else(|| BitFunError::tool("Requested line range is too large".to_string()))?;
-
         let ws_shell = context.ws_shell().ok_or_else(|| {
             BitFunError::tool("Remote workspace shell is unavailable".to_string())
         })?;
 
-        let escaped_path = shell_escape(resolved_path);
-        let command = format!(
-            "if [ ! -f {path} ]; then exit 3; fi; awk -v start={start} -v end={end} -v max={max} -v budget={budget} 'BEGIN {{ total = 0; used = 0; hit = 0; }} {{ total = NR; if (!hit && NR >= start && NR <= end) {{ line = $0; if (length(line) > max) {{ line = substr(line, 1, max) \" [truncated]\"; }} rendered = sprintf(\"%6d\\t%s\", NR, line); extra = (used > 0 ? 1 : 0); next_used = used + extra + length(rendered); if (next_used > budget) {{ hit = 1; next; }} print rendered; used = next_used; }} }} END {{ printf(\"{marker}%d\\n\", total) > \"/dev/stderr\"; printf(\"{hit_marker}%d\\n\", hit) > \"/dev/stderr\"; }}' {path}",
-            path = escaped_path,
-            start = start_line,
-            end = end_line,
-            max = self.max_line_chars,
-            budget = self.max_total_chars,
-            marker = TOTAL_LINES_MARKER,
-            hit_marker = HIT_TOTAL_CHAR_LIMIT_MARKER,
-        );
+        let command = build_remote_read_command(
+            resolved_path,
+            start_line,
+            limit,
+            self.max_line_chars,
+            self.max_total_chars,
+        )
+        .map_err(BitFunError::tool)?;
 
         let remote_read_started_at = Instant::now();
         debug!(
@@ -115,90 +105,21 @@ impl FileReadTool {
             elapsed_ms_u64(remote_read_started_at)
         );
 
-        let mut total_lines = None;
-        let mut hit_total_char_limit = false;
-        let mut stderr_messages = Vec::new();
-        for line in stderr.lines() {
-            if let Some(rest) = line.strip_prefix(TOTAL_LINES_MARKER) {
-                total_lines = rest.trim().parse::<usize>().ok();
-            } else if let Some(rest) = line.strip_prefix(HIT_TOTAL_CHAR_LIMIT_MARKER) {
-                hit_total_char_limit = rest.trim() == "1";
-            } else if !line.trim().is_empty() {
-                stderr_messages.push(line.to_string());
-            }
-        }
-
-        if status != 0 {
-            let message = if status == 3 {
-                format!("File not found or not a regular file: {}", resolved_path)
-            } else if !stderr_messages.is_empty() {
-                stderr_messages.join("\n")
-            } else {
-                format!(
-                    "Failed to read file: remote command exited with status {}",
-                    status
-                )
-            };
-            return Err(BitFunError::tool(message));
-        }
-
-        let total_lines = total_lines.ok_or_else(|| {
-            BitFunError::tool(
-                "Failed to read file: remote command did not return line-count markers".to_string(),
-            )
-        })?;
-
-        if total_lines == 0 {
-            return Ok(tool_runtime::fs::read_file::ReadFileResult {
-                start_line: 0,
-                end_line: 0,
-                total_lines: 0,
-                content: String::new(),
-                hit_total_char_limit,
-            });
-        }
-
-        if start_line > total_lines {
-            return Err(BitFunError::tool(format!(
-                "`start_line` {} is larger than the number of lines in the file: {}",
-                start_line, total_lines
-            )));
-        }
-
-        let content = stdout.trim_end_matches('\n').to_string();
-        let lines_read = if content.is_empty() {
-            0
-        } else {
-            content.lines().count()
-        };
-        let end_line = if lines_read == 0 {
-            start_line
-        } else {
-            (start_line + lines_read).saturating_sub(1)
-        };
+        let result = parse_remote_read_output(&stdout, &stderr, status, resolved_path, start_line)
+            .map_err(BitFunError::tool)?;
 
         debug!(
             "Remote file read parsed successfully: path={}, start_line={}, end_line={}, total_lines={}, hit_total_char_limit={}, duration_ms={}",
             resolved_path,
-            start_line,
-            end_line,
-            total_lines,
-            hit_total_char_limit,
+            result.start_line,
+            result.end_line,
+            result.total_lines,
+            result.hit_total_char_limit,
             elapsed_ms_u64(remote_read_started_at)
         );
 
-        Ok(tool_runtime::fs::read_file::ReadFileResult {
-            start_line,
-            end_line,
-            total_lines,
-            content,
-            hit_total_char_limit,
-        })
+        Ok(result)
     }
-}
-
-fn shell_escape(s: &str) -> String {
-    format!("'{}'", s.replace('\'', "'\\''"))
 }
 
 #[async_trait]

--- a/src/crates/core/src/agentic/tools/implementations/glob_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/glob_tool.rs
@@ -7,10 +7,10 @@ use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
 use log::{info, warn};
 use serde_json::{json, Value};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tool_runtime::search::glob_search::{
-    build_remote_find_command, build_remote_rg_command, execute_local_glob, limit_paths,
-    normalize_path, LocalGlobRequest,
+    build_remote_find_command, build_remote_rg_command, collect_remote_glob_matches,
+    execute_local_glob, normalize_path, LocalGlobRequest,
 };
 
 pub struct GlobTool;
@@ -227,15 +227,7 @@ impl Tool for GlobTool {
                     BitFunError::tool(format!("Failed to glob on remote with rg: {}", e))
                 })?;
 
-            let matches = stdout
-                .lines()
-                .filter(|l| !l.is_empty())
-                .map(|line| {
-                    let relative_path = line.strip_prefix("./").unwrap_or(line);
-                    Path::new(&search_dir).join(relative_path)
-                })
-                .collect::<Vec<_>>();
-            let limited = limit_paths(&matches, limit)
+            let limited = collect_remote_glob_matches(&search_dir, &stdout, limit)
                 .into_iter()
                 .map(|path| {
                     resolved

--- a/src/crates/core/src/agentic/tools/implementations/grep_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/grep_tool.rs
@@ -13,7 +13,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
 use tool_runtime::search::grep_search::{
-    grep_search, GrepOptions, GrepSearchResult, OutputMode, ProgressCallback,
+    apply_offset_and_limit, build_remote_grep_command, count_remote_grep_matches, grep_search,
+    relativize_result_text, render_remote_grep_result_text, GrepOptions, GrepSearchResult,
+    OutputMode, ProgressCallback, RemoteGrepCommandRequest,
 };
 
 const DEFAULT_HEAD_LIMIT: usize = 250;
@@ -58,10 +60,6 @@ impl GrepTool {
             .map(|limit| limit.saturating_add(offset))
     }
 
-    fn shell_escape(value: &str) -> String {
-        value.replace('\'', "'\\''")
-    }
-
     fn parse_glob_patterns(glob: Option<&str>) -> Vec<String> {
         let Some(glob) = glob else {
             return Vec::new();
@@ -98,29 +96,6 @@ impl GrepTool {
             .map(|workspace| workspace.root_path_string())
     }
 
-    fn relativize_result_text(result_text: &str, display_base: Option<&str>) -> String {
-        let Some(base) = display_base else {
-            return result_text.to_string();
-        };
-
-        let normalized_base = base.replace('\\', "/").trim_end_matches('/').to_string();
-        if normalized_base.is_empty() {
-            return result_text.to_string();
-        }
-
-        result_text
-            .lines()
-            .map(|line| {
-                if let Some(rest) = line.strip_prefix(&(normalized_base.clone() + "/")) {
-                    rest.to_string()
-                } else {
-                    line.to_string()
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
     async fn call_remote(
         &self,
         input: &Value,
@@ -146,6 +121,8 @@ impl GrepTool {
             .get("output_mode")
             .and_then(|v| v.as_str())
             .unwrap_or("files_with_matches");
+        let output_mode_enum =
+            OutputMode::from_str(output_mode).map_err(|e| BitFunError::tool(e.to_string()))?;
         let show_line_numbers = input
             .get("-n")
             .and_then(|v| v.as_bool())
@@ -154,86 +131,38 @@ impl GrepTool {
             .get("context")
             .or_else(|| input.get("-C"))
             .and_then(|v| v.as_u64())
-            .map(|v| v.to_string());
-        let before_context = input
-            .get("-B")
-            .and_then(|v| v.as_u64())
-            .map(|v| v.to_string());
-        let after_context = input
-            .get("-A")
-            .and_then(|v| v.as_u64())
-            .map(|v| v.to_string());
+            .map(|v| v as usize);
+        let before_context = input.get("-B").and_then(|v| v.as_u64()).map(|v| v as usize);
+        let after_context = input.get("-A").and_then(|v| v.as_u64()).map(|v| v as usize);
         let glob_patterns = Self::parse_glob_patterns(input.get("glob").and_then(|v| v.as_str()));
-        let file_type = input.get("type").and_then(|v| v.as_str());
+        let file_type = input
+            .get("type")
+            .and_then(|v| v.as_str())
+            .map(|value| value.to_string());
 
-        let escaped_path = Self::shell_escape(&resolved_path);
-        let escaped_pattern = Self::shell_escape(pattern);
-        let offset_cmd = if offset > 0 {
-            format!(" | tail -n +{}", offset + 1)
-        } else {
-            String::new()
-        };
-        let limit_cmd = head_limit
-            .map(|limit| format!(" | head -n {}", limit))
-            .unwrap_or_default();
-
-        let mut cmd = "rg --no-heading --hidden --max-columns 500".to_string();
-        if case_insensitive {
-            cmd.push_str(" -i");
-        }
-        if output_mode == "files_with_matches" {
-            cmd.push_str(" -l");
-        } else if output_mode == "count" {
-            cmd.push_str(" -c");
-        } else if show_line_numbers {
-            cmd.push_str(" --line-number");
-        }
-        if output_mode == "content" {
-            if let Some(context) = context_c {
-                cmd.push_str(&format!(" -C {}", context));
-            } else {
-                if let Some(before) = before_context {
-                    cmd.push_str(&format!(" -B {}", before));
-                }
-                if let Some(after) = after_context {
-                    cmd.push_str(&format!(" -A {}", after));
-                }
-            }
-        }
-        for glob_pattern in glob_patterns {
-            cmd.push_str(&format!(" --glob '{}'", Self::shell_escape(&glob_pattern)));
-        }
-        if let Some(ft) = file_type {
-            cmd.push_str(&format!(" --type '{}'", Self::shell_escape(ft)));
-        }
-        cmd.push_str(&format!(
-            " -e '{}' '{}' 2>/dev/null{}{}",
-            escaped_pattern, escaped_path, offset_cmd, limit_cmd
-        ));
-
-        let full_cmd = format!(
-            "if command -v rg >/dev/null 2>&1; then {}; else grep -rn{} -e '{}' '{}' 2>/dev/null{}{}; fi",
-            cmd,
-            if case_insensitive { "i" } else { "" },
-            escaped_pattern,
-            escaped_path,
-            offset_cmd,
-            limit_cmd,
-        );
+        let full_cmd = build_remote_grep_command(&RemoteGrepCommandRequest {
+            pattern: pattern.to_string(),
+            path: resolved_path,
+            case_insensitive,
+            output_mode: output_mode_enum,
+            show_line_numbers,
+            context: context_c,
+            before_context,
+            after_context,
+            glob_patterns,
+            file_type,
+            head_limit,
+            offset,
+        });
 
         let (stdout, _stderr, _exit_code) = ws_shell
             .exec(&full_cmd, Some(30_000))
             .await
             .map_err(|e| BitFunError::tool(format!("Remote grep failed: {}", e)))?;
 
-        let lines: Vec<&str> = stdout.lines().collect();
-        let total_matches = lines.len();
+        let total_matches = count_remote_grep_matches(&stdout);
         let display_base = Self::display_base(context);
-        let result_text = if lines.is_empty() {
-            format!("No matches found for pattern '{}'", pattern)
-        } else {
-            Self::relativize_result_text(&stdout, display_base.as_deref())
-        };
+        let result_text = render_remote_grep_result_text(&stdout, pattern, display_base.as_deref());
 
         Ok(vec![ToolResult::Result {
             data: json!({
@@ -432,7 +361,7 @@ impl GrepTool {
                     );
                 }
                 apply_offset_and_limit(&mut lines, offset, head_limit);
-                let rendered = Self::relativize_result_text(&lines.join("\n"), display_base);
+                let rendered = relativize_result_text(&lines.join("\n"), display_base);
                 let file_count = if result.hits.is_empty() {
                     result
                         .outcome
@@ -460,7 +389,7 @@ impl GrepTool {
                 lines.sort();
                 let mut lines = lines.into_iter().collect::<Vec<_>>();
                 apply_offset_and_limit(&mut lines, offset, head_limit);
-                let rendered = Self::relativize_result_text(&lines.join("\n"), display_base);
+                let rendered = relativize_result_text(&lines.join("\n"), display_base);
                 (rendered, result.file_counts.len(), result.matched_lines)
             }
             _ => {
@@ -473,7 +402,7 @@ impl GrepTool {
                 files.sort();
                 files.dedup();
                 apply_offset_and_limit(&mut files, offset, head_limit);
-                let rendered = Self::relativize_result_text(&files.join("\n"), display_base);
+                let rendered = relativize_result_text(&files.join("\n"), display_base);
                 let total_matches = files.len();
                 (rendered, total_matches, total_matches)
             }
@@ -532,22 +461,6 @@ fn render_workspace_search_content_lines(
     lines
 }
 
-fn apply_offset_and_limit(items: &mut Vec<String>, offset: usize, head_limit: Option<usize>) {
-    if offset > 0 {
-        if offset >= items.len() {
-            items.clear();
-        } else {
-            *items = items[offset..].to_vec();
-        }
-    }
-
-    if let Some(limit) = head_limit {
-        if items.len() > limit {
-            items.truncate(limit);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
@@ -561,6 +474,7 @@ mod tests {
         WorkspaceSearchRepoStatus,
     };
     use serde_json::json;
+    use tool_runtime::search::grep_search::relativize_result_text;
 
     #[test]
     fn head_limit_defaults_and_zero_escape_hatch() {
@@ -597,7 +511,7 @@ mod tests {
     #[test]
     fn relativizes_prefixed_result_lines() {
         let text = "/repo/src/main.rs:12:fn main()\n/repo/src/lib.rs:3:pub fn lib()";
-        let relativized = GrepTool::relativize_result_text(text, Some("/repo"));
+        let relativized = relativize_result_text(text, Some("/repo"));
 
         assert_eq!(
             relativized,

--- a/src/crates/core/src/agentic/tools/implementations/ls_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/ls_tool.rs
@@ -13,10 +13,7 @@ use chrono::{DateTime, Local};
 use serde_json::{json, Value};
 use std::path::Path;
 use std::time::SystemTime;
-
-fn shell_escape(s: &str) -> String {
-    format!("'{}'", s.replace('\'', "'\\''"))
-}
+use tool_runtime::fs::{build_remote_list_commands, parse_remote_list_entries};
 
 /// LS tool - list directory tree
 pub struct LSTool {
@@ -247,43 +244,22 @@ Usage:
                 BitFunError::tool("Workspace shell not available for remote LS".to_string())
             })?;
 
-            let ls_cmd = format!(
-                "find {} -maxdepth 1 -not -name '.*' -not -path {} | head -n {} | sort",
-                shell_escape(&resolved.resolved_path),
-                shell_escape(&resolved.resolved_path),
-                limit + 1
-            );
+            let list_commands = build_remote_list_commands(&resolved.resolved_path, limit);
 
-            let (stdout, _stderr, _exit_code) =
-                ws_shell.exec(&ls_cmd, Some(15_000)).await.map_err(|e| {
+            let (stdout, _stderr, _exit_code) = ws_shell
+                .exec(&list_commands.scan_command, Some(15_000))
+                .await
+                .map_err(|e| {
                     BitFunError::tool(format!("Failed to list remote directory: {}", e))
                 })?;
 
-            let mut file_lines = Vec::new();
-            let mut dir_lines = Vec::new();
-
-            for line in stdout.lines().filter(|l| !l.is_empty()) {
-                let name = Path::new(line)
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_else(|| line.to_string());
-                let is_dir = line.ends_with('/');
-                if is_dir || name.is_empty() {
-                    dir_lines.push((name, line.to_string()));
-                } else {
-                    file_lines.push((name, line.to_string()));
-                }
-            }
-
             // Use a simpler stat-based listing for the text output
-            let stat_cmd = format!(
-                "ls -la --time-style=long-iso {} 2>/dev/null || ls -la {}",
-                shell_escape(&resolved.resolved_path),
-                shell_escape(&resolved.resolved_path)
-            );
-            let (ls_output, _, _) = ws_shell.exec(&stat_cmd, Some(15_000)).await.map_err(|e| {
-                BitFunError::tool(format!("Failed to list remote directory: {}", e))
-            })?;
+            let (ls_output, _, _) = ws_shell
+                .exec(&list_commands.listing_command, Some(15_000))
+                .await
+                .map_err(|e| {
+                    BitFunError::tool(format!("Failed to list remote directory: {}", e))
+                })?;
 
             let result_text = format!(
                 "Directory listing: {}\n\n{}",
@@ -291,18 +267,13 @@ Usage:
                 ls_output.trim()
             );
 
-            let entries_json: Vec<Value> = stdout
-                .lines()
-                .filter(|l| !l.is_empty())
-                .map(|line| {
-                    let name = Path::new(line)
-                        .file_name()
-                        .map(|n| n.to_string_lossy().to_string())
-                        .unwrap_or_else(|| line.to_string());
+            let entries_json: Vec<Value> = parse_remote_list_entries(&stdout)
+                .into_iter()
+                .map(|entry| {
                     json!({
-                        "name": name,
-                        "path": line,
-                        "is_dir": line.ends_with('/'),
+                        "name": entry.name,
+                        "path": entry.path,
+                        "is_dir": entry.is_dir,
                     })
                 })
                 .collect();

--- a/src/crates/tool-runtime/src/fs/delete_path.rs
+++ b/src/crates/tool-runtime/src/fs/delete_path.rs
@@ -1,3 +1,4 @@
+use crate::util::string::shell_single_quote;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -74,4 +75,12 @@ pub fn delete_local_path(
         is_directory: target.is_directory,
         recursive: request.recursive,
     })
+}
+
+pub fn build_remote_delete_command(resolved_path: &str, recursive: bool) -> String {
+    if recursive {
+        format!("rm -rf {}", shell_single_quote(resolved_path))
+    } else {
+        format!("rm -f {}", shell_single_quote(resolved_path))
+    }
 }

--- a/src/crates/tool-runtime/src/fs/list_dir.rs
+++ b/src/crates/tool-runtime/src/fs/list_dir.rs
@@ -1,0 +1,48 @@
+use crate::util::string::shell_single_quote;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteListCommandPlan {
+    pub scan_command: String,
+    pub listing_command: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteListEntry {
+    pub name: String,
+    pub path: String,
+    pub is_dir: bool,
+}
+
+pub fn build_remote_list_commands(resolved_path: &str, limit: usize) -> RemoteListCommandPlan {
+    let quoted_path = shell_single_quote(resolved_path);
+    RemoteListCommandPlan {
+        scan_command: format!(
+            "find {path} -maxdepth 1 -not -name '.*' -not -path {path} | head -n {head_limit} | sort",
+            path = quoted_path,
+            head_limit = limit + 1,
+        ),
+        listing_command: format!(
+            "ls -la --time-style=long-iso {path} 2>/dev/null || ls -la {path}",
+            path = quoted_path,
+        ),
+    }
+}
+
+pub fn parse_remote_list_entries(stdout: &str) -> Vec<RemoteListEntry> {
+    stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            let name = Path::new(line)
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| line.to_string());
+            RemoteListEntry {
+                name,
+                path: line.to_string(),
+                is_dir: line.ends_with('/'),
+            }
+        })
+        .collect()
+}

--- a/src/crates/tool-runtime/src/fs/mod.rs
+++ b/src/crates/tool-runtime/src/fs/mod.rs
@@ -1,17 +1,21 @@
 pub mod backend;
 pub mod delete_path;
 pub mod edit_file;
+pub mod list_dir;
 pub mod read_file;
 pub mod write_file;
 
 pub use backend::{FileSystem, LocalFileSystem};
 pub use delete_path::{
-    delete_local_path, inspect_local_delete_target, DeleteLocalPathOutcome, DeleteLocalPathRequest,
-    LocalDeleteTarget,
+    build_remote_delete_command, delete_local_path, inspect_local_delete_target,
+    DeleteLocalPathOutcome, DeleteLocalPathRequest, LocalDeleteTarget,
 };
 pub use edit_file::{
     edit_local_file, edit_local_file_with_content, EditLocalFileOutcome, EditLocalFileRequest,
     EditLocalFileWithContentRequest,
+};
+pub use list_dir::{
+    build_remote_list_commands, parse_remote_list_entries, RemoteListCommandPlan, RemoteListEntry,
 };
 pub use write_file::{
     write_local_file, WriteLocalFileOutcome, WriteLocalFileRequest, WriteLocalFileStatus,

--- a/src/crates/tool-runtime/src/fs/read_file.rs
+++ b/src/crates/tool-runtime/src/fs/read_file.rs
@@ -1,7 +1,10 @@
-use crate::util::string::truncate_string_by_chars;
+use crate::util::string::{shell_single_quote, truncate_string_by_chars};
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
+
+const REMOTE_TOTAL_LINES_MARKER: &str = "__BITFUN_TOTAL_LINES__=";
+const REMOTE_HIT_TOTAL_CHAR_LIMIT_MARKER: &str = "__BITFUN_HIT_TOTAL_CHAR_LIMIT__=";
 
 #[derive(Debug)]
 pub struct ReadFileResult {
@@ -10,6 +13,106 @@ pub struct ReadFileResult {
     pub total_lines: usize,
     pub content: String,
     pub hit_total_char_limit: bool,
+}
+
+pub fn build_remote_read_command(
+    resolved_path: &str,
+    start_line: usize,
+    limit: usize,
+    max_line_chars: usize,
+    max_total_chars: usize,
+) -> Result<String, String> {
+    let end_line = start_line
+        .checked_add(limit.saturating_sub(1))
+        .ok_or_else(|| "Requested line range is too large".to_string())?;
+    let escaped_path = shell_single_quote(resolved_path);
+
+    Ok(format!(
+        "if [ ! -f {path} ]; then exit 3; fi; awk -v start={start} -v end={end} -v max={max} -v budget={budget} 'BEGIN {{ total = 0; used = 0; hit = 0; }} {{ total = NR; if (!hit && NR >= start && NR <= end) {{ line = $0; if (length(line) > max) {{ line = substr(line, 1, max) \" [truncated]\"; }} rendered = sprintf(\"%6d\\t%s\", NR, line); extra = (used > 0 ? 1 : 0); next_used = used + extra + length(rendered); if (next_used > budget) {{ hit = 1; next; }} print rendered; used = next_used; }} }} END {{ printf(\"{marker}%d\\n\", total) > \"/dev/stderr\"; printf(\"{hit_marker}%d\\n\", hit) > \"/dev/stderr\"; }}' {path}",
+        path = escaped_path,
+        start = start_line,
+        end = end_line,
+        max = max_line_chars,
+        budget = max_total_chars,
+        marker = REMOTE_TOTAL_LINES_MARKER,
+        hit_marker = REMOTE_HIT_TOTAL_CHAR_LIMIT_MARKER,
+    ))
+}
+
+pub fn parse_remote_read_output(
+    stdout: &str,
+    stderr: &str,
+    status: i32,
+    resolved_path: &str,
+    start_line: usize,
+) -> Result<ReadFileResult, String> {
+    let mut total_lines = None;
+    let mut hit_total_char_limit = false;
+    let mut stderr_messages = Vec::new();
+    for line in stderr.lines() {
+        if let Some(rest) = line.strip_prefix(REMOTE_TOTAL_LINES_MARKER) {
+            total_lines = rest.trim().parse::<usize>().ok();
+        } else if let Some(rest) = line.strip_prefix(REMOTE_HIT_TOTAL_CHAR_LIMIT_MARKER) {
+            hit_total_char_limit = rest.trim() == "1";
+        } else if !line.trim().is_empty() {
+            stderr_messages.push(line.to_string());
+        }
+    }
+
+    if status != 0 {
+        let message = if status == 3 {
+            format!("File not found or not a regular file: {}", resolved_path)
+        } else if !stderr_messages.is_empty() {
+            stderr_messages.join("\n")
+        } else {
+            format!(
+                "Failed to read file: remote command exited with status {}",
+                status
+            )
+        };
+        return Err(message);
+    }
+
+    let total_lines = total_lines.ok_or_else(|| {
+        "Failed to read file: remote command did not return line-count markers".to_string()
+    })?;
+
+    if total_lines == 0 {
+        return Ok(ReadFileResult {
+            start_line: 0,
+            end_line: 0,
+            total_lines: 0,
+            content: String::new(),
+            hit_total_char_limit,
+        });
+    }
+
+    if start_line > total_lines {
+        return Err(format!(
+            "`start_line` {} is larger than the number of lines in the file: {}",
+            start_line, total_lines
+        ));
+    }
+
+    let content = stdout.trim_end_matches('\n').to_string();
+    let lines_read = if content.is_empty() {
+        0
+    } else {
+        content.lines().count()
+    };
+    let end_line = if lines_read == 0 {
+        start_line
+    } else {
+        (start_line + lines_read).saturating_sub(1)
+    };
+
+    Ok(ReadFileResult {
+        start_line,
+        end_line,
+        total_lines,
+        content,
+        hit_total_char_limit,
+    })
 }
 
 /// start_line: starts from 1

--- a/src/crates/tool-runtime/src/search/glob_search.rs
+++ b/src/crates/tool-runtime/src/search/glob_search.rs
@@ -1,3 +1,4 @@
+use crate::util::string::{escape_posix_single_quotes, shell_single_quote};
 use globset::{GlobBuilder, GlobMatcher};
 use ignore::WalkBuilder;
 use log::{info, warn};
@@ -273,6 +274,19 @@ pub fn limit_paths(paths: &[PathBuf], limit: usize) -> Vec<PathBuf> {
     result
 }
 
+pub fn collect_remote_glob_matches(search_dir: &str, stdout: &str, limit: usize) -> Vec<PathBuf> {
+    let matches = stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            let relative_path = line.strip_prefix("./").unwrap_or(line);
+            Path::new(search_dir).join(relative_path)
+        })
+        .collect::<Vec<_>>();
+
+    limit_paths(&matches, limit)
+}
+
 pub fn execute_local_glob(request: LocalGlobRequest) -> Result<LocalGlobResult, String> {
     if !request.search_path.exists() {
         return Err(format!(
@@ -379,7 +393,7 @@ pub fn execute_local_glob(request: LocalGlobRequest) -> Result<LocalGlobResult, 
 }
 
 pub fn shell_escape(value: &str) -> String {
-    value.replace('\'', "'\\''")
+    escape_posix_single_quotes(value)
 }
 
 pub fn build_remote_rg_command(search_dir: &str, pattern: &str) -> String {
@@ -389,15 +403,12 @@ pub fn build_remote_rg_command(search_dir: &str, pattern: &str) -> String {
 
     let mut parts = vec![
         "cd".to_string(),
-        format!(
-            "'{}'",
-            shell_escape(remote_walk_root.to_string_lossy().as_ref())
-        ),
+        shell_single_quote(remote_walk_root.to_string_lossy().as_ref()),
         "&&".to_string(),
         "rg".to_string(),
         "--files".to_string(),
         "--glob".to_string(),
-        format!("'{}'", shell_escape(&remote_pattern)),
+        shell_single_quote(&remote_pattern),
         "--sort".to_string(),
         "path".to_string(),
     ];
@@ -427,11 +438,11 @@ pub fn build_remote_find_command(search_dir: &str, pattern: &str, limit: usize) 
         remote_pattern
     };
 
-    let escaped_dir = remote_walk_root.to_string_lossy().replace('\'', "'\\''");
-    let escaped_pattern = name_pattern.replace('\'', "'\\''");
+    let escaped_dir = shell_single_quote(remote_walk_root.to_string_lossy().as_ref());
+    let escaped_pattern = shell_single_quote(&name_pattern);
 
     format!(
-        "find '{}' -maxdepth 10 -name '{}' -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null | head -n {}",
+        "find {} -maxdepth 10 -name {} -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null | head -n {}",
         escaped_dir, escaped_pattern, limit
     )
 }

--- a/src/crates/tool-runtime/src/search/grep_search.rs
+++ b/src/crates/tool-runtime/src/search/grep_search.rs
@@ -1,4 +1,5 @@
-﻿use log::{debug, info, warn};
+use crate::util::string::shell_single_quote;
+use log::{debug, info, warn};
 use std::fmt;
 use std::io;
 use std::path::{Component, Path, PathBuf};
@@ -15,7 +16,7 @@ const MAX_DISPLAY_COLUMNS: usize = 500;
 const VCS_DIRECTORIES_TO_EXCLUDE: &[&str] = &[".git", ".svn", ".hg", ".bzr", ".jj", ".sl"];
 
 /// Output mode enumeration
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputMode {
     Content,
     FilesWithMatches,
@@ -293,6 +294,136 @@ impl Default for GrepOptions {
             globs: Vec::new(),
             file_type: None,
             display_base: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteGrepCommandRequest {
+    pub pattern: String,
+    pub path: String,
+    pub case_insensitive: bool,
+    pub output_mode: OutputMode,
+    pub show_line_numbers: bool,
+    pub context: Option<usize>,
+    pub before_context: Option<usize>,
+    pub after_context: Option<usize>,
+    pub glob_patterns: Vec<String>,
+    pub file_type: Option<String>,
+    pub head_limit: Option<usize>,
+    pub offset: usize,
+}
+
+pub fn build_remote_grep_command(request: &RemoteGrepCommandRequest) -> String {
+    let offset_cmd = if request.offset > 0 {
+        format!(" | tail -n +{}", request.offset + 1)
+    } else {
+        String::new()
+    };
+    let limit_cmd = request
+        .head_limit
+        .map(|limit| format!(" | head -n {}", limit))
+        .unwrap_or_default();
+
+    let mut cmd = "rg --no-heading --hidden --max-columns 500".to_string();
+    if request.case_insensitive {
+        cmd.push_str(" -i");
+    }
+    if request.output_mode == OutputMode::FilesWithMatches {
+        cmd.push_str(" -l");
+    } else if request.output_mode == OutputMode::Count {
+        cmd.push_str(" -c");
+    } else if request.show_line_numbers {
+        cmd.push_str(" --line-number");
+    }
+    if request.output_mode == OutputMode::Content {
+        if let Some(context) = request.context {
+            cmd.push_str(&format!(" -C {}", context));
+        } else {
+            if let Some(before) = request.before_context {
+                cmd.push_str(&format!(" -B {}", before));
+            }
+            if let Some(after) = request.after_context {
+                cmd.push_str(&format!(" -A {}", after));
+            }
+        }
+    }
+    for glob_pattern in &request.glob_patterns {
+        cmd.push_str(&format!(" --glob {}", shell_single_quote(glob_pattern)));
+    }
+    if let Some(file_type) = &request.file_type {
+        cmd.push_str(&format!(" --type {}", shell_single_quote(file_type)));
+    }
+    cmd.push_str(&format!(
+        " -e {} {} 2>/dev/null{}{}",
+        shell_single_quote(&request.pattern),
+        shell_single_quote(&request.path),
+        offset_cmd,
+        limit_cmd
+    ));
+
+    format!(
+        "if command -v rg >/dev/null 2>&1; then {}; else grep -rn{} -e {} {} 2>/dev/null{}{}; fi",
+        cmd,
+        if request.case_insensitive { "i" } else { "" },
+        shell_single_quote(&request.pattern),
+        shell_single_quote(&request.path),
+        offset_cmd,
+        limit_cmd,
+    )
+}
+
+pub fn count_remote_grep_matches(stdout: &str) -> usize {
+    stdout.lines().count()
+}
+
+pub fn relativize_result_text(result_text: &str, display_base: Option<&str>) -> String {
+    let Some(base) = display_base else {
+        return result_text.to_string();
+    };
+
+    let normalized_base = base.replace('\\', "/").trim_end_matches('/').to_string();
+    if normalized_base.is_empty() {
+        return result_text.to_string();
+    }
+
+    result_text
+        .lines()
+        .map(|line| {
+            if let Some(rest) = line.strip_prefix(&(normalized_base.clone() + "/")) {
+                rest.to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn render_remote_grep_result_text(
+    stdout: &str,
+    pattern: &str,
+    display_base: Option<&str>,
+) -> String {
+    if stdout.lines().next().is_none() {
+        format!("No matches found for pattern '{}'", pattern)
+    } else {
+        relativize_result_text(stdout, display_base)
+    }
+}
+
+pub fn apply_offset_and_limit(items: &mut Vec<String>, offset: usize, head_limit: Option<usize>) {
+    if offset > 0 {
+        if offset >= items.len() {
+            items.clear();
+        } else {
+            *items = items[offset..].to_vec();
+        }
+    }
+
+    if let Some(limit) = head_limit {
+        if items.len() > limit {
+            items.truncate(limit);
         }
     }
 }

--- a/src/crates/tool-runtime/src/search/mod.rs
+++ b/src/crates/tool-runtime/src/search/mod.rs
@@ -2,7 +2,12 @@ pub mod glob_search;
 pub mod grep_search;
 
 pub use glob_search::{
-    build_remote_find_command, build_remote_rg_command, derive_walk_root, execute_local_glob,
-    extract_glob_base_directory, limit_paths, normalize_path, LocalGlobRequest, LocalGlobResult,
+    build_remote_find_command, build_remote_rg_command, collect_remote_glob_matches,
+    derive_walk_root, execute_local_glob, extract_glob_base_directory, limit_paths, normalize_path,
+    LocalGlobRequest, LocalGlobResult,
 };
-pub use grep_search::{grep_search, GrepOptions, OutputMode, ProgressCallback};
+pub use grep_search::{
+    apply_offset_and_limit, build_remote_grep_command, count_remote_grep_matches, grep_search,
+    relativize_result_text, render_remote_grep_result_text, GrepOptions, OutputMode,
+    ProgressCallback, RemoteGrepCommandRequest,
+};

--- a/src/crates/tool-runtime/src/util/string.rs
+++ b/src/crates/tool-runtime/src/util/string.rs
@@ -10,3 +10,11 @@ pub fn truncate_string_by_chars(s: &str, kept_chars: usize) -> String {
     let chars: Vec<char> = s.chars().collect();
     chars[..kept_chars].iter().collect()
 }
+
+pub fn escape_posix_single_quotes(value: &str) -> String {
+    value.replace('\'', "'\\''")
+}
+
+pub fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", escape_posix_single_quotes(value))
+}

--- a/src/crates/tool-runtime/tests/tool_io_contracts.rs
+++ b/src/crates/tool-runtime/tests/tool_io_contracts.rs
@@ -2,12 +2,21 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use tool_runtime::fs::read_file::{build_remote_read_command, parse_remote_read_output};
 use tool_runtime::fs::{
-    delete_local_path, edit_local_file, inspect_local_delete_target, write_local_file,
+    build_remote_delete_command, build_remote_list_commands, delete_local_path, edit_local_file,
+    inspect_local_delete_target, parse_remote_list_entries, write_local_file,
     DeleteLocalPathRequest, EditLocalFileRequest, LocalDeleteTarget, WriteLocalFileRequest,
     WriteLocalFileStatus,
 };
-use tool_runtime::search::glob_search::{execute_local_glob, LocalGlobRequest};
+use tool_runtime::search::glob_search::{
+    collect_remote_glob_matches, execute_local_glob, LocalGlobRequest,
+};
+use tool_runtime::search::grep_search::{
+    apply_offset_and_limit, build_remote_grep_command, count_remote_grep_matches,
+    relativize_result_text, render_remote_grep_result_text, OutputMode, RemoteGrepCommandRequest,
+};
+use tool_runtime::util::string::shell_single_quote;
 
 fn make_temp_dir(name: &str) -> PathBuf {
     let unique = SystemTime::now()
@@ -159,4 +168,141 @@ fn execute_local_glob_keeps_shallowest_matches() {
         .any(|path| path.ends_with("/src/deep/mod.rs")));
 
     let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn remote_glob_stdout_is_normalized_and_limited_by_tool_runtime() {
+    let matches =
+        collect_remote_glob_matches("C:/repo", "./src/deep/mod.rs\nsrc/lib.rs\nREADME.md\n\n", 2)
+            .into_iter()
+            .map(|path| normalized(&path))
+            .collect::<Vec<_>>();
+
+    assert_eq!(matches, vec!["C:/repo/README.md", "C:/repo/src/lib.rs"]);
+}
+
+#[test]
+fn shell_single_quote_preserves_existing_remote_escape_style() {
+    assert_eq!(shell_single_quote("C:/repo/a'b"), "'C:/repo/a'\\''b'");
+}
+
+#[test]
+fn remote_read_command_and_parser_preserve_existing_window_markers() {
+    let command =
+        build_remote_read_command("C:/repo/a'b.txt", 2, 3, 120, 1_000).expect("command builds");
+
+    assert!(command.starts_with(
+        "if [ ! -f 'C:/repo/a'\\''b.txt' ]; then exit 3; fi; awk -v start=2 -v end=4 -v max=120 -v budget=1000"
+    ));
+    assert!(command.contains("__BITFUN_TOTAL_LINES__="));
+    assert!(command.contains("__BITFUN_HIT_TOTAL_CHAR_LIMIT__="));
+    assert!(command.ends_with("'C:/repo/a'\\''b.txt'"));
+
+    let result = parse_remote_read_output(
+        "     2\talpha\n",
+        "__BITFUN_TOTAL_LINES__=5\n__BITFUN_HIT_TOTAL_CHAR_LIMIT__=1\n",
+        0,
+        "C:/repo/a'b.txt",
+        2,
+    )
+    .expect("remote output parses");
+
+    assert_eq!(result.start_line, 2);
+    assert_eq!(result.end_line, 2);
+    assert_eq!(result.total_lines, 5);
+    assert_eq!(result.content, "     2\talpha");
+    assert!(result.hit_total_char_limit);
+}
+
+#[test]
+fn remote_ls_command_plan_and_stdout_parser_preserve_existing_shape() {
+    let plan = build_remote_list_commands("/repo/a'b", 10);
+
+    assert_eq!(
+        plan.scan_command,
+        "find '/repo/a'\\''b' -maxdepth 1 -not -name '.*' -not -path '/repo/a'\\''b' | head -n 11 | sort"
+    );
+    assert_eq!(
+        plan.listing_command,
+        "ls -la --time-style=long-iso '/repo/a'\\''b' 2>/dev/null || ls -la '/repo/a'\\''b'"
+    );
+
+    let entries = parse_remote_list_entries("/repo/a'b/file.txt\n/repo/a'b/dir/\n\n");
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].name, "file.txt");
+    assert_eq!(entries[0].path, "/repo/a'b/file.txt");
+    assert!(!entries[0].is_dir);
+    assert_eq!(entries[1].name, "dir");
+    assert_eq!(entries[1].path, "/repo/a'b/dir/");
+    assert!(entries[1].is_dir);
+}
+
+#[test]
+fn remote_delete_command_preserves_existing_recursive_flag_and_escaping() {
+    assert_eq!(
+        build_remote_delete_command("/repo/a'b.txt", false),
+        "rm -f '/repo/a'\\''b.txt'"
+    );
+    assert_eq!(
+        build_remote_delete_command("/repo/a'b", true),
+        "rm -rf '/repo/a'\\''b'"
+    );
+}
+
+#[test]
+fn remote_grep_command_preserves_rg_fallback_filters_and_windowing() {
+    let command = build_remote_grep_command(&RemoteGrepCommandRequest {
+        pattern: "panic('x')".to_string(),
+        path: "/repo/src app".to_string(),
+        case_insensitive: true,
+        output_mode: OutputMode::Content,
+        show_line_numbers: true,
+        context: Some(2),
+        before_context: Some(1),
+        after_context: Some(1),
+        glob_patterns: vec!["*.rs".to_string(), "**/*.ts".to_string()],
+        file_type: Some("rust".to_string()),
+        head_limit: Some(7),
+        offset: 3,
+    });
+
+    assert_eq!(
+        command,
+        "if command -v rg >/dev/null 2>&1; then rg --no-heading --hidden --max-columns 500 -i --line-number -C 2 --glob '*.rs' --glob '**/*.ts' --type 'rust' -e 'panic('\\''x'\\'')' '/repo/src app' 2>/dev/null | tail -n +4 | head -n 7; else grep -rni -e 'panic('\\''x'\\'')' '/repo/src app' 2>/dev/null | tail -n +4 | head -n 7; fi"
+    );
+}
+
+#[test]
+fn remote_grep_result_rendering_preserves_counts_and_display_paths() {
+    let stdout = "/repo/src/main.rs:12:panic!(\"x\")\n/repo/src/lib.rs:3:pub fn lib() {}\n";
+
+    assert_eq!(count_remote_grep_matches(stdout), 2);
+    assert_eq!(
+        render_remote_grep_result_text(stdout, "panic", Some("/repo")),
+        "src/main.rs:12:panic!(\"x\")\nsrc/lib.rs:3:pub fn lib() {}"
+    );
+    assert_eq!(
+        render_remote_grep_result_text("", "panic", Some("/repo")),
+        "No matches found for pattern 'panic'"
+    );
+}
+
+#[test]
+fn grep_result_windowing_can_be_applied_outside_core() {
+    let mut items = vec![
+        "one".to_string(),
+        "two".to_string(),
+        "three".to_string(),
+        "four".to_string(),
+    ];
+
+    apply_offset_and_limit(&mut items, 1, Some(2));
+    assert_eq!(items, vec!["two", "three"]);
+
+    let text = "C:/repo/src/main.rs:1:one\nC:/repo/src/lib.rs:2:two";
+    assert_eq!(
+        relativize_result_text(text, Some("C:/repo")),
+        "src/main.rs:1:one\nsrc/lib.rs:2:two"
+    );
 }


### PR DESCRIPTION
﻿## Summary
- Move remote Delete / Read / LS command planning and output parsing helpers into `tool-runtime`.
- Move remote Glob / Grep command planning, stdout normalization, match counting, and result windowing helpers into `tool-runtime`.
- Simplify the core tool adapters so they keep path resolution, workspace shell execution, checkpoint/UI side effects, and `ToolResult` wrapping only.
- Update the active core decomposition plan and completed summary for the M2 IO/search execution-helper boundary.

## Behavior and risk
- No tool schema, permission default, checkpoint, remote fallback, shell cwd, terminal prewarm, or PTY lifecycle behavior changes.
- `terminal-core` remains the terminal lifecycle owner; `agent-tools` remains the manifest / admission / GetToolSpec contract owner.
- No Cargo dependency changes.

## Verification
- `cargo test -p tool-runtime`
- `cargo test -p bitfun-core grep_tool -- --nocapture`
- `cargo test -p bitfun-agent-tools`
- `cargo check --workspace`
- `pnpm run check:repo-hygiene`
- `node scripts/check-core-boundaries.mjs`

Refs #970
