### PR TITLE
perf(web-ui): defer inactive session metadata startup

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -44,6 +44,15 @@ import { computeFixedPopoverPosition } from '@/shared/utils/fixedPopoverViewport
 import { sessionAPI } from '@/infrastructure/api/service-api/SessionAPI';
 import { confirmWarning } from '@/component-library/components/ConfirmDialog/confirmService';
 import ScheduledJobsModal from '@/app/components/scheduled-jobs/ScheduledJobsModal';
+import { scheduleAfterStartupPaint, scheduleAfterStartupSignal } from '@/shared/utils/startupTaskScheduling';
+import {
+  SESSION_METADATA_DEFERRED_FALLBACK_MS,
+  SESSION_METADATA_DEFERRED_FRAME_COUNT,
+  SESSION_METADATA_DEFERRED_SIGNAL,
+  getDeferredSessionMetadataDelayMs,
+  getInitialSessionMetadataLoadMode,
+  hasStartupOverlayHandedOff,
+} from './sessionMetadataStartup';
 import './SessionsSection.scss';
 
 /** Top-level parent sessions shown at each expand step (children still nest under visible parents). */
@@ -127,7 +136,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   workspacePath,
   remoteConnectionId = null,
   remoteSshHost = null,
-  isActiveWorkspace: _isActiveWorkspace = true,
+  isActiveWorkspace = true,
   assistantLabel,
   showSessionModeIcon = true,
   isVisible = true,
@@ -164,6 +173,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   const sessionMenuPopoverRef = useRef<HTMLDivElement>(null);
   const sessionMenuAnchorRef = useRef<HTMLButtonElement>(null);
   const metadataLoadRequestIdRef = useRef(0);
