### PR TITLE
perf: reduce unnecessary re-renders and serialization in nav and logging

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/components/NavItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/NavItem.tsx
@@ -123,4 +123,4 @@ const NavItem: React.FC<NavItemProps> = ({
   );
 };
 
-export default NavItem;
+export default React.memo(NavItem);

--- a/src/web-ui/src/app/components/NavPanel/components/SectionHeader.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/SectionHeader.tsx
@@ -78,4 +78,4 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   );
 };
 
-export default SectionHeader;
+export default React.memo(SectionHeader);

--- a/src/web-ui/src/shared/utils/logger.ts
+++ b/src/web-ui/src/shared/utils/logger.ts
@@ -76,6 +76,17 @@ function formatConsoleArgs(args: unknown[]): string {
   return args.map(formatConsoleArg).join(' ');
 }
 
+const CONSOLE_KIND_LEVEL: Record<string, LogLevel> = {
+  trace: LogLevel.TRACE,
+  debug: LogLevel.DEBUG,
+  log: LogLevel.INFO,
+  info: LogLevel.INFO,
+  warn: LogLevel.WARN,
+  error: LogLevel.ERROR,
+};
+
+let consoleForwardMinLevel: LogLevel = isTauri && !isDev ? LogLevel.WARN : LogLevel.TRACE;
+
 /**
  * Patch `console.*` so messages also go through `tauri_plugin_log` (webview target → webview.log).
  */
@@ -98,6 +109,7 @@ function installWebviewConsoleForward(): void {
     kind: 'log' | 'debug' | 'info' | 'warn' | 'error' | 'trace',
     args: unknown[]
   ) => {
+    if ((CONSOLE_KIND_LEVEL[kind] ?? LogLevel.INFO) < consoleForwardMinLevel) return;
     const msg = `[console] ${formatConsoleArgs(args)}`;
     switch (kind) {
       case 'log':
@@ -267,6 +279,9 @@ export class Logger {
 
   public setLevel(level: LogLevel): void {
     this.currentLevel = level;
+    if (level > consoleForwardMinLevel) {
+      consoleForwardMinLevel = level;
+    }
   }
 
   public getLevel(): LogLevel {


### PR DESCRIPTION
 **问题：** NavItem 和 SectionHeader 是纯展示组件，未用 React.memo 包裹，父组件渲染时 20+ 个列表项全部跟随渲染。日志模块的 console 转发路径在所有 console 调用时先 JSON.stringify 参数再判断 Level，生产环境 WARN 级别下大量 log/debug 调用白白做了序列化。

**修复：** NavItem / SectionHeader 的 `export default` 处包裹 `React.memo()`。logger 的 `forward` 函数增加 Level 阈值检查，未达到 `consoleForwardMinLevel`（生产环境默认 WARN）的调用跳过 `formatConsoleArgs` 和转发。


**验收标准：**

- [ ] React DevTools Profiler 中 SessionsSection 渲染时 NavItem 不跟随渲染
- [ ] active、selected、collapsed 状态切换正常
- [ ] `console.warn`/`console.error` 仍正常转发到 Rust log
- [ ] 开发环境完整日志不受影响