### PR TITLE
fix(flow-chat): preserve session bottom anchor on resize

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -162,6 +162,12 @@ interface BottomReservationState {
   pin: PinBottomReservation;
 }
 
+interface ScrollerGeometrySnapshot {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
 interface PendingTurnPinState {
   turnId: string;
   behavior: ScrollBehavior;
@@ -364,6 +370,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
   const bottomReservationStateRef = useRef<BottomReservationState>(createInitialBottomReservationState());
   const previousMeasuredHeightRef = useRef<number | null>(null);
   const previousScrollTopRef = useRef(0);
+  const previousScrollerGeometryRef = useRef<ScrollerGeometrySnapshot | null>(null);
   const markedInitialHistoryRenderWindowKeyRef = useRef<string | null>(null);
   const autoScrolledInitialHistoryRenderKeyRef = useRef<string | null>(null);
   const pendingInitialHistoryExpansionRef = useRef<{
@@ -378,6 +385,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
   const pinReservationReconcileFrameRef = useRef<number | null>(null);
   const turnPinStabilizationFrameRef = useRef<number | null>(null);
   const latestEndAnchorStabilizationFrameRef = useRef<number | null>(null);
+  const staticInitialHistoryBottomGuardFrameRef = useRef<number | null>(null);
+  const staticInitialHistoryBottomGuardUntilMsRef = useRef(0);
   const latestEndAnchorRequestRef = useRef<LatestEndAnchorRequestState | null>(null);
   const resolveLatestEndAnchorStabilizationRef = useRef<((reason: LatestEndAnchorResolveReason) => boolean) | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
@@ -466,6 +475,116 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     const compensationPx = getTotalBottomCompensationPx(reservationState);
     return Math.max(0, scroller.scrollHeight - compensationPx - inputStackFooterPxRef.current);
   }, [getTotalBottomCompensationPx]);
+
+  const recordScrollerGeometry = useCallback((scroller: HTMLElement) => {
+    previousScrollerGeometryRef.current = {
+      scrollTop: scroller.scrollTop,
+      scrollHeight: scroller.scrollHeight,
+      clientHeight: scroller.clientHeight,
+    };
+  }, []);
+
+  const recordScrollerGeometryIfLayoutStable = useCallback((scroller: HTMLElement) => {
+    const previousGeometry = previousScrollerGeometryRef.current;
+    if (
+      previousGeometry &&
+      (
+        Math.abs(scroller.clientHeight - previousGeometry.clientHeight) > COMPENSATION_EPSILON_PX ||
+        Math.abs(scroller.scrollHeight - previousGeometry.scrollHeight) > COMPENSATION_EPSILON_PX
+      )
+    ) {
+      return;
+    }
+    recordScrollerGeometry(scroller);
+  }, [recordScrollerGeometry]);
+
+  const syncPhysicalBottomAfterViewportResize = useCallback((scroller: HTMLElement): boolean => {
+    const previousGeometry = previousScrollerGeometryRef.current;
+    if (!previousGeometry) {
+      return false;
+    }
+
+    const viewportGeometryChanged =
+      Math.abs(scroller.scrollHeight - previousGeometry.scrollHeight) > COMPENSATION_EPSILON_PX ||
+      Math.abs(scroller.clientHeight - previousGeometry.clientHeight) > COMPENSATION_EPSILON_PX;
+    if (!viewportGeometryChanged || pendingCollapseIntentRef.current.active) {
+      return false;
+    }
+
+    const previousMaxScrollTop = Math.max(0, previousGeometry.scrollHeight - previousGeometry.clientHeight);
+    const wasAtPhysicalBottom =
+      Math.abs(previousMaxScrollTop - previousGeometry.scrollTop) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX;
+    if (!wasAtPhysicalBottom) {
+      return false;
+    }
+
+    const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+    if (Math.abs(maxScrollTop - scroller.scrollTop) > COMPENSATION_EPSILON_PX) {
+      scroller.scrollTop = maxScrollTop;
+    }
+    previousScrollTopRef.current = scroller.scrollTop;
+    previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+    recordScrollerGeometry(scroller);
+    return true;
+  }, [recordScrollerGeometry, snapshotMeasuredContentHeight]);
+
+  const cancelStaticInitialHistoryBottomGuard = useCallback(() => {
+    staticInitialHistoryBottomGuardUntilMsRef.current = 0;
+    if (staticInitialHistoryBottomGuardFrameRef.current !== null) {
+      cancelAnimationFrame(staticInitialHistoryBottomGuardFrameRef.current);
+      staticInitialHistoryBottomGuardFrameRef.current = null;
+    }
+  }, []);
+
+  const startStaticInitialHistoryBottomGuard = useCallback((durationMs = 2500) => {
+    const scroller = scrollerElementRef.current;
+    if (!scroller?.classList.contains('virtual-message-list__static-scroller')) {
+      return;
+    }
+
+    const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+    if (Math.abs(maxScrollTop - scroller.scrollTop) > LATEST_END_ANCHOR_STABLE_EPSILON_PX) {
+      return;
+    }
+
+    staticInitialHistoryBottomGuardUntilMsRef.current = Math.max(
+      staticInitialHistoryBottomGuardUntilMsRef.current,
+      performance.now() + durationMs,
+    );
+    if (staticInitialHistoryBottomGuardFrameRef.current !== null) {
+      return;
+    }
+
+    const tick = () => {
+      staticInitialHistoryBottomGuardFrameRef.current = null;
+      const now = performance.now();
+      if (now > staticInitialHistoryBottomGuardUntilMsRef.current) {
+        return;
+      }
+
+      const currentScroller = scrollerElementRef.current;
+      if (
+        !currentScroller?.classList.contains('virtual-message-list__static-scroller') ||
+        now <= userInitiatedUpwardScrollUntilMsRef.current
+      ) {
+        staticInitialHistoryBottomGuardUntilMsRef.current = 0;
+        return;
+      }
+
+      syncPhysicalBottomAfterViewportResize(currentScroller);
+      const distanceFromBottom = Math.max(
+        0,
+        currentScroller.scrollHeight - currentScroller.clientHeight - currentScroller.scrollTop,
+      );
+      if (distanceFromBottom <= LATEST_END_ANCHOR_STABLE_EPSILON_PX) {
+        recordScrollerGeometry(currentScroller);
+      }
+
+      staticInitialHistoryBottomGuardFrameRef.current = requestAnimationFrame(tick);
+    };
+
+    staticInitialHistoryBottomGuardFrameRef.current = requestAnimationFrame(tick);
+  }, [recordScrollerGeometry, syncPhysicalBottomAfterViewportResize]);
 
   const updateBottomReservationState = useCallback((
     updater: BottomReservationState | ((prev: BottomReservationState) => BottomReservationState),
@@ -658,8 +777,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
 
     scroller.scrollTop = targetScrollTop;
     previousScrollTopRef.current = targetScrollTop;
+    recordScrollerGeometry(scroller);
     return true;
-  }, [releaseAnchorLock]);
+  }, [recordScrollerGeometry, releaseAnchorLock]);
 
   const measureHeightChange = useCallback(() => {
     const scroller = scrollerElementRef.current;
@@ -667,6 +787,21 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
 
     const currentScrollTop = scroller.scrollTop;
     const previousScrollTop = previousScrollTopRef.current;
+    const previousScrollerGeometry = previousScrollerGeometryRef.current;
+    const viewportGeometryChanged = Boolean(
+      previousScrollerGeometry &&
+      (
+        Math.abs(scroller.scrollHeight - previousScrollerGeometry.scrollHeight) > COMPENSATION_EPSILON_PX ||
+        Math.abs(scroller.clientHeight - previousScrollerGeometry.clientHeight) > COMPENSATION_EPSILON_PX
+      )
+    );
+    const wasAtPhysicalBottom = Boolean(
+      previousScrollerGeometry &&
+      Math.abs(
+        Math.max(0, previousScrollerGeometry.scrollHeight - previousScrollerGeometry.clientHeight) -
+        previousScrollerGeometry.scrollTop
+      ) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX
+    );
     const currentTotalCompensation = getTotalBottomCompensationPx();
     const effectiveScrollHeight = Math.max(
       0,
@@ -677,12 +812,27 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
 
     if (previousMeasuredHeight === null) {
       previousScrollTopRef.current = currentScrollTop;
+      recordScrollerGeometry(scroller);
       return;
     }
 
     const heightDelta = effectiveScrollHeight - previousMeasuredHeight;
     if (Math.abs(heightDelta) <= COMPENSATION_EPSILON_PX) {
       previousScrollTopRef.current = currentScrollTop;
+      recordScrollerGeometry(scroller);
+      return;
+    }
+
+    if (viewportGeometryChanged && !pendingCollapseIntentRef.current.active) {
+      if (wasAtPhysicalBottom) {
+        const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+        if (Math.abs(maxScrollTop - scroller.scrollTop) > COMPENSATION_EPSILON_PX) {
+          scroller.scrollTop = maxScrollTop;
+        }
+      }
+      previousScrollTopRef.current = scroller.scrollTop;
+      previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+      recordScrollerGeometry(scroller);
       return;
     }
 
@@ -695,12 +845,14 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     if (heightDelta > 0) {
       if (currentTotalCompensation > COMPENSATION_EPSILON_PX && layoutTransitionCountRef.current > 0) {
         previousScrollTopRef.current = currentScrollTop;
+        recordScrollerGeometry(scroller);
         return;
       }
 
       const nextReservationState = consumeBottomCompensation(heightDelta);
       applyFooterCompensationNow(nextReservationState);
       previousScrollTopRef.current = currentScrollTop;
+      recordScrollerGeometry(scroller);
       return;
     }
 
@@ -756,6 +908,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       // scroll listener restore an older anchor during upward scroll and causes
       // the visible "wall hit" jitter.
       previousScrollTopRef.current = currentScrollTop;
+      recordScrollerGeometry(scroller);
       return;
     }
 
@@ -795,12 +948,15 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     }
 
     previousScrollTopRef.current = currentScrollTop;
+    recordScrollerGeometry(scroller);
   }, [
     activateAnchorLock,
     applyFooterCompensationNow,
     consumeBottomCompensation,
     getTotalBottomCompensationPx,
+    recordScrollerGeometry,
     restoreAnchorLockNow,
+    snapshotMeasuredContentHeight,
     updateBottomReservationState,
   ]);
 
