### PR TITLE
feat(computer-use): add describe_screen for text-only desktop automation

### DIFF
--- a/src/apps/desktop/src/computer_use/macos_ax_ui.rs
+++ b/src/apps/desktop/src/computer_use/macos_ax_ui.rs
@@ -318,14 +318,6 @@ impl CandidateMatch {
             score += 20;
         }
 
-        // WeChat (and similar): global search field is often the first AXTextField match but is the wrong target
-        // when the user wants the **chat composer**. Deprioritize known search chrome.
-        if let Some(ref id) = self.identifier {
-            if id.contains("_SC_SEARCH_FIELD") {
-                score -= 1500;
-            }
-        }
-
         // Among text inputs, the composer is usually **lower** on screen than the top search bar.
         let rl = self.role.to_lowercase();
         if rl.contains("textfield") || rl.contains("textarea") {
@@ -719,7 +711,7 @@ pub fn locate_ui_element_center(
 
     if candidates.is_empty() {
         return Err(BitFunError::tool(
-            "No accessibility element matched in the frontmost app. Tips: `role_substring` **`TextArea`** also matches **`AXTextField`** (WeChat compose is often TextField). Use `filter_combine: \"any\"` for OR matching; match UI language; ensure the target app is focused. For chat apps, if the conversation is already open, **`type_text`** may work without clicking. Or use `move_to_text` / `screenshot`."
+            "No accessibility element matched in the frontmost app. Tips: `role_substring` **`TextArea`** also matches **`AXTextField`**; use `text_contains` for any visible label; use `filter_combine: \"any\"` for OR matching; match the UI language; ensure the target app is focused. If the AX tree is sparse, fall back to `move_to_text` (OCR) or `describe_screen` / `screenshot` to observe, or `key_chord` keyboard navigation."
                 .to_string(),
         ));
     }
@@ -1223,4 +1215,83 @@ unsafe fn first_ax_window_from_ax_windows(app: AXUIElementRef) -> Option<AXUIEle
         ax_release(retained as CFTypeRef);
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    fn module_source() -> String {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/computer_use/macos_ax_ui.rs");
+        let mut src = String::new();
+        std::fs::File::open(&path)
+            .unwrap()
+            .read_to_string(&mut src)
+            .unwrap();
+        src
+    }
+
+    /// Extract the body of `fn rank_score` (the AX candidate scoring logic),
+    /// by brace-matching the function body.
+    fn rank_score_body(src: &str) -> &str {
+        let sig = src.find("fn rank_score").expect("rank_score present");
+        let open = src[sig..].find('{').expect("rank_score body open brace") + sig;
+        let mut depth: i32 = 0;
+        let mut end = open;
+        for (i, b) in src[open..].char_indices() {
+            match b {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = open + i;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        &src[open + 1..end]
+    }
+
+    /// Guard against regressing special-case, app-specific adaptations in the AX
+    /// ranking logic. A prior WeChat-private hack inspected the `identifier`
+    /// field for a vendor prefix and applied a hardcoded score penalty. It must
+    /// not come back: AX ranking stays generic (role, visibility, size, depth,
+    /// screen position) and app-specific disambiguation is left to the model via
+    /// `describe_screen` / `get_app_state`.
+    #[test]
+    fn ax_ranking_does_not_branch_on_identifier() {
+        let src = module_source();
+        let body = rank_score_body(&src);
+        assert!(
+            !body.contains("identifier"),
+            "rank_score must not branch on the AX `identifier` field — that invites app-specific hacks. Got: {}",
+            body
+        );
+    }
+
+    /// The "no AX element matched" error must stay model-neutral and app-agnostic:
+    /// no WeChat / chat-app specific guidance baked into a generic locate failure.
+    #[test]
+    fn no_match_error_is_app_agnostic() {
+        let src = module_source();
+        // The error string lives outside the test module, so scoping to the
+        // pre-`#[cfg(test)]` slice keeps the assertion self-contained.
+        let scope_end = src.find("#[cfg(test)]").unwrap_or(src.len());
+        let scope = &src[..scope_end];
+        let err_start = scope
+            .find("No accessibility element matched in the frontmost app")
+            .expect("no-match error string present");
+        let err_end = scope[err_start..]
+            .find('\n')
+            .unwrap_or(scope.len() - err_start);
+        let err = &scope[err_start..err_start + err_end];
+        assert!(
+            !err.contains("WeChat") && !err.contains("chat app"),
+            "no-match error must not name a specific app/category: {}",
+            err
+        );
+    }
 }

--- a/src/crates/assembly/core/src/agentic/agents/prompts/computer_use_mode.md
+++ b/src/crates/assembly/core/src/agentic/agents/prompts/computer_use_mode.md
@@ -55,6 +55,16 @@ When mouse is required, prefer accessibility or OCR targets over guessed coordin
 
 If the same GUI tactic fails twice, switch strategy: use keyboard navigation, app state, OCR, browser automation, scripts, or ask the user for the missing context.
 
+# Text-Only Operation (when the primary model cannot view screenshots)
+
+When Runtime Context indicates the primary model does not support image understanding, the `screenshot` action returns no image (`screenshot_unavailable: true`). Do NOT retry `screenshot` and do NOT call it to verify — it cannot help you see. Instead:
+
+- **Observe with `describe_screen`** — it returns a text snapshot (frontmost app, `ax_tree_text` with `node_idx`s, `ui_tree_text`, pointer, displays) with no image. This is your eyes. Call it before acting when state is unknown, and after an action to verify `ax_state_digest` changed.
+- **Target with AX / OCR, never guessed coordinates** — `click_element`/`app_click` with `node_idx`/`text_contains`/`title_contains`/`role_substring`; `move_to_text`/`click_target` with `target_text` (+ `move_to_text_match_index` when several OCR hits are returned as text candidates).
+- **Prefer keyboard** — `key_chord` shortcuts (command+F search, Tab/Shift+Tab focus, Return confirm, Escape cancel) and `paste` (clipboard) for CJK / long text before `type_text`.
+- **Drive hard-to-reach apps directly** — `run_apple_script` (macOS) for messaging/desktop apps whose AX tree is sparse.
+- If an AX/OCR target keeps failing twice, switch tactic immediately (different `node_idx`, different text needle, keyboard, or AppleScript). A recovery hint may tell you to "run screenshot" only when the model supports images — in text-only mode ignore that and use `describe_screen` + the alternatives above instead.
+
 # Browser Work
 
 For websites and web apps, prefer `ControlHub` with `domain: "browser"` so cookies, login state, and extensions are preserved. Do not drive browser content through desktop screenshots when browser-domain controls are available.

--- a/src/crates/assembly/core/src/agentic/tools/implementations/computer_use_actions.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/computer_use_actions.rs
@@ -33,6 +33,7 @@ fn loop_tracker_observe(
     target_sig: &str,
     before_digest: &str,
     after_digest: &str,
+    text_only: bool,
 ) -> Option<String> {
     let pid = pid?;
     // A digest change means the action mutated the tree — that is real
@@ -57,9 +58,24 @@ fn loop_tracker_observe(
         *entry = (sig, before_digest.to_string(), 1);
     }
     if entry.2 >= 2 {
+        // The primary model cannot consume screenshot images, so the classic
+        // "just take a screenshot to see what's wrong" recovery is **not**
+        // available — pointing the model at `screenshot` here would send it
+        // into a hard-reject loop (the `screenshot` action is gated to
+        // multimodal providers). Route it to the text-only observation +
+        // targeting fallbacks instead so the agent always has a live path.
+        let recovery = if text_only {
+            "NEXT TURN you MUST switch tactic (do NOT call `screenshot` — the primary model is text-only and that action is rejected): \
+             (1) re-run `get_app_state` for the frontmost app and pick a different `node_idx` (or `text_contains` / `title_contains` / `role_substring`), \
+             (2) locate the visible text with `move_to_text` + `move_to_text_match_index`, or `click_target` with `target_text`, \
+             (3) drive the app with `key_chord` shortcuts (e.g. command+F search, Tab focus, Return confirm), \
+             (4) for messaging apps use `paste` (clipboard) + `key_chord` to submit, or `run_apple_script` (macOS) to drive the app directly."
+        } else {
+            "NEXT TURN you MUST: (1) run `desktop.screenshot { screenshot_window: false }` to see the full display, (2) switch tactic — different `node_idx`, different `ocr_text` needle, or a keyboard shortcut."
+        };
         Some(format!(
-            "Detected {} consecutive `{}` calls on the same target ({}) without any AX tree mutation (digest unchanged). The target is almost certainly invisible / disabled / in a Canvas-WebGL surface that AX cannot describe. NEXT TURN you MUST: (1) run `desktop.screenshot {{ screenshot_window: false }}` to see the full display, (2) switch tactic — different `node_idx`, different `ocr_text` needle, or a keyboard shortcut.",
-            entry.2, action, target_sig
+            "Detected {} consecutive `{}` calls on the same target ({}) without any AX tree mutation (digest unchanged). The target is almost certainly invisible / disabled / in a Canvas-WebGL surface that AX cannot describe. {}",
+            entry.2, action, target_sig, recovery
         ))
     } else {
         None
@@ -315,7 +331,10 @@ impl ComputerUseActions {
             | "interactive_scroll"
             | "build_visual_mark_view"
             | "visual_click" => {
-                return self.handle_desktop_ax(host, action, params).await;
+                let text_only = !context.primary_model_supports_image_understanding();
+                return self
+                    .handle_desktop_ax(host, action, params, text_only)
+                    .await;
             }
             "focus_display" => {
                 // Accept `null` (or omitted `display_id`) to clear the pin
@@ -395,6 +414,7 @@ impl ComputerUseActions {
         host: &ComputerUseHostRef,
         action: &str,
         params: &Value,
+        text_only: bool,
     ) -> BitFunResult<Vec<ToolResult>> {
         // ── Helpers ─────────────────────────────────────────────────
         fn parse_selector(v: &Value) -> BitFunResult<AppSelector> {
@@ -973,6 +993,7 @@ impl ComputerUseActions {
                         &target_sig,
                         before.as_deref().unwrap_or(""),
                         &after.digest,
+                        text_only,
                     );
                 }
 
@@ -1022,6 +1043,7 @@ impl ComputerUseActions {
                         &target_sig,
                         before.as_deref().unwrap_or(""),
                         &after.digest,
+                        text_only,
                     );
                 }
                 let data = json!({
@@ -2359,5 +2381,64 @@ async fn clipboard_write(text: &str) -> Result<(), String> {
     {
         let _ = text;
         Err("clipboard not implemented for this OS".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::loop_tracker_observe;
+
+    // A unique PID avoids interference with the shared APP_LOOP_TRACKER state
+    // across tests in the same process.
+    const TEXT_ONLY_PID: i32 = 9_999_001;
+    const VISUAL_PID: i32 = 9_999_002;
+
+    fn first_warning(text_only: bool, pid: i32) -> String {
+        // First call seeds (count=1, no warning). Second consecutive identical
+        // (unchanged digest) call trips the guard (count>=2) and returns the hint.
+        let _ = loop_tracker_observe(Some(pid), "app_click", "[1]", "d0", "d0", text_only);
+        loop_tracker_observe(Some(pid), "app_click", "[1]", "d0", "d0", text_only)
+            .expect("second consecutive no-progress call should warn")
+    }
+
+    /// Text-only recovery hint must NOT send the model to `screenshot` (that
+    /// action is hard-rejected for text-only models and would loop forever).
+    #[test]
+    fn text_only_loop_warning_never_points_at_screenshot() {
+        let warning = first_warning(true, TEXT_ONLY_PID);
+        assert!(
+            !warning.contains("desktop.screenshot") && !warning.contains("run `screenshot`"),
+            "text-only loop warning must not tell the model to screenshot: {}",
+            warning
+        );
+        assert!(
+            warning.contains("describe_screen")
+                || warning.contains("get_app_state")
+                || warning.contains("move_to_text")
+                || warning.contains("key_chord"),
+            "text-only loop warning should offer a text-only recovery path: {}",
+            warning
+        );
+    }
+
+    /// Visual-capable models keep the classic screenshot recovery hint.
+    #[test]
+    fn visual_loop_warning_keeps_screenshot_recovery() {
+        let warning = first_warning(false, VISUAL_PID);
+        assert!(
+            warning.contains("screenshot"),
+            "visual loop warning should still offer screenshot recovery: {}",
+            warning
+        );
+    }
+
+    /// A genuine tree mutation (digest changes) must NOT trigger the warning,
+    /// even on the same target — progress resets the streak.
+    #[test]
+    fn progressed_action_does_not_warn() {
+        let pid = 9_999_003;
+        let _ = loop_tracker_observe(Some(pid), "app_click", "[2]", "d0", "d1", true);
+        let second = loop_tracker_observe(Some(pid), "app_click", "[2]", "d1", "d2", true);
+        assert!(second.is_none(), "digest change = progress, no warning");
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/computer_use_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/computer_use_tool.rs
@@ -3,7 +3,7 @@
 use super::computer_use_locate::execute_computer_use_locate;
 use crate::agentic::tools::computer_use_capability::computer_use_desktop_available;
 use crate::agentic::tools::computer_use_host::{
-    ComputerScreenshot, ComputerUseHost, ComputerUseNavigateQuadrant,
+    AppSelector, ComputerScreenshot, ComputerUseHost, ComputerUseNavigateQuadrant,
     ComputerUseScreenshotRefinement, OcrRegionNative, ScreenshotCropCenter, UiElementLocateQuery,
 };
 use crate::agentic::tools::computer_use_optimizer::hash_screenshot_bytes;
@@ -103,6 +103,7 @@ impl ComputerUseTool {
         format!(
             "Desktop automation (host OS: {}). {} \
 The **primary model cannot consume images** in tool results — **do not** use **`screenshot`**.\n\
+**OBSERVE & VERIFY (text-only):** Use **`describe_screen`** as your eyes — it returns a text snapshot (frontmost app + AX tree `ax_tree_text` with `node_idx`s + `ui_tree_text` + pointer) with NO image. Call it before acting when UI state is unknown, and after an action to verify the `ax_state_digest` changed. This replaces the `screenshot` observe→act→verify loop for text-only models.\n\
 **ACTION PRIORITY (CRITICAL):** Always think in this order:\n\
 1. **Terminal/CLI/System commands first** — Use Bash tool for terminal commands, system scripts (e.g., macOS `osascript`), shell automation. Most efficient.\n\
 2. **Keyboard shortcuts second** — Use **`key_chord`** / **`type_text`** for system/app shortcuts, navigation keys.\n\
@@ -144,8 +145,8 @@ The **primary model cannot consume images** in tool results — **do not** use *
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["click_target", "move_to_target", "click_element", "move_to_text", "click", "mouse_move", "scroll", "drag", "locate", "key_chord", "type_text", "pointer_move_rel", "wait", "list_displays", "focus_display", "paste", "list_apps", "get_app_state", "app_click", "app_type_text", "app_scroll", "app_key_chord", "app_wait_for", "build_interactive_view", "interactive_click", "interactive_type_text", "interactive_scroll", "build_visual_mark_view", "visual_click", "open_app", "open_url", "open_file", "clipboard_get", "clipboard_set", "run_script", "run_apple_script", "get_os_info"],
-                    "description": "The action to perform. **Primary model is text-only — no `screenshot`.** **ACTION PRIORITY:** 1) Use Bash tool for CLI/terminal/system commands first. 2) **`open_app`** to launch apps. **`run_apple_script`** for AppleScript (macOS). 3) Prefer `key_chord` for shortcuts/navigation. 4) Only when above fail: `click_target` / `move_to_target` (AX → OCR → screen coords in one call), then lower-level `click_element`, `move_to_text`, or `mouse_move` + `click`. Never guess coordinates."
+                    "enum": ["click_target", "move_to_target", "click_element", "move_to_text", "click", "mouse_move", "scroll", "drag", "locate", "key_chord", "type_text", "pointer_move_rel", "wait", "list_displays", "focus_display", "paste", "list_apps", "get_app_state", "describe_screen", "app_click", "app_type_text", "app_scroll", "app_key_chord", "app_wait_for", "build_interactive_view", "interactive_click", "interactive_type_text", "interactive_scroll", "build_visual_mark_view", "visual_click", "open_app", "open_url", "open_file", "clipboard_get", "clipboard_set", "run_script", "run_apple_script", "get_os_info"],
+                    "description": "The action to perform. **Primary model is text-only — no `screenshot`.** **ACTION PRIORITY:** 1) Use Bash tool for CLI/terminal/system commands first. 2) **`open_app`** to launch apps. **`run_apple_script`** for AppleScript (macOS). 3) Prefer `key_chord` for shortcuts/navigation. 4) Only when above fail: `click_target` / `move_to_target` (AX → OCR → screen coords in one call), then lower-level `click_element`, `move_to_text`, or `mouse_move` + `click`. Never guess coordinates. **`describe_screen`** is the text-only equivalent of `screenshot`: it returns a structured text snapshot (frontmost app + AX tree + UI tree text + pointer + window geometry) with NO image — use it to observe and verify state when the primary model cannot view screenshots."
                 },
                 "x": { "type": "integer", "description": "For `mouse_move` and `drag`: X in **global display** units when **`use_screen_coordinates`: true** (required). **Not** for `click`." },
                 "y": { "type": "integer", "description": "For `mouse_move` and `drag`: Y in **global display** units when **`use_screen_coordinates`: true** (required). **Not** for `click`." },
@@ -369,6 +370,82 @@ The **primary model cannot consume images** in tool results — **do not** use *
             matches.len(),
         );
         Ok(vec![ToolResult::ok(body, Some(hint))])
+    }
+
+    /// Text-only observation action: returns a structured text snapshot of
+    /// the desktop (frontmost app + AX tree + condensed UI tree text +
+    /// pointer + displays) with **no image bytes**. This is the observe and
+    /// verify step that closes the cowork loop for text-only primary models
+    /// that cannot consume `screenshot` JPEGs.
+    async fn describe_screen(
+        host: &dyn ComputerUseHost,
+        _input: &Value,
+    ) -> BitFunResult<Vec<ToolResult>> {
+        let session_snap = host.computer_use_session_snapshot().await;
+        let interaction = host.computer_use_interaction_state();
+        let pointer = session_snap.pointer_global.clone();
+        let displays = interaction.displays.clone();
+
+        // Build a frontmost-app selector from the session snapshot. The AX
+        // tree (`get_app_state`) is the richest text signal; `enumerate_ui_tree_text`
+        // is a condensed fallback that also covers apps whose `get_app_state`
+        // AX dump is sparse (Canvas / WebView surfaces).
+        let selector = session_snap
+            .foreground_application
+            .as_ref()
+            .map(|fg| AppSelector {
+                name: fg.name.clone(),
+                bundle_id: fg.bundle_id.clone(),
+                pid: fg.process_id,
+            });
+
+        let mut ax_tree_text: Option<String> = None;
+        let mut ax_nodes_count: Option<usize> = None;
+        let mut ax_digest: Option<String> = None;
+        let mut window_title: Option<String> = None;
+        if let Some(app) = selector.as_ref() {
+            match host.get_app_state(app.clone(), 8, true).await {
+                Ok(snap) => {
+                    // Deliberately drop `snap.screenshot` (JPEG) — describe_screen
+                    // never returns image bytes so text-only models are safe.
+                    window_title = snap.window_title.clone();
+                    ax_nodes_count = Some(snap.nodes.len());
+                    ax_digest = Some(snap.digest.clone());
+                    ax_tree_text = Some(snap.tree_text).filter(|t| !t.trim().is_empty());
+                }
+                Err(e) => {
+                    debug!("describe_screen: get_app_state failed: {}", e);
+                }
+            }
+        }
+
+        let ui_tree_text = host.enumerate_ui_tree_text().await;
+
+        let mut body = json!({
+            "success": true,
+            "action": "describe_screen",
+            "image_bytes": false,
+            "foreground_application": session_snap.foreground_application,
+            "pointer_global": pointer,
+            "displays": displays,
+            "window_title": window_title,
+            "ax_tree_text": ax_tree_text,
+            "ax_nodes_count": ax_nodes_count,
+            "ax_state_digest": ax_digest,
+            "ui_tree_text": ui_tree_text,
+        });
+
+        let input_coords = json!({
+            "kind": "describe_screen",
+        });
+        body = computer_use_augment_result_json(host, body, Some(input_coords)).await;
+
+        // Guide the model to use the returned text fields as its "screen view":
+        // pick `node_idx` from `ax_tree_text` for `app_click`/`click_element`, or
+        // match visible text via `move_to_text`, and compare `ax_state_digest`
+        // before/after an action to verify a mutation.
+        let hint = "describe_screen: text snapshot returned (no image). Use `ax_tree_text` node indices for `app_click`/`click_element`, match visible text with `move_to_text`, and compare `ax_state_digest` across actions to verify state changes.";
+        Ok(vec![ToolResult::ok(body, Some(hint.to_string()))])
     }
 
     fn primary_api_format(ctx: &ToolUseContext) -> String {
@@ -1117,7 +1194,7 @@ impl Tool for ComputerUseTool {
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["screenshot", "click_target", "move_to_target", "click_element", "move_to_text", "click", "mouse_move", "scroll", "drag", "locate", "key_chord", "type_text", "pointer_move_rel", "wait", "list_displays", "focus_display", "paste", "list_apps", "get_app_state", "app_click", "app_type_text", "app_scroll", "app_key_chord", "app_wait_for", "build_interactive_view", "interactive_click", "interactive_type_text", "interactive_scroll", "build_visual_mark_view", "visual_click", "open_app", "open_url", "open_file", "clipboard_get", "clipboard_set", "run_script", "run_apple_script", "get_os_info"],
+                    "enum": ["screenshot", "describe_screen", "click_target", "move_to_target", "click_element", "move_to_text", "click", "mouse_move", "scroll", "drag", "locate", "key_chord", "type_text", "pointer_move_rel", "wait", "list_displays", "focus_display", "paste", "list_apps", "get_app_state", "app_click", "app_type_text", "app_scroll", "app_key_chord", "app_wait_for", "build_interactive_view", "interactive_click", "interactive_type_text", "interactive_scroll", "build_visual_mark_view", "visual_click", "open_app", "open_url", "open_file", "clipboard_get", "clipboard_set", "run_script", "run_apple_script", "get_os_info"],
                     "description": "The action to perform. **ACTION PRIORITY:** 1) Use Bash tool for CLI/terminal/system commands (most efficient). 2) **`open_app`** to launch apps by name. **`run_apple_script`** to run AppleScript (macOS). 3) Prefer **`key_chord`** for shortcuts/navigation keys over mouse. 4) Only when above fail: `click_target` / `move_to_target` (AX → OCR → screen coords in one call) before lower-level `click_element`, `move_to_text`, or `mouse_move` + `click`. **`screenshot`** is for observation/confirmation ONLY — never derive mouse coordinates from screenshots. `click` = press at **current pointer only** (no x/y params). `scroll` supports optional position (`scroll_x`/`scroll_y`). `type_text`, `drag`, `pointer_move_rel`, `wait`, `locate` = standard actions."
                 },
                 "x": { "type": "integer", "description": "For `mouse_move` and `drag`: X in **global display** units when **`use_screen_coordinates`: true** (required). **Not** for `click`." },
@@ -1282,6 +1359,15 @@ impl Tool for ComputerUseTool {
 
         match action {
             "locate" => execute_computer_use_locate(input, context).await,
+
+            // Text-only observation: the "eyes" of the desktop loop when the
+            // primary model cannot consume screenshot images. Returns a
+            // structured text snapshot (frontmost app + AX tree + UI tree text
+            // + pointer + displays) with NO image bytes. This is the observe and
+            // verify step that closes the cowork loop for text-only models.
+            "describe_screen" => {
+                return Self::describe_screen(host_ref, input).await;
+            }
 
             // Unified target resolver: AX first, OCR second, explicit screen
             // coordinates last. This is the preferred mouse path for common
@@ -1767,6 +1853,30 @@ impl Tool for ComputerUseTool {
             }
 
             "screenshot" => {
+                // Text-only soft gate: instead of hard-rejecting (which crashes
+                // the agent loop when a stale hint or the model itself asks for
+                // `screenshot`), return a success envelope that points the model
+                // at the text-only observe action. The model keeps its turn and
+                // switches to `describe_screen` / AX / OCR / keyboard tactics.
+                if !context.primary_model_supports_image_understanding() {
+                    let body = json!({
+                        "success": true,
+                        "action": "screenshot",
+                        "screenshot_unavailable": true,
+                        "reason": "primary_model_is_text_only",
+                        "instruction": "The primary model cannot consume image bytes, so `screenshot` produced nothing. Use `describe_screen` to observe the desktop as text (frontmost app + AX tree + UI tree text + pointer), then act with `click_target`/`click_element`/`move_to_text`/`key_chord`/`paste`. Never retry `screenshot`."
+                    });
+                    let input_coords = json!({ "kind": "screenshot", "text_only": true });
+                    let body =
+                        computer_use_augment_result_json(host_ref, body, Some(input_coords)).await;
+                    return Ok(vec![ToolResult::ok(
+                        body,
+                        Some(
+                            "screenshot unavailable (text-only model): use describe_screen to observe."
+                                .to_string(),
+                        ),
+                    )]);
+                }
                 Self::require_multimodal_tool_output_for_screenshot(context)?;
                 let (params, ignored_crop_for_quadrant) = parse_screenshot_params(input)?;
                 let crop_for_debug = params.crop_center;
@@ -2111,4 +2221,61 @@ fn req_i32(input: &Value, key: &str) -> BitFunResult<i32> {
         .and_then(|v| v.as_i64())
         .map(|v| v as i32)
         .ok_or_else(|| BitFunError::tool(format!("{} is required (integer)", key)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ComputerUseTool;
+    use crate::agentic::tools::framework::Tool;
+    use serde_json::Value;
+
+    fn action_enum(schema: &Value) -> Vec<String> {
+        schema
+            .get("properties")
+            .and_then(|p| p.get("action"))
+            .and_then(|a| a.get("enum"))
+            .and_then(|e| e.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Text-only schema must NOT advertise `screenshot` (hard-rejected at runtime)
+    /// but MUST advertise `describe_screen` (the text-only observe action).
+    #[test]
+    fn text_only_schema_omits_screenshot_and_offers_describe_screen() {
+        let schema = ComputerUseTool::input_schema_text_only();
+        let actions = action_enum(&schema);
+        assert!(
+            !actions.iter().any(|a| a == "screenshot"),
+            "text-only schema must not list `screenshot` — it is rejected for text-only models. Got: {:?}",
+            actions
+        );
+        assert!(
+            actions.iter().any(|a| a == "describe_screen"),
+            "text-only schema must list `describe_screen` as the observe action. Got: {:?}",
+            actions
+        );
+    }
+
+    /// Full (visual) schema keeps `screenshot` and also offers `describe_screen`.
+    #[test]
+    fn full_schema_keeps_screenshot_and_offers_describe_screen() {
+        let schema = ComputerUseTool::new().input_schema();
+        let actions = action_enum(&schema);
+        assert!(actions.iter().any(|a| a == "screenshot"));
+        assert!(actions.iter().any(|a| a == "describe_screen"));
+    }
+
+    /// Text-only tool description must steer the model to `describe_screen` and
+    /// away from `screenshot`.
+    #[test]
+    fn text_only_description_steers_to_describe_screen() {
+        let desc = ComputerUseTool::description_text_only();
+        assert!(desc.contains("describe_screen"));
+        assert!(desc.to_lowercase().contains("do not"));
+    }
 }


### PR DESCRIPTION
## Summary

- Add **`describe_screen`** as a text-only observe action that returns frontmost app, AX tree text, UI tree text, pointer, and display metadata without image bytes — enabling a full observe→act→verify loop for non-multimodal primary models.
- Soft-gate **`screenshot`** for text-only models (returns `screenshot_unavailable: true` with guidance) instead of hard-rejecting, and route loop-recovery hints to AX/OCR/keyboard/AppleScript tactics rather than screenshot.
- Remove WeChat-specific AX identifier penalty; keep AX ranking generic and add regression tests for app-agnostic error messages and schema behavior.

## Test plan

- [x] `cargo check -p bitfun-desktop -p bitfun-core`
- [x] `cargo test -p bitfun-core computer_use`
- [x] `cargo test -p bitfun-desktop macos_ax_ui`
- [ ] Manual: run computer-use agent with a text-only primary model and verify `describe_screen` observes UI state and actions can verify via `ax_state_digest`
- [ ] Manual: confirm multimodal models still use `screenshot` normally