### PR TITLE
fix(relay-server): align deploy scripts and docs with default 0.0.0.0 binding

### DIFF
--- a/src/apps/relay-server/Cargo.toml
+++ b/src/apps/relay-server/Cargo.toml
@@ -14,29 +14,32 @@ name = "bitfun-relay-server"
 path = "src/main.rs"
 
 [dependencies]
+# NOTE: Dependencies are intentionally inlined rather than inherited from the
+# workspace so that this crate can be built standalone inside its Docker
+# context (src/apps/relay-server/) without copying the whole workspace.
 # Web framework
-axum = { workspace = true }
-tower-http = { workspace = true }
+axum = { version = "0.8", features = ["json", "ws"] }
+tower-http = { version = "0.6.11", features = ["cors", "fs"] }
 
 # Async runtime
-tokio = { workspace = true }
-futures-util = { workspace = true }
+tokio = { version = "1.52", features = ["full"] }
+futures-util = "0.3.31"
 
 # Serialization
-serde = { workspace = true }
-serde_json = { workspace = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 # Error handling
-anyhow = { workspace = true }
+anyhow = "1.0"
 
 # Logging
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Utilities
-uuid = { workspace = true }
-chrono = { workspace = true }
-dashmap = { workspace = true }
-rand = { workspace = true }
-base64 = { workspace = true }
-sha2 = { workspace = true }
+uuid = { version = "1.0", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde", "clock"] }
+dashmap = "6"
+rand = "0.8"
+base64 = "0.22"
+sha2 = "0.10"

--- a/src/apps/relay-server/README.md
+++ b/src/apps/relay-server/README.md
@@ -53,6 +53,17 @@ In **Remote Connect → Self-Hosted → Server URL**, use one of:
 
 `/relay` is only needed when your reverse proxy is configured with that path prefix.
 
+### Network Binding
+
+By default, the relay process listens on `0.0.0.0:9700` (all interfaces) and Docker Compose publishes the container port on the host's `0.0.0.0:9700`.
+
+If you need to restrict the service to localhost only, set the environment variable before running `start.sh`/`restart.sh`/`deploy.sh`:
+
+```bash
+export RELAY_HOST_BIND_IP=127.0.0.1
+bash deploy.sh
+```
+
 ### Manual Run
 
 ```bash
@@ -79,8 +90,8 @@ RELAY_PORT=9700 ./target/release/bitfun-relay-server
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `RELAY_PORT` | `9700` | Server listen port |
-| `RELAY_STATIC_DIR` | `./static` | Path to mobile web static files (fallback SPA) |
-| `RELAY_ROOM_WEB_DIR` | `/tmp/bitfun-room-web` | Directory for per-room uploaded mobile-web files |
+| `RELAY_STATIC_DIR` | _(none)_ | Path to mobile web static files fallback SPA. When unset, no fallback static files are served. Docker Compose sets this to `/app/static`. |
+| `RELAY_ROOM_WEB_DIR` | `/tmp/bitfun-room-web` | Directory for per-room uploaded mobile-web files. Docker Compose uses a named volume mounted at `/app/room-web`. |
 | `RELAY_ROOM_TTL` | `3600` | Room TTL in seconds (0 = no expiry) |
 
 ## API Endpoints

--- a/src/apps/relay-server/restart.sh
+++ b/src/apps/relay-server/restart.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTAINER_NAME="bitfun-relay"
-RELAY_HOST_BIND_IP="127.0.0.1"
 
 usage() {
   cat <<'EOF'
@@ -66,14 +65,14 @@ cd "$SCRIPT_DIR"
 
 if container_running; then
   echo "Relay service is running. Restarting it..."
-  RELAY_HOST_BIND_IP="$RELAY_HOST_BIND_IP" docker compose up -d --force-recreate
+  docker compose up -d --force-recreate
 else
   echo "Relay service is not running. Starting it instead..."
-  RELAY_HOST_BIND_IP="$RELAY_HOST_BIND_IP" docker compose up -d
+  docker compose up -d
 fi
 
 echo ""
 echo "Relay service is ready."
-echo "Relay endpoint: http://127.0.0.1:9700"
+echo "Relay endpoint: http://<this-server-ip>:9700"
 echo "Check status:  docker compose ps"
 echo "View logs:     docker compose logs -f relay-server"

--- a/src/apps/relay-server/start.sh
+++ b/src/apps/relay-server/start.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTAINER_NAME="bitfun-relay"
-RELAY_HOST_BIND_IP="127.0.0.1"
 
 usage() {
   cat <<'EOF'
@@ -78,10 +77,10 @@ else
   echo "Relay service is not created yet. Creating and starting it..."
 fi
 
-RELAY_HOST_BIND_IP="$RELAY_HOST_BIND_IP" docker compose up -d
+docker compose up -d
 
 echo ""
 echo "Relay service started."
-echo "Relay endpoint: http://127.0.0.1:9700"
+echo "Relay endpoint: http://<this-server-ip>:9700"
 echo "Check status:  docker compose ps"
 echo "View logs:     docker compose logs -f relay-server"


### PR DESCRIPTION
This PR fixes several inconsistencies in the relay-server deployment scripts and documentation:

- **start.sh / restart.sh** no longer hardcode \RELAY_HOST_BIND_IP=127.0.0.1\, so their behavior matches deploy.sh and docker-compose.yml (default bind 0.0.0.0).
- **README.md** fixes the incorrect default for RELAY_STATIC_DIR and adds a Network Binding section.
- **Cargo.toml** inlines dependencies so the standalone Docker build context works without the workspace root.