### PR TITLE
fix(agentic): rename ControlHub host field and strengthen remote SSH prompt

### DIFF
--- a/src/crates/assembly/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/assembly/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -742,6 +742,7 @@ mod tests {
         assert!(runtime_context.contains("Local BitFun client OS:"));
         assert!(runtime_context.contains("Computer use and UI automation operate on the local BitFun desktop, even when workspace file and shell tools target a remote host."));
         assert!(runtime_context.contains("ExecCommand uses the remote user's default POSIX shell"));
+        assert!(runtime_context.contains("This session operates on the remote SSH host only"));
     }
 
     #[tokio::test]

--- a/src/crates/assembly/core/src/agentic/tools/implementations/control_hub_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/control_hub_tool.rs
@@ -108,7 +108,7 @@ Use this tool via `{ domain, action, params }` for browser automation, terminal 
 - Use the `Bash` tool to run new commands; this domain only signals existing terminal sessions.
 
 ### domain: "meta"
-- `capabilities` — returns `{ domains: { browser, terminal, meta }, host: { os, arch }, workspace_execution: { is_remote }, schema_version }`.
+- `capabilities` — returns `{ domains: { browser, terminal, meta }, local_client: { os, arch }, workspace_execution: { is_remote }, schema_version }`.
 - `route_hint` — maps a free-form intent to the appropriate ControlHub domain, or tells you to use `ComputerUse` for local computer/system/desktop work.
 
 ## Unified Response Envelope
@@ -268,7 +268,7 @@ Branch on `ok` and `error.code`, not on English messages.
                         "terminal": { "available": likely_terminal_available, "reason": if likely_terminal_available { Value::Null } else { json!("TerminalApi is only available in contexts that registered it") } },
                         "meta":     { "available": true },
                     },
-                    "host": {
+                    "local_client": {
                         "os": os,
                         "arch": arch,
                         "display_server": display_server,
@@ -2092,7 +2092,7 @@ mod control_hub_tests {
     }
 
     #[tokio::test]
-    async fn meta_capabilities_reports_host_and_domain_table() {
+    async fn meta_capabilities_reports_local_client_and_domain_table() {
         let tool = ControlHubTool::new();
         let ctx = empty_context();
         let results = tool
@@ -2111,7 +2111,7 @@ mod control_hub_tests {
         assert!(domains.get("system").is_none());
         assert_eq!(
             payload
-                .get("host")
+                .get("local_client")
                 .and_then(|h| h.get("os"))
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string()),

--- a/src/crates/execution/agent-runtime/src/prompt.rs
+++ b/src/crates/execution/agent-runtime/src/prompt.rs
@@ -153,6 +153,7 @@ pub fn render_runtime_context_reminder(facts: &RuntimeContextFacts) -> Option<St
                 remote.kernel_name.replace('"', "'")
             ));
             workspace_lines.push("- Path conventions for workspace operations: POSIX paths with forward slashes and Unix shell syntax. Do not use PowerShell, `cmd.exe`, or Windows-style paths for remote workspace operations.".to_string());
+            workspace_lines.push("- This session operates on the remote SSH host only. Local filesystem, local terminal, and local OS operations are not accessible. For tasks requiring local execution (e.g. editing the local Mac's ~/.ssh/config), provide the user with commands to run on their local machine.".to_string());
         } else {
             workspace_lines.push(
                 "- Workspace file and shell tools operate on the local filesystem.".to_string(),


### PR DESCRIPTION
## Summary

- Rename ControlHub `meta.capabilities` response field from `host` to `local_client` so agents clearly distinguish the local BitFun desktop client from the remote SSH workspace host.
- Add explicit runtime prompt guidance that remote SSH sessions cannot access local filesystem, terminal, or OS operations, and should provide users with local commands when needed.
- Update unit tests to cover the renamed field and new prompt text.

Follow-up to #1283.

## Test plan

- [x] `cargo check -p bitfun-agent-runtime -p bitfun-core`
- [x] `cargo test -p bitfun-core --lib meta_capabilities_reports_local_client`
- [x] `cargo test -p bitfun-core --lib runtime_context_omits_workspace_root_for_remote_execution`