### PR TITLE
refactor(agent-runtime): move lifecycle decisions out of core

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -50,10 +50,11 @@
 
 ### 1.4 Agent Runtime 与 Harness 契约基线
 
-- `agent-runtime` 已承接 scheduler/background delivery 的纯决策、thread goal runtime 的 accounting / mutation /
-  continuation plan、subagent visibility / availability、prompt cache facts、mode/source presentation facts、
+- `agent-runtime` 已承接 scheduler/background delivery 的纯决策、turn outcome lifecycle plan、thread goal runtime 的
+  accounting / mutation / continuation plan、subagent visibility / availability、prompt cache facts、mode/source presentation facts、
   scheduled-job lifecycle state、custom subagent schema/default/markdown IO/discovery/loading、post-call hook routing、
-  tool confirmation plan、goal/user-question tool wire contract、builtin agent catalog 和部分 event fact 映射。
+  tool confirmation plan、goal/user-question tool wire contract、`SessionControl` 输入契约 / cancel route / 结果文案、
+  builtin agent catalog 和部分 event fact 映射。
 - core 仍保留 concrete session manager、metadata/persistence IO、scheduler lifecycle、event emitter、
   permission UI/channel wait、concrete prompt assembly、product `Tool` adapter 和具体 hook side effect。
 - `harness` 已建立 workflow descriptor、legacy route plan、provider registry，并注册 Deep Review、DeepResearch、

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -94,15 +94,19 @@ prompt-visible manifest、GetToolSpec、readonly/enabled filtering、expanded/co
 - `pnpm run check:repo-hygiene`
 - `node scripts/check-core-boundaries.mjs`
 
-### 4.3 M3：Agent Runtime concrete lifecycle 闭环
+### 4.3 M3（当前变更已闭环）：Agent Runtime lifecycle 决策闭环
 
 目标：让 Agent Runtime SDK 接管 session / turn / scheduler / event / permission 中可迁移的 runtime kernel 主体。
 
-- 迁移 session lifecycle、turn submission、scheduler queue/lifecycle、cancellation、event fact delivery、permission coordination、
-  prompt-loop 可移植策略和 subagent/background task concrete coordination 中可证明等价的部分。
-- 将 session metadata / persistence IO、event emitter wiring、permission UI/channel wait 和 concrete prompt assembly 明确划入
-  core compatibility / Product Assembly adapter，或在有端到端保护后迁移。
-- 禁止 Agent Runtime SDK 直接依赖 Tauri、ACP protocol、CLI TUI、desktop app state、concrete filesystem/Git/terminal/MCP client。
+完成口径：
+
+- `agent-runtime` 接管 turn outcome 后处理 plan，统一决定 queue action、round 清理、finished-turn injection drain 和
+  thread-goal continuation after-turn 动作；core scheduler 只执行清理、reply、goal continuation 和 dispatch 副作用。
+- `agent-runtime` 接管 `SessionControl` 输入契约、默认值、tool-use render、create/cancel/delete 结果文案和 cancel route 决策；
+  core tool adapter 只保留 workspace 解析、session manager 调用、scheduler/coordinator cancel 和 `ToolResult` 包装。
+- `agent-runtime` 不新增三方依赖，不依赖 `bitfun-core`、Tauri、ACP、CLI TUI、desktop state 或 concrete service crate。
+- concrete session manager、metadata / persistence IO、scheduler task lifecycle、event emitter wiring、permission UI/channel wait、
+  concrete prompt assembly 和 product `Tool` adapter execution 继续留在 core compatibility / Product Assembly adapter。
 
 **不混入：** 改变 `/goal`、AskUserQuestion、Task、subagent、post-turn hook、DeepReview measurement、token usage 或 continuation wire shape。
 

--- a/src/crates/agent-runtime/AGENTS.md
+++ b/src/crates/agent-runtime/AGENTS.md
@@ -21,7 +21,7 @@ and tested without `bitfun-core`.
   registry visibility/availability, custom subagent schema/default decisions,
   builtin agent definition catalog, thread-goal metadata / event payload /
   token usage / scheduler delivery plans, thread-goal tool wire contracts,
-  user-question validation/result contracts, DeepReview shared-context
+  user-question validation/result contracts, SessionControl input/cancel-route/result contracts, DeepReview shared-context
   measurement decisions,
   custom subagent markdown front-matter IO, custom subagent discovery/loading,
   post-call hook routing/executor orchestration,

--- a/src/crates/agent-runtime/src/lib.rs
+++ b/src/crates/agent-runtime/src/lib.rs
@@ -11,6 +11,7 @@ pub mod prompt;
 pub mod prompt_cache;
 pub mod scheduled_job;
 pub mod scheduler;
+pub mod session_control;
 pub mod thread_goal;
 pub mod thread_goal_tools;
 pub mod tool_confirmation;

--- a/src/crates/agent-runtime/src/scheduler.rs
+++ b/src/crates/agent-runtime/src/scheduler.rs
@@ -113,6 +113,10 @@ impl ActiveDialogTurnStore {
         self.inner.remove(session_id).map(|(_, turn)| turn)
     }
 
