### PR TITLE
feat: add workspace session batch invert selection and remove queued-turn preemption

### DIFF
--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1369,7 +1369,6 @@ async fn init_agentic_system() -> anyhow::Result<(
     let scheduler =
         coordination::DialogScheduler::new(coordinator.clone(), session_manager.clone());
     coordinator.set_scheduler_notifier(scheduler.outcome_sender());
-    coordinator.set_round_preempt_source(scheduler.preempt_monitor());
     coordinator.set_round_injection_source(scheduler.round_injection_monitor());
     coordination::set_global_scheduler(scheduler.clone());
 

--- a/src/apps/server/src/bootstrap.rs
+++ b/src/apps/server/src/bootstrap.rs
@@ -120,7 +120,6 @@ pub async fn initialize(workspace: Option<String>) -> anyhow::Result<Arc<ServerA
     let scheduler =
         coordination::DialogScheduler::new(coordinator.clone(), session_manager.clone());
     coordinator.set_scheduler_notifier(scheduler.outcome_sender());
-    coordinator.set_round_preempt_source(scheduler.preempt_monitor());
     coordinator.set_round_injection_source(scheduler.round_injection_monitor());
     coordination::set_global_scheduler(scheduler.clone());
 

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -33,7 +33,7 @@ use crate::agentic::remote_file_delivery::{
     needs_computer_links_for_source, remote_file_delivery_reminder,
     TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY,
 };
-use crate::agentic::round_preempt::{DialogRoundInjectionSource, DialogRoundPreemptSource};
+use crate::agentic::round_preempt::DialogRoundInjectionSource;
 use crate::agentic::session::SessionManager;
 use crate::agentic::side_question::build_btw_user_input;
 use crate::agentic::skill_agent_snapshot::{
@@ -513,8 +513,6 @@ pub struct ConversationCoordinator {
     active_subagent_executions: Arc<DashMap<String, ActiveSubagentExecution>>,
     /// Notifies DialogScheduler of turn outcomes; injected after construction
     scheduler_notify_tx: OnceLock<mpsc::Sender<(String, TurnOutcome)>>,
-    /// Round-boundary yield (same source as scheduler's yield flags); injected after construction
-    round_preempt_source: OnceLock<Arc<dyn DialogRoundPreemptSource>>,
     /// Round-boundary user steering source (mid-turn user message injection); injected after construction
     round_injection_source: OnceLock<Arc<dyn DialogRoundInjectionSource>>,
     /// In-flight dialog turn tracker per session, used to serialize cancel→start
@@ -1035,7 +1033,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             subagent_timeout_registry: Arc::new(RwLock::new(HashMap::new())),
             active_subagent_executions: Arc::new(DashMap::new()),
             scheduler_notify_tx: OnceLock::new(),
-            round_preempt_source: OnceLock::new(),
             round_injection_source: OnceLock::new(),
             active_turns_per_session: Arc::new(DashMap::new()),
             thread_goal_runtime: Arc::new(ThreadGoalRuntime::new()),
@@ -1050,11 +1047,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
     /// Called once during app initialization after the scheduler is created.
     pub fn set_scheduler_notifier(&self, tx: mpsc::Sender<(String, TurnOutcome)>) {
         let _ = self.scheduler_notify_tx.set(tx);
-    }
-
-    /// Wire round-boundary preempt (typically the scheduler's [`SessionRoundYieldFlags`](crate::agentic::round_preempt::SessionRoundYieldFlags)).
-    pub fn set_round_preempt_source(&self, source: Arc<dyn DialogRoundPreemptSource>) {
-        let _ = self.round_preempt_source.set(source);
     }
 
     /// Wire round-boundary injection source (typically the scheduler's
@@ -2613,7 +2605,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             skip_tool_confirmation: true,
             runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
             workspace_services: manual_workspace_services,
-            round_preempt: None,
             round_injection: None,
             recover_partial_on_cancel: false,
         };
@@ -3212,7 +3203,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             skip_tool_confirmation: submission_policy.skip_tool_confirmation,
             runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
             workspace_services,
-            round_preempt: self.round_preempt_source.get().cloned(),
             round_injection: self.round_injection_source.get().cloned(),
             recover_partial_on_cancel: false,
         };
@@ -4455,7 +4445,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             skip_tool_confirmation: true,
             runtime_tool_restrictions,
             workspace_services: subagent_services,
-            round_preempt: self.round_preempt_source.get().cloned(),
             // Subagents are autonomous; user steering is targeted at top-level
             // dialog turns only. Leave None so we don't intercept buffer entries
             // that belong to a different (parent) session/turn.

--- a/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
@@ -19,10 +19,7 @@ use crate::agentic::goal_mode::{
 };
 use crate::agentic::image_analysis::ImageContextData;
 use crate::agentic::init_agents_md::build_init_agents_md_user_input;
-use crate::agentic::round_preempt::{
-    DialogRoundInjectionSource, DialogRoundPreemptSource, SessionRoundInjectionBuffer,
-    SessionRoundYieldFlags,
-};
+use crate::agentic::round_preempt::{DialogRoundInjectionSource, SessionRoundInjectionBuffer};
 use crate::agentic::session::SessionManager;
 use bitfun_runtime_ports::{ThreadGoal, MAX_THREAD_GOAL_AUTO_CONTINUATIONS};
 use log::{debug, info, warn};
@@ -92,8 +89,6 @@ pub struct DialogScheduler {
     goal_continuation_abort: Arc<SessionAbortFlags>,
     /// Cloneable sender given to ConversationCoordinator for turn outcome notifications
     outcome_tx: mpsc::Sender<(String, TurnOutcome)>,
-    /// When a user submits while `Processing`, engine yields after the current model round.
-    round_yield_flags: Arc<SessionRoundYieldFlags>,
     /// Per-session FIFO buffer of round injections drained at round boundaries
     /// by the engine and injected into the running dialog turn.
     round_injection_buffer: Arc<SessionRoundInjectionBuffer>,
@@ -119,7 +114,6 @@ impl DialogScheduler {
             suppressed_cancelled_replies: Arc::new(DialogReplySuppressionSet::default()),
             goal_continuation_abort: Arc::new(SessionAbortFlags::default()),
             outcome_tx,
-            round_yield_flags: Arc::new(SessionRoundYieldFlags::default()),
             round_injection_buffer: Arc::new(SessionRoundInjectionBuffer::default()),
         });
 
@@ -134,11 +128,6 @@ impl DialogScheduler {
     /// Returns a sender to give to ConversationCoordinator for turn outcome notifications.
     pub fn outcome_sender(&self) -> mpsc::Sender<(String, TurnOutcome)> {
         self.outcome_tx.clone()
-    }
-
-    /// Pass to [`ConversationCoordinator::set_round_preempt_source`](super::coordinator::ConversationCoordinator::set_round_preempt_source).
-    pub fn preempt_monitor(&self) -> Arc<dyn DialogRoundPreemptSource> {
-        self.round_yield_flags.clone()
     }
 
     /// Pass to [`ConversationCoordinator::set_round_injection_source`](super::coordinator::ConversationCoordinator::set_round_injection_source).
@@ -424,9 +413,8 @@ impl DialogScheduler {
     ///
     /// - Session idle, queue empty → dispatched immediately.
     /// - Session idle, queue non-empty → enqueued then highest-priority queued message dispatched.
-    /// - Session processing → queued up to the runtime-owned queue limit. For interactive sources
-    ///   (desktop, CLI, bot, …), also requests a yield after the current model round so
-    ///   the queued message can start sooner than a full multi-round turn.
+    /// - Session processing → queued up to the runtime-owned queue limit and dispatched after
+    ///   the current turn completes.
     /// - Session error → queue cleared, dispatched immediately.
     ///
     /// Returns `Err(String)` if the queue is full or the coordinator returns an error.
@@ -579,14 +567,11 @@ impl DialogScheduler {
                 Ok(outcome)
             }
 
-            DialogSubmitQueueAction::EnqueueForActiveTurn { request_yield } => {
+            DialogSubmitQueueAction::EnqueueForActiveTurn => {
                 let accepted_agent_type = queued_turn.agent_type.clone();
                 self.enqueue(&session_id, queued_turn)?;
                 self.record_last_submitted_agent_type(&session_id, &accepted_agent_type)
                     .await;
-                if request_yield {
-                    self.round_yield_flags.request_yield(&session_id);
-                }
                 Ok(DialogSubmitOutcome::Queued {
                     session_id,
                     turn_id: resolved_turn_id,
@@ -896,9 +881,6 @@ impl DialogScheduler {
                 self.active_turns.contains(&session_id),
             );
 
-            if lifecycle_plan.clear_round_yield {
-                self.round_yield_flags.clear(&session_id);
-            }
             // Only drop steering messages targeted at the *finished* turn. We
             // must NOT clear the entire session buffer here: a user might have
             // legitimately submitted steering against a brand-new follow-up
@@ -1429,23 +1411,18 @@ mod tests {
     }
 
     #[test]
-    fn remote_queue_policy_preserves_interactive_preempt_and_confirmation_boundary() {
+    fn remote_queue_policy_preserves_confirmation_boundary() {
         let remote = DialogSubmissionPolicy::for_source(DialogTriggerSource::RemoteRelay);
         assert_eq!(remote.queue_priority, DialogQueuePriority::Normal);
         assert!(remote.skip_tool_confirmation);
-        assert!(bitfun_runtime_ports::dialog_policy_may_preempt(&remote));
 
         let bot = DialogSubmissionPolicy::for_source(DialogTriggerSource::Bot);
         assert_eq!(bot.queue_priority, DialogQueuePriority::Normal);
         assert!(bot.skip_tool_confirmation);
-        assert!(bitfun_runtime_ports::dialog_policy_may_preempt(&bot));
 
         let agent_session = DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession);
         assert_eq!(agent_session.queue_priority, DialogQueuePriority::Low);
         assert!(agent_session.skip_tool_confirmation);
-        assert!(!bitfun_runtime_ports::dialog_policy_may_preempt(
-            &agent_session
-        ));
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -3,7 +3,7 @@
 //! Executes complete dialog turns, managing loops of multiple model rounds
 
 use super::round_executor::RoundExecutor;
-use super::types::{ExecutionContext, ExecutionResult, RoundContext, RoundResult};
+use super::types::{ExecutionContext, ExecutionResult, RoundContext};
 use crate::agentic::agents::{
     build_prompt_context_for_workspace, get_agent_registry, PrependedPromptReminders,
     PromptBuilder, PromptBuilderContext, RuntimeContextNeeds, ToolListingSections,
@@ -245,9 +245,6 @@ pub struct ExecutionEngine {
 }
 
 impl ExecutionEngine {
-    const FINALIZE_AFTER_TOOL_USE_REMINDER: &'static str = "Tool execution for this turn has already completed, but the turn is ending at this round boundary. Do not call any more tools. Provide the final response to the user based on the tool results already available.";
-    const FORCE_TEXT_ONLY_REMINDER: &'static str = "STOP. Tool calls are disabled for this final turn. Respond ONLY with a plain-text answer summarizing what you have done and the result for the user. Do not output tool call syntax of any kind.";
-
     pub fn new(
         round_executor: Arc<RoundExecutor>,
         event_queue: Arc<EventQueue>,
@@ -354,26 +351,6 @@ impl ExecutionEngine {
         }
 
         counts.values().all(|&count| count >= 2)
-    }
-
-    fn assistant_has_tool_calls(message: &Message) -> bool {
-        matches!(
-            &message.content,
-            MessageContent::Mixed { tool_calls, .. } if !tool_calls.is_empty()
-        )
-    }
-
-    fn has_tool_result_after_last_assistant(messages: &[Message]) -> bool {
-        let Some(last_assistant_index) = messages
-            .iter()
-            .rposition(|message| message.role == MessageRole::Assistant)
-        else {
-            return false;
-        };
-
-        messages[last_assistant_index + 1..]
-            .iter()
-            .any(|message| matches!(message.content, MessageContent::ToolResult { .. }))
     }
 
     /// Emergency truncation: drop oldest API rounds (assistant+tool pairs)
@@ -845,71 +822,6 @@ impl ExecutionEngine {
             .iter()
             .copied()
             .collect()
-    }
-
-    /// Synthesize one extra finalize round with tools disabled, returning the
-    /// resulting assistant message + metadata. Used by both the
-    /// "summarize tool results" and "force text after thinking-only" paths.
-    #[allow(clippy::too_many_arguments)]
-    async fn run_finalize_round(
-        &self,
-        ai_client: Arc<crate::infrastructure::ai::AIClient>,
-        context: &ExecutionContext,
-        agent_type: String,
-        round_number: usize,
-        execution_context_vars: &HashMap<String, String>,
-        primary_supports_image_understanding: bool,
-        prepended_reminders: &[&str],
-        messages: &[Message],
-        reminder_text: &str,
-        context_window: usize,
-    ) -> BitFunResult<RoundResult> {
-        let mut final_ai_messages = Self::build_ai_messages_for_send(
-            messages,
-            &ai_client.config.format,
-            context
-                .workspace
-                .as_ref()
-                .map(|workspace| workspace.root_path()),
-            &context.dialog_turn_id,
-            primary_supports_image_understanding,
-            prepended_reminders,
-        )
-        .await?;
-        final_ai_messages.push(AIMessage::user(reminder_text.to_string()));
-
-        let round_context = RoundContext {
-            session_id: context.session_id.clone(),
-            subagent_parent_info: context.subagent_parent_info.clone(),
-            dialog_turn_id: context.dialog_turn_id.clone(),
-            turn_index: context.turn_index,
-            round_number,
-            workspace: context.workspace.clone(),
-            messages: messages.to_vec(),
-            available_tools: Vec::new(),
-            collapsed_tools: Vec::new(),
-            unlocked_collapsed_tools: Vec::new(),
-            model_name: ai_client.config.model.clone(),
-            agent_type,
-            context_vars: execution_context_vars.clone(),
-            delegation_policy: context.delegation_policy,
-            runtime_tool_restrictions: context.runtime_tool_restrictions.clone(),
-            steering_interrupt: None,
-            cancellation_token: CancellationToken::new(),
-            workspace_services: context.workspace_services.clone(),
-            recover_partial_on_cancel: context.recover_partial_on_cancel,
-        };
-
-        // Tools are disabled here (None) — model must respond in plain text.
-        self.round_executor
-            .execute_round(
-                ai_client,
-                round_context,
-                final_ai_messages,
-                None,
-                Some(context_window),
-            )
-            .await
     }
 
     async fn build_ai_messages_for_send(
@@ -2710,10 +2622,9 @@ impl ExecutionEngine {
 
             // User-steering messages submitted while this turn is running: drain and inject
             // them as user messages into the working history before starting the next round
-            // (Codex-style mid-turn injection). This does NOT end the current turn, in
-            // contrast with the `round_preempt` path below which finalizes the turn so a
-            // queued *new turn* can take over. If the model wanted to finish but the user
-            // steered, we keep the turn running so the steering message gets a response.
+            // (Codex-style mid-turn injection). This does NOT end the current turn: if the
+            // model wanted to finish but the user steered, we keep the turn running so the
+            // steering message gets a response.
             let mut injection_applied = false;
             if let Some(source) = context.round_injection.as_ref() {
                 let pending = source.take_pending(&context.session_id, &context.dialog_turn_id);
@@ -2878,23 +2789,6 @@ impl ExecutionEngine {
                 }
             }
 
-            // Queued user message while this turn was running: stop after a full model round.
-            // The round output has already been reflected in the in-memory message caches.
-            // No special deferral for tool-confirmation phases: we do not require the user to
-            // finish confirming before this boundary check runs; the check applies as soon as
-            // this `execute_round` completes (same as any other round).
-            if let Some(preempt) = context.round_preempt.as_ref() {
-                if preempt.should_yield_after_round(&context.session_id) {
-                    preempt.clear_yield_after_round(&context.session_id);
-                    info!(
-                        "Yielding dialog turn after model round (queued user message): session_id={}, dialog_turn_id={}, round_index={}",
-                        context.session_id, context.dialog_turn_id, round_index
-                    );
-                    finalization_reason = Some("queued_user_message");
-                    break;
-                }
-            }
-
             // Check if cancellation was requested after each round. Tokens stay
             // registered until final cleanup so early cancellation can be
             // observed by the first round.
@@ -2932,111 +2826,11 @@ impl ExecutionEngine {
         }
 
         // P1-6: Track the actual termination reason for downstream reporting.
-        // Defaults to "complete" (model produced a final answer naturally) and
-        // is overridden by finalize / fallback paths below.
-        let mut effective_finish_reason: &'static str = match finalization_reason {
+        // Defaults to "complete" (model produced a final answer naturally).
+        let effective_finish_reason: &'static str = match finalization_reason {
             Some(r) => r,
             None => "complete",
         };
-        let mut finalize_fallback_text_used = false;
-
-        if let Some(reason) = finalization_reason {
-            // If the turn yielded after tool use, ask the model to summarize
-            // tool results before the next queued user message takes over.
-            let needs_finalize_after_tool_use = reason == "queued_user_message"
-                && messages
-                    .iter()
-                    .rev()
-                    .find(|message| message.role == MessageRole::Assistant)
-                    .is_some_and(Self::assistant_has_tool_calls)
-                && Self::has_tool_result_after_last_assistant(&messages);
-
-            if needs_finalize_after_tool_use {
-                info!(
-                    "Finalizing dialog turn: session_id={}, turn_id={}, reason={}",
-                    context.session_id, context.dialog_turn_id, reason
-                );
-
-                let final_round_result = self
-                    .run_finalize_round(
-                        ai_client.clone(),
-                        &context,
-                        agent_type.clone(),
-                        completed_rounds,
-                        &execution_context_vars,
-                        primary_supports_image_understanding,
-                        &prepended_reminders,
-                        &messages,
-                        Self::FINALIZE_AFTER_TOOL_USE_REMINDER,
-                        context_window,
-                    )
-                    .await?;
-
-                let mut accepted =
-                    !Self::assistant_has_tool_calls(&final_round_result.assistant_message);
-                let mut chosen_assistant_message: Option<Message> = None;
-                let mut chosen_usage: Option<crate::util::types::ai::GeminiUsage> =
-                    final_round_result.usage.clone();
-
-                if accepted {
-                    chosen_assistant_message = Some(final_round_result.assistant_message.clone());
-                } else {
-                    // P1-10: First finalize round still returned tool calls
-                    // (rare; tools were not provided, but model hallucinated).
-                    // One last attempt with a stricter text-only reminder.
-                    warn!(
-                        "Finalize round still returned tool calls; retrying with text-only reminder: session_id={}, turn_id={}",
-                        context.session_id, context.dialog_turn_id
-                    );
-                    let retry_result = self
-                        .run_finalize_round(
-                            ai_client.clone(),
-                            &context,
-                            agent_type.clone(),
-                            completed_rounds,
-                            &execution_context_vars,
-                            primary_supports_image_understanding,
-                            &prepended_reminders,
-                            &messages,
-                            Self::FORCE_TEXT_ONLY_REMINDER,
-                            context_window,
-                        )
-                        .await?;
-                    finalize_fallback_text_used = true;
-                    if Self::assistant_has_tool_calls(&retry_result.assistant_message) {
-                        warn!(
-                            "Text-only retry also returned tool calls; keeping prior messages: session_id={}, turn_id={}",
-                            context.session_id, context.dialog_turn_id
-                        );
-                    } else {
-                        accepted = true;
-                        chosen_usage = retry_result.usage.clone();
-                        chosen_assistant_message = Some(retry_result.assistant_message);
-                    }
-                }
-
-                if let Some(msg) = chosen_assistant_message {
-                    completed_rounds += 1;
-                    if let Some(usage) = chosen_usage {
-                        last_usage = Some(usage);
-                    }
-                    messages.push(msg.clone());
-                    if let Err(e) = self
-                        .session_manager
-                        .add_message(&context.session_id, msg)
-                        .await
-                    {
-                        warn!("Failed to update final assistant message in memory: {}", e);
-                    }
-                }
-
-                if !accepted {
-                    effective_finish_reason = "finalize_failed";
-                } else if finalize_fallback_text_used {
-                    effective_finish_reason = "finalize_text_only_forced";
-                }
-            }
-        }
 
         let duration_ms = elapsed_ms_u64(start_time);
 
@@ -3186,7 +2980,7 @@ impl ExecutionEngine {
 #[cfg(test)]
 mod tests {
     use super::{ContextHealthSnapshot, ExecutionEngine};
-    use crate::agentic::core::{Message, MessageRole, ToolCall, ToolResult};
+    use crate::agentic::core::{Message, MessageRole, ToolResult};
     use crate::service::config::types::AIConfig;
     use crate::service::config::types::AIModelConfig;
     use crate::util::types::ToolDefinition;
@@ -3482,60 +3276,6 @@ mod tests {
         assert_eq!(snapshot.repeated_tool_signature_count, 0);
         assert_eq!(snapshot.consecutive_failed_commands, 2);
         assert_eq!(snapshot.compression_failure_count, 2);
-    }
-
-    #[test]
-    fn assistant_has_tool_calls_detects_mixed_tool_message() {
-        let message = Message::assistant_with_tools(
-            String::new(),
-            vec![ToolCall {
-                tool_id: "tool-1".to_string(),
-                tool_name: "Read".to_string(),
-                arguments: json!({ "path": "README.md" }),
-                raw_arguments: None,
-                is_error: false,
-                recovered_from_truncation: false,
-            }],
-        );
-
-        assert!(ExecutionEngine::assistant_has_tool_calls(&message));
-        assert!(!ExecutionEngine::assistant_has_tool_calls(
-            &Message::assistant("done".to_string())
-        ));
-    }
-
-    #[test]
-    fn detects_tool_result_after_last_assistant() {
-        let assistant = Message::assistant_with_tools(
-            String::new(),
-            vec![ToolCall {
-                tool_id: "tool-1".to_string(),
-                tool_name: "Read".to_string(),
-                arguments: json!({ "path": "README.md" }),
-                raw_arguments: None,
-                is_error: false,
-                recovered_from_truncation: false,
-            }],
-        );
-        let tool_result = Message::tool_result(ToolResult {
-            tool_id: "tool-1".to_string(),
-            tool_name: "Read".to_string(),
-            result: json!({ "content": "hello" }),
-            result_for_assistant: Some("hello".to_string()),
-            is_error: false,
-            duration_ms: Some(1),
-            image_attachments: None,
-        });
-
-        assert!(ExecutionEngine::has_tool_result_after_last_assistant(&[
-            Message::user("read it".to_string()),
-            assistant.clone(),
-            tool_result,
-        ]));
-        assert!(!ExecutionEngine::has_tool_result_after_last_assistant(&[
-            Message::user("read it".to_string()),
-            assistant,
-        ]));
     }
 
     fn command_result(tool_name: &str, success: bool, exit_code: Option<i32>) -> Message {

--- a/src/crates/assembly/core/src/agentic/execution/types.rs
+++ b/src/crates/assembly/core/src/agentic/execution/types.rs
@@ -1,9 +1,7 @@
 //! Execution Engine Type Definitions
 
 use crate::agentic::core::Message;
-use crate::agentic::round_preempt::{
-    DialogRoundInjectionInterrupt, DialogRoundInjectionSource, DialogRoundPreemptSource,
-};
+use crate::agentic::round_preempt::{DialogRoundInjectionInterrupt, DialogRoundInjectionSource};
 use crate::agentic::tools::pipeline::SubagentParentInfo;
 use crate::agentic::tools::ToolRuntimeRestrictions;
 use crate::agentic::workspace::WorkspaceServices;
@@ -30,8 +28,6 @@ pub struct ExecutionContext {
     pub runtime_tool_restrictions: ToolRuntimeRestrictions,
     /// Workspace I/O services (filesystem + shell) injected into tools
     pub workspace_services: Option<WorkspaceServices>,
-    /// When set, engine may end the turn after a full model round if a user message was queued.
-    pub round_preempt: Option<Arc<dyn DialogRoundPreemptSource>>,
     /// When set, engine drains pending round injections at each round boundary
     /// and injects them into the dialog history without ending the turn.
     pub round_injection: Option<Arc<dyn DialogRoundInjectionSource>>,

--- a/src/crates/assembly/core/src/agentic/mod.rs
+++ b/src/crates/assembly/core/src/agentic/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod subagent_runtime;
 pub mod fork_agent;
 
 pub(crate) mod remote_file_delivery;
-/// Round-boundary yield when user queues a message during an active turn
+/// Round-boundary injection support for steering/background updates
 pub mod round_preempt;
 
 // Image analysis module
@@ -64,9 +64,8 @@ pub use goal_mode::*;
 pub use image_analysis::{ImageAnalyzer, MessageEnhancer};
 pub use persistence::PersistenceManager;
 pub use round_preempt::{
-    DialogRoundInjectionInterrupt, DialogRoundInjectionSource, DialogRoundPreemptSource,
-    NoopDialogRoundInjectionSource, NoopDialogRoundPreemptSource, RoundInjection,
-    RoundInjectionKind, RoundInjectionTarget, SessionRoundInjectionBuffer, SessionRoundYieldFlags,
+    DialogRoundInjectionInterrupt, DialogRoundInjectionSource, NoopDialogRoundInjectionSource,
+    RoundInjection, RoundInjectionKind, RoundInjectionTarget, SessionRoundInjectionBuffer,
 };
 pub use session::*;
 pub use side_question::*;

--- a/src/crates/assembly/core/src/agentic/round_preempt.rs
+++ b/src/crates/assembly/core/src/agentic/round_preempt.rs
@@ -1,10 +1,8 @@
-//! Compatibility re-exports for round-boundary scheduler owner state.
+//! Compatibility re-exports for round-boundary injection state.
 
 pub use bitfun_agent_runtime::scheduler::{
-    DialogRoundInjectionInterrupt, NoopDialogRoundInjectionSource, NoopDialogRoundPreemptSource,
-    SessionRoundInjectionBuffer, SessionRoundYieldFlags,
+    DialogRoundInjectionInterrupt, NoopDialogRoundInjectionSource, SessionRoundInjectionBuffer,
 };
 pub use bitfun_runtime_ports::{
-    DialogRoundInjectionSource, DialogRoundPreemptSource, RoundInjection, RoundInjectionKind,
-    RoundInjectionTarget,
+    DialogRoundInjectionSource, RoundInjection, RoundInjectionKind, RoundInjectionTarget,
 };

--- a/src/crates/contracts/runtime-ports/src/lib.rs
+++ b/src/crates/contracts/runtime-ports/src/lib.rs
@@ -791,18 +791,7 @@ pub enum DialogSubmitQueueAction {
     StartImmediately,
     ClearQueueAndStartImmediately,
     EnqueueThenStartNext,
-    EnqueueForActiveTurn { request_yield: bool },
-}
-
-pub const fn dialog_policy_may_preempt(policy: &DialogSubmissionPolicy) -> bool {
-    matches!(
-        policy.trigger_source,
-        DialogTriggerSource::DesktopUi
-            | DialogTriggerSource::DesktopApi
-            | DialogTriggerSource::Cli
-            | DialogTriggerSource::RemoteRelay
-            | DialogTriggerSource::Bot
-    )
+    EnqueueForActiveTurn,
 }
 
 pub const fn resolve_dialog_submit_queue_action(
@@ -818,9 +807,7 @@ pub const fn resolve_dialog_submit_queue_action(
                 DialogSubmitQueueAction::StartImmediately
             }
         }
-        DialogSessionStateFact::Processing => DialogSubmitQueueAction::EnqueueForActiveTurn {
-            request_yield: dialog_policy_may_preempt(&facts.policy),
-        },
+        DialogSessionStateFact::Processing => DialogSubmitQueueAction::EnqueueForActiveTurn,
     }
 }
 
@@ -893,13 +880,6 @@ pub struct RoundInjection {
     pub content: String,
     pub display_content: String,
     pub created_at: std::time::SystemTime,
-}
-
-/// Observes whether the current dialog turn should end after the latest model
-/// round so a queued user message can start as a new turn.
-pub trait DialogRoundPreemptSource: Send + Sync {
-    fn should_yield_after_round(&self, session_id: &str) -> bool;
-    fn clear_yield_after_round(&self, session_id: &str);
 }
 
 /// Observes round-boundary injections for a given running turn.
@@ -1485,10 +1465,8 @@ mod tests {
     #[test]
     fn dialog_submit_queue_action_preserves_current_scheduler_routing_policy() {
         let remote = DialogSubmissionPolicy::for_source(DialogTriggerSource::RemoteRelay);
-        assert!(dialog_policy_may_preempt(&remote));
 
         let agent_session = DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession);
-        assert!(!dialog_policy_may_preempt(&agent_session));
 
         assert_eq!(
             resolve_dialog_submit_queue_action(DialogSubmitQueueFacts {
@@ -1528,9 +1506,7 @@ mod tests {
                 queue_has_items: false,
                 policy: remote,
             }),
-            DialogSubmitQueueAction::EnqueueForActiveTurn {
-                request_yield: true
-            }
+            DialogSubmitQueueAction::EnqueueForActiveTurn
         );
         assert_eq!(
             resolve_dialog_submit_queue_action(DialogSubmitQueueFacts {
@@ -1538,9 +1514,7 @@ mod tests {
                 queue_has_items: false,
                 policy: agent_session,
             }),
-            DialogSubmitQueueAction::EnqueueForActiveTurn {
-                request_yield: false
-            }
+            DialogSubmitQueueAction::EnqueueForActiveTurn
         );
     }
 

--- a/src/crates/execution/agent-runtime/src/scheduler.rs
+++ b/src/crates/execution/agent-runtime/src/scheduler.rs
@@ -5,12 +5,11 @@ use crate::thread_goal::{build_objective_updated_plan, build_thread_goal_continu
 use bitfun_runtime_ports::{
     should_skip_agent_session_reply, should_suppress_agent_session_cancelled_reply,
     AgentSessionReplyRoute, DialogQueuePriority, DialogRoundInjectionSource,
-    DialogRoundPreemptSource, DialogSessionStateFact, DialogSteerOutcome, DialogSubmissionPolicy,
-    DialogTriggerSource, RoundInjection, RoundInjectionKind, RoundInjectionTarget, ThreadGoal,
+    DialogSessionStateFact, DialogSteerOutcome, DialogSubmissionPolicy, DialogTriggerSource,
+    RoundInjection, RoundInjectionKind, RoundInjectionTarget, ThreadGoal,
 };
 use std::collections::VecDeque;
 use std::fmt;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -428,53 +427,6 @@ pub fn build_thread_goal_objective_updated_delivery_plan(
 }
 
 /// Used when no scheduler is wired (e.g. tests, isolated execution).
-pub struct NoopDialogRoundPreemptSource;
-
-impl DialogRoundPreemptSource for NoopDialogRoundPreemptSource {
-    fn should_yield_after_round(&self, _session_id: &str) -> bool {
-        false
-    }
-
-    fn clear_yield_after_round(&self, _session_id: &str) {}
-}
-
-/// Shared flag storage keyed by session; scheduler sets, engine reads and clears.
-#[derive(Debug, Default)]
-pub struct SessionRoundYieldFlags {
-    inner: dashmap::DashMap<String, Arc<AtomicBool>>,
-}
-
-impl SessionRoundYieldFlags {
-    pub fn request_yield(&self, session_id: &str) {
-        self.inner
-            .entry(session_id.to_string())
-            .or_insert_with(|| Arc::new(AtomicBool::new(false)))
-            .store(true, Ordering::SeqCst);
-    }
-
-    pub fn should_yield(&self, session_id: &str) -> bool {
-        self.inner
-            .get(session_id)
-            .map(|r| r.value().load(Ordering::SeqCst))
-            .unwrap_or(false)
-    }
-
-    pub fn clear(&self, session_id: &str) {
-        self.inner.remove(session_id);
-    }
-}
-
-impl DialogRoundPreemptSource for SessionRoundYieldFlags {
-    fn should_yield_after_round(&self, session_id: &str) -> bool {
-        self.should_yield(session_id)
-    }
-
-    fn clear_yield_after_round(&self, session_id: &str) {
-        self.clear(session_id);
-    }
-}
-
-/// Used when no scheduler is wired (e.g. tests, isolated execution).
 pub struct NoopDialogRoundInjectionSource;
 
 impl DialogRoundInjectionSource for NoopDialogRoundInjectionSource {
@@ -731,7 +683,6 @@ pub enum GoalContinuationAfterTurnAction {
 pub struct TurnOutcomeLifecyclePlan {
     pub status: TurnOutcomeStatus,
     pub queue_action: TurnOutcomeQueueAction,
-    pub clear_round_yield: bool,
     pub drain_finished_turn_injections: bool,
     pub goal_continuation: GoalContinuationAfterTurnAction,
 }
@@ -768,7 +719,6 @@ pub fn resolve_turn_outcome_lifecycle_plan(
     TurnOutcomeLifecyclePlan {
         status,
         queue_action: outcome.queue_action(),
-        clear_round_yield: true,
         drain_finished_turn_injections: true,
         goal_continuation,
     }
@@ -859,7 +809,6 @@ mod tests {
 
         assert_eq!(plan.status, TurnOutcomeStatus::Completed);
         assert_eq!(plan.queue_action, TurnOutcomeQueueAction::DispatchNext);
-        assert!(plan.clear_round_yield);
         assert!(plan.drain_finished_turn_injections);
         assert_eq!(
             plan.goal_continuation,

--- a/src/crates/execution/agent-runtime/tests/scheduler_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/scheduler_contracts.rs
@@ -5,14 +5,13 @@ use bitfun_agent_runtime::scheduler::{
     ActiveDialogTurnStore, AgentSessionReplyAction, BackgroundDeliveryAction,
     BackgroundDeliveryFacts, BackgroundInjectionKind, DialogReplySuppressionSet,
     DialogRoundInjectionInterrupt, DialogSteeringAction, DialogTurnQueue, DialogTurnQueueError,
-    NoopDialogRoundPreemptSource, SessionAbortFlags, SessionRoundInjectionBuffer,
-    SessionRoundYieldFlags, ThreadGoalDeliveryReminderKind, TurnOutcome, TurnOutcomeQueueAction,
-    TurnOutcomeStatus, DEFAULT_MAX_DIALOG_QUEUE_DEPTH,
+    SessionAbortFlags, SessionRoundInjectionBuffer, ThreadGoalDeliveryReminderKind, TurnOutcome,
+    TurnOutcomeQueueAction, TurnOutcomeStatus, DEFAULT_MAX_DIALOG_QUEUE_DEPTH,
 };
 use bitfun_runtime_ports::{
-    AgentSessionReplyRoute, DialogQueuePriority, DialogRoundPreemptSource, DialogSessionStateFact,
-    DialogSteerOutcome, DialogSubmissionPolicy, DialogTriggerSource, RoundInjection,
-    RoundInjectionKind, RoundInjectionTarget, ThreadGoal, ThreadGoalStatus,
+    AgentSessionReplyRoute, DialogQueuePriority, DialogSessionStateFact, DialogSteerOutcome,
+    DialogSubmissionPolicy, DialogTriggerSource, RoundInjection, RoundInjectionKind,
+    RoundInjectionTarget, ThreadGoal, ThreadGoalStatus,
 };
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -499,21 +498,6 @@ fn turn_outcome_status_reply_and_queue_policy_are_portable() {
     assert_eq!(failed.status(), TurnOutcomeStatus::Failed);
     assert!(failed.reply_text().contains("network offline"));
     assert_eq!(failed.queue_action(), TurnOutcomeQueueAction::ClearQueue);
-}
-
-#[test]
-fn round_yield_flags_are_session_scoped_and_clearable() {
-    let noop = NoopDialogRoundPreemptSource;
-    assert!(!noop.should_yield_after_round("s1"));
-
-    let flags = SessionRoundYieldFlags::default();
-    flags.request_yield("s1");
-
-    assert!(flags.should_yield_after_round("s1"));
-    assert!(!flags.should_yield_after_round("s2"));
-
-    flags.clear_yield_after_round("s1");
-    assert!(!flags.should_yield_after_round("s1"));
 }
 
 #[test]

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceSessionBatchModal.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceSessionBatchModal.scss
@@ -101,11 +101,21 @@
     display: flex;
     align-items: center;
     gap: 10px;
+    width: 100%;
     min-width: 0;
+    min-height: var(--button-height-sm, 32px);
+    flex-wrap: nowrap;
+  }
+
+  &__toolbar-actions {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
   }
 
   &__toolbar-summary {
     min-width: 0;
+    flex: 1 1 180px;
     font-size: 11px;
     color: var(--color-text-secondary);
     white-space: nowrap;
@@ -316,6 +326,8 @@
     &__toolbar-main {
       flex-direction: column;
       align-items: stretch;
+      width: auto;
+      min-height: 0;
     }
 
     &__toolbar-summary {

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceSessionBatchModal.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceSessionBatchModal.tsx
@@ -192,6 +192,10 @@ const WorkspaceSessionBatchModal: React.FC<WorkspaceSessionBatchModalProps> = ({
     });
   }, [allSessionIds]);
 
+  const handleInvertSelection = useCallback(() => {
+    setSelectedSessionIds(prev => new Set(allSessionIds.filter(sessionId => !prev.has(sessionId))));
+  }, [allSessionIds]);
+
   const refreshWorkspaceSessions = useCallback(async () => {
     await flowChatManager.refreshWorkspaceSessions({
       rootPath: workspacePath,
@@ -352,6 +356,19 @@ const WorkspaceSessionBatchModal: React.FC<WorkspaceSessionBatchModalProps> = ({
               disabled={isBusy || allSessionIds.length === 0}
               label={allSelected ? t('actions.deselectAll') : t('actions.selectAll')}
             />
+            {selectedCount > 0 ? (
+              <div className="workspace-session-batch-modal__toolbar-actions">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="small"
+                  onClick={handleInvertSelection}
+                  disabled={isBusy || allSessionIds.length === 0}
+                >
+                  {t('actions.invertSelection')}
+                </Button>
+              </div>
+            ) : null}
             <div className="workspace-session-batch-modal__toolbar-summary">
               {hasSessions
                 ? t('nav.sessions.batchSelectionSummary', { count: selectedCount, total: sessions.length })

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -624,6 +624,7 @@
     "select": "Select",
     "selectAll": "Select All",
     "deselectAll": "Deselect All",
+    "invertSelection": "Invert Selection",
     "expand": "Expand",
     "collapse": "Collapse",
     "more": "More",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -624,6 +624,7 @@
     "select": "选择",
     "selectAll": "全选",
     "deselectAll": "取消全选",
+    "invertSelection": "反选",
     "expand": "展开",
     "collapse": "收起",
     "more": "更多",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -624,6 +624,7 @@
     "select": "選擇",
     "selectAll": "全選",
     "deselectAll": "取消全選",
+    "invertSelection": "反選",
     "expand": "展開",
     "collapse": "收起",
     "more": "更多",


### PR DESCRIPTION
## Changes

- add invert-selection support in the workspace session batch modal
- remove queued-turn round preempt scheduling behavior
- remove finalize-after-tool cleanup logic tied to queued-turn preemption
- remove related round-preempt abstractions, wiring, and tests
- keep round-boundary injection / steering behavior intact

## Behavior change

Before:
- some runtime entry points could queue a follow-up turn and request yield after the current model round
- this could trigger a finalize-after-tool-use cleanup path

After:
- follow-up turns remain queued while the current turn is still processing
- the queued turn starts only after the active turn finishes naturally
- explicit steering / round injection behavior is unchanged