### PR TITLE
fix(web-ui): 修复 macOS 下聊天输入框无法获取焦点的问题

### DIFF
--- a/src/web-ui/src/app/styles/utilities/high-dpi-optimization.css
+++ b/src/web-ui/src/app/styles/utilities/high-dpi-optimization.css
@@ -14,7 +14,7 @@
   }
   
   /* Input and text area optimization */
-  input, textarea, [contenteditable] {
+  input, textarea {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
@@ -25,6 +25,16 @@
     -webkit-backface-visibility: hidden;
     /* Avoid subpixel rendering issues */
     will-change: auto;
+  }
+
+  /* Keep contenteditable surfaces out of forced compositing.
+     WKWebView on macOS is sensitive to 3D transforms here and can lose
+     stable focus/selection behavior on chat/editor inputs. */
+  [contenteditable] {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+    font-feature-settings: "liga", "kern";
   }
   
   /* Avoid blurry transforms */


### PR DESCRIPTION
## Summary

修复 macOS 桌面端聊天输入框无法稳定获取焦点的问题。

聊天输入框使用 `contenteditable`，而全局高 DPI 优化样式此前会对所有 `[contenteditable]` 元素强制应用 `transform: translateZ(0)` 和 `backface-visibility: hidden`。这在 macOS 的 WKWebView 中可能干扰焦点与选区行为，导致输入框点击后无法正常进入可输入状态。

本次修改保留了对原生 `input` / `textarea` 的高 DPI 优化，但将 `contenteditable` 从强制合成层样式中拆出，以避免影响聊天输入框焦点。

Fixes #1305 

## Type and Areas

Type:

- bug fix
- regression fix
- UI/UX

Areas:

- web UI
- desktop/Tauri

## Motivation / Impact

解决 macOS 桌面端聊天输入框点击后无法正常获取焦点的问题，恢复基本输入体验。

对用户的直接影响是：在 macOS 版本中，会话页聊天输入框可以再次正常点击聚焦并输入内容。

## Verification

- 执行 `pnpm run type-check:web`
- 手动验证（macOS 桌面端）：
  - 打开会话页面
  - 点击聊天输入框
  - 确认输入框可以正常获取焦点并输入内容

## Reviewer Notes

- 变更范围仅限前端样式文件 `src/web-ui/src/app/styles/utilities/high-dpi-optimization.css`
- 不涉及产品逻辑修改
- 原生 `input` / `textarea` 的行为保持不变
- 预期影响范围主要是 `contenteditable` 输入区域，重点是聊天输入框

修复前：
<img width="884" height="89" alt="image" src="https://github.com/user-attachments/assets/08679f93-c4fe-4e3a-b274-730f99439010" />


修复后：
<img width="2400" height="1600" alt="修复后" src="https://github.com/user-attachments/assets/67c4a053-e045-418e-9075-474070df8627" />


## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.