### PR TITLE
fix(terminal): preserve xterm state across tab and panel resizes

### DIFF
--- a/src/crates/services/terminal/src/api.rs
+++ b/src/crates/services/terminal/src/api.rs
@@ -15,7 +15,7 @@ use crate::events::TerminalEvent;
 use crate::session::{
     get_session_manager, init_session_manager, is_session_manager_initialized,
     CommandCompletionReason, CommandExecuteResult, ExecuteOptions, SessionManager, SessionSource,
-    TerminalSession,
+    TerminalReplayEvent, TerminalSession,
 };
 use crate::shell::{ShellDetector, ShellType};
 use crate::{TerminalError, TerminalResult};
@@ -160,6 +160,9 @@ pub struct GetHistoryResponse {
     /// Session ID
     #[serde(rename = "sessionId")]
     pub session_id: String,
+    /// Ordered resize/data replay events.
+    #[serde(default)]
+    pub events: Vec<TerminalReplayEvent>,
     /// Output history data
     pub data: String,
     /// Current history size in bytes
@@ -396,10 +399,12 @@ impl TerminalApi {
             .ok_or_else(|| TerminalError::SessionNotFound(request.session_id.to_string()))?;
 
         let data = session.get_history();
+        let events = session.get_replay_events();
         let history_size = session.history_size();
 
         Ok(GetHistoryResponse {
             session_id: request.session_id,
+            events,
             data,
             history_size,
             cols: session.cols,

--- a/src/crates/services/terminal/src/lib.rs
+++ b/src/crates/services/terminal/src/lib.rs
@@ -59,7 +59,7 @@ pub use pty::{
 pub use session::{
     CommandCompletionReason, CommandExecuteResult, CommandStream, CommandStreamEvent,
     ExecuteOptions, SessionManager, SessionSource, SessionStatus, TerminalBindingOptions,
-    TerminalSession, TerminalSessionBinding,
+    TerminalReplayEvent, TerminalReplayHistory, TerminalSession, TerminalSessionBinding,
 };
 pub use shell::{
     get_integration_script_content, CommandState, ScriptsManager, ShellDetector, ShellIntegration,

--- a/src/crates/services/terminal/src/session/mod.rs
+++ b/src/crates/services/terminal/src/session/mod.rs
@@ -6,6 +6,7 @@
 mod binding;
 mod manager;
 mod persistent;
+mod replay;
 mod serializer;
 mod singleton;
 
@@ -15,6 +16,7 @@ pub use manager::{
     ExecuteOptions, SessionManager,
 };
 pub use persistent::PersistentSession;
+pub use replay::{TerminalReplayEvent, TerminalReplayHistory};
 pub use serializer::SessionSerializer;
 pub use singleton::{
     get_session_manager, init_session_manager, is_session_manager_initialized, session_manager,
@@ -98,20 +100,15 @@ pub struct TerminalSession {
     /// Exit code if exited
     pub exit_code: Option<i32>,
 
-    /// Output history buffer (for frontend recovery)
-    /// Not serialized because it's only used during session lifetime
+    /// Replay history buffer (for frontend recovery).
+    ///
+    /// Not serialized by serde on TerminalSession itself; persistence paths use
+    /// SessionSerializer so they can control compatibility explicitly.
     #[serde(skip)]
-    pub output_history: Vec<String>,
-
-    /// Maximum size of output history (in bytes)
-    #[serde(skip)]
-    pub max_history_size: usize,
+    pub replay_history: TerminalReplayHistory,
 }
 
 impl TerminalSession {
-    /// Default maximum history size: 100KB
-    const DEFAULT_MAX_HISTORY_SIZE: usize = 100 * 1024;
-
     /// Create a new terminal session
     pub fn new(
         id: String,
@@ -141,48 +138,39 @@ impl TerminalSession {
             source,
             should_persist: true,
             exit_code: None,
-            output_history: Vec::new(),
-            max_history_size: Self::DEFAULT_MAX_HISTORY_SIZE,
+            replay_history: TerminalReplayHistory::default(),
         }
     }
 
     /// Add output to history (with automatic trimming)
     pub fn add_output(&mut self, data: &str) {
-        if data.is_empty() {
-            return;
-        }
-        self.output_history.push(data.to_string());
-        self.trim_history();
+        self.replay_history
+            .record_output(self.cols, self.rows, data);
+    }
+
+    /// Get structured replay events.
+    pub fn get_replay_events(&self) -> Vec<TerminalReplayEvent> {
+        self.replay_history.events()
+    }
+
+    /// Replace structured replay events, used by persistence restore.
+    pub fn set_replay_events(&mut self, events: Vec<TerminalReplayEvent>) {
+        self.replay_history.replace_events(events);
     }
 
     /// Get all output history as a single string
     pub fn get_history(&self) -> String {
-        self.output_history.concat()
+        self.replay_history.data()
     }
 
     /// Clear all output history
     pub fn clear_history(&mut self) {
-        self.output_history.clear();
-    }
-
-    /// Trim history to stay within max size limit
-    fn trim_history(&mut self) {
-        let mut total_size: usize = self.output_history.iter().map(|s| s.len()).sum();
-
-        // Remove oldest entries until we're under the limit
-        while total_size > self.max_history_size && !self.output_history.is_empty() {
-            if let Some(oldest) = self.output_history.first() {
-                total_size -= oldest.len();
-                self.output_history.remove(0);
-            } else {
-                break;
-            }
-        }
+        self.replay_history.clear();
     }
 
     /// Get current history size in bytes
     pub fn history_size(&self) -> usize {
-        self.output_history.iter().map(|s| s.len()).sum()
+        self.replay_history.size_bytes()
     }
 
     /// Check if the session is active
@@ -234,8 +222,12 @@ impl TerminalSession {
 
     /// Resize the terminal
     pub fn resize(&mut self, cols: u16, rows: u16) {
+        let changed = self.cols != cols || self.rows != rows;
         self.cols = cols;
         self.rows = rows;
+        if changed {
+            self.replay_history.record_resize(cols, rows);
+        }
         self.touch();
     }
 }

--- a/src/crates/services/terminal/src/session/replay.rs
+++ b/src/crates/services/terminal/src/session/replay.rs
@@ -1,0 +1,201 @@
+//! Terminal replay history.
+//!
+//! This stores enough PTY output context for frontend recovery without trying
+//! to serialize an xterm.js buffer.  Each data chunk is tagged with the PTY
+//! dimensions that were active when the backend received it.
+
+use std::collections::VecDeque;
+
+use serde::{Deserialize, Serialize};
+
+/// One replay step for rebuilding a frontend terminal instance.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalReplayEvent {
+    /// Terminal columns active for this replay step.
+    pub cols: u16,
+    /// Terminal rows active for this replay step.
+    pub rows: u16,
+    /// Raw terminal data to write after applying the dimensions.
+    #[serde(default)]
+    pub data: String,
+}
+
+impl TerminalReplayEvent {
+    pub fn resize_marker(cols: u16, rows: u16) -> Self {
+        Self {
+            cols,
+            rows,
+            data: String::new(),
+        }
+    }
+
+    pub fn data(cols: u16, rows: u16, data: String) -> Self {
+        Self { cols, rows, data }
+    }
+
+    fn is_resize_marker(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+/// Bounded replay history for one terminal session.
+#[derive(Debug, Clone)]
+pub struct TerminalReplayHistory {
+    events: VecDeque<TerminalReplayEvent>,
+    max_bytes: usize,
+    max_events: usize,
+}
+
+impl Default for TerminalReplayHistory {
+    fn default() -> Self {
+        Self {
+            events: VecDeque::new(),
+            max_bytes: Self::DEFAULT_MAX_BYTES,
+            max_events: Self::DEFAULT_MAX_EVENTS,
+        }
+    }
+}
+
+impl TerminalReplayHistory {
+    /// Default maximum output payload retained for replay: 100KB.
+    pub const DEFAULT_MAX_BYTES: usize = 100 * 1024;
+    /// Maximum event count retained for replay.
+    pub const DEFAULT_MAX_EVENTS: usize = 2_000;
+
+    pub fn record_output(&mut self, cols: u16, rows: u16, data: &str) {
+        if data.is_empty() {
+            return;
+        }
+
+        // Keep contiguous output with identical PTY dimensions in one event so
+        // replay applies geometry only at real resize boundaries.
+        match self.events.back_mut() {
+            Some(last) if last.cols == cols && last.rows == rows => {
+                last.data.push_str(data);
+            }
+            _ => self
+                .events
+                .push_back(TerminalReplayEvent::data(cols, rows, data.to_string())),
+        }
+
+        self.trim();
+    }
+
+    pub fn record_resize(&mut self, cols: u16, rows: u16) {
+        // A resize marker carries no data; it exists only so the frontend can
+        // apply the new geometry before the next output chunk.
+        match self.events.back_mut() {
+            Some(last) if last.cols == cols && last.rows == rows => {}
+            Some(last) if last.is_resize_marker() => {
+                last.cols = cols;
+                last.rows = rows;
+            }
+            _ => self
+                .events
+                .push_back(TerminalReplayEvent::resize_marker(cols, rows)),
+        }
+
+        self.trim();
+    }
+
+    pub fn replace_events(&mut self, events: Vec<TerminalReplayEvent>) {
+        self.events = events.into();
+        self.trim();
+    }
+
+    pub fn events(&self) -> Vec<TerminalReplayEvent> {
+        self.events.iter().cloned().collect()
+    }
+
+    pub fn data(&self) -> String {
+        self.events
+            .iter()
+            .map(|event| event.data.as_str())
+            .collect()
+    }
+
+    pub fn clear(&mut self) {
+        self.events.clear();
+    }
+
+    pub fn size_bytes(&self) -> usize {
+        self.events.iter().map(|event| event.data.len()).sum()
+    }
+
+    fn trim(&mut self) {
+        while self.events.len() > self.max_events {
+            self.events.pop_front();
+        }
+
+        let mut total_size = self.size_bytes();
+        while total_size > self.max_bytes && !self.events.is_empty() {
+            if let Some(oldest) = self.events.pop_front() {
+                total_size = total_size.saturating_sub(oldest.data.len());
+            }
+        }
+
+        while self.events.len() > 1
+            && self
+                .events
+                .front()
+                .map(TerminalReplayEvent::is_resize_marker)
+                .unwrap_or(false)
+        {
+            // Dropping old output can leave a leading resize-only event. Remove
+            // it so a restored terminal does not treat pure geometry as content.
+            self.events.pop_front();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coalesces_output_with_matching_dimensions() {
+        let mut history = TerminalReplayHistory::default();
+
+        history.record_output(80, 24, "hello");
+        history.record_output(80, 24, " world");
+
+        assert_eq!(
+            history.events(),
+            vec![TerminalReplayEvent::data(80, 24, "hello world".to_string())]
+        );
+    }
+
+    #[test]
+    fn keeps_dimension_changes_in_order() {
+        let mut history = TerminalReplayHistory::default();
+
+        history.record_output(80, 24, "a");
+        history.record_resize(100, 30);
+        history.record_output(100, 30, "b");
+
+        assert_eq!(
+            history.events(),
+            vec![
+                TerminalReplayEvent::data(80, 24, "a".to_string()),
+                TerminalReplayEvent::data(100, 30, "b".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn coalesces_consecutive_resize_markers() {
+        let mut history = TerminalReplayHistory::default();
+
+        history.record_output(80, 24, "a");
+        history.record_resize(90, 25);
+        history.record_resize(100, 30);
+
+        assert_eq!(
+            history.events(),
+            vec![
+                TerminalReplayEvent::data(80, 24, "a".to_string()),
+                TerminalReplayEvent::resize_marker(100, 30),
+            ]
+        );
+    }
+}

--- a/src/crates/services/terminal/src/session/serializer.rs
+++ b/src/crates/services/terminal/src/session/serializer.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use crate::shell::ShellType;
 use crate::{TerminalError, TerminalResult};
 
-use super::{SessionMetadata, SessionSource, SessionStatus, TerminalSession};
+use super::{SessionMetadata, SessionSource, SessionStatus, TerminalReplayEvent, TerminalSession};
 
 /// Version of the serialization format
 const SERIALIZATION_VERSION: u32 = 1;
@@ -57,21 +57,10 @@ pub struct SerializedSession {
     pub source: SessionSource,
 
     /// Replay events for restoring terminal content
-    pub replay_events: Vec<ReplayEvent>,
+    pub replay_events: Vec<TerminalReplayEvent>,
 
     /// Creation timestamp
     pub created_at: i64,
-}
-
-/// Event for replaying terminal content
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReplayEvent {
-    /// Terminal dimensions at this point
-    pub cols: u16,
-    pub rows: u16,
-
-    /// Data to replay
-    pub data: String,
 }
 
 /// Session serializer
@@ -94,7 +83,7 @@ impl SessionSerializer {
                 env: s.env.clone(),
                 metadata: s.metadata.clone(),
                 source: s.source.clone(),
-                replay_events: Vec::new(), // TODO: Capture replay events
+                replay_events: s.get_replay_events(),
                 created_at: s.created_at.timestamp(),
             })
             .collect();
@@ -140,6 +129,7 @@ impl SessionSerializer {
         session.metadata = serialized.metadata.clone();
         session.metadata.was_restored = true;
         session.status = SessionStatus::Starting;
+        session.set_replay_events(serialized.replay_events.clone());
 
         session
     }
@@ -149,11 +139,8 @@ impl SessionSerializer {
         session: &TerminalSession,
         replay_data: &str,
     ) -> TerminalResult<String> {
-        let replay_event = ReplayEvent {
-            cols: session.cols,
-            rows: session.rows,
-            data: replay_data.to_string(),
-        };
+        let replay_event =
+            TerminalReplayEvent::data(session.cols, session.rows, replay_data.to_string());
 
         let serialized = SerializedSession {
             id: session.id.clone(),

--- a/src/web-ui/src/app/components/panels/base/FlexiblePanel.tsx
+++ b/src/web-ui/src/app/components/panels/base/FlexiblePanel.tsx
@@ -165,6 +165,7 @@ const FlexiblePanel: React.FC<ExtendedFlexiblePanelProps> = memo(({
   onDirtyStateChange,
   isActive = true,
   onFileMissingFromDiskChange,
+  terminalResizeSuspended = false,
 }) => {
   const { t, formatDate } = useI18n('components');
 
@@ -772,6 +773,7 @@ const FlexiblePanel: React.FC<ExtendedFlexiblePanelProps> = memo(({
                 key={sessionId}
                 sessionId={sessionId}
                 autoFocus={true}
+                resizeSuspended={terminalResizeSuspended}
               />
             </div>
           </React.Suspense>

--- a/src/web-ui/src/app/components/panels/base/types.ts
+++ b/src/web-ui/src/app/components/panels/base/types.ts
@@ -55,6 +55,7 @@ export interface FlexiblePanelProps {
   onInteraction?: (itemId: string, userInput: string) => Promise<void>;
   workspacePath?: string;
   onBeforeClose?: (content: PanelContent | null) => Promise<boolean>;
+  terminalResizeSuspended?: boolean;
 }
 
 export interface TabbedFlexiblePanelProps {

--- a/src/web-ui/src/app/components/panels/content-canvas/ContentCanvas.tsx
+++ b/src/web-ui/src/app/components/panels/content-canvas/ContentCanvas.tsx
@@ -38,6 +38,8 @@ export interface ContentCanvasProps {
   onExpandPanel?: () => void;
   /** Custom collapse behavior for canvases hosted outside the right panel. */
   onCollapsePanel?: () => void;
+  /** Suspend terminal fit/PTY resize while the hosting panel is animating. */
+  terminalResizeSuspended?: boolean;
 }
 
 export const ContentCanvas: React.FC<ContentCanvasProps> = ({
@@ -51,10 +53,13 @@ export const ContentCanvas: React.FC<ContentCanvasProps> = ({
   isPanelCollapsed,
   onExpandPanel,
   onCollapsePanel,
+  terminalResizeSuspended = false,
 }) => {
   // Store state
   const {
     primaryGroup,
+    secondaryGroup,
+    tertiaryGroup,
     layout,
     isMissionControlOpen,
     setAnchorPosition,
@@ -106,11 +111,14 @@ export const ContentCanvas: React.FC<ContentCanvasProps> = ({
     void openMainSession(activeBtwSessionData.parentSessionId);
   }, [activeBtwSessionData?.parentSessionId, activeBtwSessionData?.workspacePath, activeBtwSessionTab?.id, mode, workspacePath]);
 
-  // Check if primary group has visible tabs
-  const hasPrimaryVisibleTabs = useMemo(() => {
-    const primaryVisible = primaryGroup.tabs.filter(t => !t.isHidden).length;
-    return primaryVisible > 0;
-  }, [primaryGroup.tabs]);
+  // Keep the editor area mounted for hidden terminal tabs. Closing a terminal
+  // tab backgrounds it without destroying the xterm instance.
+  const hasRenderableTabs = useMemo(() => {
+    const groups = [primaryGroup, secondaryGroup, tertiaryGroup];
+    return groups.some(group =>
+      group.tabs.some(tab => !tab.isHidden || tab.content.type === 'terminal')
+    );
+  }, [primaryGroup, secondaryGroup, tertiaryGroup]);
 
   // Handle anchor close
   const handleAnchorClose = useCallback(() => {
@@ -139,8 +147,8 @@ export const ContentCanvas: React.FC<ContentCanvasProps> = ({
 
   // Render content
   const renderContent = () => {
-    // Show empty state when primary group has no visible tabs
-    if (!hasPrimaryVisibleTabs) {
+    // Show empty state when there are no visible tabs and no terminal keep-alive tabs.
+    if (!hasRenderableTabs) {
       return <EmptyState onClose={disablePopOut ? undefined : collapsePanel} />;
     }
 
@@ -156,6 +164,7 @@ export const ContentCanvas: React.FC<ContentCanvasProps> = ({
             onTabCloseWithDirtyCheck={handleCloseWithDirtyCheck}
             onTabCloseAllWithDirtyCheck={handleCloseAllWithDirtyCheck}
             disablePopOut={disablePopOut}
+            terminalResizeSuspended={terminalResizeSuspended}
           />
         </div>
 

--- a/src/web-ui/src/app/components/panels/content-canvas/editor-area/EditorArea.tsx
+++ b/src/web-ui/src/app/components/panels/content-canvas/editor-area/EditorArea.tsx
@@ -17,6 +17,7 @@ export interface EditorAreaProps {
   onTabCloseWithDirtyCheck?: (tabId: string, groupId: EditorGroupId) => Promise<boolean>;
   onTabCloseAllWithDirtyCheck?: (groupId: EditorGroupId) => Promise<boolean>;
   disablePopOut?: boolean;
+  terminalResizeSuspended?: boolean;
 }
 
 export const EditorArea: React.FC<EditorAreaProps> = ({
@@ -27,6 +28,7 @@ export const EditorArea: React.FC<EditorAreaProps> = ({
   onTabCloseWithDirtyCheck,
   onTabCloseAllWithDirtyCheck,
   disablePopOut = false,
+  terminalResizeSuspended = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const topRowRef = useRef<HTMLDivElement>(null);
@@ -148,6 +150,7 @@ export const EditorArea: React.FC<EditorAreaProps> = ({
       onCloseAllTabs={handleCloseAllTabs(groupId)}
       onInteraction={onInteraction}
       disablePopOut={disablePopOut}
+      terminalResizeSuspended={terminalResizeSuspended}
     />
   );
 

--- a/src/web-ui/src/app/components/panels/content-canvas/editor-area/EditorGroup.tsx
+++ b/src/web-ui/src/app/components/panels/content-canvas/editor-area/EditorGroup.tsx
@@ -45,6 +45,7 @@ export interface EditorGroupProps {
   onCloseAllTabs?: () => Promise<void> | void;
   onInteraction?: (itemId: string, userInput: string) => Promise<void>;
   disablePopOut?: boolean;
+  terminalResizeSuspended?: boolean;
 }
 
 export const EditorGroup: React.FC<EditorGroupProps> = ({
@@ -72,9 +73,13 @@ export const EditorGroup: React.FC<EditorGroupProps> = ({
   onCloseAllTabs,
   onInteraction,
   disablePopOut = false,
+  terminalResizeSuspended = false,
 }) => {
   const { t } = useTranslation('components');
   const visibleTabs = useMemo(() => group.tabs.filter(t => !t.isHidden), [group.tabs]);
+  const isKeepAliveTerminalTab = useCallback((tab: EditorGroupState['tabs'][number]) =>
+    tab.content.type === 'terminal',
+  []);
   
   // Cache recently visited tabs (max 5) for instant switching
   const cachedTabsRef = useRef<Set<string>>(new Set());
@@ -82,7 +87,11 @@ export const EditorGroup: React.FC<EditorGroupProps> = ({
   // Update cache: keep active tab and 4 most recent tabs
   useEffect(() => {
     // Remove closed tabs
-    const validTabIds = new Set(group.tabs.filter(t => !t.isHidden).map(t => t.id));
+    const validTabIds = new Set(
+      group.tabs
+        .filter(t => !t.isHidden || isKeepAliveTerminalTab(t))
+        .map(t => t.id)
+    );
     cachedTabsRef.current = new Set(
       Array.from(cachedTabsRef.current).filter(id => validTabIds.has(id))
     );
@@ -102,16 +111,17 @@ export const EditorGroup: React.FC<EditorGroupProps> = ({
         cachedTabsRef.current = new Set([group.activeTabId, ...sortedTabs]);
       }
     }
-  }, [group.activeTabId, group.tabs]);
+  }, [group.activeTabId, group.tabs, isKeepAliveTerminalTab]);
   
-  // Tabs to render (active + cached)
+  // Tabs to render (active + cached). Hidden terminal tabs stay mounted so
+  // reopening a terminal reuses the xterm buffer instead of replaying history.
   const tabsToRender = useMemo(() => {
     const result = group.tabs.filter(t => 
-      !t.isHidden && 
-      (t.id === group.activeTabId || cachedTabsRef.current.has(t.id))
+      (!t.isHidden && (t.id === group.activeTabId || cachedTabsRef.current.has(t.id))) ||
+      (t.isHidden && isKeepAliveTerminalTab(t))
     );
     return result;
-  }, [group.tabs, group.activeTabId]);
+  }, [group.tabs, group.activeTabId, isKeepAliveTerminalTab]);
 
   const handleContentChange = useCallback((content: PanelContent | null) => {
     if (content && group.activeTabId) {
@@ -186,6 +196,7 @@ export const EditorGroup: React.FC<EditorGroupProps> = ({
                   }
                   onInteraction={onInteraction}
                   workspacePath={workspacePath}
+                  terminalResizeSuspended={terminalResizeSuspended}
                 />
               </div>
             ))

--- a/src/web-ui/src/app/scenes/session/AuxPane.tsx
+++ b/src/web-ui/src/app/scenes/session/AuxPane.tsx
@@ -32,10 +32,11 @@ export interface AuxPaneRef {
 interface AuxPaneProps {
   workspacePath?: string;
   isSceneActive?: boolean;
+  terminalResizeSuspended?: boolean;
 }
 
 const AuxPane = forwardRef<AuxPaneRef, AuxPaneProps>(
-  ({ workspacePath, isSceneActive = true }, ref) => {
+  ({ workspacePath, isSceneActive = true, terminalResizeSuspended = false }, ref) => {
     const { workspace } = useCurrentWorkspace();
     const workspaceId = workspace?.id;
 
@@ -137,6 +138,7 @@ const AuxPane = forwardRef<AuxPaneRef, AuxPaneProps>(
           isSceneActive={isSceneActive}
           onInteraction={handleInteraction}
           onBeforeClose={handleBeforeClose}
+          terminalResizeSuspended={terminalResizeSuspended}
         />
       </div>
     );

--- a/src/web-ui/src/app/scenes/session/BottomTerminalPane.tsx
+++ b/src/web-ui/src/app/scenes/session/BottomTerminalPane.tsx
@@ -12,6 +12,7 @@ interface BottomTerminalPaneProps {
   isCollapsed: boolean;
   onExpand: () => void;
   onCollapse: () => void;
+  terminalResizeSuspended?: boolean;
 }
 
 const BottomTerminalPane: React.FC<BottomTerminalPaneProps> = ({
@@ -20,6 +21,7 @@ const BottomTerminalPane: React.FC<BottomTerminalPaneProps> = ({
   isCollapsed,
   onExpand,
   onCollapse,
+  terminalResizeSuspended = false,
 }) => {
   const handleInteraction = useCallback(async (_itemId: string, _userInput: string) => {
     // Terminal tabs do not use ContentCanvas interaction callbacks.
@@ -42,6 +44,7 @@ const BottomTerminalPane: React.FC<BottomTerminalPaneProps> = ({
           isPanelCollapsed={isCollapsed}
           onExpandPanel={onExpand}
           onCollapsePanel={onCollapse}
+          terminalResizeSuspended={terminalResizeSuspended}
         />
       </div>
     </CanvasStoreModeContext.Provider>

--- a/src/web-ui/src/app/scenes/session/SessionScene.tsx
+++ b/src/web-ui/src/app/scenes/session/SessionScene.tsx
@@ -9,7 +9,7 @@
  * Resizer logic moved here from WorkspaceShell.
  */
 
-import React, { useRef, useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useRef, useState, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApp } from '../../hooks/useApp';
 import ChatPane from './ChatPane';
@@ -38,6 +38,7 @@ import {
 
 import './SessionScene.scss';
 
+const TERMINAL_PANEL_RESIZE_SUSPEND_FALLBACK_MS = 360;
 
 interface SessionSceneProps {
   workspacePath?: string;
@@ -64,6 +65,8 @@ const SessionScene: React.FC<SessionSceneProps> = ({
   const [isDraggingBottom, setIsDraggingBottom] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
   const [isHoveringBottom, setIsHoveringBottom] = useState(false);
+  const [isRightPanelTransitioning, setIsRightPanelTransitioning] = useState(false);
+  const [isBottomTerminalPanelTransitioning, setIsBottomTerminalPanelTransitioning] = useState(false);
   const [terminalPanelPosition, setTerminalPanelPosition] = useState<TerminalPanelPosition>(() =>
     getCachedTerminalPanelPosition(),
   );
@@ -79,11 +82,53 @@ const SessionScene: React.FC<SessionSceneProps> = ({
   const animationFrameRef = useRef<number | null>(null);
   const bottomExpandPendingRef = useRef(false);
   const bottomCollapsePendingRef = useRef(false);
+  const rightPanelTransitionTimerRef = useRef<number | null>(null);
+  const bottomPanelTransitionTimerRef = useRef<number | null>(null);
+  const previousRightTransitionKeyRef = useRef<string | null>(null);
+  const previousBottomTransitionKeyRef = useRef<string | null>(null);
 
   const currentRightWidth = state.layout.rightPanelWidth || RIGHT_PANEL_CONFIG.COMFORTABLE_DEFAULT;
   const currentBottomHeight = state.layout.bottomTerminalPanelHeight || BOTTOM_TERMINAL_PANEL_CONFIG.COMFORTABLE_DEFAULT;
   const isTerminalDockedBottom = terminalPanelPosition === 'bottom';
   const isDragging = isDraggingRight || isDraggingBottom;
+
+  const stopRightPanelTransition = useCallback(() => {
+    if (rightPanelTransitionTimerRef.current !== null) {
+      window.clearTimeout(rightPanelTransitionTimerRef.current);
+      rightPanelTransitionTimerRef.current = null;
+    }
+    setIsRightPanelTransitioning(false);
+  }, []);
+
+  const startRightPanelTransition = useCallback(() => {
+    if (rightPanelTransitionTimerRef.current !== null) {
+      window.clearTimeout(rightPanelTransitionTimerRef.current);
+    }
+    setIsRightPanelTransitioning(true);
+    rightPanelTransitionTimerRef.current = window.setTimeout(
+      stopRightPanelTransition,
+      TERMINAL_PANEL_RESIZE_SUSPEND_FALLBACK_MS,
+    );
+  }, [stopRightPanelTransition]);
+
+  const stopBottomPanelTransition = useCallback(() => {
+    if (bottomPanelTransitionTimerRef.current !== null) {
+      window.clearTimeout(bottomPanelTransitionTimerRef.current);
+      bottomPanelTransitionTimerRef.current = null;
+    }
+    setIsBottomTerminalPanelTransitioning(false);
+  }, []);
+
+  const startBottomPanelTransition = useCallback(() => {
+    if (bottomPanelTransitionTimerRef.current !== null) {
+      window.clearTimeout(bottomPanelTransitionTimerRef.current);
+    }
+    setIsBottomTerminalPanelTransitioning(true);
+    bottomPanelTransitionTimerRef.current = window.setTimeout(
+      stopBottomPanelTransition,
+      TERMINAL_PANEL_RESIZE_SUSPEND_FALLBACK_MS,
+    );
+  }, [stopBottomPanelTransition]);
 
   const rightPanelMode: PanelDisplayMode = useMemo(() => {
     if (state.layout.rightPanelCollapsed) return 'collapsed';
@@ -343,10 +388,96 @@ const SessionScene: React.FC<SessionSceneProps> = ({
   // Cleanup animation frames
   useEffect(() => () => {
     if (animationFrameRef.current !== null) cancelAnimationFrame(animationFrameRef.current);
+    if (rightPanelTransitionTimerRef.current !== null) {
+      window.clearTimeout(rightPanelTransitionTimerRef.current);
+    }
+    if (bottomPanelTransitionTimerRef.current !== null) {
+      window.clearTimeout(bottomPanelTransitionTimerRef.current);
+    }
   }, []);
 
   const isRightAsMain = state.layout.chatCollapsed;
   const isChatHidden = state.layout.centerPanelCollapsed || isRightAsMain;
+
+  // Terminal resize is suspended for the whole CSS transition. xterm.js reflows
+  // its buffer on every resize, so fitting through intermediate panel widths can
+  // permanently damage scrollback before the panel reaches its final size.
+  useLayoutEffect(() => {
+    const transitionKey = [
+      state.layout.rightPanelCollapsed ? 'collapsed' : 'open',
+      currentRightWidth,
+      isRightAsMain ? 'main' : 'side',
+    ].join(':');
+
+    if (previousRightTransitionKeyRef.current === null) {
+      previousRightTransitionKeyRef.current = transitionKey;
+      return;
+    }
+
+    if (previousRightTransitionKeyRef.current === transitionKey) {
+      return;
+    }
+
+    previousRightTransitionKeyRef.current = transitionKey;
+
+    if (isDraggingRight || isAuxPaneExpandingImmediate) {
+      return;
+    }
+
+    startRightPanelTransition();
+  }, [
+    currentRightWidth,
+    isAuxPaneExpandingImmediate,
+    isDraggingRight,
+    isRightAsMain,
+    startRightPanelTransition,
+    state.layout.rightPanelCollapsed,
+  ]);
+
+  // Bottom docking uses the same suspension as the right panel. This keeps the
+  // compact final height usable while avoiding transient animation heights.
+  useLayoutEffect(() => {
+    const transitionKey = [
+      state.layout.bottomTerminalPanelCollapsed ? 'collapsed' : 'open',
+      currentBottomHeight,
+      isTerminalDockedBottom ? 'bottom' : 'right',
+    ].join(':');
+
+    if (previousBottomTransitionKeyRef.current === null) {
+      previousBottomTransitionKeyRef.current = transitionKey;
+      return;
+    }
+
+    if (previousBottomTransitionKeyRef.current === transitionKey) {
+      return;
+    }
+
+    previousBottomTransitionKeyRef.current = transitionKey;
+
+    if (isDraggingBottom || !isTerminalDockedBottom) {
+      return;
+    }
+
+    startBottomPanelTransition();
+  }, [
+    currentBottomHeight,
+    isDraggingBottom,
+    isTerminalDockedBottom,
+    startBottomPanelTransition,
+    state.layout.bottomTerminalPanelCollapsed,
+  ]);
+
+  const handleRightPanelTransitionEnd = useCallback((event: React.TransitionEvent<HTMLDivElement>) => {
+    if (event.currentTarget !== event.target) return;
+    if (event.propertyName !== 'width') return;
+    stopRightPanelTransition();
+  }, [stopRightPanelTransition]);
+
+  const handleBottomPanelTransitionEnd = useCallback((event: React.TransitionEvent<HTMLDivElement>) => {
+    if (event.currentTarget !== event.target) return;
+    if (event.propertyName !== 'height') return;
+    stopBottomPanelTransition();
+  }, [stopBottomPanelTransition]);
 
   const panelModeLabels = useMemo(() => ({
     collapsed:    t('layout.panelMode.collapsed'),
@@ -443,11 +574,13 @@ const SessionScene: React.FC<SessionSceneProps> = ({
               : isRightAsMain ? undefined : `${currentRightWidth}px`,
           }}
           data-mode={rightPanelMode}
+          onTransitionEnd={handleRightPanelTransitionEnd}
         >
           <AuxPane
             ref={auxPaneRef}
             workspacePath={workspacePath}
             isSceneActive={isActive}
+            terminalResizeSuspended={isRightPanelTransitioning || isDraggingRight}
           />
         </div>
       </div>
@@ -498,6 +631,7 @@ const SessionScene: React.FC<SessionSceneProps> = ({
               height: state.layout.bottomTerminalPanelCollapsed ? undefined : `${currentBottomHeight}px`,
             }}
             data-mode={bottomTerminalPanelMode}
+            onTransitionEnd={handleBottomPanelTransitionEnd}
           >
             <BottomTerminalPane
               workspacePath={workspacePath}
@@ -505,6 +639,7 @@ const SessionScene: React.FC<SessionSceneProps> = ({
               isCollapsed={state.layout.bottomTerminalPanelCollapsed}
               onExpand={expandBottomTerminalPanel}
               onCollapse={collapseBottomTerminalPanel}
+              terminalResizeSuspended={isBottomTerminalPanelTransitioning || isDraggingBottom}
             />
           </div>
         </>

--- a/src/web-ui/src/app/scenes/terminal/TerminalScene.tsx
+++ b/src/web-ui/src/app/scenes/terminal/TerminalScene.tsx
@@ -29,17 +29,16 @@ const TerminalScene: React.FC<TerminalSceneProps> = ({ isActive = true }) => {
     setActiveSession(null);
   }, [setActiveSession]);
 
-  if (!isActive) {
-    return <div className="bitfun-terminal-scene" aria-hidden="true" />;
-  }
-
+  // Keep the ConnectedTerminal mounted when the scene is inactive. Unmounting
+  // would dispose xterm and force replay on return, which can lose scrollback
+  // and cursor state after resize-sensitive shell output.
   return (
-    <div className="bitfun-terminal-scene">
+    <div className="bitfun-terminal-scene" aria-hidden={!isActive}>
       {activeSessionId ? (
         <ConnectedTerminal
           key={activeSessionId}
           sessionId={activeSessionId}
-          autoFocus
+          autoFocus={isActive}
           showToolbar
           showStatusBar
           onExit={handleExit}

--- a/src/web-ui/src/tools/terminal/components/ConnectedTerminal.tsx
+++ b/src/web-ui/src/tools/terminal/components/ConnectedTerminal.tsx
@@ -8,9 +8,10 @@ import { AlertCircle, RefreshCw, Terminal as TerminalIcon, Trash2 } from 'lucide
 import Terminal, { TerminalRef } from './Terminal';
 import { useTerminal } from '../hooks/useTerminal';
 import { registerTerminalActions, unregisterTerminalActions } from '../services/TerminalActionManager';
+import { ResizeRepaintGuard, createResizeRepaintScreenSnapshot, terminalReplayHasScreenText } from '../utils';
 import { confirmWarning } from '@/component-library';
 import { createLogger } from '@/shared/utils/logger';
-import type { SessionResponse } from '../types';
+import type { SessionResponse, TerminalReplayEvent } from '../types';
 import './Terminal.scss';
 
 const log = createLogger('ConnectedTerminal');
@@ -26,6 +27,13 @@ const MULTILINE_PASTE_THRESHOLD = 1;
 // eslint-disable-next-line no-control-regex -- ESC-based cursor reposition sequences are part of terminal protocol parsing.
 const CURSOR_POS_RE = /^\x1b\[(\d+);(\d+)H$/;
 
+type QueuedTerminalItem =
+  | { type: 'write'; data: string; source: 'live' | 'replay' }
+  // Replay resize entries may be pure geometry snapshots. Only protect column
+  // width when the same replay batch contains visible screen text.
+  | { type: 'replayResize'; cols: number; rows: number; protectScreenText: boolean }
+  | { type: 'replayComplete' };
+
 export interface ConnectedTerminalProps {
   sessionId: string;
   className?: string;
@@ -37,6 +45,7 @@ export interface ConnectedTerminalProps {
   onClose?: () => void;
   onTitleChange?: (title: string) => void;
   onExit?: (exitCode?: number) => void;
+  resizeSuspended?: boolean;
 }
 
 const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
@@ -49,6 +58,7 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
   onClose,
   onTitleChange,
   onExit,
+  resizeSuspended = false,
 }) => {
   const terminalRef = useRef<TerminalRef>(null);
   const [title, setTitle] = useState<string>(initialSession?.name || 'Terminal');
@@ -56,23 +66,18 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
   const [isExited, setIsExited] = useState(false);
 
   const lastSentSizeRef = useRef<{ cols: number; rows: number } | null>(null);
+  const resizeRepaintGuardRef = useRef(new ResizeRepaintGuard());
 
   // Buffer output until the terminal is ready.
   // Use a ref (not state) to avoid stale closure issues with isTerminalReady.
   const isTerminalReadyRef = useRef(false);
-  const outputQueueRef = useRef<string[]>([]);
+  const outputQueueRef = useRef<QueuedTerminalItem[]>([]);
 
   // After history replay, ConPTY sends absolute cursor-position commands (ESC[R;CH)
   // that reference its own coordinate system, which diverges from xterm.js after replay.
   // We let those commands pass through (to avoid side effects from redirecting them) and
   // instead restore the correct cursor position via write callbacks after each one.
   const postHistoryCursorRef = useRef<{ row: number; col: number; ignoreCount: number } | null>(null);
-
-  // PTY dimensions stored with the history snapshot.
-  // Used to resize xterm.js to the correct size before replaying history, so that
-  // absolute cursor-position sequences in the history (e.g. ESC[27;1H) are not
-  // clamped to the xterm.js default row count (24).
-  const historyDimsRef = useRef<{ cols: number; rows: number } | null>(null);
 
   // While set to a positive value, Terminal's doXtermResize will refuse to shrink
   // the column count below this threshold.  Set during history flush so that the
@@ -81,7 +86,50 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
   // Cleared when post-history cursor mode exits.
   const preventShrinkBelowColsRef = useRef<number>(0);
 
+  const queueWrite = useCallback((data: string, source: 'live' | 'replay' = 'live') => {
+    outputQueueRef.current.push({ type: 'write', data, source });
+  }, []);
+
+  const setReplayColumnGuard = useCallback((cols: number) => {
+    preventShrinkBelowColsRef.current = Math.max(preventShrinkBelowColsRef.current, cols);
+  }, []);
+
+  const applyReplayResize = useCallback((cols: number, rows: number, protectScreenText: boolean) => {
+    const xterm = terminalRef.current?.getTerminal?.();
+    if (!xterm) return;
+
+    if (protectScreenText) {
+      setReplayColumnGuard(cols);
+    }
+    try {
+      if (xterm.cols !== cols || xterm.rows !== rows) {
+        xterm.resize(cols, rows);
+      }
+    } catch (error) {
+      log.warn('Replay resize failed', { sessionId, cols, rows, error });
+    }
+  }, [sessionId, setReplayColumnGuard]);
+
+  const capturePostReplayCursor = useCallback(() => {
+    const xterm = terminalRef.current?.getTerminal?.();
+    if (!xterm) return;
+
+    xterm.write('', () => {
+      const cursorY = xterm.buffer.active.cursorY; // 0-indexed
+      const cursorRow = cursorY + 1; // 1-indexed for ANSI
+      if (cursorRow > 0) {
+        const cursorCol = xterm.buffer.active.cursorX + 1; // 1-indexed
+        postHistoryCursorRef.current = { row: cursorRow, col: cursorCol, ignoreCount: 10 };
+      }
+    });
+  }, []);
+
   const handleOutput = useCallback((data: string) => {
+    const repaintDecision = resizeRepaintGuardRef.current.inspect(data);
+    if (repaintDecision.suppress) {
+      return;
+    }
+
     // Post-history cursor restoration:
     // ConPTY sends standalone cursor-position commands after resize in its own coordinate
     // system. We let them pass through unmodified (redirecting them caused content side
@@ -94,8 +142,8 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
         cursor.ignoreCount--;
         const restoreSeq = `\x1b[${cursor.row};${cursor.col}H`;
         if (!isTerminalReadyRef.current || !terminalRef.current) {
-          outputQueueRef.current.push(data);
-          outputQueueRef.current.push(restoreSeq);
+          queueWrite(data);
+          queueWrite(restoreSeq);
           return;
         }
         const xterm = terminalRef.current.getTerminal?.();
@@ -118,11 +166,11 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
     }
 
     if (!isTerminalReadyRef.current || !terminalRef.current) {
-      outputQueueRef.current.push(data);
+      queueWrite(data);
       return;
     }
     terminalRef.current.write(data);
-  }, []); // No state deps - reads from refs which are always current
+  }, [queueWrite]); // No state deps - reads from refs which are always current
 
   const flushOutputQueue = useCallback(() => {
     const queue = outputQueueRef.current;
@@ -130,44 +178,31 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
     // Clear first to prevent orphaned items if new data arrives during flush
     outputQueueRef.current = [];
 
-    // If we have historical PTY dimensions, resize xterm.js to the correct row
-    // count before replaying content.  This prevents absolute cursor-position
-    // sequences embedded in the history (e.g. ESC[27;1H) from being clamped to
-    // xterm.js's default 24-row size, which would corrupt the rendered output.
-    // We also lock doXtermResize against shrinking so that the CSS open-animation
-    // (which passes through many narrow column counts) cannot permanently truncate
-    // the history content that is about to be written at the historical width.
-    const dims = historyDimsRef.current;
-    if (dims) {
-      const xterm = terminalRef.current?.getTerminal?.();
-      if (xterm) {
-        const targetRows = Math.max(xterm.rows, dims.rows);
-        try {
-          if (xterm.rows !== targetRows) {
-            xterm.resize(xterm.cols, targetRows);
+    queue.forEach((item, index) => {
+      switch (item.type) {
+        case 'replayResize':
+          applyReplayResize(item.cols, item.rows, item.protectScreenText);
+          break;
+        case 'write':
+          if (item.source === 'live') {
+            postHistoryCursorRef.current = null;
+            preventShrinkBelowColsRef.current = 0;
           }
-        } catch { /* ignore */ }
-        // Prevent doXtermResize from shrinking below the historical col width.
-        preventShrinkBelowColsRef.current = dims.cols;
+          terminalRef.current?.write(item.data);
+          break;
+        case 'replayComplete':
+          // Cursor restoration is only meaningful after visible replay content.
+          // Pure metadata replay should not enter post-history mode because the
+          // next live shell startup output owns the real cursor position.
+          if (queue.slice(index + 1).some(next => next.type === 'write' && next.source === 'live')) {
+            preventShrinkBelowColsRef.current = 0;
+          } else {
+            capturePostReplayCursor();
+          }
+          break;
       }
-    }
-
-    queue.forEach(data => terminalRef.current?.write(data));
-
-    // After all history writes complete, save the cursor row so that subsequent
-    // ConPTY cursor-only updates can be redirected to this correct position.
-    const xterm = terminalRef.current?.getTerminal?.();
-    if (xterm) {
-      xterm.write('', () => {
-        const cursorY = xterm.buffer.active.cursorY; // 0-indexed
-        const cursorRow = cursorY + 1; // 1-indexed for ANSI
-        if (cursorRow > 0) {
-          const cursorCol = xterm.buffer.active.cursorX + 1; // 1-indexed
-          postHistoryCursorRef.current = { row: cursorRow, col: cursorCol, ignoreCount: 10 };
-        }
-      });
-    }
-  }, []);
+    });
+  }, [applyReplayResize, capturePostReplayCursor]);
 
   const handleReady = useCallback(() => {
     // Backend ready event - terminal UI is already ready via handleTerminalReady
@@ -184,9 +219,42 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
     log.error('Terminal error', { sessionId, message });
   }, [sessionId]);
 
-  const handleHistoryDims = useCallback((cols: number, rows: number) => {
-    historyDimsRef.current = { cols, rows };
-  }, []);
+  const handleReplay = useCallback((events: TerminalReplayEvent[]) => {
+    if (events.length === 0) return;
+
+    resizeRepaintGuardRef.current.clear();
+
+    // A new session can replay only resize/OSC metadata. Treating that as
+    // protected history would lock the initial 80-column xterm size and let the
+    // backend resize first, which produced blank scrollback on right terminals.
+    const hasReplayScreenText = terminalReplayHasScreenText(events);
+    const maxReplayCols = hasReplayScreenText
+      ? events.reduce((max, event) => Math.max(max, event.cols), 0)
+      : 0;
+    if (maxReplayCols > 0) {
+      setReplayColumnGuard(maxReplayCols);
+    }
+
+    events.forEach((event) => {
+      outputQueueRef.current.push({
+        type: 'replayResize',
+        cols: event.cols,
+        rows: event.rows,
+        protectScreenText: hasReplayScreenText,
+      });
+      if (event.data) {
+        queueWrite(event.data, 'replay');
+      }
+    });
+    if (hasReplayScreenText) {
+      outputQueueRef.current.push({ type: 'replayComplete' });
+    }
+
+    if (isTerminalReadyRef.current && terminalRef.current) {
+      terminalRef.current.flushResize();
+      flushOutputQueue();
+    }
+  }, [flushOutputQueue, queueWrite, setReplayColumnGuard]);
 
   const {
     session,
@@ -204,11 +272,12 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
     onReady: handleReady,
     onExit: handleExit,
     onError: handleError,
-    onHistoryDims: handleHistoryDims,
+    onReplay: handleReplay,
   });
 
   const handleData = useCallback((data: string) => {
     if (!isExited) {
+      resizeRepaintGuardRef.current.clear();
       write(data).catch(err => {
         log.error('Write failed', { sessionId, error: err });
       });
@@ -220,6 +289,20 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
     if (lastSize && lastSize.cols === cols && lastSize.rows === rows) {
       return;
     }
+
+    const xterm = terminalRef.current?.getTerminal?.() ?? null;
+    const screen = createResizeRepaintScreenSnapshot(xterm);
+    if (screen) {
+      resizeRepaintGuardRef.current.markResize({
+        cols,
+        rows,
+        previousCols: lastSize?.cols,
+        previousRows: lastSize?.rows,
+        shellType: session?.shellType ?? initialSession?.shellType,
+        screen,
+      });
+    }
+
     lastSentSizeRef.current = { cols, rows };
 
     // If post-history cursor mode is active, update the saved cursor position
@@ -237,9 +320,10 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
     resize(cols, rows).then(() => {
     }).catch(err => {
       log.error('Resize failed', { sessionId, cols, rows, error: err });
+      resizeRepaintGuardRef.current.clear();
       lastSentSizeRef.current = null;
     });
-  }, [resize, sessionId]);
+  }, [initialSession?.shellType, resize, session?.shellType, sessionId]);
 
   const handleTitleChange = useCallback((newTitle: string) => {
     setTitle(newTitle);
@@ -412,6 +496,7 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
         onReady={handleTerminalReady}
         onPaste={handlePaste}
         preventShrinkBelowColsRef={preventShrinkBelowColsRef}
+        resizeSuspended={resizeSuspended}
       />
 
       {showStatusBar && session && (

--- a/src/web-ui/src/tools/terminal/components/Terminal.tsx
+++ b/src/web-ui/src/tools/terminal/components/Terminal.tsx
@@ -24,6 +24,21 @@ import '@xterm/xterm/css/xterm.css';
 import './Terminal.scss';
 
 const log = createLogger('Terminal');
+const MIN_STABLE_TERMINAL_ROWS = 3;
+
+// Empty xterm buffers start with blank rows. Do not treat those as replayed
+// content, otherwise a new terminal can inherit the replay column guard and skip
+// its first real fit.
+function terminalHasBufferedScreenText(terminal: XTerm): boolean {
+  const buffer = terminal.buffer.active;
+  for (let index = 0; index < buffer.length; index += 1) {
+    const line = buffer.getLine(index)?.translateToString(true) ?? '';
+    if (line.trim().length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
 
 type TerminalCoreWithMeasurement = XTerm & {
   _core?: {
@@ -54,16 +69,6 @@ function remeasureTerminal(terminal: XTerm): void {
   const rawTerminal = terminal as TerminalCoreWithMeasurement;
   rawTerminal._core?._charSizeService?.measure?.();
   rawTerminal._core?._renderService?.handleDevicePixelRatioChange?.();
-}
-
-/**
- * Scroll to bottom when the cursor is below the viewport.
- */
-function scrollToBottomIfNeeded(terminal: XTerm): void {
-  const buffer = terminal.buffer.active;
-  if (buffer.cursorY >= terminal.rows - 1) {
-    terminal.scrollToBottom();
-  }
 }
 
 export interface TerminalOptions {
@@ -130,6 +135,12 @@ export interface TerminalProps {
    * content. Set back to 0 (or leave unset) to restore normal resize behaviour.
    */
   preventShrinkBelowColsRef?: React.MutableRefObject<number>;
+  /**
+   * Suspend layout-driven resize while the containing panel is animating.
+   * xterm.js reflows its buffer on resize, so intermediate transition sizes
+   * should be ignored and replaced by one final fit when animation settles.
+   */
+  resizeSuspended?: boolean;
 }
 
 export interface TerminalRef {
@@ -179,6 +190,7 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
   onReady,
   onPaste,
   preventShrinkBelowColsRef,
+  resizeSuspended = false,
 }, ref) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<XTerm | null>(null);
@@ -199,6 +211,8 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
   const onResizeRef = useRef(onResize);
   const onReadyRef = useRef(onReady);
   const onPasteRef = useRef(onPaste);
+  const resizeSuspendedRef = useRef(resizeSuspended);
+  const pendingFitAfterSuspendRef = useRef(false);
   const [isReady, setIsReady] = useState(false);
   const currentTheme = themeService.getCurrentTheme();
   const initialFontWeights = getXtermFontWeights(currentTheme.type);
@@ -226,6 +240,7 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
   onResizeRef.current = onResize;
   onReadyRef.current = onReady;
   onPasteRef.current = onPaste;
+  resizeSuspendedRef.current = resizeSuspended;
   mergedOptionsRef.current = mergedOptions;
   initialFontWeightsRef.current = initialFontWeights;
 
@@ -236,13 +251,18 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
     clearTextureAtlas(terminal);
   }, []);
 
-  const doXtermResize = useCallback((cols: number, rows: number) => {
+  const doXtermResize = useCallback((cols: number, rows: number): boolean => {
     const terminal = terminalRef.current;
-    if (!terminal) return;
+    if (!terminal) return false;
 
     try {
+      if (resizeSuspendedRef.current) {
+        pendingFitAfterSuspendRef.current = true;
+        return false;
+      }
+
       if (terminal.cols === cols && terminal.rows === rows) {
-        return;
+        return true;
       }
 
       // While the caller has set a minimum column guard (e.g., during history
@@ -250,18 +270,38 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
       // prevents CSS open-animation intermediate widths from permanently
       // truncating buffered content that was written at a wider column count.
       const minCols = preventShrinkBelowColsRef?.current ?? 0;
-      if (minCols > 0 && cols < minCols) {
-        return;
+      const hasBufferedScreenText = minCols > 0 ? terminalHasBufferedScreenText(terminal) : false;
+      // The guard only protects actual screen text. Applying it to an empty new
+      // terminal leaves xterm at 80x24 while the PTY moves to the panel size,
+      // which creates blank scrollback during shell startup repaints.
+      if (minCols > 0 && cols < minCols && hasBufferedScreenText) {
+        return false;
       }
 
       terminal.resize(cols, rows);
+
+      return true;
     } catch (error) {
       log.warn('Xterm resize error', { cols, rows, error });
+      return false;
     }
   }, [preventShrinkBelowColsRef]);
 
   // Notify backend PTY with deduping.
   const doBackendResize = useCallback((cols: number, rows: number) => {
+    if (resizeSuspendedRef.current) {
+      pendingFitAfterSuspendRef.current = true;
+      return;
+    }
+
+    const terminal = terminalRef.current;
+    // Keep frontend and PTY dimensions in lockstep. If xterm skipped a resize
+    // because of replay protection or panel suspension, sending it to the PTY
+    // would make subsequent shell repaint output land in the wrong geometry.
+    if (terminal && (terminal.cols !== cols || terminal.rows !== rows)) {
+      return;
+    }
+
     const lastSize = lastBackendSizeRef.current;
     if (lastSize && lastSize.cols === cols && lastSize.rows === rows) {
       return;
@@ -280,7 +320,6 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
     requestAnimationFrame(() => {
       if (terminalRef.current) {
         forceRefresh(terminalRef.current);
-        scrollToBottomIfNeeded(terminalRef.current);
       }
     });
   }, [forceRefresh]);
@@ -291,6 +330,11 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
     }
 
     try {
+      if (resizeSuspendedRef.current) {
+        pendingFitAfterSuspendRef.current = true;
+        return;
+      }
+
       const { clientWidth, clientHeight } = containerRef.current;
       if (clientWidth < 50 || clientHeight < 50) {
         return;
@@ -301,22 +345,20 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
         return;
       }
 
-      // Skip tiny intermediate dimensions that occur when a panel CSS-animates
-      // from zero width to its final size. xterm.js permanently truncates buffer
-      // lines to the current column count on resize, so we must avoid resizing
-      // to columns fewer than any content already in the buffer.
-      // 40 cols is the minimum usable terminal width (below this, most shells
-      // are unusable anyway and content would be permanently damaged).
-      if (dims.cols < 40 || dims.rows < 3) {
+      // Skip only unusably tiny dimensions. Panel animation and drag resizes are
+      // suspended by the parent; the final compact bottom panel still needs to
+      // resize to fewer than 10 rows so the prompt remains visible.
+      if (dims.cols < 40 || dims.rows < MIN_STABLE_TERMINAL_ROWS) {
         return;
       }
 
       if (resizeDebouncerRef.current) {
         resizeDebouncerRef.current.resize(dims.cols, dims.rows, immediate);
       } else {
-        doXtermResize(dims.cols, dims.rows);
-        doBackendResize(dims.cols, dims.rows);
-        handleResizeComplete();
+        if (doXtermResize(dims.cols, dims.rows)) {
+          doBackendResize(dims.cols, dims.rows);
+          handleResizeComplete();
+        }
       }
     } catch (error) {
       log.warn('Fit error', error);
@@ -324,6 +366,10 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
   }, [doXtermResize, doBackendResize, handleResizeComplete]);
 
   const flushResize = useCallback(() => {
+    if (resizeSuspendedRef.current) {
+      pendingFitAfterSuspendRef.current = true;
+      return;
+    }
     resizeDebouncerRef.current?.flush();
   }, []);
 
@@ -344,6 +390,22 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
   handleResizeCompleteRef.current = handleResizeComplete;
   fitRef.current = fit;
   forceRefreshRef.current = forceRefresh;
+
+  useEffect(() => {
+    if (resizeSuspended) {
+      return;
+    }
+
+    if (!pendingFitAfterSuspendRef.current) {
+      return;
+    }
+
+    pendingFitAfterSuspendRef.current = false;
+    requestAnimationFrame(() => {
+      resizeDebouncerRef.current?.flush();
+      fitRef.current(true);
+    });
+  }, [resizeSuspended]);
 
   useImperativeHandle(ref, () => ({
     write: (data: string) => {
@@ -502,7 +564,6 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
             requestAnimationFrame(() => {
               if (!terminalRef.current) return;
               forceRefreshRef.current(terminalRef.current);
-              scrollToBottomIfNeeded(terminalRef.current);
             });
           });
         });
@@ -577,7 +638,6 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
             if (term) {
               term.refresh(0, term.rows - 1);
               clearTextureAtlas(term);
-              scrollToBottomIfNeeded(term);
               if (autoFocusRef.current) {
                 term.focus();
               }

--- a/src/web-ui/src/tools/terminal/hooks/useTerminal.ts
+++ b/src/web-ui/src/tools/terminal/hooks/useTerminal.ts
@@ -7,6 +7,7 @@ import { getTerminalService, TerminalService } from '../services';
 import { createLogger } from '@/shared/utils/logger';
 import type {
   SessionResponse,
+  TerminalReplayEvent,
   TerminalEvent,
   TerminalEventCallback,
 } from '../types';
@@ -21,7 +22,9 @@ export interface UseTerminalOptions {
   onReady?: () => void;
   onExit?: (exitCode?: number) => void;
   onError?: (message: string) => void;
-  /** Called with the PTY dimensions stored alongside history, before onOutput. */
+  /** Called with ordered replay events before live events are subscribed. */
+  onReplay?: (events: TerminalReplayEvent[]) => void;
+  /** @deprecated Use onReplay so resize/write ordering is preserved. */
   onHistoryDims?: (cols: number, rows: number) => void;
 }
 
@@ -47,6 +50,7 @@ export function useTerminal(options: UseTerminalOptions): UseTerminalReturn {
     onReady,
     onExit,
     onError,
+    onReplay,
     onHistoryDims,
   } = options;
 
@@ -64,6 +68,7 @@ export function useTerminal(options: UseTerminalOptions): UseTerminalReturn {
   const onReadyRef = useRef(onReady);
   const onExitRef = useRef(onExit);
   const onErrorRef = useRef(onError);
+  const onReplayRef = useRef(onReplay);
   const onHistoryDimsRef = useRef(onHistoryDims);
 
   // Keep refs updated
@@ -73,6 +78,7 @@ export function useTerminal(options: UseTerminalOptions): UseTerminalReturn {
     onReadyRef.current = onReady;
     onExitRef.current = onExit;
     onErrorRef.current = onError;
+    onReplayRef.current = onReplay;
     onHistoryDimsRef.current = onHistoryDims;
   });
 
@@ -131,11 +137,29 @@ export function useTerminal(options: UseTerminalOptions): UseTerminalReturn {
         // appear in both the event stream and the history buffer, causing duplicate output.
         try {
           const historyResponse = await service.getHistory(sessionId);
-          if (!cancelled && historyResponse.data) {
-            // Notify before queuing data so the terminal can resize to the correct
-            // dimensions before history is written to the buffer.
-            onHistoryDimsRef.current?.(historyResponse.cols, historyResponse.rows);
-            onOutputRef.current?.(historyResponse.data);
+          if (!cancelled) {
+            const replayEvents = historyResponse.events?.length
+              ? historyResponse.events
+              : historyResponse.data
+                ? [{
+                    cols: historyResponse.cols,
+                    rows: historyResponse.rows,
+                    data: historyResponse.data,
+                  }]
+                : [];
+
+            if (replayEvents.length > 0) {
+              if (onReplayRef.current) {
+                onReplayRef.current(replayEvents);
+              } else {
+                replayEvents.forEach((event) => {
+                  onHistoryDimsRef.current?.(event.cols, event.rows);
+                  if (event.data) {
+                    onOutputRef.current?.(event.data);
+                  }
+                });
+              }
+            }
           }
         } catch (histErr) {
           // History replay is optional — a failed fetch must not break the terminal.

--- a/src/web-ui/src/tools/terminal/index.ts
+++ b/src/web-ui/src/tools/terminal/index.ts
@@ -50,6 +50,8 @@ export type {
   ExecuteCommandRequest,
   ExecuteCommandResponse,
   SendCommandRequest,
+  TerminalReplayEvent,
+  GetHistoryResponse,
   TerminalEventType,
   TerminalEventBase,
   TerminalReadyEvent,

--- a/src/web-ui/src/tools/terminal/types/session.ts
+++ b/src/web-ui/src/tools/terminal/types/session.ts
@@ -92,8 +92,19 @@ export interface SendCommandRequest {
   command: string;
 }
 
+export interface TerminalReplayEvent {
+  /** PTY column count to apply before writing data. */
+  cols: number;
+  /** PTY row count to apply before writing data. */
+  rows: number;
+  /** Raw terminal data to write at the specified dimensions. */
+  data: string;
+}
+
 export interface GetHistoryResponse {
   sessionId: string;
+  /** Ordered resize/data events for terminal recovery. */
+  events?: TerminalReplayEvent[];
   data: string;
   /** Current history size in bytes. */
   historySize: number;

--- a/src/web-ui/src/tools/terminal/utils/TerminalResizeDebouncer.ts
+++ b/src/web-ui/src/tools/terminal/utils/TerminalResizeDebouncer.ts
@@ -23,8 +23,8 @@ export interface ResizeCallback {
 export interface ResizeDebounceOptions {
   getTerminal: () => Terminal | null;
   isVisible: () => boolean;
-  /** Local xterm resize callback. */
-  onXtermResize: (cols: number, rows: number) => void;
+  /** Local xterm resize callback. Returns false when resize was intentionally skipped. */
+  onXtermResize: (cols: number, rows: number) => boolean;
   /** Backend PTY resize callback (debounced/merged). */
   onBackendResize: (cols: number, rows: number) => void | Promise<void>;
   /** Optional hook invoked after flush. */
@@ -117,8 +117,11 @@ export class TerminalResizeDebouncer {
       this.clearPendingJobs();
       if (this.isNewApi) {
         const opts = this.options as ResizeDebounceOptions;
-        opts.onXtermResize(cols, rows);
-        this.scheduleBackendResize(cols, rows);
+        // Backend resize is scheduled only after xterm accepted the same size.
+        // This prevents PTY/frontend geometry drift when callers suppress a fit.
+        if (opts.onXtermResize(cols, rows)) {
+          this.scheduleBackendResize(cols, rows);
+        }
       } else {
         this.executeResize(cols, rows, true);
       }
@@ -136,11 +139,14 @@ export class TerminalResizeDebouncer {
     if (this.isNewApi) {
       const opts = this.options as ResizeDebounceOptions;
       
-      if (rowsChanged && !colsChanged) {
-        opts.onXtermResize(currentCols, rows);
-        this.scheduleBackendResize(currentCols, rows);
+      if (rowsChanged) {
+        // Row-only updates are still gated by local success; skipped local
+        // resizes must not be mirrored to the PTY.
+        if (opts.onXtermResize(currentCols, rows)) {
+          this.scheduleBackendResize(currentCols, rows);
+        }
       }
-      else if (colsChanged) {
+      if (colsChanged) {
         this.debounceXtermResizeX(cols, rows);
       }
     } else {
@@ -205,10 +211,14 @@ export class TerminalResizeDebouncer {
   private executeResize(cols: number, rows: number, includeBackend: boolean): void {
     if (this.isNewApi) {
       const opts = this.options as ResizeDebounceOptions;
-      opts.onXtermResize(cols, rows);
+      const resized = opts.onXtermResize(cols, rows);
       if (includeBackend) {
-        opts.onBackendResize(cols, rows);
-        opts.onResizeComplete?.();
+        // Flush can run after a suspended resize. Respect the local result so a
+        // stale pending target cannot resize only the backend.
+        if (resized) {
+          opts.onBackendResize(cols, rows);
+          opts.onResizeComplete?.();
+        }
       }
     } else {
       const opts = this.options as LegacyResizeDebounceOptions;
@@ -225,8 +235,9 @@ export class TerminalResizeDebouncer {
       this.resizeXTimeoutId = null;
       if (!this.disposed && this.isNewApi) {
         const opts = this.options as ResizeDebounceOptions;
-        opts.onXtermResize(cols, rows);
-        this.scheduleBackendResize(cols, rows);
+        if (opts.onXtermResize(cols, rows)) {
+          this.scheduleBackendResize(cols, rows);
+        }
       }
     }, RESIZE_X_DEBOUNCE_MS);
   }

--- a/src/web-ui/src/tools/terminal/utils/index.ts
+++ b/src/web-ui/src/tools/terminal/utils/index.ts
@@ -4,6 +4,14 @@
 
 export { TerminalResizeDebouncer } from './TerminalResizeDebouncer';
 export type { ResizeCallback, ResizeDebounceOptions } from './TerminalResizeDebouncer';
+export { ResizeRepaintGuard, createResizeRepaintScreenSnapshot } from './resizeRepaintGuard';
+export { terminalReplayHasScreenText } from './terminalReplay';
+export type {
+  ResizeRepaintGuardDecision,
+  ResizeRepaintMark,
+  ResizeRepaintScreenSnapshot,
+  ResizeRepaintSuppressionDetails,
+} from './resizeRepaintGuard';
 export {
   buildXtermTheme,
   getXtermAnsiPalette,

--- a/src/web-ui/src/tools/terminal/utils/resizeRepaintGuard.test.ts
+++ b/src/web-ui/src/tools/terminal/utils/resizeRepaintGuard.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ResizeRepaintGuard,
+  type ResizeRepaintScreenSnapshot,
+} from './resizeRepaintGuard';
+
+function createScreenSnapshot(overrides: Partial<ResizeRepaintScreenSnapshot> = {}): ResizeRepaintScreenSnapshot {
+  return {
+    bufferType: 'normal',
+    cols: 170,
+    rows: 22,
+    viewportY: 0,
+    baseY: 0,
+    visibleNonEmptyLines: [
+      'PS C:\\Workspace\\Project> ls',
+      '    Directory: C:\\Workspace\\Project',
+      'Mode                 LastWriteTime         Length Name',
+      '----                 -------------         ------ ----',
+      'd----           2026/6/14    14:50                assets',
+      'PS C:\\Workspace\\Project>',
+    ],
+    ...overrides,
+  };
+}
+
+function createCmdScreenSnapshot(overrides: Partial<ResizeRepaintScreenSnapshot> = {}): ResizeRepaintScreenSnapshot {
+  return {
+    bufferType: 'normal',
+    cols: 170,
+    rows: 26,
+    viewportY: 0,
+    baseY: 0,
+    visibleNonEmptyLines: [
+      'Microsoft Windows [Version 10.0.26200.0000]',
+      '(c) Microsoft Corporation. All rights reserved.',
+      'C:\\Workspace\\Project>dir',
+      ' Directory of C:\\Workspace\\Project',
+      '2026/06/14  14:50    <DIR>          assets',
+      '2026/06/14  14:51    <DIR>          css',
+      '2026/06/14  14:51             1,164 index.html',
+      '2026/06/14  14:51    <DIR>          js',
+      '               1 File(s)          1,164 bytes',
+      'C:\\Workspace\\Project>',
+    ],
+    ...overrides,
+  };
+}
+
+function createGitBashScreenSnapshot(overrides: Partial<ResizeRepaintScreenSnapshot> = {}): ResizeRepaintScreenSnapshot {
+  return {
+    bufferType: 'normal',
+    cols: 170,
+    rows: 28,
+    viewportY: 0,
+    baseY: 0,
+    visibleNonEmptyLines: [
+      'dev@WORKSTATION MINGW64 /c/Workspace/Project',
+      '$ ll',
+      'total 4',
+      'drwxr-xr-x 1 dev 197609    0  Jun 14 14:50 assets/',
+      'drwxr-xr-x 1 dev 197609    0  Jun 14 14:51 css/',
+      '-rw-r--r-- 1 dev 197609 1164  Jun 14 14:51 index.html',
+      'drwxr-xr-x 1 dev 197609    0  Jun 14 14:51 js/',
+      'dev@WORKSTATION MINGW64 /c/Workspace/Project',
+      '$',
+    ],
+    ...overrides,
+  };
+}
+
+describe('ResizeRepaintGuard', () => {
+  it('suppresses an incomplete Windows resize repaint that would overwrite the top line', () => {
+    const guard = new ResizeRepaintGuard();
+    guard.markResize({
+      cols: 170,
+      rows: 22,
+      previousCols: 170,
+      previousRows: 11,
+      shellType: 'PowerShell',
+      screen: createScreenSnapshot(),
+      nowMs: 1000,
+    });
+
+    const repaint = [
+      '\x1b[?25l\x1b[H\x1b[K\r\n',
+      '    Directory: C:\\Workspace\\Project\x1b[K\r\n',
+      '\x1b[K\x1b[32m\x1b[1m\r\n',
+      'Mode                 LastWriteTime\x1b[m \x1b[32m\x1b[1m\x1b[3m        Length\x1b[23m Name\x1b[m\x1b[K\r\n',
+      '----                 -------------         ------ ----\x1b[K\r\n',
+      'd----           2026/6/14    14:50                assets\x1b[K',
+    ].join('');
+
+    const decision = guard.inspect(repaint, 1090);
+
+    expect(decision.suppress).toBe(true);
+    if (decision.suppress) {
+      expect(decision.details.reason).toBe('incomplete-resize-repaint');
+      expect(decision.details.topLine).toBe('ps c:\\workspace\\project> ls');
+      expect(decision.details.matchingLines).toContain('directory: c:\\workspace\\project');
+    }
+  });
+
+  it('allows a repaint that includes the current top line', () => {
+    const guard = new ResizeRepaintGuard();
+    guard.markResize({
+      cols: 170,
+      rows: 22,
+      screen: createScreenSnapshot(),
+      nowMs: 1000,
+    });
+
+    const decision = guard.inspect(
+      '\x1b[H\x1b[KPS C:\\Workspace\\Project> ls\r\n    Directory: C:\\Workspace\\Project',
+      1050,
+    );
+
+    expect(decision).toEqual({ suppress: false, reason: 'repaint-starts-with-top-line' });
+  });
+
+  it('suppresses a Cmd resize repaint that starts with the old small viewport', () => {
+    const guard = new ResizeRepaintGuard();
+    guard.markResize({
+      cols: 170,
+      rows: 26,
+      previousCols: 170,
+      previousRows: 6,
+      shellType: 'Cmd',
+      screen: createCmdScreenSnapshot(),
+      nowMs: 1000,
+    });
+
+    const repaint = [
+      '\x1b[?25l\x1b[H',
+      '2026/06/14  14:51             1,164 index.html\x1b[K\r\n',
+      '2026/06/14  14:51    <DIR>          js\x1b[K\r\n',
+      '               1 File(s)          1,164 bytes\x1b[K\r\n',
+      '\x1b[K\r\n',
+      'C:\\Workspace\\Project>\x1b[K\r\n',
+      '\x1b[K\r\n\x1b[K\x1b[6;22H\x1b[?25h',
+    ].join('');
+
+    const decision = guard.inspect(repaint, 1075);
+
+    expect(decision.suppress).toBe(true);
+    if (decision.suppress) {
+      expect(decision.details.reason).toBe('incomplete-resize-repaint');
+      expect(decision.details.topLine).toBe('microsoft windows [version 10.0.26200.0000]');
+      expect(decision.details.matchingLines).toContain('2026/06/14 14:51 1,164 index.html');
+    }
+  });
+
+  it('allows a Cmd resize repaint that matches the current small viewport top line', () => {
+    const guard = new ResizeRepaintGuard();
+    guard.markResize({
+      cols: 170,
+      rows: 6,
+      previousCols: 170,
+      previousRows: 26,
+      shellType: 'Cmd',
+      screen: createCmdScreenSnapshot({
+        rows: 6,
+        viewportY: 13,
+        baseY: 13,
+        visibleNonEmptyLines: [
+          '2026/06/14  14:51             1,164 index.html',
+          '2026/06/14  14:51    <DIR>          js',
+          '               1 File(s)          1,164 bytes',
+          'C:\\Workspace\\Project>',
+        ],
+      }),
+      nowMs: 1000,
+    });
+
+    const decision = guard.inspect(
+      '\x1b[?25l\x1b[H2026/06/14  14:51             1,164 index.html\x1b[K\r\n2026/06/14  14:51    <DIR>          js\x1b[K',
+      1075,
+    );
+
+    expect(decision).toEqual({ suppress: false, reason: 'repaint-starts-with-top-line' });
+  });
+
+  it('suppresses a Git Bash resize repaint even when the top prompt appears later', () => {
+    const guard = new ResizeRepaintGuard();
+    guard.markResize({
+      cols: 170,
+      rows: 28,
+      previousCols: 170,
+      previousRows: 6,
+      shellType: 'Bash',
+      screen: createGitBashScreenSnapshot(),
+      nowMs: 1000,
+    });
+
+    const repaint = [
+      '\x1b[?25l\x1b[H',
+      'drwxr-xr-x 1 dev 197609    0  Jun 14 14:51 \x1b[34m\x1b[1mcss\x1b[m/\x1b[K\r\n',
+      '-rw-r--r-- 1 dev 197609 1164  Jun 14 14:51 index.html\x1b[K\r\n',
+      'drwxr-xr-x 1 dev 197609    0  Jun 14 14:51 \x1b[34m\x1b[1mjs\x1b[m/\x1b[K\r\n',
+      '\x1b[K\x1b[32m\r\n',
+      'dev@WORKSTATION \x1b[35mMINGW64 \x1b[33m/c/Workspace/Project\x1b[K\x1b[m\r\n',
+      '$\x1b[K\r\n',
+      '\x1b[K\r\n\x1b[K\x1b[?25h',
+    ].join('');
+
+    const decision = guard.inspect(repaint, 1120);
+
+    expect(decision.suppress).toBe(true);
+    if (decision.suppress) {
+      expect(decision.details.reason).toBe('incomplete-resize-repaint');
+      expect(decision.details.topLine).toBe('dev@workstation mingw64 /c/workspace/project');
+      expect(decision.details.matchingLines).toContain('drwxr-xr-x 1 dev 197609 0 jun 14 14:51 css/');
+    }
+  });
+
+  it('allows a Git Bash repaint that starts with the current prompt', () => {
+    const guard = new ResizeRepaintGuard();
+    guard.markResize({
+      cols: 170,
+      rows: 28,
+      previousCols: 170,
+      previousRows: 6,
+      shellType: 'Bash',
+      screen: createGitBashScreenSnapshot(),
+      nowMs: 1000,
+    });
+
+    const decision = guard.inspect(
+      '\x1b[?25l\x1b[Hdev@WORKSTATION \x1b[35mMINGW64 \x1b[33m/c/Workspace/Project\x1b[K\x1b[m\r\n$ ll\x1b[K\r\ntotal 4\x1b[K',
+      1120,
+    );
+
+    expect(decision).toEqual({ suppress: false, reason: 'repaint-starts-with-top-line' });
+  });
+
+  it('does not suppress alternate-buffer repaint output', () => {
+    const guard = new ResizeRepaintGuard();
+    guard.markResize({
+      cols: 170,
+      rows: 22,
+      screen: createScreenSnapshot({ bufferType: 'alternate' }),
+      nowMs: 1000,
+    });
+
+    const decision = guard.inspect(
+      '\x1b[H\x1b[K    Directory: C:\\Workspace\\Project\r\nMode                 LastWriteTime         Length Name',
+      1050,
+    );
+
+    expect(decision).toEqual({ suppress: false, reason: 'alternate-buffer' });
+  });
+
+  it('expires the repaint guard window', () => {
+    const guard = new ResizeRepaintGuard();
+    guard.markResize({
+      cols: 170,
+      rows: 22,
+      screen: createScreenSnapshot(),
+      nowMs: 1000,
+    });
+
+    const decision = guard.inspect(
+      '\x1b[H\x1b[K    Directory: C:\\Workspace\\Project\r\nMode                 LastWriteTime         Length Name',
+      2000,
+    );
+
+    expect(decision).toEqual({ suppress: false, reason: 'expired' });
+  });
+
+  it('allows ordinary output inside the resize window', () => {
+    const guard = new ResizeRepaintGuard();
+    guard.markResize({
+      cols: 170,
+      rows: 22,
+      screen: createScreenSnapshot(),
+      nowMs: 1000,
+    });
+
+    const decision = guard.inspect('hello from the terminal\r\n', 1050);
+
+    expect(decision).toEqual({ suppress: false, reason: 'no-home-repaint-prefix' });
+  });
+});

--- a/src/web-ui/src/tools/terminal/utils/resizeRepaintGuard.ts
+++ b/src/web-ui/src/tools/terminal/utils/resizeRepaintGuard.ts
@@ -1,0 +1,308 @@
+/**
+ * Guards xterm.js against incomplete resize repaint streams from Windows PTYs.
+ */
+
+import type { Terminal } from '@xterm/xterm';
+
+const RESIZE_REPAINT_SUPPRESSION_WINDOW_MS = 750;
+const REPAINT_TAIL_SUPPRESSION_MS = 80;
+const MIN_EXISTING_LINES_FOR_REPAINT_MATCH = 3;
+const MIN_MATCHING_EXISTING_LINES = 2;
+const MIN_LINE_SIGNATURE_LENGTH = 8;
+
+export interface ResizeRepaintScreenSnapshot {
+  bufferType: 'normal' | 'alternate';
+  cols: number;
+  rows: number;
+  viewportY: number;
+  baseY: number;
+  visibleNonEmptyLines: string[];
+}
+
+export interface ResizeRepaintMark {
+  cols: number;
+  rows: number;
+  previousCols?: number;
+  previousRows?: number;
+  shellType?: string;
+  screen: ResizeRepaintScreenSnapshot;
+  nowMs?: number;
+}
+
+export interface ResizeRepaintSuppressionDetails {
+  reason: string;
+  pending: {
+    cols: number;
+    rows: number;
+    previousCols?: number;
+    previousRows?: number;
+    shellType?: string;
+    ageMs: number;
+  };
+  topLine: string;
+  matchingLines: string[];
+}
+
+export type ResizeRepaintGuardDecision =
+  | { suppress: false; reason: string }
+  | { suppress: true; details: ResizeRepaintSuppressionDetails };
+
+interface PendingResizeRepaint extends Omit<ResizeRepaintMark, 'nowMs'> {
+  markedAtMs: number;
+  expiresAtMs: number;
+}
+
+function currentTimeMs(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+export function createResizeRepaintScreenSnapshot(
+  terminal: Terminal | null,
+): ResizeRepaintScreenSnapshot | null {
+  if (!terminal) {
+    return null;
+  }
+
+  const buffer = terminal.buffer.active;
+  const visibleNonEmptyLines: string[] = [];
+  const maxRows = Math.min(terminal.rows, 80);
+
+  for (let row = 0; row < maxRows; row += 1) {
+    const line = buffer.getLine(buffer.viewportY + row)?.translateToString(true) ?? '';
+    if (line.trim().length > 0) {
+      visibleNonEmptyLines.push(line);
+    }
+  }
+
+  return {
+    bufferType: buffer.type,
+    cols: terminal.cols,
+    rows: terminal.rows,
+    viewportY: buffer.viewportY,
+    baseY: buffer.baseY,
+    visibleNonEmptyLines,
+  };
+}
+
+// eslint-disable-next-line no-control-regex -- Terminal output uses ESC control sequences.
+const OSC_SEQUENCE_RE = /\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
+// eslint-disable-next-line no-control-regex -- Terminal output uses ESC control sequences.
+const CSI_SEQUENCE_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+// eslint-disable-next-line no-control-regex -- Terminal output uses ESC control sequences.
+const ESC_SEQUENCE_RE = /\x1b(?:[@-Z\\-_]|\([A-Za-z0-9]|\)[A-Za-z0-9])/g;
+
+function stripTerminalControlSequences(value: string): string {
+  return value
+    .replace(OSC_SEQUENCE_RE, '')
+    .replace(CSI_SEQUENCE_RE, '')
+    .replace(ESC_SEQUENCE_RE, '');
+}
+
+function normalizeLineForComparison(value: string): string {
+  return stripTerminalControlSequences(value)
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function normalizeOutputForComparison(value: string): string {
+  return stripTerminalControlSequences(value)
+    .replace(/\r/g, '\n')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function lineSignature(value: string): string | null {
+  const normalized = normalizeLineForComparison(value);
+  return normalized.length >= MIN_LINE_SIGNATURE_LENGTH ? normalized : null;
+}
+
+function getTextAfterHome(data: string): string {
+  // eslint-disable-next-line no-control-regex -- Matching CSI cursor-home commands.
+  const homeMatch = /\x1b\[(?:1;1)?[Hf]/.exec(data);
+  if (!homeMatch) {
+    return data;
+  }
+
+  return data.slice(homeMatch.index + homeMatch[0].length);
+}
+
+function repaintStartsWithLine(data: string, line: string): boolean {
+  const afterHome = getTextAfterHome(data);
+  const firstNonEmptyLine = afterHome
+    .split(/\r\n|\r|\n/)
+    .map(lineSignature)
+    .find((signature): signature is string => Boolean(signature));
+
+  return firstNonEmptyLine === line;
+}
+
+function hasHomeRepaintPrefix(data: string): boolean {
+  const prefix = data.slice(0, 160);
+  // eslint-disable-next-line no-control-regex -- Matching CSI cursor-home commands.
+  const homeMatch = /\x1b\[(?:1;1)?[Hf]/.exec(prefix);
+  if (!homeMatch || homeMatch.index > 48) {
+    return false;
+  }
+
+  const beforeHome = stripTerminalControlSequences(prefix.slice(0, homeMatch.index))
+    .replace(/[\r\n]/g, '')
+    .trim();
+  if (beforeHome.length > 0) {
+    return false;
+  }
+
+  const afterHome = prefix.slice(homeMatch.index + homeMatch[0].length);
+  // eslint-disable-next-line no-control-regex -- Matching CSI erase-in-line commands.
+  const clearMatch = /\x1b\[[0-2]?K/.exec(afterHome);
+  if (!clearMatch) {
+    return false;
+  }
+
+  const firstLineBreak = afterHome.search(/\r|\n/);
+  if (firstLineBreak >= 0) {
+    return clearMatch.index <= firstLineBreak;
+  }
+
+  return clearMatch.index <= 96;
+}
+
+function buildSuppressionDecision(
+  pending: PendingResizeRepaint,
+  data: string,
+  nowMs: number,
+): ResizeRepaintGuardDecision {
+  if (nowMs > pending.expiresAtMs) {
+    return { suppress: false, reason: 'expired' };
+  }
+
+  if (pending.screen.bufferType !== 'normal') {
+    return { suppress: false, reason: 'alternate-buffer' };
+  }
+
+  if (!hasHomeRepaintPrefix(data)) {
+    return { suppress: false, reason: 'no-home-repaint-prefix' };
+  }
+
+  const existingLines = pending.screen.visibleNonEmptyLines
+    .map(lineSignature)
+    .filter((line): line is string => Boolean(line));
+
+  if (existingLines.length < MIN_EXISTING_LINES_FOR_REPAINT_MATCH) {
+    return { suppress: false, reason: 'insufficient-existing-lines' };
+  }
+
+  const topLine = existingLines[0];
+  const outputText = normalizeOutputForComparison(data);
+  // A full repaint that starts with the current top line is safe. The damaging
+  // ConPTY repaint starts from the old viewport instead and overwrites xterm's
+  // preserved scrollback head.
+  if (repaintStartsWithLine(data, topLine)) {
+    return { suppress: false, reason: 'repaint-starts-with-top-line' };
+  }
+
+  // Require overlap with later existing lines before suppressing. This keeps
+  // ordinary prompt/output that happens to move home from being dropped.
+  const matchingLines = existingLines
+    .slice(1)
+    .filter(line => outputText.includes(line));
+
+  if (matchingLines.length < MIN_MATCHING_EXISTING_LINES) {
+    return { suppress: false, reason: 'insufficient-existing-line-overlap' };
+  }
+
+  return {
+    suppress: true,
+    details: {
+      reason: 'incomplete-resize-repaint',
+      pending: {
+        cols: pending.cols,
+        rows: pending.rows,
+        previousCols: pending.previousCols,
+        previousRows: pending.previousRows,
+        shellType: pending.shellType,
+        ageMs: Math.round(nowMs - pending.markedAtMs),
+      },
+      topLine,
+      matchingLines: matchingLines.slice(0, 5),
+    },
+  };
+}
+
+export class ResizeRepaintGuard {
+  private pending: PendingResizeRepaint | null = null;
+  private suppressTailUntilMs = 0;
+
+  markResize(mark: ResizeRepaintMark): PendingResizeRepaint | null {
+    const nowMs = mark.nowMs ?? currentTimeMs();
+
+    // Empty screens are common during terminal startup. There is no existing
+    // content to protect, and suppressing the initial clear-screen repaint would
+    // hide legitimate shell initialization.
+    if (mark.screen.visibleNonEmptyLines.length === 0) {
+      this.pending = null;
+      return null;
+    }
+
+    this.pending = {
+      cols: mark.cols,
+      rows: mark.rows,
+      previousCols: mark.previousCols,
+      previousRows: mark.previousRows,
+      shellType: mark.shellType,
+      screen: mark.screen,
+      markedAtMs: nowMs,
+      expiresAtMs: nowMs + RESIZE_REPAINT_SUPPRESSION_WINDOW_MS,
+    };
+    this.suppressTailUntilMs = 0;
+    return this.pending;
+  }
+
+  inspect(data: string, nowMs = currentTimeMs()): ResizeRepaintGuardDecision {
+    if (this.suppressTailUntilMs > 0 && nowMs <= this.suppressTailUntilMs) {
+      return {
+        suppress: true,
+        details: {
+          reason: 'resize-repaint-tail',
+          pending: {
+            cols: this.pending?.cols ?? 0,
+            rows: this.pending?.rows ?? 0,
+            previousCols: this.pending?.previousCols,
+            previousRows: this.pending?.previousRows,
+            shellType: this.pending?.shellType,
+            ageMs: this.pending ? Math.round(nowMs - this.pending.markedAtMs) : 0,
+          },
+          topLine: '',
+          matchingLines: [],
+        },
+      };
+    }
+
+    if (!this.pending) {
+      return { suppress: false, reason: 'no-pending-resize' };
+    }
+
+    const decision = buildSuppressionDecision(this.pending, data, nowMs);
+    if (decision.suppress) {
+      this.pending = null;
+      this.suppressTailUntilMs = nowMs + REPAINT_TAIL_SUPPRESSION_MS;
+      return decision;
+    }
+
+    if (decision.reason === 'expired') {
+      this.pending = null;
+    }
+
+    return decision;
+  }
+
+  clear(): void {
+    this.pending = null;
+    this.suppressTailUntilMs = 0;
+  }
+}

--- a/src/web-ui/src/tools/terminal/utils/terminalReplay.test.ts
+++ b/src/web-ui/src/tools/terminal/utils/terminalReplay.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { terminalReplayHasScreenText } from './terminalReplay';
+import type { TerminalReplayEvent } from '../types';
+
+function replayEvent(data: string, cols = 80, rows = 24): TerminalReplayEvent {
+  return { cols, rows, data };
+}
+
+describe('terminalReplayHasScreenText', () => {
+  it('does not treat pure resize replay events as screen text', () => {
+    expect(terminalReplayHasScreenText([
+      replayEvent(''),
+      replayEvent('', 120, 30),
+    ])).toBe(false);
+  });
+
+  it('does not treat shell metadata-only replay as screen text', () => {
+    expect(terminalReplayHasScreenText([
+      replayEvent('\x1b]0;PowerShell\x07'),
+      replayEvent('\x1b]633;P;IsWindows=True\x07\x1b]633;P;HasRichCommandDetection=True\x07'),
+    ])).toBe(false);
+  });
+
+  it('detects printable replay content after terminal control sequences are stripped', () => {
+    expect(terminalReplayHasScreenText([
+      replayEvent('\x1b[?25l\x1b[32mPS C:\\Workspace\\Project> ls\x1b[m\r\n'),
+    ])).toBe(true);
+  });
+});

--- a/src/web-ui/src/tools/terminal/utils/terminalReplay.ts
+++ b/src/web-ui/src/tools/terminal/utils/terminalReplay.ts
@@ -1,0 +1,31 @@
+import type { TerminalReplayEvent } from '../types';
+
+// eslint-disable-next-line no-control-regex -- Terminal replay can contain OSC metadata sequences.
+const OSC_SEQUENCE_RE = /\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
+// eslint-disable-next-line no-control-regex -- Terminal replay can contain DCS metadata sequences.
+const DCS_SEQUENCE_RE = /\x1bP[\s\S]*?(?:\x07|\x1b\\)/g;
+// eslint-disable-next-line no-control-regex -- Terminal replay can contain CSI styling and cursor sequences.
+const CSI_SEQUENCE_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+// eslint-disable-next-line no-control-regex -- Terminal replay can contain single ESC control sequences.
+const ESC_SEQUENCE_RE = /\x1b(?:[@-Z\\-_]|\([A-Za-z0-9]|\)[A-Za-z0-9])/g;
+// eslint-disable-next-line no-control-regex -- Remove remaining C0/C1 control characters before checking screen text.
+const CONTROL_CHARACTER_RE = /[\x00-\x1f\x7f-\x9f]/g;
+
+function screenTextFromReplayData(data: string): string {
+  return data
+    .replace(OSC_SEQUENCE_RE, '')
+    .replace(DCS_SEQUENCE_RE, '')
+    .replace(CSI_SEQUENCE_RE, '')
+    .replace(ESC_SEQUENCE_RE, '')
+    .replace(CONTROL_CHARACTER_RE, '')
+    .trim();
+}
+
+/**
+ * The replay column guard protects historical screen text from being wrapped or
+ * truncated by intermediate panel widths. Pure resize events and shell metadata
+ * do not need that protection and should not block the first real fit.
+ */
+export function terminalReplayHasScreenText(events: TerminalReplayEvent[]): boolean {
+  return events.some(event => screenTextFromReplayData(event.data).length > 0);
+}


### PR DESCRIPTION
## Summary

Fix terminal tab/panel lifecycle and resize handling so terminal buffers survive tab close/switch, panel animation, and PTY repaint edge cases without cursor drift, blank scrollback, or lost content.

Fixes #

## Type and Areas

Type:

bug fix / regression fix

Areas:

Rust terminal service, web UI terminal, panel layout

## Motivation / Impact

Terminal tabs were being recreated or replayed in several UI transitions, and xterm/PTY resize could diverge during panel animation or replay guards. This caused stable repros such as cursor misalignment, duplicated/overwritten rows, missing terminal head content after resize, and blank scrollback in newly opened right-side terminals.

This PR:
- Keeps terminal xterm instances mounted when tabs/scenes are hidden instead of destroying them.
- Stores structured replay events with the PTY dimensions active for each output chunk.
- Replays resize/write events in order rather than flattening history into a single string.
- Suspends layout-driven terminal resize during right/bottom panel transitions and drag resize.
- Sends backend PTY resize only after local xterm accepts the same size.
- Filters incomplete Windows PTY resize repaints while preserving ordinary output.
- Avoids applying replay column protection to empty or metadata-only replay.

## Verification

- `pnpm --dir src/web-ui run test:run src/tools/terminal/utils/resizeRepaintGuard.test.ts src/tools/terminal/utils/terminalReplay.test.ts` passed.
- `pnpm run type-check:web` passed.
- Manually reproduced and confirmed fixed:
  - bottom terminal shrink/grow content loss
  - Cmd and Git Bash resize repaint content loss
  - right-side new terminal blank scrollback
  - terminal tab close/reopen cursor/content preservation

Rust changes are limited to terminal replay history DTO/storage and are covered by local unit tests in the new replay module.

## Reviewer Notes

The key invariant is that xterm and backend PTY geometry must stay in lockstep. If xterm skips a resize because replay protection or panel transition suspension is active, the backend resize must also be skipped.

Metadata-only replay must not enable column protection. A new terminal can replay only resize/OSC metadata; treating that as visible history was the root cause of the right-panel blank scrollback issue.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.