### PR TITLE
feat(web-ui): add dedicated cards for WebFetch and GetToolSpec

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/GetToolSpecCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/GetToolSpecCard.scss
@@ -1,0 +1,30 @@
+.get-tool-spec-card__expanded {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.get-tool-spec-card__section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.get-tool-spec-card__label {
+  color: var(--color-text-muted);
+  font-size: var(--flowchat-font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+
+.get-tool-spec-card__description {
+  color: var(--color-text-secondary);
+  font-size: var(--tool-card-action-font-size, var(--flowchat-font-size-sm));
+  line-height: var(--flowchat-text-line-height, 1.58);
+  white-space: pre-wrap;
+}
+
+.get-tool-spec-card__content pre {
+  margin: 0;
+}

--- a/src/web-ui/src/flow_chat/tool-cards/GetToolSpecCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GetToolSpecCard.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+import { GetToolSpecCard } from './GetToolSpecCard';
+import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-i18next', async () => {
+  const { createTestI18nT } = await import('@/test/i18nTestUtils');
+  return {
+    initReactI18next: {
+      type: '3rdParty',
+      init: vi.fn(),
+    },
+    useTranslation: () => ({
+      t: createTestI18nT('flow-chat'),
+    }),
+  };
+});
+
+const config: ToolCardConfig = {
+  toolName: 'GetToolSpec',
+  displayName: 'Read Tool Spec',
+  icon: 'SPEC',
+  requiresConfirmation: false,
+  resultDisplayType: 'detailed',
+  description: 'Read usage instructions and schema for a collapsed tool',
+  displayMode: 'compact',
+};
+
+function buildDetailItem(): FlowToolItem {
+  return {
+    id: 'tool-spec-1',
+    type: 'tool',
+    toolName: 'GetToolSpec',
+    status: 'completed',
+    timestamp: Date.now(),
+    toolCall: {
+      id: 'call-spec-1',
+      input: {
+        tool_name: 'Git',
+      },
+    },
+    toolResult: {
+      success: true,
+      result: {
+        tool_name: 'Git',
+        description: 'Inspect and operate on the Git repository.',
+        input_schema: {
+          type: 'object',
+          properties: {
+            command: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildAlreadyLoadedItem(): FlowToolItem {
+  return {
+    id: 'tool-spec-2',
+    type: 'tool',
+    toolName: 'GetToolSpec',
+    status: 'completed',
+    timestamp: Date.now(),
+    toolCall: {
+      id: 'call-spec-2',
+      input: {
+        tool_name: 'WebFetch',
+      },
+    },
+    toolResult: {
+      success: true,
+      result: {
+        tool_name: 'WebFetch',
+        already_loaded: true,
+      },
+    },
+  };
+}
+
+describe('GetToolSpecCard', () => {
+  let dom: JSDOM;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      pretendToBeVisual: true,
+      url: 'http://localhost',
+    });
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('CustomEvent', dom.window.CustomEvent);
+    vi.stubGlobal('ResizeObserver', class {
+      observe = vi.fn();
+      disconnect = vi.fn();
+    });
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  it('renders tool spec detail and expands description plus schema', () => {
+    act(() => {
+      root.render(
+        <GetToolSpecCard
+          toolItem={buildDetailItem()}
+          config={config}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('Tool Spec');
+    expect(container.textContent).toContain('Loaded spec for Git');
+    expect(container.textContent).not.toContain('Inspect and operate on the Git repository.');
+
+    const card = container.querySelector('.compact-tool-card');
+    expect(card).not.toBeNull();
+
+    act(() => {
+      card?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('Description');
+    expect(container.textContent).toContain('Inspect and operate on the Git repository.');
+    expect(container.textContent).toContain('"command"');
+  });
+
+  it('shows already-loaded summary without expanded detail affordance', () => {
+    act(() => {
+      root.render(
+        <GetToolSpecCard
+          toolItem={buildAlreadyLoadedItem()}
+          config={config}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('WebFetch is already loaded');
+    const card = container.querySelector('.compact-tool-card');
+    expect(card?.className).not.toContain('clickable');
+  });
+});

--- a/src/web-ui/src/flow_chat/tool-cards/GetToolSpecCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GetToolSpecCard.tsx
@@ -1,0 +1,149 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Info } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import type { ToolCardProps } from '../types/flow-chat';
+import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
+import { ToolCardStatusSlot } from './ToolCardStatusSlot';
+import { useToolCardHeightContract } from './useToolCardHeightContract';
+import './GetToolSpecCard.scss';
+
+interface ParsedGetToolSpecResult {
+  toolName: string;
+  description: string | null;
+  inputSchema: unknown;
+  alreadyLoaded: boolean;
+}
+
+function parseGetToolSpecResult(toolItem: ToolCardProps['toolItem']): ParsedGetToolSpecResult | null {
+  const result = toolItem.toolResult?.result;
+  const toolName = result?.tool_name || toolItem.toolCall?.input?.tool_name || '';
+
+  if (!toolName && !result) {
+    return null;
+  }
+
+  return {
+    toolName,
+    description: typeof result?.description === 'string' ? result.description : null,
+    inputSchema: result?.input_schema,
+    alreadyLoaded: result?.already_loaded === true,
+  };
+}
+
+function stringifySchema(value: unknown): string | null {
+  if (value == null) return null;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export const GetToolSpecCard: React.FC<ToolCardProps> = ({
+  toolItem,
+  onExpand,
+}) => {
+  const { t } = useTranslation('flow-chat');
+  const { toolCall, toolResult, status } = toolItem;
+  const [isExpanded, setIsExpanded] = useState(false);
+  const toolId = toolItem.id ?? toolCall?.id;
+  const { cardRootRef, applyExpandedState } = useToolCardHeightContract({
+    toolId,
+    toolName: toolItem.toolName,
+  });
+
+  const parsedResult = useMemo(() => parseGetToolSpecResult(toolItem), [toolItem]);
+  const targetToolName = parsedResult?.toolName || toolCall?.input?.tool_name || t('toolCards.getToolSpec.unknownTool');
+  const errorMessage = toolResult?.error || t('toolCards.getToolSpec.readFailed');
+  const schemaText = useMemo(() => stringifySchema(parsedResult?.inputSchema), [parsedResult?.inputSchema]);
+  const hasExpandedDetail = Boolean(parsedResult?.description || schemaText || status === 'error');
+  const isExpandable = status === 'completed'
+    ? !parsedResult?.alreadyLoaded && hasExpandedDetail
+    : status === 'error';
+
+  const handleClick = useCallback(() => {
+    if (!isExpandable) return;
+
+    applyExpandedState(isExpanded, !isExpanded, setIsExpanded, {
+      onExpand,
+    });
+  }, [applyExpandedState, isExpandable, isExpanded, onExpand]);
+
+  const renderContent = () => {
+    if (status === 'completed') {
+      if (parsedResult?.alreadyLoaded) {
+        return t('toolCards.getToolSpec.alreadyLoaded', { toolName: targetToolName });
+      }
+      return t('toolCards.getToolSpec.loaded', { toolName: targetToolName });
+    }
+
+    if (status === 'error') {
+      return errorMessage;
+    }
+
+    if (status === 'running' || status === 'streaming' || status === 'preparing') {
+      return t('toolCards.getToolSpec.reading', { toolName: targetToolName });
+    }
+
+    if (status === 'pending') {
+      return t('toolCards.getToolSpec.preparingRead', { toolName: targetToolName });
+    }
+
+    return t('toolCards.getToolSpec.readTitle', { toolName: targetToolName });
+  };
+
+  const renderExpandedContent = () => {
+    if (status === 'error') {
+      return (
+        <div className="compact-result-content get-tool-spec-card__content">
+          <pre>{errorMessage}</pre>
+        </div>
+      );
+    }
+
+    return (
+      <div className="get-tool-spec-card__expanded">
+        {parsedResult?.description && (
+          <section className="get-tool-spec-card__section">
+            <div className="get-tool-spec-card__label">
+              {t('toolCards.getToolSpec.descriptionLabel')}
+            </div>
+            <div className="get-tool-spec-card__description">{parsedResult.description}</div>
+          </section>
+        )}
+
+        {schemaText && (
+          <section className="get-tool-spec-card__section">
+            <div className="get-tool-spec-card__label">
+              {t('toolCards.getToolSpec.schemaLabel')}
+            </div>
+            <div className="compact-result-content get-tool-spec-card__content">
+              <pre>{schemaText}</pre>
+            </div>
+          </section>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div ref={cardRootRef} data-tool-card-id={toolId ?? ''}>
+      <CompactToolCard
+        status={status}
+        isExpanded={isExpanded}
+        onClick={handleClick}
+        className="get-tool-spec-card"
+        clickable={isExpandable}
+        header={(
+          <CompactToolCardHeader
+            icon={<ToolCardStatusSlot status={status} toolIcon={<Info size={16} />} />}
+            action={t('toolCards.getToolSpec.title')}
+            content={renderContent()}
+          />
+        )}
+        expandedContent={isExpandable ? renderExpandedContent() : undefined}
+      />
+    </div>
+  );
+};

--- a/src/web-ui/src/flow_chat/tool-cards/WebFetchCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/WebFetchCard.scss
@@ -1,0 +1,25 @@
+.compact-tool-card-wrapper.web-fetch-card .compact-tool-card.status-error .tool-card-icon-marks,
+.base-tool-card-wrapper.web-fetch-card .base-tool-card.status-error .tool-card-icon-marks {
+  color: var(--color-text-secondary);
+}
+
+.compact-tool-card-wrapper.web-fetch-card .compact-tool-card.status-error.clickable:hover .tool-card-icon-marks,
+.base-tool-card-wrapper.web-fetch-card:hover .base-tool-card.status-error .tool-card-icon-marks {
+  color: var(--color-error, #f87171);
+  transform: scale(1.05);
+}
+
+.web-fetch-card__expanded {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.web-fetch-card__meta-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.web-fetch-card__content pre {
+  margin: 0;
+}

--- a/src/web-ui/src/flow_chat/tool-cards/WebFetchCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/WebFetchCard.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+import { WebFetchCard } from './WebFetchCard';
+import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const openExternalMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-i18next', async () => {
+  const { createTestI18nT } = await import('@/test/i18nTestUtils');
+  return {
+    useTranslation: () => ({
+      t: createTestI18nT('flow-chat'),
+    }),
+  };
+});
+
+vi.mock('@/component-library', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../infrastructure/api', () => ({
+  systemAPI: {
+    openExternal: openExternalMock,
+  },
+}));
+
+const config: ToolCardConfig = {
+  toolName: 'WebFetch',
+  displayName: 'Read Webpage',
+  icon: 'WF',
+  requiresConfirmation: false,
+  resultDisplayType: 'detailed',
+  description: 'Fetch webpage content',
+  displayMode: 'standard',
+};
+
+function buildCompletedToolItem(): FlowToolItem {
+  return {
+    id: 'tool-webfetch-1',
+    type: 'tool',
+    toolName: 'WebFetch',
+    status: 'completed',
+    timestamp: Date.now(),
+    toolCall: {
+      id: 'call-webfetch-1',
+      input: {
+        url: 'https://example.com/article',
+        format: 'text',
+      },
+    },
+    toolResult: {
+      success: true,
+      result: {
+        url: 'https://example.com/article',
+        format: 'text',
+        content: 'Fetched body content',
+        content_length: 20,
+      },
+    },
+  };
+}
+
+describe('WebFetchCard', () => {
+  let dom: JSDOM;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      pretendToBeVisual: true,
+      url: 'http://localhost',
+    });
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('CustomEvent', dom.window.CustomEvent);
+    vi.stubGlobal('ResizeObserver', class {
+      observe = vi.fn();
+      disconnect = vi.fn();
+    });
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+    openExternalMock.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  it('renders a compact fetch summary and expands fetched content', () => {
+    act(() => {
+      root.render(
+        <WebFetchCard
+          toolItem={buildCompletedToolItem()}
+          config={config}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('Read Webpage: "https://example.com/article"');
+    expect(container.textContent).toContain('20 chars');
+    expect(container.textContent).not.toContain('Fetched body content');
+
+    const card = container.querySelector('.compact-tool-card');
+    expect(card).not.toBeNull();
+
+    act(() => {
+      card?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('Fetched body content');
+  });
+
+  it('opens the fetched URL when the expanded link row is clicked', () => {
+    act(() => {
+      root.render(
+        <WebFetchCard
+          toolItem={buildCompletedToolItem()}
+          config={config}
+        />,
+      );
+    });
+
+    const card = container.querySelector('.compact-tool-card');
+    act(() => {
+      card?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    const linkRow = container.querySelector('.compact-expanded-result-title');
+    expect(linkRow).not.toBeNull();
+
+    act(() => {
+      linkRow?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(openExternalMock).toHaveBeenCalledWith('https://example.com/article');
+  });
+});

--- a/src/web-ui/src/flow_chat/tool-cards/WebFetchCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/WebFetchCard.tsx
@@ -1,0 +1,183 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Globe, Link } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import type { ToolCardProps } from '../types/flow-chat';
+import { systemAPI } from '../../infrastructure/api';
+import { Tooltip } from '@/component-library';
+import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
+import { ToolCardStatusSlot } from './ToolCardStatusSlot';
+import { createLogger } from '@/shared/utils/logger';
+import { useToolCardHeightContract } from './useToolCardHeightContract';
+import './WebFetchCard.scss';
+
+const log = createLogger('WebFetchCard');
+
+interface ParsedWebFetchResult {
+  url: string;
+  format: string;
+  content: string;
+  contentLength: number | null;
+}
+
+function parseWebFetchResult(toolItem: ToolCardProps['toolItem']): ParsedWebFetchResult | null {
+  const result = toolItem.toolResult?.result;
+  const url = result?.url || toolItem.toolCall?.input?.url || '';
+  const format = result?.format || toolItem.toolCall?.input?.format || 'text';
+  const contentValue = result?.content ?? toolItem.toolResult?.resultForAssistant ?? '';
+  const content = typeof contentValue === 'string'
+    ? contentValue
+    : contentValue == null
+      ? ''
+      : JSON.stringify(contentValue, null, 2);
+  const contentLength = typeof result?.content_length === 'number'
+    ? result.content_length
+    : content.length > 0
+      ? content.length
+      : null;
+
+  if (!url && !content) {
+    return null;
+  }
+
+  return {
+    url,
+    format,
+    content,
+    contentLength,
+  };
+}
+
+export const WebFetchCard: React.FC<ToolCardProps> = ({
+  toolItem,
+  onExpand,
+}) => {
+  const { t } = useTranslation('flow-chat');
+  const { toolCall, toolResult, status } = toolItem;
+  const [isExpanded, setIsExpanded] = useState(false);
+  const toolId = toolItem.id ?? toolCall?.id;
+  const { cardRootRef, applyExpandedState } = useToolCardHeightContract({
+    toolId,
+    toolName: toolItem.toolName,
+  });
+
+  const parsedResult = useMemo(() => parseWebFetchResult(toolItem), [toolItem]);
+  const url = parsedResult?.url || toolCall?.input?.url || t('toolCards.webFetch.parsingUrl');
+  const errorMessage = toolResult?.error || t('toolCards.webFetch.fetchFailed');
+  const hasContent = Boolean(parsedResult?.content?.trim());
+  const hasContentLength = parsedResult?.contentLength != null && parsedResult.contentLength > 0;
+  const contentLength = hasContentLength ? parsedResult?.contentLength ?? undefined : undefined;
+  const isExpandable = status === 'completed'
+    ? Boolean(parsedResult?.url || hasContent)
+    : status === 'error';
+  const headerToolIcon = <Globe size={16} />;
+
+  const handleOpenLink = async (linkUrl: string) => {
+    if (!linkUrl || linkUrl === '#') return;
+
+    try {
+      await systemAPI.openExternal(linkUrl);
+    } catch (error) {
+      log.error('Failed to open external URL', { url: linkUrl, error });
+    }
+  };
+
+  const handleClick = useCallback(() => {
+    if (!isExpandable) return;
+
+    applyExpandedState(isExpanded, !isExpanded, setIsExpanded, {
+      onExpand,
+    });
+  }, [applyExpandedState, isExpandable, isExpanded, onExpand]);
+
+  const renderContent = () => {
+    if (status === 'completed') {
+      const details: string[] = [];
+      if (parsedResult?.format) {
+        details.push(parsedResult.format);
+      }
+      if (contentLength != null) {
+        details.push(t('toolCards.webFetch.contentLength', { count: contentLength }));
+      } else if (hasContent) {
+        details.push(t('toolCards.webFetch.contentAvailable'));
+      }
+
+      const suffix = details.length > 0 ? ` (${details.join(', ')})` : '';
+      return `${t('toolCards.webFetch.readTitle', { url })}${suffix}`;
+    }
+
+    if (status === 'error') {
+      return errorMessage;
+    }
+
+    if (status === 'running' || status === 'streaming' || status === 'preparing') {
+      return t('toolCards.webFetch.reading', { url });
+    }
+
+    if (status === 'pending') {
+      return t('toolCards.webFetch.preparingRead', { url });
+    }
+
+    return t('toolCards.webFetch.readTitle', { url });
+  };
+
+  const renderExpandedContent = () => {
+    if (status === 'error') {
+      return (
+        <div className="compact-result-content web-fetch-card__content">
+          <pre>{errorMessage}</pre>
+        </div>
+      );
+    }
+
+    return (
+      <div className="web-fetch-card__expanded">
+        {parsedResult?.url && (
+          <div className="compact-expanded-result-item web-fetch-card__meta-card">
+            <Tooltip content={t('toolCards.webFetch.clickToOpenLink')}>
+              <div
+                className="compact-expanded-result-title"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  void handleOpenLink(parsedResult.url);
+                }}
+              >
+                <Link size={12} className="inline-icon" />
+                {parsedResult.url}
+              </div>
+            </Tooltip>
+          </div>
+        )}
+
+        <div className="compact-result-content web-fetch-card__content">
+          <pre>{hasContent ? parsedResult?.content : t('toolCards.webFetch.noContent')}</pre>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div ref={cardRootRef} data-tool-card-id={toolId ?? ''}>
+      <CompactToolCard
+        status={status}
+        isExpanded={isExpanded}
+        onClick={handleClick}
+        className="web-fetch-card"
+        clickable={isExpandable}
+        header={(
+          <CompactToolCardHeader
+            icon={(
+              <ToolCardStatusSlot
+                status={status}
+                toolIcon={headerToolIcon}
+                defaultIcon={status === 'completed' || status === 'error' ? 'tool' : 'status'}
+              />
+            )}
+            content={renderContent()}
+          />
+        )}
+        expandedContent={isExpandable ? renderExpandedContent() : undefined}
+      />
+    </div>
+  );
+};

--- a/src/web-ui/src/flow_chat/tool-cards/index.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/index.ts
@@ -19,6 +19,8 @@ import { CodeReviewToolCard } from './CodeReviewToolCard';
 import { FileOperationToolCard } from './FileOperationToolCard';
 import { DefaultToolCard } from './DefaultToolCard';
 import { WebSearchCard } from './WebSearchCard'; // Temporary until WebSearchDisplay exists.
+import { WebFetchCard } from './WebFetchCard';
+import { GetToolSpecCard } from './GetToolSpecCard';
 import { ContextCompressionDisplay } from './ContextCompressionDisplay';
 import { MCPToolDisplay } from './MCPToolDisplay';
 import { SkillDisplay } from './SkillDisplay';
@@ -125,7 +127,7 @@ export const TOOL_CARD_CONFIGS: Record<string, ToolCardConfig> = {
   },
   'WebFetch': {
     toolName: 'WebFetch',
-    displayName: 'Fetch Link',
+    displayName: 'Read Webpage',
     icon: 'WF',
     requiresConfirmation: false,
     resultDisplayType: 'detailed',
@@ -174,6 +176,16 @@ export const TOOL_CARD_CONFIGS: Record<string, ToolCardConfig> = {
     description: 'Compress conversation context to reduce tokens',
     displayMode: 'compact',
     primaryColor: '#a855f7'
+  },
+  'GetToolSpec': {
+    toolName: 'GetToolSpec',
+    displayName: 'Read Tool Spec',
+    icon: 'SPEC',
+    requiresConfirmation: false,
+    resultDisplayType: 'detailed',
+    description: 'Read usage instructions and schema for a collapsed tool',
+    displayMode: 'compact',
+    primaryColor: '#14b8a6'
   },
 
   // Skill tool
@@ -353,6 +365,7 @@ export const TOOL_CARD_COMPONENTS = {
   
   // Web tools
   'WebSearch': WebSearchCard,
+  'WebFetch': WebFetchCard,
   
   // Advanced tools
   'Task': TaskToolDisplay,
@@ -362,6 +375,7 @@ export const TOOL_CARD_COMPONENTS = {
   
   // Context compression
   'ContextCompression': ContextCompressionDisplay,
+  'GetToolSpec': GetToolSpecCard,
 
   // Skill tool
   'Skill': SkillDisplay,

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1411,6 +1411,29 @@
       "noTitle": "No title",
       "summaryAvailable": "summary available"
     },
+    "webFetch": {
+      "parsingUrl": "Parsing URL...",
+      "readTitle": "Read Webpage: \"{{url}}\"",
+      "reading": "Reading \"{{url}}\"...",
+      "preparingRead": "Preparing to read \"{{url}}\"",
+      "clickToOpenLink": "Click to open link",
+      "contentAvailable": "content available",
+      "contentLength": "{{count}} chars",
+      "fetchFailed": "Failed to fetch content",
+      "noContent": "No content returned"
+    },
+    "getToolSpec": {
+      "title": "Tool Spec",
+      "readTitle": "Read tool spec: {{toolName}}",
+      "reading": "Reading tool spec for {{toolName}}...",
+      "preparingRead": "Preparing to read tool spec for {{toolName}}",
+      "loaded": "Loaded spec for {{toolName}}",
+      "alreadyLoaded": "{{toolName}} is already loaded",
+      "readFailed": "Failed to read tool spec",
+      "unknownTool": "Unknown tool",
+      "descriptionLabel": "Description",
+      "schemaLabel": "Input schema"
+    },
     "todoWrite": {
       "tasksCount": "{{count}} tasks",
       "progress": "({{completed}}/{{total}} completed)",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1411,6 +1411,29 @@
       "noTitle": "无标题",
       "summaryAvailable": "有搜索摘要"
     },
+    "webFetch": {
+      "parsingUrl": "解析链接中...",
+      "readTitle": "读取网页: \"{{url}}\"",
+      "reading": "正在读取 \"{{url}}\"...",
+      "preparingRead": "准备读取 \"{{url}}\"",
+      "clickToOpenLink": "点击打开链接",
+      "contentAvailable": "有内容可预览",
+      "contentLength": "{{count}} 个字符",
+      "fetchFailed": "抓取内容失败",
+      "noContent": "未返回内容"
+    },
+    "getToolSpec": {
+      "title": "工具说明",
+      "readTitle": "读取工具说明：{{toolName}}",
+      "reading": "正在读取 {{toolName}} 的工具说明...",
+      "preparingRead": "准备读取 {{toolName}} 的工具说明",
+      "loaded": "已读取 {{toolName}} 的说明",
+      "alreadyLoaded": "{{toolName}} 已经加载",
+      "readFailed": "读取工具说明失败",
+      "unknownTool": "未知工具",
+      "descriptionLabel": "说明",
+      "schemaLabel": "输入 Schema"
+    },
     "todoWrite": {
       "tasksCount": "{{count}} 项任务",
       "progress": "({{completed}}/{{total}} 完成)",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1411,6 +1411,29 @@
       "noTitle": "無標題",
       "summaryAvailable": "有搜尋摘要"
     },
+    "webFetch": {
+      "parsingUrl": "解析連結中...",
+      "readTitle": "讀取網頁: \"{{url}}\"",
+      "reading": "正在讀取 \"{{url}}\"...",
+      "preparingRead": "準備讀取 \"{{url}}\"",
+      "clickToOpenLink": "點擊開啟鏈接",
+      "contentAvailable": "有內容可預覽",
+      "contentLength": "{{count}} 個字符",
+      "fetchFailed": "抓取內容失敗",
+      "noContent": "未返回內容"
+    },
+    "getToolSpec": {
+      "title": "工具說明",
+      "readTitle": "讀取工具說明：{{toolName}}",
+      "reading": "正在讀取 {{toolName}} 的工具說明...",
+      "preparingRead": "準備讀取 {{toolName}} 的工具說明",
+      "loaded": "已讀取 {{toolName}} 的說明",
+      "alreadyLoaded": "{{toolName}} 已經載入",
+      "readFailed": "讀取工具說明失敗",
+      "unknownTool": "未知工具",
+      "descriptionLabel": "說明",
+      "schemaLabel": "輸入 Schema"
+    },
     "todoWrite": {
       "tasksCount": "{{count}} 項任務",
       "progress": "({{completed}}/{{total}} 完成)",


### PR DESCRIPTION
- add a dedicated WebFetch tool card in desktop Flow Chat
- match WebFetch card interaction to WebSearch with expandable content preview
- refine WebFetch header copy to "Read Webpage"
- keep WebFetch success/error states on Globe icon and use hover-only color feedback
- add a dedicated GetToolSpec card for tool spec loading, loaded, and already-loaded states
- show GetToolSpec description and input schema in expanded content
- register WebFetch and GetToolSpec specialized cards in the tool card registry
- add en-US, zh-CN, and zh-TW flow-chat locale strings for both cards
- add focused tests for WebFetchCard and GetToolSpecCard
