### PR TITLE
perf(session): reduce long session switch contention

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -64,6 +64,7 @@ import './SessionsSection.scss';
 const log = createLogger('SessionsSection');
 
 type SessionMode = 'code' | 'cowork' | 'claw';
+type HistoryOpenIntentDispatchResult = 'none' | 'dispatched' | 'already-pending';
 
 const escapeRegExp = (value: string): string =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -77,18 +78,6 @@ const resolveSessionModeType = (session: Session): SessionMode => {
 
 const getTitle = (session: Session): string =>
   resolveSessionTitle(session, (key, options) => i18nService.t(key, options));
-
-const waitForHistoryOpenIntentPaint = (): Promise<void> =>
-  new Promise(resolve => {
-    if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
-      globalThis.setTimeout(resolve, 0);
-      return;
-    }
-
-    window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => resolve());
-    });
-  });
 
 const countTopLevelSessionsInScope = (
   sessions: Iterable<Session>,
@@ -595,13 +584,13 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   const lastHistoryOpenIntentRef = useRef<{ sessionId: string; atMs: number } | null>(null);
 
   const dispatchHistoryOpenIntentForSession = useCallback(
-    (session: Session): boolean => {
+    (session: Session): HistoryOpenIntentDispatchResult => {
       const sessionId = session.sessionId;
       if (
         sessionId === activeSessionId ||
         !shouldShowHistorySessionOpenIntent(session)
       ) {
-        return false;
+        return 'none';
       }
 
       const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
@@ -611,12 +600,12 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
         lastIntent.sessionId === sessionId &&
         now - lastIntent.atMs < 250
       ) {
-        return true;
+        return 'already-pending';
       }
 
       lastHistoryOpenIntentRef.current = { sessionId, atMs: now };
       dispatchHistorySessionOpenIntent(sessionId, getTitle(session));
-      return true;
+      return 'dispatched';
     },
     [activeSessionId],
   );
@@ -626,13 +615,11 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
       if (editingSessionId) return;
       try {
         const session = flowChatStore.getState().sessions.get(sessionId);
-        const historyOpenIntentDispatched = session
+        const historyOpenIntentDispatch = session
           ? dispatchHistoryOpenIntentForSession(session)
-          : false;
-        if (session) {
-          if (historyOpenIntentDispatched) {
-            await waitForHistoryOpenIntentPaint();
-          }
+          : 'none';
+        if (session && historyOpenIntentDispatch !== 'none') {
+          flowChatManager.preloadHistoricalSessionForOpen(sessionId);
         }
         const relationship = resolveSessionRelationship(session);
         const parentSessionId = relationship.parentSessionId;
@@ -691,13 +678,19 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
       if (editingSessionId || session.sessionId === activeSessionId) {
         return;
       }
+      if (event.button !== 0) {
+        return;
+      }
 
       const target = event.target as HTMLElement | null;
       if (target?.closest('.bitfun-nav-panel__inline-item-actions, .bitfun-nav-panel__inline-item-edit')) {
         return;
       }
 
-      dispatchHistoryOpenIntentForSession(session);
+      const historyOpenIntentDispatch = dispatchHistoryOpenIntentForSession(session);
+      if (historyOpenIntentDispatch !== 'none') {
+        flowChatManager.preloadHistoricalSessionForOpen(session.sessionId);
+      }
     },
     [activeSessionId, dispatchHistoryOpenIntentForSession, editingSessionId],
   );

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 import { Folder, FolderOpen, MoreHorizontal, FolderSearch, Plus, ChevronDown, Trash2, RotateCcw, Copy, FileText, GitBranch, Bot, Link2, ListChecks, Loader2, Clock3 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -14,11 +14,16 @@ import {
 import { useNavSceneStore } from '@/app/stores/navSceneStore';
 import { useApp } from '@/app/hooks/useApp';
 import { useGitBasicInfo } from '@/tools/git/hooks/useGitState';
+import { gitStateManager } from '@/tools/git/state/GitStateManager';
 import { workspaceAPI } from '@/infrastructure/api';
 import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
 import { notificationService } from '@/shared/notification-system';
 import { flowChatManager } from '@/flow_chat/services/FlowChatManager';
 import { openMainSession } from '@/flow_chat/services/openBtwSession';
+import {
+  getHistorySessionOpenTransitionSnapshot,
+  subscribeHistorySessionOpenTransition,
+} from '@/flow_chat/services/sessionOpenIntent';
 import { findReusableEmptySessionId } from '@/app/utils/projectSessionWorkspace';
 import type { AcpClientInfo } from '@/infrastructure/api/service-api/ACPClientAPI';
 import { loadWorkspaceAcpMenuClients } from './workspaceAcpMenuClients';
@@ -36,7 +41,12 @@ import { computeFixedPopoverPosition } from '@/shared/utils/fixedPopoverViewport
 import WorkspaceRelatedPathsDialog from './WorkspaceRelatedPathsDialog';
 import WorkspaceSessionBatchModal from './WorkspaceSessionBatchModal';
 import { scheduleAfterStartupSignal } from '@/shared/utils/startupTaskScheduling';
-import { getWorkspaceGitBasicInfoOptions } from './workspaceGitRefreshOptions';
+import {
+  getWorkspaceGitBasicInfoOptions,
+  suppressWorkspaceGitRefreshOnMountDuringSessionTransition,
+  WORKSPACE_GIT_PENDING_CANCEL_REASONS,
+  WORKSPACE_GIT_PENDING_CANCEL_SOURCES,
+} from './workspaceGitRefreshOptions';
 import ScheduledJobsModal from '@/app/components/scheduled-jobs/ScheduledJobsModal';
 
 
@@ -77,6 +87,15 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
   } = useWorkspaceContext();
   const { switchLeftPanelTab } = useApp();
   const openNavScene = useNavSceneStore(s => s.openNavScene);
+  const historySessionOpenTransition = useSyncExternalStore(
+    subscribeHistorySessionOpenTransition,
+    getHistorySessionOpenTransitionSnapshot,
+    getHistorySessionOpenTransitionSnapshot
+  );
+  const gitBasicInfoOptions = suppressWorkspaceGitRefreshOnMountDuringSessionTransition(
+    getWorkspaceGitBasicInfoOptions(workspace, isActive),
+    historySessionOpenTransition !== null
+  );
   const {
     isRepository,
     isLoading: isGitBasicInfoLoading,
@@ -84,7 +103,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
     refreshBasic: refreshGitBasicInfo,
   } = useGitBasicInfo(
     workspace.rootPath,
-    getWorkspaceGitBasicInfoOptions(workspace, isActive)
+    gitBasicInfoOptions
   );
   const [menuOpen, setMenuOpen] = useState(false);
   const [worktreeModalOpen, setWorktreeModalOpen] = useState(false);
@@ -121,6 +140,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
       : workspace.name;
   const isLinkedWorktree = isLinkedWorktreeWorkspace(workspace);
   const relatedPathCount = workspace.relatedPaths?.length ?? 0;
+  const workspaceIsRemote = isRemoteWorkspace(workspace);
   const canShowSearchIndex =
     isActive
     && workspaceSearchEnabled
@@ -130,7 +150,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
     );
   const shouldRefreshGitBasicInfoOnMenuOpen =
     !isActive &&
-    !isRemoteWorkspace(workspace) &&
+    !workspaceIsRemote &&
     !gitBasicInfoState &&
     !isGitBasicInfoLoading;
   const isWorktreeActionDisabled = isGitBasicInfoLoading || !isRepository;
@@ -138,6 +158,31 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
     workspacePath: canShowSearchIndex ? workspace.rootPath : undefined,
     enabled: canShowSearchIndex,
   });
+
+  useEffect(() => {
+    if (!isActive || workspaceIsRemote) {
+      return;
+    }
+
+    const cancelPendingAutoGitRefresh = () => {
+      if (getHistorySessionOpenTransitionSnapshot() === null) {
+        return;
+      }
+
+      for (const reason of WORKSPACE_GIT_PENDING_CANCEL_REASONS) {
+        for (const source of WORKSPACE_GIT_PENDING_CANCEL_SOURCES) {
+          gitStateManager.cancelPendingRefresh(workspace.rootPath, {
+            layers: ['basic'],
+            reason,
+            source,
+          });
+        }
+      }
+    };
+
+    cancelPendingAutoGitRefresh();
+    return subscribeHistorySessionOpenTransition(cancelPendingAutoGitRefresh);
+  }, [isActive, workspace.rootPath, workspaceIsRemote]);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/workspaceGitRefreshOptions.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/workspaceGitRefreshOptions.test.ts
@@ -4,7 +4,12 @@ import {
   WorkspaceType,
   type WorkspaceInfo,
 } from '@/shared/types/global-state';
