### PR TITLE
perf: improve startup and session responsiveness

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,9 @@
     "e2e:test:smoke": "cross-env BITFUN_E2E_APP_MODE=debug pnpm --dir tests/e2e run test:smoke",
     "e2e:test:chat": "cross-env BITFUN_E2E_APP_MODE=debug pnpm --dir tests/e2e run test:chat",
     "e2e:test:perf:debug": "cross-env BITFUN_E2E_APP_MODE=debug E2E_LOG_LEVEL=warn pnpm --dir tests/e2e run test:perf",
-    "e2e:test:perf:release-fast": "cross-env BITFUN_E2E_APP_MODE=release-fast E2E_LOG_LEVEL=warn pnpm --dir tests/e2e run test:perf"
+    "e2e:test:perf:release-fast": "cross-env BITFUN_E2E_APP_MODE=release-fast E2E_LOG_LEVEL=warn pnpm --dir tests/e2e run test:perf",
+    "e2e:test:perf:startup-stability:release-fast": "cross-env BITFUN_E2E_APP_MODE=release-fast E2E_LOG_LEVEL=warn node tests/e2e/scripts/run-startup-stability.mjs",
+    "e2e:test:perf:long-session-interactions:release-fast": "cross-env BITFUN_E2E_APP_MODE=release-fast E2E_LOG_LEVEL=warn node tests/e2e/scripts/run-long-session-interaction-matrix.mjs"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.10.0",

--- a/src/apps/desktop/src/api/system_api.rs
+++ b/src/apps/desktop/src/api/system_api.rs
@@ -3,6 +3,7 @@
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::api::app_state::AppState;
+use crate::startup_trace::DesktopStartupTrace;
 use bitfun_core::service::system;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, Position, Size, State};
