### PR TITLE
refactor(product): trim no-direct-core capability plans

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -26,20 +26,20 @@
 - `harness` 已建立 descriptor、route plan 和 legacy provider registry。
 - `product-domains` 已承接 MiniApp state/workflow planning、compile / permission adaptation、import lifecycle、AI / Agent permission、rate-limit、model/message/session/workspace/turn-text bridge rules、function-agent prompt/parser/response policy 和部分 Git snapshot/fallback 逻辑。
 - `bitfun-core` 的 function-agent AI concrete acquisition 已从旧 `runtime_services` 路径收拢到明确的 core port adapter；Git / AI compatibility re-export 仍保留旧 public path。
-- Product Assembly 已承接 `DeliveryProfile`、当前交付形态入口矩阵、`CapabilitySet`、feature group matrix、product-full provider plan、service availability report、profile-scoped harness registry 入口与 legacy-route 行为保护，以及 `ProductAssembler` 对 explicit profile input、runtime services、harness registry 和 service requirement 的验证；core 只保留兼容 re-export。
+- Product Assembly 已承接 `DeliveryProfile`、当前交付形态入口矩阵、`CapabilitySet`、feature group matrix、profile-scoped capability plan、product-full provider plan、service availability report、profile-scoped harness registry 入口与 legacy-route 行为保护，以及 `ProductAssembler` 对 explicit profile input、runtime services、harness registry 和 service requirement 的验证；core 只保留兼容 re-export。ProductFull / Desktop / CLI / ACP 保留完整能力；Server / Remote / Web / MobileWeb 不再 materialize product-full capability packs、feature groups、runtime services、tool groups 或 harness routes。
 
 ## 3. 已建立保护
 
 - owner crate 不得依赖回 `bitfun-core`。
 - `product-full` 保持完整产品能力集合。
 - boundary check 覆盖 owner crate 禁止依赖、旧路径 facade-only、feature gate、six-layer path 解析、Product Assembly 收口和高风险 owner 回流。
-- focused tests 覆盖当前 delivery profile 不做能力裁剪、ProductAssembler 缺失 service 报告、SDK fake provider / services / tool / harness / hook / workspace-scoped agent registry 闭环，以及 runtime hook 顺序、timeout、错误策略和重复 id 拦截。
+- focused tests 覆盖当前 delivery profile 能力裁剪、ProductAssembler 缺失 service 报告、无直接 core 入口的空 capability plan、SDK fake provider / services / tool / harness / hook / workspace-scoped agent registry 闭环，以及 runtime hook 顺序、timeout、错误策略和重复 id 拦截。
 - focused baseline 覆盖 tool manifest、GetToolSpec、execution admission、workspace search、remote workspace fallback、MCP config/catalog、prompt cache、custom subagent、thread-goal tools、AskUserQuestion、DeepReview policy、tool confirmation、session restore、MiniApp storage/builtin/import、function-agent Git、scheduled-job state 等路径。
 
 ## 4. PR-D 完成后的后续专项
 
 - `bitfun-core` 仍承载 compatibility facade / `product-full` assembly 和少量迁移期 adapter；不应继续新增 owner 逻辑。
-- 产品入口仍主要通过 `bitfun-core/product-full` 获取完整能力；当前入口矩阵已记录这一事实，真实交付形态裁剪仍需作为产品形态专项处理。
+- 产品入口的能力裁剪已由 Product Assembly profile plan 表达；后续新增入口必须先明确 `ProductCoreDependencyMode`、unsupported / unavailable 语义和兼容性测试。
 - concrete scheduler lifecycle、tool pipeline scheduler glue、concrete prompt assembly、AI client factory / provider acquisition 仍在 core 或产品 adapter；继续迁移必须单独证明行为等价。Prompt-cache 持久化的 restore / save / delete 决策已迁入 `agent-runtime`，core 只执行实际 persistence IO。
 - DeepReview concrete Task launch 和 session metadata cache persistence 仍是 core adapter，因为它们依赖 coordinator、session manager、subagent runtime 和产品事件；provider-neutral policy / queue / retry / report shaping 与 queue event payload shaping 已在 `agent-runtime`，core 只负责事件发送。
 - MiniApp larger workflow 的 UI asset / desktop scheduler / AI factory 调用仍属于产品 host adapter；可复用规则已迁入 `product-domains`，不再在 desktop 命令内重复实现。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -18,7 +18,7 @@
 
 - workspace 已按六层目录展开，旧 `surfaces` / `providers` 目标层级不再使用。
 - `bitfun-core --no-default-features` 已裁掉 workspace-search owner、debug ingest HTTP server、AI provider adapter runtime 和 direct `reqwest`。
