### PR TITLE
docs(readme): refresh agent core metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,182 +16,121 @@
 
 ---
 
-## What BitFun Is
+## Local AI Workbench Built Around the Code Agent
 
-**BitFun is a desktop-grade Agent runtime (Local Agent Runtime) and a ready-to-use suite of desktop Agent applications.**
+BitFun is a local AI workbench built around a Code Agent designed for long-horizon tasks, engineering execution, and token economy.
 
-- It is the **foundation**—a Rust core plus a Tauri shell, with sessions, tools, memory, MCP, LSP, and remote-control protocols built in, designed for long-running use;
+It can understand complex context, call tools, wait for results, correct deviations, and keep long-horizon tasks moving until they reach a deliverable state. Coding, research, office work, documents, desktop operations, and extensible workflows all happen in the same local desktop environment.
 
-- It is the **product**—install once and you get four official Agents out of the box: Code, Cowork, Computer Use, and Personal Assistant, covering almost every mainstream Agent capability shape in the industry today.
-
-> **One install: use it as an Agent, or use it as a Runtime.**
-
-BitFun aims to pack **the coding power of Code Agents, the office productivity of Cowork, the assistant experience of OpenClaw, the control surface of Computer Use, and more**—the most popular Agent capabilities in the industry—into one desktop app, with the full protocol stack (Agentic runtime, tools, memory, MCP, Skills, context compression, remote control) ready by default. You can use it immediately, or define **your own domain Agents** on top of it.
-
+The core goal is direct: move AI from one-off task execution into a productivity system that can work over long periods.
 
 ![readme_hero](./png/readme_hero.png)
 
+---
+
+## Agent Core Metrics
+
+The data below evaluates BitFun's core Agent capabilities. All measurements use **Deepseek-V4-Pro** and focus on task completion, KV Cache reuse, and large-repository search efficiency.
+
+BitFun leads Open Code and Claude Code on both **SWE-Bench-Pro** and **SWE-Bench-Verified**. SWE-Bench-Pro focuses on complex software engineering, while SWE-Bench-Verified focuses on human-verified GitHub issue fixes.
+
+| Benchmark | BitFun | Open Code | Claude Code |
+| --- | ---: | ---: | ---: |
+| **SWE-Bench-Pro** | **52%** | 51% | 50% |
+| **SWE-Bench-Verified** | **74%** | 72% | 69% |
+
+The current numbers are BitFun's initial evaluation results, with each case run once. We will keep optimizing and release full benchmark details later. Benchmark references: [SWE-Bench-Pro](https://labs.scale.com/leaderboard/swe_bench_pro_public) / [SWE-Bench-Verified](https://www.swebench.com/verified.html)
+
+Whether Agent execution is economical depends on whether repeated context can be reused reliably. In the same SWE-Bench-Pro evaluation round, BitFun's average KV Cache hit rate was **98.67%**. Across 728 valid cache records, **83.1%** of trials reached a hit rate of at least 98%, and **51.8%** reached at least 99%. On the token side, Cached Input accounted for **98.71%**, while Uncached Input (scaled) accounted for **1.29%**.
+
+| KV Cache hit rate | Records |
+| --- | ---: |
+| 80-90% | 7 |
+| 90-95% | 13 |
+| 95-98% | 103 |
+| 98-99% | 228 |
+| 99-99.5% | 239 |
+| >=99.5% | 138 |
+
+Agents also need to retrieve context repeatedly. For large-repository retrieval, BitFun uses **flashgrep** to reduce search time by up to about **94.6%** in huge repositories such as Chromium, with an average speedup of about **36.1x**.
+
+| Retrieval path | Search time |
+| --- | ---: |
+| Traditional retrieval | 145.9s |
+| BitFun + flashgrep | 7.82s |
 
 ---
 
-## Why BitFun
+## One Desktop, Five Agent Workflows
 
