### PR TITLE
feat: add Write append mode and polish exec tool UX

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/command.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/command.rs
@@ -773,14 +773,21 @@ impl Tool for ExecCommandTool {
     }
 
     async fn description(&self) -> BitFunResult<String> {
-        Ok(r#"Runs a shell command.
+        Ok(r#"Runs a shell command in a separate process.
 
-Each call starts a separate process.
-Use tty=true only for commands that need interactive stdin; otherwise leave tty=false.
-yield_time_ms waits for output until the process exits or the deadline is reached. It does not stop the process.
-If the process is still running, the result includes a numeric session_id. Use WriteStdin to poll for more output or send input to tty=true sessions, and ExecControl to interrupt or kill it.
-Output is only what was produced during this tool call's wait window.
-With tty=false, stdout and stderr ordering is not guaranteed; use tty=true or redirect stderr with 2>&1 when terminal ordering matters."#
+TTY and stdin:
+- tty=true allocates a PTY and gives the command terminal semantics. Use tty=true only for commands that need interactive stdin.
+- tty=false runs without a PTY. Locally this uses pipe-backed stdio; remotely it uses a non-PTY SSH exec channel.
+- With tty=false, no interactive stdin is attached, and input-waiting programs may see EOF instead of a prompt.
+
+Waiting and continuation:
+- yield_time_ms waits for output until the process exits or the deadline is reached. It does not stop the process.
+- If the process is still running after `yield_time_ms`, the result includes a numeric session_id.
+- Use WriteStdin to poll for more output or send input to tty=true sessions, and ExecControl to interrupt or kill it.
+
+Output:
+- Output is only what was produced during this tool call's wait window.
+- With tty=false, stdout and stderr ordering is not guaranteed; use tty=true or redirect stderr with 2>&1 when terminal ordering matters."#
             .to_string())
     }
 
@@ -813,7 +820,7 @@ With tty=false, stdout and stderr ordering is not guaranteed; use tty=true or re
                 },
                 "yield_time_ms": {
                     "type": "number",
-                    "description": "How long to wait for output before yielding. This does not stop the process."
+                    "description": "How long to wait for output before yielding."
                 },
                 "max_output_chars": {
                     "type": "number",

--- a/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/control.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/control.rs
@@ -382,7 +382,8 @@ impl Tool for ExecControlTool {
 
 Pass the session_id returned by ExecCommand.
 Use action="interrupt" when a command should stop gracefully, like pressing Ctrl+C. Use action="kill" when the process must be terminated.
-After the action, yield_time_ms waits for output or exit status. Output is only what was produced during this tool call's wait window."#
+After the action, yield_time_ms waits for output or exit status.
+Output is only what was produced during this tool call's wait window."#
             .to_string())
     }
 
