### PR TITLE
refactor(web-ui): normalize theme exception domains

### DIFF
--- a/scripts/audit-theme-colors.mjs
+++ b/scripts/audit-theme-colors.mjs
@@ -129,6 +129,13 @@ function normalizePath(filePath) {
   return filePath.split(path.sep).join('/');
 }
 
+function isAuditTestFile(relativePath) {
+  return (
+    /(^|\/)__tests__\//.test(relativePath)
+    || /\.(?:test|spec)\.[a-z0-9]+$/i.test(relativePath)
+  );
+}
+
 function isTokenFile(relativePath) {
   return TOKEN_PATH_PARTS.some(part => relativePath.includes(part));
 }
@@ -640,6 +647,13 @@ function applyBaseline(report, options) {
     category: 'nonContractCssPrivate',
     reportField: 'nonContractCssPrivateVars',
   }));
+  baselineSummary.failures.push(...evaluateAllowlistCategory({
+    report,
+    baseline,
+    baselineLabel,
+    category: 'intentionalFallbackTokens',
+    reportField: 'fallbackVars',
+  }));
 
   return baselineSummary;
 }
@@ -649,11 +663,13 @@ function audit(options) {
   const checksFullThemeSourceRoot = root === path.resolve(DEFAULT_ROOT);
   const files = walkFiles(root);
   const cwd = process.cwd();
-  const tokenAliasDefinitionsByColorKey = collectTokenAliasDefinitions(files, cwd);
+  const auditedFiles = files.filter(file => !isAuditTestFile(normalizePath(path.relative(cwd, file))));
+  const tokenAliasDefinitionsByColorKey = collectTokenAliasDefinitions(auditedFiles, cwd);
 
   const colorCounts = new Map();
   const componentColorCounts = new Map();
   const fallbackTokenCounts = new Map();
+  const fallbackTokenFiles = new Map();
   const varUsageCounts = new Map();
   const varDefinitionCounts = new Map();
   const varDefinitionKinds = new Map();
@@ -678,7 +694,7 @@ function audit(options) {
   let componentColorOccurrences = 0;
   let fallbackOccurrences = 0;
 
-  for (const file of files) {
+  for (const file of auditedFiles) {
     const relativePath = normalizePath(path.relative(cwd, file));
     const content = createAuditContent(fs.readFileSync(file, 'utf8'), relativePath);
     const tokenFile = isTokenFile(relativePath);
@@ -761,6 +777,7 @@ function audit(options) {
     for (const match of collectMatches(content, VAR_FALLBACK_PATTERN)) {
       fallbackOccurrences += 1;
       incrementMap(fallbackTokenCounts, match[1]);
+      addToSetMap(fallbackTokenFiles, match[1], relativePath);
     }
   }
 
@@ -869,10 +886,18 @@ function audit(options) {
       topColors: topEntries(counts, options.top),
     }];
   }));
