### PR TITLE
ci: add manual CLI packaging workflow with platform selection

### DIFF
--- a/.github/workflows/cli-package-manual.yml
+++ b/.github/workflows/cli-package-manual.yml
@@ -1,0 +1,184 @@
+name: CLI Package Manual
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "Platform to build."
+        required: true
+        default: linux-arm64
+        type: choice
+        options:
+          - linux-arm64
+          - linux-x64
+          - macos-arm64
+          - macos-x64
+          - all
+      ref_name:
+        description: "Branch, tag, or commit SHA to build. Leave empty to use the selected workflow ref."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cli-package-manual-${{ inputs.platform }}-${{ inputs.ref_name || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      short_sha: ${{ steps.meta.outputs.short_sha }}
+      checkout_ref: ${{ steps.meta.outputs.checkout_ref }}
+      matrix: ${{ steps.meta.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref_name != '' && inputs.ref_name || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve build metadata
+        id: meta
+        shell: bash
+        env:
+          INPUT_PLATFORM: ${{ inputs.platform }}
+          INPUT_REF_NAME: ${{ inputs.ref_name }}
+        run: |
+          set -euo pipefail
+
+          VERSION="$(jq -r '.version' package.json)"
+          FULL_SHA="$(git rev-parse HEAD)"
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          CHECKOUT_REF="$FULL_SHA"
+
+          case "${INPUT_PLATFORM}" in
+            linux-arm64)
+              MATRIX='{"platform":[{"os":"ubuntu-24.04-arm","name":"linux-arm64","target":"aarch64-unknown-linux-gnu","can_smoke_test":true}]}'
+              ;;
+            linux-x64)
+              MATRIX='{"platform":[{"os":"ubuntu-latest","name":"linux-x64","target":"x86_64-unknown-linux-gnu","can_smoke_test":true}]}'
+              ;;
+            macos-arm64)
+              MATRIX='{"platform":[{"os":"macos-15","name":"macos-arm64","target":"aarch64-apple-darwin","can_smoke_test":true}]}'
+              ;;
+            macos-x64)
+              MATRIX='{"platform":[{"os":"macos-15-intel","name":"macos-x64","target":"x86_64-apple-darwin","can_smoke_test":true}]}'
+              ;;
+            all)
+              MATRIX='{"platform":[{"os":"macos-15","name":"macos-arm64","target":"aarch64-apple-darwin","can_smoke_test":true},{"os":"macos-15-intel","name":"macos-x64","target":"x86_64-apple-darwin","can_smoke_test":true},{"os":"ubuntu-latest","name":"linux-x64","target":"x86_64-unknown-linux-gnu","can_smoke_test":true},{"os":"ubuntu-24.04-arm","name":"linux-arm64","target":"aarch64-unknown-linux-gnu","can_smoke_test":true}]}'
+              ;;
+            *)
+              echo "Unsupported platform: ${INPUT_PLATFORM}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build (${{ matrix.platform.name }})
+    runs-on: ${{ matrix.platform.os }}
+    needs: prepare
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config \
+            build-essential \
+            libssl-dev \
+            libxcb1-dev \
+            libxcb-render0-dev \
+            libxcb-shape0-dev \
+            libxcb-xfixes0-dev
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform.target }}
+
+      - name: Cache Rust build
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: "cli-manual-v1-${{ matrix.platform.name }}"
+          cache-bin: false
+
+      - name: Build bitfun-cli
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --release \
+            --target ${{ matrix.platform.target }} \
+            -p bitfun-cli
+
+      - name: Smoke test (--version)
+        if: matrix.platform.can_smoke_test == true
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN="target/${{ matrix.platform.target }}/release/bitfun-cli"
+          "$BIN" --version
+          "$BIN" --help > /dev/null
+
+      - name: Stage tarball
+        id: stage
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          TARGET: ${{ matrix.platform.target }}
+        run: |
+          set -euo pipefail
+
+          STAGE_DIR="$(pwd)/dist-cli/bitfun-cli-${VERSION}-${TARGET}"
+          mkdir -p "$STAGE_DIR"
+
+          cp "target/${TARGET}/release/bitfun-cli" "$STAGE_DIR/"
+          cp LICENSE "$STAGE_DIR/" || true
+          cp README.md "$STAGE_DIR/" || true
+
+          if [[ -d "src/apps/cli/themes" ]]; then
+            cp -R "src/apps/cli/themes" "$STAGE_DIR/themes"
+          fi
+          if [[ -d "src/apps/cli/prompts" ]]; then
+            cp -R "src/apps/cli/prompts" "$STAGE_DIR/prompts"
+          fi
+
+          ARCHIVE="bitfun-cli-${VERSION}-${TARGET}.tar.gz"
+          tar -C "$(dirname "$STAGE_DIR")" -czf "$ARCHIVE" "$(basename "$STAGE_DIR")"
+
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256"
+          else
+            shasum -a 256 "$ARCHIVE" > "${ARCHIVE}.sha256"
+          fi
+
+          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+          echo "checksum=${ARCHIVE}.sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bitfun-cli-${{ needs.prepare.outputs.version }}-${{ needs.prepare.outputs.short_sha }}-${{ matrix.platform.name }}
+          if-no-files-found: error
+          path: |
+            ${{ steps.stage.outputs.archive }}
+            ${{ steps.stage.outputs.checksum }}


### PR DESCRIPTION
- add workflow_dispatch inputs for platform and ref selection
- support linux and macOS CLI artifact builds without release upload
- lock builds to the prepared commit SHA for reproducible artifacts
