### PR TITLE
refactor(runtime): migrate H1 owner decisions

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -40,7 +40,7 @@
 
 - `bitfun-core` 仍承载 compatibility facade / `product-full` assembly 和少量迁移期 adapter；不应继续新增 owner 逻辑。
 - 产品入口的能力裁剪已由 Product Assembly profile plan 表达；后续新增入口必须先明确 `ProductCoreDependencyMode`、unsupported / unavailable 语义和兼容性测试。
-- concrete scheduler lifecycle、tool pipeline scheduler glue、concrete prompt assembly、AI client factory / provider acquisition 仍在 core 或产品 adapter；继续迁移必须单独证明行为等价。Prompt-cache 持久化的 restore / save / delete 决策已迁入 `agent-runtime`，core 只执行实际 persistence IO。
+- H1 剩余 owner 决策已迁出：dialog start route / outcome lifecycle 继续由 `agent-runtime` 给出可测试决策，tool pipeline 的 Task batch 策略由 `tool-execution` 持有，prompt runtime / workspace / user-context 组合由 `agent-runtime` 持有，AI model selector / cache-key 解析由 `bitfun-ai-adapters` 持有。`bitfun-core` 仍只保留 coordinator 调用、config IO、credential overlay、prompt 事实收集和 prompt-cache persistence IO 等 concrete adapter。
 - DeepReview concrete Task launch 和 session metadata cache persistence 仍是 core adapter，因为它们依赖 coordinator、session manager、subagent runtime 和产品事件；provider-neutral policy / queue / retry / report shaping 与 queue event payload shaping 已在 `agent-runtime`，core 只负责事件发送。
 - MiniApp larger workflow 的 UI asset / desktop scheduler / AI factory 调用仍属于产品 host adapter；可复用规则已迁入 `product-domains`，不再在 desktop 命令内重复实现。
 - Agent Runtime SDK 已具备内部 facade、最小 fake-provider 闭环和 runtime services / tool / harness / hook / workspace-scoped agent registry 注入基线，但尚未冻结为可独立发布的外部 SDK 包、版本策略和兼容承诺。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -38,7 +38,6 @@
 
 | 专项 | 目标 | 主要范围 | 准出标准 |
 |---|---|---|---|
-| H1 | Concrete lifecycle owner 迁移 | concrete scheduler lifecycle、tool pipeline scheduler glue、concrete prompt assembly、AI client factory / provider acquisition；prompt-cache persistence IO 仍由 core 执行 | 先补行为等价测试；迁移后 core 只保留兼容 adapter；不同 OS、remote、本地和 product-full 行为不变 |
 | H2 | DeepReview / MiniApp concrete adapter 收口 | DeepReview Task launch、session metadata cache persistence；MiniApp workflow 的 UI asset / desktop scheduler / AI factory 调用；DeepReview queue event 仍由 core coordinator 发送 | 不改变审查队列、报告持久化、MiniApp 执行和权限语义；provider-neutral 规则不得回流 core |
 | H4 | 外部 Agent Runtime SDK 发布准备 | 版本策略、公开 API 冻结、最小 feature 依赖证明、示例和兼容承诺 | SDK 不依赖 `bitfun-core`、app crate、Tauri、concrete service manager 或产品命令 registry；fake provider / service / tool / harness / hook / workspace-scoped agent registry smoke 保持通过 |
 

--- a/src/crates/adapters/ai-adapters/AGENTS.md
+++ b/src/crates/adapters/ai-adapters/AGENTS.md
@@ -2,8 +2,9 @@
 
 Scope: this guide applies to `src/crates/adapters/ai-adapters`.
 
-`bitfun-ai-adapters` owns provider-specific request/response mapping and stream
-protocol parsing. Keep provider quirks here, then convert stream chunks into the
+`bitfun-ai-adapters` owns provider-specific request/response mapping, stream
+protocol parsing, and provider/model selection helpers that are independent of
+core config IO. Keep provider quirks here, then convert stream chunks into the
 provider-neutral contracts owned by `bitfun-agent-stream`.
 
 ## Guardrails

--- a/src/crates/adapters/ai-adapters/src/lib.rs
+++ b/src/crates/adapters/ai-adapters/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod client;
 pub mod diagnostics;
+pub mod model_selector;
 pub mod providers;
 pub mod stream;
 pub mod tool_call_accumulator;
