### PR TITLE
fix(startup): harden identity listener and rapid-switch guard

### DIFF
--- a/src/web-ui/src/infrastructure/services/business/workspaceManager.test.ts
+++ b/src/web-ui/src/infrastructure/services/business/workspaceManager.test.ts
@@ -272,6 +272,19 @@ describe('WorkspaceManager startup initialization', () => {
     expect(manager.getState().error).toBeNull();
   });
 
+  it('keeps startup workspace state available when identity listener registration throws synchronously', async () => {
+    listenMock.mockImplementation(() => {
+      throw new Error('listener unavailable');
+    });
+    const manager = await getFreshWorkspaceManager();
+
+    await expect(manager.initialize()).resolves.toBeUndefined();
+
+    expect(globalStateMocks.initializeWorkspaceStartupState).toHaveBeenCalledTimes(1);
+    expect(manager.getState().loading).toBe(false);
+    expect(manager.getState().error).toBeNull();
+  });
+
   it('stores the startup legacy remote workspace snapshot for one reconnect pass', async () => {
     const legacyRemoteWorkspace = {
       connectionId: 'conn-1',

--- a/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
+++ b/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
@@ -350,33 +350,41 @@ class WorkspaceManager {
     this.identityListenerReady = false;
     const registrationStartedAt = nowMs();
 
-    this.identityListenerRegistrationPromise = listen<WorkspaceIdentityChangedEvent>(
-      'workspace-identity-changed',
-      event => {
-        this.applyIdentityUpdate(event.payload);
-      }
-    )
-      .then(() => {
-        this.identityListenerReady = true;
-        startupTrace.markPhase('workspace_identity_listener_ready', {
-          durationMs: elapsedMs(registrationStartedAt),
-        });
-        if (this.identityListenerReadyResyncPending && this.isInitialized) {
-          void this.syncWorkspaceStateAfterIdentityListenerReady();
-        }
-      })
-      .catch(error => {
-        this.identityEventListening = false;
-        this.identityListenerReady = false;
-        this.identityListenerReadyResyncPending = false;
-        startupTrace.markPhase('workspace_identity_listener_failed', {
-          durationMs: elapsedMs(registrationStartedAt),
-        });
-        log.error('Failed to subscribe workspace identity updates', { error });
-      })
-      .finally(() => {
-        this.identityListenerRegistrationPromise = null;
+    const handleRegistrationFailure = (error: unknown): void => {
+      this.identityEventListening = false;
+      this.identityListenerReady = false;
+      this.identityListenerReadyResyncPending = false;
+      startupTrace.markPhase('workspace_identity_listener_failed', {
+        durationMs: elapsedMs(registrationStartedAt),
       });
+      log.error('Failed to subscribe workspace identity updates', { error });
+    };
+
+    try {
+      this.identityListenerRegistrationPromise = listen<WorkspaceIdentityChangedEvent>(
+        'workspace-identity-changed',
+        event => {
+          this.applyIdentityUpdate(event.payload);
+        }
+      )
+        .then(() => {
+          this.identityListenerReady = true;
+          startupTrace.markPhase('workspace_identity_listener_ready', {
+            durationMs: elapsedMs(registrationStartedAt),
+          });
+          if (this.identityListenerReadyResyncPending && this.isInitialized) {
+            void this.syncWorkspaceStateAfterIdentityListenerReady();
+          }
+        })
+        .catch(handleRegistrationFailure)
+        .finally(() => {
+          this.identityListenerRegistrationPromise = null;
+        });
+    } catch (error) {
+      handleRegistrationFailure(error);
+      this.identityListenerRegistrationPromise = null;
+      return;
+    }
 
     return this.identityListenerRegistrationPromise;
   }

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -3869,32 +3869,6 @@ function readRapidSwitchSessionIds(): string[] {
   return Array.from(new Set(sessionIds));
 }
 
-function chooseRapidSwitchClickOrder(
-  requestedSessionIds: string[],
-  activeSessionIdAtStart: string | null,
-): string[] {
-  if (!activeSessionIdAtStart) {
-    return requestedSessionIds;
-  }
-
-  const defaultTargetSessionId = requestedSessionIds.at(-1);
-  if (defaultTargetSessionId !== activeSessionIdAtStart) {
-    return requestedSessionIds;
-  }
-
-  const fallbackTargetSessionId = requestedSessionIds
-    .filter(sessionId => sessionId !== activeSessionIdAtStart)
-    .at(-1);
-  if (!fallbackTargetSessionId) {
-    return requestedSessionIds;
-  }
-
-  return [
-    ...requestedSessionIds.filter(sessionId => sessionId !== fallbackTargetSessionId),
-    fallbackTargetSessionId,
-  ];
-}
-
 async function readActiveSessionNavId(): Promise<string | null> {
   return browser.execute(() => {
     const active = document.querySelector<HTMLElement>(
@@ -3903,6 +3877,49 @@ async function readActiveSessionNavId(): Promise<string | null> {
     );
     return active?.getAttribute('data-session-id') ?? null;
   });
+}
+
+async function ensureRapidSwitchTargetStartsInactive(
+  targetSessionId: string,
+  requestedSessionIds: string[],
+): Promise<string | null> {
+  const activeSessionId = await readActiveSessionNavId();
+  if (activeSessionId !== targetSessionId) {
+    return activeSessionId;
+  }
+
+  const setupSessionId = requestedSessionIds.find(sessionId => sessionId !== targetSessionId);
+  if (!setupSessionId) {
+    return activeSessionId;
+  }
+
+  const setupItem = await findSessionItem(setupSessionId);
+  if (!setupItem) {
+    return activeSessionId;
+  }
+
+  const beforeSnapshot = await readStartupTraceSnapshot();
+  const frameCountBefore = countPhase(
+    beforeSnapshot,
+    'historical_session_after_state_commit_frame',
+  );
+  const clickedAtMs = await readPerformanceNow();
+  await setupItem.click();
+  const afterFrameSnapshot = await waitForOptionalTracePhaseForSessionSince(
+    'historical_session_after_state_commit_frame',
+    setupSessionId,
+    clickedAtMs,
+    10000,
+  );
+  if (countPhase(afterFrameSnapshot, 'historical_session_after_state_commit_frame') <= frameCountBefore) {
+    await waitForOptionalPhaseCount(
+      'historical_session_after_state_commit_frame',
+      frameCountBefore + 1,
+      1000,
+    );
+  }
+  await browser.pause(50);
+  return readActiveSessionNavId();
 }
 
 async function collectRapidLongSessionSwitchMeasurement(
@@ -4637,14 +4654,17 @@ describe('Performance telemetry', () => {
     await ensurePerformanceWorkspace(startupPage);
 
     const requestedSessionIds = readRapidSwitchSessionIds();
-    const activeSessionIdAtStart = await readActiveSessionNavId();
-    const sessionIds = chooseRapidSwitchClickOrder(requestedSessionIds, activeSessionIdAtStart);
+    const sessionIds = requestedSessionIds;
     if (sessionIds.length < 3) {
       this.skip();
       return;
     }
 
     const targetSessionId = sessionIds[sessionIds.length - 1];
+    const activeSessionIdAtStart = await ensureRapidSwitchTargetStartsInactive(
+      targetSessionId,
+      requestedSessionIds,
+    );
     const expectedLatestTurnId = await readExpectedLatestTurnId(targetSessionId);
     if (!expectedLatestTurnId) {
       console.log(


### PR DESCRIPTION
## Summary

- Fix the non-blocking workspace identity listener path so both async registration rejection and synchronous `listen()` throw restore listener state, keep startup usable, and do not leave an unhandled promise.
- Fix the rapid-switch performance guard so it always measures the configured target session. If the target is already active, the spec first switches to another requested session outside the measured target click instead of silently changing the target.
- Keep this PR scoped as a follow-up to #1221. It does not claim additional end-to-end performance gain beyond the already-merged startup/session optimization; it prevents a real edge-case startup failure and a misleading rapid-switch measurement path.

Refs #949

## Impact And Data

This PR is a quality/measurement fix on top of #1221, which has already merged. The normal startup/session hot path is not intentionally changed except for failure handling around listener registration.

Latest release-fast guard data from the same content before the final rebase showed the optimized scenarios remain within the accepted range:

| Scenario | Latest Guard Result | Notes |
| --- | ---: | --- |
| Cold startup to shell ready | 534.8 ms | Still below the issue-created baseline; #1232 does not claim a new startup gain |
| First open long session, latest text usable | 255.7 ms | loading/blank/scroll jump = 0/0/0 |
| First open long session, full hydrate end | 562.3 ms | `clickToFullHydrateEndMs`, excludes 3000 ms observation window |
| Warm reopen long session, latest text usable | 245.3 ms | loading/blank/scroll jump = 0/0/0 |
| Rapid switch target click to latest text usable | 195.1 ms | target session remained `perf-long-session-000`; loading/blank/scroll jump = 0/0/0 |
| Rapid switch click action completed to latest text usable | 164.3 ms | target produced fresh restore timings |

The main correctness issue found during review was that the rapid-switch guard could previously switch the measured target away from the configured long session when that target was already active. That made the guard capable of testing a short session while reporting a rapid-switch long-session path. This PR fixes that before relying on the metric.

## Risk And Compatibility

- Workspace identity listener failure handling is now more defensive; successful listener registration behavior is unchanged.
- Rapid-switch E2E setup may perform one pre-measurement click when the configured target is already active. That setup is intentionally outside the measured target click and is recorded through `activeSessionIdAtStart` / requested session ids.
- No desktop close/minimize-to-tray behavior, remote workspace protocol, ACP behavior, session storage format, or product UI behavior is intentionally changed.

## Verification

Current post-rebase checks:

- `pnpm --dir src/web-ui run test:run src/infrastructure/services/business/workspaceManager.test.ts` (7 tests)
- `pnpm --dir src/web-ui run test:run src/app/startup/startupPerformanceContract.test.ts` (39 tests)
- `pnpm run type-check:web`
- `git diff --check gcwing/main...HEAD`

Release-fast guard run used for the table above:

- `pnpm run desktop:build:release-fast`
- `pnpm --dir tests/e2e run fixture:long-session -- --workspace D:\workspace\BitFun\.tmp\e2e-perf-workspace-reload-20260616215729 --session-count 80 --long-turns 80 --last-active-at-base 1800000000000 --last-active-step-ms 1000`
- `pnpm run e2e:test:perf:release-fast` with `BITFUN_E2E_PERF_SESSION_ID=perf-long-session-000` and rapid switch ids `perf-long-session-001,perf-long-session-002,perf-long-session-000` (4 passing)

Known local limitation: `pnpm --dir tests/e2e exec tsc --noEmit --pretty false` still fails on existing project-wide WDIO type and `/src/...` dynamic import resolution issues, including files outside this PR.