### PR TITLE
perf(web-ui): narrow flow chat session restore imports

### DIFF
--- a/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
+++ b/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
@@ -9,6 +9,13 @@ function readSource(relativePath: string): string {
   return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
 }
 
+function dynamicImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(/import\(\s*(['"])(.*?)\1\s*\)/g),
+    match => match[2]
+  );
+}
+
 describe('startup performance contract', () => {
   it('keeps the pre-React startup fallback logo-only', () => {
     const source = readSource('../../../index.html');
@@ -525,11 +532,22 @@ describe('startup performance contract', () => {
 
   it('keeps startup session metadata paging on the narrow SessionAPI entrypoint', () => {
     const source = readSource('../../flow_chat/store/FlowChatStore.ts');
+    const imports = dynamicImportSpecifiers(source);
 
     expect(source).toContain("import('@/infrastructure/api/service-api/SessionAPI')");
-    expect(source).not.toMatch(
-      /const\s+\{\s*sessionAPI\s*\}\s*=\s*await\s+import\(['"]@\/infrastructure\/api['"]\)/
+    expect(imports).not.toContain('@/infrastructure/api');
+  });
+
+  it('keeps historical session restore on the narrow AgentAPI entrypoint', () => {
+    const source = readSource('../../flow_chat/store/FlowChatStore.ts');
+    const imports = dynamicImportSpecifiers(source);
+    const agentApiDynamicImports = imports.filter(specifier => specifier.endsWith('/AgentAPI'));
+
+    expect(agentApiDynamicImports.length).toBeGreaterThan(0);
+    expect(new Set(agentApiDynamicImports)).toEqual(
+      new Set(['@/infrastructure/api/service-api/AgentAPI'])
     );
+    expect(imports).not.toContain('@/infrastructure/api');
   });
 
   it('keeps Agent companion implementation modules out of the root startup bundle', () => {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -43,13 +43,6 @@ vi.mock('@/infrastructure/api', () => ({
     loadSessionTurns: apiMocks.loadSessionTurns,
     saveSessionTurn: apiMocks.saveSessionTurn,
   },
-  agentAPI: {
-    restoreSession: apiMocks.restoreSession,
-    get restoreSessionView() {
-      return apiMocks.restoreSessionView;
-    },
-    restoreSessionWithTurns: apiMocks.restoreSessionWithTurns,
-  },
 }));
 
 vi.mock('@/infrastructure/api/service-api/SessionAPI', () => ({
@@ -58,6 +51,16 @@ vi.mock('@/infrastructure/api/service-api/SessionAPI', () => ({
     listSessionsPage: apiMocks.listSessionsPage,
     loadSessionTurns: apiMocks.loadSessionTurns,
     saveSessionTurn: apiMocks.saveSessionTurn,
+  },
+}));
+
+vi.mock('@/infrastructure/api/service-api/AgentAPI', () => ({
+  agentAPI: {
+    restoreSession: apiMocks.restoreSession,
+    get restoreSessionView() {
+      return apiMocks.restoreSessionView;
+    },
+    restoreSessionWithTurns: apiMocks.restoreSessionWithTurns,
   },
 }));
 

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -1019,7 +1019,7 @@ export class FlowChatStore {
       loadedTurnCount: request.expectedDialogTurnIds.length,
     });
 
-    const { agentAPI } = await import('@/infrastructure/api');
+    const { agentAPI } = await import('@/infrastructure/api/service-api/AgentAPI');
     const restored = await agentAPI.restoreSessionView(
       request.sessionId,
       request.workspacePath,
@@ -1797,7 +1797,7 @@ export class FlowChatStore {
     });
 
     try {
-      const { agentAPI } = await import('@/infrastructure/api');
+      const { agentAPI } = await import('@/infrastructure/api/service-api/AgentAPI');
       const deleteResults = await Promise.allSettled(
         sessionIdsToDelete.map(async id => {
           const sess = this.state.sessions.get(id);
@@ -1953,7 +1953,7 @@ export class FlowChatStore {
       return [];
     }
 
-    const { agentAPI } = await import('@/infrastructure/api');
+    const { agentAPI } = await import('@/infrastructure/api/service-api/AgentAPI');
     await Promise.allSettled(
       runningSessionIds.map(async sessionId => {
         try {
@@ -3753,7 +3753,7 @@ export class FlowChatStore {
           sessionTraceId,
         });
         try {
-          const { agentAPI } = await import('@/infrastructure/api');
+          const { agentAPI } = await import('@/infrastructure/api/service-api/AgentAPI');
           const restoreSessionViewSupportKey = restoreCommandSupportKey(
             'restore_session_view',
             remoteConnectionId,


### PR DESCRIPTION
﻿## Summary
- Narrow `FlowChatStore` dynamic `agentAPI` imports from the full `@/infrastructure/api` barrel to `@/infrastructure/api/service-api/AgentAPI`.
- Keep the session restore/delete/stop command behavior unchanged while avoiding unrelated API module evaluation in historical-session restore paths.
- Add performance contract coverage that rejects broad API-barrel dynamic imports from `FlowChatStore`, and update store tests so historical restore paths must use the narrow `AgentAPI` entrypoint.

Refs #949

## Performance data

Compared latest `gcwing/main` (`753c1d25`) with this PR (`284740ae`) on Windows `release-fast`. Each side ran `pnpm run e2e:test:perf:release-fast` 5 times after rebuilding the release-fast binary. The post-review amend only tightened tests; production code is unchanged from the measured candidate.

| Scenario | latest main median | PR median | Delta | latest main range | PR range |
|---|---:|---:|---:|---:|---:|
| Cold startup: shell interactive | 806.5 ms | 709.6 ms | -96.9 ms | 793.1-1007.6 ms | 665.7-1008.8 ms |
| First long session: latest content usable | 210.1 ms | 191.8 ms | -18.3 ms | 192.1-259.1 ms | 179.1-229.5 ms |
| First long session: latest content visible | 212.7 ms | 189.7 ms | -23.0 ms | 195.5-262.5 ms | 165.3-216.6 ms |
| First long session: full hydrate complete | 543.6 ms | 497.0 ms | -46.6 ms | 517.4-623.3 ms | 483.9-576.8 ms |
| First long session: restore duration | 48.5 ms | 39.3 ms | -9.2 ms | 40.3-63.6 ms | 33.8-45.7 ms |
| Warm reopen: latest content usable | 152.8 ms | 125.7 ms | -27.1 ms | 128.0-218.0 ms | 118.9-143.8 ms |
| Rapid switch: first click to target usable | 451.2 ms | 440.7 ms | -10.5 ms | 440.9-518.6 ms | 422.7-537.2 ms |
| Rapid switch: target click to usable | 124.0 ms | 119.9 ms | -4.1 ms | 114.5-146.2 ms | 109.4-155.0 ms |
| Rapid switch: after click action to usable | 74.1 ms | 75.8 ms | +1.7 ms | 67.9-90.7 ms | 64.6-89.2 ms |

Cold startup numbers are included as a guardrail only. This PR does not touch startup work directly, and the startup delta is dominated by native WebView build variance, so the attributable win is the long-session restore path.

Additional restore-path split:

| Slice | latest main median | PR median | Delta |
|---|---:|---:|---:|
| First long session: hydrate start to restore start | 19.2 ms | 17.4 ms | -1.8 ms |
| First long session: hydrate duration | 68.1 ms | 59.2 ms | -8.9 ms |
| First long session: hydrate to latest frame | 96.2 ms | 90.0 ms | -6.2 ms |

Visual guardrails from all measured first-open, warm-reopen, and rapid-switch runs stayed clean: post-latest-visible blank surface count `0`, scroll jump count `0`, and non-target-content hold count `0`.

## Review follow-up

The adversarial review found the original regression test was too shape-specific: it only caught destructured `agentAPI` imports from the broad barrel. The PR now extracts all dynamic import specifiers from `FlowChatStore` and rejects the broad `@/infrastructure/api` entrypoint directly. `FlowChatStore.test.ts` also no longer exposes `agentAPI` from its broad API mock, so restore tests would fail if production code regressed to the barrel path.

## Risks and compatibility
- The main risk is bypassing any side effects from the broad API barrel. `AgentAPI` is self-contained and directly uses the shared API client, so session restore/delete/stop commands do not require the barrel.
- Remote workspace compatibility should be unchanged: the same `remoteConnectionId` and `remoteSshHost` arguments continue to flow into `AgentAPI` restore/delete/stop methods.
- ACP behavior should be unchanged: this PR does not touch `ACPClientAPI`, session state machine ACP paths, or ACP UI components.

## Validation
- `pnpm run desktop:build:release-fast`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/app/startup/startupPerformanceContract.test.ts src/flow_chat/store/FlowChatStore.test.ts src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx src/flow_chat/services/flow-chat-manager/SessionModule.test.ts` (117 tests)
- `pnpm run e2e:test:perf:release-fast` on latest main, 5/5 passing
- `pnpm run e2e:test:perf:release-fast` on this PR, 5/5 passing
