### PR TITLE
fix(agent): tighten custom agent discovery and skill output

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/implementations/skill_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/skill_tool.rs
@@ -273,9 +273,14 @@ impl Tool for SkillTool {
             SkillLocation::Project => "project",
         };
 
+        let loaded_from = if use_stable_key {
+            format!(" from stable key '{}'", skill_data.key)
+        } else {
+            String::new()
+        };
         let result_for_assistant = format!(
-            "Skill '{}' loaded successfully from stable key '{}'. Note: any paths mentioned in this skill are relative to {}, not the workspace.\n\n{}",
-            skill_data.name, skill_data.key, skill_data.path, skill_data.content
+            "Skill '{}' loaded successfully{}. Note: any paths mentioned in this skill are relative to {}, not the workspace.\n\n<skill_content>\n{}\n</skill_content>",
+            skill_data.name, loaded_from, skill_data.path, skill_data.content
         );
 
         let result = ToolResult::Result {
@@ -473,7 +478,12 @@ Use the remote project skill.
             .await
             .expect("explicit cso invocation should load the local built-in skill");
 
-        let ToolResult::Result { data, .. } = &results[0] else {
+        let ToolResult::Result {
+            data,
+            result_for_assistant,
+            ..
+        } = &results[0]
+        else {
             panic!("expected result payload");
         };
         assert_eq!(data["skill_name"], "cso");
@@ -482,6 +492,11 @@ Use the remote project skill.
             .as_str()
             .unwrap_or_default()
             .contains("# /cso"));
+        let assistant = result_for_assistant.as_deref().unwrap_or_default();
+        assert!(assistant.contains("<skill_content>\n"));
+        assert!(assistant.contains("\n</skill_content>"));
+        assert!(assistant.contains("# /cso"));
+        assert!(!assistant.contains("from stable key"));
     }
 
     #[tokio::test]
@@ -507,7 +522,12 @@ Use the remote project skill.
             .await
             .expect("stable key should load BitFun's built-in ppt-design skill");
 
-        let ToolResult::Result { data, .. } = &results[0] else {
+        let ToolResult::Result {
+            data,
+            result_for_assistant,
+            ..
+        } = &results[0]
+        else {
             panic!("expected result payload");
         };
         assert_eq!(data["skill_name"], "ppt-design");
@@ -517,6 +537,11 @@ Use the remote project skill.
             .as_str()
             .unwrap_or_default()
             .contains("references/editable-pptx.md"));
+        let assistant = result_for_assistant.as_deref().unwrap_or_default();
+        assert!(assistant.contains("from stable key 'user::bitfun-system::ppt-design'"));
+        assert!(assistant.contains("<skill_content>\n"));
+        assert!(assistant.contains("\n</skill_content>"));
+        assert!(assistant.contains("references/editable-pptx.md"));
     }
 
     struct OrderingRemoteFs;

--- a/src/crates/execution/agent-runtime/src/custom_agent.rs
+++ b/src/crates/execution/agent-runtime/src/custom_agent.rs
@@ -28,12 +28,9 @@ pub const DEFAULT_CUSTOM_SUBAGENT_READONLY: bool = true;
 pub const DEFAULT_CUSTOM_SUBAGENT_REVIEW: bool = false;
 pub const DEFAULT_CUSTOM_MODE_MODEL: &str = "auto";
 pub const DEFAULT_CUSTOM_SUBAGENT_MODEL: &str = "fast";
-pub const CUSTOM_AGENT_PROJECT_AGENT_SUBDIRS: &[(&str, &str)] = &[
-    (".bitfun", "agents"),
-    (".claude", "agents"),
-    (".cursor", "agents"),
-    (".codex", "agents"),
-];
+// Only BitFun custom agents are loaded. Unlike skills, custom subagents from
+// different vendors do not share a stable schema or compatible tool contract.
+pub const CUSTOM_AGENT_PROJECT_AGENT_SUBDIRS: &[(&str, &str)] = &[(".bitfun", "agents")];
 pub const CUSTOM_AGENT_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -342,21 +339,6 @@ pub fn custom_agent_possible_dirs(roots: &CustomAgentDiscoveryRoots) -> Vec<Cust
                 path: bitfun_agents.clone(),
                 level: CustomAgentLevel::User,
             });
