### PR TITLE
feat(read): add tail mode for file reads

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/implementations/file_read_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/file_read_tool.rs
@@ -10,10 +10,12 @@ use crate::util::timing::elapsed_ms_u64;
 use async_trait::async_trait;
 use log::{debug, warn};
 use serde_json::{json, Value};
+use std::convert::TryFrom;
 use std::path::Path;
 use std::time::Instant;
 use tool_runtime::fs::read_file::{
-    build_read_file_presentation, build_remote_read_command, parse_remote_read_output, read_file,
+    build_read_file_presentation, build_remote_read_command, build_remote_tail_read_command,
+    parse_remote_read_output, parse_remote_tail_read_output, read_file, read_file_tail,
 };
 
 pub struct FileReadTool {
@@ -50,6 +52,59 @@ impl FileReadTool {
             max_line_chars,
             max_total_chars,
         }
+    }
+
+    fn read_window_start_line(input: &Value) -> Result<usize, String> {
+        Self::optional_line_number(input, "offset")?.map_or(Ok(1), |offset| Ok(offset.max(1)))
+    }
+
+    fn read_tail_mode(input: &Value) -> Result<bool, String> {
+        let tail = match input.get("tail") {
+            Some(value) => value
+                .as_bool()
+                .ok_or_else(|| "tail must be a boolean".to_string())?,
+            None => false,
+        };
+
+        if tail && input.get("offset").is_some() {
+            return Err("Do not provide offset when tail is true".to_string());
+        }
+
+        Ok(tail)
+    }
+
+    fn optional_line_number(input: &Value, key: &str) -> Result<Option<usize>, String> {
+        match input.get(key) {
+            Some(value) => Self::line_number_from_value(value)
+                .map(Some)
+                .map_err(|message| format!("{} {}", key, message)),
+            None => Ok(None),
+        }
+    }
+
+    fn line_number_from_value(value: &Value) -> Result<usize, &'static str> {
+        if let Some(number) = value.as_u64() {
+            return usize::try_from(number).map_err(|_| "is too large");
+        }
+
+        if let Some(number) = value.as_i64() {
+            if number < 0 {
+                return Err("must be a non-negative integer");
+            }
+            return usize::try_from(number as u64).map_err(|_| "is too large");
+        }
+
+        if let Some(number) = value.as_f64() {
+            if !number.is_finite() || number < 0.0 || number.fract() != 0.0 {
+                return Err("must be a non-negative integer");
+            }
+            if number > usize::MAX as f64 {
+                return Err("is too large");
+            }
+            return Ok(number as usize);
+        }
+
+        Err("must be a non-negative integer")
     }
 
     async fn read_remote_window(
@@ -122,6 +177,69 @@ impl FileReadTool {
 
         Ok(result)
     }
+
+    async fn read_remote_tail_window(
+        &self,
+        resolved_path: &str,
+        limit: usize,
+        context: &ToolUseContext,
+    ) -> BitFunResult<tool_runtime::fs::read_file::ReadFileResult> {
+        let ws_shell = context.ws_shell().ok_or_else(|| {
+            BitFunError::tool("Remote workspace shell is unavailable".to_string())
+        })?;
+
+        let command = build_remote_tail_read_command(
+            resolved_path,
+            limit,
+            self.max_line_chars,
+            self.max_total_chars,
+        )
+        .map_err(BitFunError::tool)?;
+
+        let remote_read_started_at = Instant::now();
+        debug!(
+            "Remote file tail read started: path={}, limit={}, timeout_ms={:?}, session_id={:?}, dialog_turn_id={:?}",
+            resolved_path,
+            limit,
+            Option::<u64>::None,
+            context.session_id,
+            context.dialog_turn_id
+        );
+        let (stdout, stderr, status) = ws_shell.exec(&command, None).await.map_err(|e| {
+            warn!(
+                "Remote file tail read failed: path={}, limit={}, duration_ms={}, error={}",
+                resolved_path,
+                limit,
+                elapsed_ms_u64(remote_read_started_at),
+                e
+            );
+            BitFunError::tool(format!("Failed to read file: {}", e))
+        })?;
+        debug!(
+            "Remote file tail read command completed: path={}, limit={}, status={}, stdout_len={}, stderr_len={}, duration_ms={}",
+            resolved_path,
+            limit,
+            status,
+            stdout.len(),
+            stderr.len(),
+            elapsed_ms_u64(remote_read_started_at)
+        );
+
+        let result = parse_remote_tail_read_output(&stdout, &stderr, status, resolved_path, limit)
+            .map_err(BitFunError::tool)?;
+
+        debug!(
+            "Remote file tail read parsed successfully: path={}, start_line={}, end_line={}, total_lines={}, hit_total_char_limit={}, duration_ms={}",
+            resolved_path,
+            result.start_line,
+            result.end_line,
+            result.total_lines,
+            result.hit_total_char_limit,
+            elapsed_ms_u64(remote_read_started_at)
+        );
+
+        Ok(result)
+    }
 }
 
 #[async_trait]
