### PR TITLE
feat: show response timing and token usage

### DIFF
--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -2208,6 +2208,7 @@ mod tests {
             start_time: 1,
             end_time: Some(2),
             duration_ms: Some(1),
+            token_usage: None,
             status: TurnStatus::Completed,
         };
 
@@ -2285,6 +2286,7 @@ mod tests {
             start_time: 1,
             end_time: Some(2),
             duration_ms: Some(1),
+            token_usage: None,
             status: TurnStatus::Completed,
         }];
 
@@ -2343,6 +2345,7 @@ mod tests {
             start_time: 1,
             end_time: Some(2),
             duration_ms: Some(1),
+            token_usage: None,
             status: TurnStatus::Completed,
         }];
 

--- a/src/crates/assembly/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/assembly/core/src/agentic/execution/round_executor.rs
@@ -430,41 +430,23 @@ impl RoundExecutor {
             stream_result.first_visible_output_ms
         );
 
-        // Check cancellation token again after stream processing completes
+        // If stream response contains usage info, record it before the
+        // post-stream cancellation gate. A user can press stop after the
+        // provider returned usage but before this round settles; dropping that
+        // usage makes cancelled turns look unaccounted even though the provider
+        // already supplied authoritative counts.
+        if let Some(ref usage) = stream_result.usage {
+            self.emit_token_usage_update(&context, usage, context_window, is_subagent)
+                .await;
+        }
+
+        // Check cancellation token again after stream processing completes.
         if cancel_token.is_cancelled() {
             debug!(
                 "Cancel token detected after stream processing, stopping execution: session_id={}",
                 context.session_id
             );
             return Err(BitFunError::Cancelled("Execution cancelled".to_string()));
-        }
-
-        // If stream response contains usage info, update token statistics
-        if let Some(ref usage) = stream_result.usage {
-            debug!(
-                "Updating token stats from model response: input={}, output={}, total={}, is_subagent={}",
-                usage.prompt_token_count,
-                usage.candidates_token_count,
-                usage.total_token_count,
-                is_subagent
-            );
-
-            self.emit_event(
-                AgenticEvent::TokenUsageUpdated {
-                    session_id: context.session_id.clone(),
-                    turn_id: context.dialog_turn_id.clone(),
-                    model_id: context.model_name.clone(),
-                    input_tokens: usage.prompt_token_count as usize,
-                    output_tokens: Some(usage.candidates_token_count as usize),
-                    total_tokens: usage.total_token_count as usize,
-                    max_context_tokens: context_window,
-                    is_subagent,
-                    cached_tokens: usage.cached_content_token_count.map(|v| v as usize),
-                    token_details: token_details_from_usage(usage),
-                },
-                EventPriority::Normal,
-            )
-            .await;
         }
 
         // Emit model round completed event
@@ -845,6 +827,39 @@ impl RoundExecutor {
         let _ = self.event_queue.enqueue(event, Some(priority)).await;
     }
 
+    async fn emit_token_usage_update(
+        &self,
+        context: &RoundContext,
+        usage: &crate::util::types::ai::GeminiUsage,
+        context_window: Option<usize>,
+        is_subagent: bool,
+    ) {
+        debug!(
+            "Updating token stats from model response: input={}, output={}, total={}, is_subagent={}",
+            usage.prompt_token_count,
+            usage.candidates_token_count,
+            usage.total_token_count,
+            is_subagent
+        );
+
+        self.emit_event(
+            AgenticEvent::TokenUsageUpdated {
+                session_id: context.session_id.clone(),
+                turn_id: context.dialog_turn_id.clone(),
+                model_id: context.model_name.clone(),
+                input_tokens: usage.prompt_token_count as usize,
+                output_tokens: Some(usage.candidates_token_count as usize),
+                total_tokens: usage.total_token_count as usize,
+                max_context_tokens: context_window,
+                is_subagent,
+                cached_tokens: usage.cached_content_token_count.map(|v| v as usize),
+                token_details: token_details_from_usage(usage),
+            },
+            EventPriority::Normal,
+        )
+        .await;
+    }
+
     async fn emit_failed_partial_tool_calls(
         &self,
         context: &RoundContext,
@@ -1015,8 +1030,13 @@ fn token_details_from_usage(
 #[cfg(test)]
 mod tests {
     use super::{RoundExecutor, StreamProcessor};
+    use crate::agentic::execution::types::RoundContext;
     use crate::agentic::events::{EventQueue, EventQueueConfig};
+    use crate::agentic::tools::ToolRuntimeRestrictions;
+    use crate::util::types::ai::GeminiUsage;
+    use bitfun_runtime_ports::DelegationPolicy;
     use dashmap::DashMap;
+    use std::collections::HashMap;
     use std::sync::Arc;
     use tokio_util::sync::CancellationToken;
 
@@ -1027,6 +1047,30 @@ mod tests {
             tool_pipeline: None,
             event_queue,
             cancellation_tokens: Arc::new(DashMap::new()),
+        }
+    }
+
+    fn test_round_context() -> RoundContext {
+        RoundContext {
+            session_id: "session-1".to_string(),
+            subagent_parent_info: None,
+            dialog_turn_id: "turn-1".to_string(),
+            turn_index: 0,
+            round_number: 0,
+            workspace: None,
+            messages: Vec::new(),
+            available_tools: Vec::new(),
+            collapsed_tools: Vec::new(),
+            unlocked_collapsed_tools: Vec::new(),
+            model_name: "model-1".to_string(),
+            agent_type: "agentic".to_string(),
+            context_vars: HashMap::new(),
+            delegation_policy: DelegationPolicy::top_level(),
+            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
+            steering_interrupt: None,
+            cancellation_token: CancellationToken::new(),
+            workspace_services: None,
+            recover_partial_on_cancel: false,
         }
     }
 
@@ -1058,6 +1102,41 @@ mod tests {
         executor.cleanup_dialog_turn("turn-1").await;
         assert!(!executor.has_active_dialog_turn("turn-1"));
         assert!(!executor.is_dialog_turn_cancelled("turn-1"));
+    }
+
+    #[tokio::test]
+    async fn emits_token_usage_before_post_stream_cancel_stops_round() {
+        let executor = test_round_executor();
+        let context = test_round_context();
+        let usage = GeminiUsage {
+            prompt_token_count: 100,
+            candidates_token_count: 20,
+            total_token_count: 120,
+            reasoning_token_count: None,
+            cached_content_token_count: Some(30),
+            cache_creation_token_count: None,
+        };
+
+        executor
+            .emit_token_usage_update(&context, &usage, Some(128_000), false)
+            .await;
+
+        let events = executor.event_queue.dequeue_batch(10).await;
+        assert!(events.iter().any(|envelope| matches!(
+            &envelope.event,
+            crate::agentic::events::AgenticEvent::TokenUsageUpdated {
+                session_id,
+                turn_id,
+                model_id,
+                input_tokens: 100,
+                output_tokens: Some(20),
+                total_tokens: 120,
+                max_context_tokens: Some(128_000),
+                is_subagent: false,
+                cached_tokens: Some(30),
+                ..
+            } if session_id == "session-1" && turn_id == "turn-1" && model_id == "model-1"
+        )));
     }
 
     #[test]

--- a/src/crates/assembly/core/src/service/session_usage/service.rs
+++ b/src/crates/assembly/core/src/service/session_usage/service.rs
@@ -2263,6 +2263,7 @@ mod tests {
             start_time: 1_000 + turn_index as u64,
             end_time: Some(1_300 + turn_index as u64),
             duration_ms: Some(300),
+            token_usage: None,
             status: TurnStatus::Completed,
         }
     }

--- a/src/crates/assembly/core/src/service_agent_runtime.rs
+++ b/src/crates/assembly/core/src/service_agent_runtime.rs
@@ -1636,6 +1636,7 @@ mod tests {
             start_time: 1_000,
             end_time: Some(1_250),
             duration_ms: Some(250),
+            token_usage: None,
             status,
         }
     }