+  const initialMetadataLoadKeyRef = useRef<string | null>(null);
 
   // Subscribe to state machine changes for running status
   useEffect(() => {
@@ -203,6 +213,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
 
   useEffect(() => {
     metadataLoadRequestIdRef.current += 1;
+    initialMetadataLoadKeyRef.current = null;
     setExpandLevel(0);
     setMetadataPageState({
       totalTopLevelCount: null,
@@ -251,13 +262,98 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
     [workspacePath, remoteConnectionId, remoteSshHost]
   );
 
+  const initialMetadataKey = useMemo(
+    () => [
+      workspacePath ?? '',
+      remoteConnectionId ?? '',
+      remoteSshHost ?? '',
+    ].join('\n'),
+    [workspacePath, remoteConnectionId, remoteSshHost],
+  );
+
+  const loadInitialMetadataPage = useCallback(
+    async (source: string) => {
+      if (!workspacePath) {
+        return;
+      }
+      if (initialMetadataLoadKeyRef.current === initialMetadataKey) {
+        return;
+      }
+
+      initialMetadataLoadKeyRef.current = initialMetadataKey;
+      const page = await loadMetadataPage(SESSIONS_LEVEL_0, undefined, source);
+      if (!page && initialMetadataLoadKeyRef.current === initialMetadataKey) {
+        initialMetadataLoadKeyRef.current = null;
+      }
+    },
+    [initialMetadataKey, loadMetadataPage, workspacePath],
+  );
+
   useEffect(() => {
     if (!isVisible || !workspacePath) {
       return;
     }
 
-    void loadMetadataPage(SESSIONS_LEVEL_0, undefined, 'sessions_nav_initial');
-  }, [isVisible, workspacePath, remoteConnectionId, remoteSshHost, loadMetadataPage]);
+    const loadMode = getInitialSessionMetadataLoadMode({
+      hasWorkspacePath: Boolean(workspacePath),
+      isActiveWorkspace,
+      isVisible,
+      startupOverlayHandedOff: hasStartupOverlayHandedOff(),
+    });
+
+    if (loadMode === 'skip') {
+      return;
+    }
+
+    if (loadMode === 'immediate') {
+      void loadInitialMetadataPage('sessions_nav_initial_active');
+      return;
+    }
+
+    let cancelled = false;
+    let delayTimer: number | null = null;
+    const scheduleDeferredMetadataLoad = () => {
+      if (cancelled) {
+        return;
+      }
+      const delayMs = getDeferredSessionMetadataDelayMs(workspaceId ?? workspacePath);
+      const runDeferredLoad = () => {
+        delayTimer = null;
+        if (!cancelled) {
+          void loadInitialMetadataPage('sessions_nav_initial_deferred');
+        }
+      };
+
+      if (delayMs > 0) {
+        delayTimer = window.setTimeout(runDeferredLoad, delayMs);
+        return;
+      }
+      runDeferredLoad();
+    };
+    const cancelStartupSchedule = loadMode === 'after-startup-paint'
+      ? scheduleAfterStartupPaint(scheduleDeferredMetadataLoad, {
+          frameCount: SESSION_METADATA_DEFERRED_FRAME_COUNT,
+        })
+      : scheduleAfterStartupSignal(scheduleDeferredMetadataLoad, {
+          signalName: SESSION_METADATA_DEFERRED_SIGNAL,
+          fallbackTimeoutMs: SESSION_METADATA_DEFERRED_FALLBACK_MS,
+          frameCount: SESSION_METADATA_DEFERRED_FRAME_COUNT,
+        });
+
+    return () => {
+      cancelled = true;
+      cancelStartupSchedule();
+      if (delayTimer !== null) {
+        window.clearTimeout(delayTimer);
+      }
+    };
+  }, [
+    isActiveWorkspace,
+    isVisible,
+    loadInitialMetadataPage,
+    workspaceId,
+    workspacePath,
+  ]);
 
   useEffect(() => {
     if (!openMenuSessionId) return;
@@ -379,6 +475,12 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   const totalTopLevelSessionCount = metadataPageState.totalTopLevelCount ?? topLevelSessions.length;
   const hasMoreUnloadedSessions =
     metadataPageState.hasMore || topLevelSessions.length < totalTopLevelSessionCount;
+  const expandToggleAction =
+    expandLevel === 0
+      ? 'show-more'
+      : expandLevel === 1 && totalTopLevelSessionCount > SESSIONS_LEVEL_1
+        ? 'show-all'
+        : 'show-less';
 
   const visibleItems = useMemo(() => {
     const visibleParents = topLevelSessions.slice(0, sessionDisplayLimit);
@@ -961,6 +1063,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
           type="button"
           className={`bitfun-nav-panel__inline-toggle${metadataPageState.isLoading ? ' is-loading' : ''}`}
           data-testid="session-nav-show-more"
+          data-session-nav-toggle-action={expandToggleAction}
           disabled={metadataPageState.isLoading}
           onClick={() => { void handleExpandToggle(); }}
         >

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/sessionMetadataStartup.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/sessionMetadataStartup.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  SESSION_METADATA_DEFERRED_FALLBACK_MS,
+  SESSION_METADATA_DEFERRED_FRAME_COUNT,
+  SESSION_METADATA_DEFERRED_SIGNAL,
+  getDeferredSessionMetadataDelayMs,
+  getInitialSessionMetadataLoadMode,
+  hasStartupOverlayHandedOff,
+} from './sessionMetadataStartup';
+
+describe('session metadata startup scheduling', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('chooses the startup gate for each initial metadata load path', () => {
+    expect(getInitialSessionMetadataLoadMode({
+      hasWorkspacePath: false,
+      isActiveWorkspace: true,
+      isVisible: true,
+      startupOverlayHandedOff: false,
+    })).toBe('skip');
+
+    expect(getInitialSessionMetadataLoadMode({
+      hasWorkspacePath: true,
+      isActiveWorkspace: true,
+      isVisible: true,
+      startupOverlayHandedOff: false,
+    })).toBe('immediate');
+
+    expect(getInitialSessionMetadataLoadMode({
+      hasWorkspacePath: true,
+      isActiveWorkspace: false,
+      isVisible: true,
+      startupOverlayHandedOff: false,
+    })).toBe('after-startup-signal');
+
+    expect(getInitialSessionMetadataLoadMode({
+      hasWorkspacePath: true,
+      isActiveWorkspace: false,
+      isVisible: true,
+      startupOverlayHandedOff: true,
+    })).toBe('after-startup-paint');
+
+    expect(getInitialSessionMetadataLoadMode({
+      hasWorkspacePath: true,
+      isActiveWorkspace: false,
+      isVisible: false,
+      startupOverlayHandedOff: true,
+    })).toBe('skip');
+  });
+
+  it('keeps deferred metadata tied to the startup overlay handoff', () => {
+    expect(SESSION_METADATA_DEFERRED_SIGNAL).toBe('bitfun:startup-overlay-hidden');
+    expect(SESSION_METADATA_DEFERRED_FALLBACK_MS).toBe(10000);
+    expect(SESSION_METADATA_DEFERRED_FRAME_COUNT).toBe(1);
+  });
+
+  it('uses a stable bounded stagger for background workspace metadata', () => {
+    const first = getDeferredSessionMetadataDelayMs('D:\\workspace\\BitFun');
+    const second = getDeferredSessionMetadataDelayMs('D:\\workspace\\BitFun');
+    const other = getDeferredSessionMetadataDelayMs('D:\\workspace\\Other');
+
+    expect(first).toBe(second);
+    expect(first).toBeGreaterThanOrEqual(0);
+    expect(first).toBeLessThanOrEqual(120);
+    expect(other).toBeGreaterThanOrEqual(0);
+    expect(other).toBeLessThanOrEqual(120);
+    expect(getDeferredSessionMetadataDelayMs()).toBe(0);
+  });
+
+  it('detects when a late-mounted section has already missed the overlay handoff event', () => {
+    vi.stubGlobal('document', {
+      getElementById: vi.fn(() => ({})),
+    });
+    expect(hasStartupOverlayHandedOff()).toBe(false);
+
+    vi.stubGlobal('document', {
+      getElementById: vi.fn(() => null),
+    });
+    expect(hasStartupOverlayHandedOff()).toBe(true);
+  });
+});

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/sessionMetadataStartup.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/sessionMetadataStartup.ts
@@ -1,0 +1,55 @@
+import { STARTUP_OVERLAY_HIDDEN_EVENT } from '@/app/startup/startupSignals';
+import { isStartupOverlayPresent } from '@/app/startup/startupOverlay';
+
+export const SESSION_METADATA_DEFERRED_SIGNAL = STARTUP_OVERLAY_HIDDEN_EVENT;
+export const SESSION_METADATA_DEFERRED_FALLBACK_MS = 10000;
+export const SESSION_METADATA_DEFERRED_FRAME_COUNT = 1;
+
+export type InitialSessionMetadataLoadMode =
+  | 'skip'
+  | 'immediate'
+  | 'after-startup-signal'
+  | 'after-startup-paint';
+
+export function getInitialSessionMetadataLoadMode({
+  hasWorkspacePath,
+  isActiveWorkspace,
+  isVisible,
+  startupOverlayHandedOff,
+}: {
+  hasWorkspacePath: boolean;
+  isActiveWorkspace: boolean;
+  isVisible: boolean;
+  startupOverlayHandedOff: boolean;
+}): InitialSessionMetadataLoadMode {
+  if (!hasWorkspacePath || !isVisible) {
+    return 'skip';
+  }
+
+  if (isActiveWorkspace) {
+    return 'immediate';
+  }
+
+  return startupOverlayHandedOff ? 'after-startup-paint' : 'after-startup-signal';
+}
+
+export function getDeferredSessionMetadataDelayMs(workspaceKey?: string | null): number {
+  const normalized = workspaceKey?.trim();
+  if (!normalized) {
+    return 0;
+  }
+
+  let hash = 0;
+  for (let index = 0; index < normalized.length; index += 1) {
+    hash = (hash * 31 + normalized.charCodeAt(index)) >>> 0;
+  }
+
+  return (hash % 4) * 40;
+}
+
+export function hasStartupOverlayHandedOff(): boolean {
+  if (typeof document === 'undefined') {
+    return true;
+  }
+  return !isStartupOverlayPresent();
+}

--- a/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
+++ b/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
@@ -234,6 +234,23 @@ describe('startup performance contract', () => {
     expect(getSource).not.toContain('restore_session');
   });
 
+  it('keeps non-active workspace session metadata out of the first startup window', () => {
+    const source = readSource('../../app/components/NavPanel/sections/sessions/SessionsSection.tsx');
+
+    expect(source).toContain('isActiveWorkspace = true');
+    expect(source).not.toContain('isActiveWorkspace: _isActiveWorkspace');
+    expect(source).toContain('getInitialSessionMetadataLoadMode');
+    expect(source).toContain("loadMode === 'immediate'");
+    expect(source).toContain("loadMode === 'after-startup-paint'");
+    expect(source).toContain('scheduleAfterStartupSignal');
+    expect(source).toContain('scheduleAfterStartupPaint');
+    expect(source).toContain('hasStartupOverlayHandedOff');
+    expect(source).toContain('SESSION_METADATA_DEFERRED_SIGNAL');
+    expect(source).toContain('sessions_nav_initial_active');
+    expect(source).toContain('sessions_nav_initial_deferred');
+    expect(source).toContain('data-session-nav-toggle-action');
+  });
+
   it('keeps Git diff editor from importing the broad editor barrel', () => {
     const source = readSource('../../tools/git/components/GitDiffEditor/GitDiffEditor.tsx');
 

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -603,43 +603,93 @@ async function waitForOptionalTracePhaseForSessionSince(
 }
 
 async function findSessionItem(sessionId: string): Promise<ReturnType<typeof $> | null> {
-  let lastVisibleSessionIds: string[] = [];
-  for (let attempt = 0; attempt < 40; attempt += 1) {
-    const item = await $(`[data-testid="session-nav-item"][data-session-id="${sessionId}"]`);
-    if (await item.isExisting()) {
-      return item;
-    }
-
-    lastVisibleSessionIds = await browser.execute(() =>
+  const readVisibleSessionIds = async (): Promise<string[]> =>
+    browser.execute(() =>
       Array.from(document.querySelectorAll('[data-testid="session-nav-item"]'))
         .map(element => element.getAttribute('data-session-id') || '')
         .filter(Boolean)
     );
-    const showMore = await $('[data-testid="session-nav-show-more"]');
-    if (!(await showMore.isExisting()) || !(await showMore.isEnabled())) {
+
+  const findTarget = async (): Promise<ReturnType<typeof $> | null> => {
+    const item = await $(`[data-testid="session-nav-item"][data-session-id="${sessionId}"]`);
+    return await item.isExisting() ? item : null;
+  };
+
+  const findExpandableToggles = async (): Promise<Array<ReturnType<typeof $>>> => {
+    const toggles = await browser.$$('[data-testid="session-nav-show-more"]');
+    const expandable: Array<ReturnType<typeof $>> = [];
+    for (const toggle of toggles) {
+      if (
+        !(await toggle.isExisting()) ||
+        !(await toggle.isDisplayed()) ||
+        !(await toggle.isEnabled())
+      ) {
+        continue;
+      }
+
+      const action = await toggle.getAttribute('data-session-nav-toggle-action').catch(() => null);
+      if (action === 'show-less') {
+        continue;
+      }
+      expandable.push(toggle);
+    }
+    return expandable;
+  };
+
+  let lastVisibleSessionIds: string[] = [];
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    const existing = await findTarget();
+    if (existing) {
+      return existing;
+    }
+
+    lastVisibleSessionIds = await readVisibleSessionIds();
+    const toggles = await findExpandableToggles();
+    if (toggles.length === 0) {
       break;
     }
 
-    const beforeCount = lastVisibleSessionIds.length;
-    await showMore.click();
-    await browser.waitUntil(async () => {
-      const ids = await browser.execute(() =>
-        Array.from(document.querySelectorAll('[data-testid="session-nav-item"]'))
-          .map(element => element.getAttribute('data-session-id') || '')
-          .filter(Boolean)
-      );
-      const toggle = await $('[data-testid="session-nav-show-more"]');
-      const toggleReady = !(await toggle.isExisting()) || (await toggle.isEnabled());
-      return ids.length !== beforeCount && toggleReady;
-    }, { timeout: 3000, interval: 100 }).catch(() => undefined);
+    let clickedAny = false;
+    for (let toggleIndex = 0; toggleIndex < toggles.length; toggleIndex += 1) {
+      const item = await findTarget();
+      if (item) {
+        return item;
+      }
 
-    const currentVisibleSessionIds = await browser.execute(() =>
-      Array.from(document.querySelectorAll('[data-testid="session-nav-item"]'))
-        .map(element => element.getAttribute('data-session-id') || '')
-        .filter(Boolean)
-    );
-    if (currentVisibleSessionIds.length <= beforeCount && attempt > 0) {
-      lastVisibleSessionIds = currentVisibleSessionIds;
+      const currentToggles = await findExpandableToggles();
+      const toggle = currentToggles[toggleIndex];
+      if (!toggle) {
+        break;
+      }
+
+      if (
+        !(await toggle.isExisting()) ||
+        !(await toggle.isDisplayed()) ||
+        !(await toggle.isEnabled())
+      ) {
+        continue;
+      }
+
+      const action = await toggle.getAttribute('data-session-nav-toggle-action').catch(() => null);
+      if (action === 'show-less') {
+        continue;
+      }
+
+      const beforeCount = lastVisibleSessionIds.length;
+      clickedAny = true;
+      await toggle.click();
+      await browser.waitUntil(async () => {
+        if (await findTarget()) {
+          return true;
+        }
+        const ids = await readVisibleSessionIds();
+        const nextToggles = await findExpandableToggles();
+        return ids.length !== beforeCount || nextToggles.length !== toggles.length;
+      }, { timeout: 3000, interval: 100 }).catch(() => undefined);
+      lastVisibleSessionIds = await readVisibleSessionIds();
+    }
+
+    if (!clickedAny) {
       break;
     }
   }


### PR DESCRIPTION
## Summary

- Load initial session metadata immediately only for the visible active workspace during startup.
- Defer non-active workspace session metadata until the startup overlay handoff, with a bounded 0-120 ms stagger and a late-mount next-paint path so sections do not wait for the 10 s fallback after the overlay event has already fired.
- Make the performance E2E session lookup expand the relevant visible session sections without clicking `show less`, so older perf fixtures remain reachable in multi-workspace nav state.

Refs #949

## Performance data

Environment: Windows desktop `release-fast` performance E2E on the same local workspace. Current-PR before sample is the pre-change run on `gcwing/main`/this branch base; after samples are the latest three current-commit release-fast runs.

| Scenario | Before current PR | After current PR | Change |
| --- | ---: | ---: | ---: |
| Cold startup to `interactive_shell_ready` | 997.1 ms | 817.5 ms median | -179.6 ms (-18.0%) |
| Main-window-shown to interactive | 165.6 ms | 142.2 ms median | -23.4 ms (-14.1%) |
| Before-interactive API total duration | 930.9 ms | 426.6 ms median | -504.3 ms (-54.2%) |
| Before-interactive `list_persisted_sessions_page` calls | 5 calls | 1 call in all latest samples | -4 calls |

Large-session opening is kept as a regression guard in this PR, not claimed as the main optimization target because the product change is startup metadata scheduling. Latest current-commit guard results:

| Scenario | Latest current-commit result | Notes |
| --- | ---: | --- |
| First open large history session, latest text readable | 377.3 ms median | Latest 3 range: 308.9-662.6 ms; the 662.6 ms sample is retained as an outlier to keep investigating. |
| First open large history session, full history hydrated | 1198.7 ms median | This remains a residual issue and is tracked in #949. |
| Warm reopen large history session, latest text readable | 262.4 ms median | Latest 3 range: 259.1-306.1 ms. |
| Loading / blank guard while opening large history session | loading toggles=0, blank samples=0 | Latest samples still record one pre-interaction scroll stabilization event. |

## Risk and behavior impact

- Current active workspace behavior is preserved: its visible session metadata still loads immediately.
- Non-active visible workspace sections now load metadata after startup overlay handoff. This can delay non-active session rows by one paint plus at most 120 ms after first screen handoff, but avoids putting every workspace metadata page into the startup critical window.
- Existing workspace collapse behavior is not changed; this PR does not collapse older workspaces.
- Remote workspace parameters continue to flow through the existing metadata API call; this PR only changes when the initial call is scheduled.
- The new E2E `data-session-nav-toggle-action` attribute is test-only metadata on the existing show-more button and does not change the user-visible control.

## Verification

- `pnpm --dir src/web-ui run test:run src/app/startup/startupPerformanceContract.test.ts src/app/components/NavPanel/sections/sessions/sessionMetadataStartup.test.ts`
- `pnpm run type-check:web`
- `pnpm run check:repo-hygiene`
- `pnpm run desktop:build:release-fast`
- `pnpm run e2e:test:perf:release-fast`