### PR TITLE
refactor(core): move remote and shell execution owners

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -21,12 +21,13 @@
 - `runtime-ports` 已承接 workspace、session store、remote workspace/projection、tool runtime handles、thread goal DTO、scheduled-job state 等稳定接口或事实。
 - `runtime-services` 已建立 typed service bundle、builder、capability availability、provider 注册和 fake provider 测试基础。
 - remote workspace facts、remote session metadata、remote file projection DTO、remote workspace/projection host trait 已归入稳定接口层，并保留旧路径 re-export。
+- `services-integrations` 已承接 remote-connect wire command routing、response assembly、workspace/session/poll/file/dialog/cancel/interaction helper 和 state tracker contract；core `RemoteServer` 只保留加密入口、initial sync host glue、全局 tracker adapter 与 concrete runtime host 接线。
 - session restore 的 storage path resolution、turn-load request、restore timing facts 已进入 Runtime Services / Runtime Ports 边界；core 仍保留具体 persistence IO。
 
 ### 1.3 Tool 与 Product Capability 基线
 
 - `tool-contracts`（Cargo package `bitfun-agent-tools`）已承接 provider-neutral tool DTO、manifest/catalog 策略、execution admission gate、collapsed unlock gate、static provider materialization 和 plan-to-registry assembly。
-- `tool-execution`（Cargo package `tool-runtime`）已承接本地 Write / Edit / Delete / Glob 以及远程 Delete / Read / LS / Glob / Grep 的部分低层 execution helper；core 仍负责 agent-facing adapter、权限、checkpoint、remote shell 和 result 包装。
+- `tool-execution`（Cargo package `tool-runtime`）已承接本地 Write / Edit / Delete / Glob、远程 Delete / Read / LS / Glob / Grep，以及 Bash shell 可复用策略：禁用命令、工作目录命令包装、非交互环境、AppleScript/IM guard、本地/远程结果渲染和 background result 文本。core BashTool 只保留 agent-facing adapter、终端 session、权限、checkpoint、cancellation、scheduler delivery 和 host context glue。
 - `tool-provider-groups`（Cargo package `bitfun-tool-packs`）已承接 tool provider group plan、按 id 选择和 unknown provider group 校验。
 - `product-capabilities` 已承接 capability id、required service capability、tool provider group selection 和 harness provider selection 等 assembly facts。
 - Product Assembly 已承接 `DeliveryProfile`、`CapabilitySet`、product-full provider plan、service availability report 和 profile-scoped harness registry 入口。
@@ -51,6 +52,8 @@
 - owner crate 不得依赖回 `bitfun-core`。
 - `product-full` 继续保护完整产品能力集合。
 - boundary check 覆盖 owner crate 禁止依赖、旧路径 facade-only、回流约束、Product Assembly facade 收口和物理 crate layout。
+- boundary check 覆盖 remote-connect command routing owner，要求 core 委托 `services-integrations`，并阻止 response assembly / command policy 回流 core。
+- boundary check 覆盖 Bash shell helper owner，要求 core 委托 `tool-runtime::shell`，并阻止输出渲染、background result 文本、命令包装和 guard 策略回流 core。
 - DeepReview 路径分类按六层物理 crate 解析，避免把同层多个 crate 合并成一个风险 area。
 - focused baseline 已覆盖 tool manifest、GetToolSpec、execution admission、MiniApp storage / builtin asset、remote workspace fallback、MCP config/catalog、agent-runtime prompt cache、custom subagent、thread-goal tools、AskUserQuestion、DeepReview hook measurement、tool confirmation、product capability pack、session restore、local/remote tool IO helper、function-agent Git、scheduled-job state 等路径。
 
@@ -59,5 +62,5 @@
 - `bitfun-core` 仍是完整产品 runtime 组装点，不能声称已经退化为纯 compatibility facade。
 - 产品入口仍主要通过 `bitfun-core/product-full` 获取完整能力；Product Assembly 已可表达当前完整能力集合，但尚未真正按交付形态裁剪 default feature / dependency。
 - concrete session manager、scheduler lifecycle、event delivery、permission UI/channel wait、prompt assembly、session persistence IO、AI client factory / provider acquisition 仍在 core。
-- Bash tool orchestration、terminal lifecycle / PTY、indexed workspace search service owner、remote shell executor abstraction、remote terminal concrete impl、MiniApp worker / host / seed / marker IO、Deep Review / DeepResearch / MiniApp concrete workflow execution 仍未完成 owner 迁移。
+- Bash tool orchestration 的可复用 shell helper 已迁出；terminal lifecycle / PTY、permission wait、checkpoint orchestration、indexed workspace search service owner、remote shell executor abstraction、remote terminal concrete impl、MiniApp worker / host / seed / marker IO、Deep Review / DeepResearch / MiniApp concrete workflow execution 仍未完成 owner 迁移。
 - no-default 与 product-full 的依赖边界已有数据基线，但 no-default 仍包含较大 concrete 依赖；不能声称各交付形态已达到最小依赖。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -22,7 +22,8 @@
 - Cargo package / lib 名保持兼容；例如 `tool-contracts` 仍发布为 `bitfun-agent-tools`，`tool-provider-groups` 仍发布为 `bitfun-tool-packs`，`tool-execution` 仍发布为 `tool-runtime`。
 - Desktop / CLI / ACP 仍通过 `bitfun-core/product-full` 获取完整能力；Server / Web / Mobile Web 不直接依赖 core，但尚未完成按交付形态裁剪最小 feature / dependency。
 - `runtime-services` 已有 typed builder、capability availability 和 core product runtime provider adapter，但不少 concrete provider 仍在 core 创建或持有。
-- `tool-contracts` 已承接 provider-neutral tool manifest、admission、catalog、result policy 等纯策略；`tool-execution` 只承接部分低层 IO/search helper；Bash、terminal lifecycle、indexed search、remote shell、permission wait、checkpoint orchestration 和完整 execution pipeline 仍未完全迁移。
+- remote-connect command routing、wire response assembly、workspace/session/poll/file/dialog/cancel/interaction helper 和 state tracker contract 已归入 `services-integrations`；core 保留 host adapter、加密入口和全局 tracker 接线。
+- `tool-contracts` 已承接 provider-neutral tool manifest、admission、catalog、result policy 等纯策略；`tool-execution` 已承接低层 IO/search helper 以及 Bash shell 可复用策略与结果渲染。terminal lifecycle、indexed workspace search service、permission wait、checkpoint orchestration 和完整 execution pipeline 仍未完全迁移。
 - `agent-stream` 已承接统一 stream DTO、tool-call 累积和 replay 契约；provider SSE / 响应解析测试归属 `ai-adapters`。
 - `harness` 当前主要承接 descriptor / route plan / registry contract；Deep Review、DeepResearch、MiniApp 的 concrete workflow execution 仍在 core 或产品路径。
 - `product-domains` 已承接 MiniApp / function-agent 的部分纯领域逻辑；worker、host side effect、AI acquisition、marker IO 等 concrete path 仍未完成 owner 迁移。
@@ -41,13 +42,16 @@
 
 ## 4. 后续执行节奏
 
+M6 Service / Adapter owner 深迁移和 M7 Bash shell execution helper owner 迁移已完成事实归档到
+[`core-decomposition-completed.md`](core-decomposition-completed.md)。后续计划从
+tool pipeline / indexed search 等更高风险 owner 迁移开始，避免再把已完成的 service/adapter 或 Bash helper 收口项重复拆成小 PR。
+
 | 阶段 | 目标 | 准出标准 |
 |---|---|---|
-| M6 Service / Adapter owner 深迁移 | 将 core 中仍直接持有的 service、remote、MCP、Git、terminal、AI/API/transport adapter 创建路径继续下沉到 `services` 或 `adapters` | core 对应路径明显删除或简化；service/adapter 依赖不反向指向 assembly；产品行为等价测试覆盖 |
-| M7 Tool execution 深迁移 | 将 Bash、indexed search、remote shell、checkpoint/permission 边界和 tool execution pipeline 的可复用主体迁入 `tool-contracts` / `tool-execution` / `services` | prompt-visible manifest、permission、GetToolSpec、remote/local IO、oversized result 与 cancellation 行为等价 |
-| M8 Harness / Agent runtime 收口 | 将 Deep Review / DeepResearch / MiniApp workflow concrete execution、scheduler lifecycle、event delivery、prompt assembly 和 session side effect 继续从 core 收敛到 owner 边界 | workflow route 与 side effect 有 focused tests；agent runtime 不依赖 service/app concrete impl |
-| M9 Product shape / feature trimming | 基于 capability matrix 裁剪 no-default/product-full 和不同交付形态依赖 | cargo metadata / cargo tree 有对比数据；各产品形态构建与关键入口验证通过 |
-| M10 Core facade 收口 | 将 `bitfun-core` 限定为 compatibility facade、product-full assembly 和少量迁移期 adapter | core 不再是事实 runtime owner；边界脚本阻止 owner 逻辑回流 |
+| M8 Tool pipeline / indexed search 收口 | 将 indexed workspace search service owner、tool pipeline presentation / oversized-result policy、permission wait 与 checkpoint orchestration 的可复用主体继续收敛到 `tool-contracts` / `tool-execution` / `services` | prompt-visible manifest、permission、GetToolSpec、indexed/local/remote IO、oversized result 与 cancellation 行为等价；不改变工具 schema 和权限语义 |
+| M9 Harness / Agent runtime 收口 | 将 Deep Review / DeepResearch / MiniApp workflow concrete execution、scheduler lifecycle、event delivery、prompt assembly 和 session side effect 继续从 core 收敛到 owner 边界 | workflow route 与 side effect 有 focused tests；agent runtime 不依赖 service/app concrete impl |
+| M10 Product shape / feature trimming | 基于 capability matrix 裁剪 no-default/product-full 和不同交付形态依赖 | cargo metadata / cargo tree 有对比数据；各产品形态构建与关键入口验证通过 |
+| M11 Core facade 收口 | 将 `bitfun-core` 限定为 compatibility facade、product-full assembly 和少量迁移期 adapter | core 不再是事实 runtime owner；边界脚本阻止 owner 逻辑回流 |
 
 ## 5. 固定执行流程
 

--- a/scripts/core-boundaries/rules/source/forbidden-rules.mjs
+++ b/scripts/core-boundaries/rules/source/forbidden-rules.mjs
@@ -1780,6 +1780,53 @@ export const forbiddenContentRules = [
       },
     ],
   },
