### PR TITLE
fix(flow-chat): prevent stale history projection handoff

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -5,6 +5,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { VirtualMessageList } from './VirtualMessageList';
+import { activeSessionHistoryProjectionHandoff } from './historyProjectionHandoff';
 import type { Session } from '../../types/flow-chat';
 import type { VirtualItem } from '../../store/modernFlowChatStore';
 
@@ -206,5 +207,27 @@ describe('VirtualMessageList session boundary', () => {
     });
 
     expect(container.querySelector('[data-testid="scroll-to-latest"]')?.getAttribute('data-visible')).toBe('false');
+  });
+
+  it('does not expose stale history projection handoff snapshots across sessions', () => {
+    const snapshot = {
+      sessionId: 'session-a',
+      reason: 'session-open',
+      createdAtMs: 1,
+      items: [createItem('turn-a')],
+      mode: 'bottom-tail',
+      targetTurnId: 'turn-a',
+      anchorKey: null,
+      anchorOffsetTopPx: 0,
+      scrollTop: 0,
+      scrollHeight: 100,
+      clientHeight: 100,
+      footerHeightPx: 0,
+    } as const;
+
+    expect(activeSessionHistoryProjectionHandoff(snapshot, 'session-a')).toBe(snapshot);
+    expect(activeSessionHistoryProjectionHandoff(snapshot, 'session-b')).toBeNull();
+    expect(activeSessionHistoryProjectionHandoff(snapshot, null)).toBeNull();
+    expect(activeSessionHistoryProjectionHandoff(null, 'session-a')).toBeNull();
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -46,6 +46,10 @@ import {
   mapInitialHistoryExpansionScrollTop,
   selectInitialHistoryRenderWindow,
 } from './virtualMessageListLayout';
+import {
+  activeSessionHistoryProjectionHandoff,
+  type HistoryProjectionHandoffSnapshot,
+} from './historyProjectionHandoff';
 import './VirtualMessageList.scss';
 
 const COMPENSATION_EPSILON_PX = 0.5;
@@ -122,21 +126,6 @@ interface LatestEndAnchorRequestState {
   lastScrollTop: number | null;
   lastTargetTop: number | null;
   lastTargetBottom: number | null;
-}
-
-interface HistoryProjectionHandoffSnapshot {
-  sessionId: string;
-  reason: string;
-  createdAtMs: number;
-  items: VirtualItem[];
-  mode: 'scroll-position' | 'bottom-tail';
-  targetTurnId: string | null;
-  anchorKey: string | null;
-  anchorOffsetTopPx: number;
-  scrollTop: number;
-  scrollHeight: number;
-  clientHeight: number;
-  footerHeightPx: number;
 }
 
 type BottomReservationKind = 'collapse' | 'pin';
@@ -3941,7 +3930,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
   useLayoutEffect(() => {
     previousActiveSessionIdForOpenHandoffRef.current = activeSessionId;
   }, [activeSessionId]);
-  const activeHistoryProjectionHandoff = historyProjectionHandoff ?? sessionOpenProjectionHandoff;
+  const activeHistoryProjectionHandoff =
+    activeSessionHistoryProjectionHandoff(historyProjectionHandoff, activeSessionId) ??
+    activeSessionHistoryProjectionHandoff(sessionOpenProjectionHandoff, activeSessionId);
   const hasCompactHistoricalProjection = virtualItems.length >= 6 && virtualItems
     .slice(-16)
     .every(item =>

--- a/src/web-ui/src/flow_chat/components/modern/historyProjectionHandoff.ts
+++ b/src/web-ui/src/flow_chat/components/modern/historyProjectionHandoff.ts
@@ -1,0 +1,23 @@
+import type { VirtualItem } from '../../store/modernFlowChatStore';
+
+export interface HistoryProjectionHandoffSnapshot {
+  sessionId: string;
+  reason: string;
+  createdAtMs: number;
+  items: VirtualItem[];
+  mode: 'scroll-position' | 'bottom-tail';
+  targetTurnId: string | null;
+  anchorKey: string | null;
+  anchorOffsetTopPx: number;
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  footerHeightPx: number;
+}
+
+export function activeSessionHistoryProjectionHandoff(
+  snapshot: HistoryProjectionHandoffSnapshot | null,
+  activeSessionId: string | null
+): HistoryProjectionHandoffSnapshot | null {
+  return snapshot?.sessionId === activeSessionId ? snapshot : null;
+}


### PR DESCRIPTION
## Summary
- Guard history projection handoff snapshots so they only render for the currently active session.
- Move the handoff snapshot helper into a non-component module so `VirtualMessageList.tsx` remains Fast Refresh compatible.
- Add a session-boundary test that rejects stale projection snapshots from a previous session.

## Root cause
During rapid historical-session switches, `historyProjectionHandoff` could still contain the previous session snapshot for one render before the cleanup layout effect ran. That allowed the old session projection to be considered active while the new session was being opened.

## User impact
This prevents brief stale-session content from being exposed during fast A/B/C session switching. It does not change loading strategy, history hydration timing, logging, or product behavior outside the handoff guard.

## Performance impact
This PR should be treated as a correctness fix, not a performance improvement. Release-fast E2E showed the visual guards remained clean, but the normal timing sample did not show an end-to-end performance win, so no performance benefit is claimed here.

## Validation
- `pnpm run lint:web` (passes; existing unrelated `FlowChatManager.ts prefer-const` warning remains)
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx`
- `pnpm --dir tests/e2e run test:perf` with `BITFUN_E2E_PERF_RAPID_SWITCH_DELAY_MS=0`
- `pnpm --dir tests/e2e run test:perf` with default delay
- `git diff --check`