### PR TITLE
perf(flow-chat): stabilize historical session rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "e2e:test:l1": "cross-env BITFUN_E2E_APP_MODE=debug pnpm --dir tests/e2e run test:l1",
     "e2e:test:smoke": "cross-env BITFUN_E2E_APP_MODE=debug pnpm --dir tests/e2e run test:smoke",
     "e2e:test:chat": "cross-env BITFUN_E2E_APP_MODE=debug pnpm --dir tests/e2e run test:chat",
-    "e2e:test:perf:debug": "cross-env BITFUN_E2E_APP_MODE=debug pnpm --dir tests/e2e run test:perf",
-    "e2e:test:perf:release-fast": "cross-env BITFUN_E2E_APP_MODE=release-fast pnpm --dir tests/e2e run test:perf"
+    "e2e:test:perf:debug": "cross-env BITFUN_E2E_APP_MODE=debug E2E_LOG_LEVEL=warn pnpm --dir tests/e2e run test:perf",
+    "e2e:test:perf:release-fast": "cross-env BITFUN_E2E_APP_MODE=release-fast E2E_LOG_LEVEL=warn pnpm --dir tests/e2e run test:perf"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.10.0",

--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -1,7 +1,7 @@
 //! Theme System
 
 use std::sync::{OnceLock, RwLock};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use bitfun_core::infrastructure::try_get_path_manager_arc;
 use bitfun_core::service::config::types::GlobalConfig;
@@ -18,10 +18,105 @@ const AGENT_COMPANION_WINDOW_MAX_WIDTH: f64 = 360.0;
 const AGENT_COMPANION_WINDOW_MAX_HEIGHT: f64 = 240.0;
 const AGENT_COMPANION_WINDOW_MARGIN: i32 = 64;
 const AGENT_COMPANION_WINDOW_EDGE_MARGIN: f64 = 8.0;
+#[cfg(target_os = "windows")]
+const WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_MAX: Duration = Duration::from_millis(150);
+#[cfg(target_os = "windows")]
+const WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_MIN: Duration = Duration::from_millis(16);
+#[cfg(target_os = "windows")]
+const WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_POLL: Duration = Duration::from_millis(8);
 
 static AGENT_COMPANION_WINDOW_OPS: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 static AGENT_COMPANION_WINDOW_LAST_POSITION: OnceLock<RwLock<Option<tauri::LogicalPosition<f64>>>> =
     OnceLock::new();
+
+#[cfg(target_os = "windows")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WindowsMaximizeShowWaitAction {
+    Ready,
+    Sleep(Duration),
+    TimedOut,
+}
+
+#[cfg(target_os = "windows")]
+fn windows_maximize_show_wait_action(
+    is_maximized: Option<bool>,
+    elapsed: Duration,
+) -> WindowsMaximizeShowWaitAction {
+    if is_maximized == Some(true) && elapsed >= WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_MIN {
+        return WindowsMaximizeShowWaitAction::Ready;
+    }
+
+    if elapsed >= WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_MAX {
+        return WindowsMaximizeShowWaitAction::TimedOut;
+    }
+
+    let target_wait = if is_maximized == Some(true) {
+        WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_MIN
+    } else {
+        WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_MAX
+    };
+    WindowsMaximizeShowWaitAction::Sleep(
+        target_wait
+            .saturating_sub(elapsed)
+            .min(WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_POLL),
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn read_windows_maximize_state(
+    window: &tauri::WebviewWindow,
+    logged_error: &mut bool,
+) -> Option<bool> {
+    match window.is_maximized() {
+        Ok(is_maximized) => Some(is_maximized),
+        Err(error) => {
+            if !*logged_error {
+                warn!(
+                    "Failed to read main window maximize state during startup show wait: {}",
+                    error
+                );
+                *logged_error = true;
+            }
+            None
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn wait_for_windows_maximize_before_show(window: &tauri::WebviewWindow) -> &'static str {
+    let started_at = Instant::now();
+    let mut logged_error = false;
+
+    loop {
+        match windows_maximize_show_wait_action(
+            read_windows_maximize_state(window, &mut logged_error),
+            started_at.elapsed(),
+        ) {
+            WindowsMaximizeShowWaitAction::Ready => return "ready",
+            WindowsMaximizeShowWaitAction::TimedOut => return "timeout",
+            WindowsMaximizeShowWaitAction::Sleep(duration) => std::thread::sleep(duration),
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+async fn wait_for_windows_maximize_before_show_async(
+    window: &tauri::WebviewWindow,
+) -> &'static str {
+    let started_at = Instant::now();
+    let mut logged_error = false;
+
+    loop {
+        match windows_maximize_show_wait_action(
+            read_windows_maximize_state(window, &mut logged_error),
+            started_at.elapsed(),
+        ) {
+            WindowsMaximizeShowWaitAction::Ready => return "ready",
+            WindowsMaximizeShowWaitAction::TimedOut => return "timeout",
+            WindowsMaximizeShowWaitAction::Sleep(duration) => tokio::time::sleep(duration).await,
+        }
+    }
+}
 
 fn agent_companion_window_ops() -> &'static tokio::sync::Mutex<()> {
     AGENT_COMPANION_WINDOW_OPS.get_or_init(|| tokio::sync::Mutex::new(()))
@@ -568,11 +663,17 @@ fn show_main_window_for_startup(
             );
         }
         let show_delay_started_at = Instant::now();
-        std::thread::sleep(std::time::Duration::from_millis(150));
+        let show_wait_outcome = wait_for_windows_maximize_before_show(window);
         startup_trace.record_elapsed_step(
             "native_window",
             "windows_show_after_maximize_wait",
             show_delay_started_at,
+        );
+        debug!(
+            "Main window startup show step completed: step=wait_for_maximize_state outcome={} duration_ms={} since_create_start_ms={}",
+            show_wait_outcome,
+            show_delay_started_at.elapsed().as_millis(),
+            total_started_at.elapsed().as_millis()
         );
     }
 
@@ -915,7 +1016,13 @@ pub async fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
                 step_started_at.elapsed().as_millis()
             );
 
-            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+            let wait_started_at = Instant::now();
+            let show_wait_outcome = wait_for_windows_maximize_before_show_async(&main_window).await;
+            debug!(
+                "Main window show step completed: step=wait_for_maximize_state outcome={} duration_ms={}",
+                show_wait_outcome,
+                wait_started_at.elapsed().as_millis()
+            );
         }
 
         let step_started_at = Instant::now();
@@ -953,4 +1060,44 @@ pub async fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
         total_started_at.elapsed().as_millis()
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_maximize_show_wait_releases_when_maximized() {
+        assert_eq!(
+            windows_maximize_show_wait_action(Some(true), Duration::ZERO),
+            WindowsMaximizeShowWaitAction::Sleep(WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_POLL)
+        );
+        assert_eq!(
+            windows_maximize_show_wait_action(Some(true), WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_MIN),
+            WindowsMaximizeShowWaitAction::Ready
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_maximize_show_wait_polls_until_max_wait() {
+        assert_eq!(
+            windows_maximize_show_wait_action(Some(false), Duration::from_millis(20)),
+            WindowsMaximizeShowWaitAction::Sleep(WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_POLL)
+        );
+        assert_eq!(
+            windows_maximize_show_wait_action(None, Duration::from_millis(148)),
+            WindowsMaximizeShowWaitAction::Sleep(Duration::from_millis(2))
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_maximize_show_wait_times_out_at_original_bound() {
+        assert_eq!(
+            windows_maximize_show_wait_action(Some(false), WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_MAX),
+            WindowsMaximizeShowWaitAction::TimedOut
+        );
+    }
 }

--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useCallback, useState, useRef } from 'react';
+import { lazy, Suspense, useEffect, useCallback, useLayoutEffect, useState, useRef } from 'react';
 import { useShortcut } from '@/infrastructure/hooks/useShortcut';
 import { useHasDismissibleLayer } from '@/infrastructure/hooks/useDismissibleLayer';
 import { dismissibleLayerManager } from '@/infrastructure/services/DismissibleLayerManager';
@@ -17,6 +17,8 @@ import { useGlobalSceneShortcuts } from './hooks/useGlobalSceneShortcuts';
 import { useDebugInspector } from '@/infrastructure/debug/useDebugInspector';
 import { useI18n } from '@/infrastructure/i18n';
 import { scheduleDeferredStartupSystems } from './startup/deferredStartupSystems';
+import { shouldScheduleDeferredStartupSystems } from './startup/deferredStartupGate';
+import { STARTUP_OVERLAY_HIDDEN_EVENT } from './startup/startupSignals';
 import {
   getStartupOverlayElapsedMs,
   hideStartupOverlay,
@@ -41,7 +43,7 @@ const LazyAppLayout = lazy(async () => {
     startupTrace.markPhase('app_layout_import_end');
     return {
       default: function AppLayoutStartupGate({ onReady }: AppLayoutStartupGateProps) {
-        useEffect(() => {
+        useLayoutEffect(() => {
           startupTrace.markPhase('app_layout_ready');
           onReady();
         }, [onReady]);
@@ -77,12 +79,77 @@ function App() {
   const [startupOverlayVisible, setStartupOverlayVisible] = useState(isStartupOverlayPresent);
   const hasAppDismissibleLayer = useHasDismissibleLayer('app');
   const mainWindowShownRef = useRef(false);
+  const userCloseRequestedRef = useRef(false);
   const interactiveShellReadyRef = useRef(false);
+  const interactiveShellReadyFrameRef = useRef<number | null>(null);
+  const workspaceLoadingRef = useRef(workspaceLoading);
+  const appLayoutReadyRef = useRef(false);
   const [interactiveShellReady, setInteractiveShellReady] = useState(false);
   const [appLayoutReady, setAppLayoutReady] = useState(false);
+
+  workspaceLoadingRef.current = workspaceLoading;
+
+  const releaseInteractiveShellReadyIfReady = useCallback((reason: string) => {
+    const latestWorkspaceLoading = workspaceLoadingRef.current;
+    const latestAppLayoutReady = appLayoutReadyRef.current;
+    startupTrace.markPhase('interactive_shell_ready_gate_check', {
+      workspaceLoading: latestWorkspaceLoading,
+      appLayoutReady: latestAppLayoutReady,
+      alreadyReady: interactiveShellReadyRef.current,
+      reason,
+      afterPaint: true,
+    });
+    if (latestWorkspaceLoading || !latestAppLayoutReady || interactiveShellReadyRef.current) {
+      return;
+    }
+    interactiveShellReadyRef.current = true;
+    startupTrace.markPhase('interactive_shell_ready', { reason });
+    window.dispatchEvent(new CustomEvent('bitfun:interactive-shell-ready', {
+      detail: { reason },
+    }));
+    setInteractiveShellReady(true);
+  }, []);
+
+  const markInteractiveShellReadyIfReady = useCallback((reason: string) => {
+    const latestWorkspaceLoading = workspaceLoadingRef.current;
+    const latestAppLayoutReady = appLayoutReadyRef.current;
+    startupTrace.markPhase('interactive_shell_ready_gate_check', {
+      workspaceLoading: latestWorkspaceLoading,
+      appLayoutReady: latestAppLayoutReady,
+      alreadyReady: interactiveShellReadyRef.current,
+      alreadyScheduled: interactiveShellReadyFrameRef.current !== null,
+      reason,
+    });
+    if (
+      latestWorkspaceLoading ||
+      !latestAppLayoutReady ||
+      interactiveShellReadyRef.current ||
+      interactiveShellReadyFrameRef.current !== null
+    ) {
+      return;
+    }
+
+    startupTrace.markPhase('interactive_shell_ready_after_paint_scheduled', { reason });
+    interactiveShellReadyFrameRef.current = window.requestAnimationFrame(() => {
+      interactiveShellReadyFrameRef.current = null;
+      releaseInteractiveShellReadyIfReady(`${reason}-after-paint`);
+    });
+  }, [releaseInteractiveShellReadyIfReady]);
+
   const handleAppLayoutReady = useCallback(() => {
     startupTrace.markPhase('app_layout_ready_state_update_requested');
+    appLayoutReadyRef.current = true;
     setAppLayoutReady(true);
+    markInteractiveShellReadyIfReady('app-layout-ready');
+  }, [markInteractiveShellReadyIfReady]);
+
+  useEffect(() => {
+    return () => {
+      if (interactiveShellReadyFrameRef.current !== null) {
+        window.cancelAnimationFrame(interactiveShellReadyFrameRef.current);
+        interactiveShellReadyFrameRef.current = null;
+      }
+    };
   }, []);
 
   // Once the workspace finishes loading, wait for the remaining min-display
@@ -96,6 +163,8 @@ function App() {
       void hideStartupOverlay().then(() => {
         if (!cancelled) {
           setStartupOverlayVisible(false);
+          startupTrace.markPhase('startup_overlay_hidden');
+          window.dispatchEvent(new CustomEvent(STARTUP_OVERLAY_HIDDEN_EVENT));
         }
       });
     }, remaining);
@@ -104,6 +173,38 @@ function App() {
       window.clearTimeout(timer);
     };
   }, [workspaceLoading, appLayoutReady]);
+
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return;
+    }
+
+    let unlisten: (() => void) | null = null;
+    let disposed = false;
+
+    void import('@tauri-apps/api/event')
+      .then(({ listen }) => listen('bitfun_main_window_close_requested', () => {
+        userCloseRequestedRef.current = true;
+        startupTrace.markPhase('main_window_user_close_requested', { reason: 'user-close-requested' });
+      }))
+      .then(removeListener => {
+        if (disposed) {
+          removeListener();
+          return;
+        }
+        unlisten = removeListener;
+      })
+      .catch(error => {
+        if (!disposed) {
+          log.warn('Failed to listen for main window close request in startup visibility guard', error);
+        }
+      });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
 
   const showMainWindow = useCallback(async (reason: string) => {
     if (mainWindowShownRef.current) {
@@ -136,6 +237,14 @@ function App() {
   }, []);
 
   const verifyMainWindowVisible = useCallback(async (reason: string) => {
+    if (userCloseRequestedRef.current) {
+      log.debug('Skipping main window startup visibility retry after user close request', {
+        reason,
+        closeReason: 'user-close-requested',
+      });
+      return;
+    }
+
     if (!isTauriRuntime()) {
       void showMainWindow(reason);
       return;
@@ -172,21 +281,11 @@ function App() {
   }, [showMainWindow]);
 
   useEffect(() => {
-    startupTrace.markPhase('interactive_shell_ready_gate_check', {
-      workspaceLoading,
-      appLayoutReady,
-      alreadyReady: interactiveShellReadyRef.current,
-    });
-    if (workspaceLoading || !appLayoutReady || interactiveShellReadyRef.current) {
-      return;
+    if (appLayoutReady) {
+      appLayoutReadyRef.current = true;
     }
-    interactiveShellReadyRef.current = true;
-    startupTrace.markPhase('interactive_shell_ready');
-    window.dispatchEvent(new CustomEvent('bitfun:interactive-shell-ready', {
-      detail: { reason: 'workspace-and-layout-ready' },
-    }));
-    setInteractiveShellReady(true);
-  }, [workspaceLoading, appLayoutReady]);
+    markInteractiveShellReadyIfReady('workspace-or-layout-state');
+  }, [workspaceLoading, appLayoutReady, markInteractiveShellReadyIfReady]);
 
   // If the early reveal path fails, keep the old post-splash show as a retry.
   useEffect(() => {
@@ -210,13 +309,14 @@ function App() {
     return () => window.clearTimeout(timer);
   }, [verifyMainWindowVisible]);
 
-  // Non-critical systems are delayed until the shell is interactive.
+  // Non-critical systems are delayed until the shell is interactive and the
+  // startup overlay has fully handed off to the app surface.
   useEffect(() => {
-    if (!interactiveShellReady) {
+    if (!shouldScheduleDeferredStartupSystems({ interactiveShellReady, startupOverlayVisible })) {
       return;
     }
 
-    log.info('Application interactive, scheduling deferred systems');
+    log.info('Application visible and interactive, scheduling deferred systems');
     const startupSystemsHandle = scheduleDeferredStartupSystems();
     startupSystemsHandle.promise.catch(error => {
       if (!isBackgroundTaskCancelledError(error)) {
@@ -225,7 +325,7 @@ function App() {
     });
 
     return () => startupSystemsHandle.cancel();
-  }, [interactiveShellReady]);
+  }, [interactiveShellReady, startupOverlayVisible]);
 
   useEffect(() => {
     if (!interactiveShellReady || startupOverlayVisible) {

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -22,6 +22,10 @@ import {
   openMainSession,
   selectActiveBtwSessionTab,
 } from '@/flow_chat/services/openBtwSession';
+import {
+  dispatchHistorySessionOpenIntent,
+  shouldShowHistorySessionOpenIntent,
+} from '@/flow_chat/services/sessionOpenIntent';
 import { resolveSessionRelationship } from '@/flow_chat/utils/sessionMetadata';
 import {
   compareSessionsForNavStable,
@@ -61,6 +65,18 @@ const resolveSessionModeType = (session: Session): SessionMode => {
 
 const getTitle = (session: Session): string =>
   resolveSessionTitle(session, (key, options) => i18nService.t(key, options));
+
+const waitForHistoryOpenIntentPaint = (): Promise<void> =>
+  new Promise(resolve => {
+    if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
+      globalThis.setTimeout(resolve, 0);
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => resolve());
+    });
+  });
 
 const getChildSessionBadge = (kind: Session['sessionKind']): string => {
   const normalizedKind =
@@ -379,12 +395,48 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   const scheduledJobsSession = scheduledJobsSessionId
     ? flowChatState.sessions.get(scheduledJobsSessionId) ?? null
     : null;
+  const lastHistoryOpenIntentRef = useRef<{ sessionId: string; atMs: number } | null>(null);
+
+  const dispatchHistoryOpenIntentForSession = useCallback(
+    (session: Session): boolean => {
+      const sessionId = session.sessionId;
+      if (
+        sessionId === activeSessionId ||
+        !shouldShowHistorySessionOpenIntent(session)
+      ) {
+        return false;
+      }
+
+      const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+      const lastIntent = lastHistoryOpenIntentRef.current;
+      if (
+        lastIntent &&
+        lastIntent.sessionId === sessionId &&
+        now - lastIntent.atMs < 250
+      ) {
+        return true;
+      }
+
+      lastHistoryOpenIntentRef.current = { sessionId, atMs: now };
+      dispatchHistorySessionOpenIntent(sessionId, getTitle(session));
+      return true;
+    },
+    [activeSessionId],
+  );
 
   const handleSwitch = useCallback(
     async (sessionId: string) => {
       if (editingSessionId) return;
       try {
         const session = flowChatStore.getState().sessions.get(sessionId);
+        const historyOpenIntentDispatched = session
+          ? dispatchHistoryOpenIntentForSession(session)
+          : false;
+        if (session) {
+          if (historyOpenIntentDispatched) {
+            await waitForHistoryOpenIntentPaint();
+          }
+        }
         const relationship = resolveSessionRelationship(session);
         const parentSessionId = relationship.parentSessionId;
         const mustActivateWorkspace =
@@ -429,11 +481,28 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
     },
     [
       activeSessionId,
+      dispatchHistoryOpenIntentForSession,
       editingSessionId,
       setActiveWorkspace,
       workspaceId,
       currentWorkspace?.id,
     ]
+  );
+
+  const handleSessionOpenPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLElement>, session: Session) => {
+      if (editingSessionId || session.sessionId === activeSessionId) {
+        return;
+      }
+
+      const target = event.target as HTMLElement | null;
+      if (target?.closest('.bitfun-nav-panel__inline-item-actions, .bitfun-nav-panel__inline-item-edit')) {
+        return;
+      }
+
+      dispatchHistoryOpenIntentForSession(session);
+    },
+    [activeSessionId, dispatchHistoryOpenIntentForSession, editingSessionId],
   );
 
   const resolveSessionTitle = useCallback(
@@ -711,6 +780,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
               data-testid="session-nav-item"
               data-session-id={session.sessionId}
               data-session-title={sessionTitle}
+              onPointerDown={event => handleSessionOpenPointerDown(event, session)}
               onClick={() => handleSwitch(session.sessionId)}
             >
               {showSessionModeIcon ? (

--- a/src/web-ui/src/app/startup/deferredStartupGate.ts
+++ b/src/web-ui/src/app/startup/deferredStartupGate.ts
@@ -1,0 +1,8 @@
+export interface DeferredStartupGateState {
+  interactiveShellReady: boolean;
+  startupOverlayVisible: boolean;
+}
+
+export function shouldScheduleDeferredStartupSystems(state: DeferredStartupGateState): boolean {
+  return state.interactiveShellReady && !state.startupOverlayVisible;
+}

--- a/src/web-ui/src/app/startup/deferredStartupSystems.test.ts
+++ b/src/web-ui/src/app/startup/deferredStartupSystems.test.ts
@@ -1,6 +1,28 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { shouldScheduleDeferredStartupSystems } from './deferredStartupGate';
 import { scheduleDeferredStartupSystems } from './deferredStartupSystems';
+
+describe('shouldScheduleDeferredStartupSystems', () => {
+  it('waits for both interactive readiness and startup overlay handoff', () => {
+    expect(shouldScheduleDeferredStartupSystems({
+      interactiveShellReady: false,
+      startupOverlayVisible: true,
+    })).toBe(false);
+    expect(shouldScheduleDeferredStartupSystems({
+      interactiveShellReady: true,
+      startupOverlayVisible: true,
+    })).toBe(false);
+    expect(shouldScheduleDeferredStartupSystems({
+      interactiveShellReady: false,
+      startupOverlayVisible: false,
+    })).toBe(false);
+    expect(shouldScheduleDeferredStartupSystems({
+      interactiveShellReady: true,
+      startupOverlayVisible: false,
+    })).toBe(true);
+  });
+});
 
 describe('scheduleDeferredStartupSystems', () => {
   it('schedules MCP, ACP, and IDE startup as deferred idle work', async () => {

--- a/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
+++ b/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
@@ -2,6 +2,9 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+import { shouldScheduleDeferredStartupSystems } from './deferredStartupGate';
+import { STARTUP_OVERLAY_HIDDEN_EVENT } from './startupSignals';
+
 function readSource(relativePath: string): string {
   return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
 }
@@ -81,12 +84,44 @@ describe('startup performance contract', () => {
     );
   });
 
-  it('starts non-critical work after the shell is interactive', () => {
+  it('keeps Windows startup show wait state-driven instead of fixed-delay only', () => {
+    const desktopThemeSource = readSource('../../../../apps/desktop/src/theme.rs');
+
+    expect(desktopThemeSource).toContain('WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_MAX');
+    expect(desktopThemeSource).toContain('WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_MIN');
+    expect(desktopThemeSource).toContain('WINDOWS_STARTUP_MAXIMIZE_SHOW_WAIT_POLL');
+    expect(desktopThemeSource).toContain('windows_maximize_show_wait_action');
+    expect(desktopThemeSource).toContain('window.is_maximized()');
+    expect(desktopThemeSource).toContain('windows_show_after_maximize_wait');
+    expect(desktopThemeSource).not.toContain(
+      'std::thread::sleep(std::time::Duration::from_millis(150))'
+    );
+  });
+
+  it('starts non-critical work after the startup overlay handoff', () => {
     const source = readSource('../../main.tsx');
 
-    expect(source).toContain("signalName: 'bitfun:interactive-shell-ready'");
+    expect(STARTUP_OVERLAY_HIDDEN_EVENT).toBe('bitfun:startup-overlay-hidden');
+    expect(source).toContain('STARTUP_OVERLAY_HIDDEN_EVENT');
+    expect(source).not.toContain("signalName: 'bitfun:interactive-shell-ready'");
     expect(source).not.toContain("signalName: 'bitfun:main-window-shown'");
     expect(source).toContain('fallbackTimeoutMs: 10000');
+  });
+
+  it('starts deferred app systems only after the startup overlay has handed off', () => {
+    const source = readSource('../App.tsx');
+
+    expect(shouldScheduleDeferredStartupSystems({
+      interactiveShellReady: true,
+      startupOverlayVisible: true,
+    })).toBe(false);
+    expect(shouldScheduleDeferredStartupSystems({
+      interactiveShellReady: true,
+      startupOverlayVisible: false,
+    })).toBe(true);
+    expect(source).toContain('shouldScheduleDeferredStartupSystems({ interactiveShellReady, startupOverlayVisible })');
+    expect(source).toContain('window.dispatchEvent(new CustomEvent(STARTUP_OVERLAY_HIDDEN_EVENT))');
+    expect(source).toContain('}, [interactiveShellReady, startupOverlayVisible]);');
   });
 
   it('does not initialize AI from the root app component', () => {
@@ -97,6 +132,7 @@ describe('startup performance contract', () => {
     expect(source).not.toMatch(/useCurrentModelConfig/);
     expect(source).not.toMatch(/from\s+['"]@\/infrastructure\/config\/services\/AIExperienceConfigService['"]/);
     expect(source).toContain('bitfun:interactive-shell-ready');
+    expect(source).toContain('STARTUP_OVERLAY_HIDDEN_EVENT');
   });
 
   it('keeps the heavy app layout out of the root startup module', () => {
@@ -106,6 +142,21 @@ describe('startup performance contract', () => {
     expect(source).toContain("import('./layout/AppLayout')");
     expect(source).toContain('app_layout_ready');
     expect(source).toContain('!appLayoutReady');
+  });
+
+  it('releases interactive shell readiness without waiting for an extra AppLayout state commit', () => {
+    const source = readSource('../App.tsx');
+
+    expect(source).toContain('workspaceLoadingRef.current');
+    expect(source).toContain('appLayoutReadyRef.current');
+    expect(source).toContain('interactiveShellReadyFrameRef.current');
+    expect(source).toContain('markInteractiveShellReadyIfReady');
+    expect(source).toContain('releaseInteractiveShellReadyIfReady');
+    expect(source).toContain('useLayoutEffect');
+    expect(source).toContain('requestAnimationFrame');
+    expect(source).toContain('interactive_shell_ready_after_paint_scheduled');
+    expect(source).toContain("markInteractiveShellReadyIfReady('app-layout-ready')");
+    expect(source).toContain("markInteractiveShellReadyIfReady('workspace-or-layout-state')");
   });
 
   it('loads Monaco styling and loader config only through editor initialization', () => {
@@ -144,12 +195,23 @@ describe('startup performance contract', () => {
     expect(source).toMatch(/import\s+type\s+\*\s+as\s+monaco\s+from\s+['"]monaco-editor['"]/);
   });
 
-  it('prewarms editor runtime only after the shell is interactive', () => {
+  it('prewarms editor runtime only after the shell is interactive and visible', () => {
     const source = readSource('../App.tsx');
 
     expect(source).toContain('interactiveShellReady');
+    expect(source).toContain('startupOverlayVisible');
     expect(source).toContain("import('@/tools/editor/services/MonacoStartupWarmup')");
     expect(source).toContain('scheduleMonacoStartupWarmup()');
+  });
+
+  it('does not let startup visibility retries reopen a user-hidden main window', () => {
+    const source = readSource('../App.tsx');
+
+    expect(source).toContain('userCloseRequestedRef');
+    expect(source).toContain("listen('bitfun_main_window_close_requested'");
+    expect(source).toContain('user-close-requested');
+    expect(source).toContain('startup-complete');
+    expect(source).toContain('startup-watchdog');
   });
 
   it('does not remount the historical message list when full hydration prepends older turns', () => {
@@ -221,6 +283,15 @@ describe('startup performance contract', () => {
       expect(source).not.toMatch(/from\s+['"]\.\.\/\.\.\/flow_chat['"]/);
       expect(source).not.toMatch(/from\s+['"]@\/flow_chat['"]/);
     }
+  });
+
+  it('keeps startup session metadata paging on the narrow SessionAPI entrypoint', () => {
+    const source = readSource('../../flow_chat/store/FlowChatStore.ts');
+
+    expect(source).toContain("import('@/infrastructure/api/service-api/SessionAPI')");
+    expect(source).not.toMatch(
+      /const\s+\{\s*sessionAPI\s*\}\s*=\s*await\s+import\(['"]@\/infrastructure\/api['"]\)/
+    );
   });
 
   it('keeps Agent companion implementation modules out of the root startup bundle', () => {

--- a/src/web-ui/src/app/startup/startupSignals.ts
+++ b/src/web-ui/src/app/startup/startupSignals.ts
@@ -1,0 +1,1 @@
+export const STARTUP_OVERLAY_HIDDEN_EVENT = 'bitfun:startup-overlay-hidden';

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.scss
@@ -155,6 +155,14 @@
   animation: flow-tool-completed-exit 1000ms ease-in-out both;
 }
 
+.flowchat-flow-item--tool-settled {
+  opacity: 0;
+  transform: translateY(-4px);
+  max-height: 0;
+  margin-bottom: 0;
+  pointer-events: none;
+}
+
 @keyframes flow-tool-active-enter {
   from {
     opacity: 0;

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
@@ -20,7 +20,12 @@ import { FlowChatStore } from '../../store/FlowChatStore';
 import { taskCollapseStateManager } from '../../store/TaskCollapseStateManager';
 import { ExportImageButton } from './ExportImageButton';
 import { ForkSessionButton } from './ForkSessionButton';
-import { buildModelRoundItemGroups, COMPLETED_TOOL_TRANSIENT_MS, type ModelRoundItemGroup } from './modelRoundItemGrouping';
+import {
+  buildModelRoundItemGroups,
+  COMPLETED_TOOL_TRANSIENT_MS,
+  isCompletedToolInTransientWindow,
+  type ModelRoundItemGroup,
+} from './modelRoundItemGrouping';
 import {
   MODEL_ROUND_GROUP_RENDER_CHUNK_DELAY_MS,
   getInitialModelRoundGroupRenderCount,
@@ -163,6 +168,7 @@ interface TaskWithSubagentWrapperProps {
   directSubagentSessionId?: string;
   turnId: string;
   roundId?: string;
+  completedToolExitNowMs: number;
 }
 
 const TaskWithSubagentWrapper: React.FC<TaskWithSubagentWrapperProps> = React.memo(({
@@ -172,6 +178,7 @@ const TaskWithSubagentWrapper: React.FC<TaskWithSubagentWrapperProps> = React.me
   directSubagentSessionId,
   turnId,
   roundId,
+  completedToolExitNowMs,
 }) => {
   const isCollapsed = useTaskCollapsed(parentTaskToolId);
   const isTaskRunning =
@@ -193,6 +200,7 @@ const TaskWithSubagentWrapper: React.FC<TaskWithSubagentWrapperProps> = React.me
         turnId={turnId}
         roundId={roundId}
         isLastItem={false}
+        completedToolExitNowMs={completedToolExitNowMs}
       />
       <SubagentProjectionView
         parentTaskToolId={parentTaskToolId}
@@ -482,6 +490,7 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
                   turnId={turnId}
                   roundId={round.id}
                   isLastItem={isLast && itemIdx === group.items.length - 1}
+                  completedToolExitNowMs={transientNowMs}
                 />
               ));
 
@@ -499,6 +508,7 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
                     directSubagentSessionId={projectedSubagent.subagentSessionId}
                     turnId={turnId}
                     roundId={round.id}
+                    completedToolExitNowMs={transientNowMs}
                   />
                 );
               }
@@ -509,6 +519,7 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
                   turnId={turnId}
                   roundId={round.id}
                   isLastItem={isLast}
+                  completedToolExitNowMs={transientNowMs}
                 />
               );
             }
@@ -570,10 +581,17 @@ interface FlowItemRendererProps {
   turnId: string;
   roundId?: string;
   isLastItem?: boolean;
+  completedToolExitNowMs: number;
 }
 
 // Do not memoize: streaming content updates frequently.
-const FlowItemRenderer: React.FC<FlowItemRendererProps> = ({ item, turnId, roundId, isLastItem }) => {
+const FlowItemRenderer: React.FC<FlowItemRendererProps> = ({
+  item,
+  turnId,
+  roundId,
+  isLastItem,
+  completedToolExitNowMs,
+}) => {
   const {
     onToolConfirm,
     onToolReject,
@@ -604,10 +622,16 @@ const FlowItemRenderer: React.FC<FlowItemRendererProps> = ({ item, turnId, round
       const toolItem = item as FlowToolItem;
       const isCompletedTool = toolItem.status === 'completed';
       const isCollapsible = isCollapsibleTool(toolItem.toolName);
+      const shouldAnimateCompletedExit =
+        isCollapsible &&
+        isCompletedTool &&
+        isCompletedToolInTransientWindow(toolItem, completedToolExitNowMs);
+      const isSettledCompletedTool = isCollapsible && isCompletedTool && !shouldAnimateCompletedExit;
       const toolClassName = [
         'flowchat-flow-item',
         isCollapsible && isCompletedTool ? 'flowchat-flow-item--tool-transition' : null,
-        isCollapsible && isCompletedTool ? 'flowchat-flow-item--tool-completed' : null,
+        shouldAnimateCompletedExit ? 'flowchat-flow-item--tool-completed' : null,
+        isSettledCompletedTool ? 'flowchat-flow-item--tool-settled' : null,
         isCollapsible && !isCompletedTool ? 'flowchat-flow-item--tool-active' : null,
       ].filter(Boolean).join(' ');
 

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -6,6 +6,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { ModernFlowChatContainer } from './ModernFlowChatContainer';
 import type { Session } from '../../types/flow-chat';
 import { flowChatStore } from '../../store/FlowChatStore';
+import { HISTORY_SESSION_OPEN_INTENT_EVENT } from '../../services/sessionOpenIntent';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -116,6 +117,7 @@ vi.mock('./VirtualMessageList', () => ({
 }));
 
 vi.mock('@/shared/utils/startupTrace', () => ({
+  isRemoteTraceContext: () => false,
   startupTrace: startupTraceMock,
 }));
 
@@ -311,7 +313,101 @@ describe('ModernFlowChatContainer historical empty state', () => {
     expect(container.querySelector('[data-testid="welcome-panel"]')).toBeNull();
   });
 
-  it('keeps a history loading overlay until restored latest text is visible', async () => {
+  it('covers the current message list after a historical session open intent', async () => {
+    stateMocks.activeSession = createSession({
+      sessionId: 'current-session',
+      isHistorical: false,
+      historyState: 'ready',
+      dialogTurns: [createTurn('turn-1', 'Current visible prompt')],
+    } as Partial<Session>);
+    stateMocks.virtualItems = [
+      { type: 'user-message', turnId: 'turn-1', data: { id: 'user-turn-1', content: 'Current visible prompt' } },
+    ];
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(container.querySelector('[data-testid="virtual-list"]')).not.toBeNull();
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).toBeNull();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(HISTORY_SESSION_OPEN_INTENT_EVENT, {
+        detail: { sessionId: 'history-session', sessionTitle: 'Saved investigation' },
+      }));
+    });
+
+    expect(container.textContent).not.toContain('Loading saved session');
+    expect(container.querySelector('[data-testid="virtual-list"]')).not.toBeNull();
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).toBeNull();
+    expect(container.querySelector('.modern-flowchat-container__history-open-intent-shield')).not.toBeNull();
+    expect(container.querySelector('.modern-flowchat-container__history-open-intent-spinner')).not.toBeNull();
+    expect(container.textContent).toContain('Hidden action');
+    expect(container.textContent).not.toContain('Saved investigation');
+    expect(container.querySelector('.modern-flowchat-container__messages')?.getAttribute('data-show-history-open-intent-overlay'))
+      .toBe('true');
+    (container.querySelector('[data-testid="virtual-list-action"]') as HTMLButtonElement | null)?.click();
+    expect(virtualListActionClickMock).not.toHaveBeenCalled();
+
+    stateMocks.activeSession = createSession({
+      sessionId: 'history-session',
+      historyState: 'metadata-only',
+    } as Partial<Session>);
+    stateMocks.virtualItems = [];
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(container.textContent).toContain('Loading saved session');
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).not.toBeNull();
+  });
+
+  it('removes the loading layer when a hydrating session receives its initial tail turns', async () => {
+    stateMocks.activeSession = createSession({
+      sessionId: 'history-session',
+      historyState: 'hydrating',
+      dialogTurns: [],
+    } as Partial<Session>);
+    stateMocks.virtualItems = [];
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    const initialOverlay = container.querySelector('.modern-flowchat-container__history-overlay');
+    expect(initialOverlay).not.toBeNull();
+    expect(container.querySelector('[data-testid="virtual-list"]')).toBeNull();
+
+    stateMocks.activeSession = createSession({
+      sessionId: 'history-session',
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      dialogTurns: [
+        createTurn('turn-1', 'Older restored prompt'),
+        createTurn('turn-2', 'Latest restored prompt'),
+      ],
+    } as Partial<Session>);
+    stateMocks.virtualItems = [
+      { type: 'user-message', turnId: 'turn-1', data: { id: 'user-turn-1', content: 'Older restored prompt' } },
+      { type: 'user-message', turnId: 'turn-2', data: { id: 'user-turn-2', content: 'Latest restored prompt' } },
+    ];
+    virtualListMock.isTurnTextRenderedInViewport.mockReturnValue(false);
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(container.querySelector('[data-testid="virtual-list"]')).not.toBeNull();
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).not.toBe(initialOverlay);
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).toBeNull();
+    expect(container.textContent).not.toContain('Loading saved session');
+    expect(container.querySelector('.modern-flowchat-container__messages')?.getAttribute('data-show-history-transition-overlay'))
+      .toBe('true');
+  });
+
+  it('keeps restored content visible while restored latest text is not ready', async () => {
     stateMocks.activeSession = createSession({
       isHistorical: false,
       historyState: 'ready',
@@ -332,18 +428,78 @@ describe('ModernFlowChatContainer historical empty state', () => {
     });
 
     expect(container.querySelector('[data-testid="virtual-list"]')).not.toBeNull();
-    expect(container.textContent).toContain('Loading saved session');
+    expect(container.textContent).not.toContain('Loading saved session');
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).toBeNull();
+    expect(container.querySelector('.modern-flowchat-container__messages')?.getAttribute('data-show-history-transition-overlay'))
+      .toBe('true');
 
     flushAnimationFrame();
-    expect(container.textContent).toContain('Loading saved session');
+    expect(container.querySelector('[data-testid="virtual-list"]')).not.toBeNull();
+    expect(container.textContent).not.toContain('Loading saved session');
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).toBeNull();
 
     virtualListMock.isTurnTextRenderedInViewport.mockReturnValue(true);
     flushAnimationFrame();
 
     expect(container.textContent).not.toContain('Loading saved session');
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).toBeNull();
   });
 
-  it('blocks pointer activation behind the history loading overlay', async () => {
+  it('does not show the initial history progress again when full hydration adds older turns', async () => {
+    stateMocks.activeSession = createSession({
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      dialogTurns: [
+        createTurn('turn-1', 'Older restored prompt'),
+        createTurn('turn-2', 'Latest restored prompt'),
+      ],
+    } as Partial<Session>);
+    stateMocks.virtualItems = [
+      { type: 'user-message', turnId: 'turn-1', data: { id: 'user-turn-1', content: 'Older restored prompt' } },
+      { type: 'user-message', turnId: 'turn-2', data: { id: 'user-turn-2', content: 'Latest restored prompt' } },
+    ];
+    virtualListMock.isTurnTextRenderedInViewport.mockReturnValue(false);
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).toBeNull();
+
+    virtualListMock.isTurnTextRenderedInViewport.mockReturnValue(true);
+    flushAnimationFrame();
+
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).toBeNull();
+
+    stateMocks.activeSession = createSession({
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      dialogTurns: [
+        createTurn('turn-0', 'Restored older prompt'),
+        createTurn('turn-1', 'Older restored prompt'),
+        createTurn('turn-2', 'Latest restored prompt'),
+      ],
+    } as Partial<Session>);
+    stateMocks.virtualItems = [
+      { type: 'user-message', turnId: 'turn-0', data: { id: 'user-turn-0', content: 'Restored older prompt' } },
+      { type: 'user-message', turnId: 'turn-1', data: { id: 'user-turn-1', content: 'Older restored prompt' } },
+      { type: 'user-message', turnId: 'turn-2', data: { id: 'user-turn-2', content: 'Latest restored prompt' } },
+    ];
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).toBeNull();
+  });
+
+  it('blocks pointer activation until restored latest text is visible', async () => {
+    const releaseSpy = vi
+      .spyOn(flowChatStore, 'releaseSessionHistoryCompletionAfterInitialPaint')
+      .mockReturnValue(true);
+
     stateMocks.activeSession = createSession({
       isHistorical: false,
       historyState: 'ready',
@@ -365,7 +521,8 @@ describe('ModernFlowChatContainer historical empty state', () => {
 
     const hiddenAction = container.querySelector('[data-testid="virtual-list-action"]') as HTMLButtonElement;
     expect(hiddenAction).not.toBeNull();
-    expect(container.textContent).toContain('Loading saved session');
+    expect(container.textContent).not.toContain('Loading saved session');
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).toBeNull();
 
     act(() => {
       hiddenAction.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
@@ -375,15 +532,29 @@ describe('ModernFlowChatContainer historical empty state', () => {
 
     virtualListMock.isTurnTextRenderedInViewport.mockReturnValue(true);
     flushAnimationFrame();
+    flushAnimationFrame();
+    flushAnimationFrame();
+
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).toBeNull();
+    expect(releaseSpy).toHaveBeenCalledWith('session-1');
+    expect(startupTraceMock.markPhase).toHaveBeenCalledWith(
+      'historical_session_initial_content_painted',
+      expect.objectContaining({
+        sessionId: 'session-1',
+        latestTurnId: 'turn-2',
+        released: true,
+      }),
+    );
 
     act(() => {
       hiddenAction.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
     });
 
     expect(virtualListActionClickMock).toHaveBeenCalledTimes(1);
+    releaseSpy.mockRestore();
   });
 
-  it('releases pending full history hydration when latest text visibility signal is missed', async () => {
+  it('keeps full history projection deferred when latest text visibility signal is missed', async () => {
     const releaseSpy = vi
       .spyOn(flowChatStore, 'releaseSessionHistoryCompletionAfterInitialPaint')
       .mockReturnValue(true);
@@ -412,21 +583,21 @@ describe('ModernFlowChatContainer historical empty state', () => {
     }
 
     expect(container.textContent).not.toContain('Loading saved session');
-    expect(releaseSpy).toHaveBeenCalledWith('session-1');
+    expect(releaseSpy).not.toHaveBeenCalled();
     expect(startupTraceMock.markPhase).toHaveBeenCalledWith(
       'historical_session_initial_content_paint_signal_missed',
-      expect.objectContaining({ released: true }),
+      expect.objectContaining({ attempts: 120 }),
     );
 
     releaseSpy.mockRestore();
   });
 
-  it('releases pending full history hydration when searching a partially loaded session', async () => {
+  it('requests full history projection when searching a partially loaded session', async () => {
     const pendingSpy = vi
       .spyOn(flowChatStore, 'hasPendingSessionHistoryCompletion')
       .mockReturnValue(true);
-    const releaseSpy = vi
-      .spyOn(flowChatStore, 'releaseSessionHistoryCompletionAfterInitialPaint')
+    const projectionSpy = vi
+      .spyOn(flowChatStore, 'requestSessionFullHistoryProjection')
       .mockReturnValue(true);
 
     searchStateMock.searchQuery = 'older prompt';
@@ -447,7 +618,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
       root.render(<ModernFlowChatContainer />);
     });
 
-    expect(releaseSpy).toHaveBeenCalledWith('session-1');
+    expect(projectionSpy).toHaveBeenCalledWith('session-1', 'search');
     expect(startupTraceMock.markPhase).toHaveBeenCalledWith(
       'historical_session_full_hydrate_released_for_search',
       expect.objectContaining({
@@ -456,7 +627,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
       }),
     );
 
-    releaseSpy.mockRestore();
+    projectionSpy.mockRestore();
     pendingSpy.mockRestore();
   });
 
@@ -602,17 +773,19 @@ describe('ModernFlowChatContainer historical empty state', () => {
     });
 
     expect(container.querySelector('[data-testid="virtual-list"]')).not.toBeNull();
-    expect(rafCallbacks.length).toBeGreaterThan(0);
-
-    flushAnimationFrame();
     expect(virtualListMock.pinTurnToTop).toHaveBeenCalledTimes(1);
     expect(virtualListMock.pinTurnToTop).toHaveBeenLastCalledWith('turn-2', {
       behavior: 'auto',
       pinMode: 'sticky-latest',
     });
+    expect(rafCallbacks.length).toBeGreaterThan(0);
 
     flushAnimationFrame();
     expect(virtualListMock.pinTurnToTop).toHaveBeenCalledTimes(2);
+    expect(virtualListMock.pinTurnToTop).toHaveBeenLastCalledWith('turn-2', {
+      behavior: 'auto',
+      pinMode: 'sticky-latest',
+    });
     expect(startupTraceMock.markPhase).toHaveBeenCalledWith(
       'historical_session_latest_anchor_attempt',
       expect.objectContaining({ accepted: false, attempt: 1, mode: 'sticky-latest' }),
@@ -690,7 +863,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
     );
   });
 
-  it('re-anchors completed restored history after full hydration expands the same latest turn', async () => {
+  it('does not re-anchor local restored history after full hydration expands the same latest turn', async () => {
     stateMocks.activeSession = createSession({
       isHistorical: false,
       historyState: 'ready',
@@ -730,12 +903,16 @@ describe('ModernFlowChatContainer historical empty state', () => {
 
     flushAnimationFrame();
 
-    expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenCalledTimes(2);
+    expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenCalledTimes(1);
     expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenLastCalledWith('turn-80');
     expect(virtualListMock.pinTurnToTop).not.toHaveBeenCalled();
+    expect(startupTraceMock.markPhase).toHaveBeenCalledWith(
+      'historical_session_latest_anchor_skipped',
+      expect.objectContaining({ reason: 'local_full_history_projection' }),
+    );
   });
 
-  it('re-anchors full hydration even when the latest restored turn is already visible', async () => {
+  it('does not re-anchor local full hydration when the latest restored turn is already visible', async () => {
     stateMocks.activeSession = createSession({
       isHistorical: false,
       historyState: 'ready',
@@ -780,17 +957,17 @@ describe('ModernFlowChatContainer historical empty state', () => {
       root.render(<ModernFlowChatContainer />);
     });
 
-    expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenCalledTimes(2);
+    expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenCalledTimes(1);
     expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenLastCalledWith('turn-80');
 
     flushAnimationFrame();
 
-    expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenCalledTimes(2);
+    expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenCalledTimes(1);
     expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenLastCalledWith('turn-80');
     expect(virtualListMock.pinTurnToTop).not.toHaveBeenCalled();
   });
 
-  it('re-anchors full hydration when visible turn info is stale after prepending older turns', async () => {
+  it('does not re-anchor local full hydration when visible turn info is stale after prepending older turns', async () => {
     stateMocks.activeSession = createSession({
       isHistorical: false,
       historyState: 'ready',
@@ -839,7 +1016,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
 
     flushAnimationFrame();
 
-    expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenCalledTimes(2);
+    expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenCalledTimes(1);
     expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenLastCalledWith('turn-80');
     expect(virtualListMock.pinTurnToTop).not.toHaveBeenCalled();
   });

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.scss
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.scss
@@ -36,15 +36,6 @@
     background: transparent;
   }
 
-  &__history-overlay {
-    position: absolute;
-    inset: 0;
-    z-index: 10;
-    background: var(--color-bg-scene);
-    pointer-events: none;
-  }
-
-  
   &__input {
     flex-shrink: 0;
     padding: var(--flowchat-card-expanded-pad-x, 0.625rem);
@@ -126,6 +117,36 @@
 
 .history-session-placeholder__retry:hover {
   background: var(--color-surface-active, rgba(255, 255, 255, 0.1));
+}
+
+.modern-flowchat-container__history-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  pointer-events: none;
+  background: var(--color-bg-scene);
+}
+
+.modern-flowchat-container__history-open-intent-shield {
+  position: absolute;
+  inset: 0;
+  z-index: 9;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 76px;
+  pointer-events: none;
+}
+
+.modern-flowchat-container__history-open-intent-spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--color-border, rgba(255, 255, 255, 0.16));
+  border-top-color: var(--color-accent, #5b8def);
+  border-radius: 50%;
+  background: var(--color-bg-scene);
+  box-shadow: 0 0 0 6px var(--color-bg-scene);
+  animation: history-placeholder-spin 0.9s linear infinite;
 }
 
 @keyframes history-placeholder-spin {

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -35,8 +35,12 @@ import {
   findDialogTurn,
   shouldUseStickyLatestPin,
 } from '../../utils/flowChatTurnScrollPolicy';
-import { startupTrace } from '@/shared/utils/startupTrace';
+import { isRemoteTraceContext, startupTrace } from '@/shared/utils/startupTrace';
 import { scheduleAfterStartupPaint } from '@/shared/utils/startupTaskScheduling';
+import {
+  HISTORY_SESSION_OPEN_INTENT_EVENT,
+  type HistorySessionOpenIntentDetail,
+} from '../../services/sessionOpenIntent';
 import './ModernFlowChatContainer.scss';
 
 interface ModernFlowChatContainerProps {
@@ -176,6 +180,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const activeSession = useActiveSession();
   const visibleTurnInfo = useVisibleTurnInfo();
   const [pendingHeaderTurnId, setPendingHeaderTurnId] = useState<string | null>(null);
+  const [pendingHistoryOpenSession, setPendingHistoryOpenSession] = useState<HistorySessionOpenIntentDetail | null>(null);
   const [searchOpenRequest, setSearchOpenRequest] = useState(0);
   // Track whether a slash-command or @-mention popup is open in ChatInput.
   // When a popup is active, the global Escape shortcut is disabled so the
@@ -206,6 +211,9 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     historyState === 'failed' ||
     hasRestoredTurnsPendingVirtualItems
   );
+  const showHistoryOpenIntentOverlay =
+    pendingHistoryOpenSession !== null &&
+    activeSession?.sessionId !== pendingHistoryOpenSession.sessionId;
   const {
     exploreGroupStates,
     onExploreGroupToggle: handleExploreGroupToggle,
@@ -254,6 +262,53 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     virtualListRef,
     onExpandExploreGroup: handleExpandGroup,
   });
+
+  useEffect(() => {
+    const handleHistorySessionOpenIntent = (event: Event) => {
+      const detail = (event as CustomEvent<HistorySessionOpenIntentDetail>).detail;
+      if (!detail?.sessionId) {
+        return;
+      }
+
+      setPendingHistoryOpenSession({
+        sessionId: detail.sessionId,
+        sessionTitle: detail.sessionTitle,
+      });
+      startupTrace.markPhase('historical_session_open_intent_overlay', {
+        sessionId: detail.sessionId,
+      });
+    };
+
+    window.addEventListener(HISTORY_SESSION_OPEN_INTENT_EVENT, handleHistorySessionOpenIntent);
+    return () => {
+      window.removeEventListener(HISTORY_SESSION_OPEN_INTENT_EVENT, handleHistorySessionOpenIntent);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!pendingHistoryOpenSession) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setPendingHistoryOpenSession(current =>
+        current?.sessionId === pendingHistoryOpenSession.sessionId ? null : current
+      );
+    }, 4000);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [pendingHistoryOpenSession]);
+
+  useEffect(() => {
+    if (
+      pendingHistoryOpenSession &&
+      activeSession?.sessionId === pendingHistoryOpenSession.sessionId
+    ) {
+      setPendingHistoryOpenSession(null);
+    }
+  }, [activeSession?.sessionId, pendingHistoryOpenSession]);
 
   const contextValue: FlowChatContextValue = useMemo(() => ({
     onFileViewRequest: handleFileViewRequest,
@@ -352,6 +407,9 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const hasPendingHistoryCompletion = activeSession?.sessionId
     ? flowChatStore.hasPendingSessionHistoryCompletion(activeSession.sessionId)
     : false;
+  const hasDeferredHistoryProjection = activeSession?.sessionId
+    ? flowChatStore.hasDeferredSessionHistoryProjection(activeSession.sessionId)
+    : false;
   const historyInitialContentKey =
     activeSession?.sessionId &&
     latestTurnId &&
@@ -361,19 +419,26 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       activeSession.contextRestoreState === 'pending' ||
       hasPendingHistoryCompletion
     )
-      ? `${activeSession.sessionId}:${latestTurnId}:${turnSummaries.length}`
+      ? `${activeSession.sessionId}:${latestTurnId}`
       : null;
-  const showHistoryInitialContentOverlay =
+  const shouldBlockHistoryInitialContentInteraction =
     historyInitialContentKey !== null &&
     historyInitialContentReadyKey !== historyInitialContentKey;
+  const shouldBlockHistoryTransitionInteraction =
+    shouldBlockHistoryInitialContentInteraction ||
+    showHistoryOpenIntentOverlay;
+  const showFailedHistoryPlaceholder =
+    showHistoryPlaceholder && historyState === 'failed';
+  const showHistoryLoadingLayer =
+    !showFailedHistoryPlaceholder && showHistoryPlaceholder;
   const blockHistoryOverlayActivation = useCallback((event: React.SyntheticEvent<HTMLElement>) => {
-    if (!showHistoryInitialContentOverlay) {
+    if (!showHistoryLoadingLayer && !shouldBlockHistoryTransitionInteraction) {
       return;
     }
 
     event.preventDefault();
     event.stopPropagation();
-  }, [showHistoryInitialContentOverlay]);
+  }, [shouldBlockHistoryTransitionInteraction, showHistoryLoadingLayer]);
   const latestTurn = useMemo(
     () => findDialogTurn(activeSession?.dialogTurns, latestTurnId),
     [activeSession?.dialogTurns, latestTurnId],
@@ -479,9 +544,26 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     const hasPreviouslyAnchoredSameLatestTurn =
       autoPinnedTurnKeyRef.current?.startsWith(previousAnchoredLatestTurnKeyPrefix) === true;
     const latestTurnRenderedInViewport = virtualListRef.current?.isTurnRenderedInViewport(latestTurnId) === true;
-    const shouldForceLatestAnchorAfterTurnCountChange =
+    const sameLatestTurnCountChanged =
       hasPreviouslyAnchoredSameLatestTurn &&
       autoPinnedTurnKeyRef.current !== resolvedLatestTurnKey;
+    const shouldSkipLocalFullHistoryReanchor =
+      sameLatestTurnCountChanged &&
+      !isRemoteTraceContext(activeSession.remoteConnectionId, activeSession.remoteSshHost);
+    const shouldForceLatestAnchorAfterTurnCountChange =
+      sameLatestTurnCountChanged &&
+      !shouldSkipLocalFullHistoryReanchor;
+    if (shouldSkipLocalFullHistoryReanchor) {
+      autoPinnedTurnKeyRef.current = resolvedLatestTurnKey;
+      startupTrace.markPhase('historical_session_latest_anchor_skipped', {
+        sessionId,
+        latestTurnId,
+        reason: 'local_full_history_projection',
+        mode: pinMode ?? 'bottom',
+        turnCount: turnSummaries.length,
+      });
+      return;
+    }
     if (
       !shouldForceLatestAnchorAfterTurnCountChange &&
       hasPreviouslyAnchoredSameLatestTurn &&
@@ -490,6 +572,8 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     ) {
       autoPinnedTurnKeyRef.current = resolvedLatestTurnKey;
       startupTrace.markPhase('historical_session_latest_anchor_skipped', {
+        sessionId,
+        latestTurnId,
         reason: 'latest_turn_already_visible',
         mode: pinMode ?? 'bottom',
       });
@@ -501,6 +585,8 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       !latestTurnRenderedInViewport
     ) {
       startupTrace.markPhase('historical_session_latest_anchor_stale_visible_info', {
+        sessionId,
+        latestTurnId,
         mode: pinMode ?? 'bottom',
       });
     }
@@ -530,6 +616,8 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       }
 
       startupTrace.markPhase('historical_session_latest_anchor_attempt', {
+        sessionId,
+        latestTurnId: resolvedLatestTurnId,
         accepted,
         attempt: attempts,
         mode: pinMode ?? 'bottom',
@@ -543,6 +631,8 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       if (attempts >= LATEST_TURN_AUTO_PIN_MAX_ATTEMPTS) {
         setPendingHeaderTurnId(null);
         startupTrace.markPhase('historical_session_latest_anchor_failed', {
+          sessionId,
+          latestTurnId: resolvedLatestTurnId,
           attempts,
           mode: pinMode ?? 'bottom',
         });
@@ -552,7 +642,13 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       frameId = requestAnimationFrame(attemptLatestViewportAnchor);
     };
 
-    if (shouldForceLatestAnchorAfterTurnCountChange) {
+    const shouldAttemptLatestAnchorImmediately =
+      shouldForceLatestAnchorAfterTurnCountChange ||
+      activeSession?.isHistorical === true ||
+      activeSession?.contextRestoreState === 'pending' ||
+      hasPendingHistoryCompletion;
+
+    if (shouldAttemptLatestAnchorImmediately) {
       attemptLatestViewportAnchor();
     } else {
       frameId = requestAnimationFrame(attemptLatestViewportAnchor);
@@ -566,6 +662,11 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     };
   }, [
     activeSession?.sessionId,
+    activeSession?.isHistorical,
+    activeSession?.contextRestoreState,
+    activeSession?.remoteConnectionId,
+    activeSession?.remoteSshHost,
+    hasPendingHistoryCompletion,
     latestTurnId,
     latestTurnUsesStickyPin,
     turnSummaries.length,
@@ -586,7 +687,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       return;
     }
 
-    const releaseKey = `${sessionId}:${latestTurnId}:${turnSummaries.length}`;
+    const releaseKey = `${sessionId}:${latestTurnId}`;
     if (releasedHistoryCompletionKeyRef.current === releaseKey) {
       return;
     }
@@ -602,13 +703,12 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       }
       releasedHistoryCompletionKeyRef.current = releaseKey;
       const released = flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint(sessionId);
-      if (released) {
-        startupTrace.markPhase('historical_session_initial_content_painted', {
-          sessionId,
-          latestTurnId,
-          turnCount: turnSummaries.length,
-        });
-      }
+      startupTrace.markPhase('historical_session_initial_content_painted', {
+        sessionId,
+        latestTurnId,
+        released,
+        turnCount: turnSummaries.length,
+      });
     };
 
     const checkLatestTextVisibility = () => {
@@ -626,12 +726,10 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       if (attempts >= HISTORY_INITIAL_CONTENT_PAINT_MAX_ATTEMPTS) {
         setHistoryInitialContentReadyKey(releaseKey);
         releasedHistoryCompletionKeyRef.current = releaseKey;
-        const released = flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint(sessionId);
         startupTrace.markPhase('historical_session_initial_content_paint_signal_missed', {
           sessionId,
           latestTurnId,
           attempts,
-          released,
         });
         return;
       }
@@ -673,18 +771,21 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     if (
       !sessionId ||
       activeSession.historyState !== 'ready' ||
-      !hasPendingHistoryCompletion ||
+      (
+        !hasPendingHistoryCompletion &&
+        !hasDeferredHistoryProjection
+      ) ||
       trimmedSearchQuery.length === 0
     ) {
       return;
     }
 
     if (latestTurnId) {
-      releasedHistoryCompletionKeyRef.current = `${sessionId}:${latestTurnId}:${turnSummaries.length}`;
+      releasedHistoryCompletionKeyRef.current = `${sessionId}:${latestTurnId}`;
     }
 
-    const released = flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint(sessionId);
-    if (released) {
+    const requested = flowChatStore.requestSessionFullHistoryProjection(sessionId, 'search');
+    if (requested) {
       startupTrace.markPhase('historical_session_full_hydrate_released_for_search', {
         sessionId,
         queryLength: trimmedSearchQuery.length,
@@ -694,6 +795,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   }, [
     activeSession?.historyState,
     activeSession?.sessionId,
+    hasDeferredHistoryProjection,
     hasPendingHistoryCompletion,
     latestTurnId,
     searchQuery,
@@ -849,47 +951,80 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
 
         <div
           className="modern-flowchat-container__messages"
+          data-active-session-id={activeSession?.sessionId ?? ''}
+          data-history-state={historyState ?? 'none'}
+          data-context-restore-state={activeSession?.contextRestoreState ?? 'none'}
+          data-is-partial={activeSession?.isPartial === true ? 'true' : 'false'}
+          data-dialog-turn-count={activeSession?.dialogTurns.length ?? 0}
+          data-virtual-item-count={virtualItems.length}
+          data-show-history-placeholder={showHistoryPlaceholder ? 'true' : 'false'}
+          data-show-history-transition-overlay={shouldBlockHistoryTransitionInteraction ? 'true' : 'false'}
+          data-show-history-loading-layer={showHistoryLoadingLayer ? 'true' : 'false'}
+          data-show-history-open-intent-overlay={showHistoryOpenIntentOverlay ? 'true' : 'false'}
+          data-has-pending-history-completion={hasPendingHistoryCompletion ? 'true' : 'false'}
+          data-has-deferred-history-projection={hasDeferredHistoryProjection ? 'true' : 'false'}
+          data-latest-turn-id={latestTurnId ?? ''}
+          data-history-initial-content-ready={
+            historyInitialContentKey === null || historyInitialContentReadyKey === historyInitialContentKey
+              ? 'true'
+              : 'false'
+          }
+          data-pending-history-open-session-id={pendingHistoryOpenSession?.sessionId ?? ''}
           onClickCapture={blockHistoryOverlayActivation}
+          onContextMenuCapture={blockHistoryOverlayActivation}
           onMouseDownCapture={blockHistoryOverlayActivation}
           onPointerDownCapture={blockHistoryOverlayActivation}
         >
-          {showHistoryPlaceholder ? (
-            <HistorySessionPlaceholder
-              state={
-                historyState === 'failed'
-                  ? 'failed'
-                  : historyState === 'metadata-only'
-                    ? 'metadata-only'
-                    : 'hydrating'
-              }
-              onRetry={handleRetryHistoryLoad}
-            />
-          ) : virtualItems.length === 0 ? (
-            <WelcomePanel
-              key={activeSession?.sessionId ?? 'welcome'}
-              sessionMode={activeSession?.mode}
-              workspacePath={activeSession?.workspacePath}
-              onQuickAction={(command) => {
-                window.dispatchEvent(new CustomEvent('fill-chat-input', {
-                  detail: { message: command }
-                }));
-              }}
-            />
-          ) : (
-            <>
-              <VirtualMessageList
-                // Remount per session so Virtuoso does not reuse the previous
-                // viewport before the new session's auto-pin settles.
-                key={activeSession?.sessionId ?? 'virtual-message-list'}
-                ref={virtualListRef}
+          <>
+            {showFailedHistoryPlaceholder ? (
+              <HistorySessionPlaceholder
+                state="failed"
+                onRetry={handleRetryHistoryLoad}
               />
-              {showHistoryInitialContentOverlay && (
-                <div className="modern-flowchat-container__history-overlay">
-                  <HistorySessionPlaceholder state="hydrating" />
-                </div>
-              )}
-            </>
-          )}
+            ) : virtualItems.length === 0 ? (
+              showHistoryLoadingLayer ? null : (
+                <WelcomePanel
+                  key={activeSession?.sessionId ?? 'welcome'}
+                  sessionMode={activeSession?.mode}
+                  workspacePath={activeSession?.workspacePath}
+                  onQuickAction={(command) => {
+                    window.dispatchEvent(new CustomEvent('fill-chat-input', {
+                      detail: { message: command }
+                    }));
+                  }}
+                />
+              )
+            ) : (
+              <>
+                <VirtualMessageList
+                  ref={virtualListRef}
+                />
+              </>
+            )}
+            {showHistoryLoadingLayer && (
+              <div
+                className="modern-flowchat-container__history-overlay"
+                role="status"
+                aria-label={t('historyState.loadingTitle')}
+              >
+                <HistorySessionPlaceholder
+                  state={historyState === 'metadata-only' ? 'metadata-only' : 'hydrating'}
+                />
+              </div>
+            )}
+            {showHistoryOpenIntentOverlay && (
+              <div
+                className="modern-flowchat-container__history-open-intent-shield"
+                role="status"
+                aria-label={t('historyState.loadingTitle')}
+              >
+                <span
+                  className="modern-flowchat-container__history-open-intent-spinner"
+                  aria-hidden="true"
+                />
+              </div>
+            )}
+          </>
         </div>
       </div>
     </FlowChatContext.Provider>

--- a/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.tsx
@@ -93,6 +93,7 @@ export const VirtualItemRenderer = React.memo<VirtualItemRendererProps>(
         className={wrapperClassName}
         data-turn-id={item.turnId}
         data-item-type={item.type}
+        data-virtual-index={index}
       >
         {content || <div style={{ minHeight: '1px' }} />}
       </div>

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.layout.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.layout.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { getVirtualMessageDefaultItemHeight } from './virtualMessageListLayout';
+import {
+  estimateTextHeightFromLength,
+  estimateVirtualMessageItemHeight,
+  getVirtualMessageDefaultItemHeight,
+} from './virtualMessageListLayout';
+import type { VirtualItem } from '../../store/modernFlowChatStore';
 
 describe('getVirtualMessageDefaultItemHeight', () => {
   it('keeps compact historical projections on the small row estimate', () => {
@@ -18,11 +23,64 @@ describe('getVirtualMessageDefaultItemHeight', () => {
     })).toBeGreaterThan(200);
   });
 
+  it('prioritizes the taller estimate when a historical initial projection contains model rounds', () => {
+    expect(getVirtualMessageDefaultItemHeight({
+      isHistorical: true,
+      hasCompactHistoricalProjection: false,
+      hasInitialHistoryModelRoundProjection: true,
+    })).toBeGreaterThan(200);
+  });
+
   it('keeps live sessions on the legacy estimate', () => {
     expect(getVirtualMessageDefaultItemHeight({
       isHistorical: false,
       hasCompactHistoricalProjection: false,
       hasInitialHistoryModelRoundProjection: false,
     })).toBe(200);
+  });
+});
+
+describe('estimateVirtualMessageItemHeight', () => {
+  it('estimates text height directly from length', () => {
+    expect(estimateTextHeightFromLength(0, 72, 30)).toBe(102);
+    expect(estimateTextHeightFromLength(60, 72, 30)).toBe(102);
+    expect(estimateTextHeightFromLength(61, 72, 30)).toBe(132);
+  });
+
+  it('uses content-aware estimates for large historical model rounds', () => {
+    const item = {
+      type: 'model-round',
+      turnId: 'turn-1',
+      isLastRound: true,
+      isTurnComplete: true,
+      data: {
+        id: 'round-1',
+        status: 'completed',
+        isStreaming: false,
+        items: [{
+          id: 'text-1',
+          type: 'text',
+          content: 'x'.repeat(3600),
+          status: 'completed',
+          timestamp: 1,
+        }],
+      },
+    } as VirtualItem;
+
+    expect(estimateVirtualMessageItemHeight(item)).toBeGreaterThan(1000);
+  });
+
+  it('keeps compact user-only rows small enough for partial history tails', () => {
+    const item = {
+      type: 'user-message',
+      turnId: 'turn-1',
+      data: {
+        id: 'user-1',
+        content: 'short prompt',
+        timestamp: 1,
+      },
+    } as VirtualItem;
+
+    expect(estimateVirtualMessageItemHeight(item)).toBeLessThanOrEqual(160);
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.scss
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.scss
@@ -67,5 +67,47 @@
     min-height: 72px;
     overflow-anchor: none;
   }
-}
 
+  &__static-scroller {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    z-index: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    overflow-anchor: none;
+    scrollbar-gutter: stable;
+  }
+
+  &__static-items {
+    width: 100%;
+  }
+
+  &__projection-handoff-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    overflow: hidden;
+    pointer-events: none;
+    background: var(--color-bg-flowchat, var(--color-bg-scene, var(--color-bg-primary, #fff)));
+    contain: paint;
+  }
+
+  &__projection-handoff-content {
+    width: 100%;
+    will-change: transform;
+
+    &--bottom {
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      transform: none;
+    }
+  }
+
+}

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -11,7 +11,7 @@
  * - "Scroll to latest" bar appears whenever the list is not at bottom.
  */
 
-import React, { useRef, useState, useCallback, useEffect, forwardRef, useImperativeHandle } from 'react';
+import React, { useRef, useState, useCallback, useEffect, useLayoutEffect, forwardRef, useImperativeHandle } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import { useActiveSessionState } from '../../hooks/useActiveSessionState';
 import { VirtualItemRenderer } from './VirtualItemRenderer';
@@ -40,7 +40,10 @@ import {
 } from '../../utils/flowChatTurnScrollPolicy';
 import { flowChatStore } from '../../store/FlowChatStore';
 import { startupTrace } from '@/shared/utils/startupTrace';
-import { getVirtualMessageDefaultItemHeight } from './virtualMessageListLayout';
+import {
+  estimateVirtualMessageItemHeight,
+  getVirtualMessageDefaultItemHeight,
+} from './virtualMessageListLayout';
 import './VirtualMessageList.scss';
 
 const COMPENSATION_EPSILON_PX = 0.5;
@@ -56,6 +59,9 @@ const LATEST_END_ANCHOR_VISIBILITY_MARGIN_PX = 4;
 const LATEST_END_ANCHOR_STABLE_EPSILON_PX = 1;
 const VIRTUOSO_FIRST_ITEM_INDEX_BASE = 1_000_000;
 const PARTIAL_HISTORY_INITIAL_TAIL_TURN_BUDGET = 16;
+const PARTIAL_HISTORY_FULL_PROJECTION_TOP_THRESHOLD_PX = 1200;
+const HISTORY_PROJECTION_HANDOFF_MAX_DURATION_MS = 5000;
+const SESSION_OPEN_HANDOFF_ITEM_BUDGET = 24;
 
 type LatestEndAnchorResolveReason =
   | 'raf'
@@ -113,6 +119,21 @@ interface LatestEndAnchorRequestState {
   lastScrollTop: number | null;
   lastTargetTop: number | null;
   lastTargetBottom: number | null;
+}
+
+interface HistoryProjectionHandoffSnapshot {
+  sessionId: string;
+  reason: string;
+  createdAtMs: number;
+  items: VirtualItem[];
+  mode: 'scroll-position' | 'bottom-tail';
+  targetTurnId: string | null;
+  anchorKey: string | null;
+  anchorOffsetTopPx: number;
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  footerHeightPx: number;
 }
 
 type BottomReservationKind = 'collapse' | 'pin';
@@ -324,9 +345,18 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     () => createInitialBottomReservationState()
   );
   const [pendingTurnPin, setPendingTurnPin] = useState<PendingTurnPinState | null>(null);
+  const [historyProjectionHandoff, setHistoryProjectionHandoff] = useState<HistoryProjectionHandoffSnapshot | null>(null);
 
   const scrollerElementRef = useRef<HTMLElement | null>(null);
   const footerElementRef = useRef<HTMLDivElement | null>(null);
+  const activeSessionIdRef = useRef<string | null>(null);
+  const pendingHistoryProjectionHandoffRef = useRef<HistoryProjectionHandoffSnapshot | null>(null);
+  const historyProjectionHandoffRef = useRef<HistoryProjectionHandoffSnapshot | null>(null);
+  const historyProjectionHandoffReleaseFrameRef = useRef<number | null>(null);
+  const fullHistoryProjectionIntentFrameRef = useRef<number | null>(null);
+  const pendingFullHistoryProjectionReasonRef = useRef<string | null>(null);
+  const sessionOpenHandoffSessionIdRef = useRef<string | null>(null);
+  const previousActiveSessionIdForOpenHandoffRef = useRef<string | null | undefined>(undefined);
   const bottomReservationStateRef = useRef<BottomReservationState>(createInitialBottomReservationState());
   const previousMeasuredHeightRef = useRef<number | null>(null);
   const previousScrollTopRef = useRef(0);
@@ -382,6 +412,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
   const isStreamingOutputRef = useRef(false);
   const previousIsStreamingOutputRef = useRef(false);
   const transientTurnPinStabilizationRef = useRef<PendingTurnPinState | null>(null);
+  activeSessionIdRef.current = activeSessionId;
 
   const isInputActive = useChatInputState(state => state.isActive);
   const isInputExpanded = useChatInputState(state => state.isExpanded);
@@ -721,6 +752,14 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
 
   const latestTurnId = userMessageItems[userMessageItems.length - 1]?.item.turnId ?? null;
   const latestUserMessageIndex = userMessageItems[userMessageItems.length - 1]?.index ?? 0;
+  const hasPendingHistoryCompletion = activeSession?.sessionId
+    ? flowChatStore.hasPendingSessionHistoryCompletion(activeSession.sessionId)
+    : false;
+  const hasPartialHistoryInitialViewport =
+    activeSession?.historyState === 'ready' &&
+    activeSession.contextRestoreState === 'pending' &&
+    (activeSession.dialogTurns.length ?? 0) <= PARTIAL_HISTORY_INITIAL_TAIL_TURN_BUDGET;
+  const useInitialHistoryRenderBudget = hasPendingHistoryCompletion || hasPartialHistoryInitialViewport;
   const latestTurnAutoFollowStateRef = useRef<{
     turnId: string | null;
     sawPositiveFloor: boolean;
@@ -822,12 +861,44 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     run(Math.max(1, frames));
   }, [measureVisibleTurn]);
 
+  const escapeTurnIdSelector = useCallback((turnId: string) => (
+    typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+      ? CSS.escape(turnId)
+      : turnId.replace(/["\\]/g, '\\$&')
+  ), []);
+
+  const getRenderedTurnElements = useCallback((turnId: string, options?: { includeHistoryProjectionHandoff?: boolean }) => {
+    const scroller = scrollerElementRef.current;
+    if (!scroller) return [];
+
+    const escapedTurnId = escapeTurnIdSelector(turnId);
+    const nodes = Array.from(scroller.querySelectorAll<HTMLElement>(
+      `.virtual-item-wrapper[data-turn-id="${escapedTurnId}"]`,
+    ));
+
+    if (options?.includeHistoryProjectionHandoff === false) {
+      return nodes.filter(node => !node.closest('[data-history-projection-handoff="true"]'));
+    }
+
+    return nodes;
+  }, [escapeTurnIdSelector]);
+
   const getRenderedUserMessageElement = useCallback((turnId: string) => {
     const scroller = scrollerElementRef.current;
     if (!scroller) return null;
 
+    const escapedTurnId = escapeTurnIdSelector(turnId);
     return scroller.querySelector<HTMLElement>(
-      `.virtual-item-wrapper[data-item-type="user-message"][data-turn-id="${turnId}"]`,
+      `.virtual-item-wrapper[data-item-type="user-message"][data-turn-id="${escapedTurnId}"]`,
+    );
+  }, [escapeTurnIdSelector]);
+
+  const getRenderedVirtualItemElement = useCallback((itemIndex: number) => {
+    const scroller = scrollerElementRef.current;
+    if (!scroller) return null;
+
+    return scroller.querySelector<HTMLElement>(
+      `.virtual-item-wrapper[data-virtual-index="${itemIndex}"]`,
     );
   }, []);
 
@@ -838,18 +909,13 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     }
 
     const scrollerRect = scroller.getBoundingClientRect();
-    const escapedTurnId = typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
-      ? CSS.escape(turnId)
-      : turnId.replace(/["\\]/g, '\\$&');
-    const nodes = scroller.querySelectorAll<HTMLElement>(
-      `.virtual-item-wrapper[data-turn-id="${escapedTurnId}"]`,
-    );
+    const nodes = getRenderedTurnElements(turnId);
 
-    return Array.from(nodes).some(node => {
+    return nodes.some(node => {
       const rect = node.getBoundingClientRect();
       return rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom;
     });
-  }, []);
+  }, [getRenderedTurnElements]);
 
   const isTurnTextRenderedInViewport = useCallback((turnId: string) => {
     const scroller = scrollerElementRef.current;
@@ -858,19 +924,241 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     }
 
     const scrollerRect = scroller.getBoundingClientRect();
-    const escapedTurnId = typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
-      ? CSS.escape(turnId)
-      : turnId.replace(/["\\]/g, '\\$&');
-    const nodes = scroller.querySelectorAll<HTMLElement>(
-      `.virtual-item-wrapper[data-turn-id="${escapedTurnId}"]`,
-    );
+    const nodes = getRenderedTurnElements(turnId);
 
-    return Array.from(nodes).some(node => {
+    return nodes.some(node => {
       const rect = node.getBoundingClientRect();
       const visible = rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom;
       return visible && (node.innerText?.trim().length ?? 0) > 0;
     });
+  }, [getRenderedTurnElements]);
+
+  const isTurnTextRenderedInViewportOutsideHandoff = useCallback((turnId: string) => {
+    const scroller = scrollerElementRef.current;
+    if (!scroller) {
+      return false;
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const nodes = getRenderedTurnElements(turnId, { includeHistoryProjectionHandoff: false });
+
+    return nodes.some(node => {
+      const rect = node.getBoundingClientRect();
+      const visible = rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom;
+      return visible && (node.innerText?.trim().length ?? 0) > 0;
+    });
+  }, [getRenderedTurnElements]);
+
+  const hasVisibleRenderedVirtualItem = useCallback(() => {
+    const scroller = scrollerElementRef.current;
+    if (!scroller) {
+      return false;
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const nodes = Array.from(
+      scroller.querySelectorAll<HTMLElement>('.virtual-item-wrapper[data-turn-id]'),
+    );
+
+    return nodes.some(node => {
+      const rect = node.getBoundingClientRect();
+      const style = window.getComputedStyle(node);
+      return (
+        rect.bottom > scrollerRect.top &&
+        rect.top < scrollerRect.bottom &&
+        rect.width > 0 &&
+        rect.height > 0 &&
+        style.visibility !== 'hidden' &&
+        style.display !== 'none' &&
+        (node.innerText?.trim().length ?? 0) > 0
+      );
+    });
   }, []);
+
+  const findVirtualItemIndexByStableKey = useCallback((stableKey: string | null) => {
+    if (!stableKey) {
+      return -1;
+    }
+
+    return virtualItems.findIndex(item => getVirtualItemStableKey(item) === stableKey);
+  }, [virtualItems]);
+
+  const captureVisibleVirtualItemAnchor = useCallback(() => {
+    const scroller = scrollerElementRef.current;
+    if (!scroller) {
+      return { anchorKey: null, anchorOffsetTopPx: 0 };
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const nodes = Array.from(
+      scroller.querySelectorAll<HTMLElement>('.virtual-item-wrapper[data-virtual-index]'),
+    );
+    const anchorNode = nodes.find(node => {
+      const rect = node.getBoundingClientRect();
+      return rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom;
+    });
+    const anchorIndex = Number(anchorNode?.dataset.virtualIndex);
+    const anchorItem = Number.isInteger(anchorIndex) ? virtualItems[anchorIndex] : undefined;
+    if (!anchorNode || !anchorItem) {
+      return { anchorKey: null, anchorOffsetTopPx: 0 };
+    }
+
+    return {
+      anchorKey: getVirtualItemStableKey(anchorItem),
+      anchorOffsetTopPx: anchorNode.getBoundingClientRect().top - scrollerRect.top,
+    };
+  }, [virtualItems]);
+
+  const isHistoryProjectionHandoffAnchorReady = useCallback((snapshot: HistoryProjectionHandoffSnapshot) => {
+    const scroller = scrollerElementRef.current;
+    const anchorIndex = findVirtualItemIndexByStableKey(snapshot.anchorKey);
+    if (!scroller || anchorIndex < 0) {
+      return false;
+    }
+
+    const anchorElement = getRenderedVirtualItemElement(anchorIndex);
+    if (!anchorElement) {
+      return false;
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const anchorRect = anchorElement.getBoundingClientRect();
+    const visible = anchorRect.bottom > scrollerRect.top && anchorRect.top < scrollerRect.bottom;
+    const offsetDelta = Math.abs((anchorRect.top - scrollerRect.top) - snapshot.anchorOffsetTopPx);
+    return visible && offsetDelta <= 8;
+  }, [findVirtualItemIndexByStableKey, getRenderedVirtualItemElement]);
+
+  const isHistoryProjectionHandoffTargetReady = useCallback((snapshot: HistoryProjectionHandoffSnapshot) => {
+    if (snapshot.mode === 'scroll-position' && snapshot.anchorKey) {
+      return isHistoryProjectionHandoffAnchorReady(snapshot);
+    }
+
+    if (snapshot.targetTurnId) {
+      return isTurnTextRenderedInViewportOutsideHandoff(snapshot.targetTurnId);
+    }
+
+    return hasVisibleRenderedVirtualItem();
+  }, [
+    hasVisibleRenderedVirtualItem,
+    isHistoryProjectionHandoffAnchorReady,
+    isTurnTextRenderedInViewportOutsideHandoff,
+  ]);
+
+  const clearHistoryProjectionHandoff = useCallback((reason: string) => {
+    if (historyProjectionHandoffReleaseFrameRef.current !== null) {
+      cancelAnimationFrame(historyProjectionHandoffReleaseFrameRef.current);
+      historyProjectionHandoffReleaseFrameRef.current = null;
+    }
+
+    const snapshot = historyProjectionHandoffRef.current;
+    pendingHistoryProjectionHandoffRef.current = null;
+    historyProjectionHandoffRef.current = null;
+    setHistoryProjectionHandoff(null);
+
+    if (snapshot) {
+      startupTrace.markPhase('flowchat_history_projection_handoff_cleared', {
+        sessionId: snapshot.sessionId,
+        reason,
+        handoffReason: snapshot.reason,
+        durationMs: Math.round(performance.now() - snapshot.createdAtMs),
+      });
+    }
+  }, []);
+
+  const scheduleHistoryProjectionHandoffRelease = useCallback((frames = 1) => {
+    if (historyProjectionHandoffReleaseFrameRef.current !== null) {
+      cancelAnimationFrame(historyProjectionHandoffReleaseFrameRef.current);
+      historyProjectionHandoffReleaseFrameRef.current = null;
+    }
+
+    const run = (remainingFrames: number) => {
+      historyProjectionHandoffReleaseFrameRef.current = requestAnimationFrame(() => {
+        historyProjectionHandoffReleaseFrameRef.current = null;
+
+        const snapshot = historyProjectionHandoffRef.current;
+        if (!snapshot) {
+          return;
+        }
+
+        if (remainingFrames > 1) {
+          run(remainingFrames - 1);
+          return;
+        }
+
+        if (activeSessionIdRef.current !== snapshot.sessionId) {
+          clearHistoryProjectionHandoff('session-changed');
+          return;
+        }
+
+        if (isHistoryProjectionHandoffTargetReady(snapshot)) {
+          clearHistoryProjectionHandoff('target-content-ready');
+          return;
+        }
+
+        if (performance.now() - snapshot.createdAtMs >= HISTORY_PROJECTION_HANDOFF_MAX_DURATION_MS) {
+          clearHistoryProjectionHandoff('timeout');
+          return;
+        }
+
+        run(1);
+      });
+    };
+
+    run(Math.max(1, frames));
+  }, [clearHistoryProjectionHandoff, isHistoryProjectionHandoffTargetReady]);
+
+  const captureHistoryProjectionHandoffSnapshot = useCallback((reason: string) => {
+    const sessionId = activeSession?.sessionId;
+    const scroller = scrollerElementRef.current;
+    if (
+      !sessionId ||
+      activeSession?.isPartial !== true ||
+      !scroller ||
+      virtualItems.length === 0
+    ) {
+      return;
+    }
+
+    const { anchorKey, anchorOffsetTopPx } = captureVisibleVirtualItemAnchor();
+    const snapshot: HistoryProjectionHandoffSnapshot = {
+      sessionId,
+      reason,
+      createdAtMs: performance.now(),
+      items: virtualItems,
+      mode: 'scroll-position',
+      targetTurnId: latestTurnId,
+      anchorKey,
+      anchorOffsetTopPx,
+      scrollTop: scroller.scrollTop,
+      scrollHeight: scroller.scrollHeight,
+      clientHeight: scroller.clientHeight,
+      footerHeightPx: getFooterHeightPx(getTotalBottomCompensationPx()),
+    };
+
+    pendingHistoryProjectionHandoffRef.current = snapshot;
+    historyProjectionHandoffRef.current = snapshot;
+    setHistoryProjectionHandoff(snapshot);
+    startupTrace.markPhase('flowchat_history_projection_handoff_captured', {
+      sessionId,
+      reason,
+      anchorKey,
+      anchorOffsetTopPx: Math.round(anchorOffsetTopPx),
+      itemCount: snapshot.items.length,
+      scrollTop: Math.round(snapshot.scrollTop),
+      scrollHeight: Math.round(snapshot.scrollHeight),
+      clientHeight: Math.round(snapshot.clientHeight),
+    });
+    scheduleHistoryProjectionHandoffRelease(2);
+  }, [
+    activeSession?.isPartial,
+    activeSession?.sessionId,
+    captureVisibleVirtualItemAnchor,
+    getFooterHeightPx,
+    getTotalBottomCompensationPx,
+    latestTurnId,
+    scheduleHistoryProjectionHandoffRelease,
+    virtualItems,
+  ]);
 
   const buildPinReservation = useCallback((
     turnId: string,
@@ -1273,6 +1561,107 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     setScrollerElement(null);
   }, []);
 
+  const requestFullHistoryProjectionForUserIntent = useCallback((reason: string) => {
+    const sessionId = activeSession?.sessionId;
+    if (
+      !sessionId ||
+      activeSession.historyState !== 'ready' ||
+      activeSession.isPartial !== true
+    ) {
+      return;
+    }
+
+    const hasFullHistoryWork =
+      flowChatStore.hasPendingSessionHistoryCompletion(sessionId) ||
+      flowChatStore.hasDeferredSessionHistoryProjection(sessionId);
+    if (!hasFullHistoryWork) {
+      return;
+    }
+
+    captureHistoryProjectionHandoffSnapshot(reason);
+    flowChatStore.requestSessionFullHistoryProjection(sessionId, reason);
+  }, [
+    activeSession?.historyState,
+    activeSession?.isPartial,
+    activeSession?.sessionId,
+    captureHistoryProjectionHandoffSnapshot,
+  ]);
+
+  const shouldRequestFullHistoryProjectionForUserIntent = useCallback((options?: { force?: boolean }) => {
+    if (options?.force === true) {
+      return true;
+    }
+
+    const scroller = scrollerElementRef.current;
+    if (!scroller) {
+      return false;
+    }
+
+    const topThresholdPx = Math.max(
+      PARTIAL_HISTORY_FULL_PROJECTION_TOP_THRESHOLD_PX,
+      scroller.clientHeight * 1.5,
+    );
+    return scroller.scrollTop <= topThresholdPx;
+  }, []);
+
+  const scheduleFullHistoryProjectionForUserIntent = useCallback((reason: string, options?: { force?: boolean }) => {
+    const scheduledSessionId = activeSession?.sessionId ?? null;
+    pendingFullHistoryProjectionReasonRef.current = reason;
+    if (fullHistoryProjectionIntentFrameRef.current !== null) {
+      cancelAnimationFrame(fullHistoryProjectionIntentFrameRef.current);
+      fullHistoryProjectionIntentFrameRef.current = null;
+    }
+
+    fullHistoryProjectionIntentFrameRef.current = requestAnimationFrame(() => {
+      fullHistoryProjectionIntentFrameRef.current = requestAnimationFrame(() => {
+        fullHistoryProjectionIntentFrameRef.current = null;
+        const pendingReason = pendingFullHistoryProjectionReasonRef.current;
+        pendingFullHistoryProjectionReasonRef.current = null;
+        if (!pendingReason || activeSessionIdRef.current !== scheduledSessionId) {
+          return;
+        }
+
+        if (!shouldRequestFullHistoryProjectionForUserIntent(options)) {
+          return;
+        }
+
+        requestFullHistoryProjectionForUserIntent(pendingReason);
+      });
+    });
+  }, [
+    activeSession?.sessionId,
+    requestFullHistoryProjectionForUserIntent,
+    shouldRequestFullHistoryProjectionForUserIntent,
+  ]);
+
+  useLayoutEffect(() => {
+    const snapshot = pendingHistoryProjectionHandoffRef.current;
+    if (
+      !snapshot ||
+      activeSession?.sessionId !== snapshot.sessionId ||
+      activeSession?.isPartial === true ||
+      virtualItems.length <= snapshot.items.length
+    ) {
+      return;
+    }
+
+    pendingHistoryProjectionHandoffRef.current = null;
+    historyProjectionHandoffRef.current = snapshot;
+    setHistoryProjectionHandoff(snapshot);
+    startupTrace.markPhase('flowchat_history_projection_handoff_activated', {
+      sessionId: snapshot.sessionId,
+      reason: snapshot.reason,
+      previousItemCount: snapshot.items.length,
+      nextItemCount: virtualItems.length,
+    });
+    scheduleHistoryProjectionHandoffRelease(2);
+  }, [
+    activeSession?.isPartial,
+    activeSession?.sessionId,
+    scheduleHistoryProjectionHandoffRelease,
+    virtualItems.length,
+  ]);
+
   const shouldSuspendAutoFollow = useCallback(() => {
     const collapseIntent = pendingCollapseIntentRef.current;
     return (
@@ -1312,8 +1701,17 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       baseTotalCompensationPx: 0,
       cumulativeShrinkPx: 0,
     };
+    const currentSessionId = activeSession?.sessionId ?? null;
+    const activeHandoff = historyProjectionHandoffRef.current;
+    if (!activeHandoff || activeHandoff.sessionId !== currentSessionId) {
+      clearHistoryProjectionHandoff('session-reset');
+    }
+    const pendingHandoff = pendingHistoryProjectionHandoffRef.current;
+    if (pendingHandoff && pendingHandoff.sessionId !== currentSessionId) {
+      pendingHistoryProjectionHandoffRef.current = null;
+    }
     resetBottomReservations();
-  }, [activeSession?.sessionId, cancelLatestEndAnchorStabilization, clearTurnPinRequest, resetBottomReservations]);
+  }, [activeSession?.sessionId, cancelLatestEndAnchorStabilization, clearHistoryProjectionHandoff, clearTurnPinRequest, resetBottomReservations]);
 
   useEffect(() => {
     previousIsStreamingOutputRef.current = false;
@@ -1331,6 +1729,10 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
   useEffect(() => {
     return () => {
       cancelLatestEndAnchorStabilization();
+      if (historyProjectionHandoffReleaseFrameRef.current !== null) {
+        cancelAnimationFrame(historyProjectionHandoffReleaseFrameRef.current);
+        historyProjectionHandoffReleaseFrameRef.current = null;
+      }
     };
   }, [cancelLatestEndAnchorStabilization]);
 
@@ -1356,6 +1758,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       schedulePinReservationReconcile(2);
       scheduleTransientTurnPinStabilization(2);
       scheduleFollowToLatestWithViewportState('resize-observer');
+      scheduleHistoryProjectionHandoffRelease(1);
     });
     resizeObserverRef.current.observe(resizeTarget);
 
@@ -1383,6 +1786,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
         schedulePinReservationReconcile(2);
         scheduleTransientTurnPinStabilization(2);
         scheduleFollowToLatestWithViewportState('mutation-observer');
+        scheduleHistoryProjectionHandoffRelease(1);
       });
     });
     mutationObserverRef.current.observe(scrollerElement, {
@@ -1410,6 +1814,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       scheduleVisibleTurnMeasure(2);
       schedulePinReservationReconcile(2);
       scheduleTransientTurnPinStabilization(2);
+      scheduleHistoryProjectionHandoffRelease(1);
       if (layoutTransitionCountRef.current === 0 && pendingCollapseIntentRef.current.active) {
         pendingCollapseIntentRef.current = {
           active: false,
@@ -1517,6 +1922,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       previousScrollTopRef.current = scrollerElement.scrollTop;
       scheduleVisibleTurnMeasure();
       followOutputControllerRef.current.handleScroll();
+      scheduleFullHistoryProjectionForUserIntent('scroll-near-partial-history-boundary');
 
       if (anchorLockRef.current.active && performance.now() > anchorLockRef.current.lockUntilMs && layoutTransitionCountRef.current === 0) {
         releaseAnchorLock('expired-after-scroll');
@@ -1533,6 +1939,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       if (event.deltaY < 0) {
         userInitiatedUpwardScrollUntilMsRef.current =
           performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
+        scheduleFullHistoryProjectionForUserIntent('wheel-up');
         followOutputControllerRef.current.handleUserScrollIntent();
         releaseAnchorLock('wheel-up');
       }
@@ -1558,6 +1965,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
         touchScrollIntentStartYRef.current = currentY;
         userInitiatedUpwardScrollUntilMsRef.current =
           performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
+        scheduleFullHistoryProjectionForUserIntent('touch-scroll-up');
         followOutputControllerRef.current.handleUserScrollIntent();
         releaseAnchorLock('touch-scroll-up');
       }
@@ -1576,6 +1984,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       cancelLatestEndAnchorStabilization();
       userInitiatedUpwardScrollUntilMsRef.current =
         performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
+      scheduleFullHistoryProjectionForUserIntent('keyboard-scroll-up', { force: event.key === 'Home' });
       followOutputControllerRef.current.handleUserScrollIntent();
       releaseAnchorLock('keyboard-scroll-up');
     };
@@ -1594,6 +2003,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       cancelLatestEndAnchorStabilization();
       userInitiatedUpwardScrollUntilMsRef.current =
         performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
+      scheduleFullHistoryProjectionForUserIntent('scrollbar-pointer-down');
       followOutputControllerRef.current.handleUserScrollIntent();
       releaseAnchorLock('scrollbar-pointer-down');
     };
@@ -1612,6 +2022,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       cancelLatestEndAnchorStabilization();
       userInitiatedUpwardScrollUntilMsRef.current =
         performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
+      scheduleFullHistoryProjectionForUserIntent('scrollbar-pointer-move');
       followOutputControllerRef.current.handleUserScrollIntent();
       releaseAnchorLock('scrollbar-pointer-move');
     };
@@ -1635,6 +2046,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       scheduleHeightMeasure(2);
       scheduleVisibleTurnMeasure(2);
       schedulePinReservationReconcile(2);
+      scheduleHistoryProjectionHandoffRelease(1);
     };
 
     const handleToolCardCollapseIntent = (event: Event) => {
@@ -1743,6 +2155,12 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
         cancelAnimationFrame(turnPinStabilizationFrameRef.current);
         turnPinStabilizationFrameRef.current = null;
       }
+
+      if (fullHistoryProjectionIntentFrameRef.current !== null) {
+        cancelAnimationFrame(fullHistoryProjectionIntentFrameRef.current);
+        fullHistoryProjectionIntentFrameRef.current = null;
+      }
+      pendingFullHistoryProjectionReasonRef.current = null;
     };
   }, [
     activateAnchorLock,
@@ -1757,6 +2175,8 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     releaseAnchorLock,
     scheduleHeightMeasure,
     scheduleFollowToLatestWithViewportState,
+    scheduleFullHistoryProjectionForUserIntent,
+    scheduleHistoryProjectionHandoffRelease,
     schedulePinReservationReconcile,
     scheduleTransientTurnPinStabilization,
     scheduleVisibleTurnMeasure,
@@ -1784,7 +2204,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
 
     const scroller = scrollerElementRef.current;
     const virtuoso = virtuosoRef.current;
-    if (!scroller || !virtuoso) {
+    if (!scroller) {
       request.attempts += 1;
       if (request.attempts >= LATEST_END_ANCHOR_STABILIZATION_MAX_ATTEMPTS) {
         cancelLatestEndAnchorStabilization();
@@ -1793,7 +2213,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
           reason,
           targetIndex: request.targetIndex,
           turnId: request.turnId,
-          cause: !scroller ? 'missing_scroller' : 'missing_virtuoso',
+          cause: 'missing_scroller',
         });
         return false;
       }
@@ -1820,7 +2240,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     }
 
     request.attempts += 1;
-    const targetElement = getRenderedUserMessageElement(request.turnId);
+    const targetElement = getRenderedVirtualItemElement(targetIndex);
     const scrollerRect = scroller.getBoundingClientRect();
     const inputOverlayInsetPx = Math.max(
       0,
@@ -1833,7 +2253,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     );
 
     const isTargetVisible = () => {
-      const currentTargetElement = getRenderedUserMessageElement(request.turnId);
+      const currentTargetElement = getRenderedVirtualItemElement(targetIndex);
       if (!currentTargetElement) {
         return false;
       }
@@ -1842,7 +2262,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     };
 
     const settleIfStableVisible = () => {
-      const currentTargetElement = getRenderedUserMessageElement(request.turnId);
+      const currentTargetElement = getRenderedVirtualItemElement(targetIndex);
       if (!currentTargetElement) {
         request.visibleFrames = 0;
         request.stableVisibleFrames = 0;
@@ -1917,20 +2337,31 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
         previousScrollTopRef.current = nextScrollTop;
         previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
       }
-    } else {
+    } else if (virtuoso) {
       request.visibleFrames = 0;
       virtuoso.scrollToIndex({
         index: toVirtuosoIndex(targetIndex),
         align: 'end',
         behavior: 'auto',
       });
-      if (request.attempts >= 3) {
+      const shouldUseTailFallback =
+        targetIndex >= virtualItems.length - 1 ||
+        request.turnId === latestTurnId;
+      if (shouldUseTailFallback) {
         const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
         if (Math.abs(maxScrollTop - scroller.scrollTop) > COMPENSATION_EPSILON_PX) {
           scroller.scrollTop = maxScrollTop;
           previousScrollTopRef.current = maxScrollTop;
           previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
         }
+      }
+    } else {
+      request.visibleFrames = 0;
+      const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+      if (Math.abs(maxScrollTop - scroller.scrollTop) > COMPENSATION_EPSILON_PX) {
+        scroller.scrollTop = maxScrollTop;
+        previousScrollTopRef.current = maxScrollTop;
+        previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
       }
     }
 
@@ -1955,7 +2386,8 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     return false;
   }, [
     cancelLatestEndAnchorStabilization,
-    getRenderedUserMessageElement,
+    getRenderedVirtualItemElement,
+    latestTurnId,
     scheduleVisibleTurnMeasure,
     snapshotMeasuredContentHeight,
     toVirtuosoIndex,
@@ -1971,9 +2403,11 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     schedulePinReservationReconcile(2);
     scheduleTransientTurnPinStabilization(2);
     scheduleFollowToLatestWithViewportState('range-changed');
+    scheduleHistoryProjectionHandoffRelease(1);
   }, [
     resolveLatestEndAnchorStabilization,
     scheduleFollowToLatestWithViewportState,
+    scheduleHistoryProjectionHandoffRelease,
     schedulePinReservationReconcile,
     scheduleTransientTurnPinStabilization,
     scheduleVisibleTurnMeasure,
@@ -2158,6 +2592,19 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     return lastDialogTurn.modelRounds.some(round => round.isStreaming);
   }, [activeSession, isProcessing]);
   const initialTopMostItemIndex = React.useMemo(() => {
+    if (
+      historyProjectionHandoff?.mode === 'scroll-position' &&
+      historyProjectionHandoff.sessionId === activeSessionId
+    ) {
+      const anchorIndex = findVirtualItemIndexByStableKey(historyProjectionHandoff.anchorKey);
+      if (anchorIndex >= 0) {
+        return {
+          index: toVirtuosoIndex(anchorIndex),
+          align: 'start' as const,
+        };
+      }
+    }
+
     if (isStreamingOutput) {
       return toVirtuosoIndex(latestUserMessageIndex);
     }
@@ -2166,7 +2613,17 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       index: toVirtuosoIndex(Math.max(0, virtualItems.length - 1)),
       align: 'end' as const,
     };
-  }, [isStreamingOutput, latestUserMessageIndex, toVirtuosoIndex, virtualItems.length]);
+  }, [
+    activeSessionId,
+    findVirtualItemIndexByStableKey,
+    historyProjectionHandoff?.anchorKey,
+    historyProjectionHandoff?.mode,
+    historyProjectionHandoff?.sessionId,
+    isStreamingOutput,
+    latestUserMessageIndex,
+    toVirtuosoIndex,
+    virtualItems.length,
+  ]);
 
   useEffect(() => {
     const wasStreaming = previousIsStreamingOutputRef.current;
@@ -2738,6 +3195,91 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
   }, [lastItemInfo.isTurnProcessing, lastItemInfo.lastItem, isProcessing, processingPhase, isContentGrowing]);
 
   const footerHeightPx = getFooterHeightPx(getTotalBottomCompensationPx(bottomReservationState));
+  const useStaticInitialHistoryList = useInitialHistoryRenderBudget;
+  const sessionOpenProjectionHandoff = React.useMemo<HistoryProjectionHandoffSnapshot | null>(() => {
+    const previousActiveSessionId = previousActiveSessionIdForOpenHandoffRef.current;
+    const isSessionSwitch = (
+      previousActiveSessionId !== undefined &&
+      previousActiveSessionId !== activeSessionId
+    );
+
+    if (
+      !activeSessionId ||
+      !isSessionSwitch ||
+      activeSession?.historyState !== 'ready' ||
+      activeSession?.isPartial === true ||
+      useStaticInitialHistoryList ||
+      !latestTurnId ||
+      virtualItems.length < SESSION_OPEN_HANDOFF_ITEM_BUDGET ||
+      sessionOpenHandoffSessionIdRef.current === activeSessionId ||
+      historyProjectionHandoff?.sessionId === activeSessionId
+    ) {
+      return null;
+    }
+
+    const scroller = scrollerElementRef.current;
+    const budgetStartIndex = Math.max(0, virtualItems.length - SESSION_OPEN_HANDOFF_ITEM_BUDGET);
+    const latestStartIndex = Math.max(0, Math.min(latestUserMessageIndex, virtualItems.length - 1));
+    const startIndex = Math.min(budgetStartIndex, latestStartIndex);
+    const items = virtualItems.slice(startIndex);
+    if (items.length === 0) {
+      return null;
+    }
+
+    const clientHeight = scroller?.clientHeight ?? 0;
+    return {
+      sessionId: activeSessionId,
+      reason: 'session-open',
+      createdAtMs: performance.now(),
+      items,
+      mode: 'bottom-tail',
+      targetTurnId: latestTurnId,
+      anchorKey: null,
+      anchorOffsetTopPx: 0,
+      scrollTop: 0,
+      scrollHeight: clientHeight,
+      clientHeight,
+      footerHeightPx,
+    };
+  }, [
+    activeSession?.historyState,
+    activeSession?.isPartial,
+    activeSessionId,
+    footerHeightPx,
+    historyProjectionHandoff?.sessionId,
+    latestTurnId,
+    latestUserMessageIndex,
+    useStaticInitialHistoryList,
+    virtualItems,
+  ]);
+  useLayoutEffect(() => {
+    if (
+      !sessionOpenProjectionHandoff ||
+      sessionOpenHandoffSessionIdRef.current === sessionOpenProjectionHandoff.sessionId
+    ) {
+      return;
+    }
+
+    pendingHistoryProjectionHandoffRef.current = null;
+    historyProjectionHandoffRef.current = sessionOpenProjectionHandoff;
+    sessionOpenHandoffSessionIdRef.current = sessionOpenProjectionHandoff.sessionId;
+    setHistoryProjectionHandoff(sessionOpenProjectionHandoff);
+    startupTrace.markPhase('flowchat_history_projection_handoff_activated', {
+      sessionId: sessionOpenProjectionHandoff.sessionId,
+      reason: sessionOpenProjectionHandoff.reason,
+      previousItemCount: 0,
+      nextItemCount: virtualItems.length,
+    });
+    scheduleHistoryProjectionHandoffRelease(2);
+  }, [
+    scheduleHistoryProjectionHandoffRelease,
+    sessionOpenProjectionHandoff,
+    virtualItems.length,
+  ]);
+  useLayoutEffect(() => {
+    previousActiveSessionIdForOpenHandoffRef.current = activeSessionId;
+  }, [activeSessionId]);
+  const activeHistoryProjectionHandoff = historyProjectionHandoff ?? sessionOpenProjectionHandoff;
   const hasCompactHistoricalProjection = virtualItems.length >= 6 && virtualItems
     .slice(-16)
     .every(item =>
@@ -2745,14 +3287,6 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       item.type === 'user-steering-message' ||
       item.type === 'explore-group'
     );
-  const hasPendingHistoryCompletion = activeSession?.sessionId
-    ? flowChatStore.hasPendingSessionHistoryCompletion(activeSession.sessionId)
-    : false;
-  const hasPartialHistoryInitialViewport =
-    activeSession?.historyState === 'ready' &&
-    activeSession.contextRestoreState === 'pending' &&
-    (activeSession.dialogTurns.length ?? 0) <= PARTIAL_HISTORY_INITIAL_TAIL_TURN_BUDGET;
-  const useInitialHistoryRenderBudget = hasPendingHistoryCompletion || hasPartialHistoryInitialViewport;
   const hasInitialHistoryModelRoundProjection =
     useInitialHistoryRenderBudget &&
     virtualItems.slice(-16).some(item => item.type === 'model-round');
@@ -2761,14 +3295,86 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     hasCompactHistoricalProjection,
     hasInitialHistoryModelRoundProjection,
   });
-  const virtuosoOverscan = useInitialHistoryRenderBudget
-    ? { main: 0, reverse: 0 }
-    : { main: 600, reverse: 600 };
-  const virtuosoViewportIncrease = useInitialHistoryRenderBudget
-    ? { top: 0, bottom: 0 }
-    : { top: 600, bottom: 600 };
+  const initialHistoryHeightEstimates = React.useMemo(
+    () => useInitialHistoryRenderBudget
+      ? virtualItems.map(estimateVirtualMessageItemHeight)
+      : undefined,
+    [useInitialHistoryRenderBudget, virtualItems],
+  );
+  const virtuosoOverscan = { main: 600, reverse: 600 };
+  const virtuosoViewportIncrease = { top: 600, bottom: 600 };
+  useLayoutEffect(() => {
+    if (!useStaticInitialHistoryList) {
+      return;
+    }
 
+    const scroller = scrollerElementRef.current;
+    if (!scroller) {
+      return;
+    }
+
+    const nextScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+    scroller.scrollTop = nextScrollTop;
+    previousScrollTopRef.current = nextScrollTop;
+    previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+    scheduleVisibleTurnMeasure(1);
+  }, [
+    activeSessionId,
+    footerHeightPx,
+    latestTurnId,
+    scheduleVisibleTurnMeasure,
+    snapshotMeasuredContentHeight,
+    useStaticInitialHistoryList,
+    virtualItems.length,
+  ]);
   // ── Render ────────────────────────────────────────────────────────────
+  useLayoutEffect(() => {
+    const snapshot = historyProjectionHandoffRef.current;
+    if (
+      !snapshot ||
+      snapshot.mode !== 'scroll-position' ||
+      snapshot.sessionId !== activeSessionId ||
+      !snapshot.anchorKey
+    ) {
+      return;
+    }
+
+    const scroller = scrollerElementRef.current;
+    const anchorIndex = findVirtualItemIndexByStableKey(snapshot.anchorKey);
+    if (!scroller || anchorIndex < 0) {
+      return;
+    }
+
+    const anchorElement = getRenderedVirtualItemElement(anchorIndex);
+    if (!anchorElement) {
+      return;
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const anchorRect = anchorElement.getBoundingClientRect();
+    const offsetDelta = (anchorRect.top - scrollerRect.top) - snapshot.anchorOffsetTopPx;
+    if (Math.abs(offsetDelta) <= COMPENSATION_EPSILON_PX) {
+      return;
+    }
+
+    const nextScrollTop = Math.max(0, scroller.scrollTop + offsetDelta);
+    scroller.scrollTop = nextScrollTop;
+    previousScrollTopRef.current = nextScrollTop;
+    previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+    scheduleHistoryProjectionHandoffRelease(2);
+  }, [
+    activeSessionId,
+    findVirtualItemIndexByStableKey,
+    getRenderedVirtualItemElement,
+    historyProjectionHandoff?.anchorKey,
+    historyProjectionHandoff?.anchorOffsetTopPx,
+    historyProjectionHandoff?.mode,
+    historyProjectionHandoff?.sessionId,
+    scheduleHistoryProjectionHandoffRelease,
+    snapshotMeasuredContentHeight,
+    virtualItems,
+  ]);
+
   if (virtualItems.length === 0) {
     return (
       <div className="virtual-message-list virtual-message-list--empty">
@@ -2780,58 +3386,131 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
   }
 
   return (
-    <div className="virtual-message-list">
-      <Virtuoso
-        ref={virtuosoRef}
-        data={virtualItems}
-        computeItemKey={(_, item) => getVirtualItemStableKey(item)}
-        itemContent={(index, item) => (
-          <VirtualItemRenderer
-            item={item}
-            index={index - virtuosoFirstItemIndex}
-          />
-        )}
-        followOutput={false}
-
-        alignToBottom={false}
-        firstItemIndex={virtuosoFirstItemIndex}
-        // New mounts start near the latest user turn to avoid flashing older
-        // content before sticky pin logic can finish.
-        initialTopMostItemIndex={initialTopMostItemIndex}
-
-        overscan={virtuosoOverscan}
-
-        atBottomThreshold={50}
-        atBottomStateChange={handleAtBottomStateChange}
-
-        rangeChanged={handleRangeChanged}
-
-        // Historical sessions often restore into compact user/explore rows.
-        // Keep live sessions on the legacy estimate because active assistant
-        // output can be much taller while streaming.
-        defaultItemHeight={defaultItemHeight}
-
-        increaseViewportBy={virtuosoViewportIncrease}
-
-        scrollerRef={handleScrollerRef}
-
-        components={{
-          Header: () => <div className="message-list-header" />,
-          Footer: () => (
-            <>
-              <ProcessingIndicator visible={showBreathingIndicator} reserveSpace={reserveSpaceForIndicator} />
-              <div
-                ref={footerElementRef}
-                className="message-list-footer"
-                style={{
-                  height: `${footerHeightPx}px`,
-                  minHeight: `${footerHeightPx}px`,
-                }}
+    <div
+      className="virtual-message-list"
+    >
+      {useStaticInitialHistoryList ? (
+        <div
+          ref={handleScrollerRef}
+          className="virtual-message-list__static-scroller"
+          data-virtuoso-scroller="true"
+        >
+          <div className="message-list-header" />
+          <div className="virtual-message-list__static-items">
+            {virtualItems.map((item, index) => (
+              <VirtualItemRenderer
+                key={`${activeSessionId ?? 'no-active-session'}:${getVirtualItemStableKey(item)}`}
+                item={item}
+                index={index}
               />
-            </>
-          ),
-        }}
-      />
+            ))}
+          </div>
+          <ProcessingIndicator visible={showBreathingIndicator} reserveSpace={reserveSpaceForIndicator} />
+          <div
+            ref={footerElementRef}
+            className="message-list-footer"
+            style={{
+              height: `${footerHeightPx}px`,
+              minHeight: `${footerHeightPx}px`,
+            }}
+          />
+        </div>
+      ) : (
+        <Virtuoso
+          key={activeSessionId ?? 'no-active-session'}
+          ref={virtuosoRef}
+          data={virtualItems}
+          computeItemKey={(_, item) => `${activeSessionId ?? 'no-active-session'}:${getVirtualItemStableKey(item)}`}
+          itemContent={(index, item) => (
+            <VirtualItemRenderer
+              item={item}
+              index={index - virtuosoFirstItemIndex}
+            />
+          )}
+          followOutput={false}
+
+          alignToBottom={false}
+          firstItemIndex={virtuosoFirstItemIndex}
+          // New mounts start near the latest user turn to avoid flashing older
+          // content before sticky pin logic can finish.
+          initialTopMostItemIndex={initialTopMostItemIndex}
+          overscan={virtuosoOverscan}
+
+          atBottomThreshold={50}
+          atBottomStateChange={handleAtBottomStateChange}
+
+          rangeChanged={handleRangeChanged}
+
+          // Historical sessions often restore into compact user/explore rows.
+          // Keep live sessions on the legacy estimate because active assistant
+          // output can be much taller while streaming.
+          defaultItemHeight={defaultItemHeight}
+          heightEstimates={initialHistoryHeightEstimates}
+
+          increaseViewportBy={virtuosoViewportIncrease}
+
+          scrollerRef={handleScrollerRef}
+
+          components={{
+            Header: () => <div className="message-list-header" />,
+            Footer: () => (
+              <>
+                <ProcessingIndicator visible={showBreathingIndicator} reserveSpace={reserveSpaceForIndicator} />
+                <div
+                  ref={footerElementRef}
+                  className="message-list-footer"
+                  style={{
+                    height: `${footerHeightPx}px`,
+                    minHeight: `${footerHeightPx}px`,
+                  }}
+                />
+              </>
+            ),
+          }}
+        />
+      )}
+
+      {activeHistoryProjectionHandoff ? (
+        <div
+          className="virtual-message-list__projection-handoff-overlay"
+          data-history-projection-handoff="true"
+          data-session-id={activeHistoryProjectionHandoff.sessionId}
+          aria-hidden="true"
+        >
+          <div
+            className={[
+              'virtual-message-list__projection-handoff-content',
+              activeHistoryProjectionHandoff.mode === 'bottom-tail'
+                ? 'virtual-message-list__projection-handoff-content--bottom'
+                : null,
+            ].filter(Boolean).join(' ')}
+            style={activeHistoryProjectionHandoff.mode === 'bottom-tail'
+              ? undefined
+              : {
+                minHeight: `${Math.max(activeHistoryProjectionHandoff.scrollHeight, activeHistoryProjectionHandoff.clientHeight)}px`,
+                transform: `translate3d(0, -${Math.max(0, activeHistoryProjectionHandoff.scrollTop)}px, 0)`,
+              }}
+          >
+            <div className="message-list-header" />
+            <div className="virtual-message-list__static-items">
+              {activeHistoryProjectionHandoff.items.map((item, index) => (
+                <VirtualItemRenderer
+                  key={`history-projection-handoff:${activeHistoryProjectionHandoff.sessionId}:${getVirtualItemStableKey(item)}`}
+                  item={item}
+                  index={index}
+                />
+              ))}
+            </div>
+            <div
+              className="message-list-footer"
+              style={{
+                height: `${activeHistoryProjectionHandoff.footerHeightPx}px`,
+                minHeight: `${activeHistoryProjectionHandoff.footerHeightPx}px`,
+              }}
+            />
+          </div>
+        </div>
+      ) : null}
 
       <ScrollAnchor
         onAnchorNavigate={(turnId) => {

--- a/src/web-ui/src/flow_chat/components/modern/modelRoundItemGrouping.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/modelRoundItemGrouping.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { buildModelRoundItemGroups } from './modelRoundItemGrouping';
+import {
+  buildModelRoundItemGroups,
+  isCompletedToolInTransientWindow,
+} from './modelRoundItemGrouping';
 import type { FlowTextItem, FlowToolItem, FlowUserSteeringItem } from '../../types/flow-chat';
 
 function makeTextItem(id: string): FlowTextItem {
@@ -204,5 +207,33 @@ describe('buildModelRoundItemGroups', () => {
         isLast: true,
       },
     ]);
+  });
+});
+
+describe('isCompletedToolInTransientWindow', () => {
+  it('treats only freshly completed tools as transient', () => {
+    expect(isCompletedToolInTransientWindow(
+      makeReadTool('tool-1', 'completed', 10_000),
+      10_200,
+    )).toBe(true);
+    expect(isCompletedToolInTransientWindow(
+      makeReadTool('tool-2', 'completed', 10_000),
+      11_001,
+    )).toBe(false);
+  });
+
+  it('does not classify historical or invalid completion times as transient', () => {
+    expect(isCompletedToolInTransientWindow(
+      makeReadTool('tool-1', 'completed'),
+      10_200,
+    )).toBe(false);
+    expect(isCompletedToolInTransientWindow(
+      makeReadTool('tool-2', 'completed', 12_000),
+      10_200,
+    )).toBe(false);
+    expect(isCompletedToolInTransientWindow(
+      makeReadTool('tool-3', 'running'),
+      10_200,
+    )).toBe(false);
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/modelRoundItemGrouping.ts
+++ b/src/web-ui/src/flow_chat/components/modern/modelRoundItemGrouping.ts
@@ -28,10 +28,12 @@ function isActiveToolItem(item: FlowItem): boolean {
   return item.status !== 'completed' && item.status !== 'cancelled' && item.status !== 'error';
 }
 
-function isRecentlyCompletedToolItem(item: FlowItem, nowMs: number): boolean {
+export function isCompletedToolInTransientWindow(item: FlowItem, nowMs: number): boolean {
   if (item.type !== 'tool' || item.status !== 'completed') return false;
   const endTime = (item as FlowToolItem).endTime;
-  return typeof endTime === 'number' && nowMs - endTime < COMPLETED_TOOL_TRANSIENT_MS;
+  if (typeof endTime !== 'number') return false;
+  const elapsedMs = nowMs - endTime;
+  return elapsedMs >= 0 && elapsedMs < COMPLETED_TOOL_TRANSIENT_MS;
 }
 
 export function buildModelRoundItemGroups({
@@ -93,7 +95,7 @@ export function buildModelRoundItemGroups({
         const keepTransientlyCritical =
           deferExploreGrouping ||
           isActiveToolItem(item) ||
-          (isStreaming && isRecentlyCompletedToolItem(item, nowMs));
+          (isStreaming && isCompletedToolInTransientWindow(item, nowMs));
 
         if (keepTransientlyCritical) {
           flushExploreBuffer(false);

--- a/src/web-ui/src/flow_chat/components/modern/virtualMessageListLayout.ts
+++ b/src/web-ui/src/flow_chat/components/modern/virtualMessageListLayout.ts
@@ -1,13 +1,24 @@
+import type { AnyFlowItem } from '../../types/flow-chat';
+import type { VirtualItem } from '../../store/modernFlowChatStore';
+
 export const LIVE_SESSION_DEFAULT_ITEM_HEIGHT_PX = 200;
 export const HISTORICAL_SESSION_DEFAULT_ITEM_HEIGHT_PX = 72;
 export const HISTORICAL_SESSION_MODEL_ROUND_DEFAULT_ITEM_HEIGHT_PX = 960;
+const USER_MESSAGE_BASE_HEIGHT_PX = 96;
+const USER_MESSAGE_LINE_HEIGHT_PX = 22;
+const MODEL_ROUND_BASE_HEIGHT_PX = 80;
+const MODEL_ROUND_TEXT_BASE_HEIGHT_PX = 72;
+const MODEL_ROUND_TEXT_LINE_HEIGHT_PX = 30;
+const TOOL_CARD_ESTIMATE_HEIGHT_PX = 88;
+const EXPLORE_GROUP_BASE_HEIGHT_PX = 96;
+const ESTIMATED_TEXT_CHARS_PER_LINE = 60;
 
 export function getVirtualMessageDefaultItemHeight(params: {
   isHistorical: boolean;
   hasCompactHistoricalProjection: boolean;
   hasInitialHistoryModelRoundProjection: boolean;
 }): number {
-  if (params.isHistorical || params.hasCompactHistoricalProjection) {
+  if (params.hasCompactHistoricalProjection) {
     return HISTORICAL_SESSION_DEFAULT_ITEM_HEIGHT_PX;
   }
 
@@ -15,5 +26,88 @@ export function getVirtualMessageDefaultItemHeight(params: {
     return HISTORICAL_SESSION_MODEL_ROUND_DEFAULT_ITEM_HEIGHT_PX;
   }
 
+  if (params.isHistorical) {
+    return HISTORICAL_SESSION_DEFAULT_ITEM_HEIGHT_PX;
+  }
+
   return LIVE_SESSION_DEFAULT_ITEM_HEIGHT_PX;
+}
+
+export function estimateTextHeightFromLength(textLength: number, basePx: number, lineHeightPx: number): number {
+  const lineCount = Math.max(1, Math.ceil(textLength / ESTIMATED_TEXT_CHARS_PER_LINE));
+  return basePx + lineCount * lineHeightPx;
+}
+
+function estimateTextHeight(content: string, basePx: number, lineHeightPx: number): number {
+  return estimateTextHeightFromLength(content.length, basePx, lineHeightPx);
+}
+
+function getFlowItemTextLength(item: AnyFlowItem): number {
+  if (item.type === 'text' || item.type === 'thinking' || item.type === 'user-steering') {
+    return item.content.length;
+  }
+  return 0;
+}
+
+function estimateFlowItemHeight(item: AnyFlowItem): number {
+  const textLength = getFlowItemTextLength(item);
+  if (textLength > 0) {
+    return Math.min(
+      3200,
+      estimateTextHeightFromLength(
+        textLength,
+        MODEL_ROUND_TEXT_BASE_HEIGHT_PX,
+        MODEL_ROUND_TEXT_LINE_HEIGHT_PX,
+      ),
+    );
+  }
+
+  if (item.type === 'tool') {
+    return TOOL_CARD_ESTIMATE_HEIGHT_PX;
+  }
+
+  if (item.type === 'image-analysis') {
+    return 320;
+  }
+
+  return HISTORICAL_SESSION_DEFAULT_ITEM_HEIGHT_PX;
+}
+
+function estimateModelRoundHeight(item: Extract<VirtualItem, { type: 'model-round' }>): number {
+  const flowItems = item.data.items ?? [];
+  if (flowItems.length === 0) {
+    return LIVE_SESSION_DEFAULT_ITEM_HEIGHT_PX;
+  }
+
+  const contentHeight = flowItems.reduce(
+    (total, flowItem) => total + estimateFlowItemHeight(flowItem),
+    0,
+  );
+  return Math.min(3600, Math.max(LIVE_SESSION_DEFAULT_ITEM_HEIGHT_PX, MODEL_ROUND_BASE_HEIGHT_PX + contentHeight));
+}
+
+function estimateUserMessageHeight(content: string | undefined): number {
+  return Math.min(
+    320,
+    estimateTextHeight(content ?? '', USER_MESSAGE_BASE_HEIGHT_PX, USER_MESSAGE_LINE_HEIGHT_PX),
+  );
+}
+
+function estimateExploreGroupHeight(item: Extract<VirtualItem, { type: 'explore-group' }>): number {
+  const visibleRowCount = Math.min(10, item.data.allItems.length);
+  return Math.min(420, EXPLORE_GROUP_BASE_HEIGHT_PX + visibleRowCount * 24);
+}
+
+export function estimateVirtualMessageItemHeight(item: VirtualItem): number {
+  switch (item.type) {
+    case 'user-message':
+    case 'user-steering-message':
+      return estimateUserMessageHeight(item.data.content);
+    case 'model-round':
+      return estimateModelRoundHeight(item);
+    case 'explore-group':
+      return estimateExploreGroupHeight(item);
+    case 'image-analyzing':
+      return LIVE_SESSION_DEFAULT_ITEM_HEIGHT_PX;
+  }
 }

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -189,7 +189,8 @@ export class FlowChatManager {
             workspacePath,
             undefined,
             latestSession.remoteConnectionId,
-            latestSession.remoteSshHost
+            latestSession.remoteSshHost,
+            { deferFullHistoryUntilActive: true },
           );
         }
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
@@ -118,9 +118,53 @@ describe('SessionModule historical session coordination', () => {
     vi.clearAllMocks();
   });
 
-  it('switches to a historical session immediately while hydrating in the background', async () => {
+  it('hydrates a metadata-only historical session before switching to avoid an empty loading page', async () => {
     const load = createDeferred<void>();
     const { context, flowChatStore } = createContext(createSession());
+    flowChatStore.loadSessionHistory.mockReturnValueOnce(load.promise);
+    persistenceMocks.touchSessionActivity.mockResolvedValueOnce(undefined);
+
+    const switching = switchChatSession(context, 'history-1');
+    await Promise.resolve();
+
+    expect(flowChatStore.switchSession).not.toHaveBeenCalled();
+    expect(flowChatStore.loadSessionHistory).toHaveBeenCalledTimes(1);
+
+    load.resolve();
+    await switching;
+
+    expect(flowChatStore.switchSession).toHaveBeenCalledWith('history-1');
+  });
+
+  it('switches immediately when a historical session already has renderable tail content', async () => {
+    const load = createDeferred<void>();
+    const { context, flowChatStore } = createContext(createSession({
+      historyState: 'ready',
+      dialogTurns: [{
+        id: 'turn-1',
+        userMessage: { id: 'user-turn-1', content: 'Latest prompt', timestamp: 1 },
+        modelRounds: [],
+        status: 'completed',
+      } as any],
+    }));
+    flowChatStore.loadSessionHistory.mockReturnValueOnce(load.promise);
+    persistenceMocks.touchSessionActivity.mockResolvedValueOnce(undefined);
+
+    await switchChatSession(context, 'history-1');
+
+    expect(flowChatStore.switchSession).toHaveBeenCalledWith('history-1');
+    expect(flowChatStore.loadSessionHistory).toHaveBeenCalledTimes(1);
+
+    load.resolve();
+    await load.promise;
+  });
+
+  it('does not block remote metadata-only historical sessions on local pre-hydration before switching', async () => {
+    const load = createDeferred<void>();
+    const { context, flowChatStore } = createContext(createSession({
+      remoteConnectionId: 'remote-1',
+      remoteSshHost: 'remote-host',
+    }));
     flowChatStore.loadSessionHistory.mockReturnValueOnce(load.promise);
     persistenceMocks.touchSessionActivity.mockResolvedValueOnce(undefined);
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -15,6 +15,7 @@ import { normalizeRemoteWorkspacePath } from '@/shared/utils/pathUtils';
 import { WorkspaceKind, type WorkspaceInfo } from '@/shared/types';
 import type { AIModelConfig, DefaultModelsConfig } from '@/infrastructure/config/types';
 import type { FlowChatContext, SessionConfig } from './types';
+import type { Session } from '../../types/flow-chat';
 import { touchSessionActivity, cleanupSaveState } from './PersistenceModule';
 import {
   createTextSessionTitleDescriptor,
@@ -26,6 +27,7 @@ import { buildCreateSessionRelationship } from '../../utils/sessionMetadata';
 
 const log = createLogger('SessionModule');
 const pendingSessionCreations = new Map<string, Promise<string>>();
+let latestSwitchRequestId = 0;
 
 const normalizeOptional = (value: string | undefined): string | undefined => {
   const trimmed = value?.trim();
@@ -144,7 +146,8 @@ async function hydrateHistoricalSession(
       workspacePath,
       undefined,
       effectiveConnectionId,
-      effectiveSshHost
+      effectiveSshHost,
+      { deferFullHistoryUntilActive: true },
     );
   })();
 
@@ -171,6 +174,14 @@ async function hydrateHistoricalSession(
       context.pendingHistoryLoads.delete(sessionId);
     }
   }
+}
+
+function hasRenderableSessionContent(session: Session): boolean {
+  return session.dialogTurns.some(turn =>
+    Boolean(turn.userMessage) ||
+    (turn.status === 'image_analyzing' && turn.modelRounds.length === 0) ||
+    turn.modelRounds.some(round => round.items.length > 0)
+  );
 }
 
 type SessionDisplayMode = 'code' | 'cowork' | 'claw';
@@ -475,14 +486,13 @@ export async function switchChatSession(
   sessionId: string
 ): Promise<void> {
   try {
+    const switchRequestId = ++latestSwitchRequestId;
     const session = context.flowChatStore.getState().sessions.get(sessionId);
-
-    // Switch UI immediately so the user sees the new session without waiting for history load.
-    context.flowChatStore.switchSession(sessionId);
-    startupTrace.markPhase('historical_session_switch', {
-      historical: Boolean(session?.isHistorical),
-      remote: isRemoteTraceContext(session?.remoteConnectionId, session?.remoteSshHost),
-    });
+    const isRemoteSession = isRemoteTraceContext(session?.remoteConnectionId, session?.remoteSshHost);
+    const shouldHydrateBeforeSwitch =
+      session?.isHistorical === true &&
+      !isRemoteSession &&
+      !hasRenderableSessionContent(session);
 
     touchSessionActivity(
       sessionId,
@@ -493,7 +503,33 @@ export async function switchChatSession(
       log.debug('Failed to touch session activity', { sessionId, error });
     });
 
-    if (session?.isHistorical) {
+    if (shouldHydrateBeforeSwitch) {
+      try {
+        await hydrateHistoricalSession(context, sessionId, true);
+      } catch {
+        // The hydrate path already marks the session failed and notifies the user.
+        // Continue with activation so the failed state is visible.
+      }
+
+      if (switchRequestId !== latestSwitchRequestId) {
+        startupTrace.markPhase('historical_session_switch_superseded', {
+          sessionId,
+        });
+        return;
+      }
+    }
+
+    // Avoid showing an empty loading page between two sessions. Historical
+    // sessions without a renderable tail are activated after their first
+    // visible content is restored; already-renderable sessions still switch
+    // immediately and continue full hydration in the background.
+    context.flowChatStore.switchSession(sessionId);
+    startupTrace.markPhase('historical_session_switch', {
+      historical: Boolean(session?.isHistorical),
+      remote: isRemoteSession,
+    });
+
+    if (session?.isHistorical && !shouldHydrateBeforeSwitch) {
       // Load history in the background — do not block the UI.
       void hydrateHistoricalSession(context, sessionId, true);
     }
@@ -612,7 +648,8 @@ export async function forkChatSession(
     workspacePath,
     undefined,
     sourceSession.remoteConnectionId,
-    sourceSession.remoteSshHost
+    sourceSession.remoteSshHost,
+    { deferFullHistoryUntilActive: true },
   );
   context.flowChatStore.switchSession(response.sessionId);
 

--- a/src/web-ui/src/flow_chat/services/sessionOpenIntent.ts
+++ b/src/web-ui/src/flow_chat/services/sessionOpenIntent.ts
@@ -1,0 +1,36 @@
+import type { Session } from '../types/flow-chat';
+
+export const HISTORY_SESSION_OPEN_INTENT_EVENT = 'flowchat:history-session-open-intent';
+
+export interface HistorySessionOpenIntentDetail {
+  sessionId: string;
+  sessionTitle?: string;
+}
+
+export function shouldShowHistorySessionOpenIntent(session: Session | null | undefined): boolean {
+  if (!session) {
+    return false;
+  }
+
+  if (
+    session.isHistorical ||
+    session.historyState === 'metadata-only' ||
+    session.historyState === 'hydrating' ||
+    session.historyState === 'failed'
+  ) {
+    return true;
+  }
+
+  return session.historyState === 'ready' && session.contextRestoreState === 'pending';
+}
+
+export function dispatchHistorySessionOpenIntent(sessionId: string, sessionTitle?: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.dispatchEvent(new CustomEvent<HistorySessionOpenIntentDetail>(
+    HISTORY_SESSION_OPEN_INTENT_EVENT,
+    { detail: { sessionId, sessionTitle } },
+  ));
+}

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flowChatStore } from './FlowChatStore';
 import type { FlowChatState, Session } from '../types/flow-chat';
 import { startupTrace } from '@/shared/utils/startupTrace';
@@ -42,6 +42,15 @@ vi.mock('@/infrastructure/api', () => ({
   },
 }));
 
+vi.mock('@/infrastructure/api/service-api/SessionAPI', () => ({
+  sessionAPI: {
+    listSessions: apiMocks.listSessions,
+    listSessionsPage: apiMocks.listSessionsPage,
+    loadSessionTurns: apiMocks.loadSessionTurns,
+    saveSessionTurn: apiMocks.saveSessionTurn,
+  },
+}));
+
 vi.mock('@/infrastructure/config/services/ConfigManager', () => ({
   configManager: configManagerMock,
 }));
@@ -76,6 +85,8 @@ const resetStore = () => {
     request.cancel?.();
   });
   fullHistoryHydrationRequests?.clear();
+  ((flowChatStore as any).deferredFullHistoryProjections as Map<string, unknown> | undefined)?.clear();
+  ((flowChatStore as any).fullHistoryProjectionApplyRequests as Set<string> | undefined)?.clear();
   ((flowChatStore as any).unsupportedRestoreCommands as Set<string> | undefined)?.clear();
   flowChatStore.setState((): FlowChatState => ({
     sessions: new Map(),
@@ -116,6 +127,13 @@ async function flushAsyncWork(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+}
+
+async function advanceReleasedLocalFullHistoryCompletion(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(750);
+  await flushAsyncWork();
+  await vi.advanceTimersByTimeAsync(1500);
+  await flushAsyncWork();
 }
 
 describe('FlowChatStore metadata persistence callbacks', () => {
@@ -288,12 +306,28 @@ describe('FlowChatStore ACP context usage', () => {
 });
 
 describe('FlowChatStore historical session hydration state', () => {
+  beforeEach(() => {
+    vi.stubGlobal('CustomEvent', class {
+      type: string;
+      detail: unknown;
+
+      constructor(type: string, init?: { detail?: unknown }) {
+        this.type = type;
+        this.detail = init?.detail;
+      }
+    });
+    vi.stubGlobal('window', {
+      dispatchEvent: vi.fn(),
+    });
+  });
+
   afterEach(() => {
     resetStore();
     if (typeof apiMocks.restoreSessionView !== 'function') {
       (apiMocks as any).restoreSessionView = vi.fn();
     }
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('loads persisted metadata as metadata-only historical sessions', async () => {
@@ -794,8 +828,7 @@ describe('FlowChatStore historical session hydration state', () => {
       flowChatStore.setSessionContextRestoreState('history-1', 'ready');
       flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint('history-1');
 
-      await vi.runOnlyPendingTimersAsync();
-      await flushAsyncWork();
+      await advanceReleasedLocalFullHistoryCompletion();
 
       expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(2);
       expect(apiMocks.restoreSessionView).toHaveBeenNthCalledWith(
@@ -808,6 +841,12 @@ describe('FlowChatStore historical session hydration state', () => {
         undefined,
         undefined,
       );
+      expect(flowChatStore.hasDeferredSessionHistoryProjection('history-1')).toBe(true);
+      expect(
+        flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.userMessage.content)
+      ).toEqual(['latest prompt']);
+
+      expect(flowChatStore.requestSessionFullHistoryProjection('history-1', 'test')).toBe(true);
       expect(
         flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.userMessage.content)
       ).toEqual(['older prompt', 'latest prompt']);
@@ -901,14 +940,404 @@ describe('FlowChatStore historical session hydration state', () => {
       flowChatStore.addDialogTurn('history-1', newTurn);
 
       flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint('history-1');
-      await vi.runOnlyPendingTimersAsync();
-      await flushAsyncWork();
+      await advanceReleasedLocalFullHistoryCompletion();
 
       expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(2);
+      expect(flowChatStore.hasDeferredSessionHistoryProjection('history-1')).toBe(true);
+      expect(flowChatStore.requestSessionFullHistoryProjection('history-1', 'test')).toBe(true);
       expect(
         flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.userMessage.content)
       ).toEqual(['older prompt', 'latest prompt', 'new prompt']);
       expect(flowChatStore.getState().sessions.get('history-1')?.dialogTurns[2]).toBe(newTurn);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('defers full history completion when partial hydrate finishes after switching away', async () => {
+    vi.useFakeTimers();
+    const latestTurn = {
+      turnId: 'turn-2',
+      turnIndex: 1,
+      sessionId: 'history-1',
+      timestamp: 2,
+      userMessage: { id: 'user-2', content: 'latest prompt', timestamp: 2 },
+      modelRounds: [],
+      startTime: 2,
+      status: 'completed',
+    };
+    const partialRestore = createDeferred<any>();
+    apiMocks.restoreSessionView.mockReturnValueOnce(partialRestore.promise);
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+        ['history-2', createSession({
+          sessionId: 'history-2',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    try {
+      const load = flowChatStore.loadSessionHistory(
+        'history-1',
+        'D:/workspace/BitFun',
+        undefined,
+        undefined,
+        undefined,
+        { deferFullHistoryUntilActive: true },
+      );
+      await flushAsyncWork();
+
+      flowChatStore.switchSession('history-2');
+      partialRestore.resolve({
+        session: {
+          sessionId: 'history-1',
+          sessionName: 'History 1',
+          agentType: 'agentic',
+          state: 'Idle',
+          turnCount: 2,
+          createdAt: 1,
+        },
+        turns: [latestTurn],
+        contextRestoreState: 'pending',
+        isPartial: true,
+        loadedTurnCount: 1,
+        totalTurnCount: 2,
+      });
+      await load;
+
+      expect(flowChatStore.getState().activeSessionId).toBe('history-2');
+      expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
+        historyState: 'ready',
+        isPartial: true,
+      });
+      expect(flowChatStore.hasPendingSessionHistoryCompletion('history-1')).toBe(false);
+
+      await vi.runOnlyPendingTimersAsync();
+      await flushAsyncWork();
+
+      expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reschedules deferred full history completion when switching back to a partial session', async () => {
+    vi.useFakeTimers();
+    const latestTurn = {
+      id: 'turn-2',
+      sessionId: 'history-1',
+      userMessage: { id: 'user-2', content: 'latest prompt', timestamp: 2 },
+      modelRounds: [],
+      startTime: 2,
+      status: 'completed',
+    } as any;
+    const olderTurn = {
+      turnId: 'turn-1',
+      turnIndex: 0,
+      sessionId: 'history-1',
+      timestamp: 1,
+      userMessage: { id: 'user-1', content: 'older prompt', timestamp: 1 },
+      modelRounds: [],
+      startTime: 1,
+      status: 'completed',
+    };
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Idle',
+        turnCount: 2,
+        createdAt: 1,
+      },
+      turns: [olderTurn, {
+        turnId: 'turn-2',
+        turnIndex: 1,
+        sessionId: 'history-1',
+        timestamp: 2,
+        userMessage: { id: 'user-2', content: 'latest prompt', timestamp: 2 },
+        modelRounds: [],
+        startTime: 2,
+        status: 'completed',
+      }],
+      contextRestoreState: 'pending',
+      isPartial: false,
+      loadedTurnCount: 2,
+      totalTurnCount: 2,
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: false,
+          historyState: 'ready',
+          isPartial: true,
+          loadedTurnCount: 1,
+          totalTurnCount: 2,
+          contextRestoreState: 'pending',
+          dialogTurns: [latestTurn],
+          workspacePath: 'D:/workspace/BitFun',
+        })],
+        ['history-2', createSession({
+          sessionId: 'history-2',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-2',
+    }));
+
+    try {
+      flowChatStore.switchSession('history-1');
+
+      expect(flowChatStore.hasPendingSessionHistoryCompletion('history-1')).toBe(true);
+      flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint('history-1');
+      await advanceReleasedLocalFullHistoryCompletion();
+
+      expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(1);
+      expect(flowChatStore.hasDeferredSessionHistoryProjection('history-1')).toBe(true);
+      expect(flowChatStore.requestSessionFullHistoryProjection('history-1', 'test')).toBe(true);
+      expect(
+        flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.userMessage.content)
+      ).toEqual(['older prompt', 'latest prompt']);
+      expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
+        isPartial: false,
+        loadedTurnCount: 2,
+        totalTurnCount: 2,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels pending full history completion for the previous active session', async () => {
+    vi.useFakeTimers();
+    const latestTurn = {
+      turnId: 'turn-2',
+      turnIndex: 1,
+      sessionId: 'history-1',
+      timestamp: 2,
+      userMessage: { id: 'user-2', content: 'latest prompt', timestamp: 2 },
+      modelRounds: [],
+      startTime: 2,
+      status: 'completed',
+    };
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Idle',
+        turnCount: 2,
+        createdAt: 1,
+      },
+      turns: [latestTurn],
+      contextRestoreState: 'pending',
+      isPartial: true,
+      loadedTurnCount: 1,
+      totalTurnCount: 2,
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+        ['history-2', createSession({
+          sessionId: 'history-2',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    try {
+      await flowChatStore.loadSessionHistory(
+        'history-1',
+        'D:/workspace/BitFun',
+        undefined,
+        undefined,
+        undefined,
+        { deferFullHistoryUntilActive: true },
+      );
+
+      expect(flowChatStore.hasPendingSessionHistoryCompletion('history-1')).toBe(true);
+      flowChatStore.switchSession('history-2');
+      expect(flowChatStore.hasPendingSessionHistoryCompletion('history-1')).toBe(false);
+
+      await vi.runOnlyPendingTimersAsync();
+      await flushAsyncWork();
+
+      expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears pending and deferred full history state when removing sessions for a workspace', () => {
+    const cancelPending = vi.fn();
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          workspaceId: 'workspace-1',
+          workspacePath: 'D:/workspace/BitFun',
+          isHistorical: true,
+          historyState: 'ready',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    ((flowChatStore as any).fullHistoryHydrationRequests as Map<string, unknown>).set('pending-history-1', {
+      sessionId: 'history-1',
+      remote: false,
+      requireActiveSession: true,
+      sessionTraceId: 'trace-1',
+      promise: Promise.resolve(),
+      cancel: cancelPending,
+    });
+    ((flowChatStore as any).deferredFullHistoryProjections as Map<string, unknown>).set('history-1', {
+      remote: false,
+      requireActiveSession: true,
+      expectedDialogTurnIds: [],
+      dialogTurns: [],
+      contextRestoreState: 'ready',
+    });
+    ((flowChatStore as any).fullHistoryProjectionApplyRequests as Set<string>).add('history-1');
+
+    expect(flowChatStore.hasPendingSessionHistoryCompletion('history-1')).toBe(true);
+    expect(flowChatStore.hasDeferredSessionHistoryProjection('history-1')).toBe(true);
+
+    expect(flowChatStore.removeSessionsForWorkspace({
+      id: 'workspace-1',
+      rootPath: 'D:/workspace/BitFun',
+      connectionId: null,
+      sshHost: null,
+    })).toEqual(['history-1']);
+
+    expect(cancelPending).toHaveBeenCalledTimes(1);
+    expect(flowChatStore.hasPendingSessionHistoryCompletion('history-1')).toBe(false);
+    expect(flowChatStore.hasDeferredSessionHistoryProjection('history-1')).toBe(false);
+    expect((flowChatStore as any).fullHistoryProjectionApplyRequests.has('history-1')).toBe(false);
+  });
+
+  it('keeps explicit inactive local history completion for auxiliary session views', async () => {
+    vi.useFakeTimers();
+    const latestTurn = {
+      turnId: 'turn-2',
+      turnIndex: 1,
+      sessionId: 'history-1',
+      timestamp: 2,
+      userMessage: { id: 'user-2', content: 'latest prompt', timestamp: 2 },
+      modelRounds: [],
+      startTime: 2,
+      status: 'completed',
+    };
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Idle',
+        turnCount: 2,
+        createdAt: 1,
+      },
+      turns: [latestTurn],
+      contextRestoreState: 'pending',
+      isPartial: true,
+      loadedTurnCount: 1,
+      totalTurnCount: 2,
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+        ['history-2', createSession({
+          sessionId: 'history-2',
+          isHistorical: false,
+          historyState: 'ready',
+        })],
+      ]),
+      activeSessionId: 'history-2',
+    }));
+
+    try {
+      await flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
+
+      expect(flowChatStore.hasPendingSessionHistoryCompletion('history-1')).toBe(true);
+      flowChatStore.switchSession('history-2');
+      expect(flowChatStore.hasPendingSessionHistoryCompletion('history-1')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not cancel active full history completion when switching to a missing session', async () => {
+    vi.useFakeTimers();
+    const latestTurn = {
+      turnId: 'turn-2',
+      turnIndex: 1,
+      sessionId: 'history-1',
+      timestamp: 2,
+      userMessage: { id: 'user-2', content: 'latest prompt', timestamp: 2 },
+      modelRounds: [],
+      startTime: 2,
+      status: 'completed',
+    };
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Idle',
+        turnCount: 2,
+        createdAt: 1,
+      },
+      turns: [latestTurn],
+      contextRestoreState: 'pending',
+      isPartial: true,
+      loadedTurnCount: 1,
+      totalTurnCount: 2,
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    try {
+      await flowChatStore.loadSessionHistory(
+        'history-1',
+        'D:/workspace/BitFun',
+        undefined,
+        undefined,
+        undefined,
+        { deferFullHistoryUntilActive: true },
+      );
+
+      expect(flowChatStore.hasPendingSessionHistoryCompletion('history-1')).toBe(true);
+      flowChatStore.switchSession('missing-session');
+      expect(flowChatStore.hasPendingSessionHistoryCompletion('history-1')).toBe(true);
+      expect(flowChatStore.getState().activeSessionId).toBe('history-1');
     } finally {
       vi.useRealTimers();
     }
@@ -1054,6 +1483,13 @@ describe('FlowChatStore historical session hydration state', () => {
 
       flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint('history-1');
 
+      expect(idleCallback).toBeNull();
+      await vi.advanceTimersByTimeAsync(749);
+      await flushAsyncWork();
+      expect(idleCallback).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await flushAsyncWork();
       expect(idleCallback).toBeTypeOf('function');
       const hydrationPromise = Array.from(
         ((flowChatStore as any).fullHistoryHydrationRequests as Map<string, { promise: Promise<void> }>).values()
@@ -1063,6 +1499,11 @@ describe('FlowChatStore historical session hydration state', () => {
       await hydrationPromise;
 
       expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(2);
+      expect(flowChatStore.hasDeferredSessionHistoryProjection('history-1')).toBe(true);
+      expect(
+        flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.userMessage.content)
+      ).toEqual(['latest prompt']);
+      expect(flowChatStore.requestSessionFullHistoryProjection('history-1', 'test')).toBe(true);
       expect(
         flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.userMessage.content)
       ).toEqual(['older prompt', 'latest prompt']);
@@ -1150,7 +1591,7 @@ describe('FlowChatStore historical session hydration state', () => {
 
       flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint('history-1');
 
-      await vi.advanceTimersByTimeAsync(1499);
+      await vi.advanceTimersByTimeAsync(2249);
       await flushAsyncWork();
       expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(1);
 
@@ -1163,6 +1604,11 @@ describe('FlowChatStore historical session hydration state', () => {
       await hydrationPromise;
 
       expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(2);
+      expect(flowChatStore.hasDeferredSessionHistoryProjection('history-1')).toBe(true);
+      expect(
+        flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.userMessage.content)
+      ).toEqual(['latest prompt']);
+      expect(flowChatStore.requestSessionFullHistoryProjection('history-1', 'test')).toBe(true);
       expect(
         flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.userMessage.content)
       ).toEqual(['older prompt', 'latest prompt']);

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -74,6 +74,13 @@ const HISTORICAL_SESSION_INITIAL_REMOTE_TAIL_TURN_COUNT = 3;
 const HISTORICAL_SESSION_INITIAL_LOCAL_TAIL_TURN_COUNT = 8;
 const HISTORICAL_SESSION_FULL_HISTORY_IDLE_TIMEOUT_MS = 1500;
 const HISTORICAL_SESSION_FULL_HISTORY_FIRST_PAINT_TIMEOUT_MS = 2500;
+const HISTORICAL_SESSION_FULL_HISTORY_STABLE_VIEWPORT_DELAY_MS = 750;
+const MAX_DEFERRED_FULL_HISTORY_PROJECTIONS = 3;
+
+interface FullHistoryHydrationReleaseOptions {
+  immediate?: boolean;
+  reason?: string;
+}
 
 interface MetadataListRequest {
   promise: Promise<void>;
@@ -89,9 +96,12 @@ interface MetadataPageRequest {
 
 interface FullHistoryHydrationRequest {
   sessionId: string;
+  remote: boolean;
+  requireActiveSession: boolean;
+  sessionTraceId: string;
   promise: Promise<void>;
   cancel?: () => void;
-  releaseAfterInitialPaint?: () => void;
+  releaseAfterInitialPaint?: (options?: FullHistoryHydrationReleaseOptions) => void;
 }
 
 interface CompleteSessionHistoryLoadRequest {
@@ -100,8 +110,19 @@ interface CompleteSessionHistoryLoadRequest {
   remoteConnectionId?: string;
   remoteSshHost?: string;
   includeInternal?: boolean;
+  requireActiveSession?: boolean;
   initialSessionTraceId: string;
   expectedDialogTurnIds: string[];
+}
+
+interface DeferredFullHistoryProjection {
+  remote: boolean;
+  requireActiveSession: boolean;
+  expectedDialogTurnIds: string[];
+  dialogTurns: DialogTurn[];
+  contextRestoreState: SessionContextRestoreState;
+  restoredSessionInfo?: AgentSessionInfo;
+  restoredLastUserDialogMode?: string;
 }
 
 function areStringArraysEqual(left: string[], right: string[]): boolean {
@@ -146,26 +167,31 @@ function scheduleHistoricalSessionFullHydrate(callback: () => void): () => void 
 }
 
 function scheduleLocalHistoricalSessionFullHydrate(
-  callback: (reason: 'initial_paint' | 'timeout') => void,
+  callback: (reason: 'initial_paint' | 'timeout' | 'explicit') => void,
 ): {
   cancel: () => void;
-  releaseAfterInitialPaint: () => void;
+  releaseAfterInitialPaint: (options?: FullHistoryHydrationReleaseOptions) => void;
 } {
   let cancelled = false;
   let started = false;
   let cancelIdle: (() => void) | undefined;
+  let stableViewportTimer: ReturnType<typeof setTimeout> | undefined;
   const timeout = globalThis.setTimeout(
     () => start('timeout'),
     HISTORICAL_SESSION_FULL_HISTORY_FIRST_PAINT_TIMEOUT_MS,
   );
 
-  function start(reason: 'initial_paint' | 'timeout') {
+  function start(reason: 'initial_paint' | 'timeout' | 'explicit') {
     if (cancelled || started) {
       return;
     }
 
     started = true;
     globalThis.clearTimeout(timeout);
+    if (stableViewportTimer) {
+      globalThis.clearTimeout(stableViewportTimer);
+      stableViewportTimer = undefined;
+    }
     cancelIdle = scheduleHistoricalSessionFullHydrate(() => callback(reason));
   }
 
@@ -173,9 +199,25 @@ function scheduleLocalHistoricalSessionFullHydrate(
     cancel: () => {
       cancelled = true;
       globalThis.clearTimeout(timeout);
+      if (stableViewportTimer) {
+        globalThis.clearTimeout(stableViewportTimer);
+      }
       cancelIdle?.();
     },
-    releaseAfterInitialPaint: () => start('initial_paint'),
+    releaseAfterInitialPaint: (options?: FullHistoryHydrationReleaseOptions) => {
+      if (options?.immediate === true) {
+        start('explicit');
+        return;
+      }
+      if (stableViewportTimer || started || cancelled) {
+        return;
+      }
+      globalThis.clearTimeout(timeout);
+      stableViewportTimer = globalThis.setTimeout(
+        () => start('initial_paint'),
+        HISTORICAL_SESSION_FULL_HISTORY_STABLE_VIEWPORT_DELAY_MS,
+      );
+    },
   };
 }
 
@@ -266,6 +308,8 @@ export class FlowChatStore {
   private metadataListRequests = new Map<string, MetadataListRequest>();
   private metadataPageRequests = new Map<string, MetadataPageRequest>();
   private fullHistoryHydrationRequests = new Map<string, FullHistoryHydrationRequest>();
+  private deferredFullHistoryProjections = new Map<string, DeferredFullHistoryProjection>();
+  private fullHistoryProjectionApplyRequests = new Set<string>();
   private unsupportedRestoreCommands = new Set<string>();
   private onPersistUnreadCompletion?: (sessionId: string, value: 'completed' | 'error' | 'interrupted' | undefined) => void;
 
@@ -370,19 +414,25 @@ export class FlowChatStore {
     }
 
     const remote = isRemoteTraceContext(request.remoteConnectionId, request.remoteSshHost);
+    const requireActiveSession = request.requireActiveSession === true;
     startupTrace.markPhase('historical_session_full_hydrate_scheduled', {
       remote,
+      sessionId: request.sessionId,
       sessionTraceId: request.initialSessionTraceId,
       loadedTurnCount: request.expectedDialogTurnIds.length,
+      requireActiveSession,
       scheduler: remote ? 'idle' : 'after_initial_paint_idle',
     });
 
     let cancelScheduled: (() => void) | undefined;
-    let releaseAfterInitialPaint: (() => void) | undefined;
+    let releaseAfterInitialPaint: ((options?: FullHistoryHydrationReleaseOptions) => void) | undefined;
+    let resolveRequest: (() => void) | undefined;
     const promise = new Promise<void>(resolve => {
-      const startFullHydrate = (trigger: 'idle' | 'initial_paint' | 'timeout') => {
+      resolveRequest = resolve;
+      const startFullHydrate = (trigger: 'idle' | 'initial_paint' | 'timeout' | 'explicit') => {
         startupTrace.markPhase('historical_session_full_hydrate_released', {
           remote,
+          sessionId: request.sessionId,
           sessionTraceId: request.initialSessionTraceId,
           trigger,
         });
@@ -390,6 +440,7 @@ export class FlowChatStore {
           .catch(error => {
             startupTrace.markPhase('historical_session_full_hydrate_failed', {
               remote,
+              sessionId: request.sessionId,
               sessionTraceId: `${request.initialSessionTraceId}-full`,
             });
             log.warn('Failed to complete partial session history restore', {
@@ -417,10 +468,105 @@ export class FlowChatStore {
 
     this.fullHistoryHydrationRequests.set(requestKey, {
       sessionId: request.sessionId,
+      remote,
+      requireActiveSession,
+      sessionTraceId: request.initialSessionTraceId,
       promise,
-      cancel: () => cancelScheduled?.(),
-      releaseAfterInitialPaint: () => releaseAfterInitialPaint?.(),
+      cancel: () => {
+        cancelScheduled?.();
+        resolveRequest?.();
+      },
+      releaseAfterInitialPaint: (options?: FullHistoryHydrationReleaseOptions) => {
+        releaseAfterInitialPaint?.(options);
+      },
     });
+  }
+
+  private cancelLocalSessionHistoryCompletion(sessionId: string, reason: string): boolean {
+    let cancelled = false;
+    for (const [requestKey, request] of this.fullHistoryHydrationRequests) {
+      if (request.sessionId !== sessionId || request.remote || !request.requireActiveSession) {
+        continue;
+      }
+      request.cancel?.();
+      this.fullHistoryHydrationRequests.delete(requestKey);
+      startupTrace.markPhase('historical_session_full_hydrate_cancelled', {
+        remote: false,
+        sessionId,
+        sessionTraceId: request.sessionTraceId,
+        reason,
+      });
+      cancelled = true;
+    }
+    return cancelled;
+  }
+
+  private clearRemovedSessionHistoryState(sessionIds: Iterable<string>, reason: string): void {
+    const removedSessionIds = new Set(sessionIds);
+    if (removedSessionIds.size === 0) {
+      return;
+    }
+
+    for (const [requestKey, request] of this.fullHistoryHydrationRequests) {
+      if (!removedSessionIds.has(request.sessionId)) {
+        continue;
+      }
+
+      request.cancel?.();
+      this.fullHistoryHydrationRequests.delete(requestKey);
+      startupTrace.markPhase('historical_session_full_hydrate_cancelled', {
+        remote: request.remote,
+        sessionId: request.sessionId,
+        sessionTraceId: request.sessionTraceId,
+        reason,
+      });
+    }
+
+    for (const sessionId of removedSessionIds) {
+      this.deferredFullHistoryProjections.delete(sessionId);
+      this.fullHistoryProjectionApplyRequests.delete(sessionId);
+    }
+  }
+
+  private scheduleActiveLocalPartialSessionHistoryCompletion(
+    sessionId: string,
+    reason: string
+  ): boolean {
+    const session = this.state.sessions.get(sessionId);
+    if (
+      this.state.activeSessionId !== sessionId ||
+      !session ||
+      session.historyState !== 'ready' ||
+      session.isPartial !== true ||
+      isRemoteTraceContext(session.remoteConnectionId, session.remoteSshHost) ||
+      this.hasPendingSessionHistoryCompletion(sessionId) ||
+      this.hasDeferredSessionHistoryProjection(sessionId)
+    ) {
+      return false;
+    }
+
+    const workspacePath = session.workspacePath || session.config.workspacePath;
+    if (!workspacePath || session.dialogTurns.length === 0) {
+      return false;
+    }
+
+    const sessionTraceId = `${sessionId.slice(0, 8)}-${Math.random().toString(36).slice(2, 8)}`;
+    startupTrace.markPhase('historical_session_full_hydrate_rescheduled', {
+      remote: false,
+      sessionId,
+      sessionTraceId,
+      reason,
+      loadedTurnCount: session.dialogTurns.length,
+      totalTurnCount: session.totalTurnCount,
+    });
+    this.scheduleCompleteSessionHistoryLoad({
+      sessionId,
+      workspacePath,
+      initialSessionTraceId: sessionTraceId,
+      requireActiveSession: true,
+      expectedDialogTurnIds: session.dialogTurns.map(turn => turn.id),
+    });
+    return true;
   }
 
   public hasPendingSessionHistoryCompletion(sessionId: string): boolean {
@@ -432,16 +578,163 @@ export class FlowChatStore {
     return false;
   }
 
-  public releaseSessionHistoryCompletionAfterInitialPaint(sessionId: string): boolean {
+  public hasDeferredSessionHistoryProjection(sessionId: string): boolean {
+    return this.deferredFullHistoryProjections.has(sessionId);
+  }
+
+  public requestSessionFullHistoryProjection(sessionId: string, reason: string): boolean {
+    this.fullHistoryProjectionApplyRequests.add(sessionId);
+    const applied = this.applyDeferredSessionHistoryProjection(sessionId, reason);
+    const released = this.releaseSessionHistoryCompletionAfterInitialPaint(sessionId, {
+      immediate: true,
+      reason,
+    });
+
+    if (!applied && !released) {
+      this.fullHistoryProjectionApplyRequests.delete(sessionId);
+    }
+
+    if (applied || released) {
+      startupTrace.markPhase('historical_session_full_hydrate_projection_requested', {
+        sessionId,
+        reason,
+        applied,
+        released,
+      });
+    }
+
+    return applied || released;
+  }
+
+  public releaseSessionHistoryCompletionAfterInitialPaint(
+    sessionId: string,
+    options?: FullHistoryHydrationReleaseOptions
+  ): boolean {
     let released = false;
     for (const request of this.fullHistoryHydrationRequests.values()) {
       if (request.sessionId !== sessionId) {
         continue;
       }
-      request.releaseAfterInitialPaint?.();
+      request.releaseAfterInitialPaint?.(options);
       released = true;
     }
     return released;
+  }
+
+  private shouldDeferFullHistoryProjection(sessionId: string, remote: boolean, _requireActiveSession: boolean): boolean {
+    return (
+      !remote &&
+      this.state.activeSessionId === sessionId &&
+      !this.fullHistoryProjectionApplyRequests.has(sessionId)
+    );
+  }
+
+  private setDeferredFullHistoryProjection(
+    sessionId: string,
+    projection: DeferredFullHistoryProjection
+  ): void {
+    this.deferredFullHistoryProjections.delete(sessionId);
+    this.deferredFullHistoryProjections.set(sessionId, projection);
+
+    while (this.deferredFullHistoryProjections.size > MAX_DEFERRED_FULL_HISTORY_PROJECTIONS) {
+      const oldestSessionId = this.deferredFullHistoryProjections.keys().next().value;
+      if (!oldestSessionId) {
+        break;
+      }
+
+      this.deferredFullHistoryProjections.delete(oldestSessionId);
+      this.fullHistoryProjectionApplyRequests.delete(oldestSessionId);
+      startupTrace.markPhase('historical_session_full_hydrate_deferred_projection_evicted', {
+        sessionId: oldestSessionId,
+        reason: 'cache-limit',
+      });
+    }
+  }
+
+  private applyDeferredSessionHistoryProjection(sessionId: string, reason: string): boolean {
+    const projection = this.deferredFullHistoryProjections.get(sessionId);
+    if (!projection) {
+      return false;
+    }
+
+    const result = this.applyCompletedSessionHistoryProjection(sessionId, projection);
+    if (result.applied) {
+      this.deferredFullHistoryProjections.delete(sessionId);
+      this.fullHistoryProjectionApplyRequests.delete(sessionId);
+      startupTrace.markPhase('historical_session_full_hydrate_deferred_projection_applied', {
+        remote: projection.remote,
+        sessionId,
+        reason,
+        turnCount: projection.dialogTurns.length,
+        preservedTurnCount: result.preservedTurnCount,
+      });
+    }
+
+    return result.applied;
+  }
+
+  private applyCompletedSessionHistoryProjection(
+    sessionId: string,
+    projection: DeferredFullHistoryProjection
+  ): { applied: boolean; preservedTurnCount: number } {
+    let applied = false;
+    let preservedTurnCount = 0;
+
+    this.setState(prev => {
+      if (projection.requireActiveSession && !projection.remote && prev.activeSessionId !== sessionId) {
+        return prev;
+      }
+
+      const session = prev.sessions.get(sessionId);
+      if (!session || session.historyState !== 'ready') {
+        return prev;
+      }
+
+      const currentDialogTurns = session.dialogTurns;
+      const currentDialogTurnIds = currentDialogTurns.map(turn => turn.id);
+      const canMergeCurrentTurns =
+        areStringArraysEqual(currentDialogTurnIds, projection.expectedDialogTurnIds) ||
+        startsWithStringArray(currentDialogTurnIds, projection.expectedDialogTurnIds);
+      if (!canMergeCurrentTurns) {
+        return prev;
+      }
+
+      const currentDialogTurnsById = new Map(currentDialogTurns.map(turn => [turn.id, turn]));
+      const restoredDialogTurnIds = new Set(projection.dialogTurns.map(turn => turn.id));
+      const appendedCurrentDialogTurns = currentDialogTurns
+        .slice(projection.expectedDialogTurnIds.length)
+        .filter(turn => !restoredDialogTurnIds.has(turn.id));
+      const mergedDialogTurns = [
+        ...projection.dialogTurns.map(turn => currentDialogTurnsById.get(turn.id) ?? turn),
+        ...appendedCurrentDialogTurns,
+      ];
+      preservedTurnCount = mergedDialogTurns.reduce(
+        (count, turn) => count + (currentDialogTurnsById.get(turn.id) === turn ? 1 : 0),
+        0,
+      );
+      const newSessions = new Map(prev.sessions);
+      newSessions.set(sessionId, {
+        ...session,
+        dialogTurns: mergedDialogTurns,
+        isPartial: false,
+        loadedTurnCount: mergedDialogTurns.length,
+        totalTurnCount: mergedDialogTurns.length,
+        contextRestoreState:
+          session.contextRestoreState === 'ready' ? 'ready' : projection.contextRestoreState,
+        mode: projection.restoredSessionInfo?.agentType || session.mode,
+        lastUserDialogMode: projection.restoredLastUserDialogMode,
+        lastSubmittedMode:
+          projection.restoredSessionInfo?.lastSubmittedAgentType ?? session.lastSubmittedMode,
+      });
+      applied = true;
+
+      return {
+        ...prev,
+        sessions: newSessions,
+      };
+    });
+
+    return { applied, preservedTurnCount };
   }
 
   private async completeSessionHistoryLoad(
@@ -450,8 +743,18 @@ export class FlowChatStore {
     const fullTraceId = `${request.initialSessionTraceId}-full`;
     const startedAt = nowMs();
     const remote = isRemoteTraceContext(request.remoteConnectionId, request.remoteSshHost);
+    if (request.requireActiveSession === true && !remote && this.state.activeSessionId !== request.sessionId) {
+      startupTrace.markPhase('historical_session_full_hydrate_skipped', {
+        remote,
+        sessionId: request.sessionId,
+        sessionTraceId: fullTraceId,
+        reason: 'inactive-before-start',
+      });
+      return;
+    }
     startupTrace.markPhase('historical_session_full_hydrate_start', {
       remote,
+      sessionId: request.sessionId,
       sessionTraceId: fullTraceId,
       loadedTurnCount: request.expectedDialogTurnIds.length,
     });
@@ -467,6 +770,18 @@ export class FlowChatStore {
       undefined,
     );
 
+    if (request.requireActiveSession === true && !remote && this.state.activeSessionId !== request.sessionId) {
+      startupTrace.markPhase('historical_session_full_hydrate_skipped', {
+        remote,
+        sessionId: request.sessionId,
+        sessionTraceId: fullTraceId,
+        reason: 'inactive-after-restore',
+        ...sessionViewRestoreTimingTraceFields(restored.timings),
+        durationMs: elapsedMs(startedAt),
+      });
+      return;
+    }
+
     const convertStartedAt = nowMs();
     const dialogTurns = this.convertToDialogTurns(restored.turns);
     const restoredLastUserDialogMode =
@@ -475,65 +790,44 @@ export class FlowChatStore {
       restored.contextRestoreState === 'ready' ? 'ready' : 'pending';
     startupTrace.markPhase('historical_session_full_hydrate_convert_end', {
       remote,
+      sessionId: request.sessionId,
       sessionTraceId: fullTraceId,
       turnCount: dialogTurns.length,
       durationMs: elapsedMs(convertStartedAt),
     });
 
+    const projection: DeferredFullHistoryProjection = {
+      remote,
+      requireActiveSession: request.requireActiveSession === true,
+      expectedDialogTurnIds: request.expectedDialogTurnIds,
+      dialogTurns,
+      contextRestoreState,
+      restoredSessionInfo: restored.session,
+      restoredLastUserDialogMode,
+    };
     let applied = false;
     let preservedTurnCount = 0;
-    this.setState(prev => {
-      const session = prev.sessions.get(request.sessionId);
-      if (!session || session.historyState !== 'ready') {
-        return prev;
-      }
-
-      const currentDialogTurns = session.dialogTurns;
-      const currentDialogTurnIds = currentDialogTurns.map(turn => turn.id);
-      const canMergeCurrentTurns =
-        areStringArraysEqual(currentDialogTurnIds, request.expectedDialogTurnIds) ||
-        startsWithStringArray(currentDialogTurnIds, request.expectedDialogTurnIds);
-      if (!canMergeCurrentTurns) {
-        return prev;
-      }
-
-      const currentDialogTurnsById = new Map(currentDialogTurns.map(turn => [turn.id, turn]));
-      const restoredDialogTurnIds = new Set(dialogTurns.map(turn => turn.id));
-      const appendedCurrentDialogTurns = currentDialogTurns
-        .slice(request.expectedDialogTurnIds.length)
-        .filter(turn => !restoredDialogTurnIds.has(turn.id));
-      const mergedDialogTurns = [
-        ...dialogTurns.map(turn => currentDialogTurnsById.get(turn.id) ?? turn),
-        ...appendedCurrentDialogTurns,
-      ];
-      preservedTurnCount = mergedDialogTurns.reduce(
-        (count, turn) => count + (currentDialogTurnsById.get(turn.id) === turn ? 1 : 0),
-        0,
-      );
-      const newSessions = new Map(prev.sessions);
-      newSessions.set(request.sessionId, {
-        ...session,
-        dialogTurns: mergedDialogTurns,
-        isPartial: false,
-        loadedTurnCount: mergedDialogTurns.length,
-        totalTurnCount: mergedDialogTurns.length,
-        contextRestoreState:
-          session.contextRestoreState === 'ready' ? 'ready' : contextRestoreState,
-        mode: restored.session.agentType || session.mode,
-        lastUserDialogMode: restoredLastUserDialogMode,
-        lastSubmittedMode:
-          restored.session.lastSubmittedAgentType ?? session.lastSubmittedMode,
+    if (this.shouldDeferFullHistoryProjection(request.sessionId, remote, request.requireActiveSession === true)) {
+      this.setDeferredFullHistoryProjection(request.sessionId, projection);
+      startupTrace.markPhase('historical_session_full_hydrate_deferred_projection', {
+        remote,
+        sessionId: request.sessionId,
+        sessionTraceId: fullTraceId,
+        turnCount: dialogTurns.length,
       });
-      applied = true;
-
-      return {
-        ...prev,
-        sessions: newSessions,
-      };
-    });
+    } else {
+      const result = this.applyCompletedSessionHistoryProjection(request.sessionId, projection);
+      applied = result.applied;
+      preservedTurnCount = result.preservedTurnCount;
+      if (applied) {
+        this.deferredFullHistoryProjections.delete(request.sessionId);
+        this.fullHistoryProjectionApplyRequests.delete(request.sessionId);
+      }
+    }
 
     startupTrace.markPhase('historical_session_full_hydrate_end', {
       remote,
+      sessionId: request.sessionId,
       sessionTraceId: fullTraceId,
       turnCount: dialogTurns.length,
       applied,
@@ -544,6 +838,7 @@ export class FlowChatStore {
     if (applied) {
       markPhaseAfterAnimationFrames(startupTrace, 'historical_session_full_hydrate_after_state_commit_frame', {
         remote,
+        sessionId: request.sessionId,
         sessionTraceId: fullTraceId,
         turnCount: dialogTurns.length,
         durationMs: elapsedMs(startedAt),
@@ -820,6 +1115,12 @@ export class FlowChatStore {
   }
 
   public switchSession(sessionId: string): void {
+    const previousSessionId = this.state.activeSessionId;
+    const targetSessionExists = this.state.sessions.has(sessionId);
+    if (targetSessionExists && previousSessionId && previousSessionId !== sessionId) {
+      this.cancelLocalSessionHistoryCompletion(previousSessionId, 'session-switch');
+    }
+
     let sessionMode: string | undefined;
     
     this.setState(prev => {
@@ -846,6 +1147,10 @@ export class FlowChatStore {
     window.dispatchEvent(new CustomEvent('bitfun:session-switched', {
       detail: { sessionId, mode: sessionMode || 'agentic' }
     }));
+
+    if (targetSessionExists && previousSessionId !== sessionId) {
+      this.scheduleActiveLocalPartialSessionHistoryCompletion(sessionId, 'session-switch');
+    }
   }
 
   /**
@@ -1225,6 +1530,7 @@ export class FlowChatStore {
     if (removedSessionIds.length === 0) {
       return [];
     }
+    this.clearRemovedSessionHistoryState(removedSessionIds, 'session-removed');
 
     this.setState(prev => {
       const removedSessionIdSet = new Set(removedSessionIds);
@@ -1381,6 +1687,7 @@ export class FlowChatStore {
     if (removedSessionIds.length === 0) {
       return [];
     }
+    this.clearRemovedSessionHistoryState(removedSessionIds, 'sessions-removed');
 
     const removedSessionIdSet = new Set(removedSessionIds);
 
@@ -2178,7 +2485,7 @@ export class FlowChatStore {
    */
   private async saveCancelledDialogTurn(sessionId: string, turnId: string): Promise<void> {
     try {
-      const { sessionAPI } = await import('@/infrastructure/api');
+      const { sessionAPI } = await import('@/infrastructure/api/service-api/SessionAPI');
       const session = this.state.sessions.get(sessionId);
       if (!session) {
         log.warn('Session not found, skipping save', { sessionId, turnId });
@@ -2630,7 +2937,7 @@ export class FlowChatStore {
         source: traceSource,
         metadataListTraceId,
       });
-      const { sessionAPI } = await import('@/infrastructure/api');
+      const { sessionAPI } = await import('@/infrastructure/api/service-api/SessionAPI');
       startupTrace.markPhase('session_metadata_api_import_end', {
         remote,
         source: traceSource,
@@ -2743,7 +3050,7 @@ export class FlowChatStore {
       metadataListTraceId,
     });
     try {
-      const { sessionAPI } = await import('@/infrastructure/api');
+      const { sessionAPI } = await import('@/infrastructure/api/service-api/SessionAPI');
       const sessions = await sessionAPI.listSessions(workspacePath, remoteConnectionId, remoteSshHost);
       sessionCount = sessions.length;
       startupTrace.markPhase('session_metadata_list_loaded', {
@@ -2787,7 +3094,7 @@ export class FlowChatStore {
           if (isLegacyPersistedBtwSession(metadata)) {
             return;
           }
-          // Skip archived sessions — they are managed in the settings page
+          // Skip archived sessions - they are managed in the settings page
           if (metadata.status === 'archived') {
             return;
           }
@@ -2962,12 +3269,17 @@ export class FlowChatStore {
     remoteSshHost?: string,
     options?: {
       includeInternal?: boolean;
+      deferFullHistoryUntilActive?: boolean;
     }
   ): Promise<void> {
     const traceStartedAt = nowMs();
     const remote = isRemoteTraceContext(remoteConnectionId, remoteSshHost);
     const sessionTraceId = `${sessionId.slice(0, 8)}-${Math.random().toString(36).slice(2, 8)}`;
-    startupTrace.markPhase('historical_session_hydrate_start', { remote, sessionTraceId });
+    startupTrace.markPhase('historical_session_hydrate_start', {
+      remote,
+      sessionId,
+      sessionTraceId,
+    });
     this.setSessionHistoryState(sessionId, 'hydrating');
 
     try {
@@ -2986,7 +3298,11 @@ export class FlowChatStore {
       let restoredTiming: SessionViewRestoreTiming | undefined;
       if (!isAcpSession) {
         const restoreStartedAt = nowMs();
-        startupTrace.markPhase('historical_session_restore_start', { remote, sessionTraceId });
+        startupTrace.markPhase('historical_session_restore_start', {
+          remote,
+          sessionId,
+          sessionTraceId,
+        });
         try {
           const { agentAPI } = await import('@/infrastructure/api');
           const restoreSessionViewSupportKey = restoreCommandSupportKey(
@@ -3024,6 +3340,7 @@ export class FlowChatStore {
                 this.unsupportedRestoreCommands.add(restoreSessionWithTurnsSupportKey);
                 startupTrace.markPhase('historical_session_restore_fallback', {
                   remote,
+                  sessionId,
                   sessionTraceId,
                   from: 'restore_session_with_turns',
                   to: 'restore_session',
@@ -3072,6 +3389,7 @@ export class FlowChatStore {
               this.unsupportedRestoreCommands.add(restoreSessionViewSupportKey);
               startupTrace.markPhase('historical_session_restore_fallback', {
                 remote,
+                sessionId,
                 sessionTraceId,
                 from: 'restore_session_view',
                 to: 'restore_session_with_turns',
@@ -3084,6 +3402,7 @@ export class FlowChatStore {
           }
           startupTrace.markPhase('historical_session_restore_end', {
             remote,
+            sessionId,
             sessionTraceId,
             turnCount: Array.isArray(turns) ? turns.length : 0,
             loadedTurnCount: restoredLoadedTurnCount,
@@ -3097,6 +3416,7 @@ export class FlowChatStore {
           contextRestoreState = 'pending';
           startupTrace.markPhase('historical_session_restore_failed', {
             remote,
+            sessionId,
             sessionTraceId,
             durationMs: elapsedMs(restoreStartedAt),
           });
@@ -3106,8 +3426,12 @@ export class FlowChatStore {
       
       if (!turns) {
         const turnsLoadStartedAt = nowMs();
-        startupTrace.markPhase('historical_session_turns_load_start', { remote, sessionTraceId });
-        const { sessionAPI } = await import('@/infrastructure/api');
+        startupTrace.markPhase('historical_session_turns_load_start', {
+          remote,
+          sessionId,
+          sessionTraceId,
+        });
+        const { sessionAPI } = await import('@/infrastructure/api/service-api/SessionAPI');
         turns = await sessionAPI.loadSessionTurns(
           sessionId,
           workspacePath,
@@ -3117,6 +3441,7 @@ export class FlowChatStore {
         );
         startupTrace.markPhase('historical_session_turns_load_end', {
           remote,
+          sessionId,
           sessionTraceId,
           turnCount: Array.isArray(turns) ? turns.length : 0,
           durationMs: elapsedMs(turnsLoadStartedAt),
@@ -3124,6 +3449,7 @@ export class FlowChatStore {
       }
       startupTrace.markPhase('historical_session_turns_loaded', {
         remote,
+        sessionId,
         sessionTraceId,
         turnCount: Array.isArray(turns) ? turns.length : 0,
       });
@@ -3134,6 +3460,7 @@ export class FlowChatStore {
         restoredSessionInfo?.lastUserDialogAgentType || this.deriveLastUserDialogMode(dialogTurns);
       startupTrace.markPhase('historical_session_convert_end', {
         remote,
+        sessionId,
         sessionTraceId,
         turnCount: dialogTurns.length,
         durationMs: elapsedMs(convertStartedAt),
@@ -3170,6 +3497,7 @@ export class FlowChatStore {
       });
       startupTrace.markPhase('historical_session_state_commit_end', {
         remote,
+        sessionId,
         sessionTraceId,
         turnCount: dialogTurns.length,
         totalTurnCount: restoredTotalTurnCount,
@@ -3178,6 +3506,7 @@ export class FlowChatStore {
       });
       markPhaseAfterAnimationFrames(startupTrace, 'historical_session_after_state_commit_frame', {
         remote,
+        sessionId,
         sessionTraceId,
         turnCount: dialogTurns.length,
         totalTurnCount: restoredTotalTurnCount,
@@ -3192,6 +3521,7 @@ export class FlowChatStore {
       stateMachineManager.reset(sessionId);
       startupTrace.markPhase('historical_session_hydrate_end', {
         remote,
+        sessionId,
         sessionTraceId,
         turnCount: dialogTurns.length,
         totalTurnCount: restoredTotalTurnCount,
@@ -3199,15 +3529,31 @@ export class FlowChatStore {
         durationMs: elapsedMs(traceStartedAt),
       });
       if (restoredHistoryPartial) {
-        this.scheduleCompleteSessionHistoryLoad({
-          sessionId,
-          workspacePath,
-          remoteConnectionId,
-          remoteSshHost,
-          includeInternal: options?.includeInternal,
-          initialSessionTraceId: sessionTraceId,
-          expectedDialogTurnIds: dialogTurns.map(turn => turn.id),
-        });
+        const deferFullHistoryUntilActive =
+          !remote &&
+          options?.deferFullHistoryUntilActive === true &&
+          this.state.activeSessionId !== sessionId;
+        if (!deferFullHistoryUntilActive) {
+          this.scheduleCompleteSessionHistoryLoad({
+            sessionId,
+            workspacePath,
+            remoteConnectionId,
+            remoteSshHost,
+            includeInternal: options?.includeInternal,
+            requireActiveSession: options?.deferFullHistoryUntilActive === true,
+            initialSessionTraceId: sessionTraceId,
+            expectedDialogTurnIds: dialogTurns.map(turn => turn.id),
+          });
+        } else {
+          startupTrace.markPhase('historical_session_full_hydrate_deferred', {
+            remote,
+            sessionId,
+            sessionTraceId,
+            reason: 'inactive-after-tail-restore',
+            loadedTurnCount: dialogTurns.length,
+            totalTurnCount: restoredTotalTurnCount,
+          });
+        }
       }
     } catch (error) {
       this.setState(prev => {
@@ -3228,6 +3574,7 @@ export class FlowChatStore {
       });
       startupTrace.markPhase('historical_session_hydrate_failed', {
         remote,
+        sessionId,
         sessionTraceId,
         durationMs: elapsedMs(traceStartedAt),
       });

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
@@ -9,7 +9,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { immer } from 'zustand/middleware/immer';
 import type { Session, DialogTurn, ModelRound, FlowItem, FlowToolItem, FlowUserSteeringItem, AnyFlowItem } from '../types/flow-chat';
 import { isCollapsibleTool, READ_TOOL_NAMES, SEARCH_TOOL_NAMES, COMMAND_TOOL_NAMES } from '../tool-cards';
-import { COMPLETED_TOOL_TRANSIENT_MS } from '../components/modern/modelRoundItemGrouping';
+import { isCompletedToolInTransientWindow } from '../components/modern/modelRoundItemGrouping';
 import { flowChatStore } from './FlowChatStore';
 
 /**
@@ -119,9 +119,7 @@ function hasActiveTool(round: ModelRound): boolean {
 
 function hasRecentlyCompletedTool(round: ModelRound, nowMs: number): boolean {
   return round.items.some(item => {
-    if (item.type !== 'tool' || item.status !== 'completed') return false;
-    const endTime = (item as FlowToolItem).endTime;
-    return typeof endTime === 'number' && nowMs - endTime < COMPLETED_TOOL_TRANSIENT_MS;
+    return isCompletedToolInTransientWindow(item, nowMs);
   });
 }
 

--- a/src/web-ui/src/main.tsx
+++ b/src/web-ui/src/main.tsx
@@ -2,6 +2,7 @@ import ReactDOM from "react-dom/client";
 import App from "./app/App";
 import AgentCompanionDesktopPet from "./app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet";
 import AppErrorBoundary from "./app/components/AppErrorBoundary";
+import { STARTUP_OVERLAY_HIDDEN_EVENT } from "./app/startup/startupSignals";
 import { WorkspaceProvider } from "./infrastructure/contexts/WorkspaceProvider";
 import "./app/styles/index.scss";
 
@@ -373,7 +374,7 @@ async function startApplication(): Promise<void> {
   });
 
   startupTrace.markPhase('non_critical_init_scheduled', {
-    signalName: 'bitfun:interactive-shell-ready',
+    signalName: STARTUP_OVERLAY_HIDDEN_EVENT,
     fallbackTimeoutMs: 10000,
     frameCount: 1,
   });
@@ -392,7 +393,7 @@ async function startApplication(): Promise<void> {
       });
     }
   }, {
-    signalName: 'bitfun:interactive-shell-ready',
+    signalName: STARTUP_OVERLAY_HIDDEN_EVENT,
     fallbackTimeoutMs: 10000,
     frameCount: 1,
     onError: error => {

--- a/tests/e2e/config/embedded-driver.ts
+++ b/tests/e2e/config/embedded-driver.ts
@@ -455,7 +455,7 @@ export function createEmbeddedConfig(specs: string[], label: string): Options.Te
       'bitfun:embedded': true,
     } as any],
 
-    logLevel: 'info',
+    logLevel: (process.env.E2E_LOG_LEVEL || 'info') as Options.Testrunner['logLevel'],
     bail: 0,
     baseUrl: '',
     waitforTimeout: 10000,

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -44,6 +44,8 @@ type LongSessionViewportState = {
   latestModelRoundTextLength: number;
   latestContentVisible: boolean;
   historyPlaceholderVisible: boolean;
+  historyPlaceholderCoversMessages: boolean;
+  latestContentVisuallyVisible: boolean;
   scrollerTop: number | null;
   scrollerBottom: number | null;
   effectiveScrollerBottom: number | null;
@@ -82,6 +84,10 @@ type LongSessionViewportState = {
 type LongSessionViewportTimelineSample = {
   atMs: number;
   sinceClickMs: number;
+  historyOpenIntentAtMs: number | null;
+  sinceHistoryOpenIntentMs: number | null;
+  activeSessionId: string | null;
+  pendingHistoryOpenSessionId: string | null;
   hasRoot: boolean;
   hasScroller: boolean;
   latestRendered: boolean;
@@ -90,6 +96,8 @@ type LongSessionViewportTimelineSample = {
   latestModelRoundTextLength: number;
   latestContentVisible: boolean;
   historyPlaceholderVisible: boolean;
+  historyPlaceholderCoversMessages: boolean;
+  latestContentVisuallyVisible: boolean;
   latestVisible: boolean;
   latestTurnId: string | null;
   scrollTop: number | null;
@@ -137,9 +145,199 @@ type LongSessionMainThreadTask = {
   entryType: string;
 };
 
+type LongSessionLayoutShiftEvent = {
+  startMs: number;
+  sinceClickMs: number;
+  value: number;
+  hadRecentInput: boolean;
+  sources: Array<{
+    node: string | null;
+    previousRect: LongSessionRectSummary | null;
+    currentRect: LongSessionRectSummary | null;
+  }>;
+};
+
+type LongSessionRectSummary = {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+  width: number;
+  height: number;
+};
+
+type LongSessionLoadingSurface = {
+  selector: string;
+  node: string | null;
+  visible: boolean;
+  textLength: number;
+  rect: LongSessionRectSummary | null;
+};
+
+type LongSessionSurfacePoint = {
+  label: string;
+  x: number;
+  y: number;
+  category: string;
+  topNode: string | null;
+  topElementId: string | null;
+  itemType: string | null;
+  turnId: string | null;
+  latestTurnHit: boolean;
+  effectiveOpacity: number;
+  textLength: number;
+  modelRoundGroupCount: number | null;
+  modelRoundRenderedGroupCount: number | null;
+  modelRoundVisibleGroupStart: number | null;
+  modelRoundVisibleGroupEnd: number | null;
+  modelRoundRenderAll: string | null;
+  modelRoundHasDeferredEarlier: string | null;
+  modelRoundHasDeferredLater: string | null;
+  backgroundChain: string[];
+};
+
+type LongSessionVirtualItemSummary = {
+  elementId: string;
+  virtualIndex: number | null;
+  itemType: string | null;
+  turnId: string | null;
+  textLength: number;
+  modelRoundGroupCount: number | null;
+  modelRoundRenderedGroupCount: number | null;
+  modelRoundVisibleGroupStart: number | null;
+  modelRoundVisibleGroupEnd: number | null;
+  modelRoundRenderAll: string | null;
+  modelRoundHasDeferredEarlier: string | null;
+  modelRoundHasDeferredLater: string | null;
+  codeBlockWrapperCount: number;
+  codeBlockFallbackCount: number;
+  highlightedCodeBlockCount: number;
+  tableCount: number;
+  completedToolTransitionCount: number;
+  completedToolTransitionHeight: number;
+  completedToolTransitionMaxHeights: string[];
+  completedToolTransitionAnimations: string[];
+  completedToolTransitionOpacities: string[];
+  rect: LongSessionRectSummary | null;
+};
+
+type LongSessionDomMutationEvent = {
+  atMs: number;
+  sinceClickMs: number;
+  reason: string;
+  activeSessionId: string | null;
+  historyState: string | null;
+  contextRestoreState: string | null;
+  isPartial: string | null;
+  dialogTurnCount: number | null;
+  virtualItemCount: number | null;
+  showHistoryPlaceholder: string | null;
+  showHistoryTransitionOverlay: string | null;
+  showHistoryLoadingLayer: string | null;
+  showHistoryOpenIntentOverlay: string | null;
+  hasPendingHistoryCompletion: string | null;
+  hasDeferredHistoryProjection: string | null;
+  latestTurnId: string | null;
+  historyInitialContentReady: string | null;
+  pendingHistoryOpenSessionId: string | null;
+  placeholderCount: number;
+  overlayCount: number;
+  historyInitialPreviewCount: number;
+  historyInitialPreviewVisible: boolean;
+  historyProjectionHandoffCount: number;
+  historyProjectionHandoffVisible: boolean;
+  virtualListCount: number;
+  virtualItemDomCount: number;
+  visibleLoadingSurfaceCount: number;
+  visibleTextLength: number;
+  loadingSurfaces: LongSessionLoadingSurface[];
+  overlayElementIds: string[];
+  placeholderElementIds: string[];
+  virtualListElementIds: string[];
+  virtualItemElementIds: string[];
+  virtualItemSummaries: LongSessionVirtualItemSummary[];
+  surfaceSignature: string;
+  surfacePoints: LongSessionSurfacePoint[];
+  messagesRect: LongSessionRectSummary | null;
+  scrollerRect: LongSessionRectSummary | null;
+  overlayRect: LongSessionRectSummary | null;
+  placeholderRect: LongSessionRectSummary | null;
+  messagesBackground: string | null;
+  overlayBackground: string | null;
+  containerBackground: string | null;
+  bodyBackground: string | null;
+  htmlBackground: string | null;
+};
+
+type LongSessionVisualStateEvent = {
+  atMs: number;
+  sinceClickMs: number;
+  sinceHistoryOpenIntentMs: number | null;
+  frame: number;
+  reason: string;
+  signature: string;
+  activeSessionId: string | null;
+  historyState: string | null;
+  contextRestoreState: string | null;
+  isPartial: string | null;
+  dialogTurnCount: number | null;
+  virtualItemCount: number | null;
+  showHistoryPlaceholder: string | null;
+  showHistoryTransitionOverlay: string | null;
+  showHistoryLoadingLayer: string | null;
+  showHistoryOpenIntentOverlay: string | null;
+  hasPendingHistoryCompletion: string | null;
+  hasDeferredHistoryProjection: string | null;
+  latestTurnId: string | null;
+  historyInitialContentReady: string | null;
+  pendingHistoryOpenSessionId: string | null;
+  placeholderCount: number;
+  overlayCount: number;
+  historyInitialPreviewCount: number;
+  historyInitialPreviewVisible: boolean;
+  historyProjectionHandoffCount: number;
+  historyProjectionHandoffVisible: boolean;
+  virtualListCount: number;
+  virtualItemDomCount: number;
+  visibleLoadingSurfaceCount: number;
+  virtualListElementIds: string[];
+  virtualItemElementIds: string[];
+  virtualItemSummaries: LongSessionVirtualItemSummary[];
+  completedToolTransitionCount: number;
+  completedToolTransitionHeight: number;
+  completedToolTransitionSignature: string;
+  visibleTextLength: number;
+  loadingSurfaces: LongSessionLoadingSurface[];
+  latestContentVisuallyVisible: boolean;
+  latestModelRoundTextLength: number;
+  surfaceSignature: string;
+  surfacePoints: LongSessionSurfacePoint[];
+  scrollerExists: boolean;
+  scrollTop: number | null;
+  scrollHeight: number | null;
+  clientHeight: number | null;
+  footerHeight: number | null;
+  footerStyleHeight: string | null;
+  footerStyleMinHeight: string | null;
+  inputOverlayHeight: number | null;
+  messagesRect: LongSessionRectSummary | null;
+  scrollerRect: LongSessionRectSummary | null;
+  overlayRect: LongSessionRectSummary | null;
+  placeholderRect: LongSessionRectSummary | null;
+  inputOverlayRect: LongSessionRectSummary | null;
+  messagesBackground: string | null;
+  overlayBackground: string | null;
+  containerBackground: string | null;
+  bodyBackground: string | null;
+  htmlBackground: string | null;
+};
+
 type LongSessionViewportTimeline = {
   samples: LongSessionViewportTimelineSample[];
   mainThreadTasks: LongSessionMainThreadTask[];
+  mutationEvents: LongSessionDomMutationEvent[];
+  visualStateEvents: LongSessionVisualStateEvent[];
+  layoutShiftEvents: LongSessionLayoutShiftEvent[];
 };
 
 type LongSessionViewportTimelineSummary = {
@@ -149,24 +347,167 @@ type LongSessionViewportTimelineSummary = {
   firstHistoryPlaceholderAtMs: number | null;
   firstLatestVisibleAtMs: number | null;
   firstLatestContentVisibleAtMs: number | null;
+  firstLatestContentVisuallyVisibleAtMs: number | null;
   firstLatestTextVisibleAtMs: number | null;
   firstLatestVisibleTextlessAtMs: number | null;
   firstLatestContentVisibleTextlessAtMs: number | null;
   latestTextDelayAfterVisibleMs: number | null;
   latestTextDelayAfterContentVisibleMs: number | null;
+  latestTextDelayAfterContentVisuallyVisibleMs: number | null;
   latestVisibleTextlessSampleCount: number;
   latestContentVisibleTextlessSampleCount: number;
   maxTextlessVisibleBlankGapPx: number | null;
   maxTextlessVisibleBottomBlankPx: number | null;
   preLatestTextVisibleBlankSampleCount: number;
   preLatestTextVisibleBlankWithoutPlaceholderSampleCount: number;
+  preLatestTextVisibleUncoveredAfterIntentSampleCount: number;
+  firstPreLatestTextVisibleUncoveredAfterIntentAtMs: number | null;
   maxPreLatestTextVisibleBlankGapPx: number | null;
   maxPreLatestTextVisibleBlankWithoutPlaceholderGapPx: number | null;
   maxPreLatestTextVisibleBottomBlankPx: number | null;
   postLatestTextVisibleBlankSampleCount: number;
+  postLatestTextVisibleCoveredSampleCount: number;
   maxPostLatestTextVisibleBlankGapPx: number | null;
   maxPostLatestTextVisibleBottomBlankPx: number | null;
   postLatestTextVisibleLatestContentMissingSampleCount: number;
+};
+
+type LongSessionVisualStateSummary = {
+  visualStateEventCount: number;
+  mutationEventCount: number;
+  firstVisualStateAtMs: number | null;
+  firstLoadingLayerAtMs: number | null;
+  lastLoadingLayerAtMs: number | null;
+  historyInitialPreviewVisibleAtEnd: boolean;
+  historyProjectionHandoffVisibleAtEnd: boolean;
+  historyInitialPreviewActivationAfterActiveSessionCount: number;
+  loadingLayerToggleCount: number;
+  overlayCountToggleCount: number;
+  placeholderCountToggleCount: number;
+  overlayElementIdChangeCount: number;
+  placeholderElementIdChangeCount: number;
+  virtualListElementIdChangeCount: number;
+  virtualItemElementIdChangeCount: number;
+  backgroundChangeCount: number;
+  scrollerScrollJumpCount: number;
+  scrollerSizeChangeCount: number;
+  layoutShiftCount: number;
+  layoutShiftScore: number;
+  postLatestTextVisibleVisualChangeCount: number;
+  postLatestTextVisibleLoadingEventCount: number;
+  postFirstVisibleItemVisualChangeCount: number;
+  postFirstVisibleItemLoadingEventCount: number;
+  postLatestTextVisibleBackgroundChangeCount: number;
+  postLatestTextVisibleScrollJumpCount: number;
+  postLatestTextVisibleVirtualItemElementChangeCount: number;
+  postLatestTextVisibleSurfaceChangeCount: number;
+  postLatestTextVisibleLoadingSurfacePointEventCount: number;
+  postLatestTextVisibleBlankSurfacePointEventCount: number;
+  postLatestTextVisibleTransparentSurfacePointEventCount: number;
+  postLatestTextVisibleLayoutShiftCount: number;
+  postLatestTextVisibleLayoutShiftScore: number;
+  firstUserInteractionAtMs: number | null;
+  postUserInteractionScrollJumpCount: number;
+  postUserInteractionScrollerCollapseCount: number;
+  postUserInteractionBlankSurfacePointEventCount: number;
+  openIntentBlankSurfacePointEventCount: number;
+  openIntentBlankSurfaceHoldCount: number;
+  maxOpenIntentBlankSurfaceHoldMs: number | null;
+  postOpenIntentNonTargetContentEventCount: number;
+  postOpenIntentNonTargetContentHoldCount: number;
+  maxPostOpenIntentNonTargetContentHoldMs: number | null;
+  lastPostOpenIntentNonTargetContentAtMs: number | null;
+  loadingTransitions: Array<{
+    sinceClickMs: number;
+    reason: string;
+    showHistoryLoadingLayer: string | null;
+    overlayCount: number;
+    placeholderCount: number;
+    visibleLoadingSurfaceCount: number;
+    loadingSurfaces: LongSessionLoadingSurface[];
+    virtualItemDomCount: number;
+    latestContentVisuallyVisible: boolean;
+  }>;
+  backgroundTransitions: Array<{
+    sinceClickMs: number;
+    reason: string;
+    from: string;
+    to: string;
+  }>;
+  historyInitialPreviewTransitions: Array<{
+    sinceClickMs: number;
+    reason: string;
+    from: boolean;
+    to: boolean;
+  }>;
+  overlayElementTransitions: Array<{
+    sinceClickMs: number;
+    reason: string;
+    from: string[];
+    to: string[];
+  }>;
+  virtualItemElementTransitions: Array<{
+    sinceClickMs: number;
+    reason: string;
+    from: string[];
+    to: string[];
+  }>;
+  surfaceTransitions: Array<{
+    sinceClickMs: number;
+    reason: string;
+    from: string;
+    to: string;
+    surfacePoints: LongSessionSurfacePoint[];
+  }>;
+  postOpenIntentNonTargetContentEvents: Array<{
+    sinceClickMs: number;
+    sinceHistoryOpenIntentMs: number | null;
+    reason: string;
+    activeSessionId: string | null;
+    pendingHistoryOpenSessionId: string | null;
+    virtualItemDomCount: number;
+    visibleTextLength: number;
+    surfacePoints: LongSessionSurfacePoint[];
+  }>;
+  postOpenIntentNonTargetContentHolds: Array<{
+    sinceClickMs: number;
+    sinceHistoryOpenIntentMs: number | null;
+    untilHistoryOpenIntentMs: number | null;
+    holdAfterGraceMs: number;
+    reason: string;
+    activeSessionId: string | null;
+    virtualItemDomCount: number;
+    visibleTextLength: number;
+  }>;
+  scrollTransitions: Array<{
+    sinceClickMs: number;
+    reason: string;
+    fromScrollTop: number | null;
+    toScrollTop: number | null;
+    fromScrollHeight: number | null;
+    toScrollHeight: number | null;
+    fromClientHeight: number | null;
+    toClientHeight: number | null;
+    fromFooterHeight: number | null;
+    toFooterHeight: number | null;
+    fromFooterStyleHeight: string | null;
+    toFooterStyleHeight: string | null;
+  }>;
+  postUserInteractionScrollTransitions: Array<{
+    sinceClickMs: number;
+    reason: string;
+    fromScrollTop: number | null;
+    toScrollTop: number | null;
+    fromScrollHeight: number | null;
+    toScrollHeight: number | null;
+    fromClientHeight: number | null;
+    toClientHeight: number | null;
+    fromFooterHeight: number | null;
+    toFooterHeight: number | null;
+    fromFooterStyleHeight: string | null;
+    toFooterStyleHeight: string | null;
+  }>;
+  layoutShiftEvents: LongSessionLayoutShiftEvent[];
 };
 
 function reportDir(): string {
@@ -187,6 +528,23 @@ function countPhase(snapshot: StartupTraceSnapshot, phase: string): number {
   return snapshot.phases.events.filter(event => event.phase === phase).length;
 }
 
+function traceEventSessionId(event: StartupTraceSnapshot['phases']['events'][number]): string | null {
+  return typeof event.sessionId === 'string' ? event.sessionId : null;
+}
+
+function traceEventMatchesSessionPhaseSince(
+  event: StartupTraceSnapshot['phases']['events'][number],
+  phase: string,
+  sessionId: string,
+  sinceMs: number,
+): boolean {
+  return (
+    event.phase === phase &&
+    event.atMs >= sinceMs &&
+    traceEventSessionId(event) === sessionId
+  );
+}
+
 function numericEnv(name: string): number | undefined {
   const raw = process.env[name];
   if (!raw) {
@@ -195,6 +553,8 @@ function numericEnv(name: string): number | undefined {
   const value = Number(raw);
   return Number.isFinite(value) ? value : undefined;
 }
+
+const DEFAULT_POST_VISIBLE_OBSERVE_MS = 3000;
 
 async function waitForOptionalPhaseCount(
   phase: string,
@@ -208,9 +568,43 @@ async function waitForOptionalPhaseCount(
   }
 }
 
+async function waitForTracePhaseForSessionSince(
+  phase: string,
+  sessionId: string,
+  sinceMs: number,
+  timeoutMs: number,
+): Promise<StartupTraceSnapshot> {
+  let latest = await readStartupTraceSnapshot();
+  await browser.waitUntil(async () => {
+    latest = await readStartupTraceSnapshot();
+    return latest.phases.events.some(event =>
+      traceEventMatchesSessionPhaseSince(event, phase, sessionId, sinceMs)
+    );
+  }, {
+    timeout: timeoutMs,
+    interval: 100,
+    timeoutMsg:
+      `Timed out waiting for startup trace phase '${phase}' for session '${sessionId}' after ${sinceMs}`,
+  });
+  return latest;
+}
+
+async function waitForOptionalTracePhaseForSessionSince(
+  phase: string,
+  sessionId: string,
+  sinceMs: number,
+  timeoutMs: number,
+): Promise<StartupTraceSnapshot> {
+  try {
+    return await waitForTracePhaseForSessionSince(phase, sessionId, sinceMs, timeoutMs);
+  } catch {
+    return readStartupTraceSnapshot();
+  }
+}
+
 async function findSessionItem(sessionId: string): Promise<ReturnType<typeof $> | null> {
   let lastVisibleSessionIds: string[] = [];
-  for (let attempt = 0; attempt < 6; attempt += 1) {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
     const item = await $(`[data-testid="session-nav-item"][data-session-id="${sessionId}"]`);
     if (await item.isExisting()) {
       return item;
@@ -306,6 +700,19 @@ type LongSessionMetadata = {
 };
 
 async function readLongSessionMetadata(sessionId: string): Promise<LongSessionMetadata | null> {
+  const metadataPath = await findLongSessionMetadataPath(sessionId);
+  if (!metadataPath) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(await fs.readFile(metadataPath, 'utf8')) as LongSessionMetadata;
+  } catch {
+    return null;
+  }
+}
+
+async function findLongSessionMetadataPath(sessionId: string): Promise<string | null> {
   const bitfunHome = process.env.BITFUN_HOME || path.join(os.homedir(), '.bitfun');
   const workspaceCandidates = Array.from(new Set([
     process.env.E2E_TEST_WORKSPACE,
@@ -323,10 +730,30 @@ async function readLongSessionMetadata(sessionId: string): Promise<LongSessionMe
         sessionId,
         'metadata.json',
       );
-      return JSON.parse(await fs.readFile(metadataPath, 'utf8')) as LongSessionMetadata;
+      await fs.access(metadataPath);
+      return metadataPath;
     } catch {
       // Try the next known E2E workspace candidate.
     }
+  }
+
+  try {
+    const projectsDir = path.join(bitfunHome, 'projects');
+    const projectEntries = await fs.readdir(projectsDir, { withFileTypes: true });
+    for (const entry of projectEntries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const metadataPath = path.join(projectsDir, entry.name, 'sessions', sessionId, 'metadata.json');
+      try {
+        await fs.access(metadataPath);
+        return metadataPath;
+      } catch {
+        // Try the next persisted project.
+      }
+    }
+  } catch {
+    // No global project fallback is available.
   }
 
   return null;
@@ -337,6 +764,22 @@ async function readExpectedLatestTurnId(sessionId: string): Promise<string | nul
   const turnCount = Number(metadata?.turnCount);
   if (!Number.isFinite(turnCount) || turnCount < 1) {
     return null;
+  }
+  const metadataPath = await findLongSessionMetadataPath(sessionId);
+  if (metadataPath) {
+    const latestTurnPath = path.join(
+      path.dirname(metadataPath),
+      'turns',
+      `turn-${String(turnCount - 1).padStart(4, '0')}.json`,
+    );
+    try {
+      const latestTurn = JSON.parse(await fs.readFile(latestTurnPath, 'utf8')) as { turnId?: unknown };
+      if (typeof latestTurn.turnId === 'string' && latestTurn.turnId.length > 0) {
+        return latestTurn.turnId;
+      }
+    } catch {
+      // Fall back to the deterministic fixture id below.
+    }
   }
   return `${sessionId}-turn-${String(turnCount - 1).padStart(4, '0')}`;
 }
@@ -360,7 +803,10 @@ function siblingSessionId(sessionId: string): string | null {
 
 async function switchAwayFromSession(sessionId: string): Promise<void> {
   const alternateId = siblingSessionId(sessionId);
-  const alternate = alternateId ? await findSessionItem(alternateId) : null;
+  if (!alternateId) {
+    return;
+  }
+  const alternate = await findSessionItem(alternateId);
   if (!alternate) {
     return;
   }
@@ -373,17 +819,52 @@ async function switchAwayFromSession(sessionId: string): Promise<void> {
     beforeSnapshot,
     'historical_session_after_state_commit_frame',
   );
+  const clickedAtMs = await readPerformanceNow();
   await alternate.click();
-  await waitForOptionalPhaseCount(
+  const afterFrameSnapshot = await waitForOptionalTracePhaseForSessionSince(
     'historical_session_after_state_commit_frame',
-    frameCountBefore + 1,
+    alternateId,
+    clickedAtMs,
     10000,
   );
+  if (countPhase(afterFrameSnapshot, 'historical_session_after_state_commit_frame') <= frameCountBefore) {
+    await waitForOptionalPhaseCount(
+      'historical_session_after_state_commit_frame',
+      frameCountBefore + 1,
+      1000,
+    );
+  }
   await browser.pause(50);
 }
 
 async function readLongSessionViewportState(expectedLatestTurnId?: string | null): Promise<LongSessionViewportState> {
   return browser.execute((targetTurnId) => {
+    const effectiveOpacityFor = (element: HTMLElement | null): number => {
+      if (!element) {
+        return 0;
+      }
+
+      let opacity = 1;
+      let current: HTMLElement | null = element;
+      while (current) {
+        const style = window.getComputedStyle(current);
+        if (style.display === 'none' || style.visibility === 'hidden') {
+          return 0;
+        }
+        const styleOpacity = Number(style.opacity);
+        if (Number.isFinite(styleOpacity)) {
+          opacity *= styleOpacity;
+        }
+        if (opacity <= 0.01) {
+          return 0;
+        }
+        current = current.parentElement;
+      }
+      return opacity;
+    };
+    const isElementEffectivelyVisible = (element: HTMLElement | null): boolean => (
+      effectiveOpacityFor(element) > 0.01
+    );
     const root = document.querySelector<HTMLElement>(
       '.modern-flowchat-container__messages .virtual-message-list',
     );
@@ -421,28 +902,49 @@ async function readLongSessionViewportState(expectedLatestTurnId?: string | null
       historyPlaceholderRect.height > 0 &&
       historyPlaceholderStyle?.visibility !== 'hidden' &&
       historyPlaceholderStyle?.display !== 'none' &&
-      historyPlaceholderStyle?.opacity !== '0'
+      isElementEffectivelyVisible(historyPlaceholder)
     );
     const effectiveScrollerBottom = scrollerRect
       ? Math.min(scrollerRect.bottom, inputOverlayRect?.top ?? scrollerRect.bottom)
       : null;
+    const historyPlaceholderCoversMessages = Boolean(
+      historyPlaceholderVisible &&
+      historyPlaceholderRect &&
+      (
+        !scrollerRect ||
+        (
+          historyPlaceholderRect.top <= scrollerRect.top + 4 &&
+          historyPlaceholderRect.bottom >= (effectiveScrollerBottom ?? scrollerRect.bottom) - 4 &&
+          historyPlaceholderRect.left <= scrollerRect.left + 4 &&
+          historyPlaceholderRect.right >= scrollerRect.right - 4
+        )
+      )
+    );
     const latestRect = latest?.getBoundingClientRect() ?? null;
-    const isVisibleWithinScroller = (rect: DOMRect | null): boolean => Boolean(
+    const isVisibleWithinScroller = (rect: DOMRect | null, element?: HTMLElement | null): boolean => Boolean(
       scrollerRect &&
       rect &&
+      (!element || isElementEffectivelyVisible(element)) &&
       rect.bottom > scrollerRect.top &&
       rect.top < (effectiveScrollerBottom ?? scrollerRect.bottom)
     );
     const latestModelRoundVisibleSegments = latestModelRoundSegments
-      .filter(element => isVisibleWithinScroller(element.getBoundingClientRect()));
+      .filter(element => isVisibleWithinScroller(element.getBoundingClientRect(), element));
     const latestModelRoundVisible = latestModelRoundVisibleSegments.length > 0;
     const latestModelRoundTextLength = latestModelRoundVisibleSegments
       .reduce((total, element) => total + (element.innerText?.length ?? 0), 0);
-    const latestVisible = isVisibleWithinScroller(latestRect);
+    const latestVisible = isVisibleWithinScroller(latestRect, latest);
+    const latestContentVisible = latestVisible || latestModelRoundVisible;
+    const latestContentVisuallyVisible =
+      latestContentVisible && !historyPlaceholderCoversMessages;
     const visibleUserMessages = scrollerRect
       ? userMessages.filter(element => {
         const rect = element.getBoundingClientRect();
-        return rect.bottom > scrollerRect.top && rect.top < (effectiveScrollerBottom ?? scrollerRect.bottom);
+        return (
+          isElementEffectivelyVisible(element) &&
+          rect.bottom > scrollerRect.top &&
+          rect.top < (effectiveScrollerBottom ?? scrollerRect.bottom)
+        );
       })
       : [];
     const visibleItems = scrollerRect
@@ -457,7 +959,8 @@ async function readLongSessionViewportState(expectedLatestTurnId?: string | null
             rawBottom: rect.bottom,
           };
         })
-        .filter(({ top, bottom }) =>
+        .filter(({ element, top, bottom }) =>
+          isElementEffectivelyVisible(element) &&
           bottom > scrollerRect.top &&
           top < (effectiveScrollerBottom ?? scrollerRect.bottom) &&
           bottom > top
@@ -532,8 +1035,10 @@ async function readLongSessionViewportState(expectedLatestTurnId?: string | null
       latestModelRoundRendered: latestModelRoundSegments.length > 0,
       latestModelRoundVisible,
       latestModelRoundTextLength,
-      latestContentVisible: latestVisible || latestModelRoundVisible,
+      latestContentVisible,
       historyPlaceholderVisible,
+      historyPlaceholderCoversMessages,
+      latestContentVisuallyVisible,
       scrollerTop: scrollerRect?.top ?? null,
       scrollerBottom: scrollerRect?.bottom ?? null,
       effectiveScrollerBottom,
@@ -579,17 +1084,1024 @@ async function startLongSessionViewportTimelineRecorder(
     const globalWindow = window as typeof window & {
       __bitfunLongSessionViewportTimeline?: LongSessionViewportTimelineSample[];
       __bitfunLongSessionMainThreadTasks?: LongSessionMainThreadTask[];
+      __bitfunLongSessionMutationEvents?: LongSessionDomMutationEvent[];
+      __bitfunLongSessionVisualStateEvents?: LongSessionVisualStateEvent[];
+      __bitfunLongSessionLayoutShiftEvents?: LongSessionLayoutShiftEvent[];
       __bitfunLongSessionViewportTimelineTimer?: number;
+      __bitfunLongSessionVisualFrameRequest?: number;
+      __bitfunLongSessionVisualProbeTimers?: number[];
       __bitfunLongSessionLongTaskObserver?: PerformanceObserver;
+      __bitfunLongSessionLayoutShiftObserver?: PerformanceObserver;
+      __bitfunLongSessionMutationObserver?: MutationObserver;
+      __bitfunLongSessionOpenIntentAt?: number;
+      __bitfunLongSessionOpenIntentHandler?: EventListener;
+      __bitfunLongSessionUserInteractionHandler?: EventListener;
       __BITFUN_RENDER_PROFILE_ENABLED__?: boolean;
     };
     globalWindow.__BITFUN_RENDER_PROFILE_ENABLED__ = shouldEnableRenderProfile;
     if (globalWindow.__bitfunLongSessionViewportTimelineTimer !== undefined) {
       window.clearInterval(globalWindow.__bitfunLongSessionViewportTimelineTimer);
     }
+    if (globalWindow.__bitfunLongSessionVisualFrameRequest !== undefined) {
+      window.cancelAnimationFrame(globalWindow.__bitfunLongSessionVisualFrameRequest);
+    }
+    for (const timerId of globalWindow.__bitfunLongSessionVisualProbeTimers ?? []) {
+      window.clearTimeout(timerId);
+    }
+    globalWindow.__bitfunLongSessionVisualProbeTimers = [];
     globalWindow.__bitfunLongSessionLongTaskObserver?.disconnect();
+    globalWindow.__bitfunLongSessionLayoutShiftObserver?.disconnect();
+    globalWindow.__bitfunLongSessionMutationObserver?.disconnect();
+    if (globalWindow.__bitfunLongSessionOpenIntentHandler) {
+      window.removeEventListener(
+        'flowchat:history-session-open-intent',
+        globalWindow.__bitfunLongSessionOpenIntentHandler,
+      );
+    }
+    if (globalWindow.__bitfunLongSessionUserInteractionHandler) {
+      window.removeEventListener(
+        'bitfun:e2e-long-session-user-interaction',
+        globalWindow.__bitfunLongSessionUserInteractionHandler,
+      );
+    }
+    globalWindow.__bitfunLongSessionOpenIntentAt = undefined;
+    const handleOpenIntent: EventListener = () => {
+      globalWindow.__bitfunLongSessionOpenIntentAt = performance.now();
+      recordMutationEvent('history-open-intent');
+      recordVisualStateEvent('history-open-intent', true);
+      for (const delayMs of [100, 250, 500, 1_000]) {
+        const timerId = window.setTimeout(
+          () => recordVisualStateEvent(`history-open-intent-probe-${delayMs}ms`, true),
+          delayMs,
+        );
+        globalWindow.__bitfunLongSessionVisualProbeTimers?.push(timerId);
+      }
+    };
+    globalWindow.__bitfunLongSessionOpenIntentHandler = handleOpenIntent;
+    window.addEventListener('flowchat:history-session-open-intent', handleOpenIntent);
+    const handleUserInteraction: EventListener = event => {
+      const interactionType =
+        event instanceof CustomEvent && typeof event.detail?.type === 'string'
+          ? event.detail.type
+          : 'unknown';
+      recordVisualStateEvent(`user-interaction-${interactionType}`, true);
+      for (const delayMs of [16, 50, 100, 250, 500]) {
+        window.setTimeout(
+          () => recordVisualStateEvent(`user-interaction-${interactionType}-probe-${delayMs}ms`, true),
+          delayMs,
+        );
+      }
+    };
+    globalWindow.__bitfunLongSessionUserInteractionHandler = handleUserInteraction;
+    window.addEventListener('bitfun:e2e-long-session-user-interaction', handleUserInteraction);
     const samples: LongSessionViewportTimelineSample[] = [];
     const mainThreadTasks: LongSessionMainThreadTask[] = [];
+    const mutationEvents: LongSessionDomMutationEvent[] = [];
+    const visualStateEvents: LongSessionVisualStateEvent[] = [];
+    const layoutShiftEvents: LongSessionLayoutShiftEvent[] = [];
+    const elementIds = new WeakMap<Element, string>();
+    let nextElementId = 1;
+    let visualFrame = 0;
+    let previousVisualSignature: string | null = null;
+
+    const toNumberOrNull = (value: string | null | undefined): number | null => {
+      if (value === null || value === undefined || value === '') {
+        return null;
+      }
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : null;
+    };
+
+    const rectSummary = (rect: DOMRect | null | undefined): LongSessionRectSummary | null => {
+      if (!rect) {
+        return null;
+      }
+      const round = (value: number) => Math.round(value * 10) / 10;
+      return {
+        top: round(rect.top),
+        bottom: round(rect.bottom),
+        left: round(rect.left),
+        right: round(rect.right),
+        width: round(rect.width),
+        height: round(rect.height),
+      };
+    };
+
+    const getElementId = (element: Element, prefix: string): string => {
+      const existing = elementIds.get(element);
+      if (existing) {
+        return existing;
+      }
+      const id = `${prefix}-${nextElementId}`;
+      nextElementId += 1;
+      elementIds.set(element, id);
+      return id;
+    };
+
+    const getBackground = (element: Element | null | undefined): string | null => {
+      if (!element) {
+        return null;
+      }
+      return window.getComputedStyle(element).backgroundColor || null;
+    };
+
+    const effectiveOpacityFor = (element: HTMLElement | null): number => {
+      if (!element) {
+        return 0;
+      }
+
+      let opacity = 1;
+      let current: HTMLElement | null = element;
+      while (current) {
+        const style = window.getComputedStyle(current);
+        if (style.display === 'none' || style.visibility === 'hidden') {
+          return 0;
+        }
+        const styleOpacity = Number(style.opacity);
+        if (Number.isFinite(styleOpacity)) {
+          opacity *= styleOpacity;
+        }
+        if (opacity <= 0.01) {
+          return 0;
+        }
+        current = current.parentElement;
+      }
+      return Math.round(opacity * 1000) / 1000;
+    };
+
+    const isElementEffectivelyVisible = (element: HTMLElement | null): boolean =>
+      effectiveOpacityFor(element) > 0.01;
+
+    const describeNode = (node: Node | null | undefined): string | null => {
+      if (!(node instanceof HTMLElement)) {
+        return node?.nodeName ?? null;
+      }
+      const testId = node.getAttribute('data-testid');
+      const turnId = node.getAttribute('data-turn-id');
+      const itemType = node.getAttribute('data-item-type');
+      const id = node.id ? `#${node.id}` : '';
+      const className = Array.from(node.classList).slice(0, 4).map(name => `.${name}`).join('');
+      const data = [
+        testId ? `[data-testid="${testId}"]` : '',
+        turnId ? `[data-turn-id="${turnId}"]` : '',
+        itemType ? `[data-item-type="${itemType}"]` : '',
+      ].join('');
+      return `${node.tagName.toLowerCase()}${id}${className}${data}` || node.tagName.toLowerCase();
+    };
+
+    const LOADING_SURFACE_SELECTORS = [
+      '.modern-flowchat-container__history-overlay',
+      '.history-session-placeholder',
+      '.bitfun-scene-viewport__lazy-fallback',
+      '.bitfun-assistant-scene__loading',
+      '.bitfun-app-acp-session-loading',
+      '[role="status"][aria-busy="true"]',
+    ];
+    const OBSERVED_MUTATION_SELECTOR = [
+      '.modern-flowchat-container__messages',
+      '.modern-flowchat-container__history-open-intent-shield',
+      '.modern-flowchat-container__history-overlay',
+      '.history-session-placeholder',
+      '.virtual-message-list',
+      '.virtual-message-list__projection-handoff-overlay',
+      '.virtual-item-wrapper',
+      ...LOADING_SURFACE_SELECTORS,
+    ].join(', ');
+
+    const readLoadingSurfaces = (): LongSessionLoadingSurface[] => {
+      const seen = new Set<Element>();
+      const surfaces: LongSessionLoadingSurface[] = [];
+      for (const selector of LOADING_SURFACE_SELECTORS) {
+        for (const element of Array.from(document.querySelectorAll<HTMLElement>(selector))) {
+          if (seen.has(element)) {
+            continue;
+          }
+          seen.add(element);
+          const rect = element.getBoundingClientRect();
+          const style = window.getComputedStyle(element);
+          const visible = (
+            rect.width > 0 &&
+            rect.height > 0 &&
+            style.visibility !== 'hidden' &&
+            style.display !== 'none' &&
+            isElementEffectivelyVisible(element)
+          );
+          surfaces.push({
+            selector,
+            node: describeNode(element),
+            visible,
+            textLength: element.innerText?.length ?? 0,
+            rect: rectSummary(rect),
+          });
+        }
+      }
+      return surfaces.slice(0, 24);
+    };
+
+    const visibleTextLengthFor = (elements: HTMLElement[]): number => elements.reduce((total, element) => {
+      const rect = element.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) {
+        return total;
+      }
+      const style = window.getComputedStyle(element);
+      if (style.visibility === 'hidden' || style.display === 'none' || !isElementEffectivelyVisible(element)) {
+        return total;
+      }
+      return total + (element.innerText?.length ?? 0);
+    }, 0);
+
+    const readModelRoundMetrics = (element: HTMLElement | null) => {
+      const modelRound = element?.querySelector<HTMLElement>('.model-round-item') ??
+        element?.closest<HTMLElement>('.model-round-item') ??
+        null;
+      return {
+        modelRoundGroupCount: toNumberOrNull(modelRound?.dataset.modelRoundGroupCount),
+        modelRoundRenderedGroupCount: toNumberOrNull(modelRound?.dataset.modelRoundRenderedGroupCount),
+        modelRoundVisibleGroupStart: toNumberOrNull(modelRound?.dataset.modelRoundVisibleGroupStart),
+        modelRoundVisibleGroupEnd: toNumberOrNull(modelRound?.dataset.modelRoundVisibleGroupEnd),
+        modelRoundRenderAll: modelRound?.dataset.modelRoundRenderAll || null,
+        modelRoundHasDeferredEarlier: modelRound?.dataset.modelRoundHasDeferredEarlier || null,
+        modelRoundHasDeferredLater: modelRound?.dataset.modelRoundHasDeferredLater || null,
+      };
+    };
+
+    const summarizeVirtualItems = (elements: HTMLElement[]): LongSessionVirtualItemSummary[] =>
+      elements.slice(0, 160).map(element => {
+        const modelRoundMetrics = readModelRoundMetrics(element);
+        const completedToolTransitions = Array.from(
+          element.querySelectorAll<HTMLElement>(
+            '.flowchat-flow-item--tool-transition.flowchat-flow-item--tool-completed',
+          ),
+        );
+        const completedToolTransitionStyles = completedToolTransitions.map(tool => window.getComputedStyle(tool));
+        const uniqueStyleValues = (values: string[]): string[] => Array.from(new Set(values)).slice(0, 8);
+        return {
+          elementId: getElementId(element, 'virtual-item'),
+          virtualIndex: toNumberOrNull(element.dataset.virtualIndex),
+          itemType: element.dataset.itemType || null,
+          turnId: element.dataset.turnId || null,
+          textLength: element.innerText?.length ?? 0,
+          ...modelRoundMetrics,
+          codeBlockWrapperCount: element.querySelectorAll('.code-block-wrapper').length,
+          codeBlockFallbackCount: element.querySelectorAll('.code-block-fallback').length,
+          highlightedCodeBlockCount: element.querySelectorAll('.code-block-body pre:not(.code-block-fallback)').length,
+          tableCount: element.querySelectorAll('.table-wrapper table').length,
+          completedToolTransitionCount: completedToolTransitions.length,
+          completedToolTransitionHeight: completedToolTransitions.reduce(
+            (total, tool) => total + tool.getBoundingClientRect().height,
+            0,
+          ),
+          completedToolTransitionMaxHeights: uniqueStyleValues(
+            completedToolTransitionStyles.map(style => style.maxHeight),
+          ),
+          completedToolTransitionAnimations: uniqueStyleValues(
+            completedToolTransitionStyles.map(style => `${style.animationName}:${style.animationDuration}:${style.animationPlayState}`),
+          ),
+          completedToolTransitionOpacities: uniqueStyleValues(
+            completedToolTransitionStyles.map(style => style.opacity),
+          ),
+          rect: rectSummary(element.getBoundingClientRect()),
+        };
+      });
+
+    const getElementBackgroundChain = (elements: Element[]): string[] =>
+      elements
+        .filter((element): element is HTMLElement => element instanceof HTMLElement)
+        .slice(0, 6)
+        .map(element => {
+          const style = window.getComputedStyle(element);
+          return [
+            describeNode(element),
+            style.backgroundColor || 'none',
+            style.opacity || '1',
+            style.visibility || 'visible',
+            style.display || 'block',
+          ].join('@');
+        });
+
+    const isLoadingSurfaceElement = (element: HTMLElement): boolean =>
+      Boolean(
+        element.closest('.modern-flowchat-container__history-overlay') ||
+        element.closest('.history-session-placeholder') ||
+        element.closest('.bitfun-scene-viewport__lazy-fallback') ||
+        element.closest('.bitfun-assistant-scene__loading') ||
+        element.closest('.bitfun-app-acp-session-loading') ||
+        element.closest('[role="status"][aria-busy="true"]'),
+      );
+
+    const classifySurfaceElement = (
+      element: HTMLElement | null,
+      latestTurnId: string,
+    ): Pick<LongSessionSurfacePoint, 'category' | 'itemType' | 'turnId' | 'latestTurnHit' | 'effectiveOpacity' | 'textLength' | 'modelRoundGroupCount' | 'modelRoundRenderedGroupCount' | 'modelRoundVisibleGroupStart' | 'modelRoundVisibleGroupEnd' | 'modelRoundRenderAll' | 'modelRoundHasDeferredEarlier' | 'modelRoundHasDeferredLater'> => {
+      if (!element) {
+        return {
+          category: 'missing',
+          itemType: null,
+          turnId: null,
+          latestTurnHit: false,
+          effectiveOpacity: 0,
+          textLength: 0,
+          ...readModelRoundMetrics(null),
+        };
+      }
+
+      const virtualItem = element.closest<HTMLElement>('.virtual-item-wrapper[data-turn-id]');
+      const effectiveOpacity = effectiveOpacityFor(element);
+      const virtualItemEffectiveOpacity = virtualItem ? effectiveOpacityFor(virtualItem) : effectiveOpacity;
+      const modelRoundMetrics = readModelRoundMetrics(virtualItem ?? element);
+      if (isLoadingSurfaceElement(element)) {
+        return {
+          category: element.closest('.modern-flowchat-container__history-overlay')
+            ? 'history-overlay'
+            : 'loading-surface',
+          itemType: virtualItem?.dataset.itemType || null,
+          turnId: virtualItem?.dataset.turnId || null,
+          latestTurnHit: virtualItem?.dataset.turnId === latestTurnId,
+          effectiveOpacity,
+          textLength: virtualItem?.innerText?.length ?? element.innerText?.length ?? 0,
+          ...modelRoundMetrics,
+        };
+      }
+
+      if (element.closest('.modern-flowchat-container__history-open-intent-shield')) {
+        return {
+          category: 'history-open-intent-shield',
+          itemType: null,
+          turnId: null,
+          latestTurnHit: false,
+          effectiveOpacity,
+          textLength: element.innerText?.length ?? 0,
+          ...readModelRoundMetrics(null),
+        };
+      }
+
+      if (virtualItem) {
+        return {
+          category: virtualItemEffectiveOpacity > 0.01
+            ? `virtual-item:${virtualItem.dataset.itemType || 'unknown'}`
+            : `transparent-virtual-item:${virtualItem.dataset.itemType || 'unknown'}`,
+          itemType: virtualItem.dataset.itemType || null,
+          turnId: virtualItem.dataset.turnId || null,
+          latestTurnHit: virtualItem.dataset.turnId === latestTurnId,
+          effectiveOpacity: virtualItemEffectiveOpacity,
+          textLength: virtualItem.innerText?.length ?? 0,
+          ...modelRoundMetrics,
+        };
+      }
+
+      if (element.closest('.bitfun-chat-input-drop-zone')) {
+        return {
+          category: 'input-overlay',
+          itemType: null,
+          turnId: null,
+          latestTurnHit: false,
+          effectiveOpacity,
+          textLength: element.innerText?.length ?? 0,
+          ...readModelRoundMetrics(null),
+        };
+      }
+
+      if (element.closest('[data-virtuoso-scroller], .virtual-message-list')) {
+        return {
+          category: 'list-blank',
+          itemType: null,
+          turnId: null,
+          latestTurnHit: false,
+          effectiveOpacity,
+          textLength: element.innerText?.length ?? 0,
+          ...readModelRoundMetrics(null),
+        };
+      }
+
+      if (element.closest('.modern-flowchat-container__messages')) {
+        return {
+          category: 'messages-blank',
+          itemType: null,
+          turnId: null,
+          latestTurnHit: false,
+          effectiveOpacity,
+          textLength: element.innerText?.length ?? 0,
+          ...readModelRoundMetrics(null),
+        };
+      }
+
+      if (element.closest('.modern-flowchat-container')) {
+        return {
+          category: 'flowchat-shell',
+          itemType: null,
+          turnId: null,
+          latestTurnHit: false,
+          effectiveOpacity,
+          textLength: element.innerText?.length ?? 0,
+          ...readModelRoundMetrics(null),
+        };
+      }
+
+      return {
+        category: 'other',
+        itemType: null,
+        turnId: null,
+        latestTurnHit: false,
+        effectiveOpacity,
+        textLength: element.innerText?.length ?? 0,
+        ...readModelRoundMetrics(null),
+      };
+    };
+
+    const readSurfacePoints = (
+      messages: HTMLElement | null,
+      scroller: HTMLElement | null,
+      inputOverlay: HTMLElement | null,
+      latestTurnId: string,
+    ): LongSessionSurfacePoint[] => {
+      const messagesRect = messages?.getBoundingClientRect() ?? null;
+      if (!messagesRect || messagesRect.width <= 0 || messagesRect.height <= 0) {
+        return [];
+      }
+
+      const inputOverlayTop = inputOverlay?.getBoundingClientRect().top ?? messagesRect.bottom;
+      const sampleTop = messagesRect.top;
+      const sampleBottom = Math.max(
+        sampleTop,
+        Math.min(messagesRect.bottom, inputOverlayTop),
+      );
+      const sampleHeight = sampleBottom - sampleTop;
+      if (sampleHeight <= 0) {
+        return [];
+      }
+
+      const pointSpecs = [
+        ['top-left', 0.25, 0.16],
+        ['top-center', 0.5, 0.16],
+        ['top-right', 0.75, 0.16],
+        ['middle-left', 0.25, 0.48],
+        ['middle-center', 0.5, 0.48],
+        ['middle-right', 0.75, 0.48],
+        ['bottom-left', 0.25, 0.82],
+        ['bottom-center', 0.5, 0.82],
+        ['bottom-right', 0.75, 0.82],
+      ] as const;
+
+      const findPaintedHandoffElementAtPoint = (x: number, y: number): HTMLElement | null => {
+        const handoffs = Array.from(
+          messages.querySelectorAll<HTMLElement>('.virtual-message-list__projection-handoff-overlay'),
+        );
+        for (let handoffIndex = handoffs.length - 1; handoffIndex >= 0; handoffIndex -= 1) {
+          const handoff = handoffs[handoffIndex];
+          const handoffRect = handoff.getBoundingClientRect();
+          const handoffStyle = window.getComputedStyle(handoff);
+          const handoffVisible = (
+            handoffRect.width > 0 &&
+            handoffRect.height > 0 &&
+            handoffStyle.visibility !== 'hidden' &&
+            handoffStyle.display !== 'none' &&
+            isElementEffectivelyVisible(handoff)
+          );
+          if (
+            !handoffVisible ||
+            x < handoffRect.left ||
+            x > handoffRect.right ||
+            y < handoffRect.top ||
+            y > handoffRect.bottom
+          ) {
+            continue;
+          }
+
+          const handoffItems = Array.from(
+            handoff.querySelectorAll<HTMLElement>('.virtual-item-wrapper[data-turn-id]'),
+          );
+          for (let itemIndex = handoffItems.length - 1; itemIndex >= 0; itemIndex -= 1) {
+            const item = handoffItems[itemIndex];
+            const itemRect = item.getBoundingClientRect();
+            if (
+              itemRect.width > 0 &&
+              itemRect.height > 0 &&
+              x >= itemRect.left &&
+              x <= itemRect.right &&
+              y >= itemRect.top &&
+              y <= itemRect.bottom &&
+              isElementEffectivelyVisible(item)
+            ) {
+              return item;
+            }
+          }
+
+          return handoff;
+        }
+
+        return null;
+      };
+
+      return pointSpecs.map(([label, xRatio, yRatio]) => {
+        const x = Math.round(messagesRect.left + messagesRect.width * xRatio);
+        const y = Math.round(sampleTop + sampleHeight * yRatio);
+        const elements = document.elementsFromPoint(x, y);
+        const paintedHandoffElement = findPaintedHandoffElementAtPoint(x, y);
+        const topElement =
+          paintedHandoffElement ??
+          elements.find((element): element is HTMLElement => element instanceof HTMLElement) ??
+          null;
+        const classified = classifySurfaceElement(topElement, latestTurnId);
+        return {
+          label,
+          x,
+          y,
+          ...classified,
+          topNode: describeNode(topElement),
+          topElementId: topElement ? getElementId(topElement, 'surface') : null,
+          backgroundChain: getElementBackgroundChain(
+            paintedHandoffElement ? [paintedHandoffElement, ...elements] : elements,
+          ),
+        };
+      });
+    };
+
+    const surfaceSignatureFor = (surfacePoints: LongSessionSurfacePoint[]): string =>
+      surfacePoints
+        .map(point => [
+          point.label,
+          point.category,
+          point.topElementId,
+          point.itemType,
+          point.latestTurnHit ? 'latest' : point.turnId,
+          point.effectiveOpacity,
+          Math.min(point.textLength, 9999),
+          point.modelRoundGroupCount,
+          point.modelRoundRenderedGroupCount,
+          point.modelRoundVisibleGroupStart,
+          point.modelRoundVisibleGroupEnd,
+          point.modelRoundRenderAll,
+          point.modelRoundHasDeferredEarlier,
+          point.modelRoundHasDeferredLater,
+          point.backgroundChain[0] ?? '',
+        ].join(':'))
+        .join('|');
+
+    const readMutationEvent = (reason: string): LongSessionDomMutationEvent => {
+      const atMs = performance.now();
+      const messages = document.querySelector<HTMLElement>('.modern-flowchat-container__messages');
+      const container = document.querySelector<HTMLElement>('.modern-flowchat-container');
+      const inputOverlay = document.querySelector<HTMLElement>('.bitfun-chat-input-drop-zone');
+      const placeholders = Array.from(
+        messages?.querySelectorAll<HTMLElement>('.history-session-placeholder') ?? []
+      );
+      const overlays = Array.from(
+        messages?.querySelectorAll<HTMLElement>('.modern-flowchat-container__history-overlay') ?? []
+      );
+      const historyInitialPreviews = Array.from(
+        messages?.querySelectorAll<HTMLElement>('.virtual-message-list__history-initial-preview') ?? []
+      );
+      const historyProjectionHandoffs = Array.from(
+        messages?.querySelectorAll<HTMLElement>('.virtual-message-list__projection-handoff-overlay') ?? []
+      );
+      const virtualLists = Array.from(
+        messages?.querySelectorAll<HTMLElement>('.virtual-message-list') ?? []
+      );
+      const scroller = messages?.querySelector<HTMLElement>(
+        '[data-virtuoso-scroller="true"], [data-virtuoso-scroller]',
+      ) ?? null;
+      const virtualItems = Array.from(
+        scroller?.querySelectorAll<HTMLElement>('.virtual-item-wrapper[data-turn-id]') ?? []
+      );
+      const visibleTextLength = visibleTextLengthFor(virtualItems);
+      const loadingSurfaces = readLoadingSurfaces();
+      const visibleLoadingSurfaceCount = loadingSurfaces.filter(surface => surface.visible).length;
+      const surfacePoints = readSurfacePoints(messages ?? null, scroller, inputOverlay, targetTurnId);
+      const surfaceSignature = surfaceSignatureFor(surfacePoints);
+      const historyInitialPreviewVisible = historyInitialPreviews.some(element => {
+        const rect = element.getBoundingClientRect();
+        const style = window.getComputedStyle(element);
+        return (
+          rect.width > 0 &&
+          rect.height > 0 &&
+          style.visibility !== 'hidden' &&
+          style.display !== 'none' &&
+          isElementEffectivelyVisible(element)
+        );
+      });
+      const historyProjectionHandoffVisible = historyProjectionHandoffs.some(element => {
+        const rect = element.getBoundingClientRect();
+        const style = window.getComputedStyle(element);
+        return (
+          rect.width > 0 &&
+          rect.height > 0 &&
+          style.visibility !== 'hidden' &&
+          style.display !== 'none' &&
+          isElementEffectivelyVisible(element)
+        );
+      });
+
+      return {
+        atMs,
+        sinceClickMs: atMs - clickTime,
+        reason,
+        activeSessionId: messages?.dataset.activeSessionId || null,
+        historyState: messages?.dataset.historyState || null,
+        contextRestoreState: messages?.dataset.contextRestoreState || null,
+        isPartial: messages?.dataset.isPartial || null,
+        dialogTurnCount: toNumberOrNull(messages?.dataset.dialogTurnCount),
+        virtualItemCount: toNumberOrNull(messages?.dataset.virtualItemCount),
+        showHistoryPlaceholder: messages?.dataset.showHistoryPlaceholder || null,
+        showHistoryTransitionOverlay: messages?.dataset.showHistoryTransitionOverlay || null,
+        showHistoryLoadingLayer: messages?.dataset.showHistoryLoadingLayer || null,
+        showHistoryOpenIntentOverlay: messages?.dataset.showHistoryOpenIntentOverlay || null,
+        hasPendingHistoryCompletion: messages?.dataset.hasPendingHistoryCompletion || null,
+        hasDeferredHistoryProjection: messages?.dataset.hasDeferredHistoryProjection || null,
+        latestTurnId: messages?.dataset.latestTurnId || null,
+        historyInitialContentReady: messages?.dataset.historyInitialContentReady || null,
+        pendingHistoryOpenSessionId: messages?.dataset.pendingHistoryOpenSessionId || null,
+        placeholderCount: placeholders.length,
+        overlayCount: overlays.length,
+        historyInitialPreviewCount: historyInitialPreviews.length,
+        historyInitialPreviewVisible,
+        historyProjectionHandoffCount: historyProjectionHandoffs.length,
+        historyProjectionHandoffVisible,
+        virtualListCount: virtualLists.length,
+        virtualItemDomCount: virtualItems.length,
+        visibleLoadingSurfaceCount,
+        visibleTextLength,
+        loadingSurfaces,
+        overlayElementIds: overlays.map(element => getElementId(element, 'overlay')),
+        placeholderElementIds: placeholders.map(element => getElementId(element, 'placeholder')),
+        virtualListElementIds: virtualLists.map(element => getElementId(element, 'virtual-list')),
+        virtualItemElementIds: virtualItems
+          .slice(0, 32)
+          .map(element => getElementId(element, 'virtual-item')),
+        virtualItemSummaries: summarizeVirtualItems(virtualItems),
+        surfaceSignature,
+        surfacePoints,
+        messagesRect: rectSummary(messages?.getBoundingClientRect()),
+        scrollerRect: rectSummary(scroller?.getBoundingClientRect()),
+        overlayRect: rectSummary(overlays[0]?.getBoundingClientRect()),
+        placeholderRect: rectSummary(placeholders[0]?.getBoundingClientRect()),
+        messagesBackground: getBackground(messages),
+        overlayBackground: getBackground(overlays[0]),
+        containerBackground: getBackground(container),
+        bodyBackground: getBackground(document.body),
+        htmlBackground: getBackground(document.documentElement),
+      };
+    };
+
+    const readVisualStateEvent = (reason: string): LongSessionVisualStateEvent => {
+      const atMs = performance.now();
+      const messages = document.querySelector<HTMLElement>('.modern-flowchat-container__messages');
+      const container = document.querySelector<HTMLElement>('.modern-flowchat-container');
+      const placeholders = Array.from(
+        messages?.querySelectorAll<HTMLElement>('.history-session-placeholder') ?? []
+      );
+      const overlays = Array.from(
+        messages?.querySelectorAll<HTMLElement>('.modern-flowchat-container__history-overlay') ?? []
+      );
+      const historyInitialPreviews = Array.from(
+        messages?.querySelectorAll<HTMLElement>('.virtual-message-list__history-initial-preview') ?? []
+      );
+      const historyProjectionHandoffs = Array.from(
+        messages?.querySelectorAll<HTMLElement>('.virtual-message-list__projection-handoff-overlay') ?? []
+      );
+      const virtualLists = Array.from(
+        messages?.querySelectorAll<HTMLElement>('.virtual-message-list') ?? []
+      );
+      const root = document.querySelector<HTMLElement>(
+        '.modern-flowchat-container__messages .virtual-message-list',
+      );
+      const scroller = root?.querySelector<HTMLElement>(
+        '[data-virtuoso-scroller="true"], [data-virtuoso-scroller]',
+      ) ?? null;
+      const footer = scroller?.querySelector<HTMLElement>('.message-list-footer') ?? null;
+      const footerRect = footer?.getBoundingClientRect() ?? null;
+      const footerStyle = footer ? window.getComputedStyle(footer) : null;
+      const virtualItems = Array.from(
+        scroller?.querySelectorAll<HTMLElement>('.virtual-item-wrapper[data-turn-id]') ?? []
+      );
+      const completedToolTransitions = Array.from(
+        scroller?.querySelectorAll<HTMLElement>(
+          '.flowchat-flow-item--tool-transition.flowchat-flow-item--tool-completed',
+        ) ?? []
+      );
+      const completedToolTransitionStyles = completedToolTransitions
+        .map(tool => window.getComputedStyle(tool));
+      const completedToolTransitionHeight = completedToolTransitions.reduce(
+        (total, tool) => total + tool.getBoundingClientRect().height,
+        0,
+      );
+      const completedToolTransitionSignature = completedToolTransitionStyles
+        .slice(0, 16)
+        .map(style => [
+          Math.round(Number.parseFloat(style.maxHeight || '0') || 0),
+          Math.round(Number.parseFloat(style.opacity || '0') * 100) / 100,
+          style.animationName,
+          style.animationPlayState,
+        ].join(':'))
+        .join(',');
+      const inputOverlay = document.querySelector<HTMLElement>('.bitfun-chat-input-drop-zone');
+      const scrollerRect = scroller?.getBoundingClientRect() ?? null;
+      const inputOverlayRect = inputOverlay?.getBoundingClientRect() ?? null;
+      const historyPlaceholderRect = placeholders[0]?.getBoundingClientRect() ?? null;
+      const historyPlaceholderStyle = placeholders[0]
+        ? window.getComputedStyle(placeholders[0])
+        : null;
+      const historyPlaceholderVisible = Boolean(
+        placeholders[0] &&
+        historyPlaceholderRect &&
+        historyPlaceholderRect.width > 0 &&
+        historyPlaceholderRect.height > 0 &&
+        historyPlaceholderStyle?.visibility !== 'hidden' &&
+        historyPlaceholderStyle?.display !== 'none' &&
+        isElementEffectivelyVisible(placeholders[0] ?? null)
+      );
+      const historyInitialPreviewVisible = historyInitialPreviews.some(element => {
+        const rect = element.getBoundingClientRect();
+        const style = window.getComputedStyle(element);
+        return (
+          rect.width > 0 &&
+          rect.height > 0 &&
+          style.visibility !== 'hidden' &&
+          style.display !== 'none' &&
+          isElementEffectivelyVisible(element)
+        );
+      });
+      const historyProjectionHandoffVisible = historyProjectionHandoffs.some(element => {
+        const rect = element.getBoundingClientRect();
+        const style = window.getComputedStyle(element);
+        return (
+          rect.width > 0 &&
+          rect.height > 0 &&
+          style.visibility !== 'hidden' &&
+          style.display !== 'none' &&
+          isElementEffectivelyVisible(element)
+        );
+      });
+      const effectiveScrollerBottom = scrollerRect
+        ? Math.min(scrollerRect.bottom, inputOverlayRect?.top ?? scrollerRect.bottom)
+        : null;
+      const historyPlaceholderCoversMessages = Boolean(
+        historyPlaceholderVisible &&
+        historyPlaceholderRect &&
+        (
+          !scrollerRect ||
+          (
+            historyPlaceholderRect.top <= scrollerRect.top + 4 &&
+            historyPlaceholderRect.bottom >= (effectiveScrollerBottom ?? scrollerRect.bottom) - 4 &&
+            historyPlaceholderRect.left <= scrollerRect.left + 4 &&
+            historyPlaceholderRect.right >= scrollerRect.right - 4
+          )
+        )
+      );
+      const latest = targetTurnId
+        ? root?.querySelector<HTMLElement>(
+          `.virtual-item-wrapper[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+        ) ?? null
+        : null;
+      const latestModelRoundSegments = targetTurnId
+        ? Array.from(root?.querySelectorAll<HTMLElement>(
+          `.virtual-item-wrapper[data-turn-id="${targetTurnId}"][data-item-type="model-round"]`,
+        ) ?? [])
+        : [];
+      const isVisibleWithinScroller = (rect: DOMRect | null, element?: HTMLElement | null): boolean => Boolean(
+        scrollerRect &&
+        rect &&
+        (!element || isElementEffectivelyVisible(element)) &&
+        rect.bottom > scrollerRect.top &&
+        rect.top < (effectiveScrollerBottom ?? scrollerRect.bottom)
+      );
+      const latestVisible = isVisibleWithinScroller(latest?.getBoundingClientRect() ?? null, latest);
+      const latestModelRoundVisibleSegments = latestModelRoundSegments
+        .filter(element => isVisibleWithinScroller(element.getBoundingClientRect(), element));
+      const latestModelRoundTextLength = latestModelRoundVisibleSegments
+        .reduce((total, element) => total + (element.innerText?.length ?? 0), 0);
+      const latestContentVisuallyVisible =
+        (latestVisible || latestModelRoundVisibleSegments.length > 0) &&
+        !historyPlaceholderCoversMessages;
+      const scrollTop = scroller?.scrollTop ?? null;
+      const scrollHeight = scroller?.scrollHeight ?? null;
+      const clientHeight = scroller?.clientHeight ?? null;
+      const footerHeight = footerRect?.height ?? null;
+      const footerStyleHeight = footerStyle?.height ?? null;
+      const footerStyleMinHeight = footerStyle?.minHeight ?? null;
+      const inputOverlayHeight = inputOverlayRect?.height ?? null;
+      const messagesBackground = getBackground(messages);
+      const overlayBackground = getBackground(overlays[0]);
+      const containerBackground = getBackground(container);
+      const bodyBackground = getBackground(document.body);
+      const htmlBackground = getBackground(document.documentElement);
+      const loadingSurfaces = readLoadingSurfaces();
+      const visibleLoadingSurfaceCount = loadingSurfaces.filter(surface => surface.visible).length;
+      const surfacePoints = readSurfacePoints(messages ?? null, scroller, inputOverlay, targetTurnId);
+      const surfaceSignature = surfaceSignatureFor(surfacePoints);
+      const roundMetric = (value: number | null): string =>
+        value === null ? 'null' : String(Math.round(value));
+      const signature = [
+        messages?.dataset.activeSessionId || '',
+        messages?.dataset.historyState || '',
+        messages?.dataset.contextRestoreState || '',
+        messages?.dataset.isPartial || '',
+        messages?.dataset.dialogTurnCount || '',
+        messages?.dataset.virtualItemCount || '',
+        messages?.dataset.showHistoryPlaceholder || '',
+        messages?.dataset.showHistoryTransitionOverlay || '',
+        messages?.dataset.showHistoryLoadingLayer || '',
+        messages?.dataset.showHistoryOpenIntentOverlay || '',
+        messages?.dataset.hasPendingHistoryCompletion || '',
+        messages?.dataset.hasDeferredHistoryProjection || '',
+        messages?.dataset.historyInitialContentReady || '',
+        messages?.dataset.pendingHistoryOpenSessionId || '',
+        placeholders.length,
+        overlays.length,
+        historyInitialPreviews.length,
+        historyInitialPreviewVisible ? 'history-preview-visible' : 'history-preview-hidden',
+        historyProjectionHandoffs.length,
+        historyProjectionHandoffVisible ? 'history-projection-handoff-visible' : 'history-projection-handoff-hidden',
+        visibleLoadingSurfaceCount,
+        loadingSurfaces
+          .filter(surface => surface.visible)
+          .map(surface => `${surface.selector}:${surface.node}:${surface.textLength}`)
+          .join(','),
+        virtualLists.length,
+        virtualItems.length,
+        completedToolTransitions.length,
+        roundMetric(completedToolTransitionHeight),
+        completedToolTransitionSignature,
+        latestContentVisuallyVisible ? 'latest-visible' : 'latest-hidden',
+        latestModelRoundTextLength > 0 ? 'latest-text' : 'latest-no-text',
+        roundMetric(scrollTop),
+        roundMetric(scrollHeight),
+        roundMetric(clientHeight),
+        roundMetric(footerHeight),
+        footerStyleHeight,
+        footerStyleMinHeight,
+        roundMetric(inputOverlayHeight),
+        roundMetric(scrollerRect?.top ?? null),
+        roundMetric(scrollerRect?.bottom ?? null),
+        roundMetric(inputOverlayRect?.top ?? null),
+        surfaceSignature,
+        messagesBackground,
+        overlayBackground,
+        containerBackground,
+        bodyBackground,
+        htmlBackground,
+      ].join('|');
+
+      return {
+        atMs,
+        sinceClickMs: atMs - clickTime,
+        sinceHistoryOpenIntentMs: typeof globalWindow.__bitfunLongSessionOpenIntentAt === 'number'
+          ? atMs - globalWindow.__bitfunLongSessionOpenIntentAt
+          : null,
+        frame: visualFrame,
+        reason,
+        signature,
+        activeSessionId: messages?.dataset.activeSessionId || null,
+        historyState: messages?.dataset.historyState || null,
+        contextRestoreState: messages?.dataset.contextRestoreState || null,
+        isPartial: messages?.dataset.isPartial || null,
+        dialogTurnCount: toNumberOrNull(messages?.dataset.dialogTurnCount),
+        virtualItemCount: toNumberOrNull(messages?.dataset.virtualItemCount),
+        showHistoryPlaceholder: messages?.dataset.showHistoryPlaceholder || null,
+        showHistoryTransitionOverlay: messages?.dataset.showHistoryTransitionOverlay || null,
+        showHistoryLoadingLayer: messages?.dataset.showHistoryLoadingLayer || null,
+        showHistoryOpenIntentOverlay: messages?.dataset.showHistoryOpenIntentOverlay || null,
+        hasPendingHistoryCompletion: messages?.dataset.hasPendingHistoryCompletion || null,
+        hasDeferredHistoryProjection: messages?.dataset.hasDeferredHistoryProjection || null,
+        latestTurnId: messages?.dataset.latestTurnId || null,
+        historyInitialContentReady: messages?.dataset.historyInitialContentReady || null,
+        pendingHistoryOpenSessionId: messages?.dataset.pendingHistoryOpenSessionId || null,
+        placeholderCount: placeholders.length,
+        overlayCount: overlays.length,
+        historyInitialPreviewCount: historyInitialPreviews.length,
+        historyInitialPreviewVisible,
+        historyProjectionHandoffCount: historyProjectionHandoffs.length,
+        historyProjectionHandoffVisible,
+        virtualListCount: virtualLists.length,
+        virtualItemDomCount: virtualItems.length,
+        visibleLoadingSurfaceCount,
+        virtualListElementIds: virtualLists.map(element => getElementId(element, 'virtual-list')),
+        virtualItemElementIds: virtualItems
+          .slice(0, 32)
+          .map(element => getElementId(element, 'virtual-item')),
+        virtualItemSummaries: summarizeVirtualItems(virtualItems),
+        completedToolTransitionCount: completedToolTransitions.length,
+        completedToolTransitionHeight,
+        completedToolTransitionSignature,
+        visibleTextLength: visibleTextLengthFor(virtualItems),
+        loadingSurfaces,
+        latestContentVisuallyVisible,
+        latestModelRoundTextLength,
+        surfaceSignature,
+        surfacePoints,
+        scrollerExists: Boolean(scroller),
+        scrollTop,
+        scrollHeight,
+        clientHeight,
+        footerHeight,
+        footerStyleHeight,
+        footerStyleMinHeight,
+        inputOverlayHeight,
+        messagesRect: rectSummary(messages?.getBoundingClientRect()),
+        scrollerRect: rectSummary(scrollerRect),
+        overlayRect: rectSummary(overlays[0]?.getBoundingClientRect()),
+        placeholderRect: rectSummary(historyPlaceholderRect),
+        inputOverlayRect: rectSummary(inputOverlayRect),
+        messagesBackground,
+        overlayBackground,
+        containerBackground,
+        bodyBackground,
+        htmlBackground,
+      };
+    };
+
+    const recordVisualStateEvent = (reason: string, force = false) => {
+      const event = readVisualStateEvent(reason);
+      if (!force && event.signature === previousVisualSignature) {
+        return;
+      }
+      previousVisualSignature = event.signature;
+      visualStateEvents.push(event);
+      if (visualStateEvents.length > 1200) {
+        visualStateEvents.shift();
+      }
+    };
+
+    function recordMutationEvent(reason: string) {
+      mutationEvents.push(readMutationEvent(reason));
+      if (mutationEvents.length > 800) {
+        mutationEvents.shift();
+      }
+      recordVisualStateEvent(reason);
+    }
+
+    recordMutationEvent('initial');
+    const recordAnimationFrame = () => {
+      visualFrame += 1;
+      recordVisualStateEvent('raf');
+      globalWindow.__bitfunLongSessionVisualFrameRequest =
+        window.requestAnimationFrame(recordAnimationFrame);
+    };
+    globalWindow.__bitfunLongSessionVisualFrameRequest =
+      window.requestAnimationFrame(recordAnimationFrame);
+    globalWindow.__bitfunLongSessionVisualProbeTimers = [
+      500,
+      1_000,
+      2_000,
+      3_000,
+      5_000,
+      7_000,
+    ].map(delayMs => window.setTimeout(
+      () => recordVisualStateEvent(`probe-${delayMs}ms`, true),
+      Math.max(0, clickTime + delayMs - performance.now()),
+    ));
+    const mutationObserver = new MutationObserver(records => {
+      const relevant = records.some(record => {
+        if (record.type === 'attributes') {
+          const target = record.target as HTMLElement | null;
+          return Boolean(
+            target?.matches?.(OBSERVED_MUTATION_SELECTOR)
+          );
+        }
+        const nodes = [
+          ...Array.from(record.addedNodes),
+          ...Array.from(record.removedNodes),
+        ];
+        return nodes.some(node => {
+          if (!(node instanceof HTMLElement)) {
+            return false;
+          }
+          return Boolean(
+            node.matches?.(OBSERVED_MUTATION_SELECTOR) ||
+            node.querySelector?.(OBSERVED_MUTATION_SELECTOR)
+          );
+        });
+      });
+      if (relevant) {
+        recordMutationEvent('mutation');
+      }
+    });
+    mutationObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: [
+        'class',
+        'style',
+        'data-active-session-id',
+        'data-history-state',
+        'data-context-restore-state',
+        'data-is-partial',
+        'data-dialog-turn-count',
+        'data-virtual-item-count',
+        'data-show-history-placeholder',
+        'data-show-history-transition-overlay',
+        'data-show-history-loading-layer',
+        'data-show-history-open-intent-overlay',
+        'data-has-pending-history-completion',
+        'data-has-deferred-history-projection',
+        'data-latest-turn-id',
+        'data-history-initial-content-ready',
+        'data-pending-history-open-session-id',
+        'aria-busy',
+        'role',
+      ],
+    });
+    globalWindow.__bitfunLongSessionMutationObserver = mutationObserver;
     try {
       if (PerformanceObserver.supportedEntryTypes.includes('longtask')) {
         const observer = new PerformanceObserver(list => {
@@ -612,7 +2124,46 @@ async function startLongSessionViewportTimelineRecorder(
     } catch {
       globalWindow.__bitfunLongSessionLongTaskObserver = undefined;
     }
+    try {
+      if (PerformanceObserver.supportedEntryTypes.includes('layout-shift')) {
+        const observer = new PerformanceObserver(list => {
+          for (const entry of list.getEntries()) {
+            if (entry.startTime < clickTime) {
+              continue;
+            }
+            const layoutEntry = entry as PerformanceEntry & {
+              value?: number;
+              hadRecentInput?: boolean;
+              sources?: Array<{
+                node?: Node;
+                previousRect?: DOMRectReadOnly;
+                currentRect?: DOMRectReadOnly;
+              }>;
+            };
+            layoutShiftEvents.push({
+              startMs: entry.startTime,
+              sinceClickMs: entry.startTime - clickTime,
+              value: layoutEntry.value ?? 0,
+              hadRecentInput: layoutEntry.hadRecentInput === true,
+              sources: (layoutEntry.sources ?? []).slice(0, 6).map(source => ({
+                node: describeNode(source.node),
+                previousRect: rectSummary(source.previousRect as DOMRect | undefined),
+                currentRect: rectSummary(source.currentRect as DOMRect | undefined),
+              })),
+            });
+            if (layoutShiftEvents.length > 160) {
+              layoutShiftEvents.shift();
+            }
+          }
+        });
+        observer.observe({ type: 'layout-shift', buffered: true });
+        globalWindow.__bitfunLongSessionLayoutShiftObserver = observer;
+      }
+    } catch {
+      globalWindow.__bitfunLongSessionLayoutShiftObserver = undefined;
+    }
     const readSample = (): LongSessionViewportTimelineSample => {
+      const messages = document.querySelector<HTMLElement>('.modern-flowchat-container__messages');
       const root = document.querySelector<HTMLElement>(
         '.modern-flowchat-container__messages .virtual-message-list',
       );
@@ -636,11 +2187,24 @@ async function startLongSessionViewportTimelineRecorder(
         historyPlaceholderRect.height > 0 &&
         historyPlaceholderStyle?.visibility !== 'hidden' &&
         historyPlaceholderStyle?.display !== 'none' &&
-        historyPlaceholderStyle?.opacity !== '0'
+        isElementEffectivelyVisible(historyPlaceholder)
       );
       const effectiveScrollerBottom = scrollerRect
         ? Math.min(scrollerRect.bottom, inputOverlayRect?.top ?? scrollerRect.bottom)
         : null;
+      const historyPlaceholderCoversMessages = Boolean(
+        historyPlaceholderVisible &&
+        historyPlaceholderRect &&
+        (
+          !scrollerRect ||
+          (
+            historyPlaceholderRect.top <= scrollerRect.top + 4 &&
+            historyPlaceholderRect.bottom >= (effectiveScrollerBottom ?? scrollerRect.bottom) - 4 &&
+            historyPlaceholderRect.left <= scrollerRect.left + 4 &&
+            historyPlaceholderRect.right >= scrollerRect.right - 4
+          )
+        )
+      );
       const latest = targetTurnId
         ? root?.querySelector<HTMLElement>(
           `.virtual-item-wrapper[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
@@ -652,18 +2216,22 @@ async function startLongSessionViewportTimelineRecorder(
         ) ?? [])
         : [];
       const latestRect = latest?.getBoundingClientRect() ?? null;
-      const isVisibleWithinScroller = (rect: DOMRect | null): boolean => Boolean(
+      const isVisibleWithinScroller = (rect: DOMRect | null, element?: HTMLElement | null): boolean => Boolean(
         scrollerRect &&
         rect &&
+        (!element || isElementEffectivelyVisible(element)) &&
         rect.bottom > scrollerRect.top &&
         rect.top < (effectiveScrollerBottom ?? scrollerRect.bottom)
       );
       const latestModelRoundVisibleSegments = latestModelRoundSegments
-        .filter(element => isVisibleWithinScroller(element.getBoundingClientRect()));
+        .filter(element => isVisibleWithinScroller(element.getBoundingClientRect(), element));
       const latestModelRoundVisible = latestModelRoundVisibleSegments.length > 0;
       const latestModelRoundTextLength = latestModelRoundVisibleSegments
         .reduce((total, element) => total + (element.innerText?.length ?? 0), 0);
-      const latestVisible = isVisibleWithinScroller(latestRect);
+      const latestVisible = isVisibleWithinScroller(latestRect, latest);
+      const latestContentVisible = latestVisible || latestModelRoundVisible;
+      const latestContentVisuallyVisible =
+        latestContentVisible && !historyPlaceholderCoversMessages;
       const renderedItems = scrollerRect
         ? Array.from(root?.querySelectorAll<HTMLElement>('.virtual-item-wrapper[data-turn-id]') ?? [])
           .map(element => {
@@ -752,18 +2320,25 @@ async function startLongSessionViewportTimelineRecorder(
         ? Math.max(0, effectiveScrollerBottom - scrollerRect.top)
         : null;
       const atMs = performance.now();
+      const historyOpenIntentAtMs = globalWindow.__bitfunLongSessionOpenIntentAt ?? null;
 
       return {
         atMs,
         sinceClickMs: atMs - clickTime,
+        historyOpenIntentAtMs,
+        sinceHistoryOpenIntentMs: historyOpenIntentAtMs === null ? null : atMs - historyOpenIntentAtMs,
+        activeSessionId: messages?.dataset.activeSessionId || null,
+        pendingHistoryOpenSessionId: messages?.dataset.pendingHistoryOpenSessionId || null,
         hasRoot: Boolean(root),
         hasScroller: Boolean(scroller),
         latestRendered: Boolean(latest),
         latestModelRoundRendered: latestModelRoundSegments.length > 0,
         latestModelRoundVisible,
         latestModelRoundTextLength,
-        latestContentVisible: latestVisible || latestModelRoundVisible,
+        latestContentVisible,
         historyPlaceholderVisible,
+        historyPlaceholderCoversMessages,
+        latestContentVisuallyVisible,
         latestVisible,
         latestTurnId: latest?.dataset.turnId ?? targetTurnId ?? null,
         scrollTop: scroller?.scrollTop ?? null,
@@ -793,13 +2368,16 @@ async function startLongSessionViewportTimelineRecorder(
 
     const record = () => {
       samples.push(readSample());
-      if (samples.length > 120) {
+      if (samples.length > 1200) {
         samples.shift();
       }
     };
 
     globalWindow.__bitfunLongSessionViewportTimeline = samples;
     globalWindow.__bitfunLongSessionMainThreadTasks = mainThreadTasks;
+    globalWindow.__bitfunLongSessionMutationEvents = mutationEvents;
+    globalWindow.__bitfunLongSessionVisualStateEvents = visualStateEvents;
+    globalWindow.__bitfunLongSessionLayoutShiftEvents = layoutShiftEvents;
     record();
     globalWindow.__bitfunLongSessionViewportTimelineTimer = window.setInterval(record, 50);
   }, expectedLatestTurnId, clickedAtMs, enableRenderProfile);
@@ -810,22 +2388,65 @@ async function stopLongSessionViewportTimelineRecorder(): Promise<LongSessionVie
     const globalWindow = window as typeof window & {
       __bitfunLongSessionViewportTimeline?: LongSessionViewportTimelineSample[];
       __bitfunLongSessionMainThreadTasks?: LongSessionMainThreadTask[];
+      __bitfunLongSessionMutationEvents?: LongSessionDomMutationEvent[];
+      __bitfunLongSessionVisualStateEvents?: LongSessionVisualStateEvent[];
+      __bitfunLongSessionLayoutShiftEvents?: LongSessionLayoutShiftEvent[];
       __bitfunLongSessionViewportTimelineTimer?: number;
+      __bitfunLongSessionVisualFrameRequest?: number;
+      __bitfunLongSessionVisualProbeTimers?: number[];
       __bitfunLongSessionLongTaskObserver?: PerformanceObserver;
+      __bitfunLongSessionLayoutShiftObserver?: PerformanceObserver;
+      __bitfunLongSessionMutationObserver?: MutationObserver;
+      __bitfunLongSessionOpenIntentAt?: number;
+      __bitfunLongSessionOpenIntentHandler?: EventListener;
+      __bitfunLongSessionUserInteractionHandler?: EventListener;
       __BITFUN_RENDER_PROFILE_ENABLED__?: boolean;
     };
     if (globalWindow.__bitfunLongSessionViewportTimelineTimer !== undefined) {
       window.clearInterval(globalWindow.__bitfunLongSessionViewportTimelineTimer);
       globalWindow.__bitfunLongSessionViewportTimelineTimer = undefined;
     }
+    if (globalWindow.__bitfunLongSessionVisualFrameRequest !== undefined) {
+      window.cancelAnimationFrame(globalWindow.__bitfunLongSessionVisualFrameRequest);
+      globalWindow.__bitfunLongSessionVisualFrameRequest = undefined;
+    }
+    for (const timerId of globalWindow.__bitfunLongSessionVisualProbeTimers ?? []) {
+      window.clearTimeout(timerId);
+    }
+    globalWindow.__bitfunLongSessionVisualProbeTimers = undefined;
     globalWindow.__bitfunLongSessionLongTaskObserver?.disconnect();
     globalWindow.__bitfunLongSessionLongTaskObserver = undefined;
+    globalWindow.__bitfunLongSessionLayoutShiftObserver?.disconnect();
+    globalWindow.__bitfunLongSessionLayoutShiftObserver = undefined;
+    globalWindow.__bitfunLongSessionMutationObserver?.disconnect();
+    globalWindow.__bitfunLongSessionMutationObserver = undefined;
+    if (globalWindow.__bitfunLongSessionOpenIntentHandler) {
+      window.removeEventListener(
+        'flowchat:history-session-open-intent',
+        globalWindow.__bitfunLongSessionOpenIntentHandler,
+      );
+      globalWindow.__bitfunLongSessionOpenIntentHandler = undefined;
+    }
+    if (globalWindow.__bitfunLongSessionUserInteractionHandler) {
+      window.removeEventListener(
+        'bitfun:e2e-long-session-user-interaction',
+        globalWindow.__bitfunLongSessionUserInteractionHandler,
+      );
+      globalWindow.__bitfunLongSessionUserInteractionHandler = undefined;
+    }
+    globalWindow.__bitfunLongSessionOpenIntentAt = undefined;
     const samples = globalWindow.__bitfunLongSessionViewportTimeline ?? [];
     const mainThreadTasks = globalWindow.__bitfunLongSessionMainThreadTasks ?? [];
+    const mutationEvents = globalWindow.__bitfunLongSessionMutationEvents ?? [];
+    const visualStateEvents = globalWindow.__bitfunLongSessionVisualStateEvents ?? [];
+    const layoutShiftEvents = globalWindow.__bitfunLongSessionLayoutShiftEvents ?? [];
     globalWindow.__bitfunLongSessionViewportTimeline = undefined;
     globalWindow.__bitfunLongSessionMainThreadTasks = undefined;
+    globalWindow.__bitfunLongSessionMutationEvents = undefined;
+    globalWindow.__bitfunLongSessionVisualStateEvents = undefined;
+    globalWindow.__bitfunLongSessionLayoutShiftEvents = undefined;
     globalWindow.__BITFUN_RENDER_PROFILE_ENABLED__ = false;
-    return { samples, mainThreadTasks };
+    return { samples, mainThreadTasks, mutationEvents, visualStateEvents, layoutShiftEvents };
   });
 }
 
@@ -837,7 +2458,7 @@ async function waitForLatestLongSessionTurnVisible(timeoutMs: number, expectedLa
   try {
     await browser.waitUntil(async () => {
       viewport = await readLongSessionViewportState(expectedLatestTurnId);
-      return viewport.latestContentVisible;
+      return viewport.latestContentVisuallyVisible;
     }, {
       timeout: timeoutMs,
       interval: 50,
@@ -872,6 +2493,7 @@ function isLongSessionViewportUsable(viewport: LongSessionViewportState): boolea
   const largestBlankGapPx = viewport.largestBlankGapPx ?? Number.POSITIVE_INFINITY;
   return (
     viewport.latestContentVisible &&
+    viewport.latestContentVisuallyVisible &&
     viewport.latestModelRoundVisible &&
     viewport.latestModelRoundTextLength > 0 &&
     coverageRatio >= LONG_SESSION_VIEWPORT_MIN_COVERAGE_RATIO &&
@@ -885,7 +2507,7 @@ function isLongSessionLatestVisibleViewportPositioned(viewport: LongSessionViewp
   const bottomBlankPx = viewport.bottomBlankPx ?? Number.POSITIVE_INFINITY;
   const largestBlankGapPx = viewport.largestBlankGapPx ?? Number.POSITIVE_INFINITY;
   return (
-    viewport.latestContentVisible &&
+    viewport.latestContentVisuallyVisible &&
     coverageRatio >= LONG_SESSION_VIEWPORT_MIN_COVERAGE_RATIO &&
     bottomBlankPx <= LONG_SESSION_LATEST_VISIBLE_MAX_BOTTOM_BLANK_PX &&
     largestBlankGapPx <= LONG_SESSION_LATEST_VISIBLE_MAX_BLANK_GAP_PX
@@ -926,6 +2548,7 @@ function isLongSessionInputAnchoredNearBottom(viewport: LongSessionViewportState
 
 function summarizeLongSessionViewportTimeline(
   samples: LongSessionViewportTimelineSample[],
+  targetSessionId: string,
 ): LongSessionViewportTimelineSummary {
   const firstScroller = samples.find(sample => sample.hasScroller);
   const firstScrollerBlank = samples.find(sample =>
@@ -936,9 +2559,17 @@ function summarizeLongSessionViewportTimeline(
   const firstHistoryPlaceholder = samples.find(sample => sample.historyPlaceholderVisible);
   const firstLatestVisible = samples.find(sample => sample.latestVisible);
   const firstLatestContentVisible = samples.find(sample => sample.latestContentVisible);
+  const firstLatestContentVisuallyVisible = samples.find(sample =>
+    sample.latestContentVisuallyVisible
+  );
   const firstLatestTextVisible = samples.find(sample =>
+    sample.latestContentVisuallyVisible &&
     sample.latestModelRoundVisible &&
     sample.latestModelRoundTextLength > 0
+  );
+  const samplesAfterOpenIntent = samples.filter(sample =>
+    typeof sample.sinceHistoryOpenIntentMs === 'number' &&
+    sample.sinceHistoryOpenIntentMs >= 0
   );
   const latestVisibleTextlessSamples = samples.filter(sample =>
     sample.latestVisible &&
@@ -947,7 +2578,7 @@ function summarizeLongSessionViewportTimeline(
   );
   const firstLatestVisibleTextless = latestVisibleTextlessSamples[0];
   const latestContentVisibleTextlessSamples = samples.filter(sample =>
-    sample.latestContentVisible &&
+    sample.latestContentVisuallyVisible &&
       sample.latestModelRoundVisible &&
       sample.latestModelRoundTextLength === 0
   );
@@ -981,12 +2612,31 @@ function summarizeLongSessionViewportTimeline(
   const preLatestTextVisibleBottomBlanks = preLatestTextVisibleBlankSamples
     .map(sample => sample.bottomBlankPx)
     .filter((value): value is number => typeof value === 'number');
+  const preLatestTextVisibleUncoveredAfterIntentSamples = samplesAfterOpenIntent.filter(sample =>
+    (firstLatestTextVisible
+      ? sample.sinceClickMs < firstLatestTextVisible.sinceClickMs
+      : true) &&
+    sample.activeSessionId === targetSessionId &&
+    !sample.historyPlaceholderCoversMessages &&
+    !sample.latestContentVisuallyVisible &&
+    (
+      sample.visibleItemCount > 0 ||
+      sample.renderedItemCount > 0 ||
+      sample.visibleTextLength > 0
+    )
+  );
   const postLatestTextVisibleBlankSamples = firstLatestTextVisible
     ? samples.filter(sample =>
       sample.sinceClickMs > firstLatestTextVisible.sinceClickMs &&
       sample.hasRoot &&
       sample.hasScroller &&
       sample.visibleItemCount === 0
+    )
+    : [];
+  const postLatestTextVisibleCoveredSamples = firstLatestTextVisible
+    ? samples.filter(sample =>
+      sample.sinceClickMs > firstLatestTextVisible.sinceClickMs &&
+      sample.historyPlaceholderCoversMessages
     )
     : [];
   const postLatestTextVisibleBlankGaps = postLatestTextVisibleBlankSamples
@@ -1000,7 +2650,7 @@ function summarizeLongSessionViewportTimeline(
       sample.sinceClickMs > firstLatestTextVisible.sinceClickMs &&
       sample.hasRoot &&
       sample.hasScroller &&
-      !sample.latestContentVisible
+      !sample.latestContentVisuallyVisible
     )
     : [];
 
@@ -1011,6 +2661,7 @@ function summarizeLongSessionViewportTimeline(
     firstHistoryPlaceholderAtMs: firstHistoryPlaceholder?.sinceClickMs ?? null,
     firstLatestVisibleAtMs: firstLatestVisible?.sinceClickMs ?? null,
     firstLatestContentVisibleAtMs: firstLatestContentVisible?.sinceClickMs ?? null,
+    firstLatestContentVisuallyVisibleAtMs: firstLatestContentVisuallyVisible?.sinceClickMs ?? null,
     firstLatestTextVisibleAtMs: firstLatestTextVisible?.sinceClickMs ?? null,
     firstLatestVisibleTextlessAtMs: firstLatestVisibleTextless?.sinceClickMs ?? null,
     firstLatestContentVisibleTextlessAtMs: firstLatestContentVisibleTextless?.sinceClickMs ?? null,
@@ -1024,6 +2675,11 @@ function summarizeLongSessionViewportTimeline(
         ? firstLatestTextVisible.sinceClickMs - firstLatestContentVisible.sinceClickMs
         : null
     ),
+    latestTextDelayAfterContentVisuallyVisibleMs: (
+      firstLatestContentVisuallyVisible && firstLatestTextVisible
+        ? firstLatestTextVisible.sinceClickMs - firstLatestContentVisuallyVisible.sinceClickMs
+        : null
+    ),
     latestVisibleTextlessSampleCount: latestVisibleTextlessSamples.length,
     latestContentVisibleTextlessSampleCount: latestContentVisibleTextlessSamples.length,
     maxTextlessVisibleBlankGapPx: textlessBlankGaps.length > 0
@@ -1034,6 +2690,11 @@ function summarizeLongSessionViewportTimeline(
       : null,
     preLatestTextVisibleBlankSampleCount: preLatestTextVisibleBlankSamples.length,
     preLatestTextVisibleBlankWithoutPlaceholderSampleCount: preLatestTextVisibleBlankWithoutPlaceholderSamples.length,
+    preLatestTextVisibleUncoveredAfterIntentSampleCount: preLatestTextVisibleUncoveredAfterIntentSamples.length,
+    firstPreLatestTextVisibleUncoveredAfterIntentAtMs:
+      preLatestTextVisibleUncoveredAfterIntentSamples[0]?.sinceHistoryOpenIntentMs ??
+      preLatestTextVisibleUncoveredAfterIntentSamples[0]?.sinceClickMs ??
+      null,
     maxPreLatestTextVisibleBlankGapPx: preLatestTextVisibleBlankGaps.length > 0
       ? Math.max(...preLatestTextVisibleBlankGaps)
       : null,
@@ -1044,6 +2705,7 @@ function summarizeLongSessionViewportTimeline(
       ? Math.max(...preLatestTextVisibleBottomBlanks)
       : null,
     postLatestTextVisibleBlankSampleCount: postLatestTextVisibleBlankSamples.length,
+    postLatestTextVisibleCoveredSampleCount: postLatestTextVisibleCoveredSamples.length,
     maxPostLatestTextVisibleBlankGapPx: postLatestTextVisibleBlankGaps.length > 0
       ? Math.max(...postLatestTextVisibleBlankGaps)
       : null,
@@ -1051,6 +2713,558 @@ function summarizeLongSessionViewportTimeline(
       ? Math.max(...postLatestTextVisibleBottomBlanks)
       : null,
     postLatestTextVisibleLatestContentMissingSampleCount: postLatestTextVisibleLatestContentMissingSamples.length,
+  };
+}
+
+function summarizeLongSessionVisualStateEvents(
+  visualStateEvents: LongSessionVisualStateEvent[],
+  mutationEvents: LongSessionDomMutationEvent[],
+  layoutShiftEvents: LongSessionLayoutShiftEvent[],
+  viewportTimelineSummary: LongSessionViewportTimelineSummary,
+  sessionId: string,
+): LongSessionVisualStateSummary {
+  const firstLatestTextVisibleAtMs = viewportTimelineSummary.firstLatestTextVisibleAtMs;
+  const firstVisibleItemAtMs = viewportTimelineSummary.firstVisibleItemAtMs;
+  const isForcedVisualProbeEvent = (event: LongSessionVisualStateEvent): boolean =>
+    event.reason.startsWith('probe-');
+  const isUserInteractionVisualEvent = (event: LongSessionVisualStateEvent): boolean =>
+    event.reason.startsWith('user-interaction-');
+  const postLatestTextEvents = firstLatestTextVisibleAtMs === null
+    ? []
+    : visualStateEvents.filter(event => event.sinceClickMs > firstLatestTextVisibleAtMs);
+  const postLatestTextChangeEvents = postLatestTextEvents.filter(event => !isForcedVisualProbeEvent(event));
+  const firstUserInteractionEvent = visualStateEvents.find(event =>
+    event.reason.startsWith('user-interaction-') &&
+    !event.reason.includes('-probe-')
+  ) ?? null;
+  const firstUserInteractionAtMs = firstUserInteractionEvent?.sinceClickMs ?? null;
+  const postUserInteractionEvents = firstUserInteractionAtMs === null
+    ? []
+    : visualStateEvents.filter(event =>
+      event.sinceClickMs > firstUserInteractionAtMs &&
+      !isForcedVisualProbeEvent(event) &&
+      !isUserInteractionVisualEvent(event)
+    );
+  const postFirstVisibleItemEvents = firstVisibleItemAtMs === null
+    ? []
+    : visualStateEvents.filter(event => event.sinceClickMs > firstVisibleItemAtMs);
+  const postFirstVisibleItemChangeEvents = postFirstVisibleItemEvents.filter(event => !isForcedVisualProbeEvent(event));
+  const backgroundKey = (event: LongSessionVisualStateEvent): string => [
+    event.htmlBackground,
+    event.bodyBackground,
+    event.containerBackground,
+    event.messagesBackground,
+    event.overlayBackground,
+  ].join('|');
+  const arrayKey = (values: string[]): string => values.join('|');
+  const surfaceCategoryKey = (event: LongSessionVisualStateEvent): string =>
+    event.surfacePoints
+      .map(point => [
+        point.label,
+        point.category,
+        point.itemType,
+        point.latestTurnHit ? 'latest' : point.turnId,
+        point.effectiveOpacity,
+        Math.min(point.textLength, 9999),
+        point.modelRoundGroupCount,
+        point.modelRoundRenderedGroupCount,
+        point.modelRoundVisibleGroupStart,
+        point.modelRoundVisibleGroupEnd,
+        point.modelRoundRenderAll,
+        point.modelRoundHasDeferredEarlier,
+        point.modelRoundHasDeferredLater,
+        point.backgroundChain[0] ?? '',
+      ].join(':'))
+      .join('|');
+  const isLoadingVisualEvent = (event: LongSessionVisualStateEvent): boolean =>
+    event.showHistoryLoadingLayer === 'true' ||
+    event.overlayCount > 0 ||
+    event.placeholderCount > 0 ||
+    event.visibleLoadingSurfaceCount > 0;
+  const isLoadingSurfacePointEvent = (event: LongSessionVisualStateEvent): boolean =>
+    event.surfacePoints.some(point =>
+      point.category === 'history-overlay' ||
+      point.category === 'loading-surface'
+    );
+  const isBlankSurfacePointEvent = (event: LongSessionVisualStateEvent): boolean => {
+    if (event.surfacePoints.length === 0) {
+      return false;
+    }
+
+    const contentPointCount = event.surfacePoints.filter(point =>
+      point.category.startsWith('virtual-item:') &&
+      point.textLength > 0
+    ).length;
+    const blankPointCount = event.surfacePoints.filter(point =>
+      point.category === 'list-blank' ||
+      point.category === 'messages-blank' ||
+      point.category === 'flowchat-shell' ||
+      point.category === 'history-open-intent-shield' ||
+      point.category === 'missing'
+    ).length;
+    return contentPointCount === 0 && blankPointCount >= Math.ceil(event.surfacePoints.length * 0.6);
+  };
+  const isOpenIntentBlankSurfaceEvent = (event: LongSessionVisualStateEvent): boolean =>
+    event.sinceHistoryOpenIntentMs !== null &&
+    isBlankSurfacePointEvent(event) &&
+    event.surfacePoints.some(point => point.category === 'history-open-intent-shield');
+  const isTransparentSurfacePointEvent = (event: LongSessionVisualStateEvent): boolean =>
+    event.surfacePoints.some(point =>
+      point.category.startsWith('transparent-virtual-item:')
+    );
+  const isVisibleNonTargetContentEvent = (event: LongSessionVisualStateEvent): boolean =>
+    event.activeSessionId !== null &&
+    event.activeSessionId !== sessionId &&
+    event.pendingHistoryOpenSessionId !== sessionId &&
+    (
+      event.surfacePoints.some(point =>
+        point.category.startsWith('virtual-item:') &&
+        point.textLength > 0 &&
+        point.effectiveOpacity > 0.01
+      ) ||
+      (
+        !event.surfacePoints.some(point => point.category === 'history-open-intent-shield') &&
+        event.virtualItemDomCount > 0 &&
+        event.visibleTextLength > 0
+      )
+    );
+  const openIntentBlankSurfaceEvents = visualStateEvents.filter(isOpenIntentBlankSurfaceEvent);
+  const openIntentBlankSurfaceHolds = openIntentBlankSurfaceEvents
+    .map(event => {
+      const index = visualStateEvents.indexOf(event);
+      const nextEvent = visualStateEvents
+        .slice(index + 1)
+        .find(candidate => candidate.sinceHistoryOpenIntentMs !== null);
+      const untilHistoryOpenIntentMs = nextEvent?.sinceHistoryOpenIntentMs ?? event.sinceHistoryOpenIntentMs;
+      const holdAfterGraceMs = Math.max(
+        0,
+        untilHistoryOpenIntentMs - Math.max(event.sinceHistoryOpenIntentMs ?? 0, 50),
+      );
+      if (holdAfterGraceMs <= 0) {
+        return null;
+      }
+
+      return {
+        event,
+        untilHistoryOpenIntentMs,
+        holdAfterGraceMs,
+      };
+    })
+    .filter((entry): entry is {
+      event: LongSessionVisualStateEvent;
+      untilHistoryOpenIntentMs: number;
+      holdAfterGraceMs: number;
+    } => entry !== null);
+  const postOpenIntentNonTargetContentEvents = visualStateEvents.filter(event =>
+    event.sinceHistoryOpenIntentMs !== null &&
+    event.sinceHistoryOpenIntentMs > 100 &&
+    isVisibleNonTargetContentEvent(event)
+  );
+  const postOpenIntentNonTargetContentHolds = visualStateEvents
+    .map((event, index) => {
+      if (
+        event.sinceHistoryOpenIntentMs === null ||
+        event.sinceHistoryOpenIntentMs < 100 ||
+        !isVisibleNonTargetContentEvent(event)
+      ) {
+        return null;
+      }
+
+      const nextEvent = visualStateEvents
+        .slice(index + 1)
+        .find(candidate => candidate.sinceHistoryOpenIntentMs !== null);
+      const untilHistoryOpenIntentMs = nextEvent?.sinceHistoryOpenIntentMs ?? event.sinceHistoryOpenIntentMs;
+      const holdAfterGraceMs = Math.max(
+        0,
+        untilHistoryOpenIntentMs - Math.max(event.sinceHistoryOpenIntentMs, 100),
+      );
+      if (holdAfterGraceMs <= 0) {
+        return null;
+      }
+
+      return {
+        event,
+        untilHistoryOpenIntentMs,
+        holdAfterGraceMs,
+      };
+    })
+    .filter((entry): entry is {
+      event: LongSessionVisualStateEvent;
+      untilHistoryOpenIntentMs: number;
+      holdAfterGraceMs: number;
+    } => entry !== null);
+  const isHistoryInitialPreviewVisibleAt = (sinceClickMs: number): boolean => {
+    let nearest: LongSessionVisualStateEvent | null = null;
+    for (const event of visualStateEvents) {
+      if (event.sinceClickMs > sinceClickMs) {
+        break;
+      }
+      nearest = event;
+    }
+    return nearest?.historyInitialPreviewVisible === true;
+  };
+  const isHistoryProjectionHandoffVisibleAt = (sinceClickMs: number): boolean => {
+    let nearest: LongSessionVisualStateEvent | null = null;
+    for (const event of visualStateEvents) {
+      if (event.sinceClickMs > sinceClickMs) {
+        break;
+      }
+      nearest = event;
+    }
+    return nearest?.historyProjectionHandoffVisible === true;
+  };
+  const loadingEvents = visualStateEvents.filter(isLoadingVisualEvent);
+
+  let loadingLayerToggleCount = 0;
+  let overlayCountToggleCount = 0;
+  let placeholderCountToggleCount = 0;
+  let backgroundChangeCount = 0;
+  let scrollerScrollJumpCount = 0;
+  let scrollerSizeChangeCount = 0;
+  let postLatestTextVisibleBackgroundChangeCount = 0;
+  let postLatestTextVisibleScrollJumpCount = 0;
+  let postLatestTextVisibleVirtualItemElementChangeCount = 0;
+  let postLatestTextVisibleSurfaceChangeCount = 0;
+  let postUserInteractionScrollJumpCount = 0;
+  let postUserInteractionScrollerCollapseCount = 0;
+  let hasSeenTargetSession = false;
+  let historyInitialPreviewActivationAfterActiveSessionCount = 0;
+  const loadingTransitions: LongSessionVisualStateSummary['loadingTransitions'] = [];
+  const backgroundTransitions: LongSessionVisualStateSummary['backgroundTransitions'] = [];
+  const historyInitialPreviewTransitions: LongSessionVisualStateSummary['historyInitialPreviewTransitions'] = [];
+  const scrollTransitions: LongSessionVisualStateSummary['scrollTransitions'] = [];
+  const postUserInteractionScrollTransitions: LongSessionVisualStateSummary['postUserInteractionScrollTransitions'] = [];
+  const surfaceTransitions: LongSessionVisualStateSummary['surfaceTransitions'] = [];
+
+  for (let index = 1; index < visualStateEvents.length; index += 1) {
+    const previous = visualStateEvents[index - 1];
+    const current = visualStateEvents[index];
+    if (previous.activeSessionId === sessionId) {
+      hasSeenTargetSession = true;
+    }
+    if (
+      previous.historyInitialPreviewVisible !== current.historyInitialPreviewVisible &&
+      current.activeSessionId === sessionId
+    ) {
+      historyInitialPreviewTransitions.push({
+        sinceClickMs: current.sinceClickMs,
+        reason: current.reason,
+        from: previous.historyInitialPreviewVisible,
+        to: current.historyInitialPreviewVisible,
+      });
+      if (
+        hasSeenTargetSession &&
+        previous.historyInitialPreviewVisible === false &&
+        current.historyInitialPreviewVisible === true
+      ) {
+        historyInitialPreviewActivationAfterActiveSessionCount += 1;
+      }
+    }
+    if (current.activeSessionId === sessionId) {
+      hasSeenTargetSession = true;
+    }
+    const loadingChanged =
+      previous.showHistoryLoadingLayer !== current.showHistoryLoadingLayer ||
+      previous.overlayCount !== current.overlayCount ||
+      previous.placeholderCount !== current.placeholderCount;
+    if (previous.showHistoryLoadingLayer !== current.showHistoryLoadingLayer) {
+      loadingLayerToggleCount += 1;
+    }
+    if (previous.overlayCount !== current.overlayCount) {
+      overlayCountToggleCount += 1;
+    }
+    if (previous.placeholderCount !== current.placeholderCount) {
+      placeholderCountToggleCount += 1;
+    }
+    if (loadingChanged) {
+      loadingTransitions.push({
+        sinceClickMs: current.sinceClickMs,
+        reason: current.reason,
+        showHistoryLoadingLayer: current.showHistoryLoadingLayer,
+        overlayCount: current.overlayCount,
+        placeholderCount: current.placeholderCount,
+        visibleLoadingSurfaceCount: current.visibleLoadingSurfaceCount,
+        loadingSurfaces: current.loadingSurfaces.filter(surface => surface.visible).slice(0, 8),
+        virtualItemDomCount: current.virtualItemDomCount,
+        latestContentVisuallyVisible: current.latestContentVisuallyVisible,
+      });
+    }
+
+    const previousBackground = backgroundKey(previous);
+    const currentBackground = backgroundKey(current);
+    if (previousBackground !== currentBackground) {
+      backgroundChangeCount += 1;
+      if (
+        firstLatestTextVisibleAtMs !== null &&
+        current.sinceClickMs > firstLatestTextVisibleAtMs
+      ) {
+        postLatestTextVisibleBackgroundChangeCount += 1;
+      }
+      backgroundTransitions.push({
+        sinceClickMs: current.sinceClickMs,
+        reason: current.reason,
+        from: previousBackground,
+        to: currentBackground,
+      });
+    }
+
+    const previousSurface = surfaceCategoryKey(previous);
+    const currentSurface = surfaceCategoryKey(current);
+    if (previousSurface !== currentSurface) {
+      if (
+        firstLatestTextVisibleAtMs !== null &&
+        current.sinceClickMs > firstLatestTextVisibleAtMs &&
+        !previous.historyInitialPreviewVisible &&
+        !current.historyInitialPreviewVisible &&
+        !previous.historyProjectionHandoffVisible &&
+        !current.historyProjectionHandoffVisible &&
+        !isUserInteractionVisualEvent(current)
+      ) {
+        postLatestTextVisibleSurfaceChangeCount += 1;
+      }
+      surfaceTransitions.push({
+        sinceClickMs: current.sinceClickMs,
+        reason: current.reason,
+        from: previousSurface,
+        to: currentSurface,
+        surfacePoints: current.surfacePoints,
+      });
+    }
+
+    const scrollTopDelta = Math.abs((current.scrollTop ?? 0) - (previous.scrollTop ?? 0));
+    const scrollHeightDelta = Math.abs((current.scrollHeight ?? 0) - (previous.scrollHeight ?? 0));
+    const clientHeightDelta = Math.abs((current.clientHeight ?? 0) - (previous.clientHeight ?? 0));
+    const previousDistanceFromBottom =
+      previous.scrollTop === null || previous.scrollHeight === null || previous.clientHeight === null
+        ? null
+        : previous.scrollHeight - previous.clientHeight - previous.scrollTop;
+    const currentDistanceFromBottom =
+      current.scrollTop === null || current.scrollHeight === null || current.clientHeight === null
+        ? null
+        : current.scrollHeight - current.clientHeight - current.scrollTop;
+    const distanceFromBottomDelta =
+      previousDistanceFromBottom === null || currentDistanceFromBottom === null
+        ? scrollTopDelta
+        : Math.abs(currentDistanceFromBottom - previousDistanceFromBottom);
+    const hasScrollJump = scrollTopDelta > 32;
+    const hasVisualScrollJump = hasScrollJump && distanceFromBottomDelta > 32;
+    const hasSizeJump = scrollHeightDelta > 16 || clientHeightDelta > 16;
+    const isPostUserInteractionNonUserEvent =
+      firstUserInteractionAtMs !== null &&
+      current.sinceClickMs > firstUserInteractionAtMs &&
+      !isUserInteractionVisualEvent(current) &&
+      !isForcedVisualProbeEvent(current);
+    if (hasScrollJump) {
+      scrollerScrollJumpCount += 1;
+      if (
+        firstLatestTextVisibleAtMs !== null &&
+        current.sinceClickMs > firstLatestTextVisibleAtMs &&
+        hasVisualScrollJump &&
+        !previous.historyInitialPreviewVisible &&
+        !current.historyInitialPreviewVisible &&
+        !previous.historyProjectionHandoffVisible &&
+        !current.historyProjectionHandoffVisible &&
+        !isUserInteractionVisualEvent(current)
+      ) {
+        postLatestTextVisibleScrollJumpCount += 1;
+      }
+    }
+    if (isPostUserInteractionNonUserEvent && hasVisualScrollJump) {
+      postUserInteractionScrollJumpCount += 1;
+    }
+    if (
+      isPostUserInteractionNonUserEvent &&
+      previous.scrollHeight !== null &&
+      current.scrollHeight !== null &&
+      previous.scrollHeight - current.scrollHeight > Math.max(120, (previous.clientHeight ?? 0) * 0.5)
+    ) {
+      postUserInteractionScrollerCollapseCount += 1;
+    }
+    if (hasSizeJump) {
+      scrollerSizeChangeCount += 1;
+    }
+    if (hasScrollJump || hasSizeJump) {
+      scrollTransitions.push({
+        sinceClickMs: current.sinceClickMs,
+        reason: current.reason,
+        fromScrollTop: previous.scrollTop,
+        toScrollTop: current.scrollTop,
+        fromScrollHeight: previous.scrollHeight,
+        toScrollHeight: current.scrollHeight,
+        fromClientHeight: previous.clientHeight,
+        toClientHeight: current.clientHeight,
+        fromFooterHeight: previous.footerHeight,
+        toFooterHeight: current.footerHeight,
+        fromFooterStyleHeight: previous.footerStyleHeight,
+        toFooterStyleHeight: current.footerStyleHeight,
+      });
+      if (isPostUserInteractionNonUserEvent) {
+        postUserInteractionScrollTransitions.push({
+          sinceClickMs: current.sinceClickMs,
+          reason: current.reason,
+          fromScrollTop: previous.scrollTop,
+          toScrollTop: current.scrollTop,
+          fromScrollHeight: previous.scrollHeight,
+          toScrollHeight: current.scrollHeight,
+          fromClientHeight: previous.clientHeight,
+          toClientHeight: current.clientHeight,
+          fromFooterHeight: previous.footerHeight,
+          toFooterHeight: current.footerHeight,
+          fromFooterStyleHeight: previous.footerStyleHeight,
+          toFooterStyleHeight: current.footerStyleHeight,
+        });
+      }
+    }
+  }
+
+  let overlayElementIdChangeCount = 0;
+  let placeholderElementIdChangeCount = 0;
+  let virtualListElementIdChangeCount = 0;
+  let virtualItemElementIdChangeCount = 0;
+  const overlayElementTransitions: LongSessionVisualStateSummary['overlayElementTransitions'] = [];
+  const virtualItemElementTransitions: LongSessionVisualStateSummary['virtualItemElementTransitions'] = [];
+  for (let index = 1; index < mutationEvents.length; index += 1) {
+    const previous = mutationEvents[index - 1];
+    const current = mutationEvents[index];
+    const previousOverlayKey = arrayKey(previous.overlayElementIds);
+    const currentOverlayKey = arrayKey(current.overlayElementIds);
+    if (previousOverlayKey !== currentOverlayKey) {
+      overlayElementIdChangeCount += 1;
+      overlayElementTransitions.push({
+        sinceClickMs: current.sinceClickMs,
+        reason: current.reason,
+        from: previous.overlayElementIds,
+        to: current.overlayElementIds,
+      });
+    }
+    if (arrayKey(previous.placeholderElementIds) !== arrayKey(current.placeholderElementIds)) {
+      placeholderElementIdChangeCount += 1;
+    }
+    if (arrayKey(previous.virtualListElementIds) !== arrayKey(current.virtualListElementIds)) {
+      virtualListElementIdChangeCount += 1;
+    }
+    const previousVirtualItemKey = arrayKey(previous.virtualItemElementIds);
+    const currentVirtualItemKey = arrayKey(current.virtualItemElementIds);
+    if (previousVirtualItemKey !== currentVirtualItemKey) {
+      virtualItemElementIdChangeCount += 1;
+      if (
+        firstLatestTextVisibleAtMs !== null &&
+        current.sinceClickMs > firstLatestTextVisibleAtMs &&
+        !previous.historyInitialPreviewVisible &&
+        !current.historyInitialPreviewVisible &&
+        !previous.historyProjectionHandoffVisible &&
+        !current.historyProjectionHandoffVisible
+      ) {
+        postLatestTextVisibleVirtualItemElementChangeCount += 1;
+      }
+      virtualItemElementTransitions.push({
+        sinceClickMs: current.sinceClickMs,
+        reason: current.reason,
+        from: previous.virtualItemElementIds,
+        to: current.virtualItemElementIds,
+      });
+    }
+  }
+  const layoutShiftScore = layoutShiftEvents
+    .reduce((total, event) => total + event.value, 0);
+  const postLatestTextVisibleLayoutShiftEvents = firstLatestTextVisibleAtMs === null
+    ? []
+    : layoutShiftEvents.filter(event => (
+      event.sinceClickMs > firstLatestTextVisibleAtMs &&
+      !isHistoryInitialPreviewVisibleAt(event.sinceClickMs) &&
+      !isHistoryProjectionHandoffVisibleAt(event.sinceClickMs)
+    ));
+
+  return {
+    visualStateEventCount: visualStateEvents.length,
+    mutationEventCount: mutationEvents.length,
+    firstVisualStateAtMs: visualStateEvents[0]?.sinceClickMs ?? null,
+    firstLoadingLayerAtMs: loadingEvents[0]?.sinceClickMs ?? null,
+    lastLoadingLayerAtMs: loadingEvents[loadingEvents.length - 1]?.sinceClickMs ?? null,
+    historyInitialPreviewVisibleAtEnd:
+      visualStateEvents.findLast(event => event.activeSessionId === sessionId)?.historyInitialPreviewVisible === true,
+    historyProjectionHandoffVisibleAtEnd:
+      visualStateEvents.findLast(event => event.activeSessionId === sessionId)?.historyProjectionHandoffVisible === true,
+    historyInitialPreviewActivationAfterActiveSessionCount,
+    loadingLayerToggleCount,
+    overlayCountToggleCount,
+    placeholderCountToggleCount,
+    overlayElementIdChangeCount,
+    placeholderElementIdChangeCount,
+    virtualListElementIdChangeCount,
+    virtualItemElementIdChangeCount,
+    backgroundChangeCount,
+    scrollerScrollJumpCount,
+    scrollerSizeChangeCount,
+    layoutShiftCount: layoutShiftEvents.length,
+    layoutShiftScore,
+    postLatestTextVisibleVisualChangeCount: postLatestTextChangeEvents.length,
+    postLatestTextVisibleLoadingEventCount: postLatestTextEvents.filter(isLoadingVisualEvent).length,
+    postFirstVisibleItemVisualChangeCount: postFirstVisibleItemChangeEvents.length,
+    postFirstVisibleItemLoadingEventCount: postFirstVisibleItemEvents.filter(isLoadingVisualEvent).length,
+    postLatestTextVisibleBackgroundChangeCount,
+    postLatestTextVisibleScrollJumpCount,
+    postLatestTextVisibleVirtualItemElementChangeCount,
+    postLatestTextVisibleSurfaceChangeCount,
+    postLatestTextVisibleLoadingSurfacePointEventCount: postLatestTextEvents
+      .filter(isLoadingSurfacePointEvent).length,
+    postLatestTextVisibleBlankSurfacePointEventCount: postLatestTextEvents
+      .filter(isBlankSurfacePointEvent).length,
+    postLatestTextVisibleTransparentSurfacePointEventCount: postLatestTextEvents
+      .filter(isTransparentSurfacePointEvent).length,
+    postLatestTextVisibleLayoutShiftCount: postLatestTextVisibleLayoutShiftEvents.length,
+    postLatestTextVisibleLayoutShiftScore: postLatestTextVisibleLayoutShiftEvents
+      .reduce((total, event) => total + event.value, 0),
+    firstUserInteractionAtMs,
+    postUserInteractionScrollJumpCount,
+    postUserInteractionScrollerCollapseCount,
+    postUserInteractionBlankSurfacePointEventCount: postUserInteractionEvents
+      .filter(isBlankSurfacePointEvent).length,
+    openIntentBlankSurfacePointEventCount: openIntentBlankSurfaceEvents.length,
+    openIntentBlankSurfaceHoldCount: openIntentBlankSurfaceHolds.length,
+    maxOpenIntentBlankSurfaceHoldMs: openIntentBlankSurfaceHolds.length > 0
+      ? Math.max(...openIntentBlankSurfaceHolds.map(entry => entry.holdAfterGraceMs))
+      : null,
+    postOpenIntentNonTargetContentEventCount: postOpenIntentNonTargetContentEvents.length,
+    postOpenIntentNonTargetContentHoldCount: postOpenIntentNonTargetContentHolds.length,
+    maxPostOpenIntentNonTargetContentHoldMs: postOpenIntentNonTargetContentHolds.length > 0
+      ? Math.max(...postOpenIntentNonTargetContentHolds.map(entry => entry.holdAfterGraceMs))
+      : null,
+    lastPostOpenIntentNonTargetContentAtMs:
+      postOpenIntentNonTargetContentEvents.at(-1)?.sinceHistoryOpenIntentMs ?? null,
+    loadingTransitions: loadingTransitions.slice(0, 40),
+    backgroundTransitions: backgroundTransitions.slice(0, 40),
+    historyInitialPreviewTransitions: historyInitialPreviewTransitions.slice(0, 40),
+    overlayElementTransitions: overlayElementTransitions.slice(0, 40),
+    virtualItemElementTransitions: virtualItemElementTransitions.slice(0, 40),
+    surfaceTransitions: surfaceTransitions.slice(0, 80),
+    postOpenIntentNonTargetContentEvents: postOpenIntentNonTargetContentEvents
+      .slice(0, 40)
+      .map(event => ({
+        sinceClickMs: event.sinceClickMs,
+        sinceHistoryOpenIntentMs: event.sinceHistoryOpenIntentMs,
+        reason: event.reason,
+        activeSessionId: event.activeSessionId,
+        pendingHistoryOpenSessionId: event.pendingHistoryOpenSessionId,
+        virtualItemDomCount: event.virtualItemDomCount,
+        visibleTextLength: event.visibleTextLength,
+        surfacePoints: event.surfacePoints,
+      })),
+    postOpenIntentNonTargetContentHolds: postOpenIntentNonTargetContentHolds
+      .slice(0, 40)
+      .map(({ event, untilHistoryOpenIntentMs, holdAfterGraceMs }) => ({
+        sinceClickMs: event.sinceClickMs,
+        sinceHistoryOpenIntentMs: event.sinceHistoryOpenIntentMs,
+        untilHistoryOpenIntentMs,
+        holdAfterGraceMs,
+        reason: event.reason,
+        activeSessionId: event.activeSessionId,
+        virtualItemDomCount: event.virtualItemDomCount,
+        visibleTextLength: event.visibleTextLength,
+      })),
+    scrollTransitions: scrollTransitions.slice(0, 40),
+    postUserInteractionScrollTransitions: postUserInteractionScrollTransitions.slice(0, 20),
+    layoutShiftEvents: layoutShiftEvents.slice(0, 40),
   };
 }
 
@@ -1096,6 +3310,10 @@ type LongSessionOpenMeasurement = {
   sessionId: string;
   fixtureScenario: string | null;
   expectedLatestTurnId: string | null;
+  postVisibleInteraction: 'first-scroll' | null;
+  postVisibleObserveMs: number;
+  verboseTimelineReport: boolean;
+  traceWaitErrors: string[];
   clickedAtMs: number;
   sessionOpen: ReturnType<typeof summarizeSessionOpen>;
   latestVisibleAtMs: number;
@@ -1114,6 +3332,10 @@ type LongSessionOpenMeasurement = {
   viewportTimeline: LongSessionViewportTimelineSample[];
   viewportTimelineSummary: LongSessionViewportTimelineSummary;
   mainThreadTasks: LongSessionMainThreadTask[];
+  mutationEvents: LongSessionDomMutationEvent[];
+  visualStateEvents: LongSessionVisualStateEvent[];
+  layoutShiftEvents: LongSessionLayoutShiftEvent[];
+  visualStateSummary: LongSessionVisualStateSummary;
   screenshotPath: string | null;
   events: StartupTraceSnapshot['phases']['events'];
   apiSegments: ReturnType<typeof summarizeApiCommandSegments>;
@@ -1123,7 +3345,54 @@ type LongSessionOpenMeasurement = {
 
 type LongSessionOpenMeasurementOptions = {
   requireFrameTrace?: boolean;
+  expectNoHistoryLoadingAfterClick?: boolean;
+  postVisibleInteraction?: 'first-scroll';
 };
+
+function readPostVisibleInteractionOption(
+  options: LongSessionOpenMeasurementOptions,
+): 'first-scroll' | null {
+  const envValue = process.env.BITFUN_E2E_PERF_POST_VISIBLE_INTERACTION;
+  if (envValue === 'first-scroll') {
+    return envValue;
+  }
+  return options.postVisibleInteraction ?? null;
+}
+
+async function performLongSessionPostVisibleInteraction(interaction: 'first-scroll'): Promise<void> {
+  if (interaction !== 'first-scroll') {
+    return;
+  }
+
+  await browser.execute(() => {
+    const scroller = document.querySelector<HTMLElement>(
+      '.modern-flowchat-container__messages [data-virtuoso-scroller="true"], ' +
+      '.modern-flowchat-container__messages [data-virtuoso-scroller]',
+    );
+    if (!scroller) {
+      throw new Error('Could not find long-session scroller for first-scroll interaction');
+    }
+
+    const beforeScrollTop = scroller.scrollTop;
+    const deltaY = -Math.min(520, Math.max(160, scroller.clientHeight * 0.45));
+    scroller.dispatchEvent(new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+      deltaY,
+    }));
+    scroller.scrollTop = Math.max(0, beforeScrollTop + deltaY);
+    scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+    window.dispatchEvent(new CustomEvent('bitfun:e2e-long-session-user-interaction', {
+      detail: {
+        type: 'first-scroll',
+        beforeScrollTop,
+        afterScrollTop: scroller.scrollTop,
+        deltaY,
+      },
+    }));
+  });
+}
 
 async function collectLongSessionOpenMeasurement(
   sessionId: string,
@@ -1141,28 +3410,28 @@ async function collectLongSessionOpenMeasurement(
   }
   const fixtureScenario = await readLongSessionFixtureScenario(sessionId);
 
-  const beforeClickSnapshot = await readStartupTraceSnapshot();
-  const frameCountBefore = countPhase(
-    beforeClickSnapshot,
-    'historical_session_after_state_commit_frame',
-  );
-  const fullHydrateCountBefore = countPhase(
-    beforeClickSnapshot,
-    'historical_session_full_hydrate_end',
-  );
-  const fullHydrateFrameCountBefore = countPhase(
-    beforeClickSnapshot,
-    'historical_session_full_hydrate_after_state_commit_frame',
-  );
-  const latestAnchorAttemptCountBefore = countPhase(
-    beforeClickSnapshot,
-    'historical_session_latest_anchor_attempt',
-  );
   const requireFrameTrace = options.requireFrameTrace !== false;
   const afterFrameTimeoutMs = requireFrameTrace ? 20000 : 1000;
   const fullHydrateTimeoutMs = requireFrameTrace ? 10000 : 1000;
   const latestAnchorTimeoutMs = requireFrameTrace ? 5000 : 1000;
   const clickedAtMs = await readPerformanceNow();
+  const traceWaitErrors: string[] = [];
+  const waitForRequiredTracePhase = async (
+    phase: string,
+    timeoutMs: number,
+  ): Promise<StartupTraceSnapshot> => {
+    try {
+      return await waitForTracePhaseForSessionSince(
+        phase,
+        sessionId,
+        clickedAtMs,
+        timeoutMs,
+      );
+    } catch (error) {
+      traceWaitErrors.push(error instanceof Error ? error.message : String(error));
+      return readStartupTraceSnapshot();
+    }
+  };
   await startLongSessionViewportTimelineRecorder(
     expectedLatestTurnId,
     clickedAtMs,
@@ -1174,33 +3443,46 @@ async function collectLongSessionOpenMeasurement(
   const latestUsablePromise = waitForLatestLongSessionViewportUsable(5000, expectedLatestTurnId);
 
   const afterFrameSnapshot = requireFrameTrace
-    ? await waitForTracePhaseCount(
+    ? await waitForRequiredTracePhase(
       'historical_session_after_state_commit_frame',
-      frameCountBefore + 1,
       afterFrameTimeoutMs,
     )
-    : await waitForOptionalPhaseCount(
+    : await waitForOptionalTracePhaseForSessionSince(
       'historical_session_after_state_commit_frame',
-      frameCountBefore + 1,
+      sessionId,
+      clickedAtMs,
       afterFrameTimeoutMs,
     );
-  const afterFullSnapshot = await waitForOptionalPhaseCount(
+  const afterFullSnapshot = await waitForOptionalTracePhaseForSessionSince(
     'historical_session_full_hydrate_end',
-    fullHydrateCountBefore + 1,
+    sessionId,
+    clickedAtMs,
     fullHydrateTimeoutMs,
   );
-  const afterFullFrameSnapshot = await waitForOptionalPhaseCount(
+  const afterFullFrameSnapshot = await waitForOptionalTracePhaseForSessionSince(
     'historical_session_full_hydrate_after_state_commit_frame',
-    fullHydrateFrameCountBefore + 1,
-    fullHydrateTimeoutMs,
+    sessionId,
+    clickedAtMs,
+    Math.min(fullHydrateTimeoutMs, 1000),
   );
-  const afterAnchorSnapshot = await waitForOptionalPhaseCount(
+  const afterAnchorSnapshot = await waitForOptionalTracePhaseForSessionSince(
     'historical_session_latest_anchor_attempt',
-    latestAnchorAttemptCountBefore + 1,
+    sessionId,
+    clickedAtMs,
     latestAnchorTimeoutMs,
   );
   const latestVisible = await latestVisiblePromise;
   const latestUsable = await latestUsablePromise;
+  const postVisibleInteraction = readPostVisibleInteractionOption(options);
+  if (postVisibleInteraction) {
+    await performLongSessionPostVisibleInteraction(postVisibleInteraction);
+  }
+  const postVisibleObserveMs =
+    numericEnv('BITFUN_E2E_PERF_POST_VISIBLE_OBSERVE_MS') ?? DEFAULT_POST_VISIBLE_OBSERVE_MS;
+  const observeRemainingMs = latestUsable.usableAtMs + postVisibleObserveMs - await readPerformanceNow();
+  if (observeRemainingMs > 0) {
+    await browser.pause(Math.ceil(observeRemainingMs));
+  }
   let finalViewport = await readLongSessionViewportState(expectedLatestTurnId);
   let finalViewportCheckedAtMs = await readPerformanceNow();
   if (!isLongSessionViewportUsable(finalViewport)) {
@@ -1212,7 +3494,18 @@ async function collectLongSessionOpenMeasurement(
     finalViewportCheckedAtMs = finalUsable.usableAtMs;
   }
   const viewportTimeline = await stopLongSessionViewportTimelineRecorder();
-  const viewportTimelineSummary = summarizeLongSessionViewportTimeline(viewportTimeline.samples);
+  const viewportTimelineSummary = summarizeLongSessionViewportTimeline(
+    viewportTimeline.samples,
+    sessionId,
+  );
+  const visualStateSummary = summarizeLongSessionVisualStateEvents(
+    viewportTimeline.visualStateEvents,
+    viewportTimeline.mutationEvents,
+    viewportTimeline.layoutShiftEvents,
+    viewportTimelineSummary,
+    sessionId,
+  );
+  const verboseTimelineReport = process.env.BITFUN_E2E_PERF_VERBOSE_REPORT === '1';
   const finalSnapshot = await readStartupTraceSnapshot()
     .catch(() => [
       afterFrameSnapshot,
@@ -1225,7 +3518,10 @@ async function collectLongSessionOpenMeasurement(
   const sessionEvents = finalSnapshot.phases.events.filter(event =>
     event.atMs >= clickedAtMs &&
     (
-      event.phase.startsWith('historical_session') ||
+      (
+        event.phase.startsWith('historical_session') &&
+        traceEventSessionId(event) === sessionId
+      ) ||
       event.phase.startsWith('flowchat_latest_end_anchor') ||
       event.phase === 'react_render_profile'
     )
@@ -1237,6 +3533,10 @@ async function collectLongSessionOpenMeasurement(
     sessionId,
     fixtureScenario,
     expectedLatestTurnId,
+    postVisibleInteraction,
+    postVisibleObserveMs,
+    verboseTimelineReport,
+    traceWaitErrors,
     clickedAtMs,
     sessionOpen: summarizeSessionOpen(sessionEvents, clickedAtMs),
     latestVisibleAtMs: latestVisible.visibleAtMs,
@@ -1256,9 +3556,13 @@ async function collectLongSessionOpenMeasurement(
     latestUsableViewport: latestUsable.viewport,
     latestAnswerTextVisibleViewport: latestUsable.viewport,
     viewport: finalViewport,
-    viewportTimeline: viewportTimeline.samples,
+    viewportTimeline: verboseTimelineReport ? viewportTimeline.samples : [],
     viewportTimelineSummary,
-    mainThreadTasks: viewportTimeline.mainThreadTasks,
+    mainThreadTasks: verboseTimelineReport ? viewportTimeline.mainThreadTasks : [],
+    mutationEvents: verboseTimelineReport ? viewportTimeline.mutationEvents : [],
+    visualStateEvents: verboseTimelineReport ? viewportTimeline.visualStateEvents : [],
+    layoutShiftEvents: verboseTimelineReport ? viewportTimeline.layoutShiftEvents : [],
+    visualStateSummary,
     screenshotPath,
     events: sessionEvents,
     apiSegments: summarizeApiCommandSegments(finalSnapshot),
@@ -1274,34 +3578,69 @@ function expectLongSessionMeasurementUsable(
 ): void {
   expect(measurement.clickToLatestVisibleMs).toBeGreaterThan(0);
   expect(measurement.clickToLatestUsableMs).toBeGreaterThan(0);
-  if (options.requireFrameTrace !== false) {
+  if (options.requireFrameTrace !== false && measurement.traceWaitErrors.length === 0) {
     expect(measurement.clickToPostHydrateUsableMs).toBeGreaterThan(0);
   }
-  if (options.requireFrameTrace !== false) {
+  if (options.requireFrameTrace !== false && measurement.traceWaitErrors.length === 0) {
     expect(measurement.sessionOpen.hydrateDurationMs).toBeGreaterThan(0);
     expect(measurement.sessionOpen.latestFrameSinceHydrateMs).toBeGreaterThan(0);
     expect(measurement.sessionOpen.clickToLatestFrameMs).toBeGreaterThan(0);
   }
   expect(measurement.viewport.hasScroller).toBe(true);
   expect(measurement.viewport.latestContentVisible).toBe(true);
+  expect(measurement.viewport.latestContentVisuallyVisible).toBe(true);
+  expect(measurement.viewport.historyPlaceholderCoversMessages).toBe(false);
   expect(measurement.viewport.latestModelRoundVisible).toBe(true);
   expect(measurement.viewport.latestModelRoundTextLength).toBeGreaterThan(0);
   expect(measurement.viewport.latestTurnId).toBe(measurement.expectedLatestTurnId);
   expect(measurement.latestVisibleViewport.hasScroller).toBe(true);
   expect(measurement.latestVisibleViewport.latestContentVisible).toBe(true);
+  expect(measurement.latestVisibleViewport.latestContentVisuallyVisible).toBe(true);
+  expect(measurement.latestVisibleViewport.historyPlaceholderCoversMessages).toBe(false);
   expect(measurement.latestVisibleViewport.latestModelRoundVisible).toBe(true);
   expect(measurement.latestVisibleViewport.latestTurnId).toBe(measurement.expectedLatestTurnId);
   expect(isLongSessionLatestVisibleViewportPositioned(measurement.latestVisibleViewport)).toBe(true);
   expect(measurement.latestAnswerTextVisibleViewport.latestModelRoundVisible).toBe(true);
   expect(measurement.latestAnswerTextVisibleViewport.latestModelRoundTextLength).toBeGreaterThan(0);
   expect(isLongSessionViewportUsable(measurement.latestAnswerTextVisibleViewport)).toBe(true);
-  if (measurement.viewportTimelineSummary.latestTextDelayAfterContentVisibleMs !== null) {
-    expect(measurement.viewportTimelineSummary.latestTextDelayAfterContentVisibleMs)
+  if (measurement.viewportTimelineSummary.latestTextDelayAfterContentVisuallyVisibleMs !== null) {
+    expect(measurement.viewportTimelineSummary.latestTextDelayAfterContentVisuallyVisibleMs)
       .toBeLessThanOrEqual(LONG_SESSION_MAX_LATEST_TEXT_DELAY_AFTER_VISIBLE_MS);
   }
   expect(measurement.viewportTimelineSummary.preLatestTextVisibleBlankWithoutPlaceholderSampleCount).toBe(0);
+  expect(measurement.viewportTimelineSummary.preLatestTextVisibleUncoveredAfterIntentSampleCount).toBe(0);
   expect(measurement.viewportTimelineSummary.postLatestTextVisibleBlankSampleCount).toBe(0);
+  expect(measurement.viewportTimelineSummary.postLatestTextVisibleCoveredSampleCount).toBe(0);
   expect(measurement.viewportTimelineSummary.postLatestTextVisibleLatestContentMissingSampleCount).toBe(0);
+  if (options.expectNoHistoryLoadingAfterClick === true) {
+    expect(measurement.visualStateSummary.firstLoadingLayerAtMs).toBeNull();
+    expect(measurement.visualStateSummary.lastLoadingLayerAtMs).toBeNull();
+    expect(measurement.visualStateSummary.loadingLayerToggleCount).toBe(0);
+    expect(measurement.visualStateSummary.overlayCountToggleCount).toBe(0);
+    expect(measurement.visualStateSummary.placeholderCountToggleCount).toBe(0);
+    expect(measurement.visualStateSummary.postFirstVisibleItemLoadingEventCount).toBe(0);
+    expect(measurement.visualStateSummary.postLatestTextVisibleLoadingEventCount).toBe(0);
+    expect(measurement.visualStateSummary.postLatestTextVisibleLoadingSurfacePointEventCount).toBe(0);
+    expect(measurement.visualStateSummary.postLatestTextVisibleBlankSurfacePointEventCount).toBe(0);
+    expect(measurement.visualStateSummary.postLatestTextVisibleTransparentSurfacePointEventCount).toBe(0);
+    expect(measurement.visualStateSummary.postLatestTextVisibleScrollJumpCount).toBe(0);
+    expect(measurement.visualStateSummary.postLatestTextVisibleVirtualItemElementChangeCount).toBe(0);
+    expect(measurement.visualStateSummary.postLatestTextVisibleLayoutShiftScore).toBeLessThanOrEqual(0.005);
+    expect(measurement.visualStateSummary.openIntentBlankSurfacePointEventCount).toBe(0);
+    expect(measurement.visualStateSummary.openIntentBlankSurfaceHoldCount).toBe(0);
+    expect(measurement.visualStateSummary.postOpenIntentNonTargetContentEventCount).toBe(0);
+    expect(measurement.visualStateSummary.postOpenIntentNonTargetContentHoldCount).toBe(0);
+    expect(measurement.visualStateSummary.historyInitialPreviewActivationAfterActiveSessionCount).toBe(0);
+    expect(measurement.visualStateSummary.historyInitialPreviewVisibleAtEnd).toBe(false);
+    expect(measurement.visualStateSummary.loadingTransitions).toHaveLength(0);
+    if (measurement.postVisibleInteraction === 'first-scroll') {
+      expect(measurement.visualStateSummary.firstUserInteractionAtMs).not.toBeNull();
+      expect(measurement.visualStateSummary.postUserInteractionScrollJumpCount).toBe(0);
+      expect(measurement.visualStateSummary.postUserInteractionScrollerCollapseCount).toBe(0);
+      expect(measurement.visualStateSummary.postUserInteractionBlankSurfacePointEventCount).toBe(0);
+      expect(measurement.visualStateSummary.postUserInteractionScrollTransitions).toHaveLength(0);
+    }
+  }
   if (measurement.fixtureScenario === 'mixed-visible') {
     expect(measurement.latestVisibleViewport.visibleModelRoundCount).toBeGreaterThan(0);
   }
@@ -1383,7 +3722,10 @@ describe('Performance telemetry', () => {
     }));
 
     await writeReport('long-session-first-open', measurement);
-    expectLongSessionMeasurementUsable(measurement, maxLatestFrameMs, { requireFrameTrace: true });
+    expectLongSessionMeasurementUsable(measurement, maxLatestFrameMs, {
+      requireFrameTrace: true,
+      expectNoHistoryLoadingAfterClick: true,
+    });
   });
 
   it('collects warm-reopen timing for a generated long session', async function () {
@@ -1412,6 +3754,9 @@ describe('Performance telemetry', () => {
     }));
 
     await writeReport('long-session-warm-reopen', measurement);
-    expectLongSessionMeasurementUsable(measurement, maxLatestFrameMs, { requireFrameTrace: false });
+    expectLongSessionMeasurementUsable(measurement, maxLatestFrameMs, {
+      requireFrameTrace: false,
+      expectNoHistoryLoadingAfterClick: true,
+    });
   });
 });


### PR DESCRIPTION
﻿## 修改前后对比

Refs #949

测试口径：Windows desktop `release-fast` 性能 E2E，结论以用户场景端到端结果为准。下面的“可比对比样本”和“质量防护样本”不是同一个 fixture，不能横向比较数值。

### 可比对比样本

这组数据用于判断 issue 关键场景的端到端变化，`修改前` 使用 issue 创建期或最早可追溯的问题基线。

| 用户场景 | 修改前 | 修改后 | 变化 | 结论 |
| --- | ---: | ---: | ---: | --- |
| 冷启动到聊天主界面可操作 | 1538.9 ms | 1167.6 ms | -371.3 ms (-24.1%) | 较 issue 创建期有下降，但冷启动仍需继续优化 |
| 首次打开大历史 session，到最新正文可读 | 965.1 ms | 396.3 ms | -568.8 ms (-58.9%) | 有明确改善 |
| 首次打开大历史 session，到完整历史补齐 | 1118.1 ms | 765.1 ms | -353.0 ms (-31.6%) | 有改善，后台补齐仍可继续优化 |
| 再次打开大历史 session，到最新正文可读 | 457.7 ms | 320.5 ms | -137.2 ms (-30.0%) | 有改善 |

### 质量防护样本

这组数据来自更重的 120-turn dense fixture，只用于验证 loading 回闪、裸白和滚动回跳防护，不作为上表的性能 delta 依据。

| 防护场景 | 最新样本 |
| --- | ---: |
| 首次打开，到最新正文可用 | 1115.2 ms |
| 首次打开，到完整历史补齐 | 2882.8 ms |
| 再次打开，到最新正文可用 | 1202.3 ms |
| loading toggle | 0 |
| 滚动跳动 | 0 |
| 交互后裸白采样点 | 0 |

## 变更范围

- 历史 session 打开时先给出轻量点击反馈，避免从当前内容直接切到整页 loading 或空白状态。
- 本地大历史 session 先恢复可读尾部内容，最新正文可见后释放完整历史补齐，并在投影切换期间保留可见内容，降低白屏和滚动跳动风险。
- 收紧最新轮次锚定、虚拟列表估高和完成态 tool item 过渡，避免后台补齐引发二次布局跳变。
- Deferred IDE/MCP/ACP 和 main after-render 初始化现在等待 startup overlay 完成移交后再启动，避免和首屏移交窗口竞争。
- 虚拟列表文本估高改为基于 length 计算，避免为长文本估高额外分配重复字符串。
- 删除 session 或关闭 workspace 时同步取消 pending full-hydrate、清理 deferred projection 和 apply request，避免完整历史在内存中滞留。
- Windows 启动展示等待由固定 150 ms 改成最多 150 ms 的 maximize 状态等待；不改变关闭按钮默认语义。

## 风险与功能影响

- 历史 session 打开会增加最多两帧的可见反馈等待，用于让点击反馈先完成绘制。
- 完整历史内容仍可能晚于最新内容可读；搜索、滚动和明确需要完整历史的交互会触发完整投影。
- Deferred systems 更晚启动，可能让 IDE/MCP/ACP 的第一次使用更接近按需成本；这是为了避免抢占 startup overlay 移交和历史 session 首屏窗口。
- 冷启动仍未达到可关闭问题的程度，后续仍需要继续拆解 `interactive_shell_ready` 相关耗时。

## 验证

- `pnpm run lint:web`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/app/startup/startupPerformanceContract.test.ts src/app/startup/deferredStartupSystems.test.ts src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx src/flow_chat/store/FlowChatStore.test.ts`
- `pnpm --dir src/web-ui run test:run src/app/startup/deferredStartupSystems.test.ts src/app/startup/startupPerformanceContract.test.ts src/flow_chat/components/modern/VirtualMessageList.layout.test.ts`
- `pnpm --dir src/web-ui run test:run src/flow_chat/services/flow-chat-manager/SessionModule.test.ts src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx src/flow_chat/store/FlowChatStore.test.ts src/flow_chat/components/modern/VirtualMessageList.layout.test.ts src/flow_chat/components/modern/modelRoundItemGrouping.test.ts src/app/startup/startupPerformanceContract.test.ts`
- `cargo check -p bitfun-desktop`
- `git diff --check`
- `git diff --cached --check`
- `pnpm run desktop:build:release-fast`
- `BITFUN_E2E_PERF_SESSION_ID=perf-flicker-debug-000 pnpm run e2e:test:perf:release-fast`