-- **One app, almost every mainstream Agent capability in the industry**: Code / Cowork / Computer Use / document collaboration / generative UI / Mini App / MCP / remote control … No juggling multiple tools or paying for separate subscriptions for each.
-- **Download and run—no DIY assembly**: MCP / LSP / filesystem / terminal / Git / remote SSH are all built in; configure your model and go, without spending time wiring the protocol stack from scratch.
-- **Your data stays on your machine**: Sessions, memory, and working directories live under `.bitfun/sessions/`, portable, exportable, and auditable; nothing is forced to the cloud—suitable for privacy and compliance scenarios.
-- **Deeply customizable, with no gap from a single Markdown file to a full-repo fork**: ~90% of domain needs are covered with one `.md`; missing a tool? a UI? want to change the product? Have the Code Agent do it inside BitFun—**the way you customize it is by using it**.
-- **Control the desktop from your phone**: Pair by QR code, or use Telegram, Feishu Bot, or WeChat Bot as remote entry points. The Agent works on the desktop; you check progress on the go.
-- **A desktop app you can actually live with**: Rust core + Tauri shell—fast cold start, low idle footprint, fine to leave running in the background for a long time.
-- **Self-improving**: 97%+ of the code was produced by BitFun’s built-in Code Agent via Vibe Coding, so it naturally fits AI-assisted development.
-
----
-
-## What's New
-
-BitFun combines **flashgrep** with **ripgrep** into an enhanced code-search pipeline. On very large repositories such as Chromium, search time drops by up to about **94.6%**, with an average speedup of about **36.1×**, significantly reducing the time you spend exploring a project.
-
-![flashgrep feature](./png/feat_flashgrep.png)
-
----
-
-## Cutting Edge · Ready Out of the Box
-
-New paradigms appear almost weekly in the Agent space. BitFun’s pace is: **when we see something great, we ship it on the desktop and make it work seamlessly with what you already have.**
-
+| Workflow | What it solves |
+| --- | --- |
+| **Code** | A Code Agent for real repositories: Agentic, Plan, Debug, testing, review, Deep Review, and continuous iteration. |
+| **Research** | Collect context, compare sources, summarize findings, and produce structured conclusions, reports, or follow-up actions. |
+| **Cowork** | Handle PDF / DOCX / XLSX / PPTX, writing, rewriting, summarization, layout, and office collaboration. |
+| **Operate** | Use Computer Use to operate browsers and desktop apps, completing flows such as clicking, typing, navigating, waiting, and confirming. |
+| **Extend** | Connect MCP, install Skills, define Markdown Agents, generate Mini Apps, and continue reshaping BitFun itself. |
 
 ![first_screen_screenshot](./png/first_screen_screenshot.png)
 
-Below is BitFun’s **official Agent and capability inventory**, plus how we track the industry’s latest Agent patterns. Zero extra setup—download and use:
-
-| Capability | Description |
-| --- | --- |
-| **Code Agent** | Four modes: Agentic (autonomous read / edit / run / verify) / Plan (plan first, then execute) / Debug (instrument → gather evidence → root cause) / Review (repo-standard review) |
-| **Deep Review** | A parallel Code Review Team for higher-risk code changes, with reviewer roles, a quality gate, and user-approved remediation |
-| **Session usage report** | Type `/usage` in chat to view recorded runtime, token usage, and model/tool/file summaries for the current session. |
-| **Cowork Agent** | Native PDF / DOCX / XLSX / PPTX workflows; extend on demand from the Skill marketplace |
-| **Document collaboration** | Write and ask in the document; the AI rewrites, continues, summarizes, and lays out text directly in paragraphs |
-| **Computer Use** | Sees the screen and drives mouse and keyboard to operate browsers and any desktop app—hand repetitive clicking to the Agent |
-| **Personal Assistant** | Long-term memory and personality; schedules Code / Cowork / Computer Use / custom Agents as needed |
-| **Remote control / IM** | Phone QR pairing, Telegram, Feishu Bot, WeChat Bot for remote commands with live progress |
-| **MCP / MCP App** | One-click hookup for external tools; MCP can also be packaged as installable Apps |
-| **Generative UI** | On-demand interactive UI components during chat, embedded in the message stream for immediate use |
-| **Mini App** | One sentence to a standalone runnable app—generate, run, one-click package for desktop |
-| **Markdown-defined Agents** | Write a `.md` file and run it in the Runtime right away for most domain customization |
-| **Long-term memory** | Accumulates across sessions; readable by any Agent |
-| **Self-iteration** | Code Agent can change BitFun’s own repository |
-| **⋯⋯** | Next trends in progress—open an Issue with requests |
-
 ---
 
