### PR TITLE
feat(web-ui): track background subagents with activity store

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -40,7 +40,11 @@ import {
   deriveSessionReviewActivity,
   isReviewActivityBlocking,
 } from '@/flow_chat/utils/sessionReviewActivity';
-import { buildBackgroundSubagentActivityIndex } from '@/flow_chat/utils/backgroundSubagentActivity';
+import { useBackgroundSubagentActivityStore } from '@/flow_chat/store/backgroundSubagentActivityStore';
+import type {
+  BackgroundSubagentActivity,
+  BackgroundSubagentActivityItem,
+} from '@/flow_chat/utils/backgroundSubagentActivity';
 import { computeFixedPopoverPosition } from '@/shared/utils/fixedPopoverViewport';
 import { sessionAPI } from '@/infrastructure/api/service-api/SessionAPI';
 import { confirmWarning } from '@/component-library/components/ConfirmDialog/confirmService';
@@ -170,6 +174,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   const [flowChatState, setFlowChatState] = useState<FlowChatState>(() =>
     flowChatStore.getState()
   );
+  const backgroundSubagentActivities = useBackgroundSubagentActivityStore(state => state.activities);
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
   const [expandLevel, setExpandLevel] = useState<0 | 1 | 2>(0);
@@ -240,13 +245,29 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
     return () => unsub();
   }, []);
 
