### PR TITLE
fix: stabilize latest tail anchoring for long sessions

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -59,6 +59,7 @@ const LATEST_END_ANCHOR_STABILIZATION_MIN_ATTEMPTS = 12;
 const LATEST_END_ANCHOR_STABLE_VISIBLE_FRAMES = 8;
 const LATEST_END_ANCHOR_VISIBILITY_MARGIN_PX = 4;
 const LATEST_END_ANCHOR_STABLE_EPSILON_PX = 1;
+const LATEST_END_ANCHOR_STATIC_FAST_PATH_TOLERANCE_PX = 96;
 const VIRTUOSO_FIRST_ITEM_INDEX_BASE = 1_000_000;
 const PARTIAL_HISTORY_INITIAL_TAIL_TURN_BUDGET = 16;
 const PARTIAL_HISTORY_FULL_PROJECTION_TOP_THRESHOLD_PX = 1200;
@@ -2348,24 +2349,35 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       scrollerRect.bottom - inputOverlayInsetPx - LATEST_END_ANCHOR_VISIBILITY_MARGIN_PX,
     );
 
-    const isTargetVisible = () => {
-      const currentTargetElement = getRenderedVirtualItemElement(targetIndex);
+    const readTargetEndState = (currentTargetElement: HTMLElement | null) => {
       if (!currentTargetElement) {
-        return false;
+        return null;
       }
       const rect = currentTargetElement.getBoundingClientRect();
-      return rect.bottom > visibleTop && rect.top < visibleBottom;
+      const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+      const endDeltaPx = rect.bottom - visibleBottom;
+      const endAnchored =
+        Math.abs(endDeltaPx) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX ||
+        (endDeltaPx > 0 && Math.abs(maxScrollTop - scroller.scrollTop) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX) ||
+        (endDeltaPx < 0 && scroller.scrollTop <= LATEST_END_ANCHOR_STABLE_EPSILON_PX);
+      return {
+        endAnchored,
+        endDeltaPx,
+        maxScrollTop,
+        rect,
+        visible: rect.bottom > visibleTop && rect.top < visibleBottom,
+      };
     };
 
-    const settleIfStableVisible = () => {
+    const settleIfStableEndAnchored = () => {
       const currentTargetElement = getRenderedVirtualItemElement(targetIndex);
-      if (!currentTargetElement) {
+      const state = readTargetEndState(currentTargetElement);
+      if (!state?.visible || !state.endAnchored) {
         request.visibleFrames = 0;
         request.stableVisibleFrames = 0;
         return false;
       }
 
-      const targetRect = currentTargetElement.getBoundingClientRect();
       const scrollHeight = scroller.scrollHeight;
       const scrollTop = scroller.scrollTop;
       const geometryStable = (
@@ -2375,14 +2387,14 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
         request.lastTargetBottom !== null &&
         Math.abs(scrollHeight - request.lastScrollHeight) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX &&
         Math.abs(scrollTop - request.lastScrollTop) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX &&
-        Math.abs(targetRect.top - request.lastTargetTop) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX &&
-        Math.abs(targetRect.bottom - request.lastTargetBottom) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX
+        Math.abs(state.rect.top - request.lastTargetTop) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX &&
+        Math.abs(state.rect.bottom - request.lastTargetBottom) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX
       );
 
       request.lastScrollHeight = scrollHeight;
       request.lastScrollTop = scrollTop;
-      request.lastTargetTop = targetRect.top;
-      request.lastTargetBottom = targetRect.bottom;
+      request.lastTargetTop = state.rect.top;
+      request.lastTargetBottom = state.rect.bottom;
       request.visibleFrames += 1;
       request.stableVisibleFrames = geometryStable ? request.stableVisibleFrames + 1 : 1;
 
@@ -2406,8 +2418,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       return true;
     };
 
-    if (isTargetVisible()) {
-      return settleIfStableVisible();
+    if (settleIfStableEndAnchored()) {
+      return true;
     }
 
     request.visibleFrames = 0;
@@ -2418,15 +2430,14 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     request.lastTargetBottom = null;
 
     if (targetElement) {
-      const targetRect = targetElement.getBoundingClientRect();
-      const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+      const state = readTargetEndState(targetElement);
       let nextScrollTop = scroller.scrollTop;
-      if (targetRect.bottom > visibleBottom) {
-        nextScrollTop += targetRect.bottom - visibleBottom;
-      } else if (targetRect.top < visibleTop) {
-        nextScrollTop -= visibleTop - targetRect.top;
+      if (state) {
+        nextScrollTop = Math.max(
+          0,
+          Math.min(state.maxScrollTop, scroller.scrollTop + state.endDeltaPx),
+        );
       }
-      nextScrollTop = Math.max(0, Math.min(maxScrollTop, nextScrollTop));
 
       if (Math.abs(nextScrollTop - scroller.scrollTop) > COMPENSATION_EPSILON_PX) {
         scroller.scrollTop = nextScrollTop;
@@ -2461,8 +2472,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       }
     }
 
-    if (isTargetVisible()) {
-      return settleIfStableVisible();
+    if (settleIfStableEndAnchored()) {
+      return true;
     }
 
     if (request.attempts >= LATEST_END_ANCHOR_STABILIZATION_MAX_ATTEMPTS) {
@@ -3188,39 +3199,77 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
         });
       }
 
-      const scrollerRect = scroller.getBoundingClientRect();
-      const targetRect = targetElement.getBoundingClientRect();
-      const inputOverlayInsetPx = Math.max(
-        0,
-        inputStackFooterPxRef.current - FLOWCHAT_MESSAGE_TAIL_CLEARANCE_PX,
-      );
-      const visibleTop = scrollerRect.top + LATEST_END_ANCHOR_VISIBILITY_MARGIN_PX;
-      const visibleBottom = Math.max(
-        visibleTop + 1,
-        scrollerRect.bottom - inputOverlayInsetPx - LATEST_END_ANCHOR_VISIBILITY_MARGIN_PX,
-      );
-      const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
-      let nextScrollTop = scroller.scrollTop;
-      if (targetRect.bottom > visibleBottom) {
-        nextScrollTop += targetRect.bottom - visibleBottom;
-      } else if (targetRect.top < visibleTop) {
-        nextScrollTop -= visibleTop - targetRect.top;
+      const readStaticTargetEndState = () => {
+        const rect = targetElement.getBoundingClientRect();
+        const scrollerRect = scroller.getBoundingClientRect();
+        const inputOverlayInsetPx = Math.max(
+          0,
+          inputStackFooterPxRef.current - FLOWCHAT_MESSAGE_TAIL_CLEARANCE_PX,
+        );
+        const visibleTop = scrollerRect.top + LATEST_END_ANCHOR_VISIBILITY_MARGIN_PX;
+        const visibleBottom = Math.max(
+          visibleTop + 1,
+          scrollerRect.bottom - inputOverlayInsetPx - LATEST_END_ANCHOR_VISIBILITY_MARGIN_PX,
+        );
+        return {
+          endDeltaPx: rect.bottom - visibleBottom,
+          maxScrollTop: Math.max(0, scroller.scrollHeight - scroller.clientHeight),
+          rect,
+          visible: rect.bottom > visibleTop && rect.top < visibleBottom,
+          visibleHeight: visibleBottom - visibleTop,
+        };
+      };
+      const canUseStaticFastPath = (state: ReturnType<typeof readStaticTargetEndState>) => {
+        const distanceFromBottom = Math.max(0, state.maxScrollTop - scroller.scrollTop);
+        return (
+          state.visible &&
+          state.rect.height <= state.visibleHeight + LATEST_END_ANCHOR_STATIC_FAST_PATH_TOLERANCE_PX &&
+          Math.abs(state.endDeltaPx) <= LATEST_END_ANCHOR_STATIC_FAST_PATH_TOLERANCE_PX &&
+          distanceFromBottom <= LATEST_END_ANCHOR_STATIC_FAST_PATH_TOLERANCE_PX
+        );
+      };
+      let staticState = readStaticTargetEndState();
+      if (!canUseStaticFastPath(staticState)) {
+        const nextScrollTop = Math.max(
+          0,
+          Math.min(staticState.maxScrollTop, scroller.scrollTop + staticState.endDeltaPx),
+        );
+        if (Math.abs(nextScrollTop - scroller.scrollTop) > COMPENSATION_EPSILON_PX) {
+          scroller.scrollTop = nextScrollTop;
+          previousScrollTopRef.current = nextScrollTop;
+          previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+          staticState = readStaticTargetEndState();
+        }
       }
-      nextScrollTop = Math.max(0, Math.min(maxScrollTop, nextScrollTop));
-
-      if (Math.abs(nextScrollTop - scroller.scrollTop) > COMPENSATION_EPSILON_PX) {
-        scroller.scrollTop = nextScrollTop;
-        previousScrollTopRef.current = nextScrollTop;
-        previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+      if (canUseStaticFastPath(staticState)) {
+        startupTrace.markPhase('flowchat_latest_end_anchor_request', {
+          targetIndex,
+          turnId,
+          virtualItemCount: virtualItems.length,
+          mode: 'static-initial-history-fast-path',
+        });
+        scheduleVisibleTurnMeasure(1);
+        return true;
       }
 
+      latestEndAnchorRequestRef.current = {
+        turnId,
+        targetIndex,
+        attempts: 0,
+        visibleFrames: 0,
+        stableVisibleFrames: 0,
+        lastScrollHeight: null,
+        lastScrollTop: null,
+        lastTargetTop: null,
+        lastTargetBottom: null,
+      };
       startupTrace.markPhase('flowchat_latest_end_anchor_request', {
         targetIndex,
         turnId,
         virtualItemCount: virtualItems.length,
         mode: 'static-initial-history',
       });
-      scheduleVisibleTurnMeasure(1);
+      resolveLatestEndAnchorStabilization('raf');
       return true;
     }
 

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -25,6 +25,7 @@ const LONG_SESSION_VIEWPORT_MAX_BOTTOM_BLANK_PX = 64;
 const LONG_SESSION_VIEWPORT_MAX_BLANK_GAP_PX = 64;
 const LONG_SESSION_LATEST_VISIBLE_MAX_BOTTOM_BLANK_PX = 96;
 const LONG_SESSION_LATEST_VISIBLE_MAX_BLANK_GAP_PX = 96;
+const LONG_SESSION_LATEST_TAIL_BOTTOM_TOLERANCE_PX = 96;
 const LONG_SESSION_INPUT_MIN_TOP_RATIO = 0.65;
 const LONG_SESSION_INPUT_BOTTOM_TOLERANCE_PX = 96;
 const LONG_SESSION_MAX_LATEST_TEXT_DELAY_AFTER_VISIBLE_MS = 120;
@@ -2588,6 +2589,37 @@ function isLongSessionLatestVisibleViewportPositioned(viewport: LongSessionViewp
   );
 }
 
+function isLongSessionLatestTailAnchored(viewport: LongSessionViewportState): boolean {
+  if (
+    !viewport.latestTurnId ||
+    viewport.scrollTop === null ||
+    viewport.scrollHeight === null ||
+    viewport.clientHeight === null ||
+    viewport.scrollerTop === null ||
+    viewport.effectiveScrollerBottom === null
+  ) {
+    return false;
+  }
+
+  const distanceFromBottom = viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop;
+  if (distanceFromBottom > LONG_SESSION_LATEST_TAIL_BOTTOM_TOLERANCE_PX) {
+    return false;
+  }
+
+  const latestVisibleItems = viewport.visibleItemSummaries
+    .filter(item => item.turnId === viewport.latestTurnId);
+  const latestTailItem = latestVisibleItems[latestVisibleItems.length - 1];
+  if (!latestTailItem) {
+    return false;
+  }
+
+  const effectiveBottomInScroller = viewport.effectiveScrollerBottom - viewport.scrollerTop;
+  return (
+    latestTailItem.bottom <= effectiveBottomInScroller + LONG_SESSION_LATEST_TAIL_BOTTOM_TOLERANCE_PX &&
+    latestTailItem.bottom >= effectiveBottomInScroller - LONG_SESSION_LATEST_TAIL_BOTTOM_TOLERANCE_PX
+  );
+}
+
 async function maybeSavePerfScreenshot(name: string): Promise<string | null> {
   if (process.env.BITFUN_E2E_PERF_SCREENSHOTS !== '1') {
     return null;
@@ -3848,9 +3880,11 @@ function expectLongSessionMeasurementUsable(
   expect(measurement.latestVisibleViewport.latestModelRoundVisible).toBe(true);
   expect(measurement.latestVisibleViewport.latestTurnId).toBe(measurement.expectedLatestTurnId);
   expect(isLongSessionLatestVisibleViewportPositioned(measurement.latestVisibleViewport)).toBe(true);
+  expect(isLongSessionLatestTailAnchored(measurement.latestVisibleViewport)).toBe(true);
   expect(measurement.latestAnswerTextVisibleViewport.latestModelRoundVisible).toBe(true);
   expect(measurement.latestAnswerTextVisibleViewport.latestModelRoundTextLength).toBeGreaterThan(0);
   expect(isLongSessionViewportUsable(measurement.latestAnswerTextVisibleViewport)).toBe(true);
+  expect(isLongSessionLatestTailAnchored(measurement.latestAnswerTextVisibleViewport)).toBe(true);
   if (measurement.viewportTimelineSummary.latestTextDelayAfterContentVisuallyVisibleMs !== null) {
     expect(measurement.viewportTimelineSummary.latestTextDelayAfterContentVisuallyVisibleMs)
       .toBeLessThanOrEqual(LONG_SESSION_MAX_LATEST_TEXT_DELAY_AFTER_VISIBLE_MS);
@@ -3904,6 +3938,7 @@ function expectLongSessionMeasurementUsable(
   expect(isLongSessionInputAnchoredNearBottom(measurement.latestVisibleViewport)).toBe(true);
   expect(isLongSessionViewportUsable(measurement.viewport)).toBe(true);
   expect(isLongSessionInputAnchoredNearBottom(measurement.viewport)).toBe(true);
+  expect(isLongSessionLatestTailAnchored(measurement.viewport)).toBe(true);
   if (
     maxLatestFrameMs !== undefined &&
     measurement.sessionOpen.latestFrameSinceHydrateMs !== undefined


### PR DESCRIPTION
﻿## Summary
- Stabilize long-session latest-tail anchoring against the target turn end, not only target visibility.
- Keep a static-history fast path when the latest rendered item already fits the viewport and is already near the natural bottom.
- Strengthen the long-session perf E2E guard so a session is not considered usable when the latest content is visible but the viewport is still far above the tail.

## Root Cause
The static initial-history path could treat a tall latest model round as successful once any part of that turn was visible. In dense history, that left the final viewport about 1068 px above the physical bottom while still showing latest content, so the old E2E checks did not catch it.

## Measurement
Release-fast build, same long-session fixtures, latest upstream baseline `7e69cc5`. Candidate values are two runs; baseline is one latest-main run. Negative delta is faster or closer to the tail.

| Scenario | Metric | Main baseline | Candidate | Delta |
|---|---:|---:|---:|---:|
| Dense long session first open | Latest usable | 977.3 ms | 898.9 ms median, 848.3-949.5 | -78.4 ms median |
| Dense long session first open | Latest visible | 980.5 ms | 901.9 ms median, 850.8-952.9 | -78.6 ms median |
| Dense long session first open | Final distance from bottom | 1068 px | 20 px | -1048 px |
| Dense long session warm reopen | Latest usable | 644.1 ms | 636.1 ms median, 623.2-648.9 | -8.0 ms median |
| Dense rapid switch | Target latest usable | 855.8 ms | 890.3 ms median, 877.6-902.9 | +34.5 ms median |
| Mixed long session first open | Latest usable | 245.4 ms | 271.2 ms median, 255.0-287.3 | +25.8 ms median |
| Mixed long session first open | Latest visible | 290.4 ms | 279.9 ms median, 256.5-303.2 | -10.5 ms median |
| Mixed long session warm reopen | Latest usable | 177.2 ms | 170.8 ms median, 165.9-175.7 | -6.4 ms median |
| Mixed rapid switch | Target latest usable | 795.2 ms | 778.2 ms median, 717.7-838.7 | -17.0 ms median |

Visual guard results for dense and mixed candidate runs: post-latest loading events 0, blank surface events 0, scroll-jump events 0.

## Risk / Impact
- Completed historical sessions whose latest turn is taller than the viewport now bias toward the latest turn tail instead of the middle of the turn. This matches the long-session open expectation, but it is a deliberate UX behavior change for that edge case.
- Static-history fast path skips the stabilization loop only when the latest rendered item fits the viewport and is already within the bottom tolerance. Tall dense items still use stabilization.
- The mixed first-open usable metric showed a small positive delta in two candidate samples, while latest-visible, warm reopen, and rapid-switch median were neutral or better. I do not treat this as a confirmed product regression, but it is listed here because this PR touches session-open timing.

## Verification
- `pnpm run type-check:web`
- `pnpm run desktop:build:release-fast`
- `pnpm run check:repo-hygiene`
- `pnpm --dir tests/e2e run test:perf` with dense fixture `perf-anchor-afbff844-dense-a-001`
- `pnpm --dir tests/e2e run test:perf` with mixed fixture `perf-anchor-afbff844-mixed-a-001`
- Regression RED was verified before the runtime fix: the stricter tail-anchor assertion failed on the dense fixture with latest-main behavior.
