### PR TITLE
fix(prompt): discourage small-limit probe reads in Read tool description

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/implementations/file_read_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/file_read_tool.rs
@@ -143,6 +143,7 @@ Usage:
 - This tool can only read files, not directories. To read a directory, use an ls command via the Bash tool.
 - You can call multiple tools in a single response. It is always better to speculatively read multiple potentially useful files in parallel.
 - Avoid tiny repeated slices (e.g. 30-100 line chunks). If you need more context, read a larger window that covers the whole block you will edit.
+- Do not use `limit` with a small value (e.g. < 50) to probe file type or structure. Source files typically begin with copyright headers — a probe read returns no useful code.
 "#,
             self.default_max_lines_to_read, self.max_line_chars, self.max_total_chars
         ))


### PR DESCRIPTION
## Summary

- Models occasionally call `Read` with `limit: 5` to "probe" a file's type before reading it properly
- Source files begin with copyright headers, so probe reads return no useful code and waste a round trip
- The existing anti-fragmentation guidance targets 30-100 line chunks (progressive slicing) but misses this distinct pattern
- Add an explicit bullet calling out small `limit` values (< 50) as a probe anti-pattern

## Test plan

- [ ] Observe Read tool calls in eval traces — `limit: 5` probe pattern should no longer appear
- [ ] Verify legitimate range reads (e.g. `start_line: 200, limit: 50`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)