-import { getWorkspaceGitBasicInfoOptions } from './workspaceGitRefreshOptions';
+import {
+  getWorkspaceGitBasicInfoOptions,
+  suppressWorkspaceGitRefreshOnMountDuringSessionTransition,
+  WORKSPACE_GIT_PENDING_CANCEL_REASONS,
+  WORKSPACE_GIT_PENDING_CANCEL_SOURCES,
+} from './workspaceGitRefreshOptions';
 
 const createWorkspace = (workspaceKind: WorkspaceKind): WorkspaceInfo => ({
   id: `${workspaceKind}-workspace`,
@@ -25,6 +30,14 @@ const createWorkspace = (workspaceKind: WorkspaceKind): WorkspaceInfo => ({
 });
 
 describe('getWorkspaceGitBasicInfoOptions', () => {
+  it('limits history-transition cancellation to passive workspace git auto refreshes', () => {
+    expect(WORKSPACE_GIT_PENDING_CANCEL_REASONS).toEqual(['mount', 'visibility']);
+    expect(WORKSPACE_GIT_PENDING_CANCEL_SOURCES).toEqual([
+      'workspace_item_git_basic_info',
+      'workspace_git_initializer',
+    ]);
+  });
+
   it('refreshes active local workspace rows on mount', () => {
     expect(getWorkspaceGitBasicInfoOptions(createWorkspace(WorkspaceKind.Normal), true))
       .toEqual({
@@ -32,6 +45,8 @@ describe('getWorkspaceGitBasicInfoOptions', () => {
         refreshOnMount: true,
         refreshOnActive: true,
         participateInWindowFocusRefresh: false,
+        debugSource: 'workspace_item_git_basic_info',
+        cancelPendingRefreshSources: ['workspace_git_initializer'],
       });
   });
 
@@ -42,11 +57,34 @@ describe('getWorkspaceGitBasicInfoOptions', () => {
         refreshOnMount: false,
         refreshOnActive: true,
         participateInWindowFocusRefresh: false,
+        debugSource: 'workspace_item_git_basic_info',
+        cancelPendingRefreshSources: ['workspace_git_initializer'],
       });
   });
 
   it('keeps remote workspace rows on the existing default git refresh behavior', () => {
     expect(getWorkspaceGitBasicInfoOptions(createWorkspace(WorkspaceKind.Remote), false))
       .toBeUndefined();
+  });
+
+  it('suppresses only mount refresh during a history session transition', () => {
+    const options = getWorkspaceGitBasicInfoOptions(createWorkspace(WorkspaceKind.Normal), true);
+
+    expect(suppressWorkspaceGitRefreshOnMountDuringSessionTransition(options, true))
+      .toEqual({
+        isActive: true,
+        refreshOnMount: false,
+        refreshOnActive: true,
+        participateInWindowFocusRefresh: false,
+        debugSource: 'workspace_item_git_basic_info',
+        cancelPendingRefreshSources: ['workspace_git_initializer'],
+      });
+  });
+
+  it('does not allocate replacement options outside history session transitions', () => {
+    const options = getWorkspaceGitBasicInfoOptions(createWorkspace(WorkspaceKind.Normal), true);
+
+    expect(suppressWorkspaceGitRefreshOnMountDuringSessionTransition(options, false))
+      .toBe(options);
   });
 });

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/workspaceGitRefreshOptions.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/workspaceGitRefreshOptions.ts
@@ -1,6 +1,14 @@
 import { isRemoteWorkspace, type WorkspaceInfo } from '@/shared/types';
 import type { GitBasicInfoOptions } from '@/tools/git/hooks/useGitState';
 
+export const WORKSPACE_GIT_BASIC_INFO_SOURCE = 'workspace_item_git_basic_info';
+const WORKSPACE_GIT_AUTO_REFRESH_SOURCES = ['workspace_git_initializer'];
+export const WORKSPACE_GIT_PENDING_CANCEL_SOURCES = [
+  WORKSPACE_GIT_BASIC_INFO_SOURCE,
+  ...WORKSPACE_GIT_AUTO_REFRESH_SOURCES,
+] as const;
+export const WORKSPACE_GIT_PENDING_CANCEL_REASONS = ['mount', 'visibility'] as const;
+
 export function getWorkspaceGitBasicInfoOptions(
   workspace: WorkspaceInfo,
   isActive: boolean
@@ -14,5 +22,21 @@ export function getWorkspaceGitBasicInfoOptions(
     refreshOnMount: isActive,
     refreshOnActive: true,
     participateInWindowFocusRefresh: false,
+    debugSource: WORKSPACE_GIT_BASIC_INFO_SOURCE,
+    cancelPendingRefreshSources: WORKSPACE_GIT_AUTO_REFRESH_SOURCES,
+  };
+}
+
+export function suppressWorkspaceGitRefreshOnMountDuringSessionTransition(
+  options: GitBasicInfoOptions | undefined,
+  transitionActive: boolean
+): GitBasicInfoOptions | undefined {
+  if (!options || !transitionActive) {
+    return options;
+  }
+
+  return {
+    ...options,
+    refreshOnMount: false,
   };
 }

--- a/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
+++ b/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
@@ -234,6 +234,66 @@ describe('startup performance contract', () => {
     expect(getSource).not.toContain('restore_session');
   });
 
+  it('defers passive historical thread-goal refresh without delaying explicit goal entry', () => {
+    const source = readSource('../../flow_chat/hooks/useThreadGoalController.ts');
+    const passiveRefreshEffectStart = source.indexOf('if (session?.isHistorical)');
+    const openGoalEntryStart = source.indexOf('const openGoalEntry = useCallback');
+
+    expect(passiveRefreshEffectStart).toBeGreaterThan(-1);
+    expect(source).toContain('HISTORICAL_THREAD_GOAL_REFRESH_DELAY_MS');
+    expect(source).toContain('globalThis.setTimeout(() => {');
+    expect(source).toContain('globalThis.clearTimeout(timeoutId)');
+    expect(openGoalEntryStart).toBeGreaterThan(passiveRefreshEffectStart);
+    expect(source.slice(openGoalEntryStart)).toContain('await fetchSessionThreadGoal(session)');
+  });
+
+  it('uses the history open intent as a strict before-hydrate activation gate without adding a second paint wait', () => {
+    const source = readSource('../../app/components/NavPanel/sections/sessions/SessionsSection.tsx');
+    const sessionModuleSource = readSource('../../flow_chat/services/flow-chat-manager/SessionModule.ts');
+    const intentSource = readSource('../../flow_chat/services/sessionOpenIntent.ts');
+    const dispatchResultStart = source.indexOf("type HistoryOpenIntentDispatchResult = 'none' | 'dispatched' | 'already-pending'");
+    const duplicateIntentStart = source.indexOf("return 'already-pending'");
+    const switchStart = source.indexOf('const handleSwitch = useCallback');
+    const pointerDownStart = source.indexOf('const handleSessionOpenPointerDown = useCallback');
+    const beforeHydrateStart = sessionModuleSource.indexOf("activation: 'before-hydrate'");
+    const hydrateBeforeSwitchStart = sessionModuleSource.indexOf('if (shouldHydrateBeforeSwitch)');
+
+    expect(dispatchResultStart).toBeGreaterThan(-1);
+    expect(duplicateIntentStart).toBeGreaterThan(dispatchResultStart);
+    expect(source).toContain("historyOpenIntentDispatch !== 'none'");
+    expect(source).not.toContain('if (historyOpenIntentDispatched)');
+    expect(pointerDownStart).toBeGreaterThan(switchStart);
+    expect(source.slice(pointerDownStart)).toContain('dispatchHistoryOpenIntentForSession(session)');
+    expect(intentSource).toContain('RECENT_HISTORY_OPEN_INTENT_MS');
+    expect(intentSource).toContain('HISTORY_SESSION_OPEN_TRANSITION_MAX_MS');
+    expect(intentSource).toContain('subscribeHistorySessionOpenTransition');
+    expect(sessionModuleSource).toContain('consumeRecentHistorySessionOpenIntent(sessionId)');
+    expect(beforeHydrateStart).toBeGreaterThan(-1);
+    expect(hydrateBeforeSwitchStart).toBeGreaterThan(-1);
+    expect(beforeHydrateStart).toBeLessThan(hydrateBeforeSwitchStart);
+    expect(sessionModuleSource).toContain("shouldHydrateBeforeSwitch ? 'after-hydrate' : 'immediate'");
+  });
+
+  it('keeps passive chat Git refresh out of the history open transition window', () => {
+    const chatInputSource = readSource('../../flow_chat/components/ChatInput.tsx');
+    const fileCardSource = readSource('../../flow_chat/tool-cards/FileOperationToolCard.tsx');
+    const workspaceItemSource = readSource('../../app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx');
+
+    expect(chatInputSource).toContain('useSyncExternalStore');
+    expect(chatInputSource).toContain('getHistorySessionOpenTransitionSnapshot');
+    expect(chatInputSource).toContain('deferChatStripPassiveGitRefresh');
+    expect(chatInputSource).toContain('historySessionOpenTransition !== null');
+    expect(fileCardSource).toContain('getHistorySessionOpenTransitionSnapshot');
+    expect(fileCardSource).toContain('historySessionOpenTransition === null');
+    expect(fileCardSource).toContain("displayContext !== 'subagent-projection'");
+    expect(workspaceItemSource).toContain('getHistorySessionOpenTransitionSnapshot');
+    expect(workspaceItemSource).toContain('suppressWorkspaceGitRefreshOnMountDuringSessionTransition');
+    expect(workspaceItemSource).toContain('subscribeHistorySessionOpenTransition');
+    expect(workspaceItemSource).toContain('WORKSPACE_GIT_PENDING_CANCEL_SOURCES');
+    expect(workspaceItemSource).toContain('cancelPendingRefresh');
+    expect(workspaceItemSource).toContain('historySessionOpenTransition !== null');
+  });
+
   it('keeps non-active workspace session metadata out of the first startup window', () => {
     const source = readSource('../../app/components/NavPanel/sections/sessions/SessionsSection.tsx');
 
@@ -271,6 +331,14 @@ describe('startup performance contract', () => {
     for (const source of sources) {
       expect(source).not.toMatch(/from\s+['"]@\/shared\/context-menu-system['"]/);
     }
+  });
+
+  it('keeps markdown content rendering off the components i18n subscription path', () => {
+    const source = readSource('../../component-library/components/Markdown/Markdown.tsx');
+
+    expect(source).not.toContain("useI18n('components')");
+    expect(source).not.toContain('useI18n("components")');
+    expect(source).toContain("import { i18nService } from '@/infrastructure/i18n'");
   });
 
   it('avoids the infrastructure barrel from startup-visible modules', () => {

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.test.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.test.tsx
@@ -26,9 +26,9 @@ vi.mock('../../../infrastructure/api', () => ({
 }));
 
 vi.mock('@/infrastructure/i18n', () => ({
-  useI18n: () => ({
+  i18nService: {
     t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
-  }),
+  },
 }));
 
 vi.mock('@/infrastructure/theme', () => ({
@@ -100,6 +100,21 @@ describe('Markdown file links', () => {
     });
     container.remove();
     vi.clearAllMocks();
+  });
+
+  it('does not resolve workspace path for markdown without local file links', async () => {
+    await act(async () => {
+      root.render(
+        <Markdown
+          content={'Plain answer without file links.\n\n```ts\nconst value = 1;\n```'}
+          onFileViewRequest={onFileViewRequest}
+        />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.getCurrentWorkspacePath).not.toHaveBeenCalled();
   });
 
   it('routes same-label relative, absolute, and computer links independently', async () => {

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
@@ -11,7 +11,7 @@ import rehypeKatex from 'rehype-katex';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import { visit } from 'unist-util-visit';
-import { useI18n } from '@/infrastructure/i18n';
+import { i18nService } from '@/infrastructure/i18n';
 import { MermaidBlock } from './MermaidBlock';
 import { ReproductionStepsBlock } from './ReproductionStepsBlock';
 import { AsyncPrismSyntaxHighlighter } from './AsyncPrismSyntaxHighlighter';
@@ -34,6 +34,8 @@ import './Markdown.scss';
 
 const log = createLogger('Markdown');
 const COMPUTER_LINK_PREFIX = 'computer://';
+const FILE_LINK_PREFIX = 'file://';
+const WORKSPACE_FOLDER_PLACEHOLDER = '{{workspaceFolder}}';
 
 // Module-level cache so that all simultaneously-mounting Markdown instances
 // (e.g. dozens of history blocks after a workspace switch) share a single
@@ -43,6 +45,10 @@ const COMPUTER_LINK_PREFIX = 'computer://';
 let _cachedWorkspacePathResult: string | undefined;
 let _cachedWorkspacePathAt = 0;
 const WORKSPACE_PATH_CACHE_MS = 5000;
+
+function translateMarkdownLabel(key: string, options?: Record<string, unknown>): string {
+  return i18nService.t(`components:${key}`, options);
+}
 
 export interface MarkdownTraceContext {
   turnId?: string;
@@ -96,6 +102,38 @@ async function getWorkspacePathCached(): Promise<string | undefined> {
   return result;
 }
 
+function mayNeedWorkspacePathForMarkdownLinks(content: string): boolean {
+  if (!content) {
+    return false;
+  }
+
+  if (
+    content.includes(COMPUTER_LINK_PREFIX) ||
+    content.includes(FILE_LINK_PREFIX) ||
+    content.includes(WORKSPACE_FOLDER_PLACEHOLDER)
+  ) {
+    return true;
+  }
+
+  const hasMarkdownLinkSyntax = content.includes('](');
+  const hasRawAnchorSyntax = content.includes('<a') || content.includes('<A');
+  if (!hasMarkdownLinkSyntax && !hasRawAnchorSyntax) {
+    return false;
+  }
+
+  // Be conservative: false positives only cost one cached workspace lookup,
+  // while false negatives could make relative local links display poorly.
+  if (
+    hasMarkdownLinkSyntax &&
+    /!?\[[^\]]+\]\(\s*(?!https?:|mailto:|data:|asset:|tauri:|visualization:|tab:|#)[^)]+\)/i.test(content)
+  ) {
+    return true;
+  }
+
+  return hasRawAnchorSyntax &&
+    /<a\s+[^>]*href=["']\s*(?!https?:|mailto:|visualization:|tab:|#)[^"']+["']/i.test(content);
+}
+
 /** Catches render errors from react-markdown/remark-gfm (e.g. RegExp in transformGfmAutolinkLiterals) and shows plain text fallback. */
 class MarkdownErrorBoundary extends Component<
   { children: ReactNode; fallbackContent: string },
@@ -128,8 +166,6 @@ class MarkdownErrorBoundary extends Component<
     return this.props.children;
   }
 }
-const FILE_LINK_PREFIX = 'file://';
-const WORKSPACE_FOLDER_PLACEHOLDER = '{{workspaceFolder}}';
 const LOCAL_IMAGE_PLACEHOLDER =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 const EDITOR_OPENABLE_EXTENSIONS = new Set([
@@ -655,7 +691,6 @@ const CodeBlockFallback: React.FC<FlowCodeBlockFallbackProps> = ({
 };
 
 const CopyButton: React.FC<{ code: string }> = ({ code }) => {
-  const { t } = useI18n('components');
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -672,7 +707,7 @@ const CopyButton: React.FC<{ code: string }> = ({ code }) => {
     <button 
       className={`copy-button${copied ? ' copy-success' : ''}`}
       onClick={handleCopy}
-      title={copied ? t('markdown.copySuccess') : t('markdown.copyCode')}
+      title={copied ? translateMarkdownLabel('markdown.copySuccess') : translateMarkdownLabel('markdown.copyCode')}
     >
       {copied ? (
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -721,7 +756,6 @@ export const Markdown = React.memo<MarkdownProps>(({
   traceContext,
 }) => {
   const { isLight } = useTheme();
-  const { t } = useI18n('components');
   const [currentWorkspacePath, setCurrentWorkspacePath] = useState('');
   
   const syntaxTheme = useMemo(() => buildMarkdownPrismStyle(isLight), [isLight]);
@@ -730,24 +764,6 @@ export const Markdown = React.memo<MarkdownProps>(({
   const renderTraceEnabled = isStartupRenderTraceEnabled();
   const renderTraceStartedAtMs = renderTraceEnabled ? performance.now() : null;
 
-  useEffect(() => {
-    let cancelled = false;
-
-    void getWorkspacePathCached()
-      .then((workspacePath) => {
-        if (!cancelled && workspacePath) {
-          setCurrentWorkspacePath(workspacePath);
-        }
-      })
-      .catch((error) => {
-        log.warn('Failed to resolve workspace path for markdown links', { error });
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-  
   // Fault-tolerant extraction of <reproduction_steps> content
   const { markdownContent, reproductionSteps } = useMemo(() => {
     const regex = /<reproduction_steps>([\s\S]*?)<\/reproduction[\s_]*steps\s*>?/g;
@@ -777,6 +793,33 @@ export const Markdown = React.memo<MarkdownProps>(({
 
     return { markdownContent: body, reproductionSteps: steps };
   }, [contentStr, isStreaming]);
+
+  const needsWorkspacePathForLinks = useMemo(
+    () => mayNeedWorkspacePathForMarkdownLinks(markdownContent),
+    [markdownContent],
+  );
+
+  useEffect(() => {
+    if (!needsWorkspacePathForLinks || currentWorkspacePath) {
+      return;
+    }
+
+    let cancelled = false;
+
+    void getWorkspacePathCached()
+      .then((workspacePath) => {
+        if (!cancelled && workspacePath) {
+          setCurrentWorkspacePath(workspacePath);
+        }
+      })
+      .catch((error) => {
+        log.warn('Failed to resolve workspace path for markdown links', { error });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentWorkspacePath, needsWorkspacePathForLinks]);
 
   const markdownFeatureProfile = useMemo(() => ({
     contentLength: markdownContent.length,
@@ -890,7 +933,7 @@ export const Markdown = React.memo<MarkdownProps>(({
     window.dispatchEvent(new CustomEvent('agent-create-tab', {
       detail: {
         type: 'browser',
-        title: t('markdown.openInBuiltInBrowser'),
+        title: translateMarkdownLabel('markdown.openInBuiltInBrowser'),
         data: { url },
         metadata: {
           duplicateCheckKey: `browser-panel:${url}`,
@@ -900,7 +943,7 @@ export const Markdown = React.memo<MarkdownProps>(({
         replaceExisting: false,
       },
     }));
-  }, [t]);
+  }, []);
 
   const handleLocalFileContextMenu = useCallback((
     event: React.MouseEvent<HTMLElement>,
@@ -910,13 +953,13 @@ export const Markdown = React.memo<MarkdownProps>(({
     const items: MenuItem[] = [
       {
         id: 'markdown-open-in-explorer',
-        label: t('markdown.openInExplorer'),
+        label: translateMarkdownLabel('markdown.openInExplorer'),
         icon: 'FolderOpen',
         onClick: () => handleRevealInExplorer(displayPath || filePath),
       },
       {
         id: 'markdown-copy-file-path',
-        label: t('markdown.copyFilePath'),
+        label: translateMarkdownLabel('markdown.copyFilePath'),
         icon: 'Copy',
         onClick: () => void handleCopyLink(displayPath || filePath),
       },
@@ -926,20 +969,20 @@ export const Markdown = React.memo<MarkdownProps>(({
       filePath,
       displayPath,
     });
-  }, [handleRevealInExplorer, handleCopyLink, showLinkContextMenu, t]);
+  }, [handleRevealInExplorer, handleCopyLink, showLinkContextMenu]);
 
   const handleWebLinkContextMenu = useCallback((event: React.MouseEvent<HTMLElement>, url: string) => {
     const targetElement = event.currentTarget;
     const items: MenuItem[] = [
       {
         id: 'markdown-open-in-browser',
-        label: t('markdown.openInBrowser'),
+        label: translateMarkdownLabel('markdown.openInBrowser'),
         icon: 'ExternalLink',
         onClick: () => void handleOpenExternalLink(url),
       },
       {
         id: 'markdown-copy-link',
-        label: t('markdown.copyLink'),
+        label: translateMarkdownLabel('markdown.copyLink'),
         icon: 'Copy',
         onClick: () => void handleCopyLink(url),
       },
@@ -948,7 +991,7 @@ export const Markdown = React.memo<MarkdownProps>(({
     if (canOpenInBuiltInBrowser(targetElement)) {
       items.splice(1, 0, {
         id: 'markdown-open-in-built-in-browser',
-        label: t('markdown.openInBuiltInBrowser'),
+        label: translateMarkdownLabel('markdown.openInBuiltInBrowser'),
         icon: 'PanelRightOpen',
         onClick: () => handleOpenBuiltInBrowserLink(url),
       });
@@ -961,7 +1004,6 @@ export const Markdown = React.memo<MarkdownProps>(({
     handleOpenBuiltInBrowserLink,
     handleOpenExternalLink,
     showLinkContextMenu,
-    t,
   ]);
   
   const components = useMemo(() => ({

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -3,7 +3,7 @@
  * Separated from bottom bar, supports session-level state awareness
  */
 
-import React, { useRef, useCallback, useEffect, useReducer, useState, useMemo } from 'react';
+import React, { useRef, useCallback, useEffect, useReducer, useState, useMemo, useSyncExternalStore } from 'react';
 import path from 'path-browserify';
 import { useTranslation } from 'react-i18next';
 import { ArrowUp, Image, RotateCcw, Plus, X, Sparkles, Loader2, ChevronRight, Files, MessageSquarePlus } from 'lucide-react';
@@ -41,6 +41,10 @@ import { useInputHistoryStore } from '../store/inputHistoryStore';
 import { startBtwThread } from '../services/BtwThreadService';
 import { runUsageReportCommand } from '../services/usageReportService';
 import { isGoalSlashCommand, parseGoalCommand } from '../services/goalService';
+import {
+  getHistorySessionOpenTransitionSnapshot,
+  subscribeHistorySessionOpenTransition,
+} from '../services/sessionOpenIntent';
 import { useThreadGoalController } from '../hooks/useThreadGoalController';
 import { ThreadGoalDialogs } from './thread-goal/ThreadGoalDialogs';
 import { FlowChatManager } from '@/flow_chat';
@@ -288,6 +292,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const effectiveTargetSession = effectiveTargetSessionId
     ? flowChatState.sessions.get(effectiveTargetSessionId)
     : undefined;
+  const historySessionOpenTransition = useSyncExternalStore(
+    subscribeHistorySessionOpenTransition,
+    getHistorySessionOpenTransitionSnapshot,
+    getHistorySessionOpenTransitionSnapshot,
+  );
   const effectiveTargetRelationship = resolveSessionRelationship(effectiveTargetSession);
   const isBtwSession = effectiveTargetRelationship.displayAsChild;
   const acpSessionForInput = useMemo(
@@ -318,6 +327,12 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         defaultValue: t('btw.threadLabel'),
       })
     : '';
+  const deferChatStripPassiveGitRefresh =
+    historySessionOpenTransition !== null ||
+    (
+      effectiveTargetSession?.isHistorical === true &&
+      effectiveTargetSession.contextRestoreState === 'pending'
+    );
   
   // Memoize history so keyboard handlers don't see a fresh [] on every render.
   const inputHistory = useMemo(
@@ -3544,6 +3559,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         <ChatInputWorkspaceStrip
           repositoryPath={chatStripRepositoryPath}
           workspaceLabel={chatStripWorkspaceLabel}
+          deferPassiveGitRefresh={deferChatStripPassiveGitRefresh}
           usageReport={
             effectiveTargetSessionId && effectiveTargetSession
               ? { visible: true, onOpen: handleToolbarUsageReport }

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatInputWorkspaceStrip } from './ChatInputWorkspaceStrip';
+
+const mocks = vi.hoisted(() => ({
+  useGitState: vi.fn(() => ({
+    currentBranch: 'main',
+    isRepository: true,
+  })),
+}));
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn(),
+  },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/component-library', () => ({
+  IconButton: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>{children}</button>
+  ),
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/tools/git/hooks/useGitState', () => ({
+  useGitState: mocks.useGitState,
+}));
+
+describe('ChatInputWorkspaceStrip git refresh behavior', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.useGitState.mockClear();
+    mocks.useGitState.mockReturnValue({
+      currentBranch: 'main',
+      isRepository: true,
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it('uses cached git state without passive refresh while historical restore is pending', async () => {
+    await act(async () => {
+      root.render(
+        <ChatInputWorkspaceStrip
+          repositoryPath="D:/workspace/BitFun"
+          workspaceLabel="BitFun"
+          deferPassiveGitRefresh
+        />
+      );
+    });
+
+    expect(mocks.useGitState).toHaveBeenCalledWith(expect.objectContaining({
+      repositoryPath: 'D:/workspace/BitFun',
+      layers: ['basic'],
+      isActive: false,
+      refreshOnMount: false,
+      refreshOnActive: false,
+    }));
+    expect(container.textContent).toContain('BitFun');
+  });
+
+  it('keeps passive git refresh enabled for normal sessions', async () => {
+    await act(async () => {
+      root.render(
+        <ChatInputWorkspaceStrip
+          repositoryPath="D:/workspace/BitFun"
+          workspaceLabel="BitFun"
+        />
+      );
+    });
+
+    expect(mocks.useGitState).toHaveBeenCalledWith(expect.objectContaining({
+      repositoryPath: 'D:/workspace/BitFun',
+      isActive: true,
+      refreshOnMount: true,
+      refreshOnActive: false,
+    }));
+  });
+});

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
@@ -27,6 +27,8 @@ export interface ChatInputWorkspaceStripProps {
     goal: ThreadGoalSnapshot | null;
     onOpen: () => void;
   };
+  /** Keep the strip on cached Git state while historical content is still restoring. */
+  deferPassiveGitRefresh?: boolean;
 }
 
 export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = ({
@@ -34,6 +36,7 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
   workspaceLabel,
   usageReport,
   threadGoal,
+  deferPassiveGitRefresh = false,
 }) => {
   const { t } = useTranslation('flow-chat');
   const trimmedPath = repositoryPath.trim();
@@ -42,7 +45,10 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
   const { currentBranch, isRepository } = useGitState({
     repositoryPath: trimmedPath,
     layers: ['basic'],
-    isActive: true,
+    isActive: !deferPassiveGitRefresh,
+    refreshOnMount: !deferPassiveGitRefresh,
+    refreshOnActive: false,
+    debugSource: 'chat_input_workspace_strip',
   });
 
   const showUsage = usageReport?.visible && !!usageReport.onOpen;

--- a/src/web-ui/src/flow_chat/components/FlowTextBlock.test.tsx
+++ b/src/web-ui/src/flow_chat/components/FlowTextBlock.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FlowTextBlock } from './FlowTextBlock';
+import type { FlowTextItem } from '../types/flow-chat';
+
+const mocks = vi.hoisted(() => ({
+  markdownRenderer: vi.fn(),
+}));
+
+vi.mock('@/component-library', () => ({
+  MarkdownRenderer: (props: { content: string; isStreaming?: boolean }) => {
+    mocks.markdownRenderer(props);
+    return <div data-testid="markdown-renderer">{props.content}</div>;
+  },
+  DotMatrixLoader: () => <div data-testid="dot-matrix-loader" />,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: () => [],
+  }),
+}));
+
+vi.mock('./modern/FlowChatContext', () => ({
+  useFlowChatContext: () => ({}),
+}));
+
+describe('FlowTextBlock', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.markdownRenderer.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('does not re-render completed markdown just to settle streaming growth state', async () => {
+    const textItem: FlowTextItem = {
+      id: 'text-1',
+      type: 'text',
+      timestamp: 1,
+      status: 'completed',
+      content: 'Completed historical markdown',
+      isStreaming: false,
+      isMarkdown: true,
+    };
+
+    await act(async () => {
+      root.render(<FlowTextBlock textItem={textItem} />);
+      await Promise.resolve();
+    });
+
+    expect(mocks.markdownRenderer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/flow_chat/components/FlowTextBlock.tsx
+++ b/src/web-ui/src/flow_chat/components/FlowTextBlock.tsx
@@ -55,7 +55,12 @@ export const FlowTextBlock = React.memo<FlowTextBlockProps>(({
   replayStreamingOnMount = true,
   traceContext,
 }) => {
-  const { onFileViewRequest, onTabOpen, onHttpLinkClick, onOpenVisualization } = useFlowChatContext();
+  const {
+    onFileViewRequest,
+    onTabOpen,
+    onHttpLinkClick,
+    onOpenVisualization,
+  } = useFlowChatContext();
 
   // Normalize content to a string.
   const content = typeof textItem.content === 'string'
@@ -69,36 +74,37 @@ export const FlowTextBlock = React.memo<FlowTextBlockProps>(({
   });
   
   // Heuristic: if content does not change for a while, streaming is done.
-  const [isContentGrowing, setIsContentGrowing] = useState(true);
+  const [isContentGrowing, setIsContentGrowing] = useState(isStreaming);
   const lastContentRef = useRef(content);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   
   useEffect(() => {
+    const clearGrowthTimeout = () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+
+    if (!isStreaming) {
+      lastContentRef.current = content;
+      clearGrowthTimeout();
+      setIsContentGrowing((wasGrowing) => (wasGrowing ? false : wasGrowing));
+      return clearGrowthTimeout;
+    }
+
     if (content !== lastContentRef.current) {
       lastContentRef.current = content;
       setIsContentGrowing(true);
-      
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
+      clearGrowthTimeout();
       
       timeoutRef.current = setTimeout(() => {
         setIsContentGrowing(false);
       }, CONTENT_IDLE_TIMEOUT);
     }
     
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    };
-  }, [content]);
-  
-  useEffect(() => {
-    if (textItem.status === 'completed' || !textItem.isStreaming) {
-      setIsContentGrowing(false);
-    }
-  }, [textItem.status, textItem.isStreaming]);
+    return clearGrowthTimeout;
+  }, [content, isStreaming]);
   
   const isActivelyStreaming = textItem.isStreaming &&
     (textItem.status === 'streaming' || textItem.status === 'running') &&

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -17,7 +17,7 @@ import { ACPClientAPI, type AcpSessionOptions } from '@/infrastructure/api/servi
 import { getProviderDisplayName } from '@/infrastructure/config/services/modelConfigs';
 import { getEffectiveReasoningMode, isReasoningVisiblyEnabled } from '@/infrastructure/config/utils/reasoning';
 import { globalEventBus } from '@/infrastructure/event-bus';
-import type { AIModelConfig } from '@/infrastructure/config/types';
+import type { AIModelConfig, DefaultModelsConfig } from '@/infrastructure/config/types';
 import { Tooltip } from '@/component-library';
 import { FlowChatStore } from '../store/FlowChatStore';
 import { getModelMaxTokens } from '../services/flow-chat-manager/SessionModule';
@@ -156,7 +156,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
 }) => {
   const { t } = useTranslation('flow-chat');
   const [allModels, setAllModels] = useState<AIModelConfig[]>([]);
-  const [defaultModels, setDefaultModels] = useState<Record<string, string>>({});
+  const [defaultModels, setDefaultModels] = useState<DefaultModelsConfig>({});
   const [agentModels, setAgentModels] = useState<Record<string, string>>({}); // mode_id -> model_id
   const [acpOptions, setAcpOptions] = useState<AcpSessionOptions | null>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -179,11 +179,14 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   // Load configuration data.
   const loadConfigData = useCallback(async () => {
     try {
-      const [models, defaultModelsData, agentModelsData] = await Promise.all([
-        configManager.getConfig<AIModelConfig[]>('ai.models') || [],
-        configManager.getConfig<any>('ai.default_models') || {},
-        configManager.getConfig<Record<string, string>>('ai.agent_models') || {}
+      const configData = await configManager.getConfigs([
+        'ai.models',
+        'ai.default_models',
+        'ai.agent_models',
       ]);
+      const models = (configData['ai.models'] as AIModelConfig[] | undefined) || [];
+      const defaultModelsData = (configData['ai.default_models'] as DefaultModelsConfig | undefined) || {};
+      const agentModelsData = (configData['ai.agent_models'] as Record<string, string> | undefined) || {};
 
       setAllModels(models);
       setDefaultModels(defaultModelsData);
@@ -395,7 +398,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       return buildAutoModelInfo(t);
     }
 
-    if (isSpecialModel(modelId)) {
+    if (modelId === 'primary' || modelId === 'fast') {
       const actualModelId = defaultModels[modelId];
       if (!actualModelId) return buildAutoModelInfo(t);
 

--- a/src/web-ui/src/flow_chat/components/WelcomePanel.test.tsx
+++ b/src/web-ui/src/flow_chat/components/WelcomePanel.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { WelcomePanel } from './WelcomePanel';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const gitApiMock = vi.hoisted(() => ({
+  isGitRepository: vi.fn(),
+  getStatus: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, unknown>) => values?.count ?? key,
+  }),
+}));
+
+vi.mock('../../infrastructure/api', () => ({
+  gitAPI: gitApiMock,
+}));
+
+vi.mock('../../app/hooks/useApp', () => ({
+  useApp: () => ({
+    switchLeftPanelTab: vi.fn(),
+  }),
+}));
+
+vi.mock('@/infrastructure/contexts/WorkspaceContext', () => ({
+  useWorkspaceContext: () => ({
+    hasWorkspace: true,
+    currentWorkspace: {
+      id: 'workspace-1',
+      name: 'BitFun',
+      rootPath: 'D:/workspace/BitFun',
+    },
+    openedWorkspacesList: [],
+    openWorkspace: vi.fn(),
+    switchWorkspace: vi.fn(),
+  }),
+}));
+
+vi.mock('./CoworkExampleCards', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/scenes/my-agent/useAgentIdentityDocument', () => ({
+  useAgentIdentityDocument: () => ({ document: { name: '' } }),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('WelcomePanel Git summary loading', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    gitApiMock.isGitRepository.mockReset();
+    gitApiMock.getStatus.mockReset();
+    gitApiMock.getStatus.mockResolvedValue({
+      current_branch: 'main',
+      staged: [],
+      unstaged: [],
+      untracked: [],
+      ahead: 0,
+      behind: 0,
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('does not request Git status after the panel unmounts during repository detection', async () => {
+    const repositoryProbe = deferred<boolean>();
+    gitApiMock.isGitRepository.mockReturnValue(repositoryProbe.promise);
+
+    await act(async () => {
+      root.render(<WelcomePanel sessionMode="agentic" />);
+    });
+
+    expect(gitApiMock.isGitRepository).toHaveBeenCalledWith('D:/workspace/BitFun');
+
+    act(() => {
+      root.unmount();
+    });
+
+    await act(async () => {
+      repositoryProbe.resolve(true);
+      await repositoryProbe.promise;
+    });
+
+    expect(gitApiMock.getStatus).not.toHaveBeenCalled();
+  });
+
+  it('loads Git status when the panel remains mounted', async () => {
+    gitApiMock.isGitRepository.mockResolvedValue(true);
+
+    await act(async () => {
+      root.render(<WelcomePanel sessionMode="agentic" />);
+    });
+
+    expect(gitApiMock.getStatus).toHaveBeenCalledWith('D:/workspace/BitFun', 'welcome_panel');
+  });
+});

--- a/src/web-ui/src/flow_chat/components/WelcomePanel.tsx
+++ b/src/web-ui/src/flow_chat/components/WelcomePanel.tsx
@@ -108,11 +108,16 @@ export const WelcomePanel: React.FC<WelcomePanelProps> = ({
     );
   }, [gitState, handleGitClick, t]);
 
-  const loadGitState = useCallback(async (workspacePath: string) => {
+  const loadGitState = useCallback(async (
+    workspacePath: string,
+    shouldCancel: () => boolean = () => false,
+  ) => {
     try {
       const isGitRepo = await gitAPI.isGitRepository(workspacePath);
+      if (shouldCancel()) return;
       if (!isGitRepo) { setGitState(null); return; }
-      const s = await gitAPI.getStatus(workspacePath);
+      const s = await gitAPI.getStatus(workspacePath, 'welcome_panel');
+      if (shouldCancel()) return;
       setGitState({
         currentBranch: s.current_branch,
         unstagedFiles: s.unstaged.length + s.untracked.length,
@@ -129,7 +134,11 @@ export const WelcomePanel: React.FC<WelcomePanelProps> = ({
 
   useEffect(() => {
     if (isCoworkSession || isClawSession || !currentWorkspace?.rootPath) { setGitState(null); return; }
-    void loadGitState(currentWorkspace.rootPath);
+    let cancelled = false;
+    void loadGitState(currentWorkspace.rootPath, () => cancelled);
+    return () => {
+      cancelled = true;
+    };
   }, [currentWorkspace?.rootPath, isCoworkSession, isClawSession, loadGitState]);
 
   useEffect(() => {

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -6,7 +6,11 @@ import { createRoot, type Root } from 'react-dom/client';
 import { ModernFlowChatContainer } from './ModernFlowChatContainer';
 import type { Session } from '../../types/flow-chat';
 import { flowChatStore } from '../../store/FlowChatStore';
-import { HISTORY_SESSION_OPEN_INTENT_EVENT } from '../../services/sessionOpenIntent';
+import {
+  clearHistorySessionOpenTransition,
+  dispatchHistorySessionOpenIntent,
+  HISTORY_SESSION_OPEN_INTENT_EVENT,
+} from '../../services/sessionOpenIntent';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -263,6 +267,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
     searchStateMock.goToPrev.mockReset();
     searchStateMock.clearSearch.mockReset();
     headerPropsMock.latest = null;
+    clearHistorySessionOpenTransition();
   });
 
   afterEach(() => {
@@ -273,6 +278,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
     }
     container?.remove();
     stateMocks.activeSession = null;
+    clearHistorySessionOpenTransition();
     vi.unstubAllGlobals();
   });
 
@@ -368,8 +374,33 @@ describe('ModernFlowChatContainer historical empty state', () => {
       root.render(<ModernFlowChatContainer />);
     });
 
-    expect(container.textContent).toContain('Loading saved session');
-    expect(container.querySelector('.modern-flowchat-container__history-overlay')).not.toBeNull();
+    expect(container.textContent).not.toContain('Loading saved session');
+    expect(container.querySelector('.modern-flowchat-container__history-overlay')).toBeNull();
+    expect(container.querySelector('[data-testid="welcome-panel"]')).toBeNull();
+    expect(container.querySelector('.modern-flowchat-container__history-open-intent-shield')).not.toBeNull();
+    expect(container.querySelector('.modern-flowchat-container__messages')?.getAttribute('data-show-history-loading-layer'))
+      .toBe('false');
+    expect(container.querySelector('.modern-flowchat-container__messages')?.getAttribute('data-show-history-open-intent-overlay'))
+      .toBe('true');
+
+    stateMocks.activeSession = createSession({
+      sessionId: 'history-session',
+      isHistorical: false,
+      historyState: 'ready',
+      dialogTurns: [createTurn('turn-2', 'Restored latest prompt')],
+    } as Partial<Session>);
+    stateMocks.virtualItems = [
+      { type: 'user-message', turnId: 'turn-2', data: { id: 'user-turn-2', content: 'Restored latest prompt' } },
+    ];
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(container.querySelector('[data-testid="virtual-list"]')).not.toBeNull();
+    expect(container.querySelector('.modern-flowchat-container__history-open-intent-shield')).toBeNull();
+    expect(container.querySelector('.modern-flowchat-container__messages')?.getAttribute('data-show-history-open-intent-overlay'))
+      .toBe('false');
   });
 
   it('removes the loading layer when a hydrating session receives its initial tail turns', async () => {
@@ -563,7 +594,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
     releaseSpy.mockRestore();
   });
 
-  it('defers background command snapshot until restored latest text is visible', async () => {
+  it('defers background command snapshot until restored latest text is visible and painted', async () => {
     const releaseSpy = vi
       .spyOn(flowChatStore, 'releaseSessionHistoryCompletionAfterInitialPaint')
       .mockReturnValue(true);
@@ -591,14 +622,66 @@ describe('ModernFlowChatContainer historical empty state', () => {
 
     virtualListMock.isTurnTextRenderedInViewport.mockReturnValue(true);
     flushAnimationFrame();
-    flushAnimationFrame();
-    flushAnimationFrame();
+    expect(releaseSpy).not.toHaveBeenCalled();
+    expect(agentApiMock.listBackgroundCommandActivities).not.toHaveBeenCalled();
 
+    flushAnimationFrame();
+    expect(releaseSpy).not.toHaveBeenCalled();
+    expect(agentApiMock.listBackgroundCommandActivities).not.toHaveBeenCalled();
+
+    flushAnimationFrame();
     expect(releaseSpy).toHaveBeenCalledWith('session-1');
+    expect(agentApiMock.listBackgroundCommandActivities).not.toHaveBeenCalled();
+
+    flushAnimationFrame();
+    expect(agentApiMock.listBackgroundCommandActivities).not.toHaveBeenCalled();
+
+    flushAnimationFrame();
     expect(agentApiMock.listBackgroundCommandActivities).toHaveBeenCalledTimes(1);
     expect(agentApiMock.listBackgroundCommandActivities).toHaveBeenCalledWith({
       agentSessionId: 'session-1',
     });
+
+    releaseSpy.mockRestore();
+  });
+
+  it('skips stale background command snapshot when another history session open starts first', async () => {
+    const releaseSpy = vi
+      .spyOn(flowChatStore, 'releaseSessionHistoryCompletionAfterInitialPaint')
+      .mockReturnValue(true);
+
+    stateMocks.activeSession = createSession({
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      dialogTurns: [
+        createTurn('turn-1', 'Older restored prompt'),
+        createTurn('turn-2', 'Latest restored prompt'),
+      ],
+    } as Partial<Session>);
+    stateMocks.virtualItems = [
+      { type: 'user-message', turnId: 'turn-1', data: { id: 'user-turn-1', content: 'Older restored prompt' } },
+      { type: 'user-message', turnId: 'turn-2', data: { id: 'user-turn-2', content: 'Latest restored prompt' } },
+    ];
+    virtualListMock.isTurnTextRenderedInViewport.mockReturnValue(false);
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    virtualListMock.isTurnTextRenderedInViewport.mockReturnValue(true);
+    flushAnimationFrame();
+    flushAnimationFrame();
+
+    act(() => {
+      dispatchHistorySessionOpenIntent('session-2', 'Next saved session');
+    });
+    flushAnimationFrame();
+
+    expect(releaseSpy).toHaveBeenCalledWith('session-1');
+    flushAnimationFrame();
+    flushAnimationFrame();
+    expect(agentApiMock.listBackgroundCommandActivities).not.toHaveBeenCalled();
 
     releaseSpy.mockRestore();
   });

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -46,6 +46,8 @@ import { scheduleAfterStartupPaint } from '@/shared/utils/startupTaskScheduling'
 import { agentAPI } from '@/infrastructure/api';
 import { notificationService } from '@/shared/notification-system';
 import {
+  clearHistorySessionOpenTransition,
+  getHistorySessionOpenTransitionSnapshot,
   HISTORY_SESSION_OPEN_INTENT_EVENT,
   type HistorySessionOpenIntentDetail,
 } from '../../services/sessionOpenIntent';
@@ -339,6 +341,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const virtualListRef = useRef<VirtualMessageListRef>(null);
   const chatScopeRef = useRef<HTMLDivElement>(null);
   const [historyInitialContentReadyKey, setHistoryInitialContentReadyKey] = useState<string | null>(null);
+  const [historyInitialContentPostPaintKey, setHistoryInitialContentPostPaintKey] = useState<string | null>(null);
   const { workspacePath } = useWorkspaceContext();
   const allowUserMessageRollback = !isAcpFlowSession(activeSession);
   const historyState = activeSession?.historyState;
@@ -352,9 +355,9 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     historyState === 'failed' ||
     hasRestoredTurnsPendingVirtualItems
   );
-  const showHistoryOpenIntentOverlay =
+  const isPendingHistoryOpenActiveSession =
     pendingHistoryOpenSession !== null &&
-    activeSession?.sessionId !== pendingHistoryOpenSession.sessionId;
+    activeSession?.sessionId === pendingHistoryOpenSession.sessionId;
   const {
     exploreGroupStates,
     onExploreGroupToggle: handleExploreGroupToggle,
@@ -432,9 +435,13 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     }
 
     const timeoutId = window.setTimeout(() => {
-      setPendingHistoryOpenSession(current =>
-        current?.sessionId === pendingHistoryOpenSession.sessionId ? null : current
-      );
+      setPendingHistoryOpenSession(current => {
+        if (current?.sessionId === pendingHistoryOpenSession.sessionId) {
+          clearHistorySessionOpenTransition(pendingHistoryOpenSession.sessionId);
+          return null;
+        }
+        return current;
+      });
     }, 4000);
 
     return () => {
@@ -443,13 +450,24 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   }, [pendingHistoryOpenSession]);
 
   useEffect(() => {
-    if (
-      pendingHistoryOpenSession &&
-      activeSession?.sessionId === pendingHistoryOpenSession.sessionId
-    ) {
-      setPendingHistoryOpenSession(null);
+    if (!isPendingHistoryOpenActiveSession) {
+      return;
     }
-  }, [activeSession?.sessionId, pendingHistoryOpenSession]);
+
+    if (showHistoryPlaceholder && historyState !== 'failed') {
+      return;
+    }
+
+    if (historyState === 'failed') {
+      clearHistorySessionOpenTransition(pendingHistoryOpenSession.sessionId);
+    }
+    setPendingHistoryOpenSession(null);
+  }, [
+    historyState,
+    isPendingHistoryOpenActiveSession,
+    pendingHistoryOpenSession?.sessionId,
+    showHistoryPlaceholder,
+  ]);
 
   const contextValue: FlowChatContextValue = useMemo(() => ({
     onFileViewRequest: handleFileViewRequest,
@@ -588,14 +606,26 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const shouldDeferBackgroundCommandSnapshot =
     activeSession?.historyState === 'metadata-only' ||
     activeSession?.historyState === 'hydrating' ||
-    shouldBlockHistoryInitialContentInteraction;
+    (
+      historyInitialContentKey !== null &&
+      historyInitialContentPostPaintKey !== historyInitialContentKey
+    );
+  const shouldScheduleBackgroundCommandSnapshotAfterPaint =
+    historyInitialContentKey !== null &&
+    historyInitialContentPostPaintKey === historyInitialContentKey;
+  const showFailedHistoryPlaceholder =
+    showHistoryPlaceholder && historyState === 'failed';
+  const showHistoryOpenIntentOverlay =
+    pendingHistoryOpenSession !== null &&
+    (
+      activeSession?.sessionId !== pendingHistoryOpenSession.sessionId ||
+      (isPendingHistoryOpenActiveSession && showHistoryPlaceholder && !showFailedHistoryPlaceholder)
+    );
   const shouldBlockHistoryTransitionInteraction =
     shouldBlockHistoryInitialContentInteraction ||
     showHistoryOpenIntentOverlay;
-  const showFailedHistoryPlaceholder =
-    showHistoryPlaceholder && historyState === 'failed';
   const showHistoryLoadingLayer =
-    !showFailedHistoryPlaceholder && showHistoryPlaceholder;
+    !showHistoryOpenIntentOverlay && !showFailedHistoryPlaceholder && showHistoryPlaceholder;
   const blockHistoryOverlayActivation = useCallback((event: React.SyntheticEvent<HTMLElement>) => {
     if (!showHistoryLoadingLayer && !shouldBlockHistoryTransitionInteraction) {
       return;
@@ -691,6 +721,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
 
   useEffect(() => {
     setHistoryInitialContentReadyKey(null);
+    setHistoryInitialContentPostPaintKey(null);
     setPendingHeaderTurnId(null);
   }, [activeSession?.sessionId]);
 
@@ -883,12 +914,14 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       }
       releasedHistoryCompletionKeyRef.current = releaseKey;
       const released = flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint(sessionId);
+      clearHistorySessionOpenTransition(sessionId);
       startupTrace.markPhase('historical_session_initial_content_painted', {
         sessionId,
         latestTurnId,
         released,
         turnCount: turnSummaries.length,
       });
+      setHistoryInitialContentPostPaintKey(releaseKey);
     };
 
     const checkLatestTextVisibility = () => {
@@ -905,7 +938,9 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
 
       if (attempts >= HISTORY_INITIAL_CONTENT_PAINT_MAX_ATTEMPTS) {
         setHistoryInitialContentReadyKey(releaseKey);
+        setHistoryInitialContentPostPaintKey(releaseKey);
         releasedHistoryCompletionKeyRef.current = releaseKey;
+        clearHistorySessionOpenTransition(sessionId);
         startupTrace.markPhase('historical_session_initial_content_paint_signal_missed', {
           sessionId,
           latestTurnId,
@@ -1020,6 +1055,11 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   }, [activeSession?.sessionId]);
 
   const backgroundSubagentsRef = useRef<string | null>(null);
+  const activeSessionIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    activeSessionIdRef.current = activeSession?.sessionId ?? null;
+  }, [activeSession?.sessionId]);
 
   useEffect(() => {
     const syncBackgroundSubagents = () => {
@@ -1057,22 +1097,50 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     }
 
     let cancelled = false;
-    void agentAPI.listBackgroundCommandActivities({ agentSessionId })
-      .then((response) => {
-        if (!cancelled) {
-          useBackgroundCommandActivityStore
-            .getState()
-            .hydrateActivities(agentSessionId, response.activities);
-        }
-      })
-      .catch(() => {
-        /* Snapshot recovery is best-effort; live events remain authoritative. */
-      });
+    let cancelScheduledSnapshot: (() => void) | null = null;
+    const recoverSnapshot = () => {
+      const pendingHistoryTransition = getHistorySessionOpenTransitionSnapshot();
+      if (
+        cancelled ||
+        activeSessionIdRef.current !== agentSessionId ||
+        (pendingHistoryTransition && pendingHistoryTransition.sessionId !== agentSessionId)
+      ) {
+        return;
+      }
+
+      void agentAPI.listBackgroundCommandActivities({ agentSessionId })
+        .then((response) => {
+          const currentHistoryTransition = getHistorySessionOpenTransitionSnapshot();
+          if (
+            !cancelled &&
+            activeSessionIdRef.current === agentSessionId &&
+            (!currentHistoryTransition || currentHistoryTransition.sessionId === agentSessionId)
+          ) {
+            useBackgroundCommandActivityStore
+              .getState()
+              .hydrateActivities(agentSessionId, response.activities);
+          }
+        })
+        .catch(() => {
+          /* Snapshot recovery is best-effort; live events remain authoritative. */
+        });
+    };
+
+    if (shouldScheduleBackgroundCommandSnapshotAfterPaint) {
+      cancelScheduledSnapshot = scheduleAfterStartupPaint(recoverSnapshot, { frameCount: 2 });
+    } else {
+      recoverSnapshot();
+    }
 
     return () => {
       cancelled = true;
+      cancelScheduledSnapshot?.();
     };
-  }, [activeSession?.sessionId, shouldDeferBackgroundCommandSnapshot]);
+  }, [
+    activeSession?.sessionId,
+    shouldScheduleBackgroundCommandSnapshotAfterPaint,
+    shouldDeferBackgroundCommandSnapshot,
+  ]);
 
   const backgroundCommands = useMemo(
     () => visibleBackgroundCommandActivitiesForSession(
@@ -1367,7 +1435,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
                 onRetry={handleRetryHistoryLoad}
               />
             ) : virtualItems.length === 0 ? (
-              showHistoryLoadingLayer ? null : (
+              showHistoryPlaceholder || showHistoryOpenIntentOverlay ? null : (
                 <WelcomePanel
                   key={activeSession?.sessionId ?? 'welcome'}
                   sessionMode={activeSession?.mode}

--- a/src/web-ui/src/flow_chat/deep-review/launch/targetResolver.test.ts
+++ b/src/web-ui/src/flow_chat/deep-review/launch/targetResolver.test.ts
@@ -100,7 +100,7 @@ describe('Deep Review target resolver', () => {
 
     const result = await resolveSlashCommandReviewTarget('', 'D:\\workspace\\repo');
 
-    expect(mockGitGetStatus).toHaveBeenCalledWith('D:\\workspace\\repo');
+    expect(mockGitGetStatus).toHaveBeenCalledWith('D:\\workspace\\repo', 'deep_review_target_resolver');
     expect(result.target.source).toBe('workspace_diff');
     expect(result.changeStats).toEqual({
       fileCount: 2,

--- a/src/web-ui/src/flow_chat/deep-review/launch/targetResolver.ts
+++ b/src/web-ui/src/flow_chat/deep-review/launch/targetResolver.ts
@@ -137,7 +137,7 @@ export async function resolveSlashCommandReviewTarget(
 
   if (!commandFocus && workspacePath) {
     try {
-      const status = await gitAPI.getStatus(workspacePath);
+      const status = await gitAPI.getStatus(workspacePath, 'deep_review_target_resolver');
       const target = classifyReviewTargetFromFiles(
         collectWorkspaceDiffFilePaths(status),
         'workspace_diff',

--- a/src/web-ui/src/flow_chat/hooks/useMessageSender.ts
+++ b/src/web-ui/src/flow_chat/hooks/useMessageSender.ts
@@ -112,11 +112,14 @@ export function useMessageSender(props: UseMessageSenderProps): UseMessageSender
 
       if (!sessionId) {
         const { configManager } = await import('@/infrastructure/config/services/ConfigManager');
-        const [agentModels, allModels, defaultModels] = await Promise.all([
-          configManager.getConfig<Record<string, string>>('ai.agent_models') || {},
-          configManager.getConfig<AIModelConfig[]>('ai.models') || [],
-          configManager.getConfig<DefaultModelsConfig>('ai.default_models') || {},
+        const configData = await configManager.getConfigs([
+          'ai.agent_models',
+          'ai.models',
+          'ai.default_models',
         ]);
+        const agentModels = (configData['ai.agent_models'] as Record<string, string> | undefined) || {};
+        const allModels = (configData['ai.models'] as AIModelConfig[] | undefined) || [];
+        const defaultModels = (configData['ai.default_models'] as DefaultModelsConfig | undefined) || {};
         const agentType = currentAgentType || 'agentic';
         const modelId = normalizeModelSelection(agentModels[agentType], allModels, defaultModels);
 

--- a/src/web-ui/src/flow_chat/hooks/useThreadGoalController.ts
+++ b/src/web-ui/src/flow_chat/hooks/useThreadGoalController.ts
@@ -20,6 +20,8 @@ import {
   type ThreadGoalSnapshot,
 } from '../services/goalService';
 
+const HISTORICAL_THREAD_GOAL_REFRESH_DELAY_MS = 350;
+
 export interface ThreadGoalController {
   goal: ThreadGoalSnapshot | null;
   menuOpen: boolean;
@@ -149,8 +151,14 @@ export function useThreadGoalController(
 
   useEffect(() => {
     if (!sessionId || isBtwSession) return;
+    if (session?.isHistorical) {
+      const timeoutId = globalThis.setTimeout(() => {
+        void refreshGoal();
+      }, HISTORICAL_THREAD_GOAL_REFRESH_DELAY_MS);
+      return () => globalThis.clearTimeout(timeoutId);
+    }
     void refreshGoal();
-  }, [sessionId, isBtwSession, refreshGoal]);
+  }, [session?.isHistorical, sessionId, isBtwSession, refreshGoal]);
 
   const goalId = goal?.goalId;
   const goalStatus = goal?.status;

--- a/src/web-ui/src/flow_chat/services/DeepReviewService.test.ts
+++ b/src/web-ui/src/flow_chat/services/DeepReviewService.test.ts
@@ -152,7 +152,7 @@ describe('DeepReviewService slash command', () => {
       'D:\\workspace\\repo',
     );
 
-    expect(mockGitGetStatus).toHaveBeenCalledWith('D:\\workspace\\repo');
+    expect(mockGitGetStatus).toHaveBeenCalledWith('D:\\workspace\\repo', 'deep_review_target_resolver');
     expect(buildEffectiveReviewTeamManifest).toHaveBeenLastCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -25,6 +25,7 @@ import {
   saveAllInProgressTurns,
   immediateSaveDialogTurn,
   createChatSession as createChatSessionModule,
+  preloadHistoricalSessionForOpen as preloadHistoricalSessionForOpenModule,
   switchChatSession as switchChatSessionModule,
   deleteChatSession as deleteChatSessionModule,
   renameChatSessionTitle as renameChatSessionTitleModule,
@@ -379,6 +380,10 @@ export class FlowChatManager {
 
   async switchChatSession(sessionId: string): Promise<void> {
     return switchChatSessionModule(this.context, sessionId);
+  }
+
+  preloadHistoricalSessionForOpen(sessionId: string): void {
+    preloadHistoricalSessionForOpenModule(this.context, sessionId);
   }
 
   async deleteChatSession(sessionId: string): Promise<void> {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -79,14 +79,14 @@ async function syncSessionModelSelection(
     return;
   }
 
-  const [agentModelsConfig, allModelsConfig, defaultModelsConfig] = await Promise.all([
-    configManager.getConfig<Record<string, string>>('ai.agent_models'),
-    configManager.getConfig<AIModelConfig[]>('ai.models'),
-    configManager.getConfig<DefaultModelsConfig>('ai.default_models'),
+  const configData = await configManager.getConfigs([
+    'ai.agent_models',
+    'ai.models',
+    'ai.default_models',
   ]);
-  const agentModels = agentModelsConfig || {};
-  const allModels = allModelsConfig || [];
-  const defaultModels = defaultModelsConfig || {};
+  const agentModels = (configData['ai.agent_models'] as Record<string, string> | undefined) || {};
+  const allModels = (configData['ai.models'] as AIModelConfig[] | undefined) || [];
+  const defaultModels = (configData['ai.default_models'] as DefaultModelsConfig | undefined) || {};
 
   const desiredModelId = normalizeModelSelection(agentModels[agentType], allModels, defaultModels);
   const shouldForceAutoSync = desiredModelId === 'auto';

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
@@ -1,9 +1,15 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ensureBackendSession,
+  preloadHistoricalSessionForOpen,
   retryCreateBackendSession,
+  SESSION_ACTIVITY_TOUCH_DELAY_MS,
   switchChatSession,
 } from './SessionModule';
+import {
+  clearRecentHistorySessionOpenIntent,
+  dispatchHistorySessionOpenIntent,
+} from '../sessionOpenIntent';
 import type { Session } from '../../types/flow-chat';
 import type { ReviewTeamRunManifest } from '@/shared/services/reviewTeamService';
 
@@ -114,7 +120,14 @@ function createContext(session: Session) {
 }
 
 describe('SessionModule historical session coordination', () => {
-  afterEach(() => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    await vi.runOnlyPendingTimersAsync();
+    clearRecentHistorySessionOpenIntent();
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
@@ -129,6 +142,45 @@ describe('SessionModule historical session coordination', () => {
 
     expect(flowChatStore.switchSession).not.toHaveBeenCalled();
     expect(flowChatStore.loadSessionHistory).toHaveBeenCalledTimes(1);
+
+    load.resolve();
+    await switching;
+
+    expect(flowChatStore.switchSession).toHaveBeenCalledWith('history-1');
+  });
+
+  it('activates a metadata-only historical session immediately when a recent user open intent exists', async () => {
+    const load = createDeferred<void>();
+    const { context, flowChatStore } = createContext(createSession());
+    flowChatStore.loadSessionHistory.mockReturnValueOnce(load.promise);
+    persistenceMocks.touchSessionActivity.mockResolvedValueOnce(undefined);
+
+    dispatchHistorySessionOpenIntent('history-1', 'Saved session');
+    const switching = switchChatSession(context, 'history-1');
+    await Promise.resolve();
+
+    expect(flowChatStore.switchSession).toHaveBeenCalledWith('history-1');
+    expect(flowChatStore.loadSessionHistory).toHaveBeenCalledTimes(1);
+    expect(persistenceMocks.touchSessionActivity).not.toHaveBeenCalled();
+
+    load.resolve();
+    await switching;
+
+    expect(flowChatStore.switchSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps metadata-only historical sessions out of the active render path until hydrated', async () => {
+    const load = createDeferred<void>();
+    const { context, flowChatStore } = createContext(createSession());
+    context.pendingHistoryLoads.set('history-other', Promise.resolve());
+    flowChatStore.loadSessionHistory.mockReturnValueOnce(load.promise);
+    persistenceMocks.touchSessionActivity.mockResolvedValueOnce(undefined);
+
+    const switching = switchChatSession(context, 'history-1');
+    await Promise.resolve();
+
+    expect(flowChatStore.loadSessionHistory).toHaveBeenCalledTimes(1);
+    expect(flowChatStore.switchSession).not.toHaveBeenCalled();
 
     load.resolve();
     await switching;
@@ -152,6 +204,12 @@ describe('SessionModule historical session coordination', () => {
     await Promise.resolve();
 
     expect(flowChatStore.switchSession).toHaveBeenCalledWith('history-1');
+    expect(persistenceMocks.touchSessionActivity).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(SESSION_ACTIVITY_TOUCH_DELAY_MS - 1);
+    expect(persistenceMocks.touchSessionActivity).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
     expect(persistenceMocks.touchSessionActivity).toHaveBeenCalledWith(
       'history-1',
       'D:/workspace/BitFun',
@@ -183,6 +241,62 @@ describe('SessionModule historical session coordination', () => {
     await load.promise;
   });
 
+  it('touches only the latest active session during rapid switches', async () => {
+    const firstSession = createSession({
+      sessionId: 'history-1',
+      historyState: 'ready',
+      dialogTurns: [{ id: 'turn-1', userMessage: { content: 'one' } } as any],
+    });
+    const secondSession = createSession({
+      sessionId: 'history-2',
+      historyState: 'ready',
+      dialogTurns: [{ id: 'turn-2', userMessage: { content: 'two' } } as any],
+    });
+    const { context, flowChatStore } = createContext(firstSession);
+    flowChatStore.setState((prev: any) => ({
+      ...prev,
+      sessions: new Map(prev.sessions).set(secondSession.sessionId, secondSession),
+    }));
+    flowChatStore.loadSessionHistory.mockResolvedValue(undefined);
+    persistenceMocks.touchSessionActivity.mockResolvedValue(undefined);
+
+    await switchChatSession(context, 'history-1');
+    await switchChatSession(context, 'history-2');
+
+    expect(flowChatStore.switchSession).toHaveBeenNthCalledWith(1, 'history-1');
+    expect(flowChatStore.switchSession).toHaveBeenNthCalledWith(2, 'history-2');
+    expect(persistenceMocks.touchSessionActivity).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(SESSION_ACTIVITY_TOUCH_DELAY_MS);
+
+    expect(persistenceMocks.touchSessionActivity).toHaveBeenCalledTimes(1);
+    expect(persistenceMocks.touchSessionActivity).toHaveBeenCalledWith(
+      'history-2',
+      'D:/workspace/BitFun',
+      undefined,
+      undefined,
+    );
+  });
+
+  it('does not touch activity when the delayed session no longer exists', async () => {
+    const session = createSession({
+      historyState: 'ready',
+      dialogTurns: [{ id: 'turn-1', userMessage: { content: 'one' } } as any],
+    });
+    const { context, flowChatStore } = createContext(session);
+    persistenceMocks.touchSessionActivity.mockResolvedValue(undefined);
+
+    await switchChatSession(context, 'history-1');
+    flowChatStore.setState((prev: any) => ({
+      ...prev,
+      sessions: new Map(),
+    }));
+
+    await vi.advanceTimersByTimeAsync(SESSION_ACTIVITY_TOUCH_DELAY_MS);
+
+    expect(persistenceMocks.touchSessionActivity).not.toHaveBeenCalled();
+  });
+
   it('does not block remote metadata-only historical sessions on local pre-hydration before switching', async () => {
     const load = createDeferred<void>();
     const { context, flowChatStore } = createContext(createSession({
@@ -199,6 +313,58 @@ describe('SessionModule historical session coordination', () => {
 
     load.resolve();
     await load.promise;
+  });
+
+  it('preloads a local metadata-only historical session during a competing history load without switching', async () => {
+    const load = createDeferred<void>();
+    const { context, flowChatStore } = createContext(createSession());
+    context.pendingHistoryLoads.set('history-other', Promise.resolve());
+    flowChatStore.loadSessionHistory.mockReturnValueOnce(load.promise);
+
+    preloadHistoricalSessionForOpen(context, 'history-1');
+    await Promise.resolve();
+
+    expect(flowChatStore.loadSessionHistory).toHaveBeenCalledTimes(1);
+    expect(flowChatStore.switchSession).not.toHaveBeenCalled();
+
+    load.resolve();
+    await load.promise;
+  });
+
+  it('does not preload standalone historical opens before the transition shield paints', () => {
+    const { context, flowChatStore } = createContext(createSession());
+
+    preloadHistoricalSessionForOpen(context, 'history-1');
+
+    expect(flowChatStore.loadSessionHistory).not.toHaveBeenCalled();
+  });
+
+  it('does not preload remote or already renderable historical sessions', async () => {
+    const remoteSession = createSession({
+      remoteConnectionId: 'remote-1',
+      remoteSshHost: 'remote-host',
+    });
+    const { context, flowChatStore } = createContext(remoteSession);
+    context.pendingHistoryLoads.set('history-other', Promise.resolve());
+
+    preloadHistoricalSessionForOpen(context, 'history-1');
+
+    expect(flowChatStore.loadSessionHistory).not.toHaveBeenCalled();
+
+    flowChatStore.setState((prev: any) => ({
+      ...prev,
+      sessions: new Map(prev.sessions).set('history-1', createSession({
+        dialogTurns: [{
+          id: 'turn-1',
+          userMessage: { id: 'user-1', content: 'Existing prompt', timestamp: 1 },
+          modelRounds: [],
+        } as any],
+      })),
+    }));
+
+    preloadHistoricalSessionForOpen(context, 'history-1');
+
+    expect(flowChatStore.loadSessionHistory).not.toHaveBeenCalled();
   });
 
   it('reuses pending historical hydration before ensuring the backend session', async () => {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -24,15 +24,33 @@ import {
   resolveSessionTitle,
 } from '../../utils/sessionTitle';
 import { buildCreateSessionRelationship } from '../../utils/sessionMetadata';
+import { consumeRecentHistorySessionOpenIntent } from '../sessionOpenIntent';
 
 const log = createLogger('SessionModule');
 const pendingSessionCreations = new Map<string, Promise<string>>();
+export const SESSION_ACTIVITY_TOUCH_DELAY_MS = 350;
 let latestSwitchRequestId = 0;
+let pendingActivityTouchTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleSessionActivityTouch(task: () => void): void {
+  if (pendingActivityTouchTimer !== null) {
+    clearTimeout(pendingActivityTouchTimer);
+  }
+  pendingActivityTouchTimer = setTimeout(() => {
+    pendingActivityTouchTimer = null;
+    task();
+  }, SESSION_ACTIVITY_TOUCH_DELAY_MS);
+}
 
 const normalizeOptional = (value: string | undefined): string | undefined => {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
 };
+
+function hasCompetingHistoryLoad(context: FlowChatContext, sessionId: string): boolean {
+  return Array.from(context.pendingHistoryLoads.keys())
+    .some(pendingSessionId => pendingSessionId !== sessionId);
+}
 
 const hostFromSshConnectionId = (connectionId: string | undefined): string | undefined => {
   const trimmed = connectionId?.trim();
@@ -184,6 +202,34 @@ function hasRenderableSessionContent(session: Session): boolean {
   );
 }
 
+function shouldHydrateHistoricalSessionBeforeSwitch(session: Session | undefined): session is Session {
+  if (session?.isHistorical !== true) {
+    return false;
+  }
+  if (isRemoteTraceContext(session.remoteConnectionId, session.remoteSshHost)) {
+    return false;
+  }
+  return !hasRenderableSessionContent(session);
+}
+
+export function preloadHistoricalSessionForOpen(
+  context: FlowChatContext,
+  sessionId: string
+): void {
+  if (!hasCompetingHistoryLoad(context, sessionId)) {
+    return;
+  }
+
+  const session = context.flowChatStore.getState().sessions.get(sessionId);
+  if (!shouldHydrateHistoricalSessionBeforeSwitch(session)) {
+    return;
+  }
+
+  void hydrateHistoricalSession(context, sessionId, false).catch(error => {
+    log.debug('Historical session preload failed', { sessionId, error });
+  });
+}
+
 type SessionDisplayMode = 'code' | 'cowork' | 'claw';
 
 const isAssistantWorkspace = (workspace?: WorkspaceInfo | null): boolean => {
@@ -329,14 +375,14 @@ function resolveModelForContextWindow(
 export async function getModelMaxTokens(modelName?: string, agentType?: string): Promise<number> {
   try {
     const configManager = await import('@/infrastructure/config/services/ConfigManager').then(m => m.configManager);
-    const [modelsConfig, defaultModelsConfig, agentModelsConfig] = await Promise.all([
-      configManager.getConfig<AIModelConfig[]>('ai.models'),
-      configManager.getConfig<DefaultModelsConfig>('ai.default_models'),
-      configManager.getConfig<Record<string, string>>('ai.agent_models'),
+    const configData = await configManager.getConfigs([
+      'ai.models',
+      'ai.default_models',
+      'ai.agent_models',
     ]);
-    const models = modelsConfig || [];
-    const defaultModels = defaultModelsConfig || {};
-    const agentModels = agentModelsConfig || {};
+    const models = (configData['ai.models'] as AIModelConfig[] | undefined) || [];
+    const defaultModels = (configData['ai.default_models'] as DefaultModelsConfig | undefined) || {};
+    const agentModels = (configData['ai.agent_models'] as Record<string, string> | undefined) || {};
     
     const explicitModel = resolveModelForContextWindow(modelName, models, defaultModels);
     if (explicitModel?.context_window) {
@@ -489,21 +535,38 @@ export async function switchChatSession(
     const switchRequestId = ++latestSwitchRequestId;
     const session = context.flowChatStore.getState().sessions.get(sessionId);
     const isRemoteSession = isRemoteTraceContext(session?.remoteConnectionId, session?.remoteSshHost);
-    const shouldHydrateBeforeSwitch =
-      session?.isHistorical === true &&
-      !isRemoteSession &&
-      !hasRenderableSessionContent(session);
+    const shouldHydrateBeforeSwitch = shouldHydrateHistoricalSessionBeforeSwitch(session);
+    const shouldActivateBeforeHydrate =
+      shouldHydrateBeforeSwitch &&
+      consumeRecentHistorySessionOpenIntent(sessionId);
 
     const touchActiveSessionInBackground = () => {
-      touchSessionActivity(
-        sessionId,
-        session?.workspacePath,
-        session?.remoteConnectionId,
-        session?.remoteSshHost
-      ).catch(error => {
-        log.debug('Failed to touch session activity', { sessionId, error });
+      scheduleSessionActivityTouch(() => {
+        const latestState = context.flowChatStore.getState();
+        const latestSession = latestState.sessions.get(sessionId);
+        if (switchRequestId !== latestSwitchRequestId || latestState.activeSessionId !== sessionId || !latestSession) {
+          return;
+        }
+        touchSessionActivity(
+          sessionId,
+          latestSession.workspacePath,
+          latestSession.remoteConnectionId,
+          latestSession.remoteSshHost
+        ).catch(error => {
+          log.debug('Failed to touch session activity', { sessionId, error });
+        });
       });
     };
+
+    if (shouldActivateBeforeHydrate) {
+      context.flowChatStore.switchSession(sessionId);
+      startupTrace.markPhase('historical_session_switch', {
+        historical: true,
+        remote: false,
+        activation: 'before-hydrate',
+      });
+      touchActiveSessionInBackground();
+    }
 
     if (shouldHydrateBeforeSwitch) {
       try {
@@ -523,14 +586,18 @@ export async function switchChatSession(
 
     // Avoid showing an empty loading page between two sessions. Historical
     // sessions without a renderable tail are activated after their first
-    // visible content is restored; already-renderable sessions still switch
-    // immediately and continue full hydration in the background.
-    context.flowChatStore.switchSession(sessionId);
-    touchActiveSessionInBackground();
-    startupTrace.markPhase('historical_session_switch', {
-      historical: Boolean(session?.isHistorical),
-      remote: isRemoteSession,
-    });
+    // visible content is restored unless a fresh user open intent is present.
+    // In that explicit path the intent shield keeps metadata-only content from
+    // flashing while the old large session is unmounted immediately.
+    if (!shouldActivateBeforeHydrate) {
+      context.flowChatStore.switchSession(sessionId);
+      startupTrace.markPhase('historical_session_switch', {
+        historical: Boolean(session?.isHistorical),
+        remote: isRemoteSession,
+        activation: shouldHydrateBeforeSwitch ? 'after-hydrate' : 'immediate',
+      });
+      touchActiveSessionInBackground();
+    }
 
     if (session?.isHistorical && !shouldHydrateBeforeSwitch) {
       // Load history in the background — do not block the UI.

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/index.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/index.ts
@@ -31,6 +31,7 @@ export {
 export {
   getModelMaxTokens,
   createChatSession,
+  preloadHistoricalSessionForOpen,
   switchChatSession,
   deleteChatSession,
   renameChatSessionTitle,

--- a/src/web-ui/src/flow_chat/services/sessionOpenIntent.test.ts
+++ b/src/web-ui/src/flow_chat/services/sessionOpenIntent.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearHistorySessionOpenTransition,
+  clearRecentHistorySessionOpenIntent,
+  consumeRecentHistorySessionOpenIntent,
+  dispatchHistorySessionOpenIntent,
+  getHistorySessionOpenTransitionSnapshot,
+  subscribeHistorySessionOpenTransition,
+} from './sessionOpenIntent';
+
+describe('sessionOpenIntent', () => {
+  afterEach(() => {
+    clearRecentHistorySessionOpenIntent();
+    clearHistorySessionOpenTransition();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('tracks and clears the active history session open transition', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeHistorySessionOpenTransition(listener);
+
+    dispatchHistorySessionOpenIntent('history-1', 'History 1');
+
+    expect(getHistorySessionOpenTransitionSnapshot()).toMatchObject({
+      sessionId: 'history-1',
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    clearHistorySessionOpenTransition('history-1');
+
+    expect(getHistorySessionOpenTransitionSnapshot()).toBeNull();
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it('keeps transition active when before-hydrate intent is consumed', () => {
+    dispatchHistorySessionOpenIntent('history-1');
+
+    expect(consumeRecentHistorySessionOpenIntent('history-1')).toBe(true);
+    expect(getHistorySessionOpenTransitionSnapshot()).toMatchObject({
+      sessionId: 'history-1',
+    });
+  });
+
+  it('notifies subscribers when a transition expires without owner cleanup', () => {
+    vi.useFakeTimers();
+    const listener = vi.fn();
+    const unsubscribe = subscribeHistorySessionOpenTransition(listener);
+
+    dispatchHistorySessionOpenIntent('history-1');
+
+    expect(getHistorySessionOpenTransitionSnapshot()).toMatchObject({
+      sessionId: 'history-1',
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(3_999);
+    expect(getHistorySessionOpenTransitionSnapshot()).toMatchObject({
+      sessionId: 'history-1',
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+
+    expect(getHistorySessionOpenTransitionSnapshot()).toBeNull();
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it('expires stale recent intents and stale transition snapshots', () => {
+    const now = vi.fn(() => 100);
+    vi.stubGlobal('performance', { now });
+
+    dispatchHistorySessionOpenIntent('history-1');
+
+    now.mockReturnValue(900);
+    expect(consumeRecentHistorySessionOpenIntent('history-1')).toBe(false);
+
+    now.mockReturnValue(4_200);
+    expect(getHistorySessionOpenTransitionSnapshot()).toBeNull();
+  });
+});

--- a/src/web-ui/src/flow_chat/services/sessionOpenIntent.ts
+++ b/src/web-ui/src/flow_chat/services/sessionOpenIntent.ts
@@ -1,10 +1,39 @@
 import type { Session } from '../types/flow-chat';
 
 export const HISTORY_SESSION_OPEN_INTENT_EVENT = 'flowchat:history-session-open-intent';
+const RECENT_HISTORY_OPEN_INTENT_MS = 750;
+const HISTORY_SESSION_OPEN_TRANSITION_MAX_MS = 4_000;
+
+let recentHistoryOpenIntent: { sessionId: string; atMs: number } | null = null;
+let activeHistorySessionOpenTransition: { sessionId: string; atMs: number } | null = null;
+let activeHistorySessionOpenTransitionTimer: ReturnType<typeof setTimeout> | null = null;
+const transitionListeners = new Set<() => void>();
 
 export interface HistorySessionOpenIntentDetail {
   sessionId: string;
   sessionTitle?: string;
+}
+
+export interface HistorySessionOpenTransitionSnapshot {
+  sessionId: string;
+  atMs: number;
+}
+
+const nowMs = (): number => (
+  typeof performance !== 'undefined' ? performance.now() : Date.now()
+);
+
+function notifyHistorySessionOpenTransitionListeners(): void {
+  for (const listener of transitionListeners) {
+    listener();
+  }
+}
+
+function clearHistorySessionOpenTransitionTimer(): void {
+  if (activeHistorySessionOpenTransitionTimer !== null) {
+    clearTimeout(activeHistorySessionOpenTransitionTimer);
+    activeHistorySessionOpenTransitionTimer = null;
+  }
 }
 
 export function shouldShowHistorySessionOpenIntent(session: Session | null | undefined): boolean {
@@ -25,6 +54,25 @@ export function shouldShowHistorySessionOpenIntent(session: Session | null | und
 }
 
 export function dispatchHistorySessionOpenIntent(sessionId: string, sessionTitle?: string): void {
+  const atMs = nowMs();
+  recentHistoryOpenIntent = {
+    sessionId,
+    atMs,
+  };
+  activeHistorySessionOpenTransition = { sessionId, atMs };
+  clearHistorySessionOpenTransitionTimer();
+  activeHistorySessionOpenTransitionTimer = setTimeout(() => {
+    if (
+      activeHistorySessionOpenTransition?.sessionId === sessionId &&
+      activeHistorySessionOpenTransition.atMs === atMs
+    ) {
+      activeHistorySessionOpenTransition = null;
+      activeHistorySessionOpenTransitionTimer = null;
+      notifyHistorySessionOpenTransitionListeners();
+    }
+  }, HISTORY_SESSION_OPEN_TRANSITION_MAX_MS);
+  notifyHistorySessionOpenTransitionListeners();
+
   if (typeof window === 'undefined') {
     return;
   }
@@ -33,4 +81,49 @@ export function dispatchHistorySessionOpenIntent(sessionId: string, sessionTitle
     HISTORY_SESSION_OPEN_INTENT_EVENT,
     { detail: { sessionId, sessionTitle } },
   ));
+}
+
+export function consumeRecentHistorySessionOpenIntent(sessionId: string): boolean {
+  const recent = recentHistoryOpenIntent;
+  if (!recent || recent.sessionId !== sessionId) {
+    return false;
+  }
+
+  const now = nowMs();
+  recentHistoryOpenIntent = null;
+  return now - recent.atMs <= RECENT_HISTORY_OPEN_INTENT_MS;
+}
+
+export function clearRecentHistorySessionOpenIntent(sessionId?: string): void {
+  if (!sessionId || recentHistoryOpenIntent?.sessionId === sessionId) {
+    recentHistoryOpenIntent = null;
+  }
+}
+
+export function getHistorySessionOpenTransitionSnapshot(): HistorySessionOpenTransitionSnapshot | null {
+  const transition = activeHistorySessionOpenTransition;
+  if (!transition) {
+    return null;
+  }
+
+  if (nowMs() - transition.atMs > HISTORY_SESSION_OPEN_TRANSITION_MAX_MS) {
+    return null;
+  }
+
+  return transition;
+}
+
+export function clearHistorySessionOpenTransition(sessionId?: string): void {
+  if (!sessionId || activeHistorySessionOpenTransition?.sessionId === sessionId) {
+    activeHistorySessionOpenTransition = null;
+    clearHistorySessionOpenTransitionTimer();
+    notifyHistorySessionOpenTransitionListeners();
+  }
+}
+
+export function subscribeHistorySessionOpenTransition(listener: () => void): () => void {
+  transitionListeners.add(listener);
+  return () => {
+    transitionListeners.delete(listener);
+  };
 }

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -13,13 +13,23 @@ const apiMocks = vi.hoisted(() => ({
   restoreSessionWithTurns: vi.fn(),
 }));
 
-const configManagerMock = vi.hoisted(() => ({
-  getConfig: vi.fn(async (path: string) => {
+const configManagerMock = vi.hoisted(() => {
+  const getConfig = vi.fn(async (path: string) => {
     if (path === 'ai.models') return [];
     if (path === 'ai.default_models') return {};
     return undefined;
-  }),
-}));
+  });
+  return {
+    getConfig,
+    getConfigs: vi.fn(async (paths: string[]) => {
+      const configs: Record<string, unknown> = {};
+      for (const path of paths) {
+        configs[path] = await getConfig(path);
+      }
+      return configs;
+    }),
+  };
+});
 
 const stateMachineManagerMock = vi.hoisted(() => ({
   getOrCreate: vi.fn(),
@@ -381,6 +391,10 @@ describe('FlowChatStore historical session hydration state', () => {
     const configPaths = configManagerMock.getConfig.mock.calls.map(([path]) => path);
     expect(configPaths.filter(path => path === 'ai.models')).toHaveLength(1);
     expect(configPaths.filter(path => path === 'ai.default_models')).toHaveLength(1);
+    expect(configManagerMock.getConfigs).toHaveBeenCalledWith([
+      'ai.models',
+      'ai.default_models',
+    ]);
     expect(flowChatStore.getState().sessions.get('history-1')?.maxContextTokens).toBe(256000);
     expect(flowChatStore.getState().sessions.get('history-2')?.maxContextTokens).toBe(256000);
   });

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -2748,20 +2748,19 @@ export class FlowChatStore {
     let defaultModels: Record<string, string> = {};
     try {
       const { configManager } = await import('@/infrastructure/config/services/ConfigManager');
-      const [modelsResult, defaultModelsResult] = await Promise.allSettled([
-        configManager.getConfig<any[]>('ai.models'),
-        configManager.getConfig<Record<string, string>>('ai.default_models'),
+      const configData = await configManager.getConfigs([
+        'ai.models',
+        'ai.default_models',
       ]);
 
-      if (modelsResult.status === 'fulfilled' && Array.isArray(modelsResult.value)) {
-        models = modelsResult.value;
+      if (Array.isArray(configData['ai.models'])) {
+        models = configData['ai.models'];
       }
       if (
-        defaultModelsResult.status === 'fulfilled' &&
-        defaultModelsResult.value &&
-        typeof defaultModelsResult.value === 'object'
+        configData['ai.default_models'] &&
+        typeof configData['ai.default_models'] === 'object'
       ) {
-        defaultModels = defaultModelsResult.value;
+        defaultModels = configData['ai.default_models'] as Record<string, string>;
       }
     } catch (error) {
       log.warn('Failed to load model config for session metadata, using defaults', { error });
@@ -3120,20 +3119,19 @@ export class FlowChatStore {
       let defaultModels: Record<string, string> = {};
       try {
         const { configManager } = await import('@/infrastructure/config/services/ConfigManager');
-        const [modelsResult, defaultModelsResult] = await Promise.allSettled([
-          configManager.getConfig<any[]>('ai.models'),
-          configManager.getConfig<Record<string, string>>('ai.default_models'),
+        const configData = await configManager.getConfigs([
+          'ai.models',
+          'ai.default_models',
         ]);
 
-        if (modelsResult.status === 'fulfilled' && Array.isArray(modelsResult.value)) {
-          models = modelsResult.value;
+        if (Array.isArray(configData['ai.models'])) {
+          models = configData['ai.models'];
         }
         if (
-          defaultModelsResult.status === 'fulfilled' &&
-          defaultModelsResult.value &&
-          typeof defaultModelsResult.value === 'object'
+          configData['ai.default_models'] &&
+          typeof configData['ai.default_models'] === 'object'
         ) {
-          defaultModels = defaultModelsResult.value;
+          defaultModels = configData['ai.default_models'] as Record<string, string>;
         }
       } catch (error) {
         log.warn('Failed to load model config for session metadata, using defaults', { error });

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.test.tsx
@@ -4,7 +4,13 @@ import { createRoot, type Root } from 'react-dom/client';
 import { JSDOM } from 'jsdom';
 
 import { FileOperationToolCard } from './FileOperationToolCard';
-import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
+import { FlowChatContext } from '../components/modern/FlowChatContext';
+import type { FlowToolItem, Session, ToolCardConfig } from '../types/flow-chat';
+import {
+  clearHistorySessionOpenTransition,
+  clearRecentHistorySessionOpenIntent,
+  dispatchHistorySessionOpenIntent,
+} from '../services/sessionOpenIntent';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -17,6 +23,9 @@ const mocks = vi.hoisted(() => ({
     originalContent: '',
     modifiedContent: '',
     anchorLine: undefined,
+  })),
+  useGitState: vi.fn(() => ({
+    isRepository: false,
   })),
 }));
 
@@ -102,9 +111,7 @@ vi.mock('@/shared/notification-system', () => ({
 }));
 
 vi.mock('@/tools/git/hooks/useGitState', () => ({
-  useGitState: () => ({
-    isRepository: false,
-  }),
+  useGitState: mocks.useGitState,
 }));
 
 describe('FileOperationToolCard', () => {
@@ -133,6 +140,10 @@ describe('FileOperationToolCard', () => {
     mocks.createDiffEditorTab.mockReset();
     mocks.openFile.mockReset();
     mocks.codePreviewProps = [];
+    mocks.useGitState.mockClear();
+    mocks.useGitState.mockReturnValue({
+      isRepository: false,
+    });
     mocks.getOperationDiff.mockReset();
     mocks.getOperationDiff.mockResolvedValue({
       originalContent: '',
@@ -141,11 +152,171 @@ describe('FileOperationToolCard', () => {
     });
   });
 
+  it('does not trigger passive git refresh while historical restore is pending', async () => {
+    mocks.currentWorkspace = { rootPath: 'D:/workspace/BitFun' };
+    const toolItem: FlowToolItem = {
+      id: 'tool-history',
+      type: 'tool',
+      toolName: 'Write',
+      status: 'completed',
+      toolCall: {
+        id: 'call-history',
+        name: 'Write',
+        input: {
+          file_path: 'src/newFile.ts',
+          content: 'export const value = 1;',
+        },
+      },
+      toolResult: {
+        success: true,
+        result: {
+          file_path: 'src/newFile.ts',
+        },
+      },
+    } as FlowToolItem;
+
+    await act(async () => {
+      root.render(
+        <FlowChatContext.Provider
+          value={{
+            sessionId: 'history-session',
+            activeSessionOverride: {
+              sessionId: 'history-session',
+              isHistorical: true,
+              contextRestoreState: 'pending',
+            } as Session,
+          }}
+        >
+          <FileOperationToolCard
+            toolItem={toolItem}
+            config={{} as ToolCardConfig}
+            sessionId="history-session"
+          />
+        </FlowChatContext.Provider>
+      );
+    });
+
+    expect(mocks.useGitState).toHaveBeenCalledWith(expect.objectContaining({
+      repositoryPath: 'D:/workspace/BitFun',
+      isActive: false,
+      refreshOnMount: false,
+      refreshOnActive: false,
+      participateInWindowFocusRefresh: false,
+      layers: ['basic'],
+    }));
+  });
+
+  it('keeps passive git refresh enabled for normal active sessions', async () => {
+    mocks.currentWorkspace = { rootPath: 'D:/workspace/BitFun' };
+    const toolItem: FlowToolItem = {
+      id: 'tool-active',
+      type: 'tool',
+      toolName: 'Write',
+      status: 'completed',
+      toolCall: {
+        id: 'call-active',
+        name: 'Write',
+        input: {
+          file_path: 'src/newFile.ts',
+          content: 'export const value = 1;',
+        },
+      },
+      toolResult: {
+        success: true,
+        result: {
+          file_path: 'src/newFile.ts',
+        },
+      },
+    } as FlowToolItem;
+
+    await act(async () => {
+      root.render(
+        <FlowChatContext.Provider
+          value={{
+            sessionId: 'active-session',
+            activeSessionOverride: {
+              sessionId: 'active-session',
+              isHistorical: false,
+            } as Session,
+          }}
+        >
+          <FileOperationToolCard
+            toolItem={toolItem}
+            config={{} as ToolCardConfig}
+            sessionId="active-session"
+          />
+        </FlowChatContext.Provider>
+      );
+    });
+
+    expect(mocks.useGitState).toHaveBeenCalledWith(expect.objectContaining({
+      repositoryPath: 'D:/workspace/BitFun',
+      isActive: true,
+      refreshOnMount: true,
+      refreshOnActive: false,
+    }));
+  });
+
   afterEach(() => {
     act(() => {
       root.unmount();
     });
+    clearRecentHistorySessionOpenIntent();
+    clearHistorySessionOpenTransition();
     vi.unstubAllGlobals();
+  });
+
+  it('does not trigger passive git refresh during history open transition', async () => {
+    mocks.currentWorkspace = { rootPath: 'D:/workspace/BitFun' };
+    dispatchHistorySessionOpenIntent('history-session', 'History');
+    const toolItem: FlowToolItem = {
+      id: 'tool-transition',
+      type: 'tool',
+      toolName: 'Write',
+      status: 'completed',
+      toolCall: {
+        id: 'call-transition',
+        name: 'Write',
+        input: {
+          file_path: 'src/newFile.ts',
+          content: 'export const value = 1;',
+        },
+      },
+      toolResult: {
+        success: true,
+        result: {
+          file_path: 'src/newFile.ts',
+        },
+      },
+    } as FlowToolItem;
+
+    await act(async () => {
+      root.render(
+        <FlowChatContext.Provider
+          value={{
+            sessionId: 'history-session',
+            activeSessionOverride: {
+              sessionId: 'history-session',
+              isHistorical: true,
+              contextRestoreState: 'ready',
+            } as Session,
+          }}
+        >
+          <FileOperationToolCard
+            toolItem={toolItem}
+            config={{} as ToolCardConfig}
+            sessionId="history-session"
+          />
+        </FlowChatContext.Provider>
+      );
+    });
+
+    expect(mocks.useGitState).toHaveBeenCalledWith(expect.objectContaining({
+      repositoryPath: 'D:/workspace/BitFun',
+      isActive: false,
+      refreshOnMount: false,
+      refreshOnActive: false,
+    }));
   });
 
   it('renders failed write cards outside WorkspaceProvider', () => {

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -13,7 +13,7 @@
  *   instead of relying on `VirtualMessageList` fallback compensation.
  */
 
-import React, { useEffect, useCallback, useMemo, useState, useRef, useLayoutEffect } from 'react';
+import React, { useEffect, useCallback, useMemo, useState, useRef, useLayoutEffect, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 import path from 'path-browserify';
 import {
@@ -56,6 +56,11 @@ import {
 } from './fileToolGuidance';
 import { extractFilePathFromJsonBuffer } from '@/shared/utils/partialJsonParser';
 import { i18nService } from '@/infrastructure/i18n';
+import { useFlowChatContext } from '../components/modern/FlowChatContext';
+import {
+  getHistorySessionOpenTransitionSnapshot,
+  subscribeHistorySessionOpenTransition,
+} from '../services/sessionOpenIntent';
 import './FileOperationToolCard.scss';
 
 const log = createLogger('FileOperationToolCard');
@@ -112,6 +117,7 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   onOpenInEditor,
   onConfirm,
   onReject,
+  displayContext,
 }) => {
   const { t } = useTranslation('flow-chat');
   const {
@@ -148,10 +154,28 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   } = useSnapshotState(sessionId);
   const eventBus = SnapshotEventBus.getInstance();
   const { workspace: currentWorkspace } = useOptionalCurrentWorkspace();
+  const { activeSessionOverride } = useFlowChatContext();
+  const historySessionOpenTransition = useSyncExternalStore(
+    subscribeHistorySessionOpenTransition,
+    getHistorySessionOpenTransitionSnapshot,
+    getHistorySessionOpenTransitionSnapshot,
+  );
+  const isHistoricalRestorePending =
+    activeSessionOverride?.sessionId === sessionId &&
+    activeSessionOverride?.isHistorical === true &&
+    activeSessionOverride?.contextRestoreState === 'pending';
+  const allowPassiveGitRefresh =
+    historySessionOpenTransition === null &&
+    displayContext !== 'subagent-projection' &&
+    !isHistoricalRestorePending;
   const { isRepository: workspaceIsGitRepo } = useGitState({
     repositoryPath: currentWorkspace?.rootPath ?? '',
+    isActive: allowPassiveGitRefresh,
     layers: ['basic'],
+    refreshOnMount: allowPassiveGitRefresh,
+    refreshOnActive: false,
     participateInWindowFocusRefresh: false,
+    debugSource: 'file_operation_tool_card',
   });
 
   const getFilePath = useCallback((): string => {

--- a/src/web-ui/src/infrastructure/api/service-api/GitAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/GitAPI.ts
@@ -3,6 +3,7 @@
 import { api } from './ApiClient';
 import { createTauriCommandError } from '../errors/TauriCommandError';
 import { createLogger } from '@/shared/utils/logger';
+import { startupTrace } from '@/shared/utils/startupTrace';
 
 const log = createLogger('GitAPI');
 const REPOSITORY_PROBE_CACHE_TTL_MS = 1000;
@@ -241,8 +242,11 @@ export class GitAPI {
   }
 
    
-  async getStatus(repositoryPath: string): Promise<GitStatus> {
+  async getStatus(repositoryPath: string, traceSource = 'unknown'): Promise<GitStatus> {
     try {
+      if (globalThis.__BITFUN_PERF_TRACE_ENABLED__ === true) {
+        startupTrace.markPhase('git_status_request', { source: traceSource });
+      }
       return await api.invoke('git_get_status', { 
         request: { repositoryPath } 
       });

--- a/src/web-ui/src/infrastructure/config/services/ConfigManager.test.ts
+++ b/src/web-ui/src/infrastructure/config/services/ConfigManager.test.ts
@@ -56,6 +56,98 @@ describe('ConfigManager', () => {
     expect(configApiMocks.getConfig).toHaveBeenCalledTimes(1);
   });
 
+  it('batches cold multi-path reads and caches the returned configs', async () => {
+    configApiMocks.getConfigs.mockResolvedValueOnce({
+      'ai.models': [{ id: 'model-1' }],
+      'ai.default_models': { primary: 'model-1' },
+      'ai.agent_models': { agentic: 'primary' },
+    });
+
+    const configs = await configManager.getConfigs([
+      'ai.models',
+      'ai.default_models',
+      'ai.agent_models',
+    ]);
+
+    expect(configApiMocks.getConfigs).toHaveBeenCalledTimes(1);
+    expect(configApiMocks.getConfigs).toHaveBeenCalledWith([
+      'ai.models',
+      'ai.default_models',
+      'ai.agent_models',
+    ]);
+    expect(configApiMocks.getConfig).not.toHaveBeenCalled();
+    expect(configs['ai.models']).toMatchObject([{ id: 'model-1' }]);
+    await expect(configManager.getConfig('ai.default_models')).resolves.toEqual({ primary: 'model-1' });
+    expect(configApiMocks.getConfig).not.toHaveBeenCalled();
+  });
+
+  it('reuses in-flight single-path reads when batching overlapping config paths', async () => {
+    const defaultModels = createDeferred<Record<string, string>>();
+    configApiMocks.getConfig.mockReturnValueOnce(defaultModels.promise);
+    configApiMocks.getConfigs.mockResolvedValueOnce({
+      'ai.models': [],
+      'ai.agent_models': { agentic: 'fast' },
+    });
+
+    const singleRead = configManager.getConfig('ai.default_models');
+    const batchRead = configManager.getConfigs([
+      'ai.models',
+      'ai.default_models',
+      'ai.agent_models',
+    ]);
+
+    expect(configApiMocks.getConfigs).toHaveBeenCalledWith([
+      'ai.models',
+      'ai.agent_models',
+    ]);
+    defaultModels.resolve({ primary: 'model-1' });
+
+    await expect(singleRead).resolves.toEqual({ primary: 'model-1' });
+    await expect(batchRead).resolves.toEqual({
+      'ai.models': [],
+      'ai.default_models': { primary: 'model-1' },
+      'ai.agent_models': { agentic: 'fast' },
+    });
+    expect(configApiMocks.getConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles batched in-flight reads before propagating overlapping non-fallback failures', async () => {
+    const loggingLevel = createDeferred<string>();
+    const batchedConfigs = createDeferred<Record<string, unknown>>();
+    configApiMocks.getConfig.mockReturnValueOnce(loggingLevel.promise);
+    configApiMocks.getConfigs.mockReturnValueOnce(batchedConfigs.promise);
+
+    const singleRead = configManager.getConfig('app.logging.level');
+    const batchRead = configManager.getConfigs([
+      'app.logging.level',
+      'app.window.mode',
+    ]);
+
+    expect(configApiMocks.getConfigs).toHaveBeenCalledWith(['app.window.mode']);
+
+    loggingLevel.reject(new Error('single read failed'));
+    batchedConfigs.resolve({ 'app.window.mode': 'compact' });
+
+    await expect(singleRead).rejects.toThrow('single read failed');
+    await expect(batchRead).rejects.toThrow('single read failed');
+    await expect(configManager.getConfig('app.window.mode')).resolves.toBe('compact');
+    expect(configApiMocks.getConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns AI config fallbacks when a batch read fails', async () => {
+    configApiMocks.getConfigs.mockRejectedValueOnce(new Error('batch failed'));
+
+    await expect(configManager.getConfigs([
+      'ai.models',
+      'ai.default_models',
+      'ai.agent_models',
+    ])).resolves.toEqual({
+      'ai.models': [],
+      'ai.default_models': {},
+      'ai.agent_models': {},
+    });
+  });
+
   it('reloads startup config paths through one batch call', async () => {
     configApiMocks.getConfigs.mockResolvedValueOnce({
       'ai.models': [],

--- a/src/web-ui/src/infrastructure/config/services/ConfigManager.ts
+++ b/src/web-ui/src/infrastructure/config/services/ConfigManager.ts
@@ -151,6 +151,24 @@ class ConfigManagerImpl implements IConfigManager {
     return resolvedConfigs;
   }
 
+  private getFallbackConfigValue(path?: string): { hasFallback: boolean; value: unknown } {
+    if (path === 'ai.models') {
+      return { hasFallback: true, value: [] };
+    }
+    if (path === 'ai.agent_models' || path === 'ai.func_agent_models' || path === 'ai.default_models') {
+      return { hasFallback: true, value: {} };
+    }
+    return { hasFallback: false, value: undefined };
+  }
+
+  private fallbackOrThrow(path: string | undefined, error: unknown): unknown {
+    const fallback = this.getFallbackConfigValue(path);
+    if (fallback.hasFallback) {
+      return fallback.value;
+    }
+    throw error;
+  }
+
   async getConfig<T = any>(path?: string): Promise<T> {
     try {
       
@@ -190,6 +208,86 @@ class ConfigManagerImpl implements IConfigManager {
       }
       throw error;
     }
+  }
+
+  async getConfigs(paths: string[]): Promise<Record<string, unknown>> {
+    const uniquePaths = Array.from(new Set(paths));
+    const results: Record<string, unknown> = {};
+    const pendingReads: Array<[string, Promise<unknown>]> = [];
+    const missingPaths: string[] = [];
+
+    for (const path of uniquePaths) {
+      if (this.configCache.has(path)) {
+        results[path] = this.configCache.get(path);
+        continue;
+      }
+
+      const existingRead = this.inFlightReads.get(this.getReadKey(path));
+      if (existingRead) {
+        pendingReads.push([path, existingRead]);
+        continue;
+      }
+
+      missingPaths.push(path);
+    }
+
+    const batchRead = missingPaths.length > 0
+      ? this.readConfigs(missingPaths)
+      : undefined;
+    const perPathReads = new Map<string, Promise<unknown>>();
+    if (batchRead) {
+      for (const path of missingPaths) {
+        const perPathRead = batchRead.then(configs => configs[path]);
+        void perPathRead.catch(() => undefined);
+        perPathReads.set(path, perPathRead);
+        this.inFlightReads.set(this.getReadKey(path), perPathRead);
+      }
+    }
+
+    let fatalError: unknown;
+
+    try {
+      for (const [path, pendingRead] of pendingReads) {
+        try {
+          results[path] = await pendingRead;
+        } catch (error) {
+          try {
+            results[path] = this.fallbackOrThrow(path, error);
+          } catch (fallbackError) {
+            fatalError ??= fallbackError;
+          }
+        }
+      }
+
+      if (batchRead) {
+        try {
+          const batchResults = await batchRead;
+          Object.assign(results, batchResults);
+        } catch (error) {
+          log.error('Failed to get configs', { paths: missingPaths, error });
+          for (const path of missingPaths) {
+            try {
+              results[path] = this.fallbackOrThrow(path, error);
+            } catch (fallbackError) {
+              fatalError ??= fallbackError;
+            }
+          }
+        }
+      }
+    } finally {
+      for (const [path, perPathRead] of perPathReads) {
+        const readKey = this.getReadKey(path);
+        if (this.inFlightReads.get(readKey) === perPathRead) {
+          this.inFlightReads.delete(readKey);
+        }
+      }
+    }
+
+    if (fatalError) {
+      throw fatalError;
+    }
+
+    return results;
   }
 
   async setConfig<T = any>(path: string, value: T): Promise<void> {

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -474,6 +474,7 @@ export interface WorkspaceConfig {
 
 export interface IConfigManager {
   getConfig<T = any>(path?: string): Promise<T>;
+  getConfigs(paths: string[]): Promise<Record<string, unknown>>;
   setConfig<T = any>(path: string, value: T): Promise<void>;
   resetConfig(path?: string): Promise<void>;
   validateConfig(): Promise<ConfigValidationResult>;

--- a/src/web-ui/src/tools/git/hooks/useGitState.test.tsx
+++ b/src/web-ui/src/tools/git/hooks/useGitState.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useGitState } from './useGitState';
+
+const gitStateManagerMock = vi.hoisted(() => ({
+  getState: vi.fn(() => null),
+  subscribe: vi.fn(() => vi.fn()),
+  registerWindowFocusRefresh: vi.fn(() => vi.fn()),
+  refresh: vi.fn(() => Promise.resolve()),
+  cancelPendingRefresh: vi.fn(() => false),
+}));
+
+vi.mock('../state/GitStateManager', () => ({
+  gitStateManager: gitStateManagerMock,
+}));
+
+vi.mock('@/shared/utils/debugProbe', () => ({
+  sendDebugProbe: vi.fn(),
+}));
+
+function GitStateHarness({
+  isActive,
+  refreshOnMount = true,
+  cancelPendingRefreshSources,
+}: {
+  isActive: boolean;
+  refreshOnMount?: boolean;
+  cancelPendingRefreshSources?: string[];
+}): null {
+  useGitState({
+    repositoryPath: 'D:/workspace/BitFun',
+    isActive,
+    refreshOnMount,
+    refreshOnActive: true,
+    layers: ['basic', 'status'],
+    cancelPendingRefreshSources,
+  });
+  return null;
+}
+
+describe('useGitState visibility refresh', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it('does not refresh inactive consumers on first mount and refreshes when activated', async () => {
+    await act(async () => {
+      root.render(<GitStateHarness isActive={false} />);
+    });
+
+    expect(gitStateManagerMock.refresh).not.toHaveBeenCalled();
+    expect(gitStateManagerMock.registerWindowFocusRefresh).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.render(<GitStateHarness isActive />);
+    });
+
+    expect(gitStateManagerMock.refresh).toHaveBeenCalledTimes(1);
+    expect(gitStateManagerMock.refresh).toHaveBeenCalledWith(
+      'D:/workspace/BitFun',
+      {
+        layers: ['basic', 'status'],
+        reason: 'visibility',
+        source: 'use_git_state',
+      },
+    );
+    expect(gitStateManagerMock.registerWindowFocusRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels and replays active automatic refreshes when mount refresh is temporarily suppressed', async () => {
+    await act(async () => {
+      root.render(<GitStateHarness isActive refreshOnMount />);
+    });
+
+    expect(gitStateManagerMock.refresh).toHaveBeenCalledWith(
+      'D:/workspace/BitFun',
+      {
+        layers: ['basic', 'status'],
+        reason: 'mount',
+        source: 'use_git_state',
+      },
+    );
+
+    vi.clearAllMocks();
+
+    await act(async () => {
+      root.render(
+        <GitStateHarness
+          isActive
+          refreshOnMount={false}
+          cancelPendingRefreshSources={['workspace_git_initializer']}
+        />,
+      );
+    });
+
+    expect(gitStateManagerMock.cancelPendingRefresh).toHaveBeenCalledTimes(4);
+    for (const reason of ['mount', 'visibility']) {
+      expect(gitStateManagerMock.cancelPendingRefresh).toHaveBeenCalledWith(
+        'D:/workspace/BitFun',
+        {
+          layers: ['basic', 'status'],
+          reason,
+          source: 'use_git_state',
+        },
+      );
+      expect(gitStateManagerMock.cancelPendingRefresh).toHaveBeenCalledWith(
+        'D:/workspace/BitFun',
+        {
+          layers: ['basic', 'status'],
+          reason,
+          source: 'workspace_git_initializer',
+        },
+      );
+    }
+    expect(gitStateManagerMock.refresh).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+
+    await act(async () => {
+      root.render(<GitStateHarness isActive refreshOnMount />);
+    });
+
+    expect(gitStateManagerMock.refresh).toHaveBeenCalledWith(
+      'D:/workspace/BitFun',
+      {
+        layers: ['basic', 'status'],
+        reason: 'visibility',
+        source: 'use_git_state',
+      },
+    );
+  });
+});

--- a/src/web-ui/src/tools/git/hooks/useGitState.ts
+++ b/src/web-ui/src/tools/git/hooks/useGitState.ts
@@ -39,9 +39,16 @@ import {
 } from '../state/types';
 import type { GitBranch, GitCommit } from '../types/repository';
 
+const DEFAULT_CANCEL_PENDING_REFRESH_SOURCES: readonly string[] = [];
+
 export type GitBasicInfoOptions = Pick<
   UseGitStateOptions,
-  'isActive' | 'participateInWindowFocusRefresh' | 'refreshOnMount' | 'refreshOnActive'
+  | 'isActive'
+  | 'participateInWindowFocusRefresh'
+  | 'refreshOnMount'
+  | 'refreshOnActive'
+  | 'debugSource'
+  | 'cancelPendingRefreshSources'
 >;
 
 export function useGitState(options: UseGitStateOptions): UseGitStateReturn {
@@ -52,6 +59,8 @@ export function useGitState(options: UseGitStateOptions): UseGitStateReturn {
     selector,
     refreshOnMount = true,
     refreshOnActive = true,
+    debugSource = 'use_git_state',
+    cancelPendingRefreshSources = DEFAULT_CANCEL_PENDING_REFRESH_SOURCES,
     layers,
   } = options;
 
@@ -68,6 +77,7 @@ export function useGitState(options: UseGitStateOptions): UseGitStateReturn {
   const mountedRef = useRef(true);
   const selectorRef = useRef(selector);
   const layersRef = useRef(layers);
+  const suppressedMountRefreshRef = useRef(false);
 
   useEffect(() => {
     selectorRef.current = selector;
@@ -122,30 +132,79 @@ export function useGitState(options: UseGitStateOptions): UseGitStateReturn {
   }, [isActive, normalizedPath, participateInWindowFocusRefresh]);
 
   useEffect(() => {
+    if (!normalizedPath || !isActive) {
+      return;
+    }
+
+    if (!refreshOnMount) {
+      const layersToRefresh = layersRef.current || ['basic', 'status'];
+      const sourcesToCancel = Array.from(new Set([
+        debugSource,
+        ...cancelPendingRefreshSources,
+      ].filter(Boolean)));
+      const cancelAutomaticRefresh = (reason: 'mount' | 'visibility') => {
+        for (const source of sourcesToCancel) {
+          gitStateManager.cancelPendingRefresh(normalizedPath, {
+            layers: layersToRefresh,
+            reason,
+            source,
+          });
+        }
+      };
+
+      cancelAutomaticRefresh('mount');
+      cancelAutomaticRefresh('visibility');
+      suppressedMountRefreshRef.current = true;
+      return;
+    }
+
+    if (!suppressedMountRefreshRef.current) {
+      return;
+    }
+
+    suppressedMountRefreshRef.current = false;
+    gitStateManager.refresh(normalizedPath, {
+      layers: layersRef.current || ['basic', 'status'],
+      reason: 'visibility',
+      source: debugSource,
+    });
+  }, [
+    cancelPendingRefreshSources,
+    debugSource,
+    isActive,
+    normalizedPath,
+    refreshOnMount,
+  ]);
+
+  useEffect(() => {
     if (!normalizedPath) return;
 
     const isFirstMount = isFirstMountRef.current;
     isFirstMountRef.current = false;
 
-    const shouldRefresh = 
-      (isFirstMount && refreshOnMount) ||
-      (!isFirstMount && isActive && !prevActiveRef.current && refreshOnActive);
+    const shouldRefresh =
+      isActive && (
+        (isFirstMount && refreshOnMount) ||
+        (!isFirstMount && !prevActiveRef.current && refreshOnActive)
+      );
 
     if (shouldRefresh) {
       sendDebugProbe('useGitState.ts:visibilityEffect', 'Git refresh requested', {
         repositoryPath: normalizedPath,
         isActive,
         reason: isFirstMount ? 'mount' : 'visibility',
+        source: debugSource,
         layers: layersRef.current || ['basic', 'status'],
       });
       gitStateManager.refresh(normalizedPath, {
         layers: layersRef.current || ['basic', 'status'],
         reason: isFirstMount ? 'mount' : 'visibility',
+        source: debugSource,
       });
     }
 
     prevActiveRef.current = isActive;
-  }, [isActive, normalizedPath, refreshOnMount, refreshOnActive]);
+  }, [debugSource, isActive, normalizedPath, refreshOnMount, refreshOnActive]);
 
   const refresh = useCallback(
     async (options?: RefreshOptions): Promise<void> => {
@@ -185,12 +244,10 @@ export function useGitState(options: UseGitStateOptions): UseGitStateReturn {
     ahead: state?.ahead ?? 0,
     behind: state?.behind ?? 0,
     hasChanges: state?.hasChanges ?? false,
-
     staged: state?.staged ?? [],
     unstaged: state?.unstaged ?? [],
     untracked: state?.untracked ?? [],
     conflicts: state?.conflicts ?? [],
-
     branches: state?.branches,
     commits: state?.commits,
   };
@@ -211,6 +268,8 @@ export function useGitBasicInfo(
     layers: ['basic'],
     refreshOnMount: options.refreshOnMount ?? true,
     refreshOnActive: options.refreshOnActive ?? false,
+    debugSource: options.debugSource ?? 'use_git_basic_info',
+    cancelPendingRefreshSources: options.cancelPendingRefreshSources,
   });
 }
 
@@ -227,6 +286,7 @@ export function useGitFileStatus(
     layers: ['basic', 'status'],
     refreshOnMount: true,
     refreshOnActive: true,
+    debugSource: 'use_git_file_status',
   });
 }
 
@@ -241,6 +301,7 @@ export function useGitBranches(repositoryPath: string): {
     repositoryPath,
     layers: ['basic', 'detailed'],
     refreshOnMount: true,
+    debugSource: 'use_git_branches',
   });
 
   return {
@@ -263,6 +324,7 @@ export function useGitCommits(repositoryPath: string): {
     repositoryPath,
     layers: ['detailed'],
     refreshOnMount: true,
+    debugSource: 'use_git_commits',
   });
 
   return {

--- a/src/web-ui/src/tools/git/services/GitService.ts
+++ b/src/web-ui/src/tools/git/services/GitService.ts
@@ -230,7 +230,7 @@ export class GitService {
       );
       
       const result = await Promise.race([
-        gitAPI.getStatus(repositoryPath),
+        gitAPI.getStatus(repositoryPath, 'git_service'),
         timeoutPromise
       ]);
       

--- a/src/web-ui/src/tools/git/services/WorkspaceGitInitializer.test.ts
+++ b/src/web-ui/src/tools/git/services/WorkspaceGitInitializer.test.ts
@@ -33,6 +33,7 @@ describe('WorkspaceGitInitializer startup refresh', () => {
       layers: ['basic'],
       reason: 'mount',
       force: true,
+      source: 'workspace_git_initializer',
     });
   });
 });

--- a/src/web-ui/src/tools/git/services/WorkspaceGitInitializer.ts
+++ b/src/web-ui/src/tools/git/services/WorkspaceGitInitializer.ts
@@ -68,6 +68,7 @@ class WorkspaceGitInitializer {
         layers: ['basic'],
         reason: 'mount',
         force: true,
+        source: 'workspace_git_initializer',
       });
     } catch (error) {
       log.error('Failed to initialize Git state', { workspacePath, error });
@@ -95,6 +96,7 @@ class WorkspaceGitInitializer {
         layers: ['basic'],
         reason: 'mount',
         force: true,
+        source: 'workspace_git_initializer',
       });
     } catch (error) {
       log.error('Failed to initialize Git state for switched workspace', { workspacePath, error });

--- a/src/web-ui/src/tools/git/state/GitStateManager.test.ts
+++ b/src/web-ui/src/tools/git/state/GitStateManager.test.ts
@@ -132,6 +132,31 @@ describe('GitStateManager refresh performance guards', () => {
     expect(gitApiMocks.getStatus).toHaveBeenCalledTimes(1);
   });
 
+  it('cancels pending refreshes by merged source token before debounce execution', async () => {
+    const first = manager.refresh(repositoryPath, {
+      layers: ['basic'],
+      reason: 'mount',
+      source: 'workspace_git_initializer',
+    });
+    const second = manager.refresh(repositoryPath, {
+      layers: ['basic'],
+      reason: 'mount',
+      source: 'workspace_item_git_basic_info',
+    });
+
+    expect(manager.cancelPendingRefresh(repositoryPath, {
+      layers: ['basic'],
+      reason: 'mount',
+      source: 'workspace_item_git_basic_info',
+    })).toBe(true);
+
+    await Promise.all([first, second]);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(gitApiMocks.isGitRepository).not.toHaveBeenCalled();
+    expect(gitApiMocks.getRepositoryBasic).not.toHaveBeenCalled();
+  });
+
   it('does not run force refresh concurrently with an in-flight refresh', async () => {
     const firstStatus = deferred<Awaited<ReturnType<typeof gitApiMocks.getStatus>>>();
     gitApiMocks.getStatus

--- a/src/web-ui/src/tools/git/state/GitStateManager.ts
+++ b/src/web-ui/src/tools/git/state/GitStateManager.ts
@@ -33,6 +33,7 @@ import {
 } from './types';
 import { createLogger } from '@/shared/utils/logger';
 import { sendDebugProbe } from '@/shared/utils/debugProbe';
+import { startupTrace } from '@/shared/utils/startupTrace';
 import { elapsedMs, nowMs } from '@/shared/utils/timing';
 import { i18nService } from '@/infrastructure/i18n';
 
@@ -47,8 +48,13 @@ interface PendingRefresh {
   layers: Set<GitStateLayer>;
   force: boolean;
   reason: RefreshReason;
+  source?: string;
   resolve: () => void;
   reject: (error: Error) => void;
+}
+
+function pendingRefreshIncludesSource(pendingSource: string | undefined, source: string): boolean {
+  return pendingSource?.split('|').includes(source) === true;
 }
 
 export class GitStateManager {
@@ -151,9 +157,44 @@ export class GitStateManager {
       layers = ['basic', 'status'],
       silent = false,
       reason = 'manual',
+      source,
     } = options;
 
-    return this.enqueueRefresh(normalizedPath, layers, force, reason, silent);
+    return this.enqueueRefresh(normalizedPath, layers, force, reason, silent, source);
+  }
+
+  cancelPendingRefresh(
+    repositoryPath: string,
+    options: {
+      reason?: RefreshReason;
+      source?: string;
+      layers?: GitStateLayer[];
+    } = {}
+  ): boolean {
+    const normalizedPath = this.normalizePath(repositoryPath);
+    const pending = this.pendingRefreshes.get(normalizedPath);
+    if (!pending) {
+      return false;
+    }
+
+    if (options.reason && pending.reason !== options.reason) {
+      return false;
+    }
+    if (options.source && !pendingRefreshIncludesSource(pending.source, options.source)) {
+      return false;
+    }
+    if (options.layers?.some(layer => !pending.layers.has(layer))) {
+      return false;
+    }
+
+    const timer = this.refreshDebounceTimers.get(normalizedPath);
+    if (timer) {
+      clearTimeout(timer);
+      this.refreshDebounceTimers.delete(normalizedPath);
+    }
+    this.pendingRefreshes.delete(normalizedPath);
+    pending.resolve();
+    return true;
   }
 
   /**
@@ -235,7 +276,8 @@ export class GitStateManager {
     layers: GitStateLayer[],
     force: boolean,
     reason: RefreshReason,
-    silent: boolean
+    silent: boolean,
+    source?: string
   ): Promise<void> {
 
     const existingTimer = this.refreshDebounceTimers.get(repositoryPath);
@@ -253,12 +295,16 @@ export class GitStateManager {
       if (force) {
         pending.force = true;
       }
+      if (source && pending.source !== source) {
+        pending.source = pending.source ? `${pending.source}|${source}` : source;
+      }
     } else {
 
       pending = {
         layers: new Set(layers),
         force,
         reason,
+        source,
         resolve: () => {},
         reject: () => {},
       };
@@ -302,7 +348,7 @@ export class GitStateManager {
     this.pendingRefreshes.delete(repositoryPath);
     this.refreshDebounceTimers.delete(repositoryPath);
 
-    const { layers, force, reason, resolve, reject } = pending;
+    const { layers, force, reason, source, resolve, reject } = pending;
 
     try {
       await this.doRefresh(
@@ -310,7 +356,8 @@ export class GitStateManager {
         Array.from(layers),
         force,
         reason,
-        silent
+        silent,
+        source
       );
       resolve();
     } catch (error) {
@@ -326,7 +373,8 @@ export class GitStateManager {
     layers: GitStateLayer[],
     force: boolean,
     reason: RefreshReason,
-    silent: boolean
+    silent: boolean,
+    source?: string
   ): Promise<void> {
     const existingLock = this.refreshLocks.get(repositoryPath);
     if (existingLock) {
@@ -431,11 +479,25 @@ export class GitStateManager {
       } finally {
         const durationMs = elapsedMs(startedAt);
         if (probeError || shouldProbeReason || durationMs >= 80) {
+          if (globalThis.__BITFUN_PERF_TRACE_ENABLED__ === true) {
+            startupTrace.markPhase('git_state_refresh', {
+              reason,
+              force,
+              silent,
+              requestedLayers: layers,
+              refreshedLayers: layersToRefresh,
+              durationMs,
+              outcome: probeOutcome,
+              error: probeError,
+              source,
+            });
+          }
           sendDebugProbe('GitStateManager.ts:doRefresh', 'Git refresh completed', {
             repositoryPath,
             reason,
             force,
             silent,
+            source,
             requestedLayers: layers,
             refreshedLayers: layersToRefresh,
             durationMs,
@@ -488,7 +550,7 @@ export class GitStateManager {
         return;
       }
 
-      const status = await gitAPI.getStatus(repositoryPath);
+      const status = await gitAPI.getStatus(repositoryPath, 'git_state_manager');
 
       const hasChanges =
         (status.staged?.length || 0) > 0 ||

--- a/src/web-ui/src/tools/git/state/types.ts
+++ b/src/web-ui/src/tools/git/state/types.ts
@@ -69,6 +69,7 @@ export interface RefreshOptions {
   layers?: GitStateLayer[];
   silent?: boolean;
   reason?: RefreshReason;
+  source?: string;
 }
 
 export type RefreshReason =
@@ -126,6 +127,15 @@ export interface UseGitStateOptions {
   
   /** Refresh when activated */
   refreshOnActive?: boolean;
+
+  /** Debug/performance source label for automatic refreshes. */
+  debugSource?: string;
+
+  /**
+   * Additional automatic refresh source labels that may be cancelled while this
+   * consumer temporarily suppresses mount refreshes.
+   */
+  cancelPendingRefreshSources?: readonly string[];
   
   /** Layers to subscribe to */
   layers?: GitStateLayer[];

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs/promises';
 import * as fsSync from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { performance as nodePerformance } from 'node:perf_hooks';
 import {
   readPerformanceNow,
   readStartupTraceSnapshot,
@@ -3581,6 +3582,9 @@ type RapidLongSessionSwitchMeasurement = {
   clickPlan: Array<{
     sessionId: string;
     clickedAtMs: number;
+    findDurationMs: number;
+    clickDurationMs: number;
+    pauseDurationMs?: number;
   }>;
   activeSessionIdAtEnd: string | null;
   targetLatestVisibleAtMs: number;
@@ -3592,6 +3596,9 @@ type RapidLongSessionSwitchMeasurement = {
     target: {
       clickedAtMs: number;
       clickSinceFirstClickMs: number;
+      findDurationMs: number;
+      clickDurationMs: number;
+      pauseBeforeTargetMs: number;
       clickToLatestVisibleMs: number;
       clickToLatestUsableMs: number;
       latestVisibleToUsableMs: number;
@@ -3877,18 +3884,32 @@ async function collectRapidLongSessionSwitchMeasurement(
 
   for (let index = 0; index < sessionIds.length; index += 1) {
     const sessionId = sessionIds[index];
+    const findStartedAtRunnerMs = nodePerformance.now();
     const item = await findSessionItem(sessionId);
+    const findDurationMs = nodePerformance.now() - findStartedAtRunnerMs;
     if (!item) {
       throw new Error(`Rapid switch session disappeared before click: ${sessionId}`);
     }
-    clickPlan.push({
+    const itemClickedAtMs = await readPerformanceNow();
+    const clickPlanEntry: RapidLongSessionSwitchMeasurement['clickPlan'][number] = {
       sessionId,
-      clickedAtMs: await readPerformanceNow(),
+      clickedAtMs: itemClickedAtMs,
+      findDurationMs,
+      clickDurationMs: 0,
+    };
+    clickPlan.push({
+      ...clickPlanEntry,
     });
+    const clickStartedAtRunnerMs = nodePerformance.now();
     await item.click();
+    clickPlanEntry.clickDurationMs = nodePerformance.now() - clickStartedAtRunnerMs;
+    clickPlan[index] = clickPlanEntry;
     if (index < sessionIds.length - 1) {
       const delayMs = numericEnv('BITFUN_E2E_PERF_RAPID_SWITCH_DELAY_MS') ?? 75;
+      const pauseStartedAtRunnerMs = nodePerformance.now();
       await browser.pause(Math.max(0, delayMs));
+      clickPlanEntry.pauseDurationMs = nodePerformance.now() - pauseStartedAtRunnerMs;
+      clickPlan[index] = clickPlanEntry;
     }
   }
 
@@ -3929,11 +3950,20 @@ async function collectRapidLongSessionSwitchMeasurement(
       ) ||
       event.phase.startsWith('flowchat_latest_end_anchor') ||
       event.phase.startsWith('flowchat_initial_history') ||
-      event.phase === 'react_render_profile'
+      event.phase === 'react_render_profile' ||
+      event.phase === 'git_status_request' ||
+      event.phase === 'git_state_refresh'
     )
   );
   const targetClickedAtMs =
     clickPlan.find(entry => entry.sessionId === targetSessionId)?.clickedAtMs ?? clickedAtMs;
+  const targetClickPlanIndex = clickPlan.findIndex(entry => entry.sessionId === targetSessionId);
+  const targetClickPlanEntry = targetClickPlanIndex >= 0
+    ? clickPlan[targetClickPlanIndex]
+    : undefined;
+  const pauseBeforeTargetMs = clickPlan
+    .slice(0, Math.max(0, targetClickPlanIndex))
+    .reduce((total, entry) => total + (entry.pauseDurationMs ?? 0), 0);
   const sessionBreakdowns = clickPlan.map((entry, index) => {
     const sessionEvents = events.filter(event =>
       typeof event.sessionId === 'string' &&
@@ -3967,6 +3997,9 @@ async function collectRapidLongSessionSwitchMeasurement(
       target: {
         clickedAtMs: targetClickedAtMs,
         clickSinceFirstClickMs: targetClickedAtMs - clickedAtMs,
+        findDurationMs: targetClickPlanEntry?.findDurationMs ?? 0,
+        clickDurationMs: targetClickPlanEntry?.clickDurationMs ?? 0,
+        pauseBeforeTargetMs,
         clickToLatestVisibleMs: latestVisible.visibleAtMs - targetClickedAtMs,
         clickToLatestUsableMs: latestUsable.usableAtMs - targetClickedAtMs,
         latestVisibleToUsableMs: latestUsable.usableAtMs - latestVisible.visibleAtMs,
@@ -4129,7 +4162,9 @@ async function collectLongSessionOpenMeasurement(
       ) ||
       event.phase.startsWith('flowchat_latest_end_anchor') ||
       event.phase.startsWith('flowchat_initial_history') ||
-      event.phase === 'react_render_profile'
+      event.phase === 'react_render_profile' ||
+      event.phase === 'git_status_request' ||
+      event.phase === 'git_state_refresh'
     )
   );
   const screenshotPath = await maybeSavePerfScreenshot(`long-session-${sessionId}`);
@@ -4504,6 +4539,9 @@ describe('Performance telemetry', () => {
         firstClickToTargetClickMs: measurement.rapidSwitchBreakdown.firstClickToTargetClickMs,
         target: {
           clickSinceFirstClickMs: measurement.rapidSwitchBreakdown.target.clickSinceFirstClickMs,
+          findDurationMs: measurement.rapidSwitchBreakdown.target.findDurationMs,
+          clickDurationMs: measurement.rapidSwitchBreakdown.target.clickDurationMs,
+          pauseBeforeTargetMs: measurement.rapidSwitchBreakdown.target.pauseBeforeTargetMs,
           clickToLatestVisibleMs: measurement.rapidSwitchBreakdown.target.clickToLatestVisibleMs,
           latestVisibleToUsableMs: measurement.rapidSwitchBreakdown.target.latestVisibleToUsableMs,
           clickToLatestUsableMs: measurement.rapidSwitchBreakdown.target.clickToLatestUsableMs,


### PR DESCRIPTION
## Summary

- Reduce contention while opening and rapidly switching large historical sessions by using a bounded history-open transition signal.
- Keep latest historical content prioritized while suppressing only passive work in the transition window: workspace row Git refresh, chat input strip Git refresh, file-card Git probe, stale background command snapshots, passive thread-goal refresh, and avoid unnecessary markdown workspace-path lookup.
- Add release E2E breakdown for rapid switching and visual guards for post-visible loading, blank surface, and scroll jumps.

Refs #949

## Performance

Environment: Windows desktop `release-fast`, same machine, same command: `pnpm run desktop:build:release-fast` then `pnpm run e2e:test:perf:release-fast`.

Base commit: `5265a7e4` (`gcwing/main` after #1156)
After commit: `949bea71`

| Scenario | Before | After | Change | Notes |
| --- | ---: | ---: | ---: | --- |
| Cold startup to shell interactive | 931.9 ms | 834.9 ms | -97.0 ms (-10.4%) | Single-sample improvement is mostly native maximize variance (`108 ms -> 9 ms`), not claimed as this PR's main causal win. i18n worsened `186.2 ms -> 226.2 ms`. |
| First open long session: latest text visible | 272.5 ms | 235.4 ms | -37.1 ms (-13.6%) | End-to-end latest-content path improved. |
| First open long session: latest text usable | 266.3 ms | 232.8 ms | -33.5 ms (-12.6%) | End-to-end latest-content path improved. |
| First open long session: full hydrate complete | 618.9 ms | 565.3 ms | -53.6 ms (-8.7%) | Full hydrate still completes earlier overall. |
| Warm reopen long session: latest text visible | 193.6 ms | 175.4 ms | -18.2 ms (-9.4%) | No visual fallback observed. |
| Warm reopen long session: latest text usable | 191.7 ms | 173.5 ms | -18.2 ms (-9.5%) | No visual fallback observed. |
| Rapid switch A->B->C: target latest visible | 246.3 ms | 188.1 ms | -58.2 ms (-23.6%) | Target session C after user clicks C. |
| Rapid switch A->B->C: target latest usable | 291.8 ms | 229.9 ms | -61.9 ms (-21.2%) | Target session C after user clicks C. |
| Rapid switch A->B->C: first click to target usable | 895.7 ms | 676.9 ms | -218.8 ms (-24.4%) | Includes find/click/pause overhead in the test runner. |
| Visual regressions after latest text visible | loading 0 / blank 0 / jump 0 | loading 0 / blank 0 / jump 0 | no regression | Guarded by E2E visual summary. |

Sub-time-slice regressions observed and accepted because end-to-end still improves:

| Slice | Before | After | Change | Why acceptable |
| --- | ---: | ---: | ---: | --- |
| First-open `restore_session_view` | 50.8 ms | 63.1 ms | +12.3 ms | Backend restore is not the bottleneck in this sample; latest visible/usable and full hydrate still improve. |
| First-open frontend hydrate | 52.5 ms | 91.0 ms | +38.5 ms | Additional transition/guard work moves some cost into hydrate, but reduces passive contention and improves end-to-end. |
| Startup i18n provider load | 186.2 ms | 226.2 ms | +40.0 ms | Not expected to be caused by this diff; tracked as startup variance, not counted as a claimed win. |

## Risk / behavior impact

- Passive Git/background snapshots can be delayed during a bounded historical-session transition. Explicit user actions remain active: Git views, file actions, slash/deep-review target resolution, thread-goal entry, and message sending still trigger their own reads.
- Historical background command snapshot recovery is delayed by two frames after initial latest-content paint and skipped if the user starts opening another historical session first. Live events remain authoritative, so this may only delay stale snapshot recovery in the header.
- The transition signal has a 4s automatic expiry as a safety net so passive UI state cannot stay suppressed if the normal owner cleanup path is missed.
- Remote historical sessions are not forced through local pre-hydration; remote compatibility behavior is intentionally preserved.

## Verification

- `pnpm --dir src/web-ui run test:run src/tools/git/state/GitStateManager.test.ts src/tools/git/hooks/useGitState.test.tsx src/app/components/NavPanel/sections/workspaces/workspaceGitRefreshOptions.test.ts src/app/startup/startupPerformanceContract.test.ts src/flow_chat/services/sessionOpenIntent.test.ts src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx src/flow_chat/tool-cards/FileOperationToolCard.test.tsx src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx src/infrastructure/config/services/ConfigManager.test.ts src/flow_chat/services/flow-chat-manager/SessionModule.test.ts`
- `pnpm --dir src/web-ui run test:run src/flow_chat/services/sessionOpenIntent.test.ts src/flow_chat/services/flow-chat-manager/SessionModule.test.ts src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx src/tools/git/hooks/useGitState.test.tsx src/tools/git/state/GitStateManager.test.ts src/app/components/NavPanel/sections/workspaces/workspaceGitRefreshOptions.test.ts`
- `pnpm --dir src/web-ui run test:run`\n- `pnpm --dir src/web-ui run type-check`
- `pnpm run desktop:build:release-fast`
- `pnpm run e2e:test:perf:release-fast`
- `git diff --check`

## Third-party adversarial review notes

- Checked for functionality drift from performance work; reverted an unnecessary `||` fallback change in `useGitState` to preserve `??` semantics.
- Checked for stale transition suppression; added automatic expiry notification and test coverage.
- Checked log/telemetry growth; new `startupTrace` phases are gated behind `__BITFUN_PERF_TRACE_ENABLED__`, and added logs are existing-level failure diagnostics only.

