### PR TITLE
refactor(runtime): complete MiniApp H2 domain planning

### DIFF
--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -24,7 +24,7 @@
 - `tool-execution` 已承接 local / remote IO helper、Bash shell helper、batching plan、retry policy、state counting、cancellation-state/token-store policy、background exec output capture 和部分 result rendering。
 - `agent-runtime` 已承接 scheduler/background delivery 纯决策、dialog lifecycle port contracts、session management/cancellation port contracts、thread-goal facts、prompt / prompt-cache facts 与持久化写入决策、turn skill/agent snapshot DTO/diff/render/store、file-read session state、session evidence ledger 与 compression-contract projection、dialog-turn cancellation token store、tool confirmation / user-question wait channel state、custom subagent discovery/loading、post-call hook routing、DeepReview provider-neutral policy/queue/retry/diagnostics shaping 与 queue event payload shaping、DeepResearch citation renumber 与 report post-process gate，并建立不暴露 `bitfun-core` / `product-full` / concrete manager 的内部 SDK facade。SDK facade 已支持注入 fake runtime services、tool registry、harness registry、hook registry 和 agent registry。
 - `harness` 已建立 descriptor、route plan 和 legacy provider registry。
-- `product-domains` 已承接 MiniApp state/workflow planning、compile / permission adaptation、import lifecycle、AI / Agent permission、rate-limit、model/message/session/workspace/turn-text bridge rules、function-agent prompt/parser/response policy 和部分 Git snapshot/fallback 逻辑。
+- `product-domains` 已承接 MiniApp state/workflow planning、compile / permission adaptation、import lifecycle、AI / Agent permission、rate-limit、model/message/session/workspace/turn-text bridge rules、AI / Agent 请求计划、stream / runtime event payload、worker restart / draft key / workspace input 规则、function-agent prompt/parser/response policy 和部分 Git snapshot/fallback 逻辑。
 - `bitfun-core` 的 function-agent AI concrete acquisition 已从旧 `runtime_services` 路径收拢到明确的 core port adapter；Git / AI compatibility re-export 仍保留旧 public path。
 - Product Assembly 已承接 `DeliveryProfile`、当前交付形态入口矩阵、`CapabilitySet`、feature group matrix、profile-scoped capability plan、product-full provider plan、service availability report、profile-scoped harness registry 入口与 legacy-route 行为保护，以及 `ProductAssembler` 对 explicit profile input、runtime services、harness registry 和 service requirement 的验证；core 只保留兼容 re-export。ProductFull / Desktop / CLI / ACP 保留完整能力；Server / Remote / Web / MobileWeb 不再 materialize product-full capability packs、feature groups、runtime services、tool groups 或 harness routes。
 
@@ -36,11 +36,12 @@
 - focused tests 覆盖当前 delivery profile 能力裁剪、ProductAssembler 缺失 service 报告、无直接 core 入口的空 capability plan、SDK fake provider / services / tool / harness / hook / workspace-scoped agent registry 闭环，以及 runtime hook 顺序、timeout、错误策略和重复 id 拦截。
 - focused baseline 覆盖 tool manifest、GetToolSpec、execution admission、workspace search、remote workspace fallback、MCP config/catalog、prompt cache、custom subagent、thread-goal tools、AskUserQuestion、DeepReview policy、tool confirmation、session restore、MiniApp storage/builtin/import、function-agent Git、scheduled-job state 等路径。
 
-## 4. PR-D 完成后的后续专项
+## 4. Adapter 边界与后续专项
 
 - `bitfun-core` 仍承载 compatibility facade / `product-full` assembly 和少量迁移期 adapter；不应继续新增 owner 逻辑。
 - 产品入口的能力裁剪已由 Product Assembly profile plan 表达；后续新增入口必须先明确 `ProductCoreDependencyMode`、unsupported / unavailable 语义和兼容性测试。
 - H1 剩余 owner 决策已迁出：dialog start route / outcome lifecycle 继续由 `agent-runtime` 给出可测试决策，tool pipeline 的 Task batch 策略由 `tool-execution` 持有，prompt runtime / workspace / user-context 组合由 `agent-runtime` 持有，AI model selector / cache-key 解析由 `bitfun-ai-adapters` 持有。`bitfun-core` 仍只保留 coordinator 调用、config IO、credential overlay、prompt 事实收集和 prompt-cache persistence IO 等 concrete adapter。
 - DeepReview concrete Task launch 和 session metadata cache persistence 仍是 core adapter，因为它们依赖 coordinator、session manager、subagent runtime 和产品事件；provider-neutral policy / queue / retry / report shaping 与 queue event payload shaping 已在 `agent-runtime`，core 只负责事件发送。
-- MiniApp larger workflow 的 UI asset / desktop scheduler / AI factory 调用仍属于产品 host adapter；可复用规则已迁入 `product-domains`，不再在 desktop 命令内重复实现。
+- H2 已完成：MiniApp AI / Agent 请求计划、stream payload、runtime event payload、worker restart / draft key / workspace input 规则已迁入 `product-domains`，desktop 命令只保留 AI factory、scheduler、worker pool、目录创建和事件发送等 concrete host 调用。
+- MiniApp larger workflow 的 UI asset / desktop scheduler / AI factory 调用仍属于产品 host adapter；可复用规则不得回流到 desktop 命令内重复实现。
 - Agent Runtime SDK 已具备内部 facade、最小 fake-provider 闭环和 runtime services / tool / harness / hook / workspace-scoped agent registry 注入基线，但尚未冻结为可独立发布的外部 SDK 包、版本策略和兼容承诺。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -22,6 +22,7 @@
 - Runtime Services、Agent Runtime、Tool Contracts、Tool Execution、Harness、Product Domains、Services Core、Services Integrations 等 owner crate 已建立；Agent Runtime SDK 内部 facade 已能注入 runtime services、tool registry、harness registry、hook registry 和 workspace-scoped agent registry，部分 concrete 生命周期仍由 core concrete manager 或产品命令路径持有。
 - PR-B 已收口 Agent lifecycle 与 tool side-effect owner：turn skill/agent snapshot DTO / diff / render / store、file-read session state、session evidence ledger 与 compression-contract projection、dialog-turn cancellation token store、tool confirmation / user-question wait channel state 已迁入 `agent-runtime`；background exec output capture、tool cancellation token store 已迁入 `tool-execution`；core 保留 resolver、产品事件、具体工具执行、IO 编排和旧路径兼容 re-export。
 - PR-C 已收口 Harness / product workflow 的低风险 owner：MiniApp AI / Agent permission、rate-limit、model/message/session/workspace/turn-text 规则迁入 `product-domains`；DeepResearch 后处理 gate 迁入 `agent-runtime`，report IO 继续由 `services-integrations` 持有；function-agent AI concrete acquisition 收拢为 core port adapter，旧 `runtime_services` 路径删除。
+- H2 concrete adapter 收口已完成：MiniApp AI / Agent 请求计划、stream payload、runtime event payload、worker restart / draft key / workspace input 规则迁入 `product-domains`；DeepReview concrete Task launch、session metadata cache persistence 和 MiniApp concrete AI factory / scheduler / worker pool 调用已复核为 adapter 边界，不在下层 owner crate 中实现。
 
 ## 3. 已完成但仍需保持的边界
 
