### PR TITLE
refactor(core): close product assembly sdk hooks

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -22,24 +22,25 @@
 - `services-integrations` 已承接 remote-connect primitives、wire command routing / response assembly、workspace search concrete owner、remote SSH/SFTP/PTY owner、DeepResearch report IO / display-map sidecar、MiniApp host dispatch / storage / worker / import IO。
 - `tool-contracts` 已承接 provider-neutral tool DTO、manifest/catalog/admission/result presentation、confirmation facts、truncation recovery presentation、runtime restriction policy 和 provider-entry materialization。
 - `tool-execution` 已承接 local / remote IO helper、Bash shell helper、batching plan、retry policy、state counting、cancellation-state/token-store policy、background exec output capture 和部分 result rendering。
-- `agent-runtime` 已承接 scheduler/background delivery 纯决策、dialog lifecycle port contracts、session management/cancellation port contracts、thread-goal facts、prompt / prompt-cache facts、turn skill/agent snapshot DTO/diff/render/store、file-read session state、session evidence ledger 与 compression-contract projection、dialog-turn cancellation token store、tool confirmation / user-question wait channel state、custom subagent discovery/loading、post-call hook routing、DeepReview provider-neutral policy/queue/retry/diagnostics shaping、DeepResearch citation renumber 与 report post-process gate，并建立不暴露 `bitfun-core` / `product-full` / concrete manager 的内部 SDK facade 与 fake-provider smoke。
+- `agent-runtime` 已承接 scheduler/background delivery 纯决策、dialog lifecycle port contracts、session management/cancellation port contracts、thread-goal facts、prompt / prompt-cache facts、turn skill/agent snapshot DTO/diff/render/store、file-read session state、session evidence ledger 与 compression-contract projection、dialog-turn cancellation token store、tool confirmation / user-question wait channel state、custom subagent discovery/loading、post-call hook routing、DeepReview provider-neutral policy/queue/retry/diagnostics shaping、DeepResearch citation renumber 与 report post-process gate，并建立不暴露 `bitfun-core` / `product-full` / concrete manager 的内部 SDK facade。SDK facade 已支持注入 fake runtime services、tool registry、harness registry 和 hook registry。
 - `harness` 已建立 descriptor、route plan 和 legacy provider registry。
 - `product-domains` 已承接 MiniApp state/workflow planning、compile / permission adaptation、import lifecycle、AI / Agent permission、rate-limit、model/message/session/workspace/turn-text bridge rules、function-agent prompt/parser/response policy 和部分 Git snapshot/fallback 逻辑。
 - `bitfun-core` 的 function-agent AI concrete acquisition 已从旧 `runtime_services` 路径收拢到明确的 core port adapter；Git / AI compatibility re-export 仍保留旧 public path。
-- Product Assembly 已承接 `DeliveryProfile`、`CapabilitySet`、feature group matrix、product-full provider plan、service availability report、profile-scoped harness registry 入口与 legacy-route 行为保护，以及 product runtime assembly 对 selected plan 的 service requirement 验证；core 只保留兼容 re-export。
+- Product Assembly 已承接 `DeliveryProfile`、当前交付形态入口矩阵、`CapabilitySet`、feature group matrix、product-full provider plan、service availability report、profile-scoped harness registry 入口与 legacy-route 行为保护，以及 `ProductAssembler` 对 explicit profile input、runtime services、harness registry 和 service requirement 的验证；core 只保留兼容 re-export。
 
 ## 3. 已建立保护
 
 - owner crate 不得依赖回 `bitfun-core`。
 - `product-full` 保持完整产品能力集合。
 - boundary check 覆盖 owner crate 禁止依赖、旧路径 facade-only、feature gate、six-layer path 解析、Product Assembly 收口和高风险 owner 回流。
+- focused tests 覆盖当前 delivery profile 不做能力裁剪、ProductAssembler 缺失 service 报告、SDK fake provider / services / tool / harness / hook 闭环，以及 runtime hook 顺序、timeout、错误策略和重复 id 拦截。
 - focused baseline 覆盖 tool manifest、GetToolSpec、execution admission、workspace search、remote workspace fallback、MCP config/catalog、prompt cache、custom subagent、thread-goal tools、AskUserQuestion、DeepReview policy、tool confirmation、session restore、MiniApp storage/builtin/import、function-agent Git、scheduled-job state 等路径。
 
 ## 4. PR-D 后续非阻塞专项
 
 - `bitfun-core` 仍承载 compatibility facade / `product-full` assembly 和少量迁移期 adapter；不应继续新增 owner 逻辑。
-- 产品入口仍主要通过 `bitfun-core/product-full` 获取完整能力；真实交付形态裁剪需要先补入口矩阵和兼容性验证，再作为产品形态专项处理。
+- 产品入口仍主要通过 `bitfun-core/product-full` 获取完整能力；当前入口矩阵已记录这一事实，真实交付形态裁剪仍需作为产品形态专项处理。
 - concrete scheduler lifecycle、prompt-cache persistence orchestration、tool pipeline scheduler glue、concrete prompt assembly、AI client factory / provider acquisition 仍在 core 或产品 adapter；继续迁移必须单独证明行为等价。
 - DeepReview concrete Task launch、queue event emission 和 session metadata cache persistence 仍是 core adapter，因为它们依赖 coordinator、session manager、subagent runtime 和产品事件；provider-neutral policy / queue / retry / report shaping 已在 `agent-runtime`。
 - MiniApp larger workflow 的 UI asset / desktop scheduler / AI factory 调用仍属于产品 host adapter；可复用规则已迁入 `product-domains`，不再在 desktop 命令内重复实现。
-- Agent Runtime SDK 已具备内部 facade 和最小 fake-provider 闭环，但尚未冻结为可独立发布的外部 SDK 包、版本策略和兼容承诺。
+- Agent Runtime SDK 已具备内部 facade、最小 fake-provider 闭环和 registry 注入基线，但尚未冻结为可独立发布的外部 SDK 包、版本策略和兼容承诺。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -18,8 +18,8 @@
 
 - workspace 已按六层目录展开，旧 `surfaces` / `providers` 目标层级不再使用。
 - `bitfun-core --no-default-features` 已裁掉 workspace-search owner、debug ingest HTTP server、AI provider adapter runtime 和 direct `reqwest`。
