### PR TITLE
fix(ppt-live): improve responsive studio layout across breakpoints

### DIFF
--- a/src/crates/contracts/product-domains/src/miniapp/builtin/assets/ppt-live/bundle.json
+++ b/src/crates/contracts/product-domains/src/miniapp/builtin/assets/ppt-live/bundle.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "id": "builtin-ppt-live",
-  "version": 184
+  "version": 185
 }

--- a/src/crates/contracts/product-domains/src/miniapp/builtin/assets/ppt-live/meta.json
+++ b/src/crates/contracts/product-domains/src/miniapp/builtin/assets/ppt-live/meta.json
@@ -10,7 +10,7 @@
     "ppt",
     "ai"
   ],
-  "version": 184,
+  "version": 185,
   "created_at": 0,
   "updated_at": 0,
   "permissions": {

--- a/src/crates/contracts/product-domains/src/miniapp/builtin/assets/ppt-live/style.css
+++ b/src/crates/contracts/product-domains/src/miniapp/builtin/assets/ppt-live/style.css
@@ -1824,61 +1824,6 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
   background: var(--bitfun-scrollbar-thumb-hover, color-mix(in srgb, var(--studio-text) 22%, transparent));
 }
 
-@media (max-width: 980px) {
-  .app-topbar {
-    grid-template-columns: minmax(0, 1fr) auto;
-    grid-template-areas: "leading actions";
-    min-height: 44px;
-    gap: 10px;
-    padding: 0 10px;
-  }
-  .eyebrow, .topbar-deck, .topbar-divider { display: none; }
-  .brand-mark {
-    width: 24px;
-    height: 24px;
-    border-radius: 7px;
-  }
-  .topbar-action-group {
-    border: 0;
-    background: transparent;
-    padding: 0;
-  }
-  .app-topbar .btn {
-    min-height: 28px;
-    padding: 0 9px;
-  }
-  .app-topbar .btn-primary {
-    min-height: 30px;
-  }
-  .studio-shell {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: minmax(0, 1fr) auto;
-  }
-  .filmstrip, .panel-resizer--filmstrip { display: none; }
-  .panel-resizer--agent { display: none; }
-  .agent-sidebar {
-    max-height: 42vh;
-    border-left: 0;
-    border-top: 1px solid var(--studio-line);
-  }
-}
-
-@media (max-width: 640px) {
-  .app-topbar {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-areas: "leading";
-  }
-  .topbar-actions {
-    display: none;
-  }
-  .topbar-action-group {
-    display: none;
-  }
-  .app-topbar .btn-primary {
-    padding: 0 12px;
-  }
-}
-
 /* ============================================
    11. CANVAS ZOOM CONTROLS
    ============================================ */
@@ -2917,6 +2862,52 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 /* ============================================
    20. RESPONSIVE
    ============================================ */
+@media (max-width: 1180px) {
+  .studio-shell {
+    grid-template-columns:
+      clamp(150px, 18vw, 180px)
+      6px
+      minmax(0, 1fr)
+      6px
+      clamp(280px, 28vw, 320px);
+  }
+
+  .filmstrip-head {
+    padding: 8px 7px;
+  }
+
+  .slide-thumbs {
+    gap: 6px;
+    padding: 6px;
+  }
+
+  .thumb {
+    gap: 5px;
+    padding: 5px;
+    border-radius: 8px;
+  }
+
+  .agent-card {
+    padding: 10px;
+  }
+
+  .agent-card--properties {
+    max-height: clamp(160px, 30vh, 300px);
+  }
+
+  .property-section__header {
+    padding: 10px 12px;
+  }
+
+  .property-section__body {
+    padding: 0 12px 12px;
+  }
+
+  .onebox-input {
+    min-height: 100px;
+  }
+}
+
 @media (max-width: 980px) {
   .app-topbar {
     grid-template-columns: minmax(0, 1fr) auto;
@@ -2944,16 +2935,46 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
     min-height: 30px;
   }
   .studio-shell {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(320px, 1fr) minmax(260px, clamp(260px, 34vw, 320px));
+    grid-template-rows: minmax(0, 1fr);
   }
-  .filmstrip, .panel-resizer--filmstrip { display: none; }
-  .panel-resizer--agent { display: none; }
+
+  .filmstrip,
+  .panel-resizer--filmstrip,
+  .panel-resizer--agent {
+    display: none;
+  }
+
+  .canvas-area {
+    padding: clamp(6px, 1vw, 12px);
+  }
+
   .agent-sidebar {
-    max-height: 42vh;
-    border-left: 0;
-    border-top: 1px solid var(--studio-line);
+    height: 100%;
+    max-height: none;
+    grid-template-rows: auto minmax(0, 1fr);
+    border-left: 1px solid var(--studio-line);
+    border-top: 0;
   }
+
+  .agent-card--properties {
+    display: none;
+  }
+
+  .agent-card--prompt {
+    gap: 8px;
+  }
+
+  .onebox-input {
+    min-height: 88px;
+    max-height: 18vh;
+  }
+
+  .agent-stream-list {
+    min-height: 0;
+    max-height: none;
+  }
+
   .canvas-zoom-bar { display: none; }
   .export-modal__body { flex-direction: column; }
   .export-settings {
@@ -2964,19 +2985,89 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
   }
 }
 
+@media (max-width: 720px) {
+  .studio-shell {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(180px, 1fr) auto;
+  }
+
+  .agent-sidebar {
+    max-height: min(34vh, 260px);
+    grid-template-rows: auto;
+    border-left: 0;
+    border-top: 1px solid var(--studio-line);
+    overflow: auto;
+  }
+
+  .agent-card--prompt {
+    border-bottom: 0;
+  }
+
+  .agent-card--tabs {
+    display: none;
+  }
+
+  .onebox-input {
+    min-height: 72px;
+    max-height: 110px;
+    resize: vertical;
+  }
+
+  .onebox-submit {
+    min-height: 36px;
+  }
+
+  .statusbar {
+    gap: 8px;
+    padding: 0 10px;
+  }
+
+  .statusbar-left,
+  .statusbar-right {
+    gap: 8px;
+  }
+
+  .statusbar-meta {
+    display: none;
+  }
+}
+
 @media (max-width: 640px) {
+  .app-topbar {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas: "leading actions";
+  }
+
+  .topbar-title-row h1 {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .topbar-actions {
+    gap: 6px;
+  }
+
+  .app-topbar .btn {
+    padding: 0 8px;
+  }
+
+  .app-topbar .btn-primary {
+    padding: 0 10px;
+  }
+}
+
+@media (max-width: 520px) {
   .app-topbar {
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas: "leading";
   }
+
   .topbar-actions {
     display: none;
   }
+
   .topbar-action-group {
     display: none;
-  }
-  .app-topbar .btn-primary {
-    padding: 0 12px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Consolidate duplicate responsive CSS blocks in the ppt-live miniapp and bump asset version to 185.
- Add a 1180px breakpoint to tighten filmstrip, agent panel, and onebox spacing on medium-width viewports.
- Rework 980px/720px/640px/520px layouts so canvas and agent sidebar stay side-by-side longer, hide non-essential panels progressively, and defer hiding topbar actions until very narrow widths.

## Test plan
- [ ] Open ppt-live in desktop/web at widths ~1200px, 980px, 720px, 640px, and 520px
- [ ] Verify filmstrip hides at <=980px while canvas + agent sidebar remain usable
- [ ] Verify agent properties panel hides at <=980px and tabs hide at <=720px
- [ ] Verify topbar actions remain visible until <=520px
- [ ] Confirm no duplicate/conflicting responsive rules in style.css