### PR TITLE
docs: add SDLC harness design docs

### DIFF
--- a/AGENTS-CN.md
+++ b/AGENTS-CN.md
@@ -152,6 +152,17 @@ await api.invoke('your_command', { request: { ... } });
 - 产品表面可以有差异；共享稳定 facts 或 ports，不共享 UI、protocol、lifecycle 或平台实现。
 - 迁移 runtime owner 必须有评审过的 port/provider 设计、旧路径兼容、行为等价测试；如果可能改变行为边界，还需要先确认。
 
+### SDLC Harness 护栏
+
+涉及 SDLC Harness、生命周期证据、门禁、Artifact Graph、Project Profile、
+Deep Review 策略、OpenCode 兼容或目标项目治理的变更，先阅读
+[`docs/sdlc-harness/README.md`](docs/sdlc-harness/README.md)，再阅读
+[`docs/sdlc-harness/design.md`](docs/sdlc-harness/design.md)。如果变更影响模块边界或行为，
+继续参考 `docs/sdlc-harness/architecture/` 或 `docs/sdlc-harness/features/` 下的对应设计。
+
+不要把 BitFun 自身验证假设硬编码成目标项目通用规则；Harness 行为必须保持面向目标项目、
+基于证据、按风险分级、成本可控并可审计。
+
 ## 验证
 
 按触及文件选择最小本地预检。完整构建和大范围测试默认由 CI 保护；只有改动直接影响构建、

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,19 @@ Repository-level decomposition rules:
   compatibility, behavior equivalence tests, and explicit confirmation when a
   behavior boundary could change.
 
+### SDLC Harness guardrails
+
+For SDLC Harness, lifecycle evidence, gates, Artifact Graph, Project Profile,
+Deep Review policy, OpenCode compatibility, or target-project governance
+changes, read [`docs/sdlc-harness/README.md`](docs/sdlc-harness/README.md)
+first, then [`docs/sdlc-harness/design.md`](docs/sdlc-harness/design.md). If
+module boundaries or behavior change, follow the matching design under
+`docs/sdlc-harness/architecture/` or `docs/sdlc-harness/features/`.
+
+Do not hard-code BitFun repository assumptions as target-project rules; keep
+Harness behavior target-aware, evidence-backed, risk-tiered, cost-aware, and
+auditable.
+
 ## Verification
 
 Run the smallest local precheck that matches the touched files. CI is expected to

--- a/docs/sdlc-harness/README.md
+++ b/docs/sdlc-harness/README.md
@@ -1,0 +1,28 @@
+# BitFun 全软件生命周期 Harness 总览
+
+> 范围：BitFun 作为 Harness 产品加载和治理外部软件工程时的目标形态、外部调研、设计体系和实施计划。
+> 用途：作为拆分后的入口文档。设计与计划已分离，避免将战略/架构判断和执行路线混在同一篇报告中。
+
+## 文档结构
+
+| 文档 | 角色 | 主要内容 |
+|---|---|---|
+| [research/external-research.md](research/external-research.md) | 调研文档 | 外部产品、论文、标准和趋势信号 |
+| [design.md](design.md) | 设计文档 | BitFun 加载目标项目后的领域模型、逻辑架构、模块边界和风险治理 |
+| [implementation-plan.md](implementation-plan.md) | 实施计划 | 阶段性交付件、成果验收、过程风险、关键里程碑和质量保护方案 |
+| [governance/self-governance-notes.md](governance/self-governance-notes.md) | 自身治理说明 | 记录 BitFun 仓库自身作为内部验证项目暴露出的文档、边界和治理问题 |
+
+## 核心判断
+
+BitFun 的长期产品目标不是只治理自身仓库，而是成为面向外部目标项目的 Agentic Engineering Harness。用户加载一个软件工程后，BitFun 应能够识别项目画像、连接生命周期交付物、收集执行和验证证据、进行风险分级、给出质量门禁，并把评审、发布和运行期反馈回流成可复用资产。
+
+BitFun 自身已有 Agent Runtime、工具调用、Git/终端、MCP/LSP、Deep Review 和本地工程验证基础，这些是产品实现基础，不是主设计的治理对象。主设计围绕“如何让 BitFun 更好承载外部项目的 Harness 需求”展开；BitFun 自身仓库暴露出的文档缺口、模块边界不清或规则不一致问题，应进入独立自身治理文档。
+
+首个可验证价值点仍应收敛在目标项目的 PR EvidencePack、Risk Classifier 和 lightweight gate 上；Project Profile、Artifact Graph、OpenCode 兼容、需求影响分析和 Evaluation Harness 都围绕这个最小闭环逐步扩展，避免过早扩展设计边界。
+
+## 阅读建议
+
+1. 先阅读调研文档，了解外部趋势和参考信号。
+2. 再阅读设计文档，确认 BitFun 面向目标项目的长期产品形态、架构边界和风险约束。
+3. 最后阅读实施计划，确认阶段性交付件、里程碑、过程风险和质量保护方案。
+4. 需要评估 BitFun 仓库自身治理问题时，再阅读自身治理说明。