@@ -11,6 +12,10 @@ pub mod types;
 pub use client::{
     AIClient, StreamOptions, StreamResponse, DEFAULT_STREAM_IDLE_TIMEOUT_SECS,
     DEFAULT_STREAM_TTFT_TIMEOUT_SECS, REASONING_STREAM_TTFT_TIMEOUT_SECS,
+};
+pub use model_selector::{
+    classify_model_selector, resolve_cache_model_selector, resolve_required_model_selector,
+    ModelSelectorError, ModelSelectorKind,
 };
 pub use stream::{UnifiedResponse, UnifiedTokenUsage, UnifiedToolCall};
 pub use trace::{

--- a/src/crates/adapters/ai-adapters/src/model_selector.rs
+++ b/src/crates/adapters/ai-adapters/src/model_selector.rs
@@ -1,0 +1,71 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModelSelectorKind {
+    Primary,
+    Fast,
+    Explicit(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModelSelectorError {
+    PrimaryUnavailable,
+    FastUnavailable,
+}
+
+impl fmt::Display for ModelSelectorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PrimaryUnavailable => write!(f, "Primary model not configured or invalid"),
+            Self::FastUnavailable => write!(
+                f,
+                "Fast model not configured or invalid, and primary model not configured or invalid"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ModelSelectorError {}
+
+pub fn classify_model_selector(model_id: &str) -> ModelSelectorKind {
+    let trimmed = model_id.trim();
+    match trimmed {
+        "" | "auto" | "default" | "primary" => ModelSelectorKind::Primary,
+        "fast" => ModelSelectorKind::Fast,
+        _ => ModelSelectorKind::Explicit(trimmed.to_string()),
+    }
+}
+
+pub fn resolve_required_model_selector(
+    model_id: &str,
+    mut resolve_selection: impl FnMut(&str) -> Option<String>,
+    mut resolve_reference: impl FnMut(&str) -> Option<String>,
+) -> Result<String, ModelSelectorError> {
+    match classify_model_selector(model_id) {
+        ModelSelectorKind::Primary => {
+            resolve_selection("primary").ok_or(ModelSelectorError::PrimaryUnavailable)
+        }
+        ModelSelectorKind::Fast => {
+            resolve_selection("fast").ok_or(ModelSelectorError::FastUnavailable)
+        }
+        ModelSelectorKind::Explicit(model_ref) => {
+            Ok(resolve_reference(&model_ref).unwrap_or(model_ref))
+        }
+    }
+}
+
+pub fn resolve_cache_model_selector(
+    model_id: &str,
+    mut resolve_selection: impl FnMut(&str) -> Option<String>,
+    mut resolve_reference: impl FnMut(&str) -> Option<String>,
+) -> String {
+    match classify_model_selector(model_id) {
+        ModelSelectorKind::Primary => {
+            resolve_selection("primary").unwrap_or_else(|| "primary".to_string())
+        }
+        ModelSelectorKind::Fast => resolve_selection("fast").unwrap_or_else(|| "fast".to_string()),
+        ModelSelectorKind::Explicit(model_ref) => {
+            resolve_reference(&model_ref).unwrap_or(model_ref)
+        }
+    }
+}

--- a/src/crates/adapters/ai-adapters/tests/model_selector.rs
+++ b/src/crates/adapters/ai-adapters/tests/model_selector.rs
@@ -1,0 +1,93 @@
+use bitfun_ai_adapters::{
+    classify_model_selector, resolve_cache_model_selector, resolve_required_model_selector,
+    ModelSelectorError, ModelSelectorKind,
+};
+
+fn resolve_selection(selector: &str) -> Option<String> {
+    match selector {
+        "primary" => Some("model-primary".to_string()),
+        "fast" => Some("model-fast".to_string()),
+        _ => None,
+    }
+}
+
+fn resolve_reference(model_ref: &str) -> Option<String> {
+    match model_ref {
+        "Primary Chat" | "claude-sonnet-4.5" => Some("model-primary".to_string()),
+        _ => None,
+    }
+}
+
+#[test]
+fn classifies_auto_default_and_empty_as_primary() {
+    assert_eq!(classify_model_selector("auto"), ModelSelectorKind::Primary);
+    assert_eq!(
+        classify_model_selector(" default "),
+        ModelSelectorKind::Primary
+    );
+    assert_eq!(classify_model_selector(""), ModelSelectorKind::Primary);
+    assert_eq!(
+        classify_model_selector("model-primary"),
+        ModelSelectorKind::Explicit("model-primary".to_string())
+    );
+}
+
+#[test]
+fn required_selector_resolves_defaults_and_references() {
+    assert_eq!(
+        resolve_required_model_selector("primary", resolve_selection, resolve_reference)
+            .expect("primary should resolve"),
+        "model-primary"
+    );
+    assert_eq!(
+        resolve_required_model_selector("fast", resolve_selection, resolve_reference)
+            .expect("fast should resolve"),
+        "model-fast"
+    );
+    assert_eq!(
+        resolve_required_model_selector("Primary Chat", resolve_selection, resolve_reference)
+            .expect("named model should resolve"),
+        "model-primary"
+    );
+    assert_eq!(
+        resolve_required_model_selector("literal-model-id", resolve_selection, resolve_reference)
+            .expect("literal selector should pass through"),
+        "literal-model-id"
+    );
+}
+
+#[test]
+fn required_selector_preserves_current_missing_default_errors() {
+    let missing = |_selector: &str| None;
+
+    assert_eq!(
+        resolve_required_model_selector("primary", missing, resolve_reference),
+        Err(ModelSelectorError::PrimaryUnavailable)
+    );
+    assert_eq!(
+        resolve_required_model_selector("fast", missing, resolve_reference),
+        Err(ModelSelectorError::FastUnavailable)
+    );
+    assert_eq!(
+        ModelSelectorError::FastUnavailable.to_string(),
+        "Fast model not configured or invalid, and primary model not configured or invalid"
+    );
+}
+
+#[test]
+fn cache_selector_keeps_legacy_default_passthrough_when_unresolved() {
+    let missing = |_selector: &str| None;
+
+    assert_eq!(
+        resolve_cache_model_selector("primary", missing, resolve_reference),
+        "primary"
+    );
+    assert_eq!(
+        resolve_cache_model_selector("fast", missing, resolve_reference),
+        "fast"
+    );
+    assert_eq!(
+        resolve_cache_model_selector("claude-sonnet-4.5", resolve_selection, resolve_reference),
+        "model-primary"
+    );
+}

--- a/src/crates/assembly/core/src/agentic/agents/prompt_builder/mod.rs
+++ b/src/crates/assembly/core/src/agentic/agents/prompt_builder/mod.rs
@@ -1,9 +1,10 @@
 mod prompt_builder_impl;
 mod user_context;
 
-pub use bitfun_agent_runtime::prompt::{PrependedPromptReminders, ToolListingSections};
+pub use bitfun_agent_runtime::prompt::{
+    PrependedPromptReminders, RemoteExecutionHints, RuntimeContextNeeds, ToolListingSections,
+};
 pub use prompt_builder_impl::{
-    build_prompt_context_for_workspace, PromptBuilder, PromptBuilderContext, RemoteExecutionHints,
-    RuntimeContextNeeds,
+    build_prompt_context_for_workspace, PromptBuilder, PromptBuilderContext,
 };
 pub use user_context::{UserContextPolicy, UserContextSection};

--- a/src/crates/assembly/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/assembly/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -18,7 +18,10 @@ use crate::service::workspace::get_global_workspace_service;
 use crate::service::workspace::RelatedPath;
 use crate::util::errors::{BitFunError, BitFunResult};
 use bitfun_agent_runtime::prompt::{
-    PrependedPromptReminders, ToolListingSections, UserContextPolicy, UserContextSection,
+    render_project_layout, render_runtime_context_reminder, render_user_context_reminder,
+    render_workspace_context, PrependedPromptReminders, ProjectLayoutFacts, PromptRelatedPath,
+    RemoteExecutionHints, RuntimeContextFacts, RuntimeContextNeeds, RuntimeShellFacts,
+    ToolListingSections, UserContextPolicy, UserContextSection, WorkspaceContextFacts,
 };
 use log::{debug, warn};
 use std::path::Path;
@@ -31,57 +34,6 @@ const PLACEHOLDER_CLAW_WORKSPACE: &str = "{CLAW_WORKSPACE}";
 const PLACEHOLDER_VISUAL_MODE: &str = "{VISUAL_MODE}";
 const PLACEHOLDER_SESSION_ID: &str = "{SESSION_ID}";
 const PLACEHOLDER_DEEP_RESEARCH_REPORT_LINK: &str = "{DEEP_RESEARCH_REPORT_LINK}";
-const USER_CONTEXT_PROMPT: &str =
-    "As you answer the user's questions, you can use the following context.\nNote: this is a snapshot captured at the start of the conversation and may not reflect real-time changes made afterward.";
-/// SSH remote host facts for system prompt (workspace tools run here, not on the local client).
-#[derive(Debug, Clone)]
-pub struct RemoteExecutionHints {
-    pub connection_display_name: String,
-    pub kernel_name: String,
-    pub hostname: String,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct RuntimeContextNeeds {
-    pub workspace_tools: bool,
-    pub exec_command: bool,
-    pub exec_control: bool,
-    pub computer_use: bool,
-}
-
-impl RuntimeContextNeeds {
-    pub fn from_tool_names<T, I>(tool_names: I) -> Self
-    where
-        T: AsRef<str>,
-        I: IntoIterator<Item = T>,
-    {
-        let mut needs = Self::default();
-        for tool_name in tool_names {
-            let tool_name = tool_name.as_ref();
-            match tool_name {
-                "Read" | "Write" | "Edit" | "Delete" | "LS" | "Grep" | "Glob" | "ExecCommand"
-                | "WriteStdin" | "ExecControl" => {
-                    needs.workspace_tools = true;
-                    if tool_name == "ExecCommand" {
-                        needs.exec_command = true;
-                    }
-                    if tool_name == "ExecControl" {
-                        needs.exec_control = true;
-                    }
-                }
-                "ComputerUse" | "ControlHub" => {
-                    needs.computer_use = true;
-                }
-                _ => {}
-            }
-        }
-        needs
-    }
-
-    fn is_empty(self) -> bool {
-        !self.workspace_tools && !self.exec_command && !self.exec_control && !self.computer_use
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct PromptBuilderContext {
@@ -262,224 +214,56 @@ impl PromptBuilder {
         }
     }
 
-    fn local_exec_shell_runtime_guidance(shell_type: &str) -> &'static [&'static str] {
-        match shell_type {
-            "powershell" | "pwsh" => &[
-                "- For inline Python or other embedded scripts, prefer PowerShell-friendly forms such as `@'\\nprint(\"Hello\")\\n'@ | python -` instead of heavily nested quoting.",
-                "- In PowerShell, the escape character is the backtick (`), not backslash. `\\\"` is not a reliable way to escape a double quote for the shell.",
-                "- For environment variables, process filtering, and file traversal, prefer native PowerShell cmdlets and syntax over shell-specific Unix patterns.",
-                "- Avoid mixing PowerShell with `cmd.exe` or bash in the same command unless cross-shell behavior is explicitly required.",
-            ],
-            _ => &[],
-        }
-    }
-
-    fn push_local_exec_shell_runtime_context(
-        lines: &mut Vec<String>,
-        shell_display_name: &str,
-        shell_type: &str,
-        shell_invocation: &str,
-    ) {
-        lines.push(format!(
-            "- ExecCommand shell: {shell_display_name} ({shell_type}), invoked as {shell_invocation}."
-        ));
-        lines.extend(
-            Self::local_exec_shell_runtime_guidance(shell_type)
-                .iter()
-                .map(|line| (*line).to_string()),
-        );
-    }
-
-    fn push_runtime_context_section(
-        lines: &mut Vec<String>,
-        title: &str,
-        section_lines: Vec<String>,
-    ) {
-        if section_lines.is_empty() {
-            return;
-        }
-
-        if !lines.is_empty() {
-            lines.push(String::new());
-        }
-        lines.push(format!("## {title}"));
-        lines.extend(section_lines);
-    }
-
-    fn exec_control_runtime_guidance(
-        host_os: &str,
-        remote_execution: bool,
-        exec_control_available: bool,
-    ) -> Vec<String> {
-        if !exec_control_available || remote_execution || host_os != "windows" {
-            return Vec::new();
-        }
-
-        vec![
-            "- On local Windows ExecCommand sessions, `ExecControl` `interrupt` is effectively the same as `kill` for non-TTY processes.".to_string(),
-        ]
-    }
-
     /// Build runtime facts that may change independently from the agent's system prompt.
     pub async fn build_runtime_context_reminder(&self) -> Option<String> {
         let needs = self.context.runtime_context_needs;
-        if needs.is_empty() {
-            return None;
-        }
-
-        let host_os = std::env::consts::OS;
-        let host_family = std::env::consts::FAMILY;
-        let host_arch = std::env::consts::ARCH;
-
-        let computer_use_keys = match host_os {
-            "macos" => "- Computer use / `key_chord`: the local BitFun desktop is macOS. Use `command`, `option`, `control`, and `shift` modifier names.",
-            "windows" => "- Computer use / `key_chord`: the local BitFun desktop is Windows. Use `meta`/`super` for the Windows key, plus `alt`, `control`, and `shift`.",
-            "linux" => "- Computer use / `key_chord`: the local BitFun desktop is Linux. Use `control`, `alt`, `shift`, and `meta`/`super` as appropriate for the desktop environment.",
-            _ => "- Computer use / `key_chord`: match modifier names to the local BitFun desktop OS.",
+        let local_shell = if needs.exec_command && self.context.remote_execution.is_none() {
+            let shell = ExecCommandTool::local_shell_prompt_info().await;
+            Some(RuntimeShellFacts {
+                display_name: shell.display_name,
+                shell_type: shell.shell_type,
+                invocation: shell.invocation,
+            })
+        } else {
+            None
         };
 
-        let mut lines = vec!["# Runtime Context".to_string()];
-
-        if needs.workspace_tools {
-            let mut workspace_lines = Vec::new();
-            if let Some(remote) = &self.context.remote_execution {
-                workspace_lines.push(format!(
-                    "- Workspace file and shell tools operate on remote SSH connection \"{}\".",
-                    remote.connection_display_name.replace('"', "'")
-                ));
-                workspace_lines.push(format!(
-                    "- Remote host: {} (uname/kernel: {})",
-                    remote.hostname.replace('"', "'"),
-                    remote.kernel_name.replace('"', "'")
-                ));
-                workspace_lines.push("- Path conventions for workspace operations: POSIX paths with forward slashes and Unix shell syntax. Do not use PowerShell, `cmd.exe`, or Windows-style paths for remote workspace operations.".to_string());
-            } else {
-                workspace_lines.push(
-                    "- Workspace file and shell tools operate on the local filesystem.".to_string(),
-                );
-            }
-            Self::push_runtime_context_section(&mut lines, "Workspace Execution", workspace_lines);
-        }
-
-        if needs.exec_command {
-            let mut exec_command_lines = Vec::new();
-            if self.context.remote_execution.is_some() {
-                exec_command_lines.push(
-                    "- ExecCommand uses the remote user's default POSIX shell, invoked as `<shell> -lc <cmd>`."
-                        .to_string(),
-                );
-            } else {
-                let shell = ExecCommandTool::local_shell_prompt_info().await;
-                Self::push_local_exec_shell_runtime_context(
-                    &mut exec_command_lines,
-                    &shell.display_name,
-                    &shell.shell_type,
-                    &shell.invocation,
-                );
-            }
-            Self::push_runtime_context_section(&mut lines, "ExecCommand Shell", exec_command_lines);
-        }
-
-        let exec_control_lines = Self::exec_control_runtime_guidance(
-            host_os,
-            self.context.remote_execution.is_some(),
-            needs.exec_control,
-        );
-        Self::push_runtime_context_section(&mut lines, "ExecControl", exec_control_lines);
-
-        if needs.computer_use {
-            let mut local_client_lines = Vec::new();
-            if self.context.remote_execution.is_some() && needs.workspace_tools {
-                local_client_lines.push(
-                    "- Computer use and UI automation operate on the local BitFun desktop, even when workspace file and shell tools target a remote host."
-                        .to_string(),
-                );
-            }
-            local_client_lines.push(format!(
-                "- Local BitFun client OS: {host_os} ({host_family})"
-            ));
-            local_client_lines.push(format!("- Local client architecture: {host_arch}"));
-            local_client_lines.push(computer_use_keys.to_string());
-            Self::push_runtime_context_section(&mut lines, "Local Client", local_client_lines);
-        }
-
-        Some(lines.join("\n"))
+        render_runtime_context_reminder(&RuntimeContextFacts {
+            needs,
+            host_os: std::env::consts::OS.to_string(),
+            host_family: std::env::consts::FAMILY.to_string(),
+            host_arch: std::env::consts::ARCH.to_string(),
+            remote_execution: self.context.remote_execution.clone(),
+            local_shell,
+        })
     }
 
     /// Get workspace context that is intentionally injected outside the system prompt cache.
     pub fn get_workspace_context(&self) -> String {
-        let related_paths_section = if self.context.related_paths.is_empty() {
-            String::new()
-        } else {
-            let items = self
+        render_workspace_context(&WorkspaceContextFacts {
+            workspace_path: self.context.workspace_path.clone(),
+            related_paths: self
                 .context
                 .related_paths
                 .iter()
-                .map(|related_path| {
-                    let path = related_path.path.replace("\\", "/");
-                    match related_path.description.as_deref().map(str::trim) {
-                        Some(description) if !description.is_empty() => {
-                            format!("  - {} — {}", path, description)
-                        }
-                        _ => format!("  - {}", path),
-                    }
+                .map(|related_path| PromptRelatedPath {
+                    path: related_path.path.clone(),
+                    description: related_path.description.clone(),
                 })
-                .collect::<Vec<_>>()
-                .join("\n");
-            format!(
-                "- Related directories (user-specified directories related to this workspace):\n{}",
-                items
-            )
-        };
-
-        if let Some(remote) = &self.context.remote_execution {
-            format!(
-                r#"## Workspace Context
-<workspace_context>
-- Workspace root (file tools, Glob, LS, ExecCommand on workspace): {}
-{}
-- Execution environment: **Remote SSH** — connection "{}".
-- Remote host: {} (uname/kernel: {})
-</workspace_context>
-"#,
-                self.context.workspace_path,
-                if related_paths_section.is_empty() {
-                    String::new()
-                } else {
-                    format!("{}\n", related_paths_section)
-                },
-                remote.connection_display_name.replace('"', "'"),
-                remote.hostname.replace('"', "'"),
-                remote.kernel_name.replace('"', "'"),
-            )
-        } else {
-            format!(
-                r#"## Workspace Context
-<workspace_context>
-- Current Working Directory: {}
-{}
-</workspace_context>
-"#,
-                self.context.workspace_path,
-                if related_paths_section.is_empty() {
-                    String::new()
-                } else {
-                    format!("\n{}", related_paths_section)
-                }
-            )
-        }
+                .collect(),
+            remote_execution: self.context.remote_execution.clone(),
+        })
     }
 
     /// Get workspace file list
     pub fn get_project_layout(&self) -> String {
         if let Some(remote_layout) = &self.context.remote_project_layout {
-            let mut project_layout = "## Workspace Layout\n<project_layout>\n".to_string();
-            project_layout.push_str(
-                "Below is a snapshot of the current workspace's file structure on the **remote** host.\n\n",
-            );
-            project_layout.push_str(remote_layout);
-            project_layout.push_str("\n</project_layout>\n\n");
-            return project_layout;
+            return render_project_layout(&ProjectLayoutFacts {
+                listing: remote_layout.clone(),
+                reached_limit: false,
+                max_entries: self.file_tree_max_entries,
+                remote: true,
+            });
         }
 
         let formatted_listing = get_formatted_directory_listing(
@@ -490,16 +274,12 @@ impl PromptBuilder {
             reached_limit: false,
             text: format!("Error listing directory: {}", e),
         });
-        let mut project_layout = "## Workspace Layout\n<project_layout>\n".to_string();
-        if formatted_listing.reached_limit {
-            project_layout.push_str(&format!("Below is a snapshot of the current workspace's file structure (showing up to {} entries).\n\n", self.file_tree_max_entries));
-        } else {
-            project_layout
-                .push_str("Below is a snapshot of the current workspace's file structure.\n\n");
-        }
-        project_layout.push_str(&formatted_listing.text);
-        project_layout.push_str("\n</project_layout>\n\n");
-        project_layout
+        render_project_layout(&ProjectLayoutFacts {
+            listing: formatted_listing.text,
+            reached_limit: formatted_listing.reached_limit,
+            max_entries: self.file_tree_max_entries,
+            remote: false,
+        })
     }
 
     pub fn build_skill_listing_reminder(&self) -> Option<String> {
@@ -557,19 +337,7 @@ impl PromptBuilder {
             additional_sections.push(self.get_project_layout());
         }
 
-        if additional_sections.is_empty() {
-            None
-        } else {
-            Some(format!(
-                "# User Context\n{}\n\n{}",
-                USER_CONTEXT_PROMPT,
-                additional_sections
-                    .into_iter()
-                    .map(|section| section.trim().to_string())
-                    .collect::<Vec<_>>()
-                    .join("\n\n")
-            ))
-        }
+        render_user_context_reminder(additional_sections)
     }
 
     pub async fn build_prepended_reminders(
@@ -766,7 +534,6 @@ mod tests {
     use super::RemoteExecutionHints;
     use super::RuntimeContextNeeds;
     use super::ToolListingSections;
-    use super::USER_CONTEXT_PROMPT;
     use crate::agentic::agents::UserContextPolicy;
     use crate::service::workspace::RelatedPath;
 
@@ -815,7 +582,7 @@ mod tests {
         assert!(collapsed_tool_listing.contains("# Collapsed Tool Listing"));
         assert!(collapsed_tool_listing.contains("<collapsed_tools>"));
         assert!(user_context.contains("# User Context"));
-        assert!(user_context.contains(USER_CONTEXT_PROMPT));
+        assert!(user_context.contains("As you answer the user's questions"));
         assert!(user_context.contains("Current Working Directory: workspace/root"));
         assert!(runtime_context.contains("# Runtime Context"));
         assert!(runtime_context.contains("## Workspace Execution"));
@@ -883,51 +650,6 @@ mod tests {
         assert!(runtime_context.contains("ExecCommand shell:"));
         assert!(runtime_context.contains("invoked as `"));
         assert!(!runtime_context.contains("## Local Client"));
-    }
-
-    #[test]
-    fn local_exec_shell_runtime_guidance_is_added_for_powershell_shells() {
-        let guidance = PromptBuilder::local_exec_shell_runtime_guidance("powershell");
-
-        assert_eq!(
-            guidance,
-            &[
-                "- For inline Python or other embedded scripts, prefer PowerShell-friendly forms such as `@'\\nprint(\"Hello\")\\n'@ | python -` instead of heavily nested quoting.",
-                "- In PowerShell, the escape character is the backtick (`), not backslash. `\\\"` is not a reliable way to escape a double quote for the shell.",
-                "- For environment variables, process filtering, and file traversal, prefer native PowerShell cmdlets and syntax over shell-specific Unix patterns.",
-                "- Avoid mixing PowerShell with `cmd.exe` or bash in the same command unless cross-shell behavior is explicitly required.",
-            ]
-        );
-    }
-
-    #[test]
-    fn local_exec_shell_runtime_guidance_is_empty_for_non_powershell_shells() {
-        assert!(PromptBuilder::local_exec_shell_runtime_guidance("bash").is_empty());
-    }
-
-    #[test]
-    fn exec_control_runtime_guidance_is_added_for_local_windows() {
-        let guidance = PromptBuilder::exec_control_runtime_guidance("windows", false, true);
-
-        assert_eq!(
-            guidance,
-            vec![
-                "- On local Windows ExecCommand sessions, `ExecControl` `interrupt` is effectively the same as `kill` for non-TTY processes.".to_string()
-            ]
-        );
-    }
-
-    #[test]
-    fn exec_control_runtime_guidance_is_empty_when_exec_control_is_unavailable() {
-        assert!(
-            PromptBuilder::exec_control_runtime_guidance("windows", false, false).is_empty()
-        );
-    }
-
-    #[test]
-    fn exec_control_runtime_guidance_is_empty_for_remote_or_non_windows_hosts() {
-        assert!(PromptBuilder::exec_control_runtime_guidance("linux", false, true).is_empty());
-        assert!(PromptBuilder::exec_control_runtime_guidance("windows", true, true).is_empty());
     }
 
     #[tokio::test]

--- a/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
@@ -33,11 +33,12 @@ use uuid::Uuid;
 use bitfun_agent_runtime::scheduler::{
     build_thread_goal_objective_updated_delivery_plan, build_thread_goal_resumed_delivery_plan,
     resolve_agent_session_reply_action, resolve_background_delivery_action,
-    resolve_background_delivery_injection, resolve_dialog_steering_action,
-    resolve_turn_outcome_lifecycle_plan, ActiveDialogTurn, ActiveDialogTurnStore,
-    AgentSessionReplyAction, AgentSessionReplyPlan, BackgroundDeliveryAction,
-    BackgroundDeliveryFacts, BackgroundInjectionKind, DialogReplySuppressionSet,
-    DialogSteeringAction, DialogTurnQueue, GoalContinuationAfterTurnAction, SessionAbortFlags,
+    resolve_background_delivery_injection, resolve_dialog_start_route,
+    resolve_dialog_steering_action, resolve_turn_outcome_lifecycle_plan, ActiveDialogTurn,
+    ActiveDialogTurnStore, AgentSessionReplyAction, AgentSessionReplyPlan,
+    BackgroundDeliveryAction, BackgroundDeliveryFacts, BackgroundInjectionKind,
+    DialogReplySuppressionSet, DialogStartRoute, DialogStartRouteFacts, DialogSteeringAction,
+    DialogTurnQueue, GoalContinuationAfterTurnAction, SessionAbortFlags,
     ThreadGoalDeliveryReminder, ThreadGoalDeliveryReminderKind, TurnOutcomeQueueAction,
     TurnOutcomeStatus,
 };
@@ -722,72 +723,79 @@ impl DialogScheduler {
         session_id: &str,
         queued_turn: &QueuedTurn,
     ) -> Result<String, String> {
-        let res = match queued_turn
+        let images = queued_turn
             .image_contexts
             .as_ref()
-            .filter(|imgs| !imgs.is_empty())
-        {
-            Some(imgs) => {
-                if queued_turn.prepended_messages.is_empty() {
-                    self.coordinator
-                        .start_dialog_turn_with_image_contexts(
-                            session_id.to_string(),
-                            queued_turn.user_input.clone(),
-                            queued_turn.original_user_input.clone(),
-                            imgs.clone(),
-                            queued_turn.turn_id.clone(),
-                            queued_turn.agent_type.clone(),
-                            queued_turn.workspace_path.clone(),
-                            queued_turn.policy,
-                            queued_turn.user_message_metadata.clone(),
-                        )
-                        .await
-                } else {
-                    self.coordinator
-                        .start_dialog_turn_with_image_contexts_and_prepended_messages(
-                            session_id.to_string(),
-                            queued_turn.user_input.clone(),
-                            queued_turn.original_user_input.clone(),
-                            imgs.clone(),
-                            queued_turn.turn_id.clone(),
-                            queued_turn.agent_type.clone(),
-                            queued_turn.workspace_path.clone(),
-                            queued_turn.policy,
-                            queued_turn.user_message_metadata.clone(),
-                            queued_turn.prepended_messages.clone(),
-                        )
-                        .await
-                }
+            .filter(|imgs| !imgs.is_empty());
+        let route = resolve_dialog_start_route(DialogStartRouteFacts {
+            has_image_contexts: images.is_some(),
+            has_prepended_messages: !queued_turn.prepended_messages.is_empty(),
+        });
+
+        let res = match route {
+            DialogStartRoute::Plain => {
+                self.coordinator
+                    .start_dialog_turn(
+                        session_id.to_string(),
+                        queued_turn.user_input.clone(),
+                        queued_turn.original_user_input.clone(),
+                        queued_turn.turn_id.clone(),
+                        queued_turn.agent_type.clone(),
+                        queued_turn.workspace_path.clone(),
+                        queued_turn.policy,
+                        queued_turn.user_message_metadata.clone(),
+                    )
+                    .await
             }
-            None => {
-                if queued_turn.prepended_messages.is_empty() {
-                    self.coordinator
-                        .start_dialog_turn(
-                            session_id.to_string(),
-                            queued_turn.user_input.clone(),
-                            queued_turn.original_user_input.clone(),
-                            queued_turn.turn_id.clone(),
-                            queued_turn.agent_type.clone(),
-                            queued_turn.workspace_path.clone(),
-                            queued_turn.policy,
-                            queued_turn.user_message_metadata.clone(),
-                        )
-                        .await
-                } else {
-                    self.coordinator
-                        .start_dialog_turn_with_prepended_messages(
-                            session_id.to_string(),
-                            queued_turn.user_input.clone(),
-                            queued_turn.original_user_input.clone(),
-                            queued_turn.turn_id.clone(),
-                            queued_turn.agent_type.clone(),
-                            queued_turn.workspace_path.clone(),
-                            queued_turn.policy,
-                            queued_turn.user_message_metadata.clone(),
-                            queued_turn.prepended_messages.clone(),
-                        )
-                        .await
-                }
+            DialogStartRoute::WithPrependedMessages => {
+                self.coordinator
+                    .start_dialog_turn_with_prepended_messages(
+                        session_id.to_string(),
+                        queued_turn.user_input.clone(),
+                        queued_turn.original_user_input.clone(),
+                        queued_turn.turn_id.clone(),
+                        queued_turn.agent_type.clone(),
+                        queued_turn.workspace_path.clone(),
+                        queued_turn.policy,
+                        queued_turn.user_message_metadata.clone(),
+                        queued_turn.prepended_messages.clone(),
+                    )
+                    .await
+            }
+            DialogStartRoute::WithImageContexts => {
+                self.coordinator
+                    .start_dialog_turn_with_image_contexts(
+                        session_id.to_string(),
+                        queued_turn.user_input.clone(),
+                        queued_turn.original_user_input.clone(),
+                        images
+                            .cloned()
+                            .expect("image-context route requires image contexts"),
+                        queued_turn.turn_id.clone(),
+                        queued_turn.agent_type.clone(),
+                        queued_turn.workspace_path.clone(),
+                        queued_turn.policy,
+                        queued_turn.user_message_metadata.clone(),
+                    )
+                    .await
+            }
+            DialogStartRoute::WithImageContextsAndPrependedMessages => {
+                self.coordinator
+                    .start_dialog_turn_with_image_contexts_and_prepended_messages(
+                        session_id.to_string(),
+                        queued_turn.user_input.clone(),
+                        queued_turn.original_user_input.clone(),
+                        images
+                            .cloned()
+                            .expect("image-context route requires image contexts"),
+                        queued_turn.turn_id.clone(),
+                        queued_turn.agent_type.clone(),
+                        queued_turn.workspace_path.clone(),
+                        queued_turn.policy,
+                        queued_turn.user_message_metadata.clone(),
+                        queued_turn.prepended_messages.clone(),
+                    )
+                    .await
             }
         };
 

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -37,8 +37,8 @@ use tokio::time::{timeout, Duration};
 use tokio_util::sync::CancellationToken;
 use tool_runtime::pipeline::{
     partition_tool_batches, retry_delay_ms, should_cancel_tool_state, should_retry_tool_attempt,
-    summarize_dialog_turn_cancellation, ToolCancellationTokenStore, ToolExecutionErrorClass,
-    ToolRetryAttemptFacts,
+    summarize_dialog_turn_cancellation, tool_call_concurrency_safe_for_batch,
+    ToolCancellationTokenStore, ToolExecutionErrorClass, ToolRetryAttemptFacts,
 };
 
 /// Convert framework::ToolResult to core::ToolResult
@@ -244,25 +244,6 @@ fn map_tool_execution_admission_rejection(error: ToolExecutionAdmissionRejection
 
 const SUBAGENT_LAUNCH_TOOL_NAME: &str = "Task";
 
-fn resolve_subagent_tool_concurrency_safe(
-    tool_name: &str,
-    tool_is_concurrency_safe: bool,
-    same_batch_subagent_call_count: usize,
-    subagent_batch_execution_policy: SubagentBatchExecutionPolicy,
-) -> bool {
-    if tool_name != SUBAGENT_LAUNCH_TOOL_NAME {
-        return tool_is_concurrency_safe;
-    }
-
-    match subagent_batch_execution_policy {
-        SubagentBatchExecutionPolicy::SafeOnly => tool_is_concurrency_safe,
-        SubagentBatchExecutionPolicy::ForceParallel => {
-            same_batch_subagent_call_count > 1 || tool_is_concurrency_safe
-        }
-        SubagentBatchExecutionPolicy::Serial => false,
-    }
-}
-
 /// Tool pipeline
 pub struct ToolPipeline {
     tool_registry: Arc<TokioRwLock<ToolRegistry>>,
@@ -361,7 +342,7 @@ impl ToolPipeline {
                         .get_tool(&tc.tool_name)
                         .map(|tool| tool.is_concurrency_safe(Some(&tc.arguments)))
                         .unwrap_or(false);
-                    resolve_subagent_tool_concurrency_safe(
+                    tool_call_concurrency_safe_for_batch(
                         &tc.tool_name,
                         tool_is_concurrency_safe,
                         subagent_call_count,
@@ -1349,66 +1330,6 @@ mod tests {
             ),
             state => panic!("expected failed task state, got {state:?}"),
         }
-    }
-
-    #[test]
-    fn subagent_batch_policy_preserves_safe_only_scheduling() {
-        assert!(!resolve_subagent_tool_concurrency_safe(
-            "Task",
-            false,
-            2,
-            SubagentBatchExecutionPolicy::SafeOnly,
-        ));
-        assert!(resolve_subagent_tool_concurrency_safe(
-            "Task",
-            true,
-            2,
-            SubagentBatchExecutionPolicy::SafeOnly,
-        ));
-        assert!(resolve_subagent_tool_concurrency_safe(
-            "Read",
-            true,
-            2,
-            SubagentBatchExecutionPolicy::SafeOnly,
-        ));
-    }
-
-    #[test]
-    fn subagent_batch_policy_force_parallel_only_changes_multi_subagent_batches() {
-        assert!(!resolve_subagent_tool_concurrency_safe(
-            "Task",
-            false,
-            1,
-            SubagentBatchExecutionPolicy::ForceParallel,
-        ));
-        assert!(resolve_subagent_tool_concurrency_safe(
-            "Task",
-            false,
-            2,
-            SubagentBatchExecutionPolicy::ForceParallel,
-        ));
-        assert!(!resolve_subagent_tool_concurrency_safe(
-            "Write",
-            false,
-            2,
-            SubagentBatchExecutionPolicy::ForceParallel,
-        ));
-    }
-
-    #[test]
-    fn subagent_batch_policy_serial_forces_subagent_calls_out_of_parallel_batches() {
-        assert!(!resolve_subagent_tool_concurrency_safe(
-            "Task",
-            true,
-            2,
-            SubagentBatchExecutionPolicy::Serial,
-        ));
-        assert!(resolve_subagent_tool_concurrency_safe(
-            "Read",
-            true,
-            2,
-            SubagentBatchExecutionPolicy::Serial,
-        ));
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/types.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/types.rs
@@ -9,6 +9,7 @@ use crate::agentic::WorkspaceBinding;
 use bitfun_runtime_ports::DelegationPolicy;
 use std::collections::HashMap;
 use std::time::SystemTime;
+pub use tool_runtime::pipeline::SubagentBatchExecutionPolicy;
 
 /// Tool execution options
 #[derive(Debug, Clone)]
@@ -34,14 +35,6 @@ impl Default for ToolExecutionOptions {
             confirmation_timeout_secs: None, // Default no timeout (infinite waiting)
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum SubagentBatchExecutionPolicy {
-    #[default]
-    SafeOnly,
-    ForceParallel,
-    Serial,
 }
 
 #[derive(Debug, Clone)]

--- a/src/crates/assembly/core/src/infrastructure/ai/client_factory.rs
+++ b/src/crates/assembly/core/src/infrastructure/ai/client_factory.rs
@@ -15,6 +15,7 @@ use crate::service::config::{get_global_config_service, ConfigService};
 use crate::util::errors::{BitFunError, BitFunResult};
 use crate::util::types::AIConfig;
 use anyhow::{anyhow, Result};
+use bitfun_ai_adapters::{resolve_cache_model_selector, resolve_required_model_selector};
 use log::{debug, info, warn};
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, RwLock};
@@ -25,29 +26,6 @@ pub struct AIClientFactory {
 }
 
 impl AIClientFactory {
-    fn normalize_model_selector(model_id: &str) -> &str {
-        let trimmed = model_id.trim();
-        if trimmed.is_empty() || trimmed == "auto" || trimmed == "default" {
-            "primary"
-        } else {
-            trimmed
-        }
-    }
-
-    fn resolve_model_reference_in_config(
-        global_config: &crate::service::config::GlobalConfig,
-        model_ref: &str,
-    ) -> Option<String> {
-        global_config.ai.resolve_model_reference(model_ref)
-    }
-
-    fn resolve_model_selection_in_config(
-        global_config: &crate::service::config::GlobalConfig,
-        model_ref: &str,
-    ) -> Option<String> {
-        global_config.ai.resolve_model_selection(model_ref)
-    }
-
     fn new(config_service: Arc<ConfigService>) -> Self {
         Self {
             config_service,
@@ -92,17 +70,12 @@ impl AIClientFactory {
     pub async fn get_client_resolved(&self, model_id: &str) -> Result<Arc<AIClient>> {
         let global_config: crate::service::config::GlobalConfig =
             self.config_service.get_config(None).await?;
-        let model_id = Self::normalize_model_selector(model_id);
-
-        let resolved_model_id = match model_id {
-            "primary" => Self::resolve_model_selection_in_config(&global_config, "primary")
-                .ok_or_else(|| anyhow!("Primary model not configured or invalid"))?,
-            "fast" => Self::resolve_model_selection_in_config(&global_config, "fast").ok_or_else(
-                || anyhow!("Fast model not configured or invalid, and primary model not configured or invalid"),
-            )?,
-            _ => Self::resolve_model_reference_in_config(&global_config, model_id)
-                .unwrap_or_else(|| model_id.to_string()),
-        };
+        let resolved_model_id = resolve_required_model_selector(
+            model_id,
+            |selector| global_config.ai.resolve_model_selection(selector),
+            |model_ref| global_config.ai.resolve_model_reference(model_ref),
+        )
+        .map_err(|error| anyhow!(error.to_string()))?;
 
         self.get_or_create_client(&resolved_model_id).await
     }
@@ -147,13 +120,11 @@ impl AIClientFactory {
     async fn get_or_create_client(&self, model_id: &str) -> Result<Arc<AIClient>> {
         let global_config: crate::service::config::GlobalConfig =
             self.config_service.get_config(None).await?;
-        let model_id = Self::normalize_model_selector(model_id);
-        let normalized_model_id = match model_id {
-            "primary" | "fast" => Self::resolve_model_selection_in_config(&global_config, model_id)
-                .unwrap_or_else(|| model_id.to_string()),
-            _ => Self::resolve_model_reference_in_config(&global_config, model_id)
-                .unwrap_or_else(|| model_id.to_string()),
-        };
+        let normalized_model_id = resolve_cache_model_selector(
+            model_id,
+            |selector| global_config.ai.resolve_model_selection(selector),
+            |model_ref| global_config.ai.resolve_model_reference(model_ref),
+        );
 
         {
             let cache = match self.client_cache.read() {
@@ -346,8 +317,10 @@ pub async fn discover_cli_credentials() -> Vec<cli_credentials::DiscoveredCreden
 
 #[cfg(test)]
 mod tests {
-    use super::AIClientFactory;
     use crate::service::config::types::{AIModelConfig, GlobalConfig};
+    use bitfun_ai_adapters::{
+        classify_model_selector, resolve_required_model_selector, ModelSelectorKind,
+    };
 
     fn build_model(id: &str, name: &str, model_name: &str) -> AIModelConfig {
         AIModelConfig {
@@ -370,30 +343,30 @@ mod tests {
         )];
 
         assert_eq!(
-            AIClientFactory::resolve_model_reference_in_config(&config, "model-123"),
+            config.ai.resolve_model_reference("model-123"),
             Some("model-123".to_string())
         );
         assert_eq!(
-            AIClientFactory::resolve_model_reference_in_config(&config, "Primary Chat"),
+            config.ai.resolve_model_reference("Primary Chat"),
             Some("model-123".to_string())
         );
         assert_eq!(
-            AIClientFactory::resolve_model_reference_in_config(&config, "claude-sonnet-4.5"),
+            config.ai.resolve_model_reference("claude-sonnet-4.5"),
             Some("model-123".to_string())
         );
     }
 
     #[test]
     fn auto_model_selectors_normalize_to_primary_for_client_lookup() {
-        assert_eq!(AIClientFactory::normalize_model_selector("auto"), "primary");
+        assert_eq!(classify_model_selector("auto"), ModelSelectorKind::Primary);
         assert_eq!(
-            AIClientFactory::normalize_model_selector(" default "),
-            "primary"
+            classify_model_selector(" default "),
+            ModelSelectorKind::Primary
         );
-        assert_eq!(AIClientFactory::normalize_model_selector(""), "primary");
+        assert_eq!(classify_model_selector(""), ModelSelectorKind::Primary);
         assert_eq!(
-            AIClientFactory::normalize_model_selector("model-primary"),
-            "model-primary"
+            classify_model_selector("model-primary"),
+            ModelSelectorKind::Explicit("model-primary".to_string())
         );
     }
 
@@ -408,8 +381,13 @@ mod tests {
         config.ai.default_models.primary = Some("model-primary".to_string());
 
         assert_eq!(
-            AIClientFactory::resolve_model_selection_in_config(&config, "fast"),
-            Some("model-primary".to_string())
+            resolve_required_model_selector(
+                "fast",
+                |selector| config.ai.resolve_model_selection(selector),
+                |model_ref| config.ai.resolve_model_reference(model_ref),
+            )
+            .expect("fast should fall back to primary"),
+            "model-primary"
         );
     }
 
@@ -425,8 +403,13 @@ mod tests {
         config.ai.default_models.fast = Some("deleted-fast-model".to_string());
 
         assert_eq!(
-            AIClientFactory::resolve_model_selection_in_config(&config, "fast"),
-            Some("model-primary".to_string())
+            resolve_required_model_selector(
+                "fast",
+                |selector| config.ai.resolve_model_selection(selector),
+                |model_ref| config.ai.resolve_model_reference(model_ref),
+            )
+            .expect("stale fast should fall back to primary"),
+            "model-primary"
         );
     }
 }

--- a/src/crates/execution/agent-runtime/AGENTS.md
+++ b/src/crates/execution/agent-runtime/AGENTS.md
@@ -39,15 +39,15 @@ port-backed `sdk` / `AgentRuntime` facade that can be built and tested without
   round-boundary yield/injection state, turn-outcome
   queue decisions, registry source/profile facts, prompt-loop user-context
   policy, prompt listing reminder ordering, prompt-cache policy/identity/store,
-  turn skill/agent snapshot state, file-read session state, session evidence
-  ledger projection, finish-reason labels, session-state event labels, and
-  turn-outcome event facts.
-- Keep concrete prompt assembly, workspace context IO, prompt-cache persistence
-  wiring, dynamic environment collection, concrete hook side effects,
-  DeepReview task launch/provider wait/report persistence, DeepResearch
-  storage IO/post-turn hook and concrete product tool execution outside this
-  crate until a reviewed migration proves behavior
-  equivalence.
+  prompt runtime/workspace/user-context rendering, turn skill/agent snapshot
+  state, file-read session state, session evidence ledger projection,
+  finish-reason labels, session-state event labels, and turn-outcome event
+  facts.
+- Keep concrete prompt fact collection, workspace context IO, prompt-cache
+  persistence wiring, dynamic environment collection, concrete hook side
+  effects, DeepReview task launch/provider wait/report persistence,
+  DeepResearch storage IO/post-turn hook and concrete product tool execution
+  outside this crate until a reviewed migration proves behavior equivalence.
 - Add focused tests before moving any runtime decision into this crate.
 
 ## Verification

--- a/src/crates/execution/agent-runtime/src/prompt.rs
+++ b/src/crates/execution/agent-runtime/src/prompt.rs
@@ -49,6 +49,335 @@ pub fn render_prompt_environment_info(facts: PromptEnvironmentFacts<'_>) -> Stri
     }
 }
 
+/// SSH remote host facts for prompt rendering. Runtime services still own
+/// concrete remote probing and IO.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteExecutionHints {
+    pub connection_display_name: String,
+    pub kernel_name: String,
+    pub hostname: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RuntimeContextNeeds {
+    pub workspace_tools: bool,
+    pub exec_command: bool,
+    pub exec_control: bool,
+    pub computer_use: bool,
+}
+
+impl RuntimeContextNeeds {
+    pub fn from_tool_names<T, I>(tool_names: I) -> Self
+    where
+        T: AsRef<str>,
+        I: IntoIterator<Item = T>,
+    {
+        let mut needs = Self::default();
+        for tool_name in tool_names {
+            let tool_name = tool_name.as_ref();
+            match tool_name {
+                "Read" | "Write" | "Edit" | "Delete" | "LS" | "Grep" | "Glob" | "ExecCommand"
+                | "WriteStdin" | "ExecControl" => {
+                    needs.workspace_tools = true;
+                    if tool_name == "ExecCommand" {
+                        needs.exec_command = true;
+                    }
+                    if tool_name == "ExecControl" {
+                        needs.exec_control = true;
+                    }
+                }
+                "ComputerUse" | "ControlHub" => {
+                    needs.computer_use = true;
+                }
+                _ => {}
+            }
+        }
+        needs
+    }
+
+    pub fn is_empty(self) -> bool {
+        !self.workspace_tools && !self.exec_command && !self.exec_control && !self.computer_use
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeShellFacts {
+    pub display_name: String,
+    pub shell_type: String,
+    pub invocation: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeContextFacts {
+    pub needs: RuntimeContextNeeds,
+    pub host_os: String,
+    pub host_family: String,
+    pub host_arch: String,
+    pub remote_execution: Option<RemoteExecutionHints>,
+    pub local_shell: Option<RuntimeShellFacts>,
+}
+
+pub fn render_runtime_context_reminder(facts: &RuntimeContextFacts) -> Option<String> {
+    if facts.needs.is_empty() {
+        return None;
+    }
+
+    let mut lines = vec!["# Runtime Context".to_string()];
+
+    if facts.needs.workspace_tools {
+        let mut workspace_lines = Vec::new();
+        if let Some(remote) = &facts.remote_execution {
+            workspace_lines.push(format!(
+                "- Workspace file and shell tools operate on remote SSH connection \"{}\".",
+                remote.connection_display_name.replace('"', "'")
+            ));
+            workspace_lines.push(format!(
+                "- Remote host: {} (uname/kernel: {})",
+                remote.hostname.replace('"', "'"),
+                remote.kernel_name.replace('"', "'")
+            ));
+            workspace_lines.push("- Path conventions for workspace operations: POSIX paths with forward slashes and Unix shell syntax. Do not use PowerShell, `cmd.exe`, or Windows-style paths for remote workspace operations.".to_string());
+        } else {
+            workspace_lines.push(
+                "- Workspace file and shell tools operate on the local filesystem.".to_string(),
+            );
+        }
+        push_runtime_context_section(&mut lines, "Workspace Execution", workspace_lines);
+    }
+
+    if facts.needs.exec_command {
+        let mut exec_command_lines = Vec::new();
+        if facts.remote_execution.is_some() {
+            exec_command_lines.push(
+                "- ExecCommand uses the remote user's default POSIX shell, invoked as `<shell> -lc <cmd>`."
+                    .to_string(),
+            );
+        } else if let Some(shell) = &facts.local_shell {
+            push_local_exec_shell_runtime_context(
+                &mut exec_command_lines,
+                &shell.display_name,
+                &shell.shell_type,
+                &shell.invocation,
+            );
+        }
+        push_runtime_context_section(&mut lines, "ExecCommand Shell", exec_command_lines);
+    }
+
+    let exec_control_lines = exec_control_runtime_guidance(
+        &facts.host_os,
+        facts.remote_execution.is_some(),
+        facts.needs.exec_control,
+    );
+    push_runtime_context_section(&mut lines, "ExecControl", exec_control_lines);
+
+    if facts.needs.computer_use {
+        let mut local_client_lines = Vec::new();
+        if facts.remote_execution.is_some() && facts.needs.workspace_tools {
+            local_client_lines.push(
+                "- Computer use and UI automation operate on the local BitFun desktop, even when workspace file and shell tools target a remote host."
+                    .to_string(),
+            );
+        }
+        local_client_lines.push(format!(
+            "- Local BitFun client OS: {} ({})",
+            facts.host_os, facts.host_family
+        ));
+        local_client_lines.push(format!("- Local client architecture: {}", facts.host_arch));
+        local_client_lines
+            .push(runtime_computer_use_key_chord_guidance(&facts.host_os).to_string());
+        push_runtime_context_section(&mut lines, "Local Client", local_client_lines);
+    }
+
+    Some(lines.join("\n"))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptRelatedPath {
+    pub path: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceContextFacts {
+    pub workspace_path: String,
+    pub related_paths: Vec<PromptRelatedPath>,
+    pub remote_execution: Option<RemoteExecutionHints>,
+}
+
+pub fn render_workspace_context(facts: &WorkspaceContextFacts) -> String {
+    let related_paths_section = if facts.related_paths.is_empty() {
+        String::new()
+    } else {
+        let items = facts
+            .related_paths
+            .iter()
+            .map(|related_path| {
+                let path = related_path.path.replace('\\', "/");
+                match related_path.description.as_deref().map(str::trim) {
+                    Some(description) if !description.is_empty() => {
+                        format!("  - {} — {}", path, description)
+                    }
+                    _ => format!("  - {}", path),
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!(
+            "- Related directories (user-specified directories related to this workspace):\n{}",
+            items
+        )
+    };
+
+    if let Some(remote) = &facts.remote_execution {
+        format!(
+            r#"## Workspace Context
+<workspace_context>
+- Workspace root (file tools, Glob, LS, ExecCommand on workspace): {}
+{}
+- Execution environment: **Remote SSH** — connection "{}".
+- Remote host: {} (uname/kernel: {})
+</workspace_context>
+"#,
+            facts.workspace_path,
+            if related_paths_section.is_empty() {
+                String::new()
+            } else {
+                format!("{}\n", related_paths_section)
+            },
+            remote.connection_display_name.replace('"', "'"),
+            remote.hostname.replace('"', "'"),
+            remote.kernel_name.replace('"', "'"),
+        )
+    } else {
+        format!(
+            r#"## Workspace Context
+<workspace_context>
+- Current Working Directory: {}
+{}
+</workspace_context>
+"#,
+            facts.workspace_path,
+            if related_paths_section.is_empty() {
+                String::new()
+            } else {
+                format!("\n{}", related_paths_section)
+            }
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectLayoutFacts {
+    pub listing: String,
+    pub reached_limit: bool,
+    pub max_entries: usize,
+    pub remote: bool,
+}
+
+pub fn render_project_layout(facts: &ProjectLayoutFacts) -> String {
+    let mut project_layout = "## Workspace Layout\n<project_layout>\n".to_string();
+    if facts.remote {
+        project_layout.push_str(
+            "Below is a snapshot of the current workspace's file structure on the **remote** host.\n\n",
+        );
+    } else if facts.reached_limit {
+        project_layout.push_str(&format!(
+            "Below is a snapshot of the current workspace's file structure (showing up to {} entries).\n\n",
+            facts.max_entries
+        ));
+    } else {
+        project_layout
+            .push_str("Below is a snapshot of the current workspace's file structure.\n\n");
+    }
+    project_layout.push_str(&facts.listing);
+    project_layout.push_str("\n</project_layout>\n\n");
+    project_layout
+}
+
+pub fn render_user_context_reminder(sections: impl IntoIterator<Item = String>) -> Option<String> {
+    let sections = sections
+        .into_iter()
+        .map(|section| section.trim().to_string())
+        .filter(|section| !section.is_empty())
+        .collect::<Vec<_>>();
+
+    if sections.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "# User Context\n{}\n\n{}",
+            USER_CONTEXT_PROMPT,
+            sections.join("\n\n")
+        ))
+    }
+}
+
+const USER_CONTEXT_PROMPT: &str =
+    "As you answer the user's questions, you can use the following context.\nNote: this is a snapshot captured at the start of the conversation and may not reflect real-time changes made afterward.";
+
+fn local_exec_shell_runtime_guidance(shell_type: &str) -> &'static [&'static str] {
+    match shell_type {
+        "powershell" | "pwsh" => &[
+            "- For inline Python or other embedded scripts, prefer PowerShell-friendly forms such as `@'\\nprint(\"Hello\")\\n'@ | python -` instead of heavily nested quoting.",
+            "- In PowerShell, the escape character is the backtick (`), not backslash. `\\\"` is not a reliable way to escape a double quote for the shell.",
+            "- For environment variables, process filtering, and file traversal, prefer native PowerShell cmdlets and syntax over shell-specific Unix patterns.",
+            "- Avoid mixing PowerShell with `cmd.exe` or bash in the same command unless cross-shell behavior is explicitly required.",
+        ],
+        _ => &[],
+    }
+}
+
+fn push_local_exec_shell_runtime_context(
+    lines: &mut Vec<String>,
+    shell_display_name: &str,
+    shell_type: &str,
+    shell_invocation: &str,
+) {
+    lines.push(format!(
+        "- ExecCommand shell: {shell_display_name} ({shell_type}), invoked as {shell_invocation}."
+    ));
+    lines.extend(
+        local_exec_shell_runtime_guidance(shell_type)
+            .iter()
+            .map(|line| (*line).to_string()),
+    );
+}
+
+fn push_runtime_context_section(lines: &mut Vec<String>, title: &str, section_lines: Vec<String>) {
+    if section_lines.is_empty() {
+        return;
+    }
+
+    if !lines.is_empty() {
+        lines.push(String::new());
+    }
+    lines.push(format!("## {title}"));
+    lines.extend(section_lines);
+}
+
+fn exec_control_runtime_guidance(
+    host_os: &str,
+    remote_execution: bool,
+    exec_control_available: bool,
+) -> Vec<String> {
+    if !exec_control_available || remote_execution || host_os != "windows" {
+        return Vec::new();
+    }
+
+    vec![
+        "- On local Windows ExecCommand sessions, `ExecControl` `interrupt` is effectively the same as `kill` for non-TTY processes.".to_string(),
+    ]
+}
+
+fn runtime_computer_use_key_chord_guidance(host_os: &str) -> &'static str {
+    match host_os {
+        "macos" => "- Computer use / `key_chord`: the local BitFun desktop is macOS. Use `command`, `option`, `control`, and `shift` modifier names.",
+        "windows" => "- Computer use / `key_chord`: the local BitFun desktop is Windows. Use `meta`/`super` for the Windows key, plus `alt`, `control`, and `shift`.",
+        "linux" => "- Computer use / `key_chord`: the local BitFun desktop is Linux. Use `control`, `alt`, `shift`, and `meta`/`super` as appropriate for the desktop environment.",
+        _ => "- Computer use / `key_chord`: match modifier names to the local BitFun desktop OS.",
+    }
+}
+
 fn computer_use_key_chord_guidance(host_os: &str) -> &'static str {
     match host_os {
         "macos" => "Computer use / `key_chord`: the **local BitFun desktop** is **macOS** — use `command`, `option`, `control`, `shift` (not Win/Linux modifier names). **ACTION PRIORITY:** 1) Terminal/CLI/system commands (use ExecCommand for `osascript`, AppleScript, shell scripts) 2) Keyboard shortcuts: command+a/c/x/v (clipboard), command+space (Spotlight), command+tab (switch app) 3) UI control (AX/OCR/mouse) only when above fail.",

--- a/src/crates/execution/agent-runtime/src/scheduler.rs
+++ b/src/crates/execution/agent-runtime/src/scheduler.rs
@@ -697,6 +697,29 @@ impl TurnOutcomeLifecyclePlan {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DialogStartRouteFacts {
+    pub has_image_contexts: bool,
+    pub has_prepended_messages: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DialogStartRoute {
+    Plain,
+    WithPrependedMessages,
+    WithImageContexts,
+    WithImageContextsAndPrependedMessages,
+}
+
+pub const fn resolve_dialog_start_route(facts: DialogStartRouteFacts) -> DialogStartRoute {
+    match (facts.has_image_contexts, facts.has_prepended_messages) {
+        (false, false) => DialogStartRoute::Plain,
+        (false, true) => DialogStartRoute::WithPrependedMessages,
+        (true, false) => DialogStartRoute::WithImageContexts,
+        (true, true) => DialogStartRoute::WithImageContextsAndPrependedMessages,
+    }
+}
+
 pub fn resolve_turn_outcome_lifecycle_plan(
     outcome: &TurnOutcome,
     has_active_turn: bool,

--- a/src/crates/execution/agent-runtime/tests/prompt_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/prompt_contracts.rs
@@ -1,6 +1,9 @@
 use bitfun_agent_runtime::prompt::{
-    render_prompt_environment_info, PrependedPromptReminders, PromptEnvironmentFacts,
-    ToolListingSections, UserContextPolicy, UserContextSection,
+    render_project_layout, render_prompt_environment_info, render_runtime_context_reminder,
+    render_user_context_reminder, render_workspace_context, PrependedPromptReminders,
+    ProjectLayoutFacts, PromptEnvironmentFacts, PromptRelatedPath, RemoteExecutionHints,
+    RuntimeContextFacts, RuntimeContextNeeds, RuntimeShellFacts, ToolListingSections,
+    UserContextPolicy, UserContextSection, WorkspaceContextFacts,
 };
 
 #[test]
@@ -100,4 +103,110 @@ fn prompt_environment_info_preserves_local_and_remote_guidance() {
     assert!(remote.contains("- Local BitFun client OS: linux (unix)"));
     assert!(remote.contains("applies to Computer use / UI automation"));
     assert!(remote.contains("Local client architecture: aarch64"));
+}
+
+#[test]
+fn runtime_context_renderer_preserves_local_exec_and_computer_use_guidance() {
+    let reminder = render_runtime_context_reminder(&RuntimeContextFacts {
+        needs: RuntimeContextNeeds::from_tool_names(["Read", "ExecCommand", "ComputerUse"]),
+        host_os: "windows".to_string(),
+        host_family: "windows".to_string(),
+        host_arch: "x86_64".to_string(),
+        remote_execution: None,
+        local_shell: Some(RuntimeShellFacts {
+            display_name: "PowerShell".to_string(),
+            shell_type: "powershell".to_string(),
+            invocation: "powershell.exe -NoLogo".to_string(),
+        }),
+    })
+    .expect("runtime context should render");
+
+    assert!(reminder.contains("# Runtime Context"));
+    assert!(reminder.contains("## Workspace Execution"));
+    assert!(reminder.contains("- Workspace file and shell tools operate on the local filesystem."));
+    assert!(reminder.contains("## ExecCommand Shell"));
+    assert!(reminder.contains("PowerShell (powershell)"));
+    assert!(reminder.contains("prefer native PowerShell cmdlets"));
+    assert!(reminder.contains("## Local Client"));
+    assert!(reminder.contains("- Local BitFun client OS: windows (windows)"));
+    assert!(reminder.contains("meta`/`super`"));
+}
+
+#[test]
+fn runtime_context_renderer_preserves_remote_workspace_split() {
+    let reminder = render_runtime_context_reminder(&RuntimeContextFacts {
+        needs: RuntimeContextNeeds::from_tool_names([
+            "Read",
+            "ExecCommand",
+            "ExecControl",
+            "ComputerUse",
+        ]),
+        host_os: "windows".to_string(),
+        host_family: "windows".to_string(),
+        host_arch: "x86_64".to_string(),
+        remote_execution: Some(RemoteExecutionHints {
+            connection_display_name: "prod \"box\"".to_string(),
+            kernel_name: "Linux".to_string(),
+            hostname: "remote-host".to_string(),
+        }),
+        local_shell: Some(RuntimeShellFacts {
+            display_name: "PowerShell".to_string(),
+            shell_type: "powershell".to_string(),
+            invocation: "powershell.exe".to_string(),
+        }),
+    })
+    .expect("remote runtime context should render");
+
+    assert!(reminder.contains("remote SSH connection \"prod 'box'\""));
+    assert!(reminder.contains("Remote host: remote-host (uname/kernel: Linux)"));
+    assert!(reminder.contains("ExecCommand uses the remote user's default POSIX shell"));
+    assert!(!reminder.contains("## ExecControl"));
+    assert!(reminder.contains("Computer use and UI automation operate on the local BitFun desktop"));
+}
+
+#[test]
+fn workspace_and_user_context_renderers_preserve_section_shape() {
+    let local = render_workspace_context(&WorkspaceContextFacts {
+        workspace_path: "workspace/root".to_string(),
+        related_paths: vec![PromptRelatedPath {
+            path: "sibling\\project".to_string(),
+            description: Some("docs".to_string()),
+        }],
+        remote_execution: None,
+    });
+
+    assert!(local.contains("## Workspace Context"));
+    assert!(local.contains("- Current Working Directory: workspace/root"));
+    assert!(local.contains("sibling/project"));
+    assert!(local.contains("sibling/project — docs"));
+    assert!(local.contains("docs"));
+
+    let remote = render_workspace_context(&WorkspaceContextFacts {
+        workspace_path: "/srv/workspace".to_string(),
+        related_paths: Vec::new(),
+        remote_execution: Some(RemoteExecutionHints {
+            connection_display_name: "remote".to_string(),
+            kernel_name: "Linux".to_string(),
+            hostname: "host".to_string(),
+        }),
+    });
+    assert!(remote.contains(
+        "Workspace root (file tools, Glob, LS, ExecCommand on workspace): /srv/workspace"
+    ));
+    assert!(remote.contains("Execution environment: **Remote SSH**"));
+    assert!(remote.contains("**Remote SSH** — connection"));
+
+    let project_layout = render_project_layout(&ProjectLayoutFacts {
+        listing: "src\nCargo.toml".to_string(),
+        reached_limit: true,
+        max_entries: 2,
+        remote: false,
+    });
+    assert!(project_layout.contains("showing up to 2 entries"));
+
+    let user_context =
+        render_user_context_reminder(vec![local, project_layout]).expect("context should render");
+    assert!(user_context.starts_with("# User Context\nAs you answer"));
+    assert!(user_context.contains("## Workspace Context"));
+    assert!(user_context.contains("## Workspace Layout"));
 }

--- a/src/crates/execution/agent-runtime/tests/scheduler_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/scheduler_contracts.rs
@@ -1,12 +1,14 @@
 use bitfun_agent_runtime::scheduler::{
     build_thread_goal_objective_updated_delivery_plan, build_thread_goal_resumed_delivery_plan,
     resolve_agent_session_reply_action, resolve_background_delivery_action,
-    resolve_background_delivery_injection, resolve_dialog_steering_action, ActiveDialogTurn,
-    ActiveDialogTurnStore, AgentSessionReplyAction, BackgroundDeliveryAction,
-    BackgroundDeliveryFacts, BackgroundInjectionKind, DialogReplySuppressionSet,
-    DialogRoundInjectionInterrupt, DialogSteeringAction, DialogTurnQueue, DialogTurnQueueError,
-    SessionAbortFlags, SessionRoundInjectionBuffer, ThreadGoalDeliveryReminderKind, TurnOutcome,
-    TurnOutcomeQueueAction, TurnOutcomeStatus, DEFAULT_MAX_DIALOG_QUEUE_DEPTH,
+    resolve_background_delivery_injection, resolve_dialog_start_route,
+    resolve_dialog_steering_action, ActiveDialogTurn, ActiveDialogTurnStore,
+    AgentSessionReplyAction, BackgroundDeliveryAction, BackgroundDeliveryFacts,
+    BackgroundInjectionKind, DialogReplySuppressionSet, DialogRoundInjectionInterrupt,
+    DialogStartRoute, DialogStartRouteFacts, DialogSteeringAction, DialogTurnQueue,
+    DialogTurnQueueError, SessionAbortFlags, SessionRoundInjectionBuffer,
+    ThreadGoalDeliveryReminderKind, TurnOutcome, TurnOutcomeQueueAction, TurnOutcomeStatus,
+    DEFAULT_MAX_DIALOG_QUEUE_DEPTH,
 };
 use bitfun_runtime_ports::{
     AgentSessionReplyRoute, DialogQueuePriority, DialogSessionStateFact, DialogSteerOutcome,
@@ -251,6 +253,38 @@ fn dialog_turn_queue_requeued_turn_keeps_original_priority_for_later_ordering() 
 
     assert_eq!(queue.dequeue_next("s1"), Some("new-high"));
     assert_eq!(queue.dequeue_next("s1"), Some("retry-low"));
+}
+
+#[test]
+fn dialog_start_route_preserves_image_and_prepended_message_matrix() {
+    assert_eq!(
+        resolve_dialog_start_route(DialogStartRouteFacts {
+            has_image_contexts: false,
+            has_prepended_messages: false,
+        }),
+        DialogStartRoute::Plain
+    );
+    assert_eq!(
+        resolve_dialog_start_route(DialogStartRouteFacts {
+            has_image_contexts: false,
+            has_prepended_messages: true,
+        }),
+        DialogStartRoute::WithPrependedMessages
+    );
+    assert_eq!(
+        resolve_dialog_start_route(DialogStartRouteFacts {
+            has_image_contexts: true,
+            has_prepended_messages: false,
+        }),
+        DialogStartRoute::WithImageContexts
+    );
+    assert_eq!(
+        resolve_dialog_start_route(DialogStartRouteFacts {
+            has_image_contexts: true,
+            has_prepended_messages: true,
+        }),
+        DialogStartRoute::WithImageContextsAndPrependedMessages
+    );
 }
 
 #[test]

--- a/src/crates/execution/tool-execution/src/pipeline.rs
+++ b/src/crates/execution/tool-execution/src/pipeline.rs
@@ -10,6 +10,14 @@ pub struct ToolBatch {
     pub is_concurrent: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SubagentBatchExecutionPolicy {
+    #[default]
+    SafeOnly,
+    ForceParallel,
+    Serial,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolExecutionErrorClass {
     Retryable,
@@ -130,6 +138,25 @@ pub fn partition_tool_batches(task_ids: &[String], flags: &[bool]) -> Vec<ToolBa
     }
 
     batches
+}
+
+pub fn tool_call_concurrency_safe_for_batch(
+    tool_name: &str,
+    tool_is_concurrency_safe: bool,
+    same_batch_subagent_call_count: usize,
+    subagent_batch_execution_policy: SubagentBatchExecutionPolicy,
+) -> bool {
+    if tool_name != "Task" {
+        return tool_is_concurrency_safe;
+    }
+
+    match subagent_batch_execution_policy {
+        SubagentBatchExecutionPolicy::SafeOnly => tool_is_concurrency_safe,
+        SubagentBatchExecutionPolicy::ForceParallel => {
+            same_batch_subagent_call_count > 1 || tool_is_concurrency_safe
+        }
+        SubagentBatchExecutionPolicy::Serial => false,
+    }
 }
 
 pub fn should_retry_tool_attempt(facts: ToolRetryAttemptFacts) -> bool {

--- a/src/crates/execution/tool-execution/tests/tool_pipeline_planning.rs
+++ b/src/crates/execution/tool-execution/tests/tool_pipeline_planning.rs
@@ -1,6 +1,7 @@
 use tool_runtime::pipeline::{
     count_tool_states, partition_tool_batches, retry_delay_ms, should_cancel_tool_state,
-    should_retry_tool_attempt, summarize_dialog_turn_cancellation, ToolCancellationTokenStore,
+    should_retry_tool_attempt, summarize_dialog_turn_cancellation,
+    tool_call_concurrency_safe_for_batch, SubagentBatchExecutionPolicy, ToolCancellationTokenStore,
     ToolExecutionErrorClass, ToolRetryAttemptFacts, ToolTaskStateKind,
 };
 
@@ -41,6 +42,46 @@ fn partitions_serial_tools_as_individual_batches() {
     assert!(!batches[0].is_concurrent);
     assert_eq!(batches[1].task_ids, vec!["bash_1"]);
     assert!(!batches[1].is_concurrent);
+}
+
+#[test]
+fn subagent_batch_policy_preserves_task_concurrency_contract() {
+    assert!(!tool_call_concurrency_safe_for_batch(
+        "Task",
+        false,
+        2,
+        SubagentBatchExecutionPolicy::SafeOnly,
+    ));
+    assert!(tool_call_concurrency_safe_for_batch(
+        "Task",
+        true,
+        1,
+        SubagentBatchExecutionPolicy::SafeOnly,
+    ));
+    assert!(tool_call_concurrency_safe_for_batch(
+        "Task",
+        false,
+        2,
+        SubagentBatchExecutionPolicy::ForceParallel,
+    ));
+    assert!(!tool_call_concurrency_safe_for_batch(
+        "Task",
+        false,
+        1,
+        SubagentBatchExecutionPolicy::ForceParallel,
+    ));
+    assert!(!tool_call_concurrency_safe_for_batch(
+        "Task",
+        true,
+        2,
+        SubagentBatchExecutionPolicy::Serial,
+    ));
+    assert!(tool_call_concurrency_safe_for_batch(
+        "Read",
+        true,
+        0,
+        SubagentBatchExecutionPolicy::Serial,
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Move runtime/workspace/user-context prompt rendering decisions into `bitfun-agent-runtime`; `bitfun-core` now gathers facts and keeps concrete workspace IO.
- Move dialog start route selection into `bitfun-agent-runtime`, while coordinator calls remain in `bitfun-core`.
- Move Task batch concurrency policy into `tool-runtime` and model selector/cache-key resolution into `bitfun-ai-adapters`.
- Update H1 plan/completed notes and nearest `AGENTS.md` owner guidance to match the new boundaries.

## Compatibility and risk

- No intended behavior change: prompt text shape, scheduler route matrix, Task batching, and model selector fallback behavior are covered by equivalence tests.
- Existing core-facing import paths stay compatible via re-exports/adapters.
- Concrete config IO, credential overlay, coordinator calls, workspace fact collection, prompt-cache persistence IO, and concrete provider/client creation remain outside portable runtime owner crates.
- Latest upstream `main` only changed Web UI theme/color files, with no conflict against this runtime migration scope.

## Verification

- `pnpm run fmt:rs`
- `cargo test -p bitfun-agent-runtime`
- `cargo test -p tool-runtime`
- `cargo test -p bitfun-ai-adapters`
- `cargo check -p bitfun-core --no-default-features`
- `cargo check -p bitfun-core --features product-full`
- `cargo test -p bitfun-core prompt_builder --lib`
- `cargo test -p bitfun-core tool_pipeline --lib`
- `cargo test -p bitfun-core client_factory --lib`
- `cargo test -p bitfun-core scheduler --lib`
- `cargo check --workspace`
- `node --test scripts/check-core-boundaries.test.mjs`
- `node scripts/check-core-boundaries.mjs`
- `pnpm run check:repo-hygiene`
- `git diff --check`