-- Desktop / CLI / ACP 仍通过 `bitfun-core/product-full` 获取完整能力；Server / Web / Mobile Web 不直接依赖 core。Product Assembly 已显式记录当前交付形态入口矩阵，真实能力裁剪仍需单独产品形态专项。
+- Desktop / CLI / ACP 仍通过 `bitfun-core/product-full` 获取完整能力；Server / Remote / Web / Mobile Web 不直接依赖 core。Product Assembly 已按入口矩阵裁剪能力计划：完整兼容入口保留 product-full 能力，无直接 core 入口不再 materialize product-full capability packs、feature groups、runtime services、tool groups 或 harness routes。
 - Runtime Services、Agent Runtime、Tool Contracts、Tool Execution、Harness、Product Domains、Services Core、Services Integrations 等 owner crate 已建立；Agent Runtime SDK 内部 facade 已能注入 runtime services、tool registry、harness registry、hook registry 和 workspace-scoped agent registry，部分 concrete 生命周期仍由 core concrete manager 或产品命令路径持有。
 - PR-B 已收口 Agent lifecycle 与 tool side-effect owner：turn skill/agent snapshot DTO / diff / render / store、file-read session state、session evidence ledger 与 compression-contract projection、dialog-turn cancellation token store、tool confirmation / user-question wait channel state 已迁入 `agent-runtime`；background exec output capture、tool cancellation token store 已迁入 `tool-execution`；core 保留 resolver、产品事件、具体工具执行、IO 编排和旧路径兼容 re-export。
 - PR-C 已收口 Harness / product workflow 的低风险 owner：MiniApp AI / Agent permission、rate-limit、model/message/session/workspace/turn-text 规则迁入 `product-domains`；DeepResearch 后处理 gate 迁入 `agent-runtime`，report IO 继续由 `services-integrations` 持有；function-agent AI concrete acquisition 收拢为 core port adapter，旧 `runtime_services` 路径删除。
@@ -31,6 +31,7 @@
 - `tool-contracts` / `tool-execution` 已承接 tool manifest / catalog / admission、batching plan、retry policy、state counting、cancellation-state/token-store policy、background exec output capture、shell helper 和部分 local / remote IO helper。
 - `services-integrations` 已承接 remote-connect primitives、workspace search concrete owner、remote SSH/SFTP/PTY owner、MiniApp host dispatch / storage / worker IO、DeepResearch report IO。
 - `product-domains` 已承接 MiniApp workflow planning、compile / permission path adaptation、function-agent prompt / parser / response policy 和部分 Git snapshot/fallback 逻辑。
+- Product Assembly 已承接当前 delivery profile 的能力计划裁剪；下层 owner crate 不按产品形态分支。
 - boundary scripts 已覆盖核心 owner 防回流、six-layer path 解析、facade-only 文件和重点 feature gate。
 
 ## 4. 后续大块专项
@@ -39,7 +40,6 @@
 |---|---|---|---|
 | H1 | Concrete lifecycle owner 迁移 | concrete scheduler lifecycle、tool pipeline scheduler glue、concrete prompt assembly、AI client factory / provider acquisition；prompt-cache persistence IO 仍由 core 执行 | 先补行为等价测试；迁移后 core 只保留兼容 adapter；不同 OS、remote、本地和 product-full 行为不变 |
 | H2 | DeepReview / MiniApp concrete adapter 收口 | DeepReview Task launch、session metadata cache persistence；MiniApp workflow 的 UI asset / desktop scheduler / AI factory 调用；DeepReview queue event 仍由 core coordinator 发送 | 不改变审查队列、报告持久化、MiniApp 执行和权限语义；provider-neutral 规则不得回流 core |