--- a/docs/sdlc-harness/architecture/artifact-graph.md
+++ b/docs/sdlc-harness/architecture/artifact-graph.md
@@ -1,0 +1,153 @@
+# BitFun SDLC Harness 子模块设计：Artifact Graph
+
+> 上游文档：[design.md](../design.md)
+> 模块角色：把目标项目中的需求、设计、代码、测试、评审、CI、发布、运行期和复盘资产建模为可追踪交付物图谱。
+
+## 1. 模块定位
+
+Artifact Graph 是 BitFun 面向目标项目的工程上下文层。它不追求一次覆盖全部 SDLC 对象，而是先把高频、高价值、可验证的 PR 证据链建起来，再逐步扩展到需求变更、发布和 incident 回溯。
+
+P0 最小闭环是：
+
+```text
+issue/spec -> diff -> verification -> review -> PR
+```
+
+所有图谱边必须有来源、置信度、新鲜度和确认状态。低置信自动链接不能直接作为审计结论。
+
+对抗性审查后的关键判断是：Artifact Graph 不能退化成“把所有文档和代码向量化后做 RAG”。图谱必须表达可治理的工程对象和可失效的关系；RAG 只能作为候选召回手段，不能替代语义层、证据和确认状态。
+
+## 2. 行业参照与设计约束
+
+| 参照 | 启发 |
+|---|---|
+| [Atlassian Software Collection](https://www.atlassian.com/collections/software) | 工作项、文档、代码和团队上下文正在图谱化 |
+| [Harness Software Delivery Knowledge Graph](https://www.harness.io/blog/knowledge-graphs-for-ai-software-delivery) | 知识图谱必须围绕用例最小建模，并以新鲜度和结果改善衡量价值 |
+| [Kiro Specs](https://kiro.dev/docs/specs/) / [Steering](https://kiro.dev/docs/steering/) | spec、steering 和项目规则正在成为 AI 原生工程交付物 |
+| [Rovo acceptance criteria checks](https://support.atlassian.com/rovo/docs/check-acceptance-criteria-in-a-code-review/) | PR 可以检查代码是否满足 linked work item 的验收标准 |
+| [TraceLLM](https://arxiv.org/html/2602.01253v1) | LLM 可辅助 trace links，但需要置信度和人工确认 |
+| [LLM-driven requirements change impact analysis](https://arxiv.org/html/2511.00262v1) | 需求变更可驱动影响对象召回，但需衡量召回、精度和人工检查成本 |
+
+## 3. 范围与非目标
+
+范围：
+
+- 建模 artifact node、edge、evidence 和 confirmation status。
+- 支撑 PR 审计视图、需求变更影响视图和 incident 回溯视图。
+- 为 Risk Classifier 和 PR Gate 提供可解释上下文。
+
+非目标：
+
+- 不替代目标项目已有的 Jira、Linear、GitHub、CI 或 observability。
+- 不在 P0 构建完整企业知识图谱。
+- 不把 LLM 推断链接视为事实。
+- 不要求所有外部系统双向同步。
+- 不把向量检索结果直接写成 confirmed graph edge。
+
+## 4. 输入、输出与数据模型
+
+核心节点：
+
+```ts
+type ArtifactKind =
+  | "issue"
+  | "requirement"
+  | "acceptance_criteria"
+  | "spec"
+  | "design_decision"
+  | "plan"
+  | "diff"
+  | "code_symbol"
+  | "test"
+  | "review_finding"
+  | "ci_check"
+  | "release"
+  | "incident"
+  | "metric"
+  | "policy"
+  | "evidence_pack";
+```
+
+核心边：
+
+```ts
+interface ArtifactEdge {
+  from: ArtifactId;
+  to: ArtifactId;
+  relation: string;
+  source_event_id: string;
+  created_by: "system" | "agent" | "human" | "integration";
+  confidence: number;
+  evidence: EvidenceReference[];
+  last_verified_at: string;
+  staleness: "fresh" | "stale" | "unknown";
+  confirmation_status: "auto" | "confirmed" | "rejected" | "expired";
+}
+```
+
+核心输出：
+
+- PR EvidencePack linked artifacts。
+- change impact candidates。
+- required checks seed。
+- stale review / stale link warnings。
+- release readiness context。
+- incident-to-test candidate links。
+
+## 5. 核心流程
+
+```text
+collect artifacts and events
+  -> create or update nodes
+  -> infer candidate edges
+  -> attach provenance and confidence
+  -> require confirmation for high-risk low-confidence edges
+  -> expose views and graph queries
+  -> write confirmations back to graph
+```
+
+关键视图：
+
+| 视图 | 用途 |
+|---|---|
+| PR 审计视图 | 展示 PR 关联需求、diff、验证、review、risk、open gaps |
+| 需求变更视图 | 展示受影响文件、测试、owner、发布风险和待确认链接 |
+| 任务视图 | 展示从 spec 到 plan、diff、verification 的工作链路 |
+| Incident 回溯视图 | 展示 incident、release、PR、test gap 和回归补充 |
+
+## 6. 策略与治理
+
+- **边质量优先**：链接少但可信，优先于链接多但不可验证。
+- **语义层优先**：先定义 artifact kind、relation、source、confidence 和 staleness，再考虑 RAG 或 embedding 扩展。
+- **人工确认**：高风险低置信链接进入 pending 状态，不直接影响 gate pass。
+- **新鲜度管理**：diff、test、review、CI 状态变化会触发边 staleness 更新。
+- **来源分级**：human confirmed > CI/test evidence > static analysis > LLM inference。
+- **可删除但不可篡改**：错误链接用 rejected/expired 表达，不静默删除审计事实。
+
+## 7. 分阶段落地
+
+| 阶段 | 目标 |
+|---|---|
+| P0 | `issue/spec -> diff -> verification -> review -> PR` 最小图谱 |
+| P1 | required checks、stale review、PR audit view |
+| P2 | requirement impact、release readiness、incident-to-test |
+| P3 | 跨团队质量趋势、知识图谱查询和预测性风险提示 |
+
+## 8. 风险与反证
+
+| 风险 | 反证或治理要求 |
+|---|---|
+| 图谱边界扩张过快 | P0 只能围绕 PR EvidencePack 验证价值 |
+| 低质量链接影响判断可信度 | 所有边必须携带 confidence、evidence、staleness、confirmation status |
+| LLM 链接幻觉 | LLM 只生成 candidate edge，高风险链接必须人工确认 |
+| 外部系统同步成本过高 | 默认本地投影和按需导出，不要求双向实时同步 |
+| 链接过期不可见 | 任何 diff、test、review、CI 变更都应能标记 stale |
+| 团队不使用 | 先嵌入 PR 描述和 reviewer 工作流，避免单独打开图谱工具 |
+
+## 9. 成功标准
+
+- 大多数 PR 可生成包含 linked artifacts 的 EvidencePack。
+- 高风险 PR 能暴露缺失需求、测试、review 或 owner 链接。
+- 用户可以确认、拒绝或覆盖自动链接。
+- stale link 不会被作为 gate pass 的依据。
+- 需求影响分析和 PR Gate 都复用同一图谱模型。

--- a/docs/sdlc-harness/architecture/project-profile-integration.md
+++ b/docs/sdlc-harness/architecture/project-profile-integration.md
@@ -1,0 +1,158 @@
+# BitFun SDLC Harness 子模块设计：Project Profile and Integration
+
+> 上游文档：[design.md](../design.md)
+> 模块角色：在 BitFun 加载外部目标项目后，发现、归一化、版本化项目画像，并通过 adapter 连接项目依赖的代码托管、issue、CI、文档、发布和观测系统。
+
+## 1. 模块定位
+
+Project Profile and Integration 是所有 Harness 判断的入口层。它回答三个问题：
+
+1. 当前被加载的目标项目是什么。
+2. 该项目有哪些规则、边界、验证能力、owner、风险区域和外部系统。
+3. 哪些信息已经确认，哪些信息未知、冲突、过期或不可访问。
+
+没有 Project Profile，Risk Classifier 容易把未知项目误判为低风险，PR Gate 容易要求错误验证，Artifact Graph 容易建立脏链接，Deep Review 容易读取错误上下文。因此本模块不只是“项目扫描”，而是 BitFun 面向外部项目可用性的基础。
+
+## 2. 行业参照与设计约束
+
+| 参照 | 启发 |
+|---|---|
+| [Kiro Steering](https://kiro.dev/docs/steering/) / [Specs](https://kiro.dev/docs/specs/) | 项目规则、产品意图、技术栈和结构说明应成为核心上下文，而不是临时 prompt |
+| [Atlassian Rovo Dev](https://www.atlassian.com/software/rovo-dev) / [Software Collection](https://www.atlassian.com/collections/software) | Agent 需要连接 Jira、文档、代码、CI 和团队上下文，而不只读取仓库文件 |
+| [Harness Software Delivery Knowledge Graph](https://www.harness.io/blog/knowledge-graphs-for-ai-software-delivery) | 软件交付知识图谱必须以语义层和持续同步为基础，避免只做 RAG 堆料 |
+| [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/) | 跨系统事件和指标需要稳定命名与资源语义 |
+| [CDEvents](https://cdevents.dev/docs/primer/) | CI/CD 事件应保持松耦合、声明式和互操作，不应形成点对点强耦合 |
+| [SLSA Provenance](https://slsa.dev/spec/v0.1/provenance) / [in-toto attestation](https://slsa.dev/blog/2023/05/in-toto-and-slsa) | 构建和交付证据需要 provenance，而不是仅保存日志摘要 |
+
+设计约束：
+
+- 项目画像必须来源可追踪、可刷新、可失效。
+- 缺失或冲突信息必须显式暴露，不能用默认假设掩盖。
+- adapter 只负责读取、同步和投影外部系统语义，不改变 BitFun canonical model。
+- 项目画像必须支持多语言、多仓库、多 CI、多发布模式。
+- P0 只做本地项目和 PR 证据链所需画像，不建设企业级集成平台。
+
+## 3. 范围与非目标
+
+范围：
+
+- 发现目标项目结构、语言、框架、模块、owner、规则来源和验证能力。
+- 识别未知区域、规则冲突、过期规则和不可访问外部系统。
+- 为 Quality Data Plane、Risk Classifier、Artifact Graph、PR Gate 和 Evaluation 提供项目画像。
+- 提供代码托管、issue、文档、CI、发布和观测系统的 adapter 边界。
+
+非目标：
+
+- 不替代目标项目的配置管理、需求管理、CI 或发布系统。
+- 不把任何单一项目结构当作默认模板。
+- 不要求目标项目先改造成 BitFun 推荐结构。
+- 不在 P0 做完整组织知识图谱或企业权限系统。
+
+## 4. 输入、输出与数据模型
+
+输入：
+
+| 输入 | 示例 |
+|---|---|
+| Repository facts | 文件树、依赖文件、构建配置、测试目录、生成文件 |
+| Rule sources | README、CONTRIBUTING、agent rules、CODEOWNERS、module docs、team policy |
+| Verification sources | package scripts、task runner、CI workflow、test reports、lint/typecheck/build commands |
+| Ownership sources | CODEOWNERS、git history、issue assignee、team mapping |
+| External integrations | GitHub/GitLab、Jira/Linear、Confluence/Notion、CI、artifact registry、observability |
+| User confirmation | 手动确认模块边界、owner、验证命令、敏感区域和不支持状态 |
+
+输出：
+
+```ts
+interface ProjectProfile {
+  project_id: string;
+  roots: ProjectRoot[];
+  languages: LanguageProfile[];
+  modules: ModuleProfile[];
+  rule_sources: RuleSource[];
+  verification_capabilities: VerificationCapability[];
+  ownership: OwnershipProfile;
+  integrations: IntegrationProfile[];
+  risk_areas: RiskArea[];
+  unknowns: ProfileUnknown[];
+  conflicts: ProfileConflict[];
+  freshness: FreshnessSnapshot;
+  confidence: number;
+}
+```
+
+关键状态：
+
+| 状态 | 含义 | 下游影响 |
+|---|---|---|
+| `confirmed` | 来源明确且已被用户或确定性证据确认 | 可作为 gate、risk、graph 的强依据 |
+| `inferred` | 由文件、配置、历史或静态分析推断 | 可作为候选依据，需要展示置信度 |
+| `unknown` | 缺少足够信息 | 下游必须 degraded 或要求人工确认 |
+| `conflicting` | 多个规则来源冲突 | 下游不得自动选择高风险路径 |
+| `stale` | 来源已变更或超过刷新窗口 | 需要刷新或重新确认 |
+
+## 5. 核心流程
+
+```text
+open target project
+  -> local structure discovery
+  -> rule and verification source discovery
+  -> external adapter probing
+  -> profile normalization
+  -> conflict and unknown detection
+  -> user confirmation for critical gaps
+  -> emit project.profiled event
+  -> refresh / invalidate on project changes
+```
+
+画像生成优先级：
+
+| 来源 | 优先级 | 说明 |
+|---|---:|---|
+| 用户确认 | 1 | 高风险规则、owner、发布边界以用户确认为准 |
+| 确定性配置 | 2 | CI、build、package、CODEOWNERS、typed config |
+| 项目文档 | 3 | README、贡献指南、agent rules、模块文档 |
+| 历史信号 | 4 | co-change、incident、review blocker、hot files |
+| 模型推断 | 5 | 只能生成候选，不作为事实 |
+
+## 6. Adapter 边界
+
+| Adapter | 读取对象 | 输出到 BitFun |
+|---|---|---|
+| Git adapter | branch、diff、commit、PR ref、history | changeset、owner hints、risk signals |
+| Issue adapter | issue、ticket、acceptance criteria、assignee、status | artifact nodes、requirement context |
+| Docs adapter | design doc、runbook、decision record、team rules | rule source、context provenance |
+| CI adapter | workflow、job、check、artifact、log summary | verification capability、evidence item |
+| Release adapter | release、artifact、environment、rollback info | release readiness context |
+| Observability adapter | incident、metric、trace/log link、alert | runtime feedback and graph backtrace |
+
+Adapter 只输出 normalized facts 和 evidence references，不直接写 gate 结论。
+
+## 7. 分阶段落地
+
+| 阶段 | 目标 |
+|---|---|
+| P0 | 本地项目画像、规则来源、验证能力、未知/冲突标记、`project.profiled` 事件 |
+| P1 | GitHub/GitLab PR、issue、CI adapter；用户确认与 profile refresh |
+| P2 | 文档、发布、observability adapter；多仓库和多 workspace 支持 |
+| P3 | 团队级策略包、profile drift dashboard、跨项目画像对比和治理指标 |
+
+## 8. 风险与反证
+
+| 风险 | 反证或治理要求 |
+|---|---|
+| 画像误判导致错误门禁 | 未确认画像只能作为候选；高风险 gate 必须引用 confirmed 或 deterministic evidence |
+| 对 BitFun 自身验证样本过拟合 | 默认 profile 不能内置 BitFun 路径、语言或验证命令 |
+| onboarding 过重 | P0 必须在几分钟内生成可用的最小画像，并允许后续增量确认 |
+| 外部系统耦合 | adapter 输出 canonical facts，不让外部 payload 泄漏到核心策略 |
+| 敏感信息泄露 | profile 写入前执行 redaction，secret 和私有日志只存引用或摘要 |
+| 画像过期 | 文件、CI、规则或集成状态变化必须触发 freshness 更新 |
+| 用户不信任推断 | UI 必须展示来源、置信度、冲突和确认状态 |
+
+## 9. 成功标准
+
+- 新目标项目加载后可生成最小 Project Profile。
+- Risk Classifier 和 PR Gate 能解释所用项目规则和验证能力来自哪里。
+- 未知或冲突规则会导致 `degraded` 或人工确认，而不是默认通过。
+- 外部 adapter 接入不会改变 BitFun canonical event、artifact、permission 和 policy model 的一致性。
+- 用户可以修正项目画像，修正结果会影响后续 gate、risk 和 graph 判断。

--- a/docs/sdlc-harness/architecture/quality-data-plane.md
+++ b/docs/sdlc-harness/architecture/quality-data-plane.md
@@ -1,0 +1,164 @@
+# BitFun SDLC Harness 子模块设计：Quality Data Plane
+
+> 上游文档：[design.md](../design.md)
+> 模块角色：为 BitFun 加载的目标项目提供统一事件、证据、指标和审计数据模型。
+
+## 1. 模块定位
+
+Quality Data Plane 是 BitFun 面向外部目标项目建设全链路 Harness 的基础数据层。它不负责业务决策，而负责把项目画像、会话、工具调用、文件变更、验证命令、Deep Review、PR gate、CI、发布和运行期反馈统一成可追踪、可审计、可回放的数据事实。
+
+首个落地目标必须收敛在目标项目的 PR 证据链：Project Profile、本地 diff、必跑验证、风险分类、轻量 gate、PR 描述和后续审计。P0 不采集完整 SDLC 事件。
+
+## 2. 行业参照与设计约束
+
+| 参照 | 启发 |
+|---|---|
+| [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/) | traces、metrics、logs、resources 需要统一语义，避免观测数据孤岛 |
+| [CDEvents](https://cdevents.dev/) | CI/CD 事件需要可互操作的事件模型 |
+| [SLSA provenance](https://slsa.dev/spec/v1.0/) / [in-toto attestations](https://in-toto.io/) | 构建、验证和 artifact metadata 应具备 provenance 与 attestation |
+| [GitHub Advanced Security with AI coding agents](https://docs.github.com/en/code-security/how-tos/use-ghas-with-ai-coding-agents) | AI coding agent 需要与 secret、dependency、vulnerability 信号联动 |
+| [Harness Software Delivery Knowledge Graph](https://www.harness.io/blog/knowledge-graphs-for-ai-software-delivery) | 交付上下文的价值来自新鲜度、权限、策略和结果改善，而不是事件数量 |
+| [NIST SP 800-218A](https://csrc.nist.gov/pubs/sp/800/218/a/final) | AI 进入 SDLC 后，模型、数据、工具、权限和供应链都属于安全开发边界 |
+
+设计约束：
+
+- P0 只采集 Project Profile 和 PR EvidencePack 所需事件。
+- 每类事件必须定义 retention、privacy、redaction、payload size 和导出策略。
+- EvidencePack 只保存摘要和引用，不长期保存无界原始日志。
+- 内部事件模型保持 canonical；OpenTelemetry、CDEvents、SLSA 等是导出适配，不是内部事实来源。
+- 事件字段需要稳定语义命名，避免子模块各自定义不可对齐的事实。
+- 证据必须区分 trust tier：确定性事实、外部系统事实、人工确认、模型推断和插件建议不能混为同一等级。
+
+## 3. 范围与非目标
+
+范围：
+
+- 定义 `LifecycleEvent` envelope。
+- 统一 session、tool、file、verification、review、gate、cost、security 的事件域。
+- 为 EvidencePack、Artifact Graph、Risk Classifier、PR Gate 和 Evaluation Harness 提供事实输入。
+- 支持本地 append-only audit、投影查询和外部导出。
+
+非目标：
+
+- 不建设通用日志平台。
+- 不采集所有终端输出和模型上下文。
+- 不替代 CI、APM、SIEM 或数据仓库。
+- 不把模型摘要作为原始事实。
+
+## 4. 输入、输出与数据模型
+
+核心输入：
+
+| 输入 | 来源 |
+|---|---|
+| 项目画像事件 | project structure、rules、owner、verification profile、release model |
+| 会话事件 | Agent Runtime、mode、tool call、approval |
+| 文件事件 | diff、rename、delete、generated file、watcher |
+| 验证事件 | command、exit code、duration、log summary、artifact ref |
+| Review 事件 | Deep Review manifest、finding、judge、remediation |
+| Gate 事件 | required checks、risk tags、pass/warn/fail/degraded |
+| 成本事件 | token、model、wall-clock、tool time |
+| 安全事件 | permission、secret exposure、plugin execution、policy deny |
+
+核心输出：
+
+- EvidencePack references。
+- Artifact Graph edge evidence。
+- Risk Classifier calibration features。
+- PR Gate status 和 degraded reasons。
+- Evaluation Harness replay traces。
+- 审计导出和最小指标集。
+
+事件 envelope：
+
+```ts
+interface LifecycleEvent {
+  id: string;
+  type: string;
+  version: number;
+  timestamp: string;
+  source: EventSource;
+  actor: EventActor;
+  scope: EventScope;
+  correlation: EventCorrelation;
+  payload: unknown;
+  evidence?: EvidenceReference[];
+  risk?: RiskSnapshot;
+  privacy: PrivacyClass;
+  retention: RetentionPolicy;
+}
+```
+
+证据信任等级：
+
+| 等级 | 来源 | 是否可作为阻塞性 gate 依据 |
+|---|---|---|
+| `deterministic` | 本地命令、测试、CI check、签名制品、静态配置 | 可以 |
+| `external_system` | GitHub、Jira、CI、observability adapter 返回的已认证事实 | 可以，但需记录 adapter 和刷新时间 |
+| `human_confirmed` | 用户确认、reviewer 决策、risk acceptance | 可以，但必须记录 actor 和 reason |
+| `model_inferred` | LLM 摘要、候选影响面、候选风险标签 | 不可以，只能作为候选或说明 |
+| `plugin_suggested` | 第三方 hook/plugin 产生的建议 | 不可以，必须经过 BitFun policy 或人工确认 |
+
+## 5. 核心流程
+
+```text
+Project/Agent/Tool/CI/Review event
+  -> normalize LifecycleEvent
+  -> redact and classify privacy
+  -> append local audit log
+  -> update projection stores
+  -> expose EvidencePack / Gate / Eval queries
+  -> optional export adapter
+```
+
+P0 最小事件集：
+
+| 事件 | 用途 |
+|---|---|
+| `project.profiled` | 关联项目结构、规则来源和验证能力 |
+| `session.started` / `session.completed` | 关联一次工作流 |
+| `file.changed` | 更新 diff summary 和风险候选 |
+| `tool.completed` | 采集验证命令和工具输出摘要 |
+| `verification.completed` | 形成 required check evidence |
+| `risk.classified` | 固化风险标签、原因和置信度 |
+| `gate.completed` | 固化 PR Gate 结果 |
+| `review.completed` | 关联可选 Deep Review 证据 |
+
+## 6. 策略与治理
+
+- **本地优先**：默认写入本地 append-only log，外部导出需显式配置。
+- **事件预算**：每类事件设置 payload size、采样和保留周期。
+- **隐私分级**：区分 public、project、sensitive、secret；secret 不进入长期事件。
+- **证据引用**：大日志、报告、截图、trace 使用 `EvidenceReference` 引用，不内嵌。
+- **语义稳定**：核心字段采用稳定命名和版本，不把 UI 文案或外部 payload 直接写入事件模型。
+- **信任分层**：Gate 和 release readiness 必须能区分事实、候选、建议和人工接受。
+- **可重放性**：关键事件版本化，schema 变更提供 migration 或兼容读取。
+- **导出隔离**：导出到 GitHub、OpenTelemetry、CDEvents 或云端时保留 redaction 和权限策略。
+
+## 7. 分阶段落地
+
+| 阶段 | 目标 |
+|---|---|
+| P0 | Project Profile 事件、PR EvidencePack 事件、验证命令摘要、Gate 结果、本地审计 |
+| P1 | Artifact Graph 投影、Deep Review finding lifecycle、成本指标 |
+| P2 | CI/发布/incident 事件接入、外部标准导出 |
+| P3 | Evaluation replay、跨团队质量指标、策略回放分析 |
+
+## 8. 风险与反证
+
+| 风险 | 反证或治理要求 |
+|---|---|
+| telemetry bloat | P0 事件集必须能支撑 PR gate，同时事件量可解释、可裁剪 |
+| 原始日志泄露 | EvidencePack 不应包含长期原始日志；敏感片段必须 redaction |
+| 事件不可治理 | 每个事件域必须定义 owner、retention、schema version 和导出策略 |
+| 模型摘要覆盖事实层 | 模型输出只能作为 derived evidence，不能覆盖原始 command/CI/review 事实 |
+| 跨模块耦合过重 | 上游模块只能依赖查询接口和 event schema，不能直接读取内部存储 |
+| 审计不可复现 | Gate、review、risk 等关键结论必须能追溯到 event id 和 evidence ref |
+
+## 9. 成功标准
+
+- 低风险 PR 可生成完整 EvidencePack，不依赖完整图谱。
+- Gate 结果可追溯到验证事件、风险事件和人工 override。
+- Deep Review token、耗时、scope、skipped context 可被统一记录。
+- 事件模型能够导出到至少一种外部标准或平台。
+- 敏感信息扫描和 redaction 在事件写入前执行。

--- a/docs/sdlc-harness/design.md
+++ b/docs/sdlc-harness/design.md
@@ -1,0 +1,402 @@
+# BitFun 全软件生命周期 Harness 设计文档
+
+> 范围：定义 BitFun 作为 Harness 产品加载和治理外部软件工程时的目标领域模型、逻辑架构、模块职责边界和跨阶段控制闭环。
+> 边界：本文不以 BitFun 仓库自身治理为主线。BitFun 自身的文档、模块边界或工程治理问题应作为独立内部验证与平台建设输入承载，不混入产品目标架构。
+
+## 1. 设计目的
+
+BitFun 的目标形态不是只服务于自身仓库的工程治理工具，而是一个面向任意目标项目的 Agentic Engineering Harness。用户把一个外部工程加载到 BitFun 后，BitFun 应能够理解该工程的规则、代码、任务、变更、验证、评审、发布与运行反馈，并在关键节点提供上下文组织、证据沉淀、风险分级、质量门禁、人工确认和持续评估。
+
+因此，本文讨论的是三类对象之间的关系：
+
+| 对象 | 定义 | 设计含义 |
+|---|---|---|
+| BitFun 产品 | 提供 Agent Runtime、工具集成、Hook/Event、质量数据、图谱、门禁和协作界面的宿主系统 | 负责承载 Harness 能力，但不把自身仓库规则硬编码为通用规则 |
+| 目标项目 | 被用户加载、分析、修改、评审和发布的软件工程，可以是任意语言、仓库结构和团队流程 | Harness 的主要治理对象 |
+| 外部系统 | 目标项目依赖的 issue、文档、代码托管、CI、制品、发布、观测和知识库系统 | BitFun 通过 adapter 集成，不直接替代 |
+
+主设计要回答四个问题：
+
+1. 当 BitFun 面向外部目标项目时，软件生命周期中的真实断裂点是什么。
+2. 为了承载多项目、多团队、多流程，BitFun 需要怎样的目标领域模型。
+3. BitFun 的产品逻辑架构应如何分层，避免把 Agent 执行、质量事实、策略判断和团队协作混在一起。
+4. 为什么第一阶段从 PR 证据链切入，但架构必须能继续扩展到需求、发布、运行和复盘。
+
+## 2. 产品问题域识别
+
+### 2.1 被治理对象不是 BitFun 仓库，而是目标项目
+
+BitFun 可以用自身仓库作为内部验证场景，但产品设计不能默认目标项目具有同样的语言、目录、CI、分支策略、agent rules 文档、模块边界或发布流程。真实用户加载的项目可能存在以下差异：
+
+| 差异维度 | 目标项目可能状态 | 对 Harness 的要求 |
+|---|---|---|
+| 项目结构 | monorepo、multi-repo、单体仓库、生成代码仓库、服务加前端混合仓库 | 先发现结构和边界，再建立项目画像 |
+| 工程规则 | 有 agent rules，也可能只有 README、贡献指南、隐性团队约定或完全缺失 | 规则来源需要分级、溯源、冲突处理和缺失提示 |
+| 验证体系 | CI 完整、CI 不稳定、只有本地脚本、没有测试、依赖私有环境 | required checks 必须可解释，并能区分缺失、失败、跳过和不可运行 |
+| 交付流程 | issue 到 PR、ticket 到 release、直接 commit、人工发布、灰度发布 | Artifact Graph 不能绑定单一流程 |
+| 质量文化 | 强 branch protection、弱 review、依赖 owner 经验、合规审计强约束 | Gate 策略需要按项目和团队可配置 |
+| 权限边界 | 本地工程、远程 workspace、企业网络、私有依赖、敏感文件 | Hook/Event 和工具调用必须默认最小权限 |
+
+因此，BitFun 要建设的是可适配目标项目的 Harness 能力，而不是把某个仓库的实践固化为产品功能。
+
+### 2.2 外部项目中的关键断裂点
+
+从目标项目视角看，当前软件生命周期通常存在六类断裂：
+
+| 断裂点 | 表现 | 后果 |
+|---|---|---|
+| 项目理解断裂 | 代码结构、规则、owner、CI、发布方式和历史风险分散在不同系统或人的经验中 | Agent 容易读错边界、跑错验证、误判风险 |
+| 交付物断裂 | requirement、ticket、spec、plan、diff、test、review、release、incident 之间缺少稳定关系 | 变更是否满足需求、问题来自哪里、哪些验证覆盖了风险都难以证明 |
+| 证据断裂 | 上下文读取、命令输出、测试结果、review finding、跳过理由和人工确认散落在会话、终端、PR 和 CI 中 | 审计、复盘、交接和再次评审需要重复整理 |
+| 控制断裂 | tool approval、hook、CI、review、release gate 和人工审批不在同一控制平面 | 高风险动作难以一致阻断、降级、审计和复跑 |
+| 反馈断裂 | CI failure、review blocker、post-merge defect、incident 没有稳定回流到规则、测试和评估集 | 工具无法从失败中校准，团队也难以沉淀工程知识 |
+| 责任断裂 | Agent 自动结论、工具事实、人类判断和风险接受边界不清 | 自动化结果容易被误认为已验证事实，发布责任不可追踪 |
+
+这些断裂说明：BitFun 的核心产品机会不是继续强化单点代码生成能力，而是给目标项目补上一个可配置、可追踪、可审计的生命周期 Harness。
+
+### 2.3 目标系统要解决的本质问题
+
+全局设计要解决的是：
+
+```text
+当一个外部软件工程被加载到 BitFun 后，
+如何把项目规则、交付物、执行轨迹、质量证据、风险策略、人工决策和失败反馈
+组织成可追踪、可审计、可演进的工程控制系统。
+```
+
+PR 是第一个落地切口，因为它通常同时连接 diff、review、CI、issue、owner、风险接受和团队协作。但 PR 不是产品边界。完整架构必须继续向上连接需求和设计，向下连接发布、运行、incident 与回归资产。
+
+## 3. 目标领域模型
+
+### 3.1 顶层领域
+
+BitFun SDLC Harness 面向目标项目的领域模型分为六组核心对象：
+
+| 领域 | 核心对象 | 作用 |
+|---|---|---|
+| Project Profile | workspace、repository、language、framework、module、owner、rule source、verification capability、release model | 描述目标项目是什么、如何构建、如何验证、由谁负责 |
+| Lifecycle Artifact | requirement、ticket、acceptance criteria、spec、design decision、plan、task、changeset、test、review、PR、release、incident、learning asset | 表达目标项目从需求到运行反馈的交付物 |
+| Execution Trace | session、turn、model run、tool run、command run、file operation、hook invocation、adapter call | 记录 BitFun 如何读取、修改和验证目标项目 |
+| Quality Evidence | evidence pack、evidence item、command result、CI result、review finding、context provenance、skip reason、stale marker | 证明当前结论来自哪些事实和证据 |
+| Risk and Policy | risk signal、required check、gate decision、approval、override、budget profile、permission policy | 表达哪些风险需要处理、哪些检查必须执行、哪些责任需要人工确认 |
+| Evaluation and Learning | eval task、oracle、benchmark、trace replay、failure pattern、rule update、skill、regression test | 把目标项目中的失败和经验回流成可重复验证的资产 |
+
+这六组对象之间的关系构成产品架构骨架：
+
+```text
+Project Profile
+  constrains -> Execution Trace
+  informs -> Risk and Policy
+  provides context for -> Lifecycle Artifact
+
+Lifecycle Artifact
+  is changed by -> Execution Trace
+  is justified by -> Quality Evidence
+  is protected by -> Gate Decision
+  is improved by -> Evaluation and Learning
+
+Quality Evidence
+  supports -> Review / PR / Release / Incident response
+  expires with -> artifact or context change
+
+Risk and Policy
+  selects -> Required Checks / Review Profile / Approval Path
+  feeds back from -> CI Failure / Review Blocker / Incident / Override
+```
+
+### 3.2 生命周期主链路
+
+目标项目的完整生命周期链路是：
+
+```text
+Feedback / Issue / Requirement
+  -> Acceptance Criteria / Spec / Design Decision
+  -> Plan / Task
+  -> ChangeSet / Code / Config / Migration
+  -> Test / Verification / Benchmark
+  -> Review / Gate / Approval
+  -> PR / Merge / Release
+  -> Telemetry / Incident / User Report
+  -> Regression Test / Rule / Skill / Evaluation Task
+```
+
+这条链路不是要求所有节点在 P0 同时实现，而是定义 BitFun 要逐步承载的产品逻辑。任意子模块都必须能说明自己服务链路中的哪一段、消费哪些对象、输出哪些对象，以及何时需要人工确认。
+
+### 3.3 项目画像模型
+
+面向外部目标项目时，Project Profile 是所有 Harness 判断的前置条件。它至少包含：
+
+| 画像维度 | 内容 | 典型来源 |
+|---|---|---|
+| 结构画像 | repo、package、module、service、frontend、backend、generated code、test tree | 文件系统、依赖文件、构建配置、代码搜索 |
+| 规则画像 | 项目说明、贡献指南、agent rules、CODEOWNERS、分支策略、验证矩阵 | README、CONTRIBUTING、agent rules、CI、仓库设置 |
+| 验证画像 | 可运行命令、CI jobs、测试分层、flaky 信号、环境依赖 | package scripts、cargo/npm/maven/gradle、CI 配置、历史结果 |
+| 风险画像 | hot files、incident 关联、历史 review blocker、安全敏感区、发布关键路径 | Git history、PR comments、incident links、owner 标注 |
+| 权限画像 | 本地/远程 workspace、敏感文件、secret、网络、shell、MCP、桌面能力 | BitFun policy、项目配置、用户授权 |
+
+项目画像不是一次性扫描结果，而是随项目变化、用户确认和失败反馈持续更新的上下文资产。缺少画像时，系统应输出 `unknown` 或 `degraded`，而不是把未知项目误判为低风险。
+
+### 3.4 控制点模型
+
+Harness 的本质是在交付物流转中设置控制点。每个控制点都应面向目标项目输出可解释状态：
+
+| 控制点 | 关注问题 | 输出 |
+|---|---|---|
+| Project understanding control | 当前项目结构、规则、验证能力是否被正确识别 | project profile、unknown area、stale warning |
+| Context control | 当前任务是否拿到了正确、有效、不过期的上下文 | context provenance、conflict warning |
+| Permission control | 工具、插件、命令、文件和外部系统访问是否越权 | approval、deny、audit |
+| Risk control | 变更属于什么风险等级，需要哪些验证和 reviewer | risk tags、required checks、review profile |
+| Evidence control | 是否有足够证据支持当前结论 | EvidencePack、missing evidence、degraded state |
+| Review control | 问题是否被发现、处理、验证或接受 | finding lifecycle、stale review |
+| Release control | 是否具备发布、观测和回滚信心 | readiness、risk acceptance、rollback plan |
+| Learning control | 失败是否沉淀为可复用资产 | eval task、regression test、rule、skill |
+
+这使 BitFun 从 Agent 工作台升级为面向目标项目的生命周期控制平面。
+
+## 4. 目标逻辑架构
+
+### 4.1 分层架构
+
+目标架构分为六层：
+
+```text
+User and Team Surfaces
+  Agent Workbench / Project Map / PR Review / Release Readiness / Incident Review
+
+Lifecycle Harness Control Plane
+  Risk Policy / Gate / Review / Impact Analysis / Evaluation / Approval
+
+Artifact and Evidence Plane
+  Artifact Graph / EvidencePack / Finding Lifecycle / Risk Acceptance
+
+Quality Data Plane
+  Lifecycle Events / Execution Trace / Verification Results / Cost and Audit
+
+Project Integration Plane
+  Git / CI / Issue Tracker / Docs / Release / Observability / Knowledge Base
+
+Agent and Tool Runtime
+  Sessions / Agents / Tools / Terminal / MCP-LSP / Hooks / Adapters
+```
+
+各层职责：
+
+| 层 | 解决的问题 | 不承担的职责 |
+|---|---|---|
+| User and Team Surfaces | 让用户在目标项目的任务、PR、发布和复盘中消费 Harness 结论 | 不直接承载策略判断 |
+| Lifecycle Harness Control Plane | 负责风险、门禁、影响分析、评估和审批编排 | 不直接保存原始事实 |
+| Artifact and Evidence Plane | 负责交付物关系、证据投影、finding 生命周期和风险接受记录 | 不执行工具，不替代外部系统 |
+| Quality Data Plane | 负责事实、事件、轨迹、成本、审计和证据引用 | 不做业务策略，不判断是否可发布 |
+| Project Integration Plane | 负责连接目标项目及其外部系统 | 不把外部系统语义泄漏为内部 canonical model |
+| Agent and Tool Runtime | 负责实际执行、工具调用、Hook/Event 触发和 adapter 执行 | 不自行宣布质量结论 |
+
+### 4.2 逻辑架构关系
+
+```text
+Target Project and External Systems
+  source code / rules / tickets / CI / release / observability
+        |
+        v
+Project Integration Plane
+        |
+        v
+Agent and Tool Runtime
+        |
+        v
+Quality Data Plane
+        |
+        v
+Artifact and Evidence Plane
+        |
+        v
+Lifecycle Harness Control Plane
+        |
+        v
+User and Team Surfaces
+```
+
+这不是严格调用栈，而是责任流：
+
+- 目标项目和外部系统提供真实工程对象。
+- Project Integration Plane 负责读取和同步这些对象，并做 adapter 隔离。
+- Agent Runtime 在授权范围内执行分析、修改、验证和工具调用。
+- Quality Data Plane 固化事实、事件和成本。
+- Artifact and Evidence Plane 组织交付物关系、证据和 finding 状态。
+- Harness Control Plane 做风险、门禁、评估和审批判断。
+- 用户界面和团队流程消费判断，并给出确认、覆盖或风险接受。
+
+### 4.3 为什么第一阶段仍从 PR 切入
+
+PR 是第一个验证闭环，不是架构边界。原因：
+
+- PR 是大多数目标项目已经接受的协作对象，不要求 BitFun 先替代 issue、CI 或 release 平台。
+- PR 同时连接 diff、review、CI、owner、风险接受和发布信心，适合验证 EvidencePack、Risk Classifier、Gate 和 Artifact Graph 的最小关系。
+- PR 的失败模式高频可见，能快速积累后验校准信号，例如 review blocker、CI failure、stale evidence 和 override。
+- PR 之后可以自然扩展到需求影响分析、release readiness 和 incident 回溯。
+
+因此，第一阶段聚焦 PR 是产品落地策略；目标架构仍是面向外部目标项目的全生命周期领域模型。
+
+## 5. 产品采用路径
+
+从产品设计角度看，BitFun 不宜在早期一次性提供完整 SDLC Harness 能力。可采用的最小路径是：
+
+```text
+Open Project
+  -> Project Profile
+  -> Local Diff / PR
+  -> EvidencePack
+  -> Risk and Required Checks
+  -> Gate Result
+  -> Review / Confirm / Override
+  -> Graph and Eval Feedback
+```
+
+这条路径的产品含义是：
+
+| 阶段 | 用户问题 | BitFun 输出 |
+|---|---|---|
+| 加载项目 | BitFun 是否理解我的项目结构、规则和验证方式 | Project Profile、未知区域、冲突规则、可运行验证 |
+| 准备变更 | 当前 diff 有哪些风险和必须验证项 | risk tags、required checks、context provenance |
+| 提交 PR | reviewer 需要哪些证据才能信任变更 | EvidencePack、Gate result、open risks |
+| 评审修复 | review finding 是否已处理，证据是否过期 | finding lifecycle、stale evidence |
+| 发布复盘 | 本次变更与发布、incident 和回归资产如何关联 | Artifact Graph、release/incident backtrace |
+
+因此，主设计的第一产品闭环不是“自动写代码”，而是“加载外部项目后，给每一次变更提供可解释的质量保护”。这是 BitFun 区别于单纯 IDE Agent 或单点 PR Review 工具的核心路径。
+
+## 6. 模块职责与边界
+
+下表定义主设计拆出的子模块。每个模块的详细数据模型、流程、策略和成功标准在对应子模块文档中展开。
+
+| 模块 | 详细设计 | 核心解决问题 | 职责边界 | 目标状态 |
+|---|---|---|---|---|
+| Project Profile and Integration | [project-profile-integration.md](architecture/project-profile-integration.md) | 目标项目结构、规则、验证能力和外部系统不可见 | 负责项目画像和 adapter 边界，不直接做风险或 gate 判断 | 新项目加载后能明确已知、未知、冲突和过期信息 |
+| Quality Data Plane | [quality-data-plane.md](architecture/quality-data-plane.md) | 目标项目质量事实分散，证据不可复用 | 只负责事件、证据引用、指标和审计事实，不负责复杂策略判断 | gate、review、eval、impact 都能引用同一事实基础 |
+| Artifact Graph | [artifact-graph.md](architecture/artifact-graph.md) | 目标项目生命周期交付物关系断裂 | 负责交付物节点和可信链接，不替代需求、代码托管、CI 或 observability 系统 | 从最小 PR 图谱扩展到需求、发布和 incident 回溯 |
+| Risk Classifier | [risk-classifier.md](features/risk-classifier.md) | 外部项目风险规则差异大，验证选择依赖人工经验 | 负责输出风险标签、原因、置信度和 required checks；不直接宣称变更安全 | PR 和任务都有可解释的项目级风险画像和验证建议 |
+| PR Quality Gate | [pr-quality-gate.md](features/pr-quality-gate.md) | PR 放行缺少统一证据、风险和 review 状态 | 负责聚合证据、风险、验证、Deep Review 和人工确认；不替代 CI 或 human approval | PR 可输出 `pass/warn/fail/degraded`，并说明依据和未覆盖风险 |
+| Agent Evaluation | [agent-evaluation.md](features/agent-evaluation.md) | 不同目标项目中的 prompt、tool schema、model 和策略改动缺少长期评估 | 负责任务集、oracle、trace replay 和 A/B；不做通用模型排名 | Harness 改动能被质量、成本、安全和稳定性共同评估 |
+| Requirement Impact Analysis | [requirement-impact-analysis.md](features/requirement-impact-analysis.md) | 需求、验收标准、API 或设计变更后的影响面不清 | 负责输出候选影响、置信度、证据和 required checks；不宣称完整自动影响分析 | 高风险变更能形成可确认的影响面和验证清单 |
+| OpenCode Compatibility | [opencode-compatibility.md](features/opencode-compatibility.md) | 常用 hook/plugin 生态难以在 BitFun 加载的项目中复用 | 只作为 adapter，不改变 BitFun canonical event、permission、artifact 和 policy model | 常见 Harness 插件能力可迁移，同时安全边界保持清晰 |
+
+## 7. 跨模块主流程
+
+### 7.1 项目加载与画像建立
+
+```text
+Open target project
+  -> project structure discovery
+  -> rule and verification source discovery
+  -> Project Profile
+  -> unknown / conflict / stale markers
+  -> user confirmation when needed
+  -> Quality Data Plane events
+```
+
+这个流程是所有后续 Harness 判断的前提。没有项目画像时，Risk Classifier、PR Gate 和影响分析都必须显式降级。
+
+### 7.2 PR 质量闭环
+
+```text
+ChangeSet in target project
+  -> execution trace
+  -> Quality Data Plane
+  -> EvidencePack
+  -> Risk Classifier
+  -> PR Quality Gate
+  -> Deep Review when needed
+  -> Artifact Graph update
+  -> Evaluation feedback
+```
+
+这个流程验证最小可行 Harness：证据、风险、门禁、评审、图谱和评估都能在一个高频场景中形成闭环。
+
+### 7.3 需求变更影响闭环
+
+```text
+Requirement / Spec / API change
+  -> Artifact Graph lookup
+  -> Requirement Impact Analysis
+  -> Risk Classifier
+  -> required checks
+  -> human confirmation
+  -> PR Gate / Release Readiness
+```
+
+这个流程把架构从 PR 向上连接到需求和设计，避免质量控制只发生在代码提交后。
+
+### 7.4 运行期反馈闭环
+
+```text
+Incident / User Report / Telemetry
+  -> Artifact Graph backtrace
+  -> related release / PR / diff / test
+  -> EvidencePack and risk review
+  -> regression test / rule / skill / eval task
+```
+
+这个流程把架构从 PR 向下连接到发布和运行期，避免 incident 只停留在人工复盘中。
+
+## 8. 模块协作原则
+
+1. **目标项目与宿主产品分离**：目标项目的规则、CI、发布流程和团队约定进入 Project Profile；BitFun 内部实现细节不得被当成通用项目规则。
+2. **事实与策略分离**：Quality Data Plane 记录事实，Risk Classifier 和 PR Gate 使用事实做策略判断。
+3. **图谱与门禁分离**：Artifact Graph 表达交付物关系，PR Quality Gate 决定当前 PR 是否满足质量条件。
+4. **候选与事实分离**：Requirement Impact Analysis 和模型推断只能生成候选，确认状态由人类或确定性证据补齐。
+5. **兼容与内核分离**：OpenCode Compatibility 只映射外部 API，BitFun 内部始终以 canonical event 和 permission model 为准。
+6. **评估与执行分离**：Agent Evaluation 评估策略和能力变化，不直接修改生产策略；策略变更必须经过明确发布路径。
+7. **高风险与低风险分流**：低风险变更保持轻量，风险升高时逐步增加 required checks、Deep Review 和人工确认。
+
+## 9. 设计硬约束
+
+从独立架构和产品审查视角看，以下约束必须作为后续实现的准入条件：
+
+| 硬约束 | 原因 | 设计要求 |
+|---|---|---|
+| 画像先于判断 | 未理解目标项目时，任何风险和 gate 结论都可能误导用户 | Project Profile 不完整时输出 `unknown/degraded` |
+| 证据先于自动化 | Agent 能执行不等于变更可信 | Gate、review、release readiness 必须引用 evidence ref |
+| 候选不等于事实 | LLM 适合召回和总结，但不适合单独宣布影响面或安全性 | LLM 输出默认是 candidate，需要 confidence、evidence 和 confirmation |
+| 成本为核心约束 | Deep Review 和长程 Agent 容易导致 token、耗时和 CI 成本预算约束不足 | 所有高成本能力必须有 budget、profile、降级和跳过原因 |
+| 外部生态不能侵入核心模型 | 兼容 OpenCode、Codex 或 Claude Hook 不能牺牲 BitFun 自身模型一致性 | compatibility 只能作为 adapter，内部只使用 canonical model |
+| 图谱不能无界增长 | 低质量链接会比没有链接更危险 | Artifact Graph 先追求高价值、可验证、可失效的边 |
+| 人类责任不可省略 | 风险接受、发布责任和例外处理必须可追踪 | override 必须记录 actor、reason、residual risk 和 evidence |
+| 评估必须防泄漏 | 公开 benchmark 存在评测集泄漏和过拟合风险，单一分数无法代表产品质量 | Evaluation 使用 holdout、真实任务回放、成本和安全联合指标 |
+
+## 10. 非目标
+
+- 不把 BitFun 仓库自身治理当作本文主线。
+- 不要求目标项目采用 BitFun 仓库的目录、语言、CI 或文档结构。
+- 不直接替代 Jira、GitHub、Linear、CI、observability 或 release 平台。
+- 不把所有质量判断交给 LLM。
+- 不承诺需求影响分析的自动完整性。
+- 不把任意第三方 plugin 视为可信执行主体。
+- 不把 Deep Review 作为所有 PR 的默认阻塞门禁。
+- 不在主设计文档中展开各子模块的详细 schema、事件清单、策略规则和执行计划。
+
+## 11. 全局风险与治理策略
+
+| 风险 | 可能后果 | 治理策略 |
+|---|---|---|
+| 产品边界未收敛 | 基础设施建设周期过长，短期难证明价值 | 首个可验证场景收敛为目标项目的 PR EvidencePack、Risk Classifier 和 lightweight gate |
+| 把自身验证经验泛化为产品规则 | 外部项目适配失败，用户需要改造项目才能使用 | BitFun 自身经验只作为验证样本，不进入默认策略；默认策略必须项目可配置 |
+| 项目画像误判 | Agent 读错结构、跑错验证、误判 owner 或风险 | profile 必须有来源、置信度、新鲜度和用户确认状态 |
+| Artifact Graph 边界过宽 | 低质量链接累积、关系过期、置信度不足，最终降低可用性 | 先覆盖最小 PR 图谱，所有边具备来源、置信度、新鲜度和确认状态 |
+| Quality Data Plane 过重 | telemetry bloat、隐私风险、查询成本上升 | 采用事件预算、retention、redaction、sampling 和标准导出 |
+| OpenCode 兼容侵入核心模型 | 外部 API 语义影响 BitFun 权限、事件和策略模型 | 兼容层必须是 adapter，内部只承认 BitFun canonical model |
+| Deep Review 成本分级约束不足 | token 与耗时过高，低风险 PR 被阻塞 | 按风险触发，先运行低成本结构化检查，再选择 targeted/full review |
+| Risk Classifier 权威错觉 | 自动风险标签被误认为事实 | 输出原因、证据、置信度和人工 override；阻塞决策必须引用确定性证据 |
+| 需求影响分析误报/漏报 | 低价值候选过多会降低采用率，高漏报会影响发布安全 | 输出候选集合和置信度，高风险低置信链接要求人工确认 |
+| Evaluation Harness 无 oracle | 无法判断 Agent 或 Harness 是否真的变好 | 每类任务必须定义 oracle：测试、diff expectation、review rubric 或 human acceptance |
+| 插件与 hook 安全边界不足 | 第三方插件绕过权限、泄露数据或篡改证据 | 默认最小权限、超时、redaction、审计和禁用策略 |
+| 团队采用路径不清 | 工具价值停留在概念层，难进入日常流程 | 优先嵌入项目加载、本地 diff、PR 描述、required checks 和 reviewer 工作流 |
+
+## 12. 成功状态
+
+全局设计达到目标时，BitFun 应具备以下状态：
+
+- 任意目标项目被加载后，BitFun 能建立可解释的 Project Profile，并明确未知、冲突和过期区域。
+- 需求、spec、diff、test、review、PR、release、incident 之间具备可追踪关系。
+- 本地 diff 或 PR 可以生成结构化 EvidencePack。
+- PR 风险、required checks、Deep Review 状态和未覆盖风险可解释。
+- 高风险变更能够触发更强验证和人工确认，低风险变更保持低成本流转。
+- Deep Review、影响分析、评估和插件扩展都有预算、降级和审计边界。
+- 线上问题和评审失败可以回流到测试、规则、skill 或 eval 任务，形成持续改进闭环。

--- a/docs/sdlc-harness/features/agent-evaluation.md
+++ b/docs/sdlc-harness/features/agent-evaluation.md
@@ -1,0 +1,140 @@
+# BitFun SDLC Harness 子模块设计：Agent Evaluation
+
+> 上游文档：[design.md](../design.md)
+> 模块角色：为 Agent 模式、工具接口、prompt、subagent、hook、policy 和模型组合提供长期评测体系。
+
+## 1. 模块定位
+
+Agent Evaluation 的目标是回答：某次 prompt、tool schema、context policy、subagent、model 或 Harness policy 改动，是否真正提升了任务成功率、质量、成本、安全性和可审计性。
+
+没有 oracle 的 eval 不能用于决策。BitFun 的评测体系必须区分模型能力、工具接口、上下文选择、策略约束和 UI/Harness 的影响，避免把 benchmark 分数误认为产品质量。
+
+## 2. 行业参照与设计约束
+
+| 参照 | 启发 |
+|---|---|
+| [SWE-bench](https://github.com/swe-bench/SWE-bench) / [SWE-agent](https://arxiv.org/abs/2405.15793) | 真实 issue 与 Agent-Computer Interface 都影响软件工程任务成功率 |
+| [SWE-Bench Pro](https://labs.scale.com/leaderboard/swe_bench_pro_public) | 更真实、更长程、更复杂代码库暴露出评测集泄漏、任务多样性和测试可靠性问题 |
+| [Agentless](https://arxiv.org/abs/2407.01489) | 简单、结构化、可解释 pipeline 是强基线 |
+| [Terminal-Bench](https://arxiv.org/abs/2601.11868) / [Terminal-Bench 3.0](https://www.tbench.ai/) | 长程终端任务需要真实环境、可靠 oracle 和任务泄漏防护 |
+| [Agentic AI in the SDLC](https://arxiv.org/abs/2604.26275) | Agentic SDLC 需要从架构、证据、生产力和治理同时评估 |
+| [OpenAI Agent Improvement Loop](https://developers.openai.com/cookbook/examples/agents_sdk/agent_improvement_loop) | trace、feedback、eval 和 harness change 应形成持续改进闭环 |
+| [RovoDev Code Reviewer](https://arxiv.org/html/2601.01129v1) | 在线评估要同时看 resolution、PR cycle time、人类评论负载和错误反馈 |
+
+设计约束：
+
+- 评测必须有明确 oracle。
+- 不能用单一 benchmark 代表产品质量。
+- 必须记录 token、wall-clock、tool calls、失败原因和安全事件。
+- 评测集必须防止任务泄漏和过拟合。
+- 公开 benchmark、内部 golden set 和私有 holdout 必须分开管理。
+- 评测必须覆盖 Project Profile、EvidencePack、Gate 和 Graph 的协同效果，而不只评测模型补丁能力。
+
+## 3. 范围与非目标
+
+范围：
+
+- 评测 Plan、Debug、Review、Deep Review、Agentic、Mini App、remote、MCP 等模式。
+- 评测 tool interface、context policy、hook policy、approval policy。
+- 支持 replay、A/B、regression、failure taxonomy。
+- 将失败沉淀为 rule、skill、hook、test 或 benchmark。
+
+非目标：
+
+- 不声明通用模型能力排名。
+- 不用离线 benchmark 替代线上质量指标。
+- 不把 human preference 当作唯一 oracle。
+- 不在缺少隔离环境时运行高风险自动化任务。
+
+## 4. 输入、输出与数据模型
+
+输入：
+
+| 输入 | 示例 |
+|---|---|
+| Task fixture | repo snapshot、issue、expected diff、test command |
+| Project profile | 规则来源、验证能力、owner、未知区域和冲突状态 |
+| Trace | model calls、tool calls、file edits、approvals、events |
+| Policy version | prompt、tool schema、context policy、hook policy |
+| Oracle | test pass、diff expectation、review rubric、human acceptance |
+| Cost | token、wall-clock、tool time、retry count |
+
+输出：
+
+```ts
+interface EvalResult {
+  task_id: string;
+  run_id: string;
+  success: boolean;
+  oracle: OracleResult;
+  quality_scores: Record<string, number>;
+  cost: CostSnapshot;
+  safety_events: SafetyEvent[];
+  failure_taxonomy: string[];
+  trace_ref: EvidenceReference;
+  harness_versions: Record<string, string>;
+}
+```
+
+## 5. 核心流程
+
+```text
+select task set
+  -> prepare isolated environment
+  -> run baseline and candidate harness
+  -> collect trace and evidence
+  -> evaluate oracle and rubrics
+  -> compare cost/quality/safety
+  -> classify failures
+  -> promote fixes into policy/test/skill
+```
+
+任务类型：
+
+| 类型 | Oracle |
+|---|---|
+| Project profiling | 是否识别正确结构、规则、验证能力和未知区域 |
+| Mode compliance | 是否遵守只读、审批、review 约束 |
+| Tool interface | 工具调用是否正确、输出是否被使用 |
+| Real issue repair | 测试通过、diff 符合预期、无回归 |
+| Deep Review | seeded defect coverage、finding precision、judge consistency |
+| PR Gate | required checks precision、false pass/block、degraded handling |
+| Hook policy | 权限、redaction、timeout、blocking semantics |
+
+## 6. 策略与治理
+
+- **Baseline 优先**：每个复杂 agent flow 都要与简单结构化 pipeline 比较。
+- **Trace replay**：失败可在固定输入、固定工具版本和固定 policy 下回放。
+- **Holdout 管理**：公开 benchmark、内部 golden set、私有 holdout 和线上回放集分开管理，避免策略过拟合。
+- **成本约束**：报告必须展示 token、耗时、工具调用和重试。
+- **安全隔离**：高风险工具、网络、文件系统和插件在 eval 中使用最小权限。
+- **线上反馈回流**：review blocker、post-merge defect、override、incident 写入评测 backlog。
+
+## 7. 分阶段落地
+
+| 阶段 | 目标 |
+|---|---|
+| P0 | Project Profile、PR Gate、Risk Classifier、Deep Review 的小型 golden set |
+| P1 | trace replay、failure taxonomy、成本对比 |
+| P2 | 模型/harness A/B、线上反馈回流、regression dashboard |
+| P3 | 跨团队 benchmark、自动生成候选 eval、长期趋势分析 |
+
+## 8. 风险与反证
+
+| 风险 | 反证或治理要求 |
+|---|---|
+| 无 oracle 评测 | 每个任务必须声明 oracle，否则只能作为探索样本 |
+| benchmark 过拟合 | 保留 holdout set，记录任务来源和泄漏风险 |
+| 公开榜单幻觉 | 公开 benchmark 只用于参考，产品决策必须结合目标项目回放和线上指标 |
+| 只看成功率忽略成本 | token、耗时、tool calls 必须和质量一起比较 |
+| 混淆模型与 harness 贡献 | model、prompt、tool schema、context、policy 版本必须分开记录 |
+| 人工评分不稳定 | review rubric 需要结构化，并记录 reviewer variance |
+| eval 与真实工作脱节 | 从真实 PR、issue、CI failure、incident 中抽样构建任务 |
+
+## 9. 成功标准
+
+- 关键 harness/prompt/tool schema 改动可用固定任务集回放。
+- 失败能归类到模型、工具、上下文、策略或产品交互问题。
+- Evaluation 能解释质量提升是否伴随 token/耗时成本增加。
+- Deep Review、Risk Classifier、PR Gate 都有专属 eval。
+- 线上缺陷和 reviewer blocker 能沉淀为新任务。

--- a/docs/sdlc-harness/features/opencode-compatibility.md
+++ b/docs/sdlc-harness/features/opencode-compatibility.md
@@ -1,0 +1,141 @@
+# BitFun SDLC Harness 子模块设计：OpenCode Compatibility
+
+> 上游文档：[design.md](../design.md)
+> 模块角色：在 BitFun 内部 Hook/Event Bus 之上提供 OpenCode 风格插件、hook、custom tool 和 event stream 兼容能力。
+
+## 1. 模块定位
+
+OpenCode Compatibility 是生态适配层，不是 BitFun 内核能力。BitFun 内部必须以自己的 canonical event、artifact、permission 和 policy model 为准；OpenCode API 只负责降低插件迁移成本，并服务 Harness 场景，例如权限看护、证据采集、风险分类、LSP diagnostics 和 session idle 完成度检查。
+
+P0/P1 只兼容 Harness 相关核心事件和 custom tool 最小集，不承诺任意社区插件无修改运行。
+
+## 2. 行业参照与设计约束
+
+| 参照 | 启发 |
+|---|---|
+| [OpenCode Plugins](https://opencode.ai/docs/plugins/) / [SDK](https://opencode.ai/docs/sdk/) / [Server API](https://opencode.ai/docs/server/) | plugin context、hooks object、custom tools、client log、SSE event stream 是生态迁移重点 |
+| [Codex Hooks](https://developers.openai.com/codex/hooks) | hooks 是 agent lifecycle 治理和自动化拦截点 |
+| [Claude Code Hooks](https://code.claude.com/docs/en/hooks) | hook 需要明确阻塞/非阻塞、退出码、权限和上下文语义 |
+| [OWASP LLM Top 10](https://owasp.org/www-project-top-10-for-large-language-model-applications/) | 插件、工具调用、数据出境和权限提升属于 LLM app 风险面 |
+
+设计约束：
+
+- compatibility adapter 不得改变 BitFun 内部事件模型。
+- 插件不能绕过 permission、policy、redaction、audit。
+- API 兼容分级推进，先支持 L0/L1。
+- 第三方插件默认最小权限、超时、可禁用、可审计。
+- 插件来源、版本、hash、权限声明和兼容等级必须可见。
+- 兼容承诺必须通过测试矩阵表达，不用“兼容 OpenCode”这种宽泛表述替代边界。
+
+## 3. 范围与非目标
+
+范围：
+
+- 映射 OpenCode 常见事件到 BitFun Core Event Bus。
+- 提供有限 plugin context、client facade、custom tool API。
+- 支持 SSE event stream 或本地事件订阅。
+- 支持 Harness 相关 hook：tool before/after、permission、file、lsp、session。
+
+非目标：
+
+- 不复制 OpenCode runtime。
+- 不把 OpenCode config 作为 BitFun canonical config。
+- 不兼容所有插件行为和 shell 语义。
+- 不允许插件直接写入 Gate pass 或审计事实。
+
+## 4. 输入、输出与数据模型
+
+OpenCode 常见事件映射：
+
+| OpenCode event | BitFun source | Harness 用途 |
+|---|---|---|
+| `tool.execute.before` | tool runtime | 权限检查、risk policy、command rewrite |
+| `tool.execute.after` | tool runtime | EvidencePack、verification summary |
+| `permission.asked` / `permission.replied` | approval system | 风险接受和审计 |
+| `file.edited` / `file.watcher.updated` | file watcher | Risk Classifier、stale evidence |
+| `lsp.client.diagnostics` | LSP service | pre-PR diagnostics evidence |
+| `session.diff` | Git service | required checks seed |
+| `session.idle` | session runtime | 完成度、未验证风险、gate prompt |
+| `shell.env` | environment provider | secret 和环境注入策略 |
+
+兼容上下文：
+
+```ts
+interface OpenCodeCompatContext {
+  project: { root: string; worktree: string };
+  directory: string;
+  client: OpenCodeCompatClient;
+  permissions: PermissionFacade;
+  events: EventFacade;
+}
+```
+
+## 5. 核心流程
+
+```text
+BitFun lifecycle event
+  -> canonical policy and permission check
+  -> compatibility adapter mapping
+  -> plugin hook execution with timeout and sandbox
+  -> collect plugin result
+  -> normalize side effects
+  -> append audit event
+```
+
+API 兼容等级：
+
+| 等级 | 范围 | 目标 |
+|---|---|---|
+| L0 | 事件命名、payload mapping、只读 client log | 支持迁移和观察 |
+| L1 | `tool.execute.*`、`permission.*`、`file.*`、`session.*` | 支持核心 Harness 插件 |
+| L2 | custom tools、SSE event stream、limited `$` shell facade | 支持可控扩展 |
+| L3 | 更广泛 ecosystem compatibility | 仅在 L0-L2 稳定后评估 |
+
+兼容矩阵：
+
+| 能力 | P0/P1 状态 | 说明 |
+|---|---|---|
+| project-level plugin loading | 支持受限 | 仅加载明确启用目录和受信任文件 |
+| global plugin loading | 暂不默认启用 | 避免跨项目状态串扰和权限混淆 |
+| hook event mapping | 支持 L0/L1 | 以 BitFun canonical event 为事实来源 |
+| custom tool | 受限支持 | 必须声明权限和输入输出 schema |
+| shell facade | 受限支持 | 默认无网络、超时、审计、敏感信息 redaction |
+| SSE event stream | P2 评估 | 先稳定本地事件订阅和权限模型 |
+
+## 6. 策略与治理
+
+- **权限优先**：插件执行前必须通过 BitFun permission model。
+- **策略优先**：hook 只触发和采集，复杂判断进入 Policy Engine。
+- **隔离执行**：默认禁止无约束 shell、网络和全仓读写。
+- **审计可追溯**：插件输入、输出、耗时、失败和副作用写入 Quality Data Plane。
+- **来源可治理**：插件记录来源、版本、hash、权限声明和启用范围。
+- **兼容可测试**：每个兼容等级必须有 fixture plugin 和行为测试。
+- **降级可见**：插件失败不能静默影响 Gate，必须进入 warning 或 degraded。
+
+## 7. 分阶段落地
+
+| 阶段 | 目标 |
+|---|---|
+| P0 | canonical event bus、L0/L1 mapping、只读插件、审计 |
+| P1 | custom tool 最小集、权限策略、PR Gate hook |
+| P2 | SSE stream、plugin registry、签名/来源标识 |
+| P3 | 更广泛 OpenCode 生态兼容和企业策略包 |
+
+## 8. 风险与反证
+
+| 风险 | 反证或治理要求 |
+|---|---|
+| 兼容层侵入核心模型 | 内部模块不得依赖 OpenCode payload；只能依赖 canonical event |
+| 插件越权 | 文件、shell、network、secret 访问全部走 BitFun permission |
+| 插件影响 Gate 结论 | 插件只能产出 evidence 或 recommendation，不能直接写 pass/fail |
+| 运行时不一致 | L0/L1 明确支持范围，不承诺完整 OpenCode runtime |
+| 安全事故 | 默认禁用未知来源插件；记录来源、版本、hash 和执行结果 |
+| 维护成本边界不清 | API compatibility 分级推进，每级有成功标准和退出条件 |
+
+## 9. 成功标准
+
+- 常用 Harness 插件可以通过 adapter 迁移核心逻辑。
+- BitFun 内核事件、权限和审计模型保持独立。
+- 插件失败、超时、拒绝权限都能被 Gate 和 EvidencePack 感知。
+- PR Gate 能消费 OpenCode 风格 hook 产生的证据，但不信任其直接结论。
+- L0/L1 兼容范围清晰，未支持能力不会被误认为可用。

--- a/docs/sdlc-harness/features/pr-quality-gate.md
+++ b/docs/sdlc-harness/features/pr-quality-gate.md
@@ -1,0 +1,184 @@
+# BitFun SDLC Harness 子模块设计：PR Quality Gate
+
+> 上游文档：[design.md](../design.md)
+> 模块角色：将目标项目的 EvidencePack、Risk Classifier、Deep Review、验证命令、安全信号和人工风险接受整合为 PR 级质量门禁。
+
+## 1. 模块定位
+
+PR Quality Gate 是全生命周期 Harness 的首个产品级闭环。它不是替代 GitHub Checks、CI、安全扫描、CODEOWNERS 或人工 reviewer，而是在目标项目 PR 提交或更新前，把本地 diff、项目规则、验证证据和风险信号转化为一个简洁、可解释、可审计的 gate 结果。
+
+P0 采用 lightweight gate：先覆盖目标项目 Project Profile、本地 diff/PR 的 EvidencePack、required checks、risk classification、PR 描述生成和可选 Deep Review 触发。
+
+## 2. 行业参照与设计约束
+
+| 参照 | 启发 |
+|---|---|
+| [GitHub Checks API](https://docs.github.com/en/rest/checks) / [rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) | PR 门禁需要状态、结论、日志和可审计结果 |
+| [GitHub Copilot code review](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review) | AI review 正在进入 PR 协作流程 |
+| [Rovo acceptance criteria checks](https://support.atlassian.com/rovo/docs/check-acceptance-criteria-in-a-code-review/) / [RovoDev Code Reviewer](https://arxiv.org/html/2601.01129v1) | 验收标准、PR cycle time、可执行反馈和上下文完整性决定 AI review 价值 |
+| [Cursor Bugbot](https://cursor.com/blog/building-bugbot) / [Qodo Code Review](https://docs.qodo.ai/code-review) | PR 级 logic bug、security、compliance review 是 AI IDE 外延能力 |
+| [Codex Hooks](https://developers.openai.com/codex/hooks) / [Claude Code Hooks](https://code.claude.com/docs/en/hooks) / [OpenCode Plugins](https://opencode.ai/docs/plugins/) | Gate 应消费标准化 hook/event，不依赖某个 agent runtime 内部实现 |
+
+设计约束：
+
+- 默认不对所有 PR 执行 full Deep Review。
+- blocking decision 必须引用确定性证据。
+- `degraded` 是核心状态，优于错误的 `pass`。
+- 人工 override 必须记录 reason、actor、time 和 residual risk。
+- Gate 上线必须分阶段：shadow、advisory、required、blocking，不能直接从设计进入默认阻塞。
+- Project Profile 未确认、证据过期或成本超预算时，必须展示降级原因和未覆盖风险。
+
+## 3. 范围与非目标
+
+范围：
+
+- 聚合 EvidencePack、risk classification、required checks、Deep Review 和人工确认。
+- 输出 `pass|warn|fail|degraded`。
+- 生成 PR 描述中的质量证据块。
+- 标记 stale review 和 stale evidence。
+
+非目标：
+
+- 不替代 CI 或 branch protection。
+- 不代替人类最终发布责任。
+- 不保证完整影响面分析。
+- 不让第三方 hook 绕过 BitFun policy。
+
+## 4. 输入、输出与数据模型
+
+输入：
+
+| 输入 | 来源 |
+|---|---|
+| Project Profile | 项目结构、规则来源、验证能力、owner、发布模型 |
+| Diff summary | Git working tree 或 PR diff |
+| Project rules | agent rules、contribution guide、module docs、CODEOWNERS、verification profile |
+| Verification evidence | command、exit code、duration、log summary |
+| Risk classification | Risk Classifier |
+| Hook events | Quality Data Plane |
+| Deep Review result | optional targeted/full review |
+| Artifact links | issue、spec、acceptance criteria、design doc |
+
+输出：
+
+```ts
+interface PrGateResult {
+  status: "pass" | "warn" | "fail" | "degraded";
+  risk_level: "low" | "medium" | "high" | "unknown";
+  confidence: number;
+  summary: string;
+  required_checks: RequiredCheckResult[];
+  evidence: EvidenceReference[];
+  open_risks: OpenRisk[];
+  budget: {
+    deep_review_required: boolean;
+    deep_review_profile: "none" | "targeted" | "full";
+    estimated_tokens: number;
+    estimated_minutes: number;
+    actual_tokens?: number;
+    actual_minutes?: number;
+  };
+  degraded_reasons: string[];
+}
+```
+
+状态语义：
+
+| 状态 | 含义 | 行为 |
+|---|---|---|
+| `pass` | 必要证据完整且无阻塞风险 | 允许提交或更新 PR |
+| `warn` | 存在非阻塞风险或推荐检查缺失 | 允许继续，但在 PR 文本中显式展示 |
+| `fail` | 必要验证失败或违反阻塞策略 | 阻止自动提交或要求人工 override |
+| `degraded` | 上下文、证据或工具状态不足，无法可靠判断 | 允许人工确认，但必须记录降级原因 |
+
+上线模式：
+
+| 模式 | 行为 | 适用阶段 |
+|---|---|---|
+| `shadow` | 只生成结果，不影响提交和 PR | P0 初期校准 |
+| `advisory` | 在 PR 文本或本地报告中提示风险 | P0/P1 默认 |
+| `required` | 要求展示结果和 skipped/open risks | P1 团队协作 |
+| `blocking` | 对确定性失败或缺失人工风险接受进行阻断 | 仅在误报率、成本和 override 流程稳定后启用 |
+
+## 5. 核心流程
+
+```text
+local diff / PR
+  -> Project Profile
+  -> EvidencePack
+  -> Risk Classifier
+  -> required checks
+  -> lightweight gate
+  -> optional Deep Review by risk
+  -> PR description / GitHub Check summary
+```
+
+PR 质量证据块：
+
+```markdown
+Quality Evidence
+
+- Gate: warn
+- Risk: medium
+- Required checks:
+  - passed: project type check
+  - missing: project regression test
+- Open risks:
+  - Runtime boundary behavior changed without dedicated regression evidence.
+- Deep Review: skipped, estimated value lower than required checks for this change.
+```
+
+## 6. 策略与治理
+
+Deep Review 预算策略：
+
+| 风险画像 | 默认策略 |
+|---|---|
+| 低风险 docs 或小范围文案 | 不触发 Deep Review |
+| 中风险 UI 或 adapter | 本地证据不足时触发 targeted review |
+| 高风险项目核心逻辑、integration adapter、安全、发布或远程运行边界 | targeted 或 full review |
+| 大规模跨层 PR | 先完成低成本结构化检查，再决定 full review |
+
+每次 Deep Review 都必须暴露：
+
+- 预估 token 和耗时。
+- 实际 token 和耗时。
+- scope、skipped files、truncated context。
+- advisory 或 blocking。
+- 是否因预算降级。
+- 与 lightweight gate 相比的增量价值假设。
+
+Stale review 规则：
+
+- diff 变化影响 reviewed hunk，finding 标记 `stale`。
+- risk tags 或 required checks 变化，Gate 标记 `needs_rerun`。
+- EvidencePack 过期，status 不得继续保持 `pass`。
+
+## 7. 分阶段落地
+
+| 阶段 | 目标 |
+|---|---|
+| P0 | lightweight gate、本地报告、PR 质量证据块、degraded 状态 |
+| P1 | GitHub Check summary、finding lifecycle、stale review |
+| P2 | 需求验收标准、release readiness、人工风险接受审计 |
+| P3 | 团队级 gate 策略、预算优化和质量趋势 |
+
+## 8. 风险与反证
+
+| 风险 | 反证或治理要求 |
+|---|---|
+| full Deep Review 成本分级约束不足 | 低风险 PR 默认不触发；高风险先跑低成本检查 |
+| 过早 blocking 降低采用 | 先 shadow/advisory 收集误报、漏报、耗时和 override 数据 |
+| Gate 假阳性阻塞交付 | 每个 fail 必须有具体 evidence 和 override path |
+| Gate 假阴性放过风险 | critical path 小 diff 不得按行数降级为 low |
+| 缺证据仍 pass | 缺失 evidence store 或检查结果时必须 `degraded` 或 `fail` |
+| AI review 低精度 finding | finding 必须有生命周期、stale 标记和人工解决状态 |
+| 插件绕过策略 | Gate 只消费 canonical event，不信任插件直接写入 pass 结论 |
+
+## 9. 成功标准
+
+- 多数 PR 准备流程能生成结构化 Gate 结果。
+- 低风险 PR 不被 full Deep Review 阻塞。
+- 高风险 PR 能暴露 required checks 和未覆盖风险。
+- PR 描述减少 reviewer 追问验证信息的成本。
+- Deep Review token 与耗时可见、可预算、可降级。

--- a/docs/sdlc-harness/features/requirement-impact-analysis.md
+++ b/docs/sdlc-harness/features/requirement-impact-analysis.md
@@ -1,0 +1,132 @@
+# BitFun SDLC Harness 子模块设计：Requirement Impact Analysis
+
+> 上游文档：[design.md](../design.md)
+> 模块角色：在需求、验收标准、API contract 或设计决策变更时，召回受影响的代码、测试、文档、owner、release 和运行指标。
+
+## 1. 模块定位
+
+Requirement Impact Analysis 负责把“需求变更影响了什么”转化为候选影响面、置信度、证据和 required checks。它输出的是候选集合，不是完整事实。高风险、低置信链接必须人工确认，确认或拒绝结果写回 Artifact Graph，用于后续校准。
+
+P0 不做完整需求管理，而是围绕 PR EvidencePack 和 linked artifact 提供影响面提示。
+
+## 2. 行业参照与设计约束
+
+| 参照 | 启发 |
+|---|---|
+| [TraceLLM](https://arxiv.org/html/2602.01253v1) | LLM 可辅助建立 trace links，但需要人工确认和持续校准 |
+| [LLM-driven requirements change impact analysis](https://arxiv.org/html/2511.00262v1) | 影响分析应衡量召回、精度和人工检查成本 |
+| [Rovo acceptance criteria checks](https://support.atlassian.com/rovo/docs/check-acceptance-criteria-in-a-code-review/) | PR 可检查代码是否满足 linked work item 的验收标准 |
+| [Kiro Specs](https://kiro.dev/docs/specs/) | spec 应作为 AI 原生交付物参与实现、测试和追踪 |
+| MBSE traceability | 复杂系统中需求、模型、验证之间需要结构化追踪 |
+
+设计约束：
+
+- graph-first retrieval 优先于纯 LLM semantic recall。
+- Project Profile 必须先说明项目结构、owner、验证能力和未知区域。
+- 高风险低置信影响项必须人工确认。
+- 输出必须包含 confidence、evidence、required checks 和 residual risk。
+- 确认/拒绝结果必须反馈到 Artifact Graph。
+
+## 3. 范围与非目标
+
+范围：
+
+- 识别 changed requirement、acceptance criteria、API contract、design decision。
+- 从 Artifact Graph、code graph、static dependency、history 和 LLM semantic expansion 召回候选。
+- 生成 required checks 和人工确认清单。
+
+非目标：
+
+- 不替代需求管理工具。
+- 不保证完整影响面。
+- 不直接修改代码或测试。
+- 不把低置信 LLM 推断作为 gate pass 依据。
+
+## 4. 输入、输出与数据模型
+
+输入：
+
+| 输入 | 示例 |
+|---|---|
+| Requirement diff | issue 描述、acceptance criteria、spec diff |
+| Project Profile | 模块边界、owner、验证能力、未知区域 |
+| API contract change | DTO、Tauri command、MCP tool schema、OpenAPI |
+| Artifact Graph | requirement -> spec -> diff/test/review links |
+| Code graph | file、symbol、imports、tests |
+| History | past incidents、review findings、flaky tests |
+| Human hints | owner、module、risk tags |
+
+输出：
+
+```ts
+interface ImpactCandidate {
+  artifact_id: string;
+  artifact_type: string;
+  confidence: number;
+  evidence: EvidenceReference[];
+  reason: string;
+  required_checks: RequiredCheck[];
+  confirmation: "required" | "optional" | "not_required";
+  residual_risk?: string;
+}
+```
+
+## 5. 核心流程
+
+```text
+detect changed requirement/API/design
+  -> classify change type
+  -> load project profile and unknown areas
+  -> retrieve confirmed graph links
+  -> expand through static dependency and history
+  -> optional LLM semantic expansion
+  -> rank candidates by confidence and risk
+  -> generate required checks
+  -> ask human to confirm high-risk links
+  -> update Artifact Graph
+```
+
+召回策略：
+
+| 策略 | 作用 |
+|---|---|
+| Graph-first retrieval | 使用已确认 requirement/spec/file/test/review 链接 |
+| Static expansion | 通过 imports、symbol reference、test mapping 扩展 |
+| History expansion | 结合 incident、review finding、flaky test、hot file |
+| LLM semantic expansion | 在语义相似但无结构链接时生成候选 |
+
+## 6. 策略与治理
+
+- **置信度分层**：confirmed link > static dependency > historical co-change > LLM candidate。
+- **人工确认**：高风险低置信候选进入 confirmation queue。
+- **反向学习**：确认、拒绝、遗漏项都写回图谱和 eval backlog。
+- **Gate 集成**：未确认的高风险候选不能直接 pass；可进入 warn/degraded。
+- **成本控制**：优先使用图谱和静态分析，LLM semantic expansion 只处理候选不足或歧义场景。
+
+## 7. 分阶段落地
+
+| 阶段 | 目标 |
+|---|---|
+| P0 | PR linked artifact、required checks、人工确认清单 |
+| P1 | graph-first impact view、static dependency expansion |
+| P2 | LLM semantic candidate、precision/recall calibration |
+| P3 | release readiness、incident-to-requirement 回溯 |
+
+## 8. 风险与反证
+
+| 风险 | 反证或治理要求 |
+|---|---|
+| 高召回导致低价值候选过多 | 输出必须排序，并显示人工检查成本 |
+| 高精度导致漏项 | 对 high-risk area 保留低置信候选和 degraded 状态 |
+| LLM 语义幻觉 | LLM 结果只能作为 candidate，需要 evidence 和确认 |
+| 影响面过期 | graph edge 需要 staleness；diff/test/review 变化触发更新 |
+| 与 PR Gate 脱节 | 每个 high-risk candidate 必须映射 required checks 或 residual risk |
+| 团队不确认链接 | 确认动作必须嵌入 PR review 或 gate flow，而不是独立后台任务 |
+
+## 9. 成功标准
+
+- 需求或 API 变更能生成可解释影响候选。
+- 高风险候选有人工确认路径。
+- 确认/拒绝结果写回 Artifact Graph。
+- required checks 能覆盖主要影响类别。
+- precision、recall、人工检查成本可量化。

--- a/docs/sdlc-harness/features/risk-classifier.md
+++ b/docs/sdlc-harness/features/risk-classifier.md
@@ -1,0 +1,153 @@
+# BitFun SDLC Harness 子模块设计：Risk Classifier
+
+> 上游文档：[design.md](../design.md)
+> 模块角色：根据目标项目画像、变更内容、路径、历史信号和交付阶段，生成风险标签、必跑验证、reviewer 要求和 Deep Review profile。
+
+## 1. 模块定位
+
+Risk Classifier 是目标项目 PR EvidencePack 和 PR Gate 的策略输入层。它的输出是决策建议，不是事实结论。任何阻塞门禁必须引用确定性证据，例如失败测试、缺失 required check、违反项目规则或人工风险接受缺失。
+
+P0 应优先使用从 Project Profile 派生的可解释规则和路径矩阵；模型辅助只用于补充说明、风险摘要和检查建议，不直接决定 pass/fail。
+
+## 2. 行业参照与设计约束
+
+| 参照 | 启发 |
+|---|---|
+| [GitHub rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) | 质量门禁需要可解释、可配置、可审计 |
+| [Rovo acceptance criteria checks](https://support.atlassian.com/rovo/docs/check-acceptance-criteria-in-a-code-review/) | PR 风险应结合 linked work item 和验收标准 |
+| [Agentless](https://arxiv.org/abs/2407.01489) | 简单可解释 pipeline 是强基线，不应过早依赖复杂自治 |
+| [NIST SP 800-218A](https://csrc.nist.gov/pubs/sp/800/218/a/final) | AI 相关变更需要把模型、数据、工具和供应链纳入风险识别 |
+
+设计约束：
+
+- 输出必须包含 reason、evidence、confidence 和 override path。
+- 风险标签不能替代人工责任边界。
+- 规则、模型提示和路径矩阵都必须版本化。
+- 校准依赖 post-merge defect、review blocker、CI failure、override 结果。
+- Project Profile 中 `unknown/conflicting/stale` 的规则不得被当作低风险依据。
+- 风险分类必须支持项目级策略覆盖，避免把 BitFun 自身验证路径或某类技术栈硬编码为默认规则。
+
+## 3. 范围与非目标
+
+范围：
+
+- 基于 Project Profile、diff、路径、项目规则、历史信号生成风险标签。
+- 生成 required checks、reviewer 建议、Deep Review profile。
+- 向 PR Gate 输出可解释决策输入。
+- 收集后验信号用于校准。
+
+非目标：
+
+- 不预测所有线上缺陷。
+- 不用黑盒模型直接阻塞 PR。
+- 不替代 CODEOWNERS、分支保护或安全扫描。
+- 不保证需求影响分析完整性。
+
+## 4. 输入、输出与数据模型
+
+输入：
+
+| 输入 | 示例 |
+|---|---|
+| Project Profile | 语言、框架、模块、owner、规则来源、验证能力、发布模型 |
+| Diff metadata | 文件路径、hunk、rename/delete、生成文件、行数 |
+| Project policy | agent rules、contribution guide、module docs、CODEOWNERS、verification profile |
+| Artifact links | issue、spec、acceptance criteria、design decision |
+| Historical signals | flaky tests、past incidents、review findings、hot files |
+| Verification state | 已运行/缺失/失败/过期的 required checks |
+
+输出：
+
+```ts
+interface RiskClassification {
+  level: "low" | "medium" | "high" | "unknown";
+  tags: RiskTag[];
+  reasons: string[];
+  evidence: EvidenceReference[];
+  confidence: number;
+  required_checks: RequiredCheck[];
+  reviewer_requirements: ReviewerRequirement[];
+  deep_review_profile: "none" | "targeted" | "full";
+  override_policy: OverridePolicy;
+}
+```
+
+## 5. 核心流程
+
+```text
+project profile
+  -> diff summary
+  -> profile freshness and conflict check
+  -> path and module rule matching
+  -> artifact graph context lookup
+  -> historical risk enrichment
+  -> required checks generation
+  -> Deep Review profile selection
+  -> emit risk.classified event
+  -> collect calibration feedback
+```
+
+风险标签示例：
+
+| 标签 | 触发条件 |
+|---|---|
+| `project_core` | 目标项目关键业务逻辑、核心服务、公共库或关键运行路径 |
+| `integration_adapter` | 外部服务、provider、协议、schema、stream、cache 变更 |
+| `security_sensitive` | auth、secret、filesystem、shell、network、permission |
+| `deployment_sensitive` | release、migration、infra、remote workspace、runtime boundary |
+| `ui_behavior` | 用户可见状态、交互流程、前端 adapter、review surface |
+| `docs_only` | 文档或注释变更，无行为影响 |
+| `generated_large_diff` | 大量生成文件、snapshot、lockfile |
+
+## 6. 策略与治理
+
+| 风险等级 | 默认策略 |
+|---|---|
+| low | required checks 完整即可 pass，不触发 Deep Review |
+| medium | 需要相关验证；证据不足时 warn 或 targeted Deep Review |
+| high | 必须列出阻塞检查、owner/reviewer、Deep Review profile 和人工 override 条件 |
+| unknown | 缺少上下文时进入 degraded，不得标记为 low |
+
+画像状态策略：
+
+| Project Profile 状态 | 分类策略 |
+|---|---|
+| confirmed | 可使用项目路径矩阵和验证能力生成 required checks |
+| inferred | 可生成建议，但阻塞性 gate 需要确定性证据或人工确认 |
+| unknown | 输出 `unknown` 或 `degraded`，不得降级为 low |
+| conflicting | 暂停自动 pass，要求用户确认规则优先级 |
+| stale | 重新刷新画像或标记风险结论过期 |
+
+Deep Review profile：
+
+- `none`：低风险 docs/copy/small isolated change。
+- `targeted`：中风险 UI、adapter、测试覆盖不足。
+- `full`：核心运行时、AI adapter、安全、远程、跨层重构或大规模 PR。
+
+## 7. 分阶段落地
+
+| 阶段 | 目标 |
+|---|---|
+| P0 | Project Profile、路径矩阵、项目规则、required checks、risk.classified event |
+| P1 | Artifact Graph context、历史风险、override 记录 |
+| P2 | 后验校准、风险规则 dashboard、策略版本对比 |
+| P3 | 模型辅助排序和异常检测，但仍保留确定性阻塞依据 |
+
+## 8. 风险与反证
+
+| 风险 | 反证或治理要求 |
+|---|---|
+| 风险等级被当成事实 | UI 和 PR 文本必须展示 evidence、confidence、override |
+| 低风险误判 | critical path 小 diff 必须触发规则，不得只按行数判断 |
+| 高风险误报 | generated large diff 和低行为影响变更应能降级处理 |
+| required checks 过多 | 每个 required check 必须有触发原因和取消条件 |
+| Deep Review 成本被放大 | 只有 high 或 evidence weak 的 medium 风险才默认触发 targeted/full review |
+| 规则长期失准 | post-merge defect、review blocker、override 结果必须回流校准 |
+
+## 9. 成功标准
+
+- PR Gate 能用分类结果生成可解释 required checks。
+- 低风险 PR 不默认触发 full Deep Review。
+- 高风险 PR 至少暴露风险原因、必跑验证和未覆盖风险。
+- reviewer 能理解并覆盖风险结论。
+- 误报/漏报可通过校准机制被量化和修正。

--- a/docs/sdlc-harness/governance/self-governance-notes.md
+++ b/docs/sdlc-harness/governance/self-governance-notes.md
@@ -1,0 +1,52 @@
+# BitFun 自身治理与内部验证问题说明
+
+> 范围：记录 BitFun 仓库自身在建设 SDLC Harness 过程中暴露出的文档、边界、规则和内部验证问题。
+> 边界：本文不是 BitFun SDLC Harness 的产品设计主线。产品设计应围绕 BitFun 加载和治理外部目标项目展开。
+
+## 1. 文档定位
+
+BitFun 仓库可以作为 Harness 能力的首个内部验证项目，但不能被等同于产品目标项目。主设计文档中的“目标项目”应代表任意被用户加载的软件工程，而不是默认拥有 BitFun 仓库的技术栈、模块边界、AGENTS 文档、CI 规则或 fork PR 工作流。
+
+本文只承载两类内容：
+
+1. BitFun 仓库自身为了更好验证 Harness 需要补齐的问题。
+2. 这些问题对产品设计的反向约束。
+
+## 2. 当前可见问题
+
+| 问题 | 表现 | 影响 | 建议承载位置 |
+|---|---|---|---|
+| 产品对象与内部验证对象混用 | 文档中同时描述 BitFun 自身代码治理和 BitFun 作为产品治理外部项目 | 读者难以判断设计是在改某个 PR 功能，还是在定义产品级 Harness 架构 | 主设计聚焦目标项目；本文承载自身治理问题 |
+| 项目规则示例过于仓库特定 | AGENTS、CONTRIBUTING、模块文档、验证矩阵容易被写成默认前提 | 外部项目可能没有同类文件或规则结构 | 子模块文档改为 `project rules`、`agent rules`、`verification profile` |
+| 路径和风险标签过于 BitFun 化 | `core_runtime`、`src/web-ui`、远程 workspace 等例子容易被误解为产品内置分类 | Risk Classifier 难以适配不同语言和仓库结构 | 风险标签应从 Project Profile 派生，BitFun 标签只作为样例 |
+| 文档层级职责不够清晰 | 总览、设计、计划、精简版、子模块设计之间部分内容重叠 | 后续维护容易出现同一策略多处不一致 | 总览只做入口；主设计只做全局模型；计划只做执行路线；子模块承载细节 |
+| 内部验证结果缺少独立闭环 | BitFun 自身发现的问题可能直接进入主设计，造成范围漂移 | 产品设计被具体仓库问题牵引 | 内部验证 finding 先进入本文，再评估是否抽象为通用产品需求 |
+
+## 3. 对产品设计的约束
+
+- BitFun 自身能力只能作为实现基础和验证样本，不能作为目标项目的默认能力假设。
+- 任意项目规则都必须带来源、优先级、置信度和过期状态。
+- Risk Classifier 不应内置固定路径语义；路径矩阵应来自目标项目画像。
+- PR Gate 的示例命令应表达为“项目必跑验证”，而不是绑定具体仓库命令。
+- OpenCode 兼容层只作为 adapter，不能让外部插件语义影响 BitFun canonical event、permission、artifact 和 policy model 的一致性。
+- 内部验证中发现的文档缺失、模块边界不清、验证矩阵不完整，应沉淀为独立 issue 或设计债，而不是直接写成产品架构前提。
+
+## 4. 内部验证使用方式
+
+BitFun 仓库适合作为以下能力的早期验证样本：
+
+| 能力 | 内部验证价值 | 注意事项 |
+|---|---|---|
+| Project Profile | 验证复杂 Rust + React + Tauri 工作区的结构画像 | 不把 BitFun 的目录和 crate 边界作为默认模板 |
+| EvidencePack | 验证本地命令、PR 描述、Deep Review 和 CI 证据聚合 | 证据模型必须能容纳其他语言和 CI 系统 |
+| Risk Classifier | 验证路径矩阵、模块规则和 required checks 生成 | 风险标签必须可配置、可替换 |
+| PR Quality Gate | 验证 lightweight gate、stale evidence 和 Deep Review budget | fork PR 工作流只是集成样例之一 |
+| Artifact Graph | 验证 issue/spec/diff/test/review/PR 的最小链路 | 不要求所有项目都有同样完整的文档体系 |
+| Agent Evaluation | 验证真实历史 issue 和工程任务回放 | 评测集需要避免只优化 BitFun 自身模式 |
+
+## 5. 后续治理建议
+
+1. 保持主设计文档中“目标项目”与“BitFun 产品”的术语区分。
+2. 新增或修改子模块文档时，先判断内容是通用产品设计还是 BitFun 自身验证细节。
+3. 如果发现 BitFun 仓库自身文档缺失、模块边界不清或验证矩阵错误，优先记录在本文或独立 issue，再决定是否抽象为产品能力。
+4. 内部验证指标应同时观察产品收益和偏置风险：既要证明 BitFun 能治理复杂项目，也要防止产品能力过拟合 BitFun 仓库。

--- a/docs/sdlc-harness/implementation-plan.md
+++ b/docs/sdlc-harness/implementation-plan.md
@@ -1,0 +1,246 @@
+# BitFun 全软件生命周期 Harness 实施计划
+
+> 范围：基于完整设计体系，定义 BitFun 面向外部目标项目建设 SDLC Harness 的执行方案、阶段性交付件、成果验收、过程风险、关键里程碑和质量保护方案。
+> 目标：在控制复杂度、token 成本、运行耗时和团队采用成本的前提下，把 Artifact Graph Workbench 与 Lifecycle Harness Platform 分阶段落地。
+
+## 1. 执行定位
+
+本计划不是设计文档索引，也不重新定义架构。设计边界由主设计和子模块设计给出；本计划只回答五个执行问题：
+
+1. 先交付什么。
+2. 每个阶段产出什么可验收成果。
+3. 哪些过程风险会影响落地。
+4. 关键里程碑如何判断是否达成。
+5. 如何用质量保护方案控制平台化建设边界。
+
+执行主线固定为：
+
+```text
+Project Profile
+  -> PR EvidencePack
+  -> Risk Classifier
+  -> lightweight PR Gate
+  -> Artifact Graph minimal loop
+  -> Requirement / Release / Incident lifecycle
+  -> Evaluation and optimization loop
+```
+
+## 2. 执行原则
+
+| 原则 | 执行含义 |
+|---|---|
+| 画像先行 | 目标项目结构、规则、验证能力和未知区域必须先进入 Project Profile |
+| 小闭环优先 | P0/P1 只围绕目标项目 PR 证据链证明价值，不一次性覆盖全 SDLC |
+| 证据优先 | Gate、review、impact analysis、release readiness 都必须能追溯证据 |
+| 成本可见 | Deep Review、模型调用、hook、评测任务必须记录 token、耗时和降级原因 |
+| Adapter 边界 | OpenCode 兼容只作为 adapter，不改变 BitFun canonical event、artifact、permission model |
+| 反证驱动 | 每个阶段都定义失败信号，一旦命中就先收缩范围或修正策略 |
+| 本地优先 | 默认本地存储和本地审计，外部导出必须显式配置和可审计 |
+
+## 3. 阶段路线图
+
+| 阶段 | 主题 | 阶段成果 | 进入下一阶段条件 |
+|---|---|---|---|
+| P0 | 目标项目 PR 证据链 MVP | Project Profile、EvidencePack、Risk Classifier、lightweight PR Gate、事件最小集 | 大多数本地改动可生成可解释 gate 结果 |
+| P1 | 团队 PR 质量闭环 | PR gate 集成、finding lifecycle、stale evidence、最小 Artifact Graph | PR review 过程能复用证据链并减少人工补充 |
+| P2 | 需求到发布闭环 | 需求影响分析、release readiness、incident-to-test | 高风险变更能输出影响面、发布风险和回归补充 |
+| P3 | 长期评估与优化 | BitFun Harness Bench、trace replay、A/B、策略校准 | Harness 改动可被量化评估并持续优化 |
+
+## 4. P0：目标项目 PR 证据链 MVP
+
+### 4.1 阶段目标
+
+建立最小可用的 PR 质量控制闭环，让 BitFun 在加载外部目标项目后，能在不改造完整 CI/GitHub App 的前提下，为本地 diff 或 PR 准备阶段生成结构化质量证据。
+
+### 4.2 阶段交付件
+
+| 交付件 | 内容 | 依赖 |
+|---|---|---|
+| `Project Profile v0` | 项目结构、规则来源、验证能力、owner、未知区域和冲突规则 | Project Profile and Integration |
+| `LifecycleEvent` 最小事件集 | project、session、file、tool、verification、risk、gate、review 事件 | Quality Data Plane |
+| `EvidencePack v0` | context、change、verification、risk、skipped checks、open risks | Quality Data Plane |
+| `Risk Classifier v0` | 基于 Project Profile 的路径/模块规则、risk tags、required checks、Deep Review profile | Risk Classifier |
+| `Lightweight PR Gate` | `pass/warn/fail/degraded`、evidence refs、open risks | PR Quality Gate |
+| PR 质量证据块 | 自动生成 PR description 的质量摘要 | EvidencePack + Gate |
+
+### 4.3 验收成果
+
+- 目标项目本地 diff 可生成 EvidencePack。
+- Project Profile 能展示项目结构、规则来源、验证能力以及未知或冲突区域。
+- 风险分类结果包含 reason、confidence、evidence 和 override path。
+- required checks 可解释为什么需要运行。
+- 缺少 evidence store、检查结果过期或上下文不足时输出 `degraded`，不得标记为 `pass`。
+- 低风险 PR 不默认触发 full Deep Review。
+
+### 4.4 过程风险
+
+| 风险 | 处置 |
+|---|---|
+| Project Profile 误判 | inferred 规则先进入 degraded 或人工确认，不参与阻塞性 pass |
+| EvidencePack 需要大量人工修正 | 收缩事件源，优先修正 context provenance 和 verification summary |
+| required checks 低价值提示过多 | 使用 override 反馈校准路径矩阵 |
+| gate 对低风险改动产生不必要阻断 | 调整 fail/warn/degraded 语义，先非阻塞运行一段周期 |
+| Deep Review token 成本过高 | P0 只允许 targeted/full review 作为显式风险升级 |
+
+### 4.5 质量保护
+
+- 每个 gate result 必须可追溯到 event id 和 evidence ref。
+- PR 文本不得隐藏 skipped checks 和 open risks。
+- Gate 逻辑先 rule-based，模型输出只作为说明或候选。
+- P0 不接入任意第三方插件写 gate 结论。
+
+## 5. P1：团队 PR 质量闭环
+
+### 5.1 阶段目标
+
+将 P0 的本地证据链接入团队 PR 流程，形成 reviewer 可消费、可复跑、可审计的质量闭环。
+
+### 5.2 阶段交付件
+
+| 交付件 | 内容 | 依赖 |
+|---|---|---|
+| PR Gate 集成 | PR status/comment 或本地 report 到 PR 文本的稳定投影 | P0 Gate |
+| Finding Lifecycle | finding 状态、owner、resolution、stale 标记 | Deep Review + PR Gate |
+| Stale Evidence 检测 | 新 commit、risk tag 或 required check 变化后标记过期 | Quality Data Plane |
+| Artifact Graph minimal loop | `issue/spec -> diff -> verification -> review -> PR` | Artifact Graph |
+| OpenCode Compatibility L0/L1 | 常用 hook/event 映射和只读 plugin 能力 | Hook/Event Bus |
+
+### 5.3 验收成果
+
+- PR 能展示 evidence、risk、required checks、Deep Review 状态和 open risks。
+- Finding 可以被解决、失效、复跑和审计。
+- Artifact Graph 只覆盖最小 PR 证据链，但每条边都有 provenance、confidence、staleness。
+- OpenCode 兼容层不影响 BitFun canonical event 和 permission model。
+
+### 5.4 过程风险
+
+| 风险 | 处置 |
+|---|---|
+| PR cycle time 被拉长 | 将 Deep Review 降级为风险触发，默认优先轻量 gate |
+| Artifact Graph 链接低可信 | 暂停扩展节点类型，优先补 edge evidence 和 confirmation |
+| 兼容层侵入核心 | 强制 adapter 边界，核心模块不得依赖 OpenCode payload |
+| Reviewer 认为 AI finding 精度不足 | 记录 finding precision、dismiss reason 和 human override |
+
+### 5.5 质量保护
+
+- 高风险 PR 才允许 full Deep Review 作为推荐或阻塞要求。
+- stale review 不得继续支撑 gate pass。
+- plugin 只能产出 evidence 或 recommendation，不能直接写 pass/fail。
+- 所有人工 override 必须记录 reason 和 residual risk。
+
+## 6. P2：需求到发布闭环
+
+### 6.1 阶段目标
+
+把质量控制从 PR 扩展到需求变更、发布准备和运行期问题回溯，形成左移和右移并重的生命周期闭环。
+
+### 6.2 阶段交付件
+
+| 交付件 | 内容 | 依赖 |
+|---|---|---|
+| Requirement Impact Analysis | 需求/API/设计变更影响候选、置信度、required checks | Artifact Graph |
+| Spec/Acceptance Artifact | 轻量 spec、验收标准、设计决策和关联 PR | Artifact Graph |
+| Release Readiness | CI、review、known risk、rollback、telemetry 汇总 | PR Gate + Quality Data Plane |
+| Incident-to-Test | incident 关联 release/PR/diff/test gap，生成回归补充候选 | Artifact Graph + Evaluation |
+| Test Quality Gate | coverage delta、flaky risk、mutation subset、测试意图 | Quality Data Plane |
+
+### 6.3 验收成果
+
+- 需求或 API 变更能生成影响候选和人工确认清单。
+- release readiness 能解释为什么可发布、哪些风险被接受、如何回滚。
+- incident 能回溯到 release、PR、diff、需求和测试缺口。
+- 确认/拒绝的影响链接会写回 Artifact Graph。
+
+### 6.4 过程风险
+
+| 风险 | 处置 |
+|---|---|
+| 影响分析低置信候选过多 | 优先 graph-first retrieval，LLM semantic expansion 只做候选补充 |
+| 发布仪表盘只有展示没有决策力 | 每个 readiness item 必须绑定证据和 owner |
+| incident 回溯依赖人工记忆 | 强制 release、PR、gate、telemetry 关联 event id |
+| 测试质量指标过重 | 对关键模块先试点 mutation subset，不全仓铺开 |
+
+### 6.5 质量保护
+
+- 高风险低置信影响项必须人工确认。
+- 需求影响分析不能作为完整事实，只能输出候选、置信度和验证建议。
+- 发布放行必须保留 risk acceptance audit。
+- incident 复盘至少沉淀一个 regression candidate、rule 或 benchmark task。
+
+## 7. P3：评估和持续优化
+
+### 7.1 阶段目标
+
+建立长期 Evaluation Harness，让 prompt、tool schema、context policy、hook policy、Deep Review profile 和模型组合的变更可以被量化评估。
+
+### 7.2 阶段交付件
+
+| 交付件 | 内容 | 依赖 |
+|---|---|---|
+| BitFun Harness Bench | 真实 issue、终端任务、review defect、PR gate、impact analysis 黄金集和 holdout set | Evaluation Harness |
+| Trace Replay | 固定输入、工具版本、policy 版本和输出 oracle | Quality Data Plane |
+| Harness A/B | prompt、tool schema、context policy、model、budget 对比 | Evaluation Harness |
+| Failure Mining | 失败 trace 聚类，生成 rule、test、skill、policy 建议 | Quality Data Plane |
+| Adaptive Budget | 按风险和历史成功率动态分配模型与 Deep Review 成本 | Risk Classifier |
+
+### 7.3 验收成果
+
+- 关键 harness 改动可通过固定任务集回放。
+- 评测结果同时展示成功率、质量、token、耗时、tool calls 和安全事件。
+- 失败可归因到模型、工具、上下文、策略或产品交互。
+- 线上缺陷、review blocker 和 override 能进入 eval backlog。
+
+### 7.4 过程风险
+
+| 风险 | 处置 |
+|---|---|
+| benchmark 过拟合 | 保留 holdout set，记录任务来源和泄漏风险 |
+| 无 oracle 评测泛滥 | 无 oracle 任务只能用于探索，不进入决策 |
+| 只优化模型忽略 harness | model、prompt、tool schema、context、policy 版本分开记录 |
+| 成本被成功率掩盖 | 所有评测必须同时报告 token、wall-clock、tool call 和 retry |
+
+### 7.5 质量保护
+
+- 每类 eval 必须声明 oracle。
+- 公开 benchmark、内部 golden set 和 holdout set 分开管理。
+- 高风险自动化任务使用隔离环境和最小权限。
+- Evaluation 结论不能直接修改生产策略，必须经过人工批准或灰度。
+- 失败样本进入 rule/test/skill 前需要去重和稳定性检查。
+
+## 8. 关键里程碑
+
+| 里程碑 | 判定标准 |
+|---|---|
+| M1：Project Profile 与 EvidencePack 可用 | 目标项目本地 diff 可生成结构化 profile/context/change/verification/risk/open risks |
+| M2：Risk Classifier 可解释 | required checks 有触发原因、置信度和 override 反馈 |
+| M3：Lightweight Gate 可用 | Gate 输出 `pass/warn/fail/degraded`，且缺证据不误判 pass |
+| M4：PR 质量块可复用 | PR 描述能自动生成并减少 reviewer 追问验证信息 |
+| M5：Artifact Graph 最小闭环 | `issue/spec -> diff -> verification -> review -> PR` 可查询、可确认、可失效 |
+| M6：Deep Review 成本受控 | token、耗时、scope、skipped context 和 budget 降级可见 |
+| M7：需求影响分析可用 | 高风险需求/API 变更可输出影响候选、required checks 和人工确认项 |
+| M8：Evaluation 回放可用 | 关键策略变更可通过固定任务集比较质量和成本 |
+
+## 9. 全程质量保护方案
+
+| 保护面 | 方案 |
+|---|---|
+| 文档与设计一致性 | 每个实现 PR 引用对应设计模块和阶段目标 |
+| 行为等价 | 涉及现有 Agent Runtime、Deep Review、工具权限的变更必须有回归测试或行为对比 |
+| 数据安全 | event、EvidencePack、plugin output 写入前执行 redaction 和 privacy classification |
+| 成本控制 | Deep Review、模型评测、LLM impact analysis 设预算、缓存和降级状态 |
+| 插件安全 | OpenCode compatibility 默认最小权限、超时、审计、禁用未知来源 |
+| PR 治理 | Gate 必须展示 skipped checks、open risks、override reason 和 residual risk |
+| 可回滚性 | 每个阶段能力默认 feature flag 或配置开关，允许降级为只读/只提示 |
+| 评估闭环 | post-merge defect、CI failure、review blocker、incident 回流到 calibration/eval backlog |
+
+## 10. 看护指标
+
+| 类别 | 指标 |
+|---|---|
+| 交付效率 | PR cycle time、lead time、time-to-first-useful-plan |
+| 验证质量 | required check precision、CI first-pass rate、flaky rate、rerun count |
+| AI 质量 | AI-authored diff 占比、review finding density、post-merge defect rate |
+| Harness 成本 | token per accepted change、Deep Review wall-clock、budget skip rate |
+| 审计完整性 | EvidencePack coverage、gate degraded rate、risk acceptance audit coverage |
+| 图谱质量 | confirmed link ratio、stale link rate、impact analysis precision/recall |
+| 运行闭环 | incident-to-regression-test latency、release rollback readiness |

--- a/docs/sdlc-harness/research/external-research.md
+++ b/docs/sdlc-harness/research/external-research.md
@@ -1,0 +1,70 @@
+# BitFun 全软件生命周期 Harness 外部调研
+
+> 范围：围绕 AI IDE、Agentic SDLC、代码评审、Hook/Event、交付物图谱、质量治理和评测体系整理外部产品、论文、标准与趋势信号。
+> 用途：作为设计文档的外部证据池。主设计文档不依赖本文叙述，只在文末保留必要参考资料。
+
+## 1. 产品趋势
+
+| 产品/方向 | 核心能力 | 对 BitFun 的启发 |
+|---|---|---|
+| [OpenAI Codex](https://openai.com/index/introducing-codex/) / [Codex Cloud](https://developers.openai.com/codex/cloud) / [Codex CLI](https://developers.openai.com/codex/cli) / [Codex Hooks](https://developers.openai.com/codex/hooks) | 云端任务、CLI、GitHub review、sandbox、approval、hook、日志/测试证据 | 证据包、审批策略、PR 门禁、云/本地隔离、hook lifecycle 和 eval improvement loop 需要统一产品化 |
+| [GitHub Copilot coding agent](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent) | issue 到 PR、Actions 后台执行、PR review | 需要 PR/CI 深度集成，并明确 AI review 与 human approval 的治理边界 |
+| [Atlassian Software Collection](https://www.atlassian.com/collections/software) / [Rovo Dev](https://www.atlassian.com/software/rovo-dev) | Jira、Confluence、Bitbucket、Pipelines、DX、PR review、acceptance criteria check | 交付物图谱应成为核心能力，而非仅围绕编辑器和代码文件 |
+| [Linear](https://linear.app/) | 产品开发系统、AI workflow、PRD 到 PR | 产品开发上下文和任务系统正在成为 Agent 原生工作入口 |
+| [Harness](https://www.harness.io/) / [Harness AI](https://developer.harness.io/docs/platform/harness-ai/overview) / [Software Delivery Knowledge Graph](https://www.harness.io/blog/knowledge-graphs-for-ai-software-delivery) | CI/CD、测试、AppSec、SRE、成本优化、软件交付知识图谱 | 质量、安全、发布和运行期需要纳入同一交付系统，但知识图谱应从最小高价值场景开始，保持新鲜度和可验证价值 |
+| [Claude Code](https://github.com/anthropics/claude-code) / [Hooks](https://code.claude.com/docs/en/hooks) | 终端 Agent、代码库上下文、事件 hook、多 Agent review | prompt 规则应升级为可执行 hook、policy 和事件总线，并明确阻塞/非阻塞语义 |
+| [OpenCode Plugins](https://opencode.ai/docs/plugins/) / [SDK](https://opencode.ai/docs/sdk/) / [Server API](https://opencode.ai/docs/server/) | JS/TS plugin、`tool.execute.before/after`、`session.*`、`permission.*`、`file.*`、`lsp.*`、`shell.env`、custom tools、SSE event stream | 可提供独立 OpenCode API 兼容层，但底层应先建设 BitFun 自己的 Hook/Event Bus |
+| [Kiro Specs](https://kiro.dev/docs/specs/) / [Steering](https://kiro.dev/docs/steering/) | spec-driven development、workspace/team steering、hooks | spec、steering 和 agent rules 应成为核心交付物，而非仅作为 prompt 背景材料 |
+| [Cursor Bugbot](https://cursor.com/blog/building-bugbot) | PR 级 logic bug、performance、security review | AI 生成速度提高后，PR 级质量回路会成为 IDE 外延能力 |
+| [Qodo Code Review](https://docs.qodo.ai/code-review) | 多 Agent review、规则执行、ticket/security compliance | Deep Review 可扩展为 PR 门禁和合规检查 |
+| [LangChain Harness Engineering](https://www.langchain.com/blog/improving-deep-agents-with-harness-engineering) | 固定模型下优化 harness 显著提升 benchmark | Harness 本身需要版本化、评测和 A/B |
+
+## 2. 研究和基准趋势
+
+| 研究/基准 | 信号 | 设计启发 |
+|---|---|---|
+| [SWE-bench](https://github.com/swe-bench/SWE-bench) | 真实 GitHub issue 正成为代码 Agent 评测基础 | BitFun 需要真实 issue 黄金集和长期回归集 |
+| [SWE-Bench Pro](https://labs.scale.com/leaderboard/swe_bench_pro_public) | 针对更长程、更真实、更复杂代码库评估 Agent，并强调评测集泄漏、任务多样性和测试可靠性问题 | BitFun 评测不能只依赖公开 SWE-bench，需要内部 holdout、复杂项目和环境可复现性 |
+| [SWE-agent](https://arxiv.org/abs/2405.15793) | Agent-Computer Interface 影响修复能力 | 工具 schema、终端反馈、错误呈现和文件浏览本身是能力杠杆 |
+| [Agentless](https://arxiv.org/abs/2407.01489) | 简单、可解释的定位/修复/验证 pipeline 可达到强基线 | 不宜默认采用全自治，结构化 pipeline 应作为质量任务默认形态 |
+| [Agentic AI in the SDLC](https://arxiv.org/abs/2604.26275) | 提出 Agentic SDLC 参考架构，并汇总 SWE-bench Verified 和生产力研究信号 | BitFun 的定位应从代码生成扩展到可审计的 Agentic SDLC 控制面 |
+| [Terminal-Bench](https://arxiv.org/abs/2601.11868) / [Terminal-Bench 3.0](https://www.tbench.ai/) | 真实终端任务覆盖软件工程、ML、安全、数据科学等场景，并持续推进更难 benchmark | BitFun 适合构建终端任务回放和工具轨迹评测，但评测必须防止任务泄漏和 benchmark 过拟合 |
+| [RovoDev Code Reviewer](https://arxiv.org/html/2601.01129v1) | 大规模在线评估显示 AI review 可缩短 PR 周期，但缺少上下文时会产生错误或不可执行反馈 | Deep Review 必须具备上下文完整性、finding 生命周期、反证和预算控制 |
+| [AI-enhanced requirements traceability](https://sercuarc.org/wp-content/uploads/2025/09/Legesse_AI_Enhanced_Requirements_Traceability_Using_MBSE_LLM_Complex_Systems.pdf) | LLM 可辅助需求追踪，但需要高置信推荐和人工确认 | 需求到代码追踪应保留 human validation |
+| [TraceLLM](https://arxiv.org/html/2602.01253v1) / [LLM-driven requirements change impact analysis](https://arxiv.org/html/2511.00262v1) | LLM 可辅助需求追踪和变更影响分析，但输出仍需成本、召回、精度和人工确认约束 | 需求变更影响面分析应输出候选集合、置信度和验证工作量，而非宣称完整自动结论 |
+| [Testing with AI Agents](https://arxiv.org/abs/2603.13724) | AI 已大量参与测试生成，但测试质量需要结构化衡量 | 测试 Harness 需要关注质量、稳定性和变异杀伤，而非仅增加测试数量 |
+| [NIST SP 800-218A](https://csrc.nist.gov/pubs/sp/800/218/a/final) | 将生成式 AI 和基础模型纳入 SSDF 生命周期实践 | AI 参与开发后，安全开发框架需要覆盖模型、工具、数据、权限和供应链风险 |
+
+## 3. 标准与治理趋势
+
+| 标准/方向 | 信号 | 设计启发 |
+|---|---|---|
+| [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/) | traces、metrics、logs、profiles 和 resources 需要统一语义命名 | Quality Data Plane 应定义 stable semantic attributes，避免每个模块自造事件字段 |
+| [CDEvents](https://cdevents.dev/docs/primer/) | CI/CD 事件强调声明式、松耦合、跨工具互操作 | BitFun 的 lifecycle event 应是 canonical fact，不应变成点对点命令调用 |
+| [SLSA Provenance](https://slsa.dev/spec/v0.1/provenance) / [in-toto](https://slsa.dev/blog/2023/05/in-toto-and-slsa) | 构建和供应链证据需要说明 where、when、how，而不是只保存日志 | EvidencePack 应支持 provenance/attestation 引用，为 release readiness 和审计预留接口 |
+| [OWASP LLM Top 10](https://owasp.org/www-project-top-10-for-large-language-model-applications/) | prompt injection、敏感信息、供应链、过度代理和模型拒绝服务都是 LLM 应用风险 | Hook/Event、plugin、tool、memory、external adapter 必须默认最小权限、redaction、timeout 和 budget |
+| AI coding 成本治理 | 高级模型、AI review、CI/Actions 资源和长上下文都会形成显性成本 | Deep Review、Eval、Hook 和 Agent run 必须将 token、耗时、缓存命中和降级原因作为核心指标 |
+
+## 4. 对抗性审查后的趋势判断
+
+外部趋势共同指向三点：
+
+1. AI IDE 的边界正在向 PR、CI、需求、发布和运行期延伸，单纯代码编辑器不再足以承载完整工程控制面。
+2. Agent 能力的可靠性不只由模型决定，还由 hook、policy、evidence、context、permission、eval 和 feedback loop 决定。
+3. 全链路工具不宜先建设完整平台形态，应从高频、可验证、可嵌入现有流程的 PR 证据链切入，再逐步扩展到需求、发布和运行期。
+4. 先进形态正在从“多 Agent 执行”转向“项目画像、交付物图谱、事件标准、证据可信度、成本预算和人工责任”的组合治理。
+5. Benchmark 分数无法直接证明产品质量；真实项目的 holdout、trace replay、oracle、成本和安全事件才是可演进 Harness 的核心评估资产。
+
+## 5. 参考资料
+
+- OpenAI: [Codex](https://openai.com/index/introducing-codex/), [Codex agent loop](https://openai.com/index/unrolling-the-codex-agent-loop/), [Codex sandboxing](https://developers.openai.com/codex/concepts/sandboxing), [Codex hooks](https://developers.openai.com/codex/hooks), [Agent improvement loop](https://developers.openai.com/cookbook/examples/agents_sdk/agent_improvement_loop)
+- GitHub: [Copilot coding agent](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent), [Copilot code review](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review)
+- Atlassian: [Software Collection](https://www.atlassian.com/collections/software), [Rovo Dev](https://www.atlassian.com/software/rovo-dev), [Acceptance criteria checks](https://support.atlassian.com/rovo/docs/check-acceptance-criteria-in-a-code-review/), [RovoDev Code Reviewer paper](https://arxiv.org/html/2601.01129v1)
+- Linear: [Product development system](https://linear.app/)
+- Harness: [AI software delivery platform](https://www.harness.io/), [Harness AI overview](https://developer.harness.io/docs/platform/harness-ai/overview), [Software Delivery Knowledge Graph](https://www.harness.io/blog/knowledge-graphs-for-ai-software-delivery)
+- Anthropic: [Claude Code](https://github.com/anthropics/claude-code), [Claude Code Review](https://code.claude.com/docs/en/code-review), [Claude Code hooks](https://code.claude.com/docs/en/hooks)
+- OpenCode: [Plugins](https://opencode.ai/docs/plugins/), [SDK](https://opencode.ai/docs/sdk/), [Server API](https://opencode.ai/docs/server/)
+- Kiro: [Specs](https://kiro.dev/docs/specs/), [Hooks](https://kiro.dev/docs/hooks/), [Steering](https://kiro.dev/docs/steering/)
+- PR review systems: [GitHub Copilot code review](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review), [Cursor Bugbot](https://cursor.com/blog/building-bugbot), [Qodo Code Review](https://docs.qodo.ai/code-review)
+- Standards and metrics: [DORA](https://dora.dev/), [SPACE](https://queue.acm.org/detail.cfm?id=3454124), [DevEx](https://queue.acm.org/detail.cfm?id=3595878), [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/), [CDEvents](https://cdevents.dev/docs/primer/), [SLSA provenance](https://slsa.dev/spec/v0.1/provenance), [in-toto and SLSA](https://slsa.dev/blog/2023/05/in-toto-and-slsa), [OWASP LLM Top 10](https://owasp.org/www-project-top-10-for-large-language-model-applications/), [NIST SP 800-218A](https://csrc.nist.gov/pubs/sp/800/218/a/final)
+- Research: [SWE-bench](https://github.com/swe-bench/SWE-bench), [SWE-Bench Pro](https://labs.scale.com/leaderboard/swe_bench_pro_public), [SWE-agent](https://arxiv.org/abs/2405.15793), [Agentless](https://arxiv.org/abs/2407.01489), [Agentic AI in the SDLC](https://arxiv.org/abs/2604.26275), [Terminal-Bench](https://arxiv.org/abs/2601.11868), [Testing with AI Agents](https://arxiv.org/abs/2603.13724), [TraceLLM](https://arxiv.org/html/2602.01253v1), [AI-enhanced requirements traceability](https://sercuarc.org/wp-content/uploads/2025/09/Legesse_AI_Enhanced_Requirements_Traceability_Using_MBSE_LLM_Complex_Systems.pdf), [LLM-driven requirements change impact analysis](https://arxiv.org/html/2511.00262v1)


### PR DESCRIPTION
## Summary
- add a long-term `docs/sdlc-harness/` documentation tree for BitFun as an external-project SDLC Harness platform
- split the material into overview, design, implementation plan, external research, governance notes, architecture modules, and feature modules
- add concise root `AGENTS.md` and `AGENTS-CN.md` entries that direct future Harness-related changes to the design overview and module docs
- map the SDLC Harness logical layers back to the existing core decomposition and Agent Runtime Services development view
- refine Chinese wording across the docs and tracking issue to use clearer design-boundary, cost-control, and evidence-governance language
- omit the previous brief/simplified document from the maintained docs tree because the main design now serves as the overview entry

## Related issue
- #1136

## Validation
- professional wording scan over `docs/sdlc-harness`, `AGENTS.md`, `AGENTS-CN.md`, and issue #1136 returned no targeted colloquial risk terms
- stale-pattern scan over `docs/sdlc-harness`, `AGENTS.md`, and `AGENTS-CN.md` returned no unfinished markers or old brief references
- trailing-whitespace scan over `docs/sdlc-harness`, `AGENTS.md`, and `AGENTS-CN.md` returned no matches
- changed Markdown link target check returned `ALL_CHANGED_MD_LINKS_EXIST`
- `git diff --check HEAD~1..HEAD`
