### PR TITLE
Disable web tools for GeneralPurpose subagent

### DIFF
--- a/src/crates/assembly/core/src/agentic/agents/definitions/subagents/general_purpose.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/subagents/general_purpose.rs
@@ -24,11 +24,6 @@ impl GeneralPurposeAgent {
                 "ExecCommand".to_string(),
                 "WriteStdin".to_string(),
                 "ExecControl".to_string(),
-                "WebSearch".to_string(),
-                "WebFetch".to_string(),
-                "ExecCommand".to_string(),
-                "WriteStdin".to_string(),
-                "ExecControl".to_string(),
             ],
         }
     }
@@ -49,7 +44,7 @@ impl Agent for GeneralPurposeAgent {
     }
 
     fn description(&self) -> &str {
-        r#"General-purpose implementation and research subagent for multi-step tasks that need focused codebase search, targeted file edits."#
+        r#"General-purpose implementation subagent for multi-step tasks that need focused codebase search and targeted file edits."#
     }
 
     fn prompt_template_name(&self, _model_name: Option<&str>) -> &str {


### PR DESCRIPTION
## Summary
- Remove WebSearch and WebFetch from the GeneralPurpose subagent default tool list
- Update the GeneralPurpose description so it no longer presents the subagent as research-oriented
- Remove duplicate exec-session tool entries from the default tool list

## Verification
- cargo check -p bitfun-core