### PR TITLE
refactor(core): migrate remaining search runtime policies

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -27,9 +27,9 @@
 ### 1.3 Tool 与 Product Capability 基线
 
 - `tool-contracts`（Cargo package `bitfun-agent-tools`）已承接 provider-neutral tool DTO、manifest/catalog 策略、execution admission gate、collapsed unlock gate、static provider materialization 和 plan-to-registry assembly。
-- `tool-execution`（Cargo package `tool-runtime`）已承接本地 Write / Edit / Delete / Glob、远程 Delete / Read / LS / Glob / Grep，以及 Bash shell 可复用策略：禁用命令、工作目录命令包装、非交互环境、AppleScript/IM guard、本地/远程结果渲染和 background result 文本。core BashTool 只保留 agent-facing adapter、终端 session、权限、checkpoint、cancellation、scheduler delivery 和 host context glue。
-- `services-integrations` 已承接本地 indexed workspace search 的 flashgrep daemon/session lifecycle、scan fallback、scope/path normalization、status/result conversion、preview mapping 和 daemon binary resolution；core `WorkspaceSearchService` 只保留旧路径 facade、产品 config hook、workspace bootstrap hook 和 `BitFunError` 映射。remote workspace search concrete owner 仍在 core remote SSH glue，迁移前会临时复用公开的 flashgrep 协议/session 类型。
-- `tool-contracts` 已承接 tool pipeline 的截断恢复提示和 write-like tool 分类；core tool pipeline 只委托该纯策略并保留执行状态、permission channel、checkpoint、scheduler 和 cancellation glue。
+- `tool-execution`（Cargo package `tool-runtime`）已承接本地 Write / Edit / Delete / Glob、远程 Delete / Read / LS / Glob / Grep、tool pipeline batching plan、retry policy，以及 Bash shell 可复用策略：禁用命令、工作目录命令包装、非交互环境、AppleScript/IM guard、本地/远程结果渲染和 background result 文本。core BashTool / ToolPipeline 只保留 agent-facing adapter、终端 session、权限 UI/channel、checkpoint 采集、cancellation、scheduler delivery 和 host context glue。
+- `services-integrations` 已承接本地 indexed workspace search 的 flashgrep daemon/session lifecycle、scan fallback、scope/path normalization、status/result conversion、preview mapping 和 daemon binary resolution；flashgrep protocol internals 已收回为 crate-private，core 通过 `WorkspaceSearchRepoConfig` hook 接入产品配置。同时承接 remote SSH workspace search 的 provider-neutral path/scope/probe/bundle/retry 策略与 concrete owner：remote flashgrep session/context cache、binary 安装/校验、stdio 协议请求、search/glob 组装和 FilesWithMatches fallback。core `WorkspaceSearchService` 只保留旧路径 facade、产品 config hook、workspace bootstrap hook 和 `BitFunError` 映射；core remote search 只保留 provider adapter、窄 stdio facade 与 russh bridge。
+- `tool-contracts` 已承接 tool pipeline 的截断恢复提示和 write-like tool 分类；`agent-runtime` 已承接 tool confirmation plan/failure/wait-result 与 light checkpoint summary policy；core tool pipeline / tool context 只委托这些纯策略并保留执行状态、permission channel、Git facts 采集、scheduler 和 cancellation glue。
 - `tool-provider-groups`（Cargo package `bitfun-tool-packs`）已承接 tool provider group plan、按 id 选择和 unknown provider group 校验。
 - `product-capabilities` 已承接 capability id、required service capability、tool provider group selection 和 harness provider selection 等 assembly facts。
 - Product Assembly 已承接 `DeliveryProfile`、`CapabilitySet`、product-full provider plan、service availability report 和 profile-scoped harness registry 入口。
@@ -56,8 +56,8 @@
 - boundary check 覆盖 owner crate 禁止依赖、旧路径 facade-only、回流约束、Product Assembly facade 收口和物理 crate layout。
 - boundary check 覆盖 remote-connect command routing owner，要求 core 委托 `services-integrations`，并阻止 response assembly / command policy 回流 core。
 - boundary check 覆盖 Bash shell helper owner，要求 core 委托 `tool-runtime::shell`，并阻止输出渲染、background result 文本、命令包装和 guard 策略回流 core。
-- boundary check 覆盖本地 workspace search owner，要求 core search facade 委托 `services-integrations::workspace_search`，并阻止 flashgrep session、scan fallback、preview/result conversion 和 path normalization 回流 core。
-- boundary check 覆盖 tool truncation recovery presentation owner，要求 core tool pipeline 委托 `bitfun-agent-tools`。
+- boundary check 覆盖本地 workspace search owner，要求 core search facade 委托 `services-integrations::workspace_search`，并阻止 flashgrep session、scan fallback、preview/result conversion 和 path normalization 回流 core；remote SSH search 纯策略与 concrete owner 由 `services-integrations::remote_ssh::workspace_search` 承接。
+- boundary check 覆盖 tool truncation recovery presentation、confirmation wait-result、light checkpoint summary、batching plan 与 retry policy owner，要求 core tool pipeline / tool context 委托 `bitfun-agent-tools`、`bitfun-agent-runtime` 和 `tool-runtime::pipeline`。
 - DeepReview 路径分类按六层物理 crate 解析，避免把同层多个 crate 合并成一个风险 area。
 - focused baseline 已覆盖 tool manifest、GetToolSpec、execution admission、MiniApp storage / builtin asset、remote workspace fallback、MCP config/catalog、agent-runtime prompt cache、custom subagent、thread-goal tools、AskUserQuestion、DeepReview hook measurement、tool confirmation、product capability pack、session restore、local/remote tool IO helper、function-agent Git、scheduled-job state 等路径。
 
@@ -66,5 +66,5 @@
 - `bitfun-core` 仍是完整产品 runtime 组装点，不能声称已经退化为纯 compatibility facade。
 - 产品入口仍主要通过 `bitfun-core/product-full` 获取完整能力；Product Assembly 已可表达当前完整能力集合，但尚未真正按交付形态裁剪 default feature / dependency。
 - concrete session manager、scheduler lifecycle、event delivery、permission UI/channel wait、prompt assembly、session persistence IO、AI client factory / provider acquisition 仍在 core。
-- Bash tool orchestration 的可复用 shell helper 和本地 indexed workspace search owner 已迁出；terminal lifecycle / PTY、permission wait、checkpoint orchestration、remote workspace search concrete owner、remote shell executor abstraction、remote terminal concrete impl、MiniApp worker / host / seed / marker IO、Deep Review / DeepResearch / MiniApp concrete workflow execution 仍未完成 owner 迁移。
+- Bash tool orchestration 的可复用 shell helper、本地 indexed workspace search owner、remote workspace search concrete owner、tool confirmation/checkpoint 纯策略和 tool pipeline batching/retry policy 已迁出；terminal lifecycle / PTY、permission UI/channel side effect、tool pipeline concrete state/cancellation/scheduler glue、remote shell executor abstraction、remote terminal concrete impl、MiniApp worker / host / seed / marker IO、Deep Review / DeepResearch / MiniApp concrete workflow execution 仍未完成 owner 迁移。
 - no-default 与 product-full 的依赖边界已有数据基线，但 no-default 仍包含较大 concrete 依赖；不能声称各交付形态已达到最小依赖。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -23,7 +23,7 @@
 - Desktop / CLI / ACP 仍通过 `bitfun-core/product-full` 获取完整能力；Server / Web / Mobile Web 不直接依赖 core，但尚未完成按交付形态裁剪最小 feature / dependency。
 - `runtime-services` 已有 typed builder、capability availability 和 core product runtime provider adapter，但不少 concrete provider 仍在 core 创建或持有。
 - remote-connect command routing、wire response assembly、workspace/session/poll/file/dialog/cancel/interaction helper 和 state tracker contract 已归入 `services-integrations`；core 保留 host adapter、加密入口和全局 tracker 接线。
-- `tool-contracts` 已承接 provider-neutral tool manifest、admission、catalog、result policy、tool execution presentation 和截断恢复提示等纯策略；`tool-execution` 已承接低层 IO/search helper 以及 Bash shell 可复用策略与结果渲染；`services-integrations` 已承接本地 indexed workspace search service owner。terminal lifecycle、remote workspace search concrete owner、permission wait、checkpoint orchestration 和完整 execution pipeline 仍未完全迁移；当前 `flashgrep` 协议/session 公开面仅用于 remote search 迁移前兼容复用，M9 应随 remote owner 收口同步收窄。
+- `tool-contracts` 已承接 provider-neutral tool manifest、admission、catalog、result policy、tool execution presentation 和截断恢复提示等纯策略；`tool-execution` 已承接低层 IO/search helper、Bash shell 可复用策略、结果渲染、tool pipeline batching plan 与 retry policy；`services-integrations` 已承接本地 indexed workspace search service owner、crate-private flashgrep protocol internals、remote SSH search 纯策略与 remote workspace search concrete owner；`agent-runtime` 已承接 tool confirmation plan/failure/wait-result 和 light checkpoint summary policy。terminal lifecycle / PTY、permission UI channel side effect、tool pipeline concrete state/cancellation/scheduler glue 和完整 execution pipeline owner 仍未完全迁移。
 - `agent-stream` 已承接统一 stream DTO、tool-call 累积和 replay 契约；provider SSE / 响应解析测试归属 `ai-adapters`。
 - `harness` 当前主要承接 descriptor / route plan / registry contract；Deep Review、DeepResearch、MiniApp 的 concrete workflow execution 仍在 core 或产品路径。
 - `product-domains` 已承接 MiniApp / function-agent 的部分纯领域逻辑；worker、host side effect、AI acquisition、marker IO 等 concrete path 仍未完成 owner 迁移。
@@ -42,15 +42,14 @@
 
 ## 4. 后续执行节奏
 
-M6 Service / Adapter owner 深迁移、M7 Bash shell execution helper owner 迁移和 M8 本地 indexed workspace search / tool presentation 纯策略收口已完成事实归档到
+M6 Service / Adapter owner 深迁移、M7 Bash shell execution helper owner 迁移、M8 本地 indexed workspace search / tool presentation 纯策略收口，以及 M9 remote search / checkpoint / confirmation / pipeline policy 收口已完成事实归档到
 [`core-decomposition-completed.md`](core-decomposition-completed.md)。后续计划从
-remote search / permission / checkpoint / tool pipeline orchestration 等更高风险 owner 迁移开始，避免再把已完成的 service/adapter、Bash helper 或本地 search 收口项重复拆成小 PR。
+terminal lifecycle、concrete workflow execution、scheduler/session side effect、feature trimming 和 core facade 收口继续推进，避免再把已完成的 service/adapter、Bash helper、search owner 或 pipeline policy 收口项重复拆成小 PR。
 
 | 阶段 | 目标 | 准出标准 |
 |---|---|---|
-| M9 Remote search / tool pipeline orchestration 收口 | 将 remote workspace search concrete owner、permission wait、checkpoint orchestration 和可复用 tool pipeline orchestration 继续从 core 收敛到明确 owner；如需改变权限或 checkpoint 行为必须单独评审 | remote/local search、permission、GetToolSpec、oversized result、checkpoint 与 cancellation 行为等价；不改变工具 schema 和权限语义 |
 | M10 Harness / Agent runtime 收口 | 将 Deep Review / DeepResearch / MiniApp workflow concrete execution、scheduler lifecycle、event delivery、prompt assembly 和 session side effect 继续从 core 收敛到 owner 边界 | workflow route 与 side effect 有 focused tests；agent runtime 不依赖 service/app concrete impl |
-| M11 Product shape / feature trimming | 基于 capability matrix 裁剪 no-default/product-full 和不同交付形态依赖 | cargo metadata / cargo tree 有对比数据；各产品形态构建与关键入口验证通过 |
+| M11 Terminal / product shape / feature trimming | 收敛 terminal lifecycle / PTY、remote shell/terminal concrete impl，并基于 capability matrix 裁剪 no-default/product-full 和不同交付形态依赖 | cargo metadata / cargo tree 有对比数据；terminal、remote 与各产品形态关键入口验证通过 |
 | M12 Core facade 收口 | 将 `bitfun-core` 限定为 compatibility facade、product-full assembly 和少量迁移期 adapter | core 不再是事实 runtime owner；边界脚本阻止 owner 逻辑回流 |
 
 ## 5. 固定执行流程

