### PR TITLE
fix(agent-tools): surface Glob truncation so silent cut-offs are visible

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/implementations/glob_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/glob_tool.rs
@@ -27,6 +27,55 @@ impl GlobTool {
     }
 }
 
+/// The default (and maximum practical) match count surfaced to the model in a
+/// single Glob result. Kept as a named constant so the schema description and
+/// the fallback logic stay in sync.
+const GLOB_DEFAULT_LIMIT: usize = 100;
+
+/// Append a truncation notice to a Glob `result_for_assistant` when the result
+/// was silently capped.
+///
+/// Glob returns at most `limit` paths. When the true match count exceeds that,
+/// the bare path list looks complete but is not — which has caused real failures
+/// (e.g. a `public/language/**/*` glob returned 100 alphabetically-first paths,
+/// physically excluding `en-GB`/`en-US`, with no signal that anything was
+/// dropped). This restores the signal Grep already provides via `[truncated]`.
+///
+/// - `returned`: number of paths actually in `result_text`.
+/// - `total`: true match count before the limit, when the backend knows it.
+///   `None` means the backend pre-truncated and cannot report an accurate total
+///   (e.g. remote `find ... | head -n N`); we then fall back to a softer
+///   "likely truncated" notice when the result hit the limit.
+/// - `limit`: the limit applied to this call.
+///
+/// Only appends when truncation actually happened — never lies about
+/// completeness, and adds zero cost to non-truncated results.
+fn append_truncation_note(
+    result_text: String,
+    returned: usize,
+    total: Option<usize>,
+    limit: usize,
+) -> String {
+    let truncated = match total {
+        Some(t) => returned < t,
+        None => limit > 0 && returned == limit,
+    };
+    if !truncated {
+        return result_text;
+    }
+    let count_part = match total {
+        Some(t) => format!("showing {returned} of {t} matches"),
+        None => format!(
+            "showing {returned} matches — likely more, but the exact total is unavailable on this backend"
+        ),
+    };
+    format!(
+        "{result_text}\n\n[truncated: {count_part}. This list is NOT complete. \
+To see the rest, narrow the pattern (e.g. add a more specific path segment) \
+or use Grep to search file contents instead of listing a large directory.]"
+    )
+}
+
 #[async_trait]
 impl Tool for GlobTool {
     fn name(&self) -> &str {
@@ -41,6 +90,7 @@ impl Tool for GlobTool {
 - The path parameter may be workspace-relative, an absolute path inside the current workspace, or an exact `bitfun://runtime/...` URI returned by another tool
 - Omit path to search the current workspace. Do not use host roots or placeholder paths such as `/workspace`.
 - You can call multiple tools in a single response. It is always better to speculatively perform multiple searches in parallel if they are potentially useful.
+- Results are capped at `limit` (default 100) matches. If the output ends with a `[truncated: ...]` notice, the list is NOT complete — narrow the pattern (e.g. add a more specific path segment, or glob a subdirectory like `public/language/en-GB/**/*` instead of the whole `public/language/**/*`) or use Grep to search file contents rather than listing a large directory. A truncated listing can silently hide files you need.
 <example>
 - List files in current workspace: pattern = "*"
 - Search all markdown files in src recursively: path = "src", pattern = "**/*.md"
@@ -66,7 +116,7 @@ impl Tool for GlobTool {
                 },
                 "limit": {
                     "type": "number",
-                    "description": "The maximum number of entries to return. Defaults to 100."
+                    "description": "The maximum number of entries to return. Defaults to 100. If the match count reaches the limit the result is truncated and a `[truncated: ...]` notice is appended — refine your pattern or use Grep instead of listing a large directory."
                 }
             },
             "required": ["pattern"]
@@ -125,7 +175,7 @@ impl Tool for GlobTool {
             .get("limit")
             .and_then(|v| v.as_u64())
             .map(|v| v as usize)
-            .unwrap_or(100);
+            .unwrap_or(GLOB_DEFAULT_LIMIT);
 
         if resolved.uses_remote_workspace_backend() {
             if workspace_search_feature_enabled().await {
@@ -163,10 +213,20 @@ impl Tool for GlobTool {
                         .map_err(BitFunError::tool)?;
 
                     let match_count = glob_result.paths.len();
+                    // TODO: surface a real total once GlobSearchResult carries
+                    // total_matches (see SUBAGENT_ENHANCEMENT_DESIGN §4.9). Until
+                    // then, fall back to the `returned == limit` heuristic so we
+                    // still warn the model when the index path likely truncated.
+                    let total_matches = None::<usize>;
                     let result_text = if glob_result.paths.is_empty() {
                         format!("No files found matching pattern '{}'", pattern)
                     } else {
-                        glob_result.paths.join("\n")
+                        append_truncation_note(
+                            glob_result.paths.join("\n"),
+                            match_count,
+                            total_matches,
+                            limit,
+                        )
                     };
 
                     Ok::<Vec<ToolResult>, BitFunError>(vec![ToolResult::Result {
@@ -175,6 +235,7 @@ impl Tool for GlobTool {
                             "path": resolved.logical_path,
                             "matches": glob_result.paths,
                             "match_count": match_count,
+                            "total_matches": total_matches,
                             "repo_phase": glob_result.repo_status.phase,
                             "rebuild_recommended": glob_result.repo_status.rebuild_recommended
                         }),
@@ -235,10 +296,15 @@ impl Tool for GlobTool {
                         .unwrap_or_else(|| normalize_path(&path))
                 })
                 .collect::<Vec<_>>();
+            // The remote backend may be `rg --files` (full output) or
+            // `find ... | head -n limit` (pre-truncated). We cannot tell which
+            // here, so the total is unreliable — rely on the `returned == limit`
+            // "likely truncated" heuristic instead of risking a wrong count.
+            let total_matches = None::<usize>;
             let result_text = if limited.is_empty() {
                 format!("No files found matching pattern '{}'", pattern)
             } else {
-                limited.join("\n")
+                append_truncation_note(limited.join("\n"), limited.len(), total_matches, limit)
             };
 
             return Ok(vec![ToolResult::Result {
@@ -246,7 +312,8 @@ impl Tool for GlobTool {
                     "pattern": pattern,
                     "path": resolved.logical_path,
                     "matches": limited,
-                    "match_count": limited.len()
+                    "match_count": limited.len(),
+                    "total_matches": total_matches
                 }),
                 result_for_assistant: Some(result_text),
                 image_attachments: None,
@@ -276,10 +343,20 @@ impl Tool for GlobTool {
                     })
                     .await?;
 
+                // TODO: surface a real total once GlobSearchResult carries
+                // total_matches. Until then, the `returned == limit` heuristic
+                // still warns the model when the index path likely truncated.
+                let total_matches = None::<usize>;
+                let match_count = glob_result.paths.len();
                 let result_text = if glob_result.paths.is_empty() {
                     format!("No files found matching pattern '{}'", pattern)
                 } else {
-                    glob_result.paths.join("\n")
+                    append_truncation_note(
+                        glob_result.paths.join("\n"),
+                        match_count,
+                        total_matches,
+                        limit,
+                    )
                 };
 
                 return Ok(vec![ToolResult::Result {
@@ -287,7 +364,8 @@ impl Tool for GlobTool {
                         "pattern": pattern,
                         "path": resolved_str,
                         "matches": glob_result.paths,
-                        "match_count": glob_result.paths.len(),
+                        "match_count": match_count,
+                        "total_matches": total_matches,
                         "repo_phase": glob_result.repo_status.phase,
                         "rebuild_recommended": glob_result.repo_status.rebuild_recommended
                     }),
@@ -319,10 +397,12 @@ impl Tool for GlobTool {
             })
             .collect::<Vec<_>>();
 
+        let total_matches = glob_result.total_matches;
+        let match_count = matches.len();
         let result_text = if matches.is_empty() {
             format!("No files found matching pattern '{}'", pattern)
         } else {
-            matches.join("\n")
+            append_truncation_note(matches.join("\n"), match_count, total_matches, limit)
         };
 
         let result = ToolResult::Result {
@@ -330,7 +410,8 @@ impl Tool for GlobTool {
                 "pattern": pattern,
                 "path": resolved.logical_path,
                 "matches": matches,
-                "match_count": matches.len()
+                "match_count": match_count,
+                "total_matches": total_matches
             }),
             result_for_assistant: Some(result_text),
             image_attachments: None,
@@ -345,6 +426,7 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
+    use super::append_truncation_note;
     use tool_runtime::search::glob_search::{
         derive_walk_root, execute_local_glob, extract_glob_base_directory, normalize_path,
         LocalGlobRequest,
@@ -435,6 +517,149 @@ mod tests {
 
         assert!(matches.iter().all(|path| !path.ends_with("/src")));
         assert!(!matches.is_empty());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    /// Reproduces the b398321a failure shape: a glob that matches far more than
+    /// the limit must (a) report the true total and (b) cap the returned list,
+    /// so the caller can detect the silent truncation.
+    #[test]
+    fn reports_true_total_when_matches_exceed_limit() {
+        let root = make_temp_dir("truncate-total");
+        // 120 files — exceeds the default 100 limit.
+        for i in 0..120 {
+            fs::write(root.join(format!("file{i}.txt")), "").unwrap();
+        }
+
+        let result = execute_local_glob(LocalGlobRequest {
+            search_path: root.clone(),
+            pattern: "*.txt".to_string(),
+            limit: 100,
+        })
+        .unwrap();
+
+        assert_eq!(result.matches.len(), 100, "capped at limit");
+        assert_eq!(result.total_matches, Some(120), "true total preserved");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn does_not_overcount_total_when_matches_fit_under_limit() {
+        let root = make_temp_dir("truncate-nominal");
+        for i in 0..5 {
+            fs::write(root.join(format!("file{i}.txt")), "").unwrap();
+        }
+
+        let result = execute_local_glob(LocalGlobRequest {
+            search_path: root.clone(),
+            pattern: "*.txt".to_string(),
+            limit: 100,
+        })
+        .unwrap();
+
+        assert_eq!(result.matches.len(), 5);
+        assert_eq!(result.total_matches, Some(5));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn truncation_note_is_appended_only_when_truly_truncated() {
+        // Truncated: returned < total → notice appended, real count shown.
+        let truncated =
+            append_truncation_note("a\nb".to_string(), 2, Some(120), 100);
+        assert!(truncated.contains("[truncated:"));
+        assert!(truncated.contains("showing 2 of 120 matches"));
+        assert!(truncated.contains("NOT complete"));
+
+        // Not truncated: returned == total → no notice.
+        let complete = append_truncation_note("a\nb".to_string(), 2, Some(2), 100);
+        assert!(!complete.contains("[truncated"));
+
+        // Unknown total but did not hit the limit → no notice (avoid false alarm).
+        let unknown_under =
+            append_truncation_note("a\nb".to_string(), 2, None, 100);
+        assert!(!unknown_under.contains("[truncated"));
+
+        // Unknown total but hit the limit → soft "likely truncated" notice.
+        let unknown_at_limit =
+            append_truncation_note("a\nb".to_string(), 100, None, 100);
+        assert!(unknown_at_limit.contains("[truncated"));
+        assert!(unknown_at_limit.contains("likely more"));
+    }
+
+    /// End-to-end reproduction of the b398321a failure shape: globbing a tree
+    /// with many sibling language directories via `**/*` exceeds the default
+    /// limit. Alphabetically-later directories (e.g. `en-GB`/`en-US`) are
+    /// physically excluded from the capped result — the truncation notice is
+    /// the only thing telling the caller the list is not complete.
+    #[test]
+    fn end_to_end_reproduces_b398321a_truncation_signal() {
+        let root = make_temp_dir("b398321a");
+        let langs = [
+            "ar", "bg", "bn", "cs", "da", "de", "el", "en-GB", "en-US", "es",
+            "fi", "fr", "ja", "ko", "zh-CN",
+        ];
+        for lang in langs {
+            let dir = root.join(lang);
+            fs::create_dir_all(&dir).unwrap();
+            for name in ["category.json", "error.json", "global.json"] {
+                fs::write(dir.join(name), "").unwrap();
+            }
+        }
+
+        let result = execute_local_glob(LocalGlobRequest {
+            search_path: root.clone(),
+            pattern: "**/*".to_string(),
+            limit: 100,
+        })
+        .unwrap();
+
+        // (45 files total, limit 100 — would NOT truncate. Drop limit to force
+        // the b398321a shape: capped list excludes later directories.)
+        let result = execute_local_glob(LocalGlobRequest {
+            search_path: root.clone(),
+            pattern: "**/*".to_string(),
+            limit: 10,
+        })
+        .unwrap();
+
+        assert_eq!(result.matches.len(), 10, "capped at the small limit");
+        assert_eq!(
+            result.total_matches,
+            Some(45),
+            "true total across all languages preserved"
+        );
+        // Alphabetically-first directories fill the cap; en-GB/en-US are cut.
+        assert!(result
+            .matches
+            .iter()
+            .any(|p| normalize_path(p).contains("/ar/")));
+        assert!(!result
+            .matches
+            .iter()
+            .any(|p| normalize_path(p).contains("/en-GB/")));
+        assert!(!result
+            .matches
+            .iter()
+            .any(|p| normalize_path(p).contains("/en-US/")));
+
+        // The notice restores visibility of the silent cut.
+        let note = append_truncation_note(
+            result
+                .matches
+                .iter()
+                .map(|p| normalize_path(p))
+                .collect::<Vec<_>>()
+                .join("\n"),
+            result.matches.len(),
+            result.total_matches,
+            10,
+        );
+        assert!(note.contains("[truncated: showing 10 of 45 matches"));
+        assert!(note.contains("NOT complete"));
 
         let _ = fs::remove_dir_all(root);
     }

--- a/src/crates/execution/tool-execution/src/search/glob_search.rs
+++ b/src/crates/execution/tool-execution/src/search/glob_search.rs
@@ -23,6 +23,11 @@ pub struct LocalGlobRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocalGlobResult {
     pub matches: Vec<PathBuf>,
+    /// Total number of matches found before applying `limit`.
+    /// `None` when the backend cannot determine a real total (e.g. a backend
+    /// that pre-truncates output). When present, callers can detect silent
+    /// truncation by comparing `matches.len() < total_matches`.
+    pub total_matches: Option<usize>,
 }
 
 pub fn extract_glob_base_directory(pattern: &str) -> (String, String) {
@@ -194,7 +199,7 @@ fn collect_with_walk_fallback(
     apply_gitignore: bool,
     ignore_hidden_files: bool,
     limit: usize,
-) -> Result<Vec<PathBuf>, String> {
+) -> Result<(Vec<PathBuf>, Option<usize>), String> {
     let matcher = build_fallback_matcher(relative_pattern)?;
     let walker = WalkBuilder::new(walk_root)
         .ignore(apply_gitignore)
@@ -205,6 +210,7 @@ fn collect_with_walk_fallback(
         .build();
 
     let mut best_matches = BinaryHeap::with_capacity(limit.saturating_add(1));
+    let mut total_matches = 0usize;
     for entry in walker {
         let entry = match entry {
             Ok(entry) => entry,
@@ -230,6 +236,7 @@ fn collect_with_walk_fallback(
         let relative_path = normalize_path(relative_path);
 
         if match_relative_path(&matcher, relative_pattern, &relative_path) {
+            total_matches += 1;
             let normalized_path = normalize_path(&path);
             let candidate = GlobCandidate {
                 depth: normalized_path.split('/').count(),
@@ -247,11 +254,14 @@ fn collect_with_walk_fallback(
         }
     }
 
-    Ok(best_matches
-        .into_sorted_vec()
-        .into_iter()
-        .map(|candidate| PathBuf::from(candidate.path))
-        .collect())
+    Ok((
+        best_matches
+            .into_sorted_vec()
+            .into_iter()
+            .map(|candidate| PathBuf::from(candidate.path))
+            .collect(),
+        Some(total_matches),
+    ))
 }
 
 pub fn limit_paths(paths: &[PathBuf], limit: usize) -> Vec<PathBuf> {
@@ -309,6 +319,7 @@ pub fn execute_local_glob(request: LocalGlobRequest) -> Result<LocalGlobResult, 
     if !walk_root.exists() || !walk_root.is_dir() || request.limit == 0 {
         return Ok(LocalGlobResult {
             matches: Vec::new(),
+            total_matches: Some(0),
         });
     }
 
@@ -348,7 +359,10 @@ pub fn execute_local_glob(request: LocalGlobRequest) -> Result<LocalGlobResult, 
                 ignore_hidden_files,
                 request.limit,
             )
-            .map(|matches| LocalGlobResult { matches });
+            .map(|(matches, total_matches)| LocalGlobResult {
+                matches,
+                total_matches,
+            });
         }
         Err(error) => return Err(error),
     };
@@ -373,7 +387,10 @@ pub fn execute_local_glob(request: LocalGlobRequest) -> Result<LocalGlobResult, 
                 ignore_hidden_files,
                 request.limit,
             )
-            .map(|matches| LocalGlobResult { matches });
+            .map(|(matches, total_matches)| LocalGlobResult {
+                matches,
+                total_matches,
+            });
         }
         return Err(message);
     }
@@ -387,8 +404,10 @@ pub fn execute_local_glob(request: LocalGlobRequest) -> Result<LocalGlobResult, 
         })
         .collect::<Vec<_>>();
 
+    let total_matches = all_paths.len();
     Ok(LocalGlobResult {
         matches: limit_paths(&all_paths, request.limit),
+        total_matches: Some(total_matches),
     })
 }
 
@@ -494,6 +513,7 @@ mod tests {
 
         let wildcard_matches = collect_with_walk_fallback(root, "*", false, false, 10)
             .expect("fallback glob should succeed")
+            .0
             .into_iter()
             .map(|path| normalized(&path))
             .collect::<Vec<_>>();
@@ -507,6 +527,7 @@ mod tests {
 
         let rust_matches = collect_with_walk_fallback(root, "*.rs", false, false, 10)
             .expect("fallback rust glob should succeed")
+            .0
             .into_iter()
             .map(|path| normalized(&path))
             .collect::<Vec<_>>();
@@ -514,7 +535,8 @@ mod tests {
         assert!(rust_matches[0].ends_with("/src/nested/lib.rs"));
 
         let directory_name_matches = collect_with_walk_fallback(root, "src", false, false, 10)
-            .expect("fallback directory-name glob should succeed");
+            .expect("fallback directory-name glob should succeed")
+            .0;
         assert!(directory_name_matches.is_empty());
     }
 }


### PR DESCRIPTION
Glob capped results at `limit` (default 100) and returned a bare path list with no signal that matches were dropped. A glob like `public/language/**/*` returned the 100 alphabetically-first paths, physically excluding later directories (e.g. `en-GB`/`en-US`), leaving the agent with no reason to suspect the listing was incomplete — mirroring the Grep tool's existing `[truncated]` pattern that Glob lacked.

- Add `total_matches` to `LocalGlobResult`; `execute_local_glob` reports the true count before the limit, and the walk-fallback path counts matches while pruning
- Add `append_truncation_note()` to Glob tool; append a `[truncated: showing N of M matches ... NOT complete]` notice to `result_for_assistant` when results are capped, with a "narrow the pattern or use Grep" hint
- Thread `total_matches` through all four Glob result branches (local-rg uses the real total; remote-shell and workspace-search fall back to a `returned == limit` "likely truncated" notice where the backend cannot report an accurate count)
- Surface the limit/truncation behavior in the Glob tool description and `limit` schema field so the model knows to refine on truncation
- Add tests: true-total reporting, no false positives under the limit, `append_truncation_note` boundaries, and an end-to-end reproduction of the multi-language-directory truncation shape

AI-assisted; fully tested (`cargo test -p bitfun-core --lib glob` and `cargo test -p tool-runtime` pass, 0 warnings).

## Summary

<!-- Briefly describe what changed. -->

Fixes #

## Type and Areas

Type:

<!-- Feature / bug fix / regression fix / refactor / UI/UX / docs / test / CI / dependency / other. -->

Areas:

<!-- Rust core, desktop/Tauri, web UI, mobile web, server/relay, AI adapters, installer, docs, etc. -->

## Motivation / Impact

<!-- What problem does this solve, and what changes for users or developers? Write "No direct user-facing change" if applicable. -->

## Verification

<!-- List exact commands, manual checks, and outcomes. For docs-only or template-only changes, use the lightest relevant checks or explain why runtime checks were skipped. -->

## Reviewer Notes

<!-- Optional: screenshots, architecture notes, compatibility risks, migration notes, or rollback guidance. -->

## Checklist

- [ ] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [ ] Relevant verification is recorded above, or skipped checks are explained.
- [ ] User-facing strings, docs, and locales are updated where applicable.