@@ -138,11 +256,12 @@ Usage:
 - The file_path parameter must be workspace-relative, an absolute path inside the current workspace, or an exact `bitfun://runtime/...` URI returned by another tool.
 - Do not read host roots or placeholder paths such as `/workspace`.
 - By default, it reads up to {} lines starting from the beginning of the file. When you plan to Edit a file, prefer this default full read so you see the exact bytes you will need to match.
-- You can optionally specify a start_line and limit. Use a range only when you already know the target lines; the range must include every line you will copy into Edit `old_string`.
+- You can optionally specify an offset and limit. offset is a 1-based line number. Use a range only when you already know the target lines; the range must include every line you will copy into Edit `old_string`.
+- You can set tail=true with limit to read the last N lines. This is useful for command output and logs. Do not combine tail=true with offset.
 - Any lines longer than {} characters will be truncated.
-- Total output is capped at {} characters. If that limit is hit, continue with start_line/limit until the target lines are fully visible, then Edit using only text from those Read results.
+- Total output is capped at {} characters. If that limit is hit, continue with offset/limit, until the target lines are fully visible, then Edit using only text from those Read results.
 - Results are returned using cat -n format, with line numbers starting at 1.
-- This tool can only read files, not directories. To read a directory, use an ls command via the Bash tool.
+- This tool can only read files, not directories.
 - You can call multiple tools in a single response. It is always better to speculatively read multiple potentially useful files in parallel.
 - Avoid tiny repeated slices (e.g. 30-100 line chunks). If you need more context, read a larger window that covers the whole block you will edit.
 "#,
@@ -151,7 +270,7 @@ Usage:
     }
 
     fn short_description(&self) -> String {
-        "Read file contents from the current workspace.".to_string()
+        "Read file contents.".to_string()
     }
 
     fn input_schema(&self) -> Value {
@@ -162,9 +281,13 @@ Usage:
                     "type": "string",
                     "description": "The file to read. Use a workspace-relative path, an absolute path inside the current workspace, or an exact bitfun://runtime URI returned by another tool."
                 },
-                "start_line": {
+                "offset": {
                     "type": "number",
-                    "description": "The line number to start reading from. Only provide if the file is too large to read at once"
+                    "description": "The 1-based line number to start reading from. offset=0 is accepted as offset=1. Only provide if the file is too large to read at once."
+                },
+                "tail": {
+                    "type": "boolean",
+                    "description": "Read the last N lines of the file, where N is limit. Do not provide offset when tail is true."
                 },
                 "limit": {
                     "type": "number",
@@ -212,6 +335,17 @@ Usage:
                 }
             }
         };
