### PR TITLE
fix(agentic): stop background injections from interrupting tool execution

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -28,6 +28,7 @@ use bitfun_agent_tools::{
     ToolExecutionAdmissionRejection, ToolExecutionAdmissionRequest, GET_TOOL_SPEC_TOOL_NAME,
     USER_STEERING_INTERRUPTED_MESSAGE,
 };
+use bitfun_runtime_ports::RoundInjectionToolPreemption;
 use futures::future::join_all;
 use log::{debug, error, info, warn};
 use std::sync::Arc;
@@ -209,6 +210,9 @@ fn build_user_steering_interrupted_result(
     }
 }
 
+const ROUND_INJECTION_RUNNING_TOOL_CANCELLED_MESSAGE: &str =
+    "Tool execution cancelled because a pending round injection requested running-tool preemption for this turn.";
+
 fn should_retry_tool_error(error: &BitFunError) -> bool {
     matches!(
         error,
@@ -245,6 +249,7 @@ fn map_tool_execution_admission_rejection(error: ToolExecutionAdmissionRejection
 const SUBAGENT_LAUNCH_TOOL_NAME: &str = "Task";
 
 /// Tool pipeline
+#[derive(Clone)]
 pub struct ToolPipeline {
     tool_registry: Arc<TokioRwLock<ToolRegistry>>,
     state_manager: Arc<ToolStateManager>,
@@ -272,12 +277,20 @@ impl ToolPipeline {
         self.computer_use_host.clone()
     }
 
-    fn should_interrupt_for_steering(&self, context: &ToolExecutionContext) -> bool {
+    fn pending_round_injection_tool_preemption(
+        &self,
+        context: &ToolExecutionContext,
+    ) -> RoundInjectionToolPreemption {
         context
             .steering_interrupt
             .as_ref()
-            .map(|interrupt| interrupt.should_interrupt())
-            .unwrap_or(false)
+            .map(|interrupt| interrupt.pending_tool_preemption())
+            .unwrap_or(RoundInjectionToolPreemption::None)
+    }
+
+    fn should_interrupt_for_round_injection(&self, context: &ToolExecutionContext) -> bool {
+        self.pending_round_injection_tool_preemption(context)
+            .should_interrupt_after_current_atomic_unit()
     }
 
     async fn build_steering_interrupted_results(
@@ -303,6 +316,65 @@ impl ToolPipeline {
             results.push(build_user_steering_interrupted_result(&task_id, task));
         }
         results
+    }
+
+    fn append_execution_result(
+        &self,
+        task_id: &str,
+        result: BitFunResult<ToolExecutionResult>,
+        all_results: &mut Vec<ToolExecutionResult>,
+    ) {
+        match result {
+            Ok(execution_result) => all_results.push(execution_result),
+            Err(error) => {
+                error!("Tool execution failed: error={}", error);
+                let error_result = build_error_execution_result(
+                    task_id,
+                    self.state_manager.get_task(task_id),
+                    &error,
+                );
+                all_results.push(error_result);
+            }
+        }
+    }
+
+    async fn cancel_tools_for_round_injection(
+        &self,
+        task_ids: impl IntoIterator<Item = String>,
+    ) -> BitFunResult<()> {
+        for task_id in task_ids {
+            self.cancel_tool(
+                &task_id,
+                ROUND_INJECTION_RUNNING_TOOL_CANCELLED_MESSAGE.to_string(),
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    fn spawn_round_injection_cancellation_watch(
+        &self,
+        task_ids: Vec<String>,
+        interrupt: Option<crate::agentic::round_preempt::DialogRoundInjectionInterrupt>,
+    ) -> Option<tokio::task::JoinHandle<()>> {
+        if interrupt.is_none() {
+            return None;
+        }
+
+        let pipeline = self.clone();
+        Some(tokio::spawn(async move {
+            let Some(interrupt) = interrupt else {
+                return;
+            };
+
+            loop {
+                if interrupt.should_cancel_running_tools() {
+                    let _ = pipeline.cancel_tools_for_round_injection(task_ids).await;
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        }))
     }
 
     /// Execute multiple tool calls using partitioned mixed scheduling.
@@ -399,7 +471,7 @@ impl ToolPipeline {
                 .map(|task| task.context);
             if batch_context
                 .as_ref()
-                .is_some_and(|context| self.should_interrupt_for_steering(context))
+                .is_some_and(|context| self.should_interrupt_for_round_injection(context))
             {
                 let remaining_task_ids = batch
                     .task_ids
@@ -434,29 +506,29 @@ impl ToolPipeline {
         &self,
         task_ids: Vec<String>,
     ) -> BitFunResult<Vec<ToolExecutionResult>> {
+        let batch_interrupt = task_ids
+            .first()
+            .and_then(|task_id| self.state_manager.get_task(task_id))
+            .and_then(|task| task.context.steering_interrupt.clone());
+        let watch_handle =
+            self.spawn_round_injection_cancellation_watch(task_ids.clone(), batch_interrupt);
+
         let futures: Vec<_> = task_ids
             .iter()
             .map(|id| self.execute_single_tool(id.clone()))
             .collect();
 
         let results = join_all(futures).await;
+        if let Some(handle) = watch_handle {
+            handle.abort();
+            let _ = handle.await;
+        }
 
         // Collect results, including failed results
         let mut all_results = Vec::new();
         for (idx, result) in results.into_iter().enumerate() {
-            match result {
-                Ok(r) => all_results.push(r),
-                Err(e) => {
-                    error!("Tool execution failed: error={}", e);
-                    let task_id = &task_ids[idx];
-                    let error_result = build_error_execution_result(
-                        task_id,
-                        self.state_manager.get_task(task_id),
-                        &e,
-                    );
-                    all_results.push(error_result);
-                }
-            }
+            let task_id = &task_ids[idx];
+            self.append_execution_result(task_id, result, &mut all_results);
         }
 
         Ok(all_results)
@@ -474,7 +546,7 @@ impl ToolPipeline {
             let task = self.state_manager.get_task(&task_id);
             if task
                 .as_ref()
-                .is_some_and(|task| self.should_interrupt_for_steering(&task.context))
+                .is_some_and(|task| self.should_interrupt_for_round_injection(&task.context))
             {
                 let remaining_task_ids = std::iter::once(task_id).chain(task_iter);
                 results.extend(
@@ -484,18 +556,15 @@ impl ToolPipeline {
                 break;
             }
 
-            match self.execute_single_tool(task_id.clone()).await {
-                Ok(result) => results.push(result),
-                Err(e) => {
-                    error!("Tool execution failed: error={}", e);
-                    let error_result = build_error_execution_result(
-                        &task_id,
-                        self.state_manager.get_task(&task_id),
-                        &e,
-                    );
-                    results.push(error_result);
-                }
+            let interrupt = task.and_then(|task| task.context.steering_interrupt.clone());
+            let watch_handle =
+                self.spawn_round_injection_cancellation_watch(vec![task_id.clone()], interrupt);
+            let result = self.execute_single_tool(task_id.clone()).await;
+            if let Some(handle) = watch_handle {
+                handle.abort();
+                let _ = handle.await;
             }
+            self.append_execution_result(&task_id, result, &mut results);
         }
 
         Ok(results)
@@ -1265,11 +1334,82 @@ mod tests {
     use super::*;
     use crate::agentic::core::ToolExecutionState;
     use crate::agentic::events::{EventQueue, EventQueueConfig};
-    use crate::agentic::tools::framework::Tool;
+    use crate::agentic::round_preempt::{
+        DialogRoundInjectionInterrupt, SessionRoundInjectionBuffer,
+    };
+    use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext, ValidationResult};
     use crate::agentic::tools::implementations::task_tool::TaskTool;
     use crate::agentic::tools::ToolRuntimeRestrictions;
+    use async_trait::async_trait;
+    use bitfun_runtime_ports::{
+        RoundInjection, RoundInjectionExecutionPolicy, RoundInjectionKind, RoundInjectionTarget,
+        RoundInjectionToolPreemption,
+    };
     use serde_json::json;
     use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::SystemTime;
+    use tokio::time::{sleep, Duration};
+
+    struct StaticTestTool {
+        name: String,
+        response: serde_json::Value,
+        delay_ms: u64,
+    }
+
+    #[async_trait]
+    impl Tool for StaticTestTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        async fn description(&self) -> BitFunResult<String> {
+            Ok("static test tool".to_string())
+        }
+
+        fn short_description(&self) -> String {
+            "static test tool".to_string()
+        }
+
+        fn is_readonly(&self) -> bool {
+            true
+        }
+
+        fn input_schema(&self) -> serde_json::Value {
+            json!({ "type": "object" })
+        }
+
+        async fn validate_input(
+            &self,
+            _input: &serde_json::Value,
+            _context: Option<&ToolUseContext>,
+        ) -> ValidationResult {
+            ValidationResult {
+                result: true,
+                message: None,
+                error_code: None,
+                meta: None,
+            }
+        }
+
+        async fn call_impl(
+            &self,
+            _input: &serde_json::Value,
+            _context: &ToolUseContext,
+        ) -> BitFunResult<Vec<ToolResult>> {
+            if self.delay_ms > 0 {
+                sleep(Duration::from_millis(self.delay_ms)).await;
+            }
+            Ok(vec![ToolResult::Result {
+                data: self.response.clone(),
+                result_for_assistant: Some(render_tool_result_for_assistant(
+                    &self.name,
+                    &self.response,
+                )),
+                image_attachments: None,
+            }])
+        }
+    }
 
     fn test_tool_pipeline() -> ToolPipeline {
         let registry = Arc::new(TokioRwLock::new(ToolRegistry::new()));
@@ -1316,6 +1456,38 @@ mod tests {
             test_tool_execution_context(),
             ToolExecutionOptions::default(),
         )
+    }
+
+    async fn register_static_test_tool(
+        pipeline: &ToolPipeline,
+        name: &str,
+        response: serde_json::Value,
+        delay_ms: u64,
+    ) {
+        pipeline
+            .tool_registry
+            .write()
+            .await
+            .register_tool(Arc::new(StaticTestTool {
+                name: name.to_string(),
+                response,
+                delay_ms,
+            }));
+    }
+
+    fn test_round_injection(
+        kind: RoundInjectionKind,
+        tool_preemption: RoundInjectionToolPreemption,
+    ) -> RoundInjection {
+        RoundInjection {
+            id: format!("injection-{:?}-{:?}", kind, tool_preemption),
+            kind,
+            execution_policy: RoundInjectionExecutionPolicy::new(tool_preemption),
+            target: RoundInjectionTarget::CurrentRunningTurn,
+            content: "test injection".to_string(),
+            display_content: "test injection".to_string(),
+            created_at: SystemTime::now(),
+        }
     }
 
     fn assert_failed_task_contains(pipeline: &ToolPipeline, tool_id: &str, expected: &str) {
@@ -1457,6 +1629,124 @@ mod tests {
             "tool_1",
             "Call GetToolSpec first with {\"tool_name\":\"WebFetch\"}",
         );
+    }
+
+    #[tokio::test]
+    async fn background_result_pending_does_not_skip_tool_execution() {
+        let pipeline = test_tool_pipeline();
+        register_static_test_tool(&pipeline, "Read", json!({ "ok": true }), 0).await;
+
+        let buffer = Arc::new(SessionRoundInjectionBuffer::default());
+        buffer.push(
+            "session_1",
+            test_round_injection(
+                RoundInjectionKind::BackgroundResult,
+                RoundInjectionKind::BackgroundResult
+                    .default_execution_policy()
+                    .tool_preemption,
+            ),
+        );
+
+        let mut context = test_tool_execution_context();
+        context.steering_interrupt = Some(DialogRoundInjectionInterrupt::new(
+            "session_1".to_string(),
+            "turn_1".to_string(),
+            buffer,
+        ));
+
+        let results = pipeline
+            .execute_tools(
+                vec![test_tool_call("tool_1", "Read")],
+                context,
+                ToolExecutionOptions::default(),
+            )
+            .await
+            .expect("background result should not skip tool execution");
+
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].result.is_error);
+        assert_eq!(results[0].result.result["ok"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn user_steering_pending_still_skips_remaining_tool_plan() {
+        let pipeline = test_tool_pipeline();
+        let buffer = Arc::new(SessionRoundInjectionBuffer::default());
+        buffer.push(
+            "session_1",
+            test_round_injection(
+                RoundInjectionKind::UserSteering,
+                RoundInjectionKind::UserSteering
+                    .default_execution_policy()
+                    .tool_preemption,
+            ),
+        );
+
+        let mut context = test_tool_execution_context();
+        context.steering_interrupt = Some(DialogRoundInjectionInterrupt::new(
+            "session_1".to_string(),
+            "turn_1".to_string(),
+            buffer,
+        ));
+
+        let results = pipeline
+            .execute_tools(
+                vec![
+                    test_tool_call("tool_1", "Read"),
+                    test_tool_call("tool_2", "Write"),
+                ],
+                context,
+                ToolExecutionOptions::default(),
+            )
+            .await
+            .expect("user steering skip should be surfaced as tool results");
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].result.result["category"],
+            json!("user_steering_interrupted")
+        );
+        assert_eq!(
+            results[1].result.result["category"],
+            json!("user_steering_interrupted")
+        );
+    }
+
+    #[tokio::test]
+    async fn custom_round_injection_can_cancel_running_tool_cooperatively() {
+        let pipeline = test_tool_pipeline();
+        register_static_test_tool(&pipeline, "Read", json!({ "ok": true }), 30_000).await;
+
+        let buffer = Arc::new(SessionRoundInjectionBuffer::default());
+        let buffer_for_injection = buffer.clone();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(50)).await;
+            buffer_for_injection.push(
+                "session_1",
+                test_round_injection(
+                    RoundInjectionKind::UserSteering,
+                    RoundInjectionToolPreemption::CancelRunningCooperatively,
+                ),
+            );
+        });
+
+        let mut context = test_tool_execution_context();
+        context.steering_interrupt = Some(DialogRoundInjectionInterrupt::new(
+            "session_1".to_string(),
+            "turn_1".to_string(),
+            buffer,
+        ));
+        let mut options = ToolExecutionOptions::default();
+        options.allow_parallel = false;
+
+        let results = pipeline
+            .execute_tools(vec![test_tool_call("tool_1", "Read")], context, options)
+            .await
+            .expect("cooperative cancel should still return a tool result");
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].result.is_error);
+        assert_eq!(results[0].result.result["category"], json!("cancelled"));
     }
 
     #[test]

--- a/src/crates/contracts/runtime-ports/src/lib.rs
+++ b/src/crates/contracts/runtime-ports/src/lib.rs
@@ -862,6 +862,57 @@ pub enum RoundInjectionKind {
     ThreadGoalObjectiveUpdated,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RoundInjectionToolPreemption {
+    None,
+    InterruptAfterCurrentAtomicUnit,
+    CancelRunningCooperatively,
+    CancelRunningForcefully,
+}
+
+impl RoundInjectionToolPreemption {
+    pub const fn should_interrupt_after_current_atomic_unit(self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    pub const fn should_cancel_running_tools(self) -> bool {
+        matches!(
+            self,
+            Self::CancelRunningCooperatively | Self::CancelRunningForcefully
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RoundInjectionExecutionPolicy {
+    pub tool_preemption: RoundInjectionToolPreemption,
+}
+
+impl RoundInjectionExecutionPolicy {
+    pub const fn new(tool_preemption: RoundInjectionToolPreemption) -> Self {
+        Self { tool_preemption }
+    }
+}
+
+impl Default for RoundInjectionExecutionPolicy {
+    fn default() -> Self {
+        Self::new(RoundInjectionToolPreemption::None)
+    }
+}
+
+impl RoundInjectionKind {
+    pub const fn default_execution_policy(self) -> RoundInjectionExecutionPolicy {
+        match self {
+            Self::UserSteering => RoundInjectionExecutionPolicy::new(
+                RoundInjectionToolPreemption::InterruptAfterCurrentAtomicUnit,
+            ),
+            Self::BackgroundResult | Self::ThreadGoalObjectiveUpdated => {
+                RoundInjectionExecutionPolicy::new(RoundInjectionToolPreemption::None)
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RoundInjectionTarget {
     /// Only inject into the exact targeted running turn.
@@ -876,6 +927,7 @@ pub enum RoundInjectionTarget {
 pub struct RoundInjection {
     pub id: String,
     pub kind: RoundInjectionKind,
+    pub execution_policy: RoundInjectionExecutionPolicy,
     pub target: RoundInjectionTarget,
     pub content: String,
     pub display_content: String,
@@ -885,6 +937,11 @@ pub struct RoundInjection {
 /// Observes round-boundary injections for a given running turn.
 pub trait DialogRoundInjectionSource: Send + Sync {
     fn has_pending(&self, session_id: &str, turn_id: &str) -> bool;
+    fn pending_tool_preemption(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+    ) -> RoundInjectionToolPreemption;
     fn take_pending(&self, session_id: &str, turn_id: &str) -> Vec<RoundInjection>;
 }
 
@@ -1642,6 +1699,18 @@ mod tests {
             RoundInjectionTarget::ExactTurn("turn_1".to_string())
         );
         assert_ne!(target, RoundInjectionTarget::CurrentRunningTurn);
+        assert_eq!(
+            RoundInjectionKind::UserSteering
+                .default_execution_policy()
+                .tool_preemption,
+            RoundInjectionToolPreemption::InterruptAfterCurrentAtomicUnit
+        );
+        assert_eq!(
+            RoundInjectionKind::BackgroundResult
+                .default_execution_policy()
+                .tool_preemption,
+            RoundInjectionToolPreemption::None
+        );
     }
 
     #[test]
@@ -1653,6 +1722,18 @@ mod tests {
         impl DialogRoundInjectionSource for StaticInjectionSource {
             fn has_pending(&self, session_id: &str, turn_id: &str) -> bool {
                 session_id == "session_1" && turn_id == "turn_1"
+            }
+
+            fn pending_tool_preemption(
+                &self,
+                session_id: &str,
+                turn_id: &str,
+            ) -> RoundInjectionToolPreemption {
+                if self.has_pending(session_id, turn_id) {
+                    self.injection.execution_policy.tool_preemption
+                } else {
+                    RoundInjectionToolPreemption::None
+                }
             }
 
             fn take_pending(&self, session_id: &str, turn_id: &str) -> Vec<RoundInjection> {
@@ -1668,6 +1749,7 @@ mod tests {
             injection: RoundInjection {
                 id: "injection_1".to_string(),
                 kind: RoundInjectionKind::BackgroundResult,
+                execution_policy: RoundInjectionKind::BackgroundResult.default_execution_policy(),
                 target: RoundInjectionTarget::CurrentRunningTurn,
                 content: "result".to_string(),
                 display_content: "result".to_string(),
@@ -1677,6 +1759,10 @@ mod tests {
 
         assert!(source.has_pending("session_1", "turn_1"));
         assert!(!source.has_pending("session_2", "turn_1"));
+        assert_eq!(
+            source.pending_tool_preemption("session_1", "turn_1"),
+            RoundInjectionToolPreemption::None
+        );
         let drained = source.take_pending("session_1", "turn_1");
         assert_eq!(drained.len(), 1);
         assert_eq!(drained[0].id, "injection_1");

--- a/src/crates/execution/agent-runtime/src/scheduler.rs
+++ b/src/crates/execution/agent-runtime/src/scheduler.rs
@@ -6,7 +6,8 @@ use bitfun_runtime_ports::{
     should_skip_agent_session_reply, should_suppress_agent_session_cancelled_reply,
     AgentSessionReplyRoute, DialogQueuePriority, DialogRoundInjectionSource,
     DialogSessionStateFact, DialogSteerOutcome, DialogSubmissionPolicy, DialogTriggerSource,
-    RoundInjection, RoundInjectionKind, RoundInjectionTarget, ThreadGoal,
+    RoundInjection, RoundInjectionKind, RoundInjectionTarget, RoundInjectionToolPreemption,
+    ThreadGoal,
 };
 use std::collections::VecDeque;
 use std::fmt;
@@ -434,6 +435,14 @@ impl DialogRoundInjectionSource for NoopDialogRoundInjectionSource {
         false
     }
 
+    fn pending_tool_preemption(
+        &self,
+        _session_id: &str,
+        _turn_id: &str,
+    ) -> RoundInjectionToolPreemption {
+        RoundInjectionToolPreemption::None
+    }
+
     fn take_pending(&self, _session_id: &str, _turn_id: &str) -> Vec<RoundInjection> {
         Vec::new()
     }
@@ -468,8 +477,22 @@ impl DialogRoundInjectionInterrupt {
         }
     }
 
+    pub fn pending_tool_preemption(&self) -> RoundInjectionToolPreemption {
+        self.source
+            .pending_tool_preemption(&self.session_id, &self.turn_id)
+    }
+
+    pub fn should_interrupt_after_current_atomic_unit(&self) -> bool {
+        self.pending_tool_preemption()
+            .should_interrupt_after_current_atomic_unit()
+    }
+
+    pub fn should_cancel_running_tools(&self) -> bool {
+        self.pending_tool_preemption().should_cancel_running_tools()
+    }
+
     pub fn should_interrupt(&self) -> bool {
-        self.source.has_pending(&self.session_id, &self.turn_id)
+        self.should_interrupt_after_current_atomic_unit()
     }
 }
 
@@ -521,6 +544,29 @@ impl SessionRoundInjectionBuffer {
             .unwrap_or(false)
     }
 
+    pub fn pending_tool_preemption_for_turn(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+    ) -> RoundInjectionToolPreemption {
+        self.inner
+            .get(session_id)
+            .map(|entry| {
+                entry
+                    .iter()
+                    .filter(|msg| match &msg.target {
+                        RoundInjectionTarget::ExactTurn(target_turn_id) => {
+                            target_turn_id == turn_id
+                        }
+                        RoundInjectionTarget::CurrentRunningTurn => true,
+                    })
+                    .map(|msg| msg.execution_policy.tool_preemption)
+                    .max()
+                    .unwrap_or(RoundInjectionToolPreemption::None)
+            })
+            .unwrap_or(RoundInjectionToolPreemption::None)
+    }
+
     /// Drop all messages for a session (e.g. session deleted or unrecoverable error).
     pub fn clear(&self, session_id: &str) {
         self.inner.remove(session_id);
@@ -534,6 +580,14 @@ impl SessionRoundInjectionBuffer {
 impl DialogRoundInjectionSource for SessionRoundInjectionBuffer {
     fn has_pending(&self, session_id: &str, turn_id: &str) -> bool {
         self.has_pending_for_turn(session_id, turn_id)
+    }
+
+    fn pending_tool_preemption(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+    ) -> RoundInjectionToolPreemption {
+        self.pending_tool_preemption_for_turn(session_id, turn_id)
     }
 
     fn take_pending(&self, session_id: &str, turn_id: &str) -> Vec<RoundInjection> {
@@ -566,14 +620,16 @@ pub fn resolve_background_delivery_injection(
     created_at: SystemTime,
 ) -> RoundInjection {
     let display_content = display_content.unwrap_or_else(|| content.clone());
+    let kind = match kind {
+        BackgroundInjectionKind::ThreadGoalObjectiveUpdated => {
+            RoundInjectionKind::ThreadGoalObjectiveUpdated
+        }
+        BackgroundInjectionKind::BackgroundResult => RoundInjectionKind::BackgroundResult,
+    };
     RoundInjection {
         id: injection_id,
-        kind: match kind {
-            BackgroundInjectionKind::ThreadGoalObjectiveUpdated => {
-                RoundInjectionKind::ThreadGoalObjectiveUpdated
-            }
-            BackgroundInjectionKind::BackgroundResult => RoundInjectionKind::BackgroundResult,
-        },
+        kind,
+        execution_policy: kind.default_execution_policy(),
         target: RoundInjectionTarget::CurrentRunningTurn,
         content,
         display_content,
@@ -804,6 +860,7 @@ pub fn resolve_dialog_steering_action(
         injection: RoundInjection {
             id: steering_id.clone(),
             kind: RoundInjectionKind::UserSteering,
+            execution_policy: RoundInjectionKind::UserSteering.default_execution_policy(),
             target: RoundInjectionTarget::ExactTurn(turn_id.to_string()),
             content,
             display_content: display,

--- a/src/crates/execution/agent-runtime/tests/scheduler_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/scheduler_contracts.rs
@@ -13,7 +13,7 @@ use bitfun_agent_runtime::scheduler::{
 use bitfun_runtime_ports::{
     AgentSessionReplyRoute, DialogQueuePriority, DialogSessionStateFact, DialogSteerOutcome,
     DialogSubmissionPolicy, DialogTriggerSource, RoundInjection, RoundInjectionKind,
-    RoundInjectionTarget, ThreadGoal, ThreadGoalStatus,
+    RoundInjectionTarget, RoundInjectionToolPreemption, ThreadGoal, ThreadGoalStatus,
 };
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -91,6 +91,10 @@ fn background_delivery_injection_builds_thread_goal_current_turn_message() {
     assert_eq!(injection.content, "prompt");
     assert_eq!(injection.display_content, "display");
     assert_eq!(injection.created_at, created_at);
+    assert_eq!(
+        injection.execution_policy.tool_preemption,
+        RoundInjectionToolPreemption::None
+    );
 }
 
 #[test]
@@ -111,6 +115,10 @@ fn background_delivery_injection_builds_background_result_with_display_fallback(
     assert_eq!(injection.content, "result content");
     assert_eq!(injection.display_content, "result content");
     assert_eq!(injection.created_at, created_at);
+    assert_eq!(
+        injection.execution_policy.tool_preemption,
+        RoundInjectionToolPreemption::None
+    );
 }
 
 fn thread_goal() -> ThreadGoal {
@@ -465,6 +473,10 @@ fn dialog_steering_action_buffers_exact_running_turn_with_display_fallback() {
     assert_eq!(injection.display_content, "steer content");
     assert_eq!(injection.created_at, created_at);
     assert_eq!(
+        injection.execution_policy.tool_preemption,
+        RoundInjectionToolPreemption::InterruptAfterCurrentAtomicUnit
+    );
+    assert_eq!(
         outcome,
         DialogSteerOutcome::Buffered {
             session_id: "session-1".to_string(),
@@ -544,6 +556,11 @@ fn round_injection_buffer_drains_only_messages_for_the_active_turn() {
     let interrupt =
         DialogRoundInjectionInterrupt::new("s1".to_string(), "turn-a".to_string(), buffer.clone());
     assert!(interrupt.should_interrupt());
+    assert!(!interrupt.should_cancel_running_tools());
+    assert_eq!(
+        interrupt.pending_tool_preemption(),
+        RoundInjectionToolPreemption::InterruptAfterCurrentAtomicUnit
+    );
 
     let drained = buffer.drain_for_turn("s1", "turn-a");
     assert_eq!(drained.len(), 2);
@@ -561,6 +578,7 @@ fn exact_turn_msg(turn_id: &str, content: &str) -> RoundInjection {
     RoundInjection {
         id: format!("id-{turn_id}-{content}"),
         kind: RoundInjectionKind::UserSteering,
+        execution_policy: RoundInjectionKind::UserSteering.default_execution_policy(),
         target: RoundInjectionTarget::ExactTurn(turn_id.to_string()),
         content: content.to_string(),
         display_content: content.to_string(),
@@ -572,6 +590,7 @@ fn current_turn_msg(content: &str) -> RoundInjection {
     RoundInjection {
         id: format!("id-current-{content}"),
         kind: RoundInjectionKind::BackgroundResult,
+        execution_policy: RoundInjectionKind::BackgroundResult.default_execution_policy(),
         target: RoundInjectionTarget::CurrentRunningTurn,
         content: content.to_string(),
         display_content: content.to_string(),


### PR DESCRIPTION
## Summary

Make round-injection preemption explicit and stop background injections from interrupting tool execution.

- add an execution policy to `RoundInjection` and map default behavior by injection kind
- keep `BackgroundResult` and `ThreadGoalObjectiveUpdated` non-preempting
- keep `UserSteering` on its current "interrupt after current atomic unit" behavior
- add tool-pipeline support for future running-tool cancellation policies without enabling that behavior for any current injection kind

Fixes #

## Type and Areas

Type:

bug fix / refactor

Areas:

Rust core, agent runtime, assembly tool pipeline

## Motivation / Impact

This fixes the current behavior where a background subagent result can be steered back into a busy parent session and unconditionally interrupt the parent turn's tool execution.

After this change:

- background round injections no longer skip pending tool work
- user steering keeps its current behavior
- the runtime can distinguish "interrupt remaining plan" from "cancel already-running tools"
- cooperative running-tool cancellation is now wired end-to-end for future use, but no current injection kind opts into it yet

There is no API migration required for callers beyond the internal `RoundInjection` shape update.

## Verification

Passed:

- `pnpm run fmt:rs`
- `cargo test -p bitfun-runtime-ports`
- `cargo test -p bitfun-agent-runtime scheduler_contracts -- --nocapture`
- `cargo check --workspace`
- `cargo test -p bitfun-core background_result_pending_does_not_skip_tool_execution -- --nocapture`
- `cargo test -p bitfun-core user_steering_pending_still_skips_remaining_tool_plan -- --nocapture`
- `cargo test -p bitfun-core custom_round_injection_can_cancel_running_tool_cooperatively -- --nocapture`

## Reviewer Notes

Key design point: round-injection source (`kind`) is now separated from round-injection execution effect (`execution_policy.tool_preemption`).

Current defaults are intentionally conservative:

- `UserSteering` => `InterruptAfterCurrentAtomicUnit`
- `BackgroundResult` => `None`
- `ThreadGoalObjectiveUpdated` => `None`

The tool pipeline now has watcher-based plumbing to cooperatively cancel running tools if a future injection kind uses a cancellation policy, but this PR does not change any current injection kind to do that.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.