### PR TITLE
refactor(web-ui): tighten theme color governance budgets

### DIFF
--- a/scripts/theme-color-governance-baseline.json
+++ b/scripts/theme-color-governance-baseline.json
@@ -6,10 +6,10 @@
       "max": 31
     },
     "colorScopes.appUi.uniqueColors": {
-      "max": 492
+      "max": 489
     },
     "colorScopes.appUi.occurrences": {
-      "max": 831
+      "max": 827
     },
     "colorScopes.token.uniqueColors": {
       "max": 698
@@ -41,20 +41,50 @@
     "tokenAliasLiterals.uniqueColors": {
       "max": 34
     },
+    "colorDomainScopes.themePreset.occurrences": {
+      "max": 1033
+    },
+    "colorDomainScopes.themePreset.uniqueColors": {
+      "max": 611
+    },
+    "colorDomainScopes.themeRuntime.occurrences": {
+      "max": 62
+    },
+    "colorDomainScopes.tokenContract.occurrences": {
+      "max": 268
+    },
+    "colorDomainScopes.generatedWidget.occurrences": {
+      "max": 19
+    },
+    "colorDomainScopes.generatedWidget.uniqueColors": {
+      "max": 17
+    },
     "colorDomainScopes.editor.occurrences": {
-      "max": 210
+      "max": 206
+    },
+    "colorDomainScopes.syntax.occurrences": {
+      "max": 18
+    },
+    "colorDomainScopes.terminal.occurrences": {
+      "max": 39
+    },
+    "colorDomainScopes.languageIdentity.occurrences": {
+      "max": 48
     },
     "colorDomainScopes.visualEffect.occurrences": {
       "max": 42
     },
     "colorDomainScopes.appUi.occurrences": {
-      "max": 566
+      "max": 559
     },
     "colorDomainScopes.appUi.uniqueColors": {
-      "max": 344
+      "max": 343
     },
     "colorDomainScopes.mermaid.occurrences": {
       "max": 149
+    },
+    "colorDomainScopes.mermaid.uniqueColors": {
+      "max": 95
     }
   }
 }

--- a/src/web-ui/src/app/components/GalleryLayout/GalleryLayout.scss
+++ b/src/web-ui/src/app/components/GalleryLayout/GalleryLayout.scss
@@ -429,7 +429,7 @@ $content-max: 1480px;
 }
 
 :root[data-theme-type='light'] .gallery-grid--skeleton {
-  --skeleton-shimmer-0: rgba(0, 0, 0, 0);
+  --skeleton-shimmer-0: #00000000;
   --skeleton-shimmer-peak: rgba(0, 0, 0, 0.07);
 }
 

--- a/src/web-ui/src/component-library/components/FlowChatCards/ContextCompressionCard/ContextCompressionCard.scss
+++ b/src/web-ui/src/component-library/components/FlowChatCards/ContextCompressionCard/ContextCompressionCard.scss
@@ -49,7 +49,7 @@
     box-shadow: 0 4px 16px color-mix(in srgb, var(--context-compression-accent) 30%, transparent),
                 0 2px 8px color-mix(in srgb, var(--context-compression-accent) 20%, transparent),
                 inset 0 1px 0 var(--color-overlay-white-10);
-    background: linear-gradient(135deg, rgba(25, 25, 25, 0.98), rgba(20, 20, 20, 1));
+    background: linear-gradient(135deg, rgba(25, 25, 25, 0.98), #141414);
   }
 }
 

--- a/src/web-ui/src/infrastructure/theme/integrations/MonacoThemeSync.ts
+++ b/src/web-ui/src/infrastructure/theme/integrations/MonacoThemeSync.ts
@@ -9,6 +9,13 @@ const log = createLogger('MonacoThemeSync');
 
 
 const SEMANTIC_HIGHLIGHTING_RULES = BitFunDarkTheme.rules;
