### PR TITLE
perf(flow-chat): improve long session readiness

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -45,6 +45,9 @@ const searchStateMock = vi.hoisted(() => ({
 const headerPropsMock = vi.hoisted(() => ({
   latest: null as Record<string, unknown> | null,
 }));
+const agentApiMock = vi.hoisted(() => ({
+  listBackgroundCommandActivities: vi.fn(() => Promise.resolve({ activities: [] })),
+}));
 
 vi.mock('react-i18next', () => ({
   initReactI18next: {
@@ -91,6 +94,10 @@ vi.mock('@/infrastructure/contexts/WorkspaceContext', () => ({
   useWorkspaceContext: () => ({
     workspacePath: 'D:/workspace/BitFun',
   }),
+}));
+
+vi.mock('@/infrastructure/api', () => ({
+  agentAPI: agentApiMock,
 }));
 
 vi.mock('../../utils/acpSession', () => ({
@@ -244,6 +251,8 @@ describe('ModernFlowChatContainer historical empty state', () => {
     virtualListMock.pinTurnToTop.mockReturnValue(true);
     virtualListActionClickMock.mockReset();
     startupTraceMock.markPhase.mockReset();
+    agentApiMock.listBackgroundCommandActivities.mockClear();
+    agentApiMock.listBackgroundCommandActivities.mockResolvedValue({ activities: [] });
     searchStateMock.searchQuery = '';
     searchStateMock.onSearchChange.mockReset();
     searchStateMock.matches = [];
@@ -551,6 +560,46 @@ describe('ModernFlowChatContainer historical empty state', () => {
     });
 
     expect(virtualListActionClickMock).toHaveBeenCalledTimes(1);
+    releaseSpy.mockRestore();
+  });
+
+  it('defers background command snapshot until restored latest text is visible', async () => {
+    const releaseSpy = vi
+      .spyOn(flowChatStore, 'releaseSessionHistoryCompletionAfterInitialPaint')
+      .mockReturnValue(true);
+
+    stateMocks.activeSession = createSession({
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      dialogTurns: [
+        createTurn('turn-1', 'Older restored prompt'),
+        createTurn('turn-2', 'Latest restored prompt'),
+      ],
+    } as Partial<Session>);
+    stateMocks.virtualItems = [
+      { type: 'user-message', turnId: 'turn-1', data: { id: 'user-turn-1', content: 'Older restored prompt' } },
+      { type: 'user-message', turnId: 'turn-2', data: { id: 'user-turn-2', content: 'Latest restored prompt' } },
+    ];
+    virtualListMock.isTurnTextRenderedInViewport.mockReturnValue(false);
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(agentApiMock.listBackgroundCommandActivities).not.toHaveBeenCalled();
+
+    virtualListMock.isTurnTextRenderedInViewport.mockReturnValue(true);
+    flushAnimationFrame();
+    flushAnimationFrame();
+    flushAnimationFrame();
+
+    expect(releaseSpy).toHaveBeenCalledWith('session-1');
+    expect(agentApiMock.listBackgroundCommandActivities).toHaveBeenCalledTimes(1);
+    expect(agentApiMock.listBackgroundCommandActivities).toHaveBeenCalledWith({
+      agentSessionId: 'session-1',
+    });
+
     releaseSpy.mockRestore();
   });
 

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -585,6 +585,10 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const shouldBlockHistoryInitialContentInteraction =
     historyInitialContentKey !== null &&
     historyInitialContentReadyKey !== historyInitialContentKey;
+  const shouldDeferBackgroundCommandSnapshot =
+    activeSession?.historyState === 'metadata-only' ||
+    activeSession?.historyState === 'hydrating' ||
+    shouldBlockHistoryInitialContentInteraction;
   const shouldBlockHistoryTransitionInteraction =
     shouldBlockHistoryInitialContentInteraction ||
     showHistoryOpenIntentOverlay;
@@ -1048,7 +1052,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
 
   useEffect(() => {
     const agentSessionId = activeSession?.sessionId;
-    if (!agentSessionId) {
+    if (!agentSessionId || shouldDeferBackgroundCommandSnapshot) {
       return;
     }
 
@@ -1068,7 +1072,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     return () => {
       cancelled = true;
     };
-  }, [activeSession?.sessionId]);
+  }, [activeSession?.sessionId, shouldDeferBackgroundCommandSnapshot]);
 
   const backgroundCommands = useMemo(
     () => visibleBackgroundCommandActivitiesForSession(

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.layout.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.layout.test.ts
@@ -123,6 +123,18 @@ describe('selectInitialHistoryRenderWindow', () => {
     } as VirtualItem;
   }
 
+  function exploreItem(turnIndex: number): VirtualItem {
+    const id = `turn-${turnIndex}`;
+    return {
+      type: 'explore-group',
+      turnId: id,
+      data: {
+        allItems: [{ id: `explore-${id}`, label: `Explore ${turnIndex}` }],
+        timestamp: turnIndex,
+      },
+    } as VirtualItem;
+  }
+
   it('keeps only the latest render window on large partial history tails', () => {
     const items = Array.from({ length: 8 }, (_, index) => [
       userItem(index),
@@ -135,6 +147,24 @@ describe('selectInitialHistoryRenderWindow', () => {
     expect(window.items.length).toBeLessThan(items.length);
     expect(window.items[0]?.turnId).toBe('turn-6');
     expect(window.items.at(-1)?.turnId).toBe('turn-7');
+    expect(window.omittedEstimatedHeightPx).toBeGreaterThan(0);
+  });
+
+  it('keeps an extra previous turn when the latest turn is user-only', () => {
+    const items = [
+      ...Array.from({ length: 7 }, (_, index) => [
+        userItem(index),
+        exploreItem(index),
+        modelItem(index),
+      ]).flat(),
+      userItem(7),
+    ];
+
+    const window = selectInitialHistoryRenderWindow(items);
+    const renderedTurnIds = Array.from(new Set(window.items.map(item => item.turnId)));
+
+    expect(renderedTurnIds).toEqual(['turn-5', 'turn-6', 'turn-7']);
+    expect(window.items[0]?.turnId).toBe('turn-5');
     expect(window.omittedEstimatedHeightPx).toBeGreaterThan(0);
   });
 

--- a/src/web-ui/src/flow_chat/components/modern/virtualMessageListLayout.ts
+++ b/src/web-ui/src/flow_chat/components/modern/virtualMessageListLayout.ts
@@ -5,6 +5,7 @@ export const LIVE_SESSION_DEFAULT_ITEM_HEIGHT_PX = 200;
 export const HISTORICAL_SESSION_DEFAULT_ITEM_HEIGHT_PX = 72;
 export const HISTORICAL_SESSION_MODEL_ROUND_DEFAULT_ITEM_HEIGHT_PX = 960;
 export const INITIAL_HISTORY_RENDER_MIN_TURN_COUNT = 2;
+const INITIAL_HISTORY_RENDER_USER_ONLY_LATEST_MIN_TURN_COUNT = 3;
 export const INITIAL_HISTORY_RENDER_MIN_ESTIMATED_HEIGHT_PX = 1400;
 const USER_MESSAGE_BASE_HEIGHT_PX = 96;
 const USER_MESSAGE_LINE_HEIGHT_PX = 22;
@@ -163,6 +164,34 @@ function uniqueTurnCount(items: VirtualItem[]): number {
   return turnIds.size;
 }
 
+function getLatestTurnId(items: VirtualItem[]): string | null {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const turnId = items[index]?.turnId;
+    if (turnId) {
+      return turnId;
+    }
+  }
+  return null;
+}
+
+function latestTurnHasModelRound(items: VirtualItem[]): boolean {
+  const latestTurnId = getLatestTurnId(items);
+  if (!latestTurnId) {
+    return true;
+  }
+
+  return items.some(item =>
+    item.turnId === latestTurnId &&
+    item.type === 'model-round'
+  );
+}
+
+function getInitialHistoryRenderMinTurnCount(items: VirtualItem[]): number {
+  return latestTurnHasModelRound(items)
+    ? INITIAL_HISTORY_RENDER_MIN_TURN_COUNT
+    : INITIAL_HISTORY_RENDER_USER_ONLY_LATEST_MIN_TURN_COUNT;
+}
+
 export function selectInitialHistoryRenderWindow(
   items: VirtualItem[],
   options: {
@@ -170,7 +199,7 @@ export function selectInitialHistoryRenderWindow(
     minEstimatedHeightPx?: number;
   } = {},
 ): InitialHistoryRenderWindow {
-  const minTurnCount = Math.max(1, Math.floor(options.minTurnCount ?? INITIAL_HISTORY_RENDER_MIN_TURN_COUNT));
+  const minTurnCount = Math.max(1, Math.floor(options.minTurnCount ?? getInitialHistoryRenderMinTurnCount(items)));
   const minEstimatedHeightPx = Math.max(0, options.minEstimatedHeightPx ?? INITIAL_HISTORY_RENDER_MIN_ESTIMATED_HEIGHT_PX);
   const totalEstimatedHeightPx = items.reduce(
     (total, item) => total + estimateVirtualMessageItemHeight(item),

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
@@ -136,6 +136,30 @@ describe('SessionModule historical session coordination', () => {
     expect(flowChatStore.switchSession).toHaveBeenCalledWith('history-1');
   });
 
+  it('defers activity touch until a metadata-only historical session has hydrated and switched', async () => {
+    const load = createDeferred<void>();
+    const { context, flowChatStore } = createContext(createSession());
+    flowChatStore.loadSessionHistory.mockReturnValueOnce(load.promise);
+    persistenceMocks.touchSessionActivity.mockResolvedValueOnce(undefined);
+
+    const switching = switchChatSession(context, 'history-1');
+    await Promise.resolve();
+
+    expect(persistenceMocks.touchSessionActivity).not.toHaveBeenCalled();
+
+    load.resolve();
+    await switching;
+    await Promise.resolve();
+
+    expect(flowChatStore.switchSession).toHaveBeenCalledWith('history-1');
+    expect(persistenceMocks.touchSessionActivity).toHaveBeenCalledWith(
+      'history-1',
+      'D:/workspace/BitFun',
+      undefined,
+      undefined,
+    );
+  });
+
   it('switches immediately when a historical session already has renderable tail content', async () => {
     const load = createDeferred<void>();
     const { context, flowChatStore } = createContext(createSession({

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -494,14 +494,16 @@ export async function switchChatSession(
       !isRemoteSession &&
       !hasRenderableSessionContent(session);
 
-    touchSessionActivity(
-      sessionId,
-      session?.workspacePath,
-      session?.remoteConnectionId,
-      session?.remoteSshHost
-    ).catch(error => {
-      log.debug('Failed to touch session activity', { sessionId, error });
-    });
+    const touchActiveSessionInBackground = () => {
+      touchSessionActivity(
+        sessionId,
+        session?.workspacePath,
+        session?.remoteConnectionId,
+        session?.remoteSshHost
+      ).catch(error => {
+        log.debug('Failed to touch session activity', { sessionId, error });
+      });
+    };
 
     if (shouldHydrateBeforeSwitch) {
       try {
@@ -524,6 +526,7 @@ export async function switchChatSession(
     // visible content is restored; already-renderable sessions still switch
     // immediately and continue full hydration in the background.
     context.flowChatStore.switchSession(sessionId);
+    touchActiveSessionInBackground();
     startupTrace.markPhase('historical_session_switch', {
       historical: Boolean(session?.isHistorical),
       remote: isRemoteSession,

--- a/tests/e2e/helpers/workspace-helper.ts
+++ b/tests/e2e/helpers/workspace-helper.ts
@@ -21,6 +21,10 @@ export interface WorkspaceState {
   workspaceLabels: string[];
 }
 
+export interface WorkspaceReadyOptions {
+  requireWorkspaceLabel?: boolean;
+}
+
 /**
  * Open a workspace through the frontend state layer so the UI stays in sync.
  */
@@ -82,18 +86,23 @@ export async function getWorkspaceState(): Promise<WorkspaceState> {
 }
 
 /**
- * Wait until both frontend state and nav DOM reflect the target workspace.
+ * Wait until frontend state reflects the target workspace.
+ * Most flows also require the nav DOM label; perf flows can opt out when the
+ * measurement only needs an active/opened workspace and must not depend on nav
+ * expansion rendering.
  */
 export async function waitForWorkspaceReady(
   workspacePath: string,
   projectName: string = path.basename(workspacePath),
   timeout: number = 15000,
+  options: WorkspaceReadyOptions = {},
 ): Promise<WorkspaceState> {
+  const requireWorkspaceLabel = options.requireWorkspaceLabel ?? true;
   await browser.waitUntil(async () => {
     const state = await getWorkspaceState();
     return state.currentWorkspacePath === workspacePath
       && state.openedWorkspacePaths.includes(workspacePath)
-      && state.workspaceLabels.some(label => label.includes(projectName));
+      && (!requireWorkspaceLabel || state.workspaceLabels.some(label => label.includes(projectName)));
   }, {
     timeout,
     interval: 500,
@@ -108,10 +117,11 @@ export async function waitForWorkspaceReady(
  */
 export async function openWorkspace(
   workspacePath: string = process.env.E2E_TEST_WORKSPACE || process.cwd(),
+  options: WorkspaceReadyOptions = {},
 ): Promise<boolean> {
   try {
     await openWorkspaceThroughFrontend(workspacePath);
-    await waitForWorkspaceReady(workspacePath);
+    await waitForWorkspaceReady(workspacePath, path.basename(workspacePath), 15000, options);
     return true;
   } catch (error) {
     console.error('[WorkspaceHelper] Failed to open workspace through frontend state:', error);

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -722,9 +722,9 @@ async function ensurePerformanceWorkspace(startupPage: StartupPage): Promise<boo
     return ensureWorkspaceOpen(startupPage);
   }
 
-  const opened = await openWorkspace(targetWorkspace);
+  const opened = await openWorkspace(targetWorkspace, { requireWorkspaceLabel: false });
   if (!opened) {
-    return ensureWorkspaceOpen(startupPage);
+    throw new Error(`Performance workspace did not become active: ${targetWorkspace}`);
   }
   return true;
 }
@@ -3503,6 +3503,23 @@ type RapidLongSessionSwitchMeasurement = {
   targetLatestUsableAtMs: number;
   clickToTargetLatestVisibleMs: number;
   clickToTargetLatestUsableMs: number;
+  rapidSwitchBreakdown: {
+    firstClickToTargetClickMs: number;
+    target: {
+      clickedAtMs: number;
+      clickSinceFirstClickMs: number;
+      clickToLatestVisibleMs: number;
+      clickToLatestUsableMs: number;
+      latestVisibleToUsableMs: number;
+    };
+    sessions: Array<{
+      sessionId: string;
+      clickIndex: number;
+      sinceFirstClickMs: number;
+      eventCount: number;
+      sessionOpen: ReturnType<typeof summarizeSessionOpen>;
+    }>;
+  };
   postVisibleObserveMs: number;
   viewport: LongSessionViewportState;
   viewportTimelineSummary: LongSessionViewportTimelineSummary;
@@ -3661,6 +3678,22 @@ async function collectRapidLongSessionSwitchMeasurement(
       event.phase === 'react_render_profile'
     )
   );
+  const targetClickedAtMs =
+    clickPlan.find(entry => entry.sessionId === targetSessionId)?.clickedAtMs ?? clickedAtMs;
+  const sessionBreakdowns = clickPlan.map((entry, index) => {
+    const sessionEvents = events.filter(event =>
+      typeof event.sessionId === 'string' &&
+      event.sessionId === entry.sessionId
+    );
+
+    return {
+      sessionId: entry.sessionId,
+      clickIndex: index,
+      sinceFirstClickMs: entry.clickedAtMs - clickedAtMs,
+      eventCount: sessionEvents.length,
+      sessionOpen: summarizeSessionOpen(sessionEvents, entry.clickedAtMs),
+    };
+  });
   const verboseTimelineReport = process.env.BITFUN_E2E_PERF_VERBOSE_REPORT === '1';
 
   return {
@@ -3675,6 +3708,17 @@ async function collectRapidLongSessionSwitchMeasurement(
     targetLatestUsableAtMs: latestUsable.usableAtMs,
     clickToTargetLatestVisibleMs: latestVisible.visibleAtMs - clickedAtMs,
     clickToTargetLatestUsableMs: latestUsable.usableAtMs - clickedAtMs,
+    rapidSwitchBreakdown: {
+      firstClickToTargetClickMs: targetClickedAtMs - clickedAtMs,
+      target: {
+        clickedAtMs: targetClickedAtMs,
+        clickSinceFirstClickMs: targetClickedAtMs - clickedAtMs,
+        clickToLatestVisibleMs: latestVisible.visibleAtMs - targetClickedAtMs,
+        clickToLatestUsableMs: latestUsable.usableAtMs - targetClickedAtMs,
+        latestVisibleToUsableMs: latestUsable.usableAtMs - latestVisible.visibleAtMs,
+      },
+      sessions: sessionBreakdowns,
+    },
     postVisibleObserveMs,
     viewport,
     viewportTimelineSummary,
@@ -4133,6 +4177,26 @@ describe('Performance telemetry', () => {
       targetSessionId,
       clickToTargetLatestVisibleMs: measurement.clickToTargetLatestVisibleMs,
       clickToTargetLatestUsableMs: measurement.clickToTargetLatestUsableMs,
+      rapidSwitchBreakdown: {
+        firstClickToTargetClickMs: measurement.rapidSwitchBreakdown.firstClickToTargetClickMs,
+        target: {
+          clickSinceFirstClickMs: measurement.rapidSwitchBreakdown.target.clickSinceFirstClickMs,
+          clickToLatestVisibleMs: measurement.rapidSwitchBreakdown.target.clickToLatestVisibleMs,
+          latestVisibleToUsableMs: measurement.rapidSwitchBreakdown.target.latestVisibleToUsableMs,
+          clickToLatestUsableMs: measurement.rapidSwitchBreakdown.target.clickToLatestUsableMs,
+        },
+        sessions: measurement.rapidSwitchBreakdown.sessions.map(session => ({
+          sessionId: session.sessionId,
+          sinceFirstClickMs: session.sinceFirstClickMs,
+          eventCount: session.eventCount,
+          clickToHydrateStartMs: session.sessionOpen.clickToHydrateStartMs,
+          clickToLatestFrameMs: session.sessionOpen.clickToLatestFrameMs,
+          clickToHydrateEndMs: session.sessionOpen.clickToHydrateEndMs,
+          restoreDurationMs: session.sessionOpen.restoreDurationMs,
+          stateCommitDurationMs: session.sessionOpen.stateCommitDurationMs,
+          latestFrameSinceHydrateMs: session.sessionOpen.latestFrameSinceHydrateMs,
+        })),
+      },
       visualStateSummary: {
         postLatestTextVisibleLoadingEventCount:
           measurement.visualStateSummary.postLatestTextVisibleLoadingEventCount,


### PR DESCRIPTION
﻿## Summary

- Defer restored historical-session background command snapshots until the latest restored content is visible, so non-critical session metadata work does not compete with the first readable frame.
- Delay activity touch for metadata-only historical sessions until hydration completes and the target session actually switches, avoiding stale side work during rapid switching.
- Expand the initial render window only when the latest restored turn is user-only, preserving recent context without applying a global extra-turn DOM cost.
- Tighten the performance E2E workspace setup and add a clearer rapid-switch breakdown for target-click, latest-visible, latest-usable, and per-session trace phases.

## Performance Data

Measured on `release-fast` builds, 5 runs each, same generated long-session fixture. Baseline is latest `GCWing/BitFun` `main` at `bc3e5f33`; this PR is `5fb8184`.

| Scenario | Baseline median | PR median | Delta | Delta % | Baseline min-max | PR min-max | Visual guard |
|---|---:|---:|---:|---:|---:|---:|---|
| Startup interactive shell ready | 764.8 ms | 768.9 ms | +4.1 ms | +0.5% | 751.6-944.8 | 732.7-882.6 | startup guardrail only |
| Long session first open latest usable | 285.4 ms | 279.0 ms | -6.4 ms | -2.2% | 268.6-369.8 | 259.4-294.7 | no loading/blank/scroll/non-target events |
| Long session warm reopen latest usable | 177.7 ms | 169.6 ms | -8.1 ms | -4.6% | 164.0-226.0 | 161.8-194.7 | no loading/blank/scroll/non-target events |
| Rapid switch target latest usable | 958.0 ms | 865.0 ms | -93.0 ms | -9.7% | 900.4-1184.9 | 818.7-914.1 | no loading/blank/scroll/non-target events |

Startup is included only as a guardrail. The measured +4.1 ms startup delta is within run-to-run noise and this PR should not be interpreted as a startup optimization.

## Rapid-Switch Breakdown

Diagnostic sample from the latest PR run, measured from the first click in a rapid A -> B -> C session switch sequence:

| Segment | Duration |
|---|---:|
| First click -> target session click | 409.8 ms |
| Target click -> latest content visible | 374.4 ms |
| Latest visible -> latest usable viewport | 59.4 ms |
| Target click -> latest usable viewport | 433.8 ms |

Per-session trace sample from that run:

| Session | Click offset | Hydrate start | Hydrate end | Restore duration | State commit | Latest frame |
|---|---:|---:|---:|---:|---:|---:|
| A | 33.4 ms | 74.2 ms | 161.3 ms | 85.8 ms | 0.5 ms | 277.7 ms |
| B | 188.5 ms | 128.8 ms | 226.6 ms | 95.7 ms | 1.0 ms | 346.1 ms |
| C target | 409.8 ms | 193.3 ms | 262.4 ms | 67.3 ms | 0.5 ms | 403.5 ms |

## Risks and Guardrails

- Background command activity can appear slightly later on restored historical sessions, but live command events remain the source of truth and the snapshot still runs once latest content is visible.
- User-only latest turns render one extra previous turn during initial history paint; the extra DOM cost is conditional and the rapid-switch E2E path remains faster than baseline.
- Activity touch is no longer sent for a superseded metadata-only switch. This avoids stale recency updates during rapid switch, but failed or superseded opens also stop updating recency.
- Rapid-switch breakdown is test/report-only. It does not add production instrumentation or runtime logs; the console summary uses compact relative timings.
- The perf E2E helper opt-out only applies to this perf spec; default workspace tests still require nav label visibility.

## Verification

- Rebased onto latest `GCWing/BitFun` `main` at `bc3e5f33`
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/modern/VirtualMessageList.layout.test.ts src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx src/flow_chat/services/flow-chat-manager/SessionModule.test.ts` (51 tests passed)
- `pnpm run lint:web` (0 errors; existing warning in untouched `FlowChatManager.ts`)
- `pnpm run check:repo-hygiene`
- `git diff --check gcwing/main..HEAD`
- `pnpm run desktop:build:release-fast` for baseline and PR builds
- `pnpm --dir tests/e2e run test:perf` x5 for latest main baseline and x5 for this PR
