### PR TITLE
fix: preserve multimodal model capabilities

### DIFF
--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -655,6 +655,49 @@ impl ExecutionEngine {
             .unwrap_or_else(|| "auto".to_string())
     }
 
+    async fn resolve_primary_model_context(
+        model_id: &str,
+        ai_client_model: &str,
+        ai_client_provider: &str,
+        unavailable_log_message: &str,
+    ) -> (String, bool) {
+        let config_service = get_global_config_service().await.ok();
+        if let Some(service) = config_service {
+            let ai_config: crate::service::config::types::AIConfig =
+                service.get_config(Some("ai")).await.unwrap_or_default();
+
+            let resolved_id = Self::resolve_configured_model_id(&ai_config, model_id);
+            let model_cfg = ai_config
+                .models
+                .iter()
+                .find(|m| m.id == resolved_id)
+                .or_else(|| ai_config.models.iter().find(|m| m.name == resolved_id))
+                .or_else(|| {
+                    ai_config
+                        .models
+                        .iter()
+                        .find(|m| m.model_name == resolved_id)
+                })
+                .or_else(|| {
+                    ai_config.models.iter().find(|m| {
+                        m.model_name == ai_client_model && m.provider == ai_client_provider
+                    })
+                });
+
+            let supports = model_cfg.is_some_and(|m| {
+                m.capabilities
+                    .iter()
+                    .any(|cap| matches!(cap, ModelCapability::ImageUnderstanding))
+                    || matches!(m.category, ModelCategory::Multimodal)
+            });
+
+            (resolved_id, supports)
+        } else {
+            warn!("{}", unavailable_log_message);
+            (model_id.to_string(), false)
+        }
+    }
+
     async fn build_tool_listing_sections(
         manifest: &ResolvedToolManifest,
         tool_context: &crate::agentic::tools::framework::ToolUseContext,
@@ -1527,46 +1570,14 @@ impl ExecutionEngine {
                 ))
             })?;
 
-        let (resolved_primary_model_id, primary_supports_image_understanding) = {
-            let config_service = get_global_config_service().await.ok();
-            if let Some(service) = config_service {
-                let ai_config: crate::service::config::types::AIConfig =
-                    service.get_config(Some("ai")).await.unwrap_or_default();
-
-                let resolved_id = Self::resolve_configured_model_id(&ai_config, &model_id);
-                let model_cfg = ai_config
-                    .models
-                    .iter()
-                    .find(|m| m.id == resolved_id)
-                    .or_else(|| ai_config.models.iter().find(|m| m.name == resolved_id))
-                    .or_else(|| {
-                        ai_config
-                            .models
-                            .iter()
-                            .find(|m| m.model_name == resolved_id)
-                    })
-                    .or_else(|| {
-                        ai_config.models.iter().find(|m| {
-                            m.model_name == ai_client.config.model
-                                && m.provider == ai_client.config.format
-                        })
-                    });
-
-                let supports = model_cfg.is_some_and(|m| {
-                    m.capabilities
-                        .iter()
-                        .any(|cap| matches!(cap, ModelCapability::ImageUnderstanding))
-                        || matches!(m.category, ModelCategory::Multimodal)
-                });
-
-                (resolved_id, supports)
-            } else {
-                warn!(
-                    "Config service unavailable, assuming compression model is text-only for image input gating"
-                );
-                (model_id.clone(), false)
-            }
-        };
+        let (resolved_primary_model_id, primary_supports_image_understanding) =
+            Self::resolve_primary_model_context(
+                &model_id,
+                &ai_client.config.model,
+                &ai_client.config.format,
+                "Config service unavailable, assuming compression model is text-only for image input gating",
+            )
+            .await;
 
         let model_capability_profile = ModelCapabilityProfile::from_resolved_model(
             &resolved_primary_model_id,
@@ -1602,6 +1613,9 @@ impl ExecutionEngine {
             &context.agent_type,
             context.workspace.as_ref(),
             context.workspace_services.as_ref(),
+            Some(&resolved_primary_model_id),
+            Some(&ai_client.config.model),
+            Some(&ai_client.config.format),
             primary_supports_image_understanding,
             &tool_manifest_context_vars,
         );
@@ -2198,47 +2212,14 @@ impl ExecutionEngine {
             })?;
 
         // Primary model vision capability (tools + system prompt appendix; also used below for API message stripping).
