### PR TITLE
perf(startup): reduce startup IPC and trace attribution

### DIFF
--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -35,6 +35,23 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, State};
 
+struct WorkspaceStateSnapshot {
+    current_workspace: Option<WorkspaceInfoDto>,
+    recent_workspaces: Vec<WorkspaceInfoDto>,
+    opened_workspaces: Vec<WorkspaceInfoDto>,
+    legacy_remote_workspace: Option<crate::api::RemoteWorkspace>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceStartupStateSnapshotDto {
+    pub cleanup_removed_count: usize,
+    pub current_workspace: Option<WorkspaceInfoDto>,
+    pub recent_workspaces: Vec<WorkspaceInfoDto>,
+    pub opened_workspaces: Vec<WorkspaceInfoDto>,
+    pub legacy_remote_workspace: Option<crate::api::RemoteWorkspace>,
+}
+
 fn remote_workspace_from_info(info: &WorkspaceInfo) -> Option<crate::api::RemoteWorkspace> {
     if info.workspace_kind != WorkspaceKind::Remote {
         return None;
@@ -1949,6 +1966,34 @@ pub async fn get_recent_workspaces(
     result
 }
 
+async fn collect_workspace_state_snapshot(state: &State<'_, AppState>) -> WorkspaceStateSnapshot {
+    let workspace_service = &state.workspace_service;
+    let current_workspace = workspace_service
+        .get_current_workspace()
+        .await
+        .map(|info| WorkspaceInfoDto::from_workspace_info(&info));
+    let recent_workspaces = workspace_service
+        .get_recent_workspaces()
+        .await
+        .into_iter()
+        .map(|info| WorkspaceInfoDto::from_workspace_info(&info))
+        .collect();
+    let opened_workspaces = workspace_service
+        .get_opened_workspaces()
+        .await
+        .into_iter()
+        .map(|info| WorkspaceInfoDto::from_workspace_info(&info))
+        .collect();
+    let legacy_remote_workspace = state.get_remote_workspace_async().await;
+
+    WorkspaceStateSnapshot {
+        current_workspace,
+        recent_workspaces,
+        opened_workspaces,
+        legacy_remote_workspace,
+    }
+}
+
 #[tauri::command]
 pub async fn remove_recent_workspace(
     state: State<'_, AppState>,
@@ -1968,19 +2013,88 @@ pub async fn cleanup_invalid_workspaces(
     startup_trace: State<'_, DesktopStartupTrace>,
 ) -> Result<usize, String> {
     let trace_started = Instant::now();
+    cleanup_invalid_workspaces_impl(
+        &state,
+        &app,
+        &startup_trace,
+        "cleanup_invalid_workspaces",
+        Some("cleanup_invalid_workspaces"),
+        trace_started,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn cleanup_invalid_workspaces_and_get_workspace_state_snapshot(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    startup_trace: State<'_, DesktopStartupTrace>,
+) -> Result<WorkspaceStartupStateSnapshotDto, String> {
+    let trace_started = Instant::now();
+    let cleanup_removed_count = match cleanup_invalid_workspaces_impl(
+        &state,
+        &app,
+        &startup_trace,
+        "cleanup_invalid_workspaces_and_get_workspace_state_snapshot",
+        None,
+        trace_started,
+    )
+    .await
+    {
+        Ok(removed_count) => removed_count,
+        Err(error) => {
+            startup_trace.record_tauri_command_elapsed(
+                "cleanup_invalid_workspaces_and_get_workspace_state_snapshot",
+                None,
+                trace_started,
+            );
+            return Err(error);
+        }
+    };
+
+    let snapshot_started = Instant::now();
+    let snapshot = collect_workspace_state_snapshot(&state).await;
+    startup_trace.record_elapsed_step(
+        "tauri_command",
+        "cleanup_invalid_workspaces_and_get_workspace_state_snapshot.collect_workspace_state_snapshot",
+        snapshot_started,
+    );
+    startup_trace.record_tauri_command_elapsed(
+        "cleanup_invalid_workspaces_and_get_workspace_state_snapshot",
+        None,
+        trace_started,
+    );
+
+    Ok(WorkspaceStartupStateSnapshotDto {
+        cleanup_removed_count,
+        current_workspace: snapshot.current_workspace,
+        recent_workspaces: snapshot.recent_workspaces,
+        opened_workspaces: snapshot.opened_workspaces,
+        legacy_remote_workspace: snapshot.legacy_remote_workspace,
+    })
+}
+
+async fn cleanup_invalid_workspaces_impl(
+    state: &State<'_, AppState>,
+    app: &tauri::AppHandle,
+    startup_trace: &State<'_, DesktopStartupTrace>,
+    trace_step_prefix: &str,
+    command_name: Option<&str>,
+    command_started: Instant,
+) -> Result<usize, String> {
     let cleanup_started = Instant::now();
     match state.workspace_service.cleanup_invalid_workspaces().await {
         Ok(local_removed_count) => {
             startup_trace.record_elapsed_step(
                 "tauri_command",
-                "cleanup_invalid_workspaces.local_workspace_cleanup",
+                format!("{trace_step_prefix}.local_workspace_cleanup"),
                 cleanup_started,
             );
             let prune_remote_started = Instant::now();
-            let remote_removed_count = prune_unrecoverable_remote_workspaces(&state).await;
+            let remote_removed_count = prune_unrecoverable_remote_workspaces(state).await;
             startup_trace.record_elapsed_step(
                 "tauri_command",
-                "cleanup_invalid_workspaces.remote_workspace_prune",
+                format!("{trace_step_prefix}.remote_workspace_prune"),
                 prune_remote_started,
             );
             let removed_count = local_removed_count + remote_removed_count;
@@ -1993,7 +2107,7 @@ pub async fn cleanup_invalid_workspaces(
             }
             startup_trace.record_elapsed_step(
                 "tauri_command",
-                "cleanup_invalid_workspaces.apply_active_workspace_context",
+                format!("{trace_step_prefix}.apply_active_workspace_context"),
                 apply_context_started,
             );
 
@@ -2010,7 +2124,7 @@ pub async fn cleanup_invalid_workspaces(
             }
             startup_trace.record_elapsed_step(
                 "tauri_command",
-                "cleanup_invalid_workspaces.sync_identity_watchers",
+                format!("{trace_step_prefix}.sync_identity_watchers"),
                 sync_watchers_started,
             );
 
@@ -2018,20 +2132,16 @@ pub async fn cleanup_invalid_workspaces(
                 "Invalid workspaces cleaned up: removed_count={}",
                 removed_count
             );
-            startup_trace.record_tauri_command_elapsed(
-                "cleanup_invalid_workspaces",
-                None,
-                trace_started,
-            );
+            if let Some(command_name) = command_name {
+                startup_trace.record_tauri_command_elapsed(command_name, None, command_started);
+            }
             Ok(removed_count)
         }
         Err(e) => {
             error!("Failed to cleanup invalid workspaces: {}", e);
-            startup_trace.record_tauri_command_elapsed(
-                "cleanup_invalid_workspaces",
-                None,
-                trace_started,
-            );
+            if let Some(command_name) = command_name {
+                startup_trace.record_tauri_command_elapsed(command_name, None, command_started);
+            }
             Err(format!("Failed to cleanup invalid workspaces: {}", e))
         }
     }

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1068,6 +1068,7 @@ pub async fn run() {
             subscribe_config_updates,
             get_model_configs,
             get_recent_workspaces,
+            cleanup_invalid_workspaces_and_get_workspace_state_snapshot,
             remove_recent_workspace,
             cleanup_invalid_workspaces,
             get_opened_workspaces,

--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -209,6 +209,15 @@ pub struct ThemeConfig {
     pub accent_color: String,
 }
 
+#[derive(Debug, Clone)]
+struct StartupBootstrapConfig {
+    theme: ThemeConfig,
+    locale: String,
+    keybindings: Option<serde_json::Value>,
+}
+
+const MAX_BOOTSTRAP_KEYBINDINGS_JSON_BYTES: usize = 64 * 1024;
+
 impl Default for ThemeConfig {
     fn default() -> Self {
         let mut theme = Self::get_builtin_theme("bitfun-light").unwrap_or_else(|| Self {
@@ -322,9 +331,13 @@ impl ThemeConfig {
         }
     }
 
-    pub fn load_from_config() -> Self {
-        let default = Self::default();
-
+    fn load_startup_bootstrap_config() -> StartupBootstrapConfig {
+        let default_theme = Self::default();
+        let default = StartupBootstrapConfig {
+            theme: default_theme.clone(),
+            locale: "zh-CN".to_string(),
+            keybindings: None,
+        };
         let path_manager = match try_get_path_manager_arc() {
             Ok(pm) => pm,
             Err(e) => {
@@ -346,11 +359,30 @@ impl ThemeConfig {
             }
         };
 
-        let global_config: GlobalConfig = match serde_json::from_str(&config_content) {
-            Ok(config) => config,
+        let config_value: serde_json::Value = match serde_json::from_str(&config_content) {
+            Ok(value) => value,
             Err(e) => {
                 debug!("Failed to parse config file, using default theme: {}", e);
                 return default;
+            }
+        };
+
+        let locale = config_value
+            .pointer("/app/language")
+            .and_then(|value| value.as_str())
+            .or_else(|| {
+                config_value
+                    .pointer("/i18n/currentLanguage")
+                    .and_then(|value| value.as_str())
+            })
+            .unwrap_or("zh-CN")
+            .to_string();
+
+        let global_config: GlobalConfig = match serde_json::from_value(config_value) {
+            Ok(config) => config,
+            Err(e) => {
+                debug!("Failed to parse config file, using default theme: {}", e);
+                return StartupBootstrapConfig { locale, ..default };
             }
         };
 
@@ -362,15 +394,21 @@ impl ThemeConfig {
 
         let resolved_id = Self::resolve_builtin_theme_id(theme_id);
 
-        match Self::get_builtin_theme(resolved_id) {
+        let theme = match Self::get_builtin_theme(resolved_id) {
             Some(mut config) => {
                 config.selection_id = Some(theme_id.to_string());
                 config
             }
             None => {
                 warn!("Unknown theme ID: {}, using default theme", theme_id);
-                default
+                default_theme
             }
+        };
+
+        StartupBootstrapConfig {
+            theme,
+            locale,
+            keybindings: global_config.app.keybindings,
         }
     }
 
@@ -384,30 +422,6 @@ impl ThemeConfig {
             };
         }
         theme_id
-    }
-
-    fn load_startup_locale_from_config() -> String {
-        let path_manager = match try_get_path_manager_arc() {
-            Ok(pm) => pm,
-            Err(_) => return "zh-CN".to_string(),
-        };
-        let config_file = path_manager.app_config_file();
-        let Ok(config_content) = std::fs::read_to_string(config_file) else {
-            return "zh-CN".to_string();
-        };
-        let Ok(config_value) = serde_json::from_str::<serde_json::Value>(&config_content) else {
-            return "zh-CN".to_string();
-        };
-        config_value
-            .pointer("/app/language")
-            .and_then(|value| value.as_str())
-            .or_else(|| {
-                config_value
-                    .pointer("/i18n/currentLanguage")
-                    .and_then(|value| value.as_str())
-            })
-            .unwrap_or("zh-CN")
-            .to_string()
     }
 
     fn startup_messages_json(locale: &str) -> String {
@@ -437,9 +451,13 @@ impl ThemeConfig {
         messages.to_string()
     }
 
-    pub fn generate_init_script(&self, startup_trace_id: &str) -> String {
+    fn generate_init_script(
+        &self,
+        startup_trace_id: &str,
+        bootstrap_config: &StartupBootstrapConfig,
+    ) -> String {
         let theme_type = if self.is_light { "light" } else { "dark" };
-        let startup_locale = Self::load_startup_locale_from_config();
+        let startup_locale = &bootstrap_config.locale;
         let startup_locale_json =
             serde_json::to_string(&startup_locale).unwrap_or_else(|_| "\"zh-CN\"".to_string());
         let startup_messages_json = Self::startup_messages_json(&startup_locale);
@@ -460,6 +478,11 @@ impl ThemeConfig {
             .as_ref()
             .and_then(|selection| serde_json::to_string(selection).ok())
             .unwrap_or_else(|| "null".to_string());
+        let bootstrap_keybindings_assignment = serde_json::to_string(&bootstrap_config.keybindings)
+            .ok()
+            .filter(|json| json.len() <= MAX_BOOTSTRAP_KEYBINDINGS_JSON_BYTES)
+            .map(|json| format!("window.__BITFUN_BOOTSTRAP_KEYBINDINGS__ = {json};"))
+            .unwrap_or_default();
 
         format!(
             r#"
@@ -472,6 +495,7 @@ impl ThemeConfig {
                 window.__BITFUN_SHOW_STARTUP_WINDOW_CONTROLS__ = {show_startup_window_controls};
                 window.__BITFUN_BOOTSTRAP_THEME_ID__ = {bootstrap_theme_id_json};
                 window.__BITFUN_BOOTSTRAP_THEME_SELECTION__ = {bootstrap_theme_selection_json};
+                {bootstrap_keybindings_assignment}
                 function applyTheme() {{
                     var root = document.documentElement;
                     if (!root) return false;
@@ -520,6 +544,7 @@ impl ThemeConfig {
             startup_locale_json = startup_locale_json,
             startup_messages_json = startup_messages_json,
             show_startup_window_controls = show_startup_window_controls,
+            bootstrap_keybindings_assignment = bootstrap_keybindings_assignment,
         )
     }
 
@@ -538,9 +563,10 @@ pub fn create_main_window(
     startup_trace: &DesktopStartupTrace,
 ) {
     let total_started_at = Instant::now();
-    let theme = ThemeConfig::load_from_config();
+    let bootstrap_config = ThemeConfig::load_startup_bootstrap_config();
+    let theme = bootstrap_config.theme.clone();
     let bg_color = theme.to_tauri_color();
-    let init_script = theme.generate_init_script(startup_trace_id);
+    let init_script = theme.generate_init_script(startup_trace_id, &bootstrap_config);
     startup_trace.record_step(
         "native_step_end",
         "native_window",

--- a/src/web-ui/src/app/layout/AppLayout.tsx
+++ b/src/web-ui/src/app/layout/AppLayout.tsx
@@ -137,7 +137,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
   useEffect(() => {
     const load = async () => {
       try {
-        const raw = await configManager.getConfig('app.keybindings');
+        const raw = await configManager.getOptionalConfig('app.keybindings');
         const overrides = parseStoredKeybindings(raw);
         if (Object.keys(overrides).length > 0) {
           shortcutManager.loadUserOverrides(overrides);

--- a/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
+++ b/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
@@ -53,6 +53,17 @@ describe('startup performance contract', () => {
     expect(source).toContain("import('./shared/context-menu-system')");
   });
 
+  it('keeps the required i18n provider off an async startup waterfall', () => {
+    const source = readSource('../../main.tsx');
+
+    expect(source).toContain(
+      'import { I18nProvider } from "./infrastructure/i18n/providers/I18nProvider"'
+    );
+    expect(source).not.toMatch(/import\(['"]\.\/infrastructure\/i18n['"]\)/);
+    expect(source).toContain("step: 'load_i18n_provider'");
+    expect(source).toContain("mode: 'static'");
+  });
+
   it('does not block first React render on frontend log-level config reads', () => {
     const mainSource = readSource('../../main.tsx');
     const loggerSource = readSource('../../shared/utils/logger.ts');
@@ -64,6 +75,20 @@ describe('startup performance contract', () => {
     expect(mainSource).toContain('installFrontendLogLevelConfigWatcher');
     expect(loggerSource).toContain('__BITFUN_BOOTSTRAP_LOG_LEVEL__');
     expect(themeSource).toContain('__BITFUN_BOOTSTRAP_LOG_LEVEL__');
+  });
+
+  it('keeps startup keybindings on the bootstrap path instead of a first-window IPC', () => {
+    const configManagerSource = readSource('../../infrastructure/config/services/ConfigManager.ts');
+    const themeSource = readSource('../../../../apps/desktop/src/theme.rs');
+
+    expect(themeSource).toContain('__BITFUN_BOOTSTRAP_KEYBINDINGS__');
+    expect(themeSource).toContain('keybindings: global_config.app.keybindings');
+    expect(themeSource).toContain('MAX_BOOTSTRAP_KEYBINDINGS_JSON_BYTES');
+    expect(themeSource).toContain('.filter(|json| json.len() <= MAX_BOOTSTRAP_KEYBINDINGS_JSON_BYTES)');
+    expect(configManagerSource).toContain('consumeBootstrapOptionalConfig');
+    expect(configManagerSource).toContain('__BITFUN_BOOTSTRAP_KEYBINDINGS__');
+    expect(configManagerSource).toContain("path !== 'app.keybindings'");
+    expect(configManagerSource).toContain('delete globalThis.__BITFUN_BOOTSTRAP_KEYBINDINGS__');
   });
 
   it('keeps built-in theme startup on the bootstrap path without pre-render config writes', () => {

--- a/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.test.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SSHRemoteProvider } from './SSHRemoteProvider';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const workspaceManagerMock = vi.hoisted(() => ({
+  getState: vi.fn(),
+  addEventListener: vi.fn(),
+  consumeStartupLegacyRemoteWorkspaceSnapshot: vi.fn(),
+  openRemoteWorkspace: vi.fn(),
+  removeRemoteWorkspace: vi.fn(),
+}));
+
+const sshApiMock = vi.hoisted(() => ({
+  getWorkspaceInfo: vi.fn(),
+  listSavedConnections: vi.fn(),
+  hasStoredPassword: vi.fn(),
+  isConnected: vi.fn(),
+  openWorkspace: vi.fn(),
+  disconnect: vi.fn(),
+  closeWorkspace: vi.fn(),
+  removeWorkspace: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/services/business/workspaceManager', () => ({
+  workspaceManager: workspaceManagerMock,
+}));
+
+vi.mock('./sshApi', () => ({
+  sshApi: sshApiMock,
+}));
+
+vi.mock('@/flow_chat/store/FlowChatStore', () => ({
+  flowChatStore: {
+    initializeFromDisk: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock('@/infrastructure/api/service-api/ACPClientAPI', () => ({
+  ACPClientAPI: {
+    probeClientRequirements: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock('@/shared/notification-system', () => ({
+  notificationService: {
+    warning: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+describe('SSHRemoteProvider startup restore', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    workspaceManagerMock.getState.mockReturnValue({
+      loading: false,
+      openedWorkspaces: new Map(),
+      activeWorkspaceId: null,
+    });
+    workspaceManagerMock.addEventListener.mockReturnValue(() => undefined);
+    sshApiMock.getWorkspaceInfo.mockResolvedValue(null);
+    sshApiMock.listSavedConnections.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  async function renderProvider(): Promise<void> {
+    await act(async () => {
+      root.render(
+        <SSHRemoteProvider>
+          <div />
+        </SSHRemoteProvider>
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  it('skips the legacy remote IPC when the startup snapshot is available', async () => {
+    workspaceManagerMock.consumeStartupLegacyRemoteWorkspaceSnapshot.mockReturnValue({
+      available: true,
+      workspace: null,
+    });
+
+    await renderProvider();
+
+    expect(workspaceManagerMock.consumeStartupLegacyRemoteWorkspaceSnapshot).toHaveBeenCalledTimes(1);
+    expect(sshApiMock.getWorkspaceInfo).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the legacy remote IPC when no startup snapshot is available', async () => {
+    workspaceManagerMock.consumeStartupLegacyRemoteWorkspaceSnapshot.mockReturnValue({
+      available: false,
+      workspace: null,
+    });
+
+    await renderProvider();
+
+    expect(sshApiMock.getWorkspaceInfo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.tsx
@@ -395,12 +395,19 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
         ws => ws.workspaceKind === WorkspaceKind.Remote && ws.connectionId
       );
 
-      // Also check legacy single-workspace persisted in app_state
+      // Also check legacy single-workspace persisted in app_state.
+      // Startup normally receives this in the workspace snapshot, so avoid a
+      // second early invoke unless the snapshot was unavailable.
       let legacyWorkspace: RemoteWorkspace | null = null;
-      try {
-        legacyWorkspace = await sshApi.getWorkspaceInfo();
-      } catch {
-        // Ignore
+      const startupLegacyWorkspace = workspaceManager.consumeStartupLegacyRemoteWorkspaceSnapshot();
+      if (startupLegacyWorkspace.available) {
+        legacyWorkspace = startupLegacyWorkspace.workspace;
+      } else {
+        try {
+          legacyWorkspace = await sshApi.getWorkspaceInfo();
+        } catch {
+          // Ignore
+        }
       }
 
       // Key by connection + path so two servers at the same remote path stay distinct.

--- a/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.test.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.test.ts
@@ -61,4 +61,25 @@ describe('Tauri adapter expected errors', () => {
     expect(timing.invokeDurationMs).toEqual(expect.any(Number));
     expect(timing.transportDurationMs).toEqual(expect.any(Number));
   });
+
+  it('records invoke timing when a request rejects', async () => {
+    invokeMock.mockRejectedValueOnce(new Error("Config path not found: 'font'"));
+    const adapter = new TauriTransportAdapter();
+    const timing: {
+      adapterInitDurationMs?: number;
+      invokeDurationMs?: number;
+      transportDurationMs?: number;
+    } = {};
+
+    await expect(adapter.request('get_config', {
+      request: {
+        path: 'font',
+        skipRetryOnNotFound: true,
+      },
+    }, timing)).rejects.toThrow("Config path not found: 'font'");
+
+    expect(timing.adapterInitDurationMs).toEqual(expect.any(Number));
+    expect(timing.invokeDurationMs).toEqual(expect.any(Number));
+    expect(timing.transportDurationMs).toEqual(expect.any(Number));
+  });
 });

--- a/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.ts
@@ -89,15 +89,22 @@ export class TauriTransportAdapter implements ITransportAdapter {
         throw new Error('Tauri invoke function not initialized');
       }
       const invokeStartedAt = nowMs();
-      const result = params !== undefined
-        ? await this.invokeFn(action, params)
-        : await this.invokeFn(action);
-      if (timing) {
-        timing.invokeDurationMs = elapsedMs(invokeStartedAt);
-        timing.transportDurationMs = elapsedMs(transportStartedAt);
-      }
+      try {
+        const result = params !== undefined
+          ? await this.invokeFn(action, params)
+          : await this.invokeFn(action);
+        if (timing) {
+          timing.invokeDurationMs = elapsedMs(invokeStartedAt);
+          timing.transportDurationMs = elapsedMs(transportStartedAt);
+        }
 
-      return result as T;
+        return result as T;
+      } catch (error) {
+        if (timing) {
+          timing.invokeDurationMs = elapsedMs(invokeStartedAt);
+        }
+        throw error;
+      }
     } catch (error) {
       if (timing) {
         timing.transportDurationMs = elapsedMs(transportStartedAt);

--- a/src/web-ui/src/infrastructure/api/service-api/GlobalAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/GlobalAPI.ts
@@ -66,6 +66,21 @@ export interface WorkspaceInfo {
   sshHost?: string;
 }
 
+export interface RemoteWorkspaceSnapshot {
+  connectionId: string;
+  connectionName: string;
+  remotePath: string;
+  sshHost?: string;
+}
+
+export interface WorkspaceStartupStateSnapshot {
+  cleanupRemovedCount: number;
+  currentWorkspace: WorkspaceInfo | null;
+  recentWorkspaces: WorkspaceInfo[];
+  openedWorkspaces: WorkspaceInfo[];
+  legacyRemoteWorkspace?: RemoteWorkspaceSnapshot | null;
+}
+
 export interface UpdateAppStatusRequest {
   status: AppStatus;
 }
@@ -290,6 +305,17 @@ export class GlobalAPI {
       });
     } catch (error) {
       throw createTauriCommandError('get_recent_workspaces', error);
+    }
+  }
+
+  async cleanupInvalidWorkspacesAndGetWorkspaceStateSnapshot(): Promise<WorkspaceStartupStateSnapshot> {
+    try {
+      return await api.invoke('cleanup_invalid_workspaces_and_get_workspace_state_snapshot');
+    } catch (error) {
+      throw createTauriCommandError(
+        'cleanup_invalid_workspaces_and_get_workspace_state_snapshot',
+        error
+      );
     }
   }
 

--- a/src/web-ui/src/infrastructure/config/services/ConfigManager.test.ts
+++ b/src/web-ui/src/infrastructure/config/services/ConfigManager.test.ts
@@ -38,6 +38,7 @@ describe('ConfigManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     configManager.clearCache();
+    delete globalThis.__BITFUN_BOOTSTRAP_KEYBINDINGS__;
   });
 
   it('deduplicates concurrent reads for the same config path', async () => {
@@ -54,6 +55,136 @@ describe('ConfigManager', () => {
 
     await expect(Promise.all([first, second])).resolves.toEqual(['debug', 'debug']);
     expect(configApiMocks.getConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads optional configs without reporting expected missing paths as failures', async () => {
+    configApiMocks.getConfig
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+
+    await expect(configManager.getOptionalConfig('app.keybindings')).resolves.toBeUndefined();
+
+    expect(configApiMocks.getConfig).toHaveBeenCalledTimes(1);
+    expect(configApiMocks.getConfig).toHaveBeenCalledWith(
+      'app.keybindings',
+      { skipRetryOnNotFound: true }
+    );
+
+    await expect(configManager.getConfig('app.keybindings')).resolves.toBeUndefined();
+    expect(configApiMocks.getConfig).toHaveBeenCalledTimes(2);
+    expect(configApiMocks.getConfig).toHaveBeenLastCalledWith('app.keybindings');
+  });
+
+  it('uses bootstrap keybindings for the first optional startup read without a config IPC', async () => {
+    const storedKeybindings = {
+      version: 1,
+      bindings: {
+        'session.new': 'Ctrl+Shift+N',
+      },
+    };
+    globalThis.__BITFUN_BOOTSTRAP_KEYBINDINGS__ = storedKeybindings;
+    configApiMocks.getConfig.mockResolvedValueOnce({ version: 1, bindings: {} });
+
+    await expect(configManager.getOptionalConfig('app.keybindings')).resolves.toEqual(storedKeybindings);
+    expect(configApiMocks.getConfig).not.toHaveBeenCalled();
+    expect(Object.prototype.hasOwnProperty.call(globalThis, '__BITFUN_BOOTSTRAP_KEYBINDINGS__')).toBe(false);
+
+    await expect(configManager.getOptionalConfig('app.keybindings')).resolves.toEqual({ version: 1, bindings: {} });
+    expect(configApiMocks.getConfig).toHaveBeenCalledTimes(1);
+    expect(configApiMocks.getConfig).toHaveBeenCalledWith(
+      'app.keybindings',
+      { skipRetryOnNotFound: true }
+    );
+  });
+
+  it('does not reuse bootstrap keybindings after the config path is updated', async () => {
+    globalThis.__BITFUN_BOOTSTRAP_KEYBINDINGS__ = {
+      version: 1,
+      bindings: {
+        'session.new': 'Ctrl+Shift+N',
+      },
+    };
+    configApiMocks.setConfig.mockResolvedValueOnce(undefined);
+    configApiMocks.getConfig.mockResolvedValueOnce({
+      version: 1,
+      bindings: {
+        'session.new': 'Ctrl+Alt+N',
+      },
+    });
+
+    await configManager.setConfig('app.keybindings', {
+      version: 1,
+      bindings: {
+        'session.new': 'Ctrl+N',
+      },
+    });
+    configManager.clearCache();
+
+    await expect(configManager.getOptionalConfig('app.keybindings')).resolves.toEqual({
+      version: 1,
+      bindings: {
+        'session.new': 'Ctrl+Alt+N',
+      },
+    });
+    expect(configApiMocks.getConfig).toHaveBeenCalledTimes(1);
+    expect(configApiMocks.getConfig).toHaveBeenCalledWith(
+      'app.keybindings',
+      { skipRetryOnNotFound: true }
+    );
+  });
+
+  it('clears bootstrap keybindings with the config cache', async () => {
+    globalThis.__BITFUN_BOOTSTRAP_KEYBINDINGS__ = {
+      version: 1,
+      bindings: {
+        'session.new': 'Ctrl+Shift+N',
+      },
+    };
+    configApiMocks.getConfig.mockResolvedValueOnce({
+      version: 1,
+      bindings: {
+        'session.new': 'Ctrl+Alt+N',
+      },
+    });
+
+    configManager.clearCache();
+
+    await expect(configManager.getOptionalConfig('app.keybindings')).resolves.toEqual({
+      version: 1,
+      bindings: {
+        'session.new': 'Ctrl+Alt+N',
+      },
+    });
+    expect(configApiMocks.getConfig).toHaveBeenCalledTimes(1);
+    expect(configApiMocks.getConfig).toHaveBeenCalledWith(
+      'app.keybindings',
+      { skipRetryOnNotFound: true }
+    );
+  });
+
+  it('does not share optional in-flight reads with strict config reads', async () => {
+    const optionalRead = createDeferred<undefined>();
+    const strictRead = createDeferred<Record<string, string>>();
+    configApiMocks.getConfig
+      .mockReturnValueOnce(optionalRead.promise)
+      .mockReturnValueOnce(strictRead.promise);
+
+    const optionalPromise = configManager.getOptionalConfig('app.keybindings');
+    const strictPromise = configManager.getConfig('app.keybindings');
+
+    expect(configApiMocks.getConfig).toHaveBeenCalledTimes(2);
+    expect(configApiMocks.getConfig).toHaveBeenNthCalledWith(
+      1,
+      'app.keybindings',
+      { skipRetryOnNotFound: true }
+    );
+    expect(configApiMocks.getConfig).toHaveBeenNthCalledWith(2, 'app.keybindings');
+
+    optionalRead.resolve(undefined);
+    strictRead.resolve({ 'session.new': 'Ctrl+N' });
+
+    await expect(optionalPromise).resolves.toBeUndefined();
+    await expect(strictPromise).resolves.toEqual({ 'session.new': 'Ctrl+N' });
   });
 
   it('batches cold multi-path reads and caches the returned configs', async () => {

--- a/src/web-ui/src/infrastructure/config/services/ConfigManager.ts
+++ b/src/web-ui/src/infrastructure/config/services/ConfigManager.ts
@@ -13,6 +13,12 @@ import { extractProviderSegmentFromBaseUrl, matchProviderCatalogItemByBaseUrl, n
 const log = createLogger('ConfigManager');
 const PROVIDER_INSTANCE_METADATA_KEY = 'provider_instance_id';
 
+declare global {
+  // Injected by the desktop webview initialization script before the frontend
+  // bundle runs. It avoids a startup-window IPC for the initial shortcut load.
+  var __BITFUN_BOOTSTRAP_KEYBINDINGS__: unknown | undefined;
+}
+
 function legacyProviderInstanceId(seed: string): string {
   let hash = 2166136261;
   for (let i = 0; i < seed.length; i += 1) {
@@ -118,8 +124,42 @@ class ConfigManagerImpl implements IConfigManager {
 
   
 
-  private getReadKey(path?: string): string {
-    return path ?? '<root>';
+  private getReadKey(path?: string, mode: 'normal' | 'optional' = 'normal'): string {
+    return `${mode}:${path ?? '<root>'}`;
+  }
+
+  private clearBootstrapOptionalConfigs(): void {
+    delete globalThis.__BITFUN_BOOTSTRAP_KEYBINDINGS__;
+  }
+
+  private deleteInFlightReadsForPath(path?: string): void {
+    this.inFlightReads.delete(this.getReadKey(path));
+    if (path) {
+      this.inFlightReads.delete(this.getReadKey(path, 'optional'));
+      if (path === 'app.keybindings') {
+        this.clearBootstrapOptionalConfigs();
+      }
+    }
+  }
+
+  private consumeBootstrapOptionalConfig<T = any>(path: string): {
+    available: boolean;
+    value: T | undefined;
+  } {
+    if (path !== 'app.keybindings') {
+      return { available: false, value: undefined };
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(globalThis, '__BITFUN_BOOTSTRAP_KEYBINDINGS__')) {
+      return { available: false, value: undefined };
+    }
+
+    const value = globalThis.__BITFUN_BOOTSTRAP_KEYBINDINGS__;
+    delete globalThis.__BITFUN_BOOTSTRAP_KEYBINDINGS__;
+    return {
+      available: true,
+      value: value == null ? undefined : value as T,
+    };
   }
 
   private async readConfig<T = any>(path?: string): Promise<T> {
@@ -133,6 +173,15 @@ class ConfigManagerImpl implements IConfigManager {
     }
 
     return resolvedConfig as T;
+  }
+
+  private async readOptionalConfig<T = any>(path: string): Promise<T | undefined> {
+    const config = await configAPI.getConfig(path, { skipRetryOnNotFound: true });
+    const resolvedConfig = path === 'ai.models'
+      ? await this.migrateLegacyAiModelsIfNeeded(config)
+      : config;
+
+    return resolvedConfig as T | undefined;
   }
 
   private async readConfigs(paths: string[]): Promise<Record<string, unknown>> {
@@ -206,6 +255,38 @@ class ConfigManagerImpl implements IConfigManager {
       if (path === 'ai.default_models') {
         return {} as T;
       }
+      throw error;
+    }
+  }
+
+  async getOptionalConfig<T = any>(path: string): Promise<T | undefined> {
+    try {
+      if (this.configCache.has(path)) {
+        return this.configCache.get(path);
+      }
+
+      const bootstrap = this.consumeBootstrapOptionalConfig<T>(path);
+      if (bootstrap.available) {
+        return bootstrap.value;
+      }
+
+      const readKey = this.getReadKey(path, 'optional');
+      const existingRead = this.inFlightReads.get(readKey);
+      if (existingRead) {
+        return (await existingRead) as T | undefined;
+      }
+
+      const readPromise = this.readOptionalConfig<T>(path);
+      this.inFlightReads.set(readKey, readPromise);
+      try {
+        return await readPromise;
+      } finally {
+        if (this.inFlightReads.get(readKey) === readPromise) {
+          this.inFlightReads.delete(readKey);
+        }
+      }
+    } catch (error) {
+      log.error('Failed to get optional config', { path, error });
       throw error;
     }
   }
@@ -293,7 +374,7 @@ class ConfigManagerImpl implements IConfigManager {
   async setConfig<T = any>(path: string, value: T): Promise<void> {
     try {
       const oldValue = this.configCache.get(path);
-      this.inFlightReads.delete(this.getReadKey(path));
+      this.deleteInFlightReadsForPath(path);
       
       
       await configAPI.setConfig(path, value);
@@ -316,7 +397,7 @@ class ConfigManagerImpl implements IConfigManager {
       
       if (path) {
         this.configCache.delete(path);
-        this.inFlightReads.delete(this.getReadKey(path));
+        this.deleteInFlightReadsForPath(path);
       } else {
         this.configCache.clear();
         this.inFlightReads.clear();
@@ -359,6 +440,8 @@ class ConfigManagerImpl implements IConfigManager {
       
       
       this.configCache.clear();
+      this.inFlightReads.clear();
+      this.clearBootstrapOptionalConfigs();
     } catch (error) {
       log.error('Failed to import config', error);
       throw error;
@@ -378,6 +461,7 @@ class ConfigManagerImpl implements IConfigManager {
     try {
       this.configCache.clear();
       this.inFlightReads.clear();
+      this.clearBootstrapOptionalConfigs();
     } catch (error) {
       log.error('Failed to refresh cache', error);
     }
@@ -386,6 +470,7 @@ class ConfigManagerImpl implements IConfigManager {
   clearCache(): void {
     this.configCache.clear();
     this.inFlightReads.clear();
+    this.clearBootstrapOptionalConfigs();
   }
 
   

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -480,6 +480,7 @@ export interface WorkspaceConfig {
 
 export interface IConfigManager {
   getConfig<T = any>(path?: string): Promise<T>;
+  getOptionalConfig<T = any>(path: string): Promise<T | undefined>;
   getConfigs(paths: string[]): Promise<Record<string, unknown>>;
   setConfig<T = any>(path: string, value: T): Promise<void>;
   resetConfig(path?: string): Promise<void>;

--- a/src/web-ui/src/infrastructure/services/business/workspaceManager.test.ts
+++ b/src/web-ui/src/infrastructure/services/business/workspaceManager.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const globalStateMocks = vi.hoisted(() => ({
   initializeGlobalState: vi.fn(),
   cleanupInvalidWorkspaces: vi.fn(),
+  cleanupInvalidWorkspacesAndGetWorkspaceStateSnapshot: vi.fn(),
   getRecentWorkspaces: vi.fn(),
   getOpenedWorkspaces: vi.fn(),
   getCurrentWorkspace: vi.fn(),
@@ -43,6 +44,13 @@ vi.mock('@/shared/utils/startupTrace', () => ({
 function configureGlobalState(): void {
   globalStateMocks.initializeGlobalState.mockResolvedValue('initialized');
   globalStateMocks.cleanupInvalidWorkspaces.mockResolvedValue(0);
+  globalStateMocks.cleanupInvalidWorkspacesAndGetWorkspaceStateSnapshot.mockResolvedValue({
+    cleanupRemovedCount: 0,
+    recentWorkspaces: [],
+    openedWorkspaces: [],
+    currentWorkspace: null,
+    legacyRemoteWorkspace: null,
+  });
   globalStateMocks.getRecentWorkspaces.mockResolvedValue([]);
   globalStateMocks.getOpenedWorkspaces.mockResolvedValue([]);
   globalStateMocks.getCurrentWorkspace.mockResolvedValue(null);
@@ -73,11 +81,44 @@ describe('WorkspaceManager startup initialization', () => {
 
     expect(listenMock).toHaveBeenCalledWith('workspace-identity-changed', expect.any(Function));
     expect(globalStateMocks.initializeGlobalState).toHaveBeenCalledTimes(1);
-    expect(globalStateMocks.getCurrentWorkspace).not.toHaveBeenCalled();
+    expect(globalStateMocks.cleanupInvalidWorkspacesAndGetWorkspaceStateSnapshot).not.toHaveBeenCalled();
 
     resolveListener?.(() => undefined);
     await initializePromise;
 
-    expect(globalStateMocks.getCurrentWorkspace).toHaveBeenCalledTimes(1);
+    expect(globalStateMocks.cleanupInvalidWorkspacesAndGetWorkspaceStateSnapshot).toHaveBeenCalledTimes(1);
+    expect(globalStateMocks.cleanupInvalidWorkspaces).not.toHaveBeenCalled();
+    expect(globalStateMocks.getCurrentWorkspace).not.toHaveBeenCalled();
+    expect(globalStateMocks.getRecentWorkspaces).not.toHaveBeenCalled();
+    expect(globalStateMocks.getOpenedWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it('stores the startup legacy remote workspace snapshot for one reconnect pass', async () => {
+    const legacyRemoteWorkspace = {
+      connectionId: 'conn-1',
+      connectionName: 'Remote',
+      remotePath: '/repo',
+      sshHost: 'devbox',
+    };
+    globalStateMocks.cleanupInvalidWorkspacesAndGetWorkspaceStateSnapshot.mockResolvedValue({
+      cleanupRemovedCount: 0,
+      recentWorkspaces: [],
+      openedWorkspaces: [],
+      currentWorkspace: null,
+      legacyRemoteWorkspace,
+    });
+    listenMock.mockResolvedValue(() => undefined);
+    const manager = await getFreshWorkspaceManager();
+
+    await manager.initialize();
+
+    expect(manager.consumeStartupLegacyRemoteWorkspaceSnapshot()).toEqual({
+      available: true,
+      workspace: legacyRemoteWorkspace,
+    });
+    expect(manager.consumeStartupLegacyRemoteWorkspaceSnapshot()).toEqual({
+      available: false,
+      workspace: null,
+    });
   });
 });

--- a/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
+++ b/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
@@ -1,7 +1,10 @@
  
 
-import {
+import type {
+  RemoteWorkspaceSnapshot,
   WorkspaceInfo,
+} from '../../../shared/types';
+import {
   WorkspaceKind,
   globalStateAPI,
   isRemoteWorkspace,
@@ -73,6 +76,9 @@ class WorkspaceManager {
   private isInitialized = false;
   private isInitializing = false;
   private identityEventListening = false;
+  private startupLegacyRemoteWorkspaceSnapshotAvailable = false;
+  private startupLegacyRemoteWorkspaceSnapshotConsumed = false;
+  private startupLegacyRemoteWorkspace: RemoteWorkspaceSnapshot | null = null;
 
   private constructor() {
     this.state = {
@@ -104,6 +110,24 @@ class WorkspaceManager {
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);
+    };
+  }
+
+  public consumeStartupLegacyRemoteWorkspaceSnapshot(): {
+    available: boolean;
+    workspace: RemoteWorkspaceSnapshot | null;
+  } {
+    if (
+      !this.startupLegacyRemoteWorkspaceSnapshotAvailable ||
+      this.startupLegacyRemoteWorkspaceSnapshotConsumed
+    ) {
+      return { available: false, workspace: null };
+    }
+
+    this.startupLegacyRemoteWorkspaceSnapshotConsumed = true;
+    return {
+      available: true,
+      workspace: this.startupLegacyRemoteWorkspace,
     };
   }
 
@@ -416,16 +440,25 @@ class WorkspaceManager {
       await identityListenerReady;
 
       const cleanupStartedAt = markWorkspaceStartupStepStart('cleanup_invalid_workspaces');
-      await globalStateAPI.cleanupInvalidWorkspaces();
-      markWorkspaceStartupStepEnd('cleanup_invalid_workspaces', cleanupStartedAt);
+      const {
+        cleanupRemovedCount,
+        recentWorkspaces,
+        openedWorkspaces,
+        currentWorkspace,
+        legacyRemoteWorkspace,
+      } = await globalStateAPI.cleanupInvalidWorkspacesAndGetWorkspaceStateSnapshot();
+      this.startupLegacyRemoteWorkspace = legacyRemoteWorkspace;
+      this.startupLegacyRemoteWorkspaceSnapshotAvailable = true;
+      this.startupLegacyRemoteWorkspaceSnapshotConsumed = false;
+      markWorkspaceStartupStepEnd('cleanup_invalid_workspaces', cleanupStartedAt, {
+        removedCount: cleanupRemovedCount,
+        includesWorkspaceStateSnapshot: true,
+        includesLegacyRemoteWorkspace: true,
+      });
 
       const fetchStateStartedAt = markWorkspaceStartupStepStart('fetch_workspace_state');
-      const [recentWorkspaces, openedWorkspaces, currentWorkspace] = await Promise.all([
-        globalStateAPI.getRecentWorkspaces(),
-        globalStateAPI.getOpenedWorkspaces(),
-        globalStateAPI.getCurrentWorkspace(),
-      ]);
       markWorkspaceStartupStepEnd('fetch_workspace_state', fetchStateStartedAt, {
+        source: 'startup_cleanup_snapshot',
         recentCount: recentWorkspaces.length,
         openedCount: openedWorkspaces.length,
         hasCurrentWorkspace: currentWorkspace !== null,

--- a/src/web-ui/src/main.tsx
+++ b/src/web-ui/src/main.tsx
@@ -4,6 +4,7 @@ import AgentCompanionDesktopPet from "./app/components/AgentCompanionDesktopPet/
 import AppErrorBoundary from "./app/components/AppErrorBoundary";
 import { STARTUP_OVERLAY_HIDDEN_EVENT } from "./app/startup/startupSignals";
 import { WorkspaceProvider } from "./infrastructure/contexts/WorkspaceProvider";
+import { I18nProvider } from "./infrastructure/i18n/providers/I18nProvider";
 import "./app/styles/index.scss";
 
 // Font: Noto Sans SC is loaded via a <link> tag in index.html.
@@ -317,18 +318,12 @@ async function startApplication(): Promise<void> {
     log.error('Failed to initialize BitFun (pre-render)', error);
   }
 
-  // I18n Provider.
-  const i18nProviderImportResult = await traceStartupStep(
-    'startup_step',
-    'load_i18n_provider',
-    () => measureAsyncAndLog(
-      log,
-      'Startup step completed',
-      () => import('./infrastructure/i18n'),
-      { data: { step: 'loadI18nProvider' } }
-    )
-  );
-  const { I18nProvider } = i18nProviderImportResult.value;
+  startupTrace.markPhase('startup_step_start', { step: 'load_i18n_provider', mode: 'static' });
+  startupTrace.markPhase('startup_step_end', {
+    step: 'load_i18n_provider',
+    durationMs: 0,
+    mode: 'static',
+  });
   const isAgentCompanionWindow = new URLSearchParams(window.location.search)
     .get('bitfunWindow') === 'agent-companion';
 

--- a/src/web-ui/src/shared/types/global-state.ts
+++ b/src/web-ui/src/shared/types/global-state.ts
@@ -6,6 +6,7 @@ import { workspaceAPI } from '@/infrastructure/api';
 import type {
   ApplicationState as APIApplicationState,
   AppStatus as APIAppStatus,
+  RemoteWorkspaceSnapshot as APIRemoteWorkspaceSnapshot,
   WorkspaceInfo as APIWorkspaceInfo,
 } from '@/infrastructure/api/service-api/GlobalAPI';
 import { createLogger } from '../utils/logger';
@@ -109,6 +110,13 @@ export interface WorkspaceInfo {
    * Logical workspace host for stable scoping: `{sshHost}:{rootPath}`.
    * Local / assistant workspaces use `localhost` (from backend); remote uses SSH config host.
    */
+  sshHost?: string;
+}
+
+export interface RemoteWorkspaceSnapshot {
+  connectionId: string;
+  connectionName: string;
+  remotePath: string;
   sshHost?: string;
 }
 
@@ -216,6 +224,13 @@ export interface GlobalStateAPI {
   getCurrentWorkspace(): Promise<WorkspaceInfo | null>;
   getOpenedWorkspaces(): Promise<WorkspaceInfo[]>;
   getRecentWorkspaces(): Promise<WorkspaceInfo[]>;
+  cleanupInvalidWorkspacesAndGetWorkspaceStateSnapshot(): Promise<{
+    cleanupRemovedCount: number;
+    currentWorkspace: WorkspaceInfo | null;
+    recentWorkspaces: WorkspaceInfo[];
+    openedWorkspaces: WorkspaceInfo[];
+    legacyRemoteWorkspace: RemoteWorkspaceSnapshot | null;
+  }>;
   removeWorkspaceFromRecent(workspaceId: string): Promise<void>;
   cleanupInvalidWorkspaces(): Promise<number>;
   scanWorkspaceInfo(workspacePath: string): Promise<WorkspaceInfo | null>;
@@ -345,6 +360,21 @@ function mapWorkspaceInfo(workspace: APIWorkspaceInfo): WorkspaceInfo {
   };
 }
 
+function mapRemoteWorkspaceSnapshot(
+  workspace: APIRemoteWorkspaceSnapshot | null | undefined
+): RemoteWorkspaceSnapshot | null {
+  if (!workspace) {
+    return null;
+  }
+
+  return {
+    connectionId: workspace.connectionId,
+    connectionName: workspace.connectionName,
+    remotePath: workspace.remotePath,
+    sshHost: workspace.sshHost?.trim() || undefined,
+  };
+}
+
 function mapApplicationState(state: APIApplicationState): ApplicationState {
   const now = new Date().toISOString();
   return {
@@ -455,6 +485,28 @@ export function createGlobalStateAPI(): GlobalStateAPI {
       const workspaces = (await globalAPI.getRecentWorkspaces()).map(mapWorkspaceInfo);
       logger.debug('getRecentWorkspaces returned', summarizeWorkspacesForLog(workspaces));
       return workspaces;
+    },
+
+    async cleanupInvalidWorkspacesAndGetWorkspaceStateSnapshot(): Promise<{
+      cleanupRemovedCount: number;
+      currentWorkspace: WorkspaceInfo | null;
+      recentWorkspaces: WorkspaceInfo[];
+      openedWorkspaces: WorkspaceInfo[];
+      legacyRemoteWorkspace: RemoteWorkspaceSnapshot | null;
+    }> {
+      const snapshot = await globalAPI.cleanupInvalidWorkspacesAndGetWorkspaceStateSnapshot();
+      const recentWorkspaces = snapshot.recentWorkspaces.map(mapWorkspaceInfo);
+      logger.debug(
+        'cleanupInvalidWorkspacesAndGetWorkspaceStateSnapshot returned',
+        summarizeWorkspacesForLog(recentWorkspaces)
+      );
+      return {
+        cleanupRemovedCount: snapshot.cleanupRemovedCount,
+        currentWorkspace: snapshot.currentWorkspace ? mapWorkspaceInfo(snapshot.currentWorkspace) : null,
+        recentWorkspaces,
+        openedWorkspaces: snapshot.openedWorkspaces.map(mapWorkspaceInfo),
+        legacyRemoteWorkspace: mapRemoteWorkspaceSnapshot(snapshot.legacyRemoteWorkspace),
+      };
     },
 
     async removeWorkspaceFromRecent(workspaceId: string): Promise<void> {

--- a/tests/e2e/helpers/performance-trace.ts
+++ b/tests/e2e/helpers/performance-trace.ts
@@ -168,12 +168,14 @@ export type StartupPerfBreakdown = {
     beforeInteractive: {
       matchedCount: number;
       totalFrontendDurationMs: number;
+      totalFrontendDurationUntilInteractiveMs: number;
       totalBackendDurationMs: number;
       totalEstimatedQueueOrBridgeMs: number;
       byCommand: Array<{
         command: string;
         count: number;
         frontendDurationMs: number;
+        frontendDurationUntilInteractiveMs: number;
         backendDurationMs: number;
         estimatedQueueOrBridgeMs: number;
       }>;
@@ -181,7 +183,9 @@ export type StartupPerfBreakdown = {
         command: string;
         target?: string;
         startedAtMs?: number;
+        endedAtMs?: number;
         frontendDurationMs: number;
+        frontendDurationUntilInteractiveMs?: number;
         backendDurationMs?: number;
         estimatedQueueOrBridgeMs?: number;
         transportDurationMs?: number;
@@ -194,13 +198,16 @@ export type StartupPerfBreakdown = {
   apiBeforeInteractive: {
     count: number;
     totalDurationMs: number;
+    totalDurationUntilInteractiveMs: number;
     maxDurationMs?: number;
     byCommand: StartupTraceCommandAggregate[];
     slowCalls: Array<{
       command: string;
       target?: string;
       startedAtMs?: number;
+      endedAtMs?: number;
       durationMs: number;
+      durationUntilInteractiveMs?: number;
       outcome: 'success' | 'failure';
       remote: boolean;
     }>;
@@ -211,7 +218,9 @@ export interface StartupApiCommandSegment {
   command: string;
   target?: string;
   startedAtMs?: number;
+  endedAtMs?: number;
   frontendDurationMs: number;
+  frontendDurationUntilInteractiveMs?: number;
   backendDurationMs?: number;
   estimatedQueueOrBridgeMs?: number;
   transportDurationMs?: number;
@@ -362,6 +371,18 @@ function aggregateApiCalls(calls: StartupTraceApiCallRecord[]): StartupTraceComm
     .sort((left, right) => right.totalDurationMs - left.totalDurationMs);
 }
 
+function durationUntilCutoffMs(
+  startedAtMs: number | undefined,
+  durationMs: number,
+  cutoffMs: number | undefined,
+): number {
+  if (startedAtMs === undefined || cutoffMs === undefined) {
+    return durationMs;
+  }
+  const endMs = startedAtMs + durationMs;
+  return Math.max(0, Math.min(endMs, cutoffMs) - startedAtMs);
+}
+
 export function summarizeApiCommandSegments(
   snapshot: StartupTraceSnapshot,
   frontendCalls: StartupTraceApiCallRecord[] = snapshot.api.calls ?? [],
@@ -394,6 +415,7 @@ function matchBackendCommandSegments(
       command: call.command,
       target: call.target,
       startedAtMs: round(call.startedAtMs),
+      endedAtMs: round(call.endedAtMs),
       frontendDurationMs: round(call.durationMs) ?? 0,
       backendDurationMs: round(backendDurationMs),
       estimatedQueueOrBridgeMs: round(
@@ -414,12 +436,20 @@ function matchBackendCommandSegments(
 function summarizeBackendCommandOverlap(
   frontendCalls: StartupTraceApiCallRecord[],
   nativeEvents: StartupTraceNativeEvent[],
+  cutoffMs?: number,
 ) {
-  const matched = matchBackendCommandSegments(frontendCalls, nativeEvents);
+  const matched = matchBackendCommandSegments(frontendCalls, nativeEvents)
+    .map(call => ({
+      ...call,
+      frontendDurationUntilInteractiveMs: round(
+        durationUntilCutoffMs(call.startedAtMs, call.frontendDurationMs, cutoffMs)
+      ),
+    }));
   const byCommand = new Map<string, {
     command: string;
     count: number;
     frontendDurationMs: number;
+    frontendDurationUntilInteractiveMs: number;
     backendDurationMs: number;
     estimatedQueueOrBridgeMs: number;
   }>();
@@ -428,11 +458,15 @@ function summarizeBackendCommandOverlap(
       command: call.command,
       count: 0,
       frontendDurationMs: 0,
+      frontendDurationUntilInteractiveMs: 0,
       backendDurationMs: 0,
       estimatedQueueOrBridgeMs: 0,
     };
     existing.count += 1;
     existing.frontendDurationMs = round((existing.frontendDurationMs ?? 0) + call.frontendDurationMs) ?? 0;
+    existing.frontendDurationUntilInteractiveMs = round(
+      (existing.frontendDurationUntilInteractiveMs ?? 0) + (call.frontendDurationUntilInteractiveMs ?? 0)
+    ) ?? 0;
     existing.backendDurationMs = round((existing.backendDurationMs ?? 0) + (call.backendDurationMs ?? 0)) ?? 0;
     existing.estimatedQueueOrBridgeMs = round(
       (existing.estimatedQueueOrBridgeMs ?? 0) + (call.estimatedQueueOrBridgeMs ?? 0)
@@ -444,6 +478,9 @@ function summarizeBackendCommandOverlap(
     matchedCount: matched.filter(call => call.backendDurationMs !== undefined).length,
     totalFrontendDurationMs: round(
       matched.reduce((total, call) => total + call.frontendDurationMs, 0)
+    ) ?? 0,
+    totalFrontendDurationUntilInteractiveMs: round(
+      matched.reduce((total, call) => total + (call.frontendDurationUntilInteractiveMs ?? call.frontendDurationMs), 0)
     ) ?? 0,
     totalBackendDurationMs: round(
       matched.reduce((total, call) => total + (call.backendDurationMs ?? 0), 0)
@@ -534,6 +571,7 @@ export function summarizeStartupBreakdown(snapshot: StartupTraceSnapshot): Start
   const backendBeforeInteractive = summarizeBackendCommandOverlap(
     apiBeforeInteractive,
     snapshot.native?.events ?? [],
+    interactive,
   );
   const slowApiCalls = [...apiBeforeInteractive]
     .sort((left, right) => right.durationMs - left.durationMs)
@@ -542,7 +580,11 @@ export function summarizeStartupBreakdown(snapshot: StartupTraceSnapshot): Start
       command: call.command,
       target: call.target,
       startedAtMs: round(call.startedAtMs),
+      endedAtMs: round(call.endedAtMs),
       durationMs: round(call.durationMs) ?? 0,
+      durationUntilInteractiveMs: round(
+        durationUntilCutoffMs(call.startedAtMs, call.durationMs, interactive)
+      ),
       outcome: call.outcome,
       remote: call.remote,
     }));
@@ -650,6 +692,12 @@ export function summarizeStartupBreakdown(snapshot: StartupTraceSnapshot): Start
     apiBeforeInteractive: {
       count: apiBeforeInteractive.length,
       totalDurationMs: round(apiBeforeInteractive.reduce((total, call) => total + call.durationMs, 0)) ?? 0,
+      totalDurationUntilInteractiveMs: round(
+        apiBeforeInteractive.reduce(
+          (total, call) => total + durationUntilCutoffMs(call.startedAtMs, call.durationMs, interactive),
+          0,
+        )
+      ) ?? 0,
       maxDurationMs: apiBeforeInteractive.length > 0
         ? round(Math.max(...apiBeforeInteractive.map(call => call.durationMs)))
         : undefined,


### PR DESCRIPTION
﻿## Summary

- Collapse startup workspace cleanup, current/recent/opened workspace reads, and legacy remote workspace restore into one startup snapshot command.
- Bootstrap startup keybindings from the native startup config so the first window no longer needs the expected-missing `app.keybindings` IPC.
- Import the required `I18nProvider` on the static startup path and keep the trace step as a static zero-duration marker.
- Tighten perf trace attribution for API calls that start before interactive but complete after it, so queue/bridge cost is not over-counted as fully blocking startup.

## Performance Data

Measured with Windows `release-fast` E2E. Baseline is the pre-change release-fast sample set from 2026-06-15T05:18/05:19. Current data uses the final rebuilt binary plus the adjacent post-change samples from 2026-06-15T07:57-08:09. Values are milliseconds unless noted.

| Scenario | Before | Current | Delta | Notes |
| --- | ---: | ---: | ---: | --- |
| Cold startup to shell interactive, median | 677.8 | 811.4 | +133.6 | Not a stable win. Current range is 670.5-1067.8 and is dominated by native WebView build variance. |
| Native WebView build, median | 635.0 | 696.0 | +61.0 | Current range is 594.0-1255.0; this remains the main cold-start risk. |
| Frontend first script to render scheduled, median | 120.2 | 9.7 | -110.5 | Static i18n provider removes the async startup waterfall. |
| i18n provider startup step, median | 112.0 | 0.0 | -112.0 | Now traced as a static import marker. |
| Startup `get_config` calls before interactive, median count | 1 | 0 | -1 call | Startup keybindings use bootstrap data or fall back to IPC when too large/missing. |
| Workspace startup initialize, median | 66.3 | 64.0 | -2.3 | Workspace state reads are folded into the cleanup snapshot command. |
| First long session latest content usable, median | 196.6 | 223.9 | +27.3 | Not a stable win. Final rebuilt sample was 164.1, but current sample range is 164.1-291.5. |
| First long session full hydrate, median | 523.3 | 544.3 | +21.0 | Needs a separate session-render scheduling follow-up before claiming improvement. |
| Warm reopen latest content usable, median | 129.5 | 134.4 | +4.9 | Small regression/noise range, not counted as a gain. |
| Rapid switch target latest usable from first click, median | 466.1 | 440.9 | -25.2 | Target session becomes usable sooner in the rapid-switch scenario. |
| Rapid switch target click to latest usable, median | 149.0 | 122.4 | -26.6 | Measures target click only, excluding earlier queued clicks. |
| Post-visible loading/blank/scroll-jump events | 0 | 0 | 0 | Guarded by the performance E2E visual-state summary. |

## Risk / Product Impact

- This PR should not be interpreted as a stable cold-start optimization yet. The frontend startup path is shorter, but end-to-end cold startup is still dominated by native WebView build variance.
- First long-session open remains noisy and can regress in median across this sample set. The changed code does not alter long-session rendering, but this needs a dedicated follow-up before claiming session-open gains.
- Keybindings bootstrap is capped at 64KB. Larger configs fall back to the existing IPC path to avoid inflating the WebView init script.
- Remote legacy workspace restore keeps a fallback to the existing `sshApi.getWorkspaceInfo()` path when the startup snapshot is unavailable.
- No intended changes to ACP behavior, remote compatibility, session rendering, or user-facing feature semantics.

## Validation

- `pnpm --dir src/web-ui run test:run src/infrastructure/api/adapters/tauri-adapter.test.ts src/app/startup/startupPerformanceContract.test.ts src/infrastructure/config/services/ConfigManager.test.ts src/infrastructure/services/business/workspaceManager.test.ts src/features/ssh-remote/SSHRemoteProvider.test.tsx`
- `pnpm run type-check:web`
- `cargo check -p bitfun-desktop`
- `git diff --staged --check`
- `pnpm run desktop:build:release-fast`
- `pnpm run e2e:test:perf:release-fast` (final rebuilt sample plus additional post-change samples collected)