-| H3 | 产品形态能力裁剪专项 | 基于当前 delivery profile entry matrix 决定 Desktop / CLI / ACP / Server / Web / Mobile Web 是否真实裁剪能力 | 每个产品入口有兼容性验证；unsupported / unavailable 行为明确；不得让下层按产品形态分支 |
 | H4 | 外部 Agent Runtime SDK 发布准备 | 版本策略、公开 API 冻结、最小 feature 依赖证明、示例和兼容承诺 | SDK 不依赖 `bitfun-core`、app crate、Tauri、concrete service manager 或产品命令 registry；fake provider / service / tool / harness / hook / workspace-scoped agent registry smoke 保持通过 |
 
 ## 5. 固定执行流程
@@ -63,7 +63,7 @@
 | Agent lifecycle / scheduler | `cargo test -p bitfun-agent-runtime`，core scheduler / session focused tests |
 | Tool / terminal | `cargo test -p bitfun-agent-tools`，`cargo test -p tool-runtime`，terminal / exec-command focused tests |
 | Harness / Product Domains | `cargo test -p bitfun-harness`，`cargo test -p bitfun-product-domains`，DeepReview / MiniApp focused tests |
-| Product shape / SDK | `cargo test -p bitfun-agent-runtime`，`cargo test -p bitfun-runtime-services`，SDK fake-provider smoke，cargo tree / metadata 对比 |
+| Product shape / SDK | `cargo test -p bitfun-product-capabilities`，`cargo test -p bitfun-core product_tool_runtime`，SDK fake-provider smoke，cargo tree / metadata 对比 |
 | 大范围 owner 迁移 | `cargo check --workspace`，必要时补 `cargo test --workspace` |
 
 ## 7. 暂停条件

--- a/src/crates/assembly/core/src/agentic/tools/product_runtime.rs
+++ b/src/crates/assembly/core/src/agentic/tools/product_runtime.rs
@@ -137,4 +137,26 @@ mod tests {
             compatibility_registry.get_collapsed_tool_names()
         );
     }
+
+    #[test]
+    fn product_tool_runtime_keeps_no_direct_core_profiles_empty() {
+        for profile in [
+            DeliveryProfile::Server,
+            DeliveryProfile::Remote,
+            DeliveryProfile::Web,
+            DeliveryProfile::MobileWeb,
+        ] {
+            let runtime = ProductToolRuntime::for_profile(profile);
+            let registry = runtime.create_registry();
+
+            assert!(
+                registry.get_tool_names().is_empty(),
+                "{profile} must not expose product-full tools"
+            );
+            assert!(
+                registry.get_collapsed_tool_names().is_empty(),
+                "{profile} must not expose collapsed product-full tools"
+            );
+        }
+    }
 }

--- a/src/crates/assembly/product-capabilities/src/lib.rs
+++ b/src/crates/assembly/product-capabilities/src/lib.rs
@@ -890,6 +890,7 @@ const DEFAULT_PRODUCT_CAPABILITY_PACKS: &[ProductCapabilityPack] = &[
         MINIAPP_HARNESS_PROVIDERS,
     ),
 ];
