### PR TITLE
fix: reserve left space for macOS traffic lights in ToolbarMode floating window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,10 @@ src/apps/desktop/.tauri/*.key
 # E2E test reports and screenshots
 tests/e2e/reports/
 
+# Eval job artifacts
+.eval/
+Cross.toml
+
 # BitFun sandbox data - auto managed
 .bitfun/
 .cursor

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.scss
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.scss
@@ -75,6 +75,11 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
   animation: title-fade-in 0.2s $transition-timing;
 }
 
+// macOS overlay titlebar: reserve left space for traffic light buttons
+.bitfun-toolbar-mode--macos .bitfun-toolbar-mode__header {
+  padding-left: 78px;
+}
+
 .bitfun-toolbar-mode__header-left {
   flex: 0 0 auto;
   display: flex;

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.tsx
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.tsx
@@ -28,6 +28,7 @@ import { syncSessionToModernStore } from '../../services/storeSync';
 import { FlowChatState } from '../../types/flow-chat';
 import { compareSessionsForDisplay } from '../../utils/sessionOrdering';
 import { createLogger } from '@/shared/utils/logger';
+import { isMacOSDesktopRuntime } from '@/infrastructure/runtime';
 import { i18nService } from '@/infrastructure/i18n';
 import { resolveSessionTitle } from '../../utils/sessionTitle';
 
@@ -57,6 +58,8 @@ export const ToolbarMode: React.FC = () => {
   );
   const sessionPickerRef = useRef<HTMLDivElement>(null);
   const headerOverflowRef = useRef<HTMLDivElement>(null);
+
+  const isMacOS = useMemo(() => isMacOSDesktopRuntime(), []);
 
   useEffect(() => {
     const unsubscribe = flowChatStore.subscribe((state) => {
@@ -374,7 +377,8 @@ export const ToolbarMode: React.FC = () => {
     isExpanded && 'bitfun-toolbar-mode--expanded',
     currentStreamState.isStreaming && 'bitfun-toolbar-mode--processing',
     toolbarState.hasError && 'bitfun-toolbar-mode--error',
-    toolbarState.hasPendingConfirmation && 'bitfun-toolbar-mode--confirm'
+    toolbarState.hasPendingConfirmation && 'bitfun-toolbar-mode--confirm',
+    isMacOS && 'bitfun-toolbar-mode--macos',
   ].filter(Boolean).join(' ');
   
   return (


### PR DESCRIPTION
## Summary
On macOS with overlay titlebar, the traffic light buttons (close/minimize/maximize) are positioned at x=12-66 in the top-left corner. The ToolbarMode floating window's header has a '+' new-session button at x=12, which overlaps with the traffic lights.

## Fix
- Add `isMacOSDesktopRuntime()` detection to ToolbarMode component, applying `bitfun-toolbar-mode--macos` class
- On macOS, increase `__header` left padding from 12px to 78px, pushing the '+' button past the traffic light zone

## Changes
- `.gitignore` — ignore eval artifacts (`.eval/`, `Cross.toml`)
- `ToolbarMode.tsx` — add macOS platform detection
- `ToolbarMode.scss` — add macOS-specific header padding