### PR TITLE
fix(profile): preserve IDENTITY.md frontmatter in persona doc editor

### DIFF
--- a/src/web-ui/src/app/scenes/my-agent/identityDocument.test.ts
+++ b/src/web-ui/src/app/scenes/my-agent/identityDocument.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  joinMarkdownFrontmatter,
+  parseIdentityDocument,
+  serializeIdentityDocument,
+  splitMarkdownFrontmatter,
+} from './identityDocument';
+
+describe('identityDocument frontmatter helpers', () => {
+  it('splits markdown frontmatter from the body', () => {
+    const content = [
+      '---',
+      'name: Demo',
+      'emoji: 🙂',
+      '---',
+      '',
+      '# Body',
+      '',
+      'Hello',
+    ].join('\n');
+
+    expect(splitMarkdownFrontmatter(content)).toEqual({
+      hasFrontmatter: true,
+      frontmatter: 'name: Demo\nemoji: 🙂',
+      body: '# Body\n\nHello',
+    });
+  });
+
+  it('rejoins markdown frontmatter and body as a markdown document', () => {
+    const content = joinMarkdownFrontmatter('name: Demo\nemoji: 🙂', '# Body\n\nHello');
+
+    expect(content).toBe('---\nname: Demo\nemoji: 🙂\n---\n\n# Body\n\nHello\n');
+  });
+
+  it('can preserve an empty frontmatter block while editing', () => {
+    const content = joinMarkdownFrontmatter('', '# Body', {
+      preserveFrontmatterBlock: true,
+    });
+
+    expect(content).toBe('---\n\n---\n\n# Body\n');
+  });
+
+  it('serializes identity documents through the frontmatter join helper', () => {
+    const serialized = serializeIdentityDocument({
+      name: 'Demo',
+      creature: 'Cat',
+      vibe: 'Calm',
+      emoji: '🙂',
+      body: '# Body\n\nHello',
+      modelPrimary: '',
+      modelFast: '',
+    });
+
+    expect(serialized).toBe([
+      '---',
+      'name: Demo',
+      'creature: Cat',
+      'vibe: Calm',
+      'emoji: 🙂',
+      '---',
+      '',
+      '# Body',
+      '',
+      'Hello',
+      '',
+    ].join('\n'));
+  });
+
+  it('parses identity frontmatter fields and markdown body independently', () => {
+    const parsed = parseIdentityDocument([
+      '---',
+      'name: Demo',
+      'creature: Cat',
+      'vibe: Calm',
+      'emoji: 🙂',
+      '---',
+      '',
+      '# Body',
+      '',
+      'Hello',
+    ].join('\n'));
+
+    expect(parsed).toEqual({
+      name: 'Demo',
+      creature: 'Cat',
+      vibe: 'Calm',
+      emoji: '🙂',
+      body: '# Body\n\nHello',
+      modelPrimary: '',
+      modelFast: '',
+    });
+  });
+});

--- a/src/web-ui/src/app/scenes/my-agent/identityDocument.ts
+++ b/src/web-ui/src/app/scenes/my-agent/identityDocument.ts
@@ -31,6 +31,12 @@ const FRONTMATTER_FIELDS: Array<keyof Omit<IdentityDocument, 'body'>> = [
   'modelFast',
 ];
 
+export interface MarkdownFrontmatterSections {
+  hasFrontmatter: boolean;
+  frontmatter: string;
+  body: string;
+}
+
 function normalizeLineEndings(content: string): string {
   return content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 }
@@ -47,26 +53,61 @@ function serializeScalar(value: string): string {
   return yaml.stringify(value).trimEnd();
 }
 
