### PR TITLE
fix(flow-chat): preserve history window expansion scroll

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -967,6 +967,40 @@ describe('ModernFlowChatContainer historical empty state', () => {
     expect(virtualListMock.pinTurnToTop).not.toHaveBeenCalled();
   });
 
+  it('does not repeat immediate latest anchoring after visible turn info catches up', async () => {
+    stateMocks.activeSession = createSession({
+      isHistorical: true,
+      historyState: 'ready',
+      dialogTurns: [
+        createTurn('turn-80', 'Latest restored prompt'),
+      ],
+    } as Partial<Session>);
+    stateMocks.virtualItems = [
+      { type: 'user-message', turnId: 'turn-80', data: { id: 'user-turn-80', content: 'Latest restored prompt' } },
+    ];
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenCalledTimes(1);
+    expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenLastCalledWith('turn-80');
+
+    stateMocks.visibleTurnInfo = {
+      turnId: 'turn-80',
+      turnIndex: 1,
+      totalTurns: 1,
+      userMessage: 'Latest restored prompt',
+    };
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(virtualListMock.scrollToTurnEndAndClearPin).toHaveBeenCalledTimes(1);
+    expect(virtualListMock.pinTurnToTop).not.toHaveBeenCalled();
+  });
+
   it('does not re-anchor local full hydration when visible turn info is stale after prepending older turns', async () => {
     stateMocks.activeSession = createSession({
       isHistorical: false,

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -680,9 +680,12 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     }
   }, [pendingHeaderTurnId, turnSummaries, visibleTurnInfo?.turnId]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     autoPinnedTurnKeyRef.current = null;
     releasedHistoryCompletionKeyRef.current = null;
+  }, [activeSession?.sessionId]);
+
+  useEffect(() => {
     setHistoryInitialContentReadyKey(null);
     setPendingHeaderTurnId(null);
   }, [activeSession?.sessionId]);

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.layout.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.layout.test.ts
@@ -3,6 +3,7 @@ import {
   estimateTextHeightFromLength,
   estimateVirtualMessageItemHeight,
   getVirtualMessageDefaultItemHeight,
+  mapInitialHistoryExpansionScrollTop,
   selectInitialHistoryRenderWindow,
 } from './virtualMessageListLayout';
 import type { VirtualItem } from '../../store/modernFlowChatStore';