+
+        if let Err(message) =
+            Self::read_tail_mode(input).and_then(|_| Self::read_window_start_line(input))
+        {
+            return ValidationResult {
+                result: false,
+                message: Some(message),
+                error_code: Some(400),
+                meta: None,
+            };
+        }
 
         let resolved = match context.map(|ctx| ctx.resolve_tool_path(file_path)) {
             Some(Ok(path)) => path,
@@ -312,10 +446,8 @@ Usage:
             .and_then(|v| v.as_str())
             .ok_or_else(|| BitFunError::tool("file_path is required".to_string()))?;
 
-        let start_line = input
-            .get("start_line")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(1) as usize;
+        let tail = Self::read_tail_mode(input).map_err(BitFunError::tool)?;
+        let start_line = Self::read_window_start_line(input).map_err(BitFunError::tool)?;
 
         let limit = input
             .get("limit")
@@ -325,8 +457,21 @@ Usage:
         let resolved = context.resolve_tool_path(file_path)?;
 
         let read_file_result = if resolved.uses_remote_workspace_backend() {
-            self.read_remote_window(&resolved.resolved_path, start_line, limit, context)
-                .await?
+            if tail {
+                self.read_remote_tail_window(&resolved.resolved_path, limit, context)
+                    .await?
+            } else {
+                self.read_remote_window(&resolved.resolved_path, start_line, limit, context)
+                    .await?
+            }
+        } else if tail {
+            read_file_tail(
+                &resolved.resolved_path,
+                limit,
+                self.max_line_chars,
+                self.max_total_chars,
+            )
+            .map_err(BitFunError::tool)?
         } else {
             read_file(
                 &resolved.resolved_path,
@@ -356,6 +501,8 @@ Usage:
                 "content": read_file_result.content,
                 "total_lines": read_file_result.total_lines,
                 "lines_read": presentation.lines_read,
+                "offset": read_file_result.start_line,
+                "tail": tail,
                 "start_line": read_file_result.start_line,
                 "size": read_file_result.content.len(),
                 "hit_total_char_limit": read_file_result.hit_total_char_limit
@@ -365,5 +512,51 @@ Usage:
         };
 
         Ok(vec![result])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FileReadTool;
+    use crate::agentic::tools::framework::Tool;
+    use serde_json::{json, Value};
+
+    #[test]
+    fn read_tool_schema_prefers_offset() {
+        let schema = FileReadTool::new().input_schema();
+        let properties = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("properties");
+
+        assert!(properties.contains_key("offset"));
+        assert!(properties.contains_key("tail"));
+    }
+
+    #[test]
+    fn read_window_start_line_prefers_offset_and_normalizes_zero() {
+        assert_eq!(
+            FileReadTool::read_window_start_line(&json!({ "offset": 0 })).expect("offset"),
+            1
+        );
+        assert_eq!(
+            FileReadTool::read_window_start_line(&json!({ "offset": 42 })).expect("offset"),
+            42
+        );
+        assert_eq!(
+            FileReadTool::read_window_start_line(&json!({})).expect("default offset"),
+            1
+        );
+    }
+
+    #[test]
+    fn read_tail_mode_rejects_offset() {
+        let error = FileReadTool::read_tail_mode(&json!({
+            "tail": true,
+            "offset": 3
+        }))
+        .expect_err("tail and offset should not coexist");
+
+        assert_eq!(error, "Do not provide offset when tail is true");
     }
 }

--- a/src/crates/execution/tool-execution/src/fs/read_file.rs
+++ b/src/crates/execution/tool-execution/src/fs/read_file.rs
@@ -1,4 +1,5 @@
 use crate::util::string::{shell_single_quote, truncate_string_by_chars};
+use std::collections::VecDeque;
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
@@ -43,12 +44,12 @@ pub fn build_read_file_presentation(
     if let Some(next_start) = next_start_line {
         if result.hit_total_char_limit {
             result_for_assistant.push_str(&format!(
-                "\n\n[Output truncated after reaching the Read tool size limit. Use start_line={} and limit to continue reading.]",
+                "\n\n[Output truncated after reaching the Read tool size limit. Use offset={} and limit to continue reading.]",
                 next_start
             ));
         } else {
             result_for_assistant.push_str(&format!(
-                "\n\n[Showing lines {}-{} of {} total. Use start_line={} and limit to continue reading.]",
+                "\n\n[Showing lines {}-{} of {} total. Use offset={} and limit to continue reading.]",
                 result.start_line, result.end_line, result.total_lines, next_start
             ));
         }
@@ -77,6 +78,29 @@ pub fn build_remote_read_command(
         path = escaped_path,
         start = start_line,
         end = end_line,
+        max = max_line_chars,
+        budget = max_total_chars,
+        marker = REMOTE_TOTAL_LINES_MARKER,
+        hit_marker = REMOTE_HIT_TOTAL_CHAR_LIMIT_MARKER,
+    ))
+}
+
+pub fn build_remote_tail_read_command(
+    resolved_path: &str,
+    limit: usize,
+    max_line_chars: usize,
+    max_total_chars: usize,
+) -> Result<String, String> {
+    if limit == 0 {
+        return Err("`limit` can't be 0".to_string());
+    }
+
+    let escaped_path = shell_single_quote(resolved_path);
+
+    Ok(format!(
+        "if [ ! -f {path} ]; then exit 3; fi; awk -v limit={limit} -v max={max} -v budget={budget} 'BEGIN {{ total = 0; used = 0; hit = 0; }} {{ total = NR; slot = ((NR - 1) % limit) + 1; lines[slot] = $0; nums[slot] = NR; }} END {{ start = total - limit + 1; if (start < 1) start = 1; for (nr = start; nr <= total; nr++) {{ slot = ((nr - 1) % limit) + 1; line = lines[slot]; if (length(line) > max) {{ line = substr(line, 1, max) \" [truncated]\"; }} rendered = sprintf(\"%6d\\t%s\", nums[slot], line); extra = (used > 0 ? 1 : 0); next_used = used + extra + length(rendered); if (next_used > budget) {{ hit = 1; break; }} print rendered; used = next_used; }} printf(\"{marker}%d\\n\", total) > \"/dev/stderr\"; printf(\"{hit_marker}%d\\n\", hit) > \"/dev/stderr\"; }}' {path}",
+        path = escaped_path,
+        limit = limit,
         max = max_line_chars,
         budget = max_total_chars,
         marker = REMOTE_TOTAL_LINES_MARKER,
@@ -158,6 +182,35 @@ pub fn parse_remote_read_output(
         content,
         hit_total_char_limit,
     })
+}
+
+pub fn parse_remote_tail_read_output(
+    stdout: &str,
+    stderr: &str,
+    status: i32,
+    resolved_path: &str,
+    limit: usize,
+) -> Result<ReadFileResult, String> {
+    let mut result = parse_remote_read_output(stdout, stderr, status, resolved_path, 1)?;
+
+    if result.total_lines == 0 {
+        return Ok(result);
+    }
+
+    let start_line = result.total_lines.saturating_sub(limit).saturating_add(1);
+    let lines_read = if result.content.is_empty() {
+        0
+    } else {
+        result.content.lines().count()
+    };
+    result.start_line = start_line;
+    result.end_line = if lines_read == 0 {
+        start_line
+    } else {
+        start_line.saturating_add(lines_read).saturating_sub(1)
+    };
+
+    Ok(result)
 }
 
 /// start_line: starts from 1
@@ -254,9 +307,99 @@ pub fn read_file(
     })
 }
 