+  {
+    path: 'src/crates/assembly/core/src/agentic/tools/implementations/bash_tool.rs',
+    reason:
+      'BashTool must stay as terminal/session/checkpoint glue and must not re-own reusable shell execution helpers',
+    patterns: [
+      {
+        regex: /\bconst\s+MAX_OUTPUT_LENGTH\b/,
+        message: 'Bash output rendering budget is owned by tool-runtime::shell',
+      },
+      {
+        regex: /\bconst\s+BANNED_COMMANDS\b/,
+        message: 'Bash banned-command policy is owned by tool-runtime::shell',
+      },
+      {
+        regex: /\bfn\s+detect_osascript_keystroke_non_ascii\b/,
+        message: 'Bash osascript keystroke guard is owned by tool-runtime::shell',
+      },
+      {
+        regex: /\bfn\s+detect_osascript_im_app\b/,
+        message: 'Bash IM AppleScript guard is owned by tool-runtime::shell',
+      },
+      {
+        regex: /\bfn\s+truncate_output_preserving_tail\b/,
+        message: 'Bash output truncation is owned by tool-runtime::shell',
+      },
+      {
+        regex: /\bfn\s+command_for_working_directory\b/,
+        message: 'Bash working-directory command wrapping is owned by tool-runtime::shell',
+      },
+      {
+        regex: /\bfn\s+render_result\b/,
+        message: 'Bash local result rendering is owned by tool-runtime::shell',
+      },
+      {
+        regex: /\bfn\s+render_remote_result\b/,
+        message: 'Bash remote result rendering is owned by tool-runtime::shell',
+      },
+      {
+        regex: /\bfn\s+format_background_command_delivery_text\b/,
+        message: 'Bash background-result delivery text is owned by tool-runtime::shell',
+      },
+      {
+        regex: /\bfn\s+format_background_command_error_text\b/,
+        message: 'Bash background-result error text is owned by tool-runtime::shell',
+      },
+    ],
+  },
 ];
 
 export const forbiddenContentUnderRules = [

--- a/scripts/core-boundaries/rules/source/required-rules.mjs
+++ b/scripts/core-boundaries/rules/source/required-rules.mjs
@@ -1223,6 +1223,64 @@ export const requiredContentRules = [
     ],
   },
   {
+    path: 'src/crates/execution/tool-execution/src/shell/mod.rs',
+    reason:
+      'tool-runtime must own reusable Bash shell execution policy, rendering, and background-result text helpers',
+    patterns: [
+      {
+        regex: /\bpub fn banned_shell_command\b/,
+        message: 'missing Bash banned-command policy owner',
+      },
+      {
+        regex: /\bpub fn detect_osascript_keystroke_non_ascii\b/,
+        message: 'missing Bash osascript keystroke guard owner',
+      },
+      {
+        regex: /\bpub fn detect_osascript_im_app\b/,
+        message: 'missing Bash IM AppleScript guard owner',
+      },
+      {
+        regex: /\bpub fn command_for_working_directory\b/,
+        message: 'missing Bash working-directory command wrapper owner',
+      },
+      {
+        regex: /\bpub fn bash_noninteractive_env\b/,
+        message: 'missing Bash noninteractive environment owner',
+      },
+      {
+        regex: /\bpub fn render_local_shell_result\b/,
+        message: 'missing local shell result rendering owner',
+      },
+      {
+        regex: /\bpub fn render_remote_shell_result\b/,
+        message: 'missing remote shell result rendering owner',
+      },
+      {
+        regex: /\bpub fn format_background_command_delivery_text\b/,
+        message: 'missing background command delivery text owner',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/execution/tool-execution/tests/tool_io_contracts.rs',
+    reason:
+      'tool-runtime shell owner must keep focused behavior-equivalence contracts for Bash execution helpers',
+    patterns: [
+      {
+        regex: /\bbash_shell_owner_preserves_command_wrapping_and_env\b/,
+        message: 'missing Bash command/env owner regression',
+      },
+      {
+        regex: /\bbash_shell_owner_preserves_guard_and_result_rendering\b/,
+        message: 'missing Bash guard/rendering owner regression',
+      },
+      {
+        regex: /\bbash_shell_owner_preserves_background_delivery_texts\b/,
+        message: 'missing Bash background-result text owner regression',
+      },
+    ],
+  },
+  {
     path: 'src/crates/services/services-integrations/src/mcp/server/connection.rs',
     reason:
       'services-integrations MCP connection must keep initialize-scoped timeout and channel-close cleanup until MCP owner migration is reviewed',
@@ -2653,6 +2711,14 @@ export const requiredContentRules = [
         message: 'missing remote interaction command owner handler',
       },
       {
+        regex: /\bpub trait RemoteCommandRuntimeHost\b/,
+        message: 'missing remote command runtime host contract',
+      },
+      {
+        regex: /\bpub async fn handle_remote_command\b/,
+        message: 'missing remote command routing owner',
+      },
+      {
         regex: /\bpub fn remote_file_content_response\b/,
         message: 'missing remote file content response assembly helper',
       },
@@ -2923,6 +2989,14 @@ export const requiredContentRules = [
         message: 'missing remote execution response helper contract test',
       },
       {
+        regex: /\bremote_connect_command_owner_routes_send_message_and_prefers_explicit_images\b/,
+        message: 'missing remote command routing image/source regression',
+      },
+      {
+        regex: /\bremote_connect_command_owner_preserves_cancel_and_group_routing\b/,
+        message: 'missing remote command routing group/cancel regression',
+      },
+      {
         regex: /\bremote_connect_tracker_keeps_finished_turn_snapshot_until_persistence_finalizes\b/,
         message: 'missing tracker completion contract test',
       },
@@ -2982,12 +3056,12 @@ export const requiredContentRules = [
         message: 'missing remote file command owner delegation',
       },
       {
-        regex: /\bremote_dialog_submit_response\b/,
-        message: 'missing remote dialog response assembly delegation',
+        regex: /\bRemoteCommandRuntimeHost\b/,
+        message: 'missing remote command runtime host adapter',
       },
       {
-        regex: /\bremote_task_cancel_response\b/,
-        message: 'missing remote cancel response assembly delegation',
+        regex: /\bhandle_remote_command\b/,
+        message: 'missing remote command routing owner delegation',
       },
       {
         regex: /\bhandle_remote_interaction_command\b/,

--- a/src/crates/assembly/core/src/agentic/tools/implementations/bash_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/bash_tool.rs
@@ -24,124 +24,15 @@ use terminal_core::{
     TerminalBindingOptions, TerminalSessionBinding,
 };
 use tokio::io::AsyncWriteExt;
-use tool_runtime::util::ansi_cleaner::strip_ansi;
-
-// Inline rendering budget for Bash's own result formatter. When the shared
-// oversized tool-result pipeline can persist the result, it stores the raw
-// `output` field instead of this rendered/truncated fallback.
-const MAX_OUTPUT_LENGTH: usize = 30000;
-const INTERRUPT_OUTPUT_DRAIN_MS: u64 = 500;
-
-const BANNED_COMMANDS: &[&str] = &[
-    "alias",
-    // "curl",
-    // "curlie",
-    // "wget",
-    // "axel",
-    // "aria2c",
-    // "nc",
-    // "telnet",
-    // "lynx",
-    // "w3m",
-    // "links",
-    // "httpie",
-    // "xh",
-    // "http-prompt",
-    // "chrome",
-    // "firefox",
-    // "safari",
-];
-
-/// Detect a known-broken pattern: `osascript ... keystroke "<text containing
-/// non-ASCII>"`. AppleScript's `keystroke` sends raw key codes, NOT Unicode
-/// strings — typing CJK / emoji / non-Latin text via `keystroke` produces
-/// garbage like "AAA…" because the receiving app sees the wrong key codes.
-/// The correct path is `ControlHub domain:"desktop" action:"paste"` (which
-/// uses the system clipboard).
-fn detect_osascript_keystroke_non_ascii(cmd: &str) -> Option<String> {
-    if !cmd.contains("osascript") {
-        return None;
-    }
-    // Walk every `keystroke "..."` literal and check for non-ASCII inside.
-    let bytes = cmd.as_bytes();
-    let needle = b"keystroke";
-    let mut i = 0usize;
-    while i + needle.len() < bytes.len() {
-        if &bytes[i..i + needle.len()] == needle {
-            // Find the next quoted string after `keystroke`.
-            let mut j = i + needle.len();
-            while j < bytes.len() && bytes[j] != b'"' {
-                j += 1;
-            }
-            if j >= bytes.len() {
-                break;
-            }
-            let start = j + 1;
-            let mut end = start;
-            while end < bytes.len() && bytes[end] != b'"' {
-                end += 1;
-            }
-            if end > bytes.len() {
-                break;
-            }
-            let literal = &cmd[start..end.min(cmd.len())];
-            if !literal.is_ascii() {
-                return Some(literal.to_string());
-            }
-            i = end + 1;
-        } else {
-            i += 1;
-        }
-    }
-    None
-}
-
-/// Detect `osascript` driving a chat / IM application. The model loves to
-/// reach for AppleScript here, but `tell process "<App>" to keystroke …` is
-/// brittle (no CJK), opaque (no return value to verify), and almost always
-/// loses to `system.open_app + desktop.paste` or the `im_send_message`
-/// playbook. Returns the matched app name when detected.
-fn detect_osascript_im_app(cmd: &str) -> Option<&'static str> {
-    if !cmd.contains("osascript") {
-        return None;
-    }
-    const IM_APPS: &[&str] = &[
-        "WeChat", "微信", "iMessage", "Messages", "Slack", "Lark", "飞书", "Telegram", "DingTalk",
-        "钉钉", "QQ", "Discord", "Teams", "Whatsapp", "WhatsApp",
-    ];
-    let cmd_lc = cmd.to_lowercase();
-    for app in IM_APPS {
-        let app_lc = app.to_lowercase();
-        if cmd.contains(app) || cmd_lc.contains(&app_lc) {
-            return Some(*app);
-        }
-    }
-    None
-}
-
-fn truncate_output_preserving_tail(s: &str, max_chars: usize) -> String {
-    let chars: Vec<char> = s.chars().collect();
-    if chars.len() <= max_chars {
-        return s.to_string();
-    }
-
-    let tail_bias = max_chars.saturating_mul(4) / 5;
-    let separator = "\n... [truncated, middle omitted, tail preserved] ...\n";
-    let separator_len = separator.chars().count();
-
-    if separator_len >= max_chars {
-        return chars[chars.len() - max_chars..].iter().collect();
-    }
-
-    let content_budget = max_chars - separator_len;
-    let tail_len = tail_bias.min(content_budget);
-    let head_len = content_budget.saturating_sub(tail_len);
-
-    let head: String = chars[..head_len].iter().collect();
-    let tail: String = chars[chars.len() - tail_len..].iter().collect();
-
-    format!("{head}{separator}{tail}")
-}
+use tool_runtime::shell::{
+    banned_shell_command, bash_noninteractive_env, command_for_working_directory,
+    detect_osascript_im_app, detect_osascript_keystroke_non_ascii,
+    format_background_command_delivery_text, format_background_command_display_text,
+    format_background_command_error_display_text, format_background_command_error_text,
+    render_local_shell_result, render_remote_shell_result, BackgroundCommandDeliveryTextRequest,
+    BackgroundCommandErrorTextRequest, BackgroundCommandStatusFacts, LocalShellResultRenderRequest,
+    RemoteShellResultRenderRequest, BASH_INTERRUPT_OUTPUT_DRAIN_MS, BASH_RESULT_MAX_OUTPUT_LENGTH,
+};
 
 /// Result of shell resolution for bash tool
 struct ResolvedShell {
@@ -163,18 +54,6 @@ impl Default for BashTool {
 impl BashTool {
     pub fn new() -> Self {
         Self
-    }
-
-    fn sh_quote(s: &str) -> String {
-        format!("'{}'", s.replace('\'', "'\\''"))
-    }
-
-    fn command_for_working_directory(command: &str, working_directory: Option<&str>) -> String {
-        working_directory
-            .map(str::trim)
-            .filter(|dir| !dir.is_empty())
-            .map(|dir| format!("cd {} && {}", Self::sh_quote(dir), command))
-            .unwrap_or_else(|| command.to_string())
     }
 
     fn resolve_working_directory(
@@ -213,17 +92,7 @@ impl BashTool {
     /// Build environment variables that suppress interactive behaviors
     /// (pagers, editors, prompts) so agent-driven commands never block.
     pub fn noninteractive_env() -> std::collections::HashMap<String, String> {
-        let mut env = std::collections::HashMap::new();
-        env.insert("BITFUN_NONINTERACTIVE".to_string(), "1".to_string());
-        // Disable git pager globally (prevents `less`/`more` from blocking)
-        env.insert("GIT_PAGER".to_string(), "cat".to_string());
-        // Disable generic pager for other tools (man, etc.)
-        env.insert("PAGER".to_string(), "cat".to_string());
-        // Prevent git from prompting for credentials or SSH passphrases
-        env.insert("GIT_TERMINAL_PROMPT".to_string(), "0".to_string());
-        // Ensure git never opens an interactive editor (e.g. for commit messages)
-        env.insert("GIT_EDITOR".to_string(), "true".to_string());
-        env
+        bash_noninteractive_env()
     }
 
     /// Resolve shell configuration for bash tool.
@@ -268,151 +137,6 @@ impl BashTool {
         }
     }
 
-    fn render_result(
-        &self,
-        terminal_session_id: &str,
-        working_directory: &str,
-        output_text: &str,
-        interrupted: bool,
-        timed_out: bool,
-        exit_code: i32,
-        shell_state: Option<&str>,
-    ) -> String {
-        let mut result_string = String::new();
-
-        // Exit code
-        result_string.push_str(&format!("<exit_code>{}</exit_code>", exit_code));
-        if !working_directory.is_empty() {
-            result_string.push_str(&format!(
-                "<working_directory>{}</working_directory>",
-                working_directory
-            ));
-        }
-
-        // Main output content
-        if !output_text.is_empty() {
-            let cleaned_output = strip_ansi(output_text);
-            let output_len = cleaned_output.chars().count();
-            if output_len > MAX_OUTPUT_LENGTH {
-                let truncated = truncate_output_preserving_tail(&cleaned_output, MAX_OUTPUT_LENGTH);
-                result_string.push_str(&format!(
-                    "<output truncated=\"true\">{}</output>",
-                    truncated
-                ));
-            } else {
-                result_string.push_str(&format!("<output>{}</output>", cleaned_output));
-            }
-        }
-
-        // Post-command terminal state: shows what the shell displayed after the
-        // command finished (e.g., prompt, continuation prompt, or other state).
-        // This gives AI the full picture of the terminal context.
-        if let Some(state) = shell_state {
-            let cleaned_state = strip_ansi(state);
-            result_string.push_str(&format!("<shell_state>{}</shell_state>", cleaned_state));
-        }
-
-        // Interruption notice
-        if timed_out {
-            result_string.push_str(
-                "<status type=\"timeout\">Command timed out before completion. Partial output, if any, is included above.</status>",
-            );
-        } else if interrupted {
-            result_string.push_str(
-                "<status type=\"interrupted\">Command was canceled by the user. ASK THE USER what they would like to do next.</status>"
-            );
-        }
-
-        // Terminal session ID
-        result_string.push_str(&format!(
-            "<terminal_session_id>{}</terminal_session_id>",
-            terminal_session_id
-        ));
-
-        result_string
-    }
-
-    fn render_output_block_with_limit(
-        tag: &str,
-        output_text: &str,
-        max_chars: usize,
-    ) -> Option<String> {
-        if output_text.is_empty() {
-            return None;
-        }
-
-        let cleaned_output = strip_ansi(output_text);
-        let output_len = cleaned_output.chars().count();
-        if max_chars == 0 {
-            Some(format!(
-                "<{tag} truncated=\"true\">... [truncated, no budget remaining] ...</{tag}>"
-            ))
-        } else if output_len > max_chars {
-            let truncated = truncate_output_preserving_tail(&cleaned_output, max_chars);
-            Some(format!("<{tag} truncated=\"true\">{}</{tag}>", truncated))
-        } else {
-            Some(format!("<{tag}>{}</{tag}>", cleaned_output))
-        }
-    }
-
-    fn remote_stream_budgets(stdout: &str, stderr: &str) -> (usize, usize) {
-        let stdout_len = strip_ansi(stdout).chars().count();
-        let stderr_len = strip_ansi(stderr).chars().count();
-
-        if stderr_len >= MAX_OUTPUT_LENGTH {
-            return (0, MAX_OUTPUT_LENGTH);
-        }
-
-        let stderr_budget = stderr_len;
-        let stdout_budget = MAX_OUTPUT_LENGTH.saturating_sub(stderr_budget);
-        (stdout_budget.min(stdout_len), stderr_budget)
-    }
-
-    fn render_remote_result(
-        &self,
-        working_directory: &str,
-        stdout: &str,
-        stderr: &str,
-        interrupted: bool,
-        timed_out: bool,
-        exit_code: i32,
-    ) -> String {
-        let mut result_string = String::new();
-        result_string.push_str("<remote_ssh>true</remote_ssh>");
-        result_string.push_str(&format!("<exit_code>{}</exit_code>", exit_code));
-        if !working_directory.is_empty() {
-            result_string.push_str(&format!(
-                "<working_directory>{}</working_directory>",
-                working_directory
-            ));
-        }
-
-        let (stdout_budget, stderr_budget) = Self::remote_stream_budgets(stdout, stderr);
-
-        if let Some(stdout_block) =
-            Self::render_output_block_with_limit("stdout", stdout, stdout_budget)
-        {
-            result_string.push_str(&stdout_block);
-        }
-        if let Some(stderr_block) =
-            Self::render_output_block_with_limit("stderr", stderr, stderr_budget)
-        {
-            result_string.push_str(&stderr_block);
-        }
-
-        if timed_out {
-            result_string.push_str(
-                "<status type=\"timeout\">Command timed out before completion. Partial stdout/stderr, if any, is included above.</status>",
-            );
-        } else if interrupted {
-            result_string.push_str(
-                "<status type=\"interrupted\">Command was canceled before completion. ASK THE USER what they would like to do next.</status>",
-            );
-        }
-
-        result_string
-    }
-
     fn emit_terminal_ready_event(tool_use_id: &str, terminal_session_id: &str) {
         let event = ToolTerminalReady(ToolTerminalReadyInfo {
             tool_use_id: tool_use_id.to_string(),
@@ -451,97 +175,6 @@ impl BashTool {
                 &format!("tool-results/{}.txt", tool_use_id),
             )
             .unwrap_or_else(|_| output_file_path.display().to_string())
-    }
-
-    fn format_background_command_delivery_text(
-        command: &str,
-        terminal_session_id: &str,
-        working_directory: &str,
-        exit_code: Option<i32>,
-        timed_out: bool,
-        interrupted: bool,
-        output_file_reference: &str,
-        output_persist_error: Option<&str>,
-    ) -> String {
-        let (status, summary) = if timed_out {
-            ("timeout", "Background Bash command timed out.")
-        } else if interrupted {
-            ("interrupted", "Background Bash command was interrupted.")
-        } else if exit_code == Some(0) {
-            (
-                "completed",
-                "Background Bash command completed successfully.",
-            )
-        } else {
-            (
-                "failed",
-                "Background Bash command completed with a non-zero exit code.",
-            )
-        };
-        let exit_code_attr = exit_code
-            .map(|code| format!(" exit_code=\"{}\"", code))
-            .unwrap_or_default();
-        let persistence_line = output_persist_error.map_or_else(
-            || format!("Full output was saved to: {}", output_file_reference),
-            |error| {
-                format!(
-                    "Output persistence encountered an error while writing {}: {}",
-                    output_file_reference, error
-                )
-            },
-        );
-
-        format!(
-            "{summary}\n<background_command status=\"{status}\" terminal_session_id=\"{terminal_session_id}\"{exit_code_attr}>\nCommand: {command}\nWorking directory: {working_directory}\n{persistence_line}\n</background_command>"
-        )
-    }
-
-    fn format_background_command_display_text(
-        exit_code: Option<i32>,
-        timed_out: bool,
-        interrupted: bool,
-    ) -> String {
-        if timed_out {
-            "Background Bash command timed out.".to_string()
-        } else if interrupted {
-            "Background Bash command was interrupted.".to_string()
-        } else if exit_code == Some(0) {
-            "Background Bash command completed successfully.".to_string()
-        } else {
-            "Background Bash command completed with a non-zero exit code.".to_string()
-        }
-    }
-
-    fn format_background_command_error_text(
-        command: &str,
-        terminal_session_id: &str,
-        working_directory: &str,
-        output_file_reference: &str,
-        error: &str,
-        output_persist_error: Option<&str>,
-    ) -> String {
-        let persistence_line = output_persist_error.map_or_else(
-            || {
-                format!(
-                    "Any captured output was saved to: {}",
-                    output_file_reference
-                )
-            },
-            |persist_error| {
-                format!(
-                    "Output persistence encountered an error while writing {}: {}",
-                    output_file_reference, persist_error
-                )
-            },
-        );
-
-        format!(
-            "Background Bash command failed before producing a final completion result.\n<background_command status=\"error\" terminal_session_id=\"{terminal_session_id}\">\nCommand: {command}\nWorking directory: {working_directory}\n{persistence_line}\nError: {error}\n</background_command>"
-        )
-    }
-
-    fn format_background_command_error_display_text() -> String {
-        "Background Bash command failed before producing a final completion result.".to_string()
     }
 }
 
@@ -582,7 +215,7 @@ Usage notes:
   - DO NOT use multiline commands or HEREDOC syntax (e.g., <<EOF, heredoc with newlines). Only single-line commands are supported.
   - You can specify an optional timeout in milliseconds (up to 600000ms / 10 minutes). If not specified, commands will timeout after 120000ms (2 minutes).
   - It is very helpful if you write a clear, concise description of what this command does. For simple commands, keep it brief (5-10 words). For complex commands (piped commands, obscure flags, or anything hard to understand at a glance), add enough context to clarify what it does.
-  - If the output exceeds {MAX_OUTPUT_LENGTH} characters, output will be truncated before being returned to you, with the tail of the output preserved because the ending is usually more important.
+  - If the output exceeds {BASH_RESULT_MAX_OUTPUT_LENGTH} characters, output will be truncated before being returned to you, with the tail of the output preserved because the ending is usually more important.
   - You can use the `run_in_background` parameter to run the command in a new dedicated background terminal session. The tool returns immediately without waiting for the command to finish. The final completion result will be delivered back to you automatically when it is done, and the full output will be saved to a session runtime file instead of being pasted back into chat. Only use this for long-running processes (e.g., dev servers, watchers) where you do not need the output right away. You do not need to append '&' to the command. NOTE: `timeout_ms` is ignored when `run_in_background` is true.
   - Each result includes a `<terminal_session_id>` tag identifying the terminal session. The persistent shell session ID remains constant throughout the entire conversation; background sessions each have their own unique ID.
   - The output may include the command echo and/or the shell prompt prefix (for example, a printed `PS` or `$` prompt line). Do not treat these as part of the command's actual result.
@@ -683,20 +316,16 @@ Usage notes:
             .unwrap_or(false);
 
         if let Some(cmd) = command {
-            let parts: Vec<&str> = cmd.split_whitespace().collect();
-            if let Some(base_cmd) = parts.first() {
-                // Check if command is banned
-                if BANNED_COMMANDS.contains(&base_cmd.to_lowercase().as_str()) {
-                    return ValidationResult {
-                        result: false,
-                        message: Some(format!(
-                            "Command '{}' is not allowed for security reasons",
-                            base_cmd
-                        )),
-                        error_code: Some(403),
-                        meta: None,
-                    };
-                }
+            if let Some(base_cmd) = banned_shell_command(cmd) {
+                return ValidationResult {
+                    result: false,
+                    message: Some(format!(
+                        "Command '{}' is not allowed for security reasons",
+                        base_cmd
+                    )),
+                    error_code: Some(403),
+                    meta: None,
+                };
             }
 
             // Reject `osascript ... keystroke "<non-ASCII>"` — fundamentally
@@ -901,10 +530,8 @@ Usage notes:
                 "Executing command on remote workspace via SSH: {}",
                 command_str
             );
-            let remote_command = Self::command_for_working_directory(
-                command_str,
-                requested_working_directory.as_deref(),
-            );
+            let remote_command =
+                command_for_working_directory(command_str, requested_working_directory.as_deref());
 
             let timeout_ms = input
                 .get("timeout_ms")
@@ -932,14 +559,14 @@ Usage notes:
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or_default();
             let working_directory = requested_working_directory.unwrap_or(working_directory);
-            let result_for_assistant = self.render_remote_result(
-                &working_directory,
-                &exec_result.stdout,
-                &exec_result.stderr,
-                exec_result.interrupted,
-                exec_result.timed_out,
-                exec_result.exit_code,
-            );
+            let result_for_assistant = render_remote_shell_result(RemoteShellResultRenderRequest {
+                working_directory: &working_directory,
+                stdout: &exec_result.stdout,
+                stderr: &exec_result.stderr,
+                interrupted: exec_result.interrupted,
+                timed_out: exec_result.timed_out,
+                exit_code: exec_result.exit_code,
+            });
 
             let result = ToolResult::Result {
                 data: json!({
@@ -1064,10 +691,8 @@ Usage notes:
             .as_ref()
             .cloned()
             .unwrap_or_else(|| primary_cwd.clone());
-        let command_to_execute = Self::command_for_working_directory(
-            command_str,
-            requested_working_directory.as_deref(),
-        );
+        let command_to_execute =
+            command_for_working_directory(command_str, requested_working_directory.as_deref());
 
         // --- Foreground execution ---
 
@@ -1137,7 +762,7 @@ Usage notes:
                     was_interrupted = true;
                     interrupt_drain_deadline = Some(
                         tokio::time::Instant::now()
-                            + Duration::from_millis(INTERRUPT_OUTPUT_DRAIN_MS),
+                            + Duration::from_millis(BASH_INTERRUPT_OUTPUT_DRAIN_MS),
                     );
 
                     let _ = terminal_api
@@ -1253,15 +878,15 @@ Usage notes:
             "terminal_session_id": primary_session_id,
         });
 
-        let result_for_assistant = self.render_result(
-            &primary_session_id,
-            &execution_working_directory,
-            &accumulated_output,
-            was_interrupted,
+        let result_for_assistant = render_local_shell_result(LocalShellResultRenderRequest {
+            terminal_session_id: &primary_session_id,
+            working_directory: &execution_working_directory,
+            output_text: &accumulated_output,
+            interrupted: was_interrupted,
             timed_out,
-            final_exit_code.unwrap_or(-1),
-            final_shell_state.as_deref(),
-        );
+            exit_code: final_exit_code.unwrap_or(-1),
+            shell_state: final_shell_state.as_deref(),
+        });
 
         Ok(vec![ToolResult::Result {
             data: result_data,
@@ -1519,21 +1144,27 @@ impl BashTool {
                         let timed_out = completion_reason == CommandCompletionReason::TimedOut;
                         let interrupted =
                             !timed_out && matches!(exit_code, Some(130) | Some(-1073741510));
-                        let delivery_text = Self::format_background_command_delivery_text(
-                            &command,
-                            &terminal_session_id,
-                            &working_directory,
+                        let status = BackgroundCommandStatusFacts {
                             exit_code,
                             timed_out,
                             interrupted,
-                            &output_file_reference_for_task,
-                            output_persist_error.as_deref(),
+                        };
+                        let delivery_text = format_background_command_delivery_text(
+                            BackgroundCommandDeliveryTextRequest {
+                                command: &command,
+                                terminal_session_id: &terminal_session_id,
+                                working_directory: &working_directory,
+                                status,
+                                output_file_reference: &output_file_reference_for_task,
+                                output_persist_error: output_persist_error.as_deref(),
+                            },
                         );
-                        let display_text = Self::format_background_command_display_text(
-                            exit_code,
-                            timed_out,
-                            interrupted,
-                        );
+                        let display_text =
+                            format_background_command_display_text(BackgroundCommandStatusFacts {
+                                exit_code,
+                                timed_out,
+                                interrupted,
+                            });
                         let metadata = json!({
                             "kind": "background_result",
                             "sourceKind": "bash_command",
@@ -1572,15 +1203,17 @@ impl BashTool {
                         break;
                     }
                     CommandStreamEvent::Error { message } => {
-                        let delivery_text = Self::format_background_command_error_text(
-                            &command,
-                            &terminal_session_id,
-                            &working_directory,
-                            &output_file_reference_for_task,
-                            &message,
-                            output_persist_error.as_deref(),
+                        let delivery_text = format_background_command_error_text(
+                            BackgroundCommandErrorTextRequest {
+                                command: &command,
+                                terminal_session_id: &terminal_session_id,
+                                working_directory: &working_directory,
+                                output_file_reference: &output_file_reference_for_task,
+                                error: &message,
+                                output_persist_error: output_persist_error.as_deref(),
+                            },
                         );
-                        let display_text = Self::format_background_command_error_display_text();
+                        let display_text = format_background_command_error_display_text();
                         let metadata = json!({
                             "kind": "background_result",
                             "sourceKind": "bash_command",
@@ -1623,15 +1256,16 @@ impl BashTool {
             }
 
             if !saw_completion && !delivery_sent {
-                let delivery_text = Self::format_background_command_error_text(
-                    &command,
-                    &terminal_session_id,
-                    &working_directory,
-                    &output_file_reference_for_task,
-                    "Background Bash command stream ended without a completion event.",
-                    output_persist_error.as_deref(),
-                );
-                let display_text = Self::format_background_command_error_display_text();
+                let delivery_text =
+                    format_background_command_error_text(BackgroundCommandErrorTextRequest {
+                        command: &command,
+                        terminal_session_id: &terminal_session_id,
+                        working_directory: &working_directory,
+                        output_file_reference: &output_file_reference_for_task,
+                        error: "Background Bash command stream ended without a completion event.",
+                        output_persist_error: output_persist_error.as_deref(),
+                    });
+                let display_text = format_background_command_error_display_text();
                 let metadata = json!({
                     "kind": "background_result",
                     "sourceKind": "bash_command",
@@ -1716,7 +1350,7 @@ mod tests {
     fn truncate_output_preserving_tail_keeps_end_of_output() {
         let input = "BEGIN-".to_string() + &"x".repeat(120) + "-IMPORTANT-END";
 
-        let truncated = truncate_output_preserving_tail(&input, 80);
+        let truncated = tool_runtime::shell::truncate_output_preserving_tail(&input, 80);
 
         assert!(truncated.contains("tail preserved"));
         assert!(truncated.ends_with("IMPORTANT-END"));
@@ -1769,12 +1403,19 @@ mod tests {
 
     #[test]
     fn render_result_marks_truncated_output_and_keeps_tail() {
-        let tool = BashTool::new();
-        let long_output =
-            "prefix\n".to_string() + &"y".repeat(MAX_OUTPUT_LENGTH + 100) + "\nfinal-error";
+        let long_output = "prefix\n".to_string()
+            + &"y".repeat(BASH_RESULT_MAX_OUTPUT_LENGTH + 100)
+            + "\nfinal-error";
 
-        let rendered =
-            tool.render_result("session-1", "/repo", &long_output, false, false, 1, None);
+        let rendered = render_local_shell_result(LocalShellResultRenderRequest {
+            terminal_session_id: "session-1",
+            working_directory: "/repo",
+            output_text: &long_output,
+            interrupted: false,
+            timed_out: false,
+            exit_code: 1,
+            shell_state: None,
+        });
 
         assert!(rendered.contains("<output truncated=\"true\">"));
         assert!(rendered.contains("tail preserved"));
@@ -1784,10 +1425,14 @@ mod tests {
 
     #[test]
     fn render_remote_result_keeps_stdout_and_stderr_separate() {
-        let tool = BashTool::new();
-
-        let rendered =
-            tool.render_remote_result("/repo", "stdout text", "stderr text", false, false, 2);
+        let rendered = render_remote_shell_result(RemoteShellResultRenderRequest {
+            working_directory: "/repo",
+            stdout: "stdout text",
+            stderr: "stderr text",
+            interrupted: false,
+            timed_out: false,
+            exit_code: 2,
+        });
 
         assert!(rendered.contains("<remote_ssh>true</remote_ssh>"));
         assert!(rendered.contains("<exit_code>2</exit_code>"));
@@ -1798,14 +1443,21 @@ mod tests {
 
     #[test]
     fn render_remote_result_uses_shared_budget_with_stderr_priority() {
-        let tool = BashTool::new();
-        let long_stdout =
-            "prefix\n".to_string() + &"x".repeat(MAX_OUTPUT_LENGTH + 100) + "\nstdout-tail";
-        let long_stderr =
-            "prefix\n".to_string() + &"z".repeat(MAX_OUTPUT_LENGTH / 2) + "\nstderr-tail";
+        let long_stdout = "prefix\n".to_string()
+            + &"x".repeat(BASH_RESULT_MAX_OUTPUT_LENGTH + 100)
+            + "\nstdout-tail";
+        let long_stderr = "prefix\n".to_string()
+            + &"z".repeat(BASH_RESULT_MAX_OUTPUT_LENGTH / 2)
+            + "\nstderr-tail";
 
-        let rendered =
-            tool.render_remote_result("/repo", &long_stdout, &long_stderr, false, false, 1);
+        let rendered = render_remote_shell_result(RemoteShellResultRenderRequest {
+            working_directory: "/repo",
+            stdout: &long_stdout,
+            stderr: &long_stderr,
+            interrupted: false,
+            timed_out: false,
+            exit_code: 1,
+        });
 
         assert!(rendered.contains("<stdout truncated=\"true\">"));
         assert!(rendered.contains("stdout-tail"));
@@ -1815,12 +1467,18 @@ mod tests {
 
     #[test]
     fn render_remote_result_gives_all_budget_to_oversized_stderr() {
-        let tool = BashTool::new();
-        let long_stderr =
-            "prefix\n".to_string() + &"z".repeat(MAX_OUTPUT_LENGTH + 100) + "\nremote-final-error";
+        let long_stderr = "prefix\n".to_string()
+            + &"z".repeat(BASH_RESULT_MAX_OUTPUT_LENGTH + 100)
+            + "\nremote-final-error";
 
-        let rendered =
-            tool.render_remote_result("/repo", "stdout text", &long_stderr, false, false, 1);
+        let rendered = render_remote_shell_result(RemoteShellResultRenderRequest {
+            working_directory: "/repo",
+            stdout: "stdout text",
+            stderr: &long_stderr,
+            interrupted: false,
+            timed_out: false,
+            exit_code: 1,
+        });
 
         assert!(rendered.contains("<stdout truncated=\"true\">"));
         assert!(rendered.contains("no budget remaining"));
@@ -1840,33 +1498,30 @@ mod tests {
 
     #[test]
     fn command_is_prefixed_with_quoted_working_directory_when_requested() {
-        let command = BashTool::command_for_working_directory(
-            "pnpm install",
-            Some("/Users/example/My Project"),
-        );
+        let command =
+            command_for_working_directory("pnpm install", Some("/Users/example/My Project"));
 
         assert_eq!(command, "cd '/Users/example/My Project' && pnpm install");
     }
 
     #[test]
     fn command_prefix_escapes_single_quotes_in_working_directory() {
-        let command = BashTool::command_for_working_directory("pwd", Some("/tmp/it's fine"));
+        let command = command_for_working_directory("pwd", Some("/tmp/it's fine"));
 
         assert_eq!(command, "cd '/tmp/it'\\''s fine' && pwd");
     }
 
     #[test]
     fn command_result_includes_working_directory_for_model() {
-        let tool = BashTool::new();
-        let rendered = tool.render_result(
-            "session-1",
-            "/private/tmp",
-            "ERR_PNPM_NO_PKG_MANIFEST No package.json found in /private/tmp",
-            false,
-            false,
-            1,
-            None,
-        );
+        let rendered = render_local_shell_result(LocalShellResultRenderRequest {
+            terminal_session_id: "session-1",
+            working_directory: "/private/tmp",
+            output_text: "ERR_PNPM_NO_PKG_MANIFEST No package.json found in /private/tmp",
+            interrupted: false,
+            timed_out: false,
+            exit_code: 1,
+            shell_state: None,
+        });
 
         assert!(rendered.contains("<exit_code>1</exit_code>"));
         assert!(rendered.contains("<working_directory>/private/tmp</working_directory>"));
@@ -1875,16 +1530,19 @@ mod tests {
 
     #[test]
     fn background_delivery_text_points_to_saved_output_file() {
-        let rendered = BashTool::format_background_command_delivery_text(
-            "pnpm test",
-            "bg-session-1",
-            "/repo",
-            Some(0),
-            false,
-            false,
-            "/runtime/sessions/session/tool-results/bash_123.txt",
-            None,
-        );
+        let rendered =
+            format_background_command_delivery_text(BackgroundCommandDeliveryTextRequest {
+                command: "pnpm test",
+                terminal_session_id: "bg-session-1",
+                working_directory: "/repo",
+                status: BackgroundCommandStatusFacts {
+                    exit_code: Some(0),
+                    timed_out: false,
+                    interrupted: false,
+                },
+                output_file_reference: "/runtime/sessions/session/tool-results/bash_123.txt",
+                output_persist_error: None,
+            });
 
         assert!(rendered.contains("Background Bash command completed successfully."));
         assert!(rendered.contains("status=\"completed\""));
@@ -1897,23 +1555,39 @@ mod tests {
     #[test]
     fn background_display_text_is_concise() {
         assert_eq!(
-            BashTool::format_background_command_display_text(Some(0), false, false),
+            format_background_command_display_text(BackgroundCommandStatusFacts {
+                exit_code: Some(0),
+                timed_out: false,
+                interrupted: false,
+            }),
             "Background Bash command completed successfully."
         );
         assert_eq!(
-            BashTool::format_background_command_display_text(Some(1), false, false),
+            format_background_command_display_text(BackgroundCommandStatusFacts {
+                exit_code: Some(1),
+                timed_out: false,
+                interrupted: false,
+            }),
             "Background Bash command completed with a non-zero exit code."
         );
         assert_eq!(
-            BashTool::format_background_command_display_text(None, true, false),
+            format_background_command_display_text(BackgroundCommandStatusFacts {
+                exit_code: None,
+                timed_out: true,
+                interrupted: false,
+            }),
             "Background Bash command timed out."
         );
         assert_eq!(
-            BashTool::format_background_command_display_text(Some(130), false, true),
+            format_background_command_display_text(BackgroundCommandStatusFacts {
+                exit_code: Some(130),
+                timed_out: false,
+                interrupted: true,
+            }),
             "Background Bash command was interrupted."
         );
         assert_eq!(
-            BashTool::format_background_command_error_display_text(),
+            format_background_command_error_display_text(),
             "Background Bash command failed before producing a final completion result."
         );
     }

--- a/src/crates/assembly/core/src/service/remote_connect/remote_server.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/remote_server.rs
@@ -10,19 +10,18 @@
 
 use crate::service_agent_runtime::{CoreRemoteSessionTrackerHost, CoreServiceAgentRuntime};
 use anyhow::{anyhow, Result};
-use log::info;
 use serde_json::Value;
 use std::sync::{Arc, OnceLock};
 
 use super::encryption;
 use bitfun_services_integrations::remote_connect::{
     build_remote_image_contexts, cancel_remote_task, generate_remote_initial_sync,
-    handle_remote_interaction_command, handle_remote_poll_command, handle_remote_session_command,
-    handle_remote_workspace_command, handle_remote_workspace_file_command,
-    remote_dialog_submit_response, remote_task_cancel_response,
-    resolve_remote_execution_image_contexts, submit_remote_dialog, RemoteCancelTaskRequest,
-    RemoteConnectSubmissionSource, RemoteDialogSubmissionPolicy, RemoteDialogSubmissionRequest,
-    RemoteDialogSubmitOutcome, RemoteImageContext, RemoteSessionTrackerRegistry,
+    handle_remote_command, handle_remote_interaction_command, handle_remote_poll_command,
+    handle_remote_session_command, handle_remote_workspace_command,
+    handle_remote_workspace_file_command, submit_remote_dialog, RemoteCancelTaskRequest,
+    RemoteCommandRuntimeHost, RemoteConnectSubmissionSource, RemoteDialogSubmissionPolicy,
+    RemoteDialogSubmissionRequest, RemoteDialogSubmitOutcome, RemoteImageContext,
+    RemoteSessionTrackerRegistry,
 };
 pub use bitfun_services_integrations::remote_connect::{
     ActiveTurnSnapshot, AssistantEntry, ChatImageAttachment, ChatMessage, ChatMessageItem,
@@ -57,9 +56,10 @@ fn remote_image_context_to_core(
 
 // ── RemoteExecutionDispatcher (global singleton) ────────────────────
 
-/// Shared dispatch layer that owns the session state trackers.
-/// Both `RemoteServer` (mobile relay) and the bot use this to
-/// dispatch commands through the same path.
+/// Shared tracker adapter for remote relay and bot execution paths.
+///
+/// Command routing lives in `bitfun-services-integrations`; core only keeps the
+/// global tracker registry adapter needed by concrete session/runtime hosts.
 pub struct RemoteExecutionDispatcher {
     tracker_registry: RemoteSessionTrackerRegistry,
 }
@@ -156,10 +156,82 @@ impl RemoteExecutionDispatcher {
     }
 }
 
+struct CoreRemoteCommandRuntimeHost<'a> {
+    dispatcher: &'a RemoteExecutionDispatcher,
+}
+
+impl<'a> CoreRemoteCommandRuntimeHost<'a> {
+    fn new(dispatcher: &'a RemoteExecutionDispatcher) -> Self {
+        Self { dispatcher }
+    }
+}
+
+#[async_trait::async_trait]
+impl RemoteCommandRuntimeHost for CoreRemoteCommandRuntimeHost<'_> {
+    type ImageContext = crate::agentic::image_analysis::ImageContextData;
+
+    async fn handle_workspace_command(&self, command: &RemoteCommand) -> RemoteResponse {
+        let host = CoreServiceAgentRuntime::remote_workspace_host();
+        handle_remote_workspace_command(&host, command).await
+    }
+
+    async fn handle_session_command(&self, command: &RemoteCommand) -> RemoteResponse {
+        let host = match CoreServiceAgentRuntime::remote_session_host() {
+            Ok(host) => host,
+            Err(message) => return RemoteResponse::Error { message },
+        };
+        handle_remote_session_command(&host, command).await
+    }
+
+    async fn handle_poll_command(&self, command: &RemoteCommand) -> RemoteResponse {
+        let host = CoreServiceAgentRuntime::remote_poll_host(self.dispatcher);
+        handle_remote_poll_command(&host, command).await
+    }
+
+    async fn handle_workspace_file_command(&self, command: &RemoteCommand) -> RemoteResponse {
+        let host = CoreServiceAgentRuntime::remote_workspace_file_host();
+        handle_remote_workspace_file_command(&host, command).await
+    }
+
+    async fn handle_interaction_command(&self, command: &RemoteCommand) -> RemoteResponse {
+        let host = CoreServiceAgentRuntime::remote_interaction_host();
+        handle_remote_interaction_command(&host, command).await
+    }
+
+    async fn submit_dialog(
+        &self,
+        request: RemoteDialogSubmissionRequest<Self::ImageContext>,
+    ) -> std::result::Result<RemoteDialogSubmitOutcome, String> {
+        let host = CoreServiceAgentRuntime::remote_dialog_host(self.dispatcher)?;
+        submit_remote_dialog(&host, request).await
+    }
+
+    async fn cancel_task(
+        &self,
+        request: RemoteCancelTaskRequest,
+    ) -> std::result::Result<(), String> {
+        let host = CoreServiceAgentRuntime::remote_cancel_host()?;
+        cancel_remote_task(&host, request).await
+    }
+
+    fn legacy_image_contexts(&self, images: Option<&[ImageAttachment]>) -> Vec<Self::ImageContext> {
+        build_core_image_contexts(images)
+    }
+
+    fn explicit_image_contexts(
+        &self,
+        contexts: Vec<RemoteImageContext>,
+    ) -> Vec<Self::ImageContext> {
+        contexts
+            .into_iter()
+            .map(remote_image_context_to_core)
+            .collect()
+    }
+}
+
 // ── RemoteServer ───────────────────────────────────────────────────
 
-/// Bridges remote commands to local session operations.
-/// Delegates execution and tracker management to the global `RemoteExecutionDispatcher`.
+/// Bridges encrypted remote payloads to the integrations-owned command router.
 pub struct RemoteServer {
     shared_secret: [u8; 32],
 }
@@ -205,39 +277,9 @@ impl RemoteServer {
     }
 
     pub async fn dispatch(&self, cmd: &RemoteCommand) -> RemoteResponse {
-        match cmd {
-            RemoteCommand::Ping => RemoteResponse::Pong,
-
-            RemoteCommand::GetWorkspaceInfo
-            | RemoteCommand::ListRecentWorkspaces
-            | RemoteCommand::SetWorkspace { .. }
-            | RemoteCommand::ListAssistants
-            | RemoteCommand::SetAssistant { .. } => self.handle_workspace_command(cmd).await,
-
-            RemoteCommand::ListSessions { .. }
-            | RemoteCommand::CreateSession { .. }
-            | RemoteCommand::GetModelCatalog { .. }
-            | RemoteCommand::SetSessionModel { .. }
-            | RemoteCommand::UpdateSessionTitle { .. }
-            | RemoteCommand::GetSessionMessages { .. }
-            | RemoteCommand::DeleteSession { .. } => self.handle_session_command(cmd).await,
-
-            RemoteCommand::SendMessage { .. }
-            | RemoteCommand::CancelTask { .. }
-            | RemoteCommand::ConfirmTool { .. }
-            | RemoteCommand::RejectTool { .. }
-            | RemoteCommand::CancelTool { .. }
-            | RemoteCommand::AnswerQuestion { .. } => self.handle_execution_command(cmd).await,
-
-            RemoteCommand::PollSession { .. } => self.handle_poll_command(cmd).await,
-
-            RemoteCommand::ReadFile { .. }
-            | RemoteCommand::ReadFileChunk { .. }
-            | RemoteCommand::GetFileInfo { .. } => {
-                let host = CoreServiceAgentRuntime::remote_workspace_file_host();
-                handle_remote_workspace_file_command(&host, cmd).await
-            }
-        }
+        let dispatcher = get_or_init_global_dispatcher();
+        let host = CoreRemoteCommandRuntimeHost::new(dispatcher.as_ref());
+        handle_remote_command(&host, cmd, RemoteConnectSubmissionSource::Relay).await
     }
 
     pub async fn generate_initial_sync(
@@ -247,94 +289,6 @@ impl RemoteServer {
         let host = CoreServiceAgentRuntime::remote_initial_sync_host();
         generate_remote_initial_sync(&host, authenticated_user_id).await
     }
-
-    // ── Poll command handler ────────────────────────────────────────
-
-    async fn handle_poll_command(&self, cmd: &RemoteCommand) -> RemoteResponse {
-        let dispatcher = get_or_init_global_dispatcher();
-        let host = CoreServiceAgentRuntime::remote_poll_host(dispatcher.as_ref());
-        handle_remote_poll_command(&host, cmd).await
-    }
-
-    // ── Workspace commands ──────────────────────────────────────────
-
-    async fn handle_workspace_command(&self, cmd: &RemoteCommand) -> RemoteResponse {
-        let host = CoreServiceAgentRuntime::remote_workspace_host();
-        handle_remote_workspace_command(&host, cmd).await
-    }
-
-    // ── Session commands ────────────────────────────────────────────
-
-    async fn handle_session_command(&self, cmd: &RemoteCommand) -> RemoteResponse {
-        let host = match CoreServiceAgentRuntime::remote_session_host() {
-            Ok(host) => host,
-            Err(message) => return RemoteResponse::Error { message },
-        };
-        handle_remote_session_command(&host, cmd).await
-    }
-
-    // ── Execution commands ──────────────────────────────────────────
-
-    async fn handle_execution_command(&self, cmd: &RemoteCommand) -> RemoteResponse {
-        let dispatcher = get_or_init_global_dispatcher();
-
-        match cmd {
-            RemoteCommand::SendMessage {
-                session_id,
-                content,
-                agent_type: requested_agent_type,
-                images,
-                image_contexts,
-            } => {
-                // Unified: prefer image_contexts (new format), fall back to legacy images
-                let explicit_contexts = image_contexts.clone().map(|contexts| {
-                    contexts
-                        .into_iter()
-                        .map(remote_image_context_to_core)
-                        .collect()
-                });
-                let resolved_contexts = resolve_remote_execution_image_contexts(
-                    images.as_ref().map(Vec::as_slice),
-                    explicit_contexts,
-                    build_core_image_contexts,
-                );
-                info!(
-                    "Remote send_message: session={session_id}, agent_type={}, image_contexts={}",
-                    requested_agent_type.as_deref().unwrap_or("agentic"),
-                    resolved_contexts.len()
-                );
-                remote_dialog_submit_response(
-                    dispatcher
-                        .send_message(
-                            session_id,
-                            content.clone(),
-                            requested_agent_type.as_deref(),
-                            resolved_contexts,
-                            RemoteConnectSubmissionSource::Relay,
-                            None,
-                        )
-                        .await,
-                )
-            }
-            RemoteCommand::CancelTask {
-                session_id,
-                turn_id,
-            } => remote_task_cancel_response(
-                session_id.clone(),
-                dispatcher.cancel_task(session_id, turn_id.as_deref()).await,
-            ),
-            RemoteCommand::ConfirmTool { .. }
-            | RemoteCommand::RejectTool { .. }
-            | RemoteCommand::CancelTool { .. }
-            | RemoteCommand::AnswerQuestion { .. } => {
-                let host = CoreServiceAgentRuntime::remote_interaction_host();
-                handle_remote_interaction_command(&host, cmd).await
-            }
-            _ => RemoteResponse::Error {
-                message: "Unknown execution command".into(),
-            },
-        }
-    }
 }
 
 #[cfg(test)]
@@ -342,7 +296,8 @@ mod tests {
     use super::*;
     use crate::service::remote_connect::encryption::KeyPair;
     use bitfun_services_integrations::remote_connect::{
-        remote_session_restore_target, resolve_remote_cancel_decision, RemoteCancelDecision,
+        remote_session_restore_target, resolve_remote_cancel_decision,
+        resolve_remote_execution_image_contexts, RemoteCancelDecision,
     };
 
     #[test]

--- a/src/crates/execution/tool-execution/src/lib.rs
+++ b/src/crates/execution/tool-execution/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod fs;
 pub mod search;
+pub mod shell;
 pub mod util;

--- a/src/crates/execution/tool-execution/src/shell/mod.rs
+++ b/src/crates/execution/tool-execution/src/shell/mod.rs
@@ -1,0 +1,378 @@
+use std::collections::HashMap;
+
+use crate::util::ansi_cleaner::strip_ansi;
+use crate::util::string::shell_single_quote;
+
+pub const BASH_RESULT_MAX_OUTPUT_LENGTH: usize = 30_000;
+pub const BASH_INTERRUPT_OUTPUT_DRAIN_MS: u64 = 500;
+
+const BANNED_COMMANDS: &[&str] = &[
+    "alias",
+    // "curl",
+    // "curlie",
+    // "wget",
+    // "axel",
+    // "aria2c",
+    // "nc",
+    // "telnet",
+    // "lynx",
+    // "w3m",
+    // "links",
+    // "httpie",
+    // "xh",
+    // "http-prompt",
+    // "chrome",
+    // "firefox",
+    // "safari",
+];
+
+pub fn banned_shell_command(cmd: &str) -> Option<&str> {
+    let base_cmd = cmd.split_whitespace().next()?;
+    let base_cmd_lc = base_cmd.to_lowercase();
+    BANNED_COMMANDS
+        .iter()
+        .any(|banned| base_cmd_lc == *banned)
+        .then_some(base_cmd)
+}
+
+pub fn detect_osascript_keystroke_non_ascii(cmd: &str) -> Option<String> {
+    if !cmd.contains("osascript") {
+        return None;
+    }
+
+    let bytes = cmd.as_bytes();
+    let needle = b"keystroke";
+    let mut i = 0usize;
+    while i + needle.len() < bytes.len() {
+        if &bytes[i..i + needle.len()] == needle {
+            let mut j = i + needle.len();
+            while j < bytes.len() && bytes[j] != b'"' {
+                j += 1;
+            }
+            if j >= bytes.len() {
+                break;
+            }
+            let start = j + 1;
+            let mut end = start;
+            while end < bytes.len() && bytes[end] != b'"' {
+                end += 1;
+            }
+            if end > bytes.len() {
+                break;
+            }
+            let literal = &cmd[start..end.min(cmd.len())];
+            if !literal.is_ascii() {
+                return Some(literal.to_string());
+            }
+            i = end + 1;
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+pub fn detect_osascript_im_app(cmd: &str) -> Option<&'static str> {
+    if !cmd.contains("osascript") {
+        return None;
+    }
+    const IM_APPS: &[&str] = &[
+        "WeChat", "微信", "iMessage", "Messages", "Slack", "Lark", "飞书", "Telegram", "DingTalk",
+        "钉钉", "QQ", "Discord", "Teams", "Whatsapp", "WhatsApp",
+    ];
+    let cmd_lc = cmd.to_lowercase();
+    for app in IM_APPS {
+        let app_lc = app.to_lowercase();
+        if cmd.contains(app) || cmd_lc.contains(&app_lc) {
+            return Some(*app);
+        }
+    }
+    None
+}
+
+pub fn command_for_working_directory(command: &str, working_directory: Option<&str>) -> String {
+    working_directory
+        .map(str::trim)
+        .filter(|dir| !dir.is_empty())
+        .map(|dir| format!("cd {} && {}", shell_single_quote(dir), command))
+        .unwrap_or_else(|| command.to_string())
+}
+
+pub fn bash_noninteractive_env() -> HashMap<String, String> {
+    let mut env = HashMap::new();
+    env.insert("BITFUN_NONINTERACTIVE".to_string(), "1".to_string());
+    env.insert("GIT_PAGER".to_string(), "cat".to_string());
+    env.insert("PAGER".to_string(), "cat".to_string());
+    env.insert("GIT_TERMINAL_PROMPT".to_string(), "0".to_string());
+    env.insert("GIT_EDITOR".to_string(), "true".to_string());
+    env
+}
+
+pub fn truncate_output_preserving_tail(s: &str, max_chars: usize) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= max_chars {
+        return s.to_string();
+    }
+
+    let tail_bias = max_chars.saturating_mul(4) / 5;
+    let separator = "\n... [truncated, middle omitted, tail preserved] ...\n";
+    let separator_len = separator.chars().count();
+
+    if separator_len >= max_chars {
+        return chars[chars.len() - max_chars..].iter().collect();
+    }
+
+    let content_budget = max_chars - separator_len;
+    let tail_len = tail_bias.min(content_budget);
+    let head_len = content_budget.saturating_sub(tail_len);
+
+    let head: String = chars[..head_len].iter().collect();
+    let tail: String = chars[chars.len() - tail_len..].iter().collect();
+
+    format!("{head}{separator}{tail}")
+}
+
+pub struct LocalShellResultRenderRequest<'a> {
+    pub terminal_session_id: &'a str,
+    pub working_directory: &'a str,
+    pub output_text: &'a str,
+    pub interrupted: bool,
+    pub timed_out: bool,
+    pub exit_code: i32,
+    pub shell_state: Option<&'a str>,
+}
+
+pub fn render_local_shell_result(request: LocalShellResultRenderRequest<'_>) -> String {
+    let mut result_string = String::new();
+
+    result_string.push_str(&format!("<exit_code>{}</exit_code>", request.exit_code));
+    if !request.working_directory.is_empty() {
+        result_string.push_str(&format!(
+            "<working_directory>{}</working_directory>",
+            request.working_directory
+        ));
+    }
+
+    if let Some(output_block) =
+        render_output_block_with_limit("output", request.output_text, BASH_RESULT_MAX_OUTPUT_LENGTH)
+    {
+        result_string.push_str(&output_block);
+    }
+
+    if let Some(state) = request.shell_state {
+        let cleaned_state = strip_ansi(state);
+        result_string.push_str(&format!("<shell_state>{}</shell_state>", cleaned_state));
+    }
+
+    if request.timed_out {
+        result_string.push_str(
+            "<status type=\"timeout\">Command timed out before completion. Partial output, if any, is included above.</status>",
+        );
+    } else if request.interrupted {
+        result_string.push_str(
+            "<status type=\"interrupted\">Command was canceled by the user. ASK THE USER what they would like to do next.</status>"
+        );
+    }
+
+    result_string.push_str(&format!(
+        "<terminal_session_id>{}</terminal_session_id>",
+        request.terminal_session_id
+    ));
+
+    result_string
+}
+
+pub fn render_output_block_with_limit(
+    tag: &str,
+    output_text: &str,
+    max_chars: usize,
+) -> Option<String> {
+    if output_text.is_empty() {
+        return None;
+    }
+
+    let cleaned_output = strip_ansi(output_text);
+    let output_len = cleaned_output.chars().count();
+    if max_chars == 0 {
+        Some(format!(
+            "<{tag} truncated=\"true\">... [truncated, no budget remaining] ...</{tag}>"
+        ))
+    } else if output_len > max_chars {
+        let truncated = truncate_output_preserving_tail(&cleaned_output, max_chars);
+        Some(format!("<{tag} truncated=\"true\">{}</{tag}>", truncated))
+    } else {
+        Some(format!("<{tag}>{}</{tag}>", cleaned_output))
+    }
+}
+
+pub fn remote_stream_budgets(stdout: &str, stderr: &str) -> (usize, usize) {
+    let stdout_len = strip_ansi(stdout).chars().count();
+    let stderr_len = strip_ansi(stderr).chars().count();
+
+    if stderr_len >= BASH_RESULT_MAX_OUTPUT_LENGTH {
+        return (0, BASH_RESULT_MAX_OUTPUT_LENGTH);
+    }
+
+    let stderr_budget = stderr_len;
+    let stdout_budget = BASH_RESULT_MAX_OUTPUT_LENGTH.saturating_sub(stderr_budget);
+    (stdout_budget.min(stdout_len), stderr_budget)
+}
+
+pub struct RemoteShellResultRenderRequest<'a> {
+    pub working_directory: &'a str,
+    pub stdout: &'a str,
+    pub stderr: &'a str,
+    pub interrupted: bool,
+    pub timed_out: bool,
+    pub exit_code: i32,
+}
+
+pub fn render_remote_shell_result(request: RemoteShellResultRenderRequest<'_>) -> String {
+    let mut result_string = String::new();
+    result_string.push_str("<remote_ssh>true</remote_ssh>");
+    result_string.push_str(&format!("<exit_code>{}</exit_code>", request.exit_code));
+    if !request.working_directory.is_empty() {
+        result_string.push_str(&format!(
+            "<working_directory>{}</working_directory>",
+            request.working_directory
+        ));
+    }
+
+    let (stdout_budget, stderr_budget) = remote_stream_budgets(request.stdout, request.stderr);
+
+    if let Some(stdout_block) =
+        render_output_block_with_limit("stdout", request.stdout, stdout_budget)
+    {
+        result_string.push_str(&stdout_block);
+    }
+    if let Some(stderr_block) =
+        render_output_block_with_limit("stderr", request.stderr, stderr_budget)
+    {
+        result_string.push_str(&stderr_block);
+    }
+
+    if request.timed_out {
+        result_string.push_str(
+            "<status type=\"timeout\">Command timed out before completion. Partial stdout/stderr, if any, is included above.</status>",
+        );
+    } else if request.interrupted {
+        result_string.push_str(
+            "<status type=\"interrupted\">Command was canceled before completion. ASK THE USER what they would like to do next.</status>",
+        );
+    }
+
+    result_string
+}
+
+pub struct BackgroundCommandStatusFacts {
+    pub exit_code: Option<i32>,
+    pub timed_out: bool,
+    pub interrupted: bool,
+}
+
+pub struct BackgroundCommandDeliveryTextRequest<'a> {
+    pub command: &'a str,
+    pub terminal_session_id: &'a str,
+    pub working_directory: &'a str,
+    pub status: BackgroundCommandStatusFacts,
+    pub output_file_reference: &'a str,
+    pub output_persist_error: Option<&'a str>,
+}
+
+pub fn format_background_command_delivery_text(
+    request: BackgroundCommandDeliveryTextRequest<'_>,
+) -> String {
+    let (status, summary) = if request.status.timed_out {
+        ("timeout", "Background Bash command timed out.")
+    } else if request.status.interrupted {
+        ("interrupted", "Background Bash command was interrupted.")
+    } else if request.status.exit_code == Some(0) {
+        (
+            "completed",
+            "Background Bash command completed successfully.",
+        )
+    } else {
+        (
+            "failed",
+            "Background Bash command completed with a non-zero exit code.",
+        )
+    };
+    let exit_code_attr = request
+        .status
+        .exit_code
+        .map(|code| format!(" exit_code=\"{}\"", code))
+        .unwrap_or_default();
+    let persistence_line = request.output_persist_error.map_or_else(
+        || {
+            format!(
+                "Full output was saved to: {}",
+                request.output_file_reference
+            )
+        },
+        |error| {
+            format!(
+                "Output persistence encountered an error while writing {}: {}",
+                request.output_file_reference, error
+            )
+        },
+    );
+
+    format!(
+        "{summary}\n<background_command status=\"{status}\" terminal_session_id=\"{terminal_session_id}\"{exit_code_attr}>\nCommand: {command}\nWorking directory: {working_directory}\n{persistence_line}\n</background_command>",
+        terminal_session_id = request.terminal_session_id,
+        command = request.command,
+        working_directory = request.working_directory,
+    )
+}
+
+pub fn format_background_command_display_text(status: BackgroundCommandStatusFacts) -> String {
+    if status.timed_out {
+        "Background Bash command timed out.".to_string()
+    } else if status.interrupted {
+        "Background Bash command was interrupted.".to_string()
+    } else if status.exit_code == Some(0) {
+        "Background Bash command completed successfully.".to_string()
+    } else {
+        "Background Bash command completed with a non-zero exit code.".to_string()
+    }
+}
+
+pub struct BackgroundCommandErrorTextRequest<'a> {
+    pub command: &'a str,
+    pub terminal_session_id: &'a str,
+    pub working_directory: &'a str,
+    pub output_file_reference: &'a str,
+    pub error: &'a str,
+    pub output_persist_error: Option<&'a str>,
+}
+
+pub fn format_background_command_error_text(
+    request: BackgroundCommandErrorTextRequest<'_>,
+) -> String {
+    let persistence_line = request.output_persist_error.map_or_else(
+        || {
+            format!(
+                "Any captured output was saved to: {}",
+                request.output_file_reference
+            )
+        },
+        |persist_error| {
+            format!(
+                "Output persistence encountered an error while writing {}: {}",
+                request.output_file_reference, persist_error
+            )
+        },
+    );
+
+    format!(
+        "Background Bash command failed before producing a final completion result.\n<background_command status=\"error\" terminal_session_id=\"{terminal_session_id}\">\nCommand: {command}\nWorking directory: {working_directory}\n{persistence_line}\nError: {error}\n</background_command>",
+        terminal_session_id = request.terminal_session_id,
+        command = request.command,
+        working_directory = request.working_directory,
+        error = request.error,
+    )
+}
+
+pub fn format_background_command_error_display_text() -> String {
+    "Background Bash command failed before producing a final completion result.".to_string()
+}

--- a/src/crates/execution/tool-execution/tests/tool_io_contracts.rs
+++ b/src/crates/execution/tool-execution/tests/tool_io_contracts.rs
@@ -16,6 +16,16 @@ use tool_runtime::search::grep_search::{
     apply_offset_and_limit, build_remote_grep_command, count_remote_grep_matches,
     relativize_result_text, render_remote_grep_result_text, OutputMode, RemoteGrepCommandRequest,
 };
+use tool_runtime::shell::{
+    banned_shell_command, bash_noninteractive_env, command_for_working_directory,
+    detect_osascript_im_app, detect_osascript_keystroke_non_ascii,
+    format_background_command_delivery_text, format_background_command_display_text,
+    format_background_command_error_display_text, format_background_command_error_text,
+    render_local_shell_result, render_output_block_with_limit, render_remote_shell_result,
+    BackgroundCommandDeliveryTextRequest, BackgroundCommandErrorTextRequest,
+    BackgroundCommandStatusFacts, LocalShellResultRenderRequest, RemoteShellResultRenderRequest,
+    BASH_RESULT_MAX_OUTPUT_LENGTH,
+};
 use tool_runtime::util::string::shell_single_quote;
 
 fn make_temp_dir(name: &str) -> PathBuf {
@@ -184,6 +194,132 @@ fn remote_glob_stdout_is_normalized_and_limited_by_tool_runtime() {
 #[test]
 fn shell_single_quote_preserves_existing_remote_escape_style() {
     assert_eq!(shell_single_quote("C:/repo/a'b"), "'C:/repo/a'\\''b'");
+}
+
+#[test]
+fn bash_shell_owner_preserves_command_wrapping_and_env() {
+    assert_eq!(
+        command_for_working_directory("pnpm test", Some(" C:/repo/a'b ")),
+        "cd 'C:/repo/a'\\''b' && pnpm test"
+    );
+    assert_eq!(command_for_working_directory("pwd", Some("  ")), "pwd");
+    assert_eq!(command_for_working_directory("pwd", None), "pwd");
+
+    let env = bash_noninteractive_env();
+    assert_eq!(
+        env.get("BITFUN_NONINTERACTIVE").map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(env.get("GIT_PAGER").map(String::as_str), Some("cat"));
+    assert_eq!(env.get("PAGER").map(String::as_str), Some("cat"));
+    assert_eq!(
+        env.get("GIT_TERMINAL_PROMPT").map(String::as_str),
+        Some("0")
+    );
+    assert_eq!(env.get("GIT_EDITOR").map(String::as_str), Some("true"));
+
+    assert_eq!(banned_shell_command("alias ll='ls -la'"), Some("alias"));
+    assert_eq!(banned_shell_command(" git status "), None);
+}
+
+#[test]
+fn bash_shell_owner_preserves_guard_and_result_rendering() {
+    assert_eq!(
+        detect_osascript_keystroke_non_ascii(
+            r#"osascript -e 'tell app "System Events" to keystroke "你好"'"#
+        ),
+        Some("你好".to_string())
+    );
+    assert_eq!(
+        detect_osascript_im_app(r#"osascript -e 'tell application "Slack" to activate'"#),
+        Some("Slack")
+    );
+    assert_eq!(
+        detect_osascript_im_app(r#"osascript -e 'tell application "微信" to activate'"#),
+        Some("微信")
+    );
+
+    let local = render_local_shell_result(LocalShellResultRenderRequest {
+        terminal_session_id: "term-1",
+        working_directory: "C:/repo",
+        output_text: "\u{1b}[31mhello\u{1b}[0m",
+        interrupted: true,
+        timed_out: false,
+        exit_code: 130,
+        shell_state: Some("\u{1b}[32mPS C:/repo>\u{1b}[0m"),
+    });
+    assert!(local.contains("<exit_code>130</exit_code>"));
+    assert!(local.contains("<working_directory>C:/repo</working_directory>"));
+    assert!(local.contains("<output>hello</output>"));
+    assert!(local.contains("<shell_state>PS C:/repo></shell_state>"));
+    assert!(local.contains("<status type=\"interrupted\">"));
+    assert!(local.contains("<terminal_session_id>term-1</terminal_session_id>"));
+
+    let truncated =
+        render_output_block_with_limit("stdout", "abcdef", 4).expect("output block should render");
+    assert!(truncated.contains("truncated=\"true\""));
+    assert!(truncated.ends_with(">cdef</stdout>"));
+
+    let remote = render_remote_shell_result(RemoteShellResultRenderRequest {
+        working_directory: "/repo",
+        stdout: "ok",
+        stderr: "err",
+        interrupted: false,
+        timed_out: true,
+        exit_code: 124,
+    });
+    assert!(remote.contains("<remote_ssh>true</remote_ssh>"));
+    assert!(remote.contains("<stdout>ok</stdout>"));
+    assert!(remote.contains("<stderr>err</stderr>"));
+    assert!(remote.contains("<status type=\"timeout\">"));
+    assert_eq!(BASH_RESULT_MAX_OUTPUT_LENGTH, 30_000);
+}
+
+#[test]
+fn bash_shell_owner_preserves_background_delivery_texts() {
+    let delivery = format_background_command_delivery_text(BackgroundCommandDeliveryTextRequest {
+        command: "pnpm dev",
+        terminal_session_id: "term-bg",
+        working_directory: "C:/repo",
+        status: BackgroundCommandStatusFacts {
+            exit_code: Some(0),
+            timed_out: false,
+            interrupted: false,
+        },
+        output_file_reference: "artifact://tool-results/bg.txt",
+        output_persist_error: None,
+    });
+    assert!(delivery.starts_with("Background Bash command completed successfully."));
+    assert!(delivery.contains(
+        "<background_command status=\"completed\" terminal_session_id=\"term-bg\" exit_code=\"0\">"
+    ));
+    assert!(delivery.contains("Full output was saved to: artifact://tool-results/bg.txt"));
+
+    assert_eq!(
+        format_background_command_display_text(BackgroundCommandStatusFacts {
+            exit_code: None,
+            timed_out: true,
+            interrupted: false,
+        }),
+        "Background Bash command timed out."
+    );
+
+    let error = format_background_command_error_text(BackgroundCommandErrorTextRequest {
+        command: "pnpm dev",
+        terminal_session_id: "term-bg",
+        working_directory: "C:/repo",
+        output_file_reference: "artifact://tool-results/bg.txt",
+        error: "boom",
+        output_persist_error: Some("disk full"),
+    });
+    assert!(error
+        .starts_with("Background Bash command failed before producing a final completion result."));
+    assert!(error.contains("Output persistence encountered an error"));
+    assert!(error.contains("Error: boom"));
+    assert_eq!(
+        format_background_command_error_display_text(),
+        "Background Bash command failed before producing a final completion result."
+    );
 }
 
 #[test]

--- a/src/crates/services/services-integrations/src/remote_connect.rs
+++ b/src/crates/services/services-integrations/src/remote_connect.rs
@@ -17,6 +17,7 @@ pub use bitfun_runtime_ports::{
     RemoteWorkspaceFileRuntimeHost, RemoteWorkspaceKind, RemoteWorkspacePort,
     RemoteWorkspaceRuntimeHost, RemoteWorkspaceUpdate,
 };
+use log::info;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -2098,6 +2099,115 @@ pub enum RemoteResponse {
     Error {
         message: String,
     },
+}
+
+/// Host callbacks required by full remote-connect command routing.
+///
+/// This owner crate decides how wire commands are grouped and translated into
+/// remote responses. Product runtimes only provide concrete service adapters.
+#[async_trait::async_trait]
+pub trait RemoteCommandRuntimeHost: Send + Sync {
+    type ImageContext: Send + Sync + 'static;
+
+    async fn handle_workspace_command(&self, command: &RemoteCommand) -> RemoteResponse;
+    async fn handle_session_command(&self, command: &RemoteCommand) -> RemoteResponse;
+    async fn handle_poll_command(&self, command: &RemoteCommand) -> RemoteResponse;
+    async fn handle_workspace_file_command(&self, command: &RemoteCommand) -> RemoteResponse;
+    async fn handle_interaction_command(&self, command: &RemoteCommand) -> RemoteResponse;
+
+    async fn submit_dialog(
+        &self,
+        request: RemoteDialogSubmissionRequest<Self::ImageContext>,
+    ) -> Result<RemoteDialogSubmitOutcome, String>;
+
+    async fn cancel_task(&self, request: RemoteCancelTaskRequest) -> Result<(), String>;
+
+    fn legacy_image_contexts(&self, images: Option<&[ImageAttachment]>) -> Vec<Self::ImageContext>;
+
+    fn explicit_image_contexts(&self, contexts: Vec<RemoteImageContext>)
+        -> Vec<Self::ImageContext>;
+}
+
+pub async fn handle_remote_command<H>(
+    host: &H,
+    command: &RemoteCommand,
+    source: RemoteConnectSubmissionSource,
+) -> RemoteResponse
+where
+    H: RemoteCommandRuntimeHost + ?Sized,
+{
+    match command {
+        RemoteCommand::Ping => RemoteResponse::Pong,
+
+        RemoteCommand::GetWorkspaceInfo
+        | RemoteCommand::ListRecentWorkspaces
+        | RemoteCommand::SetWorkspace { .. }
+        | RemoteCommand::ListAssistants
+        | RemoteCommand::SetAssistant { .. } => host.handle_workspace_command(command).await,
+
+        RemoteCommand::ListSessions { .. }
+        | RemoteCommand::CreateSession { .. }
+        | RemoteCommand::GetModelCatalog { .. }
+        | RemoteCommand::SetSessionModel { .. }
+        | RemoteCommand::UpdateSessionTitle { .. }
+        | RemoteCommand::GetSessionMessages { .. }
+        | RemoteCommand::DeleteSession { .. } => host.handle_session_command(command).await,
+
+        RemoteCommand::PollSession { .. } => host.handle_poll_command(command).await,
+
+        RemoteCommand::ReadFile { .. }
+        | RemoteCommand::ReadFileChunk { .. }
+        | RemoteCommand::GetFileInfo { .. } => host.handle_workspace_file_command(command).await,
+
+        RemoteCommand::ConfirmTool { .. }
+        | RemoteCommand::RejectTool { .. }
+        | RemoteCommand::CancelTool { .. }
+        | RemoteCommand::AnswerQuestion { .. } => host.handle_interaction_command(command).await,
+
+        RemoteCommand::SendMessage {
+            session_id,
+            content,
+            agent_type,
+            images,
+            image_contexts,
+        } => {
+            let resolved_contexts = resolve_remote_execution_image_contexts(
+                images.as_ref().map(Vec::as_slice),
+                image_contexts
+                    .clone()
+                    .map(|contexts| host.explicit_image_contexts(contexts)),
+                |images| host.legacy_image_contexts(images),
+            );
+            info!(
+                "Remote send_message: session={session_id}, agent_type={}, image_contexts={}",
+                agent_type.as_deref().unwrap_or("agentic"),
+                resolved_contexts.len()
+            );
+            remote_dialog_submit_response(
+                host.submit_dialog(RemoteDialogSubmissionRequest {
+                    session_id: session_id.clone(),
+                    content: content.clone(),
+                    agent_type: agent_type.clone(),
+                    image_contexts: resolved_contexts,
+                    policy: RemoteDialogSubmissionPolicy::for_source(source),
+                    turn_id: None,
+                })
+                .await,
+            )
+        }
+
+        RemoteCommand::CancelTask {
+            session_id,
+            turn_id,
+        } => remote_task_cancel_response(
+            session_id.clone(),
+            host.cancel_task(RemoteCancelTaskRequest {
+                session_id: session_id.clone(),
+                requested_turn_id: turn_id.clone(),
+            })
+            .await,
+        ),
+    }
 }
 
 /// Build a slim version of tool params for remote preview payloads.

--- a/src/crates/services/services-integrations/tests/remote_connect_contracts.rs
+++ b/src/crates/services/services-integrations/tests/remote_connect_contracts.rs
@@ -8,9 +8,9 @@ use bitfun_services_integrations::remote_connect::{
     build_remote_chat_messages, build_remote_image_attachment, build_remote_image_contexts,
     build_remote_image_submission_request, build_remote_model_catalog,
     build_remote_session_create_request, build_remote_submission_request, cancel_remote_task,
-    handle_remote_workspace_file_command, make_slim_tool_params, normalize_remote_model_selection,
-    normalize_remote_session_model_id, read_remote_workspace_file,
-    read_remote_workspace_file_chunk, read_remote_workspace_file_info,
+    handle_remote_command, handle_remote_workspace_file_command, make_slim_tool_params,
+    normalize_remote_model_selection, normalize_remote_session_model_id,
+    read_remote_workspace_file, read_remote_workspace_file_chunk, read_remote_workspace_file_info,
     remote_answer_question_response, remote_assistant_list_response,
     remote_assistant_updated_response, remote_dialog_submit_outcome_from_scheduler,
     remote_dialog_submit_response, remote_file_chunk_response, remote_file_content_response,
@@ -29,15 +29,15 @@ use bitfun_services_integrations::remote_connect::{
     RemoteAssistantWorkspaceFacts, RemoteCancelDecision, RemoteCancelRuntimeHost,
     RemoteCancelTaskRequest, RemoteChatHistoryRound, RemoteChatHistoryTextItem,
     RemoteChatHistoryThinkingItem, RemoteChatHistoryToolCall, RemoteChatHistoryToolItem,
-    RemoteChatHistoryTurn, RemoteCommand, RemoteConnectSubmissionSource, RemoteDefaultModelsConfig,
-    RemoteDialogQueuePriority, RemoteDialogResolvedSubmission, RemoteDialogRuntimeHost,
-    RemoteDialogSchedulerOutcomeFact, RemoteDialogSubmissionPolicy, RemoteDialogSubmissionRequest,
-    RemoteDialogSubmitOutcome, RemoteImageContext, RemoteImageContextAdapter,
-    RemoteModelCapabilityFact, RemoteModelCatalog, RemoteModelCatalogFacts, RemoteModelConfig,
-    RemoteModelFacts, RemoteReasoningModeFact, RemoteRecentWorkspaceFacts, RemoteResponse,
-    RemoteSessionMetadata, RemoteSessionStateTracker, RemoteSessionTrackerHost,
-    RemoteSessionTrackerRegistry, RemoteTerminalPrewarmRequest, RemoteToolStatus,
-    RemoteWorkspaceFacts, RemoteWorkspaceFileChunk, RemoteWorkspaceFileContent,
+    RemoteChatHistoryTurn, RemoteCommand, RemoteCommandRuntimeHost, RemoteConnectSubmissionSource,
+    RemoteDefaultModelsConfig, RemoteDialogQueuePriority, RemoteDialogResolvedSubmission,
+    RemoteDialogRuntimeHost, RemoteDialogSchedulerOutcomeFact, RemoteDialogSubmissionPolicy,
+    RemoteDialogSubmissionRequest, RemoteDialogSubmitOutcome, RemoteImageContext,
+    RemoteImageContextAdapter, RemoteModelCapabilityFact, RemoteModelCatalog,
+    RemoteModelCatalogFacts, RemoteModelConfig, RemoteModelFacts, RemoteReasoningModeFact,
+    RemoteRecentWorkspaceFacts, RemoteResponse, RemoteSessionMetadata, RemoteSessionStateTracker,
+    RemoteSessionTrackerHost, RemoteSessionTrackerRegistry, RemoteTerminalPrewarmRequest,
+    RemoteToolStatus, RemoteWorkspaceFacts, RemoteWorkspaceFileChunk, RemoteWorkspaceFileContent,
     RemoteWorkspaceFileInfo, RemoteWorkspaceFileRuntimeHost, RemoteWorkspaceKind,
     RemoteWorkspaceUpdate, TrackerEvent, REMOTE_FILE_MAX_CHUNK_BYTES, REMOTE_FILE_MAX_READ_BYTES,
 };
@@ -576,6 +576,259 @@ impl RemoteCancelRuntimeHost for RecordingCancelHost {
             Ok(())
         }
     }
+}
+
+#[derive(Default)]
+struct RecordingCommandHost {
+    events: Mutex<Vec<String>>,
+    submitted_dialog: Mutex<Option<RemoteDialogSubmissionRequest<String>>>,
+    cancel_request: Mutex<Option<RemoteCancelTaskRequest>>,
+    explicit_context_ids: Mutex<Vec<String>>,
+    legacy_image_names: Mutex<Vec<String>>,
+}
+
+impl RecordingCommandHost {
+    fn events(&self) -> Vec<String> {
+        self.events.lock().unwrap().clone()
+    }
+
+    fn submitted_dialog(&self) -> RemoteDialogSubmissionRequest<String> {
+        self.submitted_dialog
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("dialog submitted")
+    }
+
+    fn cancel_request(&self) -> RemoteCancelTaskRequest {
+        self.cancel_request
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("cancel requested")
+    }
+}
+
+#[async_trait::async_trait]
+impl RemoteCommandRuntimeHost for RecordingCommandHost {
+    type ImageContext = String;
+
+    async fn handle_workspace_command(&self, _command: &RemoteCommand) -> RemoteResponse {
+        self.events.lock().unwrap().push("workspace".to_string());
+        RemoteResponse::WorkspaceInfo {
+            has_workspace: false,
+            path: None,
+            project_name: None,
+            git_branch: None,
+            workspace_kind: None,
+            assistant_id: None,
+        }
+    }
+
+    async fn handle_session_command(&self, _command: &RemoteCommand) -> RemoteResponse {
+        self.events.lock().unwrap().push("session".to_string());
+        RemoteResponse::SessionCreated {
+            session_id: "session-created".to_string(),
+        }
+    }
+
+    async fn handle_poll_command(&self, _command: &RemoteCommand) -> RemoteResponse {
+        self.events.lock().unwrap().push("poll".to_string());
+        RemoteResponse::SessionPoll {
+            version: 0,
+            changed: false,
+            session_state: None,
+            title: None,
+            new_messages: None,
+            total_msg_count: None,
+            active_turn: None,
+            model_catalog: Box::new(None),
+        }
+    }
+
+    async fn handle_workspace_file_command(&self, _command: &RemoteCommand) -> RemoteResponse {
+        self.events.lock().unwrap().push("file".to_string());
+        RemoteResponse::FileInfo {
+            name: "file.txt".to_string(),
+            size: 1,
+            mime_type: "text/plain".to_string(),
+        }
+    }
+
+    async fn handle_interaction_command(&self, _command: &RemoteCommand) -> RemoteResponse {
+        self.events.lock().unwrap().push("interaction".to_string());
+        RemoteResponse::InteractionAccepted {
+            action: "confirm_tool".to_string(),
+            target_id: "tool-1".to_string(),
+        }
+    }
+
+    async fn submit_dialog(
+        &self,
+        request: RemoteDialogSubmissionRequest<Self::ImageContext>,
+    ) -> Result<RemoteDialogSubmitOutcome, String> {
+        self.events.lock().unwrap().push("submit".to_string());
+        *self.submitted_dialog.lock().unwrap() = Some(request.clone());
+        Ok(RemoteDialogSubmitOutcome::Started {
+            session_id: request.session_id,
+            turn_id: "turn-command".to_string(),
+        })
+    }
+
+    async fn cancel_task(&self, request: RemoteCancelTaskRequest) -> Result<(), String> {
+        self.events.lock().unwrap().push("cancel".to_string());
+        *self.cancel_request.lock().unwrap() = Some(request);
+        Ok(())
+    }
+
+    fn legacy_image_contexts(&self, images: Option<&[ImageAttachment]>) -> Vec<Self::ImageContext> {
+        let names = images
+            .unwrap_or_default()
+            .iter()
+            .map(|image| image.name.clone())
+            .collect::<Vec<_>>();
+        *self.legacy_image_names.lock().unwrap() = names.clone();
+        names
+            .into_iter()
+            .map(|name| format!("legacy:{name}"))
+            .collect()
+    }
+
+    fn explicit_image_contexts(
+        &self,
+        contexts: Vec<RemoteImageContext>,
+    ) -> Vec<Self::ImageContext> {
+        let ids = contexts
+            .into_iter()
+            .map(|context| context.id)
+            .collect::<Vec<_>>();
+        *self.explicit_context_ids.lock().unwrap() = ids.clone();
+        ids.into_iter().map(|id| format!("explicit:{id}")).collect()
+    }
+}
+
+#[tokio::test]
+async fn remote_connect_command_owner_routes_send_message_and_prefers_explicit_images() {
+    let host = RecordingCommandHost::default();
+
+    let response = handle_remote_command(
+        &host,
+        &RemoteCommand::SendMessage {
+            session_id: "session-1".to_string(),
+            content: "hello".to_string(),
+            agent_type: Some("code".to_string()),
+            images: Some(vec![ImageAttachment {
+                name: "legacy.png".to_string(),
+                data_url: "data:image/png;base64,legacy".to_string(),
+            }]),
+            image_contexts: Some(vec![RemoteImageContext {
+                id: "ctx-1".to_string(),
+                image_path: Some("D:/workspace/project/screenshot.png".to_string()),
+                data_url: None,
+                mime_type: "image/png".to_string(),
+                metadata: Some(serde_json::json!({ "source": "desktop" })),
+            }]),
+        },
+        RemoteConnectSubmissionSource::Bot,
+    )
+    .await;
+
+    assert_eq!(
+        response,
+        RemoteResponse::MessageSent {
+            session_id: "session-1".to_string(),
+            turn_id: "turn-command".to_string()
+        }
+    );
+    assert_eq!(host.events(), vec!["submit"]);
+    assert_eq!(
+        host.explicit_context_ids.lock().unwrap().as_slice(),
+        &["ctx-1".to_string()]
+    );
+    assert!(host.legacy_image_names.lock().unwrap().is_empty());
+
+    let submitted = host.submitted_dialog();
+    assert_eq!(submitted.session_id, "session-1");
+    assert_eq!(submitted.content, "hello");
+    assert_eq!(submitted.agent_type.as_deref(), Some("code"));
+    assert_eq!(submitted.image_contexts, vec!["explicit:ctx-1".to_string()]);
+    assert_eq!(submitted.policy.source, RemoteConnectSubmissionSource::Bot);
+    assert!(submitted.turn_id.is_none());
+}
+
+#[tokio::test]
+async fn remote_connect_command_owner_preserves_cancel_and_group_routing() {
+    let host = RecordingCommandHost::default();
+
+    assert_eq!(
+        handle_remote_command(
+            &host,
+            &RemoteCommand::Ping,
+            RemoteConnectSubmissionSource::Relay
+        )
+        .await,
+        RemoteResponse::Pong
+    );
+
+    let workspace = handle_remote_command(
+        &host,
+        &RemoteCommand::GetWorkspaceInfo,
+        RemoteConnectSubmissionSource::Relay,
+    )
+    .await;
+    assert!(matches!(workspace, RemoteResponse::WorkspaceInfo { .. }));
+
+    let file = handle_remote_command(
+        &host,
+        &RemoteCommand::GetFileInfo {
+            path: "README.md".to_string(),
+            session_id: None,
+        },
+        RemoteConnectSubmissionSource::Relay,
+    )
+    .await;
+    assert!(matches!(file, RemoteResponse::FileInfo { .. }));
+
+    let interaction = handle_remote_command(
+        &host,
+        &RemoteCommand::ConfirmTool {
+            tool_id: "tool-1".to_string(),
+            updated_input: None,
+        },
+        RemoteConnectSubmissionSource::Relay,
+    )
+    .await;
+    assert!(matches!(
+        interaction,
+        RemoteResponse::InteractionAccepted { .. }
+    ));
+
+    let cancel = handle_remote_command(
+        &host,
+        &RemoteCommand::CancelTask {
+            session_id: "session-1".to_string(),
+            turn_id: Some("turn-1".to_string()),
+        },
+        RemoteConnectSubmissionSource::Relay,
+    )
+    .await;
+    assert_eq!(
+        cancel,
+        RemoteResponse::TaskCancelled {
+            session_id: "session-1".to_string()
+        }
+    );
+    assert_eq!(
+        host.events(),
+        vec!["workspace", "file", "interaction", "cancel"]
+    );
+    assert_eq!(
+        host.cancel_request(),
+        RemoteCancelTaskRequest {
+            session_id: "session-1".to_string(),
+            requested_turn_id: Some("turn-1".to_string()),
+        }
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Move remote-connect command routing and response assembly ownership into `bitfun-services-integrations`; core `RemoteServer` now delegates through host adapters.
- Move reusable Bash shell policies, command wrapping, noninteractive env, local/remote result rendering, and background-result text into `tool-runtime::shell`; core `BashTool` keeps terminal/session/checkpoint/cancellation/scheduler glue.
- Add focused owner tests and boundary rules, then update the active plan and completed-summary docs without changing stable architecture design docs.

## Risk and behavior boundary

- No tool schema, permission semantics, terminal lifecycle, remote wire shape, or product capability exposure changes are intended.
- `tool-runtime` adds no new third-party dependencies and does not depend on `bitfun-core`, Tauri, provider clients, or platform-specific runtime APIs.
- Indexed workspace search service ownership, permission wait, checkpoint orchestration, and full tool pipeline migration remain in the next milestone and are documented as unfinished.

## Verification

- `cargo test -p tool-runtime`
- `cargo test -p bitfun-core bash_tool --features product-full`
- `cargo test -p bitfun-core remote_answer_question_preserves_user_input_manager_path --features product-full`
- `cargo test -p bitfun-services-integrations --features remote-connect remote_connect_command_owner --tests`
- `cargo check -p bitfun-core --features product-full`
- `cargo check -p bitfun-core --no-default-features`
- `node scripts/check-core-boundaries.mjs`
- `node --test scripts/check-core-boundaries.test.mjs`
- `pnpm run check:repo-hygiene`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`