### PR TITLE
refactor(web-ui): consolidate theme color governance

### DIFF
--- a/docs/architecture/theme-token-optimization.md
+++ b/docs/architecture/theme-token-optimization.md
@@ -1,6 +1,6 @@
 # 主题与颜色 Token 优化方案
 
-> 当前基线：`gcwing/main` 的 `bb051cdb`，扫描日期为 2026-06-17。
+> 当前基线：`gcwing/main` 的 `e5024fdd`，扫描日期为 2026-06-17。
 
 本文档用于梳理 BitFun 前端主题、硬编码颜色、重复 token、近似色冗余、
 命名漂移和后续治理方案。目标不是把所有看起来相近的颜色都合并，而是让
@@ -64,15 +64,17 @@
 | 忽略的测试文件数 | 211 |
 | 包含颜色字面量的文件数 | 75 |
 | 颜色字面量出现次数 | 1930 |
-| 唯一颜色字面量数量 | 1040 |
+| 唯一颜色字面量数量 | 1038 |
 | 组件或非 token 文件中的颜色出现次数 | 273 |
-| 组件或非 token 唯一颜色数量 | 235 |
+| 组件或非 token 唯一颜色数量 | 233 |
 | App UI 颜色出现次数 | 108 |
 | App UI 唯一颜色数量 | 94 |
 | `var(--token, fallback)` 出现次数 | 31 |
 | fallback 唯一 token 数 | 10 |
 | token-equivalent app literal 出现次数 | 13 |
 | token-equivalent app literal 唯一颜色数量 | 11 |
+| 普通组件肉眼不可区分 near color pair | 0 |
+| 普通组件需证据复核的 near color pair | 35 |
 
 当前审计未发现 CSS 变量契约层面的硬错误：
 
@@ -154,8 +156,30 @@ fallback 决策表：
 | Phase 2：精确重复合并 | 部分完成 | 本轮已集中 code snippet language identity，并减少 StreamText 重复 visual-effect literal |
 | Phase 3：legacy fallback 迁移 | 部分完成 | 本轮已集中 widget/miniapp boundary fallback；剩余 10 个 fallback token 已完成决策表 |
 | Phase 4：组件 token 抽取 | 进行中 | 本轮补充 visual effect 私有变量和 boundary fallback owner，Flow Chat、tool card、diff/git 仍需按 surface 继续抽取 |
-| Phase 5：近似色合并 | 未开始 | 只能在调用点、相邻关系和视觉证据齐备后推进 |
-| Phase 6：防回退约束 | 未开始 | 适合先做目录级或 diff-based guard，暂不全局硬失败 |
+| Phase 5：近似色合并 | 已完成首轮 | 本轮仅合并审计标记为 `indistinguishable` 的 2 个 pair，其余 near pair 保持延后 |
+| Phase 6：防回退约束 | 已完成首轮 | baseline 已约束 app raw color、fallback、CSS var 契约和普通组件 near-pair 数量，新增普通组件不可区分 pair 会失败 |
+
+Phase 5 首轮决策：
+
+| pair | 决策 | 调用点 | 依据 |
+| --- | --- | --- | --- |
+| `#1f2024` -> `#202024` | merge | `ChatInputPixelPet.scss` panda body/decor；`bitfun-dark.theme.ts` editor subtle border | RGB distance = 1，非状态色，非相邻 surface 边界；panda 固定深色与 editor border 不在同一视觉层级承担区分 |
+| `#6e7681` -> `#6e7781` | merge | `LanguageRegistry.ts` Plain Text identity；`prismTheme.ts` light comment | RGB distance = 1，均为 neutral muted 文本/identity 色，不表达状态严重程度或数据差异 |
+| top near pairs | defer | `DiffEditor.scss`、`GitDiffEditor.scss`、`ContextMenu.scss`、`TiptapEditor.scss`、Flow Chat capture fallback 等 | alpha 或暗色层级差异可能表达 overlay/elevation/diff state，需截图和相邻关系证据后再处理 |
+
+Phase 6 首轮约束：
+
+| 约束 | 当前值 | baseline | 作用 |
+| --- | ---: | ---: | --- |
+| `nearPairs.indistinguishableTotal` | 0 | 0 | 阻止新增普通组件肉眼不可区分 pair 未被合并或记录 |
+| `nearPairs.nearTotal` | 35 | 35 | 阻止新增普通组件 near color 债务，减少时要求同步降低 baseline |
+| `colorScopes.appUi.uniqueColors` | 233 | 233 | 阻止普通组件 raw color 唯一色回涨 |
+| `colorScopes.appUi.occurrences` | 273 | 273 | 阻止普通组件 raw color 出现次数回涨 |
+| CSS var governance errors | 0 | 0 | 保持 unresolved、fallback-only、non-contract 和 dynamic family 错误为零 |
+
+`nearPairs.*` 只基于非 token、非 exception 的普通组件颜色计算。Theme preset、
+editor、syntax、terminal、language identity、boundary fallback 等专用域通过各自
+`colorDomainScopes.*` 预算约束，不用该 near-pair guard 直接判定是否可合并。
 
 ## 现有架构地图
 

--- a/docs/architecture/theme-token-optimization.md
+++ b/docs/architecture/theme-token-optimization.md
@@ -1,6 +1,6 @@
 # 主题与颜色 Token 优化方案
 
-> 基线：`gcwing/main` 的 `b5f4f131`，扫描日期为 2026-06-15。
+> 当前基线：`gcwing/main` 的 `bb051cdb`，扫描日期为 2026-06-17。
 
 本文档用于梳理 BitFun 前端主题、硬编码颜色、重复 token、近似色冗余、
 命名漂移和后续治理方案。目标不是把所有看起来相近的颜色都合并，而是让
@@ -53,63 +53,109 @@
 
 ## 当前现状
 