+  const fallbackVars = Array.from(fallbackTokenCounts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([key, count]) => ({
+      key,
+      count,
+      files: Array.from(fallbackTokenFiles.get(key) ?? []).sort().slice(0, 5),
+    }));
 
   return {
     root: normalizePath(path.relative(cwd, root)) || '.',
-    filesScanned: files.length,
+    filesScanned: auditedFiles.length,
+    ignoredTestFiles: files.length - auditedFiles.length,
     filesWithColors: fileColorCounts.size,
     colorOccurrences,
     uniqueColors: colorCounts.size,
@@ -898,6 +923,7 @@ function audit(options) {
     tokenUniqueColors: tokenColorCounts.size,
     exceptionUniqueColors: exceptionColorCounts.size,
     fallbackOccurrences,
+    fallbackUniqueTokens: fallbackVars.length,
     budget: {
       uniqueAppColorBudget: options.budget,
       uniqueComponentColors,
@@ -906,7 +932,8 @@ function audit(options) {
     topColors: topEntries(colorCounts, options.top),
     topComponentColors: topEntries(componentColorCounts, options.top),
     topFiles: topEntries(fileColorCounts, options.top),
-    topFallbackTokens: topEntries(fallbackTokenCounts, options.top),
+    topFallbackTokens: fallbackVars.slice(0, options.top).map(({ key, count }) => ({ key, count })),
+    fallbackVars,
     tokenAliasLiterals: {
       occurrences: sumMapValues(tokenAliasLiteralCounts),
       uniqueColors: tokenAliasLiteralCounts.size,
@@ -954,6 +981,7 @@ function printText(report) {
 
   console.log(`Theme color audit: ${report.root}`);
   console.log(`Files scanned: ${report.filesScanned}`);
+  console.log(`Ignored test files: ${report.ignoredTestFiles}`);
   console.log(`Files with colors: ${report.filesWithColors}`);
   console.log(`Color occurrences: ${report.colorOccurrences}`);
   console.log(`Unique colors: ${report.uniqueColors}`);
@@ -963,6 +991,7 @@ function printText(report) {
   console.log(`Unique component color budget: ${report.budget.uniqueAppColorBudget}`);
   console.log(`Over budget by: ${report.budget.overBudgetBy}`);
   console.log(`Fallback var occurrences: ${report.fallbackOccurrences}`);
+  console.log(`Fallback var unique tokens: ${report.fallbackUniqueTokens}`);
   console.log(`Token-equivalent app literal occurrences: ${report.tokenAliasLiterals.occurrences}`);
   console.log(`Token-equivalent app literal unique colors: ${report.tokenAliasLiterals.uniqueColors}`);
 

--- a/scripts/audit-theme-colors.test.mjs
+++ b/scripts/audit-theme-colors.test.mjs
@@ -125,6 +125,7 @@ test('theme color audit reports specialized color domains separately from app UI
     'tools/terminal/utils/xtermTheme.ts': "export const cursor = '#c0c0c0';\n",
     'tools/generative-widget/themePayload.ts': "export const fallback = { '--color-text-primary': '#666666' };\n",
     'shared/inspector/inspectorOverlayTheme.ts': "export const overlay = { activeBorder: '#777777' };\n",
+    'shared/theme/uiExceptionAccents.ts': "export const accents = { tool: '#dddddd' };\n",
     'infrastructure/language-detection/core/LanguageRegistry.ts': "export const rust = '#888888';\n",
     'component-library/components/TextStrokeEffect/TextStrokeEffect.tsx': "export const stroke = '#999999';\n",
     'component-library/components/StreamText/StreamText.scss': ".stream { color: #bbbbbb; }\n",
@@ -146,6 +147,7 @@ test('theme color audit reports specialized color domains separately from app UI
   assert.equal(report.colorDomainScopes.terminal.uniqueColors, 1);
   assert.equal(report.colorDomainScopes.generatedWidget.uniqueColors, 1);
   assert.equal(report.colorDomainScopes.debugOverlay.uniqueColors, 1);
+  assert.equal(report.colorDomainScopes.uiException.uniqueColors, 1);
   assert.equal(report.colorDomainScopes.languageIdentity.uniqueColors, 1);
   assert.equal(report.colorDomainScopes.visualEffect.uniqueColors, 2);
   assert.equal(report.colorDomainScopes.appUi.uniqueColors, 2);
@@ -291,6 +293,25 @@ test('theme color audit reports app literals that duplicate token values', (t) =
   assert.equal(report.colorScopes.exception.occurrences, 1);
 });
 
+test('theme color audit excludes test files from production color budgets', (t) => {
+  const { dir, sourceRoot } = createFixture({
+    'component-library/styles/tokens.scss': ':root { --color-error: #ef4444; }\n',
+    'app/App.scss': '.app { color: #ef4444; }\n',
+    'app/App.test.tsx': "expect(button).toHaveStyle({ color: '#ef4444' });\n",
+    'app/__tests__/Fixture.tsx': "export const visualLock = '#ef4444';\n",
+  });
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const result = runAudit(['--root', sourceRoot, '--json', '--no-baseline']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.filesScanned, 2);
+  assert.equal(report.ignoredTestFiles, 2);
+  assert.equal(report.colorScopes.appUi.occurrences, 1);
+  assert.equal(report.tokenAliasLiterals.occurrences, 1);
+});
+
 test('theme color audit fails when metrics exceed the checked baseline', (t) => {
   const { dir, sourceRoot } = createFixture({
     'app/App.scss': [
@@ -314,6 +335,76 @@ test('theme color audit fails when metrics exceed the checked baseline', (t) => 
   assert.match(
     `${result.stdout}\n${result.stderr}`,
     /fallbackOccurrences has 1 candidate\(s\), baseline is 0/,
+  );
+});
+
+test('theme color audit requires intentional fallback tokens to be allowlisted', (t) => {
+  const { dir, sourceRoot } = createFixture({
+    'app/App.scss': [
+      '.app {',
+      '  color: var(--runtime-accent, var(--color-accent-500));',
+      '}',
+      '',
+    ].join('\n'),
+  });
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const baselinePath = path.join(dir, 'theme-baseline.json');
+  const baseline = {
+    version: 1,
+    budgets: {
+      fallbackUniqueTokens: { max: 1 },
+    },
+    allowlists: {
+      intentionalFallbackTokens: [],
+    },
+  };
+  writeText(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`);
+
+  const blocked = runAudit(['--root', sourceRoot, '--baseline', baselinePath]);
+  assert.notEqual(blocked.status, 0, 'unallowlisted fallback tokens must fail the audit');
+  assert.match(
+    `${blocked.stdout}\n${blocked.stderr}`,
+    /intentionalFallbackTokens is missing allowlist entry for --runtime-accent/,
+  );
+
+  baseline.allowlists.intentionalFallbackTokens.push({
+    key: '--runtime-accent',
+    owner: 'scripts/audit-theme-colors.test.mjs',
+    reason: 'fixture runtime color fallback',
+  });
+  writeText(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`);
+
+  const allowed = runAudit(['--root', sourceRoot, '--baseline', baselinePath]);
+  assert.equal(allowed.status, 0, allowed.stderr || allowed.stdout);
+});
+
+test('theme color audit fails stale intentional fallback token allowlist entries', (t) => {
+  const { dir, sourceRoot } = createFixture({
+    'app/App.scss': '.app { color: var(--color-accent-500); }\n',
+  });
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const baselinePath = path.join(dir, 'theme-baseline.json');
+  writeText(baselinePath, `${JSON.stringify({
+    version: 1,
+    budgets: {
+      fallbackUniqueTokens: { max: 0 },
+    },
+    allowlists: {
+      intentionalFallbackTokens: [
+        {
+          key: '--removed-fallback',
+          owner: 'scripts/audit-theme-colors.test.mjs',
+          reason: 'fixture stale fallback token',
+        },
+      ],
+    },
+  }, null, 2)}\n`);
+
+  const result = runAudit(['--root', sourceRoot, '--baseline', baselinePath]);
+  assert.notEqual(result.status, 0, 'stale fallback allowlist entries must fail the audit');
+  assert.match(
+    `${result.stdout}\n${result.stderr}`,
+    /intentionalFallbackTokens allowlist entry --removed-fallback is stale/,
   );
 });
 

--- a/scripts/theme-color-governance-baseline.json
+++ b/scripts/theme-color-governance-baseline.json
@@ -5,17 +5,20 @@
     "fallbackOccurrences": {
       "max": 31
     },
+    "fallbackUniqueTokens": {
+      "max": 10
+    },
     "colorScopes.appUi.uniqueColors": {
-      "max": 268
+      "max": 255
     },
     "colorScopes.appUi.occurrences": {
-      "max": 398
+      "max": 309
     },
     "colorScopes.token.uniqueColors": {
-      "max": 698
+      "max": 697
     },
     "colorScopes.exception.uniqueColors": {
-      "max": 172
+      "max": 188
     },
     "cssVarDefinitions.unresolvedRequiredUnique": {
       "max": 0
@@ -42,10 +45,10 @@
       "max": 0
     },
     "tokenAliasLiterals.occurrences": {
-      "max": 54
+      "max": 34
     },
     "tokenAliasLiterals.uniqueColors": {
-      "max": 29
+      "max": 26
     },
     "colorDomainScopes.themePreset.occurrences": {
       "max": 1033
@@ -54,19 +57,19 @@
       "max": 611
     },
     "colorDomainScopes.themeRuntime.occurrences": {
-      "max": 62
+      "max": 54
     },
     "colorDomainScopes.tokenContract.occurrences": {
       "max": 268
     },
     "colorDomainScopes.generatedWidget.occurrences": {
-      "max": 19
+      "max": 17
     },
     "colorDomainScopes.generatedWidget.uniqueColors": {
       "max": 17
     },
     "colorDomainScopes.editor.occurrences": {
-      "max": 206
+      "max": 151
     },
     "colorDomainScopes.syntax.occurrences": {
       "max": 18
@@ -74,23 +77,86 @@
     "colorDomainScopes.terminal.occurrences": {
       "max": 38
     },
+    "colorDomainScopes.debugOverlay.occurrences": {
+      "max": 0
+    },
+    "colorDomainScopes.uiException.occurrences": {
+      "max": 20
+    },
+    "colorDomainScopes.uiException.uniqueColors": {
+      "max": 19
+    },
     "colorDomainScopes.languageIdentity.occurrences": {
       "max": 48
     },
     "colorDomainScopes.visualEffect.occurrences": {
-      "max": 42
+      "max": 26
     },
     "colorDomainScopes.appUi.occurrences": {
-      "max": 129
+      "max": 123
     },
     "colorDomainScopes.appUi.uniqueColors": {
-      "max": 112
+      "max": 108
     },
     "colorDomainScopes.mermaid.occurrences": {
-      "max": 149
+      "max": 139
     },
     "colorDomainScopes.mermaid.uniqueColors": {
       "max": 95
     }
+  },
+  "allowlists": {
+    "intentionalFallbackTokens": [
+      {
+        "key": "--surface-stagger-index",
+        "owner": "src/web-ui/src/app/components/GalleryLayout; app scene cards",
+        "reason": "runtime inline animation index with zero fallback for first-paint and non-animated states"
+      },
+      {
+        "key": "--mission-control-group-color",
+        "owner": "src/web-ui/src/app/components/panels/content-canvas/mission-control",
+        "reason": "runtime group identity color with accent fallback when no group color is assigned"
+      },
+      {
+        "key": "--char-index",
+        "owner": "src/web-ui/src/component-library/components/StreamText",
+        "reason": "runtime per-character animation offset with zero fallback outside animated rendering"
+      },
+      {
+        "key": "--shadow-color",
+        "owner": "agent surface cards and Markdown Mermaid block",
+        "reason": "surface-local shadow tint override with governed default shadow fallbacks"
+      },
+      {
+        "key": "--assistant-card-gradient",
+        "owner": "src/web-ui/src/app/scenes/profile/views/NurseryView.scss",
+        "reason": "runtime assistant identity gradient with static visual fallback for unloaded card metadata"
+      },
+      {
+        "key": "--gallery-grid-min",
+        "owner": "src/web-ui/src/app/components/GalleryLayout",
+        "reason": "runtime layout sizing input with stable grid fallback"
+      },
+      {
+        "key": "--gallery-skeleton-height",
+        "owner": "src/web-ui/src/app/components/GalleryLayout",
+        "reason": "runtime skeleton sizing input with stable placeholder fallback"
+      },
+      {
+        "key": "--operation-color",
+        "owner": "src/web-ui/src/component-library/components/FlowChatCards/SnapshotCard",
+        "reason": "runtime snapshot operation identity color with accent fallback"
+      },
+      {
+        "key": "--primary-color",
+        "owner": "src/web-ui/src/component-library/components/Markdown",
+        "reason": "embedded markdown primary accent override with global accent fallback"
+      },
+      {
+        "key": "--scene-viewport-border-width",
+        "owner": "src/web-ui/src/app/scenes/SceneViewport.scss",
+        "reason": "runtime viewport layout override with zero-width default"
+      }
+    ]
   }
 }

--- a/scripts/theme-css-var-contract.mjs
+++ b/scripts/theme-css-var-contract.mjs
@@ -28,6 +28,7 @@ export const RUNTIME_CONTRACT_VAR_DEFINITION_PATH_PARTS = [
 ];
 
 export const EXCEPTION_PATH_PARTS = [
+  'shared/theme/uiExceptionAccents',
   'monaco',
   'terminal',
   'mermaid',
@@ -84,6 +85,11 @@ export const COLOR_DOMAIN_RULES = [
     key: 'debugOverlay',
     label: 'Debug overlay',
     pathParts: ['shared/inspector'],
+  },
+  {
+    key: 'uiException',
+    label: 'UI exception registry',
+    pathParts: ['shared/theme/uiExceptionAccents'],
   },
   {
     key: 'languageIdentity',

--- a/src/web-ui/src/app/scenes/miniapps/utils/buildMiniAppThemeVars.test.ts
+++ b/src/web-ui/src/app/scenes/miniapps/utils/buildMiniAppThemeVars.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ThemeConfig, ThemeType } from '@/infrastructure/theme/types';
+import { buildMiniAppThemeVars } from './buildMiniAppThemeVars';
+
+function createTheme(type: ThemeType, scrollbar?: { thumb: string; thumbHover: string }): ThemeConfig {
+  return {
+    id: `${type}-fixture`,
+    name: `${type} fixture`,
+    type,
+    colors: {
+      background: {
+        primary: '#111111',
+        secondary: '#222222',
+        tertiary: '#333333',
+        elevated: '#444444',
+      },
+      text: {
+        primary: '#eeeeee',
+        secondary: '#dddddd',
+        muted: '#cccccc',
+      },
+      accent: {
+        500: '#60a5fa',
+        600: '#3b82f6',
+      },
+      semantic: {
+        success: '#22c55e',
+        warning: '#f59e0b',
+        error: '#ef4444',
+        info: '#38bdf8',
+      },
+      border: {
+        base: '#555555',
+        subtle: '#666666',
+      },
+      element: {
+        base: '#777777',
+        medium: '#888888',
+      },
+      scrollbar,
+    },
+  } as unknown as ThemeConfig;
+}
+
+describe('buildMiniAppThemeVars', () => {
+  it('keeps dark and light scrollbar fallbacks output-equivalent', () => {
+    expect(buildMiniAppThemeVars(createTheme('dark'))?.vars).toMatchObject({
+      '--bitfun-scrollbar-thumb': 'rgba(255, 255, 255, 0.12)',
+      '--bitfun-scrollbar-thumb-hover': 'rgba(255, 255, 255, 0.22)',
+    });
+
+    expect(buildMiniAppThemeVars(createTheme('light'))?.vars).toMatchObject({
+      '--bitfun-scrollbar-thumb': 'rgba(0, 0, 0, 0.15)',
+      '--bitfun-scrollbar-thumb-hover': 'rgba(0, 0, 0, 0.28)',
+    });
+  });
+
+  it('preserves theme-provided scrollbar values over fallback values', () => {
+    expect(
+      buildMiniAppThemeVars(createTheme('dark', {
+        thumb: 'theme-thumb',
+        thumbHover: 'theme-thumb-hover',
+      }))?.vars,
+    ).toMatchObject({
+      '--bitfun-scrollbar-thumb': 'theme-thumb',
+      '--bitfun-scrollbar-thumb-hover': 'theme-thumb-hover',
+    });
+  });
+});

--- a/src/web-ui/src/app/scenes/miniapps/utils/buildMiniAppThemeVars.ts
+++ b/src/web-ui/src/app/scenes/miniapps/utils/buildMiniAppThemeVars.ts
@@ -10,6 +10,17 @@ export interface MiniAppThemePayload {
   vars: Record<string, string>;
 }
 
+const MINI_APP_SCROLLBAR_FALLBACKS: Record<ThemeType, { thumb: string; thumbHover: string }> = {
+  dark: {
+    thumb: 'rgba(255, 255, 255, 0.12)',
+    thumbHover: 'rgba(255, 255, 255, 0.22)',
+  },
+  light: {
+    thumb: 'rgba(0, 0, 0, 0.15)',
+    thumbHover: 'rgba(0, 0, 0, 0.28)',
+  },
+};
+
 export function buildMiniAppThemeVars(theme: ThemeConfig | null): MiniAppThemePayload | null {
   if (!theme) return null;
 
@@ -53,10 +64,9 @@ export function buildMiniAppThemeVars(theme: ThemeConfig | null): MiniAppThemePa
     vars['--bitfun-scrollbar-thumb'] = colors.scrollbar.thumb;
     vars['--bitfun-scrollbar-thumb-hover'] = colors.scrollbar.thumbHover;
   } else {
-    vars['--bitfun-scrollbar-thumb'] =
-      theme.type === 'dark' ? 'rgba(255, 255, 255, 0.12)' : 'rgba(0, 0, 0, 0.15)';
-    vars['--bitfun-scrollbar-thumb-hover'] =
-      theme.type === 'dark' ? 'rgba(255, 255, 255, 0.22)' : 'rgba(0, 0, 0, 0.28)';
+    const scrollbarFallback = MINI_APP_SCROLLBAR_FALLBACKS[theme.type];
+    vars['--bitfun-scrollbar-thumb'] = scrollbarFallback.thumb;
+    vars['--bitfun-scrollbar-thumb-hover'] = scrollbarFallback.thumbHover;
   }
 
   return {

--- a/src/web-ui/src/component-library/components/TextStrokeEffect/TextStrokeEffect.test.ts
+++ b/src/web-ui/src/component-library/components/TextStrokeEffect/TextStrokeEffect.test.ts
@@ -4,19 +4,26 @@ import {
   TEXT_STROKE_GRADIENT_COLORS,
   buildTextStrokeColorCycle,
 } from './TextStrokeEffectGradient';
+import { UI_EXCEPTION_ACCENTS } from '@/shared/theme/uiExceptionAccents';
+
+const MIGRATED_TEXT_STROKE_VISUAL_SEQUENCE = [
+  '#eab308',
+  '#ef4444',
+  '#3b82f6',
+  '#06b6d4',
+  '#8b5cf6',
+] as const;
 
 describe('TextStrokeEffect color cycles', () => {
   it('keeps gradient animation values closed over the original visual color sequence', () => {
-    expect(TEXT_STROKE_GRADIENT_COLORS).toEqual([
-      '#eab308',
-      '#ef4444',
-      '#3b82f6',
-      '#06b6d4',
-      '#8b5cf6',
-    ]);
+    expect(UI_EXCEPTION_ACCENTS.textStroke).toEqual(MIGRATED_TEXT_STROKE_VISUAL_SEQUENCE);
+    expect(TEXT_STROKE_GRADIENT_COLORS).toBe(UI_EXCEPTION_ACCENTS.textStroke);
 
-    expect(buildTextStrokeColorCycle(2)).toBe(
-      '#3b82f6; #06b6d4; #8b5cf6; #eab308; #ef4444; #3b82f6',
-    );
+    const expectedCycle = [
+      ...MIGRATED_TEXT_STROKE_VISUAL_SEQUENCE.slice(2),
+      ...MIGRATED_TEXT_STROKE_VISUAL_SEQUENCE.slice(0, 2),
+      MIGRATED_TEXT_STROKE_VISUAL_SEQUENCE[2],
+    ].join('; ');
+    expect(buildTextStrokeColorCycle(2)).toBe(expectedCycle);
   });
 });

--- a/src/web-ui/src/component-library/components/TextStrokeEffect/TextStrokeEffectGradient.ts
+++ b/src/web-ui/src/component-library/components/TextStrokeEffect/TextStrokeEffectGradient.ts
@@ -1,10 +1,6 @@
-export const TEXT_STROKE_GRADIENT_COLORS = [
-  '#eab308',
-  '#ef4444',
-  '#3b82f6',
-  '#06b6d4',
-  '#8b5cf6',
-] as const;
+import { UI_EXCEPTION_ACCENTS } from '@/shared/theme/uiExceptionAccents';
+
+export const TEXT_STROKE_GRADIENT_COLORS = UI_EXCEPTION_ACCENTS.textStroke;
 
 export const TEXT_STROKE_GRADIENT_OFFSETS = ['0%', '25%', '50%', '75%', '100%'] as const;
 

--- a/src/web-ui/src/shared/inspector/inspectorOverlayTheme.ts
+++ b/src/web-ui/src/shared/inspector/inspectorOverlayTheme.ts
@@ -1,12 +1,3 @@
-export const INSPECTOR_OVERLAY_THEME = {
-  activeBorder: '#3b82f6',
-  activeBackground: 'rgba(59, 130, 246, 0.12)',
-  activeBorderSubtle: 'rgba(59, 130, 246, 0.4)',
-  selectedBorder: '#22c55e',
-  selectedBackground: 'rgba(34, 197, 94, 0.18)',
-  browserTooltipBackground: 'rgba(10, 10, 10, 0.92)',
-  mainTooltipBackground: 'rgba(15, 23, 42, 0.95)',
-  tooltipText: '#e2e8f0',
-  tooltipShadow: 'rgba(0, 0, 0, 0.5)',
-  staticWhite: '#ffffff',
-} as const;
+import { UI_EXCEPTION_ACCENTS } from '@/shared/theme/uiExceptionAccents';
+
+export const INSPECTOR_OVERLAY_THEME = UI_EXCEPTION_ACCENTS.inspectorOverlay;

--- a/src/web-ui/src/shared/theme/uiExceptionAccents.ts
+++ b/src/web-ui/src/shared/theme/uiExceptionAccents.ts
@@ -6,4 +6,23 @@ export const UI_EXCEPTION_ACCENTS = {
   miniApp: '#7c8cef',
   tealAction: '#14b8a6',
   todo: '#0d9488',
+  textStroke: [
+    '#eab308',
+    '#ef4444',
+    '#3b82f6',
+    '#06b6d4',
+    '#8b5cf6',
+  ],
+  inspectorOverlay: {
+    activeBorder: '#3b82f6',
+    activeBackground: 'rgba(59, 130, 246, 0.12)',
+    activeBorderSubtle: 'rgba(59, 130, 246, 0.4)',
+    selectedBorder: '#22c55e',
+    selectedBackground: 'rgba(34, 197, 94, 0.18)',
+    browserTooltipBackground: 'rgba(10, 10, 10, 0.92)',
+    mainTooltipBackground: 'rgba(15, 23, 42, 0.95)',
+    tooltipText: '#e2e8f0',
+    tooltipShadow: 'rgba(0, 0, 0, 0.5)',
+    staticWhite: '#ffffff',
+  },
 } as const;

--- a/src/web-ui/src/tools/editor/themes/bitfun-dark.theme.test.ts
+++ b/src/web-ui/src/tools/editor/themes/bitfun-dark.theme.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { BitFunDarkTheme } from './bitfun-dark.theme';
+
+describe('BitFunDarkTheme color roles', () => {
+  const colors = BitFunDarkTheme.colors;
+
+  it('keeps editor surface roles output-equivalent', () => {
+    expect(colors['editor.background']).toBe('#121214');
+    expect(colors['editor.lineHighlightBackground']).toBe('#18181a');
+    expect(colors['editor.lineHighlightBorder']).toBe('#202024');
+    expect(colors['editorWidget.background']).toBe('#18181a');
+    expect(colors['editorHoverWidget.statusBarBackground']).toBe('#202024');
+    expect(colors['diffEditor.unchangedRegionBackground']).toBe('#0D0D0F');
+    expect(colors['diffEditor.unchangedCodeBackground']).toBe('#0D0D0F');
+  });
+
+  it('keeps BitFun accent roles output-equivalent', () => {
+    expect(colors['editorCursor.foreground']).toBe('#E1AB80');
+    expect(colors['editor.selectionBackground']).toBe('#E1AB8040');
+    expect(colors['editor.inactiveSelectionBackground']).toBe('#E1AB8020');
+    expect(colors['editor.wordHighlightBorder']).toBe('#E1AB8060');
+    expect(colors['scrollbarSlider.hoverBackground']).toBe('#E1AB8070');
+    expect(colors['scrollbarSlider.activeBackground']).toBe('#E1AB80A0');
+  });
+
+  it('keeps repeated editor semantic colors aligned', () => {
+    expect(colors['editorInlayHint.foreground']).toBe(colors['editorCodeLens.foreground']);
+    expect(colors['editorError.foreground']).toBe(colors['minimap.errorHighlight']);
+    expect(colors['editorWarning.foreground']).toBe(colors['minimap.warningHighlight']);
+    expect(colors['editorLink.activeForeground']).toBe('#7DCFFF');
+  });
+});

--- a/src/web-ui/src/tools/editor/themes/bitfun-dark.theme.ts
+++ b/src/web-ui/src/tools/editor/themes/bitfun-dark.theme.ts
@@ -15,6 +15,39 @@ import type { editor } from 'monaco-editor';
 
 const TRANSPARENT_MONACO_BORDER = '#00000000';
 
+const MONACO_DARK_SURFACE = {
+  background: '#121214',
+  elevated: '#18181a',
+  borderSubtle: '#202024',
+  diffDeep: '#0D0D0F',
+} as const;
+
+const MONACO_EDITOR_TEXT = {
+  primary: '#D6DEEB',
+  secondary: '#E0E6F0',
+  muted: '#6A737D',
+} as const;
+
+const MONACO_BRAND_ACCENT = {
+  base: '#E1AB80',
+  light: '#F6D0A3',
+  alpha20: '#E1AB8020',
+  alpha30: '#E1AB8030',
+  alpha40: '#E1AB8040',
+  alpha60: '#E1AB8060',
+  alpha70: '#E1AB8070',
+  alpha80: '#E1AB8080',
+  alphaA0: '#E1AB80A0',
+} as const;
+
+const MONACO_STATUS_COLOR = {
+  error: '#FF5370',
+  warning: '#FFCB6B',
+  info: '#82AAFF',
+  success: '#ADDB67',
+  link: '#7DCFFF',
+} as const;
+
 /**
  * BitFun Dark Theme Configuration
  * Follows Monaco Editor official theme format
@@ -231,132 +264,132 @@ export const BitFunDarkTheme: editor.IStandaloneThemeData = {
     'contrastBorder': TRANSPARENT_MONACO_BORDER,
 
     // Editor Body
-    'editor.background': '#121214',
-    'editor.foreground': '#D6DEEB',
+    'editor.background': MONACO_DARK_SURFACE.background,
+    'editor.foreground': MONACO_EDITOR_TEXT.primary,
 
     // Line Numbers
     'editorLineNumber.foreground': '#707070',
-    'editorLineNumber.activeForeground': '#E1AB80',
+    'editorLineNumber.activeForeground': MONACO_BRAND_ACCENT.base,
     'editorLineNumber.dimmedForeground': '#454545',
 
     // Cursor and Selection
-    'editorCursor.foreground': '#E1AB80',
-    'editorCursor.background': '#121214',
-    'editor.selectionBackground': '#E1AB8040',
+    'editorCursor.foreground': MONACO_BRAND_ACCENT.base,
+    'editorCursor.background': MONACO_DARK_SURFACE.background,
+    'editor.selectionBackground': MONACO_BRAND_ACCENT.alpha40,
     'editor.selectionForeground': '#ffffff',
-    'editor.inactiveSelectionBackground': '#E1AB8020',
-    'editor.selectionHighlightBackground': '#E1AB8030',
-    'editor.selectionHighlightBorder': '#E1AB80',
+    'editor.inactiveSelectionBackground': MONACO_BRAND_ACCENT.alpha20,
+    'editor.selectionHighlightBackground': MONACO_BRAND_ACCENT.alpha30,
+    'editor.selectionHighlightBorder': MONACO_BRAND_ACCENT.base,
 
     // Current Line Highlight
-    'editor.lineHighlightBackground': '#18181a',
-    'editor.lineHighlightBorder': '#202024',
+    'editor.lineHighlightBackground': MONACO_DARK_SURFACE.elevated,
+    'editor.lineHighlightBorder': MONACO_DARK_SURFACE.borderSubtle,
 
     // Find and Match
-    'editor.findMatchBackground': '#E1AB80',
-    'editor.findMatchHighlightBackground': '#E1AB8040',
-    'editor.findRangeHighlightBackground': '#E1AB8020',
-    'editor.findMatchBorder': '#F6D0A3',
-    'editor.findMatchHighlightBorder': '#E1AB8080',
+    'editor.findMatchBackground': MONACO_BRAND_ACCENT.base,
+    'editor.findMatchHighlightBackground': MONACO_BRAND_ACCENT.alpha40,
+    'editor.findRangeHighlightBackground': MONACO_BRAND_ACCENT.alpha20,
+    'editor.findMatchBorder': MONACO_BRAND_ACCENT.light,
+    'editor.findMatchHighlightBorder': MONACO_BRAND_ACCENT.alpha80,
 
     // Word Highlight
-    'editor.wordHighlightBackground': '#E1AB8020',
-    'editor.wordHighlightStrongBackground': '#E1AB8040',
-    'editor.wordHighlightBorder': '#E1AB8060',
-    'editor.wordHighlightStrongBorder': '#E1AB80',
+    'editor.wordHighlightBackground': MONACO_BRAND_ACCENT.alpha20,
+    'editor.wordHighlightStrongBackground': MONACO_BRAND_ACCENT.alpha40,
+    'editor.wordHighlightBorder': MONACO_BRAND_ACCENT.alpha60,
+    'editor.wordHighlightStrongBorder': MONACO_BRAND_ACCENT.base,
 
     // Code Highlight and Decorations
-    'editor.hoverHighlightBackground': '#E1AB8020',
-    'editor.symbolHighlightBackground': '#E1AB8020',
-    'editor.symbolHighlightBorder': '#E1AB8060',
+    'editor.hoverHighlightBackground': MONACO_BRAND_ACCENT.alpha20,
+    'editor.symbolHighlightBackground': MONACO_BRAND_ACCENT.alpha20,
+    'editor.symbolHighlightBorder': MONACO_BRAND_ACCENT.alpha60,
 
     // Indent Guides and Rulers
-    'editorIndentGuide.background': '#202024',
-    'editorIndentGuide.activeBackground': '#E1AB8060',
-    'editorRuler.foreground': '#202024',
+    'editorIndentGuide.background': MONACO_DARK_SURFACE.borderSubtle,
+    'editorIndentGuide.activeBackground': MONACO_BRAND_ACCENT.alpha60,
+    'editorRuler.foreground': MONACO_DARK_SURFACE.borderSubtle,
 
     // Bracket Matching
-    'editorBracketMatch.background': '#E1AB8030',
-    'editorBracketMatch.border': '#E1AB80',
+    'editorBracketMatch.background': MONACO_BRAND_ACCENT.alpha30,
+    'editorBracketMatch.border': MONACO_BRAND_ACCENT.base,
     'editorBracketHighlight.foreground1': '#ffd700',
-    'editorBracketHighlight.foreground2': '#E1AB80',
+    'editorBracketHighlight.foreground2': MONACO_BRAND_ACCENT.base,
     'editorBracketHighlight.foreground3': '#C792EA',
     'editorBracketHighlight.foreground4': '#4ECDC4',
     'editorBracketHighlight.foreground5': '#F78C6C',
     'editorBracketHighlight.foreground6': '#A5E844',
 
     // Suggest Widget
-    'editorSuggestWidget.background': '#18181a',
-    'editorSuggestWidget.border': '#E1AB80',
-    'editorSuggestWidget.foreground': '#E0E6F0',
-    'editorSuggestWidget.highlightForeground': '#E1AB80',
-    'editorSuggestWidget.selectedBackground': '#E1AB8030',
+    'editorSuggestWidget.background': MONACO_DARK_SURFACE.elevated,
+    'editorSuggestWidget.border': MONACO_BRAND_ACCENT.base,
+    'editorSuggestWidget.foreground': MONACO_EDITOR_TEXT.secondary,
+    'editorSuggestWidget.highlightForeground': MONACO_BRAND_ACCENT.base,
+    'editorSuggestWidget.selectedBackground': MONACO_BRAND_ACCENT.alpha30,
     'editorSuggestWidget.focusHighlightForeground': '#A5E844',
 
     // Hover Widget
-    'editorHoverWidget.background': '#18181a',
-    'editorHoverWidget.border': '#E1AB80',
-    'editorHoverWidget.foreground': '#E0E6F0',
-    'editorHoverWidget.statusBarBackground': '#202024',
+    'editorHoverWidget.background': MONACO_DARK_SURFACE.elevated,
+    'editorHoverWidget.border': MONACO_BRAND_ACCENT.base,
+    'editorHoverWidget.foreground': MONACO_EDITOR_TEXT.secondary,
+    'editorHoverWidget.statusBarBackground': MONACO_DARK_SURFACE.borderSubtle,
 
     // Inlay Hints
     'editorInlayHint.background': TRANSPARENT_MONACO_BORDER,
-    'editorInlayHint.foreground': '#6A737D',
-    'editorInlayHint.typeForeground': '#6A737D',
-    'editorInlayHint.parameterForeground': '#6A737D',
+    'editorInlayHint.foreground': MONACO_EDITOR_TEXT.muted,
+    'editorInlayHint.typeForeground': MONACO_EDITOR_TEXT.muted,
+    'editorInlayHint.parameterForeground': MONACO_EDITOR_TEXT.muted,
 
     // Errors and Warnings
-    'editorError.foreground': '#FF5370',
-    'editorWarning.foreground': '#FFCB6B',
-    'editorInfo.foreground': '#82AAFF',
-    'editorHint.foreground': '#6A737D',
+    'editorError.foreground': MONACO_STATUS_COLOR.error,
+    'editorWarning.foreground': MONACO_STATUS_COLOR.warning,
+    'editorInfo.foreground': MONACO_STATUS_COLOR.info,
+    'editorHint.foreground': MONACO_EDITOR_TEXT.muted,
 
     // Scrollbar
-    'scrollbar.shadow': '#121214',
-    'scrollbarSlider.background': '#E1AB8040',
-    'scrollbarSlider.hoverBackground': '#E1AB8070',
-    'scrollbarSlider.activeBackground': '#E1AB80A0',
+    'scrollbar.shadow': MONACO_DARK_SURFACE.background,
+    'scrollbarSlider.background': MONACO_BRAND_ACCENT.alpha40,
+    'scrollbarSlider.hoverBackground': MONACO_BRAND_ACCENT.alpha70,
+    'scrollbarSlider.activeBackground': MONACO_BRAND_ACCENT.alphaA0,
 
     // Minimap
-    'minimap.background': '#121214',
-    'minimap.selectionHighlight': '#E1AB8040',
-    'minimap.findMatchHighlight': '#E1AB80',
-    'minimap.errorHighlight': '#FF5370',
-    'minimap.warningHighlight': '#FFCB6B',
-    'minimapSlider.background': '#E1AB8040',
-    'minimapSlider.hoverBackground': '#E1AB8070',
-    'minimapSlider.activeBackground': '#E1AB80A0',
+    'minimap.background': MONACO_DARK_SURFACE.background,
+    'minimap.selectionHighlight': MONACO_BRAND_ACCENT.alpha40,
+    'minimap.findMatchHighlight': MONACO_BRAND_ACCENT.base,
+    'minimap.errorHighlight': MONACO_STATUS_COLOR.error,
+    'minimap.warningHighlight': MONACO_STATUS_COLOR.warning,
+    'minimapSlider.background': MONACO_BRAND_ACCENT.alpha40,
+    'minimapSlider.hoverBackground': MONACO_BRAND_ACCENT.alpha70,
+    'minimapSlider.activeBackground': MONACO_BRAND_ACCENT.alphaA0,
 
     // Widget Borders
-    'editorWidget.background': '#18181a',
-    'editorWidget.border': '#E1AB8040',
-    'editorWidget.foreground': '#D6DEEB',
-    'editorWidget.resizeBorder': '#E1AB8060',
+    'editorWidget.background': MONACO_DARK_SURFACE.elevated,
+    'editorWidget.border': MONACO_BRAND_ACCENT.alpha40,
+    'editorWidget.foreground': MONACO_EDITOR_TEXT.primary,
+    'editorWidget.resizeBorder': MONACO_BRAND_ACCENT.alpha60,
 
     // Code Lens
-    'editorCodeLens.foreground': '#6A737D',
+    'editorCodeLens.foreground': MONACO_EDITOR_TEXT.muted,
 
     // Links
-    'editorLink.activeForeground': '#7DCFFF',
+    'editorLink.activeForeground': MONACO_STATUS_COLOR.link,
 
     // Whitespace
     'editorWhitespace.foreground': '#3A4A5A',
 
     // Overview Ruler
-    'editorOverviewRuler.border': '#18181a',
-    'editorOverviewRuler.background': '#121214',
-    'editorOverviewRuler.currentContentForeground': '#E1AB8080',
+    'editorOverviewRuler.border': MONACO_DARK_SURFACE.elevated,
+    'editorOverviewRuler.background': MONACO_DARK_SURFACE.background,
+    'editorOverviewRuler.currentContentForeground': MONACO_BRAND_ACCENT.alpha80,
     'editorOverviewRuler.incomingContentForeground': '#7FDBCA80',
     'editorOverviewRuler.findMatchForeground': '#FFCB6B80',
-    'editorOverviewRuler.rangeHighlightForeground': '#E1AB8040',
-    'editorOverviewRuler.selectionHighlightForeground': '#E1AB8060',
+    'editorOverviewRuler.rangeHighlightForeground': MONACO_BRAND_ACCENT.alpha40,
+    'editorOverviewRuler.selectionHighlightForeground': MONACO_BRAND_ACCENT.alpha60,
     'editorOverviewRuler.wordHighlightForeground': '#C792EA60',
-    'editorOverviewRuler.modifiedForeground': '#FFCB6B',
-    'editorOverviewRuler.addedForeground': '#ADDB67',
-    'editorOverviewRuler.deletedForeground': '#FF5370',
-    'editorOverviewRuler.errorForeground': '#FF5370',
-    'editorOverviewRuler.warningForeground': '#FFCB6B',
-    'editorOverviewRuler.infoForeground': '#E1AB80',
+    'editorOverviewRuler.modifiedForeground': MONACO_STATUS_COLOR.warning,
+    'editorOverviewRuler.addedForeground': MONACO_STATUS_COLOR.success,
+    'editorOverviewRuler.deletedForeground': MONACO_STATUS_COLOR.error,
+    'editorOverviewRuler.errorForeground': MONACO_STATUS_COLOR.error,
+    'editorOverviewRuler.warningForeground': MONACO_STATUS_COLOR.warning,
+    'editorOverviewRuler.infoForeground': MONACO_BRAND_ACCENT.base,
 
     // Diff Editor (GitHub Dark style)
     'diffEditor.insertedTextBackground': '#23863625',
@@ -374,8 +407,8 @@ export const BitFunDarkTheme: editor.IStandaloneThemeData = {
 
     'diffEditor.border': '#2A2D35',
     'diffEditor.diagonalFill': '#16181D',
-    'diffEditor.unchangedRegionBackground': '#0D0D0F',
-    'diffEditor.unchangedCodeBackground': '#0D0D0F',
+    'diffEditor.unchangedRegionBackground': MONACO_DARK_SURFACE.diffDeep,
+    'diffEditor.unchangedCodeBackground': MONACO_DARK_SURFACE.diffDeep,
 
     'diffEditorOverview.insertedForeground': '#3FB950',
     'diffEditorOverview.removedForeground': '#F85149',

--- a/src/web-ui/src/tools/generative-widget/themePayload.ts
+++ b/src/web-ui/src/tools/generative-widget/themePayload.ts
@@ -28,28 +28,48 @@ const FALLBACK_VAR = {
 
 type WidgetThemeFallbackVarName = typeof FALLBACK_VAR[keyof typeof FALLBACK_VAR];
 
+const WIDGET_IFRAME_FALLBACK_COLOR = {
+  textPrimary: '#e8e8e8',
+  textSecondary: '#b0b0b0',
+  textMuted: '#858585',
+  accent500: '#60a5fa',
+  accent600: '#3b82f6',
+  bgSecondary: '#1c1c1f',
+  success: '#34d399',
+  warning: '#f59e0b',
+  error: '#ef4444',
+  staticWhite: '#ffffff',
+  borderSubtle: 'rgba(255, 255, 255, 0.1)',
+  borderBase: 'rgba(255, 255, 255, 0.16)',
+  borderMedium: 'rgba(255, 255, 255, 0.24)',
+  elementBgSubtle: 'rgba(255, 255, 255, 0.05)',
+  elementBgBase: 'rgba(255, 255, 255, 0.08)',
+  elementBgMedium: 'rgba(255, 255, 255, 0.14)',
+  shadowBase: 'rgba(0, 0, 0, 0.4)',
+} as const;
+
 // Keep this fallback map small and self-contained. It is the last-resort iframe
 // contract for static widget rendering before the host theme payload arrives.
 export const WIDGET_THEME_FALLBACK_VARS = {
-  [FALLBACK_VAR.textPrimary]: '#e8e8e8',
-  [FALLBACK_VAR.textSecondary]: '#b0b0b0',
-  [FALLBACK_VAR.textMuted]: '#858585',
-  [FALLBACK_VAR.accent500]: '#60a5fa',
-  [FALLBACK_VAR.accent600]: '#3b82f6',
-  [FALLBACK_VAR.bgSecondary]: '#1c1c1f',
-  [FALLBACK_VAR.success]: '#34d399',
-  [FALLBACK_VAR.warning]: '#f59e0b',
-  [FALLBACK_VAR.error]: '#ef4444',
-  [FALLBACK_VAR.staticWhite]: '#ffffff',
-  [FALLBACK_VAR.borderSubtle]: 'rgba(255, 255, 255, 0.1)',
-  [FALLBACK_VAR.borderBase]: 'rgba(255, 255, 255, 0.16)',
-  [FALLBACK_VAR.borderMedium]: 'rgba(255, 255, 255, 0.24)',
-  [FALLBACK_VAR.elementBgSubtle]: 'rgba(255, 255, 255, 0.05)',
-  [FALLBACK_VAR.elementBgBase]: 'rgba(255, 255, 255, 0.08)',
-  [FALLBACK_VAR.elementBgMedium]: 'rgba(255, 255, 255, 0.14)',
-  [FALLBACK_VAR.elementBgSoft]: 'rgba(255, 255, 255, 0.08)',
-  [FALLBACK_VAR.shadowXs]: '0 1px 2px rgba(0, 0, 0, 0.4)',
-  [FALLBACK_VAR.shadowSm]: '0 2px 4px rgba(0, 0, 0, 0.4)',
+  [FALLBACK_VAR.textPrimary]: WIDGET_IFRAME_FALLBACK_COLOR.textPrimary,
+  [FALLBACK_VAR.textSecondary]: WIDGET_IFRAME_FALLBACK_COLOR.textSecondary,
+  [FALLBACK_VAR.textMuted]: WIDGET_IFRAME_FALLBACK_COLOR.textMuted,
+  [FALLBACK_VAR.accent500]: WIDGET_IFRAME_FALLBACK_COLOR.accent500,
+  [FALLBACK_VAR.accent600]: WIDGET_IFRAME_FALLBACK_COLOR.accent600,
+  [FALLBACK_VAR.bgSecondary]: WIDGET_IFRAME_FALLBACK_COLOR.bgSecondary,
+  [FALLBACK_VAR.success]: WIDGET_IFRAME_FALLBACK_COLOR.success,
+  [FALLBACK_VAR.warning]: WIDGET_IFRAME_FALLBACK_COLOR.warning,
+  [FALLBACK_VAR.error]: WIDGET_IFRAME_FALLBACK_COLOR.error,
+  [FALLBACK_VAR.staticWhite]: WIDGET_IFRAME_FALLBACK_COLOR.staticWhite,
+  [FALLBACK_VAR.borderSubtle]: WIDGET_IFRAME_FALLBACK_COLOR.borderSubtle,
+  [FALLBACK_VAR.borderBase]: WIDGET_IFRAME_FALLBACK_COLOR.borderBase,
+  [FALLBACK_VAR.borderMedium]: WIDGET_IFRAME_FALLBACK_COLOR.borderMedium,
+  [FALLBACK_VAR.elementBgSubtle]: WIDGET_IFRAME_FALLBACK_COLOR.elementBgSubtle,
+  [FALLBACK_VAR.elementBgBase]: WIDGET_IFRAME_FALLBACK_COLOR.elementBgBase,
+  [FALLBACK_VAR.elementBgMedium]: WIDGET_IFRAME_FALLBACK_COLOR.elementBgMedium,
+  [FALLBACK_VAR.elementBgSoft]: WIDGET_IFRAME_FALLBACK_COLOR.elementBgBase,
+  [FALLBACK_VAR.shadowXs]: `0 1px 2px ${WIDGET_IFRAME_FALLBACK_COLOR.shadowBase}`,
+  [FALLBACK_VAR.shadowSm]: `0 2px 4px ${WIDGET_IFRAME_FALLBACK_COLOR.shadowBase}`,
 } as const satisfies Record<WidgetThemeFallbackVarName, string>;
 
 export function createWidgetThemeFallbackCss(): string {


### PR DESCRIPTION
## Summary
- Normalize repeated Monaco dark-theme roles behind private editor-domain constants and add output-equivalence tests for surface, accent, and semantic status colors.
- Consolidate generated-widget iframe fallback literals and MiniApp scrollbar fallback tables without removing standalone iframe/static-render fallbacks.
- Move TextStrokeEffect and inspector overlay identity colors into `UI_EXCEPTION_ACCENTS`, then classify that registry as its own audited exception domain.
- Add fallback CSS var reporting plus a required `intentionalFallbackTokens` allowlist with owner/reason metadata for the 10 current runtime fallback keys.
- Tighten the audit after adversarial review so `.test/.spec` and `__tests__` files are excluded from production color budgets, while keeping visual output-lock tests in place.

## Governance metrics
| Metric | Before | After | Notes |
| --- | ---: | ---: | --- |
| Component/non-token color occurrences | 398 | 309 | After value is production-source only; tests are reported separately as ignored |
| Unique component/non-token colors | 268 | 255 | Reduced without merging semantically distinct near colors |
| Token-equivalent app literal occurrences | 54 | 34 | Remaining items are visible in the audit report |
| Token-equivalent app literal unique colors | 29 | 26 | No runtime token contract was loosened |
| Generated widget occurrences | 19 | 17 | Iframe fallback contract preserved |
| Editor occurrences | 206 | 151 | Monaco colors normalized inside the editor domain; test file excluded from production counts |
| Visual effect occurrences | 42 | 26 | Output-lock tests preserved without counting test literals in production budgets |
| App UI domain occurrences / unique | 129 / 112 | 123 / 108 | Main app surface still trends down |
| Fallback var occurrences / unique tokens | 31 / untracked | 31 / 10 | Same runtime behavior, now every fallback token needs allowlist evidence |
| CSS var governance debt | 0 | 0 | unresolved/fallback-only/required-missing/non-contract/unregistered all stay clean |
| Exception unique colors | 172 | 188 | Increase is intentional: scattered identity colors moved into an explicit exception registry/domain |
| Audit scope | no test exclusion | 1523 scanned / 210 ignored test files | Prevents tests from inflating production color budgets |

## Adversarial review fixes
- Fixed the main review finding: visual output-lock tests were inflating the production color baseline. The audit now excludes test/spec files and reports `ignoredTestFiles` explicitly.
- Added a regression test proving test-file colors do not count toward app UI or token-alias budgets.
- Added MiniApp theme payload tests to lock dark/light scrollbar fallbacks and theme-provided scrollbar override precedence.
- Rechecked `UI_EXCEPTION_ACCENTS` usage; consumers use direct properties, not broad object iteration, so mixed scalar/tuple/object entries do not change existing consumers.

## Risk review
- Monaco changes are private constant extraction only; representative output values are locked by `bitfun-dark.theme.test.ts`.
- Widget and MiniApp fallback values remain concrete for iframe/standalone first paint, so host-theme timing should not affect static rendering.
- `UI_EXCEPTION_ACCENTS` now contains scalar values plus a tuple/object. Existing consumers use direct property access; no broad `Object.values`/`Object.entries` consumer was found.
- The fallback-token allowlist is deliberately stricter: new dynamic fallback keys now fail audit unless they include owner and reason metadata.
- Near colors were not merged merely because they look similar; this PR focuses on domain ownership and exact duplicates/role constants to avoid collapsing intentional area distinctions.

## Verification
- `pnpm run theme:color-audit -- --top 20`
- `node --test scripts/audit-theme-colors.test.mjs` (16 tests)
- `pnpm --dir src/web-ui run test:run src/app/scenes/miniapps/utils/buildMiniAppThemeVars.test.ts src/tools/editor/themes/bitfun-dark.theme.test.ts src/tools/generative-widget/themePayload.test.ts src/component-library/components/TextStrokeEffect/TextStrokeEffect.test.ts` (4 files / 9 tests)
- `pnpm run lint:web` (0 errors; 4 existing warnings)
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run` (210 files / 1159 tests)
- `pnpm run build:web` (passed; existing Vite dynamic-import/chunk-size warnings)
- `pnpm run check:repo-hygiene`
- `git diff --check`

Related: #1197