@@ -1540,6 +1696,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
         scroller,
         bottomReservationStateRef.current,
       );
+      recordScrollerGeometry(scroller);
       scheduleVisibleTurnMeasure(2);
       schedulePinReservationReconcile(2);
     };
@@ -1555,6 +1712,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
 
     previousScrollTopRef.current = targetScrollTop;
     previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller, nextReservationState);
+    recordScrollerGeometry(scroller);
 
     const alignedRect = resolvedMetrics.targetElement.getBoundingClientRect();
     const alignedWithinTolerance = Math.abs(alignedRect.top - resolvedMetrics.viewportTop) <= 1.5;
@@ -1575,6 +1733,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     buildPinReservation,
     applyFooterCompensationNow,
     getRenderedUserMessageElement,
+    recordScrollerGeometry,
     resolveTurnPinMetrics,
     schedulePinReservationReconcile,
     scheduleVisibleTurnMeasure,
@@ -1767,6 +1926,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     previousScrollTopRef.current = 0;
     clearTurnPinRequest();
     cancelLatestEndAnchorStabilization();
+    cancelStaticInitialHistoryBottomGuard();
     anchorLockRef.current = {
       active: false,
       targetScrollTop: 0,
@@ -1783,6 +1943,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       baseTotalCompensationPx: 0,
       cumulativeShrinkPx: 0,
     };
+    previousScrollerGeometryRef.current = null;
     const currentSessionId = activeSession?.sessionId ?? null;
     const activeHandoff = historyProjectionHandoffRef.current;
     if (!activeHandoff || activeHandoff.sessionId !== currentSessionId) {
@@ -1793,7 +1954,14 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       pendingHistoryProjectionHandoffRef.current = null;
     }
     resetBottomReservations();
-  }, [activeSession?.sessionId, cancelLatestEndAnchorStabilization, clearHistoryProjectionHandoff, clearTurnPinRequest, resetBottomReservations]);
+  }, [
+    activeSession?.sessionId,
+    cancelLatestEndAnchorStabilization,
+    cancelStaticInitialHistoryBottomGuard,
+    clearHistoryProjectionHandoff,
+    clearTurnPinRequest,
+    resetBottomReservations,
+  ]);
 
   useEffect(() => {
     previousIsStreamingOutputRef.current = false;
@@ -1811,16 +1979,19 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
   useEffect(() => {
     return () => {
       cancelLatestEndAnchorStabilization();
+      cancelStaticInitialHistoryBottomGuard();
       if (historyProjectionHandoffReleaseFrameRef.current !== null) {
         cancelAnimationFrame(historyProjectionHandoffReleaseFrameRef.current);
         historyProjectionHandoffReleaseFrameRef.current = null;
       }
     };
-  }, [cancelLatestEndAnchorStabilization]);
+  }, [cancelLatestEndAnchorStabilization, cancelStaticInitialHistoryBottomGuard]);
 
   useEffect(() => {
     if (!scrollerElement) {
       previousMeasuredHeightRef.current = null;
+      previousScrollerGeometryRef.current = null;
+      cancelStaticInitialHistoryBottomGuard();
       return;
     }
 
@@ -1831,6 +2002,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
 
     previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scrollerElement);
     previousScrollTopRef.current = scrollerElement.scrollTop;
+    recordScrollerGeometry(scrollerElement);
 
     // Batch observer-triggered work into a single rAF per frame
     let observerBatchPending = false;
@@ -1850,10 +2022,22 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
 
     resizeObserverRef.current?.disconnect();
     resizeObserverRef.current = new ResizeObserver(() => {
+      syncPhysicalBottomAfterViewportResize(scrollerElement);
       resolveLatestEndAnchorStabilizationRef.current?.('resize-observer');
       scheduleObserverBatch();
     });
     resizeObserverRef.current.observe(resizeTarget);
+    if (resizeTarget !== scrollerElement) {
+      resizeObserverRef.current.observe(scrollerElement);
+    }
+
+    const handleWindowResize = () => {
+      syncPhysicalBottomAfterViewportResize(scrollerElement);
+      resolveLatestEndAnchorStabilizationRef.current?.('resize-observer');
+      scheduleObserverBatch();
+    };
+    window.addEventListener('resize', handleWindowResize);
+    window.visualViewport?.addEventListener('resize', handleWindowResize);
 
     mutationObserverRef.current?.disconnect();
     let mutationPending = false;
@@ -1982,6 +2166,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
           scrollerElement,
           nextReservationState,
         );