-基于最新 `gcwing/main` 的扫描结果，当前颜色系统已经具备一定抽象，但分散
-程度较高，重复和命名漂移明显。
+基于最新 `gcwing/main` 的扫描结果，前几轮迁移已经把测试文件噪声、明显的
+跨文件未定义 key、debug overlay 游离色值和部分 widget/editor fallback 收敛掉。
+当前剩余问题更集中在 app UI 字面量、少量边界 fallback、identity/exception 色值
+归属，以及近似色是否能安全合并的证据不足。
 
 | 指标 | 当前基线 |
 | --- | ---: |
-| 扫描的前端文件数 | 1711 |
-| 包含颜色字面量的文件数 | 297 |
-| 颜色字面量出现次数 | 5572 |
-| 唯一颜色字面量数量 | 1532 |
-| 组件或非 token 文件中的颜色出现次数 | 3735 |
-| 包含组件或非 token 颜色的文件数 | 272 |
-| `var(--token, fallback-color)` 出现次数 | 2847 |
+| 扫描的生产前端文件数 | 1525 |
+| 忽略的测试文件数 | 211 |
+| 包含颜色字面量的文件数 | 75 |
+| 颜色字面量出现次数 | 1930 |
+| 唯一颜色字面量数量 | 1040 |
+| 组件或非 token 文件中的颜色出现次数 | 273 |
+| 组件或非 token 唯一颜色数量 | 235 |
+| App UI 颜色出现次数 | 108 |
+| App UI 唯一颜色数量 | 94 |
+| `var(--token, fallback)` 出现次数 | 31 |
+| fallback 唯一 token 数 | 10 |
+| token-equivalent app literal 出现次数 | 13 |
+| token-equivalent app literal 唯一颜色数量 | 11 |
 
-债务集中在少数高频 UI 区域：
+当前审计未发现 CSS 变量契约层面的硬错误：
 
-| 区域 | 文件 | 非 token 颜色出现次数 |
-| --- | --- | ---: |
-| Flow Chat 输入区 | `src/web-ui/src/flow_chat/components/ChatInput.scss` | 158 |
-| Toolbar mode | `src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.scss` | 94 |
-| Code editor | `src/web-ui/src/component-library/components/CodeEditor/CodeEditor.scss` | 86 |
-| Profile nursery view | `src/web-ui/src/app/scenes/profile/views/NurseryView.scss` | 78 |
-| Generative widget frame | `src/web-ui/src/tools/generative-widget/GenerativeWidgetFrame.tsx` | 78 |
-| Select 组件 | `src/web-ui/src/component-library/components/Select/Select.scss` | 70 |
-| Code review tool card | `src/web-ui/src/flow_chat/tool-cards/CodeReviewToolCard.scss` | 70 |
-| Stream text | `src/web-ui/src/component-library/components/StreamText/StreamText.scss` | 66 |
-| Snapshot diff viewer | `src/web-ui/src/flow_chat/tool-cards/SnapshotFullscreenDiffViewer.css` | 64 |
-| Workspace manager | `src/web-ui/src/tools/workspace/components/WorkspaceManager.css` | 64 |
+| 契约指标 | 当前值 |
+| --- | ---: |
+| unresolved CSS vars | 0 |
+| fallback-only unresolved vars | 0 |
+| unregistered dynamic families | 0 |
+| stale registered dynamic families | 0 |
+| non-contract cross-file vars | 0 |
+| non-contract dynamic inputs | 0 |
+| non-contract component-private vars | 0 |
 
-重复最多的原始色值主要是应用强调色、状态色、白色半透明叠层和暗色表面叠层：
+剩余债务集中在几个专用域和少量 app UI 文件：
 
-| 色值 | 次数 | 推测角色 |
+| 区域 | 当前出现次数 | 当前唯一色数 | 说明 |
+| --- | ---: | ---: | --- |
+| Theme presets | 1033 | 611 | 主题个性与 palette 映射，不作为普通 app literal 直接合并 |
+| Token contracts | 268 | 159 | `tokens.scss` 等静态契约根 |
+| Editor | 151 | 122 | Monaco/editor 专用域，不能直接泛化到 app token |
+| Mermaid | 139 | 95 | Mermaid 专用渲染域 |
+| Theme runtime | 54 | 45 | `ThemeService.ts` 运行时注入 |
+| Language identity | 57 | 50 | 语言身份色，应保留数据语义或迁入 identity registry |
+| Terminal | 38 | 30 | terminal/ANSI 专用域 |
+| Boundary fallback | 21 | 21 | iframe/miniapp 早期渲染兜底值，不作为普通 app token |
+| Visual effects | 22 | 22 | 动效和装饰效果，需按效果语义审查 |
+| UI exception registry | 21 | 19 | 已归档的 UI 例外色 |
+| Generated widget | 0 | 0 | 颜色默认值已迁到 boundary fallback registry |
+| App UI | 108 | 94 | 后续普通组件迁移的主战场 |
+
+剩余高频普通组件或边界文件：
+
+| 文件 | 颜色出现次数 | 后续处理策略 |
 | --- | ---: | --- |
-| `#60a5fa` | 162 | blue accent / focus / info |
-| `rgba(255, 255, 255, 0.08)` | 115 | 暗色主题 subtle overlay |
-| `rgba(255, 255, 255, 0.1)` | 112 | 暗色主题 hover/elevated overlay |
-| `#f59e0b` | 112 | warning |
-| `#ffffff` | 107 | white / inverse text |
-| `#ef4444` | 110 | error / danger |
-| `#22c55e` | 77 | success |
-| `#3b82f6` | 70 | primary / info |
-| `rgba(255, 255, 255, 0.05)` | 70 | 暗色主题低强度 overlay |
-| `rgba(255, 255, 255, 0.06)` | 68 | 暗色主题低强度 overlay |
+| `src/web-ui/src/component-library/components/CodeEditor/CodeEditor.scss` | 65 | editor surface 专用域，先保持 exception namespace |
+| `src/web-ui/src/shared/theme/themeBoundaryFallbacks.ts` | 21 | isolated surface 边界默认值，保留集中 owner |
+| `src/web-ui/src/component-library/components/StreamText/StreamText.scss` | 21 | visual effect，应迁入视觉效果 token/例外域 |
+| `src/web-ui/src/shared/theme/uiExceptionAccents.ts` | 21 | 已归档 UI 例外，继续要求显式 owner/role |
+| `src/web-ui/src/shared/prism/prismTheme.ts` | 18 | syntax theme，不泛化到 app token |
+| `src/web-ui/src/tools/editor/components/DiffEditor.scss` | 18 | diff/editor 专用域，按 git/diff token 处理 |
+| `src/web-ui/src/app/scenes/profile/views/NurseryView.scss` | 10 | app scene surface，优先迁移到 scene/component token |
 