@@ -400,7 +401,13 @@ pub async fn quit_app(app: tauri::AppHandle) -> Result<(), String> {
 /// Hide the main window so it lives only in the system tray (used by the "ask"
 /// dialog when the user chooses to minimize instead of quitting).
 #[tauri::command]
-pub async fn minimize_to_tray(app: tauri::AppHandle) -> Result<(), String> {
+pub async fn minimize_to_tray(
+    app: tauri::AppHandle,
+    startup_trace: State<'_, DesktopStartupTrace>,
+) -> Result<(), String> {
+    if let Err(error) = crate::tray::setup_tray(&app, &startup_trace) {
+        log::warn!("Failed to initialize tray before minimizing: {}", error);
+    }
     if let Some(window) = app.get_webview_window("main") {
         window.hide().map_err(|e| e.to_string())?;
         log::info!("Main window minimized to tray via command");
@@ -408,10 +415,20 @@ pub async fn minimize_to_tray(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Initialize the desktop tray after the startup shell has become interactive.
+#[tauri::command]
+pub async fn initialize_tray_after_startup(
+    app: tauri::AppHandle,
+    startup_trace: State<'_, DesktopStartupTrace>,
+) -> Result<(), String> {
+    crate::tray::setup_tray(&app, &startup_trace).map_err(|e| e.to_string())
+}
+
 /// Minimal startup-window controls used by the static pre-React splash.
 #[tauri::command]
 pub async fn startup_window_control(
     state: State<'_, AppState>,
+    startup_trace: State<'_, DesktopStartupTrace>,
     app: tauri::AppHandle,
     request: StartupWindowControlRequest,
 ) -> Result<(), String> {
@@ -450,6 +467,9 @@ pub async fn startup_window_control(
                 crate::perform_process_exit_cleanup();
                 app.exit(0);
             } else {
+                if let Err(error) = crate::tray::setup_tray(&app, &startup_trace) {
+                    log::warn!("Failed to initialize tray before startup close: {}", error);
+                }
                 window.hide().map_err(|error| {
                     format!("Failed to hide main window during startup close: {}", error)
                 })?;

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -668,12 +668,8 @@ pub async fn run() {
             logging::spawn_log_cleanup_task();
             startup_trace.record_elapsed_step("native_setup", "spawn_log_cleanup_task", step_started);
 
-            // Set up system tray icon.
             let step_started = Instant::now();
-            if let Err(error) = crate::tray::setup_tray(app, &startup_trace) {
-                log::warn!("Failed to set up system tray: {}", error);
-            }
-            startup_trace.record_elapsed_step("native_setup", "setup_tray", step_started);
+            startup_trace.record_elapsed_step("native_setup", "setup_tray_deferred", step_started);
 
             let setup_duration_ms = elapsed_ms(setup_started);
             let since_process_start_ms = elapsed_ms(startup_started);
@@ -1117,6 +1113,7 @@ pub async fn run() {
             send_system_notification,
             api::system_api::quit_app,
             api::system_api::minimize_to_tray,
+            api::system_api::initialize_tray_after_startup,
             api::system_api::startup_window_control,
             api::system_api::toggle_main_window_fullscreen,
             check_command_exists,

--- a/src/apps/desktop/src/tray.rs
+++ b/src/apps/desktop/src/tray.rs
@@ -13,7 +13,7 @@
 //! The context menu is rebuilt every time the user left-clicks (for freshness),
 //! periodically, and after locale changes.
 
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
 use tauri::menu::{CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder};
@@ -28,6 +28,8 @@ use crate::api::app_state::AppState;
 use crate::startup_trace::DesktopStartupTrace;
 
 static TRAY_ICON: OnceLock<tauri::tray::TrayIcon> = OnceLock::new();
+static TRAY_SETUP_LOCK: Mutex<()> = Mutex::new(());
+const TRAY_TRACE_CATEGORY: &str = "native_background";
 
 struct TrayStrings {
     show_app: &'static str,
@@ -167,16 +169,27 @@ async fn tray_toggle_desktop_pet(app: &AppHandle) -> Result<(), String> {
 
 /// Build and attach the system tray icon to the Tauri application.
 pub fn setup_tray(
-    app: &tauri::App,
+    app: &tauri::AppHandle,
     startup_trace: &DesktopStartupTrace,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if TRAY_ICON.get().is_some() {
+        return Ok(());
+    }
+
+    let _guard = TRAY_SETUP_LOCK
+        .lock()
+        .map_err(|_| "Tray setup lock poisoned")?;
+    if TRAY_ICON.get().is_some() {
+        return Ok(());
+    }
+
     let step_started = Instant::now();
     let pet_item = CheckMenuItemBuilder::with_id("toggle_desktop_pet", STRINGS_EN_US.desktop_pet)
         .checked(false)
         .build(app)?;
     let show_item = MenuItemBuilder::with_id("show_window", STRINGS_EN_US.show_app).build(app)?;
     let quit_item = MenuItemBuilder::with_id("quit", STRINGS_EN_US.quit_app).build(app)?;
-    startup_trace.record_elapsed_step("native_setup", "setup_tray.menu_items", step_started);
+    startup_trace.record_elapsed_step(TRAY_TRACE_CATEGORY, "setup_tray.menu_items", step_started);
 
     let step_started = Instant::now();
     let initial_menu = MenuBuilder::new(app)
@@ -186,14 +199,14 @@ pub fn setup_tray(
         .separator()
         .item(&quit_item)
         .build()?;
-    startup_trace.record_elapsed_step("native_setup", "setup_tray.menu", step_started);
+    startup_trace.record_elapsed_step(TRAY_TRACE_CATEGORY, "setup_tray.menu", step_started);
 
     let step_started = Instant::now();
     let icon = app
         .default_window_icon()
         .ok_or("No default window icon")?
         .clone();
-    startup_trace.record_elapsed_step("native_setup", "setup_tray.icon", step_started);
+    startup_trace.record_elapsed_step(TRAY_TRACE_CATEGORY, "setup_tray.icon", step_started);
 
     let step_started = Instant::now();
     let tray = TrayIconBuilder::new()
@@ -234,14 +247,14 @@ pub fn setup_tray(
             _ => {}
         })
         .build(app)?;
-    startup_trace.record_elapsed_step("native_setup", "setup_tray.build", step_started);
+    startup_trace.record_elapsed_step(TRAY_TRACE_CATEGORY, "setup_tray.build", step_started);
 
     let step_started = Instant::now();
     let _ = TRAY_ICON.set(tray);
-    startup_trace.record_elapsed_step("native_setup", "setup_tray.store", step_started);
+    startup_trace.record_elapsed_step(TRAY_TRACE_CATEGORY, "setup_tray.store", step_started);
 
     let step_started = Instant::now();
-    let app_handle = app.handle().clone();
+    let app_handle = app.clone();
     tauri::async_runtime::spawn(async move {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         rebuild_tray_menu(&app_handle).await;
@@ -252,7 +265,7 @@ pub fn setup_tray(
             rebuild_tray_menu(&app_handle).await;
         }
     });
-    startup_trace.record_elapsed_step("native_setup", "setup_tray.spawn_refresh", step_started);
+    startup_trace.record_elapsed_step(TRAY_TRACE_CATEGORY, "setup_tray.spawn_refresh", step_started);
 
     Ok(())
 }

--- a/src/web-ui/index.html
+++ b/src/web-ui/index.html
@@ -131,7 +131,7 @@
       }
 
       #bitfun-startup-overlay.bitfun-startup-overlay--exiting {
-        animation: bitfun-startup-overlay-exit 0.5s ease-in-out both;
+        animation: bitfun-startup-overlay-exit 0.32s ease-in-out both;
       }
 
       .bitfun-startup-window-controls {

--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -69,6 +69,9 @@ const LazyAppLayout = lazy(async () => {
  */
 // Minimum time (ms) the splash is shown, so the animation is never a flash.
 const MIN_SPLASH_MS = 900;
+// Keep hidden tray setup out of the first post-handoff interaction window.
+// Close-to-tray initializes it on demand if the user closes earlier.
+const DEFERRED_TRAY_INIT_DELAY_MS = 1500;
 
 function App() {
   const { t } = useI18n('settings/basics');
@@ -356,6 +359,58 @@ function App() {
     return () => {
       disposed = true;
       editorWarmupHandle?.cancel();
+    };
+  }, [interactiveShellReady, startupOverlayVisible]);
+
+  useEffect(() => {
+    if (!isTauriRuntime() || !interactiveShellReady || startupOverlayVisible) {
+      return;
+    }
+
+    let disposed = false;
+    let trayInitHandle: { promise: Promise<void>; cancel: () => void } | null = null;
+
+    const timer = window.setTimeout(() => {
+      void import('@/shared/utils/backgroundTaskScheduler')
+        .then(({ backgroundTaskScheduler }) => {
+          if (disposed) {
+            return;
+          }
+
+          trayInitHandle = backgroundTaskScheduler.schedule(async signal => {
+            if (signal.aborted || disposed) {
+              return;
+            }
+            startupTrace.markPhase('desktop_tray_deferred_init_start');
+            const { systemAPI } = await import('@/infrastructure/api/service-api/SystemAPI');
+            if (signal.aborted || disposed) {
+              return;
+            }
+            await systemAPI.initializeTrayAfterStartup();
+            startupTrace.markPhase('desktop_tray_deferred_init_end');
+          }, {
+            idle: true,
+            inFlightKey: 'desktop-tray:startup-init',
+            priority: 'low',
+          });
+
+          trayInitHandle.promise.catch(error => {
+            if (!disposed && !isBackgroundTaskCancelledError(error)) {
+              log.warn('Deferred tray initialization failed', error);
+            }
+          });
+        })
+        .catch(error => {
+          if (!disposed) {
+            log.warn('Failed to schedule deferred tray initialization', error);
+          }
+        });
+    }, DEFERRED_TRAY_INIT_DELAY_MS);
+
+    return () => {
+      disposed = true;
+      window.clearTimeout(timer);
+      trayInitHandle?.cancel();
     };
   }, [interactiveShellReady, startupOverlayVisible]);
 

--- a/src/web-ui/src/app/services/AppManager.test.ts
+++ b/src/web-ui/src/app/services/AppManager.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AppManager } from './AppManager';
+
+describe('AppManager layout updates', () => {
+  it('does not emit layout changes when the requested layout is already current', () => {
+    const manager = new AppManager();
+    const listener = vi.fn();
+    manager.addEventListener(listener);
+    const current = manager.getState().layout;
+
+    manager.updateLayout({
+      leftPanelActiveTab: current.leftPanelActiveTab,
+      leftPanelCollapsed: current.leftPanelCollapsed,
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('emits layout changes when a layout value changes', () => {
+    const manager = new AppManager();
+    const listener = vi.fn();
+    manager.addEventListener(listener);
+    const current = manager.getState().layout;
+
+    manager.updateLayout({
+      leftPanelCollapsed: !current.leftPanelCollapsed,
+    });
+
+    expect(listener).toHaveBeenCalledWith({
+      type: 'layout:changed',
+      payload: {
+        leftPanelCollapsed: !current.leftPanelCollapsed,
+      },
+    });
+  });
+});

--- a/src/web-ui/src/app/services/AppManager.ts
+++ b/src/web-ui/src/app/services/AppManager.ts
@@ -69,6 +69,13 @@ export class AppManager implements IAppManager {
   }
 
   updateLayout(layout: Partial<LayoutState>): void {
+    const hasLayoutChange = Object.entries(layout).some(([key, value]) => (
+      this.state.layout[key as keyof LayoutState] !== value
+    ));
+    if (!hasLayoutChange) {
+      return;
+    }
+
     if (typeof layout.rightPanelWidth === 'number') {
       savePanelWidth(STORAGE_KEYS.RIGHT_PANEL_LAST_WIDTH, layout.rightPanelWidth);
     }

--- a/src/web-ui/src/app/startup/deferredStartupSystems.test.ts
+++ b/src/web-ui/src/app/startup/deferredStartupSystems.test.ts
@@ -25,7 +25,7 @@ describe('shouldScheduleDeferredStartupSystems', () => {
 });
 
 describe('scheduleDeferredStartupSystems', () => {
-  it('schedules MCP, ACP, and IDE startup as deferred idle work', async () => {
+  it('schedules MCP, ACP clients, IDE startup, and renderer preloads as deferred idle work', async () => {
     let scheduledTask: ((signal: AbortSignal) => Promise<void>) | null = null;
     const schedule = vi.fn((task: (signal: AbortSignal) => Promise<void>, options) => {
       scheduledTask = task;
@@ -55,9 +55,6 @@ describe('scheduleDeferredStartupSystems', () => {
       initializeAcpClients: async () => {
         order.push('acp');
       },
-      probeAcpClientRequirements: async () => {
-        order.push('acp-probe');
-      },
       preloadDeferredRenderers: async () => {
         order.push('renderer-preloads');
       },
@@ -73,7 +70,7 @@ describe('scheduleDeferredStartupSystems', () => {
 
     await scheduledTask?.(new AbortController().signal);
 
-    expect(order).toEqual(['ide', 'mcp', 'acp', 'acp-probe', 'renderer-preloads']);
+    expect(order).toEqual(['ide', 'mcp', 'acp', 'renderer-preloads']);
   });
 
   it('skips deferred startup systems when cancelled before execution', async () => {
@@ -101,7 +98,6 @@ describe('scheduleDeferredStartupSystems', () => {
       initializeIdeControl,
       initializeMcpServers: vi.fn(),
       initializeAcpClients: vi.fn(),
-      probeAcpClientRequirements: vi.fn(),
       preloadDeferredRenderers: vi.fn(),
     });
 

--- a/src/web-ui/src/app/startup/deferredStartupSystems.ts
+++ b/src/web-ui/src/app/startup/deferredStartupSystems.ts
@@ -25,7 +25,6 @@ export interface DeferredStartupSystemsDependencies {
   initializeIdeControl?: () => Promise<void>;
   initializeMcpServers?: () => Promise<void>;
   initializeAcpClients?: () => Promise<void>;
-  probeAcpClientRequirements?: () => Promise<void>;
   preloadDeferredRenderers?: () => Promise<void>;
 }
 
@@ -42,11 +41,6 @@ async function initializeMcpServersDefault(): Promise<void> {
 async function initializeAcpClientsDefault(): Promise<void> {
   const { ACPClientAPI } = await import('@/infrastructure/api/service-api/ACPClientAPI');
   await ACPClientAPI.initializeClients();
-}
-
-async function probeAcpClientRequirementsDefault(): Promise<void> {
-  const { ACPClientAPI } = await import('@/infrastructure/api/service-api/ACPClientAPI');
-  await ACPClientAPI.probeClientRequirements();
 }
 
 async function preloadDeferredRenderersDefault(): Promise<void> {
@@ -73,8 +67,6 @@ export function scheduleDeferredStartupSystems(
   const initializeIdeControl = dependencies.initializeIdeControl ?? initializeIdeControlDefault;
   const initializeMcpServers = dependencies.initializeMcpServers ?? initializeMcpServersDefault;
   const initializeAcpClients = dependencies.initializeAcpClients ?? initializeAcpClientsDefault;
-  const probeAcpClientRequirements =
-    dependencies.probeAcpClientRequirements ?? probeAcpClientRequirementsDefault;
   const preloadDeferredRenderers = dependencies.preloadDeferredRenderers ?? preloadDeferredRenderersDefault;
 
   return scheduler.schedule(async signal => {
@@ -99,7 +91,6 @@ export function scheduleDeferredStartupSystems(
     await runStep('ide_control', initializeIdeControl);
     await runStep('mcp_servers', initializeMcpServers);
     await runStep('acp_clients', initializeAcpClients);
-    await runStep('acp_client_requirements', probeAcpClientRequirements);
     await runStep('renderer_preloads', preloadDeferredRenderers);
 
     if (!signal.aborted) {

--- a/src/web-ui/src/app/startup/startupOverlay.test.ts
+++ b/src/web-ui/src/app/startup/startupOverlay.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
 });
 
 describe('startupOverlay', () => {
-  it('fades and removes the existing startup overlay', async () => {
+  it('removes the existing startup overlay when its exit animation completes', async () => {
     vi.useFakeTimers();
     document.body.innerHTML = '<div id="bitfun-startup-overlay"></div>';
 
@@ -25,7 +25,22 @@ describe('startupOverlay', () => {
     expect(overlay?.classList.contains('bitfun-startup-overlay--exiting')).toBe(true);
     expect(overlay?.getAttribute('aria-hidden')).toBe('true');
 
-    await vi.advanceTimersByTimeAsync(650);
+    overlay?.dispatchEvent(new Event('animationend'));
+    await hidden;
+
+    expect(isStartupOverlayPresent()).toBe(false);
+  });
+
+  it('falls back to a timer when the exit animation event is not delivered', async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '<div id="bitfun-startup-overlay"></div>';
+
+    const hidden = hideStartupOverlay();
+
+    await vi.advanceTimersByTimeAsync(449);
+    expect(isStartupOverlayPresent()).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1);
     await hidden;
 
     expect(isStartupOverlayPresent()).toBe(false);

--- a/src/web-ui/src/app/startup/startupOverlay.ts
+++ b/src/web-ui/src/app/startup/startupOverlay.ts
@@ -1,6 +1,6 @@
 const STARTUP_OVERLAY_ID = 'bitfun-startup-overlay';
 const EXIT_CLASS = 'bitfun-startup-overlay--exiting';
-const DEFAULT_EXIT_MS = 650;
+const EXIT_FALLBACK_MS = 450;
 
 declare global {
   interface Window {
@@ -24,24 +24,50 @@ export function isStartupOverlayPresent(): boolean {
   return getOverlay() !== null;
 }
 
-export function hideStartupOverlay(): Promise<void> {
+function waitForOverlayExitAnimation(overlay: HTMLElement): Promise<void> {
+  return new Promise(resolve => {
+    let done = false;
+    const state: { fallbackTimer: number | undefined } = {
+      fallbackTimer: undefined,
+    };
+
+    function finish() {
+      if (done) {
+        return;
+      }
+      done = true;
+      overlay.removeEventListener('animationend', handleAnimationEnd);
+      if (state.fallbackTimer !== undefined) {
+        window.clearTimeout(state.fallbackTimer);
+      }
+      resolve();
+    }
+
+    function handleAnimationEnd(event: AnimationEvent) {
+      if (event.target !== overlay) {
+        return;
+      }
+      finish();
+    }
+
+    overlay.addEventListener('animationend', handleAnimationEnd);
+    state.fallbackTimer = window.setTimeout(finish, EXIT_FALLBACK_MS);
+  });
+}
+
+export async function hideStartupOverlay(): Promise<void> {
   const overlay = getOverlay();
   if (!overlay) {
-    return Promise.resolve();
+    return;
   }
 
   if (overlay.classList.contains(EXIT_CLASS)) {
-    return new Promise(resolve => {
-      window.setTimeout(resolve, DEFAULT_EXIT_MS);
-    });
+    await waitForOverlayExitAnimation(overlay);
+    return;
   }
 
   overlay.classList.add(EXIT_CLASS);
   overlay.setAttribute('aria-hidden', 'true');
-  return new Promise(resolve => {
-    window.setTimeout(() => {
-      overlay.remove();
-      resolve();
-    }, DEFAULT_EXIT_MS);
-  });
+  await waitForOverlayExitAnimation(overlay);
+  overlay.remove();
 }

--- a/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
+++ b/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
@@ -55,6 +55,12 @@ describe('startup performance contract', () => {
     expect(alphaAt(64, 64)).toBeGreaterThan(240);
   });
 
+  it('keeps the startup overlay exit short enough for a fast visual handoff', () => {
+    const source = readSource('../../../index.html');
+
+    expect(source).toContain('animation: bitfun-startup-overlay-exit 0.32s ease-in-out both;');
+  });
+
   it('keeps editor and tool infrastructure out of the first startup module', () => {
     const source = readSource('../../main.tsx');
 
@@ -137,6 +143,30 @@ describe('startup performance contract', () => {
     );
   });
 
+  it('keeps system tray creation out of the synchronous Tauri setup path', () => {
+    const desktopLibSource = readSource('../../../../apps/desktop/src/lib.rs');
+    const traySource = readSource('../../../../apps/desktop/src/tray.rs');
+    const appSource = readSource('../App.tsx');
+
+    expect(desktopLibSource).not.toContain('crate::tray::setup_tray(app, &startup_trace)');
+    expect(desktopLibSource).not.toContain('Failed to set up system tray');
+    expect(traySource).toContain('const TRAY_TRACE_CATEGORY: &str = "native_background";');
+    expect(traySource).not.toContain('record_elapsed_step("native_setup", "setup_tray.');
+    expect(appSource).toContain('initializeTrayAfterStartup');
+  });
+
+  it('does not turn tray initialization failure into a close-to-tray behavior change', () => {
+    const systemApiSource = readSource('../../../../apps/desktop/src/api/system_api.rs');
+    const minimizeStart = systemApiSource.indexOf('pub async fn minimize_to_tray');
+    const initializeTrayStart = systemApiSource.indexOf('pub async fn initialize_tray_after_startup');
+    const minimizeSource = systemApiSource.slice(minimizeStart, initializeTrayStart);
+
+    expect(minimizeSource).toContain('crate::tray::setup_tray(&app, &startup_trace)');
+    expect(minimizeSource).toContain('Failed to initialize tray before minimizing');
+    expect(minimizeSource).toContain('window.hide()');
+    expect(minimizeSource).not.toContain('setup_tray(&app, &startup_trace).map_err');
+  });
+
   it('starts non-critical work after the startup overlay handoff', () => {
     const source = readSource('../../main.tsx');
 
@@ -161,6 +191,14 @@ describe('startup performance contract', () => {
     expect(source).toContain('shouldScheduleDeferredStartupSystems({ interactiveShellReady, startupOverlayVisible })');
     expect(source).toContain('window.dispatchEvent(new CustomEvent(STARTUP_OVERLAY_HIDDEN_EVENT))');
     expect(source).toContain('}, [interactiveShellReady, startupOverlayVisible]);');
+  });
+
+  it('keeps ACP requirement probing out of the startup background path', () => {
+    const source = readSource('./deferredStartupSystems.ts');
+
+    expect(source).not.toContain('probeClientRequirements');
+    expect(source).not.toContain('probe_acp_client_requirements');
+    expect(source).not.toContain('acp_client_requirements');
   });
 
   it('does not initialize AI from the root app component', () => {
@@ -224,6 +262,15 @@ describe('startup performance contract', () => {
     expect(toolbarModeProviderSource.indexOf("await import('./ToolbarMode')")).toBeLessThan(
       toolbarModeProviderSource.indexOf('setIsToolbarMode(true)')
     );
+  });
+
+  it('keeps restored historical tail content out of enter animations', () => {
+    const source = readSource('../../flow_chat/components/modern/ModernFlowChatContainer.scss');
+
+    expect(source).toContain('[data-history-state="ready"][data-is-partial="true"]');
+    expect(source).toContain('.user-message-item');
+    expect(source).toContain('.model-round-item');
+    expect(source).toContain('animation: none');
   });
 
   it('releases interactive shell readiness without waiting for an extra AppLayout state commit', () => {
@@ -591,12 +638,16 @@ describe('startup performance contract', () => {
   it('keeps historical session restore on the narrow AgentAPI entrypoint', () => {
     const source = readSource('../../flow_chat/store/FlowChatStore.ts');
     const imports = dynamicImportSpecifiers(source);
+    const staticImports = staticImportSpecifiers(source);
     const agentApiDynamicImports = imports.filter(specifier => specifier.endsWith('/AgentAPI'));
+    const agentApiStaticImports = staticImports.filter(specifier => specifier.endsWith('/AgentAPI'));
 
+    expect(agentApiStaticImports).toEqual(['@/infrastructure/api/service-api/AgentAPI']);
     expect(agentApiDynamicImports.length).toBeGreaterThan(0);
     expect(new Set(agentApiDynamicImports)).toEqual(
       new Set(['@/infrastructure/api/service-api/AgentAPI'])
     );
+    expect(staticImports).not.toContain('@/infrastructure/api');
     expect(imports).not.toContain('@/infrastructure/api');
   });
 

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.scss
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.scss
@@ -38,6 +38,13 @@
     background: transparent;
   }
 
+  &__messages[data-history-state="ready"][data-is-partial="true"] {
+    .user-message-item,
+    .model-round-item {
+      animation: none;
+    }
+  }
+
   &__input {
     flex-shrink: 0;
     padding: var(--flowchat-card-expanded-pad-x);

--- a/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.scss
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.scss
@@ -36,4 +36,3 @@
     background: color-mix(in srgb, var(--accent-primary) 8%, transparent);
   }
 }
-

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -143,10 +143,18 @@ async function flushAsyncWork(): Promise<void> {
 }
 
 async function advanceReleasedLocalFullHistoryCompletion(): Promise<void> {
-  await vi.advanceTimersByTimeAsync(250);
   await flushAsyncWork();
   await vi.advanceTimersByTimeAsync(1500);
   await flushAsyncWork();
+}
+
+function resetStartupTraceEventsForTest(): void {
+  const trace = startupTrace as unknown as {
+    phaseEvents: number;
+    phaseRecords: unknown[];
+  };
+  trace.phaseEvents = 0;
+  trace.phaseRecords.length = 0;
 }
 
 describe('FlowChatStore metadata persistence callbacks', () => {
@@ -758,6 +766,53 @@ describe('FlowChatStore historical session hydration state', () => {
     });
   });
 
+  it('starts model config lookup while a paged metadata request is in flight', async () => {
+    const events: string[] = [];
+    const page = createDeferred<{
+      sessions: any[];
+      totalTopLevelCount: number;
+      loadedTopLevelCount: number;
+      nextCursor?: string;
+      hasMore: boolean;
+    }>();
+    apiMocks.listSessionsPage.mockImplementationOnce(() => {
+      events.push('page-request-start');
+      return page.promise;
+    });
+    configManagerMock.getConfigs.mockImplementationOnce(async () => {
+      events.push('model-config-start');
+      return {
+        'ai.models': [],
+        'ai.default_models': {},
+      };
+    });
+
+    const load = flowChatStore.loadSessionMetadataPage(
+      'D:/workspace/BitFun',
+      5,
+      undefined,
+      undefined,
+      undefined,
+      'nav_initial'
+    );
+
+    await vi.waitFor(() => {
+      expect(apiMocks.listSessionsPage).toHaveBeenCalledTimes(1);
+    });
+    await flushAsyncWork();
+
+    expect(events).toContain('page-request-start');
+    expect(events).toContain('model-config-start');
+
+    page.resolve({
+      sessions: [],
+      totalTopLevelCount: 0,
+      loadedTopLevelCount: 0,
+      hasMore: false,
+    });
+    await load;
+  });
+
   it('marks historical sessions hydrating while turns are loading and ready after completion', async () => {
     const turns = createDeferred<any[]>();
     apiMocks.restoreSessionView.mockImplementationOnce(async () => ({
@@ -784,9 +839,10 @@ describe('FlowChatStore historical session hydration state', () => {
     }));
 
     const load = flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
-    await flushAsyncWork();
 
-    expect(flowChatStore.getState().sessions.get('history-1')?.historyState).toBe('hydrating');
+    await vi.waitFor(() => {
+      expect(flowChatStore.getState().sessions.get('history-1')?.historyState).toBe('hydrating');
+    });
 
     turns.resolve([]);
     await load;
@@ -796,6 +852,131 @@ describe('FlowChatStore historical session hydration state', () => {
       historyState: 'ready',
       dialogTurns: [],
     });
+  });
+
+  it('starts backend restore before notifying hydrating state', async () => {
+    const events: string[] = [];
+    const restore = createDeferred<{
+      session: {
+        sessionId: string;
+        sessionName: string;
+        agentType: string;
+        state: string;
+        turnCount: number;
+        createdAt: number;
+      };
+      turns: any[];
+      contextRestoreState: 'pending';
+    }>();
+    apiMocks.restoreSessionView.mockImplementationOnce(() => {
+      events.push('restore-start');
+      return restore.promise;
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+    const unsubscribe = flowChatStore.subscribe(state => {
+      if (state.sessions.get('history-1')?.historyState === 'hydrating') {
+        events.push('hydrating-notified');
+      }
+    });
+
+    try {
+      const load = flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
+      await vi.waitFor(() => {
+        expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(1);
+      });
+
+      expect(events).toEqual(['restore-start', 'hydrating-notified']);
+
+      restore.resolve({
+        session: {
+          sessionId: 'history-1',
+          sessionName: 'History 1',
+          agentType: 'agentic',
+          state: 'Idle',
+          turnCount: 0,
+          createdAt: 1,
+        },
+        turns: [],
+        contextRestoreState: 'pending',
+      });
+      await load;
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('keeps active deferred metadata-only sessions stable while initial restore is pending', async () => {
+    const restore = createDeferred<{
+      session: {
+        sessionId: string;
+        sessionName: string;
+        agentType: string;
+        state: string;
+        turnCount: number;
+        createdAt: number;
+      };
+      turns: any[];
+      contextRestoreState: 'pending';
+    }>();
+    const observedStates: string[] = [];
+    apiMocks.restoreSessionView.mockReturnValueOnce(restore.promise);
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+    const unsubscribe = flowChatStore.subscribe(state => {
+      observedStates.push(state.sessions.get('history-1')?.historyState ?? 'missing');
+    });
+
+    try {
+      const load = flowChatStore.loadSessionHistory(
+        'history-1',
+        'D:/workspace/BitFun',
+        undefined,
+        undefined,
+        undefined,
+        { deferFullHistoryUntilActive: true },
+      );
+      await vi.waitFor(() => {
+        expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(1);
+      });
+
+      expect(flowChatStore.getState().sessions.get('history-1')?.historyState).toBe('metadata-only');
+      expect(observedStates).not.toContain('hydrating');
+
+      restore.resolve({
+        session: {
+          sessionId: 'history-1',
+          sessionName: 'History 1',
+          agentType: 'agentic',
+          state: 'Idle',
+          turnCount: 0,
+          createdAt: 1,
+        },
+        turns: [],
+        contextRestoreState: 'pending',
+      });
+      await load;
+
+      expect(flowChatStore.getState().sessions.get('history-1')?.historyState).toBe('ready');
+    } finally {
+      unsubscribe();
+    }
   });
 
   it('marks historical sessions failed when hydrate fails', async () => {
@@ -1046,7 +1227,7 @@ describe('FlowChatStore historical session hydration state', () => {
         undefined,
         expect.any(String),
         undefined,
-        8,
+        3,
       );
       expect(
         flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.userMessage.content)
@@ -1187,7 +1368,7 @@ describe('FlowChatStore historical session hydration state', () => {
     }
   });
 
-  it('defers full history completion when partial hydrate finishes after switching away', async () => {
+  it('skips committing stale local history hydrate when switching away before restore finishes', async () => {
     vi.useFakeTimers();
     const latestTurn = {
       turnId: 'turn-2',
@@ -1248,8 +1429,9 @@ describe('FlowChatStore historical session hydration state', () => {
 
       expect(flowChatStore.getState().activeSessionId).toBe('history-2');
       expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
-        historyState: 'ready',
-        isPartial: true,
+        isHistorical: true,
+        historyState: 'metadata-only',
+        dialogTurns: [],
       });
       expect(flowChatStore.hasPendingSessionHistoryCompletion('history-1')).toBe(false);
 
@@ -1716,13 +1898,6 @@ describe('FlowChatStore historical session hydration state', () => {
 
       flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint('history-1');
 
-      expect(idleCallback).toBeNull();
-      await vi.advanceTimersByTimeAsync(249);
-      await flushAsyncWork();
-      expect(idleCallback).toBeNull();
-
-      await vi.advanceTimersByTimeAsync(1);
-      await flushAsyncWork();
       expect(idleCallback).toBeTypeOf('function');
       const hydrationPromise = Array.from(
         ((flowChatStore as any).fullHistoryHydrationRequests as Map<string, { promise: Promise<void> }>).values()
@@ -1824,7 +1999,7 @@ describe('FlowChatStore historical session hydration state', () => {
 
       flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint('history-1');
 
-      await vi.advanceTimersByTimeAsync(1749);
+      await vi.advanceTimersByTimeAsync(1499);
       await flushAsyncWork();
       expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(1);
 
@@ -2179,6 +2354,7 @@ describe('FlowChatStore historical session hydration state', () => {
   });
 
   it('records scalar restore timing fields for historical session diagnostics', async () => {
+    resetStartupTraceEventsForTest();
     const restoredTurn = {
       turnId: 'turn-1',
       turnIndex: 0,
@@ -2210,7 +2386,7 @@ describe('FlowChatStore historical session hydration state', () => {
         normalizeTurnIdsDurationMs: 4,
         totalDurationMs: 44,
         turnLoad: {
-          requestedTailTurnCount: 8,
+          requestedTailTurnCount: 3,
           loadedTurnCount: 1,
           totalTurnCount: 2,
           turnFileCount: 2,
@@ -2239,9 +2415,13 @@ describe('FlowChatStore historical session hydration state', () => {
 
     await flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
 
-    const restoreEvents = startupTrace.getSnapshot().phases.events
-      .filter(event => event.phase === 'historical_session_restore_end');
-    expect(restoreEvents[restoreEvents.length - 1]).toMatchObject({
+    const restoreEvent = startupTrace.getSnapshot().phases.events
+      .find(event =>
+        event.phase === 'historical_session_restore_end' &&
+        event.sessionId === 'history-1' &&
+        event.restoreTotalDurationMs === 44
+      );
+    expect(restoreEvent).toMatchObject({
       restoreTotalDurationMs: 44,
       restoreLoadSessionWithTurnsDurationMs: 37,
       restoreTurnReadDurationMs: 8,

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -29,9 +29,10 @@ import {
 import { elapsedMs, nowMs } from '@/shared/utils/timing';
 import { i18nService } from '@/infrastructure/i18n/core/I18nService';
 import type { DialogTurnData, LocalCommandMetadata, SessionKind } from '@/shared/types/session-history';
-import type {
-  SessionInfo as AgentSessionInfo,
-  SessionViewRestoreTiming,
+import {
+  agentAPI,
+  type SessionInfo as AgentSessionInfo,
+  type SessionViewRestoreTiming,
 } from '@/infrastructure/api/service-api/AgentAPI';
 import type { SessionMetadataPage } from '@/infrastructure/api/service-api/SessionAPI';
 import {
@@ -74,10 +75,9 @@ const VALID_AGENT_TYPES = new Set([
 ]);
 const METADATA_LIST_RECENT_DEDUPE_TTL_MS = 1000;
 const HISTORICAL_SESSION_INITIAL_REMOTE_TAIL_TURN_COUNT = 3;
-const HISTORICAL_SESSION_INITIAL_LOCAL_TAIL_TURN_COUNT = 8;
+const HISTORICAL_SESSION_INITIAL_LOCAL_TAIL_TURN_COUNT = 3;
 const HISTORICAL_SESSION_FULL_HISTORY_IDLE_TIMEOUT_MS = 1500;
 const HISTORICAL_SESSION_FULL_HISTORY_FIRST_PAINT_TIMEOUT_MS = 2500;
-const HISTORICAL_SESSION_FULL_HISTORY_STABLE_VIEWPORT_DELAY_MS = 250;
 const MAX_DEFERRED_FULL_HISTORY_PROJECTIONS = 3;
 
 function itemMatchesIdentity(item: AnyFlowItem, itemId: string): boolean {
@@ -426,7 +426,6 @@ function scheduleLocalHistoricalSessionFullHydrate(
   let cancelled = false;
   let started = false;
   let cancelIdle: (() => void) | undefined;
-  let stableViewportTimer: ReturnType<typeof setTimeout> | undefined;
   const timeout = globalThis.setTimeout(
     () => start('timeout'),
     HISTORICAL_SESSION_FULL_HISTORY_FIRST_PAINT_TIMEOUT_MS,
@@ -439,10 +438,6 @@ function scheduleLocalHistoricalSessionFullHydrate(
 
     started = true;
     globalThis.clearTimeout(timeout);
-    if (stableViewportTimer) {
-      globalThis.clearTimeout(stableViewportTimer);
-      stableViewportTimer = undefined;
-    }
     cancelIdle = scheduleHistoricalSessionFullHydrate(() => callback(reason));
   }
 
@@ -450,9 +445,6 @@ function scheduleLocalHistoricalSessionFullHydrate(
     cancel: () => {
       cancelled = true;
       globalThis.clearTimeout(timeout);
-      if (stableViewportTimer) {
-        globalThis.clearTimeout(stableViewportTimer);
-      }
       cancelIdle?.();
     },
     releaseAfterInitialPaint: (options?: FullHistoryHydrationReleaseOptions) => {
@@ -460,14 +452,10 @@ function scheduleLocalHistoricalSessionFullHydrate(
         start('explicit');
         return;
       }
-      if (stableViewportTimer || started || cancelled) {
+      if (started || cancelled) {
         return;
       }
-      globalThis.clearTimeout(timeout);
-      stableViewportTimer = globalThis.setTimeout(
-        () => start('initial_paint'),
-        HISTORICAL_SESSION_FULL_HISTORY_STABLE_VIEWPORT_DELAY_MS,
-      );
+      start('initial_paint');
     },
   };
 }
@@ -3171,9 +3159,18 @@ export class FlowChatStore {
     workspacePath: string,
     remoteConnectionId?: string,
     remoteSshHost?: string,
+    modelConfigPromise?: Promise<{
+      models: any[];
+      defaultModels: Record<string, string>;
+    }>,
   ): Promise<void> {
-    const { stateMachineManager } = await import('../state-machine');
-    const { models, defaultModels } = await this.loadSessionMetadataModelConfig();
+    const [
+      { stateMachineManager },
+      { models, defaultModels },
+    ] = await Promise.all([
+      import('../state-machine'),
+      modelConfigPromise ?? this.loadSessionMetadataModelConfig(),
+    ]);
 
     const processSession = async (metadata: any) => {
       try {
@@ -3395,6 +3392,10 @@ export class FlowChatStore {
         durationMs: elapsedMs(importStartedAt),
       });
       let page: SessionMetadataPage;
+      let modelConfigPromise: Promise<{
+        models: any[];
+        defaultModels: Record<string, string>;
+      }> | undefined;
       const pageRequestStartedAt = nowMs();
       try {
         startupTrace.markPhase('session_metadata_page_request_start', {
@@ -3403,13 +3404,15 @@ export class FlowChatStore {
           metadataListTraceId,
           command: 'list_persisted_sessions_page',
         });
-        page = await sessionAPI.listSessionsPage({
+        const pagePromise = sessionAPI.listSessionsPage({
           workspacePath,
           limit,
           cursor,
           remoteConnectionId,
           remoteSshHost,
         });
+        modelConfigPromise = this.loadSessionMetadataModelConfig();
+        page = await pagePromise;
         startupTrace.markPhase('session_metadata_page_request_end', {
           remote,
           source: traceSource,
@@ -3460,6 +3463,7 @@ export class FlowChatStore {
         workspacePath,
         remoteConnectionId,
         remoteSshHost,
+        modelConfigPromise,
       );
       startupTrace.markPhase('session_metadata_page_end', {
         remote,
@@ -3729,12 +3733,26 @@ export class FlowChatStore {
       sessionId,
       sessionTraceId,
     });
-    this.setSessionHistoryState(sessionId, 'hydrating');
+    const initialSession = this.state.sessions.get(sessionId);
+    const suppressInitialHydratingState =
+      !remote &&
+      options?.deferFullHistoryUntilActive === true &&
+      this.state.activeSessionId === sessionId &&
+      initialSession?.isHistorical === true &&
+      initialSession.historyState === 'metadata-only';
+    let hydratingStateNotified = false;
+    const notifyHydratingState = (): void => {
+      if (suppressInitialHydratingState) {
+        return;
+      }
+      if (hydratingStateNotified) {
+        return;
+      }
+      hydratingStateNotified = true;
+      this.setSessionHistoryState(sessionId, 'hydrating');
+    };
 
     try {
-      const { stateMachineManager } = await import('../state-machine');
-      stateMachineManager.getOrCreate(sessionId);
-      
       const existingSession = this.state.sessions.get(sessionId);
       const isAcpSession = existingSession?.mode?.startsWith('acp:') ||
         existingSession?.config.agentType?.startsWith('acp:');
@@ -3745,6 +3763,7 @@ export class FlowChatStore {
       let restoredLoadedTurnCount: number | undefined;
       let restoredTotalTurnCount: number | undefined;
       let restoredTiming: SessionViewRestoreTiming | undefined;
+      const stateMachineManagerPromise = import('../state-machine');
       if (!isAcpSession) {
         const restoreStartedAt = nowMs();
         startupTrace.markPhase('historical_session_restore_start', {
@@ -3753,7 +3772,6 @@ export class FlowChatStore {
           sessionTraceId,
         });
         try {
-          const { agentAPI } = await import('@/infrastructure/api/service-api/AgentAPI');
           const restoreSessionViewSupportKey = restoreCommandSupportKey(
             'restore_session_view',
             remoteConnectionId,
@@ -3770,7 +3788,7 @@ export class FlowChatStore {
               !this.unsupportedRestoreCommands.has(restoreSessionWithTurnsSupportKey)
             ) {
               try {
-                const restored = await agentAPI.restoreSessionWithTurns(
+                const restoredPromise = agentAPI.restoreSessionWithTurns(
                   sessionId,
                   workspacePath,
                   remoteConnectionId,
@@ -3778,6 +3796,8 @@ export class FlowChatStore {
                   sessionTraceId,
                   options?.includeInternal,
                 );
+                notifyHydratingState();
+                const restored = await restoredPromise;
                 restoredSessionInfo = restored.session;
                 turns = restored.turns;
                 contextRestoreState = 'ready';
@@ -3798,7 +3818,7 @@ export class FlowChatStore {
               }
             }
 
-            restoredSessionInfo = await agentAPI.restoreSession(
+            const restoredSessionPromise = agentAPI.restoreSession(
               sessionId,
               workspacePath,
               remoteConnectionId,
@@ -3806,6 +3826,8 @@ export class FlowChatStore {
               sessionTraceId,
               options?.includeInternal,
             );
+            notifyHydratingState();
+            restoredSessionInfo = await restoredSessionPromise;
             contextRestoreState = 'ready';
           };
 
@@ -3814,7 +3836,7 @@ export class FlowChatStore {
             !this.unsupportedRestoreCommands.has(restoreSessionViewSupportKey)
           ) {
             try {
-              const restored = await agentAPI.restoreSessionView(
+              const restoredPromise = agentAPI.restoreSessionView(
                 sessionId,
                 workspacePath,
                 remoteConnectionId,
@@ -3823,6 +3845,8 @@ export class FlowChatStore {
                 options?.includeInternal,
                 historicalSessionInitialTailTurnCount(remote),
               );
+              notifyHydratingState();
+              const restored = await restoredPromise;
               restoredSessionInfo = restored.session;
               turns = restored.turns;
               contextRestoreState =
@@ -3874,6 +3898,7 @@ export class FlowChatStore {
       }
       
       if (!turns) {
+        notifyHydratingState();
         const turnsLoadStartedAt = nowMs();
         startupTrace.markPhase('historical_session_turns_load_start', {
           remote,
@@ -3896,12 +3921,59 @@ export class FlowChatStore {
           durationMs: elapsedMs(turnsLoadStartedAt),
         });
       }
+      const { stateMachineManager } = await stateMachineManagerPromise;
+      stateMachineManager.getOrCreate(sessionId);
       startupTrace.markPhase('historical_session_turns_loaded', {
         remote,
         sessionId,
         sessionTraceId,
         turnCount: Array.isArray(turns) ? turns.length : 0,
       });
+
+      const skipStaleLocalHydrateCommit =
+        !remote &&
+        options?.deferFullHistoryUntilActive === true &&
+        this.state.activeSessionId !== sessionId;
+      if (skipStaleLocalHydrateCommit) {
+        this.setState(prev => {
+          const session = prev.sessions.get(sessionId);
+          if (!session || prev.activeSessionId === sessionId) {
+            return prev;
+          }
+
+          const newSessions = new Map(prev.sessions);
+          newSessions.set(sessionId, {
+            ...session,
+            historyState: session.isHistorical ? 'metadata-only' : session.historyState,
+          });
+
+          return {
+            ...prev,
+            sessions: newSessions,
+          };
+        });
+        stateMachineManager.reset(sessionId);
+        startupTrace.markPhase('historical_session_hydrate_stale_commit_skipped', {
+          remote,
+          sessionId,
+          sessionTraceId,
+          loadedTurnCount: restoredLoadedTurnCount,
+          totalTurnCount: restoredTotalTurnCount,
+          isPartial: restoredHistoryPartial,
+          durationMs: elapsedMs(traceStartedAt),
+        });
+        startupTrace.markPhase('historical_session_hydrate_end', {
+          remote,
+          sessionId,
+          sessionTraceId,
+          skipped: true,
+          loadedTurnCount: restoredLoadedTurnCount,
+          totalTurnCount: restoredTotalTurnCount,
+          isPartial: restoredHistoryPartial,
+          durationMs: elapsedMs(traceStartedAt),
+        });
+        return;
+      }
       
       const convertStartedAt = nowMs();
       const dialogTurns = this.convertToDialogTurns(turns);

--- a/src/web-ui/src/infrastructure/api/service-api/SystemAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SystemAPI.ts
@@ -229,6 +229,15 @@ export class SystemAPI {
     }
   }
 
+  /** Desktop only: initialize the system tray after the startup shell is visible. */
+  async initializeTrayAfterStartup(): Promise<void> {
+    try {
+      await api.invoke('initialize_tray_after_startup', { request: {} });
+    } catch (error) {
+      throw createTauriCommandError('initialize_tray_after_startup', error);
+    }
+  }
+
   /**
    * Desktop only: toggle OS-window fullscreen for the main window.
    *

--- a/tests/e2e/E2E-TESTING-GUIDE.md
+++ b/tests/e2e/E2E-TESTING-GUIDE.md
@@ -197,6 +197,38 @@ pnpm run desktop:build:release-fast
 cross-env E2E_TEST_WORKSPACE=<workspace-path> BITFUN_E2E_PERF_SESSION_ID=perf-long-session-000 pnpm run e2e:test:perf:release-fast
 ```
 
+For cold-start outlier checks, prefer the focused stability runner instead of
+the full perf spec:
+
+```bash
+pnpm run desktop:build:release-fast
+cross-env E2E_TEST_WORKSPACE=<workspace-path> pnpm run e2e:test:perf:startup-stability:release-fast
+```
+
+It repeats only the startup telemetry case. Tune sample count and threshold gates
+with `BITFUN_E2E_PERF_STARTUP_ITERATIONS`,
+`BITFUN_E2E_PERF_STARTUP_MAX_INTERACTIVE_MS`,
+`BITFUN_E2E_PERF_STARTUP_MAX_FIRST_SCRIPT_MS`, and
+`BITFUN_E2E_PERF_STARTUP_MAX_MAIN_SHOWN_TO_INTERACTIVE_MS`.
+The runner prints concise summaries by default; set
+`BITFUN_E2E_PERF_RUNNER_STREAM_LOGS=1` only when debugging a failing run.
+
+For long-session interaction risk, run the smallest matching profile:
+
+```bash
+cross-env E2E_TEST_WORKSPACE=<workspace-path> BITFUN_E2E_PERF_SESSION_ID=perf-long-session-000 BITFUN_E2E_PERF_MATRIX_PROFILE=core pnpm run e2e:test:perf:long-session-interactions:release-fast
+```
+
+Profiles are `core`, `scroll`, `resize`, and `full`. Use `core` for general
+session-open or rapid-switch changes, `scroll` for viewport anchoring changes,
+`resize` for layout/size changes, and `full` only when the change spans multiple
+session rendering paths. A performance PR should run the focused command that
+matches the touched surface plus any nearby unit/contract tests; it does not need
+every E2E suite unless the change broadens the runtime or product surface.
+The matrix fails when an expected performance report is missing so skipped
+fixtures are not mistaken for valid data; use
+`BITFUN_E2E_PERF_ALLOW_MISSING_REPORTS=1` only for runner plumbing checks.
+
 For debug-only comparison, build the debug binary and run:
 
 ```bash

--- a/tests/e2e/config/embedded-driver.ts
+++ b/tests/e2e/config/embedded-driver.ts
@@ -167,7 +167,18 @@ async function deleteProbeSession(sessionId: string): Promise<void> {
   }).catch(() => undefined);
 }
 
+async function setProbeScriptTimeout(sessionId: string, timeoutMs: number): Promise<void> {
+  await fetch(`http://${DRIVER_HOST}:${DRIVER_PORT}/session/${sessionId}/timeouts`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ script: timeoutMs }),
+  }).catch(() => undefined);
+}
+
 async function probeDocumentReady(sessionId: string): Promise<boolean> {
+  await setProbeScriptTimeout(sessionId, 1000);
   const response = await fetch(`http://${DRIVER_HOST}:${DRIVER_PORT}/session/${sessionId}/execute/sync`, {
     method: 'POST',
     headers: {

--- a/tests/e2e/scripts/perf-coverage-contract.test.mjs
+++ b/tests/e2e/scripts/perf-coverage-contract.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function readText(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function readJson(relativePath) {
+  return JSON.parse(readText(relativePath));
+}
+
+test('performance scripts expose focused startup stability and interaction profiles', () => {
+  const rootPackage = readJson('package.json');
+
+  assert.match(
+    rootPackage.scripts['e2e:test:perf:startup-stability:release-fast'] ?? '',
+    /run-startup-stability\.mjs/,
+  );
+  assert.match(
+    rootPackage.scripts['e2e:test:perf:long-session-interactions:release-fast'] ?? '',
+    /run-long-session-interaction-matrix\.mjs/,
+  );
+
+  const startupRunner = readText('tests/e2e/scripts/run-startup-stability.mjs');
+  assert.match(startupRunner, /BITFUN_E2E_PERF_STARTUP_ITERATIONS/);
+  assert.match(startupRunner, /BITFUN_E2E_PERF_STARTUP_MAX_INTERACTIVE_MS/);
+  assert.match(startupRunner, /collects startup timing from the current build/);
+  assert.match(startupRunner, /seenTraceIds/);
+  assert.match(startupRunner, /was already reported by an earlier iteration/);
+
+  const interactionRunner = readText('tests/e2e/scripts/run-long-session-interaction-matrix.mjs');
+  assert.match(interactionRunner, /BITFUN_E2E_PERF_MATRIX_PROFILE/);
+  assert.match(interactionRunner, /first-scroll/);
+  assert.match(interactionRunner, /resize-window-width/);
+  assert.match(interactionRunner, /BITFUN_E2E_PERF_RAPID_SWITCH_DELAY_MS/);
+  assert.match(interactionRunner, /BITFUN_E2E_PERF_ALLOW_MISSING_REPORTS/);
+  assert.match(interactionRunner, /expected performance report was not written/);
+});
+
+test('release-fast startup telemetry rejects dev-server contaminated samples', () => {
+  const startupSpec = readText('tests/e2e/specs/performance/startup-session-perf.spec.ts');
+
+  assert.match(startupSpec, /assertReleaseFastPerfRuntime/);
+  assert.match(startupSpec, /release-fast perf run loaded a dev-server URL/);
+  assert.match(startupSpec, /runtimeUrl/);
+});
+
+test('embedded startup probe uses short script timeouts while waiting for readiness', () => {
+  const embeddedDriver = readText('tests/e2e/config/embedded-driver.ts');
+
+  assert.match(embeddedDriver, /setProbeScriptTimeout/);
+  assert.match(embeddedDriver, /\/session\/\$\{sessionId\}\/timeouts/);
+  assert.match(embeddedDriver, /setProbeScriptTimeout\(sessionId, 1000\)/);
+});
+
+test('long session required frame trace samples fail when trace phases are missing', () => {
+  const startupSpec = readText('tests/e2e/specs/performance/startup-session-perf.spec.ts');
+
+  assert.match(startupSpec, /Long session measurement missing required trace phases/);
+  assert.match(startupSpec, /measurement\.traceWaitErrors\.length > 0/);
+  assert.match(startupSpec, /measurement\.clickToPostHydrateUsableMs\)\.toBeGreaterThan\(0\)/);
+});

--- a/tests/e2e/scripts/run-long-session-interaction-matrix.mjs
+++ b/tests/e2e/scripts/run-long-session-interaction-matrix.mjs
@@ -1,0 +1,291 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, '..', '..', '..');
+const REPORT_DIR = path.join(ROOT, 'tests', 'e2e', 'reports', 'performance');
+
+const scenarios = {
+  'first-open': {
+    spec: './specs/performance/startup-session-perf.spec.ts',
+    grep: 'collects first-open timing for a generated long session',
+    reportPrefix: 'long-session-first-open-',
+  },
+  'warm-reopen': {
+    spec: './specs/performance/startup-session-perf.spec.ts',
+    grep: 'collects warm-reopen timing for a generated long session',
+    reportPrefix: 'long-session-warm-reopen-',
+  },
+  'rapid-switch-zero-delay': {
+    spec: './specs/performance/startup-session-perf.spec.ts',
+    grep: 'collects rapid-switch timing across generated long sessions',
+    reportPrefix: 'long-session-rapid-switch-',
+    env: {
+      BITFUN_E2E_PERF_RAPID_SWITCH_DELAY_MS: '0',
+    },
+  },
+  'first-scroll': {
+    spec: './specs/performance/startup-session-perf.spec.ts',
+    grep: 'collects first-open timing for a generated long session',
+    reportPrefix: 'long-session-first-open-',
+    env: {
+      BITFUN_E2E_PERF_POST_VISIBLE_INTERACTION: 'first-scroll',
+    },
+  },
+  'scroll-down': {
+    spec: './specs/performance/startup-session-perf.spec.ts',
+    grep: 'collects first-open timing for a generated long session',
+    reportPrefix: 'long-session-first-open-',
+    env: {
+      BITFUN_E2E_PERF_POST_VISIBLE_INTERACTION: 'scroll-down',
+    },
+  },
+  'resize-window': {
+    spec: './specs/performance/startup-session-perf.spec.ts',
+    grep: 'collects first-open timing for a generated long session',
+    reportPrefix: 'long-session-first-open-',
+    env: {
+      BITFUN_E2E_PERF_POST_VISIBLE_INTERACTION: 'resize-window',
+    },
+  },
+  'resize-window-width': {
+    spec: './specs/performance/startup-session-perf.spec.ts',
+    grep: 'collects first-open timing for a generated long session',
+    reportPrefix: 'long-session-first-open-',
+    env: {
+      BITFUN_E2E_PERF_POST_VISIBLE_INTERACTION: 'resize-window-width',
+    },
+  },
+  'input-layout': {
+    spec: './specs/performance/session-input-layout.spec.ts',
+    reportPrefix: null,
+  },
+};
+
+const profiles = {
+  core: ['first-open', 'rapid-switch-zero-delay', 'first-scroll', 'resize-window-width'],
+  scroll: ['first-scroll', 'scroll-down'],
+  resize: ['resize-window', 'resize-window-width'],
+  full: [
+    'first-open',
+    'warm-reopen',
+    'rapid-switch-zero-delay',
+    'first-scroll',
+    'scroll-down',
+    'resize-window',
+    'resize-window-width',
+    'input-layout',
+  ],
+};
+
+function shellQuote(value) {
+  if (process.platform === 'win32') {
+    return `"${String(value).replace(/"/g, '\\"')}"`;
+  }
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function runPnpm(args, options) {
+  return spawnSync(['pnpm', ...args.map(shellQuote)].join(' '), {
+    ...options,
+    shell: true,
+  });
+}
+
+function runnerStdioOptions() {
+  if (process.env.BITFUN_E2E_PERF_RUNNER_STREAM_LOGS === '1') {
+    return { stdio: 'inherit' };
+  }
+  return { stdio: 'pipe', encoding: 'utf8' };
+}
+
+function outputTail(result) {
+  if (!result.stdout && !result.stderr) {
+    return '';
+  }
+  return [result.stdout, result.stderr]
+    .filter(Boolean)
+    .join('\n')
+    .split(/\r?\n/)
+    .slice(-80)
+    .join('\n');
+}
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  if (index < 0) {
+    return undefined;
+  }
+  return process.argv[index + 1];
+}
+
+function hasFlag(name) {
+  return process.argv.includes(name);
+}
+
+function allowMissingReports() {
+  return (
+    hasFlag('--allow-missing-reports') ||
+    process.env.BITFUN_E2E_PERF_ALLOW_MISSING_REPORTS === '1'
+  );
+}
+
+function newestReport(prefix, startedAtMs) {
+  if (!prefix || !fs.existsSync(REPORT_DIR)) {
+    return null;
+  }
+  const candidates = fs
+    .readdirSync(REPORT_DIR, { withFileTypes: true })
+    .filter(entry => entry.isFile() && entry.name.startsWith(prefix) && entry.name.endsWith('.json'))
+    .map(entry => {
+      const fullPath = path.join(REPORT_DIR, entry.name);
+      const stat = fs.statSync(fullPath);
+      return { fullPath, name: entry.name, mtimeMs: stat.mtimeMs };
+    })
+    .filter(entry => entry.mtimeMs >= startedAtMs - 1000)
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return candidates[0] ?? null;
+}
+
+function formatMs(value) {
+  return Number.isFinite(value) ? `${value.toFixed(1)}ms` : 'n/a';
+}
+
+function summarizeReport(file) {
+  if (!file) {
+    return null;
+  }
+  const report = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const sessionOpen = report.sessionOpen ?? {};
+  const rapidTarget = report.rapidSwitchBreakdown?.target ?? {};
+  const viewport = report.viewport ?? {};
+  const visualStateSummary = report.visualStateSummary ?? {};
+  return {
+    clickToLatestTextMs: Number(
+      report.clickToLatestAnswerTextVisibleMs ??
+        report.clickToLatestVisibleMs ??
+        rapidTarget.clickToLatestTextVisibleMs ??
+        rapidTarget.clickToLatestVisibleMs
+    ),
+    latestFrameSinceHydrateMs: Number(
+      sessionOpen.latestFrameSinceHydrateMs ??
+        rapidTarget.latestFrameSinceHydrateMs
+    ),
+    latestVisibleRoundCount: Number(viewport.visibleModelRoundCount),
+    postVisibleInteraction: report.postVisibleInteraction ?? 'none',
+    visualBlankEvents: Number(
+      visualStateSummary.postLatestTextVisibleBlankSurfacePointEventCount ??
+        visualStateSummary.openIntentBlankSurfacePointEventCount ??
+        visualStateSummary.blankSurfacePointEventCount
+    ),
+  };
+}
+
+function selectedScenarioNames() {
+  const requested =
+    argValue('--profile') ||
+    argValue('--scenarios') ||
+    process.env.BITFUN_E2E_PERF_MATRIX_PROFILE ||
+    'core';
+  const names = profiles[requested] ?? requested.split(',').map(name => name.trim()).filter(Boolean);
+  const unknown = names.filter(name => !scenarios[name]);
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown long-session interaction scenario/profile: ${unknown.join(', ')}. ` +
+        `Known profiles=${Object.keys(profiles).join(', ')} scenarios=${Object.keys(scenarios).join(', ')}`,
+    );
+  }
+  return { requested, names };
+}
+
+function runScenario(name, baseEnv, options) {
+  const scenario = scenarios[name];
+  const env = {
+    ...baseEnv,
+    ...(scenario.env ?? {}),
+  };
+  const args = [
+    '--dir',
+    'tests/e2e',
+    'exec',
+    'wdio',
+    'run',
+    './config/wdio.conf.ts',
+    '--spec',
+    scenario.spec,
+  ];
+  if (scenario.grep) {
+    args.push(`--mochaOpts.grep=${scenario.grep}`);
+  }
+
+  console.log(`[long-session-matrix] start scenario=${name}`);
+  const startedAtMs = Date.now();
+  const result = runPnpm(args, {
+    cwd: ROOT,
+    env,
+    ...runnerStdioOptions(),
+  });
+  const reportEntry = newestReport(scenario.reportPrefix, startedAtMs);
+  const summary = summarizeReport(reportEntry?.fullPath);
+  const missingExpectedReport =
+    Boolean(scenario.reportPrefix) && !reportEntry && !options.allowMissingReports;
+
+  if (summary) {
+    console.log(
+      `[long-session-matrix] done scenario=${name} ` +
+        `clickToLatestText=${formatMs(summary.clickToLatestTextMs)} ` +
+        `latestFrame=${formatMs(summary.latestFrameSinceHydrateMs)} ` +
+        `visibleRounds=${summary.latestVisibleRoundCount} ` +
+        `postInteraction=${summary.postVisibleInteraction} ` +
+        `blankEvents=${summary.visualBlankEvents} report=${reportEntry.name}`,
+    );
+  } else {
+    console.log(`[long-session-matrix] done scenario=${name} report=none`);
+  }
+
+  return {
+    name,
+    ok: result.status === 0 && !missingExpectedReport,
+    status: result.status,
+    error:
+      result.error?.message ??
+      (missingExpectedReport
+        ? 'expected performance report was not written; fixture may be missing or the spec skipped'
+        : outputTail(result)),
+    reportName: reportEntry?.name ?? null,
+  };
+}
+
+const { requested, names } = selectedScenarioNames();
+const missingReportsAllowed = allowMissingReports();
+const baseEnv = {
+  ...process.env,
+  BITFUN_E2E_APP_MODE: process.env.BITFUN_E2E_APP_MODE || 'release-fast',
+  E2E_LOG_LEVEL: process.env.E2E_LOG_LEVEL || 'warn',
+};
+
+if (hasFlag('--dry-run')) {
+  console.log(
+    `[long-session-matrix] dry-run profile=${requested} appMode=${baseEnv.BITFUN_E2E_APP_MODE} ` +
+      `allowMissingReports=${missingReportsAllowed} scenarios=${names.join(',')}`,
+  );
+  process.exit(0);
+}
+
+const results = names.map(name =>
+  runScenario(name, baseEnv, { allowMissingReports: missingReportsAllowed }),
+);
+const failed = results.filter(result => !result.ok);
+if (failed.length > 0) {
+  for (const failure of failed) {
+    console.error(
+      `[long-session-matrix] failed scenario=${failure.name} status=${failure.status} ` +
+        `error=${failure.error ?? 'none'} report=${failure.reportName ?? 'none'}`,
+    );
+  }
+  process.exit(1);
+}
+
+console.log(`[long-session-matrix] summary scenarios=${results.length} failed=0`);

--- a/tests/e2e/scripts/run-startup-stability.mjs
+++ b/tests/e2e/scripts/run-startup-stability.mjs
@@ -1,0 +1,259 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, '..', '..', '..');
+const REPORT_DIR = path.join(ROOT, 'tests', 'e2e', 'reports', 'performance');
+const STARTUP_TEST_NAME = 'collects startup timing from the current build';
+
+function readFlag(name) {
+  return process.argv.includes(name);
+}
+
+function readNumberEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative number, got ${raw}`);
+  }
+  return value;
+}
+
+function readIntegerEnv(name, fallback) {
+  return Math.max(1, Math.trunc(readNumberEnv(name, fallback)));
+}
+
+function shellQuote(value) {
+  if (process.platform === 'win32') {
+    return `"${String(value).replace(/"/g, '\\"')}"`;
+  }
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function runPnpm(args, options) {
+  return spawnSync(['pnpm', ...args.map(shellQuote)].join(' '), {
+    ...options,
+    shell: true,
+  });
+}
+
+function runnerStdioOptions() {
+  if (process.env.BITFUN_E2E_PERF_RUNNER_STREAM_LOGS === '1') {
+    return { stdio: 'inherit' };
+  }
+  return { stdio: 'pipe', encoding: 'utf8' };
+}
+
+function outputTail(result) {
+  if (!result.stdout && !result.stderr) {
+    return '';
+  }
+  return [result.stdout, result.stderr]
+    .filter(Boolean)
+    .join('\n')
+    .split(/\r?\n/)
+    .slice(-80)
+    .join('\n');
+}
+
+function formatMs(value) {
+  return Number.isFinite(value) ? `${value.toFixed(1)}ms` : 'n/a';
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function newestReport(prefix, startedAtMs) {
+  if (!fs.existsSync(REPORT_DIR)) {
+    return null;
+  }
+  const candidates = fs
+    .readdirSync(REPORT_DIR, { withFileTypes: true })
+    .filter(entry => entry.isFile() && entry.name.startsWith(prefix) && entry.name.endsWith('.json'))
+    .map(entry => {
+      const fullPath = path.join(REPORT_DIR, entry.name);
+      const stat = fs.statSync(fullPath);
+      return { fullPath, name: entry.name, mtimeMs: stat.mtimeMs };
+    })
+    .filter(entry => entry.mtimeMs >= startedAtMs - 1000)
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  return candidates[0] ?? null;
+}
+
+function summarizeReport(report) {
+  const startup = report.startup ?? {};
+  const firstScriptEvalMs = Number(startup.firstScriptEvalMs);
+  const mainWindowShownMs = Number(startup.mainWindowShownMs);
+  const interactiveShellReadyMs = Number(startup.interactiveShellReadyMs);
+  const mainShownToInteractiveMs =
+    Number.isFinite(interactiveShellReadyMs) && Number.isFinite(mainWindowShownMs)
+      ? interactiveShellReadyMs - mainWindowShownMs
+      : Number.NaN;
+
+  return {
+    traceId: report.traceId ?? 'unknown',
+    runtimeUrl: report.runtimeUrl ?? 'unknown',
+    runtimeHostname: report.runtimeHostname ?? 'unknown',
+    firstScriptEvalMs,
+    mainWindowShownMs,
+    interactiveShellReadyMs,
+    mainShownToInteractiveMs,
+    setupTrayBuildMs: Number(report.breakdown?.native?.setupSteps?.['setup_tray.build']),
+  };
+}
+
+function checkThresholds(summary, thresholds) {
+  const failures = [];
+  for (const field of [
+    'interactiveShellReadyMs',
+    'firstScriptEvalMs',
+    'mainShownToInteractiveMs',
+  ]) {
+    if (!Number.isFinite(summary[field])) {
+      failures.push(`${field}=n/a`);
+    }
+  }
+  if (summary.interactiveShellReadyMs > thresholds.interactiveShellReadyMs) {
+    failures.push(
+      `interactive=${formatMs(summary.interactiveShellReadyMs)} > ${formatMs(thresholds.interactiveShellReadyMs)}`,
+    );
+  }
+  if (summary.firstScriptEvalMs > thresholds.firstScriptEvalMs) {
+    failures.push(
+      `firstScript=${formatMs(summary.firstScriptEvalMs)} > ${formatMs(thresholds.firstScriptEvalMs)}`,
+    );
+  }
+  if (summary.mainShownToInteractiveMs > thresholds.mainShownToInteractiveMs) {
+    failures.push(
+      `shownToInteractive=${formatMs(summary.mainShownToInteractiveMs)} > ${formatMs(thresholds.mainShownToInteractiveMs)}`,
+    );
+  }
+  return failures;
+}
+
+function runStartupIteration(index, total, env, thresholds, seenTraceIds) {
+  const startedAtMs = Date.now();
+  const result = runPnpm(
+    [
+      '--dir',
+      'tests/e2e',
+      'exec',
+      'wdio',
+      'run',
+      './config/wdio.conf.ts',
+      '--spec',
+      './specs/performance/startup-session-perf.spec.ts',
+      `--mochaOpts.grep=${STARTUP_TEST_NAME}`,
+    ],
+    {
+      cwd: ROOT,
+      env,
+      ...runnerStdioOptions(),
+    },
+  );
+
+  const reportEntry = newestReport('startup-', startedAtMs);
+  if (result.status !== 0) {
+    const tail = outputTail(result);
+    return {
+      ok: false,
+      error: result.error
+        ? `wdio failed to spawn: ${result.error.message}`
+        : `wdio exited with ${result.status}${tail ? `\n${tail}` : ''}`,
+      reportName: reportEntry?.name ?? null,
+    };
+  }
+  if (!reportEntry) {
+    return {
+      ok: false,
+      error: 'startup report was not written',
+      reportName: null,
+    };
+  }
+
+  const summary = summarizeReport(readJson(reportEntry.fullPath));
+  const thresholdFailures = checkThresholds(summary, thresholds);
+  if (!summary.traceId || summary.traceId === 'unknown') {
+    thresholdFailures.push('traceId=missing');
+  } else if (seenTraceIds.has(summary.traceId)) {
+    thresholdFailures.push(`traceId=${summary.traceId} was already reported by an earlier iteration`);
+  } else {
+    seenTraceIds.add(summary.traceId);
+  }
+  const line =
+    `[startup-stability] ${index}/${total} ` +
+    `interactive=${formatMs(summary.interactiveShellReadyMs)} ` +
+    `firstScript=${formatMs(summary.firstScriptEvalMs)} ` +
+    `shownToInteractive=${formatMs(summary.mainShownToInteractiveMs)} ` +
+    `trayBuild=${formatMs(summary.setupTrayBuildMs)} ` +
+    `trace=${summary.traceId} runtime=${summary.runtimeHostname} report=${reportEntry.name}`;
+  console.log(line);
+
+  return {
+    ok: thresholdFailures.length === 0,
+    error: thresholdFailures.join('; '),
+    reportName: reportEntry.name,
+    summary,
+  };
+}
+
+const iterations = readIntegerEnv('BITFUN_E2E_PERF_STARTUP_ITERATIONS', 5);
+const thresholds = {
+  interactiveShellReadyMs: readNumberEnv('BITFUN_E2E_PERF_STARTUP_MAX_INTERACTIVE_MS', 5000),
+  firstScriptEvalMs: readNumberEnv('BITFUN_E2E_PERF_STARTUP_MAX_FIRST_SCRIPT_MS', 3000),
+  mainShownToInteractiveMs: readNumberEnv(
+    'BITFUN_E2E_PERF_STARTUP_MAX_MAIN_SHOWN_TO_INTERACTIVE_MS',
+    3000,
+  ),
+};
+const env = {
+  ...process.env,
+  BITFUN_E2E_APP_MODE: process.env.BITFUN_E2E_APP_MODE || 'release-fast',
+  E2E_LOG_LEVEL: process.env.E2E_LOG_LEVEL || 'warn',
+};
+
+if (readFlag('--dry-run')) {
+  console.log(
+    `[startup-stability] dry-run iterations=${iterations} appMode=${env.BITFUN_E2E_APP_MODE} ` +
+      `grep="${STARTUP_TEST_NAME}"`,
+  );
+  process.exit(0);
+}
+
+const results = [];
+const seenTraceIds = new Set();
+for (let index = 1; index <= iterations; index += 1) {
+  results.push(runStartupIteration(index, iterations, env, thresholds, seenTraceIds));
+}
+
+const failed = results.filter(result => !result.ok);
+const summaries = results.map(result => result.summary).filter(Boolean);
+if (summaries.length > 0) {
+  const interactiveValues = summaries
+    .map(summary => summary.interactiveShellReadyMs)
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const min = interactiveValues[0];
+  const max = interactiveValues[interactiveValues.length - 1];
+  const median = interactiveValues[Math.floor(interactiveValues.length / 2)];
+  console.log(
+    `[startup-stability] summary samples=${interactiveValues.length} ` +
+      `interactiveMedian=${formatMs(median)} min=${formatMs(min)} max=${formatMs(max)}`,
+  );
+}
+
+if (failed.length > 0) {
+  for (const failure of failed) {
+    console.error(
+      `[startup-stability] failed report=${failure.reportName ?? 'none'} reason=${failure.error}`,
+    );
+  }
+  process.exit(1);
+}

--- a/tests/e2e/specs/performance/startup-session-perf.spec.ts
+++ b/tests/e2e/specs/performance/startup-session-perf.spec.ts
@@ -612,6 +612,30 @@ function numericEnv(name: string): number | undefined {
   return Number.isFinite(value) ? value : undefined;
 }
 
+async function assertReleaseFastPerfRuntime(): Promise<{
+  runtimeUrl: string;
+  runtimeHostname: string;
+}> {
+  const runtime = await browser.execute(() => ({
+    runtimeUrl: window.location.href,
+    runtimeHostname: window.location.hostname,
+  }));
+  const appMode = (process.env.BITFUN_E2E_APP_MODE ?? '').toLowerCase();
+  const allowDevServer = process.env.BITFUN_E2E_ALLOW_RELEASE_FAST_DEV_SERVER === '1';
+  const isDevServerRuntime =
+    runtime.runtimeHostname === 'localhost' || runtime.runtimeHostname === '127.0.0.1';
+
+  if (appMode === 'release-fast' && isDevServerRuntime && !allowDevServer) {
+    throw new Error(
+      `release-fast perf run loaded a dev-server URL: ${runtime.runtimeUrl}. ` +
+        'Build with pnpm run desktop:build:release-fast, or set ' +
+        'BITFUN_E2E_ALLOW_RELEASE_FAST_DEV_SERVER=1 only for explicit dev-server diagnostics.',
+    );
+  }
+
+  return runtime;
+}
+
 const DEFAULT_POST_VISIBLE_OBSERVE_MS = 3000;
 
 async function waitForOptionalPhaseCount(
@@ -4366,12 +4390,16 @@ function expectLongSessionMeasurementUsable(
   options: LongSessionOpenMeasurementOptions = {},
 ): void {
   const requireLatestModelRound = requiresLatestModelRoundForFixture(measurement.fixtureScenario);
+  const requireFrameTrace = options.requireFrameTrace !== false;
   expect(measurement.clickToLatestVisibleMs).toBeGreaterThan(0);
   expect(measurement.clickToLatestUsableMs).toBeGreaterThan(0);
-  if (options.requireFrameTrace !== false && measurement.traceWaitErrors.length === 0) {
-    expect(measurement.clickToPostHydrateUsableMs).toBeGreaterThan(0);
+  if (requireFrameTrace && measurement.traceWaitErrors.length > 0) {
+    throw new Error(
+      `Long session measurement missing required trace phases: ${measurement.traceWaitErrors.join('; ')}`,
+    );
   }
-  if (options.requireFrameTrace !== false && measurement.traceWaitErrors.length === 0) {
+  if (requireFrameTrace) {
+    expect(measurement.clickToPostHydrateUsableMs).toBeGreaterThan(0);
     expect(measurement.sessionOpen.hydrateDurationMs).toBeGreaterThan(0);
     expect(measurement.sessionOpen.latestFrameSinceHydrateMs).toBeGreaterThan(0);
     expect(measurement.sessionOpen.clickToLatestFrameMs).toBeGreaterThan(0);
@@ -4545,9 +4573,11 @@ describe('Performance telemetry', () => {
 
   before(async () => {
     await waitForTracePhaseCount('interactive_shell_ready', 1, 30000);
+    await assertReleaseFastPerfRuntime();
   });
 
   it('collects startup timing from the current build', async () => {
+    const runtime = await assertReleaseFastPerfRuntime();
     const snapshot = await readStartupTraceSnapshot();
     const startup = summarizeStartup(snapshot);
     const breakdown = summarizeStartupBreakdown(snapshot);
@@ -4556,6 +4586,7 @@ describe('Performance telemetry', () => {
 
     console.log('[Perf] startup', JSON.stringify({
       appMode: process.env.BITFUN_E2E_APP_MODE ?? 'auto',
+      ...runtime,
       traceId: snapshot.traceId,
       startup,
       breakdown,
@@ -4564,6 +4595,7 @@ describe('Performance telemetry', () => {
     }));
     await writeReport('startup', {
       appMode: process.env.BITFUN_E2E_APP_MODE ?? 'auto',
+      ...runtime,
       traceId: snapshot.traceId,
       startup,
       breakdown,


### PR DESCRIPTION
## Summary

- Move desktop tray construction out of synchronous Tauri setup. Tray initialization now runs after startup handoff/idle and is still initialized on demand before close-to-tray.
- Reduce long-session first-paint contention by overlapping restore/import/config work, avoiding stale local hydrate commits after switching away, and preventing metadata-only local deferred history from showing a loading flicker.
- Add focused startup and long-session performance guards, including trace target isolation, duplicate trace-id checks, startup tray slices, and long-session frame/blank detection.

## Latest End-to-End Data

Measured on 2026-06-17 against latest `gcwing/main` `47343595`, release-fast, same machine and focused runners. For the long-session main baseline, the newer guard exits non-zero because main lacks `historical_session_after_state_commit_frame`; the shared report fields were still written and are compared below.

| Scenario | Latest main | This PR | Delta |
| --- | ---: | ---: | ---: |
| Cold startup to shell interactive, median | 455.6 ms | 452.5 ms | -3.1 ms |
| Cold startup to shell interactive, max | 631.8 ms | 538.4 ms | -93.4 ms |
| Startup setup includes tray build | 16-31 ms | n/a | removed from startup setup path |
| Long session first open, latest text visible | 154.1 ms | 157.1 ms | +3.0 ms |
| Rapid switch target, latest text visible | 190.5 ms | 178.7 ms | -11.8 ms |
| Rapid switch target, usable after click | 236.0 ms | 211.0 ms | -25.0 ms |
| Long session first scroll, latest text visible | 147.8 ms | 157.2 ms | +9.4 ms |
| Resize after session open, latest text visible | 152.2 ms | 146.7 ms | -5.5 ms |
| Long-session blank events | 0 | 0 | no regression observed |

Interpretation: the startup median is essentially flat. The measurable startup value is outlier containment and removing tray construction from the synchronous setup bucket. The clearest end-to-end session win is rapid-switch responsiveness; first-open and first-scroll have small regressions in this sample and are kept in the table as counter-metrics.

## Risks And Safeguards

- Tray icon visibility is intentionally delayed until after shell handoff. Close-to-tray still initializes the tray on demand; if that initialization fails, the app logs a warning and continues hiding instead of changing close semantics into quit.
- Full-history hydration is more aggressive after initial paint. Stale local hydrate commits are skipped when the active session changes, which protects rapid A/B/C switching.
- The ACP requirements probe was removed only from the non-critical deferred startup background path. ACP client initialization and remote-facing functionality were not otherwise changed.
- The E2E guard fails when required trace phases are missing, so perf samples should be treated as invalid instead of silently passing with incomplete observability.

## Validation

Local verification:

- `pnpm --dir src/web-ui run lint`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/app/services/AppManager.test.ts src/app/startup/startupPerformanceContract.test.ts src/flow_chat/store/FlowChatStore.test.ts`
- `node --test tests/e2e/scripts/perf-coverage-contract.test.mjs`
- `cargo check -p bitfun-desktop`
- `git diff --check gcwing/main...HEAD`
- `pnpm run desktop:build:release-fast`
- `node tests/e2e/scripts/run-startup-stability.mjs`
- `node tests/e2e/scripts/run-long-session-interaction-matrix.mjs`

GitHub Actions after the latest push:

- Frontend Build: passed
- Rust Build Check (macOS, Ubuntu, Windows): passed