--- a/src/crates/services/services-core/src/session/types.rs
+++ b/src/crates/services/services-core/src/session/types.rs
@@ -346,8 +346,36 @@ pub struct DialogTurnData {
     #[serde(skip_serializing_if = "Option::is_none", alias = "duration_ms")]
     pub duration_ms: Option<u64>,
 
+    /// Provider-reported token usage for this dialog turn, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "token_usage")]
+    pub token_usage: Option<DialogTurnTokenUsageData>,
+
     /// Turn status
     pub status: TurnStatus,
+}
+
+/// Provider-reported token usage attached to a dialog turn.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DialogTurnTokenUsageData {
+    /// Input/prompt tokens for the model request.
+    #[serde(alias = "input_tokens")]
+    pub input_tokens: u64,
+
+    /// Output/completion tokens, when the provider reports them.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "output_tokens"
+    )]
+    pub output_tokens: Option<u64>,
+
+    /// Total tokens reported by the provider for this request.
+    #[serde(alias = "total_tokens")]
+    pub total_tokens: u64,
+
+    /// Frontend event timestamp in milliseconds since epoch.
+    pub timestamp: u64,
 }
 
 /// Persisted dialog turn kind.
@@ -848,6 +876,7 @@ impl DialogTurnData {
             start_time: now,
             end_time: None,
             duration_ms: None,
+            token_usage: None,
             status: TurnStatus::InProgress,
         }
     }
@@ -919,6 +948,45 @@ mod tests {
         );
 
         assert_eq!(turn.kind, DialogTurnKind::UserDialog);
+    }
+
+    #[test]
+    fn dialog_turn_token_usage_round_trips_camel_case_payloads() {
+        let payload = serde_json::json!({
+            "turnId": "turn-1",
+            "turnIndex": 0,
+            "sessionId": "session-1",
+            "timestamp": 1,
+            "userMessage": {
+                "id": "user-1",
+                "content": "hello",
+                "timestamp": 1
+            },
+            "modelRounds": [],
+            "startTime": 1,
+            "durationMs": 10,
+            "tokenUsage": {
+                "inputTokens": 1200,
+                "outputTokens": 320,
+                "totalTokens": 1520,
+                "timestamp": 2
+            },
+            "status": "completed"
+        });
+
+        let turn: DialogTurnData =
+            serde_json::from_value(payload).expect("turn payload should deserialize");
+
+        let token_usage = turn
+            .token_usage
+            .as_ref()
+            .expect("token usage should be preserved");
+        assert_eq!(token_usage.input_tokens, 1200);
+        assert_eq!(token_usage.output_tokens, Some(320));
+        assert_eq!(token_usage.total_tokens, 1520);
+
+        let serialized = serde_json::to_value(&turn).expect("turn should serialize");
+        assert_eq!(serialized["tokenUsage"]["totalTokens"], 1520);
     }
 
     #[test]

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -24,7 +24,7 @@ import { useAcpPlan } from '../hooks/useAcpPlan';
 import { filterSlashCommands, useAcpSlashCommands } from '../hooks/useAcpSlashCommands';
 import { acpSessionRef, acpSlashCommandText } from '../utils/acpSession';
 import { AcpPlanPanel } from './AcpPlanPanel';
-import type { FlowChatState, Session } from '../types/flow-chat';
+import type { FlowChatState } from '../types/flow-chat';
 import type { FileContext, DirectoryContext, ImageContext } from '@/types/context.ts';
 import { SmartRecommendations } from './smart-recommendations';
 import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
@@ -75,6 +75,10 @@ import { useSessionReviewActivity } from '../hooks/useSessionReviewActivity';
 import { shouldBlockDeepReviewCommand } from '../utils/deepReviewCommandGuard';
 import { deriveDeepReviewSessionConcurrencyGuard } from '../utils/deepReviewCapacityGuard';
 import { acpAgentTypeFromSession } from '../utils/acpSession';
+import {
+  getSessionContextUsageDisplay,
+  type ContextUsageDisplay,
+} from '../utils/tokenUsageDisplay';
 import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
 import './ChatInput.scss';
 
@@ -217,24 +221,6 @@ function renderMcpPromptMessages(messages: MCPPromptMessage[]): string {
     })
     .filter(Boolean)
     .join('\n\n');
-}
-
-function getSessionContextUsageDisplay(session?: Session): { current: number; max: number } {
-  if (!session) {
-    return { current: 0, max: 128128 };
-  }
-
-  if (session.currentAcpContextUsage) {
-    return {
-      current: session.currentAcpContextUsage.used,
-      max: session.currentAcpContextUsage.size,
-    };
-  }
-
-  return {
-    current: session.currentTokenUsage?.totalTokens || 0,
-    max: session.maxContextTokens || 128128,
-  };
 }
 
 export const ChatInput: React.FC<ChatInputProps> = ({
@@ -622,7 +608,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     return '';
   }, [workspaceName, chatStripRepositoryPath]);
   
-  const [tokenUsage, setTokenUsage] = React.useState({ current: 0, max: 128128 });
+  const [tokenUsage, setTokenUsage] = React.useState<ContextUsageDisplay>(
+    getSessionContextUsageDisplay()
+  );
   const isAssistantWorkspace = workspace?.workspaceKind === WorkspaceKind.Assistant;
   const currentMode = modeState.current;
   const isModeDropdownOpen = modeState.dropdownOpen;
@@ -727,7 +715,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
               `${id}|${s.mode ?? ''}|${s.title ?? ''}|${s.workspacePath ?? ''}|` +
               `${s.remoteConnectionId ?? ''}|${s.remoteSshHost ?? ''}|${s.lastSubmittedMode ?? ''}|` +
               `${s.currentAcpContextUsage?.used ?? ''}|${s.currentAcpContextUsage?.size ?? ''}|` +
-              `${s.currentTokenUsage?.totalTokens ?? ''}|${s.maxContextTokens ?? ''}|` +
+              `${s.currentTokenUsage?.inputTokens ?? ''}|${s.maxContextTokens ?? ''}|` +
               `${s.needsUserAttention ? '1':'0'}`
             );
           }
