### PR TITLE
fix(flow-chat): preserve explicit session selection during restore

### DIFF
--- a/src/web-ui/src/app/layout/AppLayout.tsx
+++ b/src/web-ui/src/app/layout/AppLayout.tsx
@@ -276,6 +276,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
 
   // Initialize FlowChatManager
   React.useEffect(() => {
+    let cancelled = false;
     const initializeFlowChat = async () => {
       if (!currentWorkspace?.rootPath) return;
 
@@ -305,15 +306,24 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
             ? currentWorkspace.sshHost
             : undefined
         );
+        if (cancelled) {
+          return;
+        }
 
         let sessionId: string | undefined;
         const { flowChatStore } = await import('@/flow_chat/store/FlowChatStore');
+        if (cancelled) {
+          return;
+        }
         if (!hasHistoricalSessions) {
           const initialSessionMode =
             currentWorkspace.workspaceKind === WorkspaceKind.Assistant
               ? 'Claw'
               : explicitPreferredMode || 'agentic';
           sessionId = await flowChatManager.createChatSession({}, initialSessionMode);
+          if (cancelled) {
+            return;
+          }
         }
 
         const activeSessionId = sessionId || flowChatStore.getState().activeSessionId;
@@ -326,6 +336,9 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
           sessionStorage.removeItem('pendingProjectDescription');
 
           setTimeout(async () => {
+            if (cancelled) {
+              return;
+            }
             try {
               const targetSessionId = sessionId || flowChatStore.getState().activeSessionId;
 
@@ -353,6 +366,9 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
         if (pendingSettings) {
           sessionStorage.removeItem('pendingOpenSettings');
           setTimeout(async () => {
+            if (cancelled) {
+              return;
+            }
             try {
               const { quickActions } = await import('@/shared/services/ide-control');
               await quickActions.openSettings(pendingSettings);
@@ -362,6 +378,9 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
           }, 500);
         }
       } catch (error) {
+        if (cancelled) {
+          return;
+        }
         log.error('FlowChatManager initialization failed', error);
         import('@/shared/notification-system').then(({ notificationService }) => {
           notificationService.error(t('appLayout.flowChatInitFailed'), { duration: 5000 });
@@ -370,6 +389,9 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
     };
 
     initializeFlowChat();
+    return () => {
+      cancelled = true;
+    };
   }, [
     currentWorkspace,
     currentWorkspace?.id,

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.test.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.test.ts
@@ -153,4 +153,162 @@ describe('FlowChatManager initialization', () => {
     expect(storeMocks.store.switchSession).toHaveBeenCalledTimes(1);
     expect(storeMocks.store.switchSession).toHaveBeenCalledWith('history-1');
   });
+
+  it('does not overwrite a user-selected workspace session after initial history restore completes', async () => {
+    const historyRestore = createDeferred<void>();
+    const sessions = new Map<string, any>([
+      ['history-1', createHistoricalSession({
+        sessionId: 'history-1',
+        title: 'Newest history',
+        lastActiveAt: 30,
+        lastFinishedAt: 30,
+      })],
+      ['history-2', createHistoricalSession({
+        sessionId: 'history-2',
+        title: 'User selected history',
+        lastActiveAt: 10,
+        lastFinishedAt: 10,
+      })],
+    ]);
+    let activeSessionId: string | null = null;
+
+    storeMocks.store = {
+      registerPersistUnreadCompletionCallback: vi.fn(),
+      loadSessionMetadataPage: vi.fn(async () => ({
+        sessions: [],
+        totalTopLevelCount: 2,
+        hasMore: false,
+      })),
+      getState: vi.fn(() => ({
+        sessions,
+        activeSessionId,
+      })),
+      loadSessionHistory: vi.fn(() => historyRestore.promise),
+      switchSession: vi.fn((sessionId: string) => {
+        activeSessionId = sessionId;
+      }),
+    };
+
+    const manager = FlowChatManager.getInstance();
+    const initialize = manager.initialize('D:/workspace/BitFun');
+
+    await flushAsyncWork();
+    expect(storeMocks.store.loadSessionHistory).toHaveBeenCalledWith(
+      'history-1',
+      'D:/workspace/BitFun',
+      undefined,
+      undefined,
+      undefined,
+      { deferFullHistoryUntilActive: true },
+    );
+
+    activeSessionId = 'history-2';
+    historyRestore.resolve();
+
+    await expect(initialize).resolves.toBe(true);
+
+    expect(storeMocks.store.switchSession).not.toHaveBeenCalled();
+    expect(activeSessionId).toBe('history-2');
+  });
+
+  it('does not let a stale workspace initialization overwrite a newer active workspace', async () => {
+    const historyRestore = createDeferred<void>();
+    const sessions = new Map<string, any>([
+      ['history-1', createHistoricalSession()],
+      ['other-1', createHistoricalSession({
+        sessionId: 'other-1',
+        title: 'Other workspace',
+        workspacePath: 'D:/workspace/Other',
+        lastActiveAt: 40,
+        lastFinishedAt: 40,
+      })],
+    ]);
+    let activeSessionId: string | null = null;
+
+    storeMocks.store = {
+      registerPersistUnreadCompletionCallback: vi.fn(),
+      loadSessionMetadataPage: vi.fn(async () => ({
+        sessions: [],
+        totalTopLevelCount: 1,
+        hasMore: false,
+      })),
+      getState: vi.fn(() => ({
+        sessions,
+        activeSessionId,
+      })),
+      loadSessionHistory: vi.fn(() => historyRestore.promise),
+      switchSession: vi.fn((sessionId: string) => {
+        activeSessionId = sessionId;
+      }),
+    };
+
+    const manager = FlowChatManager.getInstance();
+    const initialize = manager.initialize('D:/workspace/BitFun');
+
+    await flushAsyncWork();
+    activeSessionId = 'other-1';
+    (manager as unknown as { context: { currentWorkspacePath: string | null } })
+      .context.currentWorkspacePath = 'D:/workspace/Other';
+    historyRestore.resolve();
+
+    await expect(initialize).resolves.toBe(true);
+
+    expect(storeMocks.store.switchSession).not.toHaveBeenCalled();
+    expect(activeSessionId).toBe('other-1');
+    expect((manager as unknown as { context: { currentWorkspacePath: string | null } })
+      .context.currentWorkspacePath).toBe('D:/workspace/Other');
+  });
+
+  it('does not let an older workspace initialization switch after a newer workspace initialize starts', async () => {
+    const bitfunHistoryRestore = createDeferred<void>();
+    const sessions = new Map<string, any>([
+      ['history-1', createHistoricalSession()],
+      ['other-1', createHistoricalSession({
+        sessionId: 'other-1',
+        title: 'Other workspace',
+        workspacePath: 'D:/workspace/Other',
+        lastActiveAt: 40,
+        lastFinishedAt: 40,
+      })],
+    ]);
+    let activeSessionId: string | null = null;
+
+    storeMocks.store = {
+      registerPersistUnreadCompletionCallback: vi.fn(),
+      loadSessionMetadataPage: vi.fn(async (
+        workspacePath: string,
+      ) => ({
+        sessions: [],
+        totalTopLevelCount: workspacePath === 'D:/workspace/BitFun' ? 1 : 0,
+        hasMore: false,
+      })),
+      getState: vi.fn(() => ({
+        sessions,
+        activeSessionId,
+      })),
+      loadSessionHistory: vi.fn((sessionId: string) => {
+        if (sessionId === 'history-1') {
+          return bitfunHistoryRestore.promise;
+        }
+        return Promise.resolve();
+      }),
+      switchSession: vi.fn((sessionId: string) => {
+        activeSessionId = sessionId;
+      }),
+    };
+
+    const manager = FlowChatManager.getInstance();
+    const bitfunInitialize = manager.initialize('D:/workspace/BitFun');
+
+    await flushAsyncWork();
+    await expect(manager.initialize('D:/workspace/Other')).resolves.toBe(true);
+
+    bitfunHistoryRestore.resolve();
+    await expect(bitfunInitialize).resolves.toBe(true);
+
+    expect(storeMocks.store.switchSession).toHaveBeenCalledWith('other-1');
+    expect(storeMocks.store.switchSession).not.toHaveBeenCalledWith('history-1');
+    expect((manager as unknown as { context: { currentWorkspacePath: string | null } })
+      .context.currentWorkspacePath).toBe('D:/workspace/Other');
+  });
 });

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -54,6 +54,7 @@ export class FlowChatManager {
   private eventListenerInitializationPromise: Promise<void> | null = null;
   private eventListenerCleanup: (() => void) | null = null;
   private initializationRequests = new Map<string, Promise<boolean>>();
+  private latestInitializationRequestKey: string | null = null;
 
   private constructor() {
     this.context = {
@@ -107,12 +108,14 @@ export class FlowChatManager {
       remoteSshHost,
     );
     const existingRequest = this.initializationRequests.get(requestKey);
+    this.latestInitializationRequestKey = requestKey;
     if (existingRequest) {
       return existingRequest;
     }
 
     let request: Promise<boolean>;
     request = this.initializeWorkspace(
+      requestKey,
       workspacePath,
       preferredMode,
       remoteConnectionId,
@@ -141,6 +144,7 @@ export class FlowChatManager {
   }
 
   private async initializeWorkspace(
+    requestKey: string,
     workspacePath: string,
     preferredMode?: string,
     remoteConnectionId?: string,
@@ -214,13 +218,19 @@ export class FlowChatManager {
         workspaceSessions.length > 0 ||
         initialMetadataPage.totalTopLevelCount > 0 ||
         initialMetadataPage.sessions.length > 0;
+      const isCurrentInitializationRequest = () =>
+        this.latestInitializationRequestKey === requestKey;
       const activeSession = state.activeSessionId
         ? state.sessions.get(state.activeSessionId) ?? null
         : null;
       const activeSessionBelongsToWorkspace =
         !!activeSession && sessionMatchesWorkspace(activeSession);
+      const activeSessionIdAtAutoSelectStart = state.activeSessionId;
 
       if (hasHistoricalSessions && !activeSessionBelongsToWorkspace) {
+        if (!isCurrentInitializationRequest()) {
+          return hasHistoricalSessions;
+        }
         const sortedWorkspaceSessions = [...workspaceSessions].sort(compareSessionsForDisplay);
         const latestSession = (preferredMode
           ? sortedWorkspaceSessions.find(session => session.mode === preferredMode)
@@ -242,10 +252,33 @@ export class FlowChatManager {
           );
         }
 
+        if (!isCurrentInitializationRequest()) {
+          return hasHistoricalSessions;
+        }
+
+        const currentState = this.context.flowChatStore.getState();
+        const currentActiveSession = currentState.activeSessionId
+          ? currentState.sessions.get(currentState.activeSessionId) ?? null
+          : null;
+        const currentActiveSessionBelongsToWorkspace =
+          !!currentActiveSession && sessionMatchesWorkspace(currentActiveSession);
+        const activeSessionChangedDuringAutoSelect =
+          currentState.activeSessionId !== activeSessionIdAtAutoSelectStart &&
+          currentState.activeSessionId !== null;
+        if (currentActiveSessionBelongsToWorkspace) {
+          this.context.currentWorkspacePath = workspacePath;
+          return hasHistoricalSessions;
+        }
+        if (activeSessionChangedDuringAutoSelect) {
+          return hasHistoricalSessions;
+        }
+
         this.context.flowChatStore.switchSession(latestSession.sessionId);
       }
 
-      this.context.currentWorkspacePath = workspacePath;
+      if (isCurrentInitializationRequest()) {
+        this.context.currentWorkspacePath = workspacePath;
+      }
 
       return hasHistoricalSessions;
     } catch (error) {

--- a/tests/e2e/scripts/generate-long-session-fixture.mjs
+++ b/tests/e2e/scripts/generate-long-session-fixture.mjs
@@ -100,8 +100,8 @@ function parseArgs(argv) {
   if (!options.sessionPrefix.trim()) {
     throw new Error('--session-prefix cannot be empty');
   }
-  if (!['explore-only', 'mixed-visible', 'dense-visible'].includes(options.scenario)) {
-    throw new Error('--scenario must be one of: explore-only, mixed-visible, dense-visible');
+  if (!['explore-only', 'mixed-visible', 'dense-visible', 'user-only-latest'].includes(options.scenario)) {
+    throw new Error('--scenario must be one of: explore-only, mixed-visible, dense-visible, user-only-latest');
   }
   return options;
 }
@@ -122,7 +122,7 @@ Options:
   --tool-items <n>          Tool item count per turn. Default: 2
   --dense-groups <n>        Groups in the latest dense-visible turn. Default: 160
   --session-prefix <text>   Session id prefix. Default: perf-long-session
-  --scenario <name>         Fixture shape: mixed-visible, dense-visible, or explore-only. Default: mixed-visible
+  --scenario <name>         Fixture shape: mixed-visible, dense-visible, explore-only, or user-only-latest. Default: mixed-visible
   --bitfun-home <path>      BitFun home root. Default: BITFUN_HOME or ~/.bitfun
   --cleanup                 Remove generated sessions for the prefix.
 `);
@@ -196,7 +196,7 @@ function makeMetadata({ sessionId, sessionName, workspacePath, createdAt, lastAc
     createdAt,
     lastActiveAt,
     turnCount,
-    messageCount: turnCount * 2,
+    messageCount: scenario === 'user-only-latest' ? (turnCount * 2) - 1 : turnCount * 2,
     toolCallCount: turnCount * toolItems,
     status: 'active',
     terminalSessionId: null,
@@ -415,7 +415,9 @@ function makeTurn({
   const turnId = `${sessionId}-turn-${String(turnIndex).padStart(4, '0')}`;
   const toolItemsData = makeToolItems({ turnId, turnIndex, timestamp, toolResultChars, toolItems });
   const isLatestTurn = turnIndex === totalTurns - 1;
-  const modelRounds = scenario === 'dense-visible' && isLatestTurn
+  const modelRounds = scenario === 'user-only-latest' && isLatestTurn
+    ? []
+    : scenario === 'dense-visible' && isLatestTurn
     ? makeDenseLatestModelRounds({
       turnId,
       turnIndex,

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -82,6 +82,10 @@ type LongSessionViewportState = {
   bottomBlankPx: number | null;
 };
 
+type LongSessionViewportUsabilityOptions = {
+  requireLatestModelRound?: boolean;
+};
+
 type LongSessionViewportTimelineSample = {
   atMs: number;
   sinceClickMs: number;
@@ -2562,15 +2566,28 @@ async function waitForLatestLongSessionTurnVisible(timeoutMs: number, expectedLa
   };
 }
 
-function isLongSessionViewportUsable(viewport: LongSessionViewportState): boolean {
+function requiresLatestModelRoundForFixture(fixtureScenario: string | null): boolean {
+  return fixtureScenario !== 'user-only-latest';
+}
+
+function isLongSessionViewportUsable(
+  viewport: LongSessionViewportState,
+  options: LongSessionViewportUsabilityOptions = {},
+): boolean {
+  const requiresLatestModelRound = options.requireLatestModelRound !== false;
   const coverageRatio = viewport.coverageRatio ?? 0;
   const bottomBlankPx = viewport.bottomBlankPx ?? Number.POSITIVE_INFINITY;
   const largestBlankGapPx = viewport.largestBlankGapPx ?? Number.POSITIVE_INFINITY;
   return (
     viewport.latestContentVisible &&
     viewport.latestContentVisuallyVisible &&
-    viewport.latestModelRoundVisible &&
-    viewport.latestModelRoundTextLength > 0 &&
+    (
+      !requiresLatestModelRound ||
+      (
+        viewport.latestModelRoundVisible &&
+        viewport.latestModelRoundTextLength > 0
+      )
+    ) &&
     coverageRatio >= LONG_SESSION_VIEWPORT_MIN_COVERAGE_RATIO &&
     bottomBlankPx <= LONG_SESSION_VIEWPORT_MAX_BOTTOM_BLANK_PX &&
     largestBlankGapPx <= LONG_SESSION_VIEWPORT_MAX_BLANK_GAP_PX
@@ -3386,7 +3403,11 @@ function summarizeLongSessionVisualStateEvents(
   };
 }
 
-async function waitForLatestLongSessionViewportUsable(timeoutMs: number, expectedLatestTurnId?: string | null): Promise<{
+async function waitForLatestLongSessionViewportUsable(
+  timeoutMs: number,
+  expectedLatestTurnId?: string | null,
+  options: LongSessionViewportUsabilityOptions = {},
+): Promise<{
   usableAtMs: number;
   viewport: LongSessionViewportState;
 }> {
@@ -3394,7 +3415,7 @@ async function waitForLatestLongSessionViewportUsable(timeoutMs: number, expecte
   try {
     await browser.waitUntil(async () => {
       viewport = await readLongSessionViewportState(expectedLatestTurnId);
-      return isLongSessionViewportUsable(viewport);
+      return isLongSessionViewportUsable(viewport, options);
     }, {
       timeout: timeoutMs,
       interval: 50,
@@ -3683,6 +3704,7 @@ async function collectLongSessionOpenMeasurement(
     throw new Error(`Could not resolve expected latest turn id for session ${sessionId}`);
   }
   const fixtureScenario = await readLongSessionFixtureScenario(sessionId);
+  const requireLatestModelRound = requiresLatestModelRoundForFixture(fixtureScenario);
 
   const requireFrameTrace = options.requireFrameTrace !== false;
   const afterFrameTimeoutMs = requireFrameTrace ? 20000 : 1000;
@@ -3714,7 +3736,11 @@ async function collectLongSessionOpenMeasurement(
 
   await item.click();
   const latestVisiblePromise = waitForLatestLongSessionTurnVisible(5000, expectedLatestTurnId);
-  const latestUsablePromise = waitForLatestLongSessionViewportUsable(5000, expectedLatestTurnId);
+  const latestUsablePromise = waitForLatestLongSessionViewportUsable(
+    5000,
+    expectedLatestTurnId,
+    { requireLatestModelRound },
+  );
   const postVisibleInteraction = readPostVisibleInteractionOption(options);
   let latestVisible: Awaited<typeof latestVisiblePromise> | null = null;
   let latestUsable: Awaited<typeof latestUsablePromise> | null = null;
@@ -3764,10 +3790,11 @@ async function collectLongSessionOpenMeasurement(
   }
   let finalViewport = await readLongSessionViewportState(expectedLatestTurnId);
   let finalViewportCheckedAtMs = await readPerformanceNow();
-  if (!isLongSessionViewportUsable(finalViewport)) {
+  if (!isLongSessionViewportUsable(finalViewport, { requireLatestModelRound })) {
     const finalUsable = await waitForLatestLongSessionViewportUsable(
       3000,
       expectedLatestTurnId,
+      { requireLatestModelRound },
     );
     finalViewport = finalUsable.viewport;
     finalViewportCheckedAtMs = finalUsable.usableAtMs;
@@ -3856,6 +3883,7 @@ function expectLongSessionMeasurementUsable(
   maxLatestFrameMs?: number,
   options: LongSessionOpenMeasurementOptions = {},
 ): void {
+  const requireLatestModelRound = requiresLatestModelRoundForFixture(measurement.fixtureScenario);
   expect(measurement.clickToLatestVisibleMs).toBeGreaterThan(0);
   expect(measurement.clickToLatestUsableMs).toBeGreaterThan(0);
   if (options.requireFrameTrace !== false && measurement.traceWaitErrors.length === 0) {
@@ -3870,30 +3898,46 @@ function expectLongSessionMeasurementUsable(
   expect(measurement.viewport.latestContentVisible).toBe(true);
   expect(measurement.viewport.latestContentVisuallyVisible).toBe(true);
   expect(measurement.viewport.historyPlaceholderCoversMessages).toBe(false);
-  expect(measurement.viewport.latestModelRoundVisible).toBe(true);
-  expect(measurement.viewport.latestModelRoundTextLength).toBeGreaterThan(0);
+  if (requireLatestModelRound) {
+    expect(measurement.viewport.latestModelRoundVisible).toBe(true);
+    expect(measurement.viewport.latestModelRoundTextLength).toBeGreaterThan(0);
+  } else {
+    expect(measurement.viewport.latestVisible).toBe(true);
+  }
   expect(measurement.viewport.latestTurnId).toBe(measurement.expectedLatestTurnId);
   expect(measurement.latestVisibleViewport.hasScroller).toBe(true);
   expect(measurement.latestVisibleViewport.latestContentVisible).toBe(true);
   expect(measurement.latestVisibleViewport.latestContentVisuallyVisible).toBe(true);
   expect(measurement.latestVisibleViewport.historyPlaceholderCoversMessages).toBe(false);
-  expect(measurement.latestVisibleViewport.latestModelRoundVisible).toBe(true);
+  if (requireLatestModelRound) {
+    expect(measurement.latestVisibleViewport.latestModelRoundVisible).toBe(true);
+  } else {
+    expect(measurement.latestVisibleViewport.latestVisible).toBe(true);
+  }
   expect(measurement.latestVisibleViewport.latestTurnId).toBe(measurement.expectedLatestTurnId);
   expect(isLongSessionLatestVisibleViewportPositioned(measurement.latestVisibleViewport)).toBe(true);
   expect(isLongSessionLatestTailAnchored(measurement.latestVisibleViewport)).toBe(true);
-  expect(measurement.latestAnswerTextVisibleViewport.latestModelRoundVisible).toBe(true);
-  expect(measurement.latestAnswerTextVisibleViewport.latestModelRoundTextLength).toBeGreaterThan(0);
-  expect(isLongSessionViewportUsable(measurement.latestAnswerTextVisibleViewport)).toBe(true);
-  expect(isLongSessionLatestTailAnchored(measurement.latestAnswerTextVisibleViewport)).toBe(true);
-  if (measurement.viewportTimelineSummary.latestTextDelayAfterContentVisuallyVisibleMs !== null) {
-    expect(measurement.viewportTimelineSummary.latestTextDelayAfterContentVisuallyVisibleMs)
-      .toBeLessThanOrEqual(LONG_SESSION_MAX_LATEST_TEXT_DELAY_AFTER_VISIBLE_MS);
+  if (requireLatestModelRound) {
+    expect(measurement.latestAnswerTextVisibleViewport.latestModelRoundVisible).toBe(true);
+    expect(measurement.latestAnswerTextVisibleViewport.latestModelRoundTextLength).toBeGreaterThan(0);
+    expect(isLongSessionViewportUsable(measurement.latestAnswerTextVisibleViewport)).toBe(true);
+    expect(isLongSessionLatestTailAnchored(measurement.latestAnswerTextVisibleViewport)).toBe(true);
+    if (measurement.viewportTimelineSummary.latestTextDelayAfterContentVisuallyVisibleMs !== null) {
+      expect(measurement.viewportTimelineSummary.latestTextDelayAfterContentVisuallyVisibleMs)
+        .toBeLessThanOrEqual(LONG_SESSION_MAX_LATEST_TEXT_DELAY_AFTER_VISIBLE_MS);
+    }
+    expect(measurement.viewportTimelineSummary.preLatestTextVisibleBlankWithoutPlaceholderSampleCount).toBe(0);
+    expect(measurement.viewportTimelineSummary.preLatestTextVisibleUncoveredAfterIntentSampleCount).toBe(0);
+    expect(measurement.viewportTimelineSummary.postLatestTextVisibleBlankSampleCount).toBe(0);
+    expect(measurement.viewportTimelineSummary.postLatestTextVisibleCoveredSampleCount).toBe(0);
+    expect(measurement.viewportTimelineSummary.postLatestTextVisibleLatestContentMissingSampleCount).toBe(0);
+  } else {
+    expect(isLongSessionViewportUsable(
+      measurement.latestAnswerTextVisibleViewport,
+      { requireLatestModelRound: false },
+    )).toBe(true);
+    expect(isLongSessionLatestTailAnchored(measurement.latestAnswerTextVisibleViewport)).toBe(true);
   }
-  expect(measurement.viewportTimelineSummary.preLatestTextVisibleBlankWithoutPlaceholderSampleCount).toBe(0);
-  expect(measurement.viewportTimelineSummary.preLatestTextVisibleUncoveredAfterIntentSampleCount).toBe(0);
-  expect(measurement.viewportTimelineSummary.postLatestTextVisibleBlankSampleCount).toBe(0);
-  expect(measurement.viewportTimelineSummary.postLatestTextVisibleCoveredSampleCount).toBe(0);
-  expect(measurement.viewportTimelineSummary.postLatestTextVisibleLatestContentMissingSampleCount).toBe(0);
   const latestAnchorFailures = measurement.events.filter(event =>
     event.phase === 'historical_session_latest_anchor_failed' &&
     traceEventSessionId(event) === measurement.sessionId
@@ -3910,13 +3954,15 @@ function expectLongSessionMeasurementUsable(
     expect(measurement.visualStateSummary.overlayCountToggleCount).toBe(0);
     expect(measurement.visualStateSummary.placeholderCountToggleCount).toBe(0);
     expect(measurement.visualStateSummary.postFirstVisibleItemLoadingEventCount).toBe(0);
-    expect(measurement.visualStateSummary.postLatestTextVisibleLoadingEventCount).toBe(0);
-    expect(measurement.visualStateSummary.postLatestTextVisibleLoadingSurfacePointEventCount).toBe(0);
-    expect(measurement.visualStateSummary.postLatestTextVisibleBlankSurfacePointEventCount).toBe(0);
-    expect(measurement.visualStateSummary.postLatestTextVisibleTransparentSurfacePointEventCount).toBe(0);
-    expect(measurement.visualStateSummary.postLatestTextVisibleScrollJumpCount).toBe(0);
-    expect(measurement.visualStateSummary.postLatestTextVisibleVirtualItemElementChangeCount).toBe(0);
-    expect(measurement.visualStateSummary.postLatestTextVisibleLayoutShiftScore).toBeLessThanOrEqual(0.005);
+    if (requireLatestModelRound) {
+      expect(measurement.visualStateSummary.postLatestTextVisibleLoadingEventCount).toBe(0);
+      expect(measurement.visualStateSummary.postLatestTextVisibleLoadingSurfacePointEventCount).toBe(0);
+      expect(measurement.visualStateSummary.postLatestTextVisibleBlankSurfacePointEventCount).toBe(0);
+      expect(measurement.visualStateSummary.postLatestTextVisibleTransparentSurfacePointEventCount).toBe(0);
+      expect(measurement.visualStateSummary.postLatestTextVisibleScrollJumpCount).toBe(0);
+      expect(measurement.visualStateSummary.postLatestTextVisibleVirtualItemElementChangeCount).toBe(0);
+      expect(measurement.visualStateSummary.postLatestTextVisibleLayoutShiftScore).toBeLessThanOrEqual(0.005);
+    }
     expect(measurement.visualStateSummary.openIntentBlankSurfacePointEventCount).toBe(0);
     expect(measurement.visualStateSummary.openIntentBlankSurfaceHoldCount).toBe(0);
     expect(measurement.visualStateSummary.postOpenIntentNonTargetContentEventCount).toBe(0);
@@ -3936,7 +3982,7 @@ function expectLongSessionMeasurementUsable(
     expect(measurement.latestVisibleViewport.visibleModelRoundCount).toBeGreaterThan(0);
   }
   expect(isLongSessionInputAnchoredNearBottom(measurement.latestVisibleViewport)).toBe(true);
-  expect(isLongSessionViewportUsable(measurement.viewport)).toBe(true);
+  expect(isLongSessionViewportUsable(measurement.viewport, { requireLatestModelRound })).toBe(true);
   expect(isLongSessionInputAnchoredNearBottom(measurement.viewport)).toBe(true);
   expect(isLongSessionLatestTailAnchored(measurement.viewport)).toBe(true);
   if (


### PR DESCRIPTION
## Summary

Fix session restore races where async historical initialization could overwrite a user-selected session or an active workspace after the user had already moved on.

## Root cause

`FlowChatManager.initializeWorkspace()` auto-selected the latest historical session and awaited `loadSessionHistory()` before calling `switchSession()`. If the user clicked another session during that await, the stale initialization could still switch back to the auto-selected session. A stricter review also found the same class of issue at workspace scope: an older workspace initialization could continue after a newer workspace became active and then write old workspace/session side effects.

## Changes

- Re-read the active session after historical restore completes and skip the stale auto-switch when the user selected another session during restore.
- Gate workspace initialization writes with a latest-request key so older workspace initialization cannot overwrite the newer active workspace path.
- Add `AppLayout` effect cleanup guards so stale initialization effects do not create sessions, send pending project descriptions, open pending settings, or show stale errors after workspace changes.
- Add unit coverage for same-workspace user selection and cross-workspace stale initialization.
- Add a `user-only-latest` E2E fixture scenario so historical sessions whose latest turn has no model response are validated against the latest visible content.

## Validation

| Check | Result |
| --- | --- |
| `pnpm --dir src/web-ui run test:run src/flow_chat/services/FlowChatManager.test.ts` | 4 tests passed |
| `pnpm run type-check:web` | Passed |
| `pnpm run check:repo-hygiene` | Passed |
| `pnpm run desktop:build:release-fast` | Passed |
| release-fast controlled rapid switch E2E | 4 tests passed; target latest visible 2772.0 ms, usable 2982.4 ms; blank/loading/scroll-jump/non-target hold counts all 0 |
| release-fast user-only latest E2E | 4 tests passed; first open latest visible 286.5 ms, usable 424.8 ms, full hydrate 1116.0 ms; blank/loading/scroll-jump/non-target hold counts all 0 |

## Risk

- Normal initialization without user interaction still auto-selects the latest historical session.
- This does not change remote session loading, history hydration policy, startup gating, or rendering strategy.
- The E2E timing values above are validation observations for this correctness fix, not a claimed performance improvement.