-fallback 也已经形成了第二套分散色板。高频 fallback token 如下：
+当前 fallback token 都已进入 allowlist，但仍需要逐项决策是否保留边界 fallback：
 
 | fallback token | 次数 |
 | --- | ---: |
-| `--color-accent-500` | 147 |
-| `--color-warning` | 127 |
-| `--color-error` | 117 |
-| `--color-success` | 109 |
-| `--color-text-muted` | 77 |
-| `--color-text-primary` | 75 |
-| `--color-text-secondary` | 71 |
-| `--border-subtle` | 55 |
-| `--element-bg-subtle` | 39 |
-| `--color-primary` | 41 |
+| `--surface-stagger-index` | 12 |
+| `--mission-control-group-color` | 6 |
+| `--char-index` | 3 |
+| `--shadow-color` | 3 |
+| `--assistant-card-gradient` | 2 |
+| `--gallery-grid-min` | 1 |
+| `--gallery-skeleton-height` | 1 |
+| `--operation-color` | 1 |
+| `--primary-color` | 1 |
+| `--scene-viewport-border-width` | 1 |
+
+fallback 决策表：
+
+| fallback token | 决策 | 依据 | 后续动作 |
+| --- | --- | --- | --- |
+| `--surface-stagger-index` | 保留 | 运行时 inline 动画序号，`0` 是安全首帧/无动画默认值 | 不迁移为颜色 token；保持 allowlist |
+| `--mission-control-group-color` | 保留 | 分组身份色由数据或 inline style 驱动，静态删除会丢失未设置分组色时的 accent 兜底 | 后续 content-canvas token 抽取时复核是否改为组件根默认值 |
+| `--char-index` | 保留 | StreamText 每字符动画偏移，`0` fallback 是无序号渲染的安全默认值 | 不迁移为颜色 token；保持 allowlist |
+| `--shadow-color` | 延后 | 同时服务 agent surface 和 Mermaid block 的局部 shadow tint，跨 surface 合并风险较高 | Flow Chat/Markdown token 抽取时拆成 surface-specific shadow token |
+| `--assistant-card-gradient` | 延后 | assistant identity gradient 在 metadata 未加载时需要静态视觉兜底 | NurseryView surface token 抽取时迁到组件根默认值 |
+| `--gallery-grid-min` | 保留 | runtime layout sizing 输入，不属于颜色债务；`320px` 保持 responsive grid 下限 | 保持 allowlist，后续只在 layout token 方案中处理 |
+| `--gallery-skeleton-height` | 保留 | runtime skeleton sizing 输入，不属于颜色债务；`140px` 保持占位高度稳定 | 保持 allowlist，后续只在 layout token 方案中处理 |
+| `--operation-color` | 延后 | Snapshot operation identity 色由操作类型驱动，直接删除会弱化操作差异 | SnapshotCard token 抽取时补根默认值后再移除局部 fallback |
+| `--primary-color` | 延后 | Markdown 嵌入内容可覆盖 primary accent，边界语义不同于全局 app primary | Markdown token 抽取时决定是否转为 `--markdown-primary-color` contract |
+| `--scene-viewport-border-width` | 保留 | viewport border width 是 runtime layout override，`1px` fallback 保持默认边界可见 | 保持 allowlist，后续只在 scene layout token 方案中处理 |
+
+阶段状态：
+
+| 阶段 | 状态 | 当前判断 |
+| --- | --- | --- |
+| Phase 0：基线与工具 | 已完成主体 | 审计脚本可区分测试文件、fallback token、dynamic families 和 exception domains |
+| Phase 1：canonical token 契约 | 已完成主体，继续补文档 | 静态/runtime/widget 契约已有治理入口，仍需保持文档基线同步 |
+| Phase 2：精确重复合并 | 部分完成 | 本轮已集中 code snippet language identity，并减少 StreamText 重复 visual-effect literal |
+| Phase 3：legacy fallback 迁移 | 部分完成 | 本轮已集中 widget/miniapp boundary fallback；剩余 10 个 fallback token 已完成决策表 |
+| Phase 4：组件 token 抽取 | 进行中 | 本轮补充 visual effect 私有变量和 boundary fallback owner，Flow Chat、tool card、diff/git 仍需按 surface 继续抽取 |
+| Phase 5：近似色合并 | 未开始 | 只能在调用点、相邻关系和视觉证据齐备后推进 |
+| Phase 6：防回退约束 | 未开始 | 适合先做目录级或 diff-based guard，暂不全局硬失败 |
 
 ## 现有架构地图
 

--- a/scripts/audit-theme-colors.mjs
+++ b/scripts/audit-theme-colors.mjs
@@ -414,7 +414,29 @@ function colorDistance(a, b) {
   );
 }
 
