### PR TITLE
refactor(runtime): close H1 H2 owner decisions

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -22,7 +22,7 @@
 - `services-integrations` 已承接 remote-connect primitives、wire command routing / response assembly、workspace search concrete owner、remote SSH/SFTP/PTY owner、DeepResearch report IO / display-map sidecar、MiniApp host dispatch / storage / worker / import IO。
 - `tool-contracts` 已承接 provider-neutral tool DTO、manifest/catalog/admission/result presentation、confirmation facts、truncation recovery presentation、runtime restriction policy 和 provider-entry materialization。
 - `tool-execution` 已承接 local / remote IO helper、Bash shell helper、batching plan、retry policy、state counting、cancellation-state/token-store policy、background exec output capture 和部分 result rendering。
-- `agent-runtime` 已承接 scheduler/background delivery 纯决策、dialog lifecycle port contracts、session management/cancellation port contracts、thread-goal facts、prompt / prompt-cache facts、turn skill/agent snapshot DTO/diff/render/store、file-read session state、session evidence ledger 与 compression-contract projection、dialog-turn cancellation token store、tool confirmation / user-question wait channel state、custom subagent discovery/loading、post-call hook routing、DeepReview provider-neutral policy/queue/retry/diagnostics shaping、DeepResearch citation renumber 与 report post-process gate，并建立不暴露 `bitfun-core` / `product-full` / concrete manager 的内部 SDK facade。SDK facade 已支持注入 fake runtime services、tool registry、harness registry 和 hook registry。
+- `agent-runtime` 已承接 scheduler/background delivery 纯决策、dialog lifecycle port contracts、session management/cancellation port contracts、thread-goal facts、prompt / prompt-cache facts 与持久化写入决策、turn skill/agent snapshot DTO/diff/render/store、file-read session state、session evidence ledger 与 compression-contract projection、dialog-turn cancellation token store、tool confirmation / user-question wait channel state、custom subagent discovery/loading、post-call hook routing、DeepReview provider-neutral policy/queue/retry/diagnostics shaping 与 queue event payload shaping、DeepResearch citation renumber 与 report post-process gate，并建立不暴露 `bitfun-core` / `product-full` / concrete manager 的内部 SDK facade。SDK facade 已支持注入 fake runtime services、tool registry、harness registry、hook registry 和 agent registry。
 - `harness` 已建立 descriptor、route plan 和 legacy provider registry。
 - `product-domains` 已承接 MiniApp state/workflow planning、compile / permission adaptation、import lifecycle、AI / Agent permission、rate-limit、model/message/session/workspace/turn-text bridge rules、function-agent prompt/parser/response policy 和部分 Git snapshot/fallback 逻辑。
 - `bitfun-core` 的 function-agent AI concrete acquisition 已从旧 `runtime_services` 路径收拢到明确的 core port adapter；Git / AI compatibility re-export 仍保留旧 public path。
@@ -33,14 +33,14 @@
 - owner crate 不得依赖回 `bitfun-core`。
 - `product-full` 保持完整产品能力集合。
 - boundary check 覆盖 owner crate 禁止依赖、旧路径 facade-only、feature gate、six-layer path 解析、Product Assembly 收口和高风险 owner 回流。
-- focused tests 覆盖当前 delivery profile 不做能力裁剪、ProductAssembler 缺失 service 报告、SDK fake provider / services / tool / harness / hook 闭环，以及 runtime hook 顺序、timeout、错误策略和重复 id 拦截。
+- focused tests 覆盖当前 delivery profile 不做能力裁剪、ProductAssembler 缺失 service 报告、SDK fake provider / services / tool / harness / hook / workspace-scoped agent registry 闭环，以及 runtime hook 顺序、timeout、错误策略和重复 id 拦截。
 - focused baseline 覆盖 tool manifest、GetToolSpec、execution admission、workspace search、remote workspace fallback、MCP config/catalog、prompt cache、custom subagent、thread-goal tools、AskUserQuestion、DeepReview policy、tool confirmation、session restore、MiniApp storage/builtin/import、function-agent Git、scheduled-job state 等路径。
 
-## 4. PR-D 后续非阻塞专项
+## 4. PR-D 完成后的后续专项
 
 - `bitfun-core` 仍承载 compatibility facade / `product-full` assembly 和少量迁移期 adapter；不应继续新增 owner 逻辑。
 - 产品入口仍主要通过 `bitfun-core/product-full` 获取完整能力；当前入口矩阵已记录这一事实，真实交付形态裁剪仍需作为产品形态专项处理。
-- concrete scheduler lifecycle、prompt-cache persistence orchestration、tool pipeline scheduler glue、concrete prompt assembly、AI client factory / provider acquisition 仍在 core 或产品 adapter；继续迁移必须单独证明行为等价。
-- DeepReview concrete Task launch、queue event emission 和 session metadata cache persistence 仍是 core adapter，因为它们依赖 coordinator、session manager、subagent runtime 和产品事件；provider-neutral policy / queue / retry / report shaping 已在 `agent-runtime`。
+- concrete scheduler lifecycle、tool pipeline scheduler glue、concrete prompt assembly、AI client factory / provider acquisition 仍在 core 或产品 adapter；继续迁移必须单独证明行为等价。Prompt-cache 持久化的 restore / save / delete 决策已迁入 `agent-runtime`，core 只执行实际 persistence IO。
+- DeepReview concrete Task launch 和 session metadata cache persistence 仍是 core adapter，因为它们依赖 coordinator、session manager、subagent runtime 和产品事件；provider-neutral policy / queue / retry / report shaping 与 queue event payload shaping 已在 `agent-runtime`，core 只负责事件发送。
 - MiniApp larger workflow 的 UI asset / desktop scheduler / AI factory 调用仍属于产品 host adapter；可复用规则已迁入 `product-domains`，不再在 desktop 命令内重复实现。
-- Agent Runtime SDK 已具备内部 facade、最小 fake-provider 闭环和 registry 注入基线，但尚未冻结为可独立发布的外部 SDK 包、版本策略和兼容承诺。
+- Agent Runtime SDK 已具备内部 facade、最小 fake-provider 闭环和 runtime services / tool / harness / hook / workspace-scoped agent registry 注入基线，但尚未冻结为可独立发布的外部 SDK 包、版本策略和兼容承诺。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -19,7 +19,7 @@
 - workspace 已按六层目录展开，旧 `surfaces` / `providers` 目标层级不再使用。
 - `bitfun-core --no-default-features` 已裁掉 workspace-search owner、debug ingest HTTP server、AI provider adapter runtime 和 direct `reqwest`。
 - Desktop / CLI / ACP 仍通过 `bitfun-core/product-full` 获取完整能力；Server / Web / Mobile Web 不直接依赖 core。Product Assembly 已显式记录当前交付形态入口矩阵，真实能力裁剪仍需单独产品形态专项。
