### PR TITLE
fix(flow-chat): keep thinking output tail-follow user intent stable

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/ModelThinkingDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ModelThinkingDisplay.tsx
@@ -32,6 +32,10 @@ export const ModelThinkingDisplay: React.FC<ModelThinkingDisplayProps> = ({
   const { content, isStreaming, status } = thinkingItem;
   const wrapperRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const shouldFollowTailRef = useRef(true);
+  const tailFollowPauseVersionRef = useRef(0);
+  const tailFollowUserPauseUntilMsRef = useRef(0);
+  const touchScrollStartYRef = useRef<number | null>(null);
 
   const isActive = isStreaming || status === 'streaming';
   const displayContent = useTypewriter(content, isActive);
@@ -70,20 +74,83 @@ export const ModelThinkingDisplay: React.FC<ModelThinkingDisplayProps> = ({
     }
   }, [applyExpandedState, isExpanded, shouldDefaultExpanded]);
 
+  const renderedContent = isActive ? displayContent : content;
+
+  const getThinkingScrollGap = useCallback((el: HTMLElement) => (
+    el.scrollHeight - el.scrollTop - el.clientHeight
+  ), []);
+
+  const scrollThinkingToBottom = useCallback((expectedPauseVersion?: number) => {
+    const el = contentRef.current;
+    if (!el) return;
+    if (
+      expectedPauseVersion !== undefined &&
+      expectedPauseVersion !== tailFollowPauseVersionRef.current
+    ) {
+      return;
+    }
+    if (!shouldFollowTailRef.current) {
+      return;
+    }
+
+    el.scrollTop = el.scrollHeight;
+    shouldFollowTailRef.current = true;
+  }, []);
+
+  const pauseTailFollowForUserScroll = useCallback(() => {
+    shouldFollowTailRef.current = false;
+    tailFollowPauseVersionRef.current += 1;
+    tailFollowUserPauseUntilMsRef.current = performance.now() + 700;
+  }, []);
+
   // Auto-scroll to bottom while content grows.
   useEffect(() => {
     if (isExpanded && contentRef.current) {
       const el = contentRef.current;
-      const gap = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (gap < 80) {
+      const gap = getThinkingScrollGap(el);
+      const wasNearBottom = gap < 80;
+      const userPauseActive = performance.now() <= tailFollowUserPauseUntilMsRef.current;
+      if (wasNearBottom && !userPauseActive) {
+        shouldFollowTailRef.current = true;
+      }
+      const shouldScroll = shouldFollowTailRef.current || (wasNearBottom && !userPauseActive);
+      if (shouldScroll) {
+        const scheduledPauseVersion = tailFollowPauseVersionRef.current;
         requestAnimationFrame(() => {
-          if (contentRef.current) {
-            contentRef.current.scrollTop = contentRef.current.scrollHeight;
-          }
+          scrollThinkingToBottom(scheduledPauseVersion);
         });
       }
     }
-  }, [displayContent, isExpanded]);
+  }, [
+    displayContent,
+    getThinkingScrollGap,
+    isExpanded,
+    scrollThinkingToBottom,
+  ]);
+
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el || !isExpanded) {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      if (isActive && shouldFollowTailRef.current) {
+        const scheduledPauseVersion = tailFollowPauseVersionRef.current;
+        requestAnimationFrame(() => {
+          scrollThinkingToBottom(scheduledPauseVersion);
+        });
+      }
+    });
+
+    observer.observe(el);
+    const markdownEl = el.querySelector('.thinking-markdown');
+    if (markdownEl instanceof HTMLElement) {
+      observer.observe(markdownEl);
+    }
+
+    return () => observer.disconnect();
+  }, [isActive, isExpanded, scrollThinkingToBottom]);
 
   // Scroll-state detection for fade gradients.
   const [scrollState, setScrollState] = useState({ hasScroll: false, atTop: true, atBottom: true });