-export function parseIdentityDocument(content: string): IdentityDocument {
+export function splitMarkdownFrontmatter(content: string): MarkdownFrontmatterSections {
   const normalizedContent = normalizeLineEndings(content || '');
   const frontmatterMatch = normalizedContent.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
 
   if (!frontmatterMatch) {
     return {
-      ...EMPTY_IDENTITY_DOCUMENT,
-      body: normalizedContent.trim(),
+      hasFrontmatter: false,
+      frontmatter: '',
+      body: normalizedContent.trimEnd(),
     };
   }
 
-  const parsed = (yaml.parse(frontmatterMatch[1]) || {}) as Record<string, unknown>;
-  const body = frontmatterMatch[2] ?? '';
+  return {
+    hasFrontmatter: true,
+    frontmatter: frontmatterMatch[1] ?? '',
+    body: (frontmatterMatch[2] ?? '').replace(/^\n+/, '').trimEnd(),
+  };
+}
+
+export function joinMarkdownFrontmatter(
+  frontmatter: string,
+  body: string,
+  options?: { preserveFrontmatterBlock?: boolean }
+): string {
+  const normalizedFrontmatter = normalizeLineEndings(frontmatter || '')
+    .replace(/^\n+/, '')
+    .trimEnd();
+  const normalizedBody = normalizeLineEndings(body || '')
+    .replace(/^\n+/, '')
+    .trimEnd();
+
+  if (!normalizedFrontmatter && !options?.preserveFrontmatterBlock) {
+    return normalizedBody ? `${normalizedBody}\n` : '';
+  }
+
+  return `---\n${normalizedFrontmatter}\n---\n\n${normalizedBody}`.trimEnd() + '\n';
+}
+
+export function parseIdentityDocument(content: string): IdentityDocument {
+  const sections = splitMarkdownFrontmatter(content);
+  if (!sections.hasFrontmatter) {
+    return {
+      ...EMPTY_IDENTITY_DOCUMENT,
+      body: sections.body.trim(),
+    };
+  }
+
+  const parsed = (yaml.parse(sections.frontmatter) || {}) as Record<string, unknown>;
 
   return {
     name: normalizeShortField(parsed.name),
     creature: normalizeShortField(parsed.creature),
     vibe: normalizeShortField(parsed.vibe),
     emoji: normalizeShortField(parsed.emoji),
-    body: body.replace(/^\n+/, '').trimEnd(),
+    body: sections.body,
     modelPrimary: normalizeShortField(parsed.modelPrimary),
     modelFast: normalizeShortField(parsed.modelFast),
   };
@@ -95,7 +136,7 @@ export function serializeIdentityDocument(document: IdentityDocument): string {
     })
     .join('\n');
 
-  return `---\n${frontmatter}\n---\n\n${normalized.body}`.trimEnd() + '\n';
+  return joinMarkdownFrontmatter(frontmatter, normalized.body);
 }
 
 export function getIdentityFilePath(workspaceRoot: string): string {

--- a/src/web-ui/src/app/scenes/profile/views/AssistantConfigPage.tsx
+++ b/src/web-ui/src/app/scenes/profile/views/AssistantConfigPage.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useEffect, useMemo, useRef, useState,
+  useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState,
   lazy,
   Suspense,
 } from 'react';
@@ -23,7 +23,12 @@ import { WorkspaceKind } from '@/shared/types';
 import { useMyAgentStore } from '@/app/scenes/my-agent/myAgentStore';
 import { useAgentIdentityDocument } from '@/app/scenes/my-agent/useAgentIdentityDocument';
 import { useTheme } from '@/infrastructure/theme/hooks/useTheme';
-import { MEditor } from '@/tools/editor/meditor';
+import { EditArea, MEditor } from '@/tools/editor/meditor';
+import { analyzeMarkdownEditability } from '@/tools/editor/meditor/utils/tiptapMarkdown';
+import {
+  joinMarkdownFrontmatter,
+  splitMarkdownFrontmatter,
+} from '@/app/scenes/my-agent/identityDocument';
 import SessionsSection from '@/app/components/NavPanel/sections/sessions/SessionsSection';
 import AssistantQuickInput from './AssistantQuickInput';
 import { useNurseryStore } from '../nurseryStore';