-        }
-    }
-
-    if let Some(home) = &roots.home_dir {
-        for (parent, sub) in CUSTOM_AGENT_PROJECT_AGENT_SUBDIRS {
-            if *parent == ".bitfun" {
-                continue;
-            }
-            let path = home.join(parent).join(sub);
-            if path.exists() && path.is_dir() {
-                entries.push(CustomAgentDirEntry {
-                    path,
-                    level: CustomAgentLevel::User,
-                });
-            }
         }
     }
 

--- a/src/crates/execution/agent-runtime/tests/custom_agent_mode_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/custom_agent_mode_contracts.rs
@@ -1,5 +1,5 @@
 use bitfun_agent_runtime::custom_agent::{
-    custom_agent_read_markdown_file, custom_agent_read_markdown_str,
+    custom_agent_possible_dirs, custom_agent_read_markdown_file, custom_agent_read_markdown_str,
     custom_agent_review_writable_tools, custom_agent_save_markdown_file,
     default_custom_agent_tools, default_custom_agent_user_context_policy,
     load_custom_agent_definitions, validate_custom_agent_definition, CustomAgentDefinition,
@@ -351,6 +351,68 @@ fn custom_agent_validation_forces_review_subagents_to_readonly_tools() {
         ),
         ["Write"]
     );
+}
+
+#[test]
+fn custom_agent_discovery_ignores_non_bitfun_agent_dirs() {
+    let workspace = TestTempDir::new("bitfun-runtime-custom-agent-workspace");
+    let user_root = TestTempDir::new("bitfun-runtime-custom-agent-user");
+    let home = TestTempDir::new("bitfun-runtime-custom-agent-home");
+    let project_bitfun = workspace.path.join(".bitfun").join("agents");
+    let project_claude = workspace.path.join(".claude").join("agents");
+    let user_agents = user_root.path.join("agents");
+    let home_claude = home.path.join(".claude").join("agents");
+    fs::create_dir_all(&project_bitfun).expect("project bitfun agents dir should be created");
+    fs::create_dir_all(&project_claude).expect("project claude agents dir should be created");
+    fs::create_dir_all(&user_agents).expect("user agents dir should be created");
+    fs::create_dir_all(&home_claude).expect("home claude agents dir should be created");
+
+    write_subagent(
+        &project_bitfun.join("project-bitfun.md"),
+        "BitfunProject",
+        CustomAgentLevel::Project,
+    );
+    write_subagent(
+        &project_claude.join("project-claude.md"),
+        "ClaudeProject",
+        CustomAgentLevel::Project,
+    );
+    write_subagent(
+        &user_agents.join("user-bitfun.md"),
+        "BitfunUser",
+        CustomAgentLevel::User,
+    );
+    write_subagent(
+        &home_claude.join("home-claude.md"),
+        "ClaudeHome",
+        CustomAgentLevel::User,
+    );
+
+    let roots = CustomAgentDiscoveryRoots {
+        workspace_root: Some(workspace.path.clone()),
+        bitfun_user_agents_dir: Some(user_agents.clone()),
+        home_dir: Some(home.path.clone()),
+    };
+
+    assert_eq!(
+        custom_agent_possible_dirs(&roots)
+            .iter()
+            .map(|entry| entry.path.as_path())
+            .collect::<Vec<_>>(),
+        vec![project_bitfun.as_path(), user_agents.as_path()]
+    );
+
+    let report = load_custom_agent_definitions(&roots);
+
+    assert_eq!(
+        report
+            .definitions
+            .iter()
+            .map(|loaded| loaded.definition.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["BitfunProject", "BitfunUser"]
+    );
+    assert!(report.errors.is_empty());
 }
 
 struct TestTempDir {


### PR DESCRIPTION
- Wrap loaded skill content in skill_content tags
- Only mention stable keys when a skill is loaded by stable key
- Restrict custom agent discovery to BitFun agent directories
- Add coverage for ignoring third-party agent directories
