### PR TITLE
fix(agentic): keep shared coding-mode cache stable across mode switches

### DIFF
--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/agentic.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/agentic.rs
@@ -1,10 +1,16 @@
 //! Agentic Mode
+//!
+//! Shared coding modes inherit the agentic baseline for
+//! `SHARED_CODING_MODE_PROMPT_TEMPLATE`, `shared_coding_mode_tools()`,
+//! `shared_coding_mode_tool_exposure_overrides()`, and
+//! `shared_coding_mode_user_context_policy()`. Across the four coding modes,
+//! only the reminder content differs.
 
 use crate::agentic::agents::{
-    get_embedded_prompt, shared_coding_mode_tools, shared_coding_mode_user_context_policy, Agent,
-    AgentToolPolicyOverrides, UserContextPolicy, SHARED_CODING_MODE_PROMPT_TEMPLATE,
+    get_embedded_prompt, shared_coding_mode_tool_exposure_overrides, shared_coding_mode_tools,
+    shared_coding_mode_user_context_policy, Agent, AgentToolPolicyOverrides, UserContextPolicy,
+    SHARED_CODING_MODE_PROMPT_TEMPLATE,
 };
-use crate::agentic::tools::framework::ToolExposure;
 use async_trait::async_trait;
 
 const AGENTIC_MODE_FIRST_ENTRY_REMINDER_TEMPLATE: &str = "agentic_mode_first_entry_reminder";