@@ -396,7 +397,7 @@ After the action, yield_time_ms waits for output or exit status. Output is only 
             "properties": {
                 "session_id": {
                     "type": "number",
-                    "description": "session_id returned by ExecCommand while a process is still running."
+                    "description": "session_id returned by ExecCommand."
                 },
                 "action": {
                     "type": "string",

--- a/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -1,6 +1,3 @@
-use crate::agentic::execution::write_content_sanitizer::{
-    contains_tool_invocation_artifacts, strip_tool_invocation_artifacts,
-};
 use crate::agentic::tools::file_read_state_runtime::{
     assert_file_not_unexpectedly_modified, file_mutation_timestamp_ms, get_stored_file_read_state,
     local_file_modification_time_ms, read_current_file_content, read_state_tracking_enabled,
@@ -19,7 +16,7 @@ use async_trait::async_trait;
 use serde_json::{json, Value};
 use std::path::Path;
 use tokio::fs;
-use tool_runtime::fs::{write_local_file, WriteLocalFileRequest};
+use tool_runtime::fs::{write_local_file, WriteLocalFileMode, WriteLocalFileRequest};
 
 pub struct FileWriteTool;
 
@@ -37,12 +34,21 @@ impl FileWriteTool {
         Self
     }
 
-    fn guidance_failure(message: String) -> ValidationResult {
-        ValidationResult {
-            result: false,
-            message: Some(file_tool_guidance_message(message)),
-            error_code: Some(400),
-            meta: Some(json!({ "failure_kind": "guidance" })),
+    fn parse_mode_value(mode: Option<&str>) -> Result<WriteLocalFileMode, String> {
+        match mode.unwrap_or("w") {
+            "w" => Ok(WriteLocalFileMode::Write),
+            "a" => Ok(WriteLocalFileMode::Append),
+            other => Err(format!(
+                "mode must be either 'w' (overwrite) or 'a' (append), got '{}'",
+                other
+            )),
+        }
+    }
+
+    fn mode_label(mode: WriteLocalFileMode) -> &'static str {
+        match mode {
+            WriteLocalFileMode::Write => "w",
+            WriteLocalFileMode::Append => "a",
         }
     }
 
@@ -171,6 +177,7 @@ impl FileWriteTool {
 
     fn write_success_result(
         logical_path: &str,
+        mode: WriteLocalFileMode,
         bytes_written: usize,
         lines_written: usize,
         status: &str,
@@ -179,6 +186,7 @@ impl FileWriteTool {
         ToolResult::Result {
             data: json!({
                 "file_path": logical_path,
+                "mode": Self::mode_label(mode),
                 "bytes_written": bytes_written,
                 "lines_written": lines_written,
                 "success": true,
@@ -201,6 +209,11 @@ impl FileWriteTool {
                 "content": {
                     "type": "string",
                     "description": "The content to write to the file"
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["w", "a"],
+                    "description": "Write mode: 'w' overwrites the file (default), 'a' appends to the file and creates it if missing"
                 }
             },
             "required": ["file_path", "content"],
@@ -212,8 +225,9 @@ impl FileWriteTool {
         r#"Writes a file to the local filesystem.
 
 Usage:
-- This tool will overwrite the existing file if there is one at the provided path.
-- Always emit `file_path` before `content` in the tool input JSON so the path is available while content streams.
+- Always output `file_path` first when calling this tool. Example: `{"file_path": "src/main.rs", "content": "fn main() {}"}`.
+- This tool defaults to `mode=\"w\"`, which overwrites the existing file if there is one at the provided path.
+- Use `mode=\"a\"` to append content; it also creates the file if it does not exist.
 - If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first.
 - Prefer the Edit tool for modifying existing files — it only sends the diff. Only use this tool to create new files or for complete rewrites.
 - NEVER create documentation files (*.md) or README files unless explicitly requested by the User.
@@ -351,6 +365,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn call_impl_appends_when_mode_is_append() {
+        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create temp workspace");
+        std::fs::write(root.join("existing.md"), "old").expect("create existing file");
+
+        let tool = FileWriteTool::new();
+        let results = tool
+            .call(
+                &json!({ "file_path": "existing.md", "content": "\nnew", "mode": "a" }),
+                &local_context(root.clone()),
+            )
+            .await
+            .expect("append should succeed");
+
+        let written = std::fs::read_to_string(root.join("existing.md")).expect("read file");
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert_eq!(written, "old\nnew");
+
+        let ToolResult::Result { data, .. } = &results[0] else {
+            panic!("expected result");
+        };
+        assert_eq!(data["status"], "appended");
+        assert_eq!(data["mode"], "a");
+        assert_eq!(data["bytes_written"], "\nnew".len());
+    }
+
+    #[tokio::test]
     async fn schema_requires_file_path_and_content() {
         let tool = FileWriteTool::new();
 
@@ -361,27 +403,10 @@ mod tests {
             serde_json::json!(["file_path", "content"])
         );
         assert!(schema["properties"].get("content").is_some());
-    }
-
-    #[tokio::test]
-    async fn validate_input_rejects_tool_invocation_content() {
-        let tool = FileWriteTool::new();
-
-        let validation = tool
-            .validate_input(
-                &json!({
-                    "file_path": "notes.md",
-                    "content": "<tool_calls><invoke name=\"Write\"></invoke></tool_calls>"
-                }),
-                None,
-            )
-            .await;
-
-        assert!(!validation.result);
-        assert!(validation
-            .message
-            .as_deref()
-            .is_some_and(|message| message.contains("tool-invocation syntax")));
+        assert_eq!(
+            schema["properties"]["mode"]["enum"],
+            serde_json::json!(["w", "a"])
+        );
     }
 
     #[tokio::test]
@@ -394,6 +419,24 @@ mod tests {
 
         assert!(!validation.result);
         assert_eq!(validation.message.as_deref(), Some("content is required"));
+    }
+
+    #[tokio::test]
+    async fn validate_input_rejects_invalid_mode() {
+        let tool = FileWriteTool::new();
+
+        let validation = tool
+            .validate_input(
+                &json!({ "file_path": "new.txt", "content": "hello", "mode": "x" }),
+                None,
+            )
+            .await;
+
+        assert!(!validation.result);
+        assert_eq!(
+            validation.message.as_deref(),
+            Some("mode must be either 'w' (overwrite) or 'a' (append), got 'x'")
+        );
     }
 }
 
@@ -471,14 +514,15 @@ impl Tool for FileWriteTool {
             };
         }
 
-        if let Some(content) = input.get("content").and_then(|v| v.as_str()) {
-            if contains_tool_invocation_artifacts(content) {
-                return Self::guidance_failure(
-                    "Write content looks like tool-invocation syntax instead of raw file content. \
-                     Output the file body directly in the `content` field without nested tool calls."
-                        .to_string(),
-                );
-            }
+        if let Err(message) =
+            Self::parse_mode_value(input.get("mode").and_then(|value| value.as_str()))
+        {
+            return ValidationResult {
+                result: false,
+                message: Some(message),
+                error_code: Some(400),
+                meta: None,
+            };
         }
 
         let large_write_warning =
@@ -531,6 +575,8 @@ impl Tool for FileWriteTool {
     }
 
     fn render_tool_use_message(&self, input: &Value, options: &ToolRenderOptions) -> String {
+        let mode = Self::parse_mode_value(input.get("mode").and_then(|v| v.as_str()))
+            .unwrap_or(WriteLocalFileMode::Write);
         if let Some(file_path) = input.get("file_path").and_then(|v| v.as_str()) {
             if options.verbose {
                 let content_len = input
@@ -538,9 +584,19 @@ impl Tool for FileWriteTool {
                     .and_then(|v| v.as_str())
                     .map(|s| s.len())
                     .unwrap_or(0);
-                format!("Writing {} characters to {}", content_len, file_path)
+                match mode {
+                    WriteLocalFileMode::Write => {
+                        format!("Writing {} characters to {}", content_len, file_path)
+                    }
+                    WriteLocalFileMode::Append => {
+                        format!("Appending {} characters to {}", content_len, file_path)
+                    }
+                }
             } else {
-                format!("Write {}", file_path)
+                match mode {
+                    WriteLocalFileMode::Write => format!("Write {}", file_path),
+                    WriteLocalFileMode::Append => format!("Append {}", file_path),
+                }
             }
         } else {
             "Writing file".to_string()
@@ -571,26 +627,18 @@ impl Tool for FileWriteTool {
             .get("content")
             .and_then(|v| v.as_str())
             .ok_or_else(|| BitFunError::tool("content is required".to_string()))?;
-        let content = strip_tool_invocation_artifacts(content);
-        if content.is_empty() {
-            return Err(BitFunError::tool(file_tool_guidance_message(
-                "Write content is empty after removing tool-invocation syntax. \
-                 Provide the raw file body in the `content` field.",
-            )));
-        }
-        if contains_tool_invocation_artifacts(&content) {
-            return Err(BitFunError::tool(file_tool_guidance_message(
-                "Write content still contains tool-invocation syntax after sanitization. \
-                 Provide raw file content only.",
-            )));
-        }
+        let content = content.to_string();
+        let mode = Self::parse_mode_value(input.get("mode").and_then(|v| v.as_str()))
+            .map_err(BitFunError::tool)?;
 
         let file_already_exists = Self::file_exists(context, &resolved).await;
-        if file_already_exists
+        if mode == WriteLocalFileMode::Write
+            && file_already_exists
             && Self::existing_file_matches_content(context, &resolved, &content).await == Some(true)
         {
             let result = Self::write_success_result(
                 &resolved.logical_path,
+                mode,
                 0,
                 0,
                 "already_exists_same_content",
@@ -603,40 +651,64 @@ impl Tool for FileWriteTool {
         }
 
         Self::assert_atomic_write_freshness_if_exists(context, &resolved).await?;
+        let final_content = match (mode, file_already_exists) {
+            (WriteLocalFileMode::Append, true) => {
+                let mut existing = read_current_file_content(context, &resolved).await?;
+                existing.push_str(&content);
+                existing
+            }
+            _ => content.clone(),
+        };
 
         if resolved.uses_remote_workspace_backend() {
             let ws_fs = context.ws_fs().ok_or_else(|| {
                 BitFunError::tool("Remote workspace file system is unavailable".to_string())
             })?;
             ws_fs
-                .write_file(&resolved.resolved_path, content.as_bytes())
+                .write_file(&resolved.resolved_path, final_content.as_bytes())
                 .await
                 .map_err(|e| BitFunError::tool(format!("Failed to write file: {}", e)))?;
             let timestamp_ms = file_mutation_timestamp_ms(context, &resolved).await;
-            update_file_read_state_after_mutation(context, &resolved, &content, timestamp_ms);
+            update_file_read_state_after_mutation(context, &resolved, &final_content, timestamp_ms);
 
-            let (status, assistant_message) = if file_already_exists {
-                (
+            let (status, assistant_message) = match (mode, file_already_exists) {
+                (WriteLocalFileMode::Write, true) => (
                     "overwritten",
                     format!(
                         "Successfully overwrote {} ({} bytes).",
                         resolved.logical_path,
                         content.len()
                     ),
-                )
-            } else {
-                (
+                ),
+                (WriteLocalFileMode::Write, false) => (
                     "created",
                     format!(
                         "Successfully created {} ({} bytes).",
                         resolved.logical_path,
                         content.len()
                     ),
-                )
+                ),
+                (WriteLocalFileMode::Append, true) => (
+                    "appended",
+                    format!(
+                        "Successfully appended to {} ({} bytes).",
+                        resolved.logical_path,
+                        content.len()
+                    ),
+                ),
+                (WriteLocalFileMode::Append, false) => (
+                    "created",
+                    format!(
+                        "Successfully created {} ({} bytes).",
+                        resolved.logical_path,
+                        content.len()
+                    ),
+                ),
             };
 
             let result = Self::write_success_result(
                 &resolved.logical_path,
+                mode,
                 content.len(),
                 if content.is_empty() {
                     0
@@ -653,6 +725,7 @@ impl Tool for FileWriteTool {
             logical_path: resolved.logical_path.clone(),
             resolved_path: Path::new(&resolved.resolved_path).to_path_buf(),
             content: content.clone(),
+            mode,
         };
         let outcome = tokio::task::spawn_blocking(move || write_local_file(write_request))
             .await
@@ -660,10 +733,11 @@ impl Tool for FileWriteTool {
             .map_err(BitFunError::tool)?;
 
         let timestamp_ms = file_mutation_timestamp_ms(context, &resolved).await;
-        update_file_read_state_after_mutation(context, &resolved, &content, timestamp_ms);
+        update_file_read_state_after_mutation(context, &resolved, &final_content, timestamp_ms);
 
         let result = Self::write_success_result(
             &resolved.logical_path,
+            mode,
             outcome.bytes_written,
             outcome.lines_written,
             outcome.status.as_str(),

--- a/src/crates/execution/tool-execution/src/fs/mod.rs
+++ b/src/crates/execution/tool-execution/src/fs/mod.rs
@@ -18,5 +18,6 @@ pub use list_dir::{
     build_remote_list_commands, parse_remote_list_entries, RemoteListCommandPlan, RemoteListEntry,
 };
 pub use write_file::{
-    write_local_file, WriteLocalFileOutcome, WriteLocalFileRequest, WriteLocalFileStatus,
+    write_local_file, WriteLocalFileMode, WriteLocalFileOutcome, WriteLocalFileRequest,
+    WriteLocalFileStatus,
 };

--- a/src/crates/execution/tool-execution/src/fs/write_file.rs
+++ b/src/crates/execution/tool-execution/src/fs/write_file.rs
@@ -1,10 +1,12 @@
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WriteLocalFileStatus {
     Created,
     Overwritten,
+    Appended,
     AlreadyExistsSameContent,
 }
 
@@ -13,9 +15,16 @@ impl WriteLocalFileStatus {
         match self {
             Self::Created => "created",
             Self::Overwritten => "overwritten",
+            Self::Appended => "appended",
             Self::AlreadyExistsSameContent => "already_exists_same_content",
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteLocalFileMode {
+    Write,
+    Append,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -23,6 +32,7 @@ pub struct WriteLocalFileRequest {
     pub logical_path: String,
     pub resolved_path: PathBuf,
     pub content: String,
+    pub mode: WriteLocalFileMode,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -43,7 +53,7 @@ fn count_written_lines(content: &str) -> usize {
 
 pub fn write_local_file(request: WriteLocalFileRequest) -> Result<WriteLocalFileOutcome, String> {
     let file_already_exists = request.resolved_path.exists();
-    if file_already_exists {
+    if request.mode == WriteLocalFileMode::Write && file_already_exists {
         let existing = fs::read(&request.resolved_path).map_err(|error| {
             format!(
                 "Failed to read existing file {}: {}",
@@ -68,17 +78,48 @@ pub fn write_local_file(request: WriteLocalFileRequest) -> Result<WriteLocalFile
             .map_err(|error| format!("Failed to create directory: {}", error))?;
     }
 
-    fs::write(&request.resolved_path, &request.content)
-        .map_err(|error| format!("Failed to write file {}: {}", request.logical_path, error))?;
+    let status = match request.mode {
+        WriteLocalFileMode::Write => {
+            fs::write(&request.resolved_path, &request.content).map_err(|error| {
+                format!("Failed to write file {}: {}", request.logical_path, error)
+            })?;
 
-    let status = if file_already_exists {
-        WriteLocalFileStatus::Overwritten
-    } else {
-        WriteLocalFileStatus::Created
+            if file_already_exists {
+                WriteLocalFileStatus::Overwritten
+            } else {
+                WriteLocalFileStatus::Created
+            }
+        }
+        WriteLocalFileMode::Append => {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&request.resolved_path)
+                .map_err(|error| {
+                    format!(
+                        "Failed to open file {} for append: {}",
+                        request.logical_path, error
+                    )
+                })?;
+            file.write_all(request.content.as_bytes())
+                .map_err(|error| {
+                    format!(
+                        "Failed to append to file {}: {}",
+                        request.logical_path, error
+                    )
+                })?;
+
+            if file_already_exists {
+                WriteLocalFileStatus::Appended
+            } else {
+                WriteLocalFileStatus::Created
+            }
+        }
     };
     let verb = match status {
         WriteLocalFileStatus::Created => "created",
         WriteLocalFileStatus::Overwritten => "overwrote",
+        WriteLocalFileStatus::Appended => "appended to",
         WriteLocalFileStatus::AlreadyExistsSameContent => unreachable!(),
     };
 

--- a/src/crates/execution/tool-execution/tests/tool_io_contracts.rs
+++ b/src/crates/execution/tool-execution/tests/tool_io_contracts.rs
@@ -6,8 +6,8 @@ use tool_runtime::fs::read_file::{build_remote_read_command, parse_remote_read_o
 use tool_runtime::fs::{
     build_remote_delete_command, build_remote_list_commands, delete_local_path, edit_local_file,
     inspect_local_delete_target, parse_remote_list_entries, write_local_file,
-    DeleteLocalPathRequest, EditLocalFileRequest, LocalDeleteTarget, WriteLocalFileRequest,
-    WriteLocalFileStatus,
+    DeleteLocalPathRequest, EditLocalFileRequest, LocalDeleteTarget, WriteLocalFileMode,
+    WriteLocalFileRequest, WriteLocalFileStatus,
 };
 use tool_runtime::search::glob_search::{
     collect_remote_glob_matches, execute_local_glob, LocalGlobRequest,
@@ -51,6 +51,7 @@ fn write_local_file_reports_created_overwritten_and_identical_retry() {
         logical_path: "nested/file.txt".to_string(),
         resolved_path: target.clone(),
         content: "hello\nworld\n".to_string(),
+        mode: WriteLocalFileMode::Write,
     })
     .expect("write should create file");
 
@@ -66,6 +67,7 @@ fn write_local_file_reports_created_overwritten_and_identical_retry() {
         logical_path: "nested/file.txt".to_string(),
         resolved_path: target.clone(),
         content: "hello\nworld\n".to_string(),
+        mode: WriteLocalFileMode::Write,
     })
     .expect("identical retry should be successful and idempotent");
 
@@ -80,6 +82,7 @@ fn write_local_file_reports_created_overwritten_and_identical_retry() {
         logical_path: "nested/file.txt".to_string(),
         resolved_path: target.clone(),
         content: "replacement".to_string(),
+        mode: WriteLocalFileMode::Write,
     })
     .expect("write should overwrite file");
 
@@ -87,6 +90,47 @@ fn write_local_file_reports_created_overwritten_and_identical_retry() {
     assert_eq!(
         fs::read_to_string(&target).expect("file should exist"),
         "replacement"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn write_local_file_append_mode_appends_and_creates_when_missing() {
+    let root = make_temp_dir("write-append");
+    let existing_target = root.join("nested").join("file.txt");
+    fs::create_dir_all(existing_target.parent().expect("parent should exist"))
+        .expect("parent should be created");
+    fs::write(&existing_target, "hello").expect("seed file should exist");
+
+    let appended = write_local_file(WriteLocalFileRequest {
+        logical_path: "nested/file.txt".to_string(),
+        resolved_path: existing_target.clone(),
+        content: "\nworld".to_string(),
+        mode: WriteLocalFileMode::Append,
+    })
+    .expect("append should succeed");
+
+    assert_eq!(appended.status, WriteLocalFileStatus::Appended);
+    assert_eq!(appended.bytes_written, "\nworld".len());
+    assert_eq!(
+        fs::read_to_string(&existing_target).expect("file should exist"),
+        "hello\nworld"
+    );
+
+    let new_target = root.join("new.txt");
+    let created = write_local_file(WriteLocalFileRequest {
+        logical_path: "new.txt".to_string(),
+        resolved_path: new_target.clone(),
+        content: "first".to_string(),
+        mode: WriteLocalFileMode::Append,
+    })
+    .expect("append should create file when missing");
+
+    assert_eq!(created.status, WriteLocalFileStatus::Created);
+    assert_eq!(
+        fs::read_to_string(&new_target).expect("file should exist"),
+        "first"
     );
 
     let _ = fs::remove_dir_all(root);

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
-import { Bot, ChevronDown, ChevronUp, GitPullRequest, Keyboard, List, MoreHorizontal, Search, Square, Terminal, X } from 'lucide-react';
+import { Activity, Bot, ChevronDown, ChevronUp, GitPullRequest, Keyboard, List, MoreHorizontal, Search, Square, Terminal, X } from 'lucide-react';
 import { Tooltip, IconButton, Input } from '@/component-library';
 import { useTranslation } from 'react-i18next';
 import { SessionFilesBadge } from './SessionFilesBadge';
@@ -459,7 +459,7 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
             data-testid="flowchat-header-background-activities"
           >
             <span className="flowchat-header__background-activity-nav-button-inner">
-              <Bot size={14} />
+              <Activity size={14} />
               {hasBackgroundActivities ? (
                 <span
                   className="flowchat-header__background-activity-status-dot"

--- a/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCardView.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCardView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Terminal } from 'lucide-react';
 import type { FlowToolItem } from '../types/flow-chat';
@@ -178,7 +178,7 @@ export const ExecProcessToolCardView: React.FC<ExecProcessToolCardViewProps> = (
     applyExecExpandedState(!isExpanded, { reason: 'manual' });
   }, [applyExecExpandedState, isExpanded]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const prevStatus = previousStatusRef.current;
     previousStatusRef.current = status;
     if (prevStatus === status) {

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.tsx
@@ -13,7 +13,7 @@
  * - Clicking "Open Terminal in right panel" opens the full Terminal tab
  */
 
-import React, { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolCardProps } from '../types/flow-chat';
 import { Terminal, Play, X, ExternalLink, Square } from 'lucide-react';
@@ -301,7 +301,7 @@ export const TerminalToolCard: React.FC<TerminalToolCardProps> = ({
     }
   }, [status]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const prevStatus = previousStatusRef.current;
     previousStatusRef.current = status;
 


### PR DESCRIPTION
This PR adds append-mode support to the Write tool and cleans up a few exec-related UX/details across the stack.

Summary:
- add append write mode for the Write tool
- relax content sanitization / invocation validation around file writing
- clarify ExecCommand and ExecControl TTY/session semantics
- fix exec tool cards flashing into expanded state on completion
- swap the flow chat background activity header icon to Activity for clearer intent