### PR TITLE
fix: refine markdown file links and remote artifact delivery

### DIFF
--- a/src/crates/assembly/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/assembly/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -1,4 +1,5 @@
 //! System prompts module providing main dialogue and agent dialogue prompts
+use crate::agentic::remote_file_delivery::user_workspace_relative_file_link;
 use crate::agentic::util::remote_workspace_layout::build_remote_workspace_layout_preview;
 use crate::agentic::workspace::WorkspaceBackend;
 use crate::agentic::WorkspaceBinding;
@@ -29,6 +30,7 @@ const PLACEHOLDER_AGENT_MEMORY: &str = "{AGENT_MEMORY}";
 const PLACEHOLDER_CLAW_WORKSPACE: &str = "{CLAW_WORKSPACE}";
 const PLACEHOLDER_VISUAL_MODE: &str = "{VISUAL_MODE}";
 const PLACEHOLDER_SESSION_ID: &str = "{SESSION_ID}";
+const PLACEHOLDER_DEEP_RESEARCH_REPORT_LINK: &str = "{DEEP_RESEARCH_REPORT_LINK}";
 const USER_CONTEXT_PROMPT: &str =
     "As you answer the user's questions, you can use the following context.\nNote: this is a snapshot captured at the start of the conversation and may not reflect real-time changes made afterward.";
 /// SSH remote host facts for system prompt (workspace tools run here, not on the local client).
@@ -53,6 +55,8 @@ pub struct PromptBuilderContext {
     pub supports_image_understanding: Option<bool>,
     /// Dynamic tool listings injected outside tool descriptions for cache stability.
     pub tool_listing_sections: ToolListingSections,
+    /// Remote mobile/bot turns need `computer://` links for file delivery.
+    pub remote_file_delivery_channel: bool,
 }
 
 impl PromptBuilderContext {
@@ -70,6 +74,7 @@ impl PromptBuilderContext {
             remote_project_layout: None,
             supports_image_understanding: None,
             tool_listing_sections: ToolListingSections::default(),
+            remote_file_delivery_channel: false,
         }
     }
 
@@ -95,6 +100,11 @@ impl PromptBuilderContext {
     ) -> Self {
         self.remote_execution = Some(execution);
         self.remote_project_layout = project_layout;
+        self
+    }
+
+    pub fn with_remote_file_delivery_channel(mut self, enabled: bool) -> Self {
+        self.remote_file_delivery_channel = enabled;
         self
     }
 }
@@ -562,11 +572,28 @@ Do not read from, modify, create, move, or delete files outside this workspace u
         // Replace {SESSION_ID} — used by deep-research Pro mode to anchor a per-session
         // work_dir under .bitfun/sessions/{SESSION_ID}/research/. Falls back to a
         // timestamp slug when no session is bound (e.g. one-shot prompt builds in tests).
