### PR TITLE
fix: refresh prompt scaffold after context compression

### DIFF
--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -90,6 +90,12 @@ struct CompressionRuntimeScaffold {
 }
 
 #[derive(Debug, Clone)]
+struct TurnPromptScaffold {
+    system_prompt_message: Message,
+    prepended_prompt_reminders: PrependedPromptReminders,
+}
+
+#[derive(Debug, Clone)]
 struct ContextHealthSnapshot {
     token_usage_ratio: f32,
     full_compression_count: usize,
@@ -805,6 +811,116 @@ impl ExecutionEngine {
         Ok(system_prompt)
     }
 
+    async fn resolve_turn_prompt_scaffold(
+        &self,
+        context: &ExecutionContext,
+        current_agent: &dyn crate::agentic::agents::Agent,
+        model_name: &str,
+        supports_image_understanding: bool,
+        tool_listing_sections: ToolListingSections,
+        runtime_context_needs: RuntimeContextNeeds,
+        stage: &str,
+    ) -> BitFunResult<TurnPromptScaffold> {
+        debug!(
+            "Resolving turn prompt scaffold: session_id={}, turn_id={}, stage={}, agent={}, model={}",
+            context.session_id,
+            context.dialog_turn_id,
+            stage,
+            current_agent.name(),
+            model_name
+        );
+
+        let prompt_context = Self::build_prompt_context(
+            context,
+            model_name,
+            supports_image_understanding,
+            tool_listing_sections,
+            runtime_context_needs,
+        )
+        .await;
+        let prepended_prompt_reminders = self
+            .build_cached_prepended_prompt_reminders(
+                &context.session_id,
+                current_agent,
+                prompt_context.as_ref(),
+                &context.context,
+            )
+            .await;
+        let system_prompt = self
+            .resolve_cached_system_prompt(
+                &context.session_id,
+                current_agent,
+                prompt_context.as_ref(),
+            )
+            .await?;
+
+        Self::log_turn_prompt_scaffold(
+            &context.session_id,
+            &context.dialog_turn_id,
+            stage,
+            system_prompt.len(),
+            &prepended_prompt_reminders,
+        );
+
+        Ok(TurnPromptScaffold {
+            system_prompt_message: Message::system(system_prompt),
+            prepended_prompt_reminders,
+        })
+    }
+
+    fn log_turn_prompt_scaffold(
+        session_id: &str,
+        turn_id: &str,
+        stage: &str,
+        system_prompt_len: usize,
+        prepended_prompt_reminders: &PrependedPromptReminders,
+    ) {
+        debug!(
+            "Turn prompt scaffold resolved: session_id={}, turn_id={}, stage={}, system_prompt_len={} bytes, skill_listing_len={}, agent_listing_len={}, collapsed_tool_listing_len={}, user_context_len={}, runtime_context_len={}",
+            session_id,
+            turn_id,
+            stage,
+            system_prompt_len,
+            prepended_prompt_reminders
+                .skill_listing
+                .as_ref()
+                .map(|text| text.len())
+                .unwrap_or(0),
+            prepended_prompt_reminders
+                .agent_listing
+                .as_ref()
+                .map(|text| text.len())
+                .unwrap_or(0),
+            prepended_prompt_reminders
+                .collapsed_tool_listing
+                .as_ref()
+                .map(|text| text.len())
+                .unwrap_or(0),
+            prepended_prompt_reminders
+                .user_context
+                .as_ref()
+                .map(|text| text.len())
+                .unwrap_or(0),
+            prepended_prompt_reminders
+                .runtime_context
+                .as_ref()
+                .map(|text| text.len())
+                .unwrap_or(0)
+        );
+    }
+
+    fn apply_turn_prompt_scaffold_to_messages(
+        messages: &mut Vec<Message>,
+        scaffold: &TurnPromptScaffold,
+    ) {
+        match messages.first_mut() {
+            Some(first_message) if first_message.role == MessageRole::System => {
+                *first_message = scaffold.system_prompt_message.clone();
+            }
+            _ => messages.insert(0, scaffold.system_prompt_message.clone()),
+        }
+    }
+
     pub(crate) async fn resolve_model_id_for_turn(
         &self,
         session: &Session,
@@ -1487,35 +1603,23 @@ impl ExecutionEngine {
         // prefix/KV cache misses on subsequent rounds.
         let tool_definitions = tool_manifest.map(|manifest| manifest.tool_definitions);
 
-        let prompt_context = Self::build_prompt_context(
-            context,
-            &ai_client.config.model,
-            primary_supports_image_understanding,
-            tool_listing_sections,
-            runtime_context_needs,
-        )
-        .await;
-        let prepended_prompt_reminders = self
-            .build_cached_prepended_prompt_reminders(
-                &context.session_id,
+        let turn_prompt_scaffold = self
+            .resolve_turn_prompt_scaffold(
+                context,
                 current_agent.as_ref(),
-                prompt_context.as_ref(),
-                &context.context,
-            )
-            .await;
-        let system_prompt = self
-            .resolve_cached_system_prompt(
-                &context.session_id,
-                current_agent.as_ref(),
-                prompt_context.as_ref(),
+                &ai_client.config.model,
+                primary_supports_image_understanding,
+                tool_listing_sections,
+                runtime_context_needs,
+                "compression_scaffold",
             )
             .await?;
 
         Ok(CompressionRuntimeScaffold {
             ai_client,
             tool_definitions,
-            system_prompt_message: Message::system(system_prompt),
-            prepended_prompt_reminders,
+            system_prompt_message: turn_prompt_scaffold.system_prompt_message,
+            prepended_prompt_reminders: turn_prompt_scaffold.prepended_prompt_reminders,
             primary_supports_image_understanding,
             compression_contract_limit: context_profile_policy.compression_contract_limit,
         })
@@ -2217,69 +2321,23 @@ impl ExecutionEngine {
             (vec![], None)
         };
 
-        // 4. Get System Prompt from current Agent
-        debug!(
-            "Building system prompt from agent: {}, model={}",
-            current_agent.name(),
-            ai_client.config.model
-        );
-        let prompt_context = Self::build_prompt_context(
-            &context,
-            &ai_client.config.model,
-            primary_supports_image_understanding,
-            tool_listing_sections,
-            runtime_context_needs,
-        )
-        .await;
-        let prepended_prompt_reminders = self
-            .build_cached_prepended_prompt_reminders(
-                &context.session_id,
+        // 4. Resolve the prompt scaffold used by model requests in this turn.
+        // It is refreshed after successful context compression so the first
+        // post-compaction request builds the new provider-side prefix cache.
+        let mut turn_prompt_scaffold = self
+            .resolve_turn_prompt_scaffold(
+                &context,
                 current_agent.as_ref(),
-                prompt_context.as_ref(),
-                &context.context,
-            )
-            .await;
-        let prepended_reminders = prepended_prompt_reminders.ordered_reminders();
-        let system_prompt = self
-            .resolve_cached_system_prompt(
-                &context.session_id,
-                current_agent.as_ref(),
-                prompt_context.as_ref(),
+                &ai_client.config.model,
+                primary_supports_image_understanding,
+                tool_listing_sections.clone(),
+                runtime_context_needs,
+                "turn_start",
             )
             .await?;
-        debug!("System prompt built, length: {} bytes", system_prompt.len());
-        debug!(
-            "Prepended reminders built: skill_listing_len={} agent_listing_len={} collapsed_tool_listing_len={} user_context_len={} runtime_context_len={}",
-            prepended_prompt_reminders
-                .skill_listing
-                .as_ref()
-                .map(|text| text.len())
-                .unwrap_or(0),
-            prepended_prompt_reminders
-                .agent_listing
-                .as_ref()
-                .map(|text| text.len())
-                .unwrap_or(0),
-            prepended_prompt_reminders
-                .collapsed_tool_listing
-                .as_ref()
-                .map(|text| text.len())
-                .unwrap_or(0),
-            prepended_prompt_reminders
-                .user_context
-                .as_ref()
-                .map(|text| text.len())
-                .unwrap_or(0),
-            prepended_prompt_reminders
-                .runtime_context
-                .as_ref()
-                .map(|text| text.len())
-                .unwrap_or(0)
-        );
-        let system_prompt_message = Message::system(system_prompt.clone());
 
         // Add System Prompt to the beginning of message list (only for this execution, not persisted)
-        let mut messages = vec![system_prompt_message.clone()];
+        let mut messages = vec![turn_prompt_scaffold.system_prompt_message.clone()];
         messages.extend(initial_messages);
 
         let mut round_index = 0;
@@ -2446,8 +2504,8 @@ impl ExecutionEngine {
                         context_window,
                         ai_client.clone(),
                         &tool_definitions,
-                        system_prompt_message.clone(),
-                        &prepended_prompt_reminders,
+                        turn_prompt_scaffold.system_prompt_message.clone(),
+                        &turn_prompt_scaffold.prepended_prompt_reminders,
                         primary_supports_image_understanding,
                         context_profile_policy.compression_contract_limit,
                         context.workspace.as_ref(),
@@ -2465,6 +2523,21 @@ impl ExecutionEngine {
                         );
 
                         messages = compressed_messages;
+                        turn_prompt_scaffold = self
+                            .resolve_turn_prompt_scaffold(
+                                &context,
+                                current_agent.as_ref(),
+                                &ai_client.config.model,
+                                primary_supports_image_understanding,
+                                tool_listing_sections.clone(),
+                                runtime_context_needs,
+                                "after_context_compression",
+                            )
+                            .await?;
+                        Self::apply_turn_prompt_scaffold_to_messages(
+                            &mut messages,
+                            &turn_prompt_scaffold,
+                        );
                         full_compression_count += 1;
                         consecutive_compression_failures = 0;
                     }
@@ -2568,6 +2641,9 @@ impl ExecutionEngine {
                 messages.len()
             );
 
+            let prepended_reminders = turn_prompt_scaffold
+                .prepended_prompt_reminders
+                .ordered_reminders();
             let ai_messages = Self::build_ai_messages_for_send(
                 &messages,
                 &ai_client.config.format,
@@ -3019,6 +3095,9 @@ impl ExecutionEngine {
                     context.session_id, context.dialog_turn_id, reason
                 );
 
+                let finalize_prepended_reminders = turn_prompt_scaffold
+                    .prepended_prompt_reminders
+                    .ordered_reminders();
                 let final_round_result = self
                     .run_finalize_round(
                         ai_client.clone(),
@@ -3028,7 +3107,7 @@ impl ExecutionEngine {
                         finalize_round_group_id.clone(),
                         &execution_context_vars,
                         primary_supports_image_understanding,
-                        &prepended_reminders,
+                        &finalize_prepended_reminders,
                         &messages,
                         finalize_reminder,
                         tool_definitions.clone(),
@@ -3058,7 +3137,7 @@ impl ExecutionEngine {
                             finalize_round_group_id.clone(),
                             &execution_context_vars,
                             primary_supports_image_understanding,
-                            &prepended_reminders,
+                            &finalize_prepended_reminders,
                             &messages,
                             finalize_reminder,
                             tool_definitions.clone(),
@@ -3278,7 +3357,8 @@ impl ExecutionEngine {
 
 #[cfg(test)]
 mod tests {
-    use super::{ContextHealthSnapshot, ExecutionEngine};
+    use super::{ContextHealthSnapshot, ExecutionEngine, TurnPromptScaffold};
+    use crate::agentic::agents::PrependedPromptReminders;
     use crate::agentic::core::{InternalReminderKind, Message, MessageRole, ToolCall, ToolResult};
     use crate::agentic::tools::ToolRuntimeRestrictions;
     use crate::service::config::types::AIConfig;
@@ -3296,6 +3376,13 @@ mod tests {
             provider: "anthropic".to_string(),
             enabled: true,
             ..Default::default()
+        }
+    }
+
+    fn message_text(message: &Message) -> Option<&str> {
+        match &message.content {
+            crate::agentic::core::MessageContent::Text(text) => Some(text.as_str()),
+            _ => None,
         }
     }
 
@@ -3329,6 +3416,41 @@ mod tests {
 
         assert!(total_tokens > conversation_tokens);
         assert!(usage_ratio < total_tokens as f32 / 128_000_f32);
+        assert_eq!(messages[1].role, MessageRole::User);
+    }
+
+    #[test]
+    fn refreshed_turn_prompt_scaffold_replaces_existing_system_message() {
+        let scaffold = TurnPromptScaffold {
+            system_prompt_message: Message::system("new system prompt".to_string()),
+            prepended_prompt_reminders: PrependedPromptReminders::default(),
+        };
+        let mut messages = vec![
+            Message::system("old system prompt".to_string()),
+            Message::user("hello".to_string()),
+        ];
+
+        ExecutionEngine::apply_turn_prompt_scaffold_to_messages(&mut messages, &scaffold);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, MessageRole::System);
+        assert_eq!(message_text(&messages[0]), Some("new system prompt"));
+        assert_eq!(messages[1].role, MessageRole::User);
+    }
+
+    #[test]
+    fn refreshed_turn_prompt_scaffold_inserts_system_message_when_missing() {
+        let scaffold = TurnPromptScaffold {
+            system_prompt_message: Message::system("new system prompt".to_string()),
+            prepended_prompt_reminders: PrependedPromptReminders::default(),
+        };
+        let mut messages = vec![Message::user("hello".to_string())];
+
+        ExecutionEngine::apply_turn_prompt_scaffold_to_messages(&mut messages, &scaffold);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, MessageRole::System);
+        assert_eq!(message_text(&messages[0]), Some("new system prompt"));
         assert_eq!(messages[1].role, MessageRole::User);
     }
 


### PR DESCRIPTION
## Summary

Refresh the active turn prompt scaffold immediately after automatic context compression.

This ensures the first model request after compaction rebuilds and uses the new system prompt / prepended reminders cache instead of continuing with the stale scaffold until the next turn.

Fixes #

## Type and Areas

Type:

Regression fix / Rust core

Areas:

Rust core, agent execution, context compression, prompt cache

## Motivation / Impact

Context compression intentionally invalidates prompt cache state, but the execution loop previously kept using the turn-start system prompt and prepended reminders for later rounds in the same turn. That delayed prompt cache rebuild until the next turn, increasing provider-side prompt cache misses after compaction.

This change introduces a `TurnPromptScaffold` for model-round prompt preparation and refreshes it after successful automatic compression. The refreshed scaffold replaces the transient system message for the current execution and is used by subsequent model and finalize rounds.

Manual compaction behavior is unchanged: it already invalidates prompt cache and the next dialog turn rebuilds prompt state.

## Verification

- `pnpm run fmt:rs` — passed
- `cargo test -p bitfun-core refreshed_turn_prompt_scaffold -- --nocapture` — passed
- `cargo check --workspace` — passed

## Reviewer Notes

The change does not alter prompt-cache persistence semantics or skill/agent snapshot mutation. It only makes the already rebuilt listing baseline and invalidated prompt cache visible to the next model request within the same automatic-compression turn.

The implementation keeps compression logic separate from model-round prompt preparation.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.