+pub fn read_file_tail(
+    file_path: &str,
+    limit: usize,
+    max_line_chars: usize,
+    max_total_chars: usize,
+) -> Result<ReadFileResult, String> {
+    if limit == 0 {
+        return Err("`limit` can't be 0".to_string());
+    }
+    if max_total_chars == 0 {
+        return Err("`max_total_chars` can't be 0".to_string());
+    }
+
+    let file =
+        File::open(file_path).map_err(|e| format!("Failed to read file {}: {}", file_path, e))?;
+    let reader = BufReader::new(file);
+
+    let mut total_lines = 0usize;
+    let mut tail_lines = VecDeque::with_capacity(limit);
+
+    for line_result in reader.lines() {
+        let line = line_result.map_err(|e| format!("Failed to read file {}: {}", file_path, e))?;
+        total_lines += 1;
+
+        if tail_lines.len() == limit {
+            tail_lines.pop_front();
+        }
+        tail_lines.push_back((total_lines, line));
+    }
+
+    if total_lines == 0 {
+        return Ok(ReadFileResult {
+            start_line: 0,
+            end_line: 0,
+            total_lines: 0,
+            content: String::new(),
+            hit_total_char_limit: false,
+        });
+    }
+
+    let start_line = total_lines.saturating_sub(limit).saturating_add(1);
+    let mut selected_lines = Vec::new();
+    let mut selected_chars = 0usize;
+    let mut hit_total_char_limit = false;
+
+    for (line_number, line) in tail_lines {
+        let line_content = if line.chars().count() > max_line_chars {
+            format!(
+                "{} [truncated]",
+                truncate_string_by_chars(&line, max_line_chars)
+            )
+        } else {
+            line
+        };
+
+        let rendered_line = format!("{:>6}\t{}", line_number, line_content);
+        let separator_chars = usize::from(!selected_lines.is_empty());
+        let next_total_chars = selected_chars
+            .saturating_add(separator_chars)
+            .saturating_add(rendered_line.chars().count());
+
+        if next_total_chars > max_total_chars {
+            hit_total_char_limit = true;
+            break;
+        }
+
+        selected_chars = next_total_chars;
+        selected_lines.push(rendered_line);
+    }
+
+    let end_line = if selected_lines.is_empty() {
+        start_line
+    } else {
+        start_line
+            .saturating_add(selected_lines.len())
+            .saturating_sub(1)
+    };
+
+    Ok(ReadFileResult {
+        start_line,
+        end_line,
+        total_lines,
+        content: selected_lines.join("\n"),
+        hit_total_char_limit,
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{build_read_file_presentation, read_file, read_file_lines_read, ReadFileResult};
+    use super::{
+        build_read_file_presentation, read_file, read_file_lines_read, read_file_tail,
+        ReadFileResult,
+    };
     use std::fs;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -325,7 +468,22 @@ mod tests {
             .contains("Read lines 1-2 from src/lib.rs (4 total lines)"));
         assert!(presentation
             .result_for_assistant
-            .contains("Use start_line=3 and limit to continue reading."));
+            .contains("Use offset=3 and limit to continue reading."));
+    }
+
+    #[test]
+    fn reads_tail_window_with_original_line_numbers() {
+        let path = write_temp_file("one\ntwo\nthree\nfour\nfive\n");
+
+        let result = read_file_tail(path.to_str().expect("utf-8 path"), 2, 50, 100)
+            .expect("tail read should succeed");
+
+        fs::remove_file(&path).expect("temp file should be deleted");
+
+        assert_eq!(result.start_line, 4);
+        assert_eq!(result.end_line, 5);
+        assert_eq!(result.total_lines, 5);
+        assert_eq!(result.content, "     4\tfour\n     5\tfive");
     }
 
     #[test]

--- a/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ReadFileDisplay.tsx
@@ -66,11 +66,17 @@ export const ReadFileDisplay: React.FC<ToolCardProps> = React.memo(({
   }, [filePath, toolItem.acpPermission?.toolCall?.rawInput]);
 
   const lineRange = useMemo(() => {
-    const start_line = toolCall?.input?.start_line;
+    // Keep legacy `start_line` so older persisted tool calls still render.
+    const offset = toolCall?.input?.offset ?? toolCall?.input?.start_line;
+    const tail = toolCall?.input?.tail === true;
     const limit = toolCall?.input?.limit;
     
-    if (start_line !== undefined || limit !== undefined) {
-      const startLine = start_line || 1;
+    if (tail && limit !== undefined) {
+      return `tail ${limit} lines`;
+    }
+
+    if (offset !== undefined || limit !== undefined) {
+      const startLine = offset || 1;
       const endLine = limit ? startLine + limit - 1 : undefined;
       
       if (endLine) {
@@ -81,7 +87,7 @@ export const ReadFileDisplay: React.FC<ToolCardProps> = React.memo(({
     }
     
     return null;
-  }, [toolCall?.input?.start_line, toolCall?.input?.limit]);
+  }, [toolCall?.input?.offset, toolCall?.input?.start_line, toolCall?.input?.tail, toolCall?.input?.limit]);
 
   const fileSize = useMemo(() => {
     if (!toolResult?.result) return null;


### PR DESCRIPTION
## Summary

Add `tail` support to the `Read` tool so models can read the last N lines of log/output files, while keeping `offset` for normal forward reads. Update file read presentation and the Read card UI to handle tail reads and preserve legacy `start_line` display for older persisted data.

Fixes #

## Type and Areas

Type:

Feature

Areas:

Rust core, execution primitives, web UI

## Motivation / Impact

This gives the model a direct way to poll the end of growing files, which is useful for command output and logs. `offset` remains the standard forward-read parameter, and `tail=true` now covers tail-follow workflows without overloading line offsets.

## Verification

- `pnpm run type-check:web`
- `cargo test -p bitfun-core read_ -- --nocapture`
- `cargo test -p tool-runtime read_file_tail -- --nocapture`

## Reviewer Notes

`tail=true` is mutually exclusive with `offset`. The result payload still reports the actual starting line so existing read-state and edit guardrails continue to work.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.