-- Runtime Services、Agent Runtime、Tool Contracts、Tool Execution、Harness、Product Domains、Services Core、Services Integrations 等 owner crate 已建立；Agent Runtime SDK 内部 facade 已能注入 runtime services、tool registry、harness registry 和 hook registry，部分 concrete 生命周期仍由 core concrete manager 或产品命令路径持有。
+- Runtime Services、Agent Runtime、Tool Contracts、Tool Execution、Harness、Product Domains、Services Core、Services Integrations 等 owner crate 已建立；Agent Runtime SDK 内部 facade 已能注入 runtime services、tool registry、harness registry、hook registry 和 workspace-scoped agent registry，部分 concrete 生命周期仍由 core concrete manager 或产品命令路径持有。
 - PR-B 已收口 Agent lifecycle 与 tool side-effect owner：turn skill/agent snapshot DTO / diff / render / store、file-read session state、session evidence ledger 与 compression-contract projection、dialog-turn cancellation token store、tool confirmation / user-question wait channel state 已迁入 `agent-runtime`；background exec output capture、tool cancellation token store 已迁入 `tool-execution`；core 保留 resolver、产品事件、具体工具执行、IO 编排和旧路径兼容 re-export。
 - PR-C 已收口 Harness / product workflow 的低风险 owner：MiniApp AI / Agent permission、rate-limit、model/message/session/workspace/turn-text 规则迁入 `product-domains`；DeepResearch 后处理 gate 迁入 `agent-runtime`，report IO 继续由 `services-integrations` 持有；function-agent AI concrete acquisition 收拢为 core port adapter，旧 `runtime_services` 路径删除。
 
@@ -27,7 +27,7 @@
 
 - `services-core` 已承接 session metadata store、session index rebuild、lineage / branch metadata shaping、JSON file store、session layout 和 legacy session-store merge。
 - `runtime-services` 已承接 typed runtime service assembly、capability validation、provider registry、backend event delivery owner 和无副作用 capability marker ports。
-- `agent-runtime` 已承接 provider-neutral scheduler decisions、dialog lifecycle port contracts、background delivery decisions、thread-goal facts、prompt-cache facts、turn skill/agent snapshot state、file-read session state、session evidence ledger、dialog-turn cancellation token store、tool confirmation / user-question wait channel state、DeepReview provider-neutral policy / queue / retry / diagnostics shaping。
+- `agent-runtime` 已承接 provider-neutral scheduler decisions、dialog lifecycle port contracts、background delivery decisions、thread-goal facts、prompt-cache facts 与持久化写入决策、turn skill/agent snapshot state、file-read session state、session evidence ledger、dialog-turn cancellation token store、tool confirmation / user-question wait channel state、DeepReview provider-neutral policy / queue / retry / diagnostics shaping 与 queue event payload shaping。
 - `tool-contracts` / `tool-execution` 已承接 tool manifest / catalog / admission、batching plan、retry policy、state counting、cancellation-state/token-store policy、background exec output capture、shell helper 和部分 local / remote IO helper。
 - `services-integrations` 已承接 remote-connect primitives、workspace search concrete owner、remote SSH/SFTP/PTY owner、MiniApp host dispatch / storage / worker IO、DeepResearch report IO。
 - `product-domains` 已承接 MiniApp workflow planning、compile / permission path adaptation、function-agent prompt / parser / response policy 和部分 Git snapshot/fallback 逻辑。
@@ -37,10 +37,10 @@
 
 | 专项 | 目标 | 主要范围 | 准出标准 |
 |---|---|---|---|
-| H1 | Concrete lifecycle owner 迁移 | concrete scheduler lifecycle、prompt-cache persistence orchestration、tool pipeline scheduler glue、concrete prompt assembly、AI client factory / provider acquisition | 先补行为等价测试；迁移后 core 只保留兼容 adapter；不同 OS、remote、本地和 product-full 行为不变 |
-| H2 | DeepReview / MiniApp concrete adapter 收口 | DeepReview Task launch、queue event emission、session metadata cache persistence；MiniApp workflow 的 UI asset / desktop scheduler / AI factory 调用 | 不改变审查队列、报告持久化、MiniApp 执行和权限语义；provider-neutral 规则不得回流 core |
+| H1 | Concrete lifecycle owner 迁移 | concrete scheduler lifecycle、tool pipeline scheduler glue、concrete prompt assembly、AI client factory / provider acquisition；prompt-cache persistence IO 仍由 core 执行 | 先补行为等价测试；迁移后 core 只保留兼容 adapter；不同 OS、remote、本地和 product-full 行为不变 |
+| H2 | DeepReview / MiniApp concrete adapter 收口 | DeepReview Task launch、session metadata cache persistence；MiniApp workflow 的 UI asset / desktop scheduler / AI factory 调用；DeepReview queue event 仍由 core coordinator 发送 | 不改变审查队列、报告持久化、MiniApp 执行和权限语义；provider-neutral 规则不得回流 core |
 | H3 | 产品形态能力裁剪专项 | 基于当前 delivery profile entry matrix 决定 Desktop / CLI / ACP / Server / Web / Mobile Web 是否真实裁剪能力 | 每个产品入口有兼容性验证；unsupported / unavailable 行为明确；不得让下层按产品形态分支 |
-| H4 | 外部 Agent Runtime SDK 发布准备 | 版本策略、公开 API 冻结、最小 feature 依赖证明、示例和兼容承诺 | SDK 不依赖 `bitfun-core`、app crate、Tauri、concrete service manager 或产品命令 registry；fake provider / service / tool / harness / hook smoke 保持通过 |
+| H4 | 外部 Agent Runtime SDK 发布准备 | 版本策略、公开 API 冻结、最小 feature 依赖证明、示例和兼容承诺 | SDK 不依赖 `bitfun-core`、app crate、Tauri、concrete service manager 或产品命令 registry；fake provider / service / tool / harness / hook / workspace-scoped agent registry smoke 保持通过 |
 
 ## 5. 固定执行流程
 

