### PR TITLE
fix(web-ui): improve terminal output copy and scrolling

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCard.scss
@@ -1,6 +1,37 @@
 @use './TerminalToolCard.scss';
 
 .exec-process-tool-card {
+  .exec-process-output-copy-region {
+    position: relative;
+  }
+
+  .exec-process-output-copy-actions {
+    position: absolute;
+    top: 0.25rem;
+    right: 0.25rem;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.16s ease;
+  }
+
+  .exec-process-output-copy-region:hover .exec-process-output-copy-actions,
+  .exec-process-output-copy-actions:focus-within {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .exec-process-copy-output-btn {
+    background: var(--color-bg-scene);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.16);
+
+    &:hover:not(:disabled) {
+      background: var(--element-bg-subtle, rgba(255, 255, 255, 0.1));
+    }
+  }
+
   .exec-process-empty-output {
     color: var(--color-text-muted);
   }

--- a/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCardView.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCardView.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next';
 import { Terminal } from 'lucide-react';
 import type { FlowToolItem } from '../types/flow-chat';
-import { TerminalOutputRenderer } from '@/tools/terminal/components';
+import { TerminalOutputRenderer, type TerminalOutputRendererHandle } from '@/tools/terminal/components';
 import { BaseToolCard, ToolCardHeader } from './BaseToolCard';
 import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
 import { ToolCardStatusSlot } from './ToolCardStatusSlot';
@@ -15,8 +15,8 @@ import { formatSessionViewPreviewText } from '../utils/sessionViewPreview';
 import './ExecProcessToolCard.scss';
 
 const EXEC_COLLAPSED_STATUSES = new Set(['completed', 'cancelled', 'error', 'rejected']);
-const EXEC_OUTPUT_STREAMING_MAX_HEIGHT = 4 * 18 + 16;
-const EXEC_OUTPUT_EXPANDED_MAX_HEIGHT = 15 * 18 + 16;
+const EXEC_OUTPUT_STREAMING_MAX_ROWS = 4;
+const EXEC_OUTPUT_EXPANDED_MAX_ROWS = 15;
 
 export interface ExecProcessCardModel {
   kind: 'command' | 'stdin';
@@ -146,13 +146,14 @@ export const ExecProcessToolCardView: React.FC<ExecProcessToolCardViewProps> = (
     return typeof progressMessage === 'string' ? progressMessage : '';
   }, [progressLogs, toolItem]);
   const isRunning = status === 'preparing' || status === 'streaming' || status === 'running' || status === 'receiving';
-  const maxHeight = isRunning ? EXEC_OUTPUT_STREAMING_MAX_HEIGHT : EXEC_OUTPUT_EXPANDED_MAX_HEIGHT;
+  const maxRows = isRunning ? EXEC_OUTPUT_STREAMING_MAX_ROWS : EXEC_OUTPUT_EXPANDED_MAX_ROWS;
   const toolId = toolItem.id ?? toolItem.toolCall?.id;
   const icon = <Terminal size={16} className="terminal-card-icon" />;
 
   const [isExpanded, setIsExpandedState] = useState(() => getInitialExpandedState(status));
   const previousStatusRef = useRef(status);
   const commandRef = useRef<HTMLElement | null>(null);
+  const outputRendererRef = useRef<TerminalOutputRendererHandle | null>(null);
   const [isPrimaryTextTruncated, setIsPrimaryTextTruncated] = useState(false);
   const { cardRootRef, applyExpandedState } = useToolCardHeightContract({
     toolId,
@@ -263,7 +264,59 @@ export const ExecProcessToolCardView: React.FC<ExecProcessToolCardViewProps> = (
       successMessage={t('toolCards.execProcess.primaryCopied')}
       failureMessage={t('toolCards.execProcess.copyPrimaryFailed')}
       ariaLabel={t('toolCards.execProcess.copyPrimary')}
+      showSuccessNotification={false}
     />
+  );
+
+  const getOutputText = useCallback(() => {
+    if (status === 'completed') {
+      return formatSessionViewPreviewText(model.resultOutput);
+    }
+
+    if (status === 'cancelled') {
+      return liveOutput;
+    }
+
+    if (liveOutput && isRunning) {
+      return liveOutput;
+    }
+
+    return '';
+  }, [isRunning, liveOutput, model.resultOutput, status]);
+
+  const getVisibleOutputText = useCallback(() => {
+    return outputRendererRef.current?.getVisibleText() ?? getOutputText();
+  }, [getOutputText]);
+
+  const renderCopyOutputButton = () => (
+    <ToolCardCopyAction
+      className="terminal-action-btn copy-command-btn exec-process-copy-output-btn"
+      getText={getVisibleOutputText}
+      disabled={!getOutputText().trim()}
+      tooltip={t('toolCards.execProcess.copyOutput')}
+      copiedTooltip={t('toolCards.execProcess.outputCopied')}
+      successMessage={t('toolCards.execProcess.outputCopied')}
+      failureMessage={t('toolCards.execProcess.copyOutputFailed')}
+      ariaLabel={t('toolCards.execProcess.copyOutput')}
+      showSuccessNotification={false}
+    />
+  );
+
+  const renderOutputWithCopyAction = (
+    output: string,
+    options?: { formatSessionPreview?: boolean },
+  ) => (
+    <div className="exec-process-output-copy-region">
+      <div className="exec-process-output-copy-actions">
+        {renderCopyOutputButton()}
+      </div>
+      <TerminalOutputRenderer
+        ref={outputRendererRef}
+        content={options?.formatSessionPreview ? formatSessionViewPreviewText(output) : output}
+        className="terminal-xterm-output"
+        maxRows={maxRows}
+      />
+    </div>
   );
 
   const renderTimeoutIndicator = () => (
@@ -306,11 +359,7 @@ export const ExecProcessToolCardView: React.FC<ExecProcessToolCardViewProps> = (
         <div className="terminal-result-container">
           {model.resultOutput ? (
             <div className="terminal-result-output">
-              <TerminalOutputRenderer
-                content={formatSessionViewPreviewText(model.resultOutput)}
-                className="terminal-xterm-output"
-                maxHeight={maxHeight}
-              />
+              {renderOutputWithCopyAction(model.resultOutput, { formatSessionPreview: true })}
             </div>
           ) : model.resultNoticeText ? (
             <div className="terminal-execution-output terminal-waiting exec-process-result-notice">
@@ -330,11 +379,7 @@ export const ExecProcessToolCardView: React.FC<ExecProcessToolCardViewProps> = (
       return (
         <div className="terminal-result-container cancelled">
           <div className="terminal-result-output">
-            <TerminalOutputRenderer
-              content={liveOutput}
-              className="terminal-xterm-output"
-              maxHeight={maxHeight}
-            />
+            {renderOutputWithCopyAction(liveOutput)}
           </div>
           <div className="terminal-result-footer">
             <span className="terminal-cancelled-text">{t('toolCards.terminal.commandInterrupted')}</span>
@@ -346,11 +391,7 @@ export const ExecProcessToolCardView: React.FC<ExecProcessToolCardViewProps> = (
     if (liveOutput && isRunning) {
       return (
         <div className="terminal-execution-output">
-          <TerminalOutputRenderer
-            content={liveOutput}
-            className="terminal-xterm-output"
-            maxHeight={maxHeight}
-          />
+          {renderOutputWithCopyAction(liveOutput)}
         </div>
       );
     }

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
@@ -82,8 +82,7 @@
 /* ========== Fix scrollbar visibility on card hover ========== */
 .base-tool-card-wrapper.terminal-tool-card:hover {
   .terminal-execution-output,
-  .terminal-result-output,
-  .xterm-viewport {
+  .terminal-result-output {
     &::-webkit-scrollbar-thumb {
       background: var(--scrollbar-thumb, rgba(255, 255, 255, 0.12));
     }
@@ -414,8 +413,6 @@
   background: transparent;
   border: none;
   overflow: hidden;
-  max-height: 300px;
-  overflow-y: auto;
 
   &.terminal-waiting {
     display: flex;
@@ -532,7 +529,7 @@
     padding: 0;
 
     .xterm-viewport {
-      overflow-y: auto !important;
+      overflow: hidden !important;
     }
 
     &:not(.allow-transparency) {
@@ -554,6 +551,13 @@
   
   .xterm {
     height: 100%;
+  }
+
+  &.terminal-output-renderer--no-scroll {
+    .xterm .scrollbar.vertical {
+      display: none !important;
+      pointer-events: none !important;
+    }
   }
 }
 

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
@@ -36,8 +36,8 @@ import './TerminalToolCard.scss';
 
 const log = createLogger('TerminalToolCard');
 const TERMINAL_COLLAPSED_STATUSES = new Set(['completed', 'cancelled', 'error', 'rejected']);
-const TERMINAL_OUTPUT_STREAMING_MAX_HEIGHT = 4 * 18 + 16;  // 88px – compact while streaming/executing
-const TERMINAL_OUTPUT_EXPANDED_MAX_HEIGHT = 15 * 18 + 16;  // 286px – comfortable reading when manually expanded
+const TERMINAL_OUTPUT_STREAMING_MAX_ROWS = 4;  // Compact while streaming/executing
+const TERMINAL_OUTPUT_EXPANDED_MAX_ROWS = 15;  // Comfortable reading when manually expanded
 
 interface TerminalToolCardProps extends ToolCardProps {
   terminalSessionId?: string;
@@ -94,9 +94,9 @@ function renderTerminalExpandedContent(params: {
     viewState.displayPhase === 'receiving_params' ||
     viewState.displayPhase === 'executing';
 
-  const maxHeight = isStreamingPhase
-    ? TERMINAL_OUTPUT_STREAMING_MAX_HEIGHT
-    : TERMINAL_OUTPUT_EXPANDED_MAX_HEIGHT;
+  const maxRows = isStreamingPhase
+    ? TERMINAL_OUTPUT_STREAMING_MAX_ROWS
+    : TERMINAL_OUTPUT_EXPANDED_MAX_ROWS;
 
   return (
     <>
@@ -105,7 +105,7 @@ function renderTerminalExpandedContent(params: {
           <TerminalOutputRenderer
             content={liveOutput}
             className="terminal-xterm-output"
-            maxHeight={maxHeight}
+            maxRows={maxRows}
           />
         </div>
       )}
@@ -123,7 +123,7 @@ function renderTerminalExpandedContent(params: {
               <TerminalOutputRenderer
                 content={parsedResult.output}
                 className="terminal-xterm-output"
-                maxHeight={maxHeight}
+                maxRows={maxRows}
               />
             </div>
           )}
@@ -152,7 +152,7 @@ function renderTerminalExpandedContent(params: {
             <TerminalOutputRenderer
               content={liveOutput}
               className="terminal-xterm-output"
-              maxHeight={maxHeight}
+              maxRows={maxRows}
             />
           </div>
           <div className="terminal-result-footer">

--- a/src/web-ui/src/flow_chat/tool-cards/ToolCardHeaderActions.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ToolCardHeaderActions.tsx
@@ -30,6 +30,7 @@ interface ToolCardCopyActionProps {
   ariaLabel?: string;
   className?: string;
   disabled?: boolean;
+  showSuccessNotification?: boolean;
 }
 
 export const ToolCardCopyAction: React.FC<ToolCardCopyActionProps> = ({
@@ -41,11 +42,13 @@ export const ToolCardCopyAction: React.FC<ToolCardCopyActionProps> = ({
   ariaLabel,
   className,
   disabled,
+  showSuccessNotification,
 }) => {
   const { copied, copy } = useCopyTextAction({
     getText,
     successMessage,
     failureMessage,
+    showSuccessNotification,
   });
 
   return (

--- a/src/web-ui/src/flow_chat/tool-cards/useCopyTextAction.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/useCopyTextAction.ts
@@ -8,6 +8,7 @@ interface UseCopyTextActionOptions {
   successMessage: string;
   failureMessage: string;
   resetMs?: number;
+  showSuccessNotification?: boolean;
 }
 
 export function useCopyTextAction({
@@ -15,6 +16,7 @@ export function useCopyTextAction({
   successMessage,
   failureMessage,
   resetMs = 1600,
+  showSuccessNotification = true,
 }: UseCopyTextActionOptions) {
   const [copied, setCopied] = useState(false);
   const resetTimerRef = useRef<number | null>(null);
@@ -42,7 +44,9 @@ export function useCopyTextAction({
     }
 
     setCopied(true);
-    notificationService.success(successMessage, { duration: resetMs });
+    if (showSuccessNotification) {
+      notificationService.success(successMessage, { duration: resetMs });
+    }
 
     if (resetTimerRef.current !== null) {
       window.clearTimeout(resetTimerRef.current);
@@ -51,7 +55,7 @@ export function useCopyTextAction({
       setCopied(false);
       resetTimerRef.current = null;
     }, resetMs);
-  }, [failureMessage, getText, resetMs, successMessage]);
+  }, [failureMessage, getText, resetMs, showSuccessNotification, successMessage]);
 
   return { copied, copy };
 }

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1331,7 +1331,10 @@
       "sessionNotFound": "Session #{{id}} was not found",
       "copyPrimary": "Copy",
       "primaryCopied": "Copied",
-      "copyPrimaryFailed": "Failed to copy"
+      "copyPrimaryFailed": "Failed to copy",
+      "copyOutput": "Copy output",
+      "outputCopied": "Output copied",
+      "copyOutputFailed": "Failed to copy output"
     },
     "plan": {
       "loadingPlan": "Loading plan...",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1331,7 +1331,10 @@
       "sessionNotFound": "未找到会话 #{{id}}",
       "copyPrimary": "复制",
       "primaryCopied": "已复制",
-      "copyPrimaryFailed": "复制失败"
+      "copyPrimaryFailed": "复制失败",
+      "copyOutput": "复制输出",
+      "outputCopied": "已复制输出",
+      "copyOutputFailed": "复制输出失败"
     },
     "plan": {
       "loadingPlan": "正在加载计划...",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1331,7 +1331,10 @@
       "sessionNotFound": "未找到會話 #{{id}}",
       "copyPrimary": "複製",
       "primaryCopied": "已複製",
-      "copyPrimaryFailed": "複製失敗"
+      "copyPrimaryFailed": "複製失敗",
+      "copyOutput": "複製輸出",
+      "outputCopied": "已複製輸出",
+      "copyOutputFailed": "複製輸出失敗"
     },
     "plan": {
       "loadingPlan": "正在載入計劃...",

--- a/src/web-ui/src/tools/terminal/components/TerminalOutputRenderer.tsx
+++ b/src/web-ui/src/tools/terminal/components/TerminalOutputRenderer.tsx
@@ -31,7 +31,22 @@ function normalizeAbsoluteCursorPositions(content: string): string {
   return content.replace(/\x1b\[\d*;?\d*[Hf]/g, '\r\n');
 }
 
-import React, { useEffect, useRef, useCallback, memo, useId } from 'react';
+function trimTrailingLineBreaksBeforeAnsiTail(content: string): string {
+  // A final newline moves the xterm cursor to an extra blank row, which can
+  // push useful content into scrollback in compact read-only previews. Preserve
+  // trailing CSI state-reset sequences such as ESC[?25h while dropping only the
+  // blank line break before them.
+  // eslint-disable-next-line no-control-regex -- ESC sequences are intentional terminal control codes.
+  return content.replace(/(?:\r\n|\r|\n)+((?:\x1b\[[0-?]*[ -/]*[@-~])*)$/g, '$1');
+}
+
+function prepareReadOnlyTerminalOutput(content: string): string {
+  return trimTrailingLineBreaksBeforeAnsiTail(
+    normalizeAbsoluteCursorPositions(content),
+  );
+}
+
+import { forwardRef, memo, useCallback, useEffect, useId, useImperativeHandle, useRef, useState } from 'react';
 import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { registerTerminalActions, unregisterTerminalActions } from '../services/TerminalActionManager';
@@ -42,6 +57,10 @@ import {
   DEFAULT_XTERM_MINIMUM_CONTRAST_RATIO,
 } from '../utils';
 import '@xterm/xterm/css/xterm.css';
+
+const OUTPUT_FONT_SIZE = 12;
+const OUTPUT_LINE_HEIGHT = 1.4;
+const FALLBACK_OUTPUT_ROW_HEIGHT = Math.ceil(OUTPUT_FONT_SIZE * OUTPUT_LINE_HEIGHT);
 
 interface TerminalOutputRendererProps {
   /** Output content to render. */
@@ -54,36 +73,103 @@ interface TerminalOutputRendererProps {
   minHeight?: number;
   /** Maximum height. */
   maxHeight?: number;
+  /** Maximum visible terminal rows. Takes precedence over maxHeight. */
+  maxRows?: number;
+}
+
+export interface TerminalOutputRendererHandle {
+  getVisibleText: () => string;
+}
+
+function getTerminalVisibleText(terminal: XTerm | null): string {
+  if (!terminal) {
+    return '';
+  }
+
+  const buffer = terminal.buffer.active;
+  const lines: string[] = [];
+  const endRow = Math.min(buffer.viewportY + terminal.rows, buffer.length);
+
+  for (let row = buffer.viewportY; row < endRow; row += 1) {
+    lines.push(buffer.getLine(row)?.translateToString(true) ?? '');
+  }
+
+  while (lines.length > 0 && !lines[lines.length - 1].trim()) {
+    lines.pop();
+  }
+
+  return lines.join('\n');
+}
+
+function hasScrollableTerminalBuffer(terminal: XTerm | null): boolean {
+  const buffer = terminal?.buffer.active;
+  if (!terminal || !buffer) {
+    return false;
+  }
+
+  return buffer.baseY > 0 || buffer.length > terminal.rows;
 }
 
 /**
  * xterm.js read-only output renderer.
  */
-export const TerminalOutputRenderer: React.FC<TerminalOutputRendererProps> = memo(({
+const TerminalOutputRendererComponent = forwardRef<TerminalOutputRendererHandle, TerminalOutputRendererProps>(({
   content,
   className = '',
   terminalId: propTerminalId,
-  minHeight = 60,
+  minHeight = FALLBACK_OUTPUT_ROW_HEIGHT,
   maxHeight = 300,
-}) => {
+  maxRows,
+}, ref) => {
   const autoId = useId();
   const terminalId = propTerminalId || `terminal-output-${autoId}`;
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
-  const lastContentRef = useRef<string>('');
+  const lastRenderedContentRef = useRef<string>('');
+  const [rowHeight, setRowHeight] = useState(FALLBACK_OUTPUT_ROW_HEIGHT);
+  const [hasScrollableBuffer, setHasScrollableBuffer] = useState(false);
+  const preparedContent = prepareReadOnlyTerminalOutput(content);
 
-  // Estimate height from content.
+  useImperativeHandle(ref, () => ({
+    getVisibleText: () => getTerminalVisibleText(terminalRef.current),
+  }), []);
+
+  const heightForRows = useCallback((rows: number): number => {
+    return Math.ceil(Math.max(rowHeight, rows * rowHeight));
+  }, [rowHeight]);
+
+  const alignHeightToRows = useCallback((height: number, mode: 'floor' | 'ceil'): number => {
+    const rows = mode === 'ceil'
+      ? Math.ceil(height / rowHeight)
+      : Math.floor(height / rowHeight);
+    return heightForRows(Math.max(1, rows));
+  }, [heightForRows, rowHeight]);
+
+  // Estimate height from content, keeping the container aligned to full xterm rows.
   const calculateHeight = useCallback((text: string): number => {
-    if (!text) return minHeight;
+    const effectiveMinHeight = alignHeightToRows(minHeight, 'ceil');
+    const effectiveMaxHeight = maxRows != null
+      ? heightForRows(maxRows)
+      : alignHeightToRows(maxHeight, 'floor');
+    const boundedMaxHeight = Math.max(effectiveMinHeight, effectiveMaxHeight);
+
+    if (!text) return Math.min(effectiveMinHeight, boundedMaxHeight);
+
+    const lines = text.split(/\r\n|\r|\n/);
+    const visibleRows = maxRows != null
+      ? Math.min(lines.length, maxRows)
+      : lines.length;
+    const estimatedHeight = heightForRows(Math.max(1, visibleRows));
     
-    const lines = text.split('\n');
-    const lineHeight = 18;
-    const estimatedHeight = lines.length * lineHeight + 16;
-    
-    return Math.min(Math.max(estimatedHeight, minHeight), maxHeight);
-  }, [minHeight, maxHeight]);
+    return Math.min(Math.max(estimatedHeight, effectiveMinHeight), boundedMaxHeight);
+  }, [alignHeightToRows, heightForRows, maxHeight, maxRows, minHeight]);
+
+  const height = calculateHeight(preparedContent);
+  const updateScrollableBufferState = useCallback(() => {
+    setHasScrollableBuffer(hasScrollableTerminalBuffer(terminalRef.current));
+  }, []);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -119,7 +205,12 @@ export const TerminalOutputRenderer: React.FC<TerminalOutputRendererProps> = mem
 
     requestAnimationFrame(() => {
       try {
+        const nextRowHeight = terminal.dimensions?.css.cell.height;
+        if (typeof nextRowHeight === 'number' && nextRowHeight > 0) {
+          setRowHeight(nextRowHeight);
+        }
         fitAddon.fit();
+        updateScrollableBufferState();
       } catch {
         // Ignore fit errors.
       }
@@ -128,7 +219,12 @@ export const TerminalOutputRenderer: React.FC<TerminalOutputRendererProps> = mem
     const resizeObserver = new ResizeObserver(() => {
       requestAnimationFrame(() => {
         try {
+          const nextRowHeight = terminal.dimensions?.css.cell.height;
+          if (typeof nextRowHeight === 'number' && nextRowHeight > 0) {
+            setRowHeight(nextRowHeight);
+          }
           fitAddon.fit();
+          updateScrollableBufferState();
         } catch {
           // Ignore fit errors.
         }
@@ -144,7 +240,7 @@ export const TerminalOutputRenderer: React.FC<TerminalOutputRendererProps> = mem
       fitAddonRef.current = null;
       resizeObserverRef.current = null;
     };
-  }, []);
+  }, [updateScrollableBufferState]);
 
   // Register with TerminalActionManager to avoid per-instance EventBus listeners.
   useEffect(() => {
@@ -188,42 +284,40 @@ export const TerminalOutputRenderer: React.FC<TerminalOutputRendererProps> = mem
     const terminal = terminalRef.current;
     if (!terminal) return;
 
-    const lastContent = lastContentRef.current;
+    const lastRenderedContent = lastRenderedContentRef.current;
     
-    // Compare raw content for incremental detection, but replace absolute
-    // cursor-position sequences with CR+LF before writing so a fresh xterm.js
-    // context does not show blank rows caused by ESC[row;colH jumps, while
-    // keeping the line boundary between the sections they separated.
-    if (content.startsWith(lastContent) && lastContent.length > 0) {
-      const newPart = content.slice(lastContent.length);
+    // Compare the normalized read-only text for incremental detection so the
+    // height estimate and xterm buffer receive the same content.
+    if (preparedContent.startsWith(lastRenderedContent) && lastRenderedContent.length > 0) {
+      const newPart = preparedContent.slice(lastRenderedContent.length);
       if (newPart) {
-        terminal.write(normalizeAbsoluteCursorPositions(newPart));
+        terminal.write(newPart);
       }
     } else {
       terminal.clear();
       terminal.reset();
-      if (content) {
-        terminal.write(normalizeAbsoluteCursorPositions(content));
+      if (preparedContent) {
+        terminal.write(preparedContent);
       }
     }
+    updateScrollableBufferState();
     
-    lastContentRef.current = content;
+    lastRenderedContentRef.current = preparedContent;
 
     requestAnimationFrame(() => {
       try {
         fitAddonRef.current?.fit();
+        updateScrollableBufferState();
       } catch {
         // Ignore fit errors.
       }
     });
-  }, [content]);
-
-  const height = calculateHeight(content);
+  }, [preparedContent, updateScrollableBufferState]);
 
   return (
     <div 
       ref={containerRef}
-      className={`terminal-output-renderer ${className}`}
+      className={`terminal-output-renderer ${className} ${hasScrollableBuffer ? 'terminal-output-renderer--scrollable' : 'terminal-output-renderer--no-scroll'}`}
       data-terminal-id={terminalId}
       data-readonly="true"
       style={{
@@ -235,6 +329,8 @@ export const TerminalOutputRenderer: React.FC<TerminalOutputRendererProps> = mem
   );
 });
 
-TerminalOutputRenderer.displayName = 'TerminalOutputRenderer';
+TerminalOutputRendererComponent.displayName = 'TerminalOutputRenderer';
+
+export const TerminalOutputRenderer = memo(TerminalOutputRendererComponent);
 
 export default TerminalOutputRenderer;

--- a/src/web-ui/src/tools/terminal/components/index.ts
+++ b/src/web-ui/src/tools/terminal/components/index.ts
@@ -9,3 +9,4 @@ export { default as ConnectedTerminal } from './ConnectedTerminal';
 export type { ConnectedTerminalProps } from './ConnectedTerminal';
 
 export { TerminalOutputRenderer } from './TerminalOutputRenderer';
+export type { TerminalOutputRendererHandle } from './TerminalOutputRenderer';


### PR DESCRIPTION
- Add a hover-only copy output action for exec process output areas
- Copy xterm visible text instead of raw ANSI output for one-click output copy
- Disable success notifications for command and output copy actions
- Align terminal output sizing to measured xterm row heights and max row counts
- Normalize read-only terminal output to avoid cursor-position and trailing newline layout artifacts
- Remove duplicate parent/xterm scroll containers and hide xterm's fake scrollbar when the buffer is not scrollable