+const TRANSPARENT_MONACO_BORDER = '#00000000';
+const TRANSPARENT_MONACO_BORDER_COLORS = {
+  'focusBorder': TRANSPARENT_MONACO_BORDER,
+  'contrastBorder': TRANSPARENT_MONACO_BORDER,
+  'diffEditor.insertedTextBorder': TRANSPARENT_MONACO_BORDER,
+  'diffEditor.removedTextBorder': TRANSPARENT_MONACO_BORDER,
+} as const;
 
 function getBitfunLightMonacoTheme(): Monaco.editor.IStandaloneThemeData {
   return {
@@ -16,10 +23,7 @@ function getBitfunLightMonacoTheme(): Monaco.editor.IStandaloneThemeData {
     inherit: true,
     rules: SEMANTIC_HIGHLIGHTING_RULES,
     colors: convertColorsToHex({
-      'focusBorder': '#00000000',
-      'contrastBorder': '#00000000',
-      'diffEditor.insertedTextBorder': '#00000000',
-      'diffEditor.removedTextBorder': '#00000000',
+      ...TRANSPARENT_MONACO_BORDER_COLORS,
 
       'editor.selectionBackground': 'rgba(15, 23, 42, 0.14)',
       'editor.selectionForeground': '#1e293b',
@@ -275,12 +279,8 @@ export class MonacoThemeSync {
       'editor.wordHighlightBackground': themeColors.accent[100],
       'editor.wordHighlightStrongBackground': themeColors.accent[200],
       'editor.lineHighlightBackground': themeColors.background.secondary,
-      
-      'focusBorder': '#00000000',
-      'contrastBorder': '#00000000',
-      
-      'diffEditor.insertedTextBorder': '#00000000',
-      'diffEditor.removedTextBorder': '#00000000',
+
+      ...TRANSPARENT_MONACO_BORDER_COLORS,
     };
     
     

--- a/src/web-ui/src/infrastructure/theme/presets/china-night-theme.ts
+++ b/src/web-ui/src/infrastructure/theme/presets/china-night-theme.ts
@@ -1,6 +1,13 @@
  
 
 import { ThemeConfig } from '../types';
+import {
+  createChinaTypography,
+  createCompactRadius,
+  createStandardEasing,
+  createStandardSpacing,
+  createWindowControls,
+} from './shared';
 
 export const bitfunChinaNightTheme: ThemeConfig = {
   
@@ -133,27 +140,9 @@ export const bitfunChinaNightTheme: ThemeConfig = {
       intense: 'blur(20px) saturate(1.3) brightness(1.08)',
     },
     
-    radius: {
-      sm: '4px',                   
-      base: '6px',
-      lg: '10px',
-      xl: '14px',
-      '2xl': '18px',
-      full: '9999px',
-    },
+    radius: createCompactRadius(),
     
-    spacing: {
-      1: '4px',
-      2: '8px',
-      3: '12px',
-      4: '16px',
-      5: '20px',
-      6: '24px',
-      8: '32px',
-      10: '40px',
-      12: '48px',
-      16: '64px',
-    },
+    spacing: createStandardSpacing(),
     
     opacity: {
       disabled: 0.45,
@@ -173,61 +162,17 @@ export const bitfunChinaNightTheme: ThemeConfig = {
       lazy: '1.2s',
     },
     
-    easing: {
-      standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
-      decelerate: 'cubic-bezier(0, 0, 0.2, 1)',
-      accelerate: 'cubic-bezier(0.4, 0, 1, 1)',
-      bounce: 'cubic-bezier(0.68, -0.55, 0.265, 1.55)',
-      smooth: 'cubic-bezier(0.25, 0.1, 0.25, 1)',
-    },
+    easing: createStandardEasing('cubic-bezier(0.25, 0.1, 0.25, 1)'),
   },
   
   
-  typography: {
-    font: {
-      sans: "'Noto Sans SC', 'Source Han Sans CN', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif",
-      mono: "'Source Han Mono CN', 'Noto Sans Mono CJK SC', 'JetBrains Mono', 'FiraCode', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Cascadia Code', Consolas, 'Liberation Mono', 'Courier New', monospace",
-    },
-    
-    weight: {
-      normal: 400,
-      medium: 500,
-      semibold: 600,
-      bold: 700,
-    },
-    
-    size: {
-      xs: '12px',
-      sm: '13px',
-      base: '14px',
-      lg: '15px',
-      xl: '16px',
-      '2xl': '18px',
-      '3xl': '22px',
-      '4xl': '26px',
-      '5xl': '32px',
-    },
-    
-    lineHeight: {
-      tight: 1.3,
-      base: 1.6,
-      relaxed: 1.8,
-    },
-  },
+  typography: createChinaTypography(),
   
   
   components: {
     
-    windowControls: {
-      minimize: {
-        dot: 'rgba(115, 165, 204, 0.45)',
-        dotShadow: '0 0 4px rgba(115, 165, 204, 0.2)',
-        hoverBg: 'rgba(115, 165, 204, 0.12)',
-        hoverColor: '#73a5cc',
-        hoverBorder: 'rgba(115, 165, 204, 0.2)',
-        hoverShadow: '0 2px 8px rgba(115, 165, 204, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
-      },
-      maximize: {
+    windowControls: createWindowControls({
+      standard: {
         dot: 'rgba(115, 165, 204, 0.45)',
         dotShadow: '0 0 4px rgba(115, 165, 204, 0.2)',
         hoverBg: 'rgba(115, 165, 204, 0.12)',
@@ -249,7 +194,7 @@ export const bitfunChinaNightTheme: ThemeConfig = {
         disabledDot: 'rgba(255, 255, 255, 0.1)',
         flowGradient: 'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.05), transparent)',
       },
-    },
+    }),
     
     button: {
       

--- a/src/web-ui/src/infrastructure/theme/presets/china-style-theme.ts
+++ b/src/web-ui/src/infrastructure/theme/presets/china-style-theme.ts
@@ -1,6 +1,13 @@
  
 
 import { ThemeConfig } from '../types';
+import {
+  createChinaTypography,
+  createCompactRadius,
+  createStandardEasing,
+  createStandardSpacing,
+  createWindowControls,
+} from './shared';
 
 export const bitfunChinaStyleTheme: ThemeConfig = {
   
@@ -131,27 +138,9 @@ export const bitfunChinaStyleTheme: ThemeConfig = {
       intense: 'blur(20px) saturate(1.12) brightness(1.03)',
     },
     
-    radius: {
-      sm: '4px',                   
-      base: '6px',
-      lg: '10px',
-      xl: '14px',
-      '2xl': '18px',
-      full: '9999px',
-    },
+    radius: createCompactRadius(),
     
-    spacing: {
-      1: '4px',
-      2: '8px',
-      3: '12px',
-      4: '16px',
-      5: '20px',
-      6: '24px',
-      8: '32px',
-      10: '40px',
-      12: '48px',
-      16: '64px',
-    },
+    spacing: createStandardSpacing(),
     
     opacity: {
       disabled: 0.5,
@@ -171,61 +160,17 @@ export const bitfunChinaStyleTheme: ThemeConfig = {
       lazy: '1.2s',                 
     },
     
-    easing: {
-      standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
-      decelerate: 'cubic-bezier(0, 0, 0.2, 1)',
-      accelerate: 'cubic-bezier(0.4, 0, 1, 1)',
-      bounce: 'cubic-bezier(0.68, -0.55, 0.265, 1.55)',
-      smooth: 'cubic-bezier(0.25, 0.1, 0.25, 1)',    
-    },
+    easing: createStandardEasing('cubic-bezier(0.25, 0.1, 0.25, 1)'),
   },
   
   
-  typography: {
-    font: {
-      sans: "'Noto Sans SC', 'Source Han Sans CN', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif",
-      mono: "'Source Han Mono CN', 'Noto Sans Mono CJK SC', 'JetBrains Mono', 'FiraCode', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Cascadia Code', Consolas, 'Liberation Mono', 'Courier New', monospace",
-    },
-    
-    weight: {
-      normal: 400,
-      medium: 500,
-      semibold: 600,
-      bold: 700,
-    },
-    
-    size: {
-      xs: '12px',
-      sm: '13px',
-      base: '14px',
-      lg: '15px',
-      xl: '16px',
-      '2xl': '18px',
-      '3xl': '22px',
-      '4xl': '26px',
-      '5xl': '32px',
-    },
-    
-    lineHeight: {
-      tight: 1.3,
-      base: 1.6,                    
-      relaxed: 1.8,
-    },
-  },
+  typography: createChinaTypography(),
   
   
   components: {
     
-    windowControls: {
-      minimize: {
-        dot: 'rgba(46, 94, 138, 0.45)',
-        dotShadow: '0 0 4px rgba(46, 94, 138, 0.2)',
-        hoverBg: 'rgba(46, 94, 138, 0.12)',
-        hoverColor: '#2e5e8a',
-        hoverBorder: 'rgba(46, 94, 138, 0.2)',
-        hoverShadow: '0 2px 8px rgba(46, 94, 138, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.5)',
-      },
-      maximize: {
+    windowControls: createWindowControls({
+      standard: {
         dot: 'rgba(46, 94, 138, 0.45)',
         dotShadow: '0 0 4px rgba(46, 94, 138, 0.2)',
         hoverBg: 'rgba(46, 94, 138, 0.12)',
@@ -247,7 +192,7 @@ export const bitfunChinaStyleTheme: ThemeConfig = {
         disabledDot: 'rgba(106, 92, 70, 0.1)',
         flowGradient: 'linear-gradient(90deg, transparent, rgba(106, 92, 70, 0.05), rgba(106, 92, 70, 0.08), rgba(106, 92, 70, 0.05), transparent)',
       },
-    },
+    }),
     
     button: {
       

--- a/src/web-ui/src/infrastructure/theme/presets/cyber-theme.ts
+++ b/src/web-ui/src/infrastructure/theme/presets/cyber-theme.ts
@@ -1,6 +1,13 @@
  
 
 import { ThemeConfig } from '../types';
+import {
+  createCompactRadius,
+  createExpressiveTypography,
+  createStandardEasing,
+  createStandardSpacing,
+  createWindowControls,
+} from './shared';
 
 export const bitfunCyberTheme: ThemeConfig = {
   
@@ -136,27 +143,9 @@ export const bitfunCyberTheme: ThemeConfig = {
       intense: 'blur(20px) saturate(1.6) brightness(1.2)',
     },
     
-    radius: {
-      sm: '4px',
-      base: '6px',
-      lg: '10px',
-      xl: '14px',
-      '2xl': '18px',
-      full: '9999px',
-    },
+    radius: createCompactRadius(),
     
-    spacing: {
-      1: '4px',
-      2: '8px',
-      3: '12px',
-      4: '16px',
-      5: '20px',
-      6: '24px',
-      8: '32px',
-      10: '40px',
-      12: '48px',
-      16: '64px',
-    },
+    spacing: createStandardSpacing(),
     
     opacity: {
       disabled: 0.5,
@@ -176,61 +165,17 @@ export const bitfunCyberTheme: ThemeConfig = {
       lazy: '0.8s',
     },
     
-    easing: {
-      standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
-      decelerate: 'cubic-bezier(0, 0, 0.2, 1)',
-      accelerate: 'cubic-bezier(0.4, 0, 1, 1)',
-      bounce: 'cubic-bezier(0.68, -0.55, 0.265, 1.55)',
-      smooth: 'cubic-bezier(0.25, 0.46, 0.45, 0.94)',
-    },
+    easing: createStandardEasing('cubic-bezier(0.25, 0.46, 0.45, 0.94)'),
   },
   
   
-  typography: {
-    font: {
-      sans: "'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif",
-      mono: "'JetBrains Mono', 'FiraCode', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Cascadia Code', Consolas, 'Liberation Mono', 'Courier New', monospace",
-    },
-    
-    weight: {
-      normal: 400,
-      medium: 500,
-      semibold: 600,
-      bold: 700,
-    },
-    
-    size: {
-      xs: '12px',
-      sm: '13px',
-      base: '14px',
-      lg: '15px',
-      xl: '16px',
-      '2xl': '18px',
-      '3xl': '22px',
-      '4xl': '26px',
-      '5xl': '32px',
-    },
-    
-    lineHeight: {
-      tight: 1.3,
-      base: 1.5,
-      relaxed: 1.65,
-    },
-  },
+  typography: createExpressiveTypography(),
   
   
   components: {
     
-    windowControls: {
-      minimize: {
-        dot: 'rgba(0, 230, 255, 0.5)',
-        dotShadow: '0 0 6px rgba(0, 230, 255, 0.35)',
-        hoverBg: 'rgba(0, 230, 255, 0.15)',
-        hoverColor: '#00e6ff',
-        hoverBorder: 'rgba(0, 230, 255, 0.3)',
-        hoverShadow: '0 0 12px rgba(0, 230, 255, 0.3), 0 2px 8px rgba(0, 230, 255, 0.2), inset 0 1px 0 rgba(0, 230, 255, 0.2)',
-      },
-      maximize: {
+    windowControls: createWindowControls({
+      standard: {
         dot: 'rgba(0, 230, 255, 0.5)',
         dotShadow: '0 0 6px rgba(0, 230, 255, 0.35)',
         hoverBg: 'rgba(0, 230, 255, 0.15)',
@@ -252,7 +197,7 @@ export const bitfunCyberTheme: ThemeConfig = {
         disabledDot: 'rgba(0, 230, 255, 0.1)',
         flowGradient: 'linear-gradient(90deg, transparent, rgba(0, 230, 255, 0.08), rgba(0, 230, 255, 0.12), rgba(0, 230, 255, 0.08), transparent)',
       },
-    },
+    }),
     
     button: {
       

--- a/src/web-ui/src/infrastructure/theme/presets/dark-theme.ts
+++ b/src/web-ui/src/infrastructure/theme/presets/dark-theme.ts
@@ -1,6 +1,16 @@
  
 
 import { ThemeConfig } from '../types';
+import {
+  createDarkNeutralBorder,
+  createDarkNeutralElement,
+  createDarkNeutralScrollbar,
+  createStandardEasing,
+  createStandardRadius,
+  createStandardSpacing,
+  createStandardTypography,
+  createWindowControls,
+} from './shared';
 
 export const bitfunDarkTheme: ThemeConfig = {
   
@@ -77,22 +87,9 @@ export const bitfunDarkTheme: ThemeConfig = {
       highlightBg: 'rgba(255, 255, 255, 0.1)',
     },
     
-    border: {
-      subtle: 'rgba(255, 255, 255, 0.12)',
-      base: 'rgba(255, 255, 255, 0.18)',
-      medium: 'rgba(255, 255, 255, 0.24)',
-      strong: 'rgba(255, 255, 255, 0.32)',
-      prominent: 'rgba(255, 255, 255, 0.4)',
-    },
+    border: createDarkNeutralBorder(),
     
-    element: {
-      subtle: 'rgba(255, 255, 255, 0.05)',
-      soft: 'rgba(255, 255, 255, 0.07)',
-      base: 'rgba(255, 255, 255, 0.095)',
-      medium: 'rgba(255, 255, 255, 0.125)',
-      strong: 'rgba(255, 255, 255, 0.155)',
-      elevated: 'rgba(255, 255, 255, 0.19)',
-    },
+    element: createDarkNeutralElement(),
     
     git: {
       branch: '#a1a1aa',
@@ -107,10 +104,7 @@ export const bitfunDarkTheme: ThemeConfig = {
       stagedBg: 'rgba(34, 197, 94, 0.1)',
     },
     
-    scrollbar: {
-      thumb: 'rgba(255, 255, 255, 0.15)',
-      thumbHover: 'rgba(255, 255, 255, 0.28)',
-    },
+    scrollbar: createDarkNeutralScrollbar(),
   },
   
   
@@ -138,27 +132,9 @@ export const bitfunDarkTheme: ThemeConfig = {
       intense: 'blur(20px) saturate(1.4) brightness(1.15)',
     },
     
-    radius: {
-      sm: '6px',
-      base: '8px',
-      lg: '12px',
-      xl: '16px',
-      '2xl': '20px',
-      full: '9999px',
-    },
+    radius: createStandardRadius(),
     
-    spacing: {
-      1: '4px',
-      2: '8px',
-      3: '12px',
-      4: '16px',
-      5: '20px',
-      6: '24px',
-      8: '32px',
-      10: '40px',
-      12: '48px',
-      16: '64px',
-    },
+    spacing: createStandardSpacing(),
     
     opacity: {
       disabled: 0.6,
@@ -178,61 +154,17 @@ export const bitfunDarkTheme: ThemeConfig = {
       lazy: '1s',
     },
     
-    easing: {
-      standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
-      decelerate: 'cubic-bezier(0, 0, 0.2, 1)',
-      accelerate: 'cubic-bezier(0.4, 0, 1, 1)',
-      bounce: 'cubic-bezier(0.68, -0.55, 0.265, 1.55)',
-      smooth: 'cubic-bezier(0.4, 0, 0.2, 1)',
-    },
+    easing: createStandardEasing(),
   },
   
   
-  typography: {
-    font: {
-      sans: "'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif",
-      mono: "'JetBrains Mono', 'FiraCode', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Cascadia Code', Consolas, 'Liberation Mono', 'Courier New', monospace",
-    },
-    
-    weight: {
-      normal: 400,
-      medium: 500,
-      semibold: 600,
-      bold: 700,
-    },
-    
-    size: {
-      xs: '12px',
-      sm: '13px',
-      base: '14px',
-      lg: '15px',
-      xl: '16px',
-      '2xl': '18px',
-      '3xl': '22px',
-      '4xl': '26px',
-      '5xl': '32px',
-    },
-    
-    lineHeight: {
-      tight: 1.2,
-      base: 1.5,
-      relaxed: 1.6,
-    },
-  },
+  typography: createStandardTypography(),
   
   
   components: {
     
-    windowControls: {
-      minimize: {
-        dot: 'rgba(255, 255, 255, 0.38)',
-        dotShadow: '0 0 4px rgba(0, 0, 0, 0.35)',
-        hoverBg: 'rgba(255, 255, 255, 0.1)',
-        hoverColor: '#e4e4e4',
-        hoverBorder: 'rgba(255, 255, 255, 0.16)',
-        hoverShadow: '0 2px 8px rgba(0, 0, 0, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.08)',
-      },
-      maximize: {
+    windowControls: createWindowControls({
+      standard: {
         dot: 'rgba(255, 255, 255, 0.38)',
         dotShadow: '0 0 4px rgba(0, 0, 0, 0.35)',
         hoverBg: 'rgba(255, 255, 255, 0.1)',
@@ -254,7 +186,7 @@ export const bitfunDarkTheme: ThemeConfig = {
         disabledDot: 'rgba(255, 255, 255, 0.1)',
         flowGradient: 'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.05), transparent)',
       },
-    },
+    }),
     
     button: {
       

--- a/src/web-ui/src/infrastructure/theme/presets/light-theme.ts
+++ b/src/web-ui/src/infrastructure/theme/presets/light-theme.ts
@@ -1,6 +1,13 @@
  
 
 import { ThemeConfig } from '../types';
+import {
+  createStandardEasing,
+  createStandardRadius,
+  createStandardSpacing,
+  createStandardTypography,
+  createWindowControls,
+} from './shared';
 
 export const bitfunLightTheme: ThemeConfig = {
   
@@ -145,27 +152,9 @@ export const bitfunLightTheme: ThemeConfig = {
       intense: 'blur(20px) saturate(1.12) brightness(1.03)',
     },
     
-    radius: {
-      sm: '6px',
-      base: '8px',
-      lg: '12px',
-      xl: '16px',
-      '2xl': '20px',
-      full: '9999px',
-    },
+    radius: createStandardRadius(),
     
-    spacing: {
-      1: '4px',
-      2: '8px',
-      3: '12px',
-      4: '16px',
-      5: '20px',
-      6: '24px',
-      8: '32px',
-      10: '40px',
-      12: '48px',
-      16: '64px',
-    },
+    spacing: createStandardSpacing(),
     
     opacity: {
       disabled: 0.55,
@@ -185,61 +174,17 @@ export const bitfunLightTheme: ThemeConfig = {
       lazy: '1s',
     },
     
-    easing: {
-      standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
-      decelerate: 'cubic-bezier(0, 0, 0.2, 1)',
-      accelerate: 'cubic-bezier(0.4, 0, 1, 1)',
-      bounce: 'cubic-bezier(0.68, -0.55, 0.265, 1.55)',
-      smooth: 'cubic-bezier(0.4, 0, 0.2, 1)',
-    },
+    easing: createStandardEasing(),
   },
   
   
-  typography: {
-    font: {
-      sans: "'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif",
-      mono: "'JetBrains Mono', 'FiraCode', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Cascadia Code', Consolas, 'Liberation Mono', 'Courier New', monospace",
-    },
-    
-    weight: {
-      normal: 400,
-      medium: 500,
-      semibold: 600,
-      bold: 700,
-    },
-    
-    size: {
-      xs: '12px',
-      sm: '13px',
-      base: '14px',
-      lg: '15px',
-      xl: '16px',
-      '2xl': '18px',
-      '3xl': '22px',
-      '4xl': '26px',
-      '5xl': '32px',
-    },
-    
-    lineHeight: {
-      tight: 1.2,
-      base: 1.5,
-      relaxed: 1.6,
-    },
-  },
+  typography: createStandardTypography(),
   
   
   components: {
     
-    windowControls: {
-      minimize: {
-        dot: 'rgba(100, 116, 139, 0.5)',
-        dotShadow: '0 0 4px rgba(15, 23, 42, 0.12)',
-        hoverBg: 'rgba(15, 23, 42, 0.08)',
-        hoverColor: '#475569',
-        hoverBorder: 'rgba(100, 116, 139, 0.28)',
-        hoverShadow: '0 2px 8px rgba(15, 23, 42, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.6)',
-      },
-      maximize: {
+    windowControls: createWindowControls({
+      standard: {
         dot: 'rgba(100, 116, 139, 0.5)',
         dotShadow: '0 0 4px rgba(15, 23, 42, 0.12)',
         hoverBg: 'rgba(15, 23, 42, 0.08)',
@@ -261,7 +206,7 @@ export const bitfunLightTheme: ThemeConfig = {
         disabledDot: 'rgba(100, 116, 139, 0.15)',
         flowGradient: 'linear-gradient(90deg, transparent, rgba(100, 116, 139, 0.06), rgba(100, 116, 139, 0.1), rgba(100, 116, 139, 0.06), transparent)',
       },
-    },
+    }),
     
     button: {
       

--- a/src/web-ui/src/infrastructure/theme/presets/midnight-theme.ts
+++ b/src/web-ui/src/infrastructure/theme/presets/midnight-theme.ts
@@ -1,6 +1,13 @@
  
 
 import { ThemeConfig } from '../types';
+import {
+  createStandardEasing,
+  createStandardRadius,
+  createStandardSpacing,
+  createStandardTypography,
+  createWindowControls,
+} from './shared';
 
 export const bitfunMidnightTheme: ThemeConfig = {
   
@@ -133,27 +140,9 @@ export const bitfunMidnightTheme: ThemeConfig = {
       intense: 'blur(20px) saturate(1.4) brightness(1.1)',
     },
     
-    radius: {
-      sm: '6px',
-      base: '8px',
-      lg: '12px',
-      xl: '16px',
-      '2xl': '20px',
-      full: '9999px',
-    },
+    radius: createStandardRadius(),
     
-    spacing: {
-      1: '4px',
-      2: '8px',
-      3: '12px',
-      4: '16px',
-      5: '20px',
-      6: '24px',
-      8: '32px',
-      10: '40px',
-      12: '48px',
-      16: '64px',
-    },
+    spacing: createStandardSpacing(),
     
     opacity: {
       disabled: 0.5,
@@ -173,61 +162,17 @@ export const bitfunMidnightTheme: ThemeConfig = {
       lazy: '1s',
     },
     
-    easing: {
-      standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
-      decelerate: 'cubic-bezier(0, 0, 0.2, 1)',
-      accelerate: 'cubic-bezier(0.4, 0, 1, 1)',
-      bounce: 'cubic-bezier(0.68, -0.55, 0.265, 1.55)',
-      smooth: 'cubic-bezier(0.4, 0, 0.2, 1)',
-    },
+    easing: createStandardEasing(),
   },
   
   
-  typography: {
-    font: {
-      sans: "'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif",
-      mono: "'JetBrains Mono', 'FiraCode', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Cascadia Code', Consolas, 'Liberation Mono', 'Courier New', monospace",
-    },
-    
-    weight: {
-      normal: 400,
-      medium: 500,
-      semibold: 600,
-      bold: 700,
-    },
-    
-    size: {
-      xs: '12px',
-      sm: '13px',
-      base: '14px',
-      lg: '15px',
-      xl: '16px',
-      '2xl': '18px',
-      '3xl': '22px',
-      '4xl': '26px',
-      '5xl': '32px',
-    },
-    
-    lineHeight: {
-      tight: 1.2,
-      base: 1.5,
-      relaxed: 1.6,
-    },
-  },
+  typography: createStandardTypography(),
   
   
   components: {
     
-    windowControls: {
-      minimize: {
-        dot: 'rgba(88, 166, 255, 0.45)',
-        dotShadow: '0 0 4px rgba(88, 166, 255, 0.2)',
-        hoverBg: 'rgba(88, 166, 255, 0.12)',
-        hoverColor: '#58a6ff',
-        hoverBorder: 'rgba(88, 166, 255, 0.2)',
-        hoverShadow: '0 2px 8px rgba(88, 166, 255, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
-      },
-      maximize: {
+    windowControls: createWindowControls({
+      standard: {
         dot: 'rgba(88, 166, 255, 0.45)',
         dotShadow: '0 0 4px rgba(88, 166, 255, 0.2)',
         hoverBg: 'rgba(88, 166, 255, 0.12)',
@@ -249,7 +194,7 @@ export const bitfunMidnightTheme: ThemeConfig = {
         disabledDot: 'rgba(188, 190, 196, 0.1)',
         flowGradient: 'linear-gradient(90deg, transparent, rgba(188, 190, 196, 0.05), rgba(188, 190, 196, 0.08), rgba(188, 190, 196, 0.05), transparent)',
       },
-    },
+    }),
     
     button: {
       

--- a/src/web-ui/src/infrastructure/theme/presets/shared.ts
+++ b/src/web-ui/src/infrastructure/theme/presets/shared.ts
@@ -1,0 +1,182 @@
+import type {
+  BorderColors,
+  ElementBackgrounds,
+  RadiusConfig,
+  ScrollbarColors,
+  ThemeConfig,
+  WindowControlsConfig,
+} from '../types';
+
+type WindowControlState = WindowControlsConfig['minimize'];
+
+export function createWindowControls(config: {
+  standard: WindowControlState;
+  close: WindowControlState;
+  common: WindowControlsConfig['common'];
+}): WindowControlsConfig {
+  return {
+    minimize: { ...config.standard },
+    maximize: { ...config.standard },
+    close: { ...config.close },
+    common: { ...config.common },
+  };
+}
+
+export function createStandardTypography(): ThemeConfig['typography'] {
+  return {
+    font: {
+      sans: "'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+      mono: "'JetBrains Mono', 'FiraCode', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Cascadia Code', Consolas, 'Liberation Mono', 'Courier New', monospace",
+    },
+    weight: {
+      normal: 400,
+      medium: 500,
+      semibold: 600,
+      bold: 700,
+    },
+    size: {
+      xs: '12px',
+      sm: '13px',
+      base: '14px',
+      lg: '15px',
+      xl: '16px',
+      '2xl': '18px',
+      '3xl': '22px',
+      '4xl': '26px',
+      '5xl': '32px',
+    },
+    lineHeight: {
+      tight: 1.2,
+      base: 1.5,
+      relaxed: 1.6,
+    },
+  };
+}
+
+export function createExpressiveTypography(): ThemeConfig['typography'] {
+  return {
+    ...createStandardTypography(),
+    lineHeight: {
+      tight: 1.3,
+      base: 1.5,
+      relaxed: 1.65,
+    },
+  };
+}
+
+export function createChinaTypography(): ThemeConfig['typography'] {
+  return {
+    font: {
+      sans: "'Noto Sans SC', 'Source Han Sans CN', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+      mono: "'Source Han Mono CN', 'Noto Sans Mono CJK SC', 'JetBrains Mono', 'FiraCode', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Cascadia Code', Consolas, 'Liberation Mono', 'Courier New', monospace",
+    },
+    weight: {
+      normal: 400,
+      medium: 500,
+      semibold: 600,
+      bold: 700,
+    },
+    size: {
+      xs: '12px',
+      sm: '13px',
+      base: '14px',
+      lg: '15px',
+      xl: '16px',
+      '2xl': '18px',
+      '3xl': '22px',
+      '4xl': '26px',
+      '5xl': '32px',
+    },
+    lineHeight: {
+      tight: 1.3,
+      base: 1.6,
+      relaxed: 1.8,
+    },
+  };
+}
+
+export function createStandardSpacing(): ThemeConfig['effects']['spacing'] {
+  return {
+    1: '4px',
+    2: '8px',
+    3: '12px',
+    4: '16px',
+    5: '20px',
+    6: '24px',
+    8: '32px',
+    10: '40px',
+    12: '48px',
+    16: '64px',
+  };
+}
+
+export function createStandardRadius(): RadiusConfig {
+  return {
+    sm: '6px',
+    base: '8px',
+    lg: '12px',
+    xl: '16px',
+    '2xl': '20px',
+    full: '9999px',
+  };
+}
+
+export function createCompactRadius(): RadiusConfig {
+  return {
+    sm: '4px',
+    base: '6px',
+    lg: '10px',
+    xl: '14px',
+    '2xl': '18px',
+    full: '9999px',
+  };
+}
+
+export function createSlateRadius(): RadiusConfig {
+  return {
+    sm: '4px',
+    base: '6px',
+    lg: '8px',
+    xl: '12px',
+    '2xl': '16px',
+    full: '9999px',
+  };
+}
+
+export function createStandardEasing(smooth = 'cubic-bezier(0.4, 0, 0.2, 1)'): ThemeConfig['motion']['easing'] {
+  return {
+    standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
+    decelerate: 'cubic-bezier(0, 0, 0.2, 1)',
+    accelerate: 'cubic-bezier(0.4, 0, 1, 1)',
+    bounce: 'cubic-bezier(0.68, -0.55, 0.265, 1.55)',
+    smooth,
+  };
+}
+
+export function createDarkNeutralBorder(): BorderColors {
+  return {
+    subtle: 'rgba(255, 255, 255, 0.12)',
+    base: 'rgba(255, 255, 255, 0.18)',
+    medium: 'rgba(255, 255, 255, 0.24)',
+    strong: 'rgba(255, 255, 255, 0.32)',
+    prominent: 'rgba(255, 255, 255, 0.4)',
+  };
+}
+
+export function createDarkNeutralElement(): ElementBackgrounds {
+  return {
+    subtle: 'rgba(255, 255, 255, 0.05)',
+    soft: 'rgba(255, 255, 255, 0.07)',
+    base: 'rgba(255, 255, 255, 0.095)',
+    medium: 'rgba(255, 255, 255, 0.125)',
+    strong: 'rgba(255, 255, 255, 0.155)',
+    elevated: 'rgba(255, 255, 255, 0.19)',
+  };
+}
+
+export function createDarkNeutralScrollbar(): ScrollbarColors {
+  return {
+    thumb: 'rgba(255, 255, 255, 0.15)',
+    thumbHover: 'rgba(255, 255, 255, 0.28)',
+  };
+}

--- a/src/web-ui/src/infrastructure/theme/presets/slate-theme.ts
+++ b/src/web-ui/src/infrastructure/theme/presets/slate-theme.ts
@@ -1,6 +1,16 @@
  
 
 import { ThemeConfig } from '../types';
+import {
+  createDarkNeutralBorder,
+  createDarkNeutralElement,
+  createDarkNeutralScrollbar,
+  createSlateRadius,
+  createStandardEasing,
+  createStandardSpacing,
+  createStandardTypography,
+  createWindowControls,
+} from './shared';
 
 export const bitfunSlateTheme: ThemeConfig = {
   
@@ -83,22 +93,9 @@ export const bitfunSlateTheme: ThemeConfig = {
       highlightBg: 'rgba(255, 255, 255, 0.1)',
     },
     
-    border: {
-      subtle: 'rgba(255, 255, 255, 0.12)',    
-      base: 'rgba(255, 255, 255, 0.18)',      
-      medium: 'rgba(255, 255, 255, 0.24)',    
-      strong: 'rgba(255, 255, 255, 0.32)',    
-      prominent: 'rgba(255, 255, 255, 0.4)',  
-    },
+    border: createDarkNeutralBorder(),
     
-    element: {
-      subtle: 'rgba(255, 255, 255, 0.05)',
-      soft: 'rgba(255, 255, 255, 0.07)',
-      base: 'rgba(255, 255, 255, 0.095)',
-      medium: 'rgba(255, 255, 255, 0.125)',
-      strong: 'rgba(255, 255, 255, 0.155)',
-      elevated: 'rgba(255, 255, 255, 0.19)',
-    },
+    element: createDarkNeutralElement(),
     
     git: {
       branch: '#9ca6b8',
@@ -113,10 +110,7 @@ export const bitfunSlateTheme: ThemeConfig = {
       stagedBg: 'rgba(127, 184, 153, 0.1)',
     },
     
-    scrollbar: {
-      thumb: 'rgba(255, 255, 255, 0.15)',
-      thumbHover: 'rgba(255, 255, 255, 0.28)',
-    },
+    scrollbar: createDarkNeutralScrollbar(),
   },
   
   
@@ -144,27 +138,9 @@ export const bitfunSlateTheme: ThemeConfig = {
       intense: 'blur(20px) saturate(1.18) brightness(0.96)',
     },
     
-    radius: {
-      sm: '4px',
-      base: '6px',
-      lg: '8px',
-      xl: '12px',
-      '2xl': '16px',
-      full: '9999px',
-    },
+    radius: createSlateRadius(),
     
-    spacing: {
-      1: '4px',
-      2: '8px',
-      3: '12px',
-      4: '16px',
-      5: '20px',
-      6: '24px',
-      8: '32px',
-      10: '40px',
-      12: '48px',
-      16: '64px',
-    },
+    spacing: createStandardSpacing(),
     
     opacity: {
       disabled: 0.5,
@@ -184,61 +160,17 @@ export const bitfunSlateTheme: ThemeConfig = {
       lazy: '0.8s',
     },
     
-    easing: {
-      standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
-      decelerate: 'cubic-bezier(0, 0, 0.2, 1)',
-      accelerate: 'cubic-bezier(0.4, 0, 1, 1)',
-      bounce: 'cubic-bezier(0.68, -0.55, 0.265, 1.55)',
-      smooth: 'cubic-bezier(0.4, 0, 0.2, 1)',
-    },
+    easing: createStandardEasing(),
   },
   
   
-  typography: {
-    font: {
-      sans: "'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif",
-      mono: "'JetBrains Mono', 'FiraCode', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Cascadia Code', Consolas, 'Liberation Mono', 'Courier New', monospace",
-    },
-    
-    weight: {
-      normal: 400,
-      medium: 500,
-      semibold: 600,
-      bold: 700,
-    },
-    
-    size: {
-      xs: '12px',
-      sm: '13px',
-      base: '14px',
-      lg: '15px',
-      xl: '16px',
-      '2xl': '18px',
-      '3xl': '22px',
-      '4xl': '26px',
-      '5xl': '32px',
-    },
-    
-    lineHeight: {
-      tight: 1.2,
-      base: 1.5,
-      relaxed: 1.6,
-    },
-  },
+  typography: createStandardTypography(),
   
   
   components: {
     
-    windowControls: {
-      minimize: {
-        dot: 'rgba(203, 213, 225, 0.42)',
-        dotShadow: '0 0 4px rgba(0, 0, 0, 0.35)',
-        hoverBg: 'rgba(255, 255, 255, 0.09)',
-        hoverColor: '#e2e6eb',
-        hoverBorder: 'rgba(255, 255, 255, 0.14)',
-        hoverShadow: '0 2px 8px rgba(0, 0, 0, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.06)',
-      },
-      maximize: {
+    windowControls: createWindowControls({
+      standard: {
         dot: 'rgba(203, 213, 225, 0.42)',
         dotShadow: '0 0 4px rgba(0, 0, 0, 0.35)',
         hoverBg: 'rgba(255, 255, 255, 0.09)',
@@ -260,7 +192,7 @@ export const bitfunSlateTheme: ThemeConfig = {
         disabledDot: 'rgba(168, 171, 176, 0.2)',
         flowGradient: 'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.05), transparent)',
       },
-    },
+    }),
     
     button: {
       

--- a/src/web-ui/src/infrastructure/theme/presets/themePresetOutput.test.ts
+++ b/src/web-ui/src/infrastructure/theme/presets/themePresetOutput.test.ts
@@ -1,0 +1,63 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import { builtinThemes } from './index';
+
+function hashTheme(theme: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(theme))
+    .digest('hex');
+}
+
+describe('builtin theme preset output', () => {
+  it('keeps resolved preset objects stable across helper refactors', () => {
+    expect(builtinThemes.map(theme => ({
+      id: theme.id,
+      type: theme.type,
+      hash: hashTheme(theme),
+    }))).toMatchInlineSnapshot(`
+      [
+        {
+          "hash": "063f8984522a0be4753e2fa36e47030f8e86cfb09057d617ffbb6c37e3821ef1",
+          "id": "bitfun-light",
+          "type": "light",
+        },
+        {
+          "hash": "466b9c64bb1625b6d191209f289802a388c29fb21d307bd139e9bfda9d4db067",
+          "id": "bitfun-slate",
+          "type": "dark",
+        },
+        {
+          "hash": "51f8ff5912d12b0105b1b595930c4d564381fb1c8ce5c6b9436a97ba31bef80e",
+          "id": "bitfun-dark",
+          "type": "dark",
+        },
+        {
+          "hash": "df6cadb36332f77286c3ac9a862dc8cd7805944ee86ed57af6e1f3b40f4f2e08",
+          "id": "bitfun-midnight",
+          "type": "dark",
+        },
+        {
+          "hash": "46ac5adf2b0dd0bc633f27665e1544893eb57617c123500b2d5b543690eca1f9",
+          "id": "bitfun-china-style",
+          "type": "light",
+        },
+        {
+          "hash": "5b2db0c0dfc253022fadd1d5bc07da65e7f473c27d66fe297cc695a50466699c",
+          "id": "bitfun-china-night",
+          "type": "dark",
+        },
+        {
+          "hash": "e974f329a592a936fe1794f7bedc9f68d1579db1663435175eb429c96e4b37d1",
+          "id": "bitfun-cyber",
+          "type": "dark",
+        },
+        {
+          "hash": "1c391cd9207188d5edf906dabd3f23f28e07952c10f1ee9ebf30432747fc0fa0",
+          "id": "bitfun-tokyo-night",
+          "type": "dark",
+        },
+      ]
+    `);
+  });
+});

--- a/src/web-ui/src/infrastructure/theme/presets/tokyo-night-theme.ts
+++ b/src/web-ui/src/infrastructure/theme/presets/tokyo-night-theme.ts
@@ -1,6 +1,13 @@
 
 
 import { ThemeConfig } from '../types';
+import {
+  createCompactRadius,
+  createExpressiveTypography,
+  createStandardEasing,
+  createStandardSpacing,
+  createWindowControls,
+} from './shared';
 
 /** Colors aligned with the Tokyo Night palette (Enkia / VS Code Tokyo Night). */
 export const bitfunTokyoNightTheme: ThemeConfig = {
@@ -139,27 +146,9 @@ export const bitfunTokyoNightTheme: ThemeConfig = {
       intense: 'blur(20px) saturate(1.35) brightness(1.1)',
     },
 
-    radius: {
-      sm: '4px',
-      base: '6px',
-      lg: '10px',
-      xl: '14px',
-      '2xl': '18px',
-      full: '9999px',
-    },
+    radius: createCompactRadius(),
 
-    spacing: {
-      1: '4px',
-      2: '8px',
-      3: '12px',
-      4: '16px',
-      5: '20px',
-      6: '24px',
-      8: '32px',
-      10: '40px',
-      12: '48px',
-      16: '64px',
-    },
+    spacing: createStandardSpacing(),
 
     opacity: {
       disabled: 0.5,
@@ -178,61 +167,14 @@ export const bitfunTokyoNightTheme: ThemeConfig = {
       lazy: '0.8s',
     },
 
-    easing: {
-      standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
-      decelerate: 'cubic-bezier(0, 0, 0.2, 1)',
-      accelerate: 'cubic-bezier(0.4, 0, 1, 1)',
-      bounce: 'cubic-bezier(0.68, -0.55, 0.265, 1.55)',
-      smooth: 'cubic-bezier(0.25, 0.46, 0.45, 0.94)',
-    },
+    easing: createStandardEasing('cubic-bezier(0.25, 0.46, 0.45, 0.94)'),
   },
 
-  typography: {
-    font: {
-      sans:
-        "'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif",
-      mono:
-        "'JetBrains Mono', 'FiraCode', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Cascadia Code', Consolas, 'Liberation Mono', 'Courier New', monospace",
-    },
-
-    weight: {
-      normal: 400,
-      medium: 500,
-      semibold: 600,
-      bold: 700,
-    },
-
-    size: {
-      xs: '12px',
-      sm: '13px',
-      base: '14px',
-      lg: '15px',
-      xl: '16px',
-      '2xl': '18px',
-      '3xl': '22px',
-      '4xl': '26px',
-      '5xl': '32px',
-    },
-
-    lineHeight: {
-      tight: 1.3,
-      base: 1.5,
-      relaxed: 1.65,
-    },
-  },
+  typography: createExpressiveTypography(),
 
   components: {
-    windowControls: {
-      minimize: {
-        dot: 'rgba(122, 162, 247, 0.55)',
-        dotShadow: '0 0 6px rgba(122, 162, 247, 0.35)',
-        hoverBg: 'rgba(122, 162, 247, 0.14)',
-        hoverColor: '#7aa2f7',
-        hoverBorder: 'rgba(122, 162, 247, 0.35)',
-        hoverShadow:
-          '0 0 12px rgba(122, 162, 247, 0.28), 0 2px 8px rgba(122, 162, 247, 0.15), inset 0 1px 0 rgba(122, 162, 247, 0.18)',
-      },
-      maximize: {
+    windowControls: createWindowControls({
+      standard: {
         dot: 'rgba(122, 162, 247, 0.55)',
         dotShadow: '0 0 6px rgba(122, 162, 247, 0.35)',
         hoverBg: 'rgba(122, 162, 247, 0.14)',
@@ -257,7 +199,7 @@ export const bitfunTokyoNightTheme: ThemeConfig = {
         flowGradient:
           'linear-gradient(90deg, transparent, rgba(122, 162, 247, 0.08), rgba(187, 154, 247, 0.1), rgba(122, 162, 247, 0.08), transparent)',
       },
-    },
+    }),
 
     button: {
       default: {

--- a/src/web-ui/src/tools/editor/themes/bitfun-dark.theme.ts
+++ b/src/web-ui/src/tools/editor/themes/bitfun-dark.theme.ts
@@ -13,6 +13,8 @@
 
 import type { editor } from 'monaco-editor';
 
+const TRANSPARENT_MONACO_BORDER = '#00000000';
+
 /**
  * BitFun Dark Theme Configuration
  * Follows Monaco Editor official theme format
@@ -225,8 +227,8 @@ export const BitFunDarkTheme: editor.IStandaloneThemeData = {
 
   colors: {
     // Global Border
-    'focusBorder': '#00000000',
-    'contrastBorder': '#00000000',
+    'focusBorder': TRANSPARENT_MONACO_BORDER,
+    'contrastBorder': TRANSPARENT_MONACO_BORDER,
 
     // Editor Body
     'editor.background': '#121214',
@@ -276,7 +278,7 @@ export const BitFunDarkTheme: editor.IStandaloneThemeData = {
     // Bracket Matching
     'editorBracketMatch.background': '#E1AB8030',
     'editorBracketMatch.border': '#E1AB80',
-    'editorBracketHighlight.foreground1': '#FFD700',
+    'editorBracketHighlight.foreground1': '#ffd700',
     'editorBracketHighlight.foreground2': '#E1AB80',
     'editorBracketHighlight.foreground3': '#C792EA',
     'editorBracketHighlight.foreground4': '#4ECDC4',
@@ -298,7 +300,7 @@ export const BitFunDarkTheme: editor.IStandaloneThemeData = {
     'editorHoverWidget.statusBarBackground': '#202024',
 
     // Inlay Hints
-    'editorInlayHint.background': '#00000000',
+    'editorInlayHint.background': TRANSPARENT_MONACO_BORDER,
     'editorInlayHint.foreground': '#6A737D',
     'editorInlayHint.typeForeground': '#6A737D',
     'editorInlayHint.parameterForeground': '#6A737D',
@@ -359,12 +361,12 @@ export const BitFunDarkTheme: editor.IStandaloneThemeData = {
     // Diff Editor (GitHub Dark style)
     'diffEditor.insertedTextBackground': '#23863625',
     'diffEditor.insertedLineBackground': '#23863630',
-    'diffEditor.insertedTextBorder': '#00000000',
+    'diffEditor.insertedTextBorder': TRANSPARENT_MONACO_BORDER,
     'diffEditorGutter.insertedLineBackground': '#23863638',
 
     'diffEditor.removedTextBackground': '#DA363325',
     'diffEditor.removedLineBackground': '#DA363330',
-    'diffEditor.removedTextBorder': '#00000000',
+    'diffEditor.removedTextBorder': TRANSPARENT_MONACO_BORDER,
     'diffEditorGutter.removedLineBackground': '#DA363338',
 
     'diffEditor.modifiedTextBackground': '#1F6FEB20',

--- a/src/web-ui/src/tools/generative-widget/themePayload.test.ts
+++ b/src/web-ui/src/tools/generative-widget/themePayload.test.ts
@@ -1,0 +1,83 @@
+import { createHash } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  WIDGET_THEME_FALLBACK_VARS,
+  createWidgetThemeFallbackCss,
+  readWidgetThemePayload,
+} from './themePayload';
+
+const WIDGET_THEME_VAR_NAMES_HASH = 'c33a807d44e85a0771a50bfc9277eb98ffbd717d9b750ff742aab06420cc46ed';
+
+function readPayloadWithHostValues(hostValues: Record<string, string> = {}) {
+  const requestedNames: string[] = [];
+  const root = {
+    getAttribute(name: string): string | null {
+      if (name === 'data-theme') {
+        return 'test-theme';
+      }
+      if (name === 'data-theme-type') {
+        return 'dark';
+      }
+      return null;
+    },
+  };
+
+  vi.stubGlobal('document', { documentElement: root });
+  vi.stubGlobal('window', {
+    getComputedStyle: () => ({
+      getPropertyValue: (name: string) => {
+        requestedNames.push(name);
+        return hostValues[name] || '';
+      },
+    }),
+  });
+
+  return {
+    payload: readWidgetThemePayload(),
+    requestedNames,
+  };
+}
+
+function hashNames(names: string[]): string {
+  return createHash('sha256')
+    .update(names.join('\n'))
+    .digest('hex');
+}
+
+describe('generated widget theme payload contract', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps the host payload allowlist stable without exposing it as API', () => {
+    const { requestedNames } = readPayloadWithHostValues();
+
+    expect(new Set(requestedNames).size).toBe(requestedNames.length);
+    expect({
+      count: requestedNames.length,
+      hash: hashNames(requestedNames),
+      first: requestedNames[0],
+      last: requestedNames[requestedNames.length - 1],
+    }).toEqual({
+      count: 323,
+      hash: WIDGET_THEME_VAR_NAMES_HASH,
+      first: '--color-bg-primary',
+      last: '--tool-card-action-font-weight',
+    });
+  });
+
+  it('includes every static iframe fallback key in the host payload allowlist', () => {
+    const { payload } = readPayloadWithHostValues();
+
+    expect(payload?.vars).toEqual(WIDGET_THEME_FALLBACK_VARS);
+  });
+
+  it('renders fallback CSS from the same reviewed fallback map', () => {
+    const css = createWidgetThemeFallbackCss();
+
+    for (const [name, value] of Object.entries(WIDGET_THEME_FALLBACK_VARS)) {
+      expect(css).toContain(`      ${name}: ${value};`);
+    }
+  });
+});

--- a/src/web-ui/src/tools/generative-widget/themePayload.ts
+++ b/src/web-ui/src/tools/generative-widget/themePayload.ts
@@ -4,27 +4,53 @@ export type WidgetThemePayload = {
   vars: Record<string, string>;
 };
 
-export const WIDGET_THEME_FALLBACK_VARS = {
-  '--color-text-primary': '#e8e8e8',
-  '--color-text-secondary': '#b0b0b0',
-  '--color-text-muted': '#858585',
-  '--color-accent-500': '#60a5fa',
-  '--color-accent-600': '#3b82f6',
-  '--color-bg-secondary': '#1c1c1f',
-  '--color-success': '#34d399',
-  '--color-warning': '#f59e0b',
-  '--color-error': '#ef4444',
-  '--color-static-white': '#ffffff',
-  '--border-subtle': 'rgba(255, 255, 255, 0.1)',
-  '--border-base': 'rgba(255, 255, 255, 0.16)',
-  '--border-medium': 'rgba(255, 255, 255, 0.24)',
-  '--element-bg-subtle': 'rgba(255, 255, 255, 0.05)',
-  '--element-bg-base': 'rgba(255, 255, 255, 0.08)',
-  '--element-bg-medium': 'rgba(255, 255, 255, 0.14)',
-  '--element-bg-soft': 'rgba(255, 255, 255, 0.08)',
-  '--shadow-xs': '0 1px 2px rgba(0, 0, 0, 0.4)',
-  '--shadow-sm': '0 2px 4px rgba(0, 0, 0, 0.4)',
+const FALLBACK_VAR = {
+  textPrimary: '--color-text-primary',
+  textSecondary: '--color-text-secondary',
+  textMuted: '--color-text-muted',
+  accent500: '--color-accent-500',
+  accent600: '--color-accent-600',
+  bgSecondary: '--color-bg-secondary',
+  success: '--color-success',
+  warning: '--color-warning',
+  error: '--color-error',
+  staticWhite: '--color-static-white',
+  borderSubtle: '--border-subtle',
+  borderBase: '--border-base',
+  borderMedium: '--border-medium',
+  elementBgSubtle: '--element-bg-subtle',
+  elementBgBase: '--element-bg-base',
+  elementBgMedium: '--element-bg-medium',
+  elementBgSoft: '--element-bg-soft',
+  shadowXs: '--shadow-xs',
+  shadowSm: '--shadow-sm',
 } as const;
+
+type WidgetThemeFallbackVarName = typeof FALLBACK_VAR[keyof typeof FALLBACK_VAR];
+
+// Keep this fallback map small and self-contained. It is the last-resort iframe
+// contract for static widget rendering before the host theme payload arrives.
+export const WIDGET_THEME_FALLBACK_VARS = {
+  [FALLBACK_VAR.textPrimary]: '#e8e8e8',
+  [FALLBACK_VAR.textSecondary]: '#b0b0b0',
+  [FALLBACK_VAR.textMuted]: '#858585',
+  [FALLBACK_VAR.accent500]: '#60a5fa',
+  [FALLBACK_VAR.accent600]: '#3b82f6',
+  [FALLBACK_VAR.bgSecondary]: '#1c1c1f',
+  [FALLBACK_VAR.success]: '#34d399',
+  [FALLBACK_VAR.warning]: '#f59e0b',
+  [FALLBACK_VAR.error]: '#ef4444',
+  [FALLBACK_VAR.staticWhite]: '#ffffff',
+  [FALLBACK_VAR.borderSubtle]: 'rgba(255, 255, 255, 0.1)',
+  [FALLBACK_VAR.borderBase]: 'rgba(255, 255, 255, 0.16)',
+  [FALLBACK_VAR.borderMedium]: 'rgba(255, 255, 255, 0.24)',
+  [FALLBACK_VAR.elementBgSubtle]: 'rgba(255, 255, 255, 0.05)',
+  [FALLBACK_VAR.elementBgBase]: 'rgba(255, 255, 255, 0.08)',
+  [FALLBACK_VAR.elementBgMedium]: 'rgba(255, 255, 255, 0.14)',
+  [FALLBACK_VAR.elementBgSoft]: 'rgba(255, 255, 255, 0.08)',
+  [FALLBACK_VAR.shadowXs]: '0 1px 2px rgba(0, 0, 0, 0.4)',
+  [FALLBACK_VAR.shadowSm]: '0 2px 4px rgba(0, 0, 0, 0.4)',
+} as const satisfies Record<WidgetThemeFallbackVarName, string>;
 
 export function createWidgetThemeFallbackCss(): string {
   return Object.entries(WIDGET_THEME_FALLBACK_VARS)
@@ -32,9 +58,12 @@ export function createWidgetThemeFallbackCss(): string {
     .join('\n');
 }
 
-const THEME_VAR_NAMES = [
+// Host -> generated-widget iframe theme contract. Keep groups explicit so
+// isolated widgets receive stable tokens without scraping every root variable.
+const WIDGET_THEME_VAR_GROUPS = {
+  staticAndOverlay: [
   '--color-bg-primary',
-  '--color-static-white',
+  FALLBACK_VAR.staticWhite,
   '--color-static-black',
   '--color-overlay-white-02',
   '--color-overlay-white-03',
@@ -58,7 +87,9 @@ const THEME_VAR_NAMES = [
   '--color-overlay-black-40',
   '--color-overlay-black-50',
   '--color-overlay-black-80',
-  '--color-bg-secondary',
+  ],
+  backgroundSurface: [
+  FALLBACK_VAR.bgSecondary,
   '--color-bg-tertiary',
   '--color-bg-quaternary',
   '--color-bg-elevated',
@@ -85,23 +116,27 @@ const THEME_VAR_NAMES = [
   '--color-surface-elevated',
   '--color-surface-hover',
   '--color-bg-tooltip',
-  '--color-text-primary',
-  '--color-text-secondary',
+  ],
+  text: [
+  FALLBACK_VAR.textPrimary,
+  FALLBACK_VAR.textSecondary,
   '--color-text-tertiary',
   '--text-primary',
   '--text-secondary',
   '--text-tertiary',
   '--text-muted',
   '--text-disabled',
-  '--color-text-muted',
+  FALLBACK_VAR.textMuted,
   '--color-text-disabled',
+  ],
+  accent: [
   '--color-accent-50',
   '--color-accent-100',
   '--color-accent-200',
   '--color-accent-300',
   '--color-accent-400',
-  '--color-accent-500',
-  '--color-accent-600',
+  FALLBACK_VAR.accent500,
+  FALLBACK_VAR.accent600,
   '--color-accent-700',
   '--color-accent-800',
   '--color-accent',
@@ -117,18 +152,20 @@ const THEME_VAR_NAMES = [
   '--color-primary-bg-subtle',
   '--accent-primary',
   '--accent-primary-hover',
-  '--color-success',
+  ],
+  semantic: [
+  FALLBACK_VAR.success,
   '--color-success-bg',
   '--color-success-border',
   '--color-success-100',
   '--color-success-500',
-  '--color-warning',
+  FALLBACK_VAR.warning,
   '--color-warning-bg',
   '--color-warning-border',
   '--color-warning-100',
   '--color-warning-500',
   '--color-warning-700',
-  '--color-error',
+  FALLBACK_VAR.error,
   '--color-error-bg',
   '--color-error-border',
   '--color-semantic-error',
@@ -141,10 +178,12 @@ const THEME_VAR_NAMES = [
   '--color-info',
   '--color-info-bg',
   '--color-info-border',
-  '--border-subtle',
+  ],
+  border: [
+  FALLBACK_VAR.borderSubtle,
   '--border-color',
-  '--border-base',
-  '--border-medium',
+  FALLBACK_VAR.borderBase,
+  FALLBACK_VAR.borderMedium,
   '--border-hover',
   '--border-strong',
   '--border-prominent',
@@ -153,6 +192,8 @@ const THEME_VAR_NAMES = [
   '--color-border',
   '--color-border-primary',
   '--color-border-subtle',
+  ],
+  zIndex: [
   '--z-base',
   '--z-decoration',
   '--z-content',
@@ -172,10 +213,12 @@ const THEME_VAR_NAMES = [
   '--z-notification',
   '--z-context-menu',
   '--z-extreme',
-  '--element-bg-subtle',
-  '--element-bg-soft',
-  '--element-bg-base',
-  '--element-bg-medium',
+  ],
+  elementGlassShadow: [
+  FALLBACK_VAR.elementBgSubtle,
+  FALLBACK_VAR.elementBgSoft,
+  FALLBACK_VAR.elementBgBase,
+  FALLBACK_VAR.elementBgMedium,
   '--element-bg-strong',
   '--element-bg-elevated',
   '--element-bg',
@@ -196,11 +239,13 @@ const THEME_VAR_NAMES = [
   '--glass-shadow-base',
   '--glass-shadow-lg',
   '--glass-shadow-xl',
-  '--shadow-xs',
-  '--shadow-sm',
+  FALLBACK_VAR.shadowXs,
+  FALLBACK_VAR.shadowSm,
   '--shadow-base',
   '--shadow-lg',
   '--shadow-xl',
+  ],
+  shapeSpacingTypography: [
   '--radius-sm',
   '--radius-base',
   '--radius-md',
@@ -246,6 +291,8 @@ const THEME_VAR_NAMES = [
   '--opacity-disabled',
   '--opacity-hover',
   '--opacity-focus',
+  ],
+  flowChat: [
   '--flowchat-font-size-xxs',
   '--flowchat-font-size-2xs',
   '--flowchat-font-size-xs',
@@ -291,10 +338,14 @@ const THEME_VAR_NAMES = [
   '--flowchat-markdown-code-block-pad-x',
   '--flowchat-markdown-table-cell-pad-y',
   '--flowchat-markdown-table-cell-pad-x',
+  ],
+  navigation: [
   '--bitfun-nav-row-action-size',
   '--bitfun-nav-row-action-icon-size',
   '--bitfun-nav-row-action-offset',
   '--bitfun-nav-row-action-gap',
+  ],
+  motionAndFonts: [
   '--motion-fast',
   '--motion-normal',
   '--motion-base',
@@ -308,6 +359,8 @@ const THEME_VAR_NAMES = [
   '--markdown-font-mono',
   '--tool-card-font-mono',
   '--tool-compact-summary-font',
+  ],
+  buttons: [
   '--btn-primary-bg',
   '--btn-primary-color',
   '--btn-primary-border',
@@ -336,6 +389,8 @@ const THEME_VAR_NAMES = [
   '--btn-ghost-active-border',
   '--btn-ghost-active-shadow',
   '--btn-ghost-active-transform',
+  ],
+  toolCard: [
   '--tool-card-bg-primary',
   '--tool-card-bg-secondary',
   '--tool-card-bg-hover',
@@ -356,7 +411,10 @@ const THEME_VAR_NAMES = [
   '--tool-card-action-font-size',
   '--tool-card-action-line-height',
   '--tool-card-action-font-weight',
-] as const;
+  ],
+} as const;
+
+const WIDGET_THEME_VAR_NAMES = Object.values(WIDGET_THEME_VAR_GROUPS).flat();
 
 export function readWidgetThemePayload(): WidgetThemePayload | null {
   if (typeof window === 'undefined' || typeof document === 'undefined') {
@@ -367,7 +425,7 @@ export function readWidgetThemePayload(): WidgetThemePayload | null {
   const styles = window.getComputedStyle(root);
   const vars: Record<string, string> = {};
 
-  for (const name of THEME_VAR_NAMES) {
+  for (const name of WIDGET_THEME_VAR_NAMES) {
     const value = styles.getPropertyValue(name).trim();
     if (value) {
       vars[name] = value;


### PR DESCRIPTION
## Background

Refs #1197. This PR advances the Web UI theme/color governance plan without closing the top-level planning issue. It is rebased on the latest `gcwing/main` observed during this update (`de08aa2e`).

## Changes

- Extract shared theme preset factories for repeated typography, spacing, radius, easing, dark neutral surfaces, scrollbars, and window controls.
- Add a hash-based `builtinThemes` output test so preset helper refactors must remain output-equivalent across all built-in themes.
- Normalize exact-equivalent color literals only: transparent Monaco borders, `#FFD700` casing, `rgba(20, 20, 20, 1)` -> `#141414`, and `rgba(0, 0, 0, 0)` -> `#00000000`.
- Group the generated widget iframe theme payload allowlist by surface while preserving the exact 323-key host payload order.
- Use a single private source for generated-widget fallback CSS var keys, then share it between the fallback map and host allowlist positions.
- Collapse repeated Monaco transparent border key definitions inside the theme sync integration into one private key set.
- Add generated widget payload contract tests for duplicate keys, public-reader coverage, fallback coverage, and fallback CSS generation.
- Tighten color governance baseline budgets for the reduced domains and add explicit domain budgets for high-risk theme surfaces.

## Metrics

| Metric | Before | After |
|---|---:|---:|
| Theme preset color occurrences | 1104 | 1033 |
| Component/non-token color occurrences | 831 | 827 |
| Unique component/non-token colors | 492 | 489 |
| Editor color occurrences | 210 | 206 |
| App UI domain occurrences | 566 | 559 |
| App UI unique colors | 344 | 343 |
| Fallback var occurrences | 31 | 31 |
| Token-equivalent app literal occurrences | 59 | 59 |
| Unresolved / fallback-only / required-missing vars | 0 | 0 |
| Non-contract cross-file / dynamic-input vars | 0 | 0 |

## Risk Review

- Theme preset output was compared against `gcwing/main`: all 8 built-in theme object hashes match exactly, so helper extraction is output-equivalent.
- Generated widget payload grouping was compared against `gcwing/main`: 323 requested keys, same order, no allowlist duplicates, and all 19 fallback keys are still covered.
- Generated widget fallback CSS var literals now have one private source; duplicate CSS var literal definitions in `themePayload.ts` dropped from 19 to 0 without changing the host payload order.
- The widget CSS-var allowlist remains private implementation detail; tests validate through public `readWidgetThemePayload()` behavior rather than exporting the allowlist.
- Monaco transparent border keys are deduplicated inside `MonacoThemeSync` without exporting a cross-module constant or changing editor theme registration.
- Near-identical colors that carry different semantics were not merged, including `#1f2024` vs `#202024` and `#6e7681` vs `#6e7781`.
- Theme audit reports no unresolved, fallback-only, required-missing, runtime-only-required, non-contract cross-file, non-contract dynamic-input, or component-private CSS vars.

## Verification

- `pnpm run theme:color-audit -- --top 20`
- `pnpm --dir src/web-ui exec vitest run src/tools/generative-widget/themePayload.test.ts src/infrastructure/theme/presets/themePresetOutput.test.ts src/infrastructure/theme/integrations/MonacoThemeSync.test.ts`
- base/head one-off checks for built-in theme hashes and widget allowlist order
- `git diff --check HEAD~1..HEAD`
- `pnpm run check:repo-hygiene`
- `pnpm run type-check:web`
- `pnpm run lint:web` (passes with 4 existing warnings outside this diff)
- `pnpm --dir src/web-ui run test:run` (1148 tests)
- `pnpm run build:web` (passes with existing Vite dynamic import/chunk-size warnings)
