### PR TITLE
feat(skills): add inline skill references and picker support

### DIFF
--- a/src/crates/assembly/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
+++ b/src/crates/assembly/core/src/agentic/agents/prompt_builder/prompt_builder_impl.rs
@@ -572,6 +572,7 @@ mod tests {
             .expect("runtime context should build");
 
         assert!(skill_listing.contains("# Skill Listing"));
+        assert!(skill_listing.contains("A skill is a set of instructions provided through a `SKILL.md` source."));
         assert!(skill_listing.contains("<available_skills>"));
         assert!(!skill_listing.contains("# Agent Listing"));
         assert!(agent_listing.contains("# Agent Listing"));

--- a/src/crates/execution/agent-runtime/src/prompt.rs
+++ b/src/crates/execution/agent-runtime/src/prompt.rs
@@ -3,8 +3,9 @@
 use serde::{Deserialize, Serialize};
 
 const SKILL_LISTING_TITLE: &str = "# Skill Listing";
-const SKILL_LISTING_GUIDANCE: &str =
-    "The following skills are available for use with the Skill tool:";
+const SKILL_LISTING_GUIDANCE: &str = r#"A skill is a set of instructions provided through a `SKILL.md` source.
+If the user names a skill (with `[$SkillName]` or plain text) OR the task clearly matches a skill's description shown below, you must use that skill for that turn. Multiple mentions mean use them all. Do not carry skills across turns unless re-mentioned.
+Below is the list of skills that can be used with the Skill tool. Each entry includes a name and description"#;
 const AGENT_LISTING_TITLE: &str = "# Agent Listing";
 const AGENT_LISTING_GUIDANCE: &str = "Available subagent types for the Task tool:";
 const COLLAPSED_TOOL_LISTING_TITLE: &str = "# Collapsed Tool Listing";

--- a/src/crates/execution/agent-runtime/src/skill_agent_snapshot.rs
+++ b/src/crates/execution/agent-runtime/src/skill_agent_snapshot.rs
@@ -13,20 +13,7 @@ pub struct SkillSnapshotEntry {
 
 impl SkillSnapshotEntry {
     fn to_xml_desc(&self) -> String {
-        format!(
-            r#"<skill>
-<name>
-{}
-</name>
-<description>
-{}
-</description>
-<location>
-{}
-</location>
-</skill>"#,
-            self.name, self.description, self.location
-        )
+        format!(r#"<skill name="{}">{}</skill>"#, self.name, self.description)
     }
 }
 
@@ -385,12 +372,12 @@ mod tests {
                 SkillSnapshotEntry {
                     name: "skill-a".to_string(),
                     description: "desc-a".to_string(),
-                    location: "/a".to_string(),
+                    location: "C:/skills/skill-a".to_string(),
                 },
                 SkillSnapshotEntry {
                     name: "skill-b".to_string(),
                     description: "desc-b".to_string(),
-                    location: "/b".to_string(),
+                    location: "C:/skills/skill-b".to_string(),
                 },
             ],
             subagents: vec![AgentSnapshotEntry {
@@ -404,12 +391,12 @@ mod tests {
                 SkillSnapshotEntry {
                     name: "skill-a".to_string(),
                     description: "desc-a2".to_string(),
-                    location: "/a".to_string(),
+                    location: "C:/skills/skill-a".to_string(),
                 },
                 SkillSnapshotEntry {
                     name: "skill-c".to_string(),
                     description: "desc-c".to_string(),
-                    location: "/c".to_string(),
+                    location: "C:/skills/skill-c".to_string(),
                 },
             ],
             subagents: vec![AgentSnapshotEntry {
@@ -430,11 +417,27 @@ mod tests {
         assert!(skill_update.contains("## Changed Skills"));
         assert!(skill_update.contains("## Added Skills"));
         assert!(skill_update.contains("## Removed Skills"));
-        assert!(skill_update.contains("skill-a"));
-        assert!(skill_update.contains("skill-c"));
+        assert!(skill_update.contains(r#"<skill name="skill-a">desc-a2</skill>"#));
+        assert!(skill_update.contains(r#"<skill name="skill-c">desc-c</skill>"#));
+        assert!(!skill_update.contains("C:/skills/skill-a"));
+        assert!(!skill_update.contains("C:/skills/skill-c"));
         assert!(skill_update.contains("- skill-b"));
         assert!(agent_update.contains("## Changed Agents"));
         assert!(agent_update.contains("Grep"));
+    }
+
+    #[test]
+    fn full_skill_listing_renders_inline_name_and_description_without_location() {
+        let listing = super::render_full_skill_listing_body(&[SkillSnapshotEntry {
+            name: "skill-a".to_string(),
+            description: "desc-a".to_string(),
+            location: "C:/skills/skill-a".to_string(),
+        }]);
+
+        assert!(listing.contains("<available_skills>"));
+        assert!(listing.contains(r#"<skill name="skill-a">desc-a</skill>"#));
+        assert!(!listing.contains("<location>"));
+        assert!(!listing.contains("C:/skills/skill-a"));
     }
 
     #[test]
@@ -473,7 +476,7 @@ mod tests {
                 skills: vec![SkillSnapshotEntry {
                     name: "skill-a".to_string(),
                     description: "desc-a".to_string(),
-                    location: "/a".to_string(),
+                    location: "C:/skills/skill-a".to_string(),
                 }],
                 ..Default::default()
             },
@@ -485,7 +488,7 @@ mod tests {
                 skills: vec![SkillSnapshotEntry {
                     name: "skill-b".to_string(),
                     description: "desc-b".to_string(),
-                    location: "/b".to_string(),
+                    location: "C:/skills/skill-b".to_string(),
                 }],
                 ..Default::default()
             },

--- a/src/crates/execution/agent-runtime/src/skills/types.rs
+++ b/src/crates/execution/agent-runtime/src/skills/types.rs
@@ -51,21 +51,7 @@ pub struct SkillInfo {
 
 impl SkillInfo {
     pub fn to_xml_desc(&self) -> String {
-        format!(
-            r#"<skill>
-<name>
-{}
-</name>
-<description>
-{}
-</description>
-<location>
-{}
-</location>
-</skill>
-"#,
-            self.name, self.description, self.path
-        )
+        format!(r#"<skill name="{}">{}</skill>"#, self.name, self.description)
     }
 }
 

--- a/src/web-ui/src/flow_chat/components/ChatInput.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInput.scss
@@ -1278,6 +1278,29 @@
       }
     }
   }
+
+  &__slash-command-section {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px var(--flowchat-card-expanded-pad-x) 4px;
+  }
+
+  &__slash-command-section-line {
+    flex: 1;
+    min-width: 16px;
+    height: 1px;
+    background: var(--border-subtle);
+  }
+
+  &__slash-command-section-title {
+    flex: 0 0 auto;
+    font-size: var(--flowchat-font-size-xxs);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+  }
   
   &__slash-command-item {
     display: flex;
@@ -1325,6 +1348,13 @@
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
     overflow: hidden;
+
+    &--single-line {
+      display: block;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      -webkit-line-clamp: unset;
+    }
   }
   
   &__slash-command-current {

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { ArrowUp, BotMessageSquare, Image, RotateCcw, Plus, X, Sparkles, Loader2, ChevronRight, Files, MessageSquarePlus, Star } from 'lucide-react';
 import { ContextDropZone, useContextStore } from '../../shared/context-system';
 import { useActiveSessionState } from '@/flow_chat/hooks';
-import { RichTextInput, type MentionState } from './RichTextInput';
+import { RichTextInput, type MentionState, type InlineTriggerState } from './RichTextInput';
 import { FileMentionPicker } from './FileMentionPicker';
 import { globalEventBus } from '@/infrastructure/event-bus';
 import {
@@ -75,6 +75,12 @@ import type { ModeSkillInfo } from '@/infrastructure/config/types';
 import MCPAPI, { type MCPPrompt, type MCPPromptMessage, type MCPServerInfo } from '@/infrastructure/api/service-api/MCPAPI';
 import { ChatInputWorkspaceStrip } from './ChatInputWorkspaceStrip';
 import { expandWidgetPromptReferenceTokens } from '@/tools/generative-widget/widgetPromptReference';
+import {
+  appendSkillPromptReferenceToken,
+  createSkillPromptReferenceToken,
+  isSlashAddressableSkillName,
+  replaceLeadingSlashCommandWithSkillToken,
+} from '../utils/skillPromptReference';
 import { useDeepReviewConsent } from './DeepReviewConsentDialog';
 import { useSessionReviewActivity } from '../hooks/useSessionReviewActivity';
 import { shouldBlockDeepReviewCommand } from '../utils/deepReviewCommandGuard';
@@ -132,7 +138,20 @@ type SlashAcpCommandItem = {
   label: string;
 };
 
-type SlashPickerItem = SlashActionItem | SlashModeItem | SlashMcpPromptItem | SlashAcpCommandItem;
+type SlashSkillItem = {
+  kind: 'skill';
+  id: string;
+  command: string;
+  label: string;
+  skillName: string;
+};
+
+type SlashPickerItem =
+  | SlashActionItem
+  | SlashModeItem
+  | SlashMcpPromptItem
+  | SlashAcpCommandItem
+  | SlashSkillItem;
 type ChatInputTarget = 'main' | 'btw';
 type PendingLargePasteMap = Record<string, string>;
 
@@ -658,8 +677,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
   const openScene = useSceneStore(s => s.openScene);
   const openCreateAgent = useAgentsStore(s => s.openCreateAgent);
-  const [boostPanelSkills, setBoostPanelSkills] = useState<ModeSkillInfo[]>([]);
-  const [boostSkillsLoading, setBoostSkillsLoading] = useState(false);
+  const [resolvedModeSkills, setResolvedModeSkills] = useState<ModeSkillInfo[]>([]);
+  const [resolvedModeSkillsLoading, setResolvedModeSkillsLoading] = useState(false);
   const [userDefaultModeId, setUserDefaultModeId] = useState<string | null>(null);
   const [defaultModeSavingId, setDefaultModeSavingId] = useState<string | null>(null);
 
@@ -708,10 +727,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const setChatInputActive = useChatInputState(state => state.setActive);
   const setChatInputExpanded = useChatInputState(state => state.setExpanded);
   const setChatInputHeight = useChatInputState(state => state.setInputHeight);
-  const runtimeBoostSkills = useMemo(
+  const runtimeResolvedSkills = useMemo(
     // Only surface skills that this mode will actually resolve at runtime.
-    () => boostPanelSkills.filter(skill => skill.selectedForRuntime),
-    [boostPanelSkills]
+    () => resolvedModeSkills.filter(skill => skill.selectedForRuntime),
+    [resolvedModeSkills]
   );
 
   useEffect(() => {
@@ -910,10 +929,16 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     query: '',
     startOffset: 0,
   });
+  const [inlineTriggerState, setInlineTriggerState] = useState<InlineTriggerState>({
+    isActive: false,
+    trigger: null,
+    query: '',
+    startOffset: 0,
+  });
   
   const [slashCommandState, setSlashCommandState] = useState<{
     isActive: boolean;
-    kind: 'modes' | 'actions' | 'all';
+    kind: 'modes' | 'actions' | 'all' | 'skills';
     query: string;
     selectedIndex: number;
   }>({
@@ -948,6 +973,39 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     slashCommandState.query,
     slashCommandState.selectedIndex,
   ]);
+
+  useEffect(() => {
+    if (isAcpInputSession) {
+      if (slashCommandState.isActive && slashCommandState.kind === 'skills') {
+        setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
+      }
+      return;
+    }
+
+    const inlineSlashSkillTrigger =
+      inlineTriggerState.isActive &&
+      (
+        inlineTriggerState.trigger === '$' ||
+        (inlineTriggerState.trigger === '/' && inlineTriggerState.startOffset > 0)
+      );
+
+    if (inlineSlashSkillTrigger) {
+      setSlashCommandState(prev => ({
+        isActive: true,
+        kind: 'skills',
+        query: inlineTriggerState.query.toLowerCase(),
+        selectedIndex:
+          prev.kind === 'skills' && prev.query === inlineTriggerState.query.toLowerCase()
+            ? prev.selectedIndex
+            : 0,
+      }));
+      return;
+    }
+
+    if (slashCommandState.isActive && slashCommandState.kind === 'skills') {
+      setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
+    }
+  }, [inlineTriggerState, isAcpInputSession, slashCommandState.isActive, slashCommandState.kind]);
 
   const clearPendingLargePastes = useCallback(() => {
     pendingLargePastesRef.current = {};
@@ -1395,12 +1453,16 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     };
   }, [modeState.dropdownOpen]);
 
+  const shouldLoadResolvedModeSkills =
+    isModeDropdownOpen ||
+    (slashCommandState.isActive && (slashCommandState.kind === 'all' || slashCommandState.kind === 'skills'));
+
   useEffect(() => {
-    if (!isModeDropdownOpen) {
+    if (!shouldLoadResolvedModeSkills) {
       return;
     }
     let cancelled = false;
-    setBoostSkillsLoading(true);
+    setResolvedModeSkillsLoading(true);
     (async () => {
       try {
         const list = await configAPI.getModeSkillConfigs({
@@ -1408,23 +1470,27 @@ export const ChatInput: React.FC<ChatInputProps> = ({
           workspacePath: workspacePath || undefined,
         });
         if (!cancelled) {
-          setBoostPanelSkills(list);
+          setResolvedModeSkills(list);
         }
       } catch (err) {
-        log.error('Failed to load mode-resolved skills for boost panel', {
+        log.error('Failed to load mode-resolved skills for chat input', {
           err,
           modeId: currentMode,
           workspacePath: workspacePath || undefined,
         });
-        if (!cancelled) setBoostPanelSkills([]);
+        if (!cancelled) {
+          setResolvedModeSkills([]);
+        }
       } finally {
-        if (!cancelled) setBoostSkillsLoading(false);
+        if (!cancelled) {
+          setResolvedModeSkillsLoading(false);
+        }
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [currentMode, isModeDropdownOpen, workspacePath]);
+  }, [currentMode, shouldLoadResolvedModeSkills, workspacePath]);
 
   useEffect(() => {
     if (!modeState.dropdownOpen) {
@@ -1623,6 +1689,45 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     }));
   }, [acpAgentCommands, slashCommandState.query]);
 
+  const getFilteredSkills = useCallback((): SlashSkillItem[] => {
+    const q = (slashCommandState.query || '').trim().toLowerCase();
+    const seenNames = new Set<string>();
+    return runtimeResolvedSkills
+      .filter(skill => {
+        const normalizedName = skill.name.trim();
+        const normalizedNameKey = normalizedName.toLowerCase();
+        if (!normalizedName || seenNames.has(normalizedNameKey)) {
+          return false;
+        }
+        if (!isSlashAddressableSkillName(normalizedName)) {
+          return false;
+        }
+
+        const matches =
+          !q ||
+          normalizedNameKey.includes(q) ||
+          skill.description.toLowerCase().includes(q);
+        if (matches) {
+          seenNames.add(normalizedNameKey);
+        }
+        return matches;
+      })
+      .map(skill => ({
+        kind: 'skill' as const,
+        id: skill.key,
+        command: `/${skill.name}`,
+        label: skill.description || skill.name,
+        skillName: skill.name,
+      }))
+      .sort((a, b) => {
+        const aName = a.skillName.toLowerCase();
+        const bName = b.skillName.toLowerCase();
+        const aExact = aName === q ? 0 : aName.startsWith(q) ? 1 : 2;
+        const bExact = bName === q ? 0 : bName.startsWith(q) ? 1 : 2;
+        return aExact - bExact || aName.localeCompare(bName);
+      });
+  }, [runtimeResolvedSkills, slashCommandState.query]);
+
   const resolveTypedMcpPromptCommand = useCallback((text: string): SlashMcpPromptItem | null => {
     const trimmed = text.trim();
     if (!trimmed.startsWith('/')) {
@@ -1647,6 +1752,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
     const actions = getFilteredActions();
     const mcpPrompts = getFilteredMcpPromptCommands();
+    const skills = getFilteredSkills();
     let modeList = incrementalCodeModes;
     if (canSwitchModes && slashCommandState.query) {
       const q = slashCommandState.query;
@@ -1661,8 +1767,18 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       id: mode.id,
       name: mode.name,
     }));
-    return [...acpCommands, ...actions, ...mcpPrompts, ...modes];
-  }, [canSwitchModes, getFilteredActions, getFilteredAcpCommands, getFilteredMcpPromptCommands, incrementalCodeModes, isAcpInputSession, slashCommandState.query]);
+    return [...acpCommands, ...actions, ...mcpPrompts, ...modes, ...skills];
+  }, [canSwitchModes, getFilteredActions, getFilteredAcpCommands, getFilteredMcpPromptCommands, getFilteredSkills, incrementalCodeModes, isAcpInputSession, slashCommandState.query]);
+
+  const getActiveSlashPickerItems = useCallback((): SlashPickerItem[] => {
+    if (slashCommandState.kind === 'actions') {
+      return getFilteredActions();
+    }
+    if (slashCommandState.kind === 'skills') {
+      return getFilteredSkills();
+    }
+    return getSlashPickerItems();
+  }, [getFilteredActions, getFilteredSkills, getSlashPickerItems, slashCommandState.kind]);
   
   const handleInputChange = useCallback((text: string, activeContexts: import('../../shared/types/context').ContextItem[]) => {
     if (!inputState.isActive && text.length > 0) {
@@ -1751,6 +1867,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     }
 
     if (slashCommandState.isActive) {
+      if (slashCommandState.kind === 'skills') {
+        return;
+      }
       setSlashCommandState({
         isActive: false,
         kind: 'modes',
@@ -2653,6 +2772,33 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     window.setTimeout(() => richTextInputRef.current?.focus(), 0);
   }, [setQueuedInput]);
 
+  const getRichTextInlineTriggerController = useCallback(() => {
+    return richTextInputRef.current as (HTMLDivElement & {
+      replaceActiveInlineTrigger?: (replacementText: string) => void;
+      appendInlineTokenAtEnd?: (token: string) => void;
+      closeInlineTrigger?: () => void;
+    }) | null;
+  }, []);
+
+  const selectSlashSkill = useCallback((item: SlashSkillItem) => {
+    const replaceInlineTrigger = getRichTextInlineTriggerController()?.replaceActiveInlineTrigger;
+
+    if (inlineTriggerState.isActive) {
+      replaceInlineTrigger?.(`[$${item.skillName}]`);
+      setQueuedInput(null);
+      setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
+      window.setTimeout(() => richTextInputRef.current?.focus(), 0);
+      return;
+    }
+
+    const next = replaceLeadingSlashCommandWithSkillToken(inputState.value, item.skillName);
+    dispatchInput({ type: 'SET_VALUE', payload: next });
+    inputValueRef.current = next;
+    setQueuedInput(null);
+    setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
+    window.setTimeout(() => richTextInputRef.current?.focus(), 0);
+  }, [getRichTextInlineTriggerController, inlineTriggerState.isActive, inputState.value, setQueuedInput]);
+
   const handleBoostStartBtw = useCallback(
     (e: React.SyntheticEvent) => {
       e.stopPropagation();
@@ -2734,7 +2880,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
       if (slashCommandState.isActive) {
         setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
-        dispatchInput({ type: 'CLEAR_VALUE' });
+        if (slashCommandState.kind !== 'skills') {
+          dispatchInput({ type: 'CLEAR_VALUE' });
+        }
       }
 
       const currentIdx = modes.findIndex(m => m.id === modeNow);
@@ -2752,16 +2900,19 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         const items =
           slashCommandState.kind === 'modes'
             ? getFilteredIncrementalModes()
-            : slashCommandState.kind === 'actions'
-              ? getFilteredActions()
-              : getSlashPickerItems();
+            : getActiveSlashPickerItems();
         const maxIndex = Math.max(0, items.length - 1);
         
         if (e.key === 'ArrowDown') {
           e.preventDefault();
           setSlashCommandState(prev => ({
             ...prev,
-            selectedIndex: Math.min(prev.selectedIndex + 1, maxIndex),
+            selectedIndex:
+              items.length === 0
+                ? 0
+                : prev.selectedIndex >= maxIndex
+                  ? 0
+                  : prev.selectedIndex + 1,
           }));
           return;
         }
@@ -2770,7 +2921,12 @@ export const ChatInput: React.FC<ChatInputProps> = ({
           e.preventDefault();
           setSlashCommandState(prev => ({
             ...prev,
-            selectedIndex: Math.max(prev.selectedIndex - 1, 0),
+            selectedIndex:
+              items.length === 0
+                ? 0
+                : prev.selectedIndex <= 0
+                  ? maxIndex
+                  : prev.selectedIndex - 1,
           }));
           return;
         }
@@ -2792,6 +2948,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 selectSlashPromptCommand(item);
               } else if (item.kind === 'acpCommand') {
                 selectSlashAcpCommand(item);
+              } else if (item.kind === 'skill') {
+                selectSlashSkill(item);
               } else {
                 selectSlashCommandAction(item.id);
               }
@@ -2803,10 +2961,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         if (e.key === 'Escape') {
           e.preventDefault();
           const kind = slashCommandState.kind;
+          if (kind === 'skills') {
+            getRichTextInlineTriggerController()?.closeInlineTrigger?.();
+          }
           setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
 
           // For mode switching picker, "/" is just a trigger and should be cleared on cancel.
-          if (kind !== 'actions') {
+          if (kind !== 'actions' && kind !== 'skills') {
             dispatchInput({ type: 'CLEAR_VALUE' });
           }
           return;
@@ -2829,6 +2990,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 selectSlashPromptCommand(item);
               } else if (item.kind === 'acpCommand') {
                 selectSlashAcpCommand(item);
+              } else if (item.kind === 'skill') {
+                selectSlashSkill(item);
               } else {
                 selectSlashCommandAction(item.id);
               }
@@ -2956,7 +3119,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       e.preventDefault();
       void handleCancelCurrentTask();
     }
-  }, [handleSendOrCancel, submitBtwFromInput, submitGoalFromInput, derivedState, handleCancelCurrentTask, slashCommandState, getFilteredIncrementalModes, getFilteredActions, getSlashPickerItems, selectSlashCommandMode, selectSlashCommandAction, selectSlashPromptCommand, selectSlashAcpCommand, canSwitchModes, historyIndex, inputHistory, savedDraft, inputState.value, currentSessionId, isBtwSession, showTargetSwitcher, setInputTarget, removeContext, t]);
+  }, [handleSendOrCancel, submitBtwFromInput, submitGoalFromInput, derivedState, handleCancelCurrentTask, slashCommandState, getFilteredIncrementalModes, getActiveSlashPickerItems, selectSlashCommandMode, selectSlashCommandAction, selectSlashPromptCommand, selectSlashAcpCommand, selectSlashSkill, canSwitchModes, getRichTextInlineTriggerController, historyIndex, inputHistory, savedDraft, inputState.value, currentSessionId, isBtwSession, showTargetSwitcher, setInputTarget, removeContext, t]);
 
   const handleImeCompositionStart = useCallback(() => {
     isImeComposingRef.current = true;
@@ -3031,17 +3194,22 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
   const insertSkillIntoInput = useCallback(
     (skillName: string) => {
-      const line = t('chatInput.insertSkillLine', { name: skillName });
       dispatchInput({ type: 'ACTIVATE' });
-      const cur = inputState.value;
-      const next = cur.trim() ? `${cur.trimEnd()}\n\n${line}` : line;
-      dispatchInput({ type: 'SET_VALUE', payload: next });
+      const token = createSkillPromptReferenceToken(skillName);
+      const appendInlineTokenAtEnd = getRichTextInlineTriggerController()?.appendInlineTokenAtEnd;
+      if (appendInlineTokenAtEnd) {
+        appendInlineTokenAtEnd(token);
+      } else {
+        const next = appendSkillPromptReferenceToken(inputState.value, skillName);
+        dispatchInput({ type: 'SET_VALUE', payload: next });
+        inputValueRef.current = next;
+      }
       clearSkillsTimer();
       setSkillsFlyoutOpen(false);
       dispatchMode({ type: 'CLOSE_DROPDOWN' });
       focusRichTextInputSoon();
     },
-    [clearSkillsTimer, focusRichTextInputSoon, inputState.value, t]
+    [clearSkillsTimer, focusRichTextInputSoon, getRichTextInlineTriggerController, inputState.value]
   );
 
   const handleBoostPickImage = useCallback(
@@ -3294,6 +3462,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 contexts={contexts}
                 onRemoveContext={removeContext}
                 onMentionStateChange={setMentionState}
+                onInlineTriggerStateChange={setInlineTriggerState}
                 data-testid="chat-input-textarea"
               />
 
@@ -3350,7 +3519,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 }
 
                 if (slashCommandState.kind === 'all') {
-                  const items = getSlashPickerItems();
+                  const items = getActiveSlashPickerItems();
+                  const firstModeIndex = items.findIndex(item => item.kind === 'mode');
+                  const firstSkillIndex = items.findIndex(item => item.kind === 'skill');
                   return (
                     <div className="bitfun-chat-input__slash-command-picker">
                       <div className="bitfun-chat-input__slash-command-header">
@@ -3358,18 +3529,107 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                         <span className="bitfun-chat-input__slash-command-hint">{t('chatInput.selectHint')}</span>
                       </div>
                       <div className="bitfun-chat-input__slash-command-list">
-                        {mcpPromptCommandsLoading && items.length === 0 ? (
+                        {items.length === 0 && (mcpPromptCommandsLoading || resolvedModeSkillsLoading) ? (
                           <div className="bitfun-chat-input__slash-command-empty">
-                            {t('chatInput.loadingMcpPrompts')}
+                            {resolvedModeSkillsLoading && !mcpPromptCommandsLoading
+                              ? t('chatInput.boostSkillsLoading')
+                              : t('chatInput.loadingMcpPrompts')}
                           </div>
                         ) : items.length > 0 ? (
                           items.map((item, index) => {
                             const commandText = item.kind === 'mode' ? `/${item.id}` : item.command;
                             const labelText = item.kind === 'mode'
                               ? item.name
+                              : item.kind === 'skill'
+                                ? item.label
                               : item.kind === 'mcpPrompt'
                                 ? `${item.serverName} · ${item.label}`
                                 : item.label;
+
+                            return (
+                              <React.Fragment key={`${item.kind}-${item.id}`}>
+                                {index === firstModeIndex && (
+                                  <div className="bitfun-chat-input__slash-command-section">
+                                    <span className="bitfun-chat-input__slash-command-section-line" aria-hidden />
+                                    <span className="bitfun-chat-input__slash-command-section-title">
+                                      {t('chatInput.modeSection')}
+                                    </span>
+                                    <span className="bitfun-chat-input__slash-command-section-line" aria-hidden />
+                                  </div>
+                                )}
+                                {index === firstSkillIndex && (
+                                  <div className="bitfun-chat-input__slash-command-section">
+                                    <span className="bitfun-chat-input__slash-command-section-line" aria-hidden />
+                                    <span className="bitfun-chat-input__slash-command-section-title">
+                                      {t('chatInput.boostSkills')}
+                                    </span>
+                                    <span className="bitfun-chat-input__slash-command-section-line" aria-hidden />
+                                  </div>
+                                )}
+                                <div
+                                  className={`bitfun-chat-input__slash-command-item ${index === slashCommandState.selectedIndex ? 'bitfun-chat-input__slash-command-item--selected' : ''} ${item.kind === 'mode' && item.id === modeState.current ? 'bitfun-chat-input__slash-command-item--active' : ''}`}
+                                  title={`${commandText}\n${labelText}`}
+                                  onClick={() => {
+                                    if (item.kind === 'mode') {
+                                      selectSlashCommandMode(item.id);
+                                    } else if (item.kind === 'skill') {
+                                      selectSlashSkill(item);
+                                    } else if (item.kind === 'mcpPrompt') {
+                                      selectSlashPromptCommand(item);
+                                    } else if (item.kind === 'acpCommand') {
+                                      selectSlashAcpCommand(item);
+                                    } else {
+                                      selectSlashCommandAction(item.id);
+                                    }
+                                  }}
+                                  onMouseEnter={() => setSlashCommandState(prev => ({ ...prev, selectedIndex: index }))}
+                                >
+                                  <span className="bitfun-chat-input__slash-command-name">
+                                    {commandText}
+                                  </span>
+                                  <span
+                                    className={`bitfun-chat-input__slash-command-label ${item.kind === 'skill' ? 'bitfun-chat-input__slash-command-label--single-line' : ''}`}
+                                  >
+                                    {labelText}
+                                  </span>
+                                  {item.kind === 'mode' && item.id === modeState.current && <span className="bitfun-chat-input__slash-command-current">{t('chatInput.current')}</span>}
+                                </div>
+                              </React.Fragment>
+                            );
+                          })
+                        ) : (
+                          <div className="bitfun-chat-input__slash-command-empty">
+                            {t('chatInput.noMatchingCommand')}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                }
+
+                if (slashCommandState.kind === 'skills') {
+                  const items = getActiveSlashPickerItems();
+                  return (
+                    <div className="bitfun-chat-input__slash-command-picker">
+                      <div className="bitfun-chat-input__slash-command-header">
+                        <span>{t('chatInput.boostSkills')}</span>
+                        <span className="bitfun-chat-input__slash-command-hint">{t('chatInput.selectHint')}</span>
+                      </div>
+                      <div className="bitfun-chat-input__slash-command-list">
+                        {items.length === 0 && resolvedModeSkillsLoading ? (
+                          <div className="bitfun-chat-input__slash-command-empty">
+                            {t('chatInput.boostSkillsLoading')}
+                          </div>
+                        ) : items.length > 0 ? (
+                          items.map((item, index) => {
+                            const commandText = item.kind === 'mode' ? `/${item.id}` : item.command;
+                            const labelText = item.kind === 'mode'
+                              ? item.name
+                              : item.kind === 'skill'
+                                ? item.label
+                                : item.kind === 'mcpPrompt'
+                                  ? `${item.serverName} · ${item.label}`
+                                  : item.label;
 
                             return (
                               <div
@@ -3379,6 +3639,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                                 onClick={() => {
                                   if (item.kind === 'mode') {
                                     selectSlashCommandMode(item.id);
+                                  } else if (item.kind === 'skill') {
+                                    selectSlashSkill(item);
                                   } else if (item.kind === 'mcpPrompt') {
                                     selectSlashPromptCommand(item);
                                   } else if (item.kind === 'acpCommand') {
@@ -3392,7 +3654,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                                 <span className="bitfun-chat-input__slash-command-name">
                                   {commandText}
                                 </span>
-                                <span className="bitfun-chat-input__slash-command-label">
+                                <span
+                                  className={`bitfun-chat-input__slash-command-label ${item.kind === 'skill' ? 'bitfun-chat-input__slash-command-label--single-line' : ''}`}
+                                >
                                   {labelText}
                                 </span>
                                 {item.kind === 'mode' && item.id === modeState.current && <span className="bitfun-chat-input__slash-command-current">{t('chatInput.current')}</span>}
@@ -3611,16 +3875,16 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                             onMouseLeave={closeSkillsFlyout}
                           >
                             <div className="bitfun-chat-input__boost-submenu-panel">
-                              {boostSkillsLoading ? (
+                              {resolvedModeSkillsLoading ? (
                                 <div className="bitfun-chat-input__boost-submenu-loading">
                                   <Loader2 size={14} className="bitfun-chat-input__boost-submenu-spinner" aria-hidden />
                                   <span>{t('chatInput.boostSkillsLoading')}</span>
                                 </div>
-                              ) : runtimeBoostSkills.length === 0 ? (
+                              ) : runtimeResolvedSkills.length === 0 ? (
                                 <div className="bitfun-chat-input__boost-submenu-empty">{t('chatInput.boostSkillsEmpty')}</div>
                               ) : (
                                 <div className="bitfun-chat-input__boost-submenu-list">
-                                  {runtimeBoostSkills.map(skill => (
+                                  {runtimeResolvedSkills.map(skill => (
                                     <div
                                       key={skill.key}
                                       role="button"

--- a/src/web-ui/src/flow_chat/components/RichTextInput.scss
+++ b/src/web-ui/src/flow_chat/components/RichTextInput.scss
@@ -195,6 +195,15 @@
   }
 }
 
+.rich-text-tag-pill--skill-ref {
+  background: color-mix(in srgb, var(--color-warning) 16%, transparent);
+  color: color-mix(in srgb, var(--color-warning) 96%, var(--color-text-primary));
+
+  &:hover {
+    background: color-mix(in srgb, var(--color-warning) 24%, transparent);
+  }
+}
+
 .rich-text-tag-pill__badge {
   display: inline-flex;
   align-items: center;
@@ -211,9 +220,31 @@
   text-transform: uppercase;
 }
 
+.rich-text-tag-pill__badge--icon {
+  min-width: 18px;
+  padding: 0 3px;
+  background: transparent;
+  letter-spacing: 0;
+  text-transform: none;
+
+  svg {
+    width: 12px;
+    height: 12px;
+    stroke: currentColor;
+    fill: none;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    flex-shrink: 0;
+  }
+}
+
 .rich-text-tag-pill__text--widget-ref {
   font-family: $font-family-sans;
   max-width: 260px;
+}
+
+.rich-text-tag-pill__text--skill-ref {
+  max-width: 220px;
 }
 
 .rich-text-tag-pill__remove {

--- a/src/web-ui/src/flow_chat/components/RichTextInput.test.tsx
+++ b/src/web-ui/src/flow_chat/components/RichTextInput.test.tsx
@@ -183,6 +183,23 @@ describeWithJsdom('RichTextInput external sync', () => {
     expect(editor.firstChild).not.toBe(originalTextNode);
   });
 
+  it('renders externally inserted skill tokens as inline pills', async () => {
+    const harnessRef = createRef<HarnessHandle>();
+    const editor = await renderHarness(harnessRef);
+
+    await act(async () => {
+      harnessRef.current?.setValue('Use [$pdf] please');
+    });
+
+    const skillPill = editor.querySelector(
+      '[data-inline-token-type="skill-ref"]',
+    ) as HTMLElement | null;
+    expect(skillPill).toBeTruthy();
+    expect(skillPill?.getAttribute('data-tag-format')).toBe('[$pdf]');
+    expect(skillPill?.querySelector('.lucide-puzzle')).toBeTruthy();
+    expect(editor.textContent).toContain('pdf');
+  });
+
   it('keeps Escape owned by IME composition', async () => {
     const onKeyDown = vi.fn();
 
@@ -246,6 +263,176 @@ describeWithJsdom('RichTextInput external sync', () => {
       query: 'root',
       startOffset: 0,
     });
+  });
+
+  it('reports inline skill triggers for $ and middle-of-text /', async () => {
+    const onInlineTriggerStateChange = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <RichTextInput
+          value=""
+          onChange={() => {}}
+          onInlineTriggerStateChange={onInlineTriggerStateChange}
+          contexts={emptyContexts}
+          onRemoveContext={() => {}}
+        />
+      );
+    });
+
+    const editor = container.querySelector('.rich-text-input');
+    expect(editor).toBeInstanceOf(HTMLDivElement);
+
+    await updateEditorText(editor as HTMLDivElement, '$pdf');
+    expect(onInlineTriggerStateChange).toHaveBeenLastCalledWith({
+      isActive: true,
+      trigger: '$',
+      query: 'pdf',
+      startOffset: 0,
+    });
+
+    await updateEditorText(editor as HTMLDivElement, 'please /pdf');
+    expect(onInlineTriggerStateChange).toHaveBeenLastCalledWith({
+      isActive: true,
+      trigger: '/',
+      query: 'pdf',
+      startOffset: 7,
+    });
+  });
+
+  it('can replace an active inline trigger with a skill token', async () => {
+    const onChange = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <RichTextInput
+          value="$pdf"
+          onChange={onChange}
+          contexts={emptyContexts}
+          onRemoveContext={() => {}}
+        />
+      );
+    });
+
+    const editor = container.querySelector('.rich-text-input') as (HTMLDivElement & {
+      replaceActiveInlineTrigger?: (replacementText: string) => void;
+    }) | null;
+    expect(editor).toBeTruthy();
+
+    setCaret(editor!, '$pdf'.length);
+    await act(async () => {
+      editor!.dispatchEvent(new window.Event('input', { bubbles: true }));
+    });
+
+    await act(async () => {
+      editor?.replaceActiveInlineTrigger?.('[$pdf]');
+    });
+
+    expect(onChange).toHaveBeenCalledWith('[$pdf]', emptyContexts);
+    const skillPill = editor?.querySelector('.rich-text-tag-pill--skill-ref');
+    expect(skillPill).toBeTruthy();
+    expect(skillPill?.querySelector('.lucide-puzzle')).toBeTruthy();
+    expect(skillPill?.nextSibling?.textContent).toBe(' ');
+    const selection = window.getSelection();
+    expect(selection?.anchorNode).toBe(editor);
+    expect(selection?.anchorOffset).toBeGreaterThan(Array.from(editor?.childNodes ?? []).indexOf(skillPill as ChildNode));
+  });
+
+  it('can close an active inline trigger imperatively', async () => {
+    const onInlineTriggerStateChange = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <RichTextInput
+          value="$pdf"
+          onChange={() => {}}
+          onInlineTriggerStateChange={onInlineTriggerStateChange}
+          contexts={emptyContexts}
+          onRemoveContext={() => {}}
+        />
+      );
+    });
+
+    const editor = container.querySelector('.rich-text-input') as (HTMLDivElement & {
+      closeInlineTrigger?: () => void;
+    }) | null;
+    expect(editor).toBeTruthy();
+
+    setCaret(editor!, '$pdf'.length);
+    await act(async () => {
+      editor!.dispatchEvent(new window.Event('input', { bubbles: true }));
+    });
+
+    await act(async () => {
+      editor?.closeInlineTrigger?.();
+    });
+
+    expect(onInlineTriggerStateChange).toHaveBeenLastCalledWith({
+      isActive: false,
+      trigger: null,
+      query: '',
+      startOffset: 0,
+    });
+  });
+
+  it('can append an inline skill token at the end with trailing space', async () => {
+    const onChange = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <RichTextInput
+          value="hello"
+          onChange={onChange}
+          contexts={emptyContexts}
+          onRemoveContext={() => {}}
+        />
+      );
+    });
+
+    const editor = container.querySelector('.rich-text-input') as (HTMLDivElement & {
+      appendInlineTokenAtEnd?: (token: string) => void;
+    }) | null;
+    expect(editor).toBeTruthy();
+
+    await act(async () => {
+      editor?.appendInlineTokenAtEnd?.('[$pdf]');
+    });
+
+    expect(onChange).toHaveBeenCalledWith('hello [$pdf]', emptyContexts);
+    const skillPill = editor?.querySelector('.rich-text-tag-pill--skill-ref');
+    expect(skillPill).toBeTruthy();
+    expect(skillPill?.previousSibling?.textContent).toBe(' ');
+    expect(skillPill?.nextSibling?.textContent).toBe(' ');
+  });
+
+  it('clears placeholder br before appending the first inline skill token', async () => {
+    const onChange = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <RichTextInput
+          value=""
+          onChange={onChange}
+          contexts={emptyContexts}
+          onRemoveContext={() => {}}
+        />
+      );
+    });
+
+    const editor = container.querySelector('.rich-text-input') as (HTMLDivElement & {
+      appendInlineTokenAtEnd?: (token: string) => void;
+    }) | null;
+    expect(editor).toBeTruthy();
+
+    editor!.innerHTML = '<br>';
+
+    await act(async () => {
+      editor?.appendInlineTokenAtEnd?.('[$pdf]');
+    });
+
+    expect(onChange).toHaveBeenCalledWith('[$pdf]', emptyContexts);
+    expect(editor?.querySelector('br')).toBeFalsy();
+    expect(editor?.firstChild).toBe(editor?.querySelector('.rich-text-tag-pill--skill-ref'));
   });
 
   it('inserts a separating space when opening mention from a mid-word caret', async () => {

--- a/src/web-ui/src/flow_chat/components/RichTextInput.tsx
+++ b/src/web-ui/src/flow_chat/components/RichTextInput.tsx
@@ -4,19 +4,36 @@
  */
 
 import React, { useRef, useEffect, useCallback, useState } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Puzzle } from 'lucide-react';
 import type { ContextItem } from '../../shared/types/context';
 import { getRichTextExternalSyncAction } from './richTextInputSync';
 import {
   getWidgetPromptReferenceMatches,
   parseWidgetPromptReferenceToken,
 } from '@/tools/generative-widget/widgetPromptReference';
+import {
+  getSkillPromptReferenceMatches,
+  parseSkillPromptReferenceToken,
+} from '../utils/skillPromptReference';
 import './RichTextInput.scss';
+
+const SKILL_REFERENCE_BADGE_ICON = renderToStaticMarkup(
+  <Puzzle size={12} strokeWidth={2.2} aria-hidden="true" />,
+);
 
 /** @ mention state */
 export interface MentionState {
   isActive: boolean;
   query: string;
   startOffset: number;  // Position of the @ symbol in text
+}
+
+export interface InlineTriggerState {
+  isActive: boolean;
+  trigger: '/' | '$' | null;
+  query: string;
+  startOffset: number;
 }
 
 export interface RichTextInputProps
@@ -39,6 +56,8 @@ export interface RichTextInputProps
   onRemoveContext: (id: string) => void;
   /** Callback when @ mention state changes */
   onMentionStateChange?: (state: MentionState) => void;
+  /** Callback when inline trigger state changes for / or $ */
+  onInlineTriggerStateChange?: (state: InlineTriggerState) => void;
 }
 
 function isWhitespaceCharacter(char: string | undefined): boolean {
@@ -137,6 +156,7 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
   contexts,
   onRemoveContext,
   onMentionStateChange,
+  onInlineTriggerStateChange,
   ...restProps
 }, ref) => {
   const editorRef = useRef<HTMLDivElement>(null);
@@ -145,6 +165,12 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
   const isComposingRef = useRef(false);
   const lastContextIdsRef = useRef<Set<string>>(new Set());
   const mentionStateRef = useRef<MentionState>({ isActive: false, query: '', startOffset: 0 });
+  const inlineTriggerStateRef = useRef<InlineTriggerState>({
+    isActive: false,
+    trigger: null,
+    query: '',
+    startOffset: 0,
+  });
   const triggerSyncRef = useRef<(() => void) | null>(null);
 
   const closeMention = useCallback(() => {
@@ -155,6 +181,25 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
     mentionStateRef.current = { isActive: false, query: '', startOffset: 0 };
     onMentionStateChange?.({ isActive: false, query: '', startOffset: 0 });
   }, [onMentionStateChange]);
+
+  const closeInlineTrigger = useCallback(() => {
+    if (!inlineTriggerStateRef.current.isActive) {
+      return;
+    }
+
+    inlineTriggerStateRef.current = {
+      isActive: false,
+      trigger: null,
+      query: '',
+      startOffset: 0,
+    };
+    onInlineTriggerStateChange?.({
+      isActive: false,
+      trigger: null,
+      query: '',
+      startOffset: 0,
+    });
+  }, [onInlineTriggerStateChange]);
 
   // Create tag element with pill style
   const createTagElement = useCallback((context: ContextItem): HTMLSpanElement => {
@@ -238,9 +283,64 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
     return tag;
   }, [internalRef, removeInlineTokenElement]);
 
+  const createSkillReferenceElement = useCallback((token: string): HTMLSpanElement | null => {
+    const payload = parseSkillPromptReferenceToken(token);
+    if (!payload) {
+      return null;
+    }
+
+    const tag = document.createElement('span');
+    tag.className = 'rich-text-tag-pill rich-text-tag-pill--skill-ref';
+    tag.contentEditable = 'false';
+    tag.dataset.tagFormat = token;
+    tag.dataset.inlineTokenType = 'skill-ref';
+    tag.title = `Skill: ${payload.skillName}`;
+
+    const badge = document.createElement('span');
+    badge.className = 'rich-text-tag-pill__badge rich-text-tag-pill__badge--icon';
+    badge.innerHTML = SKILL_REFERENCE_BADGE_ICON;
+
+    const text = document.createElement('span');
+    text.className = 'rich-text-tag-pill__text rich-text-tag-pill__text--skill-ref';
+    text.textContent = payload.skillName;
+
+    const remove = document.createElement('button');
+    remove.className = 'rich-text-tag-pill__remove';
+    remove.textContent = '×';
+    remove.title = 'Remove';
+    remove.onclick = (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      removeInlineTokenElement(tag);
+      requestAnimationFrame(() => {
+        internalRef.current?.focus();
+        triggerSyncRef.current?.();
+      });
+    };
+
+    tag.appendChild(badge);
+    tag.appendChild(text);
+    tag.appendChild(remove);
+
+    return tag;
+  }, [internalRef, removeInlineTokenElement]);
+
+  const createInlineTokenElement = useCallback((token: string): HTMLSpanElement | null => {
+    return createWidgetReferenceElement(token) ?? createSkillReferenceElement(token);
+  }, [createSkillReferenceElement, createWidgetReferenceElement]);
+
   const renderValueWithInlineTokens = useCallback((editor: HTMLElement, text: string) => {
     const fragment = document.createDocumentFragment();
-    const matches = getWidgetPromptReferenceMatches(text);
+    const matches = [
+      ...getWidgetPromptReferenceMatches(text).map(match => ({
+        ...match,
+        kind: 'widget-ref' as const,
+      })),
+      ...getSkillPromptReferenceMatches(text).map(match => ({
+        ...match,
+        kind: 'skill-ref' as const,
+      })),
+    ].sort((a, b) => a.start - b.start);
 
     if (matches.length === 0) {
       editor.textContent = text;
@@ -253,7 +353,9 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
         fragment.appendChild(document.createTextNode(text.slice(cursor, match.start)));
       }
 
-      const tokenElement = createWidgetReferenceElement(match.token);
+      const tokenElement = match.kind === 'widget-ref'
+        ? createWidgetReferenceElement(match.token)
+        : createSkillReferenceElement(match.token);
       if (tokenElement) {
         fragment.appendChild(tokenElement);
       } else {
@@ -267,7 +369,7 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
     }
 
     editor.replaceChildren(fragment);
-  }, [createWidgetReferenceElement]);
+  }, [createSkillReferenceElement, createWidgetReferenceElement]);
 
   /** Map textContent offsets to a DOM Range to replace only the @ span. */
   const getRangeByTextOffsets = useCallback((root: Node, start: number, end: number): Range | null => {
@@ -349,21 +451,21 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
     return sanitizeText(text).trim();
   }, [internalRef]);
 
-  // Detect @ mention
-  const detectMention = useCallback(() => {
+  // Detect @ mention plus inline / and $ triggers near the caret.
+  const detectActiveTrigger = useCallback(() => {
     if (!internalRef.current) return;
     
     const selection = window.getSelection();
     if (!selection || selection.rangeCount === 0) {
-      // No selection, close mention
       closeMention();
+      closeInlineTrigger();
       return;
     }
     
     const range = selection.getRangeAt(0);
     if (!range.collapsed) {
-      // Non-collapsed selection, close mention
       closeMention();
+      closeInlineTrigger();
       return;
     }
     
@@ -393,41 +495,70 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
     
     const textBeforeCursor = fullText.slice(0, cursorPosition);
     
-    // Find the last @
-    const lastAtIndex = textBeforeCursor.lastIndexOf('@');
-    
-    if (lastAtIndex !== -1) {
-      const charBeforeAt = textBeforeCursor[lastAtIndex - 1];
-      if (!isWhitespaceCharacter(charBeforeAt)) {
-        closeMention();
-        return;
-      }
+    const candidates = ['@', '/', '$'] as const;
+    let selectedTrigger: (typeof candidates)[number] | null = null;
+    let selectedIndex = -1;
 
-      // Extract query after @ up to the cursor
-      const query = textBeforeCursor.slice(lastAtIndex + 1);
-      
-      // If query contains whitespace, the mention is complete
-      if (!query.includes(' ') && !query.includes('\n')) {
-        const newState: MentionState = {
-          isActive: true,
-          query,
-          startOffset: lastAtIndex,
-        };
-        
-        // Update only on state changes
-        if (!mentionStateRef.current.isActive || 
+    for (const trigger of candidates) {
+      const index = textBeforeCursor.lastIndexOf(trigger);
+      if (index > selectedIndex) {
+        selectedIndex = index;
+        selectedTrigger = trigger;
+      }
+    }
+
+    if (selectedTrigger !== null && selectedIndex !== -1) {
+      const charBeforeTrigger = textBeforeCursor[selectedIndex - 1];
+      const query = textBeforeCursor.slice(selectedIndex + 1);
+
+      if (
+        isWhitespaceCharacter(charBeforeTrigger) &&
+        !query.includes(' ') &&
+        !query.includes('\n')
+      ) {
+        if (selectedTrigger === '@') {
+          const newState: MentionState = {
+            isActive: true,
+            query,
+            startOffset: selectedIndex,
+          };
+
+          if (
+            !mentionStateRef.current.isActive ||
             mentionStateRef.current.query !== query ||
-            mentionStateRef.current.startOffset !== lastAtIndex) {
-          mentionStateRef.current = newState;
-          onMentionStateChange?.(newState);
+            mentionStateRef.current.startOffset !== selectedIndex
+          ) {
+            mentionStateRef.current = newState;
+            onMentionStateChange?.(newState);
+          }
+          closeInlineTrigger();
+          return;
+        }
+
+        closeMention();
+        const nextInlineTriggerState: InlineTriggerState = {
+          isActive: true,
+          trigger: selectedTrigger,
+          query,
+          startOffset: selectedIndex,
+        };
+        const currentInlineTriggerState = inlineTriggerStateRef.current;
+        if (
+          currentInlineTriggerState.isActive !== nextInlineTriggerState.isActive ||
+          currentInlineTriggerState.trigger !== nextInlineTriggerState.trigger ||
+          currentInlineTriggerState.query !== nextInlineTriggerState.query ||
+          currentInlineTriggerState.startOffset !== nextInlineTriggerState.startOffset
+        ) {
+          inlineTriggerStateRef.current = nextInlineTriggerState;
+          onInlineTriggerStateChange?.(nextInlineTriggerState);
         }
         return;
       }
     }
-    
-    // No valid mention, close it
+
     closeMention();
-  }, [closeMention, internalRef, onMentionStateChange]);
+    closeInlineTrigger();
+  }, [closeInlineTrigger, closeMention, internalRef, onInlineTriggerStateChange, onMentionStateChange]);
 
   /** Compute the cursor's character offset within the editor. */
   const getCursorOffset = useCallback((editor: HTMLElement): number => {
@@ -518,9 +649,9 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
     
     // Ensure detection runs after DOM updates
     requestAnimationFrame(() => {
-      detectMention();
+      detectActiveTrigger();
     });
-  }, [contexts, detectMention, extractTextContent, getCursorOffset, internalRef, onChange, setCursorOffset]);
+  }, [contexts, detectActiveTrigger, extractTextContent, getCursorOffset, internalRef, onChange, setCursorOffset]);
 
   triggerSyncRef.current = handleInput;
 
@@ -559,8 +690,9 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
       return;
     }
     
-    // Plain text paste - close any active mention to prevent @ in pasted content from triggering mention mode
+    // Plain text paste - close active triggers so pasted marker characters do not immediately reopen pickers
     closeMention();
+    closeInlineTrigger();
     
     const text = e.clipboardData.getData('text/plain');
     const largePastePlaceholder = onLargePaste?.(text);
@@ -571,7 +703,7 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
     requestAnimationFrame(() => {
       isComposingRef.current = false;
     });
-  }, [closeMention, internalRef, onLargePaste]);
+  }, [closeInlineTrigger, closeMention, internalRef, onLargePaste]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     const nativeEvent = e.nativeEvent as KeyboardEvent;
@@ -679,6 +811,90 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
     closeMention();
   }, [closeMention, createTagElement, getRangeByTextOffsets, handleInput, insertTagAtCursor, internalRef]);
 
+  const replaceActiveInlineTrigger = useCallback((replacementText: string) => {
+    if (!internalRef.current || !inlineTriggerStateRef.current.isActive) {
+      return;
+    }
+
+    const editor = internalRef.current;
+    const triggerStart = inlineTriggerStateRef.current.startOffset;
+    const triggerEnd = triggerStart + 1 + inlineTriggerStateRef.current.query.length;
+    const range = getRangeByTextOffsets(editor, triggerStart, triggerEnd);
+    if (!range) {
+      return;
+    }
+
+    range.deleteContents();
+    const selection = window.getSelection();
+    if (replacementText) {
+      const inlineTokenElement = createInlineTokenElement(replacementText);
+      const replacementNode = inlineTokenElement ?? document.createTextNode(replacementText);
+      const trailingSpace = document.createTextNode(' ');
+      const fragment = document.createDocumentFragment();
+      fragment.appendChild(replacementNode);
+      fragment.appendChild(trailingSpace);
+      range.insertNode(fragment);
+
+      if (selection) {
+        const newRange = document.createRange();
+        newRange.setStartAfter(trailingSpace);
+        newRange.setEndAfter(trailingSpace);
+        selection.removeAllRanges();
+        selection.addRange(newRange);
+      }
+    } else if (selection) {
+      const newRange = document.createRange();
+      newRange.setStart(range.startContainer, range.startOffset);
+      newRange.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(newRange);
+    }
+
+    editor.focus();
+    closeInlineTrigger();
+    handleInput();
+  }, [closeInlineTrigger, createInlineTokenElement, getRangeByTextOffsets, handleInput, internalRef]);
+
+  const appendInlineTokenAtEnd = useCallback((token: string) => {
+    if (!internalRef.current) {
+      return;
+    }
+
+    const editor = internalRef.current;
+    const currentTextContent = extractTextContent();
+    if (!currentTextContent) {
+      editor.replaceChildren();
+    }
+    editor.focus();
+
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+
+    const fragment = document.createDocumentFragment();
+    if (currentTextContent) {
+      fragment.appendChild(document.createTextNode(' '));
+    }
+
+    const inlineTokenElement = createInlineTokenElement(token);
+    fragment.appendChild(inlineTokenElement ?? document.createTextNode(token));
+
+    const trailingSpace = document.createTextNode(' ');
+    fragment.appendChild(trailingSpace);
+    range.insertNode(fragment);
+
+    const selection = window.getSelection();
+    if (selection) {
+      const newRange = document.createRange();
+      newRange.setStartAfter(trailingSpace);
+      newRange.setEndAfter(trailingSpace);
+      selection.removeAllRanges();
+      selection.addRange(newRange);
+    }
+
+    handleInput();
+  }, [createInlineTokenElement, extractTextContent, handleInput, internalRef]);
+
   /** Insert @ at caret and open the file/folder mention picker (e.g. from ChatInput + menu). */
   const openMention = useCallback(() => {
     const editor = internalRef.current;
@@ -707,19 +923,22 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
 
     document.execCommand('insertText', false, mentionTriggerText);
     requestAnimationFrame(() => {
-      detectMention();
+      detectActiveTrigger();
     });
-  }, [detectMention, getCursorOffset, internalRef]);
+  }, [detectActiveTrigger, getCursorOffset, internalRef]);
 
   // Expose methods to parent
   useEffect(() => {
     if (internalRef.current) {
       (internalRef.current as any).insertTag = insertTagAtCursor;
       (internalRef.current as any).insertTagReplacingMention = insertTagReplacingMention;
+      (internalRef.current as any).replaceActiveInlineTrigger = replaceActiveInlineTrigger;
+      (internalRef.current as any).appendInlineTokenAtEnd = appendInlineTokenAtEnd;
       (internalRef.current as any).openMention = openMention;
       (internalRef.current as any).closeMention = closeMention;
+      (internalRef.current as any).closeInlineTrigger = closeInlineTrigger;
     }
-  }, [closeMention, insertTagAtCursor, insertTagReplacingMention, openMention, internalRef]);
+  }, [appendInlineTokenAtEnd, closeInlineTrigger, closeMention, insertTagAtCursor, insertTagReplacingMention, openMention, replaceActiveInlineTrigger, internalRef]);
 
   // Initialize and sync value changes from external sources.
   // This editor is effectively controlled by comparing the parent's value
@@ -801,9 +1020,10 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
     // Delay closing to allow picker clicks
     setTimeout(() => {
       closeMention();
+      closeInlineTrigger();
     }, 200);
     onBlur?.();
-  }, [closeMention, onBlur]);
+  }, [closeInlineTrigger, closeMention, onBlur]);
 
   // Handle IME composition
   const handleCompositionStart = useCallback(() => {

--- a/src/web-ui/src/flow_chat/utils/skillPromptReference.test.ts
+++ b/src/web-ui/src/flow_chat/utils/skillPromptReference.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendSkillPromptReferenceToken,
+  createSkillPromptReferenceToken,
+  getSkillPromptReferenceMatches,
+  isSlashAddressableSkillName,
+  parseSkillPromptReferenceToken,
+  replaceLeadingSlashCommandWithSkillToken,
+} from './skillPromptReference';
+
+describe('skillPromptReference', () => {
+  it('creates and parses skill prompt tokens', () => {
+    const token = createSkillPromptReferenceToken('pdf');
+
+    expect(token).toBe('[$pdf]');
+    expect(parseSkillPromptReferenceToken(token)).toEqual({ skillName: 'pdf' });
+  });
+
+  it('finds skill tokens inside mixed text', () => {
+    expect(getSkillPromptReferenceMatches('Use [$pdf] and [$browser].')).toEqual([
+      {
+        token: '[$pdf]',
+        start: 4,
+        end: 10,
+        payload: { skillName: 'pdf' },
+      },
+      {
+        token: '[$browser]',
+        start: 15,
+        end: 25,
+        payload: { skillName: 'browser' },
+      },
+    ]);
+  });
+
+  it('appends and replaces slash commands with skill tokens', () => {
+    expect(appendSkillPromptReferenceToken('Summarize this', 'pdf')).toBe('Summarize this [$pdf]');
+    expect(replaceLeadingSlashCommandWithSkillToken('/pdf summarize this', 'pdf')).toBe(
+      '[$pdf] summarize this',
+    );
+    expect(replaceLeadingSlashCommandWithSkillToken('  /pdf summarize this', 'pdf')).toBe(
+      '  [$pdf] summarize this',
+    );
+  });
+
+  it('matches only slash-addressable skill names', () => {
+    expect(isSlashAddressableSkillName('pdf')).toBe(true);
+    expect(isSlashAddressableSkillName('browser-control')).toBe(true);
+    expect(isSlashAddressableSkillName('browser control')).toBe(false);
+  });
+});

--- a/src/web-ui/src/flow_chat/utils/skillPromptReference.ts
+++ b/src/web-ui/src/flow_chat/utils/skillPromptReference.ts
@@ -1,0 +1,78 @@
+const SKILL_TOKEN_PATTERN = /\[\$([^\]\r\n]+)\]/g;
+const LEADING_SLASH_COMMAND_PATTERN = /^(\s*)\/[A-Za-z][\w:-]*/;
+const SLASH_ADDRESSABLE_SKILL_NAME_PATTERN = /^[A-Za-z][\w:-]*$/;
+
+export interface SkillPromptReferenceTokenPayload {
+  skillName: string;
+}
+
+export function createSkillPromptReferenceToken(skillName: string): string {
+  return `[$${skillName.trim()}]`;
+}
+
+export function parseSkillPromptReferenceToken(
+  token: string,
+): SkillPromptReferenceTokenPayload | null {
+  const match = token.match(/^\[\$([^\]\r\n]+)\]$/);
+  const skillName = match?.[1]?.trim();
+  if (!skillName) {
+    return null;
+  }
+  return { skillName };
+}
+
+export function getSkillPromptReferenceMatches(text: string): Array<{
+  token: string;
+  start: number;
+  end: number;
+  payload: SkillPromptReferenceTokenPayload;
+}> {
+  const matches: Array<{
+    token: string;
+    start: number;
+    end: number;
+    payload: SkillPromptReferenceTokenPayload;
+  }> = [];
+
+  SKILL_TOKEN_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SKILL_TOKEN_PATTERN.exec(text)) !== null) {
+    const payload = parseSkillPromptReferenceToken(match[0]);
+    if (!payload) {
+      continue;
+    }
+    matches.push({
+      token: match[0],
+      start: match.index,
+      end: match.index + match[0].length,
+      payload,
+    });
+  }
+
+  return matches;
+}
+
+export function appendSkillPromptReferenceToken(
+  text: string,
+  skillName: string,
+): string {
+  const token = createSkillPromptReferenceToken(skillName);
+  const trimmed = text.trimEnd();
+  return trimmed ? `${trimmed} ${token}` : token;
+}
+
+export function replaceLeadingSlashCommandWithSkillToken(
+  text: string,
+  skillName: string,
+): string {
+  const token = createSkillPromptReferenceToken(skillName);
+  if (!text.trimStart().startsWith('/')) {
+    return appendSkillPromptReferenceToken(text, skillName);
+  }
+
+  return text.replace(LEADING_SLASH_COMMAND_PATTERN, `${'$1'}${token}`);
+}
+
+export function isSlashAddressableSkillName(skillName: string): boolean {
+  return SLASH_ADDRESSABLE_SKILL_NAME_PATTERN.test(skillName.trim());
+}

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -555,6 +555,7 @@
     "boostStartBtw": "Start side question",
     "boostAddContext": "Reference file or folder",
     "boostSkills": "Skills",
+    "modeSection": "Modes",
     "boostSkillsLoading": "Loading skills…",
     "boostSkillsEmpty": "No enabled skills",
     "openSkillsLibrary": "Manage skills…",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -555,6 +555,7 @@
     "boostStartBtw": "发起侧问",
     "boostAddContext": "引用文件或文件夹",
     "boostSkills": "Skills",
+    "modeSection": "模式",
     "boostSkillsLoading": "正在加载 Skills…",
     "boostSkillsEmpty": "暂无已启用的 Skill",
     "openSkillsLibrary": "管理 Skills…",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -555,6 +555,7 @@
     "boostStartBtw": "發起側問",
     "boostAddContext": "引用檔案或資料夾",
     "boostSkills": "Skills",
+    "modeSection": "模式",
     "boostSkillsLoading": "正在載入 Skills…",
     "boostSkillsEmpty": "暫無已啟用的 Skill",
     "openSkillsLibrary": "管理 Skills…",


### PR DESCRIPTION
## Summary

Add inline skill reference support across the runtime prompt and FlowChat input UX.

Fixes #951
Fixes #1285

## Type and Areas

Type:

- feature
- UI/UX

Areas:

- Rust core
- web UI
- i18n

## Motivation / Impact

This introduces a unified `[$skill]` reference model for runtime skill prompts and chat input interactions.

Users can now:
- trigger skills directly from slash or `$` inline pickers
- see selected skills rendered as pills consistently
- insert skills from the legacy boost menu without spacing or line-break glitches
- navigate command picker items cyclically with the arrow keys

On the runtime side, skill snapshot and skill listing output now render as inline `<skill name="...">...</skill>` entries and the skill guidance explicitly documents the `[$SkillName]` invocation format.

## Verification

- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/RichTextInput.test.tsx src/flow_chat/utils/skillPromptReference.test.ts`

## Reviewer Notes

- This staged set spans both runtime prompt formatting and FlowChat input UX changes because they are part of the same skill-reference feature.
- Locale strings were updated for the new command picker section label.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.