-        let (resolved_primary_model_id, primary_supports_image_understanding) = {
-            let config_service = get_global_config_service().await.ok();
-            if let Some(service) = config_service {
-                let ai_config: crate::service::config::types::AIConfig =
-                    service.get_config(Some("ai")).await.unwrap_or_default();
-
-                let resolved_id = Self::resolve_configured_model_id(&ai_config, &model_id);
-
-                let model_cfg = ai_config
-                    .models
-                    .iter()
-                    .find(|m| m.id == resolved_id)
-                    .or_else(|| ai_config.models.iter().find(|m| m.name == resolved_id))
-                    .or_else(|| {
-                        ai_config
-                            .models
-                            .iter()
-                            .find(|m| m.model_name == resolved_id)
-                    })
-                    .or_else(|| {
-                        ai_config.models.iter().find(|m| {
-                            m.model_name == ai_client.config.model
-                                && m.provider == ai_client.config.format
-                        })
-                    });
-
-                let supports = model_cfg.is_some_and(|m| {
-                    m.capabilities
-                        .iter()
-                        .any(|cap| matches!(cap, ModelCapability::ImageUnderstanding))
-                        || matches!(m.category, ModelCategory::Multimodal)
-                });
-
-                (resolved_id, supports)
-            } else {
-                warn!(
-                    "Config service unavailable, assuming primary model is text-only for image input gating"
-                );
-                (model_id.clone(), false)
-            }
-        };
+        let (resolved_primary_model_id, primary_supports_image_understanding) =
+            Self::resolve_primary_model_context(
+                &model_id,
+                &ai_client.config.model,
+                &ai_client.config.format,
+                "Config service unavailable, assuming primary model is text-only for image input gating",
+            )
+            .await;
 
         let model_context_window = ai_client.config.context_window as usize;
         let session_max_tokens = session.config.max_context_tokens;
@@ -2296,6 +2277,9 @@ impl ExecutionEngine {
             &agent_type,
             context.workspace.as_ref(),
             context.workspace_services.as_ref(),
+            Some(&resolved_primary_model_id),
+            Some(&ai_client.config.model),
+            Some(&ai_client.config.format),
             primary_supports_image_understanding,
             &tool_manifest_context_vars,
         );

--- a/src/crates/assembly/core/src/agentic/skill_agent_snapshot.rs
+++ b/src/crates/assembly/core/src/agentic/skill_agent_snapshot.rs
@@ -51,6 +51,9 @@ pub async fn resolve_skill_agent_snapshot(
         agent_type,
         workspace,
         workspace_services,
+        None,
+        None,
+        None,
         true,
         context_vars,
     );

--- a/src/crates/assembly/core/src/agentic/tools/product_runtime/catalog.rs
+++ b/src/crates/assembly/core/src/agentic/tools/product_runtime/catalog.rs
@@ -239,6 +239,18 @@ mod tests {
         }
     }
 
+    fn multimodal_anthropic_tool_context(agent_type: Option<&str>) -> ToolUseContext {
+        let mut context = tool_context(agent_type);
+        context.custom_data.insert(
+            "primary_model_supports_image_understanding".to_string(),
+            json!(true),
+        );
+        context
+            .custom_data
+            .insert("primary_model_provider".to_string(), json!("anthropic"));
+        context
+    }
+
     fn context_without_agent_type() -> ToolUseContext {
         tool_context(None)
     }
@@ -481,6 +493,24 @@ mod tests {
             .tool_definitions
             .iter()
             .any(|tool| tool.name == GET_TOOL_SPEC_TOOL_NAME));
