### PR TITLE
fix: keep mcp elicitation capability legacy-compatible

### DIFF
--- a/src/crates/services/services-integrations/src/mcp/protocol/client_info.rs
+++ b/src/crates/services/services-integrations/src/mcp/protocol/client_info.rs
@@ -11,7 +11,6 @@ pub fn create_mcp_client_info(
             .enable_roots()
             .enable_sampling()
             .enable_elicitation()
-            .enable_elicitation_schema_validation()
             .build(),
         Implementation::new(client_name, client_version),
     )

--- a/src/crates/services/services-integrations/tests/mcp_contracts.rs
+++ b/src/crates/services/services-integrations/tests/mcp_contracts.rs
@@ -191,11 +191,8 @@ fn mcp_remote_client_info_declares_supported_client_capabilities() {
     assert!(info.capabilities.sampling.is_some());
     assert!(info.capabilities.elicitation.is_some());
     assert_eq!(
-        info.capabilities
-            .elicitation
-            .as_ref()
-            .and_then(|cap| cap.schema_validation),
-        Some(true)
+        serde_json::to_value(&info.capabilities.elicitation).unwrap(),
+        serde_json::json!({})
     );
 }
 


### PR DESCRIPTION
## Summary
- keep MCP client elicitation capability enabled without declaring schema validation
- update the contract assertion to expect a legacy-compatible empty elicitation object

## Verification
- pnpm run fmt:rs
- cargo check -p bitfun-services-integrations --features mcp
- cargo test -p bitfun-services-integrations --features mcp mcp_remote_client_info_declares_supported_client_capabilities (blocked by existing rmcp #[non_exhaustive] struct-expression compile errors in mcp_contracts.rs)