-function buildNearColorPairs(colorCounts) {
+function colorPairKey(left, right) {
+  return [left, right].sort((a, b) => a.localeCompare(b)).join(' <-> ');
+}
+
+function buildNearColorPairRow({ a, b, distance, alphaDiff, colorFiles }) {
+  const aFiles = Array.from(colorFiles.get(a.color) ?? []).sort();
+  const bFiles = Array.from(colorFiles.get(b.color) ?? []).sort();
+  return {
+    key: colorPairKey(a.color, b.color),
+    a: a.color,
+    b: b.color,
+    distance,
+    alphaDiff,
+    count: a.count + b.count,
+    files: Array.from(new Set([...aFiles, ...bFiles])).sort().slice(0, 8),
+    filesByColor: {
+      [a.color]: aFiles.slice(0, 5),
+      [b.color]: bFiles.slice(0, 5),
+    },
+  };
+}
+
+function buildNearColorPairs(colorCounts, colorFiles) {
   const parsed = Array.from(colorCounts.entries())
     .map(([color, count]) => ({ color, count, parsed: parseColor(color) }))
     .filter(entry => entry.parsed);
@@ -429,17 +451,21 @@ function buildNearColorPairs(colorCounts) {
       const alphaDiff = Math.abs(a.parsed.a - b.parsed.a);
       const distance = colorDistance(a.parsed, b.parsed);
       if (distance <= 2 && alphaDiff <= 0.003) {
-        indistinguishable.push({ a: a.color, b: b.color, distance, alphaDiff, count: a.count + b.count });
+        indistinguishable.push(buildNearColorPairRow({ a, b, distance, alphaDiff, colorFiles }));
       } else if (distance <= 10 && alphaDiff <= 0.03) {
-        near.push({ a: a.color, b: b.color, distance, alphaDiff, count: a.count + b.count });
+        near.push(buildNearColorPairRow({ a, b, distance, alphaDiff, colorFiles }));
       }
     }
   }
 
   const byImpact = (a, b) => b.count - a.count || a.distance - b.distance;
+  indistinguishable.sort(byImpact);
+  near.sort(byImpact);
   return {
-    indistinguishable: indistinguishable.sort(byImpact).slice(0, 50),
-    near: near.sort(byImpact).slice(0, 50),
+    indistinguishableTotal: indistinguishable.length,
+    nearTotal: near.length,
+    indistinguishable: indistinguishable.slice(0, 50),
+    near: near.slice(0, 50),
   };
 }
 
