### PR TITLE
fix(chat): prevent scroll compensation ratchet causing huge white space

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -1865,9 +1865,18 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
         isFollowingOutputRef.current &&
         isStreamingOutputRef.current &&
         !hasRecentUserUpwardIntent &&
-        !anchorLockRef.current.active
+        !anchorLockRef.current.active &&
+        layoutTransitionCountRef.current === 0
       ) {
-        const clampAmount = -intentCheckScrollDelta;
+        // Cap the clamp amount to what the footer actually needs.  Without
+        // this, repeated scroll-clamp events during CSS transitions can
+        // ratchet `collapse.px` upward without bound because the
+        // consumption path is blocked while transitions are active.
+        const rawClampAmount = -intentCheckScrollDelta;
+        const maxClampAmount = Math.max(0,
+          scrollerElement.scrollHeight - scrollerElement.clientHeight - scrollerElement.scrollTop,
+        );
+        const clampAmount = Math.min(rawClampAmount, maxClampAmount);
         const baseState = bottomReservationStateRef.current;
         const nextReservationState: BottomReservationState = {
           ...baseState,

--- a/src/web-ui/src/flow_chat/utils/flowChatScrollLayout.ts
+++ b/src/web-ui/src/flow_chat/utils/flowChatScrollLayout.ts
@@ -13,22 +13,40 @@ export const FLOWCHAT_MESSAGE_TAIL_CLEARANCE_PX = 24;
 export const SCROLL_TO_LATEST_INPUT_CLEARANCE_PX = 6;
 
 const FALLBACK_INPUT_BLOCK_ACTIVE_PX = 96;
-const FALLBACK_INPUT_BLOCK_COLLAPSED_PX = 54;
 const NORMAL_INPUT_BLOCK_SAFE_PX = 96;
 
 /**
  * Height of the Virtuoso footer spacer needed so the last message clears the floating input.
  * `measuredInputHeight` is the drop-zone `offsetHeight` from ChatInput (excluding the viewport bottom inset in `CHAT_INPUT_DROP_ZONE_BOTTOM_PX`).
+ *
+ * When `isInputActive` transitions from `true` to `false` (user sends a message,
+ * input collapses to capsule), the ResizeObserver on the drop-zone fires with the
+ * *new* collapsed height on the same microtask. If we use that new height
+ * immediately, the Virtuoso footer shrinks by ~40 px in one frame, the browser
+ * clamps `scrollTop` downward, and the viewport briefly shows blank space at the
+ * top ("white screen"). The user must scroll up to see content again.
+ *
+ * To avoid this, when the input is *not* active we ignore the measured height
+ * and use the active fallback instead. The footer stays large enough to cover
+ * the active input block until the next turn's content grows past it, at which
+ * point the footer reservation is consumed organically by the grow branch of
+ * `measureHeightChange`. The visual cost is a few extra pixels of blank tail
+ * space at the bottom — invisible to the user.
  */
 export function computeFlowChatInputStackFooterPx(
   measuredInputHeight: number,
   isInputActive: boolean,
 ): number {
-  const measuredInputBlock = measuredInputHeight > 0
+  // When the input is collapsed, always use the active fallback so the footer
+  // does not shrink on the same frame as the input collapse transition. This
+  // prevents a scrollTop clamp that would push the viewport above the content.
+  const effectiveInputHeight = isInputActive
     ? measuredInputHeight
-    : isInputActive
-      ? FALLBACK_INPUT_BLOCK_ACTIVE_PX
-      : FALLBACK_INPUT_BLOCK_COLLAPSED_PX;
+    : FALLBACK_INPUT_BLOCK_ACTIVE_PX;
+
+  const measuredInputBlock = effectiveInputHeight > 0
+    ? effectiveInputHeight
+    : FALLBACK_INPUT_BLOCK_ACTIVE_PX;
   const inputBlock = Math.max(measuredInputBlock, NORMAL_INPUT_BLOCK_SAFE_PX);
   return inputBlock + CHAT_INPUT_DROP_ZONE_BOTTOM_PX + FLOWCHAT_MESSAGE_TAIL_CLEARANCE_PX;
 }


### PR DESCRIPTION
### 问题

1. **长会话滚动条爆炸** — 随着工具卡片折叠，滚动条高度远超实际内容，底部出现巨大空白区域
2. **第二轮白屏** — 发送消息后输入框折叠，视口短暂白屏，需向上滚动才能看到内容

### 原因

- **问题1**：`handleScroll` 中的 scroll-clamp restore 在 CSS transition 期间持续增加 `collapse.px` 补偿，但消费路径在 transition 期间被阻断，补偿只增不减，随会话增长不断累积
- **问题2**：输入框折叠时 ResizeObserver 立即报告新高度，footer 骤缩导致 scrollTop 被浏览器钳位

### 修复

- `VirtualMessageList.tsx`：scroll-clamp restore 增加 `layoutTransitionCountRef === 0` 守卫和补偿量上限
- `flowChatScrollLayout.ts`：输入框折叠时使用固定回退高度，避免 footer 在折叠帧缩小

### 验证

- lint / type-check 通过
- 长会话多次工具卡片折叠后滚动条高度正常，无白屏累积
- 第二轮发送消息后无白屏闪烁