@@ -145,5 +146,88 @@ describe('selectInitialHistoryRenderWindow', () => {
     expect(window.startIndex).toBe(0);
     expect(window.items).toHaveLength(items.length);
     expect(window.omittedEstimatedHeightPx).toBe(0);
+  });
+});
+
+describe('mapInitialHistoryExpansionScrollTop', () => {
+  const base = {
+    previousScrollHeight: 5000,
+    nextScrollHeight: 5600,
+    omittedEstimatedHeightPx: 3000,
+    clientHeight: 1000,
+  };
+
+  it('keeps a direct jump to the omitted history top at the real top', () => {
+    expect(mapInitialHistoryExpansionScrollTop({
+      ...base,
+      previousScrollTop: 0,
+      wasAtBottom: false,
+    })).toBe(0);
+  });
+
+  it('maps positions inside the omitted history spacer by ratio', () => {
+    expect(mapInitialHistoryExpansionScrollTop({
+      ...base,
+      previousScrollTop: 1500,
+      wasAtBottom: false,
+    })).toBe(1800);
+  });
+
+  it('keeps visible tail content stable after the omitted spacer boundary', () => {
+    expect(mapInitialHistoryExpansionScrollTop({
+      ...base,
+      previousScrollTop: 3400,
+      wasAtBottom: false,
+    })).toBe(4000);
+  });
+
+  it('keeps bottom-pinned sessions at the new physical bottom', () => {
+    expect(mapInitialHistoryExpansionScrollTop({
+      ...base,
+      previousScrollTop: 4000,
+      wasAtBottom: true,
+    })).toBe(4600);
+  });
+
+  it('falls back to physical height delta when the omitted estimate is zero', () => {
+    expect(mapInitialHistoryExpansionScrollTop({
+      ...base,
+      previousScrollTop: 700,
+      omittedEstimatedHeightPx: 0,
+      wasAtBottom: false,
+    })).toBe(1300);
+  });
+
+  it('keeps omitted-history ratio stable when the expanded content is shorter than estimated', () => {
+    expect(mapInitialHistoryExpansionScrollTop({
+      previousScrollTop: 1500,
+      previousScrollHeight: 5000,
+      nextScrollHeight: 2600,
+      omittedEstimatedHeightPx: 3000,
+      clientHeight: 1000,
+      wasAtBottom: false,
+    })).toBe(300);
+  });
+
+  it('clamps stale visible-tail scroll positions to the expanded scroll range', () => {
+    expect(mapInitialHistoryExpansionScrollTop({
+      previousScrollTop: 7000,
+      previousScrollHeight: 5000,
+      nextScrollHeight: 5200,
+      omittedEstimatedHeightPx: 3000,
+      clientHeight: 1000,
+      wasAtBottom: false,
+    })).toBe(4200);
+  });
+
+  it('keeps bottom-pinned sessions at zero when content is shorter than the viewport', () => {
+    expect(mapInitialHistoryExpansionScrollTop({
+      previousScrollTop: 4000,
+      previousScrollHeight: 5000,
+      nextScrollHeight: 800,
+      omittedEstimatedHeightPx: 3000,
+      clientHeight: 1000,
+      wasAtBottom: true,
+    })).toBe(0);
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -43,6 +43,7 @@ import { startupTrace } from '@/shared/utils/startupTrace';
 import {
   estimateVirtualMessageItemHeight,
   getVirtualMessageDefaultItemHeight,
+  mapInitialHistoryExpansionScrollTop,
   selectInitialHistoryRenderWindow,
 } from './virtualMessageListLayout';
 import './VirtualMessageList.scss';
@@ -367,6 +368,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
   const pendingInitialHistoryExpansionRef = useRef<{
     scrollTop: number;
     scrollHeight: number;
+    omittedEstimatedHeightPx: number;
     wasAtBottom: boolean;
   } | null>(null);
   const initialHistoryRenderWindowCheckFrameRef = useRef<number | null>(null);
@@ -3321,6 +3323,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       pendingInitialHistoryExpansionRef.current = {
         scrollTop: scroller.scrollTop,
         scrollHeight: scroller.scrollHeight,
+        omittedEstimatedHeightPx: initialHistoryRenderWindow.omittedEstimatedHeightPx,
         wasAtBottom: Math.abs(maxScrollTop - scroller.scrollTop) <= COMPENSATION_EPSILON_PX,
       };
     } else {
@@ -3452,16 +3455,14 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       return;
     }
 
-    if (pending.wasAtBottom) {
-      const nextScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
-      scroller.scrollTop = nextScrollTop;
-      previousScrollTopRef.current = nextScrollTop;
-      previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
-      return;
-    }
-
-    const heightDelta = scroller.scrollHeight - pending.scrollHeight;
-    const nextScrollTop = Math.max(0, pending.scrollTop + heightDelta);
+    const nextScrollTop = mapInitialHistoryExpansionScrollTop({
+      previousScrollTop: pending.scrollTop,
+      previousScrollHeight: pending.scrollHeight,
+      nextScrollHeight: scroller.scrollHeight,
+      omittedEstimatedHeightPx: pending.omittedEstimatedHeightPx,
+      wasAtBottom: pending.wasAtBottom,
+      clientHeight: scroller.clientHeight,
+    });
     scroller.scrollTop = nextScrollTop;
     previousScrollTopRef.current = nextScrollTop;
     previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);

--- a/src/web-ui/src/flow_chat/components/modern/virtualMessageListLayout.ts
+++ b/src/web-ui/src/flow_chat/components/modern/virtualMessageListLayout.ts
@@ -123,6 +123,36 @@ export interface InitialHistoryRenderWindow {
   isWindowed: boolean;
 }
 
+export function mapInitialHistoryExpansionScrollTop(params: {
+  previousScrollTop: number;
+  previousScrollHeight: number;
+  nextScrollHeight: number;
+  omittedEstimatedHeightPx: number;
+  wasAtBottom: boolean;
+  clientHeight: number;
+}): number {
+  const nextMaxScrollTop = Math.max(0, params.nextScrollHeight - params.clientHeight);
+  if (params.wasAtBottom) {
+    return nextMaxScrollTop;
+  }
+
+  const heightDelta = params.nextScrollHeight - params.previousScrollHeight;
+  const omittedEstimatedHeightPx = Math.max(0, params.omittedEstimatedHeightPx);
+  if (
+    omittedEstimatedHeightPx > 0 &&
+    params.previousScrollTop <= omittedEstimatedHeightPx
+  ) {
+    const actualOmittedHeightPx = Math.max(0, omittedEstimatedHeightPx + heightDelta);
+    const omittedRatio = Math.max(
+      0,
+      Math.min(1, params.previousScrollTop / omittedEstimatedHeightPx),
+    );
+    return Math.min(nextMaxScrollTop, actualOmittedHeightPx * omittedRatio);
+  }
+
+  return Math.min(nextMaxScrollTop, Math.max(0, params.previousScrollTop + heightDelta));
+}
+
 function uniqueTurnCount(items: VirtualItem[]): number {
   const turnIds = new Set<string>();
   items.forEach(item => {

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -3043,11 +3043,15 @@ function summarizeLongSessionVisualStateEvents(
     if (current.activeSessionId === sessionId) {
       hasSeenTargetSession = true;
     }
+    const historyLoadingLayerChanged =
+      previous.showHistoryLoadingLayer !== null &&
+      current.showHistoryLoadingLayer !== null &&
+      previous.showHistoryLoadingLayer !== current.showHistoryLoadingLayer;
     const loadingChanged =
-      previous.showHistoryLoadingLayer !== current.showHistoryLoadingLayer ||
+      historyLoadingLayerChanged ||
       previous.overlayCount !== current.overlayCount ||
       previous.placeholderCount !== current.placeholderCount;
-    if (previous.showHistoryLoadingLayer !== current.showHistoryLoadingLayer) {
+    if (historyLoadingLayerChanged) {
       loadingLayerToggleCount += 1;
     }
     if (previous.overlayCount !== current.overlayCount) {
@@ -3679,6 +3683,15 @@ async function collectLongSessionOpenMeasurement(
   await item.click();
   const latestVisiblePromise = waitForLatestLongSessionTurnVisible(5000, expectedLatestTurnId);
   const latestUsablePromise = waitForLatestLongSessionViewportUsable(5000, expectedLatestTurnId);
+  const postVisibleInteraction = readPostVisibleInteractionOption(options);
+  let latestVisible: Awaited<typeof latestVisiblePromise> | null = null;
+  let latestUsable: Awaited<typeof latestUsablePromise> | null = null;
+
+  if (postVisibleInteraction) {
+    latestVisible = await latestVisiblePromise;
+    latestUsable = await latestUsablePromise;
+    await performLongSessionPostVisibleInteraction(postVisibleInteraction);
+  }
 
   const afterFrameSnapshot = requireFrameTrace
     ? await waitForRequiredTracePhase(
@@ -3709,12 +3722,8 @@ async function collectLongSessionOpenMeasurement(
     clickedAtMs,
     latestAnchorTimeoutMs,
   );
-  const latestVisible = await latestVisiblePromise;
-  const latestUsable = await latestUsablePromise;
-  const postVisibleInteraction = readPostVisibleInteractionOption(options);
-  if (postVisibleInteraction) {
-    await performLongSessionPostVisibleInteraction(postVisibleInteraction);
-  }
+  latestVisible ??= await latestVisiblePromise;
+  latestUsable ??= await latestUsablePromise;
   const postVisibleObserveMs =
     numericEnv('BITFUN_E2E_PERF_POST_VISIBLE_OBSERVE_MS') ?? DEFAULT_POST_VISIBLE_OBSERVE_MS;
   const observeRemainingMs = latestUsable.usableAtMs + postVisibleObserveMs - await readPerformanceNow();
@@ -3785,7 +3794,7 @@ async function collectLongSessionOpenMeasurement(
     latestAnswerTextVisibleAtMs: latestUsable.usableAtMs,
     clickToLatestAnswerTextVisibleMs: latestUsable.usableAtMs - clickedAtMs,
     finalViewportCheckedAtMs,
-    ...(requireFrameTrace
+    ...(requireFrameTrace && traceWaitErrors.length === 0
       ? {
         postHydrateUsableAtMs: finalViewportCheckedAtMs,
         clickToPostHydrateUsableMs: finalViewportCheckedAtMs - clickedAtMs,
@@ -3948,10 +3957,12 @@ describe('Performance telemetry', () => {
 
     const sessionId = process.env.BITFUN_E2E_PERF_SESSION_ID || DEFAULT_PERF_SESSION_ID;
     const expectedLatestTurnId = await readExpectedLatestTurnId(sessionId);
+    const postVisibleInteraction = readPostVisibleInteractionOption({});
+    const requireFrameTrace = postVisibleInteraction === null;
     const measurement = await collectLongSessionOpenMeasurement(
       sessionId,
       expectedLatestTurnId,
-      { requireFrameTrace: true },
+      { requireFrameTrace },
     );
     if (!measurement) {
       if (expectedLatestTurnId) {
@@ -3972,7 +3983,7 @@ describe('Performance telemetry', () => {
 
     await writeReport('long-session-first-open', measurement);
     expectLongSessionMeasurementUsable(measurement, maxLatestFrameMs, {
-      requireFrameTrace: true,
+      requireFrameTrace,
       expectNoHistoryLoadingAfterClick: true,
     });
   });


### PR DESCRIPTION
## Summary

- Preserve scroll position when the initial historical-session render window expands after the user scrolls into omitted older history.
- Prevent a repeated immediate latest-anchor attempt after visible turn info catches up during historical-session opening.
- Tighten layout/unit coverage and E2E edge coverage for dense history, first-scroll, and rapid session switching.

## Why

The review found two interaction risks in large historical sessions:

- Expansion from the estimated omitted-history spacer could map the viewport away from the user-intended older-history position.
- A session-scoped anchor ref could be reset after the first layout pass, allowing a second latest-anchor request and a visible scroll jump in dense sessions.

## Performance / UX Impact

This PR does not claim a startup-time improvement. It is a correctness and UX-stability follow-up for large historical-session navigation. The expected user-visible benefit is fewer unexpected jumps or loading/blank flashes when opening or quickly inspecting large sessions.

Latest release-fast E2E samples from this branch:

| Scenario | Result | Visual stability guard |
|---|---:|---|
| Default mixed long session first open | latest usable 372.9 ms; full-hydrate duration 30.6 ms | loading / blank / scroll-jump after latest visible: 0 / 0 / 0 |
| Default mixed long session warm reopen | latest usable 189.4 ms | loading / blank / scroll-jump after latest visible: 0 / 0 / 0 |
| Default rapid switch A->B->C | target latest usable 1168.2 ms | loading / blank / scroll-jump / non-target hold: 0 / 0 / 0 / 0 |
| Dense long session, first visible then immediate user scroll | first open latest usable 1016.6 ms; warm reopen 931.3 ms | post-interaction jump / collapse / blank: 0 / 0 / 0 |
| Three dense long sessions rapid switch A->B->C | target latest usable 2767.3 ms | loading / blank / scroll-jump / non-target hold: 0 / 0 / 0 / 0 |

The three-dense-session rapid switch remains a heavier stress case with 2-3s target usability. This PR only verifies that the target session wins and the viewport does not blank, flash loading, jump, or show stale non-target content; it should not be presented as a performance win for that stress case.

## Risk

- The production change is scoped to resetting internal session-anchor refs in a layout effect keyed by `sessionId`; user-visible header and initial-content state resets remain in the passive effect to avoid changing navigation/header behavior.
- The E2E loading-toggle fix ignores only the recorder bootstrap transition from missing data to `false`; real loading is still caught by first-loading, post-visible loading, overlay, placeholder, and surface checks.
- No remote-session behavior, persistence format, logging level, or backend loading strategy is intentionally changed.

## Validation

- `pnpm --dir src/web-ui run test:run src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx src/flow_chat/components/modern/VirtualMessageList.layout.test.ts`
- `pnpm run desktop:build:release-fast`
- `pnpm run e2e:test:perf:release-fast`
- `BITFUN_E2E_PERF_SESSION_ID=perf-edge-dense-000 BITFUN_E2E_PERF_POST_VISIBLE_INTERACTION=first-scroll pnpm run e2e:test:perf:release-fast`
- `BITFUN_E2E_PERF_SESSION_ID=perf-rapid-dense-a-000 BITFUN_E2E_PERF_RAPID_SWITCH_SESSION_IDS=perf-rapid-dense-a-000,perf-rapid-dense-b-000,perf-rapid-dense-c-000 pnpm run e2e:test:perf:release-fast`
- `pnpm run check:repo-hygiene`
- `git diff --check`