### PR TITLE
perf(acp): skip npm adapter probe when npx is available

### DIFF
--- a/src/crates/interfaces/acp/src/client/requirements.rs
+++ b/src/crates/interfaces/acp/src/client/requirements.rs
@@ -82,7 +82,14 @@ pub(crate) async fn probe_executable(command: &str) -> AcpRequirementProbeItem {
 }
 
 pub(crate) async fn probe_npm_adapter(package: &str, bin: &str) -> AcpRequirementProbeItem {
-    let npm_path = find_executable("npm");
+    probe_npm_adapter_with_path(package, bin, None).await
+}
+
+async fn probe_npm_adapter_with_path(
+    package: &str,
+    bin: &str,
+    configured_path: Option<&OsStr>,
+) -> AcpRequirementProbeItem {
     let mut item = AcpRequirementProbeItem {
         name: package.to_string(),
         installed: false,
@@ -90,8 +97,13 @@ pub(crate) async fn probe_npm_adapter(package: &str, bin: &str) -> AcpRequiremen
         path: None,
         error: None,
     };
+    if find_executable_with_path("npx", configured_path).is_some() {
+        return npx_adapter_probe_item(package);
+    }
+
+    let npm_path = find_executable_with_path("npm", configured_path);
     let Some(npm_path) = npm_path else {
-        item.error = Some("npm is not available on PATH".to_string());
+        item.error = Some("npm and npx are not available on PATH".to_string());
         return item;
     };
 
@@ -144,13 +156,17 @@ pub(crate) async fn probe_npm_adapter(package: &str, bin: &str) -> AcpRequiremen
         }
     }
 
-    if find_executable("npx").is_some() {
-        item.installed = true;
-        item.path = Some("npx auto-install".to_string());
-        item.error = None;
-    }
-
     item
