### PR TITLE
fix: clarify session usage timing diagnostics

### DIFF
--- a/src/apps/desktop/src/api/session_api.rs
+++ b/src/apps/desktop/src/api/session_api.rs
@@ -132,6 +132,12 @@ pub struct GetSessionUsageReportRequest {
     pub remote_connection_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_ssh_host: Option<String>,
+    #[serde(default = "default_include_hidden_subagents")]
+    pub include_hidden_subagents: bool,
+}
+
+fn default_include_hidden_subagents() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -305,7 +311,7 @@ pub async fn get_session_usage_report(
             workspace_path: Some(storage_workspace_path.to_string_lossy().to_string()),
             remote_connection_id: request.remote_connection_id.clone(),
             remote_ssh_host: request.remote_ssh_host.clone(),
-            include_hidden_subagents: true,
+            include_hidden_subagents: request.include_hidden_subagents,
         },
     )
     .await

--- a/src/crates/assembly/core/src/service/session_usage/service.rs
+++ b/src/crates/assembly/core/src/service/session_usage/service.rs
@@ -4,7 +4,7 @@ use crate::service::session::{
 };
 use crate::service::session_usage::classifier::classify_tool_usage;
 use crate::service::session_usage::redaction::{
-    display_workspace_relative_path, redact_usage_label,
+    display_workspace_relative_path, redact_usage_input_summary, redact_usage_label,
 };
 use crate::service::session_usage::types::*;
 use crate::service::snapshot::get_snapshot_manager_for_workspace;
