### PR TITLE
refactor(prompt): restructure runtime context and add PowerShell exec guidance

### DIFF
--- a/src/crates/assembly/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/assembly/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -258,6 +258,50 @@ impl PromptBuilder {
         }
     }
 
+    fn local_exec_shell_runtime_guidance(shell_type: &str) -> &'static [&'static str] {
+        match shell_type {
+            "powershell" | "pwsh" => &[
+                "- For inline Python or other embedded scripts, prefer PowerShell-friendly forms such as `@'\\nprint(\"Hello\")\\n'@ | python -` instead of heavily nested quoting.",
+                "- In PowerShell, the escape character is the backtick (`), not backslash. `\\\"` is not a reliable way to escape a double quote for the shell.",
+                "- For environment variables, process filtering, and file traversal, prefer native PowerShell cmdlets and syntax over shell-specific Unix patterns.",
+                "- Avoid mixing PowerShell with `cmd.exe` or bash in the same command unless cross-shell behavior is explicitly required.",
+            ],
+            _ => &[],
+        }
+    }
+
+    fn push_local_exec_shell_runtime_context(
+        lines: &mut Vec<String>,
+        shell_display_name: &str,
+        shell_type: &str,
+        shell_invocation: &str,
+    ) {
+        lines.push(format!(
+            "- ExecCommand shell: {shell_display_name} ({shell_type}), invoked as {shell_invocation}."
+        ));
+        lines.extend(
+            Self::local_exec_shell_runtime_guidance(shell_type)
+                .iter()
+                .map(|line| (*line).to_string()),
+        );
+    }
+
+    fn push_runtime_context_section(
+        lines: &mut Vec<String>,
+        title: &str,
+        section_lines: Vec<String>,
+    ) {
+        if section_lines.is_empty() {
+            return;
+        }
+
+        if !lines.is_empty() {
+            lines.push(String::new());
+        }
+        lines.push(format!("## {title}"));
+        lines.extend(section_lines);
+    }
+
     /// Build runtime facts that may change independently from the agent's system prompt.
     pub async fn build_runtime_context_reminder(&self) -> Option<String> {
         let needs = self.context.runtime_context_needs;
@@ -276,61 +320,64 @@ impl PromptBuilder {
             _ => "- Computer use / `key_chord`: match modifier names to the local BitFun desktop OS.",
         };
 
-        let mut lines = vec![
-            "# Runtime Context".to_string(),
-            "<runtime_context>".to_string(),
-        ];
-
-        if needs.computer_use {
-            lines.push(format!(
-                "- Local BitFun client OS: {host_os} ({host_family})"
-            ));
-            lines.push(format!("- Local client architecture: {host_arch}"));
-            lines.push(computer_use_keys.to_string());
-        }
+        let mut lines = vec!["# Runtime Context".to_string()];
 
         if needs.workspace_tools {
+            let mut workspace_lines = Vec::new();
             if let Some(remote) = &self.context.remote_execution {
-                lines.push(format!(
+                workspace_lines.push(format!(
                     "- Workspace file and shell tools operate on remote SSH connection \"{}\".",
                     remote.connection_display_name.replace('"', "'")
                 ));
-                lines.push(format!(
+                workspace_lines.push(format!(
                     "- Remote host: {} (uname/kernel: {})",
                     remote.hostname.replace('"', "'"),
                     remote.kernel_name.replace('"', "'")
                 ));
-                if needs.computer_use {
-                    lines.push(
-                        "- Computer use and UI automation operate on the local BitFun desktop."
-                            .to_string(),
-                    );
-                }
-                lines.push("- Path conventions for workspace operations: POSIX paths with forward slashes and Unix shell syntax. Do not use PowerShell, `cmd.exe`, or Windows-style paths for remote workspace operations.".to_string());
-                if needs.exec_command {
-                    lines.push("- ExecCommand shell: the remote user's default POSIX shell, invoked as `<shell> -lc <cmd>`.".to_string());
-                }
+                workspace_lines.push("- Path conventions for workspace operations: POSIX paths with forward slashes and Unix shell syntax. Do not use PowerShell, `cmd.exe`, or Windows-style paths for remote workspace operations.".to_string());
             } else {
-                lines.push(
+                workspace_lines.push(
                     "- Workspace file and shell tools operate on the local filesystem.".to_string(),
                 );
-                if needs.exec_command {
-                    let shell = ExecCommandTool::local_shell_prompt_info().await;
-                    lines.push(format!(
-                        "- ExecCommand shell: {} ({}) at `{}` invoked as {}.",
-                        shell.display_name, shell.shell_type, shell.path, shell.invocation
-                    ));
-                }
             }
-        } else if needs.exec_command {
-            let shell = ExecCommandTool::local_shell_prompt_info().await;
-            lines.push(format!(
-                "- ExecCommand shell: {} ({}) at `{}` invoked as {}.",
-                shell.display_name, shell.shell_type, shell.path, shell.invocation
-            ));
+            Self::push_runtime_context_section(&mut lines, "Workspace Execution", workspace_lines);
         }
 
-        lines.push("</runtime_context>".to_string());
+        if needs.exec_command {
+            let mut exec_command_lines = Vec::new();
+            if self.context.remote_execution.is_some() {
+                exec_command_lines.push(
+                    "- ExecCommand uses the remote user's default POSIX shell, invoked as `<shell> -lc <cmd>`."
+                        .to_string(),
+                );
+            } else {
+                let shell = ExecCommandTool::local_shell_prompt_info().await;
+                Self::push_local_exec_shell_runtime_context(
+                    &mut exec_command_lines,
+                    &shell.display_name,
+                    &shell.shell_type,
+                    &shell.invocation,
+                );
+            }
+            Self::push_runtime_context_section(&mut lines, "ExecCommand Shell", exec_command_lines);
+        }
+
+        if needs.computer_use {
+            let mut local_client_lines = Vec::new();
+            if self.context.remote_execution.is_some() && needs.workspace_tools {
+                local_client_lines.push(
+                    "- Computer use and UI automation operate on the local BitFun desktop, even when workspace file and shell tools target a remote host."
+                        .to_string(),
+                );
+            }
+            local_client_lines.push(format!(
+                "- Local BitFun client OS: {host_os} ({host_family})"
+            ));
+            local_client_lines.push(format!("- Local client architecture: {host_arch}"));
+            local_client_lines.push(computer_use_keys.to_string());
+            Self::push_runtime_context_section(&mut lines, "Local Client", local_client_lines);
+        }
+
         Some(lines.join("\n"))
     }
 
@@ -747,10 +794,11 @@ mod tests {
         assert!(user_context.contains(USER_CONTEXT_PROMPT));
         assert!(user_context.contains("Current Working Directory: workspace/root"));
         assert!(runtime_context.contains("# Runtime Context"));
+        assert!(runtime_context.contains("## Workspace Execution"));
         assert!(runtime_context
             .contains("Workspace file and shell tools operate on the local filesystem"));
-        assert!(!runtime_context.contains("Workspace execution target:"));
-        assert!(!runtime_context.contains("Workspace root:"));
+        assert!(!runtime_context.contains("## ExecCommand Shell"));
+        assert!(!runtime_context.contains("## Local Client"));
         assert!(!runtime_context.contains("ExecCommand shell:"));
         assert_eq!(
             ordered_reminders,
@@ -788,10 +836,11 @@ mod tests {
             .expect("runtime context should build");
 
         assert!(runtime_context.contains("# Runtime Context"));
+        assert!(runtime_context.contains("## Workspace Execution"));
         assert!(runtime_context
             .contains("Workspace file and shell tools operate on the local filesystem"));
-        assert!(!runtime_context.contains("Workspace execution target:"));
-        assert!(!runtime_context.contains("Local BitFun client OS:"));
+        assert!(!runtime_context.contains("## ExecCommand Shell"));
+        assert!(!runtime_context.contains("## Local Client"));
         assert!(!runtime_context.contains("ExecCommand shell:"));
     }
 
@@ -805,8 +854,31 @@ mod tests {
             .expect("runtime context should build");
 
         assert!(runtime_context.contains("# Runtime Context"));
+        assert!(runtime_context.contains("## Workspace Execution"));
+        assert!(runtime_context.contains("## ExecCommand Shell"));
         assert!(runtime_context.contains("ExecCommand shell:"));
         assert!(runtime_context.contains("invoked as `"));
+        assert!(!runtime_context.contains("## Local Client"));
+    }
+
+    #[test]
+    fn local_exec_shell_runtime_guidance_is_added_for_powershell_shells() {
+        let guidance = PromptBuilder::local_exec_shell_runtime_guidance("powershell");
+
+        assert_eq!(
+            guidance,
+            &[
+                "- For inline Python or other embedded scripts, prefer PowerShell-friendly forms such as `@'\\nprint(\"Hello\")\\n'@ | python -` instead of heavily nested quoting.",
+                "- In PowerShell, the escape character is the backtick (`), not backslash. `\\\"` is not a reliable way to escape a double quote for the shell.",
+                "- For environment variables, process filtering, and file traversal, prefer native PowerShell cmdlets and syntax over shell-specific Unix patterns.",
+                "- Avoid mixing PowerShell with `cmd.exe` or bash in the same command unless cross-shell behavior is explicitly required.",
+            ]
+        );
+    }
+
+    #[test]
+    fn local_exec_shell_runtime_guidance_is_empty_for_non_powershell_shells() {
+        assert!(PromptBuilder::local_exec_shell_runtime_guidance("bash").is_empty());
     }
 
     #[tokio::test]
@@ -818,9 +890,11 @@ mod tests {
             .await
             .expect("runtime context should build");
 
+        assert!(runtime_context.contains("## Local Client"));
         assert!(runtime_context.contains("Local BitFun client OS:"));
         assert!(runtime_context.contains("Computer use / `key_chord`"));
-        assert!(!runtime_context.contains("Workspace execution target:"));
+        assert!(!runtime_context.contains("## Workspace Execution"));
+        assert!(!runtime_context.contains("## ExecCommand Shell"));
         assert!(!runtime_context.contains("ExecCommand shell:"));
     }
 
@@ -847,9 +921,12 @@ mod tests {
 
         assert!(runtime_context
             .contains("Workspace file and shell tools operate on remote SSH connection"));
+        assert!(runtime_context.contains("## Workspace Execution"));
+        assert!(runtime_context.contains("## ExecCommand Shell"));
+        assert!(runtime_context.contains("## Local Client"));
         assert!(runtime_context.contains("Local BitFun client OS:"));
-        assert!(!runtime_context.contains("Workspace root:"));
-        assert!(runtime_context.contains("ExecCommand shell:"));
+        assert!(runtime_context.contains("Computer use and UI automation operate on the local BitFun desktop, even when workspace file and shell tools target a remote host."));
+        assert!(runtime_context.contains("ExecCommand uses the remote user's default POSIX shell"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
- split runtime context into workspace, exec shell, and local client sections
- add local PowerShell-specific ExecCommand guidance for quoting and shell usage
- remove duplicated shell path wording from local exec shell context
- update prompt builder tests for the new runtime context structure