-## How to Customize Your BitFun
+## Ready Out of the Box
 
-Different depths of customization map to different-effort paths. Pick from light to heavy as needed:
+### Download directly
 
-| Tier | Approach | Best for | Effort |
-| --- | --- | --- | --- |
-| **L1** | **Markdown custom Agents** | Swap prompts + pick tool bundles to define a **new Agent capability**—covers most domain needs | Write one `.md` file |
-| **L2** | **Mini App** | Capabilities that need UI (panels, forms, visualization, business flows) | One sentence to generate; run immediately |
-| **L3** | **Source-level tools** | New tools, model adapters, protocols—give your custom Agent a `tool` BitFun doesn’t ship yet | Use BitFun’s Code Agent to edit BitFun’s own source |
-| **L4** | **Free-form source changes** | Rebrand, rebuild UI, change session model, ship a totally different product | Fork the whole repo—naturally fits Vibe Coding |
+Go to [Releases](https://github.com/GCWing/BitFun/releases) to download the latest desktop installer. After installation, configure your model and start using BitFun.
 
-### Example: Code Agent vs Cowork Agent is a small difference
-
-In BitFun, an Agent = **a prompt (system role + behavior constraints) + the set of tools it may call**. The official Code Agent and Cowork Agent differ only in those two dimensions:
-
-| | Code Agent | Cowork Agent |
-| --- | --- | --- |
-| **Prompt** | Role and norms for repo work; four operating modes | Role and document workflows for knowledge work |
-| **Tooling** | Files / terminal / Git / LSP / build & test | PDF / DOCX / XLSX / PPTX / Skill marketplace |
-| **Shared foundation** | Same sessions, memory, MCP, remote control, UI, model adapters | Same sessions, memory, MCP, remote control, UI, model adapters |
-
-**So if you want a “legal review Agent,” a “research literature Agent,” or an “ops incident Agent”—L1 is enough**:
-
-1. Write a Markdown file defining role / guardrails / workflow
-2. From the tool registry, enable what it should use (files, browser, specific MCP …)
-3. If a specific tool is missing—use **L3**: open BitFun and have the Code Agent add it in source
-4. If the Agent needs a dedicated UI—use **L2**: one sentence to spin up a Mini App
-5. If you want a completely different product—use **L4**: fork the repo and have the Code Agent help you reshape it
-
-**Key point**: For L3 and L4 you never leave BitFun—**open BitFun, tell the Code Agent what to change, and it shows you the diff**. **The way you customize it is by using it.**
-
-> From one Markdown file to a full fork, there is no discontinuity. That is what “a self-improving foundation” means.
-
----
-
-## Platform Support
-
-Desktop is built on Tauri for Windows / macOS / Linux; remote control works from mobile browsers, Telegram, Feishu, and WeChat.
-
----
-
-## Quick Start
-
-### Download and use
-
-Download the latest desktop installer from [Releases](https://github.com/GCWing/BitFun/releases). After installation, configure your model and start using BitFun.
-
-### Build from source
+### Run from source
 
 **Prerequisites:**
 
 - [Node.js](https://nodejs.org/) (LTS recommended)
 - [pnpm](https://pnpm.io/)
 - [Rust toolchain](https://rustup.rs/)
-- [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) (required for desktop development)
-
-**Commands:**
+- [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/)
 
 ```bash
-# Install dependencies
 pnpm install
-
-# Run desktop in development mode
 pnpm run desktop:dev
-
-# Build desktop
-pnpm run desktop:build
 ```
 
-For more details, see the [Contributing guide](./CONTRIBUTING.md).
+For more development details, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ---
 
-## Project structure at a glance
+## Customize Your BitFun
 
-```
-src/crates/interfaces/         # Product protocol interfaces such as ACP
-src/crates/assembly/           # Compatibility facade and product capability assembly
-src/crates/adapters/           # AI, API, transport, and WebDriver adapters
-src/crates/services/           # Reusable OS, terminal, MCP, remote, git, and filesystem services
-src/crates/execution/          # Agent, harness, stream, typed-service, and tool primitives
-src/crates/contracts/          # Stable DTOs, events, runtime ports, and product domains
-src/apps/desktop        # Tauri desktop host
-src/apps/server         # Web server runtime
-src/apps/cli            # CLI runtime
-src/web-ui              # Shared desktop / Web frontend
-```
+BitFun's extension paths progress continuously from light to deep customization:
 
-Design principle: **keep product logic platform-agnostic and expose it through adapters**. See [AGENTS.md](./AGENTS.md).
+| Tier | Path | Best for |
+| --- | --- | --- |
+| **L1** | Markdown Agent | Defining roles, flows, constraints, and tool bundles. |
+| **L2** | MCP / Skills | Connecting external tools, professional capabilities, and workflows. |
+| **L3** | Mini App | Generating dedicated interfaces, forms, panels, or visualizations for tasks. |
+| **L4** | Source-level customization | Changing tools, adapters, UI, Runtime, or product shape. |
+
+You can use BitFun's Code Agent to extend BitFun itself.
 
 ---
 
 ## Contributing
 
-We welcome great ideas and code; we are maximally open to AI-generated code. Please submit PRs directly to the `main` branch; we review and merge there.
+Stars, Issues, and PRs are welcome. We especially care about:
 
-**Contribution directions we care about most:**
+1. Code Agent, Deep Review, debugging, and long-task execution capabilities
+2. Cowork, research, document, and desktop workflows
+3. MCP, Skills, Mini App, LSP plugins, and new domain Agents
+4. Runtime stability, performance, context efficiency, and verifiability
 
-1. **Runtime core**: session model, tool registry, memory system, protocol adapters
-2. **Reference Agents**: capabilities and experience for Code / Cowork / Personal Assistant
-3. **Ecosystem**: Skills, MCP, LSP plugins, Mini App templates, and new vertical Agents
-4. Ideas / creativity (features, interaction, visuals)—Issues welcome
+Please submit PRs directly to the `main` branch. For more details, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ---
 
 ## Disclaimer
 
-1. This project is spare-time exploration and research into next-generation human–machine collaboration, not a commercial profit-making project.
-2. More than 97% was built with Vibe Coding. Code feedback is welcome; refactoring and optimization via AI is encouraged.
+1. This project is spare-time exploration and research into next-generation human-machine collaboration, not a commercial profit-making project.
+2. This project is 97%+ built through Vibe Coding. Code feedback is welcome, and AI-assisted refactoring and optimization are encouraged.
 3. This project depends on and references many open-source projects. Thanks to all open-source authors. **If your rights are affected, please contact us for remediation.**
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,186 +16,119 @@
 
 ---
 
-## BitFun 是什么
+## 以 Code Agent 为核心的本地 AI 工作台
 
-**BitFun 是一个桌面级 Agent 运行时（Local Agent Runtime），同时也是一套开箱即用的桌面 Agent 应用。**
+BitFun 基于一个面向长程任务、强调工程执行与 Token 经济性的 Code Agent 打造本地 AI 工作台。
 
-- 它是**基座**——Rust 内核 + Tauri 外壳，内置会话、工具、记忆、MCP、LSP、远程控制协议，为长期运行而生；
-- 它是**产品**——下载安装就拥有 Code / Cowork / Computer Use / 个人助理四大官方 Agent，几乎覆盖了当前业界所有主流 Agent 能力形态。
+它能理解复杂上下文、调用工具、等待结果、修正偏差，把长程任务持续推进到可交付状态；编码、调研、办公、文档、桌面操作和可扩展工作流，都在同一个本地桌面环境里展开。
 
-> **一次安装，既能当 Agent 用，也能当 Runtime 做。**
-
-BitFun 的野心是把 **Code Agent 的编码力、Cowork 的办公力、OpenClaw 的助理体验、Computer Use 的操控力等等** 这些业界最受欢迎的 Agent 能力，装进同一个桌面端，并把底层协议栈（Agentic RunTime、工具、记忆、MCP、Skill、上下文压缩、远程控制）全部默认就绪——你拿来就能用，也可以基于它定义**你自己的领域 Agent**。
-
+核心目标很直接：让 AI 从一次任务执行，进化成可以长期工作的生产力系统。
 
 ![readme_hero_CN](./png/readme_hero_CN.png)
 
 ---
 
-## 为什么选 BitFun
+## Agent 核心指标
 
-- **一个应用，几乎覆盖全部业界主流 Agent 能力**：Code / Cowork / Computer Use / 文档协作 / 生成式 UI / Mini App / MCP / 远程控制 …… 不用在多个工具之间切换，也不用各配一个订阅。
-- **下载即用，不做拼装工**：MCP / LSP / 文件系统 / 终端 / Git / 远程 SSH 全部内置，模型配好就能开跑，省掉自己从零搭建协议栈的时间。
-- **数据在你自己机器上**：会话、记忆、工作目录都存在 `.bitfun/sessions/` 下，可迁移、可导出、可审计；没有强制上云，隐私与合规场景都能用。
-- **极致可定制，从一个 Markdown 到整仓 fork 没有断点**：90% 的领域化需求一个 `.md` 就能搞定；缺工具？缺界面？要改产品？在 BitFun 里直接让 Code Agent 动手——**你定制它的方式，就是用它本身**。
-- **手机也能指挥桌面**：扫码、Telegram、飞书 Bot、微信 Bot 都是远控入口。Agent 在桌面上干活，你在路上看进度。
-- **真正能装机长用的桌面应用**：Rust 内核 + Tauri 外壳，冷启动快、常驻资源低，长时间后台运行也不心疼电脑。
-- **会自我迭代**：97%+ 代码由 BitFun 内置 Code Agent 通过 Vibe Coding 完成，天然亲和AI开发。
+下面的数据用于观察 BitFun Agent 的核心能力。统一使用 **Deepseek-V4-Pro**，从任务完成率、KV Cache 复用和大仓库检索效率三个指标评估。
 
----
+BitFun 在 **SWE-Bench-Pro** 和 **SWE-Bench-Verified** 上均领先 Open Code 与 Claude Code。SWE-Bench-Pro 关注复杂软件工程，SWE-Bench-Verified 关注人工验证的 GitHub issue 修复。
 
-## 最新特性
+| 评测集 | BitFun | Open Code | Claude Code |
+| --- | ---: | ---: | ---: |
+| **SWE-Bench-Pro** | **52%** | 51% | 50% |
+| **SWE-Bench-Verified** | **74%** | 72% | 69% |
 
-BitFun 通过引入 flashgrep 与 ripgrep 联动形成增强版本的检索链路，在 Chromium 这类超大代码仓库中将代码搜索耗时最高降低约 94.6%、平均加速约 36.1×，显著缩短项目探索时间。
+当前数据为每个 case 跑 1 次得到的 BitFun 初始评测结果，后续会持续优化并放出完整评测详情。评测集说明：[SWE-Bench-Pro](https://labs.scale.com/leaderboard/swe_bench_pro_public) / [SWE-Bench-Verified](https://www.swebench.com/verified.html)
 
-![flashgrep 检索增强](./png/feat_flashgrep.png)
+Agent 执行是否经济，关键在于重复上下文能否被稳定复用。同一轮 SWE-Bench-Pro 评测中，BitFun 的 KV Cache 平均命中率为 **98.67%**；728 条有效 cache 记录里，**83.1%** 的 trials 命中率不低于 98%，**51.8%** 不低于 99%。Token 侧，Cached Input 占 **98.71%**，Uncached Input (scaled) 占 **1.29%**。
 
----
+| KV Cache 命中率 | 记录数 |
+| --- | ---: |
+| 80-90% | 7 |
+| 90-95% | 13 |
+| 95-98% | 103 |
+| 98-99% | 228 |
+| 99-99.5% | 239 |
+| >=99.5% | 138 |
 
-## 紧追前沿 · 开箱即用
+Agent 还需要反复寻找上下文。大仓库检索方面，BitFun 通过 **flashgrep** 在 Chromium 等超大仓库中最高降低约 **94.6%** 搜索耗时，平均加速约 **36.1x**。
 
-Agent 领域几乎每周都有新范式出现。BitFun 的节奏是——**看到好东西，就把它装进桌面，并让它和已有能力无缝协同**。
-
-
-![first_screen_screenshot](./png/first_screen_screenshot_CN.png)
-
-以下是 BitFun 已装箱的**官方 Agent 和能力清单**和对业界最前沿 Agent 范式的复现进度。零配置，下载即用：
-
-
-| 能力                    | 说明                                                                        |
-| --------------------- | ------------------------------------------------------------------------- |
-| **Code Agent**        | 四种模式：Agentic（自主读改跑验证）/ Plan（先规划后执行）/ Debug（插桩取证 → 根因定位）/ Review（基于仓库规范审核） |
-| **深度审核**              | 面向高风险代码变更的并行代码审核团队，内置专项审核员、质量把关和用户确认后的修复流程                                |
-| **会话用量报告**            | 在聊天中输入 `/usage`，查看当前会话的记录耗时、Token 用量和模型/工具/文件摘要。 |
-| **Cowork Agent**      | PDF / DOCX / XLSX / PPTX 原生处理能力，可从 Skill 市场按需扩展                           |
-| **文档协作**              | 在文档里边写边问，AI 直接在段落上改写、续写、总结、排版                                             |
-| **Computer Use**      | 看屏幕、动鼠标键盘，操作浏览器与任意桌面应用，把"手动点点点"交给 Agent                                   |
-| **个人助理**              | 长期记忆、个性设定，按需调度 Code / Cowork / Computer Use / 自定义 Agent                   |
-| **远程控制 / IM 接入**      | 手机扫码、Telegram、飞书 Bot、微信 Bot 远程下达指令，实时查看进度                                 |
-| **MCP / MCP App**     | 任意外部工具一键接入，MCP 也能打包成可安装的 App                                              |
-| **生成式 UI**            | 对话过程中按需生成可交互 UI 组件，嵌在消息流里直接用                                              |
-| **Mini App**          | 一句话生成独立可运行的应用，即生即跑，一键打包成桌面端                                               |
-| **Markdown 定义 Agent** | 写一个 `.md` 文件，立即在 Runtime 里跑起来，满足大多数领域化需求                                  |
-| **长期记忆 + 项目上下文**      | 跨会话积累，任意 Agent 可读                                                         |
-| **自我迭代**              | Code Agent 直接改 BitFun 自己的仓库                                               |
-| **⋯⋯**                | 下一个热点持续跟进中，欢迎 Issue 提需求                                                   |
-
+| 检索路径 | 搜索耗时 |
+| --- | ---: |
+| 传统检索 | 145.9s |
+| BitFun + flashgrep | 7.82s |
 
 ---
 
-## 怎么定制自己的 BitFun
+## 一个桌面，五类 Agent 工作流
 
-不同深度的定制需求，对应不同成本的扩展路径。按"从轻到重"依次选择即可：
+| 工作流 | 解决什么 |
+| --- | --- |
+| **Code** | 面向真实仓库的 Code Agent: Agentic、Plan、Debug、测试、审查、Deep Review 和持续迭代。 |
+| **Research** | 收集上下文、比较资料、总结发现，并输出结构化结论、报告或后续行动。 |
+| **Cowork** | 处理 PDF / DOCX / XLSX / PPTX、写作、改写、总结、排版和办公协作。 |
+| **Operate** | 通过 Computer Use 操作浏览器和桌面应用，完成点击、输入、跳转、等待和确认等流程。 |
+| **Extend** | 接入 MCP、安装 Skills、定义 Markdown Agent、生成 Mini App，并继续改造 BitFun 自己。 |
 
-
-| 层级     | 方式                     | 适合做什么                                                 | 改动成本                                 |
-| ------ | ---------------------- | ----------------------------------------------------- | ------------------------------------ |
-| **L1** | **Markdown 自定义 Agent** | 换提示词 + 挑选工具组合，即可定义一个**新的 Agent 能力**，满足大多数领域化需求        | 写一个 `.md` 文件                         |
-| **L2** | **Mini App**           | 需要用界面交互的能力（面板、表单、可视化、业务流程）                            | 一句话生成，即生即跑                           |
-| **L3** | **源码级添加工具**            | 新工具、新模型适配、新协议接入——给自定义 Agent 补齐它需要但 BitFun 还没有的 `tool` | 用 BitFun 的 Code Agent 改 BitFun 自己的源码 |
-| **L4** | **自由改源码**              | 换品牌、重做 UI、改会话模型、做完全不一样的产品                             | 整仓 fork，天然亲和 Vibe Coding 开发模式        |
-
-
-### 一个例子：Code Agent 和 Cowork Agent 的差别其实很小
-
-在 BitFun 里，一个 Agent = **一段提示词（系统角色 + 行为约束）+ 一组它能调用的工具**。官方的 Code Agent 和 Cowork Agent 区别就仅在于此：
-
-
-|          | Code Agent                  | Cowork Agent                        |
-| -------- | --------------------------- | ----------------------------------- |
-| **提示词**  | 面向仓库工作的角色、规范、四种工作模式         | 面向知识工作的角色、文档处理流程                    |
-| **工具集**  | 文件 / 终端 / Git / LSP / 构建与测试 | PDF / DOCX / XLSX / PPTX / Skill 市场 |
-| **共用底盘** | 同一套会话、记忆、MCP、远控、UI、模型适配     | 同一套会话、记忆、MCP、远控、UI、模型适配             |
-
-
-**所以，如果你想做一个"法律审阅 Agent"、"科研文献 Agent"或者"运维应急 Agent"——L1 就够了**：
-
-1. 写一个 Markdown，定好它的角色 / 禁区 / 工作流程
-2. 从工具注册表里勾上它该用的工具（文件、浏览器、特定 MCP……）
-3. 如果缺了一个特定工具 —— 走 **L3**，打开 BitFun 让 Code Agent 帮你加进源码
-4. 如果这个 Agent 需要一个专属界面 —— 走 **L2**，一句话生成一个 Mini App
-5. 如果你要做一个完全不一样的产品 —— 走 **L4**，fork 整个仓库，让 Code Agent 陪你改
-
-**关键点**：L3 和 L4 都不用你离开 BitFun——**打开 BitFun，对 Code Agent 说你要改什么，它就改给你看**。**你定制它的方式，就是用它本身**
-
-> 从一个 Markdown 文件到完整 fork，中间没有断点。这正是"会自我迭代的基座"的含义。
+![first_screen_screenshot_CN](./png/first_screen_screenshot_CN.png)
 
 ---
 
-## 平台支持
+## 开箱即用
 
-桌面端基于 Tauri，支持 Windows / macOS / Linux；远程控制支持手机浏览器、Telegram、飞书、微信。
+### 直接下载
 
----
+前往 [Releases](https://github.com/GCWing/BitFun/releases) 下载最新桌面端安装包，安装后配置模型即可开始使用。
 
-## 快速开始
-
-### 直接下载使用
-
-在 [Releases](https://github.com/GCWing/BitFun/releases) 页面下载最新桌面端安装包，安装后配置模型即可开始使用。
-
-### 从源码构建
+### 从源码运行
 
 **前置依赖：**
 
-- [Node.js](https://nodejs.org/)（推荐 LTS 版本）
+- [Node.js](https://nodejs.org/)（推荐 LTS）
 - [pnpm](https://pnpm.io/)
 - [Rust 工具链](https://rustup.rs/)
-- [Tauri 前置依赖](https://v2.tauri.app/start/prerequisites/)（桌面端开发需要）
-
-**运行指令：**
+- [Tauri 前置依赖](https://v2.tauri.app/start/prerequisites/)
 
 ```bash
-# 安装依赖
 pnpm install
-
-# 以开发模式运行桌面端
 pnpm run desktop:dev
-
-# 构建桌面端
-pnpm run desktop:build
 ```
 
-更多详情请参阅[贡献指南](./CONTRIBUTING_CN.md)。
+更多开发说明见 [CONTRIBUTING_CN.md](./CONTRIBUTING_CN.md)。
 
 ---
 
-## 项目结构一览
+## 定制你的 BitFun
 
-```
-src/crates/interfaces/         # ACP 等产品协议接口
-src/crates/assembly/           # 兼容门面与产品能力组装
-src/crates/adapters/           # AI、API、transport 与 WebDriver adapter
-src/crates/services/           # OS、terminal、MCP、remote、git 与 filesystem service
-src/crates/execution/          # Agent、harness、stream、typed-service 与 tool 原语
-src/crates/contracts/          # 稳定 DTO、事件、runtime ports 与产品领域契约
-src/apps/desktop        # Tauri 桌面宿主
-src/apps/server         # Web 服务端运行时
-src/apps/cli            # CLI 运行时
-src/web-ui              # 桌面 / Web 共用前端
-```
+BitFun 的扩展路径从轻到重连续展开：
 
-架构原则：**产品逻辑保持平台无关，通过适配器对外暴露**。详见 [AGENTS-CN.md](./AGENTS-CN.md)。
+| 层级 | 方式 | 适合场景 |
+| --- | --- | --- |
+| **L1** | Markdown Agent | 定义角色、流程、约束和工具组合。 |
+| **L2** | MCP / Skills | 接入外部工具、专业能力和工作流。 |
+| **L3** | Mini App | 为任务生成专属界面、表单、面板或可视化。 |
+| **L4** | 源码级改造 | 修改工具、适配器、UI、Runtime 或产品形态。 |
+
+你可以用 BitFun 的 Code Agent 来扩展 BitFun 本身。
 
 ---
 
 ## 贡献
 
-欢迎大家贡献好的创意和代码，我们对 AI 生成代码抱有最大的接纳程度。请将 PR 直接提交至 `main` 分支，我们会在 `main` 上直接评审与合并。
+欢迎 Star、Issue 和 PR。我们尤其关注：
 
-**我们重点关注的贡献方向：**
+1. Code Agent、Deep Review、调试和长任务执行能力
+2. Cowork、调研、文档和桌面工作流
+3. MCP、Skills、Mini App、LSP 插件和新领域 Agent
+4. Runtime 稳定性、性能、上下文效率和可验证性
 
-1. **Runtime 内核**：会话模型、工具注册、记忆系统、协议适配
-2. **样板 Agent**：Code / Cowork / 个人助理 的能力与体验
-3. **生态扩展**：Skill、MCP、LSP 插件、Mini App 模板，以及新的垂域 Agent
-4. 想法 / 创意（功能、交互、视觉），欢迎提 Issue
+请将 PR 直接提交至 `main` 分支。更多说明见 [CONTRIBUTING_CN.md](./CONTRIBUTING_CN.md)。
 
 ---
 
 ## 声明
 
 1. 本项目为业余时间探索、研究构建下一代人机协同交互，非商用盈利项目。
-2. 本项目 97%+ 由 Vibe Coding 完成，代码问题也欢迎指正，可通过 AI 进行重构优化。
-3. 本项目依赖和参考了众多开源软件，感谢所有开源作者。**如侵犯您的相关权益请联系我们整改。**
-
----
+2. 本项目 97%+ 由 Vibe Coding 完成，代码问题欢迎指正，也欢迎通过 AI 进行重构优化。
+3. 本项目依赖和参考了众多开源软件。感谢所有开源作者。如侵犯您的相关权益，请联系我们整改。


### PR DESCRIPTION
## Summary
- refresh the English README from the updated Chinese README structure
- rename the metrics section to Agent core metrics in both languages
- keep benchmark, KV Cache, and flashgrep data inline as README tables
- remove the architecture/project-structure details section from both READMEs
- update the Chinese README hero image to the latest repository asset

## Validation
- git diff --check -- README.md README.zh-CN.md
- git diff --cached --check
- git diff --check -- png/readme_hero_CN.png
- verified the PR hero image hash matches the latest local asset

## Scope
- README.md
- README.zh-CN.md
- png/readme_hero_CN.png