--- a/src/crates/assembly/core/src/agentic/agents/registry/catalog.rs
+++ b/src/crates/assembly/core/src/agentic/agents/registry/catalog.rs
@@ -22,18 +22,10 @@ pub fn builtin_agent_specs() -> Vec<BuiltinAgentSpec> {
         .into_iter()
         .map(|spec| BuiltinAgentSpec {
             factory: builtin_agent_factory(spec.id),
-            category: map_builtin_agent_category(spec.category),
+            category: spec.category,
             visibility_policy: spec.visibility_policy,
         })
         .collect()
-}
-
-fn map_builtin_agent_category(category: runtime_agents::BuiltinAgentCategory) -> AgentCategory {
-    match category {
-        runtime_agents::BuiltinAgentCategory::Mode => AgentCategory::Mode,
-        runtime_agents::BuiltinAgentCategory::SubAgent => AgentCategory::SubAgent,
-        runtime_agents::BuiltinAgentCategory::Hidden => AgentCategory::Hidden,
-    }
 }
 
 fn builtin_agent_factory(id: &str) -> fn() -> Arc<dyn Agent> {

--- a/src/crates/assembly/core/src/agentic/agents/registry/mod.rs
+++ b/src/crates/assembly/core/src/agentic/agents/registry/mod.rs
@@ -158,6 +158,23 @@ impl AgentRegistry {
     }
 }
 
+impl bitfun_agent_runtime::sdk::RuntimeAgentRegistry for AgentRegistry {
+    fn agent_ids(
+        &self,
+        query: bitfun_agent_runtime::sdk::RuntimeAgentRegistryQuery<'_>,
+    ) -> Vec<String> {
+        let mut ids = self.read_agents().keys().cloned().collect::<Vec<_>>();
+        if let Some(workspace_root) = query.workspace_root {
+            if let Some(entries) = self.read_project_subagents().get(workspace_root) {
+                ids.extend(entries.keys().cloned());
+            }
+        }
+        ids.sort();
+        ids.dedup();
+        ids
+    }
+}
+
 // Global agent registry singleton
 static GLOBAL_AGENT_REGISTRY: OnceLock<Arc<AgentRegistry>> = OnceLock::new();
 