-  const backgroundSubagentActivityByParent = useMemo(
-    () => buildBackgroundSubagentActivityIndex(
-      flowChatState.sessions,
-      sessionId => stateMachineManager.getCurrentState(sessionId),
-    ),
-    [flowChatState.sessions],
-  );
+  const backgroundSubagentActivityByParent = useMemo(() => {
+    const itemsByParent = new Map<string, BackgroundSubagentActivityItem[]>();
+    for (const item of Object.values(backgroundSubagentActivities)) {
+      const items = itemsByParent.get(item.parentSessionId) ?? [];
+      items.push(item);
+      itemsByParent.set(item.parentSessionId, items);
+    }
+
+    const activityByParent = new Map<string, BackgroundSubagentActivity>();
+    for (const [parentSessionId, items] of itemsByParent) {
+      const sortedItems = [...items].sort((left, right) => (
+        left.createdAt - right.createdAt || left.sessionId.localeCompare(right.sessionId)
+      ));
+      activityByParent.set(parentSessionId, {
+        runningCount: sortedItems.filter(item => item.status === 'processing').length,
+        finishingCount: sortedItems.filter(item => item.status === 'finishing').length,
+        totalCount: sortedItems.length,
+        items: sortedItems,
+      });
+    }
+
+    return activityByParent;
+  }, [backgroundSubagentActivities]);
 
   useEffect(() => {
     if (editingSessionId && editInputRef.current) {

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -33,6 +33,10 @@ import {
   visibleBackgroundCommandActivitiesForSession,
   type BackgroundCommandActivity,
 } from '../../store/backgroundCommandActivityStore';
+import {
+  useBackgroundSubagentActivityStore,
+  visibleBackgroundSubagentActivitiesForSession,
+} from '../../store/backgroundSubagentActivityStore';
 import type { LineRange } from '@/component-library';
 import { isChatPopupActive, subscribeChatPopupChange } from '../chatPopupState';
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
@@ -57,8 +61,6 @@ import {
   type HistorySessionOpenIntentDetail,
 } from '../../services/sessionOpenIntent';
 import {
-  buildBackgroundSubagentActivitySnapshotKey,
-  deriveBackgroundSubagentActivity,
   type BackgroundSubagentActivityItem,
 } from '../../utils/backgroundSubagentActivity';
 import './ModernFlowChatContainer.scss';
@@ -219,13 +221,13 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   // popup can be closed with Escape instead of cancelling the current task.
   const [chatPopupActive, setChatPopupActive] = useState(() => isChatPopupActive());
   const backgroundCommandActivities = useBackgroundCommandActivityStore(state => state.activities);
+  const backgroundSubagentActivities = useBackgroundSubagentActivityStore(state => state.activities);
 
   useEffect(() => {
     return subscribeChatPopupChange(() => {
       setChatPopupActive(isChatPopupActive());
     });
   }, []);
-  const [backgroundSubagents, setBackgroundSubagents] = useState<BackgroundSubagentSummary[]>([]);
   const [stoppingBackgroundSubagentIds, setStoppingBackgroundSubagentIds] = useState<Set<string>>(() => new Set());
   const [stoppingBackgroundCommandIds, setStoppingBackgroundCommandIds] = useState<Set<string>>(() => new Set());
   const [backgroundCommandInputTarget, setBackgroundCommandInputTarget] = useState<FlowChatHeaderCommandSummary | null>(null);
@@ -948,7 +950,6 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     void FlowChatManager.getInstance().switchChatSession(sessionId);
   }, [activeSession?.sessionId]);
 
-  const backgroundSubagentsRef = useRef<string | null>(null);
   const activeSessionIdRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -956,33 +957,14 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   }, [activeSession?.sessionId]);
 
   useEffect(() => {
-    const syncBackgroundSubagents = () => {
-      const parentId = activeSession?.sessionId;
-      if (!parentId) {
-        setBackgroundSubagents([]);
-        backgroundSubagentsRef.current = null;
-        return;
-      }
+    if (!activeSession?.sessionId) {
+      return;
+    }
 
-      const state = flowChatStore.getState();
-      const snapshot = buildBackgroundSubagentActivitySnapshotKey(state.sessions, parentId);
-      if (snapshot === backgroundSubagentsRef.current) {
-        return;
-      }
-      backgroundSubagentsRef.current = snapshot;
-
-      setBackgroundSubagents(deriveBackgroundSubagentActivity(state, parentId).items);
-    };
-
-    syncBackgroundSubagents();
-    const unsubscribe = flowChatStore.subscribe(syncBackgroundSubagents);
-    const intervalId = window.setInterval(syncBackgroundSubagents, 1000);
-
-    return () => {
-      unsubscribe();
-      window.clearInterval(intervalId);
-    };
-  }, [activeSession?.sessionId]);
+    useBackgroundSubagentActivityStore
+      .getState()
+      .reconcileParent(flowChatStore.getState(), activeSession.sessionId);
+  }, [activeSession?.dialogTurns.length, activeSession?.historyState, activeSession?.sessionId]);
 
   useEffect(() => {
     const agentSessionId = activeSession?.sessionId;
@@ -1042,6 +1024,13 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       activeSession?.sessionId,
     ).map(backgroundCommandSummaryFromActivity),
     [activeSession?.sessionId, backgroundCommandActivities],
+  );
+  const backgroundSubagents = useMemo(
+    () => visibleBackgroundSubagentActivitiesForSession(
+      backgroundSubagentActivities,
+      activeSession?.sessionId,
+    ),
+    [activeSession?.sessionId, backgroundSubagentActivities],
   );
 
   useEffect(() => {

--- a/src/web-ui/src/flow_chat/services/EventBatcher.test.ts
+++ b/src/web-ui/src/flow_chat/services/EventBatcher.test.ts
@@ -18,7 +18,7 @@ describe('summarizeBatchedEventsForLog', () => {
     setIncludeSensitiveDiagnostics(true);
     const events: BatchedEvent[] = [
       {
-        key: 'subagent:tool:params:session:call:tool',
+        key: 'tool:params:session:call:none',
         payload: {
           toolEvent: {
             event_type: 'ParamsPartial',
@@ -41,7 +41,7 @@ describe('summarizeBatchedEventsForLog', () => {
     setIncludeSensitiveDiagnostics(false);
     const events: BatchedEvent[] = [
       {
-        key: 'subagent:tool:params:session:call:tool',
+        key: 'tool:params:session:call:none',
         payload: {
           toolEvent: {
             event_type: 'ParamsPartial',
@@ -60,7 +60,7 @@ describe('summarizeBatchedEventsForLog', () => {
     expect(summary.rawEventCount).toBe(12);
     expect(summary.mergedEventCount).toBe(1);
     expect(summary.events[0]).toEqual({
-      key: 'subagent:tool:params:session:call:tool',
+      key: 'tool:params:session:call:none',
       strategy: 'accumulate',
       sourceCount: 12,
       timestamp: 1000,

--- a/src/web-ui/src/flow_chat/services/EventBatcher.ts
+++ b/src/web-ui/src/flow_chat/services/EventBatcher.ts
@@ -6,7 +6,7 @@
  * Design principles:
  * - Events with the same key are merged (accumulated or replaced)
  * - Batch processing triggered once per frame
- * - Supports different key generation strategies for normal and subagent events
+ * - Merge keys are scoped by session, round/tool id, and retry attempt
  */
 
 import { areSensitiveDiagnosticsEnabled, createLogger } from '@/shared/utils/logger';
@@ -380,8 +380,7 @@ function resolveAttemptMergeToken(data: { attemptId?: string; attemptIndex?: num
  * Generate merge key for TextChunk events
  * 
  * Key structure:
- * - Normal text: text:{sessionId}:{roundId}:{contentType}
- * - Subagent text: subagent:text:{sessionId}:{roundId}:{contentType}
+ * - Text chunk: text:{sessionId}:{roundId}:{contentType}:{attemptToken}
  */
 export function generateTextChunkKey(data: TextChunkEventData): string {
   const { sessionId, roundId, contentType } = data;
@@ -394,10 +393,8 @@ export function generateTextChunkKey(data: TextChunkEventData): string {
  * Returns null if the event doesn't need batching (isolated event)
  * 
  * Key structure:
- * - Tool params: tool:params:{sessionId}:{toolUseId}
- * - Subagent tool params: subagent:tool:params:{sessionId}:{subToolUseId}
- * - Tool progress: tool:progress:{sessionId}:{toolUseId}
- * - Subagent tool progress: subagent:tool:progress:{sessionId}:{subToolUseId}
+ * - Tool params: tool:params:{sessionId}:{toolUseId}:{attemptToken}
+ * - Tool progress: tool:progress:{sessionId}:{toolUseId}:{attemptToken}
  */
 export function generateToolEventKey(data: ToolEventData): { key: string; strategy: MergeStrategy } | null {
   const { sessionId, toolEvent } = data;
@@ -427,55 +424,16 @@ export function generateToolEventKey(data: ToolEventData): { key: string; strate
 }
 
 /**
- * Parse event key to extract event type information
+ * Parse event key to extract event type information.
  */
 export function parseEventKey(key: string): {
-  isSubagent: boolean;
   eventType: 'text' | 'tool:params' | 'tool:progress';
   ids: Record<string, string>;
 } | null {
-  if (key.startsWith('subagent:text:')) {
-    const parts = key.split(':');
-    if (parts.length >= 5) {
-      return {
-        isSubagent: true,
-        eventType: 'text',
-        ids: {
-          sessionId: parts[2],
-          roundId: parts[3],
-          contentType: parts[4]
-        }
-      };
-    }
-  } else if (key.startsWith('subagent:tool:params:')) {
-    const parts = key.split(':');
-    if (parts.length >= 5) {
-      return {
-        isSubagent: true,
-        eventType: 'tool:params',
-        ids: {
-          sessionId: parts[3],
-          subToolUseId: parts[4]
-        }
-      };
-    }
-  } else if (key.startsWith('subagent:tool:progress:')) {
-    const parts = key.split(':');
-    if (parts.length >= 5) {
-      return {
-        isSubagent: true,
-        eventType: 'tool:progress',
-        ids: {
-          sessionId: parts[3],
-          subToolUseId: parts[4]
-        }
-      };
-    }
-  } else if (key.startsWith('text:')) {
+  if (key.startsWith('text:')) {
     const parts = key.split(':');
     if (parts.length >= 4) {
       return {
-        isSubagent: false,
         eventType: 'text',
         ids: {
           sessionId: parts[1],
@@ -488,7 +446,6 @@ export function parseEventKey(key: string): {
     const parts = key.split(':');
     if (parts.length >= 4) {
       return {
-        isSubagent: false,
         eventType: 'tool:params',
         ids: {
           sessionId: parts[2],
@@ -500,7 +457,6 @@ export function parseEventKey(key: string): {
     const parts = key.split(':');
     if (parts.length >= 4) {
       return {
-        isSubagent: false,
         eventType: 'tool:progress',
         ids: {
           sessionId: parts[2],

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -45,6 +45,7 @@ import {
 import { useReviewActionBarStore } from '../../store/deepReviewActionBarStore';
 import { buildDeepReviewCapacityQueueStateFromEvent } from '../../utils/deepReviewQueueStateEvents';
 import { useBackgroundCommandActivityStore } from '../../store/backgroundCommandActivityStore';
+import { useBackgroundSubagentActivityStore } from '../../store/backgroundSubagentActivityStore';
 
 const pendingImageAnalysisTurns = new Map<string, string>();
 import { 
@@ -430,6 +431,36 @@ function ensureSubagentSession(
   );
 }
 
+function reconcileBackgroundSubagentSession(subagentSessionId?: string | null): void {
+  if (!subagentSessionId) {
+    return;
+  }
+
+  const flowState = FlowChatStore.getInstance().getState();
+  useBackgroundSubagentActivityStore
+    .getState()
+    .reconcileSession(flowState, subagentSessionId);
+}
+
+function reconcileBackgroundSubagentFromParentTool(
+  parentSessionId: string,
+  parentDialogTurnId: string,
+  parentToolCallId: string,
+): void {
+  const store = FlowChatStore.getInstance();
+  const parentTool = store.findToolItem(parentSessionId, parentDialogTurnId, parentToolCallId);
+  if (parentTool?.type !== 'tool') {
+    return;
+  }
+
+  const subagentSessionId = (parentTool as FlowToolItem).subagentSessionId;
+  if (typeof subagentSessionId !== 'string' || !subagentSessionId.trim()) {
+    return;
+  }
+
+  reconcileBackgroundSubagentSession(subagentSessionId);
+}
+
 function handleSubagentSessionLinked(
   context: FlowChatContext,
   event: SubagentSessionLinkedEvent,
@@ -454,6 +485,7 @@ function handleSubagentSessionLinked(
 
   attachSubagentSessionToParentTool(parentInfo, childSessionId);
   ensureSubagentSession(context, parentInfo, childSessionId, event as Record<string, unknown>, agentType);
+  reconcileBackgroundSubagentSession(childSessionId);
 }
 
 function getLinkedSubagentParentInfo(sessionId: string): SubagentParentInfo | undefined {
@@ -927,6 +959,7 @@ function finalizeTurnCompletionState(
       endTime: Date.now()
     };
   });
+  reconcileBackgroundSubagentSession(sessionId);
 
   const currentState = stateMachineManager.getCurrentState(sessionId);
   if (isStreamingExecutionState(currentState)) {
@@ -1018,6 +1051,7 @@ function handleSessionTitleGenerated(event: any): void {
 
   const store = FlowChatStore.getInstance();
   store.updateSessionTitle(sessionId, title, 'generated');
+  reconcileBackgroundSubagentSession(sessionId);
 }
 
 function handleSessionModelAutoMigrated(event: SessionModelAutoMigratedEvent): void {
@@ -1245,6 +1279,7 @@ function handleImageAnalysisStarted(context: FlowChatContext, event: ImageAnalys
         status: 'image_analyzing' as const,
         userMessage: { ...turn.userMessage, hasImages: true },
       }));
+      reconcileBackgroundSubagentSession(sessionId);
       log.info('Image analysis started: updated existing turn', {
         sessionId,
         turnId: lastTurn.id,
@@ -1289,6 +1324,7 @@ function handleImageAnalysisStarted(context: FlowChatContext, event: ImageAnalys
   };
 
   store.addDialogTurn(sessionId, tempTurn);
+  reconcileBackgroundSubagentSession(sessionId);
   pendingImageAnalysisTurns.set(sessionId, tempTurnId);
 
   context.contentBuffers.set(sessionId, new Map());
@@ -1325,6 +1361,7 @@ function handleImageAnalysisCompleted(_context: FlowChatContext, event: ImageAna
         ...turn,
         status: 'processing' as const,
       }));
+      reconcileBackgroundSubagentSession(sessionId);
     }
   }
 
@@ -1443,6 +1480,7 @@ function handleDialogTurnStarted(context: FlowChatContext, event: any): void {
       backendTurnIndex: typeof turnIndex === 'number' ? turnIndex : undefined,
     };
     store.addDialogTurn(sessionId, newTurn);
+    reconcileBackgroundSubagentSession(sessionId);
 
     context.contentBuffers.set(sessionId, new Map());
     context.activeTextItems.set(sessionId, new Map());
@@ -1469,6 +1507,7 @@ function handleDialogTurnStarted(context: FlowChatContext, event: any): void {
       backendTurnIndex: turnIndex,
     }));
   }
+  reconcileBackgroundSubagentSession(sessionId);
 
   // User may have pre-added this turn from the composer while the previous turn was still running;
   // START failed then (PROCESSING/FINISHING cannot take START). When the backend dispatches this
@@ -1580,9 +1619,11 @@ export function processBatchedEvents(
       } else if (eventType === 'tool:params') {
         const { sessionId, turnId, toolEvent } = payload;
         processToolParamsPartialInternal(sessionId, turnId, toolEvent);
+        reconcileBackgroundSubagentFromParentTool(sessionId, turnId, toolEvent.tool_id);
       } else if (eventType === 'tool:progress') {
         const { sessionId, turnId, toolEvent } = payload;
         processToolProgressInternal(sessionId, turnId, toolEvent);
+        reconcileBackgroundSubagentFromParentTool(sessionId, turnId, toolEvent.tool_id);
       }
     }
   } finally {
@@ -1655,6 +1696,7 @@ function handleToolEvent(
   }
 
   processToolEvent(context, sessionId, turnId, roundId, toolEvent, attemptId, attemptIndex, undefined, onTodoWriteResult);
+  reconcileBackgroundSubagentFromParentTool(sessionId, turnId, toolEvent.tool_id);
 }
 
 /**
@@ -2073,6 +2115,7 @@ export function handleDialogTurnComplete(
       hasFinalResponse: typeof hasFinalResponse === 'boolean' ? hasFinalResponse : undefined,
     };
   });
+  reconcileBackgroundSubagentSession(sessionId);
 
   const currentState = stateMachineManager.getCurrentState(sessionId);
   if (currentState === SessionExecutionState.PROCESSING) {
@@ -2283,6 +2326,7 @@ function handleDialogTurnFailed(context: FlowChatContext, event: any): void {
       log.warn('Failed to update failed session metadata', { sessionId, error: err });
     });
   }
+  reconcileBackgroundSubagentSession(sessionId);
   
   const currentState = stateMachineManager.getCurrentState(sessionId);
   if (isStreamingExecutionState(currentState)) {
@@ -2384,7 +2428,8 @@ function handleDialogTurnCancelled(
       endTime: Date.now()
     };
   });
-  
+  reconcileBackgroundSubagentSession(sessionId);
+   
   const dialogTurn = session.dialogTurns.find(t => t.id === turnId);
   if (dialogTurn) {
     appendPlanDisplayItemsIfNeeded(context, sessionId, turnId, dialogTurn);

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -59,6 +59,7 @@ import type { WorkspaceInfo } from '@/shared/types';
 import { sessionBelongsToWorkspaceNavRow } from '../utils/sessionOrdering';
 import { sessionMatchesWorkspace } from '../utils/workspaceScope';
 import { resolveThreadGoalUserMessageDisplay } from '../utils/threadGoalDisplay';
+import { useBackgroundSubagentActivityStore } from './backgroundSubagentActivityStore';
 
 const log = createLogger('FlowChatStore');
 const VALID_AGENT_TYPES = new Set([
@@ -1835,6 +1836,7 @@ export class FlowChatStore {
       return [];
     }
     this.clearRemovedSessionHistoryState(removedSessionIds, 'session-removed');
+    useBackgroundSubagentActivityStore.getState().removeSessions(removedSessionIds);
 
     this.setState(prev => {
       const removedSessionIdSet = new Set(removedSessionIds);

--- a/src/web-ui/src/flow_chat/store/backgroundSubagentActivityStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/backgroundSubagentActivityStore.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  useBackgroundSubagentActivityStore,
+  visibleBackgroundSubagentActivitiesForSession,
+} from './backgroundSubagentActivityStore';
+import type { FlowChatState, Session } from '../types/flow-chat';
+
+function createSession(overrides: Partial<Session>): Session {
+  return {
+    sessionId: 'session-1',
+    title: 'Session',
+    dialogTurns: [],
+    status: 'idle',
+    config: {},
+    createdAt: 1000,
+    lastActiveAt: 1000,
+    error: null,
+    sessionKind: 'normal',
+    ...overrides,
+  } as Session;
+}
+
+function createParentSession(subagentSessionId = 'subagent-1'): Session {
+  return createSession({
+    sessionId: 'parent-1',
+    title: 'Parent',
+    dialogTurns: [
+      {
+        id: 'turn-1',
+        status: 'completed',
+        modelRounds: [
+          {
+            id: 'round-1',
+            items: [
+              {
+                id: 'tool-1',
+                type: 'tool',
+                toolName: 'Task',
+                subagentSessionId,
+                toolCall: {
+                  id: 'call-1',
+                  input: {
+                    run_in_background: true,
+                    description: 'Review auth changes',
+                    subagent_type: 'ReviewSecurity',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  } as Partial<Session>);
+}
+
+function createState(sessions: Session[]): FlowChatState {
+  return {
+    activeSessionId: 'parent-1',
+    sessions: new Map(sessions.map(session => [session.sessionId, session])),
+  } as FlowChatState;
+}
+
+describe('backgroundSubagentActivityStore', () => {
+  afterEach(() => {
+    useBackgroundSubagentActivityStore.getState().clear();
+  });
+
+  it('upserts one running background subagent from flow state', () => {
+    const subagent = createSession({
+      sessionId: 'subagent-1',
+      title: '',
+      parentSessionId: 'parent-1',
+      sessionKind: 'subagent',
+      createdAt: 2000,
+      lastActiveAt: 3000,
+      dialogTurns: [{ status: 'processing', modelRounds: [] }] as any,
+    });
+
+    useBackgroundSubagentActivityStore
+      .getState()
+      .reconcileSession(createState([createParentSession(), subagent]), 'subagent-1');
+
+    expect(useBackgroundSubagentActivityStore.getState().activities['subagent-1']).toMatchObject({
+      sessionId: 'subagent-1',
+      parentSessionId: 'parent-1',
+      title: 'Review auth changes',
+      agentType: 'ReviewSecurity',
+      status: 'processing',
+    });
+  });
+
+  it('removes an activity when the subagent is no longer active', () => {
+    const runningSubagent = createSession({
+      sessionId: 'subagent-1',
+      parentSessionId: 'parent-1',
+      sessionKind: 'subagent',
+      dialogTurns: [{ status: 'processing', modelRounds: [] }] as any,
+    });
+    const completedSubagent = {
+      ...runningSubagent,
+      dialogTurns: [{ status: 'completed', modelRounds: [] }],
+    } as Session;
+
+    const store = useBackgroundSubagentActivityStore.getState();
+    store.reconcileSession(createState([createParentSession(), runningSubagent]), 'subagent-1');
+    store.reconcileSession(createState([createParentSession(), completedSubagent]), 'subagent-1');
+
+    expect(useBackgroundSubagentActivityStore.getState().activities['subagent-1']).toBeUndefined();
+  });
+
+  it('reconciles one parent session and preserves unrelated parent activities', () => {
+    const parentTwo = createSession({
+      sessionId: 'parent-2',
+      dialogTurns: [
+        {
+          id: 'turn-2',
+          status: 'completed',
+          modelRounds: [
+            {
+              id: 'round-2',
+              items: [
+                {
+                  id: 'tool-2',
+                  type: 'tool',
+                  toolName: 'Task',
+                  subagentSessionId: 'subagent-2',
+                  toolCall: {
+                    id: 'call-2',
+                    input: { run_in_background: true, description: 'Docs pass' },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as Partial<Session>);
+    const subagentOne = createSession({
+      sessionId: 'subagent-1',
+      parentSessionId: 'parent-1',
+      sessionKind: 'subagent',
+      dialogTurns: [{ status: 'completed', modelRounds: [] }] as any,
+    });
+    const subagentTwo = createSession({
+      sessionId: 'subagent-2',
+      parentSessionId: 'parent-2',
+      sessionKind: 'subagent',
+      dialogTurns: [{ status: 'processing', modelRounds: [] }] as any,
+    });
+
+    const store = useBackgroundSubagentActivityStore.getState();
+    store.reconcileSession(createState([parentTwo, subagentTwo]), 'subagent-2');
+    store.reconcileParent(createState([createParentSession(), subagentOne, parentTwo, subagentTwo]), 'parent-1');
+
+    expect(visibleBackgroundSubagentActivitiesForSession(
+      useBackgroundSubagentActivityStore.getState().activities,
+      'parent-1',
+    )).toEqual([]);
+    expect(visibleBackgroundSubagentActivitiesForSession(
+      useBackgroundSubagentActivityStore.getState().activities,
+      'parent-2',
+    )).toHaveLength(1);
+  });
+});

--- a/src/web-ui/src/flow_chat/store/backgroundSubagentActivityStore.ts
+++ b/src/web-ui/src/flow_chat/store/backgroundSubagentActivityStore.ts
@@ -1,0 +1,146 @@
+import { create } from 'zustand';
+import type { FlowChatState } from '../types/flow-chat';
+import {
+  deriveBackgroundSubagentActivity,
+  deriveBackgroundSubagentActivityItemForSession,
+  type BackgroundSubagentActivityItem,
+} from '../utils/backgroundSubagentActivity';
+
+interface BackgroundSubagentActivityState {
+  activities: Record<string, BackgroundSubagentActivityItem>;
+  reconcileParent: (state: FlowChatState, parentSessionId: string | undefined | null) => void;
+  reconcileSession: (state: FlowChatState, subagentSessionId: string | undefined | null) => void;
+  removeSession: (sessionId: string | undefined | null) => void;
+  removeSessions: (sessionIds: Iterable<string>) => void;
+  clear: () => void;
+}
+
+function sortByCreatedAt(
+  left: BackgroundSubagentActivityItem,
+  right: BackgroundSubagentActivityItem,
+): number {
+  return left.createdAt - right.createdAt || left.sessionId.localeCompare(right.sessionId);
+}
+
+function isSameActivity(
+  left: BackgroundSubagentActivityItem | undefined,
+  right: BackgroundSubagentActivityItem,
+): boolean {
+  return !!left &&
+    left.parentSessionId === right.parentSessionId &&
+    left.title === right.title &&
+    left.agentType === right.agentType &&
+    left.status === right.status &&
+    left.workspacePath === right.workspacePath &&
+    left.remoteConnectionId === right.remoteConnectionId &&
+    left.remoteSshHost === right.remoteSshHost &&
+    left.parentToolCallId === right.parentToolCallId &&
+    left.subagentType === right.subagentType &&
+    left.createdAt === right.createdAt &&
+    left.updatedAt === right.updatedAt;
+}
+
+export const useBackgroundSubagentActivityStore = create<BackgroundSubagentActivityState>((set) => ({
+  activities: {},
+
+  reconcileParent: (flowState, parentSessionId) => {
+    if (!parentSessionId) {
+      return;
+    }
+
+    const activity = deriveBackgroundSubagentActivity(flowState, parentSessionId);
+    set((state) => {
+      const nextActivities = { ...state.activities };
+      for (const [sessionId, item] of Object.entries(nextActivities)) {
+        if (item.parentSessionId === parentSessionId) {
+          delete nextActivities[sessionId];
+        }
+      }
+      for (const item of activity.items) {
+        nextActivities[item.sessionId] = item;
+      }
+      return { activities: nextActivities };
+    });
+  },
+
+  reconcileSession: (flowState, subagentSessionId) => {
+    if (!subagentSessionId) {
+      return;
+    }
+
+    const item = deriveBackgroundSubagentActivityItemForSession(flowState, subagentSessionId);
+    set((state) => {
+      const previous = state.activities[subagentSessionId];
+      if (!item) {
+        if (!previous) {
+          return state;
+        }
+        const nextActivities = { ...state.activities };
+        delete nextActivities[subagentSessionId];
+        return { activities: nextActivities };
+      }
+
+      if (isSameActivity(previous, item)) {
+        return state;
+      }
+
+      return {
+        activities: {
+          ...state.activities,
+          [item.sessionId]: item,
+        },
+      };
+    });
+  },
+
+  removeSession: (sessionId) => {
+    if (!sessionId) {
+      return;
+    }
+
+    set((state) => {
+      if (!state.activities[sessionId]) {
+        return state;
+      }
+      const nextActivities = { ...state.activities };
+      delete nextActivities[sessionId];
+      return { activities: nextActivities };
+    });
+  },
+
+  removeSessions: (sessionIds) => {
+    const sessionIdSet = new Set(sessionIds);
+    if (sessionIdSet.size === 0) {
+      return;
+    }
+
+    set((state) => {
+      let changed = false;
+      const nextActivities = { ...state.activities };
+      for (const sessionId of sessionIdSet) {
+        if (nextActivities[sessionId]) {
+          delete nextActivities[sessionId];
+          changed = true;
+        }
+      }
+      return changed ? { activities: nextActivities } : state;
+    });
+  },
+
+  clear: () => {
+    set({ activities: {} });
+  },
+}));
+
+export function visibleBackgroundSubagentActivitiesForSession(
+  activities: Record<string, BackgroundSubagentActivityItem>,
+  parentSessionId: string | undefined | null,
+): BackgroundSubagentActivityItem[] {
+  if (!parentSessionId) {
+    return [];
+  }
+
+  return Object.values(activities)
+    .filter(activity => activity.parentSessionId === parentSessionId)
+    .sort(sortByCreatedAt);
+}

--- a/src/web-ui/src/flow_chat/utils/backgroundSubagentActivity.ts
+++ b/src/web-ui/src/flow_chat/utils/backgroundSubagentActivity.ts
@@ -113,6 +113,61 @@ function collectBackgroundTaskToolsBySubagentId(
   return taskBySubagentId;
 }
 
+function findBackgroundTaskToolForSubagent(
+  sessions: Map<string, Session>,
+  parentSessionId: string,
+  subagentSessionId: string,
+): BackgroundTaskTool | null {
+  const parentSession = sessions.get(parentSessionId);
+  if (!parentSession) {
+    return null;
+  }
+
+  for (const turn of parentSession.dialogTurns) {
+    for (const round of turn.modelRounds) {
+      for (const item of round.items) {
+        if (item.type !== 'tool') {
+          continue;
+        }
+
+        const toolItem = item as BackgroundTaskTool;
+        if (
+          toolItem.toolName?.toLowerCase() === 'task' &&
+          toolItem.subagentSessionId === subagentSessionId &&
+          isBackgroundTaskTool(toolItem)
+        ) {
+          return toolItem;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+function buildBackgroundSubagentActivityItem(
+  session: Session,
+  parentSessionId: string,
+  status: BackgroundSubagentActivityStatus,
+  parentTask: BackgroundTaskTool,
+): BackgroundSubagentActivityItem {
+  const input = parentTask.toolCall?.input ?? {};
+  return {
+    sessionId: session.sessionId,
+    parentSessionId,
+    title: session.title?.trim() || input.description || 'Background subagent',
+    agentType: session.subagentType || input.subagent_type || input.subagentType,
+    status,
+    workspacePath: session.workspacePath,
+    remoteConnectionId: session.remoteConnectionId,
+    remoteSshHost: session.remoteSshHost,
+    parentToolCallId: session.parentToolCallId || parentTask.toolCall?.id || parentTask.id,
+    subagentType: session.subagentType || input.subagent_type || input.subagentType,
+    createdAt: session.createdAt,
+    updatedAt: session.lastActiveAt || session.updatedAt || session.createdAt,
+  };
+}
+
 function emptyActivity(): BackgroundSubagentActivity {
   return EMPTY_BACKGROUND_SUBAGENT_ACTIVITY;
 }
@@ -159,21 +214,7 @@ export function buildBackgroundSubagentActivityIndex(
       continue;
     }
 
-    const input = parentTask.toolCall?.input ?? {};
-    const item: BackgroundSubagentActivityItem = {
-      sessionId: session.sessionId,
-      parentSessionId,
-      title: session.title?.trim() || input.description || 'Background subagent',
-      agentType: session.subagentType || input.subagent_type || input.subagentType,
-      status,
-      workspacePath: session.workspacePath,
-      remoteConnectionId: session.remoteConnectionId,
-      remoteSshHost: session.remoteSshHost,
-      parentToolCallId: session.parentToolCallId || parentTask.toolCall?.id || parentTask.id,
-      subagentType: session.subagentType || input.subagent_type || input.subagentType,
-      createdAt: session.createdAt,
-      updatedAt: session.lastActiveAt || session.updatedAt || session.createdAt,
-    };
+    const item = buildBackgroundSubagentActivityItem(session, parentSessionId, status, parentTask);
 
     const items = itemsByParentId.get(parentSessionId) ?? [];
     items.push(item);
@@ -195,6 +236,37 @@ export function buildBackgroundSubagentActivityIndex(
   }
 
   return index;
+}
+
+export function deriveBackgroundSubagentActivityItemForSession(
+  state: FlowChatState,
+  subagentSessionId: string,
+  resolveExecutionState?: SessionExecutionStateResolver,
+): BackgroundSubagentActivityItem | null {
+  const session = state.sessions.get(subagentSessionId);
+  const parentSessionId = session?.parentSessionId;
+  if (!session || session.sessionKind !== 'subagent' || !parentSessionId) {
+    return null;
+  }
+
+  const status = deriveBackgroundSubagentExecutionStatus(
+    session,
+    resolveExecutionState?.(session.sessionId),
+  );
+  if (!status) {
+    return null;
+  }
+
+  const parentTask = findBackgroundTaskToolForSubagent(
+    state.sessions,
+    parentSessionId,
+    session.sessionId,
+  );
+  if (!parentTask) {
+    return null;
+  }
+
+  return buildBackgroundSubagentActivityItem(session, parentSessionId, status, parentTask);
 }
 
 export function deriveBackgroundSubagentActivity(


### PR DESCRIPTION
## Summary

Track background subagent activity through a shared event-driven store instead of repeated full-session scans.

Fixes #

## Type and Areas

Type:

Feature / refactor / test

Areas:

Web UI, flow chat, session navigation

## Motivation / Impact

Background subagent indicators in the flow chat header and session list previously depended on deriving activity by scanning all sessions and parent Task items. This adds a shared `backgroundSubagentActivityStore`, updates it from subagent/session/tool events, and keeps targeted reconciliation for session restore/history paths.

Users should see the same background subagent status behavior with less repeated work during active sessions and sidebar rendering.

## Verification

- `pnpm --dir src/web-ui run test:run src/flow_chat/store/backgroundSubagentActivityStore.test.ts src/flow_chat/utils/backgroundSubagentActivity.test.ts`
  - Passed: 2 files, 5 tests
- `pnpm run type-check:web`
  - Passed

## Reviewer Notes

The new store is event-driven but intentionally keeps parent/session reconciliation paths to handle event ordering and restored history. The session nav now consumes the same activity store as the flow chat header.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.