@@ -51,10 +56,43 @@ type RightPanelView = 'info' | 'personaDoc';
 
 interface PersonaDocState {
   fileName: PersonaDocFile;
+  originalContent: string;
   content: string;
   loading: boolean;
   error: string | null;
 }
+
+interface AutoResizeTextareaProps {
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+}
+
+const AutoResizeTextarea: React.FC<AutoResizeTextareaProps> = ({
+  value,
+  onChange,
+  className = '',
+}) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, [value]);
+
+  return (
+    <textarea
+      ref={textareaRef}
+      className={`m-editor-textarea ${className}`.trim()}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      spellCheck={false}
+      rows={1}
+    />
+  );
+};
 
 const AssistantConfigPage: React.FC = () => {
   const { t } = useTranslation('scenes/profile');
@@ -122,6 +160,13 @@ const AssistantConfigPage: React.FC = () => {
     const fullPath = personaDocFullPath(workspacePath, file);
     try {
       await workspaceAPI.writeFileContent(workspacePath, fullPath, content);
+      if (
+        personaPendingRef.current?.file === file &&
+        personaPendingRef.current?.content === content
+      ) {
+        personaPendingRef.current = null;
+      }
+      setPersonaDoc((prev) => prev?.fileName === file ? { ...prev, originalContent: content } : prev);
       if (file === 'IDENTITY.md') {
         await reloadIdentityDocument();
       }
@@ -141,7 +186,7 @@ const AssistantConfigPage: React.FC = () => {
       return;
     }
 
-    setPersonaDoc({ fileName, content: '', loading: true, error: null });
+    setPersonaDoc({ fileName, originalContent: '', content: '', loading: true, error: null });
     setRightView('personaDoc');
     personaPendingRef.current = null;
 
@@ -149,16 +194,32 @@ const AssistantConfigPage: React.FC = () => {
     const fullPath = personaDocFullPath(workspacePath, fileName);
     workspaceAPI.readFileContent(fullPath)
       .then((content) => {
-        setPersonaDoc((prev) => prev?.fileName === fileName ? { ...prev, content, loading: false } : prev);
-        personaPendingRef.current = { file: fileName, content };
+        setPersonaDoc((prev) => prev?.fileName === fileName ? {
+          ...prev,
+          originalContent: content,
+          content,
+          loading: false,
+        } : prev);
+        personaPendingRef.current = null;
       })
       .catch((err) => {
         if (isFileMissingError(err)) {
-          setPersonaDoc((prev) => prev?.fileName === fileName ? { ...prev, content: '', loading: false } : prev);
-          personaPendingRef.current = { file: fileName, content: '' };
+          setPersonaDoc((prev) => prev?.fileName === fileName ? {
+            ...prev,
+            originalContent: '',
+            content: '',
+            loading: false,
+          } : prev);
+          personaPendingRef.current = null;
         } else {
           setPersonaDoc((prev) => prev?.fileName === fileName
-            ? { ...prev, content: '', loading: false, error: err instanceof Error ? err.message : String(err) }
+            ? {
+              ...prev,
+              originalContent: '',
+              content: '',
+              loading: false,
+              error: err instanceof Error ? err.message : String(err),
+            }
             : prev);
         }
       });
@@ -166,7 +227,10 @@ const AssistantConfigPage: React.FC = () => {
 
   const handlePersonaDocChange = useCallback((value: string) => {
     if (!personaDoc) return;
-    const { fileName } = personaDoc;
+    const { fileName, content: previousContent } = personaDoc;
+    if (value === previousContent) {
+      return;
+    }
     setPersonaDoc((prev) => prev ? { ...prev, content: value } : prev);
     personaPendingRef.current = { file: fileName, content: value };
     if (personaSaveTimerRef.current) {
@@ -180,8 +244,42 @@ const AssistantConfigPage: React.FC = () => {
     }, 600);
   }, [personaDoc, workspacePath, flushPersonaWrite]);
 
+  const personaDocSections = useMemo(
+    () => (personaDoc ? splitMarkdownFrontmatter(personaDoc.content) : null),
+    [personaDoc]
+  );
+
+  const handlePersonaDocFrontmatterChange = useCallback((frontmatter: string) => {
+    if (!personaDocSections?.hasFrontmatter) {
+      return;
+    }
+
+    handlePersonaDocChange(joinMarkdownFrontmatter(frontmatter, personaDocSections.body, {
+      preserveFrontmatterBlock: true,
+    }));
+  }, [handlePersonaDocChange, personaDocSections]);
+
+  const handlePersonaDocBodyChange = useCallback((body: string) => {
+    if (!personaDocSections) {
+      return;
+    }
+
+    if (personaDocSections.hasFrontmatter) {
+      handlePersonaDocChange(joinMarkdownFrontmatter(personaDocSections.frontmatter, body, {
+        preserveFrontmatterBlock: true,
+      }));
+      return;
+    }
+
+    handlePersonaDocChange(body);
+  }, [handlePersonaDocChange, personaDocSections]);
+
   const closePersonaDoc = useCallback(() => {
-    if (personaDoc && personaPendingRef.current) {
+    if (
+      personaDoc &&
+      personaPendingRef.current &&
+      personaPendingRef.current.content !== personaDoc.originalContent
+    ) {
       const { file, content } = personaPendingRef.current;
       void flushPersonaWriteRef.current(file, content);
     }
@@ -309,6 +407,10 @@ const AssistantConfigPage: React.FC = () => {
     if (!personaDoc) return null;
     const { fileName, content, loading, error } = personaDoc;
     const docLabelKey = fileName.replace(/\.md$/i, '') as 'SOUL' | 'USER' | 'IDENTITY';
+    const sections = personaDocSections ?? splitMarkdownFrontmatter(content);
+    const bodyEditability = analyzeMarkdownEditability(sections.body);
+    const usesHybridEditor = sections.hasFrontmatter;
+    const usesSourceBodyEditor = bodyEditability.mode === 'unsafe';
     return (
       <div className="acp-right-info">
         <div className="acp-right-shell acp-right-shell--editor">
@@ -341,17 +443,55 @@ const AssistantConfigPage: React.FC = () => {
               {error && <p className="acp-persona-editor__error">{t('nursery.assistant.personaDocLoadFailed')}: {error}</p>}
               {loading ? (
                 <div className="acp-loading"><RefreshCw size={14} className="nursery-spinning" /></div>
-              ) : (
-                <MEditor
+              ) : usesHybridEditor ? (
+                <div className="acp-persona-editor__hybrid">
+                  <section className="acp-persona-editor__frontmatter">
+                    <AutoResizeTextarea
+                      key={`${fileName}-frontmatter`}
+                      value={sections.frontmatter}
+                      onChange={handlePersonaDocFrontmatterChange}
+                      className="acp-persona-editor__frontmatter-textarea"
+                    />
+                  </section>
+                  <div className="acp-persona-editor__divider" aria-hidden="true" />
+                  <section className="acp-persona-editor__body-editor">
+                      {usesSourceBodyEditor ? (
+                        <EditArea
+                          key={`${fileName}-body-source`}
+                          value={sections.body}
+                          onChange={handlePersonaDocBodyChange}
+                        />
+                      ) : (
+                        <MEditor
+                          key={`${fileName}-body`}
+                          value={sections.body}
+                          onChange={handlePersonaDocBodyChange}
+                          theme={isLight ? 'light' : 'dark'}
+                          toolbar={false}
+                          mode="ir"
+                          height="100%"
+                          className="acp-persona-editor__meditor"
+                        />
+                      )}
+                  </section>
+                </div>
+              ) : usesSourceBodyEditor ? (
+                <EditArea
                   key={fileName}
                   value={content}
                   onChange={handlePersonaDocChange}
-                  theme={isLight ? 'light' : 'dark'}
-                  toolbar={false}
-                  mode="ir"
-                  height="100%"
-                  className="acp-persona-editor__meditor"
                 />
+              ) : (
+                  <MEditor
+                    key={fileName}
+                    value={content}
+                    onChange={handlePersonaDocBodyChange}
+                    theme={isLight ? 'light' : 'dark'}
+                    toolbar={false}
+                    mode="ir"
+                    height="100%"
+                    className="acp-persona-editor__meditor"
+                  />
               )}
             </div>
           </div>

--- a/src/web-ui/src/app/scenes/profile/views/NurseryView.scss
+++ b/src/web-ui/src/app/scenes/profile/views/NurseryView.scss
@@ -3405,6 +3405,51 @@ $acp-content-top: clamp(40px, 4.5vh, 52px);
       background: transparent;
     }
   }
+
+  &__hybrid {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: $size-gap-3;
+  }
+
+  &__frontmatter {
+    flex: 0 0 auto;
+    min-height: 0;
+  }
+
+  &__frontmatter-textarea {
+    width: 100%;
+    min-height: 0;
+    height: auto;
+    padding: 0;
+    overflow: hidden;
+    resize: none;
+    font-size: var(--font-size-xs);
+    line-height: $line-height-relaxed;
+  }
+
+  &__divider {
+    flex: 0 0 auto;
+    height: 1px;
+    background: var(--border-subtle);
+  }
+
+  &__body-editor {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    
+    .m-editor,
+    .m-editor > div,
+    .m-editor-textarea {
+      flex: 1;
+      min-height: 0;
+    }
+  }
 }
 
 // ── Responsive ────────────────────────────────────────────────────────────────

--- a/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.test.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.test.ts
@@ -126,9 +126,10 @@ describe('tiptap markdown compatibility', () => {
   it('treats frontmatter as unsafe for the IR editor', () => {
     const markdown = [
       '---',
-      'title: Demo',
-      'tags:',
-      '  - test',
+      'name: Demo',
+      'creature: Cat',
+      'vibe: Calm',
+      'emoji: 🙂',
       '---',
       '',
       '# Body',
@@ -138,6 +139,9 @@ describe('tiptap markdown compatibility', () => {
 
     expect(analysis.mode).toBe('unsafe');
     expect(analysis.hardIssues).toContain('frontmatter');
+    expect(analysis.hardIssues).toContain('semanticMismatch');
+    expect(analysis.softIssues).toContain('roundTripMismatch');
+    expect(analysis.canonicalMarkdown).toContain('## name: Demo');
   });
 
   it('upgrades simple details regions into structured details nodes', () => {


### PR DESCRIPTION
## Summary

This fixes the assistant persona document editor corrupting `IDENTITY.md` frontmatter when the file was opened and closed from the profile scene.

The editor now uses a hybrid layout for frontmatter-based persona docs:
- YAML frontmatter is edited as source text
- Markdown body is edited separately with markdown-friendly editing when safe
- unsafe markdown content falls back to source editing
- save/close behavior only flushes real content changes

Closes #1249

## What changed

- Added frontmatter split/join helpers for persona docs
- Switched persona doc editing in the profile scene to a hybrid frontmatter/body flow
- Prevented YAML frontmatter from entering the IR markdown pipeline
- Refined the hybrid editor layout to feel like one continuous document
- Added regression tests for frontmatter parsing/serialization and unsafe markdown handling

## Verification

- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/app/scenes/my-agent/identityDocument.test.ts src/tools/editor/meditor/utils/tiptapMarkdown.test.ts`
- `pnpm run i18n:audit`

## Notes

This is a scene-level fix for assistant persona documents. It preserves user-friendly markdown editing for the body while keeping YAML frontmatter safe from markdown canonicalization.