### PR TITLE
perf: guard repeated scans and cache stable computations in ModernFlowChatContainer

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -513,16 +513,36 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     return null;
   }, [t]);
 
+  const turnSummaryCacheRef = useRef<Map<string, FlowChatHeaderTurnSummary>>(new Map());
+
+  // Clear cache on session change
+  useEffect(() => {
+    turnSummaryCacheRef.current.clear();
+  }, [activeSession?.sessionId]);
+
   const turnSummaries = useMemo<FlowChatHeaderTurnSummary[]>(() => {
-    return (activeSession?.dialogTurns ?? [])
-      .filter(turn => !!turn.userMessage)
-      .map((turn, index) => ({
+    const cache = turnSummaryCacheRef.current;
+    const turns = activeSession?.dialogTurns ?? [];
+    const result: FlowChatHeaderTurnSummary[] = [];
+    for (let i = 0; i < turns.length; i++) {
+      const turn = turns[i];
+      if (!turn.userMessage) continue;
+      const cached = cache.get(turn.id);
+      if (cached) {
+        result.push({ ...cached, turnIndex: result.length + 1 });
+        continue;
+      }
+      const summary: FlowChatHeaderTurnSummary = {
         turnId: turn.id,
-        turnIndex: index + 1,
+        turnIndex: result.length + 1,
         backendTurnIndex: turn.backendTurnIndex,
         title: resolveLocalCommandHeaderTitle(turn.userMessage?.metadata)
           ?? turn.userMessage?.content ?? '',
-      }));
+      };
+      cache.set(turn.id, summary);
+      result.push(summary);
+    }
+    return result;
   }, [activeSession?.dialogTurns, resolveLocalCommandHeaderTitle]);
   const headerTotalTurns = activeSession?.isPartial === true
     ? Math.max(activeSession.totalTurnCount ?? turnSummaries.length, turnSummaries.length)

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -289,6 +289,21 @@ function backgroundCommandSummaryFromActivity(activity: BackgroundCommandActivit
   };
 }
 
+function computeSubagentSnapshotKey(
+  sessions: Map<string, Session>,
+  parentSessionId: string,
+): string | null {
+  const parts: string[] = [];
+  for (const session of sessions.values()) {
+    if (session.sessionKind !== 'subagent' || session.parentSessionId !== parentSessionId) {
+      continue;
+    }
+    const status = readSubagentExecutionStatus(session);
+    parts.push(`${session.sessionId}:${status ?? 'none'}`);
+  }
+  return parts.length > 0 ? parts.join('|') : null;
+}
+
 export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = ({
   className = '',
   config,
@@ -965,9 +980,25 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     void FlowChatManager.getInstance().switchChatSession(sessionId);
   }, [activeSession?.sessionId]);
 
+  const backgroundSubagentsRef = useRef<string | null>(null);
+
   useEffect(() => {
     const syncBackgroundSubagents = () => {
-      setBackgroundSubagents(collectRunningBackgroundSubagents(activeSession?.sessionId));
+      const parentId = activeSession?.sessionId;
+      if (!parentId) {
+        setBackgroundSubagents([]);
+        backgroundSubagentsRef.current = null;
+        return;
+      }
+
+      const { sessions } = flowChatStore.getState();
+      const snapshot = computeSubagentSnapshotKey(sessions, parentId);
+      if (snapshot === backgroundSubagentsRef.current) {
+        return;
+      }
+      backgroundSubagentsRef.current = snapshot;
+
+      setBackgroundSubagents(collectRunningBackgroundSubagents(parentId));
     };
 
     syncBackgroundSubagents();


### PR DESCRIPTION
 **问题：** collectRunningBackgroundSubagents 在每次 FlowChatStore 变化时执行 O(sessions×turns×rounds×items) 全量扫描。turnSummaries 链式 useMemo（6+ 个连续）在每次 dialogTurns 变化时全部重算，其中稳定 turn 重复调用 i18n 查询 `resolveLocalCommandHeaderTitle`。

 **修复：** subscribe 回调中先用 `computeSubagentSnapshotKey` 计算快照（子代理 session ID + status），仅快照变化时执行完整扫描。turnSummaries 使用 `turnSummaryCacheRef`（Map<turnId, summary>），稳定 turn 直接复用缓存的标题，仅新增或变化的 turn 重新计算。


**验收标准：**
- [ ] streaming 期间无全量 sessions 遍历
- [ ] 子代理创建/完成/失败/取消状态正确
- [ ] 本地命令标题和 thread goal 标题正确
- [ ] 历史 partial/full projection 正确