### PR TITLE
perf(web-ui): narrow session interaction api imports

### DIFF
--- a/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
+++ b/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
@@ -16,6 +16,13 @@ function dynamicImportSpecifiers(source: string): string[] {
   );
 }
 
+function staticImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(/from\s+(['"])(.*?)\1/g),
+    match => match[2]
+  );
+}
+
 describe('startup performance contract', () => {
   it('keeps the pre-React startup fallback logo-only', () => {
     const source = readSource('../../../index.html');
@@ -548,6 +555,22 @@ describe('startup performance contract', () => {
       new Set(['@/infrastructure/api/service-api/AgentAPI'])
     );
     expect(imports).not.toContain('@/infrastructure/api');
+  });
+
+  it('keeps session interaction hot paths off the broad API barrel', () => {
+    const hotPathSources = [
+      '../../flow_chat/hooks/useFlowChat.ts',
+      '../../flow_chat/components/modern/ModernFlowChatContainer.tsx',
+      '../../flow_chat/components/modern/useFlowChatSync.ts',
+      '../../flow_chat/components/ChatInput.tsx',
+      '../../flow_chat/services/flow-chat-manager/PersistenceModule.ts',
+      '../../flow_chat/state-machine/SessionStateMachine.ts',
+    ].map(readSource);
+
+    for (const source of hotPathSources) {
+      expect(staticImportSpecifiers(source)).not.toContain('@/infrastructure/api');
+      expect(dynamicImportSpecifiers(source)).not.toContain('@/infrastructure/api');
+    }
   });
 
   it('keeps Agent companion implementation modules out of the root startup bundle', () => {

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -65,7 +65,7 @@ import { resolveSessionRelationship } from '../utils/sessionMetadata';
 import { resolveWorkspaceChatInputMode } from '../utils/chatInputMode';
 import { useSceneStore } from '@/app/stores/sceneStore';
 import type { SceneTabId } from '@/app/components/SceneBar/types';
-import { configAPI } from '@/infrastructure/api';
+import { configAPI } from '@/infrastructure/api/service-api/ConfigAPI';
 import type { ModeSkillInfo } from '@/infrastructure/config/types';
 import MCPAPI, { type MCPPrompt, type MCPPromptMessage, type MCPServerInfo } from '@/infrastructure/api/service-api/MCPAPI';
 import { ChatInputWorkspaceStrip } from './ChatInputWorkspaceStrip';
@@ -1767,7 +1767,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
 
     try {
-      const { agentAPI } = await import('@/infrastructure/api');
       await agentAPI.compactSession({
         sessionId: effectiveTargetSessionId,
         workspacePath: effectiveTargetSession.workspacePath,

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -100,7 +100,7 @@ vi.mock('@/infrastructure/contexts/WorkspaceContext', () => ({
   }),
 }));
 
-vi.mock('@/infrastructure/api', () => ({
+vi.mock('@/infrastructure/api/service-api/AgentAPI', () => ({
   agentAPI: agentApiMock,
 }));
 

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -52,7 +52,7 @@ import {
 } from '../../utils/flowChatTurnScrollPolicy';
 import { isRemoteTraceContext, startupTrace } from '@/shared/utils/startupTrace';
 import { scheduleAfterStartupPaint } from '@/shared/utils/startupTaskScheduling';
-import { agentAPI } from '@/infrastructure/api';
+import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
 import { notificationService } from '@/shared/notification-system';
 import {
   clearHistorySessionOpenTransition,

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatSync.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatSync.ts
@@ -3,7 +3,7 @@
  */
 
 import { useEffect } from 'react';
-import { agentAPI } from '@/infrastructure/api';
+import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
 import { flowChatStore } from '../../store/FlowChatStore';
 import { startAutoSync } from '../../services/storeSync';
 

--- a/src/web-ui/src/flow_chat/hooks/useFlowChat.ts
+++ b/src/web-ui/src/flow_chat/hooks/useFlowChat.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { aiApi, agentAPI, snapshotAPI } from '@/infrastructure/api';
+import { aiApi } from '@/infrastructure/api/service-api/AIApi';
+import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
+import { snapshotAPI } from '@/infrastructure/api/service-api/SnapshotAPI';
 import { stateMachineManager } from '../state-machine';
 import { 
   FlowChatState, 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts
@@ -10,7 +10,7 @@ const saveSessionTurn = vi.fn();
 const saveSessionMetadata = vi.fn();
 const loadSessionMetadata = vi.fn();
 
-vi.mock('@/infrastructure/api', () => ({
+vi.mock('@/infrastructure/api/service-api/SessionAPI', () => ({
   sessionAPI: {
     saveSessionTurn,
     saveSessionMetadata,

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.ts
@@ -262,7 +262,7 @@ async function performSaveDialogTurnToDisk(
   turnId: string
 ): Promise<void> {
   try {
-    const { sessionAPI } = await import('@/infrastructure/api');
+    const { sessionAPI } = await import('@/infrastructure/api/service-api/SessionAPI');
 
     const session = context.flowChatStore.getState().sessions.get(sessionId);
     if (!session) {
@@ -497,7 +497,7 @@ export async function updateSessionMetadata(
   sessionId: string
 ): Promise<void> {
   try {
-    const { sessionAPI } = await import('@/infrastructure/api');
+    const { sessionAPI } = await import('@/infrastructure/api/service-api/SessionAPI');
 
     const session = context.flowChatStore.getState().sessions.get(sessionId);
     if (!session) return;
@@ -540,7 +540,7 @@ export async function touchSessionActivity(
   remoteSshHost?: string
 ): Promise<void> {
   try {
-    const { sessionAPI } = await import('@/infrastructure/api');
+    const { sessionAPI } = await import('@/infrastructure/api/service-api/SessionAPI');
     await sessionAPI.touchSessionActivity(
       sessionId,
       requireWorkspacePath(sessionId, workspacePath),

--- a/src/web-ui/src/flow_chat/state-machine/SessionStateMachine.ts
+++ b/src/web-ui/src/flow_chat/state-machine/SessionStateMachine.ts
@@ -282,7 +282,7 @@ export class SessionStateMachineImpl {
             remoteSshHost: session?.remoteSshHost,
           });
         } else {
-          const { agentAPI } = await import('@/infrastructure/api');
+          const { agentAPI } = await import('@/infrastructure/api/service-api/AgentAPI');
           await agentAPI.cancelDialogTurn(sessionId, dialogTurnId);
         }
         log.debug('Backend cancellation completed', { sessionId, dialogTurnId, acpClientId });

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -3612,6 +3612,9 @@ type RapidLongSessionSwitchMeasurement = {
       findDurationMs: number;
       clickDurationMs: number;
       pauseBeforeTargetMs: number;
+      clickActionCompletedAtMs: number;
+      clickActionCompletedToLatestVisibleMs: number;
+      clickActionCompletedToLatestUsableMs: number;
       clickToLatestVisibleMs: number;
       clickToLatestUsableMs: number;
       latestVisibleToUsableMs: number;
@@ -3974,6 +3977,8 @@ async function collectRapidLongSessionSwitchMeasurement(
   const targetClickPlanEntry = targetClickPlanIndex >= 0
     ? clickPlan[targetClickPlanIndex]
     : undefined;
+  const targetClickDurationMs = targetClickPlanEntry?.clickDurationMs ?? 0;
+  const targetClickActionCompletedAtMs = targetClickedAtMs + targetClickDurationMs;
   const pauseBeforeTargetMs = clickPlan
     .slice(0, Math.max(0, targetClickPlanIndex))
     .reduce((total, entry) => total + (entry.pauseDurationMs ?? 0), 0);
@@ -4011,8 +4016,11 @@ async function collectRapidLongSessionSwitchMeasurement(
         clickedAtMs: targetClickedAtMs,
         clickSinceFirstClickMs: targetClickedAtMs - clickedAtMs,
         findDurationMs: targetClickPlanEntry?.findDurationMs ?? 0,
-        clickDurationMs: targetClickPlanEntry?.clickDurationMs ?? 0,
+        clickDurationMs: targetClickDurationMs,
         pauseBeforeTargetMs,
+        clickActionCompletedAtMs: targetClickActionCompletedAtMs,
+        clickActionCompletedToLatestVisibleMs: latestVisible.visibleAtMs - targetClickActionCompletedAtMs,
+        clickActionCompletedToLatestUsableMs: latestUsable.usableAtMs - targetClickActionCompletedAtMs,
         clickToLatestVisibleMs: latestVisible.visibleAtMs - targetClickedAtMs,
         clickToLatestUsableMs: latestUsable.usableAtMs - targetClickedAtMs,
         latestVisibleToUsableMs: latestUsable.usableAtMs - latestVisible.visibleAtMs,
@@ -4555,6 +4563,10 @@ describe('Performance telemetry', () => {
           findDurationMs: measurement.rapidSwitchBreakdown.target.findDurationMs,
           clickDurationMs: measurement.rapidSwitchBreakdown.target.clickDurationMs,
           pauseBeforeTargetMs: measurement.rapidSwitchBreakdown.target.pauseBeforeTargetMs,
+          clickActionCompletedToLatestVisibleMs:
+            measurement.rapidSwitchBreakdown.target.clickActionCompletedToLatestVisibleMs,
+          clickActionCompletedToLatestUsableMs:
+            measurement.rapidSwitchBreakdown.target.clickActionCompletedToLatestUsableMs,
           clickToLatestVisibleMs: measurement.rapidSwitchBreakdown.target.clickToLatestVisibleMs,
           latestVisibleToUsableMs: measurement.rapidSwitchBreakdown.target.latestVisibleToUsableMs,
           clickToLatestUsableMs: measurement.rapidSwitchBreakdown.target.clickToLatestUsableMs,


### PR DESCRIPTION
## Summary

- Route FlowChat session interaction hot paths through exact `service-api/*` modules instead of the broad `@/infrastructure/api` barrel.
- Add a startup performance contract guard so these hot paths cannot silently reintroduce the broad API barrel.
- Extend the rapid-switch E2E report with post-click app response timing, separating app response from WebDriver click duration.

Refs #949

## Performance data

Environment: Windows desktop `release-fast`, same machine, 5-run median for startup/session scenarios and 3-run median for editor first-open. Baseline is `gcwing/main` at `22508484`; after is this PR at `9d1d22f2`. Report sets are the `2026-06-15T13:30Z` baseline files and `2026-06-15T14:01Z` after files under `tests/e2e/reports/performance/`.

| Scenario | Before | After | Delta | Notes |
| --- | ---: | ---: | ---: | --- |
| Cold start to interactive chat shell | 502.9 ms | 477.1 ms | -25.8 ms | Native WebView/window work still dominates and remains environment-sensitive. |
| First open long session to latest content usable | 191.9 ms | 178.2 ms | -13.7 ms | Latest visible: 180.0 -> 170.9 ms. |
| First open long session to full hydrate end | 493.0 ms | 486.3 ms | -6.7 ms | Full history completion remains mostly IO/restore-bound. |
| Warm reopen long session to latest content usable | 119.3 ms | 118.3 ms | -1.0 ms | Neutral/slightly better. |
| Rapid switch first click to target session usable | 410.9 ms | 407.5 ms | -3.4 ms | End-to-end multi-session flow is neutral/slightly better. |
| Rapid switch target click to target session usable | 110.1 ms | 115.0 ms | +4.9 ms | Small apparent regression; one after sample had a slower click action. New post-click fields make this separable in future runs. |
| Rapid switch target post-click app response to usable | 65.5 ms | 69.0 ms | +3.5 ms | Small regression to watch; visual guards stayed clean. |
| Editor first open ready | 234.8 ms | 173.9 ms | -60.9 ms | Included as guard data; not attributed solely to this import change. |
| Long-session post-latest blank/loading/scroll-jump guard | 0 / 0 / 0 | 0 / 0 / 0 | no change | 15 long-session reports in each set. |

## Risk and compatibility review

- No runtime logging, timers, locks, listeners, storage writes, or scheduling gates were added by this PR.
- Remote and ACP behavior is preserved: command payloads and `remoteSshHost` propagation are unchanged, and the ACP cancellation path still imports `ACPClientAPI` directly.
- The imported API singletons are the same modules previously imported by the broad barrel; the change narrows module graph entrypoints rather than changing API behavior.
- Rapid-switch target-click timing shows a small median regression. It is below the 100 ms interaction target when measured after click action completion, but it is called out here because performance PRs should not hide counter-metrics.

## Validation

- `pnpm --dir src/web-ui run test:run src/app/startup/startupPerformanceContract.test.ts`
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts src/flow_chat/store/FlowChatStore.test.ts`
- `pnpm run type-check:web`
- `git diff --check`
- `git diff --cached --check`
- `pnpm run desktop:build:release-fast`
- 5x `pnpm run e2e:test:perf:release-fast` for baseline and after sets
- 3x editor first-open E2E for baseline and after sets
- GitHub Actions: Frontend Build, Rust Build Check (macos-15), Rust Build Check (ubuntu-latest), Rust Build Check (windows-latest)