### PR TITLE
refactor(runtime): prepare Agent Runtime SDK boundary

### DIFF
--- a/docs/architecture/agent-runtime-services-design.md
+++ b/docs/architecture/agent-runtime-services-design.md
@@ -36,6 +36,11 @@ Agent Runtime SDK 的发布边界以调用方能力为准，而不是以物理 c
 - SDK minimal feature 不牵引 Desktop、Tauri、Git provider、MCP client、AI HTTP client、remote SSH 或产品 UI。
 - 完整产品能力只能通过 Product Assembly 或兼容 `bitfun-core/product-full` 组装，不反向污染 SDK API。
 
+SDK 公共 API 以 `AGENT_RUNTIME_SDK_API_VERSION` 标记兼容边界。当前 API version 为 v1 preview：
+小版本更新可以增加可选 builder hook、DTO 字段或 registry 查询能力，但不得改变既有端口语义、
+错误分类、session / turn 标识含义或默认 feature 依赖。任何需要调用方改写现有嵌入代码的变更，
+必须提升 API version 并提供兼容迁移路径。
+
 只要外部调用方仍必须导入 `bitfun-core`、启用 `product-full`、持有 concrete service manager、读取产品命令
 registry 或依赖全局 mutable state，SDK 发布边界就不成立。
 
