### PR TITLE
fix: patch tao Windows input deadlock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,11 @@ shellexpand = "3"
 ssh_config = "0.1"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
+[patch.crates-io]
+# tao 0.35.3 can re-enter its Windows window callback while holding input locks.
+# Use the upstream fix until it is included in a crates.io release.
+tao = { git = "https://github.com/tauri-apps/tao.git", rev = "c704261c519c58cfdd0bc2d58ba24e06a0b71c92" }
+
 [profile.dev]
 incremental = true
 


### PR DESCRIPTION
## Summary

Patch `tao` to an upstream Git revision that fixes a Windows input reentrancy deadlock.

Fixes #

## Type and Areas

Type:

bug fix / dependency

Areas:

desktop/Tauri, Rust dependencies

## Motivation / Impact

`tao 0.35.3` can deadlock the Windows UI thread when keyboard or IME message handling calls `PeekMessageW` while holding input-related locks. `PeekMessageW` may re-enter the window callback, causing the callback to try to acquire the same non-reentrant lock again.

This PR uses the upstream Tao fix from `tauri-apps/tao` commit `c704261c519c58cfdd0bc2d58ba24e06a0b71c92` until the fix is available in a crates.io release.

Impact: reduces the risk of BitFun Desktop becoming unresponsive on Windows during keyboard/window message processing.

## Verification

- `cargo check -p bitfun-desktop`
  - Passed.
  - Confirmed Cargo resolves `tao v0.35.3` from `https://github.com/tauri-apps/tao.git?rev=c704261c519c58cfdd0bc2d58ba24e06a0b71c92`.

## Reviewer Notes

This is a temporary dependency patch. Once Tao publishes a crates.io release containing `tauri-apps/tao#1215`, this `[patch.crates-io]` override can be removed and the dependency can return to the published release path.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.