+    }
+
+    #[tokio::test]
+    async fn product_manifest_keeps_view_image_for_multimodal_anthropic_context() {
+        let allowed_tools = vec!["Read".to_string(), "view_image".to_string()];
+
+        let manifest = resolve_product_resolved_tool_manifest(
+            &allowed_tools,
+            &AgentToolPolicyOverrides::default(),
+            &multimodal_anthropic_tool_context(Some("test-agent")),
+        )
+        .await;
+
+        assert_eq!(manifest.allowed_tool_names, allowed_tools);
+        assert!(manifest
+            .tool_definitions
+            .iter()
+            .any(|tool| tool.name == "view_image"));
     }
 
     #[tokio::test]

--- a/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
+++ b/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
@@ -224,10 +224,31 @@ pub(crate) fn build_tool_description_context(
     agent_type: &str,
     workspace: Option<&WorkspaceBinding>,
     workspace_services: Option<&WorkspaceServices>,
+    primary_model_id: Option<&str>,
+    primary_model_name: Option<&str>,
+    primary_model_provider: Option<&str>,
     primary_supports_image_understanding: bool,
     context_vars: &HashMap<String, String>,
 ) -> ToolUseContext {
     let mut custom_data = HashMap::new();
+    if let Some(primary_model_id) = primary_model_id {
+        custom_data.insert(
+            "primary_model_id".to_string(),
+            Value::String(primary_model_id.to_string()),
+        );
+    }
+    if let Some(primary_model_name) = primary_model_name {
+        custom_data.insert(
+            "primary_model_name".to_string(),
+            Value::String(primary_model_name.to_string()),
+        );
+    }
+    if let Some(primary_model_provider) = primary_model_provider {
+        custom_data.insert(
+            "primary_model_provider".to_string(),
+            Value::String(primary_model_provider.to_string()),
+        );
+    }
     custom_data.insert(
         "primary_model_supports_image_understanding".to_string(),
         Value::Bool(primary_supports_image_understanding),
@@ -1197,7 +1218,16 @@ mod context_builder_tests {
             "false".to_string(),
         );
 
-        let context = build_tool_description_context("coding", None, None, true, &context_vars);
+        let context = build_tool_description_context(
+            "coding",
+            None,
+            None,
+            Some("model_1"),
+            Some("vision-model"),
+            Some("anthropic"),
+            true,
+            &context_vars,
+        );
 
         assert_eq!(context.agent_type.as_deref(), Some("coding"));
         assert!(context.tool_call_id.is_none());
@@ -1211,6 +1241,15 @@ mod context_builder_tests {
         assert_eq!(
             context.custom_data["primary_model_supports_image_understanding"],
             json!("false")
+        );
+        assert_eq!(context.custom_data["primary_model_id"], json!("model_1"));
+        assert_eq!(
+            context.custom_data["primary_model_name"],
+            json!("vision-model")
+        );
+        assert_eq!(
+            context.custom_data["primary_model_provider"],
+            json!("anthropic")
         );
     }
 }

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -6,10 +6,10 @@ import {
   AIModelConfig as AIModelConfigType, 
   ProxyConfig, 
   ModelCategory,
-  ModelCapability,
   ReasoningMode
 } from '../types';
 import { configManager } from '../services/ConfigManager';
+import { getCapabilitiesByCategory, resolveModelCategory } from '../services/modelCategory';
 import { PROVIDER_TEMPLATES, getModelDisplayName, getProviderDisplayName, getProviderTemplateId } from '../services/modelConfigs';
 import { DEFAULT_REASONING_MODE, getEffectiveReasoningMode, supportsAnthropicAdaptive, supportsAnthropicReasoning, supportsAnthropicThinkingBudget, supportsDeepSeekReasoningEffort, supportsResponsesReasoning } from '../utils/reasoning';
 import { aiApi, systemAPI } from '@/infrastructure/api';
@@ -231,15 +231,6 @@ function dedupeSelectedModelDraftsByModelName(drafts: SelectedModelDraft[]): Sel
     out[i] = !prev.configId && draft.configId ? draft : prev;
   }
   return out;