--- a/src/crates/assembly/core/src/agentic/agents/registry/tests.rs
+++ b/src/crates/assembly/core/src/agentic/agents/registry/tests.rs
@@ -12,6 +12,7 @@ use crate::agentic::agents::registry::visibility::{
 use crate::agentic::agents::{resolve_mode_config_profile_id, Agent, UserContextPolicy};
 use crate::service::config::types::AgentSubagentOverrideState;
 use async_trait::async_trait;
+use bitfun_agent_runtime::sdk::{RuntimeAgentRegistry, RuntimeAgentRegistryQuery};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -96,6 +97,43 @@ fn custom_subagent_kind_maps_to_registry_source() {
     assert_eq!(
         subagent_source_from_custom_kind(CustomSubagentKind::User),
         SubAgentSource::User
+    );
+}
+
+#[test]
+fn registry_exposes_sdk_agent_ids_without_leaking_core_agent_details() {
+    let registry = AgentRegistry::new();
+    let workspace = PathBuf::from("D:/workspace/project");
+    let other_workspace = PathBuf::from("D:/workspace/other");
+    insert_project_subagent(&registry, &workspace, "ProjectReviewer", "fast");
+    insert_project_subagent(&registry, &other_workspace, "OtherProjectReviewer", "fast");
+
+    let global_agent_ids =
+        RuntimeAgentRegistry::agent_ids(&registry, RuntimeAgentRegistryQuery::default());
+
+    assert!(global_agent_ids.contains(&"agentic".to_string()));
+    assert!(global_agent_ids.contains(&"Explore".to_string()));
+    assert!(!global_agent_ids.contains(&"ProjectReviewer".to_string()));
+    assert!(!global_agent_ids.contains(&"OtherProjectReviewer".to_string()));
+
+    let agent_ids = RuntimeAgentRegistry::agent_ids(
+        &registry,
+        RuntimeAgentRegistryQuery {
+            workspace_root: Some(&workspace),
+        },
+    );
+
+    assert!(agent_ids.contains(&"ProjectReviewer".to_string()));
+    assert!(!agent_ids.contains(&"OtherProjectReviewer".to_string()));
+    assert_eq!(
+        agent_ids,
+        {
+            let mut sorted = agent_ids.clone();
+            sorted.sort();
+            sorted.dedup();
+            sorted
+        },
+        "SDK agent registry projection must be stable and deduplicated"
     );
 }
 

--- a/src/crates/assembly/core/src/agentic/agents/registry/types.rs
+++ b/src/crates/assembly/core/src/agentic/agents/registry/types.rs
@@ -12,8 +12,8 @@ use crate::agentic::deep_review_policy::{
     REVIEW_JUDGE_AGENT_TYPE,
 };
 pub use bitfun_agent_runtime::agents::{
-    SubAgentSource, SubagentListScope, SubagentOverrideState, SubagentQueryContext,
-    SubagentStateReason,
+    BuiltinAgentCategory as AgentCategory, SubAgentSource, SubagentListScope,
+    SubagentOverrideState, SubagentQueryContext, SubagentStateReason,
 };
 use bitfun_agent_runtime::prompt_cache::prompt_cache_scope_key;
 use serde::{Deserialize, Serialize};
@@ -30,17 +30,6 @@ pub struct CustomSubagentConfig {
 pub struct AgentToolPolicy {
     pub allowed_tools: Vec<String>,
     pub exposure_overrides: AgentToolPolicyOverrides,
-}
-
-/// Agent category
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AgentCategory {
-    /// mode agent (displayed in frontend mode selector)
-    Mode,
-    /// subagent (displayed in frontend subagent list, discovered by TaskTool)
-    SubAgent,
-    /// hidden agent (not displayed in frontend, not discovered by TaskTool, used internally)
-    Hidden,
 }
 
 /// one agent record in registry

--- a/src/crates/assembly/core/src/agentic/deep_review/task_adapter.rs
+++ b/src/crates/assembly/core/src/agentic/deep_review/task_adapter.rs
@@ -22,9 +22,7 @@ use crate::agentic::deep_review_policy::{
     DeepReviewCapacityQueueDecision, DeepReviewCapacityQueueReason, DeepReviewConcurrencyPolicy,
     DeepReviewExecutionPolicy, DeepReviewPolicyViolation, DeepReviewSubagentRole,
 };
-use crate::agentic::events::{
-    DeepReviewQueueReason, DeepReviewQueueState, DeepReviewQueueStatus, ErrorCategory,
-};
+use crate::agentic::events::{DeepReviewQueueStatus, ErrorCategory};
 use crate::util::errors::{BitFunError, BitFunResult};
 use bitfun_agent_runtime::deep_review::task_execution as runtime_task_execution;
 pub(crate) use bitfun_agent_runtime::deep_review::task_execution::{
@@ -140,29 +138,6 @@ pub(crate) fn deep_review_cancelled_reviewer_result(
     )
 }
 
-pub(crate) fn queue_reason_to_event_reason(
-    reason: DeepReviewCapacityQueueReason,
-) -> DeepReviewQueueReason {
-    match reason {
-        DeepReviewCapacityQueueReason::ProviderRateLimit => {
-            DeepReviewQueueReason::ProviderRateLimit
-        }
-        DeepReviewCapacityQueueReason::ProviderConcurrencyLimit => {
-            DeepReviewQueueReason::ProviderConcurrencyLimit
-        }
-        DeepReviewCapacityQueueReason::RetryAfter => DeepReviewQueueReason::RetryAfter,
-        DeepReviewCapacityQueueReason::LocalConcurrencyCap => {
-            DeepReviewQueueReason::LocalConcurrencyCap
-        }
-        DeepReviewCapacityQueueReason::LaunchBatchBlocked => {
-            DeepReviewQueueReason::LaunchBatchBlocked
-        }
-        DeepReviewCapacityQueueReason::TemporaryOverload => {
-            DeepReviewQueueReason::TemporaryOverload
-        }
-    }
-}
-
 pub(crate) fn capacity_decision_for_provider_error(
     error: &BitFunError,
 ) -> DeepReviewCapacityQueueDecision {
@@ -258,27 +233,23 @@ pub(crate) async fn emit_queue_state(
     queue_elapsed_ms: u64,
     max_queue_wait_seconds: u64,
 ) {
-    let run_elapsed_ms = matches!(&status, DeepReviewQueueStatus::Running).then_some(0);
     if let Some(coordinator) = get_global_coordinator() {
+        let queue_state = runtime_task_execution::deep_review_queue_state(
+            runtime_task_execution::DeepReviewQueueStateInput {
+                tool_id,
+                subagent_type,
+                status,
+                reason,
+                queued_reviewer_count,
+                active_reviewer_count,
+                optional_reviewer_count,
+                effective_parallel_instances,
+                queue_elapsed_ms,
+                max_queue_wait_seconds,
+            },
+        );
         coordinator
-            .emit_deep_review_queue_state_changed(
-                session_id,
-                dialog_turn_id,
-                DeepReviewQueueState {
-                    tool_id: tool_id.to_string(),
-                    subagent_type: subagent_type.to_string(),
-                    status,
-                    reason: reason.map(queue_reason_to_event_reason),
-                    queued_reviewer_count,
-                    active_reviewer_count: Some(active_reviewer_count),
-                    effective_parallel_instances,
-                    optional_reviewer_count,
-                    queue_elapsed_ms: Some(queue_elapsed_ms),
-                    run_elapsed_ms,
-                    max_queue_wait_seconds: Some(max_queue_wait_seconds),
-                    session_concurrency_high: false,
-                },
-            )
+            .emit_deep_review_queue_state_changed(session_id, dialog_turn_id, queue_state)
             .await;
     }
 }

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -11,11 +11,13 @@ use crate::agentic::image_analysis::ImageContextData;
 use crate::agentic::persistence::PersistenceManager;
 use crate::agentic::session::session_store_port::CoreSessionStorePort;
 use crate::agentic::session::{
-    CachedSystemPrompt, CachedUserContext, EvidenceLedgerCheckpoint, EvidenceLedgerEvent,
-    EvidenceLedgerEventStatus, EvidenceLedgerSummary, EvidenceLedgerTargetKind, FileReadState,
-    FileReadStateStore, PromptCacheLookup, PromptCachePolicy, PromptCacheScope,
-    SessionContextStore, SessionEvidenceLedger, SessionPromptCache, SessionPromptCacheStore,
-    SystemPromptCacheIdentity, TurnSkillAgentSnapshotStore, UserContextCacheIdentity,
+    prompt_cache_persist_action, reconcile_prompt_cache_restore, CachedSystemPrompt,
+    CachedUserContext, EvidenceLedgerCheckpoint, EvidenceLedgerEvent, EvidenceLedgerEventStatus,
+    EvidenceLedgerSummary, EvidenceLedgerTargetKind, FileReadState, FileReadStateStore,
+    PromptCacheLookup, PromptCachePersistenceWriteAction, PromptCachePolicy,
+    PromptCacheRestoreDecision, PromptCacheScope, SessionContextStore, SessionEvidenceLedger,
+    SessionPromptCache, SessionPromptCacheStore, SystemPromptCacheIdentity,
+    TurnSkillAgentSnapshotStore, UserContextCacheIdentity,
 };
 use crate::agentic::skill_agent_snapshot::TurnSkillAgentSnapshot;
 use crate::infrastructure::ai::get_global_ai_client_factory;
@@ -732,7 +734,7 @@ impl SessionManager {
         workspace_path: &Path,
         session_id: &str,
     ) -> BitFunResult<Option<SessionPromptCache>> {
-        let mut cache = match self
+        let cache = match self
             .persistence_manager
             .load_prompt_cache(workspace_path, session_id)
             .await?
@@ -741,24 +743,22 @@ impl SessionManager {
             None => return Ok(None),
         };
 
-        let expired_entries_removed =
-            cache.apply_persistence_ttl(self.config.prompt_cache_policy.persistence_ttl);
-
-        if !expired_entries_removed {
-            return Ok(Some(cache));
+        let decision =
+            reconcile_prompt_cache_restore(cache, self.config.prompt_cache_policy.persistence_ttl);
+        match &decision {
+            PromptCacheRestoreDecision::DeleteExpired => {
+                self.persistence_manager
+                    .delete_prompt_cache(workspace_path, session_id)
+                    .await?;
+            }
+            PromptCacheRestoreDecision::SavePruned(cache) => {
+                self.persistence_manager
+                    .save_prompt_cache(workspace_path, session_id, cache)
+                    .await?;
+            }
+            PromptCacheRestoreDecision::Keep(_) => {}
         }
-
-        if cache.is_empty() {
-            self.persistence_manager
-                .delete_prompt_cache(workspace_path, session_id)
-                .await?;
-            Ok(None)
-        } else {
-            self.persistence_manager
-                .save_prompt_cache(workspace_path, session_id, &cache)
-                .await?;
-            Ok(Some(cache))
-        }
+        Ok(decision.into_cache())
     }
 
     async fn persist_prompt_cache_best_effort(&self, session_id: &str, reason: &str) {
@@ -779,14 +779,17 @@ impl SessionManager {
             .get_cache(session_id)
             .unwrap_or_default();
 
-        let persist_result = if cache.system_prompt.is_none() && cache.user_context.is_none() {
-            self.persistence_manager
-                .delete_prompt_cache(&workspace_path, session_id)
-                .await
-        } else {
-            self.persistence_manager
-                .save_prompt_cache(&workspace_path, session_id, &cache)
-                .await
+        let persist_result = match prompt_cache_persist_action(&cache) {
+            PromptCachePersistenceWriteAction::Delete => {
+                self.persistence_manager
+                    .delete_prompt_cache(&workspace_path, session_id)
+                    .await
+            }
+            PromptCachePersistenceWriteAction::Save => {
+                self.persistence_manager
+                    .save_prompt_cache(&workspace_path, session_id, &cache)
+                    .await
+            }
         };
 
         if let Err(error) = persist_result {

--- a/src/crates/assembly/core/src/service_agent_runtime.rs
+++ b/src/crates/assembly/core/src/service_agent_runtime.rs
@@ -437,6 +437,20 @@ fn agent_input_attachment_from_image_context(context: ImageContextData) -> Agent
     }
 }
 
+fn core_agent_runtime_builder(
+    submission: Arc<dyn AgentSubmissionPort>,
+    session_management: Arc<dyn AgentSessionManagementPort>,
+    cancellation: Arc<dyn AgentTurnCancellationPort>,
+) -> AgentRuntimeBuilder {
+    let agent_registry: Arc<dyn bitfun_agent_runtime::sdk::RuntimeAgentRegistry> =
+        crate::agentic::agents::get_agent_registry();
+    AgentRuntimeBuilder::new()
+        .with_submission_port(submission)
+        .with_session_management_port(session_management)
+        .with_cancellation_port(cancellation)
+        .with_agent_registry(agent_registry)
+}
+
 impl RemoteImageContextAdapter for ImageContextData {
     fn from_remote_image_context(context: RemoteImageContext) -> Self {
         Self {
@@ -644,10 +658,7 @@ impl CoreServiceAgentRuntime {
         let submission: Arc<dyn AgentSubmissionPort> = coordinator.clone();
         let session_management: Arc<dyn AgentSessionManagementPort> = coordinator.clone();
         let cancellation: Arc<dyn AgentTurnCancellationPort> = coordinator;
-        AgentRuntimeBuilder::new()
-            .with_submission_port(submission)
-            .with_session_management_port(session_management)
-            .with_cancellation_port(cancellation)
+        core_agent_runtime_builder(submission, session_management, cancellation)
             .build()
             .map_err(|error| error.to_string())
     }
@@ -661,10 +672,7 @@ impl CoreServiceAgentRuntime {
         let cancellation: Arc<dyn AgentTurnCancellationPort> = coordinator;
         let dialog_turn: Arc<dyn AgentDialogTurnPort> = scheduler.clone();
         let lifecycle_delivery: Arc<dyn AgentLifecycleDeliveryPort> = scheduler;
-        AgentRuntimeBuilder::new()
-            .with_submission_port(submission)
-            .with_session_management_port(session_management)
-            .with_cancellation_port(cancellation)
+        core_agent_runtime_builder(submission, session_management, cancellation)
             .with_dialog_turn_port(dialog_turn)
             .with_lifecycle_delivery_port(lifecycle_delivery)
             .build()
@@ -679,10 +687,7 @@ impl CoreServiceAgentRuntime {
         let session_management: Arc<dyn AgentSessionManagementPort> = coordinator.clone();
         let cancellation: Arc<dyn AgentTurnCancellationPort> = coordinator;
         let lifecycle_delivery: Arc<dyn AgentLifecycleDeliveryPort> = scheduler;
-        AgentRuntimeBuilder::new()
-            .with_submission_port(submission)
-            .with_session_management_port(session_management)
-            .with_cancellation_port(cancellation)
+        core_agent_runtime_builder(submission, session_management, cancellation)
             .with_lifecycle_delivery_port(lifecycle_delivery)
             .build()
             .map_err(|error| error.to_string())
@@ -697,10 +702,7 @@ impl CoreServiceAgentRuntime {
         let cancellation: Arc<dyn AgentTurnCancellationPort> = scheduler.clone();
         let dialog_turn: Arc<dyn AgentDialogTurnPort> = scheduler.clone();
         let lifecycle_delivery: Arc<dyn AgentLifecycleDeliveryPort> = scheduler;
-        AgentRuntimeBuilder::new()
-            .with_submission_port(submission)
-            .with_session_management_port(session_management)
-            .with_cancellation_port(cancellation)
+        core_agent_runtime_builder(submission, session_management, cancellation)
             .with_dialog_turn_port(dialog_turn)
             .with_lifecycle_delivery_port(lifecycle_delivery)
             .build()

--- a/src/crates/execution/agent-runtime/Cargo.toml
+++ b/src/crates/execution/agent-runtime/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 bitfun-agent-tools = { path = "../tool-contracts" }
+bitfun-events = { path = "../../contracts/events" }
 bitfun-harness = { path = "../harness" }
 bitfun-runtime-ports = { path = "../../contracts/runtime-ports" }
 bitfun-runtime-services = { path = "../runtime-services" }

--- a/src/crates/execution/agent-runtime/src/deep_review/task_execution.rs
+++ b/src/crates/execution/agent-runtime/src/deep_review/task_execution.rs
@@ -11,6 +11,7 @@ use super::{
     DeepReviewCapacityQueueDecision, DeepReviewCapacityQueueReason, DeepReviewConcurrencyPolicy,
     DeepReviewPolicyViolation, DeepReviewQueueControlSnapshot, DeepReviewSubagentRole,
 };
+use bitfun_events::{DeepReviewQueueReason, DeepReviewQueueState, DeepReviewQueueStatus};
 use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::time::{Duration, Instant};
@@ -189,6 +190,62 @@ pub enum DeepReviewProviderCapacityQueueRuntimeStep {
         queue_elapsed_ms: u64,
         next_sleep: Duration,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeepReviewQueueStateInput<'a> {
+    pub tool_id: &'a str,
+    pub subagent_type: &'a str,
+    pub status: DeepReviewQueueStatus,
+    pub reason: Option<DeepReviewCapacityQueueReason>,
+    pub queued_reviewer_count: usize,
+    pub active_reviewer_count: usize,
+    pub optional_reviewer_count: Option<usize>,
+    pub effective_parallel_instances: Option<usize>,
+    pub queue_elapsed_ms: u64,
+    pub max_queue_wait_seconds: u64,
+}
+
+pub fn deep_review_capacity_reason_to_event_reason(
+    reason: DeepReviewCapacityQueueReason,
+) -> DeepReviewQueueReason {
+    match reason {
+        DeepReviewCapacityQueueReason::ProviderRateLimit => {
+            DeepReviewQueueReason::ProviderRateLimit
+        }
+        DeepReviewCapacityQueueReason::ProviderConcurrencyLimit => {
+            DeepReviewQueueReason::ProviderConcurrencyLimit
+        }
+        DeepReviewCapacityQueueReason::RetryAfter => DeepReviewQueueReason::RetryAfter,
+        DeepReviewCapacityQueueReason::LocalConcurrencyCap => {
+            DeepReviewQueueReason::LocalConcurrencyCap
+        }
+        DeepReviewCapacityQueueReason::LaunchBatchBlocked => {
+            DeepReviewQueueReason::LaunchBatchBlocked
+        }
+        DeepReviewCapacityQueueReason::TemporaryOverload => {
+            DeepReviewQueueReason::TemporaryOverload
+        }
+    }
+}
+
+pub fn deep_review_queue_state(input: DeepReviewQueueStateInput<'_>) -> DeepReviewQueueState {
+    DeepReviewQueueState {
+        tool_id: input.tool_id.to_string(),
+        subagent_type: input.subagent_type.to_string(),
+        status: input.status.clone(),
+        reason: input
+            .reason
+            .map(deep_review_capacity_reason_to_event_reason),
+        queued_reviewer_count: input.queued_reviewer_count,
+        active_reviewer_count: Some(input.active_reviewer_count),
+        effective_parallel_instances: input.effective_parallel_instances,
+        optional_reviewer_count: input.optional_reviewer_count,
+        queue_elapsed_ms: Some(input.queue_elapsed_ms),
+        run_elapsed_ms: matches!(input.status, DeepReviewQueueStatus::Running).then_some(0),
+        max_queue_wait_seconds: Some(input.max_queue_wait_seconds),
+        session_concurrency_high: false,
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/crates/execution/agent-runtime/src/prompt_cache.rs
+++ b/src/crates/execution/agent-runtime/src/prompt_cache.rs
@@ -166,6 +166,53 @@ impl SessionPromptCache {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptCachePersistenceWriteAction {
+    Save,
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PromptCacheRestoreDecision {
+    Keep(SessionPromptCache),
+    SavePruned(SessionPromptCache),
+    DeleteExpired,
+}
+
+impl PromptCacheRestoreDecision {
+    pub fn into_cache(self) -> Option<SessionPromptCache> {
+        match self {
+            Self::Keep(cache) | Self::SavePruned(cache) => Some(cache),
+            Self::DeleteExpired => None,
+        }
+    }
+}
+
+pub fn reconcile_prompt_cache_restore(
+    mut cache: SessionPromptCache,
+    persistence_ttl: Option<Duration>,
+) -> PromptCacheRestoreDecision {
+    if !cache.apply_persistence_ttl(persistence_ttl) {
+        return PromptCacheRestoreDecision::Keep(cache);
+    }
+
+    if cache.is_empty() {
+        PromptCacheRestoreDecision::DeleteExpired
+    } else {
+        PromptCacheRestoreDecision::SavePruned(cache)
+    }
+}
+
+pub fn prompt_cache_persist_action(
+    cache: &SessionPromptCache,
+) -> PromptCachePersistenceWriteAction {
+    if cache.is_empty() {
+        PromptCachePersistenceWriteAction::Delete
+    } else {
+        PromptCachePersistenceWriteAction::Save
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromptCacheScope {
     SystemPrompt,
     UserContext,

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -4,6 +4,7 @@
 //! future SDK consumers a narrow agent entrypoint without depending on
 //! `bitfun-core`, app crates, Tauri, or concrete service managers.
 
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use bitfun_agent_tools::{ToolRegistry, ToolRegistryItem};
@@ -82,6 +83,15 @@ impl AgentEventStream {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RuntimeAgentRegistryQuery<'a> {
+    pub workspace_root: Option<&'a Path>,
+}
+
+pub trait RuntimeAgentRegistry: Send + Sync {
+    fn agent_ids(&self, query: RuntimeAgentRegistryQuery<'_>) -> Vec<String>;
+}
+
 #[derive(Clone)]
 pub struct AgentRuntime {
     submission: Arc<dyn AgentSubmissionPort>,
@@ -94,6 +104,7 @@ pub struct AgentRuntime {
     tool_registry: Option<Arc<dyn RuntimeToolRegistry>>,
     harness_registry: Option<Arc<HarnessRegistry>>,
     hook_registry: RuntimeHookRegistry,
+    agent_registry: Option<Arc<dyn RuntimeAgentRegistry>>,
 }
 
 impl std::fmt::Debug for AgentRuntime {
@@ -145,6 +156,13 @@ impl std::fmt::Debug for AgentRuntime {
                 &self.harness_registry.as_ref().map(|_| "<HarnessRegistry>"),
             )
             .field("hook_count", &self.hook_registry.hooks().len())
+            .field(
+                "agent_registry",
+                &self
+                    .agent_registry
+                    .as_ref()
+                    .map(|_| "<dyn RuntimeAgentRegistry>"),
+            )
             .finish()
     }
 }
@@ -174,6 +192,7 @@ pub struct AgentRuntimeBuilder {
     tool_registry: Option<Arc<dyn RuntimeToolRegistry>>,
     harness_registry: Option<Arc<HarnessRegistry>>,
     hook_registry: RuntimeHookRegistry,
+    agent_registry: Option<Arc<dyn RuntimeAgentRegistry>>,
 }
 
 impl AgentRuntimeBuilder {
@@ -237,6 +256,11 @@ impl AgentRuntimeBuilder {
         self
     }
 
+    pub fn with_agent_registry(mut self, registry: Arc<dyn RuntimeAgentRegistry>) -> Self {
+        self.agent_registry = Some(registry);
+        self
+    }
+
     pub fn build(self) -> Result<AgentRuntime, RuntimeBuildError> {
         Ok(AgentRuntime {
             submission: self
@@ -251,6 +275,7 @@ impl AgentRuntimeBuilder {
             tool_registry: self.tool_registry,
             harness_registry: self.harness_registry,
             hook_registry: self.hook_registry,
+            agent_registry: self.agent_registry,
         })
     }
 }
@@ -372,6 +397,13 @@ impl AgentRuntime {
 
     pub fn hook_registry(&self) -> &RuntimeHookRegistry {
         &self.hook_registry
+    }
+
+    pub fn registered_agent_ids(&self, query: RuntimeAgentRegistryQuery<'_>) -> Vec<String> {
+        self.agent_registry
+            .as_ref()
+            .map(|registry| registry.agent_ids(query))
+            .unwrap_or_default()
     }
 
     pub async fn create_session(

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -10,7 +10,8 @@ pub use crate::post_call_hooks::{
 };
 pub use crate::runtime::{
     AgentEventStream, AgentRunHandle, AgentRunRequest, AgentRuntime, AgentRuntimeBuilder,
-    RuntimeBuildError, RuntimeError, RuntimeToolRegistry, SessionSelector,
+    RuntimeAgentRegistry, RuntimeAgentRegistryQuery, RuntimeBuildError, RuntimeError,
+    RuntimeToolRegistry, SessionSelector,
 };
 pub use bitfun_runtime_ports::{
     AgentDialogTurnPort, AgentDialogTurnRequest, AgentInputAttachment, AgentLifecycleDeliveryPort,

--- a/src/crates/execution/agent-runtime/tests/deep_review_policy_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/deep_review_policy_contracts.rs
@@ -5,13 +5,13 @@ use bitfun_agent_runtime::deep_review::report::{
 use bitfun_agent_runtime::deep_review::task_execution::{
     capacity_decision_for_provider_error_facts, capacity_skip_result_for_local_queue_outcome,
     decide_blocked_reviewer_admission_queue_step, decide_provider_capacity_queue_step,
-    deep_review_launch_batch_for_task, deep_review_packet_id_for_cache,
+    deep_review_launch_batch_for_task, deep_review_packet_id_for_cache, deep_review_queue_state,
     ensure_deep_review_retry_coverage, local_reviewer_capacity_queue_decision,
     prompt_with_deep_review_retry_scope, provider_capacity_queue_wait_seconds_for_attempt,
     DeepReviewBlockedReviewerAdmissionQueueStepDecision,
     DeepReviewBlockedReviewerAdmissionQueueStepFacts, DeepReviewProviderCapacityErrorCategory,
     DeepReviewProviderCapacityErrorFacts, DeepReviewProviderCapacityQueueStepDecision,
-    DeepReviewProviderCapacityQueueStepFacts,
+    DeepReviewProviderCapacityQueueStepFacts, DeepReviewQueueStateInput,
 };
 use bitfun_agent_runtime::deep_review::{
     append_tool_use_context_data, apply_deep_review_queue_control,
@@ -22,6 +22,7 @@ use bitfun_agent_runtime::deep_review::{
     DeepReviewRunManifestGate, DeepReviewStrategyLevel, DeepReviewSubagentRole,
     DeepReviewToolParentContext, REVIEWER_SECURITY_AGENT_TYPE,
 };
+use bitfun_events::{DeepReviewQueueReason, DeepReviewQueueStatus};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
@@ -373,4 +374,36 @@ fn deep_review_task_execution_owner_preserves_packet_retry_and_queue_contracts()
         Some("launch_batch_blocked")
     );
     assert!(message.contains("previous launch batch did not finish"));
+}
+
+#[test]
+fn deep_review_task_execution_owner_builds_queue_event_state() {
+    let queue_state = deep_review_queue_state(DeepReviewQueueStateInput {
+        tool_id: "task-1",
+        subagent_type: "ReviewSecurity",
+        status: DeepReviewQueueStatus::Running,
+        reason: Some(DeepReviewCapacityQueueReason::ProviderConcurrencyLimit),
+        queued_reviewer_count: 0,
+        active_reviewer_count: 2,
+        optional_reviewer_count: Some(1),
+        effective_parallel_instances: Some(3),
+        queue_elapsed_ms: 1_200,
+        max_queue_wait_seconds: 60,
+    });
+
+    assert_eq!(queue_state.tool_id, "task-1");
+    assert_eq!(queue_state.subagent_type, "ReviewSecurity");
+    assert_eq!(queue_state.status, DeepReviewQueueStatus::Running);
+    assert_eq!(
+        queue_state.reason,
+        Some(DeepReviewQueueReason::ProviderConcurrencyLimit)
+    );
+    assert_eq!(queue_state.queued_reviewer_count, 0);
+    assert_eq!(queue_state.active_reviewer_count, Some(2));
+    assert_eq!(queue_state.optional_reviewer_count, Some(1));
+    assert_eq!(queue_state.effective_parallel_instances, Some(3));
+    assert_eq!(queue_state.queue_elapsed_ms, Some(1_200));
+    assert_eq!(queue_state.run_elapsed_ms, Some(0));
+    assert_eq!(queue_state.max_queue_wait_seconds, Some(60));
+    assert!(!queue_state.session_concurrency_high);
 }

--- a/src/crates/execution/agent-runtime/tests/prompt_cache_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/prompt_cache_contracts.rs
@@ -1,6 +1,8 @@
 use bitfun_agent_runtime::prompt_cache::{
-    prompt_cache_scope_key, CachedSystemPrompt, CachedUserContext, PromptCacheLookup,
-    PromptCachePolicy, PromptCacheScope, SessionPromptCacheStore, SystemPromptCacheIdentity,
+    prompt_cache_persist_action, prompt_cache_scope_key, reconcile_prompt_cache_restore,
+    CachedPromptText, CachedSystemPrompt, CachedUserContext, PromptCacheLookup,
+    PromptCachePersistenceWriteAction, PromptCachePolicy, PromptCacheRestoreDecision,
+    PromptCacheScope, SessionPromptCache, SessionPromptCacheStore, SystemPromptCacheIdentity,
     UserContextCacheIdentity, DEFAULT_PROMPT_CACHE_PERSISTENCE_TTL,
 };
 use std::time::Duration;
@@ -71,5 +73,69 @@ fn prompt_cache_scope_key_preserves_legacy_mode_switch_shape() {
             &UserContextCacheIdentity::new("workspace_context|workspace_instructions"),
         ),
         "template:agentic_mode||workspace_context|workspace_instructions"
+    );
+}
+
+#[test]
+fn prompt_cache_restore_decision_prunes_expired_persisted_entries() {
+    let mut restored = SessionPromptCache::default();
+    restored.system_prompt = Some(CachedSystemPrompt {
+        text: CachedPromptText {
+            content: "stale prompt".to_string(),
+            created_at_ms: 0,
+        },
+        identity: SystemPromptCacheIdentity::new("template:agentic_mode"),
+    });
+    restored.user_context = Some(CachedUserContext::new(
+        UserContextCacheIdentity::new("workspace_context"),
+        "fresh context",
+    ));
+
+    let decision =
+        reconcile_prompt_cache_restore(restored, Some(Duration::from_secs(60 * 60 * 24 * 365)));
+
+    let cache = match decision {
+        PromptCacheRestoreDecision::SavePruned(cache) => cache,
+        other => panic!("expected pruned cache to be saved, got {other:?}"),
+    };
+    assert!(cache.system_prompt.is_none());
+    assert_eq!(
+        cache.user_context.expect("fresh user context").text.content,
+        "fresh context"
+    );
+}
+
+#[test]
+fn prompt_cache_restore_decision_deletes_empty_expired_cache() {
+    let mut restored = SessionPromptCache::default();
+    restored.system_prompt = Some(CachedSystemPrompt {
+        text: CachedPromptText {
+            content: "stale prompt".to_string(),
+            created_at_ms: 0,
+        },
+        identity: SystemPromptCacheIdentity::new("template:agentic_mode"),
+    });
+
+    let decision =
+        reconcile_prompt_cache_restore(restored, Some(Duration::from_secs(60 * 60 * 24 * 365)));
+
+    assert_eq!(decision, PromptCacheRestoreDecision::DeleteExpired);
+}
+
+#[test]
+fn prompt_cache_persist_action_deletes_empty_cache_and_saves_non_empty_cache() {
+    assert_eq!(
+        prompt_cache_persist_action(&SessionPromptCache::default()),
+        PromptCachePersistenceWriteAction::Delete
+    );
+
+    let mut cache = SessionPromptCache::default();
+    cache.user_context = Some(CachedUserContext::new(
+        UserContextCacheIdentity::new("workspace_context"),
+        "context",
+    ));
+    assert_eq!(
+        prompt_cache_persist_action(&cache),
+        PromptCachePersistenceWriteAction::Save
     );
 }

--- a/src/crates/execution/agent-runtime/tests/sdk_smoke.rs
+++ b/src/crates/execution/agent-runtime/tests/sdk_smoke.rs
@@ -1,9 +1,11 @@
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use bitfun_agent_runtime::sdk::{
-    AgentEventStream, AgentRunRequest, AgentRuntimeBuilder, RuntimeHookErrorPolicy,
-    RuntimeHookKind, RuntimeHookPlan, RuntimeHookRegistry, SessionSelector,
+    AgentEventStream, AgentRunRequest, AgentRuntimeBuilder, RuntimeAgentRegistry,
+    RuntimeAgentRegistryQuery, RuntimeHookErrorPolicy, RuntimeHookKind, RuntimeHookPlan,
+    RuntimeHookRegistry, SessionSelector,
 };
 use bitfun_agent_tools::{ToolRegistry, ToolRegistryItem};
 use bitfun_harness::{
@@ -25,6 +27,22 @@ struct FakeSdkAgentProvider {
 }
 
 struct FakeSdkTool;
+
+#[derive(Debug)]
+struct FakeSdkAgentRegistry {
+    agent_ids: Vec<String>,
+    workspace_agent_ids: Vec<String>,
+}
+
+impl RuntimeAgentRegistry for FakeSdkAgentRegistry {
+    fn agent_ids(&self, query: RuntimeAgentRegistryQuery<'_>) -> Vec<String> {
+        if query.workspace_root.is_some() {
+            self.workspace_agent_ids.clone()
+        } else {
+            self.agent_ids.clone()
+        }
+    }
+}
 
 #[async_trait]
 impl ToolRegistryItem for FakeSdkTool {
@@ -157,12 +175,34 @@ async fn sdk_facade_accepts_fake_services_tools_harnesses_and_hooks_without_core
         .with_tool_registry(Arc::new(tools))
         .with_harness_registry(Arc::new(harnesses))
         .with_hook_registry(hooks)
+        .with_agent_registry(Arc::new(FakeSdkAgentRegistry {
+            agent_ids: vec!["agentic".to_string(), "Explore".to_string()],
+            workspace_agent_ids: vec![
+                "agentic".to_string(),
+                "Explore".to_string(),
+                "ProjectReviewer".to_string(),
+            ],
+        }))
         .build()
         .expect("sdk runtime");
 
     assert_eq!(runtime.registered_tool_names(), vec!["sdk_echo"]);
     assert_eq!(runtime.harness_provider_ids(), vec!["sdk.fake_harness"]);
     assert_eq!(runtime.hook_registry().hooks()[0].id(), "sdk.post_call");
+    assert_eq!(
+        runtime.registered_agent_ids(RuntimeAgentRegistryQuery::default()),
+        vec!["agentic".to_string(), "Explore".to_string()]
+    );
+    assert_eq!(
+        runtime.registered_agent_ids(RuntimeAgentRegistryQuery {
+            workspace_root: Some(Path::new("/workspace/project")),
+        }),
+        vec![
+            "agentic".to_string(),
+            "Explore".to_string(),
+            "ProjectReviewer".to_string()
+        ]
+    );
     assert!(runtime
         .services()
         .expect("services should be injected")


### PR DESCRIPTION
## Summary
- Expose an internal `RuntimeAgentRegistry` through the Agent Runtime SDK facade and wire the core registry as the compatibility adapter.
- Keep agent registry projection workspace-scoped through one explicit query API so project subagents are not exposed across workspace boundaries.
- Move prompt-cache restore and persist write decisions into `bitfun-agent-runtime`; core keeps only the persistence IO.
- Keep prompt-cache public decision helpers narrow by using restore enum variants and save/delete persist actions only.
- Move DeepReview queue event payload shaping into `bitfun-agent-runtime`; core keeps only coordinator event delivery.
- Update the core decomposition plan docs to clarify the completed H1/H2 owner decisions and the remaining concrete adapter work.

## Compatibility and risk
- No tool schema, MiniApp workflow, scheduler lifecycle, concrete prompt assembly, or AI provider acquisition behavior is changed.
- `bitfun-core` still owns the product-specific IO/event bridge for prompt-cache persistence and DeepReview queue emission.
- Project subagent visibility stays workspace-scoped at the SDK facade boundary; global registry queries do not aggregate every loaded workspace.
- The new runtime dependency is only on the contracts-layer `bitfun-events` crate for the queue event contract; no app, Tauri, or `bitfun-core` dependency is introduced into runtime.
- The Agent Runtime SDK remains an internal facade baseline; external SDK API freeze and version compatibility remain future H4 work.

## Verification
- `cargo test -p bitfun-agent-runtime`
- `cargo test -p bitfun-core prompt_cache`
- `cargo test -p bitfun-core deep_review_capacity_queue`
- `cargo test -p bitfun-core deep_review_provider_capacity_queue`
- `cargo test -p bitfun-core registry_exposes_sdk_agent_ids_without_leaking_core_agent_details`
- `cargo test -p bitfun-agent-runtime --test sdk_smoke`
- `cargo check -p bitfun-core --no-default-features`
- `cargo check -p bitfun-core --features product-full`
- `node --test scripts/check-core-boundaries.test.mjs`
- `node scripts/check-core-boundaries.mjs`
- `pnpm run check:repo-hygiene`
- `pnpm run fmt:rs`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`
