### PR TITLE
feat(logging): add model exchange tracing for AI requests

### DIFF
--- a/src/apps/desktop/src/api/editor_ai_api.rs
+++ b/src/apps/desktop/src/api/editor_ai_api.rs
@@ -125,7 +125,7 @@ pub async fn editor_ai_stream(
         let mut full_text = String::new();
         let mut last_finish_reason: Option<String> = None;
 
-        let mut stream = match client.send_message_stream(messages, None).await {
+        let mut stream = match client.send_message_stream(messages, None, None).await {
             Ok(response) => response.stream,
             Err(error) => {
                 runtime.remove(&request_id).await;

--- a/src/apps/desktop/src/api/miniapp_api.rs
+++ b/src/apps/desktop/src/api/miniapp_api.rs
@@ -1346,7 +1346,7 @@ pub async fn miniapp_ai_complete(
     );
 
     let stream_response = ai_client
-        .send_message_stream(messages, None)
+        .send_message_stream(messages, None, None)
         .await
         .map_err(|e| format!("AI request failed: {}", e))?;
 
@@ -1424,7 +1424,7 @@ pub async fn miniapp_ai_chat(
     let messages = build_messages_for_ai(request.system_prompt.as_deref(), &request.messages);
 
     let stream_response = ai_client
-        .send_message_stream(messages, None)
+        .send_message_stream(messages, None, None)
         .await
         .map_err(|e| format!("AI request failed: {}", e))?;
 

--- a/src/crates/adapters/ai-adapters/Cargo.toml
+++ b/src/crates/adapters/ai-adapters/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 bitfun-agent-stream = { path = "../../execution/agent-stream" }
 bitfun-core-types = { path = "../../contracts/core-types" }
 chrono = { workspace = true }
@@ -25,7 +26,6 @@ tokio-stream = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]
-async-trait = { workspace = true }
 axum = { workspace = true }
 bitfun-events = { path = "../../contracts/events" }
 tokio-util = { workspace = true }

--- a/src/crates/adapters/ai-adapters/src/client.rs
+++ b/src/crates/adapters/ai-adapters/src/client.rs
@@ -13,6 +13,7 @@ pub(crate) mod sse;
 pub(crate) mod utils;
 
 use crate::providers::{anthropic, gemini, openai};
+use crate::trace::{ModelExchangeRequestTraceHandle, ModelExchangeTraceConfig};
 use crate::types::ProxyConfig;
 use crate::types::*;
 use anyhow::Result;
@@ -31,6 +32,7 @@ pub struct StreamResponse {
         Box<dyn futures::Stream<Item = Result<crate::stream::UnifiedResponse>> + Send>,
     >,
     pub raw_sse_rx: Option<mpsc::UnboundedReceiver<String>>,
+    pub trace_handle: Option<ModelExchangeRequestTraceHandle>,
 }
 
 /// Default time to wait for the first response headers / stream body to start.
@@ -116,9 +118,10 @@ impl AIClient {
         &self,
         messages: Vec<Message>,
         tools: Option<Vec<ToolDefinition>>,
+        trace: Option<ModelExchangeTraceConfig>,
     ) -> Result<StreamResponse> {
         let custom_body = self.config.custom_request_body.clone();
-        self.send_message_stream_with_extra_body(messages, tools, custom_body)
+        self.send_message_stream_with_extra_body(messages, tools, custom_body, trace)
             .await
     }
 
@@ -127,23 +130,30 @@ impl AIClient {
         messages: Vec<Message>,
         tools: Option<Vec<ToolDefinition>>,
         extra_body: Option<serde_json::Value>,
+        trace: Option<ModelExchangeTraceConfig>,
     ) -> Result<StreamResponse> {
         let max_tries = SEND_MESSAGE_STREAM_ATTEMPTS;
         match ApiFormat::parse(&self.config.format)? {
             ApiFormat::OpenAIChat => {
-                openai::chat::send_stream(self, messages, tools, extra_body, max_tries).await
+                openai::chat::send_stream(self, messages, tools, extra_body, max_tries, trace).await
             }
             ApiFormat::OpenAIResponses => {
-                openai::responses::send_stream(self, messages, tools, extra_body, max_tries).await
+                openai::responses::send_stream(self, messages, tools, extra_body, max_tries, trace)
+                    .await
             }
             ApiFormat::Anthropic => {
-                anthropic::request::send_stream(self, messages, tools, extra_body, max_tries).await
+                anthropic::request::send_stream(self, messages, tools, extra_body, max_tries, trace)
+                    .await
             }
             ApiFormat::Gemini => {
-                gemini::request::send_stream(self, messages, tools, extra_body, max_tries).await
+                gemini::request::send_stream(self, messages, tools, extra_body, max_tries, trace)
+                    .await
             }
             ApiFormat::GeminiCodeAssist => {
-                gemini::code_assist::send_stream(self, messages, tools, extra_body, max_tries).await
+                gemini::code_assist::send_stream(
+                    self, messages, tools, extra_body, max_tries, trace,
+                )
+                .await
             }
         }
     }
@@ -170,6 +180,7 @@ impl AIClient {
                     messages.clone(),
                     tools.clone(),
                     extra_body.clone(),
+                    None,
                 )
                 .await?;
 

--- a/src/crates/adapters/ai-adapters/src/client/sse.rs
+++ b/src/crates/adapters/ai-adapters/src/client/sse.rs
@@ -1,6 +1,7 @@
 use crate::client::utils::elapsed_ms_u64;
 use crate::client::StreamResponse;
 use crate::stream::UnifiedResponse;
+use crate::trace::{ModelExchangeRequestAttempt, ModelExchangeTraceConfig};
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
 use log::{debug, error, warn};
@@ -93,10 +94,11 @@ fn retry_delay_ms(attempt: usize, headers: &HeaderMap) -> u64 {
 
 pub(crate) async fn execute_sse_request<BuildRequest, SpawnHandler>(
     label: &str,
-    _url: &str,
+    url: &str,
     request_body: &serde_json::Value,
     max_tries: usize,
     ttft_timeout: Option<Duration>,
+    trace: Option<ModelExchangeTraceConfig>,
     build_request: BuildRequest,
     spawn_handler: SpawnHandler,
 ) -> Result<StreamResponse>
@@ -110,6 +112,18 @@ where
 {
     let mut last_error = None;
     for attempt in 0..max_tries {
+        let trace_handle = if let Some(trace) = trace.as_ref() {
+            trace
+                .sink
+                .request_attempt_started(&ModelExchangeRequestAttempt {
+                    request_url: url.to_string(),
+                    request_body: request_body.clone(),
+                    attempt_number: attempt + 1,
+                })
+                .await
+        } else {
+            None
+        };
         let request_start_time = std::time::Instant::now();
         let send_outcome = send_stream_request(&build_request, request_body, ttft_timeout).await;
 
@@ -124,6 +138,15 @@ where
                         .text()
                         .await
                         .unwrap_or_else(|e| format!("Failed to read error response: {}", e));
+                    if let Some(trace) = trace.as_ref() {
+                        trace
+                            .sink
+                            .request_attempt_failed(
+                                trace_handle.as_ref(),
+                                &format!("{} client error {}: {}", label, status, error_text),
+                            )
+                            .await;
+                    }
                     error!("{} client error {}: {}", label, status, error_text);
                     return Err(anyhow!("{} client error {}: {}", label, status, error_text));
                 }
@@ -153,6 +176,18 @@ where
                         error
                     );
                     last_error = Some(error);
+                    if let Some(trace) = trace.as_ref() {
+                        trace
+                            .sink
+                            .request_attempt_failed(
+                                trace_handle.as_ref(),
+                                &last_error
+                                    .as_ref()
+                                    .map(ToString::to_string)
+                                    .unwrap_or_else(|| "unknown error".to_string()),
+                            )
+                            .await;
+                    }
 
                     if attempt < max_tries - 1 {
                         let delay_ms = retry_delay_ms(attempt, &headers);
@@ -181,6 +216,12 @@ where
                     error_msg
                 );
                 last_error = Some(error);
+                if let Some(trace) = trace.as_ref() {
+                    trace
+                        .sink
+                        .request_attempt_failed(trace_handle.as_ref(), &error_msg)
+                        .await;
+                }
 
                 if attempt < max_tries - 1 {
                     let delay_ms = exponential_retry_delay_ms(attempt);
@@ -207,6 +248,12 @@ where
                     error_msg
                 );
                 last_error = Some(error);
+                if let Some(trace) = trace.as_ref() {
+                    trace
+                        .sink
+                        .request_attempt_failed(trace_handle.as_ref(), &error_msg)
+                        .await;
+                }
 
                 if attempt < max_tries - 1 {
                     let delay_ms = exponential_retry_delay_ms(attempt);
@@ -229,6 +276,7 @@ where
         return Ok(StreamResponse {
             stream: Box::pin(tokio_stream::wrappers::UnboundedReceiverStream::new(rx)),
             raw_sse_rx: Some(rx_raw),
+            trace_handle,
         });
     }
 

--- a/src/crates/adapters/ai-adapters/src/lib.rs
+++ b/src/crates/adapters/ai-adapters/src/lib.rs
@@ -5,6 +5,7 @@ pub mod diagnostics;
 pub mod providers;
 pub mod stream;
 pub mod tool_call_accumulator;
+pub mod trace;
 pub mod types;
 
 pub use client::{
@@ -12,6 +13,10 @@ pub use client::{
     DEFAULT_STREAM_TTFT_TIMEOUT_SECS, REASONING_STREAM_TTFT_TIMEOUT_SECS,
 };
 pub use stream::{UnifiedResponse, UnifiedTokenUsage, UnifiedToolCall};
+pub use trace::{
+    ModelExchangeRequestAttempt, ModelExchangeRequestTraceHandle, ModelExchangeResponseTrace,
+    ModelExchangeTraceConfig, ModelExchangeTraceSink,
+};
 pub use types::{
     resolve_request_url, AIConfig, ConnectionTestMessageCode, ConnectionTestResult, GeminiResponse,
     GeminiUsage, Message, ProxyConfig, ReasoningMode, RemoteModelInfo, ToolCall, ToolDefinition,

--- a/src/crates/adapters/ai-adapters/src/providers/anthropic/request.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/anthropic/request.rs
@@ -7,6 +7,7 @@ use crate::client::sse::execute_sse_request;
 use crate::client::{AIClient, StreamResponse};
 use crate::providers::shared;
 use crate::stream::handle_anthropic_stream;
+use crate::trace::ModelExchangeTraceConfig;
 use crate::types::ReasoningMode;
 use crate::types::{Message, ToolDefinition};
 use anyhow::Result;
@@ -318,6 +319,7 @@ pub(crate) async fn send_stream(
     tools: Option<Vec<ToolDefinition>>,
     extra_body: Option<serde_json::Value>,
     max_tries: usize,
+    trace: Option<ModelExchangeTraceConfig>,
 ) -> Result<StreamResponse> {
     let url = client.config.request_url.clone();
     debug!(
@@ -346,6 +348,7 @@ pub(crate) async fn send_stream(
         &request_body,
         max_tries,
         ttft_timeout,
+        trace,
         || apply_headers(client, client.client.post(&url), &url),
         move |response, tx, tx_raw| {
             tokio::spawn(handle_anthropic_stream(

--- a/src/crates/adapters/ai-adapters/src/providers/gemini/code_assist.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/gemini/code_assist.rs
@@ -10,6 +10,7 @@ use crate::client::sse::execute_sse_request;
 use crate::client::{AIClient, StreamResponse};
 use crate::providers::shared;
 use crate::stream::handle_gemini_stream;
+use crate::trace::ModelExchangeTraceConfig;
 use crate::types::{Message, RemoteModelInfo, ToolDefinition};
 use anyhow::{anyhow, Result};
 use log::{debug, warn};
@@ -139,6 +140,7 @@ pub(crate) async fn send_stream(
     tools: Option<Vec<ToolDefinition>>,
     extra_body: Option<serde_json::Value>,
     max_tries: usize,
+    trace: Option<ModelExchangeTraceConfig>,
 ) -> Result<StreamResponse> {
     let project = discover_project(client).await?;
 
@@ -178,6 +180,7 @@ pub(crate) async fn send_stream(
         &request_body,
         max_tries,
         ttft_timeout,
+        trace,
         || apply_headers(client, client.client.post(&url)),
         move |response, tx, tx_raw| {
             tokio::spawn(handle_gemini_stream(response, tx, tx_raw, idle_timeout));

--- a/src/crates/adapters/ai-adapters/src/providers/gemini/request.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/gemini/request.rs
@@ -3,6 +3,7 @@ use crate::client::sse::execute_sse_request;
 use crate::client::{AIClient, StreamResponse};
 use crate::providers::shared;
 use crate::stream::handle_gemini_stream;
+use crate::trace::ModelExchangeTraceConfig;
 use crate::types::ReasoningMode;
 use crate::types::{Message, ToolDefinition};
 use anyhow::Result;
@@ -316,6 +317,7 @@ pub(crate) async fn send_stream(
     tools: Option<Vec<ToolDefinition>>,
     extra_body: Option<serde_json::Value>,
     max_tries: usize,
+    trace: Option<ModelExchangeTraceConfig>,
 ) -> Result<StreamResponse> {
     let url = resolve_request_url(&client.config.request_url, &client.config.model);
     debug!(
@@ -342,6 +344,7 @@ pub(crate) async fn send_stream(
         &request_body,
         max_tries,
         ttft_timeout,
+        trace,
         || apply_headers(client, client.client.post(&url)),
         move |response, tx, tx_raw| {
             tokio::spawn(handle_gemini_stream(response, tx, tx_raw, idle_timeout));

--- a/src/crates/adapters/ai-adapters/src/providers/openai/chat.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/openai/chat.rs
@@ -4,6 +4,7 @@ use crate::client::sse::execute_sse_request;
 use crate::client::{AIClient, StreamResponse};
 use crate::providers::shared;
 use crate::stream::handle_openai_stream;
+use crate::trace::ModelExchangeTraceConfig;
 use crate::types::{Message, ToolDefinition};
 use anyhow::Result;
 use log::{debug, warn};
@@ -76,6 +77,7 @@ pub(crate) async fn send_stream(
     tools: Option<Vec<ToolDefinition>>,
     extra_body: Option<serde_json::Value>,
     max_tries: usize,
+    trace: Option<ModelExchangeTraceConfig>,
 ) -> Result<StreamResponse> {
     let url = client.config.request_url.clone();
     debug!(
@@ -96,6 +98,7 @@ pub(crate) async fn send_stream(
         &request_body,
         max_tries,
         ttft_timeout,
+        trace,
         || common::apply_headers(client, client.client.post(&url)),
         move |response, tx, tx_raw| {
             tokio::spawn(handle_openai_stream(

--- a/src/crates/adapters/ai-adapters/src/providers/openai/codex_chatgpt.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/openai/codex_chatgpt.rs
@@ -23,6 +23,7 @@ use crate::client::sse::execute_sse_request;
 use crate::client::{AIClient, StreamResponse};
 use crate::providers::shared;
 use crate::stream::handle_responses_stream;
+use crate::trace::ModelExchangeTraceConfig;
 use crate::types::{Message, ReasoningMode, ToolDefinition};
 use anyhow::Result;
 use log::debug;
@@ -145,6 +146,7 @@ pub(crate) async fn send_stream(
     tools: Option<Vec<ToolDefinition>>,
     extra_body: Option<Value>,
     max_tries: usize,
+    trace: Option<ModelExchangeTraceConfig>,
 ) -> Result<StreamResponse> {
     let url = client.config.request_url.clone();
     debug!(
@@ -166,6 +168,7 @@ pub(crate) async fn send_stream(
         &request_body,
         max_tries,
         ttft_timeout,
+        trace,
         || common::apply_headers(client, client.client.post(&url)),
         move |response, tx, tx_raw| {
             tokio::spawn(handle_responses_stream(response, tx, tx_raw, idle_timeout));

--- a/src/crates/adapters/ai-adapters/src/providers/openai/responses.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/openai/responses.rs
@@ -3,6 +3,7 @@ use crate::client::sse::execute_sse_request;
 use crate::client::{AIClient, StreamResponse};
 use crate::providers::shared;
 use crate::stream::handle_responses_stream;
+use crate::trace::ModelExchangeTraceConfig;
 use crate::types::ReasoningMode;
 use crate::types::{Message, ToolDefinition};
 use anyhow::Result;
@@ -92,6 +93,7 @@ pub(crate) async fn send_stream(
     tools: Option<Vec<ToolDefinition>>,
     extra_body: Option<serde_json::Value>,
     max_tries: usize,
+    trace: Option<ModelExchangeTraceConfig>,
 ) -> Result<StreamResponse> {
     // Codex CLI's ChatGPT-login backend (`chatgpt.com/backend-api/codex`)
     // speaks a constrained Responses dialect with several extra
@@ -99,8 +101,10 @@ pub(crate) async fn send_stream(
     // `store: false`, no `max_output_tokens`, etc.). Keep that adapter
     // self-contained so the standard Responses path stays untouched.
     if super::codex_chatgpt::is_codex_chatgpt_endpoint(&client.config.request_url) {
-        return super::codex_chatgpt::send_stream(client, messages, tools, extra_body, max_tries)
-            .await;
+        return super::codex_chatgpt::send_stream(
+            client, messages, tools, extra_body, max_tries, trace,
+        )
+        .await;
     }
 
     let url = client.config.request_url.clone();
@@ -128,6 +132,7 @@ pub(crate) async fn send_stream(
         &request_body,
         max_tries,
         ttft_timeout,
+        trace,
         || common::apply_headers(client, client.client.post(&url)),
         move |response, tx, tx_raw| {
             tokio::spawn(handle_responses_stream(response, tx, tx_raw, idle_timeout));

--- a/src/crates/adapters/ai-adapters/src/trace.rs
+++ b/src/crates/adapters/ai-adapters/src/trace.rs
@@ -1,0 +1,59 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelExchangeRequestAttempt {
+    pub request_url: String,
+    pub request_body: Value,
+    pub attempt_number: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelExchangeRequestTraceHandle {
+    pub trace_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelExchangeResponseTrace {
+    pub kind: String,
+    pub assistant_text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_metadata: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub partial_recovery_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[async_trait]
+pub trait ModelExchangeTraceSink: Send + Sync {
+    async fn request_attempt_started(
+        &self,
+        attempt: &ModelExchangeRequestAttempt,
+    ) -> Option<ModelExchangeRequestTraceHandle>;
+
+    async fn request_attempt_failed(
+        &self,
+        handle: Option<&ModelExchangeRequestTraceHandle>,
+        error: &str,
+    );
+
+    async fn request_attempt_completed(
+        &self,
+        handle: &ModelExchangeRequestTraceHandle,
+        response: &ModelExchangeResponseTrace,
+    );
+}
+
+#[derive(Clone)]
+pub struct ModelExchangeTraceConfig {
+    pub sink: Arc<dyn ModelExchangeTraceSink>,
+}

--- a/src/crates/assembly/core/src/agentic/execution/mod.rs
+++ b/src/crates/assembly/core/src/agentic/execution/mod.rs
@@ -3,6 +3,7 @@
 //! Responsible for AI interaction and model round control
 
 pub mod execution_engine;
+pub(crate) mod model_exchange_trace;
 pub mod round_executor;
 pub mod stream_processor;
 pub mod types;

--- a/src/crates/assembly/core/src/agentic/execution/model_exchange_trace.rs
+++ b/src/crates/assembly/core/src/agentic/execution/model_exchange_trace.rs
@@ -1,0 +1,352 @@
+use super::types::RoundContext;
+use crate::infrastructure::ai::AIClient;
+use crate::service::config::GlobalConfigManager;
+use crate::service::workspace_runtime::{
+    get_workspace_runtime_service_arc, WorkspaceRuntimeContext,
+};
+use async_trait::async_trait;
+use bitfun_ai_adapters::{
+    ModelExchangeRequestAttempt, ModelExchangeRequestTraceHandle, ModelExchangeResponseTrace,
+    ModelExchangeTraceConfig, ModelExchangeTraceSink,
+};
+use chrono::{DateTime, Utc};
+use dashmap::DashMap;
+use log::{debug, warn};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+const TRACE_LAYOUT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ModelExchangeTraceRecord {
+    version: u32,
+    trace_id: String,
+    sequence: u64,
+    recorded_at: DateTime<Utc>,
+    session_id: String,
+    turn_id: String,
+    round_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    response: Option<ModelExchangeResponseTrace>,
+    request: ModelExchangeTraceRequestRecord,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ModelExchangeTraceRequestRecord {
+    provider: String,
+    api_format: String,
+    model_id: String,
+    request_url: String,
+    body: Value,
+    attempt_number: usize,
+}
+
+#[derive(Debug)]
+struct WorkspaceModelExchangeTraceSink {
+    runtime_context: WorkspaceRuntimeContext,
+    session_id: String,
+    turn_id: String,
+    round_id: String,
+    provider: String,
+    api_format: String,
+    model_id: String,
+    trace_paths: DashMap<String, PathBuf>,
+}
+
+impl WorkspaceModelExchangeTraceSink {
+    fn new(
+        runtime_context: WorkspaceRuntimeContext,
+        session_id: String,
+        turn_id: String,
+        round_id: String,
+        provider: String,
+        api_format: String,
+        model_id: String,
+    ) -> Self {
+        Self {
+            runtime_context,
+            session_id,
+            turn_id,
+            round_id,
+            provider,
+            api_format,
+            model_id,
+            trace_paths: DashMap::new(),
+        }
+    }
+
+    async fn allocate_sequence(&self) -> Result<u64, String> {
+        let session_dir = self
+            .runtime_context
+            .request_trace_session_dir(&self.session_id);
+        let key = session_dir.to_string_lossy().to_string();
+        let allocator = sequence_allocators()
+            .entry(key)
+            .or_insert_with(|| Arc::new(Mutex::new(None)))
+            .clone();
+        let mut guard = allocator.lock().await;
+        let current = match *guard {
+            Some(value) => value,
+            None => {
+                let detected = detect_last_sequence(&session_dir).await?;
+                *guard = Some(detected);
+                detected
+            }
+        };
+        let next = current.saturating_add(1);
+        *guard = Some(next);
+        Ok(next)
+    }
+
+    async fn write_record(
+        &self,
+        path: &Path,
+        record: &ModelExchangeTraceRecord,
+    ) -> Result<(), String> {
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|error| format!("Failed to create trace directory: {}", error))?;
+        }
+
+        let bytes = serde_json::to_vec_pretty(record)
+            .map_err(|error| format!("Failed to serialize trace record: {}", error))?;
+        tokio::fs::write(path, bytes)
+            .await
+            .map_err(|error| format!("Failed to write trace record: {}", error))
+    }
+
+    async fn read_record(&self, path: &Path) -> Result<ModelExchangeTraceRecord, String> {
+        let bytes = tokio::fs::read(path)
+            .await
+            .map_err(|error| format!("Failed to read trace record: {}", error))?;
+        serde_json::from_slice(&bytes)
+            .map_err(|error| format!("Failed to deserialize trace record: {}", error))
+    }
+
+    async fn update_response(
+        &self,
+        trace_id: &str,
+        response: &ModelExchangeResponseTrace,
+    ) -> Result<(), String> {
+        let Some(path) = self
+            .trace_paths
+            .get(trace_id)
+            .map(|entry| entry.value().clone())
+        else {
+            return Ok(());
+        };
+
+        let mut record = self.read_record(&path).await?;
+        record.response = Some(response.clone());
+        self.write_record(&path, &record).await?;
+        self.trace_paths.remove(trace_id);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ModelExchangeTraceSink for WorkspaceModelExchangeTraceSink {
+    async fn request_attempt_started(
+        &self,
+        attempt: &ModelExchangeRequestAttempt,
+    ) -> Option<ModelExchangeRequestTraceHandle> {
+        let sequence = match self.allocate_sequence().await {
+            Ok(value) => value,
+            Err(error) => {
+                warn!(
+                    "Model exchange trace sequence allocation failed: session_id={}, error={}",
+                    self.session_id, error
+                );
+                return None;
+            }
+        };
+
+        let trace_id = Uuid::new_v4().to_string();
+        let path = self
+            .runtime_context
+            .request_trace_path(&self.session_id, sequence);
+        let record = ModelExchangeTraceRecord {
+            version: TRACE_LAYOUT_VERSION,
+            trace_id: trace_id.clone(),
+            sequence,
+            recorded_at: Utc::now(),
+            session_id: self.session_id.clone(),
+            turn_id: self.turn_id.clone(),
+            round_id: self.round_id.clone(),
+            request: ModelExchangeTraceRequestRecord {
+                provider: self.provider.clone(),
+                api_format: self.api_format.clone(),
+                model_id: self.model_id.clone(),
+                request_url: attempt.request_url.clone(),
+                body: attempt.request_body.clone(),
+                attempt_number: attempt.attempt_number,
+            },
+            response: None,
+        };
+
+        if let Err(error) = self.write_record(&path, &record).await {
+            warn!(
+                "Model exchange trace write failed: session_id={}, trace_id={}, error={}",
+                self.session_id, trace_id, error
+            );
+            return None;
+        }
+
+        self.trace_paths.insert(trace_id.clone(), path);
+        Some(ModelExchangeRequestTraceHandle { trace_id })
+    }
+
+    async fn request_attempt_failed(
+        &self,
+        handle: Option<&ModelExchangeRequestTraceHandle>,
+        error: &str,
+    ) {
+        let Some(handle) = handle else {
+            return;
+        };
+
+        if let Err(write_error) = self
+            .update_response(
+                &handle.trace_id,
+                &ModelExchangeResponseTrace {
+                    kind: "error".to_string(),
+                    assistant_text: String::new(),
+                    thinking: None,
+                    tool_calls: None,
+                    usage: None,
+                    provider_metadata: None,
+                    partial_recovery_reason: None,
+                    error: Some(error.to_string()),
+                },
+            )
+            .await
+        {
+            warn!(
+                "Model exchange trace failure update failed: session_id={}, trace_id={}, error={}",
+                self.session_id, handle.trace_id, write_error
+            );
+        }
+    }
+
+    async fn request_attempt_completed(
+        &self,
+        handle: &ModelExchangeRequestTraceHandle,
+        response: &ModelExchangeResponseTrace,
+    ) {
+        if let Err(error) = self.update_response(&handle.trace_id, response).await {
+            warn!(
+                "Model exchange trace completion update failed: session_id={}, trace_id={}, error={}",
+                self.session_id, handle.trace_id, error
+            );
+        }
+    }
+}
+
+pub async fn prepare_model_exchange_trace(
+    context: &RoundContext,
+    round_id: &str,
+    ai_client: &AIClient,
+) -> Option<ModelExchangeTraceConfig> {
+    if !model_exchange_trace_enabled().await {
+        return None;
+    }
+
+    let Some(workspace) = context.workspace.as_ref() else {
+        debug!(
+            "Model exchange trace skipped because round has no workspace: session_id={}, turn_id={}",
+            context.session_id, context.dialog_turn_id
+        );
+        return None;
+    };
+
+    let runtime_context = match get_workspace_runtime_service_arc()
+        .ensure_runtime_for_workspace_binding(workspace)
+        .await
+    {
+        Ok(result) => result.context,
+        Err(error) => {
+            warn!(
+                "Model exchange trace skipped because runtime init failed: session_id={}, error={}",
+                context.session_id, error
+            );
+            return None;
+        }
+    };
+
+    Some(ModelExchangeTraceConfig {
+        sink: Arc::new(WorkspaceModelExchangeTraceSink::new(
+            runtime_context,
+            context.session_id.clone(),
+            context.dialog_turn_id.clone(),
+            round_id.to_string(),
+            ai_client.config.format.clone(),
+            ai_client.config.format.clone(),
+            ai_client.config.model.clone(),
+        )),
+    })
+}
+
+async fn model_exchange_trace_enabled() -> bool {
+    let Ok(config_service) = GlobalConfigManager::get_service().await else {
+        return false;
+    };
+
+    config_service
+        .get_config(Some("app.logging.model_exchange_trace"))
+        .await
+        .unwrap_or(false)
+}
+
+async fn detect_last_sequence(session_dir: &Path) -> Result<u64, String> {
+    let mut last_sequence = 0u64;
+    let mut entries = match tokio::fs::read_dir(session_dir).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => {
+            return Err(format!(
+                "Failed to inspect trace session directory '{}': {}",
+                session_dir.display(),
+                error
+            ));
+        }
+    };
+
+    loop {
+        let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|error| format!("Failed to iterate trace session directory: {}", error))?
+        else {
+            break;
+        };
+
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+        let Some(sequence) = parse_trace_sequence(file_name) else {
+            continue;
+        };
+        last_sequence = last_sequence.max(sequence);
+    }
+
+    Ok(last_sequence)
+}
+
+fn parse_trace_sequence(file_name: &str) -> Option<u64> {
+    file_name
+        .strip_prefix("request-")?
+        .strip_suffix(".json")?
+        .parse::<u64>()
+        .ok()
+}
+
+fn sequence_allocators() -> &'static DashMap<String, Arc<Mutex<Option<u64>>>> {
+    static ALLOCATORS: OnceLock<DashMap<String, Arc<Mutex<Option<u64>>>>> = OnceLock::new();
+    ALLOCATORS.get_or_init(DashMap::new)
+}

--- a/src/crates/assembly/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/assembly/core/src/agentic/execution/round_executor.rs
@@ -2,6 +2,7 @@
 //!
 //! Executes a single model round: calls AI, processes streaming responses, executes tools
 
+use super::model_exchange_trace::prepare_model_exchange_trace;
 use super::stream_processor::{StreamProcessOptions, StreamProcessor, StreamResult};
 use super::types::{FinishReason, RoundContext, RoundResult};
 use crate::agentic::core::{Message, ToolCall};
@@ -18,6 +19,9 @@ use crate::util::elapsed_ms_u64;
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::types::Message as AIMessage;
 use crate::util::types::ToolDefinition;
+use bitfun_ai_adapters::{
+    ModelExchangeRequestTraceHandle, ModelExchangeResponseTrace, ModelExchangeTraceConfig,
+};
 use dashmap::DashMap;
 use log::{debug, error, warn};
 use std::sync::Arc;
@@ -102,9 +106,11 @@ impl RoundExecutor {
         )
         .await;
 
+        let trace_config =
+            prepare_model_exchange_trace(&context, &round_id, ai_client.as_ref()).await;
         let max_attempts = Self::MAX_STREAM_ATTEMPTS;
         let mut attempt_index = 0usize;
-        let (stream_result, send_to_stream_ms, stream_processing_ms) = loop {
+        let (stream_result, send_to_stream_ms, stream_processing_ms, final_trace_handle) = loop {
             // Check cancellation before opening a model stream. This catches
             // early cancellation registered before the first round starts.
             if cancel_token.is_cancelled() {
@@ -127,7 +133,11 @@ impl RoundExecutor {
 
             // Use dynamically obtained client for call
             let (stream_response, send_to_stream_ms) = match ai_client
-                .send_message_stream(ai_messages.clone(), tool_definitions.clone())
+                .send_message_stream(
+                    ai_messages.clone(),
+                    tool_definitions.clone(),
+                    trace_config.clone(),
+                )
                 .await
             {
                 Ok(response) => {
@@ -175,9 +185,16 @@ impl RoundExecutor {
             // Destructure StreamResponse: get stream and raw SSE data receiver
             let ai_stream = stream_response.stream;
             let raw_sse_rx = stream_response.raw_sse_rx;
+            let trace_handle = stream_response.trace_handle;
 
             // Check cancellation token before calling stream processing.
             if cancel_token.is_cancelled() {
+                Self::complete_model_exchange_trace(
+                    trace_config.as_ref(),
+                    trace_handle.as_ref(),
+                    Self::error_trace_response("cancelled", "Execution cancelled".to_string()),
+                )
+                .await;
                 debug!(
                     "Cancel token detected after AI stream opened, stopping execution: session_id={}",
                     context.session_id
@@ -222,6 +239,12 @@ impl RoundExecutor {
                             && attempt_index < max_attempts - 1
                             && Self::is_transient_network_error(&err_msg)
                         {
+                            Self::complete_model_exchange_trace(
+                                trace_config.as_ref(),
+                                trace_handle.as_ref(),
+                                Self::trace_response_from_stream_result("partial", &result),
+                            )
+                            .await;
                             let delay_ms = Self::retry_delay_ms(attempt_index);
                             warn!(
                                 "Retrying stream because tool arguments were interrupted before valid JSON completed: session_id={}, round_id={}, attempt={}/{}, delay_ms={}, invalid_tool_calls={}, error={}",
@@ -265,7 +288,12 @@ impl RoundExecutor {
                             recovered
                                 .tool_calls
                                 .retain(|tool_call| tool_call.is_valid());
-                            break (recovered, send_to_stream_ms, stream_processing_ms);
+                            break (
+                                recovered,
+                                send_to_stream_ms,
+                                stream_processing_ms,
+                                trace_handle,
+                            );
                         }
 
                         self.emit_failed_partial_tool_calls(
@@ -273,6 +301,16 @@ impl RoundExecutor {
                             &round_id,
                             &result.tool_calls,
                             &err_msg,
+                        )
+                        .await;
+                        Self::complete_model_exchange_trace(
+                            trace_config.as_ref(),
+                            trace_handle.as_ref(),
+                            Self::error_trace_response_from_stream_result(
+                                "error",
+                                err_msg.clone(),
+                                &result,
+                            ),
                         )
                         .await;
                         return Err(BitFunError::AIClient(format!(
@@ -292,6 +330,12 @@ impl RoundExecutor {
                         && Self::is_transient_network_error(partial_recovery_reason)
                         && attempt_index < max_attempts - 1
                     {
+                        Self::complete_model_exchange_trace(
+                            trace_config.as_ref(),
+                            trace_handle.as_ref(),
+                            Self::trace_response_from_stream_result("partial", &result),
+                        )
+                        .await;
                         let delay_ms = Self::retry_delay_ms(attempt_index);
                         warn!(
                             "Retrying stream because tool calls arrived on an interrupted network stream without assistant text: session_id={}, round_id={}, attempt={}/{}, delay_ms={}, tool_calls={}, reason={}",
@@ -309,7 +353,18 @@ impl RoundExecutor {
                     }
 
                     if Self::is_invalid_tool_only_without_text(&result) {
+                        let err_msg = "Provider returned only invalid tool arguments".to_string();
                         if attempt_index < max_attempts - 1 {
+                            Self::complete_model_exchange_trace(
+                                trace_config.as_ref(),
+                                trace_handle.as_ref(),
+                                Self::error_trace_response_from_stream_result(
+                                    "error",
+                                    err_msg.clone(),
+                                    &result,
+                                ),
+                            )
+                            .await;
                             let delay_ms = Self::retry_delay_ms(attempt_index);
                             warn!(
                                 "Retrying stream because provider returned only invalid tool arguments: session_id={}, round_id={}, attempt={}/{}, delay_ms={}, tool_calls={}",
@@ -325,12 +380,21 @@ impl RoundExecutor {
                             continue;
                         }
 
-                        let err_msg = "Provider returned only invalid tool arguments";
                         self.emit_failed_partial_tool_calls(
                             &context,
                             &round_id,
                             &result.tool_calls,
-                            err_msg,
+                            &err_msg,
+                        )
+                        .await;
+                        Self::complete_model_exchange_trace(
+                            trace_config.as_ref(),
+                            trace_handle.as_ref(),
+                            Self::error_trace_response_from_stream_result(
+                                "error",
+                                err_msg.clone(),
+                                &result,
+                            ),
                         )
                         .await;
                         return Err(BitFunError::AIClient(format!(
@@ -340,6 +404,15 @@ impl RoundExecutor {
                     }
 
                     if no_effective_output && attempt_index < max_attempts - 1 {
+                        Self::complete_model_exchange_trace(
+                            trace_config.as_ref(),
+                            trace_handle.as_ref(),
+                            Self::error_trace_response(
+                                "error",
+                                "No effective output received".to_string(),
+                            ),
+                        )
+                        .await;
                         let delay_ms = Self::retry_delay_ms(attempt_index);
                         warn!(
                             "Retrying stream because no effective output was received: session_id={}, round_id={}, attempt={}/{}, delay_ms={}",
@@ -368,13 +441,24 @@ impl RoundExecutor {
                         );
                     }
 
-                    break (result, send_to_stream_ms, stream_processing_ms);
+                    break (
+                        result,
+                        send_to_stream_ms,
+                        stream_processing_ms,
+                        trace_handle,
+                    );
                 }
                 Err(stream_err) => {
                     let err_msg = stream_err.error.to_string();
                     let can_retry = !stream_err.has_effective_output
                         && attempt_index < max_attempts - 1
                         && Self::is_transient_network_error(&err_msg);
+                    Self::complete_model_exchange_trace(
+                        trace_config.as_ref(),
+                        trace_handle.as_ref(),
+                        Self::error_trace_response("error", err_msg.clone()),
+                    )
+                    .await;
                     if can_retry {
                         let delay_ms = Self::retry_delay_ms(attempt_index);
                         warn!(
@@ -400,6 +484,13 @@ impl RoundExecutor {
                 }
             }
         };
+
+        Self::complete_model_exchange_trace(
+            trace_config.as_ref(),
+            final_trace_handle.as_ref(),
+            Self::final_trace_response(&stream_result),
+        )
+        .await;
 
         // Model returned successfully (output to AI log file)
         if let Some(ref reason) = stream_result.partial_recovery_reason {
@@ -890,6 +981,97 @@ impl RoundExecutor {
         }
     }
 
+    async fn complete_model_exchange_trace(
+        trace_config: Option<&ModelExchangeTraceConfig>,
+        trace_handle: Option<&ModelExchangeRequestTraceHandle>,
+        response: ModelExchangeResponseTrace,
+    ) {
+        let (Some(trace_config), Some(trace_handle)) = (trace_config, trace_handle) else {
+            return;
+        };
+
+        trace_config
+            .sink
+            .request_attempt_completed(trace_handle, &response)
+            .await;
+    }
+
+    fn final_trace_response(result: &StreamResult) -> ModelExchangeResponseTrace {
+        let kind = if result.partial_recovery_reason.is_some() {
+            "partial"
+        } else {
+            "completed"
+        };
+        Self::trace_response(kind, Some(result), None)
+    }
+
+    fn trace_response_from_stream_result(
+        kind: &str,
+        result: &StreamResult,
+    ) -> ModelExchangeResponseTrace {
+        Self::trace_response(kind, Some(result), None)
+    }
+
+    fn error_trace_response_from_stream_result(
+        kind: &str,
+        error: String,
+        result: &StreamResult,
+    ) -> ModelExchangeResponseTrace {
+        Self::trace_response(kind, Some(result), Some(error))
+    }
+
+    fn error_trace_response(kind: &str, error: String) -> ModelExchangeResponseTrace {
+        Self::trace_response(kind, None, Some(error))
+    }
+
+    fn trace_response(
+        kind: &str,
+        result: Option<&StreamResult>,
+        error: Option<String>,
+    ) -> ModelExchangeResponseTrace {
+        let (
+            assistant_text,
+            thinking,
+            tool_calls,
+            usage,
+            provider_metadata,
+            partial_recovery_reason,
+        ) = if let Some(result) = result {
+            (
+                result.full_text.clone(),
+                Self::stream_result_reasoning(result),
+                serde_json::to_value(&result.tool_calls).ok(),
+                result
+                    .usage
+                    .as_ref()
+                    .and_then(|usage| serde_json::to_value(usage).ok()),
+                result.provider_metadata.clone(),
+                result.partial_recovery_reason.clone(),
+            )
+        } else {
+            (String::new(), None, None, None, None, None)
+        };
+
+        ModelExchangeResponseTrace {
+            kind: kind.to_string(),
+            assistant_text,
+            thinking,
+            tool_calls,
+            usage,
+            provider_metadata,
+            partial_recovery_reason,
+            error,
+        }
+    }
+
+    fn stream_result_reasoning(result: &StreamResult) -> Option<String> {
+        if result.full_thinking.is_empty() {
+            result.reasoning_content_present.then(String::new)
+        } else {
+            Some(result.full_thinking.clone())
+        }
+    }
+
     fn has_interrupted_invalid_tool_calls(result: &StreamResult) -> bool {
         result.partial_recovery_reason.is_some()
             && !result.tool_calls.is_empty()
@@ -1030,12 +1212,15 @@ fn token_details_from_usage(
 #[cfg(test)]
 mod tests {
     use super::{RoundExecutor, StreamProcessor};
-    use crate::agentic::execution::types::RoundContext;
+    use crate::agentic::core::ToolCall;
     use crate::agentic::events::{EventQueue, EventQueueConfig};
+    use crate::agentic::execution::stream_processor::StreamResult;
+    use crate::agentic::execution::types::RoundContext;
     use crate::agentic::tools::ToolRuntimeRestrictions;
     use crate::util::types::ai::GeminiUsage;
     use bitfun_runtime_ports::DelegationPolicy;
     use dashmap::DashMap;
+    use serde_json::json;
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio_util::sync::CancellationToken;
@@ -1198,5 +1383,92 @@ mod tests {
             cache_creation_token_count: None,
         };
         assert!(super::token_details_from_usage(&usage).is_none());
+    }
+
+    #[test]
+    fn error_trace_response_from_stream_result_preserves_structured_context() {
+        let stream_result = StreamResult {
+            full_thinking: "reasoning".to_string(),
+            reasoning_content_present: true,
+            thinking_signature: Some("sig".to_string()),
+            full_text: String::new(),
+            tool_calls: vec![ToolCall {
+                tool_id: "tool-1".to_string(),
+                tool_name: "Bash".to_string(),
+                arguments: json!({}),
+                raw_arguments: Some("{\"command\":".to_string()),
+                is_error: true,
+                recovered_from_truncation: false,
+            }],
+            usage: Some(GeminiUsage {
+                prompt_token_count: 100,
+                candidates_token_count: 20,
+                total_token_count: 120,
+                reasoning_token_count: Some(5),
+                cached_content_token_count: Some(30),
+                cache_creation_token_count: None,
+            }),
+            provider_metadata: Some(json!({ "finish_reason": "tool_calls" })),
+            has_effective_output: false,
+            first_chunk_ms: Some(10),
+            first_visible_output_ms: None,
+            partial_recovery_reason: Some("tool arguments invalid".to_string()),
+        };
+
+        let trace = RoundExecutor::error_trace_response_from_stream_result(
+            "error",
+            "Provider returned only invalid tool arguments".to_string(),
+            &stream_result,
+        );
+
+        assert_eq!(trace.kind, "error");
+        assert_eq!(
+            trace.error.as_deref(),
+            Some("Provider returned only invalid tool arguments")
+        );
+        assert_eq!(trace.assistant_text, "");
+        assert_eq!(trace.thinking.as_deref(), Some("reasoning"));
+        assert_eq!(
+            trace.partial_recovery_reason.as_deref(),
+            Some("tool arguments invalid")
+        );
+        assert_eq!(
+            trace.provider_metadata,
+            Some(json!({ "finish_reason": "tool_calls" }))
+        );
+        assert_eq!(
+            trace.usage,
+            Some(json!({
+                "promptTokenCount": 100,
+                "candidatesTokenCount": 20,
+                "totalTokenCount": 120,
+                "reasoningTokenCount": 5,
+                "cachedContentTokenCount": 30
+            }))
+        );
+        assert_eq!(
+            trace.tool_calls,
+            Some(json!([{
+                "tool_id": "tool-1",
+                "tool_name": "Bash",
+                "arguments": {},
+                "raw_arguments": "{\"command\":",
+                "is_error": true
+            }]))
+        );
+    }
+
+    #[test]
+    fn error_trace_response_without_stream_result_stays_empty() {
+        let trace = RoundExecutor::error_trace_response("error", "request failed".to_string());
+
+        assert_eq!(trace.kind, "error");
+        assert_eq!(trace.assistant_text, "");
+        assert!(trace.thinking.is_none());
+        assert!(trace.tool_calls.is_none());
+        assert!(trace.usage.is_none());
+        assert!(trace.provider_metadata.is_none());
+        assert!(trace.partial_recovery_reason.is_none());
+        assert_eq!(trace.error.as_deref(), Some("request failed"));
     }
 }

--- a/src/crates/assembly/core/src/service/config/types.rs
+++ b/src/crates/assembly/core/src/service/config/types.rs
@@ -134,6 +134,9 @@ pub struct AppLoggingConfig {
     /// Whether diagnostic logs may include sensitive troubleshooting payloads.
     #[serde(default = "default_true")]
     pub include_sensitive_diagnostics: bool,
+    /// Whether to persist per-request AI model exchange traces for developer diagnostics.
+    #[serde(default)]
+    pub model_exchange_trace: bool,
 }
 
 /// Session-related UI preferences.
@@ -1341,6 +1344,7 @@ impl Default for AppLoggingConfig {
             // Set to Debug in early development for easier diagnostics
             level: "debug".to_string(),
             include_sensitive_diagnostics: true,
+            model_exchange_trace: false,
         }
     }
 }
@@ -2068,6 +2072,7 @@ mod tests {
         .expect("logging config without sensitive preference should deserialize");
 
         assert!(config.include_sensitive_diagnostics);
+        assert!(!config.model_exchange_trace);
     }
 
     #[test]

--- a/src/crates/assembly/core/src/service/workspace_runtime/service.rs
+++ b/src/crates/assembly/core/src/service/workspace_runtime/service.rs
@@ -945,6 +945,7 @@ mod tests {
         let context = ensured.context;
         assert!(context.runtime_root.exists());
         assert!(context.sessions_dir.exists());
+        assert!(context.request_traces_dir.exists());
         assert!(context.snapshot_by_hash_dir.exists());
         assert!(context.snapshot_metadata_dir.exists());
         assert!(context.snapshot_baselines_dir.exists());

--- a/src/crates/assembly/core/src/service/workspace_runtime/types.rs
+++ b/src/crates/assembly/core/src/service/workspace_runtime/types.rs
@@ -28,6 +28,7 @@ pub struct WorkspaceRuntimeContext {
     pub target: WorkspaceRuntimeTarget,
     pub runtime_root: PathBuf,
     pub sessions_dir: PathBuf,
+    pub request_traces_dir: PathBuf,
     pub snapshots_dir: PathBuf,
     pub snapshot_by_hash_dir: PathBuf,
     pub snapshot_metadata_dir: PathBuf,
@@ -49,6 +50,7 @@ impl WorkspaceRuntimeContext {
         Self {
             target,
             sessions_dir: runtime_root.join("sessions"),
+            request_traces_dir: runtime_root.join("request-traces"),
             snapshot_by_hash_dir: snapshots_dir.join("by_hash"),
             snapshot_metadata_dir: snapshots_dir.join("metadata"),
             snapshot_baselines_dir: snapshots_dir.join("baselines"),
@@ -68,6 +70,7 @@ impl WorkspaceRuntimeContext {
         vec![
             self.runtime_root.as_path(),
             self.sessions_dir.as_path(),
+            self.request_traces_dir.as_path(),
             self.snapshots_dir.as_path(),
             self.snapshot_by_hash_dir.as_path(),
             self.snapshot_metadata_dir.as_path(),
@@ -90,6 +93,15 @@ impl WorkspaceRuntimeContext {
 
     pub fn session_tool_result_path(&self, session_id: &str, file_name: &str) -> PathBuf {
         self.session_tool_results_dir(session_id).join(file_name)
+    }
+
+    pub fn request_trace_session_dir(&self, session_id: &str) -> PathBuf {
+        self.request_traces_dir.join(session_id)
+    }
+
+    pub fn request_trace_path(&self, session_id: &str, sequence: u64) -> PathBuf {
+        self.request_trace_session_dir(session_id)
+            .join(format!("request-{:06}.json", sequence))
     }
 }
 

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -32,6 +32,7 @@ export type BackendLogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'o
 export interface AppLoggingConfig {
   level: BackendLogLevel;
   include_sensitive_diagnostics: boolean;
+  model_exchange_trace: boolean;
 }
 
 // Reserved; legacy `default_mode` in saved JSON is ignored by the app.


### PR DESCRIPTION
- add trace contracts and sink support to AI streaming clients across providers
- persist per-attempt request and response traces in workspace runtime for diagnostics
- capture partial, error, and recovered stream outcomes in round execution flow
- expose app.logging.model_exchange_trace in Rust and Web UI config types with test coverage