@@ -106,17 +106,20 @@ pub fn build_session_usage_report_from_sources(
     report.workspace = build_workspace(&request);
     report.scope = build_scope(turns, request.include_hidden_subagents);
     report.coverage = build_coverage(&request, turns, token_records, snapshot_facts);
-    report.time = build_time_breakdown(turns);
+    report.time = build_time_breakdown(turns, generated_at);
     report.tokens = build_token_breakdown(token_records);
     report.models = build_model_breakdown(turns, token_records);
     report.tools = build_tool_breakdown(turns);
     report.files = build_file_breakdown(request.workspace_path.as_deref(), turns, snapshot_facts);
     report.compression = build_compression_breakdown(turns);
     report.errors = build_error_breakdown(turns);
-    report.slowest = build_slowest_spans(turns);
+    report.slowest = build_slowest_spans(turns, token_records);
     report.privacy = UsagePrivacy {
         prompt_content_included: false,
-        tool_inputs_included: false,
+        tool_inputs_included: report
+            .slowest
+            .iter()
+            .any(|span| span.input_summary.is_some()),
         command_outputs_included: false,
         file_contents_included: false,
         redacted_fields: collect_redacted_fields(&report),
@@ -199,7 +202,7 @@ fn build_coverage(
     snapshot_facts: &UsageSnapshotFacts,
 ) -> UsageCoverage {
     let mut available = vec![UsageCoverageKey::WorkspaceIdentity];
-    if !token_records.is_empty() {
+    if request.include_hidden_subagents {
         available.push(UsageCoverageKey::SubagentScope);
     }
     if turns
@@ -233,6 +236,7 @@ fn build_coverage(
         UsageCoverageKey::CachedTokens,
         UsageCoverageKey::TokenDetailBreakdown,
         UsageCoverageKey::FileLineStats,
+        UsageCoverageKey::SubagentScope,
     ];
     if !available.contains(&UsageCoverageKey::ModelRoundTiming) {
         missing.push(UsageCoverageKey::ModelRoundTiming);
@@ -264,6 +268,9 @@ fn build_coverage(
                 .to_string(),
         );
     }
+    if missing.contains(&UsageCoverageKey::SubagentScope) {
+        notes.push("Subagent rows are excluded from this report scope.".to_string());
+    }
     if snapshot_facts.source_available {
         notes.push(
             "File line stats use cached snapshot operation summaries and do not read file bodies."
@@ -284,7 +291,7 @@ fn build_coverage(
     }
 }
 
-fn build_time_breakdown(turns: &[DialogTurnData]) -> UsageTimeBreakdown {
+fn build_time_breakdown(turns: &[DialogTurnData], generated_at: i64) -> UsageTimeBreakdown {
     if turns.is_empty() {
         return UsageTimeBreakdown {
             accounting: UsageTimeAccounting::Unavailable,
@@ -301,15 +308,20 @@ fn build_time_breakdown(turns: &[DialogTurnData]) -> UsageTimeBreakdown {
     // session/turn/model-round boundaries, not pure provider streaming
     // throughput such as first-token latency or tokens per second.
     let start = turns.iter().map(|turn| turn.start_time).min().unwrap_or(0);
+    let generated_at_ms = u64::try_from(generated_at).ok();
     let end = turns
         .iter()
-        .map(|turn| turn.end_time.unwrap_or(turn.start_time))
+        .filter_map(|turn| effective_turn_end_time(turn, generated_at_ms))
         .max()
         .unwrap_or(start);
     let wall_time_ms = end.saturating_sub(start);
     let active_intervals = turns
         .iter()
-        .filter_map(|turn| turn.end_time.map(|end| (turn.start_time, end)))
+        .filter_map(|turn| {
+            effective_turn_end_time(turn, generated_at_ms)
+                .filter(|end| *end > turn.start_time)
+                .map(|end| (turn.start_time, end))
+        })
         .collect::<Vec<_>>();
     let active_turn_ms = (!active_intervals.is_empty())
         .then(|| duration_union_ms(&active_intervals))
@@ -385,6 +397,45 @@ where
     Some(cached_sum as f64 / input_sum as f64)
 }
 
+fn effective_turn_end_time(turn: &DialogTurnData, generated_at_ms: Option<u64>) -> Option<u64> {
+    let mut end = span_end_time(turn.start_time, turn.end_time, turn.duration_ms);
+
+    for round in &turn.model_rounds {
+        end = max_optional_end(
+            end,
+            span_end_time(round.start_time, round.end_time, round.duration_ms),
+        );
+        for tool in &round.tool_items {
+            end = max_optional_end(
+                end,
+                span_end_time(tool.start_time, tool.end_time, tool_duration_ms(tool)),
+            );
+        }
+    }
+
+    if end.is_none() && turn.status == TurnStatus::InProgress {
+        end = generated_at_ms.filter(|generated_at| *generated_at > turn.start_time);
+    }
+
+    end.filter(|end| *end >= turn.start_time)
+}
+
+fn span_end_time(start_time: u64, end_time: Option<u64>, duration_ms: Option<u64>) -> Option<u64> {
+    max_optional_end(
+        end_time,
+        duration_ms.map(|duration| start_time.saturating_add(duration)),
+    )
+}
+
+fn max_optional_end(left: Option<u64>, right: Option<u64>) -> Option<u64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
+}
+
 fn build_token_breakdown(token_records: &[TokenUsageRecord]) -> UsageTokenBreakdown {
     if token_records.is_empty() {
         return UsageTokenBreakdown {
@@ -455,6 +506,7 @@ fn build_model_breakdown(
         .iter()
         .map(|turn| (turn.turn_id.as_str(), turn.turn_index))
         .collect();
+    let token_model_ids_by_turn = build_token_model_ids_by_turn(token_records);
     for record in token_records {
         let row = by_model
             .entry(record.model_id.clone())
@@ -492,7 +544,7 @@ fn build_model_breakdown(
             let Some(duration_ms) = model_round_duration_ms(round) else {
                 continue;
             };
-            let model_id = model_round_label(round);
+            let model_id = report_model_id_for_round(round, &token_model_ids_by_turn);
             let row = by_model
                 .entry(model_id.clone())
                 .or_insert_with(|| UsageModelBreakdown {
@@ -544,6 +596,45 @@ fn build_model_breakdown(
     let mut rows: Vec<_> = by_model.into_values().collect();
     rows.sort_by(|a, b| a.model_id.cmp(&b.model_id));
     rows
+}
+
+fn build_token_model_ids_by_turn(
+    token_records: &[TokenUsageRecord],
+) -> HashMap<String, BTreeSet<String>> {
+    let mut by_turn: HashMap<String, BTreeSet<String>> = HashMap::new();
+    for record in token_records {
+        by_turn
+            .entry(record.turn_id.clone())
+            .or_default()
+            .insert(record.model_id.clone());
+    }
+    by_turn
+}
+
+fn report_model_id_for_round(
+    round: &ModelRoundData,
+    token_model_ids_by_turn: &HashMap<String, BTreeSet<String>>,
+) -> String {
+    let label = model_round_label(round);
+    if is_legacy_model_identity(&label) {
+        if let Some(token_models) = token_model_ids_by_turn.get(&round.turn_id) {
+            if token_models.len() == 1 {
+                if let Some(model_id) = token_models.iter().next() {
+                    return model_id.clone();
+                }
+            }
+        }
+    }
+    label
+}
+
+fn is_legacy_model_identity(model_id: &str) -> bool {
+    let normalized = model_id.trim().to_ascii_lowercase();
+    normalized == "unknown_model"
+        || (normalized.starts_with("model round ")
+            && normalized["model round ".len()..]
+                .chars()
+                .all(|value| value.is_ascii_digit()))
 }
 
 fn build_tool_breakdown(turns: &[DialogTurnData]) -> Vec<UsageToolBreakdown> {
@@ -871,13 +962,16 @@ fn build_error_breakdown(turns: &[DialogTurnData]) -> UsageErrorBreakdown {
     }
 }
 
-fn build_slowest_spans(turns: &[DialogTurnData]) -> Vec<UsageSlowSpan> {
+fn build_slowest_spans(
+    turns: &[DialogTurnData],
+    token_records: &[TokenUsageRecord],
+) -> Vec<UsageSlowSpan> {
     let mut spans = Vec::new();
+    let token_model_ids_by_turn = build_token_model_ids_by_turn(token_records);
 
     for turn in turns {
-        if let Some(duration_ms) = turn
-            .duration_ms
-            .or_else(|| turn.end_time.map(|end| end.saturating_sub(turn.start_time)))
+        if let Some(duration_ms) =
+            effective_turn_end_time(turn, None).map(|end| end.saturating_sub(turn.start_time))
         {
             spans.push(UsageSlowSpan {
                 label: format!("turn {}", turn.turn_index),
@@ -886,18 +980,40 @@ fn build_slowest_spans(turns: &[DialogTurnData]) -> Vec<UsageSlowSpan> {
                 redacted: false,
                 turn_id: Some(turn.turn_id.clone()),
                 turn_index: Some(turn.turn_index),
+                item_id: None,
+                input_summary: None,
+                status: None,
+                timeout_seconds: None,
+                exit_code: None,
+                timed_out: None,
+                error_summary: None,
+                queue_wait_ms: None,
+                preflight_ms: None,
+                confirmation_wait_ms: None,
+                execution_ms: None,
             });
         }
 
         for round in &turn.model_rounds {
             if let Some(duration_ms) = model_round_duration_ms(round) {
                 spans.push(UsageSlowSpan {
-                    label: model_round_label(round),
+                    label: report_model_id_for_round(round, &token_model_ids_by_turn),
                     kind: UsageSlowSpanKind::Model,
                     duration_ms,
                     redacted: false,
                     turn_id: Some(turn.turn_id.clone()),
                     turn_index: Some(turn.turn_index),
+                    item_id: None,
+                    input_summary: None,
+                    status: None,
+                    timeout_seconds: None,
+                    exit_code: None,
+                    timed_out: None,
+                    error_summary: None,
+                    queue_wait_ms: None,
+                    preflight_ms: None,
+                    confirmation_wait_ms: None,
+                    execution_ms: None,
                 });
             }
         }
@@ -912,6 +1028,17 @@ fn build_slowest_spans(turns: &[DialogTurnData]) -> Vec<UsageSlowSpan> {
                     redacted: label.redacted,
                     turn_id: Some(turn.turn_id.clone()),
                     turn_index: Some(turn.turn_index),
+                    item_id: Some(tool.id.clone()),
+                    input_summary: tool_input_summary(tool),
+                    status: tool_status_summary(tool),
+                    timeout_seconds: tool_timeout_seconds(tool),
+                    exit_code: tool_exit_code(tool),
+                    timed_out: tool_timed_out(tool),
+                    error_summary: tool_error_summary(tool),
+                    queue_wait_ms: tool.queue_wait_ms,
+                    preflight_ms: tool.preflight_ms,
+                    confirmation_wait_ms: tool.confirmation_wait_ms,
+                    execution_ms: tool.execution_ms,
                 });
             }
         }
@@ -932,6 +1059,14 @@ fn collect_redacted_fields(report: &SessionUsageReport) -> Vec<String> {
     }
     if report.slowest.iter().any(|span| span.redacted) {
         fields.insert("slowest.label".to_string());
+    }
+    if report
+        .slowest
+        .iter()
+        .filter_map(|span| span.input_summary.as_deref())
+        .any(|summary| summary.contains("[redacted]"))
+    {
+        fields.insert("slowest.inputSummary".to_string());
     }
 
     let mut fields: Vec<_> = fields.into_iter().collect();
@@ -990,6 +1125,83 @@ fn tool_duration_ms(tool: &ToolItemData) -> Option<u64> {
                 .and_then(|result| result.duration_ms)
         })
         .or_else(|| tool.end_time.map(|end| end.saturating_sub(tool.start_time)))
+}
+
+fn tool_input_summary(tool: &ToolItemData) -> Option<String> {
+    let input = tool.tool_call.input.as_object()?;
+    let command = input
+        .get("command")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if let Some(command) = command {
+        return Some(redact_usage_input_summary(command, 180).value);
+    }
+
+    let url = ["url", "request_url", "endpoint"]
+        .into_iter()
+        .find_map(|field| input.get(field).and_then(|value| value.as_str()))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let method = input
+        .get("method")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let summary = method
+        .map(|method| format!("{method} {url}"))
+        .unwrap_or_else(|| url.to_string());
+    Some(redact_usage_input_summary(&summary, 180).value)
+}
+
+fn tool_timeout_seconds(tool: &ToolItemData) -> Option<u64> {
+    let input = tool.tool_call.input.as_object()?;
+    input
+        .get("timeout_seconds")
+        .and_then(|value| value.as_u64())
+        .or_else(|| {
+            input
+                .get("timeout_ms")
+                .and_then(|value| value.as_u64())
+                .map(|ms| ms.div_ceil(1000))
+        })
+}
+
+fn tool_status_summary(tool: &ToolItemData) -> Option<String> {
+    if let Some(success) = tool.tool_result.as_ref().map(|result| result.success) {
+        return Some(if success { "succeeded" } else { "failed" }.to_string());
+    }
+
+    tool.status.as_deref().map(|status| match status {
+        "completed" | "success" | "succeeded" => "succeeded".to_string(),
+        "failed" | "error" => "failed".to_string(),
+        "cancelled" | "canceled" => "cancelled".to_string(),
+        other => redact_usage_label(other, 80).value,
+    })
+}
+
+fn tool_exit_code(tool: &ToolItemData) -> Option<i64> {
+    tool.tool_result
+        .as_ref()
+        .and_then(|result| result.result.get("exit_code"))
+        .and_then(|value| value.as_i64())
+}
+
+fn tool_timed_out(tool: &ToolItemData) -> Option<bool> {
+    tool.tool_result
+        .as_ref()
+        .and_then(|result| result.result.get("timed_out"))
+        .and_then(|value| value.as_bool())
+}
+
+fn tool_error_summary(tool: &ToolItemData) -> Option<String> {
+    let error = tool
+        .tool_result
+        .as_ref()
+        .and_then(|result| result.error.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    Some(redact_usage_label(error, 180).value)
 }
 
 fn add_optional_duration(total: &mut Option<u64>, value: Option<u64>) {
@@ -1206,6 +1418,51 @@ mod tests {
     }
 
     #[test]
+    fn report_active_runtime_includes_incomplete_turn_child_spans() {
+        let request = test_request(None);
+        let mut completed = test_turn("turn-1", 0, DialogTurnKind::UserDialog);
+        completed.start_time = 1_000;
+        completed.end_time = Some(61_000);
+        completed.duration_ms = Some(60_000);
+        completed.model_rounds[0].start_time = 2_000;
+        completed.model_rounds[0].end_time = Some(12_000);
+        completed.model_rounds[0].duration_ms = Some(10_000);
+        completed.model_rounds[0].tool_items.clear();
+
+        let mut incomplete = test_turn("turn-2", 1, DialogTurnKind::UserDialog);
+        incomplete.start_time = 121_000;
+        incomplete.end_time = None;
+        incomplete.duration_ms = None;
+        incomplete.model_rounds[0].start_time = 122_000;
+        incomplete.model_rounds[0].end_time = Some(181_000);
+        incomplete.model_rounds[0].duration_ms = Some(59_000);
+        incomplete.model_rounds[0].tool_items = vec![test_tool_item_with_input(
+            "slow-bash",
+            "Bash",
+            Some(true),
+            120_000,
+            serde_json::json!({
+                "command": "pnpm install",
+                "timeout_seconds": 300
+            }),
+        )];
+        incomplete.model_rounds[0].tool_items[0].start_time = 181_000;
+        incomplete.model_rounds[0].tool_items[0].end_time = Some(301_000);
+
+        let report = build_session_usage_report_from_turns(
+            request,
+            &[completed, incomplete],
+            &[],
+            1_778_347_200_000,
+        );
+
+        assert_eq!(report.time.accounting, UsageTimeAccounting::Approximate);
+        assert_eq!(report.time.wall_time_ms, Some(300_000));
+        assert_eq!(report.time.active_turn_ms, Some(240_000));
+        assert_eq!(report.time.tool_ms, Some(120_000));
+    }
+
+    #[test]
     fn report_excludes_local_command_turns_from_usage_metrics() {
         let request = test_request(None);
         let mut user_turn = test_turn("turn-1", 0, DialogTurnKind::UserDialog);
@@ -1278,6 +1535,42 @@ mod tests {
             span.kind == UsageSlowSpanKind::Model
                 && span.label == "model-b"
                 && span.duration_ms == 140
+        }));
+    }
+
+    #[test]
+    fn report_merges_legacy_model_timing_into_token_model_row_for_same_turn() {
+        let request = test_request(None);
+        let mut turn = test_turn("turn-1", 0, DialogTurnKind::UserDialog);
+        turn.model_rounds[0].model_id = None;
+        turn.model_rounds[0].model_alias = None;
+        turn.model_rounds[0].duration_ms = Some(180);
+        let token_record = test_token_record("gpt-5.4", 120, 30, 0);
+
+        let report = build_session_usage_report_from_turns(
+            request,
+            &[turn],
+            &[token_record],
+            1_778_347_200_000,
+        );
+
+        assert_eq!(
+            report
+                .models
+                .iter()
+                .map(|model| (
+                    model.model_id.as_str(),
+                    model.call_count,
+                    model.duration_ms,
+                    model.total_tokens
+                ))
+                .collect::<Vec<_>>(),
+            vec![("gpt-5.4", 1, Some(180), Some(150))]
+        );
+        assert!(report.slowest.iter().any(|span| {
+            span.kind == UsageSlowSpanKind::Model
+                && span.label == "gpt-5.4"
+                && span.duration_ms == 180
         }));
     }
 
@@ -1557,6 +1850,145 @@ mod tests {
             .coverage
             .missing
             .contains(&UsageCoverageKey::ToolPhaseTiming));
+    }
+
+    #[test]
+    fn report_slowest_tool_spans_include_diagnostic_fields() {
+        let request = test_request(None);
+        let mut slow = test_tool_item_with_input(
+            "tool-slow",
+            "Bash",
+            Some(false),
+            95_000,
+            serde_json::json!({
+                "command": "curl https://api.example.test/slow",
+                "timeout_seconds": 90
+            }),
+        );
+        slow.queue_wait_ms = Some(5);
+        slow.preflight_ms = Some(10);
+        slow.confirmation_wait_ms = Some(15);
+        slow.execution_ms = Some(94_970);
+        slow.tool_result = Some(ToolResultData {
+            result: serde_json::json!({
+                "exit_code": 28,
+                "timed_out": true,
+                "stderr": "operation timed out"
+            }),
+            success: false,
+            result_for_assistant: None,
+            error: Some("operation timed out".to_string()),
+            duration_ms: Some(95_000),
+        });
+        let turn = test_turn_with_tools("turn-1", 0, DialogTurnKind::UserDialog, vec![slow]);
+
+        let report =
+            build_session_usage_report_from_turns(request, &[turn], &[], 1_778_347_200_000);
+        let span = report
+            .slowest
+            .iter()
+            .find(|span| span.kind == UsageSlowSpanKind::Tool)
+            .expect("slow tool span");
+
+        assert_eq!(span.item_id.as_deref(), Some("tool-slow"));
+        assert_eq!(
+            span.input_summary.as_deref(),
+            Some("curl https://api.example.test/slow")
+        );
+        assert_eq!(span.status.as_deref(), Some("failed"));
+        assert_eq!(span.exit_code, Some(28));
+        assert_eq!(span.timed_out, Some(true));
+        assert_eq!(span.error_summary.as_deref(), Some("operation timed out"));
+        assert_eq!(span.execution_ms, Some(94_970));
+    }
+
+    #[test]
+    fn report_slowest_tool_spans_summarize_url_inputs() {
+        let request = test_request(None);
+        let slow = test_tool_item_with_input(
+            "tool-slow-url",
+            "web_fetch",
+            Some(true),
+            95_000,
+            serde_json::json!({
+                "method": "GET",
+                "url": "https://api.example.test/slow"
+            }),
+        );
+        let turn = test_turn_with_tools("turn-1", 0, DialogTurnKind::UserDialog, vec![slow]);
+
+        let report =
+            build_session_usage_report_from_turns(request, &[turn], &[], 1_778_347_200_000);
+        let span = report
+            .slowest
+            .iter()
+            .find(|span| span.item_id.as_deref() == Some("tool-slow-url"))
+            .expect("slow URL tool span");
+
+        assert_eq!(
+            span.input_summary.as_deref(),
+            Some("GET https://api.example.test/slow")
+        );
+    }
+
+    #[test]
+    fn report_slowest_tool_input_summary_redacts_common_secrets() {
+        let request = test_request(None);
+        let slow_command = test_tool_item_with_input(
+            "tool-secret-command",
+            "Bash",
+            Some(true),
+            95_000,
+            serde_json::json!({
+                "command": "curl -H 'Authorization: Bearer sk-secret' https://api.example.test --api-key abc123"
+            }),
+        );
+        let slow_url = test_tool_item_with_input(
+            "tool-secret-url",
+            "web_fetch",
+            Some(true),
+            94_000,
+            serde_json::json!({
+                "method": "GET",
+                "url": "https://api.example.test/slow?token=secret-token&x=1"
+            }),
+        );
+        let turn = test_turn_with_tools(
+            "turn-1",
+            0,
+            DialogTurnKind::UserDialog,
+            vec![slow_command, slow_url],
+        );
+
+        let report =
+            build_session_usage_report_from_turns(request, &[turn], &[], 1_778_347_200_000);
+        let command_span = report
+            .slowest
+            .iter()
+            .find(|span| span.item_id.as_deref() == Some("tool-secret-command"))
+            .expect("slow command span");
+        let url_span = report
+            .slowest
+            .iter()
+            .find(|span| span.item_id.as_deref() == Some("tool-secret-url"))
+            .expect("slow URL span");
+
+        let command_summary = command_span
+            .input_summary
+            .as_deref()
+            .expect("command summary");
+        assert!(command_summary.contains("Authorization: Bearer [redacted]"));
+        assert!(command_summary.contains("--api-key [redacted]"));
+        assert!(!command_summary.contains("sk-secret"));
+        assert!(!command_summary.contains("abc123"));
+        assert_eq!(
+            url_span.input_summary.as_deref(),
+            Some("GET https://api.example.test/slow?token=[redacted]&x=1")
+        );
+        assert!(report
+            .privacy
+            .redacted_fields
+            .contains(&"slowest.inputSummary".to_string()));
     }
 
     #[test]

--- a/src/crates/services/services-core/src/session_usage/redaction.rs
+++ b/src/crates/services/services-core/src/session_usage/redaction.rs
@@ -1,3 +1,6 @@
+use regex::Regex;
+use std::sync::OnceLock;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RedactedLabel {
     pub value: String,
@@ -29,6 +32,13 @@ pub fn redact_usage_label(input: &str, max_chars: usize) -> RedactedLabel {
     RedactedLabel { value, redacted }
 }
 
+pub fn redact_usage_input_summary(input: &str, max_chars: usize) -> RedactedLabel {
+    let sanitized = redact_sensitive_input_fragments(input);
+    let mut label = redact_usage_label(&sanitized, max_chars);
+    label.redacted |= sanitized != input;
+    label
+}
+
 pub fn display_workspace_relative_path(
     workspace_root: Option<&str>,
     raw_path: &str,
@@ -56,6 +66,29 @@ fn normalize_path(path: &str) -> String {
     path.replace('\\', "/")
 }
 
+fn redact_sensitive_input_fragments(input: &str) -> String {
+    sensitive_input_patterns()
+        .iter()
+        .fold(input.to_string(), |value, pattern| {
+            pattern.replace_all(&value, "${1}[redacted]").into_owned()
+        })
+}
+
+fn sensitive_input_patterns() -> &'static [Regex] {
+    static PATTERNS: OnceLock<Vec<Regex>> = OnceLock::new();
+    PATTERNS.get_or_init(|| {
+        [
+            r#"(?i)\b(authorization\s*:\s*(?:(?:bearer|basic)\s+)?)[^\s"'`]+"#,
+            r#"(?i)\b(x-api-key\s*:\s*)[^\s"'`]+"#,
+            r#"(?i)\b((?:api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|secret|password|passwd|pwd|token)\s*=\s*)[^&\s"'`]+"#,
+            r#"(?i)(--(?:api-key|access-token|refresh-token|id-token|client-secret|secret|password|token)\s+)[^&\s"'`]+"#,
+        ]
+        .into_iter()
+        .map(|pattern| Regex::new(pattern).expect("valid usage input redaction pattern"))
+        .collect()
+    })
+}
+
 fn truncate_chars(input: &str, max_chars: usize) -> String {
     if max_chars <= 3 {
         return ".".repeat(max_chars);
@@ -79,6 +112,23 @@ mod tests {
         assert_eq!(redacted.value.len(), 12);
         assert!(!redacted.value.contains('\n'));
         assert!(!redacted.value.contains('\t'));
+    }
+
+    #[test]
+    fn redact_usage_input_summary_masks_common_secret_fragments() {
+        let redacted = redact_usage_input_summary(
+            "curl -H 'Authorization: Bearer sk-secret' https://api.example.test?token=abc&x=1 --api-key xyz",
+            240,
+        );
+
+        assert!(redacted.redacted);
+        assert_eq!(
+            redacted.value,
+            "curl -H 'Authorization: Bearer [redacted]' https://api.example.test?token=[redacted]&x=1 --api-key [redacted]"
+        );
+        assert!(!redacted.value.contains("sk-secret"));
+        assert!(!redacted.value.contains("token=abc"));
+        assert!(!redacted.value.contains("xyz"));
     }
 
     #[test]

--- a/src/crates/services/services-core/src/session_usage/render.rs
+++ b/src/crates/services/services-core/src/session_usage/render.rs
@@ -79,15 +79,21 @@ pub fn render_usage_report_terminal(report: &SessionUsageReport) -> String {
     if !report.slowest.is_empty() {
         out.push("Slowest spans:".to_string());
         for span in &report.slowest {
+            let details = slow_span_details(span);
             out.push(format!(
-                "- {} [{}]: {}",
+                "- {} [{}]: {}{}",
                 if span.redacted {
                     "redacted"
                 } else {
                     &span.label
                 },
                 slow_span_kind_label(&span.kind),
-                format_duration(span.duration_ms)
+                format_duration(span.duration_ms),
+                if details.is_empty() {
+                    String::new()
+                } else {
+                    format!(" ({})", details)
+                }
             ));
         }
     }
@@ -281,17 +287,18 @@ pub fn render_usage_report_markdown(report: &SessionUsageReport) -> String {
 
     if !report.slowest.is_empty() {
         out.push_str("## Slowest Spans\n\n");
-        out.push_str("| Label | Kind | Duration |\n| --- | --- | --- |\n");
+        out.push_str("| Label | Kind | Duration | Details |\n| --- | --- | --- | --- |\n");
         for span in &report.slowest {
             out.push_str(&format!(
-                "| {} | {} | {} |\n",
+                "| {} | {} | {} | {} |\n",
                 if span.redacted {
                     "redacted".to_string()
                 } else {
                     escape_markdown(&span.label)
                 },
                 slow_span_kind_label(&span.kind),
-                format_duration(span.duration_ms)
+                format_duration(span.duration_ms),
+                escape_markdown(&slow_span_details(span))
             ));
         }
         out.push('\n');
@@ -306,12 +313,62 @@ pub fn render_usage_report_markdown(report: &SessionUsageReport) -> String {
     }
 
     out.push_str("## Privacy\n\n");
-    out.push_str("- Prompt content included: no\n");
-    out.push_str("- Tool inputs included: no\n");
-    out.push_str("- Command outputs included: no\n");
-    out.push_str("- File contents included: no\n");
+    out.push_str(&format!(
+        "- Prompt content included: {}\n",
+        yes_no(report.privacy.prompt_content_included)
+    ));
+    out.push_str(&format!(
+        "- Tool inputs included: {}\n",
+        yes_no(report.privacy.tool_inputs_included)
+    ));
+    out.push_str(&format!(
+        "- Command outputs included: {}\n",
+        yes_no(report.privacy.command_outputs_included)
+    ));
+    out.push_str(&format!(
+        "- File contents included: {}\n",
+        yes_no(report.privacy.file_contents_included)
+    ));
 
     out
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+fn slow_span_details(span: &UsageSlowSpan) -> String {
+    if span.redacted {
+        return String::new();
+    }
+
+    let mut parts = Vec::new();
+    if let Some(input) = span.input_summary.as_deref() {
+        parts.push(format!("input: {}", input));
+    }
+    if let Some(status) = span.status.as_deref() {
+        parts.push(format!("status: {}", status));
+    }
+    if let Some(timeout_seconds) = span.timeout_seconds {
+        parts.push(format!("timeout: {}s", timeout_seconds));
+    }
+    if let Some(exit_code) = span.exit_code {
+        parts.push(format!("exit code: {}", exit_code));
+    }
+    if span.timed_out == Some(true) {
+        parts.push("timed out".to_string());
+    }
+    if let Some(execution_ms) = span.execution_ms {
+        parts.push(format!("execution: {}", format_duration(execution_ms)));
+    }
+    if let Some(error) = span.error_summary.as_deref() {
+        parts.push(format!("error: {}", error));
+    }
+    parts.join("; ")
 }
 
 fn format_optional_number(value: Option<u64>) -> String {
@@ -475,6 +532,17 @@ mod tests {
             redacted: true,
             turn_id: None,
             turn_index: None,
+            item_id: None,
+            input_summary: None,
+            status: None,
+            timeout_seconds: None,
+            exit_code: None,
+            timed_out: None,
+            error_summary: None,
+            queue_wait_ms: None,
+            preflight_ms: None,
+            confirmation_wait_ms: None,
+            execution_ms: None,
         });
 
         let rendered = render_usage_report_markdown(&report);

--- a/src/crates/services/services-core/src/session_usage/types.rs
+++ b/src/crates/services/services-core/src/session_usage/types.rs
@@ -314,6 +314,28 @@ pub struct UsageSlowSpan {
     pub turn_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_index: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timed_out: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queue_wait_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preflight_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confirmation_wait_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsageComponents.test.tsx
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsageComponents.test.tsx
@@ -145,6 +145,16 @@ vi.mock('react-i18next', async (importOriginal) => ({
         'usage.help.errorExampleCount': 'Number of matching errors.',
         'usage.help.slowestSpans': 'Slow spans are derived from recorded turn, model, and tool timestamps. They help identify time sinks, not exact provider latency.',
         'usage.help.slowestModelCall': 'Model call in this turn. Model: {{model}}.',
+        'usage.help.slowestToolCall': 'Tool call details identify whether time was spent waiting, confirming, or executing.',
+        'usage.slowest.details.input': 'Input',
+        'usage.slowest.details.status': 'Status',
+        'usage.slowest.details.exitCode': 'Exit code',
+        'usage.slowest.details.timedOut': 'Timed out',
+        'usage.slowest.details.execution': 'Execution',
+        'usage.slowest.details.error': 'Error',
+        'usage.status.timedOut': 'Timed out',
+        'shared:statuses.failed': 'Failed',
+        'shared:statuses.done': 'Done',
         'usage.meta.generatedAt': 'Generated',
         'usage.meta.sessionId': 'Session ID',
         'usage.meta.workspacePath': 'Project path',
@@ -277,7 +287,15 @@ const USAGE_LOCALE_REQUIRED_KEYS = [
   'usage.help.errorExampleCount',
   'usage.help.slowestSpans',
   'usage.help.slowestModelCall',
+  'usage.help.slowestToolCall',
   'usage.panel.errorScope',
+  'usage.slowest.details.input',
+  'usage.slowest.details.status',
+  'usage.slowest.details.exitCode',
+  'usage.slowest.details.timedOut',
+  'usage.slowest.details.execution',
+  'usage.slowest.details.error',
+  'usage.status.timedOut',
   'usage.tabs.slowest',
   'usage.table.actions',
   'usage.table.kind',
@@ -1456,6 +1474,69 @@ describe('Session usage report UI components', () => {
         turnId: 'turn-2',
         behavior: 'smooth',
         pinMode: 'transient',
+        source: 'usage-report',
+      },
+    ]);
+    unsubscribe();
+  });
+
+  it('shows diagnostic details for slow tool spans and jumps to the exact tool item', () => {
+    const report = usageReport({
+      slowest: [
+        {
+          label: 'Bash',
+          kind: 'tool',
+          durationMs: 95_000,
+          redacted: false,
+          turnId: 'turn-2',
+          turnIndex: 2,
+          itemId: 'tool-slow',
+          inputSummary: 'curl https://api.example.test/slow',
+          status: 'failed',
+          exitCode: 28,
+          timedOut: true,
+          executionMs: 94_970,
+          errorSummary: 'operation timed out',
+        },
+      ],
+    });
+
+    const focusEvents: FlowChatFocusItemRequest[] = [];
+    const unsubscribe = globalEventBus.on<FlowChatFocusItemRequest>(
+      FLOWCHAT_FOCUS_ITEM_EVENT,
+      event => focusEvents.push(event),
+    );
+
+    render(<SessionUsagePanel report={report} markdown="## Session Usage" sessionId="session-1" />);
+
+    const slowestTab = Array.from(container.querySelectorAll('.session-usage-panel__tab'))
+      .find(button => button.textContent === 'Slowest');
+    act(() => {
+      slowestTab?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('Bash');
+    expect(container.textContent).toContain('Input');
+    expect(container.textContent).toContain('curl https://api.example.test/slow');
+    expect(container.textContent).toContain('Status');
+    expect(container.textContent).toContain('Failed');
+    expect(container.textContent).toContain('Exit code');
+    expect(container.textContent).toContain('28');
+    expect(container.textContent).toContain('Timed out');
+    expect(container.textContent).toContain('Execution');
+    expect(container.textContent).toContain('1m 35s');
+    expect(container.textContent).toContain('operation timed out');
+
+    const toolLink = container.querySelector<HTMLButtonElement>('.session-usage-panel__turn-link');
+    act(() => {
+      toolLink?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(focusEvents).toEqual([
+      {
+        sessionId: 'session-1',
+        turnIndex: 2,
+        itemId: 'tool-slow',
         source: 'usage-report',
       },
     ]);

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsagePanel.scss
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsagePanel.scss
@@ -544,6 +544,38 @@
     }
   }
 
+  &__slow-span {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  &__slow-span-details {
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    gap: 3px 8px;
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: var(--flowchat-font-size-xs);
+    line-height: var(--flowchat-compact-line-height, 1.32);
+
+    > div {
+      display: contents;
+    }
+
+    dt {
+      color: var(--color-text-secondary);
+      white-space: nowrap;
+    }
+
+    dd {
+      min-width: 0;
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
+  }
+
   &__turn-indexes {
     display: inline-flex;
     align-items: center;

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsagePanel.tsx
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsagePanel.tsx
@@ -53,6 +53,7 @@ import type { SessionUsagePanelTab } from './sessionUsagePanelTypes';
 import './SessionUsagePanel.scss';
 
 const log = createLogger('SessionUsagePanel');
+type UsageTranslator = (key: string, options?: Record<string, unknown>) => string;
 interface SessionUsagePanelProps {
   report?: SessionUsageReport;
   markdown?: string;
@@ -1076,8 +1077,21 @@ function getUsageFileName(filePath: string): string {
 
 function UsageSlowest({ report, sessionId }: { report: SessionUsageReport; sessionId?: string }) {
   const { t } = useTranslation('flow-chat');
-  const handleJumpToTurn = useCallback((span: SessionUsageReport['slowest'][number]) => {
-    if (!sessionId || !span.turnId) return;
+  const handleJumpToSpan = useCallback((span: SessionUsageReport['slowest'][number]) => {
+    if (!sessionId) return;
+
+    if (span.itemId && typeof span.turnIndex === 'number') {
+      const request: FlowChatFocusItemRequest = {
+        sessionId,
+        turnIndex: span.turnIndex,
+        itemId: span.itemId,
+        source: 'usage-report',
+      };
+      globalEventBus.emit(FLOWCHAT_FOCUS_ITEM_EVENT, request, 'SessionUsagePanel');
+      return;
+    }
+
+    if (!span.turnId) return;
 
     const request: FlowChatPinTurnToTopRequest = {
       sessionId,
@@ -1113,21 +1127,37 @@ function UsageSlowest({ report, sessionId }: { report: SessionUsageReport; sessi
         rows={report.slowest.map((span, index) => {
           const spanHelp = getSlowSpanHelp(span, t);
           const spanLabel = getSlowSpanLabel(span, t);
-          const canJumpToTurn = Boolean(sessionId && span.turnId);
+          const detailRows = getSlowSpanDetailRows(span, t);
+          const canJumpToSpan = Boolean(
+            sessionId &&
+            (span.turnId || (span.itemId && typeof span.turnIndex === 'number'))
+          );
           const jumpHelp = t('usage.actions.jumpToTurn');
-          const labelCell: UsageTableCell = canJumpToTurn
+          const labelCell: UsageTableCell = canJumpToSpan
             ? {
               node: (
-                <Tooltip content={spanHelp ? `${spanHelp} ${jumpHelp}` : jumpHelp}>
-                  <button
-                    type="button"
-                    className="session-usage-panel__turn-link"
-                    onClick={() => handleJumpToTurn(span)}
-                    aria-label={`${jumpHelp}: ${spanLabel}`}
-                  >
-                    {spanLabel}
-                  </button>
-                </Tooltip>
+                <div className="session-usage-panel__slow-span">
+                  <Tooltip content={spanHelp ? `${spanHelp} ${jumpHelp}` : jumpHelp}>
+                    <button
+                      type="button"
+                      className="session-usage-panel__turn-link"
+                      onClick={() => handleJumpToSpan(span)}
+                      aria-label={`${jumpHelp}: ${spanLabel}`}
+                    >
+                      {spanLabel}
+                    </button>
+                  </Tooltip>
+                  {detailRows.length > 0 && (
+                    <dl className="session-usage-panel__slow-span-details">
+                      {detailRows.map(row => (
+                        <div key={row.label}>
+                          <dt>{row.label}</dt>
+                          <dd>{row.value}</dd>
+                        </div>
+                      ))}
+                    </dl>
+                  )}
+                </div>
               ),
             }
             : spanHelp
@@ -1145,6 +1175,70 @@ function UsageSlowest({ report, sessionId }: { report: SessionUsageReport; sessi
       />
     </section>
   );
+}
+
+function getSlowSpanDetailRows(
+  span: SessionUsageReport['slowest'][number],
+  t: UsageTranslator
+): Array<{ label: string; value: string }> {
+  if (span.kind !== 'tool' || span.redacted) {
+    return [];
+  }
+
+  const rows: Array<{ label: string; value: string }> = [];
+  if (span.inputSummary) {
+    rows.push({
+      label: t('usage.slowest.details.input'),
+      value: span.inputSummary,
+    });
+  }
+  if (span.status) {
+    rows.push({
+      label: t('usage.slowest.details.status'),
+      value: getSlowToolStatusLabel(span.status, t),
+    });
+  }
+  if (typeof span.exitCode === 'number') {
+    rows.push({
+      label: t('usage.slowest.details.exitCode'),
+      value: String(span.exitCode),
+    });
+  }
+  if (span.timedOut === true) {
+    rows.push({
+      label: t('usage.slowest.details.timedOut'),
+      value: t('usage.status.timedOut'),
+    });
+  }
+  if (typeof span.executionMs === 'number') {
+    rows.push({
+      label: t('usage.slowest.details.execution'),
+      value: formatUsageDuration(span.executionMs, t),
+    });
+  }
+  if (span.errorSummary) {
+    rows.push({
+      label: t('usage.slowest.details.error'),
+      value: span.errorSummary,
+    });
+  }
+  return rows;
+}
+
+function getSlowToolStatusLabel(
+  status: string,
+  t: UsageTranslator
+): string {
+  if (status === 'failed') {
+    return t('shared:statuses.failed');
+  }
+  if (status === 'succeeded') {
+    return t('shared:statuses.done');
+  }
+  if (status === 'timed_out') {
+    return t('usage.status.timedOut');
+  }
+  return status;
 }
 
 interface UsageTableProps {

--- a/src/web-ui/src/flow_chat/components/usage/usageReportUtils.test.ts
+++ b/src/web-ui/src/flow_chat/components/usage/usageReportUtils.test.ts
@@ -123,6 +123,7 @@ describe('usageReportUtils', () => {
   it('does not calculate timing shares when model time is missing', () => {
     expect(calculateShare(undefined, 8_000)).toBeUndefined();
     expect(calculateShare(4_000, 8_000)).toBe(50);
+    expect(calculateShare(12_000, 8_000)).toBe(150);
   });
 
   it('labels empty file activity as no file changes', () => {
@@ -154,6 +155,8 @@ describe('usageReportUtils', () => {
     expect(getModelLabel('gpt-5.4', t, 'inferred_session_model')).toBe('gpt-5.4 (inferred)');
     expect(getModelLabel('019e0c07-c7bc-73f1-b1d6-5260ed215fe0', t, 'inferred_session_model'))
       .toBe('Legacy model not tracked');
+    expect(getModelLabel('model_1780555920188_0', t, 'inferred_session_model'))
+      .toBe('Legacy model not tracked');
     expect(getSlowSpanLabel({
       label: 'gpt-5.4',
       kind: 'model',
@@ -167,6 +170,8 @@ describe('usageReportUtils', () => {
   it('returns model identity tooltip copy when the source is inferred or legacy', () => {
     expect(getModelHelp('inferred_session_model', t)).toBe('Inferred from the session model setting.');
     expect(getModelHelp('inferred_session_model', t, '019e0c07-c7bc-73f1-b1d6-5260ed215fe0'))
+      .toBe('Older sessions did not store per-round model names.');
+    expect(getModelHelp('inferred_session_model', t, 'model_1780555920188_0'))
       .toBe('Older sessions did not store per-round model names.');
     expect(getModelHelp('legacy_missing', t)).toBe('Older sessions did not store per-round model names.');
     expect(getModelHelp(undefined, t, 'model round 0')).toBe('Older sessions did not store per-round model names.');

--- a/src/web-ui/src/flow_chat/components/usage/usageReportUtils.ts
+++ b/src/web-ui/src/flow_chat/components/usage/usageReportUtils.ts
@@ -126,7 +126,7 @@ export function calculateShare(part: number | undefined, denominator: number | u
   ) {
     return undefined;
   }
-  return Math.min(100, Math.max(0, (part / denominator) * 100));
+  return Math.max(0, (part / denominator) * 100);
 }
 
 export function getCoverageLabel(level: SessionUsageReport['coverage']['level'], t: Translator): string {
@@ -239,7 +239,8 @@ export function getSlowSpanHelp(
 
 function isOpaqueModelIdentifier(modelId: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(modelId) ||
-    /^[0-9a-f]{32}$/i.test(modelId);
+    /^[0-9a-f]{32}$/i.test(modelId) ||
+    /^model_\d+(?:_\d+)+$/i.test(modelId);
 }
 
 function isLegacyModelRoundLabel(modelId: string | undefined): boolean {

--- a/src/web-ui/src/flow_chat/services/usageReportService.test.ts
+++ b/src/web-ui/src/flow_chat/services/usageReportService.test.ts
@@ -156,6 +156,13 @@ describe('runUsageReportCommand', () => {
       reportId: 'usage-report-1',
       usageReportStatus: 'completed',
     });
+    expect(sessionApiMocks.getSessionUsageReport).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      workspacePath: 'D:/workspace/BitFun',
+      remoteConnectionId: undefined,
+      remoteSshHost: undefined,
+      includeHiddenSubagents: true,
+    });
     expect(sessionApiMocks.saveSessionTurn).toHaveBeenCalledTimes(1);
   });
 
@@ -214,52 +221,57 @@ describe('runUsageReportCommand', () => {
   });
 
   it('does not infer legacy model rows from opaque session model identifiers', async () => {
-    const opaqueModelId = '019e0c07-c7bc-73f1-b1d6-5260ed215fe0';
-    const session = createSession({
-      config: { agentType: 'agentic', modelName: opaqueModelId },
-    });
-    flowChatStore.setState((): FlowChatState => ({
-      sessions: new Map([['session-1', session]]),
-      activeSessionId: 'session-1',
-    }));
-    sessionApiMocks.getSessionUsageReport.mockResolvedValue(usageReport({
-      models: [{
-        modelId: 'unknown_model',
-        callCount: 1,
-        durationMs: 120,
-      }],
-      slowest: [{
-        label: 'unknown_model',
-        kind: 'model',
-        durationMs: 120,
-        redacted: false,
-      }],
-    }));
     const { runUsageReportCommand } = await import('./usageReportService');
 
-    const result = await runUsageReportCommand({
-      session,
-      isProcessing: false,
-      busyMessage: 'busy',
-      noWorkspaceMessage: 'missing workspace',
-      failedTitle: 'failed',
-      unknownErrorMessage: 'unknown',
-      loadingMarkdown: 'Generating usage report...',
-    });
+    for (const opaqueModelId of [
+      '019e0c07-c7bc-73f1-b1d6-5260ed215fe0',
+      'model_1780555920188_0',
+    ]) {
+      const session = createSession({
+        config: { agentType: 'agentic', modelName: opaqueModelId },
+      });
+      flowChatStore.setState((): FlowChatState => ({
+        sessions: new Map([['session-1', session]]),
+        activeSessionId: 'session-1',
+      }));
+      sessionApiMocks.getSessionUsageReport.mockResolvedValueOnce(usageReport({
+        models: [{
+          modelId: 'unknown_model',
+          callCount: 1,
+          durationMs: 120,
+        }],
+        slowest: [{
+          label: 'unknown_model',
+          kind: 'model',
+          durationMs: 120,
+          redacted: false,
+        }],
+      }));
 
-    expect(result.report?.models[0]).toMatchObject({
-      modelId: 'unknown_model',
-      modelIdSource: 'legacy_missing',
-    });
-    expect(result.report?.slowest[0]).toMatchObject({
-      label: 'unknown_model',
-      modelIdSource: 'legacy_missing',
-    });
+      const result = await runUsageReportCommand({
+        session,
+        isProcessing: false,
+        busyMessage: 'busy',
+        noWorkspaceMessage: 'missing workspace',
+        failedTitle: 'failed',
+        unknownErrorMessage: 'unknown',
+        loadingMarkdown: 'Generating usage report...',
+      });
 
-    const finalTurn = flowChatStore.getState().sessions.get('session-1')?.dialogTurns[0];
-    expect(finalTurn?.userMessage.content).toContain('Legacy model not tracked');
-    expect(finalTurn?.userMessage.content).not.toContain(opaqueModelId);
-    expect(finalTurn?.userMessage.content).not.toContain('(inferred)');
+      expect(result.report?.models[0]).toMatchObject({
+        modelId: 'unknown_model',
+        modelIdSource: 'legacy_missing',
+      });
+      expect(result.report?.slowest[0]).toMatchObject({
+        label: 'unknown_model',
+        modelIdSource: 'legacy_missing',
+      });
+
+      const finalTurn = flowChatStore.getState().sessions.get('session-1')?.dialogTurns[0];
+      expect(finalTurn?.userMessage.content).toContain('Legacy model not tracked');
+      expect(finalTurn?.userMessage.content).not.toContain(opaqueModelId);
+      expect(finalTurn?.userMessage.content).not.toContain('(inferred)');
+    }
   });
 
   it('treats legacy model round placeholders as missing model identity', async () => {

--- a/src/web-ui/src/flow_chat/services/usageReportService.ts
+++ b/src/web-ui/src/flow_chat/services/usageReportService.ts
@@ -57,6 +57,7 @@ export async function runUsageReportCommand(
       workspacePath: params.session.workspacePath,
       remoteConnectionId: params.session.remoteConnectionId,
       remoteSshHost: params.session.remoteSshHost,
+      includeHiddenSubagents: true,
     });
     const report = enrichUsageReportModelIdentity(rawReport, params.session);
     const markdown = renderUsageReportMarkdown(report);
@@ -242,10 +243,10 @@ export function renderUsageReportMarkdown(report: SessionUsageReport): string {
     lines.push(
       '## Slowest Spans',
       '',
-      '| Label | Kind | Duration |',
-      '| --- | --- | --- |',
+      '| Label | Kind | Duration | Details |',
+      '| --- | --- | --- | --- |',
       ...report.slowest.map(span =>
-        `| ${span.redacted ? 'redacted' : escapeMarkdown(formatUsageMarkdownLabel(span.label, span.modelIdSource))} | ${span.kind} | ${formatDuration(span.durationMs)} |`
+        `| ${span.redacted ? 'redacted' : escapeMarkdown(formatUsageMarkdownLabel(span.label, span.modelIdSource))} | ${span.kind} | ${formatDuration(span.durationMs)} | ${escapeMarkdown(formatSlowSpanDetails(span))} |`
       ),
       '',
     );
@@ -263,10 +264,10 @@ export function renderUsageReportMarkdown(report: SessionUsageReport): string {
   lines.push(
     '## Privacy',
     '',
-    '- Prompt content included: no',
-    '- Tool inputs included: no',
-    '- Command outputs included: no',
-    '- File contents included: no',
+    `- Prompt content included: ${yesNo(report.privacy.promptContentIncluded)}`,
+    `- Tool inputs included: ${yesNo(report.privacy.toolInputsIncluded)}`,
+    `- Command outputs included: ${yesNo(report.privacy.commandOutputsIncluded)}`,
+    `- File contents included: ${yesNo(report.privacy.fileContentsIncluded)}`,
   );
 
   return lines.join('\n');
@@ -318,6 +319,40 @@ function formatDuration(value: number | undefined): string {
   return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`;
 }
 
+function yesNo(value: boolean): string {
+  return value ? 'yes' : 'no';
+}
+
+function formatSlowSpanDetails(span: SessionUsageReport['slowest'][number]): string {
+  if (span.redacted) {
+    return '';
+  }
+
+  const parts: string[] = [];
+  if (span.inputSummary) {
+    parts.push(`input: ${span.inputSummary}`);
+  }
+  if (span.status) {
+    parts.push(`status: ${span.status}`);
+  }
+  if (typeof span.timeoutSeconds === 'number') {
+    parts.push(`timeout: ${span.timeoutSeconds}s`);
+  }
+  if (typeof span.exitCode === 'number') {
+    parts.push(`exit code: ${span.exitCode}`);
+  }
+  if (span.timedOut === true) {
+    parts.push('timed out');
+  }
+  if (typeof span.executionMs === 'number') {
+    parts.push(`execution: ${formatDuration(span.executionMs)}`);
+  }
+  if (span.errorSummary) {
+    parts.push(`error: ${span.errorSummary}`);
+  }
+  return parts.join('; ');
+}
+
 function getInferableSessionModelId(session: Session): string | undefined {
   const modelId = session.config.modelName?.trim();
   if (!modelId || isMissingModelId(modelId)) {
@@ -338,7 +373,8 @@ function getInferableSessionModelId(session: Session): string | undefined {
 
 function isOpaqueModelIdentifier(modelId: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(modelId) ||
-    /^[0-9a-f]{32}$/i.test(modelId);
+    /^[0-9a-f]{32}$/i.test(modelId) ||
+    /^model_\d+(?:_\d+)+$/i.test(modelId);
 }
 
 function resolveModelIdentity(

--- a/src/web-ui/src/infrastructure/api/service-api/SessionAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SessionAPI.test.ts
@@ -47,4 +47,48 @@ describe('SessionAPI paged metadata reads', () => {
       },
     });
   });
+
+  it('requests usage reports with explicit hidden subagent scope', async () => {
+    const report = {
+      reportId: 'usage-report-1',
+      schemaVersion: 1,
+      generatedAt: 1_778_347_200_000,
+      sessionId: 'session-1',
+      workspace: { kind: 'local' },
+      scope: { kind: 'full_session', turnCount: 0 },
+      coverage: { level: 'complete', available: [], missing: [], notes: [] },
+      time: { accounting: 'unavailable', denominator: 'session_wall_time' },
+      tokens: { source: 'unavailable', cacheCoverage: 'unavailable' },
+      models: [],
+      tools: [],
+      files: { scope: 'unavailable', files: [] },
+      compression: { compactionCount: 0, manualCompactionCount: 0, automaticCompactionCount: 0 },
+      errors: { totalErrors: 0, toolErrors: 0, modelErrors: 0, examples: [] },
+      slowest: [],
+      privacy: {
+        promptContentIncluded: false,
+        toolInputsIncluded: false,
+        commandOutputsIncluded: false,
+        fileContentsIncluded: false,
+        redactedFields: [],
+      },
+    };
+    invokeMock.mockResolvedValueOnce(report);
+
+    await expect(
+      sessionAPI.getSessionUsageReport({
+        sessionId: 'session-1',
+        workspacePath: '/repo',
+        includeHiddenSubagents: false,
+      })
+    ).resolves.toBe(report);
+
+    expect(invokeMock).toHaveBeenCalledWith('get_session_usage_report', {
+      request: {
+        session_id: 'session-1',
+        workspace_path: '/repo',
+        include_hidden_subagents: false,
+      },
+    });
+  });
 });

--- a/src/web-ui/src/infrastructure/api/service-api/SessionAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SessionAPI.ts
@@ -24,6 +24,7 @@ export interface SessionUsageReportRequest {
   workspacePath: string;
   remoteConnectionId?: string;
   remoteSshHost?: string;
+  includeHiddenSubagents?: boolean;
 }
 
 export type UsageModelIdentitySource = 'recorded' | 'inferred_session_model' | 'legacy_missing';
@@ -146,6 +147,17 @@ export interface SessionUsageReport {
     redacted: boolean;
     turnId?: string;
     turnIndex?: number;
+    itemId?: string;
+    inputSummary?: string;
+    status?: string;
+    timeoutSeconds?: number;
+    exitCode?: number;
+    timedOut?: boolean;
+    errorSummary?: string;
+    queueWaitMs?: number;
+    preflightMs?: number;
+    confirmationWaitMs?: number;
+    executionMs?: number;
     modelIdSource?: UsageModelIdentitySource;
   }>;
   privacy: {
@@ -364,6 +376,7 @@ export class SessionAPI {
         request: {
           session_id: request.sessionId,
           workspace_path: request.workspacePath,
+          include_hidden_subagents: request.includeHiddenSubagents ?? true,
           ...remoteSessionFields(request.remoteConnectionId, request.remoteSshHost),
         }
       });

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -109,7 +109,8 @@
       "modelNotRecorded": "Model not recorded",
       "legacyModel": "Legacy model not tracked",
       "inferredModel": "{{model}} (inferred)",
-      "p95SampleInsufficient": "Not enough samples"
+      "p95SampleInsufficient": "Not enough samples",
+      "timedOut": "Timed out"
     },
     "cacheCoverage": {
       "available": "Reported",
@@ -189,7 +190,8 @@
       "errorExampleRow": "Safe grouped label for a model/runtime error or failing tool type.",
       "errorExampleCount": "Number of matching errors in this report scope.",
       "slowestSpans": "Slow spans are derived from recorded turn, model-call, and tool timestamps. They help identify time sinks, not exact provider latency.",
-      "slowestModelCall": "Model call in this turn. Model: {{model}}."
+      "slowestModelCall": "Model call in this turn. Model: {{model}}.",
+      "slowestToolCall": "Tool call details identify whether time was spent waiting, confirming, or executing."
     },
     "meta": {
       "generatedAt": "Generated",
@@ -265,6 +267,16 @@
     "slowestLabels": {
       "modelCall": "Turn {{turn}} model call",
       "modelCallUnknown": "Model call"
+    },
+    "slowest": {
+      "details": {
+        "input": "Input",
+        "status": "Status",
+        "exitCode": "Exit code",
+        "timedOut": "Timed out",
+        "execution": "Execution",
+        "error": "Error"
+      }
     }
   },
   "threadGoal": {

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -109,7 +109,8 @@
       "modelNotRecorded": "未记录模型名称",
       "legacyModel": "旧会话模型未统计",
       "inferredModel": "{{model}}（推测）",
-      "p95SampleInsufficient": "样本不足"
+      "p95SampleInsufficient": "样本不足",
+      "timedOut": "超时"
     },
     "cacheCoverage": {
       "available": "已上报",
@@ -232,6 +233,16 @@
       "modelCall": "第 {{turn}} 轮模型调用",
       "modelCallUnknown": "模型调用"
     },
+    "slowest": {
+      "details": {
+        "input": "输入",
+        "status": "状态",
+        "exitCode": "退出码",
+        "timedOut": "超时",
+        "execution": "执行",
+        "error": "错误"
+      }
+    },
     "help": {
       "wall": "从第一轮开始到最后一轮结束的记录跨度，可能包含轮次之间的空闲间隔。",
       "active": "产生可统计活动的轮次记录时间段并集，可能包含轮次内的编排或等待时间。",
@@ -259,7 +270,8 @@
       "errorExampleRow": "模型/运行时错误或失败工具类型的安全分组标签。",
       "errorExampleCount": "当前报告范围内匹配该标签的错误次数。",
       "slowestSpans": "慢耗时来自已记录的轮次、模型调用与工具时间戳，用于定位耗时来源，不代表精确服务商延迟。",
-      "slowestModelCall": "该行是当前轮次内的一次模型调用。模型：{{model}}。"
+      "slowestModelCall": "该行是当前轮次内的一次模型调用。模型：{{model}}。",
+      "slowestToolCall": "工具调用详情用于区分耗时来自排队、确认还是实际执行。"
     },
     "meta": {
       "generatedAt": "生成时间",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -109,7 +109,8 @@
       "modelNotRecorded": "未記錄模型名稱",
       "legacyModel": "舊會話模型未統計",
       "inferredModel": "{{model}}（推測）",
-      "p95SampleInsufficient": "樣本不足"
+      "p95SampleInsufficient": "樣本不足",
+      "timedOut": "逾時"
     },
     "cacheCoverage": {
       "available": "已回報",
@@ -232,6 +233,16 @@
       "modelCall": "第 {{turn}} 回合模型呼叫",
       "modelCallUnknown": "模型呼叫"
     },
+    "slowest": {
+      "details": {
+        "input": "輸入",
+        "status": "狀態",
+        "exitCode": "退出碼",
+        "timedOut": "逾時",
+        "execution": "執行",
+        "error": "錯誤"
+      }
+    },
     "help": {
       "wall": "從第一回合開始到最後一回合結束的記錄跨度，可能包含回合之間的閒置間隔。",
       "active": "產生可統計活動的回合記錄時間段聯集，可能包含回合內的編排或等待時間。",
@@ -259,7 +270,8 @@
       "errorExampleRow": "模型/執行期錯誤或失敗工具類型的安全分組標籤。",
       "errorExampleCount": "目前報告範圍內符合該標籤的錯誤次數。",
       "slowestSpans": "慢耗時來自已記錄的回合、模型呼叫與工具時間戳，用於定位耗時來源，不代表精確服務商延遲。",
-      "slowestModelCall": "該列是目前回合內的一次模型呼叫。模型：{{model}}。"
+      "slowestModelCall": "該列是目前回合內的一次模型呼叫。模型：{{model}}。",
+      "slowestToolCall": "工具呼叫詳情用於區分耗時來自排隊、確認還是實際執行。"
     },
     "meta": {
       "generatedAt": "產生時間",


### PR DESCRIPTION
## Summary
- Fix session usage active/wall-time accounting for incomplete turns by deriving effective turn end from recorded model/tool child spans instead of treating missing turn end as zero-length.
- Merge legacy/missing model timing rows into the recorded token model row when the same turn has a single token model, and treat opaque `model_<digits>_<digits>` values as legacy placeholders instead of inferred model names.
- Add slow-tool diagnostics to the usage report: safe input summary, status, timeout/exit/timed-out/error details, phase timing, and exact tool-item jump targets.
- Redact common sensitive fragments from slow-tool input summaries, including Authorization headers, API keys, tokens, passwords, and URL token parameters.
- Make hidden-subagent scope explicit through the desktop API and frontend request, and keep coverage notes aligned with that report scope.
- Update terminal/Markdown rendering and EN/ZH locales while reusing shared i18n status terms to avoid duplicate translation noise.

## Root Cause / Product Notes
- The reported 140-minute session duration could undercount real activity when persisted turns had no `end_time` while child model/tool spans continued recording work.
- Duplicate model rows happened when timing facts used legacy placeholders but token records had the actual model ID. The report now merges only when the turn has exactly one token model, avoiding ambiguous attribution.
- Slow tool rows previously showed duration without enough context to distinguish a long command, a slow network request, confirmation wait, or execution time.
- Slow tool input summaries now stay intentionally narrow: command text or method+URL only, with common secret-like fragments redacted before rendering or export.

## Verification
- `rustfmt --edition 2021 --check src/apps/desktop/src/api/session_api.rs src/crates/assembly/core/src/service/session_usage/service.rs src/crates/services/services-core/src/session_usage/render.rs src/crates/services/services-core/src/session_usage/types.rs src/crates/services/services-core/src/session_usage/redaction.rs`
- `pnpm run i18n:contract:test:ci`
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/usage/usageReportUtils.test.ts src/flow_chat/components/usage/SessionUsageComponents.test.tsx src/flow_chat/services/usageReportService.test.ts src/infrastructure/api/service-api/SessionAPI.test.ts`
- `cargo test -p bitfun-services-core session_usage -- --nocapture`
- `cargo test -p bitfun-services-core session_usage::redaction -- --nocapture`
- `cargo test -p bitfun-core session_usage -- --nocapture`
- `pnpm run type-check:web`
- `pnpm run lint:web` (passes with one existing unrelated warning in `src/web-ui/src/flow_chat/services/FlowChatManager.ts:115`)
- `pnpm run check:repo-hygiene`
- `cargo check -p bitfun-desktop`
- Locale JSON parse and duplicate-key check for `en-US`, `zh-CN`, and `zh-TW`
- `git diff --check`