-        if result.contains(PLACEHOLDER_SESSION_ID) {
+        let mut resolved_session_id: Option<String> = None;
+        if result.contains(PLACEHOLDER_SESSION_ID)
+            || result.contains(PLACEHOLDER_DEEP_RESEARCH_REPORT_LINK)
+        {
             let session_id = self.context.session_id.clone().unwrap_or_else(|| {
                 format!("unbound-{}", chrono::Local::now().format("%Y%m%d-%H%M%S"))
             });
+            resolved_session_id = Some(session_id.clone());
             result = result.replace(PLACEHOLDER_SESSION_ID, &session_id);
+        }
+
+        if result.contains(PLACEHOLDER_DEEP_RESEARCH_REPORT_LINK) {
+            let session_id = resolved_session_id.unwrap_or_else(|| {
+                self.context.session_id.clone().unwrap_or_else(|| {
+                    format!("unbound-{}", chrono::Local::now().format("%Y%m%d-%H%M%S"))
+                })
+            });
+            let report_link = user_workspace_relative_file_link(
+                &format!(".bitfun/sessions/{session_id}/research/report.md"),
+                self.context.remote_file_delivery_channel,
+            );
+            result = result.replace(PLACEHOLDER_DEEP_RESEARCH_REPORT_LINK, &report_link);
         }
 
         if self.context.supports_image_understanding == Some(false) {
@@ -656,6 +683,37 @@ mod tests {
             .await;
 
         assert_eq!(reminders, PrependedPromptReminders::default());
+    }
+
+    #[tokio::test]
+    async fn deep_research_report_link_defaults_to_workspace_relative_path() {
+        let context =
+            PromptBuilderContext::new("workspace/root", Some("session-1".to_string()), None);
+        let prompt = PromptBuilder::new(context)
+            .build_prompt_from_template("[View full report]({DEEP_RESEARCH_REPORT_LINK})")
+            .await
+            .expect("prompt should build");
+
+        assert_eq!(
+            prompt,
+            "[View full report](.bitfun/sessions/session-1/research/report.md)"
+        );
+    }
+
+    #[tokio::test]
+    async fn deep_research_report_link_uses_computer_scheme_for_remote_delivery() {
+        let context =
+            PromptBuilderContext::new("workspace/root", Some("session-1".to_string()), None)
+                .with_remote_file_delivery_channel(true);
+        let prompt = PromptBuilder::new(context)
+            .build_prompt_from_template("[View full report]({DEEP_RESEARCH_REPORT_LINK})")
+            .await
+            .expect("prompt should build");
+
+        assert_eq!(
+            prompt,
+            "[View full report](computer://.bitfun/sessions/session-1/research/report.md)"
+        );
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/agents/prompts/agentic_mode.md
+++ b/src/crates/assembly/core/src/agentic/agents/prompts/agentic_mode.md
@@ -82,32 +82,32 @@ assistant: [Uses Grep or Glob directly because this is a focused lookup]
 IMPORTANT: Use TodoWrite for non-trivial multi-step work and keep it current.
 
 # File References
-IMPORTANT: Whenever you mention a file path that the user might want to open, make it a clickable link using markdown link syntax `[text](url)`. Never output a bare path as plain text or wrap it in backticks.
+IMPORTANT: Whenever you mention a file path that the user might want to open, make it a clickable markdown link: [text](url).
 
-**For files inside the workspace** (source code, configs, etc.):
-- Use workspace-relative paths: `[filename.ts](src/filename.ts)`
-- For specific lines: `[filename.ts:42](src/filename.ts#L42)`
-- For line ranges: `[filename.ts:42-51](src/filename.ts#L42-L51)`
-- Link text should be the bare filename only — no directory prefix, no backticks.
+**Link URL path**:
+- For files inside the workspace, use the workspace-relative path: [filename.ts](src/filename.ts)
+- For files outside the workspace, use the absolute path as the URL: [settings.json](/external/project/settings.json)
 
-**For files you or a subagent created** (reports, plans, generated docs, any output file inside the workspace):
-- Use `computer://` with the workspace-relative path: `[filename.md](computer://path/to/filename.md)`
-- `computer://` links open the file in the system file manager, making them reliably clickable regardless of file type.
-- When a subagent result already contains a `computer://` link, preserve it exactly — do not reformat it as plain text or a code block.
+**Line targets**:
+- For a specific line, append `#L<line>` to URL: [filename.ts:42](src/filename.ts#L42)
+- For a line range, append `#L<start>-L<end>`: [filename.ts:42-51](src/filename.ts#L42-L51)
 
-**For files outside the workspace**: use the absolute path as the link URL.
+**Link text and formatting**:
+- Link text should be the bare filename, optionally with line numbers; do not include directory prefixes.
+- Do not output bare paths as plain text.
+- Do not wrap link text or the whole markdown link in backticks.
 
 <good-examples>
 - Source file: [filename.ts](src/filename.ts)
 - Specific line: [filename.ts:42](src/filename.ts#L42)
-- Generated report: [report.md](computer://deep-research/report.md)
-- Plan file returned by a tool: [my-plan.plan.md](computer:///external/projects/my-project/plans/my-plan.plan.md)
+- External file line: [settings.json:12](/external/project/settings.json#L12)
+- Generated report: [report.md](deep-research/report.md)
 </good-examples>
 <bad-examples>
 - Bare path: src/filename.ts
 - Backticks in link text: [`filename.ts:42`](src/filename.ts#L42)
+- Whole link wrapped in backticks: `[report.md](deep-research/report.md)`
 - Full path in link text: [src/filename.ts](src/filename.ts)
-- computer:// in backticks: `computer://deep-research/report.md`
 - Absolute path as plain text: /external/project/deep-research/report.md
 </bad-examples>
 

--- a/src/crates/assembly/core/src/agentic/agents/prompts/cowork_mode.md
+++ b/src/crates/assembly/core/src/agentic/agents/prompts/cowork_mode.md
@@ -90,37 +90,32 @@ Cowork mode includes WebFetch and WebSearch tools for retrieving web content. Th
 
 # High Level Computer Use Explanation
 
-      BitFun runs tools in a secure sandboxed runtime with controlled access to user files.
-      The exact host environment can vary by platform/deployment, so BitFun should rely on
-      Environment Information for OS/runtime details and should not assume a specific VM or OS.
-      Available tools:
-      * ExecCommand - Execute commands
-      * Edit - Edit existing files
-      * Write - Create new files
-      * Read - Read files and directories
-      Working directory: use the current working directory shown in Environment Information.
-      The runtime's internal file system can reset between tasks, but the selected workspace folder
-      persists on the user's actual computer. Files saved to the workspace folder remain accessible to the user after the session ends.
-      When BitFun creates files like docx, pptx, xlsx, save them in the workspace and share a direct `computer://` link when available.
+BitFun runs tools in a secure sandboxed runtime with controlled access to user files.
+The exact host environment can vary by platform/deployment, so BitFun should rely on
+Environment Information for OS/runtime details and should not assume a specific VM or OS.
+Available tools:
+  * ExecCommand - Execute commands
+  * Edit - Edit existing files
+  * Write - Create new files
+  * Read - Read files and directories
+Working directory: use the current working directory shown in Environment Information.
+The runtime's internal file system can reset between tasks, but the selected workspace folder
+persists on the user's actual computer. Files saved to the workspace folder remain accessible to the user after the session ends.
+When BitFun creates files like docx, pptx, xlsx, save them in the workspace and share a direct markdown link when available.
 
 # Suggesting Bitfun Actions
 
 When the user asks for information, first answer the question directly. If BitFun can also help execute a related workflow with available tools, offer or proceed only when the user's intent is clear. If required access or connectors are missing, explain the limitation and suggest a practical alternative without inventing unavailable integrations.
 
 # File Handling Rules
-Cowork operates on the active workspace folder. Create and edit deliverables there unless the user or runtime context indicates another accessible location. Prefer workspace-rooted `computer://` links for user-visible file outputs, and avoid exposing backend-only infrastructure paths. Relative paths are acceptable internally.
+Cowork operates on the active workspace folder. Create and edit deliverables there unless the user or runtime context indicates another accessible location. Prefer workspace-relative markdown links for user-visible file outputs, and avoid exposing backend-only infrastructure paths. Relative paths are acceptable internally.
 # Working With User Files
 
 Workspace access details are provided by runtime context. When referring to file locations, prefer user-facing phrases such as "the folder you selected" or "the workspace folder". Avoid exposing internal paths such as session storage directories. If BitFun lacks access to user files and the user asks to work with them, explain the limitation and suggest selecting the folder or providing the relevant files.
 
 # Notes On User Uploaded Files
 
-      There are some rules and nuance around how user-uploaded files work. Every file the user
-      uploads is given a filepath in the upload mount under the working directory and can be accessed programmatically in the
-      computer at this path. File contents are not included in BitFun's context unless BitFun has
-      used the file read tool to read the contents of the file into its context. BitFun does not
-      necessarily need to read files into context to process them. For example, it can use
-      code/libraries to analyze spreadsheets without reading the entire file into context.
+There are some rules and nuance around how user-uploaded files work. Every file the user uploads is given a filepath in the upload mount under the working directory and can be accessed programmatically in the computer at this path. File contents are not included in BitFun's context unless BitFun has used the file read tool to read the contents of the file into its context. BitFun does not necessarily need to read files into context to process them. For example, it can use code/libraries to analyze spreadsheets without reading the entire file into context.
 
    
 # Producing Outputs
@@ -136,8 +131,8 @@ FILE CREATION STRATEGY:
 When sharing created or edited files, provide a direct file link and a concise summary. Prefer links to files rather than folders, and avoid long postambles that repeat the file contents unless the user asks.
 
 Good file sharing examples:
-- [View your report](computer://artifacts/report.docx)
-- [View your script](computer://scripts/pi.py)
+- [View your report](artifacts/report.docx)
+- [View your script](scripts/pi.py)
 
 Putting deliverables in the workspace folder and sharing direct links helps the user access the work immediately.
 # Artifacts

--- a/src/crates/assembly/core/src/agentic/agents/prompts/deep_research_agent.md
+++ b/src/crates/assembly/core/src/agentic/agents/prompts/deep_research_agent.md
@@ -453,12 +453,12 @@ Then your final reply MUST be exactly the block below — nothing before, nothin
 
 **Pipeline stats:** <N> citations registered · <M> contested points · <K> sub-questions answered
 
-[View full report](computer://.bitfun/sessions/{SESSION_ID}/research/report.md)
+[View full report]({DEEP_RESEARCH_REPORT_LINK})
 ```
 
 Formatting rules — violations will break the user experience:
 
-1. The report link MUST use the `computer://` scheme with the relative path shown above. Do NOT use `file://` or absolute paths.
+1. The report link MUST use exactly the URL shown above. Do NOT replace it with `file://` or an absolute path.
 2. **Do NOT wrap the link in backticks, code fences, or any other markup.** Write it as a plain markdown link.
 3. **Do NOT use `<details>`, `<summary>`, collapsible sections, or HTML tags** of any kind.
 4. **Do NOT include the report content** in this reply — it is already in the file.

--- a/src/crates/assembly/core/src/agentic/agents/prompts/plan_mode_first_entry_reminder.md
+++ b/src/crates/assembly/core/src/agentic/agents/prompts/plan_mode_first_entry_reminder.md
@@ -38,7 +38,7 @@ Use `AskUserQuestion` whenever missing information would materially change the p
 Note: The `CreatePlan` tool is collapsed by default. Before your first calling `CreatePlan`, call `GetToolSpec(tool_name="CreatePlan")` to read its full usage instructions and input schema.
 
 1. When research is complete, create the implementation plan with `CreatePlan` tool. Do NOT make any file changes or run any tools that modify the system state in any way.
-2. After `CreatePlan` succeeds, stop further research for that turn and briefly tell the user the plan is ready. Your response for that turn must include the clickable `computer://` plan link returned by the tool. Do NOT output the path as plain text or wrap it in backticks.
+2. After `CreatePlan` succeeds, stop further research for that turn and briefly tell the user the plan is ready. Your response for that turn must include the clickable plan link returned by the tool.
 3. If the user asks to revise the plan, update only the generated plan file. Do not edit project source files in Plan mode.
 
 # Delegation

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -29,6 +29,10 @@ use crate::agentic::goal_mode::{
     ThreadGoalStore,
 };
 use crate::agentic::image_analysis::ImageContextData;
+use crate::agentic::remote_file_delivery::{
+    needs_computer_links_for_source, remote_file_delivery_reminder,
+    TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY,
+};
 use crate::agentic::round_preempt::{DialogRoundInjectionSource, DialogRoundPreemptSource};
 use crate::agentic::session::SessionManager;
 use crate::agentic::side_question::build_btw_user_input;
@@ -2992,6 +2996,12 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .await?;
         let effective_user_input = wrapped_user_input_payload.content.clone();
         let mut prepended_messages = additional_prepended_messages;
+        if needs_computer_links_for_source(submission_policy.trigger_source) {
+            prepended_messages.push(Message::internal_reminder(
+                InternalReminderKind::RemoteFileDelivery,
+                remote_file_delivery_reminder(),
+            ));
+        }
         prepended_messages.extend(wrapped_user_input_payload.prepended_messages.clone());
 
         if original_user_input != effective_user_input {
@@ -3152,6 +3162,12 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .unwrap_or(false)
         {
             context_vars.insert("acp_transport".to_string(), "true".to_string());
+        }
+        if needs_computer_links_for_source(submission_policy.trigger_source) {
+            context_vars.insert(
+                TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY.to_string(),
+                "true".to_string(),
+            );
         }
         let session_workspace_path = session_workspace
             .as_ref()

--- a/src/crates/assembly/core/src/agentic/core/message.rs
+++ b/src/crates/assembly/core/src/agentic/core/message.rs
@@ -96,6 +96,7 @@ pub enum InternalReminderKind {
     GoalMode,
     GoalContinuation,
     GoalObjectiveUpdated,
+    RemoteFileDelivery,
     SessionMessageRequest,
     SessionMessageReply,
     LoopRecovery,

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -19,6 +19,7 @@ use crate::agentic::image_analysis::{
     build_multimodal_message_with_images, process_image_contexts_for_provider, ImageContextData,
     ImageLimits,
 };
+use crate::agentic::remote_file_delivery::TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY;
 use crate::agentic::round_preempt::RoundInjectionKind;
 use crate::agentic::session::{CompressionMode, ContextCompressor, SessionManager};
 use crate::agentic::skill_agent_snapshot::build_skill_agent_tool_listing_sections_from_snapshot;
@@ -578,6 +579,12 @@ impl ExecutionEngine {
         tool_listing_sections: ToolListingSections,
     ) -> Option<PromptBuilderContext> {
         let workspace = context.workspace.as_ref()?;
+        let remote_file_delivery_channel = context
+            .context
+            .get(TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY)
+            .and_then(|value| value.parse::<bool>().ok())
+            .unwrap_or(false);
+
         build_prompt_context_for_workspace(
             workspace,
             workspace.workspace_id.as_deref(),
@@ -587,6 +594,9 @@ impl ExecutionEngine {
             tool_listing_sections,
         )
         .await
+        .map(|prompt_context| {
+            prompt_context.with_remote_file_delivery_channel(remote_file_delivery_channel)
+        })
     }
 
     async fn build_cached_prepended_prompt_reminders(

--- a/src/crates/assembly/core/src/agentic/mod.rs
+++ b/src/crates/assembly/core/src/agentic/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod subagent_runtime;
 // Shared-context fork-agent execution module
 pub mod fork_agent;
 
+pub(crate) mod remote_file_delivery;
 /// Round-boundary yield when user queues a message during an active turn
 pub mod round_preempt;
 

--- a/src/crates/assembly/core/src/agentic/remote_file_delivery.rs
+++ b/src/crates/assembly/core/src/agentic/remote_file_delivery.rs
@@ -1,0 +1,80 @@
+use bitfun_runtime_ports::DialogTriggerSource;
+use std::path::Path;
+
+pub const TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY: &str = "remote_file_delivery_channel";
+
+pub fn needs_computer_links_for_source(source: DialogTriggerSource) -> bool {
+    matches!(
+        source,
+        DialogTriggerSource::RemoteRelay | DialogTriggerSource::Bot
+    )
+}
+
+pub fn remote_file_delivery_reminder() -> &'static str {
+    r#"The user is messaging through a remote mobile or bot channel.
+
+When referencing a plan, report, presentation, spreadsheet, document, image, or archive, add `computer://` before the file path so the user can click to download it, for example [report.md](computer://artifacts/report.md)."#
+}
+
+pub fn workspace_relative_link(path: &Path, workspace_root: Option<&Path>) -> Option<String> {
+    workspace_root
+        .and_then(|root| path.strip_prefix(root).ok())
+        .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+}
+
+pub fn computer_link(path: &Path, workspace_root: Option<&Path>) -> String {
+    workspace_relative_link(path, workspace_root)
+        .map(|rel| format!("computer://{rel}"))
+        .unwrap_or_else(|| format!("computer://{}", path.to_string_lossy().replace('\\', "/")))
+}
+
+pub fn user_file_link(
+    path: &Path,
+    workspace_root: Option<&Path>,
+    use_computer_link: bool,
+) -> String {
+    if use_computer_link {
+        computer_link(path, workspace_root)
+    } else {
+        workspace_relative_link(path, workspace_root)
+            .unwrap_or_else(|| path.to_string_lossy().replace('\\', "/"))
+    }
+}
+
+pub fn user_workspace_relative_file_link(relative_path: &str, use_computer_link: bool) -> String {
+    let normalized = relative_path.replace('\\', "/");
+    if use_computer_link {
+        format!("computer://{normalized}")
+    } else {
+        normalized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{user_file_link, user_workspace_relative_file_link, workspace_relative_link};
+    use std::path::Path;
+
+    #[test]
+    fn desktop_links_prefer_workspace_relative_paths() {
+        let root = Path::new("/repo");
+        let report = Path::new("/repo/artifacts/report.md");
+
+        assert_eq!(
+            workspace_relative_link(report, Some(root)).as_deref(),
+            Some("artifacts/report.md")
+        );
+        assert_eq!(
+            user_file_link(report, Some(root), false),
+            "artifacts/report.md"
+        );
+    }
+
+    #[test]
+    fn remote_delivery_links_use_computer_scheme() {
+        assert_eq!(
+            user_workspace_relative_file_link(r".bitfun\sessions\s1\research\report.md", true),
+            "computer://.bitfun/sessions/s1/research/report.md"
+        );
+    }
+}

--- a/src/crates/assembly/core/src/agentic/tools/implementations/create_plan_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/create_plan_tool.rs
@@ -2,6 +2,9 @@
 //!
 //! Used to create and store plan files during the planning phase
 
+use crate::agentic::remote_file_delivery::{
+    computer_link as build_computer_link, user_file_link, TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY,
+};
 use crate::agentic::tools::framework::{Tool, ToolExposure, ToolResult, ToolUseContext};
 use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
@@ -215,17 +218,14 @@ Additional guidelines:
             vec![]
         };
 
-        // Prefer workspace-relative computer:// links, but fall back to an
-        // absolute computer:// path when plans live outside the workspace tree.
-        let computer_link = context
-            .workspace_root()
-            .and_then(|root| {
-                std::path::Path::new(&plan_file_path_str)
-                    .strip_prefix(root)
-                    .ok()
-                    .map(|rel| format!("computer://{}", rel.to_string_lossy().replace('\\', "/")))
-            })
-            .unwrap_or_else(|| format!("computer://{}", plan_file_path_str.replace('\\', "/")));
+        let use_computer_link = context
+            .custom_data
+            .get(TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY)
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let plan_path = std::path::Path::new(&plan_file_path_str);
+        let computer_link = build_computer_link(plan_path, context.workspace_root());
+        let user_link = user_file_link(plan_path, context.workspace_root(), use_computer_link);
 
         let plan_reference =
             context.build_runtime_artifact_reference(&format!("plans/{}", plan_file_name))?;
@@ -236,13 +236,14 @@ Clickable link for user: [{}]({})
 Your next reply MUST show the clickable link and then end the conversation turn. Do not continue with more planning details or additional questions.",
             plan_reference,
             plan_file_name,
-            computer_link,
+            user_link,
         );
 
         let result = json!({
             "success": true,
             "plan_file_path": plan_reference,
             "computer_link": computer_link.clone(),
+            "user_link": user_link.clone(),
             "plan_file_name": plan_file_name,
             "name": name,
             "overview": overview,

--- a/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
+++ b/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
@@ -7,6 +7,7 @@
 
 use crate::agentic::coordination::get_global_coordinator;
 use crate::agentic::deep_review::tool_context;
+use crate::agentic::remote_file_delivery::TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY;
 use crate::agentic::session::EvidenceLedgerCheckpoint;
 use crate::agentic::tools::computer_use_host::ComputerUseHostRef;
 use crate::agentic::tools::framework::{
@@ -298,6 +299,17 @@ fn build_tool_context_custom_data(context: &ToolExecutionContext) -> HashMap<Str
     if let Some(acp_transport) = context.context_vars.get("acp_transport") {
         if let Ok(flag) = acp_transport.parse::<bool>() {
             map.insert("acp_transport".to_string(), serde_json::json!(flag));
+        }
+    }
+    if let Some(remote_file_delivery) = context
+        .context_vars
+        .get(TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY)
+    {
+        if let Ok(flag) = remote_file_delivery.parse::<bool>() {
+            map.insert(
+                TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY.to_string(),
+                serde_json::json!(flag),
+            );
         }
     }
 

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.test.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.test.tsx
@@ -108,6 +108,7 @@ describe('Markdown file links', () => {
       `2. [README.md](${EXAMPLE_ABSOLUTE_README})`,
       '3. [README.md](computer://README.md)',
       `4. [README.md](computer://${EXAMPLE_ABSOLUTE_README})`,
+      '5. [deck.pptx](computer://deck.pptx)',
     ].join('\n');
 
     await act(async () => {
@@ -122,7 +123,7 @@ describe('Markdown file links', () => {
     });
 
     const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('button.file-link'));
-    expect(buttons).toHaveLength(4);
+    expect(buttons).toHaveLength(5);
 
     await act(async () => {
       buttons[0].click();
@@ -143,19 +144,26 @@ describe('Markdown file links', () => {
     await act(async () => {
       buttons[2].click();
       await Promise.resolve();
-      await Promise.resolve();
     });
 
-    expect(mocks.revealInExplorer).toHaveBeenNthCalledWith(1, `${EXAMPLE_WORKSPACE}\\README.md`);
-    expect(onFileViewRequest).toHaveBeenCalledTimes(2);
+    expect(onFileViewRequest).toHaveBeenNthCalledWith(3, 'README.md', 'README.md', undefined);
+    expect(mocks.revealInExplorer).not.toHaveBeenCalled();
 
     await act(async () => {
       buttons[3].click();
       await Promise.resolve();
+    });
+
+    expect(onFileViewRequest).toHaveBeenNthCalledWith(4, EXAMPLE_ABSOLUTE_README, 'README.md', undefined);
+    expect(mocks.revealInExplorer).not.toHaveBeenCalled();
+
+    await act(async () => {
+      buttons[4].click();
+      await Promise.resolve();
       await Promise.resolve();
     });
 
-    expect(mocks.revealInExplorer).toHaveBeenNthCalledWith(2, EXAMPLE_ABSOLUTE_README);
-    expect(onFileViewRequest).toHaveBeenCalledTimes(2);
+    expect(mocks.revealInExplorer).toHaveBeenNthCalledWith(1, `${EXAMPLE_WORKSPACE}\\deck.pptx`);
+    expect(onFileViewRequest).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.test.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Markdown } from './Markdown';
+
+const mocks = vi.hoisted(() => ({
+  getCurrentWorkspacePath: vi.fn(),
+  revealInExplorer: vi.fn(),
+  openExternal: vi.fn(),
+}));
+
+vi.mock('../../../infrastructure/api', () => ({
+  globalAPI: {
+    getCurrentWorkspacePath: (...args: unknown[]) => mocks.getCurrentWorkspacePath(...args),
+  },
+  workspaceAPI: {
+    revealInExplorer: (...args: unknown[]) => mocks.revealInExplorer(...args),
+    readFileContent: vi.fn(),
+  },
+  systemAPI: {
+    openExternal: (...args: unknown[]) => mocks.openExternal(...args),
+  },
+}));
+
+vi.mock('@/infrastructure/i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('@/infrastructure/theme', () => ({
+  useTheme: () => ({ isLight: false }),
+}));
+
+vi.mock('../Tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./MermaidBlock', () => ({
+  MermaidBlock: () => <div data-testid="mermaid-block" />,
+}));
+
+vi.mock('./ReproductionStepsBlock', () => ({
+  ReproductionStepsBlock: () => <div data-testid="reproduction-steps" />,
+}));
+
+vi.mock('./AsyncPrismSyntaxHighlighter', () => ({
+  AsyncPrismSyntaxHighlighter: ({ children }: { children: React.ReactNode }) => <pre>{children}</pre>,
+}));
+
+vi.mock('@/shared/context-menu-system/core/ContextMenuController', () => ({
+  contextMenuController: {
+    show: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('@/shared/utils/startupTrace', () => ({
+  isStartupRenderTraceEnabled: () => false,
+  recordReactRenderProfile: vi.fn(),
+  startupTrace: {},
+}));
+
+const EXAMPLE_WORKSPACE = 'C:\\ExampleWorkspace';
+const EXAMPLE_ABSOLUTE_README = 'D:\\SampleDocs\\Guides\\README.md';
+
+describe('Markdown file links', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let onFileViewRequest: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    onFileViewRequest = vi.fn();
+    mocks.getCurrentWorkspacePath.mockReset();
+    mocks.revealInExplorer.mockReset();
+    mocks.openExternal.mockReset();
+    mocks.getCurrentWorkspacePath.mockResolvedValue(EXAMPLE_WORKSPACE);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it('routes same-label relative, absolute, and computer links independently', async () => {
+    const content = [
+      '1. [README.md](.\\README.md)',
+      `2. [README.md](${EXAMPLE_ABSOLUTE_README})`,
+      '3. [README.md](computer://README.md)',
+      `4. [README.md](computer://${EXAMPLE_ABSOLUTE_README})`,
+    ].join('\n');
+
+    await act(async () => {
+      root.render(
+        <Markdown
+          content={content}
+          onFileViewRequest={onFileViewRequest}
+        />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('button.file-link'));
+    expect(buttons).toHaveLength(4);
+
+    await act(async () => {
+      buttons[0].click();
+      await Promise.resolve();
+    });
+
+    expect(onFileViewRequest).toHaveBeenNthCalledWith(1, '.\\README.md', 'README.md', undefined);
+    expect(mocks.revealInExplorer).not.toHaveBeenCalled();
+
+    await act(async () => {
+      buttons[1].click();
+      await Promise.resolve();
+    });
+
+    expect(onFileViewRequest).toHaveBeenNthCalledWith(2, EXAMPLE_ABSOLUTE_README, 'README.md', undefined);
+    expect(mocks.revealInExplorer).not.toHaveBeenCalled();
+
+    await act(async () => {
+      buttons[2].click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.revealInExplorer).toHaveBeenNthCalledWith(1, `${EXAMPLE_WORKSPACE}\\README.md`);
+    expect(onFileViewRequest).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      buttons[3].click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.revealInExplorer).toHaveBeenNthCalledWith(2, EXAMPLE_ABSOLUTE_README);
+    expect(onFileViewRequest).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
@@ -1062,7 +1062,6 @@ export const Markdown = React.memo<MarkdownProps>(({
         node?.position,
       );
       const isHashLink = typeof hrefValue === 'string' && hrefValue.startsWith('#');
-      const isComputerLink = typeof hrefValue === 'string' && hrefValue.startsWith(COMPUTER_LINK_PREFIX);
       const isVisualizationLink = typeof hrefValue === 'string' && hrefValue.startsWith('visualization:');
       const isTabLink = typeof hrefValue === 'string' && hrefValue.startsWith('tab:');
       const isHttpLink = typeof hrefValue === 'string' &&
@@ -1103,7 +1102,7 @@ export const Markdown = React.memo<MarkdownProps>(({
 
         const isFolder = filePath.endsWith('/');
         const editorOpenable = isEditorOpenableFilePath(filePath);
-        const shouldRevealInExplorer = isComputerLink || !editorOpenable;
+        const shouldRevealInExplorer = !editorOpenable;
         if (!isFolder) {
           const fileLinkButton = (
             <button

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
@@ -347,6 +347,25 @@ function resolveDisplayFilePath(targetPath: string, basePath?: string, workspace
   return normalizeDisplayPath(resolveBaseRelativePath(baseResolved, workspacePath));
 }
 
+function extractMarkdownLinkHrefFromSource(
+  markdownSource: string,
+  position?: { start?: { offset?: number }; end?: { offset?: number } },
+): string | undefined {
+  const start = position?.start?.offset;
+  const end = position?.end?.offset;
+  if (typeof start !== 'number' || typeof end !== 'number' || end <= start) {
+    return undefined;
+  }
+
+  const snippet = markdownSource.slice(start, end);
+  const markerIndex = snippet.indexOf('](');
+  if (markerIndex === -1 || !snippet.endsWith(')')) {
+    return undefined;
+  }
+
+  return snippet.slice(markerIndex + 2, -1);
+}
+
 function isLocalAssetPath(src: string): boolean {
   if (!src) {
     return false;
@@ -759,20 +778,6 @@ export const Markdown = React.memo<MarkdownProps>(({
     return { markdownContent: body, reproductionSteps: steps };
   }, [contentStr, isStreaming]);
 
-  const linkMap = useMemo(() => {
-    const map = new Map<string, string>();
-    const linkMatches = contentStr.match(/\[([^\]]+)\]\(([^)]+)\)/g) || [];
-    
-    linkMatches.forEach(match => {
-      const linkMatch = match.match(/\[([^\]]+)\]\(([^)]+)\)/);
-      if (linkMatch) {
-        const [, text, href] = linkMatch;
-        map.set(text, href);
-      }
-    });
-    return map;
-  }, [contentStr]);
-
   const markdownFeatureProfile = useMemo(() => ({
     contentLength: markdownContent.length,
     hasCodeBlock: /^[ \t]{0,3}(`{3,}|~{3,})/m.test(markdownContent),
@@ -1052,9 +1057,10 @@ export const Markdown = React.memo<MarkdownProps>(({
     },
     
     a({ node, href, children, ...props }: any) {
-      const linkText = typeof children === 'string' ? children : String(children);
-      const originalHref = linkMap.get(linkText);
-      const hrefValue = originalHref || href || node?.properties?.href;
+      const hrefValue = href || node?.properties?.href || extractMarkdownLinkHrefFromSource(
+        markdownContent,
+        node?.position,
+      );
       const isHashLink = typeof hrefValue === 'string' && hrefValue.startsWith('#');
       const isComputerLink = typeof hrefValue === 'string' && hrefValue.startsWith(COMPUTER_LINK_PREFIX);
       const isVisualizationLink = typeof hrefValue === 'string' && hrefValue.startsWith('visualization:');
@@ -1096,7 +1102,8 @@ export const Markdown = React.memo<MarkdownProps>(({
         const fileName = filePath.split(/[\\/]/).pop() || filePath;
 
         const isFolder = filePath.endsWith('/');
-        const shouldRevealInExplorer = isComputerLink || !isEditorOpenableFilePath(filePath);
+        const editorOpenable = isEditorOpenableFilePath(filePath);
+        const shouldRevealInExplorer = isComputerLink || !editorOpenable;
         if (!isFolder) {
           const fileLinkButton = (
             <button
@@ -1286,7 +1293,7 @@ export const Markdown = React.memo<MarkdownProps>(({
     basePath,
     expandDetailsByDefault,
     isStreaming,
-    linkMap,
+    markdownContent,
     handleFileViewRequest,
     handleRevealInExplorer,
     handleLocalFileContextMenu,

--- a/src/web-ui/src/shared/services/FileTabManager.ts
+++ b/src/web-ui/src/shared/services/FileTabManager.ts
@@ -8,6 +8,7 @@ import { getEditorType } from '@/infrastructure/language-detection';
 import type { LineRange } from '@/component-library/components/Markdown';
 import { enqueuePendingTab } from './pendingTabQueue';
 import type { PendingTabDetail } from './pendingTabQueue';
+
 export interface FileTabOptions {
    
   filePath: string;


### PR DESCRIPTION
## Summary

- Fix Markdown file-link routing when multiple links share the same display label, including Windows paths and `computer://` URLs.
- Scope `computer://` usage to remote mobile/bot artifact delivery instead of treating it as the default desktop file-reference format.
- Add remote-only file delivery reminders so generated/referenced downloadable artifacts can be clicked and downloaded from mobile-web or bot channels.
- Make CreatePlan and DeepResearch choose user-facing artifact links based on the delivery channel.
- Update agent prompts to prefer normal workspace-relative Markdown links by default and clarify file-reference rules, including line targets and avoiding backticks.
- Let desktop Markdown links open editor-supported `computer://` files in the built-in editor while still revealing unsupported files in the file manager.