--- a/scripts/core-boundaries/rules/source/forbidden-rules.mjs
+++ b/scripts/core-boundaries/rules/source/forbidden-rules.mjs
@@ -157,6 +157,90 @@ export const forbiddenContentRules = [
     ],
   },
   {
+    path: 'src/crates/assembly/core/src/service/search/mod.rs',
+    patterns: [
+      {
+        regex: /\bbitfun_services_integrations::workspace_search::flashgrep\b/,
+        message:
+          'core must not import flashgrep internals; use the remote workspace-search stdio facade instead',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/assembly/core/src/service/search/service.rs',
+    patterns: [
+      {
+        regex:
+          /\b(?:owner::flashgrep|workspace_search::flashgrep|bitfun_services_integrations::workspace_search::flashgrep)\b/,
+        message:
+          'core workspace search facade must not depend on flashgrep internals; use stable workspace-search config and DTO APIs',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/assembly/core/src/service/search/remote.rs',
+    patterns: [
+      {
+        regex: /\bconst\s+REMOTE_FLASHGREP_INSTALL_DIR\b/,
+        message:
+          'core remote workspace search must not own remote flashgrep install facts; use bitfun-services-integrations::remote_ssh::workspace_search',
+      },
+      {
+        regex: /\bconst\s+REMOTE_(?:OS|ARCHITECTURE)_PROBES\b/,
+        message:
+          'core remote workspace search must not own remote probe facts; use bitfun-services-integrations::remote_ssh::workspace_search',
+      },
+      {
+        regex: /\bstruct\s+LocalFlashgrepBundle\b/,
+        message:
+          'core remote workspace search must not own local remote-search bundle DTOs; use bitfun-services-integrations::remote_ssh::workspace_search',
+      },
+      {
+        regex:
+          /\bfn\s+(?:build_remote_scope|normalize_remote_scope_path|remote_flashgrep_install_dir|parse_remote_architecture_output|parse_remote_os_output|local_flashgrep_bundle_for_arch|remote_stdio_search_mode|should_retry_remote_scan_fallback_as_files_with_matches|join_remote_path|shell_escape)\b/,
+        message:
+          'core remote workspace search must not re-own provider-neutral remote search strategy helpers',
+      },
+      {
+        regex: /\b(?:RemoteStdioRepoSession|RemoteStdioDaemonClient|RemoteSearchContext|REMOTE_STDIO_SESSIONS|REMOTE_SEARCH_CONTEXTS)\b/,
+        message:
+          'core remote workspace search must not own remote flashgrep session/context lifecycle; use bitfun-services-integrations::remote_ssh::workspace_search',
+      },
+      {
+        regex: /\bfn\s+(?:ensure_remote_search_context|convert_stdio_search_results|remote_stdio_session_key|remote_search_context_key|schedule_remote_stdio_session_release)\b/,
+        message:
+          'core remote workspace search must not re-own remote search concrete lifecycle helpers',
+      },
+      {
+        regex:
+          /\b(?:ProtocolClient|drain_content_length_messages|log_flashgrep_stderr_line_with_context|FLASHGREP_LOG_TARGET)\b/,
+        message:
+          'core remote workspace search must not depend on flashgrep protocol internals; use RemoteWorkspaceSearchStdioProtocol',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/services/services-integrations/src/workspace_search/mod.rs',
+    patterns: [
+      {
+        regex: /\bpub\s+mod\s+flashgrep\b/,
+        message:
+          'workspace_search must not publicly expose flashgrep protocol internals',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/services/services-integrations/src/remote_ssh/workspace_search/mod.rs',
+    patterns: [
+      {
+        regex:
+          /\bpub\s+(?:const|struct|fn)\s+(?:REMOTE_OS_PROBES|REMOTE_ARCHITECTURE_PROBES|LocalFlashgrepBundle|build_remote_scope|remote_flashgrep_install_dir|remote_workspace_search_storage_root|looks_like_linux_workspace_root|parse_remote_architecture_output|parse_remote_os_output|local_flashgrep_bundle_for_arch|remote_stdio_search_mode|should_retry_remote_scan_fallback_as_files_with_matches|join_remote_path|shell_escape)\b/,
+        message:
+          'remote workspace-search helper APIs must stay crate-internal; expose only reviewed provider/service contracts',
+      },
+    ],
+  },
+  {
     path: 'src/crates/assembly/core/src/miniapp/runtime_detect.rs',
     patterns: [
       {
@@ -526,6 +610,41 @@ export const forbiddenContentRules = [
         regex: /\bfn is_write_like_tool_name\b/,
         message:
           'core tool pipeline must not own write-like truncation classification; use bitfun-agent-tools',
+      },
+      {
+        regex: /\bstruct\s+ToolBatch\b/,
+        message:
+          'core tool pipeline must not own portable batching DTOs; use tool-runtime::pipeline',
+      },
+      {
+        regex: /\bfn\s+partition_tool_batches\b/,
+        message:
+          'core tool pipeline must not own portable batching strategy; use tool-runtime::pipeline',
+      },
+      {
+        regex: /Duration::from_millis\(100\s*\*\s*attempts/,
+        message:
+          'core tool pipeline must not own retry backoff policy; use tool-runtime::pipeline',
+      },
+      {
+        regex: /ToolConfirmationOutcome::(?:Rejected|ChannelClosed|Timeout)/,
+        message:
+          'core tool pipeline must not own confirmation wait-result mapping; use bitfun-agent-runtime',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs',
+    patterns: [
+      {
+        regex: /remote_workspace_git_metadata_unavailable|workspace_unavailable|git_status_unavailable:/,
+        message:
+          'core tool context must not own light-checkpoint summary policy; use bitfun-agent-runtime::checkpoint',
+      },
+      {
+        regex: /format!\(\s*"staged=\{\}, unstaged=\{\}, untracked=\{\}"/,
+        message:
+          'core tool context must not own local git dirty-state checkpoint formatting; use bitfun-agent-runtime::checkpoint',
       },
     ],
   },

--- a/scripts/core-boundaries/rules/source/required-rules.mjs
+++ b/scripts/core-boundaries/rules/source/required-rules.mjs
@@ -466,6 +466,10 @@ export const requiredContentRules = [
         message: 'missing tool confirmation outcome contract',
       },
       {
+        regex: /\bpub enum ToolConfirmationWaitResult\b/,
+        message: 'missing tool confirmation wait-result contract',
+      },
+      {
         regex: /\bpub enum ConfirmationFailureKind\b/,
         message: 'missing tool confirmation failure kind',
       },
@@ -476,6 +480,33 @@ export const requiredContentRules = [
       {
         regex: /\bpub fn resolve_confirmation_failure\b/,
         message: 'missing tool confirmation failure resolver',
+      },
+      {
+        regex: /\bpub fn resolve_confirmation_wait_result\b/,
+        message: 'missing tool confirmation wait-result resolver',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/execution/agent-runtime/src/checkpoint.rs',
+    reason:
+      'agent-runtime must own provider-neutral light-checkpoint summary policy while core keeps concrete Git/session IO',
+    patterns: [
+      {
+        regex: /\bpub struct LightCheckpoint\b/,
+        message: 'missing light checkpoint DTO',
+      },
+      {
+        regex: /\bpub enum LightCheckpointWorkspaceFacts\b/,
+        message: 'missing light checkpoint workspace facts',
+      },
+      {
+        regex: /\bpub struct GitStatusCheckpointFacts\b/,
+        message: 'missing git status checkpoint facts',
+      },
+      {
+        regex: /\bpub fn build_light_checkpoint\b/,
+        message: 'missing light checkpoint builder',
       },
     ],
   },
@@ -495,6 +526,10 @@ export const requiredContentRules = [
       {
         regex: /\bconfirmation_failure_mapping_preserves_legacy_reasons_and_errors\b/,
         message: 'missing tool confirmation failure mapping regression',
+      },
+      {
+        regex: /\bconfirmation_wait_result_mapping_preserves_legacy_timeout_and_rejection\b/,
+        message: 'missing tool confirmation wait-result mapping regression',
       },
     ],
   },
@@ -1040,8 +1075,20 @@ export const requiredContentRules = [
         message: 'missing tool confirmation failure mapping delegation',
       },
       {
+        regex: /\bresolve_confirmation_wait_result\b/,
+        message: 'missing tool confirmation wait-result mapping delegation',
+      },
+      {
         regex: /\bToolConfirmationPlan::Await\b/,
         message: 'missing tool confirmation await-plan handling',
+      },
+      {
+        regex: /\bshould_retry_tool_attempt\b/,
+        message: 'missing tool-runtime retry decision delegation',
+      },
+      {
+        regex: /\bretry_delay_ms\b/,
+        message: 'missing tool-runtime retry backoff delegation',
       },
     ],
   },
@@ -1277,6 +1324,52 @@ export const requiredContentRules = [
       {
         regex: /\bbash_shell_owner_preserves_background_delivery_texts\b/,
         message: 'missing Bash background-result text owner regression',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/execution/tool-execution/src/pipeline.rs',
+    reason:
+      'tool-runtime must own provider-neutral tool batching and retry policy while core keeps concrete execution state',
+    patterns: [
+      {
+        regex: /\bpub struct ToolBatch\b/,
+        message: 'missing tool batch DTO',
+      },
+      {
+        regex: /\bpub fn partition_tool_batches\b/,
+        message: 'missing tool batching policy',
+      },
+      {
+        regex: /\bpub enum ToolExecutionErrorClass\b/,
+        message: 'missing tool retry error class',
+      },
+      {
+        regex: /\bpub struct ToolRetryAttemptFacts\b/,
+        message: 'missing tool retry attempt facts',
+      },
+      {
+        regex: /\bpub fn should_retry_tool_attempt\b/,
+        message: 'missing tool retry decision policy',
+      },
+      {
+        regex: /\bpub fn retry_delay_ms\b/,
+        message: 'missing tool retry backoff policy',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/execution/tool-execution/tests/tool_pipeline_planning.rs',
+    reason:
+      'tool-runtime pipeline owner must keep behavior-equivalence contracts for batching and retry policy',
+    patterns: [
+      {
+        regex: /\bpartitions_consecutive_concurrency_safe_tools_into_parallel_batches\b/,
+        message: 'missing tool batching regression',
+      },
+      {
+        regex: /\bretry_policy_preserves_attempt_limit_and_error_class_contract\b/,
+        message: 'missing tool retry policy regression',
       },
     ],
   },
@@ -3625,6 +3718,14 @@ export const requiredContentRules = [
         message: 'missing Deep Review checkpoint binding',
       },
       {
+        regex: /\bbuild_runtime_light_checkpoint\b/,
+        message: 'missing agent-runtime light checkpoint policy delegation',
+      },
+      {
+        regex: /\bLightCheckpointWorkspaceFacts::LocalWorkspace\b/,
+        message: 'missing local checkpoint facts delegation',
+      },
+      {
         regex: /\bcall_with_tool_runtime_hooks\b/,
         message: 'missing tool-call cancellation/post-call hook binding',
       },
@@ -4080,14 +4181,36 @@ export const requiredContentRules = [
     ],
   },
   {
+    path: 'src/crates/services/services-integrations/src/workspace_search/mod.rs',
+    reason:
+      'workspace_search must keep flashgrep protocol internals crate-private and expose stable DTO/service APIs only',
+    patterns: [
+      {
+        regex: /\bpub\(crate\)\s+mod\s+flashgrep\b/,
+        message: 'flashgrep protocol internals must stay crate-private',
+      },
+    ],
+  },
+  {
     path: 'src/crates/services/services-integrations/src/workspace_search/service.rs',
     reason:
-      'services-integrations workspace_search must own local flashgrep fallback, session lifecycle, and preview/result conversion',
+      'services-integrations workspace_search must own local flashgrep fallback and session lifecycle',
     patterns: [
+      {
+        regex: /\bpub struct WorkspaceSearchRepoConfig\b/,
+        message: 'missing stable workspace-search repo config contract',
+      },
       {
         regex: /\bwith_scan_fallback\b/,
         message: 'missing flashgrep scan fallback request flag',
       },
+    ],
+  },
+  {
+    path: 'src/crates/services/services-integrations/src/workspace_search/result_mapping.rs',
+    reason:
+      'services-integrations workspace_search result mapping must own shared flashgrep preview/result conversion',
+    patterns: [
       {
         regex: /\bconvert_hits_to_file_search_results\b/,
         message: 'missing hit-to-file-result conversion owner',
@@ -4116,6 +4239,10 @@ export const requiredContentRules = [
         message: 'missing core runtime hook adapter',
       },
       {
+        regex: /\bWorkspaceSearchRepoConfig\b/,
+        message: 'missing stable workspace-search repo config hook',
+      },
+      {
         regex: /\bget_global_config_service\b/,
         message: 'missing product config hook for workspace-search repo config',
       },
@@ -4126,25 +4253,95 @@ export const requiredContentRules = [
     ],
   },
   {
-    path: 'src/crates/assembly/core/src/service/search/remote.rs',
+    path: 'src/crates/services/services-integrations/src/remote_ssh/workspace_search/mod.rs',
     reason:
-      'core remote search runtime must continue owning remote flashgrep fallback/session behavior until search migration is reviewed',
+      'remote SSH workspace_search strategy helpers must stay crate-internal and keep behavior-equivalence tests near the owner',
     patterns: [
       {
-        regex: /\bremote_workspace_search_service_for_path\b/,
-        message: 'missing remote workspace search resolver',
+        regex: /\bpub\(crate\)\s+fn\s+build_remote_scope\b/,
+        message: 'remote scope helper must stay crate-internal',
       },
       {
-        regex: /\blookup_remote_connection_with_hint\b/,
-        message: 'missing preferred remote connection lookup',
+        regex: /\bpub\(crate\)\s+fn\s+shell_escape\b/,
+        message: 'remote shell escaping helper must stay crate-internal',
       },
       {
-        regex: /\ballow_scan_fallback\b/,
+        regex: /\bpub\(crate\)\s+fn\s+should_retry_remote_scan_fallback_as_files_with_matches\b/,
+        message: 'remote scan fallback retry policy must stay crate-internal',
+      },
+      {
+        regex: /\bremote_workspace_search_paths_preserve_current_contract\b/,
+        message: 'missing remote path contract regression',
+      },
+      {
+        regex: /\bremote_scan_fallback_retry_policy_preserves_current_contract\b/,
+        message: 'missing remote scan fallback retry regression',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/services/services-integrations/src/remote_ssh/workspace_search/service.rs',
+    reason:
+      'services-integrations remote SSH workspace_search must own remote flashgrep concrete session, fallback, and binary lifecycle behind provider traits',
+    patterns: [
+      {
+        regex: /\bpub trait RemoteWorkspaceSearchProvider\b/,
+        message: 'missing remote search provider boundary',
+      },
+      {
+        regex: /\bpub struct RemoteWorkspaceSearchService\b/,
+        message: 'missing remote workspace search service owner',
+      },
+      {
+        regex: /\bpub struct RemoteWorkspaceSearchStdioProtocol\b/,
+        message: 'missing narrow remote stdio protocol facade',
+      },
+      {
+        regex: /\bREMOTE_STDIO_SESSIONS\b/,
+        message: 'missing remote stdio session lifecycle owner',
+      },
+      {
+        regex: /\bensure_remote_search_context\b/,
+        message: 'missing remote search context lifecycle owner',
+      },
+      {
+        regex: /\ballow_scan_fallback:\s*true\b/,
         message: 'missing remote scan fallback contract',
       },
       {
         regex: /\bfallback_query\b/,
         message: 'missing FilesWithMatches fallback query',
+      },
+      {
+        regex: /\bremote_search_rejects_non_linux_before_stdio_open\b/,
+        message: 'missing remote OS gate regression',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/assembly/core/src/service/search/remote.rs',
+    reason:
+      'core remote search runtime must remain a compatibility facade over services-integrations while retaining concrete SSH/russh bridge adapters',
+    patterns: [
+      {
+        regex: /\bServiceRemoteWorkspaceSearchService\b/,
+        message: 'missing services remote search owner delegation',
+      },
+      {
+        regex: /\bimpl RemoteWorkspaceSearchProvider for CoreRemoteWorkspaceSearchProvider\b/,
+        message: 'missing core remote search provider adapter',
+      },
+      {
+        regex: /\blookup_remote_connection_with_hint\b/,
+        message: 'missing preferred remote connection lookup adapter',
+      },
+      {
+        regex: /\bopen_exec_channel\b/,
+        message: 'missing SSH stdio bridge adapter',
+      },
+      {
+        regex: /\bRemoteWorkspaceSearchStdioProtocol\b/,
+        message: 'missing narrow stdio protocol facade in core remote bridge',
       },
     ],
   },

--- a/scripts/core-boundaries/self-test.mjs
+++ b/scripts/core-boundaries/self-test.mjs
@@ -832,9 +832,11 @@ export function runManifestParserSelfTest({
         'ToolConfirmationRequestFacts',
         'ToolConfirmationPlan',
         'ToolConfirmationOutcome',
+        'ToolConfirmationWaitResult',
         'ConfirmationFailureKind',
         'resolve_tool_confirmation_plan',
         'resolve_confirmation_failure',
+        'resolve_confirmation_wait_result',
       ],
     },
     {
@@ -843,6 +845,16 @@ export function runManifestParserSelfTest({
         'confirmation_plan_requires_permission_only_when_both_flags_are_true',
         'confirmation_plan_preserves_legacy_no_timeout_one_year_deadline',
         'confirmation_failure_mapping_preserves_legacy_reasons_and_errors',
+        'confirmation_wait_result_mapping_preserves_legacy_timeout_and_rejection',
+      ],
+    },
+    {
+      path: 'src/crates/execution/agent-runtime/src/checkpoint.rs',
+      contracts: [
+        'LightCheckpoint',
+        'LightCheckpointWorkspaceFacts',
+        'GitStatusCheckpointFacts',
+        'build_light_checkpoint',
       ],
     },
     {
@@ -1052,6 +1064,12 @@ export function runManifestParserSelfTest({
     {
       path: 'src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs',
       contracts: [
+        'resolve_tool_confirmation_plan',
+        'resolve_confirmation_failure',
+        'resolve_confirmation_wait_result',
+        'ToolConfirmationPlan::Await',
+        'should_retry_tool_attempt',
+        'retry_delay_ms',
         'build_tool_call_truncation_recovery_notice',
         'truncation_notice_for_interactive_tools_does_not_claim_file_write',
         'truncation_notice_for_write_tools_keeps_write_continuation_guidance',
@@ -1065,6 +1083,24 @@ export function runManifestParserSelfTest({
     {
       path: 'src/crates/assembly/core/src/agentic/tools/tool_result_storage.rs',
       contracts: ['write_once', 'file\\.flush\\(\\)\\.await'],
+    },
+    {
+      path: 'src/crates/execution/tool-execution/src/pipeline.rs',
+      contracts: [
+        'ToolBatch',
+        'partition_tool_batches',
+        'ToolExecutionErrorClass',
+        'ToolRetryAttemptFacts',
+        'should_retry_tool_attempt',
+        'retry_delay_ms',
+      ],
+    },
+    {
+      path: 'src/crates/execution/tool-execution/tests/tool_pipeline_planning.rs',
+      contracts: [
+        'partitions_consecutive_concurrency_safe_tools_into_parallel_batches',
+        'retry_policy_preserves_attempt_limit_and_error_class_contract',
+      ],
     },
     {
       path: 'src/crates/services/services-integrations/src/mcp/server/connection.rs',
@@ -1582,6 +1618,8 @@ export function runManifestParserSelfTest({
         'unlocked_collapsed_tools',
         'impl ToolUseContext',
         'record_light_checkpoint',
+        'build_runtime_light_checkpoint',
+        'LightCheckpointWorkspaceFacts::LocalWorkspace',
         'call_with_tool_runtime_hooks',
         'call_tool_with_runtime_hooks',
         'call_records_deep_review_read_file_measurement_without_touching_result',
@@ -1705,16 +1743,38 @@ export function runManifestParserSelfTest({
       contracts: ['prepare_startup_restored_workspaces', 'WorkspaceKind::Remote', 'ensure_remote_workspace_runtime', 'sshHost'],
     },
     {
+      path: 'src/crates/services/services-integrations/src/workspace_search/mod.rs',
+      contracts: ['flashgrep'],
+    },
+    {
       path: 'src/crates/services/services-integrations/src/workspace_search/service.rs',
-      contracts: ['with_scan_fallback', 'convert_hits_to_file_search_results', 'split_preview', 'preview_inside'],
+      contracts: ['WorkspaceSearchRepoConfig', 'with_scan_fallback'],
+    },
+    {
+      path: 'src/crates/services/services-integrations/src/workspace_search/result_mapping.rs',
+      contracts: ['convert_hits_to_file_search_results', 'split_preview', 'preview_inside'],
     },
     {
       path: 'src/crates/assembly/core/src/service/search/service.rs',
-      contracts: ['owner::WorkspaceSearchService::new_with_hooks', 'CoreWorkspaceSearchRuntimeHooks', 'get_global_config_service', 'ensure_workspace_gitignore_ignores_bitfun'],
+      contracts: ['owner::WorkspaceSearchService::new_with_hooks', 'CoreWorkspaceSearchRuntimeHooks', 'WorkspaceSearchRepoConfig', 'get_global_config_service', 'ensure_workspace_gitignore_ignores_bitfun'],
     },
     {
       path: 'src/crates/assembly/core/src/service/search/remote.rs',
-      contracts: ['remote_workspace_search_service_for_path', 'lookup_remote_connection_with_hint', 'allow_scan_fallback', 'fallback_query'],
+      contracts: ['ServiceRemoteWorkspaceSearchService', 'impl RemoteWorkspaceSearchProvider for CoreRemoteWorkspaceSearchProvider', 'lookup_remote_connection_with_hint', 'open_exec_channel', 'RemoteWorkspaceSearchStdioProtocol'],
+    },
+    {
+      path: 'src/crates/services/services-integrations/src/remote_ssh/workspace_search/mod.rs',
+      contracts: [
+        'build_remote_scope',
+        'shell_escape',
+        'should_retry_remote_scan_fallback_as_files_with_matches',
+        'remote_workspace_search_paths_preserve_current_contract',
+        'remote_scan_fallback_retry_policy_preserves_current_contract',
+      ],
+    },
+    {
+      path: 'src/crates/services/services-integrations/src/remote_ssh/workspace_search/service.rs',
+      contracts: ['RemoteWorkspaceSearchProvider', 'RemoteWorkspaceSearchService', 'RemoteWorkspaceSearchStdioProtocol', 'REMOTE_STDIO_SESSIONS', 'ensure_remote_search_context', 'allow_scan_fallback', 'fallback_query', 'remote_search_rejects_non_linux_before_stdio_open'],
     },
     {
       path: 'src/crates/assembly/core/src/service/search/mod.rs',

--- a/src/crates/assembly/core/src/agentic/tools/implementations/grep_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/grep_tool.rs
@@ -888,7 +888,6 @@ Usage:
                     let (request, output_mode, show_line_numbers, offset, head_limit) =
                         self.build_workspace_search_request(input, context)?;
                     let pattern = request.pattern.clone();
-                    let search_mode = request.output_mode.search_mode();
                     let path = request
                         .search_path
                         .as_ref()
@@ -922,11 +921,10 @@ Usage:
                     let workspace_search_elapsed_ms = search_started_at.elapsed().as_millis();
 
                     log::info!(
-                        "Grep tool remote workspace-search result: pattern={}, path={}, output_mode={}, search_mode={:?}, file_count={}, total_matches={}, backend={:?}, repo_phase={:?}, rebuild_recommended={}, dirty_modified={}, dirty_deleted={}, dirty_new={}, candidate_docs={}, matched_lines={}, matched_occurrences={}, workspace_search_ms={}",
+                        "Grep tool remote workspace-search result: pattern={}, path={}, output_mode={}, file_count={}, total_matches={}, backend={:?}, repo_phase={:?}, rebuild_recommended={}, dirty_modified={}, dirty_deleted={}, dirty_new={}, candidate_docs={}, matched_lines={}, matched_occurrences={}, workspace_search_ms={}",
                         pattern,
                         path,
                         output_mode,
-                        search_mode,
                         file_count,
                         total_matches,
                         search_result.backend,
@@ -979,7 +977,6 @@ Usage:
                 let (request, output_mode, show_line_numbers, offset, head_limit) =
                     self.build_workspace_search_request(input, context)?;
                 let pattern = request.pattern.clone();
-                let search_mode = request.output_mode.search_mode();
                 let path = request
                     .search_path
                     .as_ref()
@@ -999,11 +996,10 @@ Usage:
                 let workspace_search_elapsed_ms = search_started_at.elapsed().as_millis();
 
                 log::info!(
-                    "Grep tool workspace-search result: pattern={}, path={}, output_mode={}, search_mode={:?}, file_count={}, total_matches={}, backend={:?}, repo_phase={:?}, rebuild_recommended={}, dirty_modified={}, dirty_deleted={}, dirty_new={}, candidate_docs={}, matched_lines={}, matched_occurrences={}, workspace_search_ms={}",
+                    "Grep tool workspace-search result: pattern={}, path={}, output_mode={}, file_count={}, total_matches={}, backend={:?}, repo_phase={:?}, rebuild_recommended={}, dirty_modified={}, dirty_deleted={}, dirty_new={}, candidate_docs={}, matched_lines={}, matched_occurrences={}, workspace_search_ms={}",
                     pattern,
                     path,
                     output_mode,
-                    search_mode,
                     file_count,
                     total_matches,
                     search_result.backend,

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -16,8 +16,9 @@ use crate::agentic::tools::tool_result_storage;
 use crate::util::elapsed_ms_u64;
 use crate::util::errors::{BitFunError, BitFunResult};
 use bitfun_agent_runtime::tool_confirmation::{
-    resolve_confirmation_failure, resolve_tool_confirmation_plan, ConfirmationFailureKind,
-    ToolConfirmationOutcome, ToolConfirmationPlan, ToolConfirmationRequestFacts,
+    resolve_confirmation_failure, resolve_confirmation_wait_result, resolve_tool_confirmation_plan,
+    ConfirmationFailureKind, ToolConfirmationPlan, ToolConfirmationRequestFacts,
+    ToolConfirmationWaitResult,
 };
 use bitfun_agent_tools::{
     build_invalid_tool_call_error_message, build_tool_call_truncation_recovery_notice,
@@ -35,12 +36,10 @@ use std::time::{Instant, SystemTime};
 use tokio::sync::{oneshot, RwLock as TokioRwLock};
 use tokio::time::{timeout, Duration};
 use tokio_util::sync::CancellationToken;
-
-/// A batch of tool tasks to execute together.
-struct ToolBatch {
-    task_ids: Vec<String>,
-    is_concurrent: bool,
-}
+use tool_runtime::pipeline::{
+    partition_tool_batches, retry_delay_ms, should_retry_tool_attempt, ToolExecutionErrorClass,
+    ToolRetryAttemptFacts,
+};
 
 /// Convert framework::ToolResult to core::ToolResult
 ///
@@ -223,6 +222,14 @@ fn should_retry_tool_error(error: &BitFunError) -> bool {
     )
 }
 
+fn classify_tool_retry_error(error: &BitFunError) -> ToolExecutionErrorClass {
+    if should_retry_tool_error(error) {
+        ToolExecutionErrorClass::Retryable
+    } else {
+        ToolExecutionErrorClass::Terminal
+    }
+}
+
 fn map_tool_execution_admission_rejection(error: ToolExecutionAdmissionRejection) -> BitFunError {
     match error {
         ToolExecutionAdmissionRejection::RuntimeRestriction(error) => error.into(),
@@ -387,7 +394,7 @@ impl ToolPipeline {
         }
 
         // Partition into batches of consecutive same-safety tool calls
-        let batches = Self::partition_tool_batches(&task_ids, &concurrency_flags);
+        let batches = partition_tool_batches(&task_ids, &concurrency_flags);
         debug!(
             "Tool execution plan: total_tools={}, batches={}, concurrency_safe={}, non_concurrency_safe={}, allow_parallel=true, tools={}",
             task_ids.len(),
@@ -441,30 +448,6 @@ impl ToolPipeline {
         }
 
         Ok(all_results)
-    }
-
-    /// Partition task IDs into batches where consecutive concurrency-safe tasks
-    /// are grouped together (parallel batch) and each non-safe task forms its
-    /// own batch (serial batch).
-    fn partition_tool_batches(task_ids: &[String], flags: &[bool]) -> Vec<ToolBatch> {
-        let mut batches: Vec<ToolBatch> = Vec::new();
-
-        for (id, &is_safe) in task_ids.iter().zip(flags.iter()) {
-            if is_safe {
-                if let Some(last) = batches.last_mut() {
-                    if last.is_concurrent {
-                        last.task_ids.push(id.clone());
-                        continue;
-                    }
-                }
-            }
-            batches.push(ToolBatch {
-                task_ids: vec![id.clone()],
-                is_concurrent: is_safe,
-            });
-        }
-
-        batches
     }
 
     /// Execute tools in parallel
@@ -766,19 +749,19 @@ impl ToolPipeline {
             };
             confirmation_wait_ms = elapsed_ms_u64(confirmation_started_at);
 
-            let confirmation_outcome = match confirmation_result {
+            let confirmation_wait_result = match confirmation_result {
                 Some(Ok(ConfirmationResponse::Confirmed)) => {
                     debug!("Tool confirmed: tool_name={}", tool_name);
-                    ToolConfirmationOutcome::Confirmed
+                    ToolConfirmationWaitResult::Confirmed
                 }
                 Some(Ok(ConfirmationResponse::Rejected(reason))) => {
-                    ToolConfirmationOutcome::Rejected { reason }
+                    ToolConfirmationWaitResult::Rejected(reason)
                 }
-                Some(Err(_)) => ToolConfirmationOutcome::ChannelClosed,
-                None => ToolConfirmationOutcome::Timeout {
-                    tool_name: tool_name.clone(),
-                },
+                Some(Err(_)) => ToolConfirmationWaitResult::ChannelClosed,
+                None => ToolConfirmationWaitResult::TimedOut,
             };
+            let confirmation_outcome =
+                resolve_confirmation_wait_result(confirmation_wait_result, &tool_name);
 
             if let Some(failure) = resolve_confirmation_failure(confirmation_outcome) {
                 if matches!(
@@ -1026,7 +1009,11 @@ impl ToolPipeline {
             match result {
                 Ok(r) => return Ok(r),
                 Err(e) => {
-                    if attempts >= max_attempts || !should_retry_tool_error(&e) {
+                    if !should_retry_tool_attempt(ToolRetryAttemptFacts {
+                        attempts,
+                        max_attempts,
+                        error_class: classify_tool_retry_error(&e),
+                    }) {
                         return Err(e);
                     }
 
@@ -1036,7 +1023,7 @@ impl ToolPipeline {
                     );
 
                     // Wait for a period of time and retry
-                    tokio::time::sleep(Duration::from_millis(100 * attempts as u64)).await;
+                    tokio::time::sleep(Duration::from_millis(retry_delay_ms(attempts))).await;
                 }
             }
         }

--- a/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
+++ b/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
@@ -31,6 +31,10 @@ use crate::service::git::{GitDiffParams, GitService};
 use crate::service::remote_ssh::workspace_state::remote_workspace_runtime_root;
 use crate::service::{get_workspace_runtime_service_arc, WorkspaceRuntimeContext};
 use crate::util::errors::{BitFunError, BitFunResult};
+use bitfun_agent_runtime::checkpoint::{
+    build_light_checkpoint as build_runtime_light_checkpoint, GitStatusCheckpointFacts,
+    LightCheckpoint, LightCheckpointWorkspaceFacts,
+};
 use bitfun_agent_tools::{PortableToolContextProvider, ToolContextFacts, ToolWorkspaceKind};
 use bitfun_runtime_ports::{DelegationPolicy, ToolRuntimeHandles};
 use log::warn;
@@ -57,6 +61,17 @@ pub struct ToolUseContext {
     pub runtime_tool_restrictions: ToolRuntimeRestrictions,
     /// Runtime handles such as workspace I/O services and cancellation.
     pub runtime_handles: ToolRuntimeHandles,
+}
+
+impl From<LightCheckpoint> for EvidenceLedgerCheckpoint {
+    fn from(value: LightCheckpoint) -> Self {
+        Self {
+            current_branch: value.current_branch,
+            dirty_state_summary: value.dirty_state_summary,
+            touched_files: value.touched_files,
+            diff_hash: value.diff_hash,
+        }
+    }
 }
 
 impl ToolUseContext {
@@ -349,42 +364,42 @@ impl ToolUseContext {
     }
 
     async fn build_light_checkpoint(&self, touched_files: Vec<String>) -> EvidenceLedgerCheckpoint {
-        let mut checkpoint = EvidenceLedgerCheckpoint {
-            current_branch: None,
-            dirty_state_summary: "workspace_unavailable".to_string(),
-            touched_files,
-            diff_hash: None,
-        };
-
         if self.is_remote() {
-            checkpoint.dirty_state_summary =
-                "remote_workspace_git_metadata_unavailable".to_string();
-            return checkpoint;
+            return build_runtime_light_checkpoint(
+                touched_files,
+                LightCheckpointWorkspaceFacts::RemoteWorkspace,
+            )
+            .into();
         }
 
         let Some(workspace_root) = self.workspace_root() else {
-            return checkpoint;
+            return build_runtime_light_checkpoint(
+                touched_files,
+                LightCheckpointWorkspaceFacts::WorkspaceUnavailable,
+            )
+            .into();
         };
 
-        match GitService::get_status(workspace_root).await {
-            Ok(status) => {
-                checkpoint.current_branch = Some(status.current_branch);
-                checkpoint.dirty_state_summary = format!(
-                    "staged={}, unstaged={}, untracked={}",
-                    status.staged.len(),
-                    status.unstaged.len(),
-                    status.untracked.len()
-                );
-            }
-            Err(error) => {
-                checkpoint.dirty_state_summary = format!("git_status_unavailable: {}", error);
-            }
-        }
-
-        checkpoint.diff_hash = self
-            .checkpoint_diff_hash(workspace_root, &checkpoint.touched_files)
+        let git_status = GitService::get_status(workspace_root)
+            .await
+            .map(|status| GitStatusCheckpointFacts {
+                current_branch: status.current_branch,
+                staged_count: status.staged.len(),
+                unstaged_count: status.unstaged.len(),
+                untracked_count: status.untracked.len(),
+            })
+            .map_err(|error| error.to_string());
+        let diff_hash = self
+            .checkpoint_diff_hash(workspace_root, &touched_files)
             .await;
-        checkpoint
+        build_runtime_light_checkpoint(
+            touched_files,
+            LightCheckpointWorkspaceFacts::LocalWorkspace {
+                git_status,
+                diff_hash,
+            },
+        )
+        .into()
     }
 
     async fn checkpoint_diff_hash(

--- a/src/crates/assembly/core/src/service/search/mod.rs
+++ b/src/crates/assembly/core/src/service/search/mod.rs
@@ -4,8 +4,6 @@ mod remote;
 mod remote_disabled;
 pub mod service;
 
-pub use bitfun_services_integrations::workspace_search::flashgrep;
-
 pub use bitfun_services_integrations::workspace_search::{
     ContentSearchOutputMode, ContentSearchRequest, ContentSearchResult, GlobSearchRequest,
     GlobSearchResult, IndexTaskHandle, WorkspaceIndexStatus, WorkspaceSearchBackend,

--- a/src/crates/assembly/core/src/service/search/remote.rs
+++ b/src/crates/assembly/core/src/service/search/remote.rs
@@ -1,548 +1,28 @@
-use crate::infrastructure::{FileSearchOutcome, FileSearchResult, SearchMatchType};
 use crate::service::config::{get_global_config_service, types::WorkspaceConfig, ConfigService};
 use crate::service::remote_ssh::workspace_state::{
     get_remote_workspace_manager, lookup_remote_connection, lookup_remote_connection_with_hint,
     RemoteWorkspaceEntry,
 };
-use crate::service::remote_ssh::{
-    normalize_remote_workspace_path, RemoteFileService, SSHConnectionManager,
-};
-use crate::service::search::flashgrep::{
-    drain_content_length_messages, log_flashgrep_stderr_line_with_context, ClientCapabilities,
-    ClientInfo, ConsistencyMode, GlobOutcome, GlobParams, GlobRequest, InitializeParams,
-    OpenRepoParams, PathScope, ProtocolClient, QuerySpec, RefreshPolicyConfig, RepoConfig, RepoRef,
-    RepoStatus, Request, Response, SearchBackend, SearchModeConfig, SearchOutcome, SearchParams,
-    SearchRequest, SearchResults, TaskRef, TaskStatus, FLASHGREP_LOG_TARGET,
-};
-use crate::service::search::flashgrep::{error::AppError, FlashgrepRepoSession};
+use crate::service::remote_ssh::{RemoteFileService, SSHConnectionManager};
 use crate::service::search::{
-    ContentSearchOutputMode, ContentSearchRequest, ContentSearchResult, GlobSearchRequest,
-    GlobSearchResult, IndexTaskHandle, WorkspaceIndexStatus, WorkspaceSearchFileCount,
-    WorkspaceSearchHit, WorkspaceSearchRepoStatus,
+    ContentSearchRequest, ContentSearchResult, GlobSearchRequest, GlobSearchResult,
+    IndexTaskHandle, WorkspaceIndexStatus,
 };
 use async_trait::async_trait;
-use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, HashMap};
-use std::ops::Deref;
-use std::path::{Path, PathBuf};
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc, LazyLock,
+use bitfun_services_integrations::remote_ssh::workspace_search::{
+    RemoteCommandOutput, RemoteWorkspaceSearchProvider,
+    RemoteWorkspaceSearchService as ServiceRemoteWorkspaceSearchService,
+    RemoteWorkspaceSearchStdioProtocol,
 };
-use std::time::Duration;
+use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
-use tokio::sync::{mpsc, Mutex, RwLock};
-use tokio::time::{sleep, timeout};
+use tokio::sync::mpsc;
 
-const REMOTE_FLASHGREP_INSTALL_DIR: &str = ".bitfun/bin";
-const REMOTE_STDIO_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
-const REMOTE_STDIO_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
-const REMOTE_STDIO_SESSION_IDLE_GRACE: Duration = Duration::from_secs(45);
-const CLIENT_NAME: &str = "bitfun-remote-workspace-search";
-const REMOTE_OS_PROBES: &[&str] = &["uname -s", "sh -c 'uname -s 2>/dev/null'"];
-const REMOTE_ARCHITECTURE_PROBES: &[&str] = &[
-    "uname -m",
-    "arch",
-    "sh -c 'uname -m 2>/dev/null || arch 2>/dev/null'",
-];
-const LINUX_X86_64_FLASHGREP_BUNDLES: &[&str] = &[
-    "flashgrep-x86_64-unknown-linux-musl",
-    "flashgrep-x86_64-unknown-linux-gnu",
-];
-const LINUX_AARCH64_FLASHGREP_BUNDLES: &[&str] = &[
-    "flashgrep-aarch64-unknown-linux-musl",
-    "flashgrep-aarch64-unknown-linux-gnu",
-];
-
-static REMOTE_STDIO_SESSIONS: LazyLock<RwLock<HashMap<String, RemoteStdioSessionEntry>>> =
-    LazyLock::new(|| RwLock::new(HashMap::new()));
-static REMOTE_STDIO_OPEN_GUARDS: LazyLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-static REMOTE_SEARCH_CONTEXTS: LazyLock<RwLock<HashMap<String, RemoteSearchContext>>> =
-    LazyLock::new(|| RwLock::new(HashMap::new()));
-
-#[derive(Clone)]
-struct RemoteStdioSessionEntry {
-    session: Arc<RemoteStdioRepoSession>,
-    activity_epoch: Arc<AtomicU64>,
-}
-
-struct RemoteStdioRepoSession {
-    repo_id: String,
-    client: Arc<RemoteStdioDaemonClient>,
-    activity_epoch: Arc<AtomicU64>,
-    active_operations: Arc<AtomicU64>,
-}
-
-struct RemoteStdioDaemonClient {
-    protocol: ProtocolClient,
-}
-
-struct RemoteStdioOperationLease {
-    activity_epoch: Arc<AtomicU64>,
-    active_operations: Arc<AtomicU64>,
-}
-
-struct RemoteStdioSessionLease {
-    session: Arc<RemoteStdioRepoSession>,
-    _operation: RemoteStdioOperationLease,
-}
-
-impl Drop for RemoteStdioOperationLease {
-    fn drop(&mut self) {
-        self.active_operations.fetch_sub(1, Ordering::Relaxed);
-        self.activity_epoch.fetch_add(1, Ordering::Relaxed);
-    }
-}
-
-impl RemoteStdioSessionLease {
-    fn new(session: Arc<RemoteStdioRepoSession>) -> Self {
-        let operation = session.acquire_operation();
-        Self {
-            session,
-            _operation: operation,
-        }
-    }
-}
-
-impl Deref for RemoteStdioSessionLease {
-    type Target = RemoteStdioRepoSession;
-
-    fn deref(&self) -> &Self::Target {
-        &self.session
-    }
-}
-
-impl RemoteStdioDaemonClient {
-    async fn spawn(
-        ssh_manager: SSHConnectionManager,
-        connection_id: String,
-        binary_path: String,
-    ) -> Result<Arc<Self>, String> {
-        let command = format!("{} serve --stdio", shell_escape(&binary_path));
-        let channel = ssh_manager
-            .open_exec_channel(&connection_id, &command)
-            .await
-            .map_err(|error| format!("Failed to start remote flashgrep stdio daemon: {error}"))?;
-
-        let (protocol, write_rx) = ProtocolClient::channel("remote flashgrep stdio daemon");
-        spawn_remote_stdio_owner(connection_id, channel, write_rx, protocol.clone());
-
-        let client = Arc::new(Self { protocol });
-        client.initialize().await?;
-        Ok(client)
-    }
-
-    async fn initialize(&self) -> Result<(), String> {
-        match self
-            .protocol
-            .send_request_with_timeout(
-                Request::Initialize {
-                    params: InitializeParams {
-                        client_info: Some(ClientInfo {
-                            name: CLIENT_NAME.to_string(),
-                            version: Some(env!("CARGO_PKG_VERSION").to_string()),
-                        }),
-                        capabilities: ClientCapabilities::default(),
-                    },
-                },
-                Some(REMOTE_STDIO_REQUEST_TIMEOUT),
-            )
-            .await
-            .map_err(|error| error.to_string())?
-        {
-            Response::InitializeResult { .. } => {
-                self.protocol
-                    .send_notification(Request::Initialized)
-                    .await
-                    .map_err(|error| error.to_string())?;
-                Ok(())
-            }
-            other => Err(format!(
-                "Unexpected remote flashgrep initialize response: {other:?}"
-            )),
-        }
-    }
-
-    async fn open_repo(
-        self: &Arc<Self>,
-        params: OpenRepoParams,
-    ) -> Result<RemoteStdioRepoSession, String> {
-        match self.send_request(Request::OpenRepo { params }).await? {
-            Response::RepoOpened { repo_id, .. } => Ok(RemoteStdioRepoSession {
-                repo_id,
-                client: self.clone(),
-                activity_epoch: Arc::new(AtomicU64::new(1)),
-                active_operations: Arc::new(AtomicU64::new(0)),
-            }),
-            other => Err(format!(
-                "Unexpected remote flashgrep open_repo response: {other:?}"
-            )),
-        }
-    }
-
-    async fn send_request(&self, request: Request) -> Result<Response, String> {
-        self.protocol
-            .send_request_with_timeout(request, Some(REMOTE_STDIO_REQUEST_TIMEOUT))
-            .await
-            .map_err(|error| error.to_string())
-    }
-
-    async fn shutdown(&self) {
-        let _ = timeout(
-            REMOTE_STDIO_SHUTDOWN_TIMEOUT,
-            self.send_request(Request::Shutdown),
-        )
-        .await;
-        self.protocol
-            .close_with_message("remote flashgrep stdio daemon is shutting down")
-            .await;
-    }
-
-    fn is_closed(&self) -> bool {
-        self.protocol.is_closed()
-    }
-}
-
-impl RemoteStdioRepoSession {
-    fn acquire_operation(&self) -> RemoteStdioOperationLease {
-        self.active_operations.fetch_add(1, Ordering::Relaxed);
-        self.activity_epoch.fetch_add(1, Ordering::Relaxed);
-        RemoteStdioOperationLease {
-            activity_epoch: self.activity_epoch.clone(),
-            active_operations: self.active_operations.clone(),
-        }
-    }
-
-    async fn status(&self) -> Result<RepoStatus, String> {
-        let _lease = self.acquire_operation();
-        self.status_without_activity_lease().await
-    }
-
-    async fn status_without_activity_lease(&self) -> Result<RepoStatus, String> {
-        match self
-            .client
-            .send_request(Request::GetRepoStatus {
-                params: self.repo_ref(),
-            })
-            .await?
-        {
-            Response::RepoStatus { status } => Ok(status),
-            other => Err(format!(
-                "Unexpected remote flashgrep get_repo_status response: {other:?}"
-            )),
-        }
-    }
-
-    async fn task_status(&self, task_id: impl Into<String>) -> Result<TaskStatus, String> {
-        let _lease = self.acquire_operation();
-        match self
-            .client
-            .send_request(Request::TaskStatus {
-                params: TaskRef {
-                    task_id: task_id.into(),
-                },
-            })
-            .await?
-        {
-            Response::TaskStatus { task } => Ok(task),
-            other => Err(format!(
-                "Unexpected remote flashgrep task/status response: {other:?}"
-            )),
-        }
-    }
-
-    async fn build_index(&self) -> Result<TaskStatus, String> {
-        let _lease = self.acquire_operation();
-        match self
-            .client
-            .send_request(Request::BaseSnapshotBuild {
-                params: self.repo_ref(),
-            })
-            .await?
-        {
-            Response::TaskStarted { task } => Ok(task),
-            other => Err(format!(
-                "Unexpected remote flashgrep build response: {other:?}"
-            )),
-        }
-    }
-
-    async fn rebuild_index(&self) -> Result<TaskStatus, String> {
-        let _lease = self.acquire_operation();
-        match self
-            .client
-            .send_request(Request::BaseSnapshotRebuild {
-                params: self.repo_ref(),
-            })
-            .await?
-        {
-            Response::TaskStarted { task } => Ok(task),
-            other => Err(format!(
-                "Unexpected remote flashgrep rebuild response: {other:?}"
-            )),
-        }
-    }
-
-    async fn search(
-        &self,
-        query: QuerySpec,
-        scope: PathScope,
-    ) -> Result<
-        (
-            crate::service::search::flashgrep::SearchBackend,
-            RepoStatus,
-            SearchResults,
-        ),
-        String,
-    > {
-        let _lease = self.acquire_operation();
-        match self
-            .client
-            .send_request(Request::Search {
-                params: SearchParams {
-                    repo_id: self.repo_id.clone(),
-                    query,
-                    scope,
-                    consistency: ConsistencyMode::WorkspaceEventual,
-                    allow_scan_fallback: true,
-                },
-            })
-            .await?
-        {
-            Response::SearchCompleted {
-                backend,
-                status,
-                results,
-                ..
-            } => Ok((backend, status, results)),
-            other => Err(format!(
-                "Unexpected remote flashgrep search response: {other:?}"
-            )),
-        }
-    }
-
-    async fn glob(&self, scope: PathScope) -> Result<(RepoStatus, Vec<String>), String> {
-        let _lease = self.acquire_operation();
-        match self
-            .client
-            .send_request(Request::Glob {
-                params: GlobParams {
-                    repo_id: self.repo_id.clone(),
-                    scope,
-                },
-            })
-            .await?
-        {
-            Response::GlobCompleted { status, paths, .. } => Ok((status, paths)),
-            other => Err(format!(
-                "Unexpected remote flashgrep glob response: {other:?}"
-            )),
-        }
-    }
-
-    async fn close(&self) {
-        let _ = self
-            .client
-            .send_request(Request::CloseRepo {
-                params: self.repo_ref(),
-            })
-            .await;
-    }
-
-    fn repo_ref(&self) -> RepoRef {
-        RepoRef {
-            repo_id: self.repo_id.clone(),
-        }
-    }
-}
-
-#[async_trait]
-impl FlashgrepRepoSession for RemoteStdioRepoSession {
-    async fn status(&self) -> crate::service::search::flashgrep::error::Result<RepoStatus> {
-        RemoteStdioRepoSession::status(self)
-            .await
-            .map_err(AppError::Protocol)
-    }
-
-    async fn task_status(
-        &self,
-        task_id: String,
-    ) -> crate::service::search::flashgrep::error::Result<TaskStatus> {
-        RemoteStdioRepoSession::task_status(self, task_id)
-            .await
-            .map_err(AppError::Protocol)
-    }
-
-    async fn build_index(&self) -> crate::service::search::flashgrep::error::Result<TaskStatus> {
-        RemoteStdioRepoSession::build_index(self)
-            .await
-            .map_err(AppError::Protocol)
-    }
-
-    async fn rebuild_index(&self) -> crate::service::search::flashgrep::error::Result<TaskStatus> {
-        RemoteStdioRepoSession::rebuild_index(self)
-            .await
-            .map_err(AppError::Protocol)
-    }
-
-    async fn search(
-        &self,
-        request: SearchRequest,
-    ) -> crate::service::search::flashgrep::error::Result<SearchOutcome> {
-        let (backend, status, results) =
-            RemoteStdioRepoSession::search(self, request.query, request.scope)
-                .await
-                .map_err(AppError::Protocol)?;
-        Ok(SearchOutcome {
-            backend,
-            status,
-            results,
-        })
-    }
-
-    async fn glob(
-        &self,
-        request: GlobRequest,
-    ) -> crate::service::search::flashgrep::error::Result<GlobOutcome> {
-        let (status, paths) = RemoteStdioRepoSession::glob(self, request.scope)
-            .await
-            .map_err(AppError::Protocol)?;
-        Ok(GlobOutcome { status, paths })
-    }
-
-    async fn close(&self) -> crate::service::search::flashgrep::error::Result<()> {
-        RemoteStdioRepoSession::close(self).await;
-        Ok(())
-    }
-}
-
-fn spawn_remote_stdio_owner(
-    connection_id: String,
-    mut channel: russh::Channel<russh::client::Msg>,
-    mut write_rx: mpsc::Receiver<Vec<u8>>,
-    protocol: ProtocolClient,
-) {
-    tokio::spawn(async move {
-        let mut writer = channel.make_writer();
-        let mut read_buffer = Vec::<u8>::new();
-
-        loop {
-            tokio::select! {
-                outbound = write_rx.recv() => {
-                    let Some(outbound) = outbound else {
-                        let _ = channel.eof().await;
-                        let _ = channel.close().await;
-                        break;
-                    };
-                    if let Err(error) = writer.write_all(&outbound).await {
-                        log::warn!(
-                            target: FLASHGREP_LOG_TARGET,
-                            "Failed to write remote flashgrep stdio request: connection_id={}, error={}",
-                            connection_id,
-                            error
-                        );
-                        protocol
-                            .close_with_message("remote flashgrep stdio daemon write failed")
-                            .await;
-                        break;
-                    }
-                    if let Err(error) = writer.flush().await {
-                        log::warn!(
-                            target: FLASHGREP_LOG_TARGET,
-                            "Failed to flush remote flashgrep stdio request: connection_id={}, error={}",
-                            connection_id,
-                            error
-                        );
-                        protocol
-                            .close_with_message("remote flashgrep stdio daemon flush failed")
-                            .await;
-                        break;
-                    }
-                }
-
-                message = channel.wait() => {
-                    match message {
-                        Some(russh::ChannelMsg::Data { data }) => {
-                            read_buffer.extend_from_slice(&data);
-                            match drain_content_length_messages(&mut read_buffer) {
-                                Ok(messages) => {
-                                    for message in messages {
-                                        protocol.handle_server_message(message).await;
-                                    }
-                                }
-                                Err(error) => {
-                                    log::warn!(
-                                        target: FLASHGREP_LOG_TARGET,
-                                        "Failed to decode remote flashgrep stdio message: connection_id={}, error={}",
-                                        connection_id,
-                                        error
-                                    );
-                                    protocol
-                                        .close_with_message(format!(
-                                            "remote flashgrep stdio daemon decode failed: {error}"
-                                        ))
-                                        .await;
-                                    break;
-                                }
-                            }
-                        }
-                        Some(russh::ChannelMsg::ExtendedData { data, .. }) => {
-                            let text = String::from_utf8_lossy(&data);
-                            for line in text.lines() {
-                                log_flashgrep_stderr_line_with_context(
-                                    Some(&format!("connection_id={connection_id}")),
-                                    line,
-                                );
-                            }
-                        }
-                        Some(russh::ChannelMsg::ExitStatus { exit_status }) => {
-                            log::debug!(
-                                target: FLASHGREP_LOG_TARGET,
-                                "Remote flashgrep stdio daemon exited: connection_id={}, exit_status={}",
-                                connection_id,
-                                exit_status
-                            );
-                            break;
-                        }
-                        Some(russh::ChannelMsg::Eof) | Some(russh::ChannelMsg::Close) | None => {
-                            break;
-                        }
-                        Some(_) => {}
-                    }
-                }
-            }
-        }
-
-        protocol
-            .close_with_message("remote flashgrep stdio daemon closed before sending a response")
-            .await;
-    });
-}
+const REMOTE_FLASHGREP_LOG_TARGET: &str = "flashgrep";
 
 #[derive(Clone)]
 pub struct RemoteWorkspaceSearchService {
-    ssh_manager: SSHConnectionManager,
-    remote_file_service: RemoteFileService,
-    config_service: Arc<ConfigService>,
-    preferred_connection_id: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-struct RemoteSearchContext {
-    connection: RemoteWorkspaceEntry,
-    binary_path: String,
-    repo_root: String,
-    storage_root: String,
-    remote_arch: String,
-    local_binary_sha256: String,
-}
-
-struct LocalFlashgrepBundle {
-    binary_name: String,
-    path: PathBuf,
-    bytes: Vec<u8>,
-    sha256: String,
+    inner: ServiceRemoteWorkspaceSearchService,
 }
 
 impl RemoteWorkspaceSearchService {
@@ -551,304 +31,70 @@ impl RemoteWorkspaceSearchService {
         remote_file_service: RemoteFileService,
         config_service: Arc<ConfigService>,
     ) -> Self {
-        Self {
+        let provider = Arc::new(CoreRemoteWorkspaceSearchProvider {
             ssh_manager,
             remote_file_service,
             config_service,
-            preferred_connection_id: None,
+        });
+        Self {
+            inner: ServiceRemoteWorkspaceSearchService::new(provider),
         }
     }
 
     pub fn with_preferred_connection_id(mut self, preferred_connection_id: Option<String>) -> Self {
-        self.preferred_connection_id = preferred_connection_id;
+        self.inner = self
+            .inner
+            .with_preferred_connection_id(preferred_connection_id);
         self
     }
 
     pub async fn get_index_status(&self, root_path: &str) -> Result<WorkspaceIndexStatus, String> {
-        let session = self.get_or_open_stdio_session(root_path).await?;
-        let repo_status: WorkspaceSearchRepoStatus = session.status().await?.into();
-        let active_task = match repo_status.active_task_id.clone() {
-            Some(task_id) => match session.task_status(task_id).await {
-                Ok(task) => Some(task.into()),
-                Err(error) => {
-                    log::warn!(
-                        target: FLASHGREP_LOG_TARGET,
-                        "Failed to fetch active remote flashgrep task status: {}",
-                        error
-                    );
-                    None
-                }
-            },
-            None => None,
-        };
-        Ok(WorkspaceIndexStatus {
-            active_task,
-            repo_status,
-        })
+        self.inner.get_index_status(root_path).await
     }
 
     pub async fn build_index(&self, root_path: &str) -> Result<IndexTaskHandle, String> {
-        let session = self.get_or_open_stdio_session(root_path).await?;
-        let task = session.build_index().await?;
-        let repo_status = session.status().await?;
-        Ok(IndexTaskHandle {
-            task: task.into(),
-            repo_status: repo_status.into(),
-        })
+        self.inner.build_index(root_path).await
     }
 
     pub async fn rebuild_index(&self, root_path: &str) -> Result<IndexTaskHandle, String> {
-        let session = self.get_or_open_stdio_session(root_path).await?;
-        let task = session.rebuild_index().await?;
-        let repo_status = session.status().await?;
-        Ok(IndexTaskHandle {
-            task: task.into(),
-            repo_status: repo_status.into(),
-        })
+        self.inner.rebuild_index(root_path).await
     }
 
     pub async fn search_content(
         &self,
         request: ContentSearchRequest,
     ) -> Result<ContentSearchResult, String> {
-        let repo_root = normalize_remote_workspace_path(&request.repo_root.to_string_lossy());
-        let session = self.get_or_open_stdio_session(&repo_root).await?;
-        let scope = build_remote_scope(
-            &repo_root,
-            request.search_path.as_deref(),
-            request.globs,
-            request.file_types,
-            request.exclude_file_types,
-        )?;
-        let max_results = request.max_results.filter(|limit| *limit > 0);
-        let primary_search_mode = remote_stdio_search_mode(request.output_mode);
-        let query = QuerySpec {
-            pattern: request.pattern.clone(),
-            patterns: Vec::new(),
-            case_insensitive: !request.case_sensitive,
-            multiline: request.multiline,
-            dot_matches_new_line: request.multiline,
-            fixed_strings: !request.use_regex,
-            word_regexp: request.whole_word,
-            line_regexp: false,
-            before_context: request.before_context,
-            after_context: request.after_context,
-            top_k_tokens: 6,
-            max_count: None,
-            global_max_results: max_results,
-            search_mode: primary_search_mode,
-        };
-
-        let output_mode = request.output_mode;
-        let (backend, repo_status, mut raw_results) = session.search(query, scope.clone()).await?;
-        // The bundled flashgrep daemon (v0.2.6) only emits summary statistics
-        // (`matched_lines`/`matched_occurrences`) when it falls back to the
-        // file-system scanner because the workspace has not been indexed yet.
-        // In that mode `LineMatches` returns no `hits`, no `matched_paths`,
-        // and no `file_counts`, leaving the UI showing "no results" even
-        // though the daemon reports thousands of matches. Re-issue the same
-        // query as `FilesWithMatches`, which the daemon does populate with
-        // the matching file paths, so the user at least sees the hit list
-        // while the index is being built.
-        if should_retry_remote_scan_fallback_as_files_with_matches(
-            backend,
-            primary_search_mode,
-            &raw_results,
-        ) {
-            log::info!(
-                "Remote workspace content search re-issuing as FilesWithMatches because daemon ScanFallback returned only summary statistics: pattern_chars={}, primary_search_mode={:?}, primary_matched_lines={}, primary_matched_occurrences={}",
-                request.pattern.chars().count(),
-                primary_search_mode,
-                raw_results.matched_lines,
-                raw_results.matched_occurrences,
-            );
-            let fallback_query = QuerySpec {
-                pattern: request.pattern.clone(),
-                patterns: Vec::new(),
-                case_insensitive: !request.case_sensitive,
-                multiline: request.multiline,
-                dot_matches_new_line: request.multiline,
-                fixed_strings: !request.use_regex,
-                word_regexp: request.whole_word,
-                line_regexp: false,
-                before_context: request.before_context,
-                after_context: request.after_context,
-                top_k_tokens: 6,
-                max_count: None,
-                global_max_results: max_results,
-                search_mode: SearchModeConfig::FilesWithMatches,
-            };
-            match session.search(fallback_query, scope).await {
-                Ok((_, _, fallback_results)) => {
-                    log::info!(
-                        "Remote workspace content search FilesWithMatches fallback succeeded: matched_paths={}, matched_lines={}, matched_occurrences={}",
-                        fallback_results.matched_paths.len(),
-                        fallback_results.matched_lines,
-                        fallback_results.matched_occurrences,
-                    );
-                    raw_results = fallback_results;
-                }
-                Err(error) => {
-                    // Surface the failure instead of silently keeping the
-                    // summary-only `raw_results` from the primary LineMatches
-                    // call. Otherwise the converter produces an empty result
-                    // list while `matched_lines > 0`, recreating the original
-                    // "found N lines but no results" UI inconsistency.
-                    log::warn!(
-                        "Remote workspace content search FilesWithMatches fallback failed: pattern_chars={}, primary_matched_lines={}, primary_matched_occurrences={}, error={}",
-                        request.pattern.chars().count(),
-                        raw_results.matched_lines,
-                        raw_results.matched_occurrences,
-                        error,
-                    );
-                    return Err(format!(
-                        "Remote workspace search returned only summary statistics for {primary_matched_lines} line(s) and the file-list fallback failed: {error}",
-                        primary_matched_lines = raw_results.matched_lines,
-                    ));
-                }
-            }
-        }
-
-        let mut results = convert_stdio_search_results(&raw_results, output_mode);
-        log::debug!(
-            "Remote workspace content search converted: backend={:?}, repo_phase={:?}, hits={}, file_counts={}, file_match_counts={}, matched_paths={}, converted_results={}, matched_lines={}, matched_occurrences={}",
-            backend,
-            repo_status.phase,
-            raw_results.hits.len(),
-            raw_results.file_counts.len(),
-            raw_results.file_match_counts.len(),
-            raw_results.matched_paths.len(),
-            results.len(),
-            raw_results.matched_lines,
-            raw_results.matched_occurrences
-        );
-        let truncated = max_results
-            .map(|limit| results.len() >= limit)
-            .unwrap_or(false);
-        if let Some(limit) = max_results {
-            results.truncate(limit);
-        }
-
-        Ok(ContentSearchResult {
-            outcome: FileSearchOutcome { results, truncated },
-            file_counts: raw_results
-                .file_counts
-                .clone()
-                .into_iter()
-                .map(WorkspaceSearchFileCount::from)
-                .collect(),
-            hits: raw_results
-                .hits
-                .clone()
-                .into_iter()
-                .map(WorkspaceSearchHit::from)
-                .collect(),
-            backend: backend.into(),
-            repo_status: repo_status.into(),
-            candidate_docs: raw_results.candidate_docs,
-            matched_lines: raw_results.matched_lines,
-            matched_occurrences: raw_results.matched_occurrences,
-        })
+        self.inner.search_content(request).await
     }
 
     pub async fn glob(&self, request: GlobSearchRequest) -> Result<GlobSearchResult, String> {
-        let repo_root = normalize_remote_workspace_path(&request.repo_root.to_string_lossy());
-        let session = self.get_or_open_stdio_session(&repo_root).await?;
-        let scope = build_remote_scope(
-            &repo_root,
-            request.search_path.as_deref(),
-            vec![request.pattern],
-            Vec::new(),
-            Vec::new(),
-        )?;
-        let (repo_status, mut paths) = session.glob(scope).await?;
-
-        paths.sort();
-        if request.limit > 0 {
-            paths.truncate(request.limit);
-        } else {
-            paths.clear();
-        }
-
-        Ok(GlobSearchResult {
-            paths,
-            repo_status: repo_status.into(),
-        })
-    }
-
-    async fn get_or_open_stdio_session(
-        &self,
-        root_path: &str,
-    ) -> Result<RemoteStdioSessionLease, String> {
-        let context = self.ensure_remote_search_context(root_path).await?;
-        let key = remote_stdio_session_key(&context.connection.connection_id, &context.repo_root);
-
-        if let Some(entry) = REMOTE_STDIO_SESSIONS.read().await.get(&key).cloned() {
-            entry.activity_epoch.fetch_add(1, Ordering::Relaxed);
-            if !entry.session.client.is_closed() {
-                return Ok(RemoteStdioSessionLease::new(entry.session.clone()));
-            }
-            log::warn!(
-                target: FLASHGREP_LOG_TARGET,
-                "Remote workspace search stdio session became unhealthy, reopening: connection_id={}, path={}",
-                context.connection.connection_id,
-                context.repo_root
-            );
-            REMOTE_STDIO_SESSIONS.write().await.remove(&key);
-            entry.session.close().await;
-            entry.session.client.shutdown().await;
-        }
-
-        let guard = {
-            let mut guards = REMOTE_STDIO_OPEN_GUARDS.lock().await;
-            guards
-                .entry(key.clone())
-                .or_insert_with(|| Arc::new(Mutex::new(())))
-                .clone()
-        };
-        let _guard = guard.lock().await;
-
-        if let Some(entry) = REMOTE_STDIO_SESSIONS.read().await.get(&key).cloned() {
-            entry.activity_epoch.fetch_add(1, Ordering::Relaxed);
-            return Ok(RemoteStdioSessionLease::new(entry.session));
-        }
-
-        let client = RemoteStdioDaemonClient::spawn(
-            self.ssh_manager.clone(),
-            context.connection.connection_id.clone(),
-            context.binary_path.clone(),
-        )
-        .await?;
-        let mut repo_config = RepoConfig::default();
-        repo_config.max_file_size = self.max_file_size().await;
-        let session = client
-            .open_repo(OpenRepoParams {
-                repo_path: PathBuf::from(&context.repo_root),
-                storage_root: Some(PathBuf::from(&context.storage_root)),
-                config: repo_config,
-                refresh: RefreshPolicyConfig::default(),
-            })
-            .await?;
-        let activity_epoch = session.activity_epoch.clone();
-        let session = Arc::new(session);
-        REMOTE_STDIO_SESSIONS.write().await.insert(
-            key.clone(),
-            RemoteStdioSessionEntry {
-                session: session.clone(),
-                activity_epoch: activity_epoch.clone(),
-            },
-        );
-        schedule_remote_stdio_session_release(key, activity_epoch);
-        Ok(RemoteStdioSessionLease::new(session))
+        self.inner.glob(request).await
     }
 
     pub async fn resolve_remote_workspace_entry(
         &self,
         root_path: &str,
     ) -> Result<RemoteWorkspaceEntry, String> {
+        self.inner.resolve_remote_workspace_entry(root_path).await
+    }
+}
+
+#[derive(Clone)]
+struct CoreRemoteWorkspaceSearchProvider {
+    ssh_manager: SSHConnectionManager,
+    remote_file_service: RemoteFileService,
+    config_service: Arc<ConfigService>,
+}
+
+#[async_trait]
+impl RemoteWorkspaceSearchProvider for CoreRemoteWorkspaceSearchProvider {
+    async fn resolve_workspace_entry(
+        &self,
+        root_path: &str,
+        preferred_connection_id: Option<&str>,
+    ) -> Result<RemoteWorkspaceEntry, String> {
         if let Some(entry) =
-            lookup_remote_connection_with_hint(root_path, self.preferred_connection_id.as_deref())
-                .await
+            lookup_remote_connection_with_hint(root_path, preferred_connection_id).await
         {
             return Ok(entry);
         }
@@ -857,215 +103,49 @@ impl RemoteWorkspaceSearchService {
             .ok_or_else(|| format!("Remote workspace is not registered for path: {root_path}"))
     }
 
-    async fn ensure_remote_search_context(
-        &self,
-        root_path: &str,
-    ) -> Result<RemoteSearchContext, String> {
-        let repo_root = normalize_remote_workspace_path(root_path);
-        let cache_key =
-            remote_search_context_key(self.preferred_connection_id.as_deref(), &repo_root);
-        if let Some(context) = REMOTE_SEARCH_CONTEXTS.read().await.get(&cache_key).cloned() {
-            let local_bundle = local_flashgrep_bundle_for_arch(&context.remote_arch).await?;
-            if local_bundle.sha256 == context.local_binary_sha256 {
-                return Ok(context);
-            }
-
-            log::info!(
-                target: FLASHGREP_LOG_TARGET,
-                "Bundled remote flashgrep binary changed; reopening remote search session: connection_id={}, path={}, old_sha256={}, new_sha256={}",
-                context.connection.connection_id,
-                context.repo_root,
-                context.local_binary_sha256,
-                local_bundle.sha256
-            );
-            REMOTE_SEARCH_CONTEXTS.write().await.remove(&cache_key);
-            let session_key =
-                remote_stdio_session_key(&context.connection.connection_id, &context.repo_root);
-            if let Some(entry) = REMOTE_STDIO_SESSIONS.write().await.remove(&session_key) {
-                entry.session.close().await;
-                entry.session.client.shutdown().await;
-            }
-        }
-
-        let connection = self.resolve_remote_workspace_entry(&repo_root).await?;
-        let cached_server_info = self
-            .ssh_manager
-            .get_server_info(&connection.connection_id)
-            .await;
-        let remote_os = if let Some(server_info) = cached_server_info {
-            if server_info.os_type.eq_ignore_ascii_case("unknown") {
-                self.detect_remote_os_type(&connection.connection_id)
-                    .await
-                    .unwrap_or_else(|| server_info.os_type.clone())
-            } else {
-                server_info.os_type
-            }
-        } else {
-            self.detect_remote_os_type(&connection.connection_id)
-                .await
-                .unwrap_or_else(|| "unknown".to_string())
-        };
-        let inferred_linux = remote_os.eq_ignore_ascii_case("unknown")
-            && looks_like_linux_workspace_root(&repo_root);
-        if !remote_os.eq_ignore_ascii_case("linux") && !inferred_linux {
-            return Err(format!(
-                "Remote workspace search currently supports Linux only, but server OS is {}",
-                remote_os
-            ));
-        }
-
-        let remote_arch = self
-            .detect_remote_architecture(&connection.connection_id)
-            .await?;
-        let local_bundle = local_flashgrep_bundle_for_arch(&remote_arch).await?;
-        let binary_path = self
-            .ensure_remote_flashgrep_binary(&connection.connection_id, &repo_root, &local_bundle)
-            .await?;
-        let storage_root = join_remote_path(&repo_root, ".bitfun/search/flashgrep-index");
-
-        let context = RemoteSearchContext {
-            connection,
-            binary_path,
-            repo_root,
-            storage_root,
-            remote_arch,
-            local_binary_sha256: local_bundle.sha256,
-        };
-        REMOTE_SEARCH_CONTEXTS
-            .write()
-            .await
-            .insert(cache_key, context.clone());
-        Ok(context)
-    }
-
-    async fn detect_remote_architecture(&self, connection_id: &str) -> Result<String, String> {
-        let mut attempts = Vec::new();
-
-        for probe in REMOTE_ARCHITECTURE_PROBES {
-            match self.ssh_manager.execute_command(connection_id, probe).await {
-                Ok((stdout, stderr, exit_code)) => {
-                    if let Some(arch) = parse_remote_architecture_output(&stdout, &stderr) {
-                        return Ok(arch);
-                    }
-                    attempts.push(format!(
-                        "probe=`{probe}` exit_code={exit_code} stdout={:?} stderr={:?}",
-                        stdout.trim(),
-                        stderr.trim()
-                    ));
-                }
-                Err(error) => {
-                    attempts.push(format!("probe=`{probe}` error={error}"));
-                }
-            }
-        }
-
-        Err(format!(
-            "Failed to detect remote architecture from SSH output. Attempts: {}",
-            attempts.join("; ")
-        ))
-    }
-
-    async fn detect_remote_os_type(&self, connection_id: &str) -> Option<String> {
-        for probe in REMOTE_OS_PROBES {
-            let Ok((stdout, stderr, _exit_code)) =
-                self.ssh_manager.execute_command(connection_id, probe).await
-            else {
-                continue;
-            };
-            if let Some(os_type) = parse_remote_os_output(&stdout, &stderr) {
-                return Some(os_type);
-            }
-        }
-        None
-    }
-
-    async fn ensure_remote_flashgrep_binary(
-        &self,
-        connection_id: &str,
-        repo_root: &str,
-        local_bundle: &LocalFlashgrepBundle,
-    ) -> Result<String, String> {
-        let install_dir = remote_flashgrep_install_dir(repo_root);
-        let remote_binary_path = join_remote_path(&install_dir, &local_bundle.binary_name);
-
-        self.remote_file_service
-            .create_dir_all(connection_id, &install_dir)
-            .await
-            .map_err(|error| {
-                format!("Failed to create remote flashgrep install directory: {error}")
-            })?;
-        let remote_sha256 = self
-            .remote_flashgrep_sha256(connection_id, &remote_binary_path)
-            .await?;
-        if remote_sha256.as_deref() != Some(local_bundle.sha256.as_str()) {
-            log::info!(
-                target: FLASHGREP_LOG_TARGET,
-                "Uploading bundled remote flashgrep binary: connection_id={}, path={}, bundle={}, local_path={}, local_sha256={}, remote_sha256={}",
-                connection_id,
-                remote_binary_path,
-                local_bundle.binary_name,
-                local_bundle.path.display(),
-                local_bundle.sha256,
-                remote_sha256.as_deref().unwrap_or("missing")
-            );
-            let temp_remote_binary_path =
-                format!("{}.upload-{}.tmp", remote_binary_path, local_bundle.sha256);
-            self.remote_file_service
-                .write_file(connection_id, &temp_remote_binary_path, &local_bundle.bytes)
-                .await
-                .map_err(|error| format!("Failed to upload flashgrep to remote host: {error}"))?;
-            self.ssh_manager
-                .execute_command(
-                    connection_id,
-                    &format!(
-                        "mv -f {} {}",
-                        shell_escape(&temp_remote_binary_path),
-                        shell_escape(&remote_binary_path)
-                    ),
-                )
-                .await
-                .map_err(|error| {
-                    format!("Failed to install uploaded flashgrep on remote host: {error}")
-                })?;
-        }
+    async fn cached_server_os_type(&self, connection_id: &str) -> Option<String> {
         self.ssh_manager
-            .execute_command(
-                connection_id,
-                &format!("chmod 755 {}", shell_escape(&remote_binary_path)),
-            )
+            .get_server_info(connection_id)
             .await
-            .map_err(|error| format!("Failed to mark remote flashgrep as executable: {error}"))?;
-
-        Ok(remote_binary_path)
+            .map(|info| info.os_type)
     }
 
-    async fn remote_flashgrep_sha256(
+    async fn execute_command(
         &self,
         connection_id: &str,
-        remote_binary_path: &str,
-    ) -> Result<Option<String>, String> {
-        let escaped_path = shell_escape(remote_binary_path);
-        let command = format!(
-            "if [ -f {path} ]; then if command -v sha256sum >/dev/null 2>&1; then sha256sum {path} | awk '{{print $1}}'; elif command -v shasum >/dev/null 2>&1; then shasum -a 256 {path} | awk '{{print $1}}'; fi; fi",
-            path = escaped_path
-        );
-        let (stdout, _stderr, exit_code) = self
-            .ssh_manager
-            .execute_command(connection_id, &command)
+        command: &str,
+    ) -> Result<RemoteCommandOutput, String> {
+        self.ssh_manager
+            .execute_command(connection_id, command)
             .await
-            .map_err(|error| format!("Failed to hash remote flashgrep binary: {error}"))?;
-        if exit_code != 0 {
-            return Ok(None);
-        }
-        let hash = stdout.trim();
-        if hash.len() == 64 && hash.chars().all(|character| character.is_ascii_hexdigit()) {
-            Ok(Some(hash.to_ascii_lowercase()))
-        } else {
-            Ok(None)
-        }
+            .map(|(stdout, stderr, exit_code)| RemoteCommandOutput {
+                stdout,
+                stderr,
+                exit_code,
+            })
+            .map_err(|error| error.to_string())
     }
 
-    async fn max_file_size(&self) -> u64 {
+    async fn create_dir_all(&self, connection_id: &str, path: &str) -> Result<(), String> {
+        self.remote_file_service
+            .create_dir_all(connection_id, path)
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    async fn write_file(
+        &self,
+        connection_id: &str,
+        path: &str,
+        contents: &[u8],
+    ) -> Result<(), String> {
+        self.remote_file_service
+            .write_file(connection_id, path, contents)
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    async fn repo_max_file_size(&self) -> u64 {
         match self
             .config_service
             .get_config::<WorkspaceConfig>(Some("workspace"))
@@ -1074,13 +154,29 @@ impl RemoteWorkspaceSearchService {
             Ok(workspace_config) => workspace_config.max_file_size,
             Err(error) => {
                 log::warn!(
-                    target: FLASHGREP_LOG_TARGET,
+                    target: REMOTE_FLASHGREP_LOG_TARGET,
                     "Failed to read workspace config for remote flashgrep repo open, using default max_file_size: {}",
                     error
                 );
                 WorkspaceConfig::default().max_file_size
             }
         }
+    }
+
+    async fn spawn_stdio_daemon(
+        &self,
+        connection_id: &str,
+        command: &str,
+        write_rx: mpsc::Receiver<Vec<u8>>,
+        protocol: RemoteWorkspaceSearchStdioProtocol,
+    ) -> Result<(), String> {
+        let channel = self
+            .ssh_manager
+            .open_exec_channel(connection_id, command)
+            .await
+            .map_err(|error| format!("Failed to start remote flashgrep stdio daemon: {error}"))?;
+        spawn_remote_stdio_owner(connection_id.to_string(), channel, write_rx, protocol);
+        Ok(())
     }
 }
 
@@ -1113,704 +209,95 @@ pub async fn remote_workspace_search_service_for_path(
     .with_preferred_connection_id(preferred_connection_id))
 }
 
-fn remote_stdio_session_key(connection_id: &str, repo_root: &str) -> String {
-    format!(
-        "{connection_id}\0{}",
-        normalize_remote_workspace_path(repo_root)
-    )
-}
-
-fn remote_search_context_key(preferred_connection_id: Option<&str>, repo_root: &str) -> String {
-    format!(
-        "{}\0{}",
-        preferred_connection_id.unwrap_or(""),
-        normalize_remote_workspace_path(repo_root)
-    )
-}
-
-fn schedule_remote_stdio_session_release(key: String, activity_epoch: Arc<AtomicU64>) {
+fn spawn_remote_stdio_owner(
+    connection_id: String,
+    mut channel: russh::Channel<russh::client::Msg>,
+    mut write_rx: mpsc::Receiver<Vec<u8>>,
+    protocol: RemoteWorkspaceSearchStdioProtocol,
+) {
     tokio::spawn(async move {
-        let expected_epoch = activity_epoch.load(Ordering::Relaxed);
-        sleep(REMOTE_STDIO_SESSION_IDLE_GRACE).await;
-        let entry = {
-            let sessions = REMOTE_STDIO_SESSIONS.read().await;
-            let Some(entry) = sessions.get(&key) else {
-                return;
-            };
-            if entry.session.active_operations.load(Ordering::Relaxed) > 0 {
-                schedule_remote_stdio_session_release(key.clone(), entry.activity_epoch.clone());
-                return;
-            }
-            if entry.activity_epoch.load(Ordering::Relaxed) != expected_epoch {
-                schedule_remote_stdio_session_release(key.clone(), entry.activity_epoch.clone());
-                return;
-            }
-            entry.clone()
-        };
+        let mut writer = channel.make_writer();
+        let mut read_buffer = Vec::<u8>::new();
 
-        match entry.session.status_without_activity_lease().await {
-            Ok(status) if status.active_task_id.is_some() => {
-                schedule_remote_stdio_session_release(key.clone(), entry.activity_epoch.clone());
-                return;
-            }
-            Ok(_) => {}
-            Err(error) => {
-                log::warn!(
-                    target: FLASHGREP_LOG_TARGET,
-                    "Failed to check idle remote workspace search status before release: key={}, error={}",
-                    key.replace('\0', ":"),
-                    error
-                );
+        loop {
+            tokio::select! {
+                outbound = write_rx.recv() => {
+                    let Some(outbound) = outbound else {
+                        let _ = channel.eof().await;
+                        let _ = channel.close().await;
+                        break;
+                    };
+                    if let Err(error) = writer.write_all(&outbound).await {
+                        log::warn!(
+                            target: REMOTE_FLASHGREP_LOG_TARGET,
+                            "Failed to write remote flashgrep stdio request: connection_id={}, error={}",
+                            connection_id,
+                            error
+                        );
+                        protocol
+                            .close_with_message("remote flashgrep stdio daemon write failed")
+                            .await;
+                        break;
+                    }
+                    if let Err(error) = writer.flush().await {
+                        log::warn!(
+                            target: REMOTE_FLASHGREP_LOG_TARGET,
+                            "Failed to flush remote flashgrep stdio request: connection_id={}, error={}",
+                            connection_id,
+                            error
+                        );
+                        protocol
+                            .close_with_message("remote flashgrep stdio daemon flush failed")
+                            .await;
+                        break;
+                    }
+                }
+
+                message = channel.wait() => {
+                    match message {
+                        Some(russh::ChannelMsg::Data { data }) => {
+                            if let Err(error) = protocol.handle_stdout_chunk(&mut read_buffer, data.as_ref()).await {
+                                log::warn!(
+                                    target: REMOTE_FLASHGREP_LOG_TARGET,
+                                    "Failed to decode remote flashgrep stdio message: connection_id={}, error={}",
+                                    connection_id,
+                                    error
+                                );
+                                protocol
+                                    .close_with_message(format!(
+                                        "remote flashgrep stdio daemon decode failed: {error}"
+                                    ))
+                                    .await;
+                                break;
+                            }
+                        }
+                        Some(russh::ChannelMsg::ExtendedData { data, .. }) => {
+                            let text = String::from_utf8_lossy(&data);
+                            let log_context = format!("connection_id={connection_id}");
+                            for line in text.lines() {
+                                protocol.log_stderr_line_with_context(Some(&log_context), line);
+                            }
+                        }
+                        Some(russh::ChannelMsg::ExitStatus { exit_status }) => {
+                            log::debug!(
+                                target: REMOTE_FLASHGREP_LOG_TARGET,
+                                "Remote flashgrep stdio daemon exited: connection_id={}, exit_status={}",
+                                connection_id,
+                                exit_status
+                            );
+                            break;
+                        }
+                        Some(russh::ChannelMsg::Eof) | Some(russh::ChannelMsg::Close) | None => {
+                            break;
+                        }
+                        Some(_) => {}
+                    }
+                }
             }
         }
 
-        let entry = {
-            let mut sessions = REMOTE_STDIO_SESSIONS.write().await;
-            let Some(current_entry) = sessions.get(&key) else {
-                return;
-            };
-            if !Arc::ptr_eq(&current_entry.session, &entry.session) {
-                return;
-            }
-            if current_entry
-                .session
-                .active_operations
-                .load(Ordering::Relaxed)
-                > 0
-            {
-                schedule_remote_stdio_session_release(
-                    key.clone(),
-                    current_entry.activity_epoch.clone(),
-                );
-                return;
-            }
-            if current_entry.activity_epoch.load(Ordering::Relaxed) != expected_epoch {
-                schedule_remote_stdio_session_release(
-                    key.clone(),
-                    current_entry.activity_epoch.clone(),
-                );
-                return;
-            }
-            sessions.remove(&key)
-        };
-
-        if let Some(entry) = entry {
-            log::debug!(
-                target: FLASHGREP_LOG_TARGET,
-                "Releasing idle remote workspace search stdio session: key={}",
-                key.replace('\0', ":")
-            );
-            entry.session.close().await;
-            entry.session.client.shutdown().await;
-            REMOTE_STDIO_OPEN_GUARDS.lock().await.remove(&key);
-        }
+        protocol
+            .close_with_message("remote flashgrep stdio daemon closed before sending a response")
+            .await;
     });
-}
-
-fn build_remote_scope(
-    repo_root: &str,
-    search_path: Option<&Path>,
-    globs: Vec<String>,
-    file_types: Vec<String>,
-    exclude_file_types: Vec<String>,
-) -> Result<PathScope, String> {
-    let repo_root = normalize_remote_workspace_path(repo_root);
-    let roots = match search_path {
-        Some(path) => {
-            let normalized = normalize_remote_scope_path(&repo_root, path)?;
-            if normalized == repo_root {
-                Vec::new()
-            } else {
-                vec![PathBuf::from(normalized)]
-            }
-        }
-        None => Vec::new(),
-    };
-
-    Ok(PathScope {
-        roots,
-        globs,
-        iglobs: Vec::new(),
-        type_add: Vec::new(),
-        type_clear: Vec::new(),
-        types: file_types,
-        type_not: exclude_file_types,
-    })
-}
-
-fn normalize_remote_scope_path(repo_root: &str, search_path: &Path) -> Result<String, String> {
-    let raw_path = search_path.to_string_lossy();
-    let normalized = if raw_path.starts_with('/') {
-        normalize_remote_workspace_path(&raw_path)
-    } else {
-        join_remote_path(repo_root, &raw_path)
-    };
-    let repo_root_with_slash = format!("{}/", repo_root.trim_end_matches('/'));
-    if normalized != repo_root && !normalized.starts_with(&repo_root_with_slash) {
-        return Err(format!(
-            "Remote search path is outside workspace root: {normalized}"
-        ));
-    }
-    Ok(normalized)
-}
-
-fn remote_flashgrep_install_dir(repo_root: &str) -> String {
-    join_remote_path(
-        &normalize_remote_workspace_path(repo_root),
-        REMOTE_FLASHGREP_INSTALL_DIR,
-    )
-}
-
-fn looks_like_linux_workspace_root(path: &str) -> bool {
-    path.starts_with('/') && !path.contains(':')
-}
-
-fn parse_remote_architecture_output(stdout: &str, stderr: &str) -> Option<String> {
-    for stream in [stdout, stderr] {
-        for line in stream.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-
-            let normalized = trimmed.to_ascii_lowercase();
-            if normalized.contains("x86_64") || normalized.contains("amd64") {
-                return Some("x86_64".to_string());
-            }
-            if normalized.contains("aarch64")
-                || normalized.contains("arm64")
-                || normalized.contains("armv8")
-            {
-                return Some("aarch64".to_string());
-            }
-        }
-    }
-
-    None
-}
-
-fn parse_remote_os_output(stdout: &str, stderr: &str) -> Option<String> {
-    for stream in [stdout, stderr] {
-        for line in stream.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-
-            let normalized = trimmed.to_ascii_lowercase();
-            if normalized.contains("linux") {
-                return Some("Linux".to_string());
-            }
-            if normalized.contains("darwin") || normalized.contains("macos") {
-                return Some("Darwin".to_string());
-            }
-            if normalized.contains("windows")
-                || normalized.contains("mingw")
-                || normalized.contains("msys")
-                || normalized.contains("cygwin")
-            {
-                return Some("Windows".to_string());
-            }
-        }
-    }
-
-    None
-}
-
-fn resolve_local_flashgrep_bundle(binary_name: &str) -> Option<PathBuf> {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir.join("../../../..");
-    let mut candidates = vec![workspace_root.join("resources/flashgrep").join(binary_name)];
-
-    if let Ok(current_exe) = std::env::current_exe() {
-        if let Some(parent) = current_exe.parent() {
-            candidates.push(parent.join("resources/flashgrep").join(binary_name));
-            candidates.push(parent.join("flashgrep").join(binary_name));
-            candidates.push(parent.join("../Resources/flashgrep").join(binary_name));
-            candidates.push(parent.join("../share/bitfun/flashgrep").join(binary_name));
-            candidates.push(
-                parent
-                    .join("../share/com.bitfun.desktop/flashgrep")
-                    .join(binary_name),
-            );
-        }
-    }
-
-    candidates
-        .into_iter()
-        .find(|candidate| candidate.exists())
-        .map(|candidate| candidate.canonicalize().unwrap_or(candidate))
-}
-
-async fn local_flashgrep_bundle_for_arch(
-    remote_arch: &str,
-) -> Result<LocalFlashgrepBundle, String> {
-    let bundled_binary_names = match remote_arch {
-        "x86_64" | "amd64" => LINUX_X86_64_FLASHGREP_BUNDLES,
-        "aarch64" | "arm64" => LINUX_AARCH64_FLASHGREP_BUNDLES,
-        arch => {
-            return Err(format!(
-                "Remote workspace search does not support Linux architecture: {arch}"
-            ));
-        }
-    };
-
-    let (binary_name, path) = bundled_binary_names
-        .iter()
-        .find_map(|binary_name| {
-            resolve_local_flashgrep_bundle(binary_name)
-                .map(|path| ((*binary_name).to_string(), path))
-        })
-        .ok_or_else(|| {
-            format!(
-                "Bundled Linux flashgrep binary is missing. Expected one of: {}",
-                bundled_binary_names
-                    .iter()
-                    .map(|name| format!("resources/flashgrep/{name}"))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            )
-        })?;
-    let bytes = tokio::fs::read(&path).await.map_err(|error| {
-        format!(
-            "Failed to read bundled flashgrep binary {}: {error}",
-            path.display()
-        )
-    })?;
-    let sha256 = hex::encode(Sha256::digest(&bytes));
-
-    Ok(LocalFlashgrepBundle {
-        binary_name,
-        path,
-        bytes,
-        sha256,
-    })
-}
-
-fn convert_stdio_search_results(
-    search_results: &SearchResults,
-    output_mode: ContentSearchOutputMode,
-) -> Vec<FileSearchResult> {
-    match output_mode {
-        ContentSearchOutputMode::Content => {
-            let hit_results = convert_stdio_hits_to_file_search_results(search_results);
-            if !hit_results.is_empty() {
-                return hit_results;
-            }
-
-            let line_results = convert_stdio_line_matches_to_file_search_results(search_results);
-            if !line_results.is_empty() {
-                return line_results;
-            }
-
-            let count_results = convert_stdio_file_counts_to_search_results(search_results);
-            if !count_results.is_empty() {
-                return count_results;
-            }
-
-            let match_count_results =
-                convert_stdio_file_match_counts_to_search_results(search_results);
-            if !match_count_results.is_empty() {
-                return match_count_results;
-            }
-
-            convert_stdio_matched_paths_to_file_only_results(search_results)
-        }
-        ContentSearchOutputMode::Count => {
-            convert_stdio_file_counts_to_search_results(search_results)
-        }
-        ContentSearchOutputMode::FilesWithMatches => {
-            convert_stdio_matched_paths_to_file_only_results(search_results)
-        }
-    }
-}
-
-fn remote_stdio_search_mode(output_mode: ContentSearchOutputMode) -> SearchModeConfig {
-    match output_mode {
-        ContentSearchOutputMode::Content => SearchModeConfig::LineMatches,
-        ContentSearchOutputMode::Count => SearchModeConfig::CountOnly,
-        ContentSearchOutputMode::FilesWithMatches => SearchModeConfig::FilesWithMatches,
-    }
-}
-
-fn should_retry_remote_scan_fallback_as_files_with_matches(
-    backend: SearchBackend,
-    primary_search_mode: SearchModeConfig,
-    search_results: &SearchResults,
-) -> bool {
-    let primary_has_details = !search_results.hits.is_empty()
-        || !search_results.file_counts.is_empty()
-        || !search_results.file_match_counts.is_empty()
-        || !search_results.matched_paths.is_empty();
-    matches!(backend, SearchBackend::ScanFallback)
-        && !primary_has_details
-        && search_results.matched_lines > 0
-        && !matches!(primary_search_mode, SearchModeConfig::FilesWithMatches)
-}
-
-fn convert_stdio_line_matches_to_file_search_results(
-    search_results: &SearchResults,
-) -> Vec<FileSearchResult> {
-    search_results
-        .line_matches
-        .iter()
-        .map(|matched| FileSearchResult {
-            path: matched.path.clone(),
-            name: Path::new(&matched.path)
-                .file_name()
-                .and_then(|file_name| file_name.to_str())
-                .unwrap_or(&matched.path)
-                .to_string(),
-            is_directory: false,
-            match_type: SearchMatchType::Content,
-            line_number: Some(matched.line_number),
-            matched_content: Some(matched.line_text.clone()),
-            preview_before: None,
-            preview_inside: Some(matched.line_text.clone()),
-            preview_after: None,
-        })
-        .collect()
-}
-
-fn convert_stdio_file_counts_to_search_results(
-    search_results: &SearchResults,
-) -> Vec<FileSearchResult> {
-    search_results
-        .file_counts
-        .iter()
-        .map(|count| FileSearchResult {
-            path: count.path.clone(),
-            name: Path::new(&count.path)
-                .file_name()
-                .and_then(|file_name| file_name.to_str())
-                .unwrap_or(&count.path)
-                .to_string(),
-            is_directory: false,
-            match_type: SearchMatchType::Content,
-            line_number: None,
-            matched_content: Some(count.matched_lines.to_string()),
-            preview_before: None,
-            preview_inside: None,
-            preview_after: None,
-        })
-        .collect()
-}
-
-fn convert_stdio_file_match_counts_to_search_results(
-    search_results: &SearchResults,
-) -> Vec<FileSearchResult> {
-    search_results
-        .file_match_counts
-        .iter()
-        .map(|count| FileSearchResult {
-            path: count.path.clone(),
-            name: Path::new(&count.path)
-                .file_name()
-                .and_then(|file_name| file_name.to_str())
-                .unwrap_or(&count.path)
-                .to_string(),
-            is_directory: false,
-            match_type: SearchMatchType::Content,
-            line_number: None,
-            matched_content: Some(count.matched_occurrences.to_string()),
-            preview_before: None,
-            preview_inside: None,
-            preview_after: None,
-        })
-        .collect()
-}
-
-fn convert_stdio_hits_to_file_search_results(
-    search_results: &SearchResults,
-) -> Vec<FileSearchResult> {
-    let mut file_results = Vec::new();
-    for hit in &search_results.hits {
-        let name = Path::new(&hit.path)
-            .file_name()
-            .and_then(|file_name| file_name.to_str())
-            .unwrap_or(&hit.path)
-            .to_string();
-
-        let mut lines = BTreeMap::new();
-        for file_match in &hit.matches {
-            lines
-                .entry(file_match.location.line)
-                .or_insert_with(|| file_match.clone());
-        }
-
-        for (_, file_match) in lines {
-            let (preview_before, preview_inside, preview_after) =
-                split_preview(&file_match.snippet, &file_match.matched_text);
-            file_results.push(FileSearchResult {
-                path: hit.path.clone(),
-                name: name.clone(),
-                is_directory: false,
-                match_type: SearchMatchType::Content,
-                line_number: Some(file_match.location.line),
-                matched_content: Some(file_match.snippet),
-                preview_before,
-                preview_inside,
-                preview_after,
-            });
-        }
-    }
-    file_results
-}
-
-fn convert_stdio_matched_paths_to_file_only_results(
-    search_results: &SearchResults,
-) -> Vec<FileSearchResult> {
-    search_results
-        .matched_paths
-        .iter()
-        .map(|path| FileSearchResult {
-            path: path.clone(),
-            name: Path::new(path)
-                .file_name()
-                .and_then(|file_name| file_name.to_str())
-                .unwrap_or(path)
-                .to_string(),
-            is_directory: false,
-            match_type: SearchMatchType::Content,
-            line_number: None,
-            matched_content: None,
-            preview_before: None,
-            preview_inside: None,
-            preview_after: None,
-        })
-        .collect()
-}
-
-fn split_preview(
-    snippet: &str,
-    matched_text: &str,
-) -> (Option<String>, Option<String>, Option<String>) {
-    if matched_text.is_empty() {
-        return (None, Some(snippet.to_string()), None);
-    }
-
-    if let Some(offset) = snippet.find(matched_text) {
-        let before = snippet[..offset].to_string();
-        let inside = matched_text.to_string();
-        let after = snippet[offset + matched_text.len()..].to_string();
-        return (
-            (!before.is_empty()).then_some(before),
-            Some(inside),
-            (!after.is_empty()).then_some(after),
-        );
-    }
-
-    (None, Some(snippet.to_string()), None)
-}
-
-fn join_remote_path(base: &str, child: &str) -> String {
-    let base = normalize_remote_workspace_path(base);
-    let child = child.trim_start_matches('/');
-    if base == "/" {
-        format!("/{child}")
-    } else {
-        format!("{base}/{child}")
-    }
-}
-
-fn shell_escape(value: &str) -> String {
-    if value
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '-' | '_' | ':' | '='))
-    {
-        value.to_string()
-    } else {
-        format!("'{}'", value.replace('\'', "'\\''"))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        looks_like_linux_workspace_root, parse_remote_architecture_output, parse_remote_os_output,
-        remote_flashgrep_install_dir, should_retry_remote_scan_fallback_as_files_with_matches,
-    };
-    use crate::service::search::flashgrep::{
-        drain_content_length_messages, FileCount, SearchBackend, SearchHit, SearchModeConfig,
-        SearchResults,
-    };
-
-    #[test]
-    fn parses_plain_uname_architecture_output() {
-        assert_eq!(
-            parse_remote_architecture_output("x86_64\n", ""),
-            Some("x86_64".to_string())
-        );
-        assert_eq!(
-            parse_remote_architecture_output("aarch64\n", ""),
-            Some("aarch64".to_string())
-        );
-    }
-
-    #[test]
-    fn parses_architecture_from_banner_prefixed_output() {
-        let stdout = "Welcome to Ubuntu 24.04 LTS\nLast login: today\nArchitecture: amd64\n";
-        assert_eq!(
-            parse_remote_architecture_output(stdout, ""),
-            Some("x86_64".to_string())
-        );
-    }
-
-    #[test]
-    fn parses_architecture_from_stderr_when_needed() {
-        assert_eq!(
-            parse_remote_architecture_output("", "machine: arm64\n"),
-            Some("aarch64".to_string())
-        );
-    }
-
-    #[test]
-    fn installs_remote_flashgrep_under_workspace_root() {
-        assert_eq!(
-            remote_flashgrep_install_dir("/home/wgq/workspace/bot_detection"),
-            "/home/wgq/workspace/bot_detection/.bitfun/bin"
-        );
-    }
-
-    #[test]
-    fn parses_remote_os_from_uname_output() {
-        assert_eq!(
-            parse_remote_os_output("Linux\n", ""),
-            Some("Linux".to_string())
-        );
-        assert_eq!(
-            parse_remote_os_output("Darwin Kernel Version\n", ""),
-            Some("Darwin".to_string())
-        );
-    }
-
-    #[test]
-    fn parses_remote_os_from_banner_prefixed_output() {
-        assert_eq!(
-            parse_remote_os_output("Welcome\nOperating system: linux\n", ""),
-            Some("Linux".to_string())
-        );
-    }
-
-    #[test]
-    fn infers_linux_from_posix_workspace_root() {
-        assert!(looks_like_linux_workspace_root(
-            "/home/wgq/workspace/bot_detection"
-        ));
-        assert!(!looks_like_linux_workspace_root(
-            "C:/Users/wgq/workspace/bot_detection"
-        ));
-    }
-
-    #[test]
-    fn drains_remote_stdio_content_length_messages() {
-        let body = r#"{"jsonrpc":"2.0","id":7,"result":{"kind":"pong","now_unix_secs":1}}"#;
-        let mut buffer = format!("Content-Length: {}\r\n\r\n{}", body.len(), body).into_bytes();
-        let messages = drain_content_length_messages(&mut buffer)
-            .expect("expected content-length message to decode");
-
-        assert_eq!(messages.len(), 1);
-        assert!(buffer.is_empty());
-    }
-
-    #[test]
-    fn drains_remote_stdio_initialize_response_with_legacy_search_modes() {
-        let body = r#"{"jsonrpc":"2.0","id":1,"result":{"kind":"initialize_result","protocol_version":1,"server_info":{"name":"flashgrep","version":"0.1.0"},"capabilities":{"workspace_open":true,"workspace_ensure":true,"workspace_list":false,"workspace_refresh":true,"base_snapshot_build":true,"base_snapshot_rebuild":true,"task_status":true,"task_cancel":true,"search_query":true,"glob_query":true,"progress_notifications":true,"status_notifications":true},"search":{"search_modes":["files_with_matches","line_matches","count_only","count_matches"]}}}"#;
-        let mut buffer = format!("Content-Length: {}\r\n\r\n{}", body.len(), body).into_bytes();
-        let messages = drain_content_length_messages(&mut buffer)
-            .expect("expected initialize response to decode");
-
-        assert_eq!(messages.len(), 1);
-        let debug = format!("{:?}", messages[0]);
-        assert!(debug.contains("InitializeResult"));
-    }
-
-    #[test]
-    fn retries_remote_scan_fallback_when_primary_results_are_summary_only() {
-        let summary_only = search_results_with_counts(7, 12);
-
-        assert!(should_retry_remote_scan_fallback_as_files_with_matches(
-            SearchBackend::ScanFallback,
-            SearchModeConfig::LineMatches,
-            &summary_only,
-        ));
-        assert!(should_retry_remote_scan_fallback_as_files_with_matches(
-            SearchBackend::ScanFallback,
-            SearchModeConfig::CountOnly,
-            &summary_only,
-        ));
-    }
-
-    #[test]
-    fn skips_remote_files_with_matches_retry_when_primary_results_have_details() {
-        let mut with_paths = search_results_with_counts(7, 12);
-        with_paths
-            .matched_paths
-            .push("/repo/src/lib.rs".to_string());
-        assert!(!should_retry_remote_scan_fallback_as_files_with_matches(
-            SearchBackend::ScanFallback,
-            SearchModeConfig::LineMatches,
-            &with_paths,
-        ));
-
-        let mut with_file_counts = search_results_with_counts(7, 12);
-        with_file_counts.file_counts.push(FileCount {
-            path: "/repo/src/lib.rs".to_string(),
-            matched_lines: 7,
-        });
-        assert!(!should_retry_remote_scan_fallback_as_files_with_matches(
-            SearchBackend::ScanFallback,
-            SearchModeConfig::LineMatches,
-            &with_file_counts,
-        ));
-
-        let mut with_hits = search_results_with_counts(7, 12);
-        with_hits.hits.push(SearchHit {
-            path: "/repo/src/lib.rs".to_string(),
-            matches: Vec::new(),
-            lines: Vec::new(),
-        });
-        assert!(!should_retry_remote_scan_fallback_as_files_with_matches(
-            SearchBackend::ScanFallback,
-            SearchModeConfig::LineMatches,
-            &with_hits,
-        ));
-    }
-
-    #[test]
-    fn skips_remote_files_with_matches_retry_outside_summary_only_scan_fallback() {
-        assert!(!should_retry_remote_scan_fallback_as_files_with_matches(
-            SearchBackend::IndexedClean,
-            SearchModeConfig::LineMatches,
-            &search_results_with_counts(7, 12),
-        ));
-        assert!(!should_retry_remote_scan_fallback_as_files_with_matches(
-            SearchBackend::ScanFallback,
-            SearchModeConfig::FilesWithMatches,
-            &search_results_with_counts(7, 12),
-        ));
-        assert!(!should_retry_remote_scan_fallback_as_files_with_matches(
-            SearchBackend::ScanFallback,
-            SearchModeConfig::LineMatches,
-            &search_results_with_counts(0, 0),
-        ));
-    }
-
-    fn search_results_with_counts(
-        matched_lines: usize,
-        matched_occurrences: usize,
-    ) -> SearchResults {
-        SearchResults {
-            candidate_docs: 0,
-            searches_with_match: 0,
-            bytes_searched: 0,
-            matched_lines,
-            matched_occurrences,
-            matched_paths: Vec::new(),
-            file_counts: Vec::new(),
-            file_match_counts: Vec::new(),
-            line_matches: Vec::new(),
-            hits: Vec::new(),
-        }
-    }
 }

--- a/src/crates/assembly/core/src/service/search/service.rs
+++ b/src/crates/assembly/core/src/service/search/service.rs
@@ -109,7 +109,7 @@ struct CoreWorkspaceSearchRuntimeHooks;
 
 #[async_trait]
 impl owner::WorkspaceSearchRuntimeHooks for CoreWorkspaceSearchRuntimeHooks {
-    async fn repo_config(&self) -> owner::flashgrep::RepoConfig {
+    async fn repo_config(&self) -> owner::WorkspaceSearchRepoConfig {
         let max_file_size = match get_global_config_service().await {
             Ok(config_service) => match config_service
                 .get_config::<WorkspaceConfig>(Some("workspace"))
@@ -133,10 +133,7 @@ impl owner::WorkspaceSearchRuntimeHooks for CoreWorkspaceSearchRuntimeHooks {
             }
         };
 
-        owner::flashgrep::RepoConfig {
-            max_file_size,
-            ..owner::flashgrep::RepoConfig::default()
-        }
+        owner::WorkspaceSearchRepoConfig { max_file_size }
     }
 
     async fn ensure_workspace_ready(&self, repo_root: &Path) -> owner::WorkspaceSearchResult<()> {

--- a/src/crates/execution/agent-runtime/AGENTS.md
+++ b/src/crates/execution/agent-runtime/AGENTS.md
@@ -25,7 +25,8 @@ and tested without `bitfun-core`.
   measurement decisions,
   custom subagent markdown front-matter IO, custom subagent discovery/loading,
   post-call hook routing/executor orchestration,
-  tool confirmation planning/failure mapping, round-boundary yield/injection state, turn-outcome
+  tool confirmation planning/failure/wait-result mapping, light checkpoint
+  summary policy, round-boundary yield/injection state, turn-outcome
   queue decisions, registry source/profile facts, prompt-loop user-context
   policy, prompt listing reminder ordering, prompt-cache policy/identity/store,
   finish-reason labels, session-state event labels, and turn-outcome event facts.

--- a/src/crates/execution/agent-runtime/src/checkpoint.rs
+++ b/src/crates/execution/agent-runtime/src/checkpoint.rs
@@ -1,0 +1,112 @@
+//! Provider-neutral checkpoint summary planning.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LightCheckpoint {
+    pub current_branch: Option<String>,
+    pub dirty_state_summary: String,
+    pub touched_files: Vec<String>,
+    pub diff_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LightCheckpointWorkspaceFacts {
+    WorkspaceUnavailable,
+    RemoteWorkspace,
+    LocalWorkspace {
+        git_status: Result<GitStatusCheckpointFacts, String>,
+        diff_hash: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitStatusCheckpointFacts {
+    pub current_branch: String,
+    pub staged_count: usize,
+    pub unstaged_count: usize,
+    pub untracked_count: usize,
+}
+
+pub fn build_light_checkpoint(
+    touched_files: Vec<String>,
+    workspace: LightCheckpointWorkspaceFacts,
+) -> LightCheckpoint {
+    match workspace {
+        LightCheckpointWorkspaceFacts::WorkspaceUnavailable => LightCheckpoint {
+            current_branch: None,
+            dirty_state_summary: "workspace_unavailable".to_string(),
+            touched_files,
+            diff_hash: None,
+        },
+        LightCheckpointWorkspaceFacts::RemoteWorkspace => LightCheckpoint {
+            current_branch: None,
+            dirty_state_summary: "remote_workspace_git_metadata_unavailable".to_string(),
+            touched_files,
+            diff_hash: None,
+        },
+        LightCheckpointWorkspaceFacts::LocalWorkspace {
+            git_status,
+            diff_hash,
+        } => {
+            let (current_branch, dirty_state_summary) = match git_status {
+                Ok(status) => (
+                    Some(status.current_branch),
+                    format!(
+                        "staged={}, unstaged={}, untracked={}",
+                        status.staged_count, status.unstaged_count, status.untracked_count
+                    ),
+                ),
+                Err(error) => (None, format!("git_status_unavailable: {}", error)),
+            };
+            LightCheckpoint {
+                current_branch,
+                dirty_state_summary,
+                touched_files,
+                diff_hash,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_local_checkpoint_summary_from_git_status_facts() {
+        let checkpoint = build_light_checkpoint(
+            vec!["src/lib.rs".to_string()],
+            LightCheckpointWorkspaceFacts::LocalWorkspace {
+                git_status: Ok(GitStatusCheckpointFacts {
+                    current_branch: "main".to_string(),
+                    staged_count: 1,
+                    unstaged_count: 2,
+                    untracked_count: 3,
+                }),
+                diff_hash: Some("abc".to_string()),
+            },
+        );
+
+        assert_eq!(checkpoint.current_branch, Some("main".to_string()));
+        assert_eq!(
+            checkpoint.dirty_state_summary,
+            "staged=1, unstaged=2, untracked=3"
+        );
+        assert_eq!(checkpoint.diff_hash, Some("abc".to_string()));
+        assert_eq!(checkpoint.touched_files, vec!["src/lib.rs".to_string()]);
+    }
+
+    #[test]
+    fn preserves_remote_checkpoint_unavailable_summary() {
+        let checkpoint = build_light_checkpoint(
+            vec!["/repo/src/lib.rs".to_string()],
+            LightCheckpointWorkspaceFacts::RemoteWorkspace,
+        );
+
+        assert_eq!(checkpoint.current_branch, None);
+        assert_eq!(
+            checkpoint.dirty_state_summary,
+            "remote_workspace_git_metadata_unavailable"
+        );
+        assert_eq!(checkpoint.diff_hash, None);
+    }
+}

--- a/src/crates/execution/agent-runtime/src/lib.rs
+++ b/src/crates/execution/agent-runtime/src/lib.rs
@@ -4,6 +4,7 @@
 //! depending on `bitfun-core` concrete session or scheduler lifecycle.
 
 pub mod agents;
+pub mod checkpoint;
 pub mod custom_subagent;
 pub mod events;
 pub mod post_call_hooks;

--- a/src/crates/execution/agent-runtime/src/tool_confirmation.rs
+++ b/src/crates/execution/agent-runtime/src/tool_confirmation.rs
@@ -29,6 +29,14 @@ pub enum ToolConfirmationOutcome {
     Timeout { tool_name: String },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolConfirmationWaitResult {
+    Confirmed,
+    Rejected(String),
+    ChannelClosed,
+    TimedOut,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfirmationFailureKind {
     Rejected,
@@ -80,5 +88,54 @@ pub fn resolve_confirmation_failure(
             state_reason: "Confirmation timeout".to_string(),
             error_message: format!("Confirmation timeout: {tool_name}"),
         }),
+    }
+}
+
+pub fn resolve_confirmation_wait_result(
+    result: ToolConfirmationWaitResult,
+    tool_name: &str,
+) -> ToolConfirmationOutcome {
+    match result {
+        ToolConfirmationWaitResult::Confirmed => ToolConfirmationOutcome::Confirmed,
+        ToolConfirmationWaitResult::Rejected(reason) => {
+            ToolConfirmationOutcome::Rejected { reason }
+        }
+        ToolConfirmationWaitResult::ChannelClosed => ToolConfirmationOutcome::ChannelClosed,
+        ToolConfirmationWaitResult::TimedOut => ToolConfirmationOutcome::Timeout {
+            tool_name: tool_name.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_confirmation_wait_timeout_to_tool_named_outcome() {
+        let outcome =
+            resolve_confirmation_wait_result(ToolConfirmationWaitResult::TimedOut, "Bash");
+
+        assert_eq!(
+            outcome,
+            ToolConfirmationOutcome::Timeout {
+                tool_name: "Bash".to_string()
+            }
+        );
+        let failure = resolve_confirmation_failure(outcome).unwrap();
+        assert_eq!(failure.kind, ConfirmationFailureKind::Timeout);
+        assert_eq!(failure.error_message, "Confirmation timeout: Bash");
+    }
+
+    #[test]
+    fn preserves_rejection_reason_in_confirmation_failure() {
+        let outcome = resolve_confirmation_wait_result(
+            ToolConfirmationWaitResult::Rejected("no".to_string()),
+            "Edit",
+        );
+
+        let failure = resolve_confirmation_failure(outcome).unwrap();
+        assert_eq!(failure.kind, ConfirmationFailureKind::Rejected);
+        assert_eq!(failure.error_message, "Tool was rejected by user: no");
     }
 }

--- a/src/crates/execution/agent-runtime/tests/tool_confirmation_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/tool_confirmation_contracts.rs
@@ -1,6 +1,7 @@
 use bitfun_agent_runtime::tool_confirmation::{
-    resolve_confirmation_failure, resolve_tool_confirmation_plan, ConfirmationFailureKind,
-    ToolConfirmationOutcome, ToolConfirmationPlan, ToolConfirmationRequestFacts,
+    resolve_confirmation_failure, resolve_confirmation_wait_result, resolve_tool_confirmation_plan,
+    ConfirmationFailureKind, ToolConfirmationOutcome, ToolConfirmationPlan,
+    ToolConfirmationRequestFacts, ToolConfirmationWaitResult,
 };
 use std::time::{Duration, UNIX_EPOCH};
 
@@ -85,4 +86,31 @@ fn confirmation_failure_mapping_preserves_legacy_reasons_and_errors() {
     assert_eq!(timeout.kind, ConfirmationFailureKind::Timeout);
     assert_eq!(timeout.state_reason, "Confirmation timeout");
     assert_eq!(timeout.error_message, "Confirmation timeout: Bash");
+}
+
+#[test]
+fn confirmation_wait_result_mapping_preserves_legacy_timeout_and_rejection() {
+    assert_eq!(
+        resolve_confirmation_wait_result(ToolConfirmationWaitResult::Confirmed, "Bash"),
+        ToolConfirmationOutcome::Confirmed
+    );
+    assert_eq!(
+        resolve_confirmation_wait_result(
+            ToolConfirmationWaitResult::Rejected("unsafe".to_string()),
+            "Edit"
+        ),
+        ToolConfirmationOutcome::Rejected {
+            reason: "unsafe".to_string(),
+        }
+    );
+    assert_eq!(
+        resolve_confirmation_wait_result(ToolConfirmationWaitResult::ChannelClosed, "Read"),
+        ToolConfirmationOutcome::ChannelClosed
+    );
+    assert_eq!(
+        resolve_confirmation_wait_result(ToolConfirmationWaitResult::TimedOut, "Bash"),
+        ToolConfirmationOutcome::Timeout {
+            tool_name: "Bash".to_string(),
+        }
+    );
 }

--- a/src/crates/execution/agent-stream/Cargo.toml
+++ b/src/crates/execution/agent-stream/Cargo.toml
@@ -22,4 +22,5 @@ tokio-util = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+bitfun-agent-tools = { path = "../tool-contracts" }
 tokio-stream = { workspace = true }

--- a/src/crates/execution/agent-stream/src/tool_call_accumulator.rs
+++ b/src/crates/execution/agent-stream/src/tool_call_accumulator.rs
@@ -957,6 +957,25 @@ mod tests {
     }
 
     #[test]
+    fn write_like_recovery_classification_matches_tool_presentation_contract() {
+        for tool_name in [
+            "Write",
+            "file_write",
+            "write_notebook",
+            "Read",
+            "Edit",
+            "AskUserQuestion",
+            "TodoWrite",
+        ] {
+            assert_eq!(
+                super::is_write_like_tool_name(tool_name),
+                bitfun_agent_tools::is_write_like_tool_name(tool_name),
+                "tool_name={tool_name}"
+            );
+        }
+    }
+
+    #[test]
     fn write_truncated_with_chinese_multibyte_is_recovered() {
         let raw = "{\"file_path\": \"/tmp/r.md\", \"content\": \"深度研究报告：未完";
         let mut pending = PendingToolCall::default();

--- a/src/crates/execution/tool-execution/AGENTS.md
+++ b/src/crates/execution/tool-execution/AGENTS.md
@@ -3,8 +3,9 @@
 Scope: this guide applies to `src/crates/execution/tool-execution`.
 
 `tool-runtime` owns low-level reusable tool execution helpers such as filesystem
-and search utilities. It is not the product tool registry, permission model, or
-agent-facing tool surface.
+and search utilities plus provider-neutral pipeline planning/retry policy. It
+is not the product tool registry, permission model, or agent-facing tool
+surface.
 
 ## Guardrails
 

--- a/src/crates/execution/tool-execution/src/lib.rs
+++ b/src/crates/execution/tool-execution/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod fs;
+pub mod pipeline;
 pub mod search;
 pub mod shell;
 pub mod util;

--- a/src/crates/execution/tool-execution/src/pipeline.rs
+++ b/src/crates/execution/tool-execution/src/pipeline.rs
@@ -1,0 +1,55 @@
+//! Provider-neutral tool pipeline planning helpers.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolBatch {
+    pub task_ids: Vec<String>,
+    pub is_concurrent: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolExecutionErrorClass {
+    Retryable,
+    Terminal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolRetryAttemptFacts {
+    pub attempts: usize,
+    pub max_attempts: usize,
+    pub error_class: ToolExecutionErrorClass,
+}
+
+/// Partition task IDs into execution batches.
+///
+/// Consecutive concurrency-safe tasks share one concurrent batch; non-safe
+/// tasks stay as individual serial batches. This preserves input ordering while
+/// allowing adjacent read-only work to run in parallel.
+pub fn partition_tool_batches(task_ids: &[String], flags: &[bool]) -> Vec<ToolBatch> {
+    let mut batches: Vec<ToolBatch> = Vec::new();
+
+    for (id, &is_safe) in task_ids.iter().zip(flags.iter()) {
+        if is_safe {
+            if let Some(last) = batches.last_mut() {
+                if last.is_concurrent {
+                    last.task_ids.push(id.clone());
+                    continue;
+                }
+            }
+        }
+        batches.push(ToolBatch {
+            task_ids: vec![id.clone()],
+            is_concurrent: is_safe,
+        });
+    }
+
+    batches
+}
+
+pub fn should_retry_tool_attempt(facts: ToolRetryAttemptFacts) -> bool {
+    facts.attempts < facts.max_attempts
+        && matches!(facts.error_class, ToolExecutionErrorClass::Retryable)
+}
+
+pub fn retry_delay_ms(attempts: usize) -> u64 {
+    100 * attempts as u64
+}

--- a/src/crates/execution/tool-execution/tests/tool_pipeline_planning.rs
+++ b/src/crates/execution/tool-execution/tests/tool_pipeline_planning.rs
@@ -1,0 +1,63 @@
+use tool_runtime::pipeline::{
+    partition_tool_batches, retry_delay_ms, should_retry_tool_attempt, ToolExecutionErrorClass,
+    ToolRetryAttemptFacts,
+};
+
+#[test]
+fn partitions_consecutive_concurrency_safe_tools_into_parallel_batches() {
+    let task_ids = vec![
+        "read_1".to_string(),
+        "read_2".to_string(),
+        "write_1".to_string(),
+        "grep_1".to_string(),
+        "grep_2".to_string(),
+        "bash_1".to_string(),
+    ];
+    let flags = vec![true, true, false, true, true, false];
+
+    let batches = partition_tool_batches(&task_ids, &flags);
+
+    assert_eq!(batches.len(), 4);
+    assert_eq!(batches[0].task_ids, vec!["read_1", "read_2"]);
+    assert!(batches[0].is_concurrent);
+    assert_eq!(batches[1].task_ids, vec!["write_1"]);
+    assert!(!batches[1].is_concurrent);
+    assert_eq!(batches[2].task_ids, vec!["grep_1", "grep_2"]);
+    assert!(batches[2].is_concurrent);
+    assert_eq!(batches[3].task_ids, vec!["bash_1"]);
+    assert!(!batches[3].is_concurrent);
+}
+
+#[test]
+fn partitions_serial_tools_as_individual_batches() {
+    let task_ids = vec!["write_1".to_string(), "bash_1".to_string()];
+    let flags = vec![false, false];
+
+    let batches = partition_tool_batches(&task_ids, &flags);
+
+    assert_eq!(batches.len(), 2);
+    assert_eq!(batches[0].task_ids, vec!["write_1"]);
+    assert!(!batches[0].is_concurrent);
+    assert_eq!(batches[1].task_ids, vec!["bash_1"]);
+    assert!(!batches[1].is_concurrent);
+}
+
+#[test]
+fn retry_policy_preserves_attempt_limit_and_error_class_contract() {
+    assert!(should_retry_tool_attempt(ToolRetryAttemptFacts {
+        attempts: 1,
+        max_attempts: 3,
+        error_class: ToolExecutionErrorClass::Retryable,
+    }));
+    assert!(!should_retry_tool_attempt(ToolRetryAttemptFacts {
+        attempts: 3,
+        max_attempts: 3,
+        error_class: ToolExecutionErrorClass::Retryable,
+    }));
+    assert!(!should_retry_tool_attempt(ToolRetryAttemptFacts {
+        attempts: 1,
+        max_attempts: 3,
+        error_class: ToolExecutionErrorClass::Terminal,
+    }));
+    assert_eq!(retry_delay_ms(2), 200);
+}

--- a/src/crates/services/services-integrations/AGENTS.md
+++ b/src/crates/services/services-integrations/AGENTS.md
@@ -32,6 +32,10 @@ slices that are outside pure product logic but still platform-neutral.
 - Workspace search owns the local flashgrep daemon/session lifecycle and
   indexed-search result conversion behind `workspace-search`; product config
   and workspace bootstrap stay in the core facade as injected hooks.
+- Remote SSH workspace-search owns path/scope/probe/bundle/retry strategy plus
+  flashgrep session/context lifecycle behind a provider boundary. SSH channels
+  and manager assembly remain outside this crate until a reviewed provider
+  boundary moves them with equivalence tests.
 
 ## Verification
 

--- a/src/crates/services/services-integrations/src/remote_ssh/mod.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/mod.rs
@@ -6,6 +6,8 @@
 pub mod paths;
 pub mod types;
 pub mod workspace_registry;
+#[cfg(feature = "workspace-search")]
+pub mod workspace_search;
 
 pub use paths::*;
 pub use types::*;

--- a/src/crates/services/services-integrations/src/remote_ssh/workspace_search/mod.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/workspace_search/mod.rs
@@ -1,0 +1,516 @@
+//! Remote SSH workspace-search strategy helpers.
+//!
+//! Concrete SSH channel execution remains in product assembly until a reviewed
+//! remote-command provider boundary exists. This module owns remote workspace
+//! search strategy plus the flashgrep session/context lifecycle that can run
+//! behind that provider boundary.
+
+use super::normalize_remote_workspace_path;
+use crate::workspace_search::flashgrep::{
+    PathScope, SearchBackend, SearchModeConfig, SearchResults,
+};
+use crate::workspace_search::ContentSearchOutputMode;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+mod service;
+
+pub use service::{
+    RemoteCommandOutput, RemoteWorkspaceSearchProvider, RemoteWorkspaceSearchService,
+    RemoteWorkspaceSearchStdioProtocol,
+};
+
+pub(crate) const REMOTE_OS_PROBES: &[&str] = &["uname -s", "sh -c 'uname -s 2>/dev/null'"];
+pub(crate) const REMOTE_ARCHITECTURE_PROBES: &[&str] = &[
+    "uname -m",
+    "arch",
+    "sh -c 'uname -m 2>/dev/null || arch 2>/dev/null'",
+];
+
+const REMOTE_FLASHGREP_INSTALL_DIR: &str = ".bitfun/bin";
+const LINUX_X86_64_FLASHGREP_BUNDLES: &[&str] = &[
+    "flashgrep-x86_64-unknown-linux-musl",
+    "flashgrep-x86_64-unknown-linux-gnu",
+];
+const LINUX_AARCH64_FLASHGREP_BUNDLES: &[&str] = &[
+    "flashgrep-aarch64-unknown-linux-musl",
+    "flashgrep-aarch64-unknown-linux-gnu",
+];
+
+pub(crate) struct LocalFlashgrepBundle {
+    pub(crate) binary_name: String,
+    pub(crate) path: PathBuf,
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) sha256: String,
+}
+
+pub(crate) fn build_remote_scope(
+    repo_root: &str,
+    search_path: Option<&Path>,
+    globs: Vec<String>,
+    file_types: Vec<String>,
+    exclude_file_types: Vec<String>,
+) -> Result<PathScope, String> {
+    let repo_root = normalize_remote_workspace_path(repo_root);
+    let roots = match search_path {
+        Some(path) => {
+            let normalized = normalize_remote_scope_path(&repo_root, path)?;
+            if normalized == repo_root {
+                Vec::new()
+            } else {
+                vec![PathBuf::from(normalized)]
+            }
+        }
+        None => Vec::new(),
+    };
+
+    Ok(PathScope {
+        roots,
+        globs,
+        iglobs: Vec::new(),
+        type_add: Vec::new(),
+        type_clear: Vec::new(),
+        types: file_types,
+        type_not: exclude_file_types,
+    })
+}
+
+fn normalize_remote_scope_path(repo_root: &str, search_path: &Path) -> Result<String, String> {
+    let raw_path = search_path.to_string_lossy();
+    let normalized = if raw_path.starts_with('/') {
+        normalize_remote_workspace_path(&raw_path)
+    } else {
+        join_remote_path(repo_root, &raw_path)
+    };
+    let repo_root_with_slash = format!("{}/", repo_root.trim_end_matches('/'));
+    if normalized != repo_root && !normalized.starts_with(&repo_root_with_slash) {
+        return Err(format!(
+            "Remote search path is outside workspace root: {normalized}"
+        ));
+    }
+    Ok(normalized)
+}
+
+pub(crate) fn remote_flashgrep_install_dir(repo_root: &str) -> String {
+    join_remote_path(
+        &normalize_remote_workspace_path(repo_root),
+        REMOTE_FLASHGREP_INSTALL_DIR,
+    )
+}
+
+pub(crate) fn remote_workspace_search_storage_root(repo_root: &str) -> String {
+    join_remote_path(repo_root, ".bitfun/search/flashgrep-index")
+}
+
+pub(crate) fn looks_like_linux_workspace_root(path: &str) -> bool {
+    path.starts_with('/') && !path.contains(':')
+}
+
+pub(crate) fn parse_remote_architecture_output(stdout: &str, stderr: &str) -> Option<String> {
+    for stream in [stdout, stderr] {
+        for line in stream.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let normalized = trimmed.to_ascii_lowercase();
+            if normalized.contains("x86_64") || normalized.contains("amd64") {
+                return Some("x86_64".to_string());
+            }
+            if normalized.contains("aarch64")
+                || normalized.contains("arm64")
+                || normalized.contains("armv8")
+            {
+                return Some("aarch64".to_string());
+            }
+        }
+    }
+
+    None
+}
+
+pub(crate) fn parse_remote_os_output(stdout: &str, stderr: &str) -> Option<String> {
+    for stream in [stdout, stderr] {
+        for line in stream.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let normalized = trimmed.to_ascii_lowercase();
+            if normalized.contains("linux") {
+                return Some("Linux".to_string());
+            }
+            if normalized.contains("darwin") || normalized.contains("macos") {
+                return Some("Darwin".to_string());
+            }
+            if normalized.contains("windows")
+                || normalized.contains("mingw")
+                || normalized.contains("msys")
+                || normalized.contains("cygwin")
+            {
+                return Some("Windows".to_string());
+            }
+        }
+    }
+
+    None
+}
+
+fn linux_flashgrep_bundle_names_for_arch(
+    remote_arch: &str,
+) -> Result<&'static [&'static str], String> {
+    match remote_arch {
+        "x86_64" | "amd64" => Ok(LINUX_X86_64_FLASHGREP_BUNDLES),
+        "aarch64" | "arm64" => Ok(LINUX_AARCH64_FLASHGREP_BUNDLES),
+        arch => Err(format!(
+            "Remote workspace search does not support Linux architecture: {arch}"
+        )),
+    }
+}
+
+pub(crate) async fn local_flashgrep_bundle_for_arch(
+    remote_arch: &str,
+) -> Result<LocalFlashgrepBundle, String> {
+    let bundled_binary_names = linux_flashgrep_bundle_names_for_arch(remote_arch)?;
+
+    let (binary_name, path) = bundled_binary_names
+        .iter()
+        .find_map(|binary_name| {
+            resolve_local_flashgrep_bundle(binary_name)
+                .map(|path| ((*binary_name).to_string(), path))
+        })
+        .ok_or_else(|| {
+            format!(
+                "Bundled Linux flashgrep binary is missing. Expected one of: {}",
+                bundled_binary_names
+                    .iter()
+                    .map(|name| format!("resources/flashgrep/{name}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
+    let bytes = tokio::fs::read(&path).await.map_err(|error| {
+        format!(
+            "Failed to read bundled flashgrep binary {}: {error}",
+            path.display()
+        )
+    })?;
+    let sha256 = hex_encode(&Sha256::digest(&bytes));
+
+    Ok(LocalFlashgrepBundle {
+        binary_name,
+        path,
+        bytes,
+        sha256,
+    })
+}
+
+pub(crate) fn remote_stdio_search_mode(output_mode: ContentSearchOutputMode) -> SearchModeConfig {
+    match output_mode {
+        ContentSearchOutputMode::Content => SearchModeConfig::LineMatches,
+        ContentSearchOutputMode::Count => SearchModeConfig::CountOnly,
+        ContentSearchOutputMode::FilesWithMatches => SearchModeConfig::FilesWithMatches,
+    }
+}
+
+pub(crate) fn should_retry_remote_scan_fallback_as_files_with_matches(
+    backend: SearchBackend,
+    primary_search_mode: SearchModeConfig,
+    search_results: &SearchResults,
+) -> bool {
+    let primary_has_details = !search_results.hits.is_empty()
+        || !search_results.file_counts.is_empty()
+        || !search_results.file_match_counts.is_empty()
+        || !search_results.matched_paths.is_empty();
+    matches!(backend, SearchBackend::ScanFallback)
+        && !primary_has_details
+        && search_results.matched_lines > 0
+        && !matches!(primary_search_mode, SearchModeConfig::FilesWithMatches)
+}
+
+pub(crate) fn join_remote_path(base: &str, child: &str) -> String {
+    let base = normalize_remote_workspace_path(base);
+    let child = child.trim_start_matches('/');
+    if base == "/" {
+        format!("/{child}")
+    } else {
+        format!("{base}/{child}")
+    }
+}
+
+pub(crate) fn shell_escape(value: &str) -> String {
+    if value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '-' | '_' | ':' | '='))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+fn resolve_local_flashgrep_bundle(binary_name: &str) -> Option<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir.join("../../../..");
+    let mut candidates = vec![workspace_root.join("resources/flashgrep").join(binary_name)];
+
+    if let Ok(current_exe) = std::env::current_exe() {
+        if let Some(parent) = current_exe.parent() {
+            candidates.push(parent.join("resources/flashgrep").join(binary_name));
+            candidates.push(parent.join("flashgrep").join(binary_name));
+            candidates.push(parent.join("../Resources/flashgrep").join(binary_name));
+            candidates.push(parent.join("../share/bitfun/flashgrep").join(binary_name));
+            candidates.push(
+                parent
+                    .join("../share/com.bitfun.desktop/flashgrep")
+                    .join(binary_name),
+            );
+        }
+    }
+
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.exists())
+        .map(|candidate| candidate.canonicalize().unwrap_or(candidate))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace_search::flashgrep::{
+        FileCount, SearchBackend, SearchHit, SearchModeConfig, SearchResults,
+    };
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn remote_workspace_search_paths_preserve_current_contract() {
+        assert_eq!(
+            remote_flashgrep_install_dir("/home/wgq/workspace/bot_detection"),
+            "/home/wgq/workspace/bot_detection/.bitfun/bin"
+        );
+        assert_eq!(
+            remote_workspace_search_storage_root("/home/wgq/workspace/bot_detection/"),
+            "/home/wgq/workspace/bot_detection/.bitfun/search/flashgrep-index"
+        );
+        assert_eq!(join_remote_path("/", "tmp/file.txt"), "/tmp/file.txt");
+        assert_eq!(
+            join_remote_path("/home/user/repo/", "/src/lib.rs"),
+            "/home/user/repo/src/lib.rs"
+        );
+        assert_eq!(
+            shell_escape("/home/user/repo/file.txt"),
+            "/home/user/repo/file.txt"
+        );
+        assert_eq!(
+            shell_escape("/home/user/my repo/file.txt"),
+            "'/home/user/my repo/file.txt'"
+        );
+    }
+
+    #[test]
+    fn remote_workspace_search_probe_parsers_preserve_current_contract() {
+        assert_eq!(
+            parse_remote_architecture_output("x86_64\n", ""),
+            Some("x86_64".to_string())
+        );
+        assert_eq!(
+            parse_remote_architecture_output("Welcome\nArchitecture: amd64\n", ""),
+            Some("x86_64".to_string())
+        );
+        assert_eq!(
+            parse_remote_architecture_output("", "machine: arm64\n"),
+            Some("aarch64".to_string())
+        );
+        assert_eq!(
+            parse_remote_os_output("Linux\n", ""),
+            Some("Linux".to_string())
+        );
+        assert_eq!(
+            parse_remote_os_output("Darwin Kernel Version\n", ""),
+            Some("Darwin".to_string())
+        );
+        assert_eq!(
+            parse_remote_os_output("Welcome\nOperating system: linux\n", ""),
+            Some("Linux".to_string())
+        );
+        assert!(looks_like_linux_workspace_root(
+            "/home/wgq/workspace/bot_detection"
+        ));
+        assert!(!looks_like_linux_workspace_root(
+            "C:/Users/wgq/workspace/bot_detection"
+        ));
+    }
+
+    #[tokio::test]
+    async fn remote_workspace_search_bundle_rejects_unsupported_linux_arch() {
+        let err = match local_flashgrep_bundle_for_arch("riscv64").await {
+            Ok(_) => panic!("unsupported architecture should fail before bundle lookup"),
+            Err(err) => err,
+        };
+        assert!(err.contains("does not support Linux architecture"));
+    }
+
+    #[test]
+    fn remote_workspace_search_scope_preserves_current_contract() {
+        let scope = build_remote_scope(
+            "/home/user/repo/",
+            Some(Path::new("src")),
+            vec!["*.rs".to_string()],
+            vec!["rust".to_string()],
+            vec!["lock".to_string()],
+        )
+        .unwrap();
+        assert_eq!(scope.roots, vec![PathBuf::from("/home/user/repo/src")]);
+        assert_eq!(scope.globs, vec!["*.rs".to_string()]);
+        assert_eq!(scope.types, vec!["rust".to_string()]);
+        assert_eq!(scope.type_not, vec!["lock".to_string()]);
+
+        let workspace_root_scope = build_remote_scope(
+            "/home/user/repo",
+            Some(Path::new("/home/user/repo")),
+            vec![],
+            vec![],
+            vec![],
+        )
+        .unwrap();
+        assert!(workspace_root_scope.roots.is_empty());
+
+        let err = build_remote_scope(
+            "/home/user/repo",
+            Some(Path::new("/home/user/other")),
+            vec![],
+            vec![],
+            vec![],
+        )
+        .unwrap_err();
+        assert!(err.contains("outside workspace root"));
+    }
+
+    #[test]
+    fn remote_workspace_search_mode_preserves_current_contract() {
+        assert_eq!(
+            remote_stdio_search_mode(ContentSearchOutputMode::Content),
+            SearchModeConfig::LineMatches
+        );
+        assert_eq!(
+            remote_stdio_search_mode(ContentSearchOutputMode::Count),
+            SearchModeConfig::CountOnly
+        );
+        assert_eq!(
+            remote_stdio_search_mode(ContentSearchOutputMode::FilesWithMatches),
+            SearchModeConfig::FilesWithMatches
+        );
+    }
+
+    #[test]
+    fn remote_scan_fallback_retry_policy_preserves_current_contract() {
+        let summary_only = search_results_with_counts(7, 12);
+
+        assert!(should_retry_remote_scan_fallback_as_files_with_matches(
+            SearchBackend::ScanFallback,
+            SearchModeConfig::LineMatches,
+            &summary_only,
+        ));
+        assert!(should_retry_remote_scan_fallback_as_files_with_matches(
+            SearchBackend::ScanFallback,
+            SearchModeConfig::CountOnly,
+            &summary_only,
+        ));
+
+        let mut with_paths = search_results_with_counts(7, 12);
+        with_paths
+            .matched_paths
+            .push("/repo/src/lib.rs".to_string());
+        assert!(!should_retry_remote_scan_fallback_as_files_with_matches(
+            SearchBackend::ScanFallback,
+            SearchModeConfig::LineMatches,
+            &with_paths,
+        ));
+
+        let mut with_file_counts = search_results_with_counts(7, 12);
+        with_file_counts.file_counts.push(FileCount {
+            path: "/repo/src/lib.rs".to_string(),
+            matched_lines: 7,
+        });
+        assert!(!should_retry_remote_scan_fallback_as_files_with_matches(
+            SearchBackend::ScanFallback,
+            SearchModeConfig::LineMatches,
+            &with_file_counts,
+        ));
+
+        let mut with_hits = search_results_with_counts(7, 12);
+        with_hits.hits.push(SearchHit {
+            path: "/repo/src/lib.rs".to_string(),
+            matches: Vec::new(),
+            lines: Vec::new(),
+        });
+        assert!(!should_retry_remote_scan_fallback_as_files_with_matches(
+            SearchBackend::ScanFallback,
+            SearchModeConfig::LineMatches,
+            &with_hits,
+        ));
+        assert!(!should_retry_remote_scan_fallback_as_files_with_matches(
+            SearchBackend::IndexedClean,
+            SearchModeConfig::LineMatches,
+            &summary_only,
+        ));
+        assert!(!should_retry_remote_scan_fallback_as_files_with_matches(
+            SearchBackend::ScanFallback,
+            SearchModeConfig::FilesWithMatches,
+            &summary_only,
+        ));
+        assert!(!should_retry_remote_scan_fallback_as_files_with_matches(
+            SearchBackend::ScanFallback,
+            SearchModeConfig::LineMatches,
+            &search_results_with_counts(0, 0),
+        ));
+    }
+
+    fn search_results_with_counts(
+        matched_lines: usize,
+        matched_occurrences: usize,
+    ) -> SearchResults {
+        SearchResults {
+            candidate_docs: 0,
+            searches_with_match: 0,
+            bytes_searched: 0,
+            matched_lines,
+            matched_occurrences,
+            matched_paths: Vec::new(),
+            file_counts: Vec::new(),
+            file_match_counts: Vec::new(),
+            line_matches: Vec::new(),
+            hits: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn preserves_supported_linux_flashgrep_bundle_order() {
+        assert_eq!(
+            linux_flashgrep_bundle_names_for_arch("amd64").unwrap(),
+            &[
+                "flashgrep-x86_64-unknown-linux-musl",
+                "flashgrep-x86_64-unknown-linux-gnu"
+            ]
+        );
+        assert_eq!(
+            linux_flashgrep_bundle_names_for_arch("arm64").unwrap(),
+            &[
+                "flashgrep-aarch64-unknown-linux-musl",
+                "flashgrep-aarch64-unknown-linux-gnu"
+            ]
+        );
+    }
+}

--- a/src/crates/services/services-integrations/src/remote_ssh/workspace_search/service.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/workspace_search/service.rs
@@ -1,0 +1,1313 @@
+use super::{
+    build_remote_scope, join_remote_path, local_flashgrep_bundle_for_arch,
+    looks_like_linux_workspace_root, parse_remote_architecture_output, parse_remote_os_output,
+    remote_flashgrep_install_dir, remote_stdio_search_mode, remote_workspace_search_storage_root,
+    shell_escape, should_retry_remote_scan_fallback_as_files_with_matches, LocalFlashgrepBundle,
+    REMOTE_ARCHITECTURE_PROBES, REMOTE_OS_PROBES,
+};
+use crate::remote_ssh::{normalize_remote_workspace_path, RemoteWorkspaceEntry};
+use crate::workspace_search::flashgrep::error::AppError;
+use crate::workspace_search::flashgrep::{
+    drain_content_length_messages, log_flashgrep_stderr_line_with_context, ClientCapabilities,
+    ClientInfo, ConsistencyMode, FlashgrepRepoSession, GlobOutcome, GlobParams, GlobRequest,
+    InitializeParams, OpenRepoParams, ProtocolClient, QuerySpec, RefreshPolicyConfig, RepoConfig,
+    RepoRef, RepoStatus, Request, Response, SearchBackend, SearchModeConfig, SearchOutcome,
+    SearchParams, SearchRequest, SearchResults, TaskRef, TaskStatus, FLASHGREP_LOG_TARGET,
+};
+use crate::workspace_search::result_mapping::convert_search_results;
+use crate::workspace_search::{
+    ContentSearchRequest, ContentSearchResult, GlobSearchRequest, GlobSearchResult,
+    IndexTaskHandle, WorkspaceIndexStatus, WorkspaceSearchFileCount, WorkspaceSearchHit,
+    WorkspaceSearchRepoStatus,
+};
+use async_trait::async_trait;
+use bitfun_services_core::filesystem::FileSearchOutcome;
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::path::PathBuf;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, LazyLock,
+};
+use std::time::Duration;
+use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio::time::{sleep, timeout};
+
+const REMOTE_STDIO_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const REMOTE_STDIO_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const REMOTE_STDIO_SESSION_IDLE_GRACE: Duration = Duration::from_secs(45);
+const CLIENT_NAME: &str = "bitfun-remote-workspace-search";
+
+static REMOTE_STDIO_SESSIONS: LazyLock<RwLock<HashMap<String, RemoteStdioSessionEntry>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+static REMOTE_STDIO_OPEN_GUARDS: LazyLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static REMOTE_SEARCH_CONTEXTS: LazyLock<RwLock<HashMap<String, RemoteSearchContext>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+#[derive(Debug, Clone)]
+pub struct RemoteCommandOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+#[derive(Clone)]
+pub struct RemoteWorkspaceSearchStdioProtocol {
+    protocol: ProtocolClient,
+}
+
+impl RemoteWorkspaceSearchStdioProtocol {
+    fn new(protocol: ProtocolClient) -> Self {
+        Self { protocol }
+    }
+
+    pub async fn handle_stdout_chunk(
+        &self,
+        read_buffer: &mut Vec<u8>,
+        data: &[u8],
+    ) -> Result<(), String> {
+        read_buffer.extend_from_slice(data);
+        let messages =
+            drain_content_length_messages(read_buffer).map_err(|error| error.to_string())?;
+        for message in messages {
+            self.protocol.handle_server_message(message).await;
+        }
+        Ok(())
+    }
+
+    pub fn log_stderr_line_with_context(&self, context: Option<&str>, line: &str) {
+        log_flashgrep_stderr_line_with_context(context, line);
+    }
+
+    pub async fn close_with_message(&self, message: impl Into<String>) {
+        self.protocol.close_with_message(message).await;
+    }
+}
+
+#[async_trait]
+pub trait RemoteWorkspaceSearchProvider: Send + Sync {
+    async fn resolve_workspace_entry(
+        &self,
+        root_path: &str,
+        preferred_connection_id: Option<&str>,
+    ) -> Result<RemoteWorkspaceEntry, String>;
+
+    async fn cached_server_os_type(&self, connection_id: &str) -> Option<String>;
+
+    async fn execute_command(
+        &self,
+        connection_id: &str,
+        command: &str,
+    ) -> Result<RemoteCommandOutput, String>;
+
+    async fn create_dir_all(&self, connection_id: &str, path: &str) -> Result<(), String>;
+
+    async fn write_file(
+        &self,
+        connection_id: &str,
+        path: &str,
+        contents: &[u8],
+    ) -> Result<(), String>;
+
+    async fn repo_max_file_size(&self) -> u64;
+
+    async fn spawn_stdio_daemon(
+        &self,
+        connection_id: &str,
+        command: &str,
+        write_rx: mpsc::Receiver<Vec<u8>>,
+        protocol: RemoteWorkspaceSearchStdioProtocol,
+    ) -> Result<(), String>;
+}
+
+#[derive(Clone)]
+struct RemoteStdioSessionEntry {
+    session: Arc<RemoteStdioRepoSession>,
+    activity_epoch: Arc<AtomicU64>,
+}
+
+struct RemoteStdioRepoSession {
+    repo_id: String,
+    client: Arc<RemoteStdioDaemonClient>,
+    activity_epoch: Arc<AtomicU64>,
+    active_operations: Arc<AtomicU64>,
+}
+
+struct RemoteStdioDaemonClient {
+    protocol: ProtocolClient,
+}
+
+struct RemoteStdioOperationLease {
+    activity_epoch: Arc<AtomicU64>,
+    active_operations: Arc<AtomicU64>,
+}
+
+struct RemoteStdioSessionLease {
+    session: Arc<RemoteStdioRepoSession>,
+    _operation: RemoteStdioOperationLease,
+}
+
+impl Drop for RemoteStdioOperationLease {
+    fn drop(&mut self) {
+        self.active_operations.fetch_sub(1, Ordering::Relaxed);
+        self.activity_epoch.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl RemoteStdioSessionLease {
+    fn new(session: Arc<RemoteStdioRepoSession>) -> Self {
+        let operation = session.acquire_operation();
+        Self {
+            session,
+            _operation: operation,
+        }
+    }
+}
+
+impl Deref for RemoteStdioSessionLease {
+    type Target = RemoteStdioRepoSession;
+
+    fn deref(&self) -> &Self::Target {
+        &self.session
+    }
+}
+
+impl RemoteStdioDaemonClient {
+    async fn spawn(
+        provider: Arc<dyn RemoteWorkspaceSearchProvider>,
+        connection_id: String,
+        binary_path: String,
+    ) -> Result<Arc<Self>, String> {
+        let command = format!("{} serve --stdio", shell_escape(&binary_path));
+        let (protocol, write_rx) = ProtocolClient::channel("remote flashgrep stdio daemon");
+        let stdio_protocol = RemoteWorkspaceSearchStdioProtocol::new(protocol.clone());
+        provider
+            .spawn_stdio_daemon(&connection_id, &command, write_rx, stdio_protocol)
+            .await?;
+
+        let client = Arc::new(Self { protocol });
+        client.initialize().await?;
+        Ok(client)
+    }
+
+    async fn initialize(&self) -> Result<(), String> {
+        match self
+            .protocol
+            .send_request_with_timeout(
+                Request::Initialize {
+                    params: InitializeParams {
+                        client_info: Some(ClientInfo {
+                            name: CLIENT_NAME.to_string(),
+                            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                        }),
+                        capabilities: ClientCapabilities::default(),
+                    },
+                },
+                Some(REMOTE_STDIO_REQUEST_TIMEOUT),
+            )
+            .await
+            .map_err(|error| error.to_string())?
+        {
+            Response::InitializeResult { .. } => {
+                self.protocol
+                    .send_notification(Request::Initialized)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                Ok(())
+            }
+            other => Err(format!(
+                "Unexpected remote flashgrep initialize response: {other:?}"
+            )),
+        }
+    }
+
+    async fn open_repo(
+        self: &Arc<Self>,
+        params: OpenRepoParams,
+    ) -> Result<RemoteStdioRepoSession, String> {
+        match self.send_request(Request::OpenRepo { params }).await? {
+            Response::RepoOpened { repo_id, .. } => Ok(RemoteStdioRepoSession {
+                repo_id,
+                client: self.clone(),
+                activity_epoch: Arc::new(AtomicU64::new(1)),
+                active_operations: Arc::new(AtomicU64::new(0)),
+            }),
+            other => Err(format!(
+                "Unexpected remote flashgrep open_repo response: {other:?}"
+            )),
+        }
+    }
+
+    async fn send_request(&self, request: Request) -> Result<Response, String> {
+        self.protocol
+            .send_request_with_timeout(request, Some(REMOTE_STDIO_REQUEST_TIMEOUT))
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    async fn shutdown(&self) {
+        let _ = timeout(
+            REMOTE_STDIO_SHUTDOWN_TIMEOUT,
+            self.send_request(Request::Shutdown),
+        )
+        .await;
+        self.protocol
+            .close_with_message("remote flashgrep stdio daemon is shutting down")
+            .await;
+    }
+
+    fn is_closed(&self) -> bool {
+        self.protocol.is_closed()
+    }
+}
+
+impl RemoteStdioRepoSession {
+    fn acquire_operation(&self) -> RemoteStdioOperationLease {
+        self.active_operations.fetch_add(1, Ordering::Relaxed);
+        self.activity_epoch.fetch_add(1, Ordering::Relaxed);
+        RemoteStdioOperationLease {
+            activity_epoch: self.activity_epoch.clone(),
+            active_operations: self.active_operations.clone(),
+        }
+    }
+
+    async fn status(&self) -> Result<RepoStatus, String> {
+        let _lease = self.acquire_operation();
+        self.status_without_activity_lease().await
+    }
+
+    async fn status_without_activity_lease(&self) -> Result<RepoStatus, String> {
+        match self
+            .client
+            .send_request(Request::GetRepoStatus {
+                params: self.repo_ref(),
+            })
+            .await?
+        {
+            Response::RepoStatus { status } => Ok(status),
+            other => Err(format!(
+                "Unexpected remote flashgrep get_repo_status response: {other:?}"
+            )),
+        }
+    }
+
+    async fn task_status(&self, task_id: impl Into<String>) -> Result<TaskStatus, String> {
+        let _lease = self.acquire_operation();
+        match self
+            .client
+            .send_request(Request::TaskStatus {
+                params: TaskRef {
+                    task_id: task_id.into(),
+                },
+            })
+            .await?
+        {
+            Response::TaskStatus { task } => Ok(task),
+            other => Err(format!(
+                "Unexpected remote flashgrep task/status response: {other:?}"
+            )),
+        }
+    }
+
+    async fn build_index(&self) -> Result<TaskStatus, String> {
+        let _lease = self.acquire_operation();
+        match self
+            .client
+            .send_request(Request::BaseSnapshotBuild {
+                params: self.repo_ref(),
+            })
+            .await?
+        {
+            Response::TaskStarted { task } => Ok(task),
+            other => Err(format!(
+                "Unexpected remote flashgrep build response: {other:?}"
+            )),
+        }
+    }
+
+    async fn rebuild_index(&self) -> Result<TaskStatus, String> {
+        let _lease = self.acquire_operation();
+        match self
+            .client
+            .send_request(Request::BaseSnapshotRebuild {
+                params: self.repo_ref(),
+            })
+            .await?
+        {
+            Response::TaskStarted { task } => Ok(task),
+            other => Err(format!(
+                "Unexpected remote flashgrep rebuild response: {other:?}"
+            )),
+        }
+    }
+
+    async fn search(
+        &self,
+        query: QuerySpec,
+        scope: crate::workspace_search::flashgrep::PathScope,
+    ) -> Result<(SearchBackend, RepoStatus, SearchResults), String> {
+        let _lease = self.acquire_operation();
+        match self
+            .client
+            .send_request(Request::Search {
+                params: SearchParams {
+                    repo_id: self.repo_id.clone(),
+                    query,
+                    scope,
+                    consistency: ConsistencyMode::WorkspaceEventual,
+                    allow_scan_fallback: true,
+                },
+            })
+            .await?
+        {
+            Response::SearchCompleted {
+                backend,
+                status,
+                results,
+                ..
+            } => Ok((backend, status, results)),
+            other => Err(format!(
+                "Unexpected remote flashgrep search response: {other:?}"
+            )),
+        }
+    }
+
+    async fn glob(
+        &self,
+        scope: crate::workspace_search::flashgrep::PathScope,
+    ) -> Result<(RepoStatus, Vec<String>), String> {
+        let _lease = self.acquire_operation();
+        match self
+            .client
+            .send_request(Request::Glob {
+                params: GlobParams {
+                    repo_id: self.repo_id.clone(),
+                    scope,
+                },
+            })
+            .await?
+        {
+            Response::GlobCompleted { status, paths, .. } => Ok((status, paths)),
+            other => Err(format!(
+                "Unexpected remote flashgrep glob response: {other:?}"
+            )),
+        }
+    }
+
+    async fn close(&self) {
+        let _ = self
+            .client
+            .send_request(Request::CloseRepo {
+                params: self.repo_ref(),
+            })
+            .await;
+    }
+
+    fn repo_ref(&self) -> RepoRef {
+        RepoRef {
+            repo_id: self.repo_id.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl FlashgrepRepoSession for RemoteStdioRepoSession {
+    async fn status(&self) -> crate::workspace_search::flashgrep::error::Result<RepoStatus> {
+        RemoteStdioRepoSession::status(self)
+            .await
+            .map_err(AppError::Protocol)
+    }
+
+    async fn task_status(
+        &self,
+        task_id: String,
+    ) -> crate::workspace_search::flashgrep::error::Result<TaskStatus> {
+        RemoteStdioRepoSession::task_status(self, task_id)
+            .await
+            .map_err(AppError::Protocol)
+    }
+
+    async fn build_index(&self) -> crate::workspace_search::flashgrep::error::Result<TaskStatus> {
+        RemoteStdioRepoSession::build_index(self)
+            .await
+            .map_err(AppError::Protocol)
+    }
+
+    async fn rebuild_index(&self) -> crate::workspace_search::flashgrep::error::Result<TaskStatus> {
+        RemoteStdioRepoSession::rebuild_index(self)
+            .await
+            .map_err(AppError::Protocol)
+    }
+
+    async fn search(
+        &self,
+        request: SearchRequest,
+    ) -> crate::workspace_search::flashgrep::error::Result<SearchOutcome> {
+        let (backend, status, results) =
+            RemoteStdioRepoSession::search(self, request.query, request.scope)
+                .await
+                .map_err(AppError::Protocol)?;
+        Ok(SearchOutcome {
+            backend,
+            status,
+            results,
+        })
+    }
+
+    async fn glob(
+        &self,
+        request: GlobRequest,
+    ) -> crate::workspace_search::flashgrep::error::Result<GlobOutcome> {
+        let (status, paths) = RemoteStdioRepoSession::glob(self, request.scope)
+            .await
+            .map_err(AppError::Protocol)?;
+        Ok(GlobOutcome { status, paths })
+    }
+
+    async fn close(&self) -> crate::workspace_search::flashgrep::error::Result<()> {
+        RemoteStdioRepoSession::close(self).await;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct RemoteWorkspaceSearchService {
+    provider: Arc<dyn RemoteWorkspaceSearchProvider>,
+    preferred_connection_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RemoteSearchContext {
+    connection: RemoteWorkspaceEntry,
+    binary_path: String,
+    repo_root: String,
+    storage_root: String,
+    remote_arch: String,
+    local_binary_sha256: String,
+}
+
+impl RemoteWorkspaceSearchService {
+    pub fn new(provider: Arc<dyn RemoteWorkspaceSearchProvider>) -> Self {
+        Self {
+            provider,
+            preferred_connection_id: None,
+        }
+    }
+
+    pub fn with_preferred_connection_id(mut self, preferred_connection_id: Option<String>) -> Self {
+        self.preferred_connection_id = preferred_connection_id;
+        self
+    }
+
+    pub async fn get_index_status(&self, root_path: &str) -> Result<WorkspaceIndexStatus, String> {
+        let session = self.get_or_open_stdio_session(root_path).await?;
+        let repo_status: WorkspaceSearchRepoStatus = session.status().await?.into();
+        let active_task = match repo_status.active_task_id.clone() {
+            Some(task_id) => match session.task_status(task_id).await {
+                Ok(task) => Some(task.into()),
+                Err(error) => {
+                    log::warn!(
+                        target: FLASHGREP_LOG_TARGET,
+                        "Failed to fetch active remote flashgrep task status: {}",
+                        error
+                    );
+                    None
+                }
+            },
+            None => None,
+        };
+        Ok(WorkspaceIndexStatus {
+            active_task,
+            repo_status,
+        })
+    }
+
+    pub async fn build_index(&self, root_path: &str) -> Result<IndexTaskHandle, String> {
+        let session = self.get_or_open_stdio_session(root_path).await?;
+        let task = session.build_index().await?;
+        let repo_status = session.status().await?;
+        Ok(IndexTaskHandle {
+            task: task.into(),
+            repo_status: repo_status.into(),
+        })
+    }
+
+    pub async fn rebuild_index(&self, root_path: &str) -> Result<IndexTaskHandle, String> {
+        let session = self.get_or_open_stdio_session(root_path).await?;
+        let task = session.rebuild_index().await?;
+        let repo_status = session.status().await?;
+        Ok(IndexTaskHandle {
+            task: task.into(),
+            repo_status: repo_status.into(),
+        })
+    }
+
+    pub async fn search_content(
+        &self,
+        request: ContentSearchRequest,
+    ) -> Result<ContentSearchResult, String> {
+        let repo_root = normalize_remote_workspace_path(&request.repo_root.to_string_lossy());
+        let session = self.get_or_open_stdio_session(&repo_root).await?;
+        let scope = build_remote_scope(
+            &repo_root,
+            request.search_path.as_deref(),
+            request.globs,
+            request.file_types,
+            request.exclude_file_types,
+        )?;
+        let max_results = request.max_results.filter(|limit| *limit > 0);
+        let primary_search_mode = remote_stdio_search_mode(request.output_mode);
+        let query = QuerySpec {
+            pattern: request.pattern.clone(),
+            patterns: Vec::new(),
+            case_insensitive: !request.case_sensitive,
+            multiline: request.multiline,
+            dot_matches_new_line: request.multiline,
+            fixed_strings: !request.use_regex,
+            word_regexp: request.whole_word,
+            line_regexp: false,
+            before_context: request.before_context,
+            after_context: request.after_context,
+            top_k_tokens: 6,
+            max_count: None,
+            global_max_results: max_results,
+            search_mode: primary_search_mode,
+        };
+
+        let output_mode = request.output_mode;
+        let (backend, repo_status, mut raw_results) = session.search(query, scope.clone()).await?;
+        if should_retry_remote_scan_fallback_as_files_with_matches(
+            backend,
+            primary_search_mode,
+            &raw_results,
+        ) {
+            log::info!(
+                "Remote workspace content search re-issuing as FilesWithMatches because daemon ScanFallback returned only summary statistics: pattern_chars={}, primary_search_mode={:?}, primary_matched_lines={}, primary_matched_occurrences={}",
+                request.pattern.chars().count(),
+                primary_search_mode,
+                raw_results.matched_lines,
+                raw_results.matched_occurrences,
+            );
+            let fallback_query = QuerySpec {
+                pattern: request.pattern.clone(),
+                patterns: Vec::new(),
+                case_insensitive: !request.case_sensitive,
+                multiline: request.multiline,
+                dot_matches_new_line: request.multiline,
+                fixed_strings: !request.use_regex,
+                word_regexp: request.whole_word,
+                line_regexp: false,
+                before_context: request.before_context,
+                after_context: request.after_context,
+                top_k_tokens: 6,
+                max_count: None,
+                global_max_results: max_results,
+                search_mode: SearchModeConfig::FilesWithMatches,
+            };
+            match session.search(fallback_query, scope).await {
+                Ok((_, _, fallback_results)) => {
+                    log::info!(
+                        "Remote workspace content search FilesWithMatches fallback succeeded: matched_paths={}, matched_lines={}, matched_occurrences={}",
+                        fallback_results.matched_paths.len(),
+                        fallback_results.matched_lines,
+                        fallback_results.matched_occurrences,
+                    );
+                    raw_results = fallback_results;
+                }
+                Err(error) => {
+                    log::warn!(
+                        "Remote workspace content search FilesWithMatches fallback failed: pattern_chars={}, primary_matched_lines={}, primary_matched_occurrences={}, error={}",
+                        request.pattern.chars().count(),
+                        raw_results.matched_lines,
+                        raw_results.matched_occurrences,
+                        error,
+                    );
+                    return Err(format!(
+                        "Remote workspace search returned only summary statistics for {primary_matched_lines} line(s) and the file-list fallback failed: {error}",
+                        primary_matched_lines = raw_results.matched_lines,
+                    ));
+                }
+            }
+        }
+
+        let mut results = convert_search_results(&raw_results, output_mode);
+        log::debug!(
+            "Remote workspace content search converted: backend={:?}, repo_phase={:?}, hits={}, file_counts={}, file_match_counts={}, matched_paths={}, converted_results={}, matched_lines={}, matched_occurrences={}",
+            backend,
+            repo_status.phase,
+            raw_results.hits.len(),
+            raw_results.file_counts.len(),
+            raw_results.file_match_counts.len(),
+            raw_results.matched_paths.len(),
+            results.len(),
+            raw_results.matched_lines,
+            raw_results.matched_occurrences
+        );
+        let truncated = max_results
+            .map(|limit| results.len() >= limit)
+            .unwrap_or(false);
+        if let Some(limit) = max_results {
+            results.truncate(limit);
+        }
+
+        Ok(ContentSearchResult {
+            outcome: FileSearchOutcome { results, truncated },
+            file_counts: raw_results
+                .file_counts
+                .clone()
+                .into_iter()
+                .map(WorkspaceSearchFileCount::from)
+                .collect(),
+            hits: raw_results
+                .hits
+                .clone()
+                .into_iter()
+                .map(WorkspaceSearchHit::from)
+                .collect(),
+            backend: backend.into(),
+            repo_status: repo_status.into(),
+            candidate_docs: raw_results.candidate_docs,
+            matched_lines: raw_results.matched_lines,
+            matched_occurrences: raw_results.matched_occurrences,
+        })
+    }
+
+    pub async fn glob(&self, request: GlobSearchRequest) -> Result<GlobSearchResult, String> {
+        let repo_root = normalize_remote_workspace_path(&request.repo_root.to_string_lossy());
+        let session = self.get_or_open_stdio_session(&repo_root).await?;
+        let scope = build_remote_scope(
+            &repo_root,
+            request.search_path.as_deref(),
+            vec![request.pattern],
+            Vec::new(),
+            Vec::new(),
+        )?;
+        let (repo_status, mut paths) = session.glob(scope).await?;
+
+        paths.sort();
+        if request.limit > 0 {
+            paths.truncate(request.limit);
+        } else {
+            paths.clear();
+        }
+
+        Ok(GlobSearchResult {
+            paths,
+            repo_status: repo_status.into(),
+        })
+    }
+
+    pub async fn resolve_remote_workspace_entry(
+        &self,
+        root_path: &str,
+    ) -> Result<RemoteWorkspaceEntry, String> {
+        self.provider
+            .resolve_workspace_entry(root_path, self.preferred_connection_id.as_deref())
+            .await
+    }
+
+    async fn get_or_open_stdio_session(
+        &self,
+        root_path: &str,
+    ) -> Result<RemoteStdioSessionLease, String> {
+        let context = self.ensure_remote_search_context(root_path).await?;
+        let key = remote_stdio_session_key(&context.connection.connection_id, &context.repo_root);
+
+        if let Some(entry) = REMOTE_STDIO_SESSIONS.read().await.get(&key).cloned() {
+            entry.activity_epoch.fetch_add(1, Ordering::Relaxed);
+            if !entry.session.client.is_closed() {
+                return Ok(RemoteStdioSessionLease::new(entry.session.clone()));
+            }
+            log::warn!(
+                target: FLASHGREP_LOG_TARGET,
+                "Remote workspace search stdio session became unhealthy, reopening: connection_id={}, path={}",
+                context.connection.connection_id,
+                context.repo_root
+            );
+            REMOTE_STDIO_SESSIONS.write().await.remove(&key);
+            entry.session.close().await;
+            entry.session.client.shutdown().await;
+        }
+
+        let guard = {
+            let mut guards = REMOTE_STDIO_OPEN_GUARDS.lock().await;
+            guards
+                .entry(key.clone())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+        let _open_guard = guard.lock().await;
+
+        if let Some(entry) = REMOTE_STDIO_SESSIONS.read().await.get(&key).cloned() {
+            entry.activity_epoch.fetch_add(1, Ordering::Relaxed);
+            return Ok(RemoteStdioSessionLease::new(entry.session));
+        }
+
+        let open_result = async {
+            let client = RemoteStdioDaemonClient::spawn(
+                self.provider.clone(),
+                context.connection.connection_id.clone(),
+                context.binary_path.clone(),
+            )
+            .await?;
+            let mut repo_config = RepoConfig::default();
+            repo_config.max_file_size = self.provider.repo_max_file_size().await;
+            let session = match client
+                .open_repo(OpenRepoParams {
+                    repo_path: PathBuf::from(&context.repo_root),
+                    storage_root: Some(PathBuf::from(&context.storage_root)),
+                    config: repo_config,
+                    refresh: RefreshPolicyConfig::default(),
+                })
+                .await
+            {
+                Ok(session) => session,
+                Err(error) => {
+                    client.shutdown().await;
+                    return Err(error);
+                }
+            };
+            let activity_epoch = session.activity_epoch.clone();
+            Ok::<_, String>((Arc::new(session), activity_epoch))
+        }
+        .await;
+        let (session, activity_epoch) = match open_result {
+            Ok(opened) => opened,
+            Err(error) => {
+                if Arc::strong_count(&guard) <= 2 {
+                    REMOTE_STDIO_OPEN_GUARDS.lock().await.remove(&key);
+                }
+                return Err(error);
+            }
+        };
+        REMOTE_STDIO_SESSIONS.write().await.insert(
+            key.clone(),
+            RemoteStdioSessionEntry {
+                session: session.clone(),
+                activity_epoch: activity_epoch.clone(),
+            },
+        );
+        schedule_remote_stdio_session_release(key, activity_epoch);
+        Ok(RemoteStdioSessionLease::new(session))
+    }
+
+    async fn ensure_remote_search_context(
+        &self,
+        root_path: &str,
+    ) -> Result<RemoteSearchContext, String> {
+        let repo_root = normalize_remote_workspace_path(root_path);
+        let connection = self.resolve_remote_workspace_entry(&repo_root).await?;
+        let cache_key = remote_search_context_key(&connection.connection_id, &repo_root);
+        if let Some(context) = REMOTE_SEARCH_CONTEXTS.read().await.get(&cache_key).cloned() {
+            let local_bundle = local_flashgrep_bundle_for_arch(&context.remote_arch).await?;
+            if local_bundle.sha256 == context.local_binary_sha256 {
+                return Ok(context);
+            }
+
+            log::info!(
+                target: FLASHGREP_LOG_TARGET,
+                "Bundled remote flashgrep binary changed; reopening remote search session: connection_id={}, path={}, old_sha256={}, new_sha256={}",
+                context.connection.connection_id,
+                context.repo_root,
+                context.local_binary_sha256,
+                local_bundle.sha256
+            );
+            REMOTE_SEARCH_CONTEXTS.write().await.remove(&cache_key);
+            let session_key =
+                remote_stdio_session_key(&context.connection.connection_id, &context.repo_root);
+            if let Some(entry) = REMOTE_STDIO_SESSIONS.write().await.remove(&session_key) {
+                entry.session.close().await;
+                entry.session.client.shutdown().await;
+            }
+        }
+
+        let cached_server_os_type = self
+            .provider
+            .cached_server_os_type(&connection.connection_id)
+            .await;
+        let remote_os = if let Some(os_type) = cached_server_os_type {
+            if os_type.eq_ignore_ascii_case("unknown") {
+                self.detect_remote_os_type(&connection.connection_id)
+                    .await
+                    .unwrap_or(os_type)
+            } else {
+                os_type
+            }
+        } else {
+            self.detect_remote_os_type(&connection.connection_id)
+                .await
+                .unwrap_or_else(|| "unknown".to_string())
+        };
+        let inferred_linux = remote_os.eq_ignore_ascii_case("unknown")
+            && looks_like_linux_workspace_root(&repo_root);
+        if !remote_os.eq_ignore_ascii_case("linux") && !inferred_linux {
+            return Err(format!(
+                "Remote workspace search currently supports Linux only, but server OS is {}",
+                remote_os
+            ));
+        }
+
+        let remote_arch = self
+            .detect_remote_architecture(&connection.connection_id)
+            .await?;
+        let local_bundle = local_flashgrep_bundle_for_arch(&remote_arch).await?;
+        let binary_path = self
+            .ensure_remote_flashgrep_binary(&connection.connection_id, &repo_root, &local_bundle)
+            .await?;
+        let storage_root = remote_workspace_search_storage_root(&repo_root);
+
+        let context = RemoteSearchContext {
+            connection,
+            binary_path,
+            repo_root,
+            storage_root,
+            remote_arch,
+            local_binary_sha256: local_bundle.sha256,
+        };
+        REMOTE_SEARCH_CONTEXTS
+            .write()
+            .await
+            .insert(cache_key, context.clone());
+        Ok(context)
+    }
+
+    async fn detect_remote_architecture(&self, connection_id: &str) -> Result<String, String> {
+        let mut attempts = Vec::new();
+
+        for probe in REMOTE_ARCHITECTURE_PROBES {
+            match self.provider.execute_command(connection_id, probe).await {
+                Ok(output) => {
+                    if let Some(arch) =
+                        parse_remote_architecture_output(&output.stdout, &output.stderr)
+                    {
+                        return Ok(arch);
+                    }
+                    attempts.push(format!(
+                        "probe=`{probe}` exit_code={} stdout={:?} stderr={:?}",
+                        output.exit_code,
+                        output.stdout.trim(),
+                        output.stderr.trim()
+                    ));
+                }
+                Err(error) => {
+                    attempts.push(format!("probe=`{probe}` error={error}"));
+                }
+            }
+        }
+
+        Err(format!(
+            "Failed to detect remote architecture from SSH output. Attempts: {}",
+            attempts.join("; ")
+        ))
+    }
+
+    async fn detect_remote_os_type(&self, connection_id: &str) -> Option<String> {
+        for probe in REMOTE_OS_PROBES {
+            let Ok(output) = self.provider.execute_command(connection_id, probe).await else {
+                continue;
+            };
+            if let Some(os_type) = parse_remote_os_output(&output.stdout, &output.stderr) {
+                return Some(os_type);
+            }
+        }
+        None
+    }
+
+    async fn ensure_remote_flashgrep_binary(
+        &self,
+        connection_id: &str,
+        repo_root: &str,
+        local_bundle: &LocalFlashgrepBundle,
+    ) -> Result<String, String> {
+        let install_dir = remote_flashgrep_install_dir(repo_root);
+        let remote_binary_path = join_remote_path(&install_dir, &local_bundle.binary_name);
+
+        self.provider
+            .create_dir_all(connection_id, &install_dir)
+            .await
+            .map_err(|error| {
+                format!("Failed to create remote flashgrep install directory: {error}")
+            })?;
+        let remote_sha256 = self
+            .remote_flashgrep_sha256(connection_id, &remote_binary_path)
+            .await?;
+        if remote_sha256.as_deref() != Some(local_bundle.sha256.as_str()) {
+            log::info!(
+                target: FLASHGREP_LOG_TARGET,
+                "Uploading bundled remote flashgrep binary: connection_id={}, path={}, bundle={}, local_path={}, local_sha256={}, remote_sha256={}",
+                connection_id,
+                remote_binary_path,
+                local_bundle.binary_name,
+                local_bundle.path.display(),
+                local_bundle.sha256,
+                remote_sha256.as_deref().unwrap_or("missing")
+            );
+            let temp_remote_binary_path =
+                format!("{}.upload-{}.tmp", remote_binary_path, local_bundle.sha256);
+            self.provider
+                .write_file(connection_id, &temp_remote_binary_path, &local_bundle.bytes)
+                .await
+                .map_err(|error| format!("Failed to upload flashgrep to remote host: {error}"))?;
+            self.provider
+                .execute_command(
+                    connection_id,
+                    &format!(
+                        "mv -f {} {}",
+                        shell_escape(&temp_remote_binary_path),
+                        shell_escape(&remote_binary_path)
+                    ),
+                )
+                .await
+                .map_err(|error| {
+                    format!("Failed to install uploaded flashgrep on remote host: {error}")
+                })?;
+        }
+        self.provider
+            .execute_command(
+                connection_id,
+                &format!("chmod 755 {}", shell_escape(&remote_binary_path)),
+            )
+            .await
+            .map_err(|error| format!("Failed to mark remote flashgrep as executable: {error}"))?;
+
+        Ok(remote_binary_path)
+    }
+
+    async fn remote_flashgrep_sha256(
+        &self,
+        connection_id: &str,
+        remote_binary_path: &str,
+    ) -> Result<Option<String>, String> {
+        let escaped_path = shell_escape(remote_binary_path);
+        let command = format!(
+            "if [ -f {path} ]; then if command -v sha256sum >/dev/null 2>&1; then sha256sum {path} | awk '{{print $1}}'; elif command -v shasum >/dev/null 2>&1; then shasum -a 256 {path} | awk '{{print $1}}'; fi; fi",
+            path = escaped_path
+        );
+        let output = self
+            .provider
+            .execute_command(connection_id, &command)
+            .await
+            .map_err(|error| format!("Failed to hash remote flashgrep binary: {error}"))?;
+        if output.exit_code != 0 {
+            return Ok(None);
+        }
+        let hash = output.stdout.trim();
+        if hash.len() == 64 && hash.chars().all(|character| character.is_ascii_hexdigit()) {
+            Ok(Some(hash.to_ascii_lowercase()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+fn remote_stdio_session_key(connection_id: &str, repo_root: &str) -> String {
+    format!(
+        "{connection_id}\0{}",
+        normalize_remote_workspace_path(repo_root)
+    )
+}
+
+fn remote_search_context_key(connection_id: &str, repo_root: &str) -> String {
+    format!(
+        "{connection_id}\0{}",
+        normalize_remote_workspace_path(repo_root)
+    )
+}
+
+fn schedule_remote_stdio_session_release(key: String, activity_epoch: Arc<AtomicU64>) {
+    tokio::spawn(async move {
+        let expected_epoch = activity_epoch.load(Ordering::Relaxed);
+        sleep(REMOTE_STDIO_SESSION_IDLE_GRACE).await;
+        let entry = {
+            let sessions = REMOTE_STDIO_SESSIONS.read().await;
+            let Some(entry) = sessions.get(&key) else {
+                return;
+            };
+            if entry.session.active_operations.load(Ordering::Relaxed) > 0 {
+                schedule_remote_stdio_session_release(key.clone(), entry.activity_epoch.clone());
+                return;
+            }
+            if entry.activity_epoch.load(Ordering::Relaxed) != expected_epoch {
+                schedule_remote_stdio_session_release(key.clone(), entry.activity_epoch.clone());
+                return;
+            }
+            entry.clone()
+        };
+
+        match entry.session.status_without_activity_lease().await {
+            Ok(status) if status.active_task_id.is_some() => {
+                schedule_remote_stdio_session_release(key.clone(), entry.activity_epoch.clone());
+                return;
+            }
+            Ok(_) => {}
+            Err(error) => {
+                log::warn!(
+                    target: FLASHGREP_LOG_TARGET,
+                    "Failed to check idle remote workspace search status before release: key={}, error={}",
+                    key.replace('\0', ":"),
+                    error
+                );
+            }
+        }
+
+        let entry = {
+            let mut sessions = REMOTE_STDIO_SESSIONS.write().await;
+            let Some(current_entry) = sessions.get(&key) else {
+                return;
+            };
+            if !Arc::ptr_eq(&current_entry.session, &entry.session) {
+                return;
+            }
+            if current_entry
+                .session
+                .active_operations
+                .load(Ordering::Relaxed)
+                > 0
+            {
+                schedule_remote_stdio_session_release(
+                    key.clone(),
+                    current_entry.activity_epoch.clone(),
+                );
+                return;
+            }
+            if current_entry.activity_epoch.load(Ordering::Relaxed) != expected_epoch {
+                schedule_remote_stdio_session_release(
+                    key.clone(),
+                    current_entry.activity_epoch.clone(),
+                );
+                return;
+            }
+            sessions.remove(&key)
+        };
+
+        if let Some(entry) = entry {
+            log::debug!(
+                target: FLASHGREP_LOG_TARGET,
+                "Releasing idle remote workspace search stdio session: key={}",
+                key.replace('\0', ":")
+            );
+            entry.session.close().await;
+            entry.session.client.shutdown().await;
+            REMOTE_STDIO_OPEN_GUARDS.lock().await.remove(&key);
+        }
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_remote_stdio_session_key(connection_id: &str, repo_root: &str) -> String {
+    remote_stdio_session_key(connection_id, repo_root)
+}
+
+#[cfg(test)]
+pub(crate) fn test_remote_search_context_key(connection_id: &str, repo_root: &str) -> String {
+    remote_search_context_key(connection_id, repo_root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static REMOTE_SEARCH_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    async fn clear_remote_search_test_state() {
+        REMOTE_STDIO_SESSIONS.write().await.clear();
+        REMOTE_STDIO_OPEN_GUARDS.lock().await.clear();
+        REMOTE_SEARCH_CONTEXTS.write().await.clear();
+    }
+
+    #[test]
+    fn remote_search_cache_keys_normalize_workspace_root() {
+        assert_eq!(
+            test_remote_stdio_session_key("conn-1", "/home/user/repo/"),
+            "conn-1\0/home/user/repo"
+        );
+        assert_eq!(
+            test_remote_search_context_key("conn-1", "/home/user/repo/"),
+            "conn-1\0/home/user/repo"
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_search_rejects_non_linux_before_stdio_open() {
+        let _test_guard = REMOTE_SEARCH_TEST_LOCK.lock().await;
+        clear_remote_search_test_state().await;
+        let provider = Arc::new(FakeRemoteSearchProvider {
+            cached_os_type: Some("Darwin".to_string()),
+            connection_id: "conn-1".to_string(),
+            remote_root: "/Users/example/project".to_string(),
+            fail_stdio_spawn: false,
+            resolve_count: AtomicU64::new(0),
+            stdio_spawn_count: AtomicU64::new(0),
+        });
+        let service = RemoteWorkspaceSearchService::new(provider.clone());
+
+        let error = service
+            .get_index_status("/Users/example/project")
+            .await
+            .expect_err("non-linux remotes must fail before opening flashgrep");
+
+        assert!(error.contains("supports Linux only"));
+        assert!(error.contains("Darwin"));
+        assert_eq!(provider.stdio_spawn_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn remote_search_context_ignores_stale_cache_before_resolving_connection() {
+        let _test_guard = REMOTE_SEARCH_TEST_LOCK.lock().await;
+        clear_remote_search_test_state().await;
+        let repo_root = "/home/user/repo";
+        let stale_empty_connection_key = format!("\0{repo_root}");
+        REMOTE_SEARCH_CONTEXTS.write().await.insert(
+            stale_empty_connection_key,
+            RemoteSearchContext {
+                connection: RemoteWorkspaceEntry {
+                    connection_id: "conn-stale".to_string(),
+                    connection_name: "stale".to_string(),
+                    ssh_host: "stale.example.test".to_string(),
+                    remote_root: repo_root.to_string(),
+                },
+                binary_path: "/stale/flashgrep".to_string(),
+                repo_root: repo_root.to_string(),
+                storage_root: "/stale/search".to_string(),
+                remote_arch: "riscv64".to_string(),
+                local_binary_sha256: "stale".to_string(),
+            },
+        );
+        let provider = Arc::new(FakeRemoteSearchProvider {
+            cached_os_type: Some("Darwin".to_string()),
+            connection_id: "conn-new".to_string(),
+            remote_root: repo_root.to_string(),
+            fail_stdio_spawn: false,
+            resolve_count: AtomicU64::new(0),
+            stdio_spawn_count: AtomicU64::new(0),
+        });
+        let service = RemoteWorkspaceSearchService::new(provider.clone());
+
+        let error = service
+            .get_index_status(repo_root)
+            .await
+            .expect_err("resolved non-Linux connection should reject without using stale cache");
+
+        assert_eq!(provider.resolve_count.load(Ordering::Relaxed), 1);
+        assert!(error.contains("Darwin"));
+        assert!(!error.contains("riscv64"));
+    }
+
+    #[tokio::test]
+    async fn remote_search_open_guard_is_removed_when_stdio_spawn_fails() {
+        let _test_guard = REMOTE_SEARCH_TEST_LOCK.lock().await;
+        clear_remote_search_test_state().await;
+        let repo_root = "/home/user/repo";
+        let provider = Arc::new(FakeRemoteSearchProvider {
+            cached_os_type: Some("Linux".to_string()),
+            connection_id: "conn-guard".to_string(),
+            remote_root: repo_root.to_string(),
+            fail_stdio_spawn: true,
+            resolve_count: AtomicU64::new(0),
+            stdio_spawn_count: AtomicU64::new(0),
+        });
+        let service = RemoteWorkspaceSearchService::new(provider.clone());
+
+        let error = service
+            .get_index_status(repo_root)
+            .await
+            .expect_err("fake provider rejects stdio spawn");
+
+        assert!(error.contains("spawn failed"));
+        assert_eq!(provider.stdio_spawn_count.load(Ordering::Relaxed), 1);
+        let key = remote_stdio_session_key("conn-guard", repo_root);
+        assert!(
+            !REMOTE_STDIO_OPEN_GUARDS.lock().await.contains_key(&key),
+            "failed stdio opens must not leave a global guard entry behind"
+        );
+    }
+
+    struct FakeRemoteSearchProvider {
+        cached_os_type: Option<String>,
+        connection_id: String,
+        remote_root: String,
+        fail_stdio_spawn: bool,
+        resolve_count: AtomicU64,
+        stdio_spawn_count: AtomicU64,
+    }
+
+    #[async_trait]
+    impl RemoteWorkspaceSearchProvider for FakeRemoteSearchProvider {
+        async fn resolve_workspace_entry(
+            &self,
+            _root_path: &str,
+            _preferred_connection_id: Option<&str>,
+        ) -> Result<RemoteWorkspaceEntry, String> {
+            self.resolve_count.fetch_add(1, Ordering::Relaxed);
+            Ok(RemoteWorkspaceEntry {
+                connection_id: self.connection_id.clone(),
+                connection_name: "test".to_string(),
+                ssh_host: "example.test".to_string(),
+                remote_root: self.remote_root.clone(),
+            })
+        }
+
+        async fn cached_server_os_type(&self, _connection_id: &str) -> Option<String> {
+            self.cached_os_type.clone()
+        }
+
+        async fn execute_command(
+            &self,
+            _connection_id: &str,
+            command: &str,
+        ) -> Result<RemoteCommandOutput, String> {
+            if command == "uname -m" || command == "arch" || command.contains("uname -m") {
+                return Ok(RemoteCommandOutput {
+                    stdout: "x86_64\n".to_string(),
+                    stderr: String::new(),
+                    exit_code: 0,
+                });
+            }
+            if command.contains("sha256sum")
+                || command.starts_with("mv -f ")
+                || command.starts_with("chmod 755 ")
+            {
+                return Ok(RemoteCommandOutput {
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    exit_code: 0,
+                });
+            }
+            Err(format!("unexpected remote command: {command}"))
+        }
+
+        async fn create_dir_all(&self, _connection_id: &str, _path: &str) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn write_file(
+            &self,
+            _connection_id: &str,
+            _path: &str,
+            _contents: &[u8],
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn repo_max_file_size(&self) -> u64 {
+            0
+        }
+
+        async fn spawn_stdio_daemon(
+            &self,
+            _connection_id: &str,
+            _command: &str,
+            _write_rx: mpsc::Receiver<Vec<u8>>,
+            _protocol: RemoteWorkspaceSearchStdioProtocol,
+        ) -> Result<(), String> {
+            self.stdio_spawn_count.fetch_add(1, Ordering::Relaxed);
+            if self.fail_stdio_spawn {
+                Err("spawn failed".to_string())
+            } else {
+                Err("unexpected stdio spawn".to_string())
+            }
+        }
+    }
+}

--- a/src/crates/services/services-integrations/src/workspace_search/flashgrep/rpc_client.rs
+++ b/src/crates/services/services-integrations/src/workspace_search/flashgrep/rpc_client.rs
@@ -322,3 +322,31 @@ fn request_name(request: &Request) -> &'static str {
         Request::Shutdown => "shutdown",
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drains_remote_stdio_content_length_messages() {
+        let body = r#"{"jsonrpc":"2.0","id":7,"result":{"kind":"pong","now_unix_secs":1}}"#;
+        let mut buffer = format!("Content-Length: {}\r\n\r\n{}", body.len(), body).into_bytes();
+        let messages = drain_content_length_messages(&mut buffer)
+            .expect("expected content-length message to decode");
+
+        assert_eq!(messages.len(), 1);
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn drains_remote_stdio_initialize_response_with_legacy_search_modes() {
+        let body = r#"{"jsonrpc":"2.0","id":1,"result":{"kind":"initialize_result","protocol_version":1,"server_info":{"name":"flashgrep","version":"0.1.0"},"capabilities":{"workspace_open":true,"workspace_ensure":true,"workspace_list":false,"workspace_refresh":true,"base_snapshot_build":true,"base_snapshot_rebuild":true,"task_status":true,"task_cancel":true,"search_query":true,"glob_query":true,"progress_notifications":true,"status_notifications":true},"search":{"search_modes":["files_with_matches","line_matches","count_only","count_matches"]}}}"#;
+        let mut buffer = format!("Content-Length: {}\r\n\r\n{}", body.len(), body).into_bytes();
+        let messages = drain_content_length_messages(&mut buffer)
+            .expect("expected initialize response to decode");
+
+        assert_eq!(messages.len(), 1);
+        let debug = format!("{:?}", messages[0]);
+        assert!(debug.contains("InitializeResult"));
+    }
+}

--- a/src/crates/services/services-integrations/src/workspace_search/mod.rs
+++ b/src/crates/services/services-integrations/src/workspace_search/mod.rs
@@ -4,15 +4,16 @@
 //! indexed-search DTOs. Product/runtime crates may wrap it to provide product
 //! config, bootstrap hooks, and legacy error mapping.
 
-pub mod flashgrep;
+pub(crate) mod flashgrep;
+pub(crate) mod result_mapping;
 mod service;
 mod types;
 
 pub use service::{
     resolve_workspace_search_daemon_program_path, workspace_search_daemon_available,
     workspace_search_daemon_binary_name, workspace_search_daemon_binary_names,
-    workspace_search_daemon_missing_hint, WorkspaceSearchResult, WorkspaceSearchRuntimeHooks,
-    WorkspaceSearchService,
+    workspace_search_daemon_missing_hint, WorkspaceSearchRepoConfig, WorkspaceSearchResult,
+    WorkspaceSearchRuntimeHooks, WorkspaceSearchService,
 };
 pub use types::{
     ContentSearchOutputMode, ContentSearchRequest, ContentSearchResult, GlobSearchRequest,

--- a/src/crates/services/services-integrations/src/workspace_search/result_mapping.rs
+++ b/src/crates/services/services-integrations/src/workspace_search/result_mapping.rs
@@ -1,0 +1,191 @@
+use super::flashgrep::SearchResults;
+use super::types::ContentSearchOutputMode;
+use bitfun_services_core::filesystem::{FileSearchResult, SearchMatchType};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+pub(crate) fn convert_search_results(
+    search_results: &SearchResults,
+    output_mode: ContentSearchOutputMode,
+) -> Vec<FileSearchResult> {
+    match output_mode {
+        ContentSearchOutputMode::Content => {
+            let hit_results = convert_hits_to_file_search_results(search_results);
+            if !hit_results.is_empty() {
+                return hit_results;
+            }
+
+            let line_results = convert_line_matches_to_file_search_results(search_results);
+            if !line_results.is_empty() {
+                return line_results;
+            }
+
+            let count_results = convert_file_counts_to_search_results(search_results);
+            if !count_results.is_empty() {
+                return count_results;
+            }
+
+            let match_count_results = convert_file_match_counts_to_search_results(search_results);
+            if !match_count_results.is_empty() {
+                return match_count_results;
+            }
+
+            convert_matched_paths_to_file_only_results(search_results)
+        }
+        ContentSearchOutputMode::Count => convert_file_counts_to_search_results(search_results),
+        ContentSearchOutputMode::FilesWithMatches => {
+            convert_matched_paths_to_file_only_results(search_results)
+        }
+    }
+}
+
+fn convert_line_matches_to_file_search_results(
+    search_results: &SearchResults,
+) -> Vec<FileSearchResult> {
+    search_results
+        .line_matches
+        .iter()
+        .map(|matched| FileSearchResult {
+            path: matched.path.clone(),
+            name: Path::new(&matched.path)
+                .file_name()
+                .and_then(|file_name| file_name.to_str())
+                .unwrap_or(&matched.path)
+                .to_string(),
+            is_directory: false,
+            match_type: SearchMatchType::Content,
+            line_number: Some(matched.line_number),
+            matched_content: Some(matched.line_text.clone()),
+            preview_before: None,
+            preview_inside: Some(matched.line_text.clone()),
+            preview_after: None,
+        })
+        .collect()
+}
+
+fn convert_file_counts_to_search_results(search_results: &SearchResults) -> Vec<FileSearchResult> {
+    search_results
+        .file_counts
+        .iter()
+        .map(|count| FileSearchResult {
+            path: count.path.clone(),
+            name: Path::new(&count.path)
+                .file_name()
+                .and_then(|file_name| file_name.to_str())
+                .unwrap_or(&count.path)
+                .to_string(),
+            is_directory: false,
+            match_type: SearchMatchType::Content,
+            line_number: None,
+            matched_content: Some(count.matched_lines.to_string()),
+            preview_before: None,
+            preview_inside: None,
+            preview_after: None,
+        })
+        .collect()
+}
+
+fn convert_file_match_counts_to_search_results(
+    search_results: &SearchResults,
+) -> Vec<FileSearchResult> {
+    search_results
+        .file_match_counts
+        .iter()
+        .map(|count| FileSearchResult {
+            path: count.path.clone(),
+            name: Path::new(&count.path)
+                .file_name()
+                .and_then(|file_name| file_name.to_str())
+                .unwrap_or(&count.path)
+                .to_string(),
+            is_directory: false,
+            match_type: SearchMatchType::Content,
+            line_number: None,
+            matched_content: Some(count.matched_occurrences.to_string()),
+            preview_before: None,
+            preview_inside: None,
+            preview_after: None,
+        })
+        .collect()
+}
+
+fn convert_hits_to_file_search_results(search_results: &SearchResults) -> Vec<FileSearchResult> {
+    let mut file_results = Vec::new();
+    for hit in &search_results.hits {
+        let name = Path::new(&hit.path)
+            .file_name()
+            .and_then(|file_name| file_name.to_str())
+            .unwrap_or(&hit.path)
+            .to_string();
+
+        let mut lines = BTreeMap::new();
+        for file_match in &hit.matches {
+            lines
+                .entry(file_match.location.line)
+                .or_insert_with(|| file_match.clone());
+        }
+
+        for (_, file_match) in lines {
+            let (preview_before, preview_inside, preview_after) =
+                split_preview(&file_match.snippet, &file_match.matched_text);
+            file_results.push(FileSearchResult {
+                path: hit.path.clone(),
+                name: name.clone(),
+                is_directory: false,
+                match_type: SearchMatchType::Content,
+                line_number: Some(file_match.location.line),
+                matched_content: Some(file_match.snippet),
+                preview_before,
+                preview_inside,
+                preview_after,
+            });
+        }
+    }
+    file_results
+}
+
+fn convert_matched_paths_to_file_only_results(
+    search_results: &SearchResults,
+) -> Vec<FileSearchResult> {
+    search_results
+        .matched_paths
+        .iter()
+        .map(|path| FileSearchResult {
+            path: path.clone(),
+            name: Path::new(path)
+                .file_name()
+                .and_then(|file_name| file_name.to_str())
+                .unwrap_or(path)
+                .to_string(),
+            is_directory: false,
+            match_type: SearchMatchType::Content,
+            line_number: None,
+            matched_content: None,
+            preview_before: None,
+            preview_inside: None,
+            preview_after: None,
+        })
+        .collect()
+}
+
+fn split_preview(
+    snippet: &str,
+    matched_text: &str,
+) -> (Option<String>, Option<String>, Option<String>) {
+    if matched_text.is_empty() {
+        return (None, Some(snippet.to_string()), None);
+    }
+
+    if let Some(offset) = snippet.find(matched_text) {
+        let before = snippet[..offset].to_string();
+        let inside = matched_text.to_string();
+        let after = snippet[offset + matched_text.len()..].to_string();
+        return (
+            (!before.is_empty()).then_some(before),
+            Some(inside),
+            (!after.is_empty()).then_some(after),
+        );
+    }
+
+    (None, Some(snippet.to_string()), None)
+}

--- a/src/crates/services/services-integrations/src/workspace_search/service.rs
+++ b/src/crates/services/services-integrations/src/workspace_search/service.rs
@@ -1,11 +1,10 @@
 use super::flashgrep::{
     ConsistencyMode, FlashgrepRepoSession, GlobRequest, ManagedClient, OpenRepoParams, PathScope,
-    QuerySpec, RefreshPolicyConfig, RepoConfig, RepoSession, SearchRequest, SearchResults,
-    FLASHGREP_LOG_TARGET,
+    QuerySpec, RefreshPolicyConfig, RepoConfig, RepoSession, SearchRequest, FLASHGREP_LOG_TARGET,
 };
 use async_trait::async_trait;
-use bitfun_services_core::filesystem::{FileSearchOutcome, FileSearchResult, SearchMatchType};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use bitfun_services_core::filesystem::FileSearchOutcome;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::sync::{
@@ -15,17 +14,39 @@ use std::sync::{
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, RwLock};
 
+use super::result_mapping::convert_search_results;
 use super::types::{
-    ContentSearchOutputMode, ContentSearchRequest, ContentSearchResult, GlobSearchRequest,
-    GlobSearchResult, IndexTaskHandle, WorkspaceIndexStatus, WorkspaceSearchFileCount,
-    WorkspaceSearchHit,
+    ContentSearchRequest, ContentSearchResult, GlobSearchRequest, GlobSearchResult,
+    IndexTaskHandle, WorkspaceIndexStatus, WorkspaceSearchFileCount, WorkspaceSearchHit,
 };
 
 pub type WorkspaceSearchResult<T> = Result<T, String>;
 
+#[derive(Debug, Clone)]
+pub struct WorkspaceSearchRepoConfig {
+    pub max_file_size: u64,
+}
+
+impl Default for WorkspaceSearchRepoConfig {
+    fn default() -> Self {
+        let default = RepoConfig::default();
+        Self {
+            max_file_size: default.max_file_size,
+        }
+    }
+}
+
+impl From<WorkspaceSearchRepoConfig> for RepoConfig {
+    fn from(value: WorkspaceSearchRepoConfig) -> Self {
+        let mut config = RepoConfig::default();
+        config.max_file_size = value.max_file_size;
+        config
+    }
+}
+
 #[async_trait]
 pub trait WorkspaceSearchRuntimeHooks: Send + Sync {
-    async fn repo_config(&self) -> RepoConfig;
+    async fn repo_config(&self) -> WorkspaceSearchRepoConfig;
 
     async fn ensure_workspace_ready(&self, _repo_root: &Path) -> WorkspaceSearchResult<()> {
         Ok(())
@@ -36,8 +57,8 @@ struct DefaultWorkspaceSearchRuntimeHooks;
 
 #[async_trait]
 impl WorkspaceSearchRuntimeHooks for DefaultWorkspaceSearchRuntimeHooks {
-    async fn repo_config(&self) -> RepoConfig {
-        RepoConfig::default()
+    async fn repo_config(&self) -> WorkspaceSearchRepoConfig {
+        WorkspaceSearchRepoConfig::default()
     }
 }
 
@@ -431,7 +452,7 @@ impl WorkspaceSearchService {
             }
         }
 
-        let repo_config = self.hooks.repo_config().await;
+        let repo_config: RepoConfig = self.hooks.repo_config().await.into();
         if let Err(error) = self.hooks.ensure_workspace_ready(&repo_root).await {
             log::warn!(
                 target: FLASHGREP_LOG_TARGET,
@@ -785,192 +806,6 @@ fn normalize_scope_path(repo_root: &Path, search_path: &Path) -> WorkspaceSearch
     Ok(normalized)
 }
 
-fn convert_search_results(
-    search_results: &SearchResults,
-    output_mode: ContentSearchOutputMode,
-) -> Vec<FileSearchResult> {
-    match output_mode {
-        ContentSearchOutputMode::Content => {
-            let hit_results = convert_hits_to_file_search_results(search_results);
-            if !hit_results.is_empty() {
-                return hit_results;
-            }
-
-            let line_results = convert_line_matches_to_file_search_results(search_results);
-            if !line_results.is_empty() {
-                return line_results;
-            }
-
-            let count_results = convert_file_counts_to_search_results(search_results);
-            if !count_results.is_empty() {
-                return count_results;
-            }
-
-            let match_count_results = convert_file_match_counts_to_search_results(search_results);
-            if !match_count_results.is_empty() {
-                return match_count_results;
-            }
-
-            convert_matched_paths_to_file_only_results(search_results)
-        }
-        ContentSearchOutputMode::Count => convert_file_counts_to_search_results(search_results),
-        ContentSearchOutputMode::FilesWithMatches => {
-            convert_matched_paths_to_file_only_results(search_results)
-        }
-    }
-}
-
-fn convert_line_matches_to_file_search_results(
-    search_results: &SearchResults,
-) -> Vec<FileSearchResult> {
-    search_results
-        .line_matches
-        .iter()
-        .map(|matched| FileSearchResult {
-            path: matched.path.clone(),
-            name: Path::new(&matched.path)
-                .file_name()
-                .and_then(|file_name| file_name.to_str())
-                .unwrap_or(&matched.path)
-                .to_string(),
-            is_directory: false,
-            match_type: SearchMatchType::Content,
-            line_number: Some(matched.line_number),
-            matched_content: Some(matched.line_text.clone()),
-            preview_before: None,
-            preview_inside: Some(matched.line_text.clone()),
-            preview_after: None,
-        })
-        .collect()
-}
-
-fn convert_file_counts_to_search_results(search_results: &SearchResults) -> Vec<FileSearchResult> {
-    search_results
-        .file_counts
-        .iter()
-        .map(|count| FileSearchResult {
-            path: count.path.clone(),
-            name: Path::new(&count.path)
-                .file_name()
-                .and_then(|file_name| file_name.to_str())
-                .unwrap_or(&count.path)
-                .to_string(),
-            is_directory: false,
-            match_type: SearchMatchType::Content,
-            line_number: None,
-            matched_content: Some(count.matched_lines.to_string()),
-            preview_before: None,
-            preview_inside: None,
-            preview_after: None,
-        })
-        .collect()
-}
-
-fn convert_file_match_counts_to_search_results(
-    search_results: &SearchResults,
-) -> Vec<FileSearchResult> {
-    search_results
-        .file_match_counts
-        .iter()
-        .map(|count| FileSearchResult {
-            path: count.path.clone(),
-            name: Path::new(&count.path)
-                .file_name()
-                .and_then(|file_name| file_name.to_str())
-                .unwrap_or(&count.path)
-                .to_string(),
-            is_directory: false,
-            match_type: SearchMatchType::Content,
-            line_number: None,
-            matched_content: Some(count.matched_occurrences.to_string()),
-            preview_before: None,
-            preview_inside: None,
-            preview_after: None,
-        })
-        .collect()
-}
-
-fn convert_hits_to_file_search_results(search_results: &SearchResults) -> Vec<FileSearchResult> {
-    let mut file_results = Vec::new();
-    for hit in &search_results.hits {
-        let name = Path::new(&hit.path)
-            .file_name()
-            .and_then(|file_name| file_name.to_str())
-            .unwrap_or(&hit.path)
-            .to_string();
-
-        let mut lines = BTreeMap::new();
-        for file_match in &hit.matches {
-            lines
-                .entry(file_match.location.line)
-                .or_insert_with(|| file_match.clone());
-        }
-
-        for (_, file_match) in lines {
-            let (preview_before, preview_inside, preview_after) =
-                split_preview(&file_match.snippet, &file_match.matched_text);
-            file_results.push(FileSearchResult {
-                path: hit.path.clone(),
-                name: name.clone(),
-                is_directory: false,
-                match_type: SearchMatchType::Content,
-                line_number: Some(file_match.location.line),
-                matched_content: Some(file_match.snippet),
-                preview_before,
-                preview_inside,
-                preview_after,
-            });
-        }
-    }
-    file_results
-}
-
-fn convert_matched_paths_to_file_only_results(
-    search_results: &SearchResults,
-) -> Vec<FileSearchResult> {
-    search_results
-        .matched_paths
-        .iter()
-        .map(|path| FileSearchResult {
-            path: path.clone(),
-            name: Path::new(path)
-                .file_name()
-                .and_then(|file_name| file_name.to_str())
-                .unwrap_or(path)
-                .to_string(),
-            is_directory: false,
-            match_type: SearchMatchType::Content,
-            line_number: None,
-            matched_content: None,
-            preview_before: None,
-            preview_inside: None,
-            preview_after: None,
-        })
-        .collect()
-}
-
-fn split_preview(
-    snippet: &str,
-    matched_text: &str,
-) -> (Option<String>, Option<String>, Option<String>) {
-    if matched_text.is_empty() {
-        return (None, Some(snippet.to_string()), None);
-    }
-
-    if let Some(offset) = snippet.find(matched_text) {
-        let before = snippet[..offset].to_string();
-        let inside = matched_text.to_string();
-        let after = snippet[offset + matched_text.len()..].to_string();
-        return (
-            (!before.is_empty()).then_some(before),
-            Some(inside),
-            (!after.is_empty()).then_some(after),
-        );
-    }
-
-    (None, Some(snippet.to_string()), None)
-}
-
 fn map_flashgrep_error(
     prefix: &'static str,
 ) -> impl Fn(super::flashgrep::error::AppError) -> String {
@@ -990,6 +825,8 @@ fn map_flashgrep_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::workspace_search::flashgrep::SearchResults;
+    use crate::workspace_search::ContentSearchOutputMode;
 
     fn empty_search_results() -> SearchResults {
         serde_json::from_value(serde_json::json!({
@@ -1003,10 +840,18 @@ mod tests {
     }
 
     #[test]
-    fn content_search_uses_flashgrep_line_matches_protocol() {
+    fn content_search_output_modes_use_current_flashgrep_protocol_modes() {
         assert_eq!(
             ContentSearchOutputMode::Content.search_mode(),
             crate::workspace_search::flashgrep::SearchModeConfig::LineMatches
+        );
+        assert_eq!(
+            ContentSearchOutputMode::Count.search_mode(),
+            crate::workspace_search::flashgrep::SearchModeConfig::CountOnly
+        );
+        assert_eq!(
+            ContentSearchOutputMode::FilesWithMatches.search_mode(),
+            crate::workspace_search::flashgrep::SearchModeConfig::FilesWithMatches
         );
     }
 

--- a/src/crates/services/services-integrations/src/workspace_search/types.rs
+++ b/src/crates/services/services-integrations/src/workspace_search/types.rs
@@ -20,7 +20,7 @@ pub enum ContentSearchOutputMode {
 }
 
 impl ContentSearchOutputMode {
-    pub fn search_mode(self) -> SearchModeConfig {
+    pub(crate) fn search_mode(self) -> SearchModeConfig {
         match self {
             Self::Content => SearchModeConfig::LineMatches,
             Self::Count => SearchModeConfig::CountOnly,

--- a/src/crates/services/services-integrations/tests/workspace_search_contracts.rs
+++ b/src/crates/services/services-integrations/tests/workspace_search_contracts.rs
@@ -1,9 +1,8 @@
 #[cfg(feature = "workspace-search")]
 mod workspace_search {
     use bitfun_services_integrations::workspace_search::{
-        flashgrep::SearchModeConfig, workspace_search_daemon_binary_name,
-        workspace_search_daemon_binary_names, workspace_search_daemon_missing_hint,
-        ContentSearchOutputMode, WorkspaceSearchService,
+        workspace_search_daemon_binary_name, workspace_search_daemon_binary_names,
+        workspace_search_daemon_missing_hint, WorkspaceSearchService,
     };
 
     #[test]
@@ -26,18 +25,5 @@ mod workspace_search {
     #[test]
     fn service_constructs_without_core_runtime_dependencies() {
         let _service = WorkspaceSearchService::new();
-
-        assert_eq!(
-            ContentSearchOutputMode::Content.search_mode(),
-            SearchModeConfig::LineMatches
-        );
-        assert_eq!(
-            ContentSearchOutputMode::Count.search_mode(),
-            SearchModeConfig::CountOnly
-        );
-        assert_eq!(
-            ContentSearchOutputMode::FilesWithMatches.search_mode(),
-            SearchModeConfig::FilesWithMatches
-        );
     }
 }


### PR DESCRIPTION
﻿## Summary

- Move the remote SSH workspace search concrete owner into `bitfun-services-integrations`, leaving `bitfun-core` as the compatibility facade, provider adapter, and russh stdio bridge.
- Keep flashgrep protocol internals crate-private behind stable workspace-search APIs, including `WorkspaceSearchRepoConfig` and `RemoteWorkspaceSearchStdioProtocol`.
- Move light checkpoint summary, tool confirmation wait-result mapping, and tool pipeline batching/retry policy into execution owner crates.
- Harden remote workspace search context and stdio-open lifecycle so cache keys use the resolved connection and failed daemon opens do not leave stale open guards.
- Update boundary rules and core decomposition docs so migrated owners cannot drift back into core.

## Risk and compatibility

- No intended tool schema, permission, remote search behavior, or product feature changes.
- Existing core paths remain compatible facades for current product-full consumers.
- Remote workspace search keeps the same Linux-only and flashgrep protocol behavior; the fix only prevents stale cross-connection cache reuse and failed-open guard leakage.
- Owner crates do not depend back on `bitfun-core`; boundary checks cover the new owners and old-path guardrails.
- Feature checks cover no-default, ssh-remote, workspace-search, remote-ssh, product-full, and full workspace builds.

## Verification

- `node scripts/check-core-boundaries.mjs`
- `node --test scripts/check-core-boundaries.test.mjs`
- `pnpm run check:repo-hygiene`
- `cargo metadata --no-deps --format-version 1`
- `cargo test -p bitfun-services-integrations --features remote-ssh,workspace-search remote_search_ -- --nocapture`
- `cargo test -p bitfun-services-integrations --features remote-ssh,workspace-search`
- `cargo test -p bitfun-services-integrations --features remote-ssh,workspace-search remote_workspace_search`
- `cargo test -p bitfun-services-integrations --features remote-ssh,workspace-search remote_scan_fallback`
- `cargo test -p bitfun-services-integrations --features workspace-search content_search_output_modes_use_current_flashgrep_protocol_modes`
- `cargo test -p bitfun-services-integrations --features workspace-search drains_remote_stdio`
- `cargo test -p bitfun-agent-runtime --lib checkpoint`
- `cargo test -p bitfun-agent-runtime --test tool_confirmation_contracts`
- `cargo test -p tool-runtime --test tool_pipeline_planning`
- `cargo test -p bitfun-core pipeline --features product-full`
- `cargo test -p bitfun-core search --features product-full`
- `cargo test -p bitfun-agent-stream tool_call_accumulator --tests`
- `cargo check -p bitfun-core --no-default-features`
- `cargo check -p bitfun-core --no-default-features --features ssh-remote`
- `cargo check -p bitfun-core --features product-full`
- `cargo check -p bitfun-services-integrations --no-default-features`
- `cargo check -p bitfun-services-integrations --features workspace-search`
- `cargo check -p bitfun-services-integrations --features remote-ssh`
- `cargo check -p bitfun-services-integrations --features remote-ssh,workspace-search`
- `cargo check -p tool-runtime`
- `cargo check -p bitfun-agent-runtime`
- `cargo check --workspace`
- `git diff --check`
