### PR TITLE
fix: update Write truncation recovery guidance and stabilize content canvas tab hover layout

### DIFF
--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/deep_research.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/deep_research.rs
@@ -99,7 +99,7 @@ mod tests {
         assert!(tools.contains(&"Write".to_string()));
         assert!(
             tools.contains(&"Edit".to_string()),
-            "Edit required so the agent can continue a Write that was truncated by max_tokens"
+            "Edit required for targeted file updates during research synthesis"
         );
         assert!(tools.contains(&"ExecCommand".to_string()));
         assert!(tools.contains(&"WriteStdin".to_string()));

--- a/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -189,14 +189,14 @@ impl FileWriteTool {
                     "type": "string",
                     "description": "The absolute path to the file to write (must be absolute, not relative)"
                 },
-                "content": {
-                    "type": "string",
-                    "description": "The content to write to the file"
-                },
                 "mode": {
                     "type": "string",
                     "enum": ["w", "a"],
                     "description": "Write mode: 'w' overwrites the file (default), 'a' appends to the file and creates it if missing"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The content to write to the file"
                 }
             },
             "required": ["file_path", "content"],
@@ -208,13 +208,17 @@ impl FileWriteTool {
         r#"Writes a file to the local filesystem.
 
 Usage:
-- Always output `file_path` first when calling this tool. Example: `{"file_path": "src/main.rs", "content": "fn main() {}"}`.
+- Always order arguments as: `file_path`, optional `mode`, then `content` last.
 - This tool defaults to `mode=\"w\"`, which overwrites the existing file if there is one at the provided path.
 - Use `mode=\"a\"` to append content; it also creates the file if it does not exist.
 - If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first.
 - Prefer the Edit tool for modifying existing files — it only sends the diff. Only use this tool to create new files or for complete rewrites.
 - NEVER create documentation files (*.md) or README files unless explicitly requested by the User.
-- Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked."#
+- Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.
+
+Examples:
+- Overwrite or create: `{"file_path": "/path/to/main.rs", "content": "fn main() {}"}`
+- Append: `{"file_path": "/path/to/main.rs", "mode": "a", "content": "more text"}`"#
             .to_string()
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -1790,7 +1790,8 @@ mod tests {
 
         assert!(notice.contains("file may have been written with partial content"));
         assert!(notice.contains("latest Read result"));
-        assert!(notice.contains("issue ONE Edit call"));
+        assert!(notice.contains("issue ONE Write call"));
+        assert!(notice.contains("`mode`: \"a\""));
     }
 
     #[test]

--- a/src/crates/execution/tool-contracts/src/tool_execution_presentation.rs
+++ b/src/crates/execution/tool-contracts/src/tool_execution_presentation.rs
@@ -24,7 +24,7 @@ pub fn is_write_like_tool_name(tool_name: &str) -> bool {
 pub fn build_tool_call_truncation_recovery_notice(tool_name: &str) -> String {
     if is_write_like_tool_name(tool_name) {
         return format!(
-            "[Your previous {tool_name} call was truncated mid-stream by max_tokens and was auto-repaired before execution; the file may have been written with partial content. Use the latest Read result for that file (or call Read once if no current Read result is available) to inspect what is on disk. To finish it, issue ONE Edit call where `old_string` is a final unique substring from the current file and `new_string` is that same substring plus the continuation. If you do not have a concrete plan for the continuation, stop tool-calling and tell the user the output was truncated (suggest raising max_tokens). Do NOT rewrite the whole file with Write.]\n\nOriginal tool result follows.\n\n"
+            "[Your previous {tool_name} call was truncated mid-stream by max_tokens and was auto-repaired before execution; the file may have been written with partial content. Use the latest Read result for that file (or call Read once if no current Read result is available) to inspect what is on disk. To finish it, issue ONE {tool_name} call with `mode`: \"a\" and `content` set only to the missing continuation. If you do not have a concrete plan for the continuation, stop tool-calling and tell the user the output was truncated (suggest raising max_tokens). Do NOT rewrite the whole file with overwrite mode.]\n\nOriginal tool result follows.\n\n"
         );
     }
 

--- a/src/crates/execution/tool-contracts/tests/tool_contracts.rs
+++ b/src/crates/execution/tool-contracts/tests/tool_contracts.rs
@@ -189,8 +189,10 @@ fn truncation_recovery_notice_preserves_write_like_guidance() {
     let notice = build_tool_call_truncation_recovery_notice("Write");
 
     assert!(notice.contains("latest Read result"));
-    assert!(notice.contains("ONE Edit call"));
-    assert!(notice.contains("Do NOT rewrite the whole file with Write"));
+    assert!(notice.contains("ONE Write call"));
+    assert!(notice.contains("`mode`: \"a\""));
+    assert!(notice.contains("missing continuation"));
+    assert!(notice.contains("Do NOT rewrite the whole file with overwrite mode"));
     assert!(notice.ends_with("Original tool result follows.\n\n"));
 }
 

--- a/src/web-ui/src/app/components/panels/content-canvas/tab-bar/Tab.scss
+++ b/src/web-ui/src/app/components/panels/content-canvas/tab-bar/Tab.scss
@@ -90,11 +90,6 @@
     transition: color 0.15s ease;
   }
 
-  // Keep title visually centered when tab is not hovered.
-  &:not(:hover) &__title {
-    text-align: center;
-  }
-
   // Active state title color is brighter
   &.is-active &__title {
     color: var(--color-text-primary);


### PR DESCRIPTION
- **fix(agent): update truncated Write recovery guidance**
- **fix: prevent content canvas tab labels from shifting on hover**
