### PR TITLE
perf: replace full-state subscriptions with selector-based subscriptions

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -200,7 +200,20 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   }, [flowChatState.sessions]);
 
   useEffect(() => {
-    const unsub = flowChatStore.subscribe(s => setFlowChatState(s));
+    const selector = (s: FlowChatState): string => {
+      const parts: string[] = [s.activeSessionId ?? ''];
+      for (const session of s.sessions.values()) {
+        parts.push(
+          `${session.sessionId}|${session.isTransient ? '1':'0'}|${session.sessionKind}|` +
+          `${session.workspacePath ?? ''}|${session.mode ?? ''}|${session.needsUserAttention ? '1':'0'}|` +
+          `${session.hasUnreadCompletion ? '1':'0'}|${session.title ?? ''}`
+        );
+      }
+      return parts.join(';');
+    };
+    const unsub = flowChatStore.subscribeSelector(selector, (() => {
+      setFlowChatState(flowChatStore.getState());
+    }), { isEqual: (a, b) => a === b });
     return () => unsub();
   }, []);
 

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -692,9 +692,55 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   );
 
   useEffect(() => {
-    const unsubscribe = FlowChatStore.getInstance().subscribe(setFlowChatState);
+    const store = FlowChatStore.getInstance();
+
+    const unsubscribe = store.subscribeSelector(
+      (state: FlowChatState): string => {
+        const parts: string[] = [state.activeSessionId ?? ''];
+        // Track sessions that ChatInput reads in render body (lines 278, 288, 304, 619)
+        const sessionIds = [
+          state.activeSessionId,
+          currentSessionId,
+          effectiveTargetSessionId,
+          activeBtwSessionId,
+        ].filter((id): id is string => !!id);
+        for (const id of sessionIds) {
+          const s = state.sessions.get(id);
+          if (s) {
+            parts.push(
+              `${id}|${s.mode ?? ''}|${s.title ?? ''}|${s.workspacePath ?? ''}|` +
+              `${s.remoteConnectionId ?? ''}|${s.remoteSshHost ?? ''}|${s.lastSubmittedMode ?? ''}|` +
+              `${s.currentAcpContextUsage?.used ?? ''}|${s.currentAcpContextUsage?.size ?? ''}|` +
+              `${s.currentTokenUsage?.totalTokens ?? ''}|${s.maxContextTokens ?? ''}|` +
+              `${s.needsUserAttention ? '1':'0'}`
+            );
+          }
+        }
+        return parts.join(';');
+      },
+      () => {
+        const state = store.getState();
+        setFlowChatState(state);
+        if (effectiveTargetSessionId) {
+          const session = state.sessions.get(effectiveTargetSessionId);
+          if (session) {
+            setTokenUsage(getSessionContextUsageDisplay(session));
+          }
+        }
+      },
+      { isEqual: (a: string, b: string) => a === b },
+    );
+
+    // Initial token usage sync
+    if (effectiveTargetSessionId) {
+      const session = store.getState().sessions.get(effectiveTargetSessionId);
+      if (session) {
+        setTokenUsage(getSessionContextUsageDisplay(session));
+      }
+    }
+
     return () => unsubscribe();
-  }, []);
+  }, [currentSessionId, effectiveTargetSessionId, activeBtwSessionId]);
 
   useEffect(() => {
     if (!showTargetSwitcher || !activeBtwSessionId) {
@@ -933,29 +979,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       clearPendingLargePastes();
     }
   }, [clearPendingLargePastes, inputState.value]);