+        recordScrollerGeometry(scrollerElement);
         return;
       }
 
@@ -2012,11 +2197,13 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
           if (Math.abs(restoreDelta) > ANCHOR_LOCK_MIN_DEVIATION_PX) {
             scrollerElement.scrollTop = targetScrollTop;
             previousScrollTopRef.current = targetScrollTop;
+            recordScrollerGeometry(scrollerElement);
             return;
           }
         }
       }
       previousScrollTopRef.current = scrollerElement.scrollTop;
+      recordScrollerGeometryIfLayoutStable(scrollerElement);
       scheduleVisibleTurnMeasure();
       followOutputControllerRef.current.handleScroll();
       scheduleFullHistoryProjectionForUserIntent('scroll-near-partial-history-boundary');
@@ -2226,6 +2413,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       window.removeEventListener('pointercancel', endScrollbarPointerInteraction, true);
       window.removeEventListener('tool-card-toggle', handleToolCardToggle);
       window.removeEventListener('flowchat:tool-card-collapse-intent', handleToolCardCollapseIntent as EventListener);
+      window.removeEventListener('resize', handleWindowResize);
+      window.visualViewport?.removeEventListener('resize', handleWindowResize);
       resizeObserverRef.current?.disconnect();
       resizeObserverRef.current = null;
       mutationObserverRef.current?.disconnect();
@@ -2257,18 +2446,22 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
         cancelAnimationFrame(fullHistoryProjectionIntentFrameRef.current);
         fullHistoryProjectionIntentFrameRef.current = null;
       }
+      cancelStaticInitialHistoryBottomGuard();
       pendingFullHistoryProjectionReasonRef.current = null;
     };
   }, [
     activateAnchorLock,
     applyFooterCompensationNow,
     cancelLatestEndAnchorStabilization,
+    cancelStaticInitialHistoryBottomGuard,
     consumeBottomCompensation,
     clearTurnPinRequest,
     getTotalBottomCompensationPx,
     latestTurnId,
     pendingTurnPin?.pinMode,
     pendingTurnPin?.turnId,
+    recordScrollerGeometry,
+    recordScrollerGeometryIfLayoutStable,
     releaseAnchorLock,
     scheduleHeightMeasure,
     scheduleFollowToLatestWithViewportState,
@@ -2280,6 +2473,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     scrollerElement,
     shouldSuspendAutoFollow,
     snapshotMeasuredContentHeight,
+    syncPhysicalBottomAfterViewportResize,
     isProcessing,
     updateBottomReservationState,
   ]);
@@ -2337,6 +2531,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     }
 
     request.attempts += 1;
+    const shouldSnapTargetToPhysicalBottom =
+      targetIndex >= virtualItems.length - 1 ||
+      request.turnId === latestTurnId;
     const targetElement = getRenderedVirtualItemElement(targetIndex);
     const scrollerRect = scroller.getBoundingClientRect();
     const inputOverlayInsetPx = Math.max(
@@ -2356,10 +2553,15 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       const rect = currentTargetElement.getBoundingClientRect();
       const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
       const endDeltaPx = rect.bottom - visibleBottom;
-      const endAnchored =
-        Math.abs(endDeltaPx) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX ||
-        (endDeltaPx > 0 && Math.abs(maxScrollTop - scroller.scrollTop) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX) ||
-        (endDeltaPx < 0 && scroller.scrollTop <= LATEST_END_ANCHOR_STABLE_EPSILON_PX);
+      const physicalBottomAnchored =
+        Math.abs(maxScrollTop - scroller.scrollTop) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX;
+      const endAnchored = shouldSnapTargetToPhysicalBottom
+        ? physicalBottomAnchored
+        : (
+          Math.abs(endDeltaPx) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX ||
+          (endDeltaPx > 0 && physicalBottomAnchored) ||
+          (endDeltaPx < 0 && scroller.scrollTop <= LATEST_END_ANCHOR_STABLE_EPSILON_PX)
+        );
       return {
         endAnchored,
         endDeltaPx,
@@ -2433,16 +2635,19 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       const state = readTargetEndState(targetElement);
       let nextScrollTop = scroller.scrollTop;
       if (state) {
-        nextScrollTop = Math.max(
-          0,
-          Math.min(state.maxScrollTop, scroller.scrollTop + state.endDeltaPx),
-        );
+        nextScrollTop = shouldSnapTargetToPhysicalBottom
+          ? state.maxScrollTop
+          : Math.max(
+            0,
+            Math.min(state.maxScrollTop, scroller.scrollTop + state.endDeltaPx),
+          );
       }
 
       if (Math.abs(nextScrollTop - scroller.scrollTop) > COMPENSATION_EPSILON_PX) {
         scroller.scrollTop = nextScrollTop;
         previousScrollTopRef.current = nextScrollTop;
         previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+        recordScrollerGeometry(scroller);
       }
     } else if (virtuoso) {
       request.visibleFrames = 0;
@@ -2460,6 +2665,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
           scroller.scrollTop = maxScrollTop;
           previousScrollTopRef.current = maxScrollTop;
           previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+          recordScrollerGeometry(scroller);
         }
       }
     } else {
@@ -2469,6 +2675,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
         scroller.scrollTop = maxScrollTop;
         previousScrollTopRef.current = maxScrollTop;
         previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+        recordScrollerGeometry(scroller);
       }
     }
 
@@ -2495,6 +2702,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     cancelLatestEndAnchorStabilization,
     getRenderedVirtualItemElement,
     latestTurnId,
+    recordScrollerGeometry,
     scheduleVisibleTurnMeasure,
     snapshotMeasuredContentHeight,
     toVirtuosoIndex,
@@ -2627,10 +2835,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     if (scroller) {
       previousScrollTopRef.current = scroller.scrollTop;
       previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller, nextReservationState);
