### PR TITLE
feat(remote-connect): add IM bot model switching and sync agent models globally

### DIFF
--- a/src/crates/assembly/core/src/service/remote_connect/bot/command_router.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/bot/command_router.rs
@@ -207,6 +207,7 @@ fn settings_menu_view(verbose: bool, state: &BotChatState, s: &'static BotString
     } else {
         items.push(MenuItem::default(s.item_verbose_on, "/verbose"));
     }
+    items.push(MenuItem::default(s.item_switch_model, "/model"));
     items.push(MenuItem::default(s.item_help, "/help"));
     items.push(MenuItem::default(s.item_back, "/menu"));
     let body = format!(
@@ -260,6 +261,144 @@ fn confirm_mode_switch_view(target_mode: BotDisplayMode, s: &'static BotStrings)
             MenuItem::primary(s.item_confirm_switch, "1"),
             MenuItem::default(s.item_back, "/menu"),
         ])
+}
+
+// ── Model switching ────────────────────────────────────────────────
+
+fn model_selection_view(
+    current_model_id: &Option<String>,
+    options: &[(String, String)],
+    s: &'static BotStrings,
+) -> MenuView {
+    let mut items = Vec::new();
+    let mut body = String::new();
+
+    // Option 1: Auto (default).
+    let auto_is_current = current_model_id
+        .as_deref()
+        .map(|m| m.is_empty() || m == "auto")
+        .unwrap_or(true);
+    let auto_marker = if auto_is_current {
+        s.current_marker
+    } else {
+        ""
+    };
+    body.push_str(&format!("1. {}{}\n", s.switch_model_auto, auto_marker));
+    items.push(MenuItem::default(s.switch_model_auto, "auto"));
+
+    // Remaining options: each enabled model.
+    for (i, (model_id, model_name)) in options.iter().enumerate() {
+        let is_current = current_model_id
+            .as_deref()
+            .is_some_and(|m| m == model_id.as_str());
+        let marker = if is_current { s.current_marker } else { "" };
+        body.push_str(&format!("{}. {}{}\n", i + 2, model_name, marker));
+        items.push(MenuItem::default(
+            truncate_label(model_name, 24),
+            model_id.clone(),
+        ));
+    }
+
+    items.push(MenuItem::default(s.item_back, "/menu"));
+    MenuView::plain(s.switch_model_title)
+        .with_body(body.trim_end().to_string())
+        .with_items(items)
+        .with_footer(s.footer_reply_model)
+        .without_plain_text_items()
+}
+
+async fn start_switch_model(state: &mut BotChatState, s: &'static BotStrings) -> HandleResult {
+    use crate::service_agent_runtime::CoreServiceAgentRuntime;
+    let session_id = match state.current_session_id.clone() {
+        Some(id) => id,
+        None => {
+            return result_from_menu(
+                state,
+                MenuView::plain(s.switch_model_no_session)
+                    .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+            );
+        }
+    };
+
+    let catalog = match CoreServiceAgentRuntime::load_remote_model_catalog(Some(&session_id)).await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return result_from_menu(
+                state,
+                MenuView::plain(format!("{}{e}", s.switch_model_failed_prefix))
+                    .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+            );
+        }
+    };
+
+    // Collect enabled models as (id, "name · provider") for the selection list.
+    let options: Vec<(String, String)> = catalog
+        .models
+        .iter()
+        .filter(|m| m.enabled)
+        .map(|m| (m.id.clone(), format!("{} · {}", m.model_name, m.name)))
+        .collect();
+
+    if options.is_empty() {
+        return result_from_menu(
+            state,
+            MenuView::plain(s.switch_model_no_models)
+                .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+        );
+    }
+
+    let view = model_selection_view(&catalog.session_model_id, &options, s);
+    state.set_pending(PendingAction::SelectModel { options });
+    result_from_menu(state, view)
+}
+
+async fn select_model(
+    state: &mut BotChatState,
+    model_id: &str,
+    model_name: &str,
+    s: &'static BotStrings,
+) -> HandleResult {
+    use crate::service_agent_runtime::CoreServiceAgentRuntime;
+    let session_id = match state.current_session_id.clone() {
+        Some(id) => id,
+        None => {
+            return result_from_menu(state, MenuView::plain(s.switch_model_no_session));
+        }
+    };
+
+    let coordinator = match crate::agentic::coordination::get_global_coordinator() {
+        Some(c) => c,
+        None => {
+            return result_from_menu(
+                state,
+                MenuView::plain(format!(
+                    "{}{}",
+                    s.switch_model_failed_prefix, s.session_system_unavailable,
+                )),
+            );
+        }
+    };
+
+    match CoreServiceAgentRuntime::update_remote_session_model(
+        coordinator.as_ref(),
+        &session_id,
+        model_id,
+    )
+    .await
+    {
+        Ok(_) => {
+            let body = format!("{}{}", s.switch_model_applied_prefix, model_name);
+            let mut view = main_menu_view(state, s);
+            view = view.with_body(body);
+            result_from_menu(state, view)
+        }
+        Err(e) => result_from_menu(
+            state,
+            MenuView::plain(format!("{}{e}", s.switch_model_failed_prefix))
+                .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+        ),
+    }
 }
 
 // ── Public entry points ────────────────────────────────────────────