-  
-  React.useEffect(() => {
-    const store = FlowChatStore.getInstance();
-    
-    const unsubscribe = store.subscribe((state: FlowChatState) => {
-      if (effectiveTargetSessionId) {
-        const session = state.sessions.get(effectiveTargetSessionId);
-        if (session) {
-          setTokenUsage(getSessionContextUsageDisplay(session));
-        }
-      }
-    });
-
-    if (effectiveTargetSessionId) {
-      const state = store.getState();
-      const session = state.sessions.get(effectiveTargetSessionId);
-      if (session) {
-        setTokenUsage(getSessionContextUsageDisplay(session));
-      }
-    }
-
-    return () => unsubscribe();
-  }, [effectiveTargetSessionId]);
 
   React.useEffect(() => {
     const handleFillInput = (event: Event) => {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -300,10 +300,19 @@ function isValidPersistedAgentType(agentType: string): boolean {
   return VALID_AGENT_TYPES.has(agentType) || agentType.startsWith('acp:');
 }
 
+interface SelectorListener<T = any> {
+  selector: (state: FlowChatState) => T;
+  callback: (selected: T) => void;
+  isEqual: (a: T, b: T) => boolean;
+  lastValue: T | undefined;
+  hasLastValue: boolean;
+}
+
 export class FlowChatStore {
   private static instance: FlowChatStore;
   private state: FlowChatState;
   private listeners: Set<(state: FlowChatState) => void> = new Set();
+  private selectorListeners: Set<SelectorListener> = new Set();
   private silentMode = false;
   private metadataListRequests = new Map<string, MetadataListRequest>();
   private metadataPageRequests = new Map<string, MetadataPageRequest>();
@@ -853,11 +862,26 @@ export class FlowChatStore {
     this.state = newState;
     
     if (!this.silentMode) {
+      // Notify plain listeners (backward compat)
       this.listeners.forEach(listener => {
         try {
           listener(newState);
         } catch (error) {
           console.error('[FlowChatStore] Listener threw an error, skipping:', error);
+        }
+      });
+
+      // Notify selector listeners
+      this.selectorListeners.forEach(entry => {
+        try {
+          const nextValue = entry.selector(newState);
+          if (!entry.hasLastValue || !entry.isEqual(entry.lastValue, nextValue)) {
+            entry.lastValue = nextValue;
+            entry.hasLastValue = true;
+            entry.callback(nextValue);
+          }
+        } catch (error) {
+          console.error('[FlowChatStore] Selector listener threw an error, skipping:', error);
         }
       });
     }
@@ -886,6 +910,18 @@ export class FlowChatStore {
         listener(this.state);
       } catch (error) {
         console.error('[FlowChatStore] Listener threw an error during notifyListeners, skipping:', error);
+      }
+    });
+    this.selectorListeners.forEach(entry => {
+      try {
+        const nextValue = entry.selector(this.state);
+        if (!entry.hasLastValue || !entry.isEqual(entry.lastValue, nextValue)) {
+          entry.lastValue = nextValue;
+          entry.hasLastValue = true;
+          entry.callback(nextValue);
+        }
+      } catch (error) {
+        console.error('[FlowChatStore] Selector listener threw an error during notifyListeners, skipping:', error);
       }
     });
   }
@@ -947,6 +983,24 @@ export class FlowChatStore {
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);
+    };
+  }
+
+  public subscribeSelector<T>(
+    selector: (state: FlowChatState) => T,
+    callback: (selected: T) => void,
+    options?: { isEqual?: (a: T, b: T) => boolean },
+  ): () => void {
+    const entry: SelectorListener<T> = {
+      selector,
+      callback,
+      isEqual: options?.isEqual ?? Object.is,
+      lastValue: undefined,
+      hasLastValue: false,
+    };
+    this.selectorListeners.add(entry);
+    return () => {
+      this.selectorListeners.delete(entry);
     };
   }
 


### PR DESCRIPTION
 **问题：** FlowChatStore.subscribe() 对所有 24 个 listener 同步全量通知完整 FlowChatState，无 selector 过滤、无 equality 检查。SessionsSection 和 ChatInput 全量订阅导致 streaming 期间每个 token 触发完整重渲染（1140 行 + 3496 行），ChatInput 还另有独立订阅更新 tokenUsage 造成双重重渲染。

 **修复：** 新增 `subscribeSelector(selector, callback, { isEqual? })` API，缓存上次 selector 结果，仅变化时通知。SessionsSection 换用此 API，selector 提取 session 元数据快照（id、title、status、sessionKind 等），仅导航相关字段变化时更新。ChatInput 合并两个 subscribe 为单一 subscribeSelector，selector 覆盖 mode、title、workspacePath、tokenUsage 等字段，单次回调同时更新 flowChatState 和 tokenUsage。


**验收标准：**

- [ ] Profiler 中 streaming 期间 SessionsSection 不随 token 渲染
- [ ] 会话新建/标题生成/归档删除/运行状态切换正常
- [ ] streaming 时输入框无延迟；模式切换、BTW Target Switcher 正常
- [ ] Token 计数实时更新
- [ ] 现有 `subscribe()` 调用点不受影响