-}
-
-function getCapabilitiesByCategory(category: ModelCategory): ModelCapability[] {
-  switch (category) {
-    case 'general_chat':
-    case 'multimodal':
-    default:
-      return ['text_chat', 'function_calling'];
-  }
 }
 
 /**
@@ -1047,8 +1038,18 @@ const AIModelConfig: React.FC = () => {
           enabled: editingConfig.enabled ?? true,
           context_window: draft.contextWindow,
           max_tokens: draft.maxTokens,
-          category: draft.category,
-          capabilities: getCapabilitiesByCategory(draft.category),
+          category: resolveModelCategory(
+            draft.modelName,
+            draft.category,
+            editingConfig.provider || 'openai'
+          ),
+          capabilities: getCapabilitiesByCategory(
+            resolveModelCategory(
+              draft.modelName,
+              draft.category,
+              editingConfig.provider || 'openai'
+            )
+          ),
           recommended_for: editingConfig.recommended_for || [],
           metadata: {
             ...(editingConfig.metadata || {}),

--- a/src/web-ui/src/infrastructure/config/services/modelCategory.ts
+++ b/src/web-ui/src/infrastructure/config/services/modelCategory.ts
@@ -1,0 +1,50 @@
+import type { ModelCapability, ModelCategory } from '../types';
+
+const MULTIMODAL_MODEL_HINTS = [
+  'vision',
+  'gpt-4o',
+  'gpt-4-turbo',
+  'claude-3',
+  'gemini-pro-vision',
+  'gemini-1.5',
+  'kimi',
+];
+
+export function inferModelCategory(
+  modelName: string,
+  _provider?: string
+): ModelCategory {
+  const normalized = modelName.trim().toLowerCase();
+  if (MULTIMODAL_MODEL_HINTS.some(hint => normalized.includes(hint))) {
+    return 'multimodal';
+  }
+  return 'general_chat';
+}
+
+export function resolveModelCategory(
+  modelName: string,
+  category?: ModelCategory,
+  provider?: string
+): ModelCategory {
+  const inferred = inferModelCategory(modelName, provider);
+
+  if (category === 'multimodal') {
+    return 'multimodal';
+  }
+
+  if (category === 'general_chat' && inferred === 'multimodal') {
+    return 'multimodal';
+  }
+
+  return category ?? inferred;
+}
+
+export function getCapabilitiesByCategory(category: ModelCategory): ModelCapability[] {
+  switch (category) {
+    case 'multimodal':
+      return ['text_chat', 'image_understanding', 'function_calling'];
+    case 'general_chat':
+    default:
+      return ['text_chat', 'function_calling'];
+  }
+}

--- a/src/web-ui/src/infrastructure/config/services/modelConfigs.test.ts
+++ b/src/web-ui/src/infrastructure/config/services/modelConfigs.test.ts
@@ -74,4 +74,52 @@ describe('modelConfigs', () => {
       }),
     ]);
   });
+
+  it('preserves multimodal model metadata when loading and saving ai.models', async () => {
+    configManagerMock.getConfig.mockResolvedValueOnce([
+      {
+        id: 'kimi-1',
+        name: 'Moonshot',
+        base_url: 'https://api.moonshot.cn/v1',
+        api_key: '',
+        model_name: 'kimi-k2.7',
+        provider: 'openai',
+        category: 'multimodal',
+        capabilities: ['text_chat', 'image_understanding', 'function_calling'],
+      },
+    ]);
+
+    const { modelConfigManager } = await import('./modelConfigs');
+    const listener = vi.fn();
+
+    modelConfigManager.addListener(listener);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(listener).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'kimi-1',
+        category: 'multimodal',
+        capabilities: expect.arrayContaining(['image_understanding']),
+      }),
+    ]);
+
+    modelConfigManager.updateConfig('kimi-1', {
+      category: 'multimodal',
+      capabilities: ['text_chat', 'image_understanding', 'function_calling'],
+    });
+
+    await Promise.resolve();
+
+    expect(configManagerMock.setConfig).toHaveBeenCalledWith(
+      'ai.models',
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'kimi-1',
+          category: 'multimodal',
+          capabilities: expect.arrayContaining(['image_understanding']),
+        }),
+      ])
+    );
+  });
 });

--- a/src/web-ui/src/infrastructure/config/services/modelConfigs.ts
+++ b/src/web-ui/src/infrastructure/config/services/modelConfigs.ts
@@ -1,5 +1,6 @@
 import { ModelConfig, ProviderTemplate, ApiFormat } from '../../../shared/types';
 import { configManager } from './ConfigManager';
+import { getCapabilitiesByCategory, resolveModelCategory } from './modelCategory';
 import { i18nService } from '@/infrastructure/i18n';
 import { createLogger } from '@/shared/utils/logger';
 import { extractProviderSegmentFromBaseUrl, matchProviderCatalogItemByBaseUrl } from './providerCatalog';
@@ -281,7 +282,21 @@ class ModelConfigManager {
           description: model.description || t('settings/ai-model:messages.defaultDescription', { name: model.name }),
           isBuiltIn: false,
           contextWindow: model.context_window,
-          maxTokens: model.max_tokens
+          maxTokens: model.max_tokens,
+          category: resolveModelCategory(
+            model.model_name || '',
+            model.category,
+            model.provider
+          ),
+          capabilities: Array.isArray(model.capabilities) && model.capabilities.length > 0
+            ? model.capabilities
+            : getCapabilitiesByCategory(
+                resolveModelCategory(
+                  model.model_name || '',
+                  model.category,
+                  model.provider
+                )
+              ),
         }));
       } else {
         // No config available from backend.
@@ -310,7 +325,21 @@ class ModelConfigManager {
         enabled: true,
         description: config.description,
         context_window: config.contextWindow,
-        max_tokens: config.maxTokens
+        max_tokens: config.maxTokens,
+        category: resolveModelCategory(
+          config.modelName,
+          config.category,
+          config.format
+        ),
+        capabilities: config.capabilities && config.capabilities.length > 0
+          ? config.capabilities
+          : getCapabilitiesByCategory(
+              resolveModelCategory(
+                config.modelName,
+                config.category,
+                config.format
+              )
+            ),
       }));
       
       // Save to the unified config system.
@@ -402,13 +431,17 @@ class ModelConfigManager {
     const template = PROVIDER_TEMPLATES[providerId];
     if (!template) return null;
 
+    const category = resolveModelCategory(modelName, undefined, template.format);
+
     return this.addConfig({
       name: template.name,
       baseUrl: template.baseUrl,
       modelName,
       format: template.format,
       description: t('settings/ai-model:messages.templateDescription', { description: template.description, modelName }),
-      isBuiltIn: false
+      isBuiltIn: false,
+      category,
+      capabilities: getCapabilitiesByCategory(category),
     });
   }
 

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -95,7 +95,8 @@ export interface AIExperienceConfig {
 
 export type ModelCapability =
   | 'text_chat'
-  | 'function_calling';
+  | 'function_calling'
+  | 'image_understanding';
 
 export type ModelCategory =
   | 'general_chat'

--- a/src/web-ui/src/shared/types/chat.ts
+++ b/src/web-ui/src/shared/types/chat.ts
@@ -47,6 +47,8 @@ export interface ModelConfig {
   isBuiltIn?: boolean;
   contextWindow?: number; 
   maxTokens?: number; 
+  category?: 'general_chat' | 'multimodal';
+  capabilities?: Array<'text_chat' | 'function_calling' | 'image_understanding'>;
 }
 
 


### PR DESCRIPTION
## Summary
- preserve multimodal category and image-understanding capabilities when loading and saving AI model configs
- infer multimodal defaults for known model names and expose primary model metadata to tool contexts
- keep image tools available for multimodal Anthropic contexts

## Verification
- pnpm run fmt:rs
- pnpm run type-check:web
- pnpm --dir src/web-ui run test:run src/infrastructure/config/services/modelConfigs.test.ts
- cargo check --workspace
- git diff --check