@@ -668,6 +694,7 @@ function audit(options) {
 
   const colorCounts = new Map();
   const componentColorCounts = new Map();
+  const componentColorFiles = new Map();
   const fallbackTokenCounts = new Map();
   const fallbackTokenFiles = new Map();
   const varUsageCounts = new Map();
@@ -720,6 +747,7 @@ function audit(options) {
       } else {
         componentColorOccurrences += 1;
         incrementMap(componentColorCounts, color);
+        addToSetMap(componentColorFiles, color, relativePath);
         incrementMap(componentFileColorCounts, relativePath);
 
         const colorKey = canonicalColorKey(color);
@@ -867,7 +895,7 @@ function audit(options) {
   const runtimeOnlyRequiredContractVars = runtimeOnlyRequiredContractEntries
     .slice(0, REPORT_ROW_LIMIT);
 
-  const nearPairs = buildNearColorPairs(componentColorCounts);
+  const nearPairs = buildNearColorPairs(componentColorCounts, componentColorFiles);
   const uniqueComponentColors = componentColorCounts.size;
   const tokenAliasLiteralRows = buildTokenAliasLiteralRows({
     tokenAliasLiteralCounts,
@@ -1133,8 +1161,8 @@ function printText(report) {
     }
   }
 
-  console.log('\nIndistinguishable component color pairs (sample):');
-  if (report.nearPairs.indistinguishable.length === 0) {
+  console.log(`\nIndistinguishable component color pairs (total=${report.nearPairs.indistinguishableTotal}, sample):`);
+  if (report.nearPairs.indistinguishableTotal === 0) {
     console.log('  none');
   } else {
     for (const pair of report.nearPairs.indistinguishable.slice(0, 10)) {
@@ -1142,8 +1170,8 @@ function printText(report) {
     }
   }
 
-  console.log('\nNear component color pairs needing evidence (sample):');
-  if (report.nearPairs.near.length === 0) {
+  console.log(`\nNear component color pairs needing evidence (total=${report.nearPairs.nearTotal}, sample):`);
+  if (report.nearPairs.nearTotal === 0) {
     console.log('  none');
   } else {
     for (const pair of report.nearPairs.near.slice(0, 10)) {

--- a/scripts/audit-theme-colors.test.mjs
+++ b/scripts/audit-theme-colors.test.mjs
@@ -296,6 +296,43 @@ test('theme color audit reports app literals that duplicate token values', (t) =
   assert.equal(report.colorScopes.exception.occurrences, 1);
 });
 
+test('theme color audit reports near color pair sources and enforces pair budgets', (t) => {
+  const { dir, sourceRoot } = createFixture({
+    'app/One.scss': '.one { color: #111111; }\n',
+    'app/Two.scss': '.two { color: #111112; }\n',
+  });
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const reportPath = path.join(dir, 'theme-report.json');
+
+  const reportResult = runAudit(['--root', sourceRoot, '--report-json', reportPath, '--no-baseline']);
+  assert.equal(reportResult.status, 0, reportResult.stderr || reportResult.stdout);
+  assert.match(reportResult.stdout, /Indistinguishable component color pairs \(total=1, sample\):/);
+
+  const report = readJson(reportPath);
+  assert.equal(report.nearPairs.indistinguishableTotal, 1);
+  assert.equal(report.nearPairs.indistinguishable.length, 1);
+  assert.equal(report.nearPairs.indistinguishable[0].key, '#111111 <-> #111112');
+  assert.deepEqual(
+    report.nearPairs.indistinguishable[0].files.map(file => file.replace(/\\/g, '/').split('/').slice(-2).join('/')),
+    ['app/One.scss', 'app/Two.scss'],
+  );
+
+  const baselinePath = path.join(dir, 'theme-baseline.json');
+  writeText(baselinePath, `${JSON.stringify({
+    version: 1,
+    budgets: {
+      'nearPairs.indistinguishableTotal': { max: 0 },
+    },
+  }, null, 2)}\n`);
+
+  const blocked = runAudit(['--root', sourceRoot, '--baseline', baselinePath]);
+  assert.notEqual(blocked.status, 0, 'new indistinguishable color pairs must fail the audit');
+  assert.match(
+    `${blocked.stdout}\n${blocked.stderr}`,
+    /nearPairs\.indistinguishableTotal has 1 candidate\(s\), baseline is 0/,
+  );
+});
+
 test('theme color audit excludes test files from production color budgets', (t) => {
   const { dir, sourceRoot } = createFixture({
     'component-library/styles/tokens.scss': ':root { --color-error: #ef4444; }\n',

--- a/scripts/audit-theme-colors.test.mjs
+++ b/scripts/audit-theme-colors.test.mjs
@@ -124,8 +124,10 @@ test('theme color audit reports specialized color domains separately from app UI
     'shared/prism/prismTheme.ts': "export const prism = { keyword: '#555555' };\n",
     'tools/terminal/utils/xtermTheme.ts': "export const cursor = '#c0c0c0';\n",
     'tools/generative-widget/themePayload.ts': "export const fallback = { '--color-text-primary': '#666666' };\n",
+    'shared/theme/themeBoundaryFallbacks.ts': "export const fallback = { text: '#999000' };\n",
     'shared/inspector/inspectorOverlayTheme.ts': "export const overlay = { activeBorder: '#777777' };\n",
     'shared/theme/uiExceptionAccents.ts': "export const accents = { tool: '#dddddd' };\n",
+    'shared/theme/languageIdentityAccents.ts': "export const accents = { rust: '#aa5500' };\n",
     'infrastructure/language-detection/core/LanguageRegistry.ts': "export const rust = '#888888';\n",
     'component-library/components/TextStrokeEffect/TextStrokeEffect.tsx': "export const stroke = '#999999';\n",
     'component-library/components/StreamText/StreamText.scss': ".stream { color: #bbbbbb; }\n",
@@ -146,9 +148,10 @@ test('theme color audit reports specialized color domains separately from app UI
   assert.equal(report.colorDomainScopes.syntax.uniqueColors, 1);
   assert.equal(report.colorDomainScopes.terminal.uniqueColors, 1);
   assert.equal(report.colorDomainScopes.generatedWidget.uniqueColors, 1);
+  assert.equal(report.colorDomainScopes.boundaryFallback.uniqueColors, 1);
   assert.equal(report.colorDomainScopes.debugOverlay.uniqueColors, 1);
   assert.equal(report.colorDomainScopes.uiException.uniqueColors, 1);
-  assert.equal(report.colorDomainScopes.languageIdentity.uniqueColors, 1);
+  assert.equal(report.colorDomainScopes.languageIdentity.uniqueColors, 2);
   assert.equal(report.colorDomainScopes.visualEffect.uniqueColors, 2);
   assert.equal(report.colorDomainScopes.appUi.uniqueColors, 2);
 });

--- a/scripts/theme-color-governance-baseline.json
+++ b/scripts/theme-color-governance-baseline.json
@@ -9,7 +9,7 @@
       "max": 10
     },
     "colorScopes.appUi.uniqueColors": {
-      "max": 235
+      "max": 233
     },
     "colorScopes.appUi.occurrences": {
       "max": 273
@@ -49,6 +49,12 @@
     },
     "tokenAliasLiterals.uniqueColors": {
       "max": 11
+    },
+    "nearPairs.indistinguishableTotal": {
+      "max": 0
+    },
+    "nearPairs.nearTotal": {
+      "max": 35
     },
     "colorDomainScopes.themePreset.occurrences": {
       "max": 1033

--- a/scripts/theme-color-governance-baseline.json
+++ b/scripts/theme-color-governance-baseline.json
@@ -9,16 +9,16 @@
       "max": 10
     },
     "colorScopes.appUi.uniqueColors": {
-      "max": 255
+      "max": 235
     },
     "colorScopes.appUi.occurrences": {
-      "max": 309
+      "max": 273
     },
     "colorScopes.token.uniqueColors": {
       "max": 697
     },
     "colorScopes.exception.uniqueColors": {
-      "max": 188
+      "max": 212
     },
     "cssVarDefinitions.unresolvedRequiredUnique": {
       "max": 0
@@ -45,10 +45,10 @@
       "max": 0
     },
     "tokenAliasLiterals.occurrences": {
-      "max": 34
+      "max": 13
     },
     "tokenAliasLiterals.uniqueColors": {
-      "max": 26
+      "max": 11
     },
     "colorDomainScopes.themePreset.occurrences": {
       "max": 1033
@@ -63,10 +63,16 @@
       "max": 268
     },
     "colorDomainScopes.generatedWidget.occurrences": {
-      "max": 17
+      "max": 0
     },
     "colorDomainScopes.generatedWidget.uniqueColors": {
-      "max": 17
+      "max": 0
+    },
+    "colorDomainScopes.boundaryFallback.occurrences": {
+      "max": 21
+    },
+    "colorDomainScopes.boundaryFallback.uniqueColors": {
+      "max": 21
     },
     "colorDomainScopes.editor.occurrences": {
       "max": 151
@@ -81,22 +87,25 @@
       "max": 0
     },
     "colorDomainScopes.uiException.occurrences": {
-      "max": 20
+      "max": 21
     },
     "colorDomainScopes.uiException.uniqueColors": {
       "max": 19
     },
     "colorDomainScopes.languageIdentity.occurrences": {
-      "max": 48
+      "max": 57
+    },
+    "colorDomainScopes.languageIdentity.uniqueColors": {
+      "max": 50
     },
     "colorDomainScopes.visualEffect.occurrences": {
-      "max": 26
+      "max": 22
     },
     "colorDomainScopes.appUi.occurrences": {
-      "max": 123
+      "max": 108
     },
     "colorDomainScopes.appUi.uniqueColors": {
-      "max": 108
+      "max": 94
     },
     "colorDomainScopes.mermaid.occurrences": {
       "max": 139
@@ -155,7 +164,7 @@
       {
         "key": "--scene-viewport-border-width",
         "owner": "src/web-ui/src/app/scenes/SceneViewport.scss",
-        "reason": "runtime viewport layout override with zero-width default"
+        "reason": "runtime viewport layout override with stable one-pixel default"
       }
     ]
   }

--- a/scripts/theme-css-var-contract.mjs
+++ b/scripts/theme-css-var-contract.mjs
@@ -29,6 +29,8 @@ export const RUNTIME_CONTRACT_VAR_DEFINITION_PATH_PARTS = [
 
 export const EXCEPTION_PATH_PARTS = [
   'shared/theme/uiExceptionAccents',
+  'shared/theme/languageIdentityAccents',
+  'shared/theme/themeBoundaryFallbacks',
   'monaco',
   'terminal',
   'mermaid',
@@ -56,6 +58,11 @@ export const COLOR_DOMAIN_RULES = [
     key: 'generatedWidget',
     label: 'Generated widget',
     pathParts: ['tools/generative-widget'],
+  },
+  {
+    key: 'boundaryFallback',
+    label: 'Boundary fallback',
+    pathParts: ['shared/theme/themeBoundaryFallbacks'],
   },
   {
     key: 'mermaid',
@@ -94,7 +101,7 @@ export const COLOR_DOMAIN_RULES = [
   {
     key: 'languageIdentity',
     label: 'Language identity',
-    pathParts: ['infrastructure/language-detection'],
+    pathParts: ['infrastructure/language-detection', 'shared/theme/languageIdentityAccents'],
   },
   {
     key: 'visualEffect',

--- a/src/web-ui/src/app/scenes/miniapps/utils/buildMiniAppThemeVars.ts
+++ b/src/web-ui/src/app/scenes/miniapps/utils/buildMiniAppThemeVars.ts
@@ -3,23 +3,13 @@
  * Maps to --bitfun-* CSS variables for iframe theme sync.
  */
 import type { ThemeConfig, ThemeType } from '@/infrastructure/theme/types';
+import { MINI_APP_SCROLLBAR_FALLBACKS } from '@/shared/theme/themeBoundaryFallbacks';
 
 export interface MiniAppThemePayload {
   type: ThemeType;
   id: string;
   vars: Record<string, string>;
 }
-
-const MINI_APP_SCROLLBAR_FALLBACKS: Record<ThemeType, { thumb: string; thumbHover: string }> = {
-  dark: {
-    thumb: 'rgba(255, 255, 255, 0.12)',
-    thumbHover: 'rgba(255, 255, 255, 0.22)',
-  },
-  light: {
-    thumb: 'rgba(0, 0, 0, 0.15)',
-    thumbHover: 'rgba(0, 0, 0, 0.28)',
-  },
-};
 
 export function buildMiniAppThemeVars(theme: ThemeConfig | null): MiniAppThemePayload | null {
   if (!theme) return null;

--- a/src/web-ui/src/component-library/components/StreamText/StreamText.scss
+++ b/src/web-ui/src/component-library/components/StreamText/StreamText.scss
@@ -16,6 +16,11 @@
   --stream-text-sunset-coral: #ff6b6b;
   --stream-text-sunset-yellow: #ffd93d;
   --stream-text-sunset-pink: #ff9ff3;
+  --stream-text-glitch-magenta: #ff00ff;
+  --stream-text-glitch-cyan: #00ffff;
+  --stream-text-theme-purple: #a855f7;
+  --stream-text-theme-purple-neon: #c084fc;
+  --stream-text-theme-green: #22c55e;
 
   display: inline;
   font-family: var(--font-family-sans);
@@ -129,8 +134,8 @@
     opacity: 0;
     transform: translate(calc(var(--char-index, 0) * -2px), 0);
     text-shadow:
-      2px 0 #ff00ff,
-      -2px 0 #00ffff;
+      2px 0 var(--stream-text-glitch-magenta),
+      -2px 0 var(--stream-text-glitch-cyan);
   }
   20% {
     transform: translate(calc(var(--char-index, 0) * 2px), -2px);
@@ -140,8 +145,8 @@
   }
   60% {
     text-shadow:
-      1px 0 #ff00ff,
-      -1px 0 #00ffff;
+      1px 0 var(--stream-text-glitch-magenta),
+      -1px 0 var(--stream-text-glitch-cyan);
   }
   100% {
     opacity: 1;
@@ -157,8 +162,8 @@
   20%, 60% {
     opacity: 0.8;
     text-shadow:
-      1px 0 #ff00ff,
-      -1px 0 #00ffff;
+      1px 0 var(--stream-text-glitch-magenta),
+      -1px 0 var(--stream-text-glitch-cyan);
   }
 }
 
@@ -471,16 +476,16 @@
 
 
 .stream-text--theme-purple {
-  color: #a855f7;
+  color: var(--stream-text-theme-purple);
 }
 
 .stream-text--theme-purple.stream-text--neon {
-  color: #c084fc;
+  color: var(--stream-text-theme-purple-neon);
 }
 
 
 .stream-text--theme-green {
-  color: #22c55e;
+  color: var(--stream-text-theme-green);
 }
 
 .stream-text--theme-green.stream-text--neon {

--- a/src/web-ui/src/flow_chat/components/ChatInputPixelPet.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInputPixelPet.scss
@@ -20,13 +20,13 @@
 
 .bitfun-chat-input-pixel-pet {
   /* FIXED panda body palette — never inverted. */
-  --bitfun-pet-color: #1f2024;
+  --bitfun-pet-color: #202024;
   --bitfun-pet-cream: #fafaf9;
 
   /* Decorative palette — inverts between light/dark themes so overlays
      stay readable on either chat background. */
-  --bitfun-pet-decor: #1f2024;
-  --bitfun-pet-decor-soft: rgba(31, 32, 36, 0.55);
+  --bitfun-pet-decor: #202024;
+  --bitfun-pet-decor-soft: rgba(32, 32, 36, 0.55);
   --bitfun-petdex-width: 42px;
   --bitfun-petdex-height: 46px;
   --bitfun-petdex-margin-top: -8px;

--- a/src/web-ui/src/infrastructure/language-detection/core/LanguageRegistry.ts
+++ b/src/web-ui/src/infrastructure/language-detection/core/LanguageRegistry.ts
@@ -660,7 +660,7 @@ const BUILTIN_LANGUAGES: Language[] = [
     extensions: ['txt', 'text', 'log'],
     monacoId: 'plaintext',
     iconType: 'text',
-    color: '#6e7681',
+    color: '#6e7781',
     supportsComments: false,
   },
 ];

--- a/src/web-ui/src/shared/context-system/core/registerDefaultTypes.ts
+++ b/src/web-ui/src/shared/context-system/core/registerDefaultTypes.ts
@@ -113,7 +113,7 @@ export function registerDefaultContextTypes(): void {
       displayName: i18nService.t('components:contextSystem.contextRegistry.mermaidDiagram.name'),
       description: i18nService.t('components:contextSystem.contextRegistry.mermaidDiagram.description'),
       icon: React.createElement(Network, { size: 16 }),
-      color: '#22c55e', 
+      color: UI_EXCEPTION_ACCENTS.mermaidDiagram,
       category: 'diagram',
       transformer: new MermaidDiagramContextTransformer(),
       validator: new MermaidDiagramContextValidator(),

--- a/src/web-ui/src/shared/context-system/core/types/CodeSnippetContextImpl.test.ts
+++ b/src/web-ui/src/shared/context-system/core/types/CodeSnippetContextImpl.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { UI_EXCEPTION_ACCENTS } from '@/shared/theme/uiExceptionAccents';
+import { getLanguageColor, getLanguageDisplayName } from './CodeSnippetContextImpl';
+
+describe('CodeSnippetContextImpl language metadata', () => {
+  it('preserves code snippet display name mapping', () => {
+    expect(getLanguageDisplayName('typescript')).toBe('TypeScript');
+    expect(getLanguageDisplayName('cpp')).toBe('C++');
+    expect(getLanguageDisplayName('tsx')).toBe('tsx');
+    expect(getLanguageDisplayName('unknown-lang')).toBe('unknown-lang');
+    expect(getLanguageDisplayName()).toBe('Text');
+  });
+
+  it('keeps code snippet language accents centralized', () => {
+    expect(getLanguageColor('typescript')).toBe('#3178c6');
+    expect(getLanguageColor('rust')).toBe('var(--color-bg-primary)');
+    expect(getLanguageColor('java')).toBe('#007396');
+    expect(getLanguageColor('unknown-lang')).toBe('#858585');
+    expect(getLanguageColor()).toBe('#858585');
+  });
+
+  it('keeps mermaid diagram context color in the UI exception registry', () => {
+    expect(UI_EXCEPTION_ACCENTS.mermaidDiagram).toBe('#22c55e');
+  });
+});

--- a/src/web-ui/src/shared/context-system/core/types/CodeSnippetContextImpl.tsx
+++ b/src/web-ui/src/shared/context-system/core/types/CodeSnippetContextImpl.tsx
@@ -9,6 +9,7 @@ import type {
   ContextCardRenderer 
 } from '../../../services/ContextRegistry';
 import { i18nService } from '@/infrastructure/i18n';
+import { getCodeSnippetLanguageAccent } from '@/shared/theme/languageIdentityAccents';
 
 
 
@@ -180,17 +181,5 @@ export function getLanguageDisplayName(language?: string): string {
 }
 
 export function getLanguageColor(language?: string): string {
-  const colorMap: Record<string, string> = {
-    'javascript': '#f7df1e',
-    'typescript': '#3178c6',
-    'python': '#3776ab',
-    'rust': 'var(--color-bg-primary)',
-    'go': '#00add8',
-    'java': '#007396',
-    'html': '#e34c26',
-    'css': '#1572b6',
-    'scss': '#cc6699'
-  };
-  
-  return language ? (colorMap[language] || '#858585') : '#858585';
+  return getCodeSnippetLanguageAccent(language);
 }

--- a/src/web-ui/src/shared/theme/languageIdentityAccents.ts
+++ b/src/web-ui/src/shared/theme/languageIdentityAccents.ts
@@ -1,0 +1,25 @@
+// Language identity colors are data semantics, not app theme surface colors.
+// Keep this registry narrow and only add values that are consumed outside the
+// full language registry.
+export const CODE_SNIPPET_LANGUAGE_ACCENTS = {
+  javascript: '#f7df1e',
+  typescript: '#3178c6',
+  python: '#3776ab',
+  rust: 'var(--color-bg-primary)',
+  go: '#00add8',
+  java: '#007396',
+  html: '#e34c26',
+  css: '#1572b6',
+  scss: '#cc6699',
+  fallback: '#858585',
+} as const;
+
+export function getCodeSnippetLanguageAccent(language?: string): string {
+  if (!language) {
+    return CODE_SNIPPET_LANGUAGE_ACCENTS.fallback;
+  }
+
+  return CODE_SNIPPET_LANGUAGE_ACCENTS[
+    language as keyof typeof CODE_SNIPPET_LANGUAGE_ACCENTS
+  ] ?? CODE_SNIPPET_LANGUAGE_ACCENTS.fallback;
+}

--- a/src/web-ui/src/shared/theme/themeBoundaryFallbacks.ts
+++ b/src/web-ui/src/shared/theme/themeBoundaryFallbacks.ts
@@ -1,0 +1,32 @@
+// Last-resort values for isolated surfaces that can render before root theme
+// variables are available. Keep these values exact and boundary-scoped.
+export const WIDGET_IFRAME_FALLBACK_COLOR = {
+  textPrimary: '#e8e8e8',
+  textSecondary: '#b0b0b0',
+  textMuted: '#858585',
+  accent500: '#60a5fa',
+  accent600: '#3b82f6',
+  bgSecondary: '#1c1c1f',
+  success: '#34d399',
+  warning: '#f59e0b',
+  error: '#ef4444',
+  staticWhite: '#ffffff',
+  borderSubtle: 'rgba(255, 255, 255, 0.1)',
+  borderBase: 'rgba(255, 255, 255, 0.16)',
+  borderMedium: 'rgba(255, 255, 255, 0.24)',
+  elementBgSubtle: 'rgba(255, 255, 255, 0.05)',
+  elementBgBase: 'rgba(255, 255, 255, 0.08)',
+  elementBgMedium: 'rgba(255, 255, 255, 0.14)',
+  shadowBase: 'rgba(0, 0, 0, 0.4)',
+} as const;
+
+export const MINI_APP_SCROLLBAR_FALLBACKS = {
+  dark: {
+    thumb: 'rgba(255, 255, 255, 0.12)',
+    thumbHover: 'rgba(255, 255, 255, 0.22)',
+  },
+  light: {
+    thumb: 'rgba(0, 0, 0, 0.15)',
+    thumbHover: 'rgba(0, 0, 0, 0.28)',
+  },
+} as const;

--- a/src/web-ui/src/shared/theme/uiExceptionAccents.ts
+++ b/src/web-ui/src/shared/theme/uiExceptionAccents.ts
@@ -4,6 +4,7 @@ export const UI_EXCEPTION_ACCENTS = {
   contextCompression: '#a855f7',
   generativeUi: '#38bdf8',
   miniApp: '#7c8cef',
+  mermaidDiagram: '#22c55e',
   tealAction: '#14b8a6',
   todo: '#0d9488',
   textStroke: [

--- a/src/web-ui/src/tools/generative-widget/themePayload.ts
+++ b/src/web-ui/src/tools/generative-widget/themePayload.ts
@@ -1,3 +1,5 @@
+import { WIDGET_IFRAME_FALLBACK_COLOR } from '@/shared/theme/themeBoundaryFallbacks';
+
 export type WidgetThemePayload = {
   id: string;
   type: string;
@@ -27,26 +29,6 @@ const FALLBACK_VAR = {
 } as const;
 
 type WidgetThemeFallbackVarName = typeof FALLBACK_VAR[keyof typeof FALLBACK_VAR];
-
-const WIDGET_IFRAME_FALLBACK_COLOR = {
-  textPrimary: '#e8e8e8',
-  textSecondary: '#b0b0b0',
-  textMuted: '#858585',
-  accent500: '#60a5fa',
-  accent600: '#3b82f6',
-  bgSecondary: '#1c1c1f',
-  success: '#34d399',
-  warning: '#f59e0b',
-  error: '#ef4444',
-  staticWhite: '#ffffff',
-  borderSubtle: 'rgba(255, 255, 255, 0.1)',
-  borderBase: 'rgba(255, 255, 255, 0.16)',
-  borderMedium: 'rgba(255, 255, 255, 0.24)',
-  elementBgSubtle: 'rgba(255, 255, 255, 0.05)',
-  elementBgBase: 'rgba(255, 255, 255, 0.08)',
-  elementBgMedium: 'rgba(255, 255, 255, 0.14)',
-  shadowBase: 'rgba(0, 0, 0, 0.4)',
-} as const;
 
 // Keep this fallback map small and self-contained. It is the last-resort iframe
 // contract for static widget rendering before the host theme payload arrives.


### PR DESCRIPTION
## Summary

- Centralized code snippet language accents in a narrow language identity registry while preserving existing display-name behavior and the unknown-language `#858585` fallback.
- Moved generated widget iframe defaults and miniapp scrollbar defaults into an explicit boundary fallback registry, leaving generated-widget color debt at `0/0`.
- Moved the Mermaid context accent into the UI exception registry and converted repeated StreamText visual-effect literals to component-private variables.
- Completed Phase 5 first-pass near-color cleanup by merging only two audit-classified indistinguishable pairs with RGB distance `1`.
- Completed Phase 6 first-pass guardrails by adding component near-pair totals/source reporting and baseline budgets for app raw colors, fallback debt, CSS var contracts, and component near-color drift.

## Governance impact

| Metric | Before | After |
| --- | ---: | ---: |
| Component/non-token occurrences | 309 | 273 |
| Component/non-token unique colors | 255 | 233 |
| App UI occurrences | 123 | 108 |
| App UI unique colors | 108 | 94 |
| Token-equivalent app literal occurrences | 34 | 13 |
| Token-equivalent app literal unique colors | 26 | 11 |
| Generated widget domain | 17 / 17 | 0 / 0 |
| Boundary fallback domain | n/a | 21 / 21 |
| Component indistinguishable near-color pairs | 2 | 0 |
| Component near-color pairs requiring evidence | 37 | 35 |
| CSS var governance errors | 0 | 0 |

## Risk review

- Near-color merging is limited to `#1f2024 -> #202024` and `#6e7681 -> #6e7781`; both are RGB distance `1`, non-state colors, and are not used to distinguish adjacent user-facing states.
- `nearPairs.*` is intentionally scoped to non-token/non-exception component colors. Theme preset, editor, syntax, terminal, language identity, and boundary fallback colors remain governed by `colorDomainScopes.*` budgets and require separate visual/semantic evidence before merging.
- Higher-risk component near pairs remain deferred because diff/editor/context-menu/Tiptap/Flow Chat fallback surfaces may intentionally encode elevation, overlay, or state differences through small alpha or luminance changes.
- Dynamic CSS var behavior was rechecked: this PR does not add template-composed CSS variable keys outside the existing registered families, and audit reports unresolved/fallback-only/non-contract/dynamic-family errors all at `0`.
- Boundary fallback values are still exact last-resort values for isolated widget/miniapp rendering; they were moved to a registry, not retokenized through root theme variables.
- No screenshot visual regression run was added for this pass; the only user-visible literal changes are the two audit-classified indistinguishable pairs, and broader visual-risk pairs are intentionally not merged in this PR.

## Verification

- `node --test scripts/audit-theme-colors.test.mjs` passed: 17 tests.
- `pnpm run theme:color-audit -- --top 20` passed: 1525 production files scanned, component/non-token `273/233`, app UI `108/94`, fallback vars `31/10`, component indistinguishable pairs `0`, component near pairs `35`, CSS var governance errors all `0`.
- `pnpm run lint:web` passed with 0 errors and 4 existing warnings.
- `pnpm run type-check:web` passed.
- `pnpm --dir src/web-ui run test:run` passed: 211 files, 1162 tests.
- `pnpm run build:web` passed with existing Vite dynamic import/chunk warnings.
- `pnpm run check:repo-hygiene` passed.
- `git diff --check` passed.