### PR TITLE
fix(flow-chat): window long-session history loading

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -775,7 +775,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
     releaseSpy.mockRestore();
   });
 
-  it('requests full history projection when searching a partially loaded session', async () => {
+  it('keeps partial-session search scoped to the loaded window', async () => {
     const pendingSpy = vi
       .spyOn(flowChatStore, 'hasPendingSessionHistoryCompletion')
       .mockReturnValue(true);
@@ -801,13 +801,10 @@ describe('ModernFlowChatContainer historical empty state', () => {
       root.render(<ModernFlowChatContainer />);
     });
 
-    expect(projectionSpy).toHaveBeenCalledWith('session-1', 'search');
-    expect(startupTraceMock.markPhase).toHaveBeenCalledWith(
+    expect(projectionSpy).not.toHaveBeenCalled();
+    expect(startupTraceMock.markPhase).not.toHaveBeenCalledWith(
       'historical_session_full_hydrate_released_for_search',
-      expect.objectContaining({
-        queryLength: 'older prompt'.length,
-        turnCount: 1,
-      }),
+      expect.anything(),
     );
 
     projectionSpy.mockRestore();

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -975,43 +975,6 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     };
   }, [searchCurrentMatchVirtualIndex]);
 
-  useEffect(() => {
-    const sessionId = activeSession?.sessionId;
-    const trimmedSearchQuery = searchQuery.trim();
-    if (
-      !sessionId ||
-      activeSession.historyState !== 'ready' ||
-      (
-        !hasPendingHistoryCompletion &&
-        !hasDeferredHistoryProjection
-      ) ||
-      trimmedSearchQuery.length === 0
-    ) {
-      return;
-    }
-
-    if (latestTurnId) {
-      releasedHistoryCompletionKeyRef.current = `${sessionId}:${latestTurnId}`;
-    }
-
-    const requested = flowChatStore.requestSessionFullHistoryProjection(sessionId, 'search');
-    if (requested) {
-      startupTrace.markPhase('historical_session_full_hydrate_released_for_search', {
-        sessionId,
-        queryLength: trimmedSearchQuery.length,
-        turnCount: turnSummaries.length,
-      });
-    }
-  }, [
-    activeSession?.historyState,
-    activeSession?.sessionId,
-    hasDeferredHistoryProjection,
-    hasPendingHistoryCompletion,
-    latestTurnId,
-    searchQuery,
-    turnSummaries.length,
-  ]);
-
   const handleJumpToTurn = useCallback((turnId: string) => {
     if (!turnId) return;
 

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.scss
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.scss
@@ -60,6 +60,22 @@
     min-height: 57px;
     flex-shrink: 0;
   }
+
+  &__history-boundary-status {
+    width: fit-content;
+    max-width: calc(100% - 32px);
+    margin: 0 auto 8px;
+    padding: 4px 10px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    background: var(--element-bg-subtle);
+    color: var(--color-text-muted);
+    font-size: 12px;
+    line-height: 18px;
+    text-align: center;
+    overflow-wrap: anywhere;
+    pointer-events: none;
+  }
   
   .message-list-footer {
     /* Inline height from VirtualMessageList (measured drop-zone + bottom inset + tail clearance). */

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -17,13 +17,44 @@ const stateMocks = vi.hoisted(() => ({
   visibleTurnInfo: null as unknown,
   setVisibleTurnInfo: vi.fn(),
 }));
+const flowStoreMocks = vi.hoisted(() => ({
+  hasPendingSessionHistoryCompletion: vi.fn(() => false),
+  hasDeferredSessionHistoryProjection: vi.fn(() => false),
+  requestSessionFullHistoryProjection: vi.fn(),
+  revealPreviousSessionHistoryWindow: vi.fn(() => false),
+  releaseSessionHistoryCompletionAfterInitialPaint: vi.fn(() => false),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'historyState.preparingOlderHistory': 'Preparing older history...',
+        'historyState.olderHistoryNotReady': 'Older history is not ready yet.',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
 
 vi.mock('react-virtuoso', () => ({
   Virtuoso: React.forwardRef((props: any, ref) => {
+    const scrollerRef = React.useRef<HTMLDivElement | null>(null);
     React.useImperativeHandle(ref, () => ({
       scrollTo: vi.fn(),
       scrollToIndex: vi.fn(),
     }));
+
+    React.useLayoutEffect(() => {
+      if (!scrollerRef.current) {
+        return;
+      }
+
+      props.scrollerRef?.(scrollerRef.current);
+      return () => {
+        props.scrollerRef?.(null);
+      };
+    }, [props]);
 
     React.useEffect(() => {
       if (props.data?.[0]?.turnId === 'turn-a') {
@@ -32,7 +63,14 @@ vi.mock('react-virtuoso', () => ({
     }, [props]);
 
     return (
-      <div data-testid="virtuoso" data-session-id={stateMocks.activeSession?.sessionId ?? ''}>
+      <div
+        ref={scrollerRef}
+        data-testid="virtuoso"
+        data-virtuoso-scroller="true"
+        data-session-id={stateMocks.activeSession?.sessionId ?? ''}
+        tabIndex={0}
+      >
+        {props.components?.Header ? <props.components.Header /> : null}
         {props.data?.map((item: VirtualItem, index: number) => (
           <div key={item.turnId} className="virtual-item-wrapper" data-turn-id={item.turnId} data-virtual-index={index} data-item-type={item.type}>
             {item.turnId}
@@ -77,9 +115,11 @@ vi.mock('../../store/chatInputStateStore', () => ({
 
 vi.mock('../../store/FlowChatStore', () => ({
   flowChatStore: {
-    hasPendingSessionHistoryCompletion: () => false,
-    hasDeferredSessionHistoryProjection: () => false,
-    requestSessionFullHistoryProjection: vi.fn(),
+    hasPendingSessionHistoryCompletion: flowStoreMocks.hasPendingSessionHistoryCompletion,
+    hasDeferredSessionHistoryProjection: flowStoreMocks.hasDeferredSessionHistoryProjection,
+    requestSessionFullHistoryProjection: flowStoreMocks.requestSessionFullHistoryProjection,
+    revealPreviousSessionHistoryWindow: flowStoreMocks.revealPreviousSessionHistoryWindow,
+    releaseSessionHistoryCompletionAfterInitialPaint: flowStoreMocks.releaseSessionHistoryCompletionAfterInitialPaint,
   },
 }));
 
@@ -136,7 +176,7 @@ vi.mock('./ScrollAnchor', () => ({
   ScrollAnchor: () => null,
 }));
 
-function createSession(sessionId: string, turnId: string): Session {
+function createSession(sessionId: string, turnId: string, overrides: Partial<Session> = {}): Session {
   return {
     sessionId,
     title: sessionId,
@@ -157,6 +197,7 @@ function createSession(sessionId: string, turnId: string): Session {
     todos: [],
     mode: 'agentic',
     sessionKind: 'normal',
+    ...overrides,
   } as Session;
 }
 
@@ -175,18 +216,48 @@ function createItem(turnId: string): VirtualItem {
 describe('VirtualMessageList session boundary', () => {
   let container: HTMLDivElement;
   let root: Root;
+  let rafCallbacks: FrameRequestCallback[];
+
+  const flushAnimationFrame = () => {
+    const callbacks = rafCallbacks;
+    rafCallbacks = [];
+    act(() => {
+      callbacks.forEach(callback => callback(performance.now()));
+    });
+  };
 
   beforeEach(() => {
+    rafCallbacks = [];
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      rafCallbacks.push(callback);
+      return rafCallbacks.length;
+    }));
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    vi.stubGlobal('ResizeObserver', class {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    });
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
     stateMocks.visibleTurnInfo = null;
     stateMocks.setVisibleTurnInfo.mockReset();
+    flowStoreMocks.hasPendingSessionHistoryCompletion.mockReset();
+    flowStoreMocks.hasPendingSessionHistoryCompletion.mockReturnValue(false);
+    flowStoreMocks.hasDeferredSessionHistoryProjection.mockReset();
+    flowStoreMocks.hasDeferredSessionHistoryProjection.mockReturnValue(false);
+    flowStoreMocks.requestSessionFullHistoryProjection.mockReset();
+    flowStoreMocks.revealPreviousSessionHistoryWindow.mockReset();
+    flowStoreMocks.revealPreviousSessionHistoryWindow.mockReturnValue(false);
+    flowStoreMocks.releaseSessionHistoryCompletionAfterInitialPaint.mockReset();
+    flowStoreMocks.releaseSessionHistoryCompletionAfterInitialPaint.mockReturnValue(false);
   });
 
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.unstubAllGlobals();
   });
 
   it('resets viewport-local at-bottom state when the active session changes', () => {
@@ -217,11 +288,6 @@ describe('VirtualMessageList session boundary', () => {
       items: [createItem('turn-a')],
       mode: 'bottom-tail',
       targetTurnId: 'turn-a',
-      anchorKey: null,
-      anchorOffsetTopPx: 0,
-      scrollTop: 0,
-      scrollHeight: 100,
-      clientHeight: 100,
       footerHeightPx: 0,
     } as const;
 
@@ -229,5 +295,233 @@ describe('VirtualMessageList session boundary', () => {
     expect(activeSessionHistoryProjectionHandoff(snapshot, 'session-b')).toBeNull();
     expect(activeSessionHistoryProjectionHandoff(snapshot, null)).toBeNull();
     expect(activeSessionHistoryProjectionHandoff(null, 'session-a')).toBeNull();
+  });
+
+  it('does not request full history projection for ordinary upward reading scroll', () => {
+    flowStoreMocks.hasDeferredSessionHistoryProjection.mockReturnValue(true);
+    stateMocks.activeSession = createSession('session-a', 'turn-a', {
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'ready',
+      isPartial: true,
+      dialogTurns: [
+        {
+          id: 'turn-a',
+          sessionId: 'session-a',
+          userMessage: { id: 'user-turn-a', content: 'older loaded prompt', timestamp: 1 },
+          modelRounds: [],
+          status: 'completed',
+          startTime: 1,
+        },
+        {
+          id: 'turn-b',
+          sessionId: 'session-a',
+          userMessage: { id: 'user-turn-b', content: 'latest loaded prompt', timestamp: 2 },
+          modelRounds: [],
+          status: 'completed',
+          startTime: 2,
+        },
+      ],
+    });
+    stateMocks.virtualItems = [createItem('turn-a'), createItem('turn-b')];
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    const scroller = container.querySelector('[data-virtuoso-scroller="true"]');
+    expect(scroller).not.toBeNull();
+
+    act(() => {
+      scroller?.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: -120,
+        bubbles: true,
+      }));
+    });
+    flushAnimationFrame();
+    flushAnimationFrame();
+
+    expect(flowStoreMocks.requestSessionFullHistoryProjection).not.toHaveBeenCalled();
+    expect(flowStoreMocks.revealPreviousSessionHistoryWindow).toHaveBeenCalledWith('session-a', 'wheel-up');
+  });
+
+  it('does not reveal previous history for upward scroll away from the history boundary', () => {
+    flowStoreMocks.hasDeferredSessionHistoryProjection.mockReturnValue(true);
+    stateMocks.activeSession = createSession('session-a', 'turn-a', {
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'ready',
+      isPartial: true,
+      dialogTurns: [
+        {
+          id: 'turn-a',
+          sessionId: 'session-a',
+          userMessage: { id: 'user-turn-a', content: 'older loaded prompt', timestamp: 1 },
+          modelRounds: [],
+          status: 'completed',
+          startTime: 1,
+        },
+        {
+          id: 'turn-b',
+          sessionId: 'session-a',
+          userMessage: { id: 'user-turn-b', content: 'latest loaded prompt', timestamp: 2 },
+          modelRounds: [],
+          status: 'completed',
+          startTime: 2,
+        },
+      ],
+    });
+    stateMocks.virtualItems = [createItem('turn-a'), createItem('turn-b')];
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    expect(scroller).not.toBeNull();
+    if (scroller) {
+      scroller.scrollTop = 2000;
+    }
+
+    act(() => {
+      scroller?.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: -120,
+        bubbles: true,
+      }));
+    });
+    flushAnimationFrame();
+    flushAnimationFrame();
+
+    expect(flowStoreMocks.requestSessionFullHistoryProjection).not.toHaveBeenCalled();
+    expect(flowStoreMocks.revealPreviousSessionHistoryWindow).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-history-boundary-status]')).toBeNull();
+  });
+
+  it('surfaces a not-ready boundary state when a deferred history window cannot be revealed', () => {
+    flowStoreMocks.hasDeferredSessionHistoryProjection.mockReturnValue(true);
+    flowStoreMocks.revealPreviousSessionHistoryWindow.mockReturnValue(false);
+    stateMocks.activeSession = createSession('session-a', 'turn-a', {
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'ready',
+      isPartial: true,
+      dialogTurns: [
+        {
+          id: 'turn-a',
+          sessionId: 'session-a',
+          userMessage: { id: 'user-turn-a', content: 'latest loaded prompt', timestamp: 1 },
+          modelRounds: [],
+          status: 'completed',
+          startTime: 1,
+        },
+      ],
+    });
+    stateMocks.virtualItems = [createItem('turn-a')];
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    const scroller = container.querySelector('[data-virtuoso-scroller="true"]');
+    expect(scroller).not.toBeNull();
+
+    act(() => {
+      scroller?.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: -120,
+        bubbles: true,
+      }));
+    });
+    flushAnimationFrame();
+    flushAnimationFrame();
+
+    expect(flowStoreMocks.requestSessionFullHistoryProjection).not.toHaveBeenCalled();
+    expect(flowStoreMocks.revealPreviousSessionHistoryWindow).toHaveBeenCalledWith('session-a', 'wheel-up');
+    expect(container.querySelector('[data-history-boundary-status="not-ready"]')?.textContent).toBe('Older history is not ready yet.');
+  });
+
+  it('starts background cache preparation for ordinary upward scroll before deferred cache is ready', () => {
+    flowStoreMocks.hasPendingSessionHistoryCompletion.mockReturnValue(true);
+    stateMocks.activeSession = createSession('session-a', 'turn-a', {
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'ready',
+      isPartial: true,
+      dialogTurns: [
+        {
+          id: 'turn-a',
+          sessionId: 'session-a',
+          userMessage: { id: 'user-turn-a', content: 'latest loaded prompt', timestamp: 1 },
+          modelRounds: [],
+          status: 'completed',
+          startTime: 1,
+        },
+      ],
+    });
+    stateMocks.virtualItems = [createItem('turn-a')];
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    const scroller = container.querySelector('[data-virtuoso-scroller="true"]');
+    expect(scroller).not.toBeNull();
+
+    act(() => {
+      scroller?.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: -120,
+        bubbles: true,
+      }));
+    });
+    flushAnimationFrame();
+    flushAnimationFrame();
+
+    expect(flowStoreMocks.requestSessionFullHistoryProjection).not.toHaveBeenCalled();
+    expect(flowStoreMocks.revealPreviousSessionHistoryWindow).not.toHaveBeenCalled();
+    expect(flowStoreMocks.releaseSessionHistoryCompletionAfterInitialPaint).toHaveBeenCalledWith('session-a', {
+      immediate: true,
+      reason: 'wheel-up',
+    });
+    expect(container.querySelector('[data-history-boundary-status="preparing"]')?.textContent).toBe('Preparing older history...');
+  });
+
+  it('surfaces a not-ready boundary state when older history work is unavailable', () => {
+    stateMocks.activeSession = createSession('session-a', 'turn-a', {
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'ready',
+      isPartial: true,
+      dialogTurns: [
+        {
+          id: 'turn-a',
+          sessionId: 'session-a',
+          userMessage: { id: 'user-turn-a', content: 'latest loaded prompt', timestamp: 1 },
+          modelRounds: [],
+          status: 'completed',
+          startTime: 1,
+        },
+      ],
+    });
+    stateMocks.virtualItems = [createItem('turn-a')];
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    const scroller = container.querySelector('[data-virtuoso-scroller="true"]');
+    expect(scroller).not.toBeNull();
+
+    act(() => {
+      scroller?.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: -120,
+        bubbles: true,
+      }));
+    });
+    flushAnimationFrame();
+    flushAnimationFrame();
+
+    expect(flowStoreMocks.requestSessionFullHistoryProjection).not.toHaveBeenCalled();
+    expect(flowStoreMocks.revealPreviousSessionHistoryWindow).not.toHaveBeenCalled();
+    expect(flowStoreMocks.releaseSessionHistoryCompletionAfterInitialPaint).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-history-boundary-status="not-ready"]')?.textContent).toBe('Older history is not ready yet.');
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -13,6 +13,7 @@
 
 import React, { useRef, useState, useCallback, useEffect, useLayoutEffect, forwardRef, useImperativeHandle } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
+import { useTranslation } from 'react-i18next';
 import { useActiveSessionState } from '../../hooks/useActiveSessionState';
 import { VirtualItemRenderer } from './VirtualItemRenderer';
 import { ScrollToLatestBar } from '../ScrollToLatestBar';
@@ -71,6 +72,7 @@ const PARTIAL_HISTORY_INITIAL_TAIL_TURN_BUDGET = 16;
 const PARTIAL_HISTORY_FULL_PROJECTION_TOP_THRESHOLD_PX = 1200;
 const HISTORY_PROJECTION_HANDOFF_MAX_DURATION_MS = 5000;
 const SESSION_OPEN_HANDOFF_ITEM_BUDGET = 24;
+const PREVIOUS_HISTORY_BOUNDARY_STATUS_DURATION_MS = 2500;
 
 type LatestEndAnchorResolveReason =
   | 'raf'
@@ -321,6 +323,7 @@ function getReservationConsumablePx(reservation: BottomReservationBase): number 
 }
 
 const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => {
+  const { t } = useTranslation('flow-chat');
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const virtualItems = useVirtualItems();
   const activeSession = useActiveSession();
@@ -358,17 +361,22 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
   const [historyProjectionHandoff, setHistoryProjectionHandoff] = useState<HistoryProjectionHandoffSnapshot | null>(null);
   const [expandedInitialHistoryRenderKey, setExpandedInitialHistoryRenderKey] = useState<string | null>(null);
   const [staticAnchorWindowTurnId, setStaticAnchorWindowTurnId] = useState<string | null>(null);
+  const [previousHistoryBoundaryStatus, setPreviousHistoryBoundaryStatus] = useState<{
+    sessionId: string;
+    reason: string;
+    state: 'preparing' | 'not-ready';
+  } | null>(null);
 
   const scrollerElementRef = useRef<HTMLElement | null>(null);
   const footerElementRef = useRef<HTMLDivElement | null>(null);
   const activeSessionIdRef = useRef<string | null>(null);
-  const pendingHistoryProjectionHandoffRef = useRef<HistoryProjectionHandoffSnapshot | null>(null);
   const historyProjectionHandoffRef = useRef<HistoryProjectionHandoffSnapshot | null>(null);
   const historyProjectionHandoffReleaseFrameRef = useRef<number | null>(null);
   const latestVisibleHistoryTailSnapshotRef = useRef<HistoryProjectionHandoffSnapshot | null>(null);
   const previousInitialHistoryTransitionStateRef = useRef<InitialHistoryTransitionState | null>(null);
   const fullHistoryProjectionIntentFrameRef = useRef<number | null>(null);
   const pendingFullHistoryProjectionReasonRef = useRef<string | null>(null);
+  const previousHistoryBoundaryStatusTimerRef = useRef<number | null>(null);
   const sessionOpenHandoffSessionIdRef = useRef<string | null>(null);
   const previousActiveSessionIdForOpenHandoffRef = useRef<string | null | undefined>(undefined);
   const pendingStaticAnchorTurnIdRef = useRef<string | null>(null);
@@ -1255,64 +1263,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     });
   }, []);
 
-  const findVirtualItemIndexByStableKey = useCallback((stableKey: string | null) => {
-    if (!stableKey) {
-      return -1;
-    }
-
-    return virtualItems.findIndex(item => getVirtualItemStableKey(item) === stableKey);
-  }, [virtualItems]);
-
-  const captureVisibleVirtualItemAnchor = useCallback(() => {
-    const scroller = scrollerElementRef.current;
-    if (!scroller) {
-      return { anchorKey: null, anchorOffsetTopPx: 0 };
-    }
-
-    const scrollerRect = scroller.getBoundingClientRect();
-    const nodes = Array.from(
-      scroller.querySelectorAll<HTMLElement>('.virtual-item-wrapper[data-virtual-index]'),
-    );
-    const anchorNode = nodes.find(node => {
-      const rect = node.getBoundingClientRect();
-      return rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom;
-    });
-    const anchorIndex = Number(anchorNode?.dataset.virtualIndex);
-    const anchorItem = Number.isInteger(anchorIndex) ? virtualItems[anchorIndex] : undefined;
-    if (!anchorNode || !anchorItem) {
-      return { anchorKey: null, anchorOffsetTopPx: 0 };
-    }
-
-    return {
-      anchorKey: getVirtualItemStableKey(anchorItem),
-      anchorOffsetTopPx: anchorNode.getBoundingClientRect().top - scrollerRect.top,
-    };
-  }, [virtualItems]);
-
-  const isHistoryProjectionHandoffAnchorReady = useCallback((snapshot: HistoryProjectionHandoffSnapshot) => {
-    const scroller = scrollerElementRef.current;
-    const anchorIndex = findVirtualItemIndexByStableKey(snapshot.anchorKey);
-    if (!scroller || anchorIndex < 0) {
-      return false;
-    }
-
-    const anchorElement = getRenderedVirtualItemElement(anchorIndex);
-    if (!anchorElement) {
-      return false;
-    }
-
-    const scrollerRect = scroller.getBoundingClientRect();
-    const anchorRect = anchorElement.getBoundingClientRect();
-    const visible = anchorRect.bottom > scrollerRect.top && anchorRect.top < scrollerRect.bottom;
-    const offsetDelta = Math.abs((anchorRect.top - scrollerRect.top) - snapshot.anchorOffsetTopPx);
-    return visible && offsetDelta <= 8;
-  }, [findVirtualItemIndexByStableKey, getRenderedVirtualItemElement]);
-
   const isHistoryProjectionHandoffTargetReady = useCallback((snapshot: HistoryProjectionHandoffSnapshot) => {
-    if (snapshot.mode === 'scroll-position' && snapshot.anchorKey) {
-      return isHistoryProjectionHandoffAnchorReady(snapshot);
-    }
-
     if (snapshot.targetTurnId) {
       return isTurnTextRenderedInViewportOutsideHandoff(snapshot.targetTurnId);
     }
@@ -1320,7 +1271,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     return hasVisibleRenderedVirtualItem();
   }, [
     hasVisibleRenderedVirtualItem,
-    isHistoryProjectionHandoffAnchorReady,
     isTurnTextRenderedInViewportOutsideHandoff,
   ]);
 
@@ -1331,7 +1281,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     }
 
     const snapshot = historyProjectionHandoffRef.current;
-    pendingHistoryProjectionHandoffRef.current = null;
     historyProjectionHandoffRef.current = null;
     setHistoryProjectionHandoff(null);
 
@@ -1386,59 +1335,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
 
     run(Math.max(1, frames));
   }, [clearHistoryProjectionHandoff, isHistoryProjectionHandoffTargetReady]);
-
-  const captureHistoryProjectionHandoffSnapshot = useCallback((reason: string) => {
-    const sessionId = activeSession?.sessionId;
-    const scroller = scrollerElementRef.current;
-    if (
-      !sessionId ||
-      activeSession?.isPartial !== true ||
-      !scroller ||
-      virtualItems.length === 0
-    ) {
-      return;
-    }
-
-    const { anchorKey, anchorOffsetTopPx } = captureVisibleVirtualItemAnchor();
-    const snapshot: HistoryProjectionHandoffSnapshot = {
-      sessionId,
-      reason,
-      createdAtMs: performance.now(),
-      items: virtualItems,
-      mode: 'scroll-position',
-      targetTurnId: latestTurnId,
-      anchorKey,
-      anchorOffsetTopPx,
-      scrollTop: scroller.scrollTop,
-      scrollHeight: scroller.scrollHeight,
-      clientHeight: scroller.clientHeight,
-      footerHeightPx: getFooterHeightPx(getTotalBottomCompensationPx()),
-    };
-
-    pendingHistoryProjectionHandoffRef.current = snapshot;
-    historyProjectionHandoffRef.current = snapshot;
-    setHistoryProjectionHandoff(snapshot);
-    startupTrace.markPhase('flowchat_history_projection_handoff_captured', {
-      sessionId,
-      reason,
-      anchorKey,
-      anchorOffsetTopPx: Math.round(anchorOffsetTopPx),
-      itemCount: snapshot.items.length,
-      scrollTop: Math.round(snapshot.scrollTop),
-      scrollHeight: Math.round(snapshot.scrollHeight),
-      clientHeight: Math.round(snapshot.clientHeight),
-    });
-    scheduleHistoryProjectionHandoffRelease(2);
-  }, [
-    activeSession?.isPartial,
-    activeSession?.sessionId,
-    captureVisibleVirtualItemAnchor,
-    getFooterHeightPx,
-    getTotalBottomCompensationPx,
-    latestTurnId,
-    scheduleHistoryProjectionHandoffRelease,
-    virtualItems,
-  ]);
 
   const buildPinReservation = useCallback((
     turnId: string,
@@ -1843,7 +1739,62 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     setScrollerElement(null);
   }, []);
 
-  const requestFullHistoryProjectionForUserIntent = useCallback((reason: string) => {
+  const clearPreviousHistoryBoundaryStatus = useCallback(() => {
+    if (previousHistoryBoundaryStatusTimerRef.current !== null) {
+      window.clearTimeout(previousHistoryBoundaryStatusTimerRef.current);
+      previousHistoryBoundaryStatusTimerRef.current = null;
+    }
+    setPreviousHistoryBoundaryStatus(null);
+  }, []);
+
+  const showPreviousHistoryBoundaryStatus = useCallback((
+    sessionId: string,
+    reason: string,
+    state: 'preparing' | 'not-ready'
+  ) => {
+    if (previousHistoryBoundaryStatusTimerRef.current !== null) {
+      window.clearTimeout(previousHistoryBoundaryStatusTimerRef.current);
+      previousHistoryBoundaryStatusTimerRef.current = null;
+    }
+
+    setPreviousHistoryBoundaryStatus({
+      sessionId,
+      reason,
+      state,
+    });
+
+    previousHistoryBoundaryStatusTimerRef.current = window.setTimeout(() => {
+      previousHistoryBoundaryStatusTimerRef.current = null;
+      setPreviousHistoryBoundaryStatus(current => {
+        if (
+          current?.sessionId === sessionId &&
+          current.reason === reason &&
+          current.state === state
+        ) {
+          return null;
+        }
+        return current;
+      });
+    }, PREVIOUS_HISTORY_BOUNDARY_STATUS_DURATION_MS);
+  }, []);
+
+  useEffect(() => () => {
+    if (previousHistoryBoundaryStatusTimerRef.current !== null) {
+      window.clearTimeout(previousHistoryBoundaryStatusTimerRef.current);
+      previousHistoryBoundaryStatusTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    setPreviousHistoryBoundaryStatus(current => {
+      if (current && current.sessionId !== activeSessionId) {
+        return null;
+      }
+      return current;
+    });
+  }, [activeSessionId]);
+
+  const revealPreviousHistoryWindowForUserIntent = useCallback((reason: string) => {
     const sessionId = activeSession?.sessionId;
     if (
       !sessionId ||
@@ -1853,23 +1804,48 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       return;
     }
 
-    const hasFullHistoryWork =
-      flowChatStore.hasPendingSessionHistoryCompletion(sessionId) ||
-      flowChatStore.hasDeferredSessionHistoryProjection(sessionId);
-    if (!hasFullHistoryWork) {
+    if (!flowChatStore.hasDeferredSessionHistoryProjection(sessionId)) {
+      if (flowChatStore.hasPendingSessionHistoryCompletion(sessionId)) {
+        const released = flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint(sessionId, {
+          immediate: true,
+          reason,
+        });
+        showPreviousHistoryBoundaryStatus(sessionId, reason, 'preparing');
+        startupTrace.markPhase('flowchat_previous_history_window_preparing', {
+          sessionId,
+          reason,
+          released,
+        });
+      } else {
+        showPreviousHistoryBoundaryStatus(sessionId, reason, 'not-ready');
+        startupTrace.markPhase('flowchat_previous_history_window_not_ready', {
+          sessionId,
+          reason,
+        });
+      }
       return;
     }
 
-    captureHistoryProjectionHandoffSnapshot(reason);
-    flowChatStore.requestSessionFullHistoryProjection(sessionId, reason);
+    const revealed = flowChatStore.revealPreviousSessionHistoryWindow(sessionId, reason);
+    if (revealed) {
+      clearPreviousHistoryBoundaryStatus();
+    } else {
+      showPreviousHistoryBoundaryStatus(sessionId, reason, 'not-ready');
+    }
+    startupTrace.markPhase('flowchat_previous_history_window_requested', {
+      sessionId,
+      reason,
+      revealed,
+    });
   }, [
     activeSession?.historyState,
     activeSession?.isPartial,
     activeSession?.sessionId,
-    captureHistoryProjectionHandoffSnapshot,
+    clearPreviousHistoryBoundaryStatus,
+    showPreviousHistoryBoundaryStatus,
   ]);
 
-  const shouldRequestFullHistoryProjectionForUserIntent = useCallback((options?: { force?: boolean }) => {
+  const shouldRevealPreviousHistoryWindowForUserIntent = useCallback((options?: { force?: boolean }) => {
     if (options?.force === true) {
       return true;
     }
@@ -1886,7 +1862,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     return scroller.scrollTop <= topThresholdPx;
   }, []);
 
-  const scheduleFullHistoryProjectionForUserIntent = useCallback((reason: string, options?: { force?: boolean }) => {
+  const schedulePreviousHistoryWindowForUserIntent = useCallback((reason: string, options?: { force?: boolean }) => {
     const scheduledSessionId = activeSession?.sessionId ?? null;
     pendingFullHistoryProjectionReasonRef.current = reason;
     if (fullHistoryProjectionIntentFrameRef.current !== null) {
@@ -1903,45 +1879,17 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
           return;
         }
 
-        if (!shouldRequestFullHistoryProjectionForUserIntent(options)) {
+        if (!shouldRevealPreviousHistoryWindowForUserIntent(options)) {
           return;
         }
 
-        requestFullHistoryProjectionForUserIntent(pendingReason);
+        revealPreviousHistoryWindowForUserIntent(pendingReason);
       });
     });
   }, [
     activeSession?.sessionId,
-    requestFullHistoryProjectionForUserIntent,
-    shouldRequestFullHistoryProjectionForUserIntent,
-  ]);
-
-  useLayoutEffect(() => {
-    const snapshot = pendingHistoryProjectionHandoffRef.current;
-    if (
-      !snapshot ||
-      activeSession?.sessionId !== snapshot.sessionId ||
-      activeSession?.isPartial === true ||
-      virtualItems.length <= snapshot.items.length
-    ) {
-      return;
-    }
-
-    pendingHistoryProjectionHandoffRef.current = null;
-    historyProjectionHandoffRef.current = snapshot;
-    setHistoryProjectionHandoff(snapshot);
-    startupTrace.markPhase('flowchat_history_projection_handoff_activated', {
-      sessionId: snapshot.sessionId,
-      reason: snapshot.reason,
-      previousItemCount: snapshot.items.length,
-      nextItemCount: virtualItems.length,
-    });
-    scheduleHistoryProjectionHandoffRelease(2);
-  }, [
-    activeSession?.isPartial,
-    activeSession?.sessionId,
-    scheduleHistoryProjectionHandoffRelease,
-    virtualItems.length,
+    revealPreviousHistoryWindowForUserIntent,
+    shouldRevealPreviousHistoryWindowForUserIntent,
   ]);
 
   const shouldSuspendAutoFollow = useCallback(() => {
@@ -1987,10 +1935,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     const activeHandoff = historyProjectionHandoffRef.current;
     if (!activeHandoff || activeHandoff.sessionId !== currentSessionId) {
       clearHistoryProjectionHandoff('session-reset');
-    }
-    const pendingHandoff = pendingHistoryProjectionHandoffRef.current;
-    if (pendingHandoff && pendingHandoff.sessionId !== currentSessionId) {
-      pendingHistoryProjectionHandoffRef.current = null;
     }
     resetBottomReservations();
   }, [
@@ -2238,7 +2182,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
         performance.now() <= userInitiatedUpwardScrollUntilMsRef.current ||
         scrollbarPointerInteractionActiveRef.current
       ) {
-        scheduleFullHistoryProjectionForUserIntent('scroll-near-partial-history-boundary');
+        schedulePreviousHistoryWindowForUserIntent('scroll-near-partial-history-boundary');
       }
 
       if (anchorLockRef.current.active && performance.now() > anchorLockRef.current.lockUntilMs && !collapseProtectionActive) {
@@ -2258,7 +2202,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       if (event.deltaY < 0) {
         userInitiatedUpwardScrollUntilMsRef.current =
           performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
-        scheduleFullHistoryProjectionForUserIntent('wheel-up');
+        schedulePreviousHistoryWindowForUserIntent('wheel-up');
         followOutputControllerRef.current.handleUserScrollIntent();
         releaseAnchorLock('wheel-up');
       }
@@ -2284,7 +2228,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
         touchScrollIntentStartYRef.current = currentY;
         userInitiatedUpwardScrollUntilMsRef.current =
           performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
-        scheduleFullHistoryProjectionForUserIntent('touch-scroll-up');
+        schedulePreviousHistoryWindowForUserIntent('touch-scroll-up');
         followOutputControllerRef.current.handleUserScrollIntent();
         releaseAnchorLock('touch-scroll-up');
       }
@@ -2303,7 +2247,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       cancelLatestEndAnchorStabilization();
       userInitiatedUpwardScrollUntilMsRef.current =
         performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
-      scheduleFullHistoryProjectionForUserIntent('keyboard-scroll-up', { force: event.key === 'Home' });
+      schedulePreviousHistoryWindowForUserIntent('keyboard-scroll-up', { force: event.key === 'Home' });
       followOutputControllerRef.current.handleUserScrollIntent();
       releaseAnchorLock('keyboard-scroll-up');
     };
@@ -2322,7 +2266,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       cancelLatestEndAnchorStabilization();
       userInitiatedUpwardScrollUntilMsRef.current =
         performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
-      scheduleFullHistoryProjectionForUserIntent('scrollbar-pointer-down');
+      schedulePreviousHistoryWindowForUserIntent('scrollbar-pointer-down');
       followOutputControllerRef.current.handleUserScrollIntent();
       releaseAnchorLock('scrollbar-pointer-down');
     };
@@ -2341,7 +2285,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       cancelLatestEndAnchorStabilization();
       userInitiatedUpwardScrollUntilMsRef.current =
         performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
-      scheduleFullHistoryProjectionForUserIntent('scrollbar-pointer-move');
+      schedulePreviousHistoryWindowForUserIntent('scrollbar-pointer-move');
       followOutputControllerRef.current.handleUserScrollIntent();
       releaseAnchorLock('scrollbar-pointer-move');
     };
@@ -2498,7 +2442,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     releaseAnchorLock,
     scheduleHeightMeasure,
     scheduleFollowToLatestWithViewportState,
-    scheduleFullHistoryProjectionForUserIntent,
+    schedulePreviousHistoryWindowForUserIntent,
     scheduleHistoryProjectionHandoffRelease,
     schedulePinReservationReconcile,
     scheduleTransientTurnPinStabilization,
@@ -2948,19 +2892,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     return lastDialogTurn.modelRounds.some(round => round.isStreaming);
   }, [activeSession, isProcessing]);
   const initialTopMostItemIndex = React.useMemo(() => {
-    if (
-      historyProjectionHandoff?.mode === 'scroll-position' &&
-      historyProjectionHandoff.sessionId === activeSessionId
-    ) {
-      const anchorIndex = findVirtualItemIndexByStableKey(historyProjectionHandoff.anchorKey);
-      if (anchorIndex >= 0) {
-        return {
-          index: toVirtuosoIndex(anchorIndex),
-          align: 'start' as const,
-        };
-      }
-    }
-
     if (isStreamingOutput) {
       return toVirtuosoIndex(latestUserMessageIndex);
     }
@@ -2970,11 +2901,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       align: 'end' as const,
     };
   }, [
-    activeSessionId,
-    findVirtualItemIndexByStableKey,
-    historyProjectionHandoff?.anchorKey,
-    historyProjectionHandoff?.mode,
-    historyProjectionHandoff?.sessionId,
     isStreamingOutput,
     latestUserMessageIndex,
     toVirtuosoIndex,
@@ -3822,7 +3748,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       footerHeightPx,
     };
 
-    pendingHistoryProjectionHandoffRef.current = null;
     historyProjectionHandoffRef.current = handoff;
     setHistoryProjectionHandoff(handoff);
     startupTrace.markPhase('flowchat_history_projection_handoff_activated', {
@@ -3864,11 +3789,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       items: virtualItems.slice(tailStartIndex),
       mode: 'bottom-tail',
       targetTurnId: latestTurnId,
-      anchorKey: null,
-      anchorOffsetTopPx: 0,
-      scrollTop: scroller.scrollTop,
-      scrollHeight: scroller.scrollHeight,
-      clientHeight: scroller.clientHeight,
       footerHeightPx,
     };
   }, [
@@ -4206,7 +4126,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       return null;
     }
 
-    const scroller = scrollerElementRef.current;
     const budgetStartIndex = Math.max(0, virtualItems.length - SESSION_OPEN_HANDOFF_ITEM_BUDGET);
     const latestStartIndex = Math.max(0, Math.min(latestUserMessageIndex, virtualItems.length - 1));
     const startIndex = Math.min(budgetStartIndex, latestStartIndex);
@@ -4215,7 +4134,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       return null;
     }
 
-    const clientHeight = scroller?.clientHeight ?? 0;
     return {
       sessionId: activeSessionId,
       reason: 'session-open',
@@ -4223,11 +4141,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       items,
       mode: 'bottom-tail',
       targetTurnId: latestTurnId,
-      anchorKey: null,
-      anchorOffsetTopPx: 0,
-      scrollTop: 0,
-      scrollHeight: clientHeight,
-      clientHeight,
       footerHeightPx,
     };
   }, [
@@ -4249,7 +4162,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       return;
     }
 
-    pendingHistoryProjectionHandoffRef.current = null;
     historyProjectionHandoffRef.current = sessionOpenProjectionHandoff;
     sessionOpenHandoffSessionIdRef.current = sessionOpenProjectionHandoff.sessionId;
     setHistoryProjectionHandoff(sessionOpenProjectionHandoff);
@@ -4367,55 +4279,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     useStaticInitialHistoryList,
   ]);
   // ── Render ────────────────────────────────────────────────────────────
-  useLayoutEffect(() => {
-    const snapshot = historyProjectionHandoffRef.current;
-    if (
-      !snapshot ||
-      snapshot.mode !== 'scroll-position' ||
-      snapshot.sessionId !== activeSessionId ||
-      !snapshot.anchorKey
-    ) {
-      return;
-    }
-
-    const scroller = scrollerElementRef.current;
-    const anchorIndex = findVirtualItemIndexByStableKey(snapshot.anchorKey);
-    if (!scroller || anchorIndex < 0) {
-      return;
-    }
-
-    const anchorElement = getRenderedVirtualItemElement(anchorIndex);
-    if (!anchorElement) {
-      return;
-    }
-
-    const scrollerRect = scroller.getBoundingClientRect();
-    const anchorRect = anchorElement.getBoundingClientRect();
-    const offsetDelta = (anchorRect.top - scrollerRect.top) - snapshot.anchorOffsetTopPx;
-    if (Math.abs(offsetDelta) <= COMPENSATION_EPSILON_PX) {
-      return;
-    }
-
-    const nextScrollTop = Math.max(0, scroller.scrollTop + offsetDelta);
-    scroller.scrollTop = nextScrollTop;
-    previousScrollTopRef.current = nextScrollTop;
-    previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
-    recordScrollerGeometry(scroller);
-    scheduleHistoryProjectionHandoffRelease(2);
-  }, [
-    activeSessionId,
-    findVirtualItemIndexByStableKey,
-    getRenderedVirtualItemElement,
-    historyProjectionHandoff?.anchorKey,
-    historyProjectionHandoff?.anchorOffsetTopPx,
-    historyProjectionHandoff?.mode,
-    historyProjectionHandoff?.sessionId,
-    recordScrollerGeometry,
-    scheduleHistoryProjectionHandoffRelease,
-    snapshotMeasuredContentHeight,
-    virtualItems,
-  ]);
-
   if (virtualItems.length === 0) {
     return (
       <div
@@ -4428,6 +4291,20 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       </div>
     );
   }
+
+  const previousHistoryBoundaryStatusNode =
+    previousHistoryBoundaryStatus?.sessionId === activeSessionId ? (
+      <div
+        className="virtual-message-list__history-boundary-status"
+        data-history-boundary-status={previousHistoryBoundaryStatus.state}
+        role="status"
+        aria-live="polite"
+      >
+        {previousHistoryBoundaryStatus.state === 'preparing'
+          ? t('historyState.preparingOlderHistory')
+          : t('historyState.olderHistoryNotReady')}
+      </div>
+    ) : null;
 
   return (
     <div
@@ -4445,6 +4322,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
           onKeyDownCapture={handleInitialHistoryStaticKeyDownCapture}
         >
           <div className="message-list-header" />
+          {previousHistoryBoundaryStatusNode}
           {omittedInitialHistoryEstimatedHeightPx > 0 ? (
             <div
               className="virtual-message-list__initial-history-spacer"
@@ -4511,7 +4389,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
           scrollerRef={handleScrollerRef}
 
           components={{
-            Header: () => <div className="message-list-header" />,
+            Header: () => (
+              <>
+                <div className="message-list-header" />
+                {previousHistoryBoundaryStatusNode}
+              </>
+            ),
             Footer: () => (
               <>
                 <ProcessingIndicator visible={showBreathingIndicator} reserveSpace={reserveSpaceForIndicator} />
@@ -4537,18 +4420,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
           aria-hidden="true"
         >
           <div
-            className={[
-              'virtual-message-list__projection-handoff-content',
-              activeHistoryProjectionHandoff.mode === 'bottom-tail'
-                ? 'virtual-message-list__projection-handoff-content--bottom'
-                : null,
-            ].filter(Boolean).join(' ')}
-            style={activeHistoryProjectionHandoff.mode === 'bottom-tail'
-              ? undefined
-              : {
-                minHeight: `${Math.max(activeHistoryProjectionHandoff.scrollHeight, activeHistoryProjectionHandoff.clientHeight)}px`,
-                transform: `translate3d(0, -${Math.max(0, activeHistoryProjectionHandoff.scrollTop)}px, 0)`,
-              }}
+            className="virtual-message-list__projection-handoff-content virtual-message-list__projection-handoff-content--bottom"
           >
             <div className="message-list-header" />
             <div className="virtual-message-list__static-items">

--- a/src/web-ui/src/flow_chat/components/modern/historyProjectionHandoff.ts
+++ b/src/web-ui/src/flow_chat/components/modern/historyProjectionHandoff.ts
@@ -5,13 +5,8 @@ export interface HistoryProjectionHandoffSnapshot {
   reason: string;
   createdAtMs: number;
   items: VirtualItem[];
-  mode: 'scroll-position' | 'bottom-tail';
+  mode: 'bottom-tail';
   targetTurnId: string | null;
-  anchorKey: string | null;
-  anchorOffsetTopPx: number;
-  scrollTop: number;
-  scrollHeight: number;
-  clientHeight: number;
   footerHeightPx: number;
 }
 

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -1443,6 +1443,107 @@ describe('FlowChatStore historical session hydration state', () => {
     }
   });
 
+  it('reveals a bounded previous history window from deferred cache without applying the full projection', async () => {
+    vi.useFakeTimers();
+    const turnData = (turnIndex: number) => ({
+      turnId: `turn-${turnIndex}`,
+      turnIndex: turnIndex - 1,
+      sessionId: 'history-1',
+      timestamp: turnIndex,
+      userMessage: { id: `user-${turnIndex}`, content: `prompt ${turnIndex}`, timestamp: turnIndex },
+      modelRounds: [],
+      startTime: turnIndex,
+      status: 'completed',
+    });
+    apiMocks.restoreSessionView
+      .mockResolvedValueOnce({
+        session: {
+          sessionId: 'history-1',
+          sessionName: 'History 1',
+          agentType: 'agentic',
+          state: 'Idle',
+          turnCount: 5,
+          createdAt: 1,
+        },
+        turns: [turnData(5)],
+        contextRestoreState: 'pending',
+        isPartial: true,
+        loadedTurnCount: 1,
+        totalTurnCount: 5,
+      })
+      .mockResolvedValueOnce({
+        session: {
+          sessionId: 'history-1',
+          sessionName: 'History 1',
+          agentType: 'agentic',
+          state: 'Idle',
+          turnCount: 5,
+          createdAt: 1,
+        },
+        turns: [turnData(1), turnData(2), turnData(3), turnData(4), turnData(5)],
+        contextRestoreState: 'pending',
+        isPartial: false,
+        loadedTurnCount: 5,
+        totalTurnCount: 5,
+      });
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    try {
+      await flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
+      flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint('history-1');
+      await advanceReleasedLocalFullHistoryCompletion();
+
+      expect(flowChatStore.hasDeferredSessionHistoryProjection('history-1')).toBe(true);
+      expect(
+        flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.id)
+      ).toEqual(['turn-5']);
+
+      expect(flowChatStore.revealPreviousSessionHistoryWindow('history-1', 'wheel-up', 2)).toBe(true);
+
+      const session = flowChatStore.getState().sessions.get('history-1');
+      expect(session?.dialogTurns.map(turn => turn.id)).toEqual(['turn-3', 'turn-4', 'turn-5']);
+      expect(session).toMatchObject({
+        isPartial: true,
+        loadedTurnCount: 3,
+        totalTurnCount: 5,
+      });
+      expect(flowChatStore.hasDeferredSessionHistoryProjection('history-1')).toBe(true);
+
+      const newTurn = {
+        id: 'turn-6',
+        sessionId: 'history-1',
+        userMessage: { id: 'user-6', content: 'new prompt', timestamp: 6 },
+        modelRounds: [],
+        status: 'processing',
+        startTime: 6,
+      } as any;
+      flowChatStore.addDialogTurn('history-1', newTurn);
+
+      expect(flowChatStore.requestSessionFullHistoryProjection('history-1', 'search')).toBe(true);
+      expect(
+        flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.id)
+      ).toEqual(['turn-1', 'turn-2', 'turn-3', 'turn-4', 'turn-5', 'turn-6']);
+      expect(flowChatStore.getState().sessions.get('history-1')?.dialogTurns[5]).toBe(newTurn);
+      expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
+        isPartial: false,
+        loadedTurnCount: 6,
+        totalTurnCount: 6,
+      });
+      expect(flowChatStore.hasDeferredSessionHistoryProjection('history-1')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('skips committing stale local history hydrate when switching away before restore finishes', async () => {
     vi.useFakeTimers();
     const latestTurn = {
@@ -1889,6 +1990,125 @@ describe('FlowChatStore historical session hydration state', () => {
       undefined,
       3,
     );
+  });
+
+  it('defers remote idle full history completion instead of replacing the visible tail', async () => {
+    vi.useFakeTimers();
+    let idleCallback: (() => void) | null = null;
+    const originalRequestIdleCallback = (globalThis as any).requestIdleCallback;
+    const originalCancelIdleCallback = (globalThis as any).cancelIdleCallback;
+    (globalThis as any).requestIdleCallback = vi.fn((callback: () => void) => {
+      idleCallback = callback;
+      return 1;
+    });
+    (globalThis as any).cancelIdleCallback = vi.fn();
+
+    const olderTurn = {
+      turnId: 'turn-1',
+      turnIndex: 0,
+      sessionId: 'history-remote',
+      timestamp: 1,
+      userMessage: { id: 'user-1', content: 'older prompt', timestamp: 1 },
+      modelRounds: [],
+      startTime: 1,
+      status: 'completed',
+    };
+    const latestTurn = {
+      turnId: 'turn-2',
+      turnIndex: 1,
+      sessionId: 'history-remote',
+      timestamp: 2,
+      userMessage: { id: 'user-2', content: 'latest prompt', timestamp: 2 },
+      modelRounds: [],
+      startTime: 2,
+      status: 'completed',
+    };
+    apiMocks.restoreSessionView
+      .mockResolvedValueOnce({
+        session: {
+          sessionId: 'history-remote',
+          sessionName: 'Remote History',
+          agentType: 'agentic',
+          state: 'Idle',
+          turnCount: 2,
+          createdAt: 1,
+        },
+        turns: [latestTurn],
+        contextRestoreState: 'pending',
+        isPartial: true,
+        loadedTurnCount: 1,
+        totalTurnCount: 2,
+      })
+      .mockResolvedValueOnce({
+        session: {
+          sessionId: 'history-remote',
+          sessionName: 'Remote History',
+          agentType: 'agentic',
+          state: 'Idle',
+          turnCount: 2,
+          createdAt: 1,
+        },
+        turns: [olderTurn, latestTurn],
+        contextRestoreState: 'pending',
+        isPartial: false,
+        loadedTurnCount: 2,
+        totalTurnCount: 2,
+      });
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-remote', createSession({
+          sessionId: 'history-remote',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-remote',
+    }));
+
+    try {
+      await flowChatStore.loadSessionHistory(
+        'history-remote',
+        '/remote/workspace',
+        undefined,
+        'remote-1',
+        'remote.example'
+      );
+
+      expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(1);
+      expect(idleCallback).toBeTypeOf('function');
+      const hydrationPromise = Array.from(
+        ((flowChatStore as any).fullHistoryHydrationRequests as Map<string, { promise: Promise<void> }>).values()
+      )[0]?.promise;
+      expect(hydrationPromise).toBeInstanceOf(Promise);
+
+      expect(flowChatStore.releaseSessionHistoryCompletionAfterInitialPaint('history-remote', {
+        immediate: true,
+        reason: 'test',
+      })).toBe(false);
+      expect(flowChatStore.requestSessionFullHistoryProjection('history-remote', 'search-before-idle')).toBe(false);
+      expect(
+        ((flowChatStore as any).fullHistoryProjectionApplyRequests as Set<string>).has('history-remote')
+      ).toBe(false);
+
+      idleCallback?.();
+      await hydrationPromise;
+
+      expect(apiMocks.restoreSessionView).toHaveBeenCalledTimes(2);
+      expect(flowChatStore.hasDeferredSessionHistoryProjection('history-remote')).toBe(true);
+      expect(
+        flowChatStore.getState().sessions.get('history-remote')?.dialogTurns.map(turn => turn.userMessage.content)
+      ).toEqual(['latest prompt']);
+
+      expect(flowChatStore.requestSessionFullHistoryProjection('history-remote', 'search')).toBe(false);
+      expect(flowChatStore.hasDeferredSessionHistoryProjection('history-remote')).toBe(true);
+      expect(
+        flowChatStore.getState().sessions.get('history-remote')?.dialogTurns.map(turn => turn.userMessage.content)
+      ).toEqual(['latest prompt']);
+    } finally {
+      (globalThis as any).requestIdleCallback = originalRequestIdleCallback;
+      (globalThis as any).cancelIdleCallback = originalCancelIdleCallback;
+      vi.useRealTimers();
+    }
   });
 
   it('waits for initial paint and browser idle before completing partial history in background', async () => {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -78,6 +78,7 @@ const METADATA_LIST_RECENT_DEDUPE_TTL_MS = 1000;
 const HISTORICAL_SESSION_INITIAL_REMOTE_TAIL_TURN_COUNT = 3;
 const HISTORICAL_SESSION_INITIAL_LOCAL_TAIL_TURN_COUNT = 3;
 const HISTORICAL_SESSION_FULL_HISTORY_IDLE_TIMEOUT_MS = 1500;
+const HISTORICAL_SESSION_PREVIOUS_WINDOW_TURN_COUNT = 12;
 
 type RemoveSessionOptions = {
   nextActiveSessionId?: string | null;
@@ -720,7 +721,7 @@ export class FlowChatStore {
       }
     });
 
-    this.fullHistoryHydrationRequests.set(requestKey, {
+    const hydrationRequest: FullHistoryHydrationRequest = {
       sessionId: request.sessionId,
       remote,
       requireActiveSession,
@@ -730,10 +731,15 @@ export class FlowChatStore {
         cancelScheduled?.();
         resolveRequest?.();
       },
-      releaseAfterInitialPaint: (options?: FullHistoryHydrationReleaseOptions) => {
+    };
+
+    if (releaseAfterInitialPaint) {
+      hydrationRequest.releaseAfterInitialPaint = (options?: FullHistoryHydrationReleaseOptions) => {
         releaseAfterInitialPaint?.(options);
-      },
-    });
+      };
+    }
+
+    this.fullHistoryHydrationRequests.set(requestKey, hydrationRequest);
   }
 
   private cancelLocalSessionHistoryCompletion(sessionId: string, reason: string): boolean {
@@ -869,18 +875,25 @@ export class FlowChatStore {
       if (request.sessionId !== sessionId) {
         continue;
       }
-      request.releaseAfterInitialPaint?.(options);
+      if (!request.releaseAfterInitialPaint) {
+        continue;
+      }
+      request.releaseAfterInitialPaint(options);
       released = true;
     }
     return released;
   }
 
   private shouldDeferFullHistoryProjection(sessionId: string, remote: boolean, _requireActiveSession: boolean): boolean {
-    return (
-      !remote &&
-      this.state.activeSessionId === sessionId &&
-      !this.fullHistoryProjectionApplyRequests.has(sessionId)
-    );
+    if (remote) {
+      return true;
+    }
+
+    if (this.fullHistoryProjectionApplyRequests.has(sessionId)) {
+      return false;
+    }
+
+    return this.state.activeSessionId === sessionId;
   }
 
   private setDeferredFullHistoryProjection(
@@ -911,6 +924,16 @@ export class FlowChatStore {
       return false;
     }
 
+    if (projection.remote) {
+      startupTrace.markPhase('historical_session_full_hydrate_remote_projection_blocked', {
+        remote: true,
+        sessionId,
+        reason,
+        turnCount: projection.dialogTurns.length,
+      });
+      return false;
+    }
+
     const result = this.applyCompletedSessionHistoryProjection(sessionId, projection);
     if (result.applied) {
       this.deferredFullHistoryProjections.delete(sessionId);
@@ -925,6 +948,124 @@ export class FlowChatStore {
     }
 
     return result.applied;
+  }
+
+  public revealPreviousSessionHistoryWindow(
+    sessionId: string,
+    reason: string,
+    turnLimit: number = HISTORICAL_SESSION_PREVIOUS_WINDOW_TURN_COUNT
+  ): boolean {
+    const projection = this.deferredFullHistoryProjections.get(sessionId);
+    if (!projection) {
+      return false;
+    }
+
+    const boundedTurnLimit = Math.max(1, Math.floor(turnLimit));
+    let revealed = false;
+    let revealedTurnCount = 0;
+    let loadedTurnCount = 0;
+    let totalTurnCount = projection.dialogTurns.length;
+    let remainingBefore = 0;
+    let nextExpectedDialogTurnIds: string[] = [];
+
+    this.setState(prev => {
+      if (projection.requireActiveSession && !projection.remote && prev.activeSessionId !== sessionId) {
+        return prev;
+      }
+
+      const session = prev.sessions.get(sessionId);
+      if (!session || session.historyState !== 'ready' || session.dialogTurns.length === 0) {
+        return prev;
+      }
+
+      const firstLoadedTurnId = session.dialogTurns[0]?.id;
+      if (!firstLoadedTurnId) {
+        return prev;
+      }
+
+      const firstLoadedIndex = projection.dialogTurns.findIndex(turn => turn.id === firstLoadedTurnId);
+      if (firstLoadedIndex <= 0) {
+        return prev;
+      }
+
+      const startIndex = Math.max(0, firstLoadedIndex - boundedTurnLimit);
+      const currentTurnIds = new Set(session.dialogTurns.map(turn => turn.id));
+      const previousWindow = projection.dialogTurns
+        .slice(startIndex, firstLoadedIndex)
+        .filter(turn => !currentTurnIds.has(turn.id));
+      if (previousWindow.length === 0) {
+        return prev;
+      }
+
+      const currentDialogTurnsById = new Map(session.dialogTurns.map(turn => [turn.id, turn]));
+      const projectionDialogTurnIds = new Set(projection.dialogTurns.map(turn => turn.id));
+      const mergedDialogTurns = [
+        ...previousWindow.map(turn => currentDialogTurnsById.get(turn.id) ?? turn),
+        ...session.dialogTurns,
+      ];
+      nextExpectedDialogTurnIds = [];
+      for (const turn of mergedDialogTurns) {
+        if (!projectionDialogTurnIds.has(turn.id)) {
+          break;
+        }
+        nextExpectedDialogTurnIds.push(turn.id);
+      }
+      revealed = true;
+      revealedTurnCount = previousWindow.length;
+      loadedTurnCount = mergedDialogTurns.length;
+      totalTurnCount = Math.max(
+        session.totalTurnCount ?? 0,
+        projection.dialogTurns.length,
+        mergedDialogTurns.length,
+      );
+      remainingBefore = startIndex;
+
+      const newSessions = new Map(prev.sessions);
+      newSessions.set(sessionId, {
+        ...session,
+        dialogTurns: mergedDialogTurns,
+        isPartial: remainingBefore > 0,
+        loadedTurnCount,
+        totalTurnCount,
+        contextRestoreState:
+          session.contextRestoreState === 'ready' ? 'ready' : projection.contextRestoreState,
+        mode: projection.restoredSessionInfo?.agentType || session.mode,
+        lastUserDialogMode: projection.restoredLastUserDialogMode,
+        lastSubmittedMode:
+          projection.restoredSessionInfo?.lastSubmittedAgentType ?? session.lastSubmittedMode,
+      });
+
+      return {
+        ...prev,
+        sessions: newSessions,
+      };
+    });
+
+    if (!revealed) {
+      return false;
+    }
+
+    if (remainingBefore === 0) {
+      this.deferredFullHistoryProjections.delete(sessionId);
+      this.fullHistoryProjectionApplyRequests.delete(sessionId);
+    } else if (nextExpectedDialogTurnIds.length > 0) {
+      this.deferredFullHistoryProjections.set(sessionId, {
+        ...projection,
+        expectedDialogTurnIds: nextExpectedDialogTurnIds,
+      });
+    }
+
+    startupTrace.markPhase('historical_session_deferred_window_revealed', {
+      remote: projection.remote,
+      sessionId,
+      reason,
+      turnLimit: boundedTurnLimit,
+      revealedTurnCount,
+      loadedTurnCount,
+      totalTurnCount,
+      remainingBefore,
+    });
+    return true;
   }
 
   private applyCompletedSessionHistoryProjection(

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -44,6 +44,8 @@
     "loadingDescription": "Preparing the conversation history.",
     "failedTitle": "Session history did not load",
     "failedDescription": "Retry loading the saved conversation.",
+    "preparingOlderHistory": "Preparing older history...",
+    "olderHistoryNotReady": "Older history is not ready yet.",
     "remoteSessionMissing": "The backend session data was not found. If you just reconnected an SSH remote workspace, close and reopen the remote project, or create a new session and try again.",
     "retry": "Retry"
   },

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -44,6 +44,8 @@
     "loadingDescription": "正在准备该会话的历史内容。",
     "failedTitle": "历史会话加载失败",
     "failedDescription": "可以重新加载已保存的会话内容。",
+    "preparingOlderHistory": "正在准备更早的历史记录...",
+    "olderHistoryNotReady": "更早的历史记录暂未准备好。",
     "remoteSessionMissing": "在后端找不到该会话数据。若刚重新连接过 SSH 远程工作区，请关闭并重新打开该远程项目，或新建会话后再试。",
     "retry": "重试"
   },

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -44,6 +44,8 @@
     "loadingDescription": "正在準備該會話的歷史內容。",
     "failedTitle": "歷史會話載入失敗",
     "failedDescription": "可以重新載入已儲存的會話內容。",
+    "preparingOlderHistory": "正在準備更早的歷史記錄...",
+    "olderHistoryNotReady": "更早的歷史記錄暫未準備好。",
     "remoteSessionMissing": "在後端找不到該會話資料。若剛重新連接過 SSH 遠端工作區，請關閉並重新開啟該遠端項目，或新增會話後再試。",
     "retry": "重試"
   },


### PR DESCRIPTION
## Summary
- Keep long-session openings interactive by preserving the visible tail and deferring complete history projection.
- Replace ordinary upward-scroll full-history projection with bounded previous-history window reveal and visible boundary states.
- Keep normal partial-session search scoped to the loaded window instead of implicitly loading full history.
- Block remote full-history projection from replacing the visible tail, while preserving local explicit full projection after windowed reveal.

## Architecture review notes
- Rebased on latest `gcwing/main` before validation.
- Independent adversarial review found no Critical or Important issues.
- Addressed review follow-ups: stale deferred reveal now surfaces a not-ready boundary state, and tests now prove mid-list upward scrolling does not load older history.
- Fixed remote pending release semantics so remote requests do not report a local release path or leave stale apply-request state.

## UX / performance impact
- Initial and ordinary scroll paths avoid projecting all turns into the frontend.
- Cache-running and unavailable older-history states are visible to users instead of silent no-ops.
- Existing live sessions, non-partial sessions, follow-to-latest, pin/scroll navigation, streaming output, tool-card rendering, and i18n paths remain covered by FlowChat test suites.

## Validation
- `pnpm --dir src/web-ui run test:run src/flow_chat` (115 files / 776 tests)
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx` (7 tests)
- `pnpm --dir src/web-ui run test:run src/flow_chat/store/FlowChatStore.test.ts` (46 tests)
- `pnpm run type-check:web`
- `pnpm run lint:web`
- `pnpm run i18n:audit`
- `git diff --check`

Refs #1321