+    pub fn contains(&self, session_id: &str) -> bool {
+        self.inner.contains_key(session_id)
+    }
+
     pub fn suppression_key_for_requester(
         &self,
         target_session_id: &str,
@@ -716,6 +720,60 @@ impl TurnOutcome {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GoalContinuationAfterTurnAction {
+    SkipNoActiveTurn,
+    AbortForCancelled,
+    Evaluate { turn_completed: bool },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TurnOutcomeLifecyclePlan {
+    pub status: TurnOutcomeStatus,
+    pub queue_action: TurnOutcomeQueueAction,
+    pub clear_round_yield: bool,
+    pub drain_finished_turn_injections: bool,
+    pub goal_continuation: GoalContinuationAfterTurnAction,
+}
+
+impl TurnOutcomeLifecyclePlan {
+    pub const fn dispatch_next(self) -> bool {
+        matches!(self.queue_action, TurnOutcomeQueueAction::DispatchNext)
+    }
+
+    pub const fn clear_queue(self) -> bool {
+        matches!(self.queue_action, TurnOutcomeQueueAction::ClearQueue)
+    }
+}
+
+pub fn resolve_turn_outcome_lifecycle_plan(
+    outcome: &TurnOutcome,
+    has_active_turn: bool,
+) -> TurnOutcomeLifecyclePlan {
+    let status = outcome.status();
+    let goal_continuation = if !has_active_turn {
+        GoalContinuationAfterTurnAction::SkipNoActiveTurn
+    } else {
+        match status {
+            TurnOutcomeStatus::Cancelled => GoalContinuationAfterTurnAction::AbortForCancelled,
+            TurnOutcomeStatus::Completed => GoalContinuationAfterTurnAction::Evaluate {
+                turn_completed: true,
+            },
+            TurnOutcomeStatus::Failed => GoalContinuationAfterTurnAction::Evaluate {
+                turn_completed: false,
+            },
+        }
+    };
+
+    TurnOutcomeLifecyclePlan {
+        status,
+        queue_action: outcome.queue_action(),
+        clear_round_yield: true,
+        drain_finished_turn_injections: true,
+        goal_continuation,
+    }
+}
+
 pub fn resolve_agent_session_reply_action(
     responder_session_id: &str,
     active_turn: &ActiveDialogTurn,
@@ -783,5 +841,88 @@ pub fn resolve_dialog_steering_action(
             turn_id: turn_id.to_string(),
             steering_id,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcome_lifecycle_dispatches_completed_turn_and_verifies_goal() {
+        let outcome = TurnOutcome::Completed {
+            turn_id: "turn_1".to_string(),
+            final_response: "done".to_string(),
+        };
+
+        let plan = resolve_turn_outcome_lifecycle_plan(&outcome, true);
+
+        assert_eq!(plan.status, TurnOutcomeStatus::Completed);
+        assert_eq!(plan.queue_action, TurnOutcomeQueueAction::DispatchNext);
+        assert!(plan.clear_round_yield);
+        assert!(plan.drain_finished_turn_injections);
+        assert_eq!(
+            plan.goal_continuation,
+            GoalContinuationAfterTurnAction::Evaluate {
+                turn_completed: true
+            }
+        );
+        assert!(plan.dispatch_next());
+        assert!(!plan.clear_queue());
+    }
+
+    #[test]
+    fn outcome_lifecycle_aborts_goal_continuation_for_cancelled_turn() {
+        let outcome = TurnOutcome::Cancelled {
+            turn_id: "turn_1".to_string(),
+        };
+
+        let plan = resolve_turn_outcome_lifecycle_plan(&outcome, true);
+
+        assert_eq!(plan.status, TurnOutcomeStatus::Cancelled);
+        assert_eq!(plan.queue_action, TurnOutcomeQueueAction::DispatchNext);
+        assert_eq!(
+            plan.goal_continuation,
+            GoalContinuationAfterTurnAction::AbortForCancelled
+        );
+        assert!(plan.dispatch_next());
+        assert!(!plan.clear_queue());
+    }
+
+    #[test]
+    fn outcome_lifecycle_clears_queue_for_failed_turn_and_verifies_goal() {
+        let outcome = TurnOutcome::Failed {
+            turn_id: "turn_1".to_string(),
+            error: "boom".to_string(),
+        };
+
+        let plan = resolve_turn_outcome_lifecycle_plan(&outcome, true);
+
+        assert_eq!(plan.status, TurnOutcomeStatus::Failed);
+        assert_eq!(plan.queue_action, TurnOutcomeQueueAction::ClearQueue);
+        assert_eq!(
+            plan.goal_continuation,
+            GoalContinuationAfterTurnAction::Evaluate {
+                turn_completed: false
+            }
+        );
+        assert!(!plan.dispatch_next());
+        assert!(plan.clear_queue());
+    }
+
+    #[test]
+    fn outcome_lifecycle_skips_goal_when_no_active_turn_exists() {
+        let outcome = TurnOutcome::Completed {
+            turn_id: "turn_1".to_string(),
+            final_response: "done".to_string(),
+        };
+
+        let plan = resolve_turn_outcome_lifecycle_plan(&outcome, false);
+
+        assert_eq!(
+            plan.goal_continuation,
+            GoalContinuationAfterTurnAction::SkipNoActiveTurn
+        );
+        assert!(plan.dispatch_next());
     }
 }

--- a/src/crates/agent-runtime/src/session_control.rs
+++ b/src/crates/agent-runtime/src/session_control.rs
@@ -1,0 +1,301 @@
+//! Portable SessionControl tool decisions.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::Path;
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionControlAction {
+    Create,
+    Cancel,
+    Delete,
+    List,
+}
+
+impl SessionControlAction {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Create => "create",
+            Self::Cancel => "cancel",
+            Self::Delete => "delete",
+            Self::List => "list",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub enum SessionControlAgentType {
+    #[serde(rename = "agentic", alias = "Agentic", alias = "AGENTIC")]
+    Agentic,
+    #[serde(rename = "Plan", alias = "plan", alias = "PLAN")]
+    Plan,
+    #[serde(rename = "Cowork", alias = "cowork", alias = "COWORK")]
+    Cowork,
+}
+
+impl SessionControlAgentType {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Agentic => "agentic",
+            Self::Plan => "Plan",
+            Self::Cowork => "Cowork",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct SessionControlInput {
+    pub action: SessionControlAction,
+    pub workspace: Option<String>,
+    pub session_id: Option<String>,
+    pub session_name: Option<String>,
+    pub agent_type: Option<SessionControlAgentType>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SessionControlValidationContext<'a> {
+    pub current_session_id: Option<&'a str>,
+    pub has_workspace_root: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionControlValidationResult {
+    pub result: bool,
+    pub message: Option<String>,
+    pub error_code: Option<i32>,
+    pub meta: Option<Value>,
+}
+
+impl Default for SessionControlValidationResult {
+    fn default() -> Self {
+        Self {
+            result: true,
+            message: None,
+            error_code: None,
+            meta: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionControlCancelRoute {
+    RequesterViaScheduler { requester_session_id: String },
+    CoordinatorDirect,
+}
+
+pub fn resolve_session_control_cancel_route(
+    requester_session_id: Option<&str>,
+    scheduler_available: bool,
+) -> SessionControlCancelRoute {
+    match (requester_session_id, scheduler_available) {
+        (Some(requester_session_id), true) => SessionControlCancelRoute::RequesterViaScheduler {
+            requester_session_id: requester_session_id.to_string(),
+        },
+        _ => SessionControlCancelRoute::CoordinatorDirect,
+    }
+}
+
+fn invalid(message: impl Into<String>) -> SessionControlValidationResult {
+    SessionControlValidationResult {
+        result: false,
+        message: Some(message.into()),
+        error_code: Some(400),
+        meta: None,
+    }
+}
+
+pub fn validate_session_id(session_id: &str) -> Result<(), String> {
+    if session_id.is_empty() {
+        return Err("session_id cannot be empty".to_string());
+    }
+    if session_id == "." || session_id == ".." {
+        return Err("session_id cannot be '.' or '..'".to_string());
+    }
+    if session_id.contains('/') || session_id.contains('\\') {
+        return Err("session_id cannot contain path separators".to_string());
+    }
+    if !session_id
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+    {
+        return Err("session_id can only contain ASCII letters, numbers, '-' and '_'".to_string());
+    }
+    Ok(())
+}
+
+pub fn default_session_name() -> &'static str {
+    "New Session"
+}
+
+pub fn session_control_session_name_or_default(session_name: Option<&str>) -> String {
+    session_name
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(default_session_name())
+        .to_string()
+}
+
+pub fn session_control_agent_type_or_default(
+    agent_type: Option<&SessionControlAgentType>,
+) -> String {
+    agent_type
+        .map(|agent_type| agent_type.as_str().to_string())
+        .unwrap_or_else(|| "agentic".to_string())
+}
+
+pub fn session_control_creator_marker(creator_session_id: &str) -> String {
+    format!("session-{creator_session_id}")
+}
+
+fn validate_workspace_shape(workspace: &str) -> SessionControlValidationResult {
+    if workspace.trim().is_empty() {
+        return invalid("workspace is required and cannot be empty");
+    }
+
+    if !Path::new(workspace.trim()).is_absolute() {
+        return invalid("workspace must be an absolute path");
+    }
+
+    SessionControlValidationResult::default()
+}
+
+fn validate_mutating_action_target(
+    action: &SessionControlAction,
+    input: &SessionControlInput,
+    context: SessionControlValidationContext<'_>,
+) -> SessionControlValidationResult {
+    if input.agent_type.is_some() {
+        return invalid("agent_type is only allowed for create");
+    }
+    if input.session_name.is_some() {
+        return invalid("session_name is only allowed for create");
+    }
+
+    let Some(session_id) = input.session_id.as_deref() else {
+        return invalid(format!("session_id is required for {}", action.as_str()));
+    };
+    if let Err(message) = validate_session_id(session_id) {
+        return invalid(message);
+    }
+
+    if context.current_session_id == Some(session_id) && context.has_workspace_root {
+        return invalid(format!(
+            "cannot {} the current session from SessionControl",
+            action.as_str()
+        ));
+    }
+
+    SessionControlValidationResult::default()
+}
+
+pub fn validate_session_control_input(
+    input: &SessionControlInput,
+    context: SessionControlValidationContext<'_>,
+) -> SessionControlValidationResult {
+    if let Some(workspace) = input.workspace.as_deref() {
+        let should_validate_workspace = matches!(
+            input.action,
+            SessionControlAction::Create | SessionControlAction::List
+        );
+        if !should_validate_workspace {
+            return validate_mutating_action_target(&input.action, input, context);
+        }
+
+        let workspace_validation = validate_workspace_shape(workspace);
+        if !workspace_validation.result {
+            return workspace_validation;
+        }
+    }
+
+    match input.action {
+        SessionControlAction::Create => {
+            if input.workspace.is_none() {
+                return invalid("workspace is required for create");
+            }
+            if input.session_id.is_some() {
+                return invalid("session_id is not allowed for create");
+            }
+            if context.current_session_id.is_none() {
+                return invalid("create requires a creator session in tool context");
+            }
+        }
+        SessionControlAction::Cancel | SessionControlAction::Delete => {
+            return validate_mutating_action_target(&input.action, input, context);
+        }
+        SessionControlAction::List => {
+            if input.workspace.is_none() {
+                return invalid("workspace is required for list");
+            }
+            if input.agent_type.is_some() {
+                return invalid("agent_type is only allowed for create");
+            }
+            if input.session_name.is_some() {
+                return invalid("session_name is only allowed for create");
+            }
+            if input.session_id.is_some() {
+                return invalid("session_id is not allowed for list");
+            }
+        }
+    }
+
+    SessionControlValidationResult::default()
+}
+
+pub fn render_session_control_tool_use_message(input: &Value) -> String {
+    let action = input
+        .get("action")
+        .and_then(|value| value.as_str())
+        .unwrap_or("unknown");
+    let workspace = input
+        .get("workspace")
+        .and_then(|value| value.as_str())
+        .unwrap_or("unknown workspace");
+    let session_id = input
+        .get("session_id")
+        .and_then(|value| value.as_str())
+        .unwrap_or("auto");
+
+    match action {
+        "create" => format!("Create session in {workspace}"),
+        "cancel" => format!("Cancel active turn for session {session_id}"),
+        "delete" => format!("Delete session {session_id}"),
+        "list" => format!("List sessions in {workspace}"),
+        _ => format!("Manage sessions in {workspace}"),
+    }
+}
+
+pub fn session_control_created_result_message(
+    session_id: &str,
+    workspace: &str,
+    agent_type: &str,
+) -> String {
+    format!("Created session '{session_id}' in workspace '{workspace}' using agent type '{agent_type}'.")
+}
+
+pub fn session_control_cancel_status(cancelled_turn_id: Option<&str>) -> &'static str {
+    if cancelled_turn_id.is_some() {
+        "cancel_requested"
+    } else {
+        "no_active_turn"
+    }
+}
+
+pub fn session_control_cancel_result_message(
+    session_id: &str,
+    workspace: &str,
+    cancelled_turn_id: Option<&str>,
+) -> String {
+    if let Some(turn_id) = cancelled_turn_id {
+        format!(
+            "Cancellation requested for the active turn '{turn_id}' in session '{session_id}' within workspace '{workspace}'. The session remains available for future work, and queued messages are not cleared."
+        )
+    } else {
+        format!(
+            "Session '{session_id}' in workspace '{workspace}' has no active turn to cancel. The session remains available for future work."
+        )
+    }
+}
+
+pub fn session_control_deleted_result_message(session_id: &str, workspace: &str) -> String {
+    format!("Deleted session '{session_id}' from workspace '{workspace}'.")
+}

--- a/src/crates/agent-runtime/tests/session_control_contracts.rs
+++ b/src/crates/agent-runtime/tests/session_control_contracts.rs
@@ -1,0 +1,117 @@
+use bitfun_agent_runtime::session_control::{
+    render_session_control_tool_use_message, resolve_session_control_cancel_route,
+    session_control_cancel_result_message, session_control_created_result_message,
+    validate_session_control_input, SessionControlAction, SessionControlAgentType,
+    SessionControlCancelRoute, SessionControlInput, SessionControlValidationContext,
+};
+use serde_json::json;
+
+fn base_input(action: SessionControlAction) -> SessionControlInput {
+    SessionControlInput {
+        action,
+        workspace: None,
+        session_id: None,
+        session_name: None,
+        agent_type: None,
+    }
+}
+
+#[test]
+fn validates_cancel_without_workspace_and_ignores_workspace_shape() {
+    let mut input = base_input(SessionControlAction::Cancel);
+    input.session_id = Some("worker_1".to_string());
+    input.workspace = Some("not-an-absolute-path".to_string());
+
+    let result = validate_session_control_input(&input, SessionControlValidationContext::default());
+
+    assert!(result.result, "{:?}", result.message);
+}
+
+#[test]
+fn rejects_current_session_mutation_when_context_matches() {
+    let mut input = base_input(SessionControlAction::Delete);
+    input.session_id = Some("session_a".to_string());
+
+    let result = validate_session_control_input(
+        &input,
+        SessionControlValidationContext {
+            current_session_id: Some("session_a"),
+            has_workspace_root: true,
+        },
+    );
+
+    assert!(!result.result);
+    assert_eq!(
+        result.message.as_deref(),
+        Some("cannot delete the current session from SessionControl")
+    );
+}
+
+#[test]
+fn validates_create_requires_workspace_and_creator_session() {
+    let mut input = base_input(SessionControlAction::Create);
+    input.workspace = Some(std::env::temp_dir().to_string_lossy().to_string());
+    input.agent_type = Some(SessionControlAgentType::Plan);
+
+    let missing_creator =
+        validate_session_control_input(&input, SessionControlValidationContext::default());
+
+    assert!(!missing_creator.result);
+    assert_eq!(
+        missing_creator.message.as_deref(),
+        Some("create requires a creator session in tool context")
+    );
+
+    let with_creator = validate_session_control_input(
+        &input,
+        SessionControlValidationContext {
+            current_session_id: Some("session_a"),
+            has_workspace_root: true,
+        },
+    );
+
+    assert!(with_creator.result, "{:?}", with_creator.message);
+}
+
+#[test]
+fn renders_tool_message_without_core_context() {
+    assert_eq!(
+        render_session_control_tool_use_message(&json!({
+            "action": "cancel",
+            "workspace": "/repo",
+            "session_id": "worker_1",
+        })),
+        "Cancel active turn for session worker_1"
+    );
+}
+
+#[test]
+fn builds_stable_result_messages() {
+    let workspace = std::env::temp_dir().to_string_lossy().to_string();
+    assert_eq!(
+        session_control_created_result_message("session_a", &workspace, "Plan"),
+        format!("Created session 'session_a' in workspace '{workspace}' using agent type 'Plan'.")
+    );
+    assert_eq!(
+        session_control_cancel_result_message("worker_1", &workspace, Some("turn_1")),
+        format!("Cancellation requested for the active turn 'turn_1' in session 'worker_1' within workspace '{workspace}'. The session remains available for future work, and queued messages are not cleared.")
+    );
+}
+
+#[test]
+fn routes_cancel_through_scheduler_only_when_requester_and_scheduler_exist() {
+    assert_eq!(
+        resolve_session_control_cancel_route(Some("requester"), true),
+        SessionControlCancelRoute::RequesterViaScheduler {
+            requester_session_id: "requester".to_string()
+        }
+    );
+    assert_eq!(
+        resolve_session_control_cancel_route(Some("requester"), false),
+        SessionControlCancelRoute::CoordinatorDirect
+    );
+    assert_eq!(
+        resolve_session_control_cancel_route(None, true),
+        SessionControlCancelRoute::CoordinatorDirect
+    );
+}

--- a/src/crates/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/core/src/agentic/coordination/scheduler.rs
@@ -11,7 +11,7 @@
 //! - Queue cleared on unrecoverable failure
 
 use super::coordinator::{ConversationCoordinator, DialogTriggerSource};
-use super::turn_outcome::{TurnOutcome, TurnOutcomeQueueAction, TurnOutcomeStatus};
+use super::turn_outcome::TurnOutcome;
 use crate::agentic::core::{InternalReminderKind, Message, SessionState};
 use crate::agentic::goal_mode::{
     goal_continuation_submit_retry_delay_ms, goal_internal_context_message,
@@ -37,11 +37,13 @@ use uuid::Uuid;
 use bitfun_agent_runtime::scheduler::{
     build_thread_goal_objective_updated_delivery_plan, build_thread_goal_resumed_delivery_plan,
     resolve_agent_session_reply_action, resolve_background_delivery_action,
-    resolve_background_delivery_injection, resolve_dialog_steering_action, ActiveDialogTurn,
-    ActiveDialogTurnStore, AgentSessionReplyAction, AgentSessionReplyPlan,
-    BackgroundDeliveryAction, BackgroundDeliveryFacts, BackgroundInjectionKind,
-    DialogReplySuppressionSet, DialogSteeringAction, DialogTurnQueue, SessionAbortFlags,
-    ThreadGoalDeliveryReminder, ThreadGoalDeliveryReminderKind,
+    resolve_background_delivery_injection, resolve_dialog_steering_action,
+    resolve_turn_outcome_lifecycle_plan, ActiveDialogTurn, ActiveDialogTurnStore,
+    AgentSessionReplyAction, AgentSessionReplyPlan, BackgroundDeliveryAction,
+    BackgroundDeliveryFacts, BackgroundInjectionKind, DialogReplySuppressionSet,
+    DialogSteeringAction, DialogTurnQueue, GoalContinuationAfterTurnAction, SessionAbortFlags,
+    ThreadGoalDeliveryReminder, ThreadGoalDeliveryReminderKind, TurnOutcomeQueueAction,
+    TurnOutcomeStatus,
 };
 use bitfun_runtime_ports::{
     resolve_dialog_submit_queue_action, DialogSessionStateFact, DialogSubmitQueueAction,
@@ -887,16 +889,25 @@ impl DialogScheduler {
     /// Background loop that receives turn outcome notifications from the coordinator.
     async fn run_outcome_handler(&self, mut outcome_rx: mpsc::Receiver<(String, TurnOutcome)>) {
         while let Some((session_id, outcome)) = outcome_rx.recv().await {
-            self.round_yield_flags.clear(&session_id);
+            let lifecycle_plan = resolve_turn_outcome_lifecycle_plan(
+                &outcome,
+                self.active_turns.contains(&session_id),
+            );
+
+            if lifecycle_plan.clear_round_yield {
+                self.round_yield_flags.clear(&session_id);
+            }
             // Only drop steering messages targeted at the *finished* turn. We
             // must NOT clear the entire session buffer here: a user might have
             // legitimately submitted steering against a brand-new follow-up
             // turn that the dispatcher will pick up immediately after this
             // outcome is processed (race window between turn finalize and the
             // next turn starting). Targeting by turn_id keeps those alive.
-            let _drained = self
-                .round_injection_buffer
-                .drain_for_turn(&session_id, outcome.turn_id());
+            if lifecycle_plan.drain_finished_turn_injections {
+                let _drained = self
+                    .round_injection_buffer
+                    .drain_for_turn(&session_id, outcome.turn_id());
+            }
             let suppressed_cancelled_reply =
                 self.take_suppressed_cancelled_reply(&session_id, outcome.turn_id());
 
@@ -922,91 +933,95 @@ impl DialogScheduler {
                 }
             }
 
-            let status = outcome.status();
-            let queue_action = outcome.queue_action();
+            let status = lifecycle_plan.status;
+            let queue_action = lifecycle_plan.queue_action;
             if queue_action == TurnOutcomeQueueAction::ClearQueue {
                 debug!("Turn {}, clearing queue: session_id={}", status, session_id);
                 self.clear_queue(&session_id);
             }
 
             if let Some(active_turn) = active_turn.as_ref() {
-                if matches!(outcome, TurnOutcome::Cancelled { .. }) {
-                    self.goal_continuation_abort.mark(&session_id);
-                    debug!(
-                        "Skipping thread goal continuation after user-cancelled turn: session_id={}, turn_id={}",
-                        session_id,
-                        outcome.turn_id()
-                    );
-                } else {
-                    let turn_completed = matches!(outcome, TurnOutcome::Completed { .. });
-                    self.goal_continuation_abort.clear(&session_id);
-                    match self
-                        .coordinator
-                        .prepare_goal_continuation_after_turn(
-                            &session_id,
-                            &outcome.turn_id(),
-                            active_turn.user_input(),
-                            active_turn.user_message_metadata(),
-                            turn_completed,
-                        )
-                        .await
-                    {
-                        Ok(Some(plan)) => {
-                            let prepended: Vec<Message> = plan
-                                .prepended_reminders
-                                .into_iter()
-                                .map(|text| {
-                                    Message::internal_reminder(
-                                        InternalReminderKind::GoalContinuation,
-                                        text,
-                                    )
-                                })
-                                .collect();
-                            let mut last_error = None;
-                            for attempt in 1..=MAX_THREAD_GOAL_AUTO_CONTINUATIONS {
-                                if self.goal_continuation_abort.contains(&session_id) {
-                                    debug!(
+                match lifecycle_plan.goal_continuation {
+                    GoalContinuationAfterTurnAction::SkipNoActiveTurn => {}
+                    GoalContinuationAfterTurnAction::AbortForCancelled => {
+                        self.goal_continuation_abort.mark(&session_id);
+                        debug!(
+                            "Skipping thread goal continuation after user-cancelled turn: session_id={}, turn_id={}",
+                            session_id,
+                            outcome.turn_id()
+                        );
+                    }
+                    GoalContinuationAfterTurnAction::Evaluate { turn_completed } => {
+                        self.goal_continuation_abort.clear(&session_id);
+                        match self
+                            .coordinator
+                            .prepare_goal_continuation_after_turn(
+                                &session_id,
+                                &outcome.turn_id(),
+                                active_turn.user_input(),
+                                active_turn.user_message_metadata(),
+                                turn_completed,
+                            )
+                            .await
+                        {
+                            Ok(Some(plan)) => {
+                                let prepended: Vec<Message> = plan
+                                    .prepended_reminders
+                                    .into_iter()
+                                    .map(|text| {
+                                        Message::internal_reminder(
+                                            InternalReminderKind::GoalContinuation,
+                                            text,
+                                        )
+                                    })
+                                    .collect();
+                                let mut last_error = None;
+                                for attempt in 1..=MAX_THREAD_GOAL_AUTO_CONTINUATIONS {
+                                    if self.goal_continuation_abort.contains(&session_id) {
+                                        debug!(
                                         "Aborting goal continuation submit retries after user cancellation: session_id={}",
                                         session_id
                                     );
-                                    break;
-                                }
-                                match self
-                                    .submit_with_prepended_messages(
-                                        session_id.clone(),
-                                        "Continue working toward the active thread goal."
-                                            .to_string(),
-                                        Some(plan.display_message.clone()),
-                                        None,
-                                        active_turn.agent_type_owned(),
-                                        active_turn.workspace_path_owned(),
-                                        DialogSubmissionPolicy::for_source(
-                                            DialogTriggerSource::AgentSession,
-                                        ),
-                                        None,
-                                        Some(plan.user_message_metadata.clone()),
-                                        prepended.clone(),
-                                        None,
-                                    )
-                                    .await
-                                {
-                                    Ok(_) => {
-                                        last_error = None;
                                         break;
                                     }
-                                    Err(error) => {
-                                        last_error = Some(error);
-                                        if self.goal_continuation_abort.contains(&session_id) {
-                                            debug!(
+                                    match self
+                                        .submit_with_prepended_messages(
+                                            session_id.clone(),
+                                            "Continue working toward the active thread goal."
+                                                .to_string(),
+                                            Some(plan.display_message.clone()),
+                                            None,
+                                            active_turn.agent_type_owned(),
+                                            active_turn.workspace_path_owned(),
+                                            DialogSubmissionPolicy::for_source(
+                                                DialogTriggerSource::AgentSession,
+                                            ),
+                                            None,
+                                            Some(plan.user_message_metadata.clone()),
+                                            prepended.clone(),
+                                            None,
+                                        )
+                                        .await
+                                    {
+                                        Ok(_) => {
+                                            last_error = None;
+                                            break;
+                                        }
+                                        Err(error) => {
+                                            last_error = Some(error);
+                                            if self.goal_continuation_abort.contains(&session_id) {
+                                                debug!(
                                                 "Aborting goal continuation submit retries after user cancellation: session_id={}",
                                                 session_id
                                             );
-                                            break;
-                                        }
-                                        if attempt < MAX_THREAD_GOAL_AUTO_CONTINUATIONS {
-                                            let delay_ms =
-                                                goal_continuation_submit_retry_delay_ms(attempt);
-                                            warn!(
+                                                break;
+                                            }
+                                            if attempt < MAX_THREAD_GOAL_AUTO_CONTINUATIONS {
+                                                let delay_ms =
+                                                    goal_continuation_submit_retry_delay_ms(
+                                                        attempt,
+                                                    );
+                                                warn!(
                                                 "Goal continuation submit failed; retrying: session_id={}, attempt={}/{}, delay_ms={}, error={}",
                                                 session_id,
                                                 attempt,
@@ -1014,29 +1029,30 @@ impl DialogScheduler {
                                                 delay_ms,
                                                 last_error.as_ref().unwrap()
                                             );
-                                            tokio::time::sleep(std::time::Duration::from_millis(
-                                                delay_ms,
-                                            ))
-                                            .await;
+                                                tokio::time::sleep(
+                                                    std::time::Duration::from_millis(delay_ms),
+                                                )
+                                                .await;
+                                            }
                                         }
                                     }
                                 }
-                            }
-                            if let Some(error) = last_error {
-                                if !self.goal_continuation_abort.contains(&session_id) {
-                                    warn!(
+                                if let Some(error) = last_error {
+                                    if !self.goal_continuation_abort.contains(&session_id) {
+                                        warn!(
                                         "Failed to submit goal continuation turn after retries: session_id={}, error={}",
                                         session_id, error
                                     );
+                                    }
                                 }
                             }
-                        }
-                        Ok(None) => {}
-                        Err(error) => {
-                            warn!(
+                            Ok(None) => {}
+                            Err(error) => {
+                                warn!(
                                 "Goal verification failed after turn stopped: session_id={}, status={}, error={}",
                                 session_id, status, error
                             );
+                            }
                         }
                     }
                 }

--- a/src/crates/core/src/agentic/tools/implementations/session_control_tool.rs
+++ b/src/crates/core/src/agentic/tools/implementations/session_control_tool.rs
@@ -12,7 +12,15 @@ use crate::agentic::tools::framework::{
 };
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
-use serde::Deserialize;
+use bitfun_agent_runtime::session_control::{
+    render_session_control_tool_use_message, resolve_session_control_cancel_route,
+    session_control_agent_type_or_default, session_control_cancel_result_message,
+    session_control_cancel_status, session_control_created_result_message,
+    session_control_creator_marker, session_control_deleted_result_message,
+    session_control_session_name_or_default, validate_session_control_input, validate_session_id,
+    SessionControlAction, SessionControlCancelRoute, SessionControlInput,
+    SessionControlValidationContext, SessionControlValidationResult,
+};
 use serde_json::{json, Value};
 use std::path::Path;
 use std::time::{Duration, SystemTime};
@@ -50,31 +58,6 @@ impl SessionControlTool {
         }
     }
 
-    fn validate_session_id(session_id: &str) -> Result<(), String> {
-        if session_id.is_empty() {
-            return Err("session_id cannot be empty".to_string());
-        }
-        if session_id == "." || session_id == ".." {
-            return Err("session_id cannot be '.' or '..'".to_string());
-        }
-        if session_id.contains('/') || session_id.contains('\\') {
-            return Err("session_id cannot contain path separators".to_string());
-        }
-        if !session_id
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
-        {
-            return Err(
-                "session_id can only contain ASCII letters, numbers, '-' and '_'".to_string(),
-            );
-        }
-        Ok(())
-    }
-
-    fn default_session_name() -> String {
-        "New Session".to_string()
-    }
-
     fn escape_markdown_table_cell(value: &str) -> String {
         value
             .replace('\\', "\\\\")
@@ -91,29 +74,7 @@ impl SessionControlTool {
         let creator_session_id = context.session_id.as_ref().ok_or_else(|| {
             BitFunError::tool("create requires a creator session in tool context".to_string())
         })?;
-        Ok(format!("session-{}", creator_session_id))
-    }
-
-    fn validate_workspace_shape(&self, workspace: &str) -> ValidationResult {
-        if workspace.trim().is_empty() {
-            return ValidationResult {
-                result: false,
-                message: Some("workspace is required and cannot be empty".to_string()),
-                error_code: Some(400),
-                meta: None,
-            };
-        }
-
-        if !Path::new(workspace.trim()).is_absolute() {
-            return ValidationResult {
-                result: false,
-                message: Some("workspace must be an absolute path".to_string()),
-                error_code: Some(400),
-                meta: None,
-            };
-        }
-
-        ValidationResult::default()
+        Ok(session_control_creator_marker(creator_session_id))
     }
 
     async fn resolve_effective_workspace(
@@ -152,65 +113,20 @@ impl SessionControlTool {
         }
     }
 
-    fn validate_mutating_action_target(
-        &self,
-        action: SessionControlAction,
-        parsed: &SessionControlInput,
-        context: Option<&ToolUseContext>,
-    ) -> ValidationResult {
-        if parsed.agent_type.is_some() {
-            return ValidationResult {
-                result: false,
-                message: Some("agent_type is only allowed for create".to_string()),
-                error_code: Some(400),
-                meta: None,
-            };
+    fn validation_context(context: Option<&ToolUseContext>) -> SessionControlValidationContext<'_> {
+        SessionControlValidationContext {
+            current_session_id: context.and_then(|value| value.session_id.as_deref()),
+            has_workspace_root: context.and_then(|value| value.workspace_root()).is_some(),
         }
-        if parsed.session_name.is_some() {
-            return ValidationResult {
-                result: false,
-                message: Some("session_name is only allowed for create".to_string()),
-                error_code: Some(400),
-                meta: None,
-            };
-        }
+    }
 
-        let Some(session_id) = parsed.session_id.as_deref() else {
-            return ValidationResult {
-                result: false,
-                message: Some(format!("session_id is required for {}", action.as_str())),
-                error_code: Some(400),
-                meta: None,
-            };
-        };
-        if let Err(message) = Self::validate_session_id(session_id) {
-            return ValidationResult {
-                result: false,
-                message: Some(message),
-                error_code: Some(400),
-                meta: None,
-            };
+    fn into_validation_result(result: SessionControlValidationResult) -> ValidationResult {
+        ValidationResult {
+            result: result.result,
+            message: result.message,
+            error_code: result.error_code,
+            meta: result.meta,
         }
-
-        if let Some(tool_context) = context {
-            if context
-                .and_then(|value| value.session_id.as_deref())
-                .is_some_and(|current_session_id| current_session_id == session_id)
-                && tool_context.workspace_root().is_some()
-            {
-                return ValidationResult {
-                    result: false,
-                    message: Some(format!(
-                        "cannot {} the current session from SessionControl",
-                        action.as_str()
-                    )),
-                    error_code: Some(400),
-                    meta: None,
-                };
-            }
-        }
-
-        ValidationResult::default()
     }
 
     async fn ensure_session_exists(
@@ -270,55 +186,6 @@ impl SessionControlTool {
         }
         lines.join("\n")
     }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum SessionControlAction {
-    Create,
-    Cancel,
-    Delete,
-    List,
-}
-
-impl SessionControlAction {
-    fn as_str(&self) -> &'static str {
-        match self {
-            Self::Create => "create",
-            Self::Cancel => "cancel",
-            Self::Delete => "delete",
-            Self::List => "list",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-enum SessionControlAgentType {
-    #[serde(rename = "agentic", alias = "Agentic", alias = "AGENTIC")]
-    Agentic,
-    #[serde(rename = "Plan", alias = "plan", alias = "PLAN")]
-    Plan,
-    #[serde(rename = "Cowork", alias = "cowork", alias = "COWORK")]
-    Cowork,
-}
-
-impl SessionControlAgentType {
-    fn as_str(&self) -> &'static str {
-        match self {
-            Self::Agentic => "agentic",
-            Self::Plan => "Plan",
-            Self::Cowork => "Cowork",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct SessionControlInput {
-    action: SessionControlAction,
-    workspace: Option<String>,
-    session_id: Option<String>,
-    session_name: Option<String>,
-    agent_type: Option<SessionControlAgentType>,
 }
 
 #[async_trait]
@@ -414,140 +281,14 @@ Arguments:
             }
         };
 
-        if let Some(workspace) = parsed.workspace.as_deref() {
-            let should_validate_workspace = matches!(
-                parsed.action,
-                SessionControlAction::Create | SessionControlAction::List
-            );
-            if !should_validate_workspace {
-                // Ignore workspace for cancel/delete so callers cannot accidentally
-                // scope these actions to the wrong workspace.
-                return match parsed.action {
-                    SessionControlAction::Cancel => self.validate_mutating_action_target(
-                        SessionControlAction::Cancel,
-                        &parsed,
-                        context,
-                    ),
-                    SessionControlAction::Delete => self.validate_mutating_action_target(
-                        SessionControlAction::Delete,
-                        &parsed,
-                        context,
-                    ),
-                    _ => ValidationResult::default(),
-                };
-            }
-            let workspace_validation = self.validate_workspace_shape(workspace);
-            if !workspace_validation.result {
-                return workspace_validation;
-            }
-        }
-
-        match parsed.action {
-            SessionControlAction::Create => {
-                if parsed.workspace.is_none() {
-                    return ValidationResult {
-                        result: false,
-                        message: Some("workspace is required for create".to_string()),
-                        error_code: Some(400),
-                        meta: None,
-                    };
-                }
-                if parsed.session_id.is_some() {
-                    return ValidationResult {
-                        result: false,
-                        message: Some("session_id is not allowed for create".to_string()),
-                        error_code: Some(400),
-                        meta: None,
-                    };
-                }
-                if context
-                    .and_then(|value| value.session_id.as_ref())
-                    .is_none()
-                {
-                    return ValidationResult {
-                        result: false,
-                        message: Some(
-                            "create requires a creator session in tool context".to_string(),
-                        ),
-                        error_code: Some(400),
-                        meta: None,
-                    };
-                }
-            }
-            SessionControlAction::Cancel => {
-                return self.validate_mutating_action_target(
-                    SessionControlAction::Cancel,
-                    &parsed,
-                    context,
-                );
-            }
-            SessionControlAction::Delete => {
-                return self.validate_mutating_action_target(
-                    SessionControlAction::Delete,
-                    &parsed,
-                    context,
-                );
-            }
-            SessionControlAction::List => {
-                if parsed.workspace.is_none() {
-                    return ValidationResult {
-                        result: false,
-                        message: Some("workspace is required for list".to_string()),
-                        error_code: Some(400),
-                        meta: None,
-                    };
-                }
-                if parsed.agent_type.is_some() {
-                    return ValidationResult {
-                        result: false,
-                        message: Some("agent_type is only allowed for create".to_string()),
-                        error_code: Some(400),
-                        meta: None,
-                    };
-                }
-                if parsed.session_name.is_some() {
-                    return ValidationResult {
-                        result: false,
-                        message: Some("session_name is only allowed for create".to_string()),
-                        error_code: Some(400),
-                        meta: None,
-                    };
-                }
-                if parsed.session_id.is_some() {
-                    return ValidationResult {
-                        result: false,
-                        message: Some("session_id is not allowed for list".to_string()),
-                        error_code: Some(400),
-                        meta: None,
-                    };
-                }
-            }
-        }
-
-        ValidationResult::default()
+        Self::into_validation_result(validate_session_control_input(
+            &parsed,
+            Self::validation_context(context),
+        ))
     }
 
     fn render_tool_use_message(&self, input: &Value, _options: &ToolRenderOptions) -> String {
-        let action = input
-            .get("action")
-            .and_then(|value| value.as_str())
-            .unwrap_or("unknown");
-        let workspace = input
-            .get("workspace")
-            .and_then(|value| value.as_str())
-            .unwrap_or("unknown workspace");
-        let session_id = input
-            .get("session_id")
-            .and_then(|value| value.as_str())
-            .unwrap_or("auto");
-
-        match action {
-            "create" => format!("Create session in {}", workspace),
-            "cancel" => format!("Cancel active turn for session {}", session_id),
-            "delete" => format!("Delete session {}", session_id),
-            "list" => format!("List sessions in {}", workspace),
-            _ => format!("Manage sessions in {}", workspace),
-        }
+        render_session_control_tool_use_message(input)
     }
 
     async fn call_impl(
@@ -570,16 +311,9 @@ Arguments:
                         &coordinator,
                     )
                     .await?;
-                let session_name = params
-                    .session_name
-                    .clone()
-                    .filter(|value| !value.trim().is_empty())
-                    .unwrap_or_else(Self::default_session_name);
-                let agent_type = params
-                    .agent_type
-                    .as_ref()
-                    .map(|agent_type| agent_type.as_str().to_string())
-                    .unwrap_or_else(|| "agentic".to_string());
+                let session_name =
+                    session_control_session_name_or_default(params.session_name.as_deref());
+                let agent_type = session_control_agent_type_or_default(params.agent_type.as_ref());
                 let created_by = self.creator_session_marker(context)?;
 
                 let session = coordinator
@@ -598,9 +332,10 @@ Arguments:
                 let created_session_id = session.session_id.clone();
                 let created_session_name = session.session_name.clone();
                 let created_agent_type = session.agent_type.clone();
-                let result_for_assistant = format!(
-                    "Created session '{}' in workspace '{}' using agent type '{}'.",
-                    created_session_id, workspace, created_agent_type
+                let result_for_assistant = session_control_created_result_message(
+                    &created_session_id,
+                    &workspace,
+                    &created_agent_type,
                 );
 
                 Ok(vec![ToolResult::Result {
@@ -622,7 +357,7 @@ Arguments:
                 let session_id = params.session_id.as_deref().ok_or_else(|| {
                     BitFunError::tool("session_id is required for cancel".to_string())
                 })?;
-                Self::validate_session_id(session_id).map_err(BitFunError::tool)?;
+                validate_session_id(session_id).map_err(BitFunError::tool)?;
                 let workspace = self
                     .resolve_effective_workspace(
                         SessionControlAction::Cancel,
@@ -641,50 +376,41 @@ Arguments:
                 self.ensure_session_exists(&coordinator, workspace_path, &workspace, session_id)
                     .await?;
 
-                let cancelled_turn_id =
-                    match (context.session_id.as_deref(), get_global_scheduler()) {
-                        (Some(requester_session_id), Some(scheduler)) => {
-                            scheduler
-                                .cancel_active_turn_for_session_from_requester(
-                                    session_id,
-                                    requester_session_id,
-                                    CANCEL_WAIT_TIMEOUT,
-                                )
-                                .await?
-                        }
-                        (Some(_), None) => {
-                            // Normally this should not happen: the runtime usually initializes
-                            // the global scheduler before tools are allowed to run.
-                            coordinator
-                                .cancel_active_turn_for_session(session_id, CANCEL_WAIT_TIMEOUT)
-                                .await?
-                        }
-                        (None, _) => {
-                            // Normally this should not happen: SessionControl is expected to run
-                            // inside a session-aware tool context. Fallback to plain cancellation
-                            // so the core cancel behavior still works for nonstandard callers.
-                            coordinator
-                                .cancel_active_turn_for_session(session_id, CANCEL_WAIT_TIMEOUT)
-                                .await?
-                        }
-                    };
+                let scheduler = get_global_scheduler();
+                let cancel_route = resolve_session_control_cancel_route(
+                    context.session_id.as_deref(),
+                    scheduler.is_some(),
+                );
+                let cancelled_turn_id = match (cancel_route, scheduler) {
+                    (
+                        SessionControlCancelRoute::RequesterViaScheduler {
+                            requester_session_id,
+                        },
+                        Some(scheduler),
+                    ) => {
+                        scheduler
+                            .cancel_active_turn_for_session_from_requester(
+                                session_id,
+                                &requester_session_id,
+                                CANCEL_WAIT_TIMEOUT,
+                            )
+                            .await?
+                    }
+                    _ => {
+                        // Fallback covers unusual tool contexts and startup states where the
+                        // global scheduler is not available; concrete cancellation still works.
+                        coordinator
+                            .cancel_active_turn_for_session(session_id, CANCEL_WAIT_TIMEOUT)
+                            .await?
+                    }
+                };
                 let had_active_turn = cancelled_turn_id.is_some();
-                let status = if had_active_turn {
-                    "cancel_requested"
-                } else {
-                    "no_active_turn"
-                };
-                let result_for_assistant = if let Some(turn_id) = cancelled_turn_id.as_deref() {
-                    format!(
-                        "Cancellation requested for the active turn '{}' in session '{}' within workspace '{}'. The session remains available for future work, and queued messages are not cleared.",
-                        turn_id, session_id, workspace
-                    )
-                } else {
-                    format!(
-                        "Session '{}' in workspace '{}' has no active turn to cancel. The session remains available for future work.",
-                        session_id, workspace
-                    )
-                };
+                let status = session_control_cancel_status(cancelled_turn_id.as_deref());
+                let result_for_assistant = session_control_cancel_result_message(
+                    session_id,
+                    &workspace,
+                    cancelled_turn_id.as_deref(),
+                );
 
                 Ok(vec![ToolResult::Result {
                     data: json!({
@@ -704,7 +430,7 @@ Arguments:
                 let session_id = params.session_id.as_deref().ok_or_else(|| {
                     BitFunError::tool("session_id is required for delete".to_string())
                 })?;
-                Self::validate_session_id(session_id).map_err(BitFunError::tool)?;
+                validate_session_id(session_id).map_err(BitFunError::tool)?;
                 let workspace = self
                     .resolve_effective_workspace(
                         SessionControlAction::Delete,
@@ -734,9 +460,8 @@ Arguments:
                         "workspace": workspace.clone(),
                         "session_id": session_id,
                     }),
-                    result_for_assistant: Some(format!(
-                        "Deleted session '{}' from workspace '{}'.",
-                        session_id, workspace
+                    result_for_assistant: Some(session_control_deleted_result_message(
+                        session_id, &workspace,
                     )),
                     image_attachments: None,
                 }])


### PR DESCRIPTION
## Summary
- Move turn outcome lifecycle planning into `bitfun-agent-runtime`; the core scheduler now executes the returned plan instead of owning the branching policy.
- Move `SessionControl` input validation, defaults, tool-use rendering, result text, and cancel-route decisions into `bitfun-agent-runtime`; core keeps workspace resolution, session manager calls, scheduler/coordinator cancellation, and `ToolResult` wrapping.
- Update the M3 plan/completed docs and the `agent-runtime` module guide to reflect the migrated owner boundary.

## Risk / compatibility
- No intended changes to tool schema, permissions, `/goal`, continuation wire shape, session execution, or queue semantics.
- No Cargo dependency changes; `bitfun-agent-runtime` still does not depend on `bitfun-core` or platform/concrete service crates.
- Concrete session lifecycle, metadata/persistence IO, event emitter wiring, permission UI/channel waits, concrete prompt assembly, and product tool execution remain in core/Product Assembly adapters.

## Verification
- `cargo test -p bitfun-agent-runtime`
- `cargo test -p bitfun-core session_control --features product-full -- --nocapture`
- `cargo test -p bitfun-core scheduler --features product-full -- --nocapture`
- `cargo check -p bitfun-core --features product-full`
- `cargo check --workspace`
- `node scripts/check-core-boundaries.mjs`
- `pnpm run check:repo-hygiene`