+const EMPTY_PRODUCT_CAPABILITY_PACKS: &[ProductCapabilityPack] = &[];
 
 pub fn default_product_capability_registry() -> ProductCapabilityRegistry {
     ProductCapabilityRegistry::new(DEFAULT_PRODUCT_CAPABILITY_PACKS)
@@ -900,7 +901,7 @@ pub fn default_product_capability_assembly() -> ProductCapabilityAssembly {
 }
 
 pub fn product_assembly_plan_for_profile(profile: DeliveryProfile) -> ProductAssemblyPlan {
-    default_product_capability_registry().build_assembly_plan(profile)
+    product_capability_registry_for_profile(profile).build_assembly_plan(profile)
 }
 
 pub fn default_product_assembly_plan() -> ProductAssemblyPlan {
@@ -915,4 +916,19 @@ pub fn product_harness_registry_for_profile(
 
 pub fn default_product_harness_registry() -> Result<HarnessRegistry, HarnessRegistryBuildError> {
     product_harness_registry_for_profile(DeliveryProfile::ProductFull)
+}
+
+fn product_capability_registry_for_profile(profile: DeliveryProfile) -> ProductCapabilityRegistry {
+    match profile {
+        DeliveryProfile::ProductFull
+        | DeliveryProfile::Desktop
+        | DeliveryProfile::Cli
+        | DeliveryProfile::Acp => default_product_capability_registry(),
+        DeliveryProfile::Server
+        | DeliveryProfile::Remote
+        | DeliveryProfile::Web
+        | DeliveryProfile::MobileWeb => {
+            ProductCapabilityRegistry::new(EMPTY_PRODUCT_CAPABILITY_PACKS)
+        }
+    }
 }

--- a/src/crates/assembly/product-capabilities/tests/product_capabilities.rs
+++ b/src/crates/assembly/product-capabilities/tests/product_capabilities.rs
@@ -150,7 +150,7 @@ fn capability_packs_describe_service_tool_and_harness_requirements() {
 }
 
 #[test]
-fn product_assembly_plan_makes_delivery_profile_explicit_without_reducing_capabilities() {
+fn product_assembly_plan_keeps_full_capabilities_only_for_core_compatibility_profiles() {
     let expected_capabilities = vec!["code-agent", "deep-review", "deep-research", "miniapp"];
     let expected_tool_groups = vec![
         "core.basic",
@@ -159,10 +159,12 @@ fn product_assembly_plan_makes_delivery_profile_explicit_without_reducing_capabi
         "core.integration",
     ];
 
-    for profile in DeliveryProfile::all_current_product_profiles()
-        .iter()
-        .copied()
-    {
+    for profile in [
+        DeliveryProfile::ProductFull,
+        DeliveryProfile::Desktop,
+        DeliveryProfile::Cli,
+        DeliveryProfile::Acp,
+    ] {
         let plan = product_assembly_plan_for_profile(profile);
 
         assert_eq!(plan.profile(), profile);
@@ -183,6 +185,48 @@ fn product_assembly_plan_makes_delivery_profile_explicit_without_reducing_capabi
                 .collect::<Vec<_>>(),
             expected_tool_groups,
             "{profile} must preserve current tool provider groups"
+        );
+    }
+}
+
+#[test]
+fn no_direct_core_profiles_do_not_select_product_full_runtime_capabilities() {
+    for profile in [
+        DeliveryProfile::Server,
+        DeliveryProfile::Remote,
+        DeliveryProfile::Web,
+        DeliveryProfile::MobileWeb,
+    ] {
+        let plan = product_assembly_plan_for_profile(profile);
+
+        assert_eq!(plan.profile(), profile);
+        assert!(
+            plan.capability_set().ids().is_empty(),
+            "{profile} must not implicitly select product-full capabilities"
+        );
+        assert!(
+            plan.capability_assembly().capability_ids().is_empty(),
+            "{profile} must not build runtime capability packs"
+        );
+        assert!(
+            plan.capability_assembly().service_requirements().is_empty(),
+            "{profile} must not require product-full runtime services"
+        );
+        assert!(
+            plan.feature_groups().is_empty(),
+            "{profile} must not expose product-full feature groups"
+        );
+        assert!(
+            plan.capability_assembly()
+                .tool_provider_group_plan()
+                .is_empty(),
+            "{profile} must not materialize product-full tool groups"
+        );
+        assert!(
+            plan.capability_assembly()
+                .harness_provider_descriptors()
+                .is_empty(),
+            "{profile} must not register product-full harness routes"
         );
     }
 }
@@ -240,6 +284,59 @@ fn product_delivery_profile_matrix_documents_current_core_dependency_shape() {
         DeliveryProfile::all_current_product_profiles(),
         "delivery profile matrix must cover every current product profile exactly once"
     );
+}
+
+#[test]
+fn product_assembly_plan_follows_core_dependency_matrix() {
+    for entry in product_delivery_profile_entries() {
+        let plan = product_assembly_plan_for_profile(entry.profile());
+
+        match entry.core_dependency_mode() {
+            ProductCoreDependencyMode::ProductFullCompatibility => {
+                assert!(
+                    !plan.capability_set().ids().is_empty(),
+                    "{} must retain product-full capabilities",
+                    entry.profile()
+                );
+                assert!(
+                    !plan
+                        .capability_assembly()
+                        .tool_provider_group_plan()
+                        .is_empty(),
+                    "{} must retain product-full tool groups",
+                    entry.profile()
+                );
+                assert!(
+                    !plan.feature_groups().is_empty(),
+                    "{} must retain product-full feature groups",
+                    entry.profile()
+                );
+            }
+            ProductCoreDependencyMode::NoDirectCoreDependency => {
+                assert!(
+                    plan.capability_set().ids().is_empty(),
+                    "{} must not materialize product-full capabilities",
+                    entry.profile()
+                );
+                assert!(
+                    plan.capability_assembly()
+                        .tool_provider_group_plan()
+                        .is_empty(),
+                    "{} must not materialize product-full tool groups",
+                    entry.profile()
+                );
+                assert!(
+                    plan.feature_groups().is_empty(),
+                    "{} must not expose product-full feature groups",
+                    entry.profile()
+                );
+            }
+            _ => panic!(
+                "{} has an unsupported core dependency mode in the product assembly plan test",
+                entry.profile()
+            ),
+        }
+    }
 }
 
 #[test]
@@ -403,6 +500,30 @@ fn product_assembler_reports_missing_services_without_building_runtime_parts() {
             ],
         }
     );
+}
+
+#[test]
+fn product_assembler_allows_no_direct_core_profiles_without_product_services() {
+    for profile in [
+        DeliveryProfile::Server,
+        DeliveryProfile::Remote,
+        DeliveryProfile::Web,
+        DeliveryProfile::MobileWeb,
+    ] {
+        let services = FakeRuntimeServicesProvider::with_all_required()
+            .build_services()
+            .expect("baseline runtime services should build");
+
+        let parts = ProductAssembler::new()
+            .assemble(ProductAssemblyInput::new(profile, services))
+            .expect("no-direct-core profile should not require product-full runtime services");
+
+        assert_eq!(parts.plan().profile(), profile);
+        assert!(parts.plan().capability_set().ids().is_empty());
+        assert!(parts.service_availability().is_empty());
+        assert!(parts.missing_service_requirements().is_empty());
+        assert!(parts.harness_registry().provider_ids().is_empty());
+    }
 }
 
 #[test]


### PR DESCRIPTION
﻿## Summary

Trim Product Assembly capability plans for delivery profiles that do not directly depend on `bitfun-core`.

- Keep full `product-full` capability plans for `ProductFull`, `Desktop`, `Cli`, and `Acp`.
- Use empty capability plans for `Server`, `Remote`, `Web`, and `MobileWeb` so they do not materialize product-full capability packs, feature groups, runtime services, tool groups, or harness routes.
- Update the core decomposition plan/completed notes to record H3 as complete.

## Risk and compatibility

The change is scoped to Product Assembly profile selection. Existing full-product compatibility profiles still retain the previous product-full tool and harness plan. No public API was added.

## Validation

- `cargo test -p bitfun-product-capabilities`
- `cargo test -p bitfun-core product_tool_runtime`
- `node --test scripts/check-core-boundaries.test.mjs`
- `node scripts/check-core-boundaries.mjs`
- `git diff --check gcwing/main HEAD`

Additional product-shape checks run before commit:

- `cargo check -p bitfun-desktop`
- `cargo check -p bitfun-cli`
- `cargo check -p bitfun-server`
- `cargo check -p bitfun-relay-server`
- `cargo check -p bitfun-acp`
- `cargo check -p bitfun-api-layer`
- `pnpm run type-check:web`
- `pnpm --dir src/mobile-web run type-check`
- `pnpm --dir BitFun-Installer run type-check`
- `pnpm run check:repo-hygiene`
- `cargo metadata --no-deps --format-version 1`
