### PR TITLE
fix(mcp): route large tool output through shared storage policy

### DIFF
--- a/src/crates/assembly/core/src/service/mcp/adapter/tool.rs
+++ b/src/crates/assembly/core/src/service/mcp/adapter/tool.rs
@@ -28,8 +28,6 @@ pub struct MCPToolWrapper {
 }
 
 impl MCPToolWrapper {
-    const MAX_RESULT_TEXT_CHARS: usize = 12_000;
-
     /// Creates a new MCP tool wrapper.
     pub fn new(
         mcp_tool: MCPTool,
@@ -53,6 +51,12 @@ impl MCPToolWrapper {
 
     fn is_blocked_in_context(&self, _context: Option<&ToolUseContext>) -> bool {
         false
+    }
+
+    // Do not pre-truncate MCP output here. The shared tool-result storage policy
+    // owns the model-visible budget and persists oversized results with a preview.
+    fn render_mcp_result_for_assistant(tool_name: &str, result: &MCPToolResult) -> String {
+        render_mcp_tool_result_for_assistant(tool_name, result, usize::MAX)
     }
 }
 
@@ -166,11 +170,7 @@ impl Tool for MCPToolWrapper {
 
     fn render_result_for_assistant(&self, output: &Value) -> String {
         if let Ok(result) = serde_json::from_value::<MCPToolResult>(output.clone()) {
-            return render_mcp_tool_result_for_assistant(
-                &self.mcp_tool.name,
-                &result,
-                Self::MAX_RESULT_TEXT_CHARS,
-            );
+            return Self::render_mcp_result_for_assistant(&self.mcp_tool.name, &result);
         }
 
         "MCP tool execution completed".to_string()
@@ -313,5 +313,27 @@ impl MCPToolAdapter {
 impl Default for MCPToolAdapter {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::mcp::protocol::MCPToolResultContent;
+
+    #[test]
+    fn mcp_tool_result_rendering_does_not_pretruncate_before_storage_policy() {
+        let text = "x".repeat(12_001);
+        let result = MCPToolResult {
+            content: Some(vec![MCPToolResultContent::Text { text: text.clone() }]),
+            is_error: false,
+            structured_content: None,
+            meta: None,
+        };
+
+        let rendered = MCPToolWrapper::render_mcp_result_for_assistant("large_output", &result);
+
+        assert_eq!(rendered, text);
+        assert!(!rendered.contains("[Result truncated:"));
     }
 }


### PR DESCRIPTION
## Summary

Remove the MCP adapter's 12k pre-truncation so large MCP tool outputs flow into the shared tool-result storage policy. Add regression coverage to ensure MCP rendering preserves output beyond the old limit before storage budgeting runs.

Fixes #

## Type and Areas

Type:

bug fix, test

Areas:

Rust core, MCP tools

## Motivation / Impact

MCP tool results were truncated before the shared oversized tool-result storage path could evaluate them, which could discard content instead of persisting large outputs with a preview. MCP results now use the same downstream storage policy as other large tool outputs.

## Verification

- `cargo test -p bitfun-core mcp_tool_result_rendering_does_not_pretruncate_before_storage_policy -- --nocapture` - passed

## Reviewer Notes

This keeps the existing shared storage thresholds unchanged; it only removes the MCP-specific 12k pre-truncation.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.