@@ -22,15 +28,9 @@ impl Default for AgenticMode {
 
 impl AgenticMode {
     pub fn new() -> Self {
-        // Web research is a baseline capability of the full agent mode; keep
-        // WebSearch/WebFetch expanded so models never have to go through the
-        // GetToolSpec unlock round-trip for them.
-        let mut tool_exposure_overrides = AgentToolPolicyOverrides::default();
-        tool_exposure_overrides.insert("WebSearch".to_string(), ToolExposure::Expanded);
-        tool_exposure_overrides.insert("WebFetch".to_string(), ToolExposure::Expanded);
         Self {
             default_tools: shared_coding_mode_tools(),
-            tool_exposure_overrides,
+            tool_exposure_overrides: shared_coding_mode_tool_exposure_overrides(),
         }
     }
 

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/debug.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/debug.rs
@@ -1,8 +1,15 @@
-//! Debug Mode - Evidence-driven debugging mode
+//! Debug Mode
+//!
+//! Shared coding modes inherit the agentic baseline for
+//! `SHARED_CODING_MODE_PROMPT_TEMPLATE`, `shared_coding_mode_tools()`,
+//! `shared_coding_mode_tool_exposure_overrides()`, and
+//! `shared_coding_mode_user_context_policy()`. Across the four coding modes,
+//! only the reminder content differs.
 
 use crate::agentic::agents::{
-    get_embedded_prompt, shared_coding_mode_tools, shared_coding_mode_user_context_policy, Agent,
-    UserContextPolicy, SHARED_CODING_MODE_PROMPT_TEMPLATE,
+    get_embedded_prompt, shared_coding_mode_tool_exposure_overrides, shared_coding_mode_tools,
+    shared_coding_mode_user_context_policy, Agent, AgentToolPolicyOverrides, UserContextPolicy,
+    SHARED_CODING_MODE_PROMPT_TEMPLATE,
 };
 use crate::service::config::global::GlobalConfigManager;
 use crate::service::config::types::{DebugModeConfig, LanguageDebugTemplate};
@@ -12,7 +19,10 @@ use async_trait::async_trait;
 use log::debug;
 use std::path::Path;
 
-pub struct DebugMode;
+pub struct DebugMode {
+    default_tools: Vec<String>,
+    tool_exposure_overrides: AgentToolPolicyOverrides,
+}
 
 const DEBUG_MODE_FIRST_ENTRY_REMINDER_TEMPLATE: &str = "debug_mode_first_entry_reminder";
 const DEBUG_MODE_ONGOING_REMINDER_TEMPLATE: &str = "debug_mode_ongoing_reminder";
@@ -25,7 +35,10 @@ impl Default for DebugMode {
 
 impl DebugMode {
     pub fn new() -> Self {
-        Self
+        Self {
+            default_tools: shared_coding_mode_tools(),
+            tool_exposure_overrides: shared_coding_mode_tool_exposure_overrides(),
+        }
     }
 
     async fn get_debug_config(&self) -> DebugModeConfig {
@@ -328,6 +341,10 @@ impl Agent for DebugMode {
         shared_coding_mode_user_context_policy()
     }
 
+    fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {
+        &self.tool_exposure_overrides
+    }
+
     async fn get_system_reminder(
         &self,
         previous_agent_type: Option<&str>,
@@ -352,7 +369,7 @@ impl Agent for DebugMode {
     }
 
     fn default_tools(&self) -> Vec<String> {
-        shared_coding_mode_tools()
+        self.default_tools.clone()
     }
 
     fn is_readonly(&self) -> bool {

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/multitask.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/multitask.rs
@@ -1,13 +1,21 @@
 //! Multitask Mode
+//!
+//! Shared coding modes inherit the agentic baseline for
+//! `SHARED_CODING_MODE_PROMPT_TEMPLATE`, `shared_coding_mode_tools()`,
+//! `shared_coding_mode_tool_exposure_overrides()`, and
+//! `shared_coding_mode_user_context_policy()`. Across the four coding modes,
+//! only the reminder content differs.
 
 use crate::agentic::agents::{
-    get_embedded_prompt, shared_coding_mode_tools, shared_coding_mode_user_context_policy, Agent,
-    UserContextPolicy, SHARED_CODING_MODE_PROMPT_TEMPLATE,
+    get_embedded_prompt, shared_coding_mode_tool_exposure_overrides, shared_coding_mode_tools,
+    shared_coding_mode_user_context_policy, Agent, AgentToolPolicyOverrides, UserContextPolicy,
+    SHARED_CODING_MODE_PROMPT_TEMPLATE,
 };
 use async_trait::async_trait;
 
 pub struct MultitaskMode {
     default_tools: Vec<String>,
+    tool_exposure_overrides: AgentToolPolicyOverrides,
 }
 
 const MULTITASK_MODE_FIRST_ENTRY_REMINDER_TEMPLATE: &str = "multitask_mode_first_entry_reminder";
@@ -23,6 +31,7 @@ impl MultitaskMode {
     pub fn new() -> Self {
         Self {
             default_tools: shared_coding_mode_tools(),
+            tool_exposure_overrides: shared_coding_mode_tool_exposure_overrides(),
         }
     }
 
@@ -65,6 +74,10 @@ impl Agent for MultitaskMode {
 
     fn user_context_policy(&self) -> UserContextPolicy {
         shared_coding_mode_user_context_policy()
+    }
+
+    fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {
+        &self.tool_exposure_overrides
     }
 
     async fn get_system_reminder(

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/plan.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/plan.rs
@@ -1,13 +1,21 @@
 //! Plan Mode
+//!
+//! Shared coding modes inherit the agentic baseline for
+//! `SHARED_CODING_MODE_PROMPT_TEMPLATE`, `shared_coding_mode_tools()`,
+//! `shared_coding_mode_tool_exposure_overrides()`, and
+//! `shared_coding_mode_user_context_policy()`. Across the four coding modes,
+//! only the reminder content differs.
 
 use crate::agentic::agents::{
-    get_embedded_prompt, shared_coding_mode_tools, shared_coding_mode_user_context_policy, Agent,
-    UserContextPolicy, SHARED_CODING_MODE_PROMPT_TEMPLATE,
+    get_embedded_prompt, shared_coding_mode_tool_exposure_overrides, shared_coding_mode_tools,
+    shared_coding_mode_user_context_policy, Agent, AgentToolPolicyOverrides, UserContextPolicy,
+    SHARED_CODING_MODE_PROMPT_TEMPLATE,
 };
 use async_trait::async_trait;
 
 pub struct PlanMode {
     default_tools: Vec<String>,
+    tool_exposure_overrides: AgentToolPolicyOverrides,
 }
 
 const PLAN_MODE_FIRST_ENTRY_REMINDER_TEMPLATE: &str = "plan_mode_first_entry_reminder";
@@ -23,6 +31,7 @@ impl PlanMode {
     pub fn new() -> Self {
         Self {
             default_tools: shared_coding_mode_tools(),
+            tool_exposure_overrides: shared_coding_mode_tool_exposure_overrides(),
         }
     }
 
@@ -71,6 +80,10 @@ impl Agent for PlanMode {
         shared_coding_mode_user_context_policy()
     }
 
+    fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {
+        &self.tool_exposure_overrides
+    }
+
     async fn get_system_reminder(
         &self,
         previous_agent_type: Option<&str>,
@@ -84,7 +97,6 @@ impl Agent for PlanMode {
     }
 
     fn is_readonly(&self) -> bool {
-        // only modify plan file, not modify project code
-        true
+        false
     }
 }

--- a/src/crates/assembly/core/src/agentic/agents/mod.rs
+++ b/src/crates/assembly/core/src/agentic/agents/mod.rs
@@ -62,6 +62,16 @@ pub type AgentToolPolicyOverrides = IndexMap<String, ToolExposure>;
 static EMPTY_AGENT_TOOL_POLICY_OVERRIDES: std::sync::LazyLock<AgentToolPolicyOverrides> =
     std::sync::LazyLock::new(AgentToolPolicyOverrides::default);
 
+pub fn shared_coding_mode_tool_exposure_overrides() -> AgentToolPolicyOverrides {
+    // Web research is a baseline capability of the shared coding modes; keep
+    // WebSearch/WebFetch expanded so models do not need a GetToolSpec
+    // unlock round-trip when switching between those modes.
+    let mut overrides = AgentToolPolicyOverrides::default();
+    overrides.insert("WebSearch".to_string(), ToolExposure::Expanded);
+    overrides.insert("WebFetch".to_string(), ToolExposure::Expanded);
+    overrides
+}
+
 pub fn shared_coding_mode_tools() -> Vec<String> {
     vec![
         "Task".to_string(),
@@ -202,9 +212,11 @@ pub trait Agent: Send + Sync + 'static {
 #[cfg(test)]
 mod tests {
     use super::{
-        shared_coding_mode_tools, shared_coding_mode_user_context_policy, Agent, AgenticMode,
-        DebugMode, MultitaskMode, PlanMode,
+        shared_coding_mode_tool_exposure_overrides, shared_coding_mode_tools,
+        shared_coding_mode_user_context_policy, Agent, AgenticMode, DebugMode, MultitaskMode,
+        PlanMode,
     };
+    use crate::agentic::tools::framework::ToolExposure;
 
     #[test]
     fn shared_template_modes_share_system_prompt_cache_identity() {
@@ -257,5 +269,19 @@ mod tests {
         assert_eq!(MultitaskMode::new().user_context_policy(), shared_policy);
         assert_eq!(PlanMode::new().user_context_policy(), shared_policy);
         assert_eq!(DebugMode::new().user_context_policy(), shared_policy);
+    }
+
+    #[test]
+    fn shared_coding_mode_tool_exposure_overrides_match_all_shared_modes() {
+        let shared_overrides = shared_coding_mode_tool_exposure_overrides();
+        let agentic = AgenticMode::new();
+        let multitask = MultitaskMode::new();
+        let plan = PlanMode::new();
+        let debug = DebugMode::new();
+
+        assert_eq!(agentic.tool_exposure_overrides(), &shared_overrides);
+        assert_eq!(multitask.tool_exposure_overrides(), &shared_overrides);
+        assert_eq!(plan.tool_exposure_overrides(), &shared_overrides);
+        assert_eq!(debug.tool_exposure_overrides(), &shared_overrides);
     }
 }

--- a/src/crates/assembly/core/src/agentic/agents/registry/query.rs
+++ b/src/crates/assembly/core/src/agentic/agents/registry/query.rs
@@ -50,11 +50,9 @@ impl AgentRegistry {
                 let registered_tool_names = get_all_registered_tool_names().await;
                 let valid_tools: HashSet<String> = registered_tool_names.iter().cloned().collect();
                 let profile_id = resolve_mode_config_profile_id(agent_type);
-                let resolved_tools = resolve_effective_tools(
-                    &entry.agent.default_tools(),
-                    mode_configs.get(profile_id.as_ref()),
-                    &valid_tools,
-                );
+                let default_tools = entry.agent.default_tools();
+                let config = mode_configs.get(profile_id.as_ref());
+                let resolved_tools = resolve_effective_tools(&default_tools, config, &valid_tools);
                 let allowed_tools = merge_dynamic_mcp_tools(resolved_tools, &registered_tool_names);
                 let allowed_tool_set: HashSet<&str> =
                     allowed_tools.iter().map(String::as_str).collect();


### PR DESCRIPTION
05be491 introduced this regression by expanding WebSearch/WebFetch only in
Agentic while Plan/Debug/Multitask still shared the same coding-mode prompt
cache identity. That made mode switches invalidate the shared request prefix in
practice because the tool manifest drifted even though these modes were intended
to share the same system prompt, tools, and user context baseline.

Extract shared_coding_mode_tool_exposure_overrides() and reuse it across
Agentic, Plan, Debug, and Multitask so the shared coding-mode baseline stays
consistent.
Align Plan readonly with the other coding modes so only reminder content differs.
Add focused tests to lock shared tool exposure overrides and writable behavior.
