### PR TITLE
chore: ignore local .agents directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ ASSETS_LICENSES.md
 
 external/
 /.bitfun/search/flashgrep-index/
+.agents/


### PR DESCRIPTION
## Summary
- Add `.agents/` to `.gitignore` so local agent skill directories are not accidentally committed.

## Test plan
- [x] Verified `.gitignore` change only affects untracked `.agents/` paths