### PR TITLE
fix(mobile-web): eliminate session list loading flicker on init

### DIFF
--- a/src/mobile-web/src/pages/SessionListPage.tsx
+++ b/src/mobile-web/src/pages/SessionListPage.tsx
@@ -191,7 +191,10 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
   const toastTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
   const hasSearchQuery = searchQuery.trim().length > 0;
-  const showResumeCard = !loading && sessions.length > 0 && !hasSearchQuery;
+  // Show the resume card as soon as session data is available — don't gate it
+  // behind `loading`, otherwise a background refresh hides the card and makes it
+  // pop back in after the network round-trip, lagging behind the rest of the UI.
+  const showResumeCard = sessions.length > 0 && !hasSearchQuery;
 
   // ── Long-press context menu ─────────────────────────────────────
   const clearLongPressTimer = () => {
@@ -286,6 +289,7 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
   const offsetRef = useRef(0);
   const listRef = useRef<HTMLDivElement>(null);
   const listRequestSeqRef = useRef(0);
+  const initLoadedPathRef = useRef<string | undefined>(undefined);
   const touchStartY = useRef(0);
   const isPulling = useRef(false);
 
@@ -411,11 +415,13 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
           });
           setCurrentWorkspace(null);
           setDisplayMode('assistant');
+          initLoadedPathRef.current = info.path;
           await loadFirstPage(info.path);
         } else {
           const ws = info.has_workspace ? info : null;
           setCurrentWorkspace(ws);
           if (ws?.path) {
+            initLoadedPathRef.current = ws.path;
             await loadFirstPage(ws.path);
           } else {
             await trySelectFirstProWorkspace();
@@ -470,6 +476,13 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
   useEffect(() => {
     const workspacePath = displayMode === 'assistant' ? currentAssistant?.path : currentWorkspace?.path;
     if (!workspacePath) return;
+    // Skip the redundant first load when init() already loaded this path —
+    // otherwise the state change from init() triggers a second loadFirstPage
+    // 250 ms later, causing an extra network round-trip and a loading flicker.
+    if (initLoadedPathRef.current === workspacePath) {
+      initLoadedPathRef.current = undefined;
+      return;
+    }
     const timer = setTimeout(() => {
       loadFirstPage(workspacePath, searchQuery);
     }, 250);

--- a/src/mobile-web/src/styles/components/sessions.scss
+++ b/src/mobile-web/src/styles/components/sessions.scss
@@ -166,6 +166,7 @@
   cursor: pointer;
   transition: transform var(--motion-fast) var(--easing-standard),
     background var(--motion-fast) var(--easing-standard);
+  animation: sessionItemIn var(--motion-base) var(--easing-decelerate) both;
 
   &:active {
     transform: scale(0.985);


### PR DESCRIPTION
## Summary

- Keep the resume card visible as soon as session data is available instead of hiding it behind the `loading` flag during background refresh, which caused the card to pop in late after the network round-trip.
- Skip the redundant `loadFirstPage` triggered by the post-init workspace state effect when `init()` already loaded the same path, avoiding an extra network round-trip and loading flicker.
- Add `sessionItemIn` enter animation to session list items for smoother list paint.

## Test plan

- [x] `pnpm --dir src/mobile-web run type-check`
- [ ] Open mobile web session list after pairing; confirm resume card stays visible during background refresh (no pop-in lag)
- [ ] Confirm initial session list load does not flash loading state twice on first open
- [ ] Confirm session items animate in smoothly on list render
- [ ] Verify search still hides resume card and list reload still works when switching workspace