@@ -285,22 +290,33 @@ pub struct AgentRuntimeBuilder {
 
 pub struct AgentRunRequest {
     pub session: SessionSelector,
-    pub input: AgentInput,
-    pub cancellation: CancellationToken,
+    pub message: String,
+    pub turn_id: Option<String>,
+    pub source: Option<AgentSubmissionSource>,
+    pub attachments: Vec<AgentInputAttachment>,
+    pub metadata: serde_json::Map<String, serde_json::Value>,
 }
 
 pub struct AgentRunHandle {
-    pub session_id: SessionId,
-    pub turn_id: TurnId,
-    pub events: AgentEventStream,
+    pub session_id: String,
+    pub turn_id: String,
+    pub agent_type: Option<String>,
+    pub accepted: bool,
+    pub events: Option<AgentEventStream>,
 }
 
 impl AgentRuntimeBuilder {
+    pub fn with_submission_port(self, port: Arc<dyn AgentSubmissionPort>) -> Self;
+    pub fn with_session_management_port(self, port: Arc<dyn AgentSessionManagementPort>) -> Self;
+    pub fn with_dialog_turn_port(self, port: Arc<dyn AgentDialogTurnPort>) -> Self;
+    pub fn with_lifecycle_delivery_port(self, port: Arc<dyn AgentLifecycleDeliveryPort>) -> Self;
+    pub fn with_cancellation_port(self, port: Arc<dyn AgentTurnCancellationPort>) -> Self;
     pub fn with_services(self, services: RuntimeServices) -> Self;
-    pub fn with_tools(self, tools: Arc<ToolRuntime>) -> Self;
-    pub fn with_harnesses(self, harnesses: Arc<HarnessRegistry>) -> Self;
-    pub fn with_agents(self, agents: Arc<dyn AgentDefinitionRegistry>) -> Self;
-    pub fn with_hooks(self, hooks: RuntimeHookRegistry) -> Self;
+    pub fn with_event_stream(self, events: AgentEventStream) -> Self;
+    pub fn with_tool_registry(self, registry: Arc<dyn RuntimeToolRegistry>) -> Self;
+    pub fn with_harness_registry(self, registry: Arc<HarnessRegistry>) -> Self;
+    pub fn with_hook_registry(self, hooks: RuntimeHookRegistry) -> Self;
+    pub fn with_agent_registry(self, agents: Arc<dyn RuntimeAgentRegistry>) -> Self;
     pub fn build(self) -> Result<AgentRuntime, RuntimeBuildError>;
 }
 
@@ -311,6 +327,9 @@ impl AgentRuntime {
 
 该 facade 是目标 API 形态。它必须只接收已组装的 typed parts，不负责创建
 filesystem、terminal、MCP、AI client、Remote provider 或产品命令。
+当前 v1 preview API 以 message / attachment / metadata 作为最小输入形态；若后续需要把
+model-round cancellation token、structured AgentInput 或更复杂的 event cursor 纳入公开 SDK，
+必须提升 SDK API version 并保留旧路径兼容。
 
 旧路径兼容约束：
 

--- a/docs/plans/core-decomposition-completed.md
+++ b/docs/plans/core-decomposition-completed.md
@@ -35,6 +35,7 @@
 - boundary check 覆盖 owner crate 禁止依赖、旧路径 facade-only、feature gate、six-layer path 解析、Product Assembly 收口和高风险 owner 回流。
 - focused tests 覆盖当前 delivery profile 能力裁剪、ProductAssembler 缺失 service 报告、无直接 core 入口的空 capability plan、SDK fake provider / services / tool / harness / hook / workspace-scoped agent registry 闭环，以及 runtime hook 顺序、timeout、错误策略和重复 id 拦截。
 - focused baseline 覆盖 tool manifest、GetToolSpec、execution admission、workspace search、remote workspace fallback、MCP config/catalog、prompt cache、custom subagent、thread-goal tools、AskUserQuestion、DeepReview policy、tool confirmation、session restore、MiniApp storage/builtin/import、function-agent Git、scheduled-job state 等路径。
+- H4 已完成 Agent Runtime SDK 发布准备的 workspace 内收口：`sdk` facade 暴露 v1 preview 兼容元数据、空默认 feature、稳定注入 registry/service 类型、最小外部 embedder 示例，以及 boundary required rules / self-test 保护。
 
 ## 4. Adapter 边界与后续专项
 
@@ -44,4 +45,4 @@
 - DeepReview concrete Task launch 和 session metadata cache persistence 仍是 core adapter，因为它们依赖 coordinator、session manager、subagent runtime 和产品事件；provider-neutral policy / queue / retry / report shaping 与 queue event payload shaping 已在 `agent-runtime`，core 只负责事件发送。
 - H2 已完成：MiniApp AI / Agent 请求计划、stream payload、runtime event payload、worker restart / draft key / workspace input 规则已迁入 `product-domains`，desktop 命令只保留 AI factory、scheduler、worker pool、目录创建和事件发送等 concrete host 调用。
 - MiniApp larger workflow 的 UI asset / desktop scheduler / AI factory 调用仍属于产品 host adapter；可复用规则不得回流到 desktop 命令内重复实现。
-- Agent Runtime SDK 已具备内部 facade、最小 fake-provider 闭环和 runtime services / tool / harness / hook / workspace-scoped agent registry 注入基线，但尚未冻结为可独立发布的外部 SDK 包、版本策略和兼容承诺。
+- Agent Runtime SDK 已具备 v1 preview workspace 内公开边界、最小 fake-provider 闭环、runtime services / tool / harness / hook / workspace-scoped agent registry 注入基线、最小 feature 证明和外部 embedder 示例。若后续要独立发布为外部包，需要单独评审发布流程、crate packaging、semver 承诺和长期兼容策略。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -37,9 +37,15 @@
 
 ## 4. 后续大块专项
 
-| 专项 | 目标 | 主要范围 | 准出标准 |
-|---|---|---|---|
-| H4 | 外部 Agent Runtime SDK 发布准备 | 版本策略、公开 API 冻结、最小 feature 依赖证明、示例和兼容承诺 | SDK 不依赖 `bitfun-core`、app crate、Tauri、concrete service manager 或产品命令 registry；fake provider / service / tool / harness / hook / workspace-scoped agent registry smoke 保持通过 |
+H4 收口后，设计文档中已批准的大块 owner 迁移专项暂不再保留新的待执行项。
+后续只在出现以下情况时重新开专项：
+
+- Agent Runtime SDK 需要从 workspace 内 preview facade 变成独立发布包。
+- 新产品形态需要改变 Product Assembly 的 capability / provider 选择方式。
+- 下层 crate 需要承接新的 concrete runtime owner，并且能同步删除或显著简化旧 core 主体路径。
+- 主干新增 CLI、tool、terminal、session、scheduler、remote、MiniApp、ACP 或 product interface 逻辑导致当前分层边界失效。
+
+任何新增专项仍必须满足：先补等价保护，再迁移实现主体，并证明不影响不同操作系统和交付形态的功能范围。
 
 ## 5. 固定执行流程
 

--- a/scripts/core-boundaries/rules/source/forbidden-rules.mjs
+++ b/scripts/core-boundaries/rules/source/forbidden-rules.mjs
@@ -2,6 +2,21 @@
 
 export const forbiddenContentRules = [
   {
+    path: 'src/crates/execution/agent-runtime/tests/sdk_smoke.rs',
+    patterns: [
+      {
+        regex: /\bbitfun_runtime_services::test_support\b/,
+        message:
+          'agent-runtime SDK smoke tests must prove the public sdk facade is enough; do not rely on runtime-services test_support',
+      },
+      {
+        regex: /\bFakeRuntimeServicesProvider\b/,
+        message:
+          'agent-runtime SDK smoke tests must build fake services through sdk-reexported ports and RuntimeServicesBuilder',
+      },
+    ],
+  },
+  {
     path: 'src/crates/contracts/core-types/src/ai.rs',
     patterns: [
       {

--- a/scripts/core-boundaries/rules/source/required-rules.mjs
+++ b/scripts/core-boundaries/rules/source/required-rules.mjs
@@ -258,12 +258,117 @@ export const requiredContentRules = [
       'agent-runtime SDK smoke tests must prove the facade works with injected fake provider, services, tools, harnesses, and hooks without core',
     patterns: [
       {
+        regex: /\bsdk_facade_exposes_versioned_preview_compatibility_contract\b/,
+        message: 'missing SDK API version and compatibility smoke',
+      },
+      {
         regex: /\bsdk_facade_runs_with_fake_provider_and_local_event_stream\b/,
         message: 'missing SDK fake-provider event-stream smoke',
       },
       {
         regex: /\bsdk_facade_accepts_fake_services_tools_harnesses_and_hooks_without_core\b/,
         message: 'missing SDK services/tools/harnesses/hooks injection smoke',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/execution/agent-runtime/src/sdk.rs',
+    reason:
+      'agent-runtime SDK public facade must expose versioned compatibility metadata and only stable injection contracts',
+    patterns: [
+      {
+        regex: /\bpub const AGENT_RUNTIME_SDK_API_VERSION\b/,
+        message: 'missing SDK API version constant',
+      },
+      {
+        regex: /\bpub enum AgentRuntimeSdkStability\b/,
+        message: 'missing SDK stability contract',
+      },
+      {
+        regex: /#\[non_exhaustive\]\s+pub enum AgentRuntimeSdkStability/s,
+        message: 'SDK stability contract must remain externally extensible',
+      },
+      {
+        regex: /\bpub struct AgentRuntimeSdkCompatibility\b/,
+        message: 'missing SDK compatibility contract',
+      },
+      {
+        regex: /#\[non_exhaustive\]\s+pub struct AgentRuntimeSdkCompatibility/s,
+        message: 'SDK compatibility contract must remain externally extensible',
+      },
+      {
+        regex: /\bimpl AgentRuntimeSdkCompatibility\b/,
+        message: 'missing current SDK compatibility entrypoint',
+      },
+      {
+        regex: /\bpub use bitfun_agent_tools::\{/,
+        message: 'missing SDK tool registry re-exports',
+      },
+      {
+        regex: /\bpub use bitfun_harness::\{/,
+        message: 'missing SDK harness registry re-exports',
+      },
+      {
+        regex: /\bpub use bitfun_runtime_services::\{/,
+        message: 'missing SDK runtime-services re-exports',
+      },
+      {
+        regex: /\bPortResult\b/,
+        message: 'missing SDK port result re-export',
+      },
+      {
+        regex: /\bRuntimeServicePort\b/,
+        message: 'missing SDK runtime service port re-export',
+      },
+      {
+        regex: /\bFileSystemPort\b/,
+        message: 'missing SDK filesystem service port re-export',
+      },
+      {
+        regex: /\bRemoteWorkspacePort\b/,
+        message: 'missing SDK remote workspace service port re-export',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/execution/agent-runtime/Cargo.toml',
+    reason:
+      'agent-runtime SDK package must keep an explicit empty default feature set for minimal embedders',
+    patterns: [
+      {
+        regex: /\[features\]/,
+        message: 'missing explicit SDK feature section',
+      },
+      {
+        regex: /default = \[\]/,
+        message: 'agent-runtime default feature set must stay empty',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/execution/agent-runtime/examples/sdk_minimal.rs',
+    reason:
+      'agent-runtime SDK must keep a minimal external embedder example that uses the sdk facade without core',
+    patterns: [
+      {
+        regex: /\buse bitfun_agent_runtime::sdk::\{/,
+        message: 'SDK example must import through the public sdk facade',
+      },
+      {
+        regex: /\bAgentRuntimeSdkCompatibility::current\b/,
+        message: 'SDK example must expose the compatibility contract',
+      },
+      {
+        regex: /\bimpl AgentSubmissionPort for ExampleAgentProvider\b/,
+        message: 'SDK example must show caller-provided submission port injection',
+      },
+      {
+        regex: /\bAgentRuntimeBuilder::new\(\)/,
+        message: 'SDK example must build through AgentRuntimeBuilder',
+      },
+      {
+        regex: /\bAgentRunRequest::new\b/,
+        message: 'SDK example must run through AgentRunRequest',
       },
     ],
   },

--- a/scripts/core-boundaries/self-test.mjs
+++ b/scripts/core-boundaries/self-test.mjs
@@ -1052,6 +1052,45 @@ export function runManifestParserSelfTest({
       ],
     },
     {
+      path: 'src/crates/execution/agent-runtime/src/sdk.rs',
+      contracts: [
+        'AGENT_RUNTIME_SDK_API_VERSION',
+        '#[non_exhaustive]',
+        'AgentRuntimeSdkStability',
+        'AgentRuntimeSdkCompatibility',
+        'impl AgentRuntimeSdkCompatibility',
+        'bitfun_agent_tools',
+        'bitfun_harness',
+        'bitfun_runtime_services',
+        'PortResult',
+        'RuntimeServicePort',
+        'FileSystemPort',
+        'RemoteWorkspacePort',
+      ],
+    },
+    {
+      path: 'src/crates/execution/agent-runtime/Cargo.toml',
+      contracts: ['[features]', 'default = []'],
+    },
+    {
+      path: 'src/crates/execution/agent-runtime/tests/sdk_smoke.rs',
+      contracts: [
+        'sdk_facade_exposes_versioned_preview_compatibility_contract',
+        'sdk_facade_runs_with_fake_provider_and_local_event_stream',
+        'sdk_facade_accepts_fake_services_tools_harnesses_and_hooks_without_core',
+      ],
+    },
+    {
+      path: 'src/crates/execution/agent-runtime/examples/sdk_minimal.rs',
+      contracts: [
+        'bitfun_agent_runtime::sdk',
+        'AgentRuntimeSdkCompatibility::current',
+        'impl AgentSubmissionPort for ExampleAgentProvider',
+        'AgentRuntimeBuilder::new',
+        'AgentRunRequest::new',
+      ],
+    },
+    {
       path: 'src/crates/execution/agent-runtime/src/agents.rs',
       contracts: [
         'SubagentQueryContext',
@@ -3076,6 +3115,20 @@ export function runManifestParserSelfTest({
   );
   if (!sessionControlRuleText.includes('create_session_with_workspace_and_creator')) {
     throw new Error('SessionControl old create-path boundary rule must cover legacy create path');
+  }
+
+  const sdkSmokeRuleText = forbiddenRuleTextForPath(
+    'src/crates/execution/agent-runtime/tests/sdk_smoke.rs',
+  );
+  for (const forbiddenSdkSmokeImport of [
+    'bitfun_runtime_services::test_support',
+    'FakeRuntimeServicesProvider',
+  ]) {
+    if (!sdkSmokeRuleText.includes(forbiddenSdkSmokeImport)) {
+      throw new Error(
+        `SDK smoke boundary rule must forbid ${forbiddenSdkSmokeImport}`,
+      );
+    }
   }
 
   const remoteWorkspaceRule = forbiddenContentRules.find(

--- a/src/crates/execution/agent-runtime/AGENTS.md
+++ b/src/crates/execution/agent-runtime/AGENTS.md
@@ -10,8 +10,9 @@ port-backed `sdk` / `AgentRuntime` facade that can be built and tested without
 
 - Do not depend on `bitfun-core`, app crates, Tauri, ACP protocol, web UI,
   concrete service crates, or product-domain implementations.
-- The `sdk` module may re-export only stable runtime request/response types and
-  runtime-port contracts.
+- The `sdk` module may re-export only stable runtime request/response types,
+  runtime-port contracts, and the service/tool/harness registry types needed
+  for dependency injection.
 - `AgentRuntime` may depend on stable ports plus injected `RuntimeServices`,
   tool registry, harness registry, and hook registry. Product assembly owns
   concrete registration; this crate must not create concrete managers, app

--- a/src/crates/execution/agent-runtime/Cargo.toml
+++ b/src/crates/execution/agent-runtime/Cargo.toml
@@ -9,6 +9,9 @@ description = "Agent runtime contracts and owner decisions for BitFun"
 name = "bitfun_agent_runtime"
 crate-type = ["rlib"]
 
+[features]
+default = []
+
 [dependencies]
 bitfun-agent-tools = { path = "../tool-contracts" }
 bitfun-events = { path = "../../contracts/events" }

--- a/src/crates/execution/agent-runtime/examples/sdk_minimal.rs
+++ b/src/crates/execution/agent-runtime/examples/sdk_minimal.rs
@@ -1,0 +1,83 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use bitfun_agent_runtime::sdk::{
+    AgentEventStream, AgentRunRequest, AgentRuntimeBuilder, AgentRuntimeSdkCompatibility,
+    AgentSessionCreateRequest, AgentSessionCreateResult, AgentSubmissionPort,
+    AgentSubmissionRequest, AgentSubmissionResult, AgentSubmissionSource, PortResult,
+    RuntimeEventEnvelope, RuntimeEventType, SessionSelector,
+};
+
+#[derive(Debug, Default)]
+struct ExampleAgentProvider {
+    created_sessions: Mutex<Vec<AgentSessionCreateRequest>>,
+    submitted_turns: Mutex<Vec<AgentSubmissionRequest>>,
+}
+
+#[async_trait]
+impl AgentSubmissionPort for ExampleAgentProvider {
+    async fn create_session(
+        &self,
+        request: AgentSessionCreateRequest,
+    ) -> PortResult<AgentSessionCreateResult> {
+        self.created_sessions.lock().unwrap().push(request.clone());
+        Ok(AgentSessionCreateResult {
+            session_id: "example-session".to_string(),
+            session_name: request.session_name,
+            agent_type: request.agent_type,
+        })
+    }
+
+    async fn submit_message(
+        &self,
+        request: AgentSubmissionRequest,
+    ) -> PortResult<AgentSubmissionResult> {
+        self.submitted_turns.lock().unwrap().push(request.clone());
+        Ok(AgentSubmissionResult {
+            turn_id: request
+                .turn_id
+                .unwrap_or_else(|| "example-turn".to_string()),
+            accepted: true,
+        })
+    }
+
+    async fn resolve_session_agent_type(&self, _session_id: &str) -> PortResult<Option<String>> {
+        Ok(Some("agentic".to_string()))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let compatibility = AgentRuntimeSdkCompatibility::current();
+    assert_eq!(compatibility.api_version, 1);
+
+    let provider = Arc::new(ExampleAgentProvider::default());
+    let events = AgentEventStream::new();
+    let runtime = AgentRuntimeBuilder::new()
+        .with_submission_port(provider)
+        .with_event_stream(events.clone())
+        .build()?;
+
+    let handle = runtime
+        .run(
+            AgentRunRequest::new(
+                SessionSelector::create("Example SDK Session", "agentic", None),
+                "hello from an SDK embedder",
+            )
+            .with_source(AgentSubmissionSource::Cli),
+        )
+        .await?;
+
+    runtime
+        .publish_event(RuntimeEventEnvelope {
+            session_id: handle.session_id.clone(),
+            turn_id: Some(handle.turn_id.clone()),
+            source: Some(AgentSubmissionSource::Cli),
+            event_type: RuntimeEventType::TurnStarted,
+            payload: serde_json::json!({ "example": "sdk_minimal" }),
+        })
+        .await?;
+
+    assert_eq!(events.len(), 1);
+    Ok(())
+}

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -4,6 +4,32 @@
 //! runtime with caller-provided ports. Concrete product assembly remains
 //! outside this crate.
 
+pub const AGENT_RUNTIME_SDK_API_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AgentRuntimeSdkStability {
+    Preview,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AgentRuntimeSdkCompatibility {
+    pub api_version: u32,
+    pub crate_version: &'static str,
+    pub stability: AgentRuntimeSdkStability,
+}
+
+impl AgentRuntimeSdkCompatibility {
+    pub const fn current() -> Self {
+        Self {
+            api_version: AGENT_RUNTIME_SDK_API_VERSION,
+            crate_version: env!("CARGO_PKG_VERSION"),
+            stability: AgentRuntimeSdkStability::Preview,
+        }
+    }
+}
+
 pub use crate::post_call_hooks::{
     RuntimeHookErrorPolicy, RuntimeHookKind, RuntimeHookPlan, RuntimeHookRegistry,
     RuntimeHookRegistryBuildError,
@@ -13,6 +39,11 @@ pub use crate::runtime::{
     RuntimeAgentRegistry, RuntimeAgentRegistryQuery, RuntimeBuildError, RuntimeError,
     RuntimeToolRegistry, SessionSelector,
 };
+pub use bitfun_agent_tools::{ToolRegistry, ToolRegistryItem};
+pub use bitfun_harness::{
+    build_descriptor_harness_registry, HarnessCapability, HarnessProviderDescriptor,
+    HarnessRegistry, HarnessWorkflow,
+};
 pub use bitfun_runtime_ports::{
     AgentDialogTurnPort, AgentDialogTurnRequest, AgentInputAttachment, AgentLifecycleDeliveryPort,
     AgentSessionCreateRequest, AgentSessionCreateResult, AgentSessionDeleteRequest,
@@ -20,5 +51,17 @@ pub use bitfun_runtime_ports::{
     AgentSessionWorkspaceRequest, AgentSubmissionPort, AgentSubmissionRequest,
     AgentSubmissionResult, AgentSubmissionSource, AgentThreadGoalDeliveryRequest,
     AgentTurnCancellationPort, AgentTurnCancellationRequest, AgentTurnCancellationResult,
-    DialogSubmitOutcome, PortError, RuntimeEventEnvelope, RuntimeEventType,
+    ClockPort, DialogSubmitOutcome, FileSystemPort, GitPort, McpCatalogPort, NetworkPort,
+    PermissionDecision, PermissionPort, PermissionRequest, PortError, PortResult,
+    RemoteAssistantWorkspaceFacts, RemoteCapabilityPort, RemoteConnectionPort,
+    RemoteProjectionPort, RemoteRecentWorkspaceFacts, RemoteWorkspaceFacts,
+    RemoteWorkspaceFileRuntimeHost, RemoteWorkspaceKind, RemoteWorkspacePort,
+    RemoteWorkspaceRuntimeHost, RemoteWorkspaceUpdate, RuntimeEventEnvelope, RuntimeEventSink,
+    RuntimeEventType, RuntimeServiceCapability, RuntimeServicePort, SessionStorageKind,
+    SessionStoragePathRequest, SessionStoragePathResolution, SessionStorePort, TerminalPort,
+    WorkspacePort,
+};
+pub use bitfun_runtime_services::{
+    CapabilityAvailability, RuntimeServices, RuntimeServicesBuilder, RuntimeServicesError,
+    RuntimeServicesProvider, RuntimeServicesRegistry,
 };

--- a/src/crates/execution/agent-runtime/tests/sdk_smoke.rs
+++ b/src/crates/execution/agent-runtime/tests/sdk_smoke.rs
@@ -3,21 +3,17 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use bitfun_agent_runtime::sdk::{
-    AgentEventStream, AgentRunRequest, AgentRuntimeBuilder, RuntimeAgentRegistry,
-    RuntimeAgentRegistryQuery, RuntimeHookErrorPolicy, RuntimeHookKind, RuntimeHookPlan,
-    RuntimeHookRegistry, SessionSelector,
+    build_descriptor_harness_registry, AgentEventStream, AgentRunRequest, AgentRuntimeBuilder,
+    AgentRuntimeSdkCompatibility, AgentRuntimeSdkStability, AgentSessionCreateRequest,
+    AgentSessionCreateResult, AgentSubmissionPort, AgentSubmissionRequest, AgentSubmissionResult,
+    AgentSubmissionSource, ClockPort, FileSystemPort, HarnessCapability, HarnessProviderDescriptor,
+    HarnessWorkflow, PermissionDecision, PermissionPort, PermissionRequest, PortResult,
+    RuntimeAgentRegistry, RuntimeAgentRegistryQuery, RuntimeEventEnvelope, RuntimeEventSink,
+    RuntimeEventType, RuntimeHookErrorPolicy, RuntimeHookKind, RuntimeHookPlan,
+    RuntimeHookRegistry, RuntimeServiceCapability, RuntimeServicePort, RuntimeServices,
+    RuntimeServicesBuilder, SessionSelector, SessionStorageKind, SessionStoragePathRequest,
+    SessionStoragePathResolution, SessionStorePort, ToolRegistry, ToolRegistryItem, WorkspacePort,
 };
-use bitfun_agent_tools::{ToolRegistry, ToolRegistryItem};
-use bitfun_harness::{
-    build_descriptor_harness_registry, HarnessCapability, HarnessProviderDescriptor,
-    HarnessWorkflow,
-};
-use bitfun_runtime_ports::{
-    AgentSessionCreateRequest, AgentSessionCreateResult, AgentSubmissionPort,
-    AgentSubmissionRequest, AgentSubmissionResult, AgentSubmissionSource, PortResult,
-    RuntimeEventEnvelope, RuntimeEventType,
-};
-use bitfun_runtime_services::test_support::FakeRuntimeServicesProvider;
 use serde_json::{json, Value};
 
 #[derive(Debug, Default)]
@@ -34,6 +30,23 @@ struct FakeSdkAgentRegistry {
     workspace_agent_ids: Vec<String>,
 }
 
+#[derive(Debug)]
+struct FakeSdkRuntimePort {
+    capability: RuntimeServiceCapability,
+}
+
+#[derive(Debug, Default)]
+struct FakeSdkRuntimeEventSink;
+
+#[test]
+fn sdk_facade_exposes_versioned_preview_compatibility_contract() {
+    let compatibility = AgentRuntimeSdkCompatibility::current();
+
+    assert_eq!(compatibility.api_version, 1);
+    assert_eq!(compatibility.crate_version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(compatibility.stability, AgentRuntimeSdkStability::Preview);
+}
+
 impl RuntimeAgentRegistry for FakeSdkAgentRegistry {
     fn agent_ids(&self, query: RuntimeAgentRegistryQuery<'_>) -> Vec<String> {
         if query.workspace_root.is_some() {
@@ -42,6 +55,82 @@ impl RuntimeAgentRegistry for FakeSdkAgentRegistry {
             self.agent_ids.clone()
         }
     }
+}
+
+impl FakeSdkRuntimePort {
+    fn new(capability: RuntimeServiceCapability) -> Self {
+        Self { capability }
+    }
+}
+
+impl RuntimeServicePort for FakeSdkRuntimePort {
+    fn capability(&self) -> RuntimeServiceCapability {
+        self.capability
+    }
+}
+
+impl FileSystemPort for FakeSdkRuntimePort {}
+impl WorkspacePort for FakeSdkRuntimePort {}
+
+#[async_trait]
+impl SessionStorePort for FakeSdkRuntimePort {
+    async fn resolve_session_storage_path(
+        &self,
+        request: SessionStoragePathRequest,
+    ) -> PortResult<SessionStoragePathResolution> {
+        Ok(SessionStoragePathResolution::new(
+            request.workspace_path.clone(),
+            request.workspace_path,
+            SessionStorageKind::Local,
+            request.remote_connection_id,
+            request.remote_ssh_host,
+        ))
+    }
+}
+
+#[async_trait]
+impl PermissionPort for FakeSdkRuntimePort {
+    async fn request_permission(
+        &self,
+        _request: PermissionRequest,
+    ) -> PortResult<PermissionDecision> {
+        Ok(PermissionDecision::Allow)
+    }
+}
+
+impl ClockPort for FakeSdkRuntimePort {
+    fn now_unix_millis(&self) -> i64 {
+        0
+    }
+}
+
+#[async_trait]
+impl RuntimeEventSink for FakeSdkRuntimeEventSink {
+    async fn publish_runtime_event(&self, _event: RuntimeEventEnvelope) -> PortResult<()> {
+        Ok(())
+    }
+}
+
+fn fake_sdk_services() -> RuntimeServices {
+    RuntimeServicesBuilder::new()
+        .with_filesystem(Arc::new(FakeSdkRuntimePort::new(
+            RuntimeServiceCapability::FileSystem,
+        )))
+        .with_workspace(Arc::new(FakeSdkRuntimePort::new(
+            RuntimeServiceCapability::Workspace,
+        )))
+        .with_session_store(Arc::new(FakeSdkRuntimePort::new(
+            RuntimeServiceCapability::SessionStore,
+        )))
+        .with_permission(Arc::new(FakeSdkRuntimePort::new(
+            RuntimeServiceCapability::Permission,
+        )))
+        .with_events(Arc::new(FakeSdkRuntimeEventSink))
+        .with_clock(Arc::new(FakeSdkRuntimePort::new(
+            RuntimeServiceCapability::Clock,
+        )))
+        .build()
+        .expect("fake SDK services")
 }
 
 #[async_trait]
@@ -148,9 +237,7 @@ async fn sdk_facade_runs_with_fake_provider_and_local_event_stream() {
 #[tokio::test]
 async fn sdk_facade_accepts_fake_services_tools_harnesses_and_hooks_without_core() {
     let provider = Arc::new(FakeSdkAgentProvider::default());
-    let services = FakeRuntimeServicesProvider::with_all_required()
-        .build_services()
-        .expect("fake required services");
+    let services = fake_sdk_services();
     let mut tools = ToolRegistry::new();
     tools.register_tool(Arc::new(FakeSdkTool));
     let harnesses = build_descriptor_harness_registry([HarnessProviderDescriptor::legacy_facade(
@@ -206,5 +293,5 @@ async fn sdk_facade_accepts_fake_services_tools_harnesses_and_hooks_without_core
     assert!(runtime
         .services()
         .expect("services should be injected")
-        .has_capability(bitfun_runtime_ports::RuntimeServiceCapability::SessionStore));
+        .has_capability(RuntimeServiceCapability::SessionStore));
 }


### PR DESCRIPTION
## Summary
- Add a v1 preview compatibility contract and explicit empty default feature set for the Agent Runtime SDK facade.
- Re-export stable SDK injection contracts for runtime services, tools, harnesses, hooks, events, and agent registries without exposing concrete product implementations.
- Add a minimal SDK embedder example and boundary required-rule/self-test coverage for the public facade.
- Strengthen the SDK smoke test so fake services are built through `bitfun_agent_runtime::sdk` re-exported ports and `RuntimeServicesBuilder`, with boundary and self-test coverage preventing fallback to runtime-services test support.
- Update the runtime design and core decomposition plan docs to reflect the H4 SDK boundary and future external-package trigger conditions.

## Compatibility and risk
- No agent execution, session lifecycle, tool schema, permission, product capability selection, or platform behavior is changed.
- The SDK facade remains independent from `bitfun-core`, app crates, Tauri, concrete service managers, product domains, tool packs, AI adapters, CLI, terminal runtime, and concrete network/Git/MCP clients.
- `bitfun-core` still compiles with both `--no-default-features` and `--features product-full`.

## Verification
- `pnpm run fmt:rs`
- `cargo test -p bitfun-agent-runtime --test sdk_smoke`
- `cargo test -p bitfun-agent-runtime`
- `cargo check -p bitfun-agent-runtime --no-default-features --examples`
- `node --test scripts/check-core-boundaries.test.mjs`
- `node scripts/check-core-boundaries.mjs`
- `cargo check -p bitfun-core --no-default-features`
- `cargo check -p bitfun-core --features product-full`
- `cargo metadata --no-deps --format-version 1`
- `pnpm run check:repo-hygiene`
- `git diff --check`
- SDK forbidden dependency scan for concrete product, app, Tauri, tool-pack, AI, MCP/Git/network, CLI, terminal, and tool-runtime dependencies