-- Desktop / CLI / ACP 仍通过 `bitfun-core/product-full` 获取完整能力；Server / Web / Mobile Web 不直接依赖 core。当前已显式化 Product Assembly feature group matrix，具体交付形态减少能力仍需要产品级入口验证后单独决策。
-- Runtime Services、Agent Runtime、Tool Contracts、Tool Execution、Harness、Product Domains、Services Core、Services Integrations 等 owner crate 已建立，部分 concrete 生命周期仍由 core concrete manager 或产品命令路径持有。
+- Desktop / CLI / ACP 仍通过 `bitfun-core/product-full` 获取完整能力；Server / Web / Mobile Web 不直接依赖 core。Product Assembly 已显式记录当前交付形态入口矩阵，真实能力裁剪仍需单独产品形态专项。
+- Runtime Services、Agent Runtime、Tool Contracts、Tool Execution、Harness、Product Domains、Services Core、Services Integrations 等 owner crate 已建立；Agent Runtime SDK 内部 facade 已能注入 runtime services、tool registry、harness registry 和 hook registry，部分 concrete 生命周期仍由 core concrete manager 或产品命令路径持有。
 - PR-B 已收口 Agent lifecycle 与 tool side-effect owner：turn skill/agent snapshot DTO / diff / render / store、file-read session state、session evidence ledger 与 compression-contract projection、dialog-turn cancellation token store、tool confirmation / user-question wait channel state 已迁入 `agent-runtime`；background exec output capture、tool cancellation token store 已迁入 `tool-execution`；core 保留 resolver、产品事件、具体工具执行、IO 编排和旧路径兼容 re-export。
 - PR-C 已收口 Harness / product workflow 的低风险 owner：MiniApp AI / Agent permission、rate-limit、model/message/session/workspace/turn-text 规则迁入 `product-domains`；DeepResearch 后处理 gate 迁入 `agent-runtime`，report IO 继续由 `services-integrations` 持有；function-agent AI concrete acquisition 收拢为 core port adapter，旧 `runtime_services` 路径删除。
 
@@ -33,13 +33,14 @@
 - `product-domains` 已承接 MiniApp workflow planning、compile / permission path adaptation、function-agent prompt / parser / response policy 和部分 Git snapshot/fallback 逻辑。
 - boundary scripts 已覆盖核心 owner 防回流、six-layer path 解析、facade-only 文件和重点 feature gate。
 
-## 4. 剩余大块 PR
+## 4. 后续大块专项
 
-| PR | 目标 | 主要范围 | 准出标准 |
+| 专项 | 目标 | 主要范围 | 准出标准 |
 |---|---|---|---|
-| PR-D | Product shape / Agent SDK / core facade closure | 内部 Agent Runtime SDK facade、fake provider 最小 session / turn / event stream、Product Assembly capability / feature group matrix、profile-scoped harness route 保护、product runtime assembly owner 下沉到 `product-capabilities`、runtime service marker port owner 下沉到 `runtime-services`、tool runtime restriction policy 与 provider-entry materialization 下沉到 `tool-contracts` | cargo metadata / cargo tree 有 no-default/product-full 对比；各产品入口验证通过；SDK 不暴露 `bitfun-core`、product-full、concrete manager 或全局 mutable state |
-
-PR-D 合入后，本文档不再规划新的大块 core decomposition PR。后续若要继续把内部 SDK 发布为外部 SDK，或按 Desktop / CLI / ACP / Server / Web / Mobile Web 做真实能力裁剪，需要先补产品入口矩阵和兼容性验证，再作为新的产品形态专项处理。
+| H1 | Concrete lifecycle owner 迁移 | concrete scheduler lifecycle、prompt-cache persistence orchestration、tool pipeline scheduler glue、concrete prompt assembly、AI client factory / provider acquisition | 先补行为等价测试；迁移后 core 只保留兼容 adapter；不同 OS、remote、本地和 product-full 行为不变 |
+| H2 | DeepReview / MiniApp concrete adapter 收口 | DeepReview Task launch、queue event emission、session metadata cache persistence；MiniApp workflow 的 UI asset / desktop scheduler / AI factory 调用 | 不改变审查队列、报告持久化、MiniApp 执行和权限语义；provider-neutral 规则不得回流 core |
+| H3 | 产品形态能力裁剪专项 | 基于当前 delivery profile entry matrix 决定 Desktop / CLI / ACP / Server / Web / Mobile Web 是否真实裁剪能力 | 每个产品入口有兼容性验证；unsupported / unavailable 行为明确；不得让下层按产品形态分支 |
+| H4 | 外部 Agent Runtime SDK 发布准备 | 版本策略、公开 API 冻结、最小 feature 依赖证明、示例和兼容承诺 | SDK 不依赖 `bitfun-core`、app crate、Tauri、concrete service manager 或产品命令 registry；fake provider / service / tool / harness / hook smoke 保持通过 |
 
 ## 5. 固定执行流程
 

--- a/scripts/core-boundaries/rules/source/required-rules.mjs
+++ b/scripts/core-boundaries/rules/source/required-rules.mjs
@@ -203,6 +203,22 @@ export const requiredContentRules = [
         message: 'missing agent runtime event stream builder hook',
       },
       {
+        regex: /\bpub trait RuntimeToolRegistry\b/,
+        message: 'missing SDK tool registry abstraction',
+      },
+      {
+        regex: /\bpub fn with_tool_registry\b/,
+        message: 'missing SDK tool registry builder hook',
+      },
+      {
+        regex: /\bpub fn with_harness_registry\b/,
+        message: 'missing SDK harness registry builder hook',
+      },
+      {
+        regex: /\bpub fn with_hook_registry\b/,
+        message: 'missing SDK hook registry builder hook',
+      },
+      {
         regex: /\bpub enum SessionSelector\b/,
         message: 'missing session selector contract',
       },