+}
+
+fn npx_adapter_probe_item(package: &str) -> AcpRequirementProbeItem {
+    AcpRequirementProbeItem {
+        name: package.to_string(),
+        installed: true,
+        version: None,
+        path: Some("npx auto-install".to_string()),
+        error: None,
+    }
 }
 
 pub(crate) async fn probe_remote_executable(
@@ -644,6 +660,41 @@ mod tests {
     }
 
     #[test]
+    fn npx_adapter_probe_item_marks_auto_install_available() {
+        let item = npx_adapter_probe_item("@zed-industries/codex-acp");
+
+        assert_eq!(item.name, "@zed-industries/codex-acp");
+        assert!(item.installed);
+        assert_eq!(item.path.as_deref(), Some("npx auto-install"));
+        assert!(item.error.is_none());
+    }
+
+    #[test]
+    fn probe_npm_adapter_skips_npm_probe_when_npx_is_available() {
+        let test_dir = env::temp_dir().join(format!("bitfun-acp-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&test_dir).expect("test dir should be created");
+        let npm_marker = test_dir.join("npm-was-run");
+
+        write_command_stub(&test_dir, "npx", "");
+        write_command_stub(&test_dir, "npm", &npm_probe_marker_script(&npm_marker));
+
+        let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should be created");
+        let item = runtime.block_on(probe_npm_adapter_with_path(
+            "@zed-industries/codex-acp",
+            "codex-acp",
+            Some(test_dir.as_os_str()),
+        ));
+
+        assert!(item.installed);
+        assert_eq!(item.path.as_deref(), Some("npx auto-install"));
+        assert!(
+            !npm_marker.exists(),
+            "npm probe should not run when npx can launch the adapter"
+        );
+        let _ = std::fs::remove_dir_all(&test_dir);
+    }
+
+    #[test]
     fn remote_env_prefix_uses_valid_keys_in_stable_order() {
         let env = HashMap::from([
             ("INVALID-NAME".to_string(), "ignored".to_string()),
@@ -655,5 +706,44 @@ mod tests {
             render_remote_env_prefix(Some(&env)),
             "ACP_HOME='/tmp/acp home' PATH=/remote/bin:/usr/bin "
         );
+    }
+
+    fn write_command_stub(directory: &Path, command: &str, body: &str) -> PathBuf {
+        #[cfg(windows)]
+        let path = directory.join(format!("{command}.cmd"));
+        #[cfg(not(windows))]
+        let path = directory.join(command);
+
+        std::fs::write(&path, body).expect("command stub should be written");
+
+        #[cfg(not(windows))]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&path)
+                .expect("command stub metadata should be readable")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&path, permissions)
+                .expect("command stub should be executable");
+        }
+
+        path
+    }
+
+    fn npm_probe_marker_script(marker_path: &Path) -> String {
+        #[cfg(windows)]
+        {
+            format!(
+                "@echo off\r\necho called > \"{}\"\r\nexit /b 42\r\n",
+                marker_path.display()
+            )
+        }
+        #[cfg(not(windows))]
+        {
+            format!(
+                "#!/bin/sh\necho called > '{}'\nexit 42\n",
+                marker_path.display()
+            )
+        }
     }
 }


### PR DESCRIPTION
## 变更

- 本地内置 ACP adapter 的 requirement probe 在发现 `npx` 可用时直接判定 adapter 可通过 `npx --yes <package>@latest` 启动。
- 仅在 `npx` 不可用时，才回退到原有 `npm ls -g` 和 `npm exec --offline` 探测路径。
- 补充单元测试，覆盖 `npx` 可用时不会继续触发 npm probe，防止该性能优化被后续改动回退。
- 保持 remote ACP probe 逻辑不变；不新增日志、telemetry 或启动/session 调度逻辑。

Refs #949

## 性能数据

测试环境：Windows desktop `release-fast` 性能 E2E。修改前样本为同日变更前 release-fast 报告；修改后样本为当前分支最终实现报告。以下数据使用平均值，括号内为样本数。

| 用户/系统场景 | 修改前 | 修改后 | 变化 | 结论 |
| --- | ---: | ---: | ---: | --- |
| 首屏后 ACP requirement probe 完成耗时 | 12878.8 ms (n=2) | 1733.0 ms (n=5) | -11145.8 ms / -86.5% | 直接收益，移除有 `npx` 时最多两段 npm 探测等待 |
| 非关键初始化完成时间 | 2166.6 ms (n=2) | 2154.6 ms (n=3) | -12.0 ms | 基本持平，不声明冷启动收益 |
| 冷启动到 shell 可交互 | 640.8 ms (n=2) | 762.8 ms avg / 639.7 ms median (n=3) | avg +122.0 ms | 存在 1 次 pre-ACP webview/firstScript outlier；本 PR 不解决也不声明冷启动收益 |
| 首次打开默认大历史 session，最新正文可读 | 394.3 ms (n=2) | 315.4 ms (n=4) | -78.9 ms | guardrail 未见劣化；该路径非本 PR 直接归因 |
| 三 session 快速切换目标 session 最新正文可用 | 498.0 ms (n=2) | 418.3 ms (n=5) | -79.7 ms | guardrail 未见劣化；该路径非本 PR 直接归因 |
| 长 session 内容可见后 loading 闪回事件 | 0 (n=2) | 0 (n=5) | 0 | 未引入 loading 回闪 |

样本报告文件：
- 修改前：`startup-2026-06-11T02-09/02-10*`、`long-session-*-2026-06-11T02-09/02-10*`
- 修改后：`startup-2026-06-11T02-58/03-12/03-31*`、`long-session-*-2026-06-11T02-57/02-58/03-12/03-17/03-31*`

## 风险和功能影响

- 有 `npx` 时 adapter 来源会显示为 `npx auto-install`，不再为了展示 npm global/offline cache 的版本或来源信息阻塞 requirement probe；可运行性判定与默认启动命令保持一致。
- 如果用户环境有 `npx` 但首次运行 package 需要网络，真实启动仍可能受网络或 npm cache 影响；这是既有 `npx --yes <package>@latest` 启动语义，本 PR 不改变。
- `npx` 不存在时保留原有 npm global/offline cache 回退，因此不降低仅有 npm cache 的离线场景。
- 本 PR 不改 remote ACP 探测，避免 remote shell/兼容性语义漂移。

## 验证

- `git diff --check gcwing/main...HEAD`
- `cargo test -p bitfun-acp`：51 passed
- `pnpm run desktop:build:release-fast`
- `pnpm --dir tests/e2e run test:perf`