### PR TITLE
perf: reduce RAF callback volume in VirtualMessageList event system

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -578,7 +578,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
       root.render(<ModernFlowChatContainer />);
     });
 
-    for (let index = 0; index < 120; index += 1) {
+    for (let index = 0; index < 30; index += 1) {
       flushAnimationFrame();
     }
 
@@ -586,7 +586,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
     expect(releaseSpy).not.toHaveBeenCalled();
     expect(startupTraceMock.markPhase).toHaveBeenCalledWith(
       'historical_session_initial_content_paint_signal_missed',
-      expect.objectContaining({ attempts: 120 }),
+      expect.objectContaining({ attempts: 30 }),
     );
 
     releaseSpy.mockRestore();

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -89,7 +89,7 @@ type BackgroundCommandSummary = {
 };
 
 const LATEST_TURN_AUTO_PIN_MAX_ATTEMPTS = 8;
-const HISTORY_INITIAL_CONTENT_PAINT_MAX_ATTEMPTS = 120;
+const HISTORY_INITIAL_CONTENT_PAINT_MAX_ATTEMPTS = 30;
 const MOCK_BACKGROUND_ACTIVITIES_STORAGE_KEY = 'bitfun.flowChat.mockBackgroundActivities';
 
 const MOCK_BACKGROUND_SUBAGENTS: BackgroundSubagentSummary[] = [

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -1763,15 +1763,26 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
     previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scrollerElement);
     previousScrollTopRef.current = scrollerElement.scrollTop;
 
+    // Batch observer-triggered work into a single rAF per frame
+    let observerBatchPending = false;
+    const scheduleObserverBatch = () => {
+      if (observerBatchPending) return;
+      observerBatchPending = true;
+      requestAnimationFrame(() => {
+        observerBatchPending = false;
+        scheduleHeightMeasure(2);
+        scheduleVisibleTurnMeasure(2);
+        schedulePinReservationReconcile(2);
+        scheduleTransientTurnPinStabilization(2);
+        scheduleFollowToLatestWithViewportState('observer');
+        scheduleHistoryProjectionHandoffRelease(1);
+      });
+    };
+
     resizeObserverRef.current?.disconnect();
     resizeObserverRef.current = new ResizeObserver(() => {
       resolveLatestEndAnchorStabilizationRef.current?.('resize-observer');
-      scheduleHeightMeasure();
-      scheduleVisibleTurnMeasure(2);
-      schedulePinReservationReconcile(2);
-      scheduleTransientTurnPinStabilization(2);
-      scheduleFollowToLatestWithViewportState('resize-observer');
-      scheduleHistoryProjectionHandoffRelease(1);
+      scheduleObserverBatch();
     });
     resizeObserverRef.current.observe(resizeTarget);
 
@@ -1794,12 +1805,7 @@ export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => 
       mutationPending = true;
       requestAnimationFrame(() => {
         mutationPending = false;
-        scheduleHeightMeasure(2);
-        scheduleVisibleTurnMeasure(2);
-        schedulePinReservationReconcile(2);
-        scheduleTransientTurnPinStabilization(2);
-        scheduleFollowToLatestWithViewportState('mutation-observer');
-        scheduleHistoryProjectionHandoffRelease(1);
+        scheduleObserverBatch();
       });
     });
     mutationObserverRef.current.observe(scrollerElement, {

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
@@ -177,6 +177,11 @@ export function useFlowChatFollowOutput({
       return;
     }
 
+    // Stop the loop when the page is hidden to avoid unnecessary work
+    if (document.hidden) {
+      return;
+    }
+
     continuousFollowFrameRef.current = requestAnimationFrame(runContinuousFollowFrame);
   }, [scrollerRef]);
 
@@ -440,6 +445,17 @@ export function useFlowChatFollowOutput({
     scheduleFollowToLatest('streaming-started');
     startContinuousFollowLoop();
   }, [isFollowingOutput, isStreaming, scheduleFollowToLatest, startContinuousFollowLoop, stopContinuousFollowLoop]);
+
+  // Restart follow loop when the page becomes visible again
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (!document.hidden && isFollowingOutputRef.current && isStreamingRef.current) {
+        startContinuousFollowLoop();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [startContinuousFollowLoop]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
**问题：** ResizeObserver 和 MutationObserver 每个事件各触发 6 个独立 schedule 调用，每个 token 最多产生 12 个 RAF 回调。RAF 跟随循环在 tab 隐藏时仍持续 60fps 运行。history content paint 检测最多 120 次 RAF 轮询（近 2 秒）。

**修复：** 新增 `scheduleObserverBatch` 将同帧内多个 schedule 合并为一次 rAF。RAF 跟随循环增加 `document.hidden` 检查——隐藏时停止，`visibilitychange` 监听器在可见时重启。`HISTORY_INITIAL_CONTENT_PAINT_MAX_ATTEMPTS` 从 120 降为 30。


**验收标准：**
- [ ] Performance 中每个 token 不再有多个独立 rAF
- [ ] 工具卡片展开/折叠、窗口 resize 后布局正常
- [ ] tab 后台时 RAF 停止、切回后恢复
- [ ] 历史会话打开定位正确；loading overlay 正常消失