@@ -233,6 +249,21 @@ export const requiredContentRules = [
       {
         regex: /\bport_errors_remain_typed\b/,
         message: 'missing typed port error regression',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/execution/agent-runtime/tests/sdk_smoke.rs',
+    reason:
+      'agent-runtime SDK smoke tests must prove the facade works with injected fake provider, services, tools, harnesses, and hooks without core',
+    patterns: [
+      {
+        regex: /\bsdk_facade_runs_with_fake_provider_and_local_event_stream\b/,
+        message: 'missing SDK fake-provider event-stream smoke',
+      },
+      {
+        regex: /\bsdk_facade_accepts_fake_services_tools_harnesses_and_hooks_without_core\b/,
+        message: 'missing SDK services/tools/harnesses/hooks injection smoke',
       },
     ],
   },
@@ -693,6 +724,26 @@ export const requiredContentRules = [
         message: 'missing product runtime assembly owner',
       },
       {
+        regex: /\bProductDeliveryProfileEntry\b/,
+        message: 'missing product delivery profile entry matrix',
+      },
+      {
+        regex: /\bMobileWeb\b/,
+        message: 'missing mobile web delivery profile coverage',
+      },
+      {
+        regex: /\bProductAssembler\b/,
+        message: 'missing typed product assembler',
+      },
+      {
+        regex: /\bProductAssemblyInput\b/,
+        message: 'missing product assembly input contract',
+      },
+      {
+        regex: /\bProductRuntimeParts\b/,
+        message: 'missing product runtime parts output',
+      },
+      {
         regex: /\bfeature_groups_from_tool_provider_group_plan\b/,
         message: 'missing tool-provider feature group projection owner',
       },
@@ -710,6 +761,18 @@ export const requiredContentRules = [
       {
         regex: /\bproduct_runtime_assembly_reports_runtime_service_capability_gaps\b/,
         message: 'missing product runtime service gap regression',
+      },
+      {
+        regex: /\bproduct_delivery_profile_matrix_documents_current_core_dependency_shape\b/,
+        message: 'missing delivery profile entry matrix regression',
+      },
+      {
+        regex: /\ball_current_product_profiles\b/,
+        message: 'missing delivery profile matrix coverage guard',
+      },
+      {
+        regex: /\bproduct_assembler_builds_runtime_parts_from_explicit_profile_input\b/,
+        message: 'missing typed product assembler regression',
       },
       {
         regex: /\bproduct_harness_provider_plans_legacy_facade_without_execution\b/,
@@ -946,11 +1009,39 @@ export const requiredContentRules = [
   {
     path: 'src/crates/execution/agent-runtime/src/post_call_hooks.rs',
     reason:
-      'agent-runtime must own portable post-call hook routing decisions while concrete hook execution stays in the owning runtime',
+      'agent-runtime must own portable hook registry and post-call routing decisions while concrete hook execution stays in the owning runtime',
     patterns: [
       {
-        regex: /\bpub enum PostCallHookKind\b/,
-        message: 'missing post-call hook kind contract',
+        regex: /\bpub enum RuntimeHookKind\b/,
+        message: 'missing runtime hook kind contract',
+      },
+      {
+        regex: /\bpub enum RuntimeHookErrorPolicy\b/,
+        message: 'missing runtime hook error policy contract',
+      },
+      {
+        regex: /\bpub struct RuntimeHookPlan\b/,
+        message: 'missing runtime hook plan contract',
+      },
+      {
+        regex: /\bpub struct RuntimeHookRegistry\b/,
+        message: 'missing runtime hook registry contract',
+      },
+      {
+        regex: /\btimeout_millis\b/,
+        message: 'missing runtime hook timeout contract',
+      },
+      {
+        regex: /\bDuplicateHookId\b/,
+        message: 'missing runtime hook duplicate-id guard',
+      },
+      {
+        regex: /\bEmptyHookId\b/,
+        message: 'missing runtime hook empty-id guard',
+      },
+      {
+        regex: /\bInvalidTimeoutMillis\b/,
+        message: 'missing runtime hook non-zero-timeout guard',
       },
       {
         regex: /\bpub const fn successful_tool_post_call_hooks\b/,
@@ -974,6 +1065,18 @@ export const requiredContentRules = [
       {
         regex: /\bsuccessful_tool_call_routes_to_shared_context_measurement_hook\b/,
         message: 'missing successful tool post-call hook routing regression',
+      },
+      {
+        regex: /\bruntime_hook_registry_preserves_order_timeout_and_error_policy\b/,
+        message: 'missing runtime hook order/timeout/error-policy regression',
+      },
+      {
+        regex: /\bruntime_hook_registry_rejects_duplicate_ids\b/,
+        message: 'missing runtime hook duplicate-id regression',
+      },
+      {
+        regex: /\bruntime_hook_registry_rejects_unstable_ids_and_zero_timeouts\b/,
+        message: 'missing runtime hook invalid-id/timeout regression',
       },
     ],
   },

--- a/scripts/core-boundaries/self-test.mjs
+++ b/scripts/core-boundaries/self-test.mjs
@@ -1124,7 +1124,12 @@ export function runManifestParserSelfTest({
     {
       path: 'src/crates/execution/agent-runtime/src/post_call_hooks.rs',
       contracts: [
-        'PostCallHookKind',
+        'RuntimeHookKind',
+        'RuntimeHookErrorPolicy',
+        'RuntimeHookPlan',
+        'RuntimeHookRegistry',
+        'EmptyHookId',
+        'InvalidTimeoutMillis',
         'successful_tool_post_call_hooks',
         'SuccessfulToolPostCallHookExecutor',
         'run_successful_tool_post_call_hooks',
@@ -1132,7 +1137,12 @@ export function runManifestParserSelfTest({
     },
     {
       path: 'src/crates/execution/agent-runtime/tests/post_call_hook_contracts.rs',
-      contracts: ['successful_tool_call_routes_to_shared_context_measurement_hook'],
+      contracts: [
+        'successful_tool_call_routes_to_shared_context_measurement_hook',
+        'runtime_hook_registry_preserves_order_timeout_and_error_policy',
+        'runtime_hook_registry_rejects_duplicate_ids',
+        'runtime_hook_registry_rejects_unstable_ids_and_zero_timeouts',
+      ],
     },
     {
       path: 'src/crates/execution/agent-runtime/tests/post_call_hook_execution_contracts.rs',

--- a/src/crates/assembly/core/src/product_assembly.rs
+++ b/src/crates/assembly/core/src/product_assembly.rs
@@ -7,9 +7,11 @@
 pub use bitfun_product_capabilities::{
     default_product_assembly_plan, default_product_capability_assembly,
     default_product_capability_registry, default_product_harness_registry,
-    product_assembly_plan_for_profile, DeliveryProfile, ProductAssemblyPlan,
+    product_assembly_plan_for_profile, product_delivery_profile_entries, DeliveryProfile,
+    ProductAssembler, ProductAssemblyError, ProductAssemblyInput, ProductAssemblyPlan,
     ProductCapabilityAssembly, ProductCapabilityId, ProductCapabilityPack,
-    ProductCapabilityRegistry, ProductCapabilitySet, ProductServiceCapabilityAvailability,
+    ProductCapabilityRegistry, ProductCapabilitySet, ProductCoreDependencyMode,
+    ProductDeliveryProfileEntry, ProductRuntimeParts, ProductServiceCapabilityAvailability,
     ProductServiceCapabilityRequirement, ProductServiceCapabilityStatus,
 };
 

--- a/src/crates/assembly/product-capabilities/AGENTS.md
+++ b/src/crates/assembly/product-capabilities/AGENTS.md
@@ -3,19 +3,22 @@
 Scope: this guide applies to `src/crates/assembly/product-capabilities`.
 
 `bitfun-product-capabilities` owns product capability pack assembly facts: which
-runtime services, feature groups, tool provider group ids, harness provider
-descriptors, profile-scoped harness registries, and runtime service
-availability wrappers a product capability selects. It does not own concrete
-runtime execution.
+delivery profiles, runtime services, feature groups, tool provider group ids,
+harness provider descriptors, profile-scoped harness registries, and runtime
+service availability wrappers a product capability selects. It does not own
+concrete runtime execution.
 
 ## Guardrails
 
 - Do not depend on `bitfun-core`, app crates, Tauri, product-domain
   implementations, concrete service crates, AI adapters, transport adapters,
   terminal, tool-runtime, or concrete tool implementations.
-- Keep this crate limited to stable capability ids, feature group facts, service
-  capability facts, runtime service availability checks, tool provider group id
-  selection, and harness provider descriptor selection.
+- Keep this crate limited to stable delivery profile facts, capability ids,
+  feature group facts, service capability facts, runtime service availability
+  checks, tool provider group id selection, and harness provider descriptor
+  selection.
+- `ProductAssembler` may validate explicit profile input and return immutable
+  runtime parts; it must not create concrete services or product state.
 - Do not encode product UI behavior, permission decisions, session lifecycle,
   filesystem/process IO, Git/AI provider acquisition, or feature defaults here.
 - Preserve default product tool provider order and legacy harness provider ids

--- a/src/crates/assembly/product-capabilities/src/lib.rs
+++ b/src/crates/assembly/product-capabilities/src/lib.rs
@@ -141,6 +141,7 @@ pub enum DeliveryProfile {
     Remote,
     Acp,
     Web,
+    MobileWeb,
 }
 
 impl DeliveryProfile {
@@ -153,6 +154,7 @@ impl DeliveryProfile {
             Self::Remote => "remote",
             Self::Acp => "acp",
             Self::Web => "web",
+            Self::MobileWeb => "mobile-web",
         }
     }
 
@@ -165,6 +167,7 @@ impl DeliveryProfile {
             Self::Remote,
             Self::Acp,
             Self::Web,
+            Self::MobileWeb,
         ]
     }
 }
@@ -173,6 +176,78 @@ impl fmt::Display for DeliveryProfile {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.id())
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ProductCoreDependencyMode {
+    ProductFullCompatibility,
+    NoDirectCoreDependency,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProductDeliveryProfileEntry {
+    profile: DeliveryProfile,
+    core_dependency_mode: ProductCoreDependencyMode,
+}
+
+impl ProductDeliveryProfileEntry {
+    pub const fn new(
+        profile: DeliveryProfile,
+        core_dependency_mode: ProductCoreDependencyMode,
+    ) -> Self {
+        Self {
+            profile,
+            core_dependency_mode,
+        }
+    }
+
+    pub const fn profile(self) -> DeliveryProfile {
+        self.profile
+    }
+
+    pub const fn core_dependency_mode(self) -> ProductCoreDependencyMode {
+        self.core_dependency_mode
+    }
+}
+
+const PRODUCT_DELIVERY_PROFILE_ENTRIES: &[ProductDeliveryProfileEntry] = &[
+    ProductDeliveryProfileEntry::new(
+        DeliveryProfile::ProductFull,
+        ProductCoreDependencyMode::ProductFullCompatibility,
+    ),
+    ProductDeliveryProfileEntry::new(
+        DeliveryProfile::Desktop,
+        ProductCoreDependencyMode::ProductFullCompatibility,
+    ),
+    ProductDeliveryProfileEntry::new(
+        DeliveryProfile::Cli,
+        ProductCoreDependencyMode::ProductFullCompatibility,
+    ),
+    ProductDeliveryProfileEntry::new(
+        DeliveryProfile::Server,
+        ProductCoreDependencyMode::NoDirectCoreDependency,
+    ),
+    ProductDeliveryProfileEntry::new(
+        DeliveryProfile::Remote,
+        ProductCoreDependencyMode::NoDirectCoreDependency,
+    ),
+    ProductDeliveryProfileEntry::new(
+        DeliveryProfile::Acp,
+        ProductCoreDependencyMode::ProductFullCompatibility,
+    ),
+    ProductDeliveryProfileEntry::new(
+        DeliveryProfile::Web,
+        ProductCoreDependencyMode::NoDirectCoreDependency,
+    ),
+    ProductDeliveryProfileEntry::new(
+        DeliveryProfile::MobileWeb,
+        ProductCoreDependencyMode::NoDirectCoreDependency,
+    ),
+];
+
+pub const fn product_delivery_profile_entries() -> &'static [ProductDeliveryProfileEntry] {
+    PRODUCT_DELIVERY_PROFILE_ENTRIES
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -370,6 +445,126 @@ impl ProductRuntimeAssembly {
         self.plan
             .capability_assembly()
             .missing_service_requirements(|capability| services.has_capability(capability))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProductAssemblyInput {
+    profile: DeliveryProfile,
+    services: RuntimeServices,
+}
+
+impl ProductAssemblyInput {
+    pub const fn new(profile: DeliveryProfile, services: RuntimeServices) -> Self {
+        Self { profile, services }
+    }
+
+    pub const fn profile(&self) -> DeliveryProfile {
+        self.profile
+    }
+}
+
+#[derive(Debug)]
+pub struct ProductRuntimeParts {
+    plan: ProductAssemblyPlan,
+    services: RuntimeServices,
+    harness_registry: HarnessRegistry,
+    service_availability: Vec<ProductServiceCapabilityAvailability>,
+    missing_service_requirements: Vec<ProductServiceCapabilityRequirement>,
+}
+
+impl ProductRuntimeParts {
+    pub fn plan(&self) -> &ProductAssemblyPlan {
+        &self.plan
+    }
+
+    pub fn services(&self) -> &RuntimeServices {
+        &self.services
+    }
+
+    pub fn harness_registry(&self) -> &HarnessRegistry {
+        &self.harness_registry
+    }
+
+    pub fn service_availability(&self) -> &[ProductServiceCapabilityAvailability] {
+        &self.service_availability
+    }
+
+    pub fn missing_service_requirements(&self) -> &[ProductServiceCapabilityRequirement] {
+        &self.missing_service_requirements
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProductAssemblyError {
+    MissingRuntimeServices {
+        profile: DeliveryProfile,
+        missing: Vec<ProductServiceCapabilityRequirement>,
+    },
+    HarnessRegistry {
+        profile: DeliveryProfile,
+        source: HarnessRegistryBuildError,
+    },
+}
+
+impl fmt::Display for ProductAssemblyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingRuntimeServices { profile, missing } => {
+                write!(
+                    f,
+                    "delivery profile {profile} is missing {} runtime service requirements",
+                    missing.len()
+                )
+            }
+            Self::HarnessRegistry { profile, source } => {
+                write!(
+                    f,
+                    "delivery profile {profile} failed to build harness registry: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProductAssemblyError {}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ProductAssembler;
+
+impl ProductAssembler {
+    pub const fn new() -> Self {
+        Self
+    }
+
+    pub fn assemble(
+        &self,
+        input: ProductAssemblyInput,
+    ) -> Result<ProductRuntimeParts, ProductAssemblyError> {
+        let assembly = ProductRuntimeAssembly::for_profile(input.profile);
+        let service_availability = assembly.service_availability_report(&input.services);
+        let missing_service_requirements = assembly.missing_service_requirements(&input.services);
+        if !missing_service_requirements.is_empty() {
+            return Err(ProductAssemblyError::MissingRuntimeServices {
+                profile: input.profile,
+                missing: missing_service_requirements,
+            });
+        }
+
+        let harness_registry = assembly.plan().build_harness_registry().map_err(|source| {
+            ProductAssemblyError::HarnessRegistry {
+                profile: input.profile,
+                source,
+            }
+        })?;
+
+        Ok(ProductRuntimeParts {
+            plan: assembly.plan().clone(),
+            services: input.services,
+            harness_registry,
+            service_availability,
+            missing_service_requirements,
+        })
     }
 }
 

--- a/src/crates/assembly/product-capabilities/tests/product_capabilities.rs
+++ b/src/crates/assembly/product-capabilities/tests/product_capabilities.rs
@@ -2,10 +2,11 @@ use bitfun_harness::{HarnessCapability, HarnessInput, HarnessStepKind, HarnessWo
 use bitfun_product_capabilities::{
     default_product_assembly_plan, default_product_capability_assembly,
     default_product_capability_registry, default_product_harness_registry,
-    product_assembly_plan_for_profile, product_harness_registry_for_profile, DeliveryProfile,
-    ProductCapabilityBuildError, ProductCapabilityId, ProductCapabilityPack,
-    ProductCapabilityRegistry, ProductFeatureGroup, ProductRuntimeAssembly,
-    ProductServiceCapabilityRequirement, ProductServiceCapabilityStatus,
+    product_assembly_plan_for_profile, product_delivery_profile_entries,
+    product_harness_registry_for_profile, DeliveryProfile, ProductAssembler, ProductAssemblyError,
+    ProductAssemblyInput, ProductCapabilityBuildError, ProductCapabilityId, ProductCapabilityPack,
+    ProductCapabilityRegistry, ProductCoreDependencyMode, ProductFeatureGroup,
+    ProductRuntimeAssembly, ProductServiceCapabilityRequirement, ProductServiceCapabilityStatus,
 };
 use bitfun_runtime_ports::RuntimeServiceCapability;
 use bitfun_runtime_services::test_support::FakeRuntimeServicesProvider;
@@ -187,6 +188,61 @@ fn product_assembly_plan_makes_delivery_profile_explicit_without_reducing_capabi
 }
 
 #[test]
+fn product_delivery_profile_matrix_documents_current_core_dependency_shape() {
+    let entries = product_delivery_profile_entries()
+        .iter()
+        .map(|entry| (entry.profile(), entry.core_dependency_mode()))
+        .collect::<Vec<_>>();
+    let matrix_profiles = entries
+        .iter()
+        .map(|(profile, _)| *profile)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        entries,
+        vec![
+            (
+                DeliveryProfile::ProductFull,
+                ProductCoreDependencyMode::ProductFullCompatibility,
+            ),
+            (
+                DeliveryProfile::Desktop,
+                ProductCoreDependencyMode::ProductFullCompatibility,
+            ),
+            (
+                DeliveryProfile::Cli,
+                ProductCoreDependencyMode::ProductFullCompatibility,
+            ),
+            (
+                DeliveryProfile::Server,
+                ProductCoreDependencyMode::NoDirectCoreDependency,
+            ),
+            (
+                DeliveryProfile::Remote,
+                ProductCoreDependencyMode::NoDirectCoreDependency,
+            ),
+            (
+                DeliveryProfile::Acp,
+                ProductCoreDependencyMode::ProductFullCompatibility,
+            ),
+            (
+                DeliveryProfile::Web,
+                ProductCoreDependencyMode::NoDirectCoreDependency,
+            ),
+            (
+                DeliveryProfile::MobileWeb,
+                ProductCoreDependencyMode::NoDirectCoreDependency,
+            ),
+        ]
+    );
+    assert_eq!(
+        matrix_profiles,
+        DeliveryProfile::all_current_product_profiles(),
+        "delivery profile matrix must cover every current product profile exactly once"
+    );
+}
+
+#[test]
 fn product_assembly_plan_exposes_build_feature_groups_explicitly() {
     let plan = product_assembly_plan_for_profile(DeliveryProfile::ProductFull);
 
@@ -287,6 +343,66 @@ fn product_runtime_assembly_reports_runtime_service_capability_gaps() {
         .missing_service_requirements(&complete_services)
         .is_empty());
     assert_eq!(assembly.plan().profile(), DeliveryProfile::ProductFull);
+}
+
+#[test]
+fn product_assembler_builds_runtime_parts_from_explicit_profile_input() {
+    let services = FakeRuntimeServicesProvider::with_all_required()
+        .register(RuntimeServicesBuilder::new())
+        .with_optional_terminal(Some(RuntimeServiceMarkerPort::terminal_port()))
+        .with_optional_git(Some(RuntimeServiceMarkerPort::git_port()))
+        .with_optional_network(Some(RuntimeServiceMarkerPort::network_port()))
+        .build()
+        .expect("runtime service marker ports should satisfy product requirements");
+
+    let parts = ProductAssembler::new()
+        .assemble(ProductAssemblyInput::new(DeliveryProfile::Cli, services))
+        .expect("complete service set should assemble product runtime parts");
+
+    assert_eq!(parts.plan().profile(), DeliveryProfile::Cli);
+    assert_eq!(
+        parts.harness_registry().provider_ids(),
+        vec!["core.deep_review", "core.deep_research", "core.miniapp"]
+    );
+    assert!(parts.missing_service_requirements().is_empty());
+    assert!(parts
+        .services()
+        .has_capability(RuntimeServiceCapability::Terminal));
+}
+
+#[test]
+fn product_assembler_reports_missing_services_without_building_runtime_parts() {
+    let services = FakeRuntimeServicesProvider::with_all_required()
+        .build_services()
+        .expect("required runtime services should build");
+
+    let error = ProductAssembler::new()
+        .assemble(ProductAssemblyInput::new(
+            DeliveryProfile::Desktop,
+            services,
+        ))
+        .expect_err("desktop product-full compatibility requires optional product services");
+
+    assert_eq!(
+        error,
+        ProductAssemblyError::MissingRuntimeServices {
+            profile: DeliveryProfile::Desktop,
+            missing: vec![
+                ProductServiceCapabilityRequirement::new(
+                    ProductCapabilityId::CodeAgent,
+                    RuntimeServiceCapability::Terminal,
+                ),
+                ProductServiceCapabilityRequirement::new(
+                    ProductCapabilityId::DeepReview,
+                    RuntimeServiceCapability::Git,
+                ),
+                ProductServiceCapabilityRequirement::new(
+                    ProductCapabilityId::DeepResearch,
+                    RuntimeServiceCapability::Network,
+                ),
+            ],
+        }
+    );
 }
 
 #[test]

--- a/src/crates/execution/agent-runtime/AGENTS.md
+++ b/src/crates/execution/agent-runtime/AGENTS.md
@@ -12,10 +12,10 @@ port-backed `sdk` / `AgentRuntime` facade that can be built and tested without
   concrete service crates, or product-domain implementations.
 - The `sdk` module may re-export only stable runtime request/response types and
   runtime-port contracts.
-- `AgentRuntime` may depend on stable ports and typed `RuntimeServices`
-  injected by assembly. Product assembly owns concrete registration; this crate
-  must not create concrete managers, app state, filesystem, terminal, MCP,
-  remote, or AI clients.
+- `AgentRuntime` may depend on stable ports plus injected `RuntimeServices`,
+  tool registry, harness registry, and hook registry. Product assembly owns
+  concrete registration; this crate must not create concrete managers, app
+  state, filesystem, terminal, MCP, remote, or AI clients.
 - Keep concrete scheduler/session lifecycle execution, session metadata IO,
   event emitter wiring, permission UI presentation, and product `Tool` adapter
   execution in `bitfun-core` until a reviewed owner migration proves behavior

--- a/src/crates/execution/agent-runtime/Cargo.toml
+++ b/src/crates/execution/agent-runtime/Cargo.toml
@@ -10,6 +10,8 @@ name = "bitfun_agent_runtime"
 crate-type = ["rlib"]
 
 [dependencies]
+bitfun-agent-tools = { path = "../tool-contracts" }
+bitfun-harness = { path = "../harness" }
 bitfun-runtime-ports = { path = "../../contracts/runtime-ports" }
 bitfun-runtime-services = { path = "../runtime-services" }
 dashmap = { workspace = true }

--- a/src/crates/execution/agent-runtime/src/post_call_hooks.rs
+++ b/src/crates/execution/agent-runtime/src/post_call_hooks.rs
@@ -1,18 +1,147 @@
 //! Portable post-call hook routing decisions.
 
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 /// Hook categories that concrete runtime integrations may execute after a
 /// successful tool call.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PostCallHookKind {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum RuntimeHookKind {
+    SuccessfulToolPostCall,
     DeepReviewSharedContextToolUse,
 }
 
-pub const fn successful_tool_post_call_hooks() -> [PostCallHookKind; 1] {
-    [PostCallHookKind::DeepReviewSharedContextToolUse]
+pub const fn successful_tool_post_call_hooks() -> [RuntimeHookKind; 1] {
+    [RuntimeHookKind::DeepReviewSharedContextToolUse]
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RuntimeHookErrorPolicy {
+    FailTurn,
+    SkipHook,
+    DenyTool,
+    RecordWarning,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeHookPlan {
+    id: String,
+    kind: RuntimeHookKind,
+    order: u16,
+    timeout_millis: u64,
+    error_policy: RuntimeHookErrorPolicy,
+}
+
+impl RuntimeHookPlan {
+    pub fn new(id: impl Into<String>, kind: RuntimeHookKind) -> Self {
+        Self {
+            id: id.into(),
+            kind,
+            order: 100,
+            timeout_millis: 1_000,
+            error_policy: RuntimeHookErrorPolicy::RecordWarning,
+        }
+    }
+
+    pub fn with_order(mut self, order: u16) -> Self {
+        self.order = order;
+        self
+    }
+
+    pub fn with_timeout_millis(mut self, timeout_millis: u64) -> Self {
+        self.timeout_millis = timeout_millis;
+        self
+    }
+
+    pub fn with_error_policy(mut self, error_policy: RuntimeHookErrorPolicy) -> Self {
+        self.error_policy = error_policy;
+        self
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub const fn kind(&self) -> RuntimeHookKind {
+        self.kind
+    }
+
+    pub const fn order(&self) -> u16 {
+        self.order
+    }
+
+    pub const fn timeout_millis(&self) -> u64 {
+        self.timeout_millis
+    }
+
+    pub const fn error_policy(&self) -> RuntimeHookErrorPolicy {
+        self.error_policy
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RuntimeHookRegistryBuildError {
+    #[error("runtime hook id must not be empty")]
+    EmptyHookId,
+    #[error("runtime hook {hook_id} must declare a non-zero timeout")]
+    InvalidTimeoutMillis { hook_id: String },
+    #[error("duplicate runtime hook id {hook_id}")]
+    DuplicateHookId { hook_id: String },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeHookRegistryBuilder {
+    hooks: Vec<RuntimeHookPlan>,
+}
+
+impl RuntimeHookRegistryBuilder {
+    pub fn register(mut self, hook: RuntimeHookPlan) -> Self {
+        self.hooks.push(hook);
+        self
+    }
+
+    pub fn build(mut self) -> Result<RuntimeHookRegistry, RuntimeHookRegistryBuildError> {
+        let mut hook_ids = HashSet::new();
+        for hook in &self.hooks {
+            if hook.id.trim().is_empty() {
+                return Err(RuntimeHookRegistryBuildError::EmptyHookId);
+            }
+            if hook.timeout_millis == 0 {
+                return Err(RuntimeHookRegistryBuildError::InvalidTimeoutMillis {
+                    hook_id: hook.id.clone(),
+                });
+            }
+            if !hook_ids.insert(hook.id.clone()) {
+                return Err(RuntimeHookRegistryBuildError::DuplicateHookId {
+                    hook_id: hook.id.clone(),
+                });
+            }
+        }
+        self.hooks.sort_by(|left, right| {
+            left.order
+                .cmp(&right.order)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        Ok(RuntimeHookRegistry { hooks: self.hooks })
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeHookRegistry {
+    hooks: Vec<RuntimeHookPlan>,
+}
+
+impl RuntimeHookRegistry {
+    pub fn builder() -> RuntimeHookRegistryBuilder {
+        RuntimeHookRegistryBuilder::default()
+    }
+
+    pub fn hooks(&self) -> &[RuntimeHookPlan] {
+        &self.hooks
+    }
 }
 
 pub trait SuccessfulToolPostCallHookExecutor<C> {
@@ -34,9 +163,10 @@ pub fn run_successful_tool_post_call_hooks<C, E>(
 {
     for hook in successful_tool_post_call_hooks() {
         match hook {
-            PostCallHookKind::DeepReviewSharedContextToolUse => {
+            RuntimeHookKind::DeepReviewSharedContextToolUse => {
                 executor.record_deep_review_shared_context_tool_use(tool_name, input, context);
             }
+            RuntimeHookKind::SuccessfulToolPostCall => {}
         }
     }
 }

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -6,6 +6,8 @@
 
 use std::sync::{Arc, Mutex};
 
+use bitfun_agent_tools::{ToolRegistry, ToolRegistryItem};
+use bitfun_harness::HarnessRegistry;
 use bitfun_runtime_ports::{
     AgentBackgroundResultRequest, AgentDialogTurnPort, AgentDialogTurnRequest,
     AgentInputAttachment, AgentLifecycleDeliveryPort, AgentSessionCreateRequest,
@@ -16,6 +18,8 @@ use bitfun_runtime_ports::{
     AgentTurnCancellationResult, DialogSubmitOutcome, PortError, RuntimeEventEnvelope,
 };
 use bitfun_runtime_services::RuntimeServices;
+
+use crate::post_call_hooks::RuntimeHookRegistry;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RuntimeBuildError {
@@ -87,6 +91,9 @@ pub struct AgentRuntime {
     cancellation: Option<Arc<dyn AgentTurnCancellationPort>>,
     services: Option<RuntimeServices>,
     event_stream: Option<AgentEventStream>,
+    tool_registry: Option<Arc<dyn RuntimeToolRegistry>>,
+    harness_registry: Option<Arc<HarnessRegistry>>,
+    hook_registry: RuntimeHookRegistry,
 }
 
 impl std::fmt::Debug for AgentRuntime {
@@ -129,7 +136,29 @@ impl std::fmt::Debug for AgentRuntime {
                 "event_stream",
                 &self.event_stream.as_ref().map(|_| "<AgentEventStream>"),
             )
+            .field(
+                "tool_registry",
+                &self.tool_registry.as_ref().map(|_| "<RuntimeToolRegistry>"),
+            )
+            .field(
+                "harness_registry",
+                &self.harness_registry.as_ref().map(|_| "<HarnessRegistry>"),
+            )
+            .field("hook_count", &self.hook_registry.hooks().len())
             .finish()
+    }
+}
+
+pub trait RuntimeToolRegistry: Send + Sync {
+    fn tool_names(&self) -> Vec<String>;
+}
+
+impl<Tool> RuntimeToolRegistry for ToolRegistry<Tool>
+where
+    Tool: ToolRegistryItem + ?Sized,
+{
+    fn tool_names(&self) -> Vec<String> {
+        self.get_tool_names()
     }
 }
 
@@ -142,6 +171,9 @@ pub struct AgentRuntimeBuilder {
     cancellation: Option<Arc<dyn AgentTurnCancellationPort>>,
     services: Option<RuntimeServices>,
     event_stream: Option<AgentEventStream>,
+    tool_registry: Option<Arc<dyn RuntimeToolRegistry>>,
+    harness_registry: Option<Arc<HarnessRegistry>>,
+    hook_registry: RuntimeHookRegistry,
 }
 
 impl AgentRuntimeBuilder {
@@ -190,6 +222,21 @@ impl AgentRuntimeBuilder {
         self
     }
 
+    pub fn with_tool_registry(mut self, registry: Arc<dyn RuntimeToolRegistry>) -> Self {
+        self.tool_registry = Some(registry);
+        self
+    }
+
+    pub fn with_harness_registry(mut self, registry: Arc<HarnessRegistry>) -> Self {
+        self.harness_registry = Some(registry);
+        self
+    }
+
+    pub fn with_hook_registry(mut self, registry: RuntimeHookRegistry) -> Self {
+        self.hook_registry = registry;
+        self
+    }
+
     pub fn build(self) -> Result<AgentRuntime, RuntimeBuildError> {
         Ok(AgentRuntime {
             submission: self
@@ -201,6 +248,9 @@ impl AgentRuntimeBuilder {
             cancellation: self.cancellation,
             services: self.services,
             event_stream: self.event_stream,
+            tool_registry: self.tool_registry,
+            harness_registry: self.harness_registry,
+            hook_registry: self.hook_registry,
         })
     }
 }
@@ -302,6 +352,28 @@ pub struct AgentRunHandle {
 }
 
 impl AgentRuntime {
+    pub fn services(&self) -> Option<&RuntimeServices> {
+        self.services.as_ref()
+    }
+
+    pub fn registered_tool_names(&self) -> Vec<String> {
+        self.tool_registry
+            .as_ref()
+            .map(|registry| registry.tool_names())
+            .unwrap_or_default()
+    }
+
+    pub fn harness_provider_ids(&self) -> Vec<&str> {
+        self.harness_registry
+            .as_ref()
+            .map(|registry| registry.provider_ids())
+            .unwrap_or_default()
+    }
+
+    pub fn hook_registry(&self) -> &RuntimeHookRegistry {
+        &self.hook_registry
+    }
+
     pub async fn create_session(
         &self,
         request: AgentSessionCreateRequest,

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -4,9 +4,13 @@
 //! runtime with caller-provided ports. Concrete product assembly remains
 //! outside this crate.
 
+pub use crate::post_call_hooks::{
+    RuntimeHookErrorPolicy, RuntimeHookKind, RuntimeHookPlan, RuntimeHookRegistry,
+    RuntimeHookRegistryBuildError,
+};
 pub use crate::runtime::{
     AgentEventStream, AgentRunHandle, AgentRunRequest, AgentRuntime, AgentRuntimeBuilder,
-    RuntimeBuildError, RuntimeError, SessionSelector,
+    RuntimeBuildError, RuntimeError, RuntimeToolRegistry, SessionSelector,
 };
 pub use bitfun_runtime_ports::{
     AgentDialogTurnPort, AgentDialogTurnRequest, AgentInputAttachment, AgentLifecycleDeliveryPort,

--- a/src/crates/execution/agent-runtime/tests/post_call_hook_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/post_call_hook_contracts.rs
@@ -1,9 +1,101 @@
-use bitfun_agent_runtime::post_call_hooks::{successful_tool_post_call_hooks, PostCallHookKind};
+use bitfun_agent_runtime::post_call_hooks::{
+    successful_tool_post_call_hooks, RuntimeHookErrorPolicy, RuntimeHookKind, RuntimeHookPlan,
+    RuntimeHookRegistry, RuntimeHookRegistryBuildError,
+};
 
 #[test]
 fn successful_tool_call_routes_to_shared_context_measurement_hook() {
     assert_eq!(
         successful_tool_post_call_hooks(),
-        [PostCallHookKind::DeepReviewSharedContextToolUse]
+        [RuntimeHookKind::DeepReviewSharedContextToolUse]
+    );
+}
+
+#[test]
+fn runtime_hook_registry_preserves_order_timeout_and_error_policy() {
+    let registry = RuntimeHookRegistry::builder()
+        .register(
+            RuntimeHookPlan::new(
+                "deep-review.shared-context",
+                RuntimeHookKind::DeepReviewSharedContextToolUse,
+            )
+            .with_order(20)
+            .with_timeout_millis(750)
+            .with_error_policy(RuntimeHookErrorPolicy::RecordWarning),
+        )
+        .register(
+            RuntimeHookPlan::new("audit.post-call", RuntimeHookKind::SuccessfulToolPostCall)
+                .with_order(10)
+                .with_timeout_millis(250)
+                .with_error_policy(RuntimeHookErrorPolicy::SkipHook),
+        )
+        .build()
+        .expect("hook registry should build");
+
+    assert_eq!(
+        registry
+            .hooks()
+            .iter()
+            .map(|hook| hook.id())
+            .collect::<Vec<_>>(),
+        vec!["audit.post-call", "deep-review.shared-context"]
+    );
+    assert_eq!(registry.hooks()[0].timeout_millis(), 250);
+    assert_eq!(
+        registry.hooks()[0].error_policy(),
+        RuntimeHookErrorPolicy::SkipHook
+    );
+}
+
+#[test]
+fn runtime_hook_registry_rejects_duplicate_ids() {
+    let error = RuntimeHookRegistry::builder()
+        .register(RuntimeHookPlan::new(
+            "duplicate",
+            RuntimeHookKind::SuccessfulToolPostCall,
+        ))
+        .register(RuntimeHookPlan::new(
+            "duplicate",
+            RuntimeHookKind::DeepReviewSharedContextToolUse,
+        ))
+        .build()
+        .expect_err("duplicate hook ids must not be silently accepted");
+
+    assert_eq!(
+        error,
+        RuntimeHookRegistryBuildError::DuplicateHookId {
+            hook_id: "duplicate".to_string()
+        }
+    );
+}
+
+#[test]
+fn runtime_hook_registry_rejects_unstable_ids_and_zero_timeouts() {
+    let empty_id_error = RuntimeHookRegistry::builder()
+        .register(RuntimeHookPlan::new(
+            "   ",
+            RuntimeHookKind::SuccessfulToolPostCall,
+        ))
+        .build()
+        .expect_err("blank hook ids must not become registry keys");
+
+    assert_eq!(empty_id_error, RuntimeHookRegistryBuildError::EmptyHookId);
+
+    let zero_timeout_error = RuntimeHookRegistry::builder()
+        .register(
+            RuntimeHookPlan::new(
+                "deep-review.shared-context",
+                RuntimeHookKind::DeepReviewSharedContextToolUse,
+            )
+            .with_timeout_millis(0),
+        )
+        .build()
+        .expect_err("hook timeouts must remain explicit and non-zero");
+
+    assert_eq!(
+        zero_timeout_error,
+        RuntimeHookRegistryBuildError::InvalidTimeoutMillis {
+            hook_id: "deep-review.shared-context".to_string()
+        }
     );
 }

--- a/src/crates/execution/agent-runtime/tests/sdk_smoke.rs
+++ b/src/crates/execution/agent-runtime/tests/sdk_smoke.rs
@@ -2,18 +2,48 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use bitfun_agent_runtime::sdk::{
-    AgentEventStream, AgentRunRequest, AgentRuntimeBuilder, SessionSelector,
+    AgentEventStream, AgentRunRequest, AgentRuntimeBuilder, RuntimeHookErrorPolicy,
+    RuntimeHookKind, RuntimeHookPlan, RuntimeHookRegistry, SessionSelector,
+};
+use bitfun_agent_tools::{ToolRegistry, ToolRegistryItem};
+use bitfun_harness::{
+    build_descriptor_harness_registry, HarnessCapability, HarnessProviderDescriptor,
+    HarnessWorkflow,
 };
 use bitfun_runtime_ports::{
     AgentSessionCreateRequest, AgentSessionCreateResult, AgentSubmissionPort,
     AgentSubmissionRequest, AgentSubmissionResult, AgentSubmissionSource, PortResult,
     RuntimeEventEnvelope, RuntimeEventType,
 };
+use bitfun_runtime_services::test_support::FakeRuntimeServicesProvider;
+use serde_json::{json, Value};
 
 #[derive(Debug, Default)]
 struct FakeSdkAgentProvider {
     created_sessions: Mutex<Vec<AgentSessionCreateRequest>>,
     submitted_turns: Mutex<Vec<AgentSubmissionRequest>>,
+}
+
+struct FakeSdkTool;
+
+#[async_trait]
+impl ToolRegistryItem for FakeSdkTool {
+    fn name(&self) -> &str {
+        "sdk_echo"
+    }
+
+    async fn description(&self) -> Result<String, String> {
+        Ok("Echo input for SDK smoke coverage".to_string())
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "text": { "type": "string" }
+            }
+        })
+    }
 }
 
 #[async_trait]
@@ -95,4 +125,46 @@ async fn sdk_facade_runs_with_fake_provider_and_local_event_stream() {
         events.snapshot()
     );
     assert_eq!(events.len(), 1);
+}
+
+#[tokio::test]
+async fn sdk_facade_accepts_fake_services_tools_harnesses_and_hooks_without_core() {
+    let provider = Arc::new(FakeSdkAgentProvider::default());
+    let services = FakeRuntimeServicesProvider::with_all_required()
+        .build_services()
+        .expect("fake required services");
+    let mut tools = ToolRegistry::new();
+    tools.register_tool(Arc::new(FakeSdkTool));
+    let harnesses = build_descriptor_harness_registry([HarnessProviderDescriptor::legacy_facade(
+        "sdk.fake_harness",
+        HarnessWorkflow::Sdd,
+        &[HarnessCapability::Plan],
+        "external-sdk-harness",
+    )])
+    .expect("fake harness registry should build");
+    let hooks = RuntimeHookRegistry::builder()
+        .register(
+            RuntimeHookPlan::new("sdk.post_call", RuntimeHookKind::SuccessfulToolPostCall)
+                .with_timeout_millis(250)
+                .with_error_policy(RuntimeHookErrorPolicy::RecordWarning),
+        )
+        .build()
+        .expect("hook registry should build");
+
+    let runtime = AgentRuntimeBuilder::new()
+        .with_submission_port(provider)
+        .with_services(services)
+        .with_tool_registry(Arc::new(tools))
+        .with_harness_registry(Arc::new(harnesses))
+        .with_hook_registry(hooks)
+        .build()
+        .expect("sdk runtime");
+
+    assert_eq!(runtime.registered_tool_names(), vec!["sdk_echo"]);
+    assert_eq!(runtime.harness_provider_ids(), vec!["sdk.fake_harness"]);
+    assert_eq!(runtime.hook_registry().hooks()[0].id(), "sdk.post_call");
+    assert!(runtime
+        .services()
+        .expect("services should be injected")
+        .has_capability(bitfun_runtime_ports::RuntimeServiceCapability::SessionStore));
 }


### PR DESCRIPTION
﻿## Summary
- add a delivery-profile dependency matrix and typed `ProductAssembler` validation in Product Assembly
- include Mobile Web in the explicit delivery-profile matrix so product-shape planning covers all current product surfaces
- extend the internal Agent Runtime SDK facade with injected runtime services, tool registry, harness registry, and hook registry
- add RuntimeHookRegistry order, timeout, error-policy, duplicate-id, empty-id, and non-zero-timeout contracts with boundary guard anchors
- refresh core decomposition plan/completed notes for the completed baseline and remaining high-risk migration work

## Risk and compatibility
- No product entrypoint behavior is wired to the new assembly or SDK surfaces in this PR.
- New dependencies stay within allowed layer direction: assembly depends downward, execution depends on execution/contracts crates only.
- Hook registry validation rejects invalid extension metadata before it can become runtime configuration.
- Design docs are unchanged; progress is recorded in plan/completed docs.

## Validation
- `pnpm run fmt:rs`
- `pnpm run check:repo-hygiene`
- `cargo metadata --no-deps --format-version 1`
- `cargo check --workspace`
- `cargo check -p bitfun-core --no-default-features`
- `cargo check -p bitfun-core --features product-full`
- `cargo test -p bitfun-product-capabilities --test product_capabilities`
- `cargo test -p bitfun-agent-runtime`
- `cargo test -p bitfun-agent-runtime --test post_call_hook_contracts --test sdk_smoke`
- `cargo test -p bitfun-agent-tools`
- `cargo test -p bitfun-runtime-services`
- `cargo test -p bitfun-harness`
- `node --test scripts/check-core-boundaries.test.mjs`
- `node scripts/check-core-boundaries.mjs`
- `git diff --check`
- `git diff --cached --check`