@@ -415,12 +554,32 @@ async fn dispatch(
     }
 
     match cmd {
-        BotCommand::Help => result_from_menu(
-            state,
-            MenuView::plain(s.welcome_title)
-                .with_body(s.help_body)
-                .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
-        ),
+        BotCommand::Help => {
+            let mut items: Vec<MenuItem> = Vec::new();
+            if state.display_mode == BotDisplayMode::Pro {
+                items.push(MenuItem::primary(
+                    s.item_new_code_session,
+                    "/new_code_session",
+                ));
+                items.push(MenuItem::default(
+                    s.item_new_cowork_session,
+                    "/new_cowork_session",
+                ));
+                items.push(MenuItem::default(s.item_switch_workspace, "/switch"));
+            } else {
+                items.push(MenuItem::primary(s.item_new_session, "/new"));
+                items.push(MenuItem::default(s.item_switch_assistant, "/switch"));
+            }
+            items.push(MenuItem::default(s.item_resume_session, "/resume"));
+            items.push(MenuItem::default(s.item_switch_model, "/model"));
+            items.push(MenuItem::default(s.item_settings, "/settings"));
+            result_from_menu(
+                state,
+                MenuView::plain(s.welcome_title)
+                    .with_body(s.help_body)
+                    .with_items(items),
+            )
+        }
         BotCommand::Settings => {
             let verbose = super::load_bot_persistence().verbose_mode;
             result_from_menu(state, settings_menu_view(verbose, state, s))
@@ -433,6 +592,7 @@ async fn dispatch(
         BotCommand::NewCoworkSession => guarded_new(state, "Cowork", s).await,
         BotCommand::NewClawSession => guarded_new(state, "Claw", s).await,
         BotCommand::ResumeSession => start_resume(state, 0, s).await,
+        BotCommand::SwitchModel => start_switch_model(state, s).await,
         BotCommand::ChatMessage(msg) => handle_chat(state, &msg, image_contexts, s).await,
         BotCommand::Menu
         | BotCommand::CancelTask(_)
@@ -1309,6 +1469,28 @@ async fn route_pending(
             )
             .await
         }
+        PendingAction::SelectModel { options } => {
+            let parsed: Option<usize> = raw_input.parse().ok();
+            match parsed {
+                Some(0) => {
+                    state.clear_pending();
+                    menu_or_welcome(state, s)
+                }
+                Some(1) => {
+                    state.clear_pending();
+                    select_model(state, "auto", s.switch_model_auto, s).await
+                }
+                Some(n) if n >= 2 && n <= options.len() + 1 => {
+                    state.clear_pending();
+                    let (model_id, model_name) = options[n - 2].clone();
+                    select_model(state, &model_id, &model_name, s).await
+                }
+                _ => {
+                    state.set_pending(PendingAction::SelectModel { options });
+                    Box::pin(pending_invalid(state, s)).await
+                }
+            }
+        }
         PendingAction::ConfirmModeSwitch {
             target_mode,
             target_cmd,
@@ -1371,6 +1553,7 @@ async fn pending_invalid(state: &mut BotChatState, s: &'static BotStrings) -> Ha
             awaiting_custom_text,
             ..
         } => build_question_view(s, questions, *current_index, *awaiting_custom_text),
+        PendingAction::SelectModel { options } => model_selection_view(&None, options, s),
         PendingAction::ConfirmModeSwitch { target_mode, .. } => {
             confirm_mode_switch_view(*target_mode, s)
         }

--- a/src/crates/assembly/core/src/service/remote_connect/bot/telegram.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/bot/telegram.rs
@@ -307,6 +307,7 @@ impl TelegramBot {
                 { "command": "new", "description": "Create a new session" },
                 { "command": "resume", "description": "Resume an existing session" },
                 { "command": "switch", "description": "Switch assistant or workspace" },
+                { "command": "model", "description": "Switch the session model" },
                 { "command": "cancel", "description": "Cancel the current task" },
                 { "command": "expert", "description": "Switch to Expert mode" },
                 { "command": "assistant", "description": "Switch to Assistant mode" },

--- a/src/crates/assembly/core/src/service_agent_runtime.rs
+++ b/src/crates/assembly/core/src/service_agent_runtime.rs
@@ -643,7 +643,46 @@ impl CoreServiceAgentRuntime {
             .update_session_model_id(session_id, &normalized_model_id)
             .await
             .map_err(|e| e.to_string())?;
+
+        // Propagate the model choice to every agent type already present in
+        // `ai.agent_models` so that newly created sessions of any type
+        // (including different agent types like Cowork/Claw) inherit it.
+        // Also ensure the current session's agent type is present.  This
+        // covers mobile-web and IM-bot paths; the desktop client handles
+        // its own `ai.agent_models` writing in the frontend.
+        Self::persist_model_for_all_agents(&normalized_model_id, || {
+            coordinator
+                .get_session_manager()
+                .get_session(session_id)
+                .map(|s| s.agent_type.clone())
+        })
+        .await;
+
         Ok(normalized_model_id)
+    }
+
+    /// Write `model_id` to `ai.agent_models` for **every** agent type already
+    /// present in the config, plus the current session's agent type if it is
+    /// not yet listed.  This ensures newly created sessions of any type pick
+    /// up the same model without hardcoding a fixed list of agent types.
+    async fn persist_model_for_all_agents<F>(model_id: &str, current_agent_type: F)
+    where
+        F: FnOnce() -> Option<String>,
+    {
+        let Ok(config_service) = crate::service::config::get_global_config_service().await else {
+            return;
+        };
+        let mut current: std::collections::HashMap<String, String> = config_service
+            .get_config(Some("ai.agent_models"))
+            .await
+            .unwrap_or_default();
+        for value in current.values_mut() {
+            *value = model_id.to_string();
+        }
+        if let Some(agent_type) = current_agent_type() {
+            current.insert(agent_type, model_id.to_string());
+        }
+        let _ = config_service.set_config("ai.agent_models", &current).await;
     }
 
     pub(crate) fn remote_control_state_port(

--- a/src/crates/services/services-integrations/src/remote_connect/bot/command.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/bot/command.rs
@@ -22,6 +22,8 @@ pub enum BotCommand {
     NewClawSession,
     /// Resume an existing session (workspace or assistant by mode).
     ResumeSession,
+    /// Switch the model used by the current session.
+    SwitchModel,
     /// Cancel currently running task.
     CancelTask(Option<String>),
     /// Pairing code submitted before pairing.
@@ -113,6 +115,9 @@ pub fn parse_command(text: &str) -> BotCommand {
         "/resume" | "/r" | "/resume_session" | "恢复" | "恢复会话" => {
             return BotCommand::ResumeSession;
         }
+
+        // Switch model for the current session.
+        "/model" | "/switch_model" | "切换模型" => return BotCommand::SwitchModel,
         _ => {}
     }
 

--- a/src/crates/services/services-integrations/src/remote_connect/bot/locale.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/bot/locale.rs
@@ -71,6 +71,7 @@ pub struct BotStrings {
     pub item_confirm_switch: &'static str,
     pub item_next_page: &'static str,
     pub item_other: &'static str,
+    pub item_switch_model: &'static str,
 
     // ── Auxiliary labels ─────────────────────────────────────────
     pub question_title: &'static str,
@@ -83,6 +84,7 @@ pub struct BotStrings {
     pub footer_reply_assistant: &'static str,
     pub footer_reply_session_or_next: &'static str,
     pub footer_reply_session: &'static str,
+    pub footer_reply_model: &'static str,
     pub footer_question_single: &'static str,
     pub footer_question_multi: &'static str,
     pub footer_question_custom: &'static str,
@@ -109,6 +111,14 @@ pub struct BotStrings {
     pub resume_you_label: &'static str,
     pub resume_continue_hint: &'static str,
     pub resume_first_message_hint: &'static str,
+
+    pub switch_model_title: &'static str,
+    pub switch_model_pick: &'static str,
+    pub switch_model_no_models: &'static str,
+    pub switch_model_auto: &'static str,
+    pub switch_model_applied_prefix: &'static str,
+    pub switch_model_failed_prefix: &'static str,
+    pub switch_model_no_session: &'static str,
 
     pub processing: &'static str,
     pub queued: &'static str,
@@ -204,6 +214,7 @@ const STRINGS_ZH: BotStrings = BotStrings {
     item_confirm_switch: "切换并继续",
     item_next_page: "下一页",
     item_other: "其他",
+    item_switch_model: "切换模型",
 
     question_title: "问题",
     verbose_label: "执行细节",
@@ -214,6 +225,7 @@ const STRINGS_ZH: BotStrings = BotStrings {
     footer_reply_assistant: "回复助理编号，或发送 0 返回",
     footer_reply_session_or_next: "回复会话编号；发送 0 查看下一页或返回",
     footer_reply_session: "回复会话编号，或发送 0 返回",
+    footer_reply_model: "回复模型编号，或发送 0 返回",
     footer_question_single: "回复单个选项编号；发送 /menu 退出",
     footer_question_multi: "回复一个或多个选项编号（如 1,3）；发送 /menu 退出",
     footer_question_custom: "请输入你的自定义答案；发送 /menu 退出",
@@ -221,16 +233,7 @@ const STRINGS_ZH: BotStrings = BotStrings {
 
     welcome_body: "当前未配对。",
     paired_body_intro: "可以直接发送消息开始对话。",
-    help_body: "\
-常用命令：
-/menu  返回主菜单
-/new   新建会话
-/resume  恢复历史会话
-/switch  切换助理或工作区
-/cancel  取消当前任务
-/expert  /assistant  切换模式
-/verbose /concise  开关执行细节
-/help  显示本帮助",
+    help_body: "回复编号执行对应操作，或直接发送消息开始对话。\n执行任务时可发送 /cancel 取消。",
 
     switch_pick_workspace: "请选择要切换的工作区：",
     switch_pick_assistant: "请选择要切换的助理：",
@@ -248,6 +251,14 @@ const STRINGS_ZH: BotStrings = BotStrings {
     resume_you_label: "你",
     resume_continue_hint: "可以继续对话。",
     resume_first_message_hint: "发送一条消息即可开始。",
+
+    switch_model_title: "选择模型",
+    switch_model_pick: "请选择要使用的模型：",
+    switch_model_no_models: "没有可用的模型，请先在 BitFun 桌面端配置 AI 模型。",
+    switch_model_auto: "自动（默认）",
+    switch_model_applied_prefix: "已切换模型：",
+    switch_model_failed_prefix: "切换模型失败：",
+    switch_model_no_session: "当前没有活跃会话，请先新建或恢复会话。",
 
     processing: "正在处理你的消息……",
     queued: "消息已加入队列，等当前步骤结束会自动接续。",
@@ -343,6 +354,7 @@ const STRINGS_ZH_TW: BotStrings = BotStrings {
     item_confirm_switch: "切換並繼續",
     item_next_page: "下一頁",
     item_other: "其他",
+    item_switch_model: "切換模型",
 
     question_title: "問題",
     verbose_label: "執行細節",
@@ -353,6 +365,7 @@ const STRINGS_ZH_TW: BotStrings = BotStrings {
     footer_reply_assistant: "回覆助理編號，或發送 0 返回",
     footer_reply_session_or_next: "回覆會話編號；發送 0 查看下一頁或返回",
     footer_reply_session: "回覆會話編號，或發送 0 返回",
+    footer_reply_model: "回覆模型編號，或發送 0 返回",
     footer_question_single: "回覆單個選項編號；發送 /menu 退出",
     footer_question_multi: "回覆一個或多個選項編號（如 1,3）；發送 /menu 退出",
     footer_question_custom: "請輸入你的自定義答案；發送 /menu 退出",
@@ -360,16 +373,7 @@ const STRINGS_ZH_TW: BotStrings = BotStrings {
 
     welcome_body: "當前未配對。",
     paired_body_intro: "可以直接發送消息開始對話。",
-    help_body: "\
-常用命令：
-/menu  返回主菜單
-/new   新建會話
-/resume  恢復歷史會話
-/switch  切換助理或工作區
-/cancel  取消當前任務
-/expert  /assistant  切換模式
-/verbose /concise  開關執行細節
-/help  顯示本幫助",
+    help_body: "回覆編號執行對應操作，或直接發送消息開始對話。\n執行任務時可發送 /cancel 取消。",
 
     switch_pick_workspace: "請選擇要切換的工作區：",
     switch_pick_assistant: "請選擇要切換的助理：",
@@ -387,6 +391,14 @@ const STRINGS_ZH_TW: BotStrings = BotStrings {
     resume_you_label: "你",
     resume_continue_hint: "可以繼續對話。",
     resume_first_message_hint: "發送一條消息即可開始。",
+
+    switch_model_title: "選擇模型",
+    switch_model_pick: "請選擇要使用的模型：",
+    switch_model_no_models: "沒有可用的模型，請先在 BitFun 桌面端配置 AI 模型。",
+    switch_model_auto: "自動（默認）",
+    switch_model_applied_prefix: "已切換模型：",
+    switch_model_failed_prefix: "切換模型失敗：",
+    switch_model_no_session: "當前沒有活躍會話，請先新建或恢復會話。",
 
     processing: "正在處理你的消息……",
     queued: "消息已加入隊列，等當前步驟結束會自動接續。",
@@ -482,6 +494,7 @@ Open Remote Connect in BitFun Desktop and send the 6-digit pairing code here to 
     item_confirm_switch: "Switch & Continue",
     item_next_page: "Next Page",
     item_other: "Other",
+    item_switch_model: "Switch Model",
 
     question_title: "Question",
     verbose_label: "Execution details",
@@ -492,6 +505,7 @@ Open Remote Connect in BitFun Desktop and send the 6-digit pairing code here to 
     footer_reply_assistant: "Reply with an assistant number, or 0 to go back.",
     footer_reply_session_or_next: "Reply with a session number; send 0 for next page or to go back.",
     footer_reply_session: "Reply with a session number, or 0 to go back.",
+    footer_reply_model: "Reply with a model number, or 0 to go back.",
     footer_question_single: "Reply with one option number; send /menu to exit.",
     footer_question_multi: "Reply with one or more option numbers (e.g. 1,3); send /menu to exit.",
     footer_question_custom: "Type your custom answer; send /menu to exit.",
@@ -499,16 +513,7 @@ Open Remote Connect in BitFun Desktop and send the 6-digit pairing code here to 
 
     welcome_body: "Not paired yet.",
     paired_body_intro: "Send a message to start the conversation.",
-    help_body: "\
-Common commands:
-/menu  Return to the main menu
-/new   Create a new session
-/resume  Resume an existing session
-/switch  Switch assistant or workspace
-/cancel  Cancel the current task
-/expert  /assistant  Switch modes
-/verbose /concise  Toggle execution details
-/help  Show this help",
+    help_body: "Reply with a number to perform the action, or send a message to start chatting.\nSend /cancel to abort a running task.",
 
     switch_pick_workspace: "Pick a workspace to switch to:",
     switch_pick_assistant: "Pick an assistant to switch to:",
@@ -526,6 +531,14 @@ Common commands:
     resume_you_label: "You",
     resume_continue_hint: "You can continue the conversation.",
     resume_first_message_hint: "Send a message to start.",
+
+    switch_model_title: "Select Model",
+    switch_model_pick: "Pick a model to use:",
+    switch_model_no_models: "No models available. Please configure AI models in BitFun Desktop first.",
+    switch_model_auto: "Auto (Default)",
+    switch_model_applied_prefix: "Switched model: ",
+    switch_model_failed_prefix: "Failed to switch model: ",
+    switch_model_no_session: "No active session. Create or resume a session first.",
 
     processing: "Processing your message…",
     queued: "Message queued. It will run when the current step finishes.",

--- a/src/crates/services/services-integrations/src/remote_connect/bot/menu.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/bot/menu.rs
@@ -143,7 +143,11 @@ impl MenuView {
                 if i > 0 {
                     out.push('\n');
                 }
-                out.push_str(&format!("{} {}", i + 1, item.label));
+                if item.command.starts_with('/') {
+                    out.push_str(&format!("{}. {}  {}", i + 1, item.label, item.command));
+                } else {
+                    out.push_str(&format!("{}. {}", i + 1, item.label));
+                }
             }
         }
         let hint = self

--- a/src/crates/services/services-integrations/src/remote_connect/bot/state.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/bot/state.rs
@@ -98,6 +98,9 @@ pub enum PendingAction {
         page: usize,
         has_more: bool,
     },
+    SelectModel {
+        options: Vec<(String, String)>,
+    },
     AskUserQuestion {
         tool_id: String,
         questions: Vec<BotQuestion>,

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -3,7 +3,9 @@
  * Shows the active model and allows quick switching.
  *
  * Config linkage:
- * - Unified logic: all modes use ai.agent_models[mode_id]
+ * - Model selection is shared across all agent types via ai.agent_models
+ *   — switching in one session refreshes every existing agent mapping plus
+ *   the current session's agent type, so new sessions of any type inherit it.
  * - Supports 'auto' | 'primary' | 'fast' | specific model IDs
  */
 
@@ -498,10 +500,16 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
 
       const currentAgentModels = await configManager.getConfig<Record<string, string>>('ai.agent_models') || {};
 
-      const updatedAgentModels = {
-        ...currentAgentModels,
-        [currentMode]: modelId,
-      };
+      // Refresh **every** agent mapping already present in the config so
+      // all configured agents pick up the new model.  Also ensure the
+      // current session's agent type is included.  No hardcoded list —
+      // any agent type added to the config in the future is covered
+      // automatically.
+      const updatedAgentModels = { ...currentAgentModels };
+      for (const agentType of Object.keys(updatedAgentModels)) {
+        updatedAgentModels[agentType] = modelId;
+      }
+      updatedAgentModels[currentMode] = modelId;
 
       await configManager.setConfig('ai.agent_models', updatedAgentModels);
       setAgentModels(updatedAgentModels);


### PR DESCRIPTION
## Summary

- Add `/model` command to the remote IM bot (Telegram/Feishu/etc.) so users can pick a session model from an interactive numbered menu, including Auto and all enabled models from the desktop catalog.
- Propagate model selection to every agent type already present in `ai.agent_models` on both desktop (`ModelSelector`) and remote paths (`CoreServiceAgentRuntime`), so switching in one session applies consistently across agent types.
- Refresh bot help/settings menus to expose model switching as a numbered action and show slash-command hints for menu items where applicable.

## Test plan

- [x] `cargo check -p bitfun-core -p bitfun-services-integrations`
- [x] `pnpm run type-check:web`
- [ ] In desktop Flow Chat, switch model via ModelSelector and verify all agent types in `ai.agent_models` update
- [ ] In Telegram/IM bot with an active session, run `/model`, pick Auto and a specific model, confirm session model updates
- [ ] Verify `/help` and `/settings` show the new model-switch entry and numbered menu works end-to-end