### PR TITLE
fix(web-ui): stabilize turn list jumps

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
@@ -313,8 +313,12 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
 
   const handleTurnSelect = (turnId: string) => {
     if (!onJumpToTurn) return;
+    const selectedTurn = displayTurns.find(turn => turn.turnId === turnId);
+    if (selectedTurn?.turnIndex === currentTurn) {
+      setIsTurnListOpen(false);
+      return;
+    }
     onJumpToTurn(turnId);
-    setIsTurnListOpen(false);
   };
 
   const handleSubagentSelect = (sessionId: string) => {
@@ -908,4 +912,3 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
 };
 
 FlowChatHeader.displayName = 'FlowChatHeader';
-

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -98,6 +98,7 @@ type BackgroundCommandSummary = {
 };
 
 const LATEST_TURN_AUTO_PIN_MAX_ATTEMPTS = 8;
+const HEADER_TURN_JUMP_MAX_ATTEMPTS = 30;
 const HISTORY_INITIAL_CONTENT_PAINT_MAX_ATTEMPTS = 30;
 const HISTORY_LOADING_LAYER_STALL_WARN_MS = 800;
 const MOCK_BACKGROUND_ACTIVITIES_STORAGE_KEY = 'bitfun.flowChat.mockBackgroundActivities';
@@ -220,6 +221,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const activeSession = useActiveSession();
   const visibleTurnInfo = useVisibleTurnInfo();
   const [pendingHeaderTurnId, setPendingHeaderTurnId] = useState<string | null>(null);
+  const [deferredHeaderTurnJump, setDeferredHeaderTurnJump] = useState<{ turnId: string; attempts: number } | null>(null);
   const [pendingHistoryOpenSession, setPendingHistoryOpenSession] = useState<HistorySessionOpenIntentDetail | null>(null);
   const [searchOpenRequest, setSearchOpenRequest] = useState(0);
   // Track whether a slash-command or @-mention popup is open in ChatInput.
@@ -672,6 +674,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     setHistoryInitialContentReadyKey(null);
     setHistoryInitialContentPostPaintKey(null);
     setPendingHeaderTurnId(null);
+    setDeferredHeaderTurnJump(null);
   }, [activeSession?.sessionId]);
 
   useLayoutEffect(() => {
@@ -966,22 +969,70 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     turnSummaries.length,
   ]);
 
-  const handleJumpToTurn = useCallback((turnId: string) => {
-    if (!turnId) return;
-
+  const pinHeaderTurnToTop = useCallback((turnId: string) => {
     const isLatestTurn = turnSummaries[turnSummaries.length - 1]?.turnId === turnId;
     const targetTurn = findDialogTurn(activeSession?.dialogTurns, turnId);
     const pinMode = isLatestTurn && shouldUseStickyLatestPin(targetTurn)
       ? 'sticky-latest'
       : 'transient';
 
-    const accepted = virtualListRef.current?.pinTurnToTop(turnId, {
+    return virtualListRef.current?.pinTurnToTop(turnId, {
       behavior: 'smooth',
       pinMode,
     }) ?? false;
-
-    setPendingHeaderTurnId(accepted ? turnId : null);
   }, [activeSession?.dialogTurns, turnSummaries]);
+
+  useEffect(() => {
+    if (!deferredHeaderTurnJump) return;
+
+    if (visibleTurnInfo?.turnId === deferredHeaderTurnJump.turnId) {
+      setDeferredHeaderTurnJump(null);
+      return;
+    }
+
+    const targetStillExists = turnSummaries.some(turn => turn.turnId === deferredHeaderTurnJump.turnId);
+    if (!targetStillExists || deferredHeaderTurnJump.attempts >= HEADER_TURN_JUMP_MAX_ATTEMPTS) {
+      setDeferredHeaderTurnJump(null);
+      return;
+    }
+
+    const frameId = requestAnimationFrame(() => {
+      const accepted = pinHeaderTurnToTop(deferredHeaderTurnJump.turnId);
+      if (accepted) {
+        setPendingHeaderTurnId(deferredHeaderTurnJump.turnId);
+        setDeferredHeaderTurnJump(null);
+        return;
+      }
+
+      setDeferredHeaderTurnJump(current => {
+        if (!current || current.turnId !== deferredHeaderTurnJump.turnId) {
+          return current;
+        }
+        return {
+          ...current,
+          attempts: current.attempts + 1,
+        };
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, [
+    deferredHeaderTurnJump,
+    pinHeaderTurnToTop,
+    turnSummaries,
+    visibleTurnInfo?.turnId,
+    virtualItems.length,
+  ]);
+
+  const handleJumpToTurn = useCallback((turnId: string) => {
+    if (!turnId) return;
+
+    const accepted = pinHeaderTurnToTop(turnId);
+    setPendingHeaderTurnId(accepted ? turnId : null);
+    setDeferredHeaderTurnJump(accepted ? null : { turnId, attempts: 0 });
+  }, [pinHeaderTurnToTop]);
 
   const handleJumpToPreviousTurn = useCallback(() => {
     if (!navigationVisibleTurnInfo || navigationVisibleTurnInfo.turnIndex <= 1) return;


### PR DESCRIPTION
## Summary

Stabilize Flow Chat turn-list navigation when the virtual message list is not ready to accept a requested turn jump immediately.

Fixes #1281

## Type and Areas

Type:

bug fix / UI/UX

Areas:

web UI / Flow Chat

## Motivation / Impact

Clicking a non-current item in the Flow Chat header turn list could close the list even when `VirtualMessageList.pinTurnToTop` returned `false`, leaving the chat view at the old position with no visible recovery.

This change keeps non-current turn-list selections open until the jump is accepted by the virtual list, then lets the existing `currentTurn` effect close the list after header navigation state advances. Failed jumps are retained as a bounded deferred request and retried on animation frames / virtual-item changes. Selecting the already-current turn still closes the list immediately.

## Verification

- `git diff --check --no-index src/web-ui/src/flow_chat/components/modern/__remote__/FlowChatHeader.main.tsx src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx` — passed, no output
- `git diff --check --no-index src/web-ui/src/flow_chat/components/modern/__remote__/ModernFlowChatContainer.main.tsx src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx` — passed, no output
- `pnpm dlx esbuild src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx --loader:.tsx=tsx --format=esm --outfile=/tmp/bitfun-flowchat-header-check.js` — passed
- `pnpm dlx esbuild src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx --loader:.tsx=tsx --format=esm --outfile=/tmp/bitfun-modern-flowchat-container-check.js` — passed

Not run:

- `pnpm run type-check:web`
- focused app/manual verification

Reason: full repository clone and tarball download stalled in this environment, so only the relevant source files were fetched through the GitHub API for a focused patch.

## Reviewer Notes

- PR targets `main`, as requested by `CONTRIBUTING.md`.
- Scope is intentionally limited to the header turn-list click path and container jump retry path. The optional `TurnHistoryPanel.tsx` follow-up mentioned in the issue is not included.
- AI-assisted change; testing level is lightweight static/syntax verification only because the full repository workspace was not available locally.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