@@ -3545,6 +3533,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                     sessionId={effectiveTargetSessionId || undefined}
                     currentTokens={tokenUsage.current}
                     maxTokens={tokenUsage.max}
+                    contextUsageSource={tokenUsage.source}
                   />
                 </div>
 

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -22,6 +22,10 @@ import { Tooltip } from '@/component-library';
 import { FlowChatStore } from '../store/FlowChatStore';
 import { getModelMaxTokens } from '../services/flow-chat-manager/SessionModule';
 import { acpClientIdFromAgentType } from '../utils/acpSession';
+import {
+  buildContextUsageTooltip,
+  type ContextUsageSource,
+} from '../utils/tokenUsageDisplay';
 import { createLogger } from '@/shared/utils/logger';
 import './ModelSelector.scss';
 
@@ -39,6 +43,8 @@ interface ModelSelectorProps {
   currentTokens?: number;
   /** Max token capacity. */
   maxTokens?: number;
+  /** Semantic source for the context usage number. */
+  contextUsageSource?: ContextUsageSource;
 }
 
 interface ModelInfo {
@@ -153,6 +159,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   sessionId,
   currentTokens = 0,
   maxTokens = 0,
+  contextUsageSource,
 }) => {
   const { t } = useTranslation('flow-chat');
   const [allModels, setAllModels] = useState<AIModelConfig[]>([]);
@@ -530,8 +537,8 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     return '';
   }, [tokenPercentage]);
 
-  const formatTokenCount = (n: number) =>
-    n >= 1000 ? `${Math.round(n / 1000)}K` : `${n}`;
+  const resolvedContextUsageSource: ContextUsageSource =
+    contextUsageSource ?? (isAcpSession ? 'acp_context' : 'agent_prompt');
 
   if (isAcpSession) {
     if (acpAvailableModels.length === 0) {
@@ -540,11 +547,15 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
 
     const currentAcpModelId = acpOptions?.currentModelId || acpAvailableModels[0]?.id || '';
     const acpBaseTooltip = getModelTooltipText(acpCurrentModel, acpClientId ? `${acpClientId} ACP` : 'ACP');
-    const acpUsageTooltip =
-      currentTokens > 0 && maxTokens > 0
-        ? `${formatTokenCount(currentTokens)}/${formatTokenCount(maxTokens)} (${tokenPercentage}%)`
-        : '';
-    const acpTooltip = acpUsageTooltip ? `${acpBaseTooltip} · ${acpUsageTooltip}` : acpBaseTooltip;
+    const acpTooltip = buildContextUsageTooltip({
+      baseTooltip: acpBaseTooltip,
+      usage: {
+        current: currentTokens,
+        max: maxTokens,
+        source: resolvedContextUsageSource,
+      },
+      t,
+    });
 
     return (
       <div
@@ -622,10 +633,15 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
 
   const fallbackTooltip = t('modelSelector.autoModelDesc');
   const baseTooltip = getModelTooltipText(currentModel, fallbackTooltip);
-  const tooltipContent =
-    currentTokens > 0 && maxTokens > 0
-      ? `${baseTooltip} · ${formatTokenCount(currentTokens)}/${formatTokenCount(maxTokens)} (${tokenPercentage}%)`
-      : baseTooltip;
+  const tooltipContent = buildContextUsageTooltip({
+    baseTooltip,
+    usage: {
+      current: currentTokens,
+      max: maxTokens,
+      source: resolvedContextUsageSource,
+    },
+    t,
+  });
 
   return (
     <div

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.scss
@@ -46,9 +46,60 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  flex-wrap: wrap;
   gap: var(--flowchat-inline-gap, 0.35rem);
   padding: var(--flowchat-inline-gap, 0.35rem) 0;
   margin-top: var(--flowchat-inline-gap, 0.35rem);
+}
+
+.model-round-item__meta {
+  display: flex;
+  flex: 1 1 18rem;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.6rem;
+  min-width: 0;
+  margin-right: auto;
+  color: color-mix(
+    in srgb,
+    var(--color-text-secondary, #a0a0a0) 50%,
+    var(--color-text-muted, #999)
+  );
+  font-size: 11px;
+  line-height: 16px;
+}
+
+.model-round-item__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 0;
+  max-width: 100%;
+  white-space: nowrap;
+
+  &:last-child {
+    white-space: normal;
+  }
+}
+
+.model-round-item__meta-label {
+  color: color-mix(
+    in srgb,
+    var(--color-text-secondary, #a0a0a0) 38%,
+    var(--color-text-muted, #999)
+  );
+}
+
+.model-round-item__meta-value {
+  min-width: 0;
+  color: color-mix(
+    in srgb,
+    var(--color-text-secondary, #a0a0a0) 68%,
+    var(--color-text-muted, #999)
+  );
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  text-overflow: ellipsis;
 }
 
 .model-round-item__history-loader {

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
@@ -10,7 +10,8 @@
 import React, { useMemo, useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Copy, Check } from 'lucide-react';
-import type { ModelRound, FlowItem, FlowTextItem, FlowToolItem, FlowThinkingItem } from '../../types/flow-chat';
+import type { ModelRound, FlowItem, FlowTextItem, FlowToolItem, FlowThinkingItem, TokenUsage } from '../../types/flow-chat';
+import { useI18n } from '@/infrastructure/i18n';
 import { FlowTextBlock } from '../FlowTextBlock';
 import { FlowToolCard } from '../FlowToolCard';
 import { ModelThinkingDisplay } from '../../tool-cards/ModelThinkingDisplay';
@@ -43,6 +44,7 @@ import {
 } from '@/shared/utils/startupTrace';
 import { SubagentProjectionView } from '../subagent/SubagentProjectionView';
 import { formatSessionViewPreviewText } from '../../utils/sessionViewPreview';
+import { buildModelRoundUsageMeta } from '../../utils/tokenUsageDisplay';
 import './ModelRoundItem.scss';
 import './SubagentItems.scss';
 
@@ -139,6 +141,10 @@ interface ModelRoundItemProps {
   turnId: string;
   isLastRound?: boolean;
   isTurnComplete?: boolean;
+  turnStartedAt?: number;
+  turnEndedAt?: number;
+  turnDurationMs?: number;
+  turnTokenUsage?: TokenUsage;
 }
 
 function useTaskCollapsed(toolId: string): boolean {
@@ -215,8 +221,18 @@ const TaskWithSubagentWrapper: React.FC<TaskWithSubagentWrapperProps> = React.me
 });
 
 export const ModelRoundItem = React.memo<ModelRoundItemProps>(
-  ({ round, turnId, isLastRound = false, isTurnComplete = false }) => {
+  ({
+    round,
+    turnId,
+    isLastRound = false,
+    isTurnComplete = false,
+    turnStartedAt,
+    turnEndedAt,
+    turnDurationMs,
+    turnTokenUsage,
+  }) => {
     const { t } = useTranslation('flow-chat');
+    const { formatDate, formatNumber } = useI18n('flow-chat');
     const { sessionId } = useFlowChatContext();
     const [copied, setCopied] = useState(false);
     const copyButtonRef = useRef<HTMLButtonElement>(null);
@@ -453,6 +469,29 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
       (item.type === 'text' && (item as FlowTextItem).content.trim()) ||
       (item.type === 'tool' && (item as FlowToolItem).toolCall)
     );
+
+    const completedAt = turnEndedAt ?? round.endTime;
+    const effectiveDurationMs = turnDurationMs ??
+      (typeof turnStartedAt === 'number' && typeof completedAt === 'number'
+        ? Math.max(0, completedAt - turnStartedAt)
+        : round.durationMs);
+    const usageMetaItems = useMemo(() => buildModelRoundUsageMeta({
+      completedAt,
+      durationMs: effectiveDurationMs,
+      tokenUsage: turnTokenUsage,
+      status: round.status,
+      formatTime: timestamp => formatDate(new Date(timestamp), {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }),
+      formatNumber,
+      t,
+    }), [completedAt, effectiveDurationMs, formatDate, formatNumber, round.status, t, turnTokenUsage]);
+    const shouldRenderFooter = isTurnComplete &&
+      isLastRound &&
+      !round.isStreaming &&
+      (hasContent || usageMetaItems.length > 0);
     
     return (
       <div 
@@ -535,8 +574,22 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
           </div>
         )}
 
-        {isTurnComplete && isLastRound && hasContent && !round.isStreaming && (
+        {shouldRenderFooter && (
           <div className="model-round-item__footer">
+            {usageMetaItems.length > 0 && (
+              <div
+                className="model-round-item__meta"
+                aria-label={t('modelRound.meta.label')}
+              >
+                {usageMetaItems.map(item => (
+                  <span key={item.key} className="model-round-item__meta-item">
+                    <span className="model-round-item__meta-label">{item.label}</span>
+                    <span className="model-round-item__meta-value">{item.value}</span>
+                  </span>
+                ))}
+              </div>
+            )}
+
             <ForkSessionButton sessionId={sessionId} turnId={turnId} />
 
             <Tooltip content={copied ? t('modelRound.copiedDialog') : t('modelRound.copyDialog')} placement="top">
@@ -566,7 +619,11 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
       prev.round.id === next.round.id &&
       prev.round.items === next.round.items &&
       prev.isLastRound === next.isLastRound &&
-      prev.isTurnComplete === next.isTurnComplete
+      prev.isTurnComplete === next.isTurnComplete &&
+      prev.turnStartedAt === next.turnStartedAt &&
+      prev.turnEndedAt === next.turnEndedAt &&
+      prev.turnDurationMs === next.turnDurationMs &&
+      prev.turnTokenUsage === next.turnTokenUsage
     );
   }
 );

--- a/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.tsx
@@ -49,6 +49,10 @@ export const VirtualItemRenderer = React.memo<VirtualItemRendererProps>(
               turnId={item.turnId} 
               isLastRound={item.isLastRound}
               isTurnComplete={item.isTurnComplete}
+              turnStartedAt={item.turnStartedAt}
+              turnEndedAt={item.turnEndedAt}
+              turnDurationMs={item.turnDurationMs}
+              turnTokenUsage={item.turnTokenUsage}
             />
           );
         

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -636,7 +636,7 @@ export async function initializeEventListeners(
       handleDialogTurnCancelled(context, event, onTodoWriteResult);
     },
     onTokenUsageUpdated: (event) => {
-      handleTokenUsageUpdate(event);
+      handleTokenUsageUpdate(context, event);
     },
     onAcpContextUsageUpdated: (event) => {
       handleAcpContextUsageUpdate(event);
@@ -1776,8 +1776,13 @@ function handleModelRoundComplete(context: FlowChatContext, event: ModelRoundCom
 /**
  * Handle token usage update event
  */
-function handleTokenUsageUpdate(event: any): void {
-  const { sessionId, inputTokens, outputTokens, totalTokens, maxContextTokens } = event;
+function handleTokenUsageUpdate(context: FlowChatContext, event: any): void {
+  const sessionId = event.sessionId ?? event.session_id;
+  const turnId = event.turnId ?? event.turn_id;
+  const inputTokens = event.inputTokens ?? event.input_tokens;
+  const outputTokens = event.outputTokens ?? event.output_tokens;
+  const totalTokens = event.totalTokens ?? event.total_tokens;
+  const maxContextTokens = event.maxContextTokens ?? event.max_context_tokens;
   
   const store = FlowChatStore.getInstance();
   const session = store.getState().sessions.get(sessionId);
@@ -1786,15 +1791,23 @@ function handleTokenUsageUpdate(event: any): void {
     log.debug('Session not found (token usage update)', { sessionId });
     return;
   }
+  if (typeof inputTokens !== 'number' || typeof totalTokens !== 'number') {
+    log.debug('Dropped invalid token usage update', { event });
+    return;
+  }
 
   store.updateTokenUsage(sessionId, {
     inputTokens,
-    outputTokens,
+    outputTokens: typeof outputTokens === 'number' ? outputTokens : undefined,
     totalTokens
-  });
+  }, turnId);
 
   if (maxContextTokens !== undefined && maxContextTokens !== null) {
     store.updateSessionMaxContextTokens(sessionId, maxContextTokens);
+  }
+
+  if (turnId) {
+    immediateSaveDialogTurn(context, sessionId, turnId);
   }
 }
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts
@@ -124,6 +124,25 @@ describe('PersistenceModule', () => {
     expect(persisted.modelRounds[0].textItems.map((item: any) => item.id)).toEqual(['real-text']);
   });
 
+  it('persists dialog turn token usage metadata when available', () => {
+    const turn = createDialogTurn('completed');
+    turn.tokenUsage = {
+      inputTokens: 1200,
+      outputTokens: 320,
+      totalTokens: 1520,
+      timestamp: 2400,
+    };
+
+    const persisted = convertDialogTurnToBackendFormat(turn, 0);
+
+    expect(persisted.tokenUsage).toEqual({
+      inputTokens: 1200,
+      outputTokens: 320,
+      totalTokens: 1520,
+      timestamp: 2400,
+    });
+  });
+
   it('persists ACP permission metadata for pending confirmation tools', () => {
     const turn = createDialogTurn('processing');
     turn.modelRounds[0].items = [

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.ts
@@ -87,7 +87,8 @@ export function calculateTurnHash(dialogTurn: DialogTurn): string {
         }
       : null,
     error: dialogTurn.error,
-    endTime: dialogTurn.endTime
+    endTime: dialogTurn.endTime,
+    tokenUsage: dialogTurn.tokenUsage,
   });
   
   let hash = 0;
@@ -461,6 +462,14 @@ export function convertDialogTurnToBackendFormat(dialogTurn: DialogTurn, turnInd
     }),
     startTime: dialogTurn.startTime,
     endTime: dialogTurn.endTime,
+    tokenUsage: dialogTurn.tokenUsage
+      ? {
+          inputTokens: dialogTurn.tokenUsage.inputTokens,
+          outputTokens: dialogTurn.tokenUsage.outputTokens,
+          totalTokens: dialogTurn.tokenUsage.totalTokens,
+          timestamp: dialogTurn.tokenUsage.timestamp,
+        }
+      : undefined,
     status: dialogTurn.status === 'completed' ? 'completed' : 
             dialogTurn.status === 'error' ? 'error' : 
             dialogTurn.status === 'cancelled' ? 'cancelled' : 'inprogress',

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -186,6 +186,101 @@ describe('FlowChatStore metadata persistence callbacks', () => {
   });
 });
 
+describe('FlowChatStore token usage', () => {
+  afterEach(() => {
+    resetStore();
+  });
+
+  it('stores provider token usage on the matching dialog turn', () => {
+    const session = createSession({
+      dialogTurns: [{
+        id: 'turn-1',
+        sessionId: 'session-1',
+        userMessage: {
+          id: 'user-1',
+          content: 'hello',
+          timestamp: 1000,
+        },
+        modelRounds: [],
+        status: 'completed',
+        startTime: 1000,
+        endTime: 2400,
+      }],
+    });
+
+    flowChatStore.setState(() => ({
+      sessions: new Map([[session.sessionId, session]]),
+      activeSessionId: session.sessionId,
+    }));
+
+    flowChatStore.updateTokenUsage(session.sessionId, {
+      inputTokens: 1200,
+      outputTokens: 320,
+      totalTokens: 1520,
+    }, 'turn-1');
+
+    const stored = flowChatStore.getState().sessions.get(session.sessionId);
+
+    expect(stored?.currentTokenUsage).toMatchObject({
+      inputTokens: 1200,
+      outputTokens: 320,
+      totalTokens: 1520,
+    });
+    expect(stored?.dialogTurns[0].tokenUsage).toMatchObject({
+      inputTokens: 1200,
+      outputTokens: 320,
+      totalTokens: 1520,
+    });
+    expect(stored?.dialogTurns[0].tokenUsage?.timestamp).toEqual(expect.any(Number));
+  });
+
+  it('keeps session context usage as the latest request while accumulating turn usage', () => {
+    const session = createSession({
+      dialogTurns: [{
+        id: 'turn-1',
+        sessionId: 'session-1',
+        userMessage: {
+          id: 'user-1',
+          content: 'hello',
+          timestamp: 1000,
+        },
+        modelRounds: [],
+        status: 'processing',
+        startTime: 1000,
+      }],
+    });
+
+    flowChatStore.setState(() => ({
+      sessions: new Map([[session.sessionId, session]]),
+      activeSessionId: session.sessionId,
+    }));
+
+    flowChatStore.updateTokenUsage(session.sessionId, {
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+    }, 'turn-1');
+    flowChatStore.updateTokenUsage(session.sessionId, {
+      inputTokens: 200,
+      outputTokens: 75,
+      totalTokens: 275,
+    }, 'turn-1');
+
+    const stored = flowChatStore.getState().sessions.get(session.sessionId);
+
+    expect(stored?.currentTokenUsage).toMatchObject({
+      inputTokens: 200,
+      outputTokens: 75,
+      totalTokens: 275,
+    });
+    expect(stored?.dialogTurns[0].tokenUsage).toMatchObject({
+      inputTokens: 300,
+      outputTokens: 125,
+      totalTokens: 425,
+    });
+  });
+});
+
 describe('FlowChatStore local usage reports', () => {
   afterEach(() => {
     resetStore();

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -17,6 +17,7 @@ import {
   SessionConfig,
   SessionContextRestoreState,
   SessionHistoryState,
+  TokenUsage,
 } from '../types/flow-chat';
 import { createLogger } from '@/shared/utils/logger';
 import {
@@ -2225,20 +2226,50 @@ export class FlowChatStore {
 
   public updateTokenUsage(
     sessionId: string, 
-    tokenUsage: { inputTokens: number; outputTokens?: number; totalTokens: number }
+    tokenUsage: { inputTokens: number; outputTokens?: number; totalTokens: number },
+    dialogTurnId?: string
   ): void {
     this.setState(prev => {
       const session = prev.sessions.get(sessionId);
       if (!session) return prev;
 
+      const nextTokenUsage = {
+        inputTokens: tokenUsage.inputTokens,
+        outputTokens: tokenUsage.outputTokens,
+        totalTokens: tokenUsage.totalTokens,
+        timestamp: Date.now()
+      };
+      let dialogTurns = session.dialogTurns;
+      if (dialogTurnId) {
+        const turnIndex = session.dialogTurns.findIndex(turn => turn.id === dialogTurnId);
+        if (turnIndex !== -1) {
+          const previousTurnUsage = session.dialogTurns[turnIndex].tokenUsage;
+          const accumulatedOutputTokens = previousTurnUsage
+            ? (
+                typeof previousTurnUsage.outputTokens === 'number' &&
+                typeof nextTokenUsage.outputTokens === 'number'
+                  ? previousTurnUsage.outputTokens + nextTokenUsage.outputTokens
+                  : undefined
+              )
+            : nextTokenUsage.outputTokens;
+          const accumulatedTurnUsage: TokenUsage = {
+            inputTokens: (previousTurnUsage?.inputTokens ?? 0) + nextTokenUsage.inputTokens,
+            outputTokens: accumulatedOutputTokens,
+            totalTokens: (previousTurnUsage?.totalTokens ?? 0) + nextTokenUsage.totalTokens,
+            timestamp: nextTokenUsage.timestamp,
+          };
+          dialogTurns = [...session.dialogTurns];
+          dialogTurns[turnIndex] = {
+            ...dialogTurns[turnIndex],
+            tokenUsage: accumulatedTurnUsage,
+          };
+        }
+      }
+
       const updatedSession = {
         ...session,
-        currentTokenUsage: {
-          inputTokens: tokenUsage.inputTokens,
-          outputTokens: tokenUsage.outputTokens,
-          totalTokens: tokenUsage.totalTokens,
-          timestamp: Date.now()
-        }
+        currentTokenUsage: nextTokenUsage,
+        dialogTurns
       };
 
       const newSessions = new Map(prev.sessions);
@@ -2645,6 +2676,7 @@ export class FlowChatStore {
         startTime: dialogTurn.startTime,
         endTime: dialogTurn.endTime || Date.now(),
         durationMs: (dialogTurn.endTime || Date.now()) - dialogTurn.startTime,
+        tokenUsage: dialogTurn.tokenUsage,
         status: 'cancelled' as const
       };
 
@@ -3680,6 +3712,7 @@ export class FlowChatStore {
         metadata as Record<string, unknown> | undefined
       );
       const normalizedTurnStatus = normalizeRecoveredTurnStatus(turn.status, { error: undefined });
+      const rawTokenUsage = turn.tokenUsage ?? turn.token_usage;
 
       return {
       id: turn.turnId,
@@ -3789,6 +3822,14 @@ export class FlowChatStore {
       status: normalizedTurnStatus,
       startTime: turn.startTime,
       endTime: turn.endTime,
+      tokenUsage: rawTokenUsage
+        ? {
+            inputTokens: rawTokenUsage.inputTokens ?? rawTokenUsage.input_tokens,
+            outputTokens: rawTokenUsage.outputTokens ?? rawTokenUsage.output_tokens,
+            totalTokens: rawTokenUsage.totalTokens ?? rawTokenUsage.total_tokens,
+            timestamp: rawTokenUsage.timestamp,
+          }
+        : undefined,
       backendTurnIndex: turn.turnIndex,
     };
     });

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
@@ -165,6 +165,47 @@ describe('sessionToVirtualItems explore grouping', () => {
     expect(items.map(item => item.type)).toEqual(['user-message', 'model-round']);
   });
 
+  it('carries turn timing and token metadata into the model round virtual item', () => {
+    const session = makeSession({
+      dialogTurns: [{
+        id: 'turn-1',
+        sessionId: 'session-1',
+        userMessage: {
+          id: 'user-1',
+          content: 'Help',
+          timestamp: 900,
+        },
+        modelRounds: [makeRound({
+          id: 'round-with-answer',
+          items: [makeTextItem('text-final', 'Here is the answer.')],
+        })],
+        status: 'completed',
+        startTime: 900,
+        endTime: 2400,
+        tokenUsage: {
+          inputTokens: 1200,
+          outputTokens: 300,
+          totalTokens: 1500,
+          timestamp: 2400,
+        },
+      }],
+    });
+
+    const modelItem = sessionToVirtualItems(session)
+      .find((item): item is ModelRoundVirtualItem => item.type === 'model-round');
+
+    expect(modelItem).toMatchObject({
+      turnStartedAt: 900,
+      turnEndedAt: 2400,
+      turnDurationMs: 1500,
+      turnTokenUsage: {
+        inputTokens: 1200,
+        outputTokens: 300,
+        totalTokens: 1500,
+      },
+    });
+  });
+
   it('does not special-case ACP rounds without explicit render hints', () => {
     const session = makeSession({
       sessionId: 'acp-session',

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
@@ -7,7 +7,7 @@
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 import { immer } from 'zustand/middleware/immer';
-import type { Session, DialogTurn, ModelRound, FlowItem, FlowToolItem, FlowUserSteeringItem, AnyFlowItem } from '../types/flow-chat';
+import type { Session, DialogTurn, ModelRound, FlowItem, FlowToolItem, FlowUserSteeringItem, AnyFlowItem, TokenUsage } from '../types/flow-chat';
 import { isCollapsibleTool, READ_TOOL_NAMES, SEARCH_TOOL_NAMES, COMMAND_TOOL_NAMES } from '../tool-cards';
 import { isCompletedToolInTransientWindow } from '../components/modern/modelRoundItemGrouping';
 import { flowChatStore } from './FlowChatStore';
@@ -60,6 +60,10 @@ export type VirtualItem =
       turnId: string;
       isLastRound: boolean;
       isTurnComplete: boolean;
+      turnStartedAt?: number;
+      turnEndedAt?: number;
+      turnDurationMs?: number;
+      turnTokenUsage?: TokenUsage;
       segmentId?: string;
       segmentIndex?: number;
       segmentCount?: number;
@@ -509,6 +513,12 @@ export function sessionToVirtualItems(session: Session | null): VirtualItem[] {
               turnId: turn.id,
               isLastRound: isLastRound && chunkIndex === roundChunks.length - 1,
               isTurnComplete,
+              turnStartedAt: turn.startTime,
+              turnEndedAt: turn.endTime,
+              turnDurationMs: typeof turn.endTime === 'number'
+                ? Math.max(0, turn.endTime - turn.startTime)
+                : undefined,
+              turnTokenUsage: turn.tokenUsage,
               segmentId: chunk.segmentId,
               segmentIndex: chunk.segmentIndex,
               segmentCount: chunk.segmentCount,

--- a/src/web-ui/src/flow_chat/utils/tokenUsageDisplay.test.ts
+++ b/src/web-ui/src/flow_chat/utils/tokenUsageDisplay.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import type { Session, TokenUsage } from '../types/flow-chat';
+import {
+  buildContextUsageTooltip,
+  buildModelRoundUsageMeta,
+  formatCompactTokenCount,
+  getSessionContextUsageDisplay,
+} from './tokenUsageDisplay';
+
+const t = (key: string, params?: Record<string, unknown>): string => {
+  const strings: Record<string, string> = {
+    'modelSelector.contextUsage.agentPrompt': 'Last request prompt: {{usage}}',
+    'modelSelector.contextUsage.acpContext': 'ACP reported context: {{usage}}',
+    'modelSelector.contextUsage.toolNote': 'Tool outputs may be summarized or truncated before later requests.',
+    'modelRound.meta.completed': 'Completed',
+    'modelRound.meta.stopped': 'Stopped',
+    'modelRound.meta.duration': 'Duration',
+    'modelRound.meta.tokens': 'Tokens',
+    'modelRound.meta.tokensUnavailable': 'unavailable',
+    'modelRound.meta.tokenBreakdown': '{{total}} total, {{input}} in, {{output}} out',
+  };
+
+  const template = strings[key] ?? key;
+  return Object.entries(params ?? {}).reduce(
+    (text, [paramKey, value]) => text.replace(`{{${paramKey}}}`, String(value)),
+    template,
+  );
+};
+
+const makeSession = (overrides: Partial<Session> = {}): Session => ({
+  sessionId: 'session-1',
+  title: 'Session',
+  dialogTurns: [],
+  status: 'idle',
+  config: { agentType: 'agentic' },
+  createdAt: 1,
+  lastActiveAt: 1,
+  error: null,
+  isHistorical: false,
+  todos: [],
+  mode: 'agentic',
+  workspacePath: 'D:/workspace/BitFun',
+  isTransient: false,
+  maxContextTokens: 4000,
+  ...overrides,
+});
+
+describe('tokenUsageDisplay', () => {
+  it('uses prompt/input tokens for non-ACP context usage instead of spent total tokens', () => {
+    const session = makeSession({
+      currentTokenUsage: {
+        inputTokens: 1200,
+        outputTokens: 300,
+        totalTokens: 1500,
+        timestamp: 10,
+      },
+      maxContextTokens: 4000,
+    });
+
+    expect(getSessionContextUsageDisplay(session)).toEqual({
+      current: 1200,
+      max: 4000,
+      source: 'agent_prompt',
+    });
+  });
+
+  it('preserves ACP-reported context usage as its own source', () => {
+    const session = makeSession({
+      currentAcpContextUsage: {
+        used: 42000,
+        size: 128000,
+        timestamp: 10,
+      },
+      currentTokenUsage: {
+        inputTokens: 1200,
+        outputTokens: 300,
+        totalTokens: 1500,
+        timestamp: 10,
+      },
+    });
+
+    expect(getSessionContextUsageDisplay(session)).toEqual({
+      current: 42000,
+      max: 128000,
+      source: 'acp_context',
+    });
+  });
+
+  it('labels the context usage source and tool-output caveat in the tooltip', () => {
+    const tooltip = buildContextUsageTooltip({
+      baseTooltip: 'Claude Sonnet',
+      usage: {
+        current: 1200,
+        max: 4000,
+        source: 'agent_prompt',
+      },
+      t,
+    });
+
+    expect(tooltip).toBe(
+      'Claude Sonnet · Last request prompt: 1.2K/4K (30%) · Tool outputs may be summarized or truncated before later requests.',
+    );
+  });
+
+  it('formats model-round timing and token metadata with unavailable output when missing', () => {
+    const tokenUsage: TokenUsage = {
+      inputTokens: 1000,
+      totalTokens: 1300,
+      timestamp: 10,
+    };
+
+    expect(buildModelRoundUsageMeta({
+      completedAt: 1700000000000,
+      durationMs: 12345,
+      tokenUsage,
+      formatTime: () => '12:00:00',
+      formatNumber: (value) => String(value),
+      t,
+    })).toEqual([
+      { key: 'completed', label: 'Completed', value: '12:00:00' },
+      { key: 'duration', label: 'Duration', value: '12.3s' },
+      { key: 'tokens', label: 'Tokens', value: '1300 total, 1000 in, unavailable out' },
+    ]);
+  });
+
+  it('omits the token row for cancelled rounds when provider usage is unavailable', () => {
+    expect(buildModelRoundUsageMeta({
+      completedAt: 1700000000000,
+      durationMs: 12345,
+      tokenUsage: undefined,
+      status: 'cancelled',
+      formatTime: () => '12:00:00',
+      formatNumber: (value) => String(value),
+      t,
+    })).toEqual([
+      { key: 'completed', label: 'Stopped', value: '12:00:00' },
+      { key: 'duration', label: 'Duration', value: '12.3s' },
+    ]);
+  });
+
+  it('keeps compact token formatting stable for tooltip strings', () => {
+    expect(formatCompactTokenCount(950)).toBe('950');
+    expect(formatCompactTokenCount(1200)).toBe('1.2K');
+    expect(formatCompactTokenCount(4000)).toBe('4K');
+  });
+});

--- a/src/web-ui/src/flow_chat/utils/tokenUsageDisplay.ts
+++ b/src/web-ui/src/flow_chat/utils/tokenUsageDisplay.ts
@@ -1,0 +1,160 @@
+import type { Session, TokenUsage } from '../types/flow-chat';
+
+export const DEFAULT_MAX_CONTEXT_TOKENS = 128128;
+
+export type ContextUsageSource = 'agent_prompt' | 'acp_context';
+
+export interface ContextUsageDisplay {
+  current: number;
+  max: number;
+  source: ContextUsageSource;
+}
+
+export interface TranslationFn {
+  (key: string, params?: Record<string, unknown>): string;
+}
+
+export interface ModelRoundUsageMetaItem {
+  key: 'completed' | 'duration' | 'tokens';
+  label: string;
+  value: string;
+}
+
+export function formatCompactTokenCount(value: number): string {
+  const safeValue = Math.max(0, Math.round(value));
+  if (safeValue >= 1_000_000) {
+    return `${formatCompactNumber(safeValue / 1_000_000)}M`;
+  }
+  if (safeValue >= 1_000) {
+    return `${formatCompactNumber(safeValue / 1_000)}K`;
+  }
+  return String(safeValue);
+}
+
+function formatCompactNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1).replace(/\.0$/, '');
+}
+
+export function getSessionContextUsageDisplay(session?: Session): ContextUsageDisplay {
+  if (!session) {
+    return {
+      current: 0,
+      max: DEFAULT_MAX_CONTEXT_TOKENS,
+      source: 'agent_prompt',
+    };
+  }
+
+  if (session.currentAcpContextUsage) {
+    return {
+      current: session.currentAcpContextUsage.used,
+      max: session.currentAcpContextUsage.size,
+      source: 'acp_context',
+    };
+  }
+
+  return {
+    current: session.currentTokenUsage?.inputTokens || 0,
+    max: session.maxContextTokens || DEFAULT_MAX_CONTEXT_TOKENS,
+    source: 'agent_prompt',
+  };
+}
+
+export function buildContextUsageTooltip(params: {
+  baseTooltip: string;
+  usage: ContextUsageDisplay;
+  t: TranslationFn;
+}): string {
+  const { baseTooltip, usage, t } = params;
+  if (usage.current <= 0 || usage.max <= 0) {
+    return baseTooltip;
+  }
+
+  const percentage = Math.min(100, Math.round((usage.current / usage.max) * 100));
+  const usageText = `${formatCompactTokenCount(usage.current)}/${formatCompactTokenCount(usage.max)} (${percentage}%)`;
+  const usageLabel = usage.source === 'acp_context'
+    ? t('modelSelector.contextUsage.acpContext', { usage: usageText })
+    : t('modelSelector.contextUsage.agentPrompt', { usage: usageText });
+
+  return [
+    baseTooltip,
+    usageLabel,
+    t('modelSelector.contextUsage.toolNote'),
+  ].filter(Boolean).join(' · ');
+}
+
+export function formatElapsedDuration(durationMs: number): string {
+  const safeMs = Math.max(0, Math.round(durationMs));
+  if (safeMs < 1000) {
+    return `${safeMs}ms`;
+  }
+
+  const seconds = safeMs / 1000;
+  if (seconds < 60) {
+    return `${formatCompactNumber(Math.round(seconds * 10) / 10)}s`;
+  }
+
+  const wholeSeconds = Math.round(seconds);
+  const minutes = Math.floor(wholeSeconds / 60);
+  const remainingSeconds = wholeSeconds % 60;
+  if (minutes < 60) {
+    return remainingSeconds === 0 ? `${minutes}m` : `${minutes}m ${remainingSeconds}s`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`;
+}
+
+export function buildModelRoundUsageMeta(params: {
+  completedAt?: number;
+  durationMs?: number;
+  tokenUsage?: TokenUsage;
+  status?: string;
+  formatTime: (timestamp: number) => string;
+  formatNumber: (value: number) => string;
+  t: TranslationFn;
+}): ModelRoundUsageMetaItem[] {
+  const { completedAt, durationMs, tokenUsage, status, formatTime, formatNumber, t } = params;
+  const items: ModelRoundUsageMetaItem[] = [];
+
+  if (typeof completedAt === 'number') {
+    items.push({
+      key: 'completed',
+      label: status === 'cancelled'
+        ? t('modelRound.meta.stopped')
+        : t('modelRound.meta.completed'),
+      value: formatTime(completedAt),
+    });
+  }
+
+  if (typeof durationMs === 'number') {
+    items.push({
+      key: 'duration',
+      label: t('modelRound.meta.duration'),
+      value: formatElapsedDuration(durationMs),
+    });
+  }
+
+  if (tokenUsage) {
+    const unavailable = t('modelRound.meta.tokensUnavailable');
+    items.push({
+      key: 'tokens',
+      label: t('modelRound.meta.tokens'),
+      value: t('modelRound.meta.tokenBreakdown', {
+        total: formatNumber(tokenUsage.totalTokens),
+        input: formatNumber(tokenUsage.inputTokens),
+        output: typeof tokenUsage.outputTokens === 'number'
+          ? formatNumber(tokenUsage.outputTokens)
+          : unavailable,
+      }),
+    });
+  } else if (status !== 'cancelled') {
+    items.push({
+      key: 'tokens',
+      label: t('modelRound.meta.tokens'),
+      value: t('modelRound.meta.tokensUnavailable'),
+    });
+  }
+
+  return items;
+}

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1164,7 +1164,16 @@
     "feedbackDevVersion": "Feedback is not available in dev version",
     "userLabel": "👤 User:",
     "toolCallLabel": "🔧 Tool call: {{name}}",
-    "loadingMoreHistory": "Loading more history..."
+    "loadingMoreHistory": "Loading more history...",
+    "meta": {
+      "label": "Response metadata",
+      "completed": "Completed",
+      "stopped": "Stopped",
+      "duration": "Duration",
+      "tokens": "Tokens",
+      "tokensUnavailable": "unavailable",
+      "tokenBreakdown": "{{total}} total, {{input}} in, {{output}} out"
+    }
   },
   "exploreRegion": {
     "readFiles_one": "Read {{count}} file",
@@ -1994,7 +2003,12 @@
     "autoModelDesc": "Automatically Routing",
     "primaryModel": "Primary Model",
     "fastModel": "Fast Model",
-    "modelNotConfigured": "Not Configured"
+    "modelNotConfigured": "Not Configured",
+    "contextUsage": {
+      "agentPrompt": "Last request prompt: {{usage}}",
+      "acpContext": "ACP reported context: {{usage}}",
+      "toolNote": "Tool outputs may be summarized or truncated before later requests."
+    }
   },
   "reasoningEffort": {
     "title": "Reasoning Effort",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1164,7 +1164,16 @@
     "feedbackDevVersion": "开发版本暂不提供反馈功能",
     "userLabel": "👤 用户:",
     "toolCallLabel": "🔧 工具调用: {{name}}",
-    "loadingMoreHistory": "正在加载更多历史..."
+    "loadingMoreHistory": "正在加载更多历史...",
+    "meta": {
+      "label": "回应元信息",
+      "completed": "完成",
+      "stopped": "已中止",
+      "duration": "耗时",
+      "tokens": "Token",
+      "tokensUnavailable": "不可用",
+      "tokenBreakdown": "共 {{total}}，输入 {{input}}，输出 {{output}}"
+    }
   },
   "exploreRegion": {
     "readFiles_one": "读取了 {{count}} 个文件",
@@ -1994,7 +2003,12 @@
     "autoModelDesc": "自动路由最优模型",
     "primaryModel": "Primary 模型",
     "fastModel": "Fast 模型",
-    "modelNotConfigured": "未配置"
+    "modelNotConfigured": "未配置",
+    "contextUsage": {
+      "agentPrompt": "上次请求输入上下文: {{usage}}",
+      "acpContext": "ACP 上报上下文: {{usage}}",
+      "toolNote": "工具输出在后续请求中可能会被摘要或截断。"
+    }
   },
   "reasoningEffort": {
     "title": "推理深度",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1164,7 +1164,16 @@
     "feedbackDevVersion": "開發版本暫不提供反饋功能",
     "userLabel": "👤 用戶:",
     "toolCallLabel": "🔧 工具調用: {{name}}",
-    "loadingMoreHistory": "正在載入更多歷史..."
+    "loadingMoreHistory": "正在載入更多歷史...",
+    "meta": {
+      "label": "回應中繼資料",
+      "completed": "完成",
+      "stopped": "已中止",
+      "duration": "耗時",
+      "tokens": "Token",
+      "tokensUnavailable": "不可用",
+      "tokenBreakdown": "共 {{total}}，輸入 {{input}}，輸出 {{output}}"
+    }
   },
   "exploreRegion": {
     "readFiles_one": "讀取了 {{count}} 個檔案",
@@ -1994,7 +2003,12 @@
     "autoModelDesc": "自動路由最優模型",
     "primaryModel": "Primary 模型",
     "fastModel": "Fast 模型",
-    "modelNotConfigured": "未設定"
+    "modelNotConfigured": "未設定",
+    "contextUsage": {
+      "agentPrompt": "上次請求輸入上下文: {{usage}}",
+      "acpContext": "ACP 回報上下文: {{usage}}",
+      "toolNote": "工具輸出在後續請求中可能會被摘要或截斷。"
+    }
   },
   "reasoningEffort": {
     "title": "推理深度",

--- a/src/web-ui/src/shared/types/session-history.ts
+++ b/src/web-ui/src/shared/types/session-history.ts
@@ -156,7 +156,15 @@ export interface DialogTurnData {
   startTime: number;
   endTime?: number;
   durationMs?: number;
+  tokenUsage?: DialogTurnTokenUsageData;
   status: TurnStatus;
+}
+
+export interface DialogTurnTokenUsageData {
+  inputTokens: number;
+  outputTokens?: number;
+  totalTokens: number;
+  timestamp: number;
 }
 
 export interface UserMessageData {


### PR DESCRIPTION
## Summary

- Add per-response metadata for completion/stopped time, elapsed duration, and provider-reported token usage.
- Clarify the context usage indicator so prompt/input context and ACP-reported context are labeled separately.
- Persist dialog-turn token usage into session history and include it in the usage report path.
- Handle stopped turns more carefully: if provider usage was already returned, record it before the post-stream cancel gate; if usage was not returned, show stable stopped/duration metadata without rendering a fake token total.

Closes #1138

## Validation

- `pnpm run i18n:contract:test:ci`
- `pnpm run i18n:audit`
- Locale key parity and duplicate-key scan for `en-US`, `zh-CN`, and `zh-TW` `flow-chat.json`
- `pnpm run lint:web` (passes with existing unrelated `FlowChatManager.ts:118 prefer-const` warning)
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run`
- `pnpm --dir src/web-ui run test:run src/flow_chat/utils/tokenUsageDisplay.test.ts src/flow_chat/store/FlowChatStore.test.ts src/flow_chat/store/modernFlowChatStore.test.ts src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts`
- `cargo check -p bitfun-core`
- `cargo test -p bitfun-core round_executor -- --nocapture`
- `cargo test -p bitfun-services-core dialog_turn_token_usage_round_trips_camel_case_payloads -- --nocapture`
- `cargo test -p bitfun-services-core token_usage_record_preserves_cached_availability_default -- --nocapture`
- `git diff --check gcwing/main..HEAD`