### PR TITLE
feat(exec-command): honor configured local shell with Windows fallback

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/command.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/command.rs
@@ -3,6 +3,7 @@ use super::background_command_output::{
     StartBackgroundCommandOutputCapture,
 };
 use super::env_snapshot::{remote_env_snapshot_for, RemoteEnvSnapshot};
+use super::local_shell::{resolve_local_exec_shell, ResolvedLocalExecShell};
 use super::progress::ExecOutputProgressBridge;
 use super::rendering::render_exec_response_for_assistant;
 use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext, ValidationResult};
@@ -24,7 +25,7 @@ use std::path::{Path, PathBuf};
 use terminal_core::{
     get_global_exec_process_manager, ExecProcessLifecycleEvent, ExecProcessLifecycleStatus,
     LocalExecCommandRequest, LocalExecSessionCompletion, LocalExecSessionCompletionSource,
-    LocalExecSessionCompletionStatus, ShellDetector, ShellType,
+    LocalExecSessionCompletionStatus, ShellType,
 };
 use tokio::sync::mpsc;
 
@@ -312,10 +313,13 @@ exit "$__bitfun_status""#
         }
     }
 
-    fn detected_shell_for_model() -> (String, PathBuf, ShellType, String) {
-        let shell = ShellDetector::get_default_shell();
-        let invocation = Self::shell_invocation_for_model(&shell.path, &shell.shell_type);
-        (shell.display_name, shell.path, shell.shell_type, invocation)
+    fn shell_metadata_value(shell: &ResolvedLocalExecShell) -> Value {
+        json!({
+            "name": shell.display_name,
+            "type": shell.shell_type.to_string(),
+            "path": shell.path.to_string_lossy(),
+            "invocation": Self::shell_invocation_for_model(&shell.path, &shell.shell_type),
+        })
     }
 
     fn response_for_assistant(data: &Value) -> String {
@@ -874,8 +878,8 @@ impl Tool for ExecCommandTool {
     }
 
     async fn description(&self) -> BitFunResult<String> {
-        let (shell_name, shell_path, _shell_type, shell_invocation) =
-            Self::detected_shell_for_model();
+        let shell = resolve_local_exec_shell().await;
+        let shell_invocation = Self::shell_invocation_for_model(&shell.path, &shell.shell_type);
         Ok(format!(
             r#"Runs a shell command.
 
@@ -885,7 +889,8 @@ yield_time_ms waits for output until the process exits or the deadline is reache
 If the process is still running, the result includes a numeric session_id. Use WriteStdin to poll or send input, and ExecControl to interrupt or kill it.
 Output is only what was produced during this tool call's wait window. 
 With tty=false, stdout and stderr ordering is not guaranteed; use tty=true or redirect stderr with 2>&1 when terminal ordering matters."#,
-            shell_path = shell_path.display(),
+            shell_name = shell.display_name,
+            shell_path = shell.path.display(),
         ))
     }
 
@@ -994,7 +999,7 @@ With tty=false, stdout and stderr ordering is not guaranteed; use tty=true or re
             .ok_or_else(|| BitFunError::tool("cmd is required for ExecCommand".to_string()))?;
         let workdir = Self::resolve_workdir(input, context)?;
         let tty = input.get("tty").and_then(Value::as_bool).unwrap_or(false);
-        let shell = ShellDetector::get_default_shell();
+        let shell = resolve_local_exec_shell().await;
         let yield_time_ms = input.get("yield_time_ms").and_then(Value::as_u64);
         let max_output_chars = input
             .get("max_output_chars")
@@ -1080,12 +1085,7 @@ With tty=false, stdout and stderr ordering is not guaranteed; use tty=true or re
             "completion": response.completion.map(Self::local_completion_value),
             "workdir": workdir.to_string_lossy(),
             "tty": tty,
-            "shell": {
-                "name": shell.display_name,
-                "type": shell.shell_type.to_string(),
-                "path": shell.path.to_string_lossy(),
-                "invocation": Self::shell_invocation_for_model(&shell.path, &shell.shell_type),
-            },
+            "shell": Self::shell_metadata_value(&shell),
         });
         let result_for_assistant = Self::response_for_assistant(&data);
 

--- a/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/local_shell.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/local_shell.rs
@@ -1,0 +1,330 @@
+use crate::service::config::get_global_config_service;
+use std::path::PathBuf;
+use terminal_core::{ShellDetector, ShellType};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ResolvedLocalExecShell {
+    pub display_name: String,
+    pub path: PathBuf,
+    pub shell_type: ShellType,
+}
+
+impl ResolvedLocalExecShell {
+    fn new(display_name: String, path: PathBuf, shell_type: ShellType) -> Self {
+        Self {
+            display_name,
+            path,
+            shell_type,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfiguredShellPreference {
+    PowerShellCore,
+    PowerShell,
+    Bash,
+    Cmd,
+    Zsh,
+    Fish,
+    Sh,
+    Ksh,
+    Csh,
+    Unsupported,
+}
+
+pub(super) async fn resolve_local_exec_shell() -> ResolvedLocalExecShell {
+    let configured = configured_shell_preference().await;
+    let detected_shells: Vec<_> = ShellDetector::detect_available_shells()
+        .into_iter()
+        .map(|shell| ResolvedLocalExecShell::new(shell.display_name, shell.path, shell.shell_type))
+        .collect();
+    let system_default = {
+        let shell = ShellDetector::get_default_shell();
+        ResolvedLocalExecShell::new(shell.display_name, shell.path, shell.shell_type)
+    };
+
+    if cfg!(windows) {
+        select_windows_local_exec_shell(configured, &detected_shells, &system_default)
+    } else {
+        select_non_windows_local_exec_shell(configured, &detected_shells, &system_default)
+    }
+}
+
+async fn configured_shell_preference() -> Option<ConfiguredShellPreference> {
+    let config_service = get_global_config_service().await.ok()?;
+    let shell = config_service
+        .get_config::<String>(Some("terminal.default_shell"))
+        .await
+        .ok()?;
+    parse_configured_shell_preference(&shell)
+}
+
+fn parse_configured_shell_preference(raw: &str) -> Option<ConfiguredShellPreference> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let normalized = trimmed
+        .rsplit(['\\', '/'])
+        .next()
+        .unwrap_or(trimmed)
+        .to_ascii_lowercase();
+    let normalized = normalized.trim_end_matches(".exe");
+
+    Some(match normalized {
+        "powershellcore" | "pwsh" => ConfiguredShellPreference::PowerShellCore,
+        "powershell" | "windowspowershell" => ConfiguredShellPreference::PowerShell,
+        "bash" | "gitbash" => ConfiguredShellPreference::Bash,
+        "cmd" | "commandprompt" => ConfiguredShellPreference::Cmd,
+        "zsh" => ConfiguredShellPreference::Zsh,
+        "fish" => ConfiguredShellPreference::Fish,
+        "sh" => ConfiguredShellPreference::Sh,
+        "ksh" => ConfiguredShellPreference::Ksh,
+        "csh" | "tcsh" => ConfiguredShellPreference::Csh,
+        _ => ConfiguredShellPreference::Unsupported,
+    })
+}
+
+fn select_non_windows_local_exec_shell(
+    configured: Option<ConfiguredShellPreference>,
+    detected_shells: &[ResolvedLocalExecShell],
+    system_default: &ResolvedLocalExecShell,
+) -> ResolvedLocalExecShell {
+    configured
+        .and_then(|preference| shell_type_for_supported_preference(preference))
+        .and_then(|shell_type| find_detected_shell(detected_shells, shell_type))
+        .unwrap_or_else(|| system_default.clone())
+}
+
+fn select_windows_local_exec_shell(
+    configured: Option<ConfiguredShellPreference>,
+    detected_shells: &[ResolvedLocalExecShell],
+    system_default: &ResolvedLocalExecShell,
+) -> ResolvedLocalExecShell {
+    // ExecCommand deliberately narrows Windows shells to the variants whose
+    // one-shot command behavior we explicitly support well.
+    let pwsh = || find_detected_shell(detected_shells, ShellType::PowerShellCore);
+    let powershell = || find_detected_shell(detected_shells, ShellType::PowerShell);
+    let bash = || find_detected_shell(detected_shells, ShellType::Bash);
+
+    match configured {
+        Some(ConfiguredShellPreference::PowerShellCore) => pwsh()
+            .or_else(powershell)
+            .or_else(bash)
+            .unwrap_or_else(|| system_default.clone()),
+        Some(ConfiguredShellPreference::PowerShell) => powershell()
+            .or_else(pwsh)
+            .or_else(bash)
+            .unwrap_or_else(|| system_default.clone()),
+        Some(ConfiguredShellPreference::Bash) => bash()
+            .or_else(powershell)
+            .or_else(pwsh)
+            .unwrap_or_else(|| system_default.clone()),
+        Some(ConfiguredShellPreference::Cmd) => pwsh()
+            .or_else(powershell)
+            .or_else(bash)
+            .unwrap_or_else(|| system_default.clone()),
+        Some(
+            ConfiguredShellPreference::Zsh
+            | ConfiguredShellPreference::Fish
+            | ConfiguredShellPreference::Sh
+            | ConfiguredShellPreference::Ksh
+            | ConfiguredShellPreference::Csh
+            | ConfiguredShellPreference::Unsupported,
+        ) => powershell()
+            .or_else(pwsh)
+            .or_else(bash)
+            .unwrap_or_else(|| system_default.clone()),
+        None => pwsh()
+            .or_else(powershell)
+            .or_else(bash)
+            .unwrap_or_else(|| system_default.clone()),
+    }
+}
+
+fn shell_type_for_supported_preference(preference: ConfiguredShellPreference) -> Option<ShellType> {
+    Some(match preference {
+        ConfiguredShellPreference::PowerShellCore => ShellType::PowerShellCore,
+        ConfiguredShellPreference::PowerShell => ShellType::PowerShell,
+        ConfiguredShellPreference::Bash => ShellType::Bash,
+        ConfiguredShellPreference::Cmd => ShellType::Cmd,
+        ConfiguredShellPreference::Zsh => ShellType::Zsh,
+        ConfiguredShellPreference::Fish => ShellType::Fish,
+        ConfiguredShellPreference::Sh => ShellType::Sh,
+        ConfiguredShellPreference::Ksh => ShellType::Ksh,
+        ConfiguredShellPreference::Csh => ShellType::Csh,
+        ConfiguredShellPreference::Unsupported => return None,
+    })
+}
+
+fn find_detected_shell(
+    detected_shells: &[ResolvedLocalExecShell],
+    shell_type: ShellType,
+) -> Option<ResolvedLocalExecShell> {
+    detected_shells
+        .iter()
+        .find(|shell| shell.shell_type == shell_type)
+        .cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        parse_configured_shell_preference, select_non_windows_local_exec_shell,
+        select_windows_local_exec_shell, ConfiguredShellPreference, ResolvedLocalExecShell,
+    };
+    use std::path::PathBuf;
+    use terminal_core::ShellType;
+
+    fn shell(name: &str, path: &str, shell_type: ShellType) -> ResolvedLocalExecShell {
+        ResolvedLocalExecShell {
+            display_name: name.to_string(),
+            path: PathBuf::from(path),
+            shell_type,
+        }
+    }
+
+    #[test]
+    fn parses_configured_shell_values_from_enum_names_and_paths() {
+        assert_eq!(
+            parse_configured_shell_preference("PowerShellCore"),
+            Some(ConfiguredShellPreference::PowerShellCore)
+        );
+        assert_eq!(
+            parse_configured_shell_preference("C:\\Program Files\\PowerShell\\7\\pwsh.exe"),
+            Some(ConfiguredShellPreference::PowerShellCore)
+        );
+        assert_eq!(
+            parse_configured_shell_preference("Cmd"),
+            Some(ConfiguredShellPreference::Cmd)
+        );
+        assert_eq!(
+            parse_configured_shell_preference("/usr/bin/bash"),
+            Some(ConfiguredShellPreference::Bash)
+        );
+        assert_eq!(parse_configured_shell_preference(""), None);
+    }
+
+    #[test]
+    fn windows_cmd_prefers_pwsh_then_powershell() {
+        let detected = vec![
+            shell(
+                "Windows PowerShell",
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                ShellType::PowerShell,
+            ),
+            shell(
+                "PowerShell 7",
+                "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+                ShellType::PowerShellCore,
+            ),
+            shell(
+                "Git Bash",
+                "C:\\Program Files\\Git\\bin\\bash.exe",
+                ShellType::Bash,
+            ),
+        ];
+        let resolved = select_windows_local_exec_shell(
+            Some(ConfiguredShellPreference::Cmd),
+            &detected,
+            &detected[0],
+        );
+
+        assert_eq!(resolved.shell_type, ShellType::PowerShellCore);
+        assert_eq!(
+            resolved.path,
+            PathBuf::from("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+        );
+    }
+
+    #[test]
+    fn windows_pwsh_falls_back_to_powershell_when_pwsh_is_missing() {
+        let detected = vec![shell(
+            "Windows PowerShell",
+            "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+            ShellType::PowerShell,
+        )];
+        let resolved = select_windows_local_exec_shell(
+            Some(ConfiguredShellPreference::PowerShellCore),
+            &detected,
+            &detected[0],
+        );
+
+        assert_eq!(resolved.shell_type, ShellType::PowerShell);
+    }
+
+    #[test]
+    fn windows_bash_uses_detected_git_bash_path() {
+        let detected = vec![
+            shell(
+                "PowerShell 7",
+                "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+                ShellType::PowerShellCore,
+            ),
+            shell("Git Bash", "D:\\Tools\\Git\\bin\\bash.exe", ShellType::Bash),
+        ];
+        let resolved = select_windows_local_exec_shell(
+            Some(ConfiguredShellPreference::Bash),
+            &detected,
+            &detected[0],
+        );
+
+        assert_eq!(resolved.shell_type, ShellType::Bash);
+        assert_eq!(
+            resolved.path,
+            PathBuf::from("D:\\Tools\\Git\\bin\\bash.exe")
+        );
+    }
+
+    #[test]
+    fn windows_unsupported_shell_falls_back_to_powershell() {
+        let detected = vec![
+            shell("Git Bash", "D:\\Tools\\Git\\bin\\bash.exe", ShellType::Bash),
+            shell(
+                "Windows PowerShell",
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                ShellType::PowerShell,
+            ),
+        ];
+        let resolved = select_windows_local_exec_shell(
+            Some(ConfiguredShellPreference::Fish),
+            &detected,
+            &detected[0],
+        );
+
+        assert_eq!(resolved.shell_type, ShellType::PowerShell);
+    }
+
+    #[test]
+    fn windows_auto_prefers_pwsh_then_powershell_then_bash() {
+        let detected = vec![
+            shell("Git Bash", "D:\\Tools\\Git\\bin\\bash.exe", ShellType::Bash),
+            shell(
+                "Windows PowerShell",
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                ShellType::PowerShell,
+            ),
+        ];
+        let resolved = select_windows_local_exec_shell(None, &detected, &detected[0]);
+
+        assert_eq!(resolved.shell_type, ShellType::PowerShell);
+    }
+
+    #[test]
+    fn non_windows_uses_configured_detected_shell_when_available() {
+        let detected = vec![
+            shell("Bash", "/bin/bash", ShellType::Bash),
+            shell("Zsh", "/bin/zsh", ShellType::Zsh),
+        ];
+        let resolved = select_non_windows_local_exec_shell(
+            Some(ConfiguredShellPreference::Zsh),
+            &detected,
+            &detected[0],
+        );
+
+        assert_eq!(resolved.shell_type, ShellType::Zsh);
+        assert_eq!(resolved.path, PathBuf::from("/bin/zsh"));
+    }
+}

--- a/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/mod.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/mod.rs
@@ -3,6 +3,7 @@ mod command;
 mod control;
 mod env_snapshot;
 mod input;
+mod local_shell;
 mod progress;
 mod rendering;
 mod stdin;

--- a/src/web-ui/src/infrastructure/config/components/BasicsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/BasicsConfig.tsx
@@ -558,6 +558,7 @@ function BasicsTerminalSection() {
     ],
     [t],
   );
+  const shouldShowCmdFallbackNotice = defaultShell === 'Cmd';
 
   if (loading) {
     return <ConfigPageLoading text={t('terminal.messages.loading')} />;
@@ -572,6 +573,12 @@ function BasicsTerminalSection() {
           title={t('terminal.sections.terminal')}
           description={t('terminal.sections.terminalHint')}
         >
+          {shouldShowCmdFallbackNotice && (
+            <Alert
+              type="info"
+              message={t('terminal.controls.cmdFallbackMessage')}
+            />
+          )}
           <ConfigPageRow
             label={t('terminal.sections.defaultTerminal')}
             description={t('terminal.controls.description')}

--- a/src/web-ui/src/locales/en-US/settings/basics.json
+++ b/src/web-ui/src/locales/en-US/settings/basics.json
@@ -167,7 +167,8 @@
     "controls": {
       "refreshTooltip": "Refresh available terminals",
       "autoDetect": "Auto Detect (Recommended)",
-      "description": "Default shell type for new terminals",
+      "description": "Default shell type for new terminals and for agent command execution in local workspaces.",
+      "cmdFallbackMessage": "Agent commands actually use PowerShell.",
       "placeholder": "Select default terminal",
       "noShells": "No available terminals detected"
     },

--- a/src/web-ui/src/locales/zh-CN/settings/basics.json
+++ b/src/web-ui/src/locales/zh-CN/settings/basics.json
@@ -167,7 +167,8 @@
     "controls": {
       "refreshTooltip": "刷新可用终端列表",
       "autoDetect": "自动检测 (推荐)",
-      "description": "新建终端时使用的默认 Shell 类型",
+      "description": "新建终端以及本地工作区中 agent 执行命令时使用的默认 Shell 类型。",
+      "cmdFallbackMessage": "Agent 执行命令时实际使用 PowerShell。",
       "placeholder": "选择默认终端",
       "noShells": "未检测到可用的终端"
     },

--- a/src/web-ui/src/locales/zh-TW/settings/basics.json
+++ b/src/web-ui/src/locales/zh-TW/settings/basics.json
@@ -153,7 +153,8 @@
     "controls": {
       "refreshTooltip": "重新整理可用終端列表",
       "autoDetect": "自動檢測 (推薦)",
-      "description": "新增終端時使用的默認 Shell 類型",
+      "description": "新增終端以及本地工作區中 agent 執行命令時使用的默認 Shell 類型。",
+      "cmdFallbackMessage": "Agent 執行命令時實際使用 PowerShell。",
       "placeholder": "選擇默認終端",
       "noShells": "未檢測到可用的終端"
     },


### PR DESCRIPTION
- make local ExecCommand follow the configured default terminal shell
- restrict Windows agent command shells to pwsh, powershell, and bash
- fall back from cmd to PowerShell for local agent command execution
- update settings copy to explain the actual shell used for agent commands