+      recordScrollerGeometry(scroller);
     }
   }, [
     applyFooterCompensationNow,
     clearTurnPinRequest,
+    recordScrollerGeometry,
     releaseAnchorLock,
     snapshotMeasuredContentHeight,
     updateBottomReservationState,
@@ -2669,10 +2879,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     if (scroller) {
       previousScrollTopRef.current = scroller.scrollTop;
       previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller, nextReservationState);
+      recordScrollerGeometry(scroller);
     }
   }, [
     applyFooterCompensationNow,
     clearTurnPinRequest,
+    recordScrollerGeometry,
     releaseAnchorLock,
     snapshotMeasuredContentHeight,
     updateBottomReservationState,
@@ -3151,12 +3363,16 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     const scroller = scrollerElementRef.current;
     if (scroller) {
       clearAllBottomReservationsForUserNavigation();
+      const nextScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
       scroller.scrollTo({
-        top: Math.max(0, scroller.scrollHeight - scroller.clientHeight),
+        top: nextScrollTop,
         behavior: 'auto',
       });
+      previousScrollTopRef.current = nextScrollTop;
+      previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+      recordScrollerGeometry(scroller);
     }
-  }, [clearAllBottomReservationsForUserNavigation]);
+  }, [clearAllBottomReservationsForUserNavigation, recordScrollerGeometry, snapshotMeasuredContentHeight]);
 
   const scrollToTurnEndAndClearPin = useCallback((turnId: string) => {
     const scroller = scrollerElementRef.current;
@@ -3192,6 +3408,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     clearAllBottomReservationsForUserNavigation();
 
     if (!virtuosoRef.current) {
+      const shouldSnapLatestToPhysicalBottom =
+        useStaticInitialHistoryList &&
+        (
+          targetIndex >= virtualItems.length - 1 ||
+          (Boolean(latestTurnId) && turnId === latestTurnId)
+        );
       const targetElement = getRenderedVirtualItemElement(targetIndex);
       if (!targetElement) {
         return reject('missing_static_target_element', {
@@ -3221,23 +3443,29 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       };
       const canUseStaticFastPath = (state: ReturnType<typeof readStaticTargetEndState>) => {
         const distanceFromBottom = Math.max(0, state.maxScrollTop - scroller.scrollTop);
+        const bottomTolerancePx = shouldSnapLatestToPhysicalBottom
+          ? LATEST_END_ANCHOR_STABLE_EPSILON_PX
+          : LATEST_END_ANCHOR_STATIC_FAST_PATH_TOLERANCE_PX;
         return (
           state.visible &&
           state.rect.height <= state.visibleHeight + LATEST_END_ANCHOR_STATIC_FAST_PATH_TOLERANCE_PX &&
           Math.abs(state.endDeltaPx) <= LATEST_END_ANCHOR_STATIC_FAST_PATH_TOLERANCE_PX &&
-          distanceFromBottom <= LATEST_END_ANCHOR_STATIC_FAST_PATH_TOLERANCE_PX
+          distanceFromBottom <= bottomTolerancePx
         );
       };
       let staticState = readStaticTargetEndState();
       if (!canUseStaticFastPath(staticState)) {
-        const nextScrollTop = Math.max(
-          0,
-          Math.min(staticState.maxScrollTop, scroller.scrollTop + staticState.endDeltaPx),
-        );
+        const nextScrollTop = shouldSnapLatestToPhysicalBottom
+          ? staticState.maxScrollTop
+          : Math.max(
+            0,
+            Math.min(staticState.maxScrollTop, scroller.scrollTop + staticState.endDeltaPx),
+          );
         if (Math.abs(nextScrollTop - scroller.scrollTop) > COMPENSATION_EPSILON_PX) {
           scroller.scrollTop = nextScrollTop;
           previousScrollTopRef.current = nextScrollTop;
           previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+          recordScrollerGeometry(scroller);
           staticState = readStaticTargetEndState();
         }
       }
@@ -3306,6 +3534,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     clearAllBottomReservationsForUserNavigation,
     exitFollowOutput,
     getRenderedVirtualItemElement,
+    latestTurnId,
+    recordScrollerGeometry,
     resolveLatestEndAnchorStabilization,
     scheduleVisibleTurnMeasure,
     snapshotMeasuredContentHeight,
@@ -3609,9 +3839,11 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     scroller.scrollTop = nextScrollTop;
     previousScrollTopRef.current = nextScrollTop;
     previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+    recordScrollerGeometry(scroller);
   }, [
     expandedInitialHistoryRenderKey,
     initialHistoryRenderKey,
+    recordScrollerGeometry,
     snapshotMeasuredContentHeight,
   ]);
   useEffect(() => {
@@ -3736,6 +3968,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
   useLayoutEffect(() => {
     if (!useStaticInitialHistoryList) {
       autoScrolledInitialHistoryRenderKeyRef.current = null;
+      cancelStaticInitialHistoryBottomGuard();
       return;
     }
 
@@ -3753,13 +3986,18 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     scroller.scrollTop = nextScrollTop;
     previousScrollTopRef.current = nextScrollTop;
     previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+    recordScrollerGeometry(scroller);
+    startStaticInitialHistoryBottomGuard();
     scheduleVisibleTurnMeasure(1);
   }, [
     activeSessionId,
+    cancelStaticInitialHistoryBottomGuard,
     initialHistoryRenderKey,
     latestTurnId,
+    recordScrollerGeometry,
     scheduleVisibleTurnMeasure,
     snapshotMeasuredContentHeight,
+    startStaticInitialHistoryBottomGuard,
     useStaticInitialHistoryList,
   ]);
   // ── Render ────────────────────────────────────────────────────────────
@@ -3796,6 +4034,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     scroller.scrollTop = nextScrollTop;
     previousScrollTopRef.current = nextScrollTop;
     previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+    recordScrollerGeometry(scroller);
     scheduleHistoryProjectionHandoffRelease(2);
   }, [
     activeSessionId,
@@ -3805,6 +4044,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     historyProjectionHandoff?.anchorOffsetTopPx,
     historyProjectionHandoff?.mode,
     historyProjectionHandoff?.sessionId,
+    recordScrollerGeometry,
     scheduleHistoryProjectionHandoffRelease,
     snapshotMeasuredContentHeight,
     virtualItems,

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -26,9 +26,36 @@ const LONG_SESSION_VIEWPORT_MAX_BLANK_GAP_PX = 64;
 const LONG_SESSION_LATEST_VISIBLE_MAX_BOTTOM_BLANK_PX = 96;
 const LONG_SESSION_LATEST_VISIBLE_MAX_BLANK_GAP_PX = 96;
 const LONG_SESSION_LATEST_TAIL_BOTTOM_TOLERANCE_PX = 96;
+const LONG_SESSION_PHYSICAL_BOTTOM_TOLERANCE_PX = 4;
+const LONG_SESSION_RESIZE_BOTTOM_SETTLE_MAX_MS = 120;
 const LONG_SESSION_INPUT_MIN_TOP_RATIO = 0.65;
 const LONG_SESSION_INPUT_BOTTOM_TOLERANCE_PX = 96;
 const LONG_SESSION_MAX_LATEST_TEXT_DELAY_AFTER_VISIBLE_MS = 120;
+
+type LongSessionPostVisibleInteraction =
+  | 'first-scroll'
+  | 'scroll-down'
+  | 'resize-window'
+  | 'resize-window-width';
+
+type LongSessionWindowRect = {
+  x?: number;
+  y?: number;
+  width: number;
+  height: number;
+};
+
+type LongSessionPostVisibleInteractionResult = {
+  type: LongSessionPostVisibleInteraction;
+  beforeScrollTop: number;
+  afterScrollTop: number;
+  maxScrollTop: number;
+  deltaY: number;
+  beforeClientHeight?: number;
+  afterClientHeight?: number;
+  beforeWindowRect?: LongSessionWindowRect;
+  afterWindowRect?: LongSessionWindowRect;
+};
 
 type LongSessionViewportState = {
   hasRoot: boolean;
@@ -53,6 +80,14 @@ type LongSessionViewportState = {
   inputOverlayTop: number | null;
   inputOverlayBottom: number | null;
   inputOverlayHeight: number | null;
+  staticInitialHistoryWindowed: boolean | null;
+  staticInitialHistorySpacerHeight: number | null;
+  staticItemsTop: number | null;
+  staticItemsBottom: number | null;
+  footerTop: number | null;
+  footerHeight: number | null;
+  lastRenderedItemTop: number | null;
+  lastRenderedItemBottom: number | null;
   latestVisible: boolean;
   visibleTurnIds: string[];
   visibleUserMessageCount: number;
@@ -930,10 +965,20 @@ async function readLongSessionViewportState(expectedLatestTurnId?: string | null
     const scroller = root?.querySelector<HTMLElement>(
       '[data-virtuoso-scroller="true"], [data-virtuoso-scroller]',
     ) ?? null;
+    const staticScroller = root?.querySelector<HTMLElement>('.virtual-message-list__static-scroller') ?? null;
+    const staticItems = root?.querySelector<HTMLElement>('.virtual-message-list__static-items') ?? null;
+    const staticInitialHistorySpacer = root?.querySelector<HTMLElement>(
+      '.virtual-message-list__initial-history-spacer',
+    ) ?? null;
+    const footer = root?.querySelector<HTMLElement>('.message-list-footer') ?? null;
     const userMessages = Array.from(root?.querySelectorAll<HTMLElement>(
       '.virtual-item-wrapper[data-turn-id][data-item-type="user-message"]',
     ) ?? []);
+    const renderedItems = Array.from(root?.querySelectorAll<HTMLElement>(
+      '.virtual-item-wrapper[data-turn-id]',
+    ) ?? []);
     const renderedLatest = userMessages.length > 0 ? userMessages[userMessages.length - 1] : null;
+    const lastRenderedItem = renderedItems.length > 0 ? renderedItems[renderedItems.length - 1] : null;
     const latest = targetTurnId
       ? root?.querySelector<HTMLElement>(
         `.virtual-item-wrapper[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
@@ -993,6 +1038,9 @@ async function readLongSessionViewportState(expectedLatestTurnId?: string | null
     const latestModelRoundTextLength = latestModelRoundVisibleSegments
       .reduce((total, element) => total + (element.innerText?.length ?? 0), 0);
     const latestVisible = isVisibleWithinScroller(latestRect, latest);
+    const staticItemsRect = staticItems?.getBoundingClientRect() ?? null;
+    const footerRect = footer?.getBoundingClientRect() ?? null;
+    const lastRenderedItemRect = lastRenderedItem?.getBoundingClientRect() ?? null;
     const latestContentVisible = latestVisible || latestModelRoundVisible;
     const latestContentVisuallyVisible =
       latestContentVisible && !historyPlaceholderCoversMessages;
@@ -1104,6 +1152,16 @@ async function readLongSessionViewportState(expectedLatestTurnId?: string | null
       inputOverlayTop: inputOverlayRect?.top ?? null,
       inputOverlayBottom: inputOverlayRect?.bottom ?? null,
       inputOverlayHeight: inputOverlayRect?.height ?? null,
+      staticInitialHistoryWindowed: staticScroller
+        ? staticScroller.getAttribute('data-initial-history-render-windowed') === 'true'
+        : null,
+      staticInitialHistorySpacerHeight: staticInitialHistorySpacer?.offsetHeight ?? null,
+      staticItemsTop: staticItemsRect?.top ?? null,
+      staticItemsBottom: staticItemsRect?.bottom ?? null,
+      footerTop: footerRect?.top ?? null,
+      footerHeight: footerRect?.height ?? null,
+      lastRenderedItemTop: lastRenderedItemRect?.top ?? null,
+      lastRenderedItemBottom: lastRenderedItemRect?.bottom ?? null,
       latestVisible,
       visibleTurnIds: visibleUserMessages
         .map(element => element.dataset.turnId)
@@ -2637,6 +2695,31 @@ function isLongSessionLatestTailAnchored(viewport: LongSessionViewportState): bo
   );
 }
 
+function getLongSessionPhysicalDistanceFromBottom(viewport: LongSessionViewportState): number | null {
+  if (
+    viewport.scrollTop === null ||
+    viewport.scrollHeight === null ||
+    viewport.clientHeight === null
+  ) {
+    return null;
+  }
+
+  return Math.max(0, viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop);
+}
+
+function getLongSessionScrollTransitionDistanceFromBottom(
+  transition: LongSessionVisualStateSummary['scrollTransitions'][number],
+  side: 'from' | 'to',
+): number | null {
+  const scrollTop = side === 'from' ? transition.fromScrollTop : transition.toScrollTop;
+  const scrollHeight = side === 'from' ? transition.fromScrollHeight : transition.toScrollHeight;
+  const clientHeight = side === 'from' ? transition.fromClientHeight : transition.toClientHeight;
+  if (scrollTop === null || scrollHeight === null || clientHeight === null) {
+    return null;
+  }
+  return Math.max(0, scrollHeight - clientHeight - scrollTop);
+}
+
 async function maybeSavePerfScreenshot(name: string): Promise<string | null> {
   if (process.env.BITFUN_E2E_PERF_SCREENSHOTS !== '1') {
     return null;
@@ -3449,7 +3532,8 @@ type LongSessionOpenMeasurement = {
   sessionId: string;
   fixtureScenario: string | null;
   expectedLatestTurnId: string | null;
-  postVisibleInteraction: 'first-scroll' | null;
+  postVisibleInteraction: LongSessionPostVisibleInteraction | null;
+  postVisibleInteractionResult: LongSessionPostVisibleInteractionResult | null;
   postVisibleObserveMs: number;
   verboseTimelineReport: boolean;
   traceWaitErrors: string[];
@@ -3485,7 +3569,7 @@ type LongSessionOpenMeasurement = {
 type LongSessionOpenMeasurementOptions = {
   requireFrameTrace?: boolean;
   expectNoHistoryLoadingAfterClick?: boolean;
-  postVisibleInteraction?: 'first-scroll';
+  postVisibleInteraction?: LongSessionPostVisibleInteraction;
 };
 
 type RapidLongSessionSwitchMeasurement = {
@@ -3535,20 +3619,170 @@ type RapidLongSessionSwitchMeasurement = {
 
 function readPostVisibleInteractionOption(
   options: LongSessionOpenMeasurementOptions,
-): 'first-scroll' | null {
+): LongSessionPostVisibleInteraction | null {
   const envValue = process.env.BITFUN_E2E_PERF_POST_VISIBLE_INTERACTION;
-  if (envValue === 'first-scroll') {
+  if (
+    envValue === 'first-scroll' ||
+    envValue === 'scroll-down' ||
+    envValue === 'resize-window' ||
+    envValue === 'resize-window-width'
+  ) {
     return envValue;
   }
   return options.postVisibleInteraction ?? null;
 }
 
-async function performLongSessionPostVisibleInteraction(interaction: 'first-scroll'): Promise<void> {
-  if (interaction !== 'first-scroll') {
-    return;
+function isLongSessionResizeInteraction(
+  interaction: LongSessionPostVisibleInteraction | null,
+): boolean {
+  return interaction === 'resize-window' || interaction === 'resize-window-width';
+}
+
+function getWebDriverSessionId(): string {
+  const sessionId = (browser as unknown as { sessionId?: string }).sessionId;
+  if (!sessionId) {
+    throw new Error('WebDriver session id is not available for window resize measurement');
+  }
+  return sessionId;
+}
+
+function webDriverEndpoint(pathname: string): string {
+  const port = Number(process.env.BITFUN_E2E_WEBDRIVER_PORT || 4445);
+  return `http://127.0.0.1:${port}${pathname}`;
+}
+
+async function readWebDriverWindowRect(): Promise<LongSessionWindowRect> {
+  const sessionId = getWebDriverSessionId();
+  const response = await fetch(webDriverEndpoint(`/session/${sessionId}/window/rect`));
+  if (!response.ok) {
+    throw new Error(`Failed to read WebDriver window rect: ${response.status} ${await response.text()}`);
+  }
+  const payload = await response.json() as { value?: Partial<LongSessionWindowRect> };
+  const rect = payload.value;
+  if (
+    !rect ||
+    typeof rect.width !== 'number' ||
+    typeof rect.height !== 'number'
+  ) {
+    throw new Error(`WebDriver window rect response is missing width/height: ${JSON.stringify(payload)}`);
+  }
+  return {
+    x: typeof rect.x === 'number' ? rect.x : undefined,
+    y: typeof rect.y === 'number' ? rect.y : undefined,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+async function setWebDriverWindowRect(rect: Partial<LongSessionWindowRect>): Promise<LongSessionWindowRect> {
+  const sessionId = getWebDriverSessionId();
+  const response = await fetch(webDriverEndpoint(`/session/${sessionId}/window/rect`), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(rect),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to set WebDriver window rect: ${response.status} ${await response.text()}`);
+  }
+  return readWebDriverWindowRect();
+}
+
+async function waitForBrowserAnimationFrames(frameCount = 2): Promise<void> {
+  await browser.executeAsync((frames, done) => {
+    let remaining = frames;
+    const waitFrame = () => {
+      remaining -= 1;
+      if (remaining <= 0) {
+        done();
+        return;
+      }
+      requestAnimationFrame(waitFrame);
+    };
+    requestAnimationFrame(waitFrame);
+  }, frameCount);
+}
+
+async function readLongSessionScrollerMetrics(): Promise<{
+  scrollTop: number;
+  maxScrollTop: number;
+  clientHeight: number;
+}> {
+  return browser.execute(() => {
+    const scroller = document.querySelector<HTMLElement>(
+      '.modern-flowchat-container__messages [data-virtuoso-scroller="true"], ' +
+      '.modern-flowchat-container__messages [data-virtuoso-scroller]',
+    );
+    if (!scroller) {
+      throw new Error('Could not find long-session scroller for post-visible interaction');
+    }
+    return {
+      scrollTop: scroller.scrollTop,
+      maxScrollTop: Math.max(0, scroller.scrollHeight - scroller.clientHeight),
+      clientHeight: scroller.clientHeight,
+    };
+  });
+}
+
+async function recordLongSessionPostVisibleInteraction(
+  detail: LongSessionPostVisibleInteractionResult,
+): Promise<void> {
+  await browser.execute((eventDetail) => {
+    window.dispatchEvent(new CustomEvent('bitfun:e2e-long-session-user-interaction', {
+      detail: eventDetail,
+    }));
+  }, detail);
+}
+
+async function performLongSessionPostVisibleInteraction(
+  interaction: LongSessionPostVisibleInteraction,
+): Promise<LongSessionPostVisibleInteractionResult> {
+  if (isLongSessionResizeInteraction(interaction)) {
+    const beforeWindowRect = await readWebDriverWindowRect();
+    const beforeMetrics = await readLongSessionScrollerMetrics();
+    const nextWidth = Math.max(
+      960,
+      Math.round(beforeWindowRect.width - Math.min(420, Math.max(220, beforeWindowRect.width * 0.22))),
+    );
+    const nextHeight = interaction === 'resize-window-width'
+      ? beforeWindowRect.height
+      : Math.max(
+        540,
+        Math.round(beforeWindowRect.height - Math.min(260, Math.max(140, beforeWindowRect.height * 0.22))),
+      );
+    await recordLongSessionPostVisibleInteraction({
+      type: interaction,
+      beforeScrollTop: beforeMetrics.scrollTop,
+      afterScrollTop: beforeMetrics.scrollTop,
+      maxScrollTop: beforeMetrics.maxScrollTop,
+      deltaY: 0,
+      beforeClientHeight: beforeMetrics.clientHeight,
+      beforeWindowRect,
+    });
+    const afterWindowRect = await setWebDriverWindowRect({
+      x: beforeWindowRect.x,
+      y: beforeWindowRect.y,
+      width: interaction === 'resize-window-width' ? nextWidth : beforeWindowRect.width,
+      height: nextHeight,
+    });
+    await waitForBrowserAnimationFrames(3);
+    const afterMetrics = await readLongSessionScrollerMetrics();
+    const result: LongSessionPostVisibleInteractionResult = {
+      type: interaction,
+      beforeScrollTop: beforeMetrics.scrollTop,
+      afterScrollTop: afterMetrics.scrollTop,
+      maxScrollTop: afterMetrics.maxScrollTop,
+      deltaY: 0,
+      beforeClientHeight: beforeMetrics.clientHeight,
+      afterClientHeight: afterMetrics.clientHeight,
+      beforeWindowRect,
+      afterWindowRect,
+    };
+    return result;
   }
 
-  await browser.execute(() => {
+  return browser.execute((interactionType) => {
     const scroller = document.querySelector<HTMLElement>(
       '.modern-flowchat-container__messages [data-virtuoso-scroller="true"], ' +
       '.modern-flowchat-container__messages [data-virtuoso-scroller]',
@@ -3558,24 +3792,44 @@ async function performLongSessionPostVisibleInteraction(interaction: 'first-scro
     }
 
     const beforeScrollTop = scroller.scrollTop;
-    const deltaY = -Math.min(520, Math.max(160, scroller.clientHeight * 0.45));
+    const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+    const direction = interactionType === 'first-scroll' ? -1 : 1;
+    const deltaY = direction * Math.min(520, Math.max(160, scroller.clientHeight * 0.45));
     scroller.dispatchEvent(new WheelEvent('wheel', {
       bubbles: true,
       cancelable: true,
       deltaMode: WheelEvent.DOM_DELTA_PIXEL,
       deltaY,
     }));
-    scroller.scrollTop = Math.max(0, beforeScrollTop + deltaY);
+    scroller.scrollTop = Math.max(0, Math.min(maxScrollTop, beforeScrollTop + deltaY));
     scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
     window.dispatchEvent(new CustomEvent('bitfun:e2e-long-session-user-interaction', {
       detail: {
-        type: 'first-scroll',
+        type: interactionType,
         beforeScrollTop,
         afterScrollTop: scroller.scrollTop,
+        maxScrollTop,
         deltaY,
       },
     }));
-  });
+    return {
+      type: interactionType,
+      beforeScrollTop,
+      afterScrollTop: scroller.scrollTop,
+      maxScrollTop,
+      deltaY,
+    };
+  }, interaction);
+}
+
+async function restoreLongSessionPostVisibleInteraction(
+  result: LongSessionPostVisibleInteractionResult | null,
+): Promise<void> {
+  if (!result?.beforeWindowRect) {
+    return;
+  }
+  await setWebDriverWindowRect(result.beforeWindowRect);
+  await waitForBrowserAnimationFrames(2);
 }
 
 function readRapidSwitchSessionIds(): string[] {
@@ -3786,13 +4040,14 @@ async function collectLongSessionOpenMeasurement(
     { requireLatestModelRound },
   );
   const postVisibleInteraction = readPostVisibleInteractionOption(options);
+  let postVisibleInteractionResult: LongSessionPostVisibleInteractionResult | null = null;
   let latestVisible: Awaited<typeof latestVisiblePromise> | null = null;
   let latestUsable: Awaited<typeof latestUsablePromise> | null = null;
 
   if (postVisibleInteraction) {
     latestVisible = await latestVisiblePromise;
     latestUsable = await latestUsablePromise;
-    await performLongSessionPostVisibleInteraction(postVisibleInteraction);
+    postVisibleInteractionResult = await performLongSessionPostVisibleInteraction(postVisibleInteraction);
   }
 
   const afterFrameSnapshot = requireFrameTrace
@@ -3879,12 +4134,13 @@ async function collectLongSessionOpenMeasurement(
   );
   const screenshotPath = await maybeSavePerfScreenshot(`long-session-${sessionId}`);
 
-  return {
+  const measurement: LongSessionOpenMeasurement = {
     appMode: process.env.BITFUN_E2E_APP_MODE ?? 'auto',
     sessionId,
     fixtureScenario,
     expectedLatestTurnId,
     postVisibleInteraction,
+    postVisibleInteractionResult,
     postVisibleObserveMs,
     verboseTimelineReport,
     traceWaitErrors,
@@ -3920,6 +4176,8 @@ async function collectLongSessionOpenMeasurement(
     api: finalSnapshot.api,
     native: finalSnapshot.native,
   };
+  await restoreLongSessionPostVisibleInteraction(postVisibleInteractionResult);
+  return measurement;
 }
 
 function expectLongSessionMeasurementUsable(
@@ -3982,6 +4240,8 @@ function expectLongSessionMeasurementUsable(
     )).toBe(true);
     expect(isLongSessionLatestTailAnchored(measurement.latestAnswerTextVisibleViewport)).toBe(true);
   }
+  expect(getLongSessionPhysicalDistanceFromBottom(measurement.latestUsableViewport))
+    .toBeLessThanOrEqual(LONG_SESSION_PHYSICAL_BOTTOM_TOLERANCE_PX);
   const latestAnchorFailures = measurement.events.filter(event =>
     event.phase === 'historical_session_latest_anchor_failed' &&
     traceEventSessionId(event) === measurement.sessionId
@@ -4003,9 +4263,11 @@ function expectLongSessionMeasurementUsable(
       expect(measurement.visualStateSummary.postLatestTextVisibleLoadingSurfacePointEventCount).toBe(0);
       expect(measurement.visualStateSummary.postLatestTextVisibleBlankSurfacePointEventCount).toBe(0);
       expect(measurement.visualStateSummary.postLatestTextVisibleTransparentSurfacePointEventCount).toBe(0);
-      expect(measurement.visualStateSummary.postLatestTextVisibleScrollJumpCount).toBe(0);
-      expect(measurement.visualStateSummary.postLatestTextVisibleVirtualItemElementChangeCount).toBe(0);
-      expect(measurement.visualStateSummary.postLatestTextVisibleLayoutShiftScore).toBeLessThanOrEqual(0.005);
+      if (!isLongSessionResizeInteraction(measurement.postVisibleInteraction)) {
+        expect(measurement.visualStateSummary.postLatestTextVisibleScrollJumpCount).toBe(0);
+        expect(measurement.visualStateSummary.postLatestTextVisibleVirtualItemElementChangeCount).toBe(0);
+        expect(measurement.visualStateSummary.postLatestTextVisibleLayoutShiftScore).toBeLessThanOrEqual(0.005);
+      }
     }
     expect(measurement.visualStateSummary.openIntentBlankSurfacePointEventCount).toBe(0);
     expect(measurement.visualStateSummary.openIntentBlankSurfaceHoldCount).toBe(0);
@@ -4021,6 +4283,63 @@ function expectLongSessionMeasurementUsable(
       expect(measurement.visualStateSummary.postUserInteractionBlankSurfacePointEventCount).toBe(0);
       expect(measurement.visualStateSummary.postUserInteractionScrollTransitions).toHaveLength(0);
     }
+    if (measurement.postVisibleInteraction === 'scroll-down') {
+      expect(measurement.postVisibleInteractionResult).not.toBeNull();
+      expect(
+        (measurement.postVisibleInteractionResult?.afterScrollTop ?? 0) -
+        (measurement.postVisibleInteractionResult?.beforeScrollTop ?? 0),
+      ).toBeLessThanOrEqual(LONG_SESSION_PHYSICAL_BOTTOM_TOLERANCE_PX);
+      expect(measurement.visualStateSummary.postUserInteractionScrollJumpCount).toBe(0);
+      expect(measurement.visualStateSummary.postUserInteractionScrollerCollapseCount).toBe(0);
+      expect(measurement.visualStateSummary.postUserInteractionBlankSurfacePointEventCount).toBe(0);
+      expect(measurement.visualStateSummary.postUserInteractionScrollTransitions).toHaveLength(0);
+    }
+    if (isLongSessionResizeInteraction(measurement.postVisibleInteraction)) {
+      expect(measurement.postVisibleInteractionResult).not.toBeNull();
+      if (measurement.postVisibleInteraction === 'resize-window-width') {
+        expect(measurement.postVisibleInteractionResult?.beforeWindowRect?.width).toBeGreaterThan(
+          measurement.postVisibleInteractionResult?.afterWindowRect?.width ?? 0,
+        );
+        expect(Math.abs(
+          (measurement.postVisibleInteractionResult?.beforeWindowRect?.height ?? 0) -
+          (measurement.postVisibleInteractionResult?.afterWindowRect?.height ?? 0),
+        )).toBeLessThanOrEqual(2);
+      } else {
+        expect(measurement.postVisibleInteractionResult?.beforeWindowRect?.height).toBeGreaterThan(
+          measurement.postVisibleInteractionResult?.afterWindowRect?.height ?? 0,
+        );
+        expect(measurement.postVisibleInteractionResult?.beforeClientHeight).toBeGreaterThan(
+          measurement.postVisibleInteractionResult?.afterClientHeight ?? 0,
+        );
+      }
+      expect(
+        Math.max(
+          0,
+          (measurement.postVisibleInteractionResult?.maxScrollTop ?? 0) -
+            (measurement.postVisibleInteractionResult?.afterScrollTop ?? 0),
+        ),
+      ).toBeLessThanOrEqual(LONG_SESSION_PHYSICAL_BOTTOM_TOLERANCE_PX);
+      expect(getLongSessionPhysicalDistanceFromBottom(measurement.viewport))
+        .toBeLessThanOrEqual(LONG_SESSION_PHYSICAL_BOTTOM_TOLERANCE_PX);
+      const resizeTransitions = measurement.visualStateSummary.scrollTransitions.filter(transition =>
+        measurement.visualStateSummary.firstUserInteractionAtMs !== null &&
+        transition.sinceClickMs > measurement.visualStateSummary.firstUserInteractionAtMs
+      );
+      for (const transition of resizeTransitions) {
+        const toDistanceFromBottom = getLongSessionScrollTransitionDistanceFromBottom(transition, 'to');
+        if (toDistanceFromBottom === null || toDistanceFromBottom <= LONG_SESSION_PHYSICAL_BOTTOM_TOLERANCE_PX) {
+          continue;
+        }
+        const settledTransition = resizeTransitions.find(candidate =>
+          candidate.sinceClickMs > transition.sinceClickMs &&
+          candidate.sinceClickMs - transition.sinceClickMs <= LONG_SESSION_RESIZE_BOTTOM_SETTLE_MAX_MS &&
+          (getLongSessionScrollTransitionDistanceFromBottom(candidate, 'to') ?? Number.POSITIVE_INFINITY) <=
+            LONG_SESSION_PHYSICAL_BOTTOM_TOLERANCE_PX
+        );
+        expect(settledTransition).toBeDefined();
+      }
+      expect(measurement.visualStateSummary.postUserInteractionBlankSurfacePointEventCount).toBe(0);
+    }
   }
   if (measurement.fixtureScenario === 'mixed-visible') {
     expect(measurement.latestVisibleViewport.visibleModelRoundCount).toBeGreaterThan(0);
@@ -4028,7 +4347,11 @@ function expectLongSessionMeasurementUsable(
   expect(isLongSessionInputAnchoredNearBottom(measurement.latestVisibleViewport)).toBe(true);
   expect(isLongSessionViewportUsable(measurement.viewport, { requireLatestModelRound })).toBe(true);
   expect(isLongSessionInputAnchoredNearBottom(measurement.viewport)).toBe(true);
-  expect(isLongSessionLatestTailAnchored(measurement.viewport)).toBe(true);
+  if (measurement.postVisibleInteraction !== 'first-scroll') {
+    expect(isLongSessionLatestTailAnchored(measurement.viewport)).toBe(true);
+    expect(getLongSessionPhysicalDistanceFromBottom(measurement.viewport))
+      .toBeLessThanOrEqual(LONG_SESSION_PHYSICAL_BOTTOM_TOLERANCE_PX);
+  }
   if (
     maxLatestFrameMs !== undefined &&
     measurement.sessionOpen.latestFrameSinceHydrateMs !== undefined


### PR DESCRIPTION
﻿## Summary
- Preserve the physical bottom anchor when a long historical session is first opened and the app window is resized.
- Cover both height resize and width-only resize, because width-only wrapping can change `scrollHeight` without changing `clientHeight`.
- Add E2E post-visible interaction guards for resize, width-only resize, first upward scroll, and downward scroll while already at the bottom.

## Behavior and Scope
- This PR does not change session ordering, close semantics, history hydration policy, or startup scheduling.
- The bottom correction only applies when the previous scroller geometry was already at the physical bottom.
- User upward intent from wheel, touch, keyboard, or scrollbar interaction cancels the short initial bottom guard, so reading history should not be pulled back to the bottom.
- This PR does not claim a cold-start or session-open latency improvement; it is a UX correctness fix plus regression coverage for long-session viewport stability.

## Verification
| Check | Result |
| --- | --- |
| `pnpm run lint:web` | Passed locally; one existing `prefer-const` warning remains outside this diff |
| `pnpm run type-check:web` | Passed |
| `pnpm run desktop:build:release-fast` | Passed; rebuilt the release-fast desktop binary after rebasing onto latest `main` |
| E2E `BITFUN_E2E_PERF_POST_VISIBLE_INTERACTION=resize-window` | Passed: startup, first-open long session, warm reopen, rapid switch all passed |
| E2E `BITFUN_E2E_PERF_POST_VISIBLE_INTERACTION=resize-window-width` | Passed: startup, first-open long session, warm reopen, rapid switch all passed |
| E2E `BITFUN_E2E_PERF_POST_VISIBLE_INTERACTION=scroll-down` | Passed: startup, first-open long session, warm reopen, rapid switch all passed |
| E2E `BITFUN_E2E_PERF_POST_VISIBLE_INTERACTION=first-scroll` | Passed: startup, first-open long session, warm reopen, rapid switch all passed |
| Residual process check | No `bitfun-desktop` process remained after E2E runs |

## Review Notes
- Added no runtime console/logger/telemetry output.
- The initial static-history bottom guard is bounded and cleaned up on session/scroller changes.
- Remaining risk: while the user stays at the physical bottom, viewport resize or wrapping changes intentionally snap to the new bottom; this is the desired behavior for latest-content anchoring but is still guarded by explicit user upward-intent handling.
