### PR TITLE
fix(flow-chat): retry stale reused history hydration

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -26,6 +26,7 @@ import {
   dispatchHistorySessionOpenIntent,
   shouldShowHistorySessionOpenIntent,
 } from '@/flow_chat/services/sessionOpenIntent';
+import { recordHistorySessionDiagnosticEvent } from '@/flow_chat/services/historySessionDiagnostics';
 import { resolveSessionRelationship } from '@/flow_chat/utils/sessionMetadata';
 import {
   compareSessionsForNavStable,
@@ -616,7 +617,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   const lastHistoryOpenIntentRef = useRef<{ sessionId: string; atMs: number } | null>(null);
 
   const dispatchHistoryOpenIntentForSession = useCallback(
-    (session: Session): HistoryOpenIntentDispatchResult => {
+    (session: Session, source: 'pointerdown' | 'switch'): HistoryOpenIntentDispatchResult => {
       const sessionId = session.sessionId;
       if (
         sessionId === activeSessionId ||
@@ -634,11 +635,18 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
         lastIntent.sessionId === sessionId &&
         now - lastIntent.atMs < 250
       ) {
+        recordHistorySessionDiagnosticEvent(sessionId, 'history_open_intent_deduped', {
+          source,
+          ageMs: Math.round(now - lastIntent.atMs),
+        });
         return 'already-pending';
       }
 
       lastHistoryOpenIntentRef.current = { sessionId, atMs: now };
       dispatchHistorySessionOpenIntent(sessionId, getTitle(session));
+      recordHistorySessionDiagnosticEvent(sessionId, 'history_open_intent_source', {
+        source,
+      });
       return 'dispatched';
     },
     [activeSessionId, runningSessionIds],
@@ -650,7 +658,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
       try {
         const session = flowChatStore.getState().sessions.get(sessionId);
         const historyOpenIntentDispatch = session
-          ? dispatchHistoryOpenIntentForSession(session)
+          ? dispatchHistoryOpenIntentForSession(session, 'switch')
           : 'none';
         if (session && historyOpenIntentDispatch !== 'none') {
           flowChatManager.preloadHistoricalSessionForOpen(sessionId);
@@ -721,7 +729,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
         return;
       }
 
-      const historyOpenIntentDispatch = dispatchHistoryOpenIntentForSession(session);
+      const historyOpenIntentDispatch = dispatchHistoryOpenIntentForSession(session, 'pointerdown');
       if (historyOpenIntentDispatch !== 'none') {
         flowChatManager.preloadHistoricalSessionForOpen(session.sessionId);
       }

--- a/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
+++ b/src/web-ui/src/app/startup/startupPerformanceContract.test.ts
@@ -505,7 +505,7 @@ describe('startup performance contract', () => {
     expect(source).toContain("historyOpenIntentDispatch !== 'none'");
     expect(source).not.toContain('if (historyOpenIntentDispatched)');
     expect(pointerDownStart).toBeGreaterThan(switchStart);
-    expect(source.slice(pointerDownStart)).toContain('dispatchHistoryOpenIntentForSession(session)');
+    expect(source.slice(pointerDownStart)).toContain("dispatchHistoryOpenIntentForSession(session, 'pointerdown')");
     expect(intentSource).toContain('RECENT_HISTORY_OPEN_INTENT_MS');
     expect(intentSource).toContain('HISTORY_SESSION_OPEN_TRANSITION_MAX_MS');
     expect(intentSource).toContain('subscribeHistorySessionOpenTransition');

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -35,6 +35,11 @@ const virtualListActionClickMock = vi.hoisted(() => vi.fn());
 const startupTraceMock = vi.hoisted(() => ({
   markPhase: vi.fn(),
 }));
+const historySessionDiagnosticsMock = vi.hoisted(() => ({
+  beginHistorySessionDiagnostics: vi.fn(() => 'diag-1'),
+  recordHistorySessionDiagnosticEvent: vi.fn(),
+  warnHistorySessionLoadingLayerStalled: vi.fn(),
+}));
 const searchStateMock = vi.hoisted(() => ({
   searchQuery: '',
   onSearchChange: vi.fn(),
@@ -131,6 +136,8 @@ vi.mock('@/shared/utils/startupTrace', () => ({
   isRemoteTraceContext: () => false,
   startupTrace: startupTraceMock,
 }));
+
+vi.mock('../../services/historySessionDiagnostics', () => historySessionDiagnosticsMock);
 
 vi.mock('./FlowChatHeader', () => ({
   FlowChatHeader: (props: Record<string, unknown>) => {
@@ -255,6 +262,10 @@ describe('ModernFlowChatContainer historical empty state', () => {
     virtualListMock.pinTurnToTop.mockReturnValue(true);
     virtualListActionClickMock.mockReset();
     startupTraceMock.markPhase.mockReset();
+    historySessionDiagnosticsMock.beginHistorySessionDiagnostics.mockReset();
+    historySessionDiagnosticsMock.beginHistorySessionDiagnostics.mockReturnValue('diag-1');
+    historySessionDiagnosticsMock.recordHistorySessionDiagnosticEvent.mockReset();
+    historySessionDiagnosticsMock.warnHistorySessionLoadingLayerStalled.mockReset();
     agentApiMock.listBackgroundCommandActivities.mockClear();
     agentApiMock.listBackgroundCommandActivities.mockResolvedValue({ activities: [] });
     searchStateMock.searchQuery = '';
@@ -279,6 +290,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
     container?.remove();
     stateMocks.activeSession = null;
     clearHistorySessionOpenTransition();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -302,6 +314,45 @@ describe('ModernFlowChatContainer historical empty state', () => {
 
     expect(container.textContent).toContain('Loading saved session');
     expect(container.querySelector('[data-testid="welcome-panel"]')).toBeNull();
+  });
+
+  it('reports a stalled history loading layer after the diagnostic threshold', async () => {
+    vi.useFakeTimers();
+    stateMocks.activeSession = createSession({
+      sessionId: 'history-session',
+      historyState: 'metadata-only',
+      dialogTurns: [],
+    } as Partial<Session>);
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(container.textContent).toContain('Loading saved session');
+    expect(historySessionDiagnosticsMock.warnHistorySessionLoadingLayerStalled).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(799);
+    });
+
+    expect(historySessionDiagnosticsMock.warnHistorySessionLoadingLayerStalled).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    expect(historySessionDiagnosticsMock.warnHistorySessionLoadingLayerStalled).toHaveBeenCalledWith(
+      'history-session',
+      expect.objectContaining({
+        durationMs: 800,
+        historyState: 'metadata-only',
+        isHistorical: true,
+        isRemote: false,
+        activeSessionIdMatches: true,
+        hasRenderableContent: false,
+        dialogTurnCount: 0,
+      }),
+    );
   });
 
   it('does not show the new-session welcome while a restored session is waiting for virtual items', () => {

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -57,9 +57,14 @@ import { notificationService } from '@/shared/notification-system';
 import {
   clearHistorySessionOpenTransition,
   getHistorySessionOpenTransitionSnapshot,
+  hasRenderableSessionContent,
   HISTORY_SESSION_OPEN_INTENT_EVENT,
   type HistorySessionOpenIntentDetail,
 } from '../../services/sessionOpenIntent';
+import {
+  recordHistorySessionDiagnosticEvent,
+  warnHistorySessionLoadingLayerStalled,
+} from '../../services/historySessionDiagnostics';
 import {
   type BackgroundSubagentActivityItem,
 } from '../../utils/backgroundSubagentActivity';
@@ -94,6 +99,7 @@ type BackgroundCommandSummary = {
 
 const LATEST_TURN_AUTO_PIN_MAX_ATTEMPTS = 8;
 const HISTORY_INITIAL_CONTENT_PAINT_MAX_ATTEMPTS = 30;
+const HISTORY_LOADING_LAYER_STALL_WARN_MS = 800;
 const MOCK_BACKGROUND_ACTIVITIES_STORAGE_KEY = 'bitfun.flowChat.mockBackgroundActivities';
 
 const MOCK_BACKGROUND_SUBAGENTS: BackgroundSubagentSummary[] = [
@@ -522,6 +528,53 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     showHistoryOpenIntentOverlay;
   const showHistoryLoadingLayer =
     !showHistoryOpenIntentOverlay && !showFailedHistoryPlaceholder && showHistoryPlaceholder;
+  useEffect(() => {
+    if (!showHistoryLoadingLayer || !activeSession?.sessionId) {
+      return;
+    }
+
+    const sessionId = activeSession.sessionId;
+    recordHistorySessionDiagnosticEvent(sessionId, 'loading_layer_entered', {
+      historyState,
+      isHistorical: activeSession.isHistorical === true,
+      isRemote: isRemoteTraceContext(activeSession.remoteConnectionId, activeSession.remoteSshHost),
+      hasRenderableContent: hasRenderableSessionContent(activeSession),
+      dialogTurnCount: activeSession.dialogTurns.length,
+    });
+
+    const timeoutId = window.setTimeout(() => {
+      const latestState = flowChatStore.getState();
+      const latestSession = latestState.sessions.get(sessionId) ?? activeSession;
+      const activeSessionIdMatches = latestState.activeSessionId
+        ? latestState.activeSessionId === sessionId
+        : activeSession.sessionId === sessionId;
+
+      warnHistorySessionLoadingLayerStalled(sessionId, {
+        durationMs: HISTORY_LOADING_LAYER_STALL_WARN_MS,
+        historyState: latestSession.historyState,
+        isHistorical: latestSession.isHistorical === true,
+        isRemote: isRemoteTraceContext(latestSession.remoteConnectionId, latestSession.remoteSshHost),
+        activeSessionIdMatches,
+        hasRenderableContent: hasRenderableSessionContent(latestSession),
+        dialogTurnCount: latestSession.dialogTurns.length,
+        hasPendingHistoryCompletion,
+        hasDeferredHistoryProjection,
+      });
+    }, HISTORY_LOADING_LAYER_STALL_WARN_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      recordHistorySessionDiagnosticEvent(sessionId, 'loading_layer_exited', {
+        historyState,
+      });
+    };
+  }, [
+    activeSession,
+    hasDeferredHistoryProjection,
+    hasPendingHistoryCompletion,
+    historyState,
+    showHistoryLoadingLayer,
+  ]);
   const blockHistoryOverlayActivation = useCallback((event: React.SyntheticEvent<HTMLElement>) => {
     if (!showHistoryLoadingLayer && !shouldBlockHistoryTransitionInteraction) {
       return;

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
@@ -371,6 +371,122 @@ describe('SessionModule historical session coordination', () => {
     await load.promise;
   });
 
+  it('retries a reused preload that stale-skipped after explicit activation', async () => {
+    const stalePreload = createDeferred<void>();
+    const retryLoad = createDeferred<void>();
+    const { context, flowChatStore } = createContext(createSession());
+    context.pendingHistoryLoads.set('history-other', Promise.resolve());
+    persistenceMocks.touchSessionActivity.mockResolvedValue(undefined);
+    flowChatStore.loadSessionHistory
+      .mockReturnValueOnce(stalePreload.promise)
+      .mockImplementationOnce(async () => {
+        await retryLoad.promise;
+        flowChatStore.setState((prev: any) => {
+          const session = prev.sessions.get('history-1');
+          return {
+            ...prev,
+            sessions: new Map(prev.sessions).set('history-1', {
+              ...session,
+              isHistorical: false,
+              historyState: 'ready',
+              dialogTurns: [{
+                id: 'turn-1',
+                userMessage: { id: 'user-1', content: 'Restored prompt', timestamp: 1 },
+                modelRounds: [],
+                status: 'completed',
+              }],
+            }),
+          };
+        });
+      });
+
+    preloadHistoricalSessionForOpen(context, 'history-1');
+    await Promise.resolve();
+
+    expect(flowChatStore.loadSessionHistory).toHaveBeenCalledTimes(1);
+
+    dispatchHistorySessionOpenIntent('history-1', 'Saved session');
+    const switching = switchChatSession(context, 'history-1');
+    await Promise.resolve();
+
+    expect(flowChatStore.switchSession).toHaveBeenCalledWith('history-1');
+
+    stalePreload.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(flowChatStore.loadSessionHistory).toHaveBeenCalledTimes(2);
+
+    retryLoad.resolve();
+    await switching;
+
+    expect(context.flowChatStore.getState().sessions.get('history-1')).toMatchObject({
+      isHistorical: false,
+      historyState: 'ready',
+    });
+  });
+
+  it('does not retry a reused stale preload after a newer switch request supersedes it', async () => {
+    const stalePreload = createDeferred<void>();
+    const newerSwitchLoad = createDeferred<void>();
+    const { context, flowChatStore } = createContext(createSession());
+    context.pendingHistoryLoads.set('history-other', Promise.resolve());
+    flowChatStore.setState((prev: any) => ({
+      ...prev,
+      sessions: new Map(prev.sessions).set('history-2', createSession({
+        sessionId: 'history-2',
+        title: 'Newer target',
+      })),
+    }));
+    persistenceMocks.touchSessionActivity.mockResolvedValue(undefined);
+    flowChatStore.loadSessionHistory
+      .mockReturnValueOnce(stalePreload.promise)
+      .mockImplementationOnce(async () => {
+        await newerSwitchLoad.promise;
+        flowChatStore.setState((prev: any) => {
+          const session = prev.sessions.get('history-2');
+          return {
+            ...prev,
+            sessions: new Map(prev.sessions).set('history-2', {
+              ...session,
+              isHistorical: false,
+              historyState: 'ready',
+              dialogTurns: [{
+                id: 'turn-2',
+                userMessage: { id: 'user-2', content: 'Newer prompt', timestamp: 1 },
+                modelRounds: [],
+                status: 'completed',
+              }],
+            }),
+          };
+        });
+      });
+
+    preloadHistoricalSessionForOpen(context, 'history-1');
+    await Promise.resolve();
+
+    dispatchHistorySessionOpenIntent('history-1', 'Saved session');
+    const firstSwitch = switchChatSession(context, 'history-1');
+    await Promise.resolve();
+    expect(flowChatStore.switchSession).toHaveBeenCalledWith('history-1');
+
+    const secondSwitch = switchChatSession(context, 'history-2');
+    await Promise.resolve();
+    expect(flowChatStore.loadSessionHistory).toHaveBeenCalledTimes(2);
+
+    stalePreload.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(flowChatStore.loadSessionHistory).toHaveBeenCalledTimes(2);
+
+    newerSwitchLoad.resolve();
+    await firstSwitch;
+    await secondSwitch;
+
+    expect(flowChatStore.switchSession).toHaveBeenLastCalledWith('history-2');
+  });
+
   it('does not preload standalone historical opens before the transition shield paints', () => {
     const { context, flowChatStore } = createContext(createSession());
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -30,6 +30,11 @@ import {
   hasRenderableSessionContent,
 } from '../sessionOpenIntent';
 import {
+  clearHistorySessionHydratePending,
+  markHistorySessionHydratePending,
+  recordHistorySessionDiagnosticEvent,
+} from '../historySessionDiagnostics';
+import {
   DEFAULT_CHAT_INPUT_MODE_CONFIG_PATH,
   normalizeUserDefaultChatInputModeId,
 } from '../../utils/chatInputMode';
@@ -132,12 +137,45 @@ const resolveEffectiveSshHost = (
 async function hydrateHistoricalSession(
   context: FlowChatContext,
   sessionId: string,
-  notifyOnError: boolean
+  notifyOnError: boolean,
+  options?: {
+    isRetryStillRelevant?: () => boolean;
+    retryActiveStaleReuse?: boolean;
+  },
 ): Promise<void> {
   const existing = context.pendingHistoryLoads.get(sessionId);
   if (existing) {
     startupTrace.markPhase('historical_session_hydrate_reused');
+    recordHistorySessionDiagnosticEvent(sessionId, 'hydrate_reused_pending', {
+      notifyOnError,
+      retryActiveStaleReuse: options?.retryActiveStaleReuse === true,
+    });
     await existing;
+    const retryStillRelevant = options?.isRetryStillRelevant?.() !== false;
+    const shouldRetryActiveStale = shouldRetryActiveStaleHydrate(context, sessionId);
+    recordHistorySessionDiagnosticEvent(sessionId, 'hydrate_reused_settled', {
+      retryActiveStaleReuse: options?.retryActiveStaleReuse === true,
+      retryStillRelevant,
+      shouldRetryActiveStale,
+    });
+    if (
+      options?.retryActiveStaleReuse === true &&
+      retryStillRelevant &&
+      shouldRetryActiveStale
+    ) {
+      if (context.pendingHistoryLoads.get(sessionId) === existing) {
+        context.pendingHistoryLoads.delete(sessionId);
+      }
+      startupTrace.markPhase('historical_session_hydrate_retry_active_stale_reuse', {
+        sessionId,
+      });
+      recordHistorySessionDiagnosticEvent(sessionId, 'hydrate_retry_active_stale_reuse_started');
+      await hydrateHistoricalSession(context, sessionId, notifyOnError);
+    } else if (options?.retryActiveStaleReuse === true) {
+      recordHistorySessionDiagnosticEvent(sessionId, 'hydrate_retry_active_stale_reuse_skipped', {
+        reason: retryStillRelevant ? 'active_stale_condition_not_met' : 'switch_superseded',
+      });
+    }
     return;
   }
   const traceStartedAt = nowMs();
@@ -145,12 +183,25 @@ async function hydrateHistoricalSession(
   const loadPromise = (async () => {
     const session = context.flowChatStore.getState().sessions.get(sessionId);
     if (!session?.isHistorical) {
+      recordHistorySessionDiagnosticEvent(sessionId, 'hydrate_request_skipped', {
+        reason: session ? 'not_historical' : 'missing_session',
+      });
       return;
     }
 
     const workspacePath = requireSessionWorkspacePath(session.workspacePath, sessionId);
     const remote = isRemoteTraceContext(session.remoteConnectionId, session.remoteSshHost);
+    markHistorySessionHydratePending(sessionId, {
+      notifyOnError,
+      remote,
+      deferFullHistoryUntilActive: true,
+    });
     startupTrace.markPhase('historical_session_hydrate_request', { remote });
+    recordHistorySessionDiagnosticEvent(sessionId, 'hydrate_request_started', {
+      remote,
+      historyState: session.historyState,
+      hasRenderableContent: hasRenderableSessionContent(session),
+    });
 
     // Prefer the current workspace's connection info over the session's
     // stored values.  When the user changes the SSH port the session's
@@ -181,10 +232,12 @@ async function hydrateHistoricalSession(
 
   try {
     await loadPromise;
+    recordHistorySessionDiagnosticEvent(sessionId, 'hydrate_request_finished');
     startupTrace.markPhase('historical_session_hydrate_request_end', {
       durationMs: elapsedMs(traceStartedAt),
     });
   } catch (error) {
+    recordHistorySessionDiagnosticEvent(sessionId, 'hydrate_request_failed');
     startupTrace.markPhase('historical_session_hydrate_request_failed', {
       durationMs: elapsedMs(traceStartedAt),
     });
@@ -196,6 +249,9 @@ async function hydrateHistoricalSession(
     }
     throw error;
   } finally {
+    clearHistorySessionHydratePending(sessionId, 'settled', {
+      pendingStillCurrent: context.pendingHistoryLoads.get(sessionId) === loadPromise,
+    });
     if (context.pendingHistoryLoads.get(sessionId) === loadPromise) {
       context.pendingHistoryLoads.delete(sessionId);
     }
@@ -210,6 +266,20 @@ function shouldHydrateHistoricalSessionBeforeSwitch(session: Session | undefined
     return false;
   }
   return !hasRenderableSessionContent(session);
+}
+
+function shouldRetryActiveStaleHydrate(context: FlowChatContext, sessionId: string): boolean {
+  const state = context.flowChatStore.getState();
+  if (state.activeSessionId !== sessionId) {
+    return false;
+  }
+
+  const session = state.sessions.get(sessionId);
+  if (!session || session.historyState !== 'metadata-only') {
+    return false;
+  }
+
+  return shouldHydrateHistoricalSessionBeforeSwitch(session);
 }
 
 export function preloadHistoricalSessionForOpen(
@@ -570,6 +640,15 @@ export async function switchChatSession(
     const shouldActivateBeforeHydrate =
       shouldHydrateBeforeSwitch &&
       consumeRecentHistorySessionOpenIntent(sessionId);
+    recordHistorySessionDiagnosticEvent(sessionId, 'switch_requested', {
+      switchRequestId,
+      isRemoteSession,
+      isHistorical: session?.isHistorical === true,
+      historyState: session?.historyState,
+      hasRenderableContent: session ? hasRenderableSessionContent(session) : false,
+      shouldHydrateBeforeSwitch,
+      shouldActivateBeforeHydrate,
+    });
 
     const touchActiveSessionInBackground = () => {
       scheduleSessionActivityTouch(() => {
@@ -591,6 +670,9 @@ export async function switchChatSession(
 
     if (shouldActivateBeforeHydrate) {
       context.flowChatStore.switchSession(sessionId);
+      recordHistorySessionDiagnosticEvent(sessionId, 'switch_activated_before_hydrate', {
+        switchRequestId,
+      });
       startupTrace.markPhase('historical_session_switch', {
         historical: true,
         remote: false,
@@ -601,13 +683,20 @@ export async function switchChatSession(
 
     if (shouldHydrateBeforeSwitch) {
       try {
-        await hydrateHistoricalSession(context, sessionId, true);
+        await hydrateHistoricalSession(context, sessionId, true, {
+          isRetryStillRelevant: () => switchRequestId === latestSwitchRequestId,
+          retryActiveStaleReuse: shouldActivateBeforeHydrate,
+        });
       } catch {
         // The hydrate path already marks the session failed and notifies the user.
         // Continue with activation so the failed state is visible.
       }
 
       if (switchRequestId !== latestSwitchRequestId) {
+        recordHistorySessionDiagnosticEvent(sessionId, 'switch_superseded', {
+          switchRequestId,
+          latestSwitchRequestId,
+        });
         startupTrace.markPhase('historical_session_switch_superseded', {
           sessionId,
         });
@@ -622,6 +711,10 @@ export async function switchChatSession(
     // flashing while the old large session is unmounted immediately.
     if (!shouldActivateBeforeHydrate) {
       context.flowChatStore.switchSession(sessionId);
+      recordHistorySessionDiagnosticEvent(sessionId, 'switch_activated_after_hydrate', {
+        switchRequestId,
+        shouldHydrateBeforeSwitch,
+      });
       startupTrace.markPhase('historical_session_switch', {
         historical: Boolean(session?.isHistorical),
         remote: isRemoteSession,
@@ -632,6 +725,9 @@ export async function switchChatSession(
 
     if (session?.isHistorical && !shouldHydrateBeforeSwitch) {
       // Load history in the background — do not block the UI.
+      recordHistorySessionDiagnosticEvent(sessionId, 'switch_background_hydrate_started', {
+        switchRequestId,
+      });
       void hydrateHistoricalSession(context, sessionId, true);
     }
   } catch (error) {

--- a/src/web-ui/src/flow_chat/services/historySessionDiagnostics.test.ts
+++ b/src/web-ui/src/flow_chat/services/historySessionDiagnostics.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  beginHistorySessionDiagnostics,
+  recordHistorySessionDiagnosticEvent,
+  resetHistorySessionDiagnosticsForTests,
+  warnHistorySessionLoadingLayerStalled,
+} from './historySessionDiagnostics';
+
+const loggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => loggerMock,
+}));
+
+describe('historySessionDiagnostics', () => {
+  beforeEach(() => {
+    loggerMock.debug.mockReset();
+    loggerMock.warn.mockReset();
+    resetHistorySessionDiagnosticsForTests();
+  });
+
+  it('logs a stalled loading layer as bounded grouped warnings once', () => {
+    const diagnosticId = beginHistorySessionDiagnostics('history-1', 'open_intent', {
+      source: 'pointerdown',
+    });
+
+    recordHistorySessionDiagnosticEvent('history-1', 'switch_requested', {
+      switchRequestId: 1,
+      shouldActivateBeforeHydrate: true,
+    });
+    recordHistorySessionDiagnosticEvent('history-1', 'hydrate_reused_pending', {
+      pendingHydrateAgeMs: 125,
+    });
+    recordHistorySessionDiagnosticEvent('history-1', 'store_stale_commit_skipped', {
+      activeSessionIdMatches: false,
+    });
+
+    warnHistorySessionLoadingLayerStalled('history-1', {
+      durationMs: 800,
+      historyState: 'metadata-only',
+      isHistorical: true,
+      isRemote: false,
+      activeSessionIdMatches: true,
+      hasRenderableContent: false,
+      dialogTurnCount: 0,
+    });
+    warnHistorySessionLoadingLayerStalled('history-1', {
+      durationMs: 1_200,
+      historyState: 'metadata-only',
+      isHistorical: true,
+      isRemote: false,
+      activeSessionIdMatches: true,
+      hasRenderableContent: false,
+      dialogTurnCount: 0,
+    });
+
+    expect(loggerMock.warn).toHaveBeenCalledTimes(3);
+    expect(loggerMock.warn).toHaveBeenNthCalledWith(
+      1,
+      'Historical session loading layer stalled',
+      expect.objectContaining({
+        diagnosticId,
+        sessionId: 'history-1',
+        durationMs: 800,
+        historyState: 'metadata-only',
+        hasRenderableContent: false,
+      }),
+    );
+    expect(loggerMock.warn).toHaveBeenNthCalledWith(
+      2,
+      'Historical session hydrate state at stall',
+      expect.objectContaining({
+        diagnosticId,
+        sessionId: 'history-1',
+        lastHydrateEvent: 'hydrate_reused_pending',
+        lastStoreEvent: 'store_stale_commit_skipped',
+      }),
+    );
+    expect(loggerMock.warn).toHaveBeenNthCalledWith(
+      3,
+      'Historical session recent lifecycle events',
+      expect.objectContaining({
+        diagnosticId,
+        sessionId: 'history-1',
+        events: expect.arrayContaining([
+          expect.objectContaining({ event: 'switch_requested' }),
+          expect.objectContaining({ event: 'hydrate_reused_pending' }),
+          expect.objectContaining({ event: 'store_stale_commit_skipped' }),
+        ]),
+      }),
+    );
+  });
+});

--- a/src/web-ui/src/flow_chat/services/historySessionDiagnostics.ts
+++ b/src/web-ui/src/flow_chat/services/historySessionDiagnostics.ts
@@ -1,0 +1,232 @@
+import { createLogger } from '@/shared/utils/logger';
+import { elapsedMs, nowMs, roundDurationMs } from '@/shared/utils/timing';
+
+const log = createLogger('HistorySessionDiagnostics');
+
+const RECENT_EVENT_LIMIT = 30;
+const WARN_EVENT_LIMIT = 15;
+const MAX_SESSION_DIAGNOSTICS = 50;
+
+export type HistorySessionDiagnosticValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | HistorySessionDiagnosticValue[]
+  | { [key: string]: HistorySessionDiagnosticValue };
+
+export type HistorySessionDiagnosticData = Record<string, HistorySessionDiagnosticValue>;
+
+interface HistorySessionDiagnosticEvent {
+  event: string;
+  ageMs: number;
+  data?: HistorySessionDiagnosticData;
+}
+
+interface HistorySessionDiagnosticState {
+  diagnosticId: string;
+  sessionId: string;
+  startedAtMs: number;
+  events: HistorySessionDiagnosticEvent[];
+  pendingHydrateStartedAtMs?: number;
+  pendingHydrateData?: HistorySessionDiagnosticData;
+  stalledWarned: boolean;
+}
+
+export interface HistorySessionLoadingStallSnapshot extends HistorySessionDiagnosticData {
+  durationMs: number;
+  historyState?: string;
+  isHistorical?: boolean;
+  isRemote?: boolean;
+  activeSessionIdMatches?: boolean;
+  hasRenderableContent?: boolean;
+  dialogTurnCount?: number;
+}
+
+const diagnosticsBySession = new Map<string, HistorySessionDiagnosticState>();
+let diagnosticSequence = 0;
+
+function trimOldDiagnostics(): void {
+  while (diagnosticsBySession.size > MAX_SESSION_DIAGNOSTICS) {
+    const oldestSessionId = diagnosticsBySession.keys().next().value;
+    if (!oldestSessionId) {
+      return;
+    }
+    diagnosticsBySession.delete(oldestSessionId);
+  }
+}
+
+function createDiagnosticId(sessionId: string): string {
+  diagnosticSequence += 1;
+  const prefix = sessionId.slice(0, 8) || 'session';
+  return `${prefix}-${Math.round(nowMs())}-${diagnosticSequence}`;
+}
+
+function getOrCreateDiagnostic(sessionId: string): HistorySessionDiagnosticState {
+  const existing = diagnosticsBySession.get(sessionId);
+  if (existing) {
+    return existing;
+  }
+
+  const created: HistorySessionDiagnosticState = {
+    diagnosticId: createDiagnosticId(sessionId),
+    sessionId,
+    startedAtMs: nowMs(),
+    events: [],
+    stalledWarned: false,
+  };
+  diagnosticsBySession.set(sessionId, created);
+  trimOldDiagnostics();
+  return created;
+}
+
+function pushEvent(
+  state: HistorySessionDiagnosticState,
+  event: string,
+  data?: HistorySessionDiagnosticData,
+  options?: { logEvent?: boolean },
+): void {
+  const record: HistorySessionDiagnosticEvent = {
+    event,
+    ageMs: elapsedMs(state.startedAtMs),
+    ...(data ? { data } : {}),
+  };
+
+  state.events.push(record);
+  if (state.events.length > RECENT_EVENT_LIMIT) {
+    state.events.splice(0, state.events.length - RECENT_EVENT_LIMIT);
+  }
+
+  if (options?.logEvent !== false) {
+    log.debug('Historical session diagnostic event', {
+      diagnosticId: state.diagnosticId,
+      sessionId: state.sessionId,
+      event,
+      ageMs: record.ageMs,
+      ...(data ?? {}),
+    });
+  }
+}
+
+function summarizeEvents(state: HistorySessionDiagnosticState): HistorySessionDiagnosticEvent[] {
+  return state.events.slice(-WARN_EVENT_LIMIT).map(event => ({
+    event: event.event,
+    ageMs: event.ageMs,
+    ...(event.data ? { data: event.data } : {}),
+  }));
+}
+
+function findLastEvent(
+  state: HistorySessionDiagnosticState,
+  predicate: (event: HistorySessionDiagnosticEvent) => boolean,
+): HistorySessionDiagnosticEvent | undefined {
+  for (let index = state.events.length - 1; index >= 0; index -= 1) {
+    const event = state.events[index];
+    if (predicate(event)) {
+      return event;
+    }
+  }
+  return undefined;
+}
+
+export function beginHistorySessionDiagnostics(
+  sessionId: string,
+  event: string,
+  data?: HistorySessionDiagnosticData,
+): string {
+  const state: HistorySessionDiagnosticState = {
+    diagnosticId: createDiagnosticId(sessionId),
+    sessionId,
+    startedAtMs: nowMs(),
+    events: [],
+    stalledWarned: false,
+  };
+  diagnosticsBySession.set(sessionId, state);
+  trimOldDiagnostics();
+  pushEvent(state, event, data);
+  return state.diagnosticId;
+}
+
+export function recordHistorySessionDiagnosticEvent(
+  sessionId: string,
+  event: string,
+  data?: HistorySessionDiagnosticData,
+  options?: { logEvent?: boolean },
+): void {
+  pushEvent(getOrCreateDiagnostic(sessionId), event, data, options);
+}
+
+export function markHistorySessionHydratePending(
+  sessionId: string,
+  data?: HistorySessionDiagnosticData,
+): void {
+  const state = getOrCreateDiagnostic(sessionId);
+  state.pendingHydrateStartedAtMs = nowMs();
+  state.pendingHydrateData = data;
+  pushEvent(state, 'hydrate_pending_started', data);
+}
+
+export function clearHistorySessionHydratePending(
+  sessionId: string,
+  outcome: string,
+  data?: HistorySessionDiagnosticData,
+): void {
+  const state = getOrCreateDiagnostic(sessionId);
+  const pendingHydrateAgeMs = state.pendingHydrateStartedAtMs !== undefined
+    ? elapsedMs(state.pendingHydrateStartedAtMs)
+    : undefined;
+  pushEvent(state, 'hydrate_pending_settled', {
+    outcome,
+    pendingHydrateAgeMs,
+    ...(data ?? {}),
+  });
+  state.pendingHydrateStartedAtMs = undefined;
+  state.pendingHydrateData = undefined;
+}
+
+export function warnHistorySessionLoadingLayerStalled(
+  sessionId: string,
+  snapshot: HistorySessionLoadingStallSnapshot,
+): void {
+  const state = getOrCreateDiagnostic(sessionId);
+  if (state.stalledWarned) {
+    return;
+  }
+
+  state.stalledWarned = true;
+  pushEvent(state, 'loading_layer_stalled', snapshot, { logEvent: false });
+
+  const lastHydrateEvent = findLastEvent(state, event => event.event.includes('hydrate'));
+  const lastStoreEvent = findLastEvent(state, event => event.event.startsWith('store_'));
+  const pendingHydrateAgeMs = state.pendingHydrateStartedAtMs !== undefined
+    ? roundDurationMs(nowMs() - state.pendingHydrateStartedAtMs)
+    : undefined;
+
+  log.warn('Historical session loading layer stalled', {
+    diagnosticId: state.diagnosticId,
+    sessionId,
+    ...snapshot,
+  });
+  log.warn('Historical session hydrate state at stall', {
+    diagnosticId: state.diagnosticId,
+    sessionId,
+    hasPendingHydrate: state.pendingHydrateStartedAtMs !== undefined,
+    pendingHydrateAgeMs,
+    pendingHydrateData: state.pendingHydrateData,
+    lastHydrateEvent: lastHydrateEvent?.event,
+    lastStoreEvent: lastStoreEvent?.event,
+    lastHydrateData: lastHydrateEvent?.data,
+    lastStoreData: lastStoreEvent?.data,
+  });
+  log.warn('Historical session recent lifecycle events', {
+    diagnosticId: state.diagnosticId,
+    sessionId,
+    events: summarizeEvents(state),
+  });
+}
+
+export function resetHistorySessionDiagnosticsForTests(): void {
+  diagnosticsBySession.clear();
+  diagnosticSequence = 0;
+}

--- a/src/web-ui/src/flow_chat/services/sessionOpenIntent.ts
+++ b/src/web-ui/src/flow_chat/services/sessionOpenIntent.ts
@@ -1,4 +1,8 @@
 import type { Session } from '../types/flow-chat';
+import {
+  beginHistorySessionDiagnostics,
+  recordHistorySessionDiagnosticEvent,
+} from './historySessionDiagnostics';
 
 export const HISTORY_SESSION_OPEN_INTENT_EVENT = 'flowchat:history-session-open-intent';
 const RECENT_HISTORY_OPEN_INTENT_MS = 750;
@@ -70,6 +74,7 @@ export function shouldShowHistorySessionOpenIntent(
 
 export function dispatchHistorySessionOpenIntent(sessionId: string, sessionTitle?: string): void {
   const atMs = nowMs();
+  beginHistorySessionDiagnostics(sessionId, 'history_open_intent_dispatched');
   recentHistoryOpenIntent = {
     sessionId,
     atMs,
@@ -81,6 +86,9 @@ export function dispatchHistorySessionOpenIntent(sessionId: string, sessionTitle
       activeHistorySessionOpenTransition?.sessionId === sessionId &&
       activeHistorySessionOpenTransition.atMs === atMs
     ) {
+      recordHistorySessionDiagnosticEvent(sessionId, 'history_open_transition_expired', {
+        durationMs: HISTORY_SESSION_OPEN_TRANSITION_MAX_MS,
+      });
       activeHistorySessionOpenTransition = null;
       activeHistorySessionOpenTransitionTimer = null;
       notifyHistorySessionOpenTransitionListeners();
@@ -106,7 +114,15 @@ export function consumeRecentHistorySessionOpenIntent(sessionId: string): boolea
 
   const now = nowMs();
   recentHistoryOpenIntent = null;
-  return now - recent.atMs <= RECENT_HISTORY_OPEN_INTENT_MS;
+  const ageMs = Math.round(now - recent.atMs);
+  const consumed = ageMs <= RECENT_HISTORY_OPEN_INTENT_MS;
+  recordHistorySessionDiagnosticEvent(sessionId, consumed
+    ? 'history_open_intent_consumed'
+    : 'history_open_intent_expired', {
+    ageMs,
+    maxAgeMs: RECENT_HISTORY_OPEN_INTENT_MS,
+  });
+  return consumed;
 }
 
 export function clearRecentHistorySessionOpenIntent(sessionId?: string): void {
@@ -130,6 +146,12 @@ export function getHistorySessionOpenTransitionSnapshot(): HistorySessionOpenTra
 
 export function clearHistorySessionOpenTransition(sessionId?: string): void {
   if (!sessionId || activeHistorySessionOpenTransition?.sessionId === sessionId) {
+    if (activeHistorySessionOpenTransition) {
+      recordHistorySessionDiagnosticEvent(
+        activeHistorySessionOpenTransition.sessionId,
+        'history_open_transition_cleared',
+      );
+    }
     activeHistorySessionOpenTransition = null;
     clearHistorySessionOpenTransitionTimer();
     notifyHistorySessionOpenTransitionListeners();

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -61,6 +61,7 @@ import { sessionBelongsToWorkspaceNavRow } from '../utils/sessionOrdering';
 import { sessionMatchesWorkspace } from '../utils/workspaceScope';
 import { resolveThreadGoalUserMessageDisplay } from '../utils/threadGoalDisplay';
 import { useBackgroundSubagentActivityStore } from './backgroundSubagentActivityStore';
+import { recordHistorySessionDiagnosticEvent } from '../services/historySessionDiagnostics';
 
 const log = createLogger('FlowChatStore');
 const VALID_AGENT_TYPES = new Set([
@@ -3962,6 +3963,12 @@ export class FlowChatStore {
           isPartial: restoredHistoryPartial,
           durationMs: elapsedMs(traceStartedAt),
         });
+        recordHistorySessionDiagnosticEvent(sessionId, 'store_stale_commit_skipped', {
+          remote,
+          loadedTurnCount: restoredLoadedTurnCount,
+          totalTurnCount: restoredTotalTurnCount,
+          isPartial: restoredHistoryPartial,
+        });
         startupTrace.markPhase('historical_session_hydrate_end', {
           remote,
           sessionId,
@@ -4024,6 +4031,12 @@ export class FlowChatStore {
         totalTurnCount: restoredTotalTurnCount,
         isPartial: restoredHistoryPartial,
         durationMs: elapsedMs(stateCommitStartedAt),
+      });
+      recordHistorySessionDiagnosticEvent(sessionId, 'store_state_commit_finished', {
+        remote,
+        dialogTurnCount: dialogTurns.length,
+        totalTurnCount: restoredTotalTurnCount,
+        isPartial: restoredHistoryPartial,
       });
       markPhaseAfterAnimationFrames(startupTrace, 'historical_session_after_state_commit_frame', {
         remote,
@@ -4098,6 +4111,9 @@ export class FlowChatStore {
         sessionId,
         sessionTraceId,
         durationMs: elapsedMs(traceStartedAt),
+      });
+      recordHistorySessionDiagnosticEvent(sessionId, 'store_hydrate_failed', {
+        remote,
       });
       log.error('Failed to load session history', { sessionId, error });
       throw error;


### PR DESCRIPTION
## Summary

This fixes an intermittent first-open hang where a saved local historical session can remain on the "loading history" state after the user explicitly opens it.

The race happens when an early pointer-down preload is reused by the later explicit session switch, but that preload finished while the target session was not active. In that case the store intentionally skips committing the hydrated data, leaving the session in metadata-only state. The explicit switch then observes the already-settled preload and previously had no second chance to hydrate the now-active target.

## Fix

The switch path now performs a narrowly scoped retry after reusing an existing historical-session hydrate only when all of these are true:

- the switch came from a fresh explicit open intent
- the switch request has not been superseded by a newer switch
- the target session is still the active session
- the target is still a local, non-renderable, metadata-only historical session

This keeps the retry limited to the stale preload reuse race and avoids changing normal preloads, remote sessions, ready sessions, renderable historical sessions, or superseded switches.

## Diagnostics

This also adds low-noise diagnostics for the same historical-session open path. Normal lifecycle events are recorded as debug-level structured logs and in a bounded in-memory event buffer. If the history loading layer remains visible for 800ms, the frontend emits grouped warning logs with the same diagnostic id:

- current loading-layer state
- hydrate and store state at the stall
- a bounded recent lifecycle event list

The 800ms threshold is an early suspicious-signal threshold, not a user-facing acceptable wait budget. It leaves headroom above the existing roughly 500ms typical history-content paint envelope while still capturing hangs before users are likely to wait for seconds.

The warning path is intended to show up in user diagnostic bundles without requiring DevTools or manual trace collection, while keeping normal successful opens quiet.

## Validation

- `pnpm --dir src/web-ui run test:run src/app/startup/startupPerformanceContract.test.ts`
- `pnpm --dir src/web-ui run test:run src/flow_chat/services/historySessionDiagnostics.test.ts src/flow_chat/services/sessionOpenIntent.test.ts src/flow_chat/services/flow-chat-manager/SessionModule.test.ts src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx`
- `pnpm run type-check:web`
- `git diff --check`