@@ -91,12 +158,24 @@ export const ModelThinkingDisplay: React.FC<ModelThinkingDisplayProps> = ({
   const checkScrollState = useCallback(() => {
     const el = contentRef.current;
     if (!el) return;
-    setScrollState({
+    const gap = getThinkingScrollGap(el);
+    const nextScrollState = {
       hasScroll: el.scrollHeight > el.clientHeight,
       atTop: el.scrollTop <= 5,
-      atBottom: el.scrollTop + el.clientHeight >= el.scrollHeight - 5,
+      atBottom: gap <= 5,
+    };
+    if (
+      nextScrollState.atBottom &&
+      performance.now() > tailFollowUserPauseUntilMsRef.current
+    ) {
+      shouldFollowTailRef.current = true;
+    }
+    setScrollState({
+      hasScroll: nextScrollState.hasScroll,
+      atTop: nextScrollState.atTop,
+      atBottom: nextScrollState.atBottom,
     });
-  }, []);
+  }, [getThinkingScrollGap]);
 
   useEffect(() => {
     if (isExpanded) {
@@ -116,6 +195,44 @@ export const ModelThinkingDisplay: React.FC<ModelThinkingDisplayProps> = ({
     applyExpandedState(isExpanded, nextExpanded, setIsExpanded);
   };
 
+  const handleContentWheelCapture = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
+    if (event.deltaY < 0) {
+      pauseTailFollowForUserScroll();
+    }
+  }, [pauseTailFollowForUserScroll]);
+
+  const handleContentTouchStart = useCallback((event: React.TouchEvent<HTMLDivElement>) => {
+    touchScrollStartYRef.current = event.touches[0]?.clientY ?? null;
+  }, []);
+
+  const handleContentTouchMove = useCallback((event: React.TouchEvent<HTMLDivElement>) => {
+    const startY = touchScrollStartYRef.current;
+    const currentY = event.touches[0]?.clientY;
+    if (startY === null || currentY === undefined) {
+      return;
+    }
+
+    if (currentY - startY > 6) {
+      touchScrollStartYRef.current = currentY;
+      pauseTailFollowForUserScroll();
+    }
+  }, [pauseTailFollowForUserScroll]);
+
+  const handleContentTouchEnd = useCallback(() => {
+    touchScrollStartYRef.current = null;
+  }, []);
+
+  const handleContentKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      event.key === 'ArrowUp' ||
+      event.key === 'PageUp' ||
+      event.key === 'Home' ||
+      (event.key === ' ' && event.shiftKey)
+    ) {
+      pauseTailFollowForUserScroll();
+    }
+  }, [pauseTailFollowForUserScroll]);
+
   const headerLabel = (isExpanded
     ? (isActive ? t('toolCards.think.thinking') : t('toolCards.think.thinkingProcess'))
     : contentLengthText).replace(/ /g, '\u00A0');
@@ -124,8 +241,6 @@ export const ModelThinkingDisplay: React.FC<ModelThinkingDisplayProps> = ({
     'flow-thinking-item',
     isExpanded ? 'expanded' : 'collapsed',
   ].filter(Boolean).join(' ');
-
-  const renderedContent = isActive ? displayContent : content;
 
   return (
     <div ref={wrapperRef} data-tool-card-id={thinkingItem.id} className={wrapperClassName}>
@@ -143,6 +258,11 @@ export const ModelThinkingDisplay: React.FC<ModelThinkingDisplayProps> = ({
             ref={contentRef}
             className={`thinking-content expanded`}
             onScroll={checkScrollState}
+            onWheelCapture={handleContentWheelCapture}
+            onTouchStart={handleContentTouchStart}
+            onTouchMove={handleContentTouchMove}
+            onTouchEnd={handleContentTouchEnd}
+            onKeyDown={handleContentKeyDown}
           >
             <Markdown
               content={renderedContent}


### PR DESCRIPTION
## Summary

Fix FlowChat thinking-panel auto-scroll so long streaming thinking content continues following the latest output through Markdown/code-block layout changes, while still allowing users to scroll upward to inspect history.

Fixes #

## Type and Areas

Type:

bug fix / UI/UX

Areas:

web UI, FlowChat

## Motivation / Impact

When a long thinking message streamed into a code block, the thinking panel’s internal scroller could stop following the latest output. The layout reflow made the panel think the user had moved away from the bottom.

This change tracks tail-follow intent explicitly inside `ModelThinkingDisplay`, keeps following during streaming content and code-block height changes, and pauses follow when the user scrolls upward via wheel, touch, or keyboard. This preserves live-output behavior without making historical review hard.

## Verification

- `pnpm run type-check:web` passed.
- Manually reproduced long thinking output with code blocks and confirmed the thinking panel follows latest output.
- Manually confirmed upward scrolling can enter history-viewing state without being immediately pulled back to the bottom.

## Reviewer Notes

The fix is scoped to the thinking panel’s internal scroll container. It does not change outer FlowChat list scrolling.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.