@@ -30,7 +31,7 @@
 - `agent-runtime` 已承接 provider-neutral scheduler decisions、dialog lifecycle port contracts、background delivery decisions、thread-goal facts、prompt-cache facts 与持久化写入决策、turn skill/agent snapshot state、file-read session state、session evidence ledger、dialog-turn cancellation token store、tool confirmation / user-question wait channel state、DeepReview provider-neutral policy / queue / retry / diagnostics shaping 与 queue event payload shaping。
 - `tool-contracts` / `tool-execution` 已承接 tool manifest / catalog / admission、batching plan、retry policy、state counting、cancellation-state/token-store policy、background exec output capture、shell helper 和部分 local / remote IO helper。
 - `services-integrations` 已承接 remote-connect primitives、workspace search concrete owner、remote SSH/SFTP/PTY owner、MiniApp host dispatch / storage / worker IO、DeepResearch report IO。
-- `product-domains` 已承接 MiniApp workflow planning、compile / permission path adaptation、function-agent prompt / parser / response policy 和部分 Git snapshot/fallback 逻辑。
+- `product-domains` 已承接 MiniApp workflow planning、compile / permission path adaptation、AI / Agent 请求计划、stream/event payload、worker restart / draft key / workspace input 规则、function-agent prompt / parser / response policy 和部分 Git snapshot/fallback 逻辑。
 - Product Assembly 已承接当前 delivery profile 的能力计划裁剪；下层 owner crate 不按产品形态分支。
 - boundary scripts 已覆盖核心 owner 防回流、six-layer path 解析、facade-only 文件和重点 feature gate。
 
@@ -38,7 +39,6 @@
 
 | 专项 | 目标 | 主要范围 | 准出标准 |
 |---|---|---|---|
-| H2 | DeepReview / MiniApp concrete adapter 收口 | DeepReview Task launch、session metadata cache persistence；MiniApp workflow 的 UI asset / desktop scheduler / AI factory 调用；DeepReview queue event 仍由 core coordinator 发送 | 不改变审查队列、报告持久化、MiniApp 执行和权限语义；provider-neutral 规则不得回流 core |
 | H4 | 外部 Agent Runtime SDK 发布准备 | 版本策略、公开 API 冻结、最小 feature 依赖证明、示例和兼容承诺 | SDK 不依赖 `bitfun-core`、app crate、Tauri、concrete service manager 或产品命令 registry；fake provider / service / tool / harness / hook / workspace-scoped agent registry smoke 保持通过 |
 
 ## 5. 固定执行流程

--- a/src/apps/desktop/src/api/miniapp_agent_api.rs
+++ b/src/apps/desktop/src/api/miniapp_agent_api.rs
@@ -24,11 +24,11 @@ use bitfun_core::agentic::coordination::{
 };
 use bitfun_core::agentic::core::{MessageContent, MessageRole, SessionConfig};
 use bitfun_core::miniapp::agent_bridge::{
-    agent_owner, agent_run_metadata, default_agent_run_id, extract_agent_turn_text,
-    requested_session_id, require_enabled_agent_permissions, resolve_agent_workspace_path,
-    session_name_or_default, validate_reused_session, MiniAppAgentRateLimiter,
-    MiniAppAgentRunRecord, MiniAppAgentRunRegistry, MiniAppAgentTurnMessage,
-    MiniAppAgentTurnMessageRole, MINIAPP_AGENT_KIND, UNKNOWN_AGENT_RUN_MESSAGE,
+    agent_run_id_from_request, build_agent_submission_plan, extract_agent_turn_text,
+    plan_agent_workspace, require_agent_prompt, require_enabled_agent_permissions,
+    validate_reused_session, MiniAppAgentRateLimiter, MiniAppAgentRunRecord,
+    MiniAppAgentRunRegistry, MiniAppAgentTurnMessage, MiniAppAgentTurnMessageRole,
+    MINIAPP_AGENT_KIND, UNKNOWN_AGENT_RUN_MESSAGE,
 };
 
 // ============== Run registry ==============
@@ -55,22 +55,6 @@ fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
-}
-
-/// Resolve a MiniApp-requested agent workspace inside the app's own appdata
-/// directory. The subdir must be a clean relative path (no `..`, no absolute
-/// or rooted components) so a MiniApp can never point the agent outside its
-/// own storage. The directory is created if missing.
-fn resolve_app_data_workspace(
-    state: &AppState,
-    app_id: &str,
-    subdir: &str,
-) -> Result<String, String> {
-    let app_data_dir = state.miniapp_manager.path_manager().miniapp_dir(app_id);
-    let workspace = resolve_agent_workspace_path(None, Some(subdir), &app_data_dir)?;
-    std::fs::create_dir_all(&workspace)
-        .map_err(|e| format!("Failed to create MiniApp agent workspace: {}", e))?;
-    Ok(workspace.to_string_lossy().to_string())
 }
 
 fn check_agent_rate_limit(app_id: &str, rate_limit_per_minute: u32) -> Result<(), String> {
@@ -178,50 +162,51 @@ pub async fn miniapp_agent_run(
     scheduler: State<'_, Arc<DialogScheduler>>,
     request: MiniAppAgentRunRequest,
 ) -> Result<MiniAppAgentRunResponse, String> {
-    if request.prompt.trim().is_empty() {
-        return Err("prompt is required".to_string());
-    }
+    require_agent_prompt(&request.prompt)?;
     let agent_perms = require_agent_permission(&state, &request.app_id).await?;
     check_agent_rate_limit(
         &request.app_id,
         agent_perms.rate_limit_per_minute.unwrap_or(0),
     )?;
 
-    let workspace_path = if let Some(subdir) = request
-        .app_data_workspace
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        resolve_app_data_workspace(&state, &request.app_id, subdir)?
-    } else {
-        request
-            .workspace_path
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .ok_or("workspacePath is required for MiniApp agent runs")?
-            .to_string()
-    };
-
-    let run_id = request
+    let app_data_dir = state
+        .miniapp_manager
+        .path_manager()
+        .miniapp_dir(&request.app_id);
+    let workspace_plan = plan_agent_workspace(
+        request.workspace_path.as_deref(),
+        request.app_data_workspace.as_deref(),
+        &app_data_dir,
+    )?;
+    if workspace_plan.create_if_missing {
+        std::fs::create_dir_all(&workspace_plan.path)
+            .map_err(|e| format!("Failed to create MiniApp agent workspace: {}", e))?;
+    }
+    let workspace_path = workspace_plan.workspace_path.clone();
+    let run_sequence = if request
         .run_id
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(str::to_string)
-        .unwrap_or_else(|| {
-            default_agent_run_id(
-                &request.app_id,
-                AGENT_RUN_COUNTER.fetch_add(1, Ordering::Relaxed),
-            )
-        });
-    let owner = agent_owner(&request.app_id, &run_id);
-    let session_name = session_name_or_default(request.session_name.as_deref());
+        .is_some()
+    {
+        0
+    } else {
+        AGENT_RUN_COUNTER.fetch_add(1, Ordering::Relaxed)
+    };
+    let run_id =
+        agent_run_id_from_request(&request.app_id, request.run_id.as_deref(), run_sequence);
+    let submission_plan = build_agent_submission_plan(
+        &request.app_id,
+        &run_id,
+        request.session_name.as_deref(),
+        request.session_id.as_deref(),
+        &workspace_path,
+        request.enable_tools,
+    );
 
-    let requested_session_id = requested_session_id(request.session_id.as_deref());
-
-    let session_id = if let Some(existing_session_id) = requested_session_id {
+    let session_id = if let Some(existing_session_id) = submission_plan.requested_session_id.clone()
+    {
         // Reuse a hidden session created by an earlier run of this MiniApp so
         // the new turn shares its context (skills, research, prior outputs).
         let session = coordinator
@@ -232,15 +217,14 @@ pub async fn miniapp_agent_run(
             session.created_by.as_deref(),
             session.config.workspace_path.as_deref(),
             &request.app_id,
-            &workspace_path,
+            &submission_plan.workspace_path,
         )?;
         existing_session_id
     } else {
         // One hidden session per task keeps MiniApp work isolated and out of
         // the visible session list. Follow-up turns may reuse it via sessionId.
-        let enable_tools = request.enable_tools.unwrap_or(true);
         let config = SessionConfig {
-            enable_tools,
+            enable_tools: submission_plan.enable_tools,
             safe_mode: true,
             auto_compact: true,
             enable_context_compression: true,
@@ -252,11 +236,11 @@ pub async fn miniapp_agent_run(
         let session = coordinator
             .create_hidden_subagent_session_with_workspace(
                 None,
-                session_name,
+                submission_plan.session_name.clone(),
                 MINIAPP_AGENT_KIND.to_string(),
                 config,
-                workspace_path.clone(),
-                Some(owner),
+                submission_plan.workspace_path.clone(),
+                Some(submission_plan.owner.clone()),
             )
             .await
             .map_err(|e| format!("Failed to create MiniApp agent session: {}", e))?;
@@ -265,19 +249,18 @@ pub async fn miniapp_agent_run(
 
     let policy = DialogSubmissionPolicy::for_source(DialogTriggerSource::DesktopApi)
         .with_skip_tool_confirmation(true);
-    let metadata = agent_run_metadata(&request.app_id, &run_id);
 
     let outcome = scheduler
         .submit(
             session_id.clone(),
             request.prompt.clone(),
             Some("MiniApp agent run".to_string()),
-            Some(run_id.clone()),
+            Some(submission_plan.run_id.clone()),
             MINIAPP_AGENT_KIND.to_string(),
-            Some(workspace_path),
+            Some(submission_plan.workspace_path.clone()),
             policy,
             None,
-            Some(metadata),
+            Some(submission_plan.metadata.clone()),
             None,
         )
         .await
@@ -291,13 +274,13 @@ pub async fn miniapp_agent_run(
     agent_run_registry().register(MiniAppAgentRunRecord {
         app_id: request.app_id.clone(),
         session_id: session_id.clone(),
-        turn_id: run_id.clone(),
+        turn_id: submission_plan.run_id.clone(),
     });
 
     Ok(MiniAppAgentRunResponse {
         session_id,
-        turn_id: run_id.clone(),
-        action_run_id: run_id,
+        turn_id: submission_plan.run_id.clone(),
+        action_run_id: submission_plan.run_id,
         status: status.to_string(),
     })
 }

--- a/src/apps/desktop/src/api/miniapp_api.rs
+++ b/src/apps/desktop/src/api/miniapp_api.rs
@@ -4,8 +4,16 @@ use crate::api::app_state::AppState;
 use crate::startup_trace::DesktopStartupTrace;
 use bitfun_core::infrastructure::events::{emit_global_event, BackendEvent};
 use bitfun_core::miniapp::ai_bridge::{
-    available_models_for_permissions, build_ai_message_plan, require_enabled_ai_permissions,
-    validate_model, MiniAppAiMessageRole, MiniAppAiModelDescriptor, MiniAppAiModelInfo,
+    ai_stream_chunk_payload, ai_stream_done_payload, ai_stream_error_payload,
+    available_models_for_permissions, plan_ai_chat_request, plan_ai_complete_request,
+    require_enabled_ai_permissions, require_non_empty_ai_messages, require_non_empty_stream_id,
+    MiniAppAiMessagePlan, MiniAppAiMessageRole, MiniAppAiModelDescriptor, MiniAppAiModelInfo,
+    MiniAppAiUsage,
+};
+use bitfun_core::miniapp::lifecycle::{
+    draft_worker_key, miniapp_runtime_event_payload, miniapp_worker_stopped_payload,
+    should_emit_worker_restarted, should_stop_worker_for_runtime_update, worker_restart_reason,
+    workspace_root_from_input,
 };
 use bitfun_core::miniapp::rate_limit::{MiniAppRateLimitState, MiniAppRateLimitSubject};
 use bitfun_core::miniapp::{
@@ -264,23 +272,6 @@ pub struct RecompileResult {
     pub warnings: Option<Vec<String>>,
 }
 
-fn miniapp_payload(app: &MiniApp, reason: &str) -> Value {
-    json!({
-        "id": app.id,
-        "name": app.name,
-        "version": app.version,
-        "updatedAt": app.updated_at,
-        "reason": reason,
-        "runtime": {
-            "sourceRevision": app.runtime.source_revision,
-            "depsRevision": app.runtime.deps_revision,
-            "depsDirty": app.runtime.deps_dirty,
-            "workerRestartRequired": app.runtime.worker_restart_required,
-            "uiRecompileRequired": app.runtime.ui_recompile_required,
-        }
-    })
-}
-
 async fn emit_miniapp_event(event_name: &str, payload: Value) {
     let _ = emit_global_event(BackendEvent::Custom {
         event_name: event_name.to_string(),
@@ -289,25 +280,14 @@ async fn emit_miniapp_event(event_name: &str, payload: Value) {
     .await;
 }
 
-fn workspace_root_from_input(workspace_path: Option<&str>) -> Option<PathBuf> {
-    workspace_path
-        .map(str::trim)
-        .filter(|path| !path.is_empty())
-        .map(PathBuf::from)
-}
-
-fn draft_worker_key(app_id: &str, draft_id: &str) -> String {
-    format!("{app_id}:draft:{draft_id}")
-}
-
 async fn maybe_stop_worker(state: &State<'_, AppState>, app: &MiniApp) {
-    if app.runtime.worker_restart_required {
+    if should_stop_worker_for_runtime_update(app) {
         if let Some(ref pool) = state.js_worker_pool {
             pool.stop(&app.id).await;
         }
         emit_miniapp_event(
             "miniapp-worker-stopped",
-            json!({ "id": app.id, "reason": "pending-restart" }),
+            miniapp_worker_stopped_payload(&app.id, "pending-restart"),
         )
         .await;
     }
@@ -351,7 +331,11 @@ async fn ensure_worker_dependencies(
         .mark_deps_installed(app_id)
         .await
         .map_err(|e| e.to_string())?;
-    emit_miniapp_event("miniapp-updated", miniapp_payload(app, "deps-installed")).await;
+    emit_miniapp_event(
+        "miniapp-updated",
+        miniapp_runtime_event_payload(app, "deps-installed"),
+    )
+    .await;
     Ok(true)
 }
 
@@ -420,7 +404,11 @@ pub async fn create_miniapp(
         )
         .await
         .map_err(|e| e.to_string())?;
-    emit_miniapp_event("miniapp-created", miniapp_payload(&app, "create")).await;
+    emit_miniapp_event(
+        "miniapp-created",
+        miniapp_runtime_event_payload(&app, "create"),
+    )
+    .await;
     Ok(app)
 }
 
@@ -448,7 +436,11 @@ pub async fn update_miniapp(
         .await
         .map_err(|e| e.to_string())?;
     maybe_stop_worker(&state, &app).await;
-    emit_miniapp_event("miniapp-updated", miniapp_payload(&app, "update")).await;
+    emit_miniapp_event(
+        "miniapp-updated",
+        miniapp_runtime_event_payload(&app, "update"),
+    )
+    .await;
     Ok(app)
 }
 
@@ -494,8 +486,16 @@ pub async fn rollback_miniapp(
         .await
         .map_err(|e| e.to_string())?;
     maybe_stop_worker(&state, &app).await;
-    emit_miniapp_event("miniapp-rolled-back", miniapp_payload(&app, "rollback")).await;
-    emit_miniapp_event("miniapp-updated", miniapp_payload(&app, "rollback")).await;
+    emit_miniapp_event(
+        "miniapp-rolled-back",
+        miniapp_runtime_event_payload(&app, "rollback"),
+    )
+    .await;
+    emit_miniapp_event(
+        "miniapp-updated",
+        miniapp_runtime_event_payload(&app, "rollback"),
+    )
+    .await;
     Ok(app)
 }
 
@@ -597,7 +597,11 @@ pub async fn miniapp_worker_call(
     let worker_revision = state
         .miniapp_manager
         .build_worker_revision(&app, &policy_json);
-    let should_emit_restart = !was_running || deps_installed || app.runtime.worker_restart_required;
+    let should_emit_restart = should_emit_worker_restarted(
+        was_running,
+        deps_installed,
+        app.runtime.worker_restart_required,
+    );
     let result = pool
         .call(
             &request.app_id,
@@ -617,14 +621,7 @@ pub async fn miniapp_worker_call(
             .map_err(|e| e.to_string())?;
         emit_miniapp_event(
             "miniapp-worker-restarted",
-            miniapp_payload(
-                &app,
-                if deps_installed {
-                    "deps-installed"
-                } else {
-                    "runtime-restart"
-                },
-            ),
+            miniapp_runtime_event_payload(&app, worker_restart_reason(deps_installed)),
         )
         .await;
     }
@@ -683,7 +680,7 @@ pub async fn miniapp_worker_stop(state: State<'_, AppState>, app_id: String) -> 
     }
     emit_miniapp_event(
         "miniapp-worker-stopped",
-        json!({ "id": app_id, "reason": "manual-stop" }),
+        miniapp_worker_stopped_payload(&app_id, "manual-stop"),
     )
     .await;
     Ok(())
@@ -729,7 +726,11 @@ pub async fn miniapp_install_deps(
             .mark_deps_installed(&app_id)
             .await
             .map_err(|e| e.to_string())?;
-        emit_miniapp_event("miniapp-updated", miniapp_payload(&app, "deps-installed")).await;
+        emit_miniapp_event(
+            "miniapp-updated",
+            miniapp_runtime_event_payload(&app, "deps-installed"),
+        )
+        .await;
     }
     Ok(install)
 }
@@ -746,8 +747,16 @@ pub async fn miniapp_recompile(
         .recompile(&request.app_id, theme_type, workspace_root.as_deref())
         .await
         .map_err(|e| e.to_string())?;
-    emit_miniapp_event("miniapp-recompiled", miniapp_payload(&app, "recompile")).await;
-    emit_miniapp_event("miniapp-updated", miniapp_payload(&app, "recompile")).await;
+    emit_miniapp_event(
+        "miniapp-recompiled",
+        miniapp_runtime_event_payload(&app, "recompile"),
+    )
+    .await;
+    emit_miniapp_event(
+        "miniapp-updated",
+        miniapp_runtime_event_payload(&app, "recompile"),
+    )
+    .await;
     Ok(RecompileResult {
         success: true,
         warnings: None,
@@ -778,7 +787,11 @@ pub async fn miniapp_import_from_path(
         .await
         .map_err(|e| e.to_string())?;
     maybe_stop_worker(&state, &app).await;
-    emit_miniapp_event("miniapp-created", miniapp_payload(&app, "import")).await;
+    emit_miniapp_event(
+        "miniapp-created",
+        miniapp_runtime_event_payload(&app, "import"),
+    )
+    .await;
     Ok(app)
 }
 
@@ -795,7 +808,11 @@ pub async fn miniapp_sync_from_fs(
         .await
         .map_err(|e| e.to_string())?;
     maybe_stop_worker(&state, &app).await;
-    emit_miniapp_event("miniapp-updated", miniapp_payload(&app, "sync-from-fs")).await;
+    emit_miniapp_event(
+        "miniapp-updated",
+        miniapp_runtime_event_payload(&app, "sync-from-fs"),
+    )
+    .await;
     Ok(app)
 }
 
@@ -911,10 +928,14 @@ pub async fn miniapp_apply_draft(
     }
     emit_miniapp_event(
         "miniapp-draft-applied",
-        miniapp_payload(&app, "draft-apply"),
+        miniapp_runtime_event_payload(&app, "draft-apply"),
     )
     .await;
-    emit_miniapp_event("miniapp-updated", miniapp_payload(&app, "draft-apply")).await;
+    emit_miniapp_event(
+        "miniapp-updated",
+        miniapp_runtime_event_payload(&app, "draft-apply"),
+    )
+    .await;
     Ok(app)
 }
 
@@ -1178,14 +1199,6 @@ pub struct MiniAppAiCompleteResponse {
     pub usage: Option<MiniAppAiUsage>,
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MiniAppAiUsage {
-    pub prompt_tokens: u32,
-    pub completion_tokens: u32,
-    pub total_tokens: u32,
-}
-
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MiniAppAiChatRequest {
@@ -1221,37 +1234,15 @@ pub struct MiniAppAiListModelsRequest {
     pub app_id: String,
 }
 
-// ---- Payload structs for Tauri events ----
-
-#[derive(Debug, Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
-struct AiStreamChunkPayload {
-    pub app_id: String,
-    pub stream_id: String,
-    #[serde(rename = "type")]
-    pub payload_type: String,
-    pub data: serde_json::Value,
-}
-
-// ---- Helper: build Message list from request ----
-
-fn build_messages_for_ai(
-    system_prompt: Option<&str>,
-    chat_messages: &[MiniAppAiChatMessage],
-) -> Vec<Message> {
-    build_ai_message_plan(
-        system_prompt,
-        chat_messages
-            .iter()
-            .map(|message| (message.role.as_str(), message.content.as_str())),
-    )
-    .into_iter()
-    .map(|message| match message.role {
-        MiniAppAiMessageRole::System => Message::system(message.content),
-        MiniAppAiMessageRole::Assistant => Message::assistant(message.content),
-        MiniAppAiMessageRole::User => Message::user(message.content),
-    })
-    .collect()
+fn build_messages_for_ai_plan(messages: Vec<MiniAppAiMessagePlan>) -> Vec<Message> {
+    messages
+        .into_iter()
+        .map(|message| match message.role {
+            MiniAppAiMessageRole::System => Message::system(message.content),
+            MiniAppAiMessageRole::Assistant => Message::assistant(message.content),
+            MiniAppAiMessageRole::User => Message::user(message.content),
+        })
+        .collect()
 }
 
 // ---- Commands ----
@@ -1281,21 +1272,20 @@ pub async fn miniapp_ai_complete(
             MiniAppRateLimitSubject::Ai,
         )?;
 
-    let model_ref = validate_model(request.model.as_deref(), ai_perms)?;
+    let ai_plan = plan_ai_complete_request(
+        ai_perms,
+        request.model.as_deref(),
+        request.system_prompt.as_deref(),
+        &request.prompt,
+    )?;
 
     let ai_client = state
         .ai_client_factory
-        .get_client_resolved(&model_ref)
+        .get_client_resolved(&ai_plan.model_ref)
         .await
         .map_err(|e| format!("Failed to get AI client: {}", e))?;
 
-    let messages = build_messages_for_ai(
-        request.system_prompt.as_deref(),
-        &[MiniAppAiChatMessage {
-            role: "user".to_string(),
-            content: request.prompt.clone(),
-        }],
-    );
+    let messages = build_messages_for_ai_plan(ai_plan.messages);
 
     let stream_response = ai_client
         .send_message_stream(messages, None, None)
@@ -1339,12 +1329,8 @@ pub async fn miniapp_ai_chat(
     state: State<'_, AppState>,
     request: MiniAppAiChatRequest,
 ) -> Result<MiniAppAiChatStartedResponse, String> {
-    if request.stream_id.trim().is_empty() {
-        return Err("streamId is required".to_string());
-    }
-    if request.messages.is_empty() {
-        return Err("messages must not be empty".to_string());
-    }
+    let stream_id = require_non_empty_stream_id(&request.stream_id)?;
+    require_non_empty_ai_messages(request.messages.len())?;
 
     let miniapp = state
         .miniapp_manager
@@ -1365,15 +1351,23 @@ pub async fn miniapp_ai_chat(
             MiniAppRateLimitSubject::Ai,
         )?;
 
-    let model_ref = validate_model(request.model.as_deref(), ai_perms)?;
+    let ai_plan = plan_ai_chat_request(
+        ai_perms,
+        request.model.as_deref(),
+        request.system_prompt.as_deref(),
+        request
+            .messages
+            .iter()
+            .map(|message| (message.role.as_str(), message.content.as_str())),
+    )?;
 
     let ai_client = state
         .ai_client_factory
-        .get_client_resolved(&model_ref)
+        .get_client_resolved(&ai_plan.model_ref)
         .await
         .map_err(|e| format!("Failed to get AI client: {}", e))?;
 
-    let messages = build_messages_for_ai(request.system_prompt.as_deref(), &request.messages);
+    let messages = build_messages_for_ai_plan(ai_plan.messages);
 
     let stream_response = ai_client
         .send_message_stream(messages, None, None)
@@ -1386,10 +1380,10 @@ pub async fn miniapp_ai_chat(
         let mut registry = ai_stream_registry()
             .lock()
             .unwrap_or_else(|p| p.into_inner());
-        registry.insert(request.stream_id.clone(), cancel_flag.clone());
+        registry.insert(stream_id.clone(), cancel_flag.clone());
     }
 
-    let stream_id = request.stream_id.clone();
+    let response_stream_id = stream_id.clone();
     let app_id = request.app_id.clone();
     let app_handle = app.clone();
 
@@ -1417,15 +1411,12 @@ pub async fn miniapp_ai_chat(
                         if let Some(ref t) = chunk.text {
                             full_text.push_str(t);
                         }
-                        let payload = AiStreamChunkPayload {
-                            app_id: app_id.clone(),
-                            stream_id: stream_id.clone(),
-                            payload_type: "chunk".to_string(),
-                            data: json!({
-                                "text": chunk.text,
-                                "reasoningContent": chunk.reasoning_content,
-                            }),
-                        };
+                        let payload = ai_stream_chunk_payload(
+                            &app_id,
+                            &stream_id,
+                            chunk.text,
+                            chunk.reasoning_content,
+                        );
                         if let Err(e) = app_handle.emit("miniapp://ai-stream", &payload) {
                             log::warn!("Failed to emit AI stream chunk: {}", e);
                         }
@@ -1446,12 +1437,7 @@ pub async fn miniapp_ai_chat(
                     }
                 }
                 Err(e) => {
-                    let payload = AiStreamChunkPayload {
-                        app_id: app_id.clone(),
-                        stream_id: stream_id.clone(),
-                        payload_type: "error".to_string(),
-                        data: json!({ "message": e.to_string() }),
-                    };
+                    let payload = ai_stream_error_payload(&app_id, &stream_id, e.to_string());
                     let _ = app_handle.emit("miniapp://ai-stream", &payload);
                     // Clean up registry
                     let mut registry = ai_stream_registry()
@@ -1464,22 +1450,7 @@ pub async fn miniapp_ai_chat(
         }
 
         // Emit done
-        let usage_val = last_usage.map(|u| {
-            json!({
-                "promptTokens": u.prompt_tokens,
-                "completionTokens": u.completion_tokens,
-                "totalTokens": u.total_tokens,
-            })
-        });
-        let done_payload = AiStreamChunkPayload {
-            app_id: app_id.clone(),
-            stream_id: stream_id.clone(),
-            payload_type: "done".to_string(),
-            data: json!({
-                "fullText": full_text,
-                "usage": usage_val,
-            }),
-        };
+        let done_payload = ai_stream_done_payload(&app_id, &stream_id, full_text, last_usage);
         let _ = app_handle.emit("miniapp://ai-stream", &done_payload);
 
         // Clean up registry
@@ -1490,7 +1461,7 @@ pub async fn miniapp_ai_chat(
     });
 
     Ok(MiniAppAiChatStartedResponse {
-        stream_id: request.stream_id,
+        stream_id: response_stream_id,
     })
 }
 

--- a/src/crates/assembly/core/src/miniapp/mod.rs
+++ b/src/crates/assembly/core/src/miniapp/mod.rs
@@ -16,7 +16,7 @@ pub use bitfun_product_domains::miniapp::customization::{
 };
 pub use bitfun_product_domains::miniapp::draft::{MiniAppDraft, MiniAppDraftManifest};
 pub use bitfun_product_domains::miniapp::{
-    agent_bridge, ai_bridge, bridge_builder, permission_policy, rate_limit, types,
+    agent_bridge, ai_bridge, bridge_builder, lifecycle, permission_policy, rate_limit, types,
 };
 
 pub use builtin::{seed_builtin_miniapps, BuiltinApp, BUILTIN_APPS};

--- a/src/crates/contracts/product-domains/src/miniapp/agent_bridge.rs
+++ b/src/crates/contracts/product-domains/src/miniapp/agent_bridge.rs
@@ -7,7 +7,7 @@
 use crate::miniapp::rate_limit::{MiniAppRateLimitState, MiniAppRateLimitSubject};
 use crate::miniapp::types::AgentPermissions;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -23,6 +23,25 @@ pub const WORKSPACE_MISMATCH_MESSAGE: &str =
 pub const APP_DATA_WORKSPACE_INVALID_MESSAGE: &str =
     "appDataWorkspace must be a clean relative path";
 pub const WORKSPACE_REQUIRED_MESSAGE: &str = "workspacePath is required for MiniApp agent runs";
+pub const AGENT_PROMPT_REQUIRED_MESSAGE: &str = "prompt is required";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MiniAppAgentWorkspacePlan {
+    pub path: PathBuf,
+    pub workspace_path: String,
+    pub create_if_missing: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MiniAppAgentSubmissionPlan {
+    pub run_id: String,
+    pub owner: String,
+    pub session_name: String,
+    pub requested_session_id: Option<String>,
+    pub workspace_path: String,
+    pub enable_tools: bool,
+    pub metadata: Value,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -142,6 +161,13 @@ pub fn require_enabled_agent_permissions(
     Ok(agent_permissions)
 }
 
+pub fn require_agent_prompt(prompt: &str) -> Result<(), String> {
+    if prompt.trim().is_empty() {
+        return Err(AGENT_PROMPT_REQUIRED_MESSAGE.to_string());
+    }
+    Ok(())
+}
+
 pub fn is_clean_relative_subdir(subdir: &str) -> bool {
     let relative = Path::new(subdir);
     !relative.as_os_str().is_empty()
@@ -175,8 +201,48 @@ pub fn resolve_agent_workspace_path(
         .ok_or_else(|| WORKSPACE_REQUIRED_MESSAGE.to_string())
 }
 
+pub fn plan_agent_workspace(
+    explicit_workspace_path: Option<&str>,
+    app_data_workspace: Option<&str>,
+    app_data_dir: &Path,
+) -> Result<MiniAppAgentWorkspacePlan, String> {
+    if let Some(subdir) = app_data_workspace
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let path = app_data_workspace_path(app_data_dir, subdir)?;
+        return Ok(MiniAppAgentWorkspacePlan {
+            workspace_path: path.to_string_lossy().to_string(),
+            path,
+            create_if_missing: true,
+        });
+    }
+
+    let workspace_path = explicit_workspace_path
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| WORKSPACE_REQUIRED_MESSAGE.to_string())?;
+    Ok(MiniAppAgentWorkspacePlan {
+        path: PathBuf::from(workspace_path),
+        workspace_path: workspace_path.to_string(),
+        create_if_missing: false,
+    })
+}
+
 pub fn default_agent_run_id(app_id: &str, sequence: u64) -> String {
     format!("miniapp-agent-{}-{}", app_id, sequence)
+}
+
+pub fn agent_run_id_from_request(
+    app_id: &str,
+    requested_run_id: Option<&str>,
+    sequence: u64,
+) -> String {
+    requested_run_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| default_agent_run_id(app_id, sequence))
 }
 
 pub fn agent_owner(app_id: &str, run_id: &str) -> String {
@@ -225,6 +291,25 @@ pub fn agent_run_metadata(app_id: &str, run_id: &str) -> serde_json::Value {
         "runId": run_id,
         "acp_transport": true,
     })
+}
+
+pub fn build_agent_submission_plan(
+    app_id: &str,
+    run_id: &str,
+    session_name: Option<&str>,
+    requested_session: Option<&str>,
+    workspace_path: &str,
+    enable_tools: Option<bool>,
+) -> MiniAppAgentSubmissionPlan {
+    MiniAppAgentSubmissionPlan {
+        run_id: run_id.to_string(),
+        owner: agent_owner(app_id, run_id),
+        session_name: session_name_or_default(session_name),
+        requested_session_id: requested_session_id(requested_session),
+        workspace_path: workspace_path.to_string(),
+        enable_tools: enable_tools.unwrap_or(true),
+        metadata: agent_run_metadata(app_id, run_id),
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -334,6 +419,76 @@ mod tests {
             )
             .unwrap_err(),
             WORKSPACE_MISMATCH_MESSAGE
+        );
+    }
+
+    #[test]
+    fn agent_run_plan_helpers_preserve_workspace_identity_and_metadata_contract() {
+        assert_eq!(
+            require_agent_prompt("   ").unwrap_err(),
+            AGENT_PROMPT_REQUIRED_MESSAGE
+        );
+        assert!(require_agent_prompt(" plan ").is_ok());
+
+        let explicit_workspace =
+            plan_agent_workspace(Some(" /workspace "), None, Path::new("/appdata"))
+                .expect("explicit workspace");
+        assert_eq!(explicit_workspace.path, PathBuf::from("/workspace"));
+        assert_eq!(explicit_workspace.workspace_path, "/workspace");
+        assert!(!explicit_workspace.create_if_missing);
+
+        let appdata_workspace =
+            plan_agent_workspace(None, Some("decks/deck-123"), Path::new("/appdata"))
+                .expect("appdata workspace");
+        assert_eq!(
+            appdata_workspace.path,
+            PathBuf::from("/appdata").join("decks").join("deck-123")
+        );
+        assert_eq!(
+            appdata_workspace.workspace_path,
+            appdata_workspace.path.to_string_lossy()
+        );
+        assert!(appdata_workspace.create_if_missing);
+
+        assert_eq!(
+            plan_agent_workspace(None, Some("../outside"), Path::new("/appdata")).unwrap_err(),
+            APP_DATA_WORKSPACE_INVALID_MESSAGE
+        );
+        assert_eq!(
+            plan_agent_workspace(None, None, Path::new("/appdata")).unwrap_err(),
+            WORKSPACE_REQUIRED_MESSAGE
+        );
+
+        assert_eq!(
+            agent_run_id_from_request("app-1", Some(" run-1 "), 9),
+            "run-1"
+        );
+        assert_eq!(
+            agent_run_id_from_request("app-1", Some("   "), 9),
+            "miniapp-agent-app-1-9"
+        );
+
+        let plan = build_agent_submission_plan(
+            "app-1",
+            "run-1",
+            Some(" Session "),
+            Some(" session-1 "),
+            "/workspace",
+            Some(false),
+        );
+        assert_eq!(plan.owner, "miniapp-agent:app-1:run-1");
+        assert_eq!(plan.session_name, "Session");
+        assert_eq!(plan.requested_session_id.as_deref(), Some("session-1"));
+        assert_eq!(plan.workspace_path, "/workspace");
+        assert!(!plan.enable_tools);
+        assert_eq!(
+            plan.metadata,
+            serde_json::json!({
+                "surface": MINIAPP_AGENT_SURFACE,
+                "appId": "app-1",
+                "runId": "run-1",
+                "acp_transport": true,
+            })
         );
     }
 

--- a/src/crates/contracts/product-domains/src/miniapp/ai_bridge.rs
+++ b/src/crates/contracts/product-domains/src/miniapp/ai_bridge.rs
@@ -6,7 +6,10 @@
 
 use crate::miniapp::types::AiPermissions;
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 pub const AI_ACCESS_DISABLED_MESSAGE: &str = "AI access is not enabled for this MiniApp";
+pub const AI_MESSAGES_REQUIRED_MESSAGE: &str = "messages must not be empty";
+pub const AI_STREAM_ID_REQUIRED_MESSAGE: &str = "streamId is required";
 
 pub fn require_enabled_ai_permissions(
     ai_permissions: Option<&AiPermissions>,
@@ -95,6 +98,30 @@ pub struct MiniAppAiMessagePlan {
     pub content: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MiniAppAiRequestPlan {
+    pub model_ref: String,
+    pub messages: Vec<MiniAppAiMessagePlan>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MiniAppAiUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MiniAppAiStreamPayload {
+    pub app_id: String,
+    pub stream_id: String,
+    #[serde(rename = "type")]
+    pub payload_type: String,
+    pub data: Value,
+}
+
 pub fn build_ai_message_plan<'a, I>(
     system_prompt: Option<&str>,
     chat_messages: I,
@@ -121,6 +148,98 @@ where
         });
     }
     messages
+}
+
+pub fn plan_ai_complete_request(
+    ai_permissions: &AiPermissions,
+    model: Option<&str>,
+    system_prompt: Option<&str>,
+    prompt: &str,
+) -> Result<MiniAppAiRequestPlan, String> {
+    Ok(MiniAppAiRequestPlan {
+        model_ref: validate_model(model, ai_permissions)?,
+        messages: build_ai_message_plan(system_prompt, [("user", prompt)]),
+    })
+}
+
+pub fn plan_ai_chat_request<'a, I>(
+    ai_permissions: &AiPermissions,
+    model: Option<&str>,
+    system_prompt: Option<&str>,
+    chat_messages: I,
+) -> Result<MiniAppAiRequestPlan, String>
+where
+    I: IntoIterator<Item = (&'a str, &'a str)>,
+{
+    let chat_messages: Vec<(&'a str, &'a str)> = chat_messages.into_iter().collect();
+    if chat_messages.is_empty() {
+        return Err(AI_MESSAGES_REQUIRED_MESSAGE.to_string());
+    }
+    Ok(MiniAppAiRequestPlan {
+        model_ref: validate_model(model, ai_permissions)?,
+        messages: build_ai_message_plan(system_prompt, chat_messages),
+    })
+}
+
+pub fn require_non_empty_ai_messages(message_count: usize) -> Result<(), String> {
+    if message_count == 0 {
+        return Err(AI_MESSAGES_REQUIRED_MESSAGE.to_string());
+    }
+    Ok(())
+}
+
+pub fn require_non_empty_stream_id(stream_id: &str) -> Result<String, String> {
+    if stream_id.trim().is_empty() {
+        return Err(AI_STREAM_ID_REQUIRED_MESSAGE.to_string());
+    }
+    Ok(stream_id.to_string())
+}
+
+pub fn ai_stream_chunk_payload(
+    app_id: &str,
+    stream_id: &str,
+    text: Option<String>,
+    reasoning_content: Option<String>,
+) -> MiniAppAiStreamPayload {
+    MiniAppAiStreamPayload {
+        app_id: app_id.to_string(),
+        stream_id: stream_id.to_string(),
+        payload_type: "chunk".to_string(),
+        data: json!({
+            "text": text,
+            "reasoningContent": reasoning_content,
+        }),
+    }
+}
+
+pub fn ai_stream_error_payload(
+    app_id: &str,
+    stream_id: &str,
+    message: impl Into<String>,
+) -> MiniAppAiStreamPayload {
+    MiniAppAiStreamPayload {
+        app_id: app_id.to_string(),
+        stream_id: stream_id.to_string(),
+        payload_type: "error".to_string(),
+        data: json!({ "message": message.into() }),
+    }
+}
+
+pub fn ai_stream_done_payload(
+    app_id: &str,
+    stream_id: &str,
+    full_text: impl Into<String>,
+    usage: Option<MiniAppAiUsage>,
+) -> MiniAppAiStreamPayload {
+    MiniAppAiStreamPayload {
+        app_id: app_id.to_string(),
+        stream_id: stream_id.to_string(),
+        payload_type: "done".to_string(),
+        data: json!({
+            "fullText": full_text.into(),
+            "usage": usage,
+        }),
+    }
 }
 
 #[cfg(test)]
@@ -191,5 +310,106 @@ mod tests {
         assert_eq!(messages[0].role, MiniAppAiMessageRole::System);
         assert_eq!(messages[1].role, MiniAppAiMessageRole::Assistant);
         assert_eq!(messages[2].role, MiniAppAiMessageRole::User);
+    }
+
+    #[test]
+    fn ai_request_plans_preserve_model_and_message_contract() {
+        let perms = ai_permissions(Some(vec!["primary".to_string(), "m-fast".to_string()]));
+
+        let complete =
+            plan_ai_complete_request(&perms, None, Some("system"), "hello").expect("complete plan");
+        assert_eq!(complete.model_ref, "primary");
+        assert_eq!(complete.messages.len(), 2);
+        assert_eq!(complete.messages[0].role, MiniAppAiMessageRole::System);
+        assert_eq!(complete.messages[1].role, MiniAppAiMessageRole::User);
+        assert_eq!(complete.messages[1].content, "hello");
+
+        let chat = plan_ai_chat_request(
+            &perms,
+            Some("m-fast"),
+            Some("system"),
+            [("assistant", "prior"), ("tool", "fallback user")],
+        )
+        .expect("chat plan");
+        assert_eq!(chat.model_ref, "m-fast");
+        assert_eq!(chat.messages[1].role, MiniAppAiMessageRole::Assistant);
+        assert_eq!(chat.messages[2].role, MiniAppAiMessageRole::User);
+
+        assert_eq!(
+            plan_ai_chat_request(&perms, None, None, Vec::<(&str, &str)>::new()).unwrap_err(),
+            AI_MESSAGES_REQUIRED_MESSAGE
+        );
+        assert_eq!(
+            require_non_empty_ai_messages(0).unwrap_err(),
+            AI_MESSAGES_REQUIRED_MESSAGE
+        );
+        assert!(require_non_empty_ai_messages(1).is_ok());
+        assert_eq!(
+            require_non_empty_stream_id("   ").unwrap_err(),
+            AI_STREAM_ID_REQUIRED_MESSAGE
+        );
+        assert_eq!(
+            require_non_empty_stream_id(" stream-1 ").unwrap(),
+            " stream-1 "
+        );
+    }
+
+    #[test]
+    fn ai_stream_payload_helpers_preserve_wire_shape() {
+        assert_eq!(
+            serde_json::to_value(ai_stream_chunk_payload(
+                "app-1",
+                "stream-1",
+                Some("text".to_string()),
+                Some("reasoning".to_string()),
+            ))
+            .unwrap(),
+            serde_json::json!({
+                "appId": "app-1",
+                "streamId": "stream-1",
+                "type": "chunk",
+                "data": {
+                    "text": "text",
+                    "reasoningContent": "reasoning"
+                }
+            })
+        );
+
+        assert_eq!(
+            serde_json::to_value(ai_stream_done_payload(
+                "app-1",
+                "stream-1",
+                "final",
+                Some(MiniAppAiUsage {
+                    prompt_tokens: 1,
+                    completion_tokens: 2,
+                    total_tokens: 3,
+                }),
+            ))
+            .unwrap(),
+            serde_json::json!({
+                "appId": "app-1",
+                "streamId": "stream-1",
+                "type": "done",
+                "data": {
+                    "fullText": "final",
+                    "usage": {
+                        "promptTokens": 1,
+                        "completionTokens": 2,
+                        "totalTokens": 3
+                    }
+                }
+            })
+        );
+
+        assert_eq!(
+            serde_json::to_value(ai_stream_error_payload("app-1", "stream-1", "failed")).unwrap(),
+            serde_json::json!({
+                "appId": "app-1",
+                "streamId": "stream-1",
+                "type": "error",
+                "data": { "message": "failed" }
+            })
+        );
     }
 }

--- a/src/crates/contracts/product-domains/src/miniapp/lifecycle.rs
+++ b/src/crates/contracts/product-domains/src/miniapp/lifecycle.rs
@@ -1,10 +1,11 @@
 //! MiniApp lifecycle revision helpers.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::miniapp::types::{
     MiniApp, MiniAppAiContext, MiniAppMeta, MiniAppPermissions, MiniAppRuntimeState, MiniAppSource,
 };
+use serde_json::{json, Value};
 
 #[derive(Debug, Clone)]
 pub struct MiniAppCreateInput {
@@ -329,6 +330,58 @@ pub fn workspace_dir_string(workspace_root: Option<&Path>) -> String {
         .unwrap_or_default()
 }
 
+pub fn workspace_root_from_input(workspace_path: Option<&str>) -> Option<PathBuf> {
+    workspace_path
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+}
+
+pub fn draft_worker_key(app_id: &str, draft_id: &str) -> String {
+    format!("{app_id}:draft:{draft_id}")
+}
+
+pub fn should_stop_worker_for_runtime_update(app: &MiniApp) -> bool {
+    app.runtime.worker_restart_required
+}
+
+pub fn should_emit_worker_restarted(
+    was_running: bool,
+    deps_installed: bool,
+    worker_restart_required: bool,
+) -> bool {
+    !was_running || deps_installed || worker_restart_required
+}
+
+pub fn worker_restart_reason(deps_installed: bool) -> &'static str {
+    if deps_installed {
+        "deps-installed"
+    } else {
+        "runtime-restart"
+    }
+}
+
+pub fn miniapp_runtime_event_payload(app: &MiniApp, reason: &str) -> Value {
+    json!({
+        "id": app.id,
+        "name": app.name,
+        "version": app.version,
+        "updatedAt": app.updated_at,
+        "reason": reason,
+        "runtime": {
+            "sourceRevision": app.runtime.source_revision,
+            "depsRevision": app.runtime.deps_revision,
+            "depsDirty": app.runtime.deps_dirty,
+            "workerRestartRequired": app.runtime.worker_restart_required,
+            "uiRecompileRequired": app.runtime.ui_recompile_required,
+        }
+    })
+}
+
+pub fn miniapp_worker_stopped_payload(app_id: &str, reason: &str) -> Value {
+    json!({ "id": app_id, "reason": reason })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -359,5 +412,61 @@ mod tests {
         assert_eq!(meta.name, "Imported");
         assert_eq!(meta.description, "Imported app");
         assert_eq!(meta.version, 7);
+    }
+
+    #[test]
+    fn host_event_helpers_preserve_existing_worker_and_payload_contract() {
+        let app = build_created_app(
+            "app-1".to_string(),
+            MiniAppCreateInput {
+                name: "App".to_string(),
+                description: "Desc".to_string(),
+                icon: "box".to_string(),
+                category: "utility".to_string(),
+                tags: vec![],
+                source: MiniAppSource::default(),
+                permissions: MiniAppPermissions::default(),
+                ai_context: None,
+            },
+            "<html></html>".to_string(),
+            123,
+        );
+
+        assert_eq!(
+            miniapp_runtime_event_payload(&app, "create"),
+            serde_json::json!({
+                "id": "app-1",
+                "name": "App",
+                "version": 1,
+                "updatedAt": 123,
+                "reason": "create",
+                "runtime": {
+                    "sourceRevision": "src:1:123",
+                    "depsRevision": "",
+                    "depsDirty": false,
+                    "workerRestartRequired": true,
+                    "uiRecompileRequired": false
+                }
+            })
+        );
+
+        assert_eq!(
+            miniapp_worker_stopped_payload("app-1", "pending-restart"),
+            serde_json::json!({ "id": "app-1", "reason": "pending-restart" })
+        );
+        assert_eq!(draft_worker_key("app-1", "draft-1"), "app-1:draft:draft-1");
+        assert_eq!(
+            workspace_root_from_input(Some(" /workspace ")),
+            Some(std::path::PathBuf::from("/workspace"))
+        );
+        assert_eq!(workspace_root_from_input(Some("   ")), None);
+        assert_eq!(workspace_root_from_input(None), None);
+        assert!(should_stop_worker_for_runtime_update(&app));
+        assert!(!should_emit_worker_restarted(true, false, false));
+        assert!(should_emit_worker_restarted(false, false, false));
+        assert!(should_emit_worker_restarted(true, true, false));
+        assert!(should_emit_worker_restarted(true, false, true));
+        assert_eq!(worker_restart_reason(true), "deps-installed");
+        assert_eq!(worker_restart_reason(false), "runtime-restart");
     }
 }


### PR DESCRIPTION
## Summary

- Move MiniApp AI / Agent request planning, AI stream payload shaping, runtime event payloads, worker restart decisions, draft worker keys, and workspace input normalization into `bitfun-product-domains`.
- Keep concrete host behavior in desktop/core: AI factory resolution, scheduler/coordinator calls, worker pool actions, directory creation, event emission, and DeepReview concrete Task/session metadata IO remain adapter-owned.
- Update the core decomposition plan and completed archive so H2 is recorded as complete and the remaining work focuses on external Agent Runtime SDK readiness.

## Risk and compatibility

- No intended functional behavior change: request validation order, stream id identity, event wire shape, MiniApp worker restart reasons, and Agent session/run metadata are covered by focused tests.
- No Cargo manifest changes and no new third-party dependencies.
- Contracts remain free of Tauri, concrete AI factory, scheduler, worker pool, and product command dependencies.

## Validation

- `cargo test -p bitfun-product-domains miniapp --features miniapp`
- `cargo check -p bitfun-desktop`
- `cargo check -p bitfun-core --no-default-features`
- `cargo check -p bitfun-core --features product-full`
- `cargo test -p bitfun-core miniapp --features product-full`
- `cargo test -p bitfun-core deep_review --features product-full`
- `node --test scripts/check-core-boundaries.test.mjs`
- `node scripts/check-core-boundaries.mjs`
- `pnpm run check:repo-hygiene`
- `git diff --check`