### PR TITLE
feat(web-ui): align terminal paste behavior with VS Code

### DIFF
--- a/src/web-ui/src/component-library/components/ConfirmDialog/ConfirmDialog.scss
+++ b/src/web-ui/src/component-library/components/ConfirmDialog/ConfirmDialog.scss
@@ -59,7 +59,7 @@
     font-size: var(--font-size-lg);
     font-weight: $font-weight-semibold;
     line-height: 1.35;
-    letter-spacing: -0.01em;
+    letter-spacing: 0;
     color: var(--color-text-primary);
     margin: 0 0 $size-gap-3;
     text-align: center;
@@ -137,8 +137,15 @@
     overflow: auto;
 
     pre {
+      display: block;
+      box-sizing: border-box;
+      width: 100%;
       margin: 0;
       padding: 0;
+      border: 0;
+      border-radius: 0;
+      background: transparent;
+      box-shadow: none;
       font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
       font-size: var(--font-size-xs);
       color: var(--color-text-primary);

--- a/src/web-ui/src/component-library/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/web-ui/src/component-library/components/ConfirmDialog/ConfirmDialog.tsx
@@ -19,6 +19,8 @@ export interface ConfirmDialogProps {
   onClose: () => void;
   /** Confirm callback */
   onConfirm: () => void;
+  /** Secondary action callback */
+  onSecondary?: () => void;
   /** Cancel callback */
   onCancel?: () => void;
   /** Title */
@@ -29,6 +31,8 @@ export interface ConfirmDialogProps {
   type?: ConfirmDialogType;
   /** Confirm button text */
   confirmText?: string;
+  /** Optional secondary action text */
+  secondaryText?: string;
   /** Cancel button text */
   cancelText?: string;
   /** Whether the confirm button uses danger styling */
@@ -52,11 +56,13 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   isOpen,
   onClose,
   onConfirm,
+  onSecondary,
   onCancel,
   title,
   message,
   type = 'warning',
   confirmText,
+  secondaryText,
   cancelText,
   confirmDanger = false,
   showCancel = true,
@@ -83,6 +89,10 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
 
   const handleConfirm = () => {
     onConfirm();
+  };
+
+  const handleSecondary = () => {
+    onSecondary?.();
   };
 
   const handleCancel = () => {
@@ -133,6 +143,15 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
               onClick={handleCancel}
             >
               {resolvedCancelText}
+            </Button>
+          )}
+          {secondaryText && (
+            <Button
+              variant="secondary"
+              size="medium"
+              onClick={handleSecondary}
+            >
+              {secondaryText}
             </Button>
           )}
           <Button

--- a/src/web-ui/src/component-library/components/ConfirmDialog/ConfirmDialogRenderer.tsx
+++ b/src/web-ui/src/component-library/components/ConfirmDialog/ConfirmDialogRenderer.tsx
@@ -7,7 +7,7 @@ import { ConfirmDialog } from './ConfirmDialog';
 import { useConfirmDialogStore } from './confirmService';
 
 export const ConfirmDialogRenderer: React.FC = () => {
-  const { isOpen, options, confirm, cancel, close } = useConfirmDialogStore();
+  const { isOpen, options, confirm, secondary, cancel, close } = useConfirmDialogStore();
 
   if (!options) {
     return null;
@@ -18,11 +18,13 @@ export const ConfirmDialogRenderer: React.FC = () => {
       isOpen={isOpen}
       onClose={close}
       onConfirm={confirm}
+      onSecondary={secondary}
       onCancel={cancel}
       title={options.title}
       message={options.message}
       type={options.type}
       confirmText={options.confirmText}
+      secondaryText={options.secondaryText}
       cancelText={options.cancelText}
       confirmDanger={options.confirmDanger}
       showCancel={options.showCancel}

--- a/src/web-ui/src/component-library/components/ConfirmDialog/confirmService.ts
+++ b/src/web-ui/src/component-library/components/ConfirmDialog/confirmService.ts
@@ -1,10 +1,12 @@
 /**
  * Confirm dialog service
- * Provides an imperative API and returns Promise<boolean>
+ * Provides imperative APIs for confirmation dialogs.
  */
 
 import { create } from 'zustand';
 import type { ConfirmDialogType } from './ConfirmDialog';
+
+export type ConfirmDialogChoice = 'confirm' | 'secondary' | 'cancel';
 
 export interface ConfirmDialogOptions {
   /** Title */
@@ -15,6 +17,8 @@ export interface ConfirmDialogOptions {
   type?: ConfirmDialogType;
   /** Confirm button text */
   confirmText?: string;
+  /** Optional secondary action text */
+  secondaryText?: string;
   /** Cancel button text */
   cancelText?: string;
   /** Whether the confirm button uses danger styling */
@@ -33,12 +37,16 @@ interface ConfirmDialogState {
   /** Options */
   options: ConfirmDialogOptions | null;
   /** Resolve callback */
-  resolve: ((value: boolean) => void) | null;
+  resolve: ((value: ConfirmDialogChoice) => void) | null;
   
   /** Show the dialog */
   show: (options: ConfirmDialogOptions) => Promise<boolean>;
+  /** Show the dialog and return the selected action. */
+  showChoice: (options: ConfirmDialogOptions) => Promise<ConfirmDialogChoice>;
   /** Confirm */
   confirm: () => void;
+  /** Secondary action */
+  secondary: () => void;
   /** Cancel */
   cancel: () => void;
   /** Close */
@@ -55,6 +63,16 @@ export const useConfirmDialogStore = create<ConfirmDialogState>((set, get) => ({
       set({
         isOpen: true,
         options,
+        resolve: (value) => resolve(value === 'confirm'),
+      });
+    });
+  },
+
+  showChoice: (options: ConfirmDialogOptions) => {
+    return new Promise<ConfirmDialogChoice>((resolve) => {
+      set({
+        isOpen: true,
+        options,
         resolve,
       });
     });
@@ -63,7 +81,19 @@ export const useConfirmDialogStore = create<ConfirmDialogState>((set, get) => ({
   confirm: () => {
     const { resolve } = get();
     if (resolve) {
-      resolve(true);
+      resolve('confirm');
+    }
+    set({
+      isOpen: false,
+      options: null,
+      resolve: null,
+    });
+  },
+
+  secondary: () => {
+    const { resolve } = get();
+    if (resolve) {
+      resolve('secondary');
     }
     set({
       isOpen: false,
@@ -75,7 +105,7 @@ export const useConfirmDialogStore = create<ConfirmDialogState>((set, get) => ({
   cancel: () => {
     const { resolve } = get();
     if (resolve) {
-      resolve(false);
+      resolve('cancel');
     }
     set({
       isOpen: false,
@@ -87,7 +117,7 @@ export const useConfirmDialogStore = create<ConfirmDialogState>((set, get) => ({
   close: () => {
     const { resolve } = get();
     if (resolve) {
-      resolve(false);
+      resolve('cancel');
     }
     set({
       isOpen: false,
@@ -99,6 +129,10 @@ export const useConfirmDialogStore = create<ConfirmDialogState>((set, get) => ({
 
 export function confirmDialog(options: ConfirmDialogOptions): Promise<boolean> {
   return useConfirmDialogStore.getState().show(options);
+}
+
+export function confirmDialogChoice(options: ConfirmDialogOptions): Promise<ConfirmDialogChoice> {
+  return useConfirmDialogStore.getState().showChoice(options);
 }
 
 export function confirmWarning(title: string, message: React.ReactNode, options?: Partial<ConfirmDialogOptions>): Promise<boolean> {

--- a/src/web-ui/src/component-library/components/ConfirmDialog/index.ts
+++ b/src/web-ui/src/component-library/components/ConfirmDialog/index.ts
@@ -2,9 +2,11 @@ export { ConfirmDialog, type ConfirmDialogProps, type ConfirmDialogType } from '
 export { ConfirmDialogRenderer } from './ConfirmDialogRenderer';
 export { 
   confirmDialog, 
+  confirmDialogChoice,
   confirmWarning, 
   confirmDanger, 
   confirmInfo,
   useConfirmDialogStore,
+  type ConfirmDialogChoice,
   type ConfirmDialogOptions 
 } from './confirmService';

--- a/src/web-ui/src/locales/en-US/tools.json
+++ b/src/web-ui/src/locales/en-US/tools.json
@@ -202,6 +202,13 @@
     "scrollToBottom": "Scroll to Bottom",
     "copySelection": "Copy Selection",
     "paste": "Paste",
+    "pasteDialog": {
+      "title": "Paste multiple lines",
+      "message": "The clipboard contains {{lineCount}} lines. Pasting multiple lines in a terminal may execute multiple commands.",
+      "confirm": "Paste",
+      "pasteAsOneLine": "Paste as one line",
+      "cancel": "Cancel"
+    },
     "selectAll": "Select All",
     "find": "Find",
     "shell": "Shell",

--- a/src/web-ui/src/locales/zh-CN/tools.json
+++ b/src/web-ui/src/locales/zh-CN/tools.json
@@ -202,6 +202,13 @@
     "scrollToBottom": "滚动到底部",
     "copySelection": "复制选中内容",
     "paste": "粘贴",
+    "pasteDialog": {
+      "title": "粘贴多行内容",
+      "message": "剪贴板包含 {{lineCount}} 行内容。将多行内容粘贴到终端可能会执行多条命令。",
+      "confirm": "粘贴",
+      "pasteAsOneLine": "粘贴为一行",
+      "cancel": "取消"
+    },
     "selectAll": "全选",
     "find": "查找",
     "shell": "Shell",

--- a/src/web-ui/src/locales/zh-TW/tools.json
+++ b/src/web-ui/src/locales/zh-TW/tools.json
@@ -202,6 +202,13 @@
     "scrollToBottom": "滾動到底部",
     "copySelection": "複製選中內容",
     "paste": "粘貼",
+    "pasteDialog": {
+      "title": "貼上多行內容",
+      "message": "剪貼簿包含 {{lineCount}} 行內容。將多行內容貼到終端可能會執行多條命令。",
+      "confirm": "貼上",
+      "pasteAsOneLine": "貼上為一行",
+      "cancel": "取消"
+    },
     "selectAll": "全選",
     "find": "查找",
     "shell": "Shell",

--- a/src/web-ui/src/tools/terminal/components/ConnectedTerminal.tsx
+++ b/src/web-ui/src/tools/terminal/components/ConnectedTerminal.tsx
@@ -8,16 +8,20 @@ import { AlertCircle, RefreshCw, Terminal as TerminalIcon, Trash2 } from 'lucide
 import Terminal, { TerminalRef } from './Terminal';
 import { useTerminal } from '../hooks/useTerminal';
 import { registerTerminalActions, unregisterTerminalActions } from '../services/TerminalActionManager';
-import { ResizeRepaintGuard, createResizeRepaintScreenSnapshot, terminalReplayHasScreenText } from '../utils';
-import { confirmWarning } from '@/component-library';
+import {
+  POWERSHELL_READLINE_PASTE_SEQUENCE,
+  ResizeRepaintGuard,
+  createResizeRepaintScreenSnapshot,
+  resolveTerminalPaste,
+  shouldUsePowerShellReadlinePaste,
+  terminalReplayHasScreenText,
+} from '../utils';
 import { createLogger } from '@/shared/utils/logger';
 import type { SessionResponse, TerminalReplayEvent } from '../types';
+import type { TerminalPasteDecision } from '../utils';
 import './Terminal.scss';
 
 const log = createLogger('ConnectedTerminal');
-
-/** Line threshold for multi-line paste confirmation. */
-const MULTILINE_PASTE_THRESHOLD = 1;
 
 /**
  * Matches a standalone absolute cursor position command: ESC [ R ; C H
@@ -339,40 +343,28 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
     flushOutputQueue();
   }, [flushOutputQueue]);
 
-  // Handle paste with multi-line confirmation.
-  const handlePaste = useCallback(async (text: string): Promise<boolean> => {
-    if (isExited) {
+  const handlePasteShortcut = useCallback(async (): Promise<boolean> => {
+    const shellType = session?.shellType ?? initialSession?.shellType;
+    if (isExited || !shouldUsePowerShellReadlinePaste(shellType)) {
       return false;
     }
 
-    const lines = text.split('\n');
-    const lineCount = lines.length;
+    await write(POWERSHELL_READLINE_PASTE_SEQUENCE);
+    return true;
+  }, [initialSession?.shellType, isExited, session?.shellType, write]);
 
-    if (lineCount > MULTILINE_PASTE_THRESHOLD) {
-      const maxPreviewLines = 10;
-      const previewLines = lines.slice(0, maxPreviewLines);
-      let preview = previewLines.join('\n');
-      if (lineCount > maxPreviewLines) {
-        preview += `\n... (${lineCount} lines total)`;
-      }
-
-      const confirmed = await confirmWarning(
-        'Paste multiple lines',
-        `The clipboard contains ${lineCount} lines. Pasting multiple lines in a terminal may execute multiple commands.`,
-        {
-          confirmText: 'Paste',
-          cancelText: 'Cancel',
-          preview,
-          previewMaxHeight: 150,
-        }
-      );
-
-      if (!confirmed) {
-        return false;
-      }
+  // Handle paste with VS Code-style multi-line safety policy.
+  const handlePaste = useCallback(async (
+    text: string,
+    context: { bracketedPasteMode: boolean },
+  ): Promise<TerminalPasteDecision> => {
+    if (isExited) {
+      return { allow: false };
     }
 
-    return true;
+    return resolveTerminalPaste(text, {
+      bracketedPasteMode: context.bracketedPasteMode,
+    });
   }, [isExited]);
 
   const handleSendCtrlC = useCallback(() => {
@@ -409,9 +401,10 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
     registerTerminalActions(terminalId, {
       getTerminal: () => terminalRef.current?.getTerminal() || null,
       isReadOnly: isExited,
-      write: async (data: string) => {
+      pasteShortcut: handlePasteShortcut,
+      paste: (data: string) => {
         if (!isExited) {
-          await write(data);
+          terminalRef.current?.paste(data);
         }
       },
       clear: () => {
@@ -422,7 +415,7 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
     return () => {
       unregisterTerminalActions(terminalId);
     };
-  }, [terminalId, isExited, write]);
+  }, [terminalId, isExited, handlePasteShortcut]);
 
   if (isLoading) {
     return (
@@ -494,6 +487,7 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
         onResize={handleResize}
         onTitleChange={handleTitleChange}
         onReady={handleTerminalReady}
+        onPasteShortcut={handlePasteShortcut}
         onPaste={handlePaste}
         preventShrinkBelowColsRef={preventShrinkBelowColsRef}
         resizeSuspended={resizeSuspended}

--- a/src/web-ui/src/tools/terminal/components/Terminal.tsx
+++ b/src/web-ui/src/tools/terminal/components/Terminal.tsx
@@ -15,6 +15,7 @@ import {
   getXtermFontWeights,
   DEFAULT_XTERM_MINIMUM_CONTRAST_RATIO,
 } from '../utils';
+import type { TerminalPasteDecision } from '../utils';
 import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
 import { themeService } from '@/infrastructure/theme/core/ThemeService';
 import { createLogger } from '@/shared/utils/logger';
@@ -124,10 +125,21 @@ export interface TerminalProps {
   onResize?: (cols: number, rows: number) => void;
   onReady?: (terminal: XTerm) => void;
   /**
-   * Paste interceptor: return true to allow, false to block.
-   * Uses the default multi-line confirmation when omitted.
+   * Keyboard paste shortcut interceptor. Return true when the shortcut was
+   * handled without reading clipboard text, for example by sending Ctrl+V to a
+   * shell that owns paste behavior.
    */
-  onPaste?: (text: string) => Promise<boolean> | boolean;
+  onPasteShortcut?: (
+    context: { terminal: XTerm; bracketedPasteMode: boolean },
+  ) => Promise<boolean> | boolean;
+  /**
+   * Paste interceptor: return true to allow, false to block, or a decision with
+   * modified text. When omitted, paste is allowed and xterm handles normalization.
+   */
+  onPaste?: (
+    text: string,
+    context: { terminal: XTerm; bracketedPasteMode: boolean },
+  ) => Promise<boolean | TerminalPasteDecision> | boolean | TerminalPasteDecision;
   /**
    * When set to a positive value, doXtermResize skips any resize that would
    * shrink the terminal below this column count. Used during history replay to
@@ -149,6 +161,7 @@ export interface TerminalRef {
   clear: () => void;
   reset: () => void;
   focus: () => void;
+  paste: (data: string) => void;
   fit: () => void;
   /** Flush pending debounced resize operations. */
   flushResize: () => void;
@@ -165,6 +178,21 @@ export interface TerminalRef {
  */
 function getInitialXtermTheme(overrides: TerminalOptions['theme'] = {}): ITheme {
   return buildXtermTheme(themeService.getCurrentTheme(), overrides);
+}
+
+function normalizePasteDecision(
+  decision: boolean | TerminalPasteDecision | undefined,
+  originalText: string,
+): TerminalPasteDecision {
+  if (decision === false) {
+    return { allow: false };
+  }
+
+  if (decision === true || decision === undefined) {
+    return { allow: true, text: originalText };
+  }
+
+  return decision;
 }
 
 const DEFAULT_OPTIONS: TerminalOptions = {
@@ -188,6 +216,7 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
   onTitleChange,
   onResize,
   onReady,
+  onPasteShortcut,
   onPaste,
   preventShrinkBelowColsRef,
   resizeSuspended = false,
@@ -210,6 +239,7 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
   const onTitleChangeRef = useRef(onTitleChange);
   const onResizeRef = useRef(onResize);
   const onReadyRef = useRef(onReady);
+  const onPasteShortcutRef = useRef(onPasteShortcut);
   const onPasteRef = useRef(onPaste);
   const resizeSuspendedRef = useRef(resizeSuspended);
   const pendingFitAfterSuspendRef = useRef(false);
@@ -239,6 +269,7 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
   onTitleChangeRef.current = onTitleChange;
   onResizeRef.current = onResize;
   onReadyRef.current = onReady;
+  onPasteShortcutRef.current = onPasteShortcut;
   onPasteRef.current = onPaste;
   resizeSuspendedRef.current = resizeSuspended;
   mergedOptionsRef.current = mergedOptions;
@@ -423,6 +454,9 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
     focus: () => {
       terminalRef.current?.focus();
     },
+    paste: (data: string) => {
+      terminalRef.current?.paste(data);
+    },
     fit: () => fit(false),
     flushResize,
     forceRedraw,
@@ -582,24 +616,67 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
       onTitleChangeRef.current?.(title);
     });
 
-    // Intercept paste (Ctrl+V / Ctrl+Shift+V).
+    const pasteText = async (text: string): Promise<void> => {
+      if (!text) return;
+
+      const activeTerminal = terminalRef.current ?? terminal;
+      let pasteDecision: TerminalPasteDecision = { allow: true, text };
+      if (onPasteRef.current) {
+        pasteDecision = normalizePasteDecision(
+          await onPasteRef.current(text, {
+            terminal: activeTerminal,
+            bracketedPasteMode: activeTerminal.modes.bracketedPasteMode,
+          }),
+          text,
+        );
+      }
+
+      if (!pasteDecision.allow) {
+        return;
+      }
+
+      activeTerminal.paste(pasteDecision.text);
+    };
+
+    const handleNativePaste = (event: ClipboardEvent) => {
+      const text = event.clipboardData?.getData('text/plain') ?? '';
+      if (!text) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      pasteText(text).catch((err) => {
+        log.error('Paste failed', err);
+      });
+    };
+
+    container.addEventListener('paste', handleNativePaste, true);
+
+    // Intercept paste (Ctrl+V / Ctrl+Shift+V) so callers can apply the same
+    // policy as context-menu paste before xterm normalizes/sends the data.
     terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
       if (event.type === 'keydown' && event.ctrlKey && (event.key === 'v' || event.key === 'V')) {
         event.preventDefault();
         
         (async () => {
           try {
-            const text = await navigator.clipboard.readText();
-            if (!text) return;
-
-            if (onPasteRef.current) {
-              const allowed = await onPasteRef.current(text);
-              if (!allowed) {
+            const activeTerminal = terminalRef.current ?? terminal;
+            if (onPasteShortcutRef.current) {
+              const handled = await onPasteShortcutRef.current({
+                terminal: activeTerminal,
+                bracketedPasteMode: activeTerminal.modes.bracketedPasteMode,
+              });
+              if (handled) {
                 return;
               }
             }
 
-            onDataRef.current?.(text);
+            const text = await navigator.clipboard.readText();
+            if (!text) return;
+
+            await pasteText(text);
           } catch (err) {
             log.error('Paste failed', err);
           }
@@ -668,6 +745,7 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
       dataDisposable.dispose();
       binaryDisposable.dispose();
       titleDisposable.dispose();
+      container.removeEventListener('paste', handleNativePaste, true);
       resizeObserver.disconnect();
       intersectionObserver.disconnect();
       fontLoadCancelled = true;

--- a/src/web-ui/src/tools/terminal/services/TerminalActionManager.ts
+++ b/src/web-ui/src/tools/terminal/services/TerminalActionManager.ts
@@ -6,18 +6,17 @@
 
 import { Terminal as XTerm } from '@xterm/xterm';
 import { globalEventBus } from '@/infrastructure/event-bus';
-import { confirmWarning } from '@/component-library';
 import { createLogger } from '@/shared/utils/logger';
+import { resolveTerminalPaste } from '../utils';
 
 const log = createLogger('TerminalActionManager');
-
-/** Line threshold for multi-line paste confirmation. */
-const MULTILINE_PASTE_THRESHOLD = 1;
 
 export interface TerminalActionHandler {
   getTerminal: () => XTerm | null;
   /** Read-only terminals cannot paste or clear. */
   isReadOnly?: boolean;
+  pasteShortcut?: () => Promise<boolean> | boolean;
+  paste?: (data: string) => Promise<void> | void;
   write?: (data: string) => Promise<void> | void;
   clear?: () => void;
 }
@@ -125,7 +124,7 @@ class TerminalActionManager {
       return;
     }
 
-    if (shortcutAction === 'paste' && (handler.isReadOnly || !handler.write)) {
+    if (shortcutAction === 'paste' && handler.isReadOnly) {
       return;
     }
 
@@ -140,7 +139,7 @@ class TerminalActionManager {
     }
 
     if (shortcutAction === 'paste') {
-      void this.handlePaste({ terminalId });
+      void this.handlePasteShortcut({ terminalId, handler });
       return;
     }
 
@@ -259,13 +258,24 @@ class TerminalActionManager {
   /**
    * Paste handler with multi-line confirmation.
    */
+  private handlePasteShortcut = async (data: {
+    terminalId: string;
+    handler: TerminalActionHandler;
+  }): Promise<void> => {
+    if (data.handler.pasteShortcut && await data.handler.pasteShortcut()) {
+      return;
+    }
+
+    await this.handlePaste({ terminalId: data.terminalId });
+  };
+
   private handlePaste = async (data: { terminalId: string }): Promise<void> => {
     const handler = this.handlers.get(data.terminalId);
     if (!handler) {
       return;
     }
 
-    if (handler.isReadOnly || !handler.write) {
+    if (handler.isReadOnly) {
       return;
     }
 
@@ -275,39 +285,38 @@ class TerminalActionManager {
         return;
       }
 
-      const lines = text.split('\n');
-      const lineCount = lines.length;
-      
-      if (lineCount > MULTILINE_PASTE_THRESHOLD) {
-        const maxPreviewLines = 10;
-        const previewLines = lines.slice(0, maxPreviewLines);
-        let preview = previewLines.join('\n');
-        if (lineCount > maxPreviewLines) {
-          preview += `\n... (${lineCount} lines total)`;
-        }
-        
-        const confirmed = await confirmWarning(
-          'Paste multiple lines',
-          `The clipboard contains ${lineCount} lines. Pasting multiple lines in a terminal may execute multiple commands.`,
-          {
-            confirmText: 'Paste',
-            cancelText: 'Cancel',
-            preview,
-            previewMaxHeight: 150,
-          }
-        );
-
-        if (!confirmed) {
-          return;
-        }
+      const terminal = handler.getTerminal();
+      const pasteDecision = await resolveTerminalPaste(text, {
+        bracketedPasteMode: terminal?.modes.bracketedPasteMode,
+      });
+      if (!pasteDecision.allow) {
+        return;
       }
 
-      await handler.write(text);
+      await this.pasteText(handler, terminal, pasteDecision.text);
       
     } catch (err) {
       log.error('Paste failed', { terminalId: data.terminalId, error: err });
     }
   };
+
+  private async pasteText(
+    handler: TerminalActionHandler,
+    terminal: XTerm | null,
+    text: string,
+  ): Promise<void> {
+    if (handler.paste) {
+      await handler.paste(text);
+      return;
+    }
+
+    if (terminal) {
+      terminal.paste(text);
+      return;
+    }
+
+    await handler.write?.(text);
+  }
 
   private handleSelectAll = (data: { terminalId: string }): void => {
     const handler = this.handlers.get(data.terminalId);

--- a/src/web-ui/src/tools/terminal/utils/index.ts
+++ b/src/web-ui/src/tools/terminal/utils/index.ts
@@ -6,6 +6,24 @@ export { TerminalResizeDebouncer } from './TerminalResizeDebouncer';
 export type { ResizeCallback, ResizeDebounceOptions } from './TerminalResizeDebouncer';
 export { ResizeRepaintGuard, createResizeRepaintScreenSnapshot } from './resizeRepaintGuard';
 export { terminalReplayHasScreenText } from './terminalReplay';
+export {
+  POWERSHELL_READLINE_PASTE_SEQUENCE,
+  analyzeTerminalPaste,
+  buildTerminalPastePreview,
+  confirmTerminalMultiLinePaste,
+  isPowerShellShellType,
+  isWindowsClientPlatform,
+  resolveTerminalPaste,
+  shouldUsePowerShellReadlinePaste,
+} from './terminalPaste';
+export type {
+  TerminalPasteAnalysis,
+  TerminalPasteConfirmationRequest,
+  TerminalPasteConfirmationResult,
+  TerminalPasteDecision,
+  TerminalPasteOptions,
+  TerminalPasteWarningMode,
+} from './terminalPaste';
 export type {
   ResizeRepaintGuardDecision,
   ResizeRepaintMark,

--- a/src/web-ui/src/tools/terminal/utils/terminalPaste.test.ts
+++ b/src/web-ui/src/tools/terminal/utils/terminalPaste.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  POWERSHELL_READLINE_PASTE_SEQUENCE,
+  analyzeTerminalPaste,
+  buildTerminalPastePreview,
+  resolveTerminalPaste,
+  shouldUsePowerShellReadlinePaste,
+} from './terminalPaste';
+
+describe('terminal paste policy', () => {
+  it('allows single-line text without confirmation', () => {
+    expect(analyzeTerminalPaste('echo hello')).toEqual({
+      shouldConfirm: false,
+      lineCount: 1,
+      preview: 'echo hello',
+      text: 'echo hello',
+    });
+  });
+
+  it('strips a trailing blank line in auto mode to avoid immediate execution', () => {
+    expect(analyzeTerminalPaste('echo hello\n')).toMatchObject({
+      shouldConfirm: false,
+      lineCount: 2,
+      text: 'echo hello',
+    });
+
+    expect(analyzeTerminalPaste('echo hello\n\t')).toMatchObject({
+      shouldConfirm: false,
+      lineCount: 2,
+      text: 'echo hello',
+    });
+  });
+
+  it('allows multi-line text without confirmation when bracketed paste mode is active', () => {
+    expect(analyzeTerminalPaste('echo one\necho two', { bracketedPasteMode: true })).toMatchObject({
+      shouldConfirm: false,
+      lineCount: 2,
+      text: 'echo one\necho two',
+    });
+  });
+
+  it('asks for confirmation for true multi-line text in auto mode', () => {
+    expect(analyzeTerminalPaste('echo one\necho two')).toMatchObject({
+      shouldConfirm: true,
+      lineCount: 2,
+      text: 'echo one\necho two',
+    });
+  });
+
+  it('honors always and never warning modes', () => {
+    expect(analyzeTerminalPaste('echo hello\n', { warningMode: 'always' })).toMatchObject({
+      shouldConfirm: true,
+      text: 'echo hello\n',
+    });
+
+    expect(analyzeTerminalPaste('echo one\necho two', { warningMode: 'never' })).toMatchObject({
+      shouldConfirm: false,
+      text: 'echo one\necho two',
+    });
+  });
+
+  it('builds a compact VS Code-style preview', () => {
+    expect(buildTerminalPastePreview([
+      '012345678901234567890123456789extra',
+      'second',
+      'third',
+      'fourth',
+    ])).toBe('012345678901234567890123456789...\nsecond\nthird\n...');
+  });
+
+  it('can convert confirmed multi-line paste to one line', async () => {
+    const confirmMultiLinePaste = vi.fn().mockResolvedValue('pasteAsSingleLine');
+
+    await expect(resolveTerminalPaste('echo one\necho two', {
+      confirmMultiLinePaste,
+    })).resolves.toEqual({
+      allow: true,
+      text: 'echo oneecho two',
+    });
+
+    expect(confirmMultiLinePaste).toHaveBeenCalledWith({
+      lineCount: 2,
+      preview: 'echo one\necho two',
+    });
+  });
+
+  it('detects Windows PowerShell sessions that should delegate Ctrl+V to PSReadLine', () => {
+    expect(POWERSHELL_READLINE_PASTE_SEQUENCE).toBe('\x16');
+    expect(shouldUsePowerShellReadlinePaste('PowerShell', { isWindowsClient: true })).toBe(true);
+    expect(shouldUsePowerShellReadlinePaste('pwsh', { isWindowsClient: true })).toBe(true);
+    expect(shouldUsePowerShellReadlinePaste('PowerShellCore', { isWindowsClient: true })).toBe(true);
+    expect(shouldUsePowerShellReadlinePaste('Bash', { isWindowsClient: true })).toBe(false);
+    expect(shouldUsePowerShellReadlinePaste('PowerShell', { isWindowsClient: false })).toBe(false);
+  });
+});

--- a/src/web-ui/src/tools/terminal/utils/terminalPaste.ts
+++ b/src/web-ui/src/tools/terminal/utils/terminalPaste.ts
@@ -1,0 +1,182 @@
+import { confirmDialogChoice } from '@/component-library';
+import { i18nService } from '@/infrastructure/i18n';
+
+export type TerminalPasteWarningMode = 'auto' | 'always' | 'never';
+
+export interface TerminalPasteConfirmationRequest {
+  lineCount: number;
+  preview: string;
+}
+
+export type TerminalPasteConfirmationResult = 'paste' | 'pasteAsSingleLine' | 'cancel';
+
+export interface TerminalPasteOptions {
+  bracketedPasteMode?: boolean;
+  warningMode?: TerminalPasteWarningMode;
+  confirmMultiLinePaste?: (
+    request: TerminalPasteConfirmationRequest,
+  ) => Promise<TerminalPasteConfirmationResult> | TerminalPasteConfirmationResult;
+}
+
+export type TerminalPasteDecision =
+  | { allow: true; text: string }
+  | { allow: false };
+
+export interface TerminalPasteAnalysis {
+  shouldConfirm: boolean;
+  lineCount: number;
+  preview: string;
+  text: string;
+}
+
+const DEFAULT_WARNING_MODE: TerminalPasteWarningMode = 'auto';
+const PREVIEW_LINE_COUNT = 3;
+const PREVIEW_LINE_MAX_LENGTH = 30;
+export const POWERSHELL_READLINE_PASTE_SEQUENCE = '\x16';
+
+export function isWindowsClientPlatform(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  const platform = navigator.platform ?? '';
+  const userAgent = navigator.userAgent ?? '';
+  return /\bWin/i.test(platform) || /\bWindows\b/i.test(userAgent);
+}
+
+export function isPowerShellShellType(shellType: string | undefined | null): boolean {
+  const normalized = shellType?.trim().toLowerCase() ?? '';
+  return normalized === 'powershell'
+    || normalized === 'powershellcore'
+    || normalized === 'pwsh'
+    || normalized === 'windows powershell'
+    || normalized === 'powershell 7';
+}
+
+export function shouldUsePowerShellReadlinePaste(
+  shellType: string | undefined | null,
+  options: { isWindowsClient?: boolean } = {},
+): boolean {
+  return (options.isWindowsClient ?? isWindowsClientPlatform())
+    && isPowerShellShellType(shellType);
+}
+
+function splitPasteLines(text: string): string[] {
+  return text.split(/\r?\n/);
+}
+
+function truncatePreviewLine(line: string): string {
+  if (line.length <= PREVIEW_LINE_MAX_LENGTH) {
+    return line;
+  }
+
+  return `${line.slice(0, PREVIEW_LINE_MAX_LENGTH)}...`;
+}
+
+export function buildTerminalPastePreview(lines: string[]): string {
+  const previewLines = lines
+    .slice(0, PREVIEW_LINE_COUNT)
+    .map(truncatePreviewLine);
+
+  if (lines.length > PREVIEW_LINE_COUNT) {
+    previewLines.push('...');
+  }
+
+  return previewLines.join('\n');
+}
+
+export function analyzeTerminalPaste(
+  text: string,
+  options: Pick<TerminalPasteOptions, 'bracketedPasteMode' | 'warningMode'> = {},
+): TerminalPasteAnalysis {
+  const warningMode = options.warningMode ?? DEFAULT_WARNING_MODE;
+  const lines = splitPasteLines(text);
+  const lineCount = lines.length;
+
+  if (lineCount === 1 || warningMode === 'never') {
+    return {
+      shouldConfirm: false,
+      lineCount,
+      preview: buildTerminalPastePreview(lines),
+      text,
+    };
+  }
+
+  if (warningMode === 'auto') {
+    if (options.bracketedPasteMode) {
+      return {
+        shouldConfirm: false,
+        lineCount,
+        preview: buildTerminalPastePreview(lines),
+        text,
+      };
+    }
+
+    // Match VS Code's auto-mode safety behavior: a copied command with only a
+    // trailing blank line should paste for review without immediately running.
+    if (lineCount === 2 && lines[1].trim().length === 0) {
+      return {
+        shouldConfirm: false,
+        lineCount,
+        preview: buildTerminalPastePreview(lines),
+        text: lines[0],
+      };
+    }
+  }
+
+  return {
+    shouldConfirm: true,
+    lineCount,
+    preview: buildTerminalPastePreview(lines),
+    text,
+  };
+}
+
+export async function confirmTerminalMultiLinePaste(
+  request: TerminalPasteConfirmationRequest,
+): Promise<TerminalPasteConfirmationResult> {
+  const choice = await confirmDialogChoice({
+    title: i18nService.t('tools:terminal.pasteDialog.title'),
+    message: i18nService.t('tools:terminal.pasteDialog.message', {
+      lineCount: request.lineCount,
+    }),
+    type: 'warning',
+    confirmText: i18nService.t('tools:terminal.pasteDialog.confirm'),
+    secondaryText: i18nService.t('tools:terminal.pasteDialog.pasteAsOneLine'),
+    cancelText: i18nService.t('tools:terminal.pasteDialog.cancel'),
+    preview: request.preview,
+    previewMaxHeight: 150,
+  });
+
+  if (choice === 'secondary') {
+    return 'pasteAsSingleLine';
+  }
+
+  return choice === 'confirm' ? 'paste' : 'cancel';
+}
+
+export async function resolveTerminalPaste(
+  text: string,
+  options: TerminalPasteOptions = {},
+): Promise<TerminalPasteDecision> {
+  const analysis = analyzeTerminalPaste(text, options);
+
+  if (!analysis.shouldConfirm) {
+    return { allow: true, text: analysis.text };
+  }
+
+  const confirmation = await (options.confirmMultiLinePaste ?? confirmTerminalMultiLinePaste)({
+    lineCount: analysis.lineCount,
+    preview: analysis.preview,
+  });
+
+  if (confirmation === 'cancel') {
+    return { allow: false };
+  }
+
+  if (confirmation === 'pasteAsSingleLine') {
+    return { allow: true, text: analysis.text.replace(/\r?\n/g, '') };
+  }
+
+  return { allow: true, text: analysis.text };
+}


### PR DESCRIPTION
## Summary

Align terminal paste handling with VS Code-style behavior in the Web UI terminal.

This adds a shared terminal paste policy, routes terminal paste paths through xterm paste handling, supports PowerShell-native Ctrl+V delegation on Windows, and adds a secondary "paste as one line" action for multi-line paste confirmations. It also localizes the paste warning dialog and cleans up the preview styling.

Fixes #

## Type and Areas

Type:

Feature / UI/UX / test

Areas:

web UI, terminal, component library, i18n

## Motivation / Impact

This improves terminal paste behavior so it is closer to VS Code:

- bracketed paste mode can accept multi-line paste without an extra confirmation
- single commands copied with a trailing newline are pasted for review instead of executing immediately
- PowerShell / pwsh on Windows receives Ctrl+V through PSReadLine, matching shell-native behavior
- multi-line paste warnings now offer a "Paste as one line" option
- terminal paste dialog strings are available in en-US, zh-CN, and zh-TW
- the paste preview area no longer appears with a double border

## Verification

- `pnpm --dir src/web-ui run test:run src/tools/terminal/utils/terminalPaste.test.ts`
  - Passed: 1 test file, 8 tests
- `pnpm run type-check:web`
  - Passed
- `pnpm run i18n:audit`
  - Passed with 0 warnings

## Reviewer Notes

The confirm dialog service keeps the existing boolean confirmation API and adds a choice-returning API for dialogs that need a secondary action.

Terminal paste behavior is centralized in `terminalPaste.ts` so keyboard paste, native